### PR TITLE
docs: Link to ngrok install page

### DIFF
--- a/docs/contributing/connecting-to-3rdparty-services-from-development.md
+++ b/docs/contributing/connecting-to-3rdparty-services-from-development.md
@@ -6,15 +6,7 @@ expose it via a tunnel so external services can deliver webhooks.
 
 ### 1. Install and Authenticate ngrok
 
-Install [ngrok](https://ngrok.com/):
-
-```bash
-# Install (macOS)
-brew install ngrok
-
-# Authenticate
-ngrok config add-authtoken YOUR_AUTH_TOKEN
-```
+Install [ngrok](https://ngrok.com/download/mac-os).
 
 ### 2. Start ngrok Tunnel
 


### PR DESCRIPTION
It is better to link to the install page that has links for other platforms like linux/windows/docker.