### PR TITLE
fix: run inspector sidebar improvements

### DIFF
--- a/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.ts
+++ b/web_src/src/components/CanvasRunsSidebar/useCanvasRunsSidebarState.ts
@@ -87,4 +87,5 @@ export function useCanvasRunsSidebarState(canvasId?: string) {
 
 export type CanvasRunsSidebarState = ReturnType<typeof useCanvasRunsSidebarState> & {
   showRunsSidebarToggle: boolean;
+  runningRunsCount?: number;
 };

--- a/web_src/src/components/CanvasToolSidebar/RunRow.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunRow.tsx
@@ -2,7 +2,6 @@ import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } fr
 import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import { Timestamp } from "@/components/Timestamp";
 import { appPath } from "@/lib/appPaths";
-import { formatDuration } from "@/lib/duration";
 import { cn } from "@/lib/utils";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { RunNodeIcon, RUN_NODE_ICON_SIZE } from "@/ui/Runs/RunNodeIcon";
@@ -258,7 +257,7 @@ function getRunDurationText(run: CanvasesCanvasRun, status: RunStatusKey, curren
   const endedAt = status === "running" ? currentTime : parseTimestamp(run.finishedAt);
   if (endedAt === null || endedAt < startedAt) return null;
 
-  return formatDuration(endedAt - startedAt) || null;
+  return formatSidebarDuration(endedAt - startedAt);
 }
 
 function parseTimestamp(value: string | undefined) {
@@ -266,4 +265,16 @@ function parseTimestamp(value: string | undefined) {
 
   const timestamp = new Date(value).getTime();
   return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function formatSidebarDuration(durationMs: number): string {
+  if (durationMs < 1000) return "<1s";
+
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0 && seconds > 0) return `${minutes}m ${seconds}s`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
 }

--- a/web_src/src/components/CanvasToolSidebar/RunRow.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunRow.tsx
@@ -2,6 +2,7 @@ import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } fr
 import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import { Timestamp } from "@/components/Timestamp";
 import { appPath } from "@/lib/appPaths";
+import { formatMinutesSecondsDuration } from "@/lib/duration";
 import { cn } from "@/lib/utils";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { RunNodeIcon, RUN_NODE_ICON_SIZE } from "@/ui/Runs/RunNodeIcon";
@@ -257,7 +258,7 @@ function getRunDurationText(run: CanvasesCanvasRun, status: RunStatusKey, curren
   const endedAt = status === "running" ? currentTime : parseTimestamp(run.finishedAt);
   if (endedAt === null || endedAt < startedAt) return null;
 
-  return formatSidebarDuration(endedAt - startedAt);
+  return formatMinutesSecondsDuration(endedAt - startedAt) || null;
 }
 
 function parseTimestamp(value: string | undefined) {
@@ -265,16 +266,4 @@ function parseTimestamp(value: string | undefined) {
 
   const timestamp = new Date(value).getTime();
   return Number.isFinite(timestamp) ? timestamp : null;
-}
-
-function formatSidebarDuration(durationMs: number): string {
-  if (durationMs < 1000) return "<1s";
-
-  const totalSeconds = Math.floor(durationMs / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-
-  if (minutes > 0 && seconds > 0) return `${minutes}m ${seconds}s`;
-  if (minutes > 0) return `${minutes}m`;
-  return `${seconds}s`;
 }

--- a/web_src/src/components/CanvasToolSidebar/RunsTabListRefactor.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabListRefactor.spec.tsx
@@ -142,4 +142,45 @@ describe("RunsTabList refactor", () => {
 
     expect(screen.getByText("3s")).toBeInTheDocument();
   });
+
+  it("formats sub-second run durations without milliseconds", () => {
+    render(
+      <RunsTabPanel
+        runs={[
+          makeRun({
+            createdAt: "2026-05-01T12:00:00.000Z",
+            finishedAt: "2026-05-01T12:00:00.250Z",
+          }),
+        ]}
+        selectedRunId={null}
+        {...baseProps}
+      />,
+      { wrapper: routerWrapper },
+    );
+
+    const row = screen.getByTestId("runs-sidebar-row");
+    expect(within(row).getByText("<1s")).toBeInTheDocument();
+    expect(within(row).queryByText("250ms")).not.toBeInTheDocument();
+  });
+
+  it("formats run durations with minutes and seconds only", () => {
+    render(
+      <RunsTabPanel
+        runs={[
+          makeRun({
+            createdAt: "2026-05-01T12:00:00.000Z",
+            finishedAt: "2026-05-01T13:01:30.500Z",
+          }),
+        ]}
+        selectedRunId={null}
+        {...baseProps}
+      />,
+      { wrapper: routerWrapper },
+    );
+
+    const row = screen.getByTestId("runs-sidebar-row");
+    expect(within(row).getByText("61m 30s")).toBeInTheDocument();
+    expect(within(row).queryByText(/ms/)).not.toBeInTheDocument();
+    expect(within(row).queryByText(/h/)).not.toBeInTheDocument();
+  });
 });

--- a/web_src/src/contexts/accountContextState.ts
+++ b/web_src/src/contexts/accountContextState.ts
@@ -12,6 +12,8 @@ interface Account {
   avatar_url: string;
   installation_admin: boolean;
   has_password: boolean;
+  roles?: string[];
+  groups?: string[];
   impersonation?: AccountImpersonation;
 }
 

--- a/web_src/src/lib/duration.spec.ts
+++ b/web_src/src/lib/duration.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { formatDuration } from "@/lib/duration";
+import { formatDuration, formatMinutesSecondsDuration } from "@/lib/duration";
 
 describe("duration", () => {
   afterEach(() => {
@@ -54,5 +54,14 @@ describe("duration", () => {
     expect(formatDuration(125_000)).toBe("2m 5s");
     expect(formatDuration(5_400_000)).toBe("1h 30m");
     expect(formatDuration(0)).toBe("");
+  });
+
+  it("formats minutes and seconds without milliseconds", () => {
+    expect(formatMinutesSecondsDuration(0)).toBe("");
+    expect(formatMinutesSecondsDuration(250)).toBe("<1s");
+    expect(formatMinutesSecondsDuration(1_500)).toBe("1s");
+    expect(formatMinutesSecondsDuration(51_988)).toBe("51s");
+    expect(formatMinutesSecondsDuration(61_500)).toBe("1m 1s");
+    expect(formatMinutesSecondsDuration(5_400_000)).toBe("90m");
   });
 });

--- a/web_src/src/lib/duration.ts
+++ b/web_src/src/lib/duration.ts
@@ -65,3 +65,16 @@ export function formatDuration(durationMs: number): string {
 
   return formatDurationFallback(duration);
 }
+
+export function formatMinutesSecondsDuration(durationMs: number): string {
+  if (durationMs <= 0) return "";
+  if (durationMs < 1000) return "<1s";
+
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0 && seconds > 0) return `${minutes}m ${seconds}s`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -13,6 +13,7 @@ import type {
   CanvasesCanvasNodeExecution,
   CanvasesCanvasNodeQueueItem,
   CanvasesCanvasRun,
+  CanvasesCanvasRunState,
   CanvasesCanvasVersion,
   ActionsAction,
   ComponentsEdge,
@@ -150,6 +151,7 @@ import {
   buildCanvasLogEntries,
   getCanvasLogNodesSignature,
   getNodeAnalyticsProps,
+  getRunningRunsCount,
   isCanvasLoadNotFoundError,
   isCanvasPrepLoading,
   isValidRunId,
@@ -161,6 +163,7 @@ import {
 const CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY = "canvas-auto-layout-on-update-enabled";
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
 const EMPTY_CANVAS_SPEC_ITEMS: never[] = [];
+const RUNNING_RUNS_FILTERS = { states: ["STATE_STARTED" as CanvasesCanvasRunState] };
 
 type DuplicatedNodesResult = {
   newNodes: ComponentsNode[];
@@ -491,6 +494,7 @@ export function AppPage() {
   );
   const infiniteRunsQuery = useInfiniteCanvasRuns(canvasId!, runApiFilters, showLiveActivity);
   const infiniteLogRunsQuery = useInfiniteCanvasRuns(canvasId!, {}, isViewingLiveVersion);
+  const infiniteRunningRunsQuery = useInfiniteCanvasRuns(canvasId!, RUNNING_RUNS_FILTERS, isViewingLiveVersion);
   const selectedRunIdIsValid = selectedRunId ? isValidRunId(selectedRunId) : false;
   const describedRunQuery = useDescribeRun(
     canvasId!,
@@ -522,6 +526,7 @@ export function AppPage() {
       });
     return { runs };
   }, [infiniteLogRunsQuery.data]);
+  const runningRunsCount = getRunningRunsCount(infiniteRunningRunsQuery.data, isViewingLiveVersion);
   const selectedRunFromList = useMemo(
     () => runsData.runs.find((run) => run.id === selectedRunId) || null,
     [runsData.runs, selectedRunId],
@@ -4330,6 +4335,7 @@ export function AppPage() {
           triggers={allTriggers}
           logEntries={logEntries}
           logRuns={isViewingLiveVersion ? logRunsData.runs : []}
+          runningRunsCount={runningRunsCount}
           runsNodes={canvasNodes}
           runsComponentIconMap={componentIconMap}
           onRunNodeSelect={handleLogRunNodeSelect}

--- a/web_src/src/pages/app/workflowPageHelpers.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.ts
@@ -28,6 +28,19 @@ import {
 
 export const NO_INCOMING_CONNECTIONS_WARNING = "This node has no incoming connections and will never be triggered.";
 
+type CanvasRunsPage = {
+  totalCount?: number;
+};
+
+type InfiniteCanvasRunsData = {
+  pages?: CanvasRunsPage[];
+};
+
+export function getRunningRunsCount(data: InfiniteCanvasRunsData | undefined, visible: boolean): number {
+  if (!visible) return 0;
+  return data?.pages?.[0]?.totalCount ?? 0;
+}
+
 export function getNodeAnalyticsProps(
   node: ComponentsNode,
   availableIntegrations: IntegrationsIntegrationDefinition[],

--- a/web_src/src/ui/CanvasPage/components/CanvasRunsSidebarTrigger.spec.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasRunsSidebarTrigger.spec.tsx
@@ -30,4 +30,11 @@ describe("CanvasRunsSidebarTrigger", () => {
 
     expect(handleRunsSidebarToggle).toHaveBeenCalledTimes(1);
   });
+
+  it("shows the running runs indicator", () => {
+    render(<CanvasRunsSidebarTrigger runsSidebarState={makeRunsSidebarState({ runningRunsCount: 2 })} />);
+
+    expect(screen.getByRole("button", { name: "Toggle Runs, 2 running" })).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
 });

--- a/web_src/src/ui/CanvasPage/components/CanvasRunsSidebarTrigger.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasRunsSidebarTrigger.tsx
@@ -2,15 +2,16 @@ import type { CanvasRunsSidebarState } from "@/components/CanvasRunsSidebar/useC
 import { Button as UIButton } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { PanelLeft, PanelLeftDashed } from "lucide-react";
+import { History } from "lucide-react";
 
 export type CanvasRunsSidebarTriggerProps = {
   runsSidebarState: CanvasRunsSidebarState;
 };
 
 export function CanvasRunsSidebarTrigger({ runsSidebarState }: CanvasRunsSidebarTriggerProps) {
-  const { showRunsSidebarToggle, isRunsSidebarOpen, handleRunsSidebarToggle } = runsSidebarState;
+  const { showRunsSidebarToggle, isRunsSidebarOpen, handleRunsSidebarToggle, runningRunsCount = 0 } = runsSidebarState;
   const label = "Toggle Runs";
+  const hasRunningRuns = runningRunsCount > 0;
 
   if (!showRunsSidebarToggle) {
     return null;
@@ -24,21 +25,25 @@ export function CanvasRunsSidebarTrigger({ runsSidebarState }: CanvasRunsSidebar
           variant="ghost"
           size="icon-xs"
           className={cn(
-            "size-7 rounded-full border-0 shadow-none transition-colors",
+            "relative size-7 rounded-full border-0 shadow-none transition-colors",
             isRunsSidebarOpen
               ? "bg-slate-300 text-slate-950 hover:bg-slate-300 hover:text-slate-950 focus-visible:bg-slate-300 dark:bg-gray-300 dark:text-gray-950 dark:hover:bg-gray-300 dark:hover:text-gray-950 dark:focus-visible:bg-gray-300"
               : "bg-slate-100 text-slate-500 hover:bg-slate-100 hover:text-foreground focus-visible:bg-slate-100 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus-visible:bg-gray-700",
           )}
-          aria-label={label}
+          aria-label={hasRunningRuns ? `${label}, ${runningRunsCount} running` : label}
           aria-pressed={isRunsSidebarOpen}
           data-testid="canvas-runs-sidebar-toggle"
           onClick={handleRunsSidebarToggle}
         >
-          {isRunsSidebarOpen ? (
-            <PanelLeft className="size-3.5 shrink-0" />
-          ) : (
-            <PanelLeftDashed className="size-3.5 shrink-0" />
-          )}
+          <History className="size-4 shrink-0" />
+          {hasRunningRuns ? (
+            <span
+              className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-500 px-1 text-[10px] font-semibold leading-none text-white ring-2 ring-blue-500/20 before:absolute before:inset-[-2px] before:rounded-full before:bg-blue-500/15 before:content-[''] before:animate-ping after:absolute after:inset-0 after:rounded-full after:ring-2 after:ring-white dark:ring-blue-400/20 dark:before:bg-blue-400/15 dark:after:ring-gray-900"
+              aria-hidden="true"
+            >
+              {runningRunsCount}
+            </span>
+          ) : null}
         </UIButton>
       </TooltipTrigger>
       <TooltipContent side="right" sideOffset={2}>

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -289,6 +289,7 @@ export interface CanvasPageProps {
   onAutoLayoutNodes?: (nodeIds: string[]) => void;
   onEdgeDelete?: (edgeIds: string[]) => void;
   logRuns?: CanvasesCanvasRun[];
+  runningRunsCount?: number;
   runsNodes?: ComponentsNode[];
   runsComponentIconMap?: Record<string, string>;
   toolSidebarRunsContent?: React.ReactNode;
@@ -845,8 +846,8 @@ function CanvasPage(props: CanvasPageProps) {
   const runsSidebarBaseState = useCanvasRunsSidebarState(props.canvasId);
   const showRunsSidebar = isCanvasWorkflowTab(props.headerMode) && props.toolSidebarRunsContent != null;
   const runningRunsCount = useMemo(
-    () => (props.logRuns || []).filter((run) => run.state === "STATE_STARTED").length,
-    [props.logRuns],
+    () => props.runningRunsCount ?? (props.logRuns || []).filter((run) => run.state === "STATE_STARTED").length,
+    [props.logRuns, props.runningRunsCount],
   );
   const runsSidebarState = {
     ...runsSidebarBaseState,
@@ -1567,9 +1568,12 @@ function CanvasPage(props: CanvasPageProps) {
         {runInspectorOpen && props.runNodeDetailRun ? (
           <RunInspectorPanel
             canvasId={props.runNodeDetailCanvasId!}
+            organizationId={props.organizationId}
             run={props.runNodeDetailRun!}
             workflowNodes={props.workflowNodes ?? []}
             workflowEdges={props.runNodeDetailEdges}
+            componentDefinitions={props.components}
+            triggerDefinitions={props.triggers}
             componentIconMap={props.runsComponentIconMap}
             selectedNodeId={props.runNodeDetailNodeId}
             onSelectNode={(nodeId) => props.onRunNodeDetailNavigate?.(nodeId)}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -844,9 +844,14 @@ function CanvasPage(props: CanvasPageProps) {
   });
   const runsSidebarBaseState = useCanvasRunsSidebarState(props.canvasId);
   const showRunsSidebar = isCanvasWorkflowTab(props.headerMode) && props.toolSidebarRunsContent != null;
+  const runningRunsCount = useMemo(
+    () => (props.logRuns || []).filter((run) => run.state === "STATE_STARTED").length,
+    [props.logRuns],
+  );
   const runsSidebarState = {
     ...runsSidebarBaseState,
     showRunsSidebarToggle: showRunsSidebar,
+    runningRunsCount,
   };
   const isRunsSidebarOpen = showRunsSidebar && runsSidebarBaseState.isRunsSidebarOpen;
 

--- a/web_src/src/ui/Runs/RunInspectorHeader.tsx
+++ b/web_src/src/ui/Runs/RunInspectorHeader.tsx
@@ -2,7 +2,7 @@ import { Loader2, Square } from "lucide-react";
 import type { CanvasesCanvasRun } from "@/api-client";
 import { Timestamp } from "@/components/Timestamp";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { formatDuration } from "@/lib/duration";
+import { formatMinutesSecondsDuration } from "@/lib/duration";
 import { cn } from "@/lib/utils";
 import { calculateRunDuration } from "./runNodeDetailModel";
 import { getRunStatus, RUN_STATUS_META } from "./runPresentation";
@@ -26,6 +26,7 @@ export function RunInspectorHeader({
   const meta = RUN_STATUS_META[status];
   const Icon = meta.icon;
   const duration = calculateRunDuration(run);
+  const durationText = duration !== null ? formatMinutesSecondsDuration(duration) : "";
   const actionLabel = status === "running" ? "Stop" : "Rerun";
   const actionTooltip =
     status === "running"
@@ -52,12 +53,12 @@ export function RunInspectorHeader({
         <div className="flex items-center justify-between gap-2">
           <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-gray-600 dark:text-gray-400">
             {run.createdAt ? <Timestamp date={run.createdAt} display="relative" relativeStyle="abbreviated" /> : null}
-            {duration !== null ? (
+            {durationText ? (
               <>
                 <span className="text-gray-300" aria-hidden>
                   ·
                 </span>
-                <span>{formatDuration(duration)}</span>
+                <span>{durationText}</span>
               </>
             ) : null}
             <span className="text-gray-300" aria-hidden>

--- a/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
+++ b/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
@@ -1,27 +1,38 @@
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronRight } from "lucide-react";
 import { useEffect, useRef } from "react";
-import { formatDuration } from "@/lib/duration";
+import { formatMinutesSecondsDuration } from "@/lib/duration";
 import { withEventStatusBadgeClasses } from "@/lib/eventStatusBadge";
 import { cn } from "@/lib/utils";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { AccordionContent, AccordionItem } from "@/ui/accordion";
 import { RunNodeIcon, RUN_NODE_ICON_SIZE } from "./RunNodeIcon";
 import { RunInspectorStepTimeline } from "./RunInspectorStepTimeline";
-import type { RunInspectorNodeSection } from "./runNodeDetailModel";
+import type {
+  RunInspectorApprovalRecord,
+  RunInspectorCurrentUser,
+  RunInspectorNodeSection,
+} from "./runNodeDetailModel";
+import type { useRunInspectorActions } from "./useRunInspectorActions";
 
 export function RunInspectorNodeAccordion({
   section,
   componentIconMap,
+  organizationId,
   isOpen,
   onRerun,
   rerunPending,
+  actions,
+  currentUser,
 }: {
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
+  organizationId?: string;
   isOpen: boolean;
   onRerun: () => void;
   rerunPending: boolean;
+  actions: ReturnType<typeof useRunInspectorActions>;
+  currentUser?: RunInspectorCurrentUser;
 }) {
   const iconSrc = getHeaderIconSrc(section.workflowNode?.component);
   const iconSlug = section.workflowNode?.component ? componentIconMap[section.workflowNode.component] : undefined;
@@ -77,13 +88,131 @@ export function RunInspectorNodeAccordion({
             {section.nodeName}
           </span>
         </AccordionPrimitive.Trigger>
+        <NodeActions section={section} actions={actions} currentUser={currentUser} />
         <NodeMetadata section={section} onRerun={onRerun} rerunPending={rerunPending} />
       </AccordionPrimitive.Header>
       <AccordionContent className="bg-slate-50 px-3 pb-3 pt-3 dark:bg-gray-950">
-        <RunInspectorStepTimeline section={section} componentIconMap={componentIconMap} />
+        <RunInspectorStepTimeline
+          section={section}
+          componentIconMap={componentIconMap}
+          organizationId={organizationId}
+        />
       </AccordionContent>
     </AccordionItem>
   );
+}
+
+function NodeActions({
+  section,
+  actions,
+  currentUser,
+}: {
+  section: RunInspectorNodeSection;
+  actions: ReturnType<typeof useRunInspectorActions>;
+  currentUser?: RunInspectorCurrentUser;
+}) {
+  const actionableApproval = findActionableApprovalRecord(section.actions.approvalRecords, currentUser ?? null);
+  const hasActions = section.actions.canStop || section.actions.canPushThrough || actionableApproval;
+
+  if (!hasActions) return null;
+
+  return (
+    <div className="flex shrink-0 items-center gap-2 pl-3">
+      {actionableApproval ? (
+        <>
+          <NodeActionButton
+            label="Approve"
+            tone="success"
+            disabled={actions.nodeHookPending}
+            onClick={() => actions.invokeNodeHook(section, "approve", { index: actionableApproval.index, comment: "" })}
+          />
+          <NodeActionButton
+            label="Reject"
+            tone="danger"
+            disabled={actions.nodeHookPending}
+            onClick={() => {
+              const reason = window.prompt("Reason for rejection");
+              if (!reason?.trim()) return;
+              actions.invokeNodeHook(section, "reject", { index: actionableApproval.index, reason: reason.trim() });
+            }}
+          />
+        </>
+      ) : null}
+      {section.actions.canPushThrough ? (
+        <NodeActionButton
+          label="Push through"
+          tone="neutral"
+          disabled={actions.nodeHookPending}
+          onClick={() => actions.invokeNodeHook(section, "pushThrough", null)}
+        />
+      ) : null}
+      {section.actions.canStop ? (
+        <NodeActionButton
+          label="Stop"
+          tone="danger"
+          disabled={actions.stopNodePending}
+          onClick={() => actions.stopNode(section)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function NodeActionButton({
+  label,
+  tone,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  tone: "success" | "danger" | "neutral";
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={cn(
+        "inline-flex h-7 items-center rounded-sm border bg-white px-2.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60 dark:bg-gray-950",
+        tone === "success" &&
+          "border-emerald-300 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950/50",
+        tone === "danger" &&
+          "border-red-300 text-red-600 hover:bg-red-50 dark:border-red-900 dark:text-red-300 dark:hover:bg-red-950/50",
+        tone === "neutral" &&
+          "border-slate-200 text-slate-700 hover:bg-slate-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800",
+      )}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function findActionableApprovalRecord(
+  records: RunInspectorApprovalRecord[],
+  account: RunInspectorCurrentUser | null,
+): RunInspectorApprovalRecord | null {
+  if (!account || hasCurrentUserActed(records, account)) return null;
+
+  return records.find((record) => record.state === "pending" && canCurrentUserActOnRecord(record, account)) ?? null;
+}
+
+function hasCurrentUserActed(records: RunInspectorApprovalRecord[], account: RunInspectorCurrentUser): boolean {
+  return records.some(
+    (record) => record.state !== "pending" && (record.user?.id === account.id || record.user?.email === account.email),
+  );
+}
+
+function canCurrentUserActOnRecord(record: RunInspectorApprovalRecord, account: RunInspectorCurrentUser): boolean {
+  if (record.type === "anyone") return true;
+  if (record.type === "user") return record.user?.id === account.id || record.user?.email === account.email;
+  if (record.type === "role") return !!record.roleRef?.name && (account.roles ?? []).includes(record.roleRef.name);
+  if (record.type === "group") return !!record.groupRef?.name && (account.groups ?? []).includes(record.groupRef.name);
+  return false;
 }
 
 function NodeMetadata({
@@ -121,8 +250,7 @@ function NodeMetadata({
 }
 
 function formatStepDuration(durationMs: number): string {
-  if (durationMs > 0 && durationMs < 1000) return "<1s";
-  return formatDuration(durationMs);
+  return formatMinutesSecondsDuration(durationMs);
 }
 
 function formatEventTimestamp(timestamp: string): string {

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
@@ -1,0 +1,267 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createEvent, fireEvent, render } from "@testing-library/react";
+import { useState } from "react";
+import { vi } from "vitest";
+import type {
+  ActionsAction,
+  CanvasesCanvasNodeExecution,
+  CanvasesCanvasRun,
+  SuperplaneComponentsNode,
+} from "@/api-client";
+import { AccountContext } from "@/contexts/accountContextState";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { RunInspectorPanel } from "./RunInspectorPanel";
+
+export const executions: CanvasesCanvasNodeExecution[] = [
+  {
+    id: "execution-1",
+    nodeId: "action-1",
+    state: "STATE_FINISHED",
+    result: "RESULT_FAILED",
+    resultReason: "RESULT_REASON_ERROR",
+    resultMessage: "expression evaluation failed",
+    createdAt: "2026-05-01T12:00:01Z",
+    updatedAt: "2026-05-01T12:00:02Z",
+    outputs: {},
+    metadata: {},
+    configuration: { retries: 1 },
+  },
+  {
+    id: "execution-2",
+    nodeId: "action-2",
+    previousExecutionId: "execution-1",
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    createdAt: "2026-05-01T12:00:03Z",
+    updatedAt: "2026-05-01T12:00:04Z",
+    outputs: { default: [{ data: { ok: true } }] },
+    metadata: {},
+    configuration: { mode: "create", approvers: [{ type: "anyone" }] },
+  },
+];
+
+export const runningExecutions: CanvasesCanvasNodeExecution[] = [
+  {
+    id: "execution-running",
+    nodeId: "action-2",
+    state: "STATE_STARTED",
+    result: "RESULT_UNKNOWN",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    createdAt: "2026-05-01T12:00:03Z",
+    updatedAt: "2026-05-01T12:00:04Z",
+    outputs: {},
+    metadata: {},
+    configuration: { mode: "create" },
+  },
+];
+
+export function renderInspector({
+  selectedNodeId = null,
+  onSelectNode = vi.fn(),
+  onClose = vi.fn(),
+  run: inspectedRun = run,
+  account = null,
+  passCurrentUser = true,
+}: {
+  selectedNodeId?: string | null;
+  onSelectNode?: (nodeId: string) => void;
+  onClose?: () => void;
+  run?: CanvasesCanvasRun;
+  account?: {
+    id: string;
+    name: string;
+    email: string;
+    avatar_url: string;
+    installation_admin: boolean;
+    has_password?: boolean;
+    roles?: string[];
+    groups?: string[];
+  } | null;
+  passCurrentUser?: boolean;
+} = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AccountContext.Provider
+        value={{
+          account: account ? { ...account, has_password: account.has_password ?? false } : null,
+          loading: false,
+          setupRequired: false,
+        }}
+      >
+        <ThemeProvider>
+          <RunInspectorPanel
+            canvasId="canvas-1"
+            organizationId="org-1"
+            run={inspectedRun}
+            workflowNodes={workflowNodes}
+            componentDefinitions={componentDefinitions}
+            currentUser={
+              passCurrentUser && account
+                ? { id: account.id, email: account.email, roles: account.roles, groups: account.groups }
+                : undefined
+            }
+            selectedNodeId={selectedNodeId}
+            onSelectNode={onSelectNode}
+            onClose={onClose}
+          />
+        </ThemeProvider>
+      </AccountContext.Provider>
+    </QueryClientProvider>,
+  );
+}
+
+export function renderInteractiveInspector() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function InteractiveInspector() {
+    const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <RunInspectorPanel
+            canvasId="canvas-1"
+            organizationId="org-1"
+            run={run}
+            workflowNodes={workflowNodes}
+            componentDefinitions={componentDefinitions}
+            selectedNodeId={selectedNodeId}
+            onSelectNode={setSelectedNodeId}
+            onClearSelectedNode={() => setSelectedNodeId(null)}
+            onClose={vi.fn()}
+          />
+        </ThemeProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  return render(<InteractiveInspector />);
+}
+
+export function firePointerEvent(
+  target: Window | Element,
+  eventName: "pointerDown" | "pointerMove" | "pointerUp",
+  clientX: number,
+) {
+  const event = createEvent[eventName](target, {});
+  Object.defineProperty(event, "pointerId", { value: 1 });
+  Object.defineProperty(event, "clientX", { value: clientX });
+  fireEvent(target, event);
+}
+
+const run: CanvasesCanvasRun = {
+  id: "run-1",
+  canvasId: "canvas-1",
+  state: "STATE_FINISHED",
+  result: "RESULT_FAILED",
+  createdAt: "2026-05-01T12:00:00Z",
+  updatedAt: "2026-05-01T12:00:05Z",
+  rootEvent: {
+    id: "event-1",
+    nodeId: "trigger-1",
+    customName: "Deploy main",
+    createdAt: "2026-05-01T12:00:00Z",
+    data: { repository: "superplane" },
+  },
+};
+
+export const runningRun: CanvasesCanvasRun = {
+  id: "run-running",
+  canvasId: "canvas-1",
+  state: "STATE_STARTED",
+  result: "RESULT_UNKNOWN",
+  createdAt: "2026-05-01T12:00:00Z",
+  updatedAt: "2026-05-01T12:00:05Z",
+  rootEvent: {
+    id: "event-running",
+    nodeId: "trigger-1",
+    customName: "Deploy main",
+    createdAt: "2026-05-01T12:00:00Z",
+    data: { repository: "superplane" },
+  },
+};
+
+const workflowNodes: SuperplaneComponentsNode[] = [
+  {
+    id: "trigger-1",
+    name: "On Pull Request",
+    type: "TYPE_TRIGGER",
+    component: "github.onPullRequest",
+  },
+  {
+    id: "action-1",
+    name: "Add Grade Label",
+    type: "TYPE_ACTION",
+    component: "github.addLabel",
+  },
+  {
+    id: "action-2",
+    name: "Save Assessment",
+    type: "TYPE_ACTION",
+    component: "upsertMemory",
+  },
+  {
+    id: "approval-1",
+    name: "Await Approval",
+    type: "TYPE_ACTION",
+    component: "approval",
+  },
+];
+
+const componentDefinitions: ActionsAction[] = [
+  {
+    name: "upsertMemory",
+    configuration: [
+      {
+        name: "mode",
+        label: "Mode",
+        type: "select",
+        typeOptions: {
+          select: {
+            options: [{ label: "Create", value: "create" }],
+          },
+        },
+      },
+      {
+        name: "approvers",
+        label: "Approvers",
+        type: "list",
+        typeOptions: {
+          list: {
+            itemLabel: "Approver",
+            itemDefinition: {
+              type: "object",
+              schema: [
+                {
+                  name: "type",
+                  label: "Request approval from",
+                  type: "select",
+                  typeOptions: {
+                    select: {
+                      options: [{ label: "Any one", value: "anyone" }],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+];

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -128,6 +128,10 @@ describe("RunInspectorPanel", () => {
     expect(screen.getByText("Deploy main")).toBeInTheDocument();
     expect(screen.getAllByText("Save Assessment").length).toBeGreaterThan(0);
     expect(screen.getByText("OUTPUT · DEFAULT · 0.02 KB")).toBeInTheDocument();
+    expect(screen.queryByText(/"data":\{"ok":true\}/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Output · default/i }));
+
     expect(screen.getByText(/"data":\{"ok":true\}/)).toBeInTheDocument();
     expect(screen.queryByText(/\[\{"data":\{"ok":true\}\}\]/)).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Copy" }).length).toBeGreaterThanOrEqual(2);
@@ -141,6 +145,10 @@ describe("RunInspectorPanel", () => {
     expect(screen.queryByRole("button", { name: /Input/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Runtime config/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Output · default/i })).toBeInTheDocument();
+    expect(screen.queryByText(/"repository":"superplane"/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Output · default/i }));
+
     expect(screen.getByText(/"repository":"superplane"/)).toBeInTheDocument();
   });
 
@@ -189,10 +197,21 @@ describe("RunInspectorPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
 
     expect(JSON.parse(localStorage.getItem("superplane.runInspector.internalAccordions") || "{}")).toMatchObject({
-      input: true,
-      runtime: false,
-      output: true,
+      input: false,
+      runtime: true,
+      output: false,
     });
+  });
+
+  it("honors stored internal accordion preferences", () => {
+    localStorage.setItem(
+      "superplane.runInspector.internalAccordions",
+      JSON.stringify({ input: false, runtime: false, output: true }),
+    );
+
+    renderInspector({ selectedNodeId: "action-2" });
+
+    expect(screen.getByText(/"data":\{"ok":true\}/)).toBeInTheDocument();
   });
 
   it("opens the upstream input chain in a modal from the more chip", () => {

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -1,58 +1,18 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createEvent, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { useState } from "react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 import type * as ApiClient from "@/api-client";
-import type { CanvasesCanvasNodeExecution, CanvasesCanvasRun, SuperplaneComponentsNode } from "@/api-client";
-import { ThemeProvider } from "@/contexts/ThemeProvider";
-import { RunInspectorPanel } from "./RunInspectorPanel";
-
-const executions: CanvasesCanvasNodeExecution[] = [
-  {
-    id: "execution-1",
-    nodeId: "action-1",
-    state: "STATE_FINISHED",
-    result: "RESULT_FAILED",
-    resultReason: "RESULT_REASON_ERROR",
-    resultMessage: "expression evaluation failed",
-    createdAt: "2026-05-01T12:00:01Z",
-    updatedAt: "2026-05-01T12:00:02Z",
-    outputs: {},
-    metadata: {},
-    configuration: { retries: 1 },
-  },
-  {
-    id: "execution-2",
-    nodeId: "action-2",
-    previousExecutionId: "execution-1",
-    state: "STATE_FINISHED",
-    result: "RESULT_PASSED",
-    resultReason: "RESULT_REASON_OK",
-    resultMessage: "",
-    createdAt: "2026-05-01T12:00:03Z",
-    updatedAt: "2026-05-01T12:00:04Z",
-    outputs: { default: [{ data: { ok: true } }] },
-    metadata: {},
-    configuration: { mode: "create" },
-  },
-];
-const runningExecutions: CanvasesCanvasNodeExecution[] = [
-  {
-    id: "execution-running",
-    nodeId: "action-2",
-    state: "STATE_STARTED",
-    result: "RESULT_UNKNOWN",
-    resultReason: "RESULT_REASON_OK",
-    resultMessage: "",
-    createdAt: "2026-05-01T12:00:03Z",
-    updatedAt: "2026-05-01T12:00:04Z",
-    outputs: {},
-    metadata: {},
-    configuration: { mode: "create" },
-  },
-];
+import type { CanvasesCanvasNodeExecution, SuperplaneMeUser } from "@/api-client";
+import {
+  executions,
+  firePointerEvent,
+  renderInspector,
+  renderInteractiveInspector,
+  runningExecutions,
+  runningRun,
+} from "./RunInspectorPanel.spec.fixtures";
 let mockedExecutions = executions;
 let mockedExecutionsLoading = false;
+let mockedMe: SuperplaneMeUser | null = null;
 
 vi.mock("@uiw/react-json-view", () => ({
   default: ({ value }: { value: unknown }) => <pre data-testid="json-view">{JSON.stringify(value)}</pre>,
@@ -60,6 +20,7 @@ vi.mock("@uiw/react-json-view", () => ({
 
 const reemitTriggerEventMock = vi.fn();
 const cancelExecutionMock = vi.fn();
+const invokeExecutionHookMock = vi.fn();
 const listNodeQueueItemsMock = vi.fn();
 const deleteNodeQueueItemMock = vi.fn();
 
@@ -69,6 +30,7 @@ vi.mock("@/api-client", async (importOriginal) => {
     ...actual,
     canvasesReemitTriggerEvent: (...args: unknown[]) => reemitTriggerEventMock(...args),
     canvasesCancelExecution: (...args: unknown[]) => cancelExecutionMock(...args),
+    canvasesInvokeNodeExecutionHook: (...args: unknown[]) => invokeExecutionHookMock(...args),
     canvasesListNodeQueueItems: (...args: unknown[]) => listNodeQueueItemsMock(...args),
     canvasesDeleteNodeQueueItem: (...args: unknown[]) => deleteNodeQueueItemMock(...args),
   };
@@ -79,6 +41,10 @@ vi.mock("@/hooks/useCanvasData", () => ({
     data: { executions: mockedExecutions },
     isLoading: mockedExecutionsLoading,
   }),
+}));
+
+vi.mock("@/hooks/useMe", () => ({
+  useMe: () => ({ data: mockedMe }),
 }));
 
 vi.mock("@/pages/app/mappers", () => ({
@@ -109,8 +75,10 @@ vi.mock("@/lib/toast", () => ({
 beforeEach(() => {
   mockedExecutions = executions;
   mockedExecutionsLoading = false;
+  mockedMe = null;
   reemitTriggerEventMock.mockResolvedValue({});
   cancelExecutionMock.mockResolvedValue({});
+  invokeExecutionHookMock.mockResolvedValue({});
   listNodeQueueItemsMock.mockResolvedValue({ data: { items: [] } });
   deleteNodeQueueItemMock.mockResolvedValue({});
 });
@@ -203,6 +171,27 @@ describe("RunInspectorPanel", () => {
     });
   });
 
+  it("shows applied runtime config as a read-only form with a JSON switch", () => {
+    renderInspector({ selectedNodeId: "action-2" });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    expect(screen.getByRole("button", { name: "Form" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("Mode")).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Approvers")).toBeInTheDocument();
+    expect(screen.getByText("Request approval from")).toBeInTheDocument();
+    expect(screen.getByText("Any one")).toBeInTheDocument();
+    expect(screen.queryByText(/"type":"anyone"/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("json-view")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "JSON" }));
+
+    expect(screen.getByRole("button", { name: "JSON" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("json-view")).toHaveTextContent(/"mode":"create"/);
+    expect(screen.getByTestId("json-view")).toHaveTextContent(/"type":"anyone"/);
+  });
+
   it("honors stored internal accordion preferences", () => {
     localStorage.setItem(
       "superplane.runInspector.internalAccordions",
@@ -274,7 +263,7 @@ describe("RunInspectorPanel", () => {
 
     renderInspector({ run: runningRun });
 
-    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
 
     await waitFor(() => {
       expect(cancelExecutionMock).toHaveBeenCalledWith(
@@ -297,6 +286,157 @@ describe("RunInspectorPanel", () => {
     });
 
     expect(deleteNodeQueueItemMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops an active node execution from the node accordion header", async () => {
+    mockedExecutions = runningExecutions;
+
+    renderInspector({ run: runningRun, selectedNodeId: "action-2" });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Stop" }).at(-1)!);
+
+    await waitFor(() => {
+      expect(cancelExecutionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            executionId: "execution-running",
+          },
+        }),
+      );
+    });
+  });
+
+  it("shows approval actions for actionable pending approval records", async () => {
+    mockedExecutions = [
+      {
+        id: "execution-approval",
+        nodeId: "approval-1",
+        state: "STATE_STARTED",
+        result: "RESULT_UNKNOWN",
+        resultReason: "RESULT_REASON_OK",
+        resultMessage: "",
+        createdAt: "2026-05-01T12:00:03Z",
+        updatedAt: "2026-05-01T12:00:04Z",
+        outputs: {},
+        metadata: {
+          records: [{ index: 0, state: "pending", type: "user", user: { id: "account-1", email: "me@example.com" } }],
+        },
+        configuration: {},
+      },
+    ];
+
+    renderInspector({
+      run: runningRun,
+      selectedNodeId: "approval-1",
+      account: { id: "account-1", name: "Me", email: "me@example.com", avatar_url: "", installation_admin: false },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(invokeExecutionHookMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            executionId: "execution-approval",
+            hookName: "approve",
+          },
+          body: {
+            parameters: { index: 0, comment: "" },
+          },
+        }),
+      );
+    });
+  });
+
+  it("shows approval actions for actionable role approval records", async () => {
+    mockedMe = {
+      id: "account-1",
+      email: "me@example.com",
+      roles: ["release_manager"],
+      groups: [],
+    };
+    mockedExecutions = [
+      {
+        id: "execution-approval",
+        nodeId: "approval-1",
+        state: "STATE_STARTED",
+        result: "RESULT_UNKNOWN",
+        resultReason: "RESULT_REASON_OK",
+        resultMessage: "",
+        createdAt: "2026-05-01T12:00:03Z",
+        updatedAt: "2026-05-01T12:00:04Z",
+        outputs: {},
+        metadata: {
+          records: [{ index: 1, state: "pending", type: "role", roleRef: { name: "release_manager" } }],
+        },
+        configuration: {},
+      },
+    ];
+
+    renderInspector({
+      run: runningRun,
+      selectedNodeId: "approval-1",
+      account: {
+        id: "account-1",
+        name: "Me",
+        email: "me@example.com",
+        avatar_url: "",
+        installation_admin: false,
+      },
+      passCurrentUser: false,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(invokeExecutionHookMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            executionId: "execution-approval",
+            hookName: "approve",
+          },
+          body: {
+            parameters: { index: 1, comment: "" },
+          },
+        }),
+      );
+    });
+  });
+
+  it("shows approval nodes from run execution refs when the current user cannot approve", () => {
+    mockedExecutions = [];
+
+    renderInspector({
+      run: {
+        ...runningRun,
+        executions: [
+          {
+            id: "execution-approval",
+            nodeId: "approval-1",
+            state: "STATE_STARTED",
+            result: "RESULT_UNKNOWN",
+            resultReason: "RESULT_REASON_OK",
+            createdAt: "2026-05-01T12:00:03Z",
+            updatedAt: "2026-05-01T12:00:04Z",
+          },
+        ],
+      },
+      selectedNodeId: "approval-1",
+      account: {
+        id: "account-other",
+        name: "Other user",
+        email: "other@example.com",
+        avatar_url: "",
+        installation_admin: false,
+      },
+    });
+
+    expect(screen.getByRole("button", { name: /Await Approval/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
   });
 
   it("keeps the stop action disabled while executions are loading", () => {
@@ -340,132 +480,3 @@ describe("RunInspectorPanel", () => {
     expect(localStorage.getItem("superplane.runInspector.width.v3")).toBe("520");
   });
 });
-
-function renderInspector({
-  selectedNodeId = null,
-  onSelectNode = vi.fn(),
-  onClose = vi.fn(),
-  run: inspectedRun = run,
-}: {
-  selectedNodeId?: string | null;
-  onSelectNode?: (nodeId: string) => void;
-  onClose?: () => void;
-  run?: CanvasesCanvasRun;
-} = {}) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
-
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <RunInspectorPanel
-          canvasId="canvas-1"
-          run={inspectedRun}
-          workflowNodes={workflowNodes}
-          selectedNodeId={selectedNodeId}
-          onSelectNode={onSelectNode}
-          onClose={onClose}
-        />
-      </ThemeProvider>
-    </QueryClientProvider>,
-  );
-}
-
-function renderInteractiveInspector() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
-
-  function InteractiveInspector() {
-    const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-
-    return (
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider>
-          <RunInspectorPanel
-            canvasId="canvas-1"
-            run={run}
-            workflowNodes={workflowNodes}
-            selectedNodeId={selectedNodeId}
-            onSelectNode={setSelectedNodeId}
-            onClearSelectedNode={() => setSelectedNodeId(null)}
-            onClose={vi.fn()}
-          />
-        </ThemeProvider>
-      </QueryClientProvider>
-    );
-  }
-
-  return render(<InteractiveInspector />);
-}
-
-function firePointerEvent(
-  target: Window | Element,
-  eventName: "pointerDown" | "pointerMove" | "pointerUp",
-  clientX: number,
-) {
-  const event = createEvent[eventName](target, {});
-  Object.defineProperty(event, "pointerId", { value: 1 });
-  Object.defineProperty(event, "clientX", { value: clientX });
-  fireEvent(target, event);
-}
-
-const run: CanvasesCanvasRun = {
-  id: "run-1",
-  canvasId: "canvas-1",
-  state: "STATE_FINISHED",
-  result: "RESULT_FAILED",
-  createdAt: "2026-05-01T12:00:00Z",
-  updatedAt: "2026-05-01T12:00:05Z",
-  rootEvent: {
-    id: "event-1",
-    nodeId: "trigger-1",
-    customName: "Deploy main",
-    createdAt: "2026-05-01T12:00:00Z",
-    data: { repository: "superplane" },
-  },
-};
-
-const runningRun: CanvasesCanvasRun = {
-  id: "run-running",
-  canvasId: "canvas-1",
-  state: "STATE_STARTED",
-  result: "RESULT_UNKNOWN",
-  createdAt: "2026-05-01T12:00:00Z",
-  updatedAt: "2026-05-01T12:00:05Z",
-  rootEvent: {
-    id: "event-running",
-    nodeId: "trigger-1",
-    customName: "Deploy main",
-    createdAt: "2026-05-01T12:00:00Z",
-    data: { repository: "superplane" },
-  },
-};
-
-const workflowNodes: SuperplaneComponentsNode[] = [
-  {
-    id: "trigger-1",
-    name: "On Pull Request",
-    type: "TYPE_TRIGGER",
-    component: "github.onPullRequest",
-  },
-  {
-    id: "action-1",
-    name: "Add Grade Label",
-    type: "TYPE_ACTION",
-    component: "github.addLabel",
-  },
-  {
-    id: "action-2",
-    name: "Save Assessment",
-    type: "TYPE_ACTION",
-    component: "upsertMemory",
-  },
-];

--- a/web_src/src/ui/Runs/RunInspectorPanel.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  type ActionsAction,
   type CanvasesCanvasRun,
   type ComponentsEdge,
+  type SuperplaneMeUser,
   type SuperplaneComponentsNode as ComponentsNode,
+  type TriggersTrigger,
 } from "@/api-client";
+import { useAccount } from "@/contexts/useAccount";
 import { useEventExecutions } from "@/hooks/useCanvasData";
+import { useMe } from "@/hooks/useMe";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
 import { RunInspectorChrome } from "./RunInspectorChrome";
@@ -12,41 +17,71 @@ import { RunInspectorHeader } from "./RunInspectorHeader";
 import { ResizeHandle } from "./RunInspectorResize";
 import { RunInspectorStepsList } from "./RunInspectorStepsList";
 import { buildNodeMap, buildRunPresentation } from "./runPresentation";
-import { buildRunInspectorNodeSections, findRunInspectorErrorSummaries } from "./runNodeDetailModel";
+import {
+  buildRunInspectorNodeSections,
+  findRunInspectorErrorSummaries,
+  type RunInspectorCurrentUser,
+} from "./runNodeDetailModel";
 import { useResizableInspectorWidth } from "./useResizableInspectorWidth";
 import { useRunInspectorActions } from "./useRunInspectorActions";
 
 export interface RunInspectorPanelProps {
   canvasId: string;
+  organizationId?: string;
   run: CanvasesCanvasRun;
   workflowNodes: ComponentsNode[];
   workflowEdges?: ComponentsEdge[];
+  componentDefinitions?: ActionsAction[];
+  triggerDefinitions?: TriggersTrigger[];
   componentIconMap?: Record<string, string>;
+  currentUser?: RunInspectorCurrentUser;
   selectedNodeId?: string | null;
   onSelectNode: (nodeId: string) => void;
   onClearSelectedNode?: () => void;
   onClose: () => void;
 }
 
+type AccountFallback = {
+  id: string;
+  email: string;
+  roles?: string[];
+  groups?: string[];
+} | null;
+
 export function RunInspectorPanel({
   canvasId,
+  organizationId,
   run,
   workflowNodes,
   workflowEdges,
+  componentDefinitions,
+  triggerDefinitions,
   componentIconMap = {},
+  currentUser,
   selectedNodeId = null,
   onSelectNode,
   onClearSelectedNode,
   onClose,
 }: RunInspectorPanelProps) {
+  const { account } = useAccount();
+  const { data: me } = useMe(true, organizationId ?? null);
+  const resolvedCurrentUser = useMemo(() => resolveCurrentUser(currentUser, me, account), [account, currentUser, me]);
   const rootEventId = run.rootEvent?.id || null;
   const executionsQuery = useEventExecutions(canvasId, rootEventId);
   const executions = useMemo(() => executionsQuery.data?.executions || [], [executionsQuery.data?.executions]);
   const nodeMap = useMemo(() => buildNodeMap(workflowNodes), [workflowNodes]);
   const presentation = useMemo(() => buildRunPresentation(run, nodeMap), [nodeMap, run]);
   const sections = useMemo(
-    () => buildRunInspectorNodeSections({ run, executions, workflowNodes, workflowEdges }),
-    [executions, run, workflowEdges, workflowNodes],
+    () =>
+      buildRunInspectorNodeSections({
+        run,
+        executions,
+        workflowNodes,
+        workflowEdges,
+        componentDefinitions,
+        triggerDefinitions,
+      }),
+    [componentDefinitions, executions, run, triggerDefinitions, workflowEdges, workflowNodes],
   );
   const errorSummaries = useMemo(() => findRunInspectorErrorSummaries(sections), [sections]);
   const inspectorWidth = useResizableInspectorWidth();
@@ -113,11 +148,25 @@ export function RunInspectorPanel({
         isLoading={executionsQuery.isLoading}
         selectedValue={selectedValue}
         componentIconMap={componentIconMap}
+        organizationId={organizationId}
         onValueChange={handleValueChange}
         onJumpToError={jumpToErrorOutput}
         onRerun={actions.rerun}
         rerunPending={actions.rerunPending}
+        actions={actions}
+        currentUser={resolvedCurrentUser}
       />
     </aside>
   );
+}
+
+function resolveCurrentUser(
+  currentUser: RunInspectorCurrentUser | undefined,
+  me: SuperplaneMeUser | null | undefined,
+  account: AccountFallback,
+): RunInspectorCurrentUser | undefined {
+  if (currentUser) return currentUser;
+  if (me) return { id: me.id ?? "", email: me.email ?? "", roles: me.roles, groups: me.groups };
+  if (account) return { id: account.id, email: account.email, roles: account.roles, groups: account.groups };
+  return undefined;
 }

--- a/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
@@ -1,0 +1,195 @@
+import { useState, type CSSProperties } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ConfigurationFieldRenderer } from "@/ui/configurationFieldRenderer";
+import { cn } from "@/lib/utils";
+import { EmptySectionText, JsonPayload, TimelineAccordionCard } from "./RunInspectorTimelineCard";
+import { hasObjectValue, type RunInspectorNodeSection } from "./runNodeDetailModel";
+
+export function RuntimeTimelineCard({
+  section,
+  jsonViewStyle,
+  organizationId,
+}: {
+  section: RunInspectorNodeSection;
+  jsonViewStyle: CSSProperties;
+  organizationId?: string;
+}) {
+  const [mode, setMode] = useState<"form" | "json">("form");
+  const configuration = section.tabData?.configuration;
+
+  return (
+    <TimelineAccordionCard
+      value="runtime"
+      status={{ dotClassName: "bg-blue-500", label: "Running" }}
+      title="Runtime Config"
+      trailing={<RuntimeViewToggle mode={mode} onChange={setMode} />}
+      jsonViewStyle={jsonViewStyle}
+    >
+      {mode === "form" ? (
+        <RuntimeConfigForm
+          section={section}
+          value={configuration}
+          jsonViewStyle={jsonViewStyle}
+          organizationId={organizationId}
+        />
+      ) : (
+        <JsonPayload value={configuration} jsonViewStyle={jsonViewStyle} />
+      )}
+    </TimelineAccordionCard>
+  );
+}
+
+function RuntimeViewToggle({ mode, onChange }: { mode: "form" | "json"; onChange: (mode: "form" | "json") => void }) {
+  return (
+    <span className="inline-flex h-7 items-center rounded-md border border-slate-200 bg-white p-0.5 text-xs font-medium dark:border-gray-700 dark:bg-gray-950">
+      {(["form", "json"] as const).map((item) => (
+        <Button
+          key={item}
+          type="button"
+          variant="ghost"
+          aria-label={item === "form" ? "Form" : "JSON"}
+          aria-pressed={mode === item}
+          className={cn(
+            "h-6 rounded px-2 text-xs",
+            mode === item
+              ? "bg-slate-100 text-slate-900 shadow-sm hover:bg-slate-100 dark:bg-gray-800 dark:text-gray-50 dark:hover:bg-gray-800"
+              : "text-slate-500 hover:bg-slate-50 hover:text-slate-800 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-100",
+          )}
+          onClick={(event) => {
+            event.stopPropagation();
+            onChange(item);
+          }}
+        >
+          {item === "form" ? "Form" : "JSON"}
+        </Button>
+      ))}
+    </span>
+  );
+}
+
+function RuntimeConfigForm({
+  section,
+  value,
+  jsonViewStyle,
+  organizationId,
+}: {
+  section: RunInspectorNodeSection;
+  value: unknown;
+  jsonViewStyle: CSSProperties;
+  organizationId?: string;
+}) {
+  if (!hasObjectValue(value)) {
+    return <EmptySectionText>No runtime configuration for this step.</EmptySectionText>;
+  }
+
+  if (section.configurationFields.length > 0) {
+    return (
+      <RuntimeSchemaConfigForm fields={section.configurationFields} value={value} organizationId={organizationId} />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {Object.entries(value).map(([key, fieldValue]) => (
+        <RuntimeFallbackConfigField key={key} name={key} value={fieldValue} jsonViewStyle={jsonViewStyle} />
+      ))}
+    </div>
+  );
+}
+
+function RuntimeSchemaConfigForm({
+  fields,
+  value,
+  organizationId,
+}: {
+  fields: RunInspectorNodeSection["configurationFields"];
+  value: Record<string, unknown>;
+  organizationId?: string;
+}) {
+  return (
+    <div className="space-y-4">
+      {fields.map((field) => {
+        if (!field.name) return null;
+
+        return (
+          <ConfigurationFieldRenderer
+            key={field.name}
+            field={field}
+            value={value[field.name]}
+            allValues={value}
+            onChange={() => {}}
+            domainId={organizationId}
+            organizationId={organizationId}
+            readOnly
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function RuntimeFallbackConfigField({
+  name,
+  value,
+  jsonViewStyle,
+}: {
+  name: string;
+  value: unknown;
+  jsonViewStyle: CSSProperties;
+}) {
+  const label = formatRuntimeFieldLabel(name);
+
+  if (typeof value === "boolean") {
+    return (
+      <label className="flex items-center gap-3 text-sm font-medium text-slate-800 dark:text-gray-100">
+        <span
+          className={
+            value
+              ? "relative inline-flex h-5 w-9 rounded-full bg-blue-500"
+              : "relative inline-flex h-5 w-9 rounded-full bg-slate-200 dark:bg-gray-700"
+          }
+        >
+          <span
+            className={
+              value
+                ? "absolute right-0.5 top-0.5 h-4 w-4 rounded-full bg-white"
+                : "absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white"
+            }
+          />
+        </span>
+        {label}
+      </label>
+    );
+  }
+
+  if (typeof value === "string" || typeof value === "number" || value === null) {
+    return (
+      <label className="block space-y-1.5">
+        <span className="text-sm font-medium text-slate-800 dark:text-gray-100">{label}</span>
+        <Input
+          aria-label={label}
+          readOnly
+          value={value === null ? "" : String(value)}
+          className="h-9 border-slate-300 bg-white text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+        />
+      </label>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="text-sm font-medium text-slate-800 dark:text-gray-100">{label}</div>
+      <div className="rounded-md border border-slate-200 bg-white p-2 dark:border-gray-800 dark:bg-gray-950">
+        <JsonPayload value={value} jsonViewStyle={jsonViewStyle} />
+      </div>
+    </div>
+  );
+}
+
+function formatRuntimeFieldLabel(value: string): string {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.slice(1));
+}

--- a/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
@@ -4,6 +4,7 @@ import { Accordion } from "@/ui/accordion";
 import { useTheme } from "@/contexts/useTheme";
 import { RunNodeDetailDetailsView } from "./RunNodeDetailDetailsView";
 import { InputChainMoreChip } from "./RunInspectorInputChainModal";
+import { RuntimeTimelineCard } from "./RunInspectorRuntimeConfig";
 import {
   DetailBox,
   EmptySectionText,
@@ -24,9 +25,11 @@ import { hasObjectValue, type RunInspectorNodeSection, type RunInspectorUpstream
 export function RunInspectorStepTimeline({
   section,
   componentIconMap,
+  organizationId,
 }: {
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
+  organizationId?: string;
 }) {
   const { resolvedTheme } = useTheme();
   const jsonViewStyle = getJsonViewStyle(resolvedTheme);
@@ -71,15 +74,7 @@ export function RunInspectorStepTimeline({
             {item.value === "input" ? (
               <InputTimelineCard section={section} jsonViewStyle={jsonViewStyle} componentIconMap={componentIconMap} />
             ) : item.value === "runtime" ? (
-              <TimelineAccordionCard
-                value="runtime"
-                status={{ dotClassName: "bg-blue-500", label: "Running" }}
-                title="Runtime Config"
-                trailing="JSON"
-                jsonViewStyle={jsonViewStyle}
-              >
-                <JsonPayload value={section.tabData?.configuration} jsonViewStyle={jsonViewStyle} />
-              </TimelineAccordionCard>
+              <RuntimeTimelineCard section={section} jsonViewStyle={jsonViewStyle} organizationId={organizationId} />
             ) : (
               <OutputTimelineCard section={section} jsonViewStyle={jsonViewStyle} />
             )}

--- a/web_src/src/ui/Runs/RunInspectorStepsList.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepsList.tsx
@@ -3,8 +3,9 @@ import { Accordion } from "@/ui/accordion";
 import { RunInspectorErrorSummaryCard } from "./RunInspectorErrorSummaryCard";
 import { RunInspectorNodeAccordion } from "./RunInspectorNodeAccordion";
 import { RunInspectorStepsHeader } from "./RunInspectorStepsHeader";
-import type { RunInspectorErrorSummary, RunInspectorNodeSection } from "./runNodeDetailModel";
+import type { RunInspectorCurrentUser, RunInspectorErrorSummary, RunInspectorNodeSection } from "./runNodeDetailModel";
 import type { RUN_STATUS_META } from "./runPresentation";
+import type { useRunInspectorActions } from "./useRunInspectorActions";
 
 export function RunInspectorStepsList({
   errorSummaries,
@@ -13,10 +14,13 @@ export function RunInspectorStepsList({
   isLoading,
   selectedValue,
   componentIconMap,
+  organizationId,
   onValueChange,
   onJumpToError,
   onRerun,
   rerunPending,
+  actions,
+  currentUser,
 }: {
   errorSummaries: RunInspectorErrorSummary[];
   status: keyof typeof RUN_STATUS_META;
@@ -24,10 +28,13 @@ export function RunInspectorStepsList({
   isLoading: boolean;
   selectedValue: string;
   componentIconMap: Record<string, string>;
+  organizationId?: string;
   onValueChange: (value: string) => void;
   onJumpToError: (nodeId: string) => void;
   onRerun: () => void;
   rerunPending: boolean;
+  actions: ReturnType<typeof useRunInspectorActions>;
+  currentUser?: RunInspectorCurrentUser;
 }) {
   return (
     <div className="min-h-0 flex-1 overflow-y-auto" data-testid="run-panel-step-list">
@@ -60,9 +67,12 @@ export function RunInspectorStepsList({
               key={section.nodeId}
               section={section}
               componentIconMap={componentIconMap}
+              organizationId={organizationId}
               isOpen={selectedValue === section.nodeId}
               onRerun={onRerun}
               rerunPending={rerunPending}
+              actions={actions}
+              currentUser={currentUser}
             />
           ))}
         </Accordion>

--- a/web_src/src/ui/Runs/RunInspectorTimelineTypes.ts
+++ b/web_src/src/ui/Runs/RunInspectorTimelineTypes.ts
@@ -13,9 +13,9 @@ export type StatusPill = {
 };
 
 export const defaultAccordionPreferences: InternalAccordionPreferences = {
-  input: true,
-  runtime: true,
-  output: true,
+  input: false,
+  runtime: false,
+  output: false,
 };
 
 export function buildTimelineItems(section: RunInspectorNodeSection, hasRuntimeConfig: boolean) {

--- a/web_src/src/ui/Runs/runNodeConfigurationFields.ts
+++ b/web_src/src/ui/Runs/runNodeConfigurationFields.ts
@@ -1,0 +1,44 @@
+import type {
+  ActionsAction,
+  ConfigurationField,
+  SuperplaneComponentsNode as ComponentsNode,
+  TriggersTrigger,
+} from "@/api-client";
+
+export function buildComponentDefinitionsByName(
+  componentDefinitions: ActionsAction[] | undefined,
+): Map<string, ActionsAction> {
+  return new Map(
+    componentDefinitions?.filter((definition) => definition.name).map((definition) => [definition.name!, definition]),
+  );
+}
+
+export function buildTriggerDefinitionsByName(
+  triggerDefinitions: TriggersTrigger[] | undefined,
+): Map<string, TriggersTrigger> {
+  return new Map(
+    triggerDefinitions?.filter((definition) => definition.name).map((definition) => [definition.name!, definition]),
+  );
+}
+
+export function resolveConfigurationFields({
+  workflowNode,
+  componentDefinitionsByName,
+  triggerDefinitionsByName,
+}: {
+  workflowNode?: ComponentsNode;
+  componentDefinitionsByName: Map<string, ActionsAction>;
+  triggerDefinitionsByName: Map<string, TriggersTrigger>;
+}): ConfigurationField[] {
+  if (!workflowNode?.component) return [];
+
+  if (workflowNode.type === "TYPE_ACTION") {
+    return componentDefinitionsByName.get(workflowNode.component)?.configuration ?? [];
+  }
+
+  if (workflowNode.type === "TYPE_TRIGGER") {
+    return triggerDefinitionsByName.get(workflowNode.component)?.configuration ?? [];
+  }
+
+  return [];
+}

--- a/web_src/src/ui/Runs/runNodeDetailModel.spec.ts
+++ b/web_src/src/ui/Runs/runNodeDetailModel.spec.ts
@@ -230,6 +230,44 @@ describe("buildRunInspectorNodeSections", () => {
     expect(secondAction?.primaryInputNodeId).toBe("first-action");
   });
 
+  it("includes execution refs when full execution details are unavailable", () => {
+    const run: CanvasesCanvasRun = {
+      rootEvent: {
+        id: "event-1",
+        nodeId: "trigger",
+        createdAt: "2026-05-01T12:00:00Z",
+        data: { trigger: true },
+      },
+      executions: [
+        {
+          id: "execution-approval",
+          nodeId: "approval",
+          state: "STATE_STARTED",
+          result: "RESULT_UNKNOWN",
+          resultReason: "RESULT_REASON_OK",
+          createdAt: "2026-05-01T12:00:01Z",
+          updatedAt: "2026-05-01T12:00:02Z",
+        },
+      ],
+    };
+
+    const sections = buildRunInspectorNodeSections({
+      run,
+      executions: [],
+      workflowNodes: [
+        { id: "trigger", name: "Trigger", type: "TYPE_TRIGGER", component: "github.onPullRequest" },
+        { id: "approval", name: "Await Approval", type: "TYPE_ACTION", component: "approval" },
+      ],
+    });
+
+    const approvalSection = sections.find((section) => section.nodeId === "approval");
+
+    expect(approvalSection?.nodeName).toBe("Await Approval");
+    expect(approvalSection?.execution).toBeUndefined();
+    expect(approvalSection?.executionRef?.id).toBe("execution-approval");
+    expect(approvalSection?.actions.approvalRecords).toEqual([]);
+  });
+
   it("uses edges to include only accessible upstream nodes ordered by creation time", () => {
     const run: CanvasesCanvasRun = {
       rootEvent: {
@@ -286,6 +324,105 @@ describe("buildRunInspectorNodeSections", () => {
       { first: true },
     ]);
     expect(secondAction?.primaryInputNodeId).toBe("first-action");
+  });
+
+  it("orders ref-only upstream nodes by their execution ref creation time", () => {
+    const run: CanvasesCanvasRun = {
+      rootEvent: {
+        id: "event-1",
+        nodeId: "trigger",
+        createdAt: "2026-05-01T12:00:00Z",
+        data: { trigger: true },
+      },
+      executions: [
+        {
+          id: "execution-ref-only",
+          nodeId: "ref-only-action",
+          createdAt: "2026-05-01T12:00:01Z",
+        },
+        {
+          id: "execution-loaded",
+          nodeId: "loaded-action",
+          createdAt: "2026-05-01T12:00:03Z",
+        },
+        {
+          id: "execution-current",
+          nodeId: "current-action",
+          createdAt: "2026-05-01T12:00:04Z",
+        },
+      ],
+    };
+
+    const sections = buildRunInspectorNodeSections({
+      run,
+      executions: [
+        {
+          id: "execution-loaded",
+          nodeId: "loaded-action",
+          createdAt: "2026-05-01T12:00:03Z",
+          outputs: { default: [{ loaded: true }] },
+          metadata: {},
+        },
+        {
+          id: "execution-current",
+          nodeId: "current-action",
+          createdAt: "2026-05-01T12:00:04Z",
+          outputs: {},
+          metadata: {},
+        },
+      ],
+      workflowNodes: [
+        { id: "trigger", name: "Trigger", type: "TYPE_TRIGGER", component: "github.onPullRequest" },
+        { id: "ref-only-action", name: "Ref Only Action", type: "TYPE_ACTION", component: "test.ref" },
+        { id: "loaded-action", name: "Loaded Action", type: "TYPE_ACTION", component: "test.loaded" },
+        { id: "current-action", name: "Current Action", type: "TYPE_ACTION", component: "test.current" },
+      ],
+      workflowEdges: [
+        { sourceId: "ref-only-action", targetId: "current-action" },
+        { sourceId: "loaded-action", targetId: "current-action" },
+      ],
+    });
+
+    const currentAction = sections.find((section) => section.nodeId === "current-action");
+
+    expect(currentAction?.upstreamSections.map((section) => section.nodeName)).toEqual([
+      "Ref Only Action",
+      "Loaded Action",
+    ]);
+    expect(currentAction?.primaryInputNodeId).toBe("loaded-action");
+  });
+
+  it("uses execution ref failures for node error messages", () => {
+    const run: CanvasesCanvasRun = {
+      rootEvent: {
+        id: "event-1",
+        nodeId: "trigger",
+        createdAt: "2026-05-01T12:00:00Z",
+        data: { trigger: true },
+      },
+      executions: [
+        {
+          id: "execution-failed",
+          nodeId: "failed-action",
+          result: "RESULT_FAILED",
+          resultReason: "RESULT_REASON_ERROR",
+          resultMessage: "failed before details loaded",
+        },
+      ],
+    };
+
+    const sections = buildRunInspectorNodeSections({
+      run,
+      executions: [],
+      workflowNodes: [
+        { id: "trigger", name: "Trigger", type: "TYPE_TRIGGER", component: "github.onPullRequest" },
+        { id: "failed-action", name: "Failed Action", type: "TYPE_ACTION", component: "test.failed" },
+      ],
+    });
+
+    const failedAction = sections.find((section) => section.nodeId === "failed-action");
+
+    expect(failedAction?.errorMessage).toBe("failed before details loaded");
   });
 
   it("keeps channel names when displaying multiple execution output channels", () => {

--- a/web_src/src/ui/Runs/runNodeDetailModel.ts
+++ b/web_src/src/ui/Runs/runNodeDetailModel.ts
@@ -1,13 +1,31 @@
 import type {
+  ActionsAction,
   CanvasesCanvasNodeExecution,
+  CanvasesCanvasNodeExecutionRef,
   CanvasesCanvasRun,
   ComponentsEdge,
+  ConfigurationField,
   SuperplaneComponentsNode as ComponentsNode,
+  TriggersTrigger,
 } from "@/api-client";
-import { flattenObject } from "@/lib/utils";
-import { getExecutionDetails, getState, getStateMap, getTriggerRenderer } from "@/pages/app/mappers";
-import { buildEventInfo, buildExecutionInfo } from "@/pages/app/utils";
+import { getState, getStateMap } from "@/pages/app/mappers";
+import { buildExecutionInfo } from "@/pages/app/utils";
 import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import {
+  buildComponentDefinitionsByName,
+  buildTriggerDefinitionsByName,
+  resolveConfigurationFields,
+} from "./runNodeConfigurationFields";
+import {
+  buildNodeActions,
+  buildOutputSections,
+  buildTriggerOutputSections,
+  getExecutionErrorMessage,
+  normalizeExecutionOutputsForDisplay,
+} from "./runNodeDetailOutputs";
+import { buildExecutionTabData, buildTriggerTabData } from "./runNodeDetailTabs";
+export { hasObjectValue } from "./runNodeDetailOutputs";
+export { buildExecutionTabData, buildTriggerTabData, isErrorValue } from "./runNodeDetailTabs";
 
 export type RunNodeDetailTabKey = "details" | "payload" | "configuration";
 
@@ -59,6 +77,38 @@ export type RunInspectorOutputSection = {
   sizeKb: string;
 };
 
+export type RunInspectorCurrentUser = {
+  id: string;
+  email: string;
+  roles?: string[];
+  groups?: string[];
+};
+
+export type RunInspectorApprovalRecord = {
+  index: number;
+  state?: string;
+  type?: string;
+  user?: {
+    id?: string;
+    email?: string;
+    name?: string;
+  };
+  roleRef?: {
+    name?: string;
+    displayName?: string;
+  };
+  groupRef?: {
+    name?: string;
+    displayName?: string;
+  };
+};
+
+export type RunInspectorNodeActions = {
+  canStop: boolean;
+  canPushThrough: boolean;
+  approvalRecords: RunInspectorApprovalRecord[];
+};
+
 export type RunInspectorUpstreamSection = {
   nodeId: string;
   nodeName: string;
@@ -72,6 +122,7 @@ export type RunInspectorNodeSection = {
   nodeName: string;
   workflowNode?: ComponentsNode;
   execution?: CanvasesCanvasNodeExecution;
+  executionRef?: CanvasesCanvasNodeExecutionRef;
   isTrigger: boolean;
   createdAt?: string;
   durationMs?: number;
@@ -81,6 +132,8 @@ export type RunInspectorNodeSection = {
   primaryInputNodeId?: string;
   outputSections: RunInspectorOutputSection[];
   errorMessage?: string;
+  actions: RunInspectorNodeActions;
+  configurationFields: ConfigurationField[];
 };
 
 export type RunInspectorErrorSummary = {
@@ -113,7 +166,30 @@ export function eventBadgeForExecution(
   return { badgeColor: style.badgeColor, label: style.label ?? String(eventState) };
 }
 
-export function buildExecutionChain(executions: CanvasesCanvasNodeExecution[], triggerNodeId?: string | null) {
+export function eventBadgeForExecutionRef(
+  node: ComponentsNode | undefined,
+  executionRef: CanvasesCanvasNodeExecutionRef,
+): { badgeColor: string; label: string } {
+  return eventBadgeForExecution(node, {
+    id: executionRef.id,
+    nodeId: executionRef.nodeId,
+    state: executionRef.state ?? "STATE_UNKNOWN",
+    result: executionRef.result ?? "RESULT_UNKNOWN",
+    resultReason: executionRef.resultReason ?? "RESULT_REASON_OK",
+    resultMessage: executionRef.resultMessage ?? "",
+    createdAt: executionRef.createdAt,
+    updatedAt: executionRef.updatedAt,
+    outputs: {},
+    metadata: {},
+    configuration: {},
+  });
+}
+
+export function buildExecutionChain(
+  executions: CanvasesCanvasNodeExecution[],
+  triggerNodeId?: string | null,
+  executionRefs: CanvasesCanvasNodeExecutionRef[] = [],
+) {
   const chain: string[] = [];
   const visited = new Set<string>();
 
@@ -122,10 +198,10 @@ export function buildExecutionChain(executions: CanvasesCanvasNodeExecution[], t
     visited.add(triggerNodeId);
   }
 
-  for (const execution of executions) {
-    if (execution.nodeId && !visited.has(execution.nodeId)) {
-      visited.add(execution.nodeId);
-      chain.push(execution.nodeId);
+  for (const executionRef of [...executionRefs, ...executions]) {
+    if (executionRef.nodeId && !visited.has(executionRef.nodeId)) {
+      visited.add(executionRef.nodeId);
+      chain.push(executionRef.nodeId);
     }
   }
 
@@ -149,19 +225,27 @@ export function buildRunInspectorNodeSections({
   executions,
   workflowNodes,
   workflowEdges,
+  componentDefinitions,
+  triggerDefinitions,
 }: {
   run: CanvasesCanvasRun;
   executions: CanvasesCanvasNodeExecution[];
   workflowNodes: ComponentsNode[];
   workflowEdges?: ComponentsEdge[];
+  componentDefinitions?: ActionsAction[];
+  triggerDefinitions?: TriggersTrigger[];
 }): RunInspectorNodeSection[] {
   const triggerNodeId = run.rootEvent?.nodeId;
-  const executionChain = buildExecutionChain(executions, triggerNodeId);
+  const executionChain = buildExecutionChain(executions, triggerNodeId, run.executions);
   const executionIndexByNodeId = new Map(executionChain.map((nodeId, index) => [nodeId, index]));
+  const componentDefinitionsByName = buildComponentDefinitionsByName(componentDefinitions);
+  const triggerDefinitionsByName = buildTriggerDefinitionsByName(triggerDefinitions);
 
   return executionChain.map((nodeId, index) => {
     const workflowNode = workflowNodes.find((node) => node.id === nodeId);
     const execution = executions.find((item) => item.nodeId === nodeId);
+    const executionRef = run.executions?.find((item) => item.nodeId === nodeId) ?? execution;
+    const errorSource = execution ?? executionRef;
     const isTrigger = nodeId === triggerNodeId;
     const tabData = isTrigger
       ? buildTriggerTabData(run, workflowNode)
@@ -175,6 +259,7 @@ export function buildRunInspectorNodeSections({
           currentIndex: index,
           run,
           executions,
+          executionRefs: run.executions ?? [],
           workflowNodes,
           workflowEdges,
           executionIndexByNodeId,
@@ -185,14 +270,21 @@ export function buildRunInspectorNodeSections({
       nodeName: workflowNode?.name || nodeId,
       workflowNode,
       execution,
+      executionRef,
       isTrigger,
-      createdAt: isTrigger ? run.rootEvent?.createdAt : execution?.createdAt,
-      durationMs: execution ? calculateExecutionDuration(execution) : undefined,
+      createdAt: isTrigger ? run.rootEvent?.createdAt : (execution?.createdAt ?? executionRef?.createdAt),
+      durationMs: execution
+        ? calculateExecutionDuration(execution)
+        : executionRef
+          ? calculateExecutionRefDuration(executionRef)
+          : undefined,
       badge: isTrigger
         ? eventBadgeForTriggeredTrigger(workflowNode)
         : execution
           ? eventBadgeForExecution(workflowNode, execution)
-          : null,
+          : executionRef
+            ? eventBadgeForExecutionRef(workflowNode, executionRef)
+            : null,
       tabData,
       upstreamSections,
       primaryInputNodeId: isTrigger
@@ -202,6 +294,7 @@ export function buildRunInspectorNodeSections({
             currentIndex: index,
             run,
             executions,
+            executionRefs: run.executions ?? [],
             workflowEdges,
             executionIndexByNodeId,
           }),
@@ -210,7 +303,13 @@ export function buildRunInspectorNodeSections({
         : execution
           ? buildOutputSections(execution.outputs)
           : [],
-      errorMessage: execution ? getExecutionErrorMessage(execution) : undefined,
+      errorMessage: errorSource ? getExecutionErrorMessage(errorSource) : undefined,
+      actions: buildNodeActions(workflowNode, execution),
+      configurationFields: resolveConfigurationFields({
+        workflowNode,
+        componentDefinitionsByName,
+        triggerDefinitionsByName,
+      }),
     };
   });
 }
@@ -233,6 +332,10 @@ function calculateExecutionDuration(execution: CanvasesCanvasNodeExecution): num
   return calculateDuration(execution.createdAt, execution.updatedAt) ?? undefined;
 }
 
+function calculateExecutionRefDuration(execution: CanvasesCanvasNodeExecutionRef): number | undefined {
+  return calculateDuration(execution.createdAt, execution.updatedAt) ?? undefined;
+}
+
 function calculateDuration(start?: string, end?: string): number | null {
   if (!start || !end) return null;
 
@@ -248,6 +351,7 @@ function buildUpstreamSections({
   currentIndex,
   run,
   executions,
+  executionRefs,
   workflowNodes,
   workflowEdges,
   executionIndexByNodeId,
@@ -256,6 +360,7 @@ function buildUpstreamSections({
   currentIndex: number;
   run: CanvasesCanvasRun;
   executions: CanvasesCanvasNodeExecution[];
+  executionRefs: CanvasesCanvasNodeExecutionRef[];
   workflowNodes: ComponentsNode[];
   workflowEdges?: ComponentsEdge[];
   executionIndexByNodeId: Map<string, number>;
@@ -270,7 +375,7 @@ function buildUpstreamSections({
       executionChain[currentIndex],
       workflowEdges,
       executionIndexByNodeId,
-    ).sort((left, right) => compareUpstreamCreatedAt(left, right, run, executions));
+    ).sort((left, right) => compareUpstreamCreatedAt(left, right, run, executions, executionRefs));
   }
 
   return orderedNodeIds.map((nodeId) => {
@@ -297,6 +402,7 @@ function findPrimaryInputNodeId({
   currentIndex,
   run,
   executions,
+  executionRefs,
   workflowEdges,
   executionIndexByNodeId,
 }: {
@@ -304,6 +410,7 @@ function findPrimaryInputNodeId({
   currentIndex: number;
   run: CanvasesCanvasRun;
   executions: CanvasesCanvasNodeExecution[];
+  executionRefs: CanvasesCanvasNodeExecutionRef[];
   workflowEdges?: ComponentsEdge[];
   executionIndexByNodeId: Map<string, number>;
 }): string | undefined {
@@ -323,11 +430,13 @@ function findPrimaryInputNodeId({
     });
 
   if (directInputNodeIds.length > 0) {
-    return directInputNodeIds.sort((left, right) => compareUpstreamCreatedAt(left, right, run, executions)).at(-1);
+    return directInputNodeIds
+      .sort((left, right) => compareUpstreamCreatedAt(left, right, run, executions, executionRefs))
+      .at(-1);
   }
 
   return findAccessibleUpstreamNodeIds(currentNodeId, workflowEdges, executionIndexByNodeId)
-    .sort((left, right) => compareUpstreamCreatedAt(left, right, run, executions))
+    .sort((left, right) => compareUpstreamCreatedAt(left, right, run, executions, executionRefs))
     .at(-1);
 }
 
@@ -373,209 +482,26 @@ function compareUpstreamCreatedAt(
   rightNodeId: string,
   run: CanvasesCanvasRun,
   executions: CanvasesCanvasNodeExecution[],
+  executionRefs: CanvasesCanvasNodeExecutionRef[],
 ): number {
-  return getUpstreamCreatedAt(leftNodeId, run, executions) - getUpstreamCreatedAt(rightNodeId, run, executions);
+  return (
+    getUpstreamCreatedAt(leftNodeId, run, executions, executionRefs) -
+    getUpstreamCreatedAt(rightNodeId, run, executions, executionRefs)
+  );
 }
 
 function getUpstreamCreatedAt(
   nodeId: string,
   run: CanvasesCanvasRun,
   executions: CanvasesCanvasNodeExecution[],
+  executionRefs: CanvasesCanvasNodeExecutionRef[],
 ): number {
   const createdAt =
     nodeId === run.rootEvent?.nodeId
       ? run.rootEvent?.createdAt
-      : executions.find((item) => item.nodeId === nodeId)?.createdAt;
+      : (executions.find((item) => item.nodeId === nodeId)?.createdAt ??
+        executionRefs.find((item) => item.nodeId === nodeId)?.createdAt);
 
   const timestamp = createdAt ? new Date(createdAt).getTime() : Number.POSITIVE_INFINITY;
   return Number.isFinite(timestamp) ? timestamp : Number.POSITIVE_INFINITY;
-}
-
-function buildTriggerOutputSections(run: CanvasesCanvasRun): RunInspectorOutputSection[] {
-  if (!hasObjectValue(run.rootEvent?.data)) return [];
-
-  return [
-    {
-      channel: run.rootEvent?.channel || "default",
-      value: run.rootEvent?.data,
-      sizeKb: formatJsonSizeKb(run.rootEvent?.data),
-    },
-  ];
-}
-
-function buildOutputSections(outputs?: CanvasesCanvasNodeExecution["outputs"]): RunInspectorOutputSection[] {
-  if (!outputs || Object.keys(outputs).length === 0) return [];
-
-  return Object.entries(outputs).map(([channel, value]) => {
-    const displayValue = normalizeExecutionChannelOutput(value);
-
-    return {
-      channel,
-      value: displayValue,
-      sizeKb: formatJsonSizeKb(displayValue),
-    };
-  });
-}
-
-function normalizeExecutionOutputsForDisplay(outputs?: CanvasesCanvasNodeExecution["outputs"]): unknown {
-  const outputSections = buildOutputSections(outputs);
-  if (outputSections.length === 0) return undefined;
-  if (outputSections.length === 1) return outputSections[0].value;
-
-  return Object.fromEntries(outputSections.map((section) => [section.channel, section.value]));
-}
-
-function normalizeExecutionChannelOutput(value: unknown): unknown {
-  if (!Array.isArray(value)) return value;
-  return value[0];
-}
-
-function formatJsonSizeKb(value: unknown): string {
-  const json = JSON.stringify(value ?? null);
-  const bytes = new Blob([json]).size;
-  return `${Math.max(bytes / 1024, 0.01).toFixed(2)} KB`;
-}
-
-function getExecutionErrorMessage(execution: CanvasesCanvasNodeExecution): string | undefined {
-  if (execution.result !== "RESULT_FAILED" && execution.resultReason !== "RESULT_REASON_ERROR") {
-    return undefined;
-  }
-
-  return execution.resultMessage || execution.resultReason || "Execution failed";
-}
-
-function extractExecutionPayload(execution: CanvasesCanvasNodeExecution): unknown {
-  if (!execution.outputs || Object.keys(execution.outputs).length === 0) {
-    return undefined;
-  }
-
-  const outputData = Object.values(execution.outputs).find((output) => Array.isArray(output) && output.length > 0) as
-    | unknown[]
-    | undefined;
-  if (outputData && outputData.length > 0) {
-    return outputData[0];
-  }
-
-  return execution.outputs;
-}
-
-function buildDefaultExecutionDetails(
-  execution: CanvasesCanvasNodeExecution,
-  workflowNode: ComponentsNode | undefined,
-  workflowNodes: ComponentsNode[],
-): Record<string, unknown> {
-  const componentName = typeof workflowNode?.component === "string" ? workflowNode.component : undefined;
-
-  if (componentName && workflowNode) {
-    const customDetails = getExecutionDetails(componentName, execution, workflowNode, workflowNodes);
-    if (customDetails && Object.keys(customDetails).length > 0) {
-      return { ...customDetails };
-    }
-  }
-
-  const displayOutputs = normalizeExecutionOutputsForDisplay(execution.outputs);
-  return { ...flattenObject((displayOutputs ?? execution.metadata) || {}) };
-}
-
-function applyExecutionResultDetails(
-  details: Record<string, unknown>,
-  execution: CanvasesCanvasNodeExecution,
-): Record<string, unknown> {
-  const next = { ...details };
-
-  if (
-    execution.resultMessage &&
-    (execution.resultReason === "RESULT_REASON_ERROR" || execution.result === "RESULT_FAILED") &&
-    !("Error" in next)
-  ) {
-    next.Error = {
-      __type: "error",
-      message: execution.resultMessage,
-    };
-  }
-
-  if (execution.result === "RESULT_CANCELLED" && !("Cancelled by" in next)) {
-    const cancelledBy = execution.cancelledBy;
-    next["Cancelled by"] = cancelledBy?.name || cancelledBy?.id || "Unknown";
-  }
-
-  return next;
-}
-
-function filterEmptyDetailEntries(details: Record<string, unknown>) {
-  return Object.fromEntries(
-    Object.entries(details).filter(([, value]) => value !== undefined && value !== "" && value !== null),
-  );
-}
-
-export function buildExecutionTabData(
-  execution: CanvasesCanvasNodeExecution,
-  workflowNode: ComponentsNode | undefined,
-  workflowNodes: ComponentsNode[],
-): RunNodeDetailTabData {
-  const tabData: RunNodeDetailTabData = {
-    details: filterEmptyDetailEntries(
-      applyExecutionResultDetails(buildDefaultExecutionDetails(execution, workflowNode, workflowNodes), execution),
-    ),
-    payload: extractExecutionPayload(execution),
-  };
-
-  if (execution.configuration && Object.keys(execution.configuration).length > 0) {
-    tabData.configuration = execution.configuration;
-  }
-
-  return tabData;
-}
-
-export function buildTriggerTabData(
-  run: CanvasesCanvasRun,
-  workflowNode: ComponentsNode | undefined,
-): RunNodeDetailTabData {
-  const rootEvent = run.rootEvent;
-  const mappedDetails = buildTriggerEventDetails(rootEvent, workflowNode);
-  const fallbackDetails = buildFallbackTriggerEventDetails(rootEvent);
-  const details = Object.keys(mappedDetails).length > 0 ? mappedDetails : fallbackDetails;
-
-  const tabData: RunNodeDetailTabData = {
-    details: Object.keys(details).length > 0 ? filterEmptyDetailEntries(details) : undefined,
-    payload: rootEvent?.data && Object.keys(rootEvent.data).length > 0 ? rootEvent.data : undefined,
-  };
-
-  if (
-    workflowNode?.configuration &&
-    typeof workflowNode.configuration === "object" &&
-    Object.keys(workflowNode.configuration).length > 0
-  ) {
-    tabData.configuration = workflowNode.configuration;
-  }
-
-  return tabData;
-}
-
-function buildTriggerEventDetails(
-  rootEvent: CanvasesCanvasRun["rootEvent"],
-  workflowNode: ComponentsNode | undefined,
-): Record<string, unknown> {
-  if (!rootEvent) return {};
-
-  const triggerRenderer = getTriggerRenderer(workflowComponentName(workflowNode));
-  return triggerRenderer.getRootEventValues({ event: buildEventInfo(rootEvent) });
-}
-
-function buildFallbackTriggerEventDetails(rootEvent: CanvasesCanvasRun["rootEvent"]): Record<string, unknown> {
-  const details: Record<string, unknown> = {};
-
-  if (rootEvent?.channel) details.Channel = rootEvent.channel;
-  if (rootEvent?.customName) details.Name = rootEvent.customName;
-  if (rootEvent?.createdAt) details["Triggered at"] = rootEvent.createdAt;
-
-  return details;
-}
-
-export function isErrorValue(value: unknown): value is { __type: "error"; message: string } {
-  return !!value && typeof value === "object" && (value as { __type?: string }).__type === "error";
-}
-
-export function hasObjectValue(value: unknown) {
-  return !!value && typeof value === "object" && Object.keys(value).length > 0;
 }

--- a/web_src/src/ui/Runs/runNodeDetailOutputs.ts
+++ b/web_src/src/ui/Runs/runNodeDetailOutputs.ts
@@ -1,0 +1,131 @@
+import type {
+  CanvasesCanvasNodeExecution,
+  CanvasesCanvasRun,
+  SuperplaneComponentsNode as ComponentsNode,
+} from "@/api-client";
+import type {
+  RunInspectorApprovalRecord,
+  RunInspectorNodeActions,
+  RunInspectorOutputSection,
+} from "./runNodeDetailModel";
+
+type ExecutionErrorSource = Pick<CanvasesCanvasNodeExecution, "result" | "resultReason" | "resultMessage">;
+
+export function buildTriggerOutputSections(run: CanvasesCanvasRun): RunInspectorOutputSection[] {
+  if (!hasObjectValue(run.rootEvent?.data)) return [];
+
+  return [
+    {
+      channel: run.rootEvent?.channel || "default",
+      value: run.rootEvent?.data,
+      sizeKb: formatJsonSizeKb(run.rootEvent?.data),
+    },
+  ];
+}
+
+export function buildOutputSections(outputs?: CanvasesCanvasNodeExecution["outputs"]): RunInspectorOutputSection[] {
+  if (!outputs || Object.keys(outputs).length === 0) return [];
+
+  return Object.entries(outputs).map(([channel, value]) => {
+    const displayValue = normalizeExecutionChannelOutput(value);
+
+    return {
+      channel,
+      value: displayValue,
+      sizeKb: formatJsonSizeKb(displayValue),
+    };
+  });
+}
+
+export function normalizeExecutionOutputsForDisplay(outputs?: CanvasesCanvasNodeExecution["outputs"]): unknown {
+  const outputSections = buildOutputSections(outputs);
+  if (outputSections.length === 0) return undefined;
+  if (outputSections.length === 1) return outputSections[0].value;
+
+  return Object.fromEntries(outputSections.map((section) => [section.channel, section.value]));
+}
+
+export function getExecutionErrorMessage(execution: ExecutionErrorSource): string | undefined {
+  if (execution.result !== "RESULT_FAILED" && execution.resultReason !== "RESULT_REASON_ERROR") {
+    return undefined;
+  }
+
+  return execution.resultMessage || execution.resultReason || "Execution failed";
+}
+
+export function buildNodeActions(
+  workflowNode: ComponentsNode | undefined,
+  execution: CanvasesCanvasNodeExecution | undefined,
+): RunInspectorNodeActions {
+  const isActive = execution?.state === "STATE_STARTED" || execution?.state === "STATE_PENDING";
+  const componentName = normalizeComponentName(workflowNode?.component);
+
+  return {
+    canStop: Boolean(execution?.id && isActive),
+    canPushThrough: Boolean(execution?.id && isActive && (componentName === "wait" || componentName === "timegate")),
+    approvalRecords: componentName.includes("approval") ? extractApprovalRecords(execution?.metadata) : [],
+  };
+}
+
+export function hasObjectValue(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && Object.keys(value).length > 0;
+}
+
+function normalizeExecutionChannelOutput(value: unknown): unknown {
+  if (!Array.isArray(value)) return value;
+  return value[0];
+}
+
+function formatJsonSizeKb(value: unknown): string {
+  const json = JSON.stringify(value ?? null);
+  const bytes = new Blob([json]).size;
+  return `${Math.max(bytes / 1024, 0.01).toFixed(2)} KB`;
+}
+
+function normalizeComponentName(componentName: string | undefined): string {
+  return (componentName || "").replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+function extractApprovalRecords(metadata: CanvasesCanvasNodeExecution["metadata"]): RunInspectorApprovalRecord[] {
+  const records = metadata?.records;
+  if (!Array.isArray(records)) return [];
+
+  return records.filter(isApprovalRecord).map((record) => ({
+    index: record.index,
+    state: typeof record.state === "string" ? record.state : undefined,
+    type: typeof record.type === "string" ? record.type : undefined,
+    user: isObjectRecord(record.user)
+      ? {
+          id: typeof record.user.id === "string" ? record.user.id : undefined,
+          email: typeof record.user.email === "string" ? record.user.email : undefined,
+          name: typeof record.user.name === "string" ? record.user.name : undefined,
+        }
+      : undefined,
+    roleRef: parseApprovalRecordRef(record.roleRef),
+    groupRef: parseApprovalRecordRef(record.groupRef),
+  }));
+}
+
+function parseApprovalRecordRef(value: unknown): { name?: string; displayName?: string } | undefined {
+  if (!isObjectRecord(value)) return undefined;
+
+  return {
+    name: typeof value.name === "string" ? value.name : undefined,
+    displayName: typeof value.displayName === "string" ? value.displayName : undefined,
+  };
+}
+
+function isApprovalRecord(value: unknown): value is {
+  index: number;
+  state?: unknown;
+  type?: unknown;
+  user?: unknown;
+  roleRef?: unknown;
+  groupRef?: unknown;
+} {
+  return isObjectRecord(value) && typeof value.index === "number";
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}

--- a/web_src/src/ui/Runs/runNodeDetailTabs.ts
+++ b/web_src/src/ui/Runs/runNodeDetailTabs.ts
@@ -1,0 +1,138 @@
+import type { CanvasesCanvasNodeExecution, CanvasesCanvasRun, SuperplaneComponentsNode } from "@/api-client";
+import { flattenObject } from "@/lib/utils";
+import { getExecutionDetails, getTriggerRenderer } from "@/pages/app/mappers";
+import { buildEventInfo } from "@/pages/app/utils";
+import { hasObjectValue, normalizeExecutionOutputsForDisplay } from "./runNodeDetailOutputs";
+import { workflowComponentName, type RunNodeDetailTabData } from "./runNodeDetailModel";
+
+export function buildExecutionTabData(
+  execution: CanvasesCanvasNodeExecution,
+  workflowNode: SuperplaneComponentsNode | undefined,
+  workflowNodes: SuperplaneComponentsNode[],
+): RunNodeDetailTabData {
+  const tabData: RunNodeDetailTabData = {
+    details: filterEmptyDetailEntries(
+      applyExecutionResultDetails(buildDefaultExecutionDetails(execution, workflowNode, workflowNodes), execution),
+    ),
+    payload: extractExecutionPayload(execution),
+  };
+
+  if (execution.configuration && Object.keys(execution.configuration).length > 0) {
+    tabData.configuration = execution.configuration;
+  }
+
+  return tabData;
+}
+
+export function buildTriggerTabData(
+  run: CanvasesCanvasRun,
+  workflowNode: SuperplaneComponentsNode | undefined,
+): RunNodeDetailTabData {
+  const rootEvent = run.rootEvent;
+  const mappedDetails = buildTriggerEventDetails(rootEvent, workflowNode);
+  const fallbackDetails = buildFallbackTriggerEventDetails(rootEvent);
+  const details = Object.keys(mappedDetails).length > 0 ? mappedDetails : fallbackDetails;
+
+  const tabData: RunNodeDetailTabData = {
+    details: Object.keys(details).length > 0 ? filterEmptyDetailEntries(details) : undefined,
+    payload: hasObjectValue(rootEvent?.data) ? rootEvent.data : undefined,
+  };
+
+  if (
+    workflowNode?.configuration &&
+    typeof workflowNode.configuration === "object" &&
+    Object.keys(workflowNode.configuration).length > 0
+  ) {
+    tabData.configuration = workflowNode.configuration;
+  }
+
+  return tabData;
+}
+
+export function isErrorValue(value: unknown): value is { __type: "error"; message: string } {
+  return !!value && typeof value === "object" && (value as { __type?: string }).__type === "error";
+}
+
+function extractExecutionPayload(execution: CanvasesCanvasNodeExecution): unknown {
+  if (!execution.outputs || Object.keys(execution.outputs).length === 0) {
+    return undefined;
+  }
+
+  const outputData = Object.values(execution.outputs).find((output) => Array.isArray(output) && output.length > 0) as
+    | unknown[]
+    | undefined;
+  if (outputData && outputData.length > 0) {
+    return outputData[0];
+  }
+
+  return execution.outputs;
+}
+
+function buildDefaultExecutionDetails(
+  execution: CanvasesCanvasNodeExecution,
+  workflowNode: SuperplaneComponentsNode | undefined,
+  workflowNodes: SuperplaneComponentsNode[],
+): Record<string, unknown> {
+  const componentName = typeof workflowNode?.component === "string" ? workflowNode.component : undefined;
+
+  if (componentName && workflowNode) {
+    const customDetails = getExecutionDetails(componentName, execution, workflowNode, workflowNodes);
+    if (customDetails && Object.keys(customDetails).length > 0) {
+      return { ...customDetails };
+    }
+  }
+
+  const displayOutputs = normalizeExecutionOutputsForDisplay(execution.outputs);
+  return { ...flattenObject((displayOutputs ?? execution.metadata) || {}) };
+}
+
+function applyExecutionResultDetails(
+  details: Record<string, unknown>,
+  execution: CanvasesCanvasNodeExecution,
+): Record<string, unknown> {
+  const next = { ...details };
+
+  if (
+    execution.resultMessage &&
+    (execution.resultReason === "RESULT_REASON_ERROR" || execution.result === "RESULT_FAILED") &&
+    !("Error" in next)
+  ) {
+    next.Error = {
+      __type: "error",
+      message: execution.resultMessage,
+    };
+  }
+
+  if (execution.result === "RESULT_CANCELLED" && !("Cancelled by" in next)) {
+    const cancelledBy = execution.cancelledBy;
+    next["Cancelled by"] = cancelledBy?.name || cancelledBy?.id || "Unknown";
+  }
+
+  return next;
+}
+
+function filterEmptyDetailEntries(details: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(details).filter(([, value]) => value !== undefined && value !== "" && value !== null),
+  );
+}
+
+function buildTriggerEventDetails(
+  rootEvent: CanvasesCanvasRun["rootEvent"],
+  workflowNode: SuperplaneComponentsNode | undefined,
+): Record<string, unknown> {
+  if (!rootEvent) return {};
+
+  const triggerRenderer = getTriggerRenderer(workflowComponentName(workflowNode));
+  return triggerRenderer.getRootEventValues({ event: buildEventInfo(rootEvent) });
+}
+
+function buildFallbackTriggerEventDetails(rootEvent: CanvasesCanvasRun["rootEvent"]): Record<string, unknown> {
+  const details: Record<string, unknown> = {};
+
+  if (rootEvent?.channel) details.Channel = rootEvent.channel;
+  if (rootEvent?.customName) details.Name = rootEvent.customName;
+  if (rootEvent?.createdAt) details["Triggered at"] = rootEvent.createdAt;
+
+  return details;
+}

--- a/web_src/src/ui/Runs/useRunInspectorActions.spec.tsx
+++ b/web_src/src/ui/Runs/useRunInspectorActions.spec.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import type { CanvasesCanvasRun } from "@/api-client";
+import type { RunInspectorNodeSection } from "./runNodeDetailModel";
+import { useRunInspectorActions } from "./useRunInspectorActions";
+
+const run: CanvasesCanvasRun = {
+  rootEvent: {
+    id: "root-event-1",
+    nodeId: "trigger-1",
+  },
+};
+
+function renderActions(sections: RunInspectorNodeSection[], executionsLoading = false) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return renderHook(
+    () =>
+      useRunInspectorActions({
+        canvasId: "canvas-1",
+        run,
+        sections,
+        executionsLoading,
+      }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    },
+  );
+}
+
+function actionSection(overrides: Partial<RunInspectorNodeSection> = {}): RunInspectorNodeSection {
+  return {
+    nodeId: "action-1",
+    nodeName: "Action 1",
+    isTrigger: false,
+    badge: null,
+    tabData: null,
+    upstreamSections: [],
+    outputSections: [],
+    actions: {
+      canStop: false,
+      canPushThrough: false,
+      approvalRecords: [],
+    },
+    configurationFields: [],
+    ...overrides,
+  };
+}
+
+describe("useRunInspectorActions", () => {
+  it("keeps Stop disabled when action sections only have lightweight execution refs", () => {
+    const { result } = renderActions([
+      actionSection({
+        executionRef: {
+          id: "execution-ref-1",
+          nodeId: "action-1",
+          state: "STATE_STARTED",
+        },
+      }),
+    ]);
+
+    expect(result.current.stopDisabled).toBe(true);
+  });
+
+  it("allows Stop for loaded action execution details so queued steps can be cancelled", () => {
+    const { result } = renderActions([
+      actionSection({
+        execution: {
+          id: "execution-1",
+          nodeId: "action-1",
+          state: "STATE_FINISHED",
+          result: "RESULT_PASSED",
+        },
+      }),
+    ]);
+
+    expect(result.current.stopDisabled).toBe(false);
+  });
+});

--- a/web_src/src/ui/Runs/useRunInspectorActions.ts
+++ b/web_src/src/ui/Runs/useRunInspectorActions.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 import {
   canvasesCancelExecution,
   canvasesDeleteNodeQueueItem,
+  canvasesInvokeNodeExecutionHook,
   canvasesListNodeQueueItems,
   canvasesReemitTriggerEvent,
   type CanvasesCanvasRun,
@@ -31,14 +32,63 @@ export function useRunInspectorActions({
         .map((execution) => execution!.id!),
     [sections],
   );
-  const hasActionSection = useMemo(() => sections.some((section) => !section.isTrigger), [sections]);
+  const hasLoadedActionSection = useMemo(
+    () => sections.some((section) => !section.isTrigger && section.execution),
+    [sections],
+  );
   const stoppableNodeIds = useMemo(() => [...new Set(sections.map((section) => section.nodeId))], [sections]);
 
   const refreshRunQueries = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ["canvases"] });
   }, [queryClient]);
 
-  const rerunMutation = useMutation({
+  const rerunMutation = useRerunMutation({ canvasId, run, refreshRunQueries });
+  const stopMutation = useStopMutation({
+    canvasId,
+    runningExecutionIds,
+    stoppableNodeIds,
+    rootEventId: run.rootEvent?.id,
+    refreshRunQueries,
+  });
+  const stopNodeMutation = useStopNodeMutation({ canvasId, refreshRunQueries });
+  const executionHookMutation = useExecutionHookMutation({ canvasId, refreshRunQueries });
+
+  return {
+    rerun: () => rerunMutation.mutate(),
+    rerunPending: rerunMutation.isPending,
+    stop: () => stopMutation.mutate(),
+    stopPending: stopMutation.isPending,
+    stopDisabled:
+      executionsLoading ||
+      stopMutation.isPending ||
+      (runningExecutionIds.length === 0 && (!run.rootEvent?.id || !hasLoadedActionSection)),
+    stopNode: (section: RunInspectorNodeSection) => {
+      if (!section.execution?.id) return;
+      stopNodeMutation.mutate(section.execution.id);
+    },
+    stopNodePending: stopNodeMutation.isPending,
+    invokeNodeHook: (
+      section: RunInspectorNodeSection,
+      hookName: string,
+      parameters?: Record<string, unknown> | null,
+    ) => {
+      if (!section.execution?.id) return;
+      executionHookMutation.mutate({ executionId: section.execution.id, hookName, parameters });
+    },
+    nodeHookPending: executionHookMutation.isPending,
+  };
+}
+
+function useRerunMutation({
+  canvasId,
+  run,
+  refreshRunQueries,
+}: {
+  canvasId: string;
+  run: CanvasesCanvasRun;
+  refreshRunQueries: () => Promise<void>;
+}) {
+  return useMutation({
     mutationFn: async () => {
       if (!run.rootEvent?.nodeId || !run.rootEvent?.id) {
         throw new Error("Run root event is missing");
@@ -63,13 +113,27 @@ export function useRunInspectorActions({
       showErrorToast("Failed to restart run");
     },
   });
+}
 
-  const stopMutation = useMutation({
+function useStopMutation({
+  canvasId,
+  runningExecutionIds,
+  stoppableNodeIds,
+  rootEventId,
+  refreshRunQueries,
+}: {
+  canvasId: string;
+  runningExecutionIds: string[];
+  stoppableNodeIds: string[];
+  rootEventId?: string;
+  refreshRunQueries: () => Promise<void>;
+}) {
+  return useMutation({
     mutationFn: async () => {
       const queuedItems = await listQueuedItemsForRun({
         canvasId,
         nodeIds: stoppableNodeIds,
-        rootEventId: run.rootEvent?.id,
+        rootEventId,
       });
 
       if (runningExecutionIds.length === 0 && queuedItems.length === 0) {
@@ -77,27 +141,8 @@ export function useRunInspectorActions({
       }
 
       await Promise.all([
-        ...runningExecutionIds.map((executionId) =>
-          canvasesCancelExecution(
-            withOrganizationHeader({
-              path: {
-                canvasId,
-                executionId,
-              },
-            }),
-          ),
-        ),
-        ...queuedItems.map((item) =>
-          canvasesDeleteNodeQueueItem(
-            withOrganizationHeader({
-              path: {
-                canvasId,
-                nodeId: item.nodeId,
-                itemId: item.itemId,
-              },
-            }),
-          ),
-        ),
+        ...runningExecutionIds.map((executionId) => cancelExecution(canvasId, executionId)),
+        ...queuedItems.map((item) => deleteQueuedItem(canvasId, item.nodeId, item.itemId)),
       ]);
     },
     onSuccess: async () => {
@@ -109,16 +154,107 @@ export function useRunInspectorActions({
       showErrorToast("Failed to stop run");
     },
   });
+}
 
-  return {
-    rerun: () => rerunMutation.mutate(),
-    rerunPending: rerunMutation.isPending,
-    stop: () => stopMutation.mutate(),
-    stopPending: stopMutation.isPending,
-    stopDisabled:
-      executionsLoading ||
-      stopMutation.isPending ||
-      (runningExecutionIds.length === 0 && (!run.rootEvent?.id || !hasActionSection)),
+function useStopNodeMutation({
+  canvasId,
+  refreshRunQueries,
+}: {
+  canvasId: string;
+  refreshRunQueries: () => Promise<void>;
+}) {
+  return useMutation({
+    mutationFn: (executionId: string) => cancelExecution(canvasId, executionId),
+    onSuccess: async () => {
+      await refreshRunQueries();
+      showSuccessToast("Step stopped");
+    },
+    onError: (error) => {
+      console.error("Failed to stop step", error);
+      showErrorToast("Failed to stop step");
+    },
+  });
+}
+
+function useExecutionHookMutation({
+  canvasId,
+  refreshRunQueries,
+}: {
+  canvasId: string;
+  refreshRunQueries: () => Promise<void>;
+}) {
+  return useMutation({
+    mutationFn: invokeExecutionHook(canvasId),
+    onSuccess: async (_data, variables) => {
+      await refreshRunQueries();
+      showSuccessToast(successMessageForHook(variables.hookName));
+    },
+    onError: (error, variables) => {
+      console.error(`Failed to invoke ${variables.hookName} hook`, error);
+      showErrorToast(errorMessageForHook(variables.hookName));
+    },
+  });
+}
+
+function successMessageForHook(hookName: string): string {
+  if (hookName === "approve") return "Approval submitted";
+  if (hookName === "reject") return "Rejection submitted";
+  if (hookName === "pushThrough") return "Step pushed through";
+  return "Action submitted";
+}
+
+function errorMessageForHook(hookName: string): string {
+  if (hookName === "approve") return "Failed to approve";
+  if (hookName === "reject") return "Failed to reject";
+  if (hookName === "pushThrough") return "Failed to push through";
+  return "Failed to run action";
+}
+
+async function cancelExecution(canvasId: string, executionId: string) {
+  await canvasesCancelExecution(
+    withOrganizationHeader({
+      path: {
+        canvasId,
+        executionId,
+      },
+    }),
+  );
+}
+
+async function deleteQueuedItem(canvasId: string, nodeId: string, itemId: string) {
+  await canvasesDeleteNodeQueueItem(
+    withOrganizationHeader({
+      path: {
+        canvasId,
+        nodeId,
+        itemId,
+      },
+    }),
+  );
+}
+
+function invokeExecutionHook(canvasId: string) {
+  return async ({
+    executionId,
+    hookName,
+    parameters,
+  }: {
+    executionId: string;
+    hookName: string;
+    parameters?: Record<string, unknown> | null;
+  }) => {
+    await canvasesInvokeNodeExecutionHook(
+      withOrganizationHeader({
+        path: {
+          canvasId,
+          executionId,
+          hookName,
+        },
+        body: {
+          parameters: parameters ?? undefined,
+        },
+      }),
+    );
   };
 }
 

--- a/web_src/src/ui/configurationFieldRenderer/ConfigurationFieldInput.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ConfigurationFieldInput.tsx
@@ -1,0 +1,287 @@
+import type React from "react";
+import type { AuthorizationDomainType } from "@/api-client";
+import { AnyPredicateListFieldRenderer } from "./AnyPredicateListFieldRenderer";
+import { BooleanFieldRenderer } from "./BooleanFieldRenderer";
+import { CronFieldRenderer } from "./CronFieldRenderer";
+import { DateFieldRenderer } from "./DateFieldRenderer";
+import { DateTimeFieldRenderer } from "./DateTimeFieldRenderer";
+import { DayInYearFieldRenderer } from "./DayInYearFieldRenderer";
+import { DaysOfWeekFieldRenderer } from "./DaysOfWeekFieldRenderer";
+import { ExpressionFieldRenderer } from "./ExpressionFieldRenderer";
+import { GitRefFieldRenderer } from "./GitRefFieldRenderer";
+import { GroupFieldRenderer } from "./GroupFieldRenderer";
+import { IntegrationResourceFieldRenderer } from "./IntegrationResourceFieldRenderer";
+import { ListFieldRenderer } from "./ListFieldRenderer";
+import { MultiSelectFieldRenderer } from "./MultiSelectFieldRenderer";
+import { NumberFieldRenderer } from "./NumberFieldRenderer";
+import { ObjectFieldRenderer } from "./ObjectFieldRenderer";
+import { RepositoryFileFieldRenderer } from "./RepositoryFileFieldRenderer";
+import { RoleFieldRenderer } from "./RoleFieldRenderer";
+import { SecretKeyFieldRenderer, type SecretKeyRefValue } from "./SecretKeyFieldRenderer";
+import { SelectFieldRenderer } from "./SelectFieldRenderer";
+import { StringFieldRenderer } from "./StringFieldRenderer";
+import { TextFieldRenderer } from "./TextFieldRenderer";
+import { TimeFieldRenderer } from "./TimeFieldRenderer";
+import { TimeRangeFieldRenderer } from "./TimeRangeFieldRenderer";
+import { TimezoneFieldRenderer } from "./TimezoneFieldRenderer";
+import type { FieldRendererProps, ValidationError } from "./types";
+import { UrlFieldRenderer } from "./UrlFieldRenderer";
+import { UserFieldRenderer } from "./UserFieldRenderer";
+import { XMLFieldRenderer } from "./XMLFieldRenderer";
+
+type ConfigurationFieldInputProps = {
+  commonProps: FieldRendererProps;
+  domainId?: string;
+  domainType?: AuthorizationDomainType;
+  integrationId?: string;
+  organizationId?: string;
+  allowExpressions: boolean;
+  autocompleteExampleObj?: Record<string, unknown> | null;
+  isRequired: boolean;
+  validationErrors?: ValidationError[] | Set<string>;
+  fieldPath?: string;
+  labelRightRef: React.RefObject<HTMLDivElement | null>;
+  labelRightReady: boolean;
+};
+
+export function ConfigurationFieldInput({
+  commonProps,
+  domainId,
+  domainType,
+  integrationId,
+  organizationId,
+  allowExpressions,
+  autocompleteExampleObj,
+  isRequired,
+  validationErrors,
+  fieldPath,
+  labelRightRef,
+  labelRightReady,
+}: ConfigurationFieldInputProps) {
+  const { field, value, onChange, allValues } = commonProps;
+
+  if (field.type === "user" || field.type === "role" || field.type === "group") {
+    return renderPrincipalField({ commonProps, domainId });
+  }
+
+  if (field.type === "integration-resource") {
+    return (
+      <IntegrationResourceFieldRenderer
+        field={field}
+        value={value as string | string[] | undefined}
+        onChange={onChange}
+        allValues={allValues}
+        organizationId={organizationId}
+        integrationId={integrationId}
+        allowExpressions={allowExpressions}
+        autocompleteExampleObj={autocompleteExampleObj}
+        labelRightRef={allowExpressions ? labelRightRef : undefined}
+        labelRightReady={allowExpressions ? labelRightReady : false}
+      />
+    );
+  }
+
+  if (field.type === "secret-key") {
+    if (!domainId && !organizationId) {
+      return (
+        <div className="text-sm text-red-500 dark:text-red-400">
+          Secret key field requires domain or organization context.
+        </div>
+      );
+    }
+
+    return (
+      <SecretKeyFieldRenderer
+        field={field}
+        isRequired={isRequired}
+        value={value as SecretKeyRefValue}
+        onChange={(nextValue) => onChange(nextValue)}
+        organizationId={organizationId ?? domainId}
+      />
+    );
+  }
+
+  if (field.type === "list") {
+    return (
+      <ListFieldRenderer
+        {...commonProps}
+        domainId={domainId}
+        domainType={domainType}
+        validationErrors={validationErrors}
+        fieldPath={fieldPath || field.name}
+      />
+    );
+  }
+
+  if (field.type === "object") {
+    return <ObjectFieldRenderer {...commonProps} domainId={domainId} domainType={domainType} />;
+  }
+
+  return renderStandardField({ commonProps });
+}
+
+function renderPrincipalField({ commonProps, domainId }: { commonProps: FieldRendererProps; domainId?: string }) {
+  const { field, value, onChange, allValues, readOnly } = commonProps;
+
+  if (!domainId) {
+    return (
+      <div className="text-sm text-red-500 dark:text-red-400">
+        {principalFieldLabel(field.type)} field requires domainId prop
+      </div>
+    );
+  }
+
+  if (field.type === "user") {
+    return (
+      <UserFieldRenderer
+        field={field}
+        value={value as string}
+        onChange={onChange}
+        domainId={domainId}
+        allValues={allValues}
+        readOnly={readOnly}
+      />
+    );
+  }
+
+  if (field.type === "role") {
+    return (
+      <RoleFieldRenderer
+        field={field}
+        value={value as string}
+        onChange={onChange}
+        domainId={domainId}
+        allValues={allValues}
+        readOnly={readOnly}
+      />
+    );
+  }
+
+  return (
+    <GroupFieldRenderer
+      {...commonProps}
+      field={field}
+      value={value as string}
+      onChange={onChange}
+      domainId={domainId}
+      allValues={allValues}
+      readOnly={readOnly}
+    />
+  );
+}
+
+function renderStandardField({ commonProps }: { commonProps: FieldRendererProps }) {
+  const { field } = commonProps;
+
+  if (isTextField(field.type)) {
+    return renderTextField(commonProps);
+  }
+
+  if (isDateTimeField(field.type)) {
+    return renderDateTimeField(commonProps);
+  }
+
+  if (isReferenceField(field.type)) {
+    return renderReferenceField(commonProps);
+  }
+
+  return renderFallbackField(commonProps);
+}
+
+function renderTextField(commonProps: FieldRendererProps) {
+  switch (commonProps.field.type) {
+    case "string":
+      return <StringFieldRenderer {...commonProps} />;
+    case "expression":
+      return <ExpressionFieldRenderer {...commonProps} />;
+    case "text":
+      return <TextFieldRenderer {...commonProps} />;
+    case "xml":
+      return <XMLFieldRenderer {...commonProps} />;
+    default:
+      return <StringFieldRenderer {...commonProps} />;
+  }
+}
+
+function renderDateTimeField(commonProps: FieldRendererProps) {
+  switch (commonProps.field.type) {
+    case "date":
+      return <DateFieldRenderer {...commonProps} />;
+    case "datetime":
+      return <DateTimeFieldRenderer {...commonProps} />;
+    case "time":
+      return <TimeFieldRenderer {...commonProps} />;
+    case "time-range":
+      return <TimeRangeFieldRenderer {...commonProps} />;
+    case "day-in-year":
+      return <DayInYearFieldRenderer {...commonProps} />;
+    case "cron":
+      return <CronFieldRenderer {...commonProps} />;
+    default:
+      return <StringFieldRenderer {...commonProps} />;
+  }
+}
+
+function renderReferenceField(commonProps: FieldRendererProps) {
+  switch (commonProps.field.type) {
+    case "git-ref":
+      return <GitRefFieldRenderer {...commonProps} />;
+    case "repository-file":
+      return <RepositoryFileFieldRenderer {...commonProps} />;
+    case "timezone":
+      return <TimezoneFieldRenderer {...commonProps} />;
+    default:
+      return <AnyPredicateListFieldRenderer {...commonProps} />;
+  }
+}
+
+function renderFallbackField(commonProps: FieldRendererProps) {
+  const { field } = commonProps;
+
+  switch (field.type) {
+    case "number":
+      return <NumberFieldRenderer {...commonProps} />;
+    case "boolean":
+      return <BooleanFieldRenderer {...commonProps} />;
+    case "select":
+      return <SelectFieldRenderer {...commonProps} />;
+    case "multi-select":
+      return <MultiSelectFieldRenderer {...commonProps} />;
+    case "days-of-week":
+      return <DaysOfWeekFieldRenderer {...commonProps} />;
+    case "url":
+      return <UrlFieldRenderer {...commonProps} />;
+    default:
+      return <StringFieldRenderer {...commonProps} />;
+  }
+}
+
+function isTextField(fieldType: string | undefined): boolean {
+  return fieldType === "string" || fieldType === "expression" || fieldType === "text" || fieldType === "xml";
+}
+
+function isDateTimeField(fieldType: string | undefined): boolean {
+  return (
+    fieldType === "date" ||
+    fieldType === "datetime" ||
+    fieldType === "time" ||
+    fieldType === "time-range" ||
+    fieldType === "day-in-year" ||
+    fieldType === "cron"
+  );
+}
+
+function isReferenceField(fieldType: string | undefined): boolean {
+  return (
+    fieldType === "git-ref" ||
+    fieldType === "repository-file" ||
+    fieldType === "timezone" ||
+    fieldType === "any-predicate-list"
+  );
+}
+
+function principalFieldLabel(fieldType: string | undefined): string {
+  if (fieldType === "user") return "User";
+  if (fieldType === "role") return "Role";
+  return "Group";
+}

--- a/web_src/src/ui/configurationFieldRenderer/GroupFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/GroupFieldRenderer.tsx
@@ -8,9 +8,16 @@ interface GroupFieldRendererProps {
   onChange: (value: string | undefined) => void;
   domainId: string;
   allValues?: Record<string, unknown>;
+  readOnly?: boolean;
 }
 
-export const GroupFieldRenderer = ({ value, onChange, domainId, allValues }: GroupFieldRendererProps) => {
+export const GroupFieldRenderer = ({
+  value,
+  onChange,
+  domainId,
+  allValues,
+  readOnly = false,
+}: GroupFieldRendererProps) => {
   // Fetch groups from the organization
   const { data: groups, isLoading, error } = useOrganizationGroups(domainId);
   const approvalContext = getApprovalListContext(allValues);
@@ -56,7 +63,7 @@ export const GroupFieldRenderer = ({ value, onChange, domainId, allValues }: Gro
   }
 
   return (
-    <Select value={value ?? ""} onValueChange={(val) => onChange(val || undefined)}>
+    <Select value={value ?? ""} onValueChange={(val) => onChange(val || undefined)} disabled={readOnly}>
       <SelectTrigger className="w-full">
         <SelectValue placeholder="Select group" />
       </SelectTrigger>

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -47,12 +47,13 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
   fieldPath = field.name || "",
   autocompleteExampleObj,
   allowExpressions = false,
+  readOnly = false,
 }) => {
   const listOptions = field.typeOptions?.list;
   const itemDefinition = listOptions?.itemDefinition;
   const maxItems = listOptions?.maxItems;
   const useAccordion = listOptions?.accordion === true;
-  const allowReorder = listOptions?.reorderable === true;
+  const allowReorder = listOptions?.reorderable === true && !readOnly;
   const items = Array.isArray(value)
     ? itemDefinition?.type === "day-in-year"
       ? value.filter((item) => typeof item === "string" && item.trim().length > 0)
@@ -187,6 +188,7 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
           organizationId={organizationId}
           hasError={hasNestedError}
           autocompleteExampleObj={autocompleteExampleObj}
+          readOnly={readOnly}
         />
       );
     });
@@ -221,6 +223,8 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
       <Input
         type={itemDefinition?.type === "number" ? "number" : "text"}
         value={(item as string | number) ?? ""}
+        readOnly={readOnly}
+        disabled={readOnly}
         onChange={(e) => {
           const val =
             itemDefinition?.type === "number"
@@ -320,16 +324,18 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
                       {renderListItemBody(item, index)}
                     </AccordionContent>
                   </div>
-                  {renderRemoveButton(index, "mt-1 shrink-0")}
+                  {readOnly ? null : renderRemoveButton(index, "mt-1 shrink-0")}
                 </div>
               </AccordionItem>
             );
           })}
         </Accordion>
-        <Button variant="outline" size="sm" onClick={addItem} className="mt-3 w-full" disabled={!canAddMore}>
-          <Plus />
-          Add {itemLabel}
-        </Button>
+        {readOnly ? null : (
+          <Button variant="outline" size="sm" onClick={addItem} className="mt-3 w-full" disabled={!canAddMore}>
+            <Plus />
+            Add {itemLabel}
+          </Button>
+        )}
       </div>
     );
   }
@@ -356,14 +362,16 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
                 renderListItemBody(item, index)
               )}
             </div>
-            {renderRemoveButton(index, "mt-1")}
+            {readOnly ? null : renderRemoveButton(index, "mt-1")}
           </div>
         );
       })}
-      <Button variant="outline" size="sm" onClick={addItem} className="mt-3 w-full" disabled={!canAddMore}>
-        <Plus />
-        Add {itemLabel}
-      </Button>
+      {readOnly ? null : (
+        <Button variant="outline" size="sm" onClick={addItem} className="mt-3 w-full" disabled={!canAddMore}>
+          <Plus />
+          Add {itemLabel}
+        </Button>
+      )}
     </div>
   );
 };

--- a/web_src/src/ui/configurationFieldRenderer/MultiSelectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/MultiSelectFieldRenderer.tsx
@@ -38,7 +38,12 @@ function toCheckboxOptionId(fieldName: string, optionValue: string): string {
   return `${safeFieldName}-${safeOptionValue}`;
 }
 
-export const MultiSelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange }) => {
+export const MultiSelectFieldRenderer: React.FC<FieldRendererProps> = ({
+  field,
+  value,
+  onChange,
+  readOnly = false,
+}) => {
   const useCheckboxes = field.typeOptions?.multiSelect?.useCheckboxes === true;
 
   const comboboxOptions: SelectOption[] = useMemo(() => {
@@ -64,10 +69,12 @@ export const MultiSelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, 
 
   // Set initial value on first render if no value is present but there's a default
   useEffect(() => {
+    if (readOnly) return;
+
     if ((value === undefined || value === null) && defaultValues.length > 0) {
       onChange(defaultValues);
     }
-  }, [value, defaultValues, onChange]);
+  }, [readOnly, value, defaultValues, onChange]);
 
   const currentValue = useMemo(() => {
     if (value === undefined || value === null) {
@@ -110,10 +117,14 @@ export const MultiSelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, 
                   id={optionId}
                   checked={selectedValues.has(option.value)}
                   onCheckedChange={(checked) => handleCheckboxChange(option.value, checked === true)}
+                  disabled={readOnly}
                   className="mt-0.5"
                 />
                 <div className="flex flex-col gap-1 py-0.5">
-                  <Label htmlFor={optionId} className="cursor-pointer font-medium leading-none">
+                  <Label
+                    htmlFor={optionId}
+                    className={readOnly ? "font-medium leading-none" : "cursor-pointer font-medium leading-none"}
+                  >
                     {option.label}
                   </Label>
                   {option.description && (
@@ -134,8 +145,9 @@ export const MultiSelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, 
       displayValue={(option) => option.label}
       placeholder={`Select ${field.label || field.name}...`}
       value={selectedOptions}
-      onChange={handleComboboxChange}
+      onChange={readOnly ? undefined : handleComboboxChange}
       showButton={false}
+      disabled={readOnly}
     >
       {(option) => <MultiComboboxLabel>{option.label}</MultiComboboxLabel>}
     </MultiCombobox>

--- a/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
@@ -21,6 +21,7 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
   organizationId,
   autocompleteExampleObj,
   allowExpressions = false,
+  readOnly = false,
 }) => {
   const [jsonError, setJsonError] = React.useState<string | null>(null);
   const hasInitialized = React.useRef(false);
@@ -76,6 +77,8 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
   const hasPushedSchemaDefaults = React.useRef(false);
 
   React.useEffect(() => {
+    if (readOnly) return;
+
     if (value !== undefined && value !== null) {
       hasInitialized.current = true;
     }
@@ -87,9 +90,10 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
       setEditorValue(serializeValueForEditor(defaultValue));
       setJsonError(null);
     }
-  }, [value, field.defaultValue, onChange, coerceDefaultValue, serializeValueForEditor]);
+  }, [readOnly, value, field.defaultValue, onChange, coerceDefaultValue, serializeValueForEditor]);
 
   React.useEffect(() => {
+    if (readOnly) return;
     if (!hasSchema) return;
     if (hasPushedSchemaDefaults.current) return;
     const isEmpty =
@@ -99,7 +103,7 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
     if (!isEmpty || Object.keys(schemaDefaults).length === 0) return;
     hasPushedSchemaDefaults.current = true;
     onChange(schemaDefaults);
-  }, [hasSchema, value, schemaDefaults, onChange]);
+  }, [readOnly, hasSchema, value, schemaDefaults, onChange]);
 
   const copyToClipboard = () => {
     navigator.clipboard.writeText(editorValue);
@@ -112,6 +116,8 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
     const handleEditorChange = (newValue: string | undefined) => {
       const valueToUse = newValue ?? "";
       setEditorValue(valueToUse);
+      if (readOnly) return;
+
       const trimmedValue = valueToUse.trim();
       if (trimmedValue.length === 0) {
         onChange(undefined);
@@ -158,6 +164,8 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
       scrollBeyondLastLine: false,
       renderWhitespace: "boundary" as const,
       smoothScrolling: true,
+      readOnly,
+      domReadOnly: readOnly,
       cursorBlinking: "smooth" as const,
       contextmenu: true,
       selectOnLineNumbers: true,
@@ -278,6 +286,7 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
           field={schemaField}
           value={objValue[schemaField.name!]}
           onChange={(val) => {
+            if (readOnly) return;
             const newValue: Record<string, unknown> = { ...objValue, [schemaField.name!]: val };
             onChange(newValue);
           }}
@@ -287,6 +296,7 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
           integrationId={integrationId}
           organizationId={organizationId}
           autocompleteExampleObj={autocompleteExampleObj}
+          readOnly={readOnly}
         />
       ))}
     </div>

--- a/web_src/src/ui/configurationFieldRenderer/ReadonlyFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ReadonlyFieldRenderer.tsx
@@ -1,0 +1,120 @@
+import type { ConfigurationField, ConfigurationSelectOption } from "@/api-client";
+
+export function ReadonlyConfigurationField({
+  field,
+  label,
+  description,
+  value,
+  isTogglable,
+  isEnabled,
+}: {
+  field: ConfigurationField;
+  label?: string;
+  description?: string;
+  value: unknown;
+  isTogglable: boolean;
+  isEnabled: boolean;
+}) {
+  if (isTogglable && !isEnabled) {
+    return (
+      <div className="space-y-2 opacity-70">
+        <ReadonlyFieldLabel label={label} />
+        <ReadonlyPrimitiveValue value="Disabled" />
+      </div>
+    );
+  }
+
+  if (field.type === "boolean") {
+    return <ReadonlyBooleanField label={label} value={value === true} description={description} />;
+  }
+
+  return (
+    <div className="space-y-2">
+      <ReadonlyFieldLabel label={label} />
+      <ReadonlyValue field={field} value={value} />
+      {description ? <p className="text-xs leading-normal text-gray-500 dark:text-gray-400">{description}</p> : null}
+    </div>
+  );
+}
+
+function ReadonlyBooleanField({ label, value, description }: { label?: string; value: boolean; description?: string }) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-3">
+        <span
+          className={
+            value
+              ? "relative inline-flex h-5 w-9 rounded-full bg-blue-500"
+              : "relative inline-flex h-5 w-9 rounded-full bg-slate-200 dark:bg-gray-700"
+          }
+          aria-hidden="true"
+        >
+          <span
+            className={
+              value
+                ? "absolute right-0.5 top-0.5 h-4 w-4 rounded-full bg-white"
+                : "absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white"
+            }
+          />
+        </span>
+        <ReadonlyFieldLabel label={label} />
+      </div>
+      {description ? <p className="text-xs leading-normal text-gray-500 dark:text-gray-400">{description}</p> : null}
+    </div>
+  );
+}
+
+function ReadonlyFieldLabel({ label }: { label?: string }) {
+  return <div className="text-sm font-medium text-slate-800 dark:text-gray-100">{label}</div>;
+}
+
+function ReadonlyValue({ field, value }: { field: ConfigurationField; value: unknown }) {
+  const displayValue = formatReadonlyValue(field, value);
+
+  if (isStructuredReadonlyValue(value)) {
+    return (
+      <pre className="max-h-56 overflow-auto rounded-md border border-slate-200 bg-white p-2 text-xs text-slate-900 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100">
+        {displayValue}
+      </pre>
+    );
+  }
+
+  return <ReadonlyPrimitiveValue value={displayValue} />;
+}
+
+function ReadonlyPrimitiveValue({ value }: { value: string }) {
+  return (
+    <div className="min-h-9 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100">
+      {value}
+    </div>
+  );
+}
+
+function formatReadonlyValue(field: ConfigurationField, value: unknown): string {
+  if (field.type === "select" && typeof value === "string") {
+    return findOptionLabel(field.typeOptions?.select?.options, value);
+  }
+
+  if (field.type === "multi-select" || field.type === "days-of-week") {
+    const values = Array.isArray(value) ? value : [];
+    return values.map((item) => findOptionLabel(field.typeOptions?.multiSelect?.options, String(item))).join(", ");
+  }
+
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+function findOptionLabel(options: ConfigurationSelectOption[] | undefined, value: string): string {
+  return options?.find((option) => option.value === value)?.label || value;
+}
+
+function isStructuredReadonlyValue(value: unknown): boolean {
+  return value !== null && typeof value === "object";
+}

--- a/web_src/src/ui/configurationFieldRenderer/RoleFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/RoleFieldRenderer.tsx
@@ -8,9 +8,16 @@ interface RoleFieldRendererProps {
   onChange: (value: string | undefined) => void;
   domainId: string;
   allValues?: Record<string, unknown>;
+  readOnly?: boolean;
 }
 
-export const RoleFieldRenderer = ({ value, onChange, domainId, allValues }: RoleFieldRendererProps) => {
+export const RoleFieldRenderer = ({
+  value,
+  onChange,
+  domainId,
+  allValues,
+  readOnly = false,
+}: RoleFieldRendererProps) => {
   // Fetch roles from the organization
   const { data: roles, isLoading, error } = useOrganizationRoles(domainId);
   const approvalContext = getApprovalListContext(allValues);
@@ -56,7 +63,7 @@ export const RoleFieldRenderer = ({ value, onChange, domainId, allValues }: Role
   }
 
   return (
-    <Select value={value ?? ""} onValueChange={(val) => onChange(val || undefined)}>
+    <Select value={value ?? ""} onValueChange={(val) => onChange(val || undefined)} disabled={readOnly}>
       <SelectTrigger className="w-full">
         <SelectValue placeholder="Select role" />
       </SelectTrigger>

--- a/web_src/src/ui/configurationFieldRenderer/SelectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/SelectFieldRenderer.tsx
@@ -3,11 +3,13 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import type { FieldRendererProps } from "./types";
 import { toTestId } from "@/lib/testID";
 
-export const SelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange }) => {
+export const SelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange, readOnly = false }) => {
   const selectOptions = field.typeOptions?.select?.options ?? [];
   const hasSetDefault = useRef(false);
 
   useEffect(() => {
+    if (readOnly) return;
+
     if (!hasSetDefault.current && (value === undefined || value === null) && field.defaultValue !== undefined) {
       const defaultVal = field.defaultValue as string;
       if (defaultVal && defaultVal !== "") {
@@ -15,7 +17,7 @@ export const SelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, value
         hasSetDefault.current = true;
       }
     }
-  }, [value, field.defaultValue, onChange]);
+  }, [readOnly, value, field.defaultValue, onChange]);
 
   const testId = field.name ? toTestId(`field-${field.name}-select`) : undefined;
 
@@ -23,6 +25,7 @@ export const SelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, value
     <Select
       value={(value as string) ?? (field.defaultValue as string) ?? ""}
       onValueChange={(val) => onChange(val || undefined)}
+      disabled={readOnly}
     >
       <SelectTrigger className="w-full" data-testid={testId}>
         <SelectValue placeholder={`Select ${field.label || field.name}`} />

--- a/web_src/src/ui/configurationFieldRenderer/UserFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/UserFieldRenderer.tsx
@@ -8,9 +8,16 @@ interface UserFieldRendererProps {
   onChange: (value: string | undefined) => void;
   domainId: string;
   allValues?: Record<string, unknown>;
+  readOnly?: boolean;
 }
 
-export const UserFieldRenderer = ({ value, onChange, domainId, allValues }: UserFieldRendererProps) => {
+export const UserFieldRenderer = ({
+  value,
+  onChange,
+  domainId,
+  allValues,
+  readOnly = false,
+}: UserFieldRendererProps) => {
   // Fetch users from the organization
   const { data: users, isLoading, error } = useOrganizationUsers(domainId);
   const approvalContext = getApprovalListContext(allValues);
@@ -56,7 +63,7 @@ export const UserFieldRenderer = ({ value, onChange, domainId, allValues }: User
   }
 
   return (
-    <Select value={value ?? ""} onValueChange={(val) => onChange(val || undefined)}>
+    <Select value={value ?? ""} onValueChange={(val) => onChange(val || undefined)} disabled={readOnly}>
       <SelectTrigger className="w-full">
         <SelectValue placeholder="Select user" />
       </SelectTrigger>

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -2,37 +2,13 @@ import React from "react";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/ui/switch";
 import type { FieldRendererProps, ValidationError } from "./types";
-import { StringFieldRenderer } from "./StringFieldRenderer";
-import { ExpressionFieldRenderer } from "./ExpressionFieldRenderer";
-import { TextFieldRenderer } from "./TextFieldRenderer";
-import { XMLFieldRenderer } from "./XMLFieldRenderer";
-import { NumberFieldRenderer } from "./NumberFieldRenderer";
 import { BooleanFieldRenderer } from "./BooleanFieldRenderer";
-import { SelectFieldRenderer } from "./SelectFieldRenderer";
-import { MultiSelectFieldRenderer } from "./MultiSelectFieldRenderer";
-import { DateFieldRenderer } from "./DateFieldRenderer";
-import { DateTimeFieldRenderer } from "./DateTimeFieldRenderer";
-import { UrlFieldRenderer } from "./UrlFieldRenderer";
-import { ListFieldRenderer } from "./ListFieldRenderer";
-import { ObjectFieldRenderer } from "./ObjectFieldRenderer";
-import { IntegrationResourceFieldRenderer } from "./IntegrationResourceFieldRenderer";
-import { TimeFieldRenderer } from "./TimeFieldRenderer";
-import { DayInYearFieldRenderer } from "./DayInYearFieldRenderer";
-import { CronFieldRenderer } from "./CronFieldRenderer";
-import { UserFieldRenderer } from "./UserFieldRenderer";
-import { RoleFieldRenderer } from "./RoleFieldRenderer";
-import { GroupFieldRenderer } from "./GroupFieldRenderer";
-import { GitRefFieldRenderer } from "./GitRefFieldRenderer";
-import { RepositoryFileFieldRenderer } from "./RepositoryFileFieldRenderer";
-import { TimezoneFieldRenderer } from "./TimezoneFieldRenderer";
-import { SecretKeyFieldRenderer, type SecretKeyRefValue } from "./SecretKeyFieldRenderer";
-import { AnyPredicateListFieldRenderer } from "./AnyPredicateListFieldRenderer";
-import { DaysOfWeekFieldRenderer } from "./DaysOfWeekFieldRenderer";
-import { TimeRangeFieldRenderer } from "./TimeRangeFieldRenderer";
 import { isFieldVisible, isFieldRequired, parseDefaultValues, validateFieldForSubmission } from "../../lib/components";
 import type { AuthorizationDomainType } from "@/api-client";
 import { buildTemplateParametersAutocompleteObject } from "./templateParametersAutocomplete";
 import { getRunTitlePresentation, RUN_TITLE_EXCLUDED_SUGGESTIONS } from "./runTitlePresentation";
+import { ReadonlyConfigurationField } from "./ReadonlyFieldRenderer";
+import { ConfigurationFieldInput } from "./ConfigurationFieldInput";
 
 const REQUIRED_FIELD_BADGE_CLASS =
   "ml-2 inline-flex items-center rounded border border-orange-300 px-1 py-0.5 text-[10px] uppercase tracking-wide leading-none text-orange-500 bg-orange-50 dark:border-orange-400/50 dark:bg-orange-950/30 dark:text-orange-300";
@@ -140,6 +116,7 @@ export const ConfigurationFieldRenderer = ({
   enableRealtimeValidation = false,
   autocompleteExampleObj,
   allowExpressions = false,
+  readOnly = false,
 }: ConfigurationFieldRendererProps) => {
   const isTogglable = field.togglable === true;
   const isEnabled = isTogglable ? value !== null && value !== undefined : true;
@@ -302,168 +279,40 @@ export const ConfigurationFieldRenderer = ({
     integrationId,
     organizationId,
     allowExpressions: fieldAllowsExpressions,
+    readOnly,
     excludedSuggestions: runTitlePresentation ? RUN_TITLE_EXCLUDED_SUGGESTIONS : undefined,
     valuePreviewLabel: runTitlePresentation?.previewLabel,
   };
 
-  const renderField = () => {
-    switch (field.type) {
-      case "string":
-        return <StringFieldRenderer {...commonProps} />;
+  if (readOnly && !shouldRenderFieldForReadOnly(field)) {
+    return (
+      <ReadonlyConfigurationField
+        field={field}
+        label={fieldLabel}
+        description={fieldDescription}
+        value={value}
+        isTogglable={isTogglable}
+        isEnabled={isEnabled}
+      />
+    );
+  }
 
-      case "expression":
-        return <ExpressionFieldRenderer {...commonProps} />;
-
-      case "text":
-        return <TextFieldRenderer {...commonProps} />;
-
-      case "xml":
-        return <XMLFieldRenderer {...commonProps} />;
-
-      case "number":
-        return <NumberFieldRenderer {...commonProps} />;
-
-      case "boolean":
-        return <BooleanFieldRenderer {...commonProps} />;
-
-      case "select":
-        return <SelectFieldRenderer {...commonProps} />;
-
-      case "multi-select":
-        return <MultiSelectFieldRenderer {...commonProps} />;
-
-      case "days-of-week":
-        return <DaysOfWeekFieldRenderer {...commonProps} />;
-
-      case "date":
-        return <DateFieldRenderer {...commonProps} />;
-
-      case "datetime":
-        return <DateTimeFieldRenderer {...commonProps} />;
-
-      case "url":
-        return <UrlFieldRenderer {...commonProps} />;
-
-      case "time":
-        return <TimeFieldRenderer {...commonProps} />;
-
-      case "time-range":
-        return <TimeRangeFieldRenderer {...commonProps} />;
-
-      case "day-in-year":
-        return <DayInYearFieldRenderer {...commonProps} />;
-
-      case "cron":
-        return <CronFieldRenderer {...commonProps} />;
-
-      case "integration-resource":
-        return (
-          <IntegrationResourceFieldRenderer
-            field={field}
-            value={value as string | string[] | undefined}
-            onChange={onChange}
-            allValues={allValues}
-            organizationId={organizationId}
-            integrationId={integrationId}
-            allowExpressions={allowExpressions}
-            autocompleteExampleObj={autocompleteExampleObj}
-            labelRightRef={allowExpressions ? labelRightRef : undefined}
-            labelRightReady={allowExpressions ? labelRightReady : false}
-          />
-        );
-
-      case "git-ref":
-        return <GitRefFieldRenderer {...commonProps} />;
-
-      case "repository-file":
-        return <RepositoryFileFieldRenderer {...commonProps} />;
-
-      case "user":
-        if (!domainId) {
-          return <div className="text-sm text-red-500 dark:text-red-400">User field requires domainId prop</div>;
-        }
-        return (
-          <UserFieldRenderer
-            field={field}
-            value={value as string}
-            onChange={onChange}
-            domainId={domainId}
-            allValues={allValues}
-          />
-        );
-
-      case "role":
-        if (!domainId) {
-          return <div className="text-sm text-red-500 dark:text-red-400">Role field requires domainId prop</div>;
-        }
-        return (
-          <RoleFieldRenderer
-            field={field}
-            value={value as string}
-            onChange={onChange}
-            domainId={domainId}
-            allValues={allValues}
-          />
-        );
-
-      case "group":
-        if (!domainId) {
-          return <div className="text-sm text-red-500 dark:text-red-400">Group field requires domainId prop</div>;
-        }
-        return (
-          <GroupFieldRenderer
-            {...commonProps}
-            field={field}
-            value={value as string}
-            onChange={onChange}
-            domainId={domainId}
-            allValues={allValues}
-          />
-        );
-
-      case "list":
-        return (
-          <ListFieldRenderer
-            {...commonProps}
-            domainId={domainId}
-            domainType={domainType}
-            validationErrors={validationErrors}
-            fieldPath={fieldPath || field.name}
-          />
-        );
-
-      case "any-predicate-list":
-        return <AnyPredicateListFieldRenderer {...commonProps} />;
-
-      case "object":
-        return <ObjectFieldRenderer {...commonProps} domainId={domainId} domainType={domainType} />;
-
-      case "timezone":
-        return <TimezoneFieldRenderer {...commonProps} />;
-
-      case "secret-key":
-        if (!domainId && !organizationId) {
-          return (
-            <div className="text-sm text-red-500 dark:text-red-400">
-              Secret key field requires domain or organization context.
-            </div>
-          );
-        }
-        return (
-          <SecretKeyFieldRenderer
-            field={field}
-            isRequired={isRequired}
-            value={value as SecretKeyRefValue}
-            onChange={(v) => onChange(v)}
-            organizationId={organizationId ?? domainId}
-          />
-        );
-
-      default:
-        // Fallback to text input
-        return <StringFieldRenderer {...commonProps} />;
-    }
-  };
+  const renderField = () => (
+    <ConfigurationFieldInput
+      commonProps={commonProps}
+      domainId={domainId}
+      domainType={domainType}
+      integrationId={integrationId}
+      organizationId={organizationId}
+      allowExpressions={allowExpressions}
+      autocompleteExampleObj={autocompleteExampleObj}
+      isRequired={isRequired}
+      validationErrors={validationErrors}
+      fieldPath={fieldPath}
+      labelRightRef={labelRightRef}
+      labelRightReady={labelRightReady}
+    />
+  );
 
   // Togglable booleans use the standard label row plus an optional labeled value switch.
   if (field.type === "boolean" && isTogglable) {
@@ -596,3 +445,15 @@ export const ConfigurationFieldRenderer = ({
     </div>
   );
 };
+
+function shouldRenderFieldForReadOnly(field: ConfigurationField): boolean {
+  return (
+    field.type === "list" ||
+    field.type === "select" ||
+    field.type === "multi-select" ||
+    field.type === "user" ||
+    field.type === "role" ||
+    field.type === "group" ||
+    (field.type === "object" && Boolean(field.typeOptions?.object?.schema?.length))
+  );
+}

--- a/web_src/src/ui/configurationFieldRenderer/types.ts
+++ b/web_src/src/ui/configurationFieldRenderer/types.ts
@@ -20,6 +20,7 @@ export interface FieldRendererProps {
   fieldPath?: string;
   autocompleteExampleObj?: Record<string, unknown> | null;
   allowExpressions?: boolean;
+  readOnly?: boolean;
   excludedSuggestions?: string[];
   valuePreviewLabel?: string;
 }


### PR DESCRIPTION
## Summary
- render run inspector nodes from lightweight run execution refs when full execution details are unavailable
- keep approval actions gated on detailed execution metadata so non-approvers see the node without Approve/Reject controls
- preserve runtime config form rendering improvements and duration/sidebar polish in the branch

## Tests
- npm run test:run -- src/ui/Runs/RunInspectorPanel.spec.tsx src/ui/Runs/runNodeDetailModel.spec.ts
- make format.js
- make check.build.ui

## Notes
- web_src/.eslint-budget-baseline.json was not changed.