### PR TITLE
fix: keep expression autocomplete stable on enter

### DIFF
--- a/test/e2e/canvas_page_test.go
+++ b/test/e2e/canvas_page_test.go
@@ -144,6 +144,31 @@ func TestCanvasPage(t *testing.T) {
 		steps.typeExpression("$")
 		steps.assertAutocompleteNodeSuggestionVisible()
 	})
+
+	t.Run("accepting node suggestion keeps HTTP URL autocomplete visible", func(t *testing.T) {
+		steps := &CanvasPageSteps{t: t}
+		steps.start()
+		steps.givenACanvasExists()
+		steps.addManualTrigger("Start")
+		steps.addHTTP("HTTP")
+		steps.connectNodes("Start", "HTTP")
+		steps.saveCanvas()
+		steps.waitForDraftConnection("Start", "HTTP")
+		steps.openNodeSettings("HTTP")
+		steps.typeHTTPURL("{{ $")
+		steps.assertAutocompleteSuggestionHighlighted(0)
+		steps.startTrackingAutocompleteVisibility()
+		steps.pressEnterInExpressionAutocomplete()
+		steps.assertAutocompleteRemainedVisible()
+		steps.assertHTTPURLInputContains(`$["Start"].`)
+		steps.assertAutocompleteSuggestionVisible("data")
+		steps.assertAutocompleteSuggestionHighlighted(0)
+		steps.startTrackingAutocompleteVisibility()
+		steps.pressEnterInExpressionAutocomplete()
+		steps.assertAutocompleteRemainedVisible()
+		steps.assertHTTPURLInputContains(`$["Start"].data.`)
+		steps.assertAutocompleteSuggestionVisible("message")
+	})
 }
 
 func TestCanvasPageYamlViewer(t *testing.T) {
@@ -198,6 +223,12 @@ func (s *CanvasPageSteps) addManualTrigger(name string) {
 
 func (s *CanvasPageSteps) addFilter(name string) {
 	s.canvas.AddFilter(name, models.Position{X: 900, Y: 200})
+}
+
+func (s *CanvasPageSteps) addHTTP(name string) {
+	s.canvas.AddBuildingBlockByTestID("building-block-http", models.Position{X: 900, Y: 200})
+	s.session.FillIn(q.TestID("node-name-input"), name)
+	s.session.Sleep(300)
 }
 
 func (s *CanvasPageSteps) addNoopWithDefaultName(pos models.Position) string {
@@ -463,9 +494,118 @@ func (s *CanvasPageSteps) typeExpression(value string) {
 	s.session.FillIn(q.TestID("expression-field-expression"), value)
 }
 
+func (s *CanvasPageSteps) typeHTTPURL(value string) {
+	field := q.TestID("string-field-url").Run(s.session)
+	require.NoError(s.t, field.Click(pw.LocatorClickOptions{Timeout: pw.Float(10000)}))
+	require.NoError(s.t, field.PressSequentially(value))
+}
+
+func (s *CanvasPageSteps) pressEnterInExpressionAutocomplete() {
+	s.session.PressKey("Enter")
+	s.session.Sleep(1500)
+}
+
 func (s *CanvasPageSteps) assertAutocompleteNodeSuggestionVisible() {
 	s.session.AssertVisible(q.Locator(`div[data-suggestion-index="0"]`))
 	s.session.AssertVisible(q.Locator(`div[data-suggestion-index="0"] span:has-text("node")`))
+}
+
+func (s *CanvasPageSteps) assertAutocompleteSuggestionHighlighted(index int) {
+	item := q.Locator(fmt.Sprintf(`div[data-suggestion-index="%d"]`, index)).Run(s.session)
+	require.NoError(s.t, item.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(10000),
+	}))
+
+	className, err := item.GetAttribute("class")
+	require.NoError(s.t, err)
+	require.Contains(s.t, className, "bg-slate-100", "expected suggestion %d to be highlighted", index)
+}
+
+func (s *CanvasPageSteps) assertAutocompleteSuggestionVisible(text string) {
+	s.session.AssertVisible(q.Locator(fmt.Sprintf(`div[data-suggestion-index] :text-is("%s")`, text)))
+}
+
+func (s *CanvasPageSteps) startTrackingAutocompleteVisibility() {
+	_, err := s.session.Page().Evaluate(`() => {
+		const isVisible = (element) => {
+			const style = window.getComputedStyle(element);
+			const rect = element.getBoundingClientRect();
+			return style.display !== "none" &&
+				style.visibility !== "hidden" &&
+				rect.width > 0 &&
+				rect.height > 0;
+		};
+
+		const hasVisibleSuggestion = () =>
+			Array.from(document.querySelectorAll("div[data-suggestion-index]")).some(isVisible);
+
+		const autocompleteRoot = document.querySelector("[data-testid='autocomplete-suggestions']");
+		const valuePreview = document.querySelector("[data-testid='autocomplete-value-preview']");
+		window.__autocompleteVisibilitySamples = [];
+		window.__autocompleteVisibilityObserver?.disconnect();
+
+		const sample = () => {
+			window.__autocompleteVisibilitySamples.push({
+				visible: hasVisibleSuggestion(),
+				sameRootConnected: Boolean(autocompleteRoot?.isConnected),
+				previewVisible: Boolean(valuePreview && isVisible(valuePreview)),
+				samePreviewConnected: Boolean(valuePreview?.isConnected),
+			});
+		};
+
+		sample();
+		window.__autocompleteVisibilityObserver = new MutationObserver(sample);
+		window.__autocompleteVisibilityObserver.observe(document.body, {
+			attributes: true,
+			childList: true,
+			subtree: true,
+		});
+
+		let frames = 0;
+		const sampleAnimationFrame = () => {
+			sample();
+			frames += 1;
+			if (frames < 30) {
+				window.requestAnimationFrame(sampleAnimationFrame);
+			}
+		};
+		window.requestAnimationFrame(sampleAnimationFrame);
+	}`, nil)
+	require.NoError(s.t, err)
+}
+
+func (s *CanvasPageSteps) assertAutocompleteRemainedVisible() {
+	result, err := s.session.Page().Evaluate(`() => {
+		window.__autocompleteVisibilityObserver?.disconnect();
+		return window.__autocompleteVisibilitySamples ?? [];
+	}`, nil)
+	require.NoError(s.t, err)
+
+	samples, ok := result.([]any)
+	require.True(s.t, ok, "expected autocomplete visibility samples, got %T", result)
+	require.NotEmpty(s.t, samples, "expected autocomplete visibility samples")
+
+	for i, sample := range samples {
+		entry, ok := sample.(map[string]any)
+		require.True(s.t, ok, "expected autocomplete visibility sample object, got %T", sample)
+		require.Equal(s.t, true, entry["visible"], "autocomplete disappeared at visibility sample %d: %v", i, samples)
+		require.Equal(s.t, true, entry["sameRootConnected"], "autocomplete portal remounted at sample %d: %v", i, samples)
+		require.Equal(s.t, true, entry["previewVisible"], "autocomplete preview disappeared at sample %d: %v", i, samples)
+		require.Equal(s.t, true, entry["samePreviewConnected"], "autocomplete preview remounted at sample %d: %v", i, samples)
+	}
+}
+
+func (s *CanvasPageSteps) assertExpressionInputEquals(expected string) {
+	value, err := q.TestID("expression-field-expression").Run(s.session).InputValue()
+	require.NoError(s.t, err)
+	require.Equal(s.t, expected, value)
+}
+
+func (s *CanvasPageSteps) assertHTTPURLInputContains(expected string) {
+	value, err := q.TestID("string-field-url").Run(s.session).InputValue()
+	require.NoError(s.t, err)
+	require.Contains(s.t, value, expected)
 }
 
 func (s *CanvasPageSteps) assertQueuedItemsCount(nodeName string, expected int) {

--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AutoCompleteInput } from "./AutoCompleteInput";
 import { calculateDropdownPosition } from "./dropdownPosition";
@@ -110,5 +110,73 @@ describe("AutoCompleteInput suggestions", () => {
     fireEvent.change(input, { target: { value, selectionStart: value.length } });
 
     expect(await screen.findAllByText("root()")).not.toHaveLength(0);
+  });
+
+  it("keeps keyboard highlight when rerendering the same suggestions", async () => {
+    const value = "{{ root().data.";
+    const renderInput = (exampleObj: Record<string, unknown>) => (
+      <AutoCompleteInput
+        aria-label="Run title"
+        exampleObj={exampleObj}
+        value={value}
+        onChange={vi.fn()}
+        placeholder="{{ root().data.foo }}"
+        startWord="{{"
+        prefix="{{ "
+        suffix=" }}"
+        showValuePreview
+      />
+    );
+
+    const { rerender } = render(renderInput({ __root: { data: { name: "DCO", sha: "d6f3c8a2e8b7" } } }));
+    const input = screen.getByRole("textbox", { name: "Run title" });
+
+    fireEvent.focus(input);
+    (input as HTMLTextAreaElement).setSelectionRange(value.length, value.length);
+    fireEvent.select(input);
+    expect(await screen.findByText("name")).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    rerender(renderInput({ __root: { data: { name: "DCO", sha: "d6f3c8a2e8b7" } } }));
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-suggestion-index="1"]')).toHaveClass("bg-slate-100");
+    });
+  });
+
+  it("keeps suggestions open after accepting an expandable suggestion inside an expression", async () => {
+    renderRunTitleInput();
+    const input = screen.getByRole("textbox", { name: "Run title" });
+    const value = "{{ ro";
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value, selectionStart: value.length } });
+
+    expect(await screen.findAllByText("root()")).not.toHaveLength(0);
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText("data")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(input).toHaveValue("{{ root().");
+    });
+  });
+
+  it("keeps follow-up suggestions visible after the keyboard cursor sync frame", async () => {
+    renderRunTitleInput();
+    const input = screen.getByRole("textbox", { name: "Run title" });
+    const value = "{{ ro";
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value, selectionStart: value.length } });
+
+    expect(await screen.findAllByText("root()")).not.toHaveLength(0);
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(screen.getByText("data")).toBeInTheDocument();
+    expect(screen.getByTestId("autocomplete-value-preview")).toBeInTheDocument();
   });
 });

--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -60,6 +60,20 @@ function getActiveStickyHeaderHeight(container: HTMLElement, item: HTMLElement) 
   return stackedHeight;
 }
 
+function getSuggestionListKey(suggestions: Suggestion[]) {
+  return suggestions
+    .map((suggestion) =>
+      [
+        suggestion.kind,
+        suggestion.label,
+        suggestion.insertText ?? "",
+        suggestion.nodeName ?? "",
+        suggestion.nodeId ?? "",
+      ].join("\u001f"),
+    )
+    .join("\u001e");
+}
+
 // Keep in sync with suggestion section header (`h-7`) and item row (`h-9`) classes.
 const SUGGESTION_SECTION_HEADER_HEIGHT_PX = 28;
 const SUGGESTION_ITEM_HEIGHT_PX = 36;
@@ -126,6 +140,9 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
     const dropdownWidth = 350;
     const previousWordLength = useRef<number>(0);
     const previousInputValue = useRef<string>(value);
+    const highlightedIndexRef = useRef(highlightedIndex);
+    const suggestionListKeyRef = useRef("");
+    const suggestionItemsRef = useRef<Array<ReturnType<typeof getSuggestions>[number]>>([]);
 
     const isRawExpression = expressionMode === "raw";
 
@@ -570,6 +587,30 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       return suggestion.label;
     };
 
+    const getSortedSuggestions = useCallback(
+      (expressionText: string, expressionCursor: number) =>
+        getSuggestions(expressionText, expressionCursor, exampleObj ?? {}, {
+          limit: 150,
+        })
+          .filter((s) => !excludedSuggestions?.includes(s.label))
+          .sort((a, b) => {
+            const aPriority = suggestionSortPriority[a.label as keyof typeof suggestionSortPriority];
+            const bPriority = suggestionSortPriority[b.label as keyof typeof suggestionSortPriority];
+
+            if (aPriority !== undefined && bPriority !== undefined) {
+              return aPriority - bPriority;
+            }
+            if (aPriority !== undefined) {
+              return -1;
+            }
+            if (bPriority !== undefined) {
+              return 1;
+            }
+            return a.label.localeCompare(b.label);
+          }),
+      [exampleObj, excludedSuggestions],
+    );
+
     const getReplacementRange = (left: string, insertText: string) => {
       const envBracketMatch = left.match(/\$env\s*\[\s*(['"])([^'"]*)$/);
       if (envBracketMatch) {
@@ -980,10 +1021,22 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
     }, [inputValue]);
 
     useEffect(() => {
+      highlightedIndexRef.current = highlightedIndex;
+    }, [highlightedIndex]);
+
+    useEffect(() => {
+      suggestionItemsRef.current = suggestions;
+    }, [suggestions]);
+
+    useEffect(() => {
       if (!isFocused) {
+        suggestionListKeyRef.current = "";
+        highlightedIndexRef.current = -1;
         setSuggestions([]);
         setIsOpen(false);
+        setHighlightedIndex(-1);
         setHighlightedValue(undefined);
+        setHighlightedSuggestion(null);
         return;
       }
 
@@ -994,37 +1047,42 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
 
       const context = getExpressionContext(inputValue, cursorPosition);
       if (!context || !isAllowedToSuggest(inputValue, cursorPosition)) {
+        suggestionListKeyRef.current = "";
+        highlightedIndexRef.current = -1;
         setSuggestions([]);
         setIsOpen(false);
+        setHighlightedIndex(-1);
         setHighlightedValue(undefined);
+        setHighlightedSuggestion(null);
         return;
       }
 
-      const newSuggestions = getSuggestions(context.expressionText, context.expressionCursor, exampleObj ?? {}, {
-        limit: 150,
-      })
-        .filter((s) => !excludedSuggestions?.includes(s.label))
-        .sort((a, b) => {
-          const aPriority = suggestionSortPriority[a.label as keyof typeof suggestionSortPriority];
-          const bPriority = suggestionSortPriority[b.label as keyof typeof suggestionSortPriority];
-
-          if (aPriority !== undefined && bPriority !== undefined) {
-            return aPriority - bPriority;
-          }
-          if (aPriority !== undefined) {
-            return -1;
-          }
-          if (bPriority !== undefined) {
-            return 1;
-          }
-          return a.label.localeCompare(b.label);
-        });
-      setSuggestions(newSuggestions);
+      const newSuggestions = getSortedSuggestions(context.expressionText, context.expressionCursor);
       setIsOpen(newSuggestions.length > 0);
-      const nextHighlightedIndex = showValuePreview && newSuggestions.length > 0 ? 0 : -1;
+
+      const suggestionListKey = getSuggestionListKey(newSuggestions);
+      const hasSameSuggestionList = suggestionListKeyRef.current === suggestionListKey;
+      const canPreserveHighlightedIndex =
+        hasSameSuggestionList &&
+        highlightedIndexRef.current >= 0 &&
+        highlightedIndexRef.current < newSuggestions.length;
+
+      const activeSuggestions = hasSameSuggestionList ? suggestionItemsRef.current : newSuggestions;
+      if (!hasSameSuggestionList) {
+        setSuggestions(newSuggestions);
+      }
+
+      suggestionListKeyRef.current = suggestionListKey;
+
+      const nextHighlightedIndex = canPreserveHighlightedIndex
+        ? highlightedIndexRef.current
+        : showValuePreview && newSuggestions.length > 0
+          ? 0
+          : -1;
+      highlightedIndexRef.current = nextHighlightedIndex;
       setHighlightedIndex(nextHighlightedIndex);
       if (nextHighlightedIndex >= 0) {
-        const suggestion = newSuggestions[nextHighlightedIndex];
+        const suggestion = activeSuggestions[nextHighlightedIndex] ?? newSuggestions[nextHighlightedIndex];
         setHighlightedSuggestion(suggestion);
         const value = computeHighlightedValue(suggestion, context);
         setHighlightedValue(value);
@@ -1044,6 +1102,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       excludedSuggestions,
       computeHighlightedValue,
       getExpressionContext,
+      getSortedSuggestions,
       isAllowedToSuggest,
     ]);
 
@@ -1112,6 +1171,55 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       });
     };
 
+    const isKeyboardSuggestionCommit = (key: string) =>
+      (key === "Enter" || key === "Tab") &&
+      isOpen &&
+      highlightedIndexRef.current >= 0 &&
+      highlightedIndexRef.current < suggestions.length;
+
+    const handleKeyDownCapture = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (isKeyboardSuggestionCommit(e.key)) {
+        return;
+      }
+
+      handleCursorChange();
+    };
+
+    const showFollowUpSuggestions = useCallback(
+      (
+        nextSuggestions: Array<ReturnType<typeof getSuggestions>[number]>,
+        nextContext: NonNullable<ReturnType<typeof getExpressionContext>>,
+      ) => {
+        suppressSuggestionsRef.current = false;
+        suggestionItemsRef.current = nextSuggestions;
+        suggestionListKeyRef.current = getSuggestionListKey(nextSuggestions);
+        setSuggestions(nextSuggestions);
+        setIsOpen(true);
+
+        const nextHighlightedIndex = showValuePreview ? 0 : -1;
+        highlightedIndexRef.current = nextHighlightedIndex;
+        setHighlightedIndex(nextHighlightedIndex);
+
+        if (nextHighlightedIndex >= 0) {
+          const nextSuggestion = nextSuggestions[nextHighlightedIndex];
+          setHighlightedSuggestion(nextSuggestion);
+          setHighlightedValue(computeHighlightedValue(nextSuggestion, nextContext));
+        } else {
+          setHighlightedSuggestion(null);
+          setHighlightedValue(undefined);
+        }
+      },
+      [computeHighlightedValue, showValuePreview],
+    );
+
+    const closeSuggestions = useCallback(() => {
+      highlightedIndexRef.current = -1;
+      setHighlightedIndex(-1);
+      setHighlightedSuggestion(null);
+      setHighlightedValue(undefined);
+      setIsOpen(false);
+    }, []);
+
     const handleSuggestionClick = (suggestionItem: ReturnType<typeof getSuggestions>[number]) => {
       suppressSuggestionsRef.current = true;
       const cursorPosition = inputRef.current?.selectionStart || 0;
@@ -1119,7 +1227,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       if (!context) {
         suppressSuggestionsRef.current = false;
         isInteractingWithSuggestionsRef.current = false;
-        setIsOpen(false);
+        closeSuggestions();
         return;
       }
 
@@ -1129,19 +1237,29 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       const nextExpression =
         context.expressionText.slice(0, range.start) + insertText + context.expressionText.slice(range.end);
       const newValue = inputValue.slice(0, context.startOffset) + nextExpression + inputValue.slice(context.endOffset);
+      const cursorTarget = context.startOffset + range.start + insertText.length;
+      const nextContext = getExpressionContext(newValue, cursorTarget);
+      const nextSuggestions =
+        nextContext && isAllowedToSuggest(newValue, cursorTarget)
+          ? getSortedSuggestions(nextContext.expressionText, nextContext.expressionCursor)
+          : [];
 
       setInputValue(newValue);
       onChange?.(newValue);
-      setHighlightedIndex(-1);
+      setCursorPosition(cursorTarget);
+
+      if (nextContext && nextSuggestions.length > 0) {
+        showFollowUpSuggestions(nextSuggestions, nextContext);
+      } else {
+        closeSuggestions();
+      }
+
       requestAnimationFrame(() => {
         inputRef.current?.focus();
-        const cursorTarget = context.startOffset + range.start + insertText.length;
         inputRef.current?.setSelectionRange(cursorTarget, cursorTarget);
         isInteractingWithSuggestionsRef.current = false;
         suppressSuggestionsRef.current = false;
       });
-
-      setIsOpen(false);
     };
 
     const scrollHighlightedSuggestionIntoView = useCallback((index: number) => {
@@ -1163,56 +1281,58 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       }
     }, []);
 
+    const highlightSuggestionAtIndex = useCallback(
+      (index: number) => {
+        const suggestion = suggestions[index];
+        highlightedIndexRef.current = index;
+        setHighlightedIndex(index);
+
+        if (!suggestion) {
+          setHighlightedSuggestion(null);
+          setHighlightedValue(undefined);
+          return;
+        }
+
+        setHighlightedSuggestion(suggestion);
+        const cursorPosition = inputRef.current?.selectionStart || 0;
+        const context = getExpressionContext(inputValue, cursorPosition);
+        const value = computeHighlightedValue(suggestion, context);
+        setHighlightedValue(value);
+      },
+      [computeHighlightedValue, getExpressionContext, inputValue, suggestions],
+    );
+
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (!isOpen || suggestions.length === 0) return;
 
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
-          setHighlightedIndex((prev) => {
-            const newIndex = prev < suggestions.length - 1 ? prev + 1 : prev;
-            if (newIndex !== prev && suggestions[newIndex]) {
-              setHighlightedSuggestion(suggestions[newIndex]);
-              const cursorPosition = inputRef.current?.selectionStart || 0;
-              const context = getExpressionContext(inputValue, cursorPosition);
-              const value = computeHighlightedValue(suggestions[newIndex], context);
-              setHighlightedValue(value);
-            }
-            return newIndex;
-          });
+          highlightSuggestionAtIndex(Math.min(highlightedIndexRef.current + 1, suggestions.length - 1));
           break;
         case "ArrowUp":
           e.preventDefault();
-          setHighlightedIndex((prev) => {
-            const newIndex = prev > 0 ? prev - 1 : prev;
-            if (newIndex !== prev && suggestions[newIndex]) {
-              setHighlightedSuggestion(suggestions[newIndex]);
-              const cursorPosition = inputRef.current?.selectionStart || 0;
-              const context = getExpressionContext(inputValue, cursorPosition);
-              const value = computeHighlightedValue(suggestions[newIndex], context);
-              setHighlightedValue(value);
-            }
-            return newIndex;
-          });
+          highlightSuggestionAtIndex(Math.max(highlightedIndexRef.current - 1, 0));
           break;
         case "Enter":
-          if (highlightedIndex >= 0) {
+          if (isKeyboardSuggestionCommit(e.key)) {
             e.preventDefault();
-            handleSuggestionClick(suggestions[highlightedIndex]);
+            e.stopPropagation();
+            isInteractingWithSuggestionsRef.current = true;
+            handleSuggestionClick(suggestions[highlightedIndexRef.current]);
           }
           // Allow default behavior (newline) when no suggestion is highlighted
           break;
         case "Tab":
-          if (highlightedIndex >= 0) {
+          if (isKeyboardSuggestionCommit(e.key)) {
             e.preventDefault();
-            handleSuggestionClick(suggestions[highlightedIndex]);
+            e.stopPropagation();
+            isInteractingWithSuggestionsRef.current = true;
+            handleSuggestionClick(suggestions[highlightedIndexRef.current]);
           }
           break;
         case "Escape":
-          setIsOpen(false);
-          setHighlightedIndex(-1);
-          setHighlightedValue(undefined);
-          setHighlightedSuggestion(null);
+          closeSuggestions();
           break;
       }
     };
@@ -1274,7 +1394,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             onKeyUp={handleCursorChange}
-            onKeyDownCapture={handleCursorChange}
+            onKeyDownCapture={handleKeyDownCapture}
             onClick={handleCursorChange}
             onSelect={handleCursorChange}
             onScroll={handleScroll}
@@ -1375,6 +1495,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
           createPortal(
             <div
               ref={suggestionsRef}
+              data-testid="autocomplete-suggestions"
               className="fixed z-[9999] bg-transparent"
               style={{
                 top: `${dropdownPosition.top}px`,
@@ -1384,6 +1505,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
               <div className="flex flex-col sm:flex-row">
                 {shouldShowValuePreview && isOpen && (
                   <div
+                    data-testid="autocomplete-value-preview"
                     className="border border-gray-200 dark:border-gray-600 sm:border-r-0 sm:border-t p-3 bg-white dark:bg-gray-800 sm:rounded-l-lg sm:rounded-br-none h-fit self-start shadow-lg dark:shadow-gray-950/50"
                     style={{ width: `${valuePreviewWidth}px` }}
                   >
@@ -1598,14 +1720,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
                         }}
                         onMouseEnter={(e) => {
                           e.stopPropagation();
-                          setHighlightedIndex(index);
-                          setHighlightedSuggestion(suggestionItem);
-                          if (exampleObj) {
-                            const cursorPosition = inputRef.current?.selectionStart || 0;
-                            const context = getExpressionContext(inputValue, cursorPosition);
-                            const value = computeHighlightedValue(suggestionItem, context);
-                            setHighlightedValue(value);
-                          }
+                          highlightSuggestionAtIndex(index);
                         }}
                       >
                         <span className="truncate min-w-0">{getSuggestionDisplayLabel(suggestionItem)}</span>


### PR DESCRIPTION
## Summary

- Keep expression autocomplete open when accepting expandable suggestions with Enter or Tab.
- Preserve highlighted suggestions across stable rerenders.
- Add an e2e regression for Manual Run -> HTTP component URL autocomplete, including preview visibility/remount sampling.

## Root Cause

Keyboard selection did not use the same interaction guard as mouse selection, and `onKeyDownCapture` could queue a stale cursor-position sync before the selected suggestion was applied. In the HTTP URL field this could briefly invalidate the expression context and close/reopen the autocomplete preview.

## Validation

- `cd web_src && npm run test -- AutoCompleteInput`
- `make test.e2e.single FILE=test/e2e/canvas_page_test.go LINE=148`
- `make check.lint.ui`
- `make check.build.ui`
- `make format.js`
- `make format.go`
- `git diff --check`
