### PR TITLE
feat: style markdown thematic breaks as dividers

### DIFF
--- a/web_src/src/pages/app/Markdown.spec.tsx
+++ b/web_src/src/pages/app/Markdown.spec.tsx
@@ -132,6 +132,8 @@ describe("MarkdownContent", () => {
     const divider = screen.getByTestId("markdown-divider");
     expect(divider.tagName).toBe("HR");
     expect(divider).toHaveAttribute("role", "separator");
+    expect(divider.className).toContain("border-t-2");
+    expect(divider.className).toContain("border-slate-300");
   });
 
   it.each([

--- a/web_src/src/pages/app/Markdown.spec.tsx
+++ b/web_src/src/pages/app/Markdown.spec.tsx
@@ -126,6 +126,14 @@ describe("MarkdownContent", () => {
     expect(screen.getByText("Failed").className).toContain("font-semibold");
   });
 
+  it("renders ___ as a horizontal divider", () => {
+    render(<MarkdownContent content={"Above\n\n___\n\nBelow"} />);
+
+    const divider = screen.getByTestId("markdown-divider");
+    expect(divider.tagName).toBe("HR");
+    expect(divider).toHaveAttribute("role", "separator");
+  });
+
   it.each([
     ["NOTE", "Note"],
     ["TIP", "Tip"],

--- a/web_src/src/pages/app/Markdown.tsx
+++ b/web_src/src/pages/app/Markdown.tsx
@@ -28,6 +28,9 @@ import {
   MARKDOWN_TABLE_HEAD_CLASSES,
 } from "./markdownTableStyles";
 
+/** Shared chrome for markdown thematic breaks (`___`, `---`, `***`). */
+export const MARKDOWN_DIVIDER_CLASSES = "my-4 border-0 border-t border-slate-200 dark:border-gray-700";
+
 /**
  * Tailwind class string shared by every full-document markdown renderer in the
  * app (Console panels and Files `.md` preview). We deliberately do not use the
@@ -165,6 +168,7 @@ export function MarkdownContent({
           blockquote: MarkdownBlockquote,
           code: MarkdownCodeWithDiagrams,
           pre: MarkdownPre,
+          hr: MarkdownDivider,
         }}
       >
         {normalized}
@@ -182,6 +186,10 @@ function MarkdownPre({ children, node, ...props }: ComponentProps<"pre"> & Extra
   }
 
   return <pre {...props}>{children}</pre>;
+}
+
+function MarkdownDivider(props: ComponentProps<"hr">) {
+  return <hr {...props} role="separator" data-testid="markdown-divider" className={MARKDOWN_DIVIDER_CLASSES} />;
 }
 
 function MarkdownCodeWithDiagrams({

--- a/web_src/src/pages/app/Markdown.tsx
+++ b/web_src/src/pages/app/Markdown.tsx
@@ -29,7 +29,8 @@ import {
 } from "./markdownTableStyles";
 
 /** Shared chrome for markdown thematic breaks (`___`, `---`, `***`). */
-export const MARKDOWN_DIVIDER_CLASSES = "my-4 border-0 border-t border-slate-200 dark:border-gray-700";
+export const MARKDOWN_DIVIDER_CLASSES =
+  "my-5 h-0 border-0 border-t-2 border-solid border-slate-300 dark:border-gray-600";
 
 /**
  * Tailwind class string shared by every full-document markdown renderer in the

--- a/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
@@ -24,6 +24,16 @@ Storybook fixture for the **Files** tab and Console markdown panel.
 > [!CAUTION]
 > Destructive actions in table row triggers cannot be undone.
 
+## Dividers
+
+A line of underscores becomes a horizontal rule between blocks:
+
+Above the divider.
+
+___
+
+Below the divider.
+
 ## Sections
 
 Presets pick icon + accent: `overview`, `setup`, `runbook`, `run`, `troubleshoot`,

--- a/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
+++ b/web_src/src/pages/app/__fixtures__/repository/cleanCodeAssessment.README.md
@@ -60,6 +60,8 @@ sections show a count on the parent.
 > [!SECTION:integrations] Connected integrations · GitHub, Slack
 > Wire org integrations into nodes with `[GitHub](integration:github)` chips.
 
+___
+
 ## Code
 
 ```yaml

--- a/web_src/src/pages/app/console/MarkdownPanelCard.stories.tsx
+++ b/web_src/src/pages/app/console/MarkdownPanelCard.stories.tsx
@@ -72,7 +72,10 @@ A quick reference for the **production** deploy flow.
 - Owner: _Platform team_
 - Rollback: revert + redeploy
 
-> Tip: keep an eye on the error rate panel after each deploy.
+___
+
+> [!TIP]
+> Keep an eye on the error rate panel after each deploy.
 
 \`\`\`bash
 make deploy ENV=prod

--- a/web_src/src/pages/app/console/__stories__/storyFixtures.ts
+++ b/web_src/src/pages/app/console/__stories__/storyFixtures.ts
@@ -271,6 +271,8 @@ You can also re-check from the **Recent checks** table using the row action.
 
 </details>
 
+___
+
 <details>
 <summary>How review works</summary>
 


### PR DESCRIPTION
## Summary
- Style markdown thematic breaks (`___`, also `---` / `***`) as a SuperPlane horizontal divider in console + Files markdown
- Add regression test and Storybook fixture example

## Test plan
- [x] `npx vitest run src/pages/app/Markdown.spec.tsx`
- [ ] Put `___` between two paragraphs in a console markdown widget / Files `.md` and confirm a divider renders