### PR TITLE
fix: stabilize enter-edit staging bootstrap and canvas cache reads

### DIFF
--- a/web_src/src/hooks/useCanvasData.spec.ts
+++ b/web_src/src/hooks/useCanvasData.spec.ts
@@ -432,7 +432,7 @@ describe("useUpdateCanvasConsole", () => {
 
   it("optimistically updates the dashboard cache while console changes are saving", async () => {
     const queryClient = createQueryClient();
-    const dashboardKey = canvasKeys.consoleStaged("canvas-1", "version-1");
+    const dashboardKey = canvasKeys.stagedConsole("canvas-1");
     let resolveSave: (value: unknown) => void = () => {};
     const savePromise = new Promise((resolve) => {
       resolveSave = resolve;
@@ -475,7 +475,7 @@ describe("useUpdateCanvasConsole", () => {
 
   it("rolls back the dashboard cache when console save fails", async () => {
     const queryClient = createQueryClient();
-    const dashboardKey = canvasKeys.consoleStaged("canvas-1", "version-1");
+    const dashboardKey = canvasKeys.stagedConsole("canvas-1");
     queryClient.setQueryData(dashboardKey, {
       canvasId: "canvas-1",
       versionId: "version-1",

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -50,7 +50,8 @@ import { registerLocalStagingWrite } from "../lib/canvasStagingEcho";
 import { analytics } from "../lib/analytics";
 import {
   canvasVersionWithSpecFromYaml,
-  fetchCanvasVersionWithSpec,
+  fetchCommittedCanvasVersionWithSpec,
+  fetchStagedCanvasVersionWithSpec,
   fetchCanvasStagingSummary,
   fetchConsoleSpecFromRepository,
   fetchRepositorySpecFileContent,
@@ -132,13 +133,8 @@ export const canvasKeys = {
   versionDetails: () => [...canvasKeys.versions(), "detail"] as const,
   versionDetail: (canvasId: string, versionId: string) =>
     [...canvasKeys.versionDetails(), canvasId, versionId] as const,
-  // Staged reads overlay uncommitted edits on the committed version. They must
-  // not share the committed `versionDetail` cache entry, otherwise a committed
-  // (stage=false) fetch for the same version overwrites the staged content and
-  // the editor loses pending edits. Kept as a prefix-extension of versionDetail
-  // so prefix invalidations of versionDetail also refresh the staged read.
-  versionStagedDetail: (canvasId: string, versionId: string) =>
-    [...canvasKeys.versionDetails(), canvasId, versionId, "staged"] as const,
+  // Canvas-scoped staging reads. Staging belongs to the canvas/user, not a version.
+  stagedCanvasSpec: (canvasId: string) => [...canvasKeys.all, "stagedCanvasSpec", canvasId] as const,
   canvasStaging: (canvasId: string) => [...canvasKeys.versions(), "staging", canvasId] as const,
   nodeExecutions: () => [...canvasKeys.all, "nodeExecutions"] as const,
   nodeExecution: (canvasId: string, nodeId: string, states?: string[], limit?: number) =>
@@ -175,12 +171,8 @@ export const canvasKeys = {
   canvasMemoryEntries: (canvasId: string) => [...canvasKeys.all, "memoryEntries", canvasId] as const,
   console: (canvasId: string, versionId?: string) =>
     [...canvasKeys.all, "console", canvasId, versionId ?? "live"] as const,
-  // Staged console overlays uncommitted edits; kept separate from the committed
-  // `console` entry so a committed (stage=false) refetch cannot overwrite the
-  // editor's pending edits. Prefix-extends `console`, so invalidating `console`
-  // (or `consoleAll`) also refreshes the staged read.
-  consoleStaged: (canvasId: string, versionId?: string) =>
-    [...canvasKeys.console(canvasId, versionId), "staged"] as const,
+  // Canvas-scoped staged console overlays uncommitted edits.
+  stagedConsole: (canvasId: string) => [...canvasKeys.all, "console", canvasId, "staged"] as const,
   consoleAll: (canvasId: string) => [...canvasKeys.all, "console", canvasId] as const,
   repository: (canvasId: string) => [...canvasKeys.all, "repository", canvasId] as const,
   repositoryFiles: (canvasId: string) => [...canvasKeys.repository(canvasId), "files"] as const,
@@ -195,12 +187,20 @@ export const canvasKeys = {
 };
 
 function canvasVersionScopedQueryKeys(canvasId: string, versionId: string) {
-  return [
-    canvasKeys.versionDetail(canvasId, versionId),
-    canvasKeys.versionStagedDetail(canvasId, versionId),
-    canvasKeys.console(canvasId, versionId),
-    canvasKeys.consoleStaged(canvasId, versionId),
-  ];
+  return [canvasKeys.versionDetail(canvasId, versionId), canvasKeys.console(canvasId, versionId)];
+}
+
+export function invalidateStagedCanvasCaches(queryClient: QueryClient, canvasId: string): void {
+  queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId) });
+  queryClient.invalidateQueries({ queryKey: canvasKeys.stagedCanvasSpec(canvasId) });
+  queryClient.invalidateQueries({ queryKey: canvasKeys.stagedConsole(canvasId) });
+  queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId) });
+  queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      return Array.isArray(key) && key.includes(canvasId) && key[key.length - 1] === "staged";
+    },
+  });
 }
 
 function isVersionScopedRepositoryQuery(queryKey: readonly unknown[], canvasId: string, versionId: string): boolean {
@@ -229,12 +229,6 @@ export function removeCanvasVersionScopedQueries(queryClient: QueryClient, canva
 export async function cancelCanvasVersionQueries(queryClient: QueryClient, canvasId: string, versionId: string) {
   await Promise.all(
     canvasVersionScopedQueryKeys(canvasId, versionId).map((queryKey) => queryClient.cancelQueries({ queryKey })),
-  );
-}
-
-export async function invalidateCanvasVersionQueries(queryClient: QueryClient, canvasId: string, versionId: string) {
-  await Promise.all(
-    canvasVersionScopedQueryKeys(canvasId, versionId).map((queryKey) => queryClient.invalidateQueries({ queryKey })),
   );
 }
 
@@ -405,28 +399,27 @@ export const useInfiniteCanvasLiveVersions = (
   });
 };
 
-function resolveCanvasVersionStage(stage: boolean | CanvasesCanvasVersion | null | undefined): boolean {
-  if (typeof stage === "boolean") {
-    return stage;
-  }
-
-  return !!stage;
-}
-
-export const useCanvasVersion = (
-  organizationId: string,
-  canvasId: string,
-  versionId: string,
-  enabled = true,
-  stage: boolean | CanvasesCanvasVersion | null = false,
-) => {
-  const readStaged = resolveCanvasVersionStage(stage);
+export const useCanvasVersion = (organizationId: string, canvasId: string, versionId: string, enabled = true) => {
   return useQuery({
-    queryKey: readStaged
-      ? canvasKeys.versionStagedDetail(canvasId, versionId)
-      : canvasKeys.versionDetail(canvasId, versionId),
-    queryFn: async () => fetchCanvasVersionWithSpec(canvasId, versionId, readStaged),
+    queryKey: canvasKeys.versionDetail(canvasId, versionId),
+    queryFn: async () => fetchCommittedCanvasVersionWithSpec(canvasId, versionId),
     enabled: !!organizationId && !!canvasId && !!versionId && enabled,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+};
+
+export const useStagedCanvasSpec = (
+  canvasId: string,
+  versionMetadata: CanvasesCanvasVersion | null | undefined,
+  enabled = true,
+) => {
+  const versionId = versionMetadata?.metadata?.id;
+  return useQuery({
+    queryKey: canvasKeys.stagedCanvasSpec(canvasId),
+    queryFn: async () => fetchStagedCanvasVersionWithSpec(canvasId, versionMetadata ?? undefined),
+    enabled: !!canvasId && !!versionId && enabled,
+    staleTime: Number.POSITIVE_INFINITY,
+    refetchOnMount: false,
   });
 };
 
@@ -442,10 +435,6 @@ export const useCanvasStaging = (canvasId: string | undefined, enabled = true) =
     staleTime: 0,
   });
 };
-
-/** @deprecated Use useCanvasStaging — staging is canvas-scoped, not per-version. */
-export const useCanvasVersionStaging = (canvasId: string, _versionId: string | undefined, enabled = true) =>
-  useCanvasStaging(canvasId, enabled);
 
 type CanvasGraphData = {
   nodes?: unknown[];
@@ -930,20 +919,21 @@ export const useUpdateCanvasVersion = (canvasId: string) => {
       }
 
       const [canvasYaml, stagingSummary] = await Promise.all([
-        fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH, data.versionId, true),
+        fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH, undefined, true),
         fetchCanvasStagingSummary(canvasId),
       ]);
 
-      const version = versionWithSpecFromYaml(
+      const versionShell =
+        queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.versionDetail(canvasId, data.versionId)) ??
         (
           await canvasesDescribeCanvasVersion(
             withOrganizationHeader({
               path: { canvasId, versionId: data.versionId },
             }),
           )
-        ).data?.version,
-        canvasYaml,
-      );
+        ).data?.version;
+
+      const version = versionWithSpecFromYaml(versionShell, canvasYaml);
       return { data: { canvasYaml, version, stagingSummary } };
     },
     onSuccess: (response, variables) => {
@@ -963,10 +953,8 @@ export const useUpdateCanvasVersion = (canvasId: string) => {
       }
 
       if (variables.versionId) {
-        // `version` carries the effective staged spec (fetched with stage=true),
-        // so it belongs to the staged cache entry the editor reads — not the
-        // committed version list used when previewing historical versions.
-        queryClient.setQueryData(canvasKeys.versionStagedDetail(canvasId, variables.versionId), version);
+        // Effective staged spec belongs in the canvas-scoped staging cache.
+        queryClient.setQueryData(canvasKeys.stagedCanvasSpec(canvasId), version);
       }
     },
   });
@@ -1530,10 +1518,10 @@ export const useCanvasConsole = (
   stage = false,
 ) => {
   return useQuery({
-    queryKey: stage ? canvasKeys.consoleStaged(canvasId, versionId) : canvasKeys.console(canvasId, versionId),
+    queryKey: stage ? canvasKeys.stagedConsole(canvasId) : canvasKeys.console(canvasId, versionId),
     queryFn: () => fetchCanvasConsoleData(canvasId, versionId, stage),
     enabled: enabled && !!canvasId,
-    staleTime: 30_000,
+    staleTime: stage ? 0 : Number.POSITIVE_INFINITY,
   });
 };
 
@@ -1574,7 +1562,7 @@ export const useUpdateCanvasConsole = (
   return useMutation({
     onMutate: async (input) => {
       // Console edits are stage-only; write to the staged cache the editor reads.
-      const queryKey = canvasKeys.consoleStaged(canvasId, versionId);
+      const queryKey = canvasKeys.stagedConsole(canvasId);
       const mutationGeneration = options?.getMutationGeneration?.() ?? 0;
       if (input.panels === undefined || input.layout === undefined) {
         return { previous: queryClient.getQueryData<CanvasConsoleData>(queryKey), queryKey, mutationGeneration };
@@ -1639,7 +1627,7 @@ export const useUpdateCanvasConsole = (
         return;
       }
       if (result.consoleData) {
-        queryClient.setQueryData(canvasKeys.consoleStaged(canvasId, versionId), result.consoleData);
+        queryClient.setQueryData(canvasKeys.stagedConsole(canvasId), result.consoleData);
       }
       if (versionId) {
         queryClient.setQueryData(
@@ -1678,7 +1666,7 @@ export function fetchRepositoryFileContentCached(
   return queryClient.fetchQuery({
     queryKey: canvasKeys.repositoryFileContent(canvasId, path, versionId, stage),
     queryFn: () => fetchRepositorySpecFileContent(canvasId, path, versionId, stage),
-    staleTime: stage ? 0 : 30_000,
+    staleTime: stage ? 0 : Number.POSITIVE_INFINITY,
   });
 }
 
@@ -1784,7 +1772,7 @@ export const useCommitCanvasStaging = (canvasId: string) => {
 
 // useDiscardCanvasStaging deletes staging rows for a canvas. Pass paths to revert
 // specific files; omit to discard everything.
-export const useDiscardCanvasStaging = (canvasId: string, versionId: string) => {
+export const useDiscardCanvasStaging = (canvasId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (paths?: string[]) => {
@@ -1797,22 +1785,18 @@ export const useDiscardCanvasStaging = (canvasId: string, versionId: string) => 
       );
       return response.data?.stagingSummary;
     },
-    onSuccess: (stagingSummary, _paths, _context) => {
+    onSuccess: (stagingSummary) => {
       queryClient.setQueryData(
         canvasKeys.canvasStaging(canvasId),
         stagingSummary ?? { hasStaging: false, stagedPaths: [] },
       );
-      if (versionId) {
-        queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, versionId) });
-        queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, versionId) });
-      }
-      queryClient.invalidateQueries({ queryKey: canvasKeys.repository(canvasId) });
+      invalidateStagedCanvasCaches(queryClient, canvasId);
     },
   });
 };
 
 // useStageRepositoryFiles stages arbitrary repository file edits into staging.
-export const useStageRepositoryFiles = (canvasId: string, versionId: string) => {
+export const useStageRepositoryFiles = (canvasId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (operations: CanvasesCanvasRepositoryFileOperation[]) => {
@@ -1825,25 +1809,18 @@ export const useStageRepositoryFiles = (canvasId: string, versionId: string) => 
       );
       return response.data?.stagingSummary;
     },
-    onSuccess: (stagingSummary, operations) => {
+    onSuccess: (stagingSummary) => {
       queryClient.setQueryData(
         canvasKeys.canvasStaging(canvasId),
         stagingSummary ?? { hasStaging: false, stagedPaths: [] },
       );
-      queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId) });
-
-      const affectedPaths = new Set(
-        operations.map((operation) => operation.path).filter((path): path is string => !!path),
-      );
-      for (const path of affectedPaths) {
-        queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFile(canvasId, path, versionId) });
-      }
+      invalidateStagedCanvasCaches(queryClient, canvasId);
     },
   });
 };
 
 // useDiscardRepositoryFilePaths reverts specific staged paths, refreshing StagingSummary.
-export const useDiscardRepositoryFilePaths = (canvasId: string, versionId: string) => {
+export const useDiscardRepositoryFilePaths = (canvasId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (paths: string[]) => {
@@ -1856,15 +1833,12 @@ export const useDiscardRepositoryFilePaths = (canvasId: string, versionId: strin
       );
       return response.data?.stagingSummary;
     },
-    onSuccess: (stagingSummary, paths) => {
+    onSuccess: (stagingSummary) => {
       queryClient.setQueryData(
         canvasKeys.canvasStaging(canvasId),
         stagingSummary ?? { hasStaging: false, stagedPaths: [] },
       );
-      queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId) });
-      for (const path of new Set(paths)) {
-        queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFile(canvasId, path, versionId) });
-      }
+      invalidateStagedCanvasCaches(queryClient, canvasId);
     },
   });
 };

--- a/web_src/src/hooks/useCanvasStagingResync.ts
+++ b/web_src/src/hooks/useCanvasStagingResync.ts
@@ -2,9 +2,9 @@ import { useCallback, useRef, type Dispatch, type MutableRefObject, type SetStat
 import { useQueryClient } from "@tanstack/react-query";
 
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
-import { fetchCanvasVersionWithSpec } from "@/pages/app/lib/repository-spec-files";
+import { fetchStagedCanvasVersionWithSpec } from "@/pages/app/lib/repository-spec-files";
 
-import { canvasKeys } from "@/hooks/useCanvasData";
+import { canvasKeys, invalidateStagedCanvasCaches } from "@/hooks/useCanvasData";
 
 type CanvasSpec = CanvasesCanvas["spec"] | null;
 
@@ -23,6 +23,8 @@ interface UseCanvasStagingResyncOptions {
 type ResyncStagedOptions = {
   /** Bumps stagingResetNonce so file/console baselines reset. Avoid when entering edit from agent staging — it remounts CanvasPage and can loop auto-open. */
   bumpResetNonce?: boolean;
+  /** When true, reuse a warm stagedCanvasSpec cache instead of forcing a refetch. */
+  preferCachedStagedSpec?: boolean;
 };
 
 // Re-applies the staged (uncommitted) spec into React editor state after a remote
@@ -88,22 +90,36 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
       }
 
       const bumpResetNonce = options?.bumpResetNonce ?? true;
+      const preferCachedStagedSpec = options?.preferCachedStagedSpec ?? false;
 
       const resyncPromise = (async () => {
-        await queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId) });
-
         if (activeCanvasVersionIdRef.current !== versionId) {
           draftCanvasSpecsRef.current.delete(versionId);
           return;
         }
 
+        const versionShell =
+          queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.versionDetail(canvasId, versionId)) ?? undefined;
+
+        const cachedStaged = preferCachedStagedSpec
+          ? queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.stagedCanvasSpec(canvasId))
+          : undefined;
+
+        if (cachedStaged?.spec && cachedStaged.metadata?.id === versionId) {
+          applyStagedSpec(versionId, cachedStaged.spec);
+          return;
+        }
+
         consoleMutationGenerationRef.current += 1;
-        const stagedVersion = await fetchCanvasVersionWithSpec(canvasId, versionId, true);
+        invalidateStagedCanvasCaches(queryClient, canvasId);
+
+        const stagedVersion = await queryClient.fetchQuery({
+          queryKey: canvasKeys.stagedCanvasSpec(canvasId),
+          queryFn: () => fetchStagedCanvasVersionWithSpec(canvasId, versionShell),
+          staleTime: 0,
+        });
         const stagedSpec = stagedVersion?.spec ?? null;
 
-        if (stagedVersion) {
-          queryClient.setQueryData(canvasKeys.versionStagedDetail(canvasId, versionId), stagedVersion);
-        }
         if (stagedSpec) {
           queryClient.setQueryData<CanvasesCanvas | undefined>(
             canvasKeys.detail(organizationId, canvasId),
@@ -112,7 +128,6 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
         }
         applyStagedSpec(versionId, stagedSpec);
 
-        await queryClient.invalidateQueries({ queryKey: canvasKeys.consoleStaged(canvasId, versionId) });
         if (bumpResetNonce) {
           setStagingResetNonce((nonce) => nonce + 1);
         }

--- a/web_src/src/hooks/useCanvasStagingResync.ts
+++ b/web_src/src/hooks/useCanvasStagingResync.ts
@@ -53,6 +53,9 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
 
       if (spec) {
         draftCanvasSpecsRef.current.set(versionId, spec);
+        queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) =>
+          current ? { ...current, spec: { ...current.spec, ...spec } } : current,
+        );
       } else {
         draftCanvasSpecsRef.current.delete(versionId);
       }
@@ -120,12 +123,6 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
         });
         const stagedSpec = stagedVersion?.spec ?? null;
 
-        if (stagedSpec) {
-          queryClient.setQueryData<CanvasesCanvas | undefined>(
-            canvasKeys.detail(organizationId, canvasId),
-            (current) => (current ? { ...current, spec: { ...current.spec, ...stagedSpec } } : current),
-          );
-        }
         applyStagedSpec(versionId, stagedSpec);
 
         if (bumpResetNonce) {

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -377,7 +377,6 @@ describe("useCanvasWebsocket", () => {
           false,
           true,
           onCanvasStagingEvent,
-          () => "version-1",
         ),
       {
         wrapper: ({ children }: { children: ReactNode }) =>
@@ -392,12 +391,13 @@ describe("useCanvasWebsocket", () => {
 
     expect(onCanvasStagingEvent).toHaveBeenCalledWith({ canvasId: testCanvasId, userId: "user-1" }, "staging_updated");
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.canvasStaging(testCanvasId))).toHaveLength(1);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.stagedCanvasSpec(testCanvasId))).toHaveLength(1);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.stagedConsole(testCanvasId))).toHaveLength(1);
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.repositoryFiles(testCanvasId))).toHaveLength(1);
 
     const [stagedPredicate] = getInvalidationPredicates(invalidateQueriesSpy);
     expect(stagedPredicate).toBeDefined();
-    expect(stagedPredicate({ queryKey: canvasKeys.versionStagedDetail(testCanvasId, "version-1") })).toBe(true);
-    expect(stagedPredicate({ queryKey: canvasKeys.consoleStaged(testCanvasId, "version-1") })).toBe(true);
+    expect(stagedPredicate({ queryKey: canvasKeys.stagedConsole(testCanvasId) })).toBe(true);
     expect(stagedPredicate({ queryKey: canvasKeys.repositoryFile(testCanvasId, "README.md", "version-1", true) })).toBe(
       true,
     );

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useWebSocket } from "@/lib/reactUseWebsocket";
-import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
+import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type {
   CanvasesCanvasNodeExecution,
   CanvasesCanvasEvent,
@@ -15,7 +15,7 @@ import {
   upsertRunIntoInfiniteData,
   type InfiniteRunsPage,
 } from "./canvasInfiniteCache";
-import { canvasKeys } from "./useCanvasData";
+import { canvasKeys, invalidateStagedCanvasCaches } from "./useCanvasData";
 
 const SOCKET_SERVER_URL = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws/`;
 
@@ -43,40 +43,6 @@ interface QueuedMessage {
   timestamp: number;
 }
 
-function queryKeyStartsWith(queryKey: readonly unknown[], prefix: readonly unknown[]): boolean {
-  return prefix.every((part, index) => queryKey[index] === part);
-}
-
-function isDraftRepositoryFileQuery(queryKey: readonly unknown[], canvasId: string, versionId: string): boolean {
-  const repositoryPrefix = canvasKeys.repository(canvasId);
-  const fileSegmentIndex = repositoryPrefix.length;
-  return (
-    queryKeyStartsWith(queryKey, repositoryPrefix) &&
-    queryKey.length === repositoryPrefix.length + 4 &&
-    queryKey[fileSegmentIndex] === "file" &&
-    queryKey[fileSegmentIndex + 2] === versionId &&
-    queryKey[fileSegmentIndex + 3] === "staged"
-  );
-}
-
-// Refreshes caches that read a draft version's staging layer. versionStagedDetail,
-// consoleStaged and staged repositoryFileContent keys all end with "staged";
-// repositoryFile keys feed the visible Files tab editor and include the draft id.
-function invalidateStagedCanvasQueries(queryClient: QueryClient, canvasId: string, versionId: string): void {
-  queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId) });
-  queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId) });
-  queryClient.invalidateQueries({
-    predicate: (query) => {
-      const key = query.queryKey;
-      if (!Array.isArray(key) || !key.includes(versionId)) {
-        return false;
-      }
-
-      return key[key.length - 1] === "staged" || isDraftRepositoryFileQuery(key, canvasId, versionId);
-    },
-  });
-}
-
 export function useCanvasWebsocket(
   canvasId: string,
   organizationId: string,
@@ -88,7 +54,6 @@ export function useCanvasWebsocket(
   processRuntimeEvents = true,
   enabled = true,
   onCanvasStagingEvent?: (payload: CanvasWebsocketPayload, eventName: CanvasStagingEventName) => boolean | void,
-  getStagingVersionId?: () => string | undefined,
 ): void {
   const updateNodeEvent = useNodeExecutionStore((state) => state.updateNodeEvent);
   const updateNodeExecution = useNodeExecutionStore((state) => state.updateNodeExecution);
@@ -284,13 +249,7 @@ export function useCanvasWebsocket(
           const shouldInvalidateStagingQueries =
             onCanvasStagingEvent?.(stagingMessage as CanvasWebsocketPayload, "staging_updated") !== false;
           if (shouldInvalidateStagingQueries) {
-            const stagingVersionId = getStagingVersionId?.();
-            if (stagingVersionId) {
-              invalidateStagedCanvasQueries(queryClient, canvasId, stagingVersionId);
-            } else {
-              queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId) });
-              queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId) });
-            }
+            invalidateStagedCanvasCaches(queryClient, canvasId);
           }
           break;
         }
@@ -325,7 +284,6 @@ export function useCanvasWebsocket(
       patchExecutionInCache,
       invalidateMemoryEntries,
       invalidateRuns,
-      getStagingVersionId,
     ],
   );
 

--- a/web_src/src/pages/app/files/FilesOverlayLayer.spec.tsx
+++ b/web_src/src/pages/app/files/FilesOverlayLayer.spec.tsx
@@ -55,7 +55,7 @@ vi.mock("@/hooks/useCanvasData", () => ({
     mutateAsync: vi.fn(),
     isPending: false,
   }),
-  useCanvasVersionStaging: () => ({
+  useCanvasStaging: () => ({
     data: { hasStaging: stagedPaths.length > 0, stagedPaths },
     isLoading: false,
     error: null,

--- a/web_src/src/pages/app/files/useEditor.ts
+++ b/web_src/src/pages/app/files/useEditor.ts
@@ -1,4 +1,4 @@
-import { useCanvasVersionStaging } from "@/hooks/useCanvasData";
+import { useCanvasStaging } from "@/hooks/useCanvasData";
 import { useEffectiveLeftSidebarWidth } from "@/stores/sidebarLayoutStore";
 import { useMemo, useRef, useState } from "react";
 
@@ -42,7 +42,7 @@ export function useEditor({
   const leftOffset = useEffectiveLeftSidebarWidth();
   const canManageRepositoryFiles = canWrite && !!canvasId && isEditing;
   const catalog = useCatalog(canvasId, files);
-  const stagingQuery = useCanvasVersionStaging(canvasId ?? "", versionId, canManageRepositoryFiles && !!versionId);
+  const stagingQuery = useCanvasStaging(canvasId, canManageRepositoryFiles);
   const stagedRepositoryPaths = useMemo(() => {
     const stagedPaths = stagingQuery.data?.stagedPaths ?? [];
     return stagedPaths.filter((path) => !catalog.generatedPathSet.has(path));

--- a/web_src/src/pages/app/files/useRepositoryFileStaging.ts
+++ b/web_src/src/pages/app/files/useRepositoryFileStaging.ts
@@ -95,8 +95,8 @@ export function useRepositoryFileStaging({
   pendingChanges,
   onFlushReady,
 }: UseRepositoryFileStagingOptions) {
-  const stageFiles = useStageRepositoryFiles(canvasId ?? "", versionId ?? "");
-  const discardPaths = useDiscardRepositoryFilePaths(canvasId ?? "", versionId ?? "");
+  const stageFiles = useStageRepositoryFiles(canvasId ?? "");
+  const discardPaths = useDiscardRepositoryFilePaths(canvasId ?? "");
   const stageFilesRef = useRef(stageFiles);
   stageFilesRef.current = stageFiles;
   const discardPathsRef = useRef(discardPaths);

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -1,7 +1,7 @@
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { useNodeExecutionStore } from "@/stores/nodeExecutionStore";
-import { useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import debounce from "lodash.debounce";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, startTransition, useState } from "react";
@@ -30,11 +30,8 @@ import { usePermissions } from "@/contexts/usePermissions";
 import { useComponents } from "@/hooks/useComponentData";
 import {
   canvasKeys,
-  invalidateStagedCanvasCaches,
   useCanvas,
   useCanvasMemoryEntries,
-  useStagedCanvasSpec,
-  useCanvasVersion,
   useCanvasVersions,
   useCreateCanvasMemoryNamespace,
   useDeleteCanvasMemoryEntry,
@@ -90,33 +87,24 @@ import { useWorkflowViewModeActions } from "./useWorkflowViewModeActions";
 import { useStaleRunInspectionUrlCleanup } from "./useStaleRunInspectionUrlCleanup";
 import { canEditCanvasMemory, shouldLoadCanvasMemoryEntries } from "./lib/canvas-memory-access";
 import { CanvasPageModals } from "./CanvasPageModals";
-import {
-  shouldApplyPreservedDraftSpec,
-  shouldPreserveDraftSpec,
-  shouldSkipDraftSpecSyncFromLoadedVersion,
-} from "./lib/draft-canvas-sync";
 import { resolveCanvasForView, syncLoadedVersionToCanvasDetail } from "./lib/resolve-canvas-for-view";
+import { activateCanvasVersionForEditing as applyCanvasVersionForEditing } from "./lib/canvas-version-activation";
 import {
   clearLiveEditSessionDraftState,
   clearLiveEditSessionSearchParams,
-  isAwaitingStagedCanvasSpec,
-  isViewingCurrentLiveCanvasVersion,
   resetCommittedLiveCanvasDetail,
-  resolveSelectedCanvasVersion,
-  shouldReadStagedCanvasVersion,
 } from "./lib/live-edit-session";
 import { useRefreshLatestLiveCanvasData } from "./useRefreshLatestLiveCanvasData";
 import { sortVersionsDesc } from "./lib/canvas-versions";
 import { useAppDraftStagingData } from "./useAppDraftStagingData";
-import { useCommittedDraftBaselines } from "./useCommittedDraftBaselines";
+import { useCanvasEditVersionState } from "./useCanvasEditVersionState";
+import { useEditSessionBootstrap } from "./useEditSessionBootstrap";
+import { useDraftCanvasSpecSync } from "./useDraftCanvasSpecSync";
+import { useEnterLiveEditSession } from "./useEnterLiveEditSession";
 import { useCanvasEchoReleaseGuards } from "./useCanvasEchoReleaseGuards";
 import { useCanvasLifecycleEventHandlers } from "./useCanvasLifecycleEventHandlers";
 import { useDraftStagingActions } from "./useDraftStagingActions";
 import { executeCommitStaging } from "./lib/commit-staging-flow";
-import {
-  isDraftCanvasLoadingWhileEditing,
-  isEditBootstrapReady as resolveEditBootstrapReady,
-} from "./lib/edit-staging-ready";
 import { getNodeIntegrationName, overlayIntegrationWarnings } from "./lib/node-integrations";
 import { renderCanvasNodeCustomField } from "./lib/render-canvas-node-custom-field";
 import { buildCanvasYamlExportPayload, materializeCanvasSpec } from "./lib/workflow-spec-files";
@@ -169,72 +157,6 @@ import {
 const CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY = "canvas-auto-layout-on-update-enabled";
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
 const EMPTY_CANVAS_SPEC_ITEMS: never[] = [];
-
-function updateCanvasDetailForSelectedVersion({
-  queryClient,
-  organizationId,
-  canvasId,
-  isCurrentLive,
-  version,
-  liveCanvasVersion,
-  liveCanvas,
-}: {
-  queryClient: QueryClient;
-  organizationId: string;
-  canvasId: string;
-  isCurrentLive: boolean;
-  version: CanvasesCanvasVersion;
-  liveCanvasVersion?: CanvasesCanvasVersion;
-  liveCanvas?: CanvasesCanvas | null;
-}) {
-  queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
-    if (!current) {
-      return current;
-    }
-
-    if (isCurrentLive) {
-      return { ...current, spec: liveCanvasVersion?.spec || liveCanvas?.spec };
-    }
-
-    if (!version.spec) {
-      return current;
-    }
-
-    return { ...current, spec: { ...current.spec, ...version.spec } };
-  });
-}
-
-function refreshLiveCanvasAfterVersionSelection({
-  queryClient,
-  organizationId,
-  canvasId,
-  activeCanvasVersionIdRef,
-  initializeFromWorkflow,
-}: {
-  queryClient: QueryClient;
-  organizationId: string;
-  canvasId: string;
-  activeCanvasVersionIdRef: { current: string };
-  initializeFromWorkflow: (canvas: CanvasesCanvas) => void;
-}) {
-  void Promise.all([
-    queryClient.invalidateQueries({
-      queryKey: canvasKeys.detail(organizationId, canvasId),
-      refetchType: "all",
-    }),
-    queryClient.invalidateQueries({
-      queryKey: canvasKeys.infiniteRuns(canvasId),
-      refetchType: "all",
-    }),
-  ]).then(() => {
-    const refreshedLiveCanvas = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
-    if (!refreshedLiveCanvas || activeCanvasVersionIdRef.current !== "") {
-      return;
-    }
-
-    initializeFromWorkflow(refreshedLiveCanvas);
-  });
-}
 
 export function AppPage() {
   const { organizationId, appId } = useParams<{
@@ -303,6 +225,7 @@ export function AppPage() {
   // published/discarded" (session must close). Both states look identical in
   // terms of active-version state (no selected version), so we can't derive it.
   const previewingCurrentVersionRef = useRef(false);
+  const draftCanvasSpecsRef = useRef<Map<string, CanvasesCanvas["spec"] | null>>(new Map());
   const updateCanvasVersionMutation = useUpdateCanvasVersion(canvasId!);
   const [commitDialogOpen, setCommitDialogOpen] = useState(false);
   const [isCanvasSaveInFlight, setIsCanvasSaveInFlight] = useState(false);
@@ -387,171 +310,69 @@ export function AppPage() {
     canvasId,
     effectiveLiveCanvasVersionId,
   );
-  const activeCanvasVersionId = activeCanvasVersion?.metadata?.id || "";
-  const shouldReadStagedCanvasVersionFlag = shouldReadStagedCanvasVersion({
-    editSessionActive,
-    activeCanvasVersionId,
-    effectiveLiveCanvasVersionId,
-    liveCanvasVersionId,
-  });
-  const stagedVersionMetadataShell = activeCanvasVersion ?? selectableVersionsById.get(activeCanvasVersionId) ?? null;
   const {
-    data: loadedStagedCanvasVersion,
-    isLoading: loadedStagedCanvasVersionLoading,
-    isFetching: loadedStagedCanvasVersionFetching,
-  } = useStagedCanvasSpec(canvasId!, stagedVersionMetadataShell, shouldReadStagedCanvasVersionFlag);
-  const {
-    data: loadedCommittedCanvasVersion,
-    isLoading: loadedCommittedCanvasVersionLoading,
-    isFetching: loadedCommittedCanvasVersionFetching,
-  } = useCanvasVersion(
-    organizationId!,
-    canvasId!,
     activeCanvasVersionId,
-    !!activeCanvasVersionId && !shouldReadStagedCanvasVersionFlag,
-  );
-  const loadedCanvasVersion = shouldReadStagedCanvasVersionFlag
-    ? loadedStagedCanvasVersion
-    : loadedCommittedCanvasVersion;
-  const loadedCanvasVersionLoading = shouldReadStagedCanvasVersionFlag
-    ? loadedStagedCanvasVersionLoading
-    : loadedCommittedCanvasVersionLoading;
-  const loadedCanvasVersionFetching = shouldReadStagedCanvasVersionFlag
-    ? loadedStagedCanvasVersionFetching
-    : loadedCommittedCanvasVersionFetching;
-  const isAwaitingStagedCanvasSpecFlag = isAwaitingStagedCanvasSpec({
-    activeCanvasVersionId,
-    shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
-    loadedStagedCanvasVersion,
-    loadedStagedCanvasVersionLoading,
-    loadedStagedCanvasVersionFetching,
-    isEnteringEditSession,
-  });
-  const selectedCanvasVersion = useMemo(
-    () =>
-      resolveSelectedCanvasVersion({
-        activeCanvasVersionId,
-        shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
-        loadedStagedCanvasVersion,
-        loadedCommittedCanvasVersion,
-        activeCanvasVersion,
-        isAwaitingStagedSpec: isAwaitingStagedCanvasSpecFlag,
-      }),
-    [
-      activeCanvasVersionId,
-      shouldReadStagedCanvasVersionFlag,
-      loadedStagedCanvasVersion,
-      loadedCommittedCanvasVersion,
-      activeCanvasVersion,
-      isAwaitingStagedCanvasSpecFlag,
-    ],
-  );
-  const isViewingCurrentLiveVersion = isViewingCurrentLiveCanvasVersion({
-    activeCanvasVersionId,
+    shouldReadStagedCanvasVersionFlag,
+    loadedCanvasVersion,
+    loadedCanvasVersionLoading,
+    loadedCanvasVersionFetching,
+    isAwaitingStagedCanvasSpecFlag,
     selectedCanvasVersion,
+    isViewingCurrentLiveVersion,
+    isViewingLiveVersion,
+    isEditing,
+    hasEditableVersion,
+    showLiveActivity,
+  } = useCanvasEditVersionState({
+    organizationId: organizationId!,
+    canvasId: canvasId!,
+    editSessionActive,
+    isEnteringEditSession,
+    activeCanvasVersion,
     effectiveLiveCanvasVersionId,
     liveCanvasVersionId,
+    selectableVersionsById,
+    isRunInspectionMode,
+    isMemoryMode,
   });
-  const isViewingLiveVersion = isViewingCurrentLiveVersion;
-  const isEditing = editSessionActive && isViewingCurrentLiveVersion;
-  const hasEditableVersion = isEditing;
-  // Events/runs are only surfaced in the normal live workflow context. While an
-  // edit session shows the versions sidebar (including when previewing the
-  // current version), live activity is hidden so the canvas reads as a pure
-  // visual snapshot. `isViewingLiveVersion` stays for permission/eligibility.
-  const showLiveActivity = isViewingLiveVersion && !(editSessionActive && !isRunInspectionMode && !isMemoryMode);
   const [draftCanvasSpec, setDraftCanvasSpec] = useState<CanvasesCanvas["spec"] | null>(null);
   const draftSpecToRender = draftCanvasSpec ?? selectedCanvasVersion?.spec ?? null;
-  const committedBaselinesForEdit = useCommittedDraftBaselines({
-    canvasId,
-    versionId: activeCanvasVersionId || undefined,
-    enabled: isEditing,
-    stagingResetNonce,
-  });
-  const isEditBootstrapReady = resolveEditBootstrapReady({
+  const {
+    committedBaselinesForEdit,
+    isEditBootstrapReady,
+    draftSpecForView,
+    isDraftCanvasLoading,
+    isEditSessionUiReady,
+    stableCanvasViewKey,
+    canvasRenderKey,
+  } = useEditSessionBootstrap({
+    canvasId: canvasId!,
     isEditing,
     isEnteringEditSession,
-    stagingBaselinesReady: committedBaselinesForEdit.ready,
-    draftCanvasSpec,
     shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
+    activeCanvasVersionId,
+    stagingResetNonce,
+    draftCanvasSpec,
+    draftSpecToRender,
+    loadedCanvasVersionLoading,
+    loadedCanvasVersionFetching,
+    selectedCanvasVersion,
+    liveCanvasVersionId,
+    isRunInspectionMode,
   });
-  const draftSpecForView = isEditing && !isEditBootstrapReady ? null : draftSpecToRender;
-  useEffect(() => {
-    if (!isEditing || !activeCanvasVersionId) {
-      return;
-    }
-
-    if (isEnteringEditSession) {
-      return;
-    }
-
-    if (shouldReadStagedCanvasVersionFlag && isAwaitingStagedCanvasSpecFlag) {
-      return;
-    }
-
-    const preservedDraftSpec = draftCanvasSpecsRef.current.get(activeCanvasVersionId);
-    const nextDraftSpec = selectedCanvasVersion?.spec ?? null;
-
-    if (shouldSkipDraftSpecSyncFromLoadedVersion(draftCanvasSpec, nextDraftSpec)) {
-      return;
-    }
-
-    if (shouldApplyPreservedDraftSpec(preservedDraftSpec, nextDraftSpec)) {
-      setDraftCanvasSpec(preservedDraftSpec);
-      return;
-    }
-
-    if (nextDraftSpec) {
-      draftCanvasSpecsRef.current.set(activeCanvasVersionId, nextDraftSpec);
-    } else {
-      draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
-    }
-    setDraftCanvasSpec(nextDraftSpec);
-  }, [
+  useDraftCanvasSpecSync({
     isEditing,
     isEnteringEditSession,
-    shouldReadStagedCanvasVersionFlag,
-    isAwaitingStagedCanvasSpecFlag,
+    shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
+    isAwaitingStagedCanvasSpec: isAwaitingStagedCanvasSpecFlag,
     activeCanvasVersionId,
-    selectedCanvasVersion?.metadata?.id,
-    selectedCanvasVersion?.spec,
+    selectedCanvasVersion,
     draftCanvasSpec,
-  ]);
-  useEffect(() => {
-    if (!isEditing || !activeCanvasVersionId || !liveCanvas?.spec) {
-      return;
-    }
-    if (!draftCanvasSpec && !selectedCanvasVersion?.spec) {
-      return;
-    }
-
-    if (
-      shouldPreserveDraftSpec({
-        incomingSpec: liveCanvas.spec,
-        draftSpec: draftCanvasSpec,
-        selectedDraftVersionSpec: selectedCanvasVersion?.spec,
-        liveVersionSpec: liveCanvasVersion?.spec,
-      })
-    ) {
-      return;
-    }
-
-    setDraftCanvasSpec((currentDraftSpec) => {
-      draftCanvasSpecsRef.current.set(activeCanvasVersionId, liveCanvas.spec);
-      if (currentDraftSpec === liveCanvas.spec) {
-        return currentDraftSpec;
-      }
-
-      return liveCanvas.spec;
-    });
-  }, [
-    isEditing,
-    activeCanvasVersionId,
-    liveCanvas?.spec,
-    liveCanvasVersion?.spec,
-    selectedCanvasVersion?.spec,
-    draftCanvasSpec,
-  ]);
+    setDraftCanvasSpec,
+    draftCanvasSpecsRef,
+    liveCanvas,
+    liveCanvasVersion,
+  });
 
   const canvas = useMemo(
     () =>
@@ -668,7 +489,6 @@ export function AppPage() {
   // Canvas/version the persisted viewport was fitted for; switching content re-fits the graph.
   const lastFittedContentKeyRef = useRef<string | null>(null);
   const hasSyncedVersionFromURLRef = useRef(false);
-  const stableCanvasViewKeyRef = useRef<string>("live");
 
   /**
    * Capture the initial node focus from the URL so we only zoom once.
@@ -731,14 +551,12 @@ export function AppPage() {
   // persist the previous draft's graph onto the newly-active draft while they
   // disagree.
   const canvasContentVersionIdRef = useRef<string>("");
-  const draftCanvasSpecsRef = useRef<Map<string, CanvasesCanvas["spec"] | null>>(new Map());
   const queuedCanvasSaveRef = useRef<QueuedCanvasSaveRequest | null>(null);
   const isDrainingCanvasSaveQueueRef = useRef(false);
   const hasTrackedCanvasView = useRef(false);
   const canvasSaveSessionRef = useRef(0);
   const consoleMutationGenerationRef = useRef(0);
   const handleRemoteStagingUpdatedRef = useRef<() => Promise<void>>(async () => {});
-  const enterLiveEditSessionInFlightRef = useRef<Promise<boolean> | null>(null);
   const ignoredCanvasUpdatedEchoReleasesRef = useRef<Array<CanvasEchoRelease>>([]);
   const { registerIgnoredCanvasUpdatedEcho, consumeIgnoredCanvasUpdatedEcho, resetLifecycleEchoGuards } =
     useCanvasEchoReleaseGuards({
@@ -3421,92 +3239,42 @@ export function AppPage() {
   }, [handleResetStaging]);
 
   const activateCanvasVersionForEditing = useCallback(
-    (versionID: string, version: CanvasesCanvasVersion, options?: { preserveStagedLayer?: boolean }) => {
-      if (!organizationId || !canvasId) {
-        return false;
-      }
-
-      const versionId = version.metadata?.id || "";
-      const isCurrentLive =
-        (!!effectiveLiveCanvasVersionId && versionId === effectiveLiveCanvasVersionId) ||
-        (!!liveCanvasVersionId && versionId === liveCanvasVersionId);
-      const preserveStagedLayer = !!options?.preserveStagedLayer && isCurrentLive;
-
-      clearPendingAutoSaveWork();
-
-      const previousVersionId = activeCanvasVersionIdRef.current;
-      if (previousVersionId && draftCanvasSpec) {
-        draftCanvasSpecsRef.current.set(previousVersionId, draftCanvasSpec);
-      }
-
-      if (isCurrentLive && !preserveStagedLayer) {
-        draftCanvasSpecsRef.current.delete(versionId);
-        invalidateStagedCanvasCaches(queryClient, canvasId);
-      }
-
-      if (!isCurrentLive) {
-        void queryClient.cancelQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
-      }
-
-      activeCanvasVersionIdRef.current = versionID;
-      if (!isCurrentLive) {
-        setDraftCanvasSpec(version.spec ?? null);
-      } else if (!preserveStagedLayer) {
-        setDraftCanvasSpec(null);
-      }
-      setActiveCanvasVersion(version);
-
-      lastAppliedVersionSnapshotRef.current = "";
-      setLastSavedWorkflowSnapshot(null);
-
-      setSearchParams((current) => {
-        const next = new URLSearchParams(current);
-        next.delete("branch");
-        if (isCurrentLive) {
-          next.delete("version");
-        } else {
-          next.set("version", versionID);
-        }
-        return clearComponentSidebarSearchParams(next);
-      });
-
-      if (!preserveStagedLayer) {
-        updateCanvasDetailForSelectedVersion({
-          queryClient,
-          organizationId,
-          canvasId,
-          isCurrentLive,
-          version,
-          liveCanvasVersion,
-          liveCanvas,
-        });
-      }
-
-      if (isCurrentLive && !preserveStagedLayer) {
-        refreshLiveCanvasAfterVersionSelection({
-          queryClient,
-          organizationId,
-          canvasId,
-          activeCanvasVersionIdRef,
-          initializeFromWorkflow,
-        });
-      }
-
-      return true;
-    },
+    (versionID: string, version: CanvasesCanvasVersion, options?: { preserveStagedLayer?: boolean }) =>
+      applyCanvasVersionForEditing({
+        organizationId,
+        canvasId,
+        versionID,
+        version,
+        options,
+        effectiveLiveCanvasVersionId,
+        liveCanvasVersionId,
+        queryClient,
+        draftCanvasSpec,
+        draftCanvasSpecsRef,
+        activeCanvasVersionIdRef,
+        lastAppliedVersionSnapshotRef,
+        liveCanvasVersion,
+        liveCanvas,
+        clearPendingAutoSaveWork,
+        setDraftCanvasSpec,
+        setActiveCanvasVersion,
+        setLastSavedWorkflowSnapshot,
+        setSearchParams,
+        initializeFromWorkflow,
+      }),
     [
       organizationId,
       canvasId,
       effectiveLiveCanvasVersionId,
       liveCanvasVersionId,
+      queryClient,
+      draftCanvasSpec,
       liveCanvasVersion,
       liveCanvas,
-      queryClient,
-      setSearchParams,
-      initializeFromWorkflow,
       clearPendingAutoSaveWork,
       setLastSavedWorkflowSnapshot,
-      draftCanvasSpec,
+      setSearchParams,
+      initializeFromWorkflow,
     ],
   );
 
@@ -3567,46 +3335,7 @@ export function AppPage() {
       isViewingCurrentLiveVersion,
     });
 
-  const enterLiveEditSession = useCallback(async (): Promise<boolean> => {
-    if (enterLiveEditSessionInFlightRef.current) {
-      return enterLiveEditSessionInFlightRef.current;
-    }
-
-    const enterPromise = (async (): Promise<boolean> => {
-      if (!organizationId || !canvasId || !canUpdateCanvas) {
-        return false;
-      }
-
-      if (!effectiveLiveCanvasVersionId) {
-        return false;
-      }
-
-      if (!selectableVersionsById.has(effectiveLiveCanvasVersionId)) {
-        return false;
-      }
-
-      setIsEnteringEditSession(true);
-      try {
-        previewingCurrentVersionRef.current = true;
-        handleUseVersion(effectiveLiveCanvasVersionId, { preserveStagedLayer: true });
-        await resyncStagedEditorState(effectiveLiveCanvasVersionId, {
-          bumpResetNonce: false,
-          preferCachedStagedSpec: true,
-        });
-        setEditSessionActive(true);
-        return true;
-      } finally {
-        setIsEnteringEditSession(false);
-      }
-    })();
-
-    enterLiveEditSessionInFlightRef.current = enterPromise;
-    try {
-      return await enterPromise;
-    } finally {
-      enterLiveEditSessionInFlightRef.current = null;
-    }
-  }, [
+  const { enterLiveEditSession } = useEnterLiveEditSession({
     organizationId,
     canvasId,
     canUpdateCanvas,
@@ -3614,7 +3343,10 @@ export function AppPage() {
     selectableVersionsById,
     handleUseVersion,
     resyncStagedEditorState,
-  ]);
+    previewingCurrentVersionRef,
+    setEditSessionActive,
+    setIsEnteringEditSession,
+  });
 
   handleRemoteStagingUpdatedRef.current = async () => {
     const targetVersionId = effectiveLiveCanvasVersionId;
@@ -4107,15 +3839,6 @@ export function AppPage() {
 
   const isInitialCanvasBootstrapLoading =
     !canvas && (canvasLoading || triggersLoading || componentsLoading || widgetsLoading);
-  const isDraftCanvasLoading = isDraftCanvasLoadingWhileEditing({
-    isEditing,
-    shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
-    isEnteringEditSession,
-    isEditBootstrapReady,
-    draftCanvasSpec,
-    loadedCanvasVersionLoading,
-    loadedCanvasVersionFetching,
-  });
 
   useReportPageReady(!isInitialCanvasBootstrapLoading && !!canvas, {
     failed: !canvas && !canvasLoading && !isDraftCanvasLoading,
@@ -4196,14 +3919,6 @@ export function AppPage() {
         </div>
       </div>
     ) : null;
-  const canvasViewKey = selectedCanvasVersion?.metadata?.id || liveCanvasVersionId || "live";
-  const pinCanvasViewKey = isEnteringEditSession || (isEditing && !isEditBootstrapReady);
-  if (!pinCanvasViewKey) {
-    stableCanvasViewKeyRef.current = canvasViewKey;
-  }
-  const stableCanvasViewKey = pinCanvasViewKey ? stableCanvasViewKeyRef.current : canvasViewKey;
-  const isEditSessionUiReady = !isEditing || (isEditBootstrapReady && !isDraftCanvasLoading);
-  const canvasRenderKey = `${stableCanvasViewKey}:${isRunInspectionMode ? "runs" : "canvas"}:reset-${stagingResetNonce}`;
   const headerBanners = [appBanner, remoteUpdateBanner].filter(Boolean);
   const headerBanner = headerBanners.length > 0 ? <div className="flex flex-col">{headerBanners}</div> : null;
   const enterEditModeDisabled = !canUpdateCanvas || canvasDeletedRemotely;

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -30,8 +30,10 @@ import { usePermissions } from "@/contexts/usePermissions";
 import { useComponents } from "@/hooks/useComponentData";
 import {
   canvasKeys,
+  invalidateStagedCanvasCaches,
   useCanvas,
   useCanvasMemoryEntries,
+  useStagedCanvasSpec,
   useCanvasVersion,
   useCanvasVersions,
   useCreateCanvasMemoryNamespace,
@@ -97,16 +99,24 @@ import { resolveCanvasForView, syncLoadedVersionToCanvasDetail } from "./lib/res
 import {
   clearLiveEditSessionDraftState,
   clearLiveEditSessionSearchParams,
+  isAwaitingStagedCanvasSpec,
+  isViewingCurrentLiveCanvasVersion,
   resetCommittedLiveCanvasDetail,
+  resolveSelectedCanvasVersion,
   shouldReadStagedCanvasVersion,
 } from "./lib/live-edit-session";
 import { useRefreshLatestLiveCanvasData } from "./useRefreshLatestLiveCanvasData";
 import { sortVersionsDesc } from "./lib/canvas-versions";
 import { useAppDraftStagingData } from "./useAppDraftStagingData";
+import { useCommittedDraftBaselines } from "./useCommittedDraftBaselines";
 import { useCanvasEchoReleaseGuards } from "./useCanvasEchoReleaseGuards";
 import { useCanvasLifecycleEventHandlers } from "./useCanvasLifecycleEventHandlers";
 import { useDraftStagingActions } from "./useDraftStagingActions";
 import { executeCommitStaging } from "./lib/commit-staging-flow";
+import {
+  isDraftCanvasLoadingWhileEditing,
+  isEditBootstrapReady as resolveEditBootstrapReady,
+} from "./lib/edit-staging-ready";
 import { getNodeIntegrationName, overlayIntegrationWarnings } from "./lib/node-integrations";
 import { renderCanvasNodeCustomField } from "./lib/render-canvas-node-custom-field";
 import { buildCanvasYamlExportPayload, materializeCanvasSpec } from "./lib/workflow-spec-files";
@@ -285,6 +295,7 @@ export function AppPage() {
   // sidebar visible even when previewing the current/old version (not editing a
   // draft), and ends only when the user explicitly exits.
   const [editSessionActive, setEditSessionActive] = useState(false);
+  const [isEnteringEditSession, setIsEnteringEditSession] = useState(false);
   const editSessionActiveRef = useRef(false);
   const activeCanvasVersionIdRef = useRef<string>("");
   // Distinguishes "user deliberately selected Current version from the sidebar"
@@ -383,22 +394,64 @@ export function AppPage() {
     effectiveLiveCanvasVersionId,
     liveCanvasVersionId,
   });
+  const stagedVersionMetadataShell = activeCanvasVersion ?? selectableVersionsById.get(activeCanvasVersionId) ?? null;
   const {
-    data: loadedCanvasVersion,
-    isLoading: loadedCanvasVersionLoading,
-    isFetching: loadedCanvasVersionFetching,
+    data: loadedStagedCanvasVersion,
+    isLoading: loadedStagedCanvasVersionLoading,
+    isFetching: loadedStagedCanvasVersionFetching,
+  } = useStagedCanvasSpec(canvasId!, stagedVersionMetadataShell, shouldReadStagedCanvasVersionFlag);
+  const {
+    data: loadedCommittedCanvasVersion,
+    isLoading: loadedCommittedCanvasVersionLoading,
+    isFetching: loadedCommittedCanvasVersionFetching,
   } = useCanvasVersion(
     organizationId!,
     canvasId!,
     activeCanvasVersionId,
-    !!activeCanvasVersionId,
-    shouldReadStagedCanvasVersionFlag,
+    !!activeCanvasVersionId && !shouldReadStagedCanvasVersionFlag,
   );
-  const selectedCanvasVersion = activeCanvasVersionId ? loadedCanvasVersion || activeCanvasVersion : null;
-  const isViewingCurrentLiveVersion =
-    !selectedCanvasVersion ||
-    (!!effectiveLiveCanvasVersionId && selectedCanvasVersion.metadata?.id === effectiveLiveCanvasVersionId) ||
-    selectedCanvasVersion.metadata?.id === liveCanvasVersionId;
+  const loadedCanvasVersion = shouldReadStagedCanvasVersionFlag
+    ? loadedStagedCanvasVersion
+    : loadedCommittedCanvasVersion;
+  const loadedCanvasVersionLoading = shouldReadStagedCanvasVersionFlag
+    ? loadedStagedCanvasVersionLoading
+    : loadedCommittedCanvasVersionLoading;
+  const loadedCanvasVersionFetching = shouldReadStagedCanvasVersionFlag
+    ? loadedStagedCanvasVersionFetching
+    : loadedCommittedCanvasVersionFetching;
+  const isAwaitingStagedCanvasSpecFlag = isAwaitingStagedCanvasSpec({
+    activeCanvasVersionId,
+    shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
+    loadedStagedCanvasVersion,
+    loadedStagedCanvasVersionLoading,
+    loadedStagedCanvasVersionFetching,
+    isEnteringEditSession,
+  });
+  const selectedCanvasVersion = useMemo(
+    () =>
+      resolveSelectedCanvasVersion({
+        activeCanvasVersionId,
+        shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
+        loadedStagedCanvasVersion,
+        loadedCommittedCanvasVersion,
+        activeCanvasVersion,
+        isAwaitingStagedSpec: isAwaitingStagedCanvasSpecFlag,
+      }),
+    [
+      activeCanvasVersionId,
+      shouldReadStagedCanvasVersionFlag,
+      loadedStagedCanvasVersion,
+      loadedCommittedCanvasVersion,
+      activeCanvasVersion,
+      isAwaitingStagedCanvasSpecFlag,
+    ],
+  );
+  const isViewingCurrentLiveVersion = isViewingCurrentLiveCanvasVersion({
+    activeCanvasVersionId,
+    selectedCanvasVersion,
+    effectiveLiveCanvasVersionId,
+    liveCanvasVersionId,
+  });
   const isViewingLiveVersion = isViewingCurrentLiveVersion;
   const isEditing = editSessionActive && isViewingCurrentLiveVersion;
   const hasEditableVersion = isEditing;
@@ -409,14 +462,30 @@ export function AppPage() {
   const showLiveActivity = isViewingLiveVersion && !(editSessionActive && !isRunInspectionMode && !isMemoryMode);
   const [draftCanvasSpec, setDraftCanvasSpec] = useState<CanvasesCanvas["spec"] | null>(null);
   const draftSpecToRender = draftCanvasSpec ?? selectedCanvasVersion?.spec ?? null;
+  const committedBaselinesForEdit = useCommittedDraftBaselines({
+    canvasId,
+    versionId: activeCanvasVersionId || undefined,
+    enabled: isEditing,
+    stagingResetNonce,
+  });
+  const isEditBootstrapReady = resolveEditBootstrapReady({
+    isEditing,
+    isEnteringEditSession,
+    stagingBaselinesReady: committedBaselinesForEdit.ready,
+    draftCanvasSpec,
+    shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
+  });
+  const draftSpecForView = isEditing && !isEditBootstrapReady ? null : draftSpecToRender;
   useEffect(() => {
     if (!isEditing || !activeCanvasVersionId) {
       return;
     }
 
-    const awaitingStagedVersionLoad =
-      !!activeCanvasVersion && !loadedCanvasVersion && (loadedCanvasVersionLoading || loadedCanvasVersionFetching);
-    if (awaitingStagedVersionLoad) {
+    if (isEnteringEditSession) {
+      return;
+    }
+
+    if (shouldReadStagedCanvasVersionFlag && isAwaitingStagedCanvasSpecFlag) {
       return;
     }
 
@@ -440,11 +509,10 @@ export function AppPage() {
     setDraftCanvasSpec(nextDraftSpec);
   }, [
     isEditing,
+    isEnteringEditSession,
+    shouldReadStagedCanvasVersionFlag,
+    isAwaitingStagedCanvasSpecFlag,
     activeCanvasVersionId,
-    activeCanvasVersion,
-    loadedCanvasVersion,
-    loadedCanvasVersionLoading,
-    loadedCanvasVersionFetching,
     selectedCanvasVersion?.metadata?.id,
     selectedCanvasVersion?.spec,
     draftCanvasSpec,
@@ -491,12 +559,13 @@ export function AppPage() {
         isEditing,
         isViewingCurrentLiveVersion,
         liveCanvas,
-        draftSpecToRender,
+        draftSpecToRender: draftSpecForView,
         selectedCanvasVersion,
         canvasId: canvasId!,
       }),
-    [liveCanvas, selectedCanvasVersion, isEditing, isViewingCurrentLiveVersion, draftSpecToRender, canvasId],
+    [liveCanvas, selectedCanvasVersion, isEditing, isViewingCurrentLiveVersion, draftSpecForView, canvasId],
   );
+  const canvasForPrep = canvas ?? ((isEditing || isEnteringEditSession) && liveCanvas ? liveCanvas : null);
 
   const [runStatusFilters, setRunStatusFilters] = useState<RunStatusFilter[]>([]);
   const runApiFilters = useMemo(
@@ -599,6 +668,7 @@ export function AppPage() {
   // Canvas/version the persisted viewport was fitted for; switching content re-fits the graph.
   const lastFittedContentKeyRef = useRef<string | null>(null);
   const hasSyncedVersionFromURLRef = useRef(false);
+  const stableCanvasViewKeyRef = useRef<string>("live");
 
   /**
    * Capture the initial node focus from the URL so we only zoom once.
@@ -718,15 +788,13 @@ export function AppPage() {
       setActiveCanvasVersion((current) =>
         current?.metadata?.id === activeCanvasVersionId ? { ...current, spec: updatedWorkflow.spec } : current,
       );
-      queryClient.setQueryData<CanvasesCanvasVersion | undefined>(
-        canvasKeys.versionStagedDetail(canvasId, activeCanvasVersionId),
-        (current) =>
-          current
-            ? { ...current, spec: updatedWorkflow.spec }
-            : {
-                metadata: { id: activeCanvasVersionId },
-                spec: updatedWorkflow.spec,
-              },
+      queryClient.setQueryData<CanvasesCanvasVersion | undefined>(canvasKeys.stagedCanvasSpec(canvasId), (current) =>
+        current
+          ? { ...current, spec: updatedWorkflow.spec }
+          : {
+              metadata: { id: activeCanvasVersionId },
+              spec: updatedWorkflow.spec,
+            },
       );
     },
     [organizationId, canvasId, queryClient, isEditing, activeCanvasVersionId],
@@ -912,7 +980,6 @@ export function AppPage() {
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
     } else if (activeCanvasVersionId) {
       draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, activeCanvasVersionId) });
     }
 
     setRemoteCanvasUpdatePending(false);
@@ -1002,6 +1069,8 @@ export function AppPage() {
     draftSpecToRender,
     canvas,
     getConsoleMutationGeneration: () => consoleMutationGenerationRef.current,
+    committedBaselines: committedBaselinesForEdit,
+    editBootstrapReady: isEditBootstrapReady,
   });
 
   const syncCurrentCanvasWithSavedVersion = useCallback(
@@ -1434,19 +1503,19 @@ export function AppPage() {
   }, []);
 
   const dataLoading = isCanvasPrepLoading(
-    canvas,
+    canvasForPrep,
     canvasLoading,
     triggersLoading,
     componentsLoading,
     integrationsLoading,
   );
   const { nodes: preparedNodes, edges: preparedEdges } = useMemo(() => {
-    if (dataLoading) {
+    if (dataLoading || !canvasForPrep) {
       return { nodes: [], edges: [] };
     }
 
     return prepareData(
-      canvas!,
+      canvasForPrep,
       allTriggers,
       allComponents,
       visibleNodeEventsMap,
@@ -1459,7 +1528,7 @@ export function AppPage() {
       openTriggerModal,
     );
   }, [
-    canvas,
+    canvasForPrep,
     allTriggers,
     allComponents,
     visibleNodeEventsMap,
@@ -1474,7 +1543,7 @@ export function AppPage() {
   ]);
 
   const draftVisualDiff = useDraftVisualDiff({
-    isViewingDraftVersion: isEditing,
+    isViewingDraftVersion: isEditing && isEditBootstrapReady,
     canvas,
     liveCanvasVersion,
     latestDraftVersion: liveCanvasVersion,
@@ -1748,7 +1817,6 @@ export function AppPage() {
     isViewingLiveVersion,
     true,
     handleCanvasStagingEvent,
-    () => activeCanvasVersionId || effectiveLiveCanvasVersionId || undefined,
   );
   const rawLogNodes = prepareCanvasLogNodes(canvasNodes, canvasEdges, allComponents, !dataLoading);
   const logNodesSignature = useMemo(() => getCanvasLogNodesSignature(rawLogNodes), [rawLogNodes]);
@@ -3353,7 +3421,7 @@ export function AppPage() {
   }, [handleResetStaging]);
 
   const activateCanvasVersionForEditing = useCallback(
-    (versionID: string, version: CanvasesCanvasVersion) => {
+    (versionID: string, version: CanvasesCanvasVersion, options?: { preserveStagedLayer?: boolean }) => {
       if (!organizationId || !canvasId) {
         return false;
       }
@@ -3362,6 +3430,7 @@ export function AppPage() {
       const isCurrentLive =
         (!!effectiveLiveCanvasVersionId && versionId === effectiveLiveCanvasVersionId) ||
         (!!liveCanvasVersionId && versionId === liveCanvasVersionId);
+      const preserveStagedLayer = !!options?.preserveStagedLayer && isCurrentLive;
 
       clearPendingAutoSaveWork();
 
@@ -3370,21 +3439,21 @@ export function AppPage() {
         draftCanvasSpecsRef.current.set(previousVersionId, draftCanvasSpec);
       }
 
-      if (isCurrentLive) {
+      if (isCurrentLive && !preserveStagedLayer) {
         draftCanvasSpecsRef.current.delete(versionId);
-        void queryClient.invalidateQueries({
-          queryKey: canvasKeys.versionStagedDetail(canvasId, versionId),
-        });
+        invalidateStagedCanvasCaches(queryClient, canvasId);
       }
 
       if (!isCurrentLive) {
         void queryClient.cancelQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
-        void queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, versionID) });
-        void queryClient.invalidateQueries({ queryKey: canvasKeys.versionStagedDetail(canvasId, versionID) });
       }
 
       activeCanvasVersionIdRef.current = versionID;
-      setDraftCanvasSpec(isCurrentLive ? null : (version.spec ?? null));
+      if (!isCurrentLive) {
+        setDraftCanvasSpec(version.spec ?? null);
+      } else if (!preserveStagedLayer) {
+        setDraftCanvasSpec(null);
+      }
       setActiveCanvasVersion(version);
 
       lastAppliedVersionSnapshotRef.current = "";
@@ -3401,17 +3470,19 @@ export function AppPage() {
         return clearComponentSidebarSearchParams(next);
       });
 
-      updateCanvasDetailForSelectedVersion({
-        queryClient,
-        organizationId,
-        canvasId,
-        isCurrentLive,
-        version,
-        liveCanvasVersion,
-        liveCanvas,
-      });
+      if (!preserveStagedLayer) {
+        updateCanvasDetailForSelectedVersion({
+          queryClient,
+          organizationId,
+          canvasId,
+          isCurrentLive,
+          version,
+          liveCanvasVersion,
+          liveCanvas,
+        });
+      }
 
-      if (isCurrentLive) {
+      if (isCurrentLive && !preserveStagedLayer) {
         refreshLiveCanvasAfterVersionSelection({
           queryClient,
           organizationId,
@@ -3440,7 +3511,7 @@ export function AppPage() {
   );
 
   const handleUseVersion = useCallback(
-    (versionID: string) => {
+    (versionID: string, options?: { preserveStagedLayer?: boolean }) => {
       if (!organizationId || !canvasId) {
         return;
       }
@@ -3451,7 +3522,7 @@ export function AppPage() {
         return;
       }
 
-      activateCanvasVersionForEditing(versionID, version);
+      activateCanvasVersionForEditing(versionID, version, options);
     },
     [activateCanvasVersionForEditing, canvasId, organizationId, selectableVersionsById],
   );
@@ -3492,7 +3563,7 @@ export function AppPage() {
   const { headerMode, canvasStateMode, showBottomStatusControls, hideAddControls, readOnlyViewModes } =
     getWorkflowViewPresentation({
       ...urlViewFlags,
-      hasEditableVersion,
+      hasEditableVersion: hasEditableVersion || isEnteringEditSession,
       isViewingCurrentLiveVersion,
     });
 
@@ -3514,11 +3585,19 @@ export function AppPage() {
         return false;
       }
 
-      setEditSessionActive(true);
-      previewingCurrentVersionRef.current = true;
-      handleUseVersion(effectiveLiveCanvasVersionId);
-      await resyncStagedEditorState(effectiveLiveCanvasVersionId, { bumpResetNonce: false });
-      return true;
+      setIsEnteringEditSession(true);
+      try {
+        previewingCurrentVersionRef.current = true;
+        handleUseVersion(effectiveLiveCanvasVersionId, { preserveStagedLayer: true });
+        await resyncStagedEditorState(effectiveLiveCanvasVersionId, {
+          bumpResetNonce: false,
+          preferCachedStagedSpec: true,
+        });
+        setEditSessionActive(true);
+        return true;
+      } finally {
+        setIsEnteringEditSession(false);
+      }
     })();
 
     enterLiveEditSessionInFlightRef.current = enterPromise;
@@ -3605,6 +3684,7 @@ export function AppPage() {
         activeCanvasVersionIdRef,
         previewingCurrentVersionRef,
       });
+      setIsEnteringEditSession(false);
       setSearchParams(clearLiveEditSessionSearchParams);
       void refreshLatestLiveCanvasData();
       return;
@@ -4027,11 +4107,15 @@ export function AppPage() {
 
   const isInitialCanvasBootstrapLoading =
     !canvas && (canvasLoading || triggersLoading || componentsLoading || widgetsLoading);
-  const isDraftCanvasLoading =
-    isEditing &&
-    !!activeCanvasVersionId &&
-    !draftSpecToRender &&
-    (loadedCanvasVersionLoading || loadedCanvasVersionFetching || !loadedCanvasVersion?.spec);
+  const isDraftCanvasLoading = isDraftCanvasLoadingWhileEditing({
+    isEditing,
+    shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
+    isEnteringEditSession,
+    isEditBootstrapReady,
+    draftCanvasSpec,
+    loadedCanvasVersionLoading,
+    loadedCanvasVersionFetching,
+  });
 
   useReportPageReady(!isInitialCanvasBootstrapLoading && !!canvas, {
     failed: !canvas && !canvasLoading && !isDraftCanvasLoading,
@@ -4081,10 +4165,6 @@ export function AppPage() {
       await queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
       return;
     }
-
-    if (activeCanvasVersionId) {
-      await queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, activeCanvasVersionId) });
-    }
   };
 
   const backToAppId = searchParams.get("appId") ?? undefined;
@@ -4117,7 +4197,13 @@ export function AppPage() {
       </div>
     ) : null;
   const canvasViewKey = selectedCanvasVersion?.metadata?.id || liveCanvasVersionId || "live";
-  const canvasRenderKey = `${canvasViewKey}:${isDraftCanvasLoading ? "draft-loading" : "draft-ready"}:${isRunInspectionMode ? "runs" : "canvas"}:reset-${stagingResetNonce}`;
+  const pinCanvasViewKey = isEnteringEditSession || (isEditing && !isEditBootstrapReady);
+  if (!pinCanvasViewKey) {
+    stableCanvasViewKeyRef.current = canvasViewKey;
+  }
+  const stableCanvasViewKey = pinCanvasViewKey ? stableCanvasViewKeyRef.current : canvasViewKey;
+  const isEditSessionUiReady = !isEditing || (isEditBootstrapReady && !isDraftCanvasLoading);
+  const canvasRenderKey = `${stableCanvasViewKey}:${isRunInspectionMode ? "runs" : "canvas"}:reset-${stagingResetNonce}`;
   const headerBanners = [appBanner, remoteUpdateBanner].filter(Boolean);
   const headerBanner = headerBanners.length > 0 ? <div className="flex flex-col">{headerBanners}</div> : null;
   const enterEditModeDisabled = !canUpdateCanvas || canvasDeletedRemotely;
@@ -4196,7 +4282,7 @@ export function AppPage() {
     <>
       <div className="relative h-full w-full">
         <WorkflowPageModeOverlays
-          key={`overlays:${canvasViewKey}:reset-${stagingResetNonce}`}
+          key={`overlays:${stableCanvasViewKey}:reset-${stagingResetNonce}`}
           urlViewFlags={urlViewFlags}
           console={{
             canActOnCanvas,
@@ -4218,7 +4304,7 @@ export function AppPage() {
             nodeStatuses: consoleNodeStatuses,
             onTriggerNode: handleConsoleTriggerNode,
             visualDiff: {
-              enabled: draftVisualDiff.visualDiffEnabled && isEditing,
+              enabled: draftVisualDiff.visualDiffEnabled && isEditSessionUiReady,
               summary: canvasConsoleVersionDiff.draftConsoleDiffSummary,
             },
             onEffectiveConsoleChange: handleEffectiveConsoleChange,
@@ -4341,8 +4427,8 @@ export function AppPage() {
           onRunNodeDetailPaneHeightChange={setRunNodeDetailPaneHeight}
           onShowDiff={onShowDiff}
           {...canvasConsoleVersionDiff.consoleDiffHeaderProps}
-          visualDiffEnabled={draftVisualDiff.visualDiffEnabled}
-          draftVisualDiff={draftVisualDiff}
+          visualDiffEnabled={draftVisualDiff.visualDiffEnabled && isEditSessionUiReady}
+          draftVisualDiff={isEditSessionUiReady ? draftVisualDiff : undefined}
           onToggleVisualDiff={draftVisualDiff.toggleVisualDiff}
           onShowNodeDiff={onShowNodeDiff}
           headerMode={headerMode}
@@ -4358,15 +4444,15 @@ export function AppPage() {
           exitEditModeDisabled={exitEditModeDisabled}
           exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
           {...draftChangeIndicators}
-          hasStagingChanges={isEditing && hasStagingChanges}
+          hasStagingChanges={isEditSessionUiReady && hasStagingChanges}
           stagingStale={isEditing && stagingStale}
-          editTabTone={editTabTone}
-          hasUncommittedCanvasDraftChanges={hasUncommittedCanvasDraftChanges}
-          hasUncommittedConsoleDraftChanges={hasUncommittedConsoleDraftChanges}
-          hasUncommittedFilesDraftChanges={hasUncommittedFilesDraftChanges}
+          editTabTone={isEditSessionUiReady ? editTabTone : "neutral"}
+          hasUncommittedCanvasDraftChanges={isEditSessionUiReady && hasUncommittedCanvasDraftChanges}
+          hasUncommittedConsoleDraftChanges={isEditSessionUiReady && hasUncommittedConsoleDraftChanges}
+          hasUncommittedFilesDraftChanges={isEditSessionUiReady && hasUncommittedFilesDraftChanges}
           hasCommittedCanvasDraftChanges={hasCommittedCanvasDraftChanges}
           hasCommittedConsoleDraftChanges={hasCommittedConsoleDraftChanges}
-          hasFilesStagingChanges={isEditing && hasFilesStagingChanges}
+          hasFilesStagingChanges={isEditSessionUiReady && hasFilesStagingChanges}
           onCommitStaging={handleOpenCommitDialog}
           commitStagingPending={commitStagingPending}
           resetStagingPending={resetStagingPending}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -87,6 +87,7 @@ import { useWorkflowViewModeActions } from "./useWorkflowViewModeActions";
 import { useStaleRunInspectionUrlCleanup } from "./useStaleRunInspectionUrlCleanup";
 import { canEditCanvasMemory, shouldLoadCanvasMemoryEntries } from "./lib/canvas-memory-access";
 import { CanvasPageModals } from "./CanvasPageModals";
+import { resolveEditableWorkflowSnapshot } from "./lib/editable-workflow-snapshot";
 import { resolveCanvasForView, syncLoadedVersionToCanvasDetail } from "./lib/resolve-canvas-for-view";
 import { activateCanvasVersionForEditing as applyCanvasVersionForEditing } from "./lib/canvas-version-activation";
 import {
@@ -618,6 +619,20 @@ export function AppPage() {
     [organizationId, canvasId, queryClient, isEditing, activeCanvasVersionId],
   );
 
+  const getCurrentWorkflowSnapshot = useCallback(() => {
+    const renderedWorkflow = canvasRef.current;
+    if (!organizationId || !canvasId) {
+      return renderedWorkflow;
+    }
+
+    const detailWorkflow = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+    return resolveEditableWorkflowSnapshot({
+      isEditing,
+      renderedWorkflow,
+      detailWorkflow,
+    });
+  }, [organizationId, canvasId, queryClient, isEditing]);
+
   // Use Zustand store for execution data - extract only the methods to avoid recreating callbacks
   // Subscribe to version to ensure React detects all updates
   const storeVersion = useNodeExecutionStore((state) => state.version);
@@ -941,10 +956,10 @@ export function AppPage() {
 
   const saveMatchesCurrentCanvas = useCallback(
     (workflow: CanvasesCanvas) => {
-      const currentWorkflow = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId!, canvasId!));
+      const currentWorkflow = getCurrentWorkflowSnapshot();
       return getWorkflowSaveSignature(currentWorkflow) === getWorkflowSaveSignature(workflow);
     },
-    [organizationId, canvasId, queryClient],
+    [getCurrentWorkflowSnapshot],
   );
 
   const processQueuedCanvasSave = useCallback(
@@ -1135,6 +1150,7 @@ export function AppPage() {
             canvasId,
             pendingPositionUpdatesRef,
             isReadOnly,
+            isEditing,
             canvasRef,
             queryClient,
             activeCanvasVersionIdRef,
@@ -1153,6 +1169,7 @@ export function AppPage() {
       activeCanvasVersionId,
       queryClient,
       isReadOnly,
+      isEditing,
       enqueueCanvasSave,
       applyLocalWorkflowUpdate,
       setLastSavedWorkflowSnapshot,
@@ -2167,7 +2184,7 @@ export function AppPage() {
             return;
           }
 
-          const latestWorkflow = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+          const latestWorkflow = getCurrentWorkflowSnapshot();
 
           if (!latestWorkflow?.spec?.nodes) return;
 
@@ -2210,7 +2227,7 @@ export function AppPage() {
         },
         isReadOnly ? 2000 : 100,
       ),
-    [organizationId, canvasId, queryClient, handleSaveWorkflow, isReadOnly],
+    [organizationId, canvasId, getCurrentWorkflowSnapshot, handleSaveWorkflow, isReadOnly],
   );
 
   const handleAnnotationBlur = useCallback(() => {
@@ -2238,14 +2255,6 @@ export function AppPage() {
       isDrainingCanvasSaveQueueRef.current
     );
   }, []);
-
-  const getCurrentWorkflowSnapshot = useCallback(() => {
-    if (!organizationId || !canvasId) {
-      return canvasRef.current;
-    }
-
-    return queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId)) || canvasRef.current;
-  }, [organizationId, canvasId, queryClient]);
 
   const hasPendingLocalDraftChanges = useCallback(() => {
     if (!activeCanvasVersionIdRef.current) {
@@ -2330,8 +2339,8 @@ export function AppPage() {
       if (!canvas || !organizationId || !canvasId) return;
       if (Object.keys(updates).length === 0) return;
 
-      const latestWorkflow =
-        queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId)) || canvas;
+      const latestWorkflow = getCurrentWorkflowSnapshot();
+      if (!latestWorkflow) return;
 
       // Separate position updates from configuration updates
       const { x, y, ...configurationUpdates } = updates;
@@ -2394,7 +2403,7 @@ export function AppPage() {
       canvas,
       organizationId,
       canvasId,
-      queryClient,
+      getCurrentWorkflowSnapshot,
       debouncedAnnotationAutoSave,
       debouncedAutoSave,
       isReadOnly,
@@ -2406,8 +2415,7 @@ export function AppPage() {
     async (newNodeData: NewNodeData): Promise<string> => {
       if (!canvas || !organizationId || !canvasId) return "";
 
-      const latestWorkflow =
-        queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId)) || canvas;
+      const latestWorkflow = getCurrentWorkflowSnapshot();
       if (!latestWorkflow) return "";
 
       // Save snapshot before making changes
@@ -2504,7 +2512,7 @@ export function AppPage() {
       canvas,
       organizationId,
       canvasId,
-      queryClient,
+      getCurrentWorkflowSnapshot,
       handleSaveWorkflow,
       applyAutoLayoutOnAddedNode,
       isReadOnly,
@@ -2521,8 +2529,7 @@ export function AppPage() {
     }): Promise<string> => {
       if (!canvas || !organizationId || !canvasId) return "";
 
-      const latestWorkflow =
-        queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId)) || canvas;
+      const latestWorkflow = getCurrentWorkflowSnapshot();
       if (!latestWorkflow) return "";
 
       const placeholderName = "New Component";
@@ -2574,7 +2581,7 @@ export function AppPage() {
       canvas,
       organizationId,
       canvasId,
-      queryClient,
+      getCurrentWorkflowSnapshot,
       handleSaveWorkflow,
       applyAutoLayoutOnAddedNode,
       isReadOnly,

--- a/web_src/src/pages/app/lib/canvas-version-activation.ts
+++ b/web_src/src/pages/app/lib/canvas-version-activation.ts
@@ -1,0 +1,233 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { SetURLSearchParams } from "react-router-dom";
+
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import { canvasKeys, invalidateStagedCanvasCaches } from "@/hooks/useCanvasData";
+
+import { clearComponentSidebarSearchParams } from "../viewState";
+
+export function updateCanvasDetailForSelectedVersion({
+  queryClient,
+  organizationId,
+  canvasId,
+  isCurrentLive,
+  version,
+  liveCanvasVersion,
+  liveCanvas,
+}: {
+  queryClient: QueryClient;
+  organizationId: string;
+  canvasId: string;
+  isCurrentLive: boolean;
+  version: CanvasesCanvasVersion;
+  liveCanvasVersion?: CanvasesCanvasVersion;
+  liveCanvas?: CanvasesCanvas | null;
+}) {
+  queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
+    if (!current) {
+      return current;
+    }
+
+    if (isCurrentLive) {
+      return { ...current, spec: liveCanvasVersion?.spec || liveCanvas?.spec };
+    }
+
+    if (!version.spec) {
+      return current;
+    }
+
+    return { ...current, spec: { ...current.spec, ...version.spec } };
+  });
+}
+
+export function refreshLiveCanvasAfterVersionSelection({
+  queryClient,
+  organizationId,
+  canvasId,
+  activeCanvasVersionIdRef,
+  initializeFromWorkflow,
+}: {
+  queryClient: QueryClient;
+  organizationId: string;
+  canvasId: string;
+  activeCanvasVersionIdRef: { current: string };
+  initializeFromWorkflow: (canvas: CanvasesCanvas) => void;
+}) {
+  void Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.detail(organizationId, canvasId),
+      refetchType: "all",
+    }),
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.infiniteRuns(canvasId),
+      refetchType: "all",
+    }),
+  ]).then(() => {
+    const refreshedLiveCanvas = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+    if (!refreshedLiveCanvas || activeCanvasVersionIdRef.current !== "") {
+      return;
+    }
+
+    initializeFromWorkflow(refreshedLiveCanvas);
+  });
+}
+
+type DraftSpec = CanvasesCanvas["spec"] | null;
+
+function isCurrentLiveVersion(
+  versionId: string,
+  effectiveLiveCanvasVersionId?: string,
+  liveCanvasVersionId?: string,
+): boolean {
+  return (
+    (!!effectiveLiveCanvasVersionId && versionId === effectiveLiveCanvasVersionId) ||
+    (!!liveCanvasVersionId && versionId === liveCanvasVersionId)
+  );
+}
+
+function stashDraftSpecForPreviousVersion({
+  previousVersionId,
+  draftCanvasSpec,
+  draftCanvasSpecsRef,
+}: {
+  previousVersionId: string;
+  draftCanvasSpec: DraftSpec;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, DraftSpec>>;
+}) {
+  if (!previousVersionId || !draftCanvasSpec) {
+    return;
+  }
+
+  draftCanvasSpecsRef.current.set(previousVersionId, draftCanvasSpec);
+}
+
+function applyDraftSpecForVersionSwitch({
+  isCurrentLive,
+  preserveStagedLayer,
+  version,
+  setDraftCanvasSpec,
+}: {
+  isCurrentLive: boolean;
+  preserveStagedLayer: boolean;
+  version: CanvasesCanvasVersion;
+  setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
+}) {
+  if (!isCurrentLive) {
+    setDraftCanvasSpec(version.spec ?? null);
+    return;
+  }
+
+  if (!preserveStagedLayer) {
+    setDraftCanvasSpec(null);
+  }
+}
+
+export function activateCanvasVersionForEditing({
+  organizationId,
+  canvasId,
+  versionID,
+  version,
+  options,
+  effectiveLiveCanvasVersionId,
+  liveCanvasVersionId,
+  queryClient,
+  draftCanvasSpec,
+  draftCanvasSpecsRef,
+  activeCanvasVersionIdRef,
+  lastAppliedVersionSnapshotRef,
+  liveCanvasVersion,
+  liveCanvas,
+  clearPendingAutoSaveWork,
+  setDraftCanvasSpec,
+  setActiveCanvasVersion,
+  setLastSavedWorkflowSnapshot,
+  setSearchParams,
+  initializeFromWorkflow,
+}: {
+  organizationId?: string;
+  canvasId?: string;
+  versionID: string;
+  version: CanvasesCanvasVersion;
+  options?: { preserveStagedLayer?: boolean };
+  effectiveLiveCanvasVersionId?: string;
+  liveCanvasVersionId?: string;
+  queryClient: QueryClient;
+  draftCanvasSpec: DraftSpec;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, DraftSpec>>;
+  activeCanvasVersionIdRef: MutableRefObject<string>;
+  lastAppliedVersionSnapshotRef: MutableRefObject<string>;
+  liveCanvasVersion?: CanvasesCanvasVersion;
+  liveCanvas?: CanvasesCanvas | null;
+  clearPendingAutoSaveWork: () => void;
+  setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
+  setActiveCanvasVersion: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
+  setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
+  setSearchParams: SetURLSearchParams;
+  initializeFromWorkflow: (canvas: CanvasesCanvas) => void;
+}): boolean {
+  if (!organizationId || !canvasId) {
+    return false;
+  }
+
+  const versionId = version.metadata?.id || "";
+  const isCurrentLive = isCurrentLiveVersion(versionId, effectiveLiveCanvasVersionId, liveCanvasVersionId);
+  const preserveStagedLayer = !!options?.preserveStagedLayer && isCurrentLive;
+
+  clearPendingAutoSaveWork();
+  stashDraftSpecForPreviousVersion({
+    previousVersionId: activeCanvasVersionIdRef.current,
+    draftCanvasSpec,
+    draftCanvasSpecsRef,
+  });
+
+  if (isCurrentLive && !preserveStagedLayer) {
+    draftCanvasSpecsRef.current.delete(versionId);
+    invalidateStagedCanvasCaches(queryClient, canvasId);
+  }
+
+  if (!isCurrentLive) {
+    void queryClient.cancelQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
+  }
+
+  activeCanvasVersionIdRef.current = versionID;
+  applyDraftSpecForVersionSwitch({ isCurrentLive, preserveStagedLayer, version, setDraftCanvasSpec });
+  setActiveCanvasVersion(version);
+  lastAppliedVersionSnapshotRef.current = "";
+  setLastSavedWorkflowSnapshot(null);
+
+  setSearchParams((current) => {
+    const next = new URLSearchParams(current);
+    next.delete("branch");
+    if (isCurrentLive) {
+      next.delete("version");
+    } else {
+      next.set("version", versionID);
+    }
+    return clearComponentSidebarSearchParams(next);
+  });
+
+  if (!preserveStagedLayer) {
+    updateCanvasDetailForSelectedVersion({
+      queryClient,
+      organizationId,
+      canvasId,
+      isCurrentLive,
+      version,
+      liveCanvasVersion,
+      liveCanvas,
+    });
+  }
+
+  if (isCurrentLive && !preserveStagedLayer) {
+    refreshLiveCanvasAfterVersionSelection({
+      queryClient,
+      organizationId,
+      canvasId,
+      activeCanvasVersionIdRef,
+      initializeFromWorkflow,
+    });
+  }
+
+  return true;
+}

--- a/web_src/src/pages/app/lib/commit-staging-flow.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.ts
@@ -12,11 +12,18 @@ async function invalidatePostCommitCaches(
   organizationId: string,
   canvasId: string,
 ): Promise<void> {
+  // Drop canvas-scoped staged overlays immediately so a re-enter after commit
+  // cannot briefly resolve the previous live version id from warm cache.
+  queryClient.removeQueries({ queryKey: canvasKeys.stagedCanvasSpec(canvasId) });
+  queryClient.removeQueries({ queryKey: canvasKeys.stagedConsole(canvasId) });
+
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId), refetchType: "all" }),
+    queryClient.invalidateQueries({ queryKey: canvasKeys.stagedCanvasSpec(canvasId), refetchType: "all" }),
+    queryClient.invalidateQueries({ queryKey: canvasKeys.stagedConsole(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, undefined), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId), refetchType: "all" }),
   ]);

--- a/web_src/src/pages/app/lib/commit-staging-flow.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.ts
@@ -43,6 +43,34 @@ async function removeStaleVersionQueriesAfterCommit(
   removeCanvasVersionScopedQueries(queryClient, canvasId, previousVersionId);
 }
 
+function clearDraftSpecsAfterCommit(
+  draftCanvasSpecsRef: MutableRefObject<Map<string, DraftSpec>>,
+  activeCanvasVersionId: string,
+  committedVersionId: string,
+) {
+  draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
+  if (committedVersionId !== activeCanvasVersionId) {
+    draftCanvasSpecsRef.current.delete(committedVersionId);
+  }
+}
+
+async function applyPostCommitCacheUpdates({
+  queryClient,
+  organizationId,
+  canvasId,
+  previousVersionId,
+  committedVersionId,
+}: {
+  queryClient: QueryClient;
+  organizationId: string;
+  canvasId: string;
+  previousVersionId: string;
+  committedVersionId: string;
+}) {
+  await removeStaleVersionQueriesAfterCommit(queryClient, canvasId, previousVersionId, committedVersionId);
+  await invalidatePostCommitCaches(queryClient, organizationId, canvasId);
+}
+
 export async function executeCommitStaging({
   organizationId,
   canvasId,
@@ -95,16 +123,17 @@ export async function executeCommitStaging({
   // Leave edit mode before touching caches so version-scoped hooks (console,
   // files, baselines) stop querying the pre-commit live version id.
   onCommittedVersionId?.(committedVersionId);
-
-  draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
-  if (committedVersionId !== activeCanvasVersionId) {
-    draftCanvasSpecsRef.current.delete(committedVersionId);
-  }
+  clearDraftSpecsAfterCommit(draftCanvasSpecsRef, activeCanvasVersionId, committedVersionId);
   setDraftCanvasSpec(null);
 
   if (organizationId && canvasId && committedVersionId) {
-    await removeStaleVersionQueriesAfterCommit(queryClient, canvasId, previousVersionId, committedVersionId);
-    await invalidatePostCommitCaches(queryClient, organizationId, canvasId);
+    await applyPostCommitCacheUpdates({
+      queryClient,
+      organizationId,
+      canvasId,
+      previousVersionId,
+      committedVersionId,
+    });
   }
 
   releaseCanvasUpdatedEcho?.();

--- a/web_src/src/pages/app/lib/edit-staging-ready.spec.ts
+++ b/web_src/src/pages/app/lib/edit-staging-ready.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isDraftCanvasLoadingWhileEditing, isEditBootstrapReady, isEditStagingActionsReady } from "./edit-staging-ready";
+import {
+  isDraftCanvasLoadingWhileEditing,
+  isEditBootstrapReady,
+  isEditStagingActionsReady,
+} from "./edit-staging-ready";
 
 describe("isEditBootstrapReady", () => {
   it("waits for baselines and staged draft before edit UI is shown", () => {

--- a/web_src/src/pages/app/lib/edit-staging-ready.spec.ts
+++ b/web_src/src/pages/app/lib/edit-staging-ready.spec.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import { isDraftCanvasLoadingWhileEditing, isEditBootstrapReady, isEditStagingActionsReady } from "./edit-staging-ready";
+
+describe("isEditBootstrapReady", () => {
+  it("waits for baselines and staged draft before edit UI is shown", () => {
+    expect(
+      isEditBootstrapReady({
+        isEditing: true,
+        isEnteringEditSession: false,
+        stagingBaselinesReady: false,
+        draftCanvasSpec: { nodes: [] },
+        shouldReadStagedCanvasVersion: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      isEditBootstrapReady({
+        isEditing: true,
+        isEnteringEditSession: false,
+        stagingBaselinesReady: true,
+        draftCanvasSpec: null,
+        shouldReadStagedCanvasVersion: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      isEditBootstrapReady({
+        isEditing: true,
+        isEnteringEditSession: false,
+        stagingBaselinesReady: true,
+        draftCanvasSpec: { nodes: [] },
+        shouldReadStagedCanvasVersion: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isEditStagingActionsReady", () => {
+  it("is always ready outside edit mode", () => {
+    expect(
+      isEditStagingActionsReady({
+        isEditing: false,
+        isEnteringEditSession: true,
+        stagingBaselinesReady: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("waits for the edit-session bootstrap and committed baselines", () => {
+    expect(
+      isEditStagingActionsReady({
+        isEditing: true,
+        isEnteringEditSession: true,
+        stagingBaselinesReady: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      isEditStagingActionsReady({
+        isEditing: true,
+        isEnteringEditSession: false,
+        stagingBaselinesReady: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      isEditStagingActionsReady({
+        isEditing: true,
+        isEnteringEditSession: false,
+        stagingBaselinesReady: true,
+        draftCanvasSpec: { nodes: [] },
+        shouldReadStagedCanvasVersion: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isDraftCanvasLoadingWhileEditing", () => {
+  it("keeps loading until edit bootstrap is fully ready", () => {
+    expect(
+      isDraftCanvasLoadingWhileEditing({
+        isEditing: true,
+        shouldReadStagedCanvasVersion: true,
+        isEnteringEditSession: false,
+        isEditBootstrapReady: false,
+        draftCanvasSpec: { nodes: [] },
+        loadedCanvasVersionLoading: false,
+        loadedCanvasVersionFetching: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isDraftCanvasLoadingWhileEditing({
+        isEditing: true,
+        shouldReadStagedCanvasVersion: true,
+        isEnteringEditSession: false,
+        isEditBootstrapReady: true,
+        draftCanvasSpec: { nodes: [] },
+        loadedCanvasVersionLoading: false,
+        loadedCanvasVersionFetching: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows loading while entering edit mode before the edit session is active", () => {
+    expect(
+      isDraftCanvasLoadingWhileEditing({
+        isEditing: false,
+        shouldReadStagedCanvasVersion: false,
+        isEnteringEditSession: true,
+        isEditBootstrapReady: false,
+        draftCanvasSpec: null,
+        loadedCanvasVersionLoading: false,
+        loadedCanvasVersionFetching: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not load outside edit mode when not entering edit", () => {
+    expect(
+      isDraftCanvasLoadingWhileEditing({
+        isEditing: false,
+        shouldReadStagedCanvasVersion: true,
+        isEnteringEditSession: false,
+        isEditBootstrapReady: true,
+        draftCanvasSpec: null,
+        loadedCanvasVersionLoading: true,
+        loadedCanvasVersionFetching: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      isDraftCanvasLoadingWhileEditing({
+        isEditing: true,
+        shouldReadStagedCanvasVersion: false,
+        isEnteringEditSession: false,
+        isEditBootstrapReady: true,
+        draftCanvasSpec: null,
+        loadedCanvasVersionLoading: true,
+        loadedCanvasVersionFetching: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows loading while entering edit mode before staged draft is applied", () => {
+    expect(
+      isDraftCanvasLoadingWhileEditing({
+        isEditing: true,
+        shouldReadStagedCanvasVersion: true,
+        isEnteringEditSession: true,
+        isEditBootstrapReady: false,
+        draftCanvasSpec: null,
+        loadedCanvasVersionLoading: false,
+        loadedCanvasVersionFetching: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("stops loading once the staged draft spec is available", () => {
+    expect(
+      isDraftCanvasLoadingWhileEditing({
+        isEditing: true,
+        shouldReadStagedCanvasVersion: true,
+        isEnteringEditSession: false,
+        isEditBootstrapReady: true,
+        draftCanvasSpec: { nodes: [] },
+        loadedCanvasVersionLoading: true,
+        loadedCanvasVersionFetching: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps loading until staged version data arrives when draft spec is still empty", () => {
+    expect(
+      isDraftCanvasLoadingWhileEditing({
+        isEditing: true,
+        shouldReadStagedCanvasVersion: true,
+        isEnteringEditSession: false,
+        isEditBootstrapReady: false,
+        draftCanvasSpec: null,
+        loadedCanvasVersionLoading: true,
+        loadedCanvasVersionFetching: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/web_src/src/pages/app/lib/edit-staging-ready.ts
+++ b/web_src/src/pages/app/lib/edit-staging-ready.ts
@@ -1,0 +1,79 @@
+export function isEditBootstrapReady({
+  isEditing,
+  isEnteringEditSession,
+  stagingBaselinesReady,
+  draftCanvasSpec,
+  shouldReadStagedCanvasVersion,
+}: {
+  isEditing: boolean;
+  isEnteringEditSession: boolean;
+  stagingBaselinesReady: boolean;
+  draftCanvasSpec: unknown;
+  shouldReadStagedCanvasVersion: boolean;
+}): boolean {
+  if (!isEditing) {
+    return true;
+  }
+
+  if (isEnteringEditSession || !stagingBaselinesReady) {
+    return false;
+  }
+
+  if (shouldReadStagedCanvasVersion && !draftCanvasSpec) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isEditStagingActionsReady(params: {
+  isEditing: boolean;
+  isEnteringEditSession: boolean;
+  stagingBaselinesReady: boolean;
+  draftCanvasSpec?: unknown;
+  shouldReadStagedCanvasVersion?: boolean;
+}): boolean {
+  return isEditBootstrapReady({
+    isEditing: params.isEditing,
+    isEnteringEditSession: params.isEnteringEditSession,
+    stagingBaselinesReady: params.stagingBaselinesReady,
+    draftCanvasSpec: params.draftCanvasSpec,
+    shouldReadStagedCanvasVersion: params.shouldReadStagedCanvasVersion ?? false,
+  });
+}
+
+export function isDraftCanvasLoadingWhileEditing({
+  isEditing,
+  shouldReadStagedCanvasVersion,
+  isEnteringEditSession,
+  isEditBootstrapReady,
+  draftCanvasSpec,
+  loadedCanvasVersionLoading,
+  loadedCanvasVersionFetching,
+}: {
+  isEditing: boolean;
+  shouldReadStagedCanvasVersion: boolean;
+  isEnteringEditSession: boolean;
+  isEditBootstrapReady: boolean;
+  draftCanvasSpec: unknown;
+  loadedCanvasVersionLoading: boolean;
+  loadedCanvasVersionFetching: boolean;
+}): boolean {
+  if (isEnteringEditSession) {
+    return true;
+  }
+
+  if (isEditing && !isEditBootstrapReady) {
+    return true;
+  }
+
+  if (!isEditing || !shouldReadStagedCanvasVersion) {
+    return false;
+  }
+
+  if (draftCanvasSpec) {
+    return false;
+  }
+
+  return loadedCanvasVersionLoading || loadedCanvasVersionFetching;
+}

--- a/web_src/src/pages/app/lib/editable-workflow-snapshot.spec.ts
+++ b/web_src/src/pages/app/lib/editable-workflow-snapshot.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { CanvasesCanvas } from "@/api-client";
+
+import { resolveEditableWorkflowSnapshot } from "./editable-workflow-snapshot";
+
+const stagedWorkflow = {
+  metadata: { id: "canvas-1", name: "Canvas" },
+  spec: { nodes: [{ id: "staged-note", name: "TAB1-DRAFT" }], edges: [] },
+} as CanvasesCanvas;
+
+const committedWorkflow = {
+  metadata: { id: "canvas-1", name: "Canvas" },
+  spec: { nodes: [], edges: [] },
+} as CanvasesCanvas;
+
+describe("resolveEditableWorkflowSnapshot", () => {
+  it("prefers the rendered draft workflow while editing", () => {
+    expect(
+      resolveEditableWorkflowSnapshot({
+        isEditing: true,
+        renderedWorkflow: stagedWorkflow,
+        detailWorkflow: committedWorkflow,
+      }),
+    ).toBe(stagedWorkflow);
+  });
+
+  it("uses the detail workflow in view mode", () => {
+    expect(
+      resolveEditableWorkflowSnapshot({
+        isEditing: false,
+        renderedWorkflow: stagedWorkflow,
+        detailWorkflow: committedWorkflow,
+      }),
+    ).toBe(committedWorkflow);
+  });
+
+  it("falls back to the rendered workflow when detail is missing", () => {
+    expect(
+      resolveEditableWorkflowSnapshot({
+        isEditing: false,
+        renderedWorkflow: committedWorkflow,
+        detailWorkflow: undefined,
+      }),
+    ).toBe(committedWorkflow);
+  });
+});

--- a/web_src/src/pages/app/lib/editable-workflow-snapshot.ts
+++ b/web_src/src/pages/app/lib/editable-workflow-snapshot.ts
@@ -1,0 +1,17 @@
+import type { CanvasesCanvas } from "@/api-client";
+
+export function resolveEditableWorkflowSnapshot({
+  isEditing,
+  renderedWorkflow,
+  detailWorkflow,
+}: {
+  isEditing: boolean;
+  renderedWorkflow: CanvasesCanvas | null | undefined;
+  detailWorkflow: CanvasesCanvas | null | undefined;
+}): CanvasesCanvas | null | undefined {
+  if (isEditing && renderedWorkflow?.spec) {
+    return renderedWorkflow;
+  }
+
+  return detailWorkflow ?? renderedWorkflow ?? null;
+}

--- a/web_src/src/pages/app/lib/live-edit-session.spec.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldReadStagedCanvasVersion } from "./live-edit-session";
+import {
+  isAwaitingStagedCanvasSpec,
+  isViewingCurrentLiveCanvasVersion,
+  resolveSelectedCanvasVersion,
+  shouldReadStagedCanvasVersion,
+} from "./live-edit-session";
 
 describe("shouldReadStagedCanvasVersion", () => {
   it("reads staged content only while editing the live version", () => {
@@ -34,5 +39,128 @@ describe("shouldReadStagedCanvasVersion", () => {
         liveCanvasVersionId: "live-version",
       }),
     ).toBe(false);
+  });
+});
+
+describe("isAwaitingStagedCanvasSpec", () => {
+  it("is true while entering edit before staged content is cached", () => {
+    expect(
+      isAwaitingStagedCanvasSpec({
+        activeCanvasVersionId: "live-version",
+        shouldReadStagedCanvasVersion: true,
+        loadedStagedCanvasVersion: undefined,
+        loadedStagedCanvasVersionLoading: false,
+        loadedStagedCanvasVersionFetching: false,
+        isEnteringEditSession: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores staged cache from a previous live version after commit", () => {
+    expect(
+      isAwaitingStagedCanvasSpec({
+        activeCanvasVersionId: "new-live-version",
+        shouldReadStagedCanvasVersion: true,
+        loadedStagedCanvasVersion: {
+          metadata: { id: "old-live-version" },
+          spec: { nodes: [{ id: "stale-node" }], edges: [] },
+        },
+        loadedStagedCanvasVersionLoading: false,
+        loadedStagedCanvasVersionFetching: true,
+        isEnteringEditSession: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isViewingCurrentLiveCanvasVersion", () => {
+  it("treats the active live version as current even when selected content is stale", () => {
+    expect(
+      isViewingCurrentLiveCanvasVersion({
+        activeCanvasVersionId: "new-live-version",
+        selectedCanvasVersion: {
+          metadata: { id: "old-live-version" },
+          spec: { nodes: [], edges: [] },
+        },
+        effectiveLiveCanvasVersionId: "new-live-version",
+        liveCanvasVersionId: "new-live-version",
+      }),
+    ).toBe(true);
+  });
+
+  it("still reports historical previews as non-live", () => {
+    expect(
+      isViewingCurrentLiveCanvasVersion({
+        activeCanvasVersionId: "old-version",
+        selectedCanvasVersion: {
+          metadata: { id: "old-version" },
+          spec: { nodes: [], edges: [] },
+        },
+        effectiveLiveCanvasVersionId: "new-live-version",
+        liveCanvasVersionId: "new-live-version",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveSelectedCanvasVersion", () => {
+  const shellVersion = {
+    metadata: { id: "live-version" },
+    spec: { nodes: [{ id: "list-node" }], edges: [] },
+  };
+  const stagedVersion = {
+    metadata: { id: "live-version" },
+    spec: { nodes: [{ id: "staged-node" }], edges: [] },
+  };
+
+  it("returns staged content when available", () => {
+    expect(
+      resolveSelectedCanvasVersion({
+        activeCanvasVersionId: "live-version",
+        shouldReadStagedCanvasVersion: true,
+        loadedStagedCanvasVersion: stagedVersion,
+        loadedCommittedCanvasVersion: undefined,
+        activeCanvasVersion: shellVersion,
+        isAwaitingStagedSpec: false,
+      }),
+    ).toBe(stagedVersion);
+  });
+
+  it("strips shell spec while staged content is still loading", () => {
+    expect(
+      resolveSelectedCanvasVersion({
+        activeCanvasVersionId: "live-version",
+        shouldReadStagedCanvasVersion: true,
+        loadedStagedCanvasVersion: undefined,
+        loadedCommittedCanvasVersion: undefined,
+        activeCanvasVersion: shellVersion,
+        isAwaitingStagedSpec: true,
+      }),
+    ).toEqual({
+      metadata: { id: "live-version" },
+      spec: undefined,
+    });
+  });
+
+  it("ignores staged cache from a previous live version after commit", () => {
+    expect(
+      resolveSelectedCanvasVersion({
+        activeCanvasVersionId: "new-live-version",
+        shouldReadStagedCanvasVersion: true,
+        loadedStagedCanvasVersion: {
+          metadata: { id: "old-live-version" },
+          spec: { nodes: [{ id: "stale-node" }], edges: [] },
+        },
+        loadedCommittedCanvasVersion: undefined,
+        activeCanvasVersion: {
+          metadata: { id: "new-live-version" },
+          spec: { nodes: [{ id: "live-node" }], edges: [] },
+        },
+        isAwaitingStagedSpec: false,
+      }),
+    ).toEqual({
+      metadata: { id: "new-live-version" },
+      spec: { nodes: [{ id: "live-node" }], edges: [] },
+    });
   });
 });

--- a/web_src/src/pages/app/lib/live-edit-session.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.ts
@@ -6,6 +6,131 @@ import { canvasKeys } from "@/hooks/useCanvasData";
 
 import { clearComponentSidebarSearchParams } from "../viewState";
 
+export function isActiveCanvasVersionCurrentLive({
+  activeCanvasVersionId,
+  effectiveLiveCanvasVersionId,
+  liveCanvasVersionId,
+}: {
+  activeCanvasVersionId: string;
+  effectiveLiveCanvasVersionId?: string;
+  liveCanvasVersionId?: string;
+}): boolean {
+  if (!activeCanvasVersionId) {
+    return false;
+  }
+
+  return (
+    (!!effectiveLiveCanvasVersionId && activeCanvasVersionId === effectiveLiveCanvasVersionId) ||
+    (!!liveCanvasVersionId && activeCanvasVersionId === liveCanvasVersionId)
+  );
+}
+
+export function isViewingCurrentLiveCanvasVersion({
+  activeCanvasVersionId,
+  selectedCanvasVersion,
+  effectiveLiveCanvasVersionId,
+  liveCanvasVersionId,
+}: {
+  activeCanvasVersionId: string;
+  selectedCanvasVersion: CanvasesCanvasVersion | null;
+  effectiveLiveCanvasVersionId?: string;
+  liveCanvasVersionId?: string;
+}): boolean {
+  if (
+    isActiveCanvasVersionCurrentLive({
+      activeCanvasVersionId,
+      effectiveLiveCanvasVersionId,
+      liveCanvasVersionId,
+    })
+  ) {
+    return true;
+  }
+
+  if (!selectedCanvasVersion) {
+    return true;
+  }
+
+  const selectedVersionId = selectedCanvasVersion.metadata?.id;
+  return (
+    (!!effectiveLiveCanvasVersionId && selectedVersionId === effectiveLiveCanvasVersionId) ||
+    selectedVersionId === liveCanvasVersionId
+  );
+}
+
+function isStagedCanvasVersionForActiveVersion(
+  loadedStagedCanvasVersion: CanvasesCanvasVersion | null | undefined,
+  activeCanvasVersionId: string,
+): loadedStagedCanvasVersion is CanvasesCanvasVersion {
+  return (
+    !!loadedStagedCanvasVersion?.metadata?.id && loadedStagedCanvasVersion.metadata.id === activeCanvasVersionId
+  );
+}
+
+export function isAwaitingStagedCanvasSpec({
+  activeCanvasVersionId,
+  shouldReadStagedCanvasVersion,
+  loadedStagedCanvasVersion,
+  loadedStagedCanvasVersionLoading,
+  loadedStagedCanvasVersionFetching,
+  isEnteringEditSession,
+}: {
+  activeCanvasVersionId: string;
+  shouldReadStagedCanvasVersion: boolean;
+  loadedStagedCanvasVersion: CanvasesCanvasVersion | null | undefined;
+  loadedStagedCanvasVersionLoading: boolean;
+  loadedStagedCanvasVersionFetching: boolean;
+  isEnteringEditSession: boolean;
+}): boolean {
+  const matchedStagedCanvasVersion = isStagedCanvasVersionForActiveVersion(
+    loadedStagedCanvasVersion,
+    activeCanvasVersionId,
+  )
+    ? loadedStagedCanvasVersion
+    : undefined;
+
+  return (
+    shouldReadStagedCanvasVersion &&
+    !matchedStagedCanvasVersion &&
+    (loadedStagedCanvasVersionLoading || loadedStagedCanvasVersionFetching || isEnteringEditSession)
+  );
+}
+
+// While staged canvas.yaml is still loading, avoid falling back to the version-list
+// shell spec (committed snapshot) which would overwrite resynced draft state.
+export function resolveSelectedCanvasVersion({
+  activeCanvasVersionId,
+  shouldReadStagedCanvasVersion,
+  loadedStagedCanvasVersion,
+  loadedCommittedCanvasVersion,
+  activeCanvasVersion,
+  isAwaitingStagedSpec,
+}: {
+  activeCanvasVersionId: string;
+  shouldReadStagedCanvasVersion: boolean;
+  loadedStagedCanvasVersion: CanvasesCanvasVersion | null | undefined;
+  loadedCommittedCanvasVersion: CanvasesCanvasVersion | null | undefined;
+  activeCanvasVersion: CanvasesCanvasVersion | null;
+  isAwaitingStagedSpec: boolean;
+}): CanvasesCanvasVersion | null {
+  if (!activeCanvasVersionId) {
+    return null;
+  }
+
+  if (shouldReadStagedCanvasVersion) {
+    if (isStagedCanvasVersionForActiveVersion(loadedStagedCanvasVersion, activeCanvasVersionId)) {
+      return loadedStagedCanvasVersion;
+    }
+
+    if (isAwaitingStagedSpec && activeCanvasVersion) {
+      return { ...activeCanvasVersion, spec: undefined };
+    }
+
+    return activeCanvasVersion;
+  }
+
+  return loadedCommittedCanvasVersion || activeCanvasVersion;
+}
+
 export function shouldReadStagedCanvasVersion({
   editSessionActive,
   activeCanvasVersionId,

--- a/web_src/src/pages/app/lib/live-edit-session.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.ts
@@ -61,9 +61,7 @@ function isStagedCanvasVersionForActiveVersion(
   loadedStagedCanvasVersion: CanvasesCanvasVersion | null | undefined,
   activeCanvasVersionId: string,
 ): loadedStagedCanvasVersion is CanvasesCanvasVersion {
-  return (
-    !!loadedStagedCanvasVersion?.metadata?.id && loadedStagedCanvasVersion.metadata.id === activeCanvasVersionId
-  );
+  return !!loadedStagedCanvasVersion?.metadata?.id && loadedStagedCanvasVersion.metadata.id === activeCanvasVersionId;
 }
 
 export function isAwaitingStagedCanvasSpec({

--- a/web_src/src/pages/app/lib/repository-spec-files.spec.ts
+++ b/web_src/src/pages/app/lib/repository-spec-files.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fetchRepositorySpecFileContent } from "./repository-spec-files";
+import { fetchRepositorySpecFileContent, fetchStagedCanvasVersionWithSpec } from "./repository-spec-files";
 
 describe("fetchRepositorySpecFileContent", () => {
   beforeEach(() => {
@@ -39,5 +39,33 @@ describe("fetchRepositorySpecFileContent", () => {
       "/api/v1/canvases/canvas-1/repository/file?path=canvas.yaml&stage=true",
       expect.any(Object),
     );
+  });
+});
+
+describe("fetchStagedCanvasVersionWithSpec", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nodes: []", { status: 200 })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("only reads staged canvas.yaml and reuses provided version metadata", async () => {
+    const version = await fetchStagedCanvasVersionWithSpec("canvas-1", {
+      metadata: { id: "version-1" },
+      spec: { nodes: [], edges: [] },
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/v1/canvases/canvas-1/repository/file?path=canvas.yaml&stage=true",
+      expect.any(Object),
+    );
+    expect(version?.metadata?.id).toBe("version-1");
+    expect(version?.spec?.nodes).toEqual([]);
   });
 });

--- a/web_src/src/pages/app/lib/repository-spec-files.ts
+++ b/web_src/src/pages/app/lib/repository-spec-files.ts
@@ -12,7 +12,7 @@ import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "./workflow-spec-paths";
 import { isNotFoundError } from "../workflowPageHelpers";
 
 // Confirms whether a canvas version still exists. Used to distinguish a deleted
-// version from an incidental repository-file 404, since fetchCanvasVersionWithSpec
+// version from an incidental repository-file 404, since fetchCommittedCanvasVersionWithSpec
 // loads the version and its canvas.yaml in parallel. A non-404 describe error is
 // treated as "exists" so the original failure is surfaced as transient.
 export async function canvasVersionExists(canvasId: string, versionId: string): Promise<boolean> {
@@ -66,14 +66,6 @@ export async function fetchCanvasStagingSummary(canvasId: string): Promise<Canva
   return response.data?.stagingSummary;
 }
 
-/** @deprecated Use fetchCanvasStagingSummary */
-export async function fetchCanvasVersionStagingSummary(
-  canvasId: string,
-  _versionId: string,
-): Promise<CanvasesStagingSummary | undefined> {
-  return fetchCanvasStagingSummary(canvasId);
-}
-
 export function canvasVersionWithSpecFromYaml(
   version: CanvasesCanvasVersion | undefined,
   canvasYaml: string | undefined,
@@ -94,10 +86,22 @@ export function canvasVersionWithSpecFromYaml(
   return { ...version, spec };
 }
 
-export async function fetchCanvasVersionWithSpec(
+// fetchStagedCanvasVersionWithSpec reads the canvas-scoped staging layer. Staging
+// is not keyed by version id; version metadata is only used as a display shell.
+export async function fetchStagedCanvasVersionWithSpec(
+  canvasId: string,
+  versionMetadata?: CanvasesCanvasVersion,
+): Promise<CanvasesCanvasVersion | undefined> {
+  const canvasYaml = await fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH, undefined, true);
+  return canvasVersionWithSpecFromYaml(versionMetadata, canvasYaml);
+}
+
+// fetchCommittedCanvasVersionWithSpec reads immutable committed content for a
+// specific version. Versions never change after publish, so callers should cache
+// aggressively and avoid invalidating these reads.
+export async function fetchCommittedCanvasVersionWithSpec(
   canvasId: string,
   versionId: string,
-  stage = false,
 ): Promise<CanvasesCanvasVersion | undefined> {
   const describeResponse = await canvasesDescribeCanvasVersion(
     withOrganizationHeader({
@@ -106,13 +110,9 @@ export async function fetchCanvasVersionWithSpec(
   );
 
   try {
-    const canvasYaml = await fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH, versionId, stage);
+    const canvasYaml = await fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH, versionId, false);
     return canvasVersionWithSpecFromYaml(describeResponse.data?.version, canvasYaml);
   } catch (error) {
-    if (stage) {
-      throw error;
-    }
-
     // Committed yaml reads are live-version-only. Historical versions keep their
     // graph on the version row returned by the list API.
     const listResponse = await canvasesListCanvasVersions(

--- a/web_src/src/pages/app/lib/resolve-canvas-for-view.spec.ts
+++ b/web_src/src/pages/app/lib/resolve-canvas-for-view.spec.ts
@@ -40,6 +40,19 @@ describe("resolveCanvasForView", () => {
     expect(canvas?.spec).toEqual(liveCanvas.spec);
   });
 
+  it("keeps the live canvas visible while the staged draft is still loading in edit mode", () => {
+    const canvas = resolveCanvasForView({
+      isEditing: true,
+      isViewingCurrentLiveVersion: true,
+      liveCanvas,
+      draftSpecToRender: null,
+      selectedCanvasVersion: null,
+      canvasId: "canvas-1",
+    });
+
+    expect(canvas?.spec).toEqual(liveCanvas.spec);
+  });
+
   it("overlays a committed historical version when previewing outside edit mode", () => {
     const historicalSpec = { nodes: [{ id: "old-node" }], edges: [] };
 

--- a/web_src/src/pages/app/lib/resolve-canvas-for-view.ts
+++ b/web_src/src/pages/app/lib/resolve-canvas-for-view.ts
@@ -38,7 +38,9 @@ export function resolveCanvasForView({
 }): CanvasesCanvas | null | undefined {
   if (isEditing) {
     if (!draftSpecToRender) {
-      return null;
+      // Keep the live graph visible under enter-edit loading until staged draft
+      // state is applied. Returning null here clears prepared nodes and flashes empty.
+      return liveCanvas ?? null;
     }
 
     return buildEditingCanvasView(liveCanvas, draftSpecToRender, canvasId);

--- a/web_src/src/pages/app/lib/sync-committed-canvas-draft.spec.ts
+++ b/web_src/src/pages/app/lib/sync-committed-canvas-draft.spec.ts
@@ -5,10 +5,10 @@ import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
 import { syncCommittedCanvasDraftState, syncCommittedConsoleCaches } from "./sync-committed-canvas-draft";
-import { fetchCanvasVersionWithSpec, fetchLiveCommittedCanvasVersionWithSpec } from "./repository-spec-files";
+import { fetchCommittedCanvasVersionWithSpec, fetchLiveCommittedCanvasVersionWithSpec } from "./repository-spec-files";
 
 vi.mock("./repository-spec-files", () => ({
-  fetchCanvasVersionWithSpec: vi.fn(),
+  fetchCommittedCanvasVersionWithSpec: vi.fn(),
   fetchLiveCommittedCanvasVersionWithSpec: vi.fn(),
 }));
 
@@ -33,7 +33,7 @@ describe("syncCommittedCanvasDraftState", () => {
         edges: [],
       },
     };
-    vi.mocked(fetchCanvasVersionWithSpec).mockResolvedValue(committedVersion);
+    vi.mocked(fetchCommittedCanvasVersionWithSpec).mockResolvedValue(committedVersion);
 
     const setQueryData = vi.fn();
     const queryClient = { setQueryData } as unknown as QueryClient;
@@ -46,11 +46,8 @@ describe("syncCommittedCanvasDraftState", () => {
     });
 
     expect(result).toEqual(committedVersion);
-    expect(fetchCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1", "version-1", false);
-    expect(setQueryData).toHaveBeenCalledWith(
-      canvasKeys.versionStagedDetail("canvas-1", "version-1"),
-      committedVersion,
-    );
+    expect(fetchCommittedCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1", "version-1");
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.stagedCanvasSpec("canvas-1"), committedVersion);
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "version-1"), committedVersion);
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionList("canvas-1"), expect.any(Function));
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.detail("org-1", "canvas-1"), expect.any(Function));
@@ -79,7 +76,7 @@ describe("syncCommittedCanvasDraftState", () => {
       metadata: { id: "version-2" },
       spec: { nodes: [], edges: [] },
     };
-    vi.mocked(fetchCanvasVersionWithSpec).mockResolvedValue(committedVersion);
+    vi.mocked(fetchCommittedCanvasVersionWithSpec).mockResolvedValue(committedVersion);
 
     const setQueryData = vi.fn();
     const queryClient = { setQueryData } as unknown as QueryClient;
@@ -121,13 +118,13 @@ describe("syncCommittedCanvasDraftState", () => {
 
     expect(result).toEqual(committedVersion);
     expect(fetchLiveCommittedCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1");
-    expect(fetchCanvasVersionWithSpec).not.toHaveBeenCalled();
+    expect(fetchCommittedCanvasVersionWithSpec).not.toHaveBeenCalled();
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "live-version-2"), committedVersion);
   });
 });
 
 describe("syncCommittedConsoleCaches", () => {
-  it("invalidates console caches when committed console.yaml is missing or unparsable", async () => {
+  it("invalidates staged console cache when committed console.yaml is missing or unparsable", async () => {
     vi.mocked(fetchCanvasConsoleData).mockResolvedValue(undefined);
 
     const invalidateQueries = vi.fn().mockResolvedValue(undefined);
@@ -142,10 +139,7 @@ describe("syncCommittedConsoleCaches", () => {
 
     expect(fetchCanvasConsoleData).toHaveBeenCalledWith("canvas-1", "version-1", false);
     expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: canvasKeys.console("canvas-1", "version-1"),
-    });
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: canvasKeys.consoleStaged("canvas-1", "version-1"),
+      queryKey: canvasKeys.stagedConsole("canvas-1"),
     });
     expect(setQueryData).not.toHaveBeenCalled();
   });

--- a/web_src/src/pages/app/lib/sync-committed-canvas-draft.ts
+++ b/web_src/src/pages/app/lib/sync-committed-canvas-draft.ts
@@ -4,7 +4,7 @@ import type { Dispatch, SetStateAction } from "react";
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
-import { fetchCanvasVersionWithSpec, fetchLiveCommittedCanvasVersionWithSpec } from "./repository-spec-files";
+import { fetchCommittedCanvasVersionWithSpec, fetchLiveCommittedCanvasVersionWithSpec } from "./repository-spec-files";
 
 export async function syncCommittedConsoleCaches({
   queryClient,
@@ -17,16 +17,13 @@ export async function syncCommittedConsoleCaches({
 }): Promise<void> {
   const consoleData = await fetchCanvasConsoleData(canvasId, versionId, false);
   if (!consoleData) {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, versionId) }),
-      queryClient.invalidateQueries({ queryKey: canvasKeys.consoleStaged(canvasId, versionId) }),
-    ]);
+    await queryClient.invalidateQueries({ queryKey: canvasKeys.stagedConsole(canvasId) });
     return;
   }
 
   queryClient.setQueryData(canvasKeys.console(canvasId, versionId), consoleData);
   // After commit, staging is cleared — mirror the committed console in the staged cache.
-  queryClient.setQueryData(canvasKeys.consoleStaged(canvasId, versionId), consoleData);
+  queryClient.setQueryData(canvasKeys.stagedConsole(canvasId), consoleData);
 }
 
 export async function syncCommittedCanvasDraftState({
@@ -46,14 +43,14 @@ export async function syncCommittedCanvasDraftState({
 }): Promise<CanvasesCanvasVersion | undefined> {
   const committedVersion = resolveLiveVersion
     ? await fetchLiveCommittedCanvasVersionWithSpec(canvasId)
-    : await fetchCanvasVersionWithSpec(canvasId, versionId, false);
+    : await fetchCommittedCanvasVersionWithSpec(canvasId, versionId);
   if (!committedVersion) {
     return undefined;
   }
 
   const cacheVersionId = committedVersion.metadata?.id ?? versionId;
 
-  queryClient.setQueryData(canvasKeys.versionStagedDetail(canvasId, cacheVersionId), committedVersion);
+  queryClient.setQueryData(canvasKeys.stagedCanvasSpec(canvasId), committedVersion);
   queryClient.setQueryData(canvasKeys.versionDetail(canvasId, cacheVersionId), committedVersion);
 
   if (!skipVersionListUpdate) {

--- a/web_src/src/pages/app/mappers/incident/setSigningSecretSection.tsx
+++ b/web_src/src/pages/app/mappers/incident/setSigningSecretSection.tsx
@@ -19,7 +19,7 @@ import { registerLocalStagingWrite } from "@/lib/canvasStagingEcho";
 import { canvasKeys } from "@/hooks/useCanvasData";
 import { useCanvasId } from "@/hooks/useCanvasId";
 import { encodeRepositoryFileContent } from "../../files/lib/repository-files";
-import { fetchCanvasVersionWithSpec } from "../../lib/repository-spec-files";
+import { fetchCommittedCanvasVersionWithSpec } from "../../lib/repository-spec-files";
 import { materializeCanvasSpec } from "../../lib/workflow-spec-files";
 import { CANVAS_YAML_PATH } from "../../lib/workflow-spec-paths";
 
@@ -113,7 +113,7 @@ export function SetSigningSecretSection({ nodeId }: { nodeId: string }) {
 
       const freshVersion = await queryClient.fetchQuery({
         queryKey: canvasKeys.versionDetail(canvasId, versionId),
-        queryFn: async () => fetchCanvasVersionWithSpec(canvasId, versionId),
+        queryFn: async () => fetchCommittedCanvasVersionWithSpec(canvasId, versionId),
       });
 
       if (!freshVersion) {

--- a/web_src/src/pages/app/runPositionAutoSave.ts
+++ b/web_src/src/pages/app/runPositionAutoSave.ts
@@ -4,6 +4,7 @@ import { getActiveNoteId, restoreActiveNoteFocus } from "@/ui/annotationComponen
 import type { QueryClient } from "@tanstack/react-query";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { CanvasSaveResult } from "./canvasSaveTypes";
+import { resolveEditableWorkflowSnapshot } from "./lib/editable-workflow-snapshot";
 
 function applyPositionUpdates(
   nodes: ComponentsNode[],
@@ -46,6 +47,7 @@ export type RunPositionAutoSaveOptions = {
   canvasId?: string;
   pendingPositionUpdatesRef: MutableRefObject<Map<string, { x: number; y: number }>>;
   isReadOnly: boolean;
+  isEditing: boolean;
   canvasRef: MutableRefObject<CanvasesCanvas | null>;
   queryClient: QueryClient;
   activeCanvasVersionIdRef: MutableRefObject<string>;
@@ -63,6 +65,7 @@ export async function runPositionAutoSave({
   canvasId,
   pendingPositionUpdatesRef,
   isReadOnly,
+  isEditing,
   canvasRef,
   queryClient,
   activeCanvasVersionIdRef,
@@ -85,8 +88,11 @@ export async function runPositionAutoSave({
       return;
     }
 
-    const latestWorkflow =
-      canvasRef.current || queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+    const latestWorkflow = resolveEditableWorkflowSnapshot({
+      isEditing,
+      renderedWorkflow: canvasRef.current,
+      detailWorkflow: queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId)),
+    });
 
     if (!latestWorkflow?.spec?.nodes) return;
 
@@ -117,7 +123,11 @@ export async function runPositionAutoSave({
       }
     });
 
-    const currentWorkflow = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+    const currentWorkflow = resolveEditableWorkflowSnapshot({
+      isEditing,
+      renderedWorkflow: canvasRef.current,
+      detailWorkflow: queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId)),
+    });
 
     if (currentWorkflow?.spec?.nodes && pendingPositionUpdatesRef.current.size > 0) {
       applyLocalWorkflowUpdate(mergePendingPositionUpdates(currentWorkflow, pendingPositionUpdatesRef.current));

--- a/web_src/src/pages/app/useAppDraftStagingData.ts
+++ b/web_src/src/pages/app/useAppDraftStagingData.ts
@@ -2,8 +2,10 @@ import type { CanvasesCanvas } from "@/api-client";
 import { useCanvasStaging, useCommitCanvasStaging, useDiscardCanvasStaging } from "@/hooks/useCanvasData";
 
 import { useCanvasConsoleVersionDiff } from "./useCanvasConsoleVersionDiff";
-import { useCommittedDraftBaselines } from "./useCommittedDraftBaselines";
+import type { useCommittedDraftBaselines } from "./useCommittedDraftBaselines";
 import { useDraftStagingIndicators } from "./useDraftStagingIndicators";
+
+type CommittedBaselines = ReturnType<typeof useCommittedDraftBaselines>;
 
 type UseAppDraftStagingDataOptions = {
   canvasId: string;
@@ -15,6 +17,8 @@ type UseAppDraftStagingDataOptions = {
   draftSpecToRender: CanvasesCanvas["spec"] | null | undefined;
   canvas: CanvasesCanvas | null | undefined;
   getConsoleMutationGeneration: () => number;
+  committedBaselines: CommittedBaselines;
+  editBootstrapReady: boolean;
 };
 
 export function useAppDraftStagingData({
@@ -27,16 +31,12 @@ export function useAppDraftStagingData({
   draftSpecToRender,
   canvas,
   getConsoleMutationGeneration,
+  committedBaselines,
+  editBootstrapReady,
 }: UseAppDraftStagingDataOptions) {
   const canvasStagingQuery = useCanvasStaging(canvasId, hasEditableVersion);
-  const committedBaselines = useCommittedDraftBaselines({
-    canvasId,
-    versionId: activeCanvasVersionId || undefined,
-    enabled: isEditing,
-    stagingResetNonce,
-  });
   const commitCanvasStagingMutation = useCommitCanvasStaging(canvasId);
-  const discardCanvasStagingMutation = useDiscardCanvasStaging(canvasId, activeCanvasVersionId);
+  const discardCanvasStagingMutation = useDiscardCanvasStaging(canvasId);
 
   const canvasConsoleVersionDiff = useCanvasConsoleVersionDiff({
     canvasId,
@@ -53,9 +53,10 @@ export function useAppDraftStagingData({
   });
   const { consoleQuery, updateConsoleMutation, draftChangeIndicators } = canvasConsoleVersionDiff;
 
-  const effectiveCanvasSpec = draftSpecToRender ?? canvas?.spec ?? undefined;
+  const effectiveCanvasSpec = editBootstrapReady ? (draftSpecToRender ?? canvas?.spec ?? undefined) : undefined;
   const stagingIndicators = useDraftStagingIndicators({
     isEditing,
+    editBootstrapReady,
     canvasId,
     activeCanvasVersionId,
     stagingResetNonce,
@@ -67,6 +68,7 @@ export function useAppDraftStagingData({
   });
 
   return {
+    stagingBaselinesReady: committedBaselines.ready,
     stagingStale: !!canvasStagingQuery.data?.stale,
     commitCanvasStagingMutation,
     discardCanvasStagingMutation,

--- a/web_src/src/pages/app/useCanvasEditVersionState.ts
+++ b/web_src/src/pages/app/useCanvasEditVersionState.ts
@@ -1,0 +1,120 @@
+import { useMemo } from "react";
+
+import type { CanvasesCanvasVersion } from "@/api-client";
+import { useCanvasVersion, useStagedCanvasSpec } from "@/hooks/useCanvasData";
+
+import {
+  isAwaitingStagedCanvasSpec,
+  isViewingCurrentLiveCanvasVersion,
+  resolveSelectedCanvasVersion,
+  shouldReadStagedCanvasVersion,
+} from "./lib/live-edit-session";
+
+type UseCanvasEditVersionStateOptions = {
+  organizationId: string;
+  canvasId: string;
+  editSessionActive: boolean;
+  isEnteringEditSession: boolean;
+  activeCanvasVersion: CanvasesCanvasVersion | null;
+  effectiveLiveCanvasVersionId?: string;
+  liveCanvasVersionId?: string;
+  selectableVersionsById: Map<string, CanvasesCanvasVersion>;
+  isRunInspectionMode: boolean;
+  isMemoryMode: boolean;
+};
+
+export function useCanvasEditVersionState({
+  organizationId,
+  canvasId,
+  editSessionActive,
+  isEnteringEditSession,
+  activeCanvasVersion,
+  effectiveLiveCanvasVersionId,
+  liveCanvasVersionId,
+  selectableVersionsById,
+  isRunInspectionMode,
+  isMemoryMode,
+}: UseCanvasEditVersionStateOptions) {
+  const activeCanvasVersionId = activeCanvasVersion?.metadata?.id || "";
+  const shouldReadStagedCanvasVersionFlag = shouldReadStagedCanvasVersion({
+    editSessionActive,
+    activeCanvasVersionId,
+    effectiveLiveCanvasVersionId,
+    liveCanvasVersionId,
+  });
+  const stagedVersionMetadataShell = activeCanvasVersion ?? selectableVersionsById.get(activeCanvasVersionId) ?? null;
+  const {
+    data: loadedStagedCanvasVersion,
+    isLoading: loadedStagedCanvasVersionLoading,
+    isFetching: loadedStagedCanvasVersionFetching,
+  } = useStagedCanvasSpec(canvasId, stagedVersionMetadataShell, shouldReadStagedCanvasVersionFlag);
+  const {
+    data: loadedCommittedCanvasVersion,
+    isLoading: loadedCommittedCanvasVersionLoading,
+    isFetching: loadedCommittedCanvasVersionFetching,
+  } = useCanvasVersion(
+    organizationId,
+    canvasId,
+    activeCanvasVersionId,
+    !!activeCanvasVersionId && !shouldReadStagedCanvasVersionFlag,
+  );
+  const loadedCanvasVersion = shouldReadStagedCanvasVersionFlag
+    ? loadedStagedCanvasVersion
+    : loadedCommittedCanvasVersion;
+  const loadedCanvasVersionLoading = shouldReadStagedCanvasVersionFlag
+    ? loadedStagedCanvasVersionLoading
+    : loadedCommittedCanvasVersionLoading;
+  const loadedCanvasVersionFetching = shouldReadStagedCanvasVersionFlag
+    ? loadedStagedCanvasVersionFetching
+    : loadedCommittedCanvasVersionFetching;
+  const isAwaitingStagedCanvasSpecFlag = isAwaitingStagedCanvasSpec({
+    activeCanvasVersionId,
+    shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
+    loadedStagedCanvasVersion,
+    loadedStagedCanvasVersionLoading,
+    loadedStagedCanvasVersionFetching,
+    isEnteringEditSession,
+  });
+  const selectedCanvasVersion = useMemo(
+    () =>
+      resolveSelectedCanvasVersion({
+        activeCanvasVersionId,
+        shouldReadStagedCanvasVersion: shouldReadStagedCanvasVersionFlag,
+        loadedStagedCanvasVersion,
+        loadedCommittedCanvasVersion,
+        activeCanvasVersion,
+        isAwaitingStagedSpec: isAwaitingStagedCanvasSpecFlag,
+      }),
+    [
+      activeCanvasVersionId,
+      shouldReadStagedCanvasVersionFlag,
+      loadedStagedCanvasVersion,
+      loadedCommittedCanvasVersion,
+      activeCanvasVersion,
+      isAwaitingStagedCanvasSpecFlag,
+    ],
+  );
+  const isViewingCurrentLiveVersion = isViewingCurrentLiveCanvasVersion({
+    activeCanvasVersionId,
+    selectedCanvasVersion,
+    effectiveLiveCanvasVersionId,
+    liveCanvasVersionId,
+  });
+  const isEditing = editSessionActive && isViewingCurrentLiveVersion;
+  const showLiveActivity = isViewingCurrentLiveVersion && !(editSessionActive && !isRunInspectionMode && !isMemoryMode);
+
+  return {
+    activeCanvasVersionId,
+    shouldReadStagedCanvasVersionFlag,
+    loadedCanvasVersion,
+    loadedCanvasVersionLoading,
+    loadedCanvasVersionFetching,
+    isAwaitingStagedCanvasSpecFlag,
+    selectedCanvasVersion,
+    isViewingCurrentLiveVersion,
+    isViewingLiveVersion: isViewingCurrentLiveVersion,
+    isEditing,
+    hasEditableVersion: isEditing,
+    showLiveActivity,
+  };
+}

--- a/web_src/src/pages/app/useCommittedDraftBaselines.ts
+++ b/web_src/src/pages/app/useCommittedDraftBaselines.ts
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 import type { ConsoleLayoutItem, ConsolePanel } from "@/hooks/useCanvasData";
 
-import { fetchCanvasVersionWithSpec } from "./lib/repository-spec-files";
+import { fetchCommittedCanvasVersionWithSpec } from "./lib/repository-spec-files";
 
 export type CommittedDraftBaselines = {
   canvasSpec?: CanvasesCanvas["spec"];
@@ -50,13 +50,13 @@ export function useCommittedDraftBaselines({
     void Promise.all([
       queryClient.fetchQuery({
         queryKey: canvasKeys.versionDetail(canvasId, versionId),
-        queryFn: () => fetchCanvasVersionWithSpec(canvasId, versionId, false),
-        staleTime: 30_000,
+        queryFn: () => fetchCommittedCanvasVersionWithSpec(canvasId, versionId),
+        staleTime: Number.POSITIVE_INFINITY,
       }),
       queryClient.fetchQuery({
         queryKey: canvasKeys.console(canvasId, versionId),
         queryFn: () => fetchCanvasConsoleData(canvasId, versionId, false),
-        staleTime: 30_000,
+        staleTime: Number.POSITIVE_INFINITY,
       }),
     ]).then(([version, consoleData]) => {
       if (cancelled) {

--- a/web_src/src/pages/app/useDraftCanvasSpecSync.ts
+++ b/web_src/src/pages/app/useDraftCanvasSpecSync.ts
@@ -1,0 +1,122 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { useEffect } from "react";
+
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+
+import {
+  shouldApplyPreservedDraftSpec,
+  shouldPreserveDraftSpec,
+  shouldSkipDraftSpecSyncFromLoadedVersion,
+} from "./lib/draft-canvas-sync";
+
+type DraftSpec = CanvasesCanvas["spec"] | null;
+
+type UseDraftCanvasSpecSyncOptions = {
+  isEditing: boolean;
+  isEnteringEditSession: boolean;
+  shouldReadStagedCanvasVersion: boolean;
+  isAwaitingStagedCanvasSpec: boolean;
+  activeCanvasVersionId: string;
+  selectedCanvasVersion: CanvasesCanvasVersion | null;
+  draftCanvasSpec: DraftSpec;
+  setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, DraftSpec>>;
+  liveCanvas?: CanvasesCanvas | null;
+  liveCanvasVersion?: CanvasesCanvasVersion;
+};
+
+export function useDraftCanvasSpecSync({
+  isEditing,
+  isEnteringEditSession,
+  shouldReadStagedCanvasVersion,
+  isAwaitingStagedCanvasSpec,
+  activeCanvasVersionId,
+  selectedCanvasVersion,
+  draftCanvasSpec,
+  setDraftCanvasSpec,
+  draftCanvasSpecsRef,
+  liveCanvas,
+  liveCanvasVersion,
+}: UseDraftCanvasSpecSyncOptions) {
+  useEffect(() => {
+    if (!isEditing || !activeCanvasVersionId) {
+      return;
+    }
+
+    if (isEnteringEditSession) {
+      return;
+    }
+
+    if (shouldReadStagedCanvasVersion && isAwaitingStagedCanvasSpec) {
+      return;
+    }
+
+    const preservedDraftSpec = draftCanvasSpecsRef.current.get(activeCanvasVersionId);
+    const nextDraftSpec = selectedCanvasVersion?.spec ?? null;
+
+    if (shouldSkipDraftSpecSyncFromLoadedVersion(draftCanvasSpec, nextDraftSpec)) {
+      return;
+    }
+
+    if (shouldApplyPreservedDraftSpec(preservedDraftSpec, nextDraftSpec)) {
+      setDraftCanvasSpec(preservedDraftSpec);
+      return;
+    }
+
+    if (nextDraftSpec) {
+      draftCanvasSpecsRef.current.set(activeCanvasVersionId, nextDraftSpec);
+    } else {
+      draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
+    }
+    setDraftCanvasSpec(nextDraftSpec);
+  }, [
+    isEditing,
+    isEnteringEditSession,
+    shouldReadStagedCanvasVersion,
+    isAwaitingStagedCanvasSpec,
+    activeCanvasVersionId,
+    selectedCanvasVersion?.metadata?.id,
+    selectedCanvasVersion?.spec,
+    draftCanvasSpec,
+    setDraftCanvasSpec,
+    draftCanvasSpecsRef,
+  ]);
+
+  useEffect(() => {
+    if (!isEditing || !activeCanvasVersionId || !liveCanvas?.spec) {
+      return;
+    }
+    if (!draftCanvasSpec && !selectedCanvasVersion?.spec) {
+      return;
+    }
+
+    if (
+      shouldPreserveDraftSpec({
+        incomingSpec: liveCanvas.spec,
+        draftSpec: draftCanvasSpec,
+        selectedDraftVersionSpec: selectedCanvasVersion?.spec,
+        liveVersionSpec: liveCanvasVersion?.spec,
+      })
+    ) {
+      return;
+    }
+
+    setDraftCanvasSpec((currentDraftSpec) => {
+      draftCanvasSpecsRef.current.set(activeCanvasVersionId, liveCanvas.spec);
+      if (currentDraftSpec === liveCanvas.spec) {
+        return currentDraftSpec;
+      }
+
+      return liveCanvas.spec;
+    });
+  }, [
+    isEditing,
+    activeCanvasVersionId,
+    liveCanvas?.spec,
+    liveCanvasVersion?.spec,
+    selectedCanvasVersion?.spec,
+    draftCanvasSpec,
+    setDraftCanvasSpec,
+    draftCanvasSpecsRef,
+  ]);
+}

--- a/web_src/src/pages/app/useDraftStagingIndicators.ts
+++ b/web_src/src/pages/app/useDraftStagingIndicators.ts
@@ -16,23 +16,19 @@ type ConsoleQueryData = ConsoleVersionDiff["consoleQuery"]["data"];
 
 function resolveEditingStagingFlags({
   isEditing,
+  editBootstrapReady,
   committedBaselinesReady,
   localHasCanvasStaging,
   localHasConsoleStaging,
-  serverHasCanvasStaging,
-  serverHasConsoleStaging,
-  serverHasStagingChanges,
   filesLocalStagingActive,
   localHasFilesStaging,
   serverHasFilesStaging,
 }: {
   isEditing: boolean;
+  editBootstrapReady: boolean;
   committedBaselinesReady: boolean;
   localHasCanvasStaging: boolean;
   localHasConsoleStaging: boolean;
-  serverHasCanvasStaging: boolean;
-  serverHasConsoleStaging: boolean;
-  serverHasStagingChanges: boolean;
   filesLocalStagingActive: boolean;
   localHasFilesStaging: boolean;
   serverHasFilesStaging: boolean;
@@ -46,12 +42,19 @@ function resolveEditingStagingFlags({
     };
   }
 
-  const hasCanvasStagingChanges = committedBaselinesReady ? localHasCanvasStaging : serverHasCanvasStaging;
-  const hasConsoleStagingChanges = committedBaselinesReady ? localHasConsoleStaging : serverHasConsoleStaging;
+  if (!editBootstrapReady || !committedBaselinesReady) {
+    return {
+      hasCanvasStagingChanges: false,
+      hasConsoleStagingChanges: false,
+      hasFilesStagingChanges: false,
+      hasStagingChanges: false,
+    };
+  }
+
+  const hasCanvasStagingChanges = localHasCanvasStaging;
+  const hasConsoleStagingChanges = localHasConsoleStaging;
   const hasFilesStagingChanges = filesLocalStagingActive ? localHasFilesStaging : serverHasFilesStaging;
-  const hasStagingChanges = committedBaselinesReady
-    ? localHasCanvasStaging || localHasConsoleStaging || hasFilesStagingChanges
-    : serverHasStagingChanges;
+  const hasStagingChanges = localHasCanvasStaging || localHasConsoleStaging || hasFilesStagingChanges;
 
   return { hasCanvasStagingChanges, hasConsoleStagingChanges, hasFilesStagingChanges, hasStagingChanges };
 }
@@ -90,6 +93,7 @@ function buildDraftChangeFlags({
 
 type UseDraftStagingIndicatorsOptions = {
   isEditing: boolean;
+  editBootstrapReady: boolean;
   canvasId?: string;
   activeCanvasVersionId: string;
   stagingResetNonce: number;
@@ -102,6 +106,7 @@ type UseDraftStagingIndicatorsOptions = {
 
 export function useDraftStagingIndicators({
   isEditing,
+  editBootstrapReady,
   canvasStagingQuery,
   committedBaselines,
   effectiveCanvasSpec,
@@ -148,20 +153,16 @@ export function useDraftStagingIndicators({
     [committedBaselines.console, effectiveConsole],
   );
 
-  const { serverHasCanvasStaging, serverHasConsoleStaging, serverHasFilesStaging } = getServerStagingFlags(
-    canvasStagingQuery.data?.stagedPaths,
-  );
+  const { serverHasFilesStaging } = getServerStagingFlags(canvasStagingQuery.data?.stagedPaths);
   const serverHasStagingChanges = !!canvasStagingQuery.data?.hasStaging;
 
   const { hasCanvasStagingChanges, hasConsoleStagingChanges, hasFilesStagingChanges, hasStagingChanges } =
     resolveEditingStagingFlags({
       isEditing,
+      editBootstrapReady,
       committedBaselinesReady: committedBaselines.ready,
       localHasCanvasStaging,
       localHasConsoleStaging,
-      serverHasCanvasStaging,
-      serverHasConsoleStaging,
-      serverHasStagingChanges,
       filesLocalStagingActive,
       localHasFilesStaging,
       serverHasFilesStaging,

--- a/web_src/src/pages/app/useEditSessionBootstrap.ts
+++ b/web_src/src/pages/app/useEditSessionBootstrap.ts
@@ -1,0 +1,84 @@
+import { useRef } from "react";
+
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+
+import {
+  isDraftCanvasLoadingWhileEditing,
+  isEditBootstrapReady as resolveEditBootstrapReady,
+} from "./lib/edit-staging-ready";
+import { useCommittedDraftBaselines } from "./useCommittedDraftBaselines";
+
+type UseEditSessionBootstrapOptions = {
+  canvasId: string;
+  isEditing: boolean;
+  isEnteringEditSession: boolean;
+  shouldReadStagedCanvasVersion: boolean;
+  activeCanvasVersionId: string;
+  stagingResetNonce: number;
+  draftCanvasSpec: CanvasesCanvas["spec"] | null;
+  draftSpecToRender: CanvasesCanvas["spec"] | null;
+  loadedCanvasVersionLoading: boolean;
+  loadedCanvasVersionFetching: boolean;
+  selectedCanvasVersion: CanvasesCanvasVersion | null;
+  liveCanvasVersionId?: string;
+  isRunInspectionMode: boolean;
+};
+
+export function useEditSessionBootstrap({
+  canvasId,
+  isEditing,
+  isEnteringEditSession,
+  shouldReadStagedCanvasVersion,
+  activeCanvasVersionId,
+  stagingResetNonce,
+  draftCanvasSpec,
+  draftSpecToRender,
+  loadedCanvasVersionLoading,
+  loadedCanvasVersionFetching,
+  selectedCanvasVersion,
+  liveCanvasVersionId,
+  isRunInspectionMode,
+}: UseEditSessionBootstrapOptions) {
+  const stableCanvasViewKeyRef = useRef("live");
+  const committedBaselinesForEdit = useCommittedDraftBaselines({
+    canvasId,
+    versionId: activeCanvasVersionId || undefined,
+    enabled: isEditing,
+    stagingResetNonce,
+  });
+  const isEditBootstrapReady = resolveEditBootstrapReady({
+    isEditing,
+    isEnteringEditSession,
+    stagingBaselinesReady: committedBaselinesForEdit.ready,
+    draftCanvasSpec,
+    shouldReadStagedCanvasVersion,
+  });
+  const draftSpecForView = isEditing && !isEditBootstrapReady ? null : draftSpecToRender;
+  const isDraftCanvasLoading = isDraftCanvasLoadingWhileEditing({
+    isEditing,
+    shouldReadStagedCanvasVersion,
+    isEnteringEditSession,
+    isEditBootstrapReady,
+    draftCanvasSpec,
+    loadedCanvasVersionLoading,
+    loadedCanvasVersionFetching,
+  });
+  const isEditSessionUiReady = !isEditing || (isEditBootstrapReady && !isDraftCanvasLoading);
+  const canvasViewKey = selectedCanvasVersion?.metadata?.id || liveCanvasVersionId || "live";
+  const pinCanvasViewKey = isEnteringEditSession || (isEditing && !isEditBootstrapReady);
+  if (!pinCanvasViewKey) {
+    stableCanvasViewKeyRef.current = canvasViewKey;
+  }
+  const stableCanvasViewKey = pinCanvasViewKey ? stableCanvasViewKeyRef.current : canvasViewKey;
+  const canvasRenderKey = `${stableCanvasViewKey}:${isRunInspectionMode ? "runs" : "canvas"}:reset-${stagingResetNonce}`;
+
+  return {
+    committedBaselinesForEdit,
+    isEditBootstrapReady,
+    draftSpecForView,
+    isDraftCanvasLoading,
+    isEditSessionUiReady,
+    stableCanvasViewKey,
+    canvasRenderKey,
+  };
+}

--- a/web_src/src/pages/app/useEnterLiveEditSession.ts
+++ b/web_src/src/pages/app/useEnterLiveEditSession.ts
@@ -1,0 +1,86 @@
+import { useCallback, useRef } from "react";
+
+type UseEnterLiveEditSessionOptions = {
+  organizationId?: string;
+  canvasId?: string;
+  canUpdateCanvas: boolean;
+  effectiveLiveCanvasVersionId?: string;
+  selectableVersionsById: Map<string, unknown>;
+  handleUseVersion: (versionId: string, options?: { preserveStagedLayer?: boolean }) => void;
+  resyncStagedEditorState: (
+    versionId: string,
+    options?: { bumpResetNonce?: boolean; preferCachedStagedSpec?: boolean },
+  ) => Promise<void>;
+  previewingCurrentVersionRef: React.MutableRefObject<boolean>;
+  setEditSessionActive: (value: boolean) => void;
+  setIsEnteringEditSession: (value: boolean) => void;
+};
+
+export function useEnterLiveEditSession({
+  organizationId,
+  canvasId,
+  canUpdateCanvas,
+  effectiveLiveCanvasVersionId,
+  selectableVersionsById,
+  handleUseVersion,
+  resyncStagedEditorState,
+  previewingCurrentVersionRef,
+  setEditSessionActive,
+  setIsEnteringEditSession,
+}: UseEnterLiveEditSessionOptions) {
+  const enterLiveEditSessionInFlightRef = useRef<Promise<boolean> | null>(null);
+
+  const enterLiveEditSession = useCallback(async (): Promise<boolean> => {
+    if (enterLiveEditSessionInFlightRef.current) {
+      return enterLiveEditSessionInFlightRef.current;
+    }
+
+    const enterPromise = (async (): Promise<boolean> => {
+      if (!organizationId || !canvasId || !canUpdateCanvas) {
+        return false;
+      }
+
+      if (!effectiveLiveCanvasVersionId) {
+        return false;
+      }
+
+      if (!selectableVersionsById.has(effectiveLiveCanvasVersionId)) {
+        return false;
+      }
+
+      setIsEnteringEditSession(true);
+      try {
+        previewingCurrentVersionRef.current = true;
+        handleUseVersion(effectiveLiveCanvasVersionId, { preserveStagedLayer: true });
+        await resyncStagedEditorState(effectiveLiveCanvasVersionId, {
+          bumpResetNonce: false,
+          preferCachedStagedSpec: true,
+        });
+        setEditSessionActive(true);
+        return true;
+      } finally {
+        setIsEnteringEditSession(false);
+      }
+    })();
+
+    enterLiveEditSessionInFlightRef.current = enterPromise;
+    try {
+      return await enterPromise;
+    } finally {
+      enterLiveEditSessionInFlightRef.current = null;
+    }
+  }, [
+    organizationId,
+    canvasId,
+    canUpdateCanvas,
+    effectiveLiveCanvasVersionId,
+    selectableVersionsById,
+    handleUseVersion,
+    resyncStagedEditorState,
+    previewingCurrentVersionRef,
+    setEditSessionActive,
+    setIsEnteringEditSession,
+  ]);
+
+  return { enterLiveEditSession };
+}


### PR DESCRIPTION
Fixes flaky enter-edit UX (blank canvas, premature Reset/Commit/diff, and a brief "Previewing previous version" banner after commit) by tightening how staged canvas state is cached, bootstrapped, and rendered.
- Move staged canvas/console reads to **canvas-scoped** React Query keys (`stagedCanvasSpec`, `stagedConsole`) with dedicated fetch helpers, replacing version-scoped staged detail keys and redundant `GET /versions/{id}` reads.
- Rework the enter-edit flow to resync staged editor state before activating the session, preserve the staged layer on first enter, and gate the loading overlay plus header staging UI on a single **edit bootstrap** readiness check (baselines loaded, staged draft applied).
- Keep the live graph visible under the enter-edit overlay until bootstrap completes, pin the canvas view key during bootstrap to avoid remount flashes, and defer visual diff / Reset / Commit until UI is fully ready.
- After commit, drop warm staged caches immediately and ignore staged cache entries whose version id no longer matches the active live version, preventing a post-commit re-enter from briefly resolving as a historical preview.