### PR TITLE
fix: make code blocks in notes copyable, selectable, and scrollable

### DIFF
--- a/test/e2e/canvas_note_code_block_test.go
+++ b/test/e2e/canvas_note_code_block_test.go
@@ -1,0 +1,134 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	pw "github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+)
+
+// A single long line so the rendered code block must scroll horizontally
+// instead of wrapping. Intentionally a harmless, obviously-fake sample.
+const noteCodeContent = `echo "hello from superplane" && curl https://example.com/api/sample?foo=bar&baz=qux&page=1&limit=100&sort=asc&filter=none # just a sample line`
+
+func TestCanvasNoteCodeBlock(t *testing.T) {
+	t.Run("note code block is copyable and horizontally scrollable", func(t *testing.T) {
+		steps := &noteCodeBlockSteps{t: t}
+		steps.start()
+		steps.givenCanvas("E2E Note Code Block")
+		steps.enterEditMode()
+		steps.addNote()
+
+		steps.startEditingNote()
+		steps.fillNote("```\n" + noteCodeContent + "\n```")
+		steps.blurNoteEditor()
+
+		steps.assertCopyButtonVisible()
+		steps.assertCopyButtonCopiesCode()
+		steps.assertCodeBlockScrollsHorizontally()
+	})
+}
+
+type noteCodeBlockSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+}
+
+func (s *noteCodeBlockSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+
+	// Copying uses navigator.clipboard, which requires explicit permission in Chromium.
+	require.NoError(s.t, s.session.Page().Context().GrantPermissions(
+		[]string{"clipboard-read", "clipboard-write"},
+	))
+}
+
+func (s *noteCodeBlockSteps) givenCanvas(name string) {
+	s.canvas = shared.NewCanvasSteps(name, s.t, s.session)
+	s.canvas.Create()
+	s.canvas.Visit()
+
+	s.session.AssertVisible(q.TestID("canvas-edit-button"))
+}
+
+func (s *noteCodeBlockSteps) enterEditMode() {
+	editButton := q.TestID("canvas-edit-button").Run(s.session)
+	deadline := time.Now().Add(15 * time.Second)
+
+	for {
+		disabled, err := editButton.IsDisabled()
+		require.NoError(s.t, err)
+		if !disabled {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			s.t.Fatalf("edit button did not become enabled")
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	require.NoError(s.t, editButton.Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
+	s.session.AssertVisible(q.Locator(`header button:has-text("Publish")`))
+}
+
+func (s *noteCodeBlockSteps) addNote() {
+	s.canvas.AddNote()
+}
+
+func (s *noteCodeBlockSteps) startEditingNote() {
+	note := q.Text("Double click to add and edit notes...").Run(s.session)
+	require.NoError(s.t, note.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(10000),
+	}))
+	require.NoError(s.t, note.Dblclick(pw.LocatorDblclickOptions{Timeout: pw.Float(10000)}))
+	s.session.AssertVisible(q.Locator(`textarea[aria-label="Note note"]`))
+}
+
+func (s *noteCodeBlockSteps) fillNote(text string) {
+	s.session.FillIn(q.Locator(`textarea[aria-label="Note note"]`), text)
+}
+
+func (s *noteCodeBlockSteps) blurNoteEditor() {
+	s.canvas.ClickOnEmptyCanvasArea()
+	s.session.AssertHidden(q.Locator(`textarea[aria-label="Note note"]`))
+}
+
+func (s *noteCodeBlockSteps) assertCopyButtonVisible() {
+	s.session.AssertVisible(q.TestID("note-code-copy"))
+}
+
+func (s *noteCodeBlockSteps) assertCopyButtonCopiesCode() {
+	s.session.Click(q.TestID("note-code-copy"))
+
+	require.Eventually(s.t, func() bool {
+		clipboard, err := s.session.Page().Evaluate(`() => navigator.clipboard.readText()`)
+		if err != nil {
+			return false
+		}
+		text, ok := clipboard.(string)
+		return ok && text == noteCodeContent
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+func (s *noteCodeBlockSteps) assertCodeBlockScrollsHorizontally() {
+	pre := q.Locator("pre").Run(s.session)
+	require.NoError(s.t, pre.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(10000),
+	}))
+
+	overflowing, err := pre.Evaluate(`el => el.scrollWidth > el.clientWidth`, nil)
+	require.NoError(s.t, err)
+	require.Equal(s.t, true, overflowing, "code block should overflow horizontally and scroll")
+}

--- a/web_src/src/lib/markdownCode.ts
+++ b/web_src/src/lib/markdownCode.ts
@@ -1,0 +1,47 @@
+import React from "react";
+
+/** Recursively flattens a React node tree into its plain text content. */
+export function extractTextFromNode(node: React.ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(extractTextFromNode).join("");
+  }
+
+  if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+    return extractTextFromNode(node.props.children);
+  }
+
+  return "";
+}
+
+/**
+ * Extracts the raw code text (and optional language) from the children of a
+ * markdown `pre` element, which react-markdown renders as a nested `code` node.
+ */
+export function extractCodeBlock(children: React.ReactNode): { code: string; language?: string } {
+  const childArray = React.Children.toArray(children);
+
+  const codeElement = childArray.find(
+    (
+      child,
+    ): child is React.ReactElement<{
+      className?: string;
+      children?: React.ReactNode;
+    }> => React.isValidElement(child) && child.type === "code",
+  );
+
+  if (!codeElement) {
+    return { code: extractTextFromNode(children).replace(/\n$/, "") };
+  }
+
+  const className = codeElement.props.className;
+  const language = className?.startsWith("language-") ? className.slice("language-".length) : undefined;
+
+  return {
+    code: extractTextFromNode(codeElement.props.children).replace(/\n$/, ""),
+    language,
+  };
+}

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/Instructions.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/Instructions.tsx
@@ -1,10 +1,10 @@
-import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/ui/CopyButton";
+import { extractCodeBlock, extractTextFromNode } from "@/lib/markdownCode";
 
 const INSTRUCTIONS_V2_CLASSES =
   "text-sm text-gray-800 dark:text-gray-200 [&_a]:!underline [&_a]:underline-offset-2 [&_a]:decoration-2 [&_a]:decoration-current [&_ol]:list-decimal [&_ol]:ml-5 [&_ol]:space-y-1 [&_ul]:list-disc [&_ul]:ml-5 [&_ul]:space-y-1";
@@ -20,47 +20,6 @@ export interface InstructionsProps {
   description?: string | null;
   onContinue?: () => void;
   className?: string;
-}
-
-function extractTextFromNode(node: React.ReactNode): string {
-  if (typeof node === "string" || typeof node === "number") {
-    return String(node);
-  }
-
-  if (Array.isArray(node)) {
-    return node.map(extractTextFromNode).join("");
-  }
-
-  if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
-    return extractTextFromNode(node.props.children);
-  }
-
-  return "";
-}
-
-function extractCodeBlock(children: React.ReactNode): { code: string; language?: string } {
-  const childArray = React.Children.toArray(children);
-
-  const codeElement = childArray.find(
-    (
-      child,
-    ): child is React.ReactElement<{
-      className?: string;
-      children?: React.ReactNode;
-    }> => React.isValidElement(child) && child.type === "code",
-  );
-
-  if (!codeElement) {
-    return { code: extractTextFromNode(children).replace(/\n$/, "") };
-  }
-
-  const className = codeElement.props.className;
-  const language = className?.startsWith("language-") ? className.slice("language-".length) : undefined;
-
-  return {
-    code: extractTextFromNode(codeElement.props.children).replace(/\n$/, ""),
-    language,
-  };
 }
 
 export function Instructions({ description, onContinue, className = "" }: InstructionsProps) {

--- a/web_src/src/ui/annotationComponent/index.tsx
+++ b/web_src/src/ui/annotationComponent/index.tsx
@@ -366,7 +366,7 @@ const AnnotationComponentBase: React.FC<AnnotationComponentProps> = ({
                 ) : (
                   <div
                     className={cn(
-                      "nodrag h-full w-full overflow-auto text-left select-text",
+                      "nodrag nowheel h-full w-full overflow-auto text-left select-text",
                       isNoteEditable ? "cursor-text" : "cursor-default",
                       textStyles,
                     )}
@@ -410,7 +410,7 @@ const AnnotationComponentBase: React.FC<AnnotationComponentProps> = ({
                                 <div className="absolute right-1 top-1 z-10 rounded bg-slate-700">
                                   <CopyButton text={code} dark data-testid="note-code-copy" />
                                 </div>
-                                <pre className="nodrag select-text overflow-x-auto whitespace-pre px-2.5 py-2 pr-9 text-xs leading-relaxed font-mono [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:cursor-pointer [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-thumb:hover]:bg-white/60">
+                                <pre className="nodrag nowheel select-text overflow-x-auto whitespace-pre px-2.5 py-2 pr-9 text-xs leading-relaxed font-mono [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:cursor-pointer [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-thumb:hover]:bg-white/60">
                                   {children}
                                 </pre>
                               </div>

--- a/web_src/src/ui/annotationComponent/index.tsx
+++ b/web_src/src/ui/annotationComponent/index.tsx
@@ -4,6 +4,8 @@ import { Trash2 } from "lucide-react";
 import { NodeResizeControl, type ResizeParams } from "@xyflow/react";
 import ReactMarkdown from "react-markdown";
 import { cn } from "@/lib/utils";
+import { extractCodeBlock } from "@/lib/markdownCode";
+import { CopyButton } from "@/ui/CopyButton";
 import { getDraftDiffOutlineClassName, type DraftDiffStatus } from "@/lib/draftDiff";
 import { SelectionWrapper } from "../selectionWrapper";
 import { setActiveNoteId } from "./noteFocus";
@@ -364,7 +366,7 @@ const AnnotationComponentBase: React.FC<AnnotationComponentProps> = ({
                 ) : (
                   <div
                     className={cn(
-                      "nodrag h-full w-full overflow-auto text-left",
+                      "nodrag h-full w-full overflow-auto text-left select-text",
                       isNoteEditable ? "cursor-text" : "cursor-default",
                       textStyles,
                     )}
@@ -389,10 +391,31 @@ const AnnotationComponentBase: React.FC<AnnotationComponentProps> = ({
                           h4: ({ children }) => (
                             <h4 className="mt-2 first:mt-0 mb-1 text-xs font-medium leading-tight">{children}</h4>
                           ),
-                          code: ({ children }) => <code className="bg-black/10 px-1 rounded text-xs">{children}</code>,
-                          pre: ({ children }) => (
-                            <pre className="bg-black/10 p-2 rounded text-xs overflow-auto mb-2">{children}</pre>
-                          ),
+                          code: ({ children, className: codeClassName }) => {
+                            // Block-level code (inside our custom `pre`) is rendered plain so the
+                            // `pre` wrapper controls scrolling; only inline code gets the chip style.
+                            if (codeClassName?.includes("language-")) {
+                              return <code className={codeClassName}>{children}</code>;
+                            }
+                            return <code className="px-1 rounded text-xs font-mono">{children}</code>;
+                          },
+                          pre: ({ children }) => {
+                            const { code } = extractCodeBlock(children);
+                            return (
+                              <div
+                                className="relative mb-2 overflow-hidden rounded-md bg-slate-700 text-gray-100"
+                                onDoubleClick={(event) => event.stopPropagation()}
+                              >
+                                {/* Opaque chip so code scrolling underneath stays hidden behind the button. */}
+                                <div className="absolute right-1 top-1 z-10 rounded bg-slate-700">
+                                  <CopyButton text={code} dark data-testid="note-code-copy" />
+                                </div>
+                                <pre className="nodrag select-text overflow-x-auto whitespace-pre px-2.5 py-2 pr-9 text-xs leading-relaxed font-mono [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:cursor-pointer [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-thumb:hover]:bg-white/60">
+                                  {children}
+                                </pre>
+                              </div>
+                            );
+                          },
                           a: ({ children, href }) => (
                             <a
                               target="_blank"


### PR DESCRIPTION
## Summary
Fixes [#3730](https://github.com/superplanehq/superplane/issues/3730). Long code content inside canvas notes was hard to read and impossible to copy:

No copy button on code blocks (a now-standard markdown feature).
Text couldn't be manually selected/copied because the whole note viewer was wired to double-click-to-edit.
Long lines wrapped/clipped instead of scrolling horizontally.
This reworks the note (annotation) code-block rendering to match the pattern already used in Integration Instructions.

## Changes
- Copy button: each code block now renders a CopyButton overlaid in the top-right, copying the raw code content.
Selectable text: the note viewer allows manual text selection (select-text), and interacting with a code block stops the double-click from flipping the note into edit mode — so you can select/copy inside it.
- Horizontal scroll: code blocks use overflow-x-auto whitespace-pre font-mono so long lines scroll instead of wrapping; inline code also gets font-mono.
- Styling: single solid bg-slate-700 container with overflow-hidden rounded-md (crisp edges), a thin scrollbar with a hover color and pointer cursor, and an opaque chip behind the copy button so code scrolling underneath stays hidden.
- Refactor: extracted the shared extractTextFromNode / extractCodeBlock helpers into web_src/src/lib/markdownCode.ts and reused them in both Instructions.tsx and the note component (removes duplication, no behavior change).

<img width="1508" height="1158" alt="image" src="https://github.com/user-attachments/assets/89eaab46-2c6e-4792-bef8-5da53468f816" />
