### PR TITLE
fix: improve run inspector runtime actions

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -3547,7 +3547,8 @@ export function AppPage() {
     handleUseVersion(liveCanvasVersionId);
   }, [hasEditableVersion, liveCanvasVersionId, handleUseVersion]);
 
-  const liveSidebarRunLookupEnabled = isViewingLiveVersion && !isRunInspectionMode && !isEditing;
+  const runLookupEnabled = isViewingLiveVersion && !isEditing;
+  const liveSidebarRunLookupEnabled = runLookupEnabled && !isRunInspectionMode;
 
   const handleSelectRun = useCallback(
     (runId: string) => {
@@ -3564,7 +3565,7 @@ export function AppPage() {
   );
 
   const { resolveRunIdForSidebarEvent, fetchRunIdForSidebarEvent } = useSidebarEventRunLookup({
-    enabled: liveSidebarRunLookupEnabled,
+    enabled: runLookupEnabled,
     canvasId,
     organizationId,
     queryClient,
@@ -4330,8 +4331,8 @@ export function AppPage() {
           onReEmit={canUpdateCanvas && showLiveActivity ? handleReEmit : undefined}
           onRunItemOpen={showLiveActivity ? handleRunItemOpen : undefined}
           resolveRunIdForSidebarEvent={liveSidebarRunLookupEnabled ? resolveRunIdForSidebarEvent : undefined}
-          fetchRunIdForSidebarEvent={liveSidebarRunLookupEnabled ? fetchRunIdForSidebarEvent : undefined}
-          onSelectRunFromSidebarEvent={liveSidebarRunLookupEnabled ? handleSelectRunFromSidebarEvent : undefined}
+          fetchRunIdForSidebarEvent={runLookupEnabled ? fetchRunIdForSidebarEvent : undefined}
+          onSelectRunFromSidebarEvent={runLookupEnabled ? handleSelectRunFromSidebarEvent : undefined}
           getExecutionState={getExecutionState}
           workflowNodes={canvasNodes}
           components={allComponents}

--- a/web_src/src/ui/CanvasPage/index.runInspection.sidebar.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.sidebar.spec.tsx
@@ -73,6 +73,28 @@ vi.mock("../componentSidebar", () => ({
   ComponentSidebar: () => <div data-testid="live-node-detail-pane-content" />,
 }));
 
+vi.mock("../Runs/RunInspectorPanel", () => ({
+  RunInspectorPanel: ({
+    onClose,
+    onEditNode,
+    onRerunCreated,
+  }: {
+    onClose?: () => void;
+    onEditNode?: (nodeId: string) => void;
+    onRerunCreated?: (eventId: string) => void;
+  }) => (
+    <div data-testid="run-inspector-panel">
+      <button type="button" aria-label="Close" onClick={onClose} />
+      <button type="button" onClick={() => onEditNode?.("run-node-1")}>
+        Edit runtime config
+      </button>
+      <button type="button" onClick={() => onRerunCreated?.("rerun-event-1")}>
+        Rerun
+      </button>
+    </div>
+  ),
+}));
+
 vi.mock("@/components/CanvasToolSidebar", () => ({
   CanvasToolSidebar: () => null,
 }));
@@ -217,6 +239,166 @@ describe("CanvasPage run inspection sidebar", () => {
 
     expect(onRunNodeDetailClose).toHaveBeenCalledOnce();
     expect(onBackToLiveCanvas).not.toHaveBeenCalled();
+  });
+
+  it("enters edit mode when editing runtime config from run inspection", async () => {
+    const onEnterEditMode = vi.fn();
+    const canvasProps = {
+      title: "Canvas",
+      headerMode: "version-live" as const,
+      runNodeDetailNodeId: "run-node-1",
+      runNodeDetailCanvasId: "canvas-1",
+      runNodeDetailRun: {
+        id: "run-1",
+        rootEvent: { id: "root-event-1", nodeId: "trigger-node" },
+      },
+      nodes: [
+        {
+          id: "run-node-1",
+          position: { x: 0, y: 0 },
+          data: {
+            label: "Run node",
+            state: "success",
+            type: "component",
+          },
+        },
+      ],
+      edges: [],
+      buildingBlocks: [],
+      activeCanvasVersionId: "live-version",
+      onEnterEditMode,
+    };
+
+    render(
+      <MemoryRouter>
+        <CanvasPage {...canvasProps} isRunInspectionMode isEditing={false} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("run-inspector-panel")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit runtime config" }));
+
+    expect(onEnterEditMode).toHaveBeenCalledOnce();
+    expect(screen.queryByTestId("live-node-detail-pane-content")).not.toBeInTheDocument();
+  });
+
+  it("does not open stale runtime edit settings after edit mode entry fails", async () => {
+    const onEnterEditMode = vi.fn().mockRejectedValue(new Error("edit failed"));
+    const sidebarData = {
+      title: "Run node",
+      iconSrc: "",
+      iconSlug: "box",
+      latestEvents: [],
+      nextInQueueEvents: [],
+      totalInQueueCount: 0,
+      totalInHistoryCount: 0,
+      isLoading: false,
+    };
+    const canvasProps = {
+      title: "Canvas",
+      headerMode: "version-live" as const,
+      runNodeDetailNodeId: "run-node-1",
+      runNodeDetailCanvasId: "canvas-1",
+      runNodeDetailRun: {
+        id: "run-1",
+        rootEvent: { id: "root-event-1", nodeId: "trigger-node" },
+      },
+      nodes: [
+        {
+          id: "run-node-1",
+          position: { x: 0, y: 0 },
+          data: {
+            label: "Run node",
+            state: "success",
+            type: "component",
+          },
+        },
+      ],
+      edges: [],
+      buildingBlocks: [],
+      activeCanvasVersionId: "live-version",
+      onEnterEditMode,
+      getSidebarData: vi.fn(() => sidebarData),
+    };
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <CanvasPage {...canvasProps} isRunInspectionMode isEditing={false} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("run-inspector-panel")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit runtime config" }));
+
+    await waitFor(() => {
+      expect(onEnterEditMode).toHaveBeenCalledOnce();
+    });
+
+    rerender(
+      <MemoryRouter>
+        <CanvasPage {...canvasProps} isRunInspectionMode={false} isEditing />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("live-node-detail-pane-content")).not.toBeInTheDocument();
+  });
+
+  it("selects the created run after rerun from run inspection", async () => {
+    const fetchRunIdForSidebarEvent = vi.fn().mockResolvedValue("new-run-1");
+    const onSelectRunFromSidebarEvent = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          isRunInspectionMode
+          runNodeDetailNodeId="run-node-1"
+          runNodeDetailCanvasId="canvas-1"
+          runNodeDetailRun={{
+            id: "run-1",
+            rootEvent: { id: "root-event-1", nodeId: "trigger-node" },
+          }}
+          fetchRunIdForSidebarEvent={fetchRunIdForSidebarEvent}
+          onSelectRunFromSidebarEvent={onSelectRunFromSidebarEvent}
+          nodes={[
+            {
+              id: "run-node-1",
+              position: { x: 0, y: 0 },
+              data: {
+                label: "Run node",
+                state: "success",
+                type: "component",
+              },
+            },
+          ]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Rerun" }));
+
+    await waitFor(() => {
+      expect(onSelectRunFromSidebarEvent).toHaveBeenCalledWith("new-run-1", { nodeId: "run-node-1" });
+    });
+    expect(fetchRunIdForSidebarEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "rerun-event-1",
+        nodeId: "trigger-node",
+        triggerEventId: "rerun-event-1",
+      }),
+      { maxPages: 1 },
+    );
   });
 
   it("shows right run inspector loading chrome while run detail is loading", () => {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -246,7 +246,7 @@ export interface CanvasPageProps {
   onDiscardStaleStaging?: () => void;
   discardStaleStagingPending?: boolean;
   headerMode?: "default" | "version-live" | "console" | "memory" | "files";
-  onEnterEditMode?: () => void;
+  onEnterEditMode?: () => void | Promise<void>;
   enterEditModeDisabled?: boolean;
   enterEditModeDisabledTooltip?: string;
   onExitEditMode?: () => void;
@@ -833,6 +833,7 @@ function CanvasPage(props: CanvasPageProps) {
     props.canvasStateMode === "editing" ? "settings" : "latest",
   );
   const [templateNodeId, setTemplateNodeId] = useState<string | null>(null);
+  const [pendingRuntimeEditNodeId, setPendingRuntimeEditNodeId] = useState<string | null>(null);
   const canvasWrapperRef = useRef<HTMLDivElement | null>(null);
   const localHasFitToViewRef = useRef(false);
   const localHasUserToggledSidebarRef = useRef(false);
@@ -1300,6 +1301,14 @@ function CanvasPage(props: CanvasPageProps) {
     }
   }, [props.isEditing, props.isRunInspectionMode, state.componentSidebar.isOpen, handleSidebarClose]);
 
+  useEffect(() => {
+    if (!pendingRuntimeEditNodeId || props.isRunInspectionMode || !props.isEditing) return;
+
+    state.componentSidebar.open(pendingRuntimeEditNodeId);
+    setCurrentTab("settings");
+    setPendingRuntimeEditNodeId(null);
+  }, [pendingRuntimeEditNodeId, props.isEditing, props.isRunInspectionMode, state.componentSidebar]);
+
   const canvasStateMode = props.canvasStateMode || "default";
   const showRunInspectionFloatingBar =
     props.isRunInspectionMode && !props.isEditSessionActive && !props.isEditing && !!props.onBackToLiveCanvas;
@@ -1614,13 +1623,20 @@ function CanvasPage(props: CanvasPageProps) {
             onSelectNode={(nodeId) => props.onRunNodeDetailNavigate?.(nodeId)}
             onClearSelectedNode={() => props.onRunNodeDetailClear?.()}
             onEditNode={
-              readOnly
-                ? undefined
-                : (nodeId) => {
-                    props.onBackToLiveCanvas?.();
-                    state.componentSidebar.open(nodeId);
-                    setCurrentTab("settings");
+              props.onEnterEditMode
+                ? (nodeId) => {
+                    setPendingRuntimeEditNodeId(nodeId);
+                    void (async () => {
+                      try {
+                        await props.onEnterEditMode?.();
+                      } catch {
+                        setPendingRuntimeEditNodeId((currentNodeId) =>
+                          currentNodeId === nodeId ? null : currentNodeId,
+                        );
+                      }
+                    })();
                   }
+                : undefined
             }
             onRerunCreated={(eventId) =>
               selectCreatedRerun({

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -149,6 +149,41 @@ export interface NodeEditData {
   integrationRef?: ComponentsIntegrationRef;
 }
 
+type CreatedRerunSelectionOptions = {
+  eventId: string;
+  triggerNodeId?: string;
+  selectedNodeId?: string | null;
+  fetchRunId?: (event: SidebarEvent, options?: { maxPages?: number }) => Promise<string | null>;
+  selectRun?: (runId: string, options?: { nodeId?: string }) => void;
+};
+
+async function selectCreatedRerun({
+  eventId,
+  triggerNodeId,
+  selectedNodeId,
+  fetchRunId,
+  selectRun,
+}: CreatedRerunSelectionOptions) {
+  if (!eventId || !triggerNodeId || !fetchRunId || !selectRun) return;
+
+  const runId = await fetchRunId(buildRerunLookupEvent(eventId, triggerNodeId), { maxPages: 1 });
+  if (!runId) return;
+
+  selectRun(runId, { nodeId: selectedNodeId ?? triggerNodeId });
+}
+
+function buildRerunLookupEvent(eventId: string, triggerNodeId: string): SidebarEvent {
+  return {
+    id: eventId,
+    title: "Re-emitted event",
+    state: "running",
+    isOpen: false,
+    nodeId: triggerNodeId,
+    triggerEventId: eventId,
+    kind: "trigger",
+  };
+}
+
 export interface NewNodeData {
   icon?: string;
   buildingBlock: BuildingBlock;
@@ -307,7 +342,7 @@ export interface CanvasPageProps {
   onReEmit?: (nodeId: string, eventOrExecutionId: string) => void;
   onRunItemOpen?: (nodeId: string | undefined, executionStatus: string, errorMessage?: string) => void;
   resolveRunIdForSidebarEvent?: (event: SidebarEvent) => string | null;
-  fetchRunIdForSidebarEvent?: (event: SidebarEvent) => Promise<string | null>;
+  fetchRunIdForSidebarEvent?: (event: SidebarEvent, options?: { maxPages?: number }) => Promise<string | null>;
   onSelectRunFromSidebarEvent?: (runId: string, options?: { nodeId?: string }) => void;
 
   // Building blocks for adding new nodes
@@ -1578,6 +1613,24 @@ function CanvasPage(props: CanvasPageProps) {
             selectedNodeId={props.runNodeDetailNodeId}
             onSelectNode={(nodeId) => props.onRunNodeDetailNavigate?.(nodeId)}
             onClearSelectedNode={() => props.onRunNodeDetailClear?.()}
+            onEditNode={
+              readOnly
+                ? undefined
+                : (nodeId) => {
+                    props.onBackToLiveCanvas?.();
+                    state.componentSidebar.open(nodeId);
+                    setCurrentTab("settings");
+                  }
+            }
+            onRerunCreated={(eventId) =>
+              selectCreatedRerun({
+                eventId,
+                triggerNodeId: props.runNodeDetailRun?.rootEvent?.nodeId,
+                selectedNodeId: props.runNodeDetailNodeId,
+                fetchRunId: props.fetchRunIdForSidebarEvent,
+                selectRun: props.onSelectRunFromSidebarEvent,
+              })
+            }
             onClose={() => props.onRunNodeDetailClose?.()}
           />
         ) : runInspectorOpen ? (

--- a/web_src/src/ui/Runs/RunInspectorHeader.tsx
+++ b/web_src/src/ui/Runs/RunInspectorHeader.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Square } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import type { CanvasesCanvasRun } from "@/api-client";
 import { Timestamp } from "@/components/Timestamp";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -83,11 +83,7 @@ export function RunInspectorHeader({
                   )}
                 >
                   <span className="inline-flex items-center gap-2">
-                    {actionPending ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : status === "running" ? (
-                      <Square className="h-3.5 w-3.5" />
-                    ) : null}
+                    {actionPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
                     <span>{actionPending ? `${actionLabel}...` : actionLabel}</span>
                   </span>
                 </button>

--- a/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
+++ b/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
@@ -8,10 +8,11 @@ import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { AccordionContent, AccordionItem } from "@/ui/accordion";
 import { RunNodeIcon, RUN_NODE_ICON_SIZE } from "./RunNodeIcon";
 import { RunInspectorStepTimeline } from "./RunInspectorStepTimeline";
-import type {
-  RunInspectorApprovalRecord,
-  RunInspectorCurrentUser,
-  RunInspectorNodeSection,
+import {
+  hasObjectValue,
+  type RunInspectorApprovalRecord,
+  type RunInspectorCurrentUser,
+  type RunInspectorNodeSection,
 } from "./runNodeDetailModel";
 import type { useRunInspectorActions } from "./useRunInspectorActions";
 
@@ -22,8 +23,11 @@ export function RunInspectorNodeAccordion({
   isOpen,
   onRerun,
   rerunPending,
+  onEditNode,
   actions,
   currentUser,
+  errorScrollRequestId,
+  onErrorScrolled,
 }: {
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
@@ -31,8 +35,11 @@ export function RunInspectorNodeAccordion({
   isOpen: boolean;
   onRerun: () => void;
   rerunPending: boolean;
+  onEditNode?: (nodeId: string) => void;
   actions: ReturnType<typeof useRunInspectorActions>;
   currentUser?: RunInspectorCurrentUser;
+  errorScrollRequestId?: number | null;
+  onErrorScrolled?: () => void;
 }) {
   const iconSrc = getHeaderIconSrc(section.workflowNode?.component);
   const iconSlug = section.workflowNode?.component ? componentIconMap[section.workflowNode.component] : undefined;
@@ -50,11 +57,17 @@ export function RunInspectorNodeAccordion({
     }
 
     wasOpenRef.current = true;
-    const frame = window.requestAnimationFrame(() => {
-      itemRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
+    let secondFrame = 0;
+    const firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
+        itemRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
+      });
     });
 
-    return () => window.cancelAnimationFrame(frame);
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      window.cancelAnimationFrame(secondFrame);
+    };
   }, [isOpen]);
 
   return (
@@ -88,6 +101,7 @@ export function RunInspectorNodeAccordion({
             {section.nodeName}
           </span>
         </AccordionPrimitive.Trigger>
+        <NodeEditAction section={section} onEditNode={onEditNode} />
         <NodeActions section={section} actions={actions} currentUser={currentUser} />
         <NodeMetadata section={section} onRerun={onRerun} rerunPending={rerunPending} />
       </AccordionPrimitive.Header>
@@ -96,9 +110,27 @@ export function RunInspectorNodeAccordion({
           section={section}
           componentIconMap={componentIconMap}
           organizationId={organizationId}
+          errorScrollRequestId={errorScrollRequestId}
+          onErrorScrolled={onErrorScrolled}
         />
       </AccordionContent>
     </AccordionItem>
+  );
+}
+
+function NodeEditAction({
+  section,
+  onEditNode,
+}: {
+  section: RunInspectorNodeSection;
+  onEditNode?: (nodeId: string) => void;
+}) {
+  if (!onEditNode || !hasObjectValue(section.tabData?.configuration)) return null;
+
+  return (
+    <div className="flex shrink-0 items-center pl-3">
+      <NodeActionButton label="Edit" tone="neutral" disabled={false} onClick={() => onEditNode(section.nodeId)} />
+    </div>
   );
 }
 

--- a/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
+++ b/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
@@ -9,7 +9,6 @@ import { AccordionContent, AccordionItem } from "@/ui/accordion";
 import { RunNodeIcon, RUN_NODE_ICON_SIZE } from "./RunNodeIcon";
 import { RunInspectorStepTimeline } from "./RunInspectorStepTimeline";
 import {
-  hasObjectValue,
   type RunInspectorApprovalRecord,
   type RunInspectorCurrentUser,
   type RunInspectorNodeSection,
@@ -101,7 +100,6 @@ export function RunInspectorNodeAccordion({
             {section.nodeName}
           </span>
         </AccordionPrimitive.Trigger>
-        <NodeEditAction section={section} onEditNode={onEditNode} />
         <NodeActions section={section} actions={actions} currentUser={currentUser} />
         <NodeMetadata section={section} onRerun={onRerun} rerunPending={rerunPending} />
       </AccordionPrimitive.Header>
@@ -110,27 +108,12 @@ export function RunInspectorNodeAccordion({
           section={section}
           componentIconMap={componentIconMap}
           organizationId={organizationId}
+          onEditNode={onEditNode}
           errorScrollRequestId={errorScrollRequestId}
           onErrorScrolled={onErrorScrolled}
         />
       </AccordionContent>
     </AccordionItem>
-  );
-}
-
-function NodeEditAction({
-  section,
-  onEditNode,
-}: {
-  section: RunInspectorNodeSection;
-  onEditNode?: (nodeId: string) => void;
-}) {
-  if (!onEditNode || !hasObjectValue(section.tabData?.configuration)) return null;
-
-  return (
-    <div className="flex shrink-0 items-center pl-3">
-      <NodeActionButton label="Edit" tone="neutral" disabled={false} onClick={() => onEditNode(section.nodeId)} />
-    </div>
   );
 }
 

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
@@ -62,6 +62,8 @@ export function renderInspector({
   selectedNodeId = null,
   onSelectNode = vi.fn(),
   onClose = vi.fn(),
+  onEditNode,
+  onRerunCreated,
   run: inspectedRun = run,
   account = null,
   passCurrentUser = true,
@@ -69,6 +71,8 @@ export function renderInspector({
   selectedNodeId?: string | null;
   onSelectNode?: (nodeId: string) => void;
   onClose?: () => void;
+  onEditNode?: (nodeId: string) => void;
+  onRerunCreated?: (eventId: string) => void | Promise<void>;
   run?: CanvasesCanvasRun;
   account?: {
     id: string;
@@ -112,6 +116,8 @@ export function renderInspector({
             }
             selectedNodeId={selectedNodeId}
             onSelectNode={onSelectNode}
+            onEditNode={onEditNode}
+            onRerunCreated={onRerunCreated}
             onClose={onClose}
           />
         </ThemeProvider>

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -246,12 +246,11 @@ describe("RunInspectorPanel", () => {
       expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("first line\nsecond line");
     });
 
-    it("shows an edit action on node headers with runtime config", () => {
+    it("shows an edit action in the runtime config header", () => {
       const onEditNode = vi.fn();
       renderInspector({ selectedNodeId: "action-2", onEditNode });
 
-      fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
-
+      fireEvent.click(screen.getByRole("button", { name: "Edit runtime config" }));
       expect(onEditNode).toHaveBeenCalledWith("action-2");
     });
 

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -159,6 +159,34 @@ describe("RunInspectorPanel", () => {
     });
   });
 
+  it("opens nested output before scrolling to failed emitted output", async () => {
+    const scrollIntoView = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    localStorage.setItem(
+      "superplane.runInspector.internalAccordions",
+      JSON.stringify({ input: false, runtime: false, output: false }),
+    );
+    mockedExecutions = executions.map((execution) =>
+      execution.nodeId === "action-1"
+        ? {
+            ...execution,
+            outputs: { default: [{ data: { error: "details" } }] },
+          }
+        : execution,
+    );
+
+    renderInspector({ selectedNodeId: "action-1" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Jump to error" }));
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center", behavior: "smooth" });
+    });
+    expect(JSON.parse(localStorage.getItem("superplane.runInspector.internalAccordions") || "{}")).toMatchObject({
+      output: true,
+    });
+  });
+
   it("smoothly scrolls an opened node accordion to the steps top", async () => {
     const scrollIntoView = vi.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
@@ -204,15 +232,48 @@ describe("RunInspectorPanel", () => {
     expect(screen.getByTestId("json-view")).toHaveTextContent(/"type":"anyone"/);
   });
 
-  it("honors stored internal accordion preferences", () => {
-    localStorage.setItem(
-      "superplane.runInspector.internalAccordions",
-      JSON.stringify({ input: false, runtime: false, output: true }),
-    );
+  describe("runtime and output regressions", () => {
+    it("preserves newlines in fallback runtime config strings", () => {
+      mockedExecutions = executions.map((execution) =>
+        execution.nodeId === "action-1"
+          ? { ...execution, configuration: { message: "first line\nsecond line" } }
+          : execution,
+      );
 
-    renderInspector({ selectedNodeId: "action-2" });
+      renderInspector({ selectedNodeId: "action-1" });
+      fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
 
-    expect(screen.getByText(/"data":\{"ok":true\}/)).toBeInTheDocument();
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("first line\nsecond line");
+    });
+
+    it("shows an edit action on node headers with runtime config", () => {
+      const onEditNode = vi.fn();
+      renderInspector({ selectedNodeId: "action-2", onEditNode });
+
+      fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
+
+      expect(onEditNode).toHaveBeenCalledWith("action-2");
+    });
+
+    it("honors stored internal accordion preferences", () => {
+      localStorage.setItem(
+        "superplane.runInspector.internalAccordions",
+        JSON.stringify({ input: false, runtime: false, output: true }),
+      );
+
+      renderInspector({ selectedNodeId: "action-2" });
+
+      expect(screen.getByText(/"data":\{"ok":true\}/)).toBeInTheDocument();
+    });
+
+    it("does not show an output section for steps that have no output", () => {
+      mockedExecutions = runningExecutions;
+
+      renderInspector({ run: runningRun, selectedNodeId: "action-2" });
+
+      expect(screen.queryByRole("button", { name: /Output/i })).not.toBeInTheDocument();
+      expect(screen.queryByText("No output for this step.")).not.toBeInTheDocument();
+    });
   });
 
   it("opens the upstream input chain in a modal from the more chip", () => {
@@ -270,6 +331,19 @@ describe("RunInspectorPanel", () => {
           },
         }),
       );
+    });
+  });
+
+  it("notifies callers with the new root event id after rerun", async () => {
+    const onRerunCreated = vi.fn();
+    reemitTriggerEventMock.mockResolvedValueOnce({ data: { eventId: "event-rerun" } });
+
+    renderInspector({ onRerunCreated });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Rerun/i })[0]);
+
+    await waitFor(() => {
+      expect(onRerunCreated).toHaveBeenCalledWith("event-rerun");
     });
   });
 
@@ -430,6 +504,34 @@ describe("RunInspectorPanel", () => {
         }),
       );
     });
+  });
+
+  it("hides approval actions for cancelled approval executions", () => {
+    mockedExecutions = [
+      {
+        id: "execution-approval",
+        nodeId: "approval-1",
+        state: "STATE_FINISHED",
+        result: "RESULT_CANCELLED",
+        resultReason: "RESULT_REASON_OK",
+        resultMessage: "",
+        createdAt: "2026-05-01T12:00:03Z",
+        updatedAt: "2026-05-01T12:00:04Z",
+        outputs: {},
+        metadata: {
+          records: [{ index: 0, state: "pending", type: "user", user: { id: "account-1", email: "me@example.com" } }],
+        },
+        configuration: {},
+      },
+    ];
+
+    renderInspector({
+      selectedNodeId: "approval-1",
+      account: { id: "account-1", name: "Me", email: "me@example.com", avatar_url: "", installation_admin: false },
+    });
+
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
   });
 
   it("shows approval nodes from run execution refs when the current user cannot approve", () => {

--- a/web_src/src/ui/Runs/RunInspectorPanel.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   type ActionsAction,
   type CanvasesCanvasRun,
@@ -38,6 +38,8 @@ export interface RunInspectorPanelProps {
   selectedNodeId?: string | null;
   onSelectNode: (nodeId: string) => void;
   onClearSelectedNode?: () => void;
+  onEditNode?: (nodeId: string) => void;
+  onRerunCreated?: (eventId: string) => void | Promise<void>;
   onClose: () => void;
 }
 
@@ -61,6 +63,8 @@ export function RunInspectorPanel({
   selectedNodeId = null,
   onSelectNode,
   onClearSelectedNode,
+  onEditNode,
+  onRerunCreated,
   onClose,
 }: RunInspectorPanelProps) {
   const { account } = useAccount();
@@ -86,12 +90,13 @@ export function RunInspectorPanel({
   const errorSummaries = useMemo(() => findRunInspectorErrorSummaries(sections), [sections]);
   const inspectorWidth = useResizableInspectorWidth();
   const selectedValue = selectedNodeId ?? "";
-  const [pendingErrorScrollNodeId, setPendingErrorScrollNodeId] = useState<string | null>(null);
+  const [errorScrollRequest, setErrorScrollRequest] = useState<{ nodeId: string; requestId: number } | null>(null);
   const actions = useRunInspectorActions({
     canvasId,
     run,
     sections,
     executionsLoading: executionsQuery.isLoading,
+    onRerunCreated,
   });
 
   const handleValueChange = (value: string) => {
@@ -104,21 +109,9 @@ export function RunInspectorPanel({
   };
 
   const jumpToErrorOutput = (nodeId: string) => {
-    setPendingErrorScrollNodeId(nodeId);
+    setErrorScrollRequest({ nodeId, requestId: Date.now() });
     onSelectNode(nodeId);
   };
-
-  useEffect(() => {
-    if (!pendingErrorScrollNodeId || selectedNodeId !== pendingErrorScrollNodeId) return;
-
-    const frame = window.requestAnimationFrame(() => {
-      const errorOutput = document.querySelector(`[data-run-error-output-node-id="${pendingErrorScrollNodeId}"]`);
-      errorOutput?.scrollIntoView({ block: "center", behavior: "smooth" });
-      setPendingErrorScrollNodeId(null);
-    });
-
-    return () => window.cancelAnimationFrame(frame);
-  }, [pendingErrorScrollNodeId, selectedNodeId]);
 
   return (
     <aside
@@ -152,9 +145,12 @@ export function RunInspectorPanel({
         onValueChange={handleValueChange}
         onJumpToError={jumpToErrorOutput}
         onRerun={actions.rerun}
+        onEditNode={onEditNode}
         rerunPending={actions.rerunPending}
         actions={actions}
         currentUser={resolvedCurrentUser}
+        errorScrollRequest={errorScrollRequest}
+        onErrorScrolled={() => setErrorScrollRequest(null)}
       />
     </aside>
   );

--- a/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
@@ -1,20 +1,23 @@
+import { Pencil } from "lucide-react";
 import { useState, type CSSProperties } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ConfigurationFieldRenderer } from "@/ui/configurationFieldRenderer";
 import { cn } from "@/lib/utils";
-import { EmptySectionText, JsonPayload, TimelineAccordionCard } from "./RunInspectorTimelineCard";
+import { EmptySectionText, HeaderIconButton, JsonPayload, TimelineAccordionCard } from "./RunInspectorTimelineCard";
 import { hasObjectValue, type RunInspectorNodeSection } from "./runNodeDetailModel";
 
 export function RuntimeTimelineCard({
   section,
   jsonViewStyle,
   organizationId,
+  onEditNode,
 }: {
   section: RunInspectorNodeSection;
   jsonViewStyle: CSSProperties;
   organizationId?: string;
+  onEditNode?: (nodeId: string) => void;
 }) {
   const [mode, setMode] = useState<"form" | "json">("form");
   const configuration = section.tabData?.configuration;
@@ -24,7 +27,9 @@ export function RuntimeTimelineCard({
       value="runtime"
       status={{ dotClassName: "bg-blue-500", label: "Running" }}
       title="Runtime Config"
-      trailing={<RuntimeViewToggle mode={mode} onChange={setMode} />}
+      trailing={
+        <RuntimeHeaderActions mode={mode} nodeId={section.nodeId} onModeChange={setMode} onEditNode={onEditNode} />
+      }
       jsonViewStyle={jsonViewStyle}
     >
       {mode === "form" ? (
@@ -38,6 +43,31 @@ export function RuntimeTimelineCard({
         <JsonPayload value={configuration} jsonViewStyle={jsonViewStyle} />
       )}
     </TimelineAccordionCard>
+  );
+}
+
+function RuntimeHeaderActions({
+  mode,
+  nodeId,
+  onModeChange,
+  onEditNode,
+}: {
+  mode: "form" | "json";
+  nodeId: string;
+  onModeChange: (mode: "form" | "json") => void;
+  onEditNode?: (nodeId: string) => void;
+}) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <RuntimeViewToggle mode={mode} onChange={onModeChange} />
+      {onEditNode ? (
+        <HeaderIconButton
+          label="Edit runtime config"
+          icon={<Pencil className="h-3.5 w-3.5" />}
+          onClick={() => onEditNode(nodeId)}
+        />
+      ) : null}
+    </span>
   );
 }
 

--- a/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
@@ -1,6 +1,7 @@
 import { useState, type CSSProperties } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { ConfigurationFieldRenderer } from "@/ui/configurationFieldRenderer";
 import { cn } from "@/lib/utils";
 import { EmptySectionText, JsonPayload, TimelineAccordionCard } from "./RunInspectorTimelineCard";
@@ -164,15 +165,26 @@ function RuntimeFallbackConfigField({
   }
 
   if (typeof value === "string" || typeof value === "number" || value === null) {
+    const displayValue = value === null ? "" : String(value);
+
     return (
       <label className="block space-y-1.5">
         <span className="text-sm font-medium text-slate-800 dark:text-gray-100">{label}</span>
-        <Input
-          aria-label={label}
-          readOnly
-          value={value === null ? "" : String(value)}
-          className="h-9 border-slate-300 bg-white text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
-        />
+        {displayValue.includes("\n") ? (
+          <Textarea
+            aria-label={label}
+            readOnly
+            value={displayValue}
+            className="min-h-24 resize-y border-slate-300 bg-white text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+          />
+        ) : (
+          <Input
+            aria-label={label}
+            readOnly
+            value={displayValue}
+            className="h-9 border-slate-300 bg-white text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+          />
+        )}
       </label>
     );
   }

--- a/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { getJsonViewStyle } from "@/lib/jsonViewTheme";
 import { Accordion } from "@/ui/accordion";
 import { useTheme } from "@/contexts/useTheme";
@@ -31,10 +31,14 @@ export function RunInspectorStepTimeline({
   section,
   componentIconMap,
   organizationId,
+  errorScrollRequestId,
+  onErrorScrolled,
 }: {
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
   organizationId?: string;
+  errorScrollRequestId?: number | null;
+  onErrorScrolled?: () => void;
 }) {
   const { resolvedTheme } = useTheme();
   const jsonViewStyle = getJsonViewStyle(resolvedTheme);
@@ -46,6 +50,37 @@ export function RunInspectorStepTimeline({
   const hasDetails = !!section.tabData?.details && Object.keys(section.tabData.details).length > 0;
   const hasRuntimeConfig = hasObjectValue(section.tabData?.configuration);
   const timelineItems = buildTimelineItems(section, hasRuntimeConfig);
+  const hasOutputTimelineItem = timelineItems.some((item) => item.value === "output");
+
+  useEffect(() => {
+    if (!errorScrollRequestId || !hasOutputTimelineItem) return;
+
+    setPreferences((current) => {
+      if (current.output) return current;
+
+      const next = { ...current, output: true };
+      localStorage.setItem(ACCORDION_STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, [errorScrollRequestId, hasOutputTimelineItem]);
+
+  useEffect(() => {
+    if (!errorScrollRequestId || !preferences.output) return;
+
+    let secondFrame = 0;
+    const firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
+        const errorOutput = document.querySelector(`[data-run-error-output-node-id="${section.nodeId}"]`);
+        errorOutput?.scrollIntoView({ block: "center", behavior: "smooth" });
+        onErrorScrolled?.();
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      window.cancelAnimationFrame(secondFrame);
+    };
+  }, [errorScrollRequestId, onErrorScrolled, preferences.output, section.nodeId]);
 
   const handlePreferenceChange = (values: string[]) => {
     const next: InternalAccordionPreferences = {
@@ -153,6 +188,7 @@ function OutputTimelineCard({
       title={outputTitle(section)}
       actionPayload={outputActionPayload(section)}
       jsonViewStyle={jsonViewStyle}
+      errorOutputNodeId={section.errorMessage ? section.nodeId : undefined}
     >
       {hasOutputs ? (
         <OutputSection section={section} jsonViewStyle={jsonViewStyle} />

--- a/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
@@ -31,12 +31,14 @@ export function RunInspectorStepTimeline({
   section,
   componentIconMap,
   organizationId,
+  onEditNode,
   errorScrollRequestId,
   onErrorScrolled,
 }: {
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
   organizationId?: string;
+  onEditNode?: (nodeId: string) => void;
   errorScrollRequestId?: number | null;
   onErrorScrolled?: () => void;
 }) {
@@ -114,7 +116,12 @@ export function RunInspectorStepTimeline({
             {item.value === "input" ? (
               <InputTimelineCard section={section} jsonViewStyle={jsonViewStyle} componentIconMap={componentIconMap} />
             ) : item.value === "runtime" ? (
-              <RuntimeTimelineCard section={section} jsonViewStyle={jsonViewStyle} organizationId={organizationId} />
+              <RuntimeTimelineCard
+                section={section}
+                jsonViewStyle={jsonViewStyle}
+                organizationId={organizationId}
+                onEditNode={onEditNode}
+              />
             ) : (
               <OutputTimelineCard section={section} jsonViewStyle={jsonViewStyle} />
             )}

--- a/web_src/src/ui/Runs/RunInspectorStepsList.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepsList.tsx
@@ -18,9 +18,12 @@ export function RunInspectorStepsList({
   onValueChange,
   onJumpToError,
   onRerun,
+  onEditNode,
   rerunPending,
   actions,
   currentUser,
+  errorScrollRequest,
+  onErrorScrolled,
 }: {
   errorSummaries: RunInspectorErrorSummary[];
   status: keyof typeof RUN_STATUS_META;
@@ -32,9 +35,12 @@ export function RunInspectorStepsList({
   onValueChange: (value: string) => void;
   onJumpToError: (nodeId: string) => void;
   onRerun: () => void;
+  onEditNode?: (nodeId: string) => void;
   rerunPending: boolean;
   actions: ReturnType<typeof useRunInspectorActions>;
   currentUser?: RunInspectorCurrentUser;
+  errorScrollRequest?: { nodeId: string; requestId: number } | null;
+  onErrorScrolled?: () => void;
 }) {
   return (
     <div className="min-h-0 flex-1 overflow-y-auto" data-testid="run-panel-step-list">
@@ -70,9 +76,12 @@ export function RunInspectorStepsList({
               organizationId={organizationId}
               isOpen={selectedValue === section.nodeId}
               onRerun={onRerun}
+              onEditNode={onEditNode}
               rerunPending={rerunPending}
               actions={actions}
               currentUser={currentUser}
+              errorScrollRequestId={errorScrollRequest?.nodeId === section.nodeId ? errorScrollRequest.requestId : null}
+              onErrorScrolled={onErrorScrolled}
             />
           ))}
         </Accordion>

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.spec.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { escapeJsonStringValue } from "./runInspectorJson";
+
+describe("escapeJsonStringValue", () => {
+  it("keeps JSON string control characters visible", () => {
+    expect(escapeJsonStringValue('first line\nsecond\t"quoted"\\slash')).toBe(
+      'first line\\nsecond\\t\\"quoted\\"\\\\slash',
+    );
+  });
+});

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
@@ -7,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils";
 import { jsonViewClassName } from "@/lib/jsonViewTheme";
 import { AccordionContent, AccordionItem } from "@/ui/accordion";
+import { escapeJsonStringValue } from "./runInspectorJson";
 import type { InternalAccordionKey, StatusPill } from "./RunInspectorTimelineTypes";
 
 export function TimelineAccordionCard({
@@ -175,7 +176,23 @@ export function JsonPayload({
       className={jsonViewClassName}
       displayObjectSize={false}
       enableClipboard={false}
-    />
+    >
+      <JsonView.String
+        render={({ children, ...props }, { type, value: stringValue }) => {
+          if (type !== "value") return undefined;
+
+          const displayValue = typeof children === "string" ? children : String(stringValue ?? "");
+
+          return (
+            <>
+              <JsonView.ValueQuote />
+              <span {...props}>{escapeJsonStringValue(displayValue)}</span>
+              <JsonView.ValueQuote />
+            </>
+          );
+        }}
+      />
+    </JsonView>
   );
 }
 

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
@@ -18,6 +18,7 @@ export function TimelineAccordionCard({
   trailing,
   actionPayload,
   jsonViewStyle,
+  errorOutputNodeId,
   children,
 }: {
   value: InternalAccordionKey;
@@ -28,6 +29,7 @@ export function TimelineAccordionCard({
   trailing?: ReactNode;
   actionPayload?: unknown;
   jsonViewStyle: CSSProperties;
+  errorOutputNodeId?: string;
   children: ReactNode;
 }) {
   const [modalOpen, setModalOpen] = useState(false);
@@ -85,7 +87,9 @@ export function TimelineAccordionCard({
             <ChevronDown className="h-4 w-4 transition-transform duration-200" />
           </AccordionPrimitive.Trigger>
         </AccordionPrimitive.Header>
-        <AccordionContent className="px-3 py-2.5">{children}</AccordionContent>
+        <AccordionContent className="px-3 py-2.5">
+          <div data-run-error-output-node-id={errorOutputNodeId}>{children}</div>
+        </AccordionContent>
       </AccordionItem>
 
       <Dialog open={modalOpen} onOpenChange={setModalOpen}>

--- a/web_src/src/ui/Runs/RunInspectorTimelineTypes.ts
+++ b/web_src/src/ui/Runs/RunInspectorTimelineTypes.ts
@@ -31,7 +31,9 @@ export function buildTimelineItems(section: RunInspectorNodeSection, hasRuntimeC
     items.push({ value: "runtime" });
   }
 
-  items.push({ value: "output" });
+  if (section.outputSections.length > 0 || section.errorMessage) {
+    items.push({ value: "output" });
+  }
 
   return items;
 }

--- a/web_src/src/ui/Runs/runInspectorJson.ts
+++ b/web_src/src/ui/Runs/runInspectorJson.ts
@@ -1,0 +1,4 @@
+export function escapeJsonStringValue(value: string): string {
+  const encoded = JSON.stringify(value);
+  return encoded.slice(1, -1);
+}

--- a/web_src/src/ui/Runs/runNodeDetailOutputs.ts
+++ b/web_src/src/ui/Runs/runNodeDetailOutputs.ts
@@ -63,7 +63,8 @@ export function buildNodeActions(
   return {
     canStop: Boolean(execution?.id && isActive),
     canPushThrough: Boolean(execution?.id && isActive && (componentName === "wait" || componentName === "timegate")),
-    approvalRecords: componentName.includes("approval") ? extractApprovalRecords(execution?.metadata) : [],
+    approvalRecords:
+      execution?.id && isActive && componentName.includes("approval") ? extractApprovalRecords(execution.metadata) : [],
   };
 }
 

--- a/web_src/src/ui/Runs/useRunInspectorActions.ts
+++ b/web_src/src/ui/Runs/useRunInspectorActions.ts
@@ -17,11 +17,13 @@ export function useRunInspectorActions({
   run,
   sections,
   executionsLoading,
+  onRerunCreated,
 }: {
   canvasId: string;
   run: CanvasesCanvasRun;
   sections: RunInspectorNodeSection[];
   executionsLoading: boolean;
+  onRerunCreated?: (eventId: string) => void | Promise<void>;
 }) {
   const queryClient = useQueryClient();
   const runningExecutionIds = useMemo(
@@ -42,7 +44,7 @@ export function useRunInspectorActions({
     await queryClient.invalidateQueries({ queryKey: ["canvases"] });
   }, [queryClient]);
 
-  const rerunMutation = useRerunMutation({ canvasId, run, refreshRunQueries });
+  const rerunMutation = useRerunMutation({ canvasId, run, refreshRunQueries, onRerunCreated });
   const stopMutation = useStopMutation({
     canvasId,
     runningExecutionIds,
@@ -83,10 +85,12 @@ function useRerunMutation({
   canvasId,
   run,
   refreshRunQueries,
+  onRerunCreated,
 }: {
   canvasId: string;
   run: CanvasesCanvasRun;
   refreshRunQueries: () => Promise<void>;
+  onRerunCreated?: (eventId: string) => void | Promise<void>;
 }) {
   return useMutation({
     mutationFn: async () => {
@@ -94,7 +98,7 @@ function useRerunMutation({
         throw new Error("Run root event is missing");
       }
 
-      await canvasesReemitTriggerEvent(
+      const response = await canvasesReemitTriggerEvent(
         withOrganizationHeader({
           path: {
             canvasId,
@@ -103,9 +107,14 @@ function useRerunMutation({
           },
         }),
       );
+
+      return response.data?.eventId;
     },
-    onSuccess: async () => {
+    onSuccess: async (eventId) => {
       await refreshRunQueries();
+      if (eventId) {
+        await onRerunCreated?.(eventId);
+      }
       showSuccessToast("Run restarted");
     },
     onError: (error) => {

--- a/web_src/src/ui/configurationFieldRenderer/ReadonlyFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ReadonlyFieldRenderer.tsx
@@ -84,7 +84,7 @@ function ReadonlyValue({ field, value }: { field: ConfigurationField; value: unk
 
 function ReadonlyPrimitiveValue({ value }: { value: string }) {
   return (
-    <div className="min-h-9 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100">
+    <div className="min-h-9 w-full whitespace-pre-wrap break-words rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100">
       {value}
     </div>
   );


### PR DESCRIPTION
## Summary
- add node header edit access from run inspector runtime config
- preserve multiline runtime config values and hide empty outputs
- delay error scrolling until nested accordions are open
- hide cancelled approval actions and switch to the created rerun

## Verification
- make format.js
- cd web_src && npm run test -- src/ui/Runs/RunInspectorPanel.spec.tsx
- make check.lint.ui
- make check.build.ui