### PR TITLE
fix: focus run inspection canvas on participants

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -122,6 +122,7 @@ import { buildAppFiles } from "./files/lib/app-files";
 import { useDraftVisualDiff } from "./useDraftVisualDiff";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
 import { useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
+import { useRunParticipantFitRequest } from "./useRunParticipantFitRequest";
 import { useRunsDetailState } from "./useRunsDetailState";
 import { useSidebarEventRunLookup } from "@/hooks/useSidebarEventRunLookup";
 import { useSelectedRunCanvas } from "./useSelectedRunCanvas";
@@ -3398,7 +3399,14 @@ export function AppPage() {
   );
 
   const runInspectionChromeActive = isRunInspectionMode && !editSessionActive && !isEnteringEditSession;
-
+  const runParticipantFit = useRunParticipantFitRequest({
+    isRunInspectionMode: runInspectionChromeActive,
+    selectedRunId,
+    runCanvasLoading,
+    runCanvasData,
+  });
+  const requestRunFitRef = useRef(runParticipantFit.requestParticipantFit);
+  requestRunFitRef.current = runParticipantFit.requestParticipantFit;
   const { headerMode, canvasStateMode, showBottomStatusControls, hideAddControls, readOnlyViewModes } =
     getWorkflowViewPresentation({
       ...urlViewFlags,
@@ -3547,11 +3555,12 @@ export function AppPage() {
       clearDismissedRunDetail();
       setRunDetailNodeId(null);
       setFocusRequest(null);
+      requestRunFitRef.current(runId);
       startTransition(() => {
         setSearchParams((current) => applyRunInspectionNavigationSearchParams(current, { runId }), { replace: true });
       });
     },
-    [clearDismissedRunDetail, exitEditableVersionForRunInspection, setSearchParams, setRunDetailNodeId],
+    [clearDismissedRunDetail, exitEditableVersionForRunInspection, setRunDetailNodeId, setSearchParams],
   );
 
   const { resolveRunIdForSidebarEvent, fetchRunIdForSidebarEvent } = useSidebarEventRunLookup({
@@ -3569,6 +3578,7 @@ export function AppPage() {
       clearDismissedRunDetail();
       const inspectorNodeId =
         options?.nodeId ?? (searchParams.get("sidebar") === "1" ? searchParams.get("node") : null);
+      if (!inspectorNodeId) requestRunFitRef.current(runId);
       if (inspectorNodeId) {
         preserveRunDetailNodeOnNextRunChangeRef.current = true;
         setRunDetailNodeId(inspectorNodeId);
@@ -3615,6 +3625,8 @@ export function AppPage() {
       const preservedNodeId = runDetailNodeId;
       preserveRunDetailNodeOnNextRunChangeRef.current = Boolean(preservedNodeId);
       clearDismissedRunDetail();
+      setFocusRequest(null);
+      requestRunFitRef.current(runId);
       setSearchParams(
         (current) =>
           applyRunInspectionNavigationSearchParams(current, {
@@ -3624,14 +3636,15 @@ export function AppPage() {
         { replace: true },
       );
     },
-    [clearDismissedRunDetail, exitEditableVersionForRunInspection, runDetailNodeId, setSearchParams],
+    [clearDismissedRunDetail, exitEditableVersionForRunInspection, runDetailNodeId, setFocusRequest, setSearchParams],
   );
 
   const handleClearRunInspection = useCallback(() => {
     setRunDetailNodeId(null);
     setFocusRequest(null);
+    runParticipantFit.clearParticipantFit();
     setSearchParams((current) => clearRunInspectionSearchParams(current), { replace: true });
-  }, [setSearchParams, setRunDetailNodeId]);
+  }, [runParticipantFit, setSearchParams, setRunDetailNodeId]);
 
   const handleRunNodeDetailSelection = useCallback(
     (nodeId: string | null) => {
@@ -4253,16 +4266,7 @@ export function AppPage() {
           fitViewContentKey={`${canvasId}:${resolveFitViewVersionId({ liveCanvasVersionId, activeCanvasVersionId, isViewingDraftVersion: isEditing, draftSpec: draftSpecToRender, selectedVersion: selectedCanvasVersion })}`}
           lastFittedContentKeyRef={lastFittedContentKeyRef}
           initialFocusNodeId={initialFocusNodeIdRef.current}
-          fitAllFocusNodeIds={
-            runInspectionChromeActive && selectedRun && runCanvasData && runCanvasData.participantNodeIds.length > 0
-              ? runCanvasData.participantNodeIds
-              : undefined
-          }
-          runParticipantNodeIds={
-            runInspectionChromeActive && selectedRun && runCanvasData && runCanvasData.participantNodeIds.length > 0
-              ? runCanvasData.participantNodeIds
-              : undefined
-          }
+          {...runParticipantFit.canvasFitProps}
           runCanvasLoading={
             runInspectionChromeActive &&
             selectedRunId !== null &&

--- a/web_src/src/pages/app/useRunParticipantFitRequest.spec.ts
+++ b/web_src/src/pages/app/useRunParticipantFitRequest.spec.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useRunParticipantFitRequest } from "./useRunParticipantFitRequest";
+import type { RunCanvasData } from "./useRunCanvasData";
+
+function buildRunCanvasData(participantNodeIds: string[]): RunCanvasData {
+  return {
+    nodes: [],
+    edges: [],
+    participantNodeIds,
+  };
+}
+
+type HookProps = {
+  isRunInspectionMode: boolean;
+  selectedRunId: string | null;
+  runCanvasLoading: boolean;
+  runCanvasData: RunCanvasData | null;
+};
+
+describe("useRunParticipantFitRequest", () => {
+  it("waits for the selected run participant nodes before emitting a fit request", () => {
+    const initialProps: HookProps = {
+      isRunInspectionMode: false,
+      selectedRunId: null,
+      runCanvasLoading: false,
+      runCanvasData: null,
+    };
+    const { result, rerender } = renderHook((props: HookProps) => useRunParticipantFitRequest(props), {
+      initialProps,
+    });
+
+    act(() => {
+      result.current.requestParticipantFit("run-1");
+    });
+
+    expect(result.current.fitRequest).toBeNull();
+
+    rerender({
+      isRunInspectionMode: true,
+      selectedRunId: "run-1",
+      runCanvasLoading: true,
+      runCanvasData: null,
+    });
+    expect(result.current.fitRequest).toBeNull();
+
+    rerender({
+      isRunInspectionMode: true,
+      selectedRunId: "run-1",
+      runCanvasLoading: false,
+      runCanvasData: buildRunCanvasData(["trigger-1", "action-1"]),
+    });
+
+    expect(result.current.fitRequest).toBe(1);
+  });
+
+  it("clears pending and emitted fit requests", () => {
+    const { result } = renderHook(() =>
+      useRunParticipantFitRequest({
+        isRunInspectionMode: true,
+        selectedRunId: "run-1",
+        runCanvasLoading: false,
+        runCanvasData: buildRunCanvasData(["trigger-1"]),
+      }),
+    );
+
+    act(() => {
+      result.current.requestParticipantFit("run-1");
+    });
+    expect(result.current.fitRequest).toBe(1);
+
+    act(() => {
+      result.current.clearParticipantFit();
+    });
+
+    expect(result.current.fitRequest).toBeNull();
+  });
+});

--- a/web_src/src/pages/app/useRunParticipantFitRequest.ts
+++ b/web_src/src/pages/app/useRunParticipantFitRequest.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RunCanvasData } from "./useRunCanvasData";
+
+export function useRunParticipantFitRequest({
+  isRunInspectionMode,
+  selectedRunId,
+  runCanvasLoading,
+  runCanvasData,
+}: {
+  isRunInspectionMode: boolean;
+  selectedRunId: string | null;
+  runCanvasLoading: boolean;
+  runCanvasData: RunCanvasData | null;
+}) {
+  const nextRequestRef = useRef(0);
+  const [fitIntent, setFitIntent] = useState<{ runId: string; requestId: number } | null>(null);
+  const [fitRequest, setFitRequest] = useState<number | null>(null);
+  const participantNodeIds =
+    isRunInspectionMode && runCanvasData?.participantNodeIds.length ? runCanvasData.participantNodeIds : undefined;
+  const participantNodeIdsKey = participantNodeIds?.join("|") ?? "";
+
+  const requestParticipantFit = useCallback((runId: string) => {
+    nextRequestRef.current += 1;
+    setFitIntent({ runId, requestId: nextRequestRef.current });
+  }, []);
+
+  const clearParticipantFit = useCallback(() => {
+    setFitIntent(null);
+    setFitRequest(null);
+  }, []);
+
+  useEffect(() => {
+    if (!fitIntent || !isRunInspectionMode) return;
+    if (fitIntent.runId !== selectedRunId) return;
+    if (runCanvasLoading || !participantNodeIds?.length) return;
+
+    setFitRequest(fitIntent.requestId);
+    setFitIntent(null);
+  }, [fitIntent, isRunInspectionMode, participantNodeIds, participantNodeIdsKey, runCanvasLoading, selectedRunId]);
+
+  return useMemo(
+    () => ({
+      participantNodeIds,
+      fitRequest,
+      canvasFitProps: {
+        fitAllRequest: isRunInspectionMode ? fitRequest : null,
+        fitAllFocusNodeIds: participantNodeIds,
+        runParticipantNodeIds: participantNodeIds,
+      },
+      requestParticipantFit,
+      clearParticipantFit,
+    }),
+    [clearParticipantFit, fitRequest, isRunInspectionMode, participantNodeIds, requestParticipantFit],
+  );
+}

--- a/web_src/src/ui/CanvasPage/index.runParticipantFit.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runParticipantFit.spec.tsx
@@ -1,0 +1,173 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render as testingLibraryRender } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+
+const { fitViewMock, getNodesMock, getViewportMock } = vi.hoisted(() => ({
+  fitViewMock: vi.fn().mockResolvedValue(true),
+  getNodesMock: vi.fn<() => Array<{ id: string; position: { x: number; y: number } }>>(() => []),
+  getViewportMock: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+}));
+
+vi.mock("@/sentry", () => ({
+  Sentry: {
+    withScope: (callback: (scope: { setTag: typeof vi.fn; setExtra: typeof vi.fn }) => void) =>
+      callback({
+        setTag: vi.fn(),
+        setExtra: vi.fn(),
+      }),
+    captureException: vi.fn(),
+  },
+}));
+
+vi.mock("@xyflow/react", () => ({
+  Background: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ReactFlow: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ReactFlowProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ViewportPortal: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  useOnSelectionChange: vi.fn(),
+  useReactFlow: vi.fn(() => ({
+    fitView: fitViewMock,
+    screenToFlowPosition: vi.fn((position) => position),
+    getViewport: getViewportMock,
+    setViewport: vi.fn(),
+    getInternalNode: vi.fn(),
+    zoomTo: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    getNodes: getNodesMock,
+    getZoom: vi.fn(() => 1),
+  })),
+  useStore: vi.fn((selector: (state: { minZoom: number; maxZoom: number }) => unknown) =>
+    selector({ minZoom: 0.1, maxZoom: 1.5 }),
+  ),
+  useViewport: vi.fn(() => ({ zoom: 1, x: 0, y: 0 })),
+}));
+
+vi.mock("../BuildingBlocksSidebar", () => ({
+  BuildingBlocksSidebar: () => null,
+}));
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useEventExecutions: () => ({
+    data: { executions: [] },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("../componentSidebar", () => ({
+  ComponentSidebar: () => null,
+}));
+
+vi.mock("@/components/CanvasToolSidebar", () => ({
+  CanvasToolSidebar: () => null,
+}));
+
+vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
+  useCanvasToolSidebarState: () => ({
+    canvasId: undefined,
+    organizationId: undefined,
+    isEditing: false,
+    readOnly: false,
+    isToolSidebarOpen: false,
+    showToolSidebarToggle: false,
+    handleToolSidebarToggle: vi.fn(),
+    openToolSidebar: vi.fn(),
+    closeToolSidebar: vi.fn(),
+  }),
+}));
+
+vi.mock("./Header", () => ({
+  Header: () => null,
+}));
+
+import { CanvasPage } from "./index";
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  return testingLibraryRender(ui, { wrapper: Wrapper });
+}
+
+describe("CanvasPage run participant fit", () => {
+  beforeEach(() => {
+    fitViewMock.mockClear();
+    fitViewMock.mockResolvedValue(true);
+    getNodesMock.mockReset();
+    getNodesMock.mockReturnValue([]);
+    getViewportMock.mockReset();
+    getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  it("fits run inspection to the active participant nodes when requested", async () => {
+    vi.useFakeTimers();
+    try {
+      const hasFitToViewRef = { current: true };
+      const viewportRef = { current: { x: 0, y: 0, zoom: 1 } };
+      const activeNode = { id: "run-node-1", position: { x: 0, y: 0 } };
+      const inactiveNode = { id: "run-node-2", position: { x: 1000, y: 1000 } };
+      const fittedViewport = { x: -120, y: -80, zoom: 1.1 };
+      getNodesMock.mockReturnValue([activeNode, inactiveNode]);
+      getViewportMock.mockReturnValue(fittedViewport);
+
+      render(
+        <MemoryRouter>
+          <CanvasPage
+            title="Canvas"
+            headerMode="version-live"
+            isRunInspectionMode
+            nodes={[
+              { ...activeNode, data: { label: "Run 1", state: "success", type: "component" } },
+              { ...inactiveNode, data: { label: "Run 2", state: "pending", type: "component" } },
+            ]}
+            edges={[]}
+            buildingBlocks={[]}
+            isEditing={false}
+            activeCanvasVersionId="live-version"
+            hasFitToViewRef={hasFitToViewRef}
+            viewportRef={viewportRef}
+            fitAllRequest={1}
+            fitAllFocusNodeIds={["run-node-1"]}
+          />
+        </MemoryRouter>,
+      );
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(fitViewMock).toHaveBeenCalledWith({
+        nodes: [activeNode],
+        includeHiddenNodes: true,
+        maxZoom: 1.2,
+        minZoom: 0.85,
+        padding: 0.1,
+        duration: 500,
+      });
+      expect(viewportRef.current).toEqual(fittedViewport);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2749,14 +2749,31 @@ function CanvasContent({
       const nodeSubset =
         focusIds && focusIds.size > 0 ? renderedNodes.filter((n) => n.id && focusIds.has(n.id)) : undefined;
       const fitOptions = isRunInspectionMode ? RUN_CANVAS_FIT_VIEW_OPTIONS : LIVE_CANVAS_FIT_VIEW_OPTIONS;
-      fitView({
+      void fitView({
         ...(nodeSubset && nodeSubset.length > 0 ? { nodes: nodeSubset } : {}),
         ...fitOptions,
         duration: 500,
-      });
+      }).then(
+        () => {
+          const nextViewport = getViewport();
+          viewportRef.current = nextViewport;
+          reportZoom(nextViewport.zoom);
+        },
+        () => undefined,
+      );
     }, 0);
     return () => window.clearTimeout(id);
-  }, [fitAllRequest, fitAllFocusNodeIds, fitView, getNodes, hasFitToViewRef, isRunInspectionMode]);
+  }, [
+    fitAllRequest,
+    fitAllFocusNodeIds,
+    fitView,
+    getNodes,
+    getViewport,
+    hasFitToViewRef,
+    isRunInspectionMode,
+    reportZoom,
+    viewportRef,
+  ]);
 
   const showHeader = !isReadOnly;
 


### PR DESCRIPTION
## Summary
- focus run inspection canvas on the participant nodes when selecting a run from the left runs sidebar
- wait for run participant nodes to load before issuing the fit request
- persist the fitted viewport after run participant fit completes

## Tests
- cd web_src && npm run test:run -- src/pages/app/useRunParticipantFitRequest.spec.ts src/ui/CanvasPage/index.runParticipantFit.spec.tsx src/ui/CanvasPage/index.runInspection.spec.tsx
- make check.lint.ui
- make check.build.ui