### PR TITLE
fix: keep run sidebar selection focused

### DIFF
--- a/web_src/src/hooks/canvasInfiniteCache.spec.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.spec.ts
@@ -95,6 +95,57 @@ describe("upsertRunIntoInfiniteData", () => {
     expect(next.pages[0]?.totalCount).toBe(1);
   });
 
+  it("preserves existing run details when a live update omits them", () => {
+    const old = makeInfiniteRunsData([
+      makeRun({
+        rootEvent: { id: "event-1", nodeId: "trigger-1", createdAt: "2026-06-01T12:00:00.000Z" },
+        executions: [
+          {
+            id: "execution-1",
+            nodeId: "node-1",
+            state: "STATE_FINISHED",
+            updatedAt: "2026-06-01T12:00:30.000Z",
+          },
+        ],
+        updatedAt: "2026-06-01T12:00:30.000Z",
+      }),
+    ]);
+    const incoming: CanvasesCanvasRun = {
+      id: "run-1",
+      canvasId: "canvas-1",
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      updatedAt: "2026-06-01T12:01:00.000Z",
+    };
+
+    const next = upsertRunIntoInfiniteData(old, incoming, {})!;
+    const updatedRun = next.pages[0]?.runs?.[0];
+
+    expect(updatedRun?.state).toBe("STATE_FINISHED");
+    expect(updatedRun?.result).toBe("RESULT_PASSED");
+    expect(updatedRun?.rootEvent?.id).toBe("event-1");
+    expect(updatedRun?.executions?.map((execution) => execution.id)).toEqual(["execution-1"]);
+  });
+
+  it("sorts newly inserted live runs by updatedAt when createdAt is unavailable", () => {
+    const existing = makeRun({
+      id: "run-old",
+      createdAt: "2026-06-01T11:00:00.000Z",
+      updatedAt: "2026-06-01T11:00:00.000Z",
+    });
+    const incoming = makeRun({
+      id: "run-new",
+      createdAt: undefined,
+      updatedAt: "2026-06-01T12:00:00.000Z",
+    });
+    const old = makeInfiniteRunsData([existing], 1);
+
+    const next = upsertRunIntoInfiniteData(old, incoming, {})!;
+
+    expect(next.pages[0]?.runs?.map((run) => run.id)).toEqual(["run-new", "run-old"]);
+    expect(next.pages[0]?.totalCount).toBe(2);
+  });
+
   it("rejects stale run_started updates after run_finished", () => {
     const old = makeInfiniteRunsData([
       makeRun({

--- a/web_src/src/hooks/canvasInfiniteCache.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.ts
@@ -86,8 +86,8 @@ function parseTimestamp(value: string | undefined): number {
 }
 
 function shouldAcceptRunUpdate(existing: CanvasesCanvasRun, incoming: CanvasesCanvasRun): boolean {
-  const existingUpdatedAt = parseTimestamp(existing.updatedAt);
-  const incomingUpdatedAt = parseTimestamp(incoming.updatedAt);
+  const existingUpdatedAt = getRunUpdateTimestamp(existing);
+  const incomingUpdatedAt = getRunUpdateTimestamp(incoming);
 
   if (incomingUpdatedAt < existingUpdatedAt) {
     return false;
@@ -100,6 +100,29 @@ function shouldAcceptRunUpdate(existing: CanvasesCanvasRun, incoming: CanvasesCa
   const existingState = RUN_STATE_ORDER[existing.state ?? "STATE_UNKNOWN"] ?? 0;
   const incomingState = RUN_STATE_ORDER[incoming.state ?? "STATE_UNKNOWN"] ?? 0;
   return incomingState >= existingState;
+}
+
+function getRunUpdateTimestamp(run: CanvasesCanvasRun): number {
+  return parseTimestamp(run.updatedAt) || parseTimestamp(run.finishedAt) || parseTimestamp(run.createdAt);
+}
+
+function getRunSortTimestamp(run: CanvasesCanvasRun): number {
+  return parseTimestamp(run.createdAt) || parseTimestamp(run.updatedAt);
+}
+
+function mergeRunUpdate(existing: CanvasesCanvasRun, incoming: CanvasesCanvasRun): CanvasesCanvasRun {
+  return {
+    id: incoming.id ?? existing.id,
+    canvasId: incoming.canvasId ?? existing.canvasId,
+    rootEvent: incoming.rootEvent ?? existing.rootEvent,
+    state: incoming.state ?? existing.state,
+    result: incoming.result ?? existing.result,
+    executions: incoming.executions?.length ? incoming.executions : (existing.executions ?? incoming.executions),
+    createdAt: incoming.createdAt ?? existing.createdAt,
+    updatedAt: incoming.updatedAt ?? existing.updatedAt,
+    finishedAt: incoming.finishedAt ?? existing.finishedAt,
+    versionId: incoming.versionId ?? existing.versionId,
+  };
 }
 
 function bumpTotalCountOnAllPages<T extends { totalCount?: number }>(pages: T[], delta: number): void {
@@ -120,8 +143,8 @@ function findRunLocation(pages: InfiniteRunsPage[], runId: string): { pageIndex:
 }
 
 function insertRunSorted(runs: CanvasesCanvasRun[], run: CanvasesCanvasRun): CanvasesCanvasRun[] {
-  const runCreatedAt = parseTimestamp(run.createdAt);
-  const insertIndex = runs.findIndex((existingRun) => parseTimestamp(existingRun.createdAt) < runCreatedAt);
+  const runTimestamp = getRunSortTimestamp(run);
+  const insertIndex = runs.findIndex((existingRun) => getRunSortTimestamp(existingRun) < runTimestamp);
   if (insertIndex === -1) {
     return [...runs, run];
   }
@@ -143,19 +166,25 @@ export function upsertRunIntoInfiniteData(
     runs: page.runs ? [...page.runs] : [],
   }));
   const location = findRunLocation(pages, run.id ?? "");
-  const matches = runMatchesFilters(run, filters);
 
-  if (matches) {
-    if (location) {
-      const existing = pages[location.pageIndex].runs![location.runIndex];
-      if (!shouldAcceptRunUpdate(existing, run)) {
-        return old;
-      }
+  if (location) {
+    const existing = pages[location.pageIndex].runs![location.runIndex];
+    if (!shouldAcceptRunUpdate(existing, run)) {
+      return old;
+    }
 
-      pages[location.pageIndex].runs![location.runIndex] = run;
+    const nextRun = mergeRunUpdate(existing, run);
+    if (runMatchesFilters(nextRun, filters)) {
+      pages[location.pageIndex].runs![location.runIndex] = nextRun;
       return { ...old, pages };
     }
 
+    pages[location.pageIndex].runs!.splice(location.runIndex, 1);
+    bumpTotalCountOnAllPages(pages, -1);
+    return { ...old, pages };
+  }
+
+  if (runMatchesFilters(run, filters)) {
     if (pages.length === 0) {
       return {
         ...old,
@@ -168,13 +197,7 @@ export function upsertRunIntoInfiniteData(
     return { ...old, pages };
   }
 
-  if (!location) {
-    return old;
-  }
-
-  pages[location.pageIndex].runs!.splice(location.runIndex, 1);
-  bumpTotalCountOnAllPages(pages, -1);
-  return { ...old, pages };
+  return old;
 }
 
 export function executionToRef(execution: CanvasesCanvasNodeExecution): CanvasesCanvasNodeExecutionRef {
@@ -295,5 +318,5 @@ export function upsertRunIntoDescribeRunData(
     return current;
   }
 
-  return { ...current, run: incoming };
+  return { ...current, run: mergeRunUpdate(current.run, incoming) };
 }

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -104,8 +104,9 @@ afterEach(() => {
 });
 
 describe("useCanvasWebsocket", () => {
-  it("does not patch root workflow events into the infinite runs cache", async () => {
+  it("refreshes runs for root workflow events without patching them into the cache", async () => {
     const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
     seedInfiniteRuns(queryClient, [
       {
         id: "run-old",
@@ -129,9 +130,10 @@ describe("useCanvasWebsocket", () => {
       const data = queryClient.getQueryData<InfiniteData<InfiniteRunsPage>>(canvasKeys.infiniteRuns(testCanvasId));
       expect(data?.pages[0]?.runs?.map((run) => run.rootEvent?.id)).toEqual(["event-old"]);
     });
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
   });
 
-  it("does not invalidate infinite runs query for queue_item_created", async () => {
+  it("invalidates infinite runs query for queue_item_created", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -143,7 +145,7 @@ describe("useCanvasWebsocket", () => {
 
     await flushMessageQueue();
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
   });
 
   it("does not invalidate infinite runs query for queue_item_consumed", async () => {
@@ -190,6 +192,25 @@ describe("useCanvasWebsocket", () => {
       expect(runsData?.pages[0]?.runs?.[0]?.executions?.[0]?.id).toBe("execution-1");
     });
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
+  });
+
+  it("invalidates infinite runs when execution events cannot be patched into cached runs", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    seedInfiniteRuns(queryClient, []);
+
+    renderCanvasWebsocketHook(queryClient);
+    emitWebsocketMessage("execution_created", {
+      id: "execution-1",
+      nodeId: testNodeId,
+      state: "STATE_PENDING",
+      updatedAt: "2026-06-01T12:00:00.000Z",
+      rootEvent: { id: "event-1", nodeId: testNodeId },
+    });
+
+    await flushMessageQueue();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
   });
 
   it("patches run events into all infinite runs cache variants", async () => {

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -195,14 +195,34 @@ export function useCanvasWebsocket(
   );
 
   const patchExecutionInCache = useCallback(
-    (execution: CanvasesCanvasNodeExecution) => {
-      queryClient.setQueriesData<InfiniteData<InfiniteRunsPage>>(
-        { queryKey: canvasKeys.infiniteRuns(canvasId) },
-        (old) => upsertExecutionIntoInfiniteRunsData(old, execution),
-      );
+    (execution: CanvasesCanvasNodeExecution): boolean => {
+      let patched = false;
+      const queries = queryClient.getQueriesData<InfiniteData<InfiniteRunsPage>>({
+        queryKey: canvasKeys.infiniteRuns(canvasId),
+      });
+
+      for (const [queryKey, data] of queries) {
+        if (!data) {
+          continue;
+        }
+
+        const next = upsertExecutionIntoInfiniteRunsData(data, execution);
+        if (next !== data) {
+          patched = true;
+          queryClient.setQueryData(queryKey, next);
+        }
+      }
+
+      return patched;
     },
     [queryClient, canvasId],
   );
+
+  const invalidateRuns = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.infiniteRuns(canvasId),
+    });
+  }, [queryClient, canvasId]);
 
   const invalidateMemoryEntries = useCallback(() => {
     queryClient.invalidateQueries({
@@ -235,6 +255,9 @@ export function useCanvasWebsocket(
           if (payload && "nodeId" in payload && payload.nodeId) {
             const workflowEvent = payload as CanvasesCanvasEvent;
             nodeExecutionStore.updateNodeEvent(workflowEvent.nodeId!, workflowEvent);
+            if (workflowEvent.root) {
+              invalidateRuns();
+            }
 
             onNodeEvent?.(workflowEvent.nodeId!, data.event);
             onWorkflowEvent?.(workflowEvent, data.event);
@@ -248,7 +271,9 @@ export function useCanvasWebsocket(
             if (execution.nodeId) {
               nodeExecutionStore.updateNodeExecution(execution.nodeId, execution);
 
-              patchExecutionInCache(execution);
+              if (!patchExecutionInCache(execution)) {
+                invalidateRuns();
+              }
 
               if (execution.rootEvent?.id) {
                 queryClient.invalidateQueries({
@@ -264,6 +289,7 @@ export function useCanvasWebsocket(
           if (payload && "nodeId" in payload && payload.nodeId) {
             const queueItem = payload as CanvasesCanvasNodeQueueItem;
             nodeExecutionStore.addNodeQueueItem(queueItem.nodeId!, queueItem);
+            invalidateRuns();
 
             onNodeEvent?.(queueItem.nodeId!, data.event);
           }
@@ -336,6 +362,7 @@ export function useCanvasWebsocket(
       patchRunInCache,
       patchExecutionInCache,
       invalidateMemoryEntries,
+      invalidateRuns,
     ],
   );
 
@@ -421,13 +448,11 @@ export function useCanvasWebsocket(
       return;
     }
 
-    queryClient.invalidateQueries({
-      queryKey: canvasKeys.infiniteRuns(canvasId),
-    });
+    invalidateRuns();
     // Refresh memory in case mutations happened while we were disconnected; we
     // no longer poll, so the websocket is the only push channel.
     invalidateMemoryEntries();
-  }, [queryClient, canvasId, invalidateMemoryEntries]);
+  }, [invalidateRuns, invalidateMemoryEntries]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -1782,6 +1782,7 @@ export function AppPage() {
   const [focusRequest, setFocusRequest] = useState<{
     nodeId: string;
     requestId: number;
+    targetMode: "live" | "runs";
     tab?: "latest" | "settings";
   } | null>(null);
   const handleSidebarChange = useCallback(
@@ -1827,7 +1828,7 @@ export function AppPage() {
   const handleLogNodeSelect = useCallback(
     (nodeId: string) => {
       handleSidebarChange(true, nodeId);
-      setFocusRequest({ nodeId, requestId: Date.now(), tab: "settings" });
+      setFocusRequest({ nodeId, requestId: Date.now(), targetMode: "live", tab: "settings" });
     },
     [handleSidebarChange],
   );
@@ -1835,7 +1836,7 @@ export function AppPage() {
   const handleLogRunNodeSelect = useCallback(
     (nodeId: string) => {
       handleSidebarChange(true, nodeId);
-      setFocusRequest({ nodeId, requestId: Date.now(), tab: "latest" });
+      setFocusRequest({ nodeId, requestId: Date.now(), targetMode: "live", tab: "latest" });
     },
     [handleSidebarChange],
   );
@@ -3778,7 +3779,7 @@ export function AppPage() {
       if (inspectorNodeId) {
         preserveRunDetailNodeOnNextRunChangeRef.current = true;
         setRunDetailNodeId(inspectorNodeId);
-        setFocusRequest({ nodeId: inspectorNodeId, requestId: Date.now(), tab: "latest" });
+        setFocusRequest({ nodeId: inspectorNodeId, requestId: Date.now(), targetMode: "runs", tab: "latest" });
       } else {
         setRunDetailNodeId(null);
       }
@@ -3801,7 +3802,7 @@ export function AppPage() {
       clearDismissedRunDetail();
       preserveRunDetailNodeOnNextRunChangeRef.current = true;
       setRunDetailNodeId(options.nodeId);
-      setFocusRequest({ nodeId: options.nodeId, requestId: Date.now(), tab: "latest" });
+      setFocusRequest({ nodeId: options.nodeId, requestId: Date.now(), targetMode: "runs", tab: "latest" });
       setSearchParams(
         (current) =>
           applyRunInspectionNavigationSearchParams(current, {
@@ -3872,7 +3873,7 @@ export function AppPage() {
   const handleRunNodeDetailNavigate = useCallback(
     (nodeId: string) => {
       handleRunNodeDetailSelection(nodeId);
-      setFocusRequest({ nodeId, requestId: Date.now(), tab: "latest" });
+      setFocusRequest({ nodeId, requestId: Date.now(), targetMode: "runs", tab: "latest" });
     },
     [handleRunNodeDetailSelection],
   );

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -3770,13 +3770,15 @@ export function AppPage() {
   });
 
   const handleSelectRunFromSidebarEvent = useCallback(
-    (runId: string) => {
+    (runId: string, options?: { nodeId?: string }) => {
       exitEditableVersionForRunInspection();
       clearDismissedRunDetail();
-      const inspectorNodeId = searchParams.get("sidebar") === "1" ? searchParams.get("node") : null;
+      const inspectorNodeId =
+        options?.nodeId ?? (searchParams.get("sidebar") === "1" ? searchParams.get("node") : null);
       if (inspectorNodeId) {
         preserveRunDetailNodeOnNextRunChangeRef.current = true;
         setRunDetailNodeId(inspectorNodeId);
+        setFocusRequest({ nodeId: inspectorNodeId, requestId: Date.now(), tab: "latest" });
       } else {
         setRunDetailNodeId(null);
       }

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -143,6 +143,7 @@ import {
 } from "./utils";
 import { actionsFromCapabilities, triggersFromCapabilities } from "@/lib/capabilities";
 import { runPositionAutoSave } from "./runPositionAutoSave";
+import { syncRunInspectionViewportTransition } from "./lib/run-inspection-viewport";
 import {
   clearRunDetailNodeSearchParams,
   getCanvasLogNodesSignature,
@@ -517,8 +518,6 @@ export function AppPage() {
     activateBranch,
   });
 
-  const [canvasFitAllNonce, setCanvasFitAllNonce] = useState(0);
-  const wasRunInspectionModeRef = useRef(false);
   const [runStatusFilters, setRunStatusFilters] = useState<RunStatusFilter[]>([]);
   const runApiFilters = useMemo(
     () => (isRunInspectionMode && selectedRunId ? {} : statusFiltersToApiFilters(runStatusFilters)),
@@ -662,7 +661,7 @@ export function AppPage() {
    */
   const viewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
   const runsViewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
-  const lastRunsViewportKeyRef = useRef<string | null>(null);
+  const lastRunsViewportKeyRef = useRef<"runs" | null>(null);
 
   const [isPositionAutoSaveQueued, setIsPositionAutoSaveQueued] = useState(false);
   const [isAnnotationAutoSaveQueued, setIsAnnotationAutoSaveQueued] = useState(false);
@@ -1668,24 +1667,14 @@ export function AppPage() {
     isSelectedRunVersionLoading,
     isSelectedRunExecutionsLoading: selectedRunExecutionsQuery.isLoading,
   });
-  const runsViewportKey = isRunInspectionMode ? "runs" : null;
-  if (lastRunsViewportKeyRef.current !== runsViewportKey) {
-    if (runsViewportKey) {
-      runsHasFitToViewRef.current = Boolean(viewportRef.current);
-      runsViewportRef.current = viewportRef.current ? { ...viewportRef.current } : undefined;
-    } else {
-      runsHasFitToViewRef.current = false;
-      runsViewportRef.current = undefined;
-    }
-    lastRunsViewportKeyRef.current = runsViewportKey;
-  }
-
-  useEffect(() => {
-    if (wasRunInspectionModeRef.current && !isRunInspectionMode) {
-      setCanvasFitAllNonce((n) => n + 1);
-    }
-    wasRunInspectionModeRef.current = isRunInspectionMode;
-  }, [isRunInspectionMode]);
+  syncRunInspectionViewportTransition({
+    isRunInspectionMode,
+    liveViewportRef: viewportRef,
+    runsViewportRef,
+    liveHasFitToViewRef: hasFitToViewRef,
+    runsHasFitToViewRef,
+    lastRunsViewportKeyRef,
+  });
 
   useEffect(() => {
     if (
@@ -3810,6 +3799,7 @@ export function AppPage() {
       clearDismissedRunDetail();
       preserveRunDetailNodeOnNextRunChangeRef.current = true;
       setRunDetailNodeId(options.nodeId);
+      setFocusRequest({ nodeId: options.nodeId, requestId: Date.now(), tab: "latest" });
       setSearchParams(
         (current) =>
           applyRunInspectionNavigationSearchParams(current, {
@@ -3875,6 +3865,14 @@ export function AppPage() {
       );
     },
     [setRunDetailNodeId, setSearchParams],
+  );
+
+  const handleRunNodeDetailNavigate = useCallback(
+    (nodeId: string) => {
+      handleRunNodeDetailSelection(nodeId);
+      setFocusRequest({ nodeId, requestId: Date.now(), tab: "latest" });
+    },
+    [handleRunNodeDetailSelection],
   );
 
   useStaleRunInspectionUrlCleanup({
@@ -4481,7 +4479,6 @@ export function AppPage() {
           isSidebarOpenRef={isSidebarOpenRef}
           viewportRef={isRunInspectionMode ? runsViewportRef : viewportRef}
           initialFocusNodeId={initialFocusNodeIdRef.current}
-          fitAllRequest={!isRunInspectionMode && canvasFitAllNonce > 0 ? canvasFitAllNonce : null}
           fitAllFocusNodeIds={
             isRunInspectionMode && selectedRun && runCanvasData && runCanvasData.participantNodeIds.length > 0
               ? runCanvasData.participantNodeIds
@@ -4497,7 +4494,7 @@ export function AppPage() {
           runNodeDetailNodeId={runDetailNodeId}
           runNodeDetailCanvasId={canvasId}
           onRunNodeDetailClose={() => handleRunNodeDetailSelection(null)}
-          onRunNodeDetailNavigate={handleRunNodeDetailSelection}
+          onRunNodeDetailNavigate={handleRunNodeDetailNavigate}
           runNodeDetailPaneHeight={runNodeDetailPaneHeight}
           onRunNodeDetailPaneHeightChange={setRunNodeDetailPaneHeight}
           onShowDiff={onShowDiff}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -119,7 +119,7 @@ import { useSpecFileAutosave } from "./useSpecFileAutosave";
 import { buildAppFiles } from "./files/lib/app-files";
 import { useDraftVisualDiff } from "./useDraftVisualDiff";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
-import { getRunCanvasFitKey, useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
+import { useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
 import { useRunsDetailState } from "./useRunsDetailState";
 import { useSidebarEventRunLookup } from "@/hooks/useSidebarEventRunLookup";
 import { useSelectedRunCanvas } from "./useSelectedRunCanvas";
@@ -517,7 +517,6 @@ export function AppPage() {
     activateBranch,
   });
 
-  const [runsFitAllNonce, setRunsFitAllNonce] = useState(0);
   const [canvasFitAllNonce, setCanvasFitAllNonce] = useState(0);
   const wasRunInspectionModeRef = useRef(false);
   const [runStatusFilters, setRunStatusFilters] = useState<RunStatusFilter[]>([]);
@@ -1671,21 +1670,15 @@ export function AppPage() {
   });
   const runsViewportKey = isRunInspectionMode ? "runs" : null;
   if (lastRunsViewportKeyRef.current !== runsViewportKey) {
-    runsHasFitToViewRef.current = false;
-    runsViewportRef.current = undefined;
+    if (runsViewportKey) {
+      runsHasFitToViewRef.current = Boolean(viewportRef.current);
+      runsViewportRef.current = viewportRef.current ? { ...viewportRef.current } : undefined;
+    } else {
+      runsHasFitToViewRef.current = false;
+      runsViewportRef.current = undefined;
+    }
     lastRunsViewportKeyRef.current = runsViewportKey;
   }
-
-  const runCanvasFitKey = useMemo(
-    () => getRunCanvasFitKey({ isRunInspectionMode, selectedRunId, runCanvasData, runCanvasLoading }),
-    [isRunInspectionMode, runCanvasData, runCanvasLoading, selectedRunId],
-  );
-
-  useEffect(() => {
-    if (!isRunInspectionMode) return;
-    if (!runCanvasFitKey) return;
-    setRunsFitAllNonce((n) => n + 1);
-  }, [isRunInspectionMode, runCanvasFitKey]);
 
   useEffect(() => {
     if (wasRunInspectionModeRef.current && !isRunInspectionMode) {
@@ -4488,7 +4481,7 @@ export function AppPage() {
           isSidebarOpenRef={isSidebarOpenRef}
           viewportRef={isRunInspectionMode ? runsViewportRef : viewportRef}
           initialFocusNodeId={initialFocusNodeIdRef.current}
-          fitAllRequest={isRunInspectionMode ? runsFitAllNonce : canvasFitAllNonce > 0 ? canvasFitAllNonce : null}
+          fitAllRequest={!isRunInspectionMode && canvasFitAllNonce > 0 ? canvasFitAllNonce : null}
           fitAllFocusNodeIds={
             isRunInspectionMode && selectedRun && runCanvasData && runCanvasData.participantNodeIds.length > 0
               ? runCanvasData.participantNodeIds

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -4326,7 +4326,7 @@ export function AppPage() {
     initialOpenDetail: openRunDetailOnMount,
     detailDismissedForRunId,
     selectedNodeId: runDetailNodeId,
-    onSelectNode: handleRunNodeDetailSelection,
+    onSelectNode: handleRunNodeDetailNavigate,
     hasNextPage: !!infiniteRunsQuery.hasNextPage,
     isFetchingNextPage: infiniteRunsQuery.isFetchingNextPage,
     onLoadMore: () => infiniteRunsQuery.fetchNextPage(),

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -119,7 +119,7 @@ import { useSpecFileAutosave } from "./useSpecFileAutosave";
 import { buildAppFiles } from "./files/lib/app-files";
 import { useDraftVisualDiff } from "./useDraftVisualDiff";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
-import { useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
+import { getRunCanvasFitKey, useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
 import { useRunsDetailState } from "./useRunsDetailState";
 import { useSidebarEventRunLookup } from "@/hooks/useSidebarEventRunLookup";
 import { useSelectedRunCanvas } from "./useSelectedRunCanvas";
@@ -1676,10 +1676,10 @@ export function AppPage() {
     lastRunsViewportKeyRef.current = runsViewportKey;
   }
 
-  const runCanvasFitKey = useMemo(() => {
-    if (!isRunInspectionMode || !selectedRunId || !runCanvasData) return null;
-    return `${selectedRunId}|${runCanvasData.participantNodeIds.slice().sort().join("|")}`;
-  }, [isRunInspectionMode, selectedRunId, runCanvasData]);
+  const runCanvasFitKey = useMemo(
+    () => getRunCanvasFitKey({ isRunInspectionMode, selectedRunId, runCanvasData, runCanvasLoading }),
+    [isRunInspectionMode, runCanvasData, runCanvasLoading, selectedRunId],
+  );
 
   useEffect(() => {
     if (!isRunInspectionMode) return;

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -3754,6 +3754,7 @@ export function AppPage() {
       exitEditableVersionForRunInspection();
       clearDismissedRunDetail();
       setRunDetailNodeId(null);
+      setFocusRequest(null);
       startTransition(() => {
         setSearchParams((current) => applyRunInspectionNavigationSearchParams(current, { runId }), { replace: true });
       });
@@ -3782,6 +3783,7 @@ export function AppPage() {
         setFocusRequest({ nodeId: inspectorNodeId, requestId: Date.now(), targetMode: "runs", tab: "latest" });
       } else {
         setRunDetailNodeId(null);
+        setFocusRequest(null);
       }
 
       setSearchParams(
@@ -3835,6 +3837,7 @@ export function AppPage() {
 
   const handleClearRunInspection = useCallback(() => {
     setRunDetailNodeId(null);
+    setFocusRequest(null);
     startTransition(() => {
       setSearchParams(
         (current) => {
@@ -3852,6 +3855,10 @@ export function AppPage() {
   const handleRunNodeDetailSelection = useCallback(
     (nodeId: string | null) => {
       setRunDetailNodeId(nodeId);
+      if (!nodeId) {
+        setFocusRequest(null);
+      }
+
       setSearchParams(
         (current) => {
           const next = new URLSearchParams(current);

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -4421,11 +4421,16 @@ export function AppPage() {
         />
         <CanvasPage
           key={canvasRenderKey}
-          // Persist right sidebar in query params
-          initialSidebar={{
-            isOpen: searchParams.get("sidebar") === "1",
-            nodeId: searchParams.get("node") || null,
-          }}
+          // In run inspection, sidebar/node params restore the run detail pane,
+          // not the live node inspector.
+          initialSidebar={
+            isRunInspectionMode
+              ? { isOpen: false, nodeId: null }
+              : {
+                  isOpen: searchParams.get("sidebar") === "1",
+                  nodeId: searchParams.get("node") || null,
+                }
+          }
           onSidebarChange={handleSidebarChange}
           onTriggerModalHostReady={registerTriggerModalHost}
           title={canvas?.metadata?.name || liveCanvas?.metadata?.name || "Canvas"}

--- a/web_src/src/pages/app/lib/run-inspection-viewport.spec.ts
+++ b/web_src/src/pages/app/lib/run-inspection-viewport.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { syncRunInspectionViewportTransition, type CanvasViewport } from "./run-inspection-viewport";
+
+function ref<T>(current: T): { current: T } {
+  return { current };
+}
+
+describe("syncRunInspectionViewportTransition", () => {
+  it("seeds the runs viewport from the current live viewport when entering run inspection", () => {
+    const liveViewportRef = ref<CanvasViewport | undefined>({ x: -100, y: -50, zoom: 0.8 });
+    const runsViewportRef = ref<CanvasViewport | undefined>(undefined);
+    const liveHasFitToViewRef = ref(true);
+    const runsHasFitToViewRef = ref(false);
+    const lastRunsViewportKeyRef = ref<"runs" | null>(null);
+
+    syncRunInspectionViewportTransition({
+      isRunInspectionMode: true,
+      liveViewportRef,
+      runsViewportRef,
+      liveHasFitToViewRef,
+      runsHasFitToViewRef,
+      lastRunsViewportKeyRef,
+    });
+
+    expect(runsViewportRef.current).toEqual({ x: -100, y: -50, zoom: 0.8 });
+    expect(runsViewportRef.current).not.toBe(liveViewportRef.current);
+    expect(runsHasFitToViewRef.current).toBe(true);
+    expect(lastRunsViewportKeyRef.current).toBe("runs");
+  });
+
+  it("preserves the current runs viewport as the live viewport when leaving run inspection", () => {
+    const liveViewportRef = ref<CanvasViewport | undefined>({ x: -100, y: -50, zoom: 0.8 });
+    const runsViewportRef = ref<CanvasViewport | undefined>({ x: -320, y: -180, zoom: 1.1 });
+    const liveHasFitToViewRef = ref(false);
+    const runsHasFitToViewRef = ref(true);
+    const lastRunsViewportKeyRef = ref<"runs" | null>("runs");
+
+    syncRunInspectionViewportTransition({
+      isRunInspectionMode: false,
+      liveViewportRef,
+      runsViewportRef,
+      liveHasFitToViewRef,
+      runsHasFitToViewRef,
+      lastRunsViewportKeyRef,
+    });
+
+    expect(liveViewportRef.current).toEqual({ x: -320, y: -180, zoom: 1.1 });
+    expect(runsViewportRef.current).toBeUndefined();
+    expect(liveHasFitToViewRef.current).toBe(true);
+    expect(runsHasFitToViewRef.current).toBe(false);
+    expect(lastRunsViewportKeyRef.current).toBeNull();
+  });
+});

--- a/web_src/src/pages/app/lib/run-inspection-viewport.ts
+++ b/web_src/src/pages/app/lib/run-inspection-viewport.ts
@@ -1,0 +1,50 @@
+export type CanvasViewport = {
+  x: number;
+  y: number;
+  zoom: number;
+};
+
+type MutableRef<T> = {
+  current: T;
+};
+
+type RunsViewportKey = "runs" | null;
+
+export function syncRunInspectionViewportTransition({
+  isRunInspectionMode,
+  liveViewportRef,
+  runsViewportRef,
+  liveHasFitToViewRef,
+  runsHasFitToViewRef,
+  lastRunsViewportKeyRef,
+}: {
+  isRunInspectionMode: boolean;
+  liveViewportRef: MutableRef<CanvasViewport | undefined>;
+  runsViewportRef: MutableRef<CanvasViewport | undefined>;
+  liveHasFitToViewRef: MutableRef<boolean>;
+  runsHasFitToViewRef: MutableRef<boolean>;
+  lastRunsViewportKeyRef: MutableRef<RunsViewportKey>;
+}) {
+  const nextKey: RunsViewportKey = isRunInspectionMode ? "runs" : null;
+  const previousKey = lastRunsViewportKeyRef.current;
+  if (previousKey === nextKey) {
+    return;
+  }
+
+  if (nextKey === "runs") {
+    const liveViewport = liveViewportRef.current;
+    runsHasFitToViewRef.current = Boolean(liveViewport);
+    runsViewportRef.current = liveViewport ? { ...liveViewport } : undefined;
+    lastRunsViewportKeyRef.current = nextKey;
+    return;
+  }
+
+  if (previousKey === "runs" && runsViewportRef.current) {
+    liveViewportRef.current = { ...runsViewportRef.current };
+    liveHasFitToViewRef.current = true;
+  }
+
+  runsHasFitToViewRef.current = false;
+  runsViewportRef.current = undefined;
+  lastRunsViewportKeyRef.current = nextKey;
+}

--- a/web_src/src/pages/app/useRunCanvasData.spec.ts
+++ b/web_src/src/pages/app/useRunCanvasData.spec.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { CanvasesCanvasNodeExecution, CanvasesCanvasRun } from "@/api-client";
+import { getRunCanvasFitKey, mergeRunExecutionsForCanvas, type RunCanvasData } from "./useRunCanvasData";
+
+function makeRunExecutionRef(id: string, nodeId: string): NonNullable<CanvasesCanvasRun["executions"]>[number] {
+  return {
+    id,
+    nodeId,
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+  };
+}
+
+function makeFullExecution(id: string, nodeId: string): CanvasesCanvasNodeExecution {
+  return {
+    id,
+    nodeId,
+    canvasId: "canvas-1",
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    outputs: { result: "ok" },
+  };
+}
+
+describe("mergeRunExecutionsForCanvas", () => {
+  it("uses full executions when the selected run only has summary data", () => {
+    const executions = mergeRunExecutionsForCanvas(
+      [],
+      [makeFullExecution("execution-1", "trigger-node"), makeFullExecution("execution-2", "selected-node")],
+    );
+
+    expect(executions.map((execution) => execution.nodeId)).toEqual(["trigger-node", "selected-node"]);
+  });
+
+  it("keeps summary execution order and appends full executions missing from the summary", () => {
+    const executions = mergeRunExecutionsForCanvas(
+      [makeRunExecutionRef("execution-1", "trigger-node")],
+      [makeFullExecution("execution-1", "trigger-node"), makeFullExecution("execution-2", "selected-node")],
+    );
+
+    expect(executions.map((execution) => execution.id)).toEqual(["execution-1", "execution-2"]);
+    expect(executions.map((execution) => execution.nodeId)).toEqual(["trigger-node", "selected-node"]);
+    expect(executions[0].outputs).toEqual({ result: "ok" });
+  });
+
+  it("prefers full execution fields when summary and full executions conflict", () => {
+    const executions = mergeRunExecutionsForCanvas(
+      [
+        {
+          ...makeRunExecutionRef("execution-1", "trigger-node"),
+          result: "RESULT_FAILED",
+          resultMessage: "summary result",
+        },
+      ],
+      [
+        {
+          ...makeFullExecution("execution-1", "trigger-node"),
+          result: "RESULT_PASSED",
+          resultMessage: "full result",
+        },
+      ],
+    );
+
+    expect(executions[0]).toMatchObject({
+      id: "execution-1",
+      result: "RESULT_PASSED",
+      resultMessage: "full result",
+      outputs: { result: "ok" },
+    });
+  });
+
+  it("preserves the relative order of executions without ids", () => {
+    const executions = mergeRunExecutionsForCanvas(
+      [{ nodeId: "anonymous-before" }, makeRunExecutionRef("execution-1", "identified-node")],
+      [{ nodeId: "anonymous-after" }],
+    );
+
+    expect(executions.map((execution) => execution.nodeId)).toEqual([
+      "anonymous-before",
+      "identified-node",
+      "anonymous-after",
+    ]);
+  });
+});
+
+describe("getRunCanvasFitKey", () => {
+  const runCanvasData: RunCanvasData = {
+    nodes: [],
+    edges: [],
+    participantNodeIds: ["selected-node", "trigger-node"],
+  };
+
+  it("does not request a fit outside run inspection", () => {
+    expect(
+      getRunCanvasFitKey({
+        isRunInspectionMode: false,
+        selectedRunId: "run-1",
+        runCanvasData,
+        runCanvasLoading: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not request a fit without a selected run", () => {
+    expect(
+      getRunCanvasFitKey({
+        isRunInspectionMode: true,
+        selectedRunId: null,
+        runCanvasData,
+        runCanvasLoading: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not request a fit without run canvas data", () => {
+    expect(
+      getRunCanvasFitKey({
+        isRunInspectionMode: true,
+        selectedRunId: "run-1",
+        runCanvasData: null,
+        runCanvasLoading: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not request a run canvas fit while execution data is loading", () => {
+    expect(
+      getRunCanvasFitKey({
+        isRunInspectionMode: true,
+        selectedRunId: "run-1",
+        runCanvasData,
+        runCanvasLoading: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("builds a stable fit key after the run canvas finishes loading", () => {
+    expect(
+      getRunCanvasFitKey({
+        isRunInspectionMode: true,
+        selectedRunId: "run-1",
+        runCanvasData,
+        runCanvasLoading: false,
+      }),
+    ).toBe("run-1|selected-node|trigger-node");
+  });
+});

--- a/web_src/src/pages/app/useRunCanvasData.spec.ts
+++ b/web_src/src/pages/app/useRunCanvasData.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CanvasesCanvasNodeExecution, CanvasesCanvasRun } from "@/api-client";
-import { getRunCanvasFitKey, mergeRunExecutionsForCanvas, type RunCanvasData } from "./useRunCanvasData";
+import { mergeRunExecutionsForCanvas } from "./useRunCanvasData";
 
 function makeRunExecutionRef(id: string, nodeId: string): NonNullable<CanvasesCanvasRun["executions"]>[number] {
   return {
@@ -80,68 +80,5 @@ describe("mergeRunExecutionsForCanvas", () => {
       "identified-node",
       "anonymous-after",
     ]);
-  });
-});
-
-describe("getRunCanvasFitKey", () => {
-  const runCanvasData: RunCanvasData = {
-    nodes: [],
-    edges: [],
-    participantNodeIds: ["selected-node", "trigger-node"],
-  };
-
-  it("does not request a fit outside run inspection", () => {
-    expect(
-      getRunCanvasFitKey({
-        isRunInspectionMode: false,
-        selectedRunId: "run-1",
-        runCanvasData,
-        runCanvasLoading: false,
-      }),
-    ).toBeNull();
-  });
-
-  it("does not request a fit without a selected run", () => {
-    expect(
-      getRunCanvasFitKey({
-        isRunInspectionMode: true,
-        selectedRunId: null,
-        runCanvasData,
-        runCanvasLoading: false,
-      }),
-    ).toBeNull();
-  });
-
-  it("does not request a fit without run canvas data", () => {
-    expect(
-      getRunCanvasFitKey({
-        isRunInspectionMode: true,
-        selectedRunId: "run-1",
-        runCanvasData: null,
-        runCanvasLoading: false,
-      }),
-    ).toBeNull();
-  });
-
-  it("does not request a run canvas fit while execution data is loading", () => {
-    expect(
-      getRunCanvasFitKey({
-        isRunInspectionMode: true,
-        selectedRunId: "run-1",
-        runCanvasData,
-        runCanvasLoading: true,
-      }),
-    ).toBeNull();
-  });
-
-  it("builds a stable fit key after the run canvas finishes loading", () => {
-    expect(
-      getRunCanvasFitKey({
-        isRunInspectionMode: true,
-        selectedRunId: "run-1",
-        runCanvasData,
-        runCanvasLoading: false,
-      }),
-    ).toBe("run-1|selected-node|trigger-node");
   });
 });

--- a/web_src/src/pages/app/useRunCanvasData.ts
+++ b/web_src/src/pages/app/useRunCanvasData.ts
@@ -95,21 +95,6 @@ export function mergeRunExecutionsForCanvas(
   });
 }
 
-export function getRunCanvasFitKey({
-  isRunInspectionMode,
-  selectedRunId,
-  runCanvasData,
-  runCanvasLoading,
-}: {
-  isRunInspectionMode: boolean;
-  selectedRunId: string | null;
-  runCanvasData: RunCanvasData | null;
-  runCanvasLoading: boolean;
-}): string | null {
-  if (!isRunInspectionMode || !selectedRunId || !runCanvasData || runCanvasLoading) return null;
-  return `${selectedRunId}|${runCanvasData.participantNodeIds.slice().sort().join("|")}`;
-}
-
 export function useRunCanvasData({
   isRunInspectionMode,
   selectedRun,

--- a/web_src/src/pages/app/useRunCanvasData.ts
+++ b/web_src/src/pages/app/useRunCanvasData.ts
@@ -41,11 +41,74 @@ type UseRunCanvasPresentationParams = {
   isSelectedRunExecutionsLoading: boolean;
 };
 
-type RunCanvasData = {
+export type RunCanvasData = {
   nodes: CanvasNode[];
   edges: CanvasEdge[];
   participantNodeIds: string[];
 };
+
+type RunExecutionRef = NonNullable<CanvasesCanvasRun["executions"]>[number];
+type OrderedRunExecution =
+  | { kind: "identified"; id: string }
+  | { kind: "anonymous"; execution: CanvasesCanvasNodeExecution };
+
+export function mergeRunExecutionsForCanvas(
+  runExecutions: RunExecutionRef[] = [],
+  fullExecutions: CanvasesCanvasNodeExecution[] = [],
+): CanvasesCanvasNodeExecution[] {
+  const identifiedExecutions = new Map<string, CanvasesCanvasNodeExecution>();
+  const orderedExecutions: OrderedRunExecution[] = [];
+
+  const appendExecution = (execution: RunExecutionRef | CanvasesCanvasNodeExecution): void => {
+    if (!execution.id) {
+      orderedExecutions.push({ kind: "anonymous", execution });
+      return;
+    }
+
+    if (!identifiedExecutions.has(execution.id)) {
+      identifiedExecutions.set(execution.id, execution);
+      orderedExecutions.push({ kind: "identified", id: execution.id });
+    }
+  };
+
+  runExecutions.forEach(appendExecution);
+
+  for (const execution of fullExecutions) {
+    if (!execution.id) {
+      orderedExecutions.push({ kind: "anonymous", execution });
+      continue;
+    }
+
+    const existing = identifiedExecutions.get(execution.id);
+    if (existing) {
+      identifiedExecutions.set(execution.id, { ...existing, ...execution });
+      continue;
+    }
+
+    identifiedExecutions.set(execution.id, execution);
+    orderedExecutions.push({ kind: "identified", id: execution.id });
+  }
+
+  return orderedExecutions.map((execution) => {
+    if (execution.kind === "anonymous") return execution.execution;
+    return identifiedExecutions.get(execution.id)!;
+  });
+}
+
+export function getRunCanvasFitKey({
+  isRunInspectionMode,
+  selectedRunId,
+  runCanvasData,
+  runCanvasLoading,
+}: {
+  isRunInspectionMode: boolean;
+  selectedRunId: string | null;
+  runCanvasData: RunCanvasData | null;
+  runCanvasLoading: boolean;
+}): string | null {
+  if (!isRunInspectionMode || !selectedRunId || !runCanvasData || runCanvasLoading) return null;
+  return `${selectedRunId}|${runCanvasData.participantNodeIds.slice().sort().join("|")}`;
+}
 
 export function useRunCanvasData({
   isRunInspectionMode,
@@ -80,11 +143,12 @@ export function useRunCanvasData({
     const runNodeIds = new Set<string>();
     const nodeEventsMap: Record<string, CanvasesCanvasEvent[]> = {};
     const nodeExecutionsMap: Record<string, CanvasesCanvasNodeExecution[]> = {};
+    const runExecutions = mergeRunExecutionsForCanvas(selectedRun.executions, selectedRunFullExecutions);
     if (selectedRun.rootEvent?.nodeId) {
       runNodeIds.add(selectedRun.rootEvent.nodeId);
       nodeEventsMap[selectedRun.rootEvent.nodeId] = [selectedRun.rootEvent as CanvasesCanvasEvent];
     }
-    for (const execution of selectedRun.executions || []) {
+    for (const execution of runExecutions) {
       if (!execution.nodeId) continue;
       runNodeIds.add(execution.nodeId);
       if (!nodeExecutionsMap[execution.nodeId]) {

--- a/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
@@ -298,6 +298,27 @@ describe("CanvasPage run inspection", () => {
       expect(fitViewMock).toHaveBeenCalledWith({ nodes: [runNode], duration: 500, maxZoom: 1.2 });
     });
     expect(setViewportMock).toHaveBeenCalledWith(viewportRef.current);
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          isRunInspectionMode
+          nodes={[runNode]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+          hasFitToViewRef={hasFitToViewRef}
+          viewportRef={viewportRef}
+          focusRequest={{ ...focusRequest }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
   });
 
   it("refits when leaving run inspection with the same fit request nonce", () => {

--- a/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
@@ -3,15 +3,17 @@ import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fitViewMock, getNodesMock, reactFlowPropsRef } = vi.hoisted(() => ({
+const { fitViewMock, getNodesMock, reactFlowPropsRef, setViewportMock } = vi.hoisted(() => ({
   fitViewMock: vi.fn().mockResolvedValue(true),
   getNodesMock: vi.fn<() => Array<{ id: string; position: { x: number; y: number } }>>(() => []),
   reactFlowPropsRef: {
     current: null as null | {
       nodes?: unknown;
       onPaneClick?: (...args: unknown[]) => unknown;
+      onInit?: (instance: { setViewport: (viewport: { x: number; y: number; zoom: number }) => void }) => unknown;
     },
   },
+  setViewportMock: vi.fn(),
 }));
 
 vi.mock("@/sentry", () => ({
@@ -39,7 +41,7 @@ vi.mock("@xyflow/react", () => ({
     fitView: fitViewMock,
     screenToFlowPosition: vi.fn((position) => position),
     getViewport: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
-    setViewport: vi.fn(),
+    setViewport: setViewportMock,
     getInternalNode: vi.fn(),
     zoomTo: vi.fn(),
     zoomIn: vi.fn(),
@@ -99,6 +101,7 @@ describe("CanvasPage run inspection", () => {
     fitViewMock.mockResolvedValue(true);
     getNodesMock.mockReset();
     getNodesMock.mockReturnValue([]);
+    setViewportMock.mockClear();
     globalThis.ResizeObserver = class {
       observe() {}
       unobserve() {}
@@ -189,6 +192,45 @@ describe("CanvasPage run inspection", () => {
 
     expect(fitViewMock).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
+  });
+
+  it("restores an existing run viewport on init without fitting all nodes", () => {
+    const hasFitToViewRef = { current: true };
+    const viewportRef = { current: { x: -240, y: -120, zoom: 0.75 } };
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          isRunInspectionMode
+          nodes={[
+            {
+              id: "run-node-1",
+              position: { x: 0, y: 0 },
+              data: {
+                label: "Run 1",
+                state: "pending",
+                type: "component",
+              },
+            },
+          ]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+          hasFitToViewRef={hasFitToViewRef}
+          viewportRef={viewportRef}
+        />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: setViewportMock });
+    });
+
+    expect(setViewportMock).toHaveBeenCalledWith({ x: -240, y: -120, zoom: 0.75 });
+    expect(fitViewMock).not.toHaveBeenCalled();
   });
 
   it("refits when leaving run inspection with the same fit request nonce", () => {

--- a/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
@@ -233,6 +233,63 @@ describe("CanvasPage run inspection", () => {
     expect(fitViewMock).not.toHaveBeenCalled();
   });
 
+  it("focuses a run node when the node appears after the focus request", async () => {
+    const hasFitToViewRef = { current: true };
+    const focusRequest = { nodeId: "run-node-1", requestId: 1, tab: "latest" as const };
+    getNodesMock.mockReturnValue([]);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          isRunInspectionMode
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+          hasFitToViewRef={hasFitToViewRef}
+          focusRequest={focusRequest}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(fitViewMock).not.toHaveBeenCalled();
+
+    const runNode = {
+      id: "run-node-1",
+      position: { x: 0, y: 0 },
+      data: {
+        label: "Run 1",
+        state: "pending",
+        type: "component",
+      },
+    };
+
+    getNodesMock.mockReturnValue([runNode]);
+    rerender(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          isRunInspectionMode
+          nodes={[runNode]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+          hasFitToViewRef={hasFitToViewRef}
+          focusRequest={focusRequest}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fitViewMock).toHaveBeenCalledWith({ nodes: [runNode], duration: 500, maxZoom: 1.2 });
+    });
+  });
+
   it("refits when leaving run inspection with the same fit request nonce", () => {
     vi.useFakeTimers();
     const hasFitToViewRef = { current: true };

--- a/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
@@ -235,6 +235,7 @@ describe("CanvasPage run inspection", () => {
 
   it("focuses a run node when the node appears after the focus request", async () => {
     const hasFitToViewRef = { current: true };
+    const viewportRef = { current: { x: 10, y: 20, zoom: 0.8 } };
     const focusRequest = { nodeId: "run-node-1", requestId: 1, tab: "latest" as const };
     getNodesMock.mockReturnValue([]);
 
@@ -250,6 +251,7 @@ describe("CanvasPage run inspection", () => {
           isEditing={false}
           activeCanvasVersionId="live-version"
           hasFitToViewRef={hasFitToViewRef}
+          viewportRef={viewportRef}
           focusRequest={focusRequest}
         />
       </MemoryRouter>,
@@ -280,14 +282,22 @@ describe("CanvasPage run inspection", () => {
           isEditing={false}
           activeCanvasVersionId="live-version"
           hasFitToViewRef={hasFitToViewRef}
+          viewportRef={viewportRef}
           focusRequest={focusRequest}
         />
       </MemoryRouter>,
     );
 
+    expect(fitViewMock).not.toHaveBeenCalled();
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: setViewportMock });
+    });
+
     await waitFor(() => {
       expect(fitViewMock).toHaveBeenCalledWith({ nodes: [runNode], duration: 500, maxZoom: 1.2 });
     });
+    expect(setViewportMock).toHaveBeenCalledWith(viewportRef.current);
   });
 
   it("refits when leaving run inspection with the same fit request nonce", () => {

--- a/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
@@ -236,7 +236,7 @@ describe("CanvasPage run inspection", () => {
   it("focuses a run node when the node appears after the focus request", async () => {
     const hasFitToViewRef = { current: true };
     const viewportRef = { current: { x: 10, y: 20, zoom: 0.8 } };
-    const focusRequest = { nodeId: "run-node-1", requestId: 1, tab: "latest" as const };
+    const focusRequest = { nodeId: "run-node-1", requestId: 1, targetMode: "runs" as const, tab: "latest" as const };
     getNodesMock.mockReturnValue([]);
 
     const { rerender } = render(
@@ -319,6 +319,43 @@ describe("CanvasPage run inspection", () => {
     );
 
     expect(fitViewMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a run node focus request while the live canvas is still mounted", () => {
+    const hasFitToViewRef = { current: true };
+    const runFocusRequest = { nodeId: "run-node-1", requestId: 1, targetMode: "runs" as const, tab: "latest" as const };
+    const runNode = {
+      id: "run-node-1",
+      position: { x: 0, y: 0 },
+      data: {
+        label: "Run 1",
+        state: "pending",
+        type: "component",
+      },
+    };
+    getNodesMock.mockReturnValue([runNode]);
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={[runNode]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+          hasFitToViewRef={hasFitToViewRef}
+          focusRequest={runFocusRequest}
+        />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: setViewportMock });
+    });
+
+    expect(fitViewMock).not.toHaveBeenCalled();
   });
 
   it("refits when leaving run inspection with the same fit request nonce", () => {

--- a/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.spec.tsx
@@ -3,9 +3,10 @@ import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fitViewMock, getNodesMock, reactFlowPropsRef, setViewportMock } = vi.hoisted(() => ({
+const { fitViewMock, getNodesMock, getViewportMock, reactFlowPropsRef, setViewportMock } = vi.hoisted(() => ({
   fitViewMock: vi.fn().mockResolvedValue(true),
   getNodesMock: vi.fn<() => Array<{ id: string; position: { x: number; y: number } }>>(() => []),
+  getViewportMock: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
   reactFlowPropsRef: {
     current: null as null | {
       nodes?: unknown;
@@ -40,7 +41,7 @@ vi.mock("@xyflow/react", () => ({
   useReactFlow: vi.fn(() => ({
     fitView: fitViewMock,
     screenToFlowPosition: vi.fn((position) => position),
-    getViewport: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+    getViewport: getViewportMock,
     setViewport: setViewportMock,
     getInternalNode: vi.fn(),
     zoomTo: vi.fn(),
@@ -101,6 +102,8 @@ describe("CanvasPage run inspection", () => {
     fitViewMock.mockResolvedValue(true);
     getNodesMock.mockReset();
     getNodesMock.mockReturnValue([]);
+    getViewportMock.mockReset();
+    getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
     setViewportMock.mockClear();
     globalThis.ResizeObserver = class {
       observe() {}
@@ -235,9 +238,12 @@ describe("CanvasPage run inspection", () => {
 
   it("focuses a run node when the node appears after the focus request", async () => {
     const hasFitToViewRef = { current: true };
-    const viewportRef = { current: { x: 10, y: 20, zoom: 0.8 } };
+    const initialViewport = { x: 10, y: 20, zoom: 0.8 };
+    const viewportRef = { current: initialViewport };
+    const focusedViewport = { x: -120, y: -80, zoom: 1.2 };
     const focusRequest = { nodeId: "run-node-1", requestId: 1, targetMode: "runs" as const, tab: "latest" as const };
     getNodesMock.mockReturnValue([]);
+    getViewportMock.mockReturnValue(focusedViewport);
 
     const { rerender } = render(
       <MemoryRouter>
@@ -297,7 +303,10 @@ describe("CanvasPage run inspection", () => {
     await waitFor(() => {
       expect(fitViewMock).toHaveBeenCalledWith({ nodes: [runNode], duration: 500, maxZoom: 1.2 });
     });
-    expect(setViewportMock).toHaveBeenCalledWith(viewportRef.current);
+    await waitFor(() => {
+      expect(viewportRef.current).toEqual(focusedViewport);
+    });
+    expect(setViewportMock).toHaveBeenCalledWith(initialViewport);
     expect(fitViewMock).toHaveBeenCalledTimes(1);
 
     rerender(

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2408,13 +2408,16 @@ function CanvasContent({
       : "Auto-layout on add is disabled. Click to enable connected-graph layout for newly added nodes.");
   const suppressNextPaneClickRef = useRef(false);
   const suppressNextPaneClickTimeoutRef = useRef<number | null>(null);
+  const runCanvasNodeIdsKey = useMemo(() => state.nodes.map((node) => node.id).join("|"), [state.nodes]);
 
   useEffect(() => {
     if (!focusRequest) {
       return;
     }
 
-    const targetNode = stateRef.current.nodes?.find((node) => node.id === focusRequest.nodeId);
+    const targetNode =
+      getNodes().find((node) => node.id === focusRequest.nodeId) ??
+      stateRef.current.nodes?.find((node) => node.id === focusRequest.nodeId);
     if (!targetNode) {
       return;
     }
@@ -2426,9 +2429,7 @@ function CanvasContent({
       })),
     );
     fitView({ nodes: [targetNode], duration: 500, maxZoom: 1.2 });
-  }, [focusRequest, fitView]);
-
-  const runCanvasNodeIdsKey = useMemo(() => state.nodes.map((node) => node.id).join("|"), [state.nodes]);
+  }, [focusRequest, fitView, getNodes, runCanvasNodeIdsKey]);
 
   useEffect(() => {
     if (!isRunInspectionMode) {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -294,7 +294,7 @@ export interface CanvasPageProps {
   onRunItemOpen?: (nodeId: string | undefined, executionStatus: string, errorMessage?: string) => void;
   resolveRunIdForSidebarEvent?: (event: SidebarEvent) => string | null;
   fetchRunIdForSidebarEvent?: (event: SidebarEvent) => Promise<string | null>;
-  onSelectRunFromSidebarEvent?: (runId: string) => void;
+  onSelectRunFromSidebarEvent?: (runId: string, options?: { nodeId?: string }) => void;
 
   // Building blocks for adding new nodes
   buildingBlocks: BuildingBlockCategory[];
@@ -1596,7 +1596,7 @@ function Sidebar({
   onRunItemOpen?: (nodeId: string | undefined, executionStatus: string, errorMessage?: string) => void;
   resolveRunId?: (event: SidebarEvent) => string | null;
   fetchRunId?: (event: SidebarEvent) => Promise<string | null>;
-  onSelectRun?: (runId: string) => void;
+  onSelectRun?: (runId: string, options?: { nodeId?: string }) => void;
   getAllHistoryEvents?: (nodeId: string) => SidebarEvent[];
   onLoadMoreHistory?: (nodeId: string) => void;
   getHasMoreHistory?: (nodeId: string) => boolean;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2452,8 +2452,25 @@ function CanvasContent({
         selected: node.id === focusRequest.nodeId,
       })),
     );
-    fitView({ nodes: [targetNode], duration: 500, maxZoom: 1.2 });
-  }, [focusRequest, fitView, getNodes, hasReactFlowInitialized, isRunInspectionMode, runCanvasNodeIdsKey]);
+    void fitView({ nodes: [targetNode], duration: 500, maxZoom: 1.2 }).then(
+      () => {
+        const nextViewport = getViewport();
+        viewportRef.current = nextViewport;
+        reportZoom(nextViewport.zoom);
+      },
+      () => undefined,
+    );
+  }, [
+    focusRequest,
+    fitView,
+    getNodes,
+    getViewport,
+    hasReactFlowInitialized,
+    isRunInspectionMode,
+    reportZoom,
+    runCanvasNodeIdsKey,
+    viewportRef,
+  ]);
 
   useEffect(() => {
     if (!isRunInspectionMode) {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -124,6 +124,7 @@ export interface CanvasEdge extends ReactFlowEdge {
 interface FocusRequest {
   nodeId: string;
   requestId: number;
+  targetMode: "live" | "runs";
   tab?: "latest" | "settings";
 }
 
@@ -827,8 +828,18 @@ function CanvasPage(props: CanvasPageProps) {
       return;
     }
 
+    const expectedTargetMode = props.isRunInspectionMode ? "runs" : "live";
+    if (props.focusRequest.targetMode !== expectedTargetMode) {
+      return;
+    }
+
     setCurrentTab(props.focusRequest.tab);
-  }, [props.focusRequest?.requestId, props.focusRequest?.tab]);
+  }, [
+    props.focusRequest?.requestId,
+    props.focusRequest?.tab,
+    props.focusRequest?.targetMode,
+    props.isRunInspectionMode,
+  ]);
 
   // Get editing data for the currently selected node
   const { getNodeEditData } = props;
@@ -2417,7 +2428,12 @@ function CanvasContent({
       return;
     }
 
-    const focusRequestKey = `${focusRequest.requestId}:${focusRequest.nodeId}`;
+    const expectedTargetMode = isRunInspectionMode ? "runs" : "live";
+    if (focusRequest.targetMode !== expectedTargetMode) {
+      return;
+    }
+
+    const focusRequestKey = `${focusRequest.targetMode}:${focusRequest.requestId}:${focusRequest.nodeId}`;
     if (handledFocusRequestKeyRef.current === focusRequestKey) {
       return;
     }
@@ -2437,7 +2453,7 @@ function CanvasContent({
       })),
     );
     fitView({ nodes: [targetNode], duration: 500, maxZoom: 1.2 });
-  }, [focusRequest, fitView, getNodes, hasReactFlowInitialized, runCanvasNodeIdsKey]);
+  }, [focusRequest, fitView, getNodes, hasReactFlowInitialized, isRunInspectionMode, runCanvasNodeIdsKey]);
 
   useEffect(() => {
     if (!isRunInspectionMode) {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2409,10 +2409,16 @@ function CanvasContent({
       : "Auto-layout on add is disabled. Click to enable connected-graph layout for newly added nodes.");
   const suppressNextPaneClickRef = useRef(false);
   const suppressNextPaneClickTimeoutRef = useRef<number | null>(null);
+  const handledFocusRequestKeyRef = useRef<string | null>(null);
   const runCanvasNodeIdsKey = useMemo(() => state.nodes.map((node) => node.id).join("|"), [state.nodes]);
 
   useEffect(() => {
     if (!focusRequest || !hasReactFlowInitialized) {
+      return;
+    }
+
+    const focusRequestKey = `${focusRequest.requestId}:${focusRequest.nodeId}`;
+    if (handledFocusRequestKeyRef.current === focusRequestKey) {
       return;
     }
 
@@ -2423,6 +2429,7 @@ function CanvasContent({
       return;
     }
 
+    handledFocusRequestKeyRef.current = focusRequestKey;
     stateRef.current.setNodes((nodes) =>
       nodes.map((node) => ({
         ...node,

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2173,6 +2173,7 @@ function CanvasContent({
 
   // Track if we've initialized to prevent flicker
   const [isInitialized, setIsInitialized] = useState(hasFitToViewRef.current);
+  const [hasReactFlowInitialized, setHasReactFlowInitialized] = useState(false);
   const lastFitAllRequestRef = useRef<{ nonce: number; runMode: boolean } | null>(null);
   const [isLogSidebarOpen, setIsLogSidebarOpen] = useState(() => {
     const saved = localStorage.getItem(CONSOLE_OPEN_STORAGE_KEY);
@@ -2411,7 +2412,7 @@ function CanvasContent({
   const runCanvasNodeIdsKey = useMemo(() => state.nodes.map((node) => node.id).join("|"), [state.nodes]);
 
   useEffect(() => {
-    if (!focusRequest) {
+    if (!focusRequest || !hasReactFlowInitialized) {
       return;
     }
 
@@ -2429,7 +2430,7 @@ function CanvasContent({
       })),
     );
     fitView({ nodes: [targetNode], duration: 500, maxZoom: 1.2 });
-  }, [focusRequest, fitView, getNodes, runCanvasNodeIdsKey]);
+  }, [focusRequest, fitView, getNodes, hasReactFlowInitialized, runCanvasNodeIdsKey]);
 
   useEffect(() => {
     if (!isRunInspectionMode) {
@@ -2574,12 +2575,14 @@ function CanvasContent({
 
         hasFitToViewRef.current = true;
         setIsInitialized(true);
+        setHasReactFlowInitialized(true);
       } else {
         // If we've already fit to view once and have a stored viewport, restore it
         if (viewportRef.current) {
           reactFlowInstance.setViewport(viewportRef.current);
         }
         setIsInitialized(true);
+        setHasReactFlowInitialized(true);
       }
     },
     [fitView, getViewport, reportZoom, hasFitToViewRef, viewportRef, initialFocusNodeId],

--- a/web_src/src/ui/componentSidebar/CompactSidebarEventRow.spec.tsx
+++ b/web_src/src/ui/componentSidebar/CompactSidebarEventRow.spec.tsx
@@ -57,6 +57,17 @@ describe("CompactSidebarEventRow", () => {
     expect(onSelectRun).toHaveBeenCalledWith("run-1");
   });
 
+  it("selects the run with node context when the row belongs to a selected node", async () => {
+    const user = userEvent.setup();
+    const onSelectRun = vi.fn();
+
+    renderRow({ runId: "run-1", selectionNodeId: "node-1", onSelectRun });
+
+    await user.click(screen.getByTestId("compact-sidebar-event-row-select"));
+
+    expect(onSelectRun).toHaveBeenCalledWith("run-1", { nodeId: "node-1" });
+  });
+
   it("fetches the run id on click when the row is not pre-resolved", async () => {
     const user = userEvent.setup();
     const onSelectRun = vi.fn();

--- a/web_src/src/ui/componentSidebar/CompactSidebarEventRow.tsx
+++ b/web_src/src/ui/componentSidebar/CompactSidebarEventRow.tsx
@@ -12,9 +12,10 @@ import { SidebarEventActionsMenu } from "./SidebarEventItem/SidebarEventActionsM
 
 interface CompactSidebarEventRowProps {
   event: SidebarEvent;
+  selectionNodeId?: string;
   runId?: string | null;
   fetchRunId?: (event: SidebarEvent) => Promise<string | null>;
-  onSelectRun?: (runId: string) => void;
+  onSelectRun?: (runId: string, options?: { nodeId?: string }) => void;
   onCancelQueueItem?: (id: string) => void;
   onCancelExecution?: (executionId: string) => void;
   onReEmit?: (nodeId: string, eventOrExecutionId: string) => void;
@@ -30,6 +31,7 @@ function isRunNavigableEvent(event: SidebarEvent): boolean {
 
 export function CompactSidebarEventRow({
   event,
+  selectionNodeId,
   runId,
   fetchRunId,
   onSelectRun,
@@ -71,6 +73,16 @@ export function CompactSidebarEventRow({
   const showActionsMenu = showCancel || showReEmit;
   const isSelectable = Boolean(onSelectRun && isRunNavigableEvent(event) && (runId || fetchRunId));
   const runHref = organizationId && appId && runId ? appPath(organizationId, appId, `?run=${runId}`) : null;
+  const runSelectionNodeId = event.nodeId || selectionNodeId;
+
+  const selectResolvedRun = (selectedRunId: string) => {
+    if (runSelectionNodeId) {
+      onSelectRun?.(selectedRunId, { nodeId: runSelectionNodeId });
+      return;
+    }
+
+    onSelectRun?.(selectedRunId);
+  };
 
   const selectRun = async () => {
     if (!onSelectRun || isResolvingRef.current) {
@@ -80,7 +92,7 @@ export function CompactSidebarEventRow({
     isResolvingRef.current = true;
     try {
       if (runId) {
-        onSelectRun(runId);
+        selectResolvedRun(runId);
         return;
       }
 
@@ -90,7 +102,7 @@ export function CompactSidebarEventRow({
 
       const resolvedRunId = await fetchRunId(event);
       if (resolvedRunId) {
-        onSelectRun(resolvedRunId);
+        selectResolvedRun(resolvedRunId);
       }
     } finally {
       isResolvingRef.current = false;

--- a/web_src/src/ui/componentSidebar/LatestTab.tsx
+++ b/web_src/src/ui/componentSidebar/LatestTab.tsx
@@ -28,9 +28,10 @@ interface LatestTabProps {
     execution: CanvasesCanvasNodeExecution,
   ) => { map: EventStateMap; state: EventState };
   compact?: boolean;
+  selectionNodeId?: string;
   resolveRunId?: (event: SidebarEvent) => string | null;
   fetchRunId?: (event: SidebarEvent) => Promise<string | null>;
-  onSelectRun?: (runId: string) => void;
+  onSelectRun?: (runId: string, options?: { nodeId?: string }) => void;
 }
 
 function SectionHeader({ label }: { label: string }) {
@@ -57,6 +58,7 @@ export const LatestTab = ({
   onReEmit,
   getExecutionState,
   compact = false,
+  selectionNodeId,
   resolveRunId,
   fetchRunId,
   onSelectRun,
@@ -96,6 +98,7 @@ export const LatestTab = ({
               <CompactSidebarEventRow
                 key={event.id}
                 event={event}
+                selectionNodeId={selectionNodeId}
                 runId={runIdByEventId.get(event.id) ?? null}
                 fetchRunId={fetchRunId}
                 onSelectRun={onSelectRun}
@@ -130,6 +133,7 @@ export const LatestTab = ({
                   <CompactSidebarEventRow
                     key={event.id}
                     event={event}
+                    selectionNodeId={selectionNodeId}
                     runId={runIdByEventId.get(event.id) ?? null}
                     fetchRunId={fetchRunId}
                     onSelectRun={onSelectRun}

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -154,7 +154,7 @@ interface ComponentSidebarProps {
   layout?: "sidebar" | "bottom";
   resolveRunId?: (event: SidebarEvent) => string | null;
   fetchRunId?: (event: SidebarEvent) => Promise<string | null>;
-  onSelectRun?: (runId: string) => void;
+  onSelectRun?: (runId: string, options?: { nodeId?: string }) => void;
 }
 
 export const ComponentSidebar = ({
@@ -686,6 +686,7 @@ export const ComponentSidebar = ({
                     onReEmit={onReEmit}
                     getExecutionState={getExecutionState}
                     compact={isBottomLayout}
+                    selectionNodeId={nodeId}
                     resolveRunId={resolveRunId}
                     fetchRunId={fetchRunId}
                     onSelectRun={onSelectRun}
@@ -759,6 +760,7 @@ export const ComponentSidebar = ({
                   onToggleOpen={handleToggleOpen}
                   onEventClick={onEventClick}
                   compact={isBottomLayout}
+                  selectionNodeId={nodeId}
                   resolveRunId={resolveRunId}
                   fetchRunId={fetchRunId}
                   onSelectRun={onSelectRun}

--- a/web_src/src/ui/componentSidebar/pages/HistoryQueuePage.tsx
+++ b/web_src/src/ui/componentSidebar/pages/HistoryQueuePage.tsx
@@ -24,9 +24,10 @@ interface HistoryQueuePageProps {
     execution: CanvasesCanvasNodeExecution,
   ) => { map: EventStateMap; state: EventState };
   compact?: boolean;
+  selectionNodeId?: string;
   resolveRunId?: (event: SidebarEvent) => string | null;
   fetchRunId?: (event: SidebarEvent) => Promise<string | null>;
-  onSelectRun?: (runId: string) => void;
+  onSelectRun?: (runId: string, options?: { nodeId?: string }) => void;
 
   // Pagination props
   hasMoreItems: boolean;
@@ -46,6 +47,7 @@ export const HistoryQueuePage: React.FC<HistoryQueuePageProps> = ({
   onReEmit,
   getExecutionState,
   compact = false,
+  selectionNodeId,
   resolveRunId,
   fetchRunId,
   onSelectRun,
@@ -79,6 +81,7 @@ export const HistoryQueuePage: React.FC<HistoryQueuePageProps> = ({
               <CompactSidebarEventRow
                 key={event.id}
                 event={event}
+                selectionNodeId={selectionNodeId}
                 runId={runIdByEventId.get(event.id) ?? null}
                 fetchRunId={fetchRunId}
                 onSelectRun={onSelectRun}


### PR DESCRIPTION
## Summary
- include fully fetched run executions when building run inspection canvas participants
- keep live run websocket updates visible in the runs sidebar cache
- preserve the current canvas viewport when entering and leaving run inspection
- stop refitting the run canvas when changing selected runs
- allow node-specific run clicks from the bottom runs/errors sidebar, bottom node inspector history, the runs sidebar detail node list, and the run detail pane to focus that node from the current viewport
- avoid hydrating the live node inspector from run-detail URL params while in run inspection
- wait for ReactFlow initialization before applying node focus so viewport restoration cannot override the focus animation
- suppress duplicate handling of the same focus request so the node is not zoomed twice
- scope focus requests to live vs run inspection mode so the live canvas cannot consume bottom-sidebar run focus before run inspection mounts
- clear pending run focus requests when switching to a non-node run or leaving node-specific run inspection
- persist the post-focus viewport after ReactFlow fitView so leaving run inspection keeps the viewed position
- retry node focus after run canvas nodes mount so navigation made during run loading still zooms to the target node
- add regression coverage for participant merging, live run cache updates, websocket refreshes, run/live viewport transitions, delayed run-node focus, duplicate focus suppression, ignored live/run focus requests, persisted focus viewport, and bottom-sidebar node run selection context

Fixes #5791

## Tests
- make format.js
- cd web_src && npm run test:run -- src/ui/componentSidebar/CompactSidebarEventRow.spec.tsx src/ui/componentSidebar/pages/HistoryQueuePage.spec.tsx src/ui/CanvasPage/index.runInspection.spec.tsx src/pages/app/lib/run-inspection-viewport.spec.ts src/hooks/useCanvasWebsocket.spec.ts src/hooks/canvasInfiniteCache.spec.ts src/pages/app/useRunCanvasData.spec.ts src/pages/app/useRunsDetailState.spec.ts src/pages/app/viewState.spec.ts
- git diff --check
- make check.build.ui