### PR TITLE
fix: keep component sidebar fixed width with long field values

### DIFF
--- a/web_src/src/components/AutoCompleteSelect/AutoCompleteSelect.tsx
+++ b/web_src/src/components/AutoCompleteSelect/AutoCompleteSelect.tsx
@@ -136,11 +136,11 @@ export function AutoCompleteSelect({
   }, [refs.reference, refs.floating]);
 
   return (
-    <div className="relative">
+    <div className="relative w-full min-w-0">
       <div
         ref={refs.setReference}
         className={twMerge(
-          "relative flex items-center w-full px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100",
+          "relative flex items-center w-full min-w-0 px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100",
           "border rounded-md focus-within:outline-none focus-within:ring-2 cursor-pointer",
           error
             ? "border-red-300 dark:border-red-600 focus-within:ring-red-500"
@@ -157,7 +157,7 @@ export function AutoCompleteSelect({
         }}
       >
         {!isOpen && selectedOption && query === "" ? (
-          <span className="flex-1 text-gray-800 dark:text-gray-100 truncate">{selectedOption.label}</span>
+          <span className="flex-1 min-w-0 text-gray-800 dark:text-gray-100 truncate">{selectedOption.label}</span>
         ) : (
           <input
             ref={inputRef}
@@ -165,7 +165,7 @@ export function AutoCompleteSelect({
             role="combobox"
             aria-expanded={isOpen}
             aria-haspopup="listbox"
-            className="flex-1 bg-transparent border-none outline-none placeholder:text-gray-500 dark:placeholder:text-gray-400"
+            className="flex-1 min-w-0 bg-transparent border-none outline-none placeholder:text-gray-500 dark:placeholder:text-gray-400"
             placeholder={placeholder}
             value={query}
             onChange={handleInputChange}

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -493,7 +493,7 @@ export function SettingsTab({
 
   return (
     <div
-      className={`p-4 overflow-y-auto ${showManualSaveFooter ? "pb-20" : "pb-24"}`}
+      className={`p-4 overflow-y-auto overflow-x-hidden ${showManualSaveFooter ? "pb-20" : "pb-24"}`}
       style={{ maxHeight: "80vh" }}
       onBlurCapture={(event) => {
         if (configurationSaveMode !== "auto") {

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -571,7 +571,7 @@ export const ConfigurationFieldRenderer = ({
       </div>
       {isEnabled && (
         <div className="flex items-center gap-2">
-          <div className="flex-1">{renderField()}</div>
+          <div className="flex-1 min-w-0">{renderField()}</div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Fixes #5856.

When a component configuration field held a very long value — e.g. an AWS EC2 `Image` (AMI) label like `ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260626 (ami-0a02a779008fa3b99, x86_64)` — the whole component configuration sidebar grew horizontally instead of staying at its fixed width.

### Root cause

Classic flexbox `min-width: auto` problem:

- `AutoCompleteSelect` (used for the Fixed-mode integration-resource picker, including `Image`) rendered its selected value in a `<span class="... truncate">`, but neither the component root nor the enclosing flex items had `min-w-0`.
- Because flex items default to `min-width: auto`, they refuse to shrink below their content's intrinsic width, so `truncate` never engaged and the long label pushed the panel wider.

### Changes

- `AutoCompleteSelect`: add `w-full min-w-0` to the root and `min-w-0` to the trigger row, the selected-value span and the search input so the value truncates within the available width.
- `configurationFieldRenderer`: add `min-w-0` to the field column wrapper so it can shrink below its content.
- `SettingsTab`: add a defensive `overflow-x-hidden` on the settings scroll container so no field can spill the panel horizontally.

Net effect: the sidebar keeps its fixed width; long selected values truncate with an ellipsis (full value remains visible when the dropdown is opened).

## Test plan

- [x] `make check.build.ui` passes.
- [x] `make format.js` clean.
- [ ] Manual: open a component with an `aws.ec2.createInstance` node, select an AMI with a very long label, confirm the sidebar stays fixed width and the value truncates.

Made with [Cursor](https://cursor.com)