### PR TITLE
fix: replace markdown section presets with SuperPlane set

### DIFF
--- a/web_src/src/pages/app/Markdown.spec.tsx
+++ b/web_src/src/pages/app/Markdown.spec.tsx
@@ -196,6 +196,12 @@ describe("MarkdownContent", () => {
     expect(section).toHaveTextContent("~9,202");
   });
 
+  it("applies the integrations section preset", () => {
+    render(<MarkdownContent content={"> [!SECTION:integrations] Connected integrations\n> Body copy."} />);
+
+    expect(screen.getByTestId("markdown-section")).toHaveAttribute("data-section-preset", "integrations");
+  });
+
   it("shows a count of direct nested sections beside the title", () => {
     render(
       <MarkdownContent

--- a/web_src/src/pages/app/Markdown.spec.tsx
+++ b/web_src/src/pages/app/Markdown.spec.tsx
@@ -188,32 +188,34 @@ describe("MarkdownContent", () => {
   });
 
   it("applies named section presets for icon and accent color", () => {
-    render(<MarkdownContent content={"> [!SECTION:tools] Tool definitions · ~9,202\n> Body copy."} />);
+    render(<MarkdownContent content={"> [!SECTION:runbook] Deploy checklist · prod\n> Body copy."} />);
 
     const section = screen.getByTestId("markdown-section");
-    expect(section).toHaveAttribute("data-section-preset", "tools");
-    expect(section).toHaveTextContent("Tool definitions");
-    expect(section).toHaveTextContent("~9,202");
+    expect(section).toHaveAttribute("data-section-preset", "runbook");
+    expect(section).toHaveTextContent("Deploy checklist");
+    expect(section).toHaveTextContent("prod");
   });
 
-  it("applies the integrations section preset", () => {
-    render(<MarkdownContent content={"> [!SECTION:integrations] Connected integrations\n> Body copy."} />);
+  it("applies the agent and run section presets", () => {
+    const { rerender } = render(<MarkdownContent content={"> [!SECTION:agent] Agent notes\n> Body copy."} />);
+    expect(screen.getByTestId("markdown-section")).toHaveAttribute("data-section-preset", "agent");
 
-    expect(screen.getByTestId("markdown-section")).toHaveAttribute("data-section-preset", "integrations");
+    rerender(<MarkdownContent content={"> [!SECTION:run] Promote · prod\n> Body copy."} />);
+    expect(screen.getByTestId("markdown-section")).toHaveAttribute("data-section-preset", "run");
   });
 
   it("shows a count of direct nested sections beside the title", () => {
     render(
       <MarkdownContent
         content={
-          "> [!SECTION:rules] Rules · ~5,366\n> Intro.\n>\n> > [!SECTION:folder] Project Rules\n> > One.\n>\n> > [!SECTION:folder] Cursor & User Rules\n> > Two."
+          "> [!SECTION:runbook] Score a PR · on-call\n> Intro.\n>\n> > [!SECTION:group] Analysis\n> > One.\n>\n> > [!SECTION:group] Reporting\n> > Two."
         }
       />,
     );
 
     const section = screen.getByTestId("markdown-section");
     expect(section).toHaveAttribute("data-section-count", "2");
-    expect(section).toHaveTextContent("Rules");
+    expect(section).toHaveTextContent("Score a PR");
     expect(section).toHaveTextContent("2");
   });
 

--- a/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
@@ -26,7 +26,7 @@ Storybook fixture for the **Files** tab and Console markdown panel.
 
 ## Sections
 
-Presets pick icon + accent: `tools`, `rules`, `skills`, `mcp`, `folder`.
+Presets pick icon + accent: `tools`, `rules`, `skills`, `integrations`, `folder`.
 Trailing meta after ` · ` is optional. Nested sections show a count on the parent.
 
 > [!SECTION:tools] Tool definitions · ~9,202
@@ -46,8 +46,8 @@ Trailing meta after ` · ` is optional. Nested sections show a count on the pare
 > [!SECTION:skills] Scoring
 > The agent checks out the PR, runs metric tooling, and posts a self-updating comment.
 
-> [!SECTION:mcp] MCP servers · 3
-> Connected tools the agent can call through Model Context Protocol.
+> [!SECTION:integrations] Connected integrations · GitHub, Slack
+> Wire org integrations into nodes with `[GitHub](integration:github)` chips.
 
 ## Code
 

--- a/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
@@ -26,25 +26,36 @@ Storybook fixture for the **Files** tab and Console markdown panel.
 
 ## Sections
 
-Presets pick icon + accent: `tools`, `rules`, `skills`, `integrations`, `folder`.
-Trailing meta after ` · ` is optional. Nested sections show a count on the parent.
+Presets pick icon + accent: `overview`, `setup`, `runbook`, `run`, `troubleshoot`,
+`agent`, `integrations`, `group`. Trailing meta after ` · ` is optional. Nested
+sections show a count on the parent.
 
-> [!SECTION:tools] Tool definitions · ~9,202
-> Descriptions of tools the agent can call.
+> [!SECTION:overview] Clean Code Assessment
+> Scores pull requests for maintainability and posts a self-updating comment.
 
-> [!SECTION:rules] Rules · ~5,366
-> Standing instructions the agent follows each turn. Keep them focused and lightweight.
+> [!SECTION:setup] Prerequisites
+> Connect `[GitHub](integration:github)` and `[Cursor](integration:cursor)` before the first run.
+
+> [!SECTION:runbook] Score a pull request · on-call
+> Trigger from a PR event, wait for analysis, then review the posted comment.
 >
 > Nested markdown still works: [docs](https://docs.superplane.com) and `inline code`.
 >
-> > [!SECTION:folder] Project Rules · ~2,752
-> > Project-local guidance from `AGENTS.md` and related files.
+> > [!SECTION:group] Analysis
+> > `[Analyze PR](node:analyze-pr)` runs the scoring pass.
 >
-> > [!SECTION:rules] Cursor & User Rules · ~2,522
-> > Personal and Cursor-level standing instructions.
+> > [!SECTION:group] Reporting
+> > `[Post Assessment](node:post-assessment)` updates the PR comment.
 
-> [!SECTION:skills] Scoring
-> The agent checks out the PR, runs metric tooling, and posts a self-updating comment.
+> [!SECTION:run] Promote after green canary · prod
+> 1. Confirm health checks passed.
+> 2. Promote with the deploy node on the canvas.
+
+> [!SECTION:troubleshoot] Analysis stuck
+> Re-run `[Analyze PR](node:analyze-pr)` if the Cursor job times out.
+
+> [!SECTION:agent] Agent notes
+> Prefer `node:` chips when linking canvas steps. Keep standing instructions short.
 
 > [!SECTION:integrations] Connected integrations · GitHub, Slack
 > Wire org integrations into nodes with `[GitHub](integration:github)` chips.

--- a/web_src/src/pages/app/markdownSectionParse.ts
+++ b/web_src/src/pages/app/markdownSectionParse.ts
@@ -16,7 +16,7 @@ export type ParsedMarkdownSection = {
  * return the title/preset/body with the marker line removed.
  *
  * Optional trailing meta after a middle-dot separator:
- * `> [!SECTION:rules] Rules · ~5,366`
+ * `> [!SECTION:runbook] Deploy checklist · prod`
  */
 export function parseGithubSectionChildren(children: ReactNode): ParsedMarkdownSection | null {
   const split = splitBlockquoteMarkerLine(children);

--- a/web_src/src/pages/app/markdownSectionPresets.ts
+++ b/web_src/src/pages/app/markdownSectionPresets.ts
@@ -1,7 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import { Folder, List, Plug, Sparkles, Wrench } from "lucide-react";
 
-export const MARKDOWN_SECTION_PRESET_IDS = ["tools", "rules", "skills", "mcp", "folder"] as const;
+export const MARKDOWN_SECTION_PRESET_IDS = ["tools", "rules", "skills", "integrations", "folder"] as const;
 
 export type MarkdownSectionPresetId = (typeof MARKDOWN_SECTION_PRESET_IDS)[number];
 
@@ -37,8 +37,8 @@ export const MARKDOWN_SECTION_PRESETS: Record<MarkdownSectionPresetId, MarkdownS
     iconClassName: "text-cyan-600 dark:text-cyan-400",
     barClassName: "bg-cyan-100/70 dark:bg-cyan-950/40",
   },
-  mcp: {
-    id: "mcp",
+  integrations: {
+    id: "integrations",
     Icon: Plug,
     iconClassName: "text-sky-600 dark:text-sky-400",
     barClassName: "bg-sky-100/70 dark:bg-sky-950/40",

--- a/web_src/src/pages/app/markdownSectionPresets.ts
+++ b/web_src/src/pages/app/markdownSectionPresets.ts
@@ -1,7 +1,16 @@
 import type { LucideIcon } from "lucide-react";
-import { Folder, List, Plug, Sparkles, Wrench } from "lucide-react";
+import { BookOpen, Bot, Folder, LayoutDashboard, Plug, Rocket, Settings, Wrench } from "lucide-react";
 
-export const MARKDOWN_SECTION_PRESET_IDS = ["tools", "rules", "skills", "integrations", "folder"] as const;
+export const MARKDOWN_SECTION_PRESET_IDS = [
+  "overview",
+  "setup",
+  "runbook",
+  "run",
+  "troubleshoot",
+  "agent",
+  "integrations",
+  "group",
+] as const;
 
 export type MarkdownSectionPresetId = (typeof MARKDOWN_SECTION_PRESET_IDS)[number];
 
@@ -15,44 +24,62 @@ export type MarkdownSectionPreset = {
 };
 
 /**
- * Named presets authors can pick with `> [!SECTION:tools] Title`.
- * Colors follow the Context Usage category accents (purple tools, green rules, …).
+ * Named presets authors can pick with `> [!SECTION:runbook] Title`.
+ * Accents are chosen for SuperPlane README / console runbook authoring.
  */
 export const MARKDOWN_SECTION_PRESETS: Record<MarkdownSectionPresetId, MarkdownSectionPreset> = {
-  tools: {
-    id: "tools",
-    Icon: Wrench,
-    iconClassName: "text-violet-600 dark:text-violet-400",
-    barClassName: "bg-violet-100/80 dark:bg-violet-950/50",
+  overview: {
+    id: "overview",
+    Icon: LayoutDashboard,
+    iconClassName: "text-slate-600 dark:text-gray-300",
+    barClassName: "bg-slate-100/90 dark:bg-gray-800/80",
   },
-  rules: {
-    id: "rules",
-    Icon: List,
+  setup: {
+    id: "setup",
+    Icon: Settings,
+    iconClassName: "text-sky-600 dark:text-sky-400",
+    barClassName: "bg-sky-100/70 dark:bg-sky-950/40",
+  },
+  runbook: {
+    id: "runbook",
+    Icon: BookOpen,
     iconClassName: "text-emerald-600 dark:text-emerald-400",
     barClassName: "bg-emerald-100/70 dark:bg-emerald-950/40",
   },
-  skills: {
-    id: "skills",
-    Icon: Sparkles,
-    iconClassName: "text-cyan-600 dark:text-cyan-400",
-    barClassName: "bg-cyan-100/70 dark:bg-cyan-950/40",
+  run: {
+    id: "run",
+    Icon: Rocket,
+    iconClassName: "text-blue-600 dark:text-blue-400",
+    barClassName: "bg-blue-100/70 dark:bg-blue-950/40",
+  },
+  troubleshoot: {
+    id: "troubleshoot",
+    Icon: Wrench,
+    iconClassName: "text-amber-600 dark:text-amber-400",
+    barClassName: "bg-amber-100/70 dark:bg-amber-950/40",
+  },
+  agent: {
+    id: "agent",
+    Icon: Bot,
+    iconClassName: "text-violet-600 dark:text-violet-400",
+    barClassName: "bg-violet-100/80 dark:bg-violet-950/50",
   },
   integrations: {
     id: "integrations",
     Icon: Plug,
-    iconClassName: "text-sky-600 dark:text-sky-400",
-    barClassName: "bg-sky-100/70 dark:bg-sky-950/40",
+    iconClassName: "text-cyan-600 dark:text-cyan-400",
+    barClassName: "bg-cyan-100/70 dark:bg-cyan-950/40",
   },
-  folder: {
-    id: "folder",
+  group: {
+    id: "group",
     Icon: Folder,
     iconClassName: "text-slate-500 dark:text-gray-400",
-    barClassName: "bg-slate-100/90 dark:bg-gray-800/80",
+    barClassName: "bg-slate-100/70 dark:bg-gray-800/60",
   },
 };
 
-const DEFAULT_ROOT_PRESET = MARKDOWN_SECTION_PRESETS.rules;
-const DEFAULT_NESTED_PRESET = MARKDOWN_SECTION_PRESETS.folder;
+const DEFAULT_ROOT_PRESET = MARKDOWN_SECTION_PRESETS.runbook;
+const DEFAULT_NESTED_PRESET = MARKDOWN_SECTION_PRESETS.group;
 
 export function isMarkdownSectionPresetId(value: string): value is MarkdownSectionPresetId {
   return (MARKDOWN_SECTION_PRESET_IDS as readonly string[]).includes(value);


### PR DESCRIPTION
## Summary
- Replace Cursor-oriented presets (`tools` / `rules` / `skills` / `folder`) with SuperPlane runbook presets:
  - `overview`, `setup`, `runbook`, `run` (blue), `troubleshoot`, `agent` (violet), `integrations`, `group`
- Defaults: bare root → `runbook`, nested bare → `group`
- Update Storybook fixture + tests

## Test plan
- [x] `npx vitest run src/pages/app/Markdown.spec.tsx`
- [ ] Spot-check each `[!SECTION:<preset>]` accent in Files/Console markdown