### PR TITLE
feat: add GitHub mark pull request ready for review component

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -44,6 +44,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Get Repository Permission" href="#get-repository-permission" description="Get the role and permission level for a user on a GitHub repository" />
   <LinkCard title="Get Workflow Usage" href="#get-workflow-usage" description="Retrieve billable GitHub Actions usage (minutes) for the organization" />
   <LinkCard title="List Check Runs For Ref" href="#list-check-runs-for-ref" description="List GitHub Checks API check runs for a commit, branch, or tag" />
+  <LinkCard title="Mark Pull Request Ready for Review" href="#mark-pull-request-ready-for-review" description="Take a draft pull request out of the draft state in a GitHub repository" />
   <LinkCard title="Merge Pull Request" href="#merge-pull-request" description="Merge an open pull request in a GitHub repository" />
   <LinkCard title="Publish Commit Status" href="#publish-commit-status" description="Publish a status check to a GitHub commit" />
   <LinkCard title="Remove Issue Assignee" href="#remove-issue-assignee" description="Remove assignees from a GitHub issue" />
@@ -2898,6 +2899,68 @@ Returns GitHub's check run list response, including total_count and check_runs. 
   },
   "timestamp": "2026-06-01T12:02:02Z",
   "type": "github.checkRuns"
+}
+```
+
+<a id="mark-pull-request-ready-for-review"></a>
+
+## Mark Pull Request Ready for Review
+
+**Component key:** `github.markPullRequestReadyForReview`
+
+The Mark Pull Request Ready for Review component takes a draft pull request out of the draft state, the same as clicking "Ready for review" on GitHub.
+
+### Use Cases
+
+- **Promote drafts automatically**: Mark a draft pull request ready once CI checks pass
+- **Release trains**: Open drafts early and promote them for review when the branch is ready
+- **Bot workflows**: Let an automation open work as a draft and hand it to reviewers when complete
+
+### Configuration
+
+- **Repository**: Select the GitHub repository containing the pull request
+- **Pull Request Number**: Pull request number to mark ready for review. Expressions are supported.
+
+### Behavior
+
+This component is idempotent: if the pull request is already out of the draft state, it succeeds without calling GitHub again and emits the pull request as it is.
+
+### Permissions
+
+GitHub only exposes this operation through its GraphQL API, so the integration needs the **Pull Requests: Read & Write** permission.
+
+### Output
+
+Returns the pull request object after it has been marked ready for review.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "base": {
+      "label": "acme:main",
+      "ref": "main"
+    },
+    "created_at": "2026-04-22T10:00:00Z",
+    "draft": false,
+    "head": {
+      "label": "acme:feature-branch",
+      "ref": "feature-branch"
+    },
+    "html_url": "https://github.com/acme/widgets/pull/42",
+    "id": 1234567890,
+    "number": 42,
+    "state": "open",
+    "title": "Add new feature",
+    "user": {
+      "html_url": "https://github.com/octocat",
+      "id": 1,
+      "login": "octocat"
+    }
+  },
+  "timestamp": "2026-04-22T10:00:00.000000000Z",
+  "type": "github.pullRequest"
 }
 ```
 

--- a/pkg/integrations/github/capability_mapper.go
+++ b/pkg/integrations/github/capability_mapper.go
@@ -134,6 +134,7 @@ func NewCapabilityMapper() *CapabilityMapper {
 					{ReadOnly: false, Action: &pulls.AddReaction{}},
 					{ReadOnly: false, Action: &pulls.CreatePullRequest{}},
 					{ReadOnly: false, Action: &pulls.MergePullRequest{}},
+					{ReadOnly: false, Action: &pulls.MarkPullRequestReadyForReview{}},
 					{ReadOnly: false, Action: &pulls.AddPullRequestReviewers{}},
 				},
 			},

--- a/pkg/integrations/github/capability_mapper_test.go
+++ b/pkg/integrations/github/capability_mapper_test.go
@@ -163,6 +163,14 @@ func Test__CapabilityMapper__NewPermissionSet(t *testing.T) {
 		got := ps.ForAppManifest()
 		assert.Equal(t, "write", got["pull_requests"])
 	})
+
+	t.Run("mark pull request ready for review action requests pull request write permission", func(t *testing.T) {
+		t.Parallel()
+
+		ps := m.NewPermissionSet([]string{"github.markPullRequestReadyForReview"})
+		got := ps.ForAppManifest()
+		assert.Equal(t, "write", got["pull_requests"])
+	})
 }
 
 func Test__PermissionSet__IsEmpty(t *testing.T) {

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -168,6 +168,27 @@ func (c *Client) CreatePullRequest(ctx context.Context, repository string, pullR
 	return c.underlying.PullRequests.Create(ctx, c.owner, repository, pullRequest)
 }
 
+func (c *Client) GetPullRequest(ctx context.Context, repository string, pullNumber int) (*github.PullRequest, *github.Response, error) {
+	return c.underlying.PullRequests.Get(ctx, c.owner, repository, pullNumber)
+}
+
+// MarkPullRequestReadyForReview takes a pull request out of the draft state.
+// GitHub exposes this only through the GraphQL API, so it is the one pull
+// request operation that cannot delegate to the REST client. It takes the pull
+// request node ID (github.PullRequest.NodeID), not the pull request number.
+func (c *Client) MarkPullRequestReadyForReview(ctx context.Context, pullRequestID string) error {
+	const mutation = `mutation($pullRequestId: ID!) {
+	  markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
+	    pullRequest {
+	      number
+	      isDraft
+	    }
+	  }
+	}`
+
+	return c.doGraphQL(ctx, mutation, map[string]any{"pullRequestId": pullRequestID})
+}
+
 func (c *Client) MergePullRequest(ctx context.Context, repository string, pullNumber int, commitMessage string, options *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error) {
 	return c.underlying.PullRequests.Merge(ctx, c.owner, repository, pullNumber, commitMessage, options)
 }
@@ -302,6 +323,53 @@ func (c *Client) DeleteHook(ctx context.Context, repository string, hookID int64
 
 func (c *Client) GetOrganizationUsageReport() (*github.UsageReport, *github.Response, error) {
 	return c.underlying.Billing.GetOrganizationUsageReport(context.Background(), c.owner, nil)
+}
+
+type graphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+type graphQLResponse struct {
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// doGraphQL sends a mutation or query to GitHub's GraphQL endpoint, reusing the
+// REST client so that authentication and the HTTP context transport apply.
+// GraphQL reports failures as an `errors` array on an HTTP 200, so those are
+// turned into a regular error here.
+func (c *Client) doGraphQL(ctx context.Context, query string, variables map[string]any) error {
+	request, err := c.underlying.NewRequest(http.MethodPost, "graphql", graphQLRequest{
+		Query:     query,
+		Variables: variables,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build GraphQL request: %w", err)
+	}
+
+	var response graphQLResponse
+	if _, err := c.underlying.Do(ctx, request, &response); err != nil {
+		return err
+	}
+
+	if len(response.Errors) == 0 {
+		return nil
+	}
+
+	messages := []string{}
+	for _, e := range response.Errors {
+		if e.Message != "" {
+			messages = append(messages, e.Message)
+		}
+	}
+
+	if len(messages) == 0 {
+		return errors.New("GraphQL request failed")
+	}
+
+	return errors.New(strings.Join(messages, ": "))
 }
 
 func NewClient(ctx core.IntegrationContext, httpCtx core.HTTPContext) (*Client, error) {

--- a/pkg/integrations/github/components/pulls/example.go
+++ b/pkg/integrations/github/components/pulls/example.go
@@ -31,6 +31,9 @@ var exampleOutputMergePullRequestBytes []byte
 //go:embed payloads/add_pull_request_reviewers.json
 var exampleOutputAddPullRequestReviewersBytes []byte
 
+//go:embed payloads/mark_pull_request_ready_for_review.json
+var exampleOutputMarkPullRequestReadyForReviewBytes []byte
+
 var exampleOutputAddReactionOnce sync.Once
 var exampleOutputAddReaction map[string]any
 
@@ -45,6 +48,9 @@ var exampleOutputMergePullRequest map[string]any
 
 var exampleOutputAddPullRequestReviewersOnce sync.Once
 var exampleOutputAddPullRequestReviewers map[string]any
+
+var exampleOutputMarkPullRequestReadyForReviewOnce sync.Once
+var exampleOutputMarkPullRequestReadyForReview map[string]any
 
 var exampleDataOnPullRequestOnce sync.Once
 var exampleDataOnPullRequest map[string]any
@@ -108,5 +114,13 @@ func (c *AddPullRequestReviewers) ExampleOutput() map[string]any {
 		&exampleOutputAddPullRequestReviewersOnce,
 		exampleOutputAddPullRequestReviewersBytes,
 		&exampleOutputAddPullRequestReviewers,
+	)
+}
+
+func (c *MarkPullRequestReadyForReview) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputMarkPullRequestReadyForReviewOnce,
+		exampleOutputMarkPullRequestReadyForReviewBytes,
+		&exampleOutputMarkPullRequestReadyForReview,
 	)
 }

--- a/pkg/integrations/github/components/pulls/mark_pull_request_ready_for_review.go
+++ b/pkg/integrations/github/components/pulls/mark_pull_request_ready_for_review.go
@@ -1,0 +1,229 @@
+package pulls
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+)
+
+type MarkPullRequestReadyForReview struct{}
+
+type MarkPullRequestReadyForReviewConfiguration struct {
+	Repository string `mapstructure:"repository" json:"repository"`
+	PullNumber any    `mapstructure:"pullNumber" json:"pullNumber"`
+}
+
+type markPullRequestReadyForReviewInput struct {
+	Repository string
+	PullNumber int
+}
+
+func (c *MarkPullRequestReadyForReview) Name() string {
+	return "github.markPullRequestReadyForReview"
+}
+
+func (c *MarkPullRequestReadyForReview) Label() string {
+	return "Mark Pull Request Ready for Review"
+}
+
+func (c *MarkPullRequestReadyForReview) Description() string {
+	return "Take a draft pull request out of the draft state in a GitHub repository"
+}
+
+func (c *MarkPullRequestReadyForReview) Documentation() string {
+	return `The Mark Pull Request Ready for Review component takes a draft pull request out of the draft state, the same as clicking "Ready for review" on GitHub.
+
+## Use Cases
+
+- **Promote drafts automatically**: Mark a draft pull request ready once CI checks pass
+- **Release trains**: Open drafts early and promote them for review when the branch is ready
+- **Bot workflows**: Let an automation open work as a draft and hand it to reviewers when complete
+
+## Configuration
+
+- **Repository**: Select the GitHub repository containing the pull request
+- **Pull Request Number**: Pull request number to mark ready for review. Expressions are supported.
+
+## Behavior
+
+This component is idempotent: if the pull request is already out of the draft state, it succeeds without calling GitHub again and emits the pull request as it is.
+
+## Permissions
+
+GitHub only exposes this operation through its GraphQL API, so the integration needs the **Pull Requests: Read & Write** permission.
+
+## Output
+
+Returns the pull request object after it has been marked ready for review.`
+}
+
+func (c *MarkPullRequestReadyForReview) Icon() string {
+	return "github"
+}
+
+func (c *MarkPullRequestReadyForReview) Color() string {
+	return "gray"
+}
+
+func (c *MarkPullRequestReadyForReview) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *MarkPullRequestReadyForReview) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "pullNumber",
+			Label:       "Pull Request Number",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "42 or {{event.data.pull_request.number}}",
+			Description: "Pull request number to mark ready for review. Supports expressions.",
+		},
+	}
+}
+
+func (c *MarkPullRequestReadyForReview) Setup(ctx core.SetupContext) error {
+	var config MarkPullRequestReadyForReviewConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if err := validateMarkPullRequestReadyForReviewSetup(config); err != nil {
+		return err
+	}
+
+	return common.EnsureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.HTTP,
+		ctx.Configuration,
+	)
+}
+
+func (c *MarkPullRequestReadyForReview) Execute(ctx core.ExecutionContext) error {
+	var config MarkPullRequestReadyForReviewConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	input, err := buildMarkPullRequestReadyForReviewInput(config)
+	if err != nil {
+		return err
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	pullRequest, _, err := client.GetPullRequest(context.Background(), input.Repository, input.PullNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get pull request: %w", explainGitHubError(err))
+	}
+
+	//
+	// Marking an already-ready pull request fails on GitHub's side, so a pull
+	// request that is not a draft is emitted as-is to keep re-runs idempotent.
+	//
+	if pullRequest.GetDraft() {
+		if pullRequest.GetNodeID() == "" {
+			return errors.New("pull request is missing a node ID")
+		}
+
+		err = client.MarkPullRequestReadyForReview(context.Background(), pullRequest.GetNodeID())
+		if err != nil {
+			return fmt.Errorf("failed to mark pull request ready for review: %w", explainGitHubError(err))
+		}
+
+		//
+		// The mutation response does not carry the full REST pull request shape,
+		// so it is re-fetched to emit an up-to-date object.
+		//
+		pullRequest, _, err = client.GetPullRequest(context.Background(), input.Repository, input.PullNumber)
+		if err != nil {
+			return fmt.Errorf("failed to get pull request: %w", explainGitHubError(err))
+		}
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.pullRequest",
+		[]any{pullRequest},
+	)
+}
+
+func (c *MarkPullRequestReadyForReview) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *MarkPullRequestReadyForReview) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *MarkPullRequestReadyForReview) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *MarkPullRequestReadyForReview) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func (c *MarkPullRequestReadyForReview) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *MarkPullRequestReadyForReview) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func validateMarkPullRequestReadyForReviewSetup(config MarkPullRequestReadyForReviewConfiguration) error {
+	if strings.TrimSpace(config.Repository) == "" {
+		return errors.New("repository is required")
+	}
+
+	if pullNumberText(config.PullNumber) == "" {
+		return errors.New("pull request number is required")
+	}
+
+	if common.IsExpression(pullNumberText(config.PullNumber)) {
+		return nil
+	}
+
+	_, err := parsePullNumber(config.PullNumber)
+	return err
+}
+
+func buildMarkPullRequestReadyForReviewInput(config MarkPullRequestReadyForReviewConfiguration) (*markPullRequestReadyForReviewInput, error) {
+	if strings.TrimSpace(config.Repository) == "" {
+		return nil, errors.New("repository is required")
+	}
+
+	pullNumber, err := parsePullNumber(config.PullNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	return &markPullRequestReadyForReviewInput{
+		Repository: strings.TrimSpace(config.Repository),
+		PullNumber: pullNumber,
+	}, nil
+}

--- a/pkg/integrations/github/components/pulls/mark_pull_request_ready_for_review_test.go
+++ b/pkg/integrations/github/components/pulls/mark_pull_request_ready_for_review_test.go
@@ -1,0 +1,303 @@
+package pulls
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
+)
+
+func draftPullRequestResponse() *http.Response {
+	return mocks.GitHubResponse(http.StatusOK, `{
+		"id": 1234567890,
+		"node_id": "PR_kwDOABCD12MAAAABCDEFGH",
+		"number": 42,
+		"title": "Add new feature",
+		"state": "open",
+		"draft": true,
+		"html_url": "https://github.com/testhq/hello/pull/42"
+	}`)
+}
+
+func readyPullRequestResponse() *http.Response {
+	return mocks.GitHubResponse(http.StatusOK, `{
+		"id": 1234567890,
+		"node_id": "PR_kwDOABCD12MAAAABCDEFGH",
+		"number": 42,
+		"title": "Add new feature",
+		"state": "open",
+		"draft": false,
+		"html_url": "https://github.com/testhq/hello/pull/42"
+	}`)
+}
+
+func Test__MarkPullRequestReadyForReview__Setup(t *testing.T) {
+	component := MarkPullRequestReadyForReview{}
+
+	validConfig := func(overrides map[string]any) map[string]any {
+		config := map[string]any{
+			"repository": "hello",
+			"pullNumber": "42",
+		}
+		for key, value := range overrides {
+			config[key] = value
+		}
+		return config
+	}
+
+	t.Run("repository is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"repository": ""}),
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("pull request number is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"pullNumber": ""}),
+		})
+
+		require.ErrorContains(t, err, "pull request number is required")
+	})
+
+	t.Run("literal pull request number must be positive", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"pullNumber": "0"}),
+		})
+
+		require.ErrorContains(t, err, "pull request number must be a positive integer")
+	})
+
+	t.Run("valid configuration is accepted", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Integration:   mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:          httpCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(nil),
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("expression pull request number is accepted at setup", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Integration: mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:        httpCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{
+				"pullNumber": `{{$["github.onPullRequest"].data.pull_request.number}}`,
+			}),
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__MarkPullRequestReadyForReview__Execute(t *testing.T) {
+	component := MarkPullRequestReadyForReview{}
+
+	t.Run("fails when configuration decode fails", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration:  "not a map",
+		})
+
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+
+	t.Run("repository is required", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "",
+				"pullNumber": "42",
+			},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("pull request number must be positive", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "-1",
+			},
+		})
+
+		require.ErrorContains(t, err, "pull request number must be a positive integer")
+	})
+
+	t.Run("marks a draft pull request ready for review", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				draftPullRequestResponse(),
+				mocks.GitHubResponse(http.StatusOK, `{
+					"data": {
+						"markPullRequestReadyForReview": {
+							"pullRequest": {
+								"number": 42,
+								"isDraft": false
+							}
+						}
+					}
+				}`),
+				readyPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+			},
+		})
+
+		require.NoError(t, err)
+		require.True(t, executionState.Passed)
+		require.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		require.Equal(t, "github.pullRequest", executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+		require.Len(t, httpCtx.Requests, 3)
+
+		assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[0].URL.Path)
+
+		mutation := httpCtx.Requests[1]
+		assert.Equal(t, http.MethodPost, mutation.Method)
+		assert.Equal(t, "/graphql", mutation.URL.Path)
+
+		mutationBody := readJSONBody(t, mutation)
+		assert.Contains(t, mutationBody["query"], "markPullRequestReadyForReview")
+		assert.Equal(t, map[string]any{
+			"pullRequestId": "PR_kwDOABCD12MAAAABCDEFGH",
+		}, mutationBody["variables"])
+
+		assert.Equal(t, http.MethodGet, httpCtx.Requests[2].Method)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[2].URL.Path)
+
+		payload := executionState.Payloads[0].(map[string]any)
+		pullRequest := payload["data"].(*github.PullRequest)
+		assert.Equal(t, 42, pullRequest.GetNumber())
+		assert.Equal(t, "Add new feature", pullRequest.GetTitle())
+		assert.False(t, pullRequest.GetDraft())
+	})
+
+	t.Run("pull request that is already ready is emitted without the mutation", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				readyPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+			},
+		})
+
+		require.NoError(t, err)
+		require.True(t, executionState.Passed)
+		require.Equal(t, "github.pullRequest", executionState.Type)
+		require.Len(t, httpCtx.Requests, 1)
+
+		assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[0].URL.Path)
+
+		payload := executionState.Payloads[0].(map[string]any)
+		pullRequest := payload["data"].(*github.PullRequest)
+		assert.False(t, pullRequest.GetDraft())
+	})
+
+	t.Run("fails when the pull request cannot be fetched", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusNotFound, `{"message": "Not Found"}`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+			},
+		})
+
+		require.ErrorContains(t, err, "failed to get pull request")
+		require.ErrorContains(t, err, "Not Found")
+	})
+
+	t.Run("surfaces GraphQL errors returned on a 200 response", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				draftPullRequestResponse(),
+				mocks.GitHubResponse(http.StatusOK, `{
+					"errors": [
+						{"message": "Resource not accessible by integration"}
+					]
+				}`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+			},
+		})
+
+		require.ErrorContains(t, err, "failed to mark pull request ready for review")
+		require.ErrorContains(t, err, "Resource not accessible by integration")
+	})
+}

--- a/pkg/integrations/github/components/pulls/payloads/mark_pull_request_ready_for_review.json
+++ b/pkg/integrations/github/components/pulls/payloads/mark_pull_request_ready_for_review.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "id": 1234567890,
+    "number": 42,
+    "title": "Add new feature",
+    "state": "open",
+    "draft": false,
+    "html_url": "https://github.com/acme/widgets/pull/42",
+    "created_at": "2026-04-22T10:00:00Z",
+    "head": {
+      "ref": "feature-branch",
+      "label": "acme:feature-branch"
+    },
+    "base": {
+      "ref": "main",
+      "label": "acme:main"
+    },
+    "user": {
+      "login": "octocat",
+      "id": 1,
+      "html_url": "https://github.com/octocat"
+    }
+  },
+  "timestamp": "2026-04-22T10:00:00.000000000Z",
+  "type": "github.pullRequest"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -130,6 +130,7 @@ func (g *GitHub) Actions() []core.Action {
 		&pulls.CreateReview{},
 		&pulls.CreatePullRequest{},
 		&pulls.MergePullRequest{},
+		&pulls.MarkPullRequestReadyForReview{},
 		&pulls.AddPullRequestReviewers{},
 		&pulls.AddReaction{},
 		&statuses.GetCombinedCommitStatus{},

--- a/web_src/src/pages/app/mappers/github/index.ts
+++ b/web_src/src/pages/app/mappers/github/index.ts
@@ -26,6 +26,7 @@ import { getRepositoryPermissionMapper } from "./get_repository_permission";
 import { createReviewMapper } from "./create_review";
 import { createPullRequestMapper } from "./create_pull_request";
 import { mergePullRequestMapper } from "./merge_pull_request";
+import { markPullRequestReadyForReviewMapper } from "./mark_pull_request_ready_for_review";
 import { addPullRequestReviewersMapper } from "./add_pull_request_reviewers";
 import { getWorkflowUsageMapper } from "./get_workflow_usage";
 import { labelsMapper } from "./labels";
@@ -44,6 +45,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createReview: buildActionStateRegistry("created"),
   createPullRequest: buildActionStateRegistry("created"),
   mergePullRequest: buildActionStateRegistry("merged"),
+  markPullRequestReadyForReview: buildActionStateRegistry("marked ready"),
   addPullRequestReviewers: buildActionStateRegistry("added"),
   publishCommitStatus: buildActionStateRegistry("published"),
   createDeployment: buildActionStateRegistry("created"),
@@ -72,6 +74,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   createReview: createReviewMapper,
   createPullRequest: createPullRequestMapper,
   mergePullRequest: mergePullRequestMapper,
+  markPullRequestReadyForReview: markPullRequestReadyForReviewMapper,
   addPullRequestReviewers: addPullRequestReviewersMapper,
   runWorkflow: runWorkflowMapper,
   publishCommitStatus: publishCommitStatusMapper,

--- a/web_src/src/pages/app/mappers/github/mark_pull_request_ready_for_review.spec.ts
+++ b/web_src/src/pages/app/mappers/github/mark_pull_request_ready_for_review.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { markPullRequestReadyForReviewMapper } from "./mark_pull_request_ready_for_review";
+
+describe("markPullRequestReadyForReviewMapper", () => {
+  it("shows a curated summary of the pull request that was marked ready", () => {
+    const details = markPullRequestReadyForReviewMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          repository: "hello",
+          pullNumber: "42",
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                number: 42,
+                title: "Add new feature",
+                draft: false,
+                html_url: "https://github.com/testhq/hello/pull/42",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Created At": expect.any(String),
+      Repository: "hello",
+      "Pull Request": "#42",
+      "Pull Request URL": "https://github.com/testhq/hello/pull/42",
+      Title: "Add new feature",
+      "Ready for Review": "Yes",
+    });
+  });
+
+  it("builds the pull request URL from node metadata when the output has none", () => {
+    const details = markPullRequestReadyForReviewMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          repository: "hello",
+          pullNumber: "42",
+        },
+      }),
+    );
+
+    expect(details["Pull Request URL"]).toEqual("https://github.com/testhq/hello/pull/42");
+    expect(details["Ready for Review"]).toEqual("-");
+    expect(details["Title"]).toEqual("-");
+  });
+
+  it("reports a pull request that is still a draft as not ready", () => {
+    const details = markPullRequestReadyForReviewMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: { repository: "hello", pullNumber: "42" },
+        outputs: { default: [{ data: { number: 42, draft: true } }] },
+      }),
+    );
+
+    expect(details["Ready for Review"]).toEqual("No");
+  });
+
+  it("falls back to the pull request number from the output", () => {
+    const details = markPullRequestReadyForReviewMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: { repository: "hello" },
+        outputs: { default: [{ data: { number: 7, draft: false } }] },
+      }),
+    );
+
+    expect(details["Pull Request"]).toEqual("#7");
+    expect(details["Pull Request URL"]).toEqual("https://github.com/testhq/hello/pull/7");
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Mark pull request ready for review",
+    componentName: "github.markPullRequestReadyForReview",
+    isCollapsed: false,
+    metadata: {
+      repository: {
+        id: "123456",
+        name: "hello",
+        url: "https://github.com/testhq/hello",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/github/mark_pull_request_ready_for_review.ts
+++ b/web_src/src/pages/app/mappers/github/mark_pull_request_ready_for_review.ts
@@ -1,0 +1,104 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { stringOrDash } from "../utils";
+import { baseProps } from "./base";
+import type { BaseNodeMetadata } from "./types";
+import { buildGithubExecutionSubtitle } from "./utils";
+
+interface MarkPullRequestReadyForReviewConfiguration {
+  repository?: string;
+  pullNumber?: string | number;
+}
+
+interface PullRequestOutput {
+  number?: number;
+  title?: string;
+  draft?: boolean;
+  html_url?: string;
+}
+
+export const markPullRequestReadyForReviewMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGithubExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const configuration = markPullRequestReadyForReviewConfiguration(context);
+    const pullRequest = markPullRequestReadyForReviewOutput(context);
+    const repositoryURL = repositoryUrl(context);
+    const pullNumber = configuration.pullNumber ?? pullRequest?.number;
+
+    return {
+      "Created At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+      Repository: stringOrDash(configuration.repository || repositoryName(context)),
+      "Pull Request": formatPullRequestNumber(pullNumber),
+      "Pull Request URL": stringOrDash(pullRequest?.html_url || pullRequestUrl(repositoryURL, pullNumber)),
+      Title: stringOrDash(pullRequest?.title),
+      "Ready for Review": formatReadyForReview(pullRequest?.draft),
+    };
+  },
+};
+
+function markPullRequestReadyForReviewConfiguration(
+  context: ExecutionDetailsContext,
+): MarkPullRequestReadyForReviewConfiguration {
+  return (
+    ((context.execution.configuration || context.node.configuration || {}) as
+      | MarkPullRequestReadyForReviewConfiguration
+      | undefined) || {}
+  );
+}
+
+function markPullRequestReadyForReviewOutput(context: ExecutionDetailsContext): PullRequestOutput | undefined {
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  return outputs?.default?.[0]?.data as PullRequestOutput | undefined;
+}
+
+function repositoryName(context: ExecutionDetailsContext): string | undefined {
+  const metadata = context.node.metadata as BaseNodeMetadata | undefined;
+  return metadata?.repository?.name;
+}
+
+function repositoryUrl(context: ExecutionDetailsContext): string | undefined {
+  const metadata = context.node.metadata as BaseNodeMetadata | undefined;
+  return metadata?.repository?.url;
+}
+
+function formatPullRequestNumber(value: string | number | undefined): string {
+  if (value === undefined || value === "") {
+    return "-";
+  }
+
+  const text = String(value);
+  return text.startsWith("#") ? text : `#${text}`;
+}
+
+function pullRequestUrl(
+  repositoryURL: string | undefined,
+  pullNumber: string | number | undefined,
+): string | undefined {
+  if (!repositoryURL || pullNumber === undefined || pullNumber === "") {
+    return undefined;
+  }
+
+  return `${repositoryURL}/pull/${String(pullNumber).replace(/^#/, "")}`;
+}
+
+function formatReadyForReview(draft: boolean | undefined): string {
+  if (draft === undefined) {
+    return "-";
+  }
+
+  return draft ? "No" : "Yes";
+}


### PR DESCRIPTION
## Summary

Adds the github.markPullRequestReadyForReview action, which takes a draft pull request out of the draft state, the same as clicking "Ready for review" on GitHub.

Closes https://github.com/superplanehq/superplane/issues/6112

## Demo

[Screencast from 2026-07-15 11-47-05.webm](https://github.com/user-attachments/assets/a6a26620-53d6-42c2-bf6f-d7f4da02c92f)
