### PR TITLE
fix: clarify canvas yaml diff highlights

### DIFF
--- a/web_src/src/pages/app/CanvasYamlDiffModal.spec.tsx
+++ b/web_src/src/pages/app/CanvasYamlDiffModal.spec.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MultiFileDiffProps } from "@pierre/diffs/react";
+import { CanvasYamlDiffModal } from "./CanvasYamlDiffModal";
+
+type TestMultiFileDiffProps = MultiFileDiffProps<never>;
+
+const diffProps = vi.hoisted(() => ({
+  latest: null as TestMultiFileDiffProps | null,
+}));
+
+vi.mock("@pierre/diffs/react", () => ({
+  MultiFileDiff: (props: TestMultiFileDiffProps) => {
+    diffProps.latest = props;
+    return <div data-testid="multi-file-diff" />;
+  },
+}));
+
+describe("CanvasYamlDiffModal", () => {
+  beforeEach(() => {
+    diffProps.latest = null;
+  });
+
+  it("renders YAML diffs with neutral context rows and inline word highlights", () => {
+    render(
+      <CanvasYamlDiffModal
+        open
+        onOpenChange={() => undefined}
+        liveYamlText={"name: old\nshared: same\n"}
+        draftYamlText={"name: new\nshared: same\n"}
+        filename="canvas.yaml"
+      />,
+    );
+
+    expect(screen.getByTestId("multi-file-diff")).toBeInTheDocument();
+    expect(diffProps.latest?.oldFile.contents).toBe("name: old\nshared: same\n");
+    expect(diffProps.latest?.newFile.contents).toBe("name: new\nshared: same\n");
+    expect(diffProps.latest?.options?.lineDiffType).toBe("word");
+    expect(diffProps.latest?.options?.parseDiffOptions).toEqual({ context: 6 });
+    expect(diffProps.latest?.options?.unsafeCSS).toContain("--diffs-bg-context-override: #ffffff");
+    expect(diffProps.latest?.options?.unsafeCSS).toContain('[data-line-type="context"]');
+    expect(diffProps.latest?.options?.unsafeCSS).toContain("--diffs-bg-addition-emphasis-override");
+    expect(diffProps.latest?.options?.unsafeCSS).toContain("--diffs-bg-deletion-emphasis-override");
+  });
+});

--- a/web_src/src/pages/app/CanvasYamlDiffModal.tsx
+++ b/web_src/src/pages/app/CanvasYamlDiffModal.tsx
@@ -3,6 +3,7 @@ import { FileCode, XIcon } from "lucide-react";
 import { useCallback, useMemo } from "react";
 
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import { CANVAS_YAML_DIFF_OPTIONS } from "./canvasYamlDiffOptions";
 
 export type CanvasYamlDiffModalProps = {
   open: boolean;
@@ -104,35 +105,7 @@ export function CanvasYamlDiffModal({
                 newFile={newFile}
                 disableWorkerPool
                 renderCustomHeader={renderDiffHeader}
-                options={{
-                  theme: "github-light",
-                  diffStyle: "split",
-                  diffIndicators: "classic",
-                  hunkSeparators: "line-info",
-                  lineDiffType: "word",
-                  overflow: "wrap",
-                  stickyHeader: true,
-                  tokenizeMaxLineLength: 1_000,
-                  unsafeCSS: `
-                    :host {
-                      display: block;
-                      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-                      font-size: 12px;
-                      line-height: 18px;
-                    }
-
-                    [data-diffs-header] {
-                      border-bottom: 1px solid rgb(226 232 240);
-                      background: rgb(255 255 255);
-                      z-index: 5;
-                    }
-
-                    [data-diffs-header="custom"] {
-                      display: block;
-                      padding: 0;
-                    }
-                  `,
-                }}
+                options={CANVAS_YAML_DIFF_OPTIONS}
               />
             </div>
           </div>

--- a/web_src/src/pages/app/canvasYamlDiffOptions.ts
+++ b/web_src/src/pages/app/canvasYamlDiffOptions.ts
@@ -1,0 +1,45 @@
+const CANVAS_DIFF_UNSAFE_CSS = `
+  :host {
+    display: block;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 12px;
+    line-height: 18px;
+    --diffs-bg-context-override: #ffffff;
+    --diffs-bg-context-gutter-override: #ffffff;
+    --diffs-bg-deletion-override: #fee2e2;
+    --diffs-bg-addition-override: #dcfce7;
+    --diffs-bg-deletion-emphasis-override: #fecaca;
+    --diffs-bg-addition-emphasis-override: #bbf7d0;
+  }
+
+  [data-line-type="context"],
+  [data-line-type="context-expanded"] {
+    --diffs-line-bg: #ffffff;
+    --diffs-computed-diff-line-bg: #ffffff;
+    --diffs-computed-selected-line-bg: #ffffff;
+  }
+
+  [data-diffs-header] {
+    border-bottom: 1px solid rgb(226 232 240);
+    background: rgb(255 255 255);
+    z-index: 5;
+  }
+
+  [data-diffs-header="custom"] {
+    display: block;
+    padding: 0;
+  }
+`;
+
+export const CANVAS_YAML_DIFF_OPTIONS = {
+  theme: "github-light",
+  diffStyle: "split",
+  diffIndicators: "classic",
+  hunkSeparators: "line-info",
+  lineDiffType: "word",
+  overflow: "wrap",
+  stickyHeader: true,
+  tokenizeMaxLineLength: 1_000,
+  parseDiffOptions: { context: 6 },
+  unsafeCSS: CANVAS_DIFF_UNSAFE_CSS,
+} as const;


### PR DESCRIPTION
## Analysis
The YAML diff modal used the default diff context styling, so unchanged rows inside a hunk could look highlighted alongside actual additions and removals.

## Summary
- make unchanged context rows neutral
- keep add/remove rows colored and inline word highlights stronger
- add a focused modal options test

## Tests
- cd web_src && npm test -- src/pages/app/CanvasYamlDiffModal.spec.tsx --run
- make format.js
- make check.lint.ui
- make check.build.ui

Closes #5366