### PR TITLE
fix: remove stale change request CLI reference

### DIFF
--- a/pkg/cli/commands/apps/console/root.go
+++ b/pkg/cli/commands/apps/console/root.go
@@ -49,7 +49,7 @@ YAML source resolution order:
 		Args: cobra.MaximumNArgs(2),
 	}
 	setCmd.Flags().StringVarP(&setFile, "file", "f", "", `console YAML file path, or "-" for stdin`)
-	setCmd.Flags().StringVar(&setDraftID, "draft-id", "", "target a specific draft by id; skips change-request creation (see `superplane apps drafts list`)")
+	setCmd.Flags().StringVar(&setDraftID, "draft-id", "", "target a specific draft by id instead of auto-publishing (see `superplane apps drafts list`)")
 	core.Bind(setCmd, &setCommand{file: &setFile, draftID: &setDraftID}, options)
 
 	root.AddCommand(getCmd)


### PR DESCRIPTION
## Summary
- remove stale change-request wording from `superplane apps console set --draft-id` help text
- align help text with current draft/auto-publish behavior

## Test
- go test ./pkg/cli/commands/apps/console

## Notes
- `make format.go`, `make lint`, and `make check.build.app` require the Docker app service, which was not running locally.