### PR TITLE
feat: show queued steps in run inspector

### DIFF
--- a/pkg/grpc/actions/canvases/describe_run.go
+++ b/pkg/grpc/actions/canvases/describe_run.go
@@ -32,17 +32,18 @@ func DescribeRun(ctx context.Context, registry *registry.Registry, canvasID uuid
 		return nil, grpcerrors.Internal(err, "failed to find run")
 	}
 
-	rootEventsByRunID, err := listRootEventsForRuns(ctx, canvasID, []uuid.UUID{run.ID})
+	runDetails, err := loadRunDetailsForRuns(ctx, canvasID, []uuid.UUID{run.ID})
 	if err != nil {
 		return nil, err
 	}
 
-	executions, err := models.ListExecutionsForRunsInTransaction(db, canvasID, []uuid.UUID{run.ID})
-	if err != nil {
-		return nil, err
-	}
-
-	serializedRun, err := SerializeCanvasRun(*run, rootEventsByRunID[run.ID.String()], executions)
+	serializedRun, err := SerializeCanvasRun(
+		db,
+		*run,
+		runDetails.rootEventsByRunID[run.ID.String()],
+		runDetails.executionsByRunID[run.ID.String()],
+		runDetails.queueItemsByRunID[run.ID.String()],
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/canvases/describe_run_test.go
+++ b/pkg/grpc/actions/canvases/describe_run_test.go
@@ -49,6 +49,39 @@ func Test__DescribeRun(t *testing.T) {
 		assert.Equal(t, execution.ID.String(), serializedRun.Executions[0].Id)
 	})
 
+	t.Run("returns run with queue items", func(t *testing.T) {
+		canvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{
+				{NodeID: "trigger", Type: models.NodeTypeTrigger},
+				{NodeID: "node-1", Type: models.NodeTypeComponent},
+			},
+			[]models.Edge{},
+		)
+
+		rootEvent := support.EmitCanvasEventForNodeWithData(t, canvas.ID, "trigger", "default", nil, map[string]any{
+			"approval": "waiting",
+		})
+		run := createStartedRun(t, rootEvent)
+		queueItem := support.CreateQueueItem(t, canvas.ID, "node-1", rootEvent.ID, rootEvent.ID)
+
+		response, err := DescribeRun(context.Background(), r.Registry, canvas.ID, run.ID.String())
+		require.NoError(t, err)
+		require.NotNil(t, response.Run)
+		require.Len(t, response.Run.QueueItems, 1)
+
+		serializedQueueItem := response.Run.QueueItems[0]
+		assert.Equal(t, queueItem.ID.String(), serializedQueueItem.Id)
+		assert.Equal(t, "node-1", serializedQueueItem.NodeId)
+		assert.NotNil(t, serializedQueueItem.CreatedAt)
+		require.NotNil(t, serializedQueueItem.RootEvent)
+		assert.Equal(t, rootEvent.ID.String(), serializedQueueItem.RootEvent.Id)
+		require.NotNil(t, serializedQueueItem.Input)
+		assert.Equal(t, "waiting", serializedQueueItem.Input.AsMap()["approval"])
+	})
+
 	t.Run("scopes run to canvas", func(t *testing.T) {
 		canvasOne, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{{NodeID: "trigger", Type: models.NodeTypeTrigger}}, []models.Edge{})
 		canvasTwo, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{{NodeID: "trigger", Type: models.NodeTypeTrigger}}, []models.Edge{})

--- a/pkg/grpc/actions/canvases/list_node_queue_items.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items.go
@@ -52,22 +52,31 @@ func ListNodeQueueItems(ctx context.Context, registry *registry.Registry, workfl
 }
 
 func SerializeNodeQueueItems(db *gorm.DB, queueItems []models.CanvasNodeQueueItem) ([]*pb.CanvasNodeQueueItem, error) {
-	//
-	// Fetch all input records
-	//
+	inputEvents, err := loadInputEventsForQueueItems(db, queueItems)
+	if err != nil {
+		return nil, err
+	}
+
+	return serializeNodeQueueItemsWithInputEvents(queueItems, inputEvents)
+}
+
+func loadInputEventsForQueueItems(db *gorm.DB, queueItems []models.CanvasNodeQueueItem) ([]models.CanvasEvent, error) {
 	inputEvents, err := models.FindCanvasEvents(db, eventIDsFromQueueItems(queueItems))
 	if err != nil {
 		return nil, fmt.Errorf("error find input events: %v", err)
 	}
 
-	//
-	// Combine everything into the response
-	//
+	return inputEvents, nil
+}
+
+func serializeNodeQueueItemsWithInputEvents(queueItems []models.CanvasNodeQueueItem, inputEvents []models.CanvasEvent) ([]*pb.CanvasNodeQueueItem, error) {
+	inputEventsByID := indexEventsByID(inputEvents)
 	result := make([]*pb.CanvasNodeQueueItem, 0, len(queueItems))
 	for _, queueItem := range queueItems {
-		input, err := getInputForQueueItem(queueItem, inputEvents)
+		input, err := getInputForQueueItem(queueItem, inputEventsByID)
 		if err != nil {
-			return nil, err
+			log.WithError(err).Warnf("Serializing queue item %s with empty input", queueItem.ID.String())
+			input = &structpb.Struct{}
 		}
 
 		serializedQueueItem := &pb.CanvasNodeQueueItem{
@@ -92,6 +101,15 @@ func SerializeNodeQueueItems(db *gorm.DB, queueItems []models.CanvasNodeQueueIte
 	return result, nil
 }
 
+func indexEventsByID(events []models.CanvasEvent) map[string]models.CanvasEvent {
+	eventsByID := make(map[string]models.CanvasEvent, len(events))
+	for _, event := range events {
+		eventsByID[event.ID.String()] = event
+	}
+
+	return eventsByID
+}
+
 func getLastQueueItemTimestamp(queueItems []models.CanvasNodeQueueItem) *timestamppb.Timestamp {
 	if len(queueItems) > 0 {
 		return timestamppb.New(*queueItems[len(queueItems)-1].CreatedAt)
@@ -108,22 +126,21 @@ func eventIDsFromQueueItems(queueItems []models.CanvasNodeQueueItem) []string {
 	return ids
 }
 
-func getInputForQueueItem(queueItem models.CanvasNodeQueueItem, events []models.CanvasEvent) (*structpb.Struct, error) {
-	for _, event := range events {
-		if event.ID.String() == queueItem.EventID.String() {
-			eventData, ok := event.Data.Data().(map[string]any)
-			if !ok {
-				return nil, fmt.Errorf("event data cannot be turned into input for queue item %s", queueItem.ID.String())
-			}
-
-			data, err := newStructpbStruct(eventData)
-			if err != nil {
-				return nil, err
-			}
-
-			return data, nil
-		}
+func getInputForQueueItem(queueItem models.CanvasNodeQueueItem, eventsByID map[string]models.CanvasEvent) (*structpb.Struct, error) {
+	event, ok := eventsByID[queueItem.EventID.String()]
+	if !ok {
+		return nil, fmt.Errorf("input not found for queue item %s", queueItem.ID.String())
 	}
 
-	return nil, fmt.Errorf("input not found for queue item %s", queueItem.ID.String())
+	eventData, ok := event.Data.Data().(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("event data cannot be turned into input for queue item %s", queueItem.ID.String())
+	}
+
+	data, err := newStructpbStruct(eventData)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }

--- a/pkg/grpc/actions/canvases/list_node_queue_items_test.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items_test.go
@@ -286,3 +286,43 @@ func Test__SerializeNodeQueueItems__HandlesEmptyList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
+
+func Test__SerializeNodeQueueItemsWithInputEvents__KeepsItemsWithMissingInput(t *testing.T) {
+	now := time.Now()
+	validEventID := uuid.New()
+	missingEventID := uuid.New()
+	missingQueueItemID := uuid.New()
+	validQueueItemID := uuid.New()
+
+	result, err := serializeNodeQueueItemsWithInputEvents(
+		[]models.CanvasNodeQueueItem{
+			{
+				ID:         missingQueueItemID,
+				WorkflowID: uuid.New(),
+				NodeID:     "node-1",
+				EventID:    missingEventID,
+				CreatedAt:  &now,
+			},
+			{
+				ID:         validQueueItemID,
+				WorkflowID: uuid.New(),
+				NodeID:     "node-1",
+				EventID:    validEventID,
+				CreatedAt:  &now,
+			},
+		},
+		[]models.CanvasEvent{
+			{
+				ID:   validEventID,
+				Data: models.NewJSONValue(map[string]any{"message": "queued"}),
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, missingQueueItemID.String(), result[0].Id)
+	assert.Empty(t, result[0].Input.AsMap())
+	assert.Equal(t, validQueueItemID.String(), result[1].Id)
+	assert.Equal(t, "queued", result[1].Input.AsMap()["message"])
+}

--- a/pkg/grpc/actions/canvases/list_runs.go
+++ b/pkg/grpc/actions/canvases/list_runs.go
@@ -14,7 +14,9 @@ import (
 	"github.com/superplanehq/superplane/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 func ListRuns(ctx context.Context, registry *registry.Registry, canvasID uuid.UUID, limit uint32, before *timestamppb.Timestamp, states []pb.CanvasRun_State, results []pb.CanvasRun_Result) (*pb.ListRunsResponse, error) {
@@ -40,22 +42,12 @@ func ListRuns(ctx context.Context, registry *registry.Registry, canvasID uuid.UU
 		runIDs[i] = run.ID
 	}
 
-	rootEventsByRunID, err := loadRootEventsForRunsSpan(ctx, canvasID, runIDs)
+	runDetails, err := loadRunDetailsForRuns(ctx, canvasID, runIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	executions, err := listExecutionsForRuns(ctx, canvasID, runIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	executionsByRunID := make(map[string][]models.CanvasNodeExecution, len(runIDs))
-	for _, execution := range executions {
-		executionsByRunID[execution.RunID.String()] = append(executionsByRunID[execution.RunID.String()], execution)
-	}
-
-	serialized, err := serializeCanvasRuns(ctx, runs, rootEventsByRunID, executionsByRunID)
+	serialized, err := serializeCanvasRuns(ctx, runs, runDetails.rootEventsByRunID, runDetails.executionsByRunID, runDetails.queueItemsByRunID)
 	if err != nil {
 		return nil, err
 	}
@@ -119,11 +111,28 @@ func listRootEventsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uui
 	return eventsByRunID, nil
 }
 
-func SerializeCanvasRuns(runs []models.CanvasRun, rootEventsByRunID map[string]models.CanvasEvent, executionsByRunID map[string][]models.CanvasNodeExecution) ([]*pb.CanvasRun, error) {
+func SerializeCanvasRuns(
+	db *gorm.DB,
+	runs []models.CanvasRun,
+	rootEventsByRunID map[string]models.CanvasEvent,
+	executionsByRunID map[string][]models.CanvasNodeExecution,
+	queueItemsByRunID map[string][]models.CanvasNodeQueueItem,
+) ([]*pb.CanvasRun, error) {
+	inputEvents, err := loadInputEventsForQueueItems(db, queueItemsForRuns(runs, queueItemsByRunID))
+	if err != nil {
+		return nil, err
+	}
+
 	result := make([]*pb.CanvasRun, 0, len(runs))
 
 	for _, run := range runs {
-		serializedRun, err := SerializeCanvasRun(run, rootEventsByRunID[run.ID.String()], executionsByRunID[run.ID.String()])
+		serializedRun, err := serializeCanvasRunWithQueueItemInputs(
+			run,
+			rootEventsByRunID[run.ID.String()],
+			executionsByRunID[run.ID.String()],
+			queueItemsByRunID[run.ID.String()],
+			inputEvents,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +143,28 @@ func SerializeCanvasRuns(runs []models.CanvasRun, rootEventsByRunID map[string]m
 	return result, nil
 }
 
-func SerializeCanvasRun(run models.CanvasRun, rootEvent models.CanvasEvent, executions []models.CanvasNodeExecution) (*pb.CanvasRun, error) {
+func SerializeCanvasRun(
+	db *gorm.DB,
+	run models.CanvasRun,
+	rootEvent models.CanvasEvent,
+	executions []models.CanvasNodeExecution,
+	queueItems []models.CanvasNodeQueueItem,
+) (*pb.CanvasRun, error) {
+	inputEvents, err := loadInputEventsForQueueItems(db, queueItems)
+	if err != nil {
+		return nil, err
+	}
+
+	return serializeCanvasRunWithQueueItemInputs(run, rootEvent, executions, queueItems, inputEvents)
+}
+
+func serializeCanvasRunWithQueueItemInputs(
+	run models.CanvasRun,
+	rootEvent models.CanvasEvent,
+	executions []models.CanvasNodeExecution,
+	queueItems []models.CanvasNodeQueueItem,
+	inputEvents []models.CanvasEvent,
+) (*pb.CanvasRun, error) {
 	if rootEvent.ID == uuid.Nil {
 		return nil, grpcerrors.NotFound(nil, "root event not found")
 	}
@@ -149,6 +179,11 @@ func SerializeCanvasRun(run models.CanvasRun, rootEvent models.CanvasEvent, exec
 		executionRefs = append(executionRefs, SerializeNodeExecutionRef(execution))
 	}
 
+	serializedQueueItems, err := serializeNodeQueueItemsWithInputEvents(queueItems, inputEvents)
+	if err != nil {
+		return nil, err
+	}
+
 	serialized := &pb.CanvasRun{
 		Id:         run.ID.String(),
 		CanvasId:   run.WorkflowID.String(),
@@ -157,6 +192,7 @@ func SerializeCanvasRun(run models.CanvasRun, rootEvent models.CanvasEvent, exec
 		State:      RunStateToProto(run.State),
 		Result:     RunResultToProto(run.Result),
 		Executions: executionRefs,
+		QueueItems: serializedQueueItems,
 		CreatedAt:  timestamppb.New(*run.CreatedAt),
 		UpdatedAt:  timestamppb.New(*run.UpdatedAt),
 	}
@@ -166,6 +202,20 @@ func SerializeCanvasRun(run models.CanvasRun, rootEvent models.CanvasEvent, exec
 	}
 
 	return serialized, nil
+}
+
+func queueItemsForRuns(runs []models.CanvasRun, queueItemsByRunID map[string][]models.CanvasNodeQueueItem) []models.CanvasNodeQueueItem {
+	var count int
+	for _, run := range runs {
+		count += len(queueItemsByRunID[run.ID.String()])
+	}
+
+	queueItems := make([]models.CanvasNodeQueueItem, 0, count)
+	for _, run := range runs {
+		queueItems = append(queueItems, queueItemsByRunID[run.ID.String()]...)
+	}
+
+	return queueItems
 }
 
 func ProtoRunStateToModel(state pb.CanvasRun_State) (string, error) {
@@ -216,6 +266,76 @@ func RunResultToProto(result string) pb.CanvasRun_Result {
 	}
 }
 
+type runDetailsForRuns struct {
+	rootEventsByRunID map[string]models.CanvasEvent
+	executionsByRunID map[string][]models.CanvasNodeExecution
+	queueItemsByRunID map[string][]models.CanvasNodeQueueItem
+}
+
+func loadRunDetailsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uuid.UUID) (*runDetailsForRuns, error) {
+	if len(runIDs) == 0 {
+		return &runDetailsForRuns{
+			rootEventsByRunID: map[string]models.CanvasEvent{},
+			executionsByRunID: map[string][]models.CanvasNodeExecution{},
+			queueItemsByRunID: map[string][]models.CanvasNodeQueueItem{},
+		}, nil
+	}
+
+	var rootEventsByRunID map[string]models.CanvasEvent
+	var executionsByRunID map[string][]models.CanvasNodeExecution
+	var queueItemsByRunID map[string][]models.CanvasNodeQueueItem
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		rootEventsByRunID, err = loadRootEventsForRunsSpan(gctx, canvasID, runIDs)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	g.Go(func() error {
+		executions, err := listExecutionsForRuns(gctx, canvasID, runIDs)
+		if err != nil {
+			return err
+		}
+
+		executionsByRunID = groupExecutionsByRunID(executions, len(runIDs))
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		queueItemsByRunID, err = loadQueueItemsForRuns(gctx, canvasID, runIDs)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return &runDetailsForRuns{
+		rootEventsByRunID: rootEventsByRunID,
+		executionsByRunID: executionsByRunID,
+		queueItemsByRunID: queueItemsByRunID,
+	}, nil
+}
+
+func groupExecutionsByRunID(executions []models.CanvasNodeExecution, runCount int) map[string][]models.CanvasNodeExecution {
+	executionsByRunID := make(map[string][]models.CanvasNodeExecution, runCount)
+	for _, execution := range executions {
+		executionsByRunID[execution.RunID.String()] = append(executionsByRunID[execution.RunID.String()], execution)
+	}
+
+	return executionsByRunID
+}
+
 func getLastRunTimestamp(runs []models.CanvasRun) *timestamppb.Timestamp {
 	if len(runs) > 0 {
 		return timestamppb.New(*runs[len(runs)-1].CreatedAt)
@@ -229,11 +349,12 @@ func serializeCanvasRuns(
 	runs []models.CanvasRun,
 	rootEventsByRunID map[string]models.CanvasEvent,
 	executionsByRunID map[string][]models.CanvasNodeExecution,
+	queueItemsByRunID map[string][]models.CanvasNodeQueueItem,
 ) (serialized []*pb.CanvasRun, err error) {
 	ctx, done := telemetry.Span(ctx, "runs.serialize")
 	defer done(&err)
 
-	serialized, err = SerializeCanvasRuns(runs, rootEventsByRunID, executionsByRunID)
+	serialized, err = SerializeCanvasRuns(database.DB(ctx), runs, rootEventsByRunID, executionsByRunID, queueItemsByRunID)
 	if err != nil {
 		return nil, err
 	}
@@ -271,4 +392,29 @@ func listExecutionsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uui
 	defer done(&err)
 
 	return models.ListExecutionsForRunsInTransaction(database.DB(ctx), canvasID, runIDs)
+}
+
+func loadQueueItemsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uuid.UUID) (map[string][]models.CanvasNodeQueueItem, error) {
+	queueItemsByRunID := make(map[string][]models.CanvasNodeQueueItem, len(runIDs))
+	if len(runIDs) == 0 {
+		return queueItemsByRunID, nil
+	}
+
+	queueItems, err := listQueueItemsForRuns(ctx, canvasID, runIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, queueItem := range queueItems {
+		queueItemsByRunID[queueItem.RunID.String()] = append(queueItemsByRunID[queueItem.RunID.String()], queueItem)
+	}
+
+	return queueItemsByRunID, nil
+}
+
+func listQueueItemsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uuid.UUID) (queueItems []models.CanvasNodeQueueItem, err error) {
+	ctx, done := telemetry.Span(ctx, "runs.load_queue_items")
+	defer done(&err)
+
+	return models.ListNodeQueueItemsForRuns(database.DB(ctx), canvasID, runIDs)
 }

--- a/pkg/grpc/actions/canvases/list_runs_test.go
+++ b/pkg/grpc/actions/canvases/list_runs_test.go
@@ -51,6 +51,58 @@ func Test__ListRuns__ReturnsRunsWithRootEventsAndExecutionRefs(t *testing.T) {
 	assert.False(t, response.HasNextPage)
 }
 
+func Test__ListRuns__ReturnsRunsWithQueueItems(t *testing.T) {
+	r := support.Setup(t)
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{NodeID: "node-1", Type: models.NodeTypeComponent},
+			{NodeID: "node-2", Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{},
+	)
+	otherCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{{NodeID: "trigger", Type: models.NodeTypeTrigger}}, []models.Edge{})
+
+	rootEvent := support.EmitCanvasEventForNodeWithData(t, canvas.ID, "trigger", "default", nil, map[string]any{
+		"review": "pending",
+	})
+	run := createStartedRun(t, rootEvent)
+	queueItem := support.CreateQueueItem(t, canvas.ID, "node-1", rootEvent.ID, rootEvent.ID)
+
+	emptyRootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "trigger", "default", nil)
+	emptyRun := createStartedRun(t, emptyRootEvent)
+
+	otherRootEvent := support.EmitCanvasEventForNode(t, otherCanvas.ID, "trigger", "default", nil)
+	createStartedRun(t, otherRootEvent)
+	support.CreateQueueItem(t, otherCanvas.ID, "trigger", otherRootEvent.ID, otherRootEvent.ID)
+
+	response, err := ListRuns(context.Background(), r.Registry, canvas.ID, 0, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, response.Runs, 2)
+
+	runsByID := map[string]*pb.CanvasRun{}
+	for _, serializedRun := range response.Runs {
+		runsByID[serializedRun.Id] = serializedRun
+	}
+
+	serializedRun := runsByID[run.ID.String()]
+	require.NotNil(t, serializedRun)
+	require.Len(t, serializedRun.QueueItems, 1)
+	assert.Equal(t, queueItem.ID.String(), serializedRun.QueueItems[0].Id)
+	assert.Equal(t, "node-1", serializedRun.QueueItems[0].NodeId)
+	assert.NotNil(t, serializedRun.QueueItems[0].CreatedAt)
+	require.NotNil(t, serializedRun.QueueItems[0].RootEvent)
+	assert.Equal(t, rootEvent.ID.String(), serializedRun.QueueItems[0].RootEvent.Id)
+	require.NotNil(t, serializedRun.QueueItems[0].Input)
+	assert.Equal(t, "pending", serializedRun.QueueItems[0].Input.AsMap()["review"])
+
+	require.NotNil(t, runsByID[emptyRun.ID.String()])
+	assert.Empty(t, runsByID[emptyRun.ID.String()].QueueItems)
+}
+
 func Test__ListRuns__ScopesRunsToCanvas(t *testing.T) {
 	r := support.Setup(t)
 	canvasOne, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{{NodeID: "trigger", Type: models.NodeTypeTrigger}}, []models.Edge{})

--- a/pkg/models/canvas_node.go
+++ b/pkg/models/canvas_node.go
@@ -473,6 +473,26 @@ func CountNodeQueueItemsForRootEventInTransaction(tx *gorm.DB, rootEventID uuid.
 	return count, nil
 }
 
+func ListNodeQueueItemsForRuns(tx *gorm.DB, workflowID uuid.UUID, runIDs []uuid.UUID) ([]CanvasNodeQueueItem, error) {
+	if len(runIDs) == 0 {
+		return []CanvasNodeQueueItem{}, nil
+	}
+
+	var queueItems []CanvasNodeQueueItem
+	err := tx.
+		Preload("RootEvent").
+		Where("workflow_id = ?", workflowID).
+		Where("run_id IN ?", runIDs).
+		Order("created_at ASC").
+		Find(&queueItems).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return queueItems, nil
+}
+
 func FindNodeQueueItem(workflowID uuid.UUID, queueItemID uuid.UUID) (*CanvasNodeQueueItem, error) {
 	var queueItem CanvasNodeQueueItem
 	err := database.Conn().

--- a/pkg/workers/eventdistributer/run.go
+++ b/pkg/workers/eventdistributer/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/public/ws"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -58,7 +59,8 @@ func handleRunState(workflowID string, runID string, wsHub *ws.Hub) error {
 		return fmt.Errorf("failed to parse run id: %w", err)
 	}
 
-	run, err := models.FindCanvasRunInTransaction(database.Conn(), workflowUUID, runUUID)
+	db := database.Conn()
+	run, err := models.FindCanvasRunInTransaction(db, workflowUUID, runUUID)
 	if err != nil {
 		return fmt.Errorf("failed to find run: %w", err)
 	}
@@ -68,28 +70,55 @@ func handleRunState(workflowID string, runID string, wsHub *ws.Hub) error {
 		return fmt.Errorf("unknown run state: %s", run.State)
 	}
 
-	executions, err := models.ListExecutionsForRunsInTransaction(database.Conn(), workflowUUID, []uuid.UUID{runUUID})
-	if err != nil {
-		return fmt.Errorf("failed to find run executions: %w", err)
-	}
-
+	var executions []models.CanvasNodeExecution
+	var queueItems []models.CanvasNodeQueueItem
 	var rootEvent models.CanvasEvent
-	err = database.Conn().
-		Where("workflow_id = ?", workflowUUID).
-		Where("run_id = ?", runUUID).
-		Where("execution_id IS NULL").
-		First(&rootEvent).
-		Error
-	if err != nil {
-		return fmt.Errorf("failed to find run root event: %w", err)
+
+	var g errgroup.Group
+	g.Go(func() error {
+		var err error
+		executions, err = models.ListExecutionsForRunsInTransaction(database.Conn(), workflowUUID, []uuid.UUID{runUUID})
+		if err != nil {
+			return fmt.Errorf("failed to find run executions: %w", err)
+		}
+
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		queueItems, err = models.ListNodeQueueItemsForRuns(database.Conn(), workflowUUID, []uuid.UUID{runUUID})
+		if err != nil {
+			return fmt.Errorf("failed to find run queue items: %w", err)
+		}
+
+		return nil
+	})
+
+	g.Go(func() error {
+		err := database.Conn().
+			Where("workflow_id = ?", workflowUUID).
+			Where("run_id = ?", runUUID).
+			Where("execution_id IS NULL").
+			First(&rootEvent).
+			Error
+		if err != nil {
+			return fmt.Errorf("failed to find run root event: %w", err)
+		}
+
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
-	serializedRun, err := canvases.SerializeCanvasRun(*run, rootEvent, executions)
+	serializedRun, err := canvases.SerializeCanvasRun(db, *run, rootEvent, executions, queueItems)
 	if err != nil {
 		return fmt.Errorf("failed to serialize run: %w", err)
 	}
 
-	serializedRunJSON, err := protojson.Marshal(serializedRun)
+	serializedRunJSON, err := marshalCanvasRunJSON(serializedRun)
 	if err != nil {
 		return fmt.Errorf("failed to marshal run: %w", err)
 	}
@@ -106,4 +135,8 @@ func handleRunState(workflowID string, runID string, wsHub *ws.Hub) error {
 	log.Debugf("Broadcasted %s event to workflow %s", eventName, workflowID)
 
 	return nil
+}
+
+func marshalCanvasRunJSON(run *pb.CanvasRun) ([]byte, error) {
+	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(run)
 }

--- a/pkg/workers/eventdistributer/run_test.go
+++ b/pkg/workers/eventdistributer/run_test.go
@@ -4,11 +4,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 )
 
 func Test__RunStateToWsEvent(t *testing.T) {
 	assert.Equal(t, RunStartedEvent, runStateToWsEvent(models.CanvasRunStateStarted))
 	assert.Equal(t, RunFinishedEvent, runStateToWsEvent(models.CanvasRunStateFinished))
 	assert.Empty(t, runStateToWsEvent("unknown"))
+}
+
+func Test__MarshalCanvasRunJSON__EmitsEmptyQueueItems(t *testing.T) {
+	payload, err := marshalCanvasRunJSON(&pb.CanvasRun{
+		Id:         "run-1",
+		QueueItems: []*pb.CanvasNodeQueueItem{},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), `"queueItems":[]`)
 }

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -873,6 +873,7 @@ message CanvasRun {
   google.protobuf.Timestamp updated_at = 8;
   google.protobuf.Timestamp finished_at = 9;
   string version_id = 10;
+  repeated CanvasNodeQueueItem queue_items = 11;
 }
 
 message ListEventExecutionsRequest {

--- a/web_src/src/hooks/canvasInfiniteCache.spec.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.spec.ts
@@ -107,6 +107,13 @@ describe("upsertRunIntoInfiniteData", () => {
             updatedAt: "2026-06-01T12:00:30.000Z",
           },
         ],
+        queueItems: [
+          {
+            id: "queue-item-1",
+            nodeId: "node-1",
+            createdAt: "2026-06-01T12:00:45.000Z",
+          },
+        ],
         updatedAt: "2026-06-01T12:00:30.000Z",
       }),
     ]);
@@ -125,6 +132,30 @@ describe("upsertRunIntoInfiniteData", () => {
     expect(updatedRun?.result).toBe("RESULT_PASSED");
     expect(updatedRun?.rootEvent?.id).toBe("event-1");
     expect(updatedRun?.executions?.map((execution) => execution.id)).toEqual(["execution-1"]);
+    expect(updatedRun?.queueItems?.map((queueItem) => queueItem.id)).toEqual(["queue-item-1"]);
+  });
+
+  it("clears existing queue items when a refreshed run has none", () => {
+    const old = makeInfiniteRunsData([
+      makeRun({
+        queueItems: [
+          {
+            id: "queue-item-1",
+            nodeId: "node-1",
+            createdAt: "2026-06-01T12:00:45.000Z",
+          },
+        ],
+        updatedAt: "2026-06-01T12:00:30.000Z",
+      }),
+    ]);
+    const incoming = makeRun({
+      queueItems: [],
+      updatedAt: "2026-06-01T12:01:00.000Z",
+    });
+
+    const next = upsertRunIntoInfiniteData(old, incoming, {})!;
+
+    expect(next.pages[0]?.runs?.[0]?.queueItems).toEqual([]);
   });
 
   it("sorts newly inserted live runs by updatedAt when createdAt is unavailable", () => {
@@ -190,6 +221,13 @@ describe("upsertRunIntoDescribeRunData", () => {
     const current = {
       run: makeRun({
         state: "STATE_STARTED",
+        queueItems: [
+          {
+            id: "queue-item-1",
+            nodeId: "node-1",
+            createdAt: "2026-06-01T12:00:45.000Z",
+          },
+        ],
         updatedAt: "2026-06-01T12:00:00.000Z",
       }),
     };
@@ -203,6 +241,30 @@ describe("upsertRunIntoDescribeRunData", () => {
 
     expect(next?.run?.state).toBe("STATE_FINISHED");
     expect(next?.run?.result).toBe("RESULT_PASSED");
+    expect(next?.run?.queueItems?.map((queueItem) => queueItem.id)).toEqual(["queue-item-1"]);
+  });
+
+  it("clears describe-run queue items when the incoming payload has none", () => {
+    const current = {
+      run: makeRun({
+        queueItems: [
+          {
+            id: "queue-item-1",
+            nodeId: "node-1",
+            createdAt: "2026-06-01T12:00:45.000Z",
+          },
+        ],
+        updatedAt: "2026-06-01T12:00:00.000Z",
+      }),
+    };
+    const incoming = makeRun({
+      queueItems: [],
+      updatedAt: "2026-06-01T12:01:00.000Z",
+    });
+
+    const next = upsertRunIntoDescribeRunData(current, incoming);
+
+    expect(next?.run?.queueItems).toEqual([]);
   });
 
   it("rejects stale run_started updates after run_finished", () => {

--- a/web_src/src/hooks/canvasInfiniteCache.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.ts
@@ -118,6 +118,7 @@ function mergeRunUpdate(existing: CanvasesCanvasRun, incoming: CanvasesCanvasRun
     state: incoming.state ?? existing.state,
     result: incoming.result ?? existing.result,
     executions: incoming.executions?.length ? incoming.executions : (existing.executions ?? incoming.executions),
+    queueItems: incoming.queueItems !== undefined ? incoming.queueItems : existing.queueItems,
     createdAt: incoming.createdAt ?? existing.createdAt,
     updatedAt: incoming.updatedAt ?? existing.updatedAt,
     finishedAt: incoming.finishedAt ?? existing.finishedAt,

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -80,6 +80,10 @@ function getInvalidationCalls(invalidateQueriesSpy: ReturnType<typeof vi.spyOn>,
   });
 }
 
+function canvasRunQueriesKey() {
+  return [...canvasKeys.runs(), testCanvasId] as const;
+}
+
 type QueryPredicate = (query: { queryKey: readonly unknown[] }) => boolean;
 
 function getInvalidationPredicates(invalidateQueriesSpy: ReturnType<typeof vi.spyOn>) {
@@ -134,7 +138,7 @@ describe("useCanvasWebsocket", () => {
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
   });
 
-  it("invalidates infinite runs query for queue_item_created", async () => {
+  it("invalidates canvas run queries for queue_item_created", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -146,10 +150,10 @@ describe("useCanvasWebsocket", () => {
 
     await flushMessageQueue();
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasRunQueriesKey())).toHaveLength(1);
   });
 
-  it("does not invalidate infinite runs query for queue_item_consumed", async () => {
+  it("invalidates canvas run queries for queue_item_consumed", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -161,7 +165,7 @@ describe("useCanvasWebsocket", () => {
 
     await flushMessageQueue();
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasRunQueriesKey())).toHaveLength(1);
   });
 
   it("patches execution events into infinite runs cache", async () => {

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -153,6 +153,12 @@ export function useCanvasWebsocket(
     });
   }, [queryClient, canvasId]);
 
+  const invalidateCanvasRunQueries = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: [...canvasKeys.runs(), canvasId],
+    });
+  }, [queryClient, canvasId]);
+
   const invalidateMemoryEntries = useCallback(() => {
     queryClient.invalidateQueries({
       queryKey: canvasKeys.canvasMemoryEntries(canvasId),
@@ -213,7 +219,7 @@ export function useCanvasWebsocket(
           if (payload && "nodeId" in payload && payload.nodeId) {
             const queueItem = payload as CanvasesCanvasNodeQueueItem;
             addNodeQueueItem(queueItem.nodeId!, queueItem);
-            invalidateRuns();
+            invalidateCanvasRunQueries();
 
             onNodeEvent?.(queueItem.nodeId!, data.event);
           }
@@ -222,6 +228,7 @@ export function useCanvasWebsocket(
           if (payload && "nodeId" in payload && payload.nodeId && "id" in payload && payload.id) {
             const queueItem = payload as CanvasesCanvasNodeQueueItem;
             removeNodeQueueItem(queueItem.nodeId!, queueItem.id!);
+            invalidateCanvasRunQueries();
 
             onNodeEvent?.(queueItem.nodeId!, data.event);
           }
@@ -284,6 +291,7 @@ export function useCanvasWebsocket(
       patchExecutionInCache,
       invalidateMemoryEntries,
       invalidateRuns,
+      invalidateCanvasRunQueries,
     ],
   );
 

--- a/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
+++ b/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
@@ -1,6 +1,6 @@
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronRight } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { formatMinutesSecondsDuration } from "@/lib/duration";
 import { withEventStatusBadgeClasses } from "@/lib/eventStatusBadge";
 import { cn } from "@/lib/utils";
@@ -28,6 +28,7 @@ export function RunInspectorNodeAccordion({
   currentUser,
   errorScrollRequestId,
   onErrorScrolled,
+  onSelectSection,
 }: {
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
@@ -41,6 +42,7 @@ export function RunInspectorNodeAccordion({
   currentUser?: RunInspectorCurrentUser;
   errorScrollRequestId?: number | null;
   onErrorScrolled?: () => void;
+  onSelectSection: (sectionValue: string) => void;
 }) {
   const iconSrc = getHeaderIconSrc(section.workflowNode?.component);
   const iconSlug = section.workflowNode?.component ? componentIconMap[section.workflowNode.component] : undefined;
@@ -74,23 +76,31 @@ export function RunInspectorNodeAccordion({
   return (
     <AccordionItem
       ref={itemRef}
-      value={section.nodeId}
-      className="scroll-mt-8 border-slate-950/10 dark:border-gray-800"
+      value={section.sectionValue}
+      className={cn(
+        "scroll-mt-8 border-slate-950/10 dark:border-gray-800",
+        section.isQueued && "border-l-2 border-l-amber-400 dark:border-l-amber-500",
+      )}
     >
       <AccordionPrimitive.Header
         className={cn(
           "flex items-center bg-white transition-colors hover:bg-slate-50 dark:bg-gray-950 dark:hover:bg-gray-900",
-          isOpen &&
+          section.isQueued && "bg-amber-50/80 hover:bg-amber-100/80 dark:bg-amber-950/20 dark:hover:bg-amber-950/30",
+          section.isQueued && isOpen && "bg-amber-100/80 text-slate-950 dark:bg-amber-950/40 dark:text-gray-100",
+          !section.isQueued &&
+            isOpen &&
             "sticky top-8 z-20 bg-[#e1f5ff] text-slate-950 shadow-[0_1px_0_rgba(15,23,42,0.08)] dark:bg-sky-950 dark:text-gray-100 dark:shadow-[0_1px_0_rgba(31,41,55,0.8)]",
         )}
       >
-        <AccordionPrimitive.Trigger className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left hover:no-underline">
-          <ChevronRight
-            className={cn(
-              "h-4 w-4 shrink-0 text-slate-400 transition-transform duration-200",
-              isOpen && "rotate-90 text-slate-600 dark:text-gray-300",
-            )}
-          />
+        <NodeHeaderButton section={section} onSelectSection={onSelectSection}>
+          {section.isQueued ? null : (
+            <ChevronRight
+              className={cn(
+                "h-4 w-4 shrink-0 text-slate-400 transition-transform duration-200",
+                isOpen && "rotate-90 text-slate-600 dark:text-gray-300",
+              )}
+            />
+          )}
           <RunNodeIcon
             iconSrc={iconSrc}
             iconSlug={iconSlug}
@@ -101,22 +111,52 @@ export function RunInspectorNodeAccordion({
           <span className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-gray-100">
             {section.nodeName}
           </span>
-        </AccordionPrimitive.Trigger>
+        </NodeHeaderButton>
         <NodeActions section={section} actions={actions} currentUser={currentUser} />
         <NodeMetadata section={section} onRerun={onRerun} rerunPending={rerunPending} />
       </AccordionPrimitive.Header>
-      <AccordionContent className="bg-slate-50 px-3 pb-3 pt-3 dark:bg-gray-950">
-        <RunInspectorStepTimeline
-          section={section}
-          componentIconMap={componentIconMap}
-          organizationId={organizationId}
-          canShowExpressionTemplates={canShowExpressionTemplates}
-          onEditNode={onEditNode}
-          errorScrollRequestId={errorScrollRequestId}
-          onErrorScrolled={onErrorScrolled}
-        />
-      </AccordionContent>
+      {section.isQueued ? null : (
+        <AccordionContent className="bg-slate-50 px-3 pb-3 pt-3 dark:bg-gray-950">
+          <RunInspectorStepTimeline
+            section={section}
+            componentIconMap={componentIconMap}
+            organizationId={organizationId}
+            canShowExpressionTemplates={canShowExpressionTemplates}
+            onEditNode={onEditNode}
+            errorScrollRequestId={errorScrollRequestId}
+            onErrorScrolled={onErrorScrolled}
+          />
+        </AccordionContent>
+      )}
     </AccordionItem>
+  );
+}
+
+function NodeHeaderButton({
+  section,
+  children,
+  onSelectSection,
+}: {
+  section: RunInspectorNodeSection;
+  children: ReactNode;
+  onSelectSection: (sectionValue: string) => void;
+}) {
+  if (section.isQueued) {
+    return (
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left"
+        onClick={() => onSelectSection(section.sectionValue)}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <AccordionPrimitive.Trigger className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left hover:no-underline">
+      {children}
+    </AccordionPrimitive.Trigger>
   );
 }
 
@@ -130,12 +170,21 @@ function NodeActions({
   currentUser?: RunInspectorCurrentUser;
 }) {
   const actionableApproval = findActionableApprovalRecord(section.actions.approvalRecords, currentUser ?? null);
-  const hasActions = section.actions.canStop || section.actions.canPushThrough || actionableApproval;
+  const hasActions =
+    section.queueItem || section.actions.canStop || section.actions.canPushThrough || actionableApproval;
 
   if (!hasActions) return null;
 
   return (
     <div className="flex shrink-0 items-center gap-2 pl-3">
+      {section.queueItem ? (
+        <NodeActionButton
+          label="Cancel"
+          tone="danger"
+          disabled={actions.cancelQueuedItemPending}
+          onClick={() => actions.cancelQueuedItem(section)}
+        />
+      ) : null}
       {actionableApproval ? (
         <>
           <NodeActionButton
@@ -257,7 +306,7 @@ function NodeMetadata({
           {rerunPending ? "Rerun..." : "Rerun"}
         </button>
       ) : null}
-      {section.isTrigger && section.createdAt ? (
+      {(section.isTrigger || section.isQueued) && section.createdAt ? (
         <span>{formatEventTimestamp(section.createdAt)}</span>
       ) : section.durationMs !== undefined ? (
         <span>{formatStepDuration(section.durationMs)}</span>

--- a/web_src/src/ui/Runs/RunInspectorPanel.queued.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.queued.spec.tsx
@@ -1,0 +1,446 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as ApiClient from "@/api-client";
+import type { CanvasesCanvasNodeExecution, SuperplaneMeUser } from "@/api-client";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { executions, renderInspector, runningExecutions, runningRun } from "./RunInspectorPanel.spec.fixtures";
+
+let mockedExecutions = executions;
+let mockedExecutionsLoading = false;
+let mockedMe: SuperplaneMeUser | null = null;
+
+vi.mock("@uiw/react-json-view", () => ({
+  default: ({ value, collapsed }: { value: unknown; collapsed?: boolean | number }) => (
+    <pre data-testid="json-view" data-collapsed={String(collapsed)}>
+      {JSON.stringify(value)}
+    </pre>
+  ),
+}));
+
+const reemitTriggerEventMock = vi.fn();
+const cancelExecutionMock = vi.fn();
+const invokeExecutionHookMock = vi.fn();
+const describeRunMock = vi.fn();
+const listNodeQueueItemsMock = vi.fn();
+const deleteNodeQueueItemMock = vi.fn();
+
+vi.mock("@/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof ApiClient>();
+  return {
+    ...actual,
+    canvasesReemitTriggerEvent: (...args: unknown[]) => reemitTriggerEventMock(...args),
+    canvasesCancelExecution: (...args: unknown[]) => cancelExecutionMock(...args),
+    canvasesInvokeNodeExecutionHook: (...args: unknown[]) => invokeExecutionHookMock(...args),
+    canvasesDescribeRun: (...args: unknown[]) => describeRunMock(...args),
+    canvasesListNodeQueueItems: (...args: unknown[]) => listNodeQueueItemsMock(...args),
+    canvasesDeleteNodeQueueItem: (...args: unknown[]) => deleteNodeQueueItemMock(...args),
+  };
+});
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useEventExecutions: () => ({
+    data: { executions: mockedExecutions },
+    isLoading: mockedExecutionsLoading,
+  }),
+  useCanvasVersion: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useMe", () => ({
+  useMe: () => ({ data: mockedMe }),
+}));
+
+vi.mock("@/pages/app/mappers", () => ({
+  getExecutionDetails: () => ({}),
+  getState: () => (execution: CanvasesCanvasNodeExecution) =>
+    execution.result === "RESULT_FAILED" ? "error" : "success",
+  getStateMap: () => ({
+    error: { badgeColor: "bg-red-500", label: "error" },
+    success: { badgeColor: "bg-emerald-500", label: "success" },
+    triggered: { badgeColor: "bg-blue-500", label: "triggered" },
+  }),
+  getTriggerRenderer: () => ({
+    getTitleAndSubtitle: () => ({ title: "Deploy main", subtitle: "" }),
+    getRootEventValues: () => ({ Source: "manual" }),
+  }),
+}));
+
+vi.mock("@/pages/app/utils", () => ({
+  buildEventInfo: (event: unknown) => event,
+  buildExecutionInfo: (execution: unknown) => execution,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}));
+
+beforeEach(() => {
+  mockedExecutions = executions;
+  mockedExecutionsLoading = false;
+  mockedMe = null;
+  reemitTriggerEventMock.mockResolvedValue({});
+  cancelExecutionMock.mockResolvedValue({});
+  invokeExecutionHookMock.mockResolvedValue({});
+  describeRunMock.mockResolvedValue({ data: { run: { queueItems: [] } } });
+  listNodeQueueItemsMock.mockResolvedValue({ data: { items: [] } });
+  deleteNodeQueueItemMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("RunInspectorPanel queued steps", () => {
+  it("jumps from a queued section to the failed execution for the same node", () => {
+    mockedExecutions = executions.map((execution) =>
+      execution.nodeId === "action-1"
+        ? {
+            ...execution,
+            outputs: { default: [{ data: { error: "details" } }] },
+          }
+        : execution,
+    );
+
+    renderInspector({
+      run: {
+        ...runningRun,
+        queueItems: [
+          {
+            id: "queue-failed-node",
+            nodeId: "action-1",
+            rootEvent: { id: "event-running", nodeId: "trigger-1" },
+            input: { request: "retry after approval" },
+            createdAt: "2026-05-01T12:00:05Z",
+          },
+        ],
+      },
+      selectedNodeId: "action-1",
+    });
+
+    const queuedHeader = screen.getByRole("heading", { name: /queued/i });
+    fireEvent.click(within(queuedHeader).getByRole("button", { name: /Add Grade Label/i }));
+
+    expect(screen.queryByRole("button", { name: /Input/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Output/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Jump to error" }));
+
+    expect(screen.getByRole("button", { name: /Output/i })).toBeInTheDocument();
+  });
+
+  it("stops running executions and queued items for the inspected run", async () => {
+    mockedExecutions = runningExecutions;
+    describeRunMock.mockResolvedValueOnce({
+      data: {
+        run: {
+          executions: [
+            {
+              id: "execution-running",
+              nodeId: "action-2",
+              state: "STATE_STARTED",
+            },
+          ],
+          queueItems: [
+            {
+              id: "queue-1",
+              nodeId: "action-2",
+              rootEvent: { id: "event-running" },
+              input: { approval: "pending" },
+              createdAt: "2026-05-01T12:00:04Z",
+            },
+          ],
+        },
+      },
+    });
+
+    renderInspector({
+      run: {
+        ...runningRun,
+        queueItems: [
+          {
+            id: "queue-1",
+            nodeId: "action-2",
+            rootEvent: { id: "event-running" },
+            input: { approval: "pending" },
+            createdAt: "2026-05-01T12:00:04Z",
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
+
+    await waitFor(() => {
+      expect(cancelExecutionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            executionId: "execution-running",
+          },
+        }),
+      );
+      expect(deleteNodeQueueItemMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            nodeId: "action-2",
+            itemId: "queue-1",
+          },
+        }),
+      );
+    });
+
+    expect(deleteNodeQueueItemMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops queued items that are fresher than the inspected run cache", async () => {
+    mockedExecutions = executions;
+    describeRunMock.mockResolvedValueOnce({
+      data: {
+        run: {
+          queueItems: [
+            {
+              id: "fresh-queue-1",
+              nodeId: "action-2",
+              rootEvent: { id: "event-running" },
+              input: { approval: "pending" },
+            },
+          ],
+        },
+      },
+    });
+
+    renderInspector({ run: { ...runningRun, queueItems: [] } });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
+
+    await waitFor(() => {
+      expect(deleteNodeQueueItemMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            nodeId: "action-2",
+            itemId: "fresh-queue-1",
+          },
+        }),
+      );
+    });
+
+    expect(describeRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: {
+          canvasId: "canvas-1",
+          runId: "run-running",
+        },
+      }),
+    );
+    expect(deleteNodeQueueItemMock).toHaveBeenCalledTimes(1);
+    expect(listNodeQueueItemsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not stop stale cached queued items when the fresh run has none", async () => {
+    mockedExecutions = [];
+
+    renderInspector({
+      run: {
+        ...runningRun,
+        queueItems: [
+          {
+            id: "stale-queue-1",
+            nodeId: "action-2",
+            rootEvent: { id: "event-running" },
+            input: { approval: "pending" },
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
+
+    await waitFor(() => {
+      expect(describeRunMock).toHaveBeenCalled();
+    });
+
+    expect(deleteNodeQueueItemMock).not.toHaveBeenCalled();
+    expect(cancelExecutionMock).not.toHaveBeenCalled();
+    expect(showErrorToast).not.toHaveBeenCalledWith("Failed to stop run");
+    expect(showSuccessToast).not.toHaveBeenCalledWith("Run stopped");
+  });
+
+  it("does not stop stale cached running execution refs when the fresh run has none", async () => {
+    mockedExecutions = [];
+
+    renderInspector({
+      run: {
+        ...runningRun,
+        executions: [
+          {
+            id: "stale-execution-ref",
+            nodeId: "action-2",
+            state: "STATE_STARTED",
+            result: "RESULT_UNKNOWN",
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
+
+    await waitFor(() => {
+      expect(describeRunMock).toHaveBeenCalled();
+    });
+
+    expect(cancelExecutionMock).not.toHaveBeenCalled();
+    expect(deleteNodeQueueItemMock).not.toHaveBeenCalled();
+    expect(showErrorToast).not.toHaveBeenCalledWith("Failed to stop run");
+    expect(showSuccessToast).not.toHaveBeenCalledWith("Run stopped");
+  });
+
+  it("renders queued items as non-expandable queued rows", () => {
+    mockedExecutions = [];
+    const onSelectNode = vi.fn();
+
+    renderInspector({
+      run: {
+        ...runningRun,
+        queueItems: [
+          {
+            id: "queue-approval",
+            nodeId: "approval-1",
+            rootEvent: { id: "event-running", nodeId: "trigger-1" },
+            input: { request: "approve deploy" },
+            createdAt: "2026-05-01T12:00:05Z",
+          },
+        ],
+      },
+      onSelectNode,
+    });
+
+    const queuedRow = screen.getByRole("button", { name: /Await Approval/i });
+    expect(queuedRow).toBeInTheDocument();
+    expect(queuedRow).not.toHaveAttribute("aria-expanded");
+    expect(screen.getAllByText("queued").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /Input/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Runtime config/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Output/i })).not.toBeInTheDocument();
+
+    fireEvent.click(queuedRow);
+
+    expect(onSelectNode).toHaveBeenCalledWith("approval-1");
+  });
+
+  it("renders queued steps and allows stop while executions are loading", async () => {
+    mockedExecutions = [];
+    mockedExecutionsLoading = true;
+    describeRunMock.mockResolvedValueOnce({
+      data: {
+        run: {
+          executions: [
+            {
+              id: "execution-ref-running",
+              nodeId: "action-2",
+              state: "STATE_STARTED",
+            },
+          ],
+          queueItems: [
+            {
+              id: "queue-approval",
+              nodeId: "approval-1",
+              rootEvent: { id: "event-running", nodeId: "trigger-1" },
+              input: { request: "approve deploy" },
+            },
+          ],
+        },
+      },
+    });
+
+    renderInspector({
+      run: {
+        ...runningRun,
+        executions: [
+          {
+            id: "execution-ref-running",
+            nodeId: "action-2",
+            state: "STATE_STARTED",
+            result: "RESULT_UNKNOWN",
+          },
+        ],
+        queueItems: [
+          {
+            id: "queue-approval",
+            nodeId: "approval-1",
+            rootEvent: { id: "event-running", nodeId: "trigger-1" },
+            input: { request: "approve deploy" },
+            createdAt: "2026-05-01T12:00:05Z",
+          },
+        ],
+      },
+      selectedNodeId: "approval-1",
+    });
+
+    expect(screen.queryByText("Loading run steps...")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Await Approval/i })).toBeInTheDocument();
+
+    const stopButton = screen.getAllByRole("button", { name: "Stop" })[0];
+    expect(stopButton).toBeEnabled();
+    fireEvent.click(stopButton);
+
+    await waitFor(() => {
+      expect(cancelExecutionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            executionId: "execution-ref-running",
+          },
+        }),
+      );
+      expect(deleteNodeQueueItemMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            nodeId: "approval-1",
+            itemId: "queue-approval",
+          },
+        }),
+      );
+    });
+  });
+
+  it("cancels a queued step from the node accordion header", async () => {
+    mockedExecutions = [];
+
+    renderInspector({
+      run: {
+        ...runningRun,
+        queueItems: [
+          {
+            id: "queue-approval",
+            nodeId: "approval-1",
+            rootEvent: { id: "event-running", nodeId: "trigger-1" },
+            input: { request: "approve deploy" },
+            createdAt: "2026-05-01T12:00:05Z",
+          },
+        ],
+      },
+      selectedNodeId: "approval-1",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(deleteNodeQueueItemMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: {
+            canvasId: "canvas-1",
+            nodeId: "approval-1",
+            itemId: "queue-approval",
+          },
+        }),
+      );
+    });
+  });
+});

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -25,6 +25,7 @@ vi.mock("@uiw/react-json-view", () => ({
 const reemitTriggerEventMock = vi.fn();
 const cancelExecutionMock = vi.fn();
 const invokeExecutionHookMock = vi.fn();
+const describeRunMock = vi.fn();
 const listNodeQueueItemsMock = vi.fn();
 const deleteNodeQueueItemMock = vi.fn();
 
@@ -35,6 +36,7 @@ vi.mock("@/api-client", async (importOriginal) => {
     canvasesReemitTriggerEvent: (...args: unknown[]) => reemitTriggerEventMock(...args),
     canvasesCancelExecution: (...args: unknown[]) => cancelExecutionMock(...args),
     canvasesInvokeNodeExecutionHook: (...args: unknown[]) => invokeExecutionHookMock(...args),
+    canvasesDescribeRun: (...args: unknown[]) => describeRunMock(...args),
     canvasesListNodeQueueItems: (...args: unknown[]) => listNodeQueueItemsMock(...args),
     canvasesDeleteNodeQueueItem: (...args: unknown[]) => deleteNodeQueueItemMock(...args),
   };
@@ -87,6 +89,7 @@ beforeEach(() => {
   reemitTriggerEventMock.mockResolvedValue({});
   cancelExecutionMock.mockResolvedValue({});
   invokeExecutionHookMock.mockResolvedValue({});
+  describeRunMock.mockResolvedValue({ data: { run: { queueItems: [] } } });
   listNodeQueueItemsMock.mockResolvedValue({ data: { items: [] } });
   deleteNodeQueueItemMock.mockResolvedValue({});
 });
@@ -335,47 +338,6 @@ describe("RunInspectorPanel", () => {
     await waitFor(() => {
       expect(onRerunCreated).toHaveBeenCalledWith("event-rerun");
     });
-  });
-
-  it("stops running executions and queued items for the inspected run", async () => {
-    mockedExecutions = runningExecutions;
-    listNodeQueueItemsMock.mockImplementation(({ path }: { path: { nodeId: string } }) => ({
-      data: {
-        items:
-          path.nodeId === "action-2"
-            ? [
-                { id: "queue-1", rootEvent: { id: "event-running" } },
-                { id: "queue-other", rootEvent: { id: "other-event" } },
-              ]
-            : [],
-      },
-    }));
-
-    renderInspector({ run: runningRun });
-
-    fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
-
-    await waitFor(() => {
-      expect(cancelExecutionMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: {
-            canvasId: "canvas-1",
-            executionId: "execution-running",
-          },
-        }),
-      );
-      expect(deleteNodeQueueItemMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: {
-            canvasId: "canvas-1",
-            nodeId: "action-2",
-            itemId: "queue-1",
-          },
-        }),
-      );
-    });
-
-    expect(deleteNodeQueueItemMock).toHaveBeenCalledTimes(1);
   });
 
   it("stops an active node execution from the node accordion header", async () => {

--- a/web_src/src/ui/Runs/RunInspectorPanel.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.tsx
@@ -16,11 +16,13 @@ import { RunInspectorChrome } from "./RunInspectorChrome";
 import { RunInspectorHeader } from "./RunInspectorHeader";
 import { ResizeHandle } from "./RunInspectorResize";
 import { RunInspectorStepsList } from "./RunInspectorStepsList";
-import { buildNodeMap, buildRunPresentation } from "./runPresentation";
+import { buildNodeMap, buildRunPresentation, type RUN_STATUS_META } from "./runPresentation";
 import {
   buildRunInspectorNodeSections,
   findRunInspectorErrorSummaries,
   type RunInspectorCurrentUser,
+  type RunInspectorErrorSummary,
+  type RunInspectorNodeSection,
 } from "./runNodeDetailModel";
 import { useResizableInspectorWidth } from "./useResizableInspectorWidth";
 import { useRunInspectorActions } from "./useRunInspectorActions";
@@ -53,42 +55,98 @@ type AccountFallback = {
   groups?: string[];
 } | null;
 
-export function RunInspectorPanel({
+export function RunInspectorPanel(props: RunInspectorPanelProps) {
+  const {
+    componentIconMap = {},
+    onClose,
+    onEditNode,
+    onNavigateOlder,
+    onNavigateRun,
+    organizationId,
+    run,
+    runNavigation,
+  } = props;
+  const model = useRunInspectorPanelModel(props);
+
+  return (
+    <aside
+      className={cn(
+        "relative z-20 flex h-full shrink-0 flex-col border-l bg-white shadow-sm dark:bg-gray-950",
+        appDarkModeClasses.sidebarEdge,
+      )}
+      style={{ width: model.inspectorWidth.width }}
+      data-testid="run-inspector-panel"
+      aria-label="Run inspector"
+    >
+      <ResizeHandle onPointerDown={model.inspectorWidth.startResize} isResizing={model.inspectorWidth.isResizing} />
+      <RunInspectorChrome
+        runId={run.id}
+        newerRunId={runNavigation?.newerRunId}
+        olderRunId={runNavigation?.olderRunId}
+        canNavigateOlder={runNavigation?.canNavigateOlder}
+        onNavigateRun={onNavigateRun}
+        onNavigateOlder={onNavigateOlder}
+        onClose={onClose}
+      />
+      <RunInspectorHeader
+        run={run}
+        title={model.presentation.title}
+        stepCount={model.sections.length || run.executions?.length || 0}
+        onAction={() => (model.presentation.status === "running" ? model.actions.stop() : model.actions.rerun())}
+        actionPending={model.presentation.status === "running" ? model.actions.stopPending : model.actions.rerunPending}
+        actionDisabled={model.presentation.status === "running" ? model.actions.stopDisabled : !run.rootEvent?.id}
+      />
+
+      <RunInspectorContent
+        errorSummaries={model.errorSummaries}
+        status={model.presentation.status}
+        sections={model.sections}
+        isLoading={model.isStepsLoading}
+        selectedValue={model.accordionValue}
+        componentIconMap={componentIconMap}
+        organizationId={organizationId}
+        canShowExpressionTemplates={model.hasRunVersionSpec}
+        onValueChange={model.handleValueChange}
+        onJumpToError={model.jumpToErrorOutput}
+        onRerun={model.actions.rerun}
+        onEditNode={onEditNode}
+        rerunPending={model.actions.rerunPending}
+        actions={model.actions}
+        currentUser={model.resolvedCurrentUser}
+        errorScrollRequest={model.errorScrollRequest}
+        onErrorScrolled={model.clearErrorScrollRequest}
+      />
+    </aside>
+  );
+}
+
+function useRunInspectorPanelModel({
   canvasId,
+  componentDefinitions,
+  currentUser,
+  onClearSelectedNode,
+  onRerunCreated,
+  onSelectNode,
   organizationId,
   run,
-  workflowNodes,
-  workflowEdges,
-  componentDefinitions,
-  triggerDefinitions,
-  componentIconMap = {},
-  currentUser,
   selectedNodeId = null,
-  onSelectNode,
-  onClearSelectedNode,
-  onEditNode,
-  onRerunCreated,
-  runNavigation,
-  onNavigateRun,
-  onNavigateOlder,
-  onClose,
+  triggerDefinitions,
+  workflowEdges,
+  workflowNodes,
 }: RunInspectorPanelProps) {
   const { account } = useAccount();
   const { data: me } = useMe(true, organizationId ?? null);
-  const resolvedCurrentUser = useMemo(() => resolveCurrentUser(currentUser, me, account), [account, currentUser, me]);
-  const rootEventId = run.rootEvent?.id || null;
-  const executionsQuery = useEventExecutions(canvasId, rootEventId);
+  const executionsQuery = useEventExecutions(canvasId, run.rootEvent?.id || null);
   const runVersionQuery = useCanvasVersion(organizationId ?? "", canvasId, run.versionId ?? "", Boolean(run.versionId));
   const executions = useMemo(() => executionsQuery.data?.executions || [], [executionsQuery.data?.executions]);
   const shouldUseRunVersion = Boolean(run.versionId);
   const versionWorkflowNodes = runVersionQuery.data?.spec?.nodes;
-  const versionWorkflowEdges = runVersionQuery.data?.spec?.edges;
   const hasRunVersionSpec = shouldUseRunVersion && hasWorkflowNodes(versionWorkflowNodes);
   const inspectorWorkflowNodes = useMemo(
     () => selectInspectorWorkflowNodes(shouldUseRunVersion, hasRunVersionSpec, versionWorkflowNodes, workflowNodes),
     [hasRunVersionSpec, shouldUseRunVersion, versionWorkflowNodes, workflowNodes],
   );
-  const inspectorWorkflowEdges = hasRunVersionSpec ? versionWorkflowEdges : workflowEdges;
+  const inspectorWorkflowEdges = hasRunVersionSpec ? runVersionQuery.data?.spec?.edges : workflowEdges;
   const nodeMap = useMemo(() => buildNodeMap(inspectorWorkflowNodes), [inspectorWorkflowNodes]);
   const presentation = useMemo(() => buildRunPresentation(run, nodeMap), [nodeMap, run]);
   const sections = useMemo(
@@ -106,6 +164,7 @@ export function RunInspectorPanel({
   const errorSummaries = useMemo(() => findRunInspectorErrorSummaries(sections), [sections]);
   const inspectorWidth = useResizableInspectorWidth();
   const [errorScrollRequest, setErrorScrollRequest] = useState<{ nodeId: string; requestId: number } | null>(null);
+  const [selectedSectionValue, setSelectedSectionValue] = useState<string | null>(null);
   const actions = useRunInspectorActions({
     canvasId,
     run,
@@ -113,67 +172,126 @@ export function RunInspectorPanel({
     executionsLoading: executionsQuery.isLoading,
     onRerunCreated,
   });
-
-  const handleValueChange = (value: string) => {
-    if (value) return onSelectNode(value);
-    onClearSelectedNode?.();
-  };
-
-  const jumpToErrorOutput = (nodeId: string) => {
-    setErrorScrollRequest({ nodeId, requestId: Date.now() });
-    onSelectNode(nodeId);
-  };
-
-  return (
-    <aside
-      className={cn(
-        "relative z-20 flex h-full shrink-0 flex-col border-l bg-white shadow-sm dark:bg-gray-950",
-        appDarkModeClasses.sidebarEdge,
-      )}
-      style={{ width: inspectorWidth.width }}
-      data-testid="run-inspector-panel"
-      aria-label="Run inspector"
-    >
-      <ResizeHandle onPointerDown={inspectorWidth.startResize} isResizing={inspectorWidth.isResizing} />
-      <RunInspectorChrome
-        runId={run.id}
-        newerRunId={runNavigation?.newerRunId}
-        olderRunId={runNavigation?.olderRunId}
-        canNavigateOlder={runNavigation?.canNavigateOlder}
-        onNavigateRun={onNavigateRun}
-        onNavigateOlder={onNavigateOlder}
-        onClose={onClose}
-      />
-      <RunInspectorHeader
-        run={run}
-        title={presentation.title}
-        stepCount={sections.length || run.executions?.length || 0}
-        onAction={() => (presentation.status === "running" ? actions.stop() : actions.rerun())}
-        actionPending={presentation.status === "running" ? actions.stopPending : actions.rerunPending}
-        actionDisabled={presentation.status === "running" ? actions.stopDisabled : !run.rootEvent?.id}
-      />
-
-      <RunInspectorStepsList
-        errorSummaries={errorSummaries}
-        status={presentation.status}
-        sections={sections}
-        isLoading={executionsQuery.isLoading}
-        selectedValue={selectedNodeId ?? ""}
-        componentIconMap={componentIconMap}
-        organizationId={organizationId}
-        canShowExpressionTemplates={hasRunVersionSpec}
-        onValueChange={handleValueChange}
-        onJumpToError={jumpToErrorOutput}
-        onRerun={actions.rerun}
-        onEditNode={onEditNode}
-        rerunPending={actions.rerunPending}
-        actions={actions}
-        currentUser={resolvedCurrentUser}
-        errorScrollRequest={errorScrollRequest}
-        onErrorScrolled={() => setErrorScrollRequest(null)}
-      />
-    </aside>
+  const accordionValue = useMemo(
+    () => resolveSelectedSectionValue(sections, selectedNodeId, selectedSectionValue),
+    [sections, selectedNodeId, selectedSectionValue],
   );
+  const isStepsLoading = executionsQuery.isLoading && !sections.some((section) => section.isQueued);
+  const resolvedCurrentUser = resolveCurrentUser(currentUser, me, account);
+
+  return {
+    accordionValue,
+    actions,
+    clearErrorScrollRequest: () => setErrorScrollRequest(null),
+    errorScrollRequest,
+    errorSummaries,
+    handleValueChange: (value: string) =>
+      selectRunInspectorSection(value, sections, setSelectedSectionValue, onSelectNode, onClearSelectedNode),
+    hasRunVersionSpec,
+    inspectorWidth,
+    isStepsLoading,
+    jumpToErrorOutput: (nodeId: string) => {
+      setErrorScrollRequest({ nodeId, requestId: Date.now() });
+      setSelectedSectionValue(null);
+      onSelectNode(nodeId);
+    },
+    presentation,
+    resolvedCurrentUser,
+    sections,
+  };
+}
+
+function RunInspectorContent({
+  errorSummaries,
+  status,
+  sections,
+  isLoading,
+  selectedValue,
+  componentIconMap,
+  organizationId,
+  canShowExpressionTemplates,
+  onValueChange,
+  onJumpToError,
+  onRerun,
+  onEditNode,
+  rerunPending,
+  actions,
+  currentUser,
+  errorScrollRequest,
+  onErrorScrolled,
+}: {
+  errorSummaries: RunInspectorErrorSummary[];
+  status: keyof typeof RUN_STATUS_META;
+  sections: RunInspectorNodeSection[];
+  isLoading: boolean;
+  selectedValue: string;
+  componentIconMap: Record<string, string>;
+  organizationId?: string;
+  canShowExpressionTemplates: boolean;
+  onValueChange: (value: string) => void;
+  onJumpToError: (nodeId: string) => void;
+  onRerun: () => void;
+  onEditNode?: (nodeId: string) => void;
+  rerunPending: boolean;
+  actions: ReturnType<typeof useRunInspectorActions>;
+  currentUser: RunInspectorCurrentUser | undefined;
+  errorScrollRequest: { nodeId: string; requestId: number } | null;
+  onErrorScrolled: () => void;
+}) {
+  return (
+    <RunInspectorStepsList
+      errorSummaries={errorSummaries}
+      status={status}
+      sections={sections}
+      isLoading={isLoading}
+      selectedValue={selectedValue}
+      componentIconMap={componentIconMap}
+      organizationId={organizationId}
+      canShowExpressionTemplates={canShowExpressionTemplates}
+      onValueChange={onValueChange}
+      onJumpToError={onJumpToError}
+      onRerun={onRerun}
+      onEditNode={onEditNode}
+      rerunPending={rerunPending}
+      actions={actions}
+      currentUser={currentUser}
+      errorScrollRequest={errorScrollRequest}
+      onErrorScrolled={onErrorScrolled}
+    />
+  );
+}
+
+function resolveSelectedSectionValue(
+  sections: ReturnType<typeof buildRunInspectorNodeSections>,
+  selectedNodeId: string | null,
+  selectedSectionValue: string | null,
+): string {
+  if (!selectedNodeId) return "";
+
+  const selectedSection = selectedSectionValue
+    ? sections.find((section) => section.sectionValue === selectedSectionValue && section.nodeId === selectedNodeId)
+    : undefined;
+  if (selectedSection) return selectedSection.sectionValue;
+
+  return sections.find((section) => section.nodeId === selectedNodeId)?.sectionValue ?? "";
+}
+
+function selectRunInspectorSection(
+  value: string,
+  sections: RunInspectorNodeSection[],
+  setSelectedSectionValue: (value: string | null) => void,
+  onSelectNode: (nodeId: string) => void,
+  onClearSelectedNode: (() => void) | undefined,
+) {
+  if (!value) {
+    setSelectedSectionValue(null);
+    onClearSelectedNode?.();
+    return;
+  }
+
+  const section = sections.find((item) => item.sectionValue === value);
+  setSelectedSectionValue(value);
+  onSelectNode(section?.nodeId ?? value);
 }
 
 function selectInspectorWorkflowNodes(

--- a/web_src/src/ui/Runs/RunInspectorStepsList.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepsList.tsx
@@ -72,12 +72,12 @@ export function RunInspectorStepsList({
         <Accordion type="single" collapsible value={selectedValue} onValueChange={onValueChange}>
           {sections.map((section) => (
             <RunInspectorNodeAccordion
-              key={section.nodeId}
+              key={section.sectionValue}
               section={section}
               componentIconMap={componentIconMap}
               organizationId={organizationId}
               canShowExpressionTemplates={canShowExpressionTemplates}
-              isOpen={selectedValue === section.nodeId}
+              isOpen={selectedValue === section.sectionValue}
               onRerun={onRerun}
               onEditNode={onEditNode}
               rerunPending={rerunPending}
@@ -85,6 +85,7 @@ export function RunInspectorStepsList({
               currentUser={currentUser}
               errorScrollRequestId={errorScrollRequest?.nodeId === section.nodeId ? errorScrollRequest.requestId : null}
               onErrorScrolled={onErrorScrolled}
+              onSelectSection={onValueChange}
             />
           ))}
         </Accordion>

--- a/web_src/src/ui/Runs/RunInspectorTimelineTypes.ts
+++ b/web_src/src/ui/Runs/RunInspectorTimelineTypes.ts
@@ -19,12 +19,16 @@ export const defaultAccordionPreferences: InternalAccordionPreferences = {
   output: false,
 };
 
-export function buildTimelineItems(section: RunInspectorNodeSection, hasRuntimeConfig: boolean, hasRunnerLogs = false) {
+export function buildTimelineItems(
+  section: RunInspectorNodeSection,
+  hasRuntimeConfig: boolean,
+  hasRunnerLogs = false,
+): Array<{ value: TimelineStepType }> {
   const items: Array<{
     value: TimelineStepType;
   }> = [];
 
-  if (!section.isTrigger) {
+  if (!section.isTrigger && !section.isQueued) {
     items.push({ value: "input" });
   }
 

--- a/web_src/src/ui/Runs/runNodeDetailModel.ts
+++ b/web_src/src/ui/Runs/runNodeDetailModel.ts
@@ -2,6 +2,7 @@ import type {
   ActionsAction,
   CanvasesCanvasNodeExecution,
   CanvasesCanvasNodeExecutionRef,
+  CanvasesCanvasNodeQueueItem,
   CanvasesCanvasRun,
   ComponentsEdge,
   ConfigurationField,
@@ -24,6 +25,7 @@ import {
   normalizeExecutionOutputsForDisplay,
 } from "./runNodeDetailOutputs";
 import { buildExecutionTabData, buildTriggerTabData } from "./runNodeDetailTabs";
+import { buildQueuedNodeSections } from "./runQueuedNodeSections";
 export { hasObjectValue } from "./runNodeDetailOutputs";
 export { buildExecutionTabData, buildTriggerTabData, isErrorValue } from "./runNodeDetailTabs";
 
@@ -118,12 +120,15 @@ export type RunInspectorUpstreamSection = {
 };
 
 export type RunInspectorNodeSection = {
+  sectionValue: string;
   nodeId: string;
   nodeName: string;
   workflowNode?: ComponentsNode;
   execution?: CanvasesCanvasNodeExecution;
   executionRef?: CanvasesCanvasNodeExecutionRef;
+  queueItem?: CanvasesCanvasNodeQueueItem;
   isTrigger: boolean;
+  isQueued: boolean;
   createdAt?: string;
   durationMs?: number;
   badge: { badgeColor: string; label: string } | null;
@@ -241,7 +246,7 @@ export function buildRunInspectorNodeSections({
   const componentDefinitionsByName = buildComponentDefinitionsByName(componentDefinitions);
   const triggerDefinitionsByName = buildTriggerDefinitionsByName(triggerDefinitions);
 
-  return executionChain.map((nodeId, index) => {
+  const executionSections = executionChain.map((nodeId, index) => {
     const workflowNode = workflowNodes.find((node) => node.id === nodeId);
     const execution = executions.find((item) => item.nodeId === nodeId);
     const executionRef = run.executions?.find((item) => item.nodeId === nodeId) ?? execution;
@@ -266,12 +271,14 @@ export function buildRunInspectorNodeSections({
         });
 
     return {
+      sectionValue: nodeId,
       nodeId,
       nodeName: workflowNode?.name || nodeId,
       workflowNode,
       execution,
       executionRef,
       isTrigger,
+      isQueued: false,
       createdAt: isTrigger ? run.rootEvent?.createdAt : (execution?.createdAt ?? executionRef?.createdAt),
       durationMs: execution
         ? calculateExecutionDuration(execution)
@@ -312,6 +319,8 @@ export function buildRunInspectorNodeSections({
       }),
     };
   });
+
+  return [...executionSections, ...buildQueuedNodeSections({ run, workflowNodes })];
 }
 
 export function findRunInspectorErrorSummaries(sections: RunInspectorNodeSection[]): RunInspectorErrorSummary[] {

--- a/web_src/src/ui/Runs/runQueuedNodeSections.ts
+++ b/web_src/src/ui/Runs/runQueuedNodeSections.ts
@@ -1,0 +1,62 @@
+import type {
+  CanvasesCanvasNodeQueueItem,
+  CanvasesCanvasRun,
+  SuperplaneComponentsNode as ComponentsNode,
+} from "@/api-client";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import type { RunInspectorNodeSection } from "./runNodeDetailModel";
+
+export function buildQueuedNodeSections({
+  run,
+  workflowNodes,
+}: {
+  run: CanvasesCanvasRun;
+  workflowNodes: ComponentsNode[];
+}): RunInspectorNodeSection[] {
+  return [...(run.queueItems ?? [])]
+    .filter((queueItem) => queueItem.id && queueItem.nodeId)
+    .sort(compareQueueItemCreatedAt)
+    .map((queueItem) => {
+      const nodeId = queueItem.nodeId!;
+      const workflowNode = workflowNodes.find((node) => node.id === nodeId);
+
+      return {
+        sectionValue: queuedSectionValue(queueItem),
+        nodeId,
+        nodeName: workflowNode?.name || nodeId,
+        workflowNode,
+        queueItem,
+        isTrigger: false,
+        isQueued: true,
+        createdAt: queueItem.createdAt,
+        badge: eventBadgeForQueuedItem(),
+        tabData: null,
+        upstreamSections: [],
+        outputSections: [],
+        actions: {
+          canStop: false,
+          canPushThrough: false,
+          approvalRecords: [],
+        },
+        configurationFields: [],
+      };
+    });
+}
+
+function eventBadgeForQueuedItem(): { badgeColor: string; label: string } {
+  const style = DEFAULT_EVENT_STATE_MAP.queued;
+  return { badgeColor: style.badgeColor, label: style.label ?? "queued" };
+}
+
+function queuedSectionValue(queueItem: CanvasesCanvasNodeQueueItem): string {
+  return `queue:${queueItem.nodeId}:${queueItem.id}`;
+}
+
+function compareQueueItemCreatedAt(left: CanvasesCanvasNodeQueueItem, right: CanvasesCanvasNodeQueueItem): number {
+  return queueItemCreatedAt(left) - queueItemCreatedAt(right);
+}
+
+function queueItemCreatedAt(queueItem: CanvasesCanvasNodeQueueItem): number {
+  const timestamp = queueItem.createdAt ? new Date(queueItem.createdAt).getTime() : Number.POSITIVE_INFINITY;
+  return Number.isFinite(timestamp) ? timestamp : Number.POSITIVE_INFINITY;
+}

--- a/web_src/src/ui/Runs/useRunInspectorActions.spec.tsx
+++ b/web_src/src/ui/Runs/useRunInspectorActions.spec.tsx
@@ -13,7 +13,13 @@ const run: CanvasesCanvasRun = {
   },
 };
 
-function renderActions(sections: RunInspectorNodeSection[], executionsLoading = false) {
+function renderActions(
+  sections: RunInspectorNodeSection[],
+  {
+    executionsLoading = false,
+    runOverride = run,
+  }: { executionsLoading?: boolean; runOverride?: CanvasesCanvasRun } = {},
+) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -25,7 +31,7 @@ function renderActions(sections: RunInspectorNodeSection[], executionsLoading = 
     () =>
       useRunInspectorActions({
         canvasId: "canvas-1",
-        run,
+        run: runOverride,
         sections,
         executionsLoading,
       }),
@@ -39,9 +45,11 @@ function renderActions(sections: RunInspectorNodeSection[], executionsLoading = 
 
 function actionSection(overrides: Partial<RunInspectorNodeSection> = {}): RunInspectorNodeSection {
   return {
+    sectionValue: "action-1",
     nodeId: "action-1",
     nodeName: "Action 1",
     isTrigger: false,
+    isQueued: false,
     badge: null,
     tabData: null,
     upstreamSections: [],
@@ -57,7 +65,7 @@ function actionSection(overrides: Partial<RunInspectorNodeSection> = {}): RunIns
 }
 
 describe("useRunInspectorActions", () => {
-  it("keeps Stop disabled when action sections only have lightweight execution refs", () => {
+  it("allows Stop when action sections only have lightweight running execution refs", () => {
     const { result } = renderActions([
       actionSection({
         executionRef: {
@@ -68,7 +76,7 @@ describe("useRunInspectorActions", () => {
       }),
     ]);
 
-    expect(result.current.stopDisabled).toBe(true);
+    expect(result.current.stopDisabled).toBe(false);
   });
 
   it("allows Stop for loaded action execution details so queued steps can be cancelled", () => {
@@ -82,6 +90,18 @@ describe("useRunInspectorActions", () => {
         },
       }),
     ]);
+
+    expect(result.current.stopDisabled).toBe(false);
+  });
+
+  it("allows Stop for queued items while executions are loading", () => {
+    const { result } = renderActions([], {
+      executionsLoading: true,
+      runOverride: {
+        ...run,
+        queueItems: [{ id: "queue-1", nodeId: "action-1" }],
+      },
+    });
 
     expect(result.current.stopDisabled).toBe(false);
   });

--- a/web_src/src/ui/Runs/useRunInspectorActions.ts
+++ b/web_src/src/ui/Runs/useRunInspectorActions.ts
@@ -3,8 +3,8 @@ import { useCallback, useMemo } from "react";
 import {
   canvasesCancelExecution,
   canvasesDeleteNodeQueueItem,
+  canvasesDescribeRun,
   canvasesInvokeNodeExecutionHook,
-  canvasesListNodeQueueItems,
   canvasesReemitTriggerEvent,
   type CanvasesCanvasRun,
 } from "@/api-client";
@@ -26,19 +26,34 @@ export function useRunInspectorActions({
   onRerunCreated?: (eventId: string) => void | Promise<void>;
 }) {
   const queryClient = useQueryClient();
-  const runningExecutionIds = useMemo(
-    () =>
-      sections
-        .map((section) => section.execution)
-        .filter((execution) => execution?.id && execution.state === "STATE_STARTED")
-        .map((execution) => execution!.id!),
-    [sections],
-  );
+  const runningExecutionIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const executionRef of run.executions ?? []) {
+      if (executionRef.id && executionRef.state === "STATE_STARTED") {
+        ids.add(executionRef.id);
+      }
+    }
+
+    for (const section of sections) {
+      if (section.execution?.id && section.execution.state === "STATE_STARTED") {
+        ids.add(section.execution.id);
+      }
+
+      if (section.executionRef?.id && section.executionRef.state === "STATE_STARTED") {
+        ids.add(section.executionRef.id);
+      }
+    }
+
+    return [...ids];
+  }, [run.executions, sections]);
   const hasLoadedActionSection = useMemo(
     () => sections.some((section) => !section.isTrigger && section.execution),
     [sections],
   );
-  const stoppableNodeIds = useMemo(() => [...new Set(sections.map((section) => section.nodeId))], [sections]);
+  const queuedItems = useMemo(
+    () => run.queueItems?.filter(hasQueueItemIdentity).map(toQueuedItemReference) ?? [],
+    [run.queueItems],
+  );
 
   const refreshRunQueries = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ["canvases"] });
@@ -47,13 +62,14 @@ export function useRunInspectorActions({
   const rerunMutation = useRerunMutation({ canvasId, run, refreshRunQueries, onRerunCreated });
   const stopMutation = useStopMutation({
     canvasId,
+    runId: run.id ?? null,
     runningExecutionIds,
-    stoppableNodeIds,
-    rootEventId: run.rootEvent?.id,
+    queuedItems,
     refreshRunQueries,
   });
   const stopNodeMutation = useStopNodeMutation({ canvasId, refreshRunQueries });
   const executionHookMutation = useExecutionHookMutation({ canvasId, refreshRunQueries });
+  const cancelQueuedItemMutation = useCancelQueuedItemMutation({ canvasId, refreshRunQueries });
 
   return {
     rerun: () => rerunMutation.mutate(),
@@ -61,14 +77,20 @@ export function useRunInspectorActions({
     stop: () => stopMutation.mutate(),
     stopPending: stopMutation.isPending,
     stopDisabled:
-      executionsLoading ||
       stopMutation.isPending ||
-      (runningExecutionIds.length === 0 && (!run.rootEvent?.id || !hasLoadedActionSection)),
+      (runningExecutionIds.length === 0 &&
+        queuedItems.length === 0 &&
+        (executionsLoading || !run.rootEvent?.id || !hasLoadedActionSection)),
     stopNode: (section: RunInspectorNodeSection) => {
       if (!section.execution?.id) return;
       stopNodeMutation.mutate(section.execution.id);
     },
     stopNodePending: stopNodeMutation.isPending,
+    cancelQueuedItem: (section: RunInspectorNodeSection) => {
+      if (!section.queueItem?.nodeId || !section.queueItem.id) return;
+      cancelQueuedItemMutation.mutate({ nodeId: section.queueItem.nodeId, itemId: section.queueItem.id });
+    },
+    cancelQueuedItemPending: cancelQueuedItemMutation.isPending,
     invokeNodeHook: (
       section: RunInspectorNodeSection,
       hookName: string,
@@ -126,41 +148,60 @@ function useRerunMutation({
 
 function useStopMutation({
   canvasId,
+  runId,
   runningExecutionIds,
-  stoppableNodeIds,
-  rootEventId,
+  queuedItems,
   refreshRunQueries,
 }: {
   canvasId: string;
+  runId: string | null;
   runningExecutionIds: string[];
-  stoppableNodeIds: string[];
-  rootEventId?: string;
+  queuedItems: QueuedItemReference[];
   refreshRunQueries: () => Promise<void>;
 }) {
   return useMutation({
     mutationFn: async () => {
-      const queuedItems = await listQueuedItemsForRun({
-        canvasId,
-        nodeIds: stoppableNodeIds,
-        rootEventId,
-      });
+      const workToStop = runId ? await fetchRunWorkForStop(canvasId, runId) : { runningExecutionIds, queuedItems };
 
-      if (runningExecutionIds.length === 0 && queuedItems.length === 0) {
-        throw new Error("No running or queued steps to stop");
+      if (workToStop.runningExecutionIds.length === 0 && workToStop.queuedItems.length === 0) {
+        return false;
       }
 
       await Promise.all([
-        ...runningExecutionIds.map((executionId) => cancelExecution(canvasId, executionId)),
-        ...queuedItems.map((item) => deleteQueuedItem(canvasId, item.nodeId, item.itemId)),
+        ...workToStop.runningExecutionIds.map((executionId) => cancelExecution(canvasId, executionId)),
+        ...workToStop.queuedItems.map((item) => deleteQueuedItem(canvasId, item.nodeId, item.itemId)),
       ]);
+      return true;
     },
-    onSuccess: async () => {
+    onSuccess: async (stoppedWork) => {
       await refreshRunQueries();
-      showSuccessToast("Run stopped");
+      if (stoppedWork) {
+        showSuccessToast("Run stopped");
+      }
     },
     onError: (error) => {
       console.error("Failed to stop run", error);
       showErrorToast("Failed to stop run");
+    },
+  });
+}
+
+function useCancelQueuedItemMutation({
+  canvasId,
+  refreshRunQueries,
+}: {
+  canvasId: string;
+  refreshRunQueries: () => Promise<void>;
+}) {
+  return useMutation({
+    mutationFn: (queueItem: QueuedItemReference) => deleteQueuedItem(canvasId, queueItem.nodeId, queueItem.itemId),
+    onSuccess: async () => {
+      await refreshRunQueries();
+      showSuccessToast("Queued step cancelled");
+    },
+    onError: (error) => {
+      console.error("Failed to cancel queued step", error);
+      showErrorToast("Failed to cancel queued step");
     },
   });
 }
@@ -242,6 +283,20 @@ async function deleteQueuedItem(canvasId: string, nodeId: string, itemId: string
   );
 }
 
+async function fetchRunWorkForStop(canvasId: string, runId: string): Promise<StopRunWork> {
+  const response = await canvasesDescribeRun(
+    withOrganizationHeader({
+      path: { canvasId, runId },
+    }),
+  );
+
+  const run = response.data?.run;
+  return {
+    runningExecutionIds: runningExecutionIdsFromRun(run),
+    queuedItems: run?.queueItems?.filter(hasQueueItemIdentity).map(toQueuedItemReference) ?? [],
+  };
+}
+
 function invokeExecutionHook(canvasId: string) {
   return async ({
     executionId,
@@ -267,35 +322,38 @@ function invokeExecutionHook(canvasId: string) {
   };
 }
 
-async function listQueuedItemsForRun({
-  canvasId,
-  nodeIds,
-  rootEventId,
-}: {
-  canvasId: string;
-  nodeIds: string[];
-  rootEventId?: string;
-}) {
-  if (!rootEventId || nodeIds.length === 0) {
-    return [];
+type QueueItemWithIdentity = {
+  id: string;
+  nodeId: string;
+};
+
+type QueuedItemReference = {
+  nodeId: string;
+  itemId: string;
+};
+
+type StopRunWork = {
+  runningExecutionIds: string[];
+  queuedItems: QueuedItemReference[];
+};
+
+function runningExecutionIdsFromRun(run: CanvasesCanvasRun | undefined): string[] {
+  const ids: string[] = [];
+  for (const executionRef of run?.executions ?? []) {
+    if (executionRef.id && executionRef.state === "STATE_STARTED") {
+      ids.push(executionRef.id);
+    }
   }
 
-  const responses = await Promise.all(
-    nodeIds.map(async (nodeId) => {
-      const response = await canvasesListNodeQueueItems(
-        withOrganizationHeader({
-          path: { canvasId, nodeId },
-          query: { limit: 100 },
-        }),
-      );
+  return ids;
+}
 
-      return (
-        response.data?.items
-          ?.filter((item) => item.id && item.rootEvent?.id === rootEventId)
-          .map((item) => ({ nodeId, itemId: item.id! })) ?? []
-      );
-    }),
-  );
+function hasQueueItemIdentity(
+  queueItem: NonNullable<CanvasesCanvasRun["queueItems"]>[number],
+): queueItem is QueueItemWithIdentity {
+  return Boolean(queueItem.id && queueItem.nodeId);
+}
 
-  return responses.flat();
+function toQueuedItemReference(queueItem: QueueItemWithIdentity): QueuedItemReference {
+  return { nodeId: queueItem.nodeId, itemId: queueItem.id };
 }


### PR DESCRIPTION
## Summary

- Add queued node items to `CanvasRun` so run inspection can render queued work from run payloads.
- Populate queued items in run list, describe, and websocket run serialization.
- Render queued steps at the end of the run inspector with queued state, Input-only content, and a Cancel action.
- Batch and parallelize run detail loading to avoid per-node fan-out and reduce added latency.

## Validation

- `make pb.gen`
- `make format.go`
- `make format.js`
- `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/canvases`
- `cd web_src && npm run test -- RunInspectorPanel.spec.tsx useRunInspectorActions.spec.tsx`
- `make lint && make check.build.app`
- `make check.build.ui`
- `git diff --check`