### PR TITLE
docs: clarify SSH command file field descriptions

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -1210,7 +1210,7 @@ Choose **SSH key** or **Password**, then select the organization Secret and the 
 - **Host**, **Port** (default 22), **Username**: Connection details.
 - **Command source**: Choose **Inline** to type commands directly, or **From file** to load them from a file in the app's repository (e.g. scripts/deploy.sh).
 - **Commands** (inline mode): One or more commands to run, one per line (supports expressions). Each non-empty line becomes a command joined with &&. The output payload is based on the last command.
-- **Command file** (file mode): Path to a file in the app's repository (e.g. `scripts/deploy.sh`). The file is piped to bash on the remote host (`bash -s`), so the whole script is always interpreted by bash regardless of any `#!` shebang line — write bash, not another language. Multi-line scripts, comments, and bash features (pipefail, declare -A, process substitution) all work. `{{ ... }}` syntax inside the script (Docker inspect, Helm, Go templates) is preserved. Use **Environment variables** below to inject values from upstream nodes.
+- **Command file** (file mode): Path to a file in the app's repository (e.g. `scripts/deploy.sh`).
 - **Working directory**: Optional; Changes to this directory before running the command.
 - **Environment variables**: Optional list of key/value pairs available during command execution.
 - **Timeout (seconds)**: How long the command may run (default 60).

--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -1210,7 +1210,7 @@ Choose **SSH key** or **Password**, then select the organization Secret and the 
 - **Host**, **Port** (default 22), **Username**: Connection details.
 - **Command source**: Choose **Inline** to type commands directly, or **From file** to load them from a file in the app's repository (e.g. scripts/deploy.sh).
 - **Commands** (inline mode): One or more commands to run, one per line (supports expressions). Each non-empty line becomes a command joined with &&. The output payload is based on the last command.
-- **Command file** (file mode): Path to a file in the Files tab.
+- **Command file** (file mode): Path to a file in the app's repository (e.g. `scripts/deploy.sh`). The file is piped to bash on the remote host (`bash -s`), so the whole script is always interpreted by bash regardless of any `#!` shebang line — write bash, not another language. Multi-line scripts, comments, and bash features (pipefail, declare -A, process substitution) all work. `{{ ... }}` syntax inside the script (Docker inspect, Helm, Go templates) is preserved. Use **Environment variables** below to inject values from upstream nodes.
 - **Working directory**: Optional; Changes to this directory before running the command.
 - **Environment variables**: Optional list of key/value pairs available during command execution.
 - **Timeout (seconds)**: How long the command may run (default 60).

--- a/pkg/components/ssh/ssh.go
+++ b/pkg/components/ssh/ssh.go
@@ -138,7 +138,7 @@ Choose **SSH key** or **Password**, then select the organization Secret and the 
 - **Host**, **Port** (default 22), **Username**: Connection details.
 - **Command source**: Choose **Inline** to type commands directly, or **From file** to load them from a file in the app's repository (e.g. scripts/deploy.sh).
 - **Commands** (inline mode): One or more commands to run, one per line (supports expressions). Each non-empty line becomes a command joined with &&. The output payload is based on the last command.
-- **Command file** (file mode): Path to a file in the app's repository (e.g. ` + "`scripts/deploy.sh`" + `). The file is piped to bash on the remote host (` + "`bash -s`" + `), so the whole script is always interpreted by bash regardless of any ` + "`#!`" + ` shebang line — write bash, not another language. Multi-line scripts, comments, and bash features (pipefail, declare -A, process substitution) all work. ` + "`{{ ... }}`" + ` syntax inside the script (Docker inspect, Helm, Go templates) is preserved. Use **Environment variables** below to inject values from upstream nodes.
+- **Command file** (file mode): Path to a file in the app's repository (e.g. ` + "`scripts/deploy.sh`" + `).
 - **Working directory**: Optional; Changes to this directory before running the command.
 - **Environment variables**: Optional list of key/value pairs available during command execution.
 - **Timeout (seconds)**: How long the command may run (default 60).
@@ -287,7 +287,7 @@ func (c *SSHCommand) Configuration() []configuration.Field {
 			Name:                 "commandFile",
 			Label:                "Command file",
 			Type:                 configuration.FieldTypeRepositoryFile,
-			Description:          "Path to a file in the app's repository (e.g. scripts/deploy.sh). Contents are piped to bash on the remote host (bash -s); use Environment variables below to inject values from upstream nodes.",
+			Description:          "Path to a file in the app's repository (e.g. scripts/deploy.sh).",
 			Required:             false,
 			VisibilityConditions: []configuration.VisibilityCondition{{Field: "commandSource", Values: []string{CommandSourceFile}}},
 			RequiredConditions:   []configuration.RequiredCondition{{Field: "commandSource", Values: []string{CommandSourceFile}}},

--- a/pkg/components/ssh/ssh.go
+++ b/pkg/components/ssh/ssh.go
@@ -138,7 +138,7 @@ Choose **SSH key** or **Password**, then select the organization Secret and the 
 - **Host**, **Port** (default 22), **Username**: Connection details.
 - **Command source**: Choose **Inline** to type commands directly, or **From file** to load them from a file in the app's repository (e.g. scripts/deploy.sh).
 - **Commands** (inline mode): One or more commands to run, one per line (supports expressions). Each non-empty line becomes a command joined with &&. The output payload is based on the last command.
-- **Command file** (file mode): Path to a file in the Files tab.
+- **Command file** (file mode): Path to a file in the app's repository (e.g. ` + "`scripts/deploy.sh`" + `). The file is piped to bash on the remote host (` + "`bash -s`" + `), so the whole script is always interpreted by bash regardless of any ` + "`#!`" + ` shebang line — write bash, not another language. Multi-line scripts, comments, and bash features (pipefail, declare -A, process substitution) all work. ` + "`{{ ... }}`" + ` syntax inside the script (Docker inspect, Helm, Go templates) is preserved. Use **Environment variables** below to inject values from upstream nodes.
 - **Working directory**: Optional; Changes to this directory before running the command.
 - **Environment variables**: Optional list of key/value pairs available during command execution.
 - **Timeout (seconds)**: How long the command may run (default 60).
@@ -287,7 +287,7 @@ func (c *SSHCommand) Configuration() []configuration.Field {
 			Name:                 "commandFile",
 			Label:                "Command file",
 			Type:                 configuration.FieldTypeRepositoryFile,
-			Description:          "Path to a file in the app's repository whose contents are run as the SSH command (e.g. scripts/deploy.sh). The file is piped to bash on the remote host (bash -s), so the whole script is always interpreted by bash regardless of any #! shebang line — write bash, not another language. Multi-line scripts, comments, and bash features (pipefail, declare -A, process substitution) all work. {{ ... }} syntax inside the script (Docker inspect, Helm, Go templates) is preserved. Use Environment variables below to inject values from upstream nodes.",
+			Description:          "Path to a file in the app's repository (e.g. scripts/deploy.sh). Contents are piped to bash on the remote host (bash -s); use Environment variables below to inject values from upstream nodes.",
 			Required:             false,
 			VisibilityConditions: []configuration.VisibilityCondition{{Field: "commandSource", Values: []string{CommandSourceFile}}},
 			RequiredConditions:   []configuration.RequiredCondition{{Field: "commandSource", Values: []string{CommandSourceFile}}},


### PR DESCRIPTION
Split out from #5875, where these changes were unrelated to the secrets sorting/creation work.

## Summary
- Expand SSH component documentation for command-file mode (bash -s piping, shebang behavior, template syntax preservation)
- Shorten the configuration field description shown in the component sidebar

Made with [Cursor](https://cursor.com)