### PR TITLE
chore: remove dead manual save footer from SettingsTab

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -4451,7 +4451,7 @@ export function AppPage() {
           getAutocompleteExampleObj={getAutocompleteExampleObj}
           getCustomField={getCustomField}
           onNodeConfigurationSave={!isReadOnly ? handleNodeConfigurationSave : undefined}
-          configurationSaveMode={isReadOnly ? "manual" : "auto"}
+          configurationSaveMode="auto"
           onAnnotationUpdate={!isReadOnly ? handleAnnotationUpdate : undefined}
           onAnnotationBlur={!isReadOnly ? handleAnnotationBlur : undefined}
           onEdgeCreate={!isReadOnly ? handleEdgeCreate : undefined}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -4451,7 +4451,6 @@ export function AppPage() {
           getAutocompleteExampleObj={getAutocompleteExampleObj}
           getCustomField={getCustomField}
           onNodeConfigurationSave={!isReadOnly ? handleNodeConfigurationSave : undefined}
-          configurationSaveMode="auto"
           onAnnotationUpdate={!isReadOnly ? handleAnnotationUpdate : undefined}
           onAnnotationBlur={!isReadOnly ? handleAnnotationBlur : undefined}
           onEdgeCreate={!isReadOnly ? handleEdgeCreate : undefined}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -204,8 +204,6 @@ export interface CanvasPageProps {
   /** Discards staged edits, reverting to the last committed draft. */
   onResetStaging?: () => void;
   headerMode?: "default" | "version-live" | "console" | "memory" | "files";
-  /** Node settings sidebar: canvas uses debounced autosave without closing the panel after each save. */
-  configurationSaveMode?: "manual" | "auto";
   onEnterEditMode?: () => void;
   enterEditModeDisabled?: boolean;
   enterEditModeDisabledTooltip?: string;
@@ -1115,18 +1113,15 @@ function CanvasPage(props: CanvasPageProps) {
     onOpen: handleBuildingBlocksShortcutOpen,
   });
 
+  const onNodeConfigurationSave = props.onNodeConfigurationSave;
   const handleSaveConfiguration = useCallback(
     (configuration: Record<string, unknown>, nodeName: string, integrationRef?: ComponentsIntegrationRef) => {
-      if (!editingNodeData?.nodeId || !props.onNodeConfigurationSave) {
+      if (!editingNodeData?.nodeId || !onNodeConfigurationSave) {
         return;
       }
-      const result = props.onNodeConfigurationSave(editingNodeData.nodeId, configuration, nodeName, integrationRef);
-      if (props.configurationSaveMode !== "auto") {
-        state.componentSidebar.close();
-      }
-      return result;
+      return onNodeConfigurationSave(editingNodeData.nodeId, configuration, nodeName, integrationRef);
     },
-    [editingNodeData?.nodeId, props, state.componentSidebar],
+    [editingNodeData?.nodeId, onNodeConfigurationSave],
   );
 
   const canvasNodesForToggle = state.nodes;
@@ -1257,7 +1252,6 @@ function CanvasPage(props: CanvasPageProps) {
         onSidebarClose={handleSidebarClose}
         editingNodeData={editingNodeData}
         onSaveConfiguration={handleSaveConfiguration}
-        configurationSaveMode={props.configurationSaveMode}
         currentTab={currentTab}
         onTabChange={setCurrentTab}
         canvasMode={props.isEditing ? "edit" : "live"}
@@ -1283,7 +1277,6 @@ function CanvasPage(props: CanvasPageProps) {
       props.canCreateIntegrations,
       props.canReadIntegrations,
       props.canUpdateIntegrations,
-      props.configurationSaveMode,
       props.fetchRunIdForSidebarEvent,
       props.getAllHistoryEvents,
       props.getAllQueueEvents,
@@ -1585,7 +1578,6 @@ function Sidebar({
   onSidebarClose,
   editingNodeData,
   onSaveConfiguration,
-  configurationSaveMode = "manual",
   currentTab,
   onTabChange,
   canvasMode,
@@ -1633,7 +1625,6 @@ function Sidebar({
     nodeName: string,
     integrationRef?: ComponentsIntegrationRef,
   ) => void | Promise<void>;
-  configurationSaveMode?: "manual" | "auto";
   currentTab?: "latest" | "settings" | "docs";
   onTabChange?: (tab: "latest" | "settings" | "docs") => void;
   canvasMode: "live" | "edit";
@@ -1774,7 +1765,6 @@ function Sidebar({
       nodeConfigurationFields={editingNodeData?.configurationFields ?? []}
       onNodeConfigSave={onSaveConfiguration}
       onNodeConfigCancel={undefined}
-      configurationSaveMode={configurationSaveMode}
       domainId={organizationId}
       domainType="DOMAIN_TYPE_ORGANIZATION"
       customField={

--- a/web_src/src/ui/componentSidebar/SettingsTab.stories.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.stories.tsx
@@ -80,7 +80,6 @@ function SettingsTabPlayground() {
       onOpenConfigureIntegrationDialog={(integrationId) =>
         console.log("Open integration configuration dialog", integrationId)
       }
-      configurationSaveMode="manual"
     />
   );
 }
@@ -117,7 +116,6 @@ function ReadOnlyConfigurationPlayground() {
         icon: "github",
       }}
       autocompleteExampleObj={STORY_AUTOCOMPLETE_CONTEXT}
-      configurationSaveMode="manual"
       readOnly={true}
     />
   );

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -54,8 +54,6 @@ interface SettingsTabProps {
   canReadIntegrations?: boolean;
   canCreateIntegrations?: boolean;
   canUpdateIntegrations?: boolean;
-  /** When `auto`, changes are debounced and persisted without an explicit Save control. */
-  configurationSaveMode?: "manual" | "auto";
 }
 
 function buildAutosaveSnapshot(
@@ -97,7 +95,6 @@ export function SettingsTab({
   canReadIntegrations,
   canCreateIntegrations,
   canUpdateIntegrations,
-  configurationSaveMode = "manual",
 }: SettingsTabProps) {
   const CONNECT_ANOTHER_INSTANCE_VALUE = "__connect_another_instance__";
   const isReadOnly = readOnly ?? false;
@@ -316,20 +313,11 @@ export function SettingsTab({
     pendingAutosaveSnapshotRef.current = null;
   }, []);
 
-  const queuePendingAutosave = useCallback(
-    (snapshot: string) => {
-      if (configurationSaveMode === "auto") {
-        pendingAutosaveSnapshotRef.current = snapshot;
-      }
-    },
-    [configurationSaveMode],
-  );
+  const queuePendingAutosave = useCallback((snapshot: string) => {
+    pendingAutosaveSnapshotRef.current = snapshot;
+  }, []);
 
   const flushPendingAutosave = useCallback(() => {
-    if (configurationSaveMode !== "auto") {
-      return;
-    }
-
     const pendingSnapshot = pendingAutosaveSnapshotRef.current;
     if (!pendingSnapshot || pendingSnapshot === autosaveBaselineSnapshotRef.current) {
       pendingAutosaveSnapshotRef.current = null;
@@ -340,7 +328,7 @@ export function SettingsTab({
     window.setTimeout(() => {
       void handleSaveRef.current();
     }, 0);
-  }, [configurationSaveMode]);
+  }, []);
 
   const handleSave = useCallback(async () => {
     if (isReadOnly) {
@@ -348,14 +336,13 @@ export function SettingsTab({
     }
 
     const snapshot = buildAutosaveSnapshot(nodeConfiguration, currentNodeName, selectedIntegration);
-    if (configurationSaveMode === "auto" && snapshot === autosaveBaselineSnapshotRef.current) {
+    if (snapshot === autosaveBaselineSnapshotRef.current) {
       pendingAutosaveSnapshotRef.current = null;
       return;
     }
 
-    // Always run validation for UI feedback; only gate persistence in manual mode.
-    const isValid = validateNow();
-    if (currentNodeName.trim() === "" || (configurationSaveMode !== "auto" && !isValid)) {
+    validateNow();
+    if (currentNodeName.trim() === "") {
       return;
     }
 
@@ -383,7 +370,6 @@ export function SettingsTab({
     validateNow,
     currentNodeName,
     selectedIntegration,
-    configurationSaveMode,
     nodeConfiguration,
     onSave,
     queuePendingAutosave,
@@ -395,7 +381,7 @@ export function SettingsTab({
   handleSaveRef.current = handleSave;
 
   const requestAutosave = useCallback(() => {
-    if (configurationSaveMode !== "auto" || isReadOnly) {
+    if (isReadOnly) {
       return;
     }
 
@@ -406,21 +392,21 @@ export function SettingsTab({
       autosaveTimerRef.current = null;
       void handleSaveRef.current();
     }, 300);
-  }, [configurationSaveMode, isReadOnly]);
+  }, [isReadOnly]);
 
   // Flush unsaved changes on unmount (e.g. when user switches away from the Settings tab)
   useEffect(() => {
-    if (configurationSaveMode !== "auto") {
-      return;
-    }
     return () => {
+      if (isReadOnly) {
+        return;
+      }
       if (autosaveTimerRef.current !== null) {
         window.clearTimeout(autosaveTimerRef.current);
         autosaveTimerRef.current = null;
       }
       void handleSaveRef.current();
     };
-  }, [configurationSaveMode]);
+  }, [isReadOnly]);
 
   useEffect(() => {
     return () => {
@@ -431,7 +417,7 @@ export function SettingsTab({
   }, []);
 
   useEffect(() => {
-    if (configurationSaveMode !== "auto" || isReadOnly) {
+    if (isReadOnly) {
       return;
     }
     const snapshot = buildAutosaveSnapshot(nodeConfiguration, currentNodeName, selectedIntegration);
@@ -450,7 +436,7 @@ export function SettingsTab({
     return () => {
       window.clearTimeout(fallbackTimer);
     };
-  }, [configurationSaveMode, isReadOnly, nodeConfiguration, currentNodeName, selectedIntegration]);
+  }, [isReadOnly, nodeConfiguration, currentNodeName, selectedIntegration]);
 
   const configurationDisplayModel = useMemo(
     () =>
@@ -491,9 +477,6 @@ export function SettingsTab({
       className="p-4 pb-24 overflow-y-auto overflow-x-hidden"
       style={{ maxHeight: "80vh" }}
       onBlurCapture={(event) => {
-        if (configurationSaveMode !== "auto") {
-          return;
-        }
         const target = event.target as HTMLElement | null;
         if (!target) {
           return;

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -7,7 +7,6 @@ import type {
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { Button } from "@/components/ui/button";
-import { LoadingButton } from "@/components/ui/loading-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
@@ -55,7 +54,7 @@ interface SettingsTabProps {
   canReadIntegrations?: boolean;
   canCreateIntegrations?: boolean;
   canUpdateIntegrations?: boolean;
-  /** Canvas uses debounced autosave without a footer Save; Custom Component Builder keeps explicit Save. */
+  /** When `auto`, changes are debounced and persisted without an explicit Save control. */
   configurationSaveMode?: "manual" | "auto";
 }
 
@@ -102,7 +101,6 @@ export function SettingsTab({
 }: SettingsTabProps) {
   const CONNECT_ANOTHER_INSTANCE_VALUE = "__connect_another_instance__";
   const isReadOnly = readOnly ?? false;
-  const showManualSaveFooter = configurationSaveMode !== "auto" && !isReadOnly;
   const allowIntegrations = canReadIntegrations ?? true;
   const allowCreateIntegrations = canCreateIntegrations ?? true;
   const allowUpdateIntegrations = canUpdateIntegrations ?? true;
@@ -111,7 +109,6 @@ export function SettingsTab({
   const [validationErrors, setValidationErrors] = useState<Set<string>>(new Set());
   const [showValidation, setShowValidation] = useState(false);
   const [selectedIntegration, setSelectedIntegration] = useState<ComponentsIntegrationRef | undefined>(integrationRef);
-  const [isSaving, setIsSaving] = useState(false);
   const savingRef = useRef(false);
   const autosaveTimerRef = useRef<number | null>(null);
   const autosaveBaselineSnapshotRef = useRef(buildAutosaveSnapshot(configuration || {}, nodeName, integrationRef));
@@ -374,13 +371,11 @@ export function SettingsTab({
     }
 
     savingRef.current = true;
-    setIsSaving(true);
     try {
       await result;
       updateAutosaveBaseline(snapshot);
     } finally {
       savingRef.current = false;
-      setIsSaving(false);
       flushPendingAutosave();
     }
   }, [
@@ -493,7 +488,7 @@ export function SettingsTab({
 
   return (
     <div
-      className={`p-4 overflow-y-auto overflow-x-hidden ${showManualSaveFooter ? "pb-20" : "pb-24"}`}
+      className="p-4 pb-24 overflow-y-auto overflow-x-hidden"
       style={{ maxHeight: "80vh" }}
       onBlurCapture={(event) => {
         if (configurationSaveMode !== "auto") {
@@ -799,20 +794,6 @@ export function SettingsTab({
           </div>
         )}
       </div>
-
-      {showManualSaveFooter ? (
-        <div className="flex gap-2 justify-end mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
-          <LoadingButton
-            data-testid="save-node-button"
-            variant="default"
-            onClick={handleSave}
-            loading={isSaving}
-            loadingText="Saving..."
-          >
-            Save
-          </LoadingButton>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -147,7 +147,6 @@ interface ComponentSidebarProps {
   canCreateIntegrations?: boolean;
   canUpdateIntegrations?: boolean;
   autocompleteExampleObj?: Record<string, unknown> | null;
-  configurationSaveMode?: "manual" | "auto";
 
   workflowNodes?: ComponentsNode[];
   readOnly?: boolean;
@@ -209,7 +208,6 @@ export const ComponentSidebar = ({
   canCreateIntegrations,
   canUpdateIntegrations,
   autocompleteExampleObj,
-  configurationSaveMode = "manual",
   componentDescription,
   componentExamplePayload,
   componentPayloadLabel,
@@ -722,7 +720,6 @@ export const ComponentSidebar = ({
                     autocompleteExampleObj={resolvedAutocompleteExampleObj}
                     onOpenCreateIntegrationDialog={handleOpenCreateIntegrationDialog}
                     onOpenConfigureIntegrationDialog={handleOpenConfigureIntegrationDialog}
-                    configurationSaveMode={configurationSaveMode}
                   />
                 </TabsContent>
               )}


### PR DESCRIPTION
## Summary
- Remove the manual Save footer from `SettingsTab` — it never rendered on the canvas because `configurationSaveMode` and `readOnly` were wired in opposite directions
- Always pass `configurationSaveMode="auto"` from the canvas page; read-only gating already lives in autosave logic
- Drop unused `isSaving` / `LoadingButton` state tied to the footer

## Test plan
- [x] `make format.js`
- [ ] Open a node settings sidebar on the canvas and confirm configuration still autosaves on blur
- [ ] Open a read-only canvas/view and confirm no Save footer appears


Made with [Cursor](https://cursor.com)