### PR TITLE
fix: return agent runner logs after stream goes idle

### DIFF
--- a/pkg/agents/agent_tools/actions/canvas_test.go
+++ b/pkg/agents/agent_tools/actions/canvas_test.go
@@ -1149,6 +1149,10 @@ func TestReadRuntimeAction_ReadsRunnerLogsByExecutionID(t *testing.T) {
 		assert.Equal(t, "/v1/tasks/task-agent-logs/live-logs", req.URL.Path)
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		_, _ = w.Write([]byte(`{"type":"line","text":"agent log line"}` + "\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-req.Context().Done()
 	}))
 	defer broker.Close()
 	t.Setenv("TASK_BROKER_BASE_URL", broker.URL)

--- a/pkg/agents/agent_tools/actions/read_runtime.go
+++ b/pkg/agents/agent_tools/actions/read_runtime.go
@@ -23,7 +23,13 @@ import (
 	"gorm.io/gorm"
 )
 
-const readRuntimeActionName = "read_runtime"
+const (
+	readRuntimeActionName = "read_runtime"
+	// The task-broker polls CloudWatch every 300-750ms, so 1500ms gives it at
+	// least two quiet polling intervals before an agent tool call returns a
+	// bounded snapshot instead of waiting for an open live stream to close.
+	runnerLogSnapshotIdleTimeout = 1500 * time.Millisecond
+)
 
 var runtimeResources = []string{
 	"memory",
@@ -356,7 +362,10 @@ func fetchRunnerLogsForTarget(ctx context.Context, organizationID, canvasID uuid
 		return result, err
 	}
 
-	fetch, err := runneraction.FetchLiveLogRecords(ctx, access.BrokerTaskID, runneraction.LiveLogFetchOptions{Limit: limit})
+	fetch, err := runneraction.FetchLiveLogRecords(ctx, access.BrokerTaskID, runneraction.LiveLogFetchOptions{
+		Limit:       limit,
+		IdleTimeout: runnerLogSnapshotIdleTimeout,
+	})
 	if err != nil {
 		return result, err
 	}

--- a/pkg/components/runner/live_log_fetch.go
+++ b/pkg/components/runner/live_log_fetch.go
@@ -27,9 +27,10 @@ type LiveLogRecord struct {
 }
 
 type LiveLogFetchOptions struct {
-	Limit      int
-	HTTPClient *http.Client
-	Now        time.Time
+	Limit       int
+	HTTPClient  *http.Client
+	Now         time.Time
+	IdleTimeout time.Duration
 }
 
 type LiveLogFetchResult struct {
@@ -76,6 +77,9 @@ func FetchLiveLogSessionRecords(ctx context.Context, session LiveLogSession, opt
 		return nil, fmt.Errorf("fetch live logs: %s", message)
 	}
 
+	if opts.IdleTimeout > 0 {
+		return readLiveLogRecordsUntilIdle(ctx, response.Body, limit, opts.IdleTimeout)
+	}
 	return readLiveLogRecords(response.Body, limit)
 }
 
@@ -125,6 +129,157 @@ func readLiveLogRecords(reader io.Reader, limit int) (*LiveLogFetchResult, error
 		return nil, fmt.Errorf("read live logs: %w", err)
 	}
 	return &LiveLogFetchResult{Records: records}, nil
+}
+
+type liveLogReadEvent struct {
+	record LiveLogRecord
+	err    error
+	done   bool
+}
+
+func readLiveLogRecordsUntilIdle(
+	ctx context.Context,
+	reader io.Reader,
+	limit int,
+	idleTimeout time.Duration,
+) (*LiveLogFetchResult, error) {
+	done := make(chan struct{})
+	events := make(chan liveLogReadEvent)
+
+	if closer, ok := reader.(io.Closer); ok {
+		defer func() {
+			close(done)
+			_ = closer.Close()
+		}()
+	} else {
+		defer close(done)
+	}
+
+	go streamLiveLogReadEvents(reader, events, done)
+
+	records := make([]LiveLogRecord, 0, min(limit, 32))
+	idle := time.NewTimer(idleTimeout)
+	defer idle.Stop()
+
+	for {
+		select {
+		case event := <-events:
+			result, complete, err := applyLiveLogReadEvent(records, event, limit)
+			if err != nil {
+				return nil, err
+			}
+			records = result.Records
+			if complete {
+				return result, nil
+			}
+			resetLiveLogIdleTimer(idle, idleTimeout)
+		case <-idle.C:
+			result, complete, err := drainReadyLiveLogReadEvents(records, events, limit)
+			if err != nil {
+				return nil, err
+			}
+			if complete {
+				return result, nil
+			}
+			if len(result.Records) > len(records) {
+				records = result.Records
+				resetLiveLogIdleTimer(idle, idleTimeout)
+				continue
+			}
+			return &LiveLogFetchResult{Records: records}, nil
+		case <-ctx.Done():
+			return nil, fmt.Errorf("read live logs: %w", ctx.Err())
+		}
+	}
+}
+
+func drainReadyLiveLogReadEvents(
+	records []LiveLogRecord,
+	events <-chan liveLogReadEvent,
+	limit int,
+) (*LiveLogFetchResult, bool, error) {
+	result := &LiveLogFetchResult{Records: records}
+
+	for {
+		select {
+		case event := <-events:
+			next, complete, err := applyLiveLogReadEvent(result.Records, event, limit)
+			if err != nil {
+				return nil, false, err
+			}
+			result = next
+			if complete {
+				return result, true, nil
+			}
+		default:
+			return result, false, nil
+		}
+	}
+}
+
+func applyLiveLogReadEvent(
+	records []LiveLogRecord,
+	event liveLogReadEvent,
+	limit int,
+) (*LiveLogFetchResult, bool, error) {
+	if event.err != nil {
+		return nil, false, fmt.Errorf("read live logs: %w", event.err)
+	}
+	if event.done {
+		return &LiveLogFetchResult{Records: records}, true, nil
+	}
+
+	records = append(records, event.record)
+	if len(records) >= limit {
+		return &LiveLogFetchResult{Records: records, Truncated: true}, true, nil
+	}
+	return &LiveLogFetchResult{Records: records}, false, nil
+}
+
+func streamLiveLogReadEvents(reader io.Reader, events chan<- liveLogReadEvent, done <-chan struct{}) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		record, ok := parseLiveLogRecord(line)
+		if !ok {
+			continue
+		}
+
+		if !sendLiveLogReadEvent(events, done, liveLogReadEvent{record: record}) {
+			return
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		_ = sendLiveLogReadEvent(events, done, liveLogReadEvent{err: err})
+		return
+	}
+	_ = sendLiveLogReadEvent(events, done, liveLogReadEvent{done: true})
+}
+
+func sendLiveLogReadEvent(events chan<- liveLogReadEvent, done <-chan struct{}, event liveLogReadEvent) bool {
+	select {
+	case events <- event:
+		return true
+	case <-done:
+		return false
+	}
+}
+
+func resetLiveLogIdleTimer(timer *time.Timer, idleTimeout time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(idleTimeout)
 }
 
 func parseLiveLogRecord(line string) (LiveLogRecord, bool) {

--- a/pkg/components/runner/live_log_fetch_test.go
+++ b/pkg/components/runner/live_log_fetch_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -46,4 +47,69 @@ func TestReadLiveLogRecordsStopsAfterLimitEvenWhenNextLineIsInvalid(t *testing.T
 	require.Len(t, result.Records, 1)
 	require.Equal(t, "first", result.Records[0].Text)
 	require.True(t, result.Truncated)
+}
+
+func TestReadLiveLogRecordsUntilIdleReturnsPartialOpenStream(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+
+	done := make(chan liveLogReadResult, 1)
+	go func() {
+		result, err := readLiveLogRecordsUntilIdle(context.Background(), reader, 10, 20*time.Millisecond)
+		done <- liveLogReadResult{result: result, err: err}
+	}()
+
+	_, err := writer.Write([]byte(`{"type":"line","text":"first"}` + "\n"))
+	require.NoError(t, err)
+
+	select {
+	case read := <-done:
+		require.NoError(t, read.err)
+		require.Len(t, read.result.Records, 1)
+		require.Equal(t, "first", read.result.Records[0].Text)
+		require.False(t, read.result.Truncated)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected reader to return after idle timeout")
+	}
+}
+
+func TestReadLiveLogRecordsUntilIdleReturnsContextCancellation(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan liveLogReadResult, 1)
+	go func() {
+		result, err := readLiveLogRecordsUntilIdle(ctx, reader, 10, time.Minute)
+		done <- liveLogReadResult{result: result, err: err}
+	}()
+
+	cancel()
+
+	select {
+	case read := <-done:
+		require.Nil(t, read.result)
+		require.ErrorIs(t, read.err, context.Canceled)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected reader to return after context cancellation")
+	}
+}
+
+func TestDrainReadyLiveLogReadEventsKeepsQueuedRecord(t *testing.T) {
+	events := make(chan liveLogReadEvent, 1)
+	events <- liveLogReadEvent{record: LiveLogRecord{Type: "line", Text: "second"}}
+
+	result, complete, err := drainReadyLiveLogReadEvents(
+		[]LiveLogRecord{{Type: "line", Text: "first"}},
+		events,
+		10,
+	)
+
+	require.NoError(t, err)
+	require.False(t, complete)
+	require.Len(t, result.Records, 2)
+	require.Equal(t, "first", result.Records[0].Text)
+	require.Equal(t, "second", result.Records[1].Text)
 }


### PR DESCRIPTION
## Summary
- add an idle snapshot mode for runner live-log reads
- use that bounded read path from agent runtime log access
- cover open broker streams that flush available logs without closing

## Tests
- make format.go
- make test PKG_TEST_PACKAGES=./pkg/agents/agent_tools/actions
- make test PKG_TEST_PACKAGES=./pkg/components/runner
- make lint && make check.build.app