### PR TITLE
fix: prevent approval mapper crash on missing records

### DIFF
--- a/web_src/src/pages/app/mappers/approval.spec.ts
+++ b/web_src/src/pages/app/mappers/approval.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { approvalMapper } from "./approval";
+import type { ExecutionInfo, SubtitleContext } from "./types";
+
+const DEFAULT_NODE = { id: "n1", name: "Approval Node", componentName: "approval", isCollapsed: false };
+
+function makeExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "e1",
+    createdAt: undefined,
+    updatedAt: undefined,
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    outputs: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function makeSubtitleContext(execution: ExecutionInfo): SubtitleContext {
+  return { node: DEFAULT_NODE, execution };
+}
+
+describe("approvalMapper.subtitle", () => {
+  it("does not throw when metadata exists but records is missing (STATE_STARTED)", () => {
+    const ctx = makeSubtitleContext(
+      makeExecution({
+        state: "STATE_STARTED",
+        metadata: { result: "approved" },
+      }),
+    );
+
+    expect(() => approvalMapper.subtitle(ctx)).not.toThrow();
+    expect(approvalMapper.subtitle(ctx)).toBe("");
+  });
+
+  it("renders progress string for in-progress approvals (STATE_STARTED)", () => {
+    const ctx = makeSubtitleContext(
+      makeExecution({
+        state: "STATE_STARTED",
+        metadata: {
+          result: "approved",
+          records: [{ index: 0, state: "approved", type: "user" }],
+        },
+      }),
+    );
+
+    expect(approvalMapper.subtitle(ctx)).toBe("1/1 approved");
+  });
+});
+

--- a/web_src/src/pages/app/mappers/approval.spec.ts
+++ b/web_src/src/pages/app/mappers/approval.spec.ts
@@ -52,4 +52,3 @@ describe("approvalMapper.subtitle", () => {
     expect(approvalMapper.subtitle(ctx)).toBe("1/1 approved");
   });
 });
-

--- a/web_src/src/pages/app/mappers/approval.spec.ts
+++ b/web_src/src/pages/app/mappers/approval.spec.ts
@@ -7,8 +7,8 @@ const DEFAULT_NODE = { id: "n1", name: "Approval Node", componentName: "approval
 function makeExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
   return {
     id: "e1",
-    createdAt: undefined,
-    updatedAt: undefined,
+    createdAt: "",
+    updatedAt: "",
     state: "STATE_FINISHED",
     result: "RESULT_PASSED",
     resultReason: "RESULT_REASON_OK",

--- a/web_src/src/pages/app/mappers/approval.ts
+++ b/web_src/src/pages/app/mappers/approval.ts
@@ -398,12 +398,13 @@ function getApprovalEventSections(nodes: NodeInfo[], execution: ExecutionInfo): 
 
 function getComponentSubtitle(execution: ExecutionInfo): string | React.ReactNode {
   const metadata = execution.metadata as ExecutionMetadata | undefined;
-  if (!metadata) return "";
+  if (!metadata || !metadata.records) return "";
+  const records = metadata.records;
 
   // Show progress for in-progress approvals
   if (execution.state === "STATE_STARTED") {
-    const approvalsCount = metadata.records.length || 0;
-    const approvalsApprovedCount = metadata.records.filter((record) => record.state === "approved").length || 0;
+    const approvalsCount = records.length || 0;
+    const approvalsApprovedCount = records.filter((record) => record.state === "approved").length || 0;
     const subtitle = `${approvalsApprovedCount}/${approvalsCount} approved`;
     if (execution.createdAt) {
       return renderWithTimeAgo(subtitle, new Date(execution.createdAt));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prevents `approval` component mapper crash when execution metadata is present but `records` is missing/undefined.
- Adds a defensive guard + uses a local `records` variable in `getComponentSubtitle()`.
- Adds a targeted mapper test to lock in the behavior.

## Context
- Sentry: “TypeError: Cannot read properties of undefined (reading 'length')” (issue `7584884055`).

## Testing
- `make check.build.ui`
- `make check.format.js`
- `npm run test:run -- src/pages/app/mappers/approval.spec.ts` (inside dev container)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b052e83-6a15-4b8e-a1ef-8927ba501aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b052e83-6a15-4b8e-a1ef-8927ba501aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

