### PR TITLE
fix: keep agent read results compact by default

### DIFF
--- a/pkg/agents/agent_tools/actions/canvas_test.go
+++ b/pkg/agents/agent_tools/actions/canvas_test.go
@@ -431,7 +431,8 @@ func TestAppAgentTool_ListResources(t *testing.T) {
 		Registry:    r.Registry,
 		AuthService: r.AuthService,
 	})
-	result, err := registry.Execute(context.Background(), agents.AgentSessionContext{
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	result, err := registry.Execute(ctx, agents.AgentSessionContext{
 		SessionID:      "session-1",
 		OrganizationID: r.Organization.ID.String(),
 		UserID:         r.User.String(),
@@ -475,7 +476,8 @@ func TestAppAgentTool_CreateDraftCreatesAnotherDraftBranch(t *testing.T) {
 		WebhookBaseURL: "https://hooks.example.test",
 	})
 
-	result, err := registry.Execute(context.Background(), agents.AgentSessionContext{
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	result, err := registry.Execute(ctx, agents.AgentSessionContext{
 		SessionID:      "session-1",
 		OrganizationID: r.Organization.ID.String(),
 		UserID:         r.User.String(),
@@ -625,8 +627,9 @@ func TestAppAgentTool_ReadUsesProvidedDraftVersionID(t *testing.T) {
 		UserID:         r.User.String(),
 		CanvasID:       canvas.ID.String(),
 	}, Input{
-		Action:    "read",
-		VersionID: firstDraft.ID.String(),
+		Action:            "read",
+		VersionID:         firstDraft.ID.String(),
+		IncludeCanvasYAML: true,
 	})
 
 	require.NoError(t, err)
@@ -637,6 +640,54 @@ func TestAppAgentTool_ReadUsesProvidedDraftVersionID(t *testing.T) {
 	require.NotNil(t, read.Draft)
 	assert.Equal(t, firstDraft.ID.String(), read.Draft.VersionID)
 	assert.Equal(t, "draft: first\n", read.CanvasYAML)
+	assert.Equal(t, len("draft: first\n"), read.CanvasYAMLBytes)
+}
+
+func TestAppAgentTool_ReadOmitsCanvasYAMLByDefault(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	draft, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+
+	updatedBy := r.User
+	_, err = models.UpsertWorkflowStagingPath(
+		draft.ID,
+		r.Organization.ID,
+		canvasRepository.CanvasYAMLRepositoryPath,
+		"draft: compact\n",
+		"",
+		&updatedBy,
+	)
+	require.NoError(t, err)
+
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	result, err := registry.Execute(ctx, agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Action:    "read",
+		VersionID: draft.ID.String(),
+	})
+
+	require.NoError(t, err)
+	read, ok := result.(readResult)
+	require.True(t, ok)
+	assert.Empty(t, read.CanvasYAML)
+	assert.True(t, read.CanvasYAMLOmitted)
+	assert.Equal(t, len("draft: compact\n"), read.CanvasYAMLBytes)
+	assert.Equal(t, "draft", read.Source)
+	assert.Equal(t, draft.ID.String(), read.VersionID)
 }
 
 func TestAppAgentTool_ReadUseDraftFalseIgnoresDraftVersionID(t *testing.T) {
@@ -673,9 +724,10 @@ func TestAppAgentTool_ReadUseDraftFalseIgnoresDraftVersionID(t *testing.T) {
 		UserID:         r.User.String(),
 		CanvasID:       canvas.ID.String(),
 	}, Input{
-		Action:    "read",
-		UseDraft:  &useDraft,
-		VersionID: draft.ID.String(),
+		Action:            "read",
+		UseDraft:          &useDraft,
+		VersionID:         draft.ID.String(),
+		IncludeCanvasYAML: true,
 	})
 
 	require.NoError(t, err)

--- a/pkg/agents/agent_tools/actions/read.go
+++ b/pkg/agents/agent_tools/actions/read.go
@@ -64,12 +64,17 @@ func (a readAction) Execute(ctx context.Context, session agents.AgentSessionCont
 	}
 
 	result := readResult{
-		Action:     "read",
-		CanvasID:   session.CanvasID,
-		Source:     source,
-		VersionID:  versionID,
-		Summary:    a.summarize(session.OrganizationID, canvas, version, source, canvasYAML),
-		CanvasYAML: canvasYAML,
+		Action:            "read",
+		CanvasID:          session.CanvasID,
+		Source:            source,
+		VersionID:         versionID,
+		Summary:           a.summarize(session.OrganizationID, canvas, version, source, canvasYAML),
+		CanvasYAMLBytes:   len(canvasYAML),
+		CanvasYAMLOmitted: !input.IncludeCanvasYAML,
+	}
+
+	if input.IncludeCanvasYAML {
+		result.CanvasYAML = canvasYAML
 	}
 
 	if draft != nil {

--- a/pkg/agents/agent_tools/actions/types.go
+++ b/pkg/agents/agent_tools/actions/types.go
@@ -10,6 +10,7 @@ type Input struct {
 	UseDraft            *bool             `json:"use_draft,omitempty"`
 	IncludeConsole      bool              `json:"include_console,omitempty"`
 	IncludeIntegrations bool              `json:"include_integrations,omitempty"`
+	IncludeCanvasYAML   bool              `json:"include_canvas_yaml,omitempty"`
 	ConsoleYAML         string            `json:"console_yaml,omitempty"`
 	PatchOperations     []PatchOperation  `json:"patch_operations,omitempty"`
 	AutoLayout          *AutoLayoutInput  `json:"auto_layout,omitempty"`
@@ -68,15 +69,17 @@ type AutoLayoutInput struct {
 }
 
 type readResult struct {
-	Action       string              `json:"action"`
-	CanvasID     string              `json:"canvas_id"`
-	Source       string              `json:"source"`
-	VersionID    string              `json:"version_id,omitempty"`
-	Draft        *draftResult        `json:"draft,omitempty"`
-	Summary      summary             `json:"summary"`
-	CanvasYAML   string              `json:"canvas_yaml"`
-	ConsoleYAML  string              `json:"console_yaml,omitempty"`
-	Integrations []integrationResult `json:"integrations,omitempty"`
+	Action            string              `json:"action"`
+	CanvasID          string              `json:"canvas_id"`
+	Source            string              `json:"source"`
+	VersionID         string              `json:"version_id,omitempty"`
+	Draft             *draftResult        `json:"draft,omitempty"`
+	Summary           summary             `json:"summary"`
+	CanvasYAML        string              `json:"canvas_yaml,omitempty"`
+	CanvasYAMLBytes   int                 `json:"canvas_yaml_bytes,omitempty"`
+	CanvasYAMLOmitted bool                `json:"canvas_yaml_omitted,omitempty"`
+	ConsoleYAML       string              `json:"console_yaml,omitempty"`
+	Integrations      []integrationResult `json:"integrations,omitempty"`
 }
 
 type updateResult struct {

--- a/pkg/agents/agent_tools/app_agent_tool.go
+++ b/pkg/agents/agent_tools/app_agent_tool.go
@@ -99,6 +99,10 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 				Type:        "boolean",
 				Description: "For read. Include console.yaml in the response.",
 			},
+			"include_canvas_yaml": {
+				Type:        "boolean",
+				Description: "For read. Defaults to false so read stays compact; set true only when you need the complete canvas.yaml text. Compact reads still return summary, version_id, canvas_yaml_bytes, and canvas_yaml_omitted.",
+			},
 			"include_integrations": {
 				Type:        "boolean",
 				Description: "For read. Include connected integration IDs, names, vendors, and state.",

--- a/pkg/agents/agent_tools/registry.go
+++ b/pkg/agents/agent_tools/registry.go
@@ -59,7 +59,7 @@ type toolCall struct {
 
 type factory func(Dependencies) tool
 
-const toolContractRevision = "agent-tools-v1.1"
+const toolContractRevision = "agent-tools-v1.1.1"
 
 var registeredTools = struct {
 	sync.RWMutex

--- a/pkg/agents/agent_tools/registry_test.go
+++ b/pkg/agents/agent_tools/registry_test.go
@@ -45,7 +45,7 @@ func TestSchemaRevision_IsStableForRegisteredDefinitions(t *testing.T) {
 	second := SchemaRevision()
 
 	assert.Equal(t, first, second)
-	assert.Contains(t, first, "agent-tools-v1.1:")
+	assert.Contains(t, first, "agent-tools-v1.1.1:")
 }
 
 func TestRegistryExecuteCustomTool_DispatchesByToolName(t *testing.T) {

--- a/pkg/agents/agent_tools/schema_test.go
+++ b/pkg/agents/agent_tools/schema_test.go
@@ -65,9 +65,11 @@ func TestAppAgentToolSchemaIncludesRuntimeReadAction(t *testing.T) {
 	assert.Contains(t, schema.Properties, "content")
 	assert.Contains(t, schema.Properties, "message")
 	assert.Contains(t, schema.Properties, "query")
+	assert.Contains(t, schema.Properties, "include_canvas_yaml")
 	assert.Contains(t, schema.Properties["path"].Description, "AGENTS.md")
 	assert.Contains(t, schema.Properties["content"].Description, "write_file")
 	assert.Contains(t, schema.Properties["message"].Description, "commit_files")
+	assert.Contains(t, schema.Properties["include_canvas_yaml"].Description, "Defaults to false")
 }
 
 func TestAppAgentToolSchemaUsesPatchDraftForDraftUpdates(t *testing.T) {

--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -28,7 +28,9 @@ Use `superplane_app` action `read_runtime` for memory, runs, event executions, n
 
 For Console edits, read with `superplane_app` `include_console: true`, then call `patch_draft` with `console_yaml`.
 
-Avoid re-reading the same draft repeatedly. Read it once with `superplane_app`, work from the returned YAML, and re-read only after an update.
+Keep `superplane_app` reads compact by default. A compact `read` returns summary, version metadata, `canvas_yaml_bytes`, and whether full `canvas_yaml` was omitted. Set `include_canvas_yaml: true` only when you need exact full canvas YAML for a targeted edit that cannot be derived from the summary, schema cache, or previous turn context.
+
+Avoid re-reading the same draft repeatedly. Read it once with `superplane_app`, work from the returned summary or explicitly requested YAML, and re-read only after an update.
 
 When reference files are still necessary, read each file at most once per turn. Never re-open `app-yaml-spec.md`, `canvas-yaml-spec.md`, or a component file after you already have the specific fields you need. Never read a mounted component file just to discover configuration fields or output channels that `superplane_component_schema` can return.
 
@@ -314,7 +316,7 @@ Read `/mnt/session/uploads/ref/skills/superplane-monitor/SKILL.md` for debugging
 4. **Use cached schemas** — by approval time you should already have the YAML/component fields from `superplane_component_schema`, researchers, or the quick reference. Do not read reference files again unless validation returns an unfamiliar field/channel error.
 5. **Build** — construct the canvas YAML, and the Console YAML when needed
 6. **Apply** — if `read` returned live/no `version_id`, call `superplane_app` action `create_draft`; then call `superplane_app` action `patch_draft` with `patch_operations` for graph edits and `console_yaml` for Console changes; graph patches auto-layout affected connected components by default
-7. **Verify** — after updates, read the same draft back with `superplane_app` action `read` and that `version_id`
+7. **Verify** — after updates, read the same draft back with compact `superplane_app` action `read` and that `version_id`; request full YAML only if validation details require it
 8. **Output** — :::draft-actions with version ID and summary using node chips
 
 Read `/mnt/session/uploads/ref/skills/superplane-app-builder/SKILL.md` for the complete workflow with positioning rules.
@@ -350,4 +352,4 @@ The rich-ui-widgets skill has the full syntax.
 
 - **ALWAYS** modify drafts only. Use `superplane_app` action `create_draft` when `read` returned live/no `version_id`, or when the user explicitly wants another draft branch. Use `superplane_app` action `patch_draft` with `patch_operations` for graph changes and `console_yaml` for Console changes, always passing the `version_id` returned by `read`, `create_draft`, or the previous `patch_draft`; the backend validates that it is your draft for this app. It never publishes.
 - After successful draft updates, output `:::draft-actions` with the version ID
-- After update, verify once with `superplane_app` action `read`
+- After update, verify once with compact `superplane_app` action `read`

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -580,7 +580,7 @@ func TestToolSchemaRevision_ReturnsStableRevision(t *testing.T) {
 	second := p.ToolSchemaRevision()
 
 	assert.Equal(t, first, second)
-	assert.Contains(t, first, "agent-tools-v1.1:")
+	assert.Contains(t, first, "agent-tools-v1.1.1:")
 }
 
 func TestStreamEvents_MapsKnownTypes(t *testing.T) {


### PR DESCRIPTION
## Summary
- make `superplane_app` read omit full `canvas_yaml` unless `include_canvas_yaml` is explicitly set
- return `canvas_yaml_bytes` and `canvas_yaml_omitted` metadata for compact reads
- update the managed-agent prompt and schema tests to prefer compact reads

## Tests
- make test PKG_TEST_PACKAGES='./pkg/agents/agent_tools/... ./pkg/agents/anthropic'
- make format.go
- make lint && make check.build.app