### PR TITLE
fix: preserve context cancellation error chain

### DIFF
--- a/pkg/grpc/actions/canvases/list_node_executions.go
+++ b/pkg/grpc/actions/canvases/list_node_executions.go
@@ -116,13 +116,13 @@ func LoadNodeExecutionResources(db *gorm.DB, executions []models.CanvasNodeExecu
 	wg.Wait()
 
 	if rootEventsErr != nil {
-		return nil, fmt.Errorf("error finding root events: %v", rootEventsErr)
+		return nil, fmt.Errorf("error finding root events: %w", rootEventsErr)
 	}
 	if outputEventsErr != nil {
-		return nil, fmt.Errorf("error finding output events: %v", outputEventsErr)
+		return nil, fmt.Errorf("error finding output events: %w", outputEventsErr)
 	}
 	if cancelledByUsersErr != nil {
-		return nil, fmt.Errorf("error finding cancelled-by users: %v", cancelledByUsersErr)
+		return nil, fmt.Errorf("error finding cancelled-by users: %w", cancelledByUsersErr)
 	}
 
 	cancelledByUsersByID := make(map[uuid.UUID]models.User, len(cancelledByUsers))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes rare HTTP 500s when the client disconnects mid-request by preserving the `context.Canceled` error chain.
- Updates `LoadNodeExecutionResources()` to wrap DB lookup errors with `%w` (instead of `%v`), allowing `errors.Is(err, context.Canceled)` to work through wrapping so the interceptor can return HTTP 499.

## Context

- Sentry: [View in Sentry](https://superplane.sentry.io/issues/7579525919/)
- Affected code path: `pkg/grpc/actions/canvases/list_node_executions.go` → `LoadNodeExecutionResources()`

## Testing

- Pending: run `make dev.up`, then repo checks (`make format.go`, `make lint`, `make check.build.app`, and backend tests) inside the Docker dev environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a89aa43-293f-498e-a84f-de43a8ba09bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a89aa43-293f-498e-a84f-de43a8ba09bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

