### PR TITLE
fix: share fullscreen expand dialog and improve Mermaid diagrams

### DIFF
--- a/web_src/src/components/AgentSidebar/widgets/CodeBlockWidget.spec.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/CodeBlockWidget.spec.tsx
@@ -51,4 +51,13 @@ describe("CodeBlockWidget", () => {
 
     expect(editorMountSpy.mock.calls.length).toBe(initialMounts);
   });
+
+  it("opens the shared fullscreen dialog when expand is clicked", () => {
+    const { getByRole, getByText } = render(<CodeBlockWidget code="echo hello" language="bash" />);
+
+    fireEvent.click(getByRole("button", { name: "Expand code" }));
+
+    expect(getByText("BASH")).toBeInTheDocument();
+    expect(getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
 });

--- a/web_src/src/components/AgentSidebar/widgets/CodeBlockWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/CodeBlockWidget.tsx
@@ -1,8 +1,10 @@
 import { Check, Copy, Maximize2 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
 import Editor from "@monaco-editor/react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
 import { useTheme } from "@/contexts/useTheme";
+import { FullscreenContentDialog } from "@/ui/FullscreenContentDialog";
+import { HeaderIconButton } from "@/ui/HeaderIconButton";
 
 interface CodeBlockWidgetProps {
   code: string;
@@ -57,16 +59,21 @@ function calcHeight(code: string, maxPx = 250): number {
 
 export const CodeBlockWidget = memo(function CodeBlockWidget({ code, language }: CodeBlockWidgetProps) {
   const [copied, setCopied] = useState(false);
+  const [modalCopied, setModalCopied] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const { resolvedTheme } = useTheme();
   const monacoLang = mapLanguage(language);
   const monacoTheme = resolvedTheme === "dark" ? "vs-dark" : "vs";
+  const title = (language || "code").toUpperCase();
 
-  const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }, [code]);
+  const copyCode = useCallback(
+    async (markCopied: (value: boolean) => void) => {
+      await navigator.clipboard.writeText(code);
+      markCopied(true);
+      setTimeout(() => markCopied(false), 2000);
+    },
+    [code],
+  );
 
   const height = calcHeight(code);
 
@@ -80,7 +87,7 @@ export const CodeBlockWidget = memo(function CodeBlockWidget({ code, language }:
           <div className="flex items-center gap-1">
             <button
               type="button"
-              onClick={handleCopy}
+              onClick={() => void copyCode(setCopied)}
               className="cursor-pointer rounded p-1 text-slate-400 transition-colors hover:bg-slate-200/60 hover:text-slate-600 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
               aria-label="Copy code"
             >
@@ -108,33 +115,30 @@ export const CodeBlockWidget = memo(function CodeBlockWidget({ code, language }:
         </div>
       </div>
 
-      <Dialog open={expanded} onOpenChange={setExpanded}>
-        <DialogContent size="large" className="w-[90vw] max-h-[85vh] flex flex-col">
-          <DialogHeader>
-            <DialogTitle className="flex items-center justify-between">
-              <span className="text-sm font-medium">{language || "Code"}</span>
-              <button
-                type="button"
-                onClick={handleCopy}
-                className="cursor-pointer rounded p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-                aria-label="Copy code"
-              >
-                {copied ? <Check className="size-4 text-green-600" /> : <Copy className="size-4" />}
-              </button>
-            </DialogTitle>
-          </DialogHeader>
-          <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 dark:border-gray-700">
-            <Editor
-              height={`${Math.min(Math.max(code.split("\n").length * 19 + 20, 200), window.innerHeight * 0.7)}px`}
-              width="100%"
-              defaultLanguage={monacoLang}
-              value={code}
-              theme={monacoTheme}
-              options={{ ...MONACO_OPTIONS, lineNumbers: "on", fontSize: 13 }}
-            />
-          </div>
-        </DialogContent>
-      </Dialog>
+      <FullscreenContentDialog
+        open={expanded}
+        onOpenChange={setExpanded}
+        title={title}
+        bodyClassName="overflow-hidden"
+        headerActions={
+          <HeaderIconButton
+            label={modalCopied ? "Copied" : "Copy"}
+            icon={modalCopied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
+            onClick={() => void copyCode(setModalCopied)}
+          />
+        }
+      >
+        <div className="h-full min-h-0 overflow-hidden rounded border border-slate-200 dark:border-gray-700">
+          <Editor
+            height="100%"
+            width="100%"
+            defaultLanguage={monacoLang}
+            value={code}
+            theme={monacoTheme}
+            options={{ ...MONACO_OPTIONS, lineNumbers: "on", fontSize: 13 }}
+          />
+        </div>
+      </FullscreenContentDialog>
     </>
   );
 });

--- a/web_src/src/components/AgentSidebar/widgets/MermaidWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/MermaidWidget.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useId, useRef, useState, useCallback } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { Minus, Plus, RotateCcw } from "lucide-react";
 import mermaid from "mermaid";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+import { FullscreenContentDialog } from "@/ui/FullscreenContentDialog";
+import { HeaderIconButton } from "@/ui/HeaderIconButton";
 
 mermaid.initialize({
   startOnLoad: false,
@@ -8,23 +11,46 @@ mermaid.initialize({
   securityLevel: "strict",
   fontFamily: "ui-sans-serif, system-ui, sans-serif",
   themeVariables: {
-    primaryColor: "#ede9fe",
+    // Keep the purple primary; give secondary/tertiary real mid-tone fills
+    // instead of near-white pastels that read as washed out.
+    primaryColor: "#ddd6fe",
     primaryTextColor: "#4c1d95",
-    primaryBorderColor: "#8b5cf6",
-    secondaryColor: "#ecfeff",
+    primaryBorderColor: "#7c3aed",
+    secondaryColor: "#67e8f9",
     secondaryTextColor: "#164e63",
-    secondaryBorderColor: "#06b6d4",
-    tertiaryColor: "#fffbeb",
+    secondaryBorderColor: "#0891b2",
+    tertiaryColor: "#fcd34d",
     tertiaryTextColor: "#78350f",
-    tertiaryBorderColor: "#f59e0b",
-    lineColor: "#94a3b8",
-    textColor: "#334155",
-    nodeBorder: "#8b5cf6",
+    tertiaryBorderColor: "#d97706",
+    lineColor: "#64748b",
+    textColor: "#1e293b",
+    nodeBorder: "#7c3aed",
     nodeTextColor: "#1e293b",
     clusterBkg: "#f8fafc",
-    clusterBorder: "#e2e8f0",
-    defaultLinkColor: "#8b5cf6",
+    clusterBorder: "#cbd5e1",
+    defaultLinkColor: "#7c3aed",
     fontSize: "13px",
+    // Pie slices: purple first, then saturated companions (opacity 1 so they
+    // don't look faded on white).
+    pie1: "#8b5cf6",
+    pie2: "#06b6d4",
+    pie3: "#f59e0b",
+    pie4: "#10b981",
+    pie5: "#f43f5e",
+    pie6: "#3b82f6",
+    pie7: "#eab308",
+    pie8: "#14b8a6",
+    pie9: "#ec4899",
+    pie10: "#6366f1",
+    pie11: "#84cc16",
+    pie12: "#f97316",
+    pieOpacity: "1",
+    pieStrokeColor: "#ffffff",
+    pieStrokeWidth: "1px",
+    pieOuterStrokeColor: "#e2e8f0",
+    pieTitleTextColor: "#1e293b",
+    pieSectionTextColor: "#0f172a",
+    pieLegendTextColor: "#334155",
   },
 });
 
@@ -34,10 +60,12 @@ interface MermaidWidgetProps {
 
 export function MermaidWidget({ content }: MermaidWidgetProps) {
   const id = useId().replace(/:/g, "m");
-  const containerRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
+  const [scale, setScale] = useState(1);
+  const [fitScale, setFitScale] = useState(1);
+  const fitToViewportRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -83,37 +111,152 @@ export function MermaidWidget({ content }: MermaidWidgetProps) {
 
   return (
     <>
-      <div
-        ref={containerRef}
+      <button
+        type="button"
         onClick={() => setExpanded(true)}
-        className="my-4 w-full min-w-0 cursor-pointer overflow-x-auto rounded-lg border border-slate-200 bg-white p-3 transition-colors hover:border-slate-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full"
+        aria-label="Expand diagram"
+        className="my-4 w-full min-w-0 cursor-pointer overflow-x-auto rounded-lg border border-slate-200 bg-white p-3 text-left transition-colors hover:border-slate-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full"
       >
         <div className="pointer-events-none" dangerouslySetInnerHTML={{ __html: svg }} />
-      </div>
+      </button>
 
-      <Dialog open={expanded} onOpenChange={setExpanded}>
-        <DialogContent size="large" className="w-[90vw] max-h-[85vh] flex flex-col">
-          <DialogHeader>
-            <DialogTitle className="text-sm font-medium">Diagram</DialogTitle>
-          </DialogHeader>
-          <MermaidPanZoom svg={svg} />
-        </DialogContent>
-      </Dialog>
+      <FullscreenContentDialog
+        open={expanded}
+        onOpenChange={setExpanded}
+        title="Diagram"
+        size="wide"
+        bodyClassName="overflow-hidden p-0"
+        headerActions={
+          <>
+            <HeaderIconButton
+              label="Zoom in"
+              icon={<Plus className="h-3.5 w-3.5" />}
+              onClick={() => setScale((current) => Math.min(current * 1.2, 5))}
+            />
+            <HeaderIconButton
+              label="Zoom out"
+              icon={<Minus className="h-3.5 w-3.5" />}
+              onClick={() => setScale((current) => Math.max(current * 0.8, 0.2))}
+            />
+            <HeaderIconButton
+              label="Fit to view"
+              icon={<RotateCcw className="h-3.5 w-3.5" />}
+              onClick={() => fitToViewportRef.current?.()}
+            />
+            <span className="px-1 text-[11px] tabular-nums text-slate-500 dark:text-gray-400">
+              {Math.round(scale * 100)}%{Math.abs(scale - fitScale) < 0.01 ? " · fitted" : ""}
+            </span>
+          </>
+        }
+      >
+        <MermaidPanZoom
+          svg={svg}
+          scale={scale}
+          onScaleChange={setScale}
+          onFitScaleChange={setFitScale}
+          fitToViewportRef={fitToViewportRef}
+        />
+      </FullscreenContentDialog>
     </>
   );
 }
 
-function MermaidPanZoom({ svg }: { svg: string }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(2.5);
+function MermaidPanZoom({
+  svg,
+  scale,
+  onScaleChange,
+  onFitScaleChange,
+  fitToViewportRef,
+}: {
+  svg: string;
+  scale: number;
+  onScaleChange: (scale: number) => void;
+  onFitScaleChange: (scale: number) => void;
+  fitToViewportRef: React.MutableRefObject<(() => void) | null>;
+}) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const [translate, setTranslate] = useState({ x: 0, y: 0 });
   const dragRef = useRef<{ startX: number; startY: number; startTx: number; startTy: number } | null>(null);
+  const scaleRef = useRef(scale);
+  const fitScaleRef = useRef(1);
+  scaleRef.current = scale;
 
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
-    const delta = e.deltaY > 0 ? 0.9 : 1.1;
-    setScale((prev) => Math.min(Math.max(prev * delta, 0.2), 5));
-  }, []);
+  const fitToViewport = useCallback(() => {
+    const viewport = viewportRef.current;
+    const content = contentRef.current;
+    const svgEl = content?.querySelector("svg");
+    if (!viewport || !svgEl) {
+      return;
+    }
+
+    // Mermaid emits `max-width: 100%` which shrinks the SVG to its parent
+    // before we apply transform scale — clear that so fit math uses the
+    // diagram's intrinsic size and can fill the dialog.
+    normalizeSvgForViewport(svgEl);
+
+    const padding = 48;
+    const viewportWidth = Math.max(viewport.clientWidth - padding, 1);
+    const viewportHeight = Math.max(viewport.clientHeight - padding, 1);
+    const bounds = readSvgSize(svgEl);
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      return;
+    }
+
+    // Fill the viewport (scale up or down). Cap only to stay within the
+    // interactive zoom range — do not keep diagrams artificially small.
+    const nextFit = Math.min(viewportWidth / bounds.width, viewportHeight / bounds.height, 5);
+    fitScaleRef.current = nextFit;
+    onFitScaleChange(nextFit);
+    onScaleChange(nextFit);
+    setTranslate({ x: 0, y: 0 });
+  }, [onFitScaleChange, onScaleChange]);
+
+  useEffect(() => {
+    fitToViewportRef.current = fitToViewport;
+    return () => {
+      fitToViewportRef.current = null;
+    };
+  }, [fitToViewport, fitToViewportRef]);
+
+  useLayoutEffect(() => {
+    fitToViewport();
+  }, [fitToViewport, svg]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    // Re-fit when the dialog viewport size changes, but only while the user is
+    // still at the fitted scale so intentional zoom/pan is preserved.
+    let lastWidth = viewport.clientWidth;
+    let lastHeight = viewport.clientHeight;
+    const observer = new ResizeObserver(() => {
+      const width = viewport.clientWidth;
+      const height = viewport.clientHeight;
+      if (width === lastWidth && height === lastHeight) {
+        return;
+      }
+      lastWidth = width;
+      lastHeight = height;
+      if (Math.abs(scaleRef.current - fitScaleRef.current) < 0.01) {
+        fitToViewport();
+      }
+    });
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [fitToViewport]);
+
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? 0.9 : 1.1;
+      onScaleChange(Math.min(Math.max(scaleRef.current * delta, 0.2), 5));
+    },
+    [onScaleChange],
+  );
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -140,57 +283,63 @@ function MermaidPanZoom({ svg }: { svg: string }) {
     dragRef.current = null;
   }, []);
 
-  const resetView = useCallback(() => {
-    setScale(2.5);
-    setTranslate({ x: 0, y: 0 });
-  }, []);
-
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-2 flex items-center gap-2 text-xs text-slate-500 dark:text-gray-400">
-        <button
-          type="button"
-          onClick={() => setScale((s) => Math.min(s * 1.2, 5))}
-          className="cursor-pointer rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 dark:border-gray-700 dark:hover:bg-gray-800"
-        >
-          Zoom +
-        </button>
-        <button
-          type="button"
-          onClick={() => setScale((s) => Math.max(s * 0.8, 0.2))}
-          className="cursor-pointer rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 dark:border-gray-700 dark:hover:bg-gray-800"
-        >
-          Zoom −
-        </button>
-        <button
-          type="button"
-          onClick={resetView}
-          className="cursor-pointer rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 dark:border-gray-700 dark:hover:bg-gray-800"
-        >
-          Reset
-        </button>
-        <span>{Math.round(scale * 100)}%</span>
-      </div>
+    <div
+      ref={viewportRef}
+      className="h-full min-h-0 cursor-grab overflow-hidden bg-slate-50/50 active:cursor-grabbing dark:bg-gray-900"
+      onWheel={handleWheel}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+    >
       <div
-        ref={containerRef}
-        className="min-h-0 flex-1 cursor-grab overflow-hidden rounded-lg border border-slate-200 bg-slate-50/50 active:cursor-grabbing dark:border-gray-700 dark:bg-gray-900"
-        onWheel={handleWheel}
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
+        className="flex h-full w-full items-center justify-center"
+        style={{
+          transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
+          transformOrigin: "center center",
+        }}
       >
-        <div
-          className="flex h-full w-full items-center justify-center"
-          style={{
-            transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
-            transformOrigin: "center center",
-            minHeight: "40vh",
-          }}
-        >
-          <div className="[&_svg]:max-w-none [&_svg]:h-auto" dangerouslySetInnerHTML={{ __html: svg }} />
-        </div>
+        <div ref={contentRef} className="[&_svg]:h-auto [&_svg]:max-w-none" dangerouslySetInnerHTML={{ __html: svg }} />
       </div>
     </div>
   );
+}
+
+function normalizeSvgForViewport(svgEl: SVGSVGElement) {
+  svgEl.style.maxWidth = "none";
+  svgEl.style.height = "auto";
+
+  const bounds = readSvgSize(svgEl);
+  if (bounds.width > 0) {
+    svgEl.setAttribute("width", String(bounds.width));
+  }
+  if (bounds.height > 0) {
+    svgEl.setAttribute("height", String(bounds.height));
+  }
+}
+
+function readSvgSize(svgEl: SVGSVGElement): { width: number; height: number } {
+  const viewBox = svgEl.viewBox?.baseVal;
+  if (viewBox && viewBox.width > 0 && viewBox.height > 0) {
+    return { width: viewBox.width, height: viewBox.height };
+  }
+
+  try {
+    const bbox = svgEl.getBBox();
+    if (bbox.width > 0 && bbox.height > 0) {
+      return { width: bbox.width, height: bbox.height };
+    }
+  } catch {
+    // getBBox can throw if the SVG is not rendered yet.
+  }
+
+  const widthAttr = svgEl.getAttribute("width");
+  const heightAttr = svgEl.getAttribute("height");
+  const width = widthAttr && !widthAttr.endsWith("%") ? Number.parseFloat(widthAttr) : NaN;
+  const height = heightAttr && !heightAttr.endsWith("%") ? Number.parseFloat(heightAttr) : NaN;
+  return {
+    width: Number.isFinite(width) && width > 0 ? width : svgEl.clientWidth,
+    height: Number.isFinite(height) && height > 0 ? height : svgEl.clientHeight,
+  };
 }

--- a/web_src/src/components/AgentSidebar/widgets/MermaidWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/MermaidWidget.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { Minus, Plus, RotateCcw } from "lucide-react";
 import mermaid from "mermaid";
 
 import { FullscreenContentDialog } from "@/ui/FullscreenContentDialog";
 import { HeaderIconButton } from "@/ui/HeaderIconButton";
+import { useMermaidFitToViewport, useMermaidPan } from "./useMermaidViewport";
 
 mermaid.initialize({
   startOnLoad: false,
@@ -176,78 +177,25 @@ function MermaidPanZoom({
 }) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-  const [translate, setTranslate] = useState({ x: 0, y: 0 });
-  const dragRef = useRef<{ startX: number; startY: number; startTx: number; startTy: number } | null>(null);
   const scaleRef = useRef(scale);
   const fitScaleRef = useRef(1);
   scaleRef.current = scale;
 
-  const fitToViewport = useCallback(() => {
-    const viewport = viewportRef.current;
-    const content = contentRef.current;
-    const svgEl = content?.querySelector("svg");
-    if (!viewport || !svgEl) {
-      return;
-    }
+  const { translate, resetPan, handleMouseDown, handleMouseMove, handleMouseUp } = useMermaidPan();
 
-    // Mermaid emits `max-width: 100%` which shrinks the SVG to its parent
-    // before we apply transform scale — clear that so fit math uses the
-    // diagram's intrinsic size and can fill the dialog.
-    normalizeSvgForViewport(svgEl);
-
-    const padding = 48;
-    const viewportWidth = Math.max(viewport.clientWidth - padding, 1);
-    const viewportHeight = Math.max(viewport.clientHeight - padding, 1);
-    const bounds = readSvgSize(svgEl);
-    if (bounds.width <= 0 || bounds.height <= 0) {
-      return;
-    }
-
-    // Fill the viewport (scale up or down). Cap only to stay within the
-    // interactive zoom range — do not keep diagrams artificially small.
-    const nextFit = Math.min(viewportWidth / bounds.width, viewportHeight / bounds.height, 5);
-    fitScaleRef.current = nextFit;
-    onFitScaleChange(nextFit);
-    onScaleChange(nextFit);
-    setTranslate({ x: 0, y: 0 });
-  }, [onFitScaleChange, onScaleChange]);
-
-  useEffect(() => {
-    fitToViewportRef.current = fitToViewport;
-    return () => {
-      fitToViewportRef.current = null;
-    };
-  }, [fitToViewport, fitToViewportRef]);
-
-  useLayoutEffect(() => {
-    fitToViewport();
-  }, [fitToViewport, svg]);
-
-  useEffect(() => {
-    const viewport = viewportRef.current;
-    if (!viewport || typeof ResizeObserver === "undefined") {
-      return;
-    }
-
-    // Re-fit when the dialog viewport size changes, but only while the user is
-    // still at the fitted scale so intentional zoom/pan is preserved.
-    let lastWidth = viewport.clientWidth;
-    let lastHeight = viewport.clientHeight;
-    const observer = new ResizeObserver(() => {
-      const width = viewport.clientWidth;
-      const height = viewport.clientHeight;
-      if (width === lastWidth && height === lastHeight) {
-        return;
-      }
-      lastWidth = width;
-      lastHeight = height;
-      if (Math.abs(scaleRef.current - fitScaleRef.current) < 0.01) {
-        fitToViewport();
-      }
-    });
-    observer.observe(viewport);
-    return () => observer.disconnect();
-  }, [fitToViewport]);
+  useMermaidFitToViewport({
+    viewportRef,
+    contentRef,
+    svg,
+    onScaleChange: (next) => {
+      resetPan();
+      onScaleChange(next);
+    },
+    onFitScaleChange,
+    fitToViewportRef,
+    scaleRef,
+    fitScaleRef,
+  });
 
   const handleWheel = useCallback(
     (e: React.WheelEvent) => {
@@ -257,31 +205,6 @@ function MermaidPanZoom({
     },
     [onScaleChange],
   );
-
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      dragRef.current = {
-        startX: e.clientX,
-        startY: e.clientY,
-        startTx: translate.x,
-        startTy: translate.y,
-      };
-    },
-    [translate],
-  );
-
-  const handleMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!dragRef.current) return;
-    setTranslate({
-      x: dragRef.current.startTx + (e.clientX - dragRef.current.startX),
-      y: dragRef.current.startTy + (e.clientY - dragRef.current.startY),
-    });
-  }, []);
-
-  const handleMouseUp = useCallback(() => {
-    dragRef.current = null;
-  }, []);
 
   return (
     <div
@@ -304,42 +227,4 @@ function MermaidPanZoom({
       </div>
     </div>
   );
-}
-
-function normalizeSvgForViewport(svgEl: SVGSVGElement) {
-  svgEl.style.maxWidth = "none";
-  svgEl.style.height = "auto";
-
-  const bounds = readSvgSize(svgEl);
-  if (bounds.width > 0) {
-    svgEl.setAttribute("width", String(bounds.width));
-  }
-  if (bounds.height > 0) {
-    svgEl.setAttribute("height", String(bounds.height));
-  }
-}
-
-function readSvgSize(svgEl: SVGSVGElement): { width: number; height: number } {
-  const viewBox = svgEl.viewBox?.baseVal;
-  if (viewBox && viewBox.width > 0 && viewBox.height > 0) {
-    return { width: viewBox.width, height: viewBox.height };
-  }
-
-  try {
-    const bbox = svgEl.getBBox();
-    if (bbox.width > 0 && bbox.height > 0) {
-      return { width: bbox.width, height: bbox.height };
-    }
-  } catch {
-    // getBBox can throw if the SVG is not rendered yet.
-  }
-
-  const widthAttr = svgEl.getAttribute("width");
-  const heightAttr = svgEl.getAttribute("height");
-  const width = widthAttr && !widthAttr.endsWith("%") ? Number.parseFloat(widthAttr) : NaN;
-  const height = heightAttr && !heightAttr.endsWith("%") ? Number.parseFloat(heightAttr) : NaN;
-  return {
-    width: Number.isFinite(width) && width > 0 ? width : svgEl.clientWidth,
-    height: Number.isFinite(height) && height > 0 ? height : svgEl.clientHeight,
-  };
 }

--- a/web_src/src/components/AgentSidebar/widgets/MermaidWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/MermaidWidget.tsx
@@ -183,14 +183,19 @@ function MermaidPanZoom({
 
   const { translate, resetPan, handleMouseDown, handleMouseMove, handleMouseUp } = useMermaidPan();
 
+  const applyFitScale = useCallback(
+    (next: number) => {
+      resetPan();
+      onScaleChange(next);
+    },
+    [onScaleChange, resetPan],
+  );
+
   useMermaidFitToViewport({
     viewportRef,
     contentRef,
     svg,
-    onScaleChange: (next) => {
-      resetPan();
-      onScaleChange(next);
-    },
+    onScaleChange: applyFitScale,
     onFitScaleChange,
     fitToViewportRef,
     scaleRef,

--- a/web_src/src/components/AgentSidebar/widgets/mermaidSvgSize.spec.ts
+++ b/web_src/src/components/AgentSidebar/widgets/mermaidSvgSize.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { computeFitScale } from "./mermaidSvgSize";
+
+describe("computeFitScale", () => {
+  it("fits content into the viewport and respects the max scale", () => {
+    expect(computeFitScale(400, 300, 200, 100)).toBe(2);
+    expect(computeFitScale(400, 300, 50, 50, 5)).toBe(5);
+    expect(computeFitScale(400, 300, 0, 100)).toBe(1);
+  });
+});

--- a/web_src/src/components/AgentSidebar/widgets/mermaidSvgSize.ts
+++ b/web_src/src/components/AgentSidebar/widgets/mermaidSvgSize.ts
@@ -1,0 +1,55 @@
+export function normalizeSvgForViewport(svgEl: SVGSVGElement) {
+  svgEl.style.maxWidth = "none";
+  svgEl.style.height = "auto";
+
+  const bounds = readSvgSize(svgEl);
+  if (bounds.width > 0) {
+    svgEl.setAttribute("width", String(bounds.width));
+  }
+  if (bounds.height > 0) {
+    svgEl.setAttribute("height", String(bounds.height));
+  }
+}
+
+function parseSvgLengthAttr(value: string | null): number {
+  if (!value || value.endsWith("%")) {
+    return NaN;
+  }
+  return Number.parseFloat(value);
+}
+
+export function readSvgSize(svgEl: SVGSVGElement): { width: number; height: number } {
+  const viewBox = svgEl.viewBox?.baseVal;
+  if (viewBox && viewBox.width > 0 && viewBox.height > 0) {
+    return { width: viewBox.width, height: viewBox.height };
+  }
+
+  try {
+    const bbox = svgEl.getBBox();
+    if (bbox.width > 0 && bbox.height > 0) {
+      return { width: bbox.width, height: bbox.height };
+    }
+  } catch {
+    // getBBox can throw if the SVG is not rendered yet.
+  }
+
+  const width = parseSvgLengthAttr(svgEl.getAttribute("width"));
+  const height = parseSvgLengthAttr(svgEl.getAttribute("height"));
+  return {
+    width: Number.isFinite(width) && width > 0 ? width : svgEl.clientWidth,
+    height: Number.isFinite(height) && height > 0 ? height : svgEl.clientHeight,
+  };
+}
+
+export function computeFitScale(
+  viewportWidth: number,
+  viewportHeight: number,
+  contentWidth: number,
+  contentHeight: number,
+  maxScale = 5,
+): number {
+  if (contentWidth <= 0 || contentHeight <= 0) {
+    return 1;
+  }
+  return Math.min(viewportWidth / contentWidth, viewportHeight / contentHeight, maxScale);
+}

--- a/web_src/src/components/AgentSidebar/widgets/useMermaidViewport.ts
+++ b/web_src/src/components/AgentSidebar/widgets/useMermaidViewport.ts
@@ -30,6 +30,13 @@ export function useMermaidFitToViewport({
   scaleRef: MutableRefObject<number>;
   fitScaleRef: MutableRefObject<number>;
 }) {
+  // Keep callbacks in refs so fitToViewport stays stable across parent re-renders
+  // (e.g. zoom/pan). Otherwise useLayoutEffect would re-fit and wipe user scale.
+  const onScaleChangeRef = useRef(onScaleChange);
+  const onFitScaleChangeRef = useRef(onFitScaleChange);
+  onScaleChangeRef.current = onScaleChange;
+  onFitScaleChangeRef.current = onFitScaleChange;
+
   const fitToViewport = useCallback(() => {
     const viewport = viewportRef.current;
     const svgEl = contentRef.current?.querySelector("svg");
@@ -47,9 +54,9 @@ export function useMermaidFitToViewport({
     const bounds = readSvgSize(svgEl);
     const nextFit = computeFitScale(viewportWidth, viewportHeight, bounds.width, bounds.height);
     fitScaleRef.current = nextFit;
-    onFitScaleChange(nextFit);
-    onScaleChange(nextFit);
-  }, [contentRef, fitScaleRef, onFitScaleChange, onScaleChange, viewportRef]);
+    onFitScaleChangeRef.current(nextFit);
+    onScaleChangeRef.current(nextFit);
+  }, [contentRef, fitScaleRef, viewportRef]);
 
   useEffect(() => {
     fitToViewportRef.current = fitToViewport;

--- a/web_src/src/components/AgentSidebar/widgets/useMermaidViewport.ts
+++ b/web_src/src/components/AgentSidebar/widgets/useMermaidViewport.ts
@@ -1,0 +1,126 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type RefObject,
+} from "react";
+import { computeFitScale, normalizeSvgForViewport, readSvgSize } from "./mermaidSvgSize";
+
+const FIT_PADDING = 48;
+
+export function useMermaidFitToViewport({
+  viewportRef,
+  contentRef,
+  svg,
+  onScaleChange,
+  onFitScaleChange,
+  fitToViewportRef,
+  scaleRef,
+  fitScaleRef,
+}: {
+  viewportRef: RefObject<HTMLDivElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
+  svg: string;
+  onScaleChange: (scale: number) => void;
+  onFitScaleChange: (scale: number) => void;
+  fitToViewportRef: MutableRefObject<(() => void) | null>;
+  scaleRef: MutableRefObject<number>;
+  fitScaleRef: MutableRefObject<number>;
+}) {
+  const fitToViewport = useCallback(() => {
+    const viewport = viewportRef.current;
+    const svgEl = contentRef.current?.querySelector("svg");
+    if (!viewport || !svgEl) {
+      return;
+    }
+
+    // Mermaid emits `max-width: 100%` which shrinks the SVG to its parent
+    // before we apply transform scale — clear that so fit math uses the
+    // diagram's intrinsic size and can fill the dialog.
+    normalizeSvgForViewport(svgEl);
+
+    const viewportWidth = Math.max(viewport.clientWidth - FIT_PADDING, 1);
+    const viewportHeight = Math.max(viewport.clientHeight - FIT_PADDING, 1);
+    const bounds = readSvgSize(svgEl);
+    const nextFit = computeFitScale(viewportWidth, viewportHeight, bounds.width, bounds.height);
+    fitScaleRef.current = nextFit;
+    onFitScaleChange(nextFit);
+    onScaleChange(nextFit);
+  }, [contentRef, fitScaleRef, onFitScaleChange, onScaleChange, viewportRef]);
+
+  useEffect(() => {
+    fitToViewportRef.current = fitToViewport;
+    return () => {
+      fitToViewportRef.current = null;
+    };
+  }, [fitToViewport, fitToViewportRef]);
+
+  useLayoutEffect(() => {
+    fitToViewport();
+  }, [fitToViewport, svg]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    // Re-fit when the dialog viewport size changes, but only while the user is
+    // still at the fitted scale so intentional zoom/pan is preserved.
+    let lastWidth = viewport.clientWidth;
+    let lastHeight = viewport.clientHeight;
+    const observer = new ResizeObserver(() => {
+      const width = viewport.clientWidth;
+      const height = viewport.clientHeight;
+      if (width === lastWidth && height === lastHeight) {
+        return;
+      }
+      lastWidth = width;
+      lastHeight = height;
+      if (Math.abs(scaleRef.current - fitScaleRef.current) < 0.01) {
+        fitToViewport();
+      }
+    });
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [fitScaleRef, fitToViewport, scaleRef, viewportRef]);
+
+  return fitToViewport;
+}
+
+export function useMermaidPan() {
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const dragRef = useRef<{ startX: number; startY: number; startTx: number; startTy: number } | null>(null);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        startTx: translate.x,
+        startTy: translate.y,
+      };
+    },
+    [translate],
+  );
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!dragRef.current) return;
+    setTranslate({
+      x: dragRef.current.startTx + (e.clientX - dragRef.current.startX),
+      y: dragRef.current.startTy + (e.clientY - dragRef.current.startY),
+    });
+  }, []);
+
+  const handleMouseUp = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
+  const resetPan = useCallback(() => setTranslate({ x: 0, y: 0 }), []);
+
+  return { translate, resetPan, handleMouseDown, handleMouseMove, handleMouseUp };
+}

--- a/web_src/src/ui/FullscreenContentDialog.tsx
+++ b/web_src/src/ui/FullscreenContentDialog.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+const FULLSCREEN_DIALOG_SIZE_CLASSES = {
+  /** Run inspector / code blocks */
+  default: "h-[80vh] w-[60vw] max-w-[60vw]",
+  /** Wide diagrams (Mermaid) */
+  wide: "h-[90vh] w-[90vw] max-w-[90vw]",
+} as const;
+
+export type FullscreenContentDialogSize = keyof typeof FULLSCREEN_DIALOG_SIZE_CLASSES;
+
+/**
+ * Fullscreen content shell shared by run-inspector OUTPUT expand,
+ * markdown code-block expand, and Mermaid diagram expand.
+ */
+export function FullscreenContentDialog({
+  open,
+  onOpenChange,
+  title,
+  headerActions,
+  bodyClassName,
+  size = "default",
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  headerActions?: ReactNode;
+  bodyClassName?: string;
+  size?: FullscreenContentDialogSize;
+  children: ReactNode;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        size="large"
+        className={cn("flex flex-col gap-0 overflow-hidden p-0", FULLSCREEN_DIALOG_SIZE_CLASSES[size])}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-1.5 pr-10 dark:border-gray-800 dark:bg-gray-900">
+          <DialogTitle className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-gray-400">
+            {title}
+          </DialogTitle>
+          {headerActions ? <span className="flex items-center gap-0.5">{headerActions}</span> : null}
+        </div>
+        <div className={cn("min-h-0 flex-1 overflow-auto p-3", bodyClassName)}>{children}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/ui/HeaderIconButton.tsx
+++ b/web_src/src/ui/HeaderIconButton.tsx
@@ -1,0 +1,41 @@
+import type { MouseEvent, ReactNode } from "react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+export function HeaderIconButton({
+  label,
+  icon,
+  onClick,
+  active,
+}: {
+  label: string;
+  icon: ReactNode;
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  active?: boolean;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          aria-pressed={active}
+          onClick={(event) => {
+            event.stopPropagation();
+            onClick?.(event);
+          }}
+          className={cn(
+            "flex h-6 w-6 items-center justify-center rounded transition-colors",
+            active
+              ? "bg-blue-100 text-blue-700 hover:bg-blue-200"
+              : "text-slate-400 hover:bg-slate-200 hover:text-slate-700 dark:hover:bg-gray-800 dark:hover:text-gray-100",
+          )}
+        >
+          {icon}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web_src/src/ui/Runs/RunInspectorInputChainModal.tsx
+++ b/web_src/src/ui/Runs/RunInspectorInputChainModal.tsx
@@ -3,7 +3,8 @@ import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import type { RunInspectorUpstreamSection } from "./runNodeDetailModel";
-import { HeaderIconButton, JsonPayload } from "./RunInspectorTimelineCard";
+import { JsonPayload } from "./RunInspectorTimelineCard";
+import { HeaderIconButton } from "@/ui/HeaderIconButton";
 import { NodeMarker } from "./RunInspectorTimelineMarkers";
 
 export function InputChainMoreChip({

--- a/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
@@ -5,7 +5,8 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ConfigurationFieldRenderer } from "@/ui/configurationFieldRenderer";
 import { cn } from "@/lib/utils";
-import { EmptySectionText, HeaderIconButton, JsonPayload, TimelineAccordionCard } from "./RunInspectorTimelineCard";
+import { EmptySectionText, JsonPayload, TimelineAccordionCard } from "./RunInspectorTimelineCard";
+import { HeaderIconButton } from "@/ui/HeaderIconButton";
 import { hasObjectValue, type RunInspectorNodeSection } from "./runNodeDetailModel";
 
 export function RuntimeTimelineCard({

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
@@ -1,12 +1,12 @@
 import JsonView from "@uiw/react-json-view";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { Check, ChevronDown, Copy, Maximize2 } from "lucide-react";
-import { useMemo, useState, type CSSProperties, type MouseEvent, type ReactNode } from "react";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { jsonViewClassName } from "@/lib/jsonViewTheme";
 import { AccordionContent, AccordionItem } from "@/ui/accordion";
+import { FullscreenContentDialog } from "@/ui/FullscreenContentDialog";
+import { HeaderIconButton } from "@/ui/HeaderIconButton";
 import { escapeJsonStringValue } from "./runInspectorJson";
 import type { InternalAccordionKey, StatusPill } from "./RunInspectorTimelineTypes";
 
@@ -93,69 +93,21 @@ export function TimelineAccordionCard({
         </AccordionContent>
       </AccordionItem>
 
-      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
-        <DialogContent
-          size="large"
-          className="flex h-[80vh] w-[60vw] max-w-[60vw] flex-col gap-0 overflow-hidden p-0"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <div className="flex items-center justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-1.5 pr-10 dark:border-gray-800 dark:bg-gray-900">
-            <DialogTitle className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-gray-400">
-              {title}
-            </DialogTitle>
-            <span className="flex items-center gap-0.5">
-              <HeaderIconButton
-                label={modalCopied ? "Copied" : "Copy"}
-                icon={
-                  modalCopied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />
-                }
-                onClick={() => copyPayload(setModalCopied)}
-              />
-            </span>
-          </div>
-          <div className="min-h-0 flex-1 overflow-auto p-3">
-            <JsonPayload value={actionPayload} jsonViewStyle={jsonViewStyle} collapsed={false} />
-          </div>
-        </DialogContent>
-      </Dialog>
+      <FullscreenContentDialog
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        title={title}
+        headerActions={
+          <HeaderIconButton
+            label={modalCopied ? "Copied" : "Copy"}
+            icon={modalCopied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
+            onClick={() => copyPayload(setModalCopied)}
+          />
+        }
+      >
+        <JsonPayload value={actionPayload} jsonViewStyle={jsonViewStyle} collapsed={false} />
+      </FullscreenContentDialog>
     </>
-  );
-}
-
-export function HeaderIconButton({
-  label,
-  icon,
-  onClick,
-  active,
-}: {
-  label: string;
-  icon: ReactNode;
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
-  active?: boolean;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          aria-label={label}
-          aria-pressed={active}
-          onClick={(event) => {
-            event.stopPropagation();
-            onClick?.(event);
-          }}
-          className={cn(
-            "flex h-6 w-6 items-center justify-center rounded transition-colors",
-            active
-              ? "bg-blue-100 text-blue-700 hover:bg-blue-200"
-              : "text-slate-400 hover:bg-slate-200 hover:text-slate-700 dark:hover:bg-gray-800 dark:hover:text-gray-100",
-          )}
-        >
-          {icon}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="top">{label}</TooltipContent>
-    </Tooltip>
   );
 }
 


### PR DESCRIPTION
## Summary
- Extract shared `FullscreenContentDialog` and `HeaderIconButton`
- Use them for code blocks, Mermaid expand, and run-inspector OUTPUT expand
- Improve Mermaid auto-fit / zoom UX and expand-button accessibility
- Finish HeaderIconButton import migration (no re-export from timeline card)

Split from #6030 for a focused review.

## Test plan
- [ ] Expand a code block and a Mermaid diagram from agent/markdown surfaces
- [ ] Expand run-inspector OUTPUT and confirm shared dialog chrome
- [ ] Mermaid zoom controls and fit-to-viewport behave as expected
- [ ] `npx vitest run src/components/AgentSidebar/widgets/CodeBlockWidget.spec.tsx` passes