### PR TITLE
fix: support id-bound local secret data

### DIFF
--- a/pkg/grpc/actions/secrets/create_secret.go
+++ b/pkg/grpc/actions/secrets/create_secret.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -39,12 +38,21 @@ func CreateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType st
 		return nil, grpcerrors.InvalidArgument(nil, "invalid provider")
 	}
 
-	data, err := prepareSecretData(ctx, encryptor, spec)
+	localData, err := prepareSecretData(spec)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(err, "invalid secret configuration")
 	}
 
-	secret, err := models.CreateSecret(spec.Metadata.Name, provider, userID, domainType, uuid.MustParse(domainID), data)
+	secretID := uuid.New()
+	data, err := secretstore.EncryptLocalData(ctx, encryptor, models.Secret{
+		ID:   secretID,
+		Name: spec.Metadata.Name,
+	}, localData)
+	if err != nil {
+		return nil, grpcerrors.InvalidArgument(err, "invalid secret configuration")
+	}
+
+	secret, err := models.CreateSecretWithID(secretID, spec.Metadata.Name, provider, userID, domainType, uuid.MustParse(domainID), data)
 	if err != nil {
 		if errors.Is(err, models.ErrNameAlreadyUsed) {
 			return nil, grpcerrors.InvalidArgument(err, "name already used")
@@ -80,7 +88,7 @@ func secretProviderToProto(provider string) pb.Secret_Provider {
 	}
 }
 
-func prepareSecretData(ctx context.Context, encryptor crypto.Encryptor, secret *pb.Secret) ([]byte, error) {
+func prepareSecretData(secret *pb.Secret) (map[string]string, error) {
 	if secret.Spec == nil {
 		return nil, fmt.Errorf("missing secret spec")
 	}
@@ -90,17 +98,7 @@ func prepareSecretData(ctx context.Context, encryptor crypto.Encryptor, secret *
 			return nil, fmt.Errorf("missing data")
 		}
 
-		data, err := json.Marshal(secret.Spec.Local.Data)
-		if err != nil {
-			return nil, err
-		}
-
-		encrypted, err := encryptor.Encrypt(ctx, data, []byte(secret.Metadata.Name))
-		if err != nil {
-			return nil, err
-		}
-
-		return encrypted, nil
+		return secret.Spec.Local.Data, nil
 
 	default:
 		return nil, fmt.Errorf("provider not supported")
@@ -110,9 +108,4 @@ func prepareSecretData(ctx context.Context, encryptor crypto.Encryptor, secret *
 // decryptSecretData decrypts a secret's stored data and returns the key-value map.
 func decryptSecretData(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) (map[string]string, error) {
 	return secretstore.DecryptLocalData(ctx, encryptor, secret)
-}
-
-// encryptSecretData marshals the key-value map and encrypts it for storage.
-func encryptSecretData(ctx context.Context, encryptor crypto.Encryptor, secretName string, data map[string]string) ([]byte, error) {
-	return secretstore.EncryptLocalData(ctx, encryptor, models.Secret{Name: secretName}, data)
 }

--- a/pkg/grpc/actions/secrets/create_secret.go
+++ b/pkg/grpc/actions/secrets/create_secret.go
@@ -13,7 +13,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
-	"github.com/superplanehq/superplane/pkg/secrets"
+	secretstore "github.com/superplanehq/superplane/pkg/secrets"
 )
 
 func CreateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType string, domainID string, spec *pb.Secret) (*pb.CreateSecretResponse, error) {
@@ -65,7 +65,7 @@ func CreateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType st
 func protoToSecretProvider(provider pb.Secret_Provider) string {
 	switch provider {
 	case pb.Secret_PROVIDER_LOCAL:
-		return secrets.ProviderLocal
+		return secretstore.ProviderLocal
 	default:
 		return ""
 	}
@@ -73,7 +73,7 @@ func protoToSecretProvider(provider pb.Secret_Provider) string {
 
 func secretProviderToProto(provider string) pb.Secret_Provider {
 	switch provider {
-	case secrets.ProviderLocal:
+	case secretstore.ProviderLocal:
 		return pb.Secret_PROVIDER_LOCAL
 	default:
 		return pb.Secret_PROVIDER_UNKNOWN
@@ -109,26 +109,10 @@ func prepareSecretData(ctx context.Context, encryptor crypto.Encryptor, secret *
 
 // decryptSecretData decrypts a secret's stored data and returns the key-value map.
 func decryptSecretData(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) (map[string]string, error) {
-	data, err := encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
-	if err != nil {
-		return nil, err
-	}
-	var values map[string]string
-	if len(data) == 0 {
-		return make(map[string]string), nil
-	}
-	err = json.Unmarshal(data, &values)
-	if err != nil {
-		return nil, err
-	}
-	return values, nil
+	return secretstore.DecryptLocalData(ctx, encryptor, secret)
 }
 
 // encryptSecretData marshals the key-value map and encrypts it for storage.
 func encryptSecretData(ctx context.Context, encryptor crypto.Encryptor, secretName string, data map[string]string) ([]byte, error) {
-	raw, err := json.Marshal(data)
-	if err != nil {
-		return nil, err
-	}
-	return encryptor.Encrypt(ctx, raw, []byte(secretName))
+	return secretstore.EncryptLocalData(ctx, encryptor, models.Secret{Name: secretName}, data)
 }

--- a/pkg/grpc/actions/secrets/create_secret_test.go
+++ b/pkg/grpc/actions/secrets/create_secret_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
@@ -71,6 +72,39 @@ func Test__CreateSecret(t *testing.T) {
 		assert.Equal(t, protos.Secret_PROVIDER_LOCAL, response.Secret.Spec.Provider)
 		require.NotNil(t, response.Secret.Spec.Local)
 		require.Equal(t, map[string]string{"test": "***"}, response.Secret.Spec.Local.Data)
+	})
+
+	t.Run("local data is encrypted with secret ID", func(t *testing.T) {
+		aesEncryptor := crypto.NewAESGCMEncryptor([]byte("1234567890abcdefghijklmnopqrstuv"))
+		secret := &protos.Secret{
+			Metadata: &protos.Secret_Metadata{
+				Name: support.RandomName("secret"),
+			},
+			Spec: &protos.Secret_Spec{
+				Provider: protos.Secret_PROVIDER_LOCAL,
+				Local: &protos.Secret_Local{
+					Data: map[string]string{
+						"token": "secret",
+					},
+				},
+			},
+		}
+
+		response, err := CreateSecret(ctx, aesEncryptor, models.DomainTypeOrganization, r.Organization.ID.String(), secret)
+		require.NoError(t, err)
+
+		stored, err := models.FindSecretByID(models.DomainTypeOrganization, r.Organization.ID, response.Secret.Metadata.Id)
+		require.NoError(t, err)
+
+		raw, err := aesEncryptor.Decrypt(context.Background(), stored.Data, []byte(stored.ID.String()))
+		require.NoError(t, err)
+
+		var decrypted map[string]string
+		require.NoError(t, json.Unmarshal(raw, &decrypted))
+		assert.Equal(t, map[string]string{"token": "secret"}, decrypted)
+
+		_, err = aesEncryptor.Decrypt(context.Background(), stored.Data, []byte(stored.Name))
+		require.Error(t, err)
 	})
 
 	t.Run("name already used", func(t *testing.T) {

--- a/pkg/grpc/actions/secrets/delete_secret_key.go
+++ b/pkg/grpc/actions/secrets/delete_secret_key.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	secretstore "github.com/superplanehq/superplane/pkg/secrets"
 )
 
 func DeleteSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType, domainID, idOrName, keyName string) (*pb.DeleteSecretKeyResponse, error) {
@@ -40,7 +41,7 @@ func DeleteSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType
 		return nil, grpcerrors.InvalidArgument(nil, "secret must have at least one key")
 	}
 
-	encrypted, err := encryptSecretData(ctx, encryptor, secret.Name, data)
+	encrypted, err := secretstore.EncryptLocalData(ctx, encryptor, *secret, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/secrets/describe_secret.go
+++ b/pkg/grpc/actions/secrets/describe_secret.go
@@ -2,13 +2,14 @@ package secrets
 
 import (
 	"context"
-	"encoding/json"
+
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	secretstore "github.com/superplanehq/superplane/pkg/secrets"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -65,13 +66,7 @@ func serializeSecret(ctx context.Context, encryptor crypto.Encryptor, secret mod
 }
 
 func serializeLocalSecretData(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) (*pb.Secret_Local, error) {
-	data, err := encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
-	if err != nil {
-		return nil, err
-	}
-
-	var values map[string]string
-	err = json.Unmarshal(data, &values)
+	values, err := secretstore.DecryptLocalData(ctx, encryptor, secret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/secrets/set_secret_key.go
+++ b/pkg/grpc/actions/secrets/set_secret_key.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	secretstore "github.com/superplanehq/superplane/pkg/secrets"
 )
 
 func SetSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType, domainID, idOrName, keyName, value string) (*pb.SetSecretKeyResponse, error) {
@@ -37,7 +38,7 @@ func SetSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType, d
 	}
 	data[keyName] = value
 
-	encrypted, err := encryptSecretData(ctx, encryptor, secret.Name, data)
+	encrypted, err := secretstore.EncryptLocalData(ctx, encryptor, *secret, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/secrets/update_secret.go
+++ b/pkg/grpc/actions/secrets/update_secret.go
@@ -8,6 +8,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	secretstore "github.com/superplanehq/superplane/pkg/secrets"
 )
 
 func UpdateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType, domainID, idOrName string, spec *pb.Secret) (*pb.UpdateSecretResponse, error) {
@@ -40,7 +41,11 @@ func UpdateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType, d
 		return nil, grpcerrors.InvalidArgument(nil, "cannot update provider")
 	}
 
-	data, err := prepareSecretData(ctx, encryptor, spec)
+	if spec.Spec.Local == nil || spec.Spec.Local.Data == nil {
+		return nil, grpcerrors.InvalidArgument(nil, "missing data")
+	}
+
+	data, err := secretstore.EncryptLocalData(ctx, encryptor, *secret, spec.Spec.Local.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/secrets/update_secret_name.go
+++ b/pkg/grpc/actions/secrets/update_secret_name.go
@@ -41,13 +41,15 @@ func UpdateSecretName(ctx context.Context, encryptor crypto.Encryptor, domainTyp
 
 	var reEncrypted []byte
 	if len(secret.Data) > 0 {
-		plainData, err := decryptSecretData(ctx, encryptor, *secret)
+		plainData, usedLegacyFallback, err := secretstore.DecryptLocalDataWithFallback(ctx, encryptor, *secret)
 		if err != nil {
 			return nil, grpcerrors.Internal(err, "failed to decrypt secret data for re-encryption")
 		}
-		reEncrypted, err = secretstore.EncryptLocalData(ctx, encryptor, *secret, plainData)
-		if err != nil {
-			return nil, grpcerrors.Internal(err, "failed to re-encrypt secret data with new name")
+		if usedLegacyFallback {
+			reEncrypted, err = secretstore.EncryptLocalData(ctx, encryptor, *secret, plainData)
+			if err != nil {
+				return nil, grpcerrors.Internal(err, "failed to re-encrypt secret data with secret ID")
+			}
 		}
 	}
 

--- a/pkg/grpc/actions/secrets/update_secret_name.go
+++ b/pkg/grpc/actions/secrets/update_secret_name.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	secretstore "github.com/superplanehq/superplane/pkg/secrets"
 	"gorm.io/gorm"
 )
 
@@ -38,14 +39,13 @@ func UpdateSecretName(ctx context.Context, encryptor crypto.Encryptor, domainTyp
 		return &pb.UpdateSecretNameResponse{Secret: s}, nil
 	}
 
-	oldName := secret.Name
 	var reEncrypted []byte
 	if len(secret.Data) > 0 {
-		plainData, err := decryptSecretData(ctx, encryptor, models.Secret{Name: oldName, Data: secret.Data})
+		plainData, err := decryptSecretData(ctx, encryptor, *secret)
 		if err != nil {
 			return nil, grpcerrors.Internal(err, "failed to decrypt secret data for re-encryption")
 		}
-		reEncrypted, err = encryptSecretData(ctx, encryptor, name, plainData)
+		reEncrypted, err = secretstore.EncryptLocalData(ctx, encryptor, *secret, plainData)
 		if err != nil {
 			return nil, grpcerrors.Internal(err, "failed to re-encrypt secret data with new name")
 		}

--- a/pkg/grpc/actions/secrets/update_secret_name_test.go
+++ b/pkg/grpc/actions/secrets/update_secret_name_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/crypto"
@@ -29,7 +30,18 @@ func Test__UpdateSecretName(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	t.Run("renamed secret data decrypts with new name", func(t *testing.T) {
+	createIDEncryptedSecret := func(t *testing.T, name string, data map[string]string) *models.Secret {
+		t.Helper()
+		secret := models.Secret{ID: uuid.New(), Name: name}
+		encrypted, err := secrets.EncryptLocalData(context.Background(), encryptor, secret, data)
+		require.NoError(t, err)
+
+		created, err := models.CreateSecretWithID(secret.ID, name, secrets.ProviderLocal, r.User.String(), models.DomainTypeOrganization, r.Organization.ID, encrypted)
+		require.NoError(t, err)
+		return created
+	}
+
+	t.Run("renaming legacy data migrates encryption to secret ID", func(t *testing.T) {
 		oldName := support.RandomName("secret")
 		newName := support.RandomName("secret-renamed")
 		plainData := map[string]string{"key": "value"}
@@ -77,6 +89,24 @@ func Test__UpdateSecretName(t *testing.T) {
 
 		secret, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, name)
 		require.NoError(t, err)
+
+		decrypted, err := decryptSecretData(context.Background(), encryptor, *secret)
+		require.NoError(t, err)
+		assert.Equal(t, plainData, decrypted)
+	})
+
+	t.Run("renaming ID-bound data does not re-encrypt", func(t *testing.T) {
+		oldName := support.RandomName("secret")
+		newName := support.RandomName("secret-renamed")
+		plainData := map[string]string{"key": "value"}
+		created := createIDEncryptedSecret(t, oldName, plainData)
+
+		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), oldName, newName)
+		require.NoError(t, err)
+
+		secret, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, newName)
+		require.NoError(t, err)
+		assert.Equal(t, created.Data, secret.Data)
 
 		decrypted, err := decryptSecretData(context.Background(), encryptor, *secret)
 		require.NoError(t, err)

--- a/pkg/grpc/actions/secrets/update_secret_test.go
+++ b/pkg/grpc/actions/secrets/update_secret_test.go
@@ -62,3 +62,42 @@ func Test__UpdateSecret(t *testing.T) {
 		require.Equal(t, map[string]string{"test": "***", "test2": "***"}, response.Secret.Spec.Local.Data)
 	})
 }
+
+func Test__UpdateSecretMigratesLocalDataToIDAssociatedData(t *testing.T) {
+	r := support.SetupWithOptions(t, support.SetupOptions{})
+	encryptor := crypto.NewAESGCMEncryptor([]byte("1234567890abcdefghijklmnopqrstuv"))
+	name := support.RandomName("secret")
+	legacyData := map[string]string{"test": "test"}
+	raw, err := json.Marshal(legacyData)
+	require.NoError(t, err)
+
+	encrypted, err := encryptor.Encrypt(context.Background(), raw, []byte(name))
+	require.NoError(t, err)
+
+	secret, err := models.CreateSecret(name, secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, encrypted)
+	require.NoError(t, err)
+
+	updatedData := map[string]string{"test": "updated"}
+	spec := &protos.Secret{
+		Metadata: &protos.Secret_Metadata{Name: name},
+		Spec: &protos.Secret_Spec{
+			Provider: protos.Secret_PROVIDER_LOCAL,
+			Local:    &protos.Secret_Local{Data: updatedData},
+		},
+	}
+
+	_, err = UpdateSecret(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), name, spec)
+	require.NoError(t, err)
+
+	updated, err := models.FindSecretByID(models.DomainTypeOrganization, r.Organization.ID, secret.ID.String())
+	require.NoError(t, err)
+
+	decrypted, err := encryptor.Decrypt(context.Background(), updated.Data, []byte(updated.ID.String()))
+	require.NoError(t, err)
+	var actual map[string]string
+	require.NoError(t, json.Unmarshal(decrypted, &actual))
+	require.Equal(t, updatedData, actual)
+
+	_, err = encryptor.Decrypt(context.Background(), updated.Data, []byte(updated.Name))
+	require.Error(t, err)
+}

--- a/pkg/models/secret.go
+++ b/pkg/models/secret.go
@@ -123,9 +123,14 @@ func FindSecretByIDInTransaction(tx *gorm.DB, domainType string, domainID uuid.U
 }
 
 func CreateSecret(name, provider, requesterID, domainType string, domainID uuid.UUID, data []byte) (*Secret, error) {
+	return CreateSecretWithID(uuid.Nil, name, provider, requesterID, domainType, domainID, data)
+}
+
+func CreateSecretWithID(id uuid.UUID, name, provider, requesterID, domainType string, domainID uuid.UUID, data []byte) (*Secret, error) {
 	now := time.Now()
 
 	secret := Secret{
+		ID:         id,
 		Name:       name,
 		DomainType: domainType,
 		DomainID:   domainID,
@@ -134,6 +139,10 @@ func CreateSecret(name, provider, requesterID, domainType string, domainID uuid.
 		UpdatedAt:  &now,
 		Provider:   provider,
 		Data:       data,
+	}
+
+	if id == uuid.Nil {
+		secret.ID = uuid.New()
 	}
 
 	err := database.Conn().

--- a/pkg/secrets/encryption.go
+++ b/pkg/secrets/encryption.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/crypto"
@@ -19,30 +20,49 @@ func EncryptLocalData(ctx context.Context, encryptor crypto.Encryptor, secret mo
 }
 
 func DecryptLocalData(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) (map[string]string, error) {
-	plain, err := DecryptLocalDataRaw(ctx, encryptor, secret)
+	values, _, err := DecryptLocalDataWithFallback(ctx, encryptor, secret)
+	return values, err
+}
+
+func DecryptLocalDataWithFallback(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) (map[string]string, bool, error) {
+	plain, usedLegacyFallback, err := DecryptLocalDataRawWithFallback(ctx, encryptor, secret)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if len(plain) == 0 {
-		return make(map[string]string), nil
+		return make(map[string]string), usedLegacyFallback, nil
 	}
 
 	var values map[string]string
 	if err := json.Unmarshal(plain, &values); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return values, nil
+	return values, usedLegacyFallback, nil
 }
 
 func DecryptLocalDataRaw(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) ([]byte, error) {
-	plain, err := encryptor.Decrypt(ctx, secret.Data, secretAssociatedData(secret))
-	if err != nil && secret.ID != uuid.Nil && secret.Name != "" {
-		plain, err = encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
+	plain, _, err := DecryptLocalDataRawWithFallback(ctx, encryptor, secret)
+	return plain, err
+}
+
+func DecryptLocalDataRawWithFallback(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) ([]byte, bool, error) {
+	plain, primaryErr := encryptor.Decrypt(ctx, secret.Data, secretAssociatedData(secret))
+	if primaryErr == nil {
+		return plain, false, nil
 	}
 
-	return plain, err
+	if !shouldTryLegacyNameAssociatedData(secret) {
+		return nil, false, primaryErr
+	}
+
+	plain, legacyErr := encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
+	if legacyErr == nil {
+		return plain, true, nil
+	}
+
+	return nil, false, fmt.Errorf("decrypt with secret ID associated data failed: %w; decrypt with legacy name associated data failed: %v", primaryErr, legacyErr)
 }
 
 func secretAssociatedData(secret models.Secret) []byte {
@@ -51,4 +71,8 @@ func secretAssociatedData(secret models.Secret) []byte {
 	}
 
 	return []byte(secret.Name)
+}
+
+func shouldTryLegacyNameAssociatedData(secret models.Secret) bool {
+	return secret.ID != uuid.Nil && secret.Name != ""
 }

--- a/pkg/secrets/encryption.go
+++ b/pkg/secrets/encryption.go
@@ -1,0 +1,54 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func EncryptLocalData(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret, data map[string]string) ([]byte, error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return encryptor.Encrypt(ctx, raw, secretAssociatedData(secret))
+}
+
+func DecryptLocalData(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) (map[string]string, error) {
+	plain, err := DecryptLocalDataRaw(ctx, encryptor, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(plain) == 0 {
+		return make(map[string]string), nil
+	}
+
+	var values map[string]string
+	if err := json.Unmarshal(plain, &values); err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
+func DecryptLocalDataRaw(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) ([]byte, error) {
+	plain, err := encryptor.Decrypt(ctx, secret.Data, secretAssociatedData(secret))
+	if err != nil && secret.ID != uuid.Nil && secret.Name != "" {
+		plain, err = encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
+	}
+
+	return plain, err
+}
+
+func secretAssociatedData(secret models.Secret) []byte {
+	if secret.ID != uuid.Nil {
+		return []byte(secret.ID.String())
+	}
+
+	return []byte(secret.Name)
+}

--- a/pkg/secrets/encryption_test.go
+++ b/pkg/secrets/encryption_test.go
@@ -1,0 +1,46 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func TestLocalDataEncryption(t *testing.T) {
+	encryptor := crypto.NewAESGCMEncryptor([]byte("1234567890abcdefghijklmnopqrstuv"))
+	data := map[string]string{"token": "secret"}
+
+	t.Run("uses secret ID as associated data", func(t *testing.T) {
+		secret := models.Secret{ID: uuid.New(), Name: "renamable-secret"}
+
+		encrypted, err := EncryptLocalData(context.Background(), encryptor, secret, data)
+		require.NoError(t, err)
+		secret.Data = encrypted
+
+		decrypted, err := DecryptLocalData(context.Background(), encryptor, secret)
+		require.NoError(t, err)
+		require.Equal(t, data, decrypted)
+
+		_, err = encryptor.Decrypt(context.Background(), encrypted, []byte(secret.Name))
+		require.Error(t, err)
+	})
+
+	t.Run("falls back to legacy name associated data", func(t *testing.T) {
+		secret := models.Secret{ID: uuid.New(), Name: "legacy-secret"}
+		raw, err := json.Marshal(data)
+		require.NoError(t, err)
+
+		encrypted, err := encryptor.Encrypt(context.Background(), raw, []byte(secret.Name))
+		require.NoError(t, err)
+		secret.Data = encrypted
+
+		decrypted, err := DecryptLocalData(context.Background(), encryptor, secret)
+		require.NoError(t, err)
+		require.Equal(t, data, decrypted)
+	})
+}

--- a/pkg/secrets/encryption_test.go
+++ b/pkg/secrets/encryption_test.go
@@ -43,4 +43,19 @@ func TestLocalDataEncryption(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, data, decrypted)
 	})
+
+	t.Run("returns both ID and legacy decrypt failures", func(t *testing.T) {
+		secret := models.Secret{ID: uuid.New(), Name: "broken-secret"}
+		raw, err := json.Marshal(data)
+		require.NoError(t, err)
+
+		encrypted, err := encryptor.Encrypt(context.Background(), raw, []byte("wrong-associated-data"))
+		require.NoError(t, err)
+		secret.Data = encrypted
+
+		_, err = DecryptLocalDataRaw(context.Background(), encryptor, secret)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "secret ID associated data")
+		require.Contains(t, err.Error(), "legacy name associated data")
+	})
 }

--- a/pkg/secrets/local_provider.go
+++ b/pkg/secrets/local_provider.go
@@ -26,7 +26,7 @@ func NewLocalProvider(tx *gorm.DB, encryptor crypto.Encryptor, record *models.Se
 
 func (p *LocalProvider) Load(ctx context.Context) (map[string]string, error) {
 	name := p.record.Name
-	decrypted, err := p.encryptor.Decrypt(ctx, p.record.Data, []byte(name))
+	decrypted, err := DecryptLocalDataRaw(ctx, p.encryptor, *p.record)
 	if err != nil {
 		return nil, fmt.Errorf("error decrypting secret %s: %v", name, err)
 	}

--- a/pkg/workers/contexts/secrets_context.go
+++ b/pkg/workers/contexts/secrets_context.go
@@ -2,12 +2,12 @@ package contexts
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/models"
+	secretstore "github.com/superplanehq/superplane/pkg/secrets"
 	"gorm.io/gorm"
 )
 
@@ -53,17 +53,5 @@ func (c *SecretsContext) GetKey(secretName, keyName string) ([]byte, error) {
 }
 
 func (c *SecretsContext) decryptSecretData(secret *models.Secret) (map[string]string, error) {
-	plain, err := c.encryptor.Decrypt(context.Background(), secret.Data, []byte(secret.Name))
-	if err != nil {
-		return nil, err
-	}
-
-	var data map[string]string
-	if len(plain) == 0 {
-		return make(map[string]string), nil
-	}
-	if err := json.Unmarshal(plain, &data); err != nil {
-		return nil, err
-	}
-	return data, nil
+	return secretstore.DecryptLocalData(context.Background(), c.encryptor, *secret)
 }


### PR DESCRIPTION
Updates local secret encryption helpers to prefer secret ID associated data while still reading legacy name-bound payloads.

Re-encrypting secret data through update, key changes, or rename now writes ID-bound data, and worker/API reads share the same fallback path.

Refs #5884