### PR TITLE
fix: stream multiline SSH inline scripts

### DIFF
--- a/pkg/components/ssh/ssh.go
+++ b/pkg/components/ssh/ssh.go
@@ -879,7 +879,7 @@ func (c *SSHCommand) buildExecutionCommand(metadata ExecutionMetadata, scriptBod
 	}
 
 	if isMultilineInlineScript(metadata.Commands) {
-		command, payload := c.buildScriptCommand(metadata.WorkingDirectory, metadata.Environment, metadata.Commands)
+		command, payload := c.buildInlineScriptCommand(metadata.WorkingDirectory, metadata.Environment, metadata.Commands)
 		return command, strings.NewReader(payload), nil
 	}
 
@@ -895,12 +895,20 @@ func (c *SSHCommand) buildExecutionCommand(metadata ExecutionMetadata, scriptBod
 // prepended on its own line (followed by `|| exit 1`) so a leading shebang or
 // comment in the script cannot swallow the `cd` via `#`-to-end-of-line.
 func (c *SSHCommand) buildScriptCommand(workingDirectory string, environment []EnvironmentVariable, script string) (string, string) {
+	return c.buildScriptCommandWithShell("bash -s", workingDirectory, environment, script)
+}
+
+func (c *SSHCommand) buildInlineScriptCommand(workingDirectory string, environment []EnvironmentVariable, script string) (string, string) {
+	return c.buildScriptCommandWithShell("bash -e -s", workingDirectory, environment, script)
+}
+
+func (c *SSHCommand) buildScriptCommandWithShell(shellCommand string, workingDirectory string, environment []EnvironmentVariable, script string) (string, string) {
 	payload := normalizeScriptLineEndings(script)
 	if workingDirectory != "" {
 		payload = fmt.Sprintf("cd %s || exit 1\n%s", shellQuote(workingDirectory), payload)
 	}
 
-	command := "bash -s"
+	command := shellCommand
 	if len(environment) > 0 {
 		envAssignments := make([]string, 0, len(environment))
 		for _, variable := range environment {

--- a/pkg/components/ssh/ssh.go
+++ b/pkg/components/ssh/ssh.go
@@ -855,11 +855,12 @@ func (c *SSHCommand) buildRemoteCommand(workingDirectory string, environment []E
 }
 
 // buildExecutionCommand assembles the final command sent to the remote host
-// and, for file mode, returns the script body to stream as stdin.
+// and returns a stdin payload when the command should be streamed as a script.
 //
-// Inline mode keeps the long-standing behavior of stripping blank lines and
-// joining the rest with `&&` so a list of one-liners runs as a chain. The
-// remote shell receives a single string and no stdin payload.
+// Inline mode keeps one-line commands on the command line, preserving the
+// long-standing behavior for simple invocations. Multi-line inline scripts are
+// streamed to `bash -s` so shell syntax that depends on real newlines (shebangs,
+// comments, conditionals, here-docs) is not flattened into invalid `&&` chains.
 //
 // File mode pipes the (already-loaded) script body to `bash -s` over stdin.
 // This avoids embedding the whole script in the command line — argv has size
@@ -874,6 +875,11 @@ func (c *SSHCommand) buildExecutionCommand(metadata ExecutionMetadata, scriptBod
 			return "", nil, errors.New("command file body is required")
 		}
 		command, payload := c.buildScriptCommand(metadata.WorkingDirectory, metadata.Environment, scriptBody)
+		return command, strings.NewReader(payload), nil
+	}
+
+	if isMultilineInlineScript(metadata.Commands) {
+		command, payload := c.buildScriptCommand(metadata.WorkingDirectory, metadata.Environment, metadata.Commands)
 		return command, strings.NewReader(payload), nil
 	}
 
@@ -971,6 +977,22 @@ func buildCombinedCommands(commands string) string {
 		return ""
 	}
 	return strings.Join(parts, " && ")
+}
+
+func isMultilineInlineScript(commands string) bool {
+	lines := strings.Split(normalizeScriptLineEndings(commands), "\n")
+	nonEmptyLines := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		nonEmptyLines++
+		if nonEmptyLines > 1 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func normalizeScriptLineEndings(script string) string {

--- a/pkg/components/ssh/ssh_test.go
+++ b/pkg/components/ssh/ssh_test.go
@@ -703,15 +703,78 @@ fi`
 func TestSSHCommand_BuildExecutionCommand(t *testing.T) {
 	c := &SSHCommand{}
 
-	t.Run("inline mode joins lines, uses sh, and has no stdin payload", func(t *testing.T) {
+	t.Run("inline mode streams multi-line commands", func(t *testing.T) {
 		meta := ExecutionMetadata{
 			CommandSource: CommandSourceInline,
 			Commands:      "echo 1\necho 2",
 		}
 		command, stdin, err := c.buildExecutionCommand(meta, "")
 		require.NoError(t, err)
+		assert.Equal(t, "bash -s", command)
+		require.NotNil(t, stdin)
+
+		body, readErr := io.ReadAll(stdin)
+		require.NoError(t, readErr)
+		assert.Equal(t, "echo 1\necho 2", string(body))
+	})
+
+	t.Run("inline mode keeps single-line commands on the command line", func(t *testing.T) {
+		meta := ExecutionMetadata{
+			CommandSource: CommandSourceInline,
+			Commands:      "echo 1 && echo 2",
+		}
+
+		command, stdin, err := c.buildExecutionCommand(meta, "")
+		require.NoError(t, err)
 		assert.Equal(t, "echo 1 && echo 2", command)
 		assert.Nil(t, stdin)
+	})
+
+	t.Run("inline mode streams customer bash scripts instead of flattening them", func(t *testing.T) {
+		script := strings.Join([]string{
+			"#!/bin/bash",
+			"set -euo pipefail",
+			"cd ~/preview-sso.teams.novp.com",
+			`sed -i -E "s#([a-z0-9\-]+\.teams\.novp\.com)#${APP_HOST_PREFIX}-\1#g" .env`,
+			"docker compose down --remove-orphans && docker compose up -d",
+			"docker compose run --rm php php artisan migrate",
+		}, "\r\n")
+		meta := ExecutionMetadata{
+			CommandSource: CommandSourceInline,
+			Commands:      script,
+		}
+
+		command, stdin, err := c.buildExecutionCommand(meta, "")
+		require.NoError(t, err)
+		assert.Equal(t, "bash -s", command)
+		require.NotNil(t, stdin)
+
+		body, readErr := io.ReadAll(stdin)
+		require.NoError(t, readErr)
+		assert.Equal(t, strings.ReplaceAll(script, "\r\n", "\n"), string(body))
+		assert.NotContains(t, string(body), "\r")
+		assert.Contains(t, string(body), `\1`)
+	})
+
+	t.Run("inline mode streams shell blocks that require real newlines", func(t *testing.T) {
+		script := strings.Join([]string{
+			"if [ -n \"$APP_BRANCH_NAME\" ]; then",
+			"  git switch \"$APP_BRANCH_NAME\"",
+			"fi",
+		}, "\n")
+		meta := ExecutionMetadata{
+			CommandSource: CommandSourceInline,
+			Commands:      script,
+		}
+
+		command, stdin, err := c.buildExecutionCommand(meta, "")
+		require.NoError(t, err)
+		assert.Equal(t, "bash -s", command)
+		require.NotNil(t, stdin)
+
+		body, readErr := io.ReadAll(stdin)
+		require.NoError(t, readErr)
+		assert.Equal(t, script, string(body))
 	})
 
 	t.Run("inline mode rejects empty commands", func(t *testing.T) {

--- a/pkg/components/ssh/ssh_test.go
+++ b/pkg/components/ssh/ssh_test.go
@@ -703,14 +703,14 @@ fi`
 func TestSSHCommand_BuildExecutionCommand(t *testing.T) {
 	c := &SSHCommand{}
 
-	t.Run("inline mode streams multi-line commands", func(t *testing.T) {
+	t.Run("inline mode streams multi-line commands with errexit", func(t *testing.T) {
 		meta := ExecutionMetadata{
 			CommandSource: CommandSourceInline,
 			Commands:      "echo 1\necho 2",
 		}
 		command, stdin, err := c.buildExecutionCommand(meta, "")
 		require.NoError(t, err)
-		assert.Equal(t, "bash -s", command)
+		assert.Equal(t, "bash -e -s", command)
 		require.NotNil(t, stdin)
 
 		body, readErr := io.ReadAll(stdin)
@@ -746,7 +746,7 @@ func TestSSHCommand_BuildExecutionCommand(t *testing.T) {
 
 		command, stdin, err := c.buildExecutionCommand(meta, "")
 		require.NoError(t, err)
-		assert.Equal(t, "bash -s", command)
+		assert.Equal(t, "bash -e -s", command)
 		require.NotNil(t, stdin)
 
 		body, readErr := io.ReadAll(stdin)
@@ -769,12 +769,28 @@ func TestSSHCommand_BuildExecutionCommand(t *testing.T) {
 
 		command, stdin, err := c.buildExecutionCommand(meta, "")
 		require.NoError(t, err)
-		assert.Equal(t, "bash -s", command)
+		assert.Equal(t, "bash -e -s", command)
 		require.NotNil(t, stdin)
 
 		body, readErr := io.ReadAll(stdin)
 		require.NoError(t, readErr)
 		assert.Equal(t, script, string(body))
+	})
+
+	t.Run("inline mode preserves fail-fast behavior when streaming line lists", func(t *testing.T) {
+		meta := ExecutionMetadata{
+			CommandSource: CommandSourceInline,
+			Commands:      "false\necho should-not-run",
+		}
+
+		command, stdin, err := c.buildExecutionCommand(meta, "")
+		require.NoError(t, err)
+		assert.Equal(t, "bash -e -s", command)
+		require.NotNil(t, stdin)
+
+		body, readErr := io.ReadAll(stdin)
+		require.NoError(t, readErr)
+		assert.Equal(t, "false\necho should-not-run", string(body))
 	})
 
 	t.Run("inline mode rejects empty commands", func(t *testing.T) {

--- a/test/e2e/ssh_line_endings_test.go
+++ b/test/e2e/ssh_line_endings_test.go
@@ -41,7 +41,7 @@ func TestSSHCommandLineEndings(t *testing.T) {
 	t.Run("normalizes CRLF command files before streaming them over SSH", func(t *testing.T) {
 		steps := &sshLineEndingsSteps{t: t}
 		steps.start()
-		steps.givenAnSSHServerExpectingScript("set -eo pipefail\nprintf ok\n")
+		steps.givenAnSSHServerExpectingScript("bash -s", "set -eo pipefail\nprintf ok\n")
 		steps.givenACanvasWithCRLFSSHCommandFile()
 		steps.whenTheManualTriggerRuns()
 		steps.thenTheSSHNodeCompletedSuccessfully()
@@ -51,7 +51,7 @@ func TestSSHCommandLineEndings(t *testing.T) {
 	t.Run("normalizes CRLF inline scripts before streaming them over SSH", func(t *testing.T) {
 		steps := &sshLineEndingsSteps{t: t}
 		steps.start()
-		steps.givenAnSSHServerExpectingScript(strings.Join([]string{
+		steps.givenAnSSHServerExpectingScript("bash -e -s", strings.Join([]string{
 			"#!/bin/bash",
 			"set -euo pipefail",
 			"cd ~/preview-sso.teams.novp.com",
@@ -80,8 +80,8 @@ func (s *sshLineEndingsSteps) start() {
 	s.session.Login()
 }
 
-func (s *sshLineEndingsSteps) givenAnSSHServerExpectingScript(expectedScript string) {
-	server, err := startScriptCheckingSSHServer(sshLineEndingUser, sshLineEndingPassword, expectedScript)
+func (s *sshLineEndingsSteps) givenAnSSHServerExpectingScript(expectedCommand string, expectedScript string) {
+	server, err := startScriptCheckingSSHServer(sshLineEndingUser, sshLineEndingPassword, expectedCommand, expectedScript)
 	require.NoError(s.t, err)
 	s.t.Cleanup(server.Close)
 	s.server = server
@@ -261,14 +261,15 @@ func (s *sshLineEndingsSteps) thenTheSSHServerReceivedNormalizedScript() {
 }
 
 type scriptCheckingSSHServer struct {
-	listener net.Listener
-	config   *pwssh.ServerConfig
-	expected string
-	scripts  chan string
-	errors   chan error
+	listener        net.Listener
+	config          *pwssh.ServerConfig
+	expectedCommand string
+	expected        string
+	scripts         chan string
+	errors          chan error
 }
 
-func startScriptCheckingSSHServer(username, password, expected string) (*scriptCheckingSSHServer, error) {
+func startScriptCheckingSSHServer(username, password, expectedCommand, expected string) (*scriptCheckingSSHServer, error) {
 	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, err
@@ -295,11 +296,12 @@ func startScriptCheckingSSHServer(username, password, expected string) (*scriptC
 	}
 
 	server := &scriptCheckingSSHServer{
-		listener: listener,
-		config:   config,
-		expected: expected,
-		scripts:  make(chan string, 1),
-		errors:   make(chan error, 1),
+		listener:        listener,
+		config:          config,
+		expectedCommand: expectedCommand,
+		expected:        expected,
+		scripts:         make(chan string, 1),
+		errors:          make(chan error, 1),
 	}
 
 	go server.accept()
@@ -388,7 +390,7 @@ func (s *scriptCheckingSSHServer) handleSession(channel pwssh.Channel, requests 
 			return
 		}
 
-		if payload.Command != "bash -s" {
+		if payload.Command != s.expectedCommand {
 			_ = request.Reply(false, nil)
 			s.reportError(fmt.Errorf("unexpected SSH command %q", payload.Command))
 			return

--- a/test/e2e/ssh_line_endings_test.go
+++ b/test/e2e/ssh_line_endings_test.go
@@ -41,8 +41,26 @@ func TestSSHCommandLineEndings(t *testing.T) {
 	t.Run("normalizes CRLF command files before streaming them over SSH", func(t *testing.T) {
 		steps := &sshLineEndingsSteps{t: t}
 		steps.start()
-		steps.givenAnSSHServerExpectingLFScript()
+		steps.givenAnSSHServerExpectingScript("set -eo pipefail\nprintf ok\n")
 		steps.givenACanvasWithCRLFSSHCommandFile()
+		steps.whenTheManualTriggerRuns()
+		steps.thenTheSSHNodeCompletedSuccessfully()
+		steps.thenTheSSHServerReceivedNormalizedScript()
+	})
+
+	t.Run("normalizes CRLF inline scripts before streaming them over SSH", func(t *testing.T) {
+		steps := &sshLineEndingsSteps{t: t}
+		steps.start()
+		steps.givenAnSSHServerExpectingScript(strings.Join([]string{
+			"#!/bin/bash",
+			"set -euo pipefail",
+			"cd ~/preview-sso.teams.novp.com",
+			`sed -i -E "s#([a-z0-9\-]+\.teams\.novp\.com)#${APP_HOST_PREFIX}-\1#g" .env`,
+			"docker compose down --remove-orphans && docker compose up -d",
+			"docker compose run --rm php php artisan migrate",
+			"",
+		}, "\n"))
+		steps.givenACanvasWithCRLFInlineScript()
 		steps.whenTheManualTriggerRuns()
 		steps.thenTheSSHNodeCompletedSuccessfully()
 		steps.thenTheSSHServerReceivedNormalizedScript()
@@ -62,8 +80,7 @@ func (s *sshLineEndingsSteps) start() {
 	s.session.Login()
 }
 
-func (s *sshLineEndingsSteps) givenAnSSHServerExpectingLFScript() {
-	expectedScript := "set -eo pipefail\nprintf ok\n"
+func (s *sshLineEndingsSteps) givenAnSSHServerExpectingScript(expectedScript string) {
 	server, err := startScriptCheckingSSHServer(sshLineEndingUser, sshLineEndingPassword, expectedScript)
 	require.NoError(s.t, err)
 	s.t.Cleanup(server.Close)
@@ -74,10 +91,34 @@ func (s *sshLineEndingsSteps) givenACanvasWithCRLFSSHCommandFile() {
 	require.NotNil(s.t, s.server, "SSH server must be started before creating the canvas")
 
 	s.createPasswordSecret()
-	canvas := s.createPublishedSSHCanvas()
+	canvas := s.createPublishedSSHCanvas(map[string]any{
+		"commandSource": "file",
+		"commandFile":   sshLineEndingScriptPath,
+	})
 	s.createRepositoryCommandFile(canvas, "set -eo pipefail\r\nprintf ok\r\n")
 
 	s.canvas = shared.NewCanvasSteps("SSH CRLF Line Endings", s.t, s.session)
+	s.canvas.WorkflowID = canvas.ID
+}
+
+func (s *sshLineEndingsSteps) givenACanvasWithCRLFInlineScript() {
+	require.NotNil(s.t, s.server, "SSH server must be started before creating the canvas")
+
+	s.createPasswordSecret()
+	canvas := s.createPublishedSSHCanvas(map[string]any{
+		"commandSource": "inline",
+		"commands": strings.Join([]string{
+			"#!/bin/bash",
+			"set -euo pipefail",
+			"cd ~/preview-sso.teams.novp.com",
+			`sed -i -E "s#([a-z0-9\-]+\.teams\.novp\.com)#${APP_HOST_PREFIX}-\1#g" .env`,
+			"docker compose down --remove-orphans && docker compose up -d",
+			"docker compose run --rm php php artisan migrate",
+			"",
+		}, "\r\n"),
+	})
+
+	s.canvas = shared.NewCanvasSteps("SSH Inline CRLF Line Endings", s.t, s.session)
 	s.canvas.WorkflowID = canvas.ID
 }
 
@@ -98,12 +139,29 @@ func (s *sshLineEndingsSteps) createPasswordSecret() {
 	require.NoError(s.t, err)
 }
 
-func (s *sshLineEndingsSteps) createPublishedSSHCanvas() *models.Canvas {
+func (s *sshLineEndingsSteps) createPublishedSSHCanvas(commandConfig map[string]any) *models.Canvas {
 	user, err := models.FindMaybeDeletedUserByEmail(s.session.OrgID.String(), s.session.Account.Email)
 	require.NoError(s.t, err)
 
 	startNodeID := "start-trigger"
 	sshNodeID := "ssh-command"
+	configuration := map[string]any{
+		"host":     "127.0.0.1",
+		"port":     s.server.Port(),
+		"username": sshLineEndingUser,
+		"timeout":  10,
+		"authentication": map[string]any{
+			"authMethod": "password",
+			"password": map[string]any{
+				"secret": sshLineEndingSecretName,
+				"key":    sshLineEndingSecretKey,
+			},
+		},
+	}
+	for key, value := range commandConfig {
+		configuration[key] = value
+	}
+
 	canvas, _ := support.CreateCanvas(s.t, s.session.OrgID, user.ID, []models.CanvasNode{
 		{
 			NodeID: startNodeID,
@@ -122,22 +180,8 @@ func (s *sshLineEndingsSteps) createPublishedSSHCanvas() *models.Canvas {
 			Ref: datatypes.NewJSONType(models.NodeRef{
 				Component: &models.ComponentRef{Name: "ssh"},
 			}),
-			Configuration: datatypes.NewJSONType(map[string]any{
-				"host":          "127.0.0.1",
-				"port":          s.server.Port(),
-				"username":      sshLineEndingUser,
-				"commandSource": "file",
-				"commandFile":   sshLineEndingScriptPath,
-				"timeout":       10,
-				"authentication": map[string]any{
-					"authMethod": "password",
-					"password": map[string]any{
-						"secret": sshLineEndingSecretName,
-						"key":    sshLineEndingSecretKey,
-					},
-				},
-			}),
-			Position: datatypes.NewJSONType(models.Position{X: 1000, Y: 200}),
+			Configuration: datatypes.NewJSONType(configuration),
+			Position:      datatypes.NewJSONType(models.Position{X: 1000, Y: 200}),
 		},
 	}, []models.Edge{
 		{SourceID: startNodeID, TargetID: sshNodeID, Channel: "default"},
@@ -212,7 +256,7 @@ func (s *sshLineEndingsSteps) thenTheSSHNodeCompletedSuccessfully() {
 
 func (s *sshLineEndingsSteps) thenTheSSHServerReceivedNormalizedScript() {
 	body := s.server.WaitForScript(s.t)
-	require.Equal(s.t, "set -eo pipefail\nprintf ok\n", body)
+	require.Equal(s.t, s.server.expected, body)
 	require.NotContains(s.t, body, "\r")
 }
 


### PR DESCRIPTION
## Summary
- Stream multi-line SSH inline commands through `bash -s` instead of flattening them into a single `&&` command.
- Keep single-line inline commands on the existing command-line execution path.
- Reproduce the customer-style CRLF inline bash script in unit coverage and E2E coverage.

## Why
The previous fix normalized file-mode scripts, but inline multi-line scripts were still collapsed into one shell command. That can corrupt shebang/comment handling and shell syntax that depends on real newlines, leading to remote shell errors like `sh: 1: Syntax error: end of file unexpected`.

## Tests
- make format.go
- make test PKG_TEST_PACKAGES=./pkg/components/ssh
- make test.e2e.single FILE=test/e2e/ssh_line_endings_test.go LINE=37
- make lint && make check.build.app