### PR TITLE
fix: pin run routing to canvas version

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,5 @@ Apache License 2.0. See `LICENSE`.
 
 - **[Discord](https://discord.superplane.com)** - Join our community for discussions, questions, and collaboration
 - **[X](https://x.com/superplanehq)** - Follow us for updates and announcements
+
+test

--- a/pkg/components/merge/merge_test.go
+++ b/pkg/components/merge/merge_test.go
@@ -182,6 +182,21 @@ func Test_Merge_WaitsForDistinctSources(t *testing.T) {
 	steps.AssertQueueIsEmpty()
 }
 
+func Test_Merge_WaitsForRunVersionSourcesWhenLiveCanvasChanges(t *testing.T) {
+	steps := NewMergeTestSteps(t)
+
+	steps.CreateWorkflow()
+	steps.CreateEvents()
+	steps.CreateQueueItems()
+	steps.PublishLiveVersionWithoutProcess2MergeEdge()
+
+	m := &Merge{}
+
+	steps.ProcessFirstEvent(m)
+	steps.AssertNodeExecutionCount(1)
+	steps.AssertExecutionPending()
+}
+
 type MergeTestSteps struct {
 	t  *testing.T
 	Tx *gorm.DB
@@ -406,6 +421,41 @@ func (s *MergeTestSteps) CreateWorkflowSingleSourceMultipleEdges() {
 func (s *MergeTestSteps) SetMergeConfiguration(cfg map[string]any) {
 	s.MergeNode.Configuration = datatypes.NewJSONType(cfg)
 	require.NoError(s.t, s.Tx.Save(s.MergeNode).Error)
+}
+
+func (s *MergeTestSteps) PublishLiveVersionWithoutProcess2MergeEdge() {
+	now := time.Now()
+	liveVersionID := uuid.New()
+	nodes := []models.Node{
+		{ID: s.StartNode.NodeID, Name: s.StartNode.Name, Type: s.StartNode.Type, Ref: s.StartNode.Ref.Data()},
+		{ID: s.ProcessNode1.NodeID, Name: s.ProcessNode1.Name, Type: s.ProcessNode1.Type, Ref: s.ProcessNode1.Ref.Data()},
+		{ID: s.ProcessNode2.NodeID, Name: s.ProcessNode2.Name, Type: s.ProcessNode2.Type, Ref: s.ProcessNode2.Ref.Data()},
+		{ID: s.MergeNode.NodeID, Name: s.MergeNode.Name, Type: s.MergeNode.Type, Ref: s.MergeNode.Ref.Data()},
+	}
+	edges := []models.Edge{
+		{SourceID: s.StartNode.NodeID, TargetID: s.ProcessNode1.NodeID, Channel: "default"},
+		{SourceID: s.StartNode.NodeID, TargetID: s.ProcessNode2.NodeID, Channel: "default"},
+		{SourceID: s.ProcessNode1.NodeID, TargetID: s.MergeNode.NodeID, Channel: "default"},
+	}
+
+	require.NoError(s.t, s.Tx.Transaction(func(tx *gorm.DB) error {
+		version := models.CanvasVersion{
+			ID:          liveVersionID,
+			WorkflowID:  s.Wf.ID,
+			State:       models.CanvasVersionStatePublished,
+			PublishedAt: &now,
+			Nodes:       datatypes.NewJSONSlice(nodes),
+			Edges:       datatypes.NewJSONSlice(edges),
+			CreatedAt:   &now,
+			UpdatedAt:   &now,
+		}
+		if err := tx.Create(&version).Error; err != nil {
+			return err
+		}
+
+		s.Wf.LiveVersionID = &liveVersionID
+		return tx.Model(s.Wf).Update("live_version_id", liveVersionID).Error
+	}))
 }
 
 func (s *MergeTestSteps) CreateEvents() {

--- a/pkg/models/canvas_version.go
+++ b/pkg/models/canvas_version.go
@@ -673,9 +673,24 @@ func FindLiveCanvasSpecInTransaction(tx *gorm.DB, workflowID uuid.UUID) ([]Node,
 		return nil, nil, err
 	}
 
+	nodes, edges := canvasVersionSpec(version)
+	return nodes, edges, nil
+}
+
+func FindCanvasVersionSpecInTransaction(tx *gorm.DB, workflowID, versionID uuid.UUID) ([]Node, []Edge, error) {
+	version, err := FindCanvasVersionInTransaction(tx, workflowID, versionID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nodes, edges := canvasVersionSpec(version)
+	return nodes, edges, nil
+}
+
+func canvasVersionSpec(version *CanvasVersion) ([]Node, []Edge) {
 	nodes := append([]Node(nil), version.Nodes...)
 	edges := append([]Edge(nil), version.Edges...)
-	return nodes, edges, nil
+	return nodes, edges
 }
 
 const canvasDraftBranchNamePrefix = "drafts/"

--- a/pkg/workers/contexts/process_queue_context.go
+++ b/pkg/workers/contexts/process_queue_context.go
@@ -169,17 +169,18 @@ func BuildProcessQueueContext(
 	}
 
 	ctx.DistinctIncomingSources = func() ([]core.Node, error) {
-		wf, err := models.FindCanvasWithoutOrgScopeInTransaction(tx, node.WorkflowID)
+		run, err := findQueueItemRunInTransaction(tx, queueItem)
 		if err != nil {
 			return nil, err
 		}
-		_, liveEdges, err := models.FindLiveCanvasSpecInTransaction(tx, wf.ID)
+
+		_, edges, err := models.FindCanvasVersionSpecInTransaction(tx, node.WorkflowID, run.VersionID)
 		if err != nil {
 			return nil, err
 		}
 
 		sources := []core.Node{}
-		for _, edge := range liveEdges {
+		for _, edge := range edges {
 			if edge.TargetID == node.NodeID {
 				sources = append(sources, core.Node{
 					ID: edge.SourceID,
@@ -234,6 +235,14 @@ func BuildProcessQueueContext(
 	}
 
 	return ctx, nil
+}
+
+func findQueueItemRunInTransaction(tx *gorm.DB, queueItem *models.CanvasNodeQueueItem) (*models.CanvasRun, error) {
+	if queueItem.RunID != uuid.Nil {
+		return models.FindCanvasRunInTransaction(tx, queueItem.WorkflowID, queueItem.RunID)
+	}
+
+	return models.FindCanvasRunByRootEventInTransaction(tx, queueItem.RootEventID)
 }
 
 func uniqueSourceNodes(nodes []core.Node) []core.Node {

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -243,13 +243,8 @@ func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models
 		return nil, uuid.Nil, err
 	}
 
-	_, liveEdges, err := models.FindLiveCanvasSpecInTransaction(tx, canvas.ID)
-	if err != nil {
-		return nil, uuid.Nil, err
-	}
-
 	if event.ExecutionID == nil {
-		return w.processRootEvent(tx, canvas, liveEdges, event)
+		return w.processRootEvent(tx, canvas, event)
 	}
 
 	execution, err := models.FindNodeExecutionInTransaction(tx, event.WorkflowID, *event.ExecutionID)
@@ -257,7 +252,12 @@ func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models
 		return nil, uuid.Nil, err
 	}
 
-	queueItems, err := w.processExecutionEvent(tx, logger, canvas, liveEdges, execution, event)
+	_, edges, err := findRunCanvasSpecInTransaction(tx, canvas.ID, execution.RunID)
+	if err != nil {
+		return nil, uuid.Nil, err
+	}
+
+	queueItems, err := w.processExecutionEvent(tx, logger, canvas, edges, execution, event)
 	return queueItems, execution.RunID, err
 }
 
@@ -272,10 +272,29 @@ func findOutgoingEdges(edges []models.Edge, sourceID string, channel string) []m
 	return matches
 }
 
-func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, edges []models.Edge, event *models.CanvasEvent) ([]models.CanvasNodeQueueItem, uuid.UUID, error) {
+func findRunCanvasSpecInTransaction(tx *gorm.DB, workflowID, runID uuid.UUID) ([]models.Node, []models.Edge, error) {
+	run, err := models.FindCanvasRunInTransaction(tx, workflowID, runID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return models.FindCanvasVersionSpecInTransaction(tx, workflowID, run.VersionID)
+}
+
+func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, event *models.CanvasEvent) ([]models.CanvasNodeQueueItem, uuid.UUID, error) {
 	now := time.Now()
 
 	w.logger.Infof("Processing root event %s", event.ID)
+
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(tx, event)
+	if err != nil {
+		return nil, uuid.Nil, err
+	}
+
+	_, edges, err := models.FindCanvasVersionSpecInTransaction(tx, canvas.ID, run.VersionID)
+	if err != nil {
+		return nil, uuid.Nil, err
+	}
 
 	outgoingEdges := findOutgoingEdges(edges, event.NodeID, event.Channel)
 	if len(outgoingEdges) == 0 {
@@ -283,12 +302,7 @@ func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, edges
 			return nil, uuid.Nil, err
 		}
 
-		return nil, event.RunID, nil
-	}
-
-	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(tx, event)
-	if err != nil {
-		return nil, uuid.Nil, err
+		return nil, run.ID, nil
 	}
 
 	var queueItems []models.CanvasNodeQueueItem

--- a/pkg/workers/event_router_test.go
+++ b/pkg/workers/event_router_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	testconsumer "github.com/superplanehq/superplane/test/consumer"
 	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 func Test__EventRouter_ProcessRootEvent(t *testing.T) {
@@ -204,6 +206,59 @@ func Test__EventRouter_ProcessExecutionEvent(t *testing.T) {
 	assert.False(t, runConsumer.HasReceivedMessage())
 }
 
+func Test__EventRouter_ProcessExecutionEventUsesRunVersionEdges(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	router := NewEventRouter(amqpURL)
+	logger := log.NewEntry(log.New())
+	r := support.Setup(t)
+
+	trigger := "trigger-1"
+	node1 := "component-1"
+	node2 := "component-2"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: trigger, Type: models.NodeTypeTrigger},
+			{NodeID: node1, Type: models.NodeTypeComponent},
+			{NodeID: node2, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: trigger, TargetID: node1, Channel: "default"},
+			{SourceID: node1, TargetID: node2, Channel: "default"},
+		},
+	)
+
+	triggerEvent := support.EmitCanvasEventForNode(t, canvas.ID, trigger, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), triggerEvent)
+	require.NoError(t, err)
+	require.NoError(t, triggerEvent.Routed())
+
+	publishCanvasVersionWithEdges(t, canvas.ID, []models.Edge{
+		{SourceID: trigger, TargetID: node1, Channel: "default"},
+	})
+
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, node1, triggerEvent.ID, triggerEvent.ID)
+	execution.RunID = run.ID
+	require.NoError(t, database.Conn().Save(execution).Error)
+	_, err = execution.Pass(map[string][]any{"default": {map[string]any{}}})
+	require.NoError(t, err)
+
+	events, err := models.ListCanvasEvents(canvas.ID, node1, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	err = router.LockAndProcessEvent(logger, events[0], time.Now())
+	require.NoError(t, err)
+
+	queueItems, err := models.ListNodeQueueItems(canvas.ID, node2, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, queueItems, 1)
+	assert.Equal(t, run.ID, queueItems[0].RunID)
+}
+
 func Test__EventRouter_ProcessTerminalExecutionEventFinishesRun(t *testing.T) {
 	amqpURL, _ := config.RabbitMQURL()
 
@@ -256,4 +311,36 @@ func Test__EventRouter_ProcessTerminalExecutionEventFinishesRun(t *testing.T) {
 	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
 	assert.Equal(t, models.CanvasRunResultPassed, updatedRun.Result)
 	assert.NotNil(t, updatedRun.FinishedAt)
+}
+
+func publishCanvasVersionWithEdges(t *testing.T, canvasID uuid.UUID, edges []models.Edge) {
+	t.Helper()
+
+	tx := database.Conn()
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(tx, canvasID)
+	require.NoError(t, err)
+
+	now := time.Now()
+	versionID := uuid.New()
+	version := models.CanvasVersion{
+		ID:          versionID,
+		WorkflowID:  canvasID,
+		State:       models.CanvasVersionStatePublished,
+		PublishedAt: &now,
+		Nodes:       liveVersion.Nodes,
+		Edges:       datatypes.NewJSONSlice(edges),
+		CreatedAt:   &now,
+		UpdatedAt:   &now,
+	}
+
+	require.NoError(t, tx.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&version).Error; err != nil {
+			return err
+		}
+
+		return tx.Model(&models.Canvas{}).
+			Where("id = ?", canvasID).
+			Update("live_version_id", versionID).
+			Error
+	}))
 }


### PR DESCRIPTION
## Summary
- route root and execution events using the canvas version pinned on the run
- make merge source counting use the queue item run version instead of the current live canvas
- add regressions for live canvas edits while an older run is in flight

## Context
We observed a release run where `wait-unstable-channel` emitted `Passed` while `Build superplane-demo Docker image` was still running. The code path was reading the current live canvas spec during queue processing and event routing, so publishing canvas edits during an in-flight release could change the source set or outgoing edges for an older run.

## Validation
- `make format.go`
- `make test PKG_TEST_PACKAGES=./pkg/components/merge`
- `make test PKG_TEST_PACKAGES=./pkg/workers`
- `make test PKG_TEST_PACKAGES=./pkg/workers/contexts`
- `git diff --check`

No token values, secret payloads, or raw runner logs are included in this PR.