### PR TITLE
feat: add Run Claude Code Agent component

### DIFF
--- a/docs/components/Claude.mdx
+++ b/docs/components/Claude.mdx
@@ -10,6 +10,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="Run Claude Agent" href="#run-claude-agent" description="Runs a Claude Managed Agent in Anthropic’s managed environment and waits until the session is idle or terminated." />
+  <LinkCard title="Run Code Agent" href="#run-code-agent" description="Runs an autonomous Claude coding agent against a repository in Anthropic's managed sandbox and opens (or updates) a pull request." />
   <LinkCard title="Text Prompt" href="#text-prompt" description="Generate a response using Anthropic's Claude models via the Messages API" />
 </CardGrid>
 
@@ -56,6 +57,45 @@ Emits a finished payload with **session** status, **session id**, and the final 
   },
   "timestamp": "2026-04-26T12:00:00Z",
   "type": "claude.runAgent.finished"
+}
+```
+
+<a id="run-code-agent"></a>
+
+## Run Code Agent
+
+**Component key:** `claude.runCodeAgent`
+
+The **Run Code Agent** component runs an autonomous Claude coding agent using [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview). You pick a repository (or an existing pull request) and describe a task; the component provisions a network-enabled sandbox with a scoped GitHub token, and the agent clones the repo, does the work, commits, pushes, and opens or updates a pull request — entirely on its own.
+
+### Prerequisites
+
+- A **Claude API key** on the integration.
+- A **GitHub token** (stored as a SuperPlane secret) with permission to read the repo and open pull requests.
+
+### Modes
+
+- **Repository** — start new work: the agent branches from the base branch, implements the task, and opens a PR.
+- **Pull request** — update an existing PR: the agent checks out the PR's branch, applies the task, and pushes to it.
+
+### Output
+
+Emits the final **status**, the **pull request URL**, the working **branch**, and a **summary** so downstream steps can branch or post the result.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "branch": "claude/agent-1a2b3c4d5e6f",
+    "lastMessage": "Done. PR_URL=https://github.com/owner/repo/pull/42",
+    "prUrl": "https://github.com/owner/repo/pull/42",
+    "sessionId": "sess_01ExampleCodeSession",
+    "status": "idle",
+    "summary": "Implemented the requested change and opened a pull request."
+  },
+  "timestamp": "2026-07-02T12:00:00Z",
+  "type": "claude.runCodeAgent"
 }
 ```
 

--- a/docs/components/Claude.mdx
+++ b/docs/components/Claude.mdx
@@ -76,7 +76,7 @@ The **Run Code Agent** component runs an autonomous Claude coding agent using [C
 ### Modes
 
 - **Repository** — start new work: the agent branches from the base branch, implements the task, and opens a PR.
-- **Pull request** — update an existing PR: the agent checks out the PR's branch, applies the task, and pushes to it.
+- **Pull request** — update an existing PR: the agent checks out the PR's branch, applies the task, and pushes to it. Only same-repository pull requests are supported; PRs opened from forks are rejected.
 
 ### Output
 
@@ -91,8 +91,7 @@ Emits the final **status**, the **pull request URL**, the working **branch**, an
     "lastMessage": "Done. PR_URL=https://github.com/owner/repo/pull/42",
     "prUrl": "https://github.com/owner/repo/pull/42",
     "sessionId": "sess_01ExampleCodeSession",
-    "status": "idle",
-    "summary": "Implemented the requested change and opened a pull request."
+    "status": "idle"
   },
   "timestamp": "2026-07-02T12:00:00Z",
   "type": "claude.runCodeAgent"

--- a/pkg/integrations/claude/claude.go
+++ b/pkg/integrations/claude/claude.go
@@ -7,6 +7,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/integrations/claude/runagent"
+	"github.com/superplanehq/superplane/pkg/integrations/claude/runcodeagent"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -53,6 +54,7 @@ func (i *Claude) Actions() []core.Action {
 	return []core.Action{
 		&TextPrompt{},
 		&runagent.RunAgent{},
+		&runcodeagent.RunCodeAgent{},
 	}
 }
 

--- a/pkg/integrations/claude/runagent/resources.go
+++ b/pkg/integrations/claude/runagent/resources.go
@@ -1,0 +1,120 @@
+package runagent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// EnvironmentNetworking configures a cloud environment's outbound network policy.
+type EnvironmentNetworking struct {
+	Type                 string   `json:"type"` // "unrestricted" or "limited"
+	AllowedHosts         []string `json:"allowed_hosts,omitempty"`
+	AllowPackageManagers *bool    `json:"allow_package_managers,omitempty"`
+	AllowMCPServers      *bool    `json:"allow_mcp_servers,omitempty"`
+}
+
+// EnvironmentConfig is the config object for a cloud environment.
+type EnvironmentConfig struct {
+	Type       string                `json:"type"` // "cloud"
+	Networking EnvironmentNetworking `json:"networking"`
+	Packages   map[string][]string   `json:"packages,omitempty"`
+}
+
+type createEnvironmentBody struct {
+	Name   string            `json:"name"`
+	Config EnvironmentConfig `json:"config"`
+}
+
+// CreateEnvironment provisions a cloud environment and returns its ID.
+func (c *Client) CreateEnvironment(name string, config EnvironmentConfig) (string, error) {
+	body := createEnvironmentBody{Name: name, Config: config}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("marshal environment request: %w", err)
+	}
+	responseBody, err := c.execRequestWithBeta(http.MethodPost, c.BaseURL+"/environments", bytes.NewBuffer(b), anthropicBetaManagedAgents)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return "", fmt.Errorf("decode environment response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("environment creation returned empty ID")
+	}
+	return result.ID, nil
+}
+
+// DeleteEnvironment removes an environment (only succeeds if no session references it).
+func (c *Client) DeleteEnvironment(environmentID string) error {
+	if environmentID == "" {
+		return nil
+	}
+	_, err := c.execRequestWithBeta(http.MethodDelete, c.BaseURL+"/environments/"+url.PathEscape(environmentID), nil, anthropicBetaManagedAgents)
+	return err
+}
+
+// CreateAgentRequest describes a managed agent to create.
+type CreateAgentRequest struct {
+	Name        string
+	Model       string
+	System      string
+	ToolsetType string // defaults to the agent toolset when empty
+}
+
+type createAgentBody struct {
+	Name   string           `json:"name"`
+	Model  string           `json:"model"`
+	System string           `json:"system,omitempty"`
+	Tools  []map[string]any `json:"tools"`
+}
+
+const defaultAgentToolset = "agent_toolset_20260401"
+
+// CreateAgent creates a managed agent (model + system prompt + built-in toolset)
+// and returns its ID.
+func (c *Client) CreateAgent(req CreateAgentRequest) (string, error) {
+	toolset := req.ToolsetType
+	if toolset == "" {
+		toolset = defaultAgentToolset
+	}
+	body := createAgentBody{
+		Name:   req.Name,
+		Model:  req.Model,
+		System: req.System,
+		Tools:  []map[string]any{{"type": toolset}},
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("marshal agent request: %w", err)
+	}
+	responseBody, err := c.execRequestWithBeta(http.MethodPost, c.BaseURL+"/agents", bytes.NewBuffer(b), anthropicBetaManagedAgents)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return "", fmt.Errorf("decode agent response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("agent creation returned empty ID")
+	}
+	return result.ID, nil
+}
+
+// ArchiveAgent archives an agent so it is no longer usable for new sessions.
+func (c *Client) ArchiveAgent(agentID string) error {
+	if agentID == "" {
+		return nil
+	}
+	_, err := c.execRequestWithBeta(http.MethodPost, c.BaseURL+"/agents/"+url.PathEscape(agentID)+"/archive", nil, anthropicBetaManagedAgents)
+	return err
+}

--- a/pkg/integrations/claude/runcodeagent/example.go
+++ b/pkg/integrations/claude/runcodeagent/example.go
@@ -1,0 +1,18 @@
+package runcodeagent
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_output.json
+var exampleOutputBytes []byte
+
+var exampleOutputOnce sync.Once
+var exampleOutput map[string]any
+
+func getExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputOnce, exampleOutputBytes, &exampleOutput)
+}

--- a/pkg/integrations/claude/runcodeagent/example_output.json
+++ b/pkg/integrations/claude/runcodeagent/example_output.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "status": "idle",
+    "sessionId": "sess_01ExampleCodeSession",
+    "prUrl": "https://github.com/owner/repo/pull/42",
+    "branch": "claude/agent-1a2b3c4d5e6f",
+    "summary": "Implemented the requested change and opened a pull request.",
+    "lastMessage": "Done. PR_URL=https://github.com/owner/repo/pull/42"
+  },
+  "timestamp": "2026-07-02T12:00:00Z",
+  "type": "claude.runCodeAgent"
+}

--- a/pkg/integrations/claude/runcodeagent/example_output.json
+++ b/pkg/integrations/claude/runcodeagent/example_output.json
@@ -4,7 +4,6 @@
     "sessionId": "sess_01ExampleCodeSession",
     "prUrl": "https://github.com/owner/repo/pull/42",
     "branch": "claude/agent-1a2b3c4d5e6f",
-    "summary": "Implemented the requested change and opened a pull request.",
     "lastMessage": "Done. PR_URL=https://github.com/owner/repo/pull/42"
   },
   "timestamp": "2026-07-02T12:00:00Z",

--- a/pkg/integrations/claude/runcodeagent/github.go
+++ b/pkg/integrations/claude/runcodeagent/github.go
@@ -1,0 +1,179 @@
+package runcodeagent
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const githubAPIBaseURL = "https://api.github.com"
+
+// pullRequestInfo is the subset of a GitHub pull request we need to drive PR mode.
+type pullRequestInfo struct {
+	Number   int
+	State    string
+	HTMLURL  string
+	HeadRef  string
+	HeadRepo string // owner/repo of the head (may be a fork)
+	BaseRef  string
+	BaseRepo string // owner/repo of the base
+}
+
+// isFork reports whether the PR was opened from a fork.
+func (p *pullRequestInfo) isFork() bool {
+	return p.HeadRepo != "" && p.BaseRepo != "" && !strings.EqualFold(p.HeadRepo, p.BaseRepo)
+}
+
+var prURLRegexp = regexp.MustCompile(`^https?://github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)`)
+
+// parsePRURL extracts owner, repo, and number from a GitHub PR URL.
+func parsePRURL(prURL string) (owner, repo string, number int, err error) {
+	m := prURLRegexp.FindStringSubmatch(strings.TrimSpace(prURL))
+	if m == nil {
+		return "", "", 0, fmt.Errorf("invalid pull request URL %q (expected https://github.com/owner/repo/pull/N)", prURL)
+	}
+	number, err = strconv.Atoi(m[3])
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid pull request number in %q", prURL)
+	}
+	return m[1], strings.TrimSuffix(m[2], ".git"), number, nil
+}
+
+type githubUserResponse struct {
+	Login string `json:"login"`
+	ID    int64  `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// resolveGitHubUser returns the commit author name and email for the user that
+// owns the token, so commits can be attributed to them rather than the agent.
+func resolveGitHubUser(httpCtx core.HTTPContext, token string) (name, email string, err error) {
+	body, err := githubGet(httpCtx, githubAPIBaseURL+"/user", token)
+	if err != nil {
+		return "", "", err
+	}
+	var out githubUserResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", "", fmt.Errorf("decode user response: %w", err)
+	}
+	if out.Login == "" {
+		return "", "", fmt.Errorf("GitHub user lookup returned no login")
+	}
+	name = out.Name
+	if name == "" {
+		name = out.Login
+	}
+	email = out.Email
+	if email == "" {
+		// GitHub's no-reply address always accepts pushes and links to the account.
+		email = fmt.Sprintf("%d+%s@users.noreply.github.com", out.ID, out.Login)
+	}
+	return name, email, nil
+}
+
+// githubGet performs an authenticated GitHub API GET and returns the body.
+func githubGet(httpCtx core.HTTPContext, url, token string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build GitHub request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	res, err := httpCtx.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GitHub request failed: %w", err)
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read GitHub response: %w", err)
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("GitHub request failed (%d): %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+type githubPullResponse struct {
+	Number  int    `json:"number"`
+	State   string `json:"state"`
+	HTMLURL string `json:"html_url"`
+	Head    struct {
+		Ref  string `json:"ref"`
+		Repo *struct {
+			FullName string `json:"full_name"`
+		} `json:"repo"`
+	} `json:"head"`
+	Base struct {
+		Ref  string `json:"ref"`
+		Repo *struct {
+			FullName string `json:"full_name"`
+		} `json:"repo"`
+	} `json:"base"`
+}
+
+// resolvePullRequest fetches a PR via the GitHub REST API using the provided token.
+func resolvePullRequest(httpCtx core.HTTPContext, prURL, token string) (*pullRequestInfo, error) {
+	owner, repo, number, err := parsePRURL(prURL)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", githubAPIBaseURL, owner, repo, number)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build pull request lookup: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	res, err := httpCtx.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("pull request lookup failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read pull request response: %w", err)
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("pull request lookup failed (%d): %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var out githubPullResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode pull request response: %w", err)
+	}
+
+	info := &pullRequestInfo{
+		Number:  out.Number,
+		State:   out.State,
+		HTMLURL: out.HTMLURL,
+		HeadRef: out.Head.Ref,
+		BaseRef: out.Base.Ref,
+	}
+	if out.Head.Repo != nil {
+		info.HeadRepo = out.Head.Repo.FullName
+	}
+	if out.Base.Repo != nil {
+		info.BaseRepo = out.Base.Repo.FullName
+	}
+	if info.HTMLURL == "" {
+		info.HTMLURL = strings.TrimSpace(prURL)
+	}
+	return info, nil
+}

--- a/pkg/integrations/claude/runcodeagent/github_test.go
+++ b/pkg/integrations/claude/runcodeagent/github_test.go
@@ -1,0 +1,85 @@
+package runcodeagent
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__resolvePullRequest(t *testing.T) {
+	t.Run("same-repo open PR", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{Responses: []*http.Response{resp(`{
+			"number":42,"state":"open","html_url":"https://github.com/o/r/pull/42",
+			"head":{"ref":"feature","repo":{"full_name":"o/r"}},
+			"base":{"ref":"main","repo":{"full_name":"o/r"}}
+		}`)}}
+		pr, err := resolvePullRequest(httpCtx, "https://github.com/o/r/pull/42", "tok")
+		require.NoError(t, err)
+		assert.Equal(t, "feature", pr.HeadRef)
+		assert.Equal(t, "main", pr.BaseRef)
+		assert.Equal(t, "o/r", pr.BaseRepo)
+		assert.False(t, pr.isFork())
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "Bearer tok", httpCtx.Requests[0].Header.Get("Authorization"))
+		assert.Contains(t, httpCtx.Requests[0].URL.Path, "/repos/o/r/pulls/42")
+	})
+
+	t.Run("fork PR detected", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{Responses: []*http.Response{resp(`{
+			"state":"open","head":{"ref":"feature","repo":{"full_name":"fork/r"}},
+			"base":{"ref":"main","repo":{"full_name":"o/r"}}
+		}`)}}
+		pr, err := resolvePullRequest(httpCtx, "https://github.com/o/r/pull/1", "tok")
+		require.NoError(t, err)
+		assert.True(t, pr.isFork())
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		_, err := resolvePullRequest(&contexts.HTTPContext{}, "https://github.com/o/r/issues/1", "tok")
+		require.Error(t, err)
+	})
+
+	t.Run("API error propagated", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{Responses: []*http.Response{{
+			StatusCode: 404, Body: io.NopCloser(strings.NewReader(`{"message":"Not Found"}`)),
+		}}}
+		_, err := resolvePullRequest(httpCtx, "https://github.com/o/r/pull/9", "tok")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+	})
+}
+
+func Test__resolveGitHubUser(t *testing.T) {
+	t.Run("uses name and email when present", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+			resp(`{"login":"octocat","id":583231,"name":"The Octocat","email":"octo@github.com"}`),
+		}}
+		name, email, err := resolveGitHubUser(httpCtx, "tok")
+		require.NoError(t, err)
+		assert.Equal(t, "The Octocat", name)
+		assert.Equal(t, "octo@github.com", email)
+	})
+
+	t.Run("falls back to login and noreply email", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+			resp(`{"login":"octocat","id":583231,"name":"","email":""}`),
+		}}
+		name, email, err := resolveGitHubUser(httpCtx, "tok")
+		require.NoError(t, err)
+		assert.Equal(t, "octocat", name)
+		assert.Equal(t, "583231+octocat@users.noreply.github.com", email)
+	})
+
+	t.Run("error on failure", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{Responses: []*http.Response{{
+			StatusCode: 401, Body: io.NopCloser(strings.NewReader(`{"message":"Bad credentials"}`)),
+		}}}
+		_, _, err := resolveGitHubUser(httpCtx, "tok")
+		require.Error(t, err)
+	})
+}

--- a/pkg/integrations/claude/runcodeagent/monitor.go
+++ b/pkg/integrations/claude/runcodeagent/monitor.go
@@ -130,15 +130,13 @@ func (a *RunCodeAgent) handleClientError(ctx core.ActionHookContext, meta *Execu
 
 func (a *RunCodeAgent) handleTerminalSession(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata, sess *runagent.ManagedSession, attempt, errs int) error {
 	sm, err := client.GetSessionMessagesWithRetry(meta.Session.ID, finalMessageReads, finalMessageDelay)
-	if err != nil || sm == nil || !sm.Complete {
-		// Keep polling until the event stream confirms completion; if the budget
-		// runs out first, report a timeout rather than emitting a result we could
-		// not fully assemble.
-		if attempt <= maxPollAttempts {
-			ctx.Logger.Warnf("Events not complete for session %s. Retrying poll.", meta.Session.ID)
-			return a.scheduleNextPoll(ctx, attempt+1, errs)
-		}
-		return a.finishTimeout(ctx, client, meta)
+	if (err != nil || sm == nil || !sm.Complete) && attempt <= maxPollAttempts {
+		// Give the event stream a chance to finish writing so we can assemble the
+		// full result. Once the budget is spent, emit the session's real terminal
+		// status (idle/terminated) with whatever we have — the API already
+		// confirmed the session finished, so this is not a timeout.
+		ctx.Logger.Warnf("Events not complete for session %s. Retrying poll.", meta.Session.ID)
+		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}
 
 	out := buildOutput(sess.Status, meta.Session.ID, meta.Branch, sm, meta.PrURL)

--- a/pkg/integrations/claude/runcodeagent/monitor.go
+++ b/pkg/integrations/claude/runcodeagent/monitor.go
@@ -1,0 +1,157 @@
+package runcodeagent
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/claude/runagent"
+)
+
+// HandleWebhook — Managed Agents completion is observed via polling, not webhooks.
+func (a *RunCodeAgent) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (a *RunCodeAgent) Hooks() []core.Hook {
+	return []core.Hook{{Name: "poll", Type: core.HookTypeInternal}}
+}
+
+func (a *RunCodeAgent) HandleHook(ctx core.ActionHookContext) error {
+	if ctx.Name == "poll" {
+		return a.poll(ctx)
+	}
+	return fmt.Errorf("unknown hook: %s", ctx.Name)
+}
+
+func (a *RunCodeAgent) poll(ctx core.ActionHookContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	meta := &ExecutionMetadata{}
+	if err := mapstructure.Decode(ctx.Metadata.Get(), meta); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+	if meta.Session == nil || meta.Session.ID == "" {
+		return nil
+	}
+	attempt, errs := parsePollParams(ctx)
+
+	client, err := runagent.NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return a.handleClientError(ctx, meta, attempt, errs, err)
+	}
+
+	sess, err := client.GetManagedSession(meta.Session.ID)
+	if err != nil {
+		return a.handlePollError(ctx, client, meta, attempt, errs)
+	}
+
+	if sess != nil && isSessionTerminal(sess.Status) {
+		return a.handleTerminalSession(ctx, client, meta, sess, attempt, errs)
+	}
+
+	if attempt > maxPollAttempts {
+		return a.finishTimeout(ctx, client, meta)
+	}
+	return a.scheduleNextPoll(ctx, attempt+1, 0)
+}
+
+func parsePollParams(ctx core.ActionHookContext) (int, int) {
+	attempt, errs := 1, 0
+	if a, ok := ctx.Parameters["attempt"].(float64); ok {
+		attempt = int(a)
+	}
+	if e, ok := ctx.Parameters["errors"].(float64); ok {
+		errs = int(e)
+	}
+	return attempt, errs
+}
+
+// finishTimeout reclaims the still-running session and emits a timeout. Cleanup
+// runs before the emit so nothing leaks even if the emit fails.
+func (a *RunCodeAgent) finishTimeout(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata) error {
+	ctx.Logger.Errorf("Session %s exceeded max poll attempts", meta.Session.ID)
+	a.teardown(client, meta, true, ctx.Logger.Warnf)
+	out := buildOutput("timeout", meta.Session.ID, meta.Branch, nil, meta.PrURL)
+	return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+}
+
+// handlePollError retries a failed status read, then reclaims + reports an error.
+func (a *RunCodeAgent) handlePollError(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata, attempt, errs int) error {
+	errs++
+	if errs < maxPollErrors {
+		return a.scheduleNextPoll(ctx, attempt+1, errs)
+	}
+	ctx.Logger.Errorf("Session %s: polling failed repeatedly", meta.Session.ID)
+	a.teardown(client, meta, true, ctx.Logger.Warnf)
+	out := buildOutput("error", meta.Session.ID, meta.Branch, nil, meta.PrURL)
+	return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+}
+
+// handleClientError surfaces client/config failures as errors (not timeouts).
+func (a *RunCodeAgent) handleClientError(ctx core.ActionHookContext, meta *ExecutionMetadata, attempt, errs int, cause error) error {
+	errs++
+	if errs < maxPollErrors {
+		return a.scheduleNextPoll(ctx, attempt+1, errs)
+	}
+	ctx.Logger.Errorf("Session %s: cannot create client to poll: %v", meta.Session.ID, cause)
+	// Attempt teardown with a fresh client so the session/environment/vault/agent
+	// are not left provisioned; if the client still can't be built there is
+	// nothing more we can do via the API.
+	if client, cErr := runagent.NewClient(ctx.HTTP, ctx.Integration); cErr == nil {
+		a.teardown(client, meta, true, ctx.Logger.Warnf)
+	} else {
+		ctx.Logger.Warnf("Cannot reclaim resources for session %s: client unavailable: %v", meta.Session.ID, cErr)
+	}
+	out := buildOutput("error", meta.Session.ID, meta.Branch, nil, meta.PrURL)
+	return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+}
+
+func (a *RunCodeAgent) handleTerminalSession(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata, sess *runagent.ManagedSession, attempt, errs int) error {
+	sm, err := client.GetSessionMessagesWithRetry(meta.Session.ID, finalMessageReads, finalMessageDelay)
+	if (err != nil || sm == nil || !sm.Complete) && attempt <= maxPollAttempts {
+		ctx.Logger.Warnf("Events not complete for session %s. Retrying poll.", meta.Session.ID)
+		return a.scheduleNextPoll(ctx, attempt+1, errs)
+	}
+
+	out := buildOutput(sess.Status, meta.Session.ID, meta.Branch, sm, meta.PrURL)
+	if err := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); err != nil {
+		if attempt <= maxPollAttempts {
+			// Preserve the session (it holds the result) and retry the emit.
+			ctx.Logger.Warnf("Failed to emit result for session %s: %v. Retrying poll.", meta.Session.ID, err)
+			return a.scheduleNextPoll(ctx, attempt+1, errs)
+		}
+		a.teardown(client, meta, false, ctx.Logger.Warnf)
+		return err
+	}
+
+	mergeSessionIntoMetadata(meta, sess)
+	_ = ctx.Metadata.Set(*meta)
+	a.teardown(client, meta, false, ctx.Logger.Warnf)
+	return nil
+}
+
+func (a *RunCodeAgent) scheduleNextPoll(ctx core.ActionHookContext, nextAttempt, errors int) error {
+	interval := initialPoll * time.Duration(1<<uint(min(nextAttempt-1, 8)))
+	if interval > maxPollInterval {
+		interval = maxPollInterval
+	}
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{"attempt": nextAttempt, "errors": errors}, interval)
+}
+
+func (a *RunCodeAgent) Cancel(ctx core.ExecutionContext) error {
+	meta := &ExecutionMetadata{}
+	if err := mapstructure.Decode(ctx.Metadata.Get(), meta); err != nil {
+		return nil
+	}
+	client, err := runagent.NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil
+	}
+	a.teardown(client, meta, true, ctx.Logger.Warnf)
+	return nil
+}

--- a/pkg/integrations/claude/runcodeagent/monitor.go
+++ b/pkg/integrations/claude/runcodeagent/monitor.go
@@ -36,7 +36,14 @@ func (a *RunCodeAgent) poll(ctx core.ActionHookContext) error {
 		return fmt.Errorf("failed to decode metadata: %w", err)
 	}
 	if meta.Session == nil || meta.Session.ID == "" {
-		return nil
+		// No session was recorded (anomalous): reclaim any stray resources and
+		// finish as an error instead of leaving the node running indefinitely.
+		ctx.Logger.Errorf("poll: execution metadata has no session id; finishing as error")
+		if client, err := runagent.NewClient(ctx.HTTP, ctx.Integration); err == nil {
+			a.teardown(client, meta, false, ctx.Logger.Warnf)
+		}
+		out := buildOutput("error", "", meta.Branch, nil, meta.PrURL)
+		return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
 	}
 	attempt, errs := parsePollParams(ctx)
 
@@ -71,25 +78,34 @@ func parsePollParams(ctx core.ActionHookContext) (int, int) {
 	return attempt, errs
 }
 
-// finishTimeout reclaims the still-running session and emits a timeout. Cleanup
-// runs before the emit so nothing leaks even if the emit fails.
-func (a *RunCodeAgent) finishTimeout(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata) error {
-	ctx.Logger.Errorf("Session %s exceeded max poll attempts", meta.Session.ID)
-	a.teardown(client, meta, true, ctx.Logger.Warnf)
-	out := buildOutput("timeout", meta.Session.ID, meta.Branch, nil, meta.PrURL)
-	return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+// emitFinal emits a terminal payload and, only after a successful emit, reclaims
+// the provisioned resources. On an emit failure it returns the error WITHOUT
+// tearing down, so the session survives for the hook to retry.
+func (a *RunCodeAgent) emitFinal(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata, out OutputPayload, interrupt bool) error {
+	if err := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); err != nil {
+		ctx.Logger.Warnf("Failed to emit result for session %s: %v.", meta.Session.ID, err)
+		return err
+	}
+	a.teardown(client, meta, interrupt, ctx.Logger.Warnf)
+	return nil
 }
 
-// handlePollError retries a failed status read, then reclaims + reports an error.
+// finishTimeout reports a timeout and reclaims the still-running session.
+func (a *RunCodeAgent) finishTimeout(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata) error {
+	ctx.Logger.Errorf("Session %s exceeded max poll attempts", meta.Session.ID)
+	out := buildOutput("timeout", meta.Session.ID, meta.Branch, nil, meta.PrURL)
+	return a.emitFinal(ctx, client, meta, out, true)
+}
+
+// handlePollError retries a failed status read, then reports an error and reclaims.
 func (a *RunCodeAgent) handlePollError(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata, attempt, errs int) error {
 	errs++
 	if errs < maxPollErrors {
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}
 	ctx.Logger.Errorf("Session %s: polling failed repeatedly", meta.Session.ID)
-	a.teardown(client, meta, true, ctx.Logger.Warnf)
 	out := buildOutput("error", meta.Session.ID, meta.Branch, nil, meta.PrURL)
-	return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+	return a.emitFinal(ctx, client, meta, out, true)
 }
 
 // handleClientError surfaces client/config failures as errors (not timeouts).
@@ -99,23 +115,30 @@ func (a *RunCodeAgent) handleClientError(ctx core.ActionHookContext, meta *Execu
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}
 	ctx.Logger.Errorf("Session %s: cannot create client to poll: %v", meta.Session.ID, cause)
-	// Attempt teardown with a fresh client so the session/environment/vault/agent
-	// are not left provisioned; if the client still can't be built there is
-	// nothing more we can do via the API.
+	out := buildOutput("error", meta.Session.ID, meta.Branch, nil, meta.PrURL)
+	if err := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); err != nil {
+		return err
+	}
+	// Best-effort reclaim: retry building a client now that the run is finished.
 	if client, cErr := runagent.NewClient(ctx.HTTP, ctx.Integration); cErr == nil {
 		a.teardown(client, meta, true, ctx.Logger.Warnf)
 	} else {
 		ctx.Logger.Warnf("Cannot reclaim resources for session %s: client unavailable: %v", meta.Session.ID, cErr)
 	}
-	out := buildOutput("error", meta.Session.ID, meta.Branch, nil, meta.PrURL)
-	return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+	return nil
 }
 
 func (a *RunCodeAgent) handleTerminalSession(ctx core.ActionHookContext, client *runagent.Client, meta *ExecutionMetadata, sess *runagent.ManagedSession, attempt, errs int) error {
 	sm, err := client.GetSessionMessagesWithRetry(meta.Session.ID, finalMessageReads, finalMessageDelay)
-	if (err != nil || sm == nil || !sm.Complete) && attempt <= maxPollAttempts {
-		ctx.Logger.Warnf("Events not complete for session %s. Retrying poll.", meta.Session.ID)
-		return a.scheduleNextPoll(ctx, attempt+1, errs)
+	if err != nil || sm == nil || !sm.Complete {
+		// Keep polling until the event stream confirms completion; if the budget
+		// runs out first, report a timeout rather than emitting a result we could
+		// not fully assemble.
+		if attempt <= maxPollAttempts {
+			ctx.Logger.Warnf("Events not complete for session %s. Retrying poll.", meta.Session.ID)
+			return a.scheduleNextPoll(ctx, attempt+1, errs)
+		}
+		return a.finishTimeout(ctx, client, meta)
 	}
 
 	out := buildOutput(sess.Status, meta.Session.ID, meta.Branch, sm, meta.PrURL)

--- a/pkg/integrations/claude/runcodeagent/monitor.go
+++ b/pkg/integrations/claude/runcodeagent/monitor.go
@@ -120,12 +120,14 @@ func (a *RunCodeAgent) handleTerminalSession(ctx core.ActionHookContext, client 
 
 	out := buildOutput(sess.Status, meta.Session.ID, meta.Branch, sm, meta.PrURL)
 	if err := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); err != nil {
+		// Never tear down on an emit failure: the session still holds the agent
+		// output (PR URL, summary), so a transient emit failure must remain
+		// recoverable. Retry via polling while within budget; past it, surface
+		// the error without destroying the session.
+		ctx.Logger.Warnf("Failed to emit result for session %s: %v.", meta.Session.ID, err)
 		if attempt <= maxPollAttempts {
-			// Preserve the session (it holds the result) and retry the emit.
-			ctx.Logger.Warnf("Failed to emit result for session %s: %v. Retrying poll.", meta.Session.ID, err)
 			return a.scheduleNextPoll(ctx, attempt+1, errs)
 		}
-		a.teardown(client, meta, false, ctx.Logger.Warnf)
 		return err
 	}
 
@@ -150,6 +152,7 @@ func (a *RunCodeAgent) Cancel(ctx core.ExecutionContext) error {
 	}
 	client, err := runagent.NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
+		ctx.Logger.Warnf("Cancel: cannot build client to reclaim managed agent resources: %v", err)
 		return nil
 	}
 	a.teardown(client, meta, true, ctx.Logger.Warnf)

--- a/pkg/integrations/claude/runcodeagent/prompt.go
+++ b/pkg/integrations/claude/runcodeagent/prompt.go
@@ -1,0 +1,112 @@
+package runcodeagent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// buildPrompt wraps the user's task in a deterministic operating procedure that
+// makes the agent clone, work, push, and open (or update) a pull request, then
+// report the PR URL in a machine-readable form.
+func buildPrompt(spec Spec, pr *pullRequestInfo, branch string, hasFiles bool, attr commitAttribution) string {
+	if pr != nil {
+		return buildPRPrompt(spec, pr, hasFiles, attr)
+	}
+	return buildRepositoryPrompt(spec, branch, hasFiles, attr)
+}
+
+func buildRepositoryPrompt(spec Spec, branch string, hasFiles bool, attr commitAttribution) string {
+	var b strings.Builder
+	writeIntro(&b, hasFiles)
+
+	fmt.Fprintf(&b, "1. Clone the repository and enter it:\n")
+	fmt.Fprintf(&b, "     git clone %s repo && cd repo\n", authenticatedCloneURL(spec.Repository))
+	if base := strings.TrimSpace(spec.BaseBranch); base != "" {
+		fmt.Fprintf(&b, "     git checkout %s\n", base)
+	}
+	writeIdentity(&b, attr)
+	fmt.Fprintf(&b, "2. Create and switch to a working branch: git checkout -b %s\n", branch)
+	fmt.Fprintf(&b, "3. Complete this task:\n%s\n", indent(spec.Task))
+	fmt.Fprintf(&b, "4. %s and push the branch: git push -u origin %s\n", commitInstruction(attr), branch)
+	if prEnabled(spec) {
+		target := strings.TrimSpace(spec.BaseBranch)
+		if target == "" {
+			target = "the default branch"
+		}
+		fmt.Fprintf(&b, "5. Open a pull request from %s into %s (use the GitHub API with $GITHUB_TOKEN, or the gh CLI).\n", branch, target)
+	}
+	writeFinalMarker(&b, prEnabled(spec))
+	return b.String()
+}
+
+func buildPRPrompt(spec Spec, pr *pullRequestInfo, hasFiles bool, attr commitAttribution) string {
+	var b strings.Builder
+	writeIntro(&b, hasFiles)
+	fmt.Fprintf(&b, "You are updating the existing pull request %s.\n\n", pr.HTMLURL)
+
+	fmt.Fprintf(&b, "1. Clone the repository and switch to the pull request's branch (it already exists on origin):\n")
+	fmt.Fprintf(&b, "     git clone %s repo && cd repo\n", authenticatedCloneURL(pr.BaseRepo))
+	fmt.Fprintf(&b, "     git switch %s\n", pr.HeadRef)
+	writeIdentity(&b, attr)
+	fmt.Fprintf(&b, "2. Complete this task:\n%s\n", indent(spec.Task))
+	fmt.Fprintf(&b, "3. %s and push to the SAME branch (%s) — do NOT open a new pull request; pushing updates the existing one: git push origin %s\n", commitInstruction(attr), pr.HeadRef, pr.HeadRef)
+	writeFinalMarker(&b, true)
+	fmt.Fprintf(&b, "\nThe pull request URL is %s.\n", pr.HTMLURL)
+	return b.String()
+}
+
+// writeIdentity configures git to attribute commits to the resolved user.
+func writeIdentity(b *strings.Builder, attr commitAttribution) {
+	if attr.enabled() {
+		fmt.Fprintf(b, "     git config user.name %q && git config user.email %q\n", attr.AuthorName, attr.AuthorEmail)
+	}
+}
+
+// commitInstruction returns the commit step wording, suppressing agent
+// attribution trailers when commits should appear as the user.
+func commitInstruction(attr commitAttribution) string {
+	if attr.enabled() {
+		return "Commit your changes with a clear message, without any \"Co-Authored-By\" or \"Generated with\" trailers"
+	}
+	return "Commit your changes with a clear message"
+}
+
+func writeIntro(b *strings.Builder, hasFiles bool) {
+	b.WriteString("You are an autonomous coding agent in a fresh Linux sandbox with network access. ")
+	b.WriteString("A GitHub token is available in the $GITHUB_TOKEN environment variable.\n")
+	if hasFiles {
+		fmt.Fprintf(b, "Attached files are available under %s.\n", attachmentsMountDir)
+	}
+	b.WriteString("\nFollow these steps:\n")
+}
+
+func writeFinalMarker(b *strings.Builder, prExpected bool) {
+	b.WriteString("\nWhen finished, output on the FINAL line of your last message exactly one of:\n")
+	if prExpected {
+		b.WriteString("     PR_URL=<the pull request url>\n")
+	}
+	b.WriteString("     NO_PR   (if there were no changes to submit)\n")
+}
+
+func authenticatedCloneURL(repository string) string {
+	repository = strings.TrimSpace(repository)
+	if repoOwnerRepoPattern.MatchString(repository) {
+		return fmt.Sprintf("https://x-access-token:$GITHUB_TOKEN@github.com/%s.git", repository)
+	}
+	if strings.HasPrefix(repository, "https://") {
+		return "https://x-access-token:$GITHUB_TOKEN@" + strings.TrimPrefix(repository, "https://")
+	}
+	return repository
+}
+
+func prEnabled(spec Spec) bool {
+	return spec.AutoCreatePr == nil || *spec.AutoCreatePr
+}
+
+func indent(text string) string {
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	for i, l := range lines {
+		lines[i] = "   " + l
+	}
+	return strings.Join(lines, "\n")
+}

--- a/pkg/integrations/claude/runcodeagent/prompt.go
+++ b/pkg/integrations/claude/runcodeagent/prompt.go
@@ -93,7 +93,9 @@ func authenticatedCloneURL(repository string) string {
 	if repoOwnerRepoPattern.MatchString(repository) {
 		return fmt.Sprintf("https://x-access-token:$GITHUB_TOKEN@github.com/%s.git", repository)
 	}
-	if strings.HasPrefix(repository, "https://") {
+	// Only embed the token for github.com; anything else is returned unchanged
+	// (unauthenticated) so the credential can never reach a non-GitHub host.
+	if strings.HasPrefix(repository, "https://github.com/") {
 		return "https://x-access-token:$GITHUB_TOKEN@" + strings.TrimPrefix(repository, "https://")
 	}
 	return repository

--- a/pkg/integrations/claude/runcodeagent/run_code_agent.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent.go
@@ -1,0 +1,637 @@
+package runcodeagent
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
+	"github.com/superplanehq/superplane/pkg/integrations/claude/runagent"
+)
+
+const (
+	defaultModel        = "claude-sonnet-4-6"
+	defaultSystemPrompt = "You are an autonomous software engineering agent. You work carefully, make focused changes, follow the repository's existing conventions, and verify your work before finishing."
+)
+
+type RunCodeAgent struct{}
+
+func (a *RunCodeAgent) Name() string { return "claude.runCodeAgent" }
+
+func (a *RunCodeAgent) Label() string { return "Run Code Agent" }
+
+func (a *RunCodeAgent) Description() string {
+	return "Runs an autonomous Claude coding agent against a repository in Anthropic's managed sandbox and opens (or updates) a pull request."
+}
+
+func (a *RunCodeAgent) Documentation() string {
+	return `The **Run Code Agent** component runs an autonomous Claude coding agent using [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview). You pick a repository (or an existing pull request) and describe a task; the component provisions a network-enabled sandbox with a scoped GitHub token, and the agent clones the repo, does the work, commits, pushes, and opens or updates a pull request — entirely on its own.
+
+## Prerequisites
+
+- A **Claude API key** on the integration.
+- A **GitHub token** (stored as a SuperPlane secret) with permission to read the repo and open pull requests.
+
+## Modes
+
+- **Repository** — start new work: the agent branches from the base branch, implements the task, and opens a PR.
+- **Pull request** — update an existing PR: the agent checks out the PR's branch, applies the task, and pushes to it. Only same-repository pull requests are supported; PRs opened from forks are rejected.
+
+## Output
+
+Emits the final **status**, the **pull request URL**, the working **branch**, and a **summary** so downstream steps can branch or post the result.`
+}
+
+func (a *RunCodeAgent) Icon() string { return "bot" }
+
+func (a *RunCodeAgent) Color() string { return "#C9784D" }
+
+func (a *RunCodeAgent) ExampleOutput() map[string]any { return getExampleOutput() }
+
+func (a *RunCodeAgent) OutputChannels(config any) []core.OutputChannel {
+	return []core.OutputChannel{{Name: defaultChannel, Label: "Default"}}
+}
+
+func (a *RunCodeAgent) Configuration() []configuration.Field {
+	repoMode := []configuration.VisibilityCondition{{Field: "sourceMode", Values: []string{sourceModeRepository}}}
+	prMode := []configuration.VisibilityCondition{{Field: "sourceMode", Values: []string{sourceModePR}}}
+	limitedNet := []configuration.VisibilityCondition{{Field: "networking", Values: []string{networkingLimited}}}
+
+	return []configuration.Field{
+		{
+			Name: "sourceMode", Label: "Source", Type: configuration.FieldTypeSelect, Required: true, Default: sourceModeRepository,
+			Description: "Start new work on a repository, or update an existing pull request.",
+			TypeOptions: &configuration.TypeOptions{Select: &configuration.SelectTypeOptions{Options: []configuration.FieldOption{
+				{Label: "Repository (new work)", Value: sourceModeRepository},
+				{Label: "Pull request (update existing)", Value: sourceModePR},
+			}}},
+		},
+		{
+			Name: "repository", Label: "Repository", Type: configuration.FieldTypeString, Required: false,
+			Placeholder: "owner/repo", Description: "Target repository (owner/repo or clone URL).",
+			VisibilityConditions: repoMode,
+		},
+		{
+			Name: "baseBranch", Label: "Base Branch", Type: configuration.FieldTypeString, Required: false,
+			Description:          "Branch to start from and target the PR against. Defaults to the repository's default branch.",
+			VisibilityConditions: repoMode,
+		},
+		{
+			Name: "branchName", Label: "Working Branch", Type: configuration.FieldTypeString, Required: false,
+			Description:          "Branch the agent creates and pushes. Defaults to claude/agent-<execution-id>.",
+			VisibilityConditions: repoMode,
+		},
+		{
+			Name: "prUrl", Label: "Pull Request URL", Type: configuration.FieldTypeString, Required: false,
+			Placeholder: "https://github.com/owner/repo/pull/42", Description: "Existing pull request to update in place.",
+			VisibilityConditions: prMode,
+		},
+		{
+			Name: "task", Label: "Task", Type: configuration.FieldTypeText, Required: true,
+			Description: "What the agent should do.",
+		},
+		{
+			Name: "githubToken", Label: "GitHub Token", Type: configuration.FieldTypeSecretKey, Required: true,
+			Description: "SuperPlane secret holding a GitHub token with repo + pull request permissions.",
+		},
+		{
+			Name: "model", Label: "Model", Type: configuration.FieldTypeIntegrationResource, Required: false,
+			Description: "Claude model that powers the agent.",
+			TypeOptions: &configuration.TypeOptions{Resource: &configuration.ResourceTypeOptions{Type: "model"}},
+		},
+		{
+			Name: "files", Label: "Files", Type: configuration.FieldTypeList, Required: false,
+			Description: "Files from the Files tab to mount into the agent's workspace.",
+			TypeOptions: &configuration.TypeOptions{List: &configuration.ListTypeOptions{
+				ItemLabel:      "File path",
+				ItemDefinition: &configuration.ListItemDefinition{Type: configuration.FieldTypeRepositoryFile},
+			}},
+		},
+		{
+			Name: "networking", Label: "Networking", Type: configuration.FieldTypeSelect, Required: false, Default: networkingUnrestricted,
+			Description: "Sandbox outbound access.",
+			TypeOptions: &configuration.TypeOptions{Select: &configuration.SelectTypeOptions{Options: []configuration.FieldOption{
+				{Label: "Unrestricted", Value: networkingUnrestricted},
+				{Label: "Limited (GitHub + registries)", Value: networkingLimited},
+			}}},
+		},
+		{
+			Name: "allowedHosts", Label: "Allowed Hosts", Type: configuration.FieldTypeList, Required: false,
+			Description:          "Extra hosts permitted when networking is limited.",
+			VisibilityConditions: limitedNet,
+			TypeOptions: &configuration.TypeOptions{List: &configuration.ListTypeOptions{
+				ItemLabel:      "Host",
+				ItemDefinition: &configuration.ListItemDefinition{Type: configuration.FieldTypeString},
+			}},
+		},
+		{
+			Name: "autoCreatePr", Label: "Open a Pull Request", Type: configuration.FieldTypeBool, Required: false, Default: true,
+			Description:          "Have the agent open a pull request when finished.",
+			VisibilityConditions: repoMode,
+		},
+		{
+			Name: "actAsBot", Label: "Act as Bot", Type: configuration.FieldTypeBool, Required: false, Default: true,
+			Description: "When enabled, commits are attributed to the Claude agent. Disable to attribute commits to the GitHub user that owns the token.",
+		},
+	}
+}
+
+func (a *RunCodeAgent) Setup(ctx core.SetupContext) error {
+	spec, err := decodeSpec(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+	if err := validateSpec(spec); err != nil {
+		return err
+	}
+	if err := validateConfiguredFiles(ctx, spec.Files); err != nil {
+		return err
+	}
+	return setNodeMetadata(ctx, spec)
+}
+
+func (a *RunCodeAgent) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (a *RunCodeAgent) Execute(ctx core.ExecutionContext) error {
+	spec, err := decodeSpec(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+	if err := validateSpec(spec); err != nil {
+		return err
+	}
+
+	client, err := runagent.NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	token, err := ctx.Secrets.GetKey(spec.GithubToken.Secret, spec.GithubToken.Key)
+	if err != nil {
+		return fmt.Errorf("failed to resolve GitHub token: %w", err)
+	}
+
+	var pr *pullRequestInfo
+	if spec.SourceMode == sourceModePR {
+		pr, err = resolvePullRequestForRun(ctx, spec, string(token))
+		if err != nil {
+			return err
+		}
+	}
+
+	attribution, err := resolveCommitAttribution(ctx, spec, string(token))
+	if err != nil {
+		return err
+	}
+
+	meta := &ExecutionMetadata{
+		Repository: repositoryForRun(spec, pr),
+		Branch:     branchForRun(spec, pr, ctx.ID),
+	}
+	if pr != nil {
+		meta.PrURL = pr.HTMLURL
+	}
+
+	resources, err := a.provisionResources(ctx, client, spec, string(token), meta)
+	if err != nil {
+		return err
+	}
+
+	if err := a.startSession(ctx, client, spec, pr, attribution, meta, resources); err != nil {
+		return err
+	}
+
+	refreshed, err := client.GetManagedSession(meta.Session.ID)
+	if err != nil {
+		a.teardown(client, meta, true, ctx.Logger.Warnf)
+		return fmt.Errorf("failed to get session: %w", err)
+	}
+
+	handled, err := a.emitIfTerminal(ctx, client, meta, refreshed)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+
+	ctx.Logger.Infof("Started code agent session %s. Waiting for completion...", meta.Session.ID)
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{"attempt": 1, "errors": 0}, initialPoll)
+}
+
+// startSession creates the session, persists metadata, and sends the task prompt.
+// On any failure it reclaims all provisioned resources.
+func (a *RunCodeAgent) startSession(ctx core.ExecutionContext, client *runagent.Client, spec Spec, pr *pullRequestInfo, attribution commitAttribution, meta *ExecutionMetadata, resources []runagent.FileResource) error {
+	session, err := client.CreateManagedSession(runagent.CreateManagedSessionRequest{
+		Agent:         meta.AgentID,
+		EnvironmentID: meta.EnvironmentID,
+		VaultIDs:      []string{meta.VaultID},
+		Resources:     resources,
+	})
+	if err != nil {
+		a.teardown(client, meta, false, ctx.Logger.Warnf)
+		return fmt.Errorf("failed to create managed agent session: %w", err)
+	}
+	mergeSessionIntoMetadata(meta, session)
+	if err := ctx.Metadata.Set(*meta); err != nil {
+		a.teardown(client, meta, false, ctx.Logger.Warnf)
+		return fmt.Errorf("failed to set execution metadata: %w", err)
+	}
+
+	message := buildPrompt(spec, pr, meta.Branch, len(spec.Files) > 0, attribution)
+	if err := client.SendManagedSessionUserMessage(session.ID, message); err != nil {
+		a.teardown(client, meta, true, ctx.Logger.Warnf)
+		return fmt.Errorf("failed to send task to agent: %w", err)
+	}
+	return nil
+}
+
+func (a *RunCodeAgent) Cleanup(ctx core.SetupContext) error { return nil }
+
+// provisionResources creates the agent, environment, uploaded files, and vault,
+// recording each in metadata so cleanup can always reclaim them. On any failure
+// it tears down what was created and returns the error.
+func (a *RunCodeAgent) provisionResources(ctx core.ExecutionContext, client *runagent.Client, spec Spec, token string, meta *ExecutionMetadata) ([]runagent.FileResource, error) {
+	agentID, err := client.CreateAgent(runagent.CreateAgentRequest{
+		Name:   fmt.Sprintf("superplane-%s", shortID(ctx.ID.String())),
+		Model:  modelForRun(spec),
+		System: defaultSystemPrompt,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create agent: %w", err)
+	}
+	meta.AgentID = agentID
+
+	envID, err := client.CreateEnvironment(fmt.Sprintf("superplane-%s", shortID(ctx.ID.String())), buildEnvironmentConfig(spec))
+	if err != nil {
+		a.teardown(client, meta, false, ctx.Logger.Warnf)
+		return nil, fmt.Errorf("failed to create environment: %w", err)
+	}
+	meta.EnvironmentID = envID
+
+	resources, err := uploadFiles(client, ctx, spec.Files)
+	if err != nil {
+		meta.FileIDs = fileIDsOf(resources)
+		a.teardown(client, meta, false, ctx.Logger.Warnf)
+		return nil, err
+	}
+	meta.FileIDs = fileIDsOf(resources)
+
+	vaultID, err := provisionVault(client, ctx, spec, token)
+	if err != nil {
+		meta.VaultID = vaultID // may be set even on partial failure
+		a.teardown(client, meta, false, ctx.Logger.Warnf)
+		return nil, err
+	}
+	meta.VaultID = vaultID
+
+	return resources, nil
+}
+
+// teardown best-effort reclaims every provisioned resource. Safe to call with a
+// partially-populated metadata (the client delete calls no-op on empty IDs).
+func (a *RunCodeAgent) teardown(client *runagent.Client, meta *ExecutionMetadata, interrupt bool, logWarn func(string, ...any)) {
+	if meta.Session != nil && meta.Session.ID != "" {
+		if interrupt {
+			warnErr(logWarn, client.SendManagedSessionInterrupt(meta.Session.ID), "interrupt session %s", meta.Session.ID)
+		}
+		warnErr(logWarn, client.DeleteManagedSession(meta.Session.ID), "delete session %s", meta.Session.ID)
+	}
+	warnErr(logWarn, client.DeleteEnvironment(meta.EnvironmentID), "delete environment %s", meta.EnvironmentID)
+	client.CleanupFiles(meta.FileIDs, logWarn)
+	warnErr(logWarn, client.DeleteVault(meta.VaultID), "delete vault %s", meta.VaultID)
+	warnErr(logWarn, client.ArchiveAgent(meta.AgentID), "archive agent %s", meta.AgentID)
+}
+
+// warnErr logs a best-effort cleanup failure without interrupting teardown.
+func warnErr(logWarn func(string, ...any), err error, format string, args ...any) {
+	if err != nil {
+		logWarn("failed to "+format+": %v", append(args, err)...)
+	}
+}
+
+// emitIfTerminal handles fast tasks that finish before the first poll.
+func (a *RunCodeAgent) emitIfTerminal(ctx core.ExecutionContext, client *runagent.Client, meta *ExecutionMetadata, session *runagent.ManagedSession) (bool, error) {
+	if session == nil || !isSessionTerminal(session.Status) {
+		return false, nil
+	}
+
+	sm, err := client.GetSessionMessagesWithRetry(meta.Session.ID, finalMessageReads, finalMessageDelay)
+	if err != nil || sm == nil || !sm.Complete {
+		ctx.Logger.Warnf("Session %s terminal but events not ready; scheduling poll.", meta.Session.ID)
+		return false, nil
+	}
+
+	out := buildOutput(session.Status, meta.Session.ID, meta.Branch, sm, meta.PrURL)
+	if err := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); err != nil {
+		ctx.Logger.Warnf("Failed to emit result for session %s: %v; scheduling poll.", meta.Session.ID, err)
+		return false, nil
+	}
+	mergeSessionIntoMetadata(meta, session)
+	_ = ctx.Metadata.Set(*meta)
+	a.teardown(client, meta, false, ctx.Logger.Warnf)
+	return true, nil
+}
+
+func uploadFiles(client *runagent.Client, ctx core.ExecutionContext, files []string) ([]runagent.FileResource, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+	if ctx.Files == nil {
+		return nil, fmt.Errorf("files configured but file access is not available")
+	}
+	resources := make([]runagent.FileResource, 0, len(files))
+	for _, path := range files {
+		normalized, err := gitprovider.ValidateUserPath(path)
+		if err != nil {
+			return resources, fmt.Errorf("invalid file path %q: %w", path, err)
+		}
+		reader, err := ctx.Files.Read(normalized)
+		if err != nil {
+			return resources, fmt.Errorf("read file %q: %w", path, err)
+		}
+		fileID, err := client.UploadFile(reader, normalized)
+		reader.Close()
+		if err != nil {
+			return resources, fmt.Errorf("upload file %q: %w", path, err)
+		}
+		resources = append(resources, runagent.FileResource{FileID: fileID, MountPath: attachmentsMountDir + "/" + normalized})
+	}
+	return resources, nil
+}
+
+func provisionVault(client *runagent.Client, ctx core.ExecutionContext, spec Spec, token string) (string, error) {
+	vaultID, err := client.CreateVault(fmt.Sprintf("superplane-%s", shortID(ctx.ID.String())), map[string]string{"superplane_execution": ctx.ID.String()})
+	if err != nil {
+		return "", fmt.Errorf("failed to create vault: %w", err)
+	}
+
+	githubHosts := append([]string{}, defaultGitHubHosts...)
+	githubHosts = append(githubHosts, spec.AllowedHosts...)
+	if err := client.CreateEnvVarCredential(vaultID, "GITHUB_TOKEN", "GITHUB_TOKEN", token, githubHosts); err != nil {
+		return vaultID, fmt.Errorf("failed to inject GitHub token: %w", err)
+	}
+	return vaultID, nil
+}
+
+func buildEnvironmentConfig(spec Spec) runagent.EnvironmentConfig {
+	cfg := runagent.EnvironmentConfig{Type: "cloud"}
+	if spec.Networking == networkingLimited {
+		allow := true
+		hosts := append([]string{}, defaultGitHubHosts...)
+		hosts = append(hosts, spec.AllowedHosts...)
+		cfg.Networking = runagent.EnvironmentNetworking{
+			Type:                 "limited",
+			AllowedHosts:         hosts,
+			AllowPackageManagers: &allow,
+		}
+	} else {
+		cfg.Networking = runagent.EnvironmentNetworking{Type: "unrestricted"}
+	}
+	return cfg
+}
+
+// resolvePullRequestForRun looks up the PR and validates it is workable.
+func resolvePullRequestForRun(ctx core.ExecutionContext, spec Spec, token string) (*pullRequestInfo, error) {
+	pr, err := resolvePullRequest(ctx.HTTP, spec.PrURL, token)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(pr.State, "open") {
+		return nil, fmt.Errorf("pull request %s is %s; only open pull requests can be updated", spec.PrURL, pr.State)
+	}
+	if pr.isFork() {
+		return nil, fmt.Errorf("pull request %s was opened from a fork (%s); updating fork PRs is not yet supported", spec.PrURL, pr.HeadRepo)
+	}
+	return pr, nil
+}
+
+func decodeSpec(config any) (Spec, error) {
+	var spec Spec
+	if err := mapstructure.Decode(config, &spec); err != nil {
+		return spec, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	if raw, ok := config.(map[string]any); ok {
+		if v, ok := raw["files"]; ok {
+			spec.Files = decodeStringList(v)
+		}
+		if v, ok := raw["allowedHosts"]; ok {
+			spec.AllowedHosts = decodeStringList(v)
+		}
+	}
+	if strings.TrimSpace(spec.SourceMode) == "" {
+		spec.SourceMode = sourceModeRepository
+	}
+	return spec, nil
+}
+
+func decodeStringList(v any) []string {
+	switch x := v.(type) {
+	case []string:
+		return x
+	case []any:
+		out := make([]string, 0, len(x))
+		for _, e := range x {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func validateSpec(spec Spec) error {
+	if strings.TrimSpace(spec.Task) == "" {
+		return fmt.Errorf("task is required")
+	}
+	if !spec.GithubToken.isSet() {
+		return fmt.Errorf("githubToken is required")
+	}
+	switch spec.SourceMode {
+	case sourceModeRepository:
+		if strings.TrimSpace(spec.Repository) == "" {
+			return fmt.Errorf("repository is required in repository mode")
+		}
+		if err := validateRepository(spec.Repository); err != nil {
+			return err
+		}
+		if err := validateGitRef("baseBranch", spec.BaseBranch); err != nil {
+			return err
+		}
+		if err := validateGitRef("branchName", spec.BranchName); err != nil {
+			return err
+		}
+	case sourceModePR:
+		if strings.TrimSpace(spec.PrURL) == "" {
+			return fmt.Errorf("prUrl is required in pull request mode")
+		}
+		if _, _, _, err := parsePRURL(spec.PrURL); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid sourceMode %q", spec.SourceMode)
+	}
+	return nil
+}
+
+func validateConfiguredFiles(ctx core.SetupContext, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	if ctx.Files == nil {
+		return fmt.Errorf("files configured but file access is not available")
+	}
+	available, err := ctx.Files.List()
+	if err != nil {
+		return fmt.Errorf("failed to list repository files: %v", err)
+	}
+	fileSet := make(map[string]bool, len(available))
+	for _, f := range available {
+		if norm, err := gitprovider.NormalizePath(f); err == nil {
+			fileSet[norm] = true
+		}
+	}
+	for _, f := range files {
+		norm, err := gitprovider.ValidateUserPath(f)
+		if err != nil {
+			return fmt.Errorf("invalid file path %q: %v", f, err)
+		}
+		if !fileSet[norm] {
+			return fmt.Errorf("file %q not found in app repository", f)
+		}
+	}
+	return nil
+}
+
+var gitRefPattern = regexp.MustCompile(`^[A-Za-z0-9._][A-Za-z0-9._/-]*$`)
+
+func validateGitRef(field, ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.Contains(ref, "{{") {
+		return nil
+	}
+	if !gitRefPattern.MatchString(ref) {
+		return fmt.Errorf("%s %q contains invalid characters", field, ref)
+	}
+	return nil
+}
+
+var repoOwnerRepoPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
+
+func validateRepository(repository string) error {
+	repository = strings.TrimSpace(repository)
+	if strings.Contains(repository, "{{") {
+		return nil
+	}
+	if i := strings.IndexFunc(repository, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	}); i >= 0 {
+		return fmt.Errorf("repository must not contain whitespace or control characters")
+	}
+	if repoOwnerRepoPattern.MatchString(repository) {
+		return nil
+	}
+	// Only owner/repo and https:// URLs are accepted: the agent authenticates
+	// with the injected token over HTTPS, so ssh:// / git:// URLs would clone
+	// unauthenticated and fail on private repositories.
+	if strings.HasPrefix(repository, "https://") {
+		return nil
+	}
+	return fmt.Errorf("repository must be owner/repo or an https:// git URL")
+}
+
+func setNodeMetadata(ctx core.SetupContext, spec Spec) error {
+	if ctx.Metadata == nil {
+		return nil
+	}
+	meta := NodeMetadata{
+		SourceMode: spec.SourceMode,
+		Model:      modelForRun(spec),
+	}
+	if spec.SourceMode == sourceModePR {
+		meta.PrURL = strings.TrimSpace(spec.PrURL)
+	} else {
+		meta.Repository = strings.TrimSpace(spec.Repository)
+		meta.BaseBranch = strings.TrimSpace(spec.BaseBranch)
+	}
+	return ctx.Metadata.Set(meta)
+}
+
+func modelForRun(spec Spec) string {
+	if m := strings.TrimSpace(spec.Model); m != "" {
+		return m
+	}
+	return defaultModel
+}
+
+// commitAttribution is the git author identity the agent should commit as. When
+// disabled (empty), the agent keeps its default identity and attribution trailers.
+type commitAttribution struct {
+	AuthorName  string
+	AuthorEmail string
+}
+
+func (c commitAttribution) enabled() bool { return c.AuthorName != "" }
+
+func actAsBot(spec Spec) bool {
+	return spec.ActAsBot == nil || *spec.ActAsBot
+}
+
+// resolveCommitAttribution returns the author identity to attribute commits to
+// when "Act as Bot" is off, so commits appear as the token's GitHub user rather
+// than as the agent.
+func resolveCommitAttribution(ctx core.ExecutionContext, spec Spec, token string) (commitAttribution, error) {
+	if actAsBot(spec) {
+		return commitAttribution{}, nil
+	}
+	name, email, err := resolveGitHubUser(ctx.HTTP, token)
+	if err != nil {
+		return commitAttribution{}, fmt.Errorf("failed to resolve GitHub user for commit attribution: %w", err)
+	}
+	return commitAttribution{AuthorName: name, AuthorEmail: email}, nil
+}
+
+func repositoryForRun(spec Spec, pr *pullRequestInfo) string {
+	if pr != nil {
+		return pr.BaseRepo
+	}
+	return strings.TrimSpace(spec.Repository)
+}
+
+func branchForRun(spec Spec, pr *pullRequestInfo, id uuid.UUID) string {
+	if pr != nil {
+		return pr.HeadRef
+	}
+	if b := strings.TrimSpace(spec.BranchName); b != "" {
+		return b
+	}
+	return "claude/agent-" + shortID(id.String())
+}
+
+func fileIDsOf(resources []runagent.FileResource) []string {
+	if len(resources) == 0 {
+		return nil
+	}
+	ids := make([]string, len(resources))
+	for i, r := range resources {
+		ids[i] = r.FileID
+	}
+	return ids
+}
+
+func shortID(id string) string {
+	id = strings.ReplaceAll(id, "-", "")
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}

--- a/pkg/integrations/claude/runcodeagent/run_code_agent.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent.go
@@ -223,7 +223,13 @@ func (a *RunCodeAgent) Execute(ctx core.ExecutionContext) error {
 	}
 
 	ctx.Logger.Infof("Started code agent session %s. Waiting for completion...", meta.Session.ID)
-	return ctx.Requests.ScheduleActionCall("poll", map[string]any{"attempt": 1, "errors": 0}, initialPoll)
+	if err := ctx.Requests.ScheduleActionCall("poll", map[string]any{"attempt": 1, "errors": 0}, initialPoll); err != nil {
+		// Without a scheduled poll nothing will finish or reclaim the run, so
+		// tear everything down rather than leaking the running session.
+		a.teardown(client, meta, true, ctx.Logger.Warnf)
+		return fmt.Errorf("failed to schedule poll: %w", err)
+	}
+	return nil
 }
 
 // startSession creates the session, persists metadata, and sends the task prompt.
@@ -409,6 +415,9 @@ func resolvePullRequestForRun(ctx core.ExecutionContext, spec Spec, token string
 	}
 	if pr.isFork() {
 		return nil, fmt.Errorf("pull request %s was opened from a fork (%s); updating fork PRs is not yet supported", spec.PrURL, pr.HeadRepo)
+	}
+	if strings.TrimSpace(pr.BaseRepo) == "" || strings.TrimSpace(pr.HeadRef) == "" {
+		return nil, fmt.Errorf("pull request %s is missing its base repository or head branch", spec.PrURL)
 	}
 	return pr, nil
 }

--- a/pkg/integrations/claude/runcodeagent/run_code_agent.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent.go
@@ -373,9 +373,9 @@ func provisionVault(client *runagent.Client, ctx core.ExecutionContext, spec Spe
 		return "", fmt.Errorf("failed to create vault: %w", err)
 	}
 
-	githubHosts := append([]string{}, defaultGitHubHosts...)
-	githubHosts = append(githubHosts, spec.AllowedHosts...)
-	if err := client.CreateEnvVarCredential(vaultID, "GITHUB_TOKEN", "GITHUB_TOKEN", token, githubHosts); err != nil {
+	// Restrict the token to GitHub hosts only (never the user's extra allowedHosts)
+	// so it can never be sent to another host at the egress layer.
+	if err := client.CreateEnvVarCredential(vaultID, "GITHUB_TOKEN", "GITHUB_TOKEN", token, defaultGitHubHosts); err != nil {
 		return vaultID, fmt.Errorf("failed to inject GitHub token: %w", err)
 	}
 	return vaultID, nil
@@ -540,13 +540,13 @@ func validateRepository(repository string) error {
 	if repoOwnerRepoPattern.MatchString(repository) {
 		return nil
 	}
-	// Only owner/repo and https:// URLs are accepted: the agent authenticates
-	// with the injected token over HTTPS, so ssh:// / git:// URLs would clone
-	// unauthenticated and fail on private repositories.
-	if strings.HasPrefix(repository, "https://") {
+	// Only owner/repo and https://github.com URLs are accepted. The GitHub token
+	// is embedded in the clone URL, so pointing at any other host would leak the
+	// credential to a non-GitHub server.
+	if strings.HasPrefix(repository, "https://github.com/") {
 		return nil
 	}
-	return fmt.Errorf("repository must be owner/repo or an https:// git URL")
+	return fmt.Errorf("repository must be owner/repo or an https://github.com/ URL")
 }
 
 func setNodeMetadata(ctx core.SetupContext, spec Spec) error {

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -1,6 +1,7 @@
 package runcodeagent
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -414,4 +415,68 @@ func Test__RunCodeAgent__poll__errorReclaims(t *testing.T) {
 		}
 	}
 	assert.True(t, deleted, "session should be reclaimed after repeated poll errors")
+}
+
+// failingEmitState wraps the execution-state double to force Emit to fail,
+// without modifying the shared test-support package.
+type failingEmitState struct {
+	*contexts.ExecutionStateContext
+	err error
+}
+
+func (f *failingEmitState) Emit(channel, payloadType string, payloads []any) error {
+	return f.err
+}
+
+func Test__RunCodeAgent__poll__timeoutEmitFailurePreservesSession(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"sess_1","status":"running"}`), // get session (still running)
+	}}
+	execState := &failingEmitState{
+		ExecutionStateContext: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		err:                   fmt.Errorf("boom"),
+	}
+	hookCtx := core.ActionHookContext{
+		Name:           "poll",
+		Parameters:     map[string]any{"attempt": float64(maxPollAttempts + 1), "errors": float64(0)},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       terminalMeta(),
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.Error(t, a.HandleHook(hookCtx))
+	assert.False(t, execState.Finished)
+	// The session must NOT be deleted when the emit fails, so a retry can recover.
+	for _, r := range httpCtx.Requests {
+		assert.NotEqual(t, http.MethodDelete, r.Method, "session must survive an emit failure")
+	}
+}
+
+func Test__RunCodeAgent__poll__missingSessionFinishesError(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{}`), resp(`{}`), resp(`{}`), // teardown of stray env/vault/agent
+	}}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	metadataCtx := &contexts.MetadataContext{Metadata: ExecutionMetadata{
+		AgentID: "agent_1", EnvironmentID: "env_1", VaultID: "vault_1", Branch: "b",
+	}}
+	hookCtx := core.ActionHookContext{
+		Name:           "poll",
+		Parameters:     map[string]any{"attempt": float64(1), "errors": float64(0)},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       metadataCtx,
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.HandleHook(hookCtx))
+	require.True(t, execState.Finished)
+	assert.Equal(t, "error", execState.Payloads[0].(map[string]any)["data"].(OutputPayload).Status)
 }

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -491,4 +492,55 @@ func Test__RunCodeAgent__poll__missingSessionFinishesError(t *testing.T) {
 	require.NoError(t, a.HandleHook(hookCtx))
 	require.True(t, execState.Finished)
 	assert.Equal(t, "error", execState.Payloads[0].(map[string]any)["data"].(OutputPayload).Status)
+}
+
+// failingSchedule implements core.RequestContext with a ScheduleActionCall that
+// always fails, without touching the shared test-support package.
+type failingSchedule struct{ err error }
+
+func (f *failingSchedule) ScheduleActionCall(actionName string, parameters map[string]any, interval time.Duration) error {
+	return f.err
+}
+
+func Test__RunCodeAgent__Execute__reclaimsOnScheduleFailure(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"agent_1"}`),                                   // create agent
+		resp(`{"id":"env_1"}`),                                     // create environment
+		resp(`{"id":"vault_1"}`),                                   // create vault
+		resp(`{}`),                                                 // credential
+		resp(`{"id":"sess_1","status":"running"}`),                 // create session
+		resp(`{}`),                                                 // send message
+		resp(`{"id":"sess_1","status":"running"}`),                 // get session (fast-path, not terminal)
+		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), // teardown
+	}}
+	execCtx := core.ExecutionContext{
+		ID:             uuid.New(),
+		Configuration:  repoConfig(),
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Secrets:        &contexts.SecretsContext{Values: map[string][]byte{"gh/token": []byte("ghp_123")}},
+		Metadata:       &contexts.MetadataContext{},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		Requests:       &failingSchedule{err: fmt.Errorf("schedule boom")},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.Error(t, a.Execute(execCtx))
+	var deleted bool
+	for _, r := range httpCtx.Requests {
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/sessions/sess_1") {
+			deleted = true
+		}
+	}
+	assert.True(t, deleted, "resources must be reclaimed when the poll cannot be scheduled")
+}
+
+func Test__RunCodeAgent__resolvePullRequestForRun__missingRef(t *testing.T) {
+	ctx := core.ExecutionContext{HTTP: &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"state":"open","head":{"ref":"","repo":{"full_name":"o/r"}},"base":{"ref":"main","repo":{"full_name":"o/r"}}}`),
+	}}}
+	_, err := resolvePullRequestForRun(ctx, Spec{PrURL: "https://github.com/o/r/pull/1"}, "tok")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing its base repository or head branch")
 }

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -245,6 +245,59 @@ func Test__RunCodeAgent__Execute__cleansUpOnSessionFailure(t *testing.T) {
 	assert.True(t, agentArchived, "agent should be archived")
 }
 
+func Test__RunCodeAgent__Execute__prModeSchedulesPoll(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"number":5,"state":"open","html_url":"https://github.com/o/r/pull/5","head":{"ref":"feature","repo":{"full_name":"o/r"}},"base":{"ref":"main","repo":{"full_name":"o/r"}}}`), // resolve PR
+		resp(`{"id":"agent_1"}`),                   // create agent
+		resp(`{"id":"env_1"}`),                     // create environment
+		resp(`{"id":"vault_1"}`),                   // create vault
+		resp(`{}`),                                 // credential
+		resp(`{"id":"sess_1","status":"running"}`), // create session
+		resp(`{}`),                                 // send message
+		resp(`{"id":"sess_1","status":"running"}`), // get session (fast-path)
+	}}
+	metadataCtx := &contexts.MetadataContext{}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	requestsCtx := &contexts.RequestContext{}
+	execCtx := core.ExecutionContext{
+		ID: uuid.New(),
+		Configuration: map[string]any{
+			"sourceMode":  "pr",
+			"prUrl":       "https://github.com/o/r/pull/5",
+			"task":        "address the review",
+			"githubToken": map[string]any{"secret": "gh", "key": "token"},
+		},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Secrets:        &contexts.SecretsContext{Values: map[string][]byte{"gh/token": []byte("ghp_123")}},
+		Metadata:       metadataCtx,
+		ExecutionState: execState,
+		Requests:       requestsCtx,
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.Execute(execCtx))
+	assert.Equal(t, "poll", requestsCtx.Action)
+
+	md := ExecutionMetadata{}
+	require.NoError(t, mapstructure.Decode(metadataCtx.Get(), &md))
+	assert.Equal(t, "https://github.com/o/r/pull/5", md.PrURL)
+	assert.Equal(t, "feature", md.Branch)
+
+	// The prompt updates the PR branch in place, not a new PR.
+	var sendReq *http.Request
+	for _, r := range httpCtx.Requests {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/events") {
+			sendReq = r
+		}
+	}
+	require.NotNil(t, sendReq)
+	body, _ := io.ReadAll(sendReq.Body)
+	assert.Contains(t, string(body), "git switch feature")
+	assert.Contains(t, string(body), "do NOT open a new pull request")
+}
+
 // --- poll ---
 
 func terminalMeta() *contexts.MetadataContext {

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -1,0 +1,364 @@
+package runcodeagent
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func resp(body string) *http.Response {
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+}
+
+func repoConfig() map[string]any {
+	return map[string]any{
+		"sourceMode":  "repository",
+		"repository":  "owner/repo",
+		"task":        "do the thing",
+		"githubToken": map[string]any{"secret": "gh", "key": "token"},
+	}
+}
+
+// --- Setup / validation ---
+
+func Test__RunCodeAgent__Setup__valid(t *testing.T) {
+	a := &RunCodeAgent{}
+	metadataCtx := &contexts.MetadataContext{}
+	ctx := core.SetupContext{Configuration: repoConfig(), Integration: &contexts.IntegrationContext{}, Metadata: metadataCtx}
+	require.NoError(t, a.Setup(ctx))
+
+	md := NodeMetadata{}
+	require.NoError(t, mapstructure.Decode(metadataCtx.Get(), &md))
+	assert.Equal(t, "owner/repo", md.Repository)
+	assert.Equal(t, "repository", md.SourceMode)
+	assert.Equal(t, defaultModel, md.Model)
+}
+
+func Test__RunCodeAgent__Setup__validation(t *testing.T) {
+	a := &RunCodeAgent{}
+	cases := []struct {
+		name    string
+		mutate  func(map[string]any)
+		wantErr string
+	}{
+		{"missing task", func(c map[string]any) { delete(c, "task") }, "task is required"},
+		{"missing token", func(c map[string]any) { delete(c, "githubToken") }, "githubToken is required"},
+		{"repo mode missing repository", func(c map[string]any) { delete(c, "repository") }, "repository is required"},
+		{"invalid repository", func(c map[string]any) { c["repository"] = "nonsense" }, "owner/repo or an https"},
+		{"pr mode missing prUrl", func(c map[string]any) { c["sourceMode"] = "pr"; delete(c, "repository") }, "prUrl is required"},
+		{"pr mode invalid prUrl", func(c map[string]any) { c["sourceMode"] = "pr"; c["prUrl"] = "nope" }, "invalid pull request URL"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := repoConfig()
+			tc.mutate(cfg)
+			err := a.Setup(core.SetupContext{Configuration: cfg, Integration: &contexts.IntegrationContext{}, Metadata: &contexts.MetadataContext{}})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func Test__RunCodeAgent__validateRepository(t *testing.T) {
+	valid := []string{"owner/repo", "https://github.com/owner/repo.git", "{{ event.repo }}"}
+	for _, v := range valid {
+		assert.NoError(t, validateRepository(v), v)
+	}
+	// ssh:// and git:// are rejected because token auth only works over https.
+	invalid := []string{"not a repo", "owner/repo extra", "https://github.com/o/r.git\ninjection", "ssh://git@github.com/o/r.git", "git://github.com/o/r.git"}
+	for _, v := range invalid {
+		assert.Error(t, validateRepository(v), v)
+	}
+}
+
+func Test__RunCodeAgent__parsePRURL(t *testing.T) {
+	owner, repo, number, err := parsePRURL("https://github.com/acme/widgets/pull/42")
+	require.NoError(t, err)
+	assert.Equal(t, "acme", owner)
+	assert.Equal(t, "widgets", repo)
+	assert.Equal(t, 42, number)
+
+	_, _, _, err = parsePRURL("https://github.com/acme/widgets/issues/42")
+	require.Error(t, err)
+}
+
+func Test__RunCodeAgent__extractPRURL(t *testing.T) {
+	assert.Equal(t, "https://github.com/o/r/pull/7",
+		extractPRURL([]string{"working..."}, "Done. PR_URL=https://github.com/o/r/pull/7"))
+	assert.Equal(t, "", extractPRURL([]string{"no marker here"}, "NO_PR"))
+	assert.Equal(t, "", extractPRURL(nil, ""))
+}
+
+func Test__RunCodeAgent__buildEnvironmentConfig(t *testing.T) {
+	unrestricted := buildEnvironmentConfig(Spec{Networking: networkingUnrestricted})
+	assert.Equal(t, "unrestricted", unrestricted.Networking.Type)
+
+	limited := buildEnvironmentConfig(Spec{Networking: networkingLimited, AllowedHosts: []string{"registry.internal"}})
+	assert.Equal(t, "limited", limited.Networking.Type)
+	assert.Contains(t, limited.Networking.AllowedHosts, "github.com")
+	assert.Contains(t, limited.Networking.AllowedHosts, "registry.internal")
+	require.NotNil(t, limited.Networking.AllowPackageManagers)
+	assert.True(t, *limited.Networking.AllowPackageManagers)
+}
+
+func Test__RunCodeAgent__buildPrompt__repository(t *testing.T) {
+	spec := Spec{SourceMode: "repository", Repository: "owner/repo", Task: "fix the bug", BaseBranch: "main"}
+	got := buildPrompt(spec, nil, "claude/agent-abc", false, commitAttribution{})
+	assert.Contains(t, got, "git clone https://x-access-token:$GITHUB_TOKEN@github.com/owner/repo.git")
+	assert.Contains(t, got, "git checkout -b claude/agent-abc")
+	assert.Contains(t, got, "fix the bug")
+	assert.Contains(t, got, "Open a pull request")
+	assert.Contains(t, got, "PR_URL=")
+	// Acting as bot (default): no git identity config, no trailer suppression.
+	assert.NotContains(t, got, "git config user.name")
+	assert.NotContains(t, got, "Co-Authored-By")
+}
+
+func Test__RunCodeAgent__buildPrompt__actAsUser(t *testing.T) {
+	spec := Spec{SourceMode: "repository", Repository: "owner/repo", Task: "fix the bug"}
+	attr := commitAttribution{AuthorName: "Octo Cat", AuthorEmail: "1+octocat@users.noreply.github.com"}
+	got := buildPrompt(spec, nil, "claude/agent-abc", false, attr)
+	assert.Contains(t, got, `git config user.name "Octo Cat"`)
+	assert.Contains(t, got, `git config user.email "1+octocat@users.noreply.github.com"`)
+	assert.Contains(t, got, "Co-Authored-By")
+}
+
+func Test__RunCodeAgent__buildPrompt__pr(t *testing.T) {
+	pr := &pullRequestInfo{BaseRepo: "owner/repo", HeadRef: "feature-x", HTMLURL: "https://github.com/owner/repo/pull/9"}
+	got := buildPrompt(Spec{SourceMode: "pr", Task: "address review"}, pr, "feature-x", false, commitAttribution{})
+	assert.Contains(t, got, "git switch feature-x")
+	assert.Contains(t, got, "do NOT open a new pull request")
+	assert.Contains(t, got, "address review")
+	assert.Contains(t, got, "https://github.com/owner/repo/pull/9")
+}
+
+func Test__RunCodeAgent__actAsBot(t *testing.T) {
+	no := false
+	yes := true
+	assert.True(t, actAsBot(Spec{})) // default
+	assert.True(t, actAsBot(Spec{ActAsBot: &yes}))
+	assert.False(t, actAsBot(Spec{ActAsBot: &no}))
+}
+
+// --- Execute ---
+
+func Test__RunCodeAgent__Execute__repositoryMode_schedulesPoll(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"agent_1"}`),                   // create agent
+		resp(`{"id":"env_1"}`),                     // create environment
+		resp(`{"id":"vault_1"}`),                   // create vault
+		resp(`{}`),                                 // add GITHUB_TOKEN credential
+		resp(`{"id":"sess_1","status":"running"}`), // create session
+		resp(`{}`),                                 // send message
+		resp(`{"id":"sess_1","status":"running"}`), // get session (fast-path check)
+	}}
+	metadataCtx := &contexts.MetadataContext{}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	requestsCtx := &contexts.RequestContext{}
+	execCtx := core.ExecutionContext{
+		ID:             uuid.New(),
+		Configuration:  repoConfig(),
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Secrets:        &contexts.SecretsContext{Values: map[string][]byte{"gh/token": []byte("ghp_123")}},
+		Metadata:       metadataCtx,
+		ExecutionState: execState,
+		Requests:       requestsCtx,
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.Execute(execCtx))
+	assert.False(t, execState.Finished)
+	assert.Equal(t, "poll", requestsCtx.Action)
+
+	md := ExecutionMetadata{}
+	require.NoError(t, mapstructure.Decode(metadataCtx.Get(), &md))
+	assert.Equal(t, "agent_1", md.AgentID)
+	assert.Equal(t, "env_1", md.EnvironmentID)
+	assert.Equal(t, "vault_1", md.VaultID)
+	assert.Equal(t, "sess_1", md.Session.ID)
+	assert.Equal(t, "owner/repo", md.Repository)
+	assert.True(t, strings.HasPrefix(md.Branch, "claude/agent-"))
+
+	// Sanity: the send-events body carries the clone + task.
+	var sendReq *http.Request
+	for _, r := range httpCtx.Requests {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/events") {
+			sendReq = r
+		}
+	}
+	require.NotNil(t, sendReq)
+	body, _ := io.ReadAll(sendReq.Body)
+	assert.Contains(t, string(body), "git clone")
+	assert.Contains(t, string(body), "do the thing")
+}
+
+func Test__RunCodeAgent__Execute__cleansUpOnSessionFailure(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"agent_1"}`), // create agent
+		resp(`{"id":"env_1"}`),   // create environment
+		resp(`{"id":"vault_1"}`), // create vault
+		resp(`{}`),               // credential
+		{StatusCode: 500, Body: io.NopCloser(strings.NewReader(`{"error":{"message":"boom"}}`))}, // create session fails
+		resp(`{}`), // teardown: delete environment
+		resp(`{}`), // teardown: delete vault
+		resp(`{}`), // teardown: archive agent
+	}}
+	execCtx := core.ExecutionContext{
+		ID:             uuid.New(),
+		Configuration:  repoConfig(),
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Secrets:        &contexts.SecretsContext{Values: map[string][]byte{"gh/token": []byte("ghp_123")}},
+		Metadata:       &contexts.MetadataContext{},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.Error(t, a.Execute(execCtx))
+
+	var envDeleted, vaultDeleted, agentArchived bool
+	for _, r := range httpCtx.Requests {
+		switch {
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/environments/env_1"):
+			envDeleted = true
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/vaults/vault_1"):
+			vaultDeleted = true
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/agents/agent_1/archive"):
+			agentArchived = true
+		}
+	}
+	assert.True(t, envDeleted, "environment should be deleted")
+	assert.True(t, vaultDeleted, "vault should be deleted")
+	assert.True(t, agentArchived, "agent should be archived")
+}
+
+// --- poll ---
+
+func terminalMeta() *contexts.MetadataContext {
+	return &contexts.MetadataContext{Metadata: ExecutionMetadata{
+		Session:       &SessionMetadata{ID: "sess_1", Status: "running"},
+		AgentID:       "agent_1",
+		EnvironmentID: "env_1",
+		VaultID:       "vault_1",
+		Branch:        "claude/agent-abc",
+	}}
+}
+
+func Test__RunCodeAgent__poll__terminalExtractsPR(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"sess_1","status":"idle"}`),
+		resp(`{"data":[{"type":"session.status_idle"},{"type":"agent.message","content":[{"type":"text","text":"Done. PR_URL=https://github.com/o/r/pull/7"}]}]}`),
+		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), // teardown
+	}}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	hookCtx := core.ActionHookContext{
+		Name:           "poll",
+		Parameters:     map[string]any{"attempt": float64(1), "errors": float64(0)},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       terminalMeta(),
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.HandleHook(hookCtx))
+	require.True(t, execState.Finished)
+	out := execState.Payloads[0].(map[string]any)["data"].(OutputPayload)
+	assert.Equal(t, "idle", out.Status)
+	assert.Equal(t, "https://github.com/o/r/pull/7", out.PrURL)
+	assert.Equal(t, "claude/agent-abc", out.Branch)
+}
+
+func Test__RunCodeAgent__poll__timeoutReclaims(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"sess_1","status":"running"}`), // still running
+		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), // teardown (interrupt+delete+env+vault+agent)
+	}}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	hookCtx := core.ActionHookContext{
+		Name:           "poll",
+		Parameters:     map[string]any{"attempt": float64(maxPollAttempts + 1), "errors": float64(0)},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       terminalMeta(),
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.HandleHook(hookCtx))
+	require.True(t, execState.Finished)
+	assert.Equal(t, "timeout", execState.Payloads[0].(map[string]any)["data"].(OutputPayload).Status)
+
+	var deleted bool
+	for _, r := range httpCtx.Requests {
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/sessions/sess_1") {
+			deleted = true
+		}
+	}
+	assert.True(t, deleted, "session should be deleted on timeout")
+}
+
+func Test__RunCodeAgent__poll__clientErrorReportsError(t *testing.T) {
+	a := &RunCodeAgent{}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	hookCtx := core.ActionHookContext{
+		Name:           "poll",
+		Parameters:     map[string]any{"attempt": float64(2), "errors": float64(maxPollErrors - 1)},
+		Integration:    &contexts.IntegrationContext{}, // no apiKey -> client creation fails
+		Metadata:       terminalMeta(),
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.HandleHook(hookCtx))
+	require.True(t, execState.Finished)
+	assert.Equal(t, "error", execState.Payloads[0].(map[string]any)["data"].(OutputPayload).Status)
+}
+
+func Test__RunCodeAgent__poll__errorReclaims(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		{StatusCode: 500, Body: io.NopCloser(strings.NewReader(`{"error":{"message":"boom"}}`))}, // get session fails
+		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), // teardown (interrupt, delete session, env, vault, archive)
+	}}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	hookCtx := core.ActionHookContext{
+		Name:           "poll",
+		Parameters:     map[string]any{"attempt": float64(2), "errors": float64(maxPollErrors - 1)},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       terminalMeta(),
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.HandleHook(hookCtx))
+	require.True(t, execState.Finished)
+	assert.Equal(t, "error", execState.Payloads[0].(map[string]any)["data"].(OutputPayload).Status)
+	var deleted bool
+	for _, r := range httpCtx.Requests {
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/sessions/sess_1") {
+			deleted = true
+		}
+	}
+	assert.True(t, deleted, "session should be reclaimed after repeated poll errors")
+}

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -74,11 +74,23 @@ func Test__RunCodeAgent__validateRepository(t *testing.T) {
 	for _, v := range valid {
 		assert.NoError(t, validateRepository(v), v)
 	}
-	// ssh:// and git:// are rejected because token auth only works over https.
-	invalid := []string{"not a repo", "owner/repo extra", "https://github.com/o/r.git\ninjection", "ssh://git@github.com/o/r.git", "git://github.com/o/r.git"}
+	// Non-github hosts, ssh:// and git:// are rejected: the GitHub token is
+	// embedded in the clone URL, so it must only ever target github.com.
+	invalid := []string{
+		"not a repo", "owner/repo extra", "https://github.com/o/r.git\ninjection",
+		"ssh://git@github.com/o/r.git", "git://github.com/o/r.git",
+		"https://evil.com/o/r.git", "https://gitlab.com/o/r.git",
+	}
 	for _, v := range invalid {
 		assert.Error(t, validateRepository(v), v)
 	}
+}
+
+func Test__RunCodeAgent__authenticatedCloneURL(t *testing.T) {
+	assert.Equal(t, "https://x-access-token:$GITHUB_TOKEN@github.com/owner/repo.git", authenticatedCloneURL("owner/repo"))
+	assert.Equal(t, "https://x-access-token:$GITHUB_TOKEN@github.com/o/r.git", authenticatedCloneURL("https://github.com/o/r.git"))
+	// A non-github URL must never receive the token.
+	assert.Equal(t, "https://evil.com/o/r.git", authenticatedCloneURL("https://evil.com/o/r.git"))
 }
 
 func Test__RunCodeAgent__parsePRURL(t *testing.T) {

--- a/pkg/integrations/claude/runcodeagent/types.go
+++ b/pkg/integrations/claude/runcodeagent/types.go
@@ -1,0 +1,160 @@
+package runcodeagent
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/integrations/claude/runagent"
+)
+
+const (
+	payloadType    = "claude.runCodeAgent"
+	defaultChannel = "default"
+
+	sourceModeRepository = "repository"
+	sourceModePR         = "pr"
+
+	sessionStatusIdle       = "idle"
+	sessionStatusTerminated = "terminated"
+
+	initialPoll       = 15 * time.Second
+	maxPollInterval   = 5 * time.Minute
+	maxPollAttempts   = 200
+	maxPollErrors     = 5
+	finalMessageReads = 15
+	finalMessageDelay = 2 * time.Second
+
+	// Where attached files are mounted inside the sandbox.
+	attachmentsMountDir = "/workspace/attachments"
+
+	networkingUnrestricted = "unrestricted"
+	networkingLimited      = "limited"
+)
+
+// defaultGitHubHosts are always allowed when networking is "limited" so the
+// agent can clone, push, and open pull requests.
+var defaultGitHubHosts = []string{
+	"github.com",
+	"api.github.com",
+	"codeload.github.com",
+	"*.githubusercontent.com",
+	"objects.githubusercontent.com",
+}
+
+// Spec is the workflow node configuration for claude.runCodeAgent.
+type Spec struct {
+	SourceMode   string    `json:"sourceMode" mapstructure:"sourceMode"`
+	Repository   string    `json:"repository" mapstructure:"repository"`
+	BaseBranch   string    `json:"baseBranch" mapstructure:"baseBranch"`
+	BranchName   string    `json:"branchName" mapstructure:"branchName"`
+	AutoCreatePr *bool     `json:"autoCreatePr" mapstructure:"autoCreatePr"`
+	PrURL        string    `json:"prUrl" mapstructure:"prUrl"`
+	Task         string    `json:"task" mapstructure:"task"`
+	GithubToken  SecretRef `json:"githubToken" mapstructure:"githubToken"`
+	ActAsBot     *bool     `json:"actAsBot" mapstructure:"actAsBot"`
+	Model        string    `json:"model" mapstructure:"model"`
+	Networking   string    `json:"networking" mapstructure:"networking"`
+	AllowedHosts []string  `json:"allowedHosts" mapstructure:"allowedHosts"`
+	Files        []string  `json:"files" mapstructure:"files"`
+}
+
+// SecretRef references a SuperPlane secret by name and key.
+type SecretRef struct {
+	Secret string `json:"secret" mapstructure:"secret"`
+	Key    string `json:"key" mapstructure:"key"`
+}
+
+func (r SecretRef) isSet() bool {
+	return strings.TrimSpace(r.Secret) != "" && strings.TrimSpace(r.Key) != ""
+}
+
+// NodeMetadata is resolved at Setup for display on the component card.
+type NodeMetadata struct {
+	Repository string `json:"repository,omitempty" mapstructure:"repository,omitempty"`
+	BaseBranch string `json:"baseBranch,omitempty" mapstructure:"baseBranch,omitempty"`
+	PrURL      string `json:"prUrl,omitempty" mapstructure:"prUrl,omitempty"`
+	Model      string `json:"model,omitempty" mapstructure:"model,omitempty"`
+	SourceMode string `json:"sourceMode,omitempty" mapstructure:"sourceMode,omitempty"`
+}
+
+// ExecutionMetadata tracks every resource provisioned for a run so it can be
+// displayed and, crucially, always cleaned up.
+type ExecutionMetadata struct {
+	Session       *SessionMetadata `json:"session,omitempty" mapstructure:"session,omitempty"`
+	AgentID       string           `json:"agentId,omitempty" mapstructure:"agentId,omitempty"`
+	EnvironmentID string           `json:"environmentId,omitempty" mapstructure:"environmentId,omitempty"`
+	VaultID       string           `json:"vaultId,omitempty" mapstructure:"vaultId,omitempty"`
+	FileIDs       []string         `json:"fileIds,omitempty" mapstructure:"fileIds,omitempty"`
+	Repository    string           `json:"repository,omitempty" mapstructure:"repository,omitempty"`
+	Branch        string           `json:"branch,omitempty" mapstructure:"branch,omitempty"`
+	PrURL         string           `json:"prUrl,omitempty" mapstructure:"prUrl,omitempty"`
+}
+
+// SessionMetadata tracks the Managed Agents session.
+type SessionMetadata struct {
+	ID     string `json:"id" mapstructure:"id"`
+	Status string `json:"status" mapstructure:"status"`
+}
+
+// OutputPayload is emitted on the default channel when the run completes.
+type OutputPayload struct {
+	Status      string `json:"status"`
+	SessionID   string `json:"sessionId"`
+	PrURL       string `json:"prUrl"`
+	Branch      string `json:"branch"`
+	Summary     string `json:"summary"`
+	LastMessage string `json:"lastMessage"`
+}
+
+func isSessionTerminal(status string) bool {
+	return status == sessionStatusIdle || status == sessionStatusTerminated
+}
+
+func mergeSessionIntoMetadata(metadata *ExecutionMetadata, s *runagent.ManagedSession) {
+	if metadata.Session == nil {
+		metadata.Session = &SessionMetadata{}
+	}
+	if s == nil {
+		return
+	}
+	if s.ID != "" {
+		metadata.Session.ID = s.ID
+	}
+	if s.Status != "" {
+		metadata.Session.Status = s.Status
+	}
+}
+
+// prURLPattern extracts the pull request URL the agent reports on its final line.
+var prURLPattern = regexp.MustCompile(`PR_URL=(\S+)`)
+
+// extractPRURL scans the agent's messages for the PR_URL=<url> marker.
+func extractPRURL(messages []string, lastMessage string) string {
+	candidates := append([]string{}, messages...)
+	if lastMessage != "" {
+		candidates = append(candidates, lastMessage)
+	}
+	// Scan newest-first so the most recent PR URL wins.
+	for i := len(candidates) - 1; i >= 0; i-- {
+		if m := prURLPattern.FindStringSubmatch(candidates[i]); m != nil {
+			url := strings.TrimSpace(m[1])
+			if url != "" && url != "NO_PR" {
+				return url
+			}
+		}
+	}
+	return ""
+}
+
+func buildOutput(status, sessionID, branch string, sm *runagent.SessionMessages, fallbackPrURL string) OutputPayload {
+	out := OutputPayload{Status: status, SessionID: sessionID, Branch: branch, PrURL: fallbackPrURL}
+	if sm != nil {
+		out.LastMessage = sm.LastMessage
+		out.Summary = sm.LastMessage
+		if pr := extractPRURL(sm.Messages, sm.LastMessage); pr != "" {
+			out.PrURL = pr
+		}
+	}
+	return out
+}

--- a/pkg/integrations/claude/runcodeagent/types.go
+++ b/pkg/integrations/claude/runcodeagent/types.go
@@ -18,9 +18,11 @@ const (
 	sessionStatusIdle       = "idle"
 	sessionStatusTerminated = "terminated"
 
-	initialPoll       = 15 * time.Second
-	maxPollInterval   = 5 * time.Minute
-	maxPollAttempts   = 200
+	initialPoll     = 15 * time.Second
+	maxPollInterval = 3 * time.Minute
+	// maxPollAttempts caps a run at roughly 4 hours of polling (exponential
+	// backoff up to maxPollInterval) before it is declared a timeout.
+	maxPollAttempts   = 80
 	maxPollErrors     = 5
 	finalMessageReads = 15
 	finalMessageDelay = 2 * time.Second
@@ -103,7 +105,6 @@ type OutputPayload struct {
 	SessionID   string `json:"sessionId"`
 	PrURL       string `json:"prUrl"`
 	Branch      string `json:"branch"`
-	Summary     string `json:"summary"`
 	LastMessage string `json:"lastMessage"`
 }
 
@@ -151,7 +152,6 @@ func buildOutput(status, sessionID, branch string, sm *runagent.SessionMessages,
 	out := OutputPayload{Status: status, SessionID: sessionID, Branch: branch, PrURL: fallbackPrURL}
 	if sm != nil {
 		out.LastMessage = sm.LastMessage
-		out.Summary = sm.LastMessage
 		if pr := extractPRURL(sm.Messages, sm.LastMessage); pr != "" {
 			out.PrURL = pr
 		}

--- a/web_src/src/pages/app/mappers/claude/index.ts
+++ b/web_src/src/pages/app/mappers/claude/index.ts
@@ -1,10 +1,12 @@
 import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
 import { baseMapper } from "./base";
+import { runCodeAgentMapper } from "./run_code_agent";
 import { buildActionStateRegistry } from "../utils";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   textPrompt: baseMapper,
   runAgent: baseMapper,
+  runCodeAgent: runCodeAgentMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {};
@@ -12,4 +14,5 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {};
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   textPrompt: buildActionStateRegistry("completed"),
   runAgent: buildActionStateRegistry("completed"),
+  runCodeAgent: buildActionStateRegistry("completed"),
 };

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
@@ -131,13 +131,19 @@ describe("runCodeAgentMapper.props", () => {
     expect(props.metadata).toEqual([{ icon: "git-pull-request", label: "https://github.com/o/r/pull/9" }]);
   });
 
-  it("falls back to configuration when metadata is absent", () => {
+  it("falls back to configuration (repository and base branch) when metadata is absent", () => {
     const props = runCodeAgentMapper.props(
       buildPropsContext({
-        node: buildNode({ metadata: {}, configuration: { sourceMode: "repository", repository: "acme/widgets" } }),
+        node: buildNode({
+          metadata: {},
+          configuration: { sourceMode: "repository", repository: "acme/widgets", baseBranch: "develop" },
+        }),
       }),
     );
-    expect(props.metadata).toEqual([{ icon: "git-branch", label: "acme/widgets" }]);
+    expect(props.metadata).toEqual([
+      { icon: "git-branch", label: "acme/widgets" },
+      { icon: "git-branch", label: "develop" },
+    ]);
   });
 });
 

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import { runCodeAgentMapper } from "./run_code_agent";
+import { eventStateRegistry } from "./index";
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+
+const defaultDefinition: ComponentDefinition = {
+  name: "claude.runCodeAgent",
+  label: "Run Code Agent",
+  description: "",
+  icon: "bot",
+  color: "#C9784D",
+};
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "claude.runCodeAgent",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return { type: "claude.runCodeAgent", timestamp: new Date().toISOString(), data };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: { id: "user-1", name: "Test User", email: "test@example.com", roles: [], groups: [] },
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+describe("runCodeAgentMapper.getExecutionDetails", () => {
+  it("does not throw when outputs are missing", () => {
+    expect(() => runCodeAgentMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs: undefined } }))).not.toThrow();
+    expect(() => runCodeAgentMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs: { default: [] } } }))).not.toThrow();
+  });
+
+  it("surfaces executed-at first, then status, pull request, and branch", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              status: "idle",
+              prUrl: "https://github.com/o/r/pull/7",
+              branch: "claude/agent-abc",
+              summary: "Did the work.",
+            }),
+          ],
+        },
+      },
+    });
+    const details = runCodeAgentMapper.getExecutionDetails(ctx);
+    expect(Object.keys(details)[0]).toBe("Executed At");
+    expect(details["Status"]).toBe("idle");
+    expect(details["Pull Request"]).toBe("https://github.com/o/r/pull/7");
+    expect(details["Branch"]).toBe("claude/agent-abc");
+    expect(details["Summary"]).toBeUndefined();
+    expect(details["Emitted At"]).toBeUndefined();
+  });
+});
+
+describe("runCodeAgentMapper.props", () => {
+  it("shows repository and base branch from node metadata (repository mode)", () => {
+    const props = runCodeAgentMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          metadata: { sourceMode: "repository", repository: "acme/widgets", baseBranch: "main", model: "claude-x" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "git-branch", label: "acme/widgets" },
+      { icon: "git-branch", label: "main" },
+      { icon: "bot", label: "claude-x" },
+    ]);
+  });
+
+  it("shows the pull request in PR mode", () => {
+    const props = runCodeAgentMapper.props(
+      buildPropsContext({
+        node: buildNode({ metadata: { sourceMode: "pr", prUrl: "https://github.com/o/r/pull/9" } }),
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "git-pull-request", label: "https://github.com/o/r/pull/9" }]);
+  });
+
+  it("falls back to configuration when metadata is absent", () => {
+    const props = runCodeAgentMapper.props(
+      buildPropsContext({ node: buildNode({ metadata: {}, configuration: { sourceMode: "repository", repository: "acme/widgets" } }) }),
+    );
+    expect(props.metadata).toEqual([{ icon: "git-branch", label: "acme/widgets" }]);
+  });
+});
+
+describe("eventStateRegistry.runCodeAgent", () => {
+  it("maps finished passed to completed", () => {
+    expect(eventStateRegistry.runCodeAgent.getState(buildExecution())).toBe("completed");
+  });
+});

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
@@ -73,8 +73,12 @@ function buildPropsContext(overrides?: Partial<ComponentBaseContext>): Component
 
 describe("runCodeAgentMapper.getExecutionDetails", () => {
   it("does not throw when outputs are missing", () => {
-    expect(() => runCodeAgentMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs: undefined } }))).not.toThrow();
-    expect(() => runCodeAgentMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs: { default: [] } } }))).not.toThrow();
+    expect(() =>
+      runCodeAgentMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs: undefined } })),
+    ).not.toThrow();
+    expect(() =>
+      runCodeAgentMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs: { default: [] } } })),
+    ).not.toThrow();
   });
 
   it("surfaces executed-at first, then status, pull request, and branch", () => {
@@ -129,7 +133,9 @@ describe("runCodeAgentMapper.props", () => {
 
   it("falls back to configuration when metadata is absent", () => {
     const props = runCodeAgentMapper.props(
-      buildPropsContext({ node: buildNode({ metadata: {}, configuration: { sourceMode: "repository", repository: "acme/widgets" } }) }),
+      buildPropsContext({
+        node: buildNode({ metadata: {}, configuration: { sourceMode: "repository", repository: "acme/widgets" } }),
+      }),
     );
     expect(props.metadata).toEqual([{ icon: "git-branch", label: "acme/widgets" }]);
   });

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.ts
@@ -1,0 +1,144 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import claudeIcon from "@/assets/icons/integrations/claude.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+type RunCodeAgentNodeMetadata = {
+  repository?: string;
+  baseBranch?: string;
+  prUrl?: string;
+  model?: string;
+  sourceMode?: string;
+};
+
+type RunCodeAgentConfiguration = {
+  sourceMode?: string;
+  repository?: string;
+  prUrl?: string;
+  model?: string;
+};
+
+type RunCodeAgentPayloadData = {
+  status?: string;
+  sessionId?: string;
+  prUrl?: string;
+  branch?: string;
+  summary?: string;
+  lastMessage?: string;
+};
+
+function addDetail(details: Record<string, string>, key: string, value: string | undefined) {
+  if (value) {
+    details[key] = value;
+  }
+}
+
+export const runCodeAgentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "claude";
+
+    return {
+      iconSrc: claudeIcon,
+      iconSlug: context.componentDefinition?.icon ?? "bot",
+      collapsedBackground: "bg-white",
+      collapsed: context.node.isCollapsed,
+      title:
+        context.node.name ||
+        context.componentDefinition?.label ||
+        context.componentDefinition?.name ||
+        "Run Code Agent",
+      eventSections: lastExecution ? runCodeAgentEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const data = (outputs?.default?.[0]?.data ?? {}) as RunCodeAgentPayloadData;
+
+    const entries: Array<[string, string | undefined]> = [
+      ["Status", data.status],
+      ["Pull Request", data.prUrl],
+      ["Branch", data.branch],
+    ];
+    for (const [key, value] of entries) {
+      addDetail(details, key, value);
+    }
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? renderTimeAgo(new Date(timestamp)) : "";
+  },
+};
+
+// metadataList shows the configured target on the component card, independent of
+// any execution (names resolved at Setup, with config as a fallback).
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const items: MetadataItem[] = [];
+  const meta = (node.metadata ?? {}) as RunCodeAgentNodeMetadata;
+  const config = (node.configuration ?? {}) as RunCodeAgentConfiguration;
+
+  const isPR = (meta.sourceMode ?? config.sourceMode) === "pr";
+  if (isPR) {
+    const pr = meta.prUrl || config.prUrl;
+    if (pr) {
+      items.push({ icon: "git-pull-request", label: pr });
+    }
+  } else {
+    const repo = meta.repository || config.repository;
+    if (repo) {
+      items.push({ icon: "git-branch", label: repo });
+    }
+    if (meta.baseBranch) {
+      items.push({ icon: "git-branch", label: meta.baseBranch });
+    }
+  }
+
+  const model = meta.model || config.model;
+  if (model) {
+    items.push({ icon: "bot", label: model });
+  }
+
+  return items;
+}
+
+function runCodeAgentEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const eventSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle,
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.ts
@@ -34,7 +34,6 @@ type RunCodeAgentPayloadData = {
   sessionId?: string;
   prUrl?: string;
   branch?: string;
-  summary?: string;
   lastMessage?: string;
 };
 

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.ts
@@ -25,6 +25,7 @@ type RunCodeAgentNodeMetadata = {
 type RunCodeAgentConfiguration = {
   sourceMode?: string;
   repository?: string;
+  baseBranch?: string;
   prUrl?: string;
   model?: string;
 };
@@ -111,8 +112,9 @@ function metadataList(node: NodeInfo): MetadataItem[] {
     if (repo) {
       items.push({ icon: "git-branch", label: repo });
     }
-    if (meta.baseBranch) {
-      items.push({ icon: "git-branch", label: meta.baseBranch });
+    const baseBranch = meta.baseBranch || config.baseBranch;
+    if (baseBranch) {
+      items.push({ icon: "git-branch", label: baseBranch });
     }
   }
 


### PR DESCRIPTION
## What changed

Adds a new Claude integration component, **Run Code Agent** (`claude.runCodeAgent`). It runs an autonomous Claude coding agent against a repository inside Anthropic's Managed Agents sandbox and returns a pull request. The user picks a repository (or an existing PR) and describes a task; the agent clones, does the work, commits, pushes, and opens (or updates) a PR entirely on its own.

## Why

It replicates the Cursor "Launch Cloud Agent" experience, which includes creating PRs and working on existing PRs.

## How

### Backend (`pkg/integrations/claude/runcodeagent`)
tion).
- **Repository mode:** branch from the base branch, implement the task, open a PR.
- **PR mode:** resolve the PR via the GitHub API (`GET /repos/{owner}/{repo}/pulls/{n}`), check out its head branch, and push updates in place; same-repo PRs are supported, fork PRs report a clear error.
- **Act as Bot** toggle: when off, commits are attributed to the token's GitHub user (resolved via `GET /user`) and the Claude attribution trailers are suppressed.
- **File attachments** (Files tab) are uploaded via the Files API and mounted into the sandbox.
- **Networking** is `unrestricted` by default, or `limited` with a GitHub + registries allowlist (plus extra `allowedHosts`).
- Poll-based monitoring (Managed Agents has no webhooks) with bounded backoff, a final session check before declaring timeout, client/config failures reported as errors (not timeouts), result-preserving emit retries, and full resource teardown on every terminal path (completion, timeout, cancel, failure).
- Extends the shared Managed Agents client with `CreateEnvironment`/`DeleteEnvironment`/`CreateAgent`/`ArchiveAgent`.

### Frontend
- Dedicated mapper: the component card shows the repository/PR, base branch, and model (resolved at setup, config fallback); execution details show Executed At, Status, PR link, and Branch.
