### PR TITLE
feat: preview applied runtime config expressions

### DIFF
--- a/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
+++ b/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
@@ -19,6 +19,7 @@ export function RunInspectorNodeAccordion({
   section,
   componentIconMap,
   organizationId,
+  canShowExpressionTemplates,
   isOpen,
   onRerun,
   rerunPending,
@@ -31,6 +32,7 @@ export function RunInspectorNodeAccordion({
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
   organizationId?: string;
+  canShowExpressionTemplates?: boolean;
   isOpen: boolean;
   onRerun: () => void;
   rerunPending: boolean;
@@ -108,6 +110,7 @@ export function RunInspectorNodeAccordion({
           section={section}
           componentIconMap={componentIconMap}
           organizationId={organizationId}
+          canShowExpressionTemplates={canShowExpressionTemplates}
           onEditNode={onEditNode}
           errorScrollRequestId={errorScrollRequestId}
           onErrorScrolled={onErrorScrolled}

--- a/web_src/src/ui/Runs/RunInspectorPanel.runtimeConfig.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.runtimeConfig.spec.tsx
@@ -1,0 +1,317 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CanvasesCanvasNodeExecution, CanvasesCanvasVersion, ConfigurationField } from "@/api-client";
+import { executions, run as baseRun, renderInspector, workflowNodes } from "./RunInspectorPanel.spec.fixtures";
+
+let mockedExecutions = executions;
+let mockedRunVersion: CanvasesCanvasVersion | undefined = undefined;
+
+vi.mock("@uiw/react-json-view", () => ({
+  default: ({ value, collapsed }: { value: unknown; collapsed?: boolean | number }) => (
+    <pre data-testid="json-view" data-collapsed={String(collapsed)}>
+      {JSON.stringify(value)}
+    </pre>
+  ),
+}));
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useEventExecutions: () => ({
+    data: { executions: mockedExecutions },
+    isLoading: false,
+  }),
+  useCanvasVersion: () => ({
+    data: mockedRunVersion,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useMe", () => ({
+  useMe: () => ({ data: null }),
+}));
+
+vi.mock("@/pages/app/mappers", () => ({
+  getExecutionDetails: () => ({}),
+  getState: () => (execution: CanvasesCanvasNodeExecution) =>
+    execution.result === "RESULT_FAILED" ? "error" : "success",
+  getStateMap: () => ({
+    error: { badgeColor: "bg-red-500", label: "error" },
+    success: { badgeColor: "bg-emerald-500", label: "success" },
+    triggered: { badgeColor: "bg-blue-500", label: "triggered" },
+  }),
+  getTriggerRenderer: () => ({
+    getTitleAndSubtitle: () => ({ title: "Deploy main", subtitle: "" }),
+    getRootEventValues: () => ({ Source: "manual" }),
+  }),
+}));
+
+vi.mock("@/pages/app/utils", () => ({
+  buildEventInfo: (event: unknown) => event,
+  buildExecutionInfo: (execution: unknown) => execution,
+}));
+
+beforeEach(() => {
+  mockedExecutions = executions;
+  mockedRunVersion = undefined;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("RunInspectorPanel runtime config expression preview", () => {
+  it("highlights resolved runtime config values using versioned workflow expressions", () => {
+    const resolvedMessage = "Hello, World!\n\n\nasdasfkgdokgf;dkgodkfgopdfkgpfodkgodfk ofdkgodfkgo dkfgop dkfgo";
+    mockedRunVersion = versionWithActionConfiguration({ url: "http://{{ root().data.message }}" });
+    mockedExecutions = withActionExecutionConfiguration({ url: `http://${resolvedMessage}` });
+
+    renderInspector({
+      selectedNodeId: "action-1",
+      run: {
+        ...baseRun,
+        versionId: "version-used-by-run",
+        rootEvent: baseRun.rootEvent
+          ? { ...baseRun.rootEvent, data: { data: { message: "client-side value should not render" } } }
+          : baseRun.rootEvent,
+      },
+      workflowNodes: workflowNodes.map((node) =>
+        node.id === "action-1"
+          ? { ...node, configuration: { url: "https://{{ root().data.currentConfigShouldNotBeUsed }}" } }
+          : node,
+      ),
+      componentDefinitions: [actionDefinition([{ name: "url", label: "URL", type: "string" }])],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    expect(screen.getByText("URL")).toBeInTheDocument();
+    expect(screen.queryByText(/client-side value should not render/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/currentConfigShouldNotBeUsed/)).not.toBeInTheDocument();
+    const resolvedSegment = screen
+      .getAllByText((_, element) => {
+        const className = typeof element?.className === "string" ? element.className : "";
+        return className.includes("text-emerald-700") && element?.textContent?.includes(resolvedMessage) === true;
+      })
+      .find((element) => element.className.includes("text-emerald-700"));
+    expect(resolvedSegment).toBeDefined();
+    expect(resolvedSegment!.parentElement?.textContent).toBe(`http://{{ ${resolvedMessage} }}`);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show expression" }));
+
+    expect(screen.getByText("root().data.message")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show applied" })).toBeInTheDocument();
+  });
+
+  it("does not use live workflow expressions while a run version is unavailable", () => {
+    mockedExecutions = withActionExecutionConfiguration({ url: "http://server-applied-value" });
+
+    renderInspector({
+      selectedNodeId: "action-1",
+      run: { ...baseRun, versionId: "version-still-loading" },
+      workflowNodes: liveWorkflowWithUrlExpression(),
+      componentDefinitions: [actionDefinition([{ name: "url", label: "URL", type: "string" }])],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    expect(screen.getByText("http://server-applied-value")).toBeInTheDocument();
+    expect(screen.queryByText(/currentConfigShouldNotBeUsed/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show expression" })).not.toBeInTheDocument();
+  });
+
+  it("does not enable expression templates for empty version workflow nodes", () => {
+    mockedRunVersion = {
+      metadata: { id: "empty-version" },
+      spec: { nodes: [] },
+    };
+    mockedExecutions = withActionExecutionConfiguration({ url: "http://server-applied-value" });
+
+    renderInspector({
+      selectedNodeId: "action-1",
+      run: { ...baseRun, versionId: "empty-version" },
+      workflowNodes: liveWorkflowWithUrlExpression(),
+      componentDefinitions: [actionDefinition([{ name: "url", label: "URL", type: "string" }])],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    expect(screen.getByText("http://server-applied-value")).toBeInTheDocument();
+    expect(screen.queryByText(/currentConfigShouldNotBeUsed/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show expression" })).not.toBeInTheDocument();
+  });
+
+  it("does not use live workflow expressions when a run has no version id", () => {
+    mockedExecutions = withActionExecutionConfiguration({ url: "http://server-applied-value" });
+
+    renderInspector({
+      selectedNodeId: "action-1",
+      workflowNodes: liveWorkflowWithUrlExpression(),
+      componentDefinitions: [actionDefinition([{ name: "url", label: "URL", type: "string" }])],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    expect(screen.getByText("http://server-applied-value")).toBeInTheDocument();
+    expect(screen.queryByText(/currentConfigShouldNotBeUsed/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show expression" })).not.toBeInTheDocument();
+  });
+
+  it("shows field-specific runtime config expression errors below the field", () => {
+    const expressionError =
+      'error resolving field url: expression evaluation failed: cannot fetch ss from <nil> (1:45) | $["start 2"].data.dasdkasdkaospdkoaskdopad.ss | ............................................^';
+    mockedExecutions = withActionExecutionConfiguration(
+      {
+        url: '{{ $["start 2"].data.dasdkasdkaospdkoaskdopad.ss }}',
+      },
+      expressionError,
+    );
+
+    renderInspector({
+      selectedNodeId: "action-1",
+      componentDefinitions: [actionDefinition([{ name: "url", label: "URL", type: "string" }])],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    const highlightedExpression = screen
+      .getAllByText(/start 2.*dasdkasdkaospdkoaskdopad\.ss/)
+      .find((element) => element.className.includes("underline"));
+    expect(highlightedExpression).toBeDefined();
+    expect(highlightedExpression!).toHaveClass("text-red-600");
+    const fieldError = screen.getByTestId("runtime-config-expression-error-url");
+    expect(fieldError).toHaveTextContent("expression evaluation failed: cannot fetch ss from <nil>");
+    expect(fieldError).not.toHaveTextContent("$[");
+    expect(fieldError).not.toHaveTextContent(/error resolving field url/i);
+  });
+
+  it("shows expression errors for boolean runtime config fields", () => {
+    const expressionError =
+      "error resolving field enabled: expression evaluation failed: cannot fetch enabled from <nil> (1:14) | $.data.enabled | .............^";
+    mockedExecutions = withActionExecutionConfiguration({ enabled: "{{ $.data.enabled }}" }, expressionError);
+
+    renderInspector({
+      selectedNodeId: "action-1",
+      componentDefinitions: [actionDefinition([{ name: "enabled", label: "Enabled", type: "boolean" }])],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    const highlightedExpression = screen
+      .getAllByText(/\.data\.enabled/)
+      .find((element) => element.className.includes("underline"));
+    expect(highlightedExpression).toBeDefined();
+    expect(highlightedExpression!).toHaveClass("text-red-600");
+    expect(screen.getByTestId("runtime-config-expression-error-enabled")).toHaveTextContent(
+      "expression evaluation failed: cannot fetch enabled from <nil>",
+    );
+  });
+
+  it("matches runtime config expression errors by expression text when the backend field path differs", () => {
+    const expressionError =
+      'error resolving field request.url: expression evaluation failed: cannot fetch ss from <nil> (1:45) | $["start 2"].data.dasdkasdkaospdkoaskdopad.ss | ............................................^';
+    mockedRunVersion = versionWithActionConfiguration({
+      endpoint: '{{ $["start 2"].data.dasdkasdkaospdkoaskdopad.ss }}',
+      url: "{{ root().data.url }}",
+    });
+    mockedExecutions = withActionExecutionConfiguration(
+      { endpoint: "", url: "http://server-applied-value" },
+      expressionError,
+    );
+
+    renderInspector({
+      selectedNodeId: "action-1",
+      run: { ...baseRun, versionId: "version-used-by-run" },
+      componentDefinitions: [
+        actionDefinition([
+          { name: "url", label: "URL", type: "string" },
+          { name: "endpoint", label: "Endpoint", type: "string" },
+        ]),
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    expect(screen.getByTestId("runtime-config-expression-error-endpoint")).toHaveTextContent(
+      "expression evaluation failed: cannot fetch ss from <nil>",
+    );
+    expect(screen.queryByTestId("runtime-config-expression-error-url")).not.toBeInTheDocument();
+  });
+
+  it("does not match expression errors to longer expressions that contain the failed expression", () => {
+    const expressionError =
+      "error resolving field request.url: expression evaluation failed: cannot fetch foo from <nil> (1:11) | $.data.foo | ..........^";
+    mockedRunVersion = versionWithActionConfiguration({
+      endpoint: "{{ $.data.foo.extra }}",
+      url: "{{ $.data.foo }}",
+    });
+    mockedExecutions = withActionExecutionConfiguration({ endpoint: "", url: "" }, expressionError);
+
+    renderInspector({
+      selectedNodeId: "action-1",
+      run: { ...baseRun, versionId: "version-used-by-run" },
+      componentDefinitions: [
+        actionDefinition([
+          { name: "endpoint", label: "Endpoint", type: "string" },
+          { name: "url", label: "URL", type: "string" },
+        ]),
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    expect(screen.getByTestId("runtime-config-expression-error-url")).toHaveTextContent(
+      "expression evaluation failed: cannot fetch foo from <nil>",
+    );
+    expect(screen.queryByTestId("runtime-config-expression-error-endpoint")).not.toBeInTheDocument();
+  });
+
+  it("preserves newlines in fallback runtime config strings", () => {
+    mockedExecutions = withActionExecutionConfiguration({ message: "first line\nsecond line" });
+
+    renderInspector({ selectedNodeId: "action-1" });
+    fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
+
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("first line\nsecond line");
+  });
+});
+
+function versionWithActionConfiguration(configuration: Record<string, unknown>): CanvasesCanvasVersion {
+  return {
+    metadata: { id: "version-used-by-run" },
+    spec: {
+      nodes: workflowNodes.map((node) => (node.id === "action-1" ? { ...node, configuration } : node)),
+    },
+  };
+}
+
+function withActionExecutionConfiguration(
+  configuration: Record<string, unknown>,
+  resultMessage = "",
+): CanvasesCanvasNodeExecution[] {
+  return executions.map((execution) =>
+    execution.nodeId === "action-1"
+      ? {
+          ...execution,
+          result: resultMessage ? execution.result : "RESULT_PASSED",
+          resultReason: resultMessage ? execution.resultReason : "RESULT_REASON_OK",
+          resultMessage,
+          configuration,
+        }
+      : execution,
+  );
+}
+
+function liveWorkflowWithUrlExpression() {
+  return workflowNodes.map((node) =>
+    node.id === "action-1"
+      ? { ...node, configuration: { url: "https://{{ root().data.currentConfigShouldNotBeUsed }}" } }
+      : node,
+  );
+}
+
+function actionDefinition(configuration: ConfigurationField[]) {
+  return {
+    name: "github.addLabel",
+    configuration,
+  };
+}

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
@@ -68,6 +68,8 @@ export function renderInspector({
   onNavigateRun,
   onNavigateOlder,
   run: inspectedRun = run,
+  workflowNodes: inspectedWorkflowNodes = workflowNodes,
+  componentDefinitions: inspectedComponentDefinitions = componentDefinitions,
   account = null,
   passCurrentUser = true,
 }: {
@@ -80,6 +82,8 @@ export function renderInspector({
   onNavigateRun?: (runId: string) => void;
   onNavigateOlder?: () => void;
   run?: CanvasesCanvasRun;
+  workflowNodes?: SuperplaneComponentsNode[];
+  componentDefinitions?: ActionsAction[];
   account?: {
     id: string;
     name: string;
@@ -113,8 +117,8 @@ export function renderInspector({
             canvasId="canvas-1"
             organizationId="org-1"
             run={inspectedRun}
-            workflowNodes={workflowNodes}
-            componentDefinitions={componentDefinitions}
+            workflowNodes={inspectedWorkflowNodes}
+            componentDefinitions={inspectedComponentDefinitions}
             currentUser={
               passCurrentUser && account
                 ? { id: account.id, email: account.email, roles: account.roles, groups: account.groups }
@@ -179,7 +183,7 @@ export function firePointerEvent(
   fireEvent(target, event);
 }
 
-const run: CanvasesCanvasRun = {
+export const run: CanvasesCanvasRun = {
   id: "run-1",
   canvasId: "canvas-1",
   state: "STATE_FINISHED",
@@ -211,7 +215,7 @@ export const runningRun: CanvasesCanvasRun = {
   },
 };
 
-const workflowNodes: SuperplaneComponentsNode[] = [
+export const workflowNodes: SuperplaneComponentsNode[] = [
   {
     id: "trigger-1",
     name: "On Pull Request",

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -45,6 +45,10 @@ vi.mock("@/hooks/useCanvasData", () => ({
     data: { executions: mockedExecutions },
     isLoading: mockedExecutionsLoading,
   }),
+  useCanvasVersion: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
 }));
 
 vi.mock("@/hooks/useMe", () => ({
@@ -233,19 +237,6 @@ describe("RunInspectorPanel", () => {
   });
 
   describe("runtime and output regressions", () => {
-    it("preserves newlines in fallback runtime config strings", () => {
-      mockedExecutions = executions.map((execution) =>
-        execution.nodeId === "action-1"
-          ? { ...execution, configuration: { message: "first line\nsecond line" } }
-          : execution,
-      );
-
-      renderInspector({ selectedNodeId: "action-1" });
-      fireEvent.click(screen.getByRole("button", { name: /Runtime config/i }));
-
-      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("first line\nsecond line");
-    });
-
     it("shows an edit action in the runtime config header", () => {
       const onEditNode = vi.fn();
       renderInspector({ selectedNodeId: "action-2", onEditNode });

--- a/web_src/src/ui/Runs/RunInspectorPanel.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.tsx
@@ -8,7 +8,7 @@ import {
   type TriggersTrigger,
 } from "@/api-client";
 import { useAccount } from "@/contexts/useAccount";
-import { useEventExecutions } from "@/hooks/useCanvasData";
+import { useCanvasVersion, useEventExecutions } from "@/hooks/useCanvasData";
 import { useMe } from "@/hooks/useMe";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
@@ -78,24 +78,33 @@ export function RunInspectorPanel({
   const resolvedCurrentUser = useMemo(() => resolveCurrentUser(currentUser, me, account), [account, currentUser, me]);
   const rootEventId = run.rootEvent?.id || null;
   const executionsQuery = useEventExecutions(canvasId, rootEventId);
+  const runVersionQuery = useCanvasVersion(organizationId ?? "", canvasId, run.versionId ?? "", Boolean(run.versionId));
   const executions = useMemo(() => executionsQuery.data?.executions || [], [executionsQuery.data?.executions]);
-  const nodeMap = useMemo(() => buildNodeMap(workflowNodes), [workflowNodes]);
+  const shouldUseRunVersion = Boolean(run.versionId);
+  const versionWorkflowNodes = runVersionQuery.data?.spec?.nodes;
+  const versionWorkflowEdges = runVersionQuery.data?.spec?.edges;
+  const hasRunVersionSpec = shouldUseRunVersion && hasWorkflowNodes(versionWorkflowNodes);
+  const inspectorWorkflowNodes = useMemo(
+    () => selectInspectorWorkflowNodes(shouldUseRunVersion, hasRunVersionSpec, versionWorkflowNodes, workflowNodes),
+    [hasRunVersionSpec, shouldUseRunVersion, versionWorkflowNodes, workflowNodes],
+  );
+  const inspectorWorkflowEdges = hasRunVersionSpec ? versionWorkflowEdges : workflowEdges;
+  const nodeMap = useMemo(() => buildNodeMap(inspectorWorkflowNodes), [inspectorWorkflowNodes]);
   const presentation = useMemo(() => buildRunPresentation(run, nodeMap), [nodeMap, run]);
   const sections = useMemo(
     () =>
       buildRunInspectorNodeSections({
         run,
         executions,
-        workflowNodes,
-        workflowEdges,
+        workflowNodes: inspectorWorkflowNodes,
+        workflowEdges: inspectorWorkflowEdges,
         componentDefinitions,
         triggerDefinitions,
       }),
-    [componentDefinitions, executions, run, triggerDefinitions, workflowEdges, workflowNodes],
+    [componentDefinitions, executions, run, triggerDefinitions, inspectorWorkflowEdges, inspectorWorkflowNodes],
   );
   const errorSummaries = useMemo(() => findRunInspectorErrorSummaries(sections), [sections]);
   const inspectorWidth = useResizableInspectorWidth();
-  const selectedValue = selectedNodeId ?? "";
   const [errorScrollRequest, setErrorScrollRequest] = useState<{ nodeId: string; requestId: number } | null>(null);
   const actions = useRunInspectorActions({
     canvasId,
@@ -106,11 +115,7 @@ export function RunInspectorPanel({
   });
 
   const handleValueChange = (value: string) => {
-    if (value) {
-      onSelectNode(value);
-      return;
-    }
-
+    if (value) return onSelectNode(value);
     onClearSelectedNode?.();
   };
 
@@ -153,9 +158,10 @@ export function RunInspectorPanel({
         status={presentation.status}
         sections={sections}
         isLoading={executionsQuery.isLoading}
-        selectedValue={selectedValue}
+        selectedValue={selectedNodeId ?? ""}
         componentIconMap={componentIconMap}
         organizationId={organizationId}
+        canShowExpressionTemplates={hasRunVersionSpec}
         onValueChange={handleValueChange}
         onJumpToError={jumpToErrorOutput}
         onRerun={actions.rerun}
@@ -168,6 +174,21 @@ export function RunInspectorPanel({
       />
     </aside>
   );
+}
+
+function selectInspectorWorkflowNodes(
+  shouldUseRunVersion: boolean,
+  hasRunVersionSpec: boolean,
+  versionWorkflowNodes: ComponentsNode[] | undefined,
+  workflowNodes: ComponentsNode[],
+): ComponentsNode[] {
+  if (!shouldUseRunVersion) return workflowNodes;
+  if (hasRunVersionSpec) return versionWorkflowNodes ?? [];
+  return workflowNodes.map((node) => ({ ...node, configuration: undefined }));
+}
+
+function hasWorkflowNodes(nodes: ComponentsNode[] | undefined): boolean {
+  return Boolean(nodes?.length);
 }
 
 function resolveCurrentUser(

--- a/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRuntimeConfig.tsx
@@ -1,5 +1,5 @@
 import { Pencil } from "lucide-react";
-import { useState, type CSSProperties } from "react";
+import { useMemo, useState, type CSSProperties } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -8,16 +8,19 @@ import { cn } from "@/lib/utils";
 import { EmptySectionText, JsonPayload, TimelineAccordionCard } from "./RunInspectorTimelineCard";
 import { HeaderIconButton } from "@/ui/HeaderIconButton";
 import { hasObjectValue, type RunInspectorNodeSection } from "./runNodeDetailModel";
+import { buildRuntimeExpressionContext } from "./runInspectorExpressionContext";
 
 export function RuntimeTimelineCard({
   section,
   jsonViewStyle,
   organizationId,
+  canShowExpressionTemplates = false,
   onEditNode,
 }: {
   section: RunInspectorNodeSection;
   jsonViewStyle: CSSProperties;
   organizationId?: string;
+  canShowExpressionTemplates?: boolean;
   onEditNode?: (nodeId: string) => void;
 }) {
   const [mode, setMode] = useState<"form" | "json">("form");
@@ -39,6 +42,7 @@ export function RuntimeTimelineCard({
           value={configuration}
           jsonViewStyle={jsonViewStyle}
           organizationId={organizationId}
+          canShowExpressionTemplates={canShowExpressionTemplates}
         />
       ) : (
         <JsonPayload value={configuration} jsonViewStyle={jsonViewStyle} />
@@ -105,19 +109,30 @@ function RuntimeConfigForm({
   value,
   jsonViewStyle,
   organizationId,
+  canShowExpressionTemplates,
 }: {
   section: RunInspectorNodeSection;
   value: unknown;
   jsonViewStyle: CSSProperties;
   organizationId?: string;
+  canShowExpressionTemplates: boolean;
 }) {
+  const expressionPreviewContext = useMemo(() => buildRuntimeExpressionContext(section), [section]);
+
   if (!hasObjectValue(value)) {
     return <EmptySectionText>No runtime configuration for this step.</EmptySectionText>;
   }
 
   if (section.configurationFields.length > 0) {
     return (
-      <RuntimeSchemaConfigForm fields={section.configurationFields} value={value} organizationId={organizationId} />
+      <RuntimeSchemaConfigForm
+        fields={section.configurationFields}
+        value={value}
+        templateValues={canShowExpressionTemplates ? section.workflowNode?.configuration : undefined}
+        organizationId={organizationId}
+        expressionPreviewContext={expressionPreviewContext}
+        expressionErrorMessage={section.errorMessage}
+      />
     );
   }
 
@@ -133,11 +148,17 @@ function RuntimeConfigForm({
 function RuntimeSchemaConfigForm({
   fields,
   value,
+  templateValues,
   organizationId,
+  expressionPreviewContext,
+  expressionErrorMessage,
 }: {
   fields: RunInspectorNodeSection["configurationFields"];
   value: Record<string, unknown>;
+  templateValues?: Record<string, unknown>;
   organizationId?: string;
+  expressionPreviewContext?: Record<string, unknown> | null;
+  expressionErrorMessage?: string;
 }) {
   return (
     <div className="space-y-4">
@@ -154,6 +175,9 @@ function RuntimeSchemaConfigForm({
             domainId={organizationId}
             organizationId={organizationId}
             readOnly
+            expressionPreviewContext={expressionPreviewContext}
+            expressionErrorMessage={expressionErrorMessage}
+            expressionTemplateValue={templateValues?.[field.name]}
           />
         );
       })}

--- a/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
@@ -31,6 +31,7 @@ export function RunInspectorStepTimeline({
   section,
   componentIconMap,
   organizationId,
+  canShowExpressionTemplates,
   onEditNode,
   errorScrollRequestId,
   onErrorScrolled,
@@ -38,6 +39,7 @@ export function RunInspectorStepTimeline({
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
   organizationId?: string;
+  canShowExpressionTemplates?: boolean;
   onEditNode?: (nodeId: string) => void;
   errorScrollRequestId?: number | null;
   onErrorScrolled?: () => void;
@@ -120,6 +122,7 @@ export function RunInspectorStepTimeline({
                 section={section}
                 jsonViewStyle={jsonViewStyle}
                 organizationId={organizationId}
+                canShowExpressionTemplates={canShowExpressionTemplates}
                 onEditNode={onEditNode}
               />
             ) : (

--- a/web_src/src/ui/Runs/RunInspectorStepsList.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepsList.tsx
@@ -15,6 +15,7 @@ export function RunInspectorStepsList({
   selectedValue,
   componentIconMap,
   organizationId,
+  canShowExpressionTemplates,
   onValueChange,
   onJumpToError,
   onRerun,
@@ -32,6 +33,7 @@ export function RunInspectorStepsList({
   selectedValue: string;
   componentIconMap: Record<string, string>;
   organizationId?: string;
+  canShowExpressionTemplates?: boolean;
   onValueChange: (value: string) => void;
   onJumpToError: (nodeId: string) => void;
   onRerun: () => void;
@@ -74,6 +76,7 @@ export function RunInspectorStepsList({
               section={section}
               componentIconMap={componentIconMap}
               organizationId={organizationId}
+              canShowExpressionTemplates={canShowExpressionTemplates}
               isOpen={selectedValue === section.nodeId}
               onRerun={onRerun}
               onEditNode={onEditNode}

--- a/web_src/src/ui/Runs/runInspectorExpressionContext.ts
+++ b/web_src/src/ui/Runs/runInspectorExpressionContext.ts
@@ -1,0 +1,38 @@
+import type { RunInspectorNodeSection } from "./runNodeDetailModel";
+
+export function buildRuntimeExpressionContext(section: RunInspectorNodeSection): Record<string, unknown> | null {
+  if (section.upstreamSections.length === 0) return null;
+
+  const context: Record<string, unknown> = {};
+  const nodeNames: Record<string, unknown> = {};
+
+  section.upstreamSections.forEach((upstreamSection) => {
+    const output = upstreamSection.output ?? null;
+    context[upstreamSection.nodeName] = output;
+    context[upstreamSection.nodeId] = output;
+
+    const metadata = {
+      nodeName: upstreamSection.nodeName,
+      componentType: upstreamSection.workflowNode?.component,
+    };
+    nodeNames[upstreamSection.nodeName] = metadata;
+    nodeNames[upstreamSection.nodeId] = metadata;
+  });
+
+  context.__root = section.upstreamSections[0]?.output ?? null;
+  context.__previousByDepth = buildPreviousByDepth(section);
+  context.__nodeNames = nodeNames;
+
+  return context;
+}
+
+function buildPreviousByDepth(section: RunInspectorNodeSection): Record<string, unknown> {
+  const previousByDepth: Record<string, unknown> = {};
+  const reversedUpstreamSections = [...section.upstreamSections].reverse();
+
+  reversedUpstreamSections.forEach((upstreamSection, index) => {
+    previousByDepth[String(index + 1)] = upstreamSection.output ?? null;
+  });
+
+  return previousByDepth;
+}

--- a/web_src/src/ui/configurationFieldRenderer/ReadonlyFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ReadonlyFieldRenderer.tsx
@@ -1,4 +1,8 @@
+import { Eye, EyeOff } from "lucide-react";
+import { useState, type ReactNode } from "react";
 import type { ConfigurationField, ConfigurationSelectOption } from "@/api-client";
+import { cn } from "@/lib/utils";
+import type { ReadonlyExpressionPreview } from "./expressionPreview";
 
 export function ReadonlyConfigurationField({
   field,
@@ -7,6 +11,7 @@ export function ReadonlyConfigurationField({
   value,
   isTogglable,
   isEnabled,
+  expressionPreview,
 }: {
   field: ConfigurationField;
   label?: string;
@@ -14,7 +19,12 @@ export function ReadonlyConfigurationField({
   value: unknown;
   isTogglable: boolean;
   isEnabled: boolean;
+  expressionPreview?: ReadonlyExpressionPreview | null;
 }) {
+  const [isPreviewVisible, setIsPreviewVisible] = useState(true);
+  const hasExpressionError = expressionPreview?.status === "error";
+  const shouldShowPreviewToggle = expressionPreview?.status === "resolved";
+
   if (isTogglable && !isEnabled) {
     return (
       <div className="space-y-2 opacity-70">
@@ -24,14 +34,29 @@ export function ReadonlyConfigurationField({
     );
   }
 
-  if (field.type === "boolean") {
+  if (field.type === "boolean" && !expressionPreview) {
     return <ReadonlyBooleanField label={label} value={value === true} description={description} />;
   }
 
   return (
     <div className="space-y-2">
-      <ReadonlyFieldLabel label={label} />
-      <ReadonlyValue field={field} value={value} />
+      <div className="flex items-center gap-3">
+        <ReadonlyFieldLabel label={label} />
+        {shouldShowPreviewToggle ? (
+          <ReadonlyPreviewToggle isPreviewVisible={isPreviewVisible} onToggle={setIsPreviewVisible} />
+        ) : null}
+      </div>
+      <ReadonlyValue
+        field={field}
+        value={value}
+        hasExpressionError={hasExpressionError}
+        expressionTemplate={expressionPreview?.templateValue}
+        resolvedValue={expressionPreview?.status === "resolved" ? expressionPreview.value : undefined}
+        isPreviewVisible={isPreviewVisible}
+      />
+      {expressionPreview?.status === "error" ? (
+        <ReadonlyExpressionErrorMessage fieldName={field.name} message={expressionPreview.value} />
+      ) : null}
       {description ? <p className="text-xs leading-normal text-gray-500 dark:text-gray-400">{description}</p> : null}
     </div>
   );
@@ -68,25 +93,275 @@ function ReadonlyFieldLabel({ label }: { label?: string }) {
   return <div className="text-sm font-medium text-slate-800 dark:text-gray-100">{label}</div>;
 }
 
-function ReadonlyValue({ field, value }: { field: ConfigurationField; value: unknown }) {
-  const displayValue = formatReadonlyValue(field, value);
+function ReadonlyPreviewToggle({
+  isPreviewVisible,
+  onToggle,
+}: {
+  isPreviewVisible: boolean;
+  onToggle: (isVisible: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(!isPreviewVisible)}
+      className={cn(
+        "ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium transition-colors",
+        isPreviewVisible
+          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300"
+          : "text-emerald-600 hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-900/30",
+      )}
+    >
+      {isPreviewVisible ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
+      <span>{isPreviewVisible ? "Show expression" : "Show applied"}</span>
+    </button>
+  );
+}
+
+function ReadonlyValue({
+  field,
+  value,
+  hasExpressionError = false,
+  expressionTemplate,
+  resolvedValue,
+  isPreviewVisible,
+}: {
+  field: ConfigurationField;
+  value: unknown;
+  hasExpressionError?: boolean;
+  expressionTemplate?: string;
+  resolvedValue?: string;
+  isPreviewVisible: boolean;
+}) {
+  const rawValue = formatReadonlyValue(field, value);
+  const isResolvedPreview = isPreviewVisible && resolvedValue !== undefined;
+  const displayValue = isResolvedPreview ? resolvedValue : expressionTemplate || rawValue;
+  const className = hasExpressionError
+    ? "border-red-300 dark:border-red-800"
+    : isResolvedPreview
+      ? "border-emerald-300 bg-emerald-50/40 dark:border-emerald-800 dark:bg-emerald-950/20"
+      : undefined;
 
   if (isStructuredReadonlyValue(value)) {
     return (
-      <pre className="max-h-56 overflow-auto rounded-md border border-slate-200 bg-white p-2 text-xs text-slate-900 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100">
+      <pre
+        className={cn(
+          "max-h-56 overflow-auto rounded-md border border-slate-200 bg-white p-2 text-xs text-slate-900 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100",
+          className,
+        )}
+      >
         {displayValue}
       </pre>
     );
   }
 
-  return <ReadonlyPrimitiveValue value={displayValue} />;
+  return (
+    <ReadonlyPrimitiveValue value={displayValue} className={className}>
+      {isResolvedPreview
+        ? renderAppliedExpressionValue(field, displayValue, expressionTemplate)
+        : renderReadonlyHighlightedValue(field, displayValue, hasExpressionError)}
+    </ReadonlyPrimitiveValue>
+  );
 }
 
-function ReadonlyPrimitiveValue({ value }: { value: string }) {
+function ReadonlyPrimitiveValue({
+  value,
+  className,
+  children,
+}: {
+  value: string;
+  className?: string;
+  children?: ReactNode;
+}) {
   return (
-    <div className="min-h-9 w-full whitespace-pre-wrap break-words rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100">
-      {value}
+    <div
+      className={cn(
+        "min-h-9 w-full whitespace-pre-wrap break-words rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100",
+        className,
+      )}
+    >
+      {children ?? value}
     </div>
+  );
+}
+
+function renderReadonlyHighlightedValue(
+  field: ConfigurationField,
+  value: string,
+  hasExpressionError: boolean,
+): ReactNode {
+  if (!value) return value;
+
+  if (field.type === "expression") {
+    return <ReadonlyExpressionSegment expression={value} hasError={hasExpressionError} />;
+  }
+
+  if (!hasWrappedExpression(value)) return value;
+
+  const parts: ReactNode[] = [];
+  const expressionPattern = /(\{\{)([\s\S]*?)(\}\})/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  while ((match = expressionPattern.exec(value)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(<span key={key++}>{value.slice(lastIndex, match.index)}</span>);
+    }
+
+    parts.push(
+      <ReadonlyExpressionSegment
+        key={key++}
+        expression={match[2]}
+        prefix={match[1]}
+        suffix={match[3]}
+        hasError={hasExpressionError}
+      />,
+    );
+    lastIndex = expressionPattern.lastIndex;
+  }
+
+  if (lastIndex < value.length) {
+    parts.push(<span key={key++}>{value.slice(lastIndex)}</span>);
+  }
+
+  return parts;
+}
+
+function ReadonlyExpressionSegment({
+  expression,
+  prefix,
+  suffix,
+  hasError,
+}: {
+  expression: string;
+  prefix?: string;
+  suffix?: string;
+  hasError: boolean;
+}) {
+  if (hasError) {
+    return (
+      <span className="font-medium text-red-600 underline decoration-red-300 decoration-dotted underline-offset-2 dark:text-red-400 dark:decoration-red-700">
+        {prefix}
+        {expression}
+        {suffix}
+      </span>
+    );
+  }
+
+  return (
+    <span className="rounded-sm bg-slate-100 dark:bg-gray-800">
+      {prefix ? <span className="text-gray-400 dark:text-gray-500">{prefix}</span> : null}
+      <span className="font-medium text-violet-700 dark:text-violet-300">{expression}</span>
+      {suffix ? <span className="text-gray-400 dark:text-gray-500">{suffix}</span> : null}
+    </span>
+  );
+}
+
+function hasWrappedExpression(value: string): boolean {
+  return /\{\{[\s\S]*?\}\}/.test(value);
+}
+
+function renderAppliedExpressionValue(
+  field: ConfigurationField,
+  value: string,
+  expressionTemplate?: string,
+): ReactNode {
+  if (field.type === "expression") {
+    return <ReadonlyResolvedSegment value={value} />;
+  }
+
+  if (!expressionTemplate) {
+    return <ReadonlyResolvedSegment value={value} />;
+  }
+
+  const highlightedValue = renderResolvedWrappedExpressionValue(value, expressionTemplate);
+  return highlightedValue ?? value;
+}
+
+function renderResolvedWrappedExpressionValue(value: string, expressionTemplate: string): ReactNode[] | null {
+  const templateParts = parseWrappedExpressionTemplate(expressionTemplate);
+  if (!templateParts.some((part) => part.type === "expression")) return null;
+
+  const renderedParts: ReactNode[] = [];
+  let valueIndex = 0;
+  let key = 0;
+
+  for (let index = 0; index < templateParts.length; index++) {
+    const part = templateParts[index];
+
+    if (part.type === "literal") {
+      if (!value.startsWith(part.value, valueIndex)) return null;
+      renderedParts.push(<span key={key++}>{part.value}</span>);
+      valueIndex += part.value.length;
+      continue;
+    }
+
+    const nextLiteral = findNextLiteral(templateParts, index);
+    const expressionEnd = nextLiteral ? value.indexOf(nextLiteral, valueIndex) : value.length;
+    if (expressionEnd < valueIndex) return null;
+
+    const resolvedValue = value.slice(valueIndex, expressionEnd);
+    renderedParts.push(<ReadonlyResolvedSegment key={key++} value={resolvedValue} />);
+    valueIndex = expressionEnd;
+  }
+
+  if (valueIndex !== value.length) return null;
+  return renderedParts;
+}
+
+type WrappedExpressionTemplatePart =
+  | {
+      type: "literal";
+      value: string;
+    }
+  | {
+      type: "expression";
+      value: string;
+    };
+
+function parseWrappedExpressionTemplate(template: string): WrappedExpressionTemplatePart[] {
+  const parts: WrappedExpressionTemplatePart[] = [];
+  const expressionPattern = /\{\{([\s\S]*?)\}\}/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = expressionPattern.exec(template)) !== null) {
+    parts.push({ type: "literal", value: template.slice(lastIndex, match.index) });
+    parts.push({ type: "expression", value: match[1] });
+    lastIndex = expressionPattern.lastIndex;
+  }
+
+  parts.push({ type: "literal", value: template.slice(lastIndex) });
+  return parts;
+}
+
+function findNextLiteral(parts: WrappedExpressionTemplatePart[], startIndex: number): string | null {
+  for (let index = startIndex + 1; index < parts.length; index++) {
+    const part = parts[index];
+    if (part.type === "literal" && part.value) return part.value;
+  }
+
+  return null;
+}
+
+function ReadonlyResolvedSegment({ value }: { value: string }) {
+  return (
+    <span className="rounded-sm bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+      <span className="text-emerald-500 dark:text-emerald-500">{"{{ "}</span>
+      {value}
+      <span className="text-emerald-500 dark:text-emerald-500">{" }}"}</span>
+    </span>
+  );
+}
+
+function ReadonlyExpressionErrorMessage({ fieldName, message }: { fieldName?: string; message: string }) {
+  return (
+    <p
+      data-testid={fieldName ? `runtime-config-expression-error-${fieldName}` : undefined}
+      className="text-xs leading-normal text-red-600 dark:text-red-400"
+    >
+      {message}
+    </p>
   );
 }
 

--- a/web_src/src/ui/configurationFieldRenderer/expressionPreview.ts
+++ b/web_src/src/ui/configurationFieldRenderer/expressionPreview.ts
@@ -1,0 +1,155 @@
+import type { ConfigurationField } from "@/api-client";
+
+export type ReadonlyExpressionPreview = {
+  status: "resolved" | "error";
+  label: string;
+  value: string;
+  templateValue?: string;
+};
+
+export function buildReadonlyExpressionPreview({
+  field,
+  value,
+  templateValue,
+  errorMessage,
+}: {
+  field: ConfigurationField;
+  value: unknown;
+  templateValue?: unknown;
+  context?: Record<string, unknown> | null;
+  errorMessage?: string;
+}): ReadonlyExpressionPreview | null {
+  const templateExpressionValue = expressionTemplateValue(field, templateValue);
+  const expressionValue = templateExpressionValue ?? valueExpressionValue(value);
+  const fieldExpressionError = findFieldExpressionError(errorMessage, field.name, expressionValue);
+  if (fieldExpressionError) {
+    return {
+      status: "error",
+      label: "Expression error",
+      value: fieldExpressionError,
+      templateValue: expressionValue,
+    };
+  }
+
+  if (!expressionValue) return null;
+
+  if (!templateExpressionValue) return null;
+
+  return {
+    status: "resolved",
+    label: "Applied preview",
+    value: formatAppliedValue(value),
+    templateValue: templateExpressionValue,
+  };
+}
+
+function expressionTemplateValue(field: ConfigurationField, templateValue: unknown): string | null {
+  if (typeof templateValue === "string" && (field.type === "expression" || hasExpression(templateValue))) {
+    return templateValue;
+  }
+
+  return null;
+}
+
+function valueExpressionValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return "";
+}
+
+function formatAppliedValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+function containsWrappedExpression(value: string): boolean {
+  return /\{\{[\s\S]*?\}\}/.test(value);
+}
+
+function hasExpression(value: string): boolean {
+  return containsWrappedExpression(value) || value.trim().startsWith("$") || value.includes("root()");
+}
+
+function findFieldExpressionError(
+  errorMessage: string | undefined,
+  fieldName: string | undefined,
+  expressionValue: string,
+): string | null {
+  if (!errorMessage) return null;
+
+  const match = errorMessage.match(/error resolving field\s+([^:]+):\s*(.*)$/i);
+  if (match) {
+    const errorField = match[1].trim().replace(/^["']|["']$/g, "");
+    if (fieldName && isSameField(errorField, fieldName)) {
+      return formatFieldExpressionError(match[2]?.trim() || errorMessage);
+    }
+
+    const expressionError = findErrorForExpression(errorMessage, expressionValue);
+    return expressionError ? formatFieldExpressionError(expressionError) : null;
+  }
+
+  const expressionError = findErrorForExpression(errorMessage, expressionValue);
+  return expressionError ? formatFieldExpressionError(expressionError) : null;
+}
+
+function findErrorForExpression(errorMessage: string, expressionValue: string): string | null {
+  if (!expressionValue || !errorMessage.toLowerCase().includes("expression evaluation failed")) return null;
+
+  const failedExpression = extractFailedExpression(errorMessage);
+  if (!failedExpression) return null;
+  if (!hasMatchingExpressionCandidate(expressionValue, failedExpression)) return null;
+
+  return errorMessage.trim();
+}
+
+function hasMatchingExpressionCandidate(expressionValue: string, failedExpression: string): boolean {
+  const normalizedFailedExpression = normalizeExpression(failedExpression);
+  return extractExpressionCandidates(expressionValue).some(
+    (candidate) => normalizeExpression(candidate) === normalizedFailedExpression,
+  );
+}
+
+function isSameField(errorField: string, fieldName: string): boolean {
+  const normalizedErrorField = normalizeFieldPath(errorField);
+  const normalizedFieldName = normalizeFieldPath(fieldName);
+
+  return normalizedErrorField === normalizedFieldName;
+}
+
+function normalizeFieldPath(field: string): string {
+  return field
+    .replace(/^["']|["']$/g, "")
+    .trim()
+    .toLowerCase();
+}
+
+function extractFailedExpression(errorMessage: string): string | null {
+  const parts = errorMessage.split("|");
+  if (parts.length < 2) return null;
+
+  return parts[1].trim() || null;
+}
+
+function extractExpressionCandidates(value: string): string[] {
+  const wrappedExpressionPattern = /\{\{([\s\S]*?)\}\}/g;
+  const candidates = [...value.matchAll(wrappedExpressionPattern)].map((match) => match[1]);
+  if (candidates.length > 0) return candidates;
+  return [value];
+}
+
+function normalizeExpression(value: string): string {
+  return value.replace(/\s+/g, "");
+}
+
+function formatFieldExpressionError(errorMessage: string): string {
+  return errorMessage
+    .replace(/^error resolving field\s+[^:]+:\s*/i, "")
+    .split("|")[0]
+    .trim();
+}

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -9,6 +9,7 @@ import { buildTemplateParametersAutocompleteObject } from "./templateParametersA
 import { getRunTitlePresentation, RUN_TITLE_EXCLUDED_SUGGESTIONS } from "./runTitlePresentation";
 import { ReadonlyConfigurationField } from "./ReadonlyFieldRenderer";
 import { ConfigurationFieldInput } from "./ConfigurationFieldInput";
+import { buildReadonlyExpressionPreview } from "./expressionPreview";
 
 const REQUIRED_FIELD_BADGE_CLASS =
   "ml-2 inline-flex items-center rounded border border-orange-300 px-1 py-0.5 text-[10px] uppercase tracking-wide leading-none text-orange-500 bg-orange-50 dark:border-orange-400/50 dark:bg-orange-950/30 dark:text-orange-300";
@@ -117,6 +118,9 @@ export const ConfigurationFieldRenderer = ({
   autocompleteExampleObj,
   allowExpressions = false,
   readOnly = false,
+  expressionPreviewContext,
+  expressionErrorMessage,
+  expressionTemplateValue,
 }: ConfigurationFieldRendererProps) => {
   const isTogglable = field.togglable === true;
   const isEnabled = isTogglable ? value !== null && value !== undefined : true;
@@ -282,9 +286,20 @@ export const ConfigurationFieldRenderer = ({
     readOnly,
     excludedSuggestions: runTitlePresentation ? RUN_TITLE_EXCLUDED_SUGGESTIONS : undefined,
     valuePreviewLabel: runTitlePresentation?.previewLabel,
+    expressionPreviewContext,
+    expressionErrorMessage,
+    expressionTemplateValue,
   };
 
   if (readOnly && !shouldRenderFieldForReadOnly(field)) {
+    const expressionPreview = buildReadonlyExpressionPreview({
+      field,
+      value,
+      templateValue: expressionTemplateValue,
+      context: expressionPreviewContext,
+      errorMessage: expressionErrorMessage,
+    });
+
     return (
       <ReadonlyConfigurationField
         field={field}
@@ -293,6 +308,7 @@ export const ConfigurationFieldRenderer = ({
         value={value}
         isTogglable={isTogglable}
         isEnabled={isEnabled}
+        expressionPreview={expressionPreview}
       />
     );
   }

--- a/web_src/src/ui/configurationFieldRenderer/types.ts
+++ b/web_src/src/ui/configurationFieldRenderer/types.ts
@@ -23,4 +23,7 @@ export interface FieldRendererProps {
   readOnly?: boolean;
   excludedSuggestions?: string[];
   valuePreviewLabel?: string;
+  expressionPreviewContext?: Record<string, unknown> | null;
+  expressionErrorMessage?: string;
+  expressionTemplateValue?: unknown;
 }


### PR DESCRIPTION
## Summary

Adds applied runtime configuration previews in the run inspector so expression-backed fields are easier to debug from historical runs.

## Details

- Shows applied runtime config by default and lets users switch back to the expression template with `Show expression`.
- Highlights resolved expression segments inline as `{{ resolved value }}` without repeating the global execution error.
- Uses the committed canvas version from `run.versionId` so the expression view reflects the configuration that actually produced the run.
- Shows field-specific expression resolution errors below the affected readonly field.

## Validation

- `npm run test:run -- RunInspectorPanel.spec.tsx`
- `make format.js`
- `make check.build.ui`