### PR TITLE
fix: process pending requests for deleted nodes

### DIFF
--- a/pkg/models/canvas_node.go
+++ b/pkg/models/canvas_node.go
@@ -216,6 +216,21 @@ func FindCanvasNode(tx *gorm.DB, canvasID uuid.UUID, nodeID string) (*CanvasNode
 	return &node, nil
 }
 
+func FindUnscopedCanvasNode(tx *gorm.DB, canvasID uuid.UUID, nodeID string) (*CanvasNode, error) {
+	var node CanvasNode
+	err := tx.Unscoped().
+		Where("workflow_id = ?", canvasID).
+		Where("node_id = ?", nodeID).
+		First(&node).
+		Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &node, nil
+}
+
 func FindCanvasNodesByIDs(tx *gorm.DB, canvasID uuid.UUID, nodeIDs []string) ([]CanvasNode, error) {
 	var nodes []CanvasNode
 	err := tx.

--- a/pkg/models/canvas_node_request.go
+++ b/pkg/models/canvas_node_request.go
@@ -50,7 +50,6 @@ func LockNodeRequest(tx *gorm.DB, id uuid.UUID) (*CanvasNodeRequest, error) {
 	query := tx.
 		Table("workflow_node_requests").
 		Select("workflow_node_requests.*").
-		Joins("JOIN workflow_nodes ON workflow_node_requests.workflow_id = workflow_nodes.workflow_id AND workflow_node_requests.node_id = workflow_nodes.node_id").
 		Clauses(clause.Locking{
 			Strength: "UPDATE",
 			Table:    clause.Table{Name: "workflow_node_requests"},
@@ -58,8 +57,7 @@ func LockNodeRequest(tx *gorm.DB, id uuid.UUID) (*CanvasNodeRequest, error) {
 		}).
 		Where("workflow_node_requests.id = ?", id).
 		Where("workflow_node_requests.state = ?", NodeExecutionRequestStatePending).
-		Where("workflow_node_requests.run_at <= ?", now).
-		Where("workflow_nodes.deleted_at IS NULL")
+		Where("workflow_node_requests.run_at <= ?", now)
 
 	err := withActiveCanvas(query, "workflow_node_requests.workflow_id").
 		First(&request).
@@ -79,10 +77,8 @@ func ListNodeRequests() ([]CanvasNodeRequest, error) {
 	query := database.Conn().
 		Table("workflow_node_requests").
 		Select("workflow_node_requests.*").
-		Joins("JOIN workflow_nodes ON workflow_node_requests.workflow_id = workflow_nodes.workflow_id AND workflow_node_requests.node_id = workflow_nodes.node_id").
 		Where("workflow_node_requests.state = ?", NodeExecutionRequestStatePending).
-		Where("workflow_node_requests.run_at <= ?", now).
-		Where("workflow_nodes.deleted_at IS NULL")
+		Where("workflow_node_requests.run_at <= ?", now)
 
 	err := withActiveCanvas(query, "workflow_node_requests.workflow_id").
 		Find(&requests).

--- a/pkg/models/canvas_node_request_test.go
+++ b/pkg/models/canvas_node_request_test.go
@@ -42,6 +42,22 @@ func Test__LockNodeRequest__OnlyLocksDuePendingRequests(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("locks due pending request for deleted node", func(t *testing.T) {
+		request := createCanvasNodeRequest(t, canvas.ID, "schedule-trigger", models.NodeExecutionRequestStatePending, time.Now().Add(-time.Second))
+
+		var node models.CanvasNode
+		require.NoError(t, database.Conn().Where("workflow_id = ? AND node_id = ?", canvas.ID, "schedule-trigger").First(&node).Error)
+		require.NoError(t, database.Conn().Delete(&node).Error)
+
+		err := database.Conn().Transaction(func(tx *gorm.DB) error {
+			locked, err := models.LockNodeRequest(tx, request.ID)
+			require.NoError(t, err)
+			assert.Equal(t, request.ID, locked.ID)
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("does not lock completed request", func(t *testing.T) {
 		request := createCanvasNodeRequest(t, canvas.ID, "schedule-trigger", models.NodeExecutionRequestStateCompleted, time.Now().Add(-time.Second))
 

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -144,9 +144,19 @@ func (w *NodeRequestWorker) invokeHook(logger *log.Entry, tx *gorm.DB, request *
 }
 
 func (w *NodeRequestWorker) invokeNodeHook(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent)) error {
-	node, err := models.FindCanvasNode(tx, request.WorkflowID, request.NodeID)
+	node, err := models.FindUnscopedCanvasNode(tx, request.WorkflowID, request.NodeID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			logger.Infof("Node %s not found - completing request", request.NodeID)
+			return request.Complete(tx)
+		}
+
 		return fmt.Errorf("node not found: %w", err)
+	}
+
+	if node.DeletedAt.Valid {
+		logger.Infof("Node %s deleted - completing request", request.NodeID)
+		return request.Complete(tx)
 	}
 
 	switch node.Type {
@@ -311,9 +321,33 @@ func (w *NodeRequestWorker) invokeExecutionComponentHook(
 	execution *models.CanvasNodeExecution,
 	onNewEvents func([]models.CanvasEvent),
 ) error {
-	node, err := models.FindCanvasNode(tx, execution.WorkflowID, execution.NodeID)
+	node, err := models.FindUnscopedCanvasNode(tx, execution.WorkflowID, execution.NodeID)
 	if err != nil {
-		return fmt.Errorf("node not found: %w", err)
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("node not found: %w", err)
+		}
+
+		//
+		// If the node record does not exist, we cancel the execution before completing the request.
+		//
+		logger.Infof("Node %s not found - cancelling execution and completing request", execution.NodeID)
+		if err := w.cancelExecutionForDeletedNode(logger, tx, node, execution); err != nil {
+			return err
+		}
+
+		return request.Complete(tx)
+	}
+
+	//
+	// If node was deleted, we cancel the execution before completing the request.
+	//
+	if node.DeletedAt.Valid {
+		logger.Infof("Node %s deleted - cancelling execution and completing request", execution.NodeID)
+		if err := w.cancelExecutionForDeletedNode(logger, tx, node, execution); err != nil {
+			return err
+		}
+
+		return request.Complete(tx)
 	}
 
 	spec := request.Spec.Data()
@@ -371,4 +405,62 @@ func (w *NodeRequestWorker) invokeExecutionComponentHook(
 
 	logger.Infof("Request completed")
 	return request.Complete(tx)
+}
+
+func (w *NodeRequestWorker) cancelExecutionForDeletedNode(logger *log.Entry, tx *gorm.DB, node *models.CanvasNode, execution *models.CanvasNodeExecution) error {
+	if execution.State == models.CanvasNodeExecutionStateFinished {
+		return nil
+	}
+
+	ref := node.Ref.Data()
+	if node.Type != models.NodeTypeComponent || ref.Component == nil {
+		return execution.CancelInTransaction(tx, nil)
+	}
+
+	action, err := w.registry.GetAction(ref.Component.Name)
+	if err != nil {
+		return execution.CancelInTransaction(tx, nil)
+	}
+
+	canvas, err := models.FindCanvasWithoutOrgScopeInTransaction(tx, execution.WorkflowID)
+	if err != nil {
+		return fmt.Errorf("canvas not found: %w", err)
+	}
+
+	ctx := core.ExecutionContext{
+		ID:             execution.ID,
+		WorkflowID:     execution.WorkflowID.String(),
+		OrganizationID: canvas.OrganizationID.String(),
+		CanvasName:     canvas.Name,
+		NodeID:         execution.NodeID,
+		NodeName:       node.Name,
+		Configuration:  execution.Configuration.Data(),
+		HTTP:           w.registry.HTTPContextInTransaction(tx),
+		Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
+		ExecutionState: contexts.NewExecutionStateContext(tx, execution, nil),
+		Requests:       contexts.NewExecutionRequestContext(tx, execution),
+		Auth:           contexts.NewAuthReader(tx, canvas.OrganizationID, w.authService, nil),
+	}
+
+	if node.AppInstallationID != nil {
+		integration, err := models.FindUnscopedIntegrationInTransaction(tx, *node.AppInstallationID)
+		if err != nil {
+			logger.Errorf("error finding app installation: %v", err)
+		} else {
+			ctx.Integration = contexts.NewIntegrationContext(tx, node, integration, w.encryptor, w.registry, nil)
+		}
+	}
+
+	ctx.Logger = logging.WithExecution(logger, execution)
+
+	//
+	// Best-effort for calling the Cancel() on the component implementation.
+	// If an error happens, we log it and continue with the execution cancellation.
+	//
+	err = action.Cancel(ctx)
+	if err != nil {
+		logger.Errorf("failed to cancel execution: %v", err)
+	}
+
+	return execution.CancelInTransaction(tx, nil)
 }

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -146,12 +146,7 @@ func (w *NodeRequestWorker) invokeHook(logger *log.Entry, tx *gorm.DB, request *
 func (w *NodeRequestWorker) invokeNodeHook(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent)) error {
 	node, err := models.FindUnscopedCanvasNode(tx, request.WorkflowID, request.NodeID)
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			logger.Infof("Node %s not found - completing request", request.NodeID)
-			return request.Complete(tx)
-		}
-
-		return fmt.Errorf("node not found: %w", err)
+		return fmt.Errorf("failed to find node: %w", err)
 	}
 
 	if node.DeletedAt.Valid {
@@ -323,19 +318,7 @@ func (w *NodeRequestWorker) invokeExecutionComponentHook(
 ) error {
 	node, err := models.FindUnscopedCanvasNode(tx, execution.WorkflowID, execution.NodeID)
 	if err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("node not found: %w", err)
-		}
-
-		//
-		// If the node record does not exist, we cancel the execution before completing the request.
-		//
-		logger.Infof("Node %s not found - cancelling execution and completing request", execution.NodeID)
-		if err := w.cancelExecutionForDeletedNode(logger, tx, node, execution); err != nil {
-			return err
-		}
-
-		return request.Complete(tx)
+		return fmt.Errorf("failed to find node: %w", err)
 	}
 
 	//

--- a/pkg/workers/node_request_worker_test.go
+++ b/pkg/workers/node_request_worker_test.go
@@ -1,17 +1,21 @@
 package workers
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/config"
+	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/registry"
 	testconsumer "github.com/superplanehq/superplane/test/consumer"
 	"github.com/superplanehq/superplane/test/support"
+	"github.com/superplanehq/superplane/test/support/impl"
 	"gorm.io/datatypes"
 )
 
@@ -641,6 +645,78 @@ func Test__NodeRequestWorker_CancelsExecutionForDeletedNodeRequests(t *testing.T
 
 	err := worker.LockAndProcessRequest(request)
 	require.NoError(t, err)
+
+	var updatedRequest models.CanvasNodeRequest
+	err = database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error
+	require.NoError(t, err)
+	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
+
+	var updatedExecution models.CanvasNodeExecution
+	err = database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultCancelled, updatedExecution.Result)
+}
+
+func Test__NodeRequestWorker_CancelsExecutionForDeletedNodeWhenComponentCancelFails(t *testing.T) {
+	cancelCalled := false
+	componentName := "cancel_failing_" + uuid.New().String()
+
+	registry.RegisterAction(componentName, impl.NewDummyAction(impl.DummyActionOptions{
+		Name: componentName,
+		CancelFunc: func(ctx core.ExecutionContext) error {
+			cancelCalled = true
+			return errors.New("cancel failed")
+		},
+	}))
+
+	r := support.Setup(t)
+	defer r.Close()
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, r.GitProvider, "", r.AuthService)
+
+	componentNode := "component-1"
+	canvas, canvasNodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: componentName}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, componentNode, "default", nil)
+	execution := support.CreateNodeExecutionWithConfiguration(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID, map[string]any{})
+	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
+		"state": models.CanvasNodeExecutionStateStarted,
+	}).Error)
+
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		ExecutionID: &execution.ID,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "noop",
+				Parameters: map[string]any{},
+			},
+		}),
+		State: models.NodeExecutionRequestStatePending,
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	require.NoError(t, database.Conn().Delete(&canvasNodes[0]).Error)
+
+	err := worker.LockAndProcessRequest(request)
+	require.NoError(t, err)
+
+	assert.True(t, cancelCalled, "component Cancel should be invoked")
 
 	var updatedRequest models.CanvasNodeRequest
 	err = database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error

--- a/pkg/workers/node_request_worker_test.go
+++ b/pkg/workers/node_request_worker_test.go
@@ -520,18 +520,16 @@ func Test__NodeRequestWorker_NonExistentAction(t *testing.T) {
 	assert.False(t, executionConsumer.HasReceivedMessage())
 }
 
-func Test__NodeRequestWorker_DoesNotProcessDeletedNodeRequests(t *testing.T) {
+func Test__NodeRequestWorker_CompletesDeletedNodeRequests(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, r.GitProvider, "", r.AuthService)
 
 	amqpURL, _ := config.RabbitMQURL()
 	executionConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionPendingRoutingKey)
 	executionConsumer.Start()
 	defer executionConsumer.Stop()
 
-	//
-	// Create a simple canvas with a schedule trigger node.
-	//
 	triggerNode := "trigger-1"
 	canvas, canvasNodes := support.CreateCanvas(
 		t,
@@ -553,9 +551,6 @@ func Test__NodeRequestWorker_DoesNotProcessDeletedNodeRequests(t *testing.T) {
 		[]models.Edge{},
 	)
 
-	//
-	// Create a node request for the trigger.
-	//
 	request := models.CanvasNodeRequest{
 		ID:         uuid.New(),
 		WorkflowID: canvas.ID,
@@ -571,18 +566,11 @@ func Test__NodeRequestWorker_DoesNotProcessDeletedNodeRequests(t *testing.T) {
 	}
 	require.NoError(t, database.Conn().Create(&request).Error)
 
-	//
-	// Soft delete the workflow node.
-	//
 	require.NoError(t, database.Conn().Delete(&canvasNodes[0]).Error)
 
-	//
-	// Verify that ListNodeRequests does not return the request for the deleted node.
-	//
 	requests, err := models.ListNodeRequests()
 	require.NoError(t, err)
 
-	// Check that our request is not in the list
 	found := false
 	for _, req := range requests {
 		if req.ID == request.ID {
@@ -590,9 +578,80 @@ func Test__NodeRequestWorker_DoesNotProcessDeletedNodeRequests(t *testing.T) {
 			break
 		}
 	}
-	assert.False(t, found, "Request for deleted node should not be returned by ListNodeRequests")
+	assert.True(t, found, "Request for deleted node should be returned by ListNodeRequests")
+
+	err = worker.LockAndProcessRequest(request)
+	require.NoError(t, err)
+
+	var updatedRequest models.CanvasNodeRequest
+	err = database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error
+	require.NoError(t, err)
+	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
+
+	eventCount, err := models.CountCanvasEvents(canvas.ID, triggerNode)
+	require.NoError(t, err)
+	assert.Zero(t, eventCount)
 
 	assert.False(t, executionConsumer.HasReceivedMessage())
+}
+
+func Test__NodeRequestWorker_CancelsExecutionForDeletedNodeRequests(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, r.GitProvider, "", r.AuthService)
+
+	componentNode := "component-1"
+	canvas, canvasNodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, componentNode, "default", nil)
+	execution := support.CreateNodeExecutionWithConfiguration(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID, map[string]any{})
+	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
+		"state": models.CanvasNodeExecutionStateStarted,
+	}).Error)
+
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		ExecutionID: &execution.ID,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "noop",
+				Parameters: map[string]interface{}{},
+			},
+		}),
+		State: models.NodeExecutionRequestStatePending,
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	require.NoError(t, database.Conn().Delete(&canvasNodes[0]).Error)
+
+	err := worker.LockAndProcessRequest(request)
+	require.NoError(t, err)
+
+	var updatedRequest models.CanvasNodeRequest
+	err = database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error
+	require.NoError(t, err)
+	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
+
+	var updatedExecution models.CanvasNodeExecution
+	err = database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultCancelled, updatedExecution.Result)
 }
 
 func Test__NodeRequestWorker_DoesNotProcessDeletedWorkflowRequests(t *testing.T) {


### PR DESCRIPTION
Closes #5736

---

The issue is described in [this comment](https://github.com/superplanehq/superplane/issues/5736). We fix it by no longer ignoring requests from deleted nodes:
  - For node-level requests: completes the request without invoking the hook
  - For execution-level requests: cancels the execution then completes the request

We still ignore pending requests for deleted **canvases** and **organizations**, since the cleanup workers will handle those.