### PR TITLE
fix: normalize SSH script line endings

### DIFF
--- a/pkg/components/ssh/ssh.go
+++ b/pkg/components/ssh/ssh.go
@@ -579,9 +579,9 @@ func (c *SSHCommand) Execute(ctx core.ExecutionContext) error {
 }
 
 // loadCommandFile reads, size-limits, and validates the command file referenced
-// by rawPath, returning its content verbatim. It rejects empty or
-// whitespace-only files so both Setup (publish time) and Execute (run time)
-// agree on what counts as a runnable script.
+// by rawPath, returning its content with shell-safe line endings. It rejects
+// empty or whitespace-only files so both Setup (publish time) and Execute (run
+// time) agree on what counts as a runnable script.
 func loadCommandFile(files core.RepositoryFilesContext, rawPath string) (string, error) {
 	path := strings.TrimSpace(rawPath)
 	if path == "" {
@@ -610,7 +610,7 @@ func loadCommandFile(files core.RepositoryFilesContext, rawPath string) (string,
 	if strings.TrimSpace(string(data)) == "" {
 		return "", fmt.Errorf("command file %q is empty", path)
 	}
-	return string(data), nil
+	return normalizeScriptLineEndings(string(data)), nil
 }
 
 func (c *SSHCommand) HandleHook(ctx core.ActionHookContext) error {
@@ -864,10 +864,10 @@ func (c *SSHCommand) buildRemoteCommand(workingDirectory string, environment []E
 // File mode pipes the (already-loaded) script body to `bash -s` over stdin.
 // This avoids embedding the whole script in the command line — argv has size
 // limits and nested quoting is fragile — while preserving multi-line
-// constructs, comments, and bash-only features (pipefail, declare -A,
-// here-docs, process substitution) exactly as written. The stream is always
-// interpreted by bash, so any leading `#!` line is just a comment: non-bash
-// shebangs are not honored.
+// constructs, comments, and bash-only features (pipefail, declare -A, here-docs,
+// process substitution) except for normalizing CRLF/CR line endings to LF. The
+// stream is always interpreted by bash, so any leading `#!` line is just a
+// comment: non-bash shebangs are not honored.
 func (c *SSHCommand) buildExecutionCommand(metadata ExecutionMetadata, scriptBody string) (string, io.Reader, error) {
 	if metadata.CommandSource == CommandSourceFile {
 		if scriptBody == "" {
@@ -889,9 +889,9 @@ func (c *SSHCommand) buildExecutionCommand(metadata ExecutionMetadata, scriptBod
 // prepended on its own line (followed by `|| exit 1`) so a leading shebang or
 // comment in the script cannot swallow the `cd` via `#`-to-end-of-line.
 func (c *SSHCommand) buildScriptCommand(workingDirectory string, environment []EnvironmentVariable, script string) (string, string) {
-	payload := script
+	payload := normalizeScriptLineEndings(script)
 	if workingDirectory != "" {
-		payload = fmt.Sprintf("cd %s || exit 1\n%s", shellQuote(workingDirectory), script)
+		payload = fmt.Sprintf("cd %s || exit 1\n%s", shellQuote(workingDirectory), payload)
 	}
 
 	command := "bash -s"
@@ -958,7 +958,7 @@ func validateCommandSource(ctx core.SetupContext, spec Spec) error {
 }
 
 func buildCombinedCommands(commands string) string {
-	lines := strings.Split(commands, "\n")
+	lines := strings.Split(normalizeScriptLineEndings(commands), "\n")
 	parts := make([]string, 0, len(lines))
 	for _, line := range lines {
 		l := strings.TrimSpace(line)
@@ -971,6 +971,11 @@ func buildCombinedCommands(commands string) string {
 		return ""
 	}
 	return strings.Join(parts, " && ")
+}
+
+func normalizeScriptLineEndings(script string) string {
+	script = strings.ReplaceAll(script, "\r\n", "\n")
+	return strings.ReplaceAll(script, "\r", "\n")
 }
 
 func shellQuote(value string) string {

--- a/pkg/components/ssh/ssh_test.go
+++ b/pkg/components/ssh/ssh_test.go
@@ -476,6 +476,30 @@ func TestSSHCommand_Execute_FileMode(t *testing.T) {
 	})
 }
 
+func TestLoadCommandFile_NormalizesLineEndings(t *testing.T) {
+	t.Run("normalizes Windows CRLF line endings", func(t *testing.T) {
+		files := &fakeFilesContext{
+			files: map[string]string{"scripts/deploy.sh": "set -eo pipefail\r\nprintf ok\r\n"},
+		}
+
+		body, err := loadCommandFile(files, "scripts/deploy.sh")
+		require.NoError(t, err)
+		assert.Equal(t, "set -eo pipefail\nprintf ok\n", body)
+		assert.NotContains(t, body, "\r")
+	})
+
+	t.Run("normalizes lone carriage returns", func(t *testing.T) {
+		files := &fakeFilesContext{
+			files: map[string]string{"scripts/deploy.sh": "set -eo pipefail\rprintf ok\r"},
+		}
+
+		body, err := loadCommandFile(files, "scripts/deploy.sh")
+		require.NoError(t, err)
+		assert.Equal(t, "set -eo pipefail\nprintf ok\n", body)
+		assert.NotContains(t, body, "\r")
+	})
+}
+
 func TestSSHCommand_Execute_DoesNotPanicWithoutConnectionRetry(t *testing.T) {
 	c := &SSHCommand{}
 	metadata := &testMetadataContext{}
@@ -594,6 +618,18 @@ func TestBuildCombinedCommands(t *testing.T) {
 		assert.Equal(t, "echo 1 && echo 2", combined)
 	})
 
+	t.Run("normalizes CRLF input before joining lines", func(t *testing.T) {
+		combined := buildCombinedCommands("set -eo pipefail\r\necho ok\r\n")
+		assert.Equal(t, "set -eo pipefail && echo ok", combined)
+		assert.NotContains(t, combined, "\r")
+	})
+
+	t.Run("normalizes lone carriage returns before joining lines", func(t *testing.T) {
+		combined := buildCombinedCommands("set -eo pipefail\recho ok\r")
+		assert.Equal(t, "set -eo pipefail && echo ok", combined)
+		assert.NotContains(t, combined, "\r")
+	})
+
 	t.Run("empty input yields empty string", func(t *testing.T) {
 		combined := buildCombinedCommands("\n \n")
 		assert.Equal(t, "", combined)
@@ -636,6 +672,13 @@ func TestSSHCommand_BuildScriptCommand(t *testing.T) {
 		command, payload := c.buildScriptCommand("", nil, script)
 		assert.Equal(t, "bash -s", command)
 		assert.Equal(t, script, payload)
+	})
+
+	t.Run("normalizes CRLF scripts before streaming", func(t *testing.T) {
+		command, payload := c.buildScriptCommand("", nil, "set -eo pipefail\r\necho ok\r\n")
+		assert.Equal(t, "bash -s", command)
+		assert.Equal(t, "set -eo pipefail\necho ok\n", payload)
+		assert.NotContains(t, payload, "\r")
 	})
 
 	// Regression: a bash script with embedded `{{ ... }}` template syntax
@@ -697,6 +740,24 @@ func TestSSHCommand_BuildExecutionCommand(t *testing.T) {
 		body, readErr := io.ReadAll(stdin)
 		require.NoError(t, readErr)
 		assert.Equal(t, script, string(body))
+	})
+
+	t.Run("file mode normalizes CRLF before streaming stdin", func(t *testing.T) {
+		script := "set -eo pipefail\r\necho hi\r\n"
+		meta := ExecutionMetadata{
+			CommandSource: CommandSourceFile,
+			CommandFile:   "scripts/deploy.sh",
+		}
+
+		command, stdin, err := c.buildExecutionCommand(meta, script)
+		require.NoError(t, err)
+		assert.Equal(t, "bash -s", command)
+		require.NotNil(t, stdin)
+
+		body, readErr := io.ReadAll(stdin)
+		require.NoError(t, readErr)
+		assert.Equal(t, "set -eo pipefail\necho hi\n", string(body))
+		assert.NotContains(t, string(body), "\r")
 	})
 
 	t.Run("file mode prepends working directory to the streamed script", func(t *testing.T) {

--- a/test/e2e/ssh_line_endings_test.go
+++ b/test/e2e/ssh_line_endings_test.go
@@ -1,0 +1,390 @@
+package e2e
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	pwssh "golang.org/x/crypto/ssh"
+	"gorm.io/datatypes"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	gitstorage "github.com/superplanehq/superplane/pkg/git"
+	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/secrets"
+	"github.com/superplanehq/superplane/pkg/workers/contexts"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+const (
+	sshLineEndingSecretName = "e2e-ssh-password"
+	sshLineEndingSecretKey  = "password"
+	sshLineEndingPassword   = "correct-horse-battery-staple"
+	sshLineEndingUser       = "e2e"
+	sshLineEndingNodeName   = "Run SSH Script"
+	sshLineEndingScriptPath = "scripts/deploy.sh"
+)
+
+func TestSSHCommandLineEndings(t *testing.T) {
+	t.Run("normalizes CRLF command files before streaming them over SSH", func(t *testing.T) {
+		steps := &sshLineEndingsSteps{t: t}
+		steps.start()
+		steps.givenAnSSHServerExpectingLFScript()
+		steps.givenACanvasWithCRLFSSHCommandFile()
+		steps.whenTheManualTriggerRuns()
+		steps.thenTheSSHNodeCompletedSuccessfully()
+		steps.thenTheSSHServerReceivedNormalizedScript()
+	})
+}
+
+type sshLineEndingsSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+	server  *scriptCheckingSSHServer
+}
+
+func (s *sshLineEndingsSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *sshLineEndingsSteps) givenAnSSHServerExpectingLFScript() {
+	expectedScript := "set -eo pipefail\nprintf ok\n"
+	server, err := startScriptCheckingSSHServer(sshLineEndingUser, sshLineEndingPassword, expectedScript)
+	require.NoError(s.t, err)
+	s.t.Cleanup(server.Close)
+	s.server = server
+}
+
+func (s *sshLineEndingsSteps) givenACanvasWithCRLFSSHCommandFile() {
+	require.NotNil(s.t, s.server, "SSH server must be started before creating the canvas")
+
+	s.createPasswordSecret()
+	canvas := s.createPublishedSSHCanvas()
+	s.createRepositoryCommandFile(canvas, "set -eo pipefail\r\nprintf ok\r\n")
+
+	s.canvas = shared.NewCanvasSteps("SSH CRLF Line Endings", s.t, s.session)
+	s.canvas.WorkflowID = canvas.ID
+}
+
+func (s *sshLineEndingsSteps) createPasswordSecret() {
+	data, err := json.Marshal(map[string]string{
+		sshLineEndingSecretKey: sshLineEndingPassword,
+	})
+	require.NoError(s.t, err)
+
+	_, err = models.CreateSecret(
+		sshLineEndingSecretName,
+		secrets.ProviderLocal,
+		s.session.Account.ID.String(),
+		models.DomainTypeOrganization,
+		s.session.OrgID,
+		data,
+	)
+	require.NoError(s.t, err)
+}
+
+func (s *sshLineEndingsSteps) createPublishedSSHCanvas() *models.Canvas {
+	user, err := models.FindMaybeDeletedUserByEmail(s.session.OrgID.String(), s.session.Account.Email)
+	require.NoError(s.t, err)
+
+	startNodeID := "start-trigger"
+	sshNodeID := "ssh-command"
+	canvas, _ := support.CreateCanvas(s.t, s.session.OrgID, user.ID, []models.CanvasNode{
+		{
+			NodeID: startNodeID,
+			Name:   "Start",
+			Type:   models.NodeTypeTrigger,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Trigger: &models.TriggerRef{Name: "start"},
+			}),
+			Configuration: datatypes.NewJSONType(map[string]any{}),
+			Position:      datatypes.NewJSONType(models.Position{X: 600, Y: 200}),
+		},
+		{
+			NodeID: sshNodeID,
+			Name:   sshLineEndingNodeName,
+			Type:   models.NodeTypeComponent,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Component: &models.ComponentRef{Name: "ssh"},
+			}),
+			Configuration: datatypes.NewJSONType(map[string]any{
+				"host":          "127.0.0.1",
+				"port":          s.server.Port(),
+				"username":      sshLineEndingUser,
+				"commandSource": "file",
+				"commandFile":   sshLineEndingScriptPath,
+				"timeout":       10,
+				"authentication": map[string]any{
+					"authMethod": "password",
+					"password": map[string]any{
+						"secret": sshLineEndingSecretName,
+						"key":    sshLineEndingSecretKey,
+					},
+				},
+			}),
+			Position: datatypes.NewJSONType(models.Position{X: 1000, Y: 200}),
+		},
+	}, []models.Edge{
+		{SourceID: startNodeID, TargetID: sshNodeID, Channel: "default"},
+	})
+
+	return canvas
+}
+
+func (s *sshLineEndingsSteps) createRepositoryCommandFile(canvas *models.Canvas, script string) {
+	gitProvider, err := gitstorage.NewProvider()
+	require.NoError(s.t, err)
+
+	repoID := gitProvider.GetRepositoryID(gitprovider.RepositoryOptions{
+		OrganizationID: canvas.OrganizationID,
+		CanvasID:       canvas.ID,
+	})
+
+	repository, err := canvas.CreatePendingRepository(gitProvider.Name(), repoID)
+	require.NoError(s.t, err)
+
+	_, err = gitProvider.CreateRepository(s.t.Context(), repoID)
+	require.NoError(s.t, err)
+	require.NoError(s.t, repository.MarkReady(database.Conn()))
+
+	head, err := gitProvider.Head(s.t.Context(), repoID, "")
+	require.NoError(s.t, err)
+
+	_, err = gitProvider.Commit(s.t.Context(), repoID, gitprovider.CommitOptions{
+		Branch:          "main",
+		Message:         "Add SSH command file",
+		ExpectedHeadSHA: head,
+		Author:          gitprovider.SuperPlaneBotAuthor(),
+		Operations: []gitprovider.FileOperation{
+			{
+				Path:      sshLineEndingScriptPath,
+				Content:   strings.NewReader(script),
+				SizeBytes: int64(len(script)),
+			},
+		},
+	})
+	require.NoError(s.t, err)
+}
+
+func (s *sshLineEndingsSteps) whenTheManualTriggerRuns() {
+	node := s.canvas.GetNodeFromDB("Start")
+	eventContext := contexts.NewEventContext(database.Conn(), node, func(events []models.CanvasEvent) {
+		for i := range events {
+			require.NoError(s.t, messages.PublishCanvasEventCreatedMessage(&events[i]))
+		}
+	})
+
+	require.NoError(s.t, eventContext.Emit("manual.run", map[string]any{"source": "e2e"}))
+}
+
+func (s *sshLineEndingsSteps) thenTheSSHNodeCompletedSuccessfully() {
+	s.canvas.WaitForExecution(sshLineEndingNodeName, models.CanvasNodeExecutionStateFinished, 30*time.Second)
+
+	executions := s.canvas.GetExecutionsForNode(sshLineEndingNodeName)
+	require.NotEmpty(s.t, executions)
+	execution := executions[0]
+	require.Equal(s.t, models.CanvasNodeExecutionResultPassed, execution.Result)
+
+	var successEvent models.CanvasEvent
+	err := database.Conn().
+		Where("workflow_id = ?", s.canvas.WorkflowID).
+		Where("execution_id = ?", execution.ID).
+		Where("channel = ?", "success").
+		First(&successEvent).
+		Error
+	require.NoError(s.t, err, "expected SSH node to emit on the success channel")
+}
+
+func (s *sshLineEndingsSteps) thenTheSSHServerReceivedNormalizedScript() {
+	body := s.server.WaitForScript(s.t)
+	require.Equal(s.t, "set -eo pipefail\nprintf ok\n", body)
+	require.NotContains(s.t, body, "\r")
+}
+
+type scriptCheckingSSHServer struct {
+	listener net.Listener
+	config   *pwssh.ServerConfig
+	expected string
+	scripts  chan string
+	errors   chan error
+}
+
+func startScriptCheckingSSHServer(username, password, expected string) (*scriptCheckingSSHServer, error) {
+	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := pwssh.NewSignerFromKey(hostKey)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &pwssh.ServerConfig{
+		PasswordCallback: func(metadata pwssh.ConnMetadata, candidate []byte) (*pwssh.Permissions, error) {
+			if metadata.User() == username && string(candidate) == password {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("invalid SSH credentials for %s", metadata.User())
+		},
+	}
+	config.AddHostKey(signer)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	server := &scriptCheckingSSHServer{
+		listener: listener,
+		config:   config,
+		expected: expected,
+		scripts:  make(chan string, 1),
+		errors:   make(chan error, 1),
+	}
+
+	go server.accept()
+	return server, nil
+}
+
+func (s *scriptCheckingSSHServer) Port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+func (s *scriptCheckingSSHServer) Close() {
+	_ = s.listener.Close()
+}
+
+func (s *scriptCheckingSSHServer) WaitForScript(t *testing.T) string {
+	t.Helper()
+
+	select {
+	case script := <-s.scripts:
+		return script
+	case err := <-s.errors:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for SSH script")
+	}
+
+	return ""
+}
+
+func (s *scriptCheckingSSHServer) accept() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			s.reportError(fmt.Errorf("accept SSH connection: %w", err))
+			return
+		}
+
+		go s.handleConnection(conn)
+	}
+}
+
+func (s *scriptCheckingSSHServer) handleConnection(conn net.Conn) {
+	sshConn, channels, requests, err := pwssh.NewServerConn(conn, s.config)
+	if err != nil {
+		s.reportError(fmt.Errorf("handshake SSH connection: %w", err))
+		return
+	}
+	defer sshConn.Close()
+
+	go pwssh.DiscardRequests(requests)
+
+	for channel := range channels {
+		if channel.ChannelType() != "session" {
+			_ = channel.Reject(pwssh.UnknownChannelType, "session channel required")
+			continue
+		}
+
+		accepted, channelRequests, err := channel.Accept()
+		if err != nil {
+			s.reportError(fmt.Errorf("accept SSH session channel: %w", err))
+			return
+		}
+
+		go s.handleSession(accepted, channelRequests)
+	}
+}
+
+func (s *scriptCheckingSSHServer) handleSession(channel pwssh.Channel, requests <-chan *pwssh.Request) {
+	defer channel.Close()
+
+	for request := range requests {
+		if request.Type != "exec" {
+			_ = request.Reply(false, nil)
+			continue
+		}
+
+		var payload struct {
+			Command string
+		}
+		if err := pwssh.Unmarshal(request.Payload, &payload); err != nil {
+			_ = request.Reply(false, nil)
+			s.reportError(fmt.Errorf("parse SSH exec request: %w", err))
+			return
+		}
+
+		if payload.Command != "bash -s" {
+			_ = request.Reply(false, nil)
+			s.reportError(fmt.Errorf("unexpected SSH command %q", payload.Command))
+			return
+		}
+
+		_ = request.Reply(true, nil)
+
+		body, err := io.ReadAll(channel)
+		if err != nil {
+			s.reportError(fmt.Errorf("read SSH stdin: %w", err))
+			return
+		}
+
+		status := uint32(0)
+		script := string(body)
+		if script != s.expected || strings.Contains(script, "\r") {
+			status = 1
+			_, _ = channel.Stderr().Write([]byte("script line endings were not normalized"))
+		} else {
+			_, _ = channel.Write([]byte("ok\n"))
+		}
+
+		s.publishScript(script)
+		_, _ = channel.SendRequest("exit-status", false, pwssh.Marshal(struct {
+			Status uint32
+		}{Status: status}))
+		return
+	}
+}
+
+func (s *scriptCheckingSSHServer) publishScript(script string) {
+	select {
+	case s.scripts <- script:
+	default:
+	}
+}
+
+func (s *scriptCheckingSSHServer) reportError(err error) {
+	select {
+	case s.errors <- err:
+	default:
+	}
+}


### PR DESCRIPTION
Fixes #6043

## Summary
- Normalize CRLF and lone CR line endings for SSH command files before execution.
- Normalize inline SSH script assembly defensively, while preserving script content otherwise.
- Add unit coverage plus an E2E that commits CRLF bytes and verifies the fake SSH server receives LF-normalized stdin.

## Tests
- make format.go
- make test PKG_TEST_PACKAGES=./pkg/components/ssh
- make test.e2e.single FILE=test/e2e/ssh_line_endings_test.go LINE=37
- make lint && make check.build.app