### PR TITLE
fix: open agent panel (not history) on new apps with a per-canvas preference

### DIFF
--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -79,11 +79,10 @@ func (s *CanvasSteps) ExitEditMode() {
 	s.session.Sleep(500)
 }
 
-// OpenVersionsSidebar reveals the versions sidebar. The sidebar no longer
-// auto-opens when an edit session starts (issue #5803): it starts collapsed and
-// is shown via the header toggle. If no edit session is active yet, this enters
-// edit mode (selecting the latest draft or creating one) to make the toggle
-// available, then clicks it to reveal the sidebar.
+// OpenVersionsSidebar reveals the versions sidebar, which is shown while an edit
+// session is active (unless the agent panel is the active side panel). If no
+// edit session is active yet, it enters edit mode (selecting the latest draft or
+// creating one) to reveal the sidebar.
 func (s *CanvasSteps) OpenVersionsSidebar() {
 	sidebar := q.TestID("canvas-versions-sidebar").Run(s.session)
 	if visible, _ := sidebar.IsVisible(); visible {
@@ -92,12 +91,6 @@ func (s *CanvasSteps) OpenVersionsSidebar() {
 	}
 
 	s.EnterEditMode()
-
-	if visible, _ := sidebar.IsVisible(); !visible {
-		toggle := q.TestID("canvas-versions-sidebar-toggle").Run(s.session)
-		require.NoError(s.t, toggle.Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
-	}
-
 	s.session.AssertVisible(q.TestID("canvas-versions-sidebar"))
 	s.session.Sleep(300)
 }

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -52,6 +52,7 @@ func (s *CanvasSteps) EnterEditMode() {
 // switch to the new draft so subsequent edits are staged onto it rather than the
 // draft that was being edited before.
 func (s *CanvasSteps) CreateNewDraftFromEditMenu() {
+	s.ensureEditMode()
 	s.OpenVersionsSidebar()
 	before := len(s.ListDraftVersions())
 
@@ -79,20 +80,42 @@ func (s *CanvasSteps) ExitEditMode() {
 	s.session.Sleep(500)
 }
 
-// OpenVersionsSidebar reveals the versions sidebar. If no edit session is active
-// yet, it enters edit mode (selecting the latest draft or creating one) before
-// opening the sidebar from the header toggle.
+// OpenVersionsSidebar reveals the versions sidebar from the current canvas mode.
+// If the header toggle is not available yet, it enters edit mode first.
 func (s *CanvasSteps) OpenVersionsSidebar() {
-	sidebar := q.TestID("canvas-versions-sidebar").Run(s.session)
-	if visible, _ := sidebar.IsVisible(); visible {
-		s.session.Sleep(300)
+	toggle := q.TestID("canvas-versions-sidebar-toggle").Run(s.session)
+	if visible, _ := toggle.IsVisible(); !visible {
+		s.EnterEditMode()
+	}
+
+	s.ensureVersionsSidebarOpen()
+	s.session.AssertVisible(q.TestID("canvas-versions-sidebar"))
+	s.session.Sleep(300)
+}
+
+func (s *CanvasSteps) ensureEditMode() {
+	exitEditButton := q.TestID("canvas-exit-edit-button").Run(s.session)
+	if visible, _ := exitEditButton.IsVisible(); visible {
 		return
 	}
 
 	s.EnterEditMode()
+}
+
+func (s *CanvasSteps) ensureVersionsSidebarOpen() {
+	toggle := q.TestID("canvas-versions-sidebar-toggle").Run(s.session)
+	require.NoError(s.t, toggle.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(15000),
+	}))
+
+	pressed, err := toggle.GetAttribute("aria-pressed", pw.LocatorGetAttributeOptions{Timeout: pw.Float(15000)})
+	require.NoError(s.t, err)
+	if pressed == "true" {
+		return
+	}
+
 	s.session.Click(q.TestID("canvas-versions-sidebar-toggle"))
-	s.session.AssertVisible(q.TestID("canvas-versions-sidebar"))
-	s.session.Sleep(300)
 }
 
 // SelectRunInSidebar opens run inspection by selecting a run from the runs sidebar.
@@ -139,8 +162,10 @@ func (s *CanvasSteps) waitForToolSidebarOpen() {
 
 // OpenDraftBranchInSidebar selects a draft branch from the Versions sidebar by display name.
 func (s *CanvasSteps) OpenDraftBranchInSidebar(displayName string) {
+	s.ensureEditMode()
 	s.OpenVersionsSidebar()
 	selector := q.Locator(fmt.Sprintf(`[data-testid="canvas-draft-branch-row"]:has-text("%s") > button`, displayName))
+	s.waitForVisible(selector, 15*time.Second)
 	s.session.Click(selector)
 
 	chip := q.TestID("active-draft-branch-chip").Run(s.session)
@@ -150,6 +175,14 @@ func (s *CanvasSteps) OpenDraftBranchInSidebar(displayName string) {
 	}, 30*time.Second, 200*time.Millisecond, "editor did not switch to draft %q", displayName)
 
 	s.waitForEnabledExitEditButton()
+}
+
+func (s *CanvasSteps) waitForVisible(query q.Query, timeout time.Duration) {
+	locator := query.Run(s.session)
+	require.Eventually(s.t, func() bool {
+		visible, err := locator.IsVisible()
+		return err == nil && visible
+	}, timeout, 200*time.Millisecond, "%s did not become visible", query.Describe())
 }
 
 // WaitForRunsSidebar waits until the runs sidebar is visible on the canvas tab.
@@ -188,6 +221,7 @@ func (s *CanvasSteps) AssertDraftCount(expected int) {
 
 // AssertDraftBranchesInSidebar verifies draft branch labels appear in the Versions sidebar.
 func (s *CanvasSteps) AssertDraftBranchesInSidebar(displayNames ...string) {
+	s.ensureEditMode()
 	s.OpenVersionsSidebar()
 	s.session.AssertVisible(q.TestID("canvas-drafts-section"))
 	for _, displayName := range displayNames {

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -79,10 +79,9 @@ func (s *CanvasSteps) ExitEditMode() {
 	s.session.Sleep(500)
 }
 
-// OpenVersionsSidebar reveals the versions sidebar, which is shown while an edit
-// session is active (unless the agent panel is the active side panel). If no
-// edit session is active yet, it enters edit mode (selecting the latest draft or
-// creating one) to reveal the sidebar.
+// OpenVersionsSidebar reveals the versions sidebar. If no edit session is active
+// yet, it enters edit mode (selecting the latest draft or creating one) before
+// opening the sidebar from the header toggle.
 func (s *CanvasSteps) OpenVersionsSidebar() {
 	sidebar := q.TestID("canvas-versions-sidebar").Run(s.session)
 	if visible, _ := sidebar.IsVisible(); visible {
@@ -91,6 +90,7 @@ func (s *CanvasSteps) OpenVersionsSidebar() {
 	}
 
 	s.EnterEditMode()
+	s.session.Click(q.TestID("canvas-versions-sidebar-toggle"))
 	s.session.AssertVisible(q.TestID("canvas-versions-sidebar"))
 	s.session.Sleep(300)
 }

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -79,9 +79,11 @@ func (s *CanvasSteps) ExitEditMode() {
 	s.session.Sleep(500)
 }
 
-// OpenVersionsSidebar reveals the versions sidebar, which is permanently shown
-// while an edit session is active. If no edit session is active yet, it enters
-// edit mode (selecting the latest draft or creating one) to reveal the sidebar.
+// OpenVersionsSidebar reveals the versions sidebar. The sidebar no longer
+// auto-opens when an edit session starts (issue #5803): it starts collapsed and
+// is shown via the header toggle. If no edit session is active yet, this enters
+// edit mode (selecting the latest draft or creating one) to make the toggle
+// available, then clicks it to reveal the sidebar.
 func (s *CanvasSteps) OpenVersionsSidebar() {
 	sidebar := q.TestID("canvas-versions-sidebar").Run(s.session)
 	if visible, _ := sidebar.IsVisible(); visible {
@@ -90,6 +92,12 @@ func (s *CanvasSteps) OpenVersionsSidebar() {
 	}
 
 	s.EnterEditMode()
+
+	if visible, _ := sidebar.IsVisible(); !visible {
+		toggle := q.TestID("canvas-versions-sidebar-toggle").Run(s.session)
+		require.NoError(s.t, toggle.Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
+	}
+
 	s.session.AssertVisible(q.TestID("canvas-versions-sidebar"))
 	s.session.Sleep(300)
 }

--- a/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.spec.tsx
@@ -1,14 +1,22 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { useCanvasRunsSidebarState } from "./useCanvasRunsSidebarState";
+import { useCanvasRunsSidebarState, writeCanvasRunsSidebarOpen } from "./useCanvasRunsSidebarState";
 
 describe("useCanvasRunsSidebarState", () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it("keeps the runs sidebar closed by default", () => {
+  it("opens the runs sidebar by default", () => {
     const { result } = renderHook(() => useCanvasRunsSidebarState());
+
+    expect(result.current.isRunsSidebarOpen).toBe(true);
+  });
+
+  it("falls back to the legacy global preference when a canvas does not have one", () => {
+    localStorage.setItem("canvasRunsSidebarOpen", "false");
+
+    const { result } = renderHook(() => useCanvasRunsSidebarState("canvas-a"));
 
     expect(result.current.isRunsSidebarOpen).toBe(false);
   });
@@ -28,8 +36,8 @@ describe("useCanvasRunsSidebarState", () => {
       result.current.handleRunsSidebarToggle();
     });
 
-    expect(result.current.isRunsSidebarOpen).toBe(true);
-    expect(localStorage.getItem("canvasRunsSidebarOpen:canvas-a")).toBe("true");
+    expect(result.current.isRunsSidebarOpen).toBe(false);
+    expect(localStorage.getItem("canvasRunsSidebarOpen:canvas-a")).toBe("false");
     expect(localStorage.getItem("canvasRunsSidebarOpen")).toBeNull();
   });
 
@@ -50,6 +58,15 @@ describe("useCanvasRunsSidebarState", () => {
     expect(result.current.isRunsSidebarOpen).toBe(false);
 
     rerender({ canvasId: "canvas-c" });
+    expect(result.current.isRunsSidebarOpen).toBe(true);
+  });
+
+  it("keeps a new canvas closed when it has an explicit per-canvas preference", () => {
+    localStorage.setItem("canvasRunsSidebarOpen", "true");
+    writeCanvasRunsSidebarOpen("new-canvas", false);
+
+    const { result } = renderHook(() => useCanvasRunsSidebarState("new-canvas"));
+
     expect(result.current.isRunsSidebarOpen).toBe(false);
   });
 });

--- a/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.spec.tsx
@@ -7,28 +7,49 @@ describe("useCanvasRunsSidebarState", () => {
     localStorage.clear();
   });
 
-  it("opens the runs sidebar by default", () => {
-    const { result } = renderHook(() => useCanvasRunsSidebarState());
-
-    expect(result.current.isRunsSidebarOpen).toBe(true);
-  });
-
-  it("restores persisted open state", () => {
-    localStorage.setItem("canvasRunsSidebarOpen", "false");
-
+  it("keeps the runs sidebar closed by default", () => {
     const { result } = renderHook(() => useCanvasRunsSidebarState());
 
     expect(result.current.isRunsSidebarOpen).toBe(false);
   });
 
-  it("persists toggled state", () => {
-    const { result } = renderHook(() => useCanvasRunsSidebarState());
+  it("restores persisted open state for the current canvas", () => {
+    localStorage.setItem("canvasRunsSidebarOpen:canvas-a", "true");
+
+    const { result } = renderHook(() => useCanvasRunsSidebarState("canvas-a"));
+
+    expect(result.current.isRunsSidebarOpen).toBe(true);
+  });
+
+  it("persists toggled state per canvas", () => {
+    const { result } = renderHook(() => useCanvasRunsSidebarState("canvas-a"));
 
     act(() => {
       result.current.handleRunsSidebarToggle();
     });
 
+    expect(result.current.isRunsSidebarOpen).toBe(true);
+    expect(localStorage.getItem("canvasRunsSidebarOpen:canvas-a")).toBe("true");
+    expect(localStorage.getItem("canvasRunsSidebarOpen")).toBeNull();
+  });
+
+  it("does not leak open state across canvases", () => {
+    localStorage.setItem("canvasRunsSidebarOpen:canvas-a", "true");
+    localStorage.setItem("canvasRunsSidebarOpen:canvas-b", "false");
+
+    const { result, rerender } = renderHook(
+      ({ canvasId }: { canvasId: string }) => useCanvasRunsSidebarState(canvasId),
+      {
+        initialProps: { canvasId: "canvas-a" },
+      },
+    );
+
+    expect(result.current.isRunsSidebarOpen).toBe(true);
+
+    rerender({ canvasId: "canvas-b" });
     expect(result.current.isRunsSidebarOpen).toBe(false);
-    expect(localStorage.getItem("canvasRunsSidebarOpen")).toBe("false");
+
+    rerender({ canvasId: "canvas-c" });
+    expect(result.current.isRunsSidebarOpen).toBe(false);
   });
 });

--- a/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.ts
+++ b/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.ts
@@ -1,25 +1,39 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const CANVAS_RUNS_SIDEBAR_OPEN_STORAGE_KEY = "canvasRunsSidebarOpen";
 
-function readInitialRunsSidebarOpen(): boolean {
-  if (typeof window === "undefined") return true;
+function canvasRunsSidebarOpenStorageKey(canvasId?: string): string {
+  return canvasId ? `${CANVAS_RUNS_SIDEBAR_OPEN_STORAGE_KEY}:${canvasId}` : CANVAS_RUNS_SIDEBAR_OPEN_STORAGE_KEY;
+}
+
+function readInitialRunsSidebarOpen(canvasId?: string): boolean {
+  if (typeof window === "undefined") return false;
   try {
-    const saved = window.localStorage.getItem(CANVAS_RUNS_SIDEBAR_OPEN_STORAGE_KEY);
-    if (saved === null) return true;
+    const saved = window.localStorage.getItem(canvasRunsSidebarOpenStorageKey(canvasId));
+    if (saved === null) return false;
     return saved === "true";
   } catch {
-    return true;
+    return false;
   }
 }
 
-export function useCanvasRunsSidebarState() {
-  const [isRunsSidebarOpen, setIsRunsSidebarOpen] = useState(readInitialRunsSidebarOpen);
+export function useCanvasRunsSidebarState(canvasId?: string) {
+  const [isRunsSidebarOpen, setIsRunsSidebarOpen] = useState(() => readInitialRunsSidebarOpen(canvasId));
 
-  const persistOpen = useCallback((open: boolean) => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(CANVAS_RUNS_SIDEBAR_OPEN_STORAGE_KEY, open ? "true" : "false");
-  }, []);
+  const previousCanvasIdRef = useRef(canvasId);
+  useEffect(() => {
+    if (previousCanvasIdRef.current === canvasId) return;
+    previousCanvasIdRef.current = canvasId;
+    setIsRunsSidebarOpen(readInitialRunsSidebarOpen(canvasId));
+  }, [canvasId]);
+
+  const persistOpen = useCallback(
+    (open: boolean) => {
+      if (typeof window === "undefined") return;
+      window.localStorage.setItem(canvasRunsSidebarOpenStorageKey(canvasId), open ? "true" : "false");
+    },
+    [canvasId],
+  );
 
   const handleRunsSidebarToggle = useCallback(() => {
     setIsRunsSidebarOpen((current) => {

--- a/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.ts
+++ b/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.ts
@@ -6,14 +6,29 @@ function canvasRunsSidebarOpenStorageKey(canvasId?: string): string {
   return canvasId ? `${CANVAS_RUNS_SIDEBAR_OPEN_STORAGE_KEY}:${canvasId}` : CANVAS_RUNS_SIDEBAR_OPEN_STORAGE_KEY;
 }
 
+export function writeCanvasRunsSidebarOpen(canvasId: string, open: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(canvasRunsSidebarOpenStorageKey(canvasId), open ? "true" : "false");
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
 function readInitialRunsSidebarOpen(canvasId?: string): boolean {
-  if (typeof window === "undefined") return false;
+  if (typeof window === "undefined") return true;
   try {
     const saved = window.localStorage.getItem(canvasRunsSidebarOpenStorageKey(canvasId));
-    if (saved === null) return false;
+    if (saved === null && canvasId) {
+      const legacySaved = window.localStorage.getItem(CANVAS_RUNS_SIDEBAR_OPEN_STORAGE_KEY);
+      if (legacySaved === null) return true;
+      return legacySaved === "true";
+    }
+
+    if (saved === null) return true;
     return saved === "true";
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -29,8 +44,17 @@ export function useCanvasRunsSidebarState(canvasId?: string) {
 
   const persistOpen = useCallback(
     (open: boolean) => {
+      if (canvasId) {
+        writeCanvasRunsSidebarOpen(canvasId, open);
+        return;
+      }
+
       if (typeof window === "undefined") return;
-      window.localStorage.setItem(canvasRunsSidebarOpenStorageKey(canvasId), open ? "true" : "false");
+      try {
+        window.localStorage.setItem(canvasRunsSidebarOpenStorageKey(canvasId), open ? "true" : "false");
+      } catch {
+        // Preference persistence is best-effort.
+      }
     },
     [canvasId],
   );

--- a/web_src/src/components/CanvasToolSidebar/AgentSetupState.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentSetupState.tsx
@@ -1,0 +1,61 @@
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { AgentSetupState } from "./agentSetupStateModel";
+
+export function AgentSetupNotice({
+  firstName,
+  onRetry,
+  state,
+}: {
+  firstName: string;
+  onRetry: () => void;
+  state: AgentSetupState;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex-1 overflow-y-auto p-3">
+        <div className="flex flex-col items-start">
+          <div className="max-w-[85%] break-words rounded-lg px-3 py-2 text-sm bg-slate-100 text-slate-900">
+            <AgentSetupMessage firstName={firstName} onRetry={onRetry} state={state} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentSetupMessage({
+  firstName,
+  onRetry,
+  state,
+}: {
+  firstName: string;
+  onRetry: () => void;
+  state: AgentSetupState;
+}) {
+  if (state === "unavailable") {
+    return <>The SuperPlane agent isn't available on this instance.</>;
+  }
+
+  if (state === "failed") {
+    return (
+      <>
+        I couldn't set up the SuperPlane agent. Try again in a moment.
+        <div className="mt-3">
+          <Button size="sm" variant="outline" onClick={onRetry}>
+            Try again
+          </Button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      Hi {firstName}! I'm your SuperPlane agent. Give me a moment to set up and I'll help you build.
+      <div className="mt-2 flex items-center gap-2 text-xs text-slate-400">
+        <Loader2 className="size-3 animate-spin" /> Setting up...
+      </div>
+    </>
+  );
+}

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -1,7 +1,5 @@
-import { Loader2 } from "lucide-react";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { AgentMode } from "@/components/AgentSidebar/agentMode";
-import { Button } from "@/components/ui/button";
 import { AccountContext } from "@/contexts/accountContextState";
 import { createSystemMessage } from "@/components/AgentSidebar/systemMessages";
 import { ChatComposer } from "@/components/AgentSidebar/ChatComposer";
@@ -38,10 +36,10 @@ import {
 import type { AgentMessage, AgentOutgoingImage } from "./types";
 import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 import { groupMessages } from "./agentMessageGroups";
+import { AgentSetupNotice } from "./AgentSetupState";
+import { getAgentSetupState } from "./agentSetupStateModel";
 
 const STREAMING_STATUS_RECONCILE_INTERVAL_MS = 15000;
-const AGENTS_DISABLED_CODE = 14;
-const AGENTS_DISABLED_MESSAGE = "agents are not enabled on this installation";
 
 type ChatConversationProps = {
   chatId: string;
@@ -83,68 +81,28 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
     return result.data?.status;
   }, [refetchChat]);
 
-  const chatFailed = chatQuery.isError && !chatQuery.isFetching && !chatId;
-  const agentUnavailable = chatFailed && isAgentsDisabledError(chatQuery.error);
-  const setupFailed = chatFailed && !agentUnavailable;
+  const setupState = getAgentSetupState({
+    chatId,
+    error: chatQuery.error,
+    isError: chatQuery.isError,
+    isFetching: chatQuery.isFetching,
+    isLoading: chatQuery.isLoading,
+  });
+  const agentUnavailable = setupState === "unavailable";
   const { markAgentAvailable, markAgentUnavailable } = toolSidebarState;
   useEffect(() => {
     if (agentUnavailable) markAgentUnavailable();
     if (!agentUnavailable && chatId) markAgentAvailable();
   }, [agentUnavailable, chatId, markAgentAvailable, markAgentUnavailable]);
 
-  if (agentUnavailable) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div className="flex-1 overflow-y-auto p-3">
-          <div className="flex flex-col items-start">
-            <div className="max-w-[85%] break-words rounded-lg px-3 py-2 text-sm bg-slate-100 text-slate-900">
-              The SuperPlane agent isn't available on this instance.
-            </div>
-          </div>
-        </div>
-      </div>
-    );
+  if (setupState) {
+    return <AgentSetupNotice firstName={firstName} onRetry={() => void chatQuery.refetch()} state={setupState} />;
   }
 
-  if (setupFailed) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div className="flex-1 overflow-y-auto p-3">
-          <div className="flex flex-col items-start">
-            <div className="max-w-[85%] break-words rounded-lg px-3 py-2 text-sm bg-slate-100 text-slate-900">
-              I couldn't set up the SuperPlane agent. Try again in a moment.
-              <div className="mt-3">
-                <Button size="sm" variant="outline" onClick={() => void chatQuery.refetch()}>
-                  Try again
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (chatQuery.isLoading || !chatId) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div className="flex-1 overflow-y-auto p-3">
-          <div className="flex flex-col items-start">
-            <div className="max-w-[85%] break-words rounded-lg px-3 py-2 text-sm bg-slate-100 text-slate-900">
-              Hi {firstName}! I'm your SuperPlane agent. Give me a moment to set up and I'll help you build.
-              <div className="mt-2 flex items-center gap-2 text-xs text-slate-400">
-                <Loader2 className="size-3 animate-spin" /> Setting up...
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
+  const readyChatId = chatId as string;
   return (
     <ChatConversation
-      chatId={chatId}
+      chatId={readyChatId}
       canvasId={canvasId}
       organizationId={organizationId}
       initialStatus={chatQuery.data?.status ?? "idle"}
@@ -154,34 +112,6 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
       isEditing={toolSidebarState.isEditing}
     />
   );
-}
-
-function isAgentsDisabledError(error: unknown): boolean {
-  return getErrorStatusCandidates(error).some((status) => {
-    if (!status || typeof status !== "object") return false;
-
-    const maybeStatus = status as { code?: unknown; message?: unknown };
-    return maybeStatus.code === AGENTS_DISABLED_CODE && maybeStatus.message === AGENTS_DISABLED_MESSAGE;
-  });
-}
-
-function getErrorStatusCandidates(error: unknown, seen = new Set<object>()): unknown[] {
-  if (!error || typeof error !== "object" || seen.has(error)) return [];
-  seen.add(error);
-
-  const record = error as Record<string, unknown>;
-  return [
-    error,
-    ...getNestedErrorStatusCandidates(record.response, seen),
-    ...getNestedErrorStatusCandidates(record.error, seen),
-  ];
-}
-
-function getNestedErrorStatusCandidates(error: unknown, seen: Set<object>): unknown[] {
-  if (!error || typeof error !== "object") return [];
-
-  const record = error as Record<string, unknown>;
-  return [error, ...getErrorStatusCandidates(record.data, seen), ...getErrorStatusCandidates(record.error, seen)];
 }
 
 function ChatConversation({

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -85,10 +85,11 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
   // the agent as unavailable so the sidebar hides the panel and its toggle
   // instead of spinning on "Setting up..." forever (issue #5803).
   const chatFailed = chatQuery.isError;
-  const { markAgentUnavailable } = toolSidebarState;
+  const { markAgentAvailable, markAgentUnavailable } = toolSidebarState;
   useEffect(() => {
     if (chatFailed) markAgentUnavailable();
-  }, [chatFailed, markAgentUnavailable]);
+    if (!chatFailed && chatId) markAgentAvailable();
+  }, [chatFailed, chatId, markAgentAvailable, markAgentUnavailable]);
 
   if (chatFailed) {
     return (

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -157,10 +157,31 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
 }
 
 function isAgentsDisabledError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
+  return getErrorStatusCandidates(error).some((status) => {
+    if (!status || typeof status !== "object") return false;
 
-  const status = error as { code?: unknown; message?: unknown };
-  return status.code === AGENTS_DISABLED_CODE && status.message === AGENTS_DISABLED_MESSAGE;
+    const maybeStatus = status as { code?: unknown; message?: unknown };
+    return maybeStatus.code === AGENTS_DISABLED_CODE && maybeStatus.message === AGENTS_DISABLED_MESSAGE;
+  });
+}
+
+function getErrorStatusCandidates(error: unknown, seen = new Set<object>()): unknown[] {
+  if (!error || typeof error !== "object" || seen.has(error)) return [];
+  seen.add(error);
+
+  const record = error as Record<string, unknown>;
+  return [
+    error,
+    ...getNestedErrorStatusCandidates(record.response, seen),
+    ...getNestedErrorStatusCandidates(record.error, seen),
+  ];
+}
+
+function getNestedErrorStatusCandidates(error: unknown, seen: Set<object>): unknown[] {
+  if (!error || typeof error !== "object") return [];
+
+  const record = error as Record<string, unknown>;
+  return [error, ...getErrorStatusCandidates(record.data, seen), ...getErrorStatusCandidates(record.error, seen)];
 }
 
 function ChatConversation({

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -1,6 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { AgentMode } from "@/components/AgentSidebar/agentMode";
+import { Button } from "@/components/ui/button";
 import { AccountContext } from "@/contexts/accountContextState";
 import { createSystemMessage } from "@/components/AgentSidebar/systemMessages";
 import { ChatComposer } from "@/components/AgentSidebar/ChatComposer";
@@ -39,6 +40,8 @@ import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 import { groupMessages } from "./agentMessageGroups";
 
 const STREAMING_STATUS_RECONCILE_INTERVAL_MS = 15000;
+const AGENTS_DISABLED_CODE = 14;
+const AGENTS_DISABLED_MESSAGE = "agents are not enabled on this installation";
 
 type ChatConversationProps = {
   chatId: string;
@@ -80,24 +83,41 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
     return result.data?.status;
   }, [refetchChat]);
 
-  // The chat can only be provisioned when the managed-agent provider is
-  // configured on this instance. When it isn't, GetCanvasAgentChat fails; treat
-  // the agent as unavailable and show a stable explanation instead of spinning
-  // on "Setting up..." forever (issue #5803).
   const chatFailed = chatQuery.isError && !chatQuery.isFetching && !chatId;
+  const agentUnavailable = chatFailed && isAgentsDisabledError(chatQuery.error);
+  const setupFailed = chatFailed && !agentUnavailable;
   const { markAgentAvailable, markAgentUnavailable } = toolSidebarState;
   useEffect(() => {
-    if (chatFailed) markAgentUnavailable();
-    if (!chatFailed && chatId) markAgentAvailable();
-  }, [chatFailed, chatId, markAgentAvailable, markAgentUnavailable]);
+    if (agentUnavailable) markAgentUnavailable();
+    if (!agentUnavailable && chatId) markAgentAvailable();
+  }, [agentUnavailable, chatId, markAgentAvailable, markAgentUnavailable]);
 
-  if (chatFailed) {
+  if (agentUnavailable) {
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="flex-1 overflow-y-auto p-3">
           <div className="flex flex-col items-start">
             <div className="max-w-[85%] break-words rounded-lg px-3 py-2 text-sm bg-slate-100 text-slate-900">
               The SuperPlane agent isn't available on this instance.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (setupFailed) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex-1 overflow-y-auto p-3">
+          <div className="flex flex-col items-start">
+            <div className="max-w-[85%] break-words rounded-lg px-3 py-2 text-sm bg-slate-100 text-slate-900">
+              I couldn't set up the SuperPlane agent. Try again in a moment.
+              <div className="mt-3">
+                <Button size="sm" variant="outline" onClick={() => void chatQuery.refetch()}>
+                  Try again
+                </Button>
+              </div>
             </div>
           </div>
         </div>
@@ -134,6 +154,13 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
       isEditing={toolSidebarState.isEditing}
     />
   );
+}
+
+function isAgentsDisabledError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const status = error as { code?: unknown; message?: unknown };
+  return status.code === AGENTS_DISABLED_CODE && status.message === AGENTS_DISABLED_MESSAGE;
 }
 
 function ChatConversation({

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -80,6 +80,30 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
     return result.data?.status;
   }, [refetchChat]);
 
+  // The chat can only be provisioned when the managed-agent provider is
+  // configured on this instance. When it isn't, GetCanvasAgentChat fails; treat
+  // the agent as unavailable so the sidebar hides the panel and its toggle
+  // instead of spinning on "Setting up..." forever (issue #5803).
+  const chatFailed = chatQuery.isError;
+  const { markAgentUnavailable } = toolSidebarState;
+  useEffect(() => {
+    if (chatFailed) markAgentUnavailable();
+  }, [chatFailed, markAgentUnavailable]);
+
+  if (chatFailed) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex-1 overflow-y-auto p-3">
+          <div className="flex flex-col items-start">
+            <div className="max-w-[85%] break-words rounded-lg px-3 py-2 text-sm bg-slate-100 text-slate-900">
+              The SuperPlane agent isn't available on this instance.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (chatQuery.isLoading || !chatId) {
     return (
       <div className="flex min-h-0 flex-1 flex-col">

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -84,7 +84,7 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
   // configured on this instance. When it isn't, GetCanvasAgentChat fails; treat
   // the agent as unavailable so the sidebar hides the panel and its toggle
   // instead of spinning on "Setting up..." forever (issue #5803).
-  const chatFailed = chatQuery.isError;
+  const chatFailed = chatQuery.isError && !chatQuery.isFetching && !chatId;
   const { markAgentAvailable, markAgentUnavailable } = toolSidebarState;
   useEffect(() => {
     if (chatFailed) markAgentUnavailable();

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -82,8 +82,8 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
 
   // The chat can only be provisioned when the managed-agent provider is
   // configured on this instance. When it isn't, GetCanvasAgentChat fails; treat
-  // the agent as unavailable so the sidebar hides the panel and its toggle
-  // instead of spinning on "Setting up..." forever (issue #5803).
+  // the agent as unavailable and show a stable explanation instead of spinning
+  // on "Setting up..." forever (issue #5803).
   const chatFailed = chatQuery.isError && !chatQuery.isFetching && !chatId;
   const { markAgentAvailable, markAgentUnavailable } = toolSidebarState;
   useEffect(() => {

--- a/web_src/src/components/CanvasToolSidebar/agentSetupStateModel.ts
+++ b/web_src/src/components/CanvasToolSidebar/agentSetupStateModel.ts
@@ -1,0 +1,54 @@
+const AGENTS_DISABLED_CODE = 14;
+const AGENTS_DISABLED_MESSAGE = "agents are not enabled on this installation";
+
+export type AgentSetupState = "failed" | "loading" | "unavailable";
+
+export function getAgentSetupState({
+  chatId,
+  error,
+  isError,
+  isFetching,
+  isLoading,
+}: {
+  chatId: string | null;
+  error: unknown;
+  isError: boolean;
+  isFetching: boolean;
+  isLoading: boolean;
+}): AgentSetupState | null {
+  const chatFailed = isError && !isFetching && !chatId;
+  if (chatFailed && isAgentsDisabledError(error)) return "unavailable";
+  if (chatFailed) return "failed";
+  if (isLoading || !chatId) return "loading";
+  return null;
+}
+
+function isAgentsDisabledError(error: unknown): boolean {
+  return getErrorStatusCandidates(error).some(isAgentsDisabledStatus);
+}
+
+function isAgentsDisabledStatus(status: unknown): boolean {
+  if (!status || typeof status !== "object") return false;
+
+  const maybeStatus = status as { code?: unknown; message?: unknown };
+  return maybeStatus.code === AGENTS_DISABLED_CODE && maybeStatus.message === AGENTS_DISABLED_MESSAGE;
+}
+
+function getErrorStatusCandidates(error: unknown, seen = new Set<object>()): unknown[] {
+  if (!error || typeof error !== "object" || seen.has(error)) return [];
+  seen.add(error);
+
+  const record = error as Record<string, unknown>;
+  return [
+    error,
+    ...getNestedErrorStatusCandidates(record.response, seen),
+    ...getNestedErrorStatusCandidates(record.error, seen),
+  ];
+}
+
+function getNestedErrorStatusCandidates(error: unknown, seen: Set<object>): unknown[] {
+  if (!error || typeof error !== "object") return [];
+
+  const record = error as Record<string, unknown>;
+  return [error, ...getErrorStatusCandidates(record.data, seen), ...getErrorStatusCandidates(record.error, seen)];
+}

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -9,6 +9,10 @@ const richMessageRenderSpy = vi.fn();
 
 const { sendMutation, chatState, chatRefetch } = vi.hoisted(() => {
   const state = {
+    hasChat: true,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
     status: "idle",
     refetchStatus: "idle",
   };
@@ -32,8 +36,10 @@ vi.mock("@/hooks/useCanvasData", () => ({
 
 vi.mock("@/hooks/useAgentChats", () => ({
   useCanvasAgentChat: () => ({
-    data: { id: "chat-1", status: chatState.status },
-    isLoading: false,
+    data: chatState.hasChat ? { id: "chat-1", status: chatState.status } : undefined,
+    isError: chatState.isError,
+    isFetching: chatState.isFetching,
+    isLoading: chatState.isLoading,
     refetch: chatRefetch,
   }),
   useAgentChatMessages: () => ({
@@ -101,6 +107,10 @@ function makeToolSidebarState(overrides: Partial<CanvasToolSidebarState> = {}) {
 describe("CanvasToolSidebar", () => {
   beforeEach(() => {
     richMessageRenderSpy.mockClear();
+    chatState.hasChat = true;
+    chatState.isError = false;
+    chatState.isFetching = false;
+    chatState.isLoading = false;
     chatState.status = "idle";
     chatState.refetchStatus = "idle";
     chatRefetch.mockClear();
@@ -121,6 +131,30 @@ describe("CanvasToolSidebar", () => {
 
     expect(await screen.findByPlaceholderText("Ask the agent…")).toBeInTheDocument();
     await waitFor(() => expect(markAgentAvailable).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the agent visible while a cached chat error is refetching", async () => {
+    const markAgentUnavailable = vi.fn();
+    chatState.hasChat = false;
+    chatState.isError = true;
+    chatState.isFetching = true;
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ markAgentUnavailable })} />);
+
+    expect(await screen.findByText(/Setting up/)).toBeInTheDocument();
+    expect(markAgentUnavailable).not.toHaveBeenCalled();
+  });
+
+  it("marks the agent unavailable after a settled chat setup failure", async () => {
+    const markAgentUnavailable = vi.fn();
+    chatState.hasChat = false;
+    chatState.isError = true;
+    chatState.isFetching = false;
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ markAgentUnavailable })} />);
+
+    expect(await screen.findByText("The SuperPlane agent isn't available on this instance.")).toBeInTheDocument();
+    await waitFor(() => expect(markAgentUnavailable).toHaveBeenCalledTimes(1));
   });
 
   it("allows retrying a failed session", async () => {

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CanvasToolSidebar } from ".";
@@ -88,6 +88,7 @@ function makeToolSidebarState(overrides: Partial<CanvasToolSidebarState> = {}) {
     isAgentEnabled: true,
     agentUnavailable: false,
     markAgentUnavailable: vi.fn(),
+    markAgentAvailable: vi.fn(),
     handleToolSidebarToggle: vi.fn(),
     openToolSidebar: vi.fn(),
     closeToolSidebar: vi.fn(),
@@ -114,9 +115,12 @@ describe("CanvasToolSidebar", () => {
   });
 
   it("renders the agent panel when the sidebar is open", async () => {
-    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
+    const markAgentAvailable = vi.fn();
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ markAgentAvailable })} />);
 
     expect(await screen.findByPlaceholderText("Ask the agent…")).toBeInTheDocument();
+    await waitFor(() => expect(markAgentAvailable).toHaveBeenCalledTimes(1));
   });
 
   it("allows retrying a failed session", async () => {

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -15,6 +15,7 @@ const { sendMutation, chatState, chatRefetch } = vi.hoisted(() => {
     isLoading: false,
     status: "idle",
     refetchStatus: "idle",
+    error: null as unknown,
   };
 
   return {
@@ -37,6 +38,7 @@ vi.mock("@/hooks/useCanvasData", () => ({
 vi.mock("@/hooks/useAgentChats", () => ({
   useCanvasAgentChat: () => ({
     data: chatState.hasChat ? { id: "chat-1", status: chatState.status } : undefined,
+    error: chatState.error,
     isError: chatState.isError,
     isFetching: chatState.isFetching,
     isLoading: chatState.isLoading,
@@ -113,6 +115,7 @@ describe("CanvasToolSidebar", () => {
     chatState.isLoading = false;
     chatState.status = "idle";
     chatState.refetchStatus = "idle";
+    chatState.error = null;
     chatRefetch.mockClear();
     sendMutation.isPending = false;
     sendMutation.mutateAsync.mockReset();
@@ -150,11 +153,31 @@ describe("CanvasToolSidebar", () => {
     chatState.hasChat = false;
     chatState.isError = true;
     chatState.isFetching = false;
+    chatState.error = { code: 14, message: "agents are not enabled on this installation" };
 
     render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ markAgentUnavailable })} />);
 
     expect(await screen.findByText("The SuperPlane agent isn't available on this instance.")).toBeInTheDocument();
     await waitFor(() => expect(markAgentUnavailable).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps non-disabled chat setup failures retryable", async () => {
+    const user = userEvent.setup();
+    const markAgentUnavailable = vi.fn();
+    chatState.hasChat = false;
+    chatState.isError = true;
+    chatState.isFetching = false;
+    chatState.error = { code: 7, message: "agent chat is not allowed" };
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ markAgentUnavailable })} />);
+
+    expect(
+      await screen.findByText("I couldn't set up the SuperPlane agent. Try again in a moment."),
+    ).toBeInTheDocument();
+    expect(markAgentUnavailable).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(chatRefetch).toHaveBeenCalledTimes(1);
   });
 
   it("allows retrying a failed session", async () => {

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -86,6 +86,8 @@ function makeToolSidebarState(overrides: Partial<CanvasToolSidebarState> = {}) {
     isToolSidebarOpen: true,
     showToolSidebarToggle: true,
     isAgentEnabled: true,
+    agentUnavailable: false,
+    markAgentUnavailable: vi.fn(),
     handleToolSidebarToggle: vi.fn(),
     openToolSidebar: vi.fn(),
     closeToolSidebar: vi.fn(),

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -161,6 +161,22 @@ describe("CanvasToolSidebar", () => {
     await waitFor(() => expect(markAgentUnavailable).toHaveBeenCalledTimes(1));
   });
 
+  it.each([
+    [{ response: { data: { code: 14, message: "agents are not enabled on this installation" } } }],
+    [{ error: { code: 14, message: "agents are not enabled on this installation" } }],
+  ])("marks the agent unavailable when the disabled status is nested", async (error) => {
+    const markAgentUnavailable = vi.fn();
+    chatState.hasChat = false;
+    chatState.isError = true;
+    chatState.isFetching = false;
+    chatState.error = error;
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ markAgentUnavailable })} />);
+
+    expect(await screen.findByText("The SuperPlane agent isn't available on this instance.")).toBeInTheDocument();
+    await waitFor(() => expect(markAgentUnavailable).toHaveBeenCalledTimes(1));
+  });
+
   it("keeps non-disabled chat setup failures retryable", async () => {
     const user = userEvent.setup();
     const markAgentUnavailable = vi.fn();

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -98,6 +98,7 @@ describe("useCanvasToolSidebarState", () => {
 
     expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
     expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+    expect(window.localStorage.getItem("canvasAgentSidebarOpen:canvas-x")).toBe("true");
   });
 
   it("shows the toggle again when agent provisioning later succeeds", () => {

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -101,15 +101,18 @@ describe("useCanvasToolSidebarState", () => {
     expect(window.localStorage.getItem("canvasAgentSidebarOpen:canvas-x")).toBe("true");
   });
 
-  it("shows the toggle again when agent provisioning later succeeds", () => {
+  it("shows the toggle again and restores the stored preference when agent provisioning later succeeds", () => {
+    window.localStorage.setItem("canvasAgentSidebarOpen:canvas-x", "true");
     render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-x" />);
 
     fireEvent.click(screen.getByRole("button", { name: "mark-unavailable" }));
     expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
 
     fireEvent.click(screen.getByRole("button", { name: "mark-available" }));
 
     expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
   });
 
   it("rechecks agent availability when navigating back to a canvas", () => {

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -19,6 +19,7 @@ function Harness({ onBeforeClose, canvasId }: { onBeforeClose: () => void; canva
     <div>
       <div data-testid="open-state">{state.isToolSidebarOpen ? "open" : "closed"}</div>
       <div data-testid="agent-state">{state.isAgentEnabled ? "enabled" : "disabled"}</div>
+      <div data-testid="agent-availability">{state.agentUnavailable ? "unavailable" : "available"}</div>
       <div data-testid="toggle-state">{state.showToolSidebarToggle ? "shown" : "hidden"}</div>
       <button type="button" onClick={state.handleToolSidebarToggle}>
         toggle
@@ -86,7 +87,7 @@ describe("useCanvasToolSidebarState", () => {
     expect(window.localStorage.getItem("canvasAgentSidebarOpen:canvas-a")).toBe("true");
   });
 
-  it("hides the toggle and closes the sidebar when the agent is unavailable", () => {
+  it("keeps the sidebar open so the unavailable agent message can stay visible", () => {
     window.localStorage.setItem("canvasAgentSidebarOpen:canvas-x", "true");
 
     render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-x" />);
@@ -96,8 +97,8 @@ describe("useCanvasToolSidebarState", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "mark-unavailable" }));
 
-    expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
-    expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
     expect(window.localStorage.getItem("canvasAgentSidebarOpen:canvas-x")).toBe("true");
   });
 
@@ -106,8 +107,8 @@ describe("useCanvasToolSidebarState", () => {
     render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-x" />);
 
     fireEvent.click(screen.getByRole("button", { name: "mark-unavailable" }));
-    expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
-    expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
 
     fireEvent.click(screen.getByRole("button", { name: "mark-available" }));
 
@@ -119,13 +120,16 @@ describe("useCanvasToolSidebarState", () => {
     const { rerender } = render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-a" />);
 
     fireEvent.click(screen.getByRole("button", { name: "mark-unavailable" }));
-    expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+    expect(screen.getByTestId("agent-availability")).toHaveTextContent("unavailable");
 
     rerender(<Harness onBeforeClose={vi.fn()} canvasId="canvas-b" />);
     expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+    expect(screen.getByTestId("agent-availability")).toHaveTextContent("available");
 
     rerender(<Harness onBeforeClose={vi.fn()} canvasId="canvas-a" />);
     expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+    expect(screen.getByTestId("agent-availability")).toHaveTextContent("available");
   });
 
   it("ignores Cmd/Ctrl+B while typing in an input", () => {

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -6,11 +6,12 @@ vi.mock("@/hooks/useExperimentalFeature", () => ({
   useExperimentalFeature: () => ({ has: () => false, enabledExperimentalFeatures: [] }),
 }));
 
-function Harness({ onBeforeClose }: { onBeforeClose: () => void }) {
+function Harness({ onBeforeClose, canvasId }: { onBeforeClose: () => void; canvasId?: string }) {
   const state = useCanvasToolSidebarState({
     isEditing: false,
     readOnly: false,
     forceEnable: true,
+    canvasId,
     onBeforeClose,
   });
 
@@ -58,6 +59,24 @@ describe("useCanvasToolSidebarState", () => {
 
     expect(onBeforeClose).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+  });
+
+  it("reads and persists the open state per canvas", () => {
+    window.localStorage.setItem("canvasAgentSidebarOpen:canvas-a", "true");
+    window.localStorage.setItem("canvasAgentSidebarOpen:canvas-b", "false");
+
+    const { rerender } = render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-a" />);
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
+
+    rerender(<Harness onBeforeClose={vi.fn()} canvasId="canvas-b" />);
+    expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+
+    fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
+    expect(window.localStorage.getItem("canvasAgentSidebarOpen:canvas-b")).toBe("true");
+    // The other canvas preference is untouched.
+    expect(window.localStorage.getItem("canvasAgentSidebarOpen:canvas-a")).toBe("true");
   });
 
   it("ignores Cmd/Ctrl+B while typing in an input", () => {

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -19,8 +19,12 @@ function Harness({ onBeforeClose, canvasId }: { onBeforeClose: () => void; canva
     <div>
       <div data-testid="open-state">{state.isToolSidebarOpen ? "open" : "closed"}</div>
       <div data-testid="agent-state">{state.isAgentEnabled ? "enabled" : "disabled"}</div>
+      <div data-testid="toggle-state">{state.showToolSidebarToggle ? "shown" : "hidden"}</div>
       <button type="button" onClick={state.handleToolSidebarToggle}>
         toggle
+      </button>
+      <button type="button" onClick={state.markAgentUnavailable}>
+        mark-unavailable
       </button>
     </div>
   );
@@ -77,6 +81,20 @@ describe("useCanvasToolSidebarState", () => {
     expect(window.localStorage.getItem("canvasAgentSidebarOpen:canvas-b")).toBe("true");
     // The other canvas preference is untouched.
     expect(window.localStorage.getItem("canvasAgentSidebarOpen:canvas-a")).toBe("true");
+  });
+
+  it("hides the toggle and closes the sidebar when the agent is unavailable", () => {
+    window.localStorage.setItem("canvasAgentSidebarOpen:canvas-x", "true");
+
+    render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-x" />);
+
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+
+    fireEvent.click(screen.getByRole("button", { name: "mark-unavailable" }));
+
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
   });
 
   it("ignores Cmd/Ctrl+B while typing in an input", () => {

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -26,6 +26,9 @@ function Harness({ onBeforeClose, canvasId }: { onBeforeClose: () => void; canva
       <button type="button" onClick={state.markAgentUnavailable}>
         mark-unavailable
       </button>
+      <button type="button" onClick={state.markAgentAvailable}>
+        mark-available
+      </button>
     </div>
   );
 }
@@ -95,6 +98,30 @@ describe("useCanvasToolSidebarState", () => {
 
     expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
     expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+  });
+
+  it("shows the toggle again when agent provisioning later succeeds", () => {
+    render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-x" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "mark-unavailable" }));
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
+
+    fireEvent.click(screen.getByRole("button", { name: "mark-available" }));
+
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+  });
+
+  it("rechecks agent availability when navigating back to a canvas", () => {
+    const { rerender } = render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-a" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "mark-unavailable" }));
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
+
+    rerender(<Harness onBeforeClose={vi.fn()} canvasId="canvas-b" />);
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
+
+    rerender(<Harness onBeforeClose={vi.fn()} canvasId="canvas-a" />);
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("shown");
   });
 
   it("ignores Cmd/Ctrl+B while typing in an input", () => {

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -122,8 +122,10 @@ export function useCanvasToolSidebarState({
   }, [canvasId]);
 
   useEffect(() => {
-    if ((!featureEnabled && !forceEnable) || hideCanvasToolSidebar || agentUnavailable) closeToolSidebar();
-  }, [featureEnabled, forceEnable, hideCanvasToolSidebar, agentUnavailable, closeToolSidebar]);
+    if ((!featureEnabled && !forceEnable) || hideCanvasToolSidebar || agentUnavailable) {
+      setIsToolSidebarOpen(false);
+    }
+  }, [featureEnabled, forceEnable, hideCanvasToolSidebar, agentUnavailable]);
 
   const showToolSidebarToggle = (featureEnabled || forceEnable) && !hideCanvasToolSidebar && !agentUnavailable;
 

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -76,6 +76,7 @@ export function useCanvasToolSidebarState({
     if (previousCanvasIdRef.current === canvasId) return;
     previousCanvasIdRef.current = canvasId;
     setIsToolSidebarOpen(readInitialToolSidebarOpen(canvasId));
+    setAgentUnavailableCanvasId(undefined);
   }, [canvasId]);
 
   const persistOpen = useCallback(
@@ -114,6 +115,10 @@ export function useCanvasToolSidebarState({
   // the panel avoids advertising a chat that can never work (issue #5803).
   const markAgentUnavailable = useCallback(() => {
     setAgentUnavailableCanvasId(canvasId);
+  }, [canvasId]);
+
+  const markAgentAvailable = useCallback(() => {
+    setAgentUnavailableCanvasId((currentCanvasId) => (currentCanvasId === canvasId ? undefined : currentCanvasId));
   }, [canvasId]);
 
   useEffect(() => {
@@ -160,6 +165,7 @@ export function useCanvasToolSidebarState({
     isAgentEnabled: featureEnabled,
     agentUnavailable,
     markAgentUnavailable,
+    markAgentAvailable,
     handleToolSidebarToggle,
     openToolSidebar,
     closeToolSidebar,

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -63,6 +63,12 @@ export function useCanvasToolSidebarState({
   const [isToolSidebarOpen, setIsToolSidebarOpen] = useState(() => readInitialToolSidebarOpen(canvasId));
   const [agentMode, setAgentMode] = useState<AgentMode>(readInitialAgentMode);
 
+  // Tracks the canvas whose managed-agent provider failed to provision a
+  // session (e.g. the instance has no agent credentials configured). Keyed by
+  // canvas id so navigating to another canvas re-evaluates availability.
+  const [agentUnavailableCanvasId, setAgentUnavailableCanvasId] = useState<string | undefined>(undefined);
+  const agentUnavailable = Boolean(canvasId) && agentUnavailableCanvasId === canvasId;
+
   // Re-read the preference when navigating between canvases (the open/closed
   // state is stored per canvas) so each app keeps its own sidebar state.
   const previousCanvasIdRef = useRef(canvasId);
@@ -103,11 +109,18 @@ export function useCanvasToolSidebarState({
     persistAgentMode(mode);
   }, []);
 
-  useEffect(() => {
-    if ((!featureEnabled && !forceEnable) || hideCanvasToolSidebar) closeToolSidebar();
-  }, [featureEnabled, forceEnable, hideCanvasToolSidebar, closeToolSidebar]);
+  // Called by the agent panel when it cannot set up a chat because the agent
+  // provider isn't configured on this instance. Hiding the toggle and closing
+  // the panel avoids advertising a chat that can never work (issue #5803).
+  const markAgentUnavailable = useCallback(() => {
+    setAgentUnavailableCanvasId(canvasId);
+  }, [canvasId]);
 
-  const showToolSidebarToggle = (featureEnabled || forceEnable) && !hideCanvasToolSidebar;
+  useEffect(() => {
+    if ((!featureEnabled && !forceEnable) || hideCanvasToolSidebar || agentUnavailable) closeToolSidebar();
+  }, [featureEnabled, forceEnable, hideCanvasToolSidebar, agentUnavailable, closeToolSidebar]);
+
+  const showToolSidebarToggle = (featureEnabled || forceEnable) && !hideCanvasToolSidebar && !agentUnavailable;
 
   useEffect(() => {
     if (!showToolSidebarToggle) return;
@@ -145,6 +158,8 @@ export function useCanvasToolSidebarState({
     isToolSidebarOpen,
     showToolSidebarToggle,
     isAgentEnabled: featureEnabled,
+    agentUnavailable,
+    markAgentUnavailable,
     handleToolSidebarToggle,
     openToolSidebar,
     closeToolSidebar,

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -1,16 +1,35 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { persistAgentMode, readInitialAgentMode, type AgentMode } from "@/components/AgentSidebar/agentMode";
 import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
 
 // Keep in sync with pkg/features/features.go.
 export const FEATURE_CLAUDE_MANAGED_AGENTS = "claude_managed_agents";
-/** Key unchanged so existing browser state continues to work. */
+/** Legacy global key kept as a fallback when a canvas id is not available. */
 const CANVAS_TOOL_SIDEBAR_OPEN_STORAGE_KEY = "canvasAgentSidebarOpen";
 
-function readInitialToolSidebarOpen(): boolean {
+/**
+ * localStorage key for the agent sidebar open/closed preference. The preference
+ * is stored per canvas so each app remembers its own state; the legacy global
+ * key is used only when no canvas id is available.
+ */
+export function canvasAgentSidebarOpenStorageKey(canvasId?: string): string {
+  return canvasId ? `${CANVAS_TOOL_SIDEBAR_OPEN_STORAGE_KEY}:${canvasId}` : CANVAS_TOOL_SIDEBAR_OPEN_STORAGE_KEY;
+}
+
+/** Persist the agent sidebar open/closed preference for a specific canvas. */
+export function writeCanvasAgentSidebarOpen(canvasId: string, open: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(canvasAgentSidebarOpenStorageKey(canvasId), open ? "true" : "false");
+  } catch {
+    // Ignore storage failures (e.g. private mode); preference is best-effort.
+  }
+}
+
+function readInitialToolSidebarOpen(canvasId?: string): boolean {
   if (typeof window === "undefined") return false;
   try {
-    return window.localStorage.getItem(CANVAS_TOOL_SIDEBAR_OPEN_STORAGE_KEY) === "true";
+    return window.localStorage.getItem(canvasAgentSidebarOpenStorageKey(canvasId)) === "true";
   } catch {
     return false;
   }
@@ -41,13 +60,25 @@ export function useCanvasToolSidebarState({
   const { has: hasFeature } = useExperimentalFeature(organizationId);
   const featureEnabled = hasFeature(FEATURE_CLAUDE_MANAGED_AGENTS);
 
-  const [isToolSidebarOpen, setIsToolSidebarOpen] = useState(readInitialToolSidebarOpen);
+  const [isToolSidebarOpen, setIsToolSidebarOpen] = useState(() => readInitialToolSidebarOpen(canvasId));
   const [agentMode, setAgentMode] = useState<AgentMode>(readInitialAgentMode);
 
-  const persistOpen = useCallback((open: boolean) => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(CANVAS_TOOL_SIDEBAR_OPEN_STORAGE_KEY, open ? "true" : "false");
-  }, []);
+  // Re-read the preference when navigating between canvases (the open/closed
+  // state is stored per canvas) so each app keeps its own sidebar state.
+  const previousCanvasIdRef = useRef(canvasId);
+  useEffect(() => {
+    if (previousCanvasIdRef.current === canvasId) return;
+    previousCanvasIdRef.current = canvasId;
+    setIsToolSidebarOpen(readInitialToolSidebarOpen(canvasId));
+  }, [canvasId]);
+
+  const persistOpen = useCallback(
+    (open: boolean) => {
+      if (typeof window === "undefined") return;
+      window.localStorage.setItem(canvasAgentSidebarOpenStorageKey(canvasId), open ? "true" : "false");
+    },
+    [canvasId],
+  );
 
   const closeToolSidebar = useCallback(() => {
     setIsToolSidebarOpen(false);

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -125,12 +125,12 @@ export function useCanvasToolSidebarState({
   }, [agentUnavailable, canvasId]);
 
   useEffect(() => {
-    if ((!featureEnabled && !forceEnable) || hideCanvasToolSidebar || agentUnavailable) {
+    if ((!featureEnabled && !forceEnable) || hideCanvasToolSidebar) {
       setIsToolSidebarOpen(false);
     }
-  }, [featureEnabled, forceEnable, hideCanvasToolSidebar, agentUnavailable]);
+  }, [featureEnabled, forceEnable, hideCanvasToolSidebar]);
 
-  const showToolSidebarToggle = (featureEnabled || forceEnable) && !hideCanvasToolSidebar && !agentUnavailable;
+  const showToolSidebarToggle = (featureEnabled || forceEnable) && !hideCanvasToolSidebar;
 
   useEffect(() => {
     if (!showToolSidebarToggle) return;

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -118,8 +118,11 @@ export function useCanvasToolSidebarState({
   }, [canvasId]);
 
   const markAgentAvailable = useCallback(() => {
+    if (agentUnavailable) {
+      setIsToolSidebarOpen(readInitialToolSidebarOpen(canvasId));
+    }
     setAgentUnavailableCanvasId((currentCanvasId) => (currentCanvasId === canvasId ? undefined : currentCanvasId));
-  }, [canvasId]);
+  }, [agentUnavailable, canvasId]);
 
   useEffect(() => {
     if ((!featureEnabled && !forceEnable) || hideCanvasToolSidebar || agentUnavailable) {

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
@@ -1,27 +1,60 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { useCanvasVersionsSidebarState } from "./useCanvasVersionsSidebarState";
 
 describe("useCanvasVersionsSidebarState", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("keeps the versions sidebar closed by default", () => {
     const { result } = renderHook(() => useCanvasVersionsSidebarState());
 
     expect(result.current.isVersionsSidebarOpen).toBe(false);
   });
 
-  it("toggles the open state without persisting it", () => {
-    const { result } = renderHook(() => useCanvasVersionsSidebarState());
+  it("restores persisted open state for the current canvas", () => {
+    localStorage.setItem("canvasVersionsSidebarOpen:canvas-a", "true");
+
+    const { result } = renderHook(() => useCanvasVersionsSidebarState("canvas-a"));
+
+    expect(result.current.isVersionsSidebarOpen).toBe(true);
+  });
+
+  it("persists toggled state per canvas", () => {
+    const { result } = renderHook(() => useCanvasVersionsSidebarState("canvas-a"));
 
     act(() => {
       result.current.handleVersionsSidebarToggle();
     });
     expect(result.current.isVersionsSidebarOpen).toBe(true);
+    expect(localStorage.getItem("canvasVersionsSidebarOpen:canvas-a")).toBe("true");
+    expect(localStorage.getItem("canvasVersionsSidebarOpen")).toBeNull();
 
     act(() => {
       result.current.handleVersionsSidebarToggle();
     });
     expect(result.current.isVersionsSidebarOpen).toBe(false);
+    expect(localStorage.getItem("canvasVersionsSidebarOpen:canvas-a")).toBe("false");
+  });
 
-    expect(localStorage.getItem("canvasVersionsSidebarOpen")).toBeNull();
+  it("does not leak open state across canvases", () => {
+    localStorage.setItem("canvasVersionsSidebarOpen:canvas-a", "true");
+    localStorage.setItem("canvasVersionsSidebarOpen:canvas-b", "false");
+
+    const { result, rerender } = renderHook(
+      ({ canvasId }: { canvasId: string }) => useCanvasVersionsSidebarState(canvasId),
+      {
+        initialProps: { canvasId: "canvas-a" },
+      },
+    );
+
+    expect(result.current.isVersionsSidebarOpen).toBe(true);
+
+    rerender({ canvasId: "canvas-b" });
+    expect(result.current.isVersionsSidebarOpen).toBe(false);
+
+    rerender({ canvasId: "canvas-c" });
+    expect(result.current.isVersionsSidebarOpen).toBe(false);
   });
 });

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 import { useCanvasVersionsSidebarState } from "./useCanvasVersionsSidebarState";
 
 describe("useCanvasVersionsSidebarState", () => {
-  it("opens the versions sidebar by default", () => {
+  it("keeps the versions sidebar collapsed by default", () => {
     const { result } = renderHook(() => useCanvasVersionsSidebarState());
 
-    expect(result.current.isVersionsSidebarOpen).toBe(true);
+    expect(result.current.isVersionsSidebarOpen).toBe(false);
   });
 
   it("toggles the open state without persisting it", () => {
@@ -15,12 +15,12 @@ describe("useCanvasVersionsSidebarState", () => {
     act(() => {
       result.current.handleVersionsSidebarToggle();
     });
-    expect(result.current.isVersionsSidebarOpen).toBe(false);
+    expect(result.current.isVersionsSidebarOpen).toBe(true);
 
     act(() => {
       result.current.handleVersionsSidebarToggle();
     });
-    expect(result.current.isVersionsSidebarOpen).toBe(true);
+    expect(result.current.isVersionsSidebarOpen).toBe(false);
 
     expect(localStorage.getItem("canvasVersionsSidebarOpen")).toBeNull();
   });

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 import { useCanvasVersionsSidebarState } from "./useCanvasVersionsSidebarState";
 
 describe("useCanvasVersionsSidebarState", () => {
-  it("keeps the versions sidebar collapsed by default", () => {
+  it("opens the versions sidebar by default", () => {
     const { result } = renderHook(() => useCanvasVersionsSidebarState());
 
-    expect(result.current.isVersionsSidebarOpen).toBe(false);
+    expect(result.current.isVersionsSidebarOpen).toBe(true);
   });
 
   it("toggles the open state without persisting it", () => {
@@ -15,12 +15,12 @@ describe("useCanvasVersionsSidebarState", () => {
     act(() => {
       result.current.handleVersionsSidebarToggle();
     });
-    expect(result.current.isVersionsSidebarOpen).toBe(true);
+    expect(result.current.isVersionsSidebarOpen).toBe(false);
 
     act(() => {
       result.current.handleVersionsSidebarToggle();
     });
-    expect(result.current.isVersionsSidebarOpen).toBe(false);
+    expect(result.current.isVersionsSidebarOpen).toBe(true);
 
     expect(localStorage.getItem("canvasVersionsSidebarOpen")).toBeNull();
   });

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.spec.tsx
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 import { useCanvasVersionsSidebarState } from "./useCanvasVersionsSidebarState";
 
 describe("useCanvasVersionsSidebarState", () => {
-  it("opens the versions sidebar by default", () => {
+  it("keeps the versions sidebar closed by default", () => {
     const { result } = renderHook(() => useCanvasVersionsSidebarState());
 
-    expect(result.current.isVersionsSidebarOpen).toBe(true);
+    expect(result.current.isVersionsSidebarOpen).toBe(false);
   });
 
   it("toggles the open state without persisting it", () => {
@@ -15,12 +15,12 @@ describe("useCanvasVersionsSidebarState", () => {
     act(() => {
       result.current.handleVersionsSidebarToggle();
     });
-    expect(result.current.isVersionsSidebarOpen).toBe(false);
+    expect(result.current.isVersionsSidebarOpen).toBe(true);
 
     act(() => {
       result.current.handleVersionsSidebarToggle();
     });
-    expect(result.current.isVersionsSidebarOpen).toBe(true);
+    expect(result.current.isVersionsSidebarOpen).toBe(false);
 
     expect(localStorage.getItem("canvasVersionsSidebarOpen")).toBeNull();
   });

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
@@ -1,7 +1,9 @@
 import { useCallback, useState } from "react";
 
 export function useCanvasVersionsSidebarState() {
-  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(true);
+  // The versions/history sidebar starts collapsed; it is never auto-opened as
+  // the initial view (see issue #5803) and is only shown via the header toggle.
+  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(false);
 
   const handleVersionsSidebarToggle = useCallback(() => {
     setIsVersionsSidebarOpen((current) => !current);

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 
 export function useCanvasVersionsSidebarState() {
-  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(true);
+  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(false);
 
   const handleVersionsSidebarToggle = useCallback(() => {
     setIsVersionsSidebarOpen((current) => !current);

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
@@ -1,9 +1,7 @@
 import { useCallback, useState } from "react";
 
 export function useCanvasVersionsSidebarState() {
-  // The versions/history sidebar starts collapsed; it is never auto-opened as
-  // the initial view (see issue #5803) and is only shown via the header toggle.
-  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(false);
+  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(true);
 
   const handleVersionsSidebarToggle = useCallback(() => {
     setIsVersionsSidebarOpen((current) => !current);

--- a/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
+++ b/web_src/src/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState.ts
@@ -1,19 +1,61 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-export function useCanvasVersionsSidebarState() {
-  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(false);
+const CANVAS_VERSIONS_SIDEBAR_OPEN_STORAGE_KEY = "canvasVersionsSidebarOpen";
+
+function canvasVersionsSidebarOpenStorageKey(canvasId?: string): string {
+  return canvasId
+    ? `${CANVAS_VERSIONS_SIDEBAR_OPEN_STORAGE_KEY}:${canvasId}`
+    : CANVAS_VERSIONS_SIDEBAR_OPEN_STORAGE_KEY;
+}
+
+function readInitialVersionsSidebarOpen(canvasId?: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(canvasVersionsSidebarOpenStorageKey(canvasId)) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function useCanvasVersionsSidebarState(canvasId?: string) {
+  const [isVersionsSidebarOpen, setIsVersionsSidebarOpen] = useState(() => readInitialVersionsSidebarOpen(canvasId));
+
+  const previousCanvasIdRef = useRef(canvasId);
+  useEffect(() => {
+    if (previousCanvasIdRef.current === canvasId) return;
+    previousCanvasIdRef.current = canvasId;
+    setIsVersionsSidebarOpen(readInitialVersionsSidebarOpen(canvasId));
+  }, [canvasId]);
+
+  const persistOpen = useCallback(
+    (open: boolean) => {
+      if (typeof window === "undefined") return;
+      try {
+        window.localStorage.setItem(canvasVersionsSidebarOpenStorageKey(canvasId), open ? "true" : "false");
+      } catch {
+        // Preference persistence is best-effort.
+      }
+    },
+    [canvasId],
+  );
 
   const handleVersionsSidebarToggle = useCallback(() => {
-    setIsVersionsSidebarOpen((current) => !current);
-  }, []);
+    setIsVersionsSidebarOpen((current) => {
+      const next = !current;
+      persistOpen(next);
+      return next;
+    });
+  }, [persistOpen]);
 
   const openVersionsSidebar = useCallback(() => {
     setIsVersionsSidebarOpen(true);
-  }, []);
+    persistOpen(true);
+  }, [persistOpen]);
 
   const closeVersionsSidebar = useCallback(() => {
     setIsVersionsSidebarOpen(false);
-  }, []);
+    persistOpen(false);
+  }, [persistOpen]);
 
   return {
     isVersionsSidebarOpen,

--- a/web_src/src/pages/home/useCreateApp.tsx
+++ b/web_src/src/pages/home/useCreateApp.tsx
@@ -6,6 +6,7 @@ import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { showErrorToast } from "@/lib/toast";
 import { PLACEHOLDER_NODE_CONTEXT_KEY, setAgentBootContext } from "@/lib/agentBootContext";
 import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
+import { writeCanvasRunsSidebarOpen } from "@/components/CanvasRunsSidebar/useCanvasRunsSidebarState";
 import { appPath } from "@/lib/appPaths";
 
 interface UseCreateAppOptions {
@@ -37,6 +38,7 @@ export function useCreateApp({ onCreated }: UseCreateAppOptions = {}) {
           onCreated?.();
           // A new app always starts with the agent panel open (stored per canvas).
           writeCanvasAgentSidebarOpen(canvasId, true);
+          writeCanvasRunsSidebarOpen(canvasId, false);
           localStorage.setItem("canvasSidebarOpen", "false");
           setAgentBootContext(canvasId, "blank");
           sessionStorage.setItem(PLACEHOLDER_NODE_CONTEXT_KEY, canvasId);

--- a/web_src/src/pages/home/useCreateApp.tsx
+++ b/web_src/src/pages/home/useCreateApp.tsx
@@ -5,6 +5,7 @@ import { useCreateCanvas } from "@/hooks/useCanvasData";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { showErrorToast } from "@/lib/toast";
 import { PLACEHOLDER_NODE_CONTEXT_KEY, setAgentBootContext } from "@/lib/agentBootContext";
+import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { appPath } from "@/lib/appPaths";
 
 interface UseCreateAppOptions {
@@ -34,7 +35,8 @@ export function useCreateApp({ onCreated }: UseCreateAppOptions = {}) {
         const canvasId = result?.data?.canvas?.metadata?.id;
         if (canvasId) {
           onCreated?.();
-          localStorage.setItem("canvasAgentSidebarOpen", "true");
+          // A new app always starts with the agent panel open (stored per canvas).
+          writeCanvasAgentSidebarOpen(canvasId, true);
           localStorage.setItem("canvasSidebarOpen", "false");
           setAgentBootContext(canvasId, "blank");
           sessionStorage.setItem(PLACEHOLDER_NODE_CONTEXT_KEY, canvasId);

--- a/web_src/src/pages/home/useInstallAction.ts
+++ b/web_src/src/pages/home/useInstallAction.ts
@@ -4,6 +4,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { canvasKeys } from "@/hooks/useCanvasData";
 import { generateCanvasName } from "@/lib/canvasNameGenerator";
 import { setAgentBootContext } from "@/lib/agentBootContext";
+import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { showErrorToast } from "@/lib/toast";
 import { getApiErrorMessage } from "@/lib/errors";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
@@ -43,7 +44,8 @@ function prepareAgentSidebar(app: AppEntry, canvasId: string) {
       initialMessage: app.agentInitialMessage,
     });
   }
-  localStorage.setItem("canvasAgentSidebarOpen", "true");
+  // A newly installed app always starts with the agent panel open (stored per canvas).
+  writeCanvasAgentSidebarOpen(canvasId, true);
   localStorage.setItem("canvasSidebarOpen", "false");
 }
 

--- a/web_src/src/pages/home/useInstallAction.ts
+++ b/web_src/src/pages/home/useInstallAction.ts
@@ -5,6 +5,7 @@ import { canvasKeys } from "@/hooks/useCanvasData";
 import { generateCanvasName } from "@/lib/canvasNameGenerator";
 import { setAgentBootContext } from "@/lib/agentBootContext";
 import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
+import { writeCanvasRunsSidebarOpen } from "@/components/CanvasRunsSidebar/useCanvasRunsSidebarState";
 import { showErrorToast } from "@/lib/toast";
 import { getApiErrorMessage } from "@/lib/errors";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
@@ -46,6 +47,7 @@ function prepareAgentSidebar(app: AppEntry, canvasId: string) {
   }
   // A newly installed app always starts with the agent panel open (stored per canvas).
   writeCanvasAgentSidebarOpen(canvasId, true);
+  writeCanvasRunsSidebarOpen(canvasId, false);
   localStorage.setItem("canvasSidebarOpen", "false");
 }
 

--- a/web_src/src/ui/CanvasPage/Header.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Header.spec.tsx
@@ -36,6 +36,7 @@ const toolSidebarState = {
   isAgentEnabled: false,
   agentUnavailable: false,
   markAgentUnavailable: vi.fn(),
+  markAgentAvailable: vi.fn(),
   handleToolSidebarToggle: vi.fn(),
   openToolSidebar: vi.fn(),
   closeToolSidebar: vi.fn(),

--- a/web_src/src/ui/CanvasPage/Header.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Header.spec.tsx
@@ -34,6 +34,8 @@ const toolSidebarState = {
   isToolSidebarOpen: true,
   showToolSidebarToggle: true,
   isAgentEnabled: false,
+  agentUnavailable: false,
+  markAgentUnavailable: vi.fn(),
   handleToolSidebarToggle: vi.fn(),
   openToolSidebar: vi.fn(),
   closeToolSidebar: vi.fn(),

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -211,6 +211,27 @@ describe("CanvasPage connection drop", () => {
     expect(reactFlowPropsRef.current?.onlyRenderVisibleElements).not.toBe(true);
   });
 
+  it("does not open the versions sidebar as the initial edit-session view", () => {
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={true}
+          isEditSessionActive={true}
+          activeCanvasVersionId="draft-version"
+          toolSidebarVersionsContent={<div>Version history</div>}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("canvas-versions-sidebar")).not.toBeInTheDocument();
+    expect(screen.queryByText("Version history")).not.toBeInTheDocument();
+  });
+
   it("does not close the building blocks sidebar from the pane click that follows a connection drop", () => {
     const onPlaceholderAdd = vi.fn(() => new Promise<string>(() => {}));
 

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -815,9 +815,18 @@ function CanvasPage(props: CanvasPageProps) {
   };
   const isVersionsSidebarOpen = versionsContentAvailable && versionsSidebarBaseState.isVersionsSidebarOpen;
 
-  // The versions/history sidebar is never auto-opened: canvas history is not a
-  // useful starting point (issue #5803), so it stays collapsed until the user
-  // opens it with the header toggle. New apps open with the agent panel instead.
+  // The collapse state is intentionally not persisted: the versions sidebar
+  // expands whenever the user (re)enters an edit session — except when the agent
+  // panel is the active side panel (e.g. a new app), where canvas history is a
+  // noisy starting point and the agent should take precedence (issue #5803).
+  const isEditSessionActive = props.isEditSessionActive;
+  const isToolSidebarOpen = toolSidebarState.isToolSidebarOpen;
+  const { openVersionsSidebar } = versionsSidebarBaseState;
+  useEffect(() => {
+    if (isEditSessionActive && !isToolSidebarOpen) {
+      openVersionsSidebar();
+    }
+  }, [isEditSessionActive, isToolSidebarOpen, openVersionsSidebar]);
 
   const initialCanvasZoom = props.nodes.length === 0 ? DEFAULT_CANVAS_ZOOM : 1;
   const [canvasZoom, setCanvasZoom] = useState(initialCanvasZoom);

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -804,7 +804,7 @@ function CanvasPage(props: CanvasPageProps) {
   };
   const isRunsSidebarOpen = showRunsSidebar && runsSidebarBaseState.isRunsSidebarOpen;
 
-  const versionsSidebarBaseState = useCanvasVersionsSidebarState();
+  const versionsSidebarBaseState = useCanvasVersionsSidebarState(props.canvasId);
   // Versions content is only produced during an edit session; within that session
   // the sidebar can be shown/hidden with the header toggle.
   const versionsContentAvailable = props.toolSidebarVersionsContent != null;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -815,15 +815,9 @@ function CanvasPage(props: CanvasPageProps) {
   };
   const isVersionsSidebarOpen = versionsContentAvailable && versionsSidebarBaseState.isVersionsSidebarOpen;
 
-  // The collapse state is intentionally not persisted: the versions sidebar always
-  // starts expanded whenever the user (re)enters an edit session.
-  const isEditSessionActive = props.isEditSessionActive;
-  const { openVersionsSidebar } = versionsSidebarBaseState;
-  useEffect(() => {
-    if (isEditSessionActive) {
-      openVersionsSidebar();
-    }
-  }, [isEditSessionActive, openVersionsSidebar]);
+  // The versions/history sidebar is never auto-opened: canvas history is not a
+  // useful starting point (issue #5803), so it stays collapsed until the user
+  // opens it with the header toggle. New apps open with the agent panel instead.
 
   const initialCanvasZoom = props.nodes.length === 0 ? DEFAULT_CANVAS_ZOOM : 1;
   const [canvasZoom, setCanvasZoom] = useState(initialCanvasZoom);

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -815,19 +815,6 @@ function CanvasPage(props: CanvasPageProps) {
   };
   const isVersionsSidebarOpen = versionsContentAvailable && versionsSidebarBaseState.isVersionsSidebarOpen;
 
-  // The collapse state is intentionally not persisted: the versions sidebar
-  // expands whenever the user (re)enters an edit session — except when the agent
-  // panel is the active side panel (e.g. a new app), where canvas history is a
-  // noisy starting point and the agent should take precedence (issue #5803).
-  const isEditSessionActive = props.isEditSessionActive;
-  const isToolSidebarOpen = toolSidebarState.isToolSidebarOpen;
-  const { openVersionsSidebar } = versionsSidebarBaseState;
-  useEffect(() => {
-    if (isEditSessionActive && !isToolSidebarOpen) {
-      openVersionsSidebar();
-    }
-  }, [isEditSessionActive, isToolSidebarOpen, openVersionsSidebar]);
-
   const initialCanvasZoom = props.nodes.length === 0 ? DEFAULT_CANVAS_ZOOM : 1;
   const [canvasZoom, setCanvasZoom] = useState(initialCanvasZoom);
   const [canvasModalRequest, setCanvasModalRequest] = useState<CanvasModalRequest | null>(null);

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -796,7 +796,7 @@ function CanvasPage(props: CanvasPageProps) {
     canvasId: props.canvasId,
     organizationId: props.organizationId,
   });
-  const runsSidebarBaseState = useCanvasRunsSidebarState();
+  const runsSidebarBaseState = useCanvasRunsSidebarState(props.canvasId);
   const showRunsSidebar = isCanvasWorkflowTab(props.headerMode) && props.toolSidebarRunsContent != null;
   const runsSidebarState = {
     ...runsSidebarBaseState,


### PR DESCRIPTION
## Summary

Fixes #5803.

Opening a new app defaulted to auto-expanding the canvas **version/history** sidebar — which is useless as a starting point — while the **agent panel** (the primary way to build a canvas) was hidden behind a single **global** open/closed preference shared across every canvas. This made the agent hard to discover and signalled it was a nice-to-have.

### What changed

Implements the three points from the issue's "What we want":

1. **Don't show history as the initial view.** The versions/history sidebar no longer auto-opens on entering an edit session; it starts collapsed and is only shown via the header toggle.
   - `useCanvasVersionsSidebarState`: default open state `true` → `false`.
   - `CanvasPage`: removed the `useEffect` that force-opened the versions sidebar whenever an edit session became active.
2. **Store the agent panel open/closed preference per canvas.** `useCanvasToolSidebarState` now reads/writes `canvasAgentSidebarOpen:<canvasId>` (falling back to the legacy global key only when no canvas id is available) and re-reads the preference when navigating between canvases.
3. **Always start a new app with the agent panel open.** `useCreateApp` and `useInstallAction` write the per-canvas open preference (`true`) for the freshly created/installed canvas.

The blank-canvas agent still only presents its predefined greeting and does not auto-send/analyze (unchanged; see `agentBootContext.ts`), matching the issue's request that the agent "present itself with a pre-defined message, without analyzing or doing anything".

## Test plan

- [x] `useCanvasToolSidebarState.spec.tsx` — added a test asserting the open state is read and persisted **per canvas** (toggling one canvas leaves another's preference untouched).
- [x] `useCanvasVersionsSidebarState.spec.tsx` — updated to assert the sidebar starts collapsed.
- [x] `make check.build.ui` passes; eslint on touched files reports no new errors.
- [ ] Manual (feature `claude_managed_agents` enabled): create a new app → agent panel opens with its greeting, version history is not shown; toggle history open, reload → each canvas remembers its own agent panel state.

Made with [Cursor](https://cursor.com)