### PR TITLE
fix: guard synthetic keydown events

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -82,7 +82,11 @@ export function useCanvasToolSidebarState({
     if (!showToolSidebarToggle) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key.toLowerCase() !== "b" || !(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) {
+      // Some instrumentation SDKs dispatch synthetic keyboard events where `key` is unset.
+      const { key } = event as KeyboardEvent & { key?: unknown };
+      const lowerKey = typeof key === "string" ? key.toLowerCase() : "";
+
+      if (lowerKey !== "b" || !(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) {
         return;
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Prevents `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` by guarding `event.key` in the Canvas Tool Sidebar keydown shortcut handler.
- Keeps existing Cmd/Ctrl+B behavior unchanged for real browser `KeyboardEvent`s.

## Context

Sentry issue indicates Dash0 Web SDK can invoke the listener with synthetic keyboard events where `key` is missing.

## Changes

- `web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts`: safely derive `lowerKey` and early-return when key is not the expected string.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fb04a89-d7ec-495c-8cef-2285f6d814d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fb04a89-d7ec-495c-8cef-2285f6d814d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

