### PR TITLE
fix: handle agent and account limit errors

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -429,6 +429,50 @@ func TestSendMessage_MapsDeletedSessionBadRequestToUnavailableSession(t *testing
 	assert.ErrorIs(t, err, agents.ErrProviderSessionUnavailable)
 }
 
+func TestSendMessage_MapsPayloadTooLargeToInvalidRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"request payload is too large"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendMessage(context.Background(), "sesn_live", "hi", agents.SendMessageOptions{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrInvalidRequest)
+}
+
+func TestSendMessage_MapsImageSizeLimitErrorToInvalidRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"image content exceeds the model limit"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendMessage(context.Background(), "sesn_live", "hi", agents.SendMessageOptions{
+		Images: []agents.MessageImage{{MediaType: "image/png", Data: "aGVsbG8="}},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrInvalidRequest)
+}
+
+func TestSendMessage_DoesNotMapUnrelatedImageErrorToInvalidRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"image service temporarily unavailable"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendMessage(context.Background(), "sesn_live", "hi", agents.SendMessageOptions{
+		Images: []agents.MessageImage{{MediaType: "image/png", Data: "aGVsbG8="}},
+	})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, agents.ErrInvalidRequest)
+	assert.Contains(t, err.Error(), "anthropic: send message")
+}
+
 func TestSendMessage_DoesNotTreatBadRequestNotFoundMessageAsUnavailableSession(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -131,6 +131,9 @@ func (p *Provider) SendMessage(ctx context.Context, providerSessionID, message s
 		if isProviderSessionUnavailable(err) {
 			return fmt.Errorf("%w: %w", agents.ErrProviderSessionUnavailable, err)
 		}
+		if isRequestSizeLimitError(err) {
+			return fmt.Errorf("%w: %w", agents.ErrInvalidRequest, err)
+		}
 		return fmt.Errorf("anthropic: send message: %w", err)
 	}
 	return nil
@@ -282,6 +285,28 @@ func isProviderSessionUnavailable(err error) bool {
 		strings.Contains(message, "session was deleted") ||
 		strings.Contains(message, "session has been archived") ||
 		strings.Contains(message, "session was archived")
+}
+
+func isRequestSizeLimitError(err error) bool {
+	var apiErr *apiError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.StatusCode == http.StatusRequestEntityTooLarge {
+		return true
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		return false
+	}
+
+	message := strings.ToLower(apiErr.Message)
+	return strings.Contains(message, "too large") ||
+		strings.Contains(message, "request payload") ||
+		strings.Contains(message, "request body") ||
+		strings.Contains(message, "body size") ||
+		strings.Contains(message, "size limit") ||
+		strings.Contains(message, "exceeds the model limit") ||
+		strings.Contains(message, "exceeds maximum")
 }
 
 func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, onEvent func(agents.ProviderEvent) error) error {

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -208,3 +208,4 @@ type ProviderToolSchemaRevisioner interface {
 var ErrSessionAlreadyTerminated = errors.New("agent session already terminated")
 var ErrSessionBusy = errors.New("agent session is still processing")
 var ErrProviderSessionUnavailable = errors.New("provider session is unavailable")
+var ErrInvalidRequest = errors.New("invalid agent request")

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -20,6 +20,7 @@ import (
 )
 
 var ErrSessionForbidden = errors.New("agent session is owned by another user")
+var errProviderSessionRefreshFailed = errors.New("provider session refresh failed")
 
 type Service struct {
 	provider Provider
@@ -47,11 +48,7 @@ func (s *Service) EnsureSession(ctx context.Context, organizationID, userID, can
 		return nil, err
 	}
 	if existing != nil {
-		refreshed, err := s.refreshStaleProviderSession(ctx, existing)
-		if errors.Is(err, ErrSessionBusy) {
-			return existing, nil
-		}
-		return refreshed, err
+		return s.refreshStaleProviderSessionOrExisting(ctx, existing, true)
 	}
 	return s.provisionSession(ctx, organizationID, userID, canvasID)
 }
@@ -286,7 +283,7 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 		return s.handleBusySession(sessionID, organizationID, userID)
 	}
 
-	session, err = s.refreshStaleProviderSession(ctx, session)
+	session, err = s.refreshStaleProviderSessionOrExisting(ctx, session, false)
 	if err != nil {
 		if errors.Is(err, ErrSessionBusy) {
 			return s.handleBusySession(sessionID, organizationID, userID)
@@ -362,7 +359,7 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 
 	messageOptions := resolveSendMessageRequestOptions(options)
 
-	session, err = s.refreshStaleProviderSession(ctx, session)
+	session, err = s.refreshStaleProviderSessionOrExisting(ctx, session, false)
 	if err != nil {
 		if errors.Is(err, ErrSessionBusy) {
 			return nil, s.handleBusySession(sessionID, organizationID, userID)
@@ -374,6 +371,9 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 	if err != nil {
 		if errors.Is(err, ErrSessionBusy) {
 			return nil, s.handleBusySession(sessionID, organizationID, userID)
+		}
+		if errors.Is(err, ErrInvalidRequest) {
+			return nil, fmt.Errorf("forward to provider: %w", err)
 		}
 		if errors.Is(err, ErrProviderSessionUnavailable) {
 			recovered, recoverErr := s.recoverProviderSession(ctx, session)
@@ -489,6 +489,23 @@ func (s *Service) refreshStaleProviderSession(ctx context.Context, session *mode
 	return recovered, nil
 }
 
+func (s *Service) refreshStaleProviderSessionOrExisting(ctx context.Context, session *models.AgentSession, fallbackWhenBusy bool) (*models.AgentSession, error) {
+	refreshed, err := s.refreshStaleProviderSession(ctx, session)
+	if err == nil {
+		return refreshed, nil
+	}
+	if fallbackWhenBusy && errors.Is(err, ErrSessionBusy) {
+		return session, nil
+	}
+	if errors.Is(err, errProviderSessionRefreshFailed) {
+		log.WithError(err).
+			WithField("session_id", session.ID).
+			Warn("failed to refresh stale provider session, using existing session")
+		return session, nil
+	}
+	return nil, err
+}
+
 func (s *Service) recoverProviderSession(ctx context.Context, stale *models.AgentSession) (*models.AgentSession, error) {
 	recovered, _, _, err := s.replaceProviderSession(ctx, stale, false)
 	if err != nil {
@@ -517,7 +534,7 @@ func (s *Service) replaceProviderSession(ctx context.Context, stale *models.Agen
 		Title: sessionTitle(target.organizationID, target.canvasID),
 	})
 	if err != nil {
-		return nil, "", false, fmt.Errorf("create provider session: %w", err)
+		return nil, "", false, fmt.Errorf("%w: create provider session: %w", errProviderSessionRefreshFailed, err)
 	}
 
 	recovered, err := s.installRecoveredProviderSession(stale, upstream.ProviderSessionID, requireStaleToolSchema)

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -356,6 +356,30 @@ func TestService_EnsureSession_ReturnsExistingSessionWhenStaleRefreshRacesWithSt
 	assert.Empty(t, provider.archivedSessions)
 }
 
+func TestService_EnsureSession_ReturnsExistingSessionWhenStaleRefreshProviderCreateFails(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{toolSchemaRevision: "revision-1"}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	provider.toolSchemaRevision = "revision-2"
+	provider.createSessionErr = errors.New("provider create failed")
+
+	refreshed, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, session.ID, refreshed.ID)
+	assert.Equal(t, session.ProviderSessionID, refreshed.ProviderSessionID)
+	assert.Equal(t, "revision-1", refreshed.AgentToolSchemaRevision)
+	assert.Equal(t, 2, provider.createCalled)
+	assert.Empty(t, provider.archivedSessions)
+}
+
 func TestService_EnsureSession_FailsWhenProviderErrors(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
@@ -492,6 +516,26 @@ func TestService_SendMessage_ProviderBusyKeepsSessionStreaming(t *testing.T) {
 	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
 }
 
+func TestService_SendMessage_InvalidRequestLeavesSessionIdle(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{sendErr: agents.ErrInvalidRequest}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "hello", nil)
+	require.ErrorIs(t, err, agents.ErrInvalidRequest)
+	require.Nil(t, persisted)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusIdle, refreshed.Status)
+}
+
 func TestService_SendMessage_RecreatesUnavailableProviderSession(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
@@ -610,6 +654,35 @@ func TestService_SendMessage_RewindsAfterToolSchemaRefreshAndTrimsOldMessages(t 
 	assert.NotEqual(t, originalProviderSessionID, refreshed.ProviderSessionID)
 }
 
+func TestService_SendMessage_UsesExistingProviderSessionWhenStaleRefreshProviderCreateFails(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{toolSchemaRevision: "revision-1"}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	originalProviderSessionID := session.ProviderSessionID
+
+	provider.toolSchemaRevision = "revision-2"
+	provider.createSessionErr = errors.New("provider unavailable")
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "new work", nil)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	require.Len(t, provider.sentSessions, 1)
+	assert.Equal(t, originalProviderSessionID, provider.sentSessions[0])
+	assert.Equal(t, 2, provider.createCalled)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, originalProviderSessionID, refreshed.ProviderSessionID)
+	assert.Equal(t, "revision-1", refreshed.AgentToolSchemaRevision)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
 func TestService_SendMessage_ReturnsBusyWhenRecoveredProviderSessionIsBusy(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
@@ -683,6 +756,34 @@ func TestService_DefineOutcome_ReturnsBusyWhenRecoveredProviderSessionIsBusy(t *
 	require.NoError(t, err)
 	require.Len(t, provider.defineSessions, 2)
 	assert.NotEqual(t, session.ProviderSessionID, refreshed.ProviderSessionID)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
+func TestService_DefineOutcome_UsesExistingProviderSessionWhenStaleRefreshProviderCreateFails(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{toolSchemaRevision: "revision-1"}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	originalProviderSessionID := session.ProviderSessionID
+
+	provider.toolSchemaRevision = "revision-2"
+	provider.createSessionErr = errors.New("provider unavailable")
+
+	err = svc.DefineOutcome(context.Background(), r.Organization.ID, r.User, session.ID, "build", "- done", 1)
+	require.NoError(t, err)
+	require.Len(t, provider.defineSessions, 1)
+	assert.Equal(t, originalProviderSessionID, provider.defineSessions[0])
+	assert.Equal(t, 2, provider.createCalled)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, originalProviderSessionID, refreshed.ProviderSessionID)
+	assert.Equal(t, "revision-1", refreshed.AgentToolSchemaRevision)
 	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
 }
 

--- a/pkg/grpc/actions/agents/send_agent_chat_message.go
+++ b/pkg/grpc/actions/agents/send_agent_chat_message.go
@@ -46,6 +46,9 @@ func SendAgentChatMessage(ctx context.Context, svc AgentsService, orgID, userID 
 		if errors.Is(err, agentservice.ErrSessionBusy) {
 			return nil, grpcerrors.FailedPrecondition(nil, "agent is still processing the previous turn")
 		}
+		if errors.Is(err, agentservice.ErrInvalidRequest) {
+			return nil, grpcerrors.InvalidArgument(err, "invalid agent chat message")
+		}
 		log.WithError(err).WithField("chat_id", chatID).Error("failed to send agent chat message")
 		return nil, grpcerrors.Internal(err, "failed to send agent chat message")
 	}

--- a/pkg/grpc/actions/agents/send_agent_chat_message_test.go
+++ b/pkg/grpc/actions/agents/send_agent_chat_message_test.go
@@ -90,6 +90,22 @@ func TestSendAgentChatMessage_TranslatesBusySession(t *testing.T) {
 	assert.Equal(t, codes.FailedPrecondition, grpcerrors.Code(err))
 }
 
+func TestSendAgentChatMessage_TranslatesInvalidRequest(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	svc := &stubService{
+		sendMessage: func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, string, []agentservice.MessageImage, agentservice.SendMessageRequestOptions) (*models.AgentSessionMessage, error) {
+			return nil, agentservice.ErrInvalidRequest
+		},
+	}
+	_, err := actionsagents.SendAgentChatMessage(context.Background(), svc, r.Organization.ID.String(), r.User.String(), &pb.SendAgentChatMessageRequest{
+		ChatId:  uuid.NewString(),
+		Content: "x",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
+}
+
 func TestSendAgentChatMessage_MapsBuilderMode(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -71,6 +72,8 @@ const (
 	// The size of the stage execution outputs can be up to 4k
 	MaxExecutionOutputsSize = 4 * 1024
 )
+
+var errUsageServiceUnavailable = errors.New("usage service unavailable")
 
 type Server struct {
 	httpServer            *http.Server
@@ -796,7 +799,7 @@ func (s *Server) getOrganizationCreationStatus(w http.ResponseWriter, r *http.Re
 		// the full error chain here.
 		log.WithField("account_id", account.ID.String()).
 			Error("failed to load organization creation status")
-		http.Error(w, "Failed to load organization creation status", http.StatusInternalServerError)
+		writeOrganizationCreationStatusError(w, "Failed to load organization creation status", err)
 		return
 	}
 
@@ -865,6 +868,10 @@ func (s *Server) checkAccountOrganizationCreationLimits(
 		return response, nil
 	}
 
+	if isTransientUsageServiceError(err) {
+		return nil, fmt.Errorf("%w: check account limits: %w", errUsageServiceUnavailable, err)
+	}
+
 	if status.Code(err) != codes.NotFound {
 		return nil, err
 	}
@@ -883,10 +890,31 @@ func (s *Server) checkAccountOrganizationCreationLimits(
 			WithField("account_id", accountID).
 			WithField("grpc_code", status.Code(err).String()).
 			Error("failed to check account limits after lazy provisioning")
+		if isTransientUsageServiceError(err) {
+			return nil, fmt.Errorf("%w: check account limits after lazy provisioning: %w", errUsageServiceUnavailable, err)
+		}
 		return nil, err
 	}
 
 	return response, nil
+}
+
+func isTransientUsageServiceError(err error) bool {
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+func writeOrganizationCreationStatusError(w http.ResponseWriter, fallbackMessage string, err error) {
+	if errors.Is(err, errUsageServiceUnavailable) {
+		http.Error(w, "Usage service unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	http.Error(w, fallbackMessage, http.StatusInternalServerError)
 }
 
 func (s *Server) createOrganization(w http.ResponseWriter, r *http.Request) {
@@ -920,7 +948,7 @@ func (s *Server) createOrganization(w http.ResponseWriter, r *http.Request) {
 		// error with stage-specific structured fields.
 		log.WithField("account_id", account.ID.String()).
 			Error("failed to check organization creation status before creating organization")
-		http.Error(w, "Failed to create organization", http.StatusInternalServerError)
+		writeOrganizationCreationStatusError(w, "Failed to create organization", err)
 		return
 	}
 

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -759,7 +759,7 @@ func Test__GetOrganizationCreationStatus(t *testing.T) {
 		assert.Equal(t, "account organization limit exceeded", data.Message)
 	})
 
-	t.Run("returns 500 with diagnostic context when the usage service is unavailable", func(t *testing.T) {
+	t.Run("returns 503 with diagnostic context when the usage service is unavailable", func(t *testing.T) {
 		require.NoError(t, database.TruncateTables())
 
 		account, err := models.CreateAccount("status-unavailable@example.com", "Status Unavailable")
@@ -801,6 +801,7 @@ func Test__GetOrganizationCreationStatus(t *testing.T) {
 			authCookie: token,
 		})
 
-		require.Equal(t, http.StatusInternalServerError, response.Code)
+		require.Equal(t, http.StatusServiceUnavailable, response.Code)
+		assert.Contains(t, response.Body.String(), "Usage service unavailable")
 	})
 }


### PR DESCRIPTION
Fixes #5830.
Fixes #5891.
Fixes #5905.

## Summary
- Classify Anthropic image/payload client errors as invalid agent requests, map them to gRPC `InvalidArgument`, and keep the local chat session from being marked failed for user-fixable request errors.
- Let stale agent sessions remain accessible when provider session refresh fails during a tool-schema refresh, while still surfacing non-provider refresh failures.
- Map transient usage-service failures from `/account/limits` and organization creation limit checks to HTTP 503 instead of a generic 500, without allowing by default.

## Checks
- `make test PKG_TEST_PACKAGES='./pkg/agents ./pkg/agents/anthropic ./pkg/grpc/actions/agents ./pkg/public'`
- `make format.go`
- `make lint && make check.build.app`