### PR TITLE
fix: resolve missing execution node references as nil

### DIFF
--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -833,7 +833,8 @@ func (b *NodeConfigurationBuilder) populateFromExecutions(
 	for nodeRef, nodeID := range chainRefs {
 		execution, ok := executionByNode[nodeID]
 		if !ok {
-			return fmt.Errorf("node %s not found in execution chain", nodeRef)
+			messageChain[nodeRef] = nil
+			continue
 		}
 		executionIDs = append(executionIDs, execution.ID)
 		executionIDByRef[nodeRef] = execution.ID

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -1202,6 +1202,36 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain_NodeNotInChain(t *tes
 	assert.Contains(t, err.Error(), "not found in execution chain")
 }
 
+func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain_KnownNodeWithoutExecutionResolvesNil(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	node1 := "node-1"
+	node2 := "node-2"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: node1, Name: node1, Type: models.NodeTypeComponent},
+			{NodeID: node2, Name: node2, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, node1, "default", nil)
+	execution1 := support.CreateCanvasNodeExecution(t, canvas.ID, node1, rootEvent.ID, rootEvent.ID)
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithPreviousExecution(&execution1.ID).
+		WithInput(map[string]any{})
+
+	result, err := builder.ResolveExpression(`$["node-2"] == nil ? "missing" : "present"`)
+
+	require.NoError(t, err)
+	assert.Equal(t, "missing", result)
+}
+
 func Test_NodeConfigurationBuilder_ComplexNesting(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()


### PR DESCRIPTION
## Summary
- resolve known canvas node references with no execution in the current chain as nil
- keep unknown node names and ambiguous output resolution on their existing error paths
- add regression coverage for guarded expressions that check a not-yet-executed node

## Context
The release app hit `error resolving field prompt: node Review & Approve Changelog not found in execution chain` on the first Generate Changelog loop. On the first pass, that review node has not executed yet, so guarded expressions need the reference to evaluate as nil instead of failing while building the message chain.

## Validation
- `make format.go`
- `make test PKG_TEST_PACKAGES=./pkg/workers/contexts`
- `git diff --check`

No token values or secret payloads are included in this PR body or diff.