### PR TITLE
fix: derive AWS create-instance node state from emitted channel

### DIFF
--- a/web_src/src/pages/app/mappers/aws/ec2/create_instance.spec.ts
+++ b/web_src/src/pages/app/mappers/aws/ec2/create_instance.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createInstanceMapper } from "./create_instance";
+import { createInstanceMapper, createInstanceStateFunction } from "./create_instance";
 import type { ComponentBaseContext, ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../../types";
 
 function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
@@ -167,5 +167,57 @@ describe("createInstanceMapper.getExecutionDetails", () => {
     expect(details["State"]).toBe("running");
     expect(details["Public IP"]).toBe("54.1.2.3");
     expect(details["Private IP"]).toBeUndefined();
+  });
+
+  it("surfaces the failure output when the run emitted to the failed channel", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: {
+          name: "builder",
+          region: "us-east-1",
+          instanceType: "t3.micro",
+        },
+      },
+      execution: {
+        outputs: {
+          failed: [
+            buildOutput({
+              error: "not enough capacity",
+              awsErrorCode: "InsufficientInstanceCapacity",
+              lastObservedState: "",
+            }),
+          ],
+        },
+      },
+    });
+
+    const details = createInstanceMapper.getExecutionDetails(ctx);
+    expect(details["State"]).toBe("Failed");
+    expect(details["Error"]).toBe("InsufficientInstanceCapacity: not enough capacity");
+    expect(details["Public IP"]).toBeUndefined();
+  });
+});
+
+describe("createInstanceStateFunction", () => {
+  it("returns created for a passed execution that emitted to the created channel", () => {
+    const execution = buildExecution({
+      outputs: { created: [buildOutput({ instanceId: "i-abc123", state: "running" })] },
+    });
+
+    expect(createInstanceStateFunction(execution)).toBe("created");
+  });
+
+  it("returns failed when the run emitted to the failed channel even though the execution passed", () => {
+    const execution = buildExecution({
+      outputs: { failed: [buildOutput({ error: "boom", awsErrorCode: "InsufficientInstanceCapacity" })] },
+    });
+
+    expect(createInstanceStateFunction(execution)).toBe("failed");
+  });
+
+  it("returns running while the execution is still in progress", () => {
+    const execution = buildExecution({ state: "STATE_STARTED", outputs: undefined });
+
+    expect(createInstanceStateFunction(execution)).toBe("running");
   });
 });

--- a/web_src/src/pages/app/mappers/aws/ec2/create_instance.spec.ts
+++ b/web_src/src/pages/app/mappers/aws/ec2/create_instance.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createInstanceMapper, createInstanceStateFunction } from "./create_instance";
+import { createInstanceMapper, CREATE_INSTANCE_STATE_REGISTRY } from "./create_instance";
 import type { ComponentBaseContext, ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../../types";
 
 function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
@@ -198,13 +198,13 @@ describe("createInstanceMapper.getExecutionDetails", () => {
   });
 });
 
-describe("createInstanceStateFunction", () => {
+describe("CREATE_INSTANCE_STATE_REGISTRY", () => {
   it("returns created for a passed execution that emitted to the created channel", () => {
     const execution = buildExecution({
       outputs: { created: [buildOutput({ instanceId: "i-abc123", state: "running" })] },
     });
 
-    expect(createInstanceStateFunction(execution)).toBe("created");
+    expect(CREATE_INSTANCE_STATE_REGISTRY.getState(execution)).toBe("created");
   });
 
   it("returns failed when the run emitted to the failed channel even though the execution passed", () => {
@@ -212,12 +212,17 @@ describe("createInstanceStateFunction", () => {
       outputs: { failed: [buildOutput({ error: "boom", awsErrorCode: "InsufficientInstanceCapacity" })] },
     });
 
-    expect(createInstanceStateFunction(execution)).toBe("failed");
+    expect(CREATE_INSTANCE_STATE_REGISTRY.getState(execution)).toBe("failed");
   });
 
   it("returns running while the execution is still in progress", () => {
-    const execution = buildExecution({ state: "STATE_STARTED", outputs: undefined });
+    const execution = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+      outputs: undefined,
+    });
 
-    expect(createInstanceStateFunction(execution)).toBe("running");
+    expect(CREATE_INSTANCE_STATE_REGISTRY.getState(execution)).toBe("running");
   });
 });

--- a/web_src/src/pages/app/mappers/aws/ec2/create_instance.ts
+++ b/web_src/src/pages/app/mappers/aws/ec2/create_instance.ts
@@ -1,19 +1,23 @@
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
+  EventStateRegistry,
   ExecutionDetailsContext,
   ExecutionInfo,
   NodeInfo,
   OutputPayload,
+  StateFunction,
   SubtitleContext,
 } from "../../types";
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type { ComponentBaseProps, EventSection, EventState, EventStateMap } from "@/ui/componentBase";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
 import type React from "react";
 import type { MetadataItem } from "@/ui/metadataList";
 import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
-import { getState, getStateMap, getTriggerRenderer } from "../..";
+import { getTriggerRenderer } from "../..";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import { stringOrDash } from "../../utils";
+import { defaultStateFunction } from "../../stateRegistry";
 import awsEc2Icon from "@/assets/icons/integrations/aws.ec2.svg";
 import type { Ec2Instance } from "./types";
 
@@ -43,10 +47,46 @@ interface CreateInstanceNodeMetadata {
   securityGroupName?: string;
 }
 
+interface CreateInstanceFailure {
+  error?: string;
+  awsErrorCode?: string;
+  lastObservedState?: string;
+}
+
+interface CreateInstanceOutputs {
+  created?: OutputPayload[];
+  failed?: OutputPayload[];
+  default?: OutputPayload[];
+}
+
+export const CREATE_INSTANCE_STATE_MAP: EventStateMap = {
+  ...DEFAULT_EVENT_STATE_MAP,
+  created: DEFAULT_EVENT_STATE_MAP.success,
+};
+
+// The component emits launch/wait failures to the "failed" output channel while
+// the execution itself finishes as passed, so the node state must be derived
+// from the emitted channel rather than the execution result.
+export const createInstanceStateFunction: StateFunction = (execution: ExecutionInfo): EventState => {
+  if (!execution) return "neutral";
+
+  const outputs = execution.outputs as CreateInstanceOutputs | undefined;
+  if (outputs?.failed && outputs.failed.length > 0) {
+    return "failed";
+  }
+
+  const state = defaultStateFunction(execution);
+  return state === "success" ? "created" : state;
+};
+
+export const CREATE_INSTANCE_STATE_REGISTRY: EventStateRegistry = {
+  stateMap: CREATE_INSTANCE_STATE_MAP,
+  getState: createInstanceStateFunction,
+};
+
 export const createInstanceMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
-    const componentName = context.componentDefinition.name || "unknown";
 
     return {
       title: context.node.name || context.componentDefinition.label || "Unnamed component",
@@ -54,40 +94,25 @@ export const createInstanceMapper: ComponentBaseMapper = {
       iconColor: getColorClass(context.componentDefinition.color),
       collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
       collapsed: context.node.isCollapsed,
-      eventSections: lastExecution
-        ? createInstanceEventSections(context.nodes, lastExecution, componentName)
-        : undefined,
+      eventSections: lastExecution ? createInstanceEventSections(context.nodes, lastExecution) : undefined,
       includeEmptyState: !lastExecution,
       metadata: createInstanceMetadata(context.node),
-      eventStateMap: getStateMap(componentName),
+      eventStateMap: CREATE_INSTANCE_STATE_MAP,
     };
   },
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
     const configuration = context.node.configuration as Configuration | undefined;
-    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const output = outputs?.default?.[0]?.data as Ec2Instance | undefined;
+    const outputs = context.execution.outputs as CreateInstanceOutputs | undefined;
     const createdAt = context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : undefined;
 
-    if (!output) {
-      return {
-        "Created At": stringOrDash(createdAt),
-        Name: stringOrDash(configuration?.name),
-        Region: stringOrDash(configuration?.region),
-        State: "-",
-        "Instance Type": stringOrDash(configuration?.instanceType),
-        "Public IP": "-",
-      };
+    const failure = outputs?.failed?.[0]?.data as CreateInstanceFailure | undefined;
+    if (failure) {
+      return failureExecutionDetails(configuration, failure, createdAt);
     }
 
-    return {
-      "Created At": stringOrDash(createdAt),
-      Name: stringOrDash(output.name ?? configuration?.name),
-      Region: stringOrDash(output.region ?? configuration?.region),
-      State: stringOrDash(output.state),
-      "Instance Type": stringOrDash(output.instanceType),
-      "Public IP": stringOrDash(output.publicIpAddress),
-    };
+    const output = (outputs?.created?.[0]?.data ?? outputs?.default?.[0]?.data) as Ec2Instance | undefined;
+    return instanceExecutionDetails(configuration, output, createdAt);
   },
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
@@ -98,6 +123,49 @@ export const createInstanceMapper: ComponentBaseMapper = {
     return renderTimeAgo(new Date(context.execution.createdAt));
   },
 };
+
+function failureExecutionDetails(
+  configuration: Configuration | undefined,
+  failure: CreateInstanceFailure,
+  createdAt?: string,
+): Record<string, string> {
+  const error = failure.awsErrorCode ? `${failure.awsErrorCode}: ${failure.error ?? ""}`.trim() : failure.error;
+
+  return {
+    "Created At": stringOrDash(createdAt),
+    Name: stringOrDash(configuration?.name),
+    Region: stringOrDash(configuration?.region),
+    State: failure.lastObservedState ? `Failed (${failure.lastObservedState})` : "Failed",
+    "Instance Type": stringOrDash(configuration?.instanceType),
+    Error: stringOrDash(error),
+  };
+}
+
+function instanceExecutionDetails(
+  configuration: Configuration | undefined,
+  output: Ec2Instance | undefined,
+  createdAt?: string,
+): Record<string, string> {
+  if (!output) {
+    return {
+      "Created At": stringOrDash(createdAt),
+      Name: stringOrDash(configuration?.name),
+      Region: stringOrDash(configuration?.region),
+      State: "-",
+      "Instance Type": stringOrDash(configuration?.instanceType),
+      "Public IP": "-",
+    };
+  }
+
+  return {
+    "Created At": stringOrDash(createdAt),
+    Name: stringOrDash(output.name ?? configuration?.name),
+    Region: stringOrDash(output.region ?? configuration?.region),
+    State: stringOrDash(output.state),
+    "Instance Type": stringOrDash(output.instanceType),
+    "Public IP": stringOrDash(output.publicIpAddress),
+  };
+}
 
 const MAX_METADATA_ITEMS = 3;
 
@@ -149,11 +217,7 @@ function createInstanceMetadata(node: NodeInfo): MetadataItem[] {
     .slice(0, MAX_METADATA_ITEMS);
 }
 
-function createInstanceEventSections(
-  nodes: NodeInfo[],
-  execution: ExecutionInfo,
-  componentName: string,
-): EventSection[] {
+function createInstanceEventSections(nodes: NodeInfo[], execution: ExecutionInfo): EventSection[] {
   const rootTriggerNode = nodes.find((node) => node.id === execution.rootEvent?.nodeId);
   const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName || "");
   const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
@@ -163,7 +227,7 @@ function createInstanceEventSections(
       receivedAt: new Date(execution.createdAt!),
       eventTitle: title,
       eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
-      eventState: getState(componentName)(execution),
+      eventState: createInstanceStateFunction(execution),
       eventId: execution.rootEvent?.id || "",
     },
   ];

--- a/web_src/src/pages/app/mappers/aws/index.ts
+++ b/web_src/src/pages/app/mappers/aws/index.ts
@@ -40,7 +40,7 @@ import { onImageTriggerRenderer } from "./ec2/on_image";
 import { onEc2AlarmTriggerRenderer } from "./ec2/on_alarm";
 import { createAlarmMapper } from "./ec2/create_alarm";
 import { createImageMapper } from "./ec2/create_image";
-import { createInstanceMapper } from "./ec2/create_instance";
+import { CREATE_INSTANCE_STATE_REGISTRY, createInstanceMapper } from "./ec2/create_instance";
 import { deleteInstanceMapper } from "./ec2/delete_instance";
 import { getAlarmMapper } from "./ec2/get_alarm";
 import { getImageMapper as getEc2ImageMapper } from "./ec2/get_image";
@@ -188,7 +188,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   "ec2.copyImage": buildActionStateRegistry("copied"),
   "ec2.createAlarm": buildActionStateRegistry("created"),
   "ec2.createImage": buildActionStateRegistry("created"),
-  "ec2.createInstance": buildActionStateRegistry("created"),
+  "ec2.createInstance": CREATE_INSTANCE_STATE_REGISTRY,
   "ec2.deregisterImage": buildActionStateRegistry("deregistered"),
   "ec2.deleteInstance": buildActionStateRegistry("deleted"),
   "ec2.disableImage": buildActionStateRegistry("disabled"),


### PR DESCRIPTION
Closes https://github.com/superplanehq/superplane/issues/5857

## Summary

This fixes the display state on the aws.createInstance component.

## Demo

<img width="1493" height="989" alt="image" src="https://github.com/user-attachments/assets/d41e408b-70d5-4c17-a4ae-1cb525b30bc1" />
