### PR TITLE
feat: add GitLab createMergeComment and addReaction components

### DIFF
--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -21,7 +21,9 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 ## Actions
 
 <CardGrid>
+  <LinkCard title="Add Reaction" href="#add-reaction" description="Add an award emoji reaction to a GitLab merge request or comment" />
   <LinkCard title="Create Issue" href="#create-issue" description="Create a new issue in a GitLab project" />
+  <LinkCard title="Create Merge Request Comment" href="#create-merge-request-comment" description="Add a comment to a GitLab merge request" />
   <LinkCard title="Get Latest Pipeline" href="#get-latest-pipeline" description="Get the latest GitLab pipeline for a project" />
   <LinkCard title="Get Pipeline" href="#get-pipeline" description="Get a GitLab pipeline" />
   <LinkCard title="Get Test Report Summary" href="#get-test-report-summary" description="Get GitLab pipeline test report summary" />
@@ -598,6 +600,56 @@ The On Vulnerability trigger starts a workflow execution when vulnerability even
 }
 ```
 
+<a id="add-reaction"></a>
+
+## Add Reaction
+
+**Component key:** `gitlab.addReaction`
+
+The Add Reaction component adds an award emoji reaction to a GitLab merge request or to a comment (note) on a merge request.
+
+### Use Cases
+
+- **Acknowledge commands**: Add eyes to merge request comments to indicate automation saw them
+- **Workflow feedback**: React with thumbsup or rocket on success paths
+- **Fast triage signals**: Use reactions to show status without posting extra comments
+
+### Configuration
+
+- **Project**: Select the GitLab project
+- **Merge Request IID**: The internal ID (IID) of the merge request (supports expressions)
+- **Target**: Choose whether to react to the merge request itself or to a comment on it
+- **Note ID**: The comment (note) ID to react to. Required when the target is a comment.
+- **Reaction**: The award emoji name
+
+### Output
+
+Returns the created GitLab award emoji object, including id, name, user, and timestamp.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "awardable_id": 1,
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "id": 25,
+    "name": "eyes",
+    "updated_at": "2023-01-01T10:00:00.000Z",
+    "user": {
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+      "id": 1,
+      "name": "Administrator",
+      "state": "active",
+      "username": "root",
+      "web_url": "http://gitlab.example.com/root"
+    }
+  },
+  "timestamp": "2023-01-01T10:00:00.000Z",
+  "type": "gitlab.awardEmoji"
+}
+```
+
 <a id="create-issue"></a>
 
 ## Create Issue
@@ -713,6 +765,61 @@ The component outputs the created issue object, including:
   },
   "timestamp": "2023-01-01T10:00:00.000Z",
   "type": "gitlab.issue"
+}
+```
+
+<a id="create-merge-request-comment"></a>
+
+## Create Merge Request Comment
+
+**Component key:** `gitlab.createMergeComment`
+
+The Create Merge Request Comment component adds a comment (note) to an existing GitLab merge request.
+
+### Use Cases
+
+- **Deployment updates**: Post deployment status or remediation updates to a merge request
+- **Automated feedback**: Add automated review notes based on pipeline or workflow results
+- **Cross-platform sync**: Sync Slack or PagerDuty notes into GitLab as merge request comments
+
+### Configuration
+
+- **Project** (required): The GitLab project containing the merge request
+- **Merge Request IID** (required): The internal ID (IID) of the merge request to comment on (supports expressions)
+- **Body** (required): The comment text. Supports Markdown formatting.
+
+### Output
+
+Returns the created note object, including:
+- Note ID
+- Note body
+- Author information
+- Created timestamp
+
+### Example Output
+
+```json
+{
+  "data": {
+    "author": {
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+      "id": 1,
+      "name": "Administrator",
+      "state": "active",
+      "username": "root",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "body": "This is an example comment created via SuperPlane",
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "id": 302,
+    "noteable_id": 3,
+    "noteable_iid": 1,
+    "noteable_type": "MergeRequest",
+    "system": false,
+    "updated_at": "2023-01-01T10:00:00.000Z"
+  },
+  "timestamp": "2023-01-01T10:00:00.000Z",
+  "type": "gitlab.mergeRequestNote"
 }
 ```
 

--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -646,7 +646,7 @@ Returns the created GitLab award emoji object, including id, name, user, and tim
     }
   },
   "timestamp": "2023-01-01T10:00:00.000Z",
-  "type": "gitlab.awardEmoji"
+  "type": "gitlab.addReaction"
 }
 ```
 
@@ -819,7 +819,7 @@ Returns the created note object, including:
     "updated_at": "2023-01-01T10:00:00.000Z"
   },
   "timestamp": "2023-01-01T10:00:00.000Z",
-  "type": "gitlab.mergeRequestNote"
+  "type": "gitlab.createMergeComment"
 }
 ```
 

--- a/pkg/integrations/gitlab/add_reaction.go
+++ b/pkg/integrations/gitlab/add_reaction.go
@@ -224,7 +224,7 @@ func (c *AddReaction) Execute(ctx core.ExecutionContext) error {
 
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
-		"gitlab.awardEmoji",
+		"gitlab.addReaction",
 		[]any{awardEmoji},
 	)
 }

--- a/pkg/integrations/gitlab/add_reaction.go
+++ b/pkg/integrations/gitlab/add_reaction.go
@@ -1,0 +1,254 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_add_reaction.json
+var exampleOutputAddReaction []byte
+
+type AddReaction struct{}
+
+const (
+	ReactionTargetMergeRequest = "mergeRequest"
+	ReactionTargetNote         = "note"
+)
+
+type AddReactionConfiguration struct {
+	Project         string `mapstructure:"project"`
+	MergeRequestIID string `mapstructure:"mergeRequestIid"`
+	Target          string `mapstructure:"target"`
+	NoteID          string `mapstructure:"noteId"`
+	Content         string `mapstructure:"content"`
+}
+
+func (c *AddReaction) Name() string {
+	return "gitlab.addReaction"
+}
+
+func (c *AddReaction) Label() string {
+	return "Add Reaction"
+}
+
+func (c *AddReaction) Description() string {
+	return "Add an award emoji reaction to a GitLab merge request or comment"
+}
+
+func (c *AddReaction) Documentation() string {
+	return `The Add Reaction component adds an award emoji reaction to a GitLab merge request or to a comment (note) on a merge request.
+
+## Use Cases
+
+- **Acknowledge commands**: Add eyes to merge request comments to indicate automation saw them
+- **Workflow feedback**: React with thumbsup or rocket on success paths
+- **Fast triage signals**: Use reactions to show status without posting extra comments
+
+## Configuration
+
+- **Project**: Select the GitLab project
+- **Merge Request IID**: The internal ID (IID) of the merge request (supports expressions)
+- **Target**: Choose whether to react to the merge request itself or to a comment on it
+- **Note ID**: The comment (note) ID to react to. Required when the target is a comment.
+- **Reaction**: The award emoji name
+
+## Output
+
+Returns the created GitLab award emoji object, including id, name, user, and timestamp.`
+}
+
+func (c *AddReaction) Icon() string {
+	return "gitlab"
+}
+
+func (c *AddReaction) Color() string {
+	return "orange"
+}
+
+func (c *AddReaction) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *AddReaction) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputAddReaction, &example); err != nil {
+		return map[string]any{}
+	}
+	return example
+}
+
+func (c *AddReaction) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "project",
+			Label:    "Project",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeProject,
+				},
+			},
+		},
+		{
+			Name:        "mergeRequestIid",
+			Label:       "Merge Request IID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The internal ID (IID) of the merge request",
+		},
+		{
+			Name:     "target",
+			Label:    "Target",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  ReactionTargetMergeRequest,
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Merge request", Value: ReactionTargetMergeRequest},
+						{Label: "Comment", Value: ReactionTargetNote},
+					},
+				},
+			},
+		},
+		{
+			Name:        "noteId",
+			Label:       "Note ID",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "ID of the comment to react to. Required when the target is a comment.",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "target", Values: []string{ReactionTargetNote}},
+			},
+		},
+		{
+			Name:     "content",
+			Label:    "Reaction",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "eyes",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "thumbsup", Value: "thumbsup"},
+						{Label: "thumbsdown", Value: "thumbsdown"},
+						{Label: "laughing", Value: "laughing"},
+						{Label: "confused", Value: "confused"},
+						{Label: "heart", Value: "heart"},
+						{Label: "tada", Value: "tada"},
+						{Label: "rocket", Value: "rocket"},
+						{Label: "eyes", Value: "eyes"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *AddReaction) Setup(ctx core.SetupContext) error {
+	var config AddReactionConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Project == "" {
+		return errors.New("project is required")
+	}
+
+	if config.MergeRequestIID == "" {
+		return errors.New("merge request IID is required")
+	}
+
+	if config.Content == "" {
+		return errors.New("reaction content is required")
+	}
+
+	if config.Target != ReactionTargetMergeRequest && config.Target != ReactionTargetNote {
+		return fmt.Errorf("invalid target: %s", config.Target)
+	}
+
+	if config.Target == ReactionTargetNote && strings.TrimSpace(config.NoteID) == "" {
+		return errors.New("note ID is required when target is a comment")
+	}
+
+	return ensureProjectInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		config.Project,
+	)
+}
+
+func (c *AddReaction) Execute(ctx core.ExecutionContext) error {
+	var config AddReactionConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Target != ReactionTargetMergeRequest && config.Target != ReactionTargetNote {
+		return fmt.Errorf("invalid target: %s", config.Target)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitLab client: %w", err)
+	}
+
+	req := &CreateAwardEmojiRequest{Name: config.Content}
+
+	var awardEmoji *AwardEmoji
+	switch config.Target {
+	case ReactionTargetMergeRequest:
+		awardEmoji, err = client.CreateMergeRequestAwardEmoji(context.Background(), config.Project, config.MergeRequestIID, req)
+		if err != nil {
+			return fmt.Errorf("failed to create merge request reaction: %w", err)
+		}
+	case ReactionTargetNote:
+		if strings.TrimSpace(config.NoteID) == "" {
+			return errors.New("note ID is required when target is a comment")
+		}
+		awardEmoji, err = client.CreateMergeRequestNoteAwardEmoji(context.Background(), config.Project, config.MergeRequestIID, config.NoteID, req)
+		if err != nil {
+			return fmt.Errorf("failed to create comment reaction: %w", err)
+		}
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gitlab.awardEmoji",
+		[]any{awardEmoji},
+	)
+}
+
+func (c *AddReaction) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *AddReaction) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *AddReaction) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *AddReaction) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *AddReaction) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *AddReaction) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gitlab/add_reaction_test.go
+++ b/pkg/integrations/gitlab/add_reaction_test.go
@@ -168,7 +168,7 @@ func Test__AddReaction__Execute(t *testing.T) {
 		require.Len(t, executionState.Payloads, 1)
 		payload := executionState.Payloads[0].(map[string]any)
 		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
-		assert.Equal(t, "gitlab.awardEmoji", executionState.Type)
+		assert.Equal(t, "gitlab.addReaction", executionState.Type)
 
 		var awardEmoji AwardEmoji
 		awardEmojiPayload := payload["data"]
@@ -213,7 +213,7 @@ func Test__AddReaction__Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, executionState.Payloads, 1)
-		assert.Equal(t, "gitlab.awardEmoji", executionState.Type)
+		assert.Equal(t, "gitlab.addReaction", executionState.Type)
 	})
 
 	t.Run("failure", func(t *testing.T) {

--- a/pkg/integrations/gitlab/add_reaction_test.go
+++ b/pkg/integrations/gitlab/add_reaction_test.go
@@ -179,6 +179,48 @@ func Test__AddReaction__Execute(t *testing.T) {
 		assert.Equal(t, "eyes", awardEmoji.Name)
 	})
 
+	t.Run("merge request target - already exists - returns existing reaction", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetMergeRequest,
+				"content":         "eyes",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusNotFound, `{"message":"404 Award Emoji Name has already been taken"}`),
+					GitlabMockResponse(http.StatusOK, `{"id": 42}`),
+					GitlabMockResponse(http.StatusOK, `[{"id": 25, "name": "eyes", "user": {"id": 42}}]`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		assert.Equal(t, "gitlab.addReaction", executionState.Type)
+
+		var awardEmoji AwardEmoji
+		payload := executionState.Payloads[0].(map[string]any)
+		payloadBytes, _ := json.Marshal(payload["data"])
+		json.Unmarshal(payloadBytes, &awardEmoji)
+
+		assert.Equal(t, 25, awardEmoji.ID)
+		assert.Equal(t, "eyes", awardEmoji.Name)
+	})
+
 	t.Run("note target - success", func(t *testing.T) {
 		executionState := &contexts.ExecutionStateContext{}
 		ctx := core.ExecutionContext{

--- a/pkg/integrations/gitlab/add_reaction_test.go
+++ b/pkg/integrations/gitlab/add_reaction_test.go
@@ -1,0 +1,246 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__AddReaction__Setup(t *testing.T) {
+	c := &AddReaction{}
+
+	t.Run("missing project", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetMergeRequest,
+				"content":         "eyes",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("missing merge request IID", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project": "123",
+				"target":  ReactionTargetMergeRequest,
+				"content": "eyes",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "merge request IID is required")
+	})
+
+	t.Run("missing content", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetMergeRequest,
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reaction content is required")
+	})
+
+	t.Run("invalid target", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          "bogus",
+				"content":         "eyes",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid target")
+	})
+
+	t.Run("note target missing note ID", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetNote,
+				"content":         "eyes",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "note ID is required")
+	})
+
+	t.Run("valid configuration - merge request target", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetMergeRequest,
+				"content":         "eyes",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration - note target", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetNote,
+				"noteId":          "99",
+				"content":         "eyes",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__AddReaction__Execute(t *testing.T) {
+	c := &AddReaction{}
+
+	t.Run("merge request target - success", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetMergeRequest,
+				"content":         "eyes",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusCreated, `{
+						"id": 25,
+						"name": "eyes",
+						"created_at": "2023-01-01T10:00:00.000Z"
+					}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, "gitlab.awardEmoji", executionState.Type)
+
+		var awardEmoji AwardEmoji
+		awardEmojiPayload := payload["data"]
+		payloadBytes, _ := json.Marshal(awardEmojiPayload)
+		json.Unmarshal(payloadBytes, &awardEmoji)
+
+		assert.Equal(t, 25, awardEmoji.ID)
+		assert.Equal(t, "eyes", awardEmoji.Name)
+	})
+
+	t.Run("note target - success", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetNote,
+				"noteId":          "99",
+				"content":         "rocket",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusCreated, `{
+						"id": 26,
+						"name": "rocket",
+						"created_at": "2023-01-01T10:00:00.000Z"
+					}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		assert.Equal(t, "gitlab.awardEmoji", executionState.Type)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"target":          ReactionTargetMergeRequest,
+				"content":         "eyes",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusInternalServerError, `{"error": "internal server error"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create merge request reaction")
+	})
+}

--- a/pkg/integrations/gitlab/client.go
+++ b/pkg/integrations/gitlab/client.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
@@ -515,16 +517,73 @@ type CreateAwardEmojiRequest struct {
 	Name string `json:"name"`
 }
 
+// errAwardEmojiAlreadyExists is returned when the authenticated user has already
+// awarded the given emoji to the target - GitLab reports this as a 404 with an
+// "Award Emoji Name has already been taken" message rather than a 409 Conflict.
+var errAwardEmojiAlreadyExists = errors.New("award emoji already exists")
+
 // CreateMergeRequestAwardEmoji adds an award emoji to the merge request itself.
+// If the authenticated user has already awarded this emoji, it returns the
+// existing award emoji instead of failing, making the operation idempotent.
 func (c *Client) CreateMergeRequestAwardEmoji(ctx context.Context, projectID, mergeRequestIID string, req *CreateAwardEmojiRequest) (*AwardEmoji, error) {
 	apiURL := fmt.Sprintf("%s/api/%s/projects/%s/merge_requests/%s/award_emoji", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(mergeRequestIID))
-	return c.createAwardEmoji(ctx, apiURL, req)
+	awardEmoji, err := c.createAwardEmoji(ctx, apiURL, req)
+	if errors.Is(err, errAwardEmojiAlreadyExists) {
+		return c.findExistingAwardEmoji(req.Name, func() ([]AwardEmoji, error) {
+			return c.ListMergeRequestAwardEmoji(projectID, mergeRequestIID)
+		})
+	}
+	return awardEmoji, err
 }
 
 // CreateMergeRequestNoteAwardEmoji adds an award emoji to a note on a merge request.
+// If the authenticated user has already awarded this emoji, it returns the
+// existing award emoji instead of failing, making the operation idempotent.
 func (c *Client) CreateMergeRequestNoteAwardEmoji(ctx context.Context, projectID, mergeRequestIID, noteID string, req *CreateAwardEmojiRequest) (*AwardEmoji, error) {
 	apiURL := fmt.Sprintf("%s/api/%s/projects/%s/merge_requests/%s/notes/%s/award_emoji", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(mergeRequestIID), url.PathEscape(noteID))
-	return c.createAwardEmoji(ctx, apiURL, req)
+	awardEmoji, err := c.createAwardEmoji(ctx, apiURL, req)
+	if errors.Is(err, errAwardEmojiAlreadyExists) {
+		return c.findExistingAwardEmoji(req.Name, func() ([]AwardEmoji, error) {
+			return c.ListMergeRequestNoteAwardEmoji(projectID, mergeRequestIID, noteID)
+		})
+	}
+	return awardEmoji, err
+}
+
+// ListMergeRequestAwardEmoji lists the award emoji on a merge request.
+func (c *Client) ListMergeRequestAwardEmoji(projectID, mergeRequestIID string) ([]AwardEmoji, error) {
+	return fetchAllResources[AwardEmoji](c, func(page int) string {
+		return fmt.Sprintf("%s/api/%s/projects/%s/merge_requests/%s/award_emoji?per_page=100&page=%d", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(mergeRequestIID), page)
+	})
+}
+
+// ListMergeRequestNoteAwardEmoji lists the award emoji on a note of a merge request.
+func (c *Client) ListMergeRequestNoteAwardEmoji(projectID, mergeRequestIID, noteID string) ([]AwardEmoji, error) {
+	return fetchAllResources[AwardEmoji](c, func(page int) string {
+		return fmt.Sprintf("%s/api/%s/projects/%s/merge_requests/%s/notes/%s/award_emoji?per_page=100&page=%d", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(mergeRequestIID), url.PathEscape(noteID), page)
+	})
+}
+
+// findExistingAwardEmoji locates the authenticated user's award emoji with the given
+// name among the results of listFn, used to recover from errAwardEmojiAlreadyExists.
+func (c *Client) findExistingAwardEmoji(name string, listFn func() ([]AwardEmoji, error)) (*AwardEmoji, error) {
+	user, err := c.getCurrentUser()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current user: %v", err)
+	}
+
+	awardEmoji, err := listFn()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list existing award emoji: %v", err)
+	}
+
+	for _, e := range awardEmoji {
+		if e.Name == name && e.User.ID == user.ID {
+			return &e, nil
+		}
+	}
+
+	return nil, fmt.Errorf("award emoji %q reported as already existing but could not be found", name)
 }
 
 func (c *Client) createAwardEmoji(ctx context.Context, apiURL string, req *CreateAwardEmojiRequest) (*AwardEmoji, error) {
@@ -546,7 +605,11 @@ func (c *Client) createAwardEmoji(ctx context.Context, apiURL string, req *Creat
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("failed to create award emoji: status %d, response: %s", resp.StatusCode, readResponseBody(resp))
+		responseBody := readResponseBody(resp)
+		if resp.StatusCode == http.StatusNotFound && strings.Contains(parseGitlabErrorMessage(responseBody), "already been taken") {
+			return nil, errAwardEmojiAlreadyExists
+		}
+		return nil, fmt.Errorf("failed to create award emoji: status %d, response: %s", resp.StatusCode, responseBody)
 	}
 
 	var awardEmoji AwardEmoji
@@ -555,6 +618,19 @@ func (c *Client) createAwardEmoji(ctx context.Context, apiURL string, req *Creat
 	}
 
 	return &awardEmoji, nil
+}
+
+// parseGitlabErrorMessage extracts the "message" field from a GitLab JSON error
+// body (e.g. {"message":"404 Award Emoji Name has already been taken"}),
+// falling back to the raw body if it isn't in that shape.
+func parseGitlabErrorMessage(body string) string {
+	var errResp struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(body), &errResp); err == nil && errResp.Message != "" {
+		return errResp.Message
+	}
+	return body
 }
 
 func readResponseBody(resp *http.Response) string {

--- a/pkg/integrations/gitlab/client.go
+++ b/pkg/integrations/gitlab/client.go
@@ -454,6 +454,109 @@ func (c *Client) ListPipelines(projectID string) ([]Pipeline, error) {
 	})
 }
 
+type Note struct {
+	ID           int    `json:"id"`
+	Body         string `json:"body"`
+	Author       User   `json:"author"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+	System       bool   `json:"system"`
+	NoteableID   int    `json:"noteable_id,omitempty"`
+	NoteableIID  int    `json:"noteable_iid,omitempty"`
+	NoteableType string `json:"noteable_type,omitempty"`
+}
+
+type CreateNoteRequest struct {
+	Body string `json:"body"`
+}
+
+func (c *Client) CreateMergeRequestNote(ctx context.Context, projectID, mergeRequestIID string, req *CreateNoteRequest) (*Note, error) {
+	apiURL := fmt.Sprintf("%s/api/%s/projects/%s/merge_requests/%s/notes", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(mergeRequestIID))
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create merge request note: status %d, response: %s", resp.StatusCode, readResponseBody(resp))
+	}
+
+	var note Note
+	if err := json.NewDecoder(resp.Body).Decode(&note); err != nil {
+		return nil, fmt.Errorf("failed to decode note: %v", err)
+	}
+
+	return &note, nil
+}
+
+type AwardEmoji struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	User        User   `json:"user"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+	AwardableID int    `json:"awardable_id,omitempty"`
+}
+
+type CreateAwardEmojiRequest struct {
+	Name string `json:"name"`
+}
+
+// CreateMergeRequestAwardEmoji adds an award emoji to the merge request itself.
+func (c *Client) CreateMergeRequestAwardEmoji(ctx context.Context, projectID, mergeRequestIID string, req *CreateAwardEmojiRequest) (*AwardEmoji, error) {
+	apiURL := fmt.Sprintf("%s/api/%s/projects/%s/merge_requests/%s/award_emoji", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(mergeRequestIID))
+	return c.createAwardEmoji(ctx, apiURL, req)
+}
+
+// CreateMergeRequestNoteAwardEmoji adds an award emoji to a note on a merge request.
+func (c *Client) CreateMergeRequestNoteAwardEmoji(ctx context.Context, projectID, mergeRequestIID, noteID string, req *CreateAwardEmojiRequest) (*AwardEmoji, error) {
+	apiURL := fmt.Sprintf("%s/api/%s/projects/%s/merge_requests/%s/notes/%s/award_emoji", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(mergeRequestIID), url.PathEscape(noteID))
+	return c.createAwardEmoji(ctx, apiURL, req)
+}
+
+func (c *Client) createAwardEmoji(ctx context.Context, apiURL string, req *CreateAwardEmojiRequest) (*AwardEmoji, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create award emoji: status %d, response: %s", resp.StatusCode, readResponseBody(resp))
+	}
+
+	var awardEmoji AwardEmoji
+	if err := json.NewDecoder(resp.Body).Decode(&awardEmoji); err != nil {
+		return nil, fmt.Errorf("failed to decode award emoji: %v", err)
+	}
+
+	return &awardEmoji, nil
+}
+
 func readResponseBody(resp *http.Response) string {
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if err != nil {

--- a/pkg/integrations/gitlab/client_test.go
+++ b/pkg/integrations/gitlab/client_test.go
@@ -632,3 +632,106 @@ func Test__Client__ListPipelines(t *testing.T) {
 		assert.Equal(t, "https://gitlab.com/api/v4/projects/456/pipelines?per_page=100&page=1", mockClient.Requests[0].URL.String())
 	})
 }
+
+func Test__Client__CreateMergeRequestAwardEmoji(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusCreated, `{"id": 25, "name": "eyes", "user": {"id": 42}}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			groupID:    "123",
+			httpClient: mockClient,
+		}
+
+		result, err := client.CreateMergeRequestAwardEmoji(context.Background(), "1", "1", &CreateAwardEmojiRequest{Name: "eyes"})
+		require.NoError(t, err)
+		assert.Equal(t, 25, result.ID)
+		assert.Equal(t, "eyes", result.Name)
+
+		require.Len(t, mockClient.Requests, 1)
+	})
+
+	t.Run("already exists - returns the existing award emoji", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusNotFound, `{"message":"404 Award Emoji Name has already been taken"}`),
+				GitlabMockResponse(http.StatusOK, `{"id": 42}`),
+				GitlabMockResponse(http.StatusOK, `[
+					{"id": 24, "name": "eyes", "user": {"id": 7}},
+					{"id": 25, "name": "eyes", "user": {"id": 42}},
+					{"id": 26, "name": "rocket", "user": {"id": 42}}
+				]`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			groupID:    "123",
+			httpClient: mockClient,
+		}
+
+		result, err := client.CreateMergeRequestAwardEmoji(context.Background(), "1", "1", &CreateAwardEmojiRequest{Name: "eyes"})
+		require.NoError(t, err)
+		assert.Equal(t, 25, result.ID)
+		assert.Equal(t, "eyes", result.Name)
+		assert.Equal(t, 42, result.User.ID)
+
+		require.Len(t, mockClient.Requests, 3)
+		assert.Equal(t, http.MethodPost, mockClient.Requests[0].Method)
+		assert.Equal(t, http.MethodGet, mockClient.Requests[1].Method)
+		assert.Equal(t, "https://gitlab.com/api/v4/user", mockClient.Requests[1].URL.String())
+		assert.Equal(t, http.MethodGet, mockClient.Requests[2].Method)
+	})
+
+	t.Run("already exists but not found in listing - returns an error", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusNotFound, `{"message":"404 Award Emoji Name has already been taken"}`),
+				GitlabMockResponse(http.StatusOK, `{"id": 42}`),
+				GitlabMockResponse(http.StatusOK, `[]`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			groupID:    "123",
+			httpClient: mockClient,
+		}
+
+		_, err := client.CreateMergeRequestAwardEmoji(context.Background(), "1", "1", &CreateAwardEmojiRequest{Name: "eyes"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reported as already existing but could not be found")
+	})
+
+	t.Run("other error - not treated as already-exists", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusNotFound, `{"message":"404 Project Not Found"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			groupID:    "123",
+			httpClient: mockClient,
+		}
+
+		_, err := client.CreateMergeRequestAwardEmoji(context.Background(), "1", "1", &CreateAwardEmojiRequest{Name: "eyes"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create award emoji")
+
+		require.Len(t, mockClient.Requests, 1)
+	})
+}

--- a/pkg/integrations/gitlab/create_merge_comment.go
+++ b/pkg/integrations/gitlab/create_merge_comment.go
@@ -154,7 +154,7 @@ func (c *CreateMergeComment) Execute(ctx core.ExecutionContext) error {
 
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
-		"gitlab.mergeRequestNote",
+		"gitlab.createMergeComment",
 		[]any{note},
 	)
 }

--- a/pkg/integrations/gitlab/create_merge_comment.go
+++ b/pkg/integrations/gitlab/create_merge_comment.go
@@ -1,0 +1,184 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_create_merge_comment.json
+var exampleOutputCreateMergeComment []byte
+
+type CreateMergeComment struct{}
+
+type CreateMergeCommentConfiguration struct {
+	Project         string `mapstructure:"project"`
+	MergeRequestIID string `mapstructure:"mergeRequestIid"`
+	Body            string `mapstructure:"body"`
+}
+
+func (c *CreateMergeComment) Name() string {
+	return "gitlab.createMergeComment"
+}
+
+func (c *CreateMergeComment) Label() string {
+	return "Create Merge Request Comment"
+}
+
+func (c *CreateMergeComment) Description() string {
+	return "Add a comment to a GitLab merge request"
+}
+
+func (c *CreateMergeComment) Documentation() string {
+	return `The Create Merge Request Comment component adds a comment (note) to an existing GitLab merge request.
+
+## Use Cases
+
+- **Deployment updates**: Post deployment status or remediation updates to a merge request
+- **Automated feedback**: Add automated review notes based on pipeline or workflow results
+- **Cross-platform sync**: Sync Slack or PagerDuty notes into GitLab as merge request comments
+
+## Configuration
+
+- **Project** (required): The GitLab project containing the merge request
+- **Merge Request IID** (required): The internal ID (IID) of the merge request to comment on (supports expressions)
+- **Body** (required): The comment text. Supports Markdown formatting.
+
+## Output
+
+Returns the created note object, including:
+- Note ID
+- Note body
+- Author information
+- Created timestamp`
+}
+
+func (c *CreateMergeComment) Icon() string {
+	return "gitlab"
+}
+
+func (c *CreateMergeComment) Color() string {
+	return "orange"
+}
+
+func (c *CreateMergeComment) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateMergeComment) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputCreateMergeComment, &example); err != nil {
+		return map[string]any{}
+	}
+	return example
+}
+
+func (c *CreateMergeComment) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "project",
+			Label:    "Project",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeProject,
+				},
+			},
+		},
+		{
+			Name:        "mergeRequestIid",
+			Label:       "Merge Request IID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The internal ID (IID) of the merge request to comment on",
+		},
+		{
+			Name:        "body",
+			Label:       "Body",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Description: "The comment text. Supports Markdown formatting.",
+		},
+	}
+}
+
+func (c *CreateMergeComment) Setup(ctx core.SetupContext) error {
+	var config CreateMergeCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Project == "" {
+		return fmt.Errorf("project is required")
+	}
+
+	if config.MergeRequestIID == "" {
+		return fmt.Errorf("merge request IID is required")
+	}
+
+	if config.Body == "" {
+		return fmt.Errorf("body is required")
+	}
+
+	return ensureProjectInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		config.Project,
+	)
+}
+
+func (c *CreateMergeComment) Execute(ctx core.ExecutionContext) error {
+	var config CreateMergeCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitLab client: %w", err)
+	}
+
+	note, err := client.CreateMergeRequestNote(context.Background(), config.Project, config.MergeRequestIID, &CreateNoteRequest{
+		Body: config.Body,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create merge request comment: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gitlab.mergeRequestNote",
+		[]any{note},
+	)
+}
+
+func (c *CreateMergeComment) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateMergeComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *CreateMergeComment) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateMergeComment) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateMergeComment) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateMergeComment) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gitlab/create_merge_comment_test.go
+++ b/pkg/integrations/gitlab/create_merge_comment_test.go
@@ -111,7 +111,7 @@ func Test__CreateMergeComment__Execute(t *testing.T) {
 		require.Len(t, executionState.Payloads, 1)
 		payload := executionState.Payloads[0].(map[string]any)
 		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
-		assert.Equal(t, "gitlab.mergeRequestNote", executionState.Type)
+		assert.Equal(t, "gitlab.createMergeComment", executionState.Type)
 
 		var note Note
 		notePayload := payload["data"]

--- a/pkg/integrations/gitlab/create_merge_comment_test.go
+++ b/pkg/integrations/gitlab/create_merge_comment_test.go
@@ -1,0 +1,151 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateMergeComment__Setup(t *testing.T) {
+	c := &CreateMergeComment{}
+
+	t.Run("missing project", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"mergeRequestIid": "1",
+				"body":            "Comment body",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("missing merge request IID", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project": "123",
+				"body":    "Comment body",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "merge request IID is required")
+	})
+
+	t.Run("missing body", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "body is required")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"body":            "Comment body",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreateMergeComment__Execute(t *testing.T) {
+	c := &CreateMergeComment{}
+
+	t.Run("success", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"body":            "Comment body",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusCreated, `{
+						"id": 302,
+						"body": "Comment body",
+						"created_at": "2023-01-01T10:00:00.000Z"
+					}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, "gitlab.mergeRequestNote", executionState.Type)
+
+		var note Note
+		notePayload := payload["data"]
+		payloadBytes, _ := json.Marshal(notePayload)
+		json.Unmarshal(payloadBytes, &note)
+
+		assert.Equal(t, 302, note.ID)
+		assert.Equal(t, "Comment body", note.Body)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":         "123",
+				"mergeRequestIid": "1",
+				"body":            "Comment body",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusInternalServerError, `{"error": "internal server error"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create merge request comment")
+	})
+}

--- a/pkg/integrations/gitlab/example_output_add_reaction.json
+++ b/pkg/integrations/gitlab/example_output_add_reaction.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "id": 25,
+    "name": "eyes",
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "updated_at": "2023-01-01T10:00:00.000Z",
+    "awardable_id": 1
+  },
+  "timestamp": "2023-01-01T10:00:00.000Z",
+  "type": "gitlab.awardEmoji"
+}

--- a/pkg/integrations/gitlab/example_output_add_reaction.json
+++ b/pkg/integrations/gitlab/example_output_add_reaction.json
@@ -15,5 +15,5 @@
     "awardable_id": 1
   },
   "timestamp": "2023-01-01T10:00:00.000Z",
-  "type": "gitlab.awardEmoji"
+  "type": "gitlab.addReaction"
 }

--- a/pkg/integrations/gitlab/example_output_create_merge_comment.json
+++ b/pkg/integrations/gitlab/example_output_create_merge_comment.json
@@ -18,5 +18,5 @@
     "noteable_type": "MergeRequest"
   },
   "timestamp": "2023-01-01T10:00:00.000Z",
-  "type": "gitlab.mergeRequestNote"
+  "type": "gitlab.createMergeComment"
 }

--- a/pkg/integrations/gitlab/example_output_create_merge_comment.json
+++ b/pkg/integrations/gitlab/example_output_create_merge_comment.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "id": 302,
+    "body": "This is an example comment created via SuperPlane",
+    "author": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "updated_at": "2023-01-01T10:00:00.000Z",
+    "system": false,
+    "noteable_id": 3,
+    "noteable_iid": 1,
+    "noteable_type": "MergeRequest"
+  },
+  "timestamp": "2023-01-01T10:00:00.000Z",
+  "type": "gitlab.mergeRequestNote"
+}

--- a/pkg/integrations/gitlab/gitlab.go
+++ b/pkg/integrations/gitlab/gitlab.go
@@ -175,6 +175,8 @@ func (g *GitLab) Actions() []core.Action {
 		&GetPipeline{},
 		&GetLatestPipeline{},
 		&GetTestReportSummary{},
+		&CreateMergeComment{},
+		&AddReaction{},
 	}
 }
 

--- a/web_src/src/pages/app/mappers/gitlab/add_reaction.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/add_reaction.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { addReactionMapper } from "./add_reaction";
+
+describe("addReactionMapper", () => {
+  it("shows reaction details for a merge request target", () => {
+    const details = addReactionMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          project: "123",
+          mergeRequestIid: "1",
+          target: "mergeRequest",
+          content: "eyes",
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                id: 25,
+                name: "eyes",
+                user: { username: "root" },
+                created_at: "2026-06-11T14:30:00Z",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      Reaction: "👀",
+      "Created By": "root",
+      "Created At": expect.any(String),
+    });
+  });
+
+  it("shows reaction details for a note target", () => {
+    const details = addReactionMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          project: "123",
+          mergeRequestIid: "1",
+          target: "note",
+          noteId: "302",
+          content: "rocket",
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                id: 26,
+                name: "rocket",
+                user: { username: "root" },
+                created_at: "2026-06-11T14:30:00Z",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details["Reaction"]).toEqual("🚀");
+  });
+
+  it("handles missing outputs", () => {
+    const details = addReactionMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: { project: "123", mergeRequestIid: "1", target: "mergeRequest", content: "eyes" },
+        outputs: {},
+      }),
+    );
+
+    expect(details).toEqual({});
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Add Reaction",
+    componentName: "gitlab.addReaction",
+    isCollapsed: false,
+    metadata: {
+      project: {
+        id: 123,
+        name: "felixgateru/hello-world",
+        url: "https://gitlab.com/felixgateru/hello-world",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/gitlab/add_reaction.ts
+++ b/web_src/src/pages/app/mappers/gitlab/add_reaction.ts
@@ -1,0 +1,96 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import type { AwardEmoji, GitLabNodeMetadata } from "./types";
+import { buildGitlabExecutionSubtitle } from "./utils";
+
+interface AddReactionConfiguration {
+  project?: string;
+  mergeRequestIid?: string;
+  target?: string;
+  noteId?: string;
+  content?: string;
+}
+
+function getReactionDisplay(name?: string): string {
+  switch (name) {
+    case "thumbsup":
+      return "👍";
+    case "thumbsdown":
+      return "👎";
+    case "laughing":
+      return "😄";
+    case "confused":
+      return "😕";
+    case "heart":
+      return "❤️";
+    case "tada":
+      return "🎉";
+    case "rocket":
+      return "🚀";
+    case "eyes":
+      return "👀";
+    default:
+      return name || "-";
+  }
+}
+
+export const addReactionMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as AddReactionConfiguration | undefined) ?? {};
+    const metadata = (context.node.metadata as GitLabNodeMetadata | undefined) ?? ({} as GitLabNodeMetadata);
+
+    const project = metadata?.project?.name || configuration.project;
+    const metadataItems: MetadataItem[] = [];
+
+    if (project) {
+      metadataItems.push({ icon: "book", label: project });
+    }
+
+    if (configuration.mergeRequestIid) {
+      metadataItems.push({ icon: "git-pull-request", label: `!${configuration.mergeRequestIid}` });
+    }
+
+    if (configuration.target === "note" && configuration.noteId) {
+      metadataItems.push({ icon: "message-square", label: `Comment #${configuration.noteId}` });
+    }
+
+    if (configuration.content) {
+      metadataItems.push({ icon: "smile", label: `Reaction: ${getReactionDisplay(configuration.content)}` });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGitlabExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const details: Record<string, string> = {};
+
+    if (!outputs?.default || outputs.default.length === 0) {
+      return details;
+    }
+
+    const awardEmoji = outputs.default[0].data as AwardEmoji;
+    details["Reaction"] = getReactionDisplay(awardEmoji?.name);
+    details["Created By"] = awardEmoji?.user?.username || "-";
+    details["Created At"] = awardEmoji?.created_at ? new Date(awardEmoji.created_at).toLocaleString() : "-";
+
+    return details;
+  },
+};

--- a/web_src/src/pages/app/mappers/gitlab/create_merge_comment.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/create_merge_comment.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { createMergeCommentMapper } from "./create_merge_comment";
+
+describe("createMergeCommentMapper", () => {
+  it("shows created comment details", () => {
+    const details = createMergeCommentMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          project: "123",
+          mergeRequestIid: "1",
+          body: "Automated comment",
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                id: 302,
+                body: "Automated comment",
+                author: { username: "root" },
+                created_at: "2026-06-11T14:30:00Z",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Created At": expect.any(String),
+      "Created By": "root",
+    });
+  });
+
+  it("handles missing outputs", () => {
+    const details = createMergeCommentMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: { project: "123", mergeRequestIid: "1" },
+        outputs: {},
+      }),
+    );
+
+    expect(details).toEqual({});
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Create Merge Request Comment",
+    componentName: "gitlab.createMergeComment",
+    isCollapsed: false,
+    metadata: {
+      project: {
+        id: 123,
+        name: "felixgateru/hello-world",
+        url: "https://gitlab.com/felixgateru/hello-world",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/gitlab/create_merge_comment.ts
+++ b/web_src/src/pages/app/mappers/gitlab/create_merge_comment.ts
@@ -1,0 +1,61 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import type { GitLabNodeMetadata, Note } from "./types";
+import { buildGitlabExecutionSubtitle } from "./utils";
+
+interface CreateMergeCommentConfiguration {
+  project?: string;
+  mergeRequestIid?: string;
+}
+
+export const createMergeCommentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as CreateMergeCommentConfiguration | undefined) ?? {};
+    const metadata = (context.node.metadata as GitLabNodeMetadata | undefined) ?? ({} as GitLabNodeMetadata);
+
+    const project = metadata?.project?.name || configuration.project;
+    const metadataItems: MetadataItem[] = [];
+
+    if (project) {
+      metadataItems.push({ icon: "book", label: project });
+    }
+
+    if (configuration.mergeRequestIid) {
+      metadataItems.push({ icon: "git-pull-request", label: `!${configuration.mergeRequestIid}` });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGitlabExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const details: Record<string, string> = {};
+
+    if (!outputs?.default || outputs.default.length === 0) {
+      return details;
+    }
+
+    const note = outputs.default[0].data as Note;
+    details["Created At"] = note?.created_at ? new Date(note.created_at).toLocaleString() : "-";
+    details["Created By"] = note?.author?.username || "-";
+
+    return details;
+  },
+};

--- a/web_src/src/pages/app/mappers/gitlab/index.ts
+++ b/web_src/src/pages/app/mappers/gitlab/index.ts
@@ -1,6 +1,8 @@
 import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
 import { buildActionStateRegistry } from "../utils";
+import { addReactionMapper } from "./add_reaction";
 import { createIssueMapper } from "./create_issue";
+import { createMergeCommentMapper } from "./create_merge_comment";
 import { onIssueTriggerRenderer } from "./on_issue";
 import { onMergeRequestTriggerRenderer } from "./on_merge_request";
 import { onMilestoneTriggerRenderer } from "./on_milestone";
@@ -17,6 +19,8 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   getPipeline: buildActionStateRegistry("retrieved"),
   getLatestPipeline: buildActionStateRegistry("retrieved"),
   getTestReportSummary: buildActionStateRegistry("retrieved"),
+  createMergeComment: buildActionStateRegistry("created"),
+  addReaction: buildActionStateRegistry("added"),
 };
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
@@ -25,6 +29,8 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   getPipeline: pipelineLookupMapper,
   getLatestPipeline: pipelineLookupMapper,
   getTestReportSummary: testReportSummaryMapper,
+  createMergeComment: createMergeCommentMapper,
+  addReaction: addReactionMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {

--- a/web_src/src/pages/app/mappers/gitlab/types.ts
+++ b/web_src/src/pages/app/mappers/gitlab/types.ts
@@ -41,3 +41,24 @@ export interface GitLabNodeMetadata {
     id?: number;
   };
 }
+
+export interface Note {
+  id: number;
+  body: string;
+  author: User;
+  created_at: string;
+  updated_at: string;
+  system: boolean;
+  noteable_id?: number;
+  noteable_iid?: number;
+  noteable_type?: string;
+}
+
+export interface AwardEmoji {
+  id: number;
+  name: string;
+  user: User;
+  created_at: string;
+  updated_at: string;
+  awardable_id?: number;
+}


### PR DESCRIPTION
## What changed
Added two new GitLab integration components: `gitlab.createMergeComment` (post a comment/note on a merge request) and `gitlab.addReaction` (add an award emoji reaction to a merge request or a comment on it), plus their frontend node mappers.

## Why
To let pipelines interact with GitLab merge requests directly — posting automated status/review comments and reacting to acknowledge automation activity — mirroring the existing `github.createIssueComment` and `github.addReaction` components.

## How

### Backend
Extended `pkg/integrations/gitlab/` with:
- `create_merge_comment.go` — `gitlab.createMergeComment` action. Config: `project`, `mergeRequestIid`, `body`. Calls the new `Client.CreateMergeRequestNote`.
- `add_reaction.go` — `gitlab.addReaction` action. Config: `project`, `mergeRequestIid`, `target` (`mergeRequest`/`note`), `noteId` (required for the note target), `content` (award emoji name). Calls `Client.CreateMergeRequestAwardEmoji` / `Client.CreateMergeRequestNoteAwardEmoji`.
- `client.go` — added `Note` and `AwardEmoji` types plus `CreateMergeRequestNote`, `CreateMergeRequestAwardEmoji`, and `CreateMergeRequestNoteAwardEmoji` methods (POST to `/merge_requests/:iid/notes` and `/merge_requests/:iid/award_emoji` or `/notes/:id/award_emoji`).
- `gitlab.go` — registered both new actions in `Actions()`.
- Added `create_merge_comment_test.go` and `add_reaction_test.go` covering `Setup` validation and `Execute` success/failure.
- Regenerated `docs/components/GitLab.mdx` via `make gen.components.docs`.

### Frontend
Added `web_src/src/pages/app/mappers/gitlab/create_merge_comment.ts` and `add_reaction.ts`, registered in `gitlab/index.ts`:
- Node cards show project and merge request IID as metadata chips (`create_merge_comment`), plus target comment and reaction emoji (`add_reaction`).
- Execution details panel shows Created At / Created By (`create_merge_comment`) and Reaction / Created By / Created At (`add_reaction`).
- Added `Note` and `AwardEmoji` types in `gitlab/types.ts` matching the backend response shapes.
- Added `create_merge_comment.spec.ts` and `add_reaction.spec.ts` covering `getExecutionDetails` for both mappers.
 
 ## Demo
[Screencast From 2026-07-09 15-07-44.webm](https://github.com/user-attachments/assets/4e4fa842-2063-4535-a7fc-e9615dbd380b)
