### PR TITLE
fix: render agent survey questions separately

### DIFF
--- a/web_src/src/components/AgentSidebar/widgets/parser.test.ts
+++ b/web_src/src/components/AgentSidebar/widgets/parser.test.ts
@@ -139,6 +139,60 @@ Oops!
     expect(segments[1].type).toBe("error");
   });
 
+  it("keeps normal multiple-choice survey options together", () => {
+    const segments = parseAgentContent(`:::survey
+Which environment should we deploy to?
+- Staging
+- Production
+- [input]
+:::`);
+
+    expect(segments).toEqual([
+      {
+        type: "survey",
+        questions: [
+          {
+            prompt: "Which environment should we deploy to?",
+            options: ["Staging", "Production"],
+            hasInput: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("treats question-like survey bullet items as separate free-text questions", () => {
+    const segments = parseAgentContent(`:::survey
+**When you tested \`/download-report\`:**
+- Did you first create a PR to trigger the agent and let it finish analyzing?
+- Are you trying to use \`/download-report\` on a PR that never had an agent run on it?
+- Did you wait for the agent to complete before commenting \`/download-report\`?
+:::`);
+
+    expect(segments).toEqual([
+      {
+        type: "survey",
+        questions: [
+          {
+            prompt: "Did you first create a PR to trigger the agent and let it finish analyzing?",
+            options: [],
+            hasInput: true,
+          },
+          {
+            prompt: "Are you trying to use `/download-report` on a PR that never had an agent run on it?",
+            options: [],
+            hasInput: true,
+          },
+          {
+            prompt: "Did you wait for the agent to complete before commenting `/download-report`?",
+            options: [],
+            hasInput: true,
+          },
+        ],
+      },
+    ]);
+  });
+
   it("preserves full markdown bodies inside categorized rubric sections", () => {
     const content = `:::rubric HTTP Monitor Spec
 ## Flow

--- a/web_src/src/components/AgentSidebar/widgets/parser.test.ts
+++ b/web_src/src/components/AgentSidebar/widgets/parser.test.ts
@@ -218,6 +218,32 @@ Choose the question to ask next:
     ]);
   });
 
+  it("treats markdown-emphasized question bullet items as separate free-text questions", () => {
+    const segments = parseAgentContent(`:::survey
+**When you tested \`/download-report\`:**
+- **Did you first create a PR to trigger the agent and let it finish analyzing?**
+- **Did you wait for the agent to complete before commenting \`/download-report\`?**
+:::`);
+
+    expect(segments).toEqual([
+      {
+        type: "survey",
+        questions: [
+          {
+            prompt: "**Did you first create a PR to trigger the agent and let it finish analyzing?**",
+            options: [],
+            hasInput: true,
+          },
+          {
+            prompt: "**Did you wait for the agent to complete before commenting `/download-report`?**",
+            options: [],
+            hasInput: true,
+          },
+        ],
+      },
+    ]);
+  });
+
   it("preserves full markdown bodies inside categorized rubric sections", () => {
     const content = `:::rubric HTTP Monitor Spec
 ## Flow

--- a/web_src/src/components/AgentSidebar/widgets/parser.test.ts
+++ b/web_src/src/components/AgentSidebar/widgets/parser.test.ts
@@ -161,6 +161,31 @@ Which environment should we deploy to?
     ]);
   });
 
+  it("keeps multiple-choice survey question options together", () => {
+    const segments = parseAgentContent(`:::survey
+Choose the question to ask next:
+- Did the agent finish analyzing the PR?
+- Was a report generated for the run?
+- Is the download command being run on the same PR?
+:::`);
+
+    expect(segments).toEqual([
+      {
+        type: "survey",
+        questions: [
+          {
+            prompt: "Choose the question to ask next:",
+            options: [
+              "Did the agent finish analyzing the PR?",
+              "Was a report generated for the run?",
+              "Is the download command being run on the same PR?",
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
   it("treats question-like survey bullet items as separate free-text questions", () => {
     const segments = parseAgentContent(`:::survey
 **When you tested \`/download-report\`:**

--- a/web_src/src/components/AgentSidebar/widgets/parser.ts
+++ b/web_src/src/components/AgentSidebar/widgets/parser.ts
@@ -276,6 +276,17 @@ function parseSurvey(raw: string): SurveySegment {
   let currentOptions: string[] = [];
   let hasInput = false;
 
+  const flushCurrentQuestion = () => {
+    if (!currentPrompt || (!currentOptions.length && !hasInput)) return;
+
+    if (!hasInput && currentOptions.length > 1 && currentOptions.every(isQuestionOption)) {
+      questions.push(...currentOptions.map((prompt) => ({ prompt, options: [], hasInput: true })));
+      return;
+    }
+
+    questions.push({ prompt: currentPrompt, options: currentOptions, hasInput: hasInput || undefined });
+  };
+
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -289,20 +300,20 @@ function parseSurvey(raw: string): SurveySegment {
       }
     } else {
       // New question - flush previous
-      if (currentPrompt && (currentOptions.length || hasInput)) {
-        questions.push({ prompt: currentPrompt, options: currentOptions, hasInput: hasInput || undefined });
-      }
+      flushCurrentQuestion();
       currentPrompt = trimmed;
       currentOptions = [];
       hasInput = false;
     }
   }
   // Flush last question
-  if (currentPrompt && (currentOptions.length || hasInput)) {
-    questions.push({ prompt: currentPrompt, options: currentOptions, hasInput: hasInput || undefined });
-  }
+  flushCurrentQuestion();
 
   return { type: "survey", questions };
+}
+
+function isQuestionOption(option: string): boolean {
+  return option.trim().endsWith("?");
 }
 
 function parseRubric(meta: string, raw: string): RubricSegment {

--- a/web_src/src/components/AgentSidebar/widgets/parser.ts
+++ b/web_src/src/components/AgentSidebar/widgets/parser.ts
@@ -326,7 +326,7 @@ function isContextPrompt(prompt: string): boolean {
 }
 
 function isQuestionOption(option: string): boolean {
-  return option.trim().endsWith("?");
+  return stripMarkdownEmphasis(option).trim().endsWith("?");
 }
 
 function stripMarkdownEmphasis(value: string): string {

--- a/web_src/src/components/AgentSidebar/widgets/parser.ts
+++ b/web_src/src/components/AgentSidebar/widgets/parser.ts
@@ -279,7 +279,7 @@ function parseSurvey(raw: string): SurveySegment {
   const flushCurrentQuestion = () => {
     if (!currentPrompt || (!currentOptions.length && !hasInput)) return;
 
-    if (!hasInput && currentOptions.length > 1 && currentOptions.every(isQuestionOption)) {
+    if (shouldSplitOptionsIntoQuestions(currentPrompt, currentOptions, hasInput)) {
       questions.push(...currentOptions.map((prompt) => ({ prompt, options: [], hasInput: true })));
       return;
     }
@@ -312,8 +312,25 @@ function parseSurvey(raw: string): SurveySegment {
   return { type: "survey", questions };
 }
 
+function shouldSplitOptionsIntoQuestions(prompt: string, options: string[], hasInput: boolean): boolean {
+  if (hasInput || options.length < 2) return false;
+
+  return isContextPrompt(prompt) && options.every(isQuestionOption);
+}
+
+function isContextPrompt(prompt: string): boolean {
+  const text = stripMarkdownEmphasis(prompt).trim();
+  if (!text.endsWith(":") || text.includes("?")) return false;
+
+  return !/^(choose|pick|select)\b/i.test(text);
+}
+
 function isQuestionOption(option: string): boolean {
   return option.trim().endsWith("?");
+}
+
+function stripMarkdownEmphasis(value: string): string {
+  return value.replace(/[*_]+/g, "");
 }
 
 function parseRubric(meta: string, raw: string): RubricSegment {


### PR DESCRIPTION
## Summary

- detect survey blocks where every bullet option is itself a question
- render those bullets as separate free-text questions instead of one multiple-choice question
- add parser regression coverage for the reported screenshot shape and for normal survey options

## Root cause

The agent can emit a `:::survey` block with one contextual prompt followed by several question-shaped bullets. The parser treated every bullet as an option, so the UI displayed separate clarifying questions as choices for one question.

## Validation

- `npm --prefix web_src run test:run -- src/components/AgentSidebar/widgets/parser.test.ts`
- `make format.js`
- `make check.lint.ui`
- `make check.build.ui`

Fixes #5938