### PR TITLE
fix: ignore stale execution requests

### DIFF
--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -398,6 +398,15 @@ func (e *CanvasNodeExecution) Pass(outputs map[string][]any) ([]CanvasEvent, err
 }
 
 func (e *CanvasNodeExecution) PassInTransaction(tx *gorm.DB, channelOutputs map[string][]any) ([]CanvasEvent, error) {
+	finished, err := e.IsFinished(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if finished {
+		return []CanvasEvent{}, nil
+	}
+
 	now := time.Now()
 
 	//
@@ -456,6 +465,10 @@ func (e *CanvasNodeExecution) PassInTransaction(tx *gorm.DB, channelOutputs map[
 		}).Error
 
 	if err != nil {
+		return nil, err
+	}
+
+	if err := CompletePendingRequestsForExecution(tx, e.ID); err != nil {
 		return nil, err
 	}
 
@@ -519,11 +532,21 @@ func (e *CanvasNodeExecution) EmitOutputsInTransaction(tx *gorm.DB, channelOutpu
 
 func (e *CanvasNodeExecution) Fail(reason, message string) error {
 	return database.Conn().Transaction(func(tx *gorm.DB) error {
-		return e.FailInTransaction(tx, reason, message)
+		_, err := e.FailInTransaction(tx, reason, message)
+		return err
 	})
 }
 
-func (e *CanvasNodeExecution) FailInTransaction(tx *gorm.DB, reason, message string) error {
+func (e *CanvasNodeExecution) FailInTransaction(tx *gorm.DB, reason, message string) (bool, error) {
+	finished, err := e.IsFinished(tx)
+	if err != nil {
+		return false, err
+	}
+
+	if finished {
+		return false, nil
+	}
+
 	now := time.Now()
 
 	e.State = CanvasNodeExecutionStateFinished
@@ -532,7 +555,7 @@ func (e *CanvasNodeExecution) FailInTransaction(tx *gorm.DB, reason, message str
 	e.ResultMessage = message
 	e.UpdatedAt = &now
 
-	err := tx.Model(e).
+	err = tx.Model(e).
 		Updates(map[string]interface{}{
 			"state":          CanvasNodeExecutionStateFinished,
 			"result":         CanvasNodeExecutionResultFailed,
@@ -542,7 +565,7 @@ func (e *CanvasNodeExecution) FailInTransaction(tx *gorm.DB, reason, message str
 		}).Error
 
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	//
@@ -550,17 +573,17 @@ func (e *CanvasNodeExecution) FailInTransaction(tx *gorm.DB, reason, message str
 	//
 	node, err := FindCanvasNode(tx, e.WorkflowID, e.NodeID)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
+		return false, err
 	}
 
 	if node != nil {
 		err := node.UpdateState(tx, CanvasNodeStateReady)
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 
-	return nil
+	return true, CompletePendingRequestsForExecution(tx, e.ID)
 }
 
 func (e *CanvasNodeExecution) Cancel(cancelledBy *uuid.UUID) error {
@@ -568,6 +591,15 @@ func (e *CanvasNodeExecution) Cancel(cancelledBy *uuid.UUID) error {
 }
 
 func (e *CanvasNodeExecution) CancelInTransaction(tx *gorm.DB, cancelledBy *uuid.UUID) error {
+	finished, err := e.IsFinished(tx)
+	if err != nil {
+		return err
+	}
+
+	if finished {
+		return nil
+	}
+
 	now := time.Now()
 
 	e.State = CanvasNodeExecutionStateFinished
@@ -575,7 +607,7 @@ func (e *CanvasNodeExecution) CancelInTransaction(tx *gorm.DB, cancelledBy *uuid
 	e.CancelledBy = cancelledBy
 	e.UpdatedAt = &now
 
-	err := tx.Model(e).
+	err = tx.Model(e).
 		Updates(map[string]interface{}{
 			"state":        CanvasNodeExecutionStateFinished,
 			"result":       CanvasNodeExecutionResultCancelled,
@@ -599,7 +631,7 @@ func (e *CanvasNodeExecution) CancelInTransaction(tx *gorm.DB, cancelledBy *uuid
 		}
 	}
 
-	return nil
+	return CompletePendingRequestsForExecution(tx, e.ID)
 }
 
 func (e *CanvasNodeExecution) GetInput(tx *gorm.DB) (any, error) {
@@ -637,6 +669,20 @@ func (e *CanvasNodeExecution) GetOutputsInTransaction(tx *gorm.DB) ([]CanvasEven
 	}
 
 	return events, nil
+}
+
+func (e *CanvasNodeExecution) IsFinished(tx *gorm.DB) (bool, error) {
+	var execution CanvasNodeExecution
+	err := tx.
+		Select("state").
+		Where("id = ?", e.ID).
+		First(&execution).
+		Error
+	if err != nil {
+		return false, err
+	}
+
+	return execution.State == CanvasNodeExecutionStateFinished, nil
 }
 
 func ListCanvasEventsForExecutionsInTransaction(tx *gorm.DB, executionIDs []uuid.UUID) ([]CanvasEvent, error) {

--- a/pkg/models/canvas_node_execution_test.go
+++ b/pkg/models/canvas_node_execution_test.go
@@ -1,0 +1,123 @@
+package models_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+func Test__CanvasNodeExecution_PassCompletesPendingRequests(t *testing.T) {
+	_, execution := setupRunWithExecution(t)
+
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  execution.WorkflowID,
+		NodeID:      execution.NodeID,
+		ExecutionID: &execution.ID,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "poll",
+				Parameters: map[string]any{},
+			},
+		}),
+		State: models.NodeExecutionRequestStatePending,
+		RunAt: time.Now().Add(time.Hour),
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	_, err := execution.Pass(map[string][]any{})
+	require.NoError(t, err)
+
+	pending, err := models.CountPendingRequestsForExecutionsInTransaction(database.Conn(), []uuid.UUID{execution.ID})
+	require.NoError(t, err)
+	assert.Zero(t, pending)
+
+	var updatedRequest models.CanvasNodeRequest
+	require.NoError(t, database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error)
+	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
+}
+
+func Test__CanvasNodeExecution_PassIsNoopAfterFinished(t *testing.T) {
+	_, execution := setupRunWithExecution(t)
+
+	_, err := execution.Pass(map[string][]any{"default": {map[string]any{"n": 1}}})
+	require.NoError(t, err)
+
+	finishedAt := time.Now().Add(-10 * time.Minute)
+	require.NoError(t, database.Conn().Model(execution).Update("updated_at", finishedAt).Error)
+	execution.UpdatedAt = &finishedAt
+
+	eventsBefore, err := execution.GetOutputs()
+	require.NoError(t, err)
+
+	events, err := execution.Pass(map[string][]any{"default": {map[string]any{"n": 2}}})
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	var updatedExecution models.CanvasNodeExecution
+	require.NoError(t, database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error)
+	require.NotNil(t, updatedExecution.UpdatedAt)
+	assert.WithinDuration(t, finishedAt, *updatedExecution.UpdatedAt, time.Second)
+
+	eventsAfter, err := execution.GetOutputs()
+	require.NoError(t, err)
+	assert.Len(t, eventsAfter, len(eventsBefore))
+}
+
+func Test__CanvasNodeExecution_PassIsNoopWhenPersistedExecutionIsFinished(t *testing.T) {
+	_, execution := setupRunWithExecution(t)
+	staleExecution := *execution
+
+	finishedAt := time.Now().Add(-10 * time.Minute)
+	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
+		"state":      models.CanvasNodeExecutionStateFinished,
+		"result":     models.CanvasNodeExecutionResultPassed,
+		"updated_at": finishedAt,
+	}).Error)
+
+	events, err := staleExecution.Pass(map[string][]any{"default": {map[string]any{"n": 1}}})
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	var updatedExecution models.CanvasNodeExecution
+	require.NoError(t, database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error)
+	require.NotNil(t, updatedExecution.UpdatedAt)
+	assert.WithinDuration(t, finishedAt, *updatedExecution.UpdatedAt, time.Second)
+
+	eventsAfter, err := staleExecution.GetOutputs()
+	require.NoError(t, err)
+	assert.Empty(t, eventsAfter)
+}
+
+func Test__CanvasNodeExecution_PassRetriesAfterRolledBackTransaction(t *testing.T) {
+	_, execution := setupRunWithExecution(t)
+
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		_, err := execution.PassInTransaction(tx, map[string][]any{})
+		require.NoError(t, err)
+		return errors.New("force rollback")
+	})
+	require.Error(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, execution.State)
+
+	var rolledBackExecution models.CanvasNodeExecution
+	require.NoError(t, database.Conn().Where("id = ?", execution.ID).First(&rolledBackExecution).Error)
+	require.Equal(t, models.CanvasNodeExecutionStatePending, rolledBackExecution.State)
+
+	_, err = execution.Pass(map[string][]any{})
+	require.NoError(t, err)
+
+	var updatedExecution models.CanvasNodeExecution
+	require.NoError(t, database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultPassed, updatedExecution.Result)
+}

--- a/pkg/models/canvas_node_request.go
+++ b/pkg/models/canvas_node_request.go
@@ -116,6 +116,31 @@ func (r *CanvasNodeRequest) Complete(tx *gorm.DB) error {
 		Error
 }
 
+func CompletePendingRequestsForExecution(tx *gorm.DB, executionID uuid.UUID) error {
+	var ids []uuid.UUID
+	err := tx.Model(&CanvasNodeRequest{}).
+		Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
+		Where("execution_id = ?", executionID).
+		Where("state = ?", NodeExecutionRequestStatePending).
+		Pluck("id", &ids).
+		Error
+	if err != nil {
+		return err
+	}
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	return tx.Model(&CanvasNodeRequest{}).
+		Where("id IN ?", ids).
+		Updates(map[string]any{
+			"state":      NodeExecutionRequestStateCompleted,
+			"updated_at": time.Now(),
+		}).
+		Error
+}
+
 func CountPendingRequestsForExecutionsInTransaction(tx *gorm.DB, executionIDs []uuid.UUID) (int64, error) {
 	if len(executionIDs) == 0 {
 		return 0, nil

--- a/pkg/workers/contexts/execution_request_context.go
+++ b/pkg/workers/contexts/execution_request_context.go
@@ -22,6 +22,15 @@ func (c *ExecutionRequestContext) ScheduleActionCall(actionName string, paramete
 		return fmt.Errorf("interval must be bigger than 1s")
 	}
 
+	finished, err := c.execution.IsFinished(c.tx)
+	if err != nil {
+		return err
+	}
+
+	if finished {
+		return nil
+	}
+
 	runAt := time.Now().Add(interval)
 	return c.execution.CreateRequest(c.tx, models.NodeRequestTypeInvokeAction, models.NodeExecutionRequestSpec{
 		InvokeAction: &models.InvokeAction{

--- a/pkg/workers/contexts/execution_request_context_test.go
+++ b/pkg/workers/contexts/execution_request_context_test.go
@@ -1,0 +1,50 @@
+package contexts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+)
+
+func Test__ExecutionRequestContext_DoesNotScheduleRequestWhenPersistedExecutionIsFinished(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, componentNode, "default", nil)
+	execution := support.CreateNodeExecutionWithConfiguration(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID, map[string]any{})
+	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
+		"state":      models.CanvasNodeExecutionStateFinished,
+		"result":     models.CanvasNodeExecutionResultPassed,
+		"updated_at": time.Now(),
+	}).Error)
+
+	ctx := NewExecutionRequestContext(database.Conn(), execution)
+	err := ctx.ScheduleActionCall("poll", map[string]any{}, time.Second)
+	require.NoError(t, err)
+
+	pending, err := models.CountPendingRequestsForExecutionsInTransaction(database.Conn(), []uuid.UUID{execution.ID})
+	require.NoError(t, err)
+	assert.Zero(t, pending)
+}

--- a/pkg/workers/contexts/execution_state_context.go
+++ b/pkg/workers/contexts/execution_state_context.go
@@ -130,11 +130,12 @@ func (s *ExecutionStateContext) EmitAndContinue(channel, payloadType string, pay
 }
 
 func (s *ExecutionStateContext) Fail(reason, message string) error {
-	if err := s.execution.FailInTransaction(s.tx, reason, message); err != nil {
+	failed, err := s.execution.FailInTransaction(s.tx, reason, message)
+	if err != nil {
 		return err
 	}
 
-	if reason == models.CanvasNodeExecutionResultReasonError {
+	if failed && reason == models.CanvasNodeExecutionResultReasonError {
 		DispatchOnError(s.tx, s.execution, s.onNewEvents)
 	}
 

--- a/pkg/workers/contexts/on_error_dispatch_test.go
+++ b/pkg/workers/contexts/on_error_dispatch_test.go
@@ -130,6 +130,29 @@ func Test__DispatchOnError(t *testing.T) {
 
 		assert.Empty(t, newEvents)
 	})
+
+	t.Run("does not emit when execution was already finished", func(t *testing.T) {
+		newEvents := []models.CanvasEvent{}
+		onNewEvents := func(events []models.CanvasEvent) {
+			newEvents = append(newEvents, events...)
+		}
+
+		rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNodeID, "default", nil)
+		execution := support.CreateCanvasNodeExecution(t, canvas.ID, componentNodeID, rootEvent.ID, rootEvent.ID)
+		require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
+			"state":  models.CanvasNodeExecutionStateFinished,
+			"result": models.CanvasNodeExecutionResultPassed,
+		}).Error)
+
+		ctx := NewExecutionStateContext(database.Conn(), execution, onNewEvents)
+		require.NoError(t, ctx.Fail(models.CanvasNodeExecutionResultReasonError, "late failure"))
+
+		assert.Empty(t, newEvents)
+
+		var updatedExecution models.CanvasNodeExecution
+		require.NoError(t, database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error)
+		assert.Equal(t, models.CanvasNodeExecutionResultPassed, updatedExecution.Result)
+	})
 }
 
 func Test__DispatchOnError__NoOnErrorNodes(t *testing.T) {

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -306,6 +306,11 @@ func (w *NodeRequestWorker) invokeComponentHook(logger *log.Entry, tx *gorm.DB, 
 		return fmt.Errorf("execution %s not found: %w", request.ExecutionID, err)
 	}
 
+	if execution.State == models.CanvasNodeExecutionStateFinished {
+		logger.Infof("Execution %s already finished - completing request", execution.ID)
+		return request.Complete(tx)
+	}
+
 	return w.invokeExecutionComponentHook(logger, tx, request, execution, onNewEvents)
 }
 
@@ -381,6 +386,16 @@ func (w *NodeRequestWorker) invokeExecutionComponentHook(
 	}
 
 	logger.Infof("Component execution hook completed")
+	finished, err := execution.IsFinished(tx)
+	if err != nil {
+		return err
+	}
+
+	if finished {
+		logger.Infof("Execution %s already finished after hook - completing request", execution.ID)
+		return request.Complete(tx)
+	}
+
 	err = tx.Save(&execution).Error
 	if err != nil {
 		return fmt.Errorf("error saving execution after action handler: %v", err)

--- a/pkg/workers/node_request_worker_test.go
+++ b/pkg/workers/node_request_worker_test.go
@@ -3,6 +3,7 @@ package workers
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -656,6 +657,154 @@ func Test__NodeRequestWorker_CancelsExecutionForDeletedNodeRequests(t *testing.T
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
 	assert.Equal(t, models.CanvasNodeExecutionResultCancelled, updatedExecution.Result)
+}
+
+func Test__NodeRequestWorker_CompletesRequestForFinishedExecutionWithoutInvokingHook(t *testing.T) {
+	hookCalled := false
+	componentName := "finished_execution_request_" + uuid.New().String()
+	registry.RegisterAction(componentName, impl.NewDummyAction(impl.DummyActionOptions{
+		Name:  componentName,
+		Hooks: []core.Hook{{Name: "poll", Type: core.HookTypeInternal}},
+		HandleHookFunc: func(ctx core.ActionHookContext) error {
+			hookCalled = true
+			return nil
+		},
+	}))
+
+	r := support.Setup(t)
+	defer r.Close()
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, r.GitProvider, "", r.AuthService)
+
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: componentName}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, componentNode, "default", nil)
+	execution := support.CreateNodeExecutionWithConfiguration(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID, map[string]any{})
+
+	finishedAt := time.Now().Add(-10 * time.Minute)
+	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
+		"state":      models.CanvasNodeExecutionStateFinished,
+		"result":     models.CanvasNodeExecutionResultPassed,
+		"updated_at": finishedAt,
+	}).Error)
+
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		ExecutionID: &execution.ID,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "poll",
+				Parameters: map[string]any{},
+			},
+		}),
+		State: models.NodeExecutionRequestStatePending,
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	err := worker.LockAndProcessRequest(request)
+	require.NoError(t, err)
+
+	assert.False(t, hookCalled)
+
+	var updatedRequest models.CanvasNodeRequest
+	require.NoError(t, database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error)
+	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
+
+	var updatedExecution models.CanvasNodeExecution
+	require.NoError(t, database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error)
+	require.NotNil(t, updatedExecution.UpdatedAt)
+	assert.WithinDuration(t, finishedAt, *updatedExecution.UpdatedAt, time.Second)
+}
+
+func Test__NodeRequestWorker_DoesNotSaveStaleExecutionAfterHookFindsPersistedExecutionFinished(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, r.GitProvider, "", r.AuthService)
+
+	componentName := "stale_execution_after_hook_" + uuid.New().String()
+	var executionID uuid.UUID
+	finishedAt := time.Now().Add(-10 * time.Minute)
+	r.Registry.Actions[componentName] = impl.NewDummyAction(impl.DummyActionOptions{
+		Name:  componentName,
+		Hooks: []core.Hook{{Name: "poll", Type: core.HookTypeInternal}},
+		HandleHookFunc: func(ctx core.ActionHookContext) error {
+			err := database.Conn().Model(&models.CanvasNodeExecution{}).
+				Where("id = ?", executionID).
+				Updates(map[string]any{
+					"state":      models.CanvasNodeExecutionStateFinished,
+					"result":     models.CanvasNodeExecutionResultPassed,
+					"updated_at": finishedAt,
+				}).Error
+			require.NoError(t, err)
+
+			return ctx.ExecutionState.Pass()
+		},
+	})
+
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: componentName}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, componentNode, "default", nil)
+	execution := support.CreateNodeExecutionWithConfiguration(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID, map[string]any{})
+	require.NoError(t, database.Conn().Model(execution).Update("state", models.CanvasNodeExecutionStateStarted).Error)
+	executionID = execution.ID
+
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		ExecutionID: &execution.ID,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "poll",
+				Parameters: map[string]any{},
+			},
+		}),
+		State: models.NodeExecutionRequestStatePending,
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	err := worker.LockAndProcessRequest(request)
+	require.NoError(t, err)
+
+	var updatedExecution models.CanvasNodeExecution
+	require.NoError(t, database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultPassed, updatedExecution.Result)
+	require.NotNil(t, updatedExecution.UpdatedAt)
+	assert.WithinDuration(t, finishedAt, *updatedExecution.UpdatedAt, time.Second)
+
+	var updatedRequest models.CanvasNodeRequest
+	require.NoError(t, database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error)
+	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
 }
 
 func Test__NodeRequestWorker_CancelsExecutionForDeletedNodeWhenComponentCancelFails(t *testing.T) {


### PR DESCRIPTION
## Summary
- make terminal execution completion idempotent so late poll/webhook paths cannot re-emit or move completion timestamps
- complete pending execution-scoped requests when an execution finishes, using SKIP LOCKED to avoid blocking in-flight work
- skip execution-scoped request scheduling and hook invocation once the execution is already finished

## Root cause
Runner poll requests could outlive the execution they were scheduled for. If a webhook or another path had already finished the execution, a later request could still enter the execution hook path and touch the finished execution state, which moved the timestamp surfaced as finished_at.

## Validation
- make format.go
- make lint && make check.build.app
- make db.migrate DB_NAME=superplane_test
- make test PKG_TEST_PACKAGES="./pkg/models ./pkg/workers"
- docker compose -f docker-compose.dev.yml run --rm -e DB_NAME=superplane_test app gotestsum --format short --packages="./pkg/workers/contexts" -- -p 1

Fixes #6126