### PR TITLE
fix: mock canvas repository files in AppPage Storybook fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ CLAUDE.local.md
 !.agents/skills/
 !.agents/skills/**
 .worktrees/
+.superpowers/
+docs/superpowers/
 coverage-go.out
 
 # Generated protobuf and OpenAPI artifacts

--- a/web_src/.storybook/preview.tsx
+++ b/web_src/.storybook/preview.tsx
@@ -5,6 +5,10 @@ import React from "react";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 import "../src/App.css";
 import "../src/index.css";
+// Same global React Flow stylesheet the app loads in `main.tsx`. Without it,
+// Live Canvas stories mount an unstyled graph (nodes have no absolute
+// positioning) until some other story happens to import the CSS.
+import "@xyflow/react/dist/style.css";
 
 // Load Material Symbols font for icons
 const link = document.createElement("link");

--- a/web_src/src/pages/app/__fixtures__/consoleFixtures.ts
+++ b/web_src/src/pages/app/__fixtures__/consoleFixtures.ts
@@ -2,13 +2,19 @@ import docsReviewerFixture from "./console/docsReviewer.json";
 import prRiskReviewFixture from "./console/prRiskReview.json";
 import superplaneReleaseFixture from "./console/superplaneRelease.json";
 import superplaneSaasFixture from "./console/superplaneSaas.json";
+import superplaneSaasReadme from "./repository/superplaneSaas.README.md?raw";
 import type { CanvasAppFixture } from "./handlers";
 
 // Storybook's static indexer cannot parse `.json` imports from `.stories.tsx`
 // files (it runs acorn over direct story imports). Keep JSON imports here so
 // the console page stories only reference this module.
 export const consoleFixtures = {
-  superplaneSaas: superplaneSaasFixture as CanvasAppFixture,
+  superplaneSaas: {
+    ...(superplaneSaasFixture as CanvasAppFixture),
+    repositoryFileContents: {
+      "README.md": superplaneSaasReadme,
+    },
+  } satisfies CanvasAppFixture,
   prRiskReview: prRiskReviewFixture as CanvasAppFixture,
   docsReviewer: docsReviewerFixture as CanvasAppFixture,
   superplaneRelease: superplaneReleaseFixture as CanvasAppFixture,

--- a/web_src/src/pages/app/__fixtures__/handlers.spec.ts
+++ b/web_src/src/pages/app/__fixtures__/handlers.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFixtureFetch, type CanvasAppFixture } from "./handlers";
+
+const baseFixture: CanvasAppFixture = {
+  canvasId: "canvas-1",
+  organizationId: "org-1",
+  consoleYaml: "kind: Console\n",
+  repositoryFileContents: {
+    "README.md": "# Hello from fixture\n",
+  },
+};
+
+async function fetchFixture(path: string, fixture: CanvasAppFixture = baseFixture): Promise<Response> {
+  const fallback = vi.fn() as unknown as typeof fetch;
+  const fixtureFetch = createFixtureFetch(fallback, fixture);
+  return fixtureFetch(`http://localhost${path}`);
+}
+
+describe("createFixtureFetch repository routes", () => {
+  it("returns a ready repository so the Files tab query has defined data", async () => {
+    const response = await fetchFixture("/api/v1/canvases/canvas-1/repository");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      repository: {
+        metadata: { canvasId: "canvas-1" },
+        status: { state: "STATE_READY", headSha: "storybook-fixture-head" },
+      },
+    });
+  });
+
+  it("lists the default repository file paths plus fixture contents", async () => {
+    const response = await fetchFixture("/api/v1/canvases/canvas-1/repository/files");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      files: [{ path: "README.md" }, { path: "canvas.yaml" }, { path: "console.yaml" }],
+    });
+  });
+
+  it("serves README and console.yaml bodies from the fixture", async () => {
+    const readme = await fetchFixture("/api/v1/canvases/canvas-1/repository/file?path=README.md");
+    expect(await readme.text()).toBe("# Hello from fixture\n");
+
+    const consoleYaml = await fetchFixture("/api/v1/canvases/canvas-1/repository/file?path=console.yaml");
+    expect(await consoleYaml.text()).toBe("kind: Console\n");
+  });
+
+  it("seeds a non-empty default console.yaml for Live Canvas stories", async () => {
+    const { createFixtureFetch: createDefaultFixtureFetch } = await import("./handlers");
+    const fallback = vi.fn() as unknown as typeof fetch;
+    const fixtureFetch = createDefaultFixtureFetch(fallback);
+    const response = await fixtureFetch("http://localhost/api/v1/canvases/any/repository/file?path=console.yaml");
+    const text = await response.text();
+    expect(text).toContain("kind: Console");
+    expect(text).toContain("markdown-showcase");
+    expect(text).toContain("Markdown renderer showcase");
+  });
+
+  it("honors an explicit repositoryFilePaths override", async () => {
+    const response = await fetchFixture("/api/v1/canvases/canvas-1/repository/files", {
+      ...baseFixture,
+      repositoryFilePaths: ["docs/guide.md", "canvas.yaml"],
+    });
+    await expect(response.json()).resolves.toEqual({
+      files: [{ path: "docs/guide.md" }, { path: "canvas.yaml" }],
+    });
+  });
+});

--- a/web_src/src/pages/app/__fixtures__/handlers.ts
+++ b/web_src/src/pages/app/__fixtures__/handlers.ts
@@ -1,4 +1,7 @@
+import { materializeConsoleSpec } from "../lib/workflow-spec-files";
+
 import defaultRaw from "./canvasAppResponses.json";
+import cleanCodeAssessmentReadme from "./repository/cleanCodeAssessment.README.md?raw";
 
 // Shape of a captured fixture. Endpoint bodies are stored verbatim as the
 // live API returned them (after trimming GitHub webhook payloads and
@@ -34,9 +37,54 @@ export interface CanvasAppFixture {
   memory?: { items?: unknown[] };
   /** GET /api/v1/canvases/{canvasId}/repository/file?path=console.yaml */
   consoleYaml?: string;
+  /**
+   * Extra repository file bodies keyed by path (e.g. `README.md`).
+   * `console.yaml` still prefers `consoleYaml` when both are set.
+   */
+  repositoryFileContents?: Record<string, string>;
+  /**
+   * Paths returned by GET .../repository/files. Defaults to the standard
+   * app-repo trio (`README.md`, `canvas.yaml`, `console.yaml`) plus any
+   * keys from `repositoryFileContents`.
+   */
+  repositoryFilePaths?: string[];
 }
 
-const defaultFixture = defaultRaw as CanvasAppFixture;
+const DEFAULT_REPOSITORY_FILE_PATHS = ["README.md", "canvas.yaml", "console.yaml"] as const;
+
+const capturedFixture = defaultRaw as CanvasAppFixture;
+
+// Live Canvas stories need a real console.yaml: `useCanvasConsole` treats an
+// empty/missing file as `undefined`, which TanStack Query rejects. Seed one
+// markdown panel that reuses the README showcase so Console and Files stay in
+// sync while we prototype markdown rendering.
+const defaultConsoleYaml =
+  capturedFixture.consoleYaml ??
+  materializeConsoleSpec({
+    canvasId: capturedFixture.canvasId,
+    canvasName: capturedFixture.canvas?.canvas?.metadata?.name ?? "Clean Code Assessment",
+    panels: [
+      {
+        id: "markdown-showcase",
+        type: "markdown",
+        content: {
+          title: "Markdown showcase",
+          body: cleanCodeAssessmentReadme,
+          variables: [],
+        },
+      },
+    ],
+    layout: [{ i: "markdown-showcase", x: 0, y: 0, w: 12, h: 20, minW: 4, minH: 4 }],
+  });
+
+const defaultFixture = {
+  ...capturedFixture,
+  consoleYaml: defaultConsoleYaml,
+  repositoryFileContents: {
+    "README.md": cleanCodeAssessmentReadme,
+    ...capturedFixture.repositoryFileContents,
+  },
+} satisfies CanvasAppFixture;
 
 export const canvasAppIds = {
   organizationId: defaultFixture.organizationId,
@@ -143,19 +191,31 @@ function buildRoutes(fixture: CanvasAppFixture): Route[] {
     // Real API shape is `{items: []}`; some legacy fixtures used `{memory: []}`
     // which no widget ever read successfully — normalize on `items` here.
     { pattern: re(`${CANVAS}/memory`), resolve: () => ({ json: fixture.memory ?? { items: [] } }) },
-    // Repository files are text payloads. Only `console.yaml` gets special
-    // treatment because that's what feeds the console tab; everything else
-    // (e.g. canvas.yaml, config manifests) returns an empty body so the UI
-    // renders its default empty state.
+    // Files tab needs a ready repository before it will render the tree.
+    // Without this, `useCanvasRepository` returns `undefined` and TanStack
+    // Query surfaces `["canvases","repository",…] data is undefined`.
+    {
+      pattern: re(`${CANVAS}/repository/files`),
+      resolve: () => ({
+        json: {
+          files: resolveRepositoryFilePaths(fixture).map((path) => ({ path })),
+        },
+      }),
+    },
     {
       pattern: re(`${CANVAS}/repository/file`),
-      resolve: (_m, url) => {
-        const path = url.searchParams.get("path");
-        if (path === "console.yaml" && typeof fixture.consoleYaml === "string") {
-          return { text: fixture.consoleYaml };
-        }
-        return { text: "" };
-      },
+      resolve: (_m, url) => ({ text: resolveRepositoryFileContent(fixture, url.searchParams.get("path")) }),
+    },
+    {
+      pattern: re(`${CANVAS}/repository`),
+      resolve: () => ({
+        json: {
+          repository: {
+            metadata: { canvasId: fixture.canvasId },
+            status: { state: "STATE_READY", headSha: "storybook-fixture-head" },
+          },
+        },
+      }),
     },
     { pattern: re(CANVAS), resolve: () => ({ json: fixture.canvas ?? { canvas: {} } }) },
     { pattern: re("/api/v1/canvases"), resolve: () => ({ json: { canvases: [], totalCount: 0, hasNextPage: false } }) },
@@ -231,4 +291,28 @@ function requestUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") return input;
   if (input instanceof URL) return input.href;
   return input.url;
+}
+
+function resolveRepositoryFilePaths(fixture: CanvasAppFixture): string[] {
+  if (fixture.repositoryFilePaths?.length) {
+    return [...fixture.repositoryFilePaths];
+  }
+
+  const paths = new Set<string>(DEFAULT_REPOSITORY_FILE_PATHS);
+  for (const path of Object.keys(fixture.repositoryFileContents ?? {})) {
+    paths.add(path);
+  }
+  return Array.from(paths).sort();
+}
+
+function resolveRepositoryFileContent(fixture: CanvasAppFixture, path: string | null): string {
+  if (!path) {
+    return "";
+  }
+
+  if (path === "console.yaml" && typeof fixture.consoleYaml === "string") {
+    return fixture.consoleYaml;
+  }
+
+  return fixture.repositoryFileContents?.[path] ?? "";
 }

--- a/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
@@ -1,0 +1,117 @@
+# Markdown renderer showcase
+
+Storybook fixture for the **Files** tab and Console markdown panel.
+
+## Chips
+
+- Node: [Analyze PR](node:analyze-pr) · [On Pull Request](node:on-pull-request) · [Post Assessment](node:post-assessment)
+- Integration: [GitHub](integration:github) · [Cursor](integration:cursor) · [Slack](integration:slack)
+
+## GitHub alerts
+
+> [!NOTE]
+> Useful information when skimming a runbook.
+
+> [!TIP]
+> Prefer `node:` chips when linking to canvas steps: [Analyze PR](node:analyze-pr).
+
+> [!IMPORTANT]
+> Console interpolates `{{ variables }}` before markdown renders.
+
+> [!WARNING]
+> Urgent info that needs attention before the next deploy.
+
+> [!CAUTION]
+> Destructive actions in table row triggers cannot be undone.
+
+## Sections
+
+Presets pick icon + accent: `tools`, `rules`, `skills`, `mcp`, `folder`.
+Trailing meta after ` · ` is optional. Nested sections show a count on the parent.
+
+> [!SECTION:tools] Tool definitions · ~9,202
+> Descriptions of tools the agent can call.
+
+> [!SECTION:rules] Rules · ~5,366
+> Standing instructions the agent follows each turn. Keep them focused and lightweight.
+>
+> Nested markdown still works: [docs](https://docs.superplane.com) and `inline code`.
+>
+> > [!SECTION:folder] Project Rules · ~2,752
+> > Project-local guidance from `AGENTS.md` and related files.
+>
+> > [!SECTION:rules] Cursor & User Rules · ~2,522
+> > Personal and Cursor-level standing instructions.
+
+> [!SECTION:skills] Scoring
+> The agent checks out the PR, runs metric tooling, and posts a self-updating comment.
+
+> [!SECTION:mcp] MCP servers · 3
+> Connected tools the agent can call through Model Context Protocol.
+
+## Code
+
+```yaml
+apiVersion: v1
+kind: Canvas
+metadata:
+  name: Clean Code Assessment
+spec:
+  nodes:
+    - id: analyze-pr
+      type: cursor.analyze_pr
+```
+
+## Mermaid
+
+Flowchart (custom node colors):
+
+```mermaid
+flowchart LR
+  trigger[On Pull Request] --> analyze[Analyze PR]
+  analyze --> report[Get Report]
+  report --> post[Post Assessment]
+  post --> memory[Update Saved Assessment]
+
+  style trigger fill:#e0f2fe,stroke:#0284c7,color:#0c4a6e
+  style analyze fill:#ecfdf5,stroke:#059669,color:#064e3b
+  style report fill:#fef3c7,stroke:#d97706,color:#78350f
+  style post fill:#fce7f3,stroke:#db2777,color:#831843
+  style memory fill:#f1f5f9,stroke:#64748b,color:#1e293b
+```
+
+Sequence:
+
+```mermaid
+sequenceDiagram
+  participant Dev as Developer
+  participant SP as SuperPlane
+  participant GH as GitHub
+  Dev->>SP: Open PR
+  SP->>GH: Analyze PR
+  GH-->>SP: Metrics
+  SP->>GH: Post assessment comment
+```
+
+State diagram:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued
+  Queued --> Running
+  Running --> Passed
+  Running --> Failed
+  Passed --> [*]
+  Failed --> Queued: Retry
+```
+
+Pie chart:
+
+```mermaid
+pie showData
+  title Assessment outcomes (last 30 days)
+  "Passed" : 48
+  "Failed" : 12
+  "Skipped" : 7
+  "Retried" : 5
+```

--- a/web_src/src/pages/app/__fixtures__/repository/superplaneSaas.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/superplaneSaas.README.md
@@ -1,0 +1,112 @@
+# SuperPlane Deployment
+
+This canvas orchestrates the SuperPlane delivery pipelines: CI for the OSS
+and SaaS code bases, image promotion, Helm-based staging/production
+rollouts, tagged releases of the OSS product, and post-deploy
+documentation updates. Discord notifications are wired into every
+failure path so the team finds out fast.
+
+## At a glance
+
+- **36 nodes / 30 edges** across five independent workflows
+- **5 triggers**: 3 GitHub repositories (`launchpad`, `superplane`, `saas`),
+  1 GitHub tag trigger, 1 inbound webhook from the docs deployment
+- **Integrations**: GitHub, Semaphore, Discord, Cloudflare
+
+## Workflows
+
+### 1. Launchpad — Helm staging & production rollouts
+
+Triggered by pushes to `superplanehq/launchpad@main`. The push payload is
+filtered by changed paths so the canvas only rolls out the relevant
+environment.
+
+- `Filter: Helm - Staging` matches paths under `helm/staging/*`, then runs
+  `Deploy: Helm - Staging` (`.semaphore/update-installation__staging.yml`).
+- `Filter: Helm - Production` matches paths under `helm/production/*`, then
+  runs `Deploy: Helm - Production`
+  (`.semaphore/update-installation__production.yml`).
+- Failures from either deploy fan into the `Discord: Helm update failed`
+  message in the `deployments` channel.
+
+### 2. SuperPlane OSS — CI, docs, dev image, prod promotion
+
+Triggered by pushes to `superplanehq/superplane@main`. The `CI` node runs
+`.semaphore/semaphore.yml` against the pushed SHA. On success it fans out
+in parallel to:
+
+- `Update Component Docs` — runs `.semaphore/update-components-docs.yml`
+  on `launchpad`, passing `SUPERPLANE_SHA`. Failure pings
+  `Discord: Documentation Deployment Failed`.
+- `Build Dev Image Cache` — pre-warms the dev base image via
+  `.semaphore/release-dev-base-image.yml` on `superplane-private`.
+- `Promote - Production` — runs `.semaphore/deploy-image.yml` with
+  `ENVIRONMENT=production`. On pass it posts `Discord: Deployed to Prod`,
+  on fail it posts `Discord: Prod Deployment Failed`.
+
+A CI failure on `main` directly notifies `Discord: CI on Main Failed`.
+
+### 3. SuperPlane OSS — Tagged release
+
+Triggered by `v.*` tags created on `superplanehq/superplane`. The release
+fan-out is:
+
+1. `Create Release` runs `.semaphore/github-release.yml` with the version
+   parsed from the tag ref.
+2. On pass, two release tracks run in parallel:
+   - **Stable track** (`Mark Release as STABLE` →
+     `.semaphore/github-release-promote.yml` with `REL_CHANNEL=stable`),
+     which then fans into:
+     - `Update install.superplane.com` — rewrites the Cloudflare redirect
+       rule for `install.superplane.com/*` to point at the new tag.
+     - `Publish to APT (S3)` —
+       `.semaphore/publish-apt.yml`. Failure → `Discord: APT Publish Failed`.
+     - `Publish to NPM` —
+       `.semaphore/publish-npm.yml`. Failure → `Discord: NPM Publish Failed`.
+   - **Beta track** (`Mark Release as BETA` with `REL_CHANNEL=beta`) →
+     `Update install.superplane.com/beta` Cloudflare redirect rule.
+
+> See the in-canvas annotation `How to create a new tag?` for the
+> `make tag.create.{patch,minor,major}` shortcuts.
+
+### 4. SaaS — CI and image promotion
+
+Triggered by pushes to `superplanehq/saas@main`. The chain is sequential:
+
+`SaaS CI` → `SaaS Build Image - Staging` → `SaaS Build Image - Production`,
+all running on Semaphore against the pushed commit SHA.
+
+Notifications:
+
+- CI failure → `Discord: SaaS CI on Main Failed`.
+- Production build pass → `Discord: SaaS Deployed to Prod`.
+- Production build fail → `Discord: SaaS Prod Deployment Failed`.
+
+### 5. Documentation deployment webhook
+
+Inbound webhook `On Docs Repo Deployment Finished` (no auth) routes
+straight to `Discord: Documentation Update Failed 2` to alert the team
+when the docs site finishes a deployment in a failure state.
+
+## Integrations
+
+| Vendor | Used by |
+| --- | --- |
+| GitHub | `launchpad`, `superplane`, `saas` push triggers and the `superplane` tag trigger |
+| Semaphore | All build, deploy, release, publish, and docs-update workflows |
+| Discord | All failure and success notifications (channel `deployments`) |
+| Cloudflare | `install.superplane.com` and `install.superplane.com/beta` redirect rules |
+
+## Files
+
+- `canvas.yaml` — the canvas definition (nodes, edges, triggers)
+- `console.yaml` — the Console layout for this app
+- `README.md` — this file
+
+## Open TODOs
+
+- The `TODO` annotation flags that marking every new tag both `:stable`
+  and `:beta` is not the desired long-term behaviour; the team wants a
+  promotion process instead.
+- The `How to create a new tag?` annotation suggests adding manual-run
+  buttons inside the canvas to kick off tag creation directly.

--- a/web_src/src/vite-env.d.ts
+++ b/web_src/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module "*.md?raw" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- Mock canvas repository/file routes in AppPage Storybook handlers so Live Canvas → Files works
- Seed `README.md`, `canvas.yaml`, and `console.yaml` fixtures (including a markdown showcase README)
- Load React Flow CSS in Storybook preview for cold Live Canvas opens
- Ignore `.superpowers/` local brainstorm artifacts

Split from #6030 for a focused review.

## Test plan
- [ ] Storybook `Pages/AppPage` → Live Canvas → Files: tree shows README/canvas/console without TanStack Query errors
- [ ] Live Canvas story opens without missing React Flow styles
- [ ] `npx vitest run src/pages/app/__fixtures__/handlers.spec.ts` passes