### PR TITLE
feat: create apps from folder headers

### DIFF
--- a/web_src/src/pages/home/CanvasFolderSection.tsx
+++ b/web_src/src/pages/home/CanvasFolderSection.tsx
@@ -1,3 +1,4 @@
+import { PermissionTooltip } from "@/components/PermissionGate";
 import { Heading } from "@/components/Heading/heading";
 import { Input } from "@/components/Input/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -5,7 +6,7 @@ import { useUpdateCanvasFolder } from "@/hooks/useCanvasData";
 import { cn } from "@/lib/utils";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { getApiErrorMessage } from "@/lib/errors";
-import { FolderOpen } from "lucide-react";
+import { FolderOpen, Plus } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -19,6 +20,7 @@ import { CanvasFolderActionsMenu } from "./CanvasFolderActionsMenu";
 import { CanvasCardsGrid } from "./CanvasCardsGrid";
 import { FOLDER_COLOR_OPTIONS, CANVAS_FOLDER_SECTION_SHELL_CLASS, folderColorStyles } from "./canvasFolderStyles";
 import type { CanvasCardData, CanvasFolderData } from "./types";
+import { useNavigate } from "react-router-dom";
 
 interface CanvasFolderSectionProps {
   folder: CanvasFolderData;
@@ -28,6 +30,7 @@ interface CanvasFolderSectionProps {
   onEditCanvas: (canvas: CanvasCardData) => void;
   onTogglePin: (canvasId: string, pinned: boolean) => void;
   onToggleStar: (canvasId: string, starred: boolean) => void;
+  canCreateCanvases: boolean;
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
   permissionsLoading: boolean;
@@ -64,6 +67,31 @@ interface SubmitCanvasFolderRenameOptions {
     backgroundColor: CanvasFolderData["backgroundColor"];
   }) => Promise<unknown>;
   setIsRenaming: (isRenaming: boolean) => void;
+}
+
+type UpdateCanvasFolderMutation = ReturnType<typeof useUpdateCanvasFolder>;
+
+interface CanvasFolderHeaderProps {
+  folder: CanvasFolderData;
+  organizationId: string;
+  canCreateCanvases: boolean;
+  canUpdateCanvases: boolean;
+  permissionsLoading: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  updateCanvasFolderMutation: UpdateCanvasFolderMutation;
+  renameInputRef: RefObject<HTMLInputElement | null>;
+  isRenaming: boolean;
+  draftTitle: string;
+  isSubmittingRenameRef: MutableRefObject<boolean>;
+  ignoreBlurUntilRef: MutableRefObject<number>;
+  onDraftTitleChange: (title: string) => void;
+  onStartRenaming: () => void;
+  onSubmitRename: () => void;
+  onCancelRenaming: () => void;
+  onFocusRenameInput: () => void;
+  onCreateAppInFolder: () => void;
+  onRenameRequest: () => void;
 }
 
 function CanvasFolderTitle({
@@ -157,6 +185,7 @@ export function CanvasFolderSection({
   onEditCanvas,
   onTogglePin,
   onToggleStar,
+  canCreateCanvases,
   canUpdateCanvases,
   canDeleteCanvases,
   permissionsLoading,
@@ -169,6 +198,7 @@ export function CanvasFolderSection({
   const isSubmittingRenameRef = useRef(false);
   const ignoreBlurUntilRef = useRef(0);
   const updateCanvasFolderMutation = useUpdateCanvasFolder(organizationId);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!isRenaming) {
@@ -224,35 +254,28 @@ export function CanvasFolderSection({
     <section
       className={cn(CANVAS_FOLDER_SECTION_SHELL_CLASS, FOLDER_COLOR_OPTIONS[folder.backgroundColor].backgroundClass)}
     >
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <CanvasFolderTitle
-            folder={folder}
-            canUpdateCanvases={canUpdateCanvases}
-            renameInputRef={renameInputRef}
-            isRenaming={isRenaming}
-            draftTitle={draftTitle}
-            isPending={updateCanvasFolderMutation.isPending}
-            onDraftTitleChange={setDraftTitle}
-            onStartRenaming={() => startRenaming()}
-            onSubmitRename={() => void submitRename()}
-            onCancelRenaming={cancelRenaming}
-            onFocusRenameInput={focusRenameInput}
-            isSubmittingRenameRef={isSubmittingRenameRef}
-            ignoreBlurUntilRef={ignoreBlurUntilRef}
-          />
-        </div>
-        <CanvasFolderActionsMenu
-          folder={folder}
-          organizationId={organizationId}
-          canUpdateCanvases={canUpdateCanvases}
-          permissionsLoading={permissionsLoading}
-          canMoveUp={canMoveUp}
-          canMoveDown={canMoveDown}
-          updateCanvasFolderMutation={updateCanvasFolderMutation}
-          onRenameRequest={startRenamingPreservingFocus}
-        />
-      </div>
+      <CanvasFolderHeader
+        folder={folder}
+        organizationId={organizationId}
+        canCreateCanvases={canCreateCanvases}
+        canUpdateCanvases={canUpdateCanvases}
+        permissionsLoading={permissionsLoading}
+        canMoveUp={canMoveUp}
+        canMoveDown={canMoveDown}
+        updateCanvasFolderMutation={updateCanvasFolderMutation}
+        renameInputRef={renameInputRef}
+        isRenaming={isRenaming}
+        draftTitle={draftTitle}
+        isSubmittingRenameRef={isSubmittingRenameRef}
+        ignoreBlurUntilRef={ignoreBlurUntilRef}
+        onDraftTitleChange={setDraftTitle}
+        onStartRenaming={() => startRenaming()}
+        onSubmitRename={() => void submitRename()}
+        onCancelRenaming={cancelRenaming}
+        onFocusRenameInput={focusRenameInput}
+        onCreateAppInFolder={() => navigate(`/${organizationId}/apps/new?folderId=${encodeURIComponent(folder.id)}`)}
+        onRenameRequest={startRenamingPreservingFocus}
+      />
 
       {canvases.length > 0 ? (
         <CanvasCardsGrid
@@ -273,6 +296,109 @@ export function CanvasFolderSection({
   );
 }
 
+function CanvasFolderHeader({
+  folder,
+  organizationId,
+  canCreateCanvases,
+  canUpdateCanvases,
+  permissionsLoading,
+  canMoveUp,
+  canMoveDown,
+  updateCanvasFolderMutation,
+  renameInputRef,
+  isRenaming,
+  draftTitle,
+  isSubmittingRenameRef,
+  ignoreBlurUntilRef,
+  onDraftTitleChange,
+  onStartRenaming,
+  onSubmitRename,
+  onCancelRenaming,
+  onFocusRenameInput,
+  onCreateAppInFolder,
+  onRenameRequest,
+}: CanvasFolderHeaderProps) {
+  return (
+    <div className="mb-4 flex items-center justify-between gap-3">
+      <div className="min-w-0 flex-1">
+        <CanvasFolderTitle
+          folder={folder}
+          canUpdateCanvases={canUpdateCanvases}
+          renameInputRef={renameInputRef}
+          isRenaming={isRenaming}
+          draftTitle={draftTitle}
+          isPending={updateCanvasFolderMutation.isPending}
+          onDraftTitleChange={onDraftTitleChange}
+          onStartRenaming={onStartRenaming}
+          onSubmitRename={onSubmitRename}
+          onCancelRenaming={onCancelRenaming}
+          onFocusRenameInput={onFocusRenameInput}
+          isSubmittingRenameRef={isSubmittingRenameRef}
+          ignoreBlurUntilRef={ignoreBlurUntilRef}
+        />
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <CreateAppInFolderButton
+          folder={folder}
+          canCreateCanvases={canCreateCanvases}
+          canUpdateCanvases={canUpdateCanvases}
+          permissionsLoading={permissionsLoading}
+          onCreate={onCreateAppInFolder}
+        />
+        <CanvasFolderActionsMenu
+          folder={folder}
+          organizationId={organizationId}
+          canUpdateCanvases={canUpdateCanvases}
+          permissionsLoading={permissionsLoading}
+          canMoveUp={canMoveUp}
+          canMoveDown={canMoveDown}
+          updateCanvasFolderMutation={updateCanvasFolderMutation}
+          onRenameRequest={onRenameRequest}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CreateAppInFolderButton({
+  folder,
+  canCreateCanvases,
+  canUpdateCanvases,
+  permissionsLoading,
+  onCreate,
+}: {
+  folder: CanvasFolderData;
+  canCreateCanvases: boolean;
+  canUpdateCanvases: boolean;
+  permissionsLoading: boolean;
+  onCreate: () => void;
+}) {
+  const colorStyles = folderColorStyles(folder.backgroundColor);
+  const canCreateInFolder = canCreateCanvases && canUpdateCanvases;
+  const allowed = canCreateInFolder || permissionsLoading;
+
+  return (
+    <PermissionTooltip
+      allowed={allowed}
+      message={getCreateAppInFolderPermissionMessage(canCreateCanvases, canUpdateCanvases)}
+    >
+      <button
+        type="button"
+        className={cn(
+          "rounded p-1 disabled:cursor-not-allowed disabled:opacity-50",
+          colorStyles.foregroundMutedClass,
+          colorStyles.headerInteractiveClass,
+        )}
+        aria-label={`Create app in folder ${folder.title}`}
+        disabled={!canCreateInFolder}
+        onClick={onCreate}
+      >
+        <Plus size={16} aria-hidden />
+      </button>
+    </PermissionTooltip>
+  );
+}
+
 function EmptyCanvasFolder({ backgroundColor }: { backgroundColor: CanvasFolderData["backgroundColor"] }) {
   const colorStyles = folderColorStyles(backgroundColor);
 
@@ -287,6 +413,18 @@ function EmptyCanvasFolder({ backgroundColor }: { backgroundColor: CanvasFolderD
       <span>No canvases in this folder</span>
     </div>
   );
+}
+
+function getCreateAppInFolderPermissionMessage(canCreateCanvases: boolean, canUpdateCanvases: boolean) {
+  if (!canCreateCanvases) {
+    return "You don't have permission to create canvases.";
+  }
+
+  if (!canUpdateCanvases) {
+    return "You don't have permission to update canvases.";
+  }
+
+  return "You don't have permission to update canvases.";
 }
 
 async function submitCanvasFolderRename({

--- a/web_src/src/pages/home/InstallProgressPanel.tsx
+++ b/web_src/src/pages/home/InstallProgressPanel.tsx
@@ -12,6 +12,7 @@ import { IntegrationIcons } from "./AppDetailModal";
 import { IntegrationsSection, type IntegrationSelections } from "./InstallIntegrationsSection";
 import { useInstallPreviewData } from "./useInstallPreviewData";
 import { useInstallAction } from "./useInstallAction";
+import type { CanvasFolderData } from "./types";
 import type { InstallParam } from "../install/types";
 import { cn } from "@/lib/utils";
 import {
@@ -37,6 +38,7 @@ function normalizeResourceValue(val: string | string[] | undefined): string {
 
 interface InstallProgressPanelProps {
   app: AppEntry;
+  folder?: CanvasFolderData;
   organizationId?: string;
   canvasName?: string;
   /** When provided, the panel renders the canvas name as an editable input. */
@@ -50,6 +52,7 @@ interface InstallProgressPanelProps {
 
 export function InstallProgressPanel({
   app,
+  folder,
   organizationId: propOrgId,
   canvasName,
   onCanvasNameChange,
@@ -81,6 +84,7 @@ export function InstallProgressPanel({
   const { doInstall, isInstalling } = useInstallAction({
     organizationId,
     app,
+    folder,
     canvasName,
     installParams: preview.installParams,
     paramValues: preview.paramValues,

--- a/web_src/src/pages/home/NewAppPage.tsx
+++ b/web_src/src/pages/home/NewAppPage.tsx
@@ -2,14 +2,17 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { HomePageShell } from "./HomePageShell";
 import { ZeroStatePage } from "./ZeroStatePage";
+import { useNewAppFolderContext } from "./useNewAppFolderContext";
 
 export function NewAppPage() {
-  usePageTitle(["New App"]);
+  const { folder, folderContextPending } = useNewAppFolderContext();
+  const title = folder ? `Create New App in ${folder.title} Folder` : "Create New App";
+  usePageTitle([title]);
   useReportPageReady(true);
 
   return (
     <HomePageShell>
-      <ZeroStatePage />
+      <ZeroStatePage folder={folder} folderContextPending={folderContextPending} title={title} />
     </HomePageShell>
   );
 }

--- a/web_src/src/pages/home/ZeroStatePage.tsx
+++ b/web_src/src/pages/home/ZeroStatePage.tsx
@@ -21,14 +21,21 @@ import {
   homePageSubtitleClassName,
   homePageTitleClassName,
 } from "./homePageStyles";
+import type { CanvasFolderData } from "./types";
 
-export function ZeroStatePage() {
-  const { createApp, isSaving } = useCreateApp();
+interface ZeroStatePageProps {
+  folder?: CanvasFolderData;
+  folderContextPending?: boolean;
+  title?: string;
+}
+
+export function ZeroStatePage({ folder, folderContextPending = false, title = "Create New App" }: ZeroStatePageProps) {
+  const { createApp, isSaving } = useCreateApp({ folder });
   const [visibleCount, setVisibleCount] = useState(7);
   const [selectedApp, setSelectedApp] = useState<AppEntry | null>(null);
   const [installingApp, setInstallingApp] = useState<AppEntry | null>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
-  const busy = isSaving || installingApp !== null;
+  const busy = folderContextPending || isSaving || installingApp !== null;
 
   const visible = APP_CATALOG.slice(0, visibleCount);
 
@@ -79,7 +86,7 @@ export function ZeroStatePage() {
       )}
       <div className="mx-auto w-full max-w-3xl px-8 py-16">
         <div className="mb-10 text-center">
-          <h1 className={homePageTitleClassName}>Create New App</h1>
+          <h1 className={homePageTitleClassName}>{title}</h1>
           <p className={homePageSubtitleClassName}>Create a blank app or pick one from the catalog below.</p>
         </div>
 
@@ -104,6 +111,7 @@ export function ZeroStatePage() {
               onSelect={setSelectedApp}
               onInstall={handleInstall}
               onCloseInstall={() => setInstallingApp(null)}
+              folder={folder}
             />
           ))}
           {visibleCount < APP_CATALOG.length && <div ref={sentinelRef} className="h-1" />}
@@ -138,6 +146,7 @@ function AppListItem({
   onInstall,
   onSelect,
   onCloseInstall,
+  folder,
 }: {
   app: AppEntry;
   busy: boolean;
@@ -145,6 +154,7 @@ function AppListItem({
   onInstall: (app: AppEntry) => void;
   onSelect: (app: AppEntry) => void;
   onCloseInstall: () => void;
+  folder?: CanvasFolderData;
 }) {
   return (
     <>
@@ -185,7 +195,7 @@ function AppListItem({
           </div>
         </div>
       </div>
-      {isInstalling && <InstallProgressPanel app={app} onClose={onCloseInstall} />}
+      {isInstalling && <InstallProgressPanel app={app} folder={folder} onClose={onCloseInstall} />}
     </>
   );
 }

--- a/web_src/src/pages/home/canvasFolderMembership.ts
+++ b/web_src/src/pages/home/canvasFolderMembership.ts
@@ -1,0 +1,10 @@
+import type { CanvasFolderData } from "./types";
+
+export function appendCanvasToFolderMembership(folder: CanvasFolderData, canvasId: string) {
+  return {
+    folderId: folder.id,
+    title: folder.title,
+    backgroundColor: folder.backgroundColor,
+    canvasIds: folder.canvasIds.includes(canvasId) ? folder.canvasIds : [...folder.canvasIds, canvasId],
+  };
+}

--- a/web_src/src/pages/home/index.spec.tsx
+++ b/web_src/src/pages/home/index.spec.tsx
@@ -8,14 +8,13 @@ import type { CanvasFoldersCanvasFolder, CanvasesCanvasSummary } from "@/api-cli
 import type { ReactNode } from "react";
 import { showErrorToast } from "@/lib/toast";
 
-vi.stubGlobal(
-  "ResizeObserver",
-  class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  },
-);
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
 
 const {
   useCanvases,
@@ -54,6 +53,12 @@ const mutationMocks = vi.hoisted(() => ({
   updateCanvasPreference: vi.fn(),
 }));
 
+type CanAct = (resource: string, action: string) => boolean;
+
+const permissionMocks = vi.hoisted(() => ({
+  canAct: vi.fn<CanAct>(() => true),
+}));
+
 vi.mock("@/components/OrganizationMenuButton", () => ({
   OrganizationMenuButton: () => null,
 }));
@@ -75,7 +80,7 @@ vi.mock("@/contexts/useAccount", () => ({
 
 vi.mock("@/contexts/usePermissions", () => ({
   usePermissions: () => ({
-    canAct: () => true,
+    canAct: permissionMocks.canAct,
     isLoading: false,
   }),
 }));
@@ -155,7 +160,7 @@ function makeFolder(
   } as CanvasFoldersCanvasFolder;
 }
 
-function renderHome() {
+function renderHome(initialEntries = ["/org-123"]) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -165,11 +170,12 @@ function renderHome() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={["/org-123"]}>
+      <MemoryRouter initialEntries={initialEntries}>
         <Routes>
           <Route path="/:organizationId">
             <Route index element={<HomePage />} />
             <Route path="apps/new" element={<NewAppPage />} />
+            <Route path="apps/:canvasId" element={<div>Canvas editor</div>} />
           </Route>
         </Routes>
       </MemoryRouter>
@@ -179,8 +185,11 @@ function renderHome() {
 
 describe("HomePage canvas folders", () => {
   beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
     vi.clearAllMocks();
     window.localStorage.clear();
+    permissionMocks.canAct.mockReturnValue(true);
     mutationMocks.createCanvasFolder.mockResolvedValue({ data: { folder: { metadata: { id: "new-folder" } } } });
     mutationMocks.updateCanvasFolder.mockResolvedValue({});
     mutationMocks.moveCanvasFolder.mockResolvedValue({});
@@ -404,6 +413,133 @@ describe("HomePage canvas folders", () => {
 
     await user.click(screen.getByLabelText("Folder actions"));
     expect(await screen.findByText("Change folder name")).toBeInTheDocument();
+  });
+
+  it("opens the new app page scoped to a folder", async () => {
+    const user = userEvent.setup();
+    mutationMocks.createCanvasAsync.mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-new" } } },
+    });
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({
+      data: [makeFolder("folder-1", "Deployments", "green", ["existing-canvas"])],
+      isLoading: false,
+      error: null,
+    });
+
+    renderHome();
+    const deploymentsSection = screen.getByText("Deployments").closest("section")!;
+    await user.click(within(deploymentsSection).getByLabelText("Create app in folder Deployments"));
+    expect(await screen.findByRole("heading", { name: "Create New App in Deployments Folder" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /start from scratch/i }));
+
+    await waitFor(() => {
+      expect(mutationMocks.createCanvasAsync).toHaveBeenCalledWith({
+        name: expect.stringMatching(/^[a-z]+-[a-z]+$/),
+        method: "ui",
+      });
+      expect(mutationMocks.updateCanvasFolderMembership).toHaveBeenCalledWith({
+        folderId: "folder-1",
+        title: "Deployments",
+        backgroundColor: "green",
+        canvasIds: ["existing-canvas", "canvas-new"],
+      });
+    });
+  });
+
+  it("opens a folder-scoped new app when folder membership update fails", async () => {
+    const user = userEvent.setup();
+    mutationMocks.createCanvasAsync.mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-new" } } },
+    });
+    mutationMocks.updateCanvasFolderMembership.mockRejectedValue(new Error("Failed to fetch"));
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({
+      data: [makeFolder("folder-1", "Deployments", "green")],
+      isLoading: false,
+      error: null,
+    });
+
+    renderHome();
+    const deploymentsSection = screen.getByText("Deployments").closest("section")!;
+    await user.click(within(deploymentsSection).getByLabelText("Create app in folder Deployments"));
+    await user.click(await screen.findByRole("button", { name: /start from scratch/i }));
+
+    expect(await screen.findByText("Canvas editor")).toBeInTheDocument();
+    expect(showErrorToast).toHaveBeenCalledWith("App created, but failed to add it to folder");
+  });
+
+  it("opens a folder-scoped installed app when folder membership update fails", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ integrations: [], installParams: [] }), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ canvasId: "canvas-installed", organizationId: "org-123" }), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    mutationMocks.updateCanvasFolderMembership.mockRejectedValue(new Error("Failed to fetch"));
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({
+      data: [makeFolder("folder-1", "Deployments", "green")],
+      isLoading: false,
+      error: null,
+    });
+
+    renderHome(["/org-123/apps/new?folderId=folder-1"]);
+    await user.click((await screen.findAllByRole("button", { name: "Install" }))[0]);
+    await user.click(await screen.findByRole("button", { name: "Just take me there" }));
+
+    expect(await screen.findByText("Canvas editor")).toBeInTheDocument();
+    expect(showErrorToast).toHaveBeenCalledWith("App installed, but failed to add it to folder");
+  });
+
+  it("disables folder header creation without update permission", async () => {
+    permissionMocks.canAct.mockImplementation((_resource: string, action: string) => action !== "update");
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({
+      data: [makeFolder("folder-1", "Deployments", "green")],
+      isLoading: false,
+      error: null,
+    });
+
+    renderHome();
+    const deploymentsSection = screen.getByText("Deployments").closest("section")!;
+
+    expect(within(deploymentsSection).getByLabelText("Create app in folder Deployments")).toBeDisabled();
+  });
+
+  it("does not create from a folder-scoped new app URL without update permission", async () => {
+    const user = userEvent.setup();
+    permissionMocks.canAct.mockImplementation((_resource: string, action: string) => action !== "update");
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({
+      data: [makeFolder("folder-1", "Deployments", "green")],
+      isLoading: false,
+      error: null,
+    });
+
+    renderHome(["/org-123/apps/new?folderId=folder-1"]);
+    await user.click(await screen.findByRole("button", { name: /start from scratch/i }));
+
+    expect(mutationMocks.createCanvasAsync).not.toHaveBeenCalled();
+    expect(showErrorToast).toHaveBeenCalledWith("You don't have permission to update canvases.");
+  });
+
+  it("does not create outside a folder while folder context is loading", async () => {
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({
+      data: [],
+      isLoading: true,
+      error: null,
+    });
+
+    renderHome(["/org-123/apps/new?folderId=folder-1"]);
+
+    expect(await screen.findByRole("button", { name: /start from scratch/i })).toBeDisabled();
+    expect(screen.getAllByRole("button", { name: "Install" })[0]).toBeDisabled();
+    expect(mutationMocks.createCanvasAsync).not.toHaveBeenCalled();
   });
 
   it("adds a canvas to an existing folder", async () => {

--- a/web_src/src/pages/home/index.tsx
+++ b/web_src/src/pages/home/index.tsx
@@ -44,6 +44,7 @@ export function HomePage() {
   );
   const updateCanvasPreference = useUpdateCanvasPreference(organizationId || "");
   const preferredFilteredCanvases = applyCanvasAppPreferences(filteredCanvases);
+  const canCreateCanvases = canAct("canvases", "create");
   const canUpdateCanvases = canAct("canvases", "update");
   const canDeleteCanvases = canAct("canvases", "delete");
 
@@ -89,6 +90,7 @@ export function HomePage() {
             onEditCanvas={openEdit}
             onTogglePin={(canvasId, pinned) => updateCanvasPreference.mutate({ canvasId, pinned })}
             onToggleStar={(canvasId, starred) => updateCanvasPreference.mutate({ canvasId, starred })}
+            canCreateCanvases={canCreateCanvases}
             canUpdateCanvases={canUpdateCanvases}
             canDeleteCanvases={canDeleteCanvases}
             permissionsLoading={permissionsLoading}
@@ -117,6 +119,7 @@ function Content({
   onEditCanvas,
   onTogglePin,
   onToggleStar,
+  canCreateCanvases,
   canUpdateCanvases,
   canDeleteCanvases,
   permissionsLoading,
@@ -129,6 +132,7 @@ function Content({
   onEditCanvas: (canvas: CanvasCardData) => void;
   onTogglePin: (canvasId: string, pinned: boolean) => void;
   onToggleStar: (canvasId: string, starred: boolean) => void;
+  canCreateCanvases: boolean;
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
   permissionsLoading: boolean;
@@ -187,6 +191,7 @@ function Content({
           onEditCanvas={onEditCanvas}
           onTogglePin={onTogglePin}
           onToggleStar={onToggleStar}
+          canCreateCanvases={canCreateCanvases}
           canUpdateCanvases={canUpdateCanvases}
           canDeleteCanvases={canDeleteCanvases}
           permissionsLoading={permissionsLoading}

--- a/web_src/src/pages/home/useCreateApp.tsx
+++ b/web_src/src/pages/home/useCreateApp.tsx
@@ -1,40 +1,62 @@
 import { useCallback } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { usePermissions } from "@/contexts/usePermissions";
-import { useCreateCanvas } from "@/hooks/useCanvasData";
+import { useCreateCanvas, useUpdateCanvasFolderMembership } from "@/hooks/useCanvasData";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { showErrorToast } from "@/lib/toast";
+import { getApiErrorMessage } from "@/lib/errors";
 import { PLACEHOLDER_NODE_CONTEXT_KEY, setAgentBootContext } from "@/lib/agentBootContext";
 import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { writeCanvasRunsSidebarOpen } from "@/components/CanvasRunsSidebar/useCanvasRunsSidebarState";
 import { appPath } from "@/lib/appPaths";
+import { appendCanvasToFolderMembership } from "./canvasFolderMembership";
+import type { CanvasFolderData } from "./types";
 
 interface UseCreateAppOptions {
+  folder?: CanvasFolderData;
   onCreated?: () => void;
 }
 
-export function useCreateApp({ onCreated }: UseCreateAppOptions = {}) {
+export function useCreateApp({ folder, onCreated }: UseCreateAppOptions = {}) {
   const { organizationId } = useParams<{ organizationId: string }>();
   const navigate = useNavigate();
   const { canAct } = usePermissions();
   const createCanvasMutation = useCreateCanvas(organizationId || "");
+  const updateCanvasFolderMembershipMutation = useUpdateCanvasFolderMembership(organizationId || "");
+  const { mutateAsync: createCanvas } = createCanvasMutation;
+  const { mutateAsync: updateCanvasFolderMembership } = updateCanvasFolderMembershipMutation;
 
   const canCreateCanvases = canAct("canvases", "create");
+  const canUpdateCanvases = canAct("canvases", "update");
+  const isSaving = createCanvasMutation.isPending || updateCanvasFolderMembershipMutation.isPending;
 
   const createApp = useCallback(
     async (name: string) => {
-      if (!organizationId || !canCreateCanvases || createCanvasMutation.isPending) {
+      if (!organizationId || !canCreateCanvases || isSaving) {
+        return;
+      }
+
+      if (folder && !canUpdateCanvases) {
+        showErrorToast("You don't have permission to update canvases.");
         return;
       }
 
       try {
-        const result = await createCanvasMutation.mutateAsync({
+        const result = await createCanvas({
           name,
           method: "ui",
         });
 
         const canvasId = result?.data?.canvas?.metadata?.id;
         if (canvasId) {
+          if (folder) {
+            try {
+              await updateCanvasFolderMembership(appendCanvasToFolderMembership(folder, canvasId));
+            } catch (error) {
+              showErrorToast(getApiErrorMessage(error, "App created, but failed to add it to folder"));
+            }
+          }
+
           onCreated?.();
           // A new app always starts with the agent panel open (stored per canvas).
           writeCanvasAgentSidebarOpen(canvasId, true);
@@ -49,11 +71,21 @@ export function useCreateApp({ onCreated }: UseCreateAppOptions = {}) {
         throw error;
       }
     },
-    [canCreateCanvases, createCanvasMutation, navigate, onCreated, organizationId],
+    [
+      canCreateCanvases,
+      canUpdateCanvases,
+      createCanvas,
+      folder,
+      isSaving,
+      navigate,
+      onCreated,
+      organizationId,
+      updateCanvasFolderMembership,
+    ],
   );
 
   return {
     createApp,
-    isSaving: createCanvasMutation.isPending,
+    isSaving,
   };
 }

--- a/web_src/src/pages/home/useInstallAction.ts
+++ b/web_src/src/pages/home/useInstallAction.ts
@@ -1,7 +1,8 @@
 import { useCallback, useRef, useState } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import type { QueryClient } from "@tanstack/react-query";
-import { canvasKeys } from "@/hooks/useCanvasData";
+import { canvasKeys, useUpdateCanvasFolderMembership } from "@/hooks/useCanvasData";
+import { usePermissions } from "@/contexts/usePermissions";
 import { generateCanvasName } from "@/lib/canvasNameGenerator";
 import { setAgentBootContext } from "@/lib/agentBootContext";
 import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
@@ -11,7 +12,9 @@ import { getApiErrorMessage } from "@/lib/errors";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { appPath } from "@/lib/appPaths";
 import type { AppEntry } from "./AppDetailModal";
+import { appendCanvasToFolderMembership } from "./canvasFolderMembership";
 import type { IntegrationSelections } from "./InstallIntegrationsSection";
+import type { CanvasFolderData } from "./types";
 import type { InstallParam } from "../install/types";
 
 async function executeInstall(opts: {
@@ -54,6 +57,7 @@ function prepareAgentSidebar(app: AppEntry, canvasId: string) {
 interface UseInstallActionOptions {
   organizationId: string | undefined;
   app: AppEntry;
+  folder?: CanvasFolderData;
   canvasName?: string;
   installParams: InstallParam[];
   paramValues: Record<string, string>;
@@ -65,6 +69,7 @@ interface UseInstallActionOptions {
 export function useInstallAction({
   organizationId,
   app,
+  folder,
   canvasName,
   installParams,
   paramValues,
@@ -74,10 +79,19 @@ export function useInstallAction({
 }: UseInstallActionOptions) {
   const [isInstalling, setIsInstalling] = useState(false);
   const isInstallingRef = useRef(false);
+  const updateCanvasFolderMembershipMutation = useUpdateCanvasFolderMembership(organizationId || "");
+  const { mutateAsync: updateCanvasFolderMembership } = updateCanvasFolderMembershipMutation;
+  const { canAct } = usePermissions();
+  const canUpdateCanvases = canAct("canvases", "update");
 
   const doInstall = useCallback(
     async (skipParams: boolean) => {
       if (!organizationId || isInstallingRef.current) return;
+      if (folder && !canUpdateCanvases) {
+        showErrorToast("You don't have permission to update canvases.");
+        return;
+      }
+
       isInstallingRef.current = true;
       setIsInstalling(true);
       try {
@@ -88,6 +102,14 @@ export function useInstallAction({
           installParams: !skipParams && installParams.length > 0 ? paramValues : undefined,
           integrations: integrationSelections,
         });
+        if (folder) {
+          try {
+            await updateCanvasFolderMembership(appendCanvasToFolderMembership(folder, result.canvasId));
+          } catch (error) {
+            showErrorToast(getApiErrorMessage(error, "App installed, but failed to add it to folder"));
+          }
+        }
+
         await queryClient.refetchQueries({ queryKey: canvasKeys.list(result.organizationId) });
         prepareAgentSidebar(app, result.canvasId);
         navigate(appPath(result.organizationId, result.canvasId, "?edit=1"));
@@ -97,7 +119,19 @@ export function useInstallAction({
         showErrorToast(getUsageLimitToastMessage(error, getApiErrorMessage(error, "Failed to install")));
       }
     },
-    [organizationId, app, canvasName, paramValues, installParams, integrationSelections, queryClient, navigate],
+    [
+      organizationId,
+      app,
+      canUpdateCanvases,
+      canvasName,
+      folder,
+      paramValues,
+      installParams,
+      integrationSelections,
+      queryClient,
+      navigate,
+      updateCanvasFolderMembership,
+    ],
   );
 
   return { doInstall, isInstalling };

--- a/web_src/src/pages/home/useNewAppFolderContext.ts
+++ b/web_src/src/pages/home/useNewAppFolderContext.ts
@@ -1,0 +1,41 @@
+import type { CanvasFoldersCanvasFolder } from "@/api-client";
+import { normalizeCanvasFolderColor, useCanvasFolders } from "@/hooks/useCanvasData";
+import { useMemo } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import type { CanvasFolderData } from "./types";
+
+export function useNewAppFolderContext() {
+  const { organizationId } = useParams<{ organizationId: string }>();
+  const [searchParams] = useSearchParams();
+  const folderId = searchParams.get("folderId") || undefined;
+  const { data: canvasFolders = [], isLoading } = useCanvasFolders(organizationId || "");
+
+  const folder = useMemo(() => {
+    if (!folderId) {
+      return undefined;
+    }
+
+    const matchingFolder = canvasFolders.find((item) => item.metadata?.id === folderId);
+    return matchingFolder ? toCanvasFolderData(matchingFolder) : undefined;
+  }, [canvasFolders, folderId]);
+
+  return {
+    folder,
+    folderContextPending: Boolean(folderId && isLoading),
+  };
+}
+
+function toCanvasFolderData(folder: CanvasFoldersCanvasFolder): CanvasFolderData | undefined {
+  const id = folder.metadata?.id || "";
+  const title = folder.spec?.title || "";
+  if (!id || !title) {
+    return undefined;
+  }
+
+  return {
+    id,
+    title,
+    backgroundColor: normalizeCanvasFolderColor(folder.spec?.backgroundColor),
+    canvasIds: folder.spec?.canvases?.map((canvas) => canvas.id || "").filter(Boolean) || [],
+  };
+}


### PR DESCRIPTION
## Summary
- add a plus button to each folder header on the home page
- create a blank app, assign it to that folder, then open it in edit mode
- cover the folder-header create flow with a home-page regression test

Closes #5867

## Tests
- docker compose -f docker-compose.dev.yml exec app bash -c "cd web_src && npm run test:run -- src/pages/home/index.spec.tsx"
- make check.lint.ui
- make check.build.ui