### PR TITLE
feat: add runner logs to run inspector

### DIFF
--- a/test/e2e/run_inspector_runner_logs_test.go
+++ b/test/e2e/run_inspector_runner_logs_test.go
@@ -1,0 +1,260 @@
+package e2e
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pw "github.com/mxschmitt/playwright-go"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+)
+
+const (
+	runnerLogsStartNodeID  = "start-trigger"
+	runnerLogsRunnerNodeID = "run-bash"
+	runnerLogsTaskID       = "task-e2e-runner-logs"
+)
+
+func TestRunInspectorRunnerLogs(t *testing.T) {
+	t.Run("lazy loads runner logs when the logs accordion opens", func(t *testing.T) {
+		steps := &runInspectorRunnerLogsSteps{t: t}
+		steps.start()
+		steps.givenRunnerLiveLogsAreAvailable()
+		steps.givenAPublishedCanvasWithRunner()
+		steps.givenAFinishedRunnerRun(runnerLogsTaskID)
+		steps.whenIVisitRunInspection()
+		steps.whenIOpenTheRunnerNode()
+		steps.thenTheLogsAccordionIsVisible()
+		steps.thenLiveLogsWereNotRequested()
+		steps.whenIOpenTheLogsAccordion()
+		steps.thenLiveLogsAreRequested()
+		steps.thenRunnerLogLinesAreVisible()
+	})
+
+	t.Run("hides runner logs before the runner has started", func(t *testing.T) {
+		steps := &runInspectorRunnerLogsSteps{t: t}
+		steps.start()
+		steps.givenRunnerLiveLogsAreAvailable()
+		steps.givenAPublishedCanvasWithRunner()
+		steps.givenAFinishedRunnerRun("")
+		steps.whenIVisitRunInspection()
+		steps.whenIOpenTheRunnerNode()
+		steps.thenTheLogsAccordionIsHidden()
+		steps.thenLiveLogsWereNotRequested()
+	})
+}
+
+type runInspectorRunnerLogsSteps struct {
+	t                      *testing.T
+	session                *session.TestSession
+	canvas                 *shared.CanvasSteps
+	run                    *models.CanvasRun
+	liveLogSessionRequests atomic.Int32
+}
+
+func (s *runInspectorRunnerLogsSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *runInspectorRunnerLogsSteps) givenRunnerLiveLogsAreAvailable() {
+	require.NoError(s.t, s.session.Page().Route("**/runner-live-logs/session", func(route pw.Route) {
+		s.liveLogSessionRequests.Add(1)
+		require.NoError(s.t, route.Fulfill(pw.RouteFulfillOptions{
+			Status:      pw.Int(200),
+			ContentType: pw.String("application/json"),
+			Body: fmt.Sprintf(
+				`{"stream_url":"/e2e-runner-live-logs/%s","token":"e2e-token","expires_at":"%s"}`,
+				runnerLogsTaskID,
+				time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			),
+		}))
+	}))
+
+	require.NoError(s.t, s.session.Page().Route("**/e2e-runner-live-logs/**", func(route pw.Route) {
+		require.NoError(s.t, route.Fulfill(pw.RouteFulfillOptions{
+			Status:      pw.Int(200),
+			ContentType: pw.String("application/x-ndjson"),
+			Body: "" +
+				`{"type":"cmd_start","index":0,"text":"npm run build","started_at":1710000000000}` + "\n" +
+				`{"type":"line","text":"> build"}` + "\n" +
+				`{"type":"line","text":"vite build"}` + "\n" +
+				`{"type":"cmd_end","index":0,"status":"passed","duration_ms":4200}` + "\n",
+		}))
+	}))
+}
+
+func (s *runInspectorRunnerLogsSteps) givenAPublishedCanvasWithRunner() {
+	user, err := models.FindMaybeDeletedUserByEmail(s.session.OrgID.String(), s.session.Account.Email)
+	require.NoError(s.t, err)
+
+	canvas, _ := support.CreateCanvas(s.t, s.session.OrgID, user.ID, []models.CanvasNode{
+		{
+			NodeID: runnerLogsStartNodeID,
+			Name:   "Start",
+			Type:   models.NodeTypeTrigger,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Trigger: &models.TriggerRef{Name: "start"},
+			}),
+			Configuration: datatypes.NewJSONType(map[string]any{}),
+			Position:      datatypes.NewJSONType(models.Position{X: 600, Y: 200}),
+		},
+		{
+			NodeID: runnerLogsRunnerNodeID,
+			Name:   "Run Bash",
+			Type:   models.NodeTypeComponent,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Component: &models.ComponentRef{Name: "runnerBash"},
+			}),
+			Configuration: datatypes.NewJSONType(map[string]any{
+				"script": "npm run build",
+			}),
+			Position: datatypes.NewJSONType(models.Position{X: 1000, Y: 200}),
+		},
+	}, []models.Edge{
+		{SourceID: runnerLogsStartNodeID, TargetID: runnerLogsRunnerNodeID, Channel: "default"},
+	})
+
+	s.canvas = shared.NewCanvasSteps("Run Inspector Runner Logs", s.t, s.session)
+	s.canvas.WorkflowID = canvas.ID
+	require.NoError(s.t, database.Conn().
+		Model(&models.Canvas{}).
+		Where("id = ?", s.canvas.WorkflowID).
+		Update("name", s.canvas.CanvasName).
+		Error)
+}
+
+func (s *runInspectorRunnerLogsSteps) givenAFinishedRunnerRun(taskID string) {
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), s.canvas.WorkflowID)
+	require.NoError(s.t, err)
+
+	createdAt := time.Now().Add(-time.Minute)
+	finishedAt := time.Now()
+	run := &models.CanvasRun{
+		ID:         uuid.New(),
+		WorkflowID: s.canvas.WorkflowID,
+		VersionID:  liveVersion.ID,
+		State:      models.CanvasRunStateFinished,
+		Result:     models.CanvasRunResultPassed,
+		CreatedAt:  &createdAt,
+		UpdatedAt:  &finishedAt,
+		FinishedAt: &finishedAt,
+	}
+	require.NoError(s.t, database.Conn().Create(run).Error)
+
+	customName := "Runner log E2E run"
+	rootEvent := models.CanvasEvent{
+		ID:         uuid.New(),
+		WorkflowID: s.canvas.WorkflowID,
+		NodeID:     runnerLogsStartNodeID,
+		Channel:    "default",
+		CustomName: &customName,
+		Data:       models.NewJSONValue(map[string]any{"message": "run build"}),
+		RunID:      run.ID,
+		State:      models.CanvasEventStateRouted,
+		CreatedAt:  &createdAt,
+	}
+	require.NoError(s.t, database.Conn().Create(&rootEvent).Error)
+
+	metadata := map[string]any{}
+	if taskID != "" {
+		metadata["runner_broker_task_id"] = taskID
+	}
+
+	execution := models.CanvasNodeExecution{
+		ID:            uuid.New(),
+		WorkflowID:    s.canvas.WorkflowID,
+		NodeID:        runnerLogsRunnerNodeID,
+		RootEventID:   rootEvent.ID,
+		RunID:         run.ID,
+		EventID:       rootEvent.ID,
+		State:         models.CanvasNodeExecutionStateFinished,
+		Result:        models.CanvasNodeExecutionResultPassed,
+		ResultReason:  models.CanvasNodeExecutionResultReasonOk,
+		Metadata:      datatypes.NewJSONType(metadata),
+		Configuration: datatypes.NewJSONType(map[string]any{"script": "npm run build"}),
+		CreatedAt:     &createdAt,
+		UpdatedAt:     &finishedAt,
+	}
+	require.NoError(s.t, database.Conn().Create(&execution).Error)
+
+	outputEvent := models.CanvasEvent{
+		ID:          uuid.New(),
+		WorkflowID:  s.canvas.WorkflowID,
+		NodeID:      runnerLogsRunnerNodeID,
+		Channel:     "passed",
+		Data:        models.NewJSONValue(map[string]any{"status": "succeeded", "exit_code": 0}),
+		ExecutionID: &execution.ID,
+		RunID:       run.ID,
+		State:       models.CanvasEventStateRouted,
+		CreatedAt:   &finishedAt,
+	}
+	require.NoError(s.t, database.Conn().Create(&outputEvent).Error)
+
+	s.run = run
+}
+
+func (s *runInspectorRunnerLogsSteps) whenIVisitRunInspection() {
+	require.NotNil(s.t, s.run, "expected run to be seeded before visiting run inspection")
+	s.canvas.Visit()
+	s.canvas.WaitForRunsSidebar()
+	s.canvas.SelectRunInSidebar(s.run.ID.String())
+	s.waitForRunnerInspectionReady()
+}
+
+func (s *runInspectorRunnerLogsSteps) waitForRunnerInspectionReady() {
+	s.session.AssertURLContains("run=" + s.run.ID.String())
+	s.session.AssertVisible(q.TestID("node-start-header"))
+	s.session.AssertVisible(q.TestID("node-run-bash-header"))
+}
+
+func (s *runInspectorRunnerLogsSteps) whenIOpenTheRunnerNode() {
+	s.session.Click(q.TestID("node-run-bash-header"))
+	s.session.AssertVisible(q.TestID("run-inspector-panel"))
+}
+
+func (s *runInspectorRunnerLogsSteps) thenTheLogsAccordionIsVisible() {
+	s.session.AssertVisible(q.TestID("run-inspector-logs-accordion"))
+	s.session.AssertVisible(q.TestID("run-inspector-runtime-accordion"))
+	s.session.AssertVisible(q.TestID("run-inspector-output-accordion"))
+}
+
+func (s *runInspectorRunnerLogsSteps) thenTheLogsAccordionIsHidden() {
+	s.session.AssertHidden(q.TestID("run-inspector-logs-accordion"))
+}
+
+func (s *runInspectorRunnerLogsSteps) thenLiveLogsWereNotRequested() {
+	require.Equal(s.t, int32(0), s.liveLogSessionRequests.Load())
+}
+
+func (s *runInspectorRunnerLogsSteps) whenIOpenTheLogsAccordion() {
+	s.session.Click(q.TestID("run-inspector-logs-accordion-trigger"))
+}
+
+func (s *runInspectorRunnerLogsSteps) thenLiveLogsAreRequested() {
+	require.Eventually(s.t, func() bool {
+		return s.liveLogSessionRequests.Load() > 0
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+func (s *runInspectorRunnerLogsSteps) thenRunnerLogLinesAreVisible() {
+	terminal := s.session.Page().GetByTestId("run-inspector-runner-logs-terminal")
+	require.NoError(s.t, terminal.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(15000),
+	}))
+	text, err := terminal.InnerText()
+	require.NoError(s.t, err)
+	require.Contains(s.t, text, "npm run build")
+	require.Contains(s.t, text, "vite build")
+}

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
@@ -58,6 +58,21 @@ export const runningExecutions: CanvasesCanvasNodeExecution[] = [
   },
 ];
 
+export const runnerExecution: CanvasesCanvasNodeExecution = {
+  id: "execution-runner-1",
+  nodeId: "runner-1",
+  previousExecutionId: "execution-1",
+  state: "STATE_FINISHED",
+  result: "RESULT_PASSED",
+  resultReason: "RESULT_REASON_OK",
+  resultMessage: "",
+  createdAt: "2026-05-01T12:00:03Z",
+  updatedAt: "2026-05-01T12:00:55Z",
+  outputs: { passed: [{ data: { status: "succeeded", exit_code: 0 } }] },
+  metadata: { runner_broker_task_id: "task-runner-1" },
+  configuration: { script: "npm run build" },
+};
+
 export function renderInspector({
   selectedNodeId = null,
   onSelectNode = vi.fn(),
@@ -241,6 +256,13 @@ export const workflowNodes: SuperplaneComponentsNode[] = [
     component: "approval",
   },
 ];
+
+export const runnerNode: SuperplaneComponentsNode = {
+  id: "runner-1",
+  name: "Run Bash",
+  type: "TYPE_ACTION",
+  component: "runnerBash",
+};
 
 const componentDefinitions: ActionsAction[] = [
   {

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CanvasesCanvasNodeExecution } from "@/api-client";
+import { renderInspector, runnerExecution, runnerNode, workflowNodes } from "./RunInspectorPanel.spec.fixtures";
+
+let mockedExecutions: CanvasesCanvasNodeExecution[] = [runnerExecution];
+const useLiveLogStreamMock = vi.fn();
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useEventExecutions: () => ({
+    data: { executions: mockedExecutions },
+    isLoading: false,
+  }),
+  useCanvasVersion: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useMe", () => ({
+  useMe: () => ({ data: null }),
+}));
+
+vi.mock("@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream", () => ({
+  useLiveLogStream: (...args: unknown[]) => useLiveLogStreamMock(...args),
+}));
+
+vi.mock("@/pages/app/mappers", () => ({
+  getExecutionDetails: () => ({}),
+  getState: () => () => "success",
+  getStateMap: () => ({
+    success: { badgeColor: "bg-emerald-500", label: "success" },
+    triggered: { badgeColor: "bg-blue-500", label: "triggered" },
+  }),
+  getTriggerRenderer: () => ({
+    getTitleAndSubtitle: () => ({ title: "Deploy main", subtitle: "" }),
+    getRootEventValues: () => ({ Source: "manual" }),
+  }),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}));
+
+beforeEach(() => {
+  mockedExecutions = [runnerExecution];
+  useLiveLogStreamMock.mockReturnValue({
+    sections: [{ index: 0, text: "npm run build", lines: ["> build", "vite build"], status: "passed" }],
+    orphanLines: [],
+    error: null,
+    isStreaming: false,
+    toggleSection: vi.fn(),
+    scrollRef: { current: null },
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("RunInspector runner logs", () => {
+  it("lazy loads runner logs only after the internal logs accordion is opened", () => {
+    renderRunnerInspector();
+
+    expect(screen.getByRole("button", { name: /Logs.*Run Bash/i })).toBeInTheDocument();
+    expect(useLiveLogStreamMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Logs.*Run Bash/i }));
+
+    expect(useLiveLogStreamMock).toHaveBeenCalledWith("execution-runner-1", false);
+    expect(screen.getByText(/\$ npm run build/)).toBeInTheDocument();
+    expect(screen.getByText(/vite build/)).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem("superplane.runInspector.internalAccordions") || "{}")).toMatchObject({
+      logs: true,
+    });
+  });
+
+  it("hides runner logs before the broker task has started", () => {
+    mockedExecutions = [{ ...runnerExecution, metadata: {} }];
+
+    renderRunnerInspector();
+
+    expect(screen.queryByRole("button", { name: /Logs/i })).not.toBeInTheDocument();
+    expect(useLiveLogStreamMock).not.toHaveBeenCalled();
+  });
+});
+
+function renderRunnerInspector() {
+  renderInspector({
+    selectedNodeId: "runner-1",
+    workflowNodes: [...workflowNodes, runnerNode],
+  });
+}

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
@@ -1,0 +1,84 @@
+import type { CanvasesCanvasNodeExecution } from "@/api-client";
+import { buildExecutionInfo } from "@/pages/app/utils";
+import { isExecutionInFlight } from "@/ui/CanvasPage/RunnerLiveLogDialog/types";
+import { useLiveLogStream } from "@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream";
+import { EmptySectionText, TimelineAccordionCard } from "./RunInspectorTimelineCard";
+import type { StatusPill } from "./RunInspectorTimelineTypes";
+import type { RunInspectorNodeSection } from "./runNodeDetailModel";
+
+export function RunnerLogsTimelineCard({ section, isOpen }: { section: RunInspectorNodeSection; isOpen: boolean }) {
+  const execution = section.execution;
+
+  if (!execution?.id) {
+    return null;
+  }
+
+  return (
+    <TimelineAccordionCard
+      value="logs"
+      status={runnerLogsStatus(section)}
+      title="Logs"
+      sourceName={section.nodeName}
+      trailing={section.durationMs === undefined ? null : formatSeconds(section.durationMs)}
+      actionPayload={undefined}
+      jsonViewStyle={{}}
+    >
+      {isOpen ? (
+        <RunnerLogsTerminal execution={execution} />
+      ) : (
+        <EmptySectionText>Open this section to load runner logs.</EmptySectionText>
+      )}
+    </TimelineAccordionCard>
+  );
+}
+
+function RunnerLogsTerminal({ execution }: { execution: CanvasesCanvasNodeExecution }) {
+  const executionInfo = buildExecutionInfo(execution);
+  const { sections, orphanLines, error, scrollRef } = useLiveLogStream(
+    executionInfo.id,
+    isExecutionInFlight(executionInfo),
+  );
+  const lines = runnerLogLines(orphanLines, sections);
+  const isWaiting = isExecutionInFlight(executionInfo) && lines.length === 0 && !error;
+  const hasError = Boolean(error) && !isExecutionInFlight(executionInfo);
+
+  if (hasError) {
+    return <EmptySectionText>Something went wrong while fetching logs. Please try again later.</EmptySectionText>;
+  }
+
+  if (isWaiting) {
+    return <EmptySectionText>Waiting for logs...</EmptySectionText>;
+  }
+
+  if (lines.length === 0) {
+    return <EmptySectionText>No log lines yet.</EmptySectionText>;
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      className="max-h-80 overflow-y-auto rounded-sm bg-slate-950 px-4 py-3 text-slate-100 shadow-inner ring-1 ring-slate-900/10 dark:bg-black dark:ring-gray-800"
+    >
+      <pre className="whitespace-pre-wrap font-mono text-[12px] leading-relaxed">{lines.join("\n")}</pre>
+    </div>
+  );
+}
+
+function runnerLogLines(orphanLines: string[], sections: Array<{ text: string; lines: string[] }>): string[] {
+  return [
+    ...orphanLines.filter((line) => line.trim() !== ""),
+    ...sections.flatMap((section) => [`$ ${section.text}`, ...section.lines].filter((line) => line.trim() !== "")),
+  ];
+}
+
+function runnerLogsStatus(section: RunInspectorNodeSection): StatusPill {
+  return {
+    dotClassName: section.badge?.badgeColor ?? "bg-slate-400",
+    label: section.badge?.label ?? "Logs",
+    tone: section.errorMessage ? "error" : "default",
+  };
+}
+
+function formatSeconds(durationMs: number): string {
+  return `${Math.max(0, Math.round(durationMs / 1000))}s`;
+}

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
@@ -57,6 +57,7 @@ function RunnerLogsTerminal({ execution }: { execution: CanvasesCanvasNodeExecut
   return (
     <div
       ref={scrollRef}
+      data-testid="run-inspector-runner-logs-terminal"
       className="max-h-80 overflow-y-auto rounded-sm bg-slate-950 px-4 py-3 text-slate-100 shadow-inner ring-1 ring-slate-900/10 dark:bg-black dark:ring-gray-800"
     >
       <pre className="whitespace-pre-wrap font-mono text-[12px] leading-relaxed">{lines.join("\n")}</pre>

--- a/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepTimeline.tsx
@@ -3,7 +3,9 @@ import { getJsonViewStyle } from "@/lib/jsonViewTheme";
 import { Accordion } from "@/ui/accordion";
 import { useTheme } from "@/contexts/useTheme";
 import { RunNodeDetailDetailsView } from "./RunNodeDetailDetailsView";
+import { shouldShowRunnerLogs } from "./runnerLogsVisibility";
 import { InputChainMoreChip } from "./RunInspectorInputChainModal";
+import { RunnerLogsTimelineCard } from "./RunInspectorRunnerLogs";
 import { RuntimeTimelineCard } from "./RunInspectorRuntimeConfig";
 import {
   DetailBox,
@@ -53,7 +55,8 @@ export function RunInspectorStepTimeline({
 
   const hasDetails = !!section.tabData?.details && Object.keys(section.tabData.details).length > 0;
   const hasRuntimeConfig = hasObjectValue(section.tabData?.configuration);
-  const timelineItems = buildTimelineItems(section, hasRuntimeConfig);
+  const hasRunnerLogs = shouldShowRunnerLogs(section);
+  const timelineItems = buildTimelineItems(section, hasRuntimeConfig, hasRunnerLogs);
   const hasOutputTimelineItem = timelineItems.some((item) => item.value === "output");
 
   useEffect(() => {
@@ -90,6 +93,7 @@ export function RunInspectorStepTimeline({
     const next: InternalAccordionPreferences = {
       input: values.includes("input"),
       runtime: values.includes("runtime"),
+      logs: values.includes("logs"),
       output: values.includes("output"),
     };
     setPreferences(next);
@@ -125,6 +129,8 @@ export function RunInspectorStepTimeline({
                 canShowExpressionTemplates={canShowExpressionTemplates}
                 onEditNode={onEditNode}
               />
+            ) : item.value === "logs" ? (
+              <RunnerLogsTimelineCard section={section} isOpen={preferences.logs} />
             ) : (
               <OutputTimelineCard section={section} jsonViewStyle={jsonViewStyle} />
             )}

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
@@ -49,10 +49,14 @@ export function TimelineAccordionCard({
     <>
       <AccordionItem
         value={value}
+        data-testid={`run-inspector-${value}-accordion`}
         className="overflow-hidden rounded border border-slate-200 bg-white dark:border-gray-800 dark:bg-gray-900"
       >
         <AccordionPrimitive.Header className="flex items-center gap-1 border-b border-slate-200 bg-slate-50 py-1.5 pr-2 dark:border-gray-800 dark:bg-gray-900">
-          <AccordionPrimitive.Trigger className="flex min-w-0 items-center gap-1.5 px-3 text-left hover:no-underline">
+          <AccordionPrimitive.Trigger
+            data-testid={`run-inspector-${value}-accordion-trigger`}
+            className="flex min-w-0 items-center gap-1.5 px-3 text-left hover:no-underline"
+          >
             <EventStatusPill {...status} />
             <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-slate-400 dark:text-gray-500">
               {title}

--- a/web_src/src/ui/Runs/RunInspectorTimelineMarkers.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineMarkers.tsx
@@ -1,4 +1,4 @@
-import { SquareCheckBig } from "lucide-react";
+import { ScrollText, SquareCheckBig } from "lucide-react";
 import type { ReactNode } from "react";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { RunNodeIcon, RUN_NODE_ICON_SIZE } from "./RunNodeIcon";
@@ -103,5 +103,6 @@ function OutputStepIcon({ className }: { className?: string }) {
 const stepMarkerIcons = {
   input: InputStepIcon,
   runtime: SquareCheckBig,
+  logs: ScrollText,
   output: OutputStepIcon,
 } satisfies Record<TimelineStepType, ({ className }: { className?: string }) => ReactNode>;

--- a/web_src/src/ui/Runs/RunInspectorTimelineTypes.ts
+++ b/web_src/src/ui/Runs/RunInspectorTimelineTypes.ts
@@ -2,9 +2,9 @@ import type { RunInspectorNodeSection } from "./runNodeDetailModel";
 
 export const ACCORDION_STORAGE_KEY = "superplane.runInspector.internalAccordions";
 
-export type InternalAccordionKey = "input" | "runtime" | "output";
+export type InternalAccordionKey = "input" | "runtime" | "logs" | "output";
 export type InternalAccordionPreferences = Record<InternalAccordionKey, boolean>;
-export type TimelineStepType = "input" | "runtime" | "output";
+export type TimelineStepType = "input" | "runtime" | "logs" | "output";
 
 export type StatusPill = {
   dotClassName: string;
@@ -15,10 +15,11 @@ export type StatusPill = {
 export const defaultAccordionPreferences: InternalAccordionPreferences = {
   input: false,
   runtime: false,
+  logs: false,
   output: false,
 };
 
-export function buildTimelineItems(section: RunInspectorNodeSection, hasRuntimeConfig: boolean) {
+export function buildTimelineItems(section: RunInspectorNodeSection, hasRuntimeConfig: boolean, hasRunnerLogs = false) {
   const items: Array<{
     value: TimelineStepType;
   }> = [];
@@ -29,6 +30,10 @@ export function buildTimelineItems(section: RunInspectorNodeSection, hasRuntimeC
 
   if (hasRuntimeConfig) {
     items.push({ value: "runtime" });
+  }
+
+  if (hasRunnerLogs) {
+    items.push({ value: "logs" });
   }
 
   if (section.outputSections.length > 0 || section.errorMessage) {
@@ -47,6 +52,7 @@ export function readAccordionPreferences(): InternalAccordionPreferences {
     return {
       input: parsed.input ?? defaultAccordionPreferences.input,
       runtime: parsed.runtime ?? defaultAccordionPreferences.runtime,
+      logs: parsed.logs ?? defaultAccordionPreferences.logs,
       output: parsed.output ?? defaultAccordionPreferences.output,
     };
   } catch {

--- a/web_src/src/ui/Runs/runnerLogsVisibility.ts
+++ b/web_src/src/ui/Runs/runnerLogsVisibility.ts
@@ -1,0 +1,28 @@
+import type { CanvasesCanvasNodeExecution } from "@/api-client";
+import type { RunInspectorNodeSection } from "./runNodeDetailModel";
+
+const RUNNER_COMPONENTS = new Set(["runner", "runnerBash", "runnerJS", "runnerPython"]);
+const BROKER_TASK_ID_METADATA_KEY = "runner_broker_task_id";
+
+export function shouldShowRunnerLogs(section: RunInspectorNodeSection): boolean {
+  if (section.isTrigger || !section.execution?.id) {
+    return false;
+  }
+
+  const component = section.workflowNode?.component ?? "";
+  return RUNNER_COMPONENTS.has(component) && hasBrokerTaskId(section.execution);
+}
+
+function hasBrokerTaskId(execution: CanvasesCanvasNodeExecution): boolean {
+  const metadata = execution.metadata;
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+
+  const taskId = (metadata as Record<string, unknown>)[BROKER_TASK_ID_METADATA_KEY];
+  if (typeof taskId === "string") {
+    return taskId.trim() !== "";
+  }
+
+  return taskId !== undefined && taskId !== null && String(taskId).trim() !== "";
+}


### PR DESCRIPTION
## What changed

- Add a runner-only Logs accordion to the run inspector timeline between runtime config and output.
- Reuse the existing runner live-log stream hook and mount it only when the Logs accordion is opened.
- Hide the Logs accordion until the runner execution has a broker task id, so not-yet-started runner tasks do not show log controls.
- Add focused coverage for lazy loading and pre-start visibility.

## Validation

- `make format.js`
- `npm --prefix web_src test -- run RunInspectorPanel.spec.tsx RunInspectorRunnerLogs.spec.tsx`
- `npm --prefix web_src run lint:budget`
- `npm --prefix web_src run build`

`make check.lint.ui` and `make check.build.ui` could not run locally because Docker was not running (`Cannot connect to the Docker daemon`). The equivalent local npm lint budget and build commands passed.