### PR TITLE
fix: reconcile agent chat streaming status

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -38,7 +38,7 @@ import type { AgentMessage, AgentOutgoingImage } from "./types";
 import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 import { groupMessages } from "./agentMessageGroups";
 
-const STREAMING_STATUS_RECONCILE_INTERVAL_MS = 3000;
+const STREAMING_STATUS_RECONCILE_INTERVAL_MS = 15000;
 
 type ChatConversationProps = {
   chatId: string;
@@ -248,41 +248,42 @@ function useStreamingStatusReconciler(
   setStatus: (value: string) => void,
   refreshChatStatus: () => Promise<string | undefined>,
 ) {
+  const activeRef = useRef(false);
+  const inFlightRef = useRef(false);
+  const reconcile = useCallback(async () => {
+    if (inFlightRef.current) {
+      return;
+    }
+
+    inFlightRef.current = true;
+    try {
+      const nextStatus = await refreshChatStatus();
+      if (activeRef.current && nextStatus && nextStatus !== "streaming") {
+        setStatus(nextStatus);
+      }
+    } catch {
+      // Websocket events remain the primary status path; refetch only repairs missed terminal events.
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, [refreshChatStatus, setStatus]);
+
   useEffect(() => {
     if (status !== "streaming") {
       return;
     }
 
-    let active = true;
-    let inFlight = false;
-    const reconcile = async () => {
-      if (inFlight) {
-        return;
-      }
-
-      inFlight = true;
-      try {
-        const nextStatus = await refreshChatStatus();
-        if (active && nextStatus && nextStatus !== "streaming") {
-          setStatus(nextStatus);
-        }
-      } catch {
-        // Websocket events remain the primary status path; refetch only repairs missed terminal events.
-      } finally {
-        inFlight = false;
-      }
-    };
-
+    activeRef.current = true;
     void reconcile();
     const intervalId = window.setInterval(() => {
       void reconcile();
     }, STREAMING_STATUS_RECONCILE_INTERVAL_MS);
 
     return () => {
-      active = false;
+      activeRef.current = false;
       window.clearInterval(intervalId);
     };
-  }, [refreshChatStatus, setStatus, status]);
+  }, [reconcile, status]);
 }
 
 function useAgentBootKickoff({

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -38,11 +38,14 @@ import type { AgentMessage, AgentOutgoingImage } from "./types";
 import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 import { groupMessages } from "./agentMessageGroups";
 
+const STREAMING_STATUS_RECONCILE_INTERVAL_MS = 3000;
+
 type ChatConversationProps = {
   chatId: string;
   canvasId: string;
   organizationId: string;
   initialStatus: string;
+  refreshChatStatus: () => Promise<string | undefined>;
   agentMode: AgentMode;
   onModeSwitch: (mode: AgentMode) => void;
   isEditing: boolean;
@@ -71,6 +74,11 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
   const chatId = chatQuery.data?.id ?? null;
   const { account } = useContext(AccountContext);
   const firstName = account?.name?.split(" ")[0] ?? "there";
+  const { refetch: refetchChat } = chatQuery;
+  const refreshChatStatus = useCallback(async () => {
+    const result = await refetchChat();
+    return result.data?.status;
+  }, [refetchChat]);
 
   if (chatQuery.isLoading || !chatId) {
     return (
@@ -95,6 +103,7 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
       canvasId={canvasId}
       organizationId={organizationId}
       initialStatus={chatQuery.data?.status ?? "idle"}
+      refreshChatStatus={refreshChatStatus}
       agentMode={toolSidebarState.agentMode}
       onModeSwitch={toolSidebarState.switchAgentMode}
       isEditing={toolSidebarState.isEditing}
@@ -107,6 +116,7 @@ function ChatConversation({
   canvasId,
   organizationId,
   initialStatus,
+  refreshChatStatus,
   agentMode,
   onModeSwitch,
   isEditing,
@@ -127,6 +137,7 @@ function ChatConversation({
   useEffect(() => {
     setStatus(initialStatus || "idle");
   }, [initialStatus]);
+  useStreamingStatusReconciler(status, setStatus, refreshChatStatus);
 
   // Prepend a synthetic greeting as the first message so it never disappears
   const messages = useMemo(() => {
@@ -230,6 +241,48 @@ function ChatConversation({
       />
     </div>
   );
+}
+
+function useStreamingStatusReconciler(
+  status: string,
+  setStatus: (value: string) => void,
+  refreshChatStatus: () => Promise<string | undefined>,
+) {
+  useEffect(() => {
+    if (status !== "streaming") {
+      return;
+    }
+
+    let active = true;
+    let inFlight = false;
+    const reconcile = async () => {
+      if (inFlight) {
+        return;
+      }
+
+      inFlight = true;
+      try {
+        const nextStatus = await refreshChatStatus();
+        if (active && nextStatus && nextStatus !== "streaming") {
+          setStatus(nextStatus);
+        }
+      } catch {
+        // Websocket events remain the primary status path; refetch only repairs missed terminal events.
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    void reconcile();
+    const intervalId = window.setInterval(() => {
+      void reconcile();
+    }, STREAMING_STATUS_RECONCILE_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(intervalId);
+    };
+  }, [refreshChatStatus, setStatus, status]);
 }
 
 function useAgentBootKickoff({

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -191,7 +191,6 @@ function ChatConversation({
   const messageGroups = useMemo(() => groupMessages(messages), [messages]);
   const outcomeActive = isOutcomeActive(outcomeState);
   const agentBusy = status === "streaming" || outcomeMutation.isPending || outcomeActive;
-  const modeDisabled = agentBusy;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -237,7 +236,7 @@ function ChatConversation({
         statusLabel={sendMutation.isPending ? "Starting agent..." : statusLabel(status)}
         agentMode={agentMode}
         onModeSwitch={onModeSwitch}
-        modeDisabled={modeDisabled}
+        modeDisabled={agentBusy}
       />
     </div>
   );

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -1,21 +1,27 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CanvasToolSidebar } from ".";
 import { CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT } from "./events";
 import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 
 const richMessageRenderSpy = vi.fn();
 
-const { sendMutation, chatState } = vi.hoisted(() => ({
-  sendMutation: {
-    isPending: false,
-    mutateAsync: vi.fn(),
-  },
-  chatState: {
+const { sendMutation, chatState, chatRefetch } = vi.hoisted(() => {
+  const state = {
     status: "idle",
-  },
-}));
+    refetchStatus: "idle",
+  };
+
+  return {
+    sendMutation: {
+      isPending: false,
+      mutateAsync: vi.fn(),
+    },
+    chatState: state,
+    chatRefetch: vi.fn(async () => ({ data: { id: "chat-1", status: state.refetchStatus } })),
+  };
+});
 
 vi.mock("@/hooks/useCanvasData", () => ({
   useCanvas: () => ({ data: { spec: { nodes: [] } } }),
@@ -25,7 +31,11 @@ vi.mock("@/hooks/useCanvasData", () => ({
 }));
 
 vi.mock("@/hooks/useAgentChats", () => ({
-  useCanvasAgentChat: () => ({ data: { id: "chat-1", status: chatState.status }, isLoading: false }),
+  useCanvasAgentChat: () => ({
+    data: { id: "chat-1", status: chatState.status },
+    isLoading: false,
+    refetch: chatRefetch,
+  }),
   useAgentChatMessages: () => ({
     data: {
       pages: [
@@ -89,10 +99,16 @@ describe("CanvasToolSidebar", () => {
   beforeEach(() => {
     richMessageRenderSpy.mockClear();
     chatState.status = "idle";
+    chatState.refetchStatus = "idle";
+    chatRefetch.mockClear();
     sendMutation.isPending = false;
     sendMutation.mutateAsync.mockReset();
     sendMutation.mutateAsync.mockResolvedValue(null);
     sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders the agent panel when the sidebar is open", async () => {
@@ -180,5 +196,43 @@ describe("CanvasToolSidebar", () => {
       resolveSend?.();
     });
     expect(input).toHaveValue("second");
+  });
+
+  it("clears stale streaming state when a durable chat refetch returns idle", async () => {
+    vi.useFakeTimers();
+    chatState.status = "streaming";
+    chatState.refetchStatus = "streaming";
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
+
+    expect(screen.getByTestId("agent-thinking")).toBeInTheDocument();
+    expect(screen.getByText("Agent is running...")).toBeInTheDocument();
+
+    chatState.refetchStatus = "idle";
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(screen.queryByTestId("agent-thinking")).not.toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.queryByTestId("agent-stop-button")).not.toBeInTheDocument();
+  });
+
+  it("keeps streaming state while durable chat refetches are still streaming", async () => {
+    vi.useFakeTimers();
+    chatState.status = "streaming";
+    chatState.refetchStatus = "streaming";
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
+
+    expect(screen.getByTestId("agent-thinking")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(screen.getByTestId("agent-thinking")).toBeInTheDocument();
+    expect(screen.getByText("Agent is running...")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-stop-button")).toBeInTheDocument();
   });
 });

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -210,7 +210,7 @@ describe("CanvasToolSidebar", () => {
 
     chatState.refetchStatus = "idle";
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(15000);
     });
 
     expect(screen.queryByTestId("agent-thinking")).not.toBeInTheDocument();
@@ -228,7 +228,7 @@ describe("CanvasToolSidebar", () => {
     expect(screen.getByTestId("agent-thinking")).toBeInTheDocument();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(15000);
     });
 
     expect(screen.getByTestId("agent-thinking")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Fixes #5780 by reconciling the local agent streaming state with the durable chat row when the terminal websocket event is missed.
- Adds a 3s refetch loop only while the local agent status is `streaming`; websocket events remain the primary status path.
- Keeps the Thinking indicator derived from status rather than hiding it when assistant text appears.

## Regression coverage
- Added sidebar coverage for a missed terminal event: the UI starts in `streaming`, a durable chat refetch returns `idle`, and Thinking/Stop clear.
- Added companion coverage that Thinking remains while durable refetches still report `streaming`.