### PR TITLE
feat: redesign runs sidebar list

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/RunRow.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunRow.tsx
@@ -1,7 +1,8 @@
 import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
-import type { MouseEvent } from "react";
+import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import { Timestamp } from "@/components/Timestamp";
 import { appPath } from "@/lib/appPaths";
+import { formatDuration } from "@/lib/duration";
 import { cn } from "@/lib/utils";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { RunNodeIcon, RUN_NODE_ICON_SIZE } from "@/ui/Runs/RunNodeIcon";
@@ -10,7 +11,7 @@ import { Link as LinkIcon } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { isNormalClick } from "@/lib/linkHelpers";
-import { RUNS_SIDEBAR_ROW_CLASS } from "./runsSidebarRowLayout";
+import { RUNS_SIDEBAR_RUN_ROW_CLASS } from "./runsSidebarRowLayout";
 
 interface RunRowProps {
   run: CanvasesCanvasRun;
@@ -36,6 +37,8 @@ export function RunRow({
   const { organizationId, appId } = useParams<{ organizationId: string; appId: string }>();
   const iconSrc = getHeaderIconSrc(triggerNode?.component);
   const iconSlug = triggerNode?.component ? componentIconMap[triggerNode.component] : undefined;
+  const currentTime = useRunningRunClock(status);
+  const durationText = useMemo(() => getRunDurationText(run, status, currentTime), [run, status, currentTime]);
   const runHref = organizationId && appId && run.id ? appPath(organizationId, appId, `?run=${run.id}`) : "#";
   const selectRun = () => {
     if (run.id) onSelectRun(run.id);
@@ -60,9 +63,9 @@ export function RunRow({
     <div
       data-testid="runs-sidebar-row"
       className={cn(
-        RUNS_SIDEBAR_ROW_CLASS,
+        RUNS_SIDEBAR_RUN_ROW_CLASS,
         "group relative w-full transition-colors",
-        isSelected ? "bg-sky-100 dark:bg-gray-800" : "hover:bg-gray-50 dark:hover:bg-gray-800",
+        isSelected ? "bg-sky-100 dark:bg-gray-800" : "hover:bg-slate-50 dark:hover:bg-gray-800",
       )}
     >
       <Link
@@ -76,71 +79,191 @@ export function RunRow({
         className="absolute inset-0 z-0"
         aria-label={title}
       />
-      <span className="pointer-events-none relative z-0 flex min-w-0 flex-1 items-center gap-1.5">
-        <RunNodeIcon
-          iconSrc={iconSrc}
-          iconSlug={iconSlug}
-          alt={triggerName}
-          size={RUN_NODE_ICON_SIZE}
-          className={cn(
-            "h-3.5 w-3.5 shrink-0",
-            isSelected ? "text-gray-800 dark:text-gray-100" : "text-gray-500 dark:text-gray-400",
-          )}
-        />
-        <span
-          aria-label={RUN_STATUS_META[status].label}
-          title={RUN_STATUS_META[status].label}
-          className={cn("inline-block h-2 w-2 shrink-0 rounded-full", RUN_STATUS_META[status].dotClassName)}
-        />
-        <span
-          className={cn(
-            "max-w-[35%] shrink-0 truncate rounded px-1.5 py-0.5 text-[10px] font-medium",
-            isSelected
-              ? "bg-sky-200 text-sky-800 dark:bg-gray-700 dark:text-gray-200"
-              : "bg-slate-100 text-slate-600 dark:bg-gray-800 dark:text-gray-400",
-          )}
-        >
-          {triggerName}
-        </span>
-        <span
-          className={cn(
-            "min-w-0 flex-1 truncate text-xs",
-            isSelected
-              ? "font-semibold text-sky-900 dark:text-gray-100"
-              : "font-medium text-gray-800 dark:text-gray-100",
-          )}
-        >
-          {title}
-        </span>
-      </span>
-      <button
-        type="button"
-        title="Copy link to run"
-        className="relative z-10 hidden shrink-0 rounded p-0.5 text-gray-400 hover:bg-gray-200 hover:text-gray-600 group-hover:inline-flex dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-        onClick={(event) => {
-          event.stopPropagation();
-          void (async () => {
-            const copyUrl = new URL(runHref, window.location.origin);
-            try {
-              await navigator.clipboard.writeText(copyUrl.toString());
-              toast.success("Run link copied");
-            } catch {
-              toast.error("Failed to copy run link");
-            }
-          })();
-        }}
-      >
-        <LinkIcon className="h-3 w-3" />
-      </button>
-      {run.createdAt ? (
-        <span
-          className="relative z-10 shrink-0 text-xs tabular-nums text-gray-500 dark:text-gray-400"
-          onClick={handleTimestampClick}
-          onAuxClick={handleTimestampClick}
-        >
-          <Timestamp date={run.createdAt} display="relative" relativeStyle="abbreviated" includeAgo={false} />
-        </span>
-      ) : null}
+      <RunRowTitleLine title={title} status={status} isSelected={isSelected} runHref={runHref} />
+      <RunRowMetadataLine
+        triggerName={triggerName}
+        iconSrc={iconSrc}
+        iconSlug={iconSlug}
+        isSelected={isSelected}
+        durationText={durationText}
+        createdAt={run.createdAt}
+        onTimestampClick={handleTimestampClick}
+      />
     </div>
   );
+}
+
+function RunRowTitleLine({
+  title,
+  status,
+  isSelected,
+  runHref,
+}: {
+  title: string;
+  status: RunStatusKey;
+  isSelected: boolean;
+  runHref: string;
+}) {
+  return (
+    <div className="pointer-events-none relative z-10 flex min-w-0 items-center gap-2">
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-[13px] leading-5",
+          isSelected
+            ? "font-semibold text-sky-950 dark:text-gray-50"
+            : "font-semibold text-gray-900 dark:text-gray-100",
+        )}
+        title={title}
+      >
+        {title}
+      </span>
+      <CopyRunLinkButton runHref={runHref} />
+      <RunStatusBadge status={status} />
+    </div>
+  );
+}
+
+function CopyRunLinkButton({ runHref }: { runHref: string }) {
+  return (
+    <button
+      type="button"
+      title="Copy link to run"
+      className="pointer-events-auto hidden shrink-0 rounded p-0.5 text-gray-400 hover:bg-gray-200 hover:text-gray-600 group-hover:inline-flex dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+      onClick={(event) => {
+        event.stopPropagation();
+        void copyRunLink(runHref);
+      }}
+    >
+      <LinkIcon className="h-3 w-3" />
+    </button>
+  );
+}
+
+async function copyRunLink(runHref: string) {
+  const copyUrl = new URL(runHref, window.location.origin);
+  try {
+    await navigator.clipboard.writeText(copyUrl.toString());
+    toast.success("Run link copied");
+  } catch {
+    toast.error("Failed to copy run link");
+  }
+}
+
+function RunStatusBadge({ status }: { status: RunStatusKey }) {
+  const statusMeta = RUN_STATUS_META[status];
+  const StatusIcon = statusMeta.icon;
+
+  return (
+    <span
+      aria-label={statusMeta.label}
+      title={statusMeta.label}
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[12px] font-medium leading-4 ring-1",
+        statusMeta.badgeClassName,
+      )}
+    >
+      <StatusIcon className="size-3.5" aria-hidden />
+      <span>{statusMeta.label}</span>
+    </span>
+  );
+}
+
+function RunRowMetadataLine({
+  triggerName,
+  iconSrc,
+  iconSlug,
+  isSelected,
+  durationText,
+  createdAt,
+  onTimestampClick,
+}: {
+  triggerName: string;
+  iconSrc?: string;
+  iconSlug?: string;
+  isSelected: boolean;
+  durationText: string | null;
+  createdAt?: string;
+  onTimestampClick: (event: MouseEvent<HTMLSpanElement>) => void;
+}) {
+  return (
+    <div className="pointer-events-none relative z-10 flex min-w-0 items-center gap-2">
+      <RunTriggerIdentity triggerName={triggerName} iconSrc={iconSrc} iconSlug={iconSlug} isSelected={isSelected} />
+      <span className="flex min-w-0 shrink-0 items-center gap-2 text-[12px] leading-4 text-gray-500 dark:text-gray-400">
+        {durationText ? <span className="shrink-0 tabular-nums">{durationText}</span> : null}
+        {createdAt ? (
+          <span
+            className="pointer-events-auto shrink-0 tabular-nums"
+            onClick={onTimestampClick}
+            onAuxClick={onTimestampClick}
+          >
+            <Timestamp date={createdAt} display="relative" relativeStyle="abbreviated" includeAgo />
+          </span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+function RunTriggerIdentity({
+  triggerName,
+  iconSrc,
+  iconSlug,
+  isSelected,
+}: {
+  triggerName: string;
+  iconSrc?: string;
+  iconSlug?: string;
+  isSelected: boolean;
+}) {
+  return (
+    <span className="pointer-events-none flex min-w-0 flex-1 items-center gap-1.5">
+      <RunNodeIcon
+        iconSrc={iconSrc}
+        iconSlug={iconSlug}
+        alt={triggerName}
+        size={RUN_NODE_ICON_SIZE}
+        className={cn(
+          "h-3.5 w-3.5 shrink-0",
+          isSelected ? "text-gray-800 dark:text-gray-100" : "text-gray-500 dark:text-gray-400",
+        )}
+      />
+      <span className="min-w-0 truncate text-[12px] leading-4 text-gray-600 dark:text-gray-400" title={triggerName}>
+        {triggerName}
+      </span>
+    </span>
+  );
+}
+
+function useRunningRunClock(status: RunStatusKey) {
+  const [currentTime, setCurrentTime] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (status !== "running") return;
+
+    setCurrentTime(Date.now());
+    const interval = window.setInterval(() => {
+      setCurrentTime(Date.now());
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [status]);
+
+  return currentTime;
+}
+
+function getRunDurationText(run: CanvasesCanvasRun, status: RunStatusKey, currentTime: number) {
+  const startedAt = parseTimestamp(run.createdAt);
+  if (startedAt === null) return null;
+
+  const endedAt = status === "running" ? currentTime : parseTimestamp(run.finishedAt);
+  if (endedAt === null || endedAt < startedAt) return null;
+
+  return formatDuration(endedAt - startedAt) || null;
+}
+
+function parseTimestamp(value: string | undefined) {
+  if (!value) return null;
+
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
 }

--- a/web_src/src/components/CanvasToolSidebar/RunsTabListRefactor.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabListRefactor.spec.tsx
@@ -1,0 +1,145 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CanvasesCanvasRun, SuperplaneComponentsNode } from "@/api-client";
+import { RunsTabPanel } from "./RunsTabPanel";
+
+const routerWrapper = ({ children }: { children: React.ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useEventExecutions: () => ({
+    data: { executions: [] },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  localStorage.clear();
+});
+
+const nodes: SuperplaneComponentsNode[] = [
+  {
+    id: "trigger-1",
+    name: "Deploy Trigger",
+    type: "TYPE_TRIGGER",
+    component: "webhook",
+  },
+];
+
+const baseProps = {
+  canvasId: "canvas-1",
+  onSelectRun: () => {},
+  onSelectLiveCanvas: () => {},
+  workflowNodes: nodes,
+};
+
+function makeRun(overrides: Partial<CanvasesCanvasRun> = {}): CanvasesCanvasRun {
+  return {
+    id: "run-1",
+    canvasId: "canvas-1",
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    createdAt: "2026-05-01T12:00:00Z",
+    finishedAt: "2026-05-01T12:00:01Z",
+    rootEvent: {
+      id: "event-1",
+      nodeId: "trigger-1",
+      customName: "Deploy main",
+      createdAt: "2026-05-01T12:00:00Z",
+    },
+    executions: [],
+    ...overrides,
+  };
+}
+
+describe("RunsTabList refactor", () => {
+  it("filters runs by search text", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RunsTabPanel
+        runs={[
+          makeRun({
+            id: "run-deploy",
+            rootEvent: { ...makeRun().rootEvent, customName: "Deploy production" },
+          }),
+          makeRun({
+            id: "run-release",
+            rootEvent: { ...makeRun().rootEvent, customName: "Release candidate" },
+          }),
+        ]}
+        selectedRunId={null}
+        {...baseProps}
+      />,
+      { wrapper: routerWrapper },
+    );
+
+    await user.type(screen.getByLabelText("Search runs"), "release");
+
+    expect(screen.queryByText("Deploy production")).not.toBeInTheDocument();
+    expect(screen.getByText("Release candidate")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 loaded")).toBeInTheDocument();
+  });
+
+  it("shows redesigned run row details", () => {
+    render(
+      <RunsTabPanel
+        runs={[
+          makeRun({
+            result: "RESULT_FAILED",
+            rootEvent: { ...makeRun().rootEvent, customName: "Broken deploy" },
+          }),
+        ]}
+        selectedRunId={null}
+        {...baseProps}
+      />,
+      { wrapper: routerWrapper },
+    );
+
+    const row = screen.getByTestId("runs-sidebar-row");
+    expect(within(row).getByText("Broken deploy")).toBeInTheDocument();
+    expect(within(row).getByText("Failed")).toBeInTheDocument();
+    expect(within(row).getByText("Deploy Trigger")).toBeInTheDocument();
+    expect(within(row).getByText("1s")).toBeInTheDocument();
+    expect(row.querySelector('time[datetime="2026-05-01T12:00:00.000Z"]')).toBeInTheDocument();
+  });
+
+  it("updates running run duration while the row is visible", () => {
+    vi.useFakeTimers();
+    const now = new Date();
+    vi.setSystemTime(now);
+    const startedAt = new Date(now.getTime() - 1_000).toISOString();
+
+    render(
+      <RunsTabPanel
+        runs={[
+          makeRun({
+            id: "run-running",
+            state: "STATE_STARTED",
+            result: "RESULT_UNKNOWN",
+            createdAt: startedAt,
+            finishedAt: undefined,
+            rootEvent: { ...makeRun().rootEvent, customName: "Running deploy" },
+          }),
+        ]}
+        selectedRunId={null}
+        {...baseProps}
+      />,
+      { wrapper: routerWrapper },
+    );
+
+    expect(screen.getByText("1s")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+
+    expect(screen.getByText("3s")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/components/CanvasToolSidebar/RunsTabListView.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabListView.tsx
@@ -30,11 +30,13 @@ interface RunsTabListViewProps {
   hasAnyFilter: boolean;
   selectedStatuses: Set<RunStatusFilter>;
   selectedTriggerIds: Set<string>;
+  searchQuery: string;
   triggerOptions: TriggerOption[];
   onToggleStatus: (status: RunStatusFilter) => void;
   onClearStatuses: () => void;
   onToggleTrigger: (triggerId: string) => void;
   onClearTriggers: () => void;
+  onSearchQueryChange: (query: string) => void;
 }
 
 export function RunsTabListView({
@@ -54,11 +56,13 @@ export function RunsTabListView({
   hasAnyFilter,
   selectedStatuses,
   selectedTriggerIds,
+  searchQuery,
   triggerOptions,
   onToggleStatus,
   onClearStatuses,
   onToggleTrigger,
   onClearTriggers,
+  onSearchQueryChange,
 }: RunsTabListViewProps) {
   return (
     <div
@@ -69,11 +73,13 @@ export function RunsTabListView({
       <RunsToolbar
         selectedStatuses={selectedStatuses}
         selectedTriggerIds={selectedTriggerIds}
+        searchQuery={searchQuery}
         triggerOptions={triggerOptions}
         onToggleStatus={onToggleStatus}
         onClearStatuses={onClearStatuses}
         onToggleTrigger={onToggleTrigger}
         onClearTriggers={onClearTriggers}
+        onSearchQueryChange={onSearchQueryChange}
       />
 
       <div

--- a/web_src/src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CanvasesCanvasRun, SuperplaneComponentsNode } from "@/api-client";
 import { RunsTabPanel } from "./RunsTabPanel";
 
@@ -22,6 +22,11 @@ vi.mock("@/components/TimeAgo", () => ({
 vi.mock("sonner", () => ({
   toast: { success: vi.fn() },
 }));
+
+afterEach(() => {
+  vi.useRealTimers();
+  localStorage.clear();
+});
 
 function makeRun(overrides: Partial<CanvasesCanvasRun> = {}): CanvasesCanvasRun {
   return {
@@ -167,10 +172,11 @@ describe("RunsTabPanel", () => {
     );
 
     fireEvent.click(screen.getByLabelText("Filter runs"));
-    expect(screen.getByText("Passed")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Failed"));
-    expect(screen.getByText("Cancelled")).toBeInTheDocument();
-    expect(screen.getByText("Running")).toBeInTheDocument();
+    const filters = screen.getByRole("dialog");
+    expect(within(filters).getByText("Passed")).toBeInTheDocument();
+    fireEvent.click(within(filters).getByText("Failed"));
+    expect(within(filters).getByText("Cancelled")).toBeInTheDocument();
+    expect(within(filters).getByText("Running")).toBeInTheDocument();
     expect(screen.queryByText("Completed")).not.toBeInTheDocument();
 
     expect(screen.getByText("Broken deploy")).toBeInTheDocument();
@@ -273,7 +279,7 @@ describe("RunsTabPanel", () => {
 
     rerender(<RunsTabPanel runs={runs} selectedRunId="run-1" initialOpenDetail {...baseProps} />);
 
-    expect(screen.getByText("Deploy main")).toBeInTheDocument();
+    expect(within(screen.getByTestId("run-detail-panel")).getByText("Deploy main")).toBeInTheDocument();
   });
 
   it("opens run detail when the selected run changes from the URL", () => {
@@ -292,7 +298,7 @@ describe("RunsTabPanel", () => {
 
     rerender(<RunsTabPanel runs={runs} selectedRunId="run-2" {...baseProps} />);
     expect(screen.getByTestId("run-detail-back")).toBeInTheDocument();
-    expect(screen.getByText("Second run")).toBeInTheDocument();
+    expect(within(screen.getByTestId("run-detail-panel")).getByText("Second run")).toBeInTheDocument();
   });
 
   it("stays on the list when URL navigation returns to a dismissed run", () => {
@@ -309,7 +315,7 @@ describe("RunsTabPanel", () => {
     expect(screen.getByLabelText("Filter runs")).toBeVisible();
 
     rerender(<RunsTabPanel runs={runs} selectedRunId="run-2" detailDismissedForRunId="run-1" {...baseProps} />);
-    expect(screen.getByText("Second run")).toBeInTheDocument();
+    expect(within(screen.getByTestId("run-detail-panel")).getByText("Second run")).toBeInTheDocument();
 
     rerender(<RunsTabPanel runs={runs} selectedRunId="run-1" detailDismissedForRunId="run-1" {...baseProps} />);
     expect(screen.getByLabelText("Filter runs")).toBeVisible();

--- a/web_src/src/components/CanvasToolSidebar/RunsTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabPanel.tsx
@@ -189,11 +189,13 @@ export function RunsTabPanel({
           hasAnyFilter={filterState.hasAnyFilter}
           selectedStatuses={filterState.selectedStatuses}
           selectedTriggerIds={filterState.selectedTriggerIds}
+          searchQuery={filterState.searchQuery}
           triggerOptions={filterState.triggerOptions}
           onToggleStatus={filterState.toggleStatus}
           onClearStatuses={filterState.clearStatuses}
           onToggleTrigger={filterState.toggleTrigger}
           onClearTriggers={filterState.clearTriggers}
+          onSearchQueryChange={filterState.setSearchQuery}
         />
 
         <div

--- a/web_src/src/components/CanvasToolSidebar/RunsToolbar.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsToolbar.tsx
@@ -1,32 +1,64 @@
 import type { RunStatusFilter } from "@/ui/Runs/runPresentation";
+import type { ChangeEvent } from "react";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { Search, X } from "lucide-react";
 import { RunFiltersPopover, type TriggerOption } from "./RunFiltersPopover";
 import { RUNS_SIDEBAR_ROW_CLASS } from "./runsSidebarRowLayout";
 
 interface RunsToolbarProps {
   selectedStatuses: Set<RunStatusFilter>;
   selectedTriggerIds: Set<string>;
+  searchQuery: string;
   triggerOptions: TriggerOption[];
   onToggleStatus: (status: RunStatusFilter) => void;
   onClearStatuses: () => void;
   onToggleTrigger: (triggerId: string) => void;
   onClearTriggers: () => void;
+  onSearchQueryChange: (query: string) => void;
 }
 
 export function RunsToolbar({
   selectedStatuses,
   selectedTriggerIds,
+  searchQuery,
   triggerOptions,
   onToggleStatus,
   onClearStatuses,
   onToggleTrigger,
   onClearTriggers,
+  onSearchQueryChange,
 }: RunsToolbarProps) {
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onSearchQueryChange(event.target.value);
+  };
+
   return (
-    <div className={cn(RUNS_SIDEBAR_ROW_CLASS, "justify-between pr-1.5")}>
-      <span className="min-w-0 truncate text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+    <div className={cn(RUNS_SIDEBAR_ROW_CLASS, "gap-2 pr-1.5")}>
+      <span className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
         Runs
       </span>
+      <div className="relative min-w-0 flex-1">
+        <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
+        <Input
+          type="text"
+          value={searchQuery}
+          onChange={handleSearchChange}
+          aria-label="Search runs"
+          placeholder="Search runs"
+          className="h-7 rounded-none border-0 bg-transparent pl-7 pr-6 text-[13px] shadow-none placeholder:text-gray-400 focus:border-0 dark:bg-transparent dark:placeholder:text-gray-500"
+        />
+        {searchQuery && (
+          <button
+            type="button"
+            aria-label="Clear search runs"
+            onClick={() => onSearchQueryChange("")}
+            className="absolute right-1 top-1/2 flex size-5 -translate-y-1/2 cursor-pointer items-center justify-center rounded text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+          >
+            <X className="size-3.5" strokeWidth={1.5} />
+          </button>
+        )}
+      </div>
       <RunFiltersPopover
         selectedStatuses={selectedStatuses}
         selectedTriggerIds={selectedTriggerIds}

--- a/web_src/src/components/CanvasToolSidebar/runsSidebarRowLayout.ts
+++ b/web_src/src/components/CanvasToolSidebar/runsSidebarRowLayout.ts
@@ -1,3 +1,7 @@
-/** Shared height and padding for Live Canvas, runs toolbar, and run list rows. */
+/** Shared height and padding for Live Canvas and runs toolbar rows. */
 export const RUNS_SIDEBAR_ROW_CLASS =
   "flex h-9 min-w-0 shrink-0 items-center gap-1.5 border-b border-b-slate-950/10 px-3 dark:border-gray-800/70";
+
+/** Taller fixed row used by the two-line runs list entries. */
+export const RUNS_SIDEBAR_RUN_ROW_CLASS =
+  "flex h-16 min-w-0 shrink-0 flex-col justify-center gap-1.5 border-b border-b-slate-950/10 px-3 py-2 dark:border-gray-800/70";

--- a/web_src/src/components/CanvasToolSidebar/useRunFilters.ts
+++ b/web_src/src/components/CanvasToolSidebar/useRunFilters.ts
@@ -15,6 +15,7 @@ interface UseRunFiltersParams {
 export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusFiltersChange }: UseRunFiltersParams) {
   const [selectedTriggerIds, setSelectedTriggerIds] = useState<Set<string>>(() => loadPersistedFilters().triggerIds);
   const [selectedStatuses, setSelectedStatuses] = useState<Set<RunStatusFilter>>(() => loadPersistedFilters().statuses);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const nodeMap = useMemo(() => buildNodeMap(workflowNodes), [workflowNodes]);
 
@@ -49,7 +50,9 @@ export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusF
   const decoratedRuns = useMemo(() => runs.map((run) => buildRunPresentation(run, nodeMap)), [runs, nodeMap]);
 
   const filteredRuns = useMemo(() => {
-    return decoratedRuns.filter(({ run, status }) => {
+    const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+
+    return decoratedRuns.filter(({ run, status, haystack }) => {
       if (selectedStatuses.size > 0 && (status === "unknown" || !selectedStatuses.has(status))) return false;
 
       if (selectedTriggerIds.size > 0) {
@@ -57,9 +60,11 @@ export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusF
         if (!triggerNodeId || !selectedTriggerIds.has(triggerNodeId)) return false;
       }
 
+      if (normalizedSearchQuery && !haystack.includes(normalizedSearchQuery)) return false;
+
       return true;
     });
-  }, [decoratedRuns, selectedStatuses, selectedTriggerIds]);
+  }, [decoratedRuns, searchQuery, selectedStatuses, selectedTriggerIds]);
 
   const orderedRuns = useMemo(
     () => ({
@@ -69,11 +74,13 @@ export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusF
     [filteredRuns],
   );
 
-  const hasAnyFilter = selectedTriggerIds.size > 0 || selectedStatuses.size > 0;
+  const hasSearchFilter = searchQuery.trim().length > 0;
+  const hasAnyFilter = selectedTriggerIds.size > 0 || selectedStatuses.size > 0 || hasSearchFilter;
 
   const clearFilters = useCallback(() => {
     setSelectedStatuses(new Set());
     setSelectedTriggerIds(new Set());
+    setSearchQuery("");
   }, []);
 
   const toggleStatus = useCallback((status: RunStatusFilter) => {
@@ -97,10 +104,13 @@ export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusF
   return {
     selectedStatuses,
     selectedTriggerIds,
+    searchQuery,
     triggerOptions,
     filteredRuns,
     orderedRuns,
+    hasSearchFilter,
     hasAnyFilter,
+    setSearchQuery,
     clearFilters,
     toggleStatus,
     toggleTrigger,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -4147,6 +4147,7 @@ export function AppPage() {
           onRunNodeDetailNavigate={handleRunNodeDetailNavigate}
           runNodeDetailPaneHeight={runNodeDetailPaneHeight}
           onRunNodeDetailPaneHeightChange={setRunNodeDetailPaneHeight}
+          onBackToLiveCanvas={handleSelectLiveCanvas}
           onShowDiff={onShowDiff}
           {...canvasConsoleVersionDiff.consoleDiffHeaderProps}
           visualDiffEnabled={draftVisualDiff.visualDiffEnabled && isEditSessionUiReady}

--- a/web_src/src/ui/CanvasPage/RunInspectionFloatingBar.spec.tsx
+++ b/web_src/src/ui/CanvasPage/RunInspectionFloatingBar.spec.tsx
@@ -108,4 +108,27 @@ describe("RunInspectionFloatingBar", () => {
 
     expect(onBackToLiveCanvas).toHaveBeenCalledTimes(1);
   });
+
+  it("does not show the previous version bar while inspecting a run", () => {
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          canvasStateMode="previewing-previous-version"
+          isRunInspectionMode
+          onBackToLiveCanvas={vi.fn()}
+          onSeeCurrentVersion={vi.fn()}
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Previewing previous run")).toBeInTheDocument();
+    expect(screen.queryByText("Previewing previous version")).not.toBeInTheDocument();
+  });
 });

--- a/web_src/src/ui/CanvasPage/RunInspectionFloatingBar.spec.tsx
+++ b/web_src/src/ui/CanvasPage/RunInspectionFloatingBar.spec.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render as testingLibraryRender, screen } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+
+vi.mock("@/sentry", () => ({
+  Sentry: {
+    withScope: (callback: (scope: { setTag: typeof vi.fn; setExtra: typeof vi.fn }) => void) =>
+      callback({
+        setTag: vi.fn(),
+        setExtra: vi.fn(),
+      }),
+    captureException: vi.fn(),
+  },
+}));
+
+vi.mock("@xyflow/react", () => ({
+  Background: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ReactFlow: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ReactFlowProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ViewportPortal: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  useOnSelectionChange: vi.fn(),
+  useReactFlow: vi.fn(() => ({
+    fitView: vi.fn().mockResolvedValue(true),
+    screenToFlowPosition: vi.fn((position) => position),
+    getViewport: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+    setViewport: vi.fn(),
+    getInternalNode: vi.fn(),
+    zoomTo: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    getNodes: vi.fn(() => []),
+    getZoom: vi.fn(() => 1),
+  })),
+  useStore: vi.fn((selector: (state: { minZoom: number; maxZoom: number }) => unknown) =>
+    selector({ minZoom: 0.1, maxZoom: 1.5 }),
+  ),
+  useViewport: vi.fn(() => ({ zoom: 1, x: 0, y: 0 })),
+}));
+
+vi.mock("../BuildingBlocksSidebar", () => ({
+  BuildingBlocksSidebar: () => null,
+}));
+
+vi.mock("../componentSidebar", () => ({
+  ComponentSidebar: () => null,
+}));
+
+vi.mock("@/components/CanvasToolSidebar", () => ({
+  CanvasToolSidebar: () => null,
+}));
+
+vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
+  useCanvasToolSidebarState: () => ({
+    canvasId: undefined,
+    organizationId: undefined,
+    isEditing: false,
+    readOnly: false,
+    isToolSidebarOpen: false,
+    showToolSidebarToggle: false,
+    handleToolSidebarToggle: vi.fn(),
+    openToolSidebar: vi.fn(),
+    closeToolSidebar: vi.fn(),
+  }),
+}));
+
+vi.mock("./Header", () => ({
+  Header: () => <header data-testid="canvas-header" />,
+}));
+
+import { CanvasPage } from "./index";
+
+function render(ui: ReactElement) {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+  return testingLibraryRender(ui, { wrapper: ThemeProvider });
+}
+
+describe("RunInspectionFloatingBar", () => {
+  it("returns from run inspection to the live canvas", () => {
+    const onBackToLiveCanvas = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          isRunInspectionMode
+          onBackToLiveCanvas={onBackToLiveCanvas}
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Previewing previous run")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to Live Canvas" }));
+
+    expect(onBackToLiveCanvas).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1259,8 +1259,9 @@ function CanvasPage(props: CanvasPageProps) {
   }, [props.isEditing, props.isRunInspectionMode, state.componentSidebar.isOpen, handleSidebarClose]);
 
   const canvasStateMode = props.canvasStateMode || "default";
-  const showPreviewFloatingBar = canvasStateMode === "previewing-previous-version" && !!props.onSeeCurrentVersion;
   const showRunInspectionFloatingBar = props.isRunInspectionMode && !!props.onBackToLiveCanvas;
+  const showPreviewFloatingBar =
+    canvasStateMode === "previewing-previous-version" && !!props.onSeeCurrentVersion && !showRunInspectionFloatingBar;
 
   const liveBottomInspectorOpen = !props.isRunInspectionMode && !props.isEditing && state.componentSidebar.isOpen;
 

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -398,6 +398,8 @@ export interface CanvasPageProps {
 
   /** Returns to the current live canvas version from a published history preview. */
   onSeeCurrentVersion?: () => void;
+  /** Returns from run inspection to the current live canvas. */
+  onBackToLiveCanvas?: () => void;
 }
 
 export const CANVAS_SIDEBAR_STORAGE_KEY = "canvasSidebarOpen";
@@ -447,6 +449,33 @@ const EDGE_STYLE = {
 const DEFAULT_CANVAS_ZOOM = 0.8;
 const MIN_CANVAS_ZOOM = 0.1;
 const SNAP_GRID_STEP_PX = 24;
+
+function CanvasModeFloatingBar({
+  label,
+  actionLabel,
+  onAction,
+}: {
+  label: string;
+  actionLabel: string;
+  onAction: () => void;
+}) {
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-0 z-[19] flex justify-center px-4 pt-3">
+      <div className="pointer-events-auto flex max-w-[min(100vw-2rem,34rem)] items-center gap-2 rounded-full bg-slate-500 py-1.5 pl-3 pr-1.5 shadow-sm dark:bg-slate-600">
+        <span className="min-w-0 truncate text-[13px] font-medium text-white">{label}</span>
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          className="h-7 shrink-0 rounded-full border-0 bg-white px-3 text-[13px] font-medium text-slate-800 shadow-none hover:bg-slate-100 hover:text-slate-900 dark:bg-slate-800 dark:text-slate-100 dark:ring-1 dark:ring-slate-500 dark:hover:bg-slate-700 dark:hover:text-white"
+          onClick={onAction}
+        >
+          {actionLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
 
 type CanvasAnnotationUpdate = {
   text?: string;
@@ -1231,6 +1260,7 @@ function CanvasPage(props: CanvasPageProps) {
 
   const canvasStateMode = props.canvasStateMode || "default";
   const showPreviewFloatingBar = canvasStateMode === "previewing-previous-version" && !!props.onSeeCurrentVersion;
+  const showRunInspectionFloatingBar = props.isRunInspectionMode && !!props.onBackToLiveCanvas;
 
   const liveBottomInspectorOpen = !props.isRunInspectionMode && !props.isEditing && state.componentSidebar.isOpen;
 
@@ -1450,24 +1480,22 @@ function CanvasPage(props: CanvasPageProps) {
               </div>
             ) : null}
             {showPreviewFloatingBar ? (
-              <div className="pointer-events-none absolute inset-x-0 top-0 z-[19] flex justify-center pt-3">
-                <div className="pointer-events-auto flex max-w-[min(100vw-2rem,42rem)] items-center gap-2 rounded-full bg-gray-500 pl-3 pr-1.5 py-1.5">
-                  <span className="flex min-w-0 max-w-full shrink-0 truncate items-center gap-1 text-[13px] font-medium text-white">
-                    Previewing previous version
-                  </span>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="xs"
-                    className="shrink-0 border-0 shadow-none"
-                    onClick={() => {
-                      props.onSeeCurrentVersion?.();
-                    }}
-                  >
-                    See Current Version
-                  </Button>
-                </div>
-              </div>
+              <CanvasModeFloatingBar
+                label="Previewing previous version"
+                actionLabel="See Current Version"
+                onAction={() => {
+                  props.onSeeCurrentVersion?.();
+                }}
+              />
+            ) : null}
+            {showRunInspectionFloatingBar ? (
+              <CanvasModeFloatingBar
+                label="Previewing previous run"
+                actionLabel="Back to Live Canvas"
+                onAction={() => {
+                  props.onBackToLiveCanvas?.();
+                }}
+              />
             ) : null}
             {props.headerMode === "files" ? (
               <div

--- a/web_src/src/ui/Runs/runPresentation.ts
+++ b/web_src/src/ui/Runs/runPresentation.ts
@@ -24,31 +24,33 @@ export const RUN_STATUS_FILTER_OPTIONS: { id: RunStatusFilter; label: string; do
 export const RUN_STATUS_META = {
   running: {
     label: "Running",
-    badgeClassName: "bg-blue-50 text-blue-700 ring-blue-200",
+    badgeClassName: "bg-blue-50 text-blue-700 ring-blue-200 dark:bg-blue-950/50 dark:text-blue-300 dark:ring-blue-800",
     dotClassName: "bg-blue-500 animate-pulse",
     icon: Clock,
   },
   failed: {
     label: "Failed",
-    badgeClassName: "bg-red-50 text-red-700 ring-red-200",
+    badgeClassName: "bg-red-50 text-red-700 ring-red-200 dark:bg-red-950/50 dark:text-red-300 dark:ring-red-800",
     dotClassName: "bg-red-500",
     icon: AlertTriangle,
   },
   cancelled: {
     label: "Cancelled",
-    badgeClassName: "bg-gray-100 text-gray-700 ring-gray-200",
+    badgeClassName: "bg-gray-100 text-gray-700 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700",
     dotClassName: "bg-gray-400",
     icon: MinusCircle,
   },
   passed: {
     label: "Passed",
-    badgeClassName: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+    badgeClassName:
+      "bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-950/50 dark:text-emerald-300 dark:ring-emerald-800",
     dotClassName: "bg-emerald-500",
     icon: CheckCircle2,
   },
   unknown: {
     label: "Unknown",
-    badgeClassName: "bg-slate-100 text-slate-600 ring-slate-200",
+    badgeClassName:
+      "bg-slate-100 text-slate-600 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
     dotClassName: "bg-slate-300",
     icon: CircleDashed,
   },


### PR DESCRIPTION
## Summary
- redesign the runs sidebar list with title, trigger metadata, duration, timestamp, status badges, and search
- add dark-mode styling for run rows, badges, search controls, and the run-inspection floating bar
- add the run-inspection floating bar with a Back to Live Canvas action

Fixes #5940

## Validation
- npm run test:run -- src/ui/CanvasPage/index.runInspection.spec.tsx src/ui/CanvasPage/RunInspectionFloatingBar.spec.tsx
- make format.js
- make check.lint.ui
- make check.build.ui