### PR TITLE
fix: keep expression autocomplete anchored to input on scroll

### DIFF
--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -942,6 +942,37 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       measureCursorPixelPosition();
     }, [measureCursorPixelPosition]);
 
+    // Keep the fixed-position dropdown anchored to the input while any ancestor
+    // scrolls or the window resizes. Without this the dropdown detaches from the
+    // input when the surrounding panel scrolls (issue #3615).
+    useEffect(() => {
+      if (!isOpen || suggestions.length === 0) {
+        return;
+      }
+
+      let frame = 0;
+      const reposition = () => {
+        if (frame) {
+          return;
+        }
+        frame = requestAnimationFrame(() => {
+          frame = 0;
+          measureCursorPixelPosition();
+        });
+      };
+
+      // Capture phase so scrolling of any scrollable ancestor is observed, not just window.
+      window.addEventListener("scroll", reposition, true);
+      window.addEventListener("resize", reposition);
+      return () => {
+        if (frame) {
+          cancelAnimationFrame(frame);
+        }
+        window.removeEventListener("scroll", reposition, true);
+        window.removeEventListener("resize", reposition);
+      };
+    }, [isOpen, suggestions.length, measureCursorPixelPosition]);
+
     useEffect(() => {
       setInputValue(value);
     }, [value]);


### PR DESCRIPTION
## Summary
Fixes #3615. The expression autocomplete dropdown is rendered in a portal with `position: fixed`, positioned from the input's `getBoundingClientRect()`. That position was only recomputed when the value/cursor changed, so scrolling the surrounding panel (or resizing the window) left the dropdown floating in its old spot, detached from the input.

- While the dropdown is open, listen for `scroll` (capture phase, so scrolling of any scrollable ancestor is observed) and `resize`, and recompute the dropdown position.
- Throttle repositioning with `requestAnimationFrame` and clean up listeners when the dropdown closes.
