### PR TITLE
fix: prevent canvas websocket update loop

### DIFF
--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -22,7 +22,8 @@ vi.mock("react-use-websocket", () => ({
 }));
 
 vi.mock("@/stores/nodeExecutionStore", () => ({
-  useNodeExecutionStore: () => nodeExecutionStoreMock,
+  useNodeExecutionStore: (selector?: (state: typeof nodeExecutionStoreMock) => unknown) =>
+    selector ? selector(nodeExecutionStoreMock) : nodeExecutionStoreMock,
 }));
 
 import { useCanvasWebsocket } from "@/hooks/useCanvasWebsocket";

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -102,7 +102,10 @@ export function useCanvasWebsocket(
   enabled = true,
   onCanvasStagingEvent?: (payload: CanvasWebsocketPayload, eventName: CanvasStagingEventName) => boolean | void,
 ): void {
-  const nodeExecutionStore = useNodeExecutionStore();
+  const updateNodeEvent = useNodeExecutionStore((state) => state.updateNodeEvent);
+  const updateNodeExecution = useNodeExecutionStore((state) => state.updateNodeExecution);
+  const addNodeQueueItem = useNodeExecutionStore((state) => state.addNodeQueueItem);
+  const removeNodeQueueItem = useNodeExecutionStore((state) => state.removeNodeQueueItem);
   const queryClient = useQueryClient();
 
   // Queue for messages per nodeId
@@ -254,7 +257,7 @@ export function useCanvasWebsocket(
         case "workflow_event_created":
           if (payload && "nodeId" in payload && payload.nodeId) {
             const workflowEvent = payload as CanvasesCanvasEvent;
-            nodeExecutionStore.updateNodeEvent(workflowEvent.nodeId!, workflowEvent);
+            updateNodeEvent(workflowEvent.nodeId!, workflowEvent);
             if (workflowEvent.root) {
               invalidateRuns();
             }
@@ -269,7 +272,7 @@ export function useCanvasWebsocket(
           if (payload && "nodeId" in payload && payload.nodeId) {
             const execution = payload as CanvasesCanvasNodeExecution;
             if (execution.nodeId) {
-              nodeExecutionStore.updateNodeExecution(execution.nodeId, execution);
+              updateNodeExecution(execution.nodeId, execution);
 
               if (!patchExecutionInCache(execution)) {
                 invalidateRuns();
@@ -288,7 +291,7 @@ export function useCanvasWebsocket(
         case "queue_item_created":
           if (payload && "nodeId" in payload && payload.nodeId) {
             const queueItem = payload as CanvasesCanvasNodeQueueItem;
-            nodeExecutionStore.addNodeQueueItem(queueItem.nodeId!, queueItem);
+            addNodeQueueItem(queueItem.nodeId!, queueItem);
             invalidateRuns();
 
             onNodeEvent?.(queueItem.nodeId!, data.event);
@@ -297,7 +300,7 @@ export function useCanvasWebsocket(
         case "queue_item_consumed":
           if (payload && "nodeId" in payload && payload.nodeId && "id" in payload && payload.id) {
             const queueItem = payload as CanvasesCanvasNodeQueueItem;
-            nodeExecutionStore.removeNodeQueueItem(queueItem.nodeId!, queueItem.id!);
+            removeNodeQueueItem(queueItem.nodeId!, queueItem.id!);
 
             onNodeEvent?.(queueItem.nodeId!, data.event);
           }
@@ -350,7 +353,10 @@ export function useCanvasWebsocket(
       }
     },
     [
-      nodeExecutionStore,
+      updateNodeEvent,
+      updateNodeExecution,
+      addNodeQueueItem,
+      removeNodeQueueItem,
       queryClient,
       canvasId,
       onNodeEvent,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context
- Fixes Sentry issue [7579726713](https://superplane.sentry.io/issues/7579726713/)

## What changed
- Updated `web_src/src/hooks/useCanvasWebsocket.ts` to **avoid subscribing to the entire** `useNodeExecutionStore()` state.
- Instead, `processMessage` now uses **stable Zustand action selectors** (`updateNodeEvent`, `updateNodeExecution`, `addNodeQueueItem`, `removeNodeQueueItem`), so it no longer gets recreated on every node-execution store update.
- Updated `web_src/src/hooks/useCanvasWebsocket.spec.ts` to mock `useNodeExecutionStore(selector)` correctly (tests were still mocking the old no-selector call pattern).

## Why
Subscribing to the whole store caused `processMessage` to be redefined on every store change; combined with synchronous `useSyncExternalStore` notifications during the websocket queue loop, this could hit React’s nested update limit and throw `Maximum update depth exceeded`.

## Verification
- `make check.test.ui` (was failing before test mock fix)
- `make check.format.js`
- `make check.lint.ui`
- `make check.build.ui`

## Manual smoke test (dev)
[canvas_websocket_stability_smoke_test.mp4](https://cursor.com/agents/bc-e104dd5f-bc95-484c-b22c-799898ff30b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcanvas_websocket_stability_smoke_test.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e104dd5f-bc95-484c-b22c-799898ff30b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e104dd5f-bc95-484c-b22c-799898ff30b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

