### PR TITLE
fix: apply dark theme on owner setup pages

### DIFF
--- a/web_src/src/pages/auth/OwnerSetup.tsx
+++ b/web_src/src/pages/auth/OwnerSetup.tsx
@@ -231,8 +231,8 @@ const OwnerSetup: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-100 px-4 py-8">
-      <div className="max-w-md w-full bg-white dark:bg-gray-900 rounded-lg outline outline-gray-950/10 shadow-sm p-8">
+    <div className="min-h-screen flex items-center justify-center bg-gray-400 px-4 py-8 dark:bg-gray-950">
+      <div className="max-w-md w-full rounded-lg bg-white p-8 shadow-sm outline outline-gray-950/10 dark:bg-gray-900 dark:outline-gray-700/70">
         {step === "owner" && (
           <OwnerStep
             email={email}

--- a/web_src/src/pages/auth/ownerSetup/OwnerStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/OwnerStep.tsx
@@ -25,7 +25,7 @@ type OwnerStepProps = {
 
 const OwnerStepHeader = (
   <div className="mb-8 text-center">
-    <img src={superplaneLogo} alt="SuperPlane logo" className="mx-auto mb-4 h-8 w-8" />
+    <img src={superplaneLogo} alt="SuperPlane logo" className="mx-auto mb-4 h-8 w-8 dark:brightness-0 dark:invert" />
     <h4 className="mb-1 text-xl font-medium text-gray-800 dark:text-white">Set up owner account</h4>
     <Text className="text-gray-800 dark:text-gray-300">Create an account for this SuperPlane instance.</Text>
   </div>
@@ -54,7 +54,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div>
           <Label className="mb-2 block text-left">
-            First Name <span className="text-gray-800">*</span>
+            First Name <span className="text-gray-800 dark:text-gray-300">*</span>
           </Label>
           <InputGroup>
             <Input
@@ -71,7 +71,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
         </div>
         <div>
           <Label className="mb-2 block text-left">
-            Last Name <span className="text-gray-800">*</span>
+            Last Name <span className="text-gray-800 dark:text-gray-300">*</span>
           </Label>
           <InputGroup>
             <Input
@@ -89,7 +89,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
       </div>
       <div>
         <Label className="mb-2 block text-left">
-          Email <span className="text-gray-800">*</span>
+          Email <span className="text-gray-800 dark:text-gray-300">*</span>
         </Label>
         <InputGroup>
           <Input
@@ -104,7 +104,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
       </div>
       <div>
         <Label className="mb-2 block text-left">
-          Password <span className="text-gray-800">*</span>
+          Password <span className="text-gray-800 dark:text-gray-300">*</span>
         </Label>
         <InputGroup>
           <Input
@@ -125,7 +125,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
       </div>
       <div>
         <Label className="mb-2 block text-left">
-          Confirm Password <span className="text-gray-800">*</span>
+          Confirm Password <span className="text-gray-800 dark:text-gray-300">*</span>
         </Label>
         <InputGroup>
           <Input

--- a/web_src/src/pages/auth/ownerSetup/PrivateNetworkStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/PrivateNetworkStep.tsx
@@ -33,18 +33,20 @@ export const PrivateNetworkStep: React.FC<PrivateNetworkStepProps> = ({
       </Text>
     </div>
 
-    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-4 text-left">
+    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-4 text-left dark:border-gray-700/70 dark:bg-gray-800/60">
       <div className="flex items-start justify-between gap-6">
         <div className="max-w-xs">
-          <Label className="mb-1 block text-sm font-medium text-gray-800">Allow private network targets</Label>
-          <Text className="text-sm text-gray-600">
+          <Label className="mb-1 block text-sm font-medium">Allow private network targets</Label>
+          <Text className="text-sm text-gray-600 dark:text-gray-400">
             Enable this if SuperPlane needs to reach tools inside your VPC, private Kubernetes cluster, or another
             closed network. This reduces SSRF protection for private addresses.
           </Text>
         </div>
 
         <div className="flex items-center gap-3">
-          <span className="text-xs text-gray-500">{allowPrivateNetworkAccess ? "Enabled" : "Disabled"}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {allowPrivateNetworkAccess ? "Enabled" : "Disabled"}
+          </span>
           <Switch
             data-testid="owner-setup-private-network-switch"
             checked={allowPrivateNetworkAccess}

--- a/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
@@ -68,7 +68,7 @@ const SmtpConfigFields: React.FC<SmtpConfigFieldsProps> = ({
   <>
     <div>
       <Label className="mb-2 block text-left">
-        SMTP Host <span className="text-gray-800">*</span>
+        SMTP Host <span className="text-gray-800 dark:text-gray-300">*</span>
       </Label>
       <InputGroup>
         <Input
@@ -84,7 +84,7 @@ const SmtpConfigFields: React.FC<SmtpConfigFieldsProps> = ({
 
     <div>
       <Label className="mb-2 block text-left">
-        SMTP Port <span className="text-gray-800">*</span>
+        SMTP Port <span className="text-gray-800 dark:text-gray-300">*</span>
       </Label>
       <InputGroup>
         <Input
@@ -140,7 +140,7 @@ const SmtpConfigFields: React.FC<SmtpConfigFieldsProps> = ({
 
     <div>
       <Label className="mb-2 block text-left">
-        From Email <span className="text-gray-800">*</span>
+        From Email <span className="text-gray-800 dark:text-gray-300">*</span>
       </Label>
       <InputGroup>
         <Input


### PR DESCRIPTION
In the setup pages, the inner settings card used light-only styles (bg-slate-50, gray text) while the Label component applies dark:text-gray-100. In dark mode that produced light label text on a white box. That generates things like this:

<img width="653" height="599" alt="no-dark-theme-on-setup" src="https://github.com/user-attachments/assets/cd5364e5-0913-42f8-b1c2-85b5fb21a537" />

---

Here, we apply the dark them properly in the owner setup pages.