### PR TITLE
chore: Fix e2e wiping out DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ tidy:
 	$(COMPOSE) exec app go mod tidy
 
 test.e2e:
-	$(COMPOSE) exec app gotestsum --format short --junitfile junit-report.xml --rerun-fails=3 --rerun-fails-max-failures=1 --packages="$(E2E_TEST_PACKAGES)" -- -p 1 -timeout 30m
+	$(COMPOSE) exec -e DB_NAME=superplane_test app gotestsum --format short --junitfile junit-report.xml --rerun-fails=3 --rerun-fails-max-failures=1 --packages="$(E2E_TEST_PACKAGES)" -- -p 1 -timeout 30m
 
 test.e2e.autoparallel:
-	$(COMPOSE) exec -e INDEX -e TOTAL app bash -lc "cd /app && bash scripts/test_e2e_autoparallel.sh"
+	$(COMPOSE) exec -e DB_NAME=superplane_test -e INDEX -e TOTAL app bash -lc "cd /app && bash scripts/test_e2e_autoparallel.sh"
 
 test.e2e.single:
 	bash ./scripts/vscode_run_tests.sh line $(FILE) $(LINE)

--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	postgres "gorm.io/driver/postgres"
@@ -166,7 +167,31 @@ func connect() *gorm.DB {
 	return db
 }
 
+// VerifyTestDatabase returns an error unless the connection points at a test
+// database (name ending in _test). Call it before destructive test helpers so
+// a misconfigured DB_NAME fails loudly instead of wiping a developer database.
+func VerifyTestDatabase(db *gorm.DB) error {
+	var name string
+	if err := db.Raw("SELECT current_database()").Scan(&name).Error; err != nil {
+		return fmt.Errorf("resolve current database: %w", err)
+	}
+
+	if !isTestDatabaseName(name) {
+		return fmt.Errorf("refusing to touch database %q: test helpers only run against a database ending in _test", name)
+	}
+
+	return nil
+}
+
+func isTestDatabaseName(name string) bool {
+	return strings.HasSuffix(name, "_test")
+}
+
 func TruncateTables() error {
+	if err := VerifyTestDatabase(Conn()); err != nil {
+		return err
+	}
+
 	return Conn().Exec(`
 		truncate table
 			secrets,

--- a/pkg/database/connection_test.go
+++ b/pkg/database/connection_test.go
@@ -74,6 +74,21 @@ func TestOpenDedicatedSQLDB_ConfiguresDedicatedPool(t *testing.T) {
 	require.NoError(t, db.Ping())
 }
 
+func TestIsTestDatabaseName(t *testing.T) {
+	require.True(t, isTestDatabaseName("superplane_test"))
+	require.False(t, isTestDatabaseName("superplane_dev"))
+	require.False(t, isTestDatabaseName("superplane"))
+	require.False(t, isTestDatabaseName("superplane_test_backup_dev"))
+}
+
+func TestVerifyTestDatabase(t *testing.T) {
+	if os.Getenv("DB_HOST") == "" {
+		t.Skip("DB_HOST not set (run with make test in Docker)")
+	}
+
+	require.NoError(t, VerifyTestDatabase(Conn()))
+}
+
 func TestClassifyPostgresSessionTimeout(t *testing.T) {
 	tests := []struct {
 		name string

--- a/test/e2e/session/test_session.go
+++ b/test/e2e/session/test_session.go
@@ -120,6 +120,13 @@ func (s *TestSession) Sleep(ms int) {
 }
 
 func (s *TestSession) resetDatabase() {
+	// Guard against truncating a developer's database: the E2E bootstrap
+	// points DB_NAME at superplane_test, but if that ever regresses we want
+	// a loud failure here instead of silently wiping superplane_dev.
+	if err := database.VerifyTestDatabase(database.Conn()); err != nil {
+		s.t.Fatalf("reset database: %v", err)
+	}
+
 	sql := `DO $$
     DECLARE r RECORD;
     BEGIN


### PR DESCRIPTION
## Summary

Guards against test runs truncating the `superplane_dev` database.

- `Makefile`: `test.e2e` and `test.e2e.autoparallel` now pass `DB_NAME=superplane_test`, matching the other test targets.
- `database.TruncateTables()` and the E2E `resetDatabase()` now verify via `current_database()` that they are connected to a `*_test` database, failing loudly otherwise. This closes the real wipe path: running `go test` directly inside the app container, which inherits `DB_NAME=superplane_dev`.

## Test plan

- Verified the guard refuses `superplane_dev` and allows `superplane_test`
- E2E smoke run passes with the fixed target; dev DB data survives
- `make lint`, `make check.build.app`, and `pkg/database` unit tests pass