### PR TITLE
fix: clarify $ expression description in autocomplete

### DIFF
--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -1368,7 +1368,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
                       <>
                         <div className="text-sm font-medium text-gray-950 dark:text-white mb-1">$ (Event Data)</div>
                         <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                          Root selector for accessing payload data from all connected components.
+                          {highlightedSuggestion.description}
                         </div>
                         <div className={twMerge(valuePreviewCodeBlockClassName, "text-sky-700")}>
                           {highlightedSuggestion.nodeCount ?? 0} node

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -730,7 +730,8 @@ export function getSuggestions<TGlobals extends Record<string, unknown>>(
         kind: "variable",
         insertText: "$",
         detail: getValueTypeLabel(globals),
-        description: "Root selector for accessing payload data from all connected components.",
+        description:
+          'Access event data emitted by connected components in a run, keyed by component name (e.g. $["Component Name"]).',
         nodeCount,
       });
     }


### PR DESCRIPTION
## Summary
Fixes #1803. The expression autocomplete described `$` as the "Root selector for accessing payload data from all connected components", which is misleading — `$` is not a root selector. It's the object holding event data emitted by connected components, keyed by component name.

- Reworded the `$` suggestion description to: `Access event data emitted by connected components, keyed by component name (e.g. $["Component Name"]).`
- The `$` value-preview panel now renders `highlightedSuggestion.description` instead of a hardcoded duplicate string, so the wording has a single source of truth.
