### PR TITLE
fix(ui): preserve repository file staging when re-entering edit mode

### DIFF
--- a/web_src/src/pages/app/files/useRepositoryFileStaging.spec.ts
+++ b/web_src/src/pages/app/files/useRepositoryFileStaging.spec.ts
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PendingFileChange } from "./types";
+import { useRepositoryFileStaging } from "./useRepositoryFileStaging";
+
+const mutateAsyncStage = vi.fn();
+const mutateAsyncDiscard = vi.fn();
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useStageRepositoryFiles: () => ({
+    mutateAsync: mutateAsyncStage,
+  }),
+  useDiscardRepositoryFilePaths: () => ({
+    mutateAsync: mutateAsyncDiscard,
+  }),
+}));
+
+vi.mock("../lib/staging-content-match", () => ({
+  matchesCommittedRepositoryFileContent: vi.fn(async () => false),
+}));
+
+const pendingChange: PendingFileChange = {
+  type: "modified",
+  path: "test.sh",
+  content: "#!/bin/bash\necho edited\n",
+};
+
+describe("useRepositoryFileStaging", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mutateAsyncStage.mockResolvedValue(undefined);
+    mutateAsyncDiscard.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("does not discard server staging when edit mode is toggled off and back on", async () => {
+    const { rerender } = renderHook(
+      ({ enabled, pendingChanges }: { enabled: boolean; pendingChanges: PendingFileChange[] }) =>
+        useRepositoryFileStaging({
+          canvasId: "canvas-1",
+          versionId: "version-1",
+          enabled,
+          pendingChanges,
+        }),
+      {
+        initialProps: {
+          enabled: true,
+          pendingChanges: [pendingChange],
+        },
+      },
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(mutateAsyncStage).toHaveBeenCalledTimes(1);
+    expect(mutateAsyncDiscard).not.toHaveBeenCalled();
+
+    rerender({ enabled: false, pendingChanges: [] });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(mutateAsyncDiscard).not.toHaveBeenCalled();
+
+    rerender({ enabled: true, pendingChanges: [] });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(mutateAsyncDiscard).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/app/files/useRepositoryFileStaging.ts
+++ b/web_src/src/pages/app/files/useRepositoryFileStaging.ts
@@ -131,6 +131,17 @@ export function useRepositoryFileStaging({
     stagedPathsRef.current = new Set();
   }, [versionId]);
 
+  // Leaving edit mode clears in-memory pendingChanges but keeps server staging.
+  // Drop local bookkeeping so re-entry does not treat persisted staged paths as
+  // reverted edits and DELETE them from staging.
+  useEffect(() => {
+    if (enabled) {
+      return;
+    }
+
+    stagedPathsRef.current = new Set();
+  }, [enabled]);
+
   useEffect(() => {
     if (!enabled || !canvasId || !versionId) {
       return;

--- a/web_src/src/pages/app/useDraftStagingIndicators.spec.ts
+++ b/web_src/src/pages/app/useDraftStagingIndicators.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEditingStagingFlags } from "./useDraftStagingIndicators";
+
+describe("resolveEditingStagingFlags", () => {
+  const ready = {
+    isEditing: true,
+    editBootstrapReady: true,
+    committedBaselinesReady: true,
+    localHasCanvasStaging: false,
+    localHasConsoleStaging: false,
+  };
+
+  it("uses server file staging before the user edits files in the session", () => {
+    expect(
+      resolveEditingStagingFlags({
+        ...ready,
+        filesLocalStagingActive: false,
+        localHasFilesStaging: false,
+        serverHasFilesStaging: true,
+      }),
+    ).toMatchObject({ hasFilesStagingChanges: true, hasStagingChanges: true });
+  });
+
+  it("uses local file staging while the user is actively editing files", () => {
+    expect(
+      resolveEditingStagingFlags({
+        ...ready,
+        filesLocalStagingActive: true,
+        localHasFilesStaging: true,
+        serverHasFilesStaging: false,
+      }),
+    ).toMatchObject({ hasFilesStagingChanges: true, hasStagingChanges: true });
+  });
+
+  it("ignores stale server staging after the user reverts all local file edits", () => {
+    expect(
+      resolveEditingStagingFlags({
+        ...ready,
+        filesLocalStagingActive: true,
+        localHasFilesStaging: false,
+        serverHasFilesStaging: true,
+      }),
+    ).toMatchObject({ hasFilesStagingChanges: false, hasStagingChanges: false });
+  });
+
+  it("falls back to server file staging after re-entering edit mode with cleared local pending", () => {
+    expect(
+      resolveEditingStagingFlags({
+        ...ready,
+        filesLocalStagingActive: false,
+        localHasFilesStaging: false,
+        serverHasFilesStaging: true,
+      }),
+    ).toMatchObject({ hasFilesStagingChanges: true, hasStagingChanges: true });
+  });
+});

--- a/web_src/src/pages/app/useDraftStagingIndicators.ts
+++ b/web_src/src/pages/app/useDraftStagingIndicators.ts
@@ -13,7 +13,7 @@ type CanvasStagingQuery = ReturnType<typeof useCanvasStaging>;
 type ConsoleVersionDiff = ReturnType<typeof useCanvasConsoleVersionDiff>;
 type ConsoleQueryData = ConsoleVersionDiff["consoleQuery"]["data"];
 
-function resolveEditingStagingFlags({
+export function resolveEditingStagingFlags({
   isEditing,
   editBootstrapReady,
   committedBaselinesReady,
@@ -130,6 +130,17 @@ export function useDraftStagingIndicators({
     setFilesLocalStagingActive(false);
     setLocalHasFilesStaging(false);
   }, [stagingResetNonce]);
+
+  // Leaving edit mode clears in-memory pendingChanges. Drop the local-files latch
+  // so re-entry can fall back to server staging for Reset/Commit enablement.
+  useEffect(() => {
+    if (isEditing) {
+      return;
+    }
+
+    setFilesLocalStagingActive(false);
+    setLocalHasFilesStaging(false);
+  }, [isEditing]);
 
   useEffect(() => {
     if (consoleQueryData) {


### PR DESCRIPTION
Fix a file editor bug where exiting and re-entering edit mode issued `DELETE /staging?paths=…` and discarded staged repository file changes (e.g. `test.sh`).

## Root cause

Two pieces of in-memory state were out of sync with server staging after leaving edit mode:
1. **`useRepositoryFileStaging`** kept `stagedPathsRef` across edit-mode toggles while `pendingChanges` was cleared on exit. On re-entry, the sync logic treated previously staged paths as “no longer pending” and discarded them from staging.
2. **`useDraftStagingIndicators`** latched `filesLocalStagingActive` after the first file edit. After re-entry with empty local pending state, Reset/Commit only looked at local indicators and stayed disabled even though server staging was intact.

## Fix

- Clear local repository-file staging bookkeeping when leaving edit mode so re-entry does not treat server-staged paths as reverted in-memory edits.
- Reset the files staging indicator latch on exit so Reset/Commit buttons stay enabled after re-entering edit mode when staging still exists on the server.