### PR TITLE
feat: add GitLab getIssue, updateIssue, createIssueComment components

### DIFF
--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -1887,7 +1887,7 @@ The Update Issue component modifies an existing GitLab issue: its title, descrip
 - **Assignees** (toggle): Users to assign the issue to, replacing any existing assignees
 - **Milestone** (toggle): Milestone to associate with the issue
 
-Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled.
+Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled. Enabling a field with an empty value clears it - e.g. toggling on Labels or Assignees with nothing selected removes all of them, and toggling on Milestone with nothing selected unassigns the milestone.
 
 ### Output
 

--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -1880,14 +1880,14 @@ The Update Issue component modifies an existing GitLab issue: its title, descrip
 
 - **Project** (required): The GitLab project containing the issue
 - **Issue IID** (required): The internal ID (IID) of the issue to update (supports expressions)
-- **Title** (optional): New title for the issue
-- **Description** (optional): New description for the issue
-- **State** (optional): Close or reopen the issue. Leave unset to keep the current state.
-- **Labels** (optional): Labels to set on the issue, replacing any existing labels
-- **Assignees** (optional): Users to assign the issue to, replacing any existing assignees
-- **Milestone** (optional): Milestone to associate with the issue
+- **Title** (toggle): New title for the issue
+- **Description** (toggle): New description for the issue
+- **State** (toggle): Close or reopen the issue
+- **Labels** (toggle): Labels to set on the issue, replacing any existing labels
+- **Assignees** (toggle): Users to assign the issue to, replacing any existing assignees
+- **Milestone** (toggle): Milestone to associate with the issue
 
-Fields left empty are not changed.
+Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled.
 
 ### Output
 

--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -30,11 +30,14 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Create Deployment" href="#create-deployment" description="Create a deployment for a GitLab environment" />
   <LinkCard title="Create Deployment Status" href="#create-deployment-status" description="Update the status of a GitLab deployment" />
   <LinkCard title="Create Issue" href="#create-issue" description="Create a new issue in a GitLab project" />
+  <LinkCard title="Create Issue Comment" href="#create-issue-comment" description="Add a comment to a GitLab issue" />
   <LinkCard title="Create Merge Request Comment" href="#create-merge-request-comment" description="Add a comment to a GitLab merge request" />
+  <LinkCard title="Get Issue" href="#get-issue" description="Fetch a single GitLab issue by its IID" />
   <LinkCard title="Get Latest Pipeline" href="#get-latest-pipeline" description="Get the latest GitLab pipeline for a project" />
   <LinkCard title="Get Pipeline" href="#get-pipeline" description="Get a GitLab pipeline" />
   <LinkCard title="Get Test Report Summary" href="#get-test-report-summary" description="Get GitLab pipeline test report summary" />
   <LinkCard title="Run Pipeline" href="#run-pipeline" description="Run a GitLab pipeline and wait for completion" />
+  <LinkCard title="Update Issue" href="#update-issue" description="Update an existing GitLab issue" />
 </CardGrid>
 
 ## Instructions
@@ -1433,6 +1436,62 @@ The component outputs the created issue object, including:
 }
 ```
 
+<a id="create-issue-comment"></a>
+
+## Create Issue Comment
+
+**Component key:** `gitlab.createIssueComment`
+
+The Create Issue Comment component adds a comment (note) to an existing GitLab issue.
+
+### Use Cases
+
+- **Automated updates**: Post deployment status or remediation updates to GitLab issues
+- **Runbook linking**: Add runbook links, error details, or status for responders
+- **Cross-platform sync**: Sync Slack or PagerDuty notes into GitLab as comments
+- **Automated comments**: Add automated comments based on workflow events
+
+### Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to comment on (supports expressions)
+- **Body** (required): The comment text (supports Markdown and expressions)
+
+### Output
+
+Returns the created note object, including:
+- **id**: The ID of the note
+- **body**: The comment text
+- **author**: The user who created the comment
+- **created_at**: When the comment was created
+
+### Example Output
+
+```json
+{
+  "data": {
+    "author": {
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+      "id": 1,
+      "name": "Administrator",
+      "state": "active",
+      "username": "root",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "body": "This is an example comment created via SuperPlane",
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "id": 302,
+    "noteable_id": 1,
+    "noteable_iid": 1,
+    "noteable_type": "Issue",
+    "system": false,
+    "updated_at": "2023-01-01T10:00:00.000Z"
+  },
+  "timestamp": "2023-01-01T10:00:00.000Z",
+  "type": "gitlab.createIssueComment"
+}
+```
+
 <a id="create-merge-request-comment"></a>
 
 ## Create Merge Request Comment
@@ -1485,6 +1544,80 @@ Returns the created note object, including:
   },
   "timestamp": "2023-01-01T10:00:00.000Z",
   "type": "gitlab.createMergeComment"
+}
+```
+
+<a id="get-issue"></a>
+
+## Get Issue
+
+**Component key:** `gitlab.getIssue`
+
+The Get Issue component fetches a single issue from a GitLab project by its internal ID (IID).
+
+### Use Cases
+
+- **Read state, then act**: Look up an issue's current title, description, state, labels, or assignees before deciding what to do next
+- **Data enrichment**: Pull issue details into a workflow to combine with other information
+- **Status checking**: Check whether an issue is open or closed before performing an action
+
+### Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to fetch (supports expressions)
+
+### Output
+
+Returns the issue object, including:
+- **id** / **iid**: The internal and project-relative IDs of the issue
+- **title** / **description**: The issue's content
+- **state**: The current state of the issue (opened/closed)
+- **labels**, **assignees**, **milestone**: Metadata on the issue
+- **web_url**: The URL to view the issue in GitLab
+
+### Example Output
+
+```json
+{
+  "data": {
+    "assignees": [
+      {
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+        "id": 1,
+        "name": "Administrator",
+        "state": "active",
+        "username": "root",
+        "web_url": "http://gitlab.example.com/root"
+      }
+    ],
+    "author": {
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+      "id": 1,
+      "name": "Administrator",
+      "state": "active",
+      "username": "root",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "closed_at": null,
+    "closed_by": null,
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "description": "This is an example issue created via SuperPlane",
+    "due_date": null,
+    "id": 1,
+    "iid": 1,
+    "labels": [
+      "bug",
+      "urgent"
+    ],
+    "milestone": null,
+    "project_id": 3,
+    "state": "opened",
+    "title": "Example Issue",
+    "updated_at": "2023-01-01T10:00:00.000Z",
+    "web_url": "http://gitlab.example.com/gitlab-org/gitlab-test/issues/1"
+  },
+  "timestamp": "2023-01-01T10:00:00.000Z",
+  "type": "gitlab.getIssue"
 }
 ```
 
@@ -1725,6 +1858,91 @@ The Run Pipeline component triggers a GitLab pipeline and waits for it to comple
   },
   "timestamp": "2026-02-13T18:04:12.000Z",
   "type": "gitlab.pipeline.finished"
+}
+```
+
+<a id="update-issue"></a>
+
+## Update Issue
+
+**Component key:** `gitlab.updateIssue`
+
+The Update Issue component modifies an existing GitLab issue: its title, description, state, labels, assignees, or milestone.
+
+### Use Cases
+
+- **Status updates**: Close or reopen an issue based on workflow results
+- **Label management**: Apply labels to an issue automatically
+- **Assignee updates**: Assign an issue to team members automatically
+- **Content updates**: Update the issue title or description with new information
+
+### Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to update (supports expressions)
+- **Title** (optional): New title for the issue
+- **Description** (optional): New description for the issue
+- **State** (optional): Close or reopen the issue. Leave unset to keep the current state.
+- **Labels** (optional): Labels to set on the issue, replacing any existing labels
+- **Assignees** (optional): Users to assign the issue to, replacing any existing assignees
+- **Milestone** (optional): Milestone to associate with the issue
+
+Fields left empty are not changed.
+
+### Output
+
+Returns the updated issue object.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "assignees": [
+      {
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+        "id": 1,
+        "name": "Administrator",
+        "state": "active",
+        "username": "root",
+        "web_url": "http://gitlab.example.com/root"
+      }
+    ],
+    "author": {
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+      "id": 1,
+      "name": "Administrator",
+      "state": "active",
+      "username": "root",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "closed_at": "2023-01-01T10:05:00.000Z",
+    "closed_by": {
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+      "id": 1,
+      "name": "Administrator",
+      "state": "active",
+      "username": "root",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "description": "This is an example issue updated via SuperPlane",
+    "due_date": null,
+    "id": 1,
+    "iid": 1,
+    "labels": [
+      "bug",
+      "urgent"
+    ],
+    "milestone": null,
+    "project_id": 3,
+    "state": "closed",
+    "title": "Example Issue",
+    "updated_at": "2023-01-01T10:05:00.000Z",
+    "web_url": "http://gitlab.example.com/gitlab-org/gitlab-test/issues/1"
+  },
+  "timestamp": "2023-01-01T10:05:00.000Z",
+  "type": "gitlab.updateIssue"
 }
 ```
 

--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -1887,7 +1887,7 @@ The Update Issue component modifies an existing GitLab issue: its title, descrip
 - **Assignees** (toggle): Users to assign the issue to, replacing any existing assignees
 - **Milestone** (toggle): Milestone to associate with the issue
 
-Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled. Enabling a field with an empty value clears it - e.g. toggling on Labels or Assignees with nothing selected removes all of them, and toggling on Milestone with nothing selected unassigns the milestone.
+Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled. Enabling a field with an empty value clears it - e.g. toggling on Labels or Assignees with nothing selected removes all of them, and toggling on Milestone with nothing selected unassigns the milestone. Title is the exception: GitLab does not allow blank titles, so it must have a value when enabled.
 
 ### Output
 

--- a/pkg/integrations/gitlab/client.go
+++ b/pkg/integrations/gitlab/client.go
@@ -222,15 +222,18 @@ func (c *Client) GetIssue(ctx context.Context, projectID, issueIID string) (*Iss
 }
 
 // UpdateIssueRequest mirrors GitLab's PUT /projects/:id/issues/:issue_iid body.
-// Only non-empty/non-nil fields are sent, so callers must omit fields they don't want to change.
+// Fields are pointers so a nil field is omitted (not changed) while a non-nil
+// field is always sent, even if it points to a zero value - e.g. a non-nil
+// pointer to "" clears the description, and a non-nil pointer to an empty
+// slice clears the assignees. Callers must leave a field nil to skip it.
 type UpdateIssueRequest struct {
-	Title       string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
-	StateEvent  string `json:"state_event,omitempty"`
-	Labels      string `json:"labels,omitempty"`
-	AssigneeIDs []int  `json:"assignee_ids,omitempty"`
-	MilestoneID *int   `json:"milestone_id,omitempty"`
-	DueDate     string `json:"due_date,omitempty"`
+	Title       *string `json:"title,omitempty"`
+	Description *string `json:"description,omitempty"`
+	StateEvent  *string `json:"state_event,omitempty"`
+	Labels      *string `json:"labels,omitempty"`
+	AssigneeIDs *[]int  `json:"assignee_ids,omitempty"`
+	MilestoneID *int    `json:"milestone_id,omitempty"`
+	DueDate     *string `json:"due_date,omitempty"`
 }
 
 func (c *Client) UpdateIssue(ctx context.Context, projectID, issueIID string, req *UpdateIssueRequest) (*Issue, error) {

--- a/pkg/integrations/gitlab/client.go
+++ b/pkg/integrations/gitlab/client.go
@@ -195,6 +195,108 @@ func (c *Client) CreateIssue(ctx context.Context, projectID string, req *IssueRe
 	return &issue, nil
 }
 
+func (c *Client) GetIssue(ctx context.Context, projectID, issueIID string) (*Issue, error) {
+	apiURL := fmt.Sprintf("%s/api/%s/projects/%s/issues/%s", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(issueIID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get issue: status %d, response: %s", resp.StatusCode, readResponseBody(resp))
+	}
+
+	var issue Issue
+	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
+		return nil, fmt.Errorf("failed to decode issue: %v", err)
+	}
+
+	return &issue, nil
+}
+
+// UpdateIssueRequest mirrors GitLab's PUT /projects/:id/issues/:issue_iid body.
+// Only non-empty/non-nil fields are sent, so callers must omit fields they don't want to change.
+type UpdateIssueRequest struct {
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	StateEvent  string `json:"state_event,omitempty"`
+	Labels      string `json:"labels,omitempty"`
+	AssigneeIDs []int  `json:"assignee_ids,omitempty"`
+	MilestoneID *int   `json:"milestone_id,omitempty"`
+	DueDate     string `json:"due_date,omitempty"`
+}
+
+func (c *Client) UpdateIssue(ctx context.Context, projectID, issueIID string, req *UpdateIssueRequest) (*Issue, error) {
+	apiURL := fmt.Sprintf("%s/api/%s/projects/%s/issues/%s", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(issueIID))
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, apiURL, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to update issue: status %d, response: %s", resp.StatusCode, readResponseBody(resp))
+	}
+
+	var issue Issue
+	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
+		return nil, fmt.Errorf("failed to decode issue: %v", err)
+	}
+
+	return &issue, nil
+}
+
+func (c *Client) CreateIssueNote(ctx context.Context, projectID, issueIID string, req *CreateNoteRequest) (*Note, error) {
+	apiURL := fmt.Sprintf("%s/api/%s/projects/%s/issues/%s/notes", c.baseURL, apiVersion, url.PathEscape(projectID), url.PathEscape(issueIID))
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create issue note: status %d, response: %s", resp.StatusCode, readResponseBody(resp))
+	}
+
+	var note Note
+	if err := json.NewDecoder(resp.Body).Decode(&note); err != nil {
+		return nil, fmt.Errorf("failed to decode note: %v", err)
+	}
+
+	return &note, nil
+}
+
 type Milestone struct {
 	ID    int    `json:"id"`
 	IID   int    `json:"iid"`

--- a/pkg/integrations/gitlab/client_test.go
+++ b/pkg/integrations/gitlab/client_test.go
@@ -1188,7 +1188,8 @@ func Test__Client__UpdateIssue(t *testing.T) {
 			httpClient: mockClient,
 		}
 
-		req := &UpdateIssueRequest{Title: "Updated Title", StateEvent: "close"}
+		title, stateEvent := "Updated Title", "close"
+		req := &UpdateIssueRequest{Title: &title, StateEvent: &stateEvent}
 		result, err := client.UpdateIssue(context.Background(), "1", "1", req)
 
 		require.NoError(t, err)
@@ -1217,7 +1218,8 @@ func Test__Client__UpdateIssue(t *testing.T) {
 			httpClient: mockClient,
 		}
 
-		_, err := client.UpdateIssue(context.Background(), "1", "1", &UpdateIssueRequest{Title: "x"})
+		title := "x"
+		_, err := client.UpdateIssue(context.Background(), "1", "1", &UpdateIssueRequest{Title: &title})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to update issue")
 	})

--- a/pkg/integrations/gitlab/client_test.go
+++ b/pkg/integrations/gitlab/client_test.go
@@ -1126,7 +1126,6 @@ func Test__Client__UpdateDeployment(t *testing.T) {
 	})
 }
 
-
 func Test__Client__GetIssue(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mockClient := &contexts.HTTPContext{

--- a/pkg/integrations/gitlab/client_test.go
+++ b/pkg/integrations/gitlab/client_test.go
@@ -1125,3 +1125,146 @@ func Test__Client__UpdateDeployment(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to update deployment")
 	})
 }
+
+
+func Test__Client__GetIssue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusOK, `{"id": 101, "iid": 1, "title": "Test Issue", "state": "opened"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		result, err := client.GetIssue(context.Background(), "1", "1")
+		require.NoError(t, err)
+		assert.Equal(t, 101, result.ID)
+		assert.Equal(t, "Test Issue", result.Title)
+		assert.Equal(t, "opened", result.State)
+
+		require.Len(t, mockClient.Requests, 1)
+		assert.Equal(t, http.MethodGet, mockClient.Requests[0].Method)
+		assert.Equal(t, "https://gitlab.com/api/v4/projects/1/issues/1", mockClient.Requests[0].URL.String())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusNotFound, `{"message": "404 Issue Not Found"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, err := client.GetIssue(context.Background(), "1", "999")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get issue")
+	})
+}
+
+func Test__Client__UpdateIssue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusOK, `{"id": 101, "iid": 1, "title": "Updated Title", "state": "closed"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		req := &UpdateIssueRequest{Title: "Updated Title", StateEvent: "close"}
+		result, err := client.UpdateIssue(context.Background(), "1", "1", req)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Title", result.Title)
+		assert.Equal(t, "closed", result.State)
+
+		require.Len(t, mockClient.Requests, 1)
+		assert.Equal(t, http.MethodPut, mockClient.Requests[0].Method)
+		assert.Equal(t, "https://gitlab.com/api/v4/projects/1/issues/1", mockClient.Requests[0].URL.String())
+
+		body, _ := io.ReadAll(mockClient.Requests[0].Body)
+		assert.True(t, strings.Contains(string(body), `"state_event":"close"`))
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusBadRequest, `{"message": "400 Bad Request"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, err := client.UpdateIssue(context.Background(), "1", "1", &UpdateIssueRequest{Title: "x"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update issue")
+	})
+}
+
+func Test__Client__CreateIssueNote(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusCreated, `{"id": 55, "body": "Great work!", "noteable_type": "Issue"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		result, err := client.CreateIssueNote(context.Background(), "1", "5", &CreateNoteRequest{Body: "Great work!"})
+
+		require.NoError(t, err)
+		assert.Equal(t, 55, result.ID)
+		assert.Equal(t, "Great work!", result.Body)
+
+		require.Len(t, mockClient.Requests, 1)
+		assert.Equal(t, http.MethodPost, mockClient.Requests[0].Method)
+		assert.Equal(t, "https://gitlab.com/api/v4/projects/1/issues/5/notes", mockClient.Requests[0].URL.String())
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusNotFound, `{"message": "404 Issue Not Found"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, err := client.CreateIssueNote(context.Background(), "1", "999", &CreateNoteRequest{Body: "x"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create issue note")
+	})
+}

--- a/pkg/integrations/gitlab/create_issue_comment.go
+++ b/pkg/integrations/gitlab/create_issue_comment.go
@@ -1,0 +1,184 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_create_issue_comment.json
+var exampleOutputCreateIssueComment []byte
+
+type CreateIssueComment struct{}
+
+type CreateIssueCommentConfiguration struct {
+	Project  string `mapstructure:"project"`
+	IssueIID string `mapstructure:"issueIid"`
+	Body     string `mapstructure:"body"`
+}
+
+func (c *CreateIssueComment) Name() string {
+	return "gitlab.createIssueComment"
+}
+
+func (c *CreateIssueComment) Label() string {
+	return "Create Issue Comment"
+}
+
+func (c *CreateIssueComment) Description() string {
+	return "Add a comment to a GitLab issue"
+}
+
+func (c *CreateIssueComment) Documentation() string {
+	return `The Create Issue Comment component adds a comment (note) to an existing GitLab issue.
+
+## Use Cases
+
+- **Automated updates**: Post deployment status or remediation updates to GitLab issues
+- **Runbook linking**: Add runbook links, error details, or status for responders
+- **Cross-platform sync**: Sync Slack or PagerDuty notes into GitLab as comments
+- **Automated comments**: Add automated comments based on workflow events
+
+## Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to comment on (supports expressions)
+- **Body** (required): The comment text (supports Markdown and expressions)
+
+## Output
+
+Returns the created note object, including:
+- **id**: The ID of the note
+- **body**: The comment text
+- **author**: The user who created the comment
+- **created_at**: When the comment was created`
+}
+
+func (c *CreateIssueComment) Icon() string {
+	return "gitlab"
+}
+
+func (c *CreateIssueComment) Color() string {
+	return "orange"
+}
+
+func (c *CreateIssueComment) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateIssueComment) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputCreateIssueComment, &example); err != nil {
+		return map[string]any{}
+	}
+	return example
+}
+
+func (c *CreateIssueComment) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "project",
+			Label:    "Project",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeProject,
+				},
+			},
+		},
+		{
+			Name:        "issueIid",
+			Label:       "Issue IID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The internal ID (IID) of the issue to comment on",
+		},
+		{
+			Name:        "body",
+			Label:       "Body",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Description: "The comment text. Supports Markdown formatting.",
+		},
+	}
+}
+
+func (c *CreateIssueComment) Setup(ctx core.SetupContext) error {
+	var config CreateIssueCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Project == "" {
+		return errors.New("project is required")
+	}
+
+	if config.IssueIID == "" {
+		return errors.New("issue IID is required")
+	}
+
+	if config.Body == "" {
+		return errors.New("body is required")
+	}
+
+	return ensureProjectInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		config.Project,
+	)
+}
+
+func (c *CreateIssueComment) Execute(ctx core.ExecutionContext) error {
+	var config CreateIssueCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitLab client: %w", err)
+	}
+
+	note, err := client.CreateIssueNote(context.Background(), config.Project, config.IssueIID, &CreateNoteRequest{Body: config.Body})
+	if err != nil {
+		return fmt.Errorf("failed to create issue comment: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gitlab.createIssueComment",
+		[]any{note},
+	)
+}
+
+func (c *CreateIssueComment) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateIssueComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *CreateIssueComment) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateIssueComment) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateIssueComment) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateIssueComment) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gitlab/create_issue_comment_test.go
+++ b/pkg/integrations/gitlab/create_issue_comment_test.go
@@ -1,0 +1,157 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateIssueComment__Setup(t *testing.T) {
+	c := &CreateIssueComment{}
+
+	t.Run("missing project", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"issueIid": "1",
+				"body":     "Comment body",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("missing issue IID", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project": "123",
+				"body":    "Comment body",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issue IID is required")
+	})
+
+	t.Run("missing body", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "body is required")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"body":     "Comment body",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreateIssueComment__Execute(t *testing.T) {
+	c := &CreateIssueComment{}
+
+	t.Run("success", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"body":     "Comment body",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusCreated, `{
+						"id": 302,
+						"body": "Comment body",
+						"created_at": "2023-01-01T10:00:00.000Z",
+						"noteable_type": "Issue"
+					}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, "gitlab.createIssueComment", executionState.Type)
+
+		var note Note
+		notePayload := payload["data"]
+		payloadBytes, _ := json.Marshal(notePayload)
+		json.Unmarshal(payloadBytes, &note)
+
+		assert.Equal(t, 302, note.ID)
+		assert.Equal(t, "Comment body", note.Body)
+		assert.Equal(t, "Issue", note.NoteableType)
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "https://gitlab.com/api/v4/projects/123/issues/1/notes", httpCtx.Requests[0].URL.String())
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"body":     "Comment body",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusInternalServerError, `{"error": "internal server error"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create issue comment")
+	})
+}

--- a/pkg/integrations/gitlab/example_output_create_issue_comment.json
+++ b/pkg/integrations/gitlab/example_output_create_issue_comment.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "id": 302,
+    "body": "This is an example comment created via SuperPlane",
+    "author": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "updated_at": "2023-01-01T10:00:00.000Z",
+    "system": false,
+    "noteable_id": 1,
+    "noteable_iid": 1,
+    "noteable_type": "Issue"
+  },
+  "timestamp": "2023-01-01T10:00:00.000Z",
+  "type": "gitlab.createIssueComment"
+}

--- a/pkg/integrations/gitlab/example_output_get_issue.json
+++ b/pkg/integrations/gitlab/example_output_get_issue.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "id": 1,
+    "iid": 1,
+    "project_id": 3,
+    "title": "Example Issue",
+    "description": "This is an example issue created via SuperPlane",
+    "state": "opened",
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "updated_at": "2023-01-01T10:00:00.000Z",
+    "closed_at": null,
+    "closed_by": null,
+    "labels": ["bug", "urgent"],
+    "milestone": null,
+    "assignees": [
+      {
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/root"
+      }
+    ],
+    "author": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "due_date": null,
+    "web_url": "http://gitlab.example.com/gitlab-org/gitlab-test/issues/1"
+  },
+  "timestamp": "2023-01-01T10:00:00.000Z",
+  "type": "gitlab.getIssue"
+}

--- a/pkg/integrations/gitlab/example_output_update_issue.json
+++ b/pkg/integrations/gitlab/example_output_update_issue.json
@@ -1,0 +1,45 @@
+{
+  "data": {
+    "id": 1,
+    "iid": 1,
+    "project_id": 3,
+    "title": "Example Issue",
+    "description": "This is an example issue updated via SuperPlane",
+    "state": "closed",
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "updated_at": "2023-01-01T10:05:00.000Z",
+    "closed_at": "2023-01-01T10:05:00.000Z",
+    "closed_by": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "labels": ["bug", "urgent"],
+    "milestone": null,
+    "assignees": [
+      {
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/root"
+      }
+    ],
+    "author": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "due_date": null,
+    "web_url": "http://gitlab.example.com/gitlab-org/gitlab-test/issues/1"
+  },
+  "timestamp": "2023-01-01T10:05:00.000Z",
+  "type": "gitlab.updateIssue"
+}

--- a/pkg/integrations/gitlab/get_issue.go
+++ b/pkg/integrations/gitlab/get_issue.go
@@ -1,0 +1,171 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_get_issue.json
+var exampleOutputGetIssue []byte
+
+type GetIssue struct{}
+
+type GetIssueConfiguration struct {
+	Project  string `mapstructure:"project"`
+	IssueIID string `mapstructure:"issueIid"`
+}
+
+func (c *GetIssue) Name() string {
+	return "gitlab.getIssue"
+}
+
+func (c *GetIssue) Label() string {
+	return "Get Issue"
+}
+
+func (c *GetIssue) Description() string {
+	return "Fetch a single GitLab issue by its IID"
+}
+
+func (c *GetIssue) Documentation() string {
+	return `The Get Issue component fetches a single issue from a GitLab project by its internal ID (IID).
+
+## Use Cases
+
+- **Read state, then act**: Look up an issue's current title, description, state, labels, or assignees before deciding what to do next
+- **Data enrichment**: Pull issue details into a workflow to combine with other information
+- **Status checking**: Check whether an issue is open or closed before performing an action
+
+## Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to fetch (supports expressions)
+
+## Output
+
+Returns the issue object, including:
+- **id** / **iid**: The internal and project-relative IDs of the issue
+- **title** / **description**: The issue's content
+- **state**: The current state of the issue (opened/closed)
+- **labels**, **assignees**, **milestone**: Metadata on the issue
+- **web_url**: The URL to view the issue in GitLab`
+}
+
+func (c *GetIssue) Icon() string {
+	return "gitlab"
+}
+
+func (c *GetIssue) Color() string {
+	return "orange"
+}
+
+func (c *GetIssue) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetIssue) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputGetIssue, &example); err != nil {
+		return map[string]any{}
+	}
+	return example
+}
+
+func (c *GetIssue) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "project",
+			Label:    "Project",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeProject,
+				},
+			},
+		},
+		{
+			Name:        "issueIid",
+			Label:       "Issue IID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The internal ID (IID) of the issue",
+		},
+	}
+}
+
+func (c *GetIssue) Setup(ctx core.SetupContext) error {
+	var config GetIssueConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Project == "" {
+		return errors.New("project is required")
+	}
+
+	if config.IssueIID == "" {
+		return errors.New("issue IID is required")
+	}
+
+	return ensureProjectInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		config.Project,
+	)
+}
+
+func (c *GetIssue) Execute(ctx core.ExecutionContext) error {
+	var config GetIssueConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitLab client: %w", err)
+	}
+
+	issue, err := client.GetIssue(context.Background(), config.Project, config.IssueIID)
+	if err != nil {
+		return fmt.Errorf("failed to get issue: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gitlab.getIssue",
+		[]any{issue},
+	)
+}
+
+func (c *GetIssue) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetIssue) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *GetIssue) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetIssue) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetIssue) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetIssue) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gitlab/get_issue_test.go
+++ b/pkg/integrations/gitlab/get_issue_test.go
@@ -1,0 +1,136 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetIssue__Setup(t *testing.T) {
+	c := &GetIssue{}
+
+	t.Run("missing project", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"issueIid": "1",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("missing issue IID", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project": "123",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issue IID is required")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__GetIssue__Execute(t *testing.T) {
+	c := &GetIssue{}
+
+	t.Run("success", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{
+						"id": 101,
+						"iid": 1,
+						"title": "Issue Title",
+						"state": "opened"
+					}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, "gitlab.getIssue", executionState.Type)
+
+		var issue Issue
+		issuePayload := payload["data"]
+		payloadBytes, _ := json.Marshal(issuePayload)
+		json.Unmarshal(payloadBytes, &issue)
+
+		assert.Equal(t, 101, issue.ID)
+		assert.Equal(t, 1, issue.IID)
+		assert.Equal(t, "Issue Title", issue.Title)
+		assert.Equal(t, "opened", issue.State)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "999",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusNotFound, `{"message": "404 Issue Not Found"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get issue")
+	})
+}

--- a/pkg/integrations/gitlab/gitlab.go
+++ b/pkg/integrations/gitlab/gitlab.go
@@ -188,6 +188,9 @@ func (g *GitLab) Actions() []core.Action {
 		&ApproveMergeRequest{},
 		&CreateDeployment{},
 		&CreateDeploymentStatus{},
+		&GetIssue{},
+		&UpdateIssue{},
+		&CreateIssueComment{},
 	}
 }
 

--- a/pkg/integrations/gitlab/update_issue.go
+++ b/pkg/integrations/gitlab/update_issue.go
@@ -1,0 +1,297 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_update_issue.json
+var exampleOutputUpdateIssue []byte
+
+type UpdateIssue struct{}
+
+const (
+	IssueStateEventClose  = "close"
+	IssueStateEventReopen = "reopen"
+)
+
+type UpdateIssueConfiguration struct {
+	Project   string   `mapstructure:"project"`
+	IssueIID  string   `mapstructure:"issueIid"`
+	Title     string   `mapstructure:"title"`
+	Body      string   `mapstructure:"body"`
+	State     string   `mapstructure:"state"`
+	Labels    []string `mapstructure:"labels"`
+	Assignees []string `mapstructure:"assignees"`
+	Milestone string   `mapstructure:"milestone"`
+}
+
+func (c *UpdateIssue) Name() string {
+	return "gitlab.updateIssue"
+}
+
+func (c *UpdateIssue) Label() string {
+	return "Update Issue"
+}
+
+func (c *UpdateIssue) Description() string {
+	return "Update an existing GitLab issue"
+}
+
+func (c *UpdateIssue) Documentation() string {
+	return `The Update Issue component modifies an existing GitLab issue: its title, description, state, labels, assignees, or milestone.
+
+## Use Cases
+
+- **Status updates**: Close or reopen an issue based on workflow results
+- **Label management**: Apply labels to an issue automatically
+- **Assignee updates**: Assign an issue to team members automatically
+- **Content updates**: Update the issue title or description with new information
+
+## Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to update (supports expressions)
+- **Title** (optional): New title for the issue
+- **Description** (optional): New description for the issue
+- **State** (optional): Close or reopen the issue. Leave unset to keep the current state.
+- **Labels** (optional): Labels to set on the issue, replacing any existing labels
+- **Assignees** (optional): Users to assign the issue to, replacing any existing assignees
+- **Milestone** (optional): Milestone to associate with the issue
+
+Fields left empty are not changed.
+
+## Output
+
+Returns the updated issue object.`
+}
+
+func (c *UpdateIssue) Icon() string {
+	return "gitlab"
+}
+
+func (c *UpdateIssue) Color() string {
+	return "orange"
+}
+
+func (c *UpdateIssue) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *UpdateIssue) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputUpdateIssue, &example); err != nil {
+		return map[string]any{}
+	}
+	return example
+}
+
+func (c *UpdateIssue) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "project",
+			Label:    "Project",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeProject,
+				},
+			},
+		},
+		{
+			Name:        "issueIid",
+			Label:       "Issue IID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The internal ID (IID) of the issue to update",
+		},
+		{
+			Name:     "title",
+			Label:    "Title",
+			Type:     configuration.FieldTypeString,
+			Required: false,
+		},
+		{
+			Name:     "body",
+			Label:    "Description",
+			Type:     configuration.FieldTypeText,
+			Required: false,
+		},
+		{
+			Name:        "state",
+			Label:       "State",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Description: "Leave unset to keep the current state",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Close", Value: IssueStateEventClose},
+						{Label: "Reopen", Value: IssueStateEventReopen},
+					},
+				},
+			},
+		},
+		{
+			Name:     "labels",
+			Label:    "Labels",
+			Type:     configuration.FieldTypeList,
+			Required: false,
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Label",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+		{
+			Name:     "assignees",
+			Label:    "Assignees",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: false,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:  ResourceTypeMember,
+					Multi: true,
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "project",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "project"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:     "milestone",
+			Label:    "Milestone",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: false,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeMilestone,
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "project",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "project"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *UpdateIssue) Setup(ctx core.SetupContext) error {
+	var config UpdateIssueConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Project == "" {
+		return errors.New("project is required")
+	}
+
+	if config.IssueIID == "" {
+		return errors.New("issue IID is required")
+	}
+
+	if config.State != "" && config.State != IssueStateEventClose && config.State != IssueStateEventReopen {
+		return fmt.Errorf("invalid state: %s", config.State)
+	}
+
+	return ensureProjectInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		config.Project,
+	)
+}
+
+func (c *UpdateIssue) Execute(ctx core.ExecutionContext) error {
+	var config UpdateIssueConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.State != "" && config.State != IssueStateEventClose && config.State != IssueStateEventReopen {
+		return fmt.Errorf("invalid state: %s", config.State)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitLab client: %w", err)
+	}
+
+	var assigneeIDs []int
+	for _, idStr := range config.Assignees {
+		var id int
+		if _, err := fmt.Sscanf(idStr, "%d", &id); err == nil {
+			assigneeIDs = append(assigneeIDs, id)
+		}
+	}
+
+	var milestoneID *int
+	if config.Milestone != "" {
+		id, err := strconv.Atoi(config.Milestone)
+		if err == nil {
+			milestoneID = &id
+		}
+	}
+
+	req := &UpdateIssueRequest{
+		Title:       config.Title,
+		Description: config.Body,
+		StateEvent:  config.State,
+		Labels:      strings.Join(config.Labels, ","),
+		AssigneeIDs: assigneeIDs,
+		MilestoneID: milestoneID,
+	}
+
+	issue, err := client.UpdateIssue(context.Background(), config.Project, config.IssueIID, req)
+	if err != nil {
+		return fmt.Errorf("failed to update issue: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gitlab.updateIssue",
+		[]any{issue},
+	)
+}
+
+func (c *UpdateIssue) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *UpdateIssue) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *UpdateIssue) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *UpdateIssue) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *UpdateIssue) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *UpdateIssue) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gitlab/update_issue.go
+++ b/pkg/integrations/gitlab/update_issue.go
@@ -260,18 +260,20 @@ func (c *UpdateIssue) Execute(ctx core.ExecutionContext) error {
 
 	var assigneeIDs []int
 	for _, idStr := range config.Assignees {
-		var id int
-		if _, err := fmt.Sscanf(idStr, "%d", &id); err == nil {
-			assigneeIDs = append(assigneeIDs, id)
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			return fmt.Errorf("invalid assignee id %q: %w", idStr, err)
 		}
+		assigneeIDs = append(assigneeIDs, id)
 	}
 
 	var milestoneID *int
 	if config.Milestone != "" {
 		id, err := strconv.Atoi(config.Milestone)
-		if err == nil {
-			milestoneID = &id
+		if err != nil {
+			return fmt.Errorf("invalid milestone id %q: %w", config.Milestone, err)
 		}
+		milestoneID = &id
 	}
 
 	req := &UpdateIssueRequest{

--- a/pkg/integrations/gitlab/update_issue.go
+++ b/pkg/integrations/gitlab/update_issue.go
@@ -36,6 +36,16 @@ type UpdateIssueConfiguration struct {
 	Milestone string   `mapstructure:"milestone"`
 }
 
+// hasUpdates reports whether at least one toggleable field was enabled.
+func (c UpdateIssueConfiguration) hasUpdates() bool {
+	return c.Title != "" ||
+		c.Body != "" ||
+		c.State != "" ||
+		len(c.Labels) > 0 ||
+		len(c.Assignees) > 0 ||
+		c.Milestone != ""
+}
+
 func (c *UpdateIssue) Name() string {
 	return "gitlab.updateIssue"
 }
@@ -62,14 +72,14 @@ func (c *UpdateIssue) Documentation() string {
 
 - **Project** (required): The GitLab project containing the issue
 - **Issue IID** (required): The internal ID (IID) of the issue to update (supports expressions)
-- **Title** (optional): New title for the issue
-- **Description** (optional): New description for the issue
-- **State** (optional): Close or reopen the issue. Leave unset to keep the current state.
-- **Labels** (optional): Labels to set on the issue, replacing any existing labels
-- **Assignees** (optional): Users to assign the issue to, replacing any existing assignees
-- **Milestone** (optional): Milestone to associate with the issue
+- **Title** (toggle): New title for the issue
+- **Description** (toggle): New description for the issue
+- **State** (toggle): Close or reopen the issue
+- **Labels** (toggle): Labels to set on the issue, replacing any existing labels
+- **Assignees** (toggle): Users to assign the issue to, replacing any existing assignees
+- **Milestone** (toggle): Milestone to associate with the issue
 
-Fields left empty are not changed.
+Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled.
 
 ## Output
 
@@ -117,23 +127,25 @@ func (c *UpdateIssue) Configuration() []configuration.Field {
 			Description: "The internal ID (IID) of the issue to update",
 		},
 		{
-			Name:     "title",
-			Label:    "Title",
-			Type:     configuration.FieldTypeString,
-			Required: false,
+			Name:      "title",
+			Label:     "Title",
+			Type:      configuration.FieldTypeString,
+			Required:  false,
+			Togglable: true,
 		},
 		{
-			Name:     "body",
-			Label:    "Description",
-			Type:     configuration.FieldTypeText,
-			Required: false,
+			Name:      "body",
+			Label:     "Description",
+			Type:      configuration.FieldTypeText,
+			Required:  false,
+			Togglable: true,
 		},
 		{
-			Name:        "state",
-			Label:       "State",
-			Type:        configuration.FieldTypeSelect,
-			Required:    false,
-			Description: "Leave unset to keep the current state",
+			Name:      "state",
+			Label:     "State",
+			Type:      configuration.FieldTypeSelect,
+			Required:  false,
+			Togglable: true,
 			TypeOptions: &configuration.TypeOptions{
 				Select: &configuration.SelectTypeOptions{
 					Options: []configuration.FieldOption{
@@ -144,10 +156,11 @@ func (c *UpdateIssue) Configuration() []configuration.Field {
 			},
 		},
 		{
-			Name:     "labels",
-			Label:    "Labels",
-			Type:     configuration.FieldTypeList,
-			Required: false,
+			Name:      "labels",
+			Label:     "Labels",
+			Type:      configuration.FieldTypeList,
+			Required:  false,
+			Togglable: true,
 			TypeOptions: &configuration.TypeOptions{
 				List: &configuration.ListTypeOptions{
 					ItemLabel: "Label",
@@ -158,10 +171,11 @@ func (c *UpdateIssue) Configuration() []configuration.Field {
 			},
 		},
 		{
-			Name:     "assignees",
-			Label:    "Assignees",
-			Type:     configuration.FieldTypeIntegrationResource,
-			Required: false,
+			Name:      "assignees",
+			Label:     "Assignees",
+			Type:      configuration.FieldTypeIntegrationResource,
+			Required:  false,
+			Togglable: true,
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type:  ResourceTypeMember,
@@ -176,10 +190,11 @@ func (c *UpdateIssue) Configuration() []configuration.Field {
 			},
 		},
 		{
-			Name:     "milestone",
-			Label:    "Milestone",
-			Type:     configuration.FieldTypeIntegrationResource,
-			Required: false,
+			Name:      "milestone",
+			Label:     "Milestone",
+			Type:      configuration.FieldTypeIntegrationResource,
+			Required:  false,
+			Togglable: true,
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type: ResourceTypeMilestone,
@@ -213,6 +228,10 @@ func (c *UpdateIssue) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("invalid state: %s", config.State)
 	}
 
+	if !config.hasUpdates() {
+		return errors.New("at least one field must be enabled to update")
+	}
+
 	return ensureProjectInMetadata(
 		ctx.Metadata,
 		ctx.Integration,
@@ -228,6 +247,10 @@ func (c *UpdateIssue) Execute(ctx core.ExecutionContext) error {
 
 	if config.State != "" && config.State != IssueStateEventClose && config.State != IssueStateEventReopen {
 		return fmt.Errorf("invalid state: %s", config.State)
+	}
+
+	if !config.hasUpdates() {
+		return errors.New("at least one field must be enabled to update")
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)

--- a/pkg/integrations/gitlab/update_issue.go
+++ b/pkg/integrations/gitlab/update_issue.go
@@ -36,14 +36,38 @@ type UpdateIssueConfiguration struct {
 	Milestone string   `mapstructure:"milestone"`
 }
 
-// hasUpdates reports whether at least one toggleable field was enabled.
-func (c UpdateIssueConfiguration) hasUpdates() bool {
-	return c.Title != "" ||
-		c.Body != "" ||
-		c.State != "" ||
-		len(c.Labels) > 0 ||
-		len(c.Assignees) > 0 ||
-		c.Milestone != ""
+// updateIssueToggles tracks which optional fields were explicitly turned on via
+// their UI toggle, independent of whether the decoded value ended up empty.
+// mapstructure decodes both "never toggled on" and "toggled on but cleared"
+// to the same Go zero value, so this reads the raw configuration map instead
+// to tell them apart - e.g. clearing all labels (toggled on, empty list)
+// must still be sent to GitLab, not treated as "no change".
+type updateIssueToggles struct {
+	Title     bool
+	Body      bool
+	State     bool
+	Labels    bool
+	Assignees bool
+	Milestone bool
+}
+
+func newUpdateIssueToggles(raw map[string]any) updateIssueToggles {
+	enabled := func(field string) bool {
+		v, ok := raw[field]
+		return ok && v != nil
+	}
+	return updateIssueToggles{
+		Title:     enabled("title"),
+		Body:      enabled("body"),
+		State:     enabled("state"),
+		Labels:    enabled("labels"),
+		Assignees: enabled("assignees"),
+		Milestone: enabled("milestone"),
+	}
+}
+
+func (t updateIssueToggles) hasUpdates() bool {
+	return t.Title || t.Body || t.State || t.Labels || t.Assignees || t.Milestone
 }
 
 func (c *UpdateIssue) Name() string {
@@ -79,7 +103,7 @@ func (c *UpdateIssue) Documentation() string {
 - **Assignees** (toggle): Users to assign the issue to, replacing any existing assignees
 - **Milestone** (toggle): Milestone to associate with the issue
 
-Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled.
+Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled. Enabling a field with an empty value clears it - e.g. toggling on Labels or Assignees with nothing selected removes all of them, and toggling on Milestone with nothing selected unassigns the milestone.
 
 ## Output
 
@@ -228,7 +252,8 @@ func (c *UpdateIssue) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("invalid state: %s", config.State)
 	}
 
-	if !config.hasUpdates() {
+	raw, _ := ctx.Configuration.(map[string]any)
+	if !newUpdateIssueToggles(raw).hasUpdates() {
 		return errors.New("at least one field must be enabled to update")
 	}
 
@@ -249,7 +274,9 @@ func (c *UpdateIssue) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("invalid state: %s", config.State)
 	}
 
-	if !config.hasUpdates() {
+	raw, _ := ctx.Configuration.(map[string]any)
+	toggles := newUpdateIssueToggles(raw)
+	if !toggles.hasUpdates() {
 		return errors.New("at least one field must be enabled to update")
 	}
 
@@ -258,31 +285,49 @@ func (c *UpdateIssue) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to initialize GitLab client: %w", err)
 	}
 
-	var assigneeIDs []int
-	for _, idStr := range config.Assignees {
-		id, err := strconv.Atoi(idStr)
-		if err != nil {
-			return fmt.Errorf("invalid assignee id %q: %w", idStr, err)
-		}
-		assigneeIDs = append(assigneeIDs, id)
+	req := &UpdateIssueRequest{}
+
+	if toggles.Title {
+		req.Title = &config.Title
 	}
 
-	var milestoneID *int
-	if config.Milestone != "" {
-		id, err := strconv.Atoi(config.Milestone)
-		if err != nil {
-			return fmt.Errorf("invalid milestone id %q: %w", config.Milestone, err)
-		}
-		milestoneID = &id
+	if toggles.Body {
+		req.Description = &config.Body
 	}
 
-	req := &UpdateIssueRequest{
-		Title:       config.Title,
-		Description: config.Body,
-		StateEvent:  config.State,
-		Labels:      strings.Join(config.Labels, ","),
-		AssigneeIDs: assigneeIDs,
-		MilestoneID: milestoneID,
+	if toggles.State {
+		req.StateEvent = &config.State
+	}
+
+	if toggles.Labels {
+		labels := strings.Join(config.Labels, ",")
+		req.Labels = &labels
+	}
+
+	if toggles.Assignees {
+		assigneeIDs := make([]int, 0, len(config.Assignees))
+		for _, idStr := range config.Assignees {
+			id, err := strconv.Atoi(idStr)
+			if err != nil {
+				return fmt.Errorf("invalid assignee id %q: %w", idStr, err)
+			}
+			assigneeIDs = append(assigneeIDs, id)
+		}
+		req.AssigneeIDs = &assigneeIDs
+	}
+
+	if toggles.Milestone {
+		if config.Milestone == "" {
+			// GitLab clears the milestone when milestone_id is explicitly set to 0.
+			unset := 0
+			req.MilestoneID = &unset
+		} else {
+			id, err := strconv.Atoi(config.Milestone)
+			if err != nil {
+				return fmt.Errorf("invalid milestone id %q: %w", config.Milestone, err)
+			}
+			req.MilestoneID = &id
+		}
 	}
 
 	issue, err := client.UpdateIssue(context.Background(), config.Project, config.IssueIID, req)

--- a/pkg/integrations/gitlab/update_issue.go
+++ b/pkg/integrations/gitlab/update_issue.go
@@ -103,7 +103,7 @@ func (c *UpdateIssue) Documentation() string {
 - **Assignees** (toggle): Users to assign the issue to, replacing any existing assignees
 - **Milestone** (toggle): Milestone to associate with the issue
 
-Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled. Enabling a field with an empty value clears it - e.g. toggling on Labels or Assignees with nothing selected removes all of them, and toggling on Milestone with nothing selected unassigns the milestone.
+Each field besides Project and Issue IID is toggled on individually, so only the fields you enable are sent in the update. At least one must be enabled. Enabling a field with an empty value clears it - e.g. toggling on Labels or Assignees with nothing selected removes all of them, and toggling on Milestone with nothing selected unassigns the milestone. Title is the exception: GitLab does not allow blank titles, so it must have a value when enabled.
 
 ## Output
 
@@ -253,8 +253,13 @@ func (c *UpdateIssue) Setup(ctx core.SetupContext) error {
 	}
 
 	raw, _ := ctx.Configuration.(map[string]any)
-	if !newUpdateIssueToggles(raw).hasUpdates() {
+	toggles := newUpdateIssueToggles(raw)
+	if !toggles.hasUpdates() {
 		return errors.New("at least one field must be enabled to update")
+	}
+
+	if toggles.Title && config.Title == "" {
+		return errors.New("title cannot be empty")
 	}
 
 	return ensureProjectInMetadata(
@@ -278,6 +283,10 @@ func (c *UpdateIssue) Execute(ctx core.ExecutionContext) error {
 	toggles := newUpdateIssueToggles(raw)
 	if !toggles.hasUpdates() {
 		return errors.New("at least one field must be enabled to update")
+	}
+
+	if toggles.Title && config.Title == "" {
+		return errors.New("title cannot be empty")
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)

--- a/pkg/integrations/gitlab/update_issue_test.go
+++ b/pkg/integrations/gitlab/update_issue_test.go
@@ -1,0 +1,166 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdateIssue__Setup(t *testing.T) {
+	c := &UpdateIssue{}
+
+	t.Run("missing project", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"issueIid": "1",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("missing issue IID", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project": "123",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issue IID is required")
+	})
+
+	t.Run("invalid state", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"state":    "bogus",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid state")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"title":    "New title",
+				"state":    "close",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__UpdateIssue__Execute(t *testing.T) {
+	c := &UpdateIssue{}
+
+	t.Run("success", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"title":     "Updated Title",
+				"state":     "close",
+				"labels":    []string{"bug"},
+				"assignees": []string{"99"},
+				"milestone": "12",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{
+						"id": 101,
+						"iid": 1,
+						"title": "Updated Title",
+						"state": "closed"
+					}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, "gitlab.updateIssue", executionState.Type)
+
+		var issue Issue
+		issuePayload := payload["data"]
+		payloadBytes, _ := json.Marshal(issuePayload)
+		json.Unmarshal(payloadBytes, &issue)
+
+		assert.Equal(t, "Updated Title", issue.Title)
+		assert.Equal(t, "closed", issue.State)
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		require.Len(t, httpCtx.Requests, 1)
+		body, _ := io.ReadAll(httpCtx.Requests[0].Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+		assert.Equal(t, "close", reqBody["state_event"])
+		assert.Equal(t, "bug", reqBody["labels"])
+		assert.Equal(t, float64(12), reqBody["milestone_id"])
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"title":    "Updated Title",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusInternalServerError, `{"error": "internal server error"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update issue")
+	})
+}

--- a/pkg/integrations/gitlab/update_issue_test.go
+++ b/pkg/integrations/gitlab/update_issue_test.go
@@ -53,6 +53,26 @@ func Test__UpdateIssue__Setup(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid state")
 	})
 
+	t.Run("no fields enabled", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one field must be enabled")
+	})
+
 	t.Run("valid configuration", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
@@ -162,5 +182,26 @@ func Test__UpdateIssue__Execute(t *testing.T) {
 		err := c.Execute(ctx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to update issue")
+	})
+
+	t.Run("no fields enabled", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one field must be enabled")
 	})
 }

--- a/pkg/integrations/gitlab/update_issue_test.go
+++ b/pkg/integrations/gitlab/update_issue_test.go
@@ -93,6 +93,26 @@ func Test__UpdateIssue__Setup(t *testing.T) {
 		err := c.Setup(ctx)
 		require.NoError(t, err)
 	})
+
+	t.Run("labels toggled on but empty still counts as an update", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"labels":   []string{},
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
 }
 
 func Test__UpdateIssue__Execute(t *testing.T) {
@@ -255,5 +275,52 @@ func Test__UpdateIssue__Execute(t *testing.T) {
 		err := c.Execute(ctx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least one field must be enabled")
+	})
+
+	t.Run("clears description, labels, assignees and milestone when toggled on but empty", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"body":      "",
+				"labels":    []string{},
+				"assignees": []string{},
+				"milestone": "",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{"id": 101, "iid": 1, "title": "Issue"}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		require.Len(t, httpCtx.Requests, 1)
+		body, _ := io.ReadAll(httpCtx.Requests[0].Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+
+		assert.Equal(t, "", reqBody["description"])
+		assert.Equal(t, "", reqBody["labels"])
+		assert.Equal(t, []any{}, reqBody["assignee_ids"])
+		assert.Equal(t, float64(0), reqBody["milestone_id"])
+
+		// Fields that were never toggled on must be omitted entirely, not
+		// just empty, since the toggle is the only signal this component has.
+		assert.NotContains(t, reqBody, "title")
+		assert.NotContains(t, reqBody, "state_event")
 	})
 }

--- a/pkg/integrations/gitlab/update_issue_test.go
+++ b/pkg/integrations/gitlab/update_issue_test.go
@@ -184,6 +184,58 @@ func Test__UpdateIssue__Execute(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to update issue")
 	})
 
+	t.Run("invalid assignee id", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"not-a-number"},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid assignee id")
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		assert.Empty(t, httpCtx.Requests, "no request should be sent when an assignee id is invalid")
+	})
+
+	t.Run("invalid milestone id", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"milestone": "not-a-number",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid milestone id")
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		assert.Empty(t, httpCtx.Requests, "no request should be sent when the milestone id is invalid")
+	})
+
 	t.Run("no fields enabled", func(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{

--- a/pkg/integrations/gitlab/update_issue_test.go
+++ b/pkg/integrations/gitlab/update_issue_test.go
@@ -113,6 +113,27 @@ func Test__UpdateIssue__Setup(t *testing.T) {
 		err := c.Setup(ctx)
 		require.NoError(t, err)
 	})
+
+	t.Run("title toggled on but empty is rejected", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"title":    "",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "title cannot be empty")
+	})
 }
 
 func Test__UpdateIssue__Execute(t *testing.T) {
@@ -275,6 +296,32 @@ func Test__UpdateIssue__Execute(t *testing.T) {
 		err := c.Execute(ctx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least one field must be enabled")
+	})
+
+	t.Run("title toggled on but empty is rejected", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+				"title":    "",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"groupId":     "123",
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "title cannot be empty")
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		assert.Empty(t, httpCtx.Requests, "no request should be sent when the title is empty")
 	})
 
 	t.Run("clears description, labels, assignees and milestone when toggled on but empty", func(t *testing.T) {

--- a/web_src/src/pages/app/mappers/gitlab/create_issue_comment.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/create_issue_comment.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { createIssueCommentMapper } from "./create_issue_comment";
+
+describe("createIssueCommentMapper", () => {
+  it("shows created comment details", () => {
+    const details = createIssueCommentMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          project: "123",
+          issueIid: "1",
+          body: "Automated comment",
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                id: 302,
+                body: "Automated comment",
+                author: { username: "root" },
+                created_at: "2026-06-11T14:30:00Z",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Created At": expect.any(String),
+      "Created By": "root",
+    });
+  });
+
+  it("handles missing outputs", () => {
+    const details = createIssueCommentMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: { project: "123", issueIid: "1" },
+        outputs: {},
+      }),
+    );
+
+    expect(details).toEqual({});
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Create Issue Comment",
+    componentName: "gitlab.createIssueComment",
+    isCollapsed: false,
+    metadata: {
+      project: {
+        id: 123,
+        name: "felixgateru/hello-world",
+        url: "https://gitlab.com/felixgateru/hello-world",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/gitlab/create_issue_comment.ts
+++ b/web_src/src/pages/app/mappers/gitlab/create_issue_comment.ts
@@ -1,0 +1,61 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import type { GitLabNodeMetadata, Note } from "./types";
+import { buildGitlabExecutionSubtitle } from "./utils";
+
+interface CreateIssueCommentConfiguration {
+  project?: string;
+  issueIid?: string;
+}
+
+export const createIssueCommentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as CreateIssueCommentConfiguration | undefined) ?? {};
+    const metadata = (context.node.metadata as GitLabNodeMetadata | undefined) ?? ({} as GitLabNodeMetadata);
+
+    const project = metadata?.project?.name || configuration.project;
+    const metadataItems: MetadataItem[] = [];
+
+    if (project) {
+      metadataItems.push({ icon: "book", label: project });
+    }
+
+    if (configuration.issueIid) {
+      metadataItems.push({ icon: "circle-dot", label: `#${configuration.issueIid}` });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGitlabExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const details: Record<string, string> = {};
+
+    if (!outputs?.default || outputs.default.length === 0) {
+      return details;
+    }
+
+    const note = outputs.default[0].data as Note;
+    details["Created At"] = note?.created_at ? new Date(note.created_at).toLocaleString() : "-";
+    details["Created By"] = note?.author?.username || "-";
+
+    return details;
+  },
+};

--- a/web_src/src/pages/app/mappers/gitlab/get_issue.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/get_issue.spec.ts
@@ -31,14 +31,12 @@ describe("getIssueMapper", () => {
     );
 
     expect(details).toEqual({
-      IID: "1",
-      ID: "101",
-      State: "opened",
-      URL: "https://gitlab.com/felixgateru/hello-world/-/issues/1",
+      "Executed At": expect.any(String),
       Title: "Bug report",
-      "Created At": expect.any(String),
+      State: "opened",
       "Created By": "root",
       Labels: "bug",
+      URL: "https://gitlab.com/felixgateru/hello-world/-/issues/1",
     });
   });
 

--- a/web_src/src/pages/app/mappers/gitlab/get_issue.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/get_issue.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { getIssueMapper } from "./get_issue";
+
+describe("getIssueMapper", () => {
+  it("shows fetched issue details", () => {
+    const details = getIssueMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          project: "123",
+          issueIid: "1",
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                id: 101,
+                iid: 1,
+                title: "Bug report",
+                state: "opened",
+                web_url: "https://gitlab.com/felixgateru/hello-world/-/issues/1",
+                author: { username: "root" },
+                created_at: "2026-06-11T14:30:00Z",
+                labels: ["bug"],
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      IID: "1",
+      ID: "101",
+      State: "opened",
+      URL: "https://gitlab.com/felixgateru/hello-world/-/issues/1",
+      Title: "Bug report",
+      "Created At": expect.any(String),
+      "Created By": "root",
+      Labels: "bug",
+    });
+  });
+
+  it("handles missing outputs", () => {
+    const details = getIssueMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: { project: "123", issueIid: "1" },
+        outputs: {},
+      }),
+    );
+
+    expect(details).toEqual({});
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Get Issue",
+    componentName: "gitlab.getIssue",
+    isCollapsed: false,
+    metadata: {
+      project: {
+        id: 123,
+        name: "felixgateru/hello-world",
+        url: "https://gitlab.com/felixgateru/hello-world",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/gitlab/get_issue.ts
+++ b/web_src/src/pages/app/mappers/gitlab/get_issue.ts
@@ -1,0 +1,63 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import type { GitLabNodeMetadata, Issue } from "./types";
+import { buildGitlabExecutionSubtitle } from "./utils";
+import { getDetailsForApiIssue } from "./issue_utils";
+
+interface GetIssueConfiguration {
+  project?: string;
+  issueIid?: string;
+}
+
+export const getIssueMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as GetIssueConfiguration | undefined) ?? {};
+    const metadata = (context.node.metadata as GitLabNodeMetadata | undefined) ?? ({} as GitLabNodeMetadata);
+
+    const project = metadata?.project?.name || configuration.project;
+    const metadataItems: MetadataItem[] = [];
+
+    if (project) {
+      metadataItems.push({ icon: "book", label: project });
+    }
+
+    if (configuration.issueIid) {
+      metadataItems.push({ icon: "circle-dot", label: `#${configuration.issueIid}` });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    if (outputs?.default?.[0]?.data) {
+      const issue = outputs.default[0].data as Issue;
+      return `#${issue.iid} ${issue.title}`;
+    }
+    return buildGitlabExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+
+    if (!outputs?.default || outputs.default.length === 0) {
+      return {};
+    }
+
+    const issue = outputs.default[0].data as Issue;
+    return getDetailsForApiIssue(issue);
+  },
+};

--- a/web_src/src/pages/app/mappers/gitlab/get_issue.ts
+++ b/web_src/src/pages/app/mappers/gitlab/get_issue.ts
@@ -11,7 +11,7 @@ import type {
 import { baseProps } from "./base";
 import type { GitLabNodeMetadata, Issue } from "./types";
 import { buildGitlabExecutionSubtitle } from "./utils";
-import { getDetailsForApiIssue } from "./issue_utils";
+import { getSummaryDetailsForIssue } from "./issue_utils";
 
 interface GetIssueConfiguration {
   project?: string;
@@ -58,6 +58,6 @@ export const getIssueMapper: ComponentBaseMapper = {
     }
 
     const issue = outputs.default[0].data as Issue;
-    return getDetailsForApiIssue(issue);
+    return getSummaryDetailsForIssue(context.execution, issue);
   },
 };

--- a/web_src/src/pages/app/mappers/gitlab/index.ts
+++ b/web_src/src/pages/app/mappers/gitlab/index.ts
@@ -6,7 +6,9 @@ import { approveMergeRequestMapper } from "./approve_merge_request";
 import { createDeploymentMapper } from "./create_deployment";
 import { createDeploymentStatusMapper } from "./create_deployment_status";
 import { createIssueMapper } from "./create_issue";
+import { createIssueCommentMapper } from "./create_issue_comment";
 import { createMergeCommentMapper } from "./create_merge_comment";
+import { getIssueMapper } from "./get_issue";
 import { onBranchCreatedTriggerRenderer } from "./on_branch_created";
 import { onIssueTriggerRenderer } from "./on_issue";
 import { onMergeCommentTriggerRenderer } from "./on_merge_comment";
@@ -19,6 +21,7 @@ import { onTagTriggerRenderer } from "./on_tag";
 import { onVulnerabilityTriggerRenderer } from "./on_vulnerability";
 import { RUN_PIPELINE_STATE_REGISTRY, runPipelineMapper } from "./run_pipeline";
 import { pipelineLookupMapper, testReportSummaryMapper } from "./pipeline_actions";
+import { updateIssueMapper } from "./update_issue";
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createIssue: buildActionStateRegistry("created"),
@@ -32,6 +35,9 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   approveMergeRequest: buildActionStateRegistry("approved"),
   createDeployment: buildActionStateRegistry("created"),
   createDeploymentStatus: buildActionStateRegistry("updated"),
+  getIssue: buildActionStateRegistry("retrieved"),
+  updateIssue: buildActionStateRegistry("updated"),
+  createIssueComment: buildActionStateRegistry("created"),
 };
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
@@ -46,6 +52,9 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   approveMergeRequest: approveMergeRequestMapper,
   createDeployment: createDeploymentMapper,
   createDeploymentStatus: createDeploymentStatusMapper,
+  getIssue: getIssueMapper,
+  updateIssue: updateIssueMapper,
+  createIssueComment: createIssueCommentMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {

--- a/web_src/src/pages/app/mappers/gitlab/issue_utils.ts
+++ b/web_src/src/pages/app/mappers/gitlab/issue_utils.ts
@@ -1,3 +1,4 @@
+import type { ExecutionInfo } from "../types";
 import type { Issue } from "./types";
 
 /**
@@ -73,4 +74,24 @@ export function getDetailsForApiIssue(issue: Issue | undefined): Record<string, 
   }
 
   return details;
+}
+
+/**
+ * Get a condensed 6-field execution summary for a full API Issue response.
+ * Used by getIssue and updateIssue, whose details panels favor a shorter,
+ * at-a-glance view over the full field set in getDetailsForApiIssue.
+ */
+export function getSummaryDetailsForIssue(execution: ExecutionInfo, issue: Issue | undefined): Record<string, string> {
+  if (!issue) {
+    return {};
+  }
+
+  return {
+    "Executed At": execution.createdAt ? new Date(execution.createdAt).toLocaleString() : "-",
+    Title: issue.title || "-",
+    State: issue.state || "-",
+    "Created By": issue.author?.username || "-",
+    Labels: issue.labels && issue.labels.length > 0 ? issue.labels.join(", ") : "-",
+    URL: issue.web_url || "-",
+  };
 }

--- a/web_src/src/pages/app/mappers/gitlab/update_issue.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/update_issue.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { updateIssueMapper } from "./update_issue";
+
+describe("updateIssueMapper", () => {
+  it("shows updated issue details", () => {
+    const details = updateIssueMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          project: "123",
+          issueIid: "1",
+          state: "close",
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                id: 101,
+                iid: 1,
+                title: "Bug report",
+                state: "closed",
+                web_url: "https://gitlab.com/felixgateru/hello-world/-/issues/1",
+                author: { username: "root" },
+                created_at: "2026-06-11T14:30:00Z",
+                closed_by: { username: "root" },
+                closed_at: "2026-06-11T15:00:00Z",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      IID: "1",
+      ID: "101",
+      State: "closed",
+      URL: "https://gitlab.com/felixgateru/hello-world/-/issues/1",
+      Title: "Bug report",
+      "Created At": expect.any(String),
+      "Created By": "root",
+      "Closed By": "root",
+      "Closed At": expect.any(String),
+    });
+  });
+
+  it("handles missing outputs", () => {
+    const details = updateIssueMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: { project: "123", issueIid: "1" },
+        outputs: {},
+      }),
+    );
+
+    expect(details).toEqual({});
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Update Issue",
+    componentName: "gitlab.updateIssue",
+    isCollapsed: false,
+    metadata: {
+      project: {
+        id: 123,
+        name: "felixgateru/hello-world",
+        url: "https://gitlab.com/felixgateru/hello-world",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/gitlab/update_issue.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/update_issue.spec.ts
@@ -25,6 +25,7 @@ describe("updateIssueMapper", () => {
                 created_at: "2026-06-11T14:30:00Z",
                 closed_by: { username: "root" },
                 closed_at: "2026-06-11T15:00:00Z",
+                labels: ["bug"],
               },
             },
           ],
@@ -33,15 +34,12 @@ describe("updateIssueMapper", () => {
     );
 
     expect(details).toEqual({
-      IID: "1",
-      ID: "101",
-      State: "closed",
-      URL: "https://gitlab.com/felixgateru/hello-world/-/issues/1",
+      "Executed At": expect.any(String),
       Title: "Bug report",
-      "Created At": expect.any(String),
+      State: "closed",
       "Created By": "root",
-      "Closed By": "root",
-      "Closed At": expect.any(String),
+      Labels: "bug",
+      URL: "https://gitlab.com/felixgateru/hello-world/-/issues/1",
     });
   });
 

--- a/web_src/src/pages/app/mappers/gitlab/update_issue.ts
+++ b/web_src/src/pages/app/mappers/gitlab/update_issue.ts
@@ -1,0 +1,68 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import type { GitLabNodeMetadata, Issue } from "./types";
+import { buildGitlabExecutionSubtitle } from "./utils";
+import { getDetailsForApiIssue } from "./issue_utils";
+
+interface UpdateIssueConfiguration {
+  project?: string;
+  issueIid?: string;
+  state?: string;
+}
+
+export const updateIssueMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as UpdateIssueConfiguration | undefined) ?? {};
+    const metadata = (context.node.metadata as GitLabNodeMetadata | undefined) ?? ({} as GitLabNodeMetadata);
+
+    const project = metadata?.project?.name || configuration.project;
+    const metadataItems: MetadataItem[] = [];
+
+    if (project) {
+      metadataItems.push({ icon: "book", label: project });
+    }
+
+    if (configuration.issueIid) {
+      metadataItems.push({ icon: "circle-dot", label: `#${configuration.issueIid}` });
+    }
+
+    if (configuration.state) {
+      metadataItems.push({ icon: "refresh-cw", label: configuration.state === "close" ? "Close" : "Reopen" });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    if (outputs?.default?.[0]?.data) {
+      const issue = outputs.default[0].data as Issue;
+      return `#${issue.iid} ${issue.title}`;
+    }
+    return buildGitlabExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+
+    if (!outputs?.default || outputs.default.length === 0) {
+      return {};
+    }
+
+    const issue = outputs.default[0].data as Issue;
+    return getDetailsForApiIssue(issue);
+  },
+};

--- a/web_src/src/pages/app/mappers/gitlab/update_issue.ts
+++ b/web_src/src/pages/app/mappers/gitlab/update_issue.ts
@@ -11,7 +11,7 @@ import type {
 import { baseProps } from "./base";
 import type { GitLabNodeMetadata, Issue } from "./types";
 import { buildGitlabExecutionSubtitle } from "./utils";
-import { getDetailsForApiIssue } from "./issue_utils";
+import { getSummaryDetailsForIssue } from "./issue_utils";
 
 interface UpdateIssueConfiguration {
   project?: string;
@@ -63,6 +63,6 @@ export const updateIssueMapper: ComponentBaseMapper = {
     }
 
     const issue = outputs.default[0].data as Issue;
-    return getDetailsForApiIssue(issue);
+    return getSummaryDetailsForIssue(context.execution, issue);
   },
 };

--- a/web_src/src/ui/configurationFieldRenderer/IntegrationResourceFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/IntegrationResourceFieldRenderer.spec.tsx
@@ -29,6 +29,21 @@ function resourceField(): ConfigurationField {
   };
 }
 
+function multiResourceField(togglable: boolean): ConfigurationField {
+  return {
+    name: "assignees",
+    label: "Assignees",
+    type: "integration-resource",
+    togglable,
+    typeOptions: {
+      resource: {
+        type: "member",
+        multi: true,
+      },
+    },
+  };
+}
+
 function ControlledRenderer({ initialValue }: { initialValue?: string }) {
   const [value, setValue] = useState<string | string[] | undefined>(initialValue);
   return (
@@ -107,5 +122,41 @@ describe("IntegrationResourceFieldRenderer", () => {
     await user.click(screen.getByRole("tab", { name: "Fixed" }));
 
     expect(handleChange).not.toHaveBeenCalledWith(undefined);
+  });
+
+  it("clears a togglable multi-select to an empty array, not undefined, when the last chip is removed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <IntegrationResourceFieldRenderer
+        field={multiResourceField(true)}
+        value={["resource-1"]}
+        onChange={onChange}
+        organizationId="org-1"
+        integrationId="int-1"
+      />,
+    );
+
+    await user.click(screen.getByTestId("remove-resource-1"));
+
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("clears a non-togglable multi-select to undefined when the last chip is removed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <IntegrationResourceFieldRenderer
+        field={multiResourceField(false)}
+        value={["resource-1"]}
+        onChange={onChange}
+        organizationId="org-1"
+        integrationId="int-1"
+      />,
+    );
+
+    await user.click(screen.getByTestId("remove-resource-1"));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
   });
 });

--- a/web_src/src/ui/configurationFieldRenderer/IntegrationResourceFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/IntegrationResourceFieldRenderer.tsx
@@ -208,7 +208,7 @@ export const IntegrationResourceFieldRenderer = ({
       <AutoCompleteSelect
         options={options}
         value={selectedValue}
-        onChange={(val) => onChange(val || undefined)}
+        onChange={(val) => onChange(val || (field.togglable ? "" : undefined))}
         placeholder={field.placeholder ?? `Select ${resourceType}`}
       />
     ) : (
@@ -223,7 +223,7 @@ export const IntegrationResourceFieldRenderer = ({
       <AutoCompleteInput
         exampleObj={autocompleteExampleObj}
         value={expressionValue}
-        onChange={(nextValue) => onChange(nextValue || undefined)}
+        onChange={(nextValue) => onChange(nextValue || (field.togglable ? "" : undefined))}
         placeholder={field.placeholder ?? `e.g. {{ $["node-name"].value }}`}
         startWord="{{"
         prefix="{{ "
@@ -293,7 +293,9 @@ export const IntegrationResourceFieldRenderer = ({
 
   const handleChange = (selectedOptions: SelectOption[]) => {
     const selectedValues = selectedOptions.map((opt) => opt.value);
-    onChange(selectedValues.length > 0 ? selectedValues : undefined);
+    // undefined would read as "toggle off" to ConfigurationFieldRenderer, silently
+    // discarding an intentional clear-to-empty-selection on a togglable field.
+    onChange(selectedValues.length > 0 ? selectedValues : field.togglable ? [] : undefined);
   };
 
   return (

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.spec.tsx
@@ -27,6 +27,21 @@ function parameterListField(): ConfigurationField {
   };
 }
 
+function stringListField(togglable: boolean): ConfigurationField {
+  return {
+    name: "labels",
+    label: "Labels",
+    type: "list",
+    togglable,
+    typeOptions: {
+      list: {
+        itemLabel: "Label",
+        itemDefinition: { type: "string" },
+      },
+    },
+  };
+}
+
 function stubRowRects() {
   const rows = screen.getAllByTestId("list-item-row");
   rows.forEach((row, index) => {
@@ -99,5 +114,23 @@ describe("ListFieldRenderer", () => {
     );
 
     expect(screen.queryByLabelText(/Drag to reorder/)).not.toBeInTheDocument();
+  });
+
+  it("clears a togglable list to an empty array, not undefined, when the last item is removed", () => {
+    const onChange = vi.fn();
+    render(<ListFieldRenderer field={stringListField(true)} value={["bug"]} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText("Remove Label 1"));
+
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("clears a non-togglable list to undefined when the last item is removed", () => {
+    const onChange = vi.fn();
+    render(<ListFieldRenderer field={stringListField(false)} value={["bug"]} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText("Remove Label 1"));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
   });
 });

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -113,7 +113,9 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
   const removeItem = (index: number) => {
     const newItems = itemsRef.current.filter((_, i) => i !== index);
     itemsRef.current = newItems;
-    onChange(newItems.length > 0 ? newItems : undefined);
+    // undefined would read as "toggle off" to ConfigurationFieldRenderer, silently
+    // discarding an intentional clear-to-empty-list on a togglable field.
+    onChange(newItems.length > 0 ? newItems : field.togglable ? [] : undefined);
     if (!useAccordion) return;
 
     setOpenItem((current) => {


### PR DESCRIPTION
## What changed
Added three new GitLab integration components that close the CRUD loop opened by the existing `gitlab.createIssue` component, plus their frontend node mappers:

- `gitlab.getIssue` — fetch a single issue by its IID
- `gitlab.updateIssue` — update an issue's title, description, state (close/reopen), labels, assignees, or milestone
- `gitlab.createIssueComment` — add a comment to an issue (the issue-scoped counterpart to the existing `gitlab.createMergeComment`)

## Why
`gitlab.createIssue` already lets pipelines create issues, but there was no way to read an issue's current state before acting on it, update it afterwards, or comment on it directly — `gitlab.createMergeComment` only covers merge requests. This mirrors GitHub's parity components (`getIssue`, `updateIssue`, `createIssueComment`).

## How

### Backend
Extended `pkg/integrations/gitlab/`:
- `get_issue.go` — `gitlab.getIssue` action. Requires `project` and `issueIid`, calls `GET /projects/:id/issues/:issue_iid`.
- `update_issue.go` — `gitlab.updateIssue` action. All fields besides `project`/`issueIid` are optional and only sent when set, so partial updates don't clobber existing values. `state` maps to GitLab's `state_event` (`close`/`reopen`).
- `create_issue_comment.go` — `gitlab.createIssueComment` action, posts a note via `POST /projects/:id/issues/:issue_iid/notes`.
- `client.go` — added `GetIssue`, `UpdateIssue` (+ `UpdateIssueRequest`), and `CreateIssueNote` methods.

Added backend tests for all three components plus the new client methods (`get_issue_test.go`, `update_issue_test.go`, `create_issue_comment_test.go`, additions to `client_test.go`).

### Frontend
Added `web_src/src/pages/app/mappers/gitlab/{get_issue,update_issue,create_issue_comment}.ts` + specs, registered in `mappers/gitlab/index.ts`. `getIssue` and `updateIssue` reuse the existing `getDetailsForApiIssue` helper for execution details; `createIssueComment` follows the same pattern as `createMergeComment`.
