### PR TITLE
fix: keep list field accordion controlled

### DIFF
--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -68,7 +68,8 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     itemDefinition.schema.some((schemaField) => schemaField.name === "type") &&
     itemDefinition.schema.some((schemaField) => ["user", "role", "group"].includes(schemaField.name || ""));
 
-  const [openItem, setOpenItem] = React.useState<string | undefined>(undefined);
+  // Keep Accordion controlled for its full lifetime: use "" as the "closed" value.
+  const [openItem, setOpenItem] = React.useState<string>("");
   const rowRefs = React.useRef<Array<HTMLDivElement | null>>([]);
   const {
     dragState,
@@ -85,9 +86,9 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
 
   React.useEffect(() => {
     if (items.length === 0) {
-      setOpenItem(undefined);
-    } else if (openItem !== undefined && Number(openItem) >= items.length) {
-      setOpenItem(undefined);
+      setOpenItem("");
+    } else if (openItem !== "" && Number(openItem) >= items.length) {
+      setOpenItem("");
     }
   }, [items.length, openItem]);
 
@@ -115,9 +116,9 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     if (!useAccordion) return;
 
     setOpenItem((current) => {
-      if (newItems.length === 0 || current === undefined) return undefined;
+      if (newItems.length === 0 || current === "") return "";
       const openIndex = Number(current);
-      if (openIndex === index) return undefined;
+      if (openIndex === index) return "";
       if (openIndex > index) return String(openIndex - 1);
       return current;
     });

--- a/web_src/src/ui/configurationFieldRenderer/useListFieldDragReorder.ts
+++ b/web_src/src/ui/configurationFieldRenderer/useListFieldDragReorder.ts
@@ -20,7 +20,7 @@ export function useListFieldDragReorder({
   allowReorder: boolean;
   useAccordion: boolean;
   onChange: (value: unknown) => void;
-  setOpenItem: React.Dispatch<React.SetStateAction<string | undefined>>;
+  setOpenItem: React.Dispatch<React.SetStateAction<string>>;
   rowRefs: React.MutableRefObject<Array<HTMLDivElement | null>>;
 }) {
   const itemsRef = React.useRef(items);
@@ -84,7 +84,7 @@ export function useListFieldDragReorder({
     };
   }, [isDragging, onChange, setOpenItem, useAccordion, rowRefs]);
 
-  const startDrag = (event: React.MouseEvent, index: number, openItem: string | undefined) => {
+  const startDrag = (event: React.MouseEvent, index: number, openItem: string) => {
     if (!allowReorder || items.length < 2) return;
     if (event.button !== 0) return;
     event.preventDefault();
@@ -92,7 +92,7 @@ export function useListFieldDragReorder({
 
     const wasOpen = openItem === String(index);
     if (wasOpen) {
-      setOpenItem(undefined);
+      setOpenItem("");
     }
 
     setDragState({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes a Radix UI warning where the list-field Accordion switches from uncontrolled to controlled.
- Ensures `Accordion` is controlled for the full component lifetime by using an empty string (`""`) as the closed sentinel value.

## Details
- `ListFieldRenderer` previously initialized `openItem` as `undefined` and later set it to a string index when an item opens, triggering Radix’s controlled/uncontrolled warning.
- Updated list drag-reorder hook typing/logic to match the controlled `openItem` shape.
- Added a Storybook example (`AccordionListField`) that enables `typeOptions.list.accordion = true` so the accordion behavior is easy to verify manually.

## Related
- Sentry issue: [View in Sentry](https://superplane.sentry.io/issues/7516240250/)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b572a4da-9e35-41ca-98ae-a0cac8f4a07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b572a4da-9e35-41ca-98ae-a0cac8f4a07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

