### PR TITLE
fix: resolve expressions in runner scripts safely

### DIFF
--- a/pkg/components/runner/run_bash.go
+++ b/pkg/components/runner/run_bash.go
@@ -183,6 +183,11 @@ func (c *RunBash) Configuration() []configuration.Field {
 			RequiredConditions: []configuration.RequiredCondition{
 				{Field: "enable_setup_commands", Values: []string{"true"}},
 			},
+			TypeOptions: &configuration.TypeOptions{
+				Text: &configuration.TextTypeOptions{
+					Language: "shell",
+				},
+			},
 		},
 		{
 			Name:        "script",

--- a/pkg/components/runner/run_javascript.go
+++ b/pkg/components/runner/run_javascript.go
@@ -181,6 +181,11 @@ func (c *RunJS) Configuration() []configuration.Field {
 			RequiredConditions: []configuration.RequiredCondition{
 				{Field: "enable_setup_commands", Values: []string{"true"}},
 			},
+			TypeOptions: &configuration.TypeOptions{
+				Text: &configuration.TextTypeOptions{
+					Language: "shell",
+				},
+			},
 		},
 		{
 			Name:        "script",

--- a/pkg/components/runner/run_python.go
+++ b/pkg/components/runner/run_python.go
@@ -176,6 +176,11 @@ func (c *RunPython) Configuration() []configuration.Field {
 			RequiredConditions: []configuration.RequiredCondition{
 				{Field: "enable_setup_commands", Values: []string{"true"}},
 			},
+			TypeOptions: &configuration.TypeOptions{
+				Text: &configuration.TextTypeOptions{
+					Language: "shell",
+				},
+			},
 		},
 		{
 			Name:        "script",

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -343,13 +343,21 @@ func (b *NodeConfigurationBuilder) ResolveCodeTemplateExpressions(expression str
 	return buf.String(), nil
 }
 
-// isInsideQuotedLiteral reports whether byte offset pos in source falls inside
-// an open single/double/backtick-quoted literal, by scanning from the start
-// of source and tracking quote/escape state. For Python, a triple-quote
-// delimiter (three repeated quote characters) is treated as one token rather
-// than as independent open/close events.
+// isInsideQuotedLiteral reports whether byte offset pos in source falls
+// inside an open string literal (or, for shell, a heredoc body), by scanning
+// from the start of source and tracking quote/escape state. Language-specific
+// rules are applied: JS backticks and Python triple-quotes are treated as
+// their own delimiters, and POSIX single-quoted shell strings have no escape
+// sequences at all (a backslash there is a literal character, not an escape).
 func isInsideQuotedLiteral(source string, pos int, language string) bool {
-	tripleQuotesAllowed := strings.EqualFold(language, "python")
+	language = strings.ToLower(language)
+	isShell := language == "shell"
+	tripleQuotesAllowed := language == "python"
+	backtickIsQuote := language == "javascript"
+
+	if isShell && isInsideShellHeredocBody(source, pos) {
+		return true
+	}
 
 	var openQuote byte
 	tripleQuoted := false
@@ -365,17 +373,21 @@ func isInsideQuotedLiteral(source string, pos int, language string) bool {
 				i += 3
 				continue
 			}
-			if c == '\'' || c == '"' || c == '`' {
+			if c == '\'' || c == '"' || (c == '`' && backtickIsQuote) {
 				openQuote = c
 			}
 			i++
 			continue
 		}
 
+		// POSIX single-quoted shell strings can't contain escapes; every other
+		// quote type (and every other language) does support backslash escapes.
+		escapesEnabled := !(isShell && openQuote == '\'')
+
 		switch {
-		case escaped:
+		case escapesEnabled && escaped:
 			escaped = false
-		case c == '\\':
+		case escapesEnabled && c == '\\':
 			escaped = true
 		case tripleQuoted && c == openQuote:
 			if !isTripleQuoteAt(source, i, openQuote) {
@@ -394,6 +406,74 @@ func isInsideQuotedLiteral(source string, pos int, language string) bool {
 
 func isTripleQuoteAt(source string, i int, quote byte) bool {
 	return i+2 < len(source) && source[i+1] == quote && source[i+2] == quote
+}
+
+// shellHeredocOpenerPattern matches a heredoc redirection (<<WORD, <<-WORD,
+// <<'WORD', <<"WORD"). Only quoted or ALL_CAPS delimiters are recognized, to
+// avoid mistaking arithmetic left-shift (e.g. $(( 1 << n ))) for a heredoc.
+var shellHeredocOpenerPattern = regexp.MustCompile(`(?m)<<-?[ \t]*(['"]?)([A-Za-z_][A-Za-z0-9_]*)['"]?`)
+
+func isInsideShellHeredocBody(source string, pos int) bool {
+	for _, body := range shellHeredocBodyRanges(source) {
+		if pos >= body[0] && pos < body[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// shellHeredocBodyRanges returns the [start, end) byte ranges of heredoc
+// bodies in source, which are treated as raw text (not shell code) since
+// they aren't subject to normal shell word-quoting rules.
+func shellHeredocBodyRanges(source string) [][2]int {
+	var ranges [][2]int
+
+	for _, m := range shellHeredocOpenerPattern.FindAllStringSubmatchIndex(source, -1) {
+		quoted := m[2] != m[3]
+		delimiter := source[m[4]:m[5]]
+		if !quoted && !isShoutingIdentifier(delimiter) {
+			continue
+		}
+
+		lineEnd := strings.IndexByte(source[m[1]:], '\n')
+		if lineEnd == -1 {
+			continue
+		}
+		bodyStart := m[1] + lineEnd + 1
+		bodyEnd := len(source)
+
+		for pos := bodyStart; pos <= len(source); {
+			next := strings.IndexByte(source[pos:], '\n')
+			line := source[pos:]
+			if next != -1 {
+				line = source[pos : pos+next]
+			}
+			if strings.TrimSpace(line) == delimiter {
+				bodyEnd = pos
+				break
+			}
+			if next == -1 {
+				break
+			}
+			pos += next + 1
+		}
+
+		ranges = append(ranges, [2]int{bodyStart, bodyEnd})
+	}
+
+	return ranges
+}
+
+// isShoutingIdentifier reports whether s looks like a conventional heredoc
+// delimiter (EOF, END, SCRIPT_EOF, ...): letters, digits, underscores, with
+// no lowercase letters.
+func isShoutingIdentifier(s string) bool {
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' {
+			return false
+		}
+	}
+	return true
 }
 
 func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, error) {

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -325,7 +325,7 @@ func (b *NodeConfigurationBuilder) ResolveCodeTemplateExpressions(expression str
 			return nil, err
 		}
 
-		if isInsideQuotedLiteral(expression, matchStart) {
+		if isInsideQuotedLiteral(expression, matchStart, language) {
 			buf.WriteString(formatTemplateValue(value))
 		} else {
 			literal, err := formatCodeLiteral(value, language)
@@ -345,32 +345,55 @@ func (b *NodeConfigurationBuilder) ResolveCodeTemplateExpressions(expression str
 
 // isInsideQuotedLiteral reports whether byte offset pos in source falls inside
 // an open single/double/backtick-quoted literal, by scanning from the start
-// of source and tracking quote/escape state.
-func isInsideQuotedLiteral(source string, pos int) bool {
+// of source and tracking quote/escape state. For Python, a triple-quote
+// delimiter (three repeated quote characters) is treated as one token rather
+// than as independent open/close events.
+func isInsideQuotedLiteral(source string, pos int, language string) bool {
+	tripleQuotesAllowed := strings.EqualFold(language, "python")
+
 	var openQuote byte
+	tripleQuoted := false
 	escaped := false
 
-	for i := 0; i < pos && i < len(source); i++ {
+	i := 0
+	for i < pos && i < len(source) {
 		c := source[i]
 
-		if openQuote != 0 {
-			switch {
-			case escaped:
-				escaped = false
-			case c == '\\':
-				escaped = true
-			case c == openQuote:
-				openQuote = 0
+		if openQuote == 0 {
+			if tripleQuotesAllowed && (c == '\'' || c == '"') && isTripleQuoteAt(source, i, c) {
+				openQuote, tripleQuoted = c, true
+				i += 3
+				continue
 			}
+			if c == '\'' || c == '"' || c == '`' {
+				openQuote = c
+			}
+			i++
 			continue
 		}
 
-		if c == '\'' || c == '"' || c == '`' {
-			openQuote = c
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\':
+			escaped = true
+		case tripleQuoted && c == openQuote:
+			if !isTripleQuoteAt(source, i, openQuote) {
+				break // a lone quote char inside a triple-quoted string doesn't close it
+			}
+			openQuote, tripleQuoted = 0, false
+			i += 2 // consume the other two quote chars; the trailing i++ below covers the third
+		case c == openQuote:
+			openQuote = 0
 		}
+		i++
 	}
 
 	return openQuote != 0
+}
+
+func isTripleQuoteAt(source string, i int, quote byte) bool {
+	return i+2 < len(source) && source[i+1] == quote && source[i+2] == quote
 }
 
 func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, error) {
@@ -861,9 +884,14 @@ func formatPythonList(value []any) (string, error) {
 	return buf.String(), nil
 }
 
-// formatShellLiteral renders value as a single, single-quoted POSIX shell
-// word, so it survives as one token regardless of embedded whitespace or
-// shell-special characters.
+// shellSafeWordPattern matches characters that never need quoting in a POSIX
+// shell word (mirrors Python's shlex.quote _find_unsafe allow-list).
+var shellSafeWordPattern = regexp.MustCompile(`^[\w@%+=:,./-]+$`)
+
+// formatShellLiteral renders value as a shell word, quoting it only when
+// necessary (empty, or containing whitespace/shell-special characters).
+// Plain numeric/word tokens are left bare so they still work in contexts like
+// $(( {{ x }} + 1 )) arithmetic expansion.
 func formatShellLiteral(value any) (string, error) {
 	var text string
 
@@ -880,6 +908,10 @@ func formatShellLiteral(value any) (string, error) {
 		text = string(encoded)
 	default:
 		text = formatTemplateValue(v)
+	}
+
+	if text != "" && shellSafeWordPattern.MatchString(text) {
+		return text, nil
 	}
 
 	return shellQuote(text), nil

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -168,7 +169,35 @@ func (b *NodeConfigurationBuilder) resolveFieldValue(value any, field configurat
 		}
 	}
 
+	if str, ok := value.(string); ok && field.Type == configuration.FieldTypeText {
+		if language, ok := codeFieldLanguage(field); ok {
+			return b.ResolveCodeTemplateExpressions(str, language)
+		}
+	}
+
 	return b.resolveValue(value)
+}
+
+// codeFieldLanguage returns the field's language and whether it's one we apply
+// type-aware literal substitution for (as opposed to prose fields or
+// non-executed languages like "json").
+func codeFieldLanguage(field configuration.Field) (string, bool) {
+	if field.TypeOptions == nil || field.TypeOptions.Text == nil {
+		return "", false
+	}
+
+	language := field.TypeOptions.Text.Language
+	if !isCodeLanguage(language) {
+		return "", false
+	}
+
+	return language, true
+}
+
+var codeLanguages = []string{"javascript", "python", "shell"}
+
+func isCodeLanguage(language string) bool {
+	return slices.Contains(codeLanguages, strings.ToLower(language))
 }
 
 func (b *NodeConfigurationBuilder) resolveListItems(list []any, itemDef *configuration.ListItemDefinition) ([]any, error) {
@@ -269,6 +298,79 @@ func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string)
 	}
 
 	return result, nil
+}
+
+// ResolveCodeTemplateExpressions is like ResolveTemplateExpressions, but for
+// fields holding source code. A bare placeholder is substituted as a valid,
+// correctly-typed literal for the given language instead of a naive stringified
+// value. A placeholder already inside the author's own quotes is left as-is,
+// to avoid double-quoting.
+func (b *NodeConfigurationBuilder) ResolveCodeTemplateExpressions(expression string, language string) (any, error) {
+	locations := expressionRegex.FindAllStringSubmatchIndex(expression, -1)
+	if len(locations) == 0 {
+		return expression, nil
+	}
+
+	var buf strings.Builder
+	lastEnd := 0
+
+	for _, loc := range locations {
+		matchStart, matchEnd := loc[0], loc[1]
+		innerStart, innerEnd := loc[2], loc[3]
+
+		buf.WriteString(expression[lastEnd:matchStart])
+
+		value, err := b.ResolveExpression(expression[innerStart:innerEnd])
+		if err != nil {
+			return nil, err
+		}
+
+		if isInsideQuotedLiteral(expression, matchStart) {
+			buf.WriteString(formatTemplateValue(value))
+		} else {
+			literal, err := formatCodeLiteral(value, language)
+			if err != nil {
+				return nil, fmt.Errorf("formatting %s literal: %w", language, err)
+			}
+			buf.WriteString(literal)
+		}
+
+		lastEnd = matchEnd
+	}
+
+	buf.WriteString(expression[lastEnd:])
+
+	return buf.String(), nil
+}
+
+// isInsideQuotedLiteral reports whether byte offset pos in source falls inside
+// an open single/double/backtick-quoted literal, by scanning from the start
+// of source and tracking quote/escape state.
+func isInsideQuotedLiteral(source string, pos int) bool {
+	var openQuote byte
+	escaped := false
+
+	for i := 0; i < pos && i < len(source); i++ {
+		c := source[i]
+
+		if openQuote != 0 {
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == openQuote:
+				openQuote = 0
+			}
+			continue
+		}
+
+		if c == '\'' || c == '"' || c == '`' {
+			openQuote = c
+		}
+	}
+
+	return openQuote != 0
 }
 
 func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, error) {
@@ -661,6 +763,130 @@ func formatTemplateValue(value any) string {
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+// formatCodeLiteral renders value as a syntactically valid, type-preserving
+// literal for the given source-code language.
+func formatCodeLiteral(value any, language string) (string, error) {
+	switch strings.ToLower(language) {
+	case "python":
+		return formatPythonLiteral(value)
+	case "shell":
+		return formatShellLiteral(value)
+	default:
+		// JSON literal syntax is a valid subset of JavaScript's, so this also
+		// covers "javascript" and any other code language added later.
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return "", err
+		}
+		return string(encoded), nil
+	}
+}
+
+// formatPythonLiteral renders value as a valid Python literal (None/True/False
+// instead of JSON's null/true/false).
+func formatPythonLiteral(value any) (string, error) {
+	switch v := value.(type) {
+	case nil:
+		return "None", nil
+	case bool:
+		if v {
+			return "True", nil
+		}
+		return "False", nil
+	case string:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(encoded), nil
+	case map[string]any:
+		return formatPythonDict(v)
+	case []any:
+		return formatPythonList(v)
+	default:
+		return formatTemplateValue(v), nil
+	}
+}
+
+func formatPythonDict(value map[string]any) (string, error) {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	buf.WriteByte('{')
+	for i, key := range keys {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return "", err
+		}
+		buf.Write(encodedKey)
+		buf.WriteString(": ")
+
+		literal, err := formatPythonLiteral(value[key])
+		if err != nil {
+			return "", err
+		}
+		buf.WriteString(literal)
+	}
+	buf.WriteByte('}')
+
+	return buf.String(), nil
+}
+
+func formatPythonList(value []any) (string, error) {
+	var buf strings.Builder
+	buf.WriteByte('[')
+	for i, item := range value {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+
+		literal, err := formatPythonLiteral(item)
+		if err != nil {
+			return "", err
+		}
+		buf.WriteString(literal)
+	}
+	buf.WriteByte(']')
+
+	return buf.String(), nil
+}
+
+// formatShellLiteral renders value as a single, single-quoted POSIX shell
+// word, so it survives as one token regardless of embedded whitespace or
+// shell-special characters.
+func formatShellLiteral(value any) (string, error) {
+	var text string
+
+	switch v := value.(type) {
+	case nil:
+		text = ""
+	case string:
+		text = v
+	case map[string]any, []any:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		text = string(encoded)
+	default:
+		text = formatTemplateValue(v)
+	}
+
+	return shellQuote(text), nil
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 type resolvedNodeRefs struct {

--- a/pkg/workers/contexts/node_configuration_builder_code_literal_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_code_literal_test.go
@@ -1,0 +1,137 @@
+package contexts
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+)
+
+func codeTextField(name, language string) configuration.Field {
+	return configuration.Field{
+		Name: name,
+		Type: configuration.FieldTypeText,
+		TypeOptions: &configuration.TypeOptions{
+			Text: &configuration.TextTypeOptions{
+				Language: language,
+			},
+		},
+	}
+}
+
+// Regression test for https://github.com/superplanehq/superplane/issues/5615.
+func Test_NodeConfigurationBuilder_CodeField_JavaScriptBareStringGetsQuoted(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{
+			"timestamp": "2026-07-02T08:53:06.174546542Z",
+		}).
+		WithConfigurationFields([]configuration.Field{codeTextField("script", "javascript")})
+
+	result, err := builder.Build(map[string]any{
+		"script": "console.log({{ root().timestamp }});",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, `console.log("2026-07-02T08:53:06.174546542Z");`, result["script"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_JavaScriptScalarTypes(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{
+			"count":   42,
+			"active":  true,
+			"missing": nil,
+			"nested":  map[string]any{"a": 1, "b": "x"},
+		})
+
+	fields := []configuration.Field{codeTextField("script", "javascript")}
+
+	result, err := builder.WithConfigurationFields(fields).Build(map[string]any{
+		"script": "const n = {{ root().count }}; const ok = {{ root().active }}; " +
+			"const m = {{ root().missing }}; const obj = {{ root().nested }};",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t,
+		`const n = 42; const ok = true; const m = null; const obj = {"a":1,"b":"x"};`,
+		result["script"],
+	)
+}
+
+func Test_NodeConfigurationBuilder_CodeField_PythonLiterals(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{
+			"active":  true,
+			"missing": nil,
+			"nested":  map[string]any{"a": nil, "b": true},
+		})
+
+	fields := []configuration.Field{codeTextField("script", "python")}
+
+	result, err := builder.WithConfigurationFields(fields).Build(map[string]any{
+		"script": "ok = {{ root().active }}\nm = {{ root().missing }}\nobj = {{ root().nested }}",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok = True\nm = None\nobj = {\"a\": None, \"b\": True}", result["script"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_ShellQuoting(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{
+			"message": "hello world",
+		})
+
+	fields := []configuration.Field{codeTextField("commands", "shell")}
+
+	result, err := builder.WithConfigurationFields(fields).Build(map[string]any{
+		"commands": "echo {{ root().message }}",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, `echo 'hello world'`, result["commands"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_AlreadyQuotedPlaceholderIsNotDoubleQuoted(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{
+			"timestamp": "2026-07-02T08:53:06Z",
+		})
+
+	fields := []configuration.Field{codeTextField("script", "javascript")}
+
+	backtickResult, err := builder.WithConfigurationFields(fields).Build(map[string]any{
+		"script": "console.log(`Time: {{ root().timestamp }}`);",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "console.log(`Time: 2026-07-02T08:53:06Z`);", backtickResult["script"])
+
+	doubleQuoteResult, err := builder.WithConfigurationFields(fields).Build(map[string]any{
+		"script": "console.log(\"Time: {{ root().timestamp }}\");",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "console.log(\"Time: 2026-07-02T08:53:06Z\");", doubleQuoteResult["script"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_NonCodeFieldsKeepRawSubstitution(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{
+			"name": "john",
+		})
+
+	fields := []configuration.Field{
+		{Name: "message", Type: configuration.FieldTypeText},
+		codeTextField("body", "json"),
+	}
+
+	result, err := builder.WithConfigurationFields(fields).Build(map[string]any{
+		"message": "Hello {{ root().name }}",
+		"body":    `{"name": "{{ root().name }}"}`,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Hello john", result["message"])
+	assert.Equal(t, `{"name": "john"}`, result["body"])
+}

--- a/pkg/workers/contexts/node_configuration_builder_code_literal_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_code_literal_test.go
@@ -94,6 +94,32 @@ func Test_NodeConfigurationBuilder_CodeField_ShellQuoting(t *testing.T) {
 	assert.Equal(t, `echo 'hello world'`, result["commands"])
 }
 
+func Test_NodeConfigurationBuilder_CodeField_ShellArithmeticExpansionStaysUnquoted(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"count": 5}).
+		WithConfigurationFields([]configuration.Field{codeTextField("commands", "shell")})
+
+	result, err := builder.Build(map[string]any{
+		"commands": "echo $(( {{ root().count }} + 1 ))",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "echo $(( 5 + 1 ))", result["commands"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_PythonTripleQuotedPlaceholderIsNotReQuoted(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"name": "john", "n": 5}).
+		WithConfigurationFields([]configuration.Field{codeTextField("script", "python")})
+
+	result, err := builder.Build(map[string]any{
+		"script": "msg = \"\"\"He said \"hi\" to {{ root().name }}\"\"\"\nn = {{ root().n }}",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "msg = \"\"\"He said \"hi\" to john\"\"\"\nn = 5", result["script"])
+}
+
 func Test_NodeConfigurationBuilder_CodeField_AlreadyQuotedPlaceholderIsNotDoubleQuoted(t *testing.T) {
 	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
 		WithRootPayload(map[string]any{

--- a/pkg/workers/contexts/node_configuration_builder_code_literal_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_code_literal_test.go
@@ -60,6 +60,17 @@ func Test_NodeConfigurationBuilder_CodeField_JavaScriptScalarTypes(t *testing.T)
 	)
 }
 
+func Test_NodeConfigurationBuilder_CodeField_JavaScriptFloat(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"price": 10.5}).
+		WithConfigurationFields([]configuration.Field{codeTextField("script", "javascript")})
+
+	result, err := builder.Build(map[string]any{"script": "const p = {{ root().price }};"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "const p = 10.5;", result["script"])
+}
+
 func Test_NodeConfigurationBuilder_CodeField_PythonLiterals(t *testing.T) {
 	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
 		WithRootPayload(map[string]any{
@@ -78,6 +89,19 @@ func Test_NodeConfigurationBuilder_CodeField_PythonLiterals(t *testing.T) {
 	assert.Equal(t, "ok = True\nm = None\nobj = {\"a\": None, \"b\": True}", result["script"])
 }
 
+func Test_NodeConfigurationBuilder_CodeField_PythonNumericTypes(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"price": 10.5, "count": 42}).
+		WithConfigurationFields([]configuration.Field{codeTextField("script", "python")})
+
+	result, err := builder.Build(map[string]any{
+		"script": "p = {{ root().price }}\nn = {{ root().count }}",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "p = 10.5\nn = 42", result["script"])
+}
+
 func Test_NodeConfigurationBuilder_CodeField_ShellQuoting(t *testing.T) {
 	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
 		WithRootPayload(map[string]any{
@@ -92,6 +116,68 @@ func Test_NodeConfigurationBuilder_CodeField_ShellQuoting(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, `echo 'hello world'`, result["commands"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_ShellQuoteEscapesEmbeddedQuote(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"name": "it's a test"}).
+		WithConfigurationFields([]configuration.Field{codeTextField("commands", "shell")})
+
+	result, err := builder.Build(map[string]any{"commands": "echo {{ root().name }}"})
+
+	require.NoError(t, err)
+	assert.Equal(t, `echo 'it'\''s a test'`, result["commands"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_ShellBacktickIsNotAQuote(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"cmd": "hello world"}).
+		WithConfigurationFields([]configuration.Field{codeTextField("commands", "shell")})
+
+	result, err := builder.Build(map[string]any{"commands": "result=`{{ root().cmd }}`"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "result=`'hello world'`", result["commands"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_ShellSingleQuoteHasNoEscapes(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"x": "unsafe value"}).
+		WithConfigurationFields([]configuration.Field{codeTextField("commands", "shell")})
+
+	// In POSIX shell, 'a\' is a complete string ("a\") followed by the string
+	// end; the backslash has no escaping power inside single quotes. So the
+	// placeholder below is bare (outside any quotes) and must get quoted.
+	result, err := builder.Build(map[string]any{"commands": `echo 'a\' {{ root().x }}`})
+
+	require.NoError(t, err)
+	assert.Equal(t, `echo 'a\' 'unsafe value'`, result["commands"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_ShellHeredocBodyStaysRaw(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"name": "John Smith"}).
+		WithConfigurationFields([]configuration.Field{codeTextField("script", "shell")})
+
+	result, err := builder.Build(map[string]any{
+		"script": "cat <<EOF\nHello {{ root().name }}\nEOF\necho done",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cat <<EOF\nHello John Smith\nEOF\necho done", result["script"])
+}
+
+func Test_NodeConfigurationBuilder_CodeField_ShellBitShiftIsNotMistakenForHeredoc(t *testing.T) {
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithRootPayload(map[string]any{"x": "hello world"}).
+		WithConfigurationFields([]configuration.Field{codeTextField("script", "shell")})
+
+	result, err := builder.Build(map[string]any{
+		"script": "echo $(( 1 << n ))\necho {{ root().x }}",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "echo $(( 1 << n ))\necho 'hello world'", result["script"])
 }
 
 func Test_NodeConfigurationBuilder_CodeField_ShellArithmeticExpansionStaysUnquoted(t *testing.T) {


### PR DESCRIPTION
## fix: quote and type-format template placeholders in code fields

### Problem

When a `{{ ... }}` template expression (e.g. `{{ root().timestamp }}`) was substituted into a code field (JavaScript/Python/Shell), the resolved value was inserted as a raw, unquoted string. For non-string-shaped values (like an ISO timestamp) this produced syntactically invalid code, e.g.:

```js
console.log(2026-07-02T08:53:06.174546542Z); // SyntaxError: Invalid or unexpected token
```

### What changed

Added language-aware, type-preserving literal substitution for code fields in `pkg/workers/contexts/node_configuration_builder.go`:

- **`ResolveCodeTemplateExpressions`**: for text fields tagged with a code `Language` (`javascript`, `python`, `shell`), each placeholder is now substituted as a correctly-typed, syntactically valid literal for that language (quoted strings, `null`/`None`, `true`/`True`, JSON-style objects/arrays, etc.) instead of a naive stringified value.
- **`isInsideQuotedLiteral`**: a lightweight quote-state scanner that detects when a placeholder is already inside the author's own string literal, so it's left untouched (avoiding double-quoting). It's language-aware:
  - Recognizes JS backtick template literals and Python triple-quoted strings (`"""..."""`) as single delimiters.
  - Does **not** treat backtick as a quote in shell (it's command substitution, not a string delimiter), so placeholders inside `` `...` `` get properly quoted.
  - Correctly models that POSIX single-quoted shell strings have no escape sequences at all (a `\` before the closing `'` doesn't extend the string).
  - Additionally recognizes shell heredoc bodies (`<<EOF` / `<<'EOF'`) and treats their contents as raw text rather than shell code needing quoting — restricted to quoted or ALL-CAPS delimiters to avoid misreading arithmetic left-shift (`$(( 1 << n ))`) as a heredoc.
- **`formatCodeLiteral`** dispatches to per-language formatters (`formatPythonLiteral`/`formatPythonDict`/`formatPythonList` for Python's `None`/`True`/`False`; JSON-style formatting for JS).
- **`formatShellLiteral`**: only quotes a shell value when it contains characters unsafe for bare word expansion (via `shellSafeWordPattern`), so numeric/word tokens stay unquoted (preserving shell arithmetic expansion), while unsafe strings get single-quoted with proper `'` escaping (`shellQuote`).
- Tagged `setup_commands` in `run_javascript.go`, `run_python.go`, `run_bash.go` with `Language: "shell"` so those fields get the new shell-safe substitution.

### Coverage

Added `pkg/workers/contexts/node_configuration_builder_code_literal_test.go` with regression tests for:

- The original bug (bare JS string gets quoted).
- JS/Python scalar types, including floats/ints, booleans, `nil`, and nested objects.
- Shell quoting of unsafe strings, and values containing embedded single quotes.
- Already-quoted placeholders (JS backticks/double quotes, Python triple quotes) are not double-quoted.
- Shell arithmetic expansion stays unquoted.
- Backticks in shell are treated as command substitution, not quotes.
- POSIX single-quote strings with no escape sequences are scanned correctly.
- Heredoc bodies are substituted raw.
- A `<<` bit-shift expression is not mistaken for a heredoc opener.
- Non-code text/JSON fields retain the original raw substitution behavior (no regression).

Resolves #5613 