### PR TITLE
fix: Wrap Text on the Add Secret Dialog

### DIFF
--- a/web_src/src/ui/CreateSecretDialog/index.tsx
+++ b/web_src/src/ui/CreateSecretDialog/index.tsx
@@ -56,7 +56,7 @@ interface KeyValueRowProps {
 function KeyValueRow({ pair, onChange, onRemove, disabled }: KeyValueRowProps) {
   return (
     <div className="flex gap-2 items-start">
-      <div className="flex-1">
+      <div className="flex-1 min-w-0">
         <Input
           type="text"
           value={pair.name}
@@ -71,7 +71,7 @@ function KeyValueRow({ pair, onChange, onRemove, disabled }: KeyValueRowProps) {
           onChange={(e) => onChange({ value: e.target.value })}
           placeholder="Value"
           rows={3}
-          className="font-mono text-sm"
+          className="font-mono text-sm wrap-anywhere"
           disabled={disabled}
           data-testid="secrets-create-value"
         />


### PR DESCRIPTION
## Summary
Wraps the text on the newly added add secret dialog.

<img width="714" height="492" alt="CleanShot 2026-07-05 at 20 46 11" src="https://github.com/user-attachments/assets/b914dd07-bf41-4fd4-9a61-0f07579f4371" />


Resolves: #5909 