### PR TITLE
fix: allow longer HTTP timeouts

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -734,6 +734,7 @@ and status without downloading the full response payload.
   - **Form Data**: URL-encoded form data
   - **Plain Text**: Raw text content
   - **XML**: XML formatted content
+- **Timeout**: Request timeout in seconds (default 30, maximum 300)
 
 ### Response Handling
 
@@ -1527,4 +1528,3 @@ The component emits a payload with:
   "type": "wait.finished"
 }
 ```
-

--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -1528,3 +1528,4 @@ The component emits a payload with:
   "type": "wait.finished"
 }
 ```
+

--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -255,7 +255,7 @@ Use these YAML rules by default. Read `app-yaml-spec.md` only when validation ex
 - **HTTP formData**: `[{key: "field", value: "val"}]` — uses `key`/`value`
 - **Memory lists** (matchList, valueList): `[{name: "k", value: "v"}]`
 - **successCodes**: string `"200"` or `"200-299"`
-- **timeoutSeconds**: max 30
+- **timeoutSeconds**: max 300
 - **intervalSeconds**: minimum 1
 - **Integration components**: need `integration: {id: "<uuid>"}` from `superplane_app` action `list_integrations`; integration-resource field values should come from `list_resources`
 

--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -161,6 +161,7 @@ and status without downloading the full response payload.
   - **Form Data**: URL-encoded form data
   - **Plain Text**: Raw text content
   - **XML**: XML formatted content
+- **Timeout**: Request timeout in seconds (default 30, maximum 300)
 
 ## Response Handling
 

--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -26,7 +26,7 @@ const (
 	RetryStrategyFixed       = "fixed"
 	RetryStrategyExponential = "exponential"
 	DefaultTimeout           = time.Second * 30
-	MaxTimeout               = time.Second * 30
+	MaxTimeout               = time.Minute * 5
 	RetryMinInterval         = time.Second * 5
 	RetryMaxInterval         = time.Minute * 5
 	RetryMaxAttempts         = 30
@@ -196,6 +196,16 @@ func (e *HTTP) Setup(ctx core.SetupContext) error {
 
 	if err := validateAuthorizationSpec(spec.Authorization); err != nil {
 		return err
+	}
+
+	if spec.TimeoutSeconds != nil {
+		if *spec.TimeoutSeconds < 1 {
+			return fmt.Errorf("timeout seconds must be greater than or equal to 1")
+		}
+
+		if spec.Timeout() > MaxTimeout {
+			return fmt.Errorf("timeout seconds must be less than or equal to %d", int(MaxTimeout.Seconds()))
+		}
 	}
 
 	if spec.ContentType == nil {

--- a/pkg/components/http/http_test.go
+++ b/pkg/components/http/http_test.go
@@ -232,6 +232,14 @@ func TestHTTP__Setup__ValidConfigurations(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "GET with maximum timeout",
+			config: map[string]any{
+				"method":         "GET",
+				"url":            "https://api.example.com",
+				"timeoutSeconds": int(MaxTimeout.Seconds()),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -259,6 +267,24 @@ func TestHTTP__Setup__ValidationErrors(t *testing.T) {
 			name:      "missing method",
 			config:    map[string]any{"url": "https://api.example.com"},
 			expectErr: "method is required",
+		},
+		{
+			name: "timeout below minimum",
+			config: map[string]any{
+				"method":         "GET",
+				"url":            "https://api.example.com",
+				"timeoutSeconds": 0,
+			},
+			expectErr: "timeout seconds must be greater than or equal to 1",
+		},
+		{
+			name: "timeout above maximum",
+			config: map[string]any{
+				"method":         "GET",
+				"url":            "https://api.example.com",
+				"timeoutSeconds": int(MaxTimeout.Seconds()) + 1,
+			},
+			expectErr: "timeout seconds must be less than or equal to 300",
 		},
 		{
 			name: "JSON contentType without json field",


### PR DESCRIPTION
## Summary

- raise the HTTP component timeout cap from 30 seconds to 300 seconds
- validate configured HTTP timeouts during setup and expose the new maximum in field metadata
- update agent guidance and component docs so generated configs can use the longer limit

## Root cause

The HTTP component used the same 30 second value for both its default timeout and maximum timeout, so slower external APIs could not be configured beyond the default.

## Validation

- `go test ./pkg/components/http`
- `make format.go`
- `make lint && make check.build.app`

Fixes #5774