### PR TITLE
chore: migrate SuperPlane JWT usage to jwt/v5 [wip]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.63.0
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -70,6 +69,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/expr-lang/expr v1.17.7
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-github/v84 v84.0.0
@@ -35,6 +34,7 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.63.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -63,13 +63,13 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	jwtLib "github.com/golang-jwt/jwt/v4"
+	jwtLib "github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
@@ -824,8 +824,8 @@ func (a *Handler) generateMagicLinkToken(email, code string) (string, error) {
 	token := jwtLib.NewWithClaims(jwtLib.SigningMethodHS256, jwtLib.MapClaims{
 		"email": email,
 		"code":  code,
-		"iat":   now.Unix(),
-		"exp":   now.Add(magicCodeTTL).Unix(),
+		"iat":   jwtLib.NewNumericDate(now),
+		"exp":   jwtLib.NewNumericDate(now.Add(magicCodeTTL)),
 		"type":  "magic_link",
 	})
 

--- a/pkg/authentication/session.go
+++ b/pkg/authentication/session.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	jwtLib "github.com/golang-jwt/jwt/v4"
+	jwtLib "github.com/golang-jwt/jwt/v5"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 )

--- a/pkg/authentication/session_test.go
+++ b/pkg/authentication/session_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	jwtLib "github.com/golang-jwt/jwt/v4"
+	jwtLib "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/jwt"

--- a/pkg/components/runner/live_log_session.go
+++ b/pkg/components/runner/live_log_session.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	gojwt "github.com/golang-jwt/jwt/v4"
+	gojwt "github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -187,7 +187,8 @@ func ValidateLiveLogStreamToken(tokenString, brokerTaskID, secret string) error 
 	}
 
 	claims := &LiveLogStreamTokenClaims{}
-	token, err := gojwt.ParseWithClaims(tokenString, claims, func(token *gojwt.Token) (any, error) {
+	parser := gojwt.NewParser(gojwt.WithAudience(LiveLogStreamTokenAudience))
+	token, err := parser.ParseWithClaims(tokenString, claims, func(token *gojwt.Token) (any, error) {
 		if _, ok := token.Method.(*gojwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method")
 		}
@@ -201,9 +202,6 @@ func ValidateLiveLogStreamToken(tokenString, brokerTaskID, secret string) error 
 	}
 	if claims.Purpose != LiveLogStreamTokenPurpose {
 		return fmt.Errorf("invalid purpose")
-	}
-	if !claims.VerifyAudience(LiveLogStreamTokenAudience, true) {
-		return fmt.Errorf("invalid audience")
 	}
 	if strings.TrimSpace(claims.TaskID) != brokerTaskID {
 		return fmt.Errorf("task id mismatch")

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type Signer struct {
@@ -25,9 +25,9 @@ func (s *Signer) Generate(subject string, duration time.Duration) (string, error
 func (s *Signer) GenerateWithClaims(duration time.Duration, extraClaims map[string]string) (string, error) {
 	now := time.Now()
 	claims := jwt.MapClaims{
-		"iat": now.Unix(),
-		"nbf": now.Unix(),
-		"exp": now.Add(duration).Unix(),
+		"iat": jwt.NewNumericDate(now),
+		"nbf": jwt.NewNumericDate(now),
+		"exp": jwt.NewNumericDate(now.Add(duration)),
 	}
 
 	for k, v := range extraClaims {
@@ -49,47 +49,38 @@ func (s *Signer) GenerateWithClaims(duration time.Duration, extraClaims map[stri
 }
 
 func (s *Signer) Validate(tokenString, subject string) error {
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 
 		return []byte(s.Secret), nil
 	})
-
 	if err != nil {
 		return err
 	}
 
-	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
-		epochSeconds := time.Now().Unix()
-		if !claims.VerifyExpiresAt(epochSeconds, true) {
-			return errors.New("missing exp")
-		}
-
-		if !claims.VerifyNotBefore(epochSeconds, true) {
-			return errors.New("missing nbf")
-		}
-
-		if claims["sub"] != subject {
-			return errors.New("subject is invalid")
-		}
-
-		return nil
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return errors.New("invalid token")
 	}
 
-	return errors.New("invalid token")
+	sub, _ := claims["sub"].(string)
+	if sub != subject {
+		return errors.New("subject is invalid")
+	}
+
+	return nil
 }
 
 // ValidateAndGetClaims validates a JWT token and returns the claims
 func (s *Signer) ValidateAndGetClaims(tokenString string) (jwt.MapClaims, error) {
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return []byte(s.Secret), nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -101,13 +92,6 @@ func (s *Signer) ValidateAndGetClaims(tokenString string) (jwt.MapClaims, error)
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
 		return nil, fmt.Errorf("invalid token claims")
-	}
-
-	// Check expiration
-	if exp, ok := claims["exp"].(float64); ok {
-		if time.Now().Unix() > int64(exp) {
-			return nil, fmt.Errorf("token expired")
-		}
 	}
 
 	return claims, nil

--- a/pkg/jwt/scoped.go
+++ b/pkg/jwt/scoped.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	gojwt "github.com/golang-jwt/jwt/v4"
+	gojwt "github.com/golang-jwt/jwt/v5"
 )
 
 const ScopedTokenType = "scoped"
@@ -28,6 +28,63 @@ type Permission struct {
 	ResourceType string   `json:"resourceType"`
 	Action       string   `json:"action"`
 	Resources    []string `json:"resources,omitempty"`
+}
+
+func (c ScopedTokenClaims) GetExpirationTime() (*gojwt.NumericDate, error) {
+	return c.ExpiresAt, nil
+}
+
+func (c ScopedTokenClaims) GetIssuedAt() (*gojwt.NumericDate, error) {
+	return c.IssuedAt, nil
+}
+
+func (c ScopedTokenClaims) GetNotBefore() (*gojwt.NumericDate, error) {
+	return c.NotBefore, nil
+}
+
+func (c ScopedTokenClaims) GetIssuer() (string, error) {
+	return "", nil
+}
+
+func (c ScopedTokenClaims) GetSubject() (string, error) {
+	return c.Subject, nil
+}
+
+func (c ScopedTokenClaims) GetAudience() (gojwt.ClaimStrings, error) {
+	if strings.TrimSpace(c.Audience) == "" {
+		return gojwt.ClaimStrings{}, nil
+	}
+
+	return gojwt.ClaimStrings{c.Audience}, nil
+}
+
+func (c ScopedTokenClaims) Validate() error {
+	if c.TokenType != ScopedTokenType {
+		return fmt.Errorf("invalid token_type")
+	}
+
+	if strings.TrimSpace(c.Subject) == "" {
+		return fmt.Errorf("subject is required")
+	}
+
+	if strings.TrimSpace(c.OrgID) == "" {
+		return fmt.Errorf("org_id is required")
+	}
+
+	if strings.TrimSpace(c.Purpose) == "" {
+		return fmt.Errorf("purpose is required")
+	}
+
+	scopes := normalizeScopedTokenValues(c.Scopes)
+	if len(scopes) == 0 {
+		return fmt.Errorf("at least one scope is required")
+	}
+
+	if len(PermissionsFromScopes(scopes)) == 0 {
+		return fmt.Errorf("at least one scope is required")
+	}
+
+	return nil
 }
 
 func (s *Signer) GenerateScopedToken(claims ScopedTokenClaims, duration time.Duration) (string, error) {
@@ -69,7 +126,9 @@ func (s *Signer) GenerateScopedToken(claims ScopedTokenClaims, duration time.Dur
 }
 
 func (s *Signer) ValidateScopedToken(tokenString string) (*ScopedTokenClaims, error) {
-	token, err := gojwt.ParseWithClaims(tokenString, &ScopedTokenClaims{}, func(token *gojwt.Token) (any, error) {
+	claims := &ScopedTokenClaims{}
+	parser := gojwt.NewParser(gojwt.WithAudience(ScopedTokenAudience))
+	token, err := parser.ParseWithClaims(tokenString, claims, func(token *gojwt.Token) (any, error) {
 		if _, ok := token.Method.(*gojwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
@@ -80,67 +139,17 @@ func (s *Signer) ValidateScopedToken(tokenString string) (*ScopedTokenClaims, er
 		return nil, err
 	}
 
-	claims, ok := token.Claims.(*ScopedTokenClaims)
-	if !ok || !token.Valid {
+	if !token.Valid {
 		return nil, fmt.Errorf("invalid token")
 	}
 
-	if claims.TokenType != ScopedTokenType {
-		return nil, fmt.Errorf("invalid token_type")
-	}
-
-	if !claims.VerifyAudience(ScopedTokenAudience, true) {
-		return nil, fmt.Errorf("invalid audience")
-	}
-
-	subject := strings.TrimSpace(claims.Subject)
-	if subject == "" {
-		return nil, fmt.Errorf("subject is required")
-	}
-
-	orgID := strings.TrimSpace(claims.OrgID)
-	if orgID == "" {
-		return nil, fmt.Errorf("org_id is required")
-	}
-
-	purpose := strings.TrimSpace(claims.Purpose)
-	if purpose == "" {
-		return nil, fmt.Errorf("purpose is required")
-	}
-
-	scopes := normalizeScopedTokenValues(claims.Scopes)
-	if len(scopes) == 0 {
-		return nil, fmt.Errorf("at least one scope is required")
-	}
-
-	if len(PermissionsFromScopes(scopes)) == 0 {
-		return nil, fmt.Errorf("at least one scope is required")
-	}
-
-	claims.Subject = subject
+	claims.Subject = strings.TrimSpace(claims.Subject)
 	claims.Audience = strings.TrimSpace(claims.Audience)
-	claims.OrgID = orgID
-	claims.Purpose = purpose
-	claims.Scopes = scopes
+	claims.OrgID = strings.TrimSpace(claims.OrgID)
+	claims.Purpose = strings.TrimSpace(claims.Purpose)
+	claims.Scopes = normalizeScopedTokenValues(claims.Scopes)
 
 	return claims, nil
-}
-
-func (c ScopedTokenClaims) Valid() error {
-	return gojwt.RegisteredClaims{
-		Subject:   c.Subject,
-		ExpiresAt: c.ExpiresAt,
-		NotBefore: c.NotBefore,
-		IssuedAt:  c.IssuedAt,
-	}.Valid()
-}
-
-func (c ScopedTokenClaims) VerifyAudience(cmp string, req bool) bool {
-	if c.Audience == "" {
-		return !req
-	}
-
-	return c.Audience == cmp
 }
 
 func normalizeScopedTokenValues(values []string) []string {

--- a/pkg/jwt/scoped_test.go
+++ b/pkg/jwt/scoped_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	gojwt "github.com/golang-jwt/jwt/v4"
+	gojwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,7 @@ func TestGenerateAndValidateScopedToken(t *testing.T) {
 	}, time.Minute)
 	require.NoError(t, err)
 
-	parsedToken, err := gojwt.Parse(token, func(token *gojwt.Token) (interface{}, error) {
+	parsedToken, err := gojwt.Parse(token, func(token *gojwt.Token) (any, error) {
 		return []byte(signer.Secret), nil
 	})
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestGenerateAndValidateScopedToken(t *testing.T) {
 		[]string{"canvases:read:canvas-123", "org:read"},
 		claims.Scopes,
 	)
-	assert.True(t, claims.VerifyAudience(ScopedTokenAudience, true))
+	assert.Equal(t, ScopedTokenAudience, claims.Audience)
 	assert.NotNil(t, claims.ExpiresAt)
 }
 
@@ -83,7 +83,7 @@ func TestValidateScopedTokenRejectsWrongTokenType(t *testing.T) {
 
 	_, err = signer.ValidateScopedToken(tokenString)
 	require.Error(t, err)
-	assert.Equal(t, "invalid token_type", err.Error())
+	assert.ErrorContains(t, err, "invalid token_type")
 }
 
 func TestPermissionsFromScopes(t *testing.T) {

--- a/pkg/oidc/provider.go
+++ b/pkg/oidc/provider.go
@@ -82,10 +82,10 @@ func (s *RSAProvider) Sign(subject string, duration time.Duration, audience stri
 	now := time.Now()
 	claims := jwt.MapClaims{
 		"iss": s.issuer,
-		"iat": now.Unix(),
-		"nbf": now.Unix(),
-		"exp": now.Add(duration).Unix(),
 		"sub": subject,
+		"iat": jwt.NewNumericDate(now),
+		"nbf": jwt.NewNumericDate(now),
+		"exp": jwt.NewNumericDate(now.Add(duration)),
 	}
 
 	if audience != "" {

--- a/pkg/oidc/provider.go
+++ b/pkg/oidc/provider.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type RSAProvider struct {

--- a/pkg/public/middleware/auth_test.go
+++ b/pkg/public/middleware/auth_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	jwtLib "github.com/golang-jwt/jwt/v4"
+	jwtLib "github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Summary

- Migrate all first-party JWT signing and validation to `github.com/golang-jwt/jwt/v5` per the [migration guide](https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md)
- Use `jwt.NewNumericDate()` for temporal claims in HS256 and RS256 tokens
- Replace removed v4 helpers (`VerifyExpiresAt`, `VerifyAudience`, `RegisteredClaims.Valid`) with v5 parser validation and `ClaimsValidator`
- Drop direct `jwt/v4` imports from SuperPlane code (`jwt/v4` remains only as an indirect dependency via `ghinstallation`)

## Test plan

- [x] `make test PKG_TEST_PACKAGES='./pkg/jwt ./pkg/oidc ./pkg/authentication ./pkg/components/runner ./pkg/public/middleware ./pkg/public'`
- [x] `make lint`