### PR TITLE
feat: add structured output to Run Claude Agent and Run Code Agent

### DIFF
--- a/docs/components/Claude.mdx
+++ b/docs/components/Claude.mdx
@@ -251,10 +251,13 @@ The **Run Managed Agent** component uses [Claude Managed Agents](https://platfor
 - **Prompt**: The user message (task) sent to the agent.
 - **Vault IDs** (optional): For MCP tools that need vault-backed credentials.
 - **Keep Session After Run** (optional): By default the session is deleted once the run finishes. Enable this to keep it so you can read the full transcript in the Anthropic Console when debugging. It applies only to runs that finish — a cancelled run is always cleaned up. Kept sessions are never reclaimed automatically, so delete them yourself when you're done.
+- **Structured Output** (optional): A JSON Schema the agent is asked to match in its final message. Managed Agents sessions have no server-enforced equivalent to the Messages API's `output_config.format` used by Text Prompt, so this works by appending instructions to the task asking the agent to include a JSON code block matching the schema, then best-effort parsing it from the final message. Treat the result as best-effort, not a guarantee — validate before relying on it downstream.
 
 ### Output
 
 Emits a finished payload with **session** status, **session id**, and the final **agent message** when available so downstream steps can branch or consume the result. For failure cases the status is still emitted when the **session** is *terminated* or the step times out.
+
+When Structured Output is configured, **parsed** carries the JSON object extracted from the final message — only when the session finished normally (idle), never on a timeout, error, or terminated session.
 
 Files the agent saves under `/mnt/session/outputs/` are emitted as **artifacts** with their content included in the payload (text files as plain text, everything else base64-encoded; files over 10MB carry metadata and a download link only). Instruct the agent in the task to save its deliverables there.
 
@@ -313,9 +316,15 @@ The setting applies only to runs that **finish** — including ones that fail or
 
 Kept sessions and environments are not reclaimed automatically, so delete them yourself once you're done debugging.
 
+### Structured Output
+
+Optional: a JSON Schema the agent is asked to match in its final message, in addition to the PR it opens. Managed Agents sessions have no server-enforced equivalent to the Messages API's `output_config.format` used by Text Prompt, so this works by appending instructions to the task asking the agent to include a JSON code block matching the schema, then best-effort parsing it from the final message. Treat the result as best-effort, not a guarantee — validate before relying on it downstream.
+
 ### Output
 
 Emits the final **status**, the **pull request URL**, the working **branch**, and a **summary** so downstream steps can branch or post the result.
+
+When Structured Output is configured, **parsed** carries the JSON object extracted from the final message — only when the session finished normally (idle), never on a timeout, error, or terminated session.
 
 Files the agent saves under `/mnt/session/outputs/` are additionally emitted as **artifacts** with their content included in the payload (text files as plain text, everything else base64-encoded; files over 10MB carry metadata and a download link only).
 

--- a/pkg/configuration/structuredoutput/structuredoutput.go
+++ b/pkg/configuration/structuredoutput/structuredoutput.go
@@ -14,8 +14,7 @@
 // Messages API's output_config.format — there is no server-side grammar
 // constraint for a Sessions-based run. For those, PromptSuffix and ExtractJSON
 // emulate structured output by asking the model to comply and best-effort
-// parsing its final message; callers should only trust the result on a normal
-// completion, never as a real schema guarantee.
+// parsing its final message
 package structuredoutput
 
 import (

--- a/pkg/configuration/structuredoutput/structuredoutput.go
+++ b/pkg/configuration/structuredoutput/structuredoutput.go
@@ -1,20 +1,12 @@
-// Package structuredoutput lets LLM text-prompt components accept a JSON Schema
-// that describes the desired response. The component shows a default schema the
-// user edits; the backend validates that it is well-formed JSON before the
-// provider request is fired, and normalizes it to the constraints both providers
-// enforce:
+// Package structuredoutput lets LLM components accept a JSON Schema
+// describing the desired response, validating it and normalizing it to the
+// constraints strict-mode providers enforce (every object gets
+// "additionalProperties": false; strict mode also requires listing every
+// property in "required").
 //
-//   - Every object node gets "additionalProperties": false.
-//   - OpenAI strict mode (strict=true) additionally forces every object's
-//     "required" to list all of its properties; optional fields are expressed by
-//     making their type nullable in the schema itself.
-//   - Anthropic (strict=false) leaves "required" as the user wrote it.
-//
-// Agent components (Claude Managed Agents sessions) have no equivalent to the
-// Messages API's output_config.format — there is no server-side grammar
-// constraint for a Sessions-based run. For those, PromptSuffix and ExtractJSON
-// emulate structured output by asking the model to comply and best-effort
-// parsing its final message
+// Some agent-style components have no server-side schema enforcement at all.
+// For those, PromptSuffix and ExtractJSON emulate it by asking the model to
+// comply and best-effort parsing its final message.
 package structuredoutput
 
 import (
@@ -129,9 +121,8 @@ func ValidateAtSetup(raw string) error {
 }
 
 // PromptSuffix renders schema-following instructions to append to an agent's
-// task prompt. There is no output_config.format equivalent for Managed Agents
-// sessions, so this is the only lever: ask the model to emit matching JSON,
-// then extract it with ExtractJSON. Returns "" if schema is nil.
+// task prompt, for components with no server-side schema enforcement to rely
+// on instead. Returns "" if schema is nil.
 func PromptSuffix(schema map[string]any) string {
 	if schema == nil {
 		return ""
@@ -147,14 +138,10 @@ func PromptSuffix(schema map[string]any) string {
 // language tag.
 var jsonFencePattern = regexp.MustCompile("(?s)```(?:json)?\\s*\\n?(.*?)\\n?```")
 
-// ExtractJSON pulls a JSON object out of free-form text, as produced by an
-// agent asked (via PromptSuffix) to emit structured output in its final
-// message. It tries each fenced code block, last to first, then falls back to
-// parsing the whole trimmed text, and reports false if none of those parse as
-// a JSON object. There is no schema validation here: for agent components
-// there is no server-side grammar constraint to trust, so this is inherently
-// best-effort — callers decide whether to trust it (e.g. only on a normal
-// completion).
+// ExtractJSON pulls a JSON object out of text produced by PromptSuffix's
+// instructions: it tries each fenced code block (last to first), then the
+// whole trimmed text, and reports false if none parse as a JSON object. This
+// is best-effort with no schema validation — callers decide when to trust it.
 func ExtractJSON(text string) (any, bool) {
 	matches := jsonFencePattern.FindAllStringSubmatch(text, -1)
 	for i := len(matches) - 1; i >= 0; i-- {

--- a/pkg/configuration/structuredoutput/structuredoutput.go
+++ b/pkg/configuration/structuredoutput/structuredoutput.go
@@ -9,11 +9,19 @@
 //     "required" to list all of its properties; optional fields are expressed by
 //     making their type nullable in the schema itself.
 //   - Anthropic (strict=false) leaves "required" as the user wrote it.
+//
+// Agent components (Claude Managed Agents sessions) have no equivalent to the
+// Messages API's output_config.format — there is no server-side grammar
+// constraint for a Sessions-based run. For those, PromptSuffix and ExtractJSON
+// emulate structured output by asking the model to comply and best-effort
+// parsing its final message; callers should only trust the result on a normal
+// completion, never as a real schema guarantee.
 package structuredoutput
 
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -107,6 +115,70 @@ func validateRoot(schema map[string]any) error {
 // to send. It does not mutate the input.
 func Prepare(schema map[string]any, strict bool) map[string]any {
 	return normalizeMap(schema, strict)
+}
+
+// ValidateAtSetup validates a raw structured-output config value at Setup
+// time. An empty value is fine (structured output is optional). A value that
+// still contains an unresolved "{{" expression is skipped, mirroring how the
+// prompt field itself is only resolved at Execute.
+func ValidateAtSetup(raw string) error {
+	if strings.TrimSpace(raw) == "" || strings.Contains(raw, "{{") {
+		return nil
+	}
+	_, err := Parse(raw)
+	return err
+}
+
+// PromptSuffix renders schema-following instructions to append to an agent's
+// task prompt. There is no output_config.format equivalent for Managed Agents
+// sessions, so this is the only lever: ask the model to emit matching JSON,
+// then extract it with ExtractJSON. Returns "" if schema is nil.
+func PromptSuffix(schema map[string]any) string {
+	if schema == nil {
+		return ""
+	}
+	encoded, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("\n\nBefore you finish, include a fenced json code block in your message with data matching this JSON Schema exactly:\n\n```json\n%s\n```\n", encoded)
+}
+
+// jsonFencePattern matches a fenced code block, with or without a "json"
+// language tag.
+var jsonFencePattern = regexp.MustCompile("(?s)```(?:json)?\\s*\\n?(.*?)\\n?```")
+
+// ExtractJSON pulls a JSON object out of free-form text, as produced by an
+// agent asked (via PromptSuffix) to emit structured output in its final
+// message. It tries each fenced code block, last to first, then falls back to
+// parsing the whole trimmed text, and reports false if none of those parse as
+// a JSON object. There is no schema validation here: for agent components
+// there is no server-side grammar constraint to trust, so this is inherently
+// best-effort — callers decide whether to trust it (e.g. only on a normal
+// completion).
+func ExtractJSON(text string) (any, bool) {
+	matches := jsonFencePattern.FindAllStringSubmatch(text, -1)
+	for i := len(matches) - 1; i >= 0; i-- {
+		if parsed, ok := unmarshalJSONObject(matches[i][1]); ok {
+			return parsed, true
+		}
+	}
+	return unmarshalJSONObject(text)
+}
+
+func unmarshalJSONObject(s string) (any, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, false
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return nil, false
+	}
+	if _, ok := parsed.(map[string]any); !ok {
+		return nil, false
+	}
+	return parsed, true
 }
 
 func normalizeMap(node map[string]any, strict bool) map[string]any {

--- a/pkg/configuration/structuredoutput/structuredoutput_test.go
+++ b/pkg/configuration/structuredoutput/structuredoutput_test.go
@@ -85,6 +85,20 @@ func TestPrepare_NestedObjectsAndArrays(t *testing.T) {
 	}
 }
 
+func TestPrepare_StrictWithNoProperties(t *testing.T) {
+	// An object schema with no "properties" (e.g. an empty object schema
+	// built directly rather than through Parse, which rejects that case)
+	// must not panic; strict mode just requires nothing.
+	out := Prepare(map[string]any{"type": "object"}, true)
+	req, ok := out["required"].([]string)
+	if !ok {
+		t.Fatalf("required should be []string in strict mode, got %T", out["required"])
+	}
+	if len(req) != 0 {
+		t.Errorf("expected no required properties, got %v", req)
+	}
+}
+
 func TestPrepare_StrictForcesRequired(t *testing.T) {
 	schema, _ := Parse(`{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"number"}},"required":["a"]}`)
 	out := Prepare(schema, true)
@@ -136,6 +150,15 @@ func TestPromptSuffix(t *testing.T) {
 	}
 }
 
+func TestPromptSuffix_UnencodableSchema(t *testing.T) {
+	// A channel value can't be marshaled to JSON, so PromptSuffix must fall
+	// back to its empty-string result rather than panicking or erroring.
+	schema := map[string]any{"bad": make(chan int)}
+	if got := PromptSuffix(schema); got != "" {
+		t.Errorf("PromptSuffix(unencodable) = %q, want empty", got)
+	}
+}
+
 func TestExtractJSON(t *testing.T) {
 	cases := []struct {
 		name string
@@ -181,6 +204,11 @@ func TestExtractJSON(t *testing.T) {
 		{
 			name: "JSON array is not an object",
 			text: `["a", "b"]`,
+			ok:   false,
+		},
+		{
+			name: "blank text",
+			text: "   ",
 			ok:   false,
 		},
 	}

--- a/pkg/configuration/structuredoutput/structuredoutput_test.go
+++ b/pkg/configuration/structuredoutput/structuredoutput_test.go
@@ -2,6 +2,7 @@ package structuredoutput
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -101,5 +102,101 @@ func TestPrepare_DoesNotMutateInput(t *testing.T) {
 	_ = Prepare(schema, true)
 	if _, exists := schema["additionalProperties"]; exists {
 		t.Errorf("Prepare must not mutate the input schema")
+	}
+}
+
+func TestValidateAtSetup(t *testing.T) {
+	for _, raw := range []string{"", "   ", "{{ event.schema }}"} {
+		if err := ValidateAtSetup(raw); err != nil {
+			t.Errorf("ValidateAtSetup(%q) unexpected error: %v", raw, err)
+		}
+	}
+
+	if err := ValidateAtSetup(`{"type":"object","properties":{"a":{"type":"string"}},"required":["a"]}`); err != nil {
+		t.Errorf("unexpected error for valid schema: %v", err)
+	}
+
+	if err := ValidateAtSetup(`{"type":"object"}`); err == nil {
+		t.Error("expected error for schema missing properties")
+	}
+}
+
+func TestPromptSuffix(t *testing.T) {
+	if got := PromptSuffix(nil); got != "" {
+		t.Errorf("PromptSuffix(nil) = %q, want empty", got)
+	}
+
+	schema, _ := Parse(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	got := PromptSuffix(schema)
+	if !strings.Contains(got, "```json") {
+		t.Errorf("expected a fenced json block, got %q", got)
+	}
+	if !strings.Contains(got, `"summary"`) {
+		t.Errorf("expected the schema to be embedded, got %q", got)
+	}
+}
+
+func TestExtractJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want map[string]any
+		ok   bool
+	}{
+		{
+			name: "fenced json block",
+			text: "Here you go:\n\n```json\n{\"summary\": \"ok\"}\n```\n",
+			want: map[string]any{"summary": "ok"},
+			ok:   true,
+		},
+		{
+			name: "bare fence without json tag",
+			text: "```\n{\"summary\": \"ok\"}\n```",
+			want: map[string]any{"summary": "ok"},
+			ok:   true,
+		},
+		{
+			name: "whole message is JSON",
+			text: `{"summary": "ok"}`,
+			want: map[string]any{"summary": "ok"},
+			ok:   true,
+		},
+		{
+			name: "last fenced block wins",
+			text: "Example:\n```json\n{\"summary\": \"example\"}\n```\n\nActual:\n```json\n{\"summary\": \"real\"}\n```",
+			want: map[string]any{"summary": "real"},
+			ok:   true,
+		},
+		{
+			name: "non-json fence falls back to next candidate",
+			text: "```bash\necho hi\n```\n```json\n{\"summary\": \"ok\"}\n```",
+			want: map[string]any{"summary": "ok"},
+			ok:   true,
+		},
+		{
+			name: "no JSON anywhere",
+			text: "Sorry, I can't help with that.",
+			ok:   false,
+		},
+		{
+			name: "JSON array is not an object",
+			text: `["a", "b"]`,
+			ok:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ExtractJSON(tc.text)
+			if ok != tc.ok {
+				t.Fatalf("ExtractJSON(%q) ok = %v, want %v", tc.text, ok, tc.ok)
+			}
+			if !tc.ok {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ExtractJSON(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -93,6 +93,7 @@ func (a *RunAgent) handleTerminalSession(ctx core.ActionHookContext, client *Cli
 	}
 
 	out := buildOutputFromSessionMessages(sess.Status, metadata.Session.ID, sm)
+	applyStructuredOutput(&out, sess.Status, schemaFromConfiguration(ctx.Configuration))
 	if sm != nil {
 		out.Artifacts = CollectSessionArtifacts(client, metadata.Session.ID, sm.ExpectsArtifacts, ctx.Logger.Warnf)
 	}

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -93,8 +93,12 @@ func (a *RunAgent) handleTerminalSession(ctx core.ActionHookContext, client *Cli
 	}
 
 	out := buildOutputFromSessionMessages(sess.Status, metadata.Session.ID, sm)
-	applyStructuredOutput(&out, sess.Status, schemaFromConfiguration(ctx.Configuration))
 	if sm != nil {
+		// Only trust structured output once events are confirmed complete —
+		// past the poll budget, LastMessage may not be the real final message.
+		if sm.Complete {
+			applyStructuredOutput(&out, sess.Status, schemaFromConfiguration(ctx.Configuration))
+		}
 		out.Artifacts = CollectSessionArtifacts(client, metadata.Session.ID, sm.ExpectsArtifacts, ctx.Logger.Warnf)
 	}
 	if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/configuration/structuredoutput"
 	"github.com/superplanehq/superplane/pkg/core"
 	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
 )
@@ -39,10 +40,13 @@ func (a *RunAgent) Documentation() string {
 - **Prompt**: The user message (task) sent to the agent.
 - **Vault IDs** (optional): For MCP tools that need vault-backed credentials.
 - **Keep Session After Run** (optional): By default the session is deleted once the run finishes. Enable this to keep it so you can read the full transcript in the Anthropic Console when debugging. It applies only to runs that finish — a cancelled run is always cleaned up. Kept sessions are never reclaimed automatically, so delete them yourself when you're done.
+- **Structured Output** (optional): A JSON Schema the agent is asked to match in its final message. Managed Agents sessions have no server-enforced equivalent to the Messages API's ` + "`output_config.format`" + ` used by Text Prompt, so this works by appending instructions to the task asking the agent to include a JSON code block matching the schema, then best-effort parsing it from the final message. Treat the result as best-effort, not a guarantee — validate before relying on it downstream.
 
 ## Output
 
 Emits a finished payload with **session** status, **session id**, and the final **agent message** when available so downstream steps can branch or consume the result. For failure cases the status is still emitted when the **session** is *terminated* or the step times out.
+
+When Structured Output is configured, **parsed** carries the JSON object extracted from the final message — only when the session finished normally (idle), never on a timeout, error, or terminated session.
 
 Files the agent saves under ` + "`/mnt/session/outputs/`" + ` are emitted as **artifacts** with their content included in the payload (text files as plain text, everything else base64-encoded; files over 10MB carry metadata and a download link only). Instruct the agent in the task to save its deliverables there.`
 }
@@ -118,6 +122,11 @@ func (a *RunAgent) Configuration() []configuration.Field {
 			Required:    true,
 			Description: "User message (task) for the agent",
 		},
+		structuredoutput.ConfigField(
+			"outputSchema",
+			"Structured Output",
+			"A JSON Schema the agent is asked to match in its final message. Best-effort: Managed Agents sessions have no server-side schema enforcement, so this is prompt-guided, not guaranteed.",
+		),
 		{
 			Name:     "vaultIds",
 			Label:    "Vault IDs",
@@ -215,6 +224,10 @@ func (a *RunAgent) Setup(ctx core.SetupContext) error {
 		return err
 	}
 
+	if err := structuredoutput.ValidateAtSetup(spec.OutputSchema); err != nil {
+		return err
+	}
+
 	if len(spec.Files) > 0 {
 		if ctx.Files == nil {
 			return fmt.Errorf("files configured but file access is not available")
@@ -249,6 +262,12 @@ func (a *RunAgent) Setup(ctx core.SetupContext) error {
 		}
 	}
 
+	if ctx.Metadata != nil {
+		_ = ctx.Metadata.Set(RunAgentNodeMetadata{
+			StructuredOutput: strings.TrimSpace(spec.OutputSchema) != "",
+		})
+	}
+
 	return nil
 }
 
@@ -262,6 +281,11 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 	if err := validateSpec(spec); err != nil {
+		return err
+	}
+
+	schema, err := structuredoutput.Parse(spec.OutputSchema)
+	if err != nil {
 		return err
 	}
 
@@ -344,7 +368,11 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to set managed_session_id: %w", err)
 	}
 
-	if err := client.SendManagedSessionUserMessage(session.ID, spec.Prompt); err != nil {
+	prompt := spec.Prompt
+	if schema != nil {
+		prompt += structuredoutput.PromptSuffix(structuredoutput.Prepare(schema, false))
+	}
+	if err := client.SendManagedSessionUserMessage(session.ID, prompt); err != nil {
 		cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 		return fmt.Errorf("failed to send user message: %w", err)
 	}
@@ -363,6 +391,7 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v. Scheduling poll.", session.ID, err)
 		} else if sm != nil && sm.Complete {
 			out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
+			applyStructuredOutput(&out, refreshed.Status, schema)
 			out.Artifacts = CollectSessionArtifacts(client, session.ID, sm.ExpectsArtifacts, ctx.Logger.Warnf)
 			if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
 				cleanupManagedVault(client, ctx, ctx.Logger.Warnf)

--- a/pkg/integrations/claude/runagent/run_agent_test.go
+++ b/pkg/integrations/claude/runagent/run_agent_test.go
@@ -653,6 +653,40 @@ func Test__RunAgent__poll__terminalWithIncompleteEventsReportsRealStatus(t *test
 	assert.True(t, deleted, "a finished session is still reclaimed by default")
 }
 
+// Past the poll budget with incomplete events, LastMessage may not be the
+// agent's real final message — structured output must not be trusted then,
+// even though the session is reported as genuinely finished (idle).
+func Test__RunAgent__poll__terminalWithIncompleteEventsSkipsStructuredOutput(t *testing.T) {
+	a := &RunAgent{}
+	restore := finalMessageDelay
+	finalMessageDelay = time.Millisecond
+	t.Cleanup(func() { finalMessageDelay = restore })
+
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+		{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))}, // get session: finished
+	}}
+	// Events never include session.status_idle, so Complete never becomes true,
+	// even though the message looks like valid structured-output JSON.
+	for range finalMessageReads {
+		httpContext.Responses = append(httpContext.Responses,
+			&http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(
+				`{"data":[{"type":"agent.message","content":[{"type":"text","text":"{\"summary\":\"partial\"}"}]}]}`))})
+	}
+	httpContext.Responses = append(httpContext.Responses,
+		&http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}) // delete session
+
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	require.NoError(t, a.HandleHook(timeoutHookCtx(httpContext, execState, map[string]any{
+		"agent": "agent_1", "environmentId": "env_1", "prompt": "do it", "outputSchema": structuredOutputSchema,
+	})))
+
+	require.True(t, execState.Finished)
+	out := execState.Payloads[0].(map[string]any)["data"].(OutputPayload)
+	assert.Equal(t, "idle", out.Status)
+	assert.NotEmpty(t, out.LastMessage, "the partial message we did collect must still be emitted")
+	assert.Nil(t, out.Parsed, "incomplete events must never be trusted for structured output")
+}
+
 // Repeated poll failures mean we lost sight of the session, not that it ended.
 func Test__RunAgent__poll__repeatedErrorsReclaimSession(t *testing.T) {
 	a := &RunAgent{}

--- a/pkg/integrations/claude/runagent/run_agent_test.go
+++ b/pkg/integrations/claude/runagent/run_agent_test.go
@@ -1,6 +1,7 @@
 package runagent
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
+
+const structuredOutputSchema = `{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`
 
 func Test__RunAgent__Setup(t *testing.T) {
 	a := &RunAgent{}
@@ -157,6 +160,56 @@ func Test__decodeSpec__newConfig(t *testing.T) {
 	assert.Equal(t, "3", spec.Version)
 }
 
+func Test__RunAgent__Setup__structuredOutputInvalidSchema(t *testing.T) {
+	a := &RunAgent{}
+	ctx := core.SetupContext{
+		Configuration: map[string]any{
+			"agent":         "agent_01",
+			"environmentId": "env_01",
+			"prompt":        "Do the thing",
+			"outputSchema":  `{"type":"object"}`, // missing "properties"
+		},
+		Integration: &contexts.IntegrationContext{},
+	}
+	err := a.Setup(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "properties")
+}
+
+func Test__RunAgent__Setup__structuredOutputUnresolvedExpressionSkipsValidation(t *testing.T) {
+	a := &RunAgent{}
+	ctx := core.SetupContext{
+		Configuration: map[string]any{
+			"agent":         "agent_01",
+			"environmentId": "env_01",
+			"prompt":        "Do the thing",
+			"outputSchema":  "{{ event.schema }}",
+		},
+		Integration: &contexts.IntegrationContext{},
+	}
+	require.NoError(t, a.Setup(ctx))
+}
+
+func Test__RunAgent__Setup__structuredOutputMetadata(t *testing.T) {
+	a := &RunAgent{}
+	metadataCtx := &contexts.MetadataContext{}
+	ctx := core.SetupContext{
+		Configuration: map[string]any{
+			"agent":         "agent_01",
+			"environmentId": "env_01",
+			"prompt":        "Do the thing",
+			"outputSchema":  structuredOutputSchema,
+		},
+		Integration: &contexts.IntegrationContext{},
+		Metadata:    metadataCtx,
+	}
+	require.NoError(t, a.Setup(ctx))
+
+	meta, ok := metadataCtx.Metadata.(RunAgentNodeMetadata)
+	require.True(t, ok, "expected RunAgentNodeMetadata, got %T", metadataCtx.Metadata)
+	assert.True(t, meta.StructuredOutput)
+}
+
 func Test__RunAgent__Execute__syncIdle(t *testing.T) {
 	a := &RunAgent{}
 	httpContext := &contexts.HTTPContext{
@@ -218,6 +271,98 @@ func Test__RunAgent__Execute__syncIdle(t *testing.T) {
 	assert.Equal(t, sessionEventsPageLimit, httpContext.Requests[3].URL.Query().Get("limit"))
 	assert.Contains(t, httpContext.Requests[4].URL.Path, "/files")
 	assert.Equal(t, "sess_1", httpContext.Requests[4].URL.Query().Get("scope_id"))
+}
+
+func Test__RunAgent__Execute__structuredOutput(t *testing.T) {
+	a := &RunAgent{}
+	agentMessage := "Here is the result.\n\n```json\n{\"summary\": \"looks good\"}\n```\n"
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"running"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(fmt.Sprintf(`{"data":[{"type":"session.status_idle"},{"type":"agent.message","content":[{"type":"text","text":%q}]}]}`, agentMessage)))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "sk-test"}}
+	metadataCtx := &contexts.MetadataContext{}
+	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	requestsCtx := &contexts.RequestContext{}
+
+	execCtx := core.ExecutionContext{
+		ID: uuid.New(),
+		Configuration: map[string]any{
+			"agent":         "ag_1",
+			"environmentId": "ev_1",
+			"prompt":        "Summarize this",
+			"outputSchema":  structuredOutputSchema,
+		},
+		HTTP:           httpContext,
+		Integration:    integrationCtx,
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Requests:       requestsCtx,
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	err := a.Execute(execCtx)
+	require.NoError(t, err)
+	require.True(t, executionState.Finished)
+
+	out := executionState.Payloads[0].(map[string]any)["data"].(OutputPayload)
+	assert.Equal(t, "idle", out.Status)
+
+	parsed, ok := out.Parsed.(map[string]any)
+	require.True(t, ok, "expected Parsed to be an object, got %T", out.Parsed)
+	assert.Equal(t, "looks good", parsed["summary"])
+
+	// The sent user message must include the schema instructions.
+	sendBody, err := io.ReadAll(httpContext.Requests[1].Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(sendBody), "fenced json code block")
+	assert.Contains(t, string(sendBody), `\"summary\"`)
+}
+
+func Test__RunAgent__Execute__structuredOutputRefusalStaysUnparsed(t *testing.T) {
+	a := &RunAgent{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"running"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"terminated"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_terminated"},{"type":"agent.message","content":[{"type":"text","text":"I can't finish this task."}]}]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "sk-test"}}
+	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+	execCtx := core.ExecutionContext{
+		ID: uuid.New(),
+		Configuration: map[string]any{
+			"agent":         "ag_1",
+			"environmentId": "ev_1",
+			"prompt":        "Summarize this",
+			"outputSchema":  structuredOutputSchema,
+		},
+		HTTP:           httpContext,
+		Integration:    integrationCtx,
+		Metadata:       &contexts.MetadataContext{},
+		ExecutionState: executionState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	err := a.Execute(execCtx)
+	require.NoError(t, err)
+	require.True(t, executionState.Finished)
+
+	out := executionState.Payloads[0].(map[string]any)["data"].(OutputPayload)
+	assert.Equal(t, "terminated", out.Status)
+	assert.Nil(t, out.Parsed, "a terminated session must never be trusted for structured output")
 }
 
 func Test__RunAgent__Execute__schedulesPoll(t *testing.T) {
@@ -292,6 +437,50 @@ func Test__RunAgent__poll__terminal(t *testing.T) {
 	assert.Equal(t, "file_out1", out.Artifacts[0].FileID)
 	assert.Equal(t, "text", out.Artifacts[0].Encoding)
 	assert.Equal(t, "# Report\n", out.Artifacts[0].Content)
+}
+
+func Test__RunAgent__poll__structuredOutput(t *testing.T) {
+	a := &RunAgent{}
+	agentMessage := "```json\n{\"summary\": \"async result\"}\n```"
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(fmt.Sprintf(`{"data":[{"type":"session.status_idle"},{"type":"agent.message","content":[{"type":"text","text":%q}]}]}`, agentMessage)))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: ExecutionMetadata{
+			Session: &SessionMetadata{ID: "sess_1", Status: "running"},
+		},
+	}
+	hookCtx := core.ActionHookContext{
+		Name:       "poll",
+		Parameters: map[string]any{"attempt": float64(1), "errors": float64(0)},
+		Configuration: map[string]any{
+			"agent":         "agent_1",
+			"environmentId": "env_1",
+			"prompt":        "do it",
+			"outputSchema":  structuredOutputSchema,
+		},
+		HTTP:           httpContext,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Logger:         logrus.NewEntry(logrus.New()),
+		Requests:       &contexts.RequestContext{},
+	}
+
+	err := a.HandleHook(hookCtx)
+	require.NoError(t, err)
+	require.True(t, executionState.Finished)
+	out := executionState.Payloads[0].(map[string]any)["data"].(OutputPayload)
+	assert.Equal(t, "idle", out.Status)
+	parsed, ok := out.Parsed.(map[string]any)
+	require.True(t, ok, "expected Parsed to be an object, got %T", out.Parsed)
+	assert.Equal(t, "async result", parsed["summary"])
 }
 
 func Test__RunAgent__poll__persistSessionKeepsSession(t *testing.T) {

--- a/pkg/integrations/claude/runagent/types.go
+++ b/pkg/integrations/claude/runagent/types.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"strings"
 	"time"
+
+	"github.com/superplanehq/superplane/pkg/configuration/structuredoutput"
 )
 
 const (
@@ -52,6 +54,15 @@ type Spec struct {
 	// PersistSession keeps the Managed Agents session after the run finishes so
 	// its transcript stays readable in the Anthropic Console.
 	PersistSession bool `json:"persistSession" mapstructure:"persistSession"`
+	// OutputSchema is a JSON Schema the agent is asked (via a prompt suffix, not
+	// a server-enforced constraint) to match in its final message.
+	OutputSchema string `json:"outputSchema" mapstructure:"outputSchema"`
+}
+
+// RunAgentNodeMetadata is node-level metadata surfaced in the UI so configured
+// options are visible on the node without opening it.
+type RunAgentNodeMetadata struct {
+	StructuredOutput bool `json:"structuredOutput" mapstructure:"structuredOutput"`
 }
 
 // SecretBinding maps a SuperPlane secret to an environment variable in the agent session.
@@ -85,6 +96,9 @@ type OutputPayload struct {
 	LastMessage string            `json:"lastMessage"`
 	Messages    []string          `json:"messages"`
 	Artifacts   []SessionArtifact `json:"artifacts,omitempty"`
+	// Parsed is the JSON object extracted from LastMessage when Structured
+	// Output is configured and the session completed normally.
+	Parsed any `json:"parsed,omitempty"`
 }
 
 // SessionArtifact is a file the agent generated during the session (written to
@@ -203,6 +217,34 @@ func buildOutputFromSessionMessages(status, sessionID string, sm *SessionMessage
 		out.Messages = sm.Messages
 	}
 	return out
+}
+
+// applyStructuredOutput sets out.Parsed by best-effort extracting JSON from
+// the agent's final message, when a schema is configured and the session
+// completed normally ("idle"). There is no server-side schema enforcement for
+// Managed Agents sessions (unlike output_config.format on the Messages API),
+// so this is prompt-guided and best-effort — a "terminated" session may have
+// errored or been interrupted mid-task, so its message is not trusted either.
+func applyStructuredOutput(out *OutputPayload, status string, schema map[string]any) {
+	if schema == nil || status != sessionStatusIdle || out.LastMessage == "" {
+		return
+	}
+	if parsed, ok := structuredoutput.ExtractJSON(out.LastMessage); ok {
+		out.Parsed = parsed
+	}
+}
+
+// schemaFromConfiguration re-derives the parsed output schema from the node's
+// raw configuration for the async poll path, where the schema was already
+// validated at Setup/Execute — a decode or parse failure here is tolerated as
+// "no schema" rather than failing an otherwise-complete run.
+func schemaFromConfiguration(config any) map[string]any {
+	spec, err := decodeSpec(config)
+	if err != nil {
+		return nil
+	}
+	schema, _ := structuredoutput.Parse(spec.OutputSchema)
+	return schema
 }
 
 func buildOutput(status, sessionID string, lastMessage ...string) OutputPayload {

--- a/pkg/integrations/claude/runcodeagent/monitor.go
+++ b/pkg/integrations/claude/runcodeagent/monitor.go
@@ -145,7 +145,11 @@ func (a *RunCodeAgent) handleTerminalSession(ctx core.ActionHookContext, client 
 	// Past the poll budget the events may still be unavailable (sm == nil);
 	// emit what we have and only look for artifacts when events were read.
 	if sm != nil {
-		applyStructuredOutput(&out, sess.Status, schemaFromConfiguration(ctx.Configuration))
+		// Only trust structured output once events are confirmed complete —
+		// past the poll budget, LastMessage may not be the real final message.
+		if sm.Complete {
+			applyStructuredOutput(&out, sess.Status, schemaFromConfiguration(ctx.Configuration))
+		}
 		out.Artifacts = runagent.CollectSessionArtifacts(client, meta.Session.ID, sm.ExpectsArtifacts, ctx.Logger.Warnf)
 	}
 	if err := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); err != nil {

--- a/pkg/integrations/claude/runcodeagent/monitor.go
+++ b/pkg/integrations/claude/runcodeagent/monitor.go
@@ -145,6 +145,7 @@ func (a *RunCodeAgent) handleTerminalSession(ctx core.ActionHookContext, client 
 	// Past the poll budget the events may still be unavailable (sm == nil);
 	// emit what we have and only look for artifacts when events were read.
 	if sm != nil {
+		applyStructuredOutput(&out, sess.Status, schemaFromConfiguration(ctx.Configuration))
 		out.Artifacts = runagent.CollectSessionArtifacts(client, meta.Session.ID, sm.ExpectsArtifacts, ctx.Logger.Warnf)
 	}
 	if err := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); err != nil {

--- a/pkg/integrations/claude/runcodeagent/prompt.go
+++ b/pkg/integrations/claude/runcodeagent/prompt.go
@@ -84,8 +84,7 @@ func writeIntro(b *strings.Builder, hasFiles bool) {
 }
 
 // writeFinalMarker writes the machine-readable PR_URL/NO_PR marker the agent
-// must end its message with. When schema is set, the structured-output
-// instructions are written first so the marker line stays truly last.
+// must end its message with.
 func writeFinalMarker(b *strings.Builder, prExpected bool, schema map[string]any) {
 	if schema != nil {
 		b.WriteString(structuredoutput.PromptSuffix(structuredoutput.Prepare(schema, false)))

--- a/pkg/integrations/claude/runcodeagent/prompt.go
+++ b/pkg/integrations/claude/runcodeagent/prompt.go
@@ -3,19 +3,22 @@ package runcodeagent
 import (
 	"fmt"
 	"strings"
+
+	"github.com/superplanehq/superplane/pkg/configuration/structuredoutput"
 )
 
 // buildPrompt wraps the user's task in a deterministic operating procedure that
 // makes the agent clone, work, push, and open (or update) a pull request, then
-// report the PR URL in a machine-readable form.
-func buildPrompt(spec Spec, pr *pullRequestInfo, branch string, hasFiles bool, attr commitAttribution) string {
+// report the PR URL in a machine-readable form. schema, when non-nil, adds
+// instructions asking the agent to also include a JSON block matching it.
+func buildPrompt(spec Spec, pr *pullRequestInfo, branch string, hasFiles bool, attr commitAttribution, schema map[string]any) string {
 	if pr != nil {
-		return buildPRPrompt(spec, pr, hasFiles, attr)
+		return buildPRPrompt(spec, pr, hasFiles, attr, schema)
 	}
-	return buildRepositoryPrompt(spec, branch, hasFiles, attr)
+	return buildRepositoryPrompt(spec, branch, hasFiles, attr, schema)
 }
 
-func buildRepositoryPrompt(spec Spec, branch string, hasFiles bool, attr commitAttribution) string {
+func buildRepositoryPrompt(spec Spec, branch string, hasFiles bool, attr commitAttribution, schema map[string]any) string {
 	var b strings.Builder
 	writeIntro(&b, hasFiles)
 
@@ -35,11 +38,11 @@ func buildRepositoryPrompt(spec Spec, branch string, hasFiles bool, attr commitA
 		}
 		fmt.Fprintf(&b, "5. Open a pull request from %s into %s (use the GitHub API with $GITHUB_TOKEN, or the gh CLI).\n", branch, target)
 	}
-	writeFinalMarker(&b, prEnabled(spec))
+	writeFinalMarker(&b, prEnabled(spec), schema)
 	return b.String()
 }
 
-func buildPRPrompt(spec Spec, pr *pullRequestInfo, hasFiles bool, attr commitAttribution) string {
+func buildPRPrompt(spec Spec, pr *pullRequestInfo, hasFiles bool, attr commitAttribution, schema map[string]any) string {
 	var b strings.Builder
 	writeIntro(&b, hasFiles)
 	fmt.Fprintf(&b, "You are updating the existing pull request %s.\n\n", pr.HTMLURL)
@@ -50,7 +53,7 @@ func buildPRPrompt(spec Spec, pr *pullRequestInfo, hasFiles bool, attr commitAtt
 	writeIdentity(&b, attr)
 	fmt.Fprintf(&b, "2. Complete this task:\n%s\n", indent(spec.Task))
 	fmt.Fprintf(&b, "3. %s and push to the SAME branch (%s) — do NOT open a new pull request; pushing updates the existing one: git push origin %s\n", commitInstruction(attr), pr.HeadRef, pr.HeadRef)
-	writeFinalMarker(&b, true)
+	writeFinalMarker(&b, true, schema)
 	fmt.Fprintf(&b, "\nThe pull request URL is %s.\n", pr.HTMLURL)
 	return b.String()
 }
@@ -80,7 +83,13 @@ func writeIntro(b *strings.Builder, hasFiles bool) {
 	b.WriteString("\nFollow these steps:\n")
 }
 
-func writeFinalMarker(b *strings.Builder, prExpected bool) {
+// writeFinalMarker writes the machine-readable PR_URL/NO_PR marker the agent
+// must end its message with. When schema is set, the structured-output
+// instructions are written first so the marker line stays truly last.
+func writeFinalMarker(b *strings.Builder, prExpected bool, schema map[string]any) {
+	if schema != nil {
+		b.WriteString(structuredoutput.PromptSuffix(structuredoutput.Prepare(schema, false)))
+	}
 	b.WriteString("\nWhen finished, output on the FINAL line of your last message exactly one of:\n")
 	if prExpected {
 		b.WriteString("     PR_URL=<the pull request url>\n")

--- a/pkg/integrations/claude/runcodeagent/run_code_agent.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/configuration/structuredoutput"
 	"github.com/superplanehq/superplane/pkg/core"
 	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
 	"github.com/superplanehq/superplane/pkg/integrations/claude/runagent"
@@ -51,9 +52,15 @@ The setting applies only to runs that **finish** — including ones that fail or
 
 Kept sessions and environments are not reclaimed automatically, so delete them yourself once you're done debugging.
 
+## Structured Output
+
+Optional: a JSON Schema the agent is asked to match in its final message, in addition to the PR it opens. Managed Agents sessions have no server-enforced equivalent to the Messages API's ` + "`output_config.format`" + ` used by Text Prompt, so this works by appending instructions to the task asking the agent to include a JSON code block matching the schema, then best-effort parsing it from the final message. Treat the result as best-effort, not a guarantee — validate before relying on it downstream.
+
 ## Output
 
 Emits the final **status**, the **pull request URL**, the working **branch**, and a **summary** so downstream steps can branch or post the result.
+
+When Structured Output is configured, **parsed** carries the JSON object extracted from the final message — only when the session finished normally (idle), never on a timeout, error, or terminated session.
 
 Files the agent saves under ` + "`/mnt/session/outputs/`" + ` are additionally emitted as **artifacts** with their content included in the payload (text files as plain text, everything else base64-encoded; files over 10MB carry metadata and a download link only).`
 }
@@ -106,6 +113,11 @@ func (a *RunCodeAgent) Configuration() []configuration.Field {
 			Name: "task", Label: "Task", Type: configuration.FieldTypeText, Required: true,
 			Description: "What the agent should do.",
 		},
+		structuredoutput.ConfigField(
+			"outputSchema",
+			"Structured Output",
+			"A JSON Schema the agent is asked to match in its final message, alongside the PR it opens. Best-effort: Managed Agents sessions have no server-side schema enforcement, so this is prompt-guided, not guaranteed.",
+		),
 		{
 			Name: "githubToken", Label: "GitHub Token", Type: configuration.FieldTypeSecretKey, Required: true,
 			Description: "SuperPlane secret holding a GitHub token with repo + pull request permissions.",
@@ -167,6 +179,9 @@ func (a *RunCodeAgent) Setup(ctx core.SetupContext) error {
 	if err := validateConfiguredFiles(ctx, spec.Files); err != nil {
 		return err
 	}
+	if err := structuredoutput.ValidateAtSetup(spec.OutputSchema); err != nil {
+		return err
+	}
 	return setNodeMetadata(ctx, spec)
 }
 
@@ -180,6 +195,11 @@ func (a *RunCodeAgent) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 	if err := validateSpec(spec); err != nil {
+		return err
+	}
+
+	schema, err := structuredoutput.Parse(spec.OutputSchema)
+	if err != nil {
 		return err
 	}
 
@@ -219,7 +239,7 @@ func (a *RunCodeAgent) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	if err := a.startSession(ctx, client, spec, pr, attribution, meta, resources); err != nil {
+	if err := a.startSession(ctx, client, spec, pr, attribution, meta, resources, schema); err != nil {
 		return err
 	}
 
@@ -229,7 +249,7 @@ func (a *RunCodeAgent) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to get session: %w", err)
 	}
 
-	handled, err := a.emitIfTerminal(ctx, client, spec, meta, refreshed)
+	handled, err := a.emitIfTerminal(ctx, client, spec, meta, refreshed, schema)
 	if err != nil {
 		return err
 	}
@@ -251,7 +271,7 @@ func (a *RunCodeAgent) Execute(ctx core.ExecutionContext) error {
 // On any failure it reclaims all provisioned resources — always, regardless of
 // "Keep Session After Run": the run never started, so there is no transcript
 // worth keeping, and no poll exists to reclaim it later.
-func (a *RunCodeAgent) startSession(ctx core.ExecutionContext, client *runagent.Client, spec Spec, pr *pullRequestInfo, attribution commitAttribution, meta *ExecutionMetadata, resources []runagent.FileResource) error {
+func (a *RunCodeAgent) startSession(ctx core.ExecutionContext, client *runagent.Client, spec Spec, pr *pullRequestInfo, attribution commitAttribution, meta *ExecutionMetadata, resources []runagent.FileResource, schema map[string]any) error {
 	session, err := client.CreateManagedSession(runagent.CreateManagedSessionRequest{
 		Agent:         meta.AgentID,
 		EnvironmentID: meta.EnvironmentID,
@@ -268,7 +288,7 @@ func (a *RunCodeAgent) startSession(ctx core.ExecutionContext, client *runagent.
 		return fmt.Errorf("failed to set execution metadata: %w", err)
 	}
 
-	message := buildPrompt(spec, pr, meta.Branch, len(spec.Files) > 0, attribution)
+	message := buildPrompt(spec, pr, meta.Branch, len(spec.Files) > 0, attribution, schema)
 	if err := client.SendManagedSessionUserMessage(session.ID, message); err != nil {
 		a.teardown(client, meta, true, false, ctx.Logger.Warnf)
 		return fmt.Errorf("failed to send task to agent: %w", err)
@@ -367,7 +387,7 @@ func warnErr(logWarn func(string, ...any), err error, format string, args ...any
 }
 
 // emitIfTerminal handles fast tasks that finish before the first poll.
-func (a *RunCodeAgent) emitIfTerminal(ctx core.ExecutionContext, client *runagent.Client, spec Spec, meta *ExecutionMetadata, session *runagent.ManagedSession) (bool, error) {
+func (a *RunCodeAgent) emitIfTerminal(ctx core.ExecutionContext, client *runagent.Client, spec Spec, meta *ExecutionMetadata, session *runagent.ManagedSession, schema map[string]any) (bool, error) {
 	if session == nil || !isSessionTerminal(session.Status) {
 		return false, nil
 	}
@@ -379,6 +399,7 @@ func (a *RunCodeAgent) emitIfTerminal(ctx core.ExecutionContext, client *runagen
 	}
 
 	out := buildOutput(session.Status, meta.Session.ID, meta.Branch, sm, meta.PrURL)
+	applyStructuredOutput(&out, session.Status, schema)
 	out.Artifacts = runagent.CollectSessionArtifacts(client, meta.Session.ID, sm.ExpectsArtifacts, ctx.Logger.Warnf)
 	if err := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); err != nil {
 		ctx.Logger.Warnf("Failed to emit result for session %s: %v; scheduling poll.", meta.Session.ID, err)
@@ -604,8 +625,9 @@ func setNodeMetadata(ctx core.SetupContext, spec Spec) error {
 		return nil
 	}
 	meta := NodeMetadata{
-		SourceMode: spec.SourceMode,
-		Model:      modelForRun(spec),
+		SourceMode:       spec.SourceMode,
+		Model:            modelForRun(spec),
+		StructuredOutput: strings.TrimSpace(spec.OutputSchema) != "",
 	}
 	if spec.SourceMode == sourceModePR {
 		meta.PrURL = strings.TrimSpace(spec.PrURL)

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -69,6 +69,27 @@ func Test__RunCodeAgent__Setup__validation(t *testing.T) {
 	}
 }
 
+func Test__RunCodeAgent__Setup__structuredOutputInvalidSchema(t *testing.T) {
+	a := &RunCodeAgent{}
+	cfg := repoConfig()
+	cfg["outputSchema"] = `{"type":"object"}` // missing "properties"
+	err := a.Setup(core.SetupContext{Configuration: cfg, Integration: &contexts.IntegrationContext{}, Metadata: &contexts.MetadataContext{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "properties")
+}
+
+func Test__RunCodeAgent__Setup__structuredOutputMetadata(t *testing.T) {
+	a := &RunCodeAgent{}
+	cfg := repoConfig()
+	cfg["outputSchema"] = `{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`
+	metadataCtx := &contexts.MetadataContext{}
+	require.NoError(t, a.Setup(core.SetupContext{Configuration: cfg, Integration: &contexts.IntegrationContext{}, Metadata: metadataCtx}))
+
+	md := NodeMetadata{}
+	require.NoError(t, mapstructure.Decode(metadataCtx.Get(), &md))
+	assert.True(t, md.StructuredOutput)
+}
+
 func Test__RunCodeAgent__validateRepository(t *testing.T) {
 	valid := []string{"owner/repo", "https://github.com/owner/repo.git", "{{ event.repo }}"}
 	for _, v := range valid {
@@ -125,7 +146,7 @@ func Test__RunCodeAgent__buildEnvironmentConfig(t *testing.T) {
 
 func Test__RunCodeAgent__buildPrompt__repository(t *testing.T) {
 	spec := Spec{SourceMode: "repository", Repository: "owner/repo", Task: "fix the bug", BaseBranch: "main"}
-	got := buildPrompt(spec, nil, "claude/agent-abc", false, commitAttribution{})
+	got := buildPrompt(spec, nil, "claude/agent-abc", false, commitAttribution{}, nil)
 	assert.Contains(t, got, "git clone https://x-access-token:$GITHUB_TOKEN@github.com/owner/repo.git")
 	assert.Contains(t, got, "git checkout -b claude/agent-abc")
 	assert.Contains(t, got, "fix the bug")
@@ -139,7 +160,7 @@ func Test__RunCodeAgent__buildPrompt__repository(t *testing.T) {
 func Test__RunCodeAgent__buildPrompt__actAsUser(t *testing.T) {
 	spec := Spec{SourceMode: "repository", Repository: "owner/repo", Task: "fix the bug"}
 	attr := commitAttribution{AuthorName: "Octo Cat", AuthorEmail: "1+octocat@users.noreply.github.com"}
-	got := buildPrompt(spec, nil, "claude/agent-abc", false, attr)
+	got := buildPrompt(spec, nil, "claude/agent-abc", false, attr, nil)
 	assert.Contains(t, got, `git config user.name "Octo Cat"`)
 	assert.Contains(t, got, `git config user.email "1+octocat@users.noreply.github.com"`)
 	assert.Contains(t, got, "Co-Authored-By")
@@ -147,11 +168,27 @@ func Test__RunCodeAgent__buildPrompt__actAsUser(t *testing.T) {
 
 func Test__RunCodeAgent__buildPrompt__pr(t *testing.T) {
 	pr := &pullRequestInfo{BaseRepo: "owner/repo", HeadRef: "feature-x", HTMLURL: "https://github.com/owner/repo/pull/9"}
-	got := buildPrompt(Spec{SourceMode: "pr", Task: "address review"}, pr, "feature-x", false, commitAttribution{})
+	got := buildPrompt(Spec{SourceMode: "pr", Task: "address review"}, pr, "feature-x", false, commitAttribution{}, nil)
 	assert.Contains(t, got, "git switch feature-x")
 	assert.Contains(t, got, "do NOT open a new pull request")
 	assert.Contains(t, got, "address review")
 	assert.Contains(t, got, "https://github.com/owner/repo/pull/9")
+}
+
+func Test__RunCodeAgent__buildPrompt__structuredOutput(t *testing.T) {
+	schema := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"summary": map[string]any{"type": "string"}},
+		"required":   []any{"summary"},
+	}
+	spec := Spec{SourceMode: "repository", Repository: "owner/repo", Task: "fix the bug"}
+	got := buildPrompt(spec, nil, "claude/agent-abc", false, commitAttribution{}, schema)
+
+	assert.Contains(t, got, "fenced json code block")
+	assert.Contains(t, got, `"summary"`)
+	// The structured-output instructions must precede the FINAL line marker,
+	// so the marker instruction is still the last thing the agent is told.
+	assert.Less(t, strings.Index(got, "fenced json code block"), strings.Index(got, "output on the FINAL line"))
 }
 
 func Test__RunCodeAgent__actAsBot(t *testing.T) {
@@ -214,6 +251,53 @@ func Test__RunCodeAgent__Execute__repositoryMode_schedulesPoll(t *testing.T) {
 	body, _ := io.ReadAll(sendReq.Body)
 	assert.Contains(t, string(body), "git clone")
 	assert.Contains(t, string(body), "do the thing")
+}
+
+func Test__RunCodeAgent__Execute__structuredOutputInPrompt(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"agent_1"}`),                   // create agent
+		resp(`{"id":"env_1"}`),                     // create environment
+		resp(`{"id":"vault_1"}`),                   // create vault
+		resp(`{}`),                                 // add GITHUB_TOKEN credential
+		resp(`{"id":"sess_1","status":"running"}`), // create session
+		resp(`{}`),                                 // send message
+		resp(`{"id":"sess_1","status":"running"}`), // get session (fast-path check)
+	}}
+	metadataCtx := &contexts.MetadataContext{}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	requestsCtx := &contexts.RequestContext{}
+	cfg := repoConfig()
+	cfg["outputSchema"] = `{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`
+	execCtx := core.ExecutionContext{
+		ID:             uuid.New(),
+		Configuration:  cfg,
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Secrets:        &contexts.SecretsContext{Values: map[string][]byte{"gh/token": []byte("ghp_123")}},
+		Metadata:       metadataCtx,
+		ExecutionState: execState,
+		Requests:       requestsCtx,
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.Execute(execCtx))
+	assert.False(t, execState.Finished)
+
+	var sendReq *http.Request
+	for _, r := range httpCtx.Requests {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/events") {
+			sendReq = r
+		}
+	}
+	require.NotNil(t, sendReq)
+	body, _ := io.ReadAll(sendReq.Body)
+	// Structured-output instructions and the PR_URL marker must both be present,
+	// and in the order that keeps the marker the true final line.
+	assert.Contains(t, string(body), "fenced json code block")
+	assert.Contains(t, string(body), `\"summary\"`)
+	assert.Contains(t, string(body), "PR_URL=")
+	assert.Less(t, strings.Index(string(body), "fenced json code block"), strings.Index(string(body), "PR_URL="))
 }
 
 func Test__RunCodeAgent__Execute__cleansUpOnSessionFailure(t *testing.T) {
@@ -355,6 +439,45 @@ func Test__RunCodeAgent__poll__terminalExtractsPR(t *testing.T) {
 	assert.Equal(t, "migration-notes.md", out.Artifacts[0].Filename)
 	assert.Equal(t, "text", out.Artifacts[0].Encoding)
 	assert.Equal(t, "# Migration notes\n", out.Artifacts[0].Content)
+}
+
+func Test__RunCodeAgent__poll__structuredOutput(t *testing.T) {
+	a := &RunCodeAgent{}
+	agentMessage := "Done.\n\n```json\n{\"summary\": \"fixed the bug\"}\n```\n\nPR_URL=https://github.com/o/r/pull/7"
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"sess_1","status":"idle"}`),
+		resp(fmt.Sprintf(`{"data":[{"type":"session.status_idle"},{"type":"agent.message","content":[{"type":"text","text":%q}]}]}`, agentMessage)),
+		resp(`{"data":[]}`),                            // session artifacts (empty)
+		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), // teardown
+	}}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	hookCtx := core.ActionHookContext{
+		Name:       "poll",
+		Parameters: map[string]any{"attempt": float64(1), "errors": float64(0)},
+		Configuration: map[string]any{
+			"sourceMode":   "repository",
+			"repository":   "o/r",
+			"task":         "do it",
+			"githubToken":  map[string]any{"secret": "gh", "key": "token"},
+			"outputSchema": `{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`,
+		},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       terminalMeta(),
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.HandleHook(hookCtx))
+	require.True(t, execState.Finished)
+	out := execState.Payloads[0].(map[string]any)["data"].(OutputPayload)
+	assert.Equal(t, "idle", out.Status)
+	assert.Equal(t, "https://github.com/o/r/pull/7", out.PrURL)
+
+	parsed, ok := out.Parsed.(map[string]any)
+	require.True(t, ok, "expected Parsed to be an object, got %T", out.Parsed)
+	assert.Equal(t, "fixed the bug", parsed["summary"])
 }
 
 func Test__RunCodeAgent__poll__persistSessionKeepsSessionAndEnvironment(t *testing.T) {

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -790,3 +790,50 @@ func Test__RunCodeAgent__poll__terminalWithUnavailableEventsPastBudget(t *testin
 	assert.Equal(t, "idle", out.Status)
 	assert.Nil(t, out.Artifacts)
 }
+
+// Past the poll budget with incomplete events, LastMessage may not be the
+// agent's real final message — structured output must not be trusted then,
+// even though the session is reported as genuinely finished (idle).
+func Test__RunCodeAgent__poll__terminalWithIncompleteEventsSkipsStructuredOutput(t *testing.T) {
+	a := &RunCodeAgent{}
+	restore := finalMessageDelay
+	finalMessageDelay = time.Millisecond
+	t.Cleanup(func() { finalMessageDelay = restore })
+
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"sess_1","status":"idle"}`),
+	}}
+	// Events never include session.status_idle, so Complete never becomes
+	// true, even though the message looks like valid structured-output JSON.
+	for range finalMessageReads {
+		httpCtx.Responses = append(httpCtx.Responses, resp(
+			`{"data":[{"type":"agent.message","content":[{"type":"text","text":"{\"summary\":\"partial\"}"}]}]}`))
+	}
+	httpCtx.Responses = append(httpCtx.Responses, resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`)) // teardown
+
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	hookCtx := core.ActionHookContext{
+		Name:       "poll",
+		Parameters: map[string]any{"attempt": float64(maxPollAttempts + 1), "errors": float64(0)},
+		Configuration: map[string]any{
+			"sourceMode":   "repository",
+			"repository":   "o/r",
+			"task":         "do it",
+			"githubToken":  map[string]any{"secret": "gh", "key": "token"},
+			"outputSchema": `{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`,
+		},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       terminalMeta(),
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	require.NoError(t, a.HandleHook(hookCtx))
+	require.True(t, execState.Finished)
+	out := execState.Payloads[0].(map[string]any)["data"].(OutputPayload)
+	assert.Equal(t, "idle", out.Status)
+	assert.NotEmpty(t, out.LastMessage, "the partial message we did collect must still be emitted")
+	assert.Nil(t, out.Parsed, "incomplete events must never be trusted for structured output")
+}

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -791,9 +791,6 @@ func Test__RunCodeAgent__poll__terminalWithUnavailableEventsPastBudget(t *testin
 	assert.Nil(t, out.Artifacts)
 }
 
-// Past the poll budget with incomplete events, LastMessage may not be the
-// agent's real final message — structured output must not be trusted then,
-// even though the session is reported as genuinely finished (idle).
 func Test__RunCodeAgent__poll__terminalWithIncompleteEventsSkipsStructuredOutput(t *testing.T) {
 	a := &RunCodeAgent{}
 	restore := finalMessageDelay

--- a/pkg/integrations/claude/runcodeagent/types.go
+++ b/pkg/integrations/claude/runcodeagent/types.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/superplanehq/superplane/pkg/configuration/structuredoutput"
 	"github.com/superplanehq/superplane/pkg/integrations/claude/runagent"
 )
 
@@ -63,6 +64,9 @@ type Spec struct {
 	// runs in) after the run finishes so the transcript stays readable in the
 	// Anthropic Console.
 	PersistSession bool `json:"persistSession" mapstructure:"persistSession"`
+	// OutputSchema is a JSON Schema the agent is asked (via a prompt suffix, not
+	// a server-enforced constraint) to match in its final message.
+	OutputSchema string `json:"outputSchema" mapstructure:"outputSchema"`
 }
 
 // SecretRef references a SuperPlane secret by name and key.
@@ -77,11 +81,12 @@ func (r SecretRef) isSet() bool {
 
 // NodeMetadata is resolved at Setup for display on the component card.
 type NodeMetadata struct {
-	Repository string `json:"repository,omitempty" mapstructure:"repository,omitempty"`
-	BaseBranch string `json:"baseBranch,omitempty" mapstructure:"baseBranch,omitempty"`
-	PrURL      string `json:"prUrl,omitempty" mapstructure:"prUrl,omitempty"`
-	Model      string `json:"model,omitempty" mapstructure:"model,omitempty"`
-	SourceMode string `json:"sourceMode,omitempty" mapstructure:"sourceMode,omitempty"`
+	Repository       string `json:"repository,omitempty" mapstructure:"repository,omitempty"`
+	BaseBranch       string `json:"baseBranch,omitempty" mapstructure:"baseBranch,omitempty"`
+	PrURL            string `json:"prUrl,omitempty" mapstructure:"prUrl,omitempty"`
+	Model            string `json:"model,omitempty" mapstructure:"model,omitempty"`
+	SourceMode       string `json:"sourceMode,omitempty" mapstructure:"sourceMode,omitempty"`
+	StructuredOutput bool   `json:"structuredOutput" mapstructure:"structuredOutput"`
 }
 
 // ExecutionMetadata tracks every resource provisioned for a run so it can be
@@ -111,6 +116,9 @@ type OutputPayload struct {
 	Branch      string                     `json:"branch"`
 	LastMessage string                     `json:"lastMessage"`
 	Artifacts   []runagent.SessionArtifact `json:"artifacts,omitempty"`
+	// Parsed is the JSON object extracted from LastMessage when Structured
+	// Output is configured and the session completed normally.
+	Parsed any `json:"parsed,omitempty"`
 }
 
 func isSessionTerminal(status string) bool {
@@ -162,4 +170,32 @@ func buildOutput(status, sessionID, branch string, sm *runagent.SessionMessages,
 		}
 	}
 	return out
+}
+
+// applyStructuredOutput sets out.Parsed by best-effort extracting JSON from
+// the agent's final message, when a schema is configured and the session
+// completed normally ("idle"). There is no server-side schema enforcement for
+// Managed Agents sessions (unlike output_config.format on the Messages API),
+// so this is prompt-guided and best-effort — a "terminated" session may have
+// errored or been interrupted mid-task, so its message is not trusted either.
+func applyStructuredOutput(out *OutputPayload, status string, schema map[string]any) {
+	if schema == nil || status != sessionStatusIdle || out.LastMessage == "" {
+		return
+	}
+	if parsed, ok := structuredoutput.ExtractJSON(out.LastMessage); ok {
+		out.Parsed = parsed
+	}
+}
+
+// schemaFromConfiguration re-derives the parsed output schema from the node's
+// raw configuration for the async poll path, where the schema was already
+// validated at Setup/Execute — a decode or parse failure here is tolerated as
+// "no schema" rather than failing an otherwise-complete run.
+func schemaFromConfiguration(config any) map[string]any {
+	spec, err := decodeSpec(config)
+	if err != nil {
+		return nil
+	}
+	schema, _ := structuredoutput.Parse(spec.OutputSchema)
+	return schema
 }

--- a/pkg/integrations/claude/runcodeagent/types.go
+++ b/pkg/integrations/claude/runcodeagent/types.go
@@ -26,7 +26,6 @@ const (
 	maxPollAttempts   = 80
 	maxPollErrors     = 5
 	finalMessageReads = 15
-	finalMessageDelay = 2 * time.Second
 
 	// Where attached files are mounted inside the sandbox.
 	attachmentsMountDir = "/workspace/attachments"
@@ -34,6 +33,10 @@ const (
 	networkingUnrestricted = "unrestricted"
 	networkingLimited      = "limited"
 )
+
+// finalMessageDelay is the pause between event-stream reads while waiting for
+// the terminal event to be written. A var so tests can shrink it.
+var finalMessageDelay = 2 * time.Second
 
 // defaultGitHubHosts are always allowed when networking is "limited" so the
 // agent can clone, push, and open pull requests.

--- a/pkg/integrations/claude/runcodeagent/types.go
+++ b/pkg/integrations/claude/runcodeagent/types.go
@@ -176,11 +176,7 @@ func buildOutput(status, sessionID, branch string, sm *runagent.SessionMessages,
 }
 
 // applyStructuredOutput sets out.Parsed by best-effort extracting JSON from
-// the agent's final message, when a schema is configured and the session
-// completed normally ("idle"). There is no server-side schema enforcement for
-// Managed Agents sessions (unlike output_config.format on the Messages API),
-// so this is prompt-guided and best-effort — a "terminated" session may have
-// errored or been interrupted mid-task, so its message is not trusted either.
+// the agent's final message.
 func applyStructuredOutput(out *OutputPayload, status string, schema map[string]any) {
 	if schema == nil || status != sessionStatusIdle || out.LastMessage == "" {
 		return
@@ -191,9 +187,7 @@ func applyStructuredOutput(out *OutputPayload, status string, schema map[string]
 }
 
 // schemaFromConfiguration re-derives the parsed output schema from the node's
-// raw configuration for the async poll path, where the schema was already
-// validated at Setup/Execute — a decode or parse failure here is tolerated as
-// "no schema" rather than failing an otherwise-complete run.
+// raw configuration for the async poll path.
 func schemaFromConfiguration(config any) map[string]any {
 	spec, err := decodeSpec(config)
 	if err != nil {

--- a/web_src/src/pages/app/mappers/claude/run_agent.spec.ts
+++ b/web_src/src/pages/app/mappers/claude/run_agent.spec.ts
@@ -115,6 +115,52 @@ describe("runAgentMapper.getExecutionDetails", () => {
     const details = runAgentMapper.getExecutionDetails(ctx);
     expect(details["Artifacts"]).toBeUndefined();
   });
+
+  it("surfaces parsed structured output as JSON", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: { default: [buildOutput({ status: "idle", parsed: { summary: "looks good" } })] },
+      },
+    });
+    const details = runAgentMapper.getExecutionDetails(ctx);
+    expect(details["Parsed Output"]).toBe('{"summary":"looks good"}');
+  });
+
+  it("omits parsed output when structured output was not configured", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({ status: "idle" })] } },
+    });
+    const details = runAgentMapper.getExecutionDetails(ctx);
+    expect(details["Parsed Output"]).toBeUndefined();
+  });
+});
+
+describe("runAgentMapper node metadata", () => {
+  it("shows a structured output badge when the schema is configured", () => {
+    const props = runAgentMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: { outputSchema: "{}" } }) }),
+    );
+    expect(props.metadata).toEqual([{ icon: "braces", label: "Structured output" }]);
+  });
+
+  it("omits the badge when no schema is configured", () => {
+    const props = runAgentMapper.props(buildPropsContext());
+    expect(props.metadata).toEqual([]);
+  });
+
+  it("falls back to node metadata when the node has no configuration yet", () => {
+    const props = runAgentMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: undefined, metadata: { structuredOutput: true } }) }),
+    );
+    expect(props.metadata).toEqual([{ icon: "braces", label: "Structured output" }]);
+  });
+
+  it("prefers the live configuration over stale metadata", () => {
+    const props = runAgentMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: {}, metadata: { structuredOutput: true } }) }),
+    );
+    expect(props.metadata).toEqual([]);
+  });
 });
 
 describe("runAgentMapper.props", () => {

--- a/web_src/src/pages/app/mappers/claude/run_agent.ts
+++ b/web_src/src/pages/app/mappers/claude/run_agent.ts
@@ -10,6 +10,7 @@ import type {
   OutputPayload,
   SubtitleContext,
 } from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
 import claudeIcon from "@/assets/icons/integrations/claude.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 
@@ -27,6 +28,15 @@ type RunAgentPayloadData = {
   lastMessage?: string;
   messages?: unknown[];
   artifacts?: SessionArtifact[];
+  parsed?: unknown;
+};
+
+type RunAgentNodeMetadata = {
+  structuredOutput?: boolean;
+};
+
+type RunAgentConfiguration = {
+  outputSchema?: string;
 };
 
 function addDetail(details: Record<string, string>, key: string, value: string | undefined) {
@@ -45,6 +55,40 @@ function formatArtifacts(artifacts?: SessionArtifact[]): string | undefined {
   return names.length > 0 ? names.join(", ") : undefined;
 }
 
+// formatParsed renders the structured-output JSON extracted from the agent's
+// final message. Best-effort: the backend only sets this when a schema is
+// configured and the session finished normally, so it's absent otherwise.
+function formatParsed(parsed?: unknown): string | undefined {
+  if (parsed === undefined || parsed === null) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function hasSchema(schema: unknown): boolean {
+  return typeof schema === "string" && schema.trim().length > 0;
+}
+
+// metadataList shows the structured-output badge on the canvas node tile. It's
+// derived from the live configuration when available, since autosave updates
+// configuration only, not metadata (which can lag behind).
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const items: MetadataItem[] = [];
+  const meta = node.metadata as RunAgentNodeMetadata | undefined;
+  const config = node.configuration as RunAgentConfiguration | undefined;
+
+  const structured = config ? hasSchema(config.outputSchema) : Boolean(meta?.structuredOutput);
+  if (structured) {
+    items.push({ icon: "braces", label: "Structured output" });
+  }
+
+  return items;
+}
+
 export const runAgentMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
@@ -61,6 +105,7 @@ export const runAgentMapper: ComponentBaseMapper = {
         context.componentDefinition?.name ||
         "Run Managed Agent",
       eventSections: lastExecution ? runAgentEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
       includeEmptyState: !lastExecution,
       eventStateMap: getStateMap(componentName),
     };
@@ -79,6 +124,7 @@ export const runAgentMapper: ComponentBaseMapper = {
 
     addDetail(details, "Status", data.status);
     addDetail(details, "Session ID", data.sessionId);
+    addDetail(details, "Parsed Output", formatParsed(data.parsed));
     addDetail(details, "Artifacts", formatArtifacts(data.artifacts));
 
     return details;

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
@@ -201,6 +201,15 @@ describe("runCodeAgentMapper.props", () => {
     );
     expect(props.metadata).not.toContainEqual({ icon: "braces", label: "Structured output" });
   });
+
+  it("falls back to node metadata for structured output when configuration is null", () => {
+    const props = runCodeAgentMapper.props(
+      buildPropsContext({
+        node: buildNode({ configuration: null as unknown as undefined, metadata: { structuredOutput: true } }),
+      }),
+    );
+    expect(props.metadata).toContainEqual({ icon: "braces", label: "Structured output" });
+  });
 });
 
 describe("eventStateRegistry.runCodeAgent", () => {

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.spec.ts
@@ -130,6 +130,22 @@ describe("runCodeAgentMapper.getExecutionDetails", () => {
     );
     expect(withoutArtifacts["Artifacts"]).toBeUndefined();
   });
+
+  it("surfaces parsed structured output as JSON", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: { default: [buildOutput({ status: "idle", parsed: { summary: "fixed the bug" } })] },
+      },
+    });
+    const details = runCodeAgentMapper.getExecutionDetails(ctx);
+    expect(details["Parsed Output"]).toBe('{"summary":"fixed the bug"}');
+  });
+
+  it("omits parsed output when structured output was not configured", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({ status: "idle" })] } } });
+    const details = runCodeAgentMapper.getExecutionDetails(ctx);
+    expect(details["Parsed Output"]).toBeUndefined();
+  });
 });
 
 describe("runCodeAgentMapper.props", () => {
@@ -170,6 +186,20 @@ describe("runCodeAgentMapper.props", () => {
       { icon: "git-branch", label: "acme/widgets" },
       { icon: "git-branch", label: "develop" },
     ]);
+  });
+
+  it("shows a structured output badge when the schema is configured", () => {
+    const props = runCodeAgentMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: { outputSchema: "{}" } }) }),
+    );
+    expect(props.metadata).toContainEqual({ icon: "braces", label: "Structured output" });
+  });
+
+  it("prefers the live configuration over stale metadata for structured output", () => {
+    const props = runCodeAgentMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: {}, metadata: { structuredOutput: true } }) }),
+    );
+    expect(props.metadata).not.toContainEqual({ icon: "braces", label: "Structured output" });
   });
 });
 

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.ts
@@ -20,6 +20,7 @@ type RunCodeAgentNodeMetadata = {
   prUrl?: string;
   model?: string;
   sourceMode?: string;
+  structuredOutput?: boolean;
 };
 
 type RunCodeAgentConfiguration = {
@@ -28,6 +29,7 @@ type RunCodeAgentConfiguration = {
   baseBranch?: string;
   prUrl?: string;
   model?: string;
+  outputSchema?: string;
 };
 
 type RunCodeAgentArtifact = {
@@ -42,6 +44,7 @@ type RunCodeAgentPayloadData = {
   branch?: string;
   lastMessage?: string;
   artifacts?: RunCodeAgentArtifact[];
+  parsed?: unknown;
 };
 
 function addDetail(details: Record<string, string>, key: string, value: string | undefined) {
@@ -58,6 +61,24 @@ function formatArtifacts(artifacts?: RunCodeAgentArtifact[]): string | undefined
     .map((artifact) => artifact.filename || artifact.fileId)
     .filter((name): name is string => Boolean(name));
   return names.length > 0 ? names.join(", ") : undefined;
+}
+
+// formatParsed renders the structured-output JSON extracted from the agent's
+// final message. Best-effort: the backend only sets this when a schema is
+// configured and the session finished normally, so it's absent otherwise.
+function formatParsed(parsed?: unknown): string | undefined {
+  if (parsed === undefined || parsed === null) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function hasSchema(schema: unknown): boolean {
+  return typeof schema === "string" && schema.trim().length > 0;
 }
 
 export const runCodeAgentMapper: ComponentBaseMapper = {
@@ -96,6 +117,7 @@ export const runCodeAgentMapper: ComponentBaseMapper = {
       ["Status", data.status],
       ["Pull Request", data.prUrl],
       ["Branch", data.branch],
+      ["Parsed Output", formatParsed(data.parsed)],
       ["Artifacts", formatArtifacts(data.artifacts)],
     ];
     for (const [key, value] of entries) {
@@ -138,6 +160,14 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   const model = meta.model || config.model;
   if (model) {
     items.push({ icon: "bot", label: model });
+  }
+
+  // Unlike repository/model above, this prefers the live configuration when
+  // it exists at all (even if the schema was just cleared) — autosave
+  // updates configuration only, so node.metadata can lag behind.
+  const structured = node.configuration !== undefined ? hasSchema(config.outputSchema) : Boolean(meta.structuredOutput);
+  if (structured) {
+    items.push({ icon: "braces", label: "Structured output" });
   }
 
   return items;

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.ts
@@ -162,9 +162,6 @@ function metadataList(node: NodeInfo): MetadataItem[] {
     items.push({ icon: "bot", label: model });
   }
 
-  // Unlike repository/model above, this prefers the live configuration when
-  // it exists at all (even if the schema was just cleared) — autosave
-  // updates configuration only, so node.metadata can lag behind.
   const structured = node.configuration != null ? hasSchema(config.outputSchema) : Boolean(meta.structuredOutput);
   if (structured) {
     items.push({ icon: "braces", label: "Structured output" });

--- a/web_src/src/pages/app/mappers/claude/run_code_agent.ts
+++ b/web_src/src/pages/app/mappers/claude/run_code_agent.ts
@@ -165,7 +165,7 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   // Unlike repository/model above, this prefers the live configuration when
   // it exists at all (even if the schema was just cleared) — autosave
   // updates configuration only, so node.metadata can lag behind.
-  const structured = node.configuration !== undefined ? hasSchema(config.outputSchema) : Boolean(meta.structuredOutput);
+  const structured = node.configuration != null ? hasSchema(config.outputSchema) : Boolean(meta.structuredOutput);
   if (structured) {
     items.push({ icon: "braces", label: "Structured output" });
   }


### PR DESCRIPTION
## Summary
- Adds an optional JSON Schema (`outputSchema`) to `claude.runAgent` and `claude.runCodeAgent`, matching the option already on `claude.textPrompt`.
- Managed Agents sessions have no `output_config.format` equivalent (that's a Messages-API-only feature), so this works by appending schema instructions to the task prompt and best-effort parsing the final agent message into a `parsed` field — trusted only when the session completes normally (`idle`).
- Shared logic (`PromptSuffix`, `ExtractJSON`, `ValidateAtSetup`) lives in `pkg/configuration/structuredoutput` so both components (and any future agent component) reuse the same schema validation/config-field code already used by `textPrompt`.
- Frontend mappers for both components now surface a "Structured Output" badge on the node card (config-first, matching the existing `textPrompt` badge pattern to avoid staleness) and the parsed JSON in execution details.

