### PR TITLE
Remove "Pin App" button and Pinned section from homepage

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,108 @@
+# Plan: Remove "Pin App" from Homepage — Keep Only Star
+
+## 1. Summary
+
+The homepage (`/web_src/src/pages/home/`) currently shows two preference buttons on each app card: a **Pin** button (thumbtack icon) and a **Star** button. There is also a "Pinned" section at the top of the page that groups all pinned apps.
+
+The goal is to remove the Pin feature from the homepage UI entirely, leaving only the Star button. The backend API that supports pinning does not need to change; only the frontend presentation layer is affected.
+
+---
+
+## 2. Ordered Implementation Steps
+
+### Step 1 — Remove the Pin button from the card UI (`CanvasCardsGrid.tsx`)
+
+- Delete the `<CanvasPreferenceButton>` block that renders the `Pin` icon (lines 116–124).
+- Remove the `Pin` import from `lucide-react` (line 6).
+- Remove the `onTogglePin` prop from `CanvasCardsGridProps` and `CanvasCardProps` interfaces and from the destructured parameters of both `CanvasCardsGrid` and `CanvasCard`.
+
+### Step 2 — Remove `onTogglePin` from `CanvasFolderSection.tsx`
+
+- Remove `onTogglePin` from `CanvasFolderSectionProps`.
+- Remove it from the destructured parameters of `CanvasFolderSection`.
+- Remove it from the `<CanvasCardsGrid>` JSX props call inside `CanvasFolderSection`.
+
+### Step 3 — Remove the "Pinned" section and `onTogglePin` wiring from the homepage root (`index.tsx`)
+
+- Remove the `Pin` import from `lucide-react` (line 5).
+- Remove the `pinnedCanvases` variable and the entire "Pinned" `<section>` block (lines 140–182).
+- Remove the `onTogglePin` prop from the `Content` component's props interface and destructuring.
+- Remove all three `onTogglePin={onTogglePin}` prop passes to `<CanvasCardsGrid>` / `<CanvasFolderSection>` inside `Content`.
+- Remove the `onTogglePin` callback prop and its associated `updateCanvasPreference.mutate({ canvasId, pinned })` call from `HomePage` (lines 91–92).
+- The `buildFolderedLayout` function contains a guard `if (canvas.isPinned) continue;` that prevented pinned canvases from appearing in the free section. Remove that guard so that formerly-pinned canvases (which may still have `isPinned: true` from the backend) are displayed normally.
+
+### Step 4 — Update `canvasAppPreferencePresentation.ts` (optional simplification, but keeps correctness)
+
+- The `canvasPreferenceRank` and `preferenceTime` functions still reference `isPinned`. Since the "Pinned" section is removed, the ordering between pinned and starred canvases in the remaining sections no longer matters to users. However, leaving the logic in place is harmless and avoids a breaking behavioral change for starred ordering.
+- **Decision:** Leave `canvasAppPreferencePresentation.ts` unchanged for now. The star-based ordering still works correctly. If desired in a future pass, the pin-related branches can be removed from the ranking/time functions.
+
+### Step 5 — Update `types.ts` (optional cleanup)
+
+- `CanvasCardData.isPinned`, `pinnedAt` are used only by the UI layer being removed. They are still populated by `useHomePageCanvasList.ts` from the API response.
+- **Decision:** Leave `types.ts` unchanged for now. The fields are cheap to carry and removing them would require changes to `useHomePageCanvasList.ts` and the spec for `canvasAppPreferencePresentation`. A follow-up cleanup PR can handle this.
+
+### Step 6 — Update tests (`index.spec.tsx`)
+
+- The test `"orders preferred canvases and requests preference updates"` clicks `"Unpin app Z Free Canvas"` and asserts `mutationMocks.updateCanvasPreference` was called with `{ canvasId: "z-free", pinned: false }`. After removing the Pin button, this assertion is invalid.
+- Remove the pin-related click and assertion from that test, keeping the star-related assertion intact.
+- Remove any assertion that looks for a "Pinned" section heading.
+- The test setup data for `pinned: true` on canvas `z-free` can be simplified (or kept as-is since it only affects sorting, which is still exercised).
+
+### Step 7 — Run checks and formatting
+
+```bash
+make format.js
+make check.build.ui
+```
+
+---
+
+## 3. Files That Will Change
+
+| File | Why |
+|------|-----|
+| `web_src/src/pages/home/CanvasCardsGrid.tsx` | Remove Pin button, `onTogglePin` prop, `Pin` import |
+| `web_src/src/pages/home/CanvasFolderSection.tsx` | Remove `onTogglePin` prop pass-through |
+| `web_src/src/pages/home/index.tsx` | Remove Pin import, "Pinned" section, `onTogglePin` wiring, `isPinned` guard in `buildFolderedLayout` |
+| `web_src/src/pages/home/index.spec.tsx` | Update test that asserts Pin button click and "Pinned" section |
+
+**Files that do NOT need to change (out of scope):**
+
+| File | Reason untouched |
+|------|-----------------|
+| `web_src/src/pages/home/types.ts` | Fields kept for forward-compat; no visible behavior |
+| `web_src/src/pages/home/canvasAppPreferencePresentation.ts` | Pin-rank branch is a no-op once no pin section exists; star ordering unaffected |
+| `web_src/src/pages/home/canvasAppPreferencePresentation.spec.ts` | Pinned ordering test still passes (logic unchanged) |
+| `web_src/src/pages/home/useHomePageCanvasList.ts` | Still maps `pinned`/`pinnedAt` from API — harmless |
+| `web_src/src/hooks/useCanvasData.ts` | Backend preference API kept as-is |
+| Backend Go code | No backend changes needed |
+
+---
+
+## 4. How to Verify
+
+### Automated checks
+```bash
+# Format JS/TS code
+make format.js
+
+# Confirm TypeScript compiles and Vite bundle succeeds
+make check.build.ui
+```
+
+### Manual UI check
+1. Start the dev server (`make dev.server`).
+2. Navigate to the homepage (`/`).
+3. Confirm each app card shows only a **Star** button — no thumbtack/pin icon.
+4. Confirm there is no "Pinned" section above the folder/card grid.
+5. Click the Star button on a card and confirm it toggles correctly.
+6. Confirm apps that had `isPinned: true` in the API response are now displayed in the normal grid (not segregated).
+
+---
+
+## 5. Risks / Out-of-Scope Notes
+
+- **Backend data:** The API still stores and returns `pinned`/`pinnedAt` for canvases. Removing the UI button means users can no longer pin, but existing pinned state remains in the database silently. This is acceptable for a UI-only removal. A future backend cleanup task could clear the `pinned` field via migration or API change.
+- **`buildFolderedLayout` guard:** The guard `if (canvas.isPinned) continue` currently hides pinned canvases from the unfiled section (they appear only in the Pinned section). Removing the Pinned section without removing this guard would cause formerly-pinned canvases to disappear. The guard **must** be removed as part of Step 3.
+- **Out of scope:** Removing pin-related fields from the API, protobuf definitions, database models, or any backend logic is explicitly out of scope for this change.
+- **Out of scope:** The `canvasAppPreferencePresentation.ts` sorting logic (which still references `isPinned`) is intentionally left unchanged to avoid scope creep.

--- a/web_src/src/pages/home/CanvasCardsGrid.tsx
+++ b/web_src/src/pages/home/CanvasCardsGrid.tsx
@@ -3,7 +3,7 @@ import type { ComponentsEdge, SuperplaneComponentsNode } from "@/api-client";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Link } from "react-router-dom";
-import { Pin, Star } from "lucide-react";
+import { Star } from "lucide-react";
 import type { ReactNode } from "react";
 import { appPath } from "@/lib/appPaths";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
@@ -27,7 +27,6 @@ interface CanvasCardsGridProps {
   canvasFolders: CanvasFolderData[];
   organizationId: string;
   onEditCanvas: (canvas: CanvasCardData) => void;
-  onTogglePin: (canvasId: string, pinned: boolean) => void;
   onToggleStar: (canvasId: string, starred: boolean) => void;
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
@@ -39,7 +38,6 @@ export function CanvasCardsGrid({
   canvasFolders,
   organizationId,
   onEditCanvas,
-  onTogglePin,
   onToggleStar,
   canUpdateCanvases,
   canDeleteCanvases,
@@ -54,7 +52,6 @@ export function CanvasCardsGrid({
           canvasFolders={canvasFolders}
           organizationId={organizationId}
           onEdit={onEditCanvas}
-          onTogglePin={onTogglePin}
           onToggleStar={onToggleStar}
           canUpdateCanvases={canUpdateCanvases}
           canDeleteCanvases={canDeleteCanvases}
@@ -70,7 +67,6 @@ interface CanvasCardProps {
   canvasFolders: CanvasFolderData[];
   organizationId: string;
   onEdit: (canvas: CanvasCardData) => void;
-  onTogglePin: (canvasId: string, pinned: boolean) => void;
   onToggleStar: (canvasId: string, starred: boolean) => void;
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
@@ -82,7 +78,6 @@ function CanvasCard({
   canvasFolders,
   organizationId,
   onEdit,
-  onTogglePin,
   onToggleStar,
   canUpdateCanvases,
   canDeleteCanvases,
@@ -113,15 +108,6 @@ function CanvasCard({
               </Heading>
             </div>
             <div className="pointer-events-auto flex items-center gap-1">
-              <CanvasPreferenceButton
-                active={Boolean(canvas.isPinned)}
-                activeLabel={`Unpin app ${canvas.name}`}
-                inactiveLabel={`Pin app ${canvas.name}`}
-                activeTooltip="Unpin"
-                inactiveTooltip="Pin"
-                onClick={() => onTogglePin(canvas.id, !canvas.isPinned)}
-                icon={<Pin size={15} className={cn(canvas.isPinned && "fill-current")} aria-hidden />}
-              />
               <CanvasPreferenceButton
                 active={Boolean(canvas.isStarred)}
                 activeLabel={`Unstar app ${canvas.name}`}

--- a/web_src/src/pages/home/CanvasFolderSection.tsx
+++ b/web_src/src/pages/home/CanvasFolderSection.tsx
@@ -28,7 +28,6 @@ interface CanvasFolderSectionProps {
   canvasFolders: CanvasFolderData[];
   organizationId: string;
   onEditCanvas: (canvas: CanvasCardData) => void;
-  onTogglePin: (canvasId: string, pinned: boolean) => void;
   onToggleStar: (canvasId: string, starred: boolean) => void;
   canCreateCanvases: boolean;
   canUpdateCanvases: boolean;
@@ -183,7 +182,6 @@ export function CanvasFolderSection({
   canvasFolders,
   organizationId,
   onEditCanvas,
-  onTogglePin,
   onToggleStar,
   canCreateCanvases,
   canUpdateCanvases,
@@ -283,7 +281,6 @@ export function CanvasFolderSection({
           canvasFolders={canvasFolders}
           organizationId={organizationId}
           onEditCanvas={onEditCanvas}
-          onTogglePin={onTogglePin}
           onToggleStar={onToggleStar}
           canUpdateCanvases={canUpdateCanvases}
           canDeleteCanvases={canDeleteCanvases}

--- a/web_src/src/pages/home/index.spec.tsx
+++ b/web_src/src/pages/home/index.spec.tsx
@@ -361,11 +361,7 @@ describe("HomePage canvas folders", () => {
     const user = userEvent.setup();
     useCanvases.mockReturnValue({
       data: [
-        makeCanvas("z-free", "Z Free Canvas", undefined, {
-          folderId: "folder-1",
-          pinned: true,
-          pinnedAt: "2026-05-06T00:00:00Z",
-        }),
+        makeCanvas("z-free", "Z Free Canvas", "folder-1"),
         makeCanvas("starred", "Starred Canvas", undefined, {
           starred: true,
           starredAt: "2026-05-06T00:00:00Z",
@@ -383,23 +379,14 @@ describe("HomePage canvas folders", () => {
 
     renderHome();
 
-    const pinnedSection = screen.getByRole("heading", { name: "Pinned" }).closest("section")!;
     const deploymentsSection = screen.getByText("Deployments").closest("section")!;
-    expect(pinnedSection).toHaveClass("dark:bg-white/5");
-    expect(within(pinnedSection).getByText("Z Free Canvas")).toBeInTheDocument();
     expect(within(deploymentsSection).getByText("Z Free Canvas")).toBeInTheDocument();
-    expect(
-      within(pinnedSection).getByText("Z Free Canvas").compareDocumentPosition(screen.getByText("A Free Canvas")) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
     expect(
       screen.getByText("Starred Canvas").compareDocumentPosition(screen.getByText("A Free Canvas")) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
-    await user.click(within(pinnedSection).getByLabelText("Unpin app Z Free Canvas"));
     await user.click(screen.getByLabelText("Unstar app Starred Canvas"));
-    expect(mutationMocks.updateCanvasPreference).toHaveBeenCalledWith({ canvasId: "z-free", pinned: false });
     expect(mutationMocks.updateCanvasPreference).toHaveBeenCalledWith({ canvasId: "starred", starred: false });
   });
 

--- a/web_src/src/pages/home/index.tsx
+++ b/web_src/src/pages/home/index.tsx
@@ -2,7 +2,7 @@ import { usePermissions } from "@/contexts/usePermissions";
 import { useUpdateCanvasPreference } from "@/hooks/useCanvasData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
-import { Palette, Pin } from "lucide-react";
+import { Palette } from "lucide-react";
 import { useState } from "react";
 import { Navigate, useParams } from "react-router-dom";
 import { Heading } from "../../components/Heading/heading";
@@ -88,7 +88,6 @@ export function HomePage() {
             organizationId={organizationId}
             searchQuery={searchQuery}
             onEditCanvas={openEdit}
-            onTogglePin={(canvasId, pinned) => updateCanvasPreference.mutate({ canvasId, pinned })}
             onToggleStar={(canvasId, starred) => updateCanvasPreference.mutate({ canvasId, starred })}
             canCreateCanvases={canCreateCanvases}
             canUpdateCanvases={canUpdateCanvases}
@@ -117,7 +116,6 @@ function Content({
   organizationId,
   searchQuery,
   onEditCanvas,
-  onTogglePin,
   onToggleStar,
   canCreateCanvases,
   canUpdateCanvases,
@@ -130,14 +128,12 @@ function Content({
   organizationId: string;
   searchQuery: string;
   onEditCanvas: (canvas: CanvasCardData) => void;
-  onTogglePin: (canvasId: string, pinned: boolean) => void;
   onToggleStar: (canvasId: string, starred: boolean) => void;
   canCreateCanvases: boolean;
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
   permissionsLoading: boolean;
 }) {
-  const pinnedCanvases = preferredFilteredCanvases.filter((canvas) => canvas.isPinned);
   const folderedLayout = buildFolderedLayout(
     preferredFilteredCanvases,
     preferredFilteredCanvases,
@@ -149,38 +145,12 @@ function Content({
     return searchQuery ? <CanvasesSearchEmptyState /> : <CanvasesEmptyState />;
   }
 
-  if (
-    pinnedCanvases.length === 0 &&
-    folderedLayout.visibleFolders.length === 0 &&
-    folderedLayout.unfiledCanvases.length === 0
-  ) {
+  if (folderedLayout.visibleFolders.length === 0 && folderedLayout.unfiledCanvases.length === 0) {
     return searchQuery ? <CanvasesSearchEmptyState /> : <CanvasesEmptyState />;
   }
 
   return (
     <div className="space-y-6">
-      {pinnedCanvases.length > 0 ? (
-        <section className={cn(CANVAS_FOLDER_SECTION_SHELL_CLASS, "bg-white dark:bg-white/5")}>
-          <div className="mb-4 flex items-center gap-2 text-gray-800 dark:text-gray-100">
-            <Pin size={16} className="text-blue-600 dark:text-blue-400" aria-hidden />
-            <Heading level={3} className="mb-0 !text-base font-medium">
-              Pinned
-            </Heading>
-          </div>
-          <CanvasCardsGrid
-            canvases={pinnedCanvases}
-            canvasFolders={canvasFolders}
-            organizationId={organizationId}
-            onEditCanvas={onEditCanvas}
-            onTogglePin={onTogglePin}
-            onToggleStar={onToggleStar}
-            canUpdateCanvases={canUpdateCanvases}
-            canDeleteCanvases={canDeleteCanvases}
-            permissionsLoading={permissionsLoading}
-          />
-        </section>
-      ) : null}
-
       {folderedLayout.visibleFolders.map((folder) => (
         <CanvasFolderSection
           key={folder.id}
@@ -189,7 +159,6 @@ function Content({
           canvasFolders={canvasFolders}
           organizationId={organizationId}
           onEditCanvas={onEditCanvas}
-          onTogglePin={onTogglePin}
           onToggleStar={onToggleStar}
           canCreateCanvases={canCreateCanvases}
           canUpdateCanvases={canUpdateCanvases}
@@ -209,7 +178,6 @@ function Content({
             canvasFolders={canvasFolders}
             organizationId={organizationId}
             onEditCanvas={onEditCanvas}
-            onTogglePin={onTogglePin}
             onToggleStar={onToggleStar}
             canUpdateCanvases={canUpdateCanvases}
             canDeleteCanvases={canDeleteCanvases}
@@ -246,10 +214,6 @@ function buildFolderedLayout(
   for (const canvas of sectionCanvases) {
     if (canvas.canvasFolderId && folderIDs.has(canvas.canvasFolderId)) {
       canvasesByFolderID.get(canvas.canvasFolderId)?.push(canvas);
-      continue;
-    }
-
-    if (canvas.isPinned) {
       continue;
     }
 


### PR DESCRIPTION
Removes the thumbtack Pin button from app cards and the "Pinned" section from the homepage, leaving only the star functionality.

The `onTogglePin` callback and prop are removed from `HomePage` → `Content` → `CanvasFolderSection` → `CanvasCardsGrid` → `CanvasCard`. The "Pinned" section JSX and `pinnedCanvases` filter are dropped from `Content`. Critically, the `if (canvas.isPinned) continue` guard in `buildFolderedLayout` is also removed — without this, apps that still have `isPinned: true` in the backend would silently disappear from the UI. The `Pin` import is cleaned up from both `index.tsx` and `CanvasCardsGrid.tsx`.

Backend data (`pinned`/`pinnedAt` fields) and sorting logic in `canvasAppPreferencePresentation.ts` are intentionally left untouched to keep scope minimal.


<details>
<summary>Full plan</summary>

````md
The plan has been written to `/workspace/superplane/plan.md`. Here's a summary of what I found and documented:

---

## What I Found

The "Pin App" feature spans four files in `web_src/src/pages/home/`:

1. **`CanvasCardsGrid.tsx`** — renders the thumbtack `<Pin>` button on each card alongside the star button
2. **`index.tsx`** — wires the `onTogglePin` callback, renders the **"Pinned" section** at the top of the page, and has a guard in `buildFolderedLayout` that hides pinned canvases from the main grid
3. **`CanvasFolderSection.tsx`** — passes `onTogglePin` through to the grid
4. **`index.spec.tsx`** — has a test that clicks "Unpin app" and asserts on the Pinned section

---

## Key Risks Called Out

- The `buildFolderedLayout` function has an `if (canvas.isPinned) continue` guard that **must be removed** along with the Pinned section — otherwise previously-pinned canvases would vanish from the UI entirely.
- The backend API still stores `pinned`/`pinnedAt`; this is intentionally out of scope.
- `canvasAppPreferencePresentation.ts` sorting logic references `isPinned` but is left unchanged since it's harmless and keeps the scope minimal.
````

</details>

### Fabro Details

<details>
<summary>Ran 5 stages in 8m 5s for $2.17</summary>

| Stage | Duration | Cost | Retries |
|---|---|---|---|
| start | 0s | – | 0 |
| plan | 1m 29s | $0.54 | 0 |
| approve | 47s | – | 0 |
| implement | 3m 39s | $1.28 | 0 |
| verify | 1m 40s | $0.36 | 0 |
| **Total** | **8m 5s** | **$2.17** | **0** |

</details>

<details>
<summary>Ran <code>PlanImplement.fabro</code> (7 nodes and 9 edges)</summary>

```dot
digraph PlanImplement {
    graph [goal="{{ goal }}"]
    rankdir=LR

    start [shape=Mdiamond, label="Start"]
    exit  [shape=Msquare, label="Exit"]

    plan      [label="Plan", max_visits=5, reasoning_effort="high", prompt="@prompts/plan.md"]
    approve   [shape=hexagon, label="Approve Plan"]
    implement [label="Implement", prompt="@prompts/implement.md"]
    verify    [label="Verify", prompt="@prompts/verify.md", output_schema="routing"]
    fix       [label="Fix Failures", max_visits=3, prompt="@prompts/fix.md"]

    start -> plan -> approve
    approve -> implement [label="[A] Approve"]
    approve -> plan      [label="[R] Revise"]
    implement -> verify
    verify -> exit [label="Pass", condition="outcome=succeeded"]
    verify -> fix  [label="Fix", condition="outcome=failed"]
    verify -> fix  [label="Fix"]
    fix -> verify
}

```

</details>

⚒️ Generated with [Fabro](https://fabro.sh)