### PR TITLE
feat: add GitLab onMergeComment trigger and update onMergeRequest

### DIFF
--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -10,6 +10,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="On Issue" href="#on-issue" description="Listen to issue events from GitLab" />
+  <LinkCard title="On Merge Comment" href="#on-merge-comment" description="Listen to merge request comment events from GitLab" />
   <LinkCard title="On Merge Request" href="#on-merge-request" description="Listen to merge request events from GitLab" />
   <LinkCard title="On Milestone" href="#on-milestone" description="Listen to milestone events from GitLab" />
   <LinkCard title="On Pipeline" href="#on-pipeline" description="Listen to pipeline events from GitLab" />
@@ -40,6 +41,8 @@ To connect with **App OAuth**:
 To connect with a **Personal Access Token**:
 1. [Create a personal access token](https://gitlab.com/-/user_settings/personal_access_tokens?name=SuperPlane&scopes=api,read_user,read_api,write_repository,read_repository) — the link prefills the name and scopes (api, read_user, read_api, write_repository, read_repository), so you only need to click **Create personal access token**. On a self-managed instance, use the same path on your GitLab URL.
 2. Paste the token into the **Access Token** field and click **Save**.
+
+**Note:** Triggers (On Issue, On Merge Request, On Merge Comment, etc.) create project webhooks, so the connected user needs at least the **Maintainer** role on the projects you want to monitor.
 
 <a id="on-issue"></a>
 
@@ -138,6 +141,129 @@ This trigger automatically sets up a GitLab webhook when configured. The webhook
   },
   "timestamp": "2026-02-05T14:00:00.000000000Z",
   "type": "gitlab.issue"
+}
+```
+
+<a id="on-merge-comment"></a>
+
+## On Merge Comment
+
+**Trigger key:** `gitlab.onMergeComment`
+
+The On Merge Comment trigger starts a workflow execution when a comment is added to a merge request in a GitLab project.
+
+### Use Cases
+
+- **Command processing**: Process slash commands in merge request comments (e.g., /deploy, /test)
+- **Bot interactions**: Respond to merge request comments with automated actions
+- **Notification systems**: Notify teams when important merge request comments are added
+
+### Configuration
+
+- **Project** (required): GitLab project to monitor
+- **Content Filter** (optional): Regex pattern to filter comments by content (e.g., `/deploy` to only trigger on comments containing "/deploy")
+
+### Event Data
+
+Each comment event includes:
+- **object_attributes**: Comment information including note body, author, and URL
+- **merge_request**: Merge request the comment was added to
+- **user**: User who added the comment
+- **project**: Project information
+
+Common expression paths:
+- Merge request IID: `root().data.merge_request.iid`
+- Merge request title: `root().data.merge_request.title`
+- Comment body: `root().data.object_attributes.note`
+- Comment URL: `root().data.object_attributes.url`
+
+### Webhook Setup
+
+This trigger automatically sets up a GitLab webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.
+
+### Example Data
+
+```json
+{
+  "data": {
+    "event_type": "note",
+    "merge_request": {
+      "author_id": 1,
+      "created_at": "2026-02-12 18:30:00 UTC",
+      "description": "Adds support for additional GitLab webhook trigger types.",
+      "draft": false,
+      "id": 93,
+      "iid": 12,
+      "last_commit": {
+        "author": {
+          "email": "agarcia@example.com",
+          "name": "Alex Garcia"
+        },
+        "id": "372fa8f809fe161ee0f22e04d1a4074e0be6ac47",
+        "message": "Add merge request trigger",
+        "timestamp": "2026-02-12T18:25:00Z",
+        "url": "https://gitlab.example.com/group/example/-/commit/372fa8f809fe161ee0f22e04d1a4074e0be6ac47"
+      },
+      "merge_status": "can_be_merged",
+      "source_branch": "feature/merge-request-trigger",
+      "source_project_id": 1,
+      "state": "opened",
+      "target_branch": "main",
+      "target_project_id": 1,
+      "title": "Add merge request trigger",
+      "updated_at": "2026-02-12 20:40:00 UTC",
+      "url": "https://gitlab.example.com/group/example/-/merge_requests/12",
+      "work_in_progress": false
+    },
+    "object_attributes": {
+      "action": "create",
+      "attachment": null,
+      "author_id": 1,
+      "commit_id": "",
+      "created_at": "2026-02-12 20:40:00 UTC",
+      "discussion_id": "6c2bb44bdc7f5c8f21b9ff8422f3d60cc0e5e719",
+      "id": 1244,
+      "line_code": null,
+      "note": "This looks good, but please update the docs before merging.",
+      "noteable_id": 93,
+      "noteable_type": "MergeRequest",
+      "project_id": 1,
+      "system": false,
+      "updated_at": "2026-02-12 20:40:00 UTC",
+      "url": "https://gitlab.example.com/group/example/-/merge_requests/12#note_1244"
+    },
+    "object_kind": "note",
+    "project": {
+      "avatar_url": null,
+      "ci_config_path": null,
+      "default_branch": "main",
+      "description": "Project used to demonstrate merge request comment webhook payloads.",
+      "git_http_url": "https://gitlab.example.com/group/example.git",
+      "git_ssh_url": "ssh://git@gitlab.example.com:group/example.git",
+      "id": 1,
+      "name": "Example Project",
+      "namespace": "group",
+      "path_with_namespace": "group/example",
+      "visibility_level": 20,
+      "web_url": "https://gitlab.example.com/group/example"
+    },
+    "project_id": 1,
+    "repository": {
+      "description": "Project used to demonstrate merge request comment webhook payloads.",
+      "homepage": "https://gitlab.example.com/group/example",
+      "name": "Example Project",
+      "url": "ssh://git@gitlab.example.com/group/example.git"
+    },
+    "user": {
+      "avatar_url": "https://www.gravatar.com/avatar/1a29da0ccd099482194440fac762f5ccb4ec53227761d1859979367644a889a5?s=80\u0026d=identicon",
+      "email": "agarcia@example.com",
+      "id": 1,
+      "name": "Alex Garcia",
+      "username": "agarcia"
+    }
+  },
+  "timestamp": "2026-02-12T20:40:00.000000000Z",
+  "type": "gitlab.mergeComment"
 }
 ```
 

--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -275,14 +275,42 @@ This trigger automatically sets up a GitLab webhook when configured. The webhook
 
 The On Merge Request trigger starts a workflow execution when merge request events occur in a GitLab project.
 
+### Use Cases
+
+- **MR automation**: Automate actions when merge requests are opened, merged, or closed
+- **Code review workflows**: Trigger review processes or notifications
+- **CI/CD integration**: Run tests, builds, or preview environments on merge request events
+- **Status updates**: Update systems when merge request status changes
+
 ### Configuration
 
 - **Project** (required): GitLab project to monitor
-- **Actions** (required): Select which merge request actions to listen for (open, close, merge, etc.). Default: open.
+- **Actions** (required): Select which merge request actions to listen for (open, close, reopen, update, approved, merge, etc.). Default: open.
 
-### Outputs
+### Event Data
 
-- **Default channel**: Emits merge request payload data with action, project, and object attributes
+Each merge request event includes:
+- **object_attributes**: Complete merge request information including title, description, state, action, source/target branches, and URL
+- **changes**: When the merge request is updated, includes what changed (title, description, labels, etc.)
+- **assignees**: Users assigned to the merge request
+- **reviewers**: Users requested to review the merge request
+- **labels**: Labels applied to the merge request
+- **project**: Project information
+- **repository**: Repository information
+- **user**: User who triggered the event
+
+Common expression paths:
+- Merge request IID: `root().data.object_attributes.iid`
+- Merge request title: `root().data.object_attributes.title`
+- Action: `root().data.object_attributes.action`
+- State: `root().data.object_attributes.state`
+- Source branch: `root().data.object_attributes.source_branch`
+- Target branch: `root().data.object_attributes.target_branch`
+- Merge request URL: `root().data.object_attributes.url`
+
+### Webhook Setup
+
+This trigger automatically sets up a GitLab webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.
 
 ### Example Data
 
@@ -314,10 +342,16 @@ The On Merge Request trigger starts a workflow execution when merge request even
     "object_attributes": {
       "action": "open",
       "description": "Adds support for additional GitLab webhook trigger types.",
+      "draft": false,
       "id": 93,
       "iid": 12,
+      "merge_status": "can_be_merged",
+      "source_branch": "feature/merge-request-trigger",
       "state": "opened",
-      "title": "Add merge request trigger"
+      "target_branch": "main",
+      "title": "Add merge request trigger",
+      "url": "https://gitlab.example.com/group/example/-/merge_requests/12",
+      "work_in_progress": false
     },
     "object_kind": "merge_request",
     "project": {

--- a/pkg/grpc/actions/run_title_defaults.go
+++ b/pkg/grpc/actions/run_title_defaults.go
@@ -64,6 +64,7 @@ var defaultRunTitleExpressions = map[string]string{
 	"github.onWorkflowRun":     "{{ root().data.workflow_run.name }} {{ root().data.workflow_run.conclusion }} #{{ root().data.workflow_run.run_number }}",
 
 	"gitlab.onIssue":         "#{{ root().data.object_attributes.iid }} - {{ root().data.object_attributes.title }}",
+	"gitlab.onMergeComment":  "!{{ root().data.merge_request.iid }} - {{ root().data.merge_request.title }}",
 	"gitlab.onMergeRequest":  "!{{ root().data.object_attributes.iid }} - {{ root().data.object_attributes.title }}",
 	"gitlab.onMilestone":     "{{ root().data.object_attributes.title }}",
 	"gitlab.onPipeline":      "{{ root().data.object_attributes.ref }}",

--- a/pkg/integrations/gitlab/example.go
+++ b/pkg/integrations/gitlab/example.go
@@ -10,6 +10,9 @@ import (
 //go:embed example_data_on_issue.json
 var exampleDataOnIssueBytes []byte
 
+//go:embed example_data_on_merge_comment.json
+var exampleDataOnMergeCommentBytes []byte
+
 //go:embed example_data_on_merge_request.json
 var exampleDataOnMergeRequestBytes []byte
 
@@ -31,6 +34,9 @@ var exampleDataOnVulnerabilityBytes []byte
 var exampleDataOnIssueOnce sync.Once
 var exampleDataOnIssue map[string]any
 
+var exampleDataOnMergeCommentOnce sync.Once
+var exampleDataOnMergeComment map[string]any
+
 var exampleDataOnMergeRequestOnce sync.Once
 var exampleDataOnMergeRequest map[string]any
 
@@ -51,6 +57,10 @@ var exampleDataOnVulnerability map[string]any
 
 func (i *OnIssue) ExampleData() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleDataOnIssueOnce, exampleDataOnIssueBytes, &exampleDataOnIssue)
+}
+
+func (m *OnMergeComment) ExampleData() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleDataOnMergeCommentOnce, exampleDataOnMergeCommentBytes, &exampleDataOnMergeComment)
 }
 
 func (m *OnMergeRequest) ExampleData() map[string]any {

--- a/pkg/integrations/gitlab/example_data_on_merge_comment.json
+++ b/pkg/integrations/gitlab/example_data_on_merge_comment.json
@@ -1,0 +1,81 @@
+{
+  "data": {
+    "object_kind": "note",
+    "event_type": "note",
+    "user": {
+      "id": 1,
+      "name": "Alex Garcia",
+      "username": "agarcia",
+      "avatar_url": "https://www.gravatar.com/avatar/1a29da0ccd099482194440fac762f5ccb4ec53227761d1859979367644a889a5?s=80&d=identicon",
+      "email": "agarcia@example.com"
+    },
+    "project_id": 1,
+    "project": {
+      "id": 1,
+      "name": "Example Project",
+      "description": "Project used to demonstrate merge request comment webhook payloads.",
+      "web_url": "https://gitlab.example.com/group/example",
+      "avatar_url": null,
+      "git_ssh_url": "ssh://git@gitlab.example.com:group/example.git",
+      "git_http_url": "https://gitlab.example.com/group/example.git",
+      "namespace": "group",
+      "visibility_level": 20,
+      "path_with_namespace": "group/example",
+      "default_branch": "main",
+      "ci_config_path": null
+    },
+    "repository": {
+      "name": "Example Project",
+      "url": "ssh://git@gitlab.example.com/group/example.git",
+      "description": "Project used to demonstrate merge request comment webhook payloads.",
+      "homepage": "https://gitlab.example.com/group/example"
+    },
+    "object_attributes": {
+      "id": 1244,
+      "note": "This looks good, but please update the docs before merging.",
+      "noteable_type": "MergeRequest",
+      "author_id": 1,
+      "created_at": "2026-02-12 20:40:00 UTC",
+      "updated_at": "2026-02-12 20:40:00 UTC",
+      "project_id": 1,
+      "attachment": null,
+      "line_code": null,
+      "commit_id": "",
+      "discussion_id": "6c2bb44bdc7f5c8f21b9ff8422f3d60cc0e5e719",
+      "noteable_id": 93,
+      "system": false,
+      "url": "https://gitlab.example.com/group/example/-/merge_requests/12#note_1244",
+      "action": "create"
+    },
+    "merge_request": {
+      "id": 93,
+      "iid": 12,
+      "title": "Add merge request trigger",
+      "description": "Adds support for additional GitLab webhook trigger types.",
+      "state": "opened",
+      "author_id": 1,
+      "created_at": "2026-02-12 18:30:00 UTC",
+      "updated_at": "2026-02-12 20:40:00 UTC",
+      "target_branch": "main",
+      "source_branch": "feature/merge-request-trigger",
+      "source_project_id": 1,
+      "target_project_id": 1,
+      "merge_status": "can_be_merged",
+      "url": "https://gitlab.example.com/group/example/-/merge_requests/12",
+      "work_in_progress": false,
+      "draft": false,
+      "last_commit": {
+        "id": "372fa8f809fe161ee0f22e04d1a4074e0be6ac47",
+        "message": "Add merge request trigger",
+        "timestamp": "2026-02-12T18:25:00Z",
+        "url": "https://gitlab.example.com/group/example/-/commit/372fa8f809fe161ee0f22e04d1a4074e0be6ac47",
+        "author": {
+          "name": "Alex Garcia",
+          "email": "agarcia@example.com"
+        }
+      }
+    }
+  },
+  "timestamp": "2026-02-12T20:40:00.000000000Z",
+  "type": "gitlab.mergeComment"
+}

--- a/pkg/integrations/gitlab/example_data_on_merge_request.json
+++ b/pkg/integrations/gitlab/example_data_on_merge_request.json
@@ -29,7 +29,13 @@
       "title": "Add merge request trigger",
       "description": "Adds support for additional GitLab webhook trigger types.",
       "state": "opened",
-      "action": "open"
+      "action": "open",
+      "source_branch": "feature/merge-request-trigger",
+      "target_branch": "main",
+      "merge_status": "can_be_merged",
+      "work_in_progress": false,
+      "draft": false,
+      "url": "https://gitlab.example.com/group/example/-/merge_requests/12"
     },
     "changes": {
       "title": {

--- a/pkg/integrations/gitlab/gitlab.go
+++ b/pkg/integrations/gitlab/gitlab.go
@@ -104,6 +104,8 @@ To connect with **App OAuth**:
 To connect with a **Personal Access Token**:
 1. [Create a personal access token](https://gitlab.com/-/user_settings/personal_access_tokens?name=SuperPlane&scopes=%s) — the link prefills the name and scopes (%s), so you only need to click **Create personal access token**. On a self-managed instance, use the same path on your GitLab URL.
 2. Paste the token into the **Access Token** field and click **Save**.
+
+**Note:** Triggers (On Issue, On Merge Request, On Merge Comment, etc.) create project webhooks, so the connected user needs at least the **Maintainer** role on the projects you want to monitor.
 `, strings.Join(scopeList, ","), strings.Join(scopeList, ", "))
 }
 
@@ -181,6 +183,7 @@ func (g *GitLab) Actions() []core.Action {
 func (g *GitLab) Triggers() []core.Trigger {
 	return []core.Trigger{
 		&OnIssue{},
+		&OnMergeComment{},
 		&OnMergeRequest{},
 		&OnMilestone{},
 		&OnPipeline{},

--- a/pkg/integrations/gitlab/on_merge_comment.go
+++ b/pkg/integrations/gitlab/on_merge_comment.go
@@ -155,11 +155,6 @@ func (m *OnMergeComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *co
 		return http.StatusOK, nil, nil
 	}
 
-	if !isNewNote(data) {
-		ctx.Logger.Info("Comment is not a newly created note - ignoring")
-		return http.StatusOK, nil, nil
-	}
-
 	matched, err := m.matchesContentFilter(config.ContentFilter, data)
 	if err != nil {
 		return http.StatusBadRequest, nil, err
@@ -184,6 +179,11 @@ func (m *OnMergeComment) Cleanup(ctx core.TriggerContext) error {
 func (m *OnMergeComment) isMergeRequestComment(logger *log.Entry, data map[string]any) bool {
 	attrs, ok := data["object_attributes"].(map[string]any)
 	if !ok {
+		return false
+	}
+
+	if system, ok := attrs["system"].(bool); ok && system {
+		logger.Info("Comment is a system-generated note - ignoring")
 		return false
 	}
 
@@ -221,23 +221,4 @@ func (m *OnMergeComment) matchesContentFilter(filter string, data map[string]any
 	}
 
 	return matched, nil
-}
-
-// isNewNote reports whether the note event is for a newly created comment.
-// GitLab emits note hooks on comment creation, but we guard against any explicit
-// non-create action (e.g. edits) so comment edits don't start duplicate runs.
-// Older GitLab versions omit the action field on notes, so a missing action is
-// treated as a new comment for backward compatibility.
-func isNewNote(data map[string]any) bool {
-	attrs, ok := data["object_attributes"].(map[string]any)
-	if !ok {
-		return true
-	}
-
-	action, ok := attrs["action"].(string)
-	if !ok || action == "" {
-		return true
-	}
-
-	return action == "create"
 }

--- a/pkg/integrations/gitlab/on_merge_comment.go
+++ b/pkg/integrations/gitlab/on_merge_comment.go
@@ -155,6 +155,11 @@ func (m *OnMergeComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *co
 		return http.StatusOK, nil, nil
 	}
 
+	if !isNewNote(data) {
+		ctx.Logger.Info("Comment is not a newly created note - ignoring")
+		return http.StatusOK, nil, nil
+	}
+
 	matched, err := m.matchesContentFilter(config.ContentFilter, data)
 	if err != nil {
 		return http.StatusBadRequest, nil, err
@@ -216,4 +221,23 @@ func (m *OnMergeComment) matchesContentFilter(filter string, data map[string]any
 	}
 
 	return matched, nil
+}
+
+// isNewNote reports whether the note event is for a newly created comment.
+// GitLab emits note hooks on comment creation, but we guard against any explicit
+// non-create action (e.g. edits) so comment edits don't start duplicate runs.
+// Older GitLab versions omit the action field on notes, so a missing action is
+// treated as a new comment for backward compatibility.
+func isNewNote(data map[string]any) bool {
+	attrs, ok := data["object_attributes"].(map[string]any)
+	if !ok {
+		return true
+	}
+
+	action, ok := attrs["action"].(string)
+	if !ok || action == "" {
+		return true
+	}
+
+	return action == "create"
 }

--- a/pkg/integrations/gitlab/on_merge_comment.go
+++ b/pkg/integrations/gitlab/on_merge_comment.go
@@ -1,0 +1,219 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/mitchellh/mapstructure"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type OnMergeComment struct{}
+
+type OnMergeCommentConfiguration struct {
+	Project       string `json:"project" mapstructure:"project"`
+	ContentFilter string `json:"contentFilter" mapstructure:"contentFilter"`
+}
+
+func (m *OnMergeComment) Name() string {
+	return "gitlab.onMergeComment"
+}
+
+func (m *OnMergeComment) Label() string {
+	return "On Merge Comment"
+}
+
+func (m *OnMergeComment) Description() string {
+	return "Listen to merge request comment events from GitLab"
+}
+
+func (m *OnMergeComment) Documentation() string {
+	return `The On Merge Comment trigger starts a workflow execution when a comment is added to a merge request in a GitLab project.
+
+## Use Cases
+
+- **Command processing**: Process slash commands in merge request comments (e.g., /deploy, /test)
+- **Bot interactions**: Respond to merge request comments with automated actions
+- **Notification systems**: Notify teams when important merge request comments are added
+
+## Configuration
+
+- **Project** (required): GitLab project to monitor
+- **Content Filter** (optional): Regex pattern to filter comments by content (e.g., ` + "`/deploy`" + ` to only trigger on comments containing "/deploy")
+
+## Event Data
+
+Each comment event includes:
+- **object_attributes**: Comment information including note body, author, and URL
+- **merge_request**: Merge request the comment was added to
+- **user**: User who added the comment
+- **project**: Project information
+
+Common expression paths:
+- Merge request IID: ` + "`root().data.merge_request.iid`" + `
+- Merge request title: ` + "`root().data.merge_request.title`" + `
+- Comment body: ` + "`root().data.object_attributes.note`" + `
+- Comment URL: ` + "`root().data.object_attributes.url`" + `
+
+## Webhook Setup
+
+This trigger automatically sets up a GitLab webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.`
+}
+
+func (m *OnMergeComment) Icon() string {
+	return "gitlab"
+}
+
+func (m *OnMergeComment) Color() string {
+	return "orange"
+}
+
+func (m *OnMergeComment) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "project",
+			Label:    "Project",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeProject,
+				},
+			},
+		},
+		{
+			Name:        "contentFilter",
+			Label:       "Content Filter",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Placeholder: "e.g., /deploy",
+			Description: "Optional regex pattern to filter comments by content",
+		},
+	}
+}
+
+func (m *OnMergeComment) Setup(ctx core.TriggerContext) error {
+	var config OnMergeCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.ContentFilter != "" {
+		if _, err := regexp.Compile(config.ContentFilter); err != nil {
+			return fmt.Errorf("invalid content filter pattern: %w", err)
+		}
+	}
+
+	if err := ensureProjectInMetadata(ctx.Metadata, ctx.Integration, config.Project); err != nil {
+		return err
+	}
+
+	return ctx.Integration.RequestWebhook(WebhookConfiguration{
+		EventType: "note",
+		ProjectID: config.Project,
+	})
+}
+
+func (m *OnMergeComment) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (m *OnMergeComment) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (m *OnMergeComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	var config OnMergeCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	eventType := ctx.Headers.Get("X-Gitlab-Event")
+	if eventType == "" {
+		return http.StatusBadRequest, nil, fmt.Errorf("missing X-Gitlab-Event header")
+	}
+
+	if eventType != "Note Hook" {
+		return http.StatusOK, nil, nil
+	}
+
+	code, err := verifyWebhookToken(ctx)
+	if err != nil {
+		return code, nil, err
+	}
+
+	data := map[string]any{}
+	if err := json.Unmarshal(ctx.Body, &data); err != nil {
+		return http.StatusBadRequest, nil, fmt.Errorf("error parsing request body: %v", err)
+	}
+
+	if !m.isMergeRequestComment(ctx.Logger, data) {
+		return http.StatusOK, nil, nil
+	}
+
+	matched, err := m.matchesContentFilter(config.ContentFilter, data)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	if !matched {
+		ctx.Logger.Info("Comment does not match the content filter - ignoring")
+		return http.StatusOK, nil, nil
+	}
+
+	if err := ctx.Events.Emit("gitlab.mergeComment", data); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("error emitting event: %v", err)
+	}
+
+	return http.StatusOK, nil, nil
+}
+
+func (m *OnMergeComment) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func (m *OnMergeComment) isMergeRequestComment(logger *log.Entry, data map[string]any) bool {
+	attrs, ok := data["object_attributes"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	noteableType, ok := attrs["noteable_type"].(string)
+	if !ok {
+		return false
+	}
+
+	if noteableType != "MergeRequest" {
+		logger.Infof("Comment is on a %s, not a merge request - ignoring", noteableType)
+		return false
+	}
+
+	return true
+}
+
+func (m *OnMergeComment) matchesContentFilter(filter string, data map[string]any) (bool, error) {
+	if filter == "" {
+		return true, nil
+	}
+
+	attrs, ok := data["object_attributes"].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+
+	note, ok := attrs["note"].(string)
+	if !ok {
+		return false, nil
+	}
+
+	matched, err := regexp.MatchString(filter, note)
+	if err != nil {
+		return false, fmt.Errorf("invalid content filter pattern: %w", err)
+	}
+
+	return matched, nil
+}

--- a/pkg/integrations/gitlab/on_merge_comment_test.go
+++ b/pkg/integrations/gitlab/on_merge_comment_test.go
@@ -169,18 +169,14 @@ func Test__OnMergeComment__HandleWebhook__NonMergeRequestComment(t *testing.T) {
 	assert.Zero(t, events.Count())
 }
 
-func Test__OnMergeComment__HandleWebhook__EditedCommentIgnored(t *testing.T) {
+func Test__OnMergeComment__HandleWebhook__SystemNote(t *testing.T) {
 	trigger := &OnMergeComment{}
 
 	body, _ := json.Marshal(map[string]any{
 		"object_attributes": map[string]any{
-			"note":          "This looks good to me",
+			"note":          "assigned to @agarcia",
 			"noteable_type": "MergeRequest",
-			"action":        "update",
-		},
-		"merge_request": map[string]any{
-			"iid":   12,
-			"title": "Add merge request trigger",
+			"system":        true,
 		},
 	})
 
@@ -197,37 +193,6 @@ func Test__OnMergeComment__HandleWebhook__EditedCommentIgnored(t *testing.T) {
 	assert.Equal(t, http.StatusOK, code)
 	assert.NoError(t, err)
 	assert.Zero(t, events.Count())
-}
-
-func Test__OnMergeComment__HandleWebhook__CreatedCommentEmitted(t *testing.T) {
-	trigger := &OnMergeComment{}
-
-	body, _ := json.Marshal(map[string]any{
-		"object_attributes": map[string]any{
-			"note":          "This looks good to me",
-			"noteable_type": "MergeRequest",
-			"action":        "create",
-		},
-		"merge_request": map[string]any{
-			"iid":   12,
-			"title": "Add merge request trigger",
-		},
-	})
-
-	events := &contexts.EventContext{}
-	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
-		Headers:       gitlabHeaders("Note Hook", "token"),
-		Body:          body,
-		Configuration: map[string]any{"project": "123"},
-		Webhook:       &contexts.NodeWebhookContext{Secret: "token"},
-		Events:        events,
-		Logger:        log.NewEntry(log.New()),
-	})
-
-	assert.Equal(t, http.StatusOK, code)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, events.Count())
-	assert.Equal(t, "gitlab.mergeComment", events.Payloads[0].Type)
 }
 
 func Test__OnMergeComment__HandleWebhook__ContentFilterMatch(t *testing.T) {

--- a/pkg/integrations/gitlab/on_merge_comment_test.go
+++ b/pkg/integrations/gitlab/on_merge_comment_test.go
@@ -1,0 +1,221 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__OnMergeComment__Setup(t *testing.T) {
+	trigger := &OnMergeComment{}
+	metadata := Metadata{
+		Projects: []ProjectMetadata{
+			{ID: 123, Name: "group/example", URL: "https://gitlab.com/group/example"},
+		},
+	}
+
+	t.Run("project is required", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			Integration:   &contexts.IntegrationContext{Metadata: metadata},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"project": ""},
+		})
+
+		require.ErrorContains(t, err, "project is required")
+	})
+
+	t.Run("invalid content filter", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			Integration:   &contexts.IntegrationContext{Metadata: metadata},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"project": "123", "contentFilter": "["},
+		})
+
+		require.ErrorContains(t, err, "invalid content filter pattern")
+	})
+
+	t.Run("project is not accessible", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			Integration:   &contexts.IntegrationContext{Metadata: metadata},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"project": "456"},
+		})
+
+		require.ErrorContains(t, err, "project 456 is not accessible to integration")
+	})
+
+	t.Run("metadata is set and webhook is requested", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{Metadata: metadata}
+		metadataCtx := &contexts.MetadataContext{}
+
+		require.NoError(t, trigger.Setup(core.TriggerContext{
+			Integration:   integrationCtx,
+			Metadata:      metadataCtx,
+			Configuration: map[string]any{"project": "123", "contentFilter": "/deploy"},
+		}))
+
+		require.Len(t, integrationCtx.WebhookRequests, 1)
+		webhookConfig, ok := integrationCtx.WebhookRequests[0].(WebhookConfiguration)
+		require.True(t, ok)
+		assert.Equal(t, "note", webhookConfig.EventType)
+		assert.Equal(t, "123", webhookConfig.ProjectID)
+	})
+}
+
+func Test__OnMergeComment__HandleWebhook__MissingEventHeader(t *testing.T) {
+	trigger := &OnMergeComment{}
+
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       http.Header{},
+		Body:          []byte(`{}`),
+		Configuration: map[string]any{"project": "123"},
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.ErrorContains(t, err, "X-Gitlab-Event")
+}
+
+func Test__OnMergeComment__HandleWebhook__WrongEventType(t *testing.T) {
+	trigger := &OnMergeComment{}
+	events := &contexts.EventContext{}
+
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       gitlabHeaders("Merge Request Hook", "token"),
+		Body:          []byte(`{}`),
+		Configuration: map[string]any{"project": "123"},
+		Events:        events,
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+	assert.Zero(t, events.Count())
+}
+
+func Test__OnMergeComment__HandleWebhook__InvalidToken(t *testing.T) {
+	trigger := &OnMergeComment{}
+
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       gitlabHeaders("Note Hook", "wrong"),
+		Body:          []byte(`{}`),
+		Configuration: map[string]any{"project": "123"},
+		Webhook:       &contexts.NodeWebhookContext{Secret: "token"},
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusForbidden, code)
+	assert.ErrorContains(t, err, "invalid webhook token")
+}
+
+func Test__OnMergeComment__HandleWebhook__MergeRequestComment(t *testing.T) {
+	trigger := &OnMergeComment{}
+
+	body, _ := json.Marshal(map[string]any{
+		"object_attributes": map[string]any{
+			"note":          "This looks good to me",
+			"noteable_type": "MergeRequest",
+		},
+		"merge_request": map[string]any{
+			"iid":   12,
+			"title": "Add merge request trigger",
+		},
+	})
+
+	events := &contexts.EventContext{}
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       gitlabHeaders("Note Hook", "token"),
+		Body:          body,
+		Configuration: map[string]any{"project": "123"},
+		Webhook:       &contexts.NodeWebhookContext{Secret: "token"},
+		Events:        events,
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, events.Count())
+	assert.Equal(t, "gitlab.mergeComment", events.Payloads[0].Type)
+}
+
+func Test__OnMergeComment__HandleWebhook__NonMergeRequestComment(t *testing.T) {
+	trigger := &OnMergeComment{}
+
+	body, _ := json.Marshal(map[string]any{
+		"object_attributes": map[string]any{
+			"note":          "This is an issue comment",
+			"noteable_type": "Issue",
+		},
+	})
+
+	events := &contexts.EventContext{}
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       gitlabHeaders("Note Hook", "token"),
+		Body:          body,
+		Configuration: map[string]any{"project": "123"},
+		Webhook:       &contexts.NodeWebhookContext{Secret: "token"},
+		Events:        events,
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+	assert.Zero(t, events.Count())
+}
+
+func Test__OnMergeComment__HandleWebhook__ContentFilterMatch(t *testing.T) {
+	trigger := &OnMergeComment{}
+
+	body, _ := json.Marshal(map[string]any{
+		"object_attributes": map[string]any{
+			"note":          "/deploy to staging",
+			"noteable_type": "MergeRequest",
+		},
+	})
+
+	events := &contexts.EventContext{}
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       gitlabHeaders("Note Hook", "token"),
+		Body:          body,
+		Configuration: map[string]any{"project": "123", "contentFilter": "/deploy"},
+		Webhook:       &contexts.NodeWebhookContext{Secret: "token"},
+		Events:        events,
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, events.Count())
+	assert.Equal(t, "gitlab.mergeComment", events.Payloads[0].Type)
+}
+
+func Test__OnMergeComment__HandleWebhook__ContentFilterMismatch(t *testing.T) {
+	trigger := &OnMergeComment{}
+
+	body, _ := json.Marshal(map[string]any{
+		"object_attributes": map[string]any{
+			"note":          "Just a regular comment",
+			"noteable_type": "MergeRequest",
+		},
+	})
+
+	events := &contexts.EventContext{}
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       gitlabHeaders("Note Hook", "token"),
+		Body:          body,
+		Configuration: map[string]any{"project": "123", "contentFilter": "/deploy"},
+		Webhook:       &contexts.NodeWebhookContext{Secret: "token"},
+		Events:        events,
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+	assert.Zero(t, events.Count())
+}

--- a/pkg/integrations/gitlab/on_merge_comment_test.go
+++ b/pkg/integrations/gitlab/on_merge_comment_test.go
@@ -169,6 +169,67 @@ func Test__OnMergeComment__HandleWebhook__NonMergeRequestComment(t *testing.T) {
 	assert.Zero(t, events.Count())
 }
 
+func Test__OnMergeComment__HandleWebhook__EditedCommentIgnored(t *testing.T) {
+	trigger := &OnMergeComment{}
+
+	body, _ := json.Marshal(map[string]any{
+		"object_attributes": map[string]any{
+			"note":          "This looks good to me",
+			"noteable_type": "MergeRequest",
+			"action":        "update",
+		},
+		"merge_request": map[string]any{
+			"iid":   12,
+			"title": "Add merge request trigger",
+		},
+	})
+
+	events := &contexts.EventContext{}
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       gitlabHeaders("Note Hook", "token"),
+		Body:          body,
+		Configuration: map[string]any{"project": "123"},
+		Webhook:       &contexts.NodeWebhookContext{Secret: "token"},
+		Events:        events,
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+	assert.Zero(t, events.Count())
+}
+
+func Test__OnMergeComment__HandleWebhook__CreatedCommentEmitted(t *testing.T) {
+	trigger := &OnMergeComment{}
+
+	body, _ := json.Marshal(map[string]any{
+		"object_attributes": map[string]any{
+			"note":          "This looks good to me",
+			"noteable_type": "MergeRequest",
+			"action":        "create",
+		},
+		"merge_request": map[string]any{
+			"iid":   12,
+			"title": "Add merge request trigger",
+		},
+	})
+
+	events := &contexts.EventContext{}
+	code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Headers:       gitlabHeaders("Note Hook", "token"),
+		Body:          body,
+		Configuration: map[string]any{"project": "123"},
+		Webhook:       &contexts.NodeWebhookContext{Secret: "token"},
+		Events:        events,
+		Logger:        log.NewEntry(log.New()),
+	})
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, events.Count())
+	assert.Equal(t, "gitlab.mergeComment", events.Payloads[0].Type)
+}
+
 func Test__OnMergeComment__HandleWebhook__ContentFilterMatch(t *testing.T) {
 	trigger := &OnMergeComment{}
 

--- a/pkg/integrations/gitlab/on_merge_request.go
+++ b/pkg/integrations/gitlab/on_merge_request.go
@@ -34,14 +34,42 @@ func (m *OnMergeRequest) Description() string {
 func (m *OnMergeRequest) Documentation() string {
 	return `The On Merge Request trigger starts a workflow execution when merge request events occur in a GitLab project.
 
+## Use Cases
+
+- **MR automation**: Automate actions when merge requests are opened, merged, or closed
+- **Code review workflows**: Trigger review processes or notifications
+- **CI/CD integration**: Run tests, builds, or preview environments on merge request events
+- **Status updates**: Update systems when merge request status changes
+
 ## Configuration
 
 - **Project** (required): GitLab project to monitor
-- **Actions** (required): Select which merge request actions to listen for (open, close, merge, etc.). Default: open.
+- **Actions** (required): Select which merge request actions to listen for (open, close, reopen, update, approved, merge, etc.). Default: open.
 
-## Outputs
+## Event Data
 
-- **Default channel**: Emits merge request payload data with action, project, and object attributes`
+Each merge request event includes:
+- **object_attributes**: Complete merge request information including title, description, state, action, source/target branches, and URL
+- **changes**: When the merge request is updated, includes what changed (title, description, labels, etc.)
+- **assignees**: Users assigned to the merge request
+- **reviewers**: Users requested to review the merge request
+- **labels**: Labels applied to the merge request
+- **project**: Project information
+- **repository**: Repository information
+- **user**: User who triggered the event
+
+Common expression paths:
+- Merge request IID: ` + "`root().data.object_attributes.iid`" + `
+- Merge request title: ` + "`root().data.object_attributes.title`" + `
+- Action: ` + "`root().data.object_attributes.action`" + `
+- State: ` + "`root().data.object_attributes.state`" + `
+- Source branch: ` + "`root().data.object_attributes.source_branch`" + `
+- Target branch: ` + "`root().data.object_attributes.target_branch`" + `
+- Merge request URL: ` + "`root().data.object_attributes.url`" + `
+
+## Webhook Setup
+
+This trigger automatically sets up a GitLab webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.`
 }
 
 func (m *OnMergeRequest) Icon() string {

--- a/web_src/src/pages/app/mappers/gitlab/index.ts
+++ b/web_src/src/pages/app/mappers/gitlab/index.ts
@@ -2,6 +2,7 @@ import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from ".
 import { buildActionStateRegistry } from "../utils";
 import { createIssueMapper } from "./create_issue";
 import { onIssueTriggerRenderer } from "./on_issue";
+import { onMergeCommentTriggerRenderer } from "./on_merge_comment";
 import { onMergeRequestTriggerRenderer } from "./on_merge_request";
 import { onMilestoneTriggerRenderer } from "./on_milestone";
 import { onPipelineTriggerRenderer } from "./on_pipeline";
@@ -29,6 +30,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
   onIssue: onIssueTriggerRenderer,
+  onMergeComment: onMergeCommentTriggerRenderer,
   onMergeRequest: onMergeRequestTriggerRenderer,
   onMilestone: onMilestoneTriggerRenderer,
   onPipeline: onPipelineTriggerRenderer,

--- a/web_src/src/pages/app/mappers/gitlab/on_merge_comment.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/on_merge_comment.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import { onMergeCommentTriggerRenderer } from "./on_merge_comment";
+import type { NodeInfo, TriggerEventContext, TriggerRendererContext, ComponentDefinition, EventInfo } from "../types";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "On Merge Comment",
+    componentName: "gitlab.onMergeComment",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildDefinition(overrides?: Partial<ComponentDefinition>): ComponentDefinition {
+  return {
+    name: "onMergeComment",
+    label: "On Merge Comment",
+    description: "",
+    icon: "gitlab",
+    color: "orange",
+    ...overrides,
+  };
+}
+
+function buildEvent(overrides?: Partial<NonNullable<EventInfo>>): EventInfo {
+  return {
+    id: "evt-1",
+    createdAt: new Date().toISOString(),
+    data: {},
+    nodeId: "node-1",
+    type: "gitlab.mergeComment",
+    ...overrides,
+  };
+}
+
+function buildEventData() {
+  return {
+    object_kind: "note",
+    user: { id: 1, name: "Alex Garcia", username: "agarcia" },
+    project: {
+      id: 1,
+      name: "Example Project",
+      path_with_namespace: "group/example",
+      web_url: "https://gitlab.example.com/group/example",
+    },
+    object_attributes: {
+      id: 1244,
+      note: "/deploy to staging",
+      noteable_type: "MergeRequest",
+      url: "https://gitlab.example.com/group/example/-/merge_requests/12#note_1244",
+    },
+    merge_request: {
+      id: 93,
+      iid: 12,
+      title: "Add merge request trigger",
+      state: "opened",
+      url: "https://gitlab.example.com/group/example/-/merge_requests/12",
+    },
+  };
+}
+
+// ── getTitleAndSubtitle ─────────────────────────────────────────────
+
+describe("onMergeCommentTriggerRenderer.getTitleAndSubtitle", () => {
+  it("uses merge request iid and title", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: buildEventData() }) };
+    expect(onMergeCommentTriggerRenderer.getTitleAndSubtitle(ctx).title).toBe("!12 - Add merge request trigger");
+  });
+
+  it("falls back to default title when merge request is missing", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: {} }) };
+    expect(onMergeCommentTriggerRenderer.getTitleAndSubtitle(ctx).title).toBe("! - Merge Comment");
+  });
+
+  it("includes comment author in subtitle", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ createdAt: "", data: buildEventData() }) };
+    const { subtitle } = onMergeCommentTriggerRenderer.getTitleAndSubtitle(ctx);
+    expect(subtitle).toBe("By agarcia");
+  });
+
+  it("handles undefined event data gracefully", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: undefined }) };
+    expect(() => onMergeCommentTriggerRenderer.getTitleAndSubtitle(ctx)).not.toThrow();
+  });
+});
+
+// ── getRootEventValues ──────────────────────────────────────────────
+
+describe("onMergeCommentTriggerRenderer.getRootEventValues", () => {
+  it("extracts comment details from event data", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: buildEventData() }) };
+    const values = onMergeCommentTriggerRenderer.getRootEventValues(ctx);
+    expect(values["Comment"]).toBe("/deploy to staging");
+    expect(values["Comment URL"]).toBe("https://gitlab.example.com/group/example/-/merge_requests/12#note_1244");
+    expect(values["Author"]).toBe("agarcia");
+    expect(values["Merge Request"]).toBe("!12 - Add merge request trigger");
+    expect(values["Project"]).toBe("group/example");
+  });
+
+  it("includes received at as the first value", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: buildEventData() }) };
+    const values = onMergeCommentTriggerRenderer.getRootEventValues(ctx);
+    expect(Object.keys(values)[0]).toBe("Received At");
+    expect(values["Received At"]).not.toBe("-");
+  });
+
+  it("returns at most 6 values", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: buildEventData() }) };
+    expect(Object.keys(onMergeCommentTriggerRenderer.getRootEventValues(ctx)).length).toBeLessThanOrEqual(6);
+  });
+
+  it("returns placeholders when event data is missing", () => {
+    const values = onMergeCommentTriggerRenderer.getRootEventValues({ event: buildEvent({ data: {} }) });
+    expect(values["Comment"]).toBe("-");
+    expect(values["Comment URL"]).toBe("-");
+    expect(values["Author"]).toBe("-");
+    expect(values["Merge Request"]).toBe("-");
+    expect(values["Project"]).toBe("-");
+  });
+});
+
+// ── getTriggerProps ─────────────────────────────────────────────────
+
+describe("onMergeCommentTriggerRenderer.getTriggerProps", () => {
+  it("returns props with correct title from node name", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode({ name: "My Merge Comment Trigger" }),
+      definition: buildDefinition(),
+      lastEvent: buildEvent(),
+    };
+    expect(onMergeCommentTriggerRenderer.getTriggerProps(ctx).title).toBe("My Merge Comment Trigger");
+  });
+
+  it("falls back to definition label when node name is empty", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode({ name: "" }),
+      definition: buildDefinition({ label: "On Merge Comment" }),
+      lastEvent: buildEvent(),
+    };
+    expect(onMergeCommentTriggerRenderer.getTriggerProps(ctx).title).toBe("On Merge Comment");
+  });
+
+  it("includes project metadata and content filter", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode({
+        metadata: { project: { id: 1, name: "group/example" } },
+        configuration: { contentFilter: "/deploy" },
+      }),
+      definition: buildDefinition(),
+      lastEvent: buildEvent(),
+    };
+    const props = onMergeCommentTriggerRenderer.getTriggerProps(ctx);
+    expect(props.metadata?.find((m) => String(m.label).includes("group/example"))).toBeDefined();
+    expect(props.metadata?.find((m) => String(m.label).includes("/deploy"))).toBeDefined();
+  });
+
+  it("omits metadata when project and content filter are not configured", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode({ metadata: {}, configuration: {} }),
+      definition: buildDefinition(),
+      lastEvent: buildEvent(),
+    };
+    expect(onMergeCommentTriggerRenderer.getTriggerProps(ctx).metadata).toEqual([]);
+  });
+
+  it("includes lastEventData when lastEvent is provided", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode(),
+      definition: buildDefinition(),
+      lastEvent: buildEvent({ data: buildEventData() }),
+    };
+    const props = onMergeCommentTriggerRenderer.getTriggerProps(ctx);
+    expect(props.lastEventData).toBeDefined();
+    expect(props.lastEventData!.title).toBe("!12 - Add merge request trigger");
+    expect(props.lastEventData!.state).toBe("triggered");
+  });
+
+  it("omits lastEventData when lastEvent is missing", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode(),
+      definition: buildDefinition(),
+      lastEvent: undefined,
+    };
+    expect(onMergeCommentTriggerRenderer.getTriggerProps(ctx).lastEventData).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/app/mappers/gitlab/on_merge_comment.ts
+++ b/web_src/src/pages/app/mappers/gitlab/on_merge_comment.ts
@@ -5,24 +5,28 @@ import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } fro
 import { buildGitlabSubtitle } from "./utils";
 import type { GitLabNodeMetadata } from "./types";
 
-interface OnMergeRequestConfiguration {
-  actions: string[];
+interface OnMergeCommentConfiguration {
+  contentFilter?: string;
 }
 
-interface MergeRequestObjectAttributes {
+interface MergeCommentObjectAttributes {
   id?: number;
-  iid?: number;
-  title?: string;
-  description?: string;
-  state?: string;
-  action?: string;
+  note?: string;
+  noteable_type?: string;
   url?: string;
 }
 
-interface OnMergeRequestEventData {
+interface OnMergeCommentEventData {
   object_kind?: string;
   event_type?: string;
-  object_attributes?: MergeRequestObjectAttributes;
+  object_attributes?: MergeCommentObjectAttributes;
+  merge_request?: {
+    id?: number;
+    iid?: number;
+    title?: string;
+    state?: string;
+    url?: string;
+  };
   user?: {
     id: number;
     name: string;
@@ -40,16 +44,25 @@ function formatReceivedAt(createdAt?: string): string {
   return createdAt ? new Date(createdAt).toLocaleString() : "-";
 }
 
-function mergeRequestEventTitle(eventData?: OnMergeRequestEventData): string {
-  const mr = eventData?.object_attributes;
-  return `!${mr?.iid ?? ""} - ${mr?.title || "Merge Request"}`;
+function mergeRequestRef(mr?: OnMergeCommentEventData["merge_request"]): string {
+  if (!mr?.iid) {
+    return "-";
+  }
+
+  return `!${mr.iid} - ${mr.title || ""}`;
 }
 
-function mergeRequestEventSubtitle(eventData?: OnMergeRequestEventData, createdAt?: string) {
-  return buildGitlabSubtitle(eventData?.object_attributes?.action || "", createdAt);
+function commentEventTitle(eventData?: OnMergeCommentEventData): string {
+  const mr = eventData?.merge_request;
+  return `!${mr?.iid ?? ""} - ${mr?.title || "Merge Comment"}`;
 }
 
-function buildMetadataItems(metadata?: GitLabNodeMetadata, configuration?: OnMergeRequestConfiguration) {
+function commentEventSubtitle(eventData?: OnMergeCommentEventData, createdAt?: string) {
+  const author = eventData?.user?.username;
+  return buildGitlabSubtitle(author ? `By ${author}` : "", createdAt);
+}
+
+function buildMetadataItems(metadata?: GitLabNodeMetadata, configuration?: OnMergeCommentConfiguration) {
   const metadataItems = [];
 
   if (metadata?.project?.name) {
@@ -59,44 +72,44 @@ function buildMetadataItems(metadata?: GitLabNodeMetadata, configuration?: OnMer
     });
   }
 
-  if (configuration?.actions) {
+  if (configuration?.contentFilter) {
     metadataItems.push({
       icon: "funnel",
-      label: configuration.actions.join(", "),
+      label: `Filter: ${configuration.contentFilter}`,
     });
   }
 
   return metadataItems;
 }
 
-export const onMergeRequestTriggerRenderer: TriggerRenderer = {
+export const onMergeCommentTriggerRenderer: TriggerRenderer = {
   getTitleAndSubtitle: (context: TriggerEventContext) => {
-    const eventData = context.event?.data as OnMergeRequestEventData;
+    const eventData = context.event?.data as OnMergeCommentEventData;
 
     return {
-      title: mergeRequestEventTitle(eventData),
-      subtitle: mergeRequestEventSubtitle(eventData, context.event?.createdAt),
+      title: commentEventTitle(eventData),
+      subtitle: commentEventSubtitle(eventData, context.event?.createdAt),
     };
   },
 
   getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
-    const eventData = context.event?.data as OnMergeRequestEventData;
-    const mr = eventData?.object_attributes;
+    const eventData = context.event?.data as OnMergeCommentEventData;
+    const comment = eventData?.object_attributes;
 
     return {
       "Received At": formatReceivedAt(context.event?.createdAt),
-      Title: mr?.title || "-",
-      URL: mr?.url || "-",
-      Action: mr?.action || "-",
-      State: mr?.state || "-",
+      Comment: comment?.note || "-",
+      "Comment URL": comment?.url || "-",
       Author: eventData?.user?.username || "-",
+      "Merge Request": mergeRequestRef(eventData?.merge_request),
+      Project: eventData?.project?.path_with_namespace || "-",
     };
   },
 
   getTriggerProps: (context: TriggerRendererContext): TriggerProps => {
     const { node, definition, lastEvent } = context;
     const metadata = node.metadata as unknown as GitLabNodeMetadata;
-    const configuration = node.configuration as unknown as OnMergeRequestConfiguration;
+    const configuration = node.configuration as unknown as OnMergeCommentConfiguration;
 
     const props: TriggerProps = {
       title: node.name || definition.label || "Unnamed trigger",
@@ -107,11 +120,11 @@ export const onMergeRequestTriggerRenderer: TriggerRenderer = {
     };
 
     if (lastEvent) {
-      const eventData = lastEvent.data as OnMergeRequestEventData;
+      const eventData = lastEvent.data as OnMergeCommentEventData;
 
       props.lastEventData = {
-        title: mergeRequestEventTitle(eventData),
-        subtitle: mergeRequestEventSubtitle(eventData, lastEvent.createdAt),
+        title: commentEventTitle(eventData),
+        subtitle: commentEventSubtitle(eventData, lastEvent.createdAt),
         receivedAt: new Date(lastEvent.createdAt!),
         state: "triggered",
         eventId: lastEvent.id!,

--- a/web_src/src/pages/app/mappers/gitlab/on_merge_request.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/on_merge_request.spec.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import { onMergeRequestTriggerRenderer } from "./on_merge_request";
+import type { NodeInfo, TriggerEventContext, TriggerRendererContext, ComponentDefinition, EventInfo } from "../types";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "On Merge Request",
+    componentName: "gitlab.onMergeRequest",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildDefinition(overrides?: Partial<ComponentDefinition>): ComponentDefinition {
+  return {
+    name: "onMergeRequest",
+    label: "On Merge Request",
+    description: "",
+    icon: "gitlab",
+    color: "orange",
+    ...overrides,
+  };
+}
+
+function buildEvent(overrides?: Partial<NonNullable<EventInfo>>): EventInfo {
+  return {
+    id: "evt-1",
+    createdAt: new Date().toISOString(),
+    data: {},
+    nodeId: "node-1",
+    type: "gitlab.mergeRequest",
+    ...overrides,
+  };
+}
+
+function buildEventData() {
+  return {
+    object_kind: "merge_request",
+    user: { id: 1, name: "Alex Garcia", username: "agarcia" },
+    project: {
+      id: 1,
+      name: "Example Project",
+      path_with_namespace: "group/example",
+      web_url: "https://gitlab.example.com/group/example",
+    },
+    object_attributes: {
+      id: 93,
+      iid: 12,
+      title: "Add merge request trigger",
+      state: "opened",
+      action: "open",
+      url: "https://gitlab.example.com/group/example/-/merge_requests/12",
+    },
+  };
+}
+
+// ── getTitleAndSubtitle ─────────────────────────────────────────────
+
+describe("onMergeRequestTriggerRenderer.getTitleAndSubtitle", () => {
+  it("uses merge request iid and title", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: buildEventData() }) };
+    expect(onMergeRequestTriggerRenderer.getTitleAndSubtitle(ctx).title).toBe("!12 - Add merge request trigger");
+  });
+
+  it("falls back to default title when merge request is missing", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: {} }) };
+    expect(onMergeRequestTriggerRenderer.getTitleAndSubtitle(ctx).title).toBe("! - Merge Request");
+  });
+
+  it("includes action in subtitle", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ createdAt: "", data: buildEventData() }) };
+    const { subtitle } = onMergeRequestTriggerRenderer.getTitleAndSubtitle(ctx);
+    expect(subtitle).toBe("open");
+  });
+
+  it("handles undefined event data gracefully", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: undefined }) };
+    expect(() => onMergeRequestTriggerRenderer.getTitleAndSubtitle(ctx)).not.toThrow();
+  });
+});
+
+// ── getRootEventValues ──────────────────────────────────────────────
+
+describe("onMergeRequestTriggerRenderer.getRootEventValues", () => {
+  it("extracts merge request details from event data", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: buildEventData() }) };
+    const values = onMergeRequestTriggerRenderer.getRootEventValues(ctx);
+    expect(values["Title"]).toBe("Add merge request trigger");
+    expect(values["URL"]).toBe("https://gitlab.example.com/group/example/-/merge_requests/12");
+    expect(values["Action"]).toBe("open");
+    expect(values["State"]).toBe("opened");
+    expect(values["Author"]).toBe("agarcia");
+  });
+
+  it("includes received at as the first value", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: buildEventData() }) };
+    const values = onMergeRequestTriggerRenderer.getRootEventValues(ctx);
+    expect(Object.keys(values)[0]).toBe("Received At");
+    expect(values["Received At"]).not.toBe("-");
+  });
+
+  it("returns at most 6 values", () => {
+    const ctx: TriggerEventContext = { event: buildEvent({ data: buildEventData() }) };
+    expect(Object.keys(onMergeRequestTriggerRenderer.getRootEventValues(ctx)).length).toBeLessThanOrEqual(6);
+  });
+
+  it("returns placeholders when event data is missing", () => {
+    const values = onMergeRequestTriggerRenderer.getRootEventValues({ event: buildEvent({ data: {} }) });
+    expect(values["Title"]).toBe("-");
+    expect(values["URL"]).toBe("-");
+    expect(values["Action"]).toBe("-");
+    expect(values["State"]).toBe("-");
+    expect(values["Author"]).toBe("-");
+  });
+});
+
+// ── getTriggerProps ─────────────────────────────────────────────────
+
+describe("onMergeRequestTriggerRenderer.getTriggerProps", () => {
+  it("returns props with correct title from node name", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode({ name: "My Merge Request Trigger" }),
+      definition: buildDefinition(),
+      lastEvent: buildEvent(),
+    };
+    expect(onMergeRequestTriggerRenderer.getTriggerProps(ctx).title).toBe("My Merge Request Trigger");
+  });
+
+  it("falls back to definition label when node name is empty", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode({ name: "" }),
+      definition: buildDefinition({ label: "On Merge Request" }),
+      lastEvent: buildEvent(),
+    };
+    expect(onMergeRequestTriggerRenderer.getTriggerProps(ctx).title).toBe("On Merge Request");
+  });
+
+  it("includes project metadata and configured actions", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode({
+        metadata: { project: { id: 1, name: "group/example" } },
+        configuration: { actions: ["open", "merge"] },
+      }),
+      definition: buildDefinition(),
+      lastEvent: buildEvent(),
+    };
+    const props = onMergeRequestTriggerRenderer.getTriggerProps(ctx);
+    expect(props.metadata?.find((m) => String(m.label).includes("group/example"))).toBeDefined();
+    expect(props.metadata?.find((m) => String(m.label).includes("open, merge"))).toBeDefined();
+  });
+
+  it("omits metadata when project and actions are not configured", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode({ metadata: {}, configuration: {} }),
+      definition: buildDefinition(),
+      lastEvent: buildEvent(),
+    };
+    expect(onMergeRequestTriggerRenderer.getTriggerProps(ctx).metadata).toEqual([]);
+  });
+
+  it("includes lastEventData when lastEvent is provided", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode(),
+      definition: buildDefinition(),
+      lastEvent: buildEvent({ data: buildEventData() }),
+    };
+    const props = onMergeRequestTriggerRenderer.getTriggerProps(ctx);
+    expect(props.lastEventData).toBeDefined();
+    expect(props.lastEventData!.title).toBe("!12 - Add merge request trigger");
+    expect(props.lastEventData!.state).toBe("triggered");
+  });
+
+  it("omits lastEventData when lastEvent is missing", () => {
+    const ctx: TriggerRendererContext = {
+      node: buildNode(),
+      definition: buildDefinition(),
+      lastEvent: undefined,
+    };
+    expect(onMergeRequestTriggerRenderer.getTriggerProps(ctx).lastEventData).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

This updates the Gitlab Integration in the following ways:

1. Adds the `onMergeComment` trigger
2. Updates the `onMergeRequest` trigger documentation


## Demo

[Screencast from 2026-07-09 13-24-56.webm](https://github.com/user-attachments/assets/3a7b05d8-1377-4d23-a1a6-d67b2a7c99a9)
