### PR TITLE
fix: warn on unconnected action nodes

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -138,7 +138,6 @@ import {
   buildTabData,
   generateNodeId,
   generateUniqueNodeName,
-  mapCanvasNodesToLogEntries,
   getWorkflowSaveSignature,
 } from "./utils";
 import { actionsFromCapabilities, triggersFromCapabilities } from "@/lib/capabilities";
@@ -146,18 +145,20 @@ import { runPositionAutoSave } from "./runPositionAutoSave";
 import { syncRunInspectionViewportTransition } from "./lib/run-inspection-viewport";
 import {
   clearRunDetailNodeSearchParams,
+  buildCanvasLogEntries,
   getCanvasLogNodesSignature,
   getNodeAnalyticsProps,
   isCanvasLoadNotFoundError,
+  isCanvasPrepLoading,
   isValidRunId,
+  prepareCanvasLogNodes,
   prepareData,
   prepareSidebarData,
   shouldClearRunDetailNode,
 } from "./workflowPageHelpers";
 const CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY = "canvas-auto-layout-on-update-enabled";
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
-const EMPTY_CANVAS_NODES: ComponentsNode[] = [];
-const EMPTY_CANVAS_EDGES: ComponentsEdge[] = [];
+const EMPTY_CANVAS_SPEC_ITEMS: never[] = [];
 
 function updateCanvasDetailForSelectedVersion({
   queryClient,
@@ -1347,8 +1348,8 @@ export function AppPage() {
     () => buildBuildingBlockCategories(triggers, components, availableIntegrations),
     [triggers, components, availableIntegrations],
   );
-  const canvasNodes = canvas?.spec?.nodes ?? EMPTY_CANVAS_NODES;
-  const canvasEdges = canvas?.spec?.edges ?? EMPTY_CANVAS_EDGES;
+  const canvasNodes = canvas?.spec?.nodes ?? EMPTY_CANVAS_SPEC_ITEMS;
+  const canvasEdges = canvas?.spec?.edges ?? EMPTY_CANVAS_SPEC_ITEMS;
   const canvasNodesById = useMemo(() => {
     const nodesById = new Map<string, ComponentsNode>();
     canvasNodes.forEach((node) => {
@@ -1432,13 +1433,20 @@ export function AppPage() {
     triggerModalHostRef.current?.(modal);
   }, []);
 
+  const dataLoading = isCanvasPrepLoading(
+    canvas,
+    canvasLoading,
+    triggersLoading,
+    componentsLoading,
+    integrationsLoading,
+  );
   const { nodes: preparedNodes, edges: preparedEdges } = useMemo(() => {
-    if (!canvas || canvasLoading || triggersLoading || componentsLoading || integrationsLoading) {
+    if (dataLoading) {
       return { nodes: [], edges: [] };
     }
 
     return prepareData(
-      canvas,
+      canvas!,
       allTriggers,
       allComponents,
       visibleNodeEventsMap,
@@ -1459,10 +1467,7 @@ export function AppPage() {
     visibleNodeQueueItemsMap,
     canvasId,
     queryClient,
-    canvasLoading,
-    triggersLoading,
-    componentsLoading,
-    integrationsLoading,
+    dataLoading,
     me,
     canvasMode,
     openTriggerModal,
@@ -1745,31 +1750,21 @@ export function AppPage() {
     handleCanvasStagingEvent,
     () => activeCanvasVersionId || effectiveLiveCanvasVersionId || undefined,
   );
-
-  const rawLogNodes = canvasNodes;
+  const rawLogNodes = prepareCanvasLogNodes(canvasNodes, canvasEdges, allComponents, !dataLoading);
   const logNodesSignature = useMemo(() => getCanvasLogNodesSignature(rawLogNodes), [rawLogNodes]);
   const logNodesRef = useRef<{ signature: string; nodes: ComponentsNode[] }>({ signature: "", nodes: [] });
   const logNodes = useMemo(() => {
     if (logNodesRef.current.signature === logNodesSignature) {
       return logNodesRef.current.nodes;
     }
-
     logNodesRef.current = { signature: logNodesSignature, nodes: rawLogNodes };
     return rawLogNodes;
   }, [rawLogNodes, logNodesSignature]);
 
-  const logEntries = useMemo(() => {
-    return mapCanvasNodesToLogEntries({
-      nodes: logNodes,
-      workflowUpdatedAt: canvas?.metadata?.updatedAt || "",
-      onNodeSelect: handleLogNodeSelect,
-    }).sort((a, b) => {
-      const aTime = Date.parse(a.timestamp || "") || 0;
-      const bTime = Date.parse(b.timestamp || "") || 0;
-      return aTime - bTime;
-    });
-  }, [handleLogNodeSelect, canvas?.metadata?.updatedAt, logNodes]);
-
+  const logEntries = useMemo(
+    () => buildCanvasLogEntries(logNodes, canvas?.metadata?.updatedAt || "", handleLogNodeSelect),
+    [handleLogNodeSelect, canvas?.metadata?.updatedAt, logNodes],
+  );
   const nodeHistoryQuery = useNodeHistory({
     canvasId: canvasId || "",
     nodeId: currentHistoryNode?.nodeId || "",

--- a/web_src/src/pages/app/workflowPageHelpers.spec.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.spec.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  NO_INCOMING_CONNECTIONS_WARNING,
   clearRunDetailNodeSearchParams,
   isValidRunId,
   shouldClearRunDetailNode,
   shouldClearStaleRunUrl,
+  withDerivedNodeWarnings,
 } from "./workflowPageHelpers";
+import { makeComponentsNode, makeEdge } from "@/test/factories";
+import type { ActionsAction } from "@/api-client";
 
 const validRunId = "550e8400-e29b-41d4-a716-446655440000";
 
@@ -131,5 +135,55 @@ describe("workflowPageHelpers run inspection", () => {
 
     expect(unchanged.get("sidebar")).toBe("1");
     expect(unchanged.get("node")).toBe("node-b");
+  });
+});
+
+describe("withDerivedNodeWarnings", () => {
+  const componentDefinitions = [
+    {
+      name: "source",
+      outputChannels: [{ name: "success" }],
+    },
+    {
+      name: "target",
+      outputChannels: [{ name: "default" }],
+    },
+  ] as ActionsAction[];
+
+  it("warns action nodes without valid incoming connections", () => {
+    const source = makeComponentsNode({ id: "source", component: "source" });
+    const target = makeComponentsNode({ id: "target", component: "target" });
+
+    const [preparedSource, preparedTarget] = withDerivedNodeWarnings(
+      [source, target],
+      [makeEdge({ sourceId: "source", targetId: "target", channel: "default" })],
+      componentDefinitions,
+    );
+
+    expect(preparedSource.warningMessage).toBe(NO_INCOMING_CONNECTIONS_WARNING);
+    expect(preparedTarget.warningMessage).toBe(NO_INCOMING_CONNECTIONS_WARNING);
+  });
+
+  it("does not warn action nodes with valid incoming connections", () => {
+    const source = makeComponentsNode({ id: "source", component: "source" });
+    const target = makeComponentsNode({ id: "target", component: "target" });
+
+    const prepared = withDerivedNodeWarnings(
+      [source, target],
+      [makeEdge({ sourceId: "source", targetId: "target", channel: "success" })],
+      componentDefinitions,
+    );
+
+    expect(prepared.find((node) => node.id === "target")?.warningMessage).toBeUndefined();
+  });
+
+  it("does not warn trigger nodes or replace existing warnings", () => {
+    const trigger = makeComponentsNode({ id: "trigger", type: "TYPE_TRIGGER" });
+    const target = makeComponentsNode({ id: "target", component: "target", warningMessage: "Existing warning" });
+
+    const prepared = withDerivedNodeWarnings([trigger, target], [], componentDefinitions);
+
+    expect(prepared.find((node) => node.id === "trigger")?.warningMessage).toBeUndefined();
+    expect(prepared.find((node) => node.id === "target")?.warningMessage).toBe("Existing warning");
   });
 });

--- a/web_src/src/pages/app/workflowPageHelpers.spec.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.spec.ts
@@ -1,14 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   NO_INCOMING_CONNECTIONS_WARNING,
   clearRunDetailNodeSearchParams,
   isValidRunId,
+  prepareCanvasLogNodes,
   shouldClearRunDetailNode,
   shouldClearStaleRunUrl,
   withDerivedNodeWarnings,
 } from "./workflowPageHelpers";
 import { makeComponentsNode, makeEdge } from "@/test/factories";
 import type { ActionsAction } from "@/api-client";
+import { mapCanvasNodesToLogEntries } from "./utils";
 
 const validRunId = "550e8400-e29b-41d4-a716-446655440000";
 
@@ -185,5 +187,53 @@ describe("withDerivedNodeWarnings", () => {
 
     expect(prepared.find((node) => node.id === "trigger")?.warningMessage).toBeUndefined();
     expect(prepared.find((node) => node.id === "target")?.warningMessage).toBe("Existing warning");
+  });
+});
+
+describe("prepareCanvasLogNodes", () => {
+  it("includes derived connectivity warnings in canvas log entries", () => {
+    const source = makeComponentsNode({ id: "source", name: "Source", component: "source" });
+    const target = makeComponentsNode({ id: "target", name: "Target", component: "target" });
+    const logNodes = prepareCanvasLogNodes(
+      [source, target],
+      [makeEdge({ sourceId: "source", targetId: "target", channel: "default" })],
+      [
+        {
+          name: "source",
+          outputChannels: [{ name: "success" }],
+        },
+        {
+          name: "target",
+          outputChannels: [{ name: "default" }],
+        },
+      ] as ActionsAction[],
+      true,
+    );
+
+    const entries = mapCanvasNodesToLogEntries({
+      nodes: logNodes,
+      workflowUpdatedAt: "2026-07-06T16:00:00Z",
+      onNodeSelect: vi.fn(),
+    });
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.searchText)).toEqual([
+      `Source source ${NO_INCOMING_CONNECTIONS_WARNING}`,
+      `Target target ${NO_INCOMING_CONNECTIONS_WARNING}`,
+    ]);
+  });
+
+  it("keeps log nodes unchanged until component metadata is ready", () => {
+    const source = makeComponentsNode({ id: "source", name: "Source", component: "source" });
+    const target = makeComponentsNode({ id: "target", name: "Target", component: "target" });
+
+    const logNodes = prepareCanvasLogNodes(
+      [source, target],
+      [makeEdge({ sourceId: "source", targetId: "target", channel: "default" })],
+      [] as ActionsAction[],
+      false,
+    );
+
+    expect(logNodes).toEqual([source, target]);
   });
 });

--- a/web_src/src/pages/app/workflowPageHelpers.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.ts
@@ -24,6 +24,8 @@ import {
   mapTriggerEventsToSidebarEvents,
 } from "./utils";
 
+export const NO_INCOMING_CONNECTIONS_WARNING = "This node has no incoming connections and will never be triggered.";
+
 export function getNodeAnalyticsProps(
   node: ComponentsNode,
   availableIntegrations: IntegrationsIntegrationDefinition[],
@@ -86,7 +88,7 @@ export function prepareData(
   const currentUser = buildUserInfo(user);
   const edges = workflow?.spec?.edges?.map(prepareEdge) || [];
   const workflowEdges = workflow?.spec?.edges || [];
-  const workflowNodes = workflow?.spec?.nodes || [];
+  const workflowNodes = withDerivedNodeWarnings(workflow?.spec?.nodes || [], workflowEdges, components);
   const nodes =
     workflowNodes
       ?.map((node) => {
@@ -112,6 +114,82 @@ export function prepareData(
       })) || [];
 
   return { nodes, edges };
+}
+
+export function withDerivedNodeWarnings(
+  nodes: ComponentsNode[],
+  edges: ComponentsEdge[],
+  components: ActionsAction[],
+): ComponentsNode[] {
+  const nodesById = nodesByDefinedId(nodes);
+  const componentsByName = componentsByDefinedName(components);
+
+  return nodes.map((node) => {
+    if (
+      node.type !== "TYPE_ACTION" ||
+      node.warningMessage ||
+      hasValidIncomingConnection(node, edges, nodesById, componentsByName)
+    ) {
+      return node;
+    }
+
+    return {
+      ...node,
+      warningMessage: NO_INCOMING_CONNECTIONS_WARNING,
+    };
+  });
+}
+
+function hasValidIncomingConnection(
+  node: ComponentsNode,
+  edges: ComponentsEdge[],
+  nodesById: Map<string, ComponentsNode>,
+  componentsByName: Map<string, ActionsAction>,
+): boolean {
+  return edges.some((edge) => {
+    if (!node.id || edge.targetId !== node.id || !edge.sourceId) {
+      return false;
+    }
+
+    const sourceNode = nodesById.get(edge.sourceId);
+    if (!sourceNode) {
+      return false;
+    }
+
+    return getSourceOutputChannels(sourceNode, componentsByName).has(edge.channel || "default");
+  });
+}
+
+function getSourceOutputChannels(node: ComponentsNode, componentsByName: Map<string, ActionsAction>): Set<string> {
+  if (node.type !== "TYPE_ACTION") {
+    return new Set(["default"]);
+  }
+
+  const outputChannels = componentsByName
+    .get(node.component || "")
+    ?.outputChannels?.map((channel) => channel.name)
+    .filter((name): name is string => !!name);
+  return new Set(outputChannels?.length ? outputChannels : ["default"]);
+}
+
+function nodesByDefinedId(nodes: ComponentsNode[]): Map<string, ComponentsNode> {
+  const nodesById = new Map<string, ComponentsNode>();
+  for (const node of nodes) {
+    if (node.id) {
+      nodesById.set(node.id, node);
+    }
+  }
+  return nodesById;
+}
+
+function componentsByDefinedName(components: ActionsAction[]): Map<string, ActionsAction> {
+  const componentsByName = new Map<string, ActionsAction>();
+  for (const component of components) {
+    if (component.name) {
+      componentsByName.set(component.name, component);
+    }
+  }
+  return componentsByName;
 }
 
 export function prepareNode(

--- a/web_src/src/pages/app/workflowPageHelpers.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/api-client";
 import type { QueryClient } from "@tanstack/react-query";
 import type { CanvasEdge, CanvasNode, SidebarData } from "@/ui/CanvasPage";
+import type { LogEntry } from "@/ui/CanvasLogSidebar";
 import { getColorClass } from "@/lib/colors";
 import { prepareAnnotationNode } from "./lib/canvas-annotation-node";
 import { prepareComponentNode, prepareTriggerNode } from "./lib/canvas-node-preparation";
@@ -19,6 +20,7 @@ import { getNodeIntegrationName } from "./lib/node-integrations";
 import type { TriggerActionModal, User } from "./mappers/types";
 import {
   buildUserInfo,
+  mapCanvasNodesToLogEntries,
   mapExecutionsToSidebarEvents,
   mapQueueItemsToSidebarEvents,
   mapTriggerEventsToSidebarEvents,
@@ -48,6 +50,41 @@ export function getCanvasLogNodesSignature(nodes: ComponentsNode[]): string {
       warningMessage: node.warningMessage,
     })),
   );
+}
+
+export function prepareCanvasLogNodes(
+  nodes: ComponentsNode[],
+  edges: ComponentsEdge[],
+  components: ActionsAction[],
+  includeDerivedWarnings: boolean,
+): ComponentsNode[] {
+  if (!includeDerivedWarnings) {
+    return nodes;
+  }
+
+  return withDerivedNodeWarnings(nodes, edges, components);
+}
+
+export function buildCanvasLogEntries(
+  nodes: ComponentsNode[],
+  workflowUpdatedAt: string,
+  onNodeSelect: (nodeId: string) => void,
+): LogEntry[] {
+  return mapCanvasNodesToLogEntries({ nodes, workflowUpdatedAt, onNodeSelect }).sort((a, b) => {
+    const aTime = Date.parse(a.timestamp || "") || 0;
+    const bTime = Date.parse(b.timestamp || "") || 0;
+    return aTime - bTime;
+  });
+}
+
+export function isCanvasPrepLoading(
+  canvas: CanvasesCanvas | null | undefined,
+  canvasLoading: boolean,
+  triggersLoading: boolean,
+  componentsLoading: boolean,
+  integrationsLoading: boolean,
+): boolean {
+  return !canvas || canvasLoading || triggersLoading || componentsLoading || integrationsLoading;
 }
 
 // Merge a run's lightweight execution ref with the matching full execution (preferred from the


### PR DESCRIPTION
Fixes #4751

## Summary
- derive a warning for action nodes with no valid incoming connections
- treat source-channel mismatches as disconnected
- add frontend unit coverage

## Tests
- make format.js
- cd web_src && npm test -- workflowPageHelpers.spec.ts --run
- make check.lint.ui
- make check.build.ui