### PR TITLE
fix: remove horizontal scroll from the members table

### DIFF
--- a/web_src/src/pages/organization/settings/Members.tsx
+++ b/web_src/src/pages/organization/settings/Members.tsx
@@ -334,7 +334,7 @@ export function Members({ organizationId }: MembersProps) {
               <p className="text-gray-500 dark:text-gray-400">Loading...</p>
             </div>
           ) : (
-            <Table dense>
+            <Table dense className="!overflow-x-hidden !whitespace-normal">
               <TableHead>
                 <TableRow>
                   <TableHeader
@@ -387,7 +387,11 @@ export function Members({ organizationId }: MembersProps) {
                         </div>
                       </div>
                     </TableCell>
-                    <TableCell>{member.email}</TableCell>
+                    <TableCell className="min-w-0">
+                      <div className="max-w-[26rem] truncate" title={member.email}>
+                        {member.email}
+                      </div>
+                    </TableCell>
                     <TableCell>
                       {(() => {
                         const isSelf = me?.id === member.id;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes the unwanted horizontal scrollbar in the Organization Settings → Members table by disabling the table’s horizontal scroll container for this page and truncating long email values.

## Changes
- `web_src/src/pages/organization/settings/Members.tsx`
  - Override the shared `Table` wrapper’s `overflow-x-auto`/`whitespace-nowrap` behavior for this specific table.
  - Truncate the email column (with `title` tooltip) to prevent layout overflow.

## Testing
- Pending: manual UI verification + `make check.build.ui`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fbfe320-9b16-4b88-ad17-fc7e3dd6a37b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fbfe320-9b16-4b88-ad17-fc7e3dd6a37b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

