### PR TITLE
feat: add standardized Timestamp component

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/RunDetailPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunDetailPanel.spec.tsx
@@ -20,11 +20,6 @@ vi.mock("@/hooks/useCanvasData", () => ({
   }),
 }));
 
-vi.mock("@/components/TimeAgo", () => ({
-  TimeAgo: () => <span>time ago</span>,
-  renderTimeAgo: () => "time ago",
-}));
-
 vi.mock("sonner", () => ({
   toast: { success: vi.fn() },
 }));

--- a/web_src/src/components/CanvasToolSidebar/RunDetailPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunDetailPanel.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, ChevronLeft, ChevronRight, Link as LinkIcon } from "lucide-react";
 import { useMemo } from "react";
 import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
-import { TimeAgo } from "@/components/TimeAgo";
+import { Timestamp } from "@/components/Timestamp";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useEventExecutions } from "@/hooks/useCanvasData";
@@ -132,7 +132,7 @@ export function RunDetailPanel({
         {run.createdAt ? (
           <div className="mt-1 flex items-center gap-1">
             <span className="text-xs text-gray-500">
-              <TimeAgo date={run.createdAt} />
+              <Timestamp date={run.createdAt} display="relative" relativeStyle="abbreviated" />
             </span>
             <button
               type="button"

--- a/web_src/src/components/CanvasToolSidebar/RunRow.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunRow.tsx
@@ -1,5 +1,5 @@
 import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
-import { TimeAgo } from "@/components/TimeAgo";
+import { Timestamp } from "@/components/Timestamp";
 import { appPath } from "@/lib/appPaths";
 import { cn } from "@/lib/utils";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
@@ -107,8 +107,8 @@ export function RunRow({
         <LinkIcon className="h-3 w-3" />
       </button>
       {run.createdAt ? (
-        <span className="pointer-events-none relative shrink-0 text-xs tabular-nums text-gray-500">
-          <TimeAgo date={run.createdAt} includeAgo={false} />
+        <span className="relative z-10 shrink-0 text-xs tabular-nums text-gray-500">
+          <Timestamp date={run.createdAt} display="relative" relativeStyle="abbreviated" includeAgo={false} />
         </span>
       ) : null}
     </div>

--- a/web_src/src/components/CanvasToolSidebar/RunRow.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunRow.tsx
@@ -40,14 +40,20 @@ export function RunRow({
   const selectRun = () => {
     if (run.id) onSelectRun(run.id);
   };
+  const openRunInNewTab = () => {
+    if (runHref === "#") return;
+    window.open(runHref, "_blank", "noopener,noreferrer");
+  };
   const handleTimestampClick = (event: MouseEvent<HTMLSpanElement>) => {
-    if (!isNormalClick(event)) {
+    if (isNormalClick(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+      selectRun();
       return;
     }
 
-    event.preventDefault();
     event.stopPropagation();
-    selectRun();
+    openRunInNewTab();
   };
 
   return (
@@ -120,7 +126,11 @@ export function RunRow({
         <LinkIcon className="h-3 w-3" />
       </button>
       {run.createdAt ? (
-        <span className="relative z-10 shrink-0 text-xs tabular-nums text-gray-500" onClick={handleTimestampClick}>
+        <span
+          className="relative z-10 shrink-0 text-xs tabular-nums text-gray-500"
+          onClick={handleTimestampClick}
+          onAuxClick={handleTimestampClick}
+        >
           <Timestamp date={run.createdAt} display="relative" relativeStyle="abbreviated" includeAgo={false} />
         </span>
       ) : null}

--- a/web_src/src/components/CanvasToolSidebar/RunRow.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunRow.tsx
@@ -1,4 +1,5 @@
 import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import type { MouseEvent } from "react";
 import { Timestamp } from "@/components/Timestamp";
 import { appPath } from "@/lib/appPaths";
 import { cn } from "@/lib/utils";
@@ -36,6 +37,18 @@ export function RunRow({
   const iconSrc = getHeaderIconSrc(triggerNode?.component);
   const iconSlug = triggerNode?.component ? componentIconMap[triggerNode.component] : undefined;
   const runHref = organizationId && appId && run.id ? appPath(organizationId, appId, `?run=${run.id}`) : "#";
+  const selectRun = () => {
+    if (run.id) onSelectRun(run.id);
+  };
+  const handleTimestampClick = (event: MouseEvent<HTMLSpanElement>) => {
+    if (!isNormalClick(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    selectRun();
+  };
 
   return (
     <div
@@ -51,7 +64,7 @@ export function RunRow({
         onClick={(e) => {
           if (isNormalClick(e)) {
             e.preventDefault();
-            if (run.id) onSelectRun(run.id);
+            selectRun();
           }
         }}
         className="absolute inset-0 z-0"
@@ -107,7 +120,7 @@ export function RunRow({
         <LinkIcon className="h-3 w-3" />
       </button>
       {run.createdAt ? (
-        <span className="relative z-10 shrink-0 text-xs tabular-nums text-gray-500">
+        <span className="relative z-10 shrink-0 text-xs tabular-nums text-gray-500" onClick={handleTimestampClick}>
           <Timestamp date={run.createdAt} display="relative" relativeStyle="abbreviated" includeAgo={false} />
         </span>
       ) : null}

--- a/web_src/src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import type { CanvasesCanvasRun, SuperplaneComponentsNode } from "@/api-client";
 import { RunsTabPanel } from "./RunsTabPanel";
@@ -119,6 +119,30 @@ describe("RunsTabPanel", () => {
 
     expect(onSelectRun).toHaveBeenCalledTimes(1);
     expect(onSelectRun).toHaveBeenCalledWith("run-1");
+  });
+
+  it("opens a run in a new tab when its timestamp is modified-clicked", () => {
+    const onSelectRun = vi.fn();
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(
+      <MemoryRouter initialEntries={["/org-1/apps/app-1"]}>
+        <Routes>
+          <Route
+            path="/:organizationId/apps/:appId"
+            element={<RunsTabPanel runs={[makeRun()]} selectedRunId={null} {...baseProps} onSelectRun={onSelectRun} />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const timestamp = document.querySelector('time[datetime="2026-05-01T12:00:00.000Z"]') as HTMLElement;
+    fireEvent.click(timestamp, { metaKey: true });
+
+    expect(onSelectRun).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith("/org-1/apps/app-1?run=run-1", "_blank", "noopener,noreferrer");
+
+    open.mockRestore();
   });
 
   it("filters runs by status", () => {

--- a/web_src/src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
@@ -106,6 +106,21 @@ describe("RunsTabPanel", () => {
     expect(within(rows[1]).getByText("Completed run")).toBeInTheDocument();
   });
 
+  it("selects a run when its timestamp is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelectRun = vi.fn();
+
+    render(<RunsTabPanel runs={[makeRun()]} selectedRunId={null} {...baseProps} onSelectRun={onSelectRun} />, {
+      wrapper: routerWrapper,
+    });
+
+    const timestamp = document.querySelector('time[datetime="2026-05-01T12:00:00.000Z"]') as HTMLElement;
+    await user.click(timestamp);
+
+    expect(onSelectRun).toHaveBeenCalledTimes(1);
+    expect(onSelectRun).toHaveBeenCalledWith("run-1");
+  });
+
   it("filters runs by status", () => {
     render(
       <RunsTabPanel

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanelRow.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanelRow.tsx
@@ -1,5 +1,5 @@
 import type { CanvasesCanvasVersion } from "@/api-client";
-import { TimeAgo } from "@/components/TimeAgo";
+import { Timestamp } from "@/components/Timestamp";
 import { cn } from "@/lib/utils";
 import { useCallback } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
@@ -66,7 +66,13 @@ export function VersionRow({
       ) : null}
       <span className="max-w-[40%] shrink-0 truncate text-[11px] text-slate-500">{ownerName}</span>
       {timestamp ? (
-        <TimeAgo date={timestamp} includeAgo={false} className="shrink-0 text-xs tabular-nums text-slate-500" />
+        <Timestamp
+          date={timestamp}
+          display="relative"
+          relativeStyle="abbreviated"
+          includeAgo={false}
+          className="shrink-0 text-xs tabular-nums text-slate-500"
+        />
       ) : null}
     </div>
   );

--- a/web_src/src/components/TimeAgo/TimeAgo.tsx
+++ b/web_src/src/components/TimeAgo/TimeAgo.tsx
@@ -24,6 +24,10 @@ interface TimeAgoProps {
   includeAgo?: boolean;
 }
 
+/**
+ * @deprecated Use `Timestamp` from `@/components/Timestamp` so users get the
+ * standardized hover details and copy affordance from issue #5150.
+ */
 export const TimeAgo = React.memo(function TimeAgo({ date, className, includeAgo = true }: TimeAgoProps) {
   const d = typeof date === "string" ? new Date(date) : date;
   const dateMs = d.getTime();

--- a/web_src/src/components/TimeAgo/helpers.ts
+++ b/web_src/src/components/TimeAgo/helpers.ts
@@ -4,6 +4,9 @@ import { TimeAgo } from "./TimeAgo";
 /**
  * Creates a TimeAgo React element from a Date or string.
  * Use in .ts files where JSX is not available.
+ *
+ * @deprecated Use `Timestamp` from `@/components/Timestamp` so users get the
+ * standardized hover details and copy affordance from issue #5150.
  */
 export function renderTimeAgo(date: Date | string): React.ReactNode {
   return React.createElement(TimeAgo, { date });
@@ -12,6 +15,9 @@ export function renderTimeAgo(date: Date | string): React.ReactNode {
 /**
  * Creates a React element with a text prefix followed by a separator and a self-updating TimeAgo.
  * Use in .ts files where JSX is not available.
+ *
+ * @deprecated Compose the prefix with `Timestamp` from `@/components/Timestamp`
+ * so users get the standardized hover details and copy affordance from issue #5150.
  */
 export function renderWithTimeAgo(prefix: string, date: Date | string, separator = " · "): React.ReactNode {
   return React.createElement(React.Fragment, null, prefix, separator, React.createElement(TimeAgo, { date }));

--- a/web_src/src/components/Timestamp/Timestamp.spec.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.spec.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Timestamp } from "./Timestamp";
+
+describe("Timestamp", () => {
+  const iso = "2026-06-02T10:01:10.561Z";
+
+  it("renders an absolute label with a machine-readable dateTime", () => {
+    render(<Timestamp date={iso} />);
+    const time = screen.getByText(/2026/);
+    expect(time.tagName).toBe("TIME");
+    expect(time).toHaveAttribute("dateTime", iso);
+  });
+
+  it("renders the dashed underline hint by default and omits it when disabled", () => {
+    const { rerender } = render(<Timestamp date={iso} />);
+    expect(screen.getByText(/2026/).closest("span")).toHaveClass("decoration-dashed");
+
+    rerender(<Timestamp date={iso} withHint={false} />);
+    expect(screen.getByText(/2026/).closest("span")).not.toHaveClass("decoration-dashed");
+  });
+
+  it("renders relative text when display is relative", () => {
+    render(<Timestamp date={new Date()} display="relative" />);
+    expect(screen.getByText(/ago$/)).toBeInTheDocument();
+  });
+
+  it("renders the fallback for missing or invalid dates", () => {
+    const { rerender } = render(<Timestamp date={null} fallback={<span>—</span>} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+
+    rerender(<Timestamp date="not-a-date" fallback={<span>n/a</span>} />);
+    expect(screen.getByText("n/a")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/components/Timestamp/Timestamp.spec.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.spec.tsx
@@ -30,6 +30,24 @@ describe("Timestamp", () => {
     expect(screen.getByText(/^in /)).toBeInTheDocument();
   });
 
+  it("renders a compact abbreviated relative label without a suffix", () => {
+    render(
+      <Timestamp
+        date={new Date(Date.now() - 5 * 60 * 1000)}
+        display="relative"
+        relativeStyle="abbreviated"
+        includeAgo={false}
+      />,
+    );
+    const time = screen.getByText("5m");
+    expect(time.tagName).toBe("TIME");
+  });
+
+  it("renders a compact abbreviated relative label with an 'ago' suffix", () => {
+    render(<Timestamp date={new Date(Date.now() - 5 * 60 * 1000)} display="relative" relativeStyle="abbreviated" />);
+    expect(screen.getByText("5m ago")).toBeInTheDocument();
+  });
+
   it("renders the fallback for missing or invalid dates", () => {
     const { rerender } = render(<Timestamp date={null} fallback={<span>—</span>} />);
     expect(screen.getByText("—")).toBeInTheDocument();

--- a/web_src/src/components/Timestamp/Timestamp.spec.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.spec.tsx
@@ -5,19 +5,25 @@ import { Timestamp } from "./Timestamp";
 describe("Timestamp", () => {
   const iso = "2026-06-02T10:01:10.561Z";
 
+  function getTimeByDateTime(dateTime: string): HTMLElement {
+    const time = document.querySelector(`time[datetime="${dateTime}"]`);
+    expect(time).toBeInstanceOf(HTMLElement);
+    return time as HTMLElement;
+  }
+
   it("renders an absolute label with a machine-readable dateTime", () => {
     render(<Timestamp date={iso} />);
-    const time = screen.getByText(/2026/);
+    const time = getTimeByDateTime(iso);
     expect(time.tagName).toBe("TIME");
     expect(time).toHaveAttribute("dateTime", iso);
   });
 
   it("renders the dashed underline hint by default and omits it when disabled", () => {
     const { rerender } = render(<Timestamp date={iso} />);
-    expect(screen.getByText(/2026/).closest("span")).toHaveClass("decoration-dashed");
+    expect(getTimeByDateTime(iso).closest("span")).toHaveClass("decoration-dashed");
 
     rerender(<Timestamp date={iso} withHint={false} />);
-    expect(screen.getByText(/2026/).closest("span")).not.toHaveClass("decoration-dashed");
+    expect(getTimeByDateTime(iso).closest("span")).not.toHaveClass("decoration-dashed");
   });
 
   it("renders past times as '… ago' when display is relative", () => {

--- a/web_src/src/components/Timestamp/Timestamp.spec.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.spec.tsx
@@ -20,9 +20,14 @@ describe("Timestamp", () => {
     expect(screen.getByText(/2026/).closest("span")).not.toHaveClass("decoration-dashed");
   });
 
-  it("renders relative text when display is relative", () => {
-    render(<Timestamp date={new Date()} display="relative" />);
+  it("renders past times as '… ago' when display is relative", () => {
+    render(<Timestamp date={new Date(Date.now() - 5000)} display="relative" />);
     expect(screen.getByText(/ago$/)).toBeInTheDocument();
+  });
+
+  it("renders future times as 'in …' instead of clamping to zero", () => {
+    render(<Timestamp date={new Date(Date.now() + 3 * 60 * 60 * 1000)} display="relative" />);
+    expect(screen.getByText(/^in /)).toBeInTheDocument();
   });
 
   it("renders the fallback for missing or invalid dates", () => {

--- a/web_src/src/components/Timestamp/Timestamp.stories.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.stories.tsx
@@ -13,6 +13,13 @@ const meta: Meta<typeof Timestamp> = {
       control: "radio",
       options: ["absolute", "relative"],
     },
+    relativeStyle: {
+      control: "radio",
+      options: ["full", "abbreviated"],
+    },
+    includeAgo: {
+      control: "boolean",
+    },
     withHint: {
       control: "boolean",
     },
@@ -35,6 +42,25 @@ export const Relative: Story = {
   args: {
     date: oneDayAgo,
     display: "relative",
+  },
+};
+
+const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+export const RelativeAbbreviated: Story = {
+  args: {
+    date: fiveMinutesAgo,
+    display: "relative",
+    relativeStyle: "abbreviated",
+  },
+};
+
+export const RelativeAbbreviatedNoAgo: Story = {
+  args: {
+    date: fiveMinutesAgo,
+    display: "relative",
+    relativeStyle: "abbreviated",
+    includeAgo: false,
   },
 };
 

--- a/web_src/src/components/Timestamp/Timestamp.stories.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Timestamp } from "./Timestamp";
+
+const meta: Meta<typeof Timestamp> = {
+  title: "Components/Timestamp",
+  component: Timestamp,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    display: {
+      control: "radio",
+      options: ["absolute", "relative"],
+    },
+    withHint: {
+      control: "boolean",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+export const Absolute: Story = {
+  args: {
+    date: oneDayAgo,
+    display: "absolute",
+  },
+};
+
+export const Relative: Story = {
+  args: {
+    date: oneDayAgo,
+    display: "relative",
+  },
+};
+
+export const InTableCell: Story = {
+  render: () => (
+    <table className="text-sm">
+      <tbody>
+        <tr>
+          <td className="pr-6 text-gray-500">Modified</td>
+          <td>
+            <Timestamp date={oneDayAgo} />
+          </td>
+        </tr>
+        <tr>
+          <td className="pr-6 text-gray-500">Created</td>
+          <td>
+            <Timestamp date={new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString()} />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  ),
+};

--- a/web_src/src/components/Timestamp/Timestamp.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.tsx
@@ -1,9 +1,39 @@
-import React from "react";
+import React, { useEffect, useReducer } from "react";
 import { twMerge } from "tailwind-merge";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { CopyButton } from "@/ui/CopyButton";
-import { TimeAgo } from "@/components/TimeAgo";
 import { formatAbsolute, formatISO, formatRelative, formatUTC, toDate, type TimestampInput } from "@/lib/datetime";
+
+// A single shared 1s ticker drives every relative label so a page with many
+// timestamps doesn't spin up an interval per instance (mirrors `TimeAgo`).
+const relativeTickListeners = new Set<() => void>();
+let relativeTickInterval: ReturnType<typeof setInterval> | null = null;
+
+function subscribeRelativeTick(listener: () => void): () => void {
+  relativeTickListeners.add(listener);
+  if (!relativeTickInterval) {
+    relativeTickInterval = setInterval(() => {
+      relativeTickListeners.forEach((cb) => cb());
+    }, 1000);
+  }
+  return () => {
+    relativeTickListeners.delete(listener);
+    if (relativeTickInterval && relativeTickListeners.size === 0) {
+      clearInterval(relativeTickInterval);
+      relativeTickInterval = null;
+    }
+  };
+}
+
+/**
+ * Live-updating relative label. Uses `formatRelative` (not `TimeAgo`) so future
+ * timestamps render as "in …" instead of being clamped to "0s ago".
+ */
+function RelativeLabel({ date, iso }: { date: Date; iso: string }) {
+  const [, tick] = useReducer((n: number) => n + 1, 0);
+  useEffect(() => subscribeRelativeTick(tick), []);
+  return <time dateTime={iso}>{formatRelative(date)}</time>;
+}
 
 interface TimestampProps {
   /** Accepts a `Date`, ISO string, or epoch milliseconds. */
@@ -58,7 +88,7 @@ export const Timestamp = React.memo(function Timestamp({
       <HoverCardTrigger asChild>
         <span className={twMerge(hintClasses, className)}>
           {display === "relative" ? (
-            <TimeAgo date={resolved} />
+            <RelativeLabel date={resolved} iso={iso} />
           ) : (
             <time dateTime={iso}>{formatAbsolute(resolved)}</time>
           )}

--- a/web_src/src/components/Timestamp/Timestamp.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useReducer } from "react";
 import { twMerge } from "tailwind-merge";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { CopyButton } from "@/ui/CopyButton";
+import { formatTimeAgo } from "@/lib/date";
 import { formatAbsolute, formatISO, formatRelative, formatUTC, toDate, type TimestampInput } from "@/lib/datetime";
 
 // A single shared 1s ticker drives every relative label so a page with many
@@ -26,13 +27,28 @@ function subscribeRelativeTick(listener: () => void): () => void {
 }
 
 /**
- * Live-updating relative label. Uses `formatRelative` (not `TimeAgo`) so future
- * timestamps render as "in …" instead of being clamped to "0s ago".
+ * Live-updating relative label driven by the shared 1s ticker.
+ *
+ * - `"full"` uses `formatRelative` so future timestamps render as "in …"
+ *   instead of being clamped ("in 3 hours", "5 minutes ago").
+ * - `"abbreviated"` reuses `formatTimeAgo` (the helper `TimeAgo` uses) so dense
+ *   rows keep their compact "5m" / "5m ago" text byte-for-byte.
  */
-function RelativeLabel({ date, iso }: { date: Date; iso: string }) {
+function RelativeLabel({
+  date,
+  iso,
+  relativeStyle,
+  includeAgo,
+}: {
+  date: Date;
+  iso: string;
+  relativeStyle: "full" | "abbreviated";
+  includeAgo: boolean;
+}) {
   const [, tick] = useReducer((n: number) => n + 1, 0);
   useEffect(() => subscribeRelativeTick(tick), []);
-  return <time dateTime={iso}>{formatRelative(date)}</time>;
+  const label = relativeStyle === "abbreviated" ? formatTimeAgo(date, includeAgo) : formatRelative(date);
+  return <time dateTime={iso}>{label}</time>;
 }
 
 interface TimestampProps {
@@ -44,6 +60,18 @@ interface TimestampProps {
    * - `"relative"`: live-updating "5m ago" style text.
    */
   display?: "absolute" | "relative";
+  /**
+   * Style of the relative label (only applies when `display="relative"`):
+   * - `"full"` (default): verbose Intl text, e.g. "5 minutes ago" / "in 3 hours".
+   * - `"abbreviated"`: compact text for dense rows, e.g. "5m" / "5m ago".
+   */
+  relativeStyle?: "full" | "abbreviated";
+  /**
+   * Whether the abbreviated relative label includes the "ago" suffix, e.g. "5m ago"
+   * vs "5m". Only applies when `display="relative"` and `relativeStyle="abbreviated"`.
+   * Default `true`.
+   */
+  includeAgo?: boolean;
   /** Render the dashed underline affordance that hints at the hover details. Default `true`. */
   withHint?: boolean;
   className?: string;
@@ -70,6 +98,8 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
 export const Timestamp = React.memo(function Timestamp({
   date,
   display = "absolute",
+  relativeStyle = "full",
+  includeAgo = true,
   withHint = true,
   className,
   align = "start",
@@ -88,7 +118,7 @@ export const Timestamp = React.memo(function Timestamp({
       <HoverCardTrigger asChild>
         <span className={twMerge(hintClasses, className)}>
           {display === "relative" ? (
-            <RelativeLabel date={resolved} iso={iso} />
+            <RelativeLabel date={resolved} iso={iso} relativeStyle={relativeStyle} includeAgo={includeAgo} />
           ) : (
             <time dateTime={iso}>{formatAbsolute(resolved)}</time>
           )}

--- a/web_src/src/components/Timestamp/Timestamp.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.tsx
@@ -92,7 +92,7 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
 
 /**
  * Standardized timestamp display: a locale-aware label with a dashed underline
- * hint that reveals absolute (UTC), relative, and raw ISO values on hover,
+ * hint that reveals local absolute, relative, UTC, and raw ISO values on hover,
  * with a copy button for the ISO value.
  */
 export const Timestamp = React.memo(function Timestamp({
@@ -126,6 +126,7 @@ export const Timestamp = React.memo(function Timestamp({
       </HoverCardTrigger>
       <HoverCardContent align={align} className="w-auto max-w-sm p-3">
         <dl className="grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-1.5 text-sm">
+          <DetailRow label="Local">{formatAbsolute(resolved)}</DetailRow>
           <DetailRow label="UTC">{formatUTC(resolved)}</DetailRow>
           <DetailRow label="Relative">{formatRelative(resolved)}</DetailRow>
           <DetailRow label="Timestamp">

--- a/web_src/src/components/Timestamp/Timestamp.tsx
+++ b/web_src/src/components/Timestamp/Timestamp.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { twMerge } from "tailwind-merge";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { CopyButton } from "@/ui/CopyButton";
+import { TimeAgo } from "@/components/TimeAgo";
+import { formatAbsolute, formatISO, formatRelative, formatUTC, toDate, type TimestampInput } from "@/lib/datetime";
+
+interface TimestampProps {
+  /** Accepts a `Date`, ISO string, or epoch milliseconds. */
+  date: TimestampInput | null | undefined;
+  /**
+   * Controls the visible label:
+   * - `"absolute"` (default): locale date-time in the user's timezone.
+   * - `"relative"`: live-updating "5m ago" style text.
+   */
+  display?: "absolute" | "relative";
+  /** Render the dashed underline affordance that hints at the hover details. Default `true`. */
+  withHint?: boolean;
+  className?: string;
+  /** Alignment of the hover card relative to the trigger. */
+  align?: "start" | "center" | "end";
+  /** Rendered when the date is missing/invalid. */
+  fallback?: React.ReactNode;
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <>
+      <dt className="text-right font-medium text-gray-500 dark:text-gray-400">{label}</dt>
+      <dd className="min-w-0 text-gray-800 dark:text-gray-100">{children}</dd>
+    </>
+  );
+}
+
+/**
+ * Standardized timestamp display: a locale-aware label with a dashed underline
+ * hint that reveals absolute (UTC), relative, and raw ISO values on hover,
+ * with a copy button for the ISO value.
+ */
+export const Timestamp = React.memo(function Timestamp({
+  date,
+  display = "absolute",
+  withHint = true,
+  className,
+  align = "start",
+  fallback = null,
+}: TimestampProps) {
+  const resolved = toDate(date);
+  if (!resolved) return <>{fallback}</>;
+
+  const iso = formatISO(resolved);
+  const hintClasses = withHint
+    ? "underline decoration-dashed decoration-gray-300 dark:decoration-gray-600 underline-offset-2 cursor-default"
+    : "cursor-default";
+
+  return (
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <span className={twMerge(hintClasses, className)}>
+          {display === "relative" ? (
+            <TimeAgo date={resolved} />
+          ) : (
+            <time dateTime={iso}>{formatAbsolute(resolved)}</time>
+          )}
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent align={align} className="w-auto max-w-sm p-3">
+        <dl className="grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-1.5 text-sm">
+          <DetailRow label="UTC">{formatUTC(resolved)}</DetailRow>
+          <DetailRow label="Relative">{formatRelative(resolved)}</DetailRow>
+          <DetailRow label="Timestamp">
+            <div className="flex items-center gap-1.5">
+              <span className="min-w-0 truncate font-mono text-xs">{iso}</span>
+              <CopyButton text={iso} data-testid="timestamp-copy" />
+            </div>
+          </DetailRow>
+        </dl>
+      </HoverCardContent>
+    </HoverCard>
+  );
+});

--- a/web_src/src/components/Timestamp/index.ts
+++ b/web_src/src/components/Timestamp/index.ts
@@ -1,0 +1,1 @@
+export { Timestamp } from "./Timestamp";

--- a/web_src/src/lib/datetime.spec.ts
+++ b/web_src/src/lib/datetime.spec.ts
@@ -60,6 +60,13 @@ describe("datetime", () => {
       expect(formatRelative(now - 60 * 24 * 60 * 60 * 1000, "en", now)).toBe("2 months ago");
       expect(formatRelative(now - 400 * 24 * 60 * 60 * 1000, "en", now)).toBe("1 year ago");
     });
+
+    it("rounds across unit boundaries instead of returning maxed-out units", () => {
+      expect(formatRelative(now - 59_600, "en", now)).toBe("1 minute ago");
+      expect(formatRelative(now + 59_600, "en", now)).toBe("in 1 minute");
+      expect(formatRelative(now - 23.6 * 60 * 60 * 1000, "en", now)).toBe("1 day ago");
+      expect(formatRelative(now + 6.6 * 24 * 60 * 60 * 1000, "en", now)).toBe("in 1 week");
+    });
   });
 
   describe("formatISO", () => {

--- a/web_src/src/lib/datetime.spec.ts
+++ b/web_src/src/lib/datetime.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { formatAbsolute, formatISO, formatRelative, formatUTC, toDate } from "@/lib/datetime";
+
+describe("datetime", () => {
+  const iso = "2026-06-02T10:01:10.561Z";
+
+  describe("toDate", () => {
+    it("returns null for missing or invalid values", () => {
+      expect(toDate(null)).toBeNull();
+      expect(toDate(undefined)).toBeNull();
+      expect(toDate("")).toBeNull();
+      expect(toDate("not-a-date")).toBeNull();
+    });
+
+    it("accepts Date, string, and epoch millis", () => {
+      const date = new Date(iso);
+      expect(toDate(date)).toEqual(date);
+      expect(toDate(iso)).toEqual(date);
+      expect(toDate(date.getTime())).toEqual(date);
+    });
+  });
+
+  describe("formatUTC", () => {
+    it("renders the timestamp in UTC without a timezone suffix", () => {
+      // Locale fixed for a deterministic assertion; UTC is timezone-stable.
+      expect(formatUTC(iso, "en-GB")).toBe("02 Jun 2026, 10:01:10");
+    });
+
+    it("returns an empty string for invalid input", () => {
+      expect(formatUTC("nope", "en-GB")).toBe("");
+    });
+  });
+
+  describe("formatAbsolute", () => {
+    it("includes a short timezone name", () => {
+      // Local timezone is environment-dependent, so assert structure only.
+      const formatted = formatAbsolute(iso, "en-GB");
+      expect(formatted).toMatch(/Jun 2026/);
+      expect(formatted.trim().length).toBeGreaterThan("02 Jun 2026, 10:01:10".length);
+    });
+  });
+
+  describe("formatRelative", () => {
+    const now = new Date(iso).getTime();
+
+    it('reads "1 day ago" rather than "yesterday"', () => {
+      const yesterday = now - 24 * 60 * 60 * 1000;
+      expect(formatRelative(yesterday, "en", now)).toBe("1 day ago");
+    });
+
+    it("handles seconds, minutes, hours, and future times", () => {
+      expect(formatRelative(now - 30 * 1000, "en", now)).toBe("30 seconds ago");
+      expect(formatRelative(now - 5 * 60 * 1000, "en", now)).toBe("5 minutes ago");
+      expect(formatRelative(now - 3 * 60 * 60 * 1000, "en", now)).toBe("3 hours ago");
+      expect(formatRelative(now + 2 * 60 * 60 * 1000, "en", now)).toBe("in 2 hours");
+    });
+
+    it("scales up to weeks, months, and years", () => {
+      expect(formatRelative(now - 10 * 24 * 60 * 60 * 1000, "en", now)).toBe("1 week ago");
+      expect(formatRelative(now - 60 * 24 * 60 * 60 * 1000, "en", now)).toBe("2 months ago");
+      expect(formatRelative(now - 400 * 24 * 60 * 60 * 1000, "en", now)).toBe("1 year ago");
+    });
+  });
+
+  describe("formatISO", () => {
+    it("returns the full-precision ISO string", () => {
+      expect(formatISO(iso)).toBe(iso);
+      expect(formatISO(new Date(iso).getTime())).toBe(iso);
+    });
+  });
+});

--- a/web_src/src/lib/datetime.ts
+++ b/web_src/src/lib/datetime.ts
@@ -53,6 +53,27 @@ const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 const MONTH = 30 * DAY;
 const YEAR = 365 * DAY;
+const DEFAULT_LOCALE_KEY = "__default__";
+const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>();
+
+function relativeFormatter(locale?: string): Intl.RelativeTimeFormat {
+  const key = locale ?? DEFAULT_LOCALE_KEY;
+  const cached = relativeTimeFormatters.get(key);
+  if (cached) return cached;
+
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: "always" });
+  relativeTimeFormatters.set(key, formatter);
+  return formatter;
+}
+
+function formatRelativeUnit(
+  diff: number,
+  unitSize: number,
+  unit: Intl.RelativeTimeFormatUnit,
+  formatter: Intl.RelativeTimeFormat,
+): string {
+  return formatter.format(Math.round(diff / unitSize), unit);
+}
 
 /**
  * Locale-aware relative time from now, e.g. `"1 day ago"` or `"in 3 hours"`.
@@ -65,15 +86,15 @@ export function formatRelative(value: TimestampInput, locale?: string, now: numb
 
   const diff = date.getTime() - now;
   const abs = Math.abs(diff);
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "always" });
+  const rtf = relativeFormatter(locale);
 
-  if (abs < MINUTE) return rtf.format(Math.round(diff / SECOND), "second");
-  if (abs < HOUR) return rtf.format(Math.round(diff / MINUTE), "minute");
-  if (abs < DAY) return rtf.format(Math.round(diff / HOUR), "hour");
-  if (abs < WEEK) return rtf.format(Math.round(diff / DAY), "day");
-  if (abs < MONTH) return rtf.format(Math.round(diff / WEEK), "week");
-  if (abs < YEAR) return rtf.format(Math.round(diff / MONTH), "month");
-  return rtf.format(Math.round(diff / YEAR), "year");
+  if (Math.round(abs / SECOND) < 60) return formatRelativeUnit(diff, SECOND, "second", rtf);
+  if (Math.round(abs / MINUTE) < 60) return formatRelativeUnit(diff, MINUTE, "minute", rtf);
+  if (Math.round(abs / HOUR) < 24) return formatRelativeUnit(diff, HOUR, "hour", rtf);
+  if (Math.round(abs / DAY) < 7) return formatRelativeUnit(diff, DAY, "day", rtf);
+  if (Math.round(abs / WEEK) < 4) return formatRelativeUnit(diff, WEEK, "week", rtf);
+  if (Math.round(abs / MONTH) < 12) return formatRelativeUnit(diff, MONTH, "month", rtf);
+  return formatRelativeUnit(diff, YEAR, "year", rtf);
 }
 
 /**

--- a/web_src/src/lib/datetime.ts
+++ b/web_src/src/lib/datetime.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared date/time formatting helpers used by the `Timestamp` component and
+ * anywhere timestamps are shown to users. Formatting is locale-aware via the
+ * platform `Intl` APIs; pass a fixed `locale` only for deterministic tests.
+ */
+
+export type TimestampInput = Date | string | number;
+
+/**
+ * Coerce the accepted timestamp inputs into a `Date`.
+ * Returns `null` when the value is missing or not a valid date.
+ */
+export function toDate(value: TimestampInput | null | undefined): Date | null {
+  if (value === null || value === undefined || value === "") return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+const ABSOLUTE_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+};
+
+/**
+ * Locale-aware absolute timestamp in the user's local timezone, including a
+ * short timezone name, e.g. `"02 Jun 2026, 12:01:10 CEST"`.
+ */
+export function formatAbsolute(value: TimestampInput, locale?: string): string {
+  const date = toDate(value);
+  if (!date) return "";
+  return new Intl.DateTimeFormat(locale, { ...ABSOLUTE_OPTIONS, timeZoneName: "short" }).format(date);
+}
+
+/**
+ * Locale-aware absolute timestamp rendered in UTC (no timezone suffix, since
+ * callers label it as UTC), e.g. `"02 Jun 2026, 10:01:10"`.
+ */
+export function formatUTC(value: TimestampInput, locale?: string): string {
+  const date = toDate(value);
+  if (!date) return "";
+  return new Intl.DateTimeFormat(locale, { ...ABSOLUTE_OPTIONS, timeZone: "UTC" }).format(date);
+}
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+
+/**
+ * Locale-aware relative time from now, e.g. `"1 day ago"` or `"in 3 hours"`.
+ * Uses `numeric: "always"` so results read `"1 day ago"` rather than
+ * `"yesterday"`, matching the reference design.
+ */
+export function formatRelative(value: TimestampInput, locale?: string, now: number = Date.now()): string {
+  const date = toDate(value);
+  if (!date) return "";
+
+  const diff = date.getTime() - now;
+  const abs = Math.abs(diff);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "always" });
+
+  if (abs < MINUTE) return rtf.format(Math.round(diff / SECOND), "second");
+  if (abs < HOUR) return rtf.format(Math.round(diff / MINUTE), "minute");
+  if (abs < DAY) return rtf.format(Math.round(diff / HOUR), "hour");
+  if (abs < WEEK) return rtf.format(Math.round(diff / DAY), "day");
+  if (abs < MONTH) return rtf.format(Math.round(diff / WEEK), "week");
+  if (abs < YEAR) return rtf.format(Math.round(diff / MONTH), "month");
+  return rtf.format(Math.round(diff / YEAR), "year");
+}
+
+/**
+ * Full-precision ISO 8601 timestamp (UTC), e.g. `"2026-06-02T10:01:10.561Z"`.
+ */
+export function formatISO(value: TimestampInput): string {
+  const date = toDate(value);
+  if (!date) return "";
+  return date.toISOString();
+}

--- a/web_src/src/pages/admin/RunnerTasks.tsx
+++ b/web_src/src/pages/admin/RunnerTasks.tsx
@@ -1,10 +1,9 @@
 import { Text } from "@/components/Text/text";
-import { formatRelativeTime } from "@/lib/timezone";
+import { Timestamp } from "@/components/Timestamp";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { showErrorToast } from "@/lib/toast";
 import { Terminal } from "lucide-react";
 import React, { useCallback, useEffect, useState } from "react";
-import { formatDateTime } from "./formatDate";
 
 type RunnerTask = {
   id: string;
@@ -59,17 +58,14 @@ const formatExecutionMode = (task: RunnerTask) => {
   return mode;
 };
 
-const RelativeTimestamp = ({ value }: { value?: string }) => {
-  if (!value) {
-    return <span className="text-gray-400">—</span>;
-  }
-
-  return (
-    <span className="text-gray-600 whitespace-nowrap" title={formatDateTime(value)}>
-      {formatRelativeTime(value)}
-    </span>
-  );
-};
+const RelativeTimestamp = ({ value }: { value?: string }) => (
+  <Timestamp
+    date={value}
+    display="relative"
+    className="text-gray-600 whitespace-nowrap"
+    fallback={<span className="text-gray-400">—</span>}
+  />
+);
 
 const RunnerTasksTable = ({ tasks }: { tasks: RunnerTask[] }) => (
   <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden">

--- a/web_src/src/pages/app/ErrorsConsoleContent.tsx
+++ b/web_src/src/pages/app/ErrorsConsoleContent.tsx
@@ -5,7 +5,7 @@ import type {
   CanvasesCanvasRun,
   SuperplaneComponentsNode as ComponentsNode,
 } from "@/api-client";
-import { TimeAgo } from "@/components/TimeAgo";
+import { Timestamp } from "@/components/Timestamp";
 import { cn, resolveIcon } from "@/lib/utils";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { findNode, getStatusBadgeProps, resolveNodeIconSlug } from "@/pages/app/lib/canvas-runs";
@@ -115,7 +115,11 @@ function ErrorItemRow({
         <AcknowledgeButton executionId={item.execution.id} onAcknowledgeErrors={onAcknowledgeErrors} />
       )}
       <span className="text-xs text-gray-400 tabular-nums whitespace-nowrap">
-        {item.execution.createdAt ? <TimeAgo date={item.execution.createdAt} /> : ""}
+        {item.execution.createdAt ? (
+          <Timestamp date={item.execution.createdAt} display="relative" relativeStyle="abbreviated" />
+        ) : (
+          ""
+        )}
       </span>
     </div>
   );

--- a/web_src/src/pages/organization/settings/Groups.tsx
+++ b/web_src/src/pages/organization/settings/Groups.tsx
@@ -1,4 +1,4 @@
-import { formatRelativeTime } from "@/lib/timezone";
+import { Timestamp } from "@/components/Timestamp";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePageTitle } from "@/hooks/usePageTitle";
@@ -247,9 +247,12 @@ export function Groups({ organizationId }: GroupsProps) {
                     </TableCell>
 
                     <TableCell>
-                      <span className="text-sm text-gray-500 dark:text-gray-400">
-                        {formatRelativeTime(group.metadata?.createdAt)}
-                      </span>
+                      <Timestamp
+                        date={group.metadata?.createdAt}
+                        display="relative"
+                        className="text-sm text-gray-500 dark:text-gray-400"
+                        fallback={<span className="text-sm text-gray-500 dark:text-gray-400">N/A</span>}
+                      />
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">

--- a/web_src/src/ui/Runs/RunNodeDetailDetailsView.tsx
+++ b/web_src/src/ui/Runs/RunNodeDetailDetailsView.tsx
@@ -1,4 +1,4 @@
-import { TimeAgo } from "@/components/TimeAgo";
+import { Timestamp } from "@/components/Timestamp";
 import { cn, isUrl } from "@/lib/utils";
 import { isErrorValue } from "./runNodeDetailModel";
 
@@ -37,7 +37,7 @@ export function RunNodeDetailDetailsView({
         <div className="flex items-start gap-2">
           <span className="w-[120px] shrink-0 truncate text-right text-gray-500">Relative time:</span>
           <span className="min-w-0 break-all text-gray-800">
-            <TimeAgo date={relativeTime} />
+            <Timestamp date={relativeTime} display="relative" relativeStyle="abbreviated" />
           </span>
         </div>
       ) : null}

--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -11,7 +11,7 @@ import { SelectionWrapper } from "../selectionWrapper";
 import type { ComponentActionsProps } from "../types/componentActions";
 import { PayloadTooltip } from "./PayloadTooltip";
 import { SpecsTooltip } from "./SpecsTooltip";
-import { TimeAgo } from "@/components/TimeAgo";
+import { Timestamp } from "@/components/Timestamp";
 
 interface EventSectionDisplayProps {
   section: EventSection;
@@ -82,7 +82,7 @@ const EventSectionDisplay: React.FC<EventSectionDisplayProps> = ({
           </span>
         ) : (
           <span className="text-[13px] font-medium truncate flex-shrink-0 max-w-[65%] text-gray-950/50">
-            <TimeAgo date={section.receivedAt!} />
+            <Timestamp date={section.receivedAt} display="relative" relativeStyle="abbreviated" />
           </span>
         )}
       </div>

--- a/web_src/src/ui/componentSidebar/CompactSidebarEventRow.spec.tsx
+++ b/web_src/src/ui/componentSidebar/CompactSidebarEventRow.spec.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
@@ -68,6 +68,21 @@ describe("CompactSidebarEventRow", () => {
 
     expect(onSelectRun).toHaveBeenCalledTimes(1);
     expect(onSelectRun).toHaveBeenCalledWith("run-1");
+  });
+
+  it("opens the run in a new tab when the timestamp is modified-clicked", () => {
+    const onSelectRun = vi.fn();
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    renderRow({ runId: "run-1", onSelectRun });
+
+    const timestamp = document.querySelector('time[datetime="2026-02-06T15:28:05.000Z"]') as HTMLElement;
+    fireEvent.click(timestamp, { metaKey: true });
+
+    expect(onSelectRun).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith("/org-1/apps/app-1?run=run-1", "_blank", "noopener,noreferrer");
+
+    open.mockRestore();
   });
 
   it("selects the run with node context when the row belongs to a selected node", async () => {

--- a/web_src/src/ui/componentSidebar/CompactSidebarEventRow.spec.tsx
+++ b/web_src/src/ui/componentSidebar/CompactSidebarEventRow.spec.tsx
@@ -57,6 +57,19 @@ describe("CompactSidebarEventRow", () => {
     expect(onSelectRun).toHaveBeenCalledWith("run-1");
   });
 
+  it("selects the run when the timestamp is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelectRun = vi.fn();
+
+    renderRow({ runId: "run-1", onSelectRun });
+
+    const timestamp = document.querySelector('time[datetime="2026-02-06T15:28:05.000Z"]') as HTMLElement;
+    await user.click(timestamp);
+
+    expect(onSelectRun).toHaveBeenCalledTimes(1);
+    expect(onSelectRun).toHaveBeenCalledWith("run-1");
+  });
+
   it("selects the run with node context when the row belongs to a selected node", async () => {
     const user = userEvent.setup();
     const onSelectRun = vi.fn();

--- a/web_src/src/ui/componentSidebar/CompactSidebarEventRow.tsx
+++ b/web_src/src/ui/componentSidebar/CompactSidebarEventRow.tsx
@@ -118,6 +118,15 @@ export function CompactSidebarEventRow({
     clickEvent.stopPropagation();
     void selectRun();
   };
+  const handleTimestampClick = (clickEvent: MouseEvent<HTMLSpanElement>) => {
+    if (!isNormalClick(clickEvent)) {
+      return;
+    }
+
+    clickEvent.preventDefault();
+    clickEvent.stopPropagation();
+    void selectRun();
+  };
 
   return (
     <div
@@ -180,7 +189,7 @@ export function CompactSidebarEventRow({
         </div>
       ) : null}
       {event.receivedAt ? (
-        <span className="relative z-20 shrink-0 text-xs tabular-nums text-gray-500">
+        <span className="relative z-20 shrink-0 text-xs tabular-nums text-gray-500" onClick={handleTimestampClick}>
           <Timestamp date={event.receivedAt} display="relative" relativeStyle="abbreviated" includeAgo={false} />
         </span>
       ) : null}

--- a/web_src/src/ui/componentSidebar/CompactSidebarEventRow.tsx
+++ b/web_src/src/ui/componentSidebar/CompactSidebarEventRow.tsx
@@ -119,13 +119,17 @@ export function CompactSidebarEventRow({
     void selectRun();
   };
   const handleTimestampClick = (clickEvent: MouseEvent<HTMLSpanElement>) => {
-    if (!isNormalClick(clickEvent)) {
+    if (isNormalClick(clickEvent)) {
+      clickEvent.preventDefault();
+      clickEvent.stopPropagation();
+      void selectRun();
       return;
     }
 
-    clickEvent.preventDefault();
     clickEvent.stopPropagation();
-    void selectRun();
+    if (runHref) {
+      window.open(runHref, "_blank", "noopener,noreferrer");
+    }
   };
 
   return (
@@ -189,7 +193,11 @@ export function CompactSidebarEventRow({
         </div>
       ) : null}
       {event.receivedAt ? (
-        <span className="relative z-20 shrink-0 text-xs tabular-nums text-gray-500" onClick={handleTimestampClick}>
+        <span
+          className="relative z-20 shrink-0 text-xs tabular-nums text-gray-500"
+          onClick={handleTimestampClick}
+          onAuxClick={handleTimestampClick}
+        >
           <Timestamp date={event.receivedAt} display="relative" relativeStyle="abbreviated" includeAgo={false} />
         </span>
       ) : null}

--- a/web_src/src/ui/componentSidebar/CompactSidebarEventRow.tsx
+++ b/web_src/src/ui/componentSidebar/CompactSidebarEventRow.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState, type MouseEvent } from "react";
 import type { CanvasesCanvasNodeExecution } from "@/api-client";
-import { TimeAgo } from "@/components/TimeAgo";
+import { Timestamp } from "@/components/Timestamp";
 import { RUNS_SIDEBAR_ROW_CLASS } from "@/components/CanvasToolSidebar/runsSidebarRowLayout";
 import { appPath } from "@/lib/appPaths";
 import { isNormalClick } from "@/lib/linkHelpers";
@@ -180,8 +180,8 @@ export function CompactSidebarEventRow({
         </div>
       ) : null}
       {event.receivedAt ? (
-        <span className="pointer-events-none relative shrink-0 text-xs tabular-nums text-gray-500">
-          <TimeAgo date={event.receivedAt} includeAgo={false} />
+        <span className="relative z-20 shrink-0 text-xs tabular-nums text-gray-500">
+          <Timestamp date={event.receivedAt} display="relative" relativeStyle="abbreviated" includeAgo={false} />
         </span>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

Refs #5150.

Timestamps are rendered inconsistently across the app — a mix of `toLocaleString`, `formatRelativeTime`, `TimeAgo`, and various ad-hoc helpers — and there is no consistent affordance to reveal the absolute / UTC / raw value.

This PR introduces a reusable, locale-aware `Timestamp` component modeled on the reference design from the issue (Cloudflare-style):

- A human-readable label — locale absolute time in the user's timezone by default, or a live-updating relative label (`display="relative"`).
- A **dashed-underline hint** signalling the value is interactive.
- On hover, a card showing **UTC**, **Relative** ("1 day ago"), and the full **ISO Timestamp** with a **copy button**.

### Changes

- `web_src/src/lib/datetime.ts` — shared, locale-aware helpers (`formatAbsolute`, `formatUTC`, `formatRelative`, `formatISO`, `toDate`) + unit tests.
- `web_src/src/components/Timestamp/` — the component, a Storybook story, and a component spec.
- Adopted the component in two first call sites: the admin **Runner Tasks** table (previously a native `title` tooltip) and the organization **Groups** settings table.

Broader migration of the ~250 remaining `toLocaleString` / `renderTimeAgo` call sites can follow incrementally on top of this component.

### Verification

Rendered via Storybook (`Components/Timestamp` → `In Table Cell`), hovering the label opens the details card:

```
Modified   Jul 02, 2026, 12:38:49 GMT-3   (dashed underline)
           ┌─────────────────────────────────────────┐
           │       UTC  Jul 02, 2026, 15:38:49        │
           │  Relative  1 day ago                     │
           │ Timestamp  2026-07-02T15:38:49.751Z  [⧉] │
           └─────────────────────────────────────────┘
```

## Test plan

- [x] `npx vitest run` for `lib/datetime.spec.ts` and `components/Timestamp/Timestamp.spec.tsx` (13 tests) pass.
- [x] `make check.build.ui` passes.
- [x] `make format.js` clean; eslint on touched files reports no new errors.
- [x] Verified the hover card + copy button in Storybook.

Made with [Cursor](https://cursor.com)