### PR TITLE
fix: add missing dark mode styles across signup, admin, diff modal, and canvas

### DIFF
--- a/web_src/src/components/ui/dialog.tsx
+++ b/web_src/src/components/ui/dialog.tsx
@@ -73,7 +73,7 @@ function DialogContent({
           <DialogPrimitive.Close
             data-slot="dialog-close"
             className={cn(
-              "absolute top-2 right-2 flex h-6 w-6 cursor-pointer items-center justify-center rounded leading-none hover:bg-slate-950/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none",
+              "absolute top-2 right-2 flex h-6 w-6 cursor-pointer items-center justify-center rounded leading-none hover:bg-slate-950/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dark:hover:bg-white/10",
               closeButtonClassName,
             )}
           >
@@ -121,7 +121,7 @@ function DialogDescription({ className, ...props }: React.ComponentProps<typeof 
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-sm text-gray-600", className)}
+      className={cn("text-sm text-gray-600 dark:text-gray-400", className)}
       {...props}
     />
   );

--- a/web_src/src/components/ui/tabs.tsx
+++ b/web_src/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimi
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-slate-100 text-muted-foreground inline-flex h-7 w-fit items-center justify-center rounded-full p-0.5",
+        "bg-slate-100 text-muted-foreground inline-flex h-7 w-fit items-center justify-center rounded-full p-0.5 dark:bg-gray-800",
         className,
       )}
       {...props}

--- a/web_src/src/lib/darkThemeSurfaces.ts
+++ b/web_src/src/lib/darkThemeSurfaces.ts
@@ -1,1 +1,1 @@
-export const DARK_BASE_BG_HEX = "#111827";
+export const DARK_BASE_BG_HEX = "#17191c";

--- a/web_src/src/pages/admin/AccountRow.tsx
+++ b/web_src/src/pages/admin/AccountRow.tsx
@@ -22,32 +22,34 @@ interface AccountRowProps {
 
 export function AccountRow({ acc, isSelf, toggling, onPromoteDemote, impersonateButton }: AccountRowProps) {
   return (
-    <tr className="border-b border-slate-50 last:border-0">
-      <td className="px-4 py-2.5 text-gray-800">
+    <tr className="border-b border-slate-50 last:border-0 dark:border-gray-800/70">
+      <td className="px-4 py-2.5 text-gray-800 dark:text-gray-100">
         {acc.name || (
-          <span className="text-gray-400 italic" title={acc.id}>
+          <span className="text-gray-400 italic dark:text-gray-500" title={acc.id}>
             {acc.id.slice(0, 8)}...
           </span>
         )}
-        {isSelf && <span className="ml-1.5 text-xs text-gray-400">(you)</span>}
+        {isSelf && <span className="ml-1.5 text-xs text-gray-400 dark:text-gray-500">(you)</span>}
       </td>
-      <td className="px-4 py-2.5 text-gray-500">{acc.email}</td>
+      <td className="px-4 py-2.5 text-gray-500 dark:text-gray-400">{acc.email}</td>
       <td className="px-4 py-2.5">
         {acc.installation_admin ? (
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded">
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded dark:bg-amber-950/40 dark:text-amber-300">
             <Shield size={12} />
             Admin
           </span>
         ) : (
-          <span className="text-xs text-gray-400">User</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">User</span>
         )}
       </td>
-      <td className="px-4 py-2.5 text-gray-400 text-xs whitespace-nowrap">{formatDate(acc.created_at)}</td>
+      <td className="px-4 py-2.5 text-gray-400 text-xs whitespace-nowrap dark:text-gray-500">
+        {formatDate(acc.created_at)}
+      </td>
       <td className="px-4 py-2.5 text-right">
         <div className="flex items-center justify-end gap-2">
           {!isSelf && impersonateButton}
           {isSelf ? (
-            <Text className="text-xs text-gray-400">Cannot change own access</Text>
+            <Text className="text-xs text-gray-400 dark:text-gray-500">Cannot change own access</Text>
           ) : (
             <Button variant="outline" size="sm" onClick={onPromoteDemote} disabled={toggling}>
               {toggling ? (

--- a/web_src/src/pages/admin/AccountsList.tsx
+++ b/web_src/src/pages/admin/AccountsList.tsx
@@ -44,10 +44,10 @@ function AccountsTable({
   onPromoteDemote,
 }: AccountsTableProps) {
   return (
-    <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden">
+    <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden dark:bg-gray-900 dark:outline-gray-700/70">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-slate-100">
+          <tr className="border-b border-slate-100 dark:border-gray-700/70">
             <SortableHeader
               label="Name"
               field="name"
@@ -62,7 +62,7 @@ function AccountsTable({
               currentDirection={sortDirection}
               onSort={onSort}
             />
-            <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Access</th>
+            <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Access</th>
             <SortableHeader
               label="Created"
               field="created_at"
@@ -70,7 +70,7 @@ function AccountsTable({
               currentDirection={sortDirection}
               onSort={onSort}
             />
-            <th className="text-right px-4 py-2.5 text-gray-500 font-medium">Actions</th>
+            <th className="text-right px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -158,8 +158,8 @@ const AccountsList: React.FC = () => {
   if (loading && accounts.length === 0)
     return (
       <div className="flex flex-col items-center space-y-4 py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b border-gray-500"></div>
-        <Text className="text-gray-500">Loading accounts...</Text>
+        <div className="animate-spin rounded-full h-8 w-8 border-b border-gray-500 dark:border-gray-400"></div>
+        <Text className="text-gray-500 dark:text-gray-400">Loading accounts...</Text>
       </div>
     );
 
@@ -182,7 +182,9 @@ const AccountsList: React.FC = () => {
       />
       {accounts.length === 0 ? (
         <div className="text-center py-12">
-          <Text className="text-gray-500">{search ? "No accounts match." : "No accounts found."}</Text>
+          <Text className="text-gray-500 dark:text-gray-400">
+            {search ? "No accounts match." : "No accounts found."}
+          </Text>
         </div>
       ) : (
         <>

--- a/web_src/src/pages/admin/AdminLayout.tsx
+++ b/web_src/src/pages/admin/AdminLayout.tsx
@@ -10,10 +10,10 @@ const AdminLayout: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-slate-100">
+      <div className="min-h-screen flex items-center justify-center bg-slate-100 dark:bg-gray-950">
         <div className="flex flex-col items-center space-y-4">
-          <div className="animate-spin rounded-full h-8 w-8 border-b border-gray-500"></div>
-          <Text className="text-gray-500">Loading...</Text>
+          <div className="animate-spin rounded-full h-8 w-8 border-b border-gray-500 dark:border-gray-400"></div>
+          <Text className="text-gray-500 dark:text-gray-400">Loading...</Text>
         </div>
       </div>
     );
@@ -25,26 +25,28 @@ const AdminLayout: React.FC = () => {
 
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     `flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded transition-colors ${
-      isActive ? "bg-slate-200/80 text-gray-800" : "text-gray-500 hover:text-gray-800 hover:bg-slate-100"
+      isActive
+        ? "bg-slate-200/80 text-gray-800 dark:bg-gray-800 dark:text-gray-100"
+        : "text-gray-500 hover:text-gray-800 hover:bg-slate-100 dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-800"
     }`;
 
   return (
-    <div className="min-h-screen flex flex-col bg-slate-100">
-      <header className="bg-white border-b border-slate-950/15">
+    <div className="min-h-screen flex flex-col bg-slate-100 dark:bg-gray-950">
+      <header className="bg-white border-b border-slate-950/15 dark:bg-gray-900 dark:border-gray-700/70">
         <div className="px-4 h-12 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Link to="/" className="flex items-center">
-              <img src={SuperplaneLogo} alt="SuperPlane" className="w-7 h-7" />
+              <img src={SuperplaneLogo} alt="SuperPlane" className="w-7 h-7 dark:brightness-0 dark:invert" />
             </Link>
 
-            <div className="h-5 w-px bg-slate-200" />
+            <div className="h-5 w-px bg-slate-200 dark:bg-gray-700" />
 
             <div className="flex items-center gap-1.5">
-              <Shield size={14} className="text-amber-600" />
-              <span className="text-sm font-medium text-gray-800">Installation Admin</span>
+              <Shield size={14} className="text-amber-600 dark:text-amber-400" />
+              <span className="text-sm font-medium text-gray-800 dark:text-gray-100">Installation Admin</span>
             </div>
 
-            <div className="h-5 w-px bg-slate-200" />
+            <div className="h-5 w-px bg-slate-200 dark:bg-gray-700" />
 
             <nav className="flex items-center gap-1">
               <NavLink to="/admin" end className={navLinkClass}>
@@ -67,10 +69,10 @@ const AdminLayout: React.FC = () => {
           </div>
 
           <div className="flex items-center gap-4">
-            <span className="text-sm text-gray-500">{account.name}</span>
+            <span className="text-sm text-gray-500 dark:text-gray-400">{account.name}</span>
             <Link
               to="/"
-              className="group flex items-center gap-1 text-sm font-medium text-gray-500 hover:text-gray-800 transition-colors"
+              className="group flex items-center gap-1 text-sm font-medium text-gray-500 hover:text-gray-800 transition-colors dark:text-gray-400 dark:hover:text-gray-100"
             >
               <ArrowLeft size={14} className="transition-transform group-hover:-translate-x-0.5" />
               Back to app

--- a/web_src/src/pages/admin/AdminPagination.tsx
+++ b/web_src/src/pages/admin/AdminPagination.tsx
@@ -15,7 +15,7 @@ const AdminPagination: React.FC<AdminPaginationProps> = ({ offset, total, pageSi
   if (totalPages <= 1) return null;
 
   return (
-    <div className="flex items-center justify-between mt-4 text-sm text-gray-500">
+    <div className="flex items-center justify-between mt-4 text-sm text-gray-500 dark:text-gray-400">
       <Text>
         Showing {offset + 1}–{Math.min(offset + pageSize, total)} of {total}
       </Text>
@@ -23,14 +23,14 @@ const AdminPagination: React.FC<AdminPaginationProps> = ({ offset, total, pageSi
         <button
           onClick={() => onPageChange(offset - pageSize)}
           disabled={offset === 0}
-          className="px-3 py-1 rounded border border-slate-200 bg-white hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed text-xs"
+          className="px-3 py-1 rounded border border-slate-200 bg-white hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed text-xs dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
         >
           Previous
         </button>
         <button
           onClick={() => onPageChange(offset + pageSize)}
           disabled={currentPage >= totalPages}
-          className="px-3 py-1 rounded border border-slate-200 bg-white hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed text-xs"
+          className="px-3 py-1 rounded border border-slate-200 bg-white hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed text-xs dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
         >
           Next
         </button>

--- a/web_src/src/pages/admin/AdminSearchHeader.tsx
+++ b/web_src/src/pages/admin/AdminSearchHeader.tsx
@@ -20,18 +20,18 @@ const AdminSearchHeader: React.FC<AdminSearchHeaderProps> = ({
 }) => (
   <div className="flex items-center justify-between mb-4">
     <div>
-      <Heading className="text-gray-800 mb-0.5">{title}</Heading>
-      <Text className="text-gray-500 text-sm">{subtitle}</Text>
+      <Heading className="text-gray-800 mb-0.5 dark:text-gray-100">{title}</Heading>
+      <Text className="text-gray-500 text-sm dark:text-gray-400">{subtitle}</Text>
     </div>
 
     <div className="relative w-72">
-      <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+      <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
       <input
         type="text"
         placeholder={placeholder}
         value={search}
         onChange={(e) => onSearchChange(e.target.value)}
-        className="w-full pl-9 pr-3 py-1.5 text-sm border border-slate-200 rounded-md bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+        className="w-full pl-9 pr-3 py-1.5 text-sm border border-slate-200 rounded-md bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
       />
     </div>
   </div>

--- a/web_src/src/pages/admin/ConfirmAdminDialog.tsx
+++ b/web_src/src/pages/admin/ConfirmAdminDialog.tsx
@@ -22,22 +22,28 @@ const ConfirmAdminDialog: React.FC<ConfirmAdminDialogProps> = ({
 }) => (
   <Dialog open={open} onClose={onClose} size="md">
     <div className="flex items-center gap-3 mb-2">
-      <div className={`p-2 rounded-full ${isPromoting ? "bg-amber-100 text-amber-600" : "bg-red-100 text-red-600"}`}>
+      <div
+        className={`p-2 rounded-full ${
+          isPromoting
+            ? "bg-amber-100 text-amber-600 dark:bg-amber-950/40 dark:text-amber-300"
+            : "bg-red-100 text-red-600 dark:bg-red-950/40 dark:text-red-300"
+        }`}
+      >
         <AlertTriangle size={20} />
       </div>
-      <DialogTitle className="text-gray-800">
+      <DialogTitle className="text-gray-800 dark:text-gray-100">
         {isPromoting ? "Promote to Installation Admin" : "Remove Installation Admin"}
       </DialogTitle>
     </div>
 
-    <DialogDescription className="text-sm text-gray-600 mt-2 space-y-2">
+    <DialogDescription className="text-sm text-gray-600 mt-2 space-y-2 dark:text-gray-400">
       {isPromoting ? (
         <>
           <p>
             You are about to grant <strong>{accountName}</strong> ({accountEmail}) installation admin access.
           </p>
           <p>This will allow them to:</p>
-          <ul className="list-disc pl-5 space-y-1 text-gray-500">
+          <ul className="list-disc pl-5 space-y-1 text-gray-500 dark:text-gray-400">
             <li>View all organizations and their data across this installation</li>
             <li>Impersonate any user in any organization</li>
             <li>Promote or demote other installation admins</li>

--- a/web_src/src/pages/admin/InstallationSettings.tsx
+++ b/web_src/src/pages/admin/InstallationSettings.tsx
@@ -199,12 +199,14 @@ const SignupAccessSection = ({
   const effectiveEnabled = enabled && !blockedByEnvironment;
 
   return (
-    <section className="border-t border-slate-200 py-6">
+    <section className="border-t border-slate-200 py-6 dark:border-gray-700/70">
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
         <div className="max-w-2xl">
-          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Signup access</p>
-          <h2 className="mt-1 text-base font-semibold text-gray-900">Public signups</h2>
-          <Text className="mt-2 text-sm text-gray-600">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Signup access
+          </p>
+          <h2 className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100">Public signups</h2>
+          <Text className="mt-2 text-sm text-gray-600 dark:text-gray-400">
             Control whether visitors can create new accounts from the signup page. Invite links can still create
             accounts while public signups are closed.
           </Text>
@@ -212,8 +214,12 @@ const SignupAccessSection = ({
 
         <div className="flex items-center justify-between gap-4 lg:justify-end">
           <div className="space-y-1 lg:text-right">
-            <p className="text-sm font-medium text-gray-900">{effectiveEnabled ? "Signups open" : "Signups closed"}</p>
-            <Text className="text-xs text-gray-500">{getSignupAccessDescription(enabled, blockedByEnvironment)}</Text>
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+              {effectiveEnabled ? "Signups open" : "Signups closed"}
+            </p>
+            <Text className="text-xs text-gray-500 dark:text-gray-400">
+              {getSignupAccessDescription(enabled, blockedByEnvironment)}
+            </Text>
           </div>
           <Switch
             data-testid="installation-signups-switch"
@@ -233,7 +239,7 @@ const SignupAccessSection = ({
         >
           {saving ? "Saving..." : "Save signup settings"}
         </Button>
-        <Text className="text-xs text-gray-500">
+        <Text className="text-xs text-gray-500 dark:text-gray-400">
           {blockedByEnvironment
             ? "`BLOCK_SIGNUP` is active, so public signups remain closed until the environment override is removed."
             : "When closed, /signup collects waitlist emails instead of creating accounts."}
@@ -245,14 +251,14 @@ const SignupAccessSection = ({
 
 const PolicyList = ({ title, items, overridden, emptyMessage }: PolicyListProps) => (
   <div className="min-w-0">
-    <h3 className="text-sm font-medium text-gray-900">{title}</h3>
-    <Text className="mt-1 text-xs text-gray-500">
+    <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">{title}</h3>
+    <Text className="mt-1 text-xs text-gray-500 dark:text-gray-400">
       {overridden ? "Overridden by environment." : "Resolved from installation settings."}
     </Text>
     {items.length === 0 ? (
-      <Text className="mt-3 text-sm text-gray-500">{emptyMessage}</Text>
+      <Text className="mt-3 text-sm text-gray-500 dark:text-gray-400">{emptyMessage}</Text>
     ) : (
-      <ul className="mt-3 max-h-40 space-y-1 overflow-auto font-mono text-xs text-gray-700">
+      <ul className="mt-3 max-h-40 space-y-1 overflow-auto font-mono text-xs text-gray-700 dark:text-gray-300">
         {items.map((item) => (
           <li key={item}>{item}</li>
         ))}
@@ -272,12 +278,12 @@ const NetworkPolicySection = ({
   onChange,
   onSave,
 }: NetworkPolicySectionProps) => (
-  <section className="border-t border-slate-200 py-6">
+  <section className="border-t border-slate-200 py-6 dark:border-gray-700/70">
     <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
       <div className="max-w-2xl">
-        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Network policy</p>
-        <h2 className="mt-1 text-base font-semibold text-gray-900">Private network access</h2>
-        <Text className="mt-2 text-sm text-gray-600">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Network policy</p>
+        <h2 className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100">Private network access</h2>
+        <Text className="mt-2 text-sm text-gray-600 dark:text-gray-400">
           Control whether integrations, components, and triggers can reach internal Kubernetes DNS names or private IP
           ranges.
         </Text>
@@ -285,10 +291,10 @@ const NetworkPolicySection = ({
 
       <div className="flex items-center justify-between gap-4 lg:justify-end">
         <div className="space-y-1 lg:text-right">
-          <p className="text-sm font-medium text-gray-900">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
             {allowPrivateNetworkAccess ? "Private access enabled" : "Private access blocked"}
           </p>
-          <Text className="text-xs text-gray-500">
+          <Text className="text-xs text-gray-500 dark:text-gray-400">
             {allowPrivateNetworkAccess ? "Internal hosts can be reached." : "SSRF safeguards remain active."}
           </Text>
         </div>
@@ -320,12 +326,12 @@ const NetworkPolicySection = ({
         {saving ? "Saving..." : "Save network settings"}
       </Button>
       {blockedHTTPHostsOverridden || privateIPRangesOverridden ? (
-        <Text className="text-xs text-amber-700">
+        <Text className="text-xs text-amber-700 dark:text-amber-400">
           Environment overrides are active. `BLOCKED_HTTP_HOSTS` and `BLOCKED_PRIVATE_IP_RANGES` take precedence over
           this toggle.
         </Text>
       ) : (
-        <Text className="text-xs text-gray-500">
+        <Text className="text-xs text-gray-500 dark:text-gray-400">
           Changes apply without a restart and may take a few seconds to propagate across all app instances.
         </Text>
       )}
@@ -378,7 +384,9 @@ const SMTPFields = ({ form, passwordConfigured, onFieldChange }: SMTPFieldsProps
           />
         </InputGroup>
         {passwordConfigured ? (
-          <Text className="mt-1 text-xs text-gray-500">Leave blank to keep the existing SMTP password.</Text>
+          <Text className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Leave blank to keep the existing SMTP password.
+          </Text>
         ) : null}
       </div>
 
@@ -408,8 +416,8 @@ const SMTPFields = ({ form, passwordConfigured, onFieldChange }: SMTPFieldsProps
 
     <div className="flex items-center justify-between gap-4 pt-2">
       <div>
-        <p className="text-sm font-medium text-gray-900">Use TLS (STARTTLS)</p>
-        <Text className="mt-1 text-xs text-gray-500">
+        <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Use TLS (STARTTLS)</p>
+        <Text className="mt-1 text-xs text-gray-500 dark:text-gray-400">
           Enable transport encryption when connecting to the SMTP server.
         </Text>
       </div>
@@ -423,20 +431,22 @@ const SMTPFields = ({ form, passwordConfigured, onFieldChange }: SMTPFieldsProps
 );
 
 const SMTPSection = ({ form, hasChanges, passwordConfigured, saving, onFieldChange, onSave }: SMTPSectionProps) => (
-  <section className="border-t border-slate-200 py-6">
+  <section className="border-t border-slate-200 py-6 dark:border-gray-700/70">
     <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
       <div className="max-w-2xl">
-        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Email delivery</p>
-        <h2 className="mt-1 text-base font-semibold text-gray-900">SMTP configuration</h2>
-        <Text className="mt-2 text-sm text-gray-600">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Email delivery</p>
+        <h2 className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100">SMTP configuration</h2>
+        <Text className="mt-2 text-sm text-gray-600 dark:text-gray-400">
           Manage the SMTP credentials used for installation-wide notifications and emails.
         </Text>
       </div>
 
       <div className="flex items-center justify-between gap-4 lg:justify-end">
         <div className="space-y-1 lg:text-right">
-          <p className="text-sm font-medium text-gray-900">{form.enabled ? "SMTP enabled" : "SMTP disabled"}</p>
-          <Text className="text-xs text-gray-500">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+            {form.enabled ? "SMTP enabled" : "SMTP disabled"}
+          </p>
+          <Text className="text-xs text-gray-500 dark:text-gray-400">
             {form.enabled ? "Emails can be sent from this instance." : "Notification email delivery is off."}
           </Text>
         </div>
@@ -451,7 +461,7 @@ const SMTPSection = ({ form, hasChanges, passwordConfigured, saving, onFieldChan
     {form.enabled ? (
       <SMTPFields form={form} passwordConfigured={passwordConfigured} onFieldChange={onFieldChange} />
     ) : (
-      <Text className="mt-5 text-sm text-gray-500">
+      <Text className="mt-5 text-sm text-gray-500 dark:text-gray-400">
         Enable SMTP to configure the installation-wide email provider used by SuperPlane notifications.
       </Text>
     )}
@@ -460,7 +470,9 @@ const SMTPSection = ({ form, hasChanges, passwordConfigured, saving, onFieldChan
       <Button type="button" data-testid="installation-smtp-save" onClick={onSave} disabled={saving || !hasChanges}>
         {saving ? "Saving..." : form.enabled ? "Save SMTP settings" : "Disable SMTP"}
       </Button>
-      <Text className="text-xs text-gray-500">SMTP changes apply to installation-wide email delivery.</Text>
+      <Text className="text-xs text-gray-500 dark:text-gray-400">
+        SMTP changes apply to installation-wide email delivery.
+      </Text>
     </div>
   </section>
 );
@@ -612,8 +624,8 @@ const InstallationSettings: React.FC = () => {
   if (loading && !settings) {
     return (
       <div className="flex flex-col items-center space-y-4 py-12">
-        <div className="h-8 w-8 animate-spin rounded-full border-b border-gray-500"></div>
-        <Text className="text-gray-500">Loading installation settings...</Text>
+        <div className="h-8 w-8 animate-spin rounded-full border-b border-gray-500 dark:border-gray-400"></div>
+        <Text className="text-gray-500 dark:text-gray-400">Loading installation settings...</Text>
       </div>
     );
   }
@@ -624,13 +636,13 @@ const InstallationSettings: React.FC = () => {
   return (
     <div>
       <div className="pb-2">
-        <h1 className="text-xl font-semibold text-gray-900">Installation Settings</h1>
-        <Text className="mt-1 text-sm text-gray-500">
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Installation Settings</h1>
+        <Text className="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Configure installation-wide network policy and email delivery for this SuperPlane instance.
         </Text>
       </div>
 
-      <div className="mt-5 bg-white px-6">
+      <div className="mt-5 bg-white px-6 dark:bg-gray-900">
         {showSignupAccessSection ? (
           <SignupAccessSection
             enabled={signupsEnabled}

--- a/web_src/src/pages/admin/OrgCanvasesTable.tsx
+++ b/web_src/src/pages/admin/OrgCanvasesTable.tsx
@@ -49,42 +49,42 @@ export function OrgCanvasesTable({ orgId }: { orgId: string }) {
     <div className="mb-8">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <Palette size={16} className="text-gray-600" />
-          <Heading level={2} className="text-gray-800 text-base">
+          <Palette size={16} className="text-gray-600 dark:text-gray-400" />
+          <Heading level={2} className="text-gray-800 text-base dark:text-gray-100">
             Canvases ({total})
           </Heading>
         </div>
         <div className="relative w-56">
-          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
           <input
             type="text"
             placeholder="Search canvases..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full pl-9 pr-3 py-1.5 text-sm border border-slate-200 rounded-md bg-white focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="w-full pl-9 pr-3 py-1.5 text-sm border border-slate-200 rounded-md bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
       </div>
 
       {canvases.length === 0 ? (
-        <Text className="text-gray-500 text-sm">
+        <Text className="text-gray-500 text-sm dark:text-gray-400">
           {search ? "No canvases match your search." : "No canvases in this organization."}
         </Text>
       ) : (
         <>
-          <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden">
+          <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden dark:bg-gray-900 dark:outline-gray-700/70">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-slate-100">
-                  <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Name</th>
-                  <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Description</th>
+                <tr className="border-b border-slate-100 dark:border-gray-700/70">
+                  <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Name</th>
+                  <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Description</th>
                 </tr>
               </thead>
               <tbody>
                 {canvases.map((canvas) => (
-                  <tr key={canvas.id} className="border-b border-slate-50 last:border-0">
-                    <td className="px-4 py-2.5 text-gray-800 font-medium">{canvas.name}</td>
-                    <td className="px-4 py-2.5 text-gray-500">{canvas.description || "—"}</td>
+                  <tr key={canvas.id} className="border-b border-slate-50 last:border-0 dark:border-gray-800/70">
+                    <td className="px-4 py-2.5 text-gray-800 font-medium dark:text-gray-100">{canvas.name}</td>
+                    <td className="px-4 py-2.5 text-gray-500 dark:text-gray-400">{canvas.description || "—"}</td>
                   </tr>
                 ))}
               </tbody>

--- a/web_src/src/pages/admin/OrgExperimentalFeaturesTable.tsx
+++ b/web_src/src/pages/admin/OrgExperimentalFeaturesTable.tsx
@@ -36,24 +36,26 @@ export function OrgExperimentalFeaturesTable({ orgId }: { orgId: string }) {
   return (
     <div className="mb-8">
       <div className="flex items-center gap-2 mb-3">
-        <FlaskConical size={16} className="text-gray-600" />
-        <Heading level={2} className="text-gray-800 text-base">
+        <FlaskConical size={16} className="text-gray-600 dark:text-gray-400" />
+        <Heading level={2} className="text-gray-800 text-base dark:text-gray-100">
           Experimental Features ({visible.length})
         </Heading>
       </div>
 
       {isLoading ? (
-        <Text className="text-gray-500 text-sm">Loading...</Text>
+        <Text className="text-gray-500 text-sm dark:text-gray-400">Loading...</Text>
       ) : visible.length === 0 ? (
-        <Text className="text-gray-500 text-sm">No experimental features are available right now.</Text>
+        <Text className="text-gray-500 text-sm dark:text-gray-400">
+          No experimental features are available right now.
+        </Text>
       ) : (
-        <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden">
+        <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden dark:bg-gray-900 dark:outline-gray-700/70">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-slate-100">
-                <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Feature</th>
-                <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Description</th>
-                <th className="text-right px-4 py-2.5 text-gray-500 font-medium w-32">Status</th>
+              <tr className="border-b border-slate-100 dark:border-gray-700/70">
+                <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Feature</th>
+                <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Description</th>
+                <th className="text-right px-4 py-2.5 text-gray-500 font-medium w-32 dark:text-gray-400">Status</th>
               </tr>
             </thead>
             <tbody>
@@ -61,9 +63,9 @@ export function OrgExperimentalFeaturesTable({ orgId }: { orgId: string }) {
                 const isOn = enabled.has(feature.id);
                 const isBusy = pendingId === feature.id;
                 return (
-                  <tr key={feature.id} className="border-b border-slate-50 last:border-0">
-                    <td className="px-4 py-2.5 text-gray-800 font-medium">{feature.label}</td>
-                    <td className="px-4 py-2.5 text-gray-500">{feature.description || "—"}</td>
+                  <tr key={feature.id} className="border-b border-slate-50 last:border-0 dark:border-gray-800/70">
+                    <td className="px-4 py-2.5 text-gray-800 font-medium dark:text-gray-100">{feature.label}</td>
+                    <td className="px-4 py-2.5 text-gray-500 dark:text-gray-400">{feature.description || "—"}</td>
                     <td className="px-4 py-2.5 text-right">
                       <Switch
                         checked={isOn}
@@ -80,7 +82,7 @@ export function OrgExperimentalFeaturesTable({ orgId }: { orgId: string }) {
         </div>
       )}
 
-      {error ? <Text className="text-red-600 text-sm mt-2">{error}</Text> : null}
+      {error ? <Text className="text-red-600 text-sm mt-2 dark:text-red-400">{error}</Text> : null}
     </div>
   );
 }

--- a/web_src/src/pages/admin/OrgUsersTable.tsx
+++ b/web_src/src/pages/admin/OrgUsersTable.tsx
@@ -25,12 +25,12 @@ function UserRow({ user }: { user: OrgUser }) {
   const isSelf = user.account_id === account?.id;
 
   return (
-    <tr className="border-b border-slate-50 last:border-0">
-      <td className="px-4 py-2.5 text-gray-800">{user.name}</td>
-      <td className="px-4 py-2.5 text-gray-500">{user.email || "—"}</td>
+    <tr className="border-b border-slate-50 last:border-0 dark:border-gray-800/70">
+      <td className="px-4 py-2.5 text-gray-800 dark:text-gray-100">{user.name}</td>
+      <td className="px-4 py-2.5 text-gray-500 dark:text-gray-400">{user.email || "—"}</td>
       <td className="px-4 py-2.5 text-right">
         {isSelf ? (
-          <Text className="text-xs text-gray-400">You</Text>
+          <Text className="text-xs text-gray-400 dark:text-gray-500">You</Text>
         ) : user.account_id ? (
           <Button variant="outline" size="sm" onClick={() => startImpersonation(user.account_id!)}>
             Impersonate
@@ -73,35 +73,35 @@ export function OrgUsersTable({ orgId }: { orgId: string }) {
     <div className="mb-8">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <UserIcon size={16} className="text-gray-600" />
-          <Heading level={2} className="text-gray-800 text-base">
+          <UserIcon size={16} className="text-gray-600 dark:text-gray-400" />
+          <Heading level={2} className="text-gray-800 text-base dark:text-gray-100">
             Users ({total})
           </Heading>
         </div>
         <div className="relative w-56">
-          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
           <input
             type="text"
             placeholder="Search users..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full pl-9 pr-3 py-1.5 text-sm border border-slate-200 rounded-md bg-white focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="w-full pl-9 pr-3 py-1.5 text-sm border border-slate-200 rounded-md bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
       </div>
       {users.length === 0 ? (
-        <Text className="text-gray-500 text-sm">
+        <Text className="text-gray-500 text-sm dark:text-gray-400">
           {search ? "No users match your search." : "No users in this organization."}
         </Text>
       ) : (
         <>
-          <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden">
+          <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden dark:bg-gray-900 dark:outline-gray-700/70">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-slate-100">
-                  <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Name</th>
-                  <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Email</th>
-                  <th className="text-right px-4 py-2.5 text-gray-500 font-medium">Actions</th>
+                <tr className="border-b border-slate-100 dark:border-gray-700/70">
+                  <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Name</th>
+                  <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Email</th>
+                  <th className="text-right px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Actions</th>
                 </tr>
               </thead>
               <tbody>

--- a/web_src/src/pages/admin/OrganizationDetail.tsx
+++ b/web_src/src/pages/admin/OrganizationDetail.tsx
@@ -13,7 +13,10 @@ const OrganizationDetail: React.FC = () => {
 
   return (
     <div>
-      <Link to="/admin" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-4">
+      <Link
+        to="/admin"
+        className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-4 dark:text-gray-400 dark:hover:text-gray-200"
+      >
         <ArrowLeft size={14} />
         All organizations
       </Link>

--- a/web_src/src/pages/admin/OrganizationsList.tsx
+++ b/web_src/src/pages/admin/OrganizationsList.tsx
@@ -30,10 +30,10 @@ interface OrganizationsTableProps {
 
 function OrganizationsTable({ organizations, sortBy, sortDirection, onSort }: OrganizationsTableProps) {
   return (
-    <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden">
+    <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden dark:bg-gray-900 dark:outline-gray-700/70">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-slate-100">
+          <tr className="border-b border-slate-100 dark:border-gray-700/70">
             <SortableHeader
               label="Name"
               field="name"
@@ -41,7 +41,7 @@ function OrganizationsTable({ organizations, sortBy, sortDirection, onSort }: Or
               currentDirection={sortDirection}
               onSort={onSort}
             />
-            <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Description</th>
+            <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Description</th>
             <SortableHeader
               label="Canvases"
               field="canvas_count"
@@ -67,36 +67,41 @@ function OrganizationsTable({ organizations, sortBy, sortDirection, onSort }: Or
         </thead>
         <tbody>
           {organizations.map((org) => (
-            <tr key={org.id} className="border-b border-slate-50 last:border-0 hover:bg-slate-50 transition-colors">
+            <tr
+              key={org.id}
+              className="border-b border-slate-50 last:border-0 hover:bg-slate-50 transition-colors dark:border-gray-800/70 dark:hover:bg-gray-800/50"
+            >
               <td className="px-4 py-2.5">
                 <Link
                   to={`/admin/organizations/${org.id}`}
-                  className="flex items-center gap-2 text-gray-800 hover:text-blue-600 transition-colors font-medium"
+                  className="flex items-center gap-2 text-gray-800 hover:text-blue-600 transition-colors font-medium dark:text-gray-100 dark:hover:text-blue-400"
                 >
-                  <Building size={14} className="text-gray-400 shrink-0" />
+                  <Building size={14} className="text-gray-400 shrink-0 dark:text-gray-500" />
                   {org.name || (
-                    <span className="text-gray-400 italic" title={org.id}>
+                    <span className="text-gray-400 italic dark:text-gray-500" title={org.id}>
                       {org.id.slice(0, 8)}...
                     </span>
                   )}
                 </Link>
               </td>
-              <td className="px-4 py-2.5 text-gray-500 max-w-xs truncate">
-                {org.description || <span className="text-gray-300">—</span>}
+              <td className="px-4 py-2.5 text-gray-500 max-w-xs truncate dark:text-gray-400">
+                {org.description || <span className="text-gray-300 dark:text-gray-600">—</span>}
               </td>
               <td className="px-4 py-2.5">
-                <span className="inline-flex items-center gap-1.5 text-gray-500">
+                <span className="inline-flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
                   <Palette size={13} />
                   {org.canvas_count}
                 </span>
               </td>
               <td className="px-4 py-2.5">
-                <span className="inline-flex items-center gap-1.5 text-gray-500">
+                <span className="inline-flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
                   <User size={13} />
                   {org.member_count}
                 </span>
               </td>
-              <td className="px-4 py-2.5 text-gray-400 text-xs whitespace-nowrap">{formatDate(org.created_at)}</td>
+              <td className="px-4 py-2.5 text-gray-400 text-xs whitespace-nowrap dark:text-gray-500">
+                {formatDate(org.created_at)}
+              </td>
             </tr>
           ))}
         </tbody>
@@ -157,8 +162,8 @@ const OrganizationsList: React.FC = () => {
   if (loading && organizations.length === 0) {
     return (
       <div className="flex flex-col items-center space-y-4 py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b border-gray-500"></div>
-        <Text className="text-gray-500">Loading organizations...</Text>
+        <div className="animate-spin rounded-full h-8 w-8 border-b border-gray-500 dark:border-gray-400"></div>
+        <Text className="text-gray-500 dark:text-gray-400">Loading organizations...</Text>
       </div>
     );
   }
@@ -174,7 +179,7 @@ const OrganizationsList: React.FC = () => {
       />
       {organizations.length === 0 ? (
         <div className="text-center py-12">
-          <Text className="text-gray-500">
+          <Text className="text-gray-500 dark:text-gray-400">
             {search ? "No organizations match your search." : "No organizations found."}
           </Text>
         </div>

--- a/web_src/src/pages/admin/RunnerTasks.tsx
+++ b/web_src/src/pages/admin/RunnerTasks.tsx
@@ -28,16 +28,16 @@ const REFRESH_INTERVAL_MS = 5000;
 
 const statusBadgeClass = (status: string, cancelRequested: boolean) => {
   if (cancelRequested) {
-    return "bg-amber-100 text-amber-800";
+    return "bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300";
   }
 
   switch (status) {
     case "queued":
-      return "bg-slate-100 text-slate-700";
+      return "bg-slate-100 text-slate-700 dark:bg-gray-800 dark:text-gray-300";
     case "claimed":
-      return "bg-blue-100 text-blue-800";
+      return "bg-blue-100 text-blue-800 dark:bg-blue-950/40 dark:text-blue-300";
     default:
-      return "bg-gray-100 text-gray-700";
+      return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
   }
 };
 
@@ -62,30 +62,33 @@ const RelativeTimestamp = ({ value }: { value?: string }) => (
   <Timestamp
     date={value}
     display="relative"
-    className="text-gray-600 whitespace-nowrap"
-    fallback={<span className="text-gray-400">—</span>}
+    className="text-gray-600 whitespace-nowrap dark:text-gray-400"
+    fallback={<span className="text-gray-400 dark:text-gray-500">—</span>}
   />
 );
 
 const RunnerTasksTable = ({ tasks }: { tasks: RunnerTask[] }) => (
-  <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden">
+  <div className="bg-white rounded-md shadow-sm outline outline-slate-950/10 overflow-hidden dark:bg-gray-900 dark:outline-gray-700/70">
     <table className="w-full text-sm">
       <thead>
-        <tr className="border-b border-slate-100">
-          <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Task ID</th>
-          <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Status</th>
-          <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Fleet</th>
-          <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Runner</th>
-          <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Execution</th>
-          <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Created</th>
-          <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Claimed</th>
-          <th className="text-left px-4 py-2.5 text-gray-500 font-medium">Lease until</th>
+        <tr className="border-b border-slate-100 dark:border-gray-700/70">
+          <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Task ID</th>
+          <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Status</th>
+          <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Fleet</th>
+          <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Runner</th>
+          <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Execution</th>
+          <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Created</th>
+          <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Claimed</th>
+          <th className="text-left px-4 py-2.5 text-gray-500 font-medium dark:text-gray-400">Lease until</th>
         </tr>
       </thead>
       <tbody>
         {tasks.map((task) => (
-          <tr key={task.id} className="border-b border-slate-50 last:border-0 hover:bg-slate-50 transition-colors">
-            <td className="px-4 py-2.5 font-mono text-xs text-gray-800" title={task.id}>
+          <tr
+            key={task.id}
+            className="border-b border-slate-50 last:border-0 hover:bg-slate-50 transition-colors dark:border-gray-800/70 dark:hover:bg-gray-800/50"
+          >
+            <td className="px-4 py-2.5 font-mono text-xs text-gray-800 dark:text-gray-100" title={task.id}>
               {task.id}
             </td>
             <td className="px-4 py-2.5">
@@ -95,9 +98,11 @@ const RunnerTasksTable = ({ tasks }: { tasks: RunnerTask[] }) => (
                 {formatStatus(task.status, task.cancel_requested ?? false)}
               </span>
             </td>
-            <td className="px-4 py-2.5 font-mono text-xs text-gray-700">{task.fleet_id || "—"}</td>
-            <td className="px-4 py-2.5 font-mono text-xs text-gray-700">{task.runner_id?.trim() || "—"}</td>
-            <td className="px-4 py-2.5 text-gray-700">{formatExecutionMode(task)}</td>
+            <td className="px-4 py-2.5 font-mono text-xs text-gray-700 dark:text-gray-300">{task.fleet_id || "—"}</td>
+            <td className="px-4 py-2.5 font-mono text-xs text-gray-700 dark:text-gray-300">
+              {task.runner_id?.trim() || "—"}
+            </td>
+            <td className="px-4 py-2.5 text-gray-700 dark:text-gray-300">{formatExecutionMode(task)}</td>
             <td className="px-4 py-2.5">
               <RelativeTimestamp value={task.created_at} />
             </td>
@@ -157,8 +162,8 @@ const RunnerTasks: React.FC = () => {
   if (loading && configured === null) {
     return (
       <div className="flex flex-col items-center space-y-4 py-12">
-        <div className="h-8 w-8 animate-spin rounded-full border-b border-gray-500"></div>
-        <Text className="text-gray-500">Loading runner tasks...</Text>
+        <div className="h-8 w-8 animate-spin rounded-full border-b border-gray-500 dark:border-gray-400"></div>
+        <Text className="text-gray-500 dark:text-gray-400">Loading runner tasks...</Text>
       </div>
     );
   }
@@ -167,30 +172,35 @@ const RunnerTasks: React.FC = () => {
     <div className="space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="text-xl font-semibold text-gray-900">Runner Tasks</h1>
-          <Text className="mt-1 text-sm text-gray-500">
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Runner Tasks</h1>
+          <Text className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Active tasks on the task broker (queued or claimed). Refreshes every {REFRESH_INTERVAL_MS / 1000} seconds.
           </Text>
         </div>
-        <Text className="text-xs text-gray-500">
+        <Text className="text-xs text-gray-500 dark:text-gray-400">
           {tasks.length} active task{tasks.length === 1 ? "" : "s"}
         </Text>
       </div>
 
       {!configured ? (
-        <div className="rounded-xl border border-dashed border-slate-300 bg-white p-8 text-center shadow-sm">
-          <Terminal size={24} className="mx-auto text-gray-400" />
-          <Text className="mt-3 text-sm text-gray-600">
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white p-8 text-center shadow-sm dark:border-gray-700 dark:bg-gray-900">
+          <Terminal size={24} className="mx-auto text-gray-400 dark:text-gray-500" />
+          <Text className="mt-3 text-sm text-gray-600 dark:text-gray-400">
             Runner task broker is not configured. Set{" "}
-            <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs">TASK_BROKER_BASE_URL</code> and{" "}
-            <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs">TASK_BROKER_AUTH_TOKEN</code> on the
-            app server.
+            <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs dark:bg-gray-800 dark:text-gray-200">
+              TASK_BROKER_BASE_URL
+            </code>{" "}
+            and{" "}
+            <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs dark:bg-gray-800 dark:text-gray-200">
+              TASK_BROKER_AUTH_TOKEN
+            </code>{" "}
+            on the app server.
           </Text>
         </div>
       ) : tasks.length === 0 ? (
-        <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm">
-          <Terminal size={24} className="mx-auto text-gray-400" />
-          <Text className="mt-3 text-sm text-gray-600">No active runner tasks right now.</Text>
+        <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-gray-700 dark:bg-gray-900">
+          <Terminal size={24} className="mx-auto text-gray-400 dark:text-gray-500" />
+          <Text className="mt-3 text-sm text-gray-600 dark:text-gray-400">No active runner tasks right now.</Text>
         </div>
       ) : (
         <RunnerTasksTable tasks={tasks} />

--- a/web_src/src/pages/admin/SortableHeader.tsx
+++ b/web_src/src/pages/admin/SortableHeader.tsx
@@ -26,7 +26,7 @@ export function SortableHeader<TField extends string>({
     <th className={`px-4 py-2.5 ${className}`} aria-sort={ariaSort}>
       <button
         type="button"
-        className="inline-flex w-full items-center gap-1 text-left text-gray-500 font-medium select-none hover:text-gray-700 transition-colors"
+        className="inline-flex w-full items-center gap-1 text-left text-gray-500 font-medium select-none hover:text-gray-700 transition-colors dark:text-gray-400 dark:hover:text-gray-200"
         onClick={() => onSort(field)}
       >
         <span>{label}</span>
@@ -37,7 +37,7 @@ export function SortableHeader<TField extends string>({
             <ArrowDown size={12} />
           )
         ) : (
-          <ArrowUpDown size={12} className="text-gray-300" />
+          <ArrowUpDown size={12} className="text-gray-300 dark:text-gray-600" />
         )}
       </button>
     </th>

--- a/web_src/src/pages/app/CanvasYamlDiffModal.spec.tsx
+++ b/web_src/src/pages/app/CanvasYamlDiffModal.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MultiFileDiffProps } from "@pierre/diffs/react";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
 import { CanvasYamlDiffModal } from "./CanvasYamlDiffModal";
 
 type TestMultiFileDiffProps = MultiFileDiffProps<never>;
@@ -23,13 +24,15 @@ describe("CanvasYamlDiffModal", () => {
 
   it("renders YAML diffs with neutral context rows and inline word highlights", () => {
     render(
-      <CanvasYamlDiffModal
-        open
-        onOpenChange={() => undefined}
-        liveYamlText={"name: old\nshared: same\n"}
-        draftYamlText={"name: new\nshared: same\n"}
-        filename="canvas.yaml"
-      />,
+      <ThemeProvider>
+        <CanvasYamlDiffModal
+          open
+          onOpenChange={() => undefined}
+          liveYamlText={"name: old\nshared: same\n"}
+          draftYamlText={"name: new\nshared: same\n"}
+          filename="canvas.yaml"
+        />
+      </ThemeProvider>,
     );
 
     expect(screen.getByTestId("multi-file-diff")).toBeInTheDocument();

--- a/web_src/src/pages/app/CanvasYamlDiffModal.tsx
+++ b/web_src/src/pages/app/CanvasYamlDiffModal.tsx
@@ -3,7 +3,8 @@ import { FileCode, XIcon } from "lucide-react";
 import { useCallback, useMemo } from "react";
 
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
-import { CANVAS_YAML_DIFF_OPTIONS } from "./canvasYamlDiffOptions";
+import { useTheme } from "@/contexts/useTheme";
+import { getCanvasYamlDiffOptions } from "./canvasYamlDiffOptions";
 
 export type CanvasYamlDiffModalProps = {
   open: boolean;
@@ -30,6 +31,9 @@ export function CanvasYamlDiffModal({
   liveLabel = "Live",
   draftLabel = "Draft",
 }: CanvasYamlDiffModalProps) {
+  const { resolvedTheme } = useTheme();
+  const diffOptions = useMemo(() => getCanvasYamlDiffOptions(resolvedTheme), [resolvedTheme]);
+
   const { oldFile, newFile } = useMemo(() => {
     const liveFile: FileContents = {
       name: filename,
@@ -57,19 +61,25 @@ export function CanvasYamlDiffModal({
 
       return (
         <div className="w-full">
-          <div className="flex min-h-11 items-center justify-between gap-4 border-b border-slate-200 bg-white px-4 py-2">
+          <div className="flex min-h-11 items-center justify-between gap-4 border-b border-slate-200 bg-white px-4 py-2 dark:border-gray-700/70 dark:bg-gray-900">
             <div className="flex min-w-0 items-center gap-2">
-              <FileCode className="h-4 w-4 shrink-0 text-slate-500" aria-hidden />
-              <span className="truncate font-sans text-sm font-medium text-slate-900">{filename}</span>
+              <FileCode className="h-4 w-4 shrink-0 text-slate-500 dark:text-gray-400" aria-hidden />
+              <span className="truncate font-sans text-sm font-medium text-slate-900 dark:text-gray-100">
+                {filename}
+              </span>
             </div>
             <div className="flex shrink-0 items-center gap-2 font-mono text-xs">
-              <span className="text-red-600">-{deletions}</span>
-              <span className="text-emerald-600">+{additions}</span>
+              <span className="text-red-600 dark:text-red-400">-{deletions}</span>
+              <span className="text-emerald-600 dark:text-emerald-400">+{additions}</span>
             </div>
           </div>
           <div className="grid grid-cols-2 font-mono text-xs font-semibold">
-            <div className="border-r border-slate-200 bg-red-50/70 px-4 py-1.5 text-red-700">{liveLabel}</div>
-            <div className="bg-emerald-50/70 px-4 py-1.5 text-emerald-700">{draftLabel}</div>
+            <div className="border-r border-slate-200 bg-red-50/70 px-4 py-1.5 text-red-700 dark:border-gray-700/70 dark:bg-red-950/40 dark:text-red-300">
+              {liveLabel}
+            </div>
+            <div className="bg-emerald-50/70 px-4 py-1.5 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+              {draftLabel}
+            </div>
           </div>
         </div>
       );
@@ -87,25 +97,25 @@ export function CanvasYamlDiffModal({
         <DialogTitle className="sr-only">{dialogTitle}</DialogTitle>
         <DialogDescription className="sr-only">{description}</DialogDescription>
 
-        <div className="flex min-h-0 flex-1 flex-col bg-slate-50">
-          <div className="relative flex items-center border-b border-slate-200 bg-white px-5 py-3 pr-12">
+        <div className="flex min-h-0 flex-1 flex-col bg-slate-50 dark:bg-gray-900">
+          <div className="relative flex items-center border-b border-slate-200 bg-white px-5 py-3 pr-12 dark:border-gray-700/70 dark:bg-gray-900">
             <div className="flex min-w-0 items-center gap-3">
-              <h2 className="truncate text-sm font-medium text-slate-900">{title}</h2>
+              <h2 className="truncate text-sm font-medium text-slate-900 dark:text-gray-100">{title}</h2>
             </div>
-            <DialogClose className="absolute top-1/2 right-2 flex h-6 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded leading-none hover:bg-slate-950/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none">
+            <DialogClose className="absolute top-1/2 right-2 flex h-6 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded leading-none hover:bg-slate-950/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dark:hover:bg-white/10">
               <XIcon className="h-4 w-4" />
               <span className="sr-only">Close</span>
             </DialogClose>
           </div>
 
           <div className="min-h-0 flex-1 overflow-auto">
-            <div className="min-w-[980px] border-x border-b border-slate-200 bg-white">
+            <div className="min-w-[980px] border-x border-b border-slate-200 bg-white dark:border-gray-700/70 dark:bg-gray-900">
               <MultiFileDiff
                 oldFile={oldFile}
                 newFile={newFile}
                 disableWorkerPool
                 renderCustomHeader={renderDiffHeader}
-                options={CANVAS_YAML_DIFF_OPTIONS}
+                options={diffOptions}
               />
             </div>
           </div>

--- a/web_src/src/pages/app/CanvasYamlDiffModal.tsx
+++ b/web_src/src/pages/app/CanvasYamlDiffModal.tsx
@@ -22,15 +22,36 @@ export type CanvasYamlDiffModalProps = {
 export function CanvasYamlDiffModal({
   open,
   onOpenChange,
+  dialogTitle = "Canvas YAML diff",
+  description = "Side-by-side YAML comparison between live and draft canvas versions.",
+  ...bodyProps
+}: CanvasYamlDiffModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        size="large"
+        className="flex h-[90vh] w-[94vw] max-w-[1600px] flex-col gap-0 overflow-hidden p-0"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">{dialogTitle}</DialogTitle>
+        <DialogDescription className="sr-only">{description}</DialogDescription>
+        {/* Body is only mounted by DialogContent while open, so theme/diff hooks never run when closed. */}
+        <CanvasYamlDiffBody {...bodyProps} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type CanvasYamlDiffBodyProps = Omit<CanvasYamlDiffModalProps, "open" | "onOpenChange" | "dialogTitle" | "description">;
+
+function CanvasYamlDiffBody({
   liveYamlText,
   draftYamlText,
   filename,
   title = "Show Diff",
-  dialogTitle = "Canvas YAML diff",
-  description = "Side-by-side YAML comparison between live and draft canvas versions.",
   liveLabel = "Live",
   draftLabel = "Draft",
-}: CanvasYamlDiffModalProps) {
+}: CanvasYamlDiffBodyProps) {
   const { resolvedTheme } = useTheme();
   const diffOptions = useMemo(() => getCanvasYamlDiffOptions(resolvedTheme), [resolvedTheme]);
 
@@ -88,39 +109,28 @@ export function CanvasYamlDiffModal({
   );
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        size="large"
-        className="flex h-[90vh] w-[94vw] max-w-[1600px] flex-col gap-0 overflow-hidden p-0"
-        showCloseButton={false}
-      >
-        <DialogTitle className="sr-only">{dialogTitle}</DialogTitle>
-        <DialogDescription className="sr-only">{description}</DialogDescription>
-
-        <div className="flex min-h-0 flex-1 flex-col bg-slate-50 dark:bg-gray-900">
-          <div className="relative flex items-center border-b border-slate-200 bg-white px-5 py-3 pr-12 dark:border-gray-700/70 dark:bg-gray-900">
-            <div className="flex min-w-0 items-center gap-3">
-              <h2 className="truncate text-sm font-medium text-slate-900 dark:text-gray-100">{title}</h2>
-            </div>
-            <DialogClose className="absolute top-1/2 right-2 flex h-6 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded leading-none hover:bg-slate-950/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dark:hover:bg-white/10">
-              <XIcon className="h-4 w-4" />
-              <span className="sr-only">Close</span>
-            </DialogClose>
-          </div>
-
-          <div className="min-h-0 flex-1 overflow-auto">
-            <div className="min-w-[980px] border-x border-b border-slate-200 bg-white dark:border-gray-700/70 dark:bg-gray-900">
-              <MultiFileDiff
-                oldFile={oldFile}
-                newFile={newFile}
-                disableWorkerPool
-                renderCustomHeader={renderDiffHeader}
-                options={diffOptions}
-              />
-            </div>
-          </div>
+    <div className="flex min-h-0 flex-1 flex-col bg-slate-50 dark:bg-gray-900">
+      <div className="relative flex items-center border-b border-slate-200 bg-white px-5 py-3 pr-12 dark:border-gray-700/70 dark:bg-gray-900">
+        <div className="flex min-w-0 items-center gap-3">
+          <h2 className="truncate text-sm font-medium text-slate-900 dark:text-gray-100">{title}</h2>
         </div>
-      </DialogContent>
-    </Dialog>
+        <DialogClose className="absolute top-1/2 right-2 flex h-6 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded leading-none hover:bg-slate-950/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dark:hover:bg-white/10">
+          <XIcon className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogClose>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="min-w-[980px] border-x border-b border-slate-200 bg-white dark:border-gray-700/70 dark:bg-gray-900">
+          <MultiFileDiff
+            oldFile={oldFile}
+            newFile={newFile}
+            disableWorkerPool
+            renderCustomHeader={renderDiffHeader}
+            options={diffOptions}
+          />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/web_src/src/pages/app/canvasYamlDiffOptions.ts
+++ b/web_src/src/pages/app/canvasYamlDiffOptions.ts
@@ -1,4 +1,7 @@
-const CANVAS_DIFF_UNSAFE_CSS = `
+import type { ResolvedTheme } from "@/lib/themePreference";
+import { DARK_BASE_BG_HEX } from "@/lib/darkThemeSurfaces";
+
+const LIGHT_DIFF_CSS = `
   :host {
     display: block;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -31,15 +34,50 @@ const CANVAS_DIFF_UNSAFE_CSS = `
   }
 `;
 
-export const CANVAS_YAML_DIFF_OPTIONS = {
-  theme: "github-light",
-  diffStyle: "split",
-  diffIndicators: "classic",
-  hunkSeparators: "line-info",
-  lineDiffType: "word",
-  overflow: "wrap",
-  stickyHeader: true,
-  tokenizeMaxLineLength: 1_000,
-  parseDiffOptions: { context: 6 },
-  unsafeCSS: CANVAS_DIFF_UNSAFE_CSS,
-} as const;
+const DARK_DIFF_CSS = `
+  :host {
+    display: block;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 12px;
+    line-height: 18px;
+    --diffs-bg-context-override: ${DARK_BASE_BG_HEX};
+    --diffs-bg-context-gutter-override: ${DARK_BASE_BG_HEX};
+    --diffs-bg-deletion-override: #3f1d1d;
+    --diffs-bg-addition-override: #14311f;
+    --diffs-bg-deletion-emphasis-override: #5b2626;
+    --diffs-bg-addition-emphasis-override: #1c4a2c;
+  }
+
+  [data-line-type="context"],
+  [data-line-type="context-expanded"] {
+    --diffs-line-bg: ${DARK_BASE_BG_HEX};
+    --diffs-computed-diff-line-bg: ${DARK_BASE_BG_HEX};
+    --diffs-computed-selected-line-bg: ${DARK_BASE_BG_HEX};
+  }
+
+  [data-diffs-header] {
+    border-bottom: 1px solid rgb(55 65 81);
+    background: ${DARK_BASE_BG_HEX};
+    z-index: 5;
+  }
+
+  [data-diffs-header="custom"] {
+    display: block;
+    padding: 0;
+  }
+`;
+
+export const getCanvasYamlDiffOptions = (resolvedTheme: ResolvedTheme) =>
+  ({
+    theme: resolvedTheme === "dark" ? "github-dark" : "github-light",
+    themeType: resolvedTheme === "dark" ? "dark" : "light",
+    diffStyle: "split",
+    diffIndicators: "classic",
+    hunkSeparators: "line-info",
+    lineDiffType: "word",
+    overflow: "wrap",
+    stickyHeader: true,
+    tokenizeMaxLineLength: 1_000,
+    parseDiffOptions: { context: 6 },
+    unsafeCSS: resolvedTheme === "dark" ? DARK_DIFF_CSS : LIGHT_DIFF_CSS,
+  }) as const;

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -102,14 +102,17 @@ const getAuthErrorMessage = (authError: string | null, signupUnavailableReason: 
 };
 
 const LastUsedHint: React.FC<{ label: string }> = ({ label }) => (
-  <p className="mt-2 text-center text-xs text-gray-500">You used {label} to log in last time</p>
+  <p className="mt-2 text-center text-xs text-gray-500 dark:text-gray-400">You used {label} to log in last time</p>
 );
 
 const ProductUpdatesOptIn: React.FC<{
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
 }> = ({ checked, onCheckedChange }) => (
-  <label htmlFor="signup-product-updates" className="flex cursor-pointer items-start gap-2 text-sm text-gray-700">
+  <label
+    htmlFor="signup-product-updates"
+    className="flex cursor-pointer items-start gap-2 text-sm text-gray-700 dark:text-gray-300"
+  >
     <Checkbox
       id="signup-product-updates"
       checked={checked}
@@ -121,7 +124,7 @@ const ProductUpdatesOptIn: React.FC<{
 );
 
 const SignupClosedNotice: React.FC = () => (
-  <p className="text-left text-sm leading-6 text-gray-600">
+  <p className="text-left text-sm leading-6 text-gray-600 dark:text-gray-400">
     This installation is not accepting new account signups right now. Contact your SuperPlane administrator if you need
     access.
   </p>
@@ -674,19 +677,19 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-400 flex items-center justify-center px-4 py-10">
-      <div className="max-w-sm w-full rounded-3xl bg-white p-8 shadow-sm outline outline-gray-950/10 dark:bg-gray-900">
+    <div className="min-h-screen bg-gray-400 flex items-center justify-center px-4 py-10 dark:bg-gray-950">
+      <div className="max-w-sm w-full rounded-3xl bg-white p-8 shadow-sm outline outline-gray-950/10 dark:bg-gray-900 dark:outline-gray-700/70">
         <div className="text-center">
-          <img src={superplaneLogo} alt="SuperPlane logo" className="mx-auto h-8 w-8" />
-          <h1 className="mt-2 !text-lg font-medium text-gray-900">{getHeading()}</h1>
-          <p className="mt-1 text-sm text-gray-600">{getSubheading()}</p>
+          <img src={superplaneLogo} alt="SuperPlane logo" className="mx-auto h-8 w-8 dark:brightness-0 dark:invert" />
+          <h1 className="mt-2 !text-lg font-medium text-gray-900 dark:text-gray-100">{getHeading()}</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">{getSubheading()}</p>
         </div>
 
         <div className="pt-6">
-          {configLoading && <p className="text-sm text-gray-500">Loading...</p>}
+          {configLoading && <p className="text-sm text-gray-500 dark:text-gray-400">Loading...</p>}
 
           {configError && (
-            <div className="mb-4 rounded-md border border-red-300 bg-white px-3 py-1 text-sm text-red-500">
+            <div className="mb-4 rounded-md border border-red-300 bg-white px-3 py-1 text-sm text-red-500 dark:border-red-500/40 dark:bg-red-950/40 dark:text-red-300">
               {configError}
             </div>
           )}
@@ -695,11 +698,11 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
           {!configLoading && showSignupClosedNotice && <SignupClosedNotice />}
 
           {!configLoading && !isSignupMode && !hasAnyFormMethod && (
-            <p className="text-sm text-gray-500">No login methods are configured.</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">No login methods are configured.</p>
           )}
 
           {!configLoading && visibleFormError && (
-            <div className="mb-4 rounded-md border border-red-300 bg-white px-3 py-1 text-sm text-red-500">
+            <div className="mb-4 rounded-md border border-red-300 bg-white px-3 py-1 text-sm text-red-500 dark:border-red-500/40 dark:bg-red-950/40 dark:text-red-300">
               {visibleFormError}
             </div>
           )}
@@ -757,7 +760,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
                 <button
                   type="button"
                   onClick={handleMagicCodeBack}
-                  className="text-sm text-gray-500 underline underline-offset-2"
+                  className="text-sm text-gray-500 underline underline-offset-2 dark:text-gray-400"
                 >
                   Use a different email
                 </button>
@@ -899,7 +902,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
                     setShowPasswordLogin(true);
                     setFormError(null);
                   }}
-                  className="text-sm text-gray-500 underline underline-offset-2"
+                  className="text-sm text-gray-500 underline underline-offset-2 dark:text-gray-400"
                 >
                   Sign in with password instead
                 </button>
@@ -918,7 +921,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
                     setShowPasswordLogin(false);
                     setFormError(null);
                   }}
-                  className="text-sm text-gray-500 underline underline-offset-2"
+                  className="text-sm text-gray-500 underline underline-offset-2 dark:text-gray-400"
                 >
                   Sign in with email code instead
                 </button>
@@ -932,10 +935,10 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
               : useMagicCodePrimary
                 ? magicCodeStep === "email"
                 : canLoginWithPassword) && (
-              <div className="my-5 flex items-center gap-3 text-sm text-gray-800">
-                <div className="h-px flex-1 bg-gray-300" />
+              <div className="my-5 flex items-center gap-3 text-sm text-gray-800 dark:text-gray-300">
+                <div className="h-px flex-1 bg-gray-300 dark:bg-gray-700" />
                 <span>or</span>
-                <div className="h-px flex-1 bg-gray-300" />
+                <div className="h-px flex-1 bg-gray-300 dark:bg-gray-700" />
               </div>
             )}
 
@@ -991,18 +994,24 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
           )}
 
           {!configLoading && !isSignupMode && showSignupEntryPoint && !useMagicCodePrimary && (
-            <div className="mt-6 text-sm text-gray-500">
+            <div className="mt-6 text-sm text-gray-500 dark:text-gray-400">
               {"Don't have an account? "}
-              <Link to={`/signup${redirectQuery}`} className="font-medium text-gray-900 underline underline-offset-2">
+              <Link
+                to={`/signup${redirectQuery}`}
+                className="font-medium text-gray-900 underline underline-offset-2 dark:text-gray-100"
+              >
                 Create an account
               </Link>
             </div>
           )}
 
           {!configLoading && isSignupMode && (
-            <div className="mt-6 text-sm text-gray-500">
+            <div className="mt-6 text-sm text-gray-500 dark:text-gray-400">
               Already have an account?{" "}
-              <Link to={`/login${redirectQuery}`} className="font-medium text-gray-900 underline underline-offset-2">
+              <Link
+                to={`/login${redirectQuery}`}
+                className="font-medium text-gray-900 underline underline-offset-2 dark:text-gray-100"
+              >
                 Sign in
               </Link>
             </div>
@@ -1013,9 +1022,12 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             magicCodeStep === "email" &&
             !isSignupMode &&
             showSignupEntryPoint && (
-              <div className="mt-6 text-center text-sm text-gray-500">
+              <div className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
                 {"Don't have an account? "}
-                <Link to={`/signup${redirectQuery}`} className="font-medium text-gray-900 underline underline-offset-2">
+                <Link
+                  to={`/signup${redirectQuery}`}
+                  className="font-medium text-gray-900 underline underline-offset-2 dark:text-gray-100"
+                >
                   Sign up
                 </Link>
               </div>

--- a/web_src/src/pages/auth/SignupWaitlist.tsx
+++ b/web_src/src/pages/auth/SignupWaitlist.tsx
@@ -35,7 +35,7 @@ export const SignupWaitlist: React.FC = () => {
 
   return (
     <div className="space-y-4">
-      <Text className="text-left text-sm leading-6 text-gray-600">
+      <Text className="text-left text-sm leading-6 text-gray-600 dark:text-gray-400">
         We are opening access gradually while demand is high.
         {hubSpotConfig && " Leave your email and we will send an invite as capacity opens."}
       </Text>
@@ -72,13 +72,13 @@ export const SignupWaitlist: React.FC = () => {
           </LoadingButton>
 
           {status === "submitted" && (
-            <p className="text-left text-sm leading-6 text-gray-700" role="status">
+            <p className="text-left text-sm leading-6 text-gray-700 dark:text-gray-300" role="status">
               You are on the waitlist. We will email you when access opens.
             </p>
           )}
 
           {status === "failed" && (
-            <p className="text-left text-sm leading-6 text-red-600" role="alert">
+            <p className="text-left text-sm leading-6 text-red-600 dark:text-red-400" role="alert">
               We could not save your email. Please try again.
             </p>
           )}

--- a/web_src/src/ui/approvalGroup/ApprovalItem.tsx
+++ b/web_src/src/ui/approvalGroup/ApprovalItem.tsx
@@ -72,9 +72,9 @@ export const ApprovalItem: React.FC<ApprovalItemProps> = ({
                 </span>
               </HoverCardTrigger>
               <HoverCardContent side="top" className="w-64 space-y-3 text-xs">
-                <p className="text-sm font-medium text-neutral-900">Artifacts</p>
+                <p className="text-sm font-medium text-neutral-900 dark:text-gray-100">Artifacts</p>
                 <div className="space-y-3">
-                  <p className="font-medium text-neutral-900">Comment</p>
+                  <p className="font-medium text-neutral-900 dark:text-gray-100">Comment</p>
                   <p className="text-muted-foreground">{approvalComment}</p>
                 </div>
               </HoverCardContent>
@@ -88,7 +88,7 @@ export const ApprovalItem: React.FC<ApprovalItemProps> = ({
                 </span>
               </HoverCardTrigger>
               <HoverCardContent side="top" className="w-64 text-xs">
-                <p className="text-sm font-medium text-neutral-900 mb-2">Rejection Reason</p>
+                <p className="text-sm font-medium text-neutral-900 mb-2 dark:text-gray-100">Rejection Reason</p>
                 <p className="text-muted-foreground">{rejectionReason}</p>
               </HoverCardContent>
             </HoverCard>
@@ -161,13 +161,13 @@ export const ApprovalItem: React.FC<ApprovalItemProps> = ({
         </Item>
         {showRejectionForm && (
           <div
-            className="w-full border bg-gray-50 px-3 py-2 my-2 rounded-lg text-left"
+            className="w-full border bg-gray-50 px-3 py-2 my-2 rounded-lg text-left dark:border-gray-700/70 dark:bg-gray-800"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex flex-col gap-4">
               <div className="flex items-start justify-between">
                 <div className="flex-1">
-                  <Label htmlFor="rejection-comment" className="text-sm font-semibold text-gray-800">
+                  <Label htmlFor="rejection-comment" className="text-sm font-semibold text-gray-800 dark:text-gray-100">
                     Comment
                   </Label>
                 </div>
@@ -220,14 +220,17 @@ export const ApprovalItem: React.FC<ApprovalItemProps> = ({
         )}
         {showApprovalForm && (
           <div
-            className="w-full border my-2 bg-gray-50 px-3 py-2 rounded-lg text-left"
+            className="w-full border my-2 bg-gray-50 px-3 py-2 rounded-lg text-left dark:border-gray-700/70 dark:bg-gray-800"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex flex-col gap-4">
               <div className="flex flex-col gap-2">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
-                    <Label htmlFor="approval-comment" className="text-sm font-semibold text-neutral-900">
+                    <Label
+                      htmlFor="approval-comment"
+                      className="text-sm font-semibold text-neutral-900 dark:text-gray-100"
+                    >
                       Comment
                     </Label>
                   </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Several pages/components were missing dark mode handling. This PR fills those gaps using the app's existing dark tokens/patterns.

### Changes

- **Signup / Login page** (`Login.tsx`, `SignupWaitlist.tsx`) — dark page background + card outline, white logo (`dark:brightness-0 dark:invert`), and the previously-invisible "Create an account"/"Sign in" links (near-black `text-gray-900` on the dark card), plus all other light-only text/dividers/error boxes.

- **Installation admin** — dark mode across the whole admin area:
  - `AdminLayout` + `InstallationSettings` (page shell, header, nav, sections, headings, body text, warnings).
  - Admin **tables and inputs**: `OrganizationsList`, `AccountsList`, `AccountRow`, `OrganizationDetail`, `OrgUsersTable`, `OrgCanvasesTable`, `OrgExperimentalFeaturesTable`, `RunnerTasks`, plus the shared `AdminSearchHeader`, `SortableHeader`, `AdminPagination`, and `ConfirmAdminDialog` (table containers, thead/rows, cells, search inputs, pagination buttons, status/access badges were all white before).

- **Canvas YAML diff modal** (`CanvasYamlDiffModal.tsx`, `canvasYamlDiffOptions.ts`) — theme-aware diff options (`github-dark` + dark `unsafeCSS`) and dark modal chrome. Theme/diff hooks are scoped to a body component that only mounts while the dialog is open (avoids `useTheme` throwing when the modal is mounted-but-closed by `PanelEditorDialog`).

- **Approval inputs** (`ui/approvalGroup/ApprovalItem.tsx`) — the approval/rejection comment form cards used `bg-gray-50` with dark-blind labels/hovercards; added dark backgrounds, borders, and label/hovercard text colors.

- **Fixed/Expression toggle** (`components/ui/tabs.tsx`) — `TabsList` used `bg-slate-100` with no dark variant, so the segmented toggle stayed light in dark mode (issue #5958). Added `dark:bg-gray-800`. This also fixes any other Tabs usage in dark mode.

- **Buttons** (`dialog.tsx`) — shared `DialogClose` had `hover:bg-slate-950/5` with no dark equivalent; added `dark:hover:bg-white/10`, plus a dark variant on `DialogDescription`.

- **Canvas background** (`darkThemeSurfaces.ts`) — `DARK_BASE_BG_HEX` was bluish `#111827`; switched to the theme's neutral gray-900 `#17191c` so the canvas/file tree no longer looks too blue.

Closes #5958.

### Testing

- Full UI suite: **2757 passed / 0 failed** (380 files). `npm run build` (tsc + vite) passes; `npm run format` applied.
- Manual dark-mode verification in a running instance:

Login page — white logo, readable text, visible buttons:
[Login page dark mode](https://cursor.com/agents/bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_dark_mode.webp)

Signup page — "Sign in" link now visible on the dark card:
[Signup page dark mode](https://cursor.com/agents/bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsignup_dark_mode.webp)

Installation admin settings — fully dark, no white panels:
[Installation admin settings dark mode](https://cursor.com/agents/bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_settings_dark_mode.webp)

Admin Organizations — dark table and search input:
[Admin organizations dark mode](https://cursor.com/agents/bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_organizations_dark_mode.webp)

Admin Accounts — dark table, legible access badge, dark search input:
[Admin accounts dark mode](https://cursor.com/agents/bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_accounts_dark_mode.webp)

Canvas background — neutral dark gray (no longer bluish):
[Canvas dark mode background](https://cursor.com/agents/bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcanvas_dark_mode.webp)

Canvas YAML diff modal — dark chrome/code area, red "Live"/green "Draft" labels:
[YAML diff modal dark mode](https://cursor.com/agents/bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyaml_diff_modal_dark_mode.webp)

Note: the approval comment forms and the Fixed/Expression toggle only appear inside deep canvas/integration flows, so they were fixed as targeted background-class additions on the shared `ApprovalItem`/`TabsList` components and verified via the type-check and the passing `tabs`/`approvalGroup` unit tests rather than a screenshot.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee81d8ae-a6d1-4319-a25d-0a7822bd69ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

