### PR TITLE
fix: allow expression values for GitLab project field

### DIFF
--- a/pkg/integrations/gitlab/accept_merge_request_test.go
+++ b/pkg/integrations/gitlab/accept_merge_request_test.go
@@ -56,6 +56,19 @@ func Test__AcceptMergeRequest__Setup(t *testing.T) {
 		err := c.Setup(ctx)
 		require.NoError(t, err)
 	})
+
+	t.Run("expression project is allowed", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":         "{{ $['On Merge Request'].data.project.id }}",
+				"mergeRequestIid": "{{ $['On Merge Request'].data.object_attributes.iid }}",
+			},
+			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
 }
 
 func Test__AcceptMergeRequest__Execute(t *testing.T) {

--- a/pkg/integrations/gitlab/common.go
+++ b/pkg/integrations/gitlab/common.go
@@ -4,12 +4,22 @@ import (
 	"crypto/subtle"
 	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/core"
 )
+
+var expressionPlaceholderRegex = regexp.MustCompile(`(?s)\{\{.*?\}\}`)
+
+// isExpression reports whether the given string contains an expression
+// placeholder (e.g. `{{ ... }}`). Useful in Setup paths to skip strict
+// validation of values that will only be known at execution time.
+func isExpression(s string) bool {
+	return expressionPlaceholderRegex.MatchString(s)
+}
 
 const (
 	PipelineStatusSuccess   = "success"
@@ -99,6 +109,14 @@ func ensureProjectInMetadata(ctx core.MetadataWriter, app core.IntegrationContex
 
 	if projectID == "" {
 		return fmt.Errorf("project is required")
+	}
+
+	//
+	// Expression values are only known at execution time, so skip the
+	// accessibility check and node metadata caching until then.
+	//
+	if isExpression(projectID) {
+		return nil
 	}
 
 	//

--- a/pkg/integrations/gitlab/common_test.go
+++ b/pkg/integrations/gitlab/common_test.go
@@ -1,0 +1,62 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__IsExpression(t *testing.T) {
+	assert.True(t, isExpression("{{ $['On Merge Request'].data.project.id }}"))
+	assert.True(t, isExpression("prefix-{{ inputs.project }}-suffix"))
+	assert.True(t, isExpression("{{\n  inputs.project\n}}"))
+	assert.False(t, isExpression("123456"))
+	assert.False(t, isExpression("my-group/my-project"))
+	assert.False(t, isExpression(""))
+	assert.False(t, isExpression("{ not an expression }"))
+}
+
+func Test__EnsureProjectInMetadata(t *testing.T) {
+	integration := &contexts.IntegrationContext{
+		Metadata: Metadata{
+			Projects: []ProjectMetadata{
+				{ID: 123, Name: "group/project", URL: "https://gitlab.com/group/project"},
+			},
+		},
+	}
+
+	t.Run("empty project", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := ensureProjectInMetadata(metadata, integration, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("expression project skips validation and metadata caching", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := ensureProjectInMetadata(metadata, integration, "{{ $['On Merge Request'].data.project.id }}")
+		require.NoError(t, err)
+		assert.Nil(t, metadata.Metadata)
+	})
+
+	t.Run("accessible project is cached in node metadata", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := ensureProjectInMetadata(metadata, integration, "123")
+		require.NoError(t, err)
+
+		nodeMetadata, ok := metadata.Metadata.(NodeMetadata)
+		require.True(t, ok)
+		require.NotNil(t, nodeMetadata.Project)
+		assert.Equal(t, 123, nodeMetadata.Project.ID)
+		assert.Equal(t, "group/project", nodeMetadata.Project.Name)
+	})
+
+	t.Run("inaccessible project", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := ensureProjectInMetadata(metadata, integration, "999")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not accessible to integration")
+	})
+}

--- a/pkg/integrations/gitlab/run_pipeline.go
+++ b/pkg/integrations/gitlab/run_pipeline.go
@@ -168,6 +168,12 @@ func (r *RunPipeline) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("project is required")
 	}
 
+	// Run Pipeline tracks completion through a project webhook created at
+	// setup time, so the project cannot come from an expression.
+	if isExpression(spec.Project) {
+		return fmt.Errorf("project does not support expressions: Run Pipeline creates a project webhook, so it needs a concrete project")
+	}
+
 	if strings.TrimSpace(spec.Ref) == "" {
 		return fmt.Errorf("ref is required")
 	}

--- a/pkg/integrations/gitlab/run_pipeline_test.go
+++ b/pkg/integrations/gitlab/run_pipeline_test.go
@@ -11,6 +11,37 @@ import (
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
+func Test__RunPipeline__Setup(t *testing.T) {
+	r := &RunPipeline{}
+
+	t.Run("expression project is rejected", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project": "{{ $['On Merge Request'].data.project.id }}",
+				"ref":     "main",
+			},
+			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
+		}
+		err := r.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project does not support expressions")
+	})
+
+	t.Run("missing project", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"ref": "main",
+			},
+			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
+		}
+		err := r.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+}
+
 func Test__RunPipeline__Execute(t *testing.T) {
 	component := &RunPipeline{}
 	metadataCtx := &contexts.MetadataContext{}


### PR DESCRIPTION
## Summary

This allows expressions to be used in the project field on the component gitlab.MergeRequest


Closes: https://github.com/superplanehq/superplane/issues/6108