### PR TITLE
fix: sanitize describe organization errors

### DIFF
--- a/pkg/grpc/actions/organizations/describe_organization.go
+++ b/pkg/grpc/actions/organizations/describe_organization.go
@@ -22,7 +22,7 @@ func DescribeOrganization(ctx context.Context, orgID string) (*pb.DescribeOrgani
 		}
 
 		log.Errorf("Error describing organization %s: %v", orgID, err)
-		return nil, err
+		return nil, grpcerrors.Internal(err, "failed to describe organization")
 	}
 
 	response := &pb.DescribeOrganizationResponse{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Wraps the non-NotFound error path in `DescribeOrganization` with `grpcerrors.Internal(...)` so the gateway sanitizer can reliably classify and return client-safe errors (and still preserve the underlying error via `Unwrap()`).

## Why
- Prevents raw DB/infra errors from bubbling up as unsanitized HTTP 500s after the internal gRPC hop removal.
- Keeps the error chain intact for context cancellation classification (HTTP 499) and other gateway mapping.

## Testing
- `make format.go`
- `make lint`
- `make check.build.app`
- `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/organizations`
- `make test PKG_TEST_PACKAGES=./pkg/grpc`

## References
- Sentry issue: `7568909224`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8a30a14-5efb-492a-973d-90ef3b6be5b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8a30a14-5efb-492a-973d-90ef3b6be5b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

