### PR TITLE
fix: filter Dash0 SDK fetch failures from Sentry

### DIFF
--- a/web_src/src/sentry.ts
+++ b/web_src/src/sentry.ts
@@ -6,7 +6,7 @@ interface SentryWindow extends Window {
 }
 
 // Dash0 Web SDK logs export failures to the console; captureConsoleIntegration would forward them.
-const DASH0_TELEMETRY_CONSOLE_IGNORE = /^(Failed to send telemetry to|Error sending telemetry to)/;
+const DASH0_TELEMETRY_CONSOLE_IGNORE = /^(Failed to send telemetry to|Error sending telemetry to|Failed to fetch)/;
 
 let dsn: string | undefined;
 let environment: string | undefined;
@@ -22,6 +22,15 @@ if (dsn) {
     dsn,
     environment,
     ignoreErrors: [DASH0_TELEMETRY_CONSOLE_IGNORE],
+    beforeSend(event) {
+      const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+      const allDash0 = frames.length > 0 && frames.every((frame) => frame.filename?.includes("@dash0/sdk-web"));
+      if (allDash0) {
+        return null;
+      }
+
+      return event;
+    },
     beforeBreadcrumb(breadcrumb) {
       if (
         breadcrumb.category === "console" &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #5829 (Sentry PRODUCTION-7S — `TypeError: Failed to fetch`).

PR #5784 added `captureConsoleIntegration`, which began forwarding Dash0 SDK telemetry export failures to Sentry. The existing `DASH0_TELEMETRY_CONSOLE_IGNORE` filter matched prefixed log messages like `Failed to send telemetry to`, but not the raw `Failed to fetch` TypeError thrown when the OTLP endpoint is unreachable (e.g. blocked by firewall/network).

## Changes

- Extend `DASH0_TELEMETRY_CONSOLE_IGNORE` to also match `Failed to fetch`
- Add a `beforeSend` hook that drops events whose entire stack trace originates in `@dash0/sdk-web`

## Testing

- `make check.format.js`
- `make check.build.ui`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b59178d6-0782-401b-8644-8fab9670ec17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b59178d6-0782-401b-8644-8fab9670ec17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

