### PR TITLE
feat: unify Console and Files markdown chips and link styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ CLAUDE.local.md
 !.agents/skills/
 !.agents/skills/**
 .worktrees/
+.superpowers/
 coverage-go.out
 
 # Generated protobuf and OpenAPI artifacts

--- a/docs/superpowers/specs/2026-07-10-github-markdown-alerts-design.md
+++ b/docs/superpowers/specs/2026-07-10-github-markdown-alerts-design.md
@@ -1,0 +1,58 @@
+# GitHub-style markdown alerts in Files and Console
+
+**Date:** 2026-07-10  
+**Status:** Approved for planning  
+**Surfaces:** Files `.md` preview, Console markdown panels (shared `MarkdownContent`)
+
+## Goal
+
+Support GitHub Flavored Markdown alerts (`> [!NOTE]`, etc.) in both Files and Console so README-style docs and console panels render the same callouts.
+
+## Decisions
+
+| Topic | Choice |
+| --- | --- |
+| Feature | GitHub Alerts (not other “annotation” features) |
+| Visual style | SuperPlane chrome (white/slate surface, thin accent bar, title-case label) — not GitHub’s tinted backgrounds |
+| Types | All five: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION` |
+| Implementation | Custom `blockquote` renderer inside `MarkdownContent` (no new remark plugin / dependency) |
+| Scope | Shared renderer only; agent chat out of scope |
+
+## Architecture
+
+Extend `web_src/src/pages/app/Markdown.tsx` only. Files and Console already consume `MarkdownContent`, so both pick up alerts automatically.
+
+1. Register a custom `blockquote` component on `ReactMarkdown`.
+2. Inspect the blockquote’s first text line for a GitHub alert marker: `[!TYPE]` where `TYPE` is one of the five names (case-insensitive).
+3. On match:
+   - Render an alert shell (accent bar + label + body) instead of the default blockquote.
+   - Omit the marker line from the body.
+   - Keep nested markdown in the body (links, code, lists, `node:` / `integration:` chips).
+4. On no match (or unknown marker such as `[!TODO]`): keep existing blockquote styles.
+
+Styles live in a sibling module (e.g. `markdownAlertStyles.ts`) next to other markdown token modules, with light and dark variants aligned to Console/Files chrome.
+
+Remark/rehype plugins and sanitize schema stay unchanged; alerts are still blockquotes in the AST.
+
+## Behavior & edge cases
+
+- Display labels: Title Case (`Note`, `Tip`, `Important`, `Warning`, `Caution`).
+- Multi-paragraph content is supported when it remains one blockquote.
+- Nested alerts are out of scope (GitHub also discourages nesting).
+- Custom titles (`> [!NOTE] Custom title`) are out of scope for v1; treat as non-matching / plain blockquote unless the first line is exactly the marker.
+- CEL interpolation in Console still runs before markdown render (unchanged).
+
+## Testing & fixtures
+
+- Unit tests in `Markdown.spec.tsx`:
+  - Each of the five types renders as an alert (not a plain blockquote).
+  - Unknown marker stays a plain blockquote.
+  - Body markdown (e.g. a link or inline code) still works inside an alert.
+- Update Storybook showcase README (`cleanCodeAssessment.README.md`) with examples of all five types for visual checks in Files and Console.
+
+## Out of scope
+
+- Agent chat / `RichMessage` pipeline
+- New npm dependencies for alert parsing
+- GitHub-faithful tinted alert skins
+- E2E coverage for this pass

--- a/web_src/src/pages/app/Markdown.spec.tsx
+++ b/web_src/src/pages/app/Markdown.spec.tsx
@@ -124,4 +124,38 @@ describe("MarkdownContent", () => {
     expect(screen.getByText("Failed").tagName).toBe("STRONG");
     expect(screen.getByText("Failed").className).toContain("font-semibold");
   });
+
+  it.each([
+    ["NOTE", "Note"],
+    ["TIP", "Tip"],
+    ["IMPORTANT", "Important"],
+    ["WARNING", "Warning"],
+    ["CAUTION", "Caution"],
+  ] as const)("renders GitHub %s alerts with SuperPlane chrome", (type, label) => {
+    render(<MarkdownContent content={`> [!${type}]\n> Useful ${label.toLowerCase()} details.`} />);
+
+    const alert = screen.getByTestId(`markdown-alert-${type.toLowerCase()}`);
+    expect(alert.tagName).toBe("ASIDE");
+    expect(alert).toHaveTextContent(label);
+    expect(alert).toHaveTextContent(`Useful ${label.toLowerCase()} details.`);
+    expect(alert).not.toHaveTextContent(`[!${type}]`);
+    expect(document.querySelector("blockquote")).toBeNull();
+  });
+
+  it("keeps unknown alert markers as plain blockquotes", () => {
+    render(<MarkdownContent content={"> [!TODO]\n> Ship it later."} />);
+
+    expect(screen.queryByTestId(/markdown-alert-/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Ship it later/)).toBeInTheDocument();
+    expect(document.querySelector("blockquote")).toBeTruthy();
+  });
+
+  it("preserves nested markdown inside alert bodies", () => {
+    render(<MarkdownContent content={"> [!TIP]\n> See [docs](https://example.com) and `sha`."} />);
+
+    const alert = screen.getByTestId("markdown-alert-tip");
+    expect(alert).toHaveTextContent("Tip");
+    expect(screen.getByRole("link", { name: "docs" })).toHaveAttribute("href", "https://example.com");
+    expect(screen.getByTestId("markdown-code")).toHaveTextContent("sha");
+  });
 });

--- a/web_src/src/pages/app/Markdown.spec.tsx
+++ b/web_src/src/pages/app/Markdown.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { MarkdownContent } from "./Markdown";
 
@@ -157,5 +158,72 @@ describe("MarkdownContent", () => {
     expect(alert).toHaveTextContent("Tip");
     expect(screen.getByRole("link", { name: "docs" })).toHaveAttribute("href", "https://example.com");
     expect(screen.getByTestId("markdown-code")).toHaveTextContent("sha");
+  });
+
+  it("renders [!SECTION] blockquotes as collapsed accordions", async () => {
+    const user = userEvent.setup();
+    render(
+      <MarkdownContent
+        content={"> [!SECTION] Rules\n> Standing instructions for the agent.\n>\n> Keep them focused."}
+      />,
+    );
+
+    const section = screen.getByTestId("markdown-section");
+    expect(section).toHaveTextContent("Rules");
+    expect(section).not.toHaveTextContent("[!SECTION]");
+    expect(screen.queryByText(/Standing instructions/)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Rules/i }));
+    expect(screen.getByText(/Standing instructions for the agent/)).toBeInTheDocument();
+    expect(screen.getByText(/Keep them focused/)).toBeInTheDocument();
+  });
+
+  it("renders optional section trailing meta after a middle dot", () => {
+    render(<MarkdownContent content={"> [!SECTION] Rules · ~5,366\n> Body copy."} />);
+
+    const section = screen.getByTestId("markdown-section");
+    expect(section).toHaveTextContent("Rules");
+    expect(section).toHaveTextContent("~5,366");
+    expect(section).not.toHaveTextContent("[!SECTION]");
+  });
+
+  it("applies named section presets for icon and accent color", () => {
+    render(<MarkdownContent content={"> [!SECTION:tools] Tool definitions · ~9,202\n> Body copy."} />);
+
+    const section = screen.getByTestId("markdown-section");
+    expect(section).toHaveAttribute("data-section-preset", "tools");
+    expect(section).toHaveTextContent("Tool definitions");
+    expect(section).toHaveTextContent("~9,202");
+  });
+
+  it("shows a count of direct nested sections beside the title", () => {
+    render(
+      <MarkdownContent
+        content={
+          "> [!SECTION:rules] Rules · ~5,366\n> Intro.\n>\n> > [!SECTION:folder] Project Rules\n> > One.\n>\n> > [!SECTION:folder] Cursor & User Rules\n> > Two."
+        }
+      />,
+    );
+
+    const section = screen.getByTestId("markdown-section");
+    expect(section).toHaveAttribute("data-section-count", "2");
+    expect(section).toHaveTextContent("Rules");
+    expect(section).toHaveTextContent("2");
+  });
+
+  it("preserves nested markdown inside section bodies", async () => {
+    const user = userEvent.setup();
+    render(<MarkdownContent content={"> [!SECTION] Tips\n> See [docs](https://example.com) and `sha`."} />);
+
+    await user.click(screen.getByRole("button", { name: /Tips/i }));
+    expect(screen.getByRole("link", { name: "docs" })).toHaveAttribute("href", "https://example.com");
+    expect(screen.getByTestId("markdown-code")).toHaveTextContent("sha");
+  });
+
+  it("does not treat [!SECTION] without a title as a section", () => {
+    render(<MarkdownContent content={"> [!SECTION]\n> Missing title stays a quote."} />);
+
+    expect(screen.queryByTestId("markdown-section")).not.toBeInTheDocument();
+    expect(document.querySelector("blockquote")).toBeTruthy();
   });
 });

--- a/web_src/src/pages/app/Markdown.spec.tsx
+++ b/web_src/src/pages/app/Markdown.spec.tsx
@@ -24,11 +24,19 @@ vi.mock("@/components/AgentSidebar/widgets/NodeChip", () => ({
   ),
 }));
 
+vi.mock("@/components/AgentSidebar/widgets/IntegrationButton", () => ({
+  IntegrationButton: ({ integrationRef, label }: { integrationRef: string; label?: string }) => (
+    <button type="button" data-testid="integration-chip">
+      {label}:{integrationRef}
+    </button>
+  ),
+}));
+
 vi.mock("@/components/AgentSidebar/widgets/MarkdownCode", () => ({
   MarkdownCode: ({ children, className }: { children?: string; className?: string }) => (
-    <div data-language={className?.replace("language-", "")} data-testid="markdown-code">
+    <code data-language={className?.replace("language-", "")} data-testid="markdown-code">
       {children}
-    </div>
+    </code>
   ),
 }));
 
@@ -53,12 +61,28 @@ describe("MarkdownContent", () => {
     expect(screen.getByTestId("node-chip")).toHaveTextContent("Deploy:deploy-node:canvas-1:org-1");
   });
 
+  it("renders integration links as chips", () => {
+    render(<MarkdownContent content={"Connect [GitHub](integration:github) to continue."} />);
+
+    expect(screen.getByTestId("integration-chip")).toHaveTextContent("GitHub:github");
+    expect(screen.queryByRole("link", { name: "GitHub" })).not.toBeInTheDocument();
+  });
+
   it("keeps regular markdown links on native anchors", () => {
     render(<MarkdownContent content={'Open [docs](../docs "Local docs").'} />);
 
     expect(screen.getByRole("link", { name: "docs" })).toHaveAttribute("href", "../docs");
     expect(screen.getByRole("link", { name: "docs" })).toHaveAttribute("title", "Local docs");
     expect(screen.getByRole("link", { name: "docs" })).not.toHaveAttribute("target");
+  });
+
+  it("applies shared console link and inline-code styles", () => {
+    const { container } = render(<MarkdownContent content={"See [docs](https://example.com) and `sha`."} />);
+
+    expect(container.firstChild).toHaveClass("[&_a]:text-sky-600");
+    expect(container.firstChild).toHaveClass("[&_a]:no-underline");
+    expect(container.firstChild).toHaveClass("[&_code]:bg-gray-950/5");
+    expect(container.firstChild).not.toHaveClass("[&_a]:underline");
   });
 
   it("keeps regular fenced code blocks as code", () => {

--- a/web_src/src/pages/app/Markdown.tsx
+++ b/web_src/src/pages/app/Markdown.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { CONSOLE_CODE_BADGE_ANCHOR_SELECTOR_CLASSES } from "./console/consoleCodeStyles";
 import { CONSOLE_LINK_ANCHOR_SELECTOR_CLASSES } from "./console/consoleLinkStyles";
 import { MarkdownAlert, parseGithubAlertChildren } from "./markdownAlerts";
+import { MarkdownSection, parseGithubSectionChildren } from "./markdownSection";
 import { markdownHeadingClassName } from "./markdownHeadingStyles";
 import {
   MARKDOWN_TABLE_CLASSES,
@@ -201,6 +202,15 @@ function MarkdownCodeWithDiagrams({
 }
 
 function MarkdownBlockquote({ children, node: _node, ...props }: ComponentProps<"blockquote"> & ExtraProps) {
+  const section = parseGithubSectionChildren(children);
+  if (section) {
+    return (
+      <MarkdownSection title={section.title} trailing={section.trailing} presetId={section.presetId}>
+        {section.body}
+      </MarkdownSection>
+    );
+  }
+
   const alert = parseGithubAlertChildren(children);
   if (alert) {
     return <MarkdownAlert type={alert.type}>{alert.body}</MarkdownAlert>;

--- a/web_src/src/pages/app/Markdown.tsx
+++ b/web_src/src/pages/app/Markdown.tsx
@@ -8,11 +8,14 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
+import { IntegrationButton } from "@/components/AgentSidebar/widgets/IntegrationButton";
 import { MarkdownCode } from "@/components/AgentSidebar/widgets/MarkdownCode";
 import { MermaidWidget } from "@/components/AgentSidebar/widgets/MermaidWidget";
 import { NodeChipFromLink } from "@/components/AgentSidebar/widgets/NodeChip";
 import { cn } from "@/lib/utils";
 
+import { CONSOLE_CODE_BADGE_ANCHOR_SELECTOR_CLASSES } from "./console/consoleCodeStyles";
+import { CONSOLE_LINK_ANCHOR_SELECTOR_CLASSES } from "./console/consoleLinkStyles";
 import { markdownHeadingClassName } from "./markdownHeadingStyles";
 import {
   MARKDOWN_TABLE_CLASSES,
@@ -23,31 +26,34 @@ import {
 
 /**
  * Tailwind class string shared by every full-document markdown renderer in the
- * app. We deliberately do not use the official `prose` plugin so headings,
- * code blocks, tables, and `<details>` stay visually consistent with the
- * canvas chrome at small panel sizes.
+ * app (Console panels and Files `.md` preview). We deliberately do not use the
+ * official `prose` plugin so headings, code blocks, tables, and `<details>`
+ * stay visually consistent with the canvas chrome at small panel sizes.
+ *
+ * Link and inline-code colors come from the shared console tokens so Files and
+ * Console markdown match HTML panels and table cells.
  *
  * Heading spacing is applied on the rendered `<h1>`–`<h4>` elements (see
  * `markdownHeadingComponents`) because parent `[&_h2]:mt-*` utilities are not
  * reliably generated/applied in our Tailwind v4 setup.
  */
-const MARKDOWN_CONTENT_CLASSES =
+const MARKDOWN_CONTENT_CLASSES = cn(
   "max-w-none text-[13px] text-slate-800 dark:text-gray-100 " +
-  "[&_p]:mb-2 [&_p]:leading-relaxed " +
-  "[&_strong]:font-semibold [&_b]:font-semibold " +
-  "[&_ol]:mb-2 [&_ol]:ml-5 [&_ol]:list-decimal " +
-  "[&_ul]:mb-2 [&_ul]:ml-5 [&_ul]:list-disc [&_li]:mb-1 " +
-  "[&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-slate-300 [&_blockquote]:pl-3 dark:[&_blockquote]:border-gray-600 " +
-  "[&_code]:rounded [&_code]:bg-slate-100 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-xs dark:[&_code]:bg-gray-800 " +
-  "[&_pre]:my-2 [&_pre]:overflow-auto [&_pre]:rounded [&_pre]:bg-slate-100 [&_pre]:p-2 dark:[&_pre]:bg-gray-800 " +
-  "[&_pre_code]:bg-transparent [&_pre_code]:p-0 " +
-  "[&_a]:underline [&_a]:underline-offset-2 [&_a]:decoration-current " +
-  "[&_details]:my-3 [&_details]:rounded-md [&_details]:border [&_details]:border-slate-200 [&_details]:bg-slate-50/60 [&_details]:px-3 [&_details]:py-2 dark:[&_details]:border-gray-700 dark:[&_details]:bg-gray-800/60 " +
-  "[&_details>summary]:flex [&_details>summary]:items-center [&_details>summary]:cursor-pointer [&_details>summary]:select-none [&_details>summary]:text-[13px] [&_details>summary]:font-semibold [&_details>summary]:text-slate-900 [&_details>summary]:list-none [&_details>summary]:marker:hidden [&_details>summary]:hover:text-gray-600 dark:[&_details>summary]:text-gray-100 dark:[&_details>summary]:hover:text-gray-400 " +
-  "[&_details>summary]:before:content-['▸'] [&_details>summary]:before:mr-2 [&_details>summary]:before:text-slate-500 [&_details>summary]:before:transition-transform [&_details>summary]:before:duration-200 dark:[&_details>summary]:before:text-gray-400 " +
-  "[&_details[open]>summary]:mb-3 [&_details[open]>summary]:before:rotate-90 " +
-  "[&_details>*:last-child]:mb-0";
-
+    "[&_p]:mb-2 [&_p]:leading-relaxed " +
+    "[&_strong]:font-semibold [&_b]:font-semibold " +
+    "[&_ol]:mb-2 [&_ol]:ml-5 [&_ol]:list-decimal " +
+    "[&_ul]:mb-2 [&_ul]:ml-5 [&_ul]:list-disc [&_li]:mb-1 " +
+    "[&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-slate-300 [&_blockquote]:pl-3 dark:[&_blockquote]:border-gray-600 " +
+    "[&_pre]:my-2 [&_pre]:overflow-auto [&_pre]:rounded [&_pre]:bg-slate-100 [&_pre]:p-2 dark:[&_pre]:bg-gray-800 " +
+    "[&_pre_code]:bg-transparent [&_pre_code]:p-0 " +
+    "[&_details]:my-3 [&_details]:rounded-md [&_details]:border [&_details]:border-slate-200 [&_details]:bg-slate-50/60 [&_details]:px-3 [&_details]:py-2 dark:[&_details]:border-gray-700 dark:[&_details]:bg-gray-800/60 " +
+    "[&_details>summary]:flex [&_details>summary]:items-center [&_details>summary]:cursor-pointer [&_details>summary]:select-none [&_details>summary]:text-[13px] [&_details>summary]:font-semibold [&_details>summary]:text-slate-900 [&_details>summary]:list-none [&_details>summary]:marker:hidden [&_details>summary]:hover:text-gray-600 dark:[&_details>summary]:text-gray-100 dark:[&_details>summary]:hover:text-gray-400 " +
+    "[&_details>summary]:before:content-['▸'] [&_details>summary]:before:mr-2 [&_details>summary]:before:text-slate-500 [&_details>summary]:before:transition-transform [&_details>summary]:before:duration-200 dark:[&_details>summary]:before:text-gray-400 " +
+    "[&_details[open]>summary]:mb-3 [&_details[open]>summary]:before:rotate-90 " +
+    "[&_details>*:last-child]:mb-0",
+  CONSOLE_LINK_ANCHOR_SELECTOR_CLASSES,
+  CONSOLE_CODE_BADGE_ANCHOR_SELECTOR_CLASSES,
+);
 /**
  * Sanitize schema extending the rehype-sanitize defaults with `<details>` /
  * `<summary>` (plus the `open` attribute) so collapsible sections can be
@@ -64,7 +70,7 @@ const MARKDOWN_SANITIZE_SCHEMA = {
   },
   protocols: {
     ...(defaultSchema.protocols ?? {}),
-    href: [...(defaultSchema.protocols?.href ?? []), "node"],
+    href: [...(defaultSchema.protocols?.href ?? []), "node", "integration"],
   },
 };
 
@@ -100,7 +106,7 @@ export function MarkdownContent({
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
         rehypePlugins={[rehypeRaw, [rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA]]}
-        urlTransform={(url) => (isNodeLink(url) ? url : defaultUrlTransform(url))}
+        urlTransform={(url) => (isSpecialMarkdownLink(url) ? url : defaultUrlTransform(url))}
         components={{
           h1: ({ children, ...props }) => (
             <h1 className={markdownHeadingClassName("h1")} {...props}>
@@ -199,9 +205,15 @@ function MarkdownLink({
   organizationId,
   ...props
 }: ComponentProps<"a"> & { canvasId?: string; organizationId?: string }) {
+  const label = typeof children === "string" ? children : undefined;
+
+  const integrationMatch = href?.match(/^integration:(.+)$/);
+  if (integrationMatch) {
+    return <IntegrationButton integrationRef={integrationMatch[1]} label={label} />;
+  }
+
   const nodeMatch = href?.match(/^node:(.+)$/);
   if (nodeMatch && canvasId && organizationId) {
-    const label = typeof children === "string" ? children : undefined;
     return (
       <NodeChipFromLink nodeId={nodeMatch[1]} rawLabel={label} canvasId={canvasId} organizationId={organizationId} />
     );
@@ -214,8 +226,8 @@ function MarkdownLink({
   );
 }
 
-function isNodeLink(url: string): boolean {
-  return url.startsWith("node:");
+function isSpecialMarkdownLink(url: string): boolean {
+  return url.startsWith("node:") || url.startsWith("integration:");
 }
 
 function hasLanguageCodeChild(children: ReactNode): boolean {

--- a/web_src/src/pages/app/Markdown.tsx
+++ b/web_src/src/pages/app/Markdown.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 
 import { CONSOLE_CODE_BADGE_ANCHOR_SELECTOR_CLASSES } from "./console/consoleCodeStyles";
 import { CONSOLE_LINK_ANCHOR_SELECTOR_CLASSES } from "./console/consoleLinkStyles";
+import { MarkdownAlert, parseGithubAlertChildren } from "./markdownAlerts";
 import { markdownHeadingClassName } from "./markdownHeadingStyles";
 import {
   MARKDOWN_TABLE_CLASSES,
@@ -158,6 +159,7 @@ export function MarkdownContent({
               {children}
             </MarkdownLink>
           ),
+          blockquote: MarkdownBlockquote,
           code: MarkdownCodeWithDiagrams,
           pre: MarkdownPre,
         }}
@@ -196,6 +198,15 @@ function MarkdownCodeWithDiagrams({
       {children}
     </MarkdownCode>
   );
+}
+
+function MarkdownBlockquote({ children, node: _node, ...props }: ComponentProps<"blockquote"> & ExtraProps) {
+  const alert = parseGithubAlertChildren(children);
+  if (alert) {
+    return <MarkdownAlert type={alert.type}>{alert.body}</MarkdownAlert>;
+  }
+
+  return <blockquote {...props}>{children}</blockquote>;
 }
 
 function MarkdownLink({

--- a/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
@@ -1,61 +1,11 @@
 # Markdown renderer showcase
 
-This README is a Storybook fixture for the **Files** tab. It exercises every
-feature currently supported by `MarkdownContent` (Console markdown panels and
-Files `.md` preview share the same renderer).
+Storybook fixture for the **Files** tab and Console markdown panel.
 
-> Agent-only widgets (`:::chart`, `:::buttons`, `run:` chips, etc.) are **not**
-> rendered here yet — those are the next feature.
+## Chips
 
----
-
-## Headings
-
-### Heading level 3
-
-#### Heading level 4
-
-## Inline formatting
-
-**Bold**, *italic*, ***bold italic***, ~~strikethrough~~, and `inline code`.
-
-Soft line breaks are enabled (remark-breaks), so a single newline
-becomes a `<br>` in the rendered output.
-
-## Links
-
-- External: [SuperPlane docs](https://docs.superplane.com)
-- Relative: [local docs](../docs "Local docs title")
-- Node chip (canvas context required): [Analyze PR](node:analyze-pr) · [On Pull Request](node:on-pull-request) · [Post Assessment](node:post-assessment)
-- Integration chip: [GitHub](integration:github) · [Cursor](integration:cursor)
-
-## Lists
-
-Unordered:
-
-- First item
-- Second item
-  - Nested item
-- Third item
-
-Ordered:
-
-1. One
-2. Two
-3. Three
-
-Task list (GFM):
-
-- [x] Supported today
-- [x] Integration chips
-- [x] GitHub alerts
-- [ ] Agent widgets (charts, run chips, …)
-- [ ] Interactive confirm / survey blocks
-
-## Blockquote
-
-> Use markdown panels for runbooks, status notes, and lightweight docs.
-> Nested quotes and **formatting** work inside blockquotes.
+- Node: [Analyze PR](node:analyze-pr) · [On Pull Request](node:on-pull-request) · [Post Assessment](node:post-assessment)
+- Integration: [GitHub](integration:github) · [Cursor](integration:cursor) · [Slack](integration:slack)
 
 ## GitHub alerts
 
@@ -63,7 +13,7 @@ Task list (GFM):
 > Useful information when skimming a runbook.
 
 > [!TIP]
-> Prefer `node:` chips when linking to canvas steps.
+> Prefer `node:` chips when linking to canvas steps: [Analyze PR](node:analyze-pr).
 
 > [!IMPORTANT]
 > Console interpolates `{{ variables }}` before markdown renders.
@@ -74,39 +24,34 @@ Task list (GFM):
 > [!CAUTION]
 > Destructive actions in table row triggers cannot be undone.
 
-## Table
+## Sections
 
-| Feature        | Console | Files | Agent chat |
-| -------------- | ------- | ----- | ---------- |
-| GFM markdown   | yes     | yes   | yes        |
-| Mermaid        | yes     | yes   | yes        |
-| `node:` chips  | yes     | yes   | yes        |
-| `integration:` | yes     | yes   | yes        |
-| GitHub alerts  | yes     | yes   | no         |
-| `:::chart`     | no      | no    | yes        |
-| `run:` chips   | no      | no    | yes        |
+Presets pick icon + accent: `tools`, `rules`, `skills`, `mcp`, `folder`.
+Trailing meta after ` · ` is optional. Nested sections show a count on the parent.
 
-## Code blocks
+> [!SECTION:tools] Tool definitions · ~9,202
+> Descriptions of tools the agent can call.
 
-Labeled fence (Monaco widget):
+> [!SECTION:rules] Rules · ~5,366
+> Standing instructions the agent follows each turn. Keep them focused and lightweight.
+>
+> Nested markdown still works: [docs](https://docs.superplane.com) and `inline code`.
+>
+> > [!SECTION:folder] Project Rules · ~2,752
+> > Project-local guidance from `AGENTS.md` and related files.
+>
+> > [!SECTION:rules] Cursor & User Rules · ~2,522
+> > Personal and Cursor-level standing instructions.
 
-```yaml
-apiVersion: v1
-kind: Canvas
-metadata:
-  name: Clean Code Assessment
-```
+> [!SECTION:skills] Scoring
+> The agent checks out the PR, runs metric tooling, and posts a self-updating comment.
 
-Unlabeled fence (plain `<pre><code>`):
+> [!SECTION:mcp] MCP servers · 3
+> Connected tools the agent can call through Model Context Protocol.
 
-```
-raw output line 1
-raw output line 2
-```
+## Mermaid
 
-Inline: call `upsertMemory` with namespace `prScores`.
-
-## Mermaid diagram
+Flowchart (custom node colors):
 
 ```mermaid
 flowchart LR
@@ -114,45 +59,35 @@ flowchart LR
   analyze --> report[Get Report]
   report --> post[Post Assessment]
   post --> memory[Update Saved Assessment]
+
+  style trigger fill:#e0f2fe,stroke:#0284c7,color:#0c4a6e
+  style analyze fill:#ecfdf5,stroke:#059669,color:#064e3b
+  style report fill:#fef3c7,stroke:#d97706,color:#78350f
+  style post fill:#fce7f3,stroke:#db2777,color:#831843
+  style memory fill:#f1f5f9,stroke:#64748b,color:#1e293b
 ```
 
-## Collapsible details
+Sequence:
 
-<details>
-<summary>How scoring works</summary>
+```mermaid
+sequenceDiagram
+  participant Dev as Developer
+  participant SP as SuperPlane
+  participant GH as GitHub
+  Dev->>SP: Open PR
+  SP->>GH: Analyze PR
+  GH-->>SP: Metrics
+  SP->>GH: Post assessment comment
+```
 
-The agent checks out the PR, runs metric tooling, and posts a single
-self-updating comment with a 0–100 Clean Code score.
+State diagram:
 
-You can nest markdown inside details:
-
-- Coverage
-- Complexity
-- Module size
-
-</details>
-
-<details open>
-<summary>Open by default</summary>
-
-This section uses `<details open>` so it starts expanded.
-
-</details>
-
-## Horizontal rule
-
-Above the rule.
-
----
-
-Below the rule.
-
-## Escaped / edge cases
-
-HTML that should be stripped for safety (script tags must not run):
-
-<script>window.__shouldNotRun = true</script>
-
-Anchors keep their `href` but lose event handlers:
-
-<a href="#safe" onclick="alert('nope')">Safe link text</a>
+```mermaid
+stateDiagram-v2
+  [*] --> Queued
+  Queued --> Running
+  Running --> Passed
+  Running --> Failed
+  Passed --> [*]
+  Failed --> Queued: Retry
+```

--- a/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
@@ -4,8 +4,8 @@ This README is a Storybook fixture for the **Files** tab. It exercises every
 feature currently supported by `MarkdownContent` (Console markdown panels and
 Files `.md` preview share the same renderer).
 
-> Agent-only widgets (`:::chart`, `:::buttons`, `run:` / `integration:` chips,
-> etc.) are **not** rendered here yet — those are the next feature.
+> Agent-only widgets (`:::chart`, `:::buttons`, `run:` chips, etc.) are **not**
+> rendered here yet — those are the next feature.
 
 ---
 
@@ -27,6 +27,7 @@ becomes a `<br>` in the rendered output.
 - External: [SuperPlane docs](https://docs.superplane.com)
 - Relative: [local docs](../docs "Local docs title")
 - Node chip (canvas context required): [Analyze PR](node:analyze-pr) · [On Pull Request](node:on-pull-request) · [Post Assessment](node:post-assessment)
+- Integration chip: [GitHub](integration:github) · [Cursor](integration:cursor)
 
 ## Lists
 
@@ -46,6 +47,7 @@ Ordered:
 Task list (GFM):
 
 - [x] Supported today
+- [x] Integration chips
 - [ ] Agent widgets (charts, run chips, …)
 - [ ] Interactive confirm / survey blocks
 
@@ -61,6 +63,7 @@ Task list (GFM):
 | GFM markdown   | yes     | yes   | yes        |
 | Mermaid        | yes     | yes   | yes        |
 | `node:` chips  | yes     | yes   | yes        |
+| `integration:` | yes     | yes   | yes        |
 | `:::chart`     | no      | no    | yes        |
 | `run:` chips   | no      | no    | yes        |
 

--- a/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
@@ -48,6 +48,7 @@ Task list (GFM):
 
 - [x] Supported today
 - [x] Integration chips
+- [x] GitHub alerts
 - [ ] Agent widgets (charts, run chips, …)
 - [ ] Interactive confirm / survey blocks
 
@@ -55,6 +56,23 @@ Task list (GFM):
 
 > Use markdown panels for runbooks, status notes, and lightweight docs.
 > Nested quotes and **formatting** work inside blockquotes.
+
+## GitHub alerts
+
+> [!NOTE]
+> Useful information when skimming a runbook.
+
+> [!TIP]
+> Prefer `node:` chips when linking to canvas steps.
+
+> [!IMPORTANT]
+> Console interpolates `{{ variables }}` before markdown renders.
+
+> [!WARNING]
+> Urgent info that needs attention before the next deploy.
+
+> [!CAUTION]
+> Destructive actions in table row triggers cannot be undone.
 
 ## Table
 
@@ -64,6 +82,7 @@ Task list (GFM):
 | Mermaid        | yes     | yes   | yes        |
 | `node:` chips  | yes     | yes   | yes        |
 | `integration:` | yes     | yes   | yes        |
+| GitHub alerts  | yes     | yes   | no         |
 | `:::chart`     | no      | no    | yes        |
 | `run:` chips   | no      | no    | yes        |
 

--- a/web_src/src/pages/app/console/MarkdownBody.tsx
+++ b/web_src/src/pages/app/console/MarkdownBody.tsx
@@ -1,12 +1,9 @@
 import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
 
-import { cn } from "@/lib/utils";
-
 import { MarkdownContent } from "../Markdown";
 
-import { CONSOLE_CODE_BADGE_ANCHOR_SELECTOR_CLASSES } from "./consoleCodeStyles";
-import { CONSOLE_LINK_ANCHOR_SELECTOR_CLASSES } from "./consoleLinkStyles";
+import { useConsoleContext } from "./ConsoleContext";
 import { interpolateMarkdownTemplate } from "./markdownInterpolation";
 
 /**
@@ -14,8 +11,26 @@ import { interpolateMarkdownTemplate } from "./markdownInterpolation";
  * `{{ name.field }}` variable interpolation applied first. Returns `null`
  * when the resulting markdown is empty so the caller can decide whether to
  * show its own empty state.
+ *
+ * Canvas ids come from `ConsoleContext` so `[label](node:…)` links render as
+ * node chips the same way they do in the Files markdown preview. Link and
+ * inline-code styling live on `MarkdownContent` so Files and Console match.
  */
-export function MarkdownBody({ body, vars }: { body: string; vars: Record<string, unknown> }) {
+export function MarkdownBody({
+  body,
+  vars,
+  canvasId,
+  organizationId,
+}: {
+  body: string;
+  vars: Record<string, unknown>;
+  canvasId?: string;
+  organizationId?: string;
+}) {
+  const ctx = useConsoleContext();
+  const resolvedCanvasId = canvasId ?? ctx?.canvasId;
+  const resolvedOrganizationId = organizationId ?? ctx?.organizationId;
+
   // Interpolate `{{ name.field }}` (and `$["Node"]` run-node references) before
   // delegating to the shared markdown renderer so live values flow through the
   // same sanitize + GFM pipeline as static markdown. Trim here (not in
@@ -26,7 +41,8 @@ export function MarkdownBody({ body, vars }: { body: string; vars: Record<string
   return (
     <MarkdownContent
       content={interpolated}
-      className={cn(CONSOLE_LINK_ANCHOR_SELECTOR_CLASSES, CONSOLE_CODE_BADGE_ANCHOR_SELECTOR_CLASSES)}
+      canvasId={resolvedCanvasId}
+      organizationId={resolvedOrganizationId}
       data-testid="console-markdown"
     />
   );

--- a/web_src/src/pages/app/console/MarkdownPanelCard.spec.tsx
+++ b/web_src/src/pages/app/console/MarkdownPanelCard.spec.tsx
@@ -1,12 +1,30 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { canvasKeys, type CanvasMemoryEntry, type ConsolePanel } from "@/hooks/useCanvasData";
 
 import { ConsoleContextProvider } from "./ConsoleContextProvider";
 import { MarkdownPanelCard } from "./MarkdownPanelCard";
+
+vi.mock("@/components/AgentSidebar/widgets/NodeChip", () => ({
+  NodeChipFromLink: ({
+    nodeId,
+    rawLabel,
+    canvasId,
+    organizationId,
+  }: {
+    nodeId: string;
+    rawLabel?: string;
+    canvasId: string;
+    organizationId: string;
+  }) => (
+    <button type="button" data-testid="node-chip">
+      {rawLabel}:{nodeId}:{canvasId}:{organizationId}
+    </button>
+  ),
+}));
 
 function renderMarkdown(body: string) {
   // The MarkdownPanelCard always issues queries through `useMarkdownVariables`,
@@ -57,6 +75,13 @@ describe("MarkdownPanelCard rendering", () => {
     expect(rows).toHaveLength(2);
     expect(rows[0].textContent).toMatch(/api/);
     expect(rows[1].textContent).toMatch(/failed/);
+  });
+
+  it("renders node links as chips using console canvas context", () => {
+    renderMarkdown("Open [Deploy](node:deploy-node) before continuing.");
+
+    expect(screen.getByTestId("node-chip")).toHaveTextContent("Deploy:deploy-node:canvas-1:org-1");
+    expect(screen.queryByRole("link", { name: "Deploy" })).not.toBeInTheDocument();
   });
 
   it("preserves <details>/<summary> accordions and the open attribute", () => {

--- a/web_src/src/pages/app/console/consoleCodeStyles.ts
+++ b/web_src/src/pages/app/console/consoleCodeStyles.ts
@@ -6,6 +6,6 @@
 export const CONSOLE_CODE_BADGE_CLASSES =
   "rounded bg-gray-950/5 px-1 py-0.5 font-mono text-xs text-slate-800 dark:text-gray-100";
 
-/** Selector utilities for `<code>` inside html/markdown panel roots. */
+/** Selector utilities for `<code>` inside html/markdown roots (`MarkdownContent`, HTML panels). */
 export const CONSOLE_CODE_BADGE_ANCHOR_SELECTOR_CLASSES =
   "[&_code]:rounded [&_code]:bg-gray-950/5 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs [&_code]:text-slate-800 dark:[&_code]:text-gray-100";

--- a/web_src/src/pages/app/console/consoleLinkStyles.ts
+++ b/web_src/src/pages/app/console/consoleLinkStyles.ts
@@ -8,8 +8,9 @@ export const CONSOLE_LINK_CLASSES =
 
 /**
  * Tailwind selector utilities applied to all `<a>` tags inside console panel
- * bodies. For HTML panels, mount on a wrapper outside `dark-mode-disabled` so
- * `dark:` link colors still apply when the app is in dark mode.
+ * bodies and shared markdown (`MarkdownContent`). For HTML panels, mount on a
+ * wrapper outside `dark-mode-disabled` so `dark:` link colors still apply when
+ * the app is in dark mode.
  */
 export const CONSOLE_LINK_ANCHOR_SELECTOR_CLASSES =
   "[&_a]:text-sky-600 [&_a]:no-underline [&_a]:underline-offset-2 [&_a]:hover:!underline [&_a]:hover:text-sky-700 dark:[&_a]:text-indigo-300 dark:[&_a]:hover:!underline dark:[&_a]:hover:text-indigo-200";

--- a/web_src/src/pages/app/markdownAlertStyles.ts
+++ b/web_src/src/pages/app/markdownAlertStyles.ts
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/utils";
+
+export const MARKDOWN_ALERT_TYPES = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"] as const;
+
+export type MarkdownAlertType = (typeof MARKDOWN_ALERT_TYPES)[number];
+
+export const MARKDOWN_ALERT_LABELS: Record<MarkdownAlertType, string> = {
+  NOTE: "Note",
+  TIP: "Tip",
+  IMPORTANT: "Important",
+  WARNING: "Warning",
+  CAUTION: "Caution",
+};
+
+/** Shared shell for SuperPlane-chrome GitHub alerts (white surface, thin accent). */
+export const MARKDOWN_ALERT_SHELL_CLASSES = "my-3 border-l-2 bg-white px-3 py-2 dark:bg-gray-900/40";
+
+export const MARKDOWN_ALERT_LABEL_CLASSES = "mb-1 text-[11px] font-semibold tracking-wide";
+
+export const MARKDOWN_ALERT_BODY_CLASSES = "[&_p]:mb-2 [&_p:last-child]:mb-0";
+
+const MARKDOWN_ALERT_ACCENT: Record<MarkdownAlertType, string> = {
+  NOTE: "border-sky-600 dark:border-sky-400",
+  TIP: "border-emerald-600 dark:border-emerald-400",
+  IMPORTANT: "border-violet-600 dark:border-violet-400",
+  WARNING: "border-amber-600 dark:border-amber-400",
+  CAUTION: "border-red-600 dark:border-red-400",
+};
+
+const MARKDOWN_ALERT_LABEL_COLOR: Record<MarkdownAlertType, string> = {
+  NOTE: "text-sky-700 dark:text-sky-300",
+  TIP: "text-emerald-700 dark:text-emerald-300",
+  IMPORTANT: "text-violet-700 dark:text-violet-300",
+  WARNING: "text-amber-700 dark:text-amber-300",
+  CAUTION: "text-red-700 dark:text-red-300",
+};
+
+export function markdownAlertShellClassName(type: MarkdownAlertType): string {
+  return cn(MARKDOWN_ALERT_SHELL_CLASSES, MARKDOWN_ALERT_ACCENT[type]);
+}
+
+export function markdownAlertLabelClassName(type: MarkdownAlertType): string {
+  return cn(MARKDOWN_ALERT_LABEL_CLASSES, MARKDOWN_ALERT_LABEL_COLOR[type]);
+}
+
+export function isMarkdownAlertType(value: string): value is MarkdownAlertType {
+  return (MARKDOWN_ALERT_TYPES as readonly string[]).includes(value);
+}

--- a/web_src/src/pages/app/markdownAlerts.tsx
+++ b/web_src/src/pages/app/markdownAlerts.tsx
@@ -1,5 +1,4 @@
-import { Children, cloneElement, isValidElement } from "react";
-import type { ReactElement, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import {
   isMarkdownAlertType,
@@ -9,6 +8,7 @@ import {
   markdownAlertShellClassName,
   MARKDOWN_ALERT_BODY_CLASSES,
 } from "./markdownAlertStyles";
+import { splitBlockquoteMarkerLine } from "./markdownBlockquoteMarker";
 
 const ALERT_MARKER_RE = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]$/i;
 
@@ -25,20 +25,12 @@ type ParsedAlert = {
  * whose children are `[!TYPE]`, `<br>`, then the body — not two paragraphs.
  */
 export function parseGithubAlertChildren(children: ReactNode): ParsedAlert | null {
-  const kids = skipLeadingWhitespaceNodes(Children.toArray(children));
-  const first = kids[0];
-  if (!isValidElement<{ children?: ReactNode }>(first)) {
+  const split = splitBlockquoteMarkerLine(children);
+  if (!split) {
     return null;
   }
 
-  const inner = Children.toArray(first.props.children);
-  const markerIndex = inner.findIndex((child) => typeof child === "string" && child.trim().length > 0);
-  if (markerIndex < 0) {
-    return null;
-  }
-
-  const markerText = String(inner[markerIndex]).trim();
-  const match = markerText.match(ALERT_MARKER_RE);
+  const match = split.markerText.match(ALERT_MARKER_RE);
   if (!match) {
     return null;
   }
@@ -48,20 +40,7 @@ export function parseGithubAlertChildren(children: ReactNode): ParsedAlert | nul
     return null;
   }
 
-  let restInner = inner.slice(markerIndex + 1);
-  restInner = skipLeadingWhitespaceNodes(restInner);
-  if (restInner.length > 0 && isBreakElement(restInner[0])) {
-    restInner = restInner.slice(1);
-    restInner = skipLeadingWhitespaceNodes(restInner);
-  }
-  if (restInner.length > 0 && typeof restInner[0] === "string") {
-    restInner = [restInner[0].replace(/^\n/, ""), ...restInner.slice(1)];
-  }
-
-  const restKids = kids.slice(1);
-  const body = buildAlertBody(first, restInner, restKids);
-
-  return { type: typeName, body };
+  return { type: typeName, body: split.body };
 }
 
 export function MarkdownAlert({ type, children }: { type: MarkdownAlertType; children: ReactNode }) {
@@ -75,33 +54,4 @@ export function MarkdownAlert({ type, children }: { type: MarkdownAlertType; chi
       <div className={MARKDOWN_ALERT_BODY_CLASSES}>{children}</div>
     </aside>
   );
-}
-
-function buildAlertBody(
-  firstParagraph: ReactElement<{ children?: ReactNode }>,
-  restInner: ReactNode[],
-  restKids: ReactNode[],
-): ReactNode {
-  if (restInner.length === 0) {
-    return restKids;
-  }
-
-  const rewrittenFirst = cloneElement(firstParagraph, undefined, restInner);
-  if (restKids.length === 0) {
-    return rewrittenFirst;
-  }
-
-  return [rewrittenFirst, ...restKids];
-}
-
-function skipLeadingWhitespaceNodes(nodes: ReactNode[]): ReactNode[] {
-  let index = 0;
-  while (index < nodes.length && typeof nodes[index] === "string" && !String(nodes[index]).trim()) {
-    index += 1;
-  }
-  return nodes.slice(index);
-}
-
-function isBreakElement(node: ReactNode): boolean {
-  return isValidElement(node) && node.type === "br";
 }

--- a/web_src/src/pages/app/markdownAlerts.tsx
+++ b/web_src/src/pages/app/markdownAlerts.tsx
@@ -1,0 +1,107 @@
+import { Children, cloneElement, isValidElement } from "react";
+import type { ReactElement, ReactNode } from "react";
+
+import {
+  isMarkdownAlertType,
+  MARKDOWN_ALERT_LABELS,
+  type MarkdownAlertType,
+  markdownAlertLabelClassName,
+  markdownAlertShellClassName,
+  MARKDOWN_ALERT_BODY_CLASSES,
+} from "./markdownAlertStyles";
+
+const ALERT_MARKER_RE = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]$/i;
+
+type ParsedAlert = {
+  type: MarkdownAlertType;
+  body: ReactNode;
+};
+
+/**
+ * If `children` are a GitHub alert blockquote (`[!NOTE]` …), return the type
+ * and body with the marker line removed. Otherwise return null.
+ *
+ * With `remark-breaks`, GitHub’s two-line alert often arrives as a single `<p>`
+ * whose children are `[!TYPE]`, `<br>`, then the body — not two paragraphs.
+ */
+export function parseGithubAlertChildren(children: ReactNode): ParsedAlert | null {
+  const kids = skipLeadingWhitespaceNodes(Children.toArray(children));
+  const first = kids[0];
+  if (!isValidElement<{ children?: ReactNode }>(first)) {
+    return null;
+  }
+
+  const inner = Children.toArray(first.props.children);
+  const markerIndex = inner.findIndex((child) => typeof child === "string" && child.trim().length > 0);
+  if (markerIndex < 0) {
+    return null;
+  }
+
+  const markerText = String(inner[markerIndex]).trim();
+  const match = markerText.match(ALERT_MARKER_RE);
+  if (!match) {
+    return null;
+  }
+
+  const typeName = match[1].toUpperCase();
+  if (!isMarkdownAlertType(typeName)) {
+    return null;
+  }
+
+  let restInner = inner.slice(markerIndex + 1);
+  restInner = skipLeadingWhitespaceNodes(restInner);
+  if (restInner.length > 0 && isBreakElement(restInner[0])) {
+    restInner = restInner.slice(1);
+    restInner = skipLeadingWhitespaceNodes(restInner);
+  }
+  if (restInner.length > 0 && typeof restInner[0] === "string") {
+    restInner = [restInner[0].replace(/^\n/, ""), ...restInner.slice(1)];
+  }
+
+  const restKids = kids.slice(1);
+  const body = buildAlertBody(first, restInner, restKids);
+
+  return { type: typeName, body };
+}
+
+export function MarkdownAlert({ type, children }: { type: MarkdownAlertType; children: ReactNode }) {
+  return (
+    <aside
+      className={markdownAlertShellClassName(type)}
+      data-testid={`markdown-alert-${type.toLowerCase()}`}
+      data-alert={type.toLowerCase()}
+    >
+      <div className={markdownAlertLabelClassName(type)}>{MARKDOWN_ALERT_LABELS[type]}</div>
+      <div className={MARKDOWN_ALERT_BODY_CLASSES}>{children}</div>
+    </aside>
+  );
+}
+
+function buildAlertBody(
+  firstParagraph: ReactElement<{ children?: ReactNode }>,
+  restInner: ReactNode[],
+  restKids: ReactNode[],
+): ReactNode {
+  if (restInner.length === 0) {
+    return restKids;
+  }
+
+  const rewrittenFirst = cloneElement(firstParagraph, undefined, restInner);
+  if (restKids.length === 0) {
+    return rewrittenFirst;
+  }
+
+  return [rewrittenFirst, ...restKids];
+}
+
+function skipLeadingWhitespaceNodes(nodes: ReactNode[]): ReactNode[] {
+  let index = 0;
+  while (index < nodes.length && typeof nodes[index] === "string" && !String(nodes[index]).trim()) {
+    index += 1;
+  }
+  return nodes.slice(index);
+}
+
+function isBreakElement(node: ReactNode): boolean {
+  return isValidElement(node) && node.type === "br";
+}

--- a/web_src/src/pages/app/markdownBlockquoteMarker.ts
+++ b/web_src/src/pages/app/markdownBlockquoteMarker.ts
@@ -1,0 +1,73 @@
+import { Children, cloneElement, isValidElement } from "react";
+import type { ReactElement, ReactNode } from "react";
+
+/**
+ * Shared split of a markdown blockquote’s first text line from the rest of the
+ * body. With `remark-breaks`, GitHub-style two-line quotes often arrive as a
+ * single `<p>` whose children are `marker`, `<br>`, then body — not two paragraphs.
+ */
+export type BlockquoteMarkerSplit = {
+  firstParagraph: ReactElement<{ children?: ReactNode }>;
+  markerText: string;
+  body: ReactNode;
+};
+
+export function splitBlockquoteMarkerLine(children: ReactNode): BlockquoteMarkerSplit | null {
+  const kids = skipLeadingWhitespaceNodes(Children.toArray(children));
+  const first = kids[0];
+  if (!isValidElement<{ children?: ReactNode }>(first)) {
+    return null;
+  }
+
+  const inner = Children.toArray(first.props.children);
+  const markerIndex = inner.findIndex((child) => typeof child === "string" && child.trim().length > 0);
+  if (markerIndex < 0) {
+    return null;
+  }
+
+  const markerText = String(inner[markerIndex]).trim();
+  let restInner = inner.slice(markerIndex + 1);
+  restInner = skipLeadingWhitespaceNodes(restInner);
+  if (restInner.length > 0 && isBreakElement(restInner[0])) {
+    restInner = restInner.slice(1);
+    restInner = skipLeadingWhitespaceNodes(restInner);
+  }
+  if (restInner.length > 0 && typeof restInner[0] === "string") {
+    restInner = [restInner[0].replace(/^\n/, ""), ...restInner.slice(1)];
+  }
+
+  return {
+    firstParagraph: first,
+    markerText,
+    body: buildBlockquoteBody(first, restInner, kids.slice(1)),
+  };
+}
+
+function buildBlockquoteBody(
+  firstParagraph: ReactElement<{ children?: ReactNode }>,
+  restInner: ReactNode[],
+  restKids: ReactNode[],
+): ReactNode {
+  if (restInner.length === 0) {
+    return restKids;
+  }
+
+  const rewrittenFirst = cloneElement(firstParagraph, undefined, restInner);
+  if (restKids.length === 0) {
+    return rewrittenFirst;
+  }
+
+  return [rewrittenFirst, ...restKids];
+}
+
+function skipLeadingWhitespaceNodes(nodes: ReactNode[]): ReactNode[] {
+  let index = 0;
+  while (index < nodes.length && typeof nodes[index] === "string" && !String(nodes[index]).trim()) {
+    index += 1;
+  }
+  return nodes.slice(index);
+}
+
+function isBreakElement(node: ReactNode): boolean {
+  return isValidElement(node) && node.type === "br";
+}

--- a/web_src/src/pages/app/markdownSection.tsx
+++ b/web_src/src/pages/app/markdownSection.tsx
@@ -1,0 +1,184 @@
+import { Children, createContext, isValidElement, useContext, useId, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { splitBlockquoteMarkerLine } from "./markdownBlockquoteMarker";
+import { resolveMarkdownSectionPreset } from "./markdownSectionPresets";
+
+const SECTION_MARKER_RE = /^\[!SECTION(?::([a-z0-9_-]+))?\]\s+(.+)$/i;
+
+type ParsedSection = {
+  title: string;
+  trailing?: string;
+  presetId?: string;
+  body: ReactNode;
+};
+
+const SectionDepthContext = createContext(0);
+
+/**
+ * If `children` are a `[!SECTION] Title` or `[!SECTION:preset] Title` blockquote,
+ * return the title/preset/body with the marker line removed.
+ *
+ * Optional trailing meta after a middle-dot separator:
+ * `> [!SECTION:rules] Rules · ~5,366`
+ */
+export function parseGithubSectionChildren(children: ReactNode): ParsedSection | null {
+  const split = splitBlockquoteMarkerLine(children);
+  if (!split) {
+    return null;
+  }
+
+  const match = split.markerText.match(SECTION_MARKER_RE);
+  if (!match) {
+    return null;
+  }
+
+  const presetId = match[1]?.toLowerCase();
+  const rawTitle = match[2].trim();
+  if (!rawTitle) {
+    return null;
+  }
+
+  const { title, trailing } = splitSectionTitle(rawTitle);
+  return { title, trailing, presetId, body: split.body };
+}
+
+export function MarkdownSection({
+  title,
+  trailing,
+  presetId,
+  children,
+}: {
+  title: string;
+  trailing?: string;
+  presetId?: string;
+  children: ReactNode;
+}) {
+  const depth = useContext(SectionDepthContext);
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+  const isRoot = depth === 0;
+  const preset = resolveMarkdownSectionPreset(presetId, depth);
+  const Icon = preset.Icon;
+  const childSectionCount = useMemo(() => countDirectChildSections(children), [children]);
+
+  return (
+    <div
+      className={cn("min-w-0", isRoot ? "my-2" : "my-0.5")}
+      data-testid="markdown-section"
+      data-section-preset={preset.id}
+      data-section-count={childSectionCount > 0 ? String(childSectionCount) : undefined}
+    >
+      <div className={cn("min-w-0 rounded-lg", isRoot && preset.barClassName)}>
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={panelId}
+          className={cn(
+            "flex w-full min-w-0 items-center gap-2 px-2.5 text-left",
+            isRoot ? "min-h-9" : "min-h-8 rounded-md hover:bg-slate-100/70 dark:hover:bg-gray-800/60",
+          )}
+          onClick={() => setOpen((current) => !current)}
+        >
+          <span className="flex size-5 shrink-0 items-center justify-center">
+            <ChevronRight
+              className={cn(
+                "size-3.5 text-slate-500 transition-transform duration-200 dark:text-gray-400",
+                open && "rotate-90",
+              )}
+              aria-hidden
+            />
+          </span>
+          <span className="flex size-5 shrink-0 items-center justify-center">
+            <Icon className={cn("size-3.5", preset.iconClassName)} aria-hidden />
+          </span>
+          <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+            <span className="truncate text-[13px] font-semibold text-slate-900 dark:text-gray-100">{title}</span>
+            {childSectionCount > 0 ? (
+              <span
+                className="shrink-0 text-[12px] font-normal tabular-nums text-slate-500 dark:text-gray-400"
+                data-testid="markdown-section-count"
+              >
+                {childSectionCount}
+              </span>
+            ) : null}
+          </span>
+          {trailing ? (
+            <span className="shrink-0 text-[12px] tabular-nums text-slate-500 dark:text-gray-400">{trailing}</span>
+          ) : null}
+        </button>
+      </div>
+
+      {open ? (
+        <div id={panelId} role="region" className={cn("min-w-0 pt-1", isRoot ? "pl-2" : "pl-0")}>
+          <SectionDepthContext.Provider value={depth + 1}>
+            <div
+              className={cn(
+                "min-w-0 border-l border-slate-200/90 pl-3 dark:border-gray-700/80",
+                "text-[13px] leading-relaxed text-slate-600 dark:text-gray-300",
+                "[&_p]:mb-2 [&_p:last-child]:mb-0",
+                "[&_[data-testid=markdown-section]]:ml-1",
+              )}
+            >
+              {children}
+            </div>
+          </SectionDepthContext.Provider>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Count nested `[!SECTION]` blocks that are direct children of this section’s
+ * body (walking through wrapper elements, but not into other sections).
+ *
+ * Nested quotes arrive from react-markdown as unevaluated `blockquote`
+ * components (not yet `MarkdownSection`), so we detect them by parsing their
+ * children for a `[!SECTION]` marker.
+ */
+export function countDirectChildSections(children: ReactNode): number {
+  let count = 0;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement<{ children?: ReactNode }>(child)) {
+      return;
+    }
+
+    if (child.type === MarkdownSection) {
+      count += 1;
+      return;
+    }
+
+    // Unevaluated nested blockquote that will render as a section.
+    if (child.props.children != null && parseGithubSectionChildren(child.props.children)) {
+      count += 1;
+      return;
+    }
+
+    if (child.props.children != null) {
+      count += countDirectChildSections(child.props.children);
+    }
+  });
+
+  return count;
+}
+
+function splitSectionTitle(rawTitle: string): { title: string; trailing?: string } {
+  const separator = " · ";
+  const separatorIndex = rawTitle.indexOf(separator);
+  if (separatorIndex < 0) {
+    return { title: rawTitle };
+  }
+
+  const title = rawTitle.slice(0, separatorIndex).trim();
+  const trailing = rawTitle.slice(separatorIndex + separator.length).trim();
+  if (!title) {
+    return { title: rawTitle };
+  }
+
+  return trailing ? { title, trailing } : { title };
+}

--- a/web_src/src/pages/app/markdownSectionPresets.ts
+++ b/web_src/src/pages/app/markdownSectionPresets.ts
@@ -1,0 +1,67 @@
+import type { LucideIcon } from "lucide-react";
+import { Folder, List, Plug, Sparkles, Wrench } from "lucide-react";
+
+export const MARKDOWN_SECTION_PRESET_IDS = ["tools", "rules", "skills", "mcp", "folder"] as const;
+
+export type MarkdownSectionPresetId = (typeof MARKDOWN_SECTION_PRESET_IDS)[number];
+
+export type MarkdownSectionPreset = {
+  id: MarkdownSectionPresetId;
+  Icon: LucideIcon;
+  /** Icon accent */
+  iconClassName: string;
+  /** Tinted header bar for root-level sections */
+  barClassName: string;
+};
+
+/**
+ * Named presets authors can pick with `> [!SECTION:tools] Title`.
+ * Colors follow the Context Usage category accents (purple tools, green rules, …).
+ */
+export const MARKDOWN_SECTION_PRESETS: Record<MarkdownSectionPresetId, MarkdownSectionPreset> = {
+  tools: {
+    id: "tools",
+    Icon: Wrench,
+    iconClassName: "text-violet-600 dark:text-violet-400",
+    barClassName: "bg-violet-100/80 dark:bg-violet-950/50",
+  },
+  rules: {
+    id: "rules",
+    Icon: List,
+    iconClassName: "text-emerald-600 dark:text-emerald-400",
+    barClassName: "bg-emerald-100/70 dark:bg-emerald-950/40",
+  },
+  skills: {
+    id: "skills",
+    Icon: Sparkles,
+    iconClassName: "text-cyan-600 dark:text-cyan-400",
+    barClassName: "bg-cyan-100/70 dark:bg-cyan-950/40",
+  },
+  mcp: {
+    id: "mcp",
+    Icon: Plug,
+    iconClassName: "text-sky-600 dark:text-sky-400",
+    barClassName: "bg-sky-100/70 dark:bg-sky-950/40",
+  },
+  folder: {
+    id: "folder",
+    Icon: Folder,
+    iconClassName: "text-slate-500 dark:text-gray-400",
+    barClassName: "bg-slate-100/90 dark:bg-gray-800/80",
+  },
+};
+
+const DEFAULT_ROOT_PRESET = MARKDOWN_SECTION_PRESETS.rules;
+const DEFAULT_NESTED_PRESET = MARKDOWN_SECTION_PRESETS.folder;
+
+export function isMarkdownSectionPresetId(value: string): value is MarkdownSectionPresetId {
+  return (MARKDOWN_SECTION_PRESET_IDS as readonly string[]).includes(value);
+}
+
+export function resolveMarkdownSectionPreset(presetId: string | undefined, depth: number): MarkdownSectionPreset {
+  if (presetId && isMarkdownSectionPresetId(presetId)) {
+    return MARKDOWN_SECTION_PRESETS[presetId];
+  }
+
+  return depth === 0 ? DEFAULT_ROOT_PRESET : DEFAULT_NESTED_PRESET;
+}


### PR DESCRIPTION
## Summary
- Render `integration:` links as chips in shared `MarkdownContent` (Console + Files)
- Pass canvas/org context from Console so `node:` links become chips (matching Files)
- Move Console link and inline-code styles onto `MarkdownContent` so Files and Console markdown look the same

Depends on #6030 (Storybook repository fixtures / markdown showcase).

## Test plan
- [ ] Live Canvas → Console: showcase panel shows GitHub/Cursor integration chips and node chips; links are sky/indigo with hover underline
- [ ] Live Canvas → Files → `README.md`: same chip and link/code styling as Console
- [ ] `npx vitest run src/pages/app/Markdown.spec.tsx src/pages/app/console/MarkdownPanelCard.spec.tsx` passes