### PR TITLE
fix: keep staged canvas changes out of live view

### DIFF
--- a/test/e2e/canvas_staging_live_view_test.go
+++ b/test/e2e/canvas_staging_live_view_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+)
+
+func TestCanvasStagingHiddenOnLiveView(t *testing.T) {
+	t.Run("staged nodes are not visible on live view until commit", func(t *testing.T) {
+		steps := &canvasStagingLiveViewSteps{t: t}
+		steps.start()
+		steps.givenACanvasOnLiveView()
+		steps.whenIEnterEditMode()
+		steps.whenIStageNode("StagedOnlyNode")
+		steps.thenNodeIsVisibleInEditor("StagedOnlyNode")
+		steps.thenNodeIsOnlyStagedNotLive("StagedOnlyNode")
+		steps.whenIExitEditMode()
+		steps.thenNodeIsHiddenOnLiveView("StagedOnlyNode")
+		steps.thenNodeIsOnlyStagedNotLive("StagedOnlyNode")
+		steps.whenIEnterEditMode()
+		steps.thenNodeIsVisibleInEditor("StagedOnlyNode")
+	})
+}
+
+type canvasStagingLiveViewSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+}
+
+func (s *canvasStagingLiveViewSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *canvasStagingLiveViewSteps) givenACanvasOnLiveView() {
+	s.canvas = shared.NewCanvasSteps("E2E Staging Live View", s.t, s.session)
+	s.canvas.Create()
+	s.canvas.Visit()
+	s.session.AssertVisible(q.TestID("canvas-edit-button"))
+}
+
+func (s *canvasStagingLiveViewSteps) whenIEnterEditMode() {
+	s.canvas.EnterEditMode()
+}
+
+func (s *canvasStagingLiveViewSteps) whenIStageNode(name string) {
+	s.canvas.AddNoop(name, models.Position{X: 500, Y: 200})
+	s.canvas.WaitForStagingOnCurrentDraft()
+	s.session.AssertVisible(q.TestID("canvas-commit-staging-button"))
+	s.canvas.ClickOnEmptyCanvasArea()
+}
+
+func (s *canvasStagingLiveViewSteps) whenIExitEditMode() {
+	s.canvas.ExitEditMode()
+}
+
+func (s *canvasStagingLiveViewSteps) thenNodeIsVisibleInEditor(nodeName string) {
+	s.session.AssertText(nodeName)
+}
+
+func (s *canvasStagingLiveViewSteps) thenNodeIsHiddenOnLiveView(nodeName string) {
+	s.session.AssertVisible(q.TestID("canvas-edit-button"))
+	s.session.AssertHidden(q.TestID("node", nodeName, "header"))
+}
+
+func (s *canvasStagingLiveViewSteps) thenNodeIsOnlyStagedNotLive(nodeName string) {
+	s.canvas.AssertHasStaging(uuid.Nil)
+	require.True(s.t, s.canvas.StagingContainsNodeForUser(s.canvas.UserIDForEmail(s.session.Account.Email), nodeName))
+	s.canvas.AssertLiveCanvasLacksNode(nodeName)
+	s.canvas.AssertLiveVersionLacksNode(nodeName)
+}

--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -12,8 +12,8 @@
     "no-eslint-disable-next-line": 3
   },
   "maxAllowedMetricMaximumByRule": {
-    "max-lines": 3829,
+    "max-lines": 3851,
     "complexity": 220
   },
-  "updatedAt": "2026-07-06T13:32:21.993Z"
+  "updatedAt": "2026-07-06T14:04:36.479Z"
 }

--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -1,10 +1,10 @@
 {
-  "maxAllowedTotalIssues": 604,
+  "maxAllowedTotalIssues": 601,
   "maxAllowedByRule": {
-    "complexity": 213,
+    "complexity": 212,
     "@typescript-eslint/no-explicit-any": 153,
-    "@typescript-eslint/no-non-null-asserted-optional-chain": 79,
-    "max-lines-per-function": 68,
+    "@typescript-eslint/no-non-null-asserted-optional-chain": 78,
+    "max-lines-per-function": 67,
     "max-statements": 62,
     "max-lines": 15,
     "max-depth": 6,
@@ -12,8 +12,8 @@
     "no-eslint-disable-next-line": 3
   },
   "maxAllowedMetricMaximumByRule": {
-    "max-lines": 3804,
-    "complexity": 221
+    "max-lines": 3829,
+    "complexity": 220
   },
-  "updatedAt": "2026-07-04T20:13:15.423Z"
+  "updatedAt": "2026-07-06T13:32:21.993Z"
 }

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -88,11 +88,16 @@ import { useWorkflowViewModeActions } from "./useWorkflowViewModeActions";
 import { useStaleRunInspectionUrlCleanup } from "./useStaleRunInspectionUrlCleanup";
 import { canEditCanvasMemory, shouldLoadCanvasMemoryEntries } from "./lib/canvas-memory-access";
 import { CanvasPageModals } from "./CanvasPageModals";
-import { shouldApplyPreservedDraftSpec, shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
+import {
+  shouldApplyPreservedDraftSpec,
+  shouldPreserveDraftSpec,
+  shouldSkipDraftSpecSyncFromLoadedVersion,
+} from "./lib/draft-canvas-sync";
 import { resolveCanvasForView, syncLoadedVersionToCanvasDetail } from "./lib/resolve-canvas-for-view";
 import {
   clearLiveEditSessionDraftState,
   clearLiveEditSessionSearchParams,
+  resetCommittedLiveCanvasDetail,
   shouldReadStagedCanvasVersion,
 } from "./lib/live-edit-session";
 import { useRefreshLatestLiveCanvasData } from "./useRefreshLatestLiveCanvasData";
@@ -417,6 +422,10 @@ export function AppPage() {
     const preservedDraftSpec = draftCanvasSpecsRef.current.get(activeCanvasVersionId);
     const nextDraftSpec = selectedCanvasVersion?.spec ?? null;
 
+    if (shouldSkipDraftSpecSyncFromLoadedVersion(draftCanvasSpec, nextDraftSpec)) {
+      return;
+    }
+
     if (shouldApplyPreservedDraftSpec(preservedDraftSpec, nextDraftSpec)) {
       setDraftCanvasSpec(preservedDraftSpec);
       return;
@@ -437,6 +446,7 @@ export function AppPage() {
     loadedCanvasVersionFetching,
     selectedCanvasVersion?.metadata?.id,
     selectedCanvasVersion?.spec,
+    draftCanvasSpec,
   ]);
   useEffect(() => {
     if (!isEditing || !activeCanvasVersionId || !liveCanvas?.spec) {
@@ -696,9 +706,7 @@ export function AppPage() {
         return;
       }
 
-      if (!isEditing) {
-        queryClient.setQueryData(canvasKeys.detail(organizationId, canvasId), updatedWorkflow);
-      }
+      queryClient.setQueryData(canvasKeys.detail(organizationId, canvasId), updatedWorkflow);
 
       if (!isEditing || !activeCanvasVersionId || !updatedWorkflow.spec) {
         return;
@@ -711,7 +719,13 @@ export function AppPage() {
       );
       queryClient.setQueryData<CanvasesCanvasVersion | undefined>(
         canvasKeys.versionStagedDetail(canvasId, activeCanvasVersionId),
-        (current) => (current ? { ...current, spec: updatedWorkflow.spec } : current),
+        (current) =>
+          current
+            ? { ...current, spec: updatedWorkflow.spec }
+            : {
+                metadata: { id: activeCanvasVersionId },
+                spec: updatedWorkflow.spec,
+              },
       );
     },
     [organizationId, canvasId, queryClient, isEditing, activeCanvasVersionId],
@@ -3580,6 +3594,14 @@ export function AppPage() {
     }
 
     if (editSessionActive) {
+      if (organizationId && canvasId) {
+        resetCommittedLiveCanvasDetail({
+          queryClient,
+          organizationId,
+          canvasId,
+          liveCanvasVersion,
+        });
+      }
       clearLiveEditSessionDraftState({
         setEditSessionActive,
         setActiveCanvasVersion,
@@ -3613,6 +3635,7 @@ export function AppPage() {
     enterLiveEditSession,
     refreshLatestLiveCanvasData,
     setSearchParams,
+    queryClient,
   ]);
 
   const exitEditableVersionForRunInspection = useCallback(() => {

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -89,6 +89,13 @@ import { useStaleRunInspectionUrlCleanup } from "./useStaleRunInspectionUrlClean
 import { canEditCanvasMemory, shouldLoadCanvasMemoryEntries } from "./lib/canvas-memory-access";
 import { CanvasPageModals } from "./CanvasPageModals";
 import { shouldApplyPreservedDraftSpec, shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
+import { resolveCanvasForView, syncLoadedVersionToCanvasDetail } from "./lib/resolve-canvas-for-view";
+import {
+  clearLiveEditSessionDraftState,
+  clearLiveEditSessionSearchParams,
+  shouldReadStagedCanvasVersion,
+} from "./lib/live-edit-session";
+import { useRefreshLatestLiveCanvasData } from "./useRefreshLatestLiveCanvasData";
 import { sortVersionsDesc } from "./lib/canvas-versions";
 import { useAppDraftStagingData } from "./useAppDraftStagingData";
 import { useCanvasEchoReleaseGuards } from "./useCanvasEchoReleaseGuards";
@@ -358,12 +365,29 @@ export function AppPage() {
 
     return canvasVersions[0]?.metadata?.id;
   }, [liveCanvasVersionId, paginatedVersions, canvasVersions]);
+  const refreshLatestLiveCanvasData = useRefreshLatestLiveCanvasData(
+    organizationId,
+    canvasId,
+    effectiveLiveCanvasVersionId,
+  );
   const activeCanvasVersionId = activeCanvasVersion?.metadata?.id || "";
+  const shouldReadStagedCanvasVersionFlag = shouldReadStagedCanvasVersion({
+    editSessionActive,
+    activeCanvasVersionId,
+    effectiveLiveCanvasVersionId,
+    liveCanvasVersionId,
+  });
   const {
     data: loadedCanvasVersion,
     isLoading: loadedCanvasVersionLoading,
     isFetching: loadedCanvasVersionFetching,
-  } = useCanvasVersion(organizationId!, canvasId!, activeCanvasVersionId, !!activeCanvasVersionId, activeCanvasVersion);
+  } = useCanvasVersion(
+    organizationId!,
+    canvasId!,
+    activeCanvasVersionId,
+    !!activeCanvasVersionId,
+    shouldReadStagedCanvasVersionFlag,
+  );
   const selectedCanvasVersion = activeCanvasVersionId ? loadedCanvasVersion || activeCanvasVersion : null;
   const isViewingCurrentLiveVersion =
     !selectedCanvasVersion ||
@@ -450,25 +474,18 @@ export function AppPage() {
     draftCanvasSpec,
   ]);
 
-  const canvas = useMemo(() => {
-    if (isEditing) {
-      if (!draftSpecToRender) return null;
-      return {
-        ...(liveCanvas ?? {}),
-        metadata: {
-          ...(liveCanvas?.metadata ?? {}),
-          id: liveCanvas?.metadata?.id ?? canvasId,
-          name: liveCanvas?.metadata?.name || "Canvas",
-          description: liveCanvas?.metadata?.description ?? "",
-        },
-        spec: draftSpecToRender,
-      };
-    }
-    if (!liveCanvas) return liveCanvas;
-    const versionSpec = selectedCanvasVersion?.spec;
-    if (!versionSpec) return liveCanvas;
-    return { ...liveCanvas, spec: versionSpec };
-  }, [liveCanvas, selectedCanvasVersion, isEditing, draftSpecToRender, canvasId]);
+  const canvas = useMemo(
+    () =>
+      resolveCanvasForView({
+        isEditing,
+        isViewingCurrentLiveVersion,
+        liveCanvas,
+        draftSpecToRender,
+        selectedCanvasVersion,
+        canvasId: canvasId!,
+      }),
+    [liveCanvas, selectedCanvasVersion, isEditing, isViewingCurrentLiveVersion, draftSpecToRender, canvasId],
+  );
 
   const [runStatusFilters, setRunStatusFilters] = useState<RunStatusFilter[]>([]);
   const runApiFilters = useMemo(
@@ -679,7 +696,9 @@ export function AppPage() {
         return;
       }
 
-      queryClient.setQueryData(canvasKeys.detail(organizationId, canvasId), updatedWorkflow);
+      if (!isEditing) {
+        queryClient.setQueryData(canvasKeys.detail(organizationId, canvasId), updatedWorkflow);
+      }
 
       if (!isEditing || !activeCanvasVersionId || !updatedWorkflow.spec) {
         return;
@@ -845,33 +864,27 @@ export function AppPage() {
   ]);
 
   useEffect(() => {
-    if (!organizationId || !canvasId || !activeCanvasVersionId || !loadedCanvasVersion?.spec || hasLocalSaveActivity) {
-      return;
-    }
-
-    const loadedVersionID = loadedCanvasVersion.metadata?.id;
-    if (!loadedVersionID || loadedVersionID !== activeCanvasVersionId) {
-      return;
-    }
-
-    const snapshotKey = `${loadedVersionID}:${loadedCanvasVersion.metadata?.updatedAt || ""}`;
-    if (lastAppliedVersionSnapshotRef.current === snapshotKey) {
-      return;
-    }
-
-    queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
-      if (!current) {
-        return current;
-      }
-
-      return {
-        ...current,
-        spec: { ...current.spec, ...loadedCanvasVersion.spec },
-      };
+    syncLoadedVersionToCanvasDetail({
+      organizationId,
+      canvasId,
+      activeCanvasVersionId,
+      loadedCanvasVersion,
+      hasLocalSaveActivity,
+      isEditing,
+      isViewingCurrentLiveVersion,
+      queryClient,
+      lastAppliedVersionSnapshotRef,
     });
-
-    lastAppliedVersionSnapshotRef.current = snapshotKey;
-  }, [organizationId, canvasId, activeCanvasVersionId, loadedCanvasVersion, queryClient, hasLocalSaveActivity]);
+  }, [
+    organizationId,
+    canvasId,
+    activeCanvasVersionId,
+    loadedCanvasVersion,
+    queryClient,
+    hasLocalSaveActivity,
+    isEditing,
+    isViewingCurrentLiveVersion,
+  ]);
 
   useEffect(() => {
     if (!remoteCanvasUpdatePending || hasLocalSaveActivity || canvasDeletedRemotely || !organizationId || !canvasId) {
@@ -3567,10 +3580,16 @@ export function AppPage() {
     }
 
     if (editSessionActive) {
-      setEditSessionActive(false);
-      if (effectiveLiveCanvasVersionId) {
-        handleUseVersion(effectiveLiveCanvasVersionId);
-      }
+      clearLiveEditSessionDraftState({
+        setEditSessionActive,
+        setActiveCanvasVersion,
+        setDraftCanvasSpec,
+        draftCanvasSpecsRef,
+        activeCanvasVersionIdRef,
+        previewingCurrentVersionRef,
+      });
+      setSearchParams(clearLiveEditSessionSearchParams);
+      void refreshLatestLiveCanvasData();
       return;
     }
 
@@ -3592,7 +3611,8 @@ export function AppPage() {
     liveCanvasVersion,
     isLiveVersionLoading,
     enterLiveEditSession,
-    handleUseVersion,
+    refreshLatestLiveCanvasData,
+    setSearchParams,
   ]);
 
   const exitEditableVersionForRunInspection = useCallback(() => {

--- a/web_src/src/pages/app/lib/draft-canvas-sync.spec.ts
+++ b/web_src/src/pages/app/lib/draft-canvas-sync.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldApplyPreservedDraftSpec, shouldPreserveDraftSpec } from "./draft-canvas-sync";
+import {
+  shouldApplyPreservedDraftSpec,
+  shouldPreserveDraftSpec,
+  shouldSkipDraftSpecSyncFromLoadedVersion,
+} from "./draft-canvas-sync";
 
 describe("shouldPreserveDraftSpec", () => {
   const liveVersionSpec = {
@@ -90,5 +94,28 @@ describe("shouldApplyPreservedDraftSpec", () => {
 
   it("keeps preserved draft spec when it already matches the staged version", () => {
     expect(shouldApplyPreservedDraftSpec(stagedSpec, stagedSpec)).toBe(true);
+  });
+});
+
+describe("shouldSkipDraftSpecSyncFromLoadedVersion", () => {
+  const localDraftSpec = {
+    nodes: [{ id: "local-node" }],
+    edges: [],
+  };
+  const loadedDraftSpec = {
+    nodes: [{ id: "loaded-node" }],
+    edges: [],
+  };
+
+  it("skips sync when local draft is ahead of the loaded version", () => {
+    expect(shouldSkipDraftSpecSyncFromLoadedVersion(localDraftSpec, loadedDraftSpec)).toBe(true);
+  });
+
+  it("allows sync when local draft is not seeded yet", () => {
+    expect(shouldSkipDraftSpecSyncFromLoadedVersion(null, loadedDraftSpec)).toBe(false);
+  });
+
+  it("allows sync when local draft already matches the loaded version", () => {
+    expect(shouldSkipDraftSpecSyncFromLoadedVersion(localDraftSpec, localDraftSpec)).toBe(false);
   });
 });

--- a/web_src/src/pages/app/lib/draft-canvas-sync.ts
+++ b/web_src/src/pages/app/lib/draft-canvas-sync.ts
@@ -59,3 +59,16 @@ export function shouldApplyPreservedDraftSpec(
 
   return getWorkflowSpecSignature(preservedDraftSpec) === getWorkflowSpecSignature(selectedDraftSpec);
 }
+
+// When local draft state is ahead of a stale loaded version query, keep the
+// local draft instead of overwriting it with older server/cache data.
+export function shouldSkipDraftSpecSyncFromLoadedVersion(
+  currentDraftSpec: CanvasesCanvas["spec"] | null | undefined,
+  nextDraftSpec: CanvasesCanvasVersion["spec"] | null | undefined,
+): boolean {
+  if (!currentDraftSpec || !nextDraftSpec) {
+    return false;
+  }
+
+  return getWorkflowSpecSignature(currentDraftSpec) !== getWorkflowSpecSignature(nextDraftSpec);
+}

--- a/web_src/src/pages/app/lib/live-edit-session.spec.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldReadStagedCanvasVersion } from "./live-edit-session";
+
+describe("shouldReadStagedCanvasVersion", () => {
+  it("reads staged content only while editing the live version", () => {
+    expect(
+      shouldReadStagedCanvasVersion({
+        editSessionActive: true,
+        activeCanvasVersionId: "live-version",
+        effectiveLiveCanvasVersionId: "live-version",
+        liveCanvasVersionId: "live-version",
+      }),
+    ).toBe(true);
+  });
+
+  it("reads committed content outside edit mode", () => {
+    expect(
+      shouldReadStagedCanvasVersion({
+        editSessionActive: false,
+        activeCanvasVersionId: "live-version",
+        effectiveLiveCanvasVersionId: "live-version",
+        liveCanvasVersionId: "live-version",
+      }),
+    ).toBe(false);
+  });
+
+  it("reads committed content when previewing a historical version in edit mode", () => {
+    expect(
+      shouldReadStagedCanvasVersion({
+        editSessionActive: true,
+        activeCanvasVersionId: "old-version",
+        effectiveLiveCanvasVersionId: "live-version",
+        liveCanvasVersionId: "live-version",
+      }),
+    ).toBe(false);
+  });
+});

--- a/web_src/src/pages/app/lib/live-edit-session.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.ts
@@ -1,0 +1,57 @@
+import type { MutableRefObject } from "react";
+
+import type { CanvasesCanvas } from "@/api-client";
+
+import { clearComponentSidebarSearchParams } from "../viewState";
+
+export function shouldReadStagedCanvasVersion({
+  editSessionActive,
+  activeCanvasVersionId,
+  effectiveLiveCanvasVersionId,
+  liveCanvasVersionId,
+}: {
+  editSessionActive: boolean;
+  activeCanvasVersionId: string;
+  effectiveLiveCanvasVersionId?: string;
+  liveCanvasVersionId?: string;
+}): boolean {
+  return (
+    editSessionActive &&
+    !!activeCanvasVersionId &&
+    ((!!effectiveLiveCanvasVersionId && activeCanvasVersionId === effectiveLiveCanvasVersionId) ||
+      activeCanvasVersionId === liveCanvasVersionId)
+  );
+}
+
+type LiveEditSessionDraftRefs = {
+  draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"]>>;
+  activeCanvasVersionIdRef: MutableRefObject<string>;
+  previewingCurrentVersionRef: MutableRefObject<boolean>;
+};
+
+export function clearLiveEditSessionDraftState({
+  setEditSessionActive,
+  setActiveCanvasVersion,
+  setDraftCanvasSpec,
+  draftCanvasSpecsRef,
+  activeCanvasVersionIdRef,
+  previewingCurrentVersionRef,
+}: LiveEditSessionDraftRefs & {
+  setEditSessionActive: (value: boolean) => void;
+  setActiveCanvasVersion: (value: null) => void;
+  setDraftCanvasSpec: (value: null) => void;
+}): void {
+  setEditSessionActive(false);
+  setActiveCanvasVersion(null);
+  setDraftCanvasSpec(null);
+  draftCanvasSpecsRef.current.clear();
+  activeCanvasVersionIdRef.current = "";
+  previewingCurrentVersionRef.current = false;
+}
+
+export function clearLiveEditSessionSearchParams(current: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(current);
+  next.delete("version");
+  next.delete("branch");
+  return clearComponentSidebarSearchParams(next);
+}

--- a/web_src/src/pages/app/lib/live-edit-session.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.ts
@@ -1,6 +1,8 @@
+import type { QueryClient } from "@tanstack/react-query";
 import type { MutableRefObject } from "react";
 
-import type { CanvasesCanvas } from "@/api-client";
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import { canvasKeys } from "@/hooks/useCanvasData";
 
 import { clearComponentSidebarSearchParams } from "../viewState";
 
@@ -24,7 +26,7 @@ export function shouldReadStagedCanvasVersion({
 }
 
 type LiveEditSessionDraftRefs = {
-  draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"]>>;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"] | null>>;
   activeCanvasVersionIdRef: MutableRefObject<string>;
   previewingCurrentVersionRef: MutableRefObject<boolean>;
 };
@@ -54,4 +56,29 @@ export function clearLiveEditSessionSearchParams(current: URLSearchParams): URLS
   next.delete("version");
   next.delete("branch");
   return clearComponentSidebarSearchParams(next);
+}
+
+export function resetCommittedLiveCanvasDetail({
+  queryClient,
+  organizationId,
+  canvasId,
+  liveCanvasVersion,
+}: {
+  queryClient: QueryClient;
+  organizationId: string;
+  canvasId: string;
+  liveCanvasVersion?: CanvasesCanvasVersion | null;
+}): void {
+  const committedSpec = liveCanvasVersion?.spec;
+  if (!committedSpec) {
+    return;
+  }
+
+  queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
+    if (!current) {
+      return current;
+    }
+
+    return { ...current, spec: committedSpec };
+  });
 }

--- a/web_src/src/pages/app/lib/resolve-canvas-for-view.spec.ts
+++ b/web_src/src/pages/app/lib/resolve-canvas-for-view.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { makeCanvas } from "@/test/factories";
+
+import { resolveCanvasForView, shouldSyncLoadedVersionToCanvasDetail } from "./resolve-canvas-for-view";
+
+describe("resolveCanvasForView", () => {
+  const liveCanvas = makeCanvas({
+    metadata: { id: "canvas-1", name: "Live" },
+    spec: { nodes: [{ id: "live-node" }], edges: [] },
+  });
+  const stagedSpec = { nodes: [{ id: "staged-node" }], edges: [] };
+
+  it("renders staged draft spec while editing the live version", () => {
+    const canvas = resolveCanvasForView({
+      isEditing: true,
+      isViewingCurrentLiveVersion: true,
+      liveCanvas,
+      draftSpecToRender: stagedSpec,
+      selectedCanvasVersion: null,
+      canvasId: "canvas-1",
+    });
+
+    expect(canvas?.spec).toEqual(stagedSpec);
+  });
+
+  it("keeps committed live canvas when not editing even if a version overlay is present", () => {
+    const canvas = resolveCanvasForView({
+      isEditing: false,
+      isViewingCurrentLiveVersion: true,
+      liveCanvas,
+      draftSpecToRender: stagedSpec,
+      selectedCanvasVersion: {
+        metadata: { id: "live-version" },
+        spec: stagedSpec,
+      },
+      canvasId: "canvas-1",
+    });
+
+    expect(canvas?.spec).toEqual(liveCanvas.spec);
+  });
+
+  it("overlays a committed historical version when previewing outside edit mode", () => {
+    const historicalSpec = { nodes: [{ id: "old-node" }], edges: [] };
+
+    const canvas = resolveCanvasForView({
+      isEditing: false,
+      isViewingCurrentLiveVersion: false,
+      liveCanvas,
+      draftSpecToRender: null,
+      selectedCanvasVersion: {
+        metadata: { id: "old-version" },
+        spec: historicalSpec,
+      },
+      canvasId: "canvas-1",
+    });
+
+    expect(canvas?.spec).toEqual(historicalSpec);
+  });
+});
+
+describe("shouldSyncLoadedVersionToCanvasDetail", () => {
+  it("skips syncing staged reads for the live version while editing", () => {
+    expect(
+      shouldSyncLoadedVersionToCanvasDetail({
+        activeCanvasVersionId: "live-version",
+        loadedCanvasVersionId: "live-version",
+        hasLocalSaveActivity: false,
+        isEditing: true,
+        isViewingCurrentLiveVersion: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips syncing version overlays onto the live canvas detail cache", () => {
+    expect(
+      shouldSyncLoadedVersionToCanvasDetail({
+        activeCanvasVersionId: "live-version",
+        loadedCanvasVersionId: "live-version",
+        hasLocalSaveActivity: false,
+        isEditing: false,
+        isViewingCurrentLiveVersion: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows syncing committed historical version previews", () => {
+    expect(
+      shouldSyncLoadedVersionToCanvasDetail({
+        activeCanvasVersionId: "old-version",
+        loadedCanvasVersionId: "old-version",
+        hasLocalSaveActivity: false,
+        isEditing: false,
+        isViewingCurrentLiveVersion: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/web_src/src/pages/app/lib/resolve-canvas-for-view.ts
+++ b/web_src/src/pages/app/lib/resolve-canvas-for-view.ts
@@ -1,0 +1,145 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { MutableRefObject } from "react";
+
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import { canvasKeys } from "@/hooks/useCanvasData";
+
+function buildEditingCanvasView(
+  liveCanvas: CanvasesCanvas | null | undefined,
+  draftSpecToRender: CanvasesCanvas["spec"],
+  canvasId: string,
+): CanvasesCanvas {
+  return {
+    ...(liveCanvas ?? {}),
+    metadata: {
+      ...(liveCanvas?.metadata ?? {}),
+      id: liveCanvas?.metadata?.id ?? canvasId,
+      name: liveCanvas?.metadata?.name || "Canvas",
+      description: liveCanvas?.metadata?.description ?? "",
+    },
+    spec: draftSpecToRender,
+  };
+}
+
+export function resolveCanvasForView({
+  isEditing,
+  isViewingCurrentLiveVersion,
+  liveCanvas,
+  draftSpecToRender,
+  selectedCanvasVersion,
+  canvasId,
+}: {
+  isEditing: boolean;
+  isViewingCurrentLiveVersion: boolean;
+  liveCanvas?: CanvasesCanvas | null;
+  draftSpecToRender: CanvasesCanvas["spec"] | null;
+  selectedCanvasVersion: CanvasesCanvasVersion | null;
+  canvasId: string;
+}): CanvasesCanvas | null | undefined {
+  if (isEditing) {
+    if (!draftSpecToRender) {
+      return null;
+    }
+
+    return buildEditingCanvasView(liveCanvas, draftSpecToRender, canvasId);
+  }
+
+  if (!liveCanvas) {
+    return liveCanvas;
+  }
+
+  const versionSpec = selectedCanvasVersion?.spec;
+  if (!versionSpec || isViewingCurrentLiveVersion) {
+    return liveCanvas;
+  }
+
+  return { ...liveCanvas, spec: versionSpec };
+}
+
+export function shouldSyncLoadedVersionToCanvasDetail({
+  activeCanvasVersionId,
+  loadedCanvasVersionId,
+  hasLocalSaveActivity,
+  isEditing,
+  isViewingCurrentLiveVersion,
+}: {
+  activeCanvasVersionId: string;
+  loadedCanvasVersionId?: string;
+  hasLocalSaveActivity: boolean;
+  isEditing: boolean;
+  isViewingCurrentLiveVersion: boolean;
+}): boolean {
+  if (!activeCanvasVersionId || !loadedCanvasVersionId || hasLocalSaveActivity) {
+    return false;
+  }
+
+  if (loadedCanvasVersionId !== activeCanvasVersionId) {
+    return false;
+  }
+
+  if (isEditing || isViewingCurrentLiveVersion) {
+    return false;
+  }
+
+  return true;
+}
+
+export function syncLoadedVersionToCanvasDetail({
+  organizationId,
+  canvasId,
+  activeCanvasVersionId,
+  loadedCanvasVersion,
+  hasLocalSaveActivity,
+  isEditing,
+  isViewingCurrentLiveVersion,
+  queryClient,
+  lastAppliedVersionSnapshotRef,
+}: {
+  organizationId?: string;
+  canvasId?: string;
+  activeCanvasVersionId: string;
+  loadedCanvasVersion?: CanvasesCanvasVersion | null;
+  hasLocalSaveActivity: boolean;
+  isEditing: boolean;
+  isViewingCurrentLiveVersion: boolean;
+  queryClient: QueryClient;
+  lastAppliedVersionSnapshotRef: MutableRefObject<string>;
+}): void {
+  if (
+    !organizationId ||
+    !canvasId ||
+    !shouldSyncLoadedVersionToCanvasDetail({
+      activeCanvasVersionId,
+      loadedCanvasVersionId: loadedCanvasVersion?.metadata?.id,
+      hasLocalSaveActivity,
+      isEditing,
+      isViewingCurrentLiveVersion,
+    }) ||
+    !loadedCanvasVersion?.spec
+  ) {
+    return;
+  }
+
+  const loadedVersionID = loadedCanvasVersion.metadata?.id;
+  if (!loadedVersionID) {
+    return;
+  }
+
+  const snapshotKey = `${loadedVersionID}:${loadedCanvasVersion.metadata?.updatedAt || ""}`;
+  if (lastAppliedVersionSnapshotRef.current === snapshotKey) {
+    return;
+  }
+
+  queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
+    if (!current) {
+      return current;
+    }
+
+    return {
+      ...current,
+      spec: { ...current.spec, ...loadedCanvasVersion.spec },
+    };
+  });
+
+  lastAppliedVersionSnapshotRef.current = snapshotKey;
+}


### PR DESCRIPTION
Fixes #5918.

Staged changes were leaking into the Live Canvas after the new editing flow. Live view now always shows committed state; staged edits only appear while editing until explicitly committed.
  - Read staged version content only during an active edit session on the live version (`shouldReadStagedCanvasVersion`)
  - Resolve live canvas from committed data when not editing (`resolveCanvasForView`)
  - Stop syncing staged version specs into the committed canvas detail cache while editing or viewing live
  - On exit edit mode, clear draft/version overlay state and refetch committed live canvas data
  - Add E2E regression: `TestCanvasStagingHiddenOnLiveView` — stage a node, exit edit mode, assert it is hidden on live view, re-enter edit mode and assert it reappears