### PR TITLE
fix: guard ssh commands split

### DIFF
--- a/web_src/src/pages/app/mappers/ssh.ts
+++ b/web_src/src/pages/app/mappers/ssh.ts
@@ -255,7 +255,7 @@ function getSSHMetadataList(node: NodeInfo): Array<{ icon: string; label: string
         label: config.commandFile,
       });
     }
-  } else if (config?.commands) {
+  } else if (typeof config?.commands === "string" && config.commands) {
     const oneline = config.commands
       .split("\n")
       .filter((l) => l.trim() !== "")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Prevents canvas render crashes when an SSH node has a persisted non-string `commands` value (e.g. array/object) by only calling `.split("\n")` when `commands` is a string.

## Context

- Sentry issue: `TypeError: t.commands.split is not a function` ([View in Sentry](https://superplane.sentry.io/issues/7473638984/))
- Crash breadcrumb: `[SafeMapper] Component mapper "ssh" threw in props()`

## Changes

- `web_src/src/pages/app/mappers/ssh.ts`: guard `getSSHMetadataList()` inline-commands preview with `typeof config?.commands === "string"`.

## Testing

- Will be validated with `npm run format` and `npm run build` in the dev container (`make check.build.ui`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-623003d8-067d-44da-9f53-10ef2ca879fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-623003d8-067d-44da-9f53-10ef2ca879fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

