### PR TITLE
fix: wrap long JSON viewer values

### DIFF
--- a/web_src/src/App.css
+++ b/web_src/src/App.css
@@ -393,6 +393,12 @@
   display: none !important;
 }
 
+.json-viewer-wrap-values .w-rjv-value {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .dark .json-viewer-hide-types {
   --w-rjv-line-color: #404348;
 }

--- a/web_src/src/lib/jsonViewTheme.ts
+++ b/web_src/src/lib/jsonViewTheme.ts
@@ -37,7 +37,7 @@ export const darkJsonViewStyle: JsonViewStyle = {
   "--w-rjv-info-color": "#6b7280",
 };
 
-export const jsonViewClassName = "json-viewer-hide-types";
+export const jsonViewClassName = "json-viewer-hide-types json-viewer-wrap-values";
 
 export function getJsonViewStyle(theme: "light" | "dark"): CSSProperties {
   return theme === "dark" ? darkJsonViewStyle : lightJsonViewStyle;

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.spec.tsx
@@ -1,10 +1,22 @@
+import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { escapeJsonStringValue } from "./runInspectorJson";
+import { JsonPayload } from "./RunInspectorTimelineCard";
 
 describe("escapeJsonStringValue", () => {
   it("keeps JSON string control characters visible", () => {
     expect(escapeJsonStringValue('first line\nsecond\t"quoted"\\slash')).toBe(
       'first line\\nsecond\\t\\"quoted\\"\\\\slash',
     );
+  });
+});
+
+describe("JsonPayload", () => {
+  it("allows long string values to wrap inside the viewer", () => {
+    const longValue = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=".repeat(4);
+    const { container } = render(<JsonPayload value={{ content: longValue }} jsonViewStyle={{}} collapsed={false} />);
+    const viewer = container.querySelector(".w-json-view-container");
+
+    expect(viewer).toHaveClass("json-viewer-wrap-values");
   });
 });

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
@@ -144,7 +144,9 @@ export function JsonPayload({
               <span aria-hidden className={props.className}>
                 &quot;
               </span>
-              <span {...props}>{escapeJsonStringValue(displayValue)}</span>
+              <span {...props} className={cn(props.className, "wrap-anywhere whitespace-pre-wrap")}>
+                {escapeJsonStringValue(displayValue)}
+              </span>
               <span aria-hidden className={props.className}>
                 &quot;
               </span>


### PR DESCRIPTION
Fixes #6062.

## Summary
- Allow shared JSON viewer values to wrap instead of overflowing their container.
- Apply the same wrapping classes to the run inspector custom JSON string renderer.
- Add coverage that the run inspector JSON payload uses the wrapping viewer class.
<img width="630" height="426" alt="image" src="https://github.com/user-attachments/assets/ec6dc08b-7022-468d-b9c6-f0c6cfd236e1" />
