### PR TITLE
feat: canvas auto-focus toggle in zoom toolbar

### DIFF
--- a/web_src/src/components/zoom-slider.spec.tsx
+++ b/web_src/src/components/zoom-slider.spec.tsx
@@ -1,0 +1,65 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@xyflow/react", () => ({
+  Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  useReactFlow: vi.fn(() => ({
+    zoomTo: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    fitView: vi.fn(),
+    getNodes: vi.fn(() => []),
+  })),
+  useStore: vi.fn((selector: (state: { minZoom: number; maxZoom: number }) => unknown) =>
+    selector({ minZoom: 0.1, maxZoom: 1.5 }),
+  ),
+  useViewport: vi.fn(() => ({ zoom: 1, x: 0, y: 0 })),
+  getNodesBounds: vi.fn(() => ({ x: 0, y: 0, width: 0, height: 0 })),
+  getViewportForBounds: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+}));
+
+vi.mock("html-to-image", () => ({
+  toPng: vi.fn(),
+}));
+
+import { ZoomSlider } from "./zoom-slider";
+
+describe("ZoomSlider auto-focus toggle", () => {
+  it("does not render the auto-focus toggle when no callback is provided", () => {
+    const { queryByTestId } = render(<ZoomSlider usePanel={false} />);
+
+    expect(queryByTestId("canvas-auto-focus-toggle")).toBeNull();
+  });
+
+  it("marks the toggle as pressed and labels it for disabling when auto-focus is enabled", () => {
+    const { getByTestId } = render(<ZoomSlider usePanel={false} isAutoFocusEnabled onAutoFocusToggle={vi.fn()} />);
+
+    const button = getByTestId("canvas-auto-focus-toggle");
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    expect(button.getAttribute("aria-label")).toBe("Disable auto-focus on selection");
+  });
+
+  it("marks the toggle as not pressed and labels it for enabling when auto-focus is disabled", () => {
+    const { getByTestId } = render(
+      <ZoomSlider usePanel={false} isAutoFocusEnabled={false} onAutoFocusToggle={vi.fn()} />,
+    );
+
+    const button = getByTestId("canvas-auto-focus-toggle");
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+    expect(button.getAttribute("aria-label")).toBe("Enable auto-focus on selection");
+  });
+
+  it("invokes the callback when clicked", async () => {
+    const onAutoFocusToggle = vi.fn();
+    const user = userEvent.setup();
+    const { getByTestId } = render(
+      <ZoomSlider usePanel={false} isAutoFocusEnabled onAutoFocusToggle={onAutoFocusToggle} />,
+    );
+
+    await user.click(getByTestId("canvas-auto-focus-toggle"));
+
+    expect(onAutoFocusToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web_src/src/components/zoom-slider.tsx
+++ b/web_src/src/components/zoom-slider.tsx
@@ -1,7 +1,18 @@
 "use client";
 
 import React, { memo, useCallback, useEffect } from "react";
-import { Camera, CircleDot, CircleDotDashed, Eye, LayoutDashboard, LayoutGrid, Minus, Plus } from "lucide-react";
+import {
+  Camera,
+  CircleDot,
+  CircleDotDashed,
+  Eye,
+  LayoutDashboard,
+  LayoutGrid,
+  Locate,
+  LocateOff,
+  Minus,
+  Plus,
+} from "lucide-react";
 import { toPng } from "html-to-image";
 
 import {
@@ -56,6 +67,8 @@ export const ZoomSlider = memo(function ZoomSlider({
   onAutoLayoutOnUpdateToggle,
   autoLayoutOnUpdateDisabled,
   autoLayoutOnUpdateDisabledTooltip,
+  isAutoFocusEnabled,
+  onAutoFocusToggle,
   usePanel = true,
   ...props
 }: Omit<PanelProps, "children"> & {
@@ -69,6 +82,8 @@ export const ZoomSlider = memo(function ZoomSlider({
   onAutoLayoutOnUpdateToggle?: () => void;
   autoLayoutOnUpdateDisabled?: boolean;
   autoLayoutOnUpdateDisabledTooltip?: string;
+  isAutoFocusEnabled?: boolean;
+  onAutoFocusToggle?: () => void;
   usePanel?: boolean;
 }) {
   const { zoom } = useViewport();
@@ -283,6 +298,30 @@ export const ZoomSlider = memo(function ZoomSlider({
             </span>
           </TooltipTrigger>
           <TooltipContent>{autoLayoutTooltipMessage}</TooltipContent>
+        </Tooltip>
+      )}
+      {onAutoFocusToggle && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="h-7 w-7"
+              onClick={onAutoFocusToggle}
+              aria-pressed={isAutoFocusEnabled}
+              aria-label={
+                isAutoFocusEnabled ? "Disable auto-focus on selection" : "Enable auto-focus on selection"
+              }
+              data-testid="canvas-auto-focus-toggle"
+            >
+              {isAutoFocusEnabled ? <Locate className="h-3 w-3" /> : <LocateOff className="h-3 w-3" />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {isAutoFocusEnabled
+              ? "Auto-focus is on. Selecting a run or step centers the canvas on it."
+              : "Auto-focus is off. Selecting a run or step keeps the current viewport."}
+          </TooltipContent>
         </Tooltip>
       )}
       {children}

--- a/web_src/src/components/zoom-slider.tsx
+++ b/web_src/src/components/zoom-slider.tsx
@@ -309,9 +309,7 @@ export const ZoomSlider = memo(function ZoomSlider({
               className="h-7 w-7"
               onClick={onAutoFocusToggle}
               aria-pressed={isAutoFocusEnabled}
-              aria-label={
-                isAutoFocusEnabled ? "Disable auto-focus on selection" : "Enable auto-focus on selection"
-              }
+              aria-label={isAutoFocusEnabled ? "Disable auto-focus on selection" : "Enable auto-focus on selection"}
               data-testid="canvas-auto-focus-toggle"
             >
               {isAutoFocusEnabled ? <Locate className="h-3 w-3" /> : <LocateOff className="h-3 w-3" />}

--- a/web_src/src/components/zoom-slider.tsx
+++ b/web_src/src/components/zoom-slider.tsx
@@ -55,6 +55,31 @@ function isScreenshotShortcut(event: KeyboardEvent, screenshotName?: string) {
   return Boolean(screenshotName) && hasPrimaryModifier(event) && event.shiftKey && event.key === "s";
 }
 
+function AutoFocusToggleButton({ enabled, onToggle }: { enabled: boolean; onToggle: () => void }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="h-7 w-7"
+          onClick={onToggle}
+          aria-pressed={enabled}
+          aria-label={enabled ? "Disable auto-focus on selection" : "Enable auto-focus on selection"}
+          data-testid="canvas-auto-focus-toggle"
+        >
+          {enabled ? <Locate className="h-3 w-3" /> : <LocateOff className="h-3 w-3" />}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {enabled
+          ? "Auto-focus is on. Selecting a run or step centers the canvas on it."
+          : "Auto-focus is off. Selecting a run or step keeps the current viewport."}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 export const ZoomSlider = memo(function ZoomSlider({
   className,
   orientation = "horizontal",
@@ -301,26 +326,7 @@ export const ZoomSlider = memo(function ZoomSlider({
         </Tooltip>
       )}
       {onAutoFocusToggle && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="h-7 w-7"
-              onClick={onAutoFocusToggle}
-              aria-pressed={isAutoFocusEnabled}
-              aria-label={isAutoFocusEnabled ? "Disable auto-focus on selection" : "Enable auto-focus on selection"}
-              data-testid="canvas-auto-focus-toggle"
-            >
-              {isAutoFocusEnabled ? <Locate className="h-3 w-3" /> : <LocateOff className="h-3 w-3" />}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {isAutoFocusEnabled
-              ? "Auto-focus is on. Selecting a run or step centers the canvas on it."
-              : "Auto-focus is off. Selecting a run or step keeps the current viewport."}
-          </TooltipContent>
-        </Tooltip>
+        <AutoFocusToggleButton enabled={Boolean(isAutoFocusEnabled)} onToggle={onAutoFocusToggle} />
       )}
       {children}
     </>

--- a/web_src/src/hooks/useCanvasAutoFocusPreference.spec.ts
+++ b/web_src/src/hooks/useCanvasAutoFocusPreference.spec.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CANVAS_AUTO_FOCUS_STORAGE_KEY,
+  readStoredCanvasAutoFocusEnabled,
+  useCanvasAutoFocusPreference,
+} from "./useCanvasAutoFocusPreference";
+
+describe("useCanvasAutoFocusPreference", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to enabled when nothing is stored", () => {
+    const { result } = renderHook(() => useCanvasAutoFocusPreference());
+
+    expect(result.current.isAutoFocusEnabled).toBe(true);
+  });
+
+  it("reads a persisted disabled value on init", () => {
+    window.localStorage.setItem(CANVAS_AUTO_FOCUS_STORAGE_KEY, "false");
+
+    const { result } = renderHook(() => useCanvasAutoFocusPreference());
+
+    expect(result.current.isAutoFocusEnabled).toBe(false);
+  });
+
+  it("reads a persisted enabled value on init", () => {
+    window.localStorage.setItem(CANVAS_AUTO_FOCUS_STORAGE_KEY, "true");
+
+    const { result } = renderHook(() => useCanvasAutoFocusPreference());
+
+    expect(result.current.isAutoFocusEnabled).toBe(true);
+  });
+
+  it("falls back to enabled when the stored value is not JSON", () => {
+    window.localStorage.setItem(CANVAS_AUTO_FOCUS_STORAGE_KEY, "not-json");
+
+    expect(readStoredCanvasAutoFocusEnabled()).toBe(true);
+  });
+
+  it("falls back to enabled when the stored value is not a boolean", () => {
+    window.localStorage.setItem(CANVAS_AUTO_FOCUS_STORAGE_KEY, JSON.stringify("yes"));
+
+    expect(readStoredCanvasAutoFocusEnabled()).toBe(true);
+  });
+
+  it("falls back to enabled when localStorage.getItem throws", () => {
+    const spy = vi.spyOn(window.localStorage.__proto__, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+
+    expect(readStoredCanvasAutoFocusEnabled()).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("toggles and persists the new value", () => {
+    const { result } = renderHook(() => useCanvasAutoFocusPreference());
+
+    act(() => {
+      result.current.handleToggleAutoFocus();
+    });
+
+    expect(result.current.isAutoFocusEnabled).toBe(false);
+    expect(window.localStorage.getItem(CANVAS_AUTO_FOCUS_STORAGE_KEY)).toBe("false");
+
+    act(() => {
+      result.current.handleToggleAutoFocus();
+    });
+
+    expect(result.current.isAutoFocusEnabled).toBe(true);
+    expect(window.localStorage.getItem(CANVAS_AUTO_FOCUS_STORAGE_KEY)).toBe("true");
+  });
+
+  it("keeps state stable when localStorage.setItem throws", () => {
+    const spy = vi.spyOn(window.localStorage.__proto__, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+
+    const { result } = renderHook(() => useCanvasAutoFocusPreference());
+
+    act(() => {
+      result.current.handleToggleAutoFocus();
+    });
+
+    expect(result.current.isAutoFocusEnabled).toBe(false);
+    spy.mockRestore();
+  });
+});

--- a/web_src/src/hooks/useCanvasAutoFocusPreference.ts
+++ b/web_src/src/hooks/useCanvasAutoFocusPreference.ts
@@ -7,13 +7,9 @@ const DEFAULT_ENABLED = true;
 /**
  * Read the persisted auto-focus preference from `localStorage`. The default
  * is `true` so existing users keep the current framing behavior when the
- * value is missing, invalid, or unavailable (SSR, private mode, quota).
+ * value is missing, invalid, or unavailable (private mode, quota).
  */
 export function readStoredCanvasAutoFocusEnabled(): boolean {
-  if (typeof window === "undefined") {
-    return DEFAULT_ENABLED;
-  }
-
   try {
     const stored = window.localStorage.getItem(CANVAS_AUTO_FOCUS_STORAGE_KEY);
     if (stored === null) {
@@ -28,10 +24,6 @@ export function readStoredCanvasAutoFocusEnabled(): boolean {
 }
 
 function persistCanvasAutoFocusEnabled(value: boolean): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-
   try {
     window.localStorage.setItem(CANVAS_AUTO_FOCUS_STORAGE_KEY, JSON.stringify(value));
   } catch {

--- a/web_src/src/hooks/useCanvasAutoFocusPreference.ts
+++ b/web_src/src/hooks/useCanvasAutoFocusPreference.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from "react";
+
+export const CANVAS_AUTO_FOCUS_STORAGE_KEY = "canvas-auto-focus-enabled";
+
+const DEFAULT_ENABLED = true;
+
+/**
+ * Read the persisted auto-focus preference from `localStorage`. The default
+ * is `true` so existing users keep the current framing behavior when the
+ * value is missing, invalid, or unavailable (SSR, private mode, quota).
+ */
+export function readStoredCanvasAutoFocusEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return DEFAULT_ENABLED;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(CANVAS_AUTO_FOCUS_STORAGE_KEY);
+    if (stored === null) {
+      return DEFAULT_ENABLED;
+    }
+
+    const parsed: unknown = JSON.parse(stored);
+    return typeof parsed === "boolean" ? parsed : DEFAULT_ENABLED;
+  } catch {
+    return DEFAULT_ENABLED;
+  }
+}
+
+function persistCanvasAutoFocusEnabled(value: boolean): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(CANVAS_AUTO_FOCUS_STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // Ignore storage failures (private mode, quota, etc.).
+  }
+}
+
+/**
+ * Owns the "auto-focus canvas viewport on run/step selection" preference.
+ * Defaults to enabled, persists on toggle, and exposes a stable callback so
+ * downstream memoized props do not thrash.
+ */
+export function useCanvasAutoFocusPreference(): {
+  isAutoFocusEnabled: boolean;
+  handleToggleAutoFocus: () => void;
+} {
+  const [isAutoFocusEnabled, setIsAutoFocusEnabled] = useState<boolean>(readStoredCanvasAutoFocusEnabled);
+
+  const handleToggleAutoFocus = useCallback(() => {
+    setIsAutoFocusEnabled((prev) => {
+      const next = !prev;
+      persistCanvasAutoFocusEnabled(next);
+      return next;
+    });
+  }, []);
+
+  return { isAutoFocusEnabled, handleToggleAutoFocus };
+}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -130,6 +130,7 @@ import { isRunDetailDismissed, useRunsDetailState } from "./useRunsDetailState";
 import { useComponentIconMap } from "./useComponentIconMap";
 import { useRunSidebarNavigationState } from "./useRunSidebarNavigationState";
 import { useSidebarEventRunLookup } from "@/hooks/useSidebarEventRunLookup";
+import { useCanvasAutoFocusPreference } from "@/hooks/useCanvasAutoFocusPreference";
 import { useSelectedRunCanvas } from "./useSelectedRunCanvas";
 import {
   applyRunInspectionNavigationSearchParams,
@@ -607,6 +608,7 @@ export function AppPage() {
   const isAutoSaveQueued = isPositionAutoSaveQueued || isAnnotationAutoSaveQueued;
   const hasLocalSaveActivity = isCanvasSaveInFlight || isCanvasSaveQueued || isAutoSaveQueued;
   const { handleToggleAutoLayoutOnUpdate, isAutoLayoutOnUpdateEnabled } = useAutoLayoutOnUpdatePreference();
+  const { handleToggleAutoFocus, isAutoFocusEnabled } = useCanvasAutoFocusPreference();
 
   const lastSavedWorkflowSignatureRef = useRef("");
   const lastAppliedVersionSnapshotRef = useRef("");
@@ -4267,6 +4269,8 @@ export function AppPage() {
           discardStaleStagingPending={resetStagingPending}
           autoLayoutOnUpdateDisabled={isReadOnly}
           autoLayoutOnUpdateDisabledTooltip={isReadOnly ? "You don't have permission to edit this canvas." : undefined}
+          isAutoFocusEnabled={isAutoFocusEnabled}
+          onToggleAutoFocus={handleToggleAutoFocus}
           onCancelQueueItem={onCancelQueueItem}
           onCancelExecution={showLiveActivity ? onCancelExecution : undefined}
           getAllHistoryEvents={getAllHistoryEvents}

--- a/web_src/src/ui/CanvasPage/index.autoFocusToggle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.autoFocusToggle.spec.tsx
@@ -1,0 +1,356 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render as testingLibraryRender, waitFor } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+
+const { fitViewMock, getNodesMock, getViewportMock, reactFlowPropsRef, setViewportMock } = vi.hoisted(() => ({
+  fitViewMock: vi.fn().mockResolvedValue(true),
+  getNodesMock: vi.fn<() => Array<{ id: string; position: { x: number; y: number } }>>(() => []),
+  getViewportMock: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+  reactFlowPropsRef: {
+    current: null as null | {
+      nodes?: unknown;
+      onInit?: (instance: { setViewport: (viewport: { x: number; y: number; zoom: number }) => void }) => unknown;
+    },
+  },
+  setViewportMock: vi.fn(),
+}));
+
+vi.mock("@/sentry", () => ({
+  Sentry: {
+    withScope: (callback: (scope: { setTag: typeof vi.fn; setExtra: typeof vi.fn }) => void) =>
+      callback({
+        setTag: vi.fn(),
+        setExtra: vi.fn(),
+      }),
+    captureException: vi.fn(),
+  },
+}));
+
+vi.mock("@xyflow/react", () => ({
+  Background: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ReactFlow: (props: { children?: ReactNode; nodes?: unknown }) => {
+    reactFlowPropsRef.current = props;
+    return <div>{props.children}</div>;
+  },
+  ReactFlowProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ViewportPortal: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  useOnSelectionChange: vi.fn(),
+  useReactFlow: vi.fn(() => ({
+    fitView: fitViewMock,
+    screenToFlowPosition: vi.fn((position) => position),
+    getViewport: getViewportMock,
+    setViewport: setViewportMock,
+    getInternalNode: vi.fn(),
+    zoomTo: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    getNodes: getNodesMock,
+    getZoom: vi.fn(() => 1),
+  })),
+  useStore: vi.fn((selector: (state: { minZoom: number; maxZoom: number }) => unknown) =>
+    selector({ minZoom: 0.1, maxZoom: 1.5 }),
+  ),
+  useViewport: vi.fn(() => ({ zoom: 1, x: 0, y: 0 })),
+}));
+
+vi.mock("../BuildingBlocksSidebar", () => ({
+  BuildingBlocksSidebar: () => null,
+}));
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useEventExecutions: () => ({
+    data: { executions: [] },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("../componentSidebar", () => ({
+  ComponentSidebar: () => <div data-testid="live-node-detail-pane-content" />,
+}));
+
+vi.mock("@/components/CanvasToolSidebar", () => ({
+  CanvasToolSidebar: () => null,
+}));
+
+vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
+  useCanvasToolSidebarState: () => ({
+    canvasId: undefined,
+    organizationId: undefined,
+    isEditing: false,
+    readOnly: false,
+    isToolSidebarOpen: false,
+    showToolSidebarToggle: false,
+    handleToolSidebarToggle: vi.fn(),
+    openToolSidebar: vi.fn(),
+    closeToolSidebar: vi.fn(),
+  }),
+}));
+
+vi.mock("./Header", () => ({
+  Header: () => <header data-testid="canvas-header" />,
+}));
+
+import { CanvasPage } from "./index";
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  return testingLibraryRender(ui, { wrapper: Wrapper });
+}
+
+function selectedRunNodes() {
+  return (reactFlowPropsRef.current?.nodes as Array<{ id: string; selected?: boolean }> | undefined) ?? [];
+}
+
+describe("CanvasPage auto-focus toggle", () => {
+  beforeEach(() => {
+    reactFlowPropsRef.current = null;
+    fitViewMock.mockClear();
+    fitViewMock.mockResolvedValue(true);
+    getNodesMock.mockReset();
+    getNodesMock.mockReturnValue([]);
+    getViewportMock.mockReset();
+    getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
+    setViewportMock.mockClear();
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  it("skips fitView for focus requests when auto-focus is disabled but still selects the node", async () => {
+    const hasFitToViewRef = { current: true };
+    const initialViewport = { x: 10, y: 20, zoom: 0.8 };
+    const viewportRef = { current: initialViewport };
+    const runNode = {
+      id: "run-node-1",
+      position: { x: 0, y: 0 },
+      data: { label: "Run 1", state: "pending", type: "component" },
+    };
+    const focusRequest = { nodeId: "run-node-1", requestId: 42, targetMode: "runs" as const, tab: "latest" as const };
+    getNodesMock.mockReturnValue([runNode]);
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          isRunInspectionMode
+          isAutoFocusEnabled={false}
+          nodes={[runNode]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+          hasFitToViewRef={hasFitToViewRef}
+          viewportRef={viewportRef}
+          focusRequest={focusRequest}
+        />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: setViewportMock });
+    });
+
+    await waitFor(() => {
+      expect(selectedRunNodes().some((node) => node.id === "run-node-1" && node.selected)).toBe(true);
+    });
+
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(viewportRef.current).toEqual(initialViewport);
+  });
+
+  it("skips fitView for run participant fit requests when auto-focus is disabled and consumes the nonce", () => {
+    vi.useFakeTimers();
+    try {
+      const hasFitToViewRef = { current: true };
+      const viewportRef = { current: { x: 0, y: 0, zoom: 1 } };
+      const activeNode = { id: "run-node-1", position: { x: 0, y: 0 } };
+      const renderedNodes = [{ ...activeNode, data: { label: "Run 1", state: "success", type: "component" } }];
+      getNodesMock.mockReturnValue([activeNode]);
+
+      const { rerender } = render(
+        <MemoryRouter>
+          <CanvasPage
+            title="Canvas"
+            headerMode="version-live"
+            isRunInspectionMode
+            isAutoFocusEnabled={false}
+            nodes={renderedNodes}
+            edges={[]}
+            buildingBlocks={[]}
+            isEditing={false}
+            activeCanvasVersionId="live-version"
+            hasFitToViewRef={hasFitToViewRef}
+            viewportRef={viewportRef}
+            fitAllRequest={1}
+            fitAllFocusNodeIds={["run-node-1"]}
+          />
+        </MemoryRouter>,
+      );
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(fitViewMock).not.toHaveBeenCalled();
+
+      // Re-enabling auto-focus later must NOT retroactively fit for the already-consumed nonce.
+      rerender(
+        <MemoryRouter>
+          <CanvasPage
+            title="Canvas"
+            headerMode="version-live"
+            isRunInspectionMode
+            isAutoFocusEnabled
+            nodes={renderedNodes}
+            edges={[]}
+            buildingBlocks={[]}
+            isEditing={false}
+            activeCanvasVersionId="live-version"
+            hasFitToViewRef={hasFitToViewRef}
+            viewportRef={viewportRef}
+            fitAllRequest={1}
+            fitAllFocusNodeIds={["run-node-1"]}
+          />
+        </MemoryRouter>,
+      );
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(fitViewMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fits when a new run participant fit request arrives after auto-focus is re-enabled", () => {
+    vi.useFakeTimers();
+    try {
+      const hasFitToViewRef = { current: true };
+      const viewportRef = { current: { x: 0, y: 0, zoom: 1 } };
+      const activeNode = { id: "run-node-1", position: { x: 0, y: 0 } };
+      const renderedNodes = [{ ...activeNode, data: { label: "Run 1", state: "success", type: "component" } }];
+      getNodesMock.mockReturnValue([activeNode]);
+
+      const { rerender } = render(
+        <MemoryRouter>
+          <CanvasPage
+            title="Canvas"
+            headerMode="version-live"
+            isRunInspectionMode
+            isAutoFocusEnabled={false}
+            nodes={renderedNodes}
+            edges={[]}
+            buildingBlocks={[]}
+            isEditing={false}
+            activeCanvasVersionId="live-version"
+            hasFitToViewRef={hasFitToViewRef}
+            viewportRef={viewportRef}
+            fitAllRequest={1}
+            fitAllFocusNodeIds={["run-node-1"]}
+          />
+        </MemoryRouter>,
+      );
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(fitViewMock).not.toHaveBeenCalled();
+
+      rerender(
+        <MemoryRouter>
+          <CanvasPage
+            title="Canvas"
+            headerMode="version-live"
+            isRunInspectionMode
+            isAutoFocusEnabled
+            nodes={renderedNodes}
+            edges={[]}
+            buildingBlocks={[]}
+            isEditing={false}
+            activeCanvasVersionId="live-version"
+            hasFitToViewRef={hasFitToViewRef}
+            viewportRef={viewportRef}
+            fitAllRequest={2}
+            fitAllFocusNodeIds={["run-node-1"]}
+          />
+        </MemoryRouter>,
+      );
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(fitViewMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fits for focus requests when auto-focus is enabled (default)", async () => {
+    const hasFitToViewRef = { current: true };
+    const initialViewport = { x: 10, y: 20, zoom: 0.8 };
+    const focusedViewport = { x: -120, y: -80, zoom: 1.2 };
+    const viewportRef = { current: initialViewport };
+    const runNode = {
+      id: "run-node-1",
+      position: { x: 0, y: 0 },
+      data: { label: "Run 1", state: "pending", type: "component" },
+    };
+    const focusRequest = { nodeId: "run-node-1", requestId: 3, targetMode: "runs" as const, tab: "latest" as const };
+    getNodesMock.mockReturnValue([runNode]);
+    getViewportMock.mockReturnValue(focusedViewport);
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          isRunInspectionMode
+          nodes={[runNode]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+          hasFitToViewRef={hasFitToViewRef}
+          viewportRef={viewportRef}
+          focusRequest={focusRequest}
+        />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      reactFlowPropsRef.current?.onInit?.({ setViewport: setViewportMock });
+    });
+
+    await waitFor(() => {
+      expect(fitViewMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(viewportRef.current).toEqual(focusedViewport);
+    });
+  });
+});

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -248,6 +248,8 @@ export interface CanvasPageProps {
   onToggleAutoLayoutOnUpdate?: () => void;
   autoLayoutOnUpdateDisabled?: boolean;
   autoLayoutOnUpdateDisabledTooltip?: string;
+  isAutoFocusEnabled?: boolean;
+  onToggleAutoFocus?: () => void;
   canvasStateMode?: "default" | "editing" | "previewing-previous-version";
   /** When true, enables inline rename and app settings in the project switcher. */
   showCanvasSettingsMenu?: boolean;
@@ -1554,6 +1556,8 @@ function CanvasPage(props: CanvasPageProps) {
                   onToggleAutoLayoutOnUpdate={props.onToggleAutoLayoutOnUpdate}
                   autoLayoutOnUpdateDisabled={props.autoLayoutOnUpdateDisabled}
                   autoLayoutOnUpdateDisabledTooltip={props.autoLayoutOnUpdateDisabledTooltip}
+                  isAutoFocusEnabled={props.isAutoFocusEnabled}
+                  onToggleAutoFocus={props.onToggleAutoFocus}
                   readOnly={props.readOnly}
                   logEntries={props.logEntries}
                   focusRequest={props.focusRequest}
@@ -2166,6 +2170,8 @@ function CanvasContent({
   onToggleAutoLayoutOnUpdate,
   autoLayoutOnUpdateDisabled,
   autoLayoutOnUpdateDisabledTooltip,
+  isAutoFocusEnabled = true,
+  onToggleAutoFocus,
   readOnly,
   logEntries = [],
   focusRequest,
@@ -2220,6 +2226,8 @@ function CanvasContent({
   onToggleAutoLayoutOnUpdate?: () => void;
   autoLayoutOnUpdateDisabled?: boolean;
   autoLayoutOnUpdateDisabledTooltip?: string;
+  isAutoFocusEnabled?: boolean;
+  onToggleAutoFocus?: () => void;
   readOnly?: boolean;
   logEntries?: LogEntry[];
   focusRequest?: FocusRequest | null;
@@ -2546,6 +2554,12 @@ function CanvasContent({
         selected: node.id === focusRequest.nodeId,
       })),
     );
+    // Auto-focus toggle: when disabled, still record the focus request as handled
+    // (so re-enabling later does not replay a stale request) and let the sidebar/
+    // selection update above stand, but keep the viewport where the user left it.
+    if (!isAutoFocusEnabled) {
+      return;
+    }
     void fitView({ nodes: [targetNode], duration: 500, ...CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS }).then(
       () => {
         const nextViewport = getViewport();
@@ -2560,6 +2574,7 @@ function CanvasContent({
     getNodes,
     getViewport,
     hasReactFlowInitialized,
+    isAutoFocusEnabled,
     isRunInspectionMode,
     reportZoom,
     runCanvasNodeIdsKey,
@@ -2757,7 +2772,10 @@ function CanvasContent({
     const last = lastFitAllRequestRef.current;
     if (last?.nonce === fitAllRequest && last.runMode === isRunInspectionMode) return;
     if (!hasFitToViewRef.current) return;
+    // Consume the nonce so re-enabling auto-focus later does not retroactively
+    // replay this run's participant fit. The viewport stays where the user is.
     lastFitAllRequestRef.current = { nonce: fitAllRequest, runMode: isRunInspectionMode };
+    if (!isAutoFocusEnabled) return;
     let timeoutId: number | null = null;
     const runFit = (attempt: number) => {
       const focusIds = fitAllFocusNodeIds?.length ? new Set(fitAllFocusNodeIds) : null;
@@ -2799,6 +2817,7 @@ function CanvasContent({
     getNodes,
     getViewport,
     hasFitToViewRef,
+    isAutoFocusEnabled,
     isRunInspectionMode,
     reportZoom,
     viewportRef,
@@ -3295,6 +3314,8 @@ function CanvasContent({
                   autoLayoutOnUpdateDisabledTooltip={
                     isReadOnly ? "You don't have permission to edit this canvas." : autoLayoutOnUpdateDisabledTooltip
                   }
+                  isAutoFocusEnabled={isAutoFocusEnabled}
+                  onAutoFocusToggle={onToggleAutoFocus}
                 >
                   {zoomSliderContent}
                 </ZoomSlider>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a browser-persisted, default-on auto-focus preference to the canvas zoom toolbar. When users turn it off, opening a run and selecting a step from the run inspection list no longer moves the viewport; when on, framing behaves exactly as it does today.

Closes #6104.

## Walkthrough

[canvas_auto_focus_toggle_demo.mp4](https://cursor.com/agents/bc-57c7f651-6272-484d-aff8-f9ec9f8ac099/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcanvas_auto_focus_toggle_demo.mp4)
End-to-end demo: pan/zoom, click a step with auto-focus on (canvas re-centers), toggle off, pan/zoom again, click steps (canvas stays put), toggle back on, click again (canvas re-centers).

Toolbar tooltip states:
[Auto-focus on tooltip](https://cursor.com/agents/bc-57c7f651-6272-484d-aff8-f9ec9f8ac099/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_auto_focus_on_tooltip.webp)
[Auto-focus off tooltip](https://cursor.com/agents/bc-57c7f651-6272-484d-aff8-f9ec9f8ac099/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_auto_focus_off_tooltip.webp)

Auto-focus off — viewport before/after clicking a run step:
[Canvas viewport before step click, auto-focus off](https://cursor.com/agents/bc-57c7f651-6272-484d-aff8-f9ec9f8ac099/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_canvas_pre_click_off.webp)
[Canvas viewport after step click, auto-focus off (unchanged)](https://cursor.com/agents/bc-57c7f651-6272-484d-aff8-f9ec9f8ac099/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_canvas_after_click_off.webp)

Auto-focus re-enabled — canvas re-frames on step selection:
[Canvas re-centered after re-enabling auto-focus](https://cursor.com/agents/bc-57c7f651-6272-484d-aff8-f9ec9f8ac099/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_canvas_recentered_on.webp)

## Scope

- New `useCanvasAutoFocusPreference` hook stores the preference in `localStorage` under `canvas-auto-focus-enabled`, defaulting to enabled and gracefully tolerating unavailable/invalid storage.
- `ZoomSlider` grows an accessible toggle button (`aria-pressed`, `aria-label`, tooltip, `Locate`/`LocateOff` icons) that only renders when a callback is provided, matching the existing snap-to-grid / auto-layout patterns.
- `AppPage` wires the preference into `CanvasPage`, which passes it through to `CanvasContent` and the toolbar.
- `CanvasContent` gates only the two issue-specific automatic `fitView` paths — the run participant frame and the node focus request — while still selecting the target node and consuming the fit request nonce so re-enabling later does not replay stale requests. Initial mount framing, canvas-version refits, edit-mode placeholder pans, explicit zoom controls, and the command-palette search are unchanged.

## Testing

- `web_src/src/hooks/useCanvasAutoFocusPreference.spec.ts` — default-on, persisted read/write, invalid storage fallbacks, safe when `localStorage` throws.
- `web_src/src/components/zoom-slider.spec.tsx` — toggle only renders when connected, correct `aria-pressed`/`aria-label` per state, click invokes the callback.
- `web_src/src/ui/CanvasPage/index.autoFocusToggle.spec.tsx` — disabling auto-focus keeps the viewport still on focus/participant requests, retains node selection, consumes the nonce so re-enabling does not retroactively fit, and a fresh nonce after re-enabling does fit.
- Existing `CanvasPage` run-inspection and participant-fit suites still pass unchanged (144 tests across the CanvasPage / app viewport hooks).
- `make check.lint.ui` and `make check.build.ui` both pass.
- Manual end-to-end verification captured above.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57c7f651-6272-484d-aff8-f9ec9f8ac099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57c7f651-6272-484d-aff8-f9ec9f8ac099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

