### PR TITLE
fix: show agent staged canvas changes without leaving edit mode

### DIFF
--- a/test/e2e/agent_staging_edit_test.go
+++ b/test/e2e/agent_staging_edit_test.go
@@ -1,0 +1,228 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pw "github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/agents"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/features"
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+const (
+	agentStagedNoopName      = "AgentStagedNoop"
+	agentStagingEditTimeout  = 30 * time.Second
+	agentStagingPollInterval = 200 * time.Millisecond
+)
+
+func TestAgentStagingEditTransition(t *testing.T) {
+	t.Run("auto-enters edit mode from live view when agent stages via websocket", func(t *testing.T) {
+		steps := newAgentStagingEditSteps(t)
+		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
+			steps.canvas.StageNoopNodeViaAgentPatch(agentStagedNoopName, models.Position{X: 500, Y: 200})
+			// Real turns also emit staging-actions, but auto-enter must work from the
+			// staging_updated websocket alone when the user is already on live view.
+			return agentAssistantTurn("Added agent noop node."), nil
+		})
+
+		steps.start()
+		steps.warmLiveViewStagingCaches()
+		steps.openAgent()
+		steps.switchToBuildMode()
+		steps.sendMessage("Add a noop node to the canvas")
+		steps.assertAssistantMessage("Added agent noop node")
+		steps.assertAutoEnteredEditModeWithoutManualEdit()
+		steps.assertStagedNodeVisibleInEditor(agentStagedNoopName)
+		steps.canvas.AssertLiveCanvasLacksNode(agentStagedNoopName)
+		steps.canvas.AssertHasStaging(uuid.Nil)
+	})
+
+	t.Run("already in edit shows agent staged changes without reload", func(t *testing.T) {
+		steps := newAgentStagingEditSteps(t)
+		steps.start()
+		steps.warmLiveViewStagingCaches()
+		steps.canvas.EnterEditMode()
+		steps.canvas.StageNoopNodeViaAgentPatch(agentStagedNoopName, models.Position{X: 500, Y: 200})
+		steps.assertStagedNodeVisibleInEditor(agentStagedNoopName)
+		steps.canvas.AssertLiveCanvasLacksNode(agentStagedNoopName)
+		steps.canvas.AssertHasStaging(uuid.Nil)
+	})
+}
+
+type agentStagingEditSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+}
+
+func newAgentStagingEditSteps(t *testing.T) *agentStagingEditSteps {
+	ctx.ResetAgentProvider()
+	return &agentStagingEditSteps{t: t}
+}
+
+func (s *agentStagingEditSteps) withSendMessageHandler(
+	handler func(support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error),
+) {
+	ctx.AgentProvider.SetSendMessageHandler(handler)
+}
+
+func (s *agentStagingEditSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+	require.NoError(s.t, models.EnableExperimentalFeature(s.session.OrgID, features.FeatureClaudeManagedAgents))
+	require.NoError(s.t, s.session.Page().AddInitScript(pw.Script{Content: pw.String(`
+		() => {
+			window.localStorage.setItem("canvasAgentMode", "operator");
+			window.localStorage.setItem("canvasAgentSidebarOpen", "false");
+			window.sessionStorage.clear();
+		}
+	`)}))
+
+	s.canvas = shared.NewCanvasSteps("E2E Agent Staging Edit "+uuid.NewString(), s.t, s.session)
+	s.canvas.Create()
+}
+
+// warmLiveViewStagingCaches reproduces the manual bug preconditions on a canvas that
+// has already been open on live view: React Query holds hasStaging=false from the
+// initial /staging fetch and a warm stagedCanvasSpec snapshot from a prior edit session.
+func (s *agentStagingEditSteps) warmLiveViewStagingCaches() {
+	s.assertOnLiveView()
+	s.canvas.EnterEditMode()
+	s.canvas.ExitEditMode()
+	s.assertOnLiveView()
+}
+
+func (s *agentStagingEditSteps) openAgent() {
+	s.waitForToolSidebarOpen()
+	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
+	s.waitForAgentInput()
+	s.currentAgentSession()
+}
+
+func (s *agentStagingEditSteps) waitForToolSidebarOpen() {
+	deadline := time.Now().Add(agentWaitTimeout)
+	sidebar := q.TestID("canvas-tool-sidebar").Run(s.session)
+	openButton := q.TestID("canvas-tool-sidebar-toggle").Run(s.session)
+
+	for time.Now().Before(deadline) {
+		visible, err := sidebar.IsVisible()
+		require.NoError(s.t, err)
+		if visible {
+			return
+		}
+
+		visible, err = openButton.IsVisible()
+		require.NoError(s.t, err)
+		if visible {
+			err = openButton.Click(pw.LocatorClickOptions{Timeout: pw.Float(1000)})
+			if err == nil {
+				continue
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
+}
+
+func (s *agentStagingEditSteps) waitForAgentInput() {
+	input := q.TestID("agent-input").Run(s.session)
+	require.Eventually(s.t, func() bool {
+		visible, err := input.IsVisible()
+		return err == nil && visible
+	}, agentWaitTimeout, agentPollInterval)
+}
+
+func (s *agentStagingEditSteps) switchToBuildMode() {
+	s.session.Click(q.TestID("agent-mode-builder"))
+	s.assertEventuallyVisible(q.Locator(`[data-testid="agent-mode-builder"][aria-pressed="true"]`))
+}
+
+func (s *agentStagingEditSteps) sendMessage(message string) {
+	s.session.FillIn(q.TestID("agent-input"), message)
+	s.session.Click(q.TestID("agent-send-message-button"))
+}
+
+func (s *agentStagingEditSteps) currentAgentSession() *models.AgentSession {
+	user, err := models.FindActiveUserByEmail(s.session.OrgID.String(), s.session.Account.Email)
+	require.NoError(s.t, err)
+
+	var agentSession *models.AgentSession
+	require.Eventually(s.t, func() bool {
+		session, err := models.FindAgentSessionByCanvasInTransaction(
+			database.Conn(),
+			s.session.OrgID,
+			user.ID,
+			s.canvas.WorkflowID,
+		)
+		if err != nil {
+			return false
+		}
+
+		agentSession = session
+		return true
+	}, 10*time.Second, agentPollInterval)
+
+	return agentSession
+}
+
+func (s *agentStagingEditSteps) assertOnLiveView() {
+	editButton := q.TestID("canvas-edit-button").Run(s.session)
+	require.Eventually(s.t, func() bool {
+		visible, err := editButton.IsVisible()
+		if err != nil || !visible {
+			return false
+		}
+		disabled, err := editButton.IsDisabled()
+		return err == nil && !disabled
+	}, agentStagingEditTimeout, agentStagingPollInterval)
+
+	exitEditButton := q.TestID("canvas-exit-edit-button").Run(s.session)
+	visible, err := exitEditButton.IsVisible()
+	require.NoError(s.t, err)
+	require.False(s.t, visible, "expected live view")
+}
+
+func (s *agentStagingEditSteps) assertAutoEnteredEditModeWithoutManualEdit() {
+	exitEditButton := q.TestID("canvas-exit-edit-button").Run(s.session)
+	require.Eventually(s.t, func() bool {
+		visible, err := exitEditButton.IsVisible()
+		if err != nil || !visible {
+			return false
+		}
+		disabled, err := exitEditButton.IsDisabled()
+		return err == nil && !disabled
+	}, agentStagingEditTimeout, agentStagingPollInterval, "agent staging should auto-enter edit mode from live view")
+
+	editButton := q.TestID("canvas-edit-button").Run(s.session)
+	visible, err := editButton.IsVisible()
+	require.NoError(s.t, err)
+	require.False(s.t, visible, "edit button should be hidden after auto-entering edit mode")
+}
+
+func (s *agentStagingEditSteps) assertStagedNodeVisibleInEditor(nodeName string) {
+	s.session.AssertVisible(q.TestID("node", nodeName, "header"))
+}
+
+func (s *agentStagingEditSteps) assertAssistantMessage(message string) {
+	s.assertEventuallyVisible(q.Locator(fmt.Sprintf(`[data-testid="agent-assistant-message"]:has-text("%s")`, message)))
+}
+
+func (s *agentStagingEditSteps) assertEventuallyVisible(query q.Query) {
+	locator := query.Run(s.session)
+	require.Eventually(s.t, func() bool {
+		visible, err := locator.IsVisible()
+		return err == nil && visible
+	}, agentStagingEditTimeout, agentStagingPollInterval)
+}

--- a/test/e2e/shared/agent_staging.go
+++ b/test/e2e/shared/agent_staging.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	canvasactions "github.com/superplanehq/superplane/pkg/agents/agent_tools/actions"
 	"github.com/superplanehq/superplane/pkg/agents"
+	canvasactions "github.com/superplanehq/superplane/pkg/agents/agent_tools/actions"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/crypto"

--- a/test/e2e/shared/agent_staging.go
+++ b/test/e2e/shared/agent_staging.go
@@ -1,0 +1,89 @@
+package shared
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	canvasactions "github.com/superplanehq/superplane/pkg/agents/agent_tools/actions"
+	"github.com/superplanehq/superplane/pkg/agents"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/registry"
+
+	// Register components used by patch_staging.
+	_ "github.com/superplanehq/superplane/pkg/components/noop"
+)
+
+var agentPatchStagingRegistry struct {
+	once sync.Once
+	reg  *canvasactions.Registry
+}
+
+func agentPatchStagingActionRegistry(t *testing.T) *canvasactions.Registry {
+	t.Helper()
+
+	agentPatchStagingRegistry.once.Do(func() {
+		encryptor := crypto.NewNoOpEncryptor()
+		componentRegistry, err := registry.NewRegistry(encryptor, registry.HTTPOptions{})
+		require.NoError(t, err)
+
+		authService, err := authorization.NewAuthService()
+		require.NoError(t, err)
+
+		agentPatchStagingRegistry.reg = canvasactions.NewDefaultRegistry(canvasactions.Dependencies{
+			Encryptor:      encryptor,
+			Registry:       componentRegistry,
+			AuthService:    authService,
+			WebhookBaseURL: "https://hooks.example.test",
+		})
+	})
+
+	return agentPatchStagingRegistry.reg
+}
+
+// StageNoopNodeViaAgentPatch stages a noop node the same way the managed agent does
+// (patch_staging -> PutCanvasStaging -> staging_updated websocket).
+func StageNoopNodeViaAgentPatch(
+	t *testing.T,
+	organizationID uuid.UUID,
+	userID uuid.UUID,
+	canvasID uuid.UUID,
+	nodeName string,
+	pos models.Position,
+) {
+	t.Helper()
+
+	nodeID := "agent-staged-" + uuid.NewString()
+	ctx := authentication.SetUserIdInMetadata(context.Background(), userID.String())
+
+	_, err := agentPatchStagingActionRegistry(t).Execute(ctx, agents.AgentSessionContext{
+		SessionID:      "e2e-agent-staging",
+		OrganizationID: organizationID.String(),
+		UserID:         userID.String(),
+		CanvasID:       canvasID.String(),
+	}, canvasactions.Input{
+		Action: "patch_staging",
+		PatchOperations: []canvasactions.PatchOperation{
+			{
+				Op: "add_node",
+				Node: &canvasactions.PatchNode{
+					ID:        nodeID,
+					Name:      nodeName,
+					Component: "noop",
+					Position:  &canvasactions.PatchPosition{X: pos.X, Y: pos.Y},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
+// StageNoopNodeViaAgentPatch is a CanvasSteps wrapper around StageNoopNodeViaAgentPatch.
+func (s *CanvasSteps) StageNoopNodeViaAgentPatch(nodeName string, pos models.Position) {
+	StageNoopNodeViaAgentPatch(s.t, s.session.OrgID, s.sessionUserID(), s.WorkflowID, nodeName, pos)
+}

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -416,7 +416,10 @@ export const useStagedCanvasSpec = (
   const versionId = versionMetadata?.metadata?.id;
   return useQuery({
     queryKey: canvasKeys.stagedCanvasSpec(canvasId),
-    queryFn: async () => fetchStagedCanvasVersionWithSpec(canvasId, versionMetadata ?? undefined),
+    queryFn: async () => {
+      const staged = await fetchStagedCanvasVersionWithSpec(canvasId, versionMetadata ?? undefined);
+      return staged ?? null;
+    },
     enabled: !!canvasId && !!versionId && enabled,
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnMount: false,

--- a/web_src/src/hooks/useCanvasStagingResync.ts
+++ b/web_src/src/hooks/useCanvasStagingResync.ts
@@ -4,7 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { fetchStagedCanvasVersionWithSpec } from "@/pages/app/lib/repository-spec-files";
 
-import { canvasKeys, invalidateStagedCanvasCaches } from "@/hooks/useCanvasData";
+import { canvasKeys } from "@/hooks/useCanvasData";
 
 type CanvasSpec = CanvasesCanvas["spec"] | null;
 
@@ -101,29 +101,44 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
           return;
         }
 
-        const versionShell =
-          queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.versionDetail(canvasId, versionId)) ?? undefined;
+        const versionShell = queryClient.getQueryData<CanvasesCanvasVersion>(
+          canvasKeys.versionDetail(canvasId, versionId),
+        ) ??
+          queryClient
+            .getQueryData<CanvasesCanvasVersion[]>(canvasKeys.versionList(canvasId))
+            ?.find((item) => item.metadata?.id === versionId) ?? { metadata: { id: versionId } };
 
+        const stagedCanvasSpecKey = canvasKeys.stagedCanvasSpec(canvasId);
         const cachedStaged = preferCachedStagedSpec
-          ? queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.stagedCanvasSpec(canvasId))
+          ? queryClient.getQueryData<CanvasesCanvasVersion>(stagedCanvasSpecKey)
+          : undefined;
+        const cachedStagedQueryState = preferCachedStagedSpec
+          ? queryClient.getQueryState(stagedCanvasSpecKey)
           : undefined;
 
-        if (cachedStaged?.spec && cachedStaged.metadata?.id === versionId) {
+        if (
+          cachedStaged?.spec &&
+          cachedStaged.metadata?.id === versionId &&
+          cachedStagedQueryState?.isInvalidated !== true
+        ) {
           applyStagedSpec(versionId, cachedStaged.spec);
           return;
         }
 
         consoleMutationGenerationRef.current += 1;
-        invalidateStagedCanvasCaches(queryClient, canvasId);
+        await queryClient.cancelQueries({ queryKey: stagedCanvasSpecKey });
+        queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId) });
+        queryClient.invalidateQueries({ queryKey: canvasKeys.stagedConsole(canvasId) });
+        queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFiles(canvasId) });
 
-        const stagedVersion = await queryClient.fetchQuery({
-          queryKey: canvasKeys.stagedCanvasSpec(canvasId),
-          queryFn: () => fetchStagedCanvasVersionWithSpec(canvasId, versionShell),
-          staleTime: 0,
-        });
+        const stagedVersion = await fetchStagedCanvasVersionWithSpec(canvasId, versionShell);
         const stagedSpec = stagedVersion?.spec ?? null;
 
+        // Apply editor state before updating the staged query cache so draft sync
+        // effects cannot briefly overwrite resynced content with a stale snapshot.
         applyStagedSpec(versionId, stagedSpec);
+        await queryClient.cancelQueries({ queryKey: stagedCanvasSpecKey });
+        queryClient.setQueryData(stagedCanvasSpecKey, stagedVersion ?? null);
 
         if (bumpResetNonce) {
           setStagingResetNonce((nonce) => nonce + 1);

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -101,6 +101,7 @@ import { useAppDraftStagingData } from "./useAppDraftStagingData";
 import { useCanvasEditVersionState } from "./useCanvasEditVersionState";
 import { useEditSessionBootstrap } from "./useEditSessionBootstrap";
 import { useDraftCanvasSpecSync } from "./useDraftCanvasSpecSync";
+import { fetchCanvasStagingSummary } from "./lib/repository-spec-files";
 import { useEnterLiveEditSession } from "./useEnterLiveEditSession";
 import { useCanvasEchoReleaseGuards } from "./useCanvasEchoReleaseGuards";
 import { useCanvasLifecycleEventHandlers } from "./useCanvasLifecycleEventHandlers";
@@ -817,6 +818,7 @@ export function AppPage() {
     }
 
     setRemoteCanvasUpdatePending(false);
+    void handleRemoteStagingUpdatedRef.current();
   }, [
     remoteCanvasUpdatePending,
     hasLocalSaveActivity,
@@ -3361,24 +3363,28 @@ export function AppPage() {
 
   handleRemoteStagingUpdatedRef.current = async () => {
     const targetVersionId = effectiveLiveCanvasVersionId;
-    if (!targetVersionId || targetVersionId !== effectiveLiveCanvasVersionId || !canvasId) {
+    if (!targetVersionId || !canvasId) {
       return;
     }
 
-    const stagingSummary = queryClient.getQueryData<{ hasStaging?: boolean }>(canvasKeys.canvasStaging(canvasId));
-    // Commit/discard clears staging in the cache before the websocket echo arrives.
-    if (stagingSummary?.hasStaging === false) {
-      return;
-    }
-
-    if (editSessionActive && isViewingCurrentLiveVersion) {
+    if (editSessionActiveRef.current && activeCanvasVersionIdRef.current === targetVersionId) {
       await resyncStagedEditorState(targetVersionId, { bumpResetNonce: false });
       return;
     }
 
-    if (!editSessionActive) {
-      await enterLiveEditSession();
+    const stagingSummary = await queryClient.fetchQuery({
+      queryKey: canvasKeys.canvasStaging(canvasId),
+      queryFn: async () => {
+        const summary = await fetchCanvasStagingSummary(canvasId);
+        return summary ?? { hasStaging: false, stagedPaths: [] };
+      },
+      staleTime: 0,
+    });
+    if (!stagingSummary.hasStaging) {
+      return;
     }
+
+    await enterLiveEditSession();
   };
 
   const handleAgentStagingReady = useCallback(async (): Promise<boolean> => {

--- a/web_src/src/pages/app/lib/live-edit-session.spec.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.spec.ts
@@ -71,6 +71,38 @@ describe("isAwaitingStagedCanvasSpec", () => {
       }),
     ).toBe(true);
   });
+
+  it("waits while a matched staged cache is refetching", () => {
+    expect(
+      isAwaitingStagedCanvasSpec({
+        activeCanvasVersionId: "live-version",
+        shouldReadStagedCanvasVersion: true,
+        loadedStagedCanvasVersion: {
+          metadata: { id: "live-version" },
+          spec: { nodes: [{ id: "stale-node" }], edges: [] },
+        },
+        loadedStagedCanvasVersionLoading: false,
+        loadedStagedCanvasVersionFetching: true,
+        isEnteringEditSession: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("uses a settled staged cache for the active live version", () => {
+    expect(
+      isAwaitingStagedCanvasSpec({
+        activeCanvasVersionId: "live-version",
+        shouldReadStagedCanvasVersion: true,
+        loadedStagedCanvasVersion: {
+          metadata: { id: "live-version" },
+          spec: { nodes: [{ id: "staged-node" }], edges: [] },
+        },
+        loadedStagedCanvasVersionLoading: false,
+        loadedStagedCanvasVersionFetching: false,
+        isEnteringEditSession: false,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("isViewingCurrentLiveCanvasVersion", () => {

--- a/web_src/src/pages/app/lib/live-edit-session.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.ts
@@ -79,18 +79,19 @@ export function isAwaitingStagedCanvasSpec({
   loadedStagedCanvasVersionFetching: boolean;
   isEnteringEditSession: boolean;
 }): boolean {
-  const matchedStagedCanvasVersion = isStagedCanvasVersionForActiveVersion(
-    loadedStagedCanvasVersion,
-    activeCanvasVersionId,
-  )
-    ? loadedStagedCanvasVersion
-    : undefined;
+  if (!shouldReadStagedCanvasVersion) {
+    return false;
+  }
 
-  return (
-    shouldReadStagedCanvasVersion &&
-    !matchedStagedCanvasVersion &&
-    (loadedStagedCanvasVersionLoading || loadedStagedCanvasVersionFetching || isEnteringEditSession)
-  );
+  if (isEnteringEditSession) {
+    return true;
+  }
+
+  if (loadedStagedCanvasVersionLoading || loadedStagedCanvasVersionFetching) {
+    return true;
+  }
+
+  return !isStagedCanvasVersionForActiveVersion(loadedStagedCanvasVersion, activeCanvasVersionId);
 }
 
 // While staged canvas.yaml is still loading, avoid falling back to the version-list

--- a/web_src/src/pages/app/useCanvasLifecycleEventHandlers.ts
+++ b/web_src/src/pages/app/useCanvasLifecycleEventHandlers.ts
@@ -93,11 +93,11 @@ export function useCanvasLifecycleEventHandlers({
 
       if (editSessionActiveRef.current && hasLocalSaveActivity) {
         setRemoteCanvasUpdatePending(true);
-        return true;
+        return false;
       }
 
       onRemoteStagingUpdated?.();
-      return true;
+      return false;
     },
     [
       editSessionActiveRef,

--- a/web_src/src/pages/app/useDraftCanvasSpecSync.ts
+++ b/web_src/src/pages/app/useDraftCanvasSpecSync.ts
@@ -43,31 +43,33 @@ export function useDraftCanvasSpecSync({
       return;
     }
 
-    if (isEnteringEditSession) {
+    // Live staged edit draft state is owned by resyncStagedEditorState (remote
+    // staging) and local canvas mutations — not by React Query sync effects.
+    if (shouldReadStagedCanvasVersion) {
       return;
     }
 
-    if (shouldReadStagedCanvasVersion && isAwaitingStagedCanvasSpec) {
+    if (isEnteringEditSession || isAwaitingStagedCanvasSpec) {
       return;
     }
 
-    const preservedDraftSpec = draftCanvasSpecsRef.current.get(activeCanvasVersionId);
     const nextDraftSpec = selectedCanvasVersion?.spec ?? null;
+    if (!nextDraftSpec) {
+      return;
+    }
 
     if (shouldSkipDraftSpecSyncFromLoadedVersion(draftCanvasSpec, nextDraftSpec)) {
       return;
     }
+
+    const preservedDraftSpec = draftCanvasSpecsRef.current.get(activeCanvasVersionId);
 
     if (shouldApplyPreservedDraftSpec(preservedDraftSpec, nextDraftSpec)) {
       setDraftCanvasSpec(preservedDraftSpec);
       return;
     }
 
-    if (nextDraftSpec) {
-      draftCanvasSpecsRef.current.set(activeCanvasVersionId, nextDraftSpec);
-    } else {
-      draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
-    }
+    draftCanvasSpecsRef.current.set(activeCanvasVersionId, nextDraftSpec);
     setDraftCanvasSpec(nextDraftSpec);
   }, [
     isEditing,
@@ -86,6 +88,11 @@ export function useDraftCanvasSpecSync({
     if (!isEditing || !activeCanvasVersionId || !liveCanvas?.spec) {
       return;
     }
+
+    if (shouldReadStagedCanvasVersion) {
+      return;
+    }
+
     if (!draftCanvasSpec && !selectedCanvasVersion?.spec) {
       return;
     }
@@ -111,6 +118,7 @@ export function useDraftCanvasSpecSync({
     });
   }, [
     isEditing,
+    shouldReadStagedCanvasVersion,
     activeCanvasVersionId,
     liveCanvas?.spec,
     liveCanvasVersion?.spec,

--- a/web_src/src/pages/app/useEnterLiveEditSession.ts
+++ b/web_src/src/pages/app/useEnterLiveEditSession.ts
@@ -54,7 +54,6 @@ export function useEnterLiveEditSession({
         handleUseVersion(effectiveLiveCanvasVersionId, { preserveStagedLayer: true });
         await resyncStagedEditorState(effectiveLiveCanvasVersionId, {
           bumpResetNonce: false,
-          preferCachedStagedSpec: true,
         });
         setEditSessionActive(true);
         return true;


### PR DESCRIPTION
Two main issues in the agent / staging / edit flow:
- If I am on live, and agent updates staging, I am not switched to edit mode
- If I am on edit, and agent updates staging, I do not see it right away, I have to leave and re-enter edit

### Fix

- Remote `staging_updated` events now reliably update the graph whether the user is on live view or already editing the live version.
- Resync staged spec directly into editor state (`resyncStagedEditorState`) instead of relying on stale React Query caches
- Stop `useDraftCanvasSpecSync` from overwriting live staged drafts with outdated query snapshots
- Avoid a websocket invalidation race that could repopulate `stagedCanvasSpec` with committed content after resync
- Refetch staging summary before auto-entering edit from live view (instead of trusting a warm `hasStaging: false` cache)
- Always refetch staged spec on enter-edit (remove `preferCachedStagedSpec` shortcut)

### Testing

New E2Es added to catch regressions in this area.