### PR TITLE
fix: re-encrypt secret data when renaming secrets

### DIFF
--- a/.models-tx-debt-baseline.json
+++ b/.models-tx-debt-baseline.json
@@ -1,6 +1,6 @@
 {
   "maxAllowedInTransactionDefinitions": 183,
-  "maxAllowedDatabaseConnCalls": 206,
+  "maxAllowedDatabaseConnCalls": 205,
   "inTransactionDefinitionKeys": [
     "pkg/models/account.go:MarkPasswordChangedInTransaction",
     "pkg/models/account.go:CreateAccountInTransaction",
@@ -353,7 +353,6 @@
     "pkg/models/role_metadata.go:DeleteGroupMetadata:database.Conn()#1",
     "pkg/models/role_metadata.go:FindRoleMetadataByNames:database.Conn()#1",
     "pkg/models/secret.go:UpdateData:database.Conn()#1",
-    "pkg/models/secret.go:UpdateName:database.Conn()#1",
     "pkg/models/secret.go:Delete:database.Conn()#1",
     "pkg/models/secret.go:FindSecretByName:database.Conn()#1",
     "pkg/models/secret.go:FindSecretByID:database.Conn()#1",
@@ -394,5 +393,5 @@
     "pkg/models/workflow_staging.go:HasWorkflowStaging:database.Conn()#1",
     "pkg/models/workflow_staging.go:FindWorkflowStagingPath:database.Conn()#1"
   ],
-  "updatedAt": "2026-07-04T12:30:25Z"
+  "updatedAt": "2026-07-04T19:40:12Z"
 }

--- a/pkg/grpc/actions/secrets/update_secret_name.go
+++ b/pkg/grpc/actions/secrets/update_secret_name.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	"gorm.io/gorm"
 )
 
 func UpdateSecretName(ctx context.Context, encryptor crypto.Encryptor, domainType, domainID, idOrName, name string) (*pb.UpdateSecretNameResponse, error) {
@@ -37,28 +39,29 @@ func UpdateSecretName(ctx context.Context, encryptor crypto.Encryptor, domainTyp
 	}
 
 	oldName := secret.Name
-	updated, err := secret.UpdateName(name)
-	if err != nil {
-		if errors.Is(err, models.ErrNameAlreadyUsed) {
-			return nil, grpcerrors.InvalidArgument(err, "invalid secret name")
-		}
-		return nil, grpcerrors.Internal(err, "failed to update secret name")
-	}
-
+	var reEncrypted []byte
 	if len(secret.Data) > 0 {
 		plainData, err := decryptSecretData(ctx, encryptor, models.Secret{Name: oldName, Data: secret.Data})
 		if err != nil {
 			return nil, grpcerrors.Internal(err, "failed to decrypt secret data for re-encryption")
 		}
-		reEncrypted, err := encryptSecretData(ctx, encryptor, name, plainData)
+		reEncrypted, err = encryptSecretData(ctx, encryptor, name, plainData)
 		if err != nil {
 			return nil, grpcerrors.Internal(err, "failed to re-encrypt secret data with new name")
 		}
-		updated, err = updated.UpdateData(reEncrypted)
-		if err != nil {
-			return nil, grpcerrors.Internal(err, "failed to persist re-encrypted secret data")
+	}
+
+	var updated *models.Secret
+	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
+		var txErr error
+		updated, txErr = secret.UpdateNameAndData(tx, name, reEncrypted)
+		return txErr
+	})
+	if err != nil {
+		if errors.Is(err, models.ErrNameAlreadyUsed) {
+			return nil, grpcerrors.InvalidArgument(err, "invalid secret name")
 		}
-		updated.Data = reEncrypted
+		return nil, grpcerrors.Internal(err, "failed to update secret name")
 	}
 
 	s, err := serializeSecret(ctx, encryptor, *updated)

--- a/pkg/grpc/actions/secrets/update_secret_name.go
+++ b/pkg/grpc/actions/secrets/update_secret_name.go
@@ -36,12 +36,29 @@ func UpdateSecretName(ctx context.Context, encryptor crypto.Encryptor, domainTyp
 		return &pb.UpdateSecretNameResponse{Secret: s}, nil
 	}
 
+	oldName := secret.Name
 	updated, err := secret.UpdateName(name)
 	if err != nil {
 		if errors.Is(err, models.ErrNameAlreadyUsed) {
 			return nil, grpcerrors.InvalidArgument(err, "invalid secret name")
 		}
 		return nil, grpcerrors.Internal(err, "failed to update secret name")
+	}
+
+	if len(secret.Data) > 0 {
+		plainData, err := decryptSecretData(ctx, encryptor, models.Secret{Name: oldName, Data: secret.Data})
+		if err != nil {
+			return nil, grpcerrors.Internal(err, "failed to decrypt secret data for re-encryption")
+		}
+		reEncrypted, err := encryptSecretData(ctx, encryptor, name, plainData)
+		if err != nil {
+			return nil, grpcerrors.Internal(err, "failed to re-encrypt secret data with new name")
+		}
+		updated, err = updated.UpdateData(reEncrypted)
+		if err != nil {
+			return nil, grpcerrors.Internal(err, "failed to persist re-encrypted secret data")
+		}
+		updated.Data = reEncrypted
 	}
 
 	s, err := serializeSecret(ctx, encryptor, *updated)

--- a/pkg/grpc/actions/secrets/update_secret_name_test.go
+++ b/pkg/grpc/actions/secrets/update_secret_name_test.go
@@ -1,0 +1,98 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/secrets"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+)
+
+func Test__UpdateSecretName(t *testing.T) {
+	r := support.SetupWithOptions(t, support.SetupOptions{})
+	encryptor := crypto.NewAESGCMEncryptor([]byte("1234567890abcdefghijklmnopqrstuv"))
+
+	createEncryptedSecret := func(t *testing.T, name string, data map[string]string) {
+		t.Helper()
+		raw, err := json.Marshal(data)
+		require.NoError(t, err)
+		encrypted, err := encryptor.Encrypt(context.Background(), raw, []byte(name))
+		require.NoError(t, err)
+		_, err = models.CreateSecret(name, secrets.ProviderLocal, r.User.String(), models.DomainTypeOrganization, r.Organization.ID, encrypted)
+		require.NoError(t, err)
+	}
+
+	t.Run("renamed secret data decrypts with new name", func(t *testing.T) {
+		oldName := support.RandomName("secret")
+		newName := support.RandomName("secret-renamed")
+		plainData := map[string]string{"key": "value"}
+		createEncryptedSecret(t, oldName, plainData)
+
+		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), oldName, newName)
+		require.NoError(t, err)
+
+		secret, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, newName)
+		require.NoError(t, err)
+		assert.Equal(t, newName, secret.Name)
+
+		decrypted, err := decryptSecretData(context.Background(), encryptor, *secret)
+		require.NoError(t, err)
+		assert.Equal(t, plainData, decrypted)
+	})
+
+	t.Run("key operations work after rename", func(t *testing.T) {
+		oldName := support.RandomName("secret")
+		newName := support.RandomName("secret-renamed")
+		plainData := map[string]string{"key": "value", "key2": "value2"}
+		createEncryptedSecret(t, oldName, plainData)
+
+		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), oldName, newName)
+		require.NoError(t, err)
+
+		_, err = DeleteSecretKey(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), newName, "key2")
+		require.NoError(t, err)
+
+		secret, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, newName)
+		require.NoError(t, err)
+
+		decrypted, err := decryptSecretData(context.Background(), encryptor, *secret)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": "value"}, decrypted)
+	})
+
+	t.Run("same name is a no-op", func(t *testing.T) {
+		name := support.RandomName("secret")
+		plainData := map[string]string{"key": "value"}
+		createEncryptedSecret(t, name, plainData)
+
+		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), name, name)
+		require.NoError(t, err)
+
+		secret, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, name)
+		require.NoError(t, err)
+
+		decrypted, err := decryptSecretData(context.Background(), encryptor, *secret)
+		require.NoError(t, err)
+		assert.Equal(t, plainData, decrypted)
+	})
+
+	t.Run("name already used", func(t *testing.T) {
+		existingName := support.RandomName("secret")
+		otherName := support.RandomName("secret")
+		createEncryptedSecret(t, existingName, map[string]string{"key": "value"})
+		createEncryptedSecret(t, otherName, map[string]string{"key": "value"})
+
+		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), otherName, existingName)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, code)
+		assert.Equal(t, "invalid secret name", msg)
+	})
+}

--- a/pkg/grpc/actions/secrets/update_secret_name_test.go
+++ b/pkg/grpc/actions/secrets/update_secret_name_test.go
@@ -86,13 +86,27 @@ func Test__UpdateSecretName(t *testing.T) {
 	t.Run("name already used", func(t *testing.T) {
 		existingName := support.RandomName("secret")
 		otherName := support.RandomName("secret")
-		createEncryptedSecret(t, existingName, map[string]string{"key": "value"})
-		createEncryptedSecret(t, otherName, map[string]string{"key": "value"})
+		existingData := map[string]string{"key": "existing"}
+		otherData := map[string]string{"key": "other"}
+		createEncryptedSecret(t, existingName, existingData)
+		createEncryptedSecret(t, otherName, otherData)
 
-		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), otherName, existingName)
+		secretBefore, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, otherName)
+		require.NoError(t, err)
+
+		_, err = UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), otherName, existingName)
 		code, msg, ok := grpcerrors.HandlerStatus(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, code)
 		assert.Equal(t, "invalid secret name", msg)
+
+		secretAfter, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, otherName)
+		require.NoError(t, err)
+		assert.Equal(t, secretBefore.Name, secretAfter.Name)
+		assert.Equal(t, secretBefore.Data, secretAfter.Data)
+
+		decrypted, err := decryptSecretData(context.Background(), encryptor, *secretAfter)
+		require.NoError(t, err)
+		assert.Equal(t, otherData, decrypted)
 	})
 }

--- a/pkg/models/secret.go
+++ b/pkg/models/secret.go
@@ -26,6 +26,38 @@ type SecretData struct {
 	Local map[string]string `json:"local"`
 }
 
+func (s *Secret) UpdateNameAndData(tx *gorm.DB, name string, data []byte) (*Secret, error) {
+	now := time.Now()
+	updates := map[string]any{
+		"name":       name,
+		"updated_at": &now,
+	}
+	if data != nil {
+		updates["data"] = data
+	}
+
+	err := tx.
+		Model(s).
+		Clauses(clause.Returning{}).
+		Where("id = ?", s.ID).
+		Updates(updates).
+		Error
+
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+			return nil, ErrNameAlreadyUsed
+		}
+		return nil, err
+	}
+
+	s.Name = name
+	if data != nil {
+		s.Data = data
+	}
+	s.UpdatedAt = &now
+	return s, nil
+}
+
 func (s *Secret) UpdateData(data []byte) (*Secret, error) {
 	now := time.Now()
 

--- a/pkg/models/secret.go
+++ b/pkg/models/secret.go
@@ -76,29 +76,6 @@ func (s *Secret) UpdateData(data []byte) (*Secret, error) {
 	return s, nil
 }
 
-func (s *Secret) UpdateName(name string) (*Secret, error) {
-	now := time.Now()
-
-	err := database.Conn().
-		Model(s).
-		Clauses(clause.Returning{}).
-		Where("id = ?", s.ID).
-		Update("name", name).
-		Update("updated_at", &now).
-		Error
-
-	if err != nil {
-		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
-			return nil, ErrNameAlreadyUsed
-		}
-		return nil, err
-	}
-
-	s.Name = name
-	s.UpdatedAt = &now
-	return s, nil
-}
-
 func (s *Secret) Delete() error {
 	return database.Conn().Delete(s).Error
 }


### PR DESCRIPTION
## Summary
- Re-encrypt local secret data in `UpdateSecretName` after a rename so AES-GCM associated data matches the stored name
- Add AES-GCM unit tests covering rename and subsequent key operations

Fixes #5877. Follow-up to move AD from name to secret ID: #5884.

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/secrets`
- [ ] Rename a local secret in a production-like env (`NO_ENCRYPTION` off) and delete/edit a key — should succeed instead of HTTP 500


Made with [Cursor](https://cursor.com)