### PR TITLE
feat: add Sentry Link GitHub Issue action

### DIFF
--- a/docs/components/Sentry.mdx
+++ b/docs/components/Sentry.mdx
@@ -21,7 +21,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete Alert" href="#delete-alert" description="Delete a Sentry metric alert rule" />
   <LinkCard title="Get Alert" href="#get-alert" description="Retrieve a Sentry metric alert rule with its thresholds, projects, and actions" />
   <LinkCard title="Get Issue" href="#get-issue" description="Retrieve a Sentry issue with tags, frequency, assignee, and recent events" />
-  <LinkCard title="Link GitHub Issue" href="#link-github-issue" description="Link an existing GitHub issue to a Sentry issue through the Sentry GitHub integration" />
+  <LinkCard title="Link GitHub Issue" href="#link-git-hub-issue" description="Link an existing GitHub issue to a Sentry issue through the Sentry GitHub integration" />
   <LinkCard title="List Alerts" href="#list-alerts" description="List Sentry metric alert rules for the connected organization or a selected project" />
   <LinkCard title="Update Alert" href="#update-alert" description="Update a Sentry metric alert rule with new thresholds, conditions, or notification targets" />
   <LinkCard title="Update Issue" href="#update-issue" description="Update a Sentry issue status, priority, assignee, or visibility flags" />
@@ -502,6 +502,53 @@ Returns the Sentry issue object including:
 }
 ```
 
+<a id="link-git-hub-issue"></a>
+
+## Link GitHub Issue
+
+**Component key:** `sentry.linkGitHubIssue`
+
+The Link GitHub Issue component connects a Sentry issue to an existing GitHub issue using the GitHub integration installed in your Sentry organization.
+
+### Use Cases
+
+- **Automated triage**: link a GitHub issue created by an upstream workflow to the triggering Sentry exception
+- **Cross-tool traceability**: connect incident tickets to the Sentry issues that caused them
+- **Release follow-up**: associate remediation tasks in GitHub with unresolved Sentry errors
+
+### Prerequisites
+
+- A GitHub integration must be installed in your Sentry organization (**Settings → Integrations → GitHub**)
+- The Sentry personal token must include **Issue & Event → Read & Write**
+
+### Configuration
+
+- **Issue**: Select the Sentry issue to link
+- **GitHub Integration**: Select the GitHub integration installed in Sentry
+- **Repository**: GitHub repository in owner/repo format
+- **GitHub Issue Number**: The number of the existing GitHub issue to link
+- **Comment**: Optional comment added when the link is created
+
+### Output
+
+Returns the external issue link object created by Sentry, including the linked issue URL and display name.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "displayName": "example-org/example-repo#42",
+    "id": 5,
+    "integrationId": 123456,
+    "key": "42",
+    "url": "https://github.com/example-org/example-repo/issues/42"
+  },
+  "timestamp": "2026-07-05T15:00:00.000000Z",
+  "type": "sentry.externalIssue"
+}
+```
+
 <a id="list-alerts"></a>
 
 ## List Alerts
@@ -712,53 +759,6 @@ Returns the updated Sentry issue object.
   },
   "timestamp": "2022-04-04T18:17:18.320000Z",
   "type": "sentry.issue"
-}
-```
-
-<a id="link-github-issue"></a>
-
-## Link GitHub Issue
-
-**Component key:** `sentry.linkGitHubIssue`
-
-The Link GitHub Issue component connects a Sentry issue to an existing GitHub issue using the GitHub integration installed in your Sentry organization.
-
-### Use Cases
-
-- **Automated triage**: link a GitHub issue created by an upstream workflow to the triggering Sentry exception
-- **Cross-tool traceability**: connect incident tickets to the Sentry issues that caused them
-- **Release follow-up**: associate remediation tasks in GitHub with unresolved Sentry errors
-
-### Prerequisites
-
-- A GitHub integration must be installed in your Sentry organization (**Settings → Integrations → GitHub**)
-- The Sentry personal token must include **Issue & Event → Read & Write**
-
-### Configuration
-
-- **Issue**: Select the Sentry issue to link
-- **GitHub Integration**: Select the GitHub integration installed in Sentry
-- **Repository**: GitHub repository in `owner/repo` format
-- **GitHub Issue Number**: The number of the existing GitHub issue to link
-- **Comment**: Optional comment added when the link is created
-
-### Output
-
-Returns the external issue link object created by Sentry, including the linked issue URL and display name.
-
-### Example Output
-
-```json
-{
-  "data": {
-    "displayName": "example-org/example-repo#42",
-    "id": 5,
-    "integrationId": 123456,
-    "key": "42",
-    "url": "https://github.com/example-org/example-repo/issues/42"
-  },
-  "timestamp": "2026-07-05T15:00:00.000000Z",
-  "type": "sentry.externalIssue"
 }
 ```
 

--- a/docs/components/Sentry.mdx
+++ b/docs/components/Sentry.mdx
@@ -21,6 +21,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete Alert" href="#delete-alert" description="Delete a Sentry metric alert rule" />
   <LinkCard title="Get Alert" href="#get-alert" description="Retrieve a Sentry metric alert rule with its thresholds, projects, and actions" />
   <LinkCard title="Get Issue" href="#get-issue" description="Retrieve a Sentry issue with tags, frequency, assignee, and recent events" />
+  <LinkCard title="Link GitHub Issue" href="#link-github-issue" description="Link an existing GitHub issue to a Sentry issue through the Sentry GitHub integration" />
   <LinkCard title="List Alerts" href="#list-alerts" description="List Sentry metric alert rules for the connected organization or a selected project" />
   <LinkCard title="Update Alert" href="#update-alert" description="Update a Sentry metric alert rule with new thresholds, conditions, or notification targets" />
   <LinkCard title="Update Issue" href="#update-issue" description="Update a Sentry issue status, priority, assignee, or visibility flags" />
@@ -711,6 +712,53 @@ Returns the updated Sentry issue object.
   },
   "timestamp": "2022-04-04T18:17:18.320000Z",
   "type": "sentry.issue"
+}
+```
+
+<a id="link-github-issue"></a>
+
+## Link GitHub Issue
+
+**Component key:** `sentry.linkGitHubIssue`
+
+The Link GitHub Issue component connects a Sentry issue to an existing GitHub issue using the GitHub integration installed in your Sentry organization.
+
+### Use Cases
+
+- **Automated triage**: link a GitHub issue created by an upstream workflow to the triggering Sentry exception
+- **Cross-tool traceability**: connect incident tickets to the Sentry issues that caused them
+- **Release follow-up**: associate remediation tasks in GitHub with unresolved Sentry errors
+
+### Prerequisites
+
+- A GitHub integration must be installed in your Sentry organization (**Settings → Integrations → GitHub**)
+- The Sentry personal token must include **Issue & Event → Read & Write**
+
+### Configuration
+
+- **Issue**: Select the Sentry issue to link
+- **GitHub Integration**: Select the GitHub integration installed in Sentry
+- **Repository**: GitHub repository in `owner/repo` format
+- **GitHub Issue Number**: The number of the existing GitHub issue to link
+- **Comment**: Optional comment added when the link is created
+
+### Output
+
+Returns the external issue link object created by Sentry, including the linked issue URL and display name.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "displayName": "example-org/example-repo#42",
+    "id": 5,
+    "integrationId": 123456,
+    "key": "42",
+    "url": "https://github.com/example-org/example-repo/issues/42"
+  },
+  "timestamp": "2026-07-05T15:00:00.000000Z",
+  "type": "sentry.externalIssue"
 }
 ```
 

--- a/pkg/integrations/sentry/client.go
+++ b/pkg/integrations/sentry/client.go
@@ -222,6 +222,30 @@ type UpdateIssueRequest struct {
 	IsSubscribed *bool  `json:"isSubscribed,omitempty"`
 }
 
+type OrganizationIntegration struct {
+	ID       string `json:"id" mapstructure:"id"`
+	Name     string `json:"name" mapstructure:"name"`
+	Status   string `json:"status" mapstructure:"status"`
+	Provider struct {
+		Key  string `json:"key" mapstructure:"key"`
+		Name string `json:"name" mapstructure:"name"`
+	} `json:"provider" mapstructure:"provider"`
+}
+
+type LinkExternalIssueRequest struct {
+	Repo          string `json:"repo"`
+	ExternalIssue any    `json:"externalIssue"`
+	Comment       string `json:"comment,omitempty"`
+}
+
+type ExternalIssueLink struct {
+	ID            any    `json:"id" mapstructure:"id"`
+	Key           string `json:"key" mapstructure:"key"`
+	URL           string `json:"url" mapstructure:"url"`
+	IntegrationID any    `json:"integrationId" mapstructure:"integrationId"`
+	DisplayName   string `json:"displayName" mapstructure:"displayName"`
+}
+
 type MetricAlertRule struct {
 	ID               string                    `json:"id" mapstructure:"id"`
 	Name             string                    `json:"name" mapstructure:"name"`
@@ -703,6 +727,48 @@ func (c *Client) UpdateIssue(issueID string, request UpdateIssueRequest) (*Issue
 	}
 
 	return c.GetIssue(issueID)
+}
+
+func (c *Client) ListOrganizationIntegrations(providerKey string) ([]OrganizationIntegration, error) {
+	path := fmt.Sprintf("/api/0/organizations/%s/integrations/", c.orgSlug)
+	if strings.TrimSpace(providerKey) != "" {
+		path += "?providerKey=" + url.QueryEscape(strings.TrimSpace(providerKey))
+	}
+
+	responseBody, err := c.doJSON(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	integrations := []OrganizationIntegration{}
+	if err := json.Unmarshal(responseBody, &integrations); err != nil {
+		return nil, err
+	}
+
+	return integrations, nil
+}
+
+func (c *Client) LinkExternalIssue(issueID, integrationID string, request LinkExternalIssueRequest) (*ExternalIssueLink, error) {
+	responseBody, err := c.doJSON(
+		http.MethodPut,
+		fmt.Sprintf(
+			"/api/0/organizations/%s/issues/%s/integrations/%s/",
+			c.orgSlug,
+			url.PathEscape(issueID),
+			url.PathEscape(integrationID),
+		),
+		request,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	link := ExternalIssueLink{}
+	if err := json.Unmarshal(responseBody, &link); err != nil {
+		return nil, err
+	}
+
+	return &link, nil
 }
 
 func (c *Client) ListAlertRules() ([]MetricAlertRule, error) {

--- a/pkg/integrations/sentry/example.go
+++ b/pkg/integrations/sentry/example.go
@@ -67,6 +67,12 @@ var exampleOutputCreateDeployBytes []byte
 var exampleOutputCreateDeployOnce sync.Once
 var exampleOutputCreateDeploy map[string]any
 
+//go:embed example_output_link_github_issue.json
+var exampleOutputLinkGitHubIssueBytes []byte
+
+var exampleOutputLinkGitHubIssueOnce sync.Once
+var exampleOutputLinkGitHubIssue map[string]any
+
 func (t *OnIssue) ExampleData() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleDataOnIssueOnce, exampleDataOnIssueBytes, &exampleDataOnIssue)
 }
@@ -128,5 +134,13 @@ func (c *CreateDeploy) ExampleOutput() map[string]any {
 		&exampleOutputCreateDeployOnce,
 		exampleOutputCreateDeployBytes,
 		&exampleOutputCreateDeploy,
+	)
+}
+
+func (c *LinkGitHubIssue) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputLinkGitHubIssueOnce,
+		exampleOutputLinkGitHubIssueBytes,
+		&exampleOutputLinkGitHubIssue,
 	)
 }

--- a/pkg/integrations/sentry/example_output_link_github_issue.json
+++ b/pkg/integrations/sentry/example_output_link_github_issue.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": 5,
+    "key": "42",
+    "url": "https://github.com/example-org/example-repo/issues/42",
+    "integrationId": 123456,
+    "displayName": "example-org/example-repo#42"
+  },
+  "timestamp": "2026-07-05T15:00:00.000000Z",
+  "type": "sentry.externalIssue"
+}

--- a/pkg/integrations/sentry/link_github_issue.go
+++ b/pkg/integrations/sentry/link_github_issue.go
@@ -1,0 +1,305 @@
+package sentry
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type LinkGitHubIssue struct{}
+
+type LinkGitHubIssueConfiguration struct {
+	IssueID             string `json:"issueId" mapstructure:"issueId"`
+	GitHubIntegrationID string `json:"githubIntegrationId" mapstructure:"githubIntegrationId"`
+	Repo                string `json:"repo" mapstructure:"repo"`
+	ExternalIssue       string `json:"externalIssue" mapstructure:"externalIssue"`
+	Comment             string `json:"comment" mapstructure:"comment"`
+}
+
+type LinkGitHubIssueNodeMetadata struct {
+	IssueTitle             string `json:"issueTitle,omitempty" mapstructure:"issueTitle"`
+	GitHubIntegrationLabel string `json:"githubIntegrationLabel,omitempty" mapstructure:"githubIntegrationLabel"`
+	ExternalIssueLabel     string `json:"externalIssueLabel,omitempty" mapstructure:"externalIssueLabel"`
+}
+
+func (c *LinkGitHubIssue) Name() string {
+	return "sentry.linkGitHubIssue"
+}
+
+func (c *LinkGitHubIssue) Label() string {
+	return "Link GitHub Issue"
+}
+
+func (c *LinkGitHubIssue) Description() string {
+	return "Link an existing GitHub issue to a Sentry issue through the Sentry GitHub integration"
+}
+
+func (c *LinkGitHubIssue) Documentation() string {
+	return `The Link GitHub Issue component connects a Sentry issue to an existing GitHub issue using the GitHub integration installed in your Sentry organization.
+
+## Use Cases
+
+- **Automated triage**: link a GitHub issue created by an upstream workflow to the triggering Sentry exception
+- **Cross-tool traceability**: connect incident tickets to the Sentry issues that caused them
+- **Release follow-up**: associate remediation tasks in GitHub with unresolved Sentry errors
+
+## Prerequisites
+
+- A GitHub integration must be installed in your Sentry organization (**Settings → Integrations → GitHub**)
+- The Sentry personal token must include **Issue & Event → Read & Write**
+
+## Configuration
+
+- **Issue**: Select the Sentry issue to link
+- **GitHub Integration**: Select the GitHub integration installed in Sentry
+- **Repository**: GitHub repository in owner/repo format
+- **GitHub Issue Number**: The number of the existing GitHub issue to link
+- **Comment**: Optional comment added when the link is created
+
+## Output
+
+Returns the external issue link object created by Sentry, including the linked issue URL and display name.`
+}
+
+func (c *LinkGitHubIssue) Icon() string {
+	return "bug"
+}
+
+func (c *LinkGitHubIssue) Color() string {
+	return "gray"
+}
+
+func (c *LinkGitHubIssue) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *LinkGitHubIssue) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "issueId",
+			Label:       "Issue",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Select the Sentry issue to link",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeIssue,
+				},
+			},
+		},
+		{
+			Name:        "githubIntegrationId",
+			Label:       "GitHub Integration",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Select the GitHub integration installed in your Sentry organization",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeGitHubIntegration,
+				},
+			},
+		},
+		{
+			Name:        "repo",
+			Label:       "Repository",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "GitHub repository in owner/repo format",
+		},
+		{
+			Name:        "externalIssue",
+			Label:       "GitHub Issue Number",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Number of the existing GitHub issue to link",
+		},
+		{
+			Name:        "comment",
+			Label:       "Comment",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Description: "Optional comment added when the link is created",
+		},
+	}
+}
+
+func (c *LinkGitHubIssue) Setup(ctx core.SetupContext) error {
+	config, err := decodeLinkGitHubIssueConfiguration(ctx.Configuration)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	normalizeLinkGitHubIssueConfiguration(&config)
+
+	if err := validateLinkGitHubIssueConfiguration(config); err != nil {
+		return err
+	}
+
+	if isExpressionValue(config.IssueID) || isExpressionValue(config.GitHubIntegrationID) {
+		return ctx.Metadata.Set(LinkGitHubIssueNodeMetadata{})
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create sentry client: %w", err)
+	}
+
+	nodeMetadata := LinkGitHubIssueNodeMetadata{
+		ExternalIssueLabel: displayExternalIssueLabel(config.Repo, config.ExternalIssue),
+	}
+
+	issue, err := client.GetIssue(config.IssueID)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve sentry issue: %w", err)
+	}
+	nodeMetadata.IssueTitle = displayIssueLabel(issue.ShortID, issue.Title)
+
+	integrations, err := client.ListOrganizationIntegrations("github")
+	if err != nil {
+		return fmt.Errorf("failed to list sentry github integrations: %w", err)
+	}
+
+	for _, integration := range integrations {
+		if integration.ID == config.GitHubIntegrationID {
+			nodeMetadata.GitHubIntegrationLabel = integration.Name
+			break
+		}
+	}
+
+	return ctx.Metadata.Set(nodeMetadata)
+}
+
+func validateLinkGitHubIssueConfiguration(config LinkGitHubIssueConfiguration) error {
+	if config.IssueID == "" {
+		return errors.New("issueId is required")
+	}
+
+	if config.GitHubIntegrationID == "" {
+		return errors.New("githubIntegrationId is required")
+	}
+
+	if config.Repo == "" {
+		return errors.New("repo is required")
+	}
+
+	if config.ExternalIssue == "" {
+		return errors.New("externalIssue is required")
+	}
+
+	if !strings.Contains(config.Repo, "/") {
+		return errors.New("repo must be in owner/repo format")
+	}
+
+	return nil
+}
+
+func normalizeLinkGitHubIssueConfiguration(config *LinkGitHubIssueConfiguration) {
+	if config == nil {
+		return
+	}
+
+	config.IssueID = strings.TrimSpace(config.IssueID)
+	config.GitHubIntegrationID = strings.TrimSpace(config.GitHubIntegrationID)
+	config.Repo = strings.TrimSpace(config.Repo)
+	config.ExternalIssue = strings.TrimSpace(config.ExternalIssue)
+	config.Comment = strings.TrimSpace(config.Comment)
+}
+
+func (c *LinkGitHubIssue) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *LinkGitHubIssue) Execute(ctx core.ExecutionContext) error {
+	config, err := decodeLinkGitHubIssueConfiguration(ctx.Configuration)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	normalizeLinkGitHubIssueConfiguration(&config)
+
+	if err := validateLinkGitHubIssueConfiguration(config); err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create sentry client: %w", err)
+	}
+
+	link, err := client.LinkExternalIssue(config.IssueID, config.GitHubIntegrationID, LinkExternalIssueRequest{
+		Repo:          config.Repo,
+		ExternalIssue: parseExternalIssueValue(config.ExternalIssue),
+		Comment:       config.Comment,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to link github issue to sentry issue: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, "sentry.externalIssue", []any{link})
+}
+
+func (c *LinkGitHubIssue) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *LinkGitHubIssue) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *LinkGitHubIssue) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func decodeLinkGitHubIssueConfiguration(input any) (LinkGitHubIssueConfiguration, error) {
+	config := LinkGitHubIssueConfiguration{}
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &config,
+		TagName:          "mapstructure",
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
+		return LinkGitHubIssueConfiguration{}, err
+	}
+
+	if err := decoder.Decode(input); err != nil {
+		return LinkGitHubIssueConfiguration{}, err
+	}
+
+	return config, nil
+}
+
+func parseExternalIssueValue(value string) any {
+	if issueNumber, err := strconv.Atoi(value); err == nil {
+		return issueNumber
+	}
+
+	return value
+}
+
+func displayExternalIssueLabel(repo, externalIssue string) string {
+	repo = strings.TrimSpace(repo)
+	externalIssue = strings.TrimSpace(externalIssue)
+
+	switch {
+	case repo != "" && externalIssue != "":
+		return fmt.Sprintf("%s#%s", repo, externalIssue)
+	case externalIssue != "":
+		return externalIssue
+	default:
+		return repo
+	}
+}
+
+func (c *LinkGitHubIssue) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *LinkGitHubIssue) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/sentry/link_github_issue_test.go
+++ b/pkg/integrations/sentry/link_github_issue_test.go
@@ -1,0 +1,199 @@
+package sentry
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__LinkGitHubIssue__Setup(t *testing.T) {
+	component := &LinkGitHubIssue{}
+
+	t.Run("requires issueId", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"githubIntegrationId": "456",
+				"repo":                "example-org/example-repo",
+				"externalIssue":       "42",
+			},
+		})
+
+		require.ErrorContains(t, err, "issueId is required")
+	})
+
+	t.Run("requires githubIntegrationId", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"issueId":       "123",
+				"repo":          "example-org/example-repo",
+				"externalIssue": "42",
+			},
+		})
+
+		require.ErrorContains(t, err, "githubIntegrationId is required")
+	})
+
+	t.Run("requires repo in owner/repo format", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"issueId":             "123",
+				"githubIntegrationId": "456",
+				"repo":                "example-repo",
+				"externalIssue":       "42",
+			},
+		})
+
+		require.ErrorContains(t, err, "repo must be in owner/repo format")
+	})
+
+	t.Run("stores metadata for configured issue and integration", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"issueId":             "123",
+				"githubIntegrationId": "456",
+				"repo":                "example-org/example-repo",
+				"externalIssue":       "42",
+			},
+			Metadata: metadata,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"baseUrl":   "https://sentry.io",
+					"userToken": "user-token",
+				},
+				Metadata: Metadata{
+					Organization: &OrganizationSummary{
+						Slug: "example",
+					},
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					sentryMockResponse(http.StatusOK, `{"id":"123","shortId":"EXAMPLE-1","title":"RuntimeError: Database timeout","project":{"slug":"backend","name":"Backend"}}`),
+					sentryMockResponse(http.StatusOK, `[{"id":"456","name":"GitHub","status":"active","provider":{"key":"github","name":"GitHub"}}]`),
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, LinkGitHubIssueNodeMetadata{
+			IssueTitle:             "EXAMPLE-1 · Database timeout",
+			GitHubIntegrationLabel: "GitHub",
+			ExternalIssueLabel:     "example-org/example-repo#42",
+		}, metadata.Metadata)
+	})
+
+	t.Run("uses issue and github integration resources", func(t *testing.T) {
+		fields := component.Configuration()
+
+		assert.Equal(t, configuration.FieldTypeIntegrationResource, fields[0].Type)
+		require.NotNil(t, fields[0].TypeOptions)
+		require.NotNil(t, fields[0].TypeOptions.Resource)
+		assert.Equal(t, ResourceTypeIssue, fields[0].TypeOptions.Resource.Type)
+
+		assert.Equal(t, configuration.FieldTypeIntegrationResource, fields[1].Type)
+		require.NotNil(t, fields[1].TypeOptions)
+		require.NotNil(t, fields[1].TypeOptions.Resource)
+		assert.Equal(t, ResourceTypeGitHubIntegration, fields[1].TypeOptions.Resource.Type)
+	})
+}
+
+func Test__LinkGitHubIssue__Execute(t *testing.T) {
+	component := &LinkGitHubIssue{}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"baseUrl":   "https://sentry.io",
+			"userToken": "user-token",
+		},
+		Metadata: Metadata{
+			Organization: &OrganizationSummary{
+				Slug: "example",
+			},
+		},
+	}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			sentryMockResponse(http.StatusCreated, `{"id":5,"key":"42","url":"https://github.com/example-org/example-repo/issues/42","integrationId":456,"displayName":"example-org/example-repo#42"}`),
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"issueId":             "123",
+			"githubIntegrationId": "456",
+			"repo":                "example-org/example-repo",
+			"externalIssue":       "42",
+			"comment":             "Linked from SuperPlane",
+		},
+		HTTP:           httpCtx,
+		Integration:    integrationCtx,
+		ExecutionState: executionState,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, "sentry.externalIssue", executionState.Type)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Equal(t, "https://sentry.io/api/0/organizations/example/issues/123/integrations/456/", httpCtx.Requests[0].URL.String())
+	assert.Equal(t, http.MethodPut, httpCtx.Requests[0].Method)
+
+	body, readErr := io.ReadAll(httpCtx.Requests[0].Body)
+	require.NoError(t, readErr)
+
+	requestBody := map[string]any{}
+	require.NoError(t, json.Unmarshal(body, &requestBody))
+	assert.Equal(t, "example-org/example-repo", requestBody["repo"])
+	assert.EqualValues(t, 42, requestBody["externalIssue"])
+	assert.Equal(t, "Linked from SuperPlane", requestBody["comment"])
+}
+
+func Test__LinkGitHubIssue__Execute_AcceptsNonNumericExternalIssue(t *testing.T) {
+	component := &LinkGitHubIssue{}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"baseUrl":   "https://sentry.io",
+			"userToken": "user-token",
+		},
+		Metadata: Metadata{
+			Organization: &OrganizationSummary{
+				Slug: "example",
+			},
+		},
+	}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			sentryMockResponse(http.StatusCreated, `{"id":5,"key":"SCRUM-24","url":"https://example.atlassian.net/browse/SCRUM-24","integrationId":456,"displayName":"SCRUM-24"}`),
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"issueId":             "123",
+			"githubIntegrationId": "456",
+			"repo":                "example-org/example-repo",
+			"externalIssue":       "SCRUM-24",
+		},
+		HTTP:           httpCtx,
+		Integration:    integrationCtx,
+		ExecutionState: executionState,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, executionState.Passed)
+
+	body, readErr := io.ReadAll(httpCtx.Requests[0].Body)
+	require.NoError(t, readErr)
+
+	requestBody := map[string]any{}
+	require.NoError(t, json.Unmarshal(body, &requestBody))
+	assert.Equal(t, "SCRUM-24", requestBody["externalIssue"])
+}

--- a/pkg/integrations/sentry/sentry.go
+++ b/pkg/integrations/sentry/sentry.go
@@ -22,13 +22,14 @@ import (
 const (
 	DefaultBaseURL = "https://sentry.io"
 
-	ResourceTypeProject     = "project"
-	ResourceTypeTeam        = "team"
-	ResourceTypeIssue       = "issue"
-	ResourceTypeAssignee    = "assignee"
-	ResourceTypeAlert       = "alert"
-	ResourceTypeAlertTarget = "alert-target"
-	ResourceTypeRelease     = "release"
+	ResourceTypeProject           = "project"
+	ResourceTypeTeam              = "team"
+	ResourceTypeIssue             = "issue"
+	ResourceTypeAssignee          = "assignee"
+	ResourceTypeAlert             = "alert"
+	ResourceTypeAlertTarget       = "alert-target"
+	ResourceTypeRelease           = "release"
+	ResourceTypeGitHubIntegration = "github-integration"
 
 	SentryPersonalTokensURL = "https://sentry.io/settings/account/api/auth-tokens/"
 )
@@ -209,6 +210,7 @@ func (s *Sentry) Actions() []core.Action {
 		&CreateRelease{},
 		&CreateDeploy{},
 		&UpdateIssue{},
+		&LinkGitHubIssue{},
 	}
 }
 
@@ -799,6 +801,34 @@ func (s *Sentry) ListResources(resourceType string, ctx core.ListResourcesContex
 				Type: ResourceTypeRelease,
 				ID:   version,
 				Name: version,
+			})
+		}
+
+		return resources, nil
+
+	case ResourceTypeGitHubIntegration:
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create sentry client: %w", err)
+		}
+
+		integrations, err := client.ListOrganizationIntegrations("github")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list github integrations: %w", err)
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(integrations))
+		for _, integration := range integrations {
+			id := strings.TrimSpace(integration.ID)
+			name := strings.TrimSpace(integration.Name)
+			if id == "" || name == "" {
+				continue
+			}
+
+			resources = append(resources, core.IntegrationResource{
+				Type: ResourceTypeGitHubIntegration,
+				ID:   id,
+				Name: name,
 			})
 		}
 

--- a/web_src/src/pages/app/mappers/sentry/index.ts
+++ b/web_src/src/pages/app/mappers/sentry/index.ts
@@ -6,6 +6,7 @@ import { createReleaseMapper } from "./create_release";
 import { deleteAlertMapper } from "./delete_alert";
 import { getAlertMapper } from "./get_alert";
 import { getIssueMapper } from "./get_issue";
+import { linkGitHubIssueMapper } from "./link_github_issue";
 import { listAlertsMapper } from "./list_alerts";
 import { onIssueTriggerRenderer } from "./on_issue";
 import { updateAlertMapper } from "./update_alert";
@@ -18,6 +19,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   deleteAlert: deleteAlertMapper,
   getAlert: getAlertMapper,
   getIssue: getIssueMapper,
+  linkGitHubIssue: linkGitHubIssueMapper,
   listAlerts: listAlertsMapper,
   updateAlert: updateAlertMapper,
   updateIssue: updateIssueMapper,
@@ -34,6 +36,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   deleteAlert: buildActionStateRegistry("deleted"),
   getAlert: buildActionStateRegistry("retrieved"),
   getIssue: buildActionStateRegistry("retrieved"),
+  linkGitHubIssue: buildActionStateRegistry("linked"),
   listAlerts: buildActionStateRegistry("listed"),
   updateAlert: buildActionStateRegistry("updated"),
   updateIssue: buildActionStateRegistry("updated"),

--- a/web_src/src/pages/app/mappers/sentry/link_github_issue.ts
+++ b/web_src/src/pages/app/mappers/sentry/link_github_issue.ts
@@ -1,0 +1,118 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { formatTimeAgo } from "@/lib/date";
+import sentryIcon from "@/assets/icons/integrations/sentry.svg";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import { addDetail, addFormattedTimestamp, buildEventSections } from "./utils";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+
+interface LinkGitHubIssueConfiguration {
+  issueId?: string;
+  githubIntegrationId?: string;
+  repo?: string;
+  externalIssue?: string;
+  comment?: string;
+}
+
+interface LinkGitHubIssueNodeMetadata {
+  issueTitle?: string;
+  githubIntegrationLabel?: string;
+  externalIssueLabel?: string;
+}
+
+interface ExternalIssueLink {
+  id?: number | string;
+  key?: string;
+  url?: string;
+  integrationId?: number | string;
+  displayName?: string;
+}
+
+export const linkGitHubIssueMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name || "unknown";
+
+    return {
+      iconSrc: sentryIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title:
+        context.node.name ||
+        context.componentDefinition.label ||
+        context.componentDefinition.name ||
+        "Unnamed component",
+      eventSections: lastExecution
+        ? buildEventSections(context.nodes, lastExecution, componentName, getTriggerRenderer, getState)
+        : undefined,
+      metadata: buildMetadata(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  subtitle(context: SubtitleContext): string {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const link = outputs?.default?.[0]?.data as ExternalIssueLink | undefined;
+    const timestamp = formatTimeAgo(new Date(context.execution.updatedAt || context.execution.createdAt));
+    return [link?.displayName || link?.key, timestamp].filter(Boolean).join(" · ");
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const link = outputs?.default?.[0]?.data as ExternalIssueLink | undefined;
+    const details: Record<string, string> = {};
+
+    addFormattedTimestamp(details, "Triggered At", context.execution.createdAt);
+
+    const orderedDetails: Array<[string, string | undefined]> = [
+      ["Display Name", link?.displayName],
+      ["Issue Key", link?.key],
+      ["URL", link?.url],
+    ];
+
+    for (const [label, value] of orderedDetails) {
+      if (Object.keys(details).length >= 6) {
+        break;
+      }
+
+      addDetail(details, label, value);
+    }
+
+    return details;
+  },
+};
+
+function buildMetadata(node: NodeInfo) {
+  const configuration = node.configuration as LinkGitHubIssueConfiguration | undefined;
+  const nodeMetadata = node.metadata as LinkGitHubIssueNodeMetadata | undefined;
+  const metadata = [];
+
+  const issueLabel = nodeMetadata?.issueTitle || configuration?.issueId;
+  if (issueLabel) {
+    metadata.push({ icon: "bug", label: issueLabel });
+  }
+
+  const externalIssueLabel =
+    nodeMetadata?.externalIssueLabel ||
+    (configuration?.repo && configuration?.externalIssue
+      ? `${configuration.repo}#${configuration.externalIssue}`
+      : configuration?.externalIssue);
+  if (externalIssueLabel) {
+    metadata.push({ icon: "link", label: externalIssueLabel });
+  }
+
+  const integrationLabel = nodeMetadata?.githubIntegrationLabel || configuration?.githubIntegrationId;
+  if (integrationLabel) {
+    metadata.push({ icon: "github", label: integrationLabel });
+  }
+
+  return metadata.slice(0, 3);
+}


### PR DESCRIPTION
## Summary
- Adds a new `sentry.linkGitHubIssue` action that links an existing GitHub issue to a Sentry issue using Sentry's external issue linking API
- Lists installed GitHub integrations from Sentry as a resource picker for configuration
- Includes backend tests, UI mapper, and component documentation

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/integrations/sentry`
- [x] `make format.go format.js`
- [x] `make lint && make check.build.app && make check.build.ui`
- [ ] Manual: connect Sentry + GitHub integration, run workflow that creates a GitHub issue then links it to a Sentry issue, verify link appears under External Links in Sentry UI


Made with [Cursor](https://cursor.com)