### PR TITLE
fix: focus node chips from Files and improve hover cards

### DIFF
--- a/web_src/src/components/AgentSidebar/widgets/NodeChip.stories.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/NodeChip.stories.tsx
@@ -52,12 +52,61 @@ const mockCanvas: CanvasesCanvas = {
         type: "TYPE_ACTION",
         component: "ssh",
         configuration: { host: "192.168.1.1", username: "ubuntu" },
+        errorMessage: "Integration SSH is disconnected",
+      },
+      {
+        id: "create-issue",
+        name: "Create GitHub Issue",
+        type: "TYPE_ACTION",
+        component: "github.createIssue",
+        configuration: { title: "Bug report" },
+        metadata: { repository: { name: "acme/widgets" } },
+      },
+      {
+        id: "hub-node",
+        name: "Fan Out Hub",
+        type: "TYPE_ACTION",
+        component: "http",
+        configuration: { method: "POST", url: "https://example.com/fanout" },
+      },
+      {
+        id: "branch-a",
+        name: "Branch A",
+        type: "TYPE_ACTION",
+        component: "http",
+        configuration: { method: "GET", url: "https://example.com/a" },
+      },
+      {
+        id: "branch-b",
+        name: "Branch B",
+        type: "TYPE_ACTION",
+        component: "http",
+        configuration: { method: "GET", url: "https://example.com/b" },
+      },
+      {
+        id: "branch-c",
+        name: "Branch C",
+        type: "TYPE_ACTION",
+        component: "http",
+        configuration: { method: "GET", url: "https://example.com/c" },
+      },
+      {
+        id: "branch-d",
+        name: "Branch D",
+        type: "TYPE_ACTION",
+        component: "http",
+        configuration: { method: "GET", url: "https://example.com/d" },
       },
     ],
     edges: [
       { sourceId: "webhook-trigger", targetId: "call-api", channel: "default" },
       { sourceId: "call-api", targetId: "check-result", channel: "success" },
       { sourceId: "check-result", targetId: "notify-success", channel: "true" },
+      { sourceId: "webhook-trigger", targetId: "hub-node", channel: "default" },
+      { sourceId: "hub-node", targetId: "branch-a", channel: "default" },
+      { sourceId: "hub-node", targetId: "branch-b", channel: "default" },
+      { sourceId: "hub-node", targetId: "branch-c", channel: "default" },
+      { sourceId: "hub-node", targetId: "branch-d", channel: "default" },
     ],
   },
 };
@@ -95,7 +144,7 @@ type Story = StoryObj<typeof RichMessage>;
 
 export const NodeReferences: Story = {
   args: {
-    content: `Check the [Webhook Trigger](node:webhook-trigger) and the [Call Target API](node:call-api) node.`,
+    content: `Hover [Call Target API](node:call-api) for HTTP details, [Create GitHub Issue](node:create-issue) for repo metadata, or [SSH Deploy](node:ssh-deploy) for an error state.`,
     canvasId: CANVAS_ID,
     organizationId: ORG_ID,
   },
@@ -111,6 +160,14 @@ export const AllComponentTypes: Story = {
 - Wait: [Random Wait](node:random-wait)
 - SSH: [SSH Deploy](node:ssh-deploy)
 - Notify: [Notify Success](node:notify-success)`,
+    canvasId: CANVAS_ID,
+    organizationId: ORG_ID,
+  },
+};
+
+export const OverflowNeighbors: Story = {
+  args: {
+    content: `Hub with many edges: [Fan Out Hub](node:hub-node) should show capped neighbors and +N more.`,
     canvasId: CANVAS_ID,
     organizationId: ORG_ID,
   },

--- a/web_src/src/components/AgentSidebar/widgets/NodeChip.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/NodeChip.tsx
@@ -6,7 +6,9 @@ import { useCanvas } from "@/hooks/useCanvasData";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import type { CanvasesCanvas, SuperplaneComponentsNode } from "@/api-client";
+import { MetadataList } from "@/ui/metadataList";
 import { BUILTIN_COMPONENT_ICON_SLUGS } from "./componentIcons";
+import { getNodeHoverMetadataItems, listNodeNeighbors, type NodeNeighbor } from "./nodeChipHover";
 
 const TRIGGER_COMPONENTS = new Set(["start", "schedule", "webhook"]);
 
@@ -98,6 +100,23 @@ function NodeHoverIcon({ component, isTrigger }: { component?: string; isTrigger
   return <span className={cn("size-3 rounded-full shrink-0", isTrigger ? "bg-violet-400" : "bg-blue-400")} />;
 }
 
+function NeighborChip({ neighbor }: { neighbor: NodeNeighbor }) {
+  const label = neighbor.direction === "upstream" ? `← ${neighbor.label}` : `${neighbor.label} →`;
+  return (
+    <span className="max-w-full truncate rounded-full bg-slate-100 px-2 py-0.5 text-[11px] text-slate-600 dark:bg-gray-800 dark:text-gray-300">
+      {label}
+    </span>
+  );
+}
+
+function HoverSectionLabel({ children }: { children: string }) {
+  return (
+    <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400 dark:text-gray-500">
+      {children}
+    </div>
+  );
+}
+
 function NodeHoverHeader({
   node,
   component,
@@ -110,14 +129,18 @@ function NodeHoverHeader({
   return (
     <div
       className={cn(
-        "flex items-center gap-2 border-b border-slate-100 px-3 py-2 dark:border-gray-700",
-        isTrigger ? "bg-violet-50 dark:bg-violet-950/40" : "bg-blue-50 dark:bg-blue-950/40",
+        "flex items-center gap-2.5 border-b px-3.5 py-3",
+        isTrigger
+          ? "border-violet-200 bg-violet-100 dark:border-violet-800/60 dark:bg-violet-950/55"
+          : "border-blue-200 bg-blue-100 dark:border-blue-800/60 dark:bg-blue-950/55",
       )}
     >
-      <NodeHoverIcon component={component} isTrigger={isTrigger} />
-      <div className="flex-1 min-w-0">
-        <p className="truncate text-xs font-medium text-slate-900 dark:text-gray-100">{node.name || node.id}</p>
-        <p className="text-[10px] text-slate-500 dark:text-gray-400">
+      <div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-white/80 shadow-sm dark:bg-gray-900/70">
+        <NodeHoverIcon component={component} isTrigger={isTrigger} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[13px] font-semibold text-slate-900 dark:text-gray-100">{node.name || node.id}</p>
+        <p className="text-[11px] text-slate-500 dark:text-gray-400">
           {component || "unknown"} · {isTrigger ? "Trigger" : "Action"}
         </p>
       </div>
@@ -161,8 +184,8 @@ export function NodeChip({ nodeId, label, canvasId, organizationId }: NodeChipPr
         </button>
       </HoverCardTrigger>
       {node && (
-        <HoverCardContent className="w-64 p-0" side="top" align="start">
-          <NodeHoverContent node={node} edges={edges} component={component} />
+        <HoverCardContent className="w-[280px] p-0" side="top" align="start">
+          <NodeHoverContent node={node} nodes={nodes} edges={edges} component={component} />
         </HoverCardContent>
       )}
     </HoverCard>
@@ -171,67 +194,69 @@ export function NodeChip({ nodeId, label, canvasId, organizationId }: NodeChipPr
 
 function NodeHoverContent({
   node,
+  nodes,
   edges,
   component: resolvedComponent,
 }: {
   node: SuperplaneComponentsNode;
+  nodes: SuperplaneComponentsNode[] | undefined;
   edges: NonNullable<CanvasesCanvas["spec"]>["edges"];
   component?: string;
 }) {
-  const isTrigger = node.type === "TYPE_TRIGGER";
+  const isTrigger = node.type === "TYPE_TRIGGER" || isTriggerNode(node, resolvedComponent);
   const component = resolvedComponent ?? resolveNodeComponent(node, node.id ?? "");
-  const config = node.configuration ?? {};
-
-  // Count connections
-  const incoming = (edges ?? []).filter((e) => e.targetId === node.id).length;
-  const outgoing = (edges ?? []).filter((e) => e.sourceId === node.id).length;
-
-  // Extract key config summary
-  const summary = getConfigSummary(component, config);
+  const metadataItems = getNodeHoverMetadataItems(node, component);
+  const neighbors = listNodeNeighbors(node.id, edges, nodes);
+  const hasBody = Boolean(metadataItems.length > 0 || neighbors.items.length > 0 || node.errorMessage);
 
   return (
     <div>
-      {/* Header */}
       <NodeHoverHeader node={node} component={component} isTrigger={isTrigger} />
 
-      {/* Config summary */}
-      {summary && (
-        <div className="border-b border-slate-100 px-3 py-2 dark:border-gray-700">
-          <p className="truncate font-mono text-[10px] text-slate-500 dark:text-gray-400">{summary}</p>
+      {hasBody && (
+        <div className="space-y-2.5 px-3.5 pt-3 pb-2.5">
+          {metadataItems.length > 0 && (
+            <div>
+              <HoverSectionLabel>Details</HoverSectionLabel>
+              <MetadataList
+                items={metadataItems}
+                maxVisibleItems={3}
+                iconSize={14}
+                className="flex flex-col gap-1 text-slate-600 dark:text-gray-300"
+              />
+            </div>
+          )}
+
+          {neighbors.items.length > 0 && (
+            <div>
+              <HoverSectionLabel>Connected to</HoverSectionLabel>
+              <div className="flex flex-wrap gap-1">
+                {neighbors.items.map((neighbor) => (
+                  <NeighborChip key={`${neighbor.direction}:${neighbor.id}`} neighbor={neighbor} />
+                ))}
+                {neighbors.overflow > 0 && (
+                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-gray-800 dark:text-gray-400">
+                    +{neighbors.overflow} more
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {node.errorMessage && (
+            <div className="flex items-start gap-1.5 rounded-lg bg-red-50 px-2.5 py-2 text-[11px] text-red-700 dark:bg-red-950/40 dark:text-red-300">
+              <span className="shrink-0" aria-hidden>
+                ⚠
+              </span>
+              <span className="min-w-0 truncate">{node.errorMessage}</span>
+            </div>
+          )}
         </div>
       )}
 
-      {/* Connections */}
-      <div className="flex items-center gap-3 px-3 py-2 text-[10px] text-slate-500 dark:text-gray-400">
-        <span>{incoming} incoming</span>
-        <span>·</span>
-        <span>{outgoing} outgoing</span>
+      <div className="border-t border-slate-100 px-3.5 py-2 text-[11px] text-slate-400 dark:border-gray-800 dark:text-gray-500">
+        Click to open on canvas
       </div>
-
-      {/* Error/warning */}
-      {node.errorMessage && (
-        <div className="truncate border-t border-red-100 bg-red-50 px-3 py-1.5 text-[10px] text-red-600 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-          ⚠ {node.errorMessage}
-        </div>
-      )}
     </div>
   );
 }
-
-const CONFIG_SUMMARIZERS: Record<string, (c: Record<string, unknown>) => string> = {
-  http: (c) => `${c.method || "GET"} ${c.url || ""}`,
-  ssh: (c) => `${c.username || "root"}@${c.host || ""}`,
-  if: (c) => String(c.expression || ""),
-  filter: (c) => String(c.expression || ""),
-  wait: (c) => `Wait: ${c.duration || c.waitFor || ""}`,
-  webhook: (c) => `Auth: ${c.authentication || "none"}`,
-  schedule: (c) => `Cron: ${c.cron || ""}`,
-  approval: (c) => String(c.message || "Approval required"),
-};
-
-function getConfigSummary(component?: string, config?: Record<string, unknown>): string | null {
-  if (!component || !config) return null;
-  const summarizer = CONFIG_SUMMARIZERS[component];
-  return summarizer ? summarizer(config) : null;
-}
-// already at end of file

--- a/web_src/src/components/AgentSidebar/widgets/nodeChipHover.spec.ts
+++ b/web_src/src/components/AgentSidebar/widgets/nodeChipHover.spec.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import { getConfigSummary, getNodeHoverMetadataItems, listNodeNeighbors } from "./nodeChipHover";
+import type { SuperplaneComponentsNode } from "@/api-client";
+
+vi.mock("@/pages/app/mappers", () => ({
+  getComponentBaseMapper: (name: string) => ({
+    props: () => {
+      if (name === "github.createIssue") {
+        return {
+          metadata: [{ icon: "book", label: "acme/widgets" }],
+        };
+      }
+      if (name === "http") {
+        return {
+          metadata: [{ icon: "link", label: "GET https://example.com" }],
+        };
+      }
+      return { metadata: [] };
+    },
+  }),
+  getTriggerRenderer: (name: string) => ({
+    getTriggerProps: () => {
+      if (name === "github.onPullRequest") {
+        return {
+          metadata: [
+            { icon: "book", label: "acme/widgets" },
+            { icon: "funnel", label: "opened, synchronize" },
+          ],
+        };
+      }
+      return { metadata: [] };
+    },
+  }),
+}));
+
+const nodes: SuperplaneComponentsNode[] = [
+  { id: "a", name: "Webhook Trigger" },
+  { id: "b", name: "Call Target API" },
+  { id: "c", name: "Check API Result" },
+  { id: "d", name: "Notify Success" },
+  { id: "e", name: "Notify Failure" },
+  { id: "f" },
+];
+
+describe("getConfigSummary", () => {
+  it("returns a one-line http summary", () => {
+    expect(getConfigSummary("http", { method: "GET", url: "https://example.com" })).toBe("GET https://example.com");
+  });
+
+  it("returns null for unknown components or empty summaries", () => {
+    expect(getConfigSummary("unknown", { foo: "bar" })).toBeNull();
+    expect(getConfigSummary("if", { expression: "" })).toBeNull();
+    expect(getConfigSummary("http", undefined)).toBeNull();
+  });
+});
+
+describe("getNodeHoverMetadataItems", () => {
+  it("uses mapper metadata for integration components", () => {
+    expect(
+      getNodeHoverMetadataItems(
+        {
+          id: "gh-1",
+          name: "Create Issue",
+          type: "TYPE_ACTION",
+          component: "github.createIssue",
+          metadata: { repository: { name: "acme/widgets" } },
+        },
+        "github.createIssue",
+      ),
+    ).toEqual([{ icon: "book", label: "acme/widgets" }]);
+  });
+
+  it("uses trigger mapper metadata", () => {
+    expect(
+      getNodeHoverMetadataItems(
+        {
+          id: "gh-pr",
+          name: "On PR",
+          type: "TYPE_TRIGGER",
+          component: "github.onPullRequest",
+          metadata: { repository: { name: "acme/widgets" } },
+        },
+        "github.onPullRequest",
+      ),
+    ).toEqual([
+      { icon: "book", label: "acme/widgets" },
+      { icon: "funnel", label: "opened, synchronize" },
+    ]);
+  });
+
+  it("falls back to built-in summarizers when mapper metadata is empty", () => {
+    expect(
+      getNodeHoverMetadataItems(
+        {
+          id: "wait-1",
+          name: "Wait",
+          type: "TYPE_ACTION",
+          component: "wait",
+          configuration: { duration: "30" },
+        },
+        "wait",
+      ),
+    ).toEqual([{ icon: "info", label: "Wait: 30" }]);
+  });
+});
+
+describe("listNodeNeighbors", () => {
+  it("lists upstream then downstream with names", () => {
+    const result = listNodeNeighbors(
+      "b",
+      [
+        { sourceId: "a", targetId: "b" },
+        { sourceId: "b", targetId: "c" },
+      ],
+      nodes,
+    );
+
+    expect(result).toEqual({
+      items: [
+        { id: "a", label: "Webhook Trigger", direction: "upstream" },
+        { id: "c", label: "Check API Result", direction: "downstream" },
+      ],
+      overflow: 0,
+    });
+  });
+
+  it("dedupes repeated edges and falls back to id for unnamed nodes", () => {
+    const result = listNodeNeighbors(
+      "b",
+      [
+        { sourceId: "f", targetId: "b" },
+        { sourceId: "f", targetId: "b" },
+        { sourceId: "b", targetId: "c" },
+      ],
+      nodes,
+    );
+
+    expect(result.items).toEqual([
+      { id: "f", label: "f", direction: "upstream" },
+      { id: "c", label: "Check API Result", direction: "downstream" },
+    ]);
+  });
+
+  it("caps visible neighbors and reports overflow", () => {
+    const result = listNodeNeighbors(
+      "b",
+      [
+        { sourceId: "a", targetId: "b" },
+        { sourceId: "b", targetId: "c" },
+        { sourceId: "b", targetId: "d" },
+        { sourceId: "b", targetId: "e" },
+        { sourceId: "b", targetId: "f" },
+      ],
+      nodes,
+      4,
+    );
+
+    expect(result.items).toHaveLength(4);
+    expect(result.overflow).toBe(1);
+    expect(result.items.map((item) => item.id)).toEqual(["a", "c", "d", "e"]);
+  });
+
+  it("returns an empty list when there are no edges", () => {
+    expect(listNodeNeighbors("b", [], nodes)).toEqual({ items: [], overflow: 0 });
+    expect(listNodeNeighbors(undefined, [{ sourceId: "a", targetId: "b" }], nodes)).toEqual({
+      items: [],
+      overflow: 0,
+    });
+  });
+});

--- a/web_src/src/components/AgentSidebar/widgets/nodeChipHover.ts
+++ b/web_src/src/components/AgentSidebar/widgets/nodeChipHover.ts
@@ -1,0 +1,154 @@
+import type { CanvasesCanvas, SuperplaneComponentsNode } from "@/api-client";
+import type { MetadataItem } from "@/ui/metadataList";
+import { getComponentBaseMapper, getTriggerRenderer } from "@/pages/app/mappers";
+import { buildComponentDefinition, buildNodeInfo } from "@/pages/app/utils";
+
+type CanvasEdge = NonNullable<NonNullable<CanvasesCanvas["spec"]>["edges"]>[number];
+
+export type NodeNeighbor = {
+  id: string;
+  label: string;
+  direction: "upstream" | "downstream";
+};
+
+export type NodeNeighborList = {
+  items: NodeNeighbor[];
+  overflow: number;
+};
+
+const CONFIG_SUMMARIZERS: Record<string, (config: Record<string, unknown>) => string> = {
+  http: (c) => `${c.method || "GET"} ${c.url || ""}`.trim(),
+  ssh: (c) => `${c.username || "root"}@${c.host || ""}`.trim(),
+  if: (c) => String(c.expression || "").trim(),
+  filter: (c) => String(c.expression || "").trim(),
+  wait: (c) => {
+    const value = c.duration || c.waitFor || "";
+    return value ? `Wait: ${value}` : "";
+  },
+  webhook: (c) => `Auth: ${c.authentication || "none"}`,
+  schedule: (c) => {
+    const cron = c.cron || "";
+    return cron ? `Cron: ${cron}` : "";
+  },
+  approval: (c) => String(c.message || "Approval required").trim(),
+};
+
+export function getConfigSummary(component?: string, config?: Record<string, unknown>): string | null {
+  if (!component || !config) return null;
+  const summarizer = CONFIG_SUMMARIZERS[component];
+  if (!summarizer) return null;
+  const summary = summarizer(config);
+  return summary || null;
+}
+
+function isTriggerNode(node: SuperplaneComponentsNode): boolean {
+  return node.type === "TYPE_TRIGGER";
+}
+
+function fallbackMetadataItems(component: string | undefined, configuration: unknown): MetadataItem[] {
+  const summary = getConfigSummary(
+    component,
+    configuration && typeof configuration === "object" ? (configuration as Record<string, unknown>) : undefined,
+  );
+  if (!summary) return [];
+  return [{ icon: "info", label: summary }];
+}
+
+/**
+ * Same secondary details the canvas node card shows (repo, channel, URL, …),
+ * via the component/trigger mapper registry. Falls back to built-in one-line
+ * summarizers when the mapper returns no metadata.
+ */
+export function getNodeHoverMetadataItems(node: SuperplaneComponentsNode, component?: string): MetadataItem[] {
+  const componentName = component || node.component || "";
+  const nodeInfo = buildNodeInfo(node);
+  const definition = buildComponentDefinition({ name: componentName });
+
+  try {
+    if (isTriggerNode(node)) {
+      const props = getTriggerRenderer(componentName).getTriggerProps({
+        node: nodeInfo,
+        definition,
+        lastEvent: undefined,
+        canvasMode: "live",
+      });
+      if (props.metadata?.length) {
+        return props.metadata;
+      }
+    } else {
+      const props = getComponentBaseMapper(componentName).props({
+        nodes: [nodeInfo],
+        node: nodeInfo,
+        componentDefinition: definition,
+        lastExecutions: [],
+        currentUser: undefined,
+        actions: {
+          invokeNodeExecutionHook: async () => undefined,
+        },
+        canvasMode: "live",
+      });
+      if (props.metadata?.length) {
+        return props.metadata;
+      }
+    }
+  } catch (error) {
+    // Hover cards must not crash on mapper failures; fall through to summarizers.
+    if (import.meta.env.DEV) {
+      console.warn(`Failed to resolve hover metadata for ${componentName}`, error);
+    }
+  }
+
+  return fallbackMetadataItems(componentName, node.configuration);
+}
+
+function nodeLabel(nodesById: Map<string, SuperplaneComponentsNode>, id: string): string {
+  const node = nodesById.get(id);
+  return node?.name || id;
+}
+
+/** Upstream neighbors first, then downstream. Caps visible items and reports overflow. */
+export function listNodeNeighbors(
+  nodeId: string | undefined,
+  edges: CanvasEdge[] | undefined,
+  nodes: SuperplaneComponentsNode[] | undefined,
+  maxVisible = 4,
+): NodeNeighborList {
+  if (!nodeId || !edges?.length) {
+    return { items: [], overflow: 0 };
+  }
+
+  const nodesById = new Map((nodes ?? []).filter((node) => node.id).map((node) => [node.id!, node]));
+  const upstream: NodeNeighbor[] = [];
+  const downstream: NodeNeighbor[] = [];
+  const seenUpstream = new Set<string>();
+  const seenDownstream = new Set<string>();
+
+  for (const edge of edges) {
+    if (edge.targetId === nodeId && edge.sourceId && !seenUpstream.has(edge.sourceId)) {
+      seenUpstream.add(edge.sourceId);
+      upstream.push({
+        id: edge.sourceId,
+        label: nodeLabel(nodesById, edge.sourceId),
+        direction: "upstream",
+      });
+    }
+    if (edge.sourceId === nodeId && edge.targetId && !seenDownstream.has(edge.targetId)) {
+      seenDownstream.add(edge.targetId);
+      downstream.push({
+        id: edge.targetId,
+        label: nodeLabel(nodesById, edge.targetId),
+        direction: "downstream",
+      });
+    }
+  }
+
+  const all = [...upstream, ...downstream];
+  if (all.length <= maxVisible) {
+    return { items: all, overflow: 0 };
+  }
+
+  return {
+    items: all.slice(0, maxVisible),
+    overflow: all.length - maxVisible,
+  };
+}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -1649,8 +1649,6 @@ export function AppPage() {
 
   const [currentHistoryNode, setCurrentHistoryNode] = useState<{ nodeId: string; nodeType: string } | null>(null);
   const [focusRequest, setFocusRequest] = useState<CanvasFocusRequest | null>(null);
-  const focusTargetModeRef = useRef<"live" | "runs">("live");
-  useAgentNodeFocusRequest(setFocusRequest, focusTargetModeRef);
   const handleSidebarChange = useCallback(
     (open: boolean, nodeId: string | null) => {
       // Use the functional updater so this composes with other concurrent
@@ -3396,7 +3394,7 @@ export function AppPage() {
   );
 
   const runInspectionChromeActive = isRunInspectionMode && !editSessionActive && !isEnteringEditSession;
-  focusTargetModeRef.current = runInspectionChromeActive ? "runs" : "live";
+  useAgentNodeFocusRequest(setFocusRequest, runInspectionChromeActive);
   const runParticipantFit = useRunParticipantFitRequest({
     isRunInspectionMode: runInspectionChromeActive,
     selectedRunId,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -123,6 +123,7 @@ import { useDraftVisualDiff } from "./useDraftVisualDiff";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
 import { useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
 import { useRunParticipantFitRequest } from "./useRunParticipantFitRequest";
+import { useAgentNodeFocusRequest } from "./useAgentNodeFocusRequest";
 import { isRunDetailDismissed, useRunsDetailState } from "./useRunsDetailState";
 import { useComponentIconMap } from "./useComponentIconMap";
 import { useRunSidebarNavigationState } from "./useRunSidebarNavigationState";
@@ -1653,6 +1654,7 @@ export function AppPage() {
     targetMode: "live" | "runs";
     tab?: "latest" | "settings";
   } | null>(null);
+  useAgentNodeFocusRequest(setFocusRequest);
   const handleSidebarChange = useCallback(
     (open: boolean, nodeId: string | null) => {
       // Use the functional updater so this composes with other concurrent

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -1649,7 +1649,8 @@ export function AppPage() {
 
   const [currentHistoryNode, setCurrentHistoryNode] = useState<{ nodeId: string; nodeType: string } | null>(null);
   const [focusRequest, setFocusRequest] = useState<CanvasFocusRequest | null>(null);
-  useAgentNodeFocusRequest(setFocusRequest);
+  const focusTargetModeRef = useRef<"live" | "runs">("live");
+  useAgentNodeFocusRequest(setFocusRequest, focusTargetModeRef);
   const handleSidebarChange = useCallback(
     (open: boolean, nodeId: string | null) => {
       // Use the functional updater so this composes with other concurrent
@@ -3395,6 +3396,7 @@ export function AppPage() {
   );
 
   const runInspectionChromeActive = isRunInspectionMode && !editSessionActive && !isEnteringEditSession;
+  focusTargetModeRef.current = runInspectionChromeActive ? "runs" : "live";
   const runParticipantFit = useRunParticipantFitRequest({
     isRunInspectionMode: runInspectionChromeActive,
     selectedRunId,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -123,7 +123,7 @@ import { useDraftVisualDiff } from "./useDraftVisualDiff";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
 import { useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
 import { useRunParticipantFitRequest } from "./useRunParticipantFitRequest";
-import { useAgentNodeFocusRequest } from "./useAgentNodeFocusRequest";
+import { useAgentNodeFocusRequest, type CanvasFocusRequest } from "./useAgentNodeFocusRequest";
 import { isRunDetailDismissed, useRunsDetailState } from "./useRunsDetailState";
 import { useComponentIconMap } from "./useComponentIconMap";
 import { useRunSidebarNavigationState } from "./useRunSidebarNavigationState";
@@ -1648,12 +1648,7 @@ export function AppPage() {
   });
 
   const [currentHistoryNode, setCurrentHistoryNode] = useState<{ nodeId: string; nodeType: string } | null>(null);
-  const [focusRequest, setFocusRequest] = useState<{
-    nodeId: string;
-    requestId: number;
-    targetMode: "live" | "runs";
-    tab?: "latest" | "settings";
-  } | null>(null);
+  const [focusRequest, setFocusRequest] = useState<CanvasFocusRequest | null>(null);
   useAgentNodeFocusRequest(setFocusRequest);
   const handleSidebarChange = useCallback(
     (open: boolean, nodeId: string | null) => {

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.spec.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.spec.ts
@@ -5,7 +5,8 @@ import { useAgentNodeFocusRequest, type CanvasFocusRequest } from "./useAgentNod
 describe("useAgentNodeFocusRequest", () => {
   it("turns agent:focus-node into a live canvas focus request", () => {
     const setFocusRequest = vi.fn<(request: CanvasFocusRequest) => void>();
-    renderHook(() => useAgentNodeFocusRequest(setFocusRequest));
+    const targetModeRef = { current: "live" as const };
+    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, targetModeRef));
 
     act(() => {
       window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: { nodeId: "http-fetch-abc123" } }));
@@ -22,9 +23,28 @@ describe("useAgentNodeFocusRequest", () => {
     expect(setFocusRequest.mock.calls[0][0].requestId).toEqual(expect.any(Number));
   });
 
+  it("targets the run canvas while run inspection is active", () => {
+    const setFocusRequest = vi.fn<(request: CanvasFocusRequest) => void>();
+    const targetModeRef = { current: "runs" as const };
+    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, targetModeRef));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: { nodeId: "http-fetch-abc123" } }));
+    });
+
+    expect(setFocusRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "http-fetch-abc123",
+        targetMode: "runs",
+      }),
+    );
+    expect(setFocusRequest.mock.calls[0][0].tab).toBeUndefined();
+  });
+
   it("ignores events without a node id", () => {
     const setFocusRequest = vi.fn<(request: CanvasFocusRequest) => void>();
-    renderHook(() => useAgentNodeFocusRequest(setFocusRequest));
+    const targetModeRef = { current: "live" as const };
+    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, targetModeRef));
 
     act(() => {
       window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: {} }));

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.spec.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.spec.ts
@@ -5,8 +5,7 @@ import { useAgentNodeFocusRequest, type CanvasFocusRequest } from "./useAgentNod
 describe("useAgentNodeFocusRequest", () => {
   it("turns agent:focus-node into a live canvas focus request", () => {
     const setFocusRequest = vi.fn<(request: CanvasFocusRequest) => void>();
-    const targetModeRef = { current: "live" as const };
-    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, targetModeRef));
+    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, false));
 
     act(() => {
       window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: { nodeId: "http-fetch-abc123" } }));
@@ -25,8 +24,7 @@ describe("useAgentNodeFocusRequest", () => {
 
   it("targets the run canvas while run inspection is active", () => {
     const setFocusRequest = vi.fn<(request: CanvasFocusRequest) => void>();
-    const targetModeRef = { current: "runs" as const };
-    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, targetModeRef));
+    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, true));
 
     act(() => {
       window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: { nodeId: "http-fetch-abc123" } }));
@@ -43,8 +41,7 @@ describe("useAgentNodeFocusRequest", () => {
 
   it("ignores events without a node id", () => {
     const setFocusRequest = vi.fn<(request: CanvasFocusRequest) => void>();
-    const targetModeRef = { current: "live" as const };
-    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, targetModeRef));
+    renderHook(() => useAgentNodeFocusRequest(setFocusRequest, false));
 
     act(() => {
       window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: {} }));

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.spec.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.spec.ts
@@ -1,10 +1,10 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { useAgentNodeFocusRequest, type AgentNodeFocusRequest } from "./useAgentNodeFocusRequest";
+import { useAgentNodeFocusRequest, type CanvasFocusRequest } from "./useAgentNodeFocusRequest";
 
 describe("useAgentNodeFocusRequest", () => {
   it("turns agent:focus-node into a live canvas focus request", () => {
-    const setFocusRequest = vi.fn<(request: AgentNodeFocusRequest) => void>();
+    const setFocusRequest = vi.fn<(request: CanvasFocusRequest) => void>();
     renderHook(() => useAgentNodeFocusRequest(setFocusRequest));
 
     act(() => {
@@ -23,7 +23,7 @@ describe("useAgentNodeFocusRequest", () => {
   });
 
   it("ignores events without a node id", () => {
-    const setFocusRequest = vi.fn<(request: AgentNodeFocusRequest) => void>();
+    const setFocusRequest = vi.fn<(request: CanvasFocusRequest) => void>();
     renderHook(() => useAgentNodeFocusRequest(setFocusRequest));
 
     act(() => {

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.spec.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.spec.ts
@@ -1,0 +1,35 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAgentNodeFocusRequest, type AgentNodeFocusRequest } from "./useAgentNodeFocusRequest";
+
+describe("useAgentNodeFocusRequest", () => {
+  it("turns agent:focus-node into a live canvas focus request", () => {
+    const setFocusRequest = vi.fn<(request: AgentNodeFocusRequest) => void>();
+    renderHook(() => useAgentNodeFocusRequest(setFocusRequest));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: { nodeId: "http-fetch-abc123" } }));
+    });
+
+    expect(setFocusRequest).toHaveBeenCalledTimes(1);
+    expect(setFocusRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "http-fetch-abc123",
+        targetMode: "live",
+        tab: "settings",
+      }),
+    );
+    expect(setFocusRequest.mock.calls[0][0].requestId).toEqual(expect.any(Number));
+  });
+
+  it("ignores events without a node id", () => {
+    const setFocusRequest = vi.fn<(request: AgentNodeFocusRequest) => void>();
+    renderHook(() => useAgentNodeFocusRequest(setFocusRequest));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: {} }));
+    });
+
+    expect(setFocusRequest).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+
+export type AgentNodeFocusRequest = {
+  nodeId: string;
+  requestId: number;
+  targetMode: "live";
+  tab: "settings";
+};
+
+type FocusRequestSetter = (request: {
+  nodeId: string;
+  requestId: number;
+  targetMode: "live" | "runs";
+  tab?: "latest" | "settings";
+}) => void;
+
+/**
+ * Persists node-chip focus across canvas remounts (e.g. leaving Files mode, which
+ * unmounts ReactFlow). Node chips dispatch `agent:focus-node`; AppPage owns that
+ * event and converts it to `focusRequest`. CanvasContent applies `focusRequest`
+ * only — it does not listen for the event directly.
+ */
+export function useAgentNodeFocusRequest(setFocusRequest: FocusRequestSetter): void {
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const nodeId = (event as CustomEvent<{ nodeId?: string }>).detail?.nodeId;
+      if (!nodeId) {
+        return;
+      }
+
+      setFocusRequest({
+        nodeId,
+        requestId: Date.now(),
+        targetMode: "live",
+        tab: "settings",
+      });
+    };
+
+    window.addEventListener("agent:focus-node", handler);
+    return () => window.removeEventListener("agent:focus-node", handler);
+  }, [setFocusRequest]);
+}

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.ts
@@ -1,4 +1,4 @@
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef } from "react";
 
 /** Focus payload AppPage stores and CanvasContent applies. */
 export type CanvasFocusRequest = {
@@ -16,13 +16,16 @@ type FocusRequestSetter = (request: CanvasFocusRequest) => void;
  * event and converts it to `focusRequest`. CanvasContent applies `focusRequest`
  * only — it does not listen for the event directly.
  *
- * `targetModeRef` must track the canvas currently mounted (live vs run inspection),
- * matching CanvasContent's `isRunInspectionMode` gate.
+ * Pass the same run-inspection flag CanvasContent uses so chips focus the
+ * currently mounted canvas (live vs runs).
  */
 export function useAgentNodeFocusRequest(
   setFocusRequest: FocusRequestSetter,
-  targetModeRef: RefObject<"live" | "runs">,
+  isRunInspectionMode: boolean,
 ): void {
+  const targetModeRef = useRef<"live" | "runs">("live");
+  targetModeRef.current = isRunInspectionMode ? "runs" : "live";
+
   useEffect(() => {
     const handler = (event: Event) => {
       const nodeId = (event as CustomEvent<{ nodeId?: string }>).detail?.nodeId;
@@ -30,7 +33,7 @@ export function useAgentNodeFocusRequest(
         return;
       }
 
-      const targetMode = targetModeRef.current ?? "live";
+      const targetMode = targetModeRef.current;
       setFocusRequest({
         nodeId,
         requestId: Date.now(),
@@ -41,5 +44,5 @@ export function useAgentNodeFocusRequest(
 
     window.addEventListener("agent:focus-node", handler);
     return () => window.removeEventListener("agent:focus-node", handler);
-  }, [setFocusRequest, targetModeRef]);
+  }, [setFocusRequest]);
 }

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.ts
@@ -19,10 +19,7 @@ type FocusRequestSetter = (request: CanvasFocusRequest) => void;
  * Pass the same run-inspection flag CanvasContent uses so chips focus the
  * currently mounted canvas (live vs runs).
  */
-export function useAgentNodeFocusRequest(
-  setFocusRequest: FocusRequestSetter,
-  isRunInspectionMode: boolean,
-): void {
+export function useAgentNodeFocusRequest(setFocusRequest: FocusRequestSetter, isRunInspectionMode: boolean): void {
   const targetModeRef = useRef<"live" | "runs">("live");
   targetModeRef.current = isRunInspectionMode ? "runs" : "live";
 

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.ts
@@ -1,5 +1,14 @@
 import { useEffect } from "react";
 
+/** Focus payload AppPage stores and CanvasContent applies. */
+export type CanvasFocusRequest = {
+  nodeId: string;
+  requestId: number;
+  targetMode: "live" | "runs";
+  tab?: "latest" | "settings";
+};
+
+/** Payload produced by `agent:focus-node` (always live settings). */
 export type AgentNodeFocusRequest = {
   nodeId: string;
   requestId: number;
@@ -7,12 +16,7 @@ export type AgentNodeFocusRequest = {
   tab: "settings";
 };
 
-type FocusRequestSetter = (request: {
-  nodeId: string;
-  requestId: number;
-  targetMode: "live" | "runs";
-  tab?: "latest" | "settings";
-}) => void;
+type FocusRequestSetter = (request: CanvasFocusRequest) => void;
 
 /**
  * Persists node-chip focus across canvas remounts (e.g. leaving Files mode, which

--- a/web_src/src/pages/app/useAgentNodeFocusRequest.ts
+++ b/web_src/src/pages/app/useAgentNodeFocusRequest.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, type RefObject } from "react";
 
 /** Focus payload AppPage stores and CanvasContent applies. */
 export type CanvasFocusRequest = {
@@ -8,14 +8,6 @@ export type CanvasFocusRequest = {
   tab?: "latest" | "settings";
 };
 
-/** Payload produced by `agent:focus-node` (always live settings). */
-export type AgentNodeFocusRequest = {
-  nodeId: string;
-  requestId: number;
-  targetMode: "live";
-  tab: "settings";
-};
-
 type FocusRequestSetter = (request: CanvasFocusRequest) => void;
 
 /**
@@ -23,8 +15,14 @@ type FocusRequestSetter = (request: CanvasFocusRequest) => void;
  * unmounts ReactFlow). Node chips dispatch `agent:focus-node`; AppPage owns that
  * event and converts it to `focusRequest`. CanvasContent applies `focusRequest`
  * only — it does not listen for the event directly.
+ *
+ * `targetModeRef` must track the canvas currently mounted (live vs run inspection),
+ * matching CanvasContent's `isRunInspectionMode` gate.
  */
-export function useAgentNodeFocusRequest(setFocusRequest: FocusRequestSetter): void {
+export function useAgentNodeFocusRequest(
+  setFocusRequest: FocusRequestSetter,
+  targetModeRef: RefObject<"live" | "runs">,
+): void {
   useEffect(() => {
     const handler = (event: Event) => {
       const nodeId = (event as CustomEvent<{ nodeId?: string }>).detail?.nodeId;
@@ -32,15 +30,16 @@ export function useAgentNodeFocusRequest(setFocusRequest: FocusRequestSetter): v
         return;
       }
 
+      const targetMode = targetModeRef.current ?? "live";
       setFocusRequest({
         nodeId,
         requestId: Date.now(),
-        targetMode: "live",
-        tab: "settings",
+        targetMode,
+        ...(targetMode === "live" ? { tab: "settings" as const } : {}),
       });
     };
 
     window.addEventListener("agent:focus-node", handler);
     return () => window.removeEventListener("agent:focus-node", handler);
-  }, [setFocusRequest]);
+  }, [setFocusRequest, targetModeRef]);
 }

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -823,4 +823,61 @@ describe("CanvasPage fit-to-view on canvas/version switch", () => {
     expect(fitViewMock).toHaveBeenCalledTimes(1);
     expect(setViewport).toHaveBeenCalled();
   });
+
+  it("applies a live focus request after leaving files mode remounts ReactFlow", async () => {
+    // Files mode replaces ReactFlow with a backdrop, so agent:focus-node cannot
+    // reach CanvasContent. focusRequest on AppPage must survive the remount.
+    const focusNode = {
+      id: "node-1",
+      position: { x: 0, y: 0 },
+      data: { label: "Node 1", type: "component" },
+    };
+    getNodesMock.mockReturnValue([focusNode]);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="files"
+          nodes={[focusNode]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="v1"
+          focusRequest={{ nodeId: "node-1", requestId: 42, targetMode: "live", tab: "settings" }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("canvas-files-backdrop")).toBeInTheDocument();
+    expect(reactFlowPropsRef.current).toBeNull();
+
+    rerender(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={[focusNode]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="v1"
+          focusRequest={{ nodeId: "node-1", requestId: 42, targetMode: "live", tab: "settings" }}
+        />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+    });
+
+    await waitFor(() => {
+      expect(fitViewMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodes: [focusNode],
+          duration: 500,
+        }),
+      );
+    });
+  });
 });

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2607,20 +2607,6 @@ function CanvasContent({
     });
   }, [isRunInspectionMode, runSelectedNodeId, runCanvasNodeIdsKey]);
 
-  // Listen for agent sidebar node chip clicks to zoom to nodes
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const nodeId = (e as CustomEvent).detail?.nodeId;
-      if (!nodeId) return;
-      const targetNode = stateRef.current.nodes?.find((n) => n.id === nodeId);
-      if (!targetNode) return;
-      stateRef.current.setNodes((nodes) => nodes.map((n) => ({ ...n, selected: n.id === nodeId })));
-      fitView({ nodes: [targetNode], duration: 500, ...CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS });
-    };
-    window.addEventListener("agent:focus-node", handler);
-    return () => window.removeEventListener("agent:focus-node", handler);
-  }, [fitView]);
-
   useEffect(() => {
     return () => {
       if (suppressNextPaneClickTimeoutRef.current !== null && typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- Persist `node:` chip focus via AppPage `focusRequest` so selection survives Files remounts (ReactFlow is unmounted in Files mode)
- Redesign node-chip hover cards with canvas-aligned mapper metadata, named neighbors, and clearer header styling
- Own `agent:focus-node` in AppPage only (CanvasContent applies `focusRequest`)

Split from #6030 for a focused review.

## Test plan
- [ ] From Files markdown, click a `node:` chip → Live Canvas selects and fits the node
- [ ] From Console markdown, same chip focus still works
- [ ] Hover card shows Details (e.g. GitHub repo), Connected to neighbors, and open hint
- [ ] `npx vitest run src/pages/app/useAgentNodeFocusRequest.spec.ts src/components/AgentSidebar/widgets/nodeChipHover.spec.ts src/ui/CanvasPage/index.spec.tsx` passes