### PR TITLE
fix: refine run inspector input timeline behavior

### DIFF
--- a/web_src/src/ui/Runs/RunInspectorInputChainModal.tsx
+++ b/web_src/src/ui/Runs/RunInspectorInputChainModal.tsx
@@ -137,7 +137,7 @@ function InputChainModal({
               </div>
             </div>
             <div className="min-h-0 flex-1 overflow-auto p-3">
-              <JsonPayload value={selected?.output} jsonViewStyle={jsonViewStyle} />
+              <JsonPayload value={selected?.output} jsonViewStyle={jsonViewStyle} collapsed={false} />
             </div>
           </div>
         </div>

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -15,7 +15,11 @@ let mockedExecutionsLoading = false;
 let mockedMe: SuperplaneMeUser | null = null;
 
 vi.mock("@uiw/react-json-view", () => ({
-  default: ({ value }: { value: unknown }) => <pre data-testid="json-view">{JSON.stringify(value)}</pre>,
+  default: ({ value, collapsed }: { value: unknown; collapsed?: boolean | number }) => (
+    <pre data-testid="json-view" data-collapsed={String(collapsed)}>
+      {JSON.stringify(value)}
+    </pre>
+  ),
 }));
 
 const reemitTriggerEventMock = vi.fn();
@@ -105,6 +109,14 @@ describe("RunInspectorPanel", () => {
     expect(screen.getAllByRole("button", { name: "Copy" }).length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByRole("button", { name: "Open fullscreen" }).length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText("Add Grade Label").length).toBeGreaterThan(0);
+  });
+
+  it("shows input as the fixed triggered event for the selected node", () => {
+    renderInspector({ selectedNodeId: "action-2" });
+
+    const inputHeader = screen.getByRole("button", { name: /Triggered\s+Input\s+Add Grade Label/i });
+    expect(within(inputHeader).getByText("Triggered")).toBeInTheDocument();
+    expect(within(inputHeader).queryByText("error")).not.toBeInTheDocument();
   });
 
   it("does not show trigger input and shows the root event payload as trigger output", () => {
@@ -213,6 +225,20 @@ describe("RunInspectorPanel", () => {
     expect(within(dialog).getByRole("button", { name: /On Pull Request/i })).toBeInTheDocument();
     expect(within(dialog).getAllByText("Add Grade Label").length).toBeGreaterThanOrEqual(2);
     expect(within(dialog).getByTestId("json-view")).toHaveTextContent("{}");
+    expect(within(dialog).getByTestId("json-view")).toHaveAttribute("data-collapsed", "false");
+  });
+
+  it("expands timeline JSON by default in fullscreen modals only", () => {
+    renderInspector({ selectedNodeId: "action-2" });
+
+    fireEvent.click(screen.getByRole("button", { name: /Output · default/i }));
+
+    expect(screen.getByTestId("json-view")).toHaveAttribute("data-collapsed", "2");
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Open fullscreen" })[0]);
+
+    const dialog = screen.getByRole("dialog", { name: "Input" });
+    expect(within(dialog).getByTestId("json-view")).toHaveAttribute("data-collapsed", "false");
   });
 
   it("renders a single close button that closes the inspector", () => {

--- a/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
@@ -22,6 +22,11 @@ import {
 } from "./RunInspectorTimelineTypes";
 import { hasObjectValue, type RunInspectorNodeSection, type RunInspectorUpstreamSection } from "./runNodeDetailModel";
 
+const INPUT_TRIGGERED_STATUS: StatusPill = {
+  dotClassName: "bg-violet-400",
+  label: "Triggered",
+};
+
 export function RunInspectorStepTimeline({
   section,
   componentIconMap,
@@ -102,7 +107,7 @@ function InputTimelineCard({
   return (
     <TimelineAccordionCard
       value="input"
-      status={inputStatus(leadInput)}
+      status={INPUT_TRIGGERED_STATUS}
       title="Input"
       sourceName={leadInput?.nodeName}
       actionPayload={leadInput ? (leadInput.output ?? {}) : undefined}
@@ -196,13 +201,6 @@ function outputActionPayload(section: RunInspectorNodeSection): unknown {
   }
 
   return section.errorMessage ? { error: section.errorMessage } : undefined;
-}
-
-function inputStatus(section?: RunInspectorUpstreamSection): StatusPill {
-  return {
-    dotClassName: section?.badge?.badgeColor ?? "bg-violet-400",
-    label: section?.badge?.label ?? "Triggered",
-  };
 }
 
 function outputStatus(section: RunInspectorNodeSection): StatusPill {

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
@@ -109,7 +109,7 @@ export function TimelineAccordionCard({
             </span>
           </div>
           <div className="min-h-0 flex-1 overflow-auto p-3">
-            <JsonPayload value={actionPayload} jsonViewStyle={jsonViewStyle} />
+            <JsonPayload value={actionPayload} jsonViewStyle={jsonViewStyle} collapsed={false} />
           </div>
         </DialogContent>
       </Dialog>
@@ -154,11 +154,19 @@ export function HeaderIconButton({
   );
 }
 
-export function JsonPayload({ value, jsonViewStyle }: { value: unknown; jsonViewStyle: CSSProperties }) {
+export function JsonPayload({
+  value,
+  jsonViewStyle,
+  collapsed = 2,
+}: {
+  value: unknown;
+  jsonViewStyle: CSSProperties;
+  collapsed?: boolean | number;
+}) {
   return (
     <JsonView
       value={(value ?? {}) as object}
-      collapsed={2}
+      collapsed={collapsed}
       style={jsonViewStyle}
       className={jsonViewClassName}
       displayObjectSize={false}


### PR DESCRIPTION
## Summary
- keep the Run Inspector input timeline status fixed as purple Triggered
- expand JSON by default in right-sidebar modals while preserving inline collapsed JSON
- add regression coverage for the input status and modal JSON behavior

## Tests
- make format.js
- cd web_src && npm run test:run -- src/ui/Runs/RunInspectorPanel.spec.tsx
- make check.lint.ui
- make check.build.ui