### PR TITLE
fix: guard restricted canvas actions

### DIFF
--- a/test/e2e/canvas_permission_guards_test.go
+++ b/test/e2e/canvas_permission_guards_test.go
@@ -1,0 +1,192 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/features"
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestCanvasPermissionGuards(t *testing.T) {
+	t.Run("viewer can read canvas but cannot enter edit mode", func(t *testing.T) {
+		steps := &canvasPermissionGuardSteps{t: t}
+		steps.start()
+		steps.givenACanvasExists("Viewer Read Only Canvas")
+		steps.loginAsViewer()
+		steps.visitCanvas()
+		steps.assertEditDisabled()
+		steps.assertNoStagingActions()
+	})
+
+	t.Run("viewer cannot open agent without agent permissions", func(t *testing.T) {
+		steps := &canvasPermissionGuardSteps{t: t}
+		steps.start()
+		steps.enableAgentFeature()
+		steps.givenACanvasExists("Viewer Agent Guard Canvas")
+		steps.loginAsViewer()
+		steps.visitCanvas()
+		steps.assertAgentHidden()
+	})
+
+	t.Run("update version without update can stage and reset but cannot commit", func(t *testing.T) {
+		steps := &canvasPermissionGuardSteps{t: t}
+		steps.start()
+		steps.givenACanvasExists("Version Editor Canvas")
+		steps.loginWithCanvasPermissions("canvas-version-editor", canvasPermission("update_version"))
+		steps.visitCanvas()
+		steps.enterEditMode()
+		steps.stageNoopNode("Draft Only Node")
+		steps.assertResetVisible()
+		steps.assertCommitHidden()
+		steps.assertVersionHistoryAllowsEditing()
+	})
+}
+
+type canvasPermissionGuardSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+}
+
+func (s *canvasPermissionGuardSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *canvasPermissionGuardSteps) givenACanvasExists(name string) {
+	s.canvas = shared.NewCanvasSteps(name, s.t, s.session)
+	s.canvas.Create()
+}
+
+func (s *canvasPermissionGuardSteps) enableAgentFeature() {
+	require.NoError(s.t, models.EnableExperimentalFeature(s.session.OrgID, features.FeatureClaudeManagedAgents))
+}
+
+func (s *canvasPermissionGuardSteps) loginAsViewer() {
+	loginAsViewer(s.t, s.session)
+}
+
+func (s *canvasPermissionGuardSteps) loginWithCanvasPermissions(roleLabel string, permissions ...*permissionSpec) {
+	loginWithCanvasPermissions(s.t, s.session, roleLabel, permissions...)
+}
+
+func (s *canvasPermissionGuardSteps) visitCanvas() {
+	s.canvas.Visit()
+}
+
+func (s *canvasPermissionGuardSteps) enterEditMode() {
+	s.canvas.EnterEditModeWithoutStagingActionAssertions()
+}
+
+func (s *canvasPermissionGuardSteps) stageNoopNode(name string) {
+	s.canvas.AddNoop(name, models.Position{X: 500, Y: 200})
+	s.canvas.WaitForStaging(uuid.Nil)
+	s.canvas.ClickOnEmptyCanvasArea()
+}
+
+func (s *canvasPermissionGuardSteps) assertEditDisabled() {
+	s.session.AssertDisabled(q.TestID("canvas-edit-button"))
+}
+
+func (s *canvasPermissionGuardSteps) assertNoStagingActions() {
+	s.session.AssertHidden(q.TestID("canvas-reset-staging-button"))
+	s.session.AssertHidden(q.TestID("canvas-commit-staging-button"))
+}
+
+func (s *canvasPermissionGuardSteps) assertAgentHidden() {
+	s.session.AssertHidden(q.TestID("canvas-tool-sidebar-toggle"))
+	s.session.AssertHidden(q.TestID("canvas-tool-sidebar"))
+}
+
+func (s *canvasPermissionGuardSteps) assertResetVisible() {
+	s.session.AssertVisible(q.TestID("canvas-reset-staging-button"))
+}
+
+func (s *canvasPermissionGuardSteps) assertCommitHidden() {
+	s.session.AssertHidden(q.TestID("canvas-commit-staging-button"))
+}
+
+func (s *canvasPermissionGuardSteps) assertVersionHistoryAllowsEditing() {
+	s.session.Click(q.TestID("canvas-versions-sidebar-toggle"))
+	s.session.AssertHidden(q.Text("You do not have permission to edit this canvas."))
+}
+
+type permissionSpec struct {
+	resource string
+	action   string
+}
+
+func canvasPermission(action string) *permissionSpec {
+	return organizationPermission("canvases", action)
+}
+
+func organizationPermission(resource, action string) *permissionSpec {
+	return &permissionSpec{resource: resource, action: action}
+}
+
+func loginAsViewer(t *testing.T, sess *session.TestSession) {
+	account := createAccountForRole(t, sess, "viewer", models.RoleOrgViewer)
+	sess.Account = account
+	sess.Login()
+}
+
+func loginWithCanvasPermissions(t *testing.T, sess *session.TestSession, roleLabel string, permissions ...*permissionSpec) {
+	loginWithOrganizationPermissions(t, sess, roleLabel, permissions...)
+}
+
+func loginWithOrganizationPermissions(t *testing.T, sess *session.TestSession, roleLabel string, permissions ...*permissionSpec) {
+	roleName := support.RandomName(roleLabel)
+	rolePermissions := make([]*authorization.Permission, 0, len(permissions))
+	for _, permission := range permissions {
+		rolePermissions = append(rolePermissions, &authorization.Permission{
+			Resource:   permission.resource,
+			Action:     permission.action,
+			DomainType: models.DomainTypeOrganization,
+		})
+	}
+
+	authService, err := authorization.NewAuthService()
+	require.NoError(t, err)
+
+	err = authService.CreateCustomRole(sess.OrgID.String(), &authorization.RoleDefinition{
+		Name:        roleName,
+		DisplayName: roleLabel,
+		DomainType:  models.DomainTypeOrganization,
+		Description: "E2E permission guard role",
+		Permissions: rolePermissions,
+		InheritsFrom: &authorization.RoleDefinition{
+			Name:       models.RoleOrgViewer,
+			DomainType: models.DomainTypeOrganization,
+		},
+	})
+	require.NoError(t, err)
+
+	account := createAccountForRole(t, sess, roleLabel, roleName)
+	sess.Account = account
+	sess.Login()
+}
+
+func createAccountForRole(t *testing.T, sess *session.TestSession, label, roleName string) *models.Account {
+	email := support.RandomName(label) + "@superplane.local"
+	account, err := models.CreateAccount(label, email)
+	require.NoError(t, err)
+
+	user, err := models.CreateUser(sess.OrgID, account.ID, email, label)
+	require.NoError(t, err)
+
+	authService, err := authorization.NewAuthService()
+	require.NoError(t, err)
+
+	err = authService.AssignRole(user.ID.String(), roleName, sess.OrgID.String(), models.DomainTypeOrganization)
+	require.NoError(t, err)
+
+	return account
+}

--- a/test/e2e/home_page_test.go
+++ b/test/e2e/home_page_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/models"
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
@@ -26,6 +27,35 @@ func TestHomePage(t *testing.T) {
 		steps.VisitHomePage()
 		steps.AssertCanvasFolderVisible("Deployments", "Foldered Canvas")
 	})
+
+	t.Run("viewer cannot create canvases from empty home", func(t *testing.T) {
+		steps := &TestHomePageSteps{t: t}
+		steps.Start()
+		steps.LoginAsViewer()
+		steps.VisitHomePage()
+		steps.AssertEmptyHomeVisible()
+		steps.AssertNewAppDisabled()
+		steps.AssertNotRedirectedToNewApp()
+	})
+
+	t.Run("viewer cannot open new app page directly", func(t *testing.T) {
+		steps := &TestHomePageSteps{t: t}
+		steps.Start()
+		steps.LoginAsViewer()
+		steps.VisitNewAppPage()
+		steps.AssertNewAppPageNotFound()
+	})
+
+	t.Run("canvas creator without update cannot create inside a folder", func(t *testing.T) {
+		steps := &TestHomePageSteps{t: t}
+		steps.Start()
+		folder := steps.GivenCanvasFolder("Deployments")
+		steps.LoginWithCanvasPermissions("canvas-folder-creator", canvasPermission("create"))
+		steps.VisitNewAppPageForFolder(folder.ID.String())
+		steps.ClickStartFromScratch()
+		steps.AssertUpdatePermissionToast()
+		steps.AssertCanvasCount(0)
+	})
 }
 
 type TestHomePageSteps struct {
@@ -43,9 +73,38 @@ func (steps *TestHomePageSteps) VisitHomePage() {
 	steps.session.Visit("/" + steps.session.OrgID.String() + "/")
 }
 
+func (steps *TestHomePageSteps) VisitNewAppPage() {
+	steps.session.Visit("/" + steps.session.OrgID.String() + "/apps/new")
+}
+
+func (steps *TestHomePageSteps) VisitNewAppPageForFolder(folderID string) {
+	steps.session.Visit("/" + steps.session.OrgID.String() + "/apps/new?folderId=" + folderID)
+	steps.session.AssertText("Create New App in Deployments Folder")
+}
+
 func (steps *TestHomePageSteps) AssertNavigatedToCanvas() {
 	url := steps.session.Page().URL()
 	assert.Regexp(steps.t, `/apps/[0-9a-f-]{36}`, url)
+}
+
+func (steps *TestHomePageSteps) AssertNotRedirectedToNewApp() {
+	url := steps.session.Page().URL()
+	assert.NotContains(steps.t, url, "/apps/new")
+}
+
+func (steps *TestHomePageSteps) AssertNewAppPageNotFound() {
+	steps.session.AssertText("404")
+	steps.session.AssertHidden(q.Text("Start from scratch"))
+}
+
+func (steps *TestHomePageSteps) AssertEmptyHomeVisible() {
+	steps.session.AssertText("Apps")
+	steps.session.AssertText("No apps yet")
+}
+
+func (steps *TestHomePageSteps) AssertNewAppDisabled() {
+	steps.session.AssertDisabled(q.Locator(`button[aria-label="Create new app"]`))
+	steps.session.AssertHidden(q.Text("Start from scratch"))
 }
 
 func (steps *TestHomePageSteps) AssertCanvasSavedInDB(canvasName string) {
@@ -55,20 +114,48 @@ func (steps *TestHomePageSteps) AssertCanvasSavedInDB(canvasName string) {
 	assert.Equal(steps.t, canvasName, canvas.Name)
 }
 
+func (steps *TestHomePageSteps) AssertCanvasCount(expected int) {
+	count, err := models.CountCanvasesByOrganization(steps.session.OrgID.String())
+	require.NoError(steps.t, err)
+	assert.Equal(steps.t, int64(expected), count)
+}
+
 func (steps *TestHomePageSteps) GivenCanvasInFolder(canvasName, folderTitle string) {
 	canvas := shared.NewCanvasSteps(canvasName, steps.t, steps.session)
 	canvas.Create()
 
-	folder, err := models.CreateCanvasFolder(steps.session.OrgID, folderTitle, models.CanvasFolderColorBlue)
-	assert.NoError(steps.t, err)
+	folder := steps.GivenCanvasFolder(folderTitle)
 
-	_, err = models.UpdateCanvasFolderMembership(steps.session.OrgID, canvas.WorkflowID, &folder.ID)
+	_, err := models.UpdateCanvasFolderMembership(steps.session.OrgID, canvas.WorkflowID, &folder.ID)
 	assert.NoError(steps.t, err)
+}
+
+func (steps *TestHomePageSteps) GivenCanvasFolder(folderTitle string) *models.CanvasFolder {
+	folder, err := models.CreateCanvasFolder(steps.session.OrgID, folderTitle, models.CanvasFolderColorBlue)
+	require.NoError(steps.t, err)
+	return folder
 }
 
 func (steps *TestHomePageSteps) AssertCanvasFolderVisible(folderTitle, canvasName string) {
 	steps.session.AssertText(folderTitle)
 	steps.session.AssertText(canvasName)
+}
+
+func (steps *TestHomePageSteps) LoginAsViewer() {
+	loginAsViewer(steps.t, steps.session)
+}
+
+func (steps *TestHomePageSteps) LoginWithCanvasPermissions(roleLabel string, permissions ...*permissionSpec) {
+	loginWithCanvasPermissions(steps.t, steps.session, roleLabel, permissions...)
+}
+
+func (steps *TestHomePageSteps) ClickStartFromScratch() {
+	steps.session.Click(q.Text("Start from scratch"))
+	steps.session.Sleep(500)
+}
+
+func (steps *TestHomePageSteps) AssertUpdatePermissionToast() {
+	steps.session.AssertText("You don't have permission to update canvases.")
 }
 
 func (steps *TestHomePageSteps) ClickNewApp() {

--- a/test/e2e/settings_permission_guards_test.go
+++ b/test/e2e/settings_permission_guards_test.go
@@ -1,0 +1,315 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	pw "github.com/mxschmitt/playwright-go"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestSettingsPermissionGuards(t *testing.T) {
+	t.Run("viewer can read settings resources but cannot manage them", func(t *testing.T) {
+		steps := &settingsPermissionGuardSteps{t: t}
+		steps.start()
+		steps.givenGroupExists("readonly-team")
+		steps.givenRoleExists("readonly-role")
+		steps.givenServiceAccountExists("readonly-bot")
+		memberEmail := steps.givenMemberExists("readonly-member")
+		steps.loginAsViewer()
+
+		steps.visitGeneralSettings()
+		steps.assertOrgUpdateDisabled()
+		steps.assertOrgDeleteDisabled()
+
+		steps.visitGroupsSettings()
+		steps.assertGroupsCreateDisabled()
+		steps.assertGroupUpdateDisabled("readonly-team")
+		steps.assertGroupDeleteDisabled("readonly-team")
+
+		steps.visitRolesSettings()
+		steps.assertRolesCreateDisabled()
+		steps.assertRoleUpdateDisabled("readonly-role")
+		steps.assertRoleDeleteDisabled("readonly-role")
+
+		steps.visitMembersSettings()
+		steps.assertInviteLinkCreateDisabled()
+		steps.assertMemberUpdateDisabled(memberEmail)
+		steps.assertMemberDeleteDisabled(memberEmail)
+
+		steps.visitServiceAccountsSettings()
+		steps.assertServiceAccountCreateDisabled()
+		steps.openServiceAccount("readonly-bot")
+		steps.assertServiceAccountUpdateDisabled()
+		steps.assertServiceAccountDeleteDisabled()
+	})
+
+	t.Run("secrets reader cannot create update or delete secrets", func(t *testing.T) {
+		steps := &settingsPermissionGuardSteps{t: t}
+		steps.start()
+		steps.givenSecretExists("readonly-secret")
+		steps.loginWithPermissions("secret-reader", organizationPermission("secrets", "read"))
+
+		steps.visitSecretsSettings()
+		steps.assertSecretCreateDisabled()
+		steps.openSecret("readonly-secret")
+		steps.assertSecretUpdateDisabled()
+		steps.assertSecretDeleteDisabled()
+	})
+
+	t.Run("integrations reader cannot create update or delete integrations", func(t *testing.T) {
+		steps := &settingsPermissionGuardSteps{t: t}
+		steps.start()
+		integration := steps.givenIntegrationExists("readonly-integration")
+		steps.loginWithPermissions("integration-reader", organizationPermission("integrations", "read"))
+
+		steps.visitIntegrationsSettings()
+		steps.assertIntegrationCreateDisabled()
+		steps.assertIntegrationUpdateDisabled()
+		steps.visitIntegrationDetail(integration.ID.String())
+		steps.assertIntegrationDeleteDisabled()
+	})
+}
+
+type settingsPermissionGuardSteps struct {
+	t       *testing.T
+	session *session.TestSession
+}
+
+func (s *settingsPermissionGuardSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *settingsPermissionGuardSteps) loginAsViewer() {
+	loginAsViewer(s.t, s.session)
+}
+
+func (s *settingsPermissionGuardSteps) loginWithPermissions(roleLabel string, permissions ...*permissionSpec) {
+	loginWithOrganizationPermissions(s.t, s.session, roleLabel, permissions...)
+}
+
+func (s *settingsPermissionGuardSteps) visitGeneralSettings() {
+	s.visitSettings("general")
+}
+
+func (s *settingsPermissionGuardSteps) visitGroupsSettings() {
+	s.visitSettings("groups")
+}
+
+func (s *settingsPermissionGuardSteps) visitRolesSettings() {
+	s.visitSettings("roles")
+}
+
+func (s *settingsPermissionGuardSteps) visitMembersSettings() {
+	s.visitSettings("members")
+}
+
+func (s *settingsPermissionGuardSteps) visitSecretsSettings() {
+	s.visitSettings("secrets")
+}
+
+func (s *settingsPermissionGuardSteps) visitIntegrationsSettings() {
+	s.visitSettings("integrations")
+}
+
+func (s *settingsPermissionGuardSteps) visitServiceAccountsSettings() {
+	s.visitSettings("service-accounts")
+}
+
+func (s *settingsPermissionGuardSteps) visitSettings(section string) {
+	s.session.Visit("/" + s.session.OrgID.String() + "/settings/" + section)
+	s.session.Sleep(500)
+}
+
+func (s *settingsPermissionGuardSteps) visitIntegrationDetail(integrationID string) {
+	s.session.Visit("/" + s.session.OrgID.String() + "/settings/integrations/" + integrationID)
+	s.session.Sleep(500)
+}
+
+func (s *settingsPermissionGuardSteps) openSecret(name string) {
+	link := s.session.Page().GetByTestId("secrets-secret-link").GetByText(name, pw.LocatorGetByTextOptions{Exact: pw.Bool(true)})
+	require.NoError(s.t, link.Click())
+	s.session.Sleep(500)
+}
+
+func (s *settingsPermissionGuardSteps) openServiceAccount(name string) {
+	link := s.session.Page().GetByTestId("sa-link").GetByText(name, pw.LocatorGetByTextOptions{Exact: pw.Bool(true)})
+	require.NoError(s.t, link.Click())
+	s.session.Sleep(500)
+}
+
+func (s *settingsPermissionGuardSteps) assertOrgUpdateDisabled() {
+	s.session.AssertDisabled(q.Locator(`button:has-text("Save Changes")`))
+}
+
+func (s *settingsPermissionGuardSteps) assertOrgDeleteDisabled() {
+	s.session.AssertDisabled(q.Locator(`button:has-text("Delete Organization...")`))
+}
+
+func (s *settingsPermissionGuardSteps) assertGroupsCreateDisabled() {
+	s.session.AssertDisabled(q.Locator(`button:has-text("Create New Group")`))
+}
+
+func (s *settingsPermissionGuardSteps) assertGroupUpdateDisabled(name string) {
+	row := s.rowByText(name)
+	require.NoError(s.t, row.GetByRole("button", pw.LocatorGetByRoleOptions{Name: "Viewer"}).WaitFor())
+	disabled, err := row.GetByRole("button", pw.LocatorGetByRoleOptions{Name: "Viewer"}).IsDisabled()
+	require.NoError(s.t, err)
+	require.True(s.t, disabled)
+}
+
+func (s *settingsPermissionGuardSteps) assertGroupDeleteDisabled(name string) {
+	row := s.rowByText(name)
+	disabled, err := row.GetByRole("button", pw.LocatorGetByRoleOptions{Name: "Delete group"}).IsDisabled()
+	require.NoError(s.t, err)
+	require.True(s.t, disabled)
+}
+
+func (s *settingsPermissionGuardSteps) assertRolesCreateDisabled() {
+	s.session.AssertDisabled(q.Locator(`button:has-text("New Organization Role")`))
+}
+
+func (s *settingsPermissionGuardSteps) assertRoleUpdateDisabled(name string) {
+	row := s.rowByText(name)
+	require.NoError(s.t, row.Locator(`[aria-label="Edit role"]`).WaitFor())
+	linkCount, err := row.Locator(`a[aria-label="Edit role"]`).Count()
+	require.NoError(s.t, err)
+	require.Equal(s.t, 0, linkCount)
+}
+
+func (s *settingsPermissionGuardSteps) assertRoleDeleteDisabled(name string) {
+	row := s.rowByText(name)
+	disabled, err := row.GetByRole("button", pw.LocatorGetByRoleOptions{Name: "Delete role"}).IsDisabled()
+	require.NoError(s.t, err)
+	require.True(s.t, disabled)
+}
+
+func (s *settingsPermissionGuardSteps) assertInviteLinkCreateDisabled() {
+	s.session.AssertDisabled(q.Locator(`[aria-label="Toggle invite link"]`))
+}
+
+func (s *settingsPermissionGuardSteps) assertMemberUpdateDisabled(email string) {
+	row := s.rowByText(email)
+	disabled, err := row.GetByRole("button", pw.LocatorGetByRoleOptions{Name: "Viewer"}).IsDisabled()
+	require.NoError(s.t, err)
+	require.True(s.t, disabled)
+}
+
+func (s *settingsPermissionGuardSteps) assertMemberDeleteDisabled(email string) {
+	row := s.rowByText(email)
+	buttons := row.GetByRole("button")
+	count, err := buttons.Count()
+	require.NoError(s.t, err)
+	require.GreaterOrEqual(s.t, count, 2)
+	disabled, err := buttons.Nth(count - 1).IsDisabled()
+	require.NoError(s.t, err)
+	require.True(s.t, disabled)
+}
+
+func (s *settingsPermissionGuardSteps) assertSecretCreateDisabled() {
+	s.session.AssertDisabled(q.TestID("secrets-create-btn"))
+}
+
+func (s *settingsPermissionGuardSteps) assertSecretUpdateDisabled() {
+	s.session.AssertDisabled(q.TestID("secret-detail-edit-name"))
+	s.session.AssertDisabled(q.TestID("secret-detail-edit-key"))
+	s.session.AssertDisabled(q.TestID("secret-detail-remove-key"))
+	s.session.AssertDisabled(q.TestID("secret-detail-add-key"))
+}
+
+func (s *settingsPermissionGuardSteps) assertSecretDeleteDisabled() {
+	s.session.AssertDisabled(q.TestID("secret-detail-delete"))
+}
+
+func (s *settingsPermissionGuardSteps) assertIntegrationCreateDisabled() {
+	s.session.AssertDisabled(q.Locator(`button:has-text("Connect")`))
+}
+
+func (s *settingsPermissionGuardSteps) assertIntegrationUpdateDisabled() {
+	s.session.AssertDisabled(q.Locator(`button:has-text("Configure")`))
+}
+
+func (s *settingsPermissionGuardSteps) assertIntegrationDeleteDisabled() {
+	s.session.AssertDisabled(q.TestID("integration-detail-delete"))
+}
+
+func (s *settingsPermissionGuardSteps) assertServiceAccountCreateDisabled() {
+	s.session.AssertDisabled(q.TestID("sa-create-btn"))
+}
+
+func (s *settingsPermissionGuardSteps) assertServiceAccountUpdateDisabled() {
+	s.session.AssertDisabled(q.TestID("sa-detail-edit"))
+	s.session.AssertDisabled(q.TestID("sa-detail-regenerate-token"))
+}
+
+func (s *settingsPermissionGuardSteps) assertServiceAccountDeleteDisabled() {
+	s.session.AssertDisabled(q.TestID("sa-detail-delete"))
+}
+
+func (s *settingsPermissionGuardSteps) rowByText(text string) pw.Locator {
+	row := s.session.Page().GetByRole("row", pw.PageGetByRoleOptions{Name: text})
+	require.NoError(s.t, row.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(10000)}))
+	return row
+}
+
+func (s *settingsPermissionGuardSteps) givenGroupExists(name string) {
+	authService, err := authorization.NewAuthService()
+	require.NoError(s.t, err)
+	require.NoError(s.t, authService.CreateGroup(
+		s.session.OrgID.String(),
+		models.DomainTypeOrganization,
+		name,
+		models.RoleOrgViewer,
+		name,
+		name,
+	))
+}
+
+func (s *settingsPermissionGuardSteps) givenRoleExists(displayName string) {
+	authService, err := authorization.NewAuthService()
+	require.NoError(s.t, err)
+	require.NoError(s.t, authService.CreateCustomRole(s.session.OrgID.String(), &authorization.RoleDefinition{
+		Name:        support.RandomName("readonly-role"),
+		DisplayName: displayName,
+		DomainType:  models.DomainTypeOrganization,
+		Description: "E2E permission guard role",
+		Permissions: []*authorization.Permission{
+			{
+				Resource:   "canvases",
+				Action:     "read",
+				DomainType: models.DomainTypeOrganization,
+			},
+		},
+	}))
+}
+
+func (s *settingsPermissionGuardSteps) givenMemberExists(label string) string {
+	account := createAccountForRole(s.t, s.session, label, models.RoleOrgViewer)
+	return account.Email
+}
+
+func (s *settingsPermissionGuardSteps) givenSecretExists(name string) {
+	secretSteps := &SecretsSteps{t: s.t, session: s.session}
+	secretSteps.givenASecretExists(name, map[string]string{"KEY1": "value1", "KEY2": "value2"})
+}
+
+func (s *settingsPermissionGuardSteps) givenServiceAccountExists(name string) {
+	serviceAccountSteps := &serviceAccountSteps{t: s.t, session: s.session}
+	serviceAccountSteps.givenServiceAccountExists(name, "Permission guard test")
+}
+
+func (s *settingsPermissionGuardSteps) givenIntegrationExists(name string) *models.Integration {
+	integration, err := models.CreateIntegration(uuid.New(), s.session.OrgID, "github", name, nil)
+	require.NoError(s.t, err)
+	require.NoError(s.t, database.Conn().Model(integration).Update("state", models.IntegrationStateReady).Error)
+	integration.State = models.IntegrationStateReady
+	return integration
+}

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -40,17 +40,23 @@ func NewCanvasSteps(name string, t *testing.T, session *session.TestSession) *Ca
 // EnterEditMode clicks the Edit button in the header to start editing the live canvas.
 // This must be called before making any canvas changes.
 func (s *CanvasSteps) EnterEditMode() {
+	s.EnterEditModeWithoutStagingActionAssertions()
+	if s.userHasStaging() {
+		s.AssertStagingActionsVisibleAndEnabled()
+		return
+	}
+	s.AssertStagingActionsVisibleAndDisabled()
+}
+
+// EnterEditModeWithoutStagingActionAssertions enters edit mode without assuming
+// which staging actions the current user's permissions allow.
+func (s *CanvasSteps) EnterEditModeWithoutStagingActionAssertions() {
 	s.waitForEnabledEditButton()
 	editButton := q.TestID("canvas-edit-button").Run(s.session)
 	require.NoError(s.t, editButton.Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
 	s.session.Sleep(500)
 	s.waitForEnabledExitEditButton()
 	s.AssertEditModeTabChrome()
-	if s.userHasStaging() {
-		s.AssertStagingActionsVisibleAndEnabled()
-		return
-	}
-	s.AssertStagingActionsVisibleAndDisabled()
 }
 
 func (s *CanvasSteps) userHasStaging() bool {

--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -115,7 +115,7 @@ function AppRouter() {
               <Route path=":organizationId" element={<OrganizationScope />}>
                 <Route index element={withAuthAndPermission(HomePage, "canvases", "read")} />
                 <Route path="apps">
-                  <Route path="new" element={withAuthAndPermission(NewAppPage, "canvases", "read")} />
+                  <Route path="new" element={withAuthAndPermission(NewAppPage, "canvases", "create")} />
                   <Route
                     path=":appId/settings"
                     element={withAuthAndPermission(CanvasSettingsPage, "canvases", "update")}

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
@@ -19,7 +19,7 @@ describe("VersionsTabPanel", () => {
     render(
       <VersionsTabPanel
         liveVersions={[]}
-        canUpdateCanvas={true}
+        canEditCanvasVersion={true}
         canvasDeletedRemotely={false}
         onUseVersion={vi.fn()}
       />,
@@ -35,7 +35,7 @@ describe("VersionsTabPanel", () => {
       <VersionsTabPanel
         liveCanvasVersionId="version-2"
         liveVersions={[makeVersion("version-2", "Latest"), makeVersion("version-1", "Earlier")]}
-        canUpdateCanvas={true}
+        canEditCanvasVersion={true}
         canvasDeletedRemotely={false}
         onUseVersion={onUseVersion}
       />,

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.tsx
@@ -10,7 +10,7 @@ export interface VersionsTabPanelProps {
   liveCanvasVersion?: CanvasesCanvasVersion | null;
   selectedCanvasVersion?: CanvasesCanvasVersion | null;
   liveVersions: CanvasesCanvasVersion[];
-  canUpdateCanvas: boolean;
+  canEditCanvasVersion: boolean;
   canvasDeletedRemotely: boolean;
   onUseVersion: (versionID: string) => void;
   onLoadMoreLiveVersions?: () => void;
@@ -33,7 +33,7 @@ export function VersionsTabPanel({
   liveCanvasVersion,
   selectedCanvasVersion,
   liveVersions,
-  canUpdateCanvas,
+  canEditCanvasVersion,
   canvasDeletedRemotely,
   onUseVersion,
   onLoadMoreLiveVersions,
@@ -64,7 +64,7 @@ export function VersionsTabPanel({
         data-testid="versions-sidebar-scroll"
         onScroll={handleScroll}
       >
-        <VersionsNotices canUpdateCanvas={canUpdateCanvas} canvasDeletedRemotely={canvasDeletedRemotely} />
+        <VersionsNotices canEditCanvasVersion={canEditCanvasVersion} canvasDeletedRemotely={canvasDeletedRemotely} />
 
         <section>
           <VersionsSectionHeader label="History" />
@@ -120,15 +120,15 @@ function VersionsSectionHeader({ label }: { label: string }) {
 }
 
 function VersionsNotices({
-  canUpdateCanvas,
+  canEditCanvasVersion,
   canvasDeletedRemotely,
 }: {
-  canUpdateCanvas: boolean;
+  canEditCanvasVersion: boolean;
   canvasDeletedRemotely: boolean;
 }) {
   return (
     <>
-      {!canUpdateCanvas && !canvasDeletedRemotely ? (
+      {!canEditCanvasVersion && !canvasDeletedRemotely ? (
         <p className="px-3 py-2 text-xs text-slate-600 dark:text-gray-400">
           You do not have permission to edit this canvas.
         </p>

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -1,17 +1,30 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCanvasToolSidebarState } from "./useCanvasToolSidebarState";
 
+const featureFlags = vi.hoisted(() => ({ enabled: false }));
+
 vi.mock("@/hooks/useExperimentalFeature", () => ({
-  useExperimentalFeature: () => ({ has: () => false, enabledExperimentalFeatures: [] }),
+  useExperimentalFeature: () => ({ has: () => featureFlags.enabled, enabledExperimentalFeatures: [] }),
 }));
 
-function Harness({ onBeforeClose, canvasId }: { onBeforeClose: () => void; canvasId?: string }) {
+function Harness({
+  onBeforeClose,
+  canvasId,
+  canUseAgents,
+  forceEnable = true,
+}: {
+  onBeforeClose: () => void;
+  canvasId?: string;
+  canUseAgents?: boolean;
+  forceEnable?: boolean;
+}) {
   const state = useCanvasToolSidebarState({
     isEditing: false,
     readOnly: false,
-    forceEnable: true,
+    forceEnable,
     canvasId,
+    canUseAgents,
     onBeforeClose,
   });
 
@@ -35,6 +48,11 @@ function Harness({ onBeforeClose, canvasId }: { onBeforeClose: () => void; canva
 }
 
 describe("useCanvasToolSidebarState", () => {
+  beforeEach(() => {
+    featureFlags.enabled = false;
+    window.localStorage.clear();
+  });
+
   it("invokes onBeforeClose when toggling from open to closed", () => {
     window.localStorage.setItem("canvasAgentSidebarOpen", "true");
     const onBeforeClose = vi.fn();
@@ -67,6 +85,14 @@ describe("useCanvasToolSidebarState", () => {
 
     expect(onBeforeClose).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+  });
+
+  it("hides the agent surface when the user cannot use agents", () => {
+    featureFlags.enabled = true;
+    render(<Harness onBeforeClose={vi.fn()} canUseAgents={false} forceEnable={false} />);
+
+    expect(screen.getByTestId("agent-state")).toHaveTextContent("disabled");
+    expect(screen.getByTestId("toggle-state")).toHaveTextContent("hidden");
   });
 
   it("reads and persists the open state per canvas", () => {

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -50,6 +50,8 @@ export type UseCanvasToolSidebarStateOptions = {
   onAgentStagingCommit?: (commitMessage: string) => Promise<boolean>;
   /** When true (e.g. template canvas picker), hides the tool sidebar toggle and clears open state. */
   hideCanvasToolSidebar?: boolean;
+  /** Whether the current user can use managed agent chat endpoints. */
+  canUseAgents?: boolean;
   /** Keeps the tool sidebar available even when managed agents are disabled (runs/versions flows). */
   forceEnable?: boolean;
   /** Called before the user closes the tool sidebar via the header toggle. */
@@ -67,11 +69,13 @@ export function useCanvasToolSidebarState({
   onAgentStagingReady,
   onAgentStagingCommit,
   hideCanvasToolSidebar,
+  canUseAgents = true,
   forceEnable = false,
   onBeforeClose,
 }: UseCanvasToolSidebarStateOptions) {
   const { has: hasFeature } = useExperimentalFeature(organizationId);
   const featureEnabled = hasFeature(FEATURE_CLAUDE_MANAGED_AGENTS);
+  const agentEnabled = canUseAgents && featureEnabled;
 
   const [isToolSidebarOpen, setIsToolSidebarOpen] = useState(() => readInitialToolSidebarOpen(canvasId));
   const [agentMode, setAgentMode] = useState<AgentMode>(readInitialAgentMode);
@@ -138,12 +142,12 @@ export function useCanvasToolSidebarState({
   }, [agentUnavailable, canvasId]);
 
   useEffect(() => {
-    if ((!featureEnabled && !forceEnable) || hideCanvasToolSidebar) {
+    if ((!agentEnabled && !forceEnable) || hideCanvasToolSidebar) {
       setIsToolSidebarOpen(false);
     }
-  }, [featureEnabled, forceEnable, hideCanvasToolSidebar]);
+  }, [agentEnabled, forceEnable, hideCanvasToolSidebar]);
 
-  const showToolSidebarToggle = (featureEnabled || forceEnable) && !hideCanvasToolSidebar;
+  const showToolSidebarToggle = (agentEnabled || forceEnable) && !hideCanvasToolSidebar;
 
   useEffect(() => {
     if (!showToolSidebarToggle) return;
@@ -185,7 +189,7 @@ export function useCanvasToolSidebarState({
     readOnly,
     isToolSidebarOpen,
     showToolSidebarToggle,
-    isAgentEnabled: featureEnabled,
+    isAgentEnabled: agentEnabled,
     agentUnavailable,
     markAgentUnavailable,
     markAgentAvailable,

--- a/web_src/src/pages/app/canvasToolSidebarPanelContent.tsx
+++ b/web_src/src/pages/app/canvasToolSidebarPanelContent.tsx
@@ -41,7 +41,7 @@ export interface CanvasVersionsSidebarPanelConfig {
   liveCanvasVersion?: CanvasesCanvasVersion | null;
   selectedCanvasVersion?: CanvasesCanvasVersion | null;
   liveVersions: CanvasesCanvasVersion[];
-  canUpdateCanvas: boolean;
+  canEditCanvasVersion: boolean;
   canvasDeletedRemotely: boolean;
   onUseVersion: (versionID: string) => void;
   onLoadMoreLiveVersions?: () => void;
@@ -57,6 +57,6 @@ export function renderCanvasRunsSidebarPanel(config: CanvasRunsSidebarPanelConfi
 
 export function renderCanvasVersionsSidebarPanel(config: CanvasVersionsSidebarPanelConfig): ReactNode {
   if (!config.isOpen) return null;
-  const { isOpen: _isOpen, ...props } = config;
-  return <VersionsTabPanel {...props} />;
+  const { isOpen: _isOpen, canEditCanvasVersion, ...props } = config;
+  return <VersionsTabPanel {...props} canEditCanvasVersion={canEditCanvasVersion} />;
 }

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -224,6 +224,37 @@ function buildDuplicatedEdges(
     }));
 }
 
+function getCanvasVersionEditPermissionState({
+  canUpdateCanvasVersion,
+  canvasDeletedRemotely,
+}: {
+  canUpdateCanvasVersion: boolean;
+  canvasDeletedRemotely: boolean;
+}) {
+  if (canvasDeletedRemotely) {
+    return {
+      canStageCanvasVersion: false,
+      tooltip: "This canvas was deleted in another session.",
+    };
+  }
+
+  if (!canUpdateCanvasVersion) {
+    return {
+      canStageCanvasVersion: false,
+      tooltip: "You don't have permission to edit this canvas.",
+    };
+  }
+
+  return {
+    canStageCanvasVersion: true,
+    tooltip: undefined,
+  };
+}
+
+function whenAllowed<T>(allowed: boolean, value: T): T | undefined {
+  return allowed ? value : undefined;
+}
+
 export function AppPage() {
   const { organizationId, appId } = useParams<{
     organizationId: string;
@@ -309,6 +340,7 @@ export function AppPage() {
   const { data: availableIntegrations = [], isLoading: integrationsLoading } = useAvailableIntegrations();
   const canReadIntegrations = canAct("integrations", "read");
   const canUpdateIntegrations = canAct("integrations", "update");
+  const canUseAgents = canAct("agents", "create") && canAct("agents", "read");
   const { data: integrations = [] } = useConnectedIntegrations(organizationId!, { enabled: canReadIntegrations });
   const {
     data: liveCanvas,
@@ -538,12 +570,18 @@ export function AppPage() {
   const createCanvasMemoryNamespace = useCreateCanvasMemoryNamespace(canvasId!);
   const updateCanvasMemoryNamespace = useUpdateCanvasMemoryNamespace(canvasId!);
   const canUpdateCanvas = canAct("canvases", "update");
+  const canUpdateCanvasVersion = canAct("canvases", "update_version");
   usePageTitle([canvas?.metadata?.name || "Canvas"]);
   const [canvasDeletedRemotely, setCanvasDeletedRemotely] = useState(false);
   const [remoteCanvasUpdatePending, setRemoteCanvasUpdatePending] = useState(false);
   const canvasAccess = { canUpdateCanvas, canvasDeletedRemotely };
   const canActOnCanvas = canUpdateCanvas && !canvasDeletedRemotely;
-  const isReadOnly = !canActOnCanvas || !hasEditableVersion;
+  const canvasVersionEditPermission = getCanvasVersionEditPermissionState({
+    canUpdateCanvasVersion,
+    canvasDeletedRemotely,
+  });
+  const canStageCanvasVersion = canvasVersionEditPermission.canStageCanvasVersion;
+  const isReadOnly = !canStageCanvasVersion || !hasEditableVersion;
   /**
    * Track if we've already done the initial fit to view.
    * This ref persists across re-renders to prevent viewport changes on save.
@@ -1874,9 +1912,9 @@ export function AppPage() {
     async (workflowToSave?: CanvasesCanvas, options?: { showToast?: boolean; savingVersionId?: string }) => {
       const targetWorkflow = workflowToSave || canvasRef.current;
       if (!targetWorkflow || !organizationId || !canvasId) return;
-      if (!canUpdateCanvas) {
+      if (!canUpdateCanvasVersion) {
         if (options?.showToast !== false) {
-          showErrorToast("You don't have permission to update this canvas");
+          showErrorToast("You don't have permission to edit this canvas version");
         }
         return;
       }
@@ -1936,7 +1974,14 @@ export function AppPage() {
         }
       }
     },
-    [organizationId, canvasId, activeCanvasVersionId, canUpdateCanvas, enqueueCanvasSave, setLastSavedWorkflowSnapshot],
+    [
+      organizationId,
+      canvasId,
+      activeCanvasVersionId,
+      canUpdateCanvasVersion,
+      enqueueCanvasSave,
+      setLastSavedWorkflowSnapshot,
+    ],
   );
 
   const getNodeEditData = useCallback(
@@ -3360,7 +3405,7 @@ export function AppPage() {
   const { enterLiveEditSession } = useEnterLiveEditSession({
     organizationId,
     canvasId,
-    canUpdateCanvas,
+    canUpdateCanvas: canStageCanvasVersion,
     effectiveLiveCanvasVersionId,
     selectableVersionsById,
     handleUseVersion,
@@ -3420,7 +3465,7 @@ export function AppPage() {
       return;
     }
 
-    if (!canUpdateCanvas) {
+    if (!canStageCanvasVersion) {
       showErrorToast("You don't have permission to edit this canvas");
       return;
     }
@@ -3467,7 +3512,7 @@ export function AppPage() {
   }, [
     organizationId,
     canvasId,
-    canUpdateCanvas,
+    canStageCanvasVersion,
     editSessionActive,
     effectiveLiveCanvasVersionId,
     liveCanvasVersion,
@@ -3658,7 +3703,7 @@ export function AppPage() {
   } = useWorkflowViewModeActions({
     ...urlViewFlags,
     hasEditableVersion,
-    canUpdateCanvas,
+    canUpdateCanvas: canStageCanvasVersion,
     canvasDeletedRemotely,
     handleExitConsoleMode,
     handleExitMemoryMode,
@@ -3677,7 +3722,7 @@ export function AppPage() {
     setSearchParams,
     startup: {
       hasEditableVersion,
-      canUpdateCanvas,
+      canUpdateCanvas: canStageCanvasVersion,
       canvas,
       liveVersionLoading: isLiveVersionLoading,
       handlePlaceholderAdd,
@@ -4005,15 +4050,11 @@ export function AppPage() {
     ) : null;
   const headerBanners = [appBanner, remoteUpdateBanner].filter(Boolean);
   const headerBanner = headerBanners.length > 0 ? <div className="flex flex-col">{headerBanners}</div> : null;
-  const enterEditModeDisabled = !canUpdateCanvas || canvasDeletedRemotely;
-  const enterEditModeDisabledTooltip = !canUpdateCanvas
-    ? "You don't have permission to edit this canvas."
-    : canvasDeletedRemotely
-      ? "This canvas was deleted in another session."
-      : undefined;
-  const exitEditModeDisabled = !canUpdateCanvas || canvasDeletedRemotely;
+  const enterEditModeDisabled = !canStageCanvasVersion;
+  const enterEditModeDisabledTooltip = canvasVersionEditPermission.tooltip;
+  const exitEditModeDisabled = !canStageCanvasVersion;
   const exitEditModeDisabledTooltip = getExitEditModeDisabledTooltip({
-    canUpdateCanvas,
+    canUpdateCanvas: canStageCanvasVersion,
     canvasDeletedRemotely,
     hasEditableVersion,
   });
@@ -4069,7 +4110,7 @@ export function AppPage() {
     liveCanvasVersion,
     selectedCanvasVersion,
     liveVersions,
-    canUpdateCanvas,
+    canEditCanvasVersion: canStageCanvasVersion,
     canvasDeletedRemotely,
     onUseVersion: handleUseVersionFromVersionPanel,
     onLoadMoreLiveVersions: hasMoreLiveVersions ? () => canvasLiveVersionsQuery.fetchNextPage() : undefined,
@@ -4125,7 +4166,7 @@ export function AppPage() {
             canvasId: canvasId || undefined,
             organizationId,
             versionId: activeCanvasVersionId || undefined,
-            canWrite: canActOnCanvas,
+            canWrite: canStageCanvasVersion,
             files: appFiles,
             headerActionsSlotId: filesHeaderActionsSlotId,
             stagingResetNonce,
@@ -4187,7 +4228,7 @@ export function AppPage() {
           activeCanvasVersionId={activeCanvasVersionId}
           liveCanvasVersionId={effectiveLiveCanvasVersionId}
           onAgentStagingReady={handleAgentStagingReady}
-          onAgentStagingCommit={handleAgentSidebarStagingCommit}
+          onAgentStagingCommit={whenAllowed(canUpdateCanvas, handleAgentSidebarStagingCommit)}
           onNodeAdd={!isReadOnly ? handleNodeAdd : undefined}
           onPlaceholderAdd={!isReadOnly ? handlePlaceholderAdd : undefined}
           onPlaceholderConfigure={!isReadOnly ? handlePlaceholderConfigure : undefined}
@@ -4195,6 +4236,7 @@ export function AppPage() {
           canReadIntegrations={canReadIntegrations}
           canCreateIntegrations={canAct("integrations", "create")}
           canUpdateIntegrations={canUpdateIntegrations}
+          canUseAgents={canUseAgents}
           missingIntegrations={missingIntegrations}
           onConnectIntegration={!isReadOnly ? handleConnectIntegration : undefined}
           readOnly={isReadOnly || readOnlyViewModes}
@@ -4259,11 +4301,11 @@ export function AppPage() {
           hasCommittedCanvasDraftChanges={hasCommittedCanvasDraftChanges}
           hasCommittedConsoleDraftChanges={hasCommittedConsoleDraftChanges}
           hasFilesStagingChanges={isEditSessionUiReady && hasFilesStagingChanges}
-          onCommitStaging={handleOpenCommitDialog}
+          onCommitStaging={whenAllowed(canUpdateCanvas, handleOpenCommitDialog)}
           commitStagingPending={commitStagingPending}
           resetStagingPending={resetStagingPending}
-          onResetStaging={handleResetStaging}
-          onDiscardStaleStaging={handleDiscardStaleStaging}
+          onResetStaging={whenAllowed(canUpdateCanvasVersion, handleResetStaging)}
+          onDiscardStaleStaging={whenAllowed(canUpdateCanvasVersion, handleDiscardStaleStaging)}
           discardStaleStagingPending={resetStagingPending}
           autoLayoutOnUpdateDisabled={isReadOnly}
           autoLayoutOnUpdateDisabledTooltip={isReadOnly ? "You don't have permission to edit this canvas." : undefined}

--- a/web_src/src/pages/app/viewState.spec.ts
+++ b/web_src/src/pages/app/viewState.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyRunInspectionNavigationSearchParams,
   clearRunInspectionSearchParams,
+  getExitEditModeDisabledTooltip,
   getWorkflowViewPresentation,
 } from "./viewState";
 
@@ -56,5 +57,17 @@ describe("getWorkflowViewPresentation", () => {
 
     expect(editingAfterRunInspection.readOnlyViewModes).toBe(false);
     expect(editingAfterRunInspection.hideAddControls).toBe(false);
+  });
+});
+
+describe("getExitEditModeDisabledTooltip", () => {
+  it("prioritizes remote deletion over permission denial", () => {
+    expect(
+      getExitEditModeDisabledTooltip({
+        canUpdateCanvas: false,
+        canvasDeletedRemotely: true,
+        hasEditableVersion: true,
+      }),
+    ).toBe("This canvas was deleted in another session.");
   });
 });

--- a/web_src/src/pages/app/viewState.ts
+++ b/web_src/src/pages/app/viewState.ts
@@ -206,12 +206,12 @@ export function getExitEditModeDisabledTooltip({
   canvasDeletedRemotely: boolean;
   hasEditableVersion: boolean;
 }): string | undefined {
-  if (!canUpdateCanvas) {
-    return "You don't have permission to edit this canvas.";
-  }
-
   if (canvasDeletedRemotely) {
     return "This canvas was deleted in another session.";
+  }
+
+  if (!canUpdateCanvas) {
+    return "You don't have permission to edit this canvas.";
   }
 
   if (!hasEditableVersion) {

--- a/web_src/src/pages/home/NewAppPage.tsx
+++ b/web_src/src/pages/home/NewAppPage.tsx
@@ -1,3 +1,4 @@
+import { RequirePermission } from "@/components/PermissionGate";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { HomePageShell } from "./HomePageShell";
@@ -11,8 +12,10 @@ export function NewAppPage() {
   useReportPageReady(true);
 
   return (
-    <HomePageShell>
-      <ZeroStatePage folder={folder} folderContextPending={folderContextPending} title={title} />
-    </HomePageShell>
+    <RequirePermission resource="canvases" action="create">
+      <HomePageShell>
+        <ZeroStatePage folder={folder} folderContextPending={folderContextPending} title={title} />
+      </HomePageShell>
+    </RequirePermission>
   );
 }

--- a/web_src/src/pages/home/index.spec.tsx
+++ b/web_src/src/pages/home/index.spec.tsx
@@ -128,7 +128,9 @@ vi.mock("@/hooks/useCanvasData", () => ({
 }));
 
 import { HomePage } from "./index";
+import { InstallProgressPanel } from "./InstallProgressPanel";
 import { NewAppPage } from "./NewAppPage";
+import type { AppEntry } from "./AppDetailModal";
 
 function makeCanvas(
   id: string,
@@ -178,6 +180,30 @@ function renderHome(initialEntries = ["/org-123"]) {
             <Route path="apps/:canvasId" element={<div>Canvas editor</div>} />
           </Route>
         </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function renderInstallProgressPanel(app: AppEntry) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/org-123/apps/new"]}>
+        <InstallProgressPanel
+          app={app}
+          organizationId="org-123"
+          skipPreviewFetch
+          preloadedIntegrations={[]}
+          preloadedParams={[]}
+          onClose={vi.fn()}
+        />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -240,6 +266,53 @@ describe("HomePage canvas folders", () => {
         }),
       );
     });
+  });
+
+  it("does not redirect an empty home page to creation without create permission", () => {
+    permissionMocks.canAct.mockImplementation((_resource: string, action: string) => action !== "create");
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderHome();
+
+    expect(screen.getByRole("heading", { name: "Apps" })).toBeInTheDocument();
+    expect(screen.getByText("No apps yet")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create new app" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /start from scratch/i })).not.toBeInTheDocument();
+  });
+
+  it("blocks direct navigation to the new app page without create permission", () => {
+    permissionMocks.canAct.mockImplementation((_resource: string, action: string) => action !== "create");
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderHome(["/org-123/apps/new"]);
+
+    expect(screen.getByRole("heading", { name: "404" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /start from scratch/i })).not.toBeInTheDocument();
+  });
+
+  it("does not install an app without create permission if the install action is invoked", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    permissionMocks.canAct.mockImplementation((_resource: string, action: string) => action !== "create");
+
+    renderInstallProgressPanel({
+      repo: "github.com/superplanehq/example-app",
+      icon: "",
+      title: "Example App",
+      description: "",
+      integrations: [],
+      tags: [],
+      requirements: [],
+      agentInstructions: "",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Just take me there" }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(showErrorToast).toHaveBeenCalledWith("You don't have permission to create canvases.");
   });
 
   it("renders folders before free canvases using the manual folder order", () => {

--- a/web_src/src/pages/home/index.tsx
+++ b/web_src/src/pages/home/index.tsx
@@ -63,7 +63,7 @@ export function HomePage() {
     return <ErrorView />;
   }
 
-  if (canvases.length === 0 && canvasFolders.length === 0 && !canvasError) {
+  if (canvases.length === 0 && canvasFolders.length === 0 && !canvasError && canCreateCanvases) {
     return <Navigate to={`/${organizationId}/apps/new`} replace />;
   }
 

--- a/web_src/src/pages/home/useInstallAction.ts
+++ b/web_src/src/pages/home/useInstallAction.ts
@@ -82,11 +82,17 @@ export function useInstallAction({
   const updateCanvasFolderMembershipMutation = useUpdateCanvasFolderMembership(organizationId || "");
   const { mutateAsync: updateCanvasFolderMembership } = updateCanvasFolderMembershipMutation;
   const { canAct } = usePermissions();
+  const canCreateCanvases = canAct("canvases", "create");
   const canUpdateCanvases = canAct("canvases", "update");
 
   const doInstall = useCallback(
     async (skipParams: boolean) => {
       if (!organizationId || isInstallingRef.current) return;
+      if (!canCreateCanvases) {
+        showErrorToast("You don't have permission to create canvases.");
+        return;
+      }
+
       if (folder && !canUpdateCanvases) {
         showErrorToast("You don't have permission to update canvases.");
         return;
@@ -122,6 +128,7 @@ export function useInstallAction({
     [
       organizationId,
       app,
+      canCreateCanvases,
       canUpdateCanvases,
       canvasName,
       folder,

--- a/web_src/src/pages/organization/settings/CreateRolePage.tsx
+++ b/web_src/src/pages/organization/settings/CreateRolePage.tsx
@@ -433,6 +433,14 @@ export function CreateRolePage() {
     }
   };
 
+  if (permissionsLoading) {
+    return (
+      <div className="flex justify-center items-center min-h-[40vh]">
+        <p className="text-gray-500">Checking permissions...</p>
+      </div>
+    );
+  }
+
   if (!canReadRoles) {
     return <NotFoundPage />;
   }
@@ -443,14 +451,6 @@ export function CreateRolePage() {
 
   if (!isEditMode && !canCreateRoles) {
     return <NotFoundPage />;
-  }
-
-  if (permissionsLoading) {
-    return (
-      <div className="flex justify-center items-center min-h-[40vh]">
-        <p className="text-gray-500">Checking permissions...</p>
-      </div>
-    );
   }
 
   return (

--- a/web_src/src/pages/organization/settings/SecretDetail.tsx
+++ b/web_src/src/pages/organization/settings/SecretDetail.tsx
@@ -1,10 +1,12 @@
 import { Breadcrumbs } from "@/components/Breadcrumbs/breadcrumbs";
+import { PermissionTooltip } from "@/components/PermissionGate";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { Textarea } from "@/components/Textarea/textarea";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { usePermissions } from "@/contexts/usePermissions";
 import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { Edit2, Key, Loader2, Plus, Trash2 } from "lucide-react";
@@ -25,6 +27,7 @@ interface SecretDetailProps {
 export function SecretDetail({ organizationId }: SecretDetailProps) {
   const navigate = useNavigate();
   const { secretId } = useParams<{ secretId: string }>();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
 
   const { data: secret, isLoading, error } = useSecret(organizationId, "DOMAIN_TYPE_ORGANIZATION", secretId || "");
   usePageTitle(["Secrets", secret?.metadata?.name]);
@@ -46,8 +49,11 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
   const deleteSecretKeyMutation = useDeleteSecretKey(organizationId, "DOMAIN_TYPE_ORGANIZATION", secretId || "");
   const updateSecretNameMutation = useUpdateSecretName(organizationId, "DOMAIN_TYPE_ORGANIZATION", secretId || "");
   const deleteSecretMutation = useDeleteSecret(organizationId, "DOMAIN_TYPE_ORGANIZATION");
+  const canUpdateSecrets = canAct("secrets", "update");
+  const canDeleteSecrets = canAct("secrets", "delete");
 
   const handleSaveEdit = async () => {
+    if (!canUpdateSecrets) return;
     if (!secret || !editingKey || !editingValue.trim()) return;
     const newName = editingKeyName.trim();
     if (!newName) {
@@ -83,11 +89,13 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
   };
 
   const handleStartEditSecretName = () => {
+    if (!canUpdateSecrets) return;
     setEditingSecretNameValue(secret?.metadata?.name || "");
     setEditingSecretName(true);
   };
 
   const handleSaveSecretName = async () => {
+    if (!canUpdateSecrets) return;
     const name = editingSecretNameValue.trim();
     if (!name) {
       showErrorToast("Secret name is required");
@@ -114,6 +122,7 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
   };
 
   const handleAddKey = async () => {
+    if (!canUpdateSecrets) return;
     if (!secret || !newKey.trim() || !newValue.trim()) {
       showErrorToast("Key and value are required");
       return;
@@ -144,6 +153,7 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
   };
 
   const handleRemoveKey = async (keyToRemove: string) => {
+    if (!canUpdateSecrets) return;
     if (!secret) return;
     const secretData = secret.spec?.local?.data || {};
     const remainingCount = Object.keys(secretData).filter((k) => k !== keyToRemove).length;
@@ -164,6 +174,7 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
   };
 
   const handleDelete = async () => {
+    if (!canDeleteSecrets) return;
     if (!secret) return;
     if (
       !confirm(`Are you sure you want to delete the secret "${secret.metadata?.name}"? This action cannot be undone.`)
@@ -268,35 +279,46 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
                 <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-100 truncate">
                   {secret.metadata?.name || "Unnamed Secret"}
                 </h2>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleStartEditSecretName}
-                  className="shrink-0 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                  title="Edit secret name"
-                  data-testid="secret-detail-edit-name"
+                <PermissionTooltip
+                  allowed={canUpdateSecrets || permissionsLoading}
+                  message="You don't have permission to update secrets."
                 >
-                  <Edit2 className="w-4 h-4" />
-                </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleStartEditSecretName}
+                    disabled={!canUpdateSecrets}
+                    className="shrink-0 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                    title="Edit secret name"
+                    data-testid="secret-detail-edit-name"
+                  >
+                    <Edit2 className="w-4 h-4" />
+                  </Button>
+                </PermissionTooltip>
               </>
             )}
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleDelete}
-            disabled={deleteSecretMutation.isPending}
-            className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 shrink-0"
-            title="Delete secret"
-            data-testid="secret-detail-delete"
+          <PermissionTooltip
+            allowed={canDeleteSecrets || permissionsLoading}
+            message="You don't have permission to delete secrets."
           >
-            {deleteSecretMutation.isPending ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <Trash2 className="w-4 h-4" />
-            )}
-            <span className="ml-1">Delete secret</span>
-          </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDelete}
+              disabled={deleteSecretMutation.isPending || !canDeleteSecrets}
+              className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 shrink-0"
+              title="Delete secret"
+              data-testid="secret-detail-delete"
+            >
+              {deleteSecretMutation.isPending ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Trash2 className="w-4 h-4" />
+              )}
+              <span className="ml-1">Delete secret</span>
+            </Button>
+          </PermissionTooltip>
         </div>
 
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-800 overflow-hidden">
@@ -359,32 +381,44 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
                           {keyName}
                         </span>
                         <span className="text-gray-500 dark:text-gray-400">•••</span>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => {
-                            setEditingKey(keyName);
-                            setEditingKeyName(keyName);
-                            setEditingValue("");
-                          }}
-                          className="shrink-0 text-gray-600 dark:text-gray-300"
-                          title="Edit value"
-                          data-testid="secret-detail-edit-key"
+                        <PermissionTooltip
+                          allowed={canUpdateSecrets || permissionsLoading}
+                          message="You don't have permission to update secrets."
                         >
-                          <Edit2 className="w-3 h-3" />
-                        </Button>
-                        {keys.length > 1 && (
                           <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => handleRemoveKey(keyName)}
-                            disabled={isUpdating}
-                            className="shrink-0 text-red-600 hover:text-red-700 dark:text-red-400"
-                            title="Remove key"
-                            data-testid="secret-detail-remove-key"
+                            onClick={() => {
+                              if (!canUpdateSecrets) return;
+                              setEditingKey(keyName);
+                              setEditingKeyName(keyName);
+                              setEditingValue("");
+                            }}
+                            disabled={!canUpdateSecrets}
+                            className="shrink-0 text-gray-600 dark:text-gray-300"
+                            title="Edit value"
+                            data-testid="secret-detail-edit-key"
                           >
-                            <Trash2 className="w-3 h-3" />
+                            <Edit2 className="w-3 h-3" />
                           </Button>
+                        </PermissionTooltip>
+                        {keys.length > 1 && (
+                          <PermissionTooltip
+                            allowed={canUpdateSecrets || permissionsLoading}
+                            message="You don't have permission to update secrets."
+                          >
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleRemoveKey(keyName)}
+                              disabled={isUpdating || !canUpdateSecrets}
+                              className="shrink-0 text-red-600 hover:text-red-700 dark:text-red-400"
+                              title="Remove key"
+                              data-testid="secret-detail-remove-key"
+                            >
+                              <Trash2 className="w-3 h-3" />
+                            </Button>
+                          </PermissionTooltip>
                         )}
                       </>
                     )}
@@ -430,20 +464,27 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
               )}
             </div>
             {!isAddingKey && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setIsAddingKey(true);
-                  setNewKey("");
-                  setNewValue("");
-                }}
-                className="mt-3 text-xs"
-                data-testid="secret-detail-add-key"
+              <PermissionTooltip
+                allowed={canUpdateSecrets || permissionsLoading}
+                message="You don't have permission to update secrets."
               >
-                <Plus className="w-3 h-3 mr-1" />
-                Add key
-              </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    if (!canUpdateSecrets) return;
+                    setIsAddingKey(true);
+                    setNewKey("");
+                    setNewValue("");
+                  }}
+                  disabled={!canUpdateSecrets}
+                  className="mt-3 text-xs"
+                  data-testid="secret-detail-add-key"
+                >
+                  <Plus className="w-3 h-3 mr-1" />
+                  Add key
+                </Button>
+              </PermissionTooltip>
             )}
           </div>
         </div>

--- a/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/Header.tsx
+++ b/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/Header.tsx
@@ -79,6 +79,7 @@ export function Header({
             className="shrink-0 text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400"
             aria-label="Delete integration"
             disabled={!canDeleteIntegrations}
+            data-testid="integration-detail-delete"
             onClick={() => {
               if (!canDeleteIntegrations) return;
               onRequestDelete();

--- a/web_src/src/pages/organization/settings/components/IntegrationDetailsRoute/LegacyIntegrationDetails.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationDetailsRoute/LegacyIntegrationDetails.tsx
@@ -394,6 +394,7 @@ export function LegacyIntegrationDetails({ organizationId, integration }: Legacy
                 }}
                 className="border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-600 dark:hover:text-red-400 gap-1"
                 disabled={!canDeleteIntegrations}
+                data-testid="integration-detail-delete"
               >
                 <Trash2 className="w-4 h-4" />
                 Delete Integration

--- a/web_src/src/pages/organization/settings/index.tsx
+++ b/web_src/src/pages/organization/settings/index.tsx
@@ -509,7 +509,14 @@ export function OrganizationSettings() {
                 </RequirePermission>
               }
             />
-            <Route path="secrets/:secretId" element={<SecretDetail organizationId={organizationId || ""} />} />
+            <Route
+              path="secrets/:secretId"
+              element={
+                <RequirePermission resource="secrets" action="read">
+                  <SecretDetail organizationId={organizationId || ""} />
+                </RequirePermission>
+              }
+            />
             <Route
               path="service-accounts"
               element={
@@ -526,8 +533,22 @@ export function OrganizationSettings() {
                 </RequirePermission>
               }
             />
-            <Route path="create-role" element={<CreateRolePage />} />
-            <Route path="create-role/:roleName" element={<CreateRolePage />} />
+            <Route
+              path="create-role"
+              element={
+                <RequirePermission resource="roles" action="create">
+                  <CreateRolePage />
+                </RequirePermission>
+              }
+            />
+            <Route
+              path="create-role/:roleName"
+              element={
+                <RequirePermission resource="roles" action="read">
+                  <CreateRolePage />
+                </RequirePermission>
+              }
+            />
             <Route path="profile" element={<Profile />} />
             <Route
               path="billing"

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
@@ -133,6 +133,24 @@ describe("SecondaryHeaderActions", () => {
     expect(screen.queryByTestId("canvas-publish-version-button")).not.toBeInTheDocument();
   });
 
+  it("shows reset without commit when committing is not allowed", () => {
+    render(
+      <SecondaryHeaderActions
+        canvasName="Canvas"
+        mode="version-live"
+        isEditing
+        hasStagingChanges
+        onResetStaging={vi.fn()}
+        toolSidebarState={{} as CanvasToolSidebarState}
+        runsSidebarState={runsSidebarState}
+        versionsSidebarState={versionsSidebarState}
+      />,
+    );
+
+    expect(screen.getByTestId("canvas-reset-staging-button")).toBeEnabled();
+    expect(screen.queryByTestId("canvas-commit-staging-button")).not.toBeInTheDocument();
+  });
+
   it("keeps staging controls disabled while reset settles after staging clears", () => {
     render(
       <SecondaryHeaderActions

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -145,7 +145,9 @@ function EditModeStagingActions({
     );
   }
 
-  if (!onCommitStaging) {
+  const showStagingActions =
+    (!!onCommitStaging || !!onResetStaging) && (!!onCommitStaging || !!hasStagingChanges || stagingActionPending);
+  if (!showStagingActions) {
     return null;
   }
 
@@ -156,7 +158,9 @@ function EditModeStagingActions({
       {onResetStaging ? (
         <ResetStagingButton onReset={() => onResetStaging()} disabled={stagingActionsDisabled} />
       ) : null}
-      <CommitStagingButton onCommit={() => onCommitStaging?.()} disabled={stagingActionsDisabled} />
+      {onCommitStaging ? (
+        <CommitStagingButton onCommit={() => onCommitStaging()} disabled={stagingActionsDisabled} />
+      ) : null}
     </div>
   );
 }

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -255,6 +255,8 @@ export interface CanvasPageProps {
   hideAddControls?: boolean;
   /** Hide the Agent / Versions left panel toggle (templates only). */
   hideCanvasToolSidebar?: boolean;
+  /** Enables managed agent chat controls when the user has the required RBAC permissions. */
+  canUseAgents?: boolean;
   canReadIntegrations?: boolean;
   canCreateIntegrations?: boolean;
   canUpdateIntegrations?: boolean;
@@ -830,6 +832,7 @@ function CanvasPage(props: CanvasPageProps) {
   const toolSidebarState = useCanvasToolSidebarState({
     isEditing: props.isEditing,
     hideCanvasToolSidebar: props.hideCanvasToolSidebar ?? false,
+    canUseAgents: props.canUseAgents ?? true,
     readOnly,
     canvasId: props.canvasId,
     organizationId: props.organizationId,


### PR DESCRIPTION
## Summary
- require `canvases:create` for direct and empty-state app creation flows
- block starter app installs before the create-canvas API call when the user lacks create permission
- align draft/staging editor controls with `canvases:update_version` while keeping commit/live actions on `canvases:update`
- add E2E coverage for viewer creation guards, folder-scoped create/update guard, viewer canvas edit guard, and update-version-only staging controls

Closes #5964

## Tests
- `make format.js`
- `make format.go`
- `docker compose -f docker-compose.dev.yml exec app bash -c "cd web_src && npm run test:run -- src/pages/home/index.spec.tsx src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx"`
- `make check.lint.ui`
- `make check.build.ui`
- `make test.e2e.single FILE=test/e2e/canvas_permission_guards_test.go LINE=15`
- `make test.e2e.single FILE=test/e2e/home_page_test.go LINE=31`
- `make test.e2e.single FILE=test/e2e/home_page_test.go LINE=41`
- `make test.e2e.single FILE=test/e2e/home_page_test.go LINE=49`
- `make lint && make check.build.app`