### PR TITLE
fix: stop agent from acting unsolicited on canvas open/refresh

### DIFF
--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -29,10 +29,6 @@ func TestAgentE2E(t *testing.T) {
 	t.Run("sends a message and renders the streamed assistant response", func(t *testing.T) {
 		steps := newAgentSteps(t)
 		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
-			if isAgentSystemMessage(call.Message) {
-				return agentAssistantTurn("Agent ready for e2e"), nil
-			}
-
 			return agentAssistantTurn("E2E assistant response for: " + call.Message), nil
 		})
 
@@ -47,10 +43,6 @@ func TestAgentE2E(t *testing.T) {
 	t.Run("switches to build mode before sending a message", func(t *testing.T) {
 		steps := newAgentSteps(t)
 		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
-			if isAgentSystemMessage(call.Message) {
-				return []agents.ProviderEvent{agentTurnCompletedEvent()}, nil
-			}
-
 			return agentAssistantTurn("Builder mode acknowledged"), nil
 		})
 
@@ -65,10 +57,6 @@ func TestAgentE2E(t *testing.T) {
 	t.Run("renders tool activity from provider events", func(t *testing.T) {
 		steps := newAgentSteps(t)
 		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
-			if isAgentSystemMessage(call.Message) {
-				return []agents.ProviderEvent{agentTurnCompletedEvent()}, nil
-			}
-
 			return []agents.ProviderEvent{
 				agentToolStartedEvent("tool-1", "bash", "superplane apps canvas get"),
 				agentToolFinishedEvent("tool-1", "bash"),
@@ -89,10 +77,6 @@ func TestAgentE2E(t *testing.T) {
 	t.Run("stops a running turn", func(t *testing.T) {
 		steps := newAgentSteps(t)
 		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
-			if isAgentSystemMessage(call.Message) {
-				return []agents.ProviderEvent{agentTurnCompletedEvent()}, nil
-			}
-
 			return nil, nil
 		})
 
@@ -118,10 +102,6 @@ func TestAgentE2E(t *testing.T) {
 	t.Run("sends a follow-up message while a turn is still running", func(t *testing.T) {
 		steps := newAgentSteps(t)
 		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
-			if isAgentSystemMessage(call.Message) {
-				return []agents.ProviderEvent{agentTurnCompletedEvent()}, nil
-			}
-
 			return nil, nil
 		})
 
@@ -141,10 +121,6 @@ func TestAgentE2E(t *testing.T) {
 		var approvalReceived bool
 		steps := newAgentSteps(t)
 		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
-			if isAgentSystemMessage(call.Message) {
-				return []agents.ProviderEvent{agentTurnCompletedEvent()}, nil
-			}
-
 			if call.Message == "Specs approved. Start building." {
 				approvalReceived = true
 				return agentAssistantTurn("Building now."), nil
@@ -209,9 +185,24 @@ func (s *agentSteps) openAgent() {
 
 	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
 	s.waitForAgentInput()
-	s.waitForSendCall(func(call support.AgentProviderSendMessageCall) bool {
-		return isAgentSystemMessage(call.Message)
-	})
+
+	// Opening or refreshing a canvas must not invoke the agent: it no longer sends a
+	// boot message (see web_src/src/lib/agentBootContext.ts). Sync on the provisioned
+	// session instead of a boot round-trip, then assert nothing was auto-sent.
+	s.currentAgentSession()
+	s.assertNoBootMessageSent()
+}
+
+func (s *agentSteps) assertNoBootMessageSent() {
+	require.Never(s.t, func() bool {
+		for _, call := range ctx.AgentProvider.SendMessageCalls() {
+			if isAgentSystemMessage(call.Message) {
+				return true
+			}
+		}
+
+		return false
+	}, 2*time.Second, agentPollInterval, "agent must not auto-send a boot message on canvas open")
 }
 
 func (s *agentSteps) waitForAgentInput() {

--- a/web_src/src/lib/agentBootContext.spec.ts
+++ b/web_src/src/lib/agentBootContext.spec.ts
@@ -11,21 +11,22 @@ import {
   setAgentBootContext,
 } from "./agentBootContext";
 
-const DEFAULT_BOOT_MESSAGE =
-  "Session ready. Use the [Canvas Snapshot] from the session context to greet the user. Do not run CLI commands or fetch the canvas just to summarize it. Only check connected integrations if the user asks for integration-specific work.";
-
 describe("agent boot context", () => {
   beforeEach(() => {
     sessionStorage.clear();
   });
 
-  it("defaults to using the backend canvas snapshot without CLI fetches", () => {
-    const message = getAgentBootMessage("canvas-1");
+  it("sends no boot message by default so opening a canvas never invokes the agent", () => {
+    expect(getAgentBootMessage("canvas-1")).toBe("");
+  });
 
-    expect(message).toBe(DEFAULT_BOOT_MESSAGE);
-    expect(message).toContain("[Canvas Snapshot]");
-    expect(message).toContain("Do not run CLI commands");
-    expect(message).toContain("fetch the canvas");
+  it("sends no boot message when the stored context is for a different canvas", () => {
+    setAgentBootContext("canvas-1", {
+      instructions: "This template deploys preview environments.",
+      initialMessage: "Here's what you've got on this canvas.",
+    });
+
+    expect(getAgentBootMessage("canvas-2")).toBe("");
   });
 
   it("blocks boot while a placeholder node is pending for the canvas", () => {
@@ -59,7 +60,7 @@ describe("agent boot context", () => {
 
     expect(isAgentBootReady("canvas-1")).toBe(true);
     expect(sessionStorage.getItem(PLACEHOLDER_NODE_CONTEXT_KEY)).toBeNull();
-    expect(getAgentBootMessage("canvas-1")).toBe(DEFAULT_BOOT_MESSAGE);
+    expect(getAgentBootMessage("canvas-1")).toBe("");
     expect(listener).toHaveBeenCalledWith(expect.objectContaining({ detail: { canvasId: "canvas-1" } }));
 
     window.removeEventListener(AGENT_BOOT_CONTEXT_READY_EVENT, listener);
@@ -101,6 +102,6 @@ describe("agent boot context", () => {
     clearAgentBootContext("canvas-1");
 
     expect(getAgentBootInitialMessage("canvas-1")).toBe("Here's what you've got on this canvas.");
-    expect(getAgentBootMessage("canvas-1")).toBe(DEFAULT_BOOT_MESSAGE);
+    expect(getAgentBootMessage("canvas-1")).toBe("");
   });
 });

--- a/web_src/src/lib/agentBootContext.ts
+++ b/web_src/src/lib/agentBootContext.ts
@@ -3,14 +3,6 @@ const AGENT_BOOT_INITIAL_MESSAGES_KEY = "agent-boot-initial-messages";
 export const PLACEHOLDER_NODE_CONTEXT_KEY = "add-placeholder-node";
 export const AGENT_BOOT_CONTEXT_READY_EVENT = "agent-boot-context-ready";
 
-// Opening or refreshing a canvas must never invoke the agent. Without an explicit
-// boot context (a template install), we send no message so the agent stays idle and
-// spends no tokens until the user asks for something. A static greeting (rendered
-// client-side in AgentTabPanel) welcomes the user instead.
-const DEFAULT_BOOT_MESSAGE = "";
-
-const BLANK_BOOT_MESSAGE = ""; // No agent boot message for blank canvas — static greeting only
-
 const BLANK_INITIAL_MESSAGE =
   "You can describe the workflow you want to build, or click on the 'New Component' node on the canvas to get started. I'm here to help!";
 
@@ -44,18 +36,23 @@ export function setAgentBootContext(canvasId: string, message: string | Template
   sessionStorage.setItem(AGENT_BOOT_CONTEXT_KEY, JSON.stringify(context));
 }
 
+// Returns the message to auto-send to the agent on canvas boot, or "" to send nothing.
+// Opening or refreshing a canvas must never invoke the agent: without an explicit boot
+// context (a template install) we return "", so the agent stays idle and spends no tokens
+// until the user asks for something. A static greeting (rendered client-side in
+// AgentTabPanel) welcomes the user instead.
 export function getAgentBootMessage(canvasId: string): string {
-  if (typeof window === "undefined") return DEFAULT_BOOT_MESSAGE;
+  if (typeof window === "undefined") return "";
   const raw = sessionStorage.getItem(AGENT_BOOT_CONTEXT_KEY);
-  if (!raw) return DEFAULT_BOOT_MESSAGE;
+  if (!raw) return "";
 
   try {
     const context = JSON.parse(raw) as AgentBootContext;
-    if (context.canvasId !== canvasId) return DEFAULT_BOOT_MESSAGE;
-    if (context.message === "blank") return BLANK_BOOT_MESSAGE;
+    if (context.canvasId !== canvasId) return "";
+    if (context.message === "blank") return ""; // Blank canvas — static greeting only.
     return context.message;
   } catch {
-    return DEFAULT_BOOT_MESSAGE;
+    return "";
   }
 }
 
@@ -76,7 +73,7 @@ export function getAgentBootInitialMessage(canvasId: string): string | null {
 }
 
 function buildTemplateBootMessage({ instructions, initialMessage }: TemplateAgentBootContext): string {
-  if (!initialMessage) return instructions || DEFAULT_BOOT_MESSAGE;
+  if (!initialMessage) return instructions ?? "";
 
   return [
     "The UI has already shown the user the template introduction.",

--- a/web_src/src/lib/agentBootContext.ts
+++ b/web_src/src/lib/agentBootContext.ts
@@ -3,8 +3,11 @@ const AGENT_BOOT_INITIAL_MESSAGES_KEY = "agent-boot-initial-messages";
 export const PLACEHOLDER_NODE_CONTEXT_KEY = "add-placeholder-node";
 export const AGENT_BOOT_CONTEXT_READY_EVENT = "agent-boot-context-ready";
 
-const DEFAULT_BOOT_MESSAGE =
-  "Session ready. Use the [Canvas Snapshot] from the session context to greet the user. Do not run CLI commands or fetch the canvas just to summarize it. Only check connected integrations if the user asks for integration-specific work.";
+// Opening or refreshing a canvas must never invoke the agent. Without an explicit
+// boot context (a template install), we send no message so the agent stays idle and
+// spends no tokens until the user asks for something. A static greeting (rendered
+// client-side in AgentTabPanel) welcomes the user instead.
+const DEFAULT_BOOT_MESSAGE = "";
 
 const BLANK_BOOT_MESSAGE = ""; // No agent boot message for blank canvas — static greeting only
 


### PR DESCRIPTION
## Problem

Fixes #5110.

Opening or refreshing a canvas kicked off the agent automatically. The frontend boot-kickoff (`useAgentBootKickoff`) sent a default boot message — `"Session ready. Use the [Canvas Snapshot] ... to greet the user ..."` — to the agent whenever a canvas's chat was empty.

Even though that message told the agent not to run CLI commands, in practice the agent still produced verbose, zero-value openings (see the screenshot in the issue) and spent tokens without the user asking for anything. This made the agent feel out of control by default.

## Fix

Send **no** boot message by default. With no explicit boot context, `getAgentBootMessage` now returns an empty string, so the existing kickoff guard (`if (!bootMessage) skip`) means the agent stays idle until the user actually sends a message.

The user is still greeted: `AgentTabPanel` already prepends a static, client-side greeting (no tokens spent). The solicited flows are unchanged — a template install still sets its own boot context, and blank canvases already sent nothing.

## Testing

- Updated `agentBootContext.spec.ts` to assert no boot message is produced by default.
- `agentBootContext.spec.ts` passes (8/8).
- `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)