### PR TITLE
fix: silence Dash0 telemetry export noise in Sentry

### DIFF
--- a/web_src/src/sentry.ts
+++ b/web_src/src/sentry.ts
@@ -1,4 +1,9 @@
 import * as Sentry from "@sentry/react";
+import {
+  DASH0_TELEMETRY_CONSOLE_IGNORE,
+  shouldDropDash0TelemetryBreadcrumb,
+  shouldDropDash0TelemetryEvent,
+} from "@/sentryDash0Filters";
 
 interface SentryWindow extends Window {
   SUPERPLANE_SENTRY_DSN?: string;
@@ -18,6 +23,13 @@ if (dsn) {
   Sentry.init({
     dsn,
     environment,
+    ignoreErrors: [DASH0_TELEMETRY_CONSOLE_IGNORE],
+    beforeSend(event) {
+      return shouldDropDash0TelemetryEvent(event) ? null : event;
+    },
+    beforeBreadcrumb(breadcrumb) {
+      return shouldDropDash0TelemetryBreadcrumb(breadcrumb) ? null : breadcrumb;
+    },
     integrations: [
       Sentry.captureConsoleIntegration({
         levels: ["warn", "error"],

--- a/web_src/src/sentryDash0Filters.spec.ts
+++ b/web_src/src/sentryDash0Filters.spec.ts
@@ -1,0 +1,103 @@
+import type { Breadcrumb, ErrorEvent } from "@sentry/react";
+import { describe, expect, it } from "vitest";
+import {
+  isDash0TelemetryConsoleMessage,
+  shouldDropDash0TelemetryBreadcrumb,
+  shouldDropDash0TelemetryEvent,
+} from "@/sentryDash0Filters";
+
+describe("sentryDash0Filters", () => {
+  describe("isDash0TelemetryConsoleMessage", () => {
+    it("matches Dash0 export failure console messages", () => {
+      expect(
+        isDash0TelemetryConsoleMessage(
+          "Error sending telemetry to https://ingress.us-west-2.aws.dash0.com/v1/traces: TypeError: Failed to fetch",
+        ),
+      ).toBe(true);
+      expect(
+        isDash0TelemetryConsoleMessage(
+          "Failed to send telemetry to https://ingress.us-west-2.aws.dash0.com/v1/traces: 400 Bad Request",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not match unrelated console messages", () => {
+      expect(isDash0TelemetryConsoleMessage("Failed to fetch canvas data")).toBe(false);
+      expect(isDash0TelemetryConsoleMessage("TypeError: Failed to fetch")).toBe(false);
+    });
+  });
+
+  describe("shouldDropDash0TelemetryBreadcrumb", () => {
+    it("drops Dash0 telemetry console breadcrumbs", () => {
+      const breadcrumb: Breadcrumb = {
+        category: "console",
+        message:
+          "Error sending telemetry to https://ingress.us-west-2.aws.dash0.com/v1/traces: TypeError: Failed to fetch",
+      };
+
+      expect(shouldDropDash0TelemetryBreadcrumb(breadcrumb)).toBe(true);
+    });
+
+    it("keeps unrelated console breadcrumbs", () => {
+      const breadcrumb: Breadcrumb = {
+        category: "console",
+        message: "Canvas load failed",
+      };
+
+      expect(shouldDropDash0TelemetryBreadcrumb(breadcrumb)).toBe(false);
+    });
+  });
+
+  describe("shouldDropDash0TelemetryEvent", () => {
+    it("drops Failed to fetch events paired with Dash0 telemetry console breadcrumbs", () => {
+      const event: ErrorEvent = {
+        type: undefined,
+        exception: {
+          values: [{ type: "TypeError", value: "Failed to fetch" }],
+        },
+        breadcrumbs: [
+          {
+            category: "console",
+            message:
+              "Error sending telemetry to https://ingress.us-west-2.aws.dash0.com/v1/traces: TypeError: Failed to fetch",
+          },
+        ],
+      };
+
+      expect(shouldDropDash0TelemetryEvent(event)).toBe(true);
+    });
+
+    it("drops events whose message is a Dash0 telemetry console warning", () => {
+      const event: ErrorEvent = {
+        type: undefined,
+        exception: {
+          values: [
+            {
+              type: "Error",
+              value: "Failed to send telemetry to https://ingress.us-west-2.aws.dash0.com/v1/traces: 400 Bad Request",
+            },
+          ],
+        },
+      };
+
+      expect(shouldDropDash0TelemetryEvent(event)).toBe(true);
+    });
+
+    it("keeps unrelated Failed to fetch events", () => {
+      const event: ErrorEvent = {
+        type: undefined,
+        exception: {
+          values: [{ type: "TypeError", value: "Failed to fetch" }],
+        },
+        breadcrumbs: [
+          {
+            category: "fetch",
+            message: "GET https://app.superplane.com/api/v1/canvases",
+          },
+        ],
+      };
+
+      expect(shouldDropDash0TelemetryEvent(event)).toBe(false);
+    });
+  });
+});

--- a/web_src/src/sentryDash0Filters.ts
+++ b/web_src/src/sentryDash0Filters.ts
@@ -1,0 +1,46 @@
+import type { Breadcrumb, ErrorEvent } from "@sentry/react";
+
+// Dash0 Web SDK logs export failures to the console; captureConsoleIntegration would forward them.
+export const DASH0_TELEMETRY_CONSOLE_IGNORE = /^(Failed to send telemetry to|Error sending telemetry to)/;
+
+export function isDash0TelemetryConsoleMessage(message: string): boolean {
+  return DASH0_TELEMETRY_CONSOLE_IGNORE.test(message);
+}
+
+export function shouldDropDash0TelemetryBreadcrumb(breadcrumb: Breadcrumb): boolean {
+  return (
+    breadcrumb.category === "console" &&
+    typeof breadcrumb.message === "string" &&
+    isDash0TelemetryConsoleMessage(breadcrumb.message)
+  );
+}
+
+function hasDash0TelemetryConsoleBreadcrumb(breadcrumbs: Breadcrumb[] | undefined): boolean {
+  return (
+    breadcrumbs?.some(
+      (breadcrumb) =>
+        breadcrumb.category === "console" &&
+        typeof breadcrumb.message === "string" &&
+        (isDash0TelemetryConsoleMessage(breadcrumb.message) || breadcrumb.message.includes("dash0.com")),
+    ) ?? false
+  );
+}
+
+export function shouldDropDash0TelemetryEvent(event: ErrorEvent): boolean {
+  const exception = event.exception?.values?.[0];
+  if (!exception) {
+    return false;
+  }
+
+  const message = exception.value ?? "";
+  if (typeof message === "string" && isDash0TelemetryConsoleMessage(message)) {
+    return true;
+  }
+
+  // captureConsoleIntegration emits the underlying fetch error from console.warn(..., error).
+  if (exception.type === "TypeError" && message === "Failed to fetch") {
+    return hasDash0TelemetryConsoleBreadcrumb(event.breadcrumbs);
+  }
+
+  return false;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stops Dash0 Web SDK telemetry export failures from being reported to Sentry as production errors.

When the browser cannot send telemetry to Dash0 (ad blockers, network issues, ingest rejections), the Dash0 Web SDK logs warnings to the console. SuperPlane captures console `warn`/`error` output in Sentry via `captureConsoleIntegration`, so those SDK messages were creating Sentry events and breadcrumbs even though they are expected noise from a secondary telemetry pipeline—not application bugs.

## Changes

- Added `sentryDash0Filters.ts` with shared filter helpers and unit tests.
- Configured Sentry `ignoreErrors` and `beforeBreadcrumb` to drop Dash0 telemetry console messages (`Failed to send telemetry to…`, `Error sending telemetry to…`).
- Added `beforeSend` to drop the underlying `TypeError: Failed to fetch` events that `captureConsoleIntegration` emits when the SDK passes the fetch error as a console argument (the exact failure mode shown in the issue screenshot).

## Review feedback addressed

- **Issue #5683 / screenshot from @shiroyasha:** The Sentry breadcrumbs showed both a Dash0 console warning and a separate `TypeError: Failed to fetch` exception. Filtering console messages alone (as in #5784) does not suppress the exception event; `beforeSend` now drops those paired failures while leaving unrelated `Failed to fetch` errors intact.
- **No agent review comment** was present on the issue; implementation follows the human-provided Sentry breadcrumb evidence.

Fixes #5683

## Test plan

- [x] `npm run test -- src/sentryDash0Filters.spec.ts` (7 tests)
- [x] `make check.build.ui`
- [ ] Load the app with Sentry and Dash0 enabled; confirm Dash0 export failures no longer appear as Sentry events
- [ ] Confirm unrelated console warnings/errors and real application errors still reach Sentry

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e33847e8-5943-496b-a4a0-4defdc753d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e33847e8-5943-496b-a4a0-4defdc753d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

