### PR TITLE
fix: fit all run inspection nodes

### DIFF
--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -1,10 +1,10 @@
 {
-  "maxAllowedTotalIssues": 599,
+  "maxAllowedTotalIssues": 594,
   "maxAllowedByRule": {
-    "complexity": 211,
+    "complexity": 208,
     "@typescript-eslint/no-explicit-any": 153,
     "@typescript-eslint/no-non-null-asserted-optional-chain": 78,
-    "max-lines-per-function": 65,
+    "max-lines-per-function": 64,
     "max-statements": 62,
     "max-lines": 15,
     "max-depth": 6,
@@ -13,7 +13,7 @@
   },
   "maxAllowedMetricMaximumByRule": {
     "max-lines": 3817,
-    "complexity": 210
+    "complexity": 198
   },
-  "updatedAt": "2026-07-07T21:06:50.319Z"
+  "updatedAt": "2026-07-09T19:14:38.365Z"
 }

--- a/web_src/src/ui/CanvasPage/canvasFitOptions.spec.ts
+++ b/web_src/src/ui/CanvasPage/canvasFitOptions.spec.ts
@@ -13,4 +13,8 @@ describe("canvasFitOptions", () => {
     expect(RUN_CANVAS_FIT_VIEW_OPTIONS.includeHiddenNodes).toBe(true);
     expect(CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS.includeHiddenNodes).toBe(true);
   });
+
+  it("does not clamp run participant fitting to a minimum zoom", () => {
+    expect(RUN_CANVAS_FIT_VIEW_OPTIONS).not.toHaveProperty("minZoom");
+  });
 });

--- a/web_src/src/ui/CanvasPage/canvasFitOptions.ts
+++ b/web_src/src/ui/CanvasPage/canvasFitOptions.ts
@@ -14,7 +14,6 @@ export const LIVE_CANVAS_FIT_VIEW_OPTIONS = {
 export const RUN_CANVAS_FIT_VIEW_OPTIONS = {
   ...CANVAS_FIT_VIEW_INCLUDE_HIDDEN,
   maxZoom: 1.2,
-  minZoom: 0.85,
   padding: 0.1,
 } as const;
 

--- a/web_src/src/ui/CanvasPage/index.runParticipantFit.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runParticipantFit.spec.tsx
@@ -120,15 +120,20 @@ describe("CanvasPage run participant fit", () => {
     };
   });
 
-  it("fits run inspection to the active participant nodes when requested", async () => {
+  it("fits run inspection to all requested participant nodes", async () => {
     vi.useFakeTimers();
     try {
       const hasFitToViewRef = { current: true };
       const viewportRef = { current: { x: 0, y: 0, zoom: 1 } };
       const activeNode = { id: "run-node-1", position: { x: 0, y: 0 } };
-      const inactiveNode = { id: "run-node-2", position: { x: 1000, y: 1000 } };
+      const secondParticipantNode = { id: "run-node-2", position: { x: 1000, y: 1000 } };
+      const renderedActiveNode = { ...activeNode, data: { label: "Run 1", state: "success", type: "component" } };
+      const renderedSecondNode = {
+        ...secondParticipantNode,
+        data: { label: "Run 2", state: "pending", type: "component" },
+      };
       const fittedViewport = { x: -120, y: -80, zoom: 1.1 };
-      getNodesMock.mockReturnValue([activeNode, inactiveNode]);
+      getNodesMock.mockReturnValue([activeNode]);
       getViewportMock.mockReturnValue(fittedViewport);
 
       render(
@@ -137,10 +142,7 @@ describe("CanvasPage run participant fit", () => {
             title="Canvas"
             headerMode="version-live"
             isRunInspectionMode
-            nodes={[
-              { ...activeNode, data: { label: "Run 1", state: "success", type: "component" } },
-              { ...inactiveNode, data: { label: "Run 2", state: "pending", type: "component" } },
-            ]}
+            nodes={[renderedActiveNode, renderedSecondNode]}
             edges={[]}
             buildingBlocks={[]}
             isEditing={false}
@@ -148,7 +150,7 @@ describe("CanvasPage run participant fit", () => {
             hasFitToViewRef={hasFitToViewRef}
             viewportRef={viewportRef}
             fitAllRequest={1}
-            fitAllFocusNodeIds={["run-node-1"]}
+            fitAllFocusNodeIds={["run-node-1", "run-node-2"]}
           />
         </MemoryRouter>,
       );
@@ -158,10 +160,9 @@ describe("CanvasPage run participant fit", () => {
       });
 
       expect(fitViewMock).toHaveBeenCalledWith({
-        nodes: [activeNode],
+        nodes: [activeNode, renderedSecondNode],
         includeHiddenNodes: true,
         maxZoom: 1.2,
-        minZoom: 0.85,
         padding: 0.1,
         duration: 500,
       });

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2743,11 +2743,21 @@ function CanvasContent({
     if (last?.nonce === fitAllRequest && last.runMode === isRunInspectionMode) return;
     if (!hasFitToViewRef.current) return;
     lastFitAllRequestRef.current = { nonce: fitAllRequest, runMode: isRunInspectionMode };
-    const id = window.setTimeout(() => {
+    let timeoutId: number | null = null;
+    const runFit = (attempt: number) => {
       const focusIds = fitAllFocusNodeIds?.length ? new Set(fitAllFocusNodeIds) : null;
-      const renderedNodes = getNodes();
-      const nodeSubset =
-        focusIds && focusIds.size > 0 ? renderedNodes.filter((n) => n.id && focusIds.has(n.id)) : undefined;
+      const nodesById = new Map(stateRef.current.nodes.map((node) => [node.id, node]));
+      getNodes().forEach((node) => nodesById.set(node.id, node));
+      const nodeSubset = focusIds
+        ? Array.from(focusIds)
+            .map((nodeId) => nodesById.get(nodeId))
+            .filter((node) => node !== undefined)
+        : undefined;
+      if (focusIds && nodeSubset && nodeSubset.length < focusIds.size && attempt < 10) {
+        timeoutId = window.setTimeout(() => runFit(attempt + 1), 50);
+        return;
+      }
+
       const fitOptions = isRunInspectionMode ? RUN_CANVAS_FIT_VIEW_OPTIONS : LIVE_CANVAS_FIT_VIEW_OPTIONS;
       void fitView({
         ...(nodeSubset && nodeSubset.length > 0 ? { nodes: nodeSubset } : {}),
@@ -2761,8 +2771,12 @@ function CanvasContent({
         },
         () => undefined,
       );
-    }, 0);
-    return () => window.clearTimeout(id);
+    };
+
+    timeoutId = window.setTimeout(() => runFit(0), 0);
+    return () => {
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    };
   }, [
     fitAllRequest,
     fitAllFocusNodeIds,


### PR DESCRIPTION
## Summary
- fit run inspection participant requests against the full requested run node set
- remove the minimum zoom clamp from run participant fitting so spread-out run nodes remain visible
- add regression coverage for fitting multiple run participant nodes

## Tests
- cd web_src && npm run test:run -- src/ui/CanvasPage/canvasFitOptions.spec.ts src/ui/CanvasPage/index.runParticipantFit.spec.tsx src/pages/app/useRunParticipantFitRequest.spec.ts src/ui/CanvasPage/index.runInspection.spec.tsx
- make check.lint.ui
- make check.build.ui