### PR TITLE
fix: show text selection in Firefox

### DIFF
--- a/web_src/src/App.css
+++ b/web_src/src/App.css
@@ -384,8 +384,8 @@
 
   input:focus::selection,
   textarea:focus::selection {
-    background-color: revert;
-    color: revert;
+    background-color: Highlight;
+    color: HighlightText;
   }
 }
 


### PR DESCRIPTION
## Summary
- Use explicit browser/OS selection colors for focused input and textarea selections
- Fix Firefox rendering selected form text as if it were unselected in component configuration forms

## Root cause
The focused field selection rule used `revert` for the selection background and foreground. Firefox can resolve that reset in a way that leaves the selection highlight invisible in the themed form fields.

## Validation
- `make check.lint.ui`
- `make check.build.ui`

Fixes #6106
