### PR TITLE
fix: silence Dash0 telemetry export noise in Sentry

### DIFF
--- a/web_src/src/sentry.ts
+++ b/web_src/src/sentry.ts
@@ -5,6 +5,9 @@ interface SentryWindow extends Window {
   SUPERPLANE_SENTRY_ENVIRONMENT?: string;
 }
 
+// Dash0 Web SDK logs export failures to the console; captureConsoleIntegration would forward them.
+const DASH0_TELEMETRY_CONSOLE_IGNORE = /^(Failed to send telemetry to|Error sending telemetry to)/;
+
 let dsn: string | undefined;
 let environment: string | undefined;
 
@@ -18,6 +21,18 @@ if (dsn) {
   Sentry.init({
     dsn,
     environment,
+    ignoreErrors: [DASH0_TELEMETRY_CONSOLE_IGNORE],
+    beforeBreadcrumb(breadcrumb) {
+      if (
+        breadcrumb.category === "console" &&
+        typeof breadcrumb.message === "string" &&
+        DASH0_TELEMETRY_CONSOLE_IGNORE.test(breadcrumb.message)
+      ) {
+        return null;
+      }
+
+      return breadcrumb;
+    },
     integrations: [
       Sentry.captureConsoleIntegration({
         levels: ["warn", "error"],


### PR DESCRIPTION
## Summary

- Filter Dash0 Web SDK console warnings out of Sentry via `ignoreErrors` and `beforeBreadcrumb`.
- Stops observability export failures (400 responses, blocked requests, network errors) from creating Sentry events or breadcrumbs.

The Dash0 Web SDK logs export failures to the browser console when it cannot send telemetry to Dash0 (e.g. ad blockers, ingest rejections, connectivity issues). We capture console `warn`/`error` output in Sentry, so those SDK messages were being reported as production issues even though they are expected noise from a secondary telemetry pipeline—not application bugs.

Fixes https://github.com/superplanehq/superplane/issues/5683

## Test plan

- [ ] Load the app with Sentry and Dash0 enabled; confirm Dash0 export failures no longer appear as Sentry events
- [ ] Confirm unrelated console warnings/errors still reach Sentry
- [ ] Confirm real application errors still reach Sentry


Made with [Cursor](https://cursor.com)