### PR TITLE
fix: improve textarea contrast in dark mode

### DIFF
--- a/web_src/src/components/Textarea/textarea.spec.tsx
+++ b/web_src/src/components/Textarea/textarea.spec.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Textarea } from "./textarea";
+
+describe("Textarea", () => {
+  it("uses a readable text color in dark mode", () => {
+    render(<Textarea aria-label="Secret value" />);
+
+    expect(screen.getByRole("textbox", { name: "Secret value" })).toHaveClass("dark:text-gray-100");
+  });
+});

--- a/web_src/src/components/Textarea/textarea.tsx
+++ b/web_src/src/components/Textarea/textarea.tsx
@@ -15,7 +15,7 @@ export const Textarea = forwardRef(function Textarea(
       ref={ref}
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-gray-500 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-sm wrap-anywhere whitespace-pre-wrap shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 text-[rgba(10,10,10,1)]",
+        "border-input placeholder:text-muted-foreground focus-visible:border-gray-500 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-sm wrap-anywhere whitespace-pre-wrap shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 text-[rgba(10,10,10,1)] dark:text-gray-100",
         resizable ? "resize-y" : "resize-none",
         className,
       )}


### PR DESCRIPTION
Closes #6137

## What changed

- Added an explicit dark-mode text color to the shared Textarea component.
- Added a focused regression test that checks the dark-mode class.

## Why

The Create Secret dialog uses the shared Textarea for secret values. The component set a dark background but kept its light-theme text color, making entered values difficult to read in dark mode.

## Verification

- Prettier check passed.
- Focused ESLint check passed.
- Focused Vitest regression test passed on Node 24.
- Git diff validation passed.