### PR TITLE
feat: Table Widget, Value + Trend Column

### DIFF
--- a/docs/prd/console-and-widgets.md
+++ b/docs/prd/console-and-widgets.md
@@ -236,14 +236,15 @@ Each column needs a non-empty `field`. Optional fields:
 | `href` | Link template for `link` columns. Accepts `{{ cel }}` expressions and templates (e.g. `{{ prUrl }}` or `https://github.com/{{ org }}/pull/{{ prNumber }}`), legacy single-brace `{field}` placeholders, and bare static URLs. The column editor shows a dedicated href input with a field picker (values inserted as `{{ field }}`) when the format is `link`. |
 | `progressTarget` | Target (100%) for `format: progress`. Required for progress columns. Accepts a numeric literal (`"10"`, `"100.5"`), a row field path (`total`, `payload.goal`), or a full `{{ CEL }}` expression (`{{ base * 2 }}`). Resolved with the same helper as `field`. |
 | `progressLabel` | Text rendered next to the progress bar: `none`, `number` (`5/10`), or `percent` (`50%`). Defaults to `percent`. The bar itself clamps at `[0, 100]%`, but the label and hover tooltip always show the real percentage, so overshoots (`120%`, `12/10`) stay visible. |
-| `trendBetter` | For `format: trend`. `up` (default) treats an increase as better (green), `down` treats a decrease as better. |
-| `trendDisplay` | For `format: trend`. `percent` (default) prints a signed percent change, `value` prints a signed absolute delta, `none` renders arrow only. |
+| `trendBetter` | For `format: trend` or numeric columns with `showTrend: true`. `up` (default) treats an increase as better (green), `down` treats a decrease as better. |
+| `trendDisplay` | For `format: trend` or numeric columns with `showTrend: true`. `percent` (default) prints a signed percent change, `value` prints a signed absolute delta, `none` renders arrow only. |
+| `showTrend` | When `true` on `number`, `percent`, or `duration`, renders the formatted value plus a trend chip in the same cell (same row-below semantics as `format: trend`). Ignored on other formats. |
 
 Column fields can be direct paths such as `status` or expression templates where supported by the widget helpers.
 
 #### Trend columns
 
-`format: trend` turns a numeric column into a row-to-row comparison. The cell resolves the column's `field` (path or `{{ CEL }}`) on both the current row and the row directly below it, then renders one of the following:
+`format: trend` turns a numeric column into a **trend-only** row-to-row comparison. The cell resolves the column's `field` (path or `{{ CEL }}`) on both the current row and the row directly below it, then renders one of the following:
 
 | Case | Cell |
 | --- | --- |
@@ -262,8 +263,33 @@ Notes:
 - On progressive tables, when more rows are already loaded but still hidden behind the display window, the last visible trend cell compares against that first hidden row instead of showing pending `...`. Pending is reserved for baselines that have not been fetched yet.
 - Percent math is `(current - previous) / |previous| * 100`, rounded to one decimal, capped at ±999% (values beyond the cap render as `>+999%` / `<-999%`).
 - `trend` cells never carry a link/href — combine with a separate `link` column when both are needed.
+- Prefer **`showTrend: true`** on `number` / `percent` / `duration` when you want the formatted value and the trend in one column (e.g. `4.5s  ↘ -10%`). Keep `format: trend` when you want a dedicated delta column.
 
-Example — duration trend where a shorter run is a win:
+Example — duration and pass rate with value + trend in one column:
+
+```yaml
+render:
+  kind: table
+  sort:
+    field: createdAt
+    order: desc
+  columns:
+    - field: name
+      label: Node
+    - field: durationMs
+      label: Duration
+      format: duration
+      showTrend: true
+      trendBetter: down
+      trendDisplay: percent
+    - field: passRate
+      label: Pass rate
+      format: percent
+      showTrend: true
+      trendBetter: up
+```
+
+Example — standalone trend column where a shorter run is a win:
 
 ```yaml
 render:

--- a/pkg/yaml/console.go
+++ b/pkg/yaml/console.go
@@ -703,6 +703,11 @@ var (
 )
 
 func validateTableColumnTrend(panelID string, index int, column map[string]any) error {
+	if raw, ok := column["showTrend"]; ok && raw != nil {
+		if _, isBool := raw.(bool); !isBool {
+			return fmt.Errorf("panel %q render.columns[%d].showTrend must be a boolean", panelID, index)
+		}
+	}
 	if raw, ok := column["trendBetter"]; ok && raw != nil {
 		s, isString := raw.(string)
 		if !isString || !slices.Contains(allowedTrendBetter, s) {

--- a/pkg/yaml/console_test.go
+++ b/pkg/yaml/console_test.go
@@ -832,6 +832,27 @@ func TestValidateConsoleContent_RejectsInvalidTypedPanelConfig(t *testing.T) {
 			contains: "render.columns[0].trendDisplay must be one of",
 		},
 		{
+			name: "table column with invalid showTrend",
+			panel: ConsolePanel{
+				ID:   "table",
+				Type: ConsolePanelTypeTable,
+				Content: map[string]any{
+					"dataSource": map[string]any{"kind": "memory", "namespace": "env"},
+					"render": map[string]any{
+						"kind": "table",
+						"columns": []any{
+							map[string]any{
+								"field":     "durationMs",
+								"format":    "duration",
+								"showTrend": "yes",
+							},
+						},
+					},
+				},
+			},
+			contains: "render.columns[0].showTrend must be a boolean",
+		},
+		{
 			name: "row style with unknown tone",
 			panel: ConsolePanel{
 				ID:   "table",
@@ -1288,6 +1309,18 @@ func TestValidateConsoleContent_AcceptsTableTrendColumns(t *testing.T) {
 							"field":        "coverage",
 							"format":       "trend",
 							"trendDisplay": "none",
+						},
+						map[string]any{
+							"field":        "durationMs",
+							"format":       "duration",
+							"showTrend":    true,
+							"trendBetter":  "down",
+							"trendDisplay": "percent",
+						},
+						map[string]any{
+							"field":     "passRate",
+							"format":    "percent",
+							"showTrend": true,
 						},
 					},
 				},

--- a/web_src/src/pages/app/console/TablePanelFormRows.tsx
+++ b/web_src/src/pages/app/console/TablePanelFormRows.tsx
@@ -1,8 +1,11 @@
+import { useId } from "react";
 import { Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Checkbox } from "@/ui/checkbox";
 
 import { ROW_STYLE_CLASS, ROW_STYLE_LABEL } from "./widget/rowStyles";
 import {
@@ -10,6 +13,7 @@ import {
   WIDGET_ROW_STYLE_TONES,
   WIDGET_TREND_BETTER,
   WIDGET_TREND_DISPLAYS,
+  columnSupportsShowTrend,
   type WidgetColumnFormat,
   type WidgetProgressLabel,
   type WidgetRowStyle,
@@ -56,13 +60,18 @@ const TREND_DISPLAY_LABEL: Record<WidgetTrendDisplay, string> = {
 };
 
 function columnFormatPatch(format: WidgetColumnFormat | undefined, col: WidgetTableColumn): Partial<WidgetTableColumn> {
+  const keepTrendOpts = format === "trend" || columnSupportsShowTrend(format);
   return {
     format,
     ...(format === "link" ? {} : { href: undefined }),
     ...(format === "progress"
       ? { progressLabel: col.progressLabel ?? "percent" }
       : { progressTarget: undefined, progressLabel: undefined }),
-    ...(format === "trend" ? {} : { trendBetter: undefined, trendDisplay: undefined }),
+    ...(keepTrendOpts
+      ? format === "trend"
+        ? { showTrend: undefined }
+        : {}
+      : { showTrend: undefined, trendBetter: undefined, trendDisplay: undefined }),
   };
 }
 
@@ -144,6 +153,36 @@ function TrendFormatFields({
   );
 }
 
+function ShowTrendToggle({
+  col,
+  onChange,
+}: {
+  col: WidgetTableColumn;
+  onChange: (patch: Partial<WidgetTableColumn>) => void;
+}) {
+  const showTrendId = useId();
+  return (
+    <div className="col-span-12 flex items-center gap-2">
+      <Checkbox
+        id={showTrendId}
+        checked={Boolean(col.showTrend)}
+        onCheckedChange={(checked) =>
+          onChange(
+            checked === true
+              ? { showTrend: true }
+              : { showTrend: undefined, trendBetter: undefined, trendDisplay: undefined },
+          )
+        }
+        className="border-slate-300 data-[state=checked]:border-sky-600 data-[state=checked]:bg-sky-600 dark:border-gray-600"
+        data-testid="table-column-show-trend"
+      />
+      <Label htmlFor={showTrendId} className="text-xs text-slate-700 dark:text-gray-300">
+        Show trend
+      </Label>
+    </div>
+  );
+}
+
 export function ColumnRow({
   col,
   fieldOptions,
@@ -211,6 +250,12 @@ export function ColumnRow({
         ) : null}
         {col.format === "progress" ? (
           <ProgressFormatFields col={col} fieldOptions={fieldOptions} onChange={onChange} />
+        ) : null}
+        {columnSupportsShowTrend(col.format) ? (
+          <>
+            <ShowTrendToggle col={col} onChange={onChange} />
+            {col.showTrend ? <TrendFormatFields col={col} onChange={onChange} /> : null}
+          </>
         ) : null}
         {col.format === "trend" ? <TrendFormatFields col={col} onChange={onChange} /> : null}
       </div>

--- a/web_src/src/pages/app/console/panelTypes.tableColumns.spec.ts
+++ b/web_src/src/pages/app/console/panelTypes.tableColumns.spec.ts
@@ -60,4 +60,41 @@ describe("normalizeTablePanelContent — progress/trend columns", () => {
     expect(normalized.render.columns[1].trendBetter).toBeUndefined();
     expect(normalized.render.columns[1].trendDisplay).toBeUndefined();
   });
+
+  it("preserves showTrend on numeric columns and drops non-true values", () => {
+    const normalized = normalizeTablePanelContent({
+      dataSource: { kind: "memory", namespace: "runs" },
+      render: {
+        kind: "table",
+        columns: [
+          {
+            field: "durationMs",
+            format: "duration",
+            showTrend: true,
+            trendBetter: "down",
+            trendDisplay: "percent",
+          },
+          {
+            field: "passRate",
+            format: "percent",
+            showTrend: "yes",
+          },
+          {
+            field: "score",
+            format: "number",
+            showTrend: false,
+          },
+        ],
+      },
+    });
+    expect(normalized.render.columns[0]).toMatchObject({
+      field: "durationMs",
+      format: "duration",
+      showTrend: true,
+      trendBetter: "down",
+      trendDisplay: "percent",
+    });
+    expect(normalized.render.columns[1].showTrend).toBeUndefined();
+    expect(normalized.render.columns[2].showTrend).toBeUndefined();
+  });
 });

--- a/web_src/src/pages/app/console/panelTypes.ts
+++ b/web_src/src/pages/app/console/panelTypes.ts
@@ -476,6 +476,7 @@ function normalizeTableColumns(raw: unknown): WidgetTableColumn[] {
       avatarCommitterField: typeof c.avatarCommitterField === "string" ? c.avatarCommitterField : undefined,
       progressTarget: typeof c.progressTarget === "string" ? c.progressTarget : undefined,
       progressLabel: optionalEnum(c.progressLabel, WIDGET_PROGRESS_LABELS),
+      showTrend: c.showTrend === true ? true : undefined,
       trendBetter: optionalEnum(c.trendBetter, WIDGET_TREND_BETTER),
       trendDisplay: optionalEnum(c.trendDisplay, WIDGET_TREND_DISPLAYS),
     };

--- a/web_src/src/pages/app/console/widget/WidgetTable.stories.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTable.stories.tsx
@@ -395,6 +395,62 @@ export const TrendDisplayWindowPeek: Story = {
   },
 };
 
+/**
+ * Value + trend in one column via `showTrend` on number / percent / duration.
+ * Same deploy rows as the Trend story — compare side-by-side with Trend.
+ */
+export const ValueWithTrend: Story = {
+  render: (args) => <TablePanel title="Deploys (value + trend)" {...args} />,
+  args: {
+    render: {
+      kind: "table",
+      columns: [
+        { field: "deploy", label: "Deploy" },
+        {
+          field: "durationMs",
+          label: "Duration",
+          format: "duration",
+          showTrend: true,
+          trendBetter: "down",
+          trendDisplay: "percent",
+        },
+        {
+          field: "errorRate",
+          label: "Errors %",
+          format: "number",
+          showTrend: true,
+          trendBetter: "down",
+          trendDisplay: "value",
+        },
+        {
+          field: "throughput",
+          label: "RPS",
+          format: "number",
+          showTrend: true,
+          trendBetter: "up",
+          trendDisplay: "percent",
+        },
+        {
+          field: "passRate",
+          label: "Pass rate",
+          format: "percent",
+          showTrend: true,
+          trendBetter: "up",
+          trendDisplay: "percent",
+        },
+      ],
+    },
+    rows: [
+      { deploy: "deploy #106", durationMs: 4200, errorRate: 0.4, throughput: 1250, passRate: 0.96 },
+      { deploy: "deploy #105", durationMs: 5100, errorRate: 0.8, throughput: 1180, passRate: 0.93 },
+      { deploy: "deploy #104", durationMs: 5100, errorRate: 0.8, throughput: 1180, passRate: 0.93 },
+      { deploy: "deploy #103", durationMs: 4700, errorRate: 1.2, throughput: 940, passRate: 0.88 },
+      { deploy: "deploy #102", durationMs: 6800, errorRate: 2.5, throughput: 720, passRate: 0.81 },
+    ],
+    isLoading: false,
+  },
+};
+
 /** Org fixture: `pr-risk-review` console → `checks-table` memory panel. */
 export const PrRiskRecentChecks: Story = {
   render: (args) => (

--- a/web_src/src/pages/app/console/widget/WidgetTable.trend.spec.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTable.trend.spec.tsx
@@ -220,4 +220,59 @@ describe("WidgetTable trend columns", () => {
     expect(cells[0].textContent).toContain("-1");
     view.unmount();
   });
+
+  it("renders formatted value beside the trend chip when showTrend is set", () => {
+    const view = renderTrend({
+      render: {
+        kind: "table",
+        columns: [
+          { field: "id", label: "Deploy" },
+          {
+            field: "durationMs",
+            label: "Duration",
+            format: "duration",
+            showTrend: true,
+            trendBetter: "down",
+            trendDisplay: "percent",
+          },
+        ],
+      },
+      rows: TREND_ROWS,
+    });
+    const combined = view.container.querySelectorAll('[data-testid="widget-value-with-trend"]');
+    expect(combined).toHaveLength(3);
+    expect(combined[0].textContent).toContain("900ms");
+    expect(combined[0].textContent).toContain("-10%");
+    const chip = combined[0].querySelector('[data-testid="widget-trend-cell"]');
+    expect(chip?.getAttribute("data-trend-kind")).toBe("changed");
+    expect(chip?.getAttribute("data-trend-direction")).toBe("down");
+    expect(chip?.getAttribute("data-trend-polarity")).toBe("better");
+    view.unmount();
+  });
+
+  it("keeps the value visible when the trend chip is pending", () => {
+    const view = renderTrend({
+      render: {
+        kind: "table",
+        columns: [
+          {
+            field: "passRate",
+            label: "Pass rate",
+            format: "percent",
+            showTrend: true,
+            trendBetter: "up",
+          },
+        ],
+      },
+      rows: [{ passRate: 0.9 }, { passRate: 0.8 }],
+      hasMore: true,
+    });
+    const combined = view.container.querySelectorAll('[data-testid="widget-value-with-trend"]');
+    const last = combined[combined.length - 1];
+    expect(last.textContent).toContain("80%");
+    const chip = last.querySelector('[data-testid="widget-trend-cell"]');
+    expect(chip?.getAttribute("data-trend-kind")).toBe("pending");
+    expect(chip?.textContent).toContain("...");
+    view.unmount();
+  });
 });

--- a/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
@@ -247,7 +247,7 @@ function TrendChip({ result, display }: { result: TrendResult; display: WidgetTa
 
   const content = (
     <span
-      className={cn("inline-flex items-center gap-1 whitespace-nowrap tabular-nums", trendColorClasses(result))}
+      className={cn("inline-flex items-center whitespace-nowrap tabular-nums", trendColorClasses(result))}
       data-testid="widget-trend-cell"
       data-trend-kind={result.kind}
       data-trend-direction={result.kind === "changed" ? result.direction : undefined}

--- a/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
@@ -216,9 +216,11 @@ function ValueWithTrendCell({
   const result = resolveColumnTrend(col, row, nextRow, hasMoreBelow);
   return (
     <td className="px-3 py-1.5 align-middle">
-      <span className="inline-flex items-center gap-1 whitespace-nowrap" data-testid="widget-value-with-trend">
+      <span className="inline-flex items-center whitespace-nowrap" data-testid="widget-value-with-trend">
         <span className="tabular-nums text-slate-700 dark:text-gray-300">{label}</span>
-        <TrendChip result={result} display={col.trendDisplay} />
+        <span className="ml-1">
+          <TrendChip result={result} display={col.trendDisplay} />
+        </span>
       </span>
     </td>
   );

--- a/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
@@ -218,9 +218,7 @@ function ValueWithTrendCell({
     <td className="px-3 py-1.5 align-middle">
       <span className="inline-flex items-center whitespace-nowrap" data-testid="widget-value-with-trend">
         <span className="tabular-nums text-slate-700 dark:text-gray-300">{label}</span>
-        <span className="ml-1">
-          <TrendChip result={result} display={col.trendDisplay} />
-        </span>
+        <TrendChip result={result} display={col.trendDisplay} />
       </span>
     </td>
   );

--- a/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
@@ -13,6 +13,7 @@ import { evaluateRowShow } from "./rowVisibility";
 import { resolveCellValue } from "./resolveCellValue";
 import { resolveHref } from "./resolveHref";
 import type { WidgetTableRender } from "./types";
+import { columnSupportsShowTrend } from "./types";
 import { coerceWidgetTimestamp, computeProgress, formatPercentageDisplay, formatValue } from "./widgetFormat";
 import { computeTrend, formatTrendLabel, formatTrendTooltip, type TrendResult } from "./widgetTrend";
 
@@ -23,17 +24,17 @@ export interface WidgetTableCellProps {
   row: Record<string, unknown>;
   /**
    * The row rendered immediately below the current one, after filter+sort.
-   * Only consumed by `format: "trend"` columns. `undefined` for the last
-   * visible row.
+   * Consumed by `format: "trend"` and by numeric columns with `showTrend`.
+   * `undefined` for the last visible row.
    */
   nextRow?: Record<string, unknown>;
   /**
    * Whether more rows can still be loaded below the current one. Only
    * meaningful for the last visible row of a paginated table when the
    * previous entry has not been fetched yet; enables the `...` pending
-   * state on `format: "trend"` cells. Must not be set merely because more
-   * rows are loaded but still hidden behind the progressive display window
-   * — pass those via `nextRow` instead.
+   * state on trend chips. Must not be set merely because more rows are
+   * loaded but still hidden behind the progressive display window — pass
+   * those via `nextRow` instead.
    */
   hasMoreBelow?: boolean;
 }
@@ -43,11 +44,15 @@ export function WidgetTableCell({ col, row, nextRow, hasMoreBelow }: WidgetTable
   if (!visible) return <EmptyCell />;
 
   if (col.format === "trend") {
-    return <TrendCell col={col} row={row} nextRow={nextRow} hasMoreBelow={hasMoreBelow} />;
+    return <TrendOnlyCell col={col} row={row} nextRow={nextRow} hasMoreBelow={hasMoreBelow} />;
   }
 
   const value = resolveCellValue(col.field, row);
   const formatted = formatValue(value, col.format);
+
+  if (col.showTrend && columnSupportsShowTrend(col.format)) {
+    return <ValueWithTrendCell col={col} row={row} nextRow={nextRow} hasMoreBelow={hasMoreBelow} label={formatted} />;
+  }
 
   switch (col.format) {
     case "badge":
@@ -176,7 +181,7 @@ const TREND_MUTED_CLASSES = "text-slate-400 dark:text-gray-500";
 const TREND_BETTER_CLASSES = "text-emerald-600 dark:text-emerald-400";
 const TREND_WORSE_CLASSES = "text-red-600 dark:text-red-400";
 
-function TrendCell({
+function TrendOnlyCell({
   col,
   row,
   nextRow,
@@ -187,16 +192,57 @@ function TrendCell({
   nextRow: Record<string, unknown> | undefined;
   hasMoreBelow: boolean | undefined;
 }) {
+  const result = resolveColumnTrend(col, row, nextRow, hasMoreBelow);
+  return (
+    <td className="px-3 py-1.5 align-middle">
+      <TrendChip result={result} display={col.trendDisplay} />
+    </td>
+  );
+}
+
+function ValueWithTrendCell({
+  col,
+  row,
+  nextRow,
+  hasMoreBelow,
+  label,
+}: {
+  col: WidgetTableColumn;
+  row: Record<string, unknown>;
+  nextRow: Record<string, unknown> | undefined;
+  hasMoreBelow: boolean | undefined;
+  label: string;
+}) {
+  const result = resolveColumnTrend(col, row, nextRow, hasMoreBelow);
+  return (
+    <td className="px-3 py-1.5 align-middle">
+      <span className="inline-flex items-center gap-2 whitespace-nowrap" data-testid="widget-value-with-trend">
+        <span className="tabular-nums text-slate-700 dark:text-gray-300">{label}</span>
+        <TrendChip result={result} display={col.trendDisplay} />
+      </span>
+    </td>
+  );
+}
+
+function resolveColumnTrend(
+  col: WidgetTableColumn,
+  row: Record<string, unknown>,
+  nextRow: Record<string, unknown> | undefined,
+  hasMoreBelow: boolean | undefined,
+): TrendResult {
   const current = resolveCellValue(col.field, row);
   // `undefined` means "no row below" to computeTrend. A present next row with a
   // missing field must become `null` so it renders as incomparable, not no-baseline.
   const previous = nextRow ? (resolveCellValue(col.field, nextRow) ?? null) : undefined;
-  const result = computeTrend(current, previous, {
+  return computeTrend(current, previous, {
     better: col.trendBetter,
     display: col.trendDisplay,
     hasMoreBelow: nextRow ? false : Boolean(hasMoreBelow),
   });
-  const label = formatTrendLabel(result, col.trendDisplay);
+}
+
+function TrendChip({ result, display }: { result: TrendResult; display: WidgetTableColumn["trendDisplay"] }) {
+  const label = formatTrendLabel(result, display);
   const tooltip = formatTrendTooltip(result);
 
   const content = (
@@ -212,19 +258,15 @@ function TrendCell({
     </span>
   );
 
+  if (!tooltip) return content;
+
   return (
-    <td className="px-3 py-1.5 align-middle">
-      {tooltip ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex cursor-default">{content}</span>
-          </TooltipTrigger>
-          <TooltipContent side="top">{tooltip}</TooltipContent>
-        </Tooltip>
-      ) : (
-        content
-      )}
-    </td>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex cursor-default">{content}</span>
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
@@ -216,7 +216,7 @@ function ValueWithTrendCell({
   const result = resolveColumnTrend(col, row, nextRow, hasMoreBelow);
   return (
     <td className="px-3 py-1.5 align-middle">
-      <span className="inline-flex items-center gap-2 whitespace-nowrap" data-testid="widget-value-with-trend">
+      <span className="inline-flex items-center gap-1 whitespace-nowrap" data-testid="widget-value-with-trend">
         <span className="tabular-nums text-slate-700 dark:text-gray-300">{label}</span>
         <TrendChip result={result} display={col.trendDisplay} />
       </span>

--- a/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTableCell.tsx
@@ -218,7 +218,9 @@ function ValueWithTrendCell({
     <td className="px-3 py-1.5 align-middle">
       <span className="inline-flex items-center whitespace-nowrap" data-testid="widget-value-with-trend">
         <span className="tabular-nums text-slate-700 dark:text-gray-300">{label}</span>
-        <TrendChip result={result} display={col.trendDisplay} />
+        <span className="ml-1.5">
+          <TrendChip result={result} display={col.trendDisplay} />
+        </span>
       </span>
     </td>
   );

--- a/web_src/src/pages/app/console/widget/types.ts
+++ b/web_src/src/pages/app/console/widget/types.ts
@@ -45,7 +45,7 @@ export type WidgetProgressLabel = "none" | "number" | "percent";
 export const WIDGET_PROGRESS_LABELS: WidgetProgressLabel[] = ["none", "number", "percent"];
 
 /**
- * Direction that signals a "better" trend for `format: trend` columns.
+ * Direction that signals a "better" trend for trend columns / `showTrend`.
  * `up` (default) → an increase is good (green), a decrease is bad (red).
  * `down` → an increase is bad (red), a decrease is good (green).
  */
@@ -53,13 +53,20 @@ export type WidgetTrendBetter = "up" | "down";
 export const WIDGET_TREND_BETTER: WidgetTrendBetter[] = ["up", "down"];
 
 /**
- * How a trend cell prints its magnitude alongside the arrow.
+ * How a trend chip prints its magnitude alongside the arrow.
  * `percent` (default) → signed percent change vs. the row below.
  * `value` → signed absolute delta vs. the row below.
  * `none` → arrow only (still shows `- 0` / `...` / `-` for edge states).
  */
 export type WidgetTrendDisplay = "percent" | "value" | "none";
 export const WIDGET_TREND_DISPLAYS: WidgetTrendDisplay[] = ["percent", "value", "none"];
+
+/** Formats that can show a value + trend chip via `showTrend`. */
+export const WIDGET_SHOW_TREND_FORMATS: WidgetColumnFormat[] = ["number", "percent", "duration"];
+
+export function columnSupportsShowTrend(format: WidgetColumnFormat | undefined): boolean {
+  return format != null && WIDGET_SHOW_TREND_FORMATS.includes(format);
+}
 
 export interface WidgetTableColumn {
   field: string;
@@ -77,9 +84,14 @@ export interface WidgetTableColumn {
   progressTarget?: string;
   /** Label style rendered next to the progress bar. Defaults to `"percent"`. */
   progressLabel?: WidgetProgressLabel;
-  /** For `format: trend`: which direction is "better". Defaults to `up`. */
+  /**
+   * When true on `number` | `percent` | `duration`, render the formatted value
+   * plus a trend chip (same semantics as `format: trend`). Ignored otherwise.
+   */
+  showTrend?: boolean;
+  /** Which direction is "better" for trend / `showTrend`. Defaults to `up`. */
   trendBetter?: WidgetTrendBetter;
-  /** For `format: trend`: what to show next to the arrow. Defaults to `percent`. */
+  /** What to show next to the trend arrow. Defaults to `percent`. */
   trendDisplay?: WidgetTrendDisplay;
 }
 

--- a/web_src/src/pages/app/console/widget/widgetTrend.ts
+++ b/web_src/src/pages/app/console/widget/widgetTrend.ts
@@ -1,7 +1,8 @@
 /**
- * Pure comparison math for `format: "trend"` table columns.
+ * Pure comparison math for `format: "trend"` columns and for numeric columns
+ * with `showTrend: true`.
  *
- * A trend cell compares the current row's numeric value against the "row
+ * A trend chip compares the current row's numeric value against the "row
  * below" in the filtered+sorted table (the previous entry in whatever
  * ordering the author configured). Rendering is intentionally split out —
  * this module returns a discriminated result the cell renderer can


### PR DESCRIPTION
## Summary
- Add `showTrend` on `number` / `percent` / `duration` table columns so the formatted value and row-below trend chip render in one cell (e.g. `4.5s ↘ -10%`)
- Keep standalone `format: trend` for trend-only columns; panel form gets a Show trend toggle with the existing better/display options
- Cover normalize/YAML validation, WidgetTable specs, Storybook `ValueWithTrend`, and PRD examples

## Test plan
- [ ] Open Storybook → Console/Table → **ValueWithTrend** and confirm duration/percent/number cells show value + trend
- [ ] In a console table panel editor, set format to duration/percent/number, enable Show trend, and verify YAML round-trips `showTrend` / `trendBetter` / `trendDisplay`
- [ ] Confirm standalone `format: trend` columns still behave as before (including pending / flat / no-baseline)
- [ ] Confirm pending edge state still shows the value when more rows are loading
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/superplanehq/superplane/pull/6048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->