### PR TITLE
fix: resolve missing expression tokens as null

### DIFF
--- a/pkg/components/merge/merge_test.go
+++ b/pkg/components/merge/merge_test.go
@@ -123,7 +123,7 @@ func Test_Merge_StopIfExpressionEvaluationError(t *testing.T) {
 
 	steps.ProcessFirstEventExpectFinish(m)
 	steps.AssertNodeExecutionCount(1)
-	steps.AssertExecutionFailedWithError("node name missing-node not found in execution chain")
+	steps.AssertExecutionFailedWithErrorContaining("expression evaluation failed")
 	steps.AssertNodeIsAllowedToProcessNextQueueItem()
 
 	steps.ProcessSecondEventExpectNoFinish(m)
@@ -587,6 +587,15 @@ func (s *MergeTestSteps) AssertExecutionFailedWithError(errorMessage string) {
 	assert.Equal(s.t, models.CanvasNodeExecutionResultFailed, execution.Result)
 	assert.Equal(s.t, "error", execution.ResultReason)
 	assert.Equal(s.t, errorMessage, execution.ResultMessage)
+}
+
+func (s *MergeTestSteps) AssertExecutionFailedWithErrorContaining(errorMessage string) {
+	var execution models.CanvasNodeExecution
+	require.NoError(s.t, s.Tx.Where("node_id = ?", s.MergeNode.NodeID).First(&execution).Error)
+	assert.Equal(s.t, models.CanvasNodeExecutionStateFinished, execution.State)
+	assert.Equal(s.t, models.CanvasNodeExecutionResultFailed, execution.Result)
+	assert.Equal(s.t, "error", execution.ResultReason)
+	assert.Contains(s.t, execution.ResultMessage, errorMessage)
 }
 
 // AssertExecutionFailed checks that the execution finished and emitted to the fail channel.

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -242,7 +242,8 @@ func asAnyMap(value any) (map[string]any, bool) {
 }
 
 func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string) (any, error) {
-	if !expressionRegex.MatchString(expression) {
+	matches := expressionRegex.FindAllStringIndex(expression, -1)
+	if len(matches) == 0 {
 		return expression, nil
 	}
 
@@ -410,20 +411,29 @@ func (b *NodeConfigurationBuilder) buildMessageChain(referencedNodes []string) (
 		executionChainNodeIDs = append(executionChainNodeIDs, rootEvent.NodeID)
 	}
 
-	refToNodeID, err := b.resolveNodeRefs(referencedNodes, executionChainNodeIDs)
+	nodeRefs, err := b.resolveNodeRefs(referencedNodes, executionChainNodeIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	chainRefs := populateFromInputOrRoot(messageChain, inputMap, rootEvent, refToNodeID)
+	for _, nodeRef := range nodeRefs.unresolved {
+		messageChain[nodeRef] = nil
+	}
+
+	chainRefs := populateFromInputOrRoot(messageChain, inputMap, rootEvent, nodeRefs.byRef)
 
 	if len(chainRefs) == 0 {
-		b.injectConfigIntoMessageChain(messageChain, refToNodeID, executionByNodeID)
+		b.injectConfigIntoMessageChain(messageChain, nodeRefs.byRef, executionByNodeID)
 		return messageChain, nil
 	}
 
 	if b.previousExecutionID == nil {
-		return nil, fmt.Errorf("node name %s not found in execution chain", firstChainRef(chainRefs))
+		for nodeRef := range chainRefs {
+			messageChain[nodeRef] = nil
+		}
+
+		b.injectConfigIntoMessageChain(messageChain, nodeRefs.byRef, executionByNodeID)
+		return messageChain, nil
 	}
 
 	err = b.populateFromExecutions(messageChain, chainRefs, executionByNodeID)
@@ -431,7 +441,7 @@ func (b *NodeConfigurationBuilder) buildMessageChain(referencedNodes []string) (
 		return nil, err
 	}
 
-	b.injectConfigIntoMessageChain(messageChain, refToNodeID, executionByNodeID)
+	b.injectConfigIntoMessageChain(messageChain, nodeRefs.byRef, executionByNodeID)
 	return messageChain, nil
 }
 
@@ -553,13 +563,6 @@ func (b *NodeConfigurationBuilder) injectConfigIntoMessageChain(
 	}
 }
 
-func firstChainRef(chainRefs map[string]string) string {
-	for nodeRef := range chainRefs {
-		return nodeRef
-	}
-	return ""
-}
-
 func extractInputMap(input any) map[string]any {
 	if inputMap, ok := input.(map[string]any); ok {
 		return inputMap
@@ -649,6 +652,8 @@ func normalizeJSONNumber(value json.Number) any {
 
 func formatTemplateValue(value any) string {
 	switch v := value.(type) {
+	case nil:
+		return "null"
 	case float32:
 		return strconv.FormatFloat(float64(v), 'f', -1, 32)
 	case float64:
@@ -658,10 +663,15 @@ func formatTemplateValue(value any) string {
 	}
 }
 
-func (b *NodeConfigurationBuilder) resolveNodeRefs(nodeRefs []string, executionChainNodeIDs []string) (map[string]string, error) {
+type resolvedNodeRefs struct {
+	byRef      map[string]string
+	unresolved []string
+}
+
+func (b *NodeConfigurationBuilder) resolveNodeRefs(nodeRefs []string, executionChainNodeIDs []string) (resolvedNodeRefs, error) {
 	nodes, err := models.FindCanvasNodesInTransaction(b.tx, b.workflowID)
 	if err != nil {
-		return nil, err
+		return resolvedNodeRefs{}, err
 	}
 
 	nameToNodeID := make(map[string]string, len(nodes))
@@ -693,10 +703,10 @@ func (b *NodeConfigurationBuilder) resolveNodeRefs(nodeRefs []string, executionC
 		executionChainOrder[nodeID] = i
 	}
 
-	refToNodeID := make(map[string]string, len(nodeRefs))
+	resolved := resolvedNodeRefs{byRef: make(map[string]string, len(nodeRefs))}
 	for _, nodeRef := range nodeRefs {
 		if nodeID, ok := nameToNodeID[nodeRef]; ok {
-			refToNodeID[nodeRef] = nodeID
+			resolved.byRef[nodeRef] = nodeID
 			continue
 		}
 
@@ -714,17 +724,17 @@ func (b *NodeConfigurationBuilder) resolveNodeRefs(nodeRefs []string, executionC
 			}
 
 			if closestNodeID != "" {
-				refToNodeID[nodeRef] = closestNodeID
+				resolved.byRef[nodeRef] = closestNodeID
 				continue
 			}
 
-			return nil, fmt.Errorf("node name %s is not unique and none of the matching nodes are in the execution chain", nodeRef)
+			return resolvedNodeRefs{}, fmt.Errorf("node name %s is not unique and none of the matching nodes are in the execution chain", nodeRef)
 		}
 
-		return nil, fmt.Errorf("node name %s not found in execution chain", nodeRef)
+		resolved.unresolved = append(resolved.unresolved, nodeRef)
 	}
 
-	return refToNodeID, nil
+	return resolved, nil
 }
 
 func (b *NodeConfigurationBuilder) fetchRootEvent() (*models.CanvasEvent, error) {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -809,7 +809,7 @@ func Test_NodeConfigurationBuilder_NodeIDNotAllowed(t *testing.T) {
 
 	_, err := builder.Build(configuration)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "node name node-1 not found in execution chain")
+	assert.Contains(t, err.Error(), "expression evaluation failed")
 }
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root_NoRootEvent(t *testing.T) {
@@ -835,7 +835,7 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root_NoRootEvent(t *testing
 
 	_, err := builder.Build(configuration)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found in execution chain")
+	assert.Contains(t, err.Error(), "expression evaluation failed")
 }
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain(t *testing.T) {
@@ -1166,7 +1166,7 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain_NoPreviousExecution(t
 
 	_, err := builder.Build(configuration)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found in execution chain")
+	assert.Contains(t, err.Error(), "expression evaluation failed")
 }
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain_NodeNotInChain(t *testing.T) {
@@ -1199,7 +1199,41 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain_NodeNotInChain(t *tes
 
 	_, err := builder.Build(configuration)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found in execution chain")
+	assert.Contains(t, err.Error(), "expression evaluation failed")
+}
+
+func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain_MissingReferenceResolvesNil(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	node1 := "node-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: node1, Name: node1, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, node1, "default", nil)
+	execution1 := support.CreateCanvasNodeExecution(t, canvas.ID, node1, rootEvent.ID, rootEvent.ID)
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithPreviousExecution(&execution1.ID).
+		WithInput(map[string]any{})
+
+	result, err := builder.Build(map[string]any{
+		"field": "{{ $[\"token that does not exist\"] }}",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "null", result["field"])
+
+	value, err := builder.ResolveExpression(`$["token that does not exist"]`)
+	require.NoError(t, err)
+	assert.Nil(t, value)
 }
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain_KnownNodeWithoutExecutionResolvesNil(t *testing.T) {


### PR DESCRIPTION
## Summary
- Resolve missing `$["..."]` node references as null instead of failing while building the expression environment
- Keep ambiguous node-name errors intact and preserve dereference failures as expression evaluation errors
- Add regression coverage for missing expression token resolution

## Tests
- `gofmt -w pkg/workers/contexts/node_configuration_builder.go pkg/workers/contexts/node_configuration_builder_test.go`
- `git diff --check`
- `go test ./pkg/components/runner -run TestRunnerExecuteSendsEnvironmentToBroker`

Note: `make format.go` and targeted `go test ./pkg/workers/contexts ...` were blocked locally because Docker was unavailable and generated protobuf packages were missing in the checkout.