### PR TITLE
fix: fit view to whole graph when switching canvas or version

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -72,7 +72,7 @@ import { getActiveNoteId, restoreActiveNoteFocus } from "@/ui/annotationComponen
 import { buildBuildingBlockCategories } from "@/ui/buildingBlocks";
 import type { CanvasNode, NewNodeData, NodeEditData, SidebarData } from "@/ui/CanvasPage";
 import { CANVAS_SIDEBAR_STORAGE_KEY, CanvasPage, type MissingIntegration } from "@/ui/CanvasPage";
-import { computeFitViewContentKey } from "@/ui/CanvasPage/fitView";
+import { resolveFitViewVersionId } from "@/ui/CanvasPage/fitView";
 import type { EventState, EventStateMap } from "@/ui/componentBase";
 import type { TabData } from "@/ui/componentSidebar/SidebarEventItem/SidebarEventItem";
 import type { SidebarEvent } from "@/ui/componentSidebar/types";
@@ -4489,7 +4489,7 @@ export function AppPage() {
           hasUserToggledSidebarRef={hasUserToggledSidebarRef}
           isSidebarOpenRef={isSidebarOpenRef}
           viewportRef={isRunInspectionMode ? runsViewportRef : viewportRef}
-          fitViewContentKey={computeFitViewContentKey({ isRunInspectionMode, canvasId, canvasViewKey })}
+          fitViewContentKey={`${canvasId}:${resolveFitViewVersionId({ liveCanvasVersionId, activeCanvasVersionId, isViewingDraftVersion, draftSpec: draftSpecToRender, selectedVersion: selectedCanvasVersion })}`}
           lastFittedContentKeyRef={lastFittedContentKeyRef}
           initialFocusNodeId={initialFocusNodeIdRef.current}
           fitAllFocusNodeIds={

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -72,6 +72,7 @@ import { getActiveNoteId, restoreActiveNoteFocus } from "@/ui/annotationComponen
 import { buildBuildingBlockCategories } from "@/ui/buildingBlocks";
 import type { CanvasNode, NewNodeData, NodeEditData, SidebarData } from "@/ui/CanvasPage";
 import { CANVAS_SIDEBAR_STORAGE_KEY, CanvasPage, type MissingIntegration } from "@/ui/CanvasPage";
+import { computeFitViewContentKey } from "@/ui/CanvasPage/fitView";
 import type { EventState, EventStateMap } from "@/ui/componentBase";
 import type { TabData } from "@/ui/componentSidebar/SidebarEventItem/SidebarEventItem";
 import type { SidebarEvent } from "@/ui/componentSidebar/types";
@@ -618,6 +619,8 @@ export function AppPage() {
    */
   const hasFitToViewRef = useRef(false);
   const runsHasFitToViewRef = useRef(false);
+  // Canvas/version the persisted viewport was fitted for; switching content re-fits the graph.
+  const lastFittedContentKeyRef = useRef<string | null>(null);
   const hasSyncedVersionFromURLRef = useRef(false);
 
   /**
@@ -4240,12 +4243,7 @@ export function AppPage() {
       </div>
     ) : null;
   const canvasViewKey = selectedCanvasVersion?.metadata?.id || liveCanvasVersionId || "live";
-  const canvasRenderKey = [
-    canvasViewKey,
-    isDraftCanvasLoading ? "draft-loading" : "draft-ready",
-    isRunInspectionMode ? "runs" : "canvas",
-    `reset-${stagingResetNonce}`,
-  ].join(":");
+  const canvasRenderKey = `${canvasViewKey}:${isDraftCanvasLoading ? "draft-loading" : "draft-ready"}:${isRunInspectionMode ? "runs" : "canvas"}:reset-${stagingResetNonce}`;
   const headerBanners = [appBanner, remoteUpdateBanner].filter(Boolean);
   const headerBanner = headerBanners.length > 0 ? <div className="flex flex-col">{headerBanners}</div> : null;
   const enterEditModeDisabled = !canUpdateCanvas || canvasDeletedRemotely;
@@ -4491,6 +4489,8 @@ export function AppPage() {
           hasUserToggledSidebarRef={hasUserToggledSidebarRef}
           isSidebarOpenRef={isSidebarOpenRef}
           viewportRef={isRunInspectionMode ? runsViewportRef : viewportRef}
+          fitViewContentKey={computeFitViewContentKey({ isRunInspectionMode, canvasId, canvasViewKey })}
+          lastFittedContentKeyRef={lastFittedContentKeyRef}
           initialFocusNodeId={initialFocusNodeIdRef.current}
           fitAllFocusNodeIds={
             isRunInspectionMode && selectedRun && runCanvasData && runCanvasData.participantNodeIds.length > 0

--- a/web_src/src/ui/CanvasPage/fitView.spec.ts
+++ b/web_src/src/ui/CanvasPage/fitView.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { computeFitViewContentKey, shouldRefitOnInit, stampFittedContentKey } from "./fitView";
+
+describe("computeFitViewContentKey", () => {
+  it("combines canvas id and view key outside run inspection", () => {
+    expect(computeFitViewContentKey({ isRunInspectionMode: false, canvasId: "c1", canvasViewKey: "v1" })).toBe("c1:v1");
+  });
+
+  it("returns undefined in run inspection so run mode keeps its own fit handling", () => {
+    expect(
+      computeFitViewContentKey({ isRunInspectionMode: true, canvasId: "c1", canvasViewKey: "v1" }),
+    ).toBeUndefined();
+  });
+
+  it("tolerates a missing canvas id", () => {
+    expect(computeFitViewContentKey({ isRunInspectionMode: false, canvasViewKey: "live" })).toBe(":live");
+  });
+});
+
+describe("shouldRefitOnInit", () => {
+  it("fits on the first initialization", () => {
+    expect(shouldRefitOnInit({ hasFittedBefore: false, fitViewContentKey: "c1:v1", lastFittedContentKey: null })).toBe(
+      true,
+    );
+  });
+
+  it("re-fits when the displayed content key changed", () => {
+    expect(
+      shouldRefitOnInit({ hasFittedBefore: true, fitViewContentKey: "c1:v2", lastFittedContentKey: "c1:v1" }),
+    ).toBe(true);
+  });
+
+  it("restores instead of re-fitting when the content key is unchanged", () => {
+    expect(
+      shouldRefitOnInit({ hasFittedBefore: true, fitViewContentKey: "c1:v1", lastFittedContentKey: "c1:v1" }),
+    ).toBe(false);
+  });
+
+  it("does not force a re-fit when there is no content key (run inspection)", () => {
+    expect(
+      shouldRefitOnInit({ hasFittedBefore: true, fitViewContentKey: undefined, lastFittedContentKey: "c1:v1" }),
+    ).toBe(false);
+  });
+});
+
+describe("stampFittedContentKey", () => {
+  it("records the fitted content key", () => {
+    const ref = { current: null as string | null };
+    stampFittedContentKey(ref, "c1:v1");
+    expect(ref.current).toBe("c1:v1");
+  });
+
+  it("ignores an undefined content key so a later init re-fits", () => {
+    const ref = { current: "c1:v1" as string | null };
+    stampFittedContentKey(ref, undefined);
+    expect(ref.current).toBe("c1:v1");
+  });
+
+  it("is a no-op without a ref", () => {
+    expect(() => stampFittedContentKey(undefined, "c1:v1")).not.toThrow();
+  });
+});

--- a/web_src/src/ui/CanvasPage/fitView.spec.ts
+++ b/web_src/src/ui/CanvasPage/fitView.spec.ts
@@ -1,19 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { computeFitViewContentKey, shouldRefitOnInit, stampFittedContentKey } from "./fitView";
+import { resolveFitViewVersionId, shouldRefitOnInit, stampFittedContentKey } from "./fitView";
 
-describe("computeFitViewContentKey", () => {
-  it("combines canvas id and view key outside run inspection", () => {
-    expect(computeFitViewContentKey({ isRunInspectionMode: false, canvasId: "c1", canvasViewKey: "v1" })).toBe("c1:v1");
+describe("resolveFitViewVersionId", () => {
+  const liveParams = {
+    liveCanvasVersionId: "live1",
+    activeCanvasVersionId: "",
+    isViewingDraftVersion: false,
+    draftSpec: null as unknown,
+    selectedVersion: null as { spec?: unknown } | null,
+  };
+
+  it("uses the live version id when no version is being previewed", () => {
+    expect(resolveFitViewVersionId(liveParams)).toBe("live1");
   });
 
-  it("returns undefined in run inspection so run mode keeps its own fit handling", () => {
-    expect(
-      computeFitViewContentKey({ isRunInspectionMode: true, canvasId: "c1", canvasViewKey: "v1" }),
-    ).toBeUndefined();
+  it("keeps the live version id while a previewed version's spec is still loading (stale graph on screen)", () => {
+    expect(resolveFitViewVersionId({ ...liveParams, activeCanvasVersionId: "v2", selectedVersion: {} })).toBe("live1");
   });
 
-  it("tolerates a missing canvas id", () => {
-    expect(computeFitViewContentKey({ isRunInspectionMode: false, canvasViewKey: "live" })).toBe(":live");
+  it("switches to the previewed version id once its spec is loaded", () => {
+    expect(resolveFitViewVersionId({ ...liveParams, activeCanvasVersionId: "v2", selectedVersion: { spec: {} } })).toBe(
+      "v2",
+    );
+  });
+
+  it("uses the draft version id only once the draft spec is available", () => {
+    const draftLoading = { ...liveParams, activeCanvasVersionId: "d1", isViewingDraftVersion: true, draftSpec: null };
+    expect(resolveFitViewVersionId(draftLoading)).toBe("live1");
+    expect(resolveFitViewVersionId({ ...draftLoading, draftSpec: {} })).toBe("d1");
+  });
+
+  it("falls back to 'live' when there is no live version id", () => {
+    expect(resolveFitViewVersionId({ ...liveParams, liveCanvasVersionId: undefined })).toBe("live");
   });
 });
 

--- a/web_src/src/ui/CanvasPage/fitView.ts
+++ b/web_src/src/ui/CanvasPage/fitView.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure helpers for deciding when the canvas should re-run its first-load
+ * fit-to-view. Switching canvas or version must re-fit the whole graph instead
+ * of restoring the previous content's persisted viewport.
+ */
+
+/** Builds the key identifying the displayed canvas/version, or undefined in run inspection. */
+export function computeFitViewContentKey(params: {
+  isRunInspectionMode: boolean;
+  canvasId?: string;
+  canvasViewKey: string;
+}): string | undefined {
+  if (params.isRunInspectionMode) {
+    return undefined;
+  }
+  return `${params.canvasId ?? ""}:${params.canvasViewKey}`;
+}
+
+/** True on first init or whenever the displayed content changed since the last fit. */
+export function shouldRefitOnInit(params: {
+  hasFittedBefore: boolean;
+  fitViewContentKey?: string;
+  lastFittedContentKey: string | null;
+}): boolean {
+  if (!params.hasFittedBefore) {
+    return true;
+  }
+  if (params.fitViewContentKey === undefined) {
+    return false;
+  }
+  return params.lastFittedContentKey !== params.fitViewContentKey;
+}
+
+/** Records the content key that was just fitted (only once real nodes were present). */
+export function stampFittedContentKey(
+  ref: { current: string | null } | undefined,
+  fitViewContentKey: string | undefined,
+): void {
+  if (!ref || fitViewContentKey === undefined) {
+    return;
+  }
+  ref.current = fitViewContentKey;
+}

--- a/web_src/src/ui/CanvasPage/fitView.ts
+++ b/web_src/src/ui/CanvasPage/fitView.ts
@@ -4,16 +4,27 @@
  * of restoring the previous content's persisted viewport.
  */
 
-/** Builds the key identifying the displayed canvas/version, or undefined in run inspection. */
-export function computeFitViewContentKey(params: {
-  isRunInspectionMode: boolean;
-  canvasId?: string;
-  canvasViewKey: string;
-}): string | undefined {
-  if (params.isRunInspectionMode) {
-    return undefined;
+/**
+ * Resolves the version id of the graph actually rendered right now.
+ *
+ * It reflects the *rendered* content, not just the selected version: while a
+ * previewed version's spec is still loading, the graph on screen is still the
+ * previous (live) content, so this stays on the live id. That way the fit waits
+ * for the real nodes instead of fitting (and stamping) the stale graph, which would
+ * otherwise block the re-fit once the version's spec arrives without a remount.
+ */
+export function resolveFitViewVersionId(params: {
+  liveCanvasVersionId?: string;
+  activeCanvasVersionId?: string;
+  isViewingDraftVersion: boolean;
+  draftSpec?: unknown;
+  selectedVersion?: { spec?: unknown } | null;
+}): string {
+  const showingSelectedVersion = params.isViewingDraftVersion ? !!params.draftSpec : !!params.selectedVersion?.spec;
+  if (params.activeCanvasVersionId && showingSelectedVersion) {
+    return params.activeCanvasVersionId;
   }
-  return `${params.canvasId ?? ""}:${params.canvasViewKey}`;
+  return params.liveCanvasVersionId || "live";
 }
 
 /** True on first init or whenever the displayed content changed since the last fit. */

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -734,6 +734,47 @@ describe("CanvasPage fit-to-view on canvas/version switch", () => {
     }
   });
 
+  it("does not re-fit while editing when the draft version changes", () => {
+    const hasFitToViewRef = { current: false };
+    const lastFittedContentKeyRef = { current: null as string | null };
+
+    const canvas = (fitViewContentKey: string) => (
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={singleNode}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={true}
+          activeCanvasVersionId="draft-1"
+          fitViewContentKey={fitViewContentKey}
+          hasFitToViewRef={hasFitToViewRef}
+          lastFittedContentKeyRef={lastFittedContentKeyRef}
+        />
+      </MemoryRouter>
+    );
+
+    const { rerender } = render(canvas("canvas-1:draft-1"));
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+    });
+    // First mount still performs the initial fit so a freshly opened editor is framed.
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+
+    // Entering edit mode / saving churns the draft version id. That must not move
+    // the viewport, otherwise coordinate-based interactions (e.g. deleting an edge)
+    // would land on the wrong place.
+    rerender(canvas("canvas-1:draft-2"));
+    const setViewport = vi.fn();
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport });
+    });
+
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+    expect(setViewport).toHaveBeenCalled();
+  });
+
   it("restores the stored viewport instead of re-fitting when the content key is unchanged", () => {
     const hasFitToViewRef = { current: false };
     const lastFittedContentKeyRef = { current: null as string | null };

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -687,6 +687,45 @@ describe("CanvasPage fit-to-view on canvas/version switch", () => {
     expect(lastFittedContentKeyRef.current).toBe("canvas-1:v2");
   });
 
+  it("honors the URL node focus only on the first fit, not on later switches", () => {
+    const hasFitToViewRef = { current: false };
+    const lastFittedContentKeyRef = { current: null as string | null };
+
+    const canvas = (fitViewContentKey: string) => (
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={singleNode}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="v1"
+          initialFocusNodeId="node-1"
+          fitViewContentKey={fitViewContentKey}
+          hasFitToViewRef={hasFitToViewRef}
+          lastFittedContentKeyRef={lastFittedContentKeyRef}
+        />
+      </MemoryRouter>
+    );
+
+    const { rerender } = render(canvas("canvas-1:v1"));
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+    });
+    // First fit frames the deep-linked node.
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+    expect(fitViewMock.mock.calls[0][0]?.nodes).toBeDefined();
+
+    // Switching version must frame the whole graph, not re-zoom onto the URL node.
+    rerender(canvas("canvas-1:v2"));
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+    });
+    expect(fitViewMock).toHaveBeenCalledTimes(2);
+    expect(fitViewMock.mock.calls[1][0]?.nodes).toBeUndefined();
+  });
+
   it("re-fits without a remount once the previewed version's nodes arrive", () => {
     vi.useFakeTimers();
     try {

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -687,6 +687,53 @@ describe("CanvasPage fit-to-view on canvas/version switch", () => {
     expect(lastFittedContentKeyRef.current).toBe("canvas-1:v2");
   });
 
+  it("re-fits without a remount once the previewed version's nodes arrive", () => {
+    vi.useFakeTimers();
+    try {
+      const hasFitToViewRef = { current: false };
+      const lastFittedContentKeyRef = { current: null as string | null };
+      const workflowNodes = [{ id: "node-1", type: "TYPE_ACTION" as const, name: "Node" }];
+
+      const canvas = (fitViewContentKey: string) => (
+        <MemoryRouter>
+          <CanvasPage
+            title="Canvas"
+            headerMode="version-live"
+            nodes={singleNode}
+            edges={[]}
+            buildingBlocks={[]}
+            isEditing={false}
+            activeCanvasVersionId="v1"
+            fitViewContentKey={fitViewContentKey}
+            hasFitToViewRef={hasFitToViewRef}
+            lastFittedContentKeyRef={lastFittedContentKeyRef}
+            workflowNodes={workflowNodes}
+          />
+        </MemoryRouter>
+      );
+
+      // Previewing a published version renders the stale live graph first.
+      const { rerender } = render(canvas("canvas-1:live"));
+      act(() => {
+        reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+      });
+      expect(fitViewMock).toHaveBeenCalledTimes(1);
+      expect(lastFittedContentKeyRef.current).toBe("canvas-1:live");
+
+      // The version's spec loads without a remount: the content key flips to the
+      // version, so the graph must re-fit to the real nodes rather than stay stale.
+      rerender(canvas("canvas-1:v2"));
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(fitViewMock).toHaveBeenCalledTimes(2);
+      expect(lastFittedContentKeyRef.current).toBe("canvas-1:v2");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("restores the stored viewport instead of re-fitting when the content key is unchanged", () => {
     const hasFitToViewRef = { current: false };
     const lastFittedContentKeyRef = { current: null as string | null };

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -16,6 +16,7 @@ const { captureException, fitViewMock, getNodesMock, reactFlowPropsRef } = vi.ho
       onPaneClick?: (...args: unknown[]) => unknown;
       onEdgeMouseEnter?: (...args: unknown[]) => unknown;
       onEdgeMouseLeave?: (...args: unknown[]) => unknown;
+      onInit?: (instance: { setViewport: (viewport: unknown) => void }) => void;
       onlyRenderVisibleElements?: boolean;
     },
   },
@@ -585,5 +586,124 @@ describe("CanvasPage connection drop", () => {
     expect(screen.getByTestId("live-node-detail-pane")).toBeInTheDocument();
     expect(screen.getByTestId("live-bottom-inspector-empty")).toBeInTheDocument();
     expect(screen.getByText("Select component to inspect")).toBeInTheDocument();
+  });
+});
+
+describe("CanvasPage fit-to-view on canvas/version switch", () => {
+  beforeEach(() => {
+    reactFlowPropsRef.current = null;
+    fitViewMock.mockClear();
+    fitViewMock.mockResolvedValue(true);
+    getNodesMock.mockReset();
+    getNodesMock.mockReturnValue([]);
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  const singleNode = [
+    {
+      id: "node-1",
+      position: { x: 0, y: 0 },
+      data: { label: "Node", state: "pending" as const, type: "component" as const },
+    },
+  ];
+
+  function renderCanvas(overrides: {
+    fitViewContentKey?: string;
+    hasFitToViewRef: { current: boolean };
+    lastFittedContentKeyRef: { current: string | null };
+  }) {
+    return render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={singleNode}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="v1"
+          {...overrides}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("fits to view and stamps the content key on first initialization", () => {
+    const hasFitToViewRef = { current: false };
+    const lastFittedContentKeyRef = { current: null as string | null };
+
+    renderCanvas({ fitViewContentKey: "canvas-1:v1", hasFitToViewRef, lastFittedContentKeyRef });
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+    });
+
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+    expect(lastFittedContentKeyRef.current).toBe("canvas-1:v1");
+  });
+
+  it("re-fits when the content key changes (canvas/version switch)", () => {
+    const hasFitToViewRef = { current: false };
+    const lastFittedContentKeyRef = { current: null as string | null };
+
+    const { rerender } = renderCanvas({
+      fitViewContentKey: "canvas-1:v1",
+      hasFitToViewRef,
+      lastFittedContentKeyRef,
+    });
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+    });
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+
+    // Simulate switching to another version: refs persist across the remount.
+    rerender(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={singleNode}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="v2"
+          fitViewContentKey="canvas-1:v2"
+          hasFitToViewRef={hasFitToViewRef}
+          lastFittedContentKeyRef={lastFittedContentKeyRef}
+        />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+    });
+
+    expect(fitViewMock).toHaveBeenCalledTimes(2);
+    expect(lastFittedContentKeyRef.current).toBe("canvas-1:v2");
+  });
+
+  it("restores the stored viewport instead of re-fitting when the content key is unchanged", () => {
+    const hasFitToViewRef = { current: false };
+    const lastFittedContentKeyRef = { current: null as string | null };
+
+    renderCanvas({ fitViewContentKey: "canvas-1:v1", hasFitToViewRef, lastFittedContentKeyRef });
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+    });
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+
+    const setViewport = vi.fn();
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport });
+    });
+
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+    expect(setViewport).toHaveBeenCalled();
   });
 });

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2073,7 +2073,7 @@ function CanvasContent({
   onZoomChange,
   hasFitToViewRef,
   viewportRefProp,
-  fitViewContentKey,
+  fitViewContentKey: fitViewContentKeyProp,
   lastFittedContentKeyRef,
   onPendingConnectionNodeClick,
   onNodeClick,
@@ -2163,6 +2163,9 @@ function CanvasContent({
   const { fitView, screenToFlowPosition, getViewport, getInternalNode, getNodes, setViewport } = useReactFlow();
   const { zoom } = useViewport();
   const isReadOnly = readOnly ?? false;
+  // Run inspection keeps its own dedicated fit/viewport handling, so the
+  // content-key driven re-fit only applies to the live/version canvas.
+  const fitViewContentKey = isRunInspectionMode ? undefined : fitViewContentKeyProp;
 
   // Determine selection key code to support both Control (Windows/Linux) and Meta (Mac)
   // Similar to existing keyboard shortcuts that check (e.ctrlKey || e.metaKey)
@@ -2667,6 +2670,35 @@ function CanvasContent({
       lastFittedContentKeyRef,
     ],
   );
+
+  // Re-fit when the displayed content changes without a remount. `handleInit` only
+  // runs on mount, so previewing a published version whose spec loads afterwards (or
+  // any switch whose nodes arrive late) would otherwise keep the stale viewport. We
+  // wait for the real nodes for the new content key to be present, then fit and stamp.
+  useEffect(() => {
+    if (!hasReactFlowInitialized || !hasFitToViewRef.current) return;
+    if (fitViewContentKey === undefined) return;
+    if ((lastFittedContentKeyRef?.current ?? null) === fitViewContentKey) return;
+    if ((workflowNodes?.length ?? 0) === 0) return;
+    const id = window.setTimeout(() => {
+      fitView({ ...LIVE_CANVAS_FIT_VIEW_OPTIONS, duration: 500 });
+      const viewport = getViewport();
+      viewportRef.current = viewport;
+      reportZoom(viewport.zoom);
+      stampFittedContentKey(lastFittedContentKeyRef, fitViewContentKey);
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [
+    fitViewContentKey,
+    lastFittedContentKeyRef,
+    workflowNodes,
+    hasReactFlowInitialized,
+    hasFitToViewRef,
+    fitView,
+    getViewport,
+    reportZoom,
+    viewportRef,
+  ]);
 
   // Fit all currently-rendered nodes into view whenever the parent bumps `fitAllRequest`.
   // Wait a microtask so ReactFlow has measured the just-swapped node set (e.g. switching

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -95,6 +95,7 @@ import { CustomEdge } from "./CustomEdge";
 import { Header } from "./Header";
 import { isComponentSidebarVisibleMode } from "./canvasTabHeaderMode";
 import { isCanvasNodeHighlighted, shouldBlankCanvasNodeBody } from "./nodeDimming";
+import { shouldRefitOnInit, stampFittedContentKey } from "./fitView";
 import { RightSideControls } from "./RightSideControls";
 import { useBuildingBlocksShortcut } from "./useBuildingBlocksShortcut";
 import type { CanvasPageState } from "./useCanvasState";
@@ -329,6 +330,14 @@ export interface CanvasPageProps {
   hasUserToggledSidebarRef?: React.MutableRefObject<boolean>;
   isSidebarOpenRef?: React.MutableRefObject<boolean | null>;
   viewportRef?: React.MutableRefObject<{ x: number; y: number; zoom: number } | undefined>;
+  /**
+   * Identifies the canvas/version currently displayed. When it changes (switching
+   * canvas or version), the viewport is re-fit to the whole graph instead of
+   * restoring the previous canvas/version viewport from `viewportRef`.
+   */
+  fitViewContentKey?: string;
+  /** Tracks the content key the persisted viewport was fitted for. Paired with `fitViewContentKey`. */
+  lastFittedContentKeyRef?: React.MutableRefObject<string | null>;
 
   // Optional: control and observe component sidebar state
   onSidebarChange?: (isOpen: boolean, selectedNodeId: string | null) => void;
@@ -1480,6 +1489,8 @@ function CanvasPage(props: CanvasPageProps) {
                   onZoomChange={setCanvasZoom}
                   hasFitToViewRef={hasFitToViewRef}
                   viewportRefProp={props.viewportRef}
+                  fitViewContentKey={props.fitViewContentKey}
+                  lastFittedContentKeyRef={props.lastFittedContentKeyRef}
                   workflowNodes={props.workflowNodes}
                   setCurrentTab={setCurrentTab}
                   showBottomStatusControls={props.showBottomStatusControls}
@@ -2062,6 +2073,8 @@ function CanvasContent({
   onZoomChange,
   hasFitToViewRef,
   viewportRefProp,
+  fitViewContentKey,
+  lastFittedContentKeyRef,
   onPendingConnectionNodeClick,
   onNodeClick,
   workflowNodes,
@@ -2115,6 +2128,8 @@ function CanvasContent({
   onZoomChange?: (zoom: number) => void;
   hasFitToViewRef: React.MutableRefObject<boolean>;
   viewportRefProp?: React.MutableRefObject<{ x: number; y: number; zoom: number } | undefined>;
+  fitViewContentKey?: string;
+  lastFittedContentKeyRef?: React.MutableRefObject<string | null>;
   onPendingConnectionNodeClick?: (nodeId: string) => void;
   onNodeClick?: (nodeId: string) => void;
   workflowNodes?: ComponentsNode[];
@@ -2594,7 +2609,15 @@ function CanvasContent({
   // Handle fit to view on ReactFlow initialization
   const handleInit = useCallback(
     (reactFlowInstance: { setViewport: (viewport: Viewport) => void }) => {
-      if (!hasFitToViewRef.current) {
+      // Switching to a different canvas/version must re-fit the whole graph instead of
+      // reusing the previous content's viewport, matching the first-load behavior.
+      const needsInitialFit = shouldRefitOnInit({
+        hasFittedBefore: hasFitToViewRef.current,
+        fitViewContentKey,
+        lastFittedContentKey: lastFittedContentKeyRef?.current ?? null,
+      });
+
+      if (needsInitialFit) {
         const hasNodes = (stateRef.current.nodes?.length ?? 0) > 0;
 
         const focusNodeId = initialFocusNodeId;
@@ -2611,6 +2634,9 @@ function CanvasContent({
           const initialViewport = getViewport();
           viewportRef.current = initialViewport;
           reportZoom(initialViewport.zoom);
+          // Only stamp once real nodes were fitted; while the switched content is still
+          // loading (no nodes yet), leave the key stale so the next init re-fits.
+          stampFittedContentKey(lastFittedContentKeyRef, fitViewContentKey);
         } else {
           const defaultViewport = viewportRef.current ?? { x: 0, y: 0, zoom: DEFAULT_CANVAS_ZOOM };
           viewportRef.current = defaultViewport;
@@ -2630,7 +2656,16 @@ function CanvasContent({
         setHasReactFlowInitialized(true);
       }
     },
-    [fitView, getViewport, reportZoom, hasFitToViewRef, viewportRef, initialFocusNodeId],
+    [
+      fitView,
+      getViewport,
+      reportZoom,
+      hasFitToViewRef,
+      viewportRef,
+      initialFocusNodeId,
+      fitViewContentKey,
+      lastFittedContentKeyRef,
+    ],
   );
 
   // Fit all currently-rendered nodes into view whenever the parent bumps `fitAllRequest`.

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2625,8 +2625,14 @@ function CanvasContent({
       if (needsInitialFit) {
         const hasNodes = (stateRef.current.nodes?.length ?? 0) > 0;
 
-        const focusNodeId = initialFocusNodeId;
-        const focusNode = focusNodeId ? stateRef.current.nodes?.find((node) => node.id === focusNodeId) : null;
+        // The URL deep-link focus (?node=) must only zoom once, on the very first
+        // fit. Later canvas/version switches also enter this branch, but they should
+        // frame the whole graph rather than re-zoom onto that node.
+        const isFirstFit = !hasFitToViewRef.current;
+        const focusNode =
+          isFirstFit && initialFocusNodeId
+            ? stateRef.current.nodes?.find((node) => node.id === initialFocusNodeId)
+            : null;
 
         if (focusNode) {
           fitView({ nodes: [focusNode], duration: 500, ...CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS });

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2163,9 +2163,11 @@ function CanvasContent({
   const { fitView, screenToFlowPosition, getViewport, getInternalNode, getNodes, setViewport } = useReactFlow();
   const { zoom } = useViewport();
   const isReadOnly = readOnly ?? false;
-  // Run inspection keeps its own dedicated fit/viewport handling, so the
-  // content-key driven re-fit only applies to the live/version canvas.
-  const fitViewContentKey = isRunInspectionMode ? undefined : fitViewContentKeyProp;
+  // The content-key driven re-fit only applies when viewing the live/version
+  // canvas. Run inspection keeps its own dedicated fit/viewport handling, and
+  // while editing the viewport must stay put (the draft is the same graph the
+  // user was already looking at, and re-fitting would disrupt interactions).
+  const fitViewContentKey = isRunInspectionMode || isEditing ? undefined : fitViewContentKeyProp;
 
   // Determine selection key code to support both Control (Windows/Linux) and Meta (Mac)
   // Similar to existing keyboard shortcuts that check (e.ctrlKey || e.metaKey)


### PR DESCRIPTION
## Summary

Fixes #4025. Switching to another canvas or version reused the previous
viewport (pan/zoom), so the graph often opened off-center or zoomed wrong.
Now a context switch re-runs the same fit-to-view used on first load.

**Root cause:** `CanvasPage` already remounts on a canvas/version switch (via
`canvasRenderKey`), but the fit-state refs (`hasFitToViewRef`, `viewportRef`)
are owned by the parent and persist across remounts. So `handleInit` took the
"restore previous viewport" branch instead of fitting the new content.

## Changes

- `web_src/src/ui/CanvasPage/fitView.ts` (new): pure helpers —
  `computeFitViewContentKey`, `shouldRefitOnInit`, `stampFittedContentKey`.
- `web_src/src/ui/CanvasPage/index.tsx`: `handleInit` re-fits when the displayed
  content key changes (not only on first init), and only stamps the key once real
  nodes were fitted, so a still-loading switch re-fits when its nodes arrive.
  Added `fitViewContentKey` / `lastFittedContentKeyRef` props.
- `web_src/src/pages/app/index.tsx`: owns `lastFittedContentKeyRef` (survives
  remounts) and passes the content key. Returns `undefined` in run-inspection so
  that mode keeps its dedicated fit/viewport handling. Also compacted the adjacent
  `canvasRenderKey` construction into an equivalent single-line template literal to
  stay within the existing ESLint line budget (no baseline change).

The decision lives inside `handleInit`, avoiding effect-vs-`onInit` ordering races.
