### PR TITLE
fix: make previous resolve latest upstream event

### DIFF
--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -865,7 +865,8 @@ func (b *NodeConfigurationBuilder) populateFromExecutions(
 			return fmt.Errorf("node %s: %w", nodeRef, err)
 		}
 		if !ok {
-			return fmt.Errorf("node %s has no outputs", nodeRef)
+			messageChain[nodeRef] = nil
+			continue
 		}
 
 		messageChain[nodeRef] = normalizeExpressionValue(event.Data.Data())
@@ -933,14 +934,44 @@ func (b *NodeConfigurationBuilder) resolvePreviousPayload(depth int) (any, error
 		return nil, err
 	}
 	step := 0
+	var currentOutput currentOutputRef
 	if hasInput {
 		step++
+		currentOutput = b.currentInputOutputRef()
 		if step >= depth && inputPayload != nil {
 			return b.injectConfigFromPreviousExecution(inputPayload), nil
 		}
 	}
 
-	step, payload, err := b.resolveFromExecutions(depth, step, hasInput)
+	if !hasInput {
+		incomingPayload, ok, err := b.incomingEventPayload()
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			step++
+			currentOutput = currentOutputRef{eventID: b.incomingEventID}
+			if step >= depth {
+				return incomingPayload, nil
+			}
+		}
+	}
+
+	payloads, err := b.latestDirectUpstreamOutputPayloads()
+	if err != nil {
+		return nil, err
+	}
+	for _, payload := range payloads {
+		if currentOutput.matches(payload.event) {
+			continue
+		}
+		step++
+		if step >= depth {
+			return payload.data, nil
+		}
+	}
+
+	step, payload, err := b.resolveFromExecutions(depth, step, step > 0)
 	if err != nil {
 		return nil, err
 	}
@@ -949,6 +980,174 @@ func (b *NodeConfigurationBuilder) resolvePreviousPayload(depth int) (any, error
 	}
 
 	return b.resolveFromRoot(depth, step)
+}
+
+func (b *NodeConfigurationBuilder) incomingEventPayload() (any, bool, error) {
+	if b.incomingEventID == nil {
+		return nil, false, nil
+	}
+
+	event, err := models.FindCanvasEventInTransaction(b.tx, *b.incomingEventID)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return b.payloadFromEvent(*event), true, nil
+}
+
+type canvasEventPayload struct {
+	event models.CanvasEvent
+	data  any
+}
+
+type currentOutputRef struct {
+	eventID     *uuid.UUID
+	executionID *uuid.UUID
+}
+
+func (b *NodeConfigurationBuilder) currentInputOutputRef() currentOutputRef {
+	if b.incomingEventID != nil {
+		return currentOutputRef{eventID: b.incomingEventID}
+	}
+
+	return currentOutputRef{executionID: b.previousExecutionID}
+}
+
+func (r currentOutputRef) matches(event models.CanvasEvent) bool {
+	if r.eventID != nil {
+		return event.ID == *r.eventID
+	}
+
+	return r.executionID != nil && event.ExecutionID != nil && *event.ExecutionID == *r.executionID
+}
+
+func (b *NodeConfigurationBuilder) latestDirectUpstreamOutputPayloads() ([]canvasEventPayload, error) {
+	if b.nodeID == "" || b.rootEventID == nil {
+		return nil, nil
+	}
+
+	directExecutions, err := b.listDirectUpstreamExecutions()
+	if err != nil {
+		return nil, err
+	}
+	if len(directExecutions) == 0 {
+		return nil, nil
+	}
+
+	linearExecutions, err := b.listLinearExecutionsInChain()
+	if err != nil {
+		return nil, err
+	}
+	executions := selectCurrentExecutionsByNode(directExecutions, linearExecutions)
+
+	outputs, err := newExecutionOutputLookup(
+		b.tx,
+		linearExecutions,
+		executionIDsFromExecutions(executions),
+		b.incomingEventID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	payloads := make([]canvasEventPayload, 0, len(executions))
+	for _, execution := range executions {
+		event, ok, err := outputs.outputEvent(execution.ID)
+		if err != nil {
+			return nil, fmt.Errorf("node %s: %w", execution.NodeID, err)
+		}
+		if !ok {
+			continue
+		}
+
+		payloads = append(payloads, canvasEventPayload{
+			event: event,
+			data:  injectConfig(normalizeExpressionValue(event.Data.Data()), execution.Configuration.Data()),
+		})
+	}
+	sort.Slice(payloads, func(i, j int) bool {
+		return canvasEventAfter(payloads[i].event, payloads[j].event)
+	})
+
+	return payloads, nil
+}
+
+func selectCurrentExecutionsByNode(
+	executions []models.CanvasNodeExecution,
+	linearExecutions []models.CanvasNodeExecution,
+) []models.CanvasNodeExecution {
+	linearByNode := make(map[string]models.CanvasNodeExecution, len(linearExecutions))
+	for _, execution := range linearExecutions {
+		if _, exists := linearByNode[execution.NodeID]; exists {
+			continue
+		}
+		linearByNode[execution.NodeID] = execution
+	}
+
+	selectedByNode := make(map[string]models.CanvasNodeExecution, len(executions))
+	for _, execution := range executions {
+		if linear, ok := linearByNode[execution.NodeID]; ok {
+			selectedByNode[execution.NodeID] = linear
+			continue
+		}
+
+		selected, exists := selectedByNode[execution.NodeID]
+		if !exists || executionCreatedAfter(execution, selected) {
+			selectedByNode[execution.NodeID] = execution
+		}
+	}
+
+	selected := make([]models.CanvasNodeExecution, 0, len(selectedByNode))
+	for _, execution := range selectedByNode {
+		selected = append(selected, execution)
+	}
+	return selected
+}
+
+func executionCreatedAfter(left models.CanvasNodeExecution, right models.CanvasNodeExecution) bool {
+	if left.CreatedAt == nil && right.CreatedAt == nil {
+		return left.ID.String() > right.ID.String()
+	}
+	if left.CreatedAt == nil {
+		return false
+	}
+	if right.CreatedAt == nil {
+		return true
+	}
+	if left.CreatedAt.Equal(*right.CreatedAt) {
+		return left.ID.String() > right.ID.String()
+	}
+	return left.CreatedAt.After(*right.CreatedAt)
+}
+
+func canvasEventAfter(left models.CanvasEvent, right models.CanvasEvent) bool {
+	if left.CreatedAt == nil && right.CreatedAt == nil {
+		return left.ID.String() > right.ID.String()
+	}
+	if left.CreatedAt == nil {
+		return false
+	}
+	if right.CreatedAt == nil {
+		return true
+	}
+	if left.CreatedAt.Equal(*right.CreatedAt) {
+		return left.ID.String() > right.ID.String()
+	}
+	return left.CreatedAt.After(*right.CreatedAt)
+}
+
+func (b *NodeConfigurationBuilder) payloadFromEvent(event models.CanvasEvent) any {
+	payload := normalizeExpressionValue(event.Data.Data())
+	if event.ExecutionID == nil {
+		return payload
+	}
+
+	execution, err := models.FindNodeExecutionInTransaction(b.tx, b.workflowID, *event.ExecutionID)
+	if err != nil || execution == nil {
+		return payload
+	}
+
+	return injectConfig(payload, execution.Configuration.Data())
 }
 
 func (b *NodeConfigurationBuilder) injectConfigFromPreviousExecution(payload any) any {
@@ -964,7 +1163,7 @@ func (b *NodeConfigurationBuilder) injectConfigFromPreviousExecution(payload any
 	return injectConfig(payload, execution.Configuration.Data())
 }
 
-func (b *NodeConfigurationBuilder) resolveFromExecutions(depth int, step int, hasInput bool) (int, any, error) {
+func (b *NodeConfigurationBuilder) resolveFromExecutions(depth int, step int, hasCurrentPayload bool) (int, any, error) {
 	if b.previousExecutionID == nil {
 		return step, nil, nil
 	}
@@ -978,7 +1177,7 @@ func (b *NodeConfigurationBuilder) resolveFromExecutions(depth int, step int, ha
 	}
 
 	startIndex := 0
-	if hasInput {
+	if hasCurrentPayload {
 		startIndex = 1
 	}
 
@@ -1290,4 +1489,60 @@ func (b *NodeConfigurationBuilder) listUpstreamNodeIDs() ([]string, error) {
 	}
 	sort.Strings(ids)
 	return ids, nil
+}
+
+func (b *NodeConfigurationBuilder) listDirectSourceNodeIDs() ([]string, error) {
+	if b.nodeID == "" {
+		return nil, nil
+	}
+
+	canvas, err := models.FindCanvasWithoutOrgScopeInTransaction(b.tx, b.workflowID)
+	if err != nil {
+		return nil, err
+	}
+
+	_, liveEdges, err := models.FindLiveCanvasSpecInTransaction(b.tx, canvas.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]struct{}{}
+	ids := []string{}
+	for _, edge := range liveEdges {
+		if edge.TargetID != b.nodeID {
+			continue
+		}
+		if _, exists := seen[edge.SourceID]; exists {
+			continue
+		}
+		seen[edge.SourceID] = struct{}{}
+		ids = append(ids, edge.SourceID)
+	}
+
+	return ids, nil
+}
+
+func (b *NodeConfigurationBuilder) listDirectUpstreamExecutions() ([]models.CanvasNodeExecution, error) {
+	if b.rootEventID == nil {
+		return nil, nil
+	}
+
+	sourceIDs, err := b.listDirectSourceNodeIDs()
+	if err != nil {
+		return nil, err
+	}
+	if len(sourceIDs) == 0 {
+		return nil, nil
+	}
+
+	var executions []models.CanvasNodeExecution
+	err = b.tx.
+		Where("workflow_id = ? AND root_event_id = ? AND node_id IN ?", b.workflowID, *b.rootEventID, sourceIDs).
+		Find(&executions).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return executions, nil
 }

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -394,6 +394,355 @@ func Test_NodeConfigurationBuilder_CyclicFeedback_UsesCurrentLineage(t *testing.
 	assert.Equal(t, true, done)
 }
 
+func Test_NodeConfigurationBuilder_ReferencedUpstreamNodeWithNoOutputsResolvesToNil(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "start", Name: "start", Type: models.NodeTypeTrigger},
+			{NodeID: "build-a", Name: "Build A", Type: models.NodeTypeComponent},
+			{NodeID: "build-b", Name: "Build B", Type: models.NodeTypeComponent},
+			{NodeID: "merge", Name: "merge", Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: "start", TargetID: "build-a", Channel: "default"},
+			{SourceID: "start", TargetID: "build-b", Channel: "default"},
+			{SourceID: "build-a", TargetID: "merge", Channel: "passed"},
+			{SourceID: "build-b", TargetID: "merge", Channel: "passed"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "start", "default", nil)
+	buildAExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "build-a", rootEvent.ID, rootEvent.ID)
+	buildAEvent := support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-a",
+		"passed",
+		&buildAExecution.ID,
+		map[string]any{"status": "succeeded"},
+	)
+
+	// The sibling execution exists in the same run but has not emitted an event yet.
+	support.CreateCanvasNodeExecution(t, canvas.ID, "build-b", rootEvent.ID, rootEvent.ID)
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithNodeID("merge").
+		WithPreviousExecution(&buildAExecution.ID).
+		WithIncomingEventID(&buildAEvent.ID).
+		WithRootEvent(&rootEvent.ID).
+		WithInput(map[string]any{"build-a": map[string]any{"status": "succeeded"}})
+
+	missing, err := builder.ResolveExpression(`$["Build B"] == nil`)
+	require.NoError(t, err)
+	assert.Equal(t, true, missing)
+}
+
+func setCanvasEventCreatedAt(t *testing.T, eventID uuid.UUID, createdAt time.Time) {
+	t.Helper()
+
+	err := database.Conn().
+		Model(&models.CanvasEvent{}).
+		Where("id = ?", eventID).
+		Update("created_at", createdAt).
+		Error
+	require.NoError(t, err)
+}
+
+func Test_NodeConfigurationBuilder_PreviousFallsBackToLatestUpstreamOutput(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "start", Name: "start", Type: models.NodeTypeTrigger},
+			{NodeID: "build-a", Name: "Build A", Type: models.NodeTypeComponent},
+			{NodeID: "build-b", Name: "Build B", Type: models.NodeTypeComponent},
+			{NodeID: "merge", Name: "merge", Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: "start", TargetID: "build-a", Channel: "default"},
+			{SourceID: "start", TargetID: "build-b", Channel: "default"},
+			{SourceID: "build-a", TargetID: "merge", Channel: "passed"},
+			{SourceID: "build-b", TargetID: "merge", Channel: "passed"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "start", "default", nil)
+	buildAExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "build-a", rootEvent.ID, rootEvent.ID)
+	buildAEvent := support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-a",
+		"passed",
+		&buildAExecution.ID,
+		map[string]any{"status": "succeeded"},
+	)
+	buildBExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "build-b", rootEvent.ID, rootEvent.ID)
+	buildBEvent := support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-b",
+		"failed",
+		&buildBExecution.ID,
+		map[string]any{"status": "failed"},
+	)
+	createdAt := time.Now()
+	setCanvasEventCreatedAt(t, buildAEvent.ID, createdAt)
+	setCanvasEventCreatedAt(t, buildBEvent.ID, createdAt.Add(time.Second))
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithNodeID("merge").
+		WithPreviousExecution(&buildAExecution.ID).
+		WithIncomingEventID(&buildBEvent.ID).
+		WithRootEvent(&rootEvent.ID)
+
+	status, err := builder.ResolveExpression(`previous().status`)
+	require.NoError(t, err)
+	assert.Equal(t, "failed", status)
+
+	status, err = builder.ResolveExpression(`previous(2).status`)
+	require.NoError(t, err)
+	assert.Equal(t, "succeeded", status)
+}
+
+func Test_NodeConfigurationBuilder_PreviousPrefersCurrentInputOverLatestUpstreamOutput(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "start", Name: "start", Type: models.NodeTypeTrigger},
+			{NodeID: "build-a", Name: "Build A", Type: models.NodeTypeComponent},
+			{NodeID: "build-b", Name: "Build B", Type: models.NodeTypeComponent},
+			{NodeID: "merge", Name: "merge", Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: "start", TargetID: "build-a", Channel: "default"},
+			{SourceID: "start", TargetID: "build-b", Channel: "default"},
+			{SourceID: "build-a", TargetID: "merge", Channel: "passed"},
+			{SourceID: "build-b", TargetID: "merge", Channel: "passed"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "start", "default", nil)
+	buildAExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "build-a", rootEvent.ID, rootEvent.ID)
+	buildAEvent := support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-a",
+		"passed",
+		&buildAExecution.ID,
+		map[string]any{"status": "succeeded"},
+	)
+	buildBExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "build-b", rootEvent.ID, rootEvent.ID)
+	buildBEvent := support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-b",
+		"failed",
+		&buildBExecution.ID,
+		map[string]any{"status": "failed"},
+	)
+	createdAt := time.Now()
+	setCanvasEventCreatedAt(t, buildAEvent.ID, createdAt)
+	setCanvasEventCreatedAt(t, buildBEvent.ID, createdAt.Add(time.Second))
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithNodeID("merge").
+		WithPreviousExecution(&buildAExecution.ID).
+		WithIncomingEventID(&buildAEvent.ID).
+		WithRootEvent(&rootEvent.ID).
+		WithInput(map[string]any{"build-a": map[string]any{"status": "succeeded"}})
+
+	status, err := builder.ResolveExpression(`previous().status`)
+	require.NoError(t, err)
+	assert.Equal(t, "succeeded", status)
+
+	nextStatus, err := builder.ResolveExpression(`previous(2).status`)
+	require.NoError(t, err)
+	assert.Equal(t, "failed", nextStatus)
+}
+
+func Test_NodeConfigurationBuilder_PreviousFallbackUsesDirectParentsOnly(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "start", Name: "start", Type: models.NodeTypeTrigger},
+			{NodeID: "prepare", Name: "Prepare", Type: models.NodeTypeComponent},
+			{NodeID: "build-a", Name: "Build A", Type: models.NodeTypeComponent},
+			{NodeID: "build-b", Name: "Build B", Type: models.NodeTypeComponent},
+			{NodeID: "merge", Name: "merge", Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: "start", TargetID: "prepare", Channel: "default"},
+			{SourceID: "prepare", TargetID: "build-a", Channel: "default"},
+			{SourceID: "prepare", TargetID: "build-b", Channel: "default"},
+			{SourceID: "build-a", TargetID: "merge", Channel: "passed"},
+			{SourceID: "build-b", TargetID: "merge", Channel: "passed"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "start", "default", nil)
+	buildAExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "build-a", rootEvent.ID, rootEvent.ID)
+	buildAEvent := support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-a",
+		"passed",
+		&buildAExecution.ID,
+		map[string]any{"status": "build-a"},
+	)
+	buildBExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "build-b", rootEvent.ID, rootEvent.ID)
+	buildBEvent := support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-b",
+		"passed",
+		&buildBExecution.ID,
+		map[string]any{"status": "build-b"},
+	)
+	prepareExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "prepare", rootEvent.ID, rootEvent.ID)
+	prepareEvent := support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"prepare",
+		"passed",
+		&prepareExecution.ID,
+		map[string]any{"status": "prepare"},
+	)
+	createdAt := time.Now()
+	setCanvasEventCreatedAt(t, buildAEvent.ID, createdAt)
+	setCanvasEventCreatedAt(t, buildBEvent.ID, createdAt.Add(time.Second))
+	setCanvasEventCreatedAt(t, prepareEvent.ID, createdAt.Add(2*time.Second))
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithNodeID("merge").
+		WithPreviousExecution(&buildAExecution.ID).
+		WithRootEvent(&rootEvent.ID)
+
+	status, err := builder.ResolveExpression(`previous().status`)
+	require.NoError(t, err)
+	assert.Equal(t, "build-b", status)
+
+	status, err = builder.ResolveExpression(`previous(2).status`)
+	require.NoError(t, err)
+	assert.Equal(t, "build-a", status)
+}
+
+func Test_NodeConfigurationBuilder_PreviousFallbackUsesOutputLookupAmbiguityRules(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "start", Name: "start", Type: models.NodeTypeTrigger},
+			{NodeID: "build-a", Name: "Build A", Type: models.NodeTypeComponent},
+			{NodeID: "merge", Name: "merge", Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: "start", TargetID: "build-a", Channel: "default"},
+			{SourceID: "build-a", TargetID: "merge", Channel: "passed"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "start", "default", nil)
+	buildAExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "build-a", rootEvent.ID, rootEvent.ID)
+	support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-a",
+		"passed",
+		&buildAExecution.ID,
+		map[string]any{"status": "first"},
+	)
+	support.EmitCanvasEventForNodeWithData(
+		t,
+		canvas.ID,
+		"build-a",
+		"passed",
+		&buildAExecution.ID,
+		map[string]any{"status": "second"},
+	)
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithNodeID("merge").
+		WithPreviousExecution(&buildAExecution.ID).
+		WithRootEvent(&rootEvent.ID)
+
+	_, err := builder.ResolveExpression(`previous().status`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous outputs")
+
+	_, err = builder.ResolveExpression(`$["Build A"].status`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous outputs")
+}
+
+func Test_selectCurrentExecutionsByNode_PrefersLinearExecutionAndLatestFallback(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-time.Minute)
+	newer := now.Add(time.Minute)
+
+	staleLoopExecution := models.CanvasNodeExecution{
+		ID:        uuid.New(),
+		NodeID:    "loop-body",
+		CreatedAt: &newer,
+	}
+	currentLoopExecution := models.CanvasNodeExecution{
+		ID:        uuid.New(),
+		NodeID:    "loop-body",
+		CreatedAt: &old,
+	}
+	oldBuildExecution := models.CanvasNodeExecution{
+		ID:        uuid.New(),
+		NodeID:    "build",
+		CreatedAt: &old,
+	}
+	newBuildExecution := models.CanvasNodeExecution{
+		ID:        uuid.New(),
+		NodeID:    "build",
+		CreatedAt: &newer,
+	}
+
+	selected := selectCurrentExecutionsByNode(
+		[]models.CanvasNodeExecution{
+			staleLoopExecution,
+			currentLoopExecution,
+			oldBuildExecution,
+			newBuildExecution,
+		},
+		[]models.CanvasNodeExecution{currentLoopExecution},
+	)
+
+	selectedByNode := map[string]uuid.UUID{}
+	for _, execution := range selected {
+		selectedByNode[execution.NodeID] = execution.ID
+	}
+
+	assert.Equal(t, currentLoopExecution.ID, selectedByNode["loop-body"])
+	assert.Equal(t, newBuildExecution.ID, selectedByNode["build"])
+	assert.Len(t, selectedByNode, 2)
+}
+
 func Test_NodeConfigurationBuilder_NodeNameNotUnique_NoneInChain(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()


### PR DESCRIPTION
## Summary
- make named upstream references with execution rows but no emitted output resolve as `nil` instead of failing expression evaluation
- make `previous()` recover the current incoming event payload from `incomingEventID` when no single input map is present
- make fan-in `previous(N)` walk direct upstream output events in latest-first order, without pulling stale events from transitive ancestors
- select direct upstream outputs through `executionOutputLookup`, so `previous()` uses the same consumed-event, incoming-event, and ambiguous-output rules as `$[node]`

## Context
The release app merge failed with `node Build superplane Docker image has no outputs` because the merge stop-if expression evaluated while parallel upstream nodes were still running. For fan-in components, expressions need to tolerate not-yet-emitted sibling outputs, and `previous()` should represent the current/latest direct upstream event payload rather than only a linear previous node.

## Validation
- `gofmt -w pkg/workers/contexts/node_configuration_builder.go pkg/workers/contexts/node_configuration_builder_test.go`
- `git diff --check`
- `go test -c ./pkg/workers/contexts`
- targeted DB-backed tests were attempted locally, but the host Postgres socket was unavailable; CI should run them with the test database
