### PR TITLE
[SUPERSEDED — please close] fix: Persist Building Blocks sidebar display settings

### DIFF
--- a/web_src/src/ui/BuildingBlocksSidebar/CategorySection.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/CategorySection.tsx
@@ -5,7 +5,7 @@ import { ChevronRight, Plug } from "lucide-react";
 import { memo, useState, type DragEvent } from "react";
 import { toTestId } from "../../lib/testID";
 import { getHeaderIconSrc, getIntegrationIconSrc } from "../componentSidebar/integrationIconMaps";
-import { filterBlocksInCategory, type TypeFilter } from "./filter";
+import { filterBlocksInCategory, normalizeIntegrationName, type TypeFilter } from "./filter";
 import type { BuildingBlock, BuildingBlockCategory } from "./types";
 
 const TYPE_HOVER_BG: Record<string, string> = {
@@ -152,7 +152,8 @@ export function CategorySection({
   const integrationName = firstBlock?.integrationName || category.name.toLowerCase();
   const categoryIconSrc = integrationName === "smtp" ? undefined : getIntegrationIconSrc(integrationName);
   const CategoryIcon = categoryIconSrc ? null : resolveCategoryIcon(category.name, integrationName);
-  const integrationStatusColorClass = INTEGRATION_STATE_COLOR[resolveIntegrationState(category, integrations, firstBlock)];
+  const integrationStatusColorClass =
+    INTEGRATION_STATE_COLOR[resolveIntegrationState(category, integrations, firstBlock)];
 
   return (
     <details
@@ -185,10 +186,6 @@ export function CategorySection({
       </ItemGroup>
     </details>
   );
-}
-
-export function normalizeIntegrationName(value?: string) {
-  return (value || "").toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
 function resolveIntegrationState(

--- a/web_src/src/ui/BuildingBlocksSidebar/CategorySection.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/CategorySection.tsx
@@ -1,6 +1,7 @@
+import type { OrganizationsIntegration } from "@/api-client";
 import { Item, ItemContent, ItemGroup, ItemMedia, ItemTitle } from "@/components/ui/item";
 import { resolveIcon } from "@/lib/utils";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Plug } from "lucide-react";
 import { memo, useState, type DragEvent } from "react";
 import { toTestId } from "../../lib/testID";
 import { getHeaderIconSrc, getIntegrationIconSrc } from "../componentSidebar/integrationIconMaps";
@@ -112,12 +113,30 @@ const BlockItem = memo(function BlockItem({ block, onBlockClick }: BlockItemProp
 
 export interface CategorySectionProps {
   category: BuildingBlockCategory;
+  integrations?: OrganizationsIntegration[];
+  showIntegrationSetupStatus?: boolean;
   searchTerm?: string;
   typeFilter?: TypeFilter;
   onBlockClick?: (block: BuildingBlock) => void;
 }
 
-export function CategorySection({ category, searchTerm = "", typeFilter = "all", onBlockClick }: CategorySectionProps) {
+type IntegrationState = "ready" | "error" | "pending" | "notConfigured";
+
+const INTEGRATION_STATE_COLOR: Record<IntegrationState, string> = {
+  ready: "text-green-500",
+  error: "text-red-500",
+  pending: "text-amber-600",
+  notConfigured: "text-gray-500",
+};
+
+export function CategorySection({
+  category,
+  integrations = [],
+  showIntegrationSetupStatus = false,
+  searchTerm = "",
+  typeFilter = "all",
+  onBlockClick,
+}: CategorySectionProps) {
   const sortedBlocks = filterBlocksInCategory(category, searchTerm, typeFilter);
 
   const isCoreCategory = category.name === "Core";
@@ -133,6 +152,7 @@ export function CategorySection({ category, searchTerm = "", typeFilter = "all",
   const integrationName = firstBlock?.integrationName || category.name.toLowerCase();
   const categoryIconSrc = integrationName === "smtp" ? undefined : getIntegrationIconSrc(integrationName);
   const CategoryIcon = categoryIconSrc ? null : resolveCategoryIcon(category.name, integrationName);
+  const integrationStatusColorClass = INTEGRATION_STATE_COLOR[resolveIntegrationState(category, integrations, firstBlock)];
 
   return (
     <details
@@ -151,6 +171,11 @@ export function CategorySection({ category, searchTerm = "", typeFilter = "all",
           {renderCategoryIcon(categoryIconSrc, category.name, CategoryIcon)}
           <span className="text-[13px] text-gray-800 font-medium pl-1">{category.name}</span>
         </span>
+        {showIntegrationSetupStatus && (
+          <span className="relative z-10 shrink-0 bg-white dark:bg-gray-900 pl-3">
+            <Plug size={14} className={integrationStatusColorClass} />
+          </span>
+        )}
       </summary>
 
       <ItemGroup>
@@ -160,4 +185,34 @@ export function CategorySection({ category, searchTerm = "", typeFilter = "all",
       </ItemGroup>
     </details>
   );
+}
+
+export function normalizeIntegrationName(value?: string) {
+  return (value || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function resolveIntegrationState(
+  category: BuildingBlockCategory,
+  integrations: OrganizationsIntegration[],
+  firstBlock: BuildingBlock,
+): IntegrationState {
+  if (category.name === "Core" || category.name === "Memory" || category.name === "Debugging") {
+    return "ready";
+  }
+
+  const name = normalizeIntegrationName(firstBlock?.integrationName);
+  const matchingStates = integrations
+    .filter((integration) => normalizeIntegrationName(integration.metadata?.integrationName) === name)
+    .map((integration) => integration.status?.state);
+
+  if (matchingStates.includes("ready")) {
+    return "ready";
+  }
+  if (matchingStates.includes("error")) {
+    return "error";
+  }
+  if (matchingStates.includes("pending")) {
+    return "pending";
+  }
+  return "notConfigured";
 }

--- a/web_src/src/ui/BuildingBlocksSidebar/filter.ts
+++ b/web_src/src/ui/BuildingBlocksSidebar/filter.ts
@@ -2,6 +2,15 @@ import type { BuildingBlock, BuildingBlockCategory } from "./types";
 
 export type TypeFilter = "all" | "trigger" | "component";
 
+/**
+ * Normalizes an integration name for comparison by lowercasing and stripping
+ * any non-alphanumeric characters, so that values like "GitHub" and "github"
+ * (or "google-cloud" and "googlecloud") are treated as the same integration.
+ */
+export function normalizeIntegrationName(value?: string): string {
+  return (value || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 const TYPE_SORT_ORDER: Record<BuildingBlock["type"], number> = {
   trigger: 0,
   component: 1,

--- a/web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BuildingBlocksSidebar } from "./index";
 import type { BuildingBlockCategory } from "./types";
 
@@ -20,6 +21,10 @@ const coreCategory: BuildingBlockCategory = {
 };
 
 describe("BuildingBlocksSidebar", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it("calls onToggle(false) when close button is clicked while disabled", () => {
     const onToggle = vi.fn();
     render(
@@ -63,6 +68,29 @@ describe("BuildingBlocksSidebar", () => {
     const { container } = render(<BuildingBlocksSidebar {...defaultProps} isOpen={false} />);
 
     expect(container.querySelector('[data-testid="building-blocks-sidebar"]')).not.toBeInTheDocument();
+  });
+
+  it("persists display settings after remounting", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<BuildingBlocksSidebar {...defaultProps} blocks={[coreCategory]} />);
+
+    const openSettings = () => user.click(screen.getByLabelText("Sidebar settings"));
+    const getSetting = (name: string) => screen.getByRole("menuitemcheckbox", { name });
+
+    // Toggle both settings
+    await openSettings();
+    await user.click(getSetting("Show integration setup status"));
+    await openSettings();
+    await user.click(getSetting("Connected integrations on top"));
+
+    // Remount the component
+    unmount();
+    render(<BuildingBlocksSidebar {...defaultProps} blocks={[coreCategory]} />);
+
+    // Verify settings persisted
+    await openSettings();
+    expect(getSetting("Show integration setup status")).toHaveAttribute("aria-checked", "false");
+    expect(getSetting("Connected integrations on top")).toHaveAttribute("aria-checked", "true");
   });
 
   describe("Enter-to-submit", () => {

--- a/web_src/src/ui/BuildingBlocksSidebar/index.stories.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.stories.tsx
@@ -189,3 +189,46 @@ export const OnlyTriggers: Story = {
     );
   },
 };
+
+const integrationBlocks: BuildingBlockCategory[] = [
+  { name: "Core", blocks: [...sampleTriggers, ...sampleComponents] },
+  {
+    name: "AWS",
+    blocks: [{ name: "aws.lambda", label: "Lambda", type: "component", integrationName: "aws" }],
+  },
+  {
+    name: "GitHub",
+    blocks: [{ name: "github.pr", label: "Open PR", type: "component", integrationName: "github" }],
+  },
+  {
+    name: "Zendesk",
+    blocks: [{ name: "zendesk.ticket", label: "Create Ticket", type: "component", integrationName: "zendesk" }],
+  },
+];
+
+export const WithIntegrations: Story = {
+  args: {
+    isOpen: true,
+    blocks: integrationBlocks,
+    // AWS is not connected; GitHub is connected (ready) and Zendesk is connected (error).
+    // With "Connected integrations on top" enabled, GitHub and Zendesk sort above AWS.
+    integrations: [
+      { metadata: { integrationName: "github" }, status: { state: "ready" } },
+      { metadata: { integrationName: "zendesk" }, status: { state: "error" } },
+    ],
+  },
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(args.isOpen);
+
+    const handleToggle = (open: boolean) => {
+      setIsOpen(open);
+      args.onToggle?.(open);
+    };
+
+    return (
+      <div className="h-screen w-screen flex bg-gray-100">
+        <BuildingBlocksSidebar {...args} isOpen={isOpen} onToggle={handleToggle} />
+      </div>
+    );
+  },
+};

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -1,12 +1,15 @@
 import type { OrganizationsIntegration } from "@/api-client";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Search, X } from "lucide-react";
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/ui/dropdownMenu";
+import { Search, Settings2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSidebarLayoutStore, useSidebarLayoutViewport, useSidebarMount } from "@/stores/sidebarLayoutStore";
-import { CategorySection } from "./CategorySection";
+import { CategorySection, normalizeIntegrationName } from "./CategorySection";
 import { findFirstVisibleBlock } from "./filter";
 import type { BuildingBlock, BuildingBlockCategory } from "./types";
+import { useSidebarSettings } from "./useSidebarSettings";
 
 export type { BuildingBlock, BuildingBlockCategory } from "./types";
 
@@ -71,7 +74,7 @@ interface OpenBuildingBlocksSidebarProps {
 function OpenBuildingBlocksSidebar({
   onToggle,
   blocks,
-  integrations: _integrations,
+  integrations,
   disabled,
   disabledTooltip,
   onBlockClick,
@@ -81,6 +84,12 @@ function OpenBuildingBlocksSidebar({
   const sidebarRef = useRef<HTMLDivElement>(null);
   const activeResizePointerIdRef = useRef<number | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const {
+    showIntegrationSetupStatus,
+    setShowIntegrationSetupStatus,
+    showConnectedIntegrationsOnTop,
+    setShowConnectedIntegrationsOnTop,
+  } = useSidebarSettings();
 
   const sidebarWidth = useSidebarLayoutStore((state) => state.rightWidth);
   const isResizing = useSidebarLayoutStore((state) => state.isRightResizing);
@@ -164,6 +173,17 @@ function OpenBuildingBlocksSidebar({
       Memory: 3,
     };
 
+    const isConnectedCategory = (category: BuildingBlockCategory) => {
+      const integrationName = category.blocks.find((block) => block.integrationName)?.integrationName;
+      if (!integrationName) {
+        return false;
+      }
+      return integrations.some(
+        (integration) =>
+          normalizeIntegrationName(integration.metadata?.integrationName) === normalizeIntegrationName(integrationName),
+      );
+    };
+
     return [...blocks].sort((a, b) => {
       const aOrder = categoryOrder[a.name] ?? Infinity;
       const bOrder = categoryOrder[b.name] ?? Infinity;
@@ -171,9 +191,18 @@ function OpenBuildingBlocksSidebar({
       if (aOrder !== bOrder) {
         return aOrder - bOrder;
       }
+
+      if (showConnectedIntegrationsOnTop && aOrder === Infinity && bOrder === Infinity) {
+        const aConnected = isConnectedCategory(a);
+        const bConnected = isConnectedCategory(b);
+        if (aConnected !== bConnected) {
+          return aConnected ? -1 : 1;
+        }
+      }
+
       return a.name.localeCompare(b.name);
     });
-  }, [blocks]);
+  }, [blocks, integrations, showConnectedIntegrationsOnTop]);
 
   return (
     <div
@@ -239,6 +268,27 @@ function OpenBuildingBlocksSidebar({
                 }}
               />
             </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="icon-sm" className="h-8 w-8 shrink-0" aria-label="Sidebar settings">
+                  <Settings2 className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuCheckboxItem
+                  checked={showIntegrationSetupStatus}
+                  onCheckedChange={(checked) => setShowIntegrationSetupStatus(Boolean(checked))}
+                >
+                  Show integration setup status
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={showConnectedIntegrationsOnTop}
+                  onCheckedChange={(checked) => setShowConnectedIntegrationsOnTop(Boolean(checked))}
+                >
+                  Connected integrations on top
+                </DropdownMenuCheckboxItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
 
           <div className="relative flex-1 min-h-0 gap-2 py-6">
@@ -246,6 +296,8 @@ function OpenBuildingBlocksSidebar({
               <CategorySection
                 key={category.name}
                 category={category}
+                integrations={integrations}
+                showIntegrationSetupStatus={showIntegrationSetupStatus}
                 searchTerm={searchTerm}
                 onBlockClick={onBlockClick}
               />

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -6,8 +6,8 @@ import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMe
 import { Search, Settings2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSidebarLayoutStore, useSidebarLayoutViewport, useSidebarMount } from "@/stores/sidebarLayoutStore";
-import { CategorySection, normalizeIntegrationName } from "./CategorySection";
-import { findFirstVisibleBlock } from "./filter";
+import { CategorySection } from "./CategorySection";
+import { findFirstVisibleBlock, normalizeIntegrationName } from "./filter";
 import type { BuildingBlock, BuildingBlockCategory } from "./types";
 import { useSidebarSettings } from "./useSidebarSettings";
 

--- a/web_src/src/ui/BuildingBlocksSidebar/useSidebarSettings.spec.ts
+++ b/web_src/src/ui/BuildingBlocksSidebar/useSidebarSettings.spec.ts
@@ -1,0 +1,82 @@
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY, useSidebarSettings } from "./useSidebarSettings";
+
+describe("useSidebarSettings", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns defaults when localStorage is empty", () => {
+    const { result } = renderHook(() => useSidebarSettings());
+
+    expect(result.current.showIntegrationSetupStatus).toBe(true);
+    expect(result.current.showConnectedIntegrationsOnTop).toBe(false);
+  });
+
+  it("reads persisted values from localStorage on init", () => {
+    window.localStorage.setItem(
+      BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY,
+      JSON.stringify({ showIntegrationSetupStatus: false, showConnectedIntegrationsOnTop: true }),
+    );
+
+    const { result } = renderHook(() => useSidebarSettings());
+
+    expect(result.current.showIntegrationSetupStatus).toBe(false);
+    expect(result.current.showConnectedIntegrationsOnTop).toBe(true);
+  });
+
+  it("writes to localStorage when a setting changes", () => {
+    const { result } = renderHook(() => useSidebarSettings());
+
+    act(() => {
+      result.current.setShowConnectedIntegrationsOnTop(true);
+    });
+
+    const stored = JSON.parse(window.localStorage.getItem(BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY) || "{}");
+    expect(stored.showConnectedIntegrationsOnTop).toBe(true);
+    expect(stored.showIntegrationSetupStatus).toBe(true);
+  });
+
+  it("handles corrupted JSON gracefully", () => {
+    window.localStorage.setItem(BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY, "not-json");
+
+    const { result } = renderHook(() => useSidebarSettings());
+
+    expect(result.current.showIntegrationSetupStatus).toBe(true);
+    expect(result.current.showConnectedIntegrationsOnTop).toBe(false);
+  });
+
+  it("handles a stored array gracefully", () => {
+    window.localStorage.setItem(BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY, "[1,2,3]");
+
+    const { result } = renderHook(() => useSidebarSettings());
+
+    expect(result.current.showIntegrationSetupStatus).toBe(true);
+    expect(result.current.showConnectedIntegrationsOnTop).toBe(false);
+  });
+
+  it("fills missing fields with defaults", () => {
+    window.localStorage.setItem(
+      BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY,
+      JSON.stringify({ showConnectedIntegrationsOnTop: true }),
+    );
+
+    const { result } = renderHook(() => useSidebarSettings());
+
+    expect(result.current.showIntegrationSetupStatus).toBe(true);
+    expect(result.current.showConnectedIntegrationsOnTop).toBe(true);
+  });
+
+  it("ignores non-boolean stored values and falls back to defaults", () => {
+    window.localStorage.setItem(
+      BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY,
+      JSON.stringify({ showIntegrationSetupStatus: "yes", showConnectedIntegrationsOnTop: 1 }),
+    );
+
+    const { result } = renderHook(() => useSidebarSettings());
+
+    expect(result.current.showIntegrationSetupStatus).toBe(true);
+    expect(result.current.showConnectedIntegrationsOnTop).toBe(false);
+  });
+});

--- a/web_src/src/ui/BuildingBlocksSidebar/useSidebarSettings.ts
+++ b/web_src/src/ui/BuildingBlocksSidebar/useSidebarSettings.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+
+export const BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY = "buildingBlocksSidebarSettings";
+
+interface SidebarSettings {
+  showIntegrationSetupStatus: boolean;
+  showConnectedIntegrationsOnTop: boolean;
+}
+
+const DEFAULTS: SidebarSettings = {
+  showIntegrationSetupStatus: true,
+  showConnectedIntegrationsOnTop: false,
+};
+
+function readSettings(): SidebarSettings {
+  if (typeof window === "undefined") {
+    return DEFAULTS;
+  }
+
+  const raw = window.localStorage.getItem(BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY);
+  if (raw === null) {
+    return DEFAULTS;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return DEFAULTS;
+    }
+
+    const obj = parsed as Record<string, unknown>;
+    return {
+      showIntegrationSetupStatus:
+        typeof obj.showIntegrationSetupStatus === "boolean"
+          ? obj.showIntegrationSetupStatus
+          : DEFAULTS.showIntegrationSetupStatus,
+      showConnectedIntegrationsOnTop:
+        typeof obj.showConnectedIntegrationsOnTop === "boolean"
+          ? obj.showConnectedIntegrationsOnTop
+          : DEFAULTS.showConnectedIntegrationsOnTop,
+    };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+/**
+ * Manages the BuildingBlocksSidebar display settings and persists them
+ * to localStorage so they survive remounts and page reloads.
+ */
+export function useSidebarSettings() {
+  const [settings, setSettings] = useState<SidebarSettings>(readSettings);
+
+  useEffect(() => {
+    window.localStorage.setItem(BUILDING_BLOCKS_SIDEBAR_SETTINGS_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  return {
+    showIntegrationSetupStatus: settings.showIntegrationSetupStatus,
+    showConnectedIntegrationsOnTop: settings.showConnectedIntegrationsOnTop,
+    setShowIntegrationSetupStatus: (value: boolean) =>
+      setSettings((prev) => ({ ...prev, showIntegrationSetupStatus: value })),
+    setShowConnectedIntegrationsOnTop: (value: boolean) =>
+      setSettings((prev) => ({ ...prev, showConnectedIntegrationsOnTop: value })),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**This PR is superseded and can be closed.**

The same changes were pushed directly onto the original PR #4631 (branch `lucasdelafuentep:fix/persist-building-blocks-sidebar-settings`), which is now up to date with `main` and mergeable. Continue the review there.

I was unable to close this PR automatically because the agent's token is read-only for write operations (`closePullRequest` returns "Resource not accessible by integration"). Please close it manually.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39bdf0b8-b1f7-44f0-9443-4465b4e98935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39bdf0b8-b1f7-44f0-9443-4465b4e98935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

