### PR TITLE
feat: expose runner logs to cli and agents

### DIFF
--- a/pkg/agents/agent_tools/actions/canvas_test.go
+++ b/pkg/agents/agent_tools/actions/canvas_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +16,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/agents"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	canvasyaml "github.com/superplanehq/superplane/pkg/canvas/yaml"
+	runneraction "github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/database"
 	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
@@ -23,6 +27,8 @@ import (
 	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/test/support"
 	"github.com/superplanehq/superplane/test/support/impl"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 func TestResolveToolAutoLayoutInput_DefaultsNodeIDsToConnectedComponent(t *testing.T) {
@@ -1081,6 +1087,93 @@ func TestReadRuntimeAction_RejectsUnknownResource(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported runtime resource")
+}
+
+func TestReadRuntimeAction_ReadsRunnerLogsByExecutionID(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/v1/tasks/task-agent-logs/live-logs", req.URL.Path)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"line","text":"agent log line"}` + "\n"))
+	}))
+	defer broker.Close()
+	t.Setenv("TASK_BROKER_BASE_URL", broker.URL)
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "live-log-secret")
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{
+		{
+			NodeID: "trigger-1",
+			Type:   models.NodeTypeTrigger,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Trigger: &models.TriggerRef{Name: "start"},
+			}),
+		},
+		{
+			NodeID: "runner-1",
+			Type:   models.NodeTypeComponent,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Component: &models.ComponentRef{Name: "runnerBash"},
+			}),
+		},
+	}, nil)
+	event := support.EmitCanvasEventForNode(t, canvas.ID, "trigger-1", "default", nil)
+
+	var run *models.CanvasRun
+	require.NoError(t, database.Conn().Transaction(func(tx *gorm.DB) error {
+		var err error
+		run, err = models.FindOrCreateCanvasRunForRootEventInTransaction(tx, event)
+		if err != nil {
+			return err
+		}
+		return event.RoutedInTransaction(tx)
+	}))
+
+	now := time.Now()
+	execution := models.CanvasNodeExecution{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      "runner-1",
+		RootEventID: event.ID,
+		RunID:       run.ID,
+		EventID:     event.ID,
+		State:       models.CanvasNodeExecutionStateStarted,
+		Metadata: datatypes.NewJSONType(map[string]any{
+			runneraction.ExecutionMetadataBrokerTaskID: "task-agent-logs",
+		}),
+		Configuration: datatypes.NewJSONType(map[string]any{}),
+		CreatedAt:     &now,
+		UpdatedAt:     &now,
+	}
+	require.NoError(t, database.Conn().Create(&execution).Error)
+
+	action := readRuntimeAction{
+		registry: r.Registry,
+		auth:     allowingPermissionChecker{},
+	}
+
+	result, err := action.Execute(context.Background(), agents.AgentSessionContext{
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Resource:    "runner_logs",
+		ExecutionID: execution.ID.String(),
+		Limit:       10,
+	})
+
+	require.NoError(t, err)
+	read, ok := result.(runtimeReadResult)
+	require.True(t, ok)
+	payload, ok := read.Payload.(runnerLogsPayload)
+	require.True(t, ok)
+	require.Len(t, payload.Logs, 1)
+	assert.Equal(t, execution.ID.String(), payload.Logs[0].ExecutionID)
+	assert.Equal(t, "runner-1", payload.Logs[0].NodeID)
+	assert.Equal(t, "task-agent-logs", payload.Logs[0].BrokerTaskID)
+	require.Len(t, payload.Logs[0].Records, 1)
+	assert.Equal(t, "agent log line", payload.Logs[0].Records[0].Text)
 }
 
 type allowingPermissionChecker struct{}

--- a/pkg/agents/agent_tools/actions/canvas_test.go
+++ b/pkg/agents/agent_tools/actions/canvas_test.go
@@ -1176,6 +1176,118 @@ func TestReadRuntimeAction_ReadsRunnerLogsByExecutionID(t *testing.T) {
 	assert.Equal(t, "agent log line", payload.Logs[0].Records[0].Text)
 }
 
+func TestReadRuntimeAction_ReadsRunnerLogsByRunIDWithMissingNodeExecution(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/v1/tasks/task-agent-logs/live-logs", req.URL.Path)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"line","text":"agent log line"}` + "\n"))
+	}))
+	defer broker.Close()
+	t.Setenv("TASK_BROKER_BASE_URL", broker.URL)
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "live-log-secret")
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{
+		{
+			NodeID: "trigger-1",
+			Type:   models.NodeTypeTrigger,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Trigger: &models.TriggerRef{Name: "start"},
+			}),
+		},
+		{
+			NodeID: "runner-1",
+			Type:   models.NodeTypeComponent,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Component: &models.ComponentRef{Name: "runnerBash"},
+			}),
+		},
+		{
+			NodeID: "missing-node",
+			Type:   models.NodeTypeComponent,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Component: &models.ComponentRef{Name: "runnerBash"},
+			}),
+		},
+	}, nil)
+	event := support.EmitCanvasEventForNode(t, canvas.ID, "trigger-1", "default", nil)
+
+	var run *models.CanvasRun
+	require.NoError(t, database.Conn().Transaction(func(tx *gorm.DB) error {
+		var err error
+		run, err = models.FindOrCreateCanvasRunForRootEventInTransaction(tx, event)
+		if err != nil {
+			return err
+		}
+		return event.RoutedInTransaction(tx)
+	}))
+
+	now := time.Now()
+	executions := []models.CanvasNodeExecution{
+		{
+			ID:            uuid.New(),
+			WorkflowID:    canvas.ID,
+			NodeID:        "missing-node",
+			RootEventID:   event.ID,
+			RunID:         run.ID,
+			EventID:       event.ID,
+			State:         models.CanvasNodeExecutionStateStarted,
+			Metadata:      datatypes.NewJSONType(map[string]any{}),
+			Configuration: datatypes.NewJSONType(map[string]any{}),
+			CreatedAt:     &now,
+			UpdatedAt:     &now,
+		},
+		{
+			ID:          uuid.New(),
+			WorkflowID:  canvas.ID,
+			NodeID:      "runner-1",
+			RootEventID: event.ID,
+			RunID:       run.ID,
+			EventID:     event.ID,
+			State:       models.CanvasNodeExecutionStateStarted,
+			Metadata: datatypes.NewJSONType(map[string]any{
+				runneraction.ExecutionMetadataBrokerTaskID: "task-agent-logs",
+			}),
+			Configuration: datatypes.NewJSONType(map[string]any{}),
+			CreatedAt:     &now,
+			UpdatedAt:     &now,
+		},
+	}
+	require.NoError(t, database.Conn().Create(&executions).Error)
+	require.NoError(t, database.Conn().
+		Where("workflow_id = ?", canvas.ID).
+		Where("node_id = ?", "missing-node").
+		Delete(&models.CanvasNode{}).
+		Error)
+
+	action := readRuntimeAction{
+		registry: r.Registry,
+		auth:     allowingPermissionChecker{},
+	}
+
+	result, err := action.Execute(context.Background(), agents.AgentSessionContext{
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Resource: "runner_logs",
+		RunID:    run.ID.String(),
+		Limit:    10,
+	})
+
+	require.NoError(t, err)
+	read, ok := result.(runtimeReadResult)
+	require.True(t, ok)
+	payload, ok := read.Payload.(runnerLogsPayload)
+	require.True(t, ok)
+	require.Len(t, payload.Logs, 1)
+	assert.Equal(t, executions[1].ID.String(), payload.Logs[0].ExecutionID)
+	assert.Equal(t, "runner-1", payload.Logs[0].NodeID)
+	assert.Equal(t, "agent log line", payload.Logs[0].Records[0].Text)
+}
+
 type allowingPermissionChecker struct{}
 
 func (allowingPermissionChecker) CheckOrganizationPermission(_ context.Context, _, _, _, _ string) (bool, error) {

--- a/pkg/agents/agent_tools/actions/read_runtime.go
+++ b/pkg/agents/agent_tools/actions/read_runtime.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -314,6 +315,9 @@ func findRunnerLogExecutionTarget(tx *gorm.DB, canvasID, executionID uuid.UUID) 
 func isRunnerLogExecutionTarget(tx *gorm.DB, canvasID uuid.UUID, nodeID string) (bool, error) {
 	node, err := models.FindCanvasNode(tx, canvasID, nodeID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
 		return false, fmt.Errorf("load node %q: %w", nodeID, err)
 	}
 	ref := node.Ref.Data()

--- a/pkg/agents/agent_tools/actions/read_runtime.go
+++ b/pkg/agents/agent_tools/actions/read_runtime.go
@@ -10,12 +10,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/agents"
+	runneraction "github.com/superplanehq/superplane/pkg/components/runner"
+	"github.com/superplanehq/superplane/pkg/database"
 	canvasactions "github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
+	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 const readRuntimeActionName = "read_runtime"
@@ -27,6 +31,29 @@ var runtimeResources = []string{
 	"node_executions",
 	"node_queue_items",
 	"node_events",
+	"runner_logs",
+}
+
+type runnerLogTarget struct {
+	ExecutionID uuid.UUID
+	NodeID      string
+	RunID       uuid.UUID
+}
+
+type runnerLogsPayload struct {
+	Count int                `json:"count"`
+	Logs  []runnerLogsResult `json:"logs"`
+}
+
+type runnerLogsResult struct {
+	ExecutionID  string                       `json:"execution_id"`
+	NodeID       string                       `json:"node_id,omitempty"`
+	RunID        string                       `json:"run_id,omitempty"`
+	BrokerTaskID string                       `json:"broker_task_id,omitempty"`
+	Count        int                          `json:"count"`
+	Truncated    bool                         `json:"truncated,omitempty"`
+	Records      []runneraction.LiveLogRecord `json:"records,omitempty"`
+	Error        string                       `json:"error,omitempty"`
 }
 
 type readRuntimeAction struct {
@@ -145,9 +172,177 @@ func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSession
 			return nil, fmt.Errorf("node_id is required for node_events")
 		}
 		return protoPayload(canvasactions.ListNodeEvents(ctx, a.registry, canvasID, input.NodeID, input.Limit, before))
+	case "runner_logs":
+		return a.readRunnerLogs(ctx, session, canvasID, input)
 	default:
 		return nil, fmt.Errorf("unsupported runtime resource %q", resource)
 	}
+}
+
+func (a readRuntimeAction) readRunnerLogs(ctx context.Context, session agents.AgentSessionContext, canvasID uuid.UUID, input Input) (any, error) {
+	organizationID, err := uuid.Parse(session.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid session organization id: %w", err)
+	}
+
+	targets, err := resolveRunnerLogTargets(database.DB(ctx), canvasID, input)
+	if err != nil {
+		return nil, err
+	}
+
+	logs := make([]runnerLogsResult, 0, len(targets))
+	for _, target := range targets {
+		log, err := fetchRunnerLogsForTarget(ctx, organizationID, canvasID, target, int(input.Limit))
+		if err != nil && len(targets) == 1 {
+			return nil, err
+		}
+		if err != nil {
+			log.Error = err.Error()
+		}
+		logs = append(logs, log)
+	}
+
+	return runnerLogsPayload{
+		Count: len(logs),
+		Logs:  logs,
+	}, nil
+}
+
+func resolveRunnerLogTargets(tx *gorm.DB, canvasID uuid.UUID, input Input) ([]runnerLogTarget, error) {
+	if strings.TrimSpace(input.ExecutionID) != "" {
+		return resolveRunnerLogExecutionTarget(tx, canvasID, input.ExecutionID)
+	}
+
+	if strings.TrimSpace(input.RunID) != "" {
+		return resolveRunnerLogRunTargets(tx, canvasID, input.RunID, input.NodeID)
+	}
+
+	if strings.TrimSpace(input.NodeID) != "" {
+		return resolveLatestRunnerLogNodeTarget(tx, canvasID, input.NodeID)
+	}
+
+	return nil, fmt.Errorf("execution_id, run_id, or node_id is required for runner_logs")
+}
+
+func resolveRunnerLogExecutionTarget(tx *gorm.DB, canvasID uuid.UUID, rawExecutionID string) ([]runnerLogTarget, error) {
+	executionID, err := uuid.Parse(strings.TrimSpace(rawExecutionID))
+	if err != nil {
+		return nil, fmt.Errorf("invalid execution_id: %w", err)
+	}
+
+	execution, err := findRunnerLogExecutionTarget(tx, canvasID, executionID)
+	if err != nil {
+		return nil, fmt.Errorf("load execution: %w", err)
+	}
+
+	return []runnerLogTarget{{
+		ExecutionID: execution.ID,
+		NodeID:      execution.NodeID,
+		RunID:       execution.RunID,
+	}}, nil
+}
+
+func resolveRunnerLogRunTargets(tx *gorm.DB, canvasID uuid.UUID, rawRunID, nodeID string) ([]runnerLogTarget, error) {
+	runID, err := uuid.Parse(strings.TrimSpace(rawRunID))
+	if err != nil {
+		return nil, fmt.Errorf("invalid run_id: %w", err)
+	}
+
+	if _, err := models.FindCanvasRunInTransaction(tx, canvasID, runID); err != nil {
+		return nil, fmt.Errorf("load run: %w", err)
+	}
+
+	executions, err := models.ListExecutionsForRunsInTransaction(tx, canvasID, []uuid.UUID{runID})
+	if err != nil {
+		return nil, fmt.Errorf("list run executions: %w", err)
+	}
+
+	targets := make([]runnerLogTarget, 0, len(executions))
+	for _, execution := range executions {
+		if strings.TrimSpace(nodeID) != "" && execution.NodeID != nodeID {
+			continue
+		}
+		targets = append(targets, runnerLogTarget{
+			ExecutionID: execution.ID,
+			NodeID:      execution.NodeID,
+			RunID:       execution.RunID,
+		})
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no executions found for runner_logs target")
+	}
+	return targets, nil
+}
+
+func resolveLatestRunnerLogNodeTarget(tx *gorm.DB, canvasID uuid.UUID, nodeID string) ([]runnerLogTarget, error) {
+	executions, err := listLatestRunnerLogNodeExecutions(tx, canvasID, nodeID)
+	if err != nil {
+		return nil, fmt.Errorf("list node executions: %w", err)
+	}
+	if len(executions) == 0 {
+		return nil, fmt.Errorf("no executions found for node_id %q", nodeID)
+	}
+
+	execution := executions[0]
+	return []runnerLogTarget{{
+		ExecutionID: execution.ID,
+		NodeID:      execution.NodeID,
+		RunID:       execution.RunID,
+	}}, nil
+}
+
+func findRunnerLogExecutionTarget(tx *gorm.DB, canvasID, executionID uuid.UUID) (*models.CanvasNodeExecution, error) {
+	var execution models.CanvasNodeExecution
+	err := tx.
+		Where("workflow_id = ?", canvasID).
+		Where("id = ?", executionID).
+		First(&execution).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	return &execution, nil
+}
+
+func listLatestRunnerLogNodeExecutions(tx *gorm.DB, canvasID uuid.UUID, nodeID string) ([]models.CanvasNodeExecution, error) {
+	var executions []models.CanvasNodeExecution
+	err := tx.
+		Where("workflow_id = ?", canvasID).
+		Where("node_id = ?", nodeID).
+		Order("created_at DESC").
+		Limit(1).
+		Find(&executions).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	return executions, nil
+}
+
+func fetchRunnerLogsForTarget(ctx context.Context, organizationID, canvasID uuid.UUID, target runnerLogTarget, limit int) (runnerLogsResult, error) {
+	result := runnerLogsResult{
+		ExecutionID: target.ExecutionID.String(),
+		NodeID:      target.NodeID,
+	}
+	if target.RunID != uuid.Nil {
+		result.RunID = target.RunID.String()
+	}
+
+	access, err := runneraction.ResolveLiveLogAccess(organizationID, canvasID, target.ExecutionID)
+	if err != nil {
+		return result, err
+	}
+
+	fetch, err := runneraction.FetchLiveLogRecords(ctx, access.BrokerTaskID, runneraction.LiveLogFetchOptions{Limit: limit})
+	if err != nil {
+		return result, err
+	}
+
+	result.BrokerTaskID = access.BrokerTaskID
+	result.Records = fetch.Records
+	result.Count = len(fetch.Records)
+	result.Truncated = fetch.Truncated
+	return result, nil
 }
 
 func filterMemoryResponse(response *pb.ListCanvasMemoriesResponse, namespace string) (any, error) {

--- a/pkg/agents/agent_tools/actions/read_runtime.go
+++ b/pkg/agents/agent_tools/actions/read_runtime.go
@@ -262,6 +262,13 @@ func resolveRunnerLogRunTargets(tx *gorm.DB, canvasID uuid.UUID, rawRunID, nodeI
 		if strings.TrimSpace(nodeID) != "" && execution.NodeID != nodeID {
 			continue
 		}
+		isRunner, err := isRunnerLogExecutionTarget(tx, canvasID, execution.NodeID)
+		if err != nil {
+			return nil, err
+		}
+		if !isRunner {
+			continue
+		}
 		targets = append(targets, runnerLogTarget{
 			ExecutionID: execution.ID,
 			NodeID:      execution.NodeID,
@@ -269,7 +276,7 @@ func resolveRunnerLogRunTargets(tx *gorm.DB, canvasID uuid.UUID, rawRunID, nodeI
 		})
 	}
 	if len(targets) == 0 {
-		return nil, fmt.Errorf("no executions found for runner_logs target")
+		return nil, fmt.Errorf("no runner executions found for runner_logs target")
 	}
 	return targets, nil
 }
@@ -302,6 +309,18 @@ func findRunnerLogExecutionTarget(tx *gorm.DB, canvasID, executionID uuid.UUID) 
 		return nil, err
 	}
 	return &execution, nil
+}
+
+func isRunnerLogExecutionTarget(tx *gorm.DB, canvasID uuid.UUID, nodeID string) (bool, error) {
+	node, err := models.FindCanvasNode(tx, canvasID, nodeID)
+	if err != nil {
+		return false, fmt.Errorf("load node %q: %w", nodeID, err)
+	}
+	ref := node.Ref.Data()
+	if ref.Component == nil {
+		return false, nil
+	}
+	return runneraction.IsRunnerComponent(ref.Component.Name), nil
 }
 
 func listLatestRunnerLogNodeExecutions(tx *gorm.DB, canvasID uuid.UUID, nodeID string) ([]models.CanvasNodeExecution, error) {

--- a/pkg/agents/agent_tools/actions/types.go
+++ b/pkg/agents/agent_tools/actions/types.go
@@ -21,6 +21,7 @@ type Input struct {
 	NodeID              string            `json:"node_id,omitempty"`
 	EventID             string            `json:"event_id,omitempty"`
 	ExecutionID         string            `json:"execution_id,omitempty"`
+	RunID               string            `json:"run_id,omitempty"`
 	Limit               uint32            `json:"limit,omitempty"`
 	Before              string            `json:"before,omitempty"`
 	States              []string          `json:"states,omitempty"`

--- a/pkg/agents/agent_tools/app_agent_tool.go
+++ b/pkg/agents/agent_tools/app_agent_tool.go
@@ -157,8 +157,8 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 			},
 			"resource": {
 				Type:        "string",
-				Enum:        []string{"memory", "runs", "event_executions", "node_executions", "node_queue_items", "node_events"},
-				Description: "For read_runtime. Defaults to memory. Selects the canvas-scoped runtime data to read.",
+				Enum:        []string{"memory", "runs", "event_executions", "node_executions", "node_queue_items", "node_events", "runner_logs"},
+				Description: "For read_runtime. Defaults to memory. Selects the canvas-scoped runtime data to read. Use runner_logs to fetch bounded logs for a runner execution, run, or latest node execution.",
 			},
 			"namespace": {
 				Type:        "string",
@@ -174,11 +174,15 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 			},
 			"execution_id": {
 				Type:        "string",
-				Description: "Reserved for future runtime resources that target a specific execution.",
+				Description: "For read_runtime resource runner_logs. Fetch logs for a specific node execution.",
+			},
+			"run_id": {
+				Type:        "string",
+				Description: "For read_runtime resource runner_logs. Fetch logs for runner executions in a run; combine with node_id to target one node in that run.",
 			},
 			"limit": {
 				Type:        "integer",
-				Description: "For read_runtime paginated resources and list_resources. Backend defaults apply when omitted; list_resources caps results to keep responses concise.",
+				Description: "For read_runtime paginated resources, runner_logs, and list_resources. Backend defaults apply when omitted; list_resources and runner_logs cap results to keep responses concise.",
 			},
 			"before": {
 				Type:        "string",

--- a/pkg/agents/agent_tools/schema_test.go
+++ b/pkg/agents/agent_tools/schema_test.go
@@ -55,11 +55,13 @@ func TestAppAgentToolSchemaIncludesRuntimeReadAction(t *testing.T) {
 		"node_executions",
 		"node_queue_items",
 		"node_events",
+		"runner_logs",
 	}, resourceSchema.Enum)
 	assert.Contains(t, schema.Properties, "namespace")
 	assert.Contains(t, schema.Properties, "node_id")
 	assert.Contains(t, schema.Properties, "event_id")
 	assert.Contains(t, schema.Properties, "execution_id")
+	assert.Contains(t, schema.Properties, "run_id")
 	assert.Contains(t, schema.Properties, "path")
 	assert.Contains(t, schema.Properties, "paths")
 	assert.Contains(t, schema.Properties, "content")
@@ -68,6 +70,7 @@ func TestAppAgentToolSchemaIncludesRuntimeReadAction(t *testing.T) {
 	assert.Contains(t, schema.Properties["path"].Description, "AGENTS.md")
 	assert.Contains(t, schema.Properties["content"].Description, "write_file")
 	assert.Contains(t, schema.Properties["message"].Description, "commit_files")
+	assert.Contains(t, schema.Properties["run_id"].Description, "runner_logs")
 }
 
 func TestAppAgentToolSchemaUsesPatchDraftForDraftUpdates(t *testing.T) {

--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -24,7 +24,7 @@ When building or modifying apps:
 
 Use `superplane_app` action `access` when you need to know what the current session can do. It reports the intersection of the session's permissions and the backend authorization interceptor, including which canvas-scoped actions are allowed for the current app. Do this when a permission boundary is unclear before attempting an operation.
 
-Use `superplane_app` action `read_runtime` for memory, runs, event executions, node executions, node queue items, and node events. Use it for all runtime inspection.
+Use `superplane_app` action `read_runtime` for memory, runs, event executions, node executions, node queue items, node events, and runner logs. Use `resource: "runner_logs"` with `execution_id`, `run_id`, or `node_id` when debugging Runner components.
 
 For Console edits, read with `superplane_app` `include_console: true`, then call `patch_draft` with `console_yaml`.
 

--- a/pkg/agents/constants.go
+++ b/pkg/agents/constants.go
@@ -53,9 +53,9 @@ const preambleTemplate = "[SuperPlane session context — refreshed every turn; 
 	"SuperPlane has no separate `events` permission. The canvases:read\n" +
 	"permission grants every read scoped to this app: describe the app,\n" +
 	"read Console panels and layout, and list app events, event\n" +
-	"executions, runs, node events, and node executions. Use\n" +
+	"executions, runs, node events, node executions, and runner logs. Use\n" +
 	"`superplane_app` action `read` for the app YAML and action\n" +
-	"`read_runtime` for memory, runs, executions, and queues.\n" +
+	"`read_runtime` for memory, runs, executions, queues, and runner logs.\n" +
 	"If a read returns empty or not-found, the cause is not a missing\n" +
 	"permission — it is the wrong canvas_id, the wrong resource, or data\n" +
 	"that does not exist yet."
@@ -95,7 +95,7 @@ Rules:
 - You can update the app Console when the task asks for status views, runbooks, tables, charts, or KPI panels. Read it with 'superplane_app' include_console and save it with action 'patch_draft' using console_yaml.
 - You can configure integration references and set up expressions. Secrets are managed by the user; reference them in YAML and ask the user to create any that do not exist.
 - For direct app edits, prefer the shortest reliable path: use 'superplane_app' action 'read' to read the draft app once, list integrations only if integration IDs are needed, make the draft update, then report the result.
-- Use the 'superplane_app' custom tool for canvas reads, runtime reads, draft updates, and connected integration lists. Use action 'read_runtime' for memory, runs, event executions, node executions, node queue items, and node events. It returns the current YAML plus version metadata in one call. patch_draft auto-layouts affected connected components by default. Pass auto_layout only when you need full_canvas, custom connected_component node_ids, or a layout-only update.
+- Use the 'superplane_app' custom tool for canvas reads, runtime reads, draft updates, and connected integration lists. Use action 'read_runtime' for memory, runs, event executions, node executions, node queue items, node events, and runner logs. patch_draft auto-layouts affected connected components by default. Pass auto_layout only when you need full_canvas, custom connected_component node_ids, or a layout-only update.
 - When reading an app for build work, read it once with 'superplane_app' action 'read' and work from the returned YAML. Re-read only after you update the draft.
 - When editing the Console, work from the Console YAML already returned by 'superplane_app' (include_console). Read ref/docs/prd/console-and-widgets.md only if the task needs widget details you do not already know.
 - The tools return everything you need in one call; do not fan out repeated discovery commands. Read once, then work from the returned data.
@@ -113,7 +113,7 @@ You are in Ask mode. Your job is to help the user understand and monitor their a
 Rules:
 - NEVER modify the app. No creates, no updates, no deletes.
 - Use 'superplane_app' action 'access' when a permission boundary is unclear before attempting an operation.
-- You CAN read app state, list memory, list runs, inspect events/executions/queues, check node status, and explain how things work. Use 'superplane_app' action 'read_runtime' for these runtime reads.
+- You CAN read app state, list memory, list runs, inspect events/executions/queues, check node status, fetch runner logs, and explain how things work. Use 'superplane_app' action 'read_runtime' for these runtime reads.
 - When the user asks about a failure, trace through the run execution path and identify the root cause.
 - If the user explicitly asks you to make a change, let them know you can't do that in Ask mode and they need to switch to Build mode.
 - Use charts, tables, and mermaid diagrams to visualize run data and app topology when helpful.

--- a/pkg/cli/commands/executions/logs.go
+++ b/pkg/cli/commands/executions/logs.go
@@ -15,8 +15,6 @@ import (
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
-const runnerLiveLogSessionEndpoint = "RunnerLiveLogSession"
-
 type LogsCommand struct {
 	CanvasID    *string
 	ExecutionID *string
@@ -208,7 +206,7 @@ func (c *LogsCommand) fetchLiveLogSession(ctx core.CommandContext, canvasID, exe
 		return nil, fmt.Errorf("api client config is required")
 	}
 
-	baseURL, err := config.ServerURLWithContext(ctx.Context, runnerLiveLogSessionEndpoint)
+	baseURL, err := config.ServerURLWithContext(ctx.Context, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/commands/executions/logs.go
+++ b/pkg/cli/commands/executions/logs.go
@@ -1,0 +1,300 @@
+package executions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+type LogsCommand struct {
+	CanvasID    *string
+	ExecutionID *string
+	RunID       *string
+	NodeID      *string
+	Limit       *int64
+}
+
+type runnerLogRecord struct {
+	Type       string `json:"type,omitempty"`
+	Text       string `json:"text,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Index      *int   `json:"index,omitempty"`
+	Status     string `json:"status,omitempty"`
+	DurationMS *int64 `json:"duration_ms,omitempty"`
+	StartedAt  *int64 `json:"started_at,omitempty"`
+}
+
+type runnerLogsResponse struct {
+	CanvasID     string            `json:"canvas_id"`
+	ExecutionID  string            `json:"execution_id"`
+	BrokerTaskID string            `json:"broker_task_id"`
+	Count        int               `json:"count"`
+	Truncated    bool              `json:"truncated,omitempty"`
+	Records      []runnerLogRecord `json:"records"`
+}
+
+type runnerLogTarget struct {
+	ExecutionID string
+	NodeID      string
+}
+
+type runnerLogOutput struct {
+	CanvasID     string            `json:"canvas_id"`
+	ExecutionID  string            `json:"execution_id"`
+	NodeID       string            `json:"node_id,omitempty"`
+	BrokerTaskID string            `json:"broker_task_id,omitempty"`
+	Count        int               `json:"count"`
+	Truncated    bool              `json:"truncated,omitempty"`
+	Records      []runnerLogRecord `json:"records,omitempty"`
+	Error        string            `json:"error,omitempty"`
+}
+
+func (c *LogsCommand) Execute(ctx core.CommandContext) error {
+	canvasID, err := core.ResolveAppID(ctx, *c.CanvasID)
+	if err != nil {
+		return err
+	}
+
+	targets, err := c.resolveTargets(ctx, canvasID)
+	if err != nil {
+		return err
+	}
+
+	outputs := make([]runnerLogOutput, 0, len(targets))
+	for _, target := range targets {
+		outputs = append(outputs, c.fetchTargetLogs(ctx, canvasID, target))
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(outputs)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		return renderRunnerLogsText(stdout, outputs)
+	})
+}
+
+func (c *LogsCommand) resolveTargets(ctx core.CommandContext, canvasID string) ([]runnerLogTarget, error) {
+	if strings.TrimSpace(*c.ExecutionID) != "" {
+		return []runnerLogTarget{{ExecutionID: strings.TrimSpace(*c.ExecutionID)}}, nil
+	}
+
+	if strings.TrimSpace(*c.RunID) != "" {
+		return c.resolveRunTargets(ctx, canvasID)
+	}
+
+	if strings.TrimSpace(*c.NodeID) != "" {
+		return c.resolveLatestNodeTarget(ctx, canvasID)
+	}
+
+	return nil, fmt.Errorf("one of --execution-id, --run-id, or --node-id is required")
+}
+
+func (c *LogsCommand) resolveRunTargets(ctx core.CommandContext, canvasID string) ([]runnerLogTarget, error) {
+	response, _, err := ctx.API.CanvasRunAPI.
+		CanvasesDescribeRun(ctx.Context, canvasID, strings.TrimSpace(*c.RunID)).
+		Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	run := response.GetRun()
+	executions := run.GetExecutions()
+	targets := make([]runnerLogTarget, 0, len(executions))
+	for _, execution := range executions {
+		if strings.TrimSpace(*c.NodeID) != "" && execution.GetNodeId() != strings.TrimSpace(*c.NodeID) {
+			continue
+		}
+		targets = append(targets, runnerLogTarget{
+			ExecutionID: execution.GetId(),
+			NodeID:      execution.GetNodeId(),
+		})
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no executions found for log target")
+	}
+	return targets, nil
+}
+
+func (c *LogsCommand) resolveLatestNodeTarget(ctx core.CommandContext, canvasID string) ([]runnerLogTarget, error) {
+	response, _, err := ctx.API.CanvasNodeAPI.
+		CanvasesListNodeExecutions(ctx.Context, canvasID, strings.TrimSpace(*c.NodeID)).
+		Limit(1).
+		Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	executions := response.GetExecutions()
+	if len(executions) == 0 {
+		return nil, fmt.Errorf("no executions found for node %q", strings.TrimSpace(*c.NodeID))
+	}
+
+	execution := executions[0]
+	return []runnerLogTarget{{
+		ExecutionID: execution.GetId(),
+		NodeID:      execution.GetNodeId(),
+	}}, nil
+}
+
+func (c *LogsCommand) fetchTargetLogs(ctx core.CommandContext, canvasID string, target runnerLogTarget) runnerLogOutput {
+	output := runnerLogOutput{
+		CanvasID:    canvasID,
+		ExecutionID: target.ExecutionID,
+		NodeID:      target.NodeID,
+	}
+
+	response, err := c.fetchExecutionLogs(ctx, canvasID, target.ExecutionID)
+	if err != nil {
+		output.Error = err.Error()
+		return output
+	}
+
+	output.BrokerTaskID = response.BrokerTaskID
+	output.Count = response.Count
+	output.Truncated = response.Truncated
+	output.Records = response.Records
+	return output
+}
+
+func (c *LogsCommand) fetchExecutionLogs(ctx core.CommandContext, canvasID, executionID string) (*runnerLogsResponse, error) {
+	config := ctx.API.GetConfig()
+	if config == nil {
+		return nil, fmt.Errorf("api client config is required")
+	}
+
+	baseURL, err := config.ServerURLWithContext(ctx.Context, "CanvasNodeExecutionAPIService.CanvasesCancelExecution")
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, fmt.Errorf("api_url is required")
+	}
+
+	endpoint := fmt.Sprintf(
+		"%s/api/v1/canvases/%s/node-executions/%s/runner-live-logs?limit=%d",
+		strings.TrimRight(baseURL, "/"),
+		url.PathEscape(canvasID),
+		url.PathEscape(executionID),
+		normalizedLogLimit(c.Limit),
+	)
+
+	request, err := http.NewRequestWithContext(ctx.Context, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/json")
+	if authorization := strings.TrimSpace(config.DefaultHeader["Authorization"]); authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+
+	response, err := logHTTPClient(config).Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode >= http.StatusMultipleChoices {
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = response.Status
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+
+	var payload runnerLogsResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	return &payload, nil
+}
+
+func normalizedLogLimit(limit *int64) int64 {
+	if limit == nil || *limit <= 0 {
+		return 200
+	}
+	return *limit
+}
+
+func logHTTPClient(config *openapi_client.Configuration) *http.Client {
+	if config.HTTPClient != nil {
+		return config.HTTPClient
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func renderRunnerLogsText(stdout io.Writer, outputs []runnerLogOutput) error {
+	for i, output := range outputs {
+		if i > 0 {
+			_, _ = fmt.Fprintln(stdout)
+		}
+		if err := renderRunnerLogHeader(stdout, output); err != nil {
+			return err
+		}
+		if output.Error != "" {
+			_, err := fmt.Fprintf(stdout, "Error: %s\n", output.Error)
+			return err
+		}
+		for _, record := range output.Records {
+			if err := renderRunnerLogRecord(stdout, record); err != nil {
+				return err
+			}
+		}
+		if output.Truncated {
+			_, err := fmt.Fprintln(stdout, "... truncated")
+			return err
+		}
+	}
+	return nil
+}
+
+func renderRunnerLogHeader(stdout io.Writer, output runnerLogOutput) error {
+	writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+	_, _ = fmt.Fprintf(writer, "Execution\t%s\n", output.ExecutionID)
+	if output.NodeID != "" {
+		_, _ = fmt.Fprintf(writer, "Node\t%s\n", output.NodeID)
+	}
+	if output.BrokerTaskID != "" {
+		_, _ = fmt.Fprintf(writer, "Broker task\t%s\n", output.BrokerTaskID)
+	}
+	_, _ = fmt.Fprintln(writer, "Logs")
+	return writer.Flush()
+}
+
+func renderRunnerLogRecord(stdout io.Writer, record runnerLogRecord) error {
+	switch record.Type {
+	case "line":
+		_, err := fmt.Fprintln(stdout, record.Text)
+		return err
+	case "error":
+		_, err := fmt.Fprintf(stdout, "ERROR: %s\n", record.Message)
+		return err
+	case "cmd_start":
+		_, err := fmt.Fprintf(stdout, "$ %s\n", record.Text)
+		return err
+	case "cmd_end":
+		_, err := fmt.Fprintf(stdout, "# command %s (%dms)\n", record.Status, int64Value(record.DurationMS))
+		return err
+	default:
+		return nil
+	}
+}
+
+func int64Value(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}

--- a/pkg/cli/commands/executions/logs.go
+++ b/pkg/cli/commands/executions/logs.go
@@ -95,20 +95,55 @@ func (c *LogsCommand) resolveRunTargets(ctx core.CommandContext, canvasID string
 	}
 
 	executions := run.GetExecutions()
+	runnerNodes, err := c.runnerNodeIDs(ctx, canvasID)
+	if err != nil {
+		return nil, err
+	}
+
 	targets := make([]runnerLogTarget, 0, len(executions))
 	for _, execution := range executions {
-		if strings.TrimSpace(*c.NodeID) != "" && execution.GetNodeId() != strings.TrimSpace(*c.NodeID) {
+		nodeID := execution.GetNodeId()
+		if strings.TrimSpace(*c.NodeID) != "" && nodeID != strings.TrimSpace(*c.NodeID) {
+			continue
+		}
+		if !runnerNodes[nodeID] {
 			continue
 		}
 		targets = append(targets, runnerLogTarget{
 			ExecutionID: execution.GetId(),
-			NodeID:      execution.GetNodeId(),
+			NodeID:      nodeID,
 		})
 	}
 	if len(targets) == 0 {
-		return nil, fmt.Errorf("no executions found for log target")
+		return nil, fmt.Errorf("no runner executions found for log target")
 	}
 	return targets, nil
+}
+
+func (c *LogsCommand) runnerNodeIDs(ctx core.CommandContext, canvasID string) (map[string]bool, error) {
+	response, _, err := ctx.API.CanvasAPI.
+		CanvasesDescribeCanvas(ctx.Context, canvasID).
+		Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	canvas, ok := response.GetCanvasOk()
+	if !ok || canvas == nil {
+		return nil, fmt.Errorf("canvas %q not found", canvasID)
+	}
+
+	spec := canvas.GetSpec()
+	nodes := spec.GetNodes()
+	ids := make(map[string]bool, len(nodes))
+	for _, node := range nodes {
+		id := strings.TrimSpace(node.GetId())
+		if id == "" || !runneraction.IsRunnerComponent(node.GetComponent()) {
+			continue
+		}
+		ids[id] = true
+	}
+	return ids, nil
 }
 
 func (c *LogsCommand) resolveLatestNodeTarget(ctx core.CommandContext, canvasID string) ([]runnerLogTarget, error) {
@@ -252,8 +287,10 @@ func renderRunnerLogsText(stdout io.Writer, outputs []runnerLogOutput) error {
 			return err
 		}
 		if output.Error != "" {
-			_, err := fmt.Fprintf(stdout, "Error: %s\n", output.Error)
-			return err
+			if _, err := fmt.Fprintf(stdout, "Error: %s\n", output.Error); err != nil {
+				return err
+			}
+			continue
 		}
 		for _, record := range output.Records {
 			if err := renderRunnerLogRecord(stdout, record); err != nil {
@@ -261,8 +298,9 @@ func renderRunnerLogsText(stdout io.Writer, outputs []runnerLogOutput) error {
 			}
 		}
 		if output.Truncated {
-			_, err := fmt.Fprintln(stdout, "... truncated")
-			return err
+			if _, err := fmt.Fprintln(stdout, "... truncated"); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/cli/commands/executions/logs.go
+++ b/pkg/cli/commands/executions/logs.go
@@ -11,8 +11,11 @@ import (
 	"time"
 
 	"github.com/superplanehq/superplane/pkg/cli/core"
+	runneraction "github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
+
+const runnerLiveLogSessionEndpoint = "RunnerLiveLogSession"
 
 type LogsCommand struct {
 	CanvasID    *string
@@ -22,39 +25,19 @@ type LogsCommand struct {
 	Limit       *int64
 }
 
-type runnerLogRecord struct {
-	Type       string `json:"type,omitempty"`
-	Text       string `json:"text,omitempty"`
-	Message    string `json:"message,omitempty"`
-	Index      *int   `json:"index,omitempty"`
-	Status     string `json:"status,omitempty"`
-	DurationMS *int64 `json:"duration_ms,omitempty"`
-	StartedAt  *int64 `json:"started_at,omitempty"`
-}
-
-type runnerLogsResponse struct {
-	CanvasID     string            `json:"canvas_id"`
-	ExecutionID  string            `json:"execution_id"`
-	BrokerTaskID string            `json:"broker_task_id"`
-	Count        int               `json:"count"`
-	Truncated    bool              `json:"truncated,omitempty"`
-	Records      []runnerLogRecord `json:"records"`
-}
-
 type runnerLogTarget struct {
 	ExecutionID string
 	NodeID      string
 }
 
 type runnerLogOutput struct {
-	CanvasID     string            `json:"canvas_id"`
-	ExecutionID  string            `json:"execution_id"`
-	NodeID       string            `json:"node_id,omitempty"`
-	BrokerTaskID string            `json:"broker_task_id,omitempty"`
-	Count        int               `json:"count"`
-	Truncated    bool              `json:"truncated,omitempty"`
-	Records      []runnerLogRecord `json:"records,omitempty"`
-	Error        string            `json:"error,omitempty"`
+	CanvasID    string                       `json:"canvas_id"`
+	ExecutionID string                       `json:"execution_id"`
+	NodeID      string                       `json:"node_id,omitempty"`
+	Count       int                          `json:"count"`
+	Truncated   bool                         `json:"truncated,omitempty"`
+	Records     []runneraction.LiveLogRecord `json:"records,omitempty"`
+	Error       string                       `json:"error,omitempty"`
 }
 
 func (c *LogsCommand) Execute(ctx core.CommandContext) error {
@@ -106,7 +89,11 @@ func (c *LogsCommand) resolveRunTargets(ctx core.CommandContext, canvasID string
 		return nil, err
 	}
 
-	run := response.GetRun()
+	run, ok := response.GetRunOk()
+	if !ok || run == nil {
+		return nil, fmt.Errorf("run %q not found", strings.TrimSpace(*c.RunID))
+	}
+
 	executions := run.GetExecutions()
 	targets := make([]runnerLogTarget, 0, len(executions))
 	for _, execution := range executions {
@@ -152,26 +139,41 @@ func (c *LogsCommand) fetchTargetLogs(ctx core.CommandContext, canvasID string, 
 		NodeID:      target.NodeID,
 	}
 
-	response, err := c.fetchExecutionLogs(ctx, canvasID, target.ExecutionID)
+	records, err := c.fetchExecutionLogs(ctx, canvasID, target.ExecutionID)
 	if err != nil {
 		output.Error = err.Error()
 		return output
 	}
 
-	output.BrokerTaskID = response.BrokerTaskID
-	output.Count = response.Count
-	output.Truncated = response.Truncated
-	output.Records = response.Records
+	output.Count = len(records.Records)
+	output.Truncated = records.Truncated
+	output.Records = records.Records
 	return output
 }
 
-func (c *LogsCommand) fetchExecutionLogs(ctx core.CommandContext, canvasID, executionID string) (*runnerLogsResponse, error) {
+func (c *LogsCommand) fetchExecutionLogs(ctx core.CommandContext, canvasID, executionID string) (*runneraction.LiveLogFetchResult, error) {
+	session, err := c.fetchLiveLogSession(ctx, canvasID, executionID)
+	if err != nil {
+		return nil, err
+	}
+
+	records, err := runneraction.FetchLiveLogSessionRecords(ctx.Context, *session, runneraction.LiveLogFetchOptions{
+		Limit:      normalizedLogLimit(c.Limit),
+		HTTPClient: logHTTPClient(ctx.API.GetConfig()),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch runner logs for execution %s: %w", executionID, err)
+	}
+	return records, nil
+}
+
+func (c *LogsCommand) fetchLiveLogSession(ctx core.CommandContext, canvasID, executionID string) (*runneraction.LiveLogSession, error) {
 	config := ctx.API.GetConfig()
 	if config == nil {
 		return nil, fmt.Errorf("api client config is required")
 	}
 
-	baseURL, err := config.ServerURLWithContext(ctx.Context, "CanvasNodeExecutionAPIService.CanvasesCancelExecution")
+	baseURL, err := config.ServerURLWithContext(ctx.Context, runnerLiveLogSessionEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -180,11 +182,10 @@ func (c *LogsCommand) fetchExecutionLogs(ctx core.CommandContext, canvasID, exec
 	}
 
 	endpoint := fmt.Sprintf(
-		"%s/api/v1/canvases/%s/node-executions/%s/runner-live-logs?limit=%d",
+		"%s/api/v1/canvases/%s/node-executions/%s/runner-live-logs/session",
 		strings.TrimRight(baseURL, "/"),
 		url.PathEscape(canvasID),
 		url.PathEscape(executionID),
-		normalizedLogLimit(c.Limit),
 	)
 
 	request, err := http.NewRequestWithContext(ctx.Context, http.MethodGet, endpoint, nil)
@@ -207,29 +208,36 @@ func (c *LogsCommand) fetchExecutionLogs(ctx core.CommandContext, canvasID, exec
 		return nil, err
 	}
 	if response.StatusCode >= http.StatusMultipleChoices {
-		message := strings.TrimSpace(string(body))
-		if message == "" {
-			message = response.Status
-		}
-		return nil, fmt.Errorf("%s", message)
+		return nil, fmt.Errorf("create runner log session for execution %s: %s", executionID, responseErrorMessage(response.Status, body))
 	}
 
-	var payload runnerLogsResponse
-	if err := json.Unmarshal(body, &payload); err != nil {
+	var session runneraction.LiveLogSession
+	if err := json.Unmarshal(body, &session); err != nil {
 		return nil, err
 	}
-	return &payload, nil
+	return &session, nil
 }
 
-func normalizedLogLimit(limit *int64) int64 {
-	if limit == nil || *limit <= 0 {
-		return 200
+func responseErrorMessage(status string, body []byte) string {
+	message := strings.TrimSpace(string(body))
+	if message != "" {
+		return message
 	}
-	return *limit
+	return status
+}
+
+func normalizedLogLimit(limit *int64) int {
+	if limit == nil || *limit <= 0 {
+		return runneraction.DefaultLiveLogRecordLimit
+	}
+	if *limit > int64(runneraction.MaxLiveLogRecordLimit) {
+		return runneraction.MaxLiveLogRecordLimit
+	}
+	return int(*limit)
 }
 
 func logHTTPClient(config *openapi_client.Configuration) *http.Client {
-	if config.HTTPClient != nil {
+	if config != nil && config.HTTPClient != nil {
 		return config.HTTPClient
 	}
 	return &http.Client{Timeout: 30 * time.Second}
@@ -266,14 +274,11 @@ func renderRunnerLogHeader(stdout io.Writer, output runnerLogOutput) error {
 	if output.NodeID != "" {
 		_, _ = fmt.Fprintf(writer, "Node\t%s\n", output.NodeID)
 	}
-	if output.BrokerTaskID != "" {
-		_, _ = fmt.Fprintf(writer, "Broker task\t%s\n", output.BrokerTaskID)
-	}
 	_, _ = fmt.Fprintln(writer, "Logs")
 	return writer.Flush()
 }
 
-func renderRunnerLogRecord(stdout io.Writer, record runnerLogRecord) error {
+func renderRunnerLogRecord(stdout io.Writer, record runneraction.LiveLogRecord) error {
 	switch record.Type {
 	case "line":
 		_, err := fmt.Fprintln(stdout, record.Text)

--- a/pkg/cli/commands/executions/logs_test.go
+++ b/pkg/cli/commands/executions/logs_test.go
@@ -1,0 +1,138 @@
+package executions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+func TestLogsCommandReturnsExecutionLogsJSON(t *testing.T) {
+	server := newExecutionLogsServer(t)
+	ctx, stdout := newExecutionsCommandContext(t, server, "json")
+	canvasID := "canvas-001"
+	executionID := "exec-001"
+	empty := ""
+	limit := int64(5)
+
+	cmd := &LogsCommand{
+		CanvasID:    &canvasID,
+		ExecutionID: &executionID,
+		RunID:       &empty,
+		NodeID:      &empty,
+		Limit:       &limit,
+	}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	var output []runnerLogOutput
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
+	require.Len(t, output, 1)
+	require.Equal(t, "exec-001", output[0].ExecutionID)
+	require.Equal(t, "task-001", output[0].BrokerTaskID)
+	require.Len(t, output[0].Records, 2)
+	require.Equal(t, "hello", output[0].Records[0].Text)
+}
+
+func TestLogsCommandResolvesLatestNodeExecution(t *testing.T) {
+	server := newExecutionLogsServer(t)
+	ctx, stdout := newExecutionsCommandContext(t, server, "text")
+	canvasID := "canvas-001"
+	empty := ""
+	nodeID := "node-001"
+	limit := int64(5)
+
+	cmd := &LogsCommand{
+		CanvasID:    &canvasID,
+		ExecutionID: &empty,
+		RunID:       &empty,
+		NodeID:      &nodeID,
+		Limit:       &limit,
+	}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	raw := stdout.String()
+	require.Contains(t, raw, "Execution")
+	require.Contains(t, raw, "exec-001")
+	require.Contains(t, raw, "Node")
+	require.Contains(t, raw, "node-001")
+	require.Contains(t, raw, "hello")
+}
+
+func newExecutionLogsServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/canvases/canvas-001/node-executions/exec-001/runner-live-logs":
+			require.Equal(t, "5", r.URL.Query().Get("limit"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"canvas_id":"canvas-001",
+				"execution_id":"exec-001",
+				"broker_task_id":"task-001",
+				"count":2,
+				"records":[
+					{"type":"line","text":"hello"},
+					{"type":"cmd_end","status":"passed","duration_ms":10}
+				]
+			}`))
+		case r.URL.Path == "/api/v1/canvases/canvas-001/nodes/node-001/executions":
+			require.Equal(t, "1", r.URL.Query().Get("limit"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"executions":[
+					{"id":"exec-001","nodeId":"node-001","state":"STATE_FINISHED","result":"RESULT_PASSED"}
+				]
+			}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/canvases/canvas-001/runs/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"run":{
+					"id":"run-001",
+					"canvasId":"canvas-001",
+					"executions":[
+						{"id":"exec-001","nodeId":"node-001","state":"STATE_FINISHED"}
+					]
+				}
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newExecutionsCommandContext(
+	t *testing.T,
+	server *httptest.Server,
+	outputFormat string,
+) (core.CommandContext, *bytes.Buffer) {
+	t.Helper()
+
+	stdout := bytes.NewBuffer(nil)
+	renderer, err := core.NewRenderer(outputFormat, stdout)
+	require.NoError(t, err)
+
+	config := openapi_client.NewConfiguration()
+	config.Servers = openapi_client.ServerConfigurations{{URL: server.URL}}
+
+	cobraCmd := &cobra.Command{}
+	cobraCmd.SetOut(stdout)
+
+	return core.CommandContext{
+		Context:  context.Background(),
+		Cmd:      cobraCmd,
+		API:      openapi_client.NewAPIClient(config),
+		Renderer: renderer,
+	}, stdout
+}

--- a/pkg/cli/commands/executions/logs_test.go
+++ b/pkg/cli/commands/executions/logs_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/cli/core"
+	runneraction "github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
@@ -98,6 +99,36 @@ func TestLogsCommandResolvesRunExecutions(t *testing.T) {
 	require.Empty(t, output[0].Error)
 }
 
+func TestRenderRunnerLogsTextPrintsAllOutputsAfterTruncatedOutput(t *testing.T) {
+	stdout := bytes.NewBuffer(nil)
+	outputs := []runnerLogOutput{
+		{
+			ExecutionID: "exec-001",
+			NodeID:      "node-001",
+			Truncated:   true,
+			Records: []runneraction.LiveLogRecord{
+				{Type: "line", Text: "first execution"},
+			},
+		},
+		{
+			ExecutionID: "exec-002",
+			NodeID:      "node-002",
+			Records: []runneraction.LiveLogRecord{
+				{Type: "line", Text: "second execution"},
+			},
+		},
+	}
+
+	require.NoError(t, renderRunnerLogsText(stdout, outputs))
+
+	raw := stdout.String()
+	require.Contains(t, raw, "exec-001")
+	require.Contains(t, raw, "first execution")
+	require.Contains(t, raw, "... truncated")
+	require.Contains(t, raw, "exec-002")
+	require.Contains(t, raw, "second execution")
+}
+
 func newExecutionLogBroker(t *testing.T) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -123,6 +154,18 @@ func newExecutionLogsServer(t *testing.T, brokerURL string) *httptest.Server {
 				"token":"token-001",
 				"expires_at":"2026-07-01T10:00:00Z"
 			}`, brokerURL+"/v1/tasks/task-001/live-logs")
+		case r.URL.Path == "/api/v1/canvases/canvas-001":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"canvas":{
+					"spec":{
+						"nodes":[
+							{"id":"node-ignored","component":"noop"},
+							{"id":"node-001","component":"runner"}
+						]
+					}
+				}
+			}`))
 		case r.URL.Path == "/api/v1/canvases/canvas-001/nodes/node-001/executions":
 			require.Equal(t, "1", r.URL.Query().Get("limit"))
 			w.Header().Set("Content-Type", "application/json")
@@ -138,6 +181,7 @@ func newExecutionLogsServer(t *testing.T, brokerURL string) *httptest.Server {
 					"id":"run-001",
 					"canvasId":"canvas-001",
 					"executions":[
+						{"id":"exec-ignored","nodeId":"node-ignored","state":"STATE_FINISHED"},
 						{"id":"exec-001","nodeId":"node-001","state":"STATE_FINISHED"}
 					]
 				}

--- a/pkg/cli/commands/executions/logs_test.go
+++ b/pkg/cli/commands/executions/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,12 +17,13 @@ import (
 )
 
 func TestLogsCommandReturnsExecutionLogsJSON(t *testing.T) {
-	server := newExecutionLogsServer(t)
+	broker := newExecutionLogBroker(t)
+	server := newExecutionLogsServer(t, broker.URL)
 	ctx, stdout := newExecutionsCommandContext(t, server, "json")
 	canvasID := "canvas-001"
 	executionID := "exec-001"
 	empty := ""
-	limit := int64(5)
+	limit := int64(2)
 
 	cmd := &LogsCommand{
 		CanvasID:    &canvasID,
@@ -37,13 +39,14 @@ func TestLogsCommandReturnsExecutionLogsJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
 	require.Len(t, output, 1)
 	require.Equal(t, "exec-001", output[0].ExecutionID)
-	require.Equal(t, "task-001", output[0].BrokerTaskID)
 	require.Len(t, output[0].Records, 2)
+	require.True(t, output[0].Truncated)
 	require.Equal(t, "hello", output[0].Records[0].Text)
 }
 
 func TestLogsCommandResolvesLatestNodeExecution(t *testing.T) {
-	server := newExecutionLogsServer(t)
+	broker := newExecutionLogBroker(t)
+	server := newExecutionLogsServer(t, broker.URL)
 	ctx, stdout := newExecutionsCommandContext(t, server, "text")
 	canvasID := "canvas-001"
 	empty := ""
@@ -68,23 +71,58 @@ func TestLogsCommandResolvesLatestNodeExecution(t *testing.T) {
 	require.Contains(t, raw, "hello")
 }
 
-func newExecutionLogsServer(t *testing.T) *httptest.Server {
+func TestLogsCommandResolvesRunExecutions(t *testing.T) {
+	broker := newExecutionLogBroker(t)
+	server := newExecutionLogsServer(t, broker.URL)
+	ctx, stdout := newExecutionsCommandContext(t, server, "json")
+	canvasID := "canvas-001"
+	empty := ""
+	runID := "run-001"
+	limit := int64(5)
+
+	cmd := &LogsCommand{
+		CanvasID:    &canvasID,
+		ExecutionID: &empty,
+		RunID:       &runID,
+		NodeID:      &empty,
+		Limit:       &limit,
+	}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	var output []runnerLogOutput
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
+	require.Len(t, output, 1)
+	require.Equal(t, "exec-001", output[0].ExecutionID)
+	require.Equal(t, "node-001", output[0].NodeID)
+	require.Empty(t, output[0].Error)
+}
+
+func newExecutionLogBroker(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/tasks/task-001/live-logs", r.URL.Path)
+		require.Equal(t, "Bearer token-001", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"type":"line","text":"hello"}`)
+		_, _ = fmt.Fprintln(w, `{"type":"cmd_end","status":"passed","duration_ms":10}`)
+		_, _ = fmt.Fprintln(w, `{"type":"line","text":"after limit"}`)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newExecutionLogsServer(t *testing.T, brokerURL string) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/api/v1/canvases/canvas-001/node-executions/exec-001/runner-live-logs":
-			require.Equal(t, "5", r.URL.Query().Get("limit"))
+		case r.URL.Path == "/api/v1/canvases/canvas-001/node-executions/exec-001/runner-live-logs/session":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{
-				"canvas_id":"canvas-001",
-				"execution_id":"exec-001",
-				"broker_task_id":"task-001",
-				"count":2,
-				"records":[
-					{"type":"line","text":"hello"},
-					{"type":"cmd_end","status":"passed","duration_ms":10}
-				]
-			}`))
+			_, _ = fmt.Fprintf(w, `{
+				"stream_url":%q,
+				"token":"token-001",
+				"expires_at":"2026-07-01T10:00:00Z"
+			}`, brokerURL+"/v1/tasks/task-001/live-logs")
 		case r.URL.Path == "/api/v1/canvases/canvas-001/nodes/node-001/executions":
 			require.Equal(t, "1", r.URL.Query().Get("limit"))
 			w.Header().Set("Content-Type", "application/json")

--- a/pkg/cli/commands/executions/root.go
+++ b/pkg/cli/commands/executions/root.go
@@ -9,6 +9,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	var appID string
 	var nodeID string
 	var executionID string
+	var runID string
 	var limit int64
 	var before string
 
@@ -48,8 +49,27 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		ExecutionID: &executionID,
 	}, options)
 
+	logsCmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Fetch runner logs for an execution, run, or node",
+		Args:  cobra.NoArgs,
+	}
+	core.BindAppIDFlag(logsCmd, &appID, "app ID")
+	logsCmd.Flags().StringVar(&executionID, "execution-id", "", "execution ID")
+	logsCmd.Flags().StringVar(&runID, "run-id", "", "run ID")
+	logsCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
+	logsCmd.Flags().Int64Var(&limit, "limit", 200, "maximum number of log records to return per execution")
+	core.Bind(logsCmd, &LogsCommand{
+		CanvasID:    &appID,
+		ExecutionID: &executionID,
+		RunID:       &runID,
+		NodeID:      &nodeID,
+		Limit:       &limit,
+	}, options)
+
 	root.AddCommand(listCmd)
 	root.AddCommand(cancelCmd)
+	root.AddCommand(logsCmd)
 
 	return root
 }

--- a/pkg/components/runner/live_log_fetch.go
+++ b/pkg/components/runner/live_log_fetch.go
@@ -102,6 +102,10 @@ func readLiveLogRecords(reader io.Reader, limit int) (*LiveLogFetchResult, error
 
 	records := make([]LiveLogRecord, 0, min(limit, 32))
 	for scanner.Scan() {
+		if len(records) >= limit {
+			return &LiveLogFetchResult{Records: records, Truncated: true}, nil
+		}
+
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
@@ -110,9 +114,6 @@ func readLiveLogRecords(reader io.Reader, limit int) (*LiveLogFetchResult, error
 		record, ok := parseLiveLogRecord(line)
 		if !ok {
 			continue
-		}
-		if len(records) >= limit {
-			return &LiveLogFetchResult{Records: records, Truncated: true}, nil
 		}
 		records = append(records, record)
 	}

--- a/pkg/components/runner/live_log_fetch.go
+++ b/pkg/components/runner/live_log_fetch.go
@@ -1,0 +1,130 @@
+package runner
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultLiveLogRecordLimit = 200
+	MaxLiveLogRecordLimit     = 1000
+)
+
+type LiveLogRecord struct {
+	Type       string `json:"type,omitempty"`
+	Text       string `json:"text,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Index      *int   `json:"index,omitempty"`
+	Status     string `json:"status,omitempty"`
+	DurationMS *int64 `json:"duration_ms,omitempty"`
+	StartedAt  *int64 `json:"started_at,omitempty"`
+}
+
+type LiveLogFetchOptions struct {
+	Limit      int
+	HTTPClient *http.Client
+	Now        time.Time
+}
+
+type LiveLogFetchResult struct {
+	Records   []LiveLogRecord
+	Truncated bool
+}
+
+func FetchLiveLogRecords(ctx context.Context, brokerTaskID string, opts LiveLogFetchOptions) (*LiveLogFetchResult, error) {
+	limit := normalizeLiveLogRecordLimit(opts.Limit)
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	session, err := NewLiveLogSession(brokerTaskID, now)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, session.StreamURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/x-ndjson")
+	request.Header.Set("Accept-Encoding", "identity")
+	request.Header.Set("Authorization", "Bearer "+session.Token)
+
+	response, err := liveLogHTTPClient(opts.HTTPClient).Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = response.Status
+		}
+		return nil, fmt.Errorf("fetch live logs: %s", message)
+	}
+
+	return readLiveLogRecords(response.Body, limit)
+}
+
+func normalizeLiveLogRecordLimit(limit int) int {
+	if limit <= 0 {
+		return DefaultLiveLogRecordLimit
+	}
+	if limit > MaxLiveLogRecordLimit {
+		return MaxLiveLogRecordLimit
+	}
+	return limit
+}
+
+func liveLogHTTPClient(client *http.Client) *http.Client {
+	if client != nil {
+		return client
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func readLiveLogRecords(reader io.Reader, limit int) (*LiveLogFetchResult, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	records := make([]LiveLogRecord, 0, min(limit, 32))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		record, ok := parseLiveLogRecord(line)
+		if !ok {
+			continue
+		}
+		if len(records) >= limit {
+			return &LiveLogFetchResult{Records: records, Truncated: true}, nil
+		}
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read live logs: %w", err)
+	}
+	return &LiveLogFetchResult{Records: records}, nil
+}
+
+func parseLiveLogRecord(line string) (LiveLogRecord, bool) {
+	var record LiveLogRecord
+	if err := json.Unmarshal([]byte(line), &record); err != nil {
+		return LiveLogRecord{}, false
+	}
+	if strings.TrimSpace(record.Type) == "" {
+		return LiveLogRecord{}, false
+	}
+	return record, true
+}

--- a/pkg/components/runner/live_log_fetch.go
+++ b/pkg/components/runner/live_log_fetch.go
@@ -38,7 +38,6 @@ type LiveLogFetchResult struct {
 }
 
 func FetchLiveLogRecords(ctx context.Context, brokerTaskID string, opts LiveLogFetchOptions) (*LiveLogFetchResult, error) {
-	limit := normalizeLiveLogRecordLimit(opts.Limit)
 	now := opts.Now
 	if now.IsZero() {
 		now = time.Now()
@@ -49,6 +48,11 @@ func FetchLiveLogRecords(ctx context.Context, brokerTaskID string, opts LiveLogF
 		return nil, err
 	}
 
+	return FetchLiveLogSessionRecords(ctx, *session, opts)
+}
+
+func FetchLiveLogSessionRecords(ctx context.Context, session LiveLogSession, opts LiveLogFetchOptions) (*LiveLogFetchResult, error) {
+	limit := normalizeLiveLogRecordLimit(opts.Limit)
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, session.StreamURL, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/components/runner/live_log_fetch_test.go
+++ b/pkg/components/runner/live_log_fetch_test.go
@@ -1,0 +1,17 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadLiveLogRecordsStopsAfterLimitEvenWhenNextLineIsInvalid(t *testing.T) {
+	result, err := readLiveLogRecords(strings.NewReader(`{"type":"line","text":"first"}`+"\nnot-json\n"), 1)
+
+	require.NoError(t, err)
+	require.Len(t, result.Records, 1)
+	require.Equal(t, "first", result.Records[0].Text)
+	require.True(t, result.Truncated)
+}

--- a/pkg/components/runner/live_log_session.go
+++ b/pkg/components/runner/live_log_session.go
@@ -25,6 +25,7 @@ var (
 	ErrLiveLogNodeNotFound      = errors.New("node not found")
 	ErrLiveLogNotRunner         = errors.New("not a runner component")
 	ErrLiveLogBrokerTaskMissing = errors.New("broker task id missing")
+	ErrLiveLogNotConfigured     = errors.New("live logs not configured")
 )
 
 // LiveLogStreamTokenClaims is the JWT payload SuperPlane mints for browser → task-broker streaming.
@@ -46,7 +47,7 @@ type LiveLogAccessContext struct {
 	BrokerTaskID string
 }
 
-func isRunnerComponent(name string) bool {
+func IsRunnerComponent(name string) bool {
 	switch strings.TrimSpace(name) {
 	case ComponentName, RunJSComponentName, RunPythonComponentName, RunBashComponentName:
 		return true
@@ -85,7 +86,7 @@ func ResolveLiveLogAccess(orgID uuid.UUID, canvasID uuid.UUID, executionID uuid.
 	}
 
 	ref := node.Ref.Data()
-	if ref.Component == nil || !isRunnerComponent(ref.Component.Name) {
+	if ref.Component == nil || !IsRunnerComponent(ref.Component.Name) {
 		return nil, ErrLiveLogNotRunner
 	}
 
@@ -100,7 +101,7 @@ func ResolveLiveLogAccess(orgID uuid.UUID, canvasID uuid.UUID, executionID uuid.
 func taskBrokerBaseURL() (string, error) {
 	base := strings.TrimRight(strings.TrimSpace(os.Getenv("TASK_BROKER_BASE_URL")), "/")
 	if base == "" {
-		return "", fmt.Errorf("TASK_BROKER_BASE_URL is not set")
+		return "", fmt.Errorf("%w: TASK_BROKER_BASE_URL is not set", ErrLiveLogNotConfigured)
 	}
 	return base, nil
 }
@@ -120,7 +121,7 @@ func LiveLogStreamURL(brokerTaskID string) (string, error) {
 func taskBrokerAuthToken() (string, error) {
 	token := strings.TrimSpace(os.Getenv("TASK_BROKER_AUTH_TOKEN"))
 	if token == "" {
-		return "", fmt.Errorf("TASK_BROKER_AUTH_TOKEN is not set")
+		return "", fmt.Errorf("%w: TASK_BROKER_AUTH_TOKEN is not set", ErrLiveLogNotConfigured)
 	}
 	return token, nil
 }

--- a/pkg/public/runner_live_log_session.go
+++ b/pkg/public/runner_live_log_session.go
@@ -1,9 +1,11 @@
 package public
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -12,6 +14,17 @@ import (
 	runneraction "github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/public/middleware"
 )
+
+const defaultRunnerLiveLogRequestTimeout = 30 * time.Second
+
+type runnerLiveLogsResponse struct {
+	CanvasID     string                       `json:"canvas_id"`
+	ExecutionID  string                       `json:"execution_id"`
+	BrokerTaskID string                       `json:"broker_task_id"`
+	Count        int                          `json:"count"`
+	Truncated    bool                         `json:"truncated,omitempty"`
+	Records      []runneraction.LiveLogRecord `json:"records"`
+}
 
 func (s *Server) handleRunnerLiveLogSession(w http.ResponseWriter, r *http.Request) {
 	user, ok := middleware.GetUserFromContext(r.Context())
@@ -68,6 +81,90 @@ func (s *Server) handleRunnerLiveLogSession(w http.ResponseWriter, r *http.Reque
 	if err := json.NewEncoder(w).Encode(session); err != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 	}
+}
+
+func (s *Server) handleRunnerLiveLogs(w http.ResponseWriter, r *http.Request) {
+	user, ok := middleware.GetUserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	allowed, err := s.authService.CheckOrganizationPermission(r.Context(),
+		user.ID.String(),
+		user.OrganizationID.String(),
+		"canvases",
+		"read",
+	)
+	if err != nil {
+		http.Error(w, "Authorization check failed", http.StatusInternalServerError)
+		return
+	}
+	if !allowed {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	vars := mux.Vars(r)
+	canvasID, err := uuid.Parse(strings.TrimSpace(vars["canvas_id"]))
+	if err != nil {
+		http.Error(w, "Invalid canvas id", http.StatusBadRequest)
+		return
+	}
+	executionID, err := uuid.Parse(strings.TrimSpace(vars["execution_id"]))
+	if err != nil {
+		http.Error(w, "Invalid execution id", http.StatusBadRequest)
+		return
+	}
+
+	access, err := runneraction.ResolveLiveLogAccess(user.OrganizationID, canvasID, executionID)
+	if err != nil {
+		writeRunnerLiveLogSessionError(w, err)
+		return
+	}
+
+	limit, err := parseRunnerLiveLogLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), defaultRunnerLiveLogRequestTimeout)
+	defer cancel()
+	result, err := runneraction.FetchLiveLogRecords(ctx, access.BrokerTaskID, runneraction.LiveLogFetchOptions{Limit: limit})
+	if err != nil {
+		if strings.Contains(err.Error(), "is not set") {
+			http.Error(w, "Live logs are not configured on this installation", http.StatusServiceUnavailable)
+			return
+		}
+		http.Error(w, "Could not fetch live logs", http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := json.NewEncoder(w).Encode(runnerLiveLogsResponse{
+		CanvasID:     canvasID.String(),
+		ExecutionID:  executionID.String(),
+		BrokerTaskID: access.BrokerTaskID,
+		Count:        len(result.Records),
+		Truncated:    result.Truncated,
+		Records:      result.Records,
+	}); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func parseRunnerLiveLogLimit(value string) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return runneraction.DefaultLiveLogRecordLimit, nil
+	}
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit < 0 {
+		return 0, errors.New("Invalid limit")
+	}
+	return limit, nil
 }
 
 func writeRunnerLiveLogSessionError(w http.ResponseWriter, err error) {

--- a/pkg/public/runner_live_log_session.go
+++ b/pkg/public/runner_live_log_session.go
@@ -1,11 +1,9 @@
 package public
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -14,17 +12,6 @@ import (
 	runneraction "github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/public/middleware"
 )
-
-const defaultRunnerLiveLogRequestTimeout = 30 * time.Second
-
-type runnerLiveLogsResponse struct {
-	CanvasID     string                       `json:"canvas_id"`
-	ExecutionID  string                       `json:"execution_id"`
-	BrokerTaskID string                       `json:"broker_task_id"`
-	Count        int                          `json:"count"`
-	Truncated    bool                         `json:"truncated,omitempty"`
-	Records      []runneraction.LiveLogRecord `json:"records"`
-}
 
 func (s *Server) handleRunnerLiveLogSession(w http.ResponseWriter, r *http.Request) {
 	user, ok := middleware.GetUserFromContext(r.Context())
@@ -68,7 +55,7 @@ func (s *Server) handleRunnerLiveLogSession(w http.ResponseWriter, r *http.Reque
 
 	session, err := runneraction.NewLiveLogSession(access.BrokerTaskID, time.Now())
 	if err != nil {
-		if strings.Contains(err.Error(), "is not set") {
+		if errors.Is(err, runneraction.ErrLiveLogNotConfigured) {
 			http.Error(w, "Live logs are not configured on this installation", http.StatusServiceUnavailable)
 			return
 		}
@@ -81,90 +68,6 @@ func (s *Server) handleRunnerLiveLogSession(w http.ResponseWriter, r *http.Reque
 	if err := json.NewEncoder(w).Encode(session); err != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 	}
-}
-
-func (s *Server) handleRunnerLiveLogs(w http.ResponseWriter, r *http.Request) {
-	user, ok := middleware.GetUserFromContext(r.Context())
-	if !ok {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return
-	}
-
-	allowed, err := s.authService.CheckOrganizationPermission(r.Context(),
-		user.ID.String(),
-		user.OrganizationID.String(),
-		"canvases",
-		"read",
-	)
-	if err != nil {
-		http.Error(w, "Authorization check failed", http.StatusInternalServerError)
-		return
-	}
-	if !allowed {
-		http.Error(w, "Forbidden", http.StatusForbidden)
-		return
-	}
-
-	vars := mux.Vars(r)
-	canvasID, err := uuid.Parse(strings.TrimSpace(vars["canvas_id"]))
-	if err != nil {
-		http.Error(w, "Invalid canvas id", http.StatusBadRequest)
-		return
-	}
-	executionID, err := uuid.Parse(strings.TrimSpace(vars["execution_id"]))
-	if err != nil {
-		http.Error(w, "Invalid execution id", http.StatusBadRequest)
-		return
-	}
-
-	access, err := runneraction.ResolveLiveLogAccess(user.OrganizationID, canvasID, executionID)
-	if err != nil {
-		writeRunnerLiveLogSessionError(w, err)
-		return
-	}
-
-	limit, err := parseRunnerLiveLogLimit(r.URL.Query().Get("limit"))
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), defaultRunnerLiveLogRequestTimeout)
-	defer cancel()
-	result, err := runneraction.FetchLiveLogRecords(ctx, access.BrokerTaskID, runneraction.LiveLogFetchOptions{Limit: limit})
-	if err != nil {
-		if strings.Contains(err.Error(), "is not set") {
-			http.Error(w, "Live logs are not configured on this installation", http.StatusServiceUnavailable)
-			return
-		}
-		http.Error(w, "Could not fetch live logs", http.StatusBadGateway)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-store")
-	if err := json.NewEncoder(w).Encode(runnerLiveLogsResponse{
-		CanvasID:     canvasID.String(),
-		ExecutionID:  executionID.String(),
-		BrokerTaskID: access.BrokerTaskID,
-		Count:        len(result.Records),
-		Truncated:    result.Truncated,
-		Records:      result.Records,
-	}); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-	}
-}
-
-func parseRunnerLiveLogLimit(value string) (int, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return runneraction.DefaultLiveLogRecordLimit, nil
-	}
-	limit, err := strconv.Atoi(value)
-	if err != nil || limit < 0 {
-		return 0, errors.New("Invalid limit")
-	}
-	return limit, nil
 }
 
 func writeRunnerLiveLogSessionError(w http.ResponseWriter, err error) {

--- a/pkg/public/runner_live_log_session_test.go
+++ b/pkg/public/runner_live_log_session_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -67,29 +66,6 @@ func runnerLiveLogSessionGET(
 	return rec
 }
 
-func runnerLiveLogsGET(
-	t *testing.T,
-	server *Server,
-	signer *jwt.Signer,
-	r *support.ResourceRegistry,
-	canvasID, executionID string,
-	limit int,
-) *httptest.ResponseRecorder {
-	t.Helper()
-	path := fmt.Sprintf("/api/v1/canvases/%s/node-executions/%s/runner-live-logs", canvasID, executionID)
-	if limit > 0 {
-		path += fmt.Sprintf("?limit=%d", limit)
-	}
-	req := httptest.NewRequest(http.MethodGet, path, nil)
-	req.Header.Set("x-organization-id", r.Organization.ID.String())
-	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
-	require.NoError(t, err)
-	req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
-	rec := httptest.NewRecorder()
-	server.Router.ServeHTTP(rec, req)
-	return rec
-}
-
 func createExecutionForCanvasRun(
 	t *testing.T,
 	run *models.CanvasRun,
@@ -112,44 +88,6 @@ func createExecutionForCanvasRun(
 	}
 	require.NoError(t, database.Conn().Create(&execution).Error)
 	return &execution
-}
-
-func TestHandleRunnerLiveLogs(t *testing.T) {
-	r := support.Setup(t)
-	defer r.Close()
-
-	server, signer := mustRunnerLiveLogServer(t, r)
-	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "/v1/tasks/task-logs/live-logs", req.URL.Path)
-		assert.True(t, strings.HasPrefix(req.Header.Get("Authorization"), "Bearer "))
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		_, _ = fmt.Fprintln(w, `{"type":"cmd_start","index":1,"text":"echo hello","started_at":1761850000000}`)
-		_, _ = fmt.Fprintln(w, `{"type":"line","text":"hello"}`)
-		_, _ = fmt.Fprintln(w, `{"type":"cmd_end","index":1,"status":"passed","duration_ms":12}`)
-	}))
-	defer broker.Close()
-
-	t.Setenv("TASK_BROKER_BASE_URL", broker.URL)
-	t.Setenv("TASK_BROKER_AUTH_TOKEN", "live-log-secret")
-
-	canvasID, execID := createCanvasWithComponentExecution(t, r, "runnerBash", "runner-logs-1", map[string]any{
-		runneraction.ExecutionMetadataBrokerTaskID: "task-logs",
-	})
-
-	rec := runnerLiveLogsGET(t, server, signer, r, canvasID.String(), execID.String(), 2)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
-
-	var response runnerLiveLogsResponse
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
-	assert.Equal(t, canvasID.String(), response.CanvasID)
-	assert.Equal(t, execID.String(), response.ExecutionID)
-	assert.Equal(t, "task-logs", response.BrokerTaskID)
-	assert.Equal(t, 2, response.Count)
-	assert.True(t, response.Truncated)
-	require.Len(t, response.Records, 2)
-	assert.Equal(t, "cmd_start", response.Records[0].Type)
-	assert.Equal(t, "hello", response.Records[1].Text)
 }
 
 func createCanvasWithComponentExecution(

--- a/pkg/public/runner_live_log_session_test.go
+++ b/pkg/public/runner_live_log_session_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,6 +67,29 @@ func runnerLiveLogSessionGET(
 	return rec
 }
 
+func runnerLiveLogsGET(
+	t *testing.T,
+	server *Server,
+	signer *jwt.Signer,
+	r *support.ResourceRegistry,
+	canvasID, executionID string,
+	limit int,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	path := fmt.Sprintf("/api/v1/canvases/%s/node-executions/%s/runner-live-logs", canvasID, executionID)
+	if limit > 0 {
+		path += fmt.Sprintf("?limit=%d", limit)
+	}
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("x-organization-id", r.Organization.ID.String())
+	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+	rec := httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, req)
+	return rec
+}
+
 func createExecutionForCanvasRun(
 	t *testing.T,
 	run *models.CanvasRun,
@@ -88,6 +112,44 @@ func createExecutionForCanvasRun(
 	}
 	require.NoError(t, database.Conn().Create(&execution).Error)
 	return &execution
+}
+
+func TestHandleRunnerLiveLogs(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	server, signer := mustRunnerLiveLogServer(t, r)
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/v1/tasks/task-logs/live-logs", req.URL.Path)
+		assert.True(t, strings.HasPrefix(req.Header.Get("Authorization"), "Bearer "))
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"type":"cmd_start","index":1,"text":"echo hello","started_at":1761850000000}`)
+		_, _ = fmt.Fprintln(w, `{"type":"line","text":"hello"}`)
+		_, _ = fmt.Fprintln(w, `{"type":"cmd_end","index":1,"status":"passed","duration_ms":12}`)
+	}))
+	defer broker.Close()
+
+	t.Setenv("TASK_BROKER_BASE_URL", broker.URL)
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "live-log-secret")
+
+	canvasID, execID := createCanvasWithComponentExecution(t, r, "runnerBash", "runner-logs-1", map[string]any{
+		runneraction.ExecutionMetadataBrokerTaskID: "task-logs",
+	})
+
+	rec := runnerLiveLogsGET(t, server, signer, r, canvasID.String(), execID.String(), 2)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+
+	var response runnerLiveLogsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Equal(t, canvasID.String(), response.CanvasID)
+	assert.Equal(t, execID.String(), response.ExecutionID)
+	assert.Equal(t, "task-logs", response.BrokerTaskID)
+	assert.Equal(t, 2, response.Count)
+	assert.True(t, response.Truncated)
+	require.Len(t, response.Records, 2)
+	assert.Equal(t, "cmd_start", response.Records[0].Type)
+	assert.Equal(t, "hello", response.Records[1].Text)
 }
 
 func createCanvasWithComponentExecution(

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -372,6 +372,10 @@ func (s *Server) RegisterGRPCGateway(services *grpc.Services) error {
 		"/api/v1/canvases/{canvas_id}/node-executions/{execution_id}/runner-live-logs/session",
 		middleware.OrganizationAuthMiddleware(s.jwt)(http.HandlerFunc(s.handleRunnerLiveLogSession)),
 	).Methods("GET")
+	s.Router.Handle(
+		"/api/v1/canvases/{canvas_id}/node-executions/{execution_id}/runner-live-logs",
+		middleware.OrganizationAuthMiddleware(s.jwt)(http.HandlerFunc(s.handleRunnerLiveLogs)),
+	).Methods("GET")
 
 	// Protect the gRPC gateway routes with organization authentication
 	orgAuthMiddleware := middleware.OrganizationAuthMiddleware(s.jwt)

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -372,10 +372,6 @@ func (s *Server) RegisterGRPCGateway(services *grpc.Services) error {
 		"/api/v1/canvases/{canvas_id}/node-executions/{execution_id}/runner-live-logs/session",
 		middleware.OrganizationAuthMiddleware(s.jwt)(http.HandlerFunc(s.handleRunnerLiveLogSession)),
 	).Methods("GET")
-	s.Router.Handle(
-		"/api/v1/canvases/{canvas_id}/node-executions/{execution_id}/runner-live-logs",
-		middleware.OrganizationAuthMiddleware(s.jwt)(http.HandlerFunc(s.handleRunnerLiveLogs)),
-	).Methods("GET")
 
 	// Protect the gRPC gateway routes with organization authentication
 	orgAuthMiddleware := middleware.OrganizationAuthMiddleware(s.jwt)


### PR DESCRIPTION
Closes #5728

## Summary
- add a shared runner live-log fetcher for bounded task-broker NDJSON records
- add a scoped SuperPlane endpoint for runner execution logs
- add `superplane executions logs` targeting `--execution-id`, `--run-id`, and/or `--node-id`
- add `read_runtime` `runner_logs` for agent tooling with execution/run/node targeting

## Tests
- make test PKG_TEST_PACKAGES='./pkg/components/runner ./pkg/public ./pkg/agents/agent_tools/... ./pkg/cli/commands/executions'
- make format.go
- make lint && make check.build.app