### PR TITLE
fix: prevent auth middleware panic on gateway authorization failures

### DIFF
--- a/pkg/grpc/gateway_authorization_middleware.go
+++ b/pkg/grpc/gateway_authorization_middleware.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/superplanehq/superplane/pkg/authorization"
-	"google.golang.org/grpc/status"
 )
 
 func GatewayAuthorizationMiddleware(
+	muxPtr **runtime.ServeMux,
 	authorizer *authorization.GatewayAuthorizer,
 ) runtime.Middleware {
 	return func(next runtime.HandlerFunc) runtime.HandlerFunc {
@@ -21,14 +21,14 @@ func GatewayAuthorizationMiddleware(
 
 			ctx, err := authorizer.AuthorizeHTTP(r.Context(), r, route, pathParams)
 			if err != nil {
-				sanitized := SanitizeError(r.Context(), err)
-				st, ok := status.FromError(sanitized)
-				if !ok {
+				mux := *muxPtr
+				if mux == nil {
 					http.Error(w, "internal server error", http.StatusInternalServerError)
 					return
 				}
-				httpCode := runtime.HTTPStatusFromCode(st.Code())
-				http.Error(w, st.Message(), httpCode)
+
+				_, outboundMarshaler := runtime.MarshalerForRequest(mux, r)
+				runtime.HTTPError(r.Context(), mux, outboundMarshaler, w, r, err)
 				return
 			}
 

--- a/pkg/grpc/gateway_authorization_middleware.go
+++ b/pkg/grpc/gateway_authorization_middleware.go
@@ -8,7 +8,6 @@ import (
 )
 
 func GatewayAuthorizationMiddleware(
-	muxPtr **runtime.ServeMux,
 	authorizer *authorization.GatewayAuthorizer,
 ) runtime.Middleware {
 	return func(next runtime.HandlerFunc) runtime.HandlerFunc {
@@ -21,14 +20,7 @@ func GatewayAuthorizationMiddleware(
 
 			ctx, err := authorizer.AuthorizeHTTP(r.Context(), r, route, pathParams)
 			if err != nil {
-				mux := *muxPtr
-				if mux == nil {
-					http.Error(w, "internal server error", http.StatusInternalServerError)
-					return
-				}
-
-				_, outboundMarshaler := runtime.MarshalerForRequest(mux, r)
-				runtime.HTTPError(r.Context(), mux, outboundMarshaler, w, r, err)
+				writeGatewayHTTPError(r.Context(), w, err)
 				return
 			}
 

--- a/pkg/grpc/gateway_authorization_middleware.go
+++ b/pkg/grpc/gateway_authorization_middleware.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"google.golang.org/grpc/status"
 )
 
 func GatewayAuthorizationMiddleware(
-	mux *runtime.ServeMux,
 	authorizer *authorization.GatewayAuthorizer,
 ) runtime.Middleware {
 	return func(next runtime.HandlerFunc) runtime.HandlerFunc {
@@ -21,8 +21,14 @@ func GatewayAuthorizationMiddleware(
 
 			ctx, err := authorizer.AuthorizeHTTP(r.Context(), r, route, pathParams)
 			if err != nil {
-				_, outboundMarshaler := runtime.MarshalerForRequest(mux, r)
-				runtime.HTTPError(r.Context(), mux, outboundMarshaler, w, r, err)
+				sanitized := SanitizeError(r.Context(), err)
+				st, ok := status.FromError(sanitized)
+				if !ok {
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+					return
+				}
+				httpCode := runtime.HTTPStatusFromCode(st.Code())
+				http.Error(w, st.Message(), httpCode)
 				return
 			}
 

--- a/pkg/grpc/gateway_authorization_middleware_test.go
+++ b/pkg/grpc/gateway_authorization_middleware_test.go
@@ -1,0 +1,77 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authorization"
+)
+
+type erringPermissionChecker struct {
+	err error
+}
+
+func (c erringPermissionChecker) CheckOrganizationPermission(_ context.Context, _, _, _, _ string) (bool, error) {
+	return false, c.err
+}
+
+func TestGatewayAuthorizationMiddlewareReturnsHTTPErrorOnAuthorizationFailure(t *testing.T) {
+	t.Parallel()
+
+	authorizer := authorization.NewGatewayAuthorizer(erringPermissionChecker{err: errors.New("db down")})
+	middleware := GatewayAuthorizationMiddleware(authorizer)
+
+	called := false
+	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
+		called = true
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/actions", nil)
+	r.Header.Set("x-user-id", "22222222-2222-4222-8222-222222222222")
+	r.Header.Set("x-organization-id", "11111111-1111-4111-8111-111111111111")
+
+	rec := httptest.NewRecorder()
+	require.NotPanics(t, func() {
+		handler(rec, r, nil)
+	})
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "internal error")
+}
+
+func TestGatewayAuthorizationMiddlewareReturnsNotFoundWhenPermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	authorizer := authorization.NewGatewayAuthorizer(denyingPermissionChecker{})
+	middleware := GatewayAuthorizationMiddleware(authorizer)
+
+	called := false
+	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
+		called = true
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/actions", nil)
+	r.Header.Set("x-user-id", "22222222-2222-4222-8222-222222222222")
+	r.Header.Set("x-organization-id", "11111111-1111-4111-8111-111111111111")
+
+	rec := httptest.NewRecorder()
+	require.NotPanics(t, func() {
+		handler(rec, r, nil)
+	})
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Not found")
+}
+
+type denyingPermissionChecker struct{}
+
+func (denyingPermissionChecker) CheckOrganizationPermission(_ context.Context, _, _, _, _ string) (bool, error) {
+	return false, nil
+}

--- a/pkg/grpc/gateway_authorization_middleware_test.go
+++ b/pkg/grpc/gateway_authorization_middleware_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authorization"
@@ -28,23 +27,11 @@ func (denyingPermissionChecker) CheckOrganizationPermission(_ context.Context, _
 	return false, nil
 }
 
-func newTestGatewayMux(t *testing.T) *runtime.ServeMux {
-	t.Helper()
-
-	return runtime.NewServeMux(
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{}),
-		runtime.WithErrorHandler(SanitizedGatewayErrorHandler),
-	)
-}
-
 func TestGatewayAuthorizationMiddlewareReturnsJSONErrorOnAuthorizationFailure(t *testing.T) {
 	t.Parallel()
 
 	authorizer := authorization.NewGatewayAuthorizer(erringPermissionChecker{err: errors.New("db down")})
-
-	var mux *runtime.ServeMux
-	mux = newTestGatewayMux(t)
-	middleware := GatewayAuthorizationMiddleware(&mux, authorizer)
+	middleware := GatewayAuthorizationMiddleware(authorizer)
 
 	called := false
 	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
@@ -73,10 +60,7 @@ func TestGatewayAuthorizationMiddlewareReturnsNotFoundWhenPermissionDenied(t *te
 	t.Parallel()
 
 	authorizer := authorization.NewGatewayAuthorizer(denyingPermissionChecker{})
-
-	var mux *runtime.ServeMux
-	mux = newTestGatewayMux(t)
-	middleware := GatewayAuthorizationMiddleware(&mux, authorizer)
+	middleware := GatewayAuthorizationMiddleware(authorizer)
 
 	called := false
 	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
@@ -99,30 +83,4 @@ func TestGatewayAuthorizationMiddlewareReturnsNotFoundWhenPermissionDenied(t *te
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Equal(t, "Not found", body["message"])
-}
-
-func TestGatewayAuthorizationMiddlewareResolvesDeferredMuxPointer(t *testing.T) {
-	t.Parallel()
-
-	authorizer := authorization.NewGatewayAuthorizer(denyingPermissionChecker{})
-
-	var mux *runtime.ServeMux
-	middleware := GatewayAuthorizationMiddleware(&mux, authorizer)
-	mux = newTestGatewayMux(t)
-
-	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
-		t.Fatal("next handler should not be called")
-	})
-
-	r := httptest.NewRequest(http.MethodGet, "/api/v1/actions", nil)
-	r.Header.Set("x-user-id", "22222222-2222-4222-8222-222222222222")
-	r.Header.Set("x-organization-id", "11111111-1111-4111-8111-111111111111")
-
-	rec := httptest.NewRecorder()
-	require.NotPanics(t, func() {
-		handler(rec, r, nil)
-	})
-
-	assert.Equal(t, http.StatusNotFound, rec.Code)
-	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
 }

--- a/pkg/grpc/gateway_authorization_middleware_test.go
+++ b/pkg/grpc/gateway_authorization_middleware_test.go
@@ -2,11 +2,13 @@ package grpc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authorization"
@@ -20,11 +22,29 @@ func (c erringPermissionChecker) CheckOrganizationPermission(_ context.Context, 
 	return false, c.err
 }
 
-func TestGatewayAuthorizationMiddlewareReturnsHTTPErrorOnAuthorizationFailure(t *testing.T) {
+type denyingPermissionChecker struct{}
+
+func (denyingPermissionChecker) CheckOrganizationPermission(_ context.Context, _, _, _, _ string) (bool, error) {
+	return false, nil
+}
+
+func newTestGatewayMux(t *testing.T) *runtime.ServeMux {
+	t.Helper()
+
+	return runtime.NewServeMux(
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{}),
+		runtime.WithErrorHandler(SanitizedGatewayErrorHandler),
+	)
+}
+
+func TestGatewayAuthorizationMiddlewareReturnsJSONErrorOnAuthorizationFailure(t *testing.T) {
 	t.Parallel()
 
 	authorizer := authorization.NewGatewayAuthorizer(erringPermissionChecker{err: errors.New("db down")})
-	middleware := GatewayAuthorizationMiddleware(authorizer)
+
+	var mux *runtime.ServeMux
+	mux = newTestGatewayMux(t)
+	middleware := GatewayAuthorizationMiddleware(&mux, authorizer)
 
 	called := false
 	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
@@ -42,14 +62,21 @@ func TestGatewayAuthorizationMiddlewareReturnsHTTPErrorOnAuthorizationFailure(t 
 
 	assert.False(t, called)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
-	assert.Contains(t, rec.Body.String(), "internal error")
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "internal error", body["message"])
 }
 
 func TestGatewayAuthorizationMiddlewareReturnsNotFoundWhenPermissionDenied(t *testing.T) {
 	t.Parallel()
 
 	authorizer := authorization.NewGatewayAuthorizer(denyingPermissionChecker{})
-	middleware := GatewayAuthorizationMiddleware(authorizer)
+
+	var mux *runtime.ServeMux
+	mux = newTestGatewayMux(t)
+	middleware := GatewayAuthorizationMiddleware(&mux, authorizer)
 
 	called := false
 	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
@@ -67,11 +94,35 @@ func TestGatewayAuthorizationMiddlewareReturnsNotFoundWhenPermissionDenied(t *te
 
 	assert.False(t, called)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
-	assert.Contains(t, rec.Body.String(), "Not found")
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "Not found", body["message"])
 }
 
-type denyingPermissionChecker struct{}
+func TestGatewayAuthorizationMiddlewareResolvesDeferredMuxPointer(t *testing.T) {
+	t.Parallel()
 
-func (denyingPermissionChecker) CheckOrganizationPermission(_ context.Context, _, _, _, _ string) (bool, error) {
-	return false, nil
+	authorizer := authorization.NewGatewayAuthorizer(denyingPermissionChecker{})
+
+	var mux *runtime.ServeMux
+	middleware := GatewayAuthorizationMiddleware(&mux, authorizer)
+	mux = newTestGatewayMux(t)
+
+	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
+		t.Fatal("next handler should not be called")
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/actions", nil)
+	r.Header.Set("x-user-id", "22222222-2222-4222-8222-222222222222")
+	r.Header.Set("x-organization-id", "11111111-1111-4111-8111-111111111111")
+
+	rec := httptest.NewRecorder()
+	require.NotPanics(t, func() {
+		handler(rec, r, nil)
+	})
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
 }

--- a/pkg/grpc/gateway_http_error.go
+++ b/pkg/grpc/gateway_http_error.go
@@ -1,0 +1,31 @@
+package grpc
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func writeGatewayHTTPError(ctx context.Context, w http.ResponseWriter, err error) {
+	sanitized := SanitizeError(ctx, err)
+	s := status.Convert(sanitized)
+
+	marshaler := &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			EmitUnpopulated: true,
+		},
+	}
+
+	body, marshalErr := marshaler.Marshal(s.Proto())
+	if marshalErr != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", marshaler.ContentType(s.Proto()))
+	w.WriteHeader(runtime.HTTPStatusFromCode(s.Code()))
+	_, _ = w.Write(body)
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -274,7 +274,7 @@ func (s *Server) RegisterGRPCGateway(services *grpc.Services) error {
 		runtime.WithIncomingHeaderMatcher(headersMatcher),
 		runtime.WithMiddlewares(
 			grpc.GatewayRecoveryMiddleware(),
-			grpc.GatewayAuthorizationMiddleware(&grpcGatewayMux, authorizer),
+			grpc.GatewayAuthorizationMiddleware(authorizer),
 		),
 		runtime.WithErrorHandler(grpc.SanitizedGatewayErrorHandler),
 		runtime.WithMetadata(func(ctx context.Context, _ *http.Request) metadata.MD {

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -274,7 +274,7 @@ func (s *Server) RegisterGRPCGateway(services *grpc.Services) error {
 		runtime.WithIncomingHeaderMatcher(headersMatcher),
 		runtime.WithMiddlewares(
 			grpc.GatewayRecoveryMiddleware(),
-			grpc.GatewayAuthorizationMiddleware(authorizer),
+			grpc.GatewayAuthorizationMiddleware(&grpcGatewayMux, authorizer),
 		),
 		runtime.WithErrorHandler(grpc.SanitizedGatewayErrorHandler),
 		runtime.WithMetadata(func(ctx context.Context, _ *http.Request) metadata.MD {

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -274,7 +274,7 @@ func (s *Server) RegisterGRPCGateway(services *grpc.Services) error {
 		runtime.WithIncomingHeaderMatcher(headersMatcher),
 		runtime.WithMiddlewares(
 			grpc.GatewayRecoveryMiddleware(),
-			grpc.GatewayAuthorizationMiddleware(grpcGatewayMux, authorizer),
+			grpc.GatewayAuthorizationMiddleware(authorizer),
 		),
 		runtime.WithErrorHandler(grpc.SanitizedGatewayErrorHandler),
 		runtime.WithMetadata(func(ctx context.Context, _ *http.Request) metadata.MD {


### PR DESCRIPTION
## Summary

- Fix nil-pointer panic in `GatewayAuthorizationMiddleware` when authorization fails — the middleware captured a nil `*runtime.ServeMux` during mux construction (see #5896)
- Return HTTP error responses directly via gRPC status code mapping instead of calling `runtime.MarshalerForRequest` / `runtime.HTTPError` with a nil mux
- Add unit tests covering authorization failure and permission-denied paths without panics

## Test plan

- [x] `make test PKG_TEST_PACKAGES=./pkg/grpc`
- [x] `make lint`

Fixes #5896


Made with [Cursor](https://cursor.com)