### PR TITLE
fix: collapse versions sidebar by default when landing on App in edit mode

### DIFF
--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
@@ -9,6 +9,12 @@ describe("useCanvasVersionsSidebarState", () => {
     expect(result.current.isVersionsSidebarOpen).toBe(true);
   });
 
+  it("supports a collapsed default state", () => {
+    const { result } = renderHook(() => useCanvasVersionsSidebarState({ defaultOpen: false }));
+
+    expect(result.current.isVersionsSidebarOpen).toBe(false);
+  });
+
   it("toggles the open state without persisting it", () => {
     const { result } = renderHook(() => useCanvasVersionsSidebarState());
 

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
@@ -1,7 +1,12 @@
 import { useCallback, useState } from "react";
 
-export function useCanvasVersionsSidebarState() {
-  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(true);
+interface CanvasVersionsSidebarStateConfig {
+  defaultOpen?: boolean;
+}
+
+export function useCanvasVersionsSidebarState(config: CanvasVersionsSidebarStateConfig = {}) {
+  const { defaultOpen = true } = config;
+  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(defaultOpen);
 
   const handleVersionsSidebarToggle = useCallback(() => {
     setIsVersionsSidebarOpen((current) => !current);

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -795,7 +795,9 @@ function CanvasPage(props: CanvasPageProps) {
   };
   const isRunsSidebarOpen = showRunsSidebar && runsSidebarBaseState.isRunsSidebarOpen;
 
-  const versionsSidebarBaseState = useCanvasVersionsSidebarState();
+  const versionsSidebarBaseState = useCanvasVersionsSidebarState({
+    defaultOpen: !props.isEditSessionActive,
+  });
   // Versions content is only produced during an edit session; within that session
   // the sidebar can be shown/hidden with the header toggle.
   const versionsContentAvailable = props.toolSidebarVersionsContent != null;
@@ -807,14 +809,14 @@ function CanvasPage(props: CanvasPageProps) {
   const isVersionsSidebarOpen = versionsContentAvailable && versionsSidebarBaseState.isVersionsSidebarOpen;
 
   // The collapse state is intentionally not persisted: the versions sidebar always
-  // starts expanded whenever the user (re)enters an edit session.
+  // starts collapsed whenever the user (re)enters an edit session.
   const isEditSessionActive = props.isEditSessionActive;
-  const { openVersionsSidebar } = versionsSidebarBaseState;
+  const { closeVersionsSidebar } = versionsSidebarBaseState;
   useEffect(() => {
     if (isEditSessionActive) {
-      openVersionsSidebar();
+      closeVersionsSidebar();
     }
-  }, [isEditSessionActive, openVersionsSidebar]);
+  }, [isEditSessionActive, closeVersionsSidebar]);
 
   const initialCanvasZoom = props.nodes.length === 0 ? DEFAULT_CANVAS_ZOOM : 1;
   const [canvasZoom, setCanvasZoom] = useState(initialCanvasZoom);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When an App canvas enters an edit session, the versions sidebar should start collapsed by default so users can focus on configuration.

Changes:
- Initialize versions sidebar closed when edit session is active.
- Reset to closed each time the user (re)enters an edit session.
- Extend `useCanvasVersionsSidebarState` to support a `defaultOpen` config and cover it with a unit test.

Test evidence:
- Manual UI recording: [versions_sidebar_collapsed_default_edit_mode_toggle.mp4](https://cursor.com/agents/bc-dfe7c5e2-9241-4698-bce9-a3a58fed1b12/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fversions_sidebar_collapsed_default_edit_mode_toggle.mp4)

Checks:
- `make format.js`
- `make check.build.ui`
- `make check.test.ui`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfe7c5e2-9241-4698-bce9-a3a58fed1b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfe7c5e2-9241-4698-bce9-a3a58fed1b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

