### PR TITLE
fix: prevent crash when display message metadata is missing

### DIFF
--- a/web_src/src/pages/app/mappers/display/Message.spec.tsx
+++ b/web_src/src/pages/app/mappers/display/Message.spec.tsx
@@ -34,4 +34,3 @@ describe("Message", () => {
     expect(screen.getByText("hello")).toBeInTheDocument();
   });
 });
-

--- a/web_src/src/pages/app/mappers/display/Message.spec.tsx
+++ b/web_src/src/pages/app/mappers/display/Message.spec.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Message } from "./Message";
+import type { ExecutionInfo } from "../types";
+
+function buildExecution(metadata: unknown): ExecutionInfo {
+  return {
+    id: "execution-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata,
+    configuration: {},
+    rootEvent: undefined,
+  };
+}
+
+describe("Message", () => {
+  it("renders a fallback when metadata is undefined", () => {
+    render(<Message lastExecution={buildExecution(undefined)} />);
+    expect(screen.getByText("Empty message")).toBeInTheDocument();
+  });
+
+  it("renders a fallback when metadata is null", () => {
+    render(<Message lastExecution={buildExecution(null)} />);
+    expect(screen.getByText("Empty message")).toBeInTheDocument();
+  });
+
+  it("renders the provided message when metadata.message is a non-empty string", () => {
+    render(<Message lastExecution={buildExecution({ message: "hello" })} />);
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+});
+

--- a/web_src/src/pages/app/mappers/display/Message.tsx
+++ b/web_src/src/pages/app/mappers/display/Message.tsx
@@ -3,14 +3,24 @@ import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import type { ExecutionInfo } from "../types";
 
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as Record<string, unknown>;
+}
+
 export function Message({ lastExecution }: { lastExecution: ExecutionInfo | null }): React.ReactNode {
   if (!lastExecution) {
     return null;
   }
 
-  const metadata = lastExecution?.metadata as Record<string, unknown>;
-  const message = (metadata["message"] as string | undefined) || "Empty message";
-  const color = (metadata["color"] as string | undefined) || "gray";
+  const metadata = asRecord(lastExecution.metadata);
+  const rawMessage = metadata["message"];
+  const message = typeof rawMessage === "string" && rawMessage.length > 0 ? rawMessage : "Empty message";
+  const rawColor = metadata["color"];
+  const color = typeof rawColor === "string" && rawColor.length > 0 ? rawColor : "gray";
 
   const colorClass = getBackgroundColorClass(color);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prevents a UI crash in the display mapper when an execution has no `metadata`.

## Details
- `Message.tsx` now guards `lastExecution.metadata` at runtime before reading `message`/`color`.
- When metadata is missing or not an object, it falls back to `Empty message` and `gray`.
- Adds a small Vitest spec to ensure missing metadata never throws.

## Context
- Sentry issue: [TypeError: Cannot read properties of undefined (reading 'message')](https://superplane.sentry.io/issues/7587152949/)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63ed415b-8e00-4a33-98f2-6497c8d459e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63ed415b-8e00-4a33-98f2-6497c8d459e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

