### PR TITLE
fix: stop runner log fetches at record limit

### DIFF
--- a/pkg/components/runner/live_log_fetch.go
+++ b/pkg/components/runner/live_log_fetch.go
@@ -115,7 +115,11 @@ func readLiveLogRecords(reader io.Reader, limit int) (*LiveLogFetchResult, error
 		if !ok {
 			continue
 		}
+
 		records = append(records, record)
+		if len(records) >= limit {
+			return &LiveLogFetchResult{Records: records, Truncated: true}, nil
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("read live logs: %w", err)

--- a/pkg/components/runner/live_log_fetch_test.go
+++ b/pkg/components/runner/live_log_fetch_test.go
@@ -1,11 +1,43 @@
 package runner
 
 import (
+	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+type liveLogReadResult struct {
+	result *LiveLogFetchResult
+	err    error
+}
+
+func TestReadLiveLogRecordsReturnsAfterLimitOnOpenStream(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+
+	done := make(chan liveLogReadResult, 1)
+	go func() {
+		result, err := readLiveLogRecords(reader, 1)
+		done <- liveLogReadResult{result: result, err: err}
+	}()
+
+	_, err := writer.Write([]byte(`{"type":"line","text":"first"}` + "\n"))
+	require.NoError(t, err)
+
+	select {
+	case read := <-done:
+		require.NoError(t, read.err)
+		require.Len(t, read.result.Records, 1)
+		require.Equal(t, "first", read.result.Records[0].Text)
+		require.True(t, read.result.Truncated)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected reader to return after reaching record limit")
+	}
+}
 
 func TestReadLiveLogRecordsStopsAfterLimitEvenWhenNextLineIsInvalid(t *testing.T) {
 	result, err := readLiveLogRecords(strings.NewReader(`{"type":"line","text":"first"}`+"\nnot-json\n"), 1)


### PR DESCRIPTION
## Summary
- stop runner live-log reads as soon as the requested record limit is reached
- avoid waiting for the task broker live stream to close before returning agent/CLI log slices
- add regression coverage for open broker streams that keep the body alive after emitting enough records

## Tests
- go test ./pkg/components/runner -run TestReadLiveLogRecordsReturnsAfterLimitOnOpenStream -count=1
- go test ./pkg/components/runner -count=1
- make format.go
- make test PKG_TEST_PACKAGES='./pkg/components/runner ./pkg/agents/agent_tools/... ./pkg/cli/commands/executions'
- make lint
- make check.build.app