### PR TITLE
fix: restore dark mode surfaces

### DIFF
--- a/web_src/src/components/Textarea/textarea.spec.tsx
+++ b/web_src/src/components/Textarea/textarea.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Textarea } from "./textarea";
+
+describe("Textarea", () => {
+  it("applies a dark-mode text color so typed values stay visible on dark backgrounds", () => {
+    render(<Textarea data-testid="textarea" />);
+
+    expect(screen.getByTestId("textarea").className).toContain("dark:text-gray-100");
+  });
+
+  it("keeps caller-provided classes when applying base theme styles", () => {
+    render(<Textarea data-testid="textarea" className="font-mono" />);
+
+    const textarea = screen.getByTestId("textarea");
+    expect(textarea.className).toContain("font-mono");
+    expect(textarea.className).toContain("dark:text-gray-100");
+  });
+});

--- a/web_src/src/components/Textarea/textarea.tsx
+++ b/web_src/src/components/Textarea/textarea.tsx
@@ -15,7 +15,7 @@ export const Textarea = forwardRef(function Textarea(
       ref={ref}
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-gray-500 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-sm wrap-anywhere whitespace-pre-wrap shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 text-[rgba(10,10,10,1)]",
+        "border-input placeholder:text-muted-foreground focus-visible:border-gray-500 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-sm wrap-anywhere whitespace-pre-wrap shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 text-[rgba(10,10,10,1)] dark:text-gray-100",
         resizable ? "resize-y" : "resize-none",
         className,
       )}

--- a/web_src/src/index.css
+++ b/web_src/src/index.css
@@ -63,8 +63,16 @@ div.monaco-editor .view-overlays .current-line {
 
 .dark div.monaco-editor {
   --vscode-focusBorder: transparent;
+  --vscode-editor-background: rgb(31 41 55);
+  --vscode-editorGutter-background: rgb(31 41 55);
+  --vscode-editor-foreground: rgb(243 244 246);
   --vscode-editorLineHighlightBackground: rgb(31 41 55);
   --vscode-editorLineHighlightBorder: transparent;
+}
+
+.dark div.monaco-editor .margin,
+.dark div.monaco-editor .monaco-editor-background {
+  background-color: rgb(31 41 55) !important;
 }
 
 .dark div.monaco-editor .margin-view-overlays .current-line,

--- a/web_src/src/pages/auth/OwnerSetup.tsx
+++ b/web_src/src/pages/auth/OwnerSetup.tsx
@@ -6,6 +6,8 @@ import { PrivateNetworkStep } from "./ownerSetup/PrivateNetworkStep";
 import { SmtpPromptStep } from "./ownerSetup/SmtpPromptStep";
 import { SmtpConfigStep } from "./ownerSetup/SmtpConfigStep";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
+import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
+import { cn } from "@/lib/utils";
 
 const OWNER_SETUP_SURVEY_NAME = "Owner Setup Survey";
 
@@ -231,8 +233,16 @@ const OwnerSetup: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-400 px-4 py-8 dark:bg-gray-950">
-      <div className="max-w-md w-full rounded-lg bg-white p-8 shadow-sm outline outline-gray-950/10 dark:bg-gray-900 dark:outline-gray-700/70">
+    <div
+      className={cn("min-h-screen flex items-center justify-center bg-slate-100 px-4 py-8", appDarkModeClasses.surface)}
+    >
+      <div
+        className={cn(
+          "max-w-md w-full rounded-lg bg-white p-8 shadow-sm",
+          appDarkModeClasses.modalEdge,
+          appDarkModeClasses.surfaceRaised,
+        )}
+      >
         {step === "owner" && (
           <OwnerStep
             email={email}

--- a/web_src/src/pages/auth/ownerSetup/OwnerStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/OwnerStep.tsx
@@ -54,7 +54,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div>
           <Label className="mb-2 block text-left">
-            First Name <span className="text-gray-800 dark:text-gray-300">*</span>
+            First Name <span className="text-gray-800 dark:text-gray-100">*</span>
           </Label>
           <InputGroup>
             <Input
@@ -71,7 +71,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
         </div>
         <div>
           <Label className="mb-2 block text-left">
-            Last Name <span className="text-gray-800 dark:text-gray-300">*</span>
+            Last Name <span className="text-gray-800 dark:text-gray-100">*</span>
           </Label>
           <InputGroup>
             <Input
@@ -89,7 +89,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
       </div>
       <div>
         <Label className="mb-2 block text-left">
-          Email <span className="text-gray-800 dark:text-gray-300">*</span>
+          Email <span className="text-gray-800 dark:text-gray-100">*</span>
         </Label>
         <InputGroup>
           <Input
@@ -104,7 +104,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
       </div>
       <div>
         <Label className="mb-2 block text-left">
-          Password <span className="text-gray-800 dark:text-gray-300">*</span>
+          Password <span className="text-gray-800 dark:text-gray-100">*</span>
         </Label>
         <InputGroup>
           <Input
@@ -125,7 +125,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
       </div>
       <div>
         <Label className="mb-2 block text-left">
-          Confirm Password <span className="text-gray-800 dark:text-gray-300">*</span>
+          Confirm Password <span className="text-gray-800 dark:text-gray-100">*</span>
         </Label>
         <InputGroup>
           <Input

--- a/web_src/src/pages/auth/ownerSetup/PrivateNetworkStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/PrivateNetworkStep.tsx
@@ -33,10 +33,12 @@ export const PrivateNetworkStep: React.FC<PrivateNetworkStepProps> = ({
       </Text>
     </div>
 
-    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-4 text-left dark:border-gray-700/70 dark:bg-gray-800/60">
+    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-4 text-left dark:border-gray-700 dark:bg-gray-900/60">
       <div className="flex items-start justify-between gap-6">
         <div className="max-w-xs">
-          <Label className="mb-1 block text-sm font-medium">Allow private network targets</Label>
+          <Label className="mb-1 block text-sm font-medium text-gray-800 dark:text-gray-100">
+            Allow private network targets
+          </Label>
           <Text className="text-sm text-gray-600 dark:text-gray-400">
             Enable this if SuperPlane needs to reach tools inside your VPC, private Kubernetes cluster, or another
             closed network. This reduces SSRF protection for private addresses.

--- a/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
@@ -68,7 +68,7 @@ const SmtpConfigFields: React.FC<SmtpConfigFieldsProps> = ({
   <>
     <div>
       <Label className="mb-2 block text-left">
-        SMTP Host <span className="text-gray-800 dark:text-gray-300">*</span>
+        SMTP Host <span className="text-gray-800 dark:text-gray-100">*</span>
       </Label>
       <InputGroup>
         <Input
@@ -84,7 +84,7 @@ const SmtpConfigFields: React.FC<SmtpConfigFieldsProps> = ({
 
     <div>
       <Label className="mb-2 block text-left">
-        SMTP Port <span className="text-gray-800 dark:text-gray-300">*</span>
+        SMTP Port <span className="text-gray-800 dark:text-gray-100">*</span>
       </Label>
       <InputGroup>
         <Input
@@ -140,7 +140,7 @@ const SmtpConfigFields: React.FC<SmtpConfigFieldsProps> = ({
 
     <div>
       <Label className="mb-2 block text-left">
-        From Email <span className="text-gray-800 dark:text-gray-300">*</span>
+        From Email <span className="text-gray-800 dark:text-gray-100">*</span>
       </Label>
       <InputGroup>
         <Input

--- a/web_src/src/ui/BuildingBlocksSidebar/PayloadDialog.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/PayloadDialog.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import Editor from "@monaco-editor/react";
 import { Copy, Check } from "lucide-react";
 import { useState } from "react";
+import { useTheme } from "@/contexts/useTheme";
 
 interface PayloadDialogProps {
   open: boolean;
@@ -13,6 +14,8 @@ interface PayloadDialogProps {
 
 export function PayloadDialog({ open, onOpenChange, title, payloadString }: PayloadDialogProps) {
   const [copied, setCopied] = useState(false);
+  const { resolvedTheme } = useTheme();
+  const monacoTheme = resolvedTheme === "dark" ? "vs-dark" : "vs";
   const lineCount = payloadString.split("\n").length;
   const lineHeight = 19;
   const editorHeight = Math.min(Math.max(lineCount * lineHeight + 10, 100), 500);
@@ -42,7 +45,7 @@ export function PayloadDialog({ open, onOpenChange, title, payloadString }: Payl
             height={`${editorHeight}px`}
             defaultLanguage="json"
             value={payloadString}
-            theme="vs"
+            theme={monacoTheme}
             options={{
               readOnly: true,
               minimap: { enabled: false },

--- a/web_src/src/ui/componentBase/PayloadTooltip.spec.tsx
+++ b/web_src/src/ui/componentBase/PayloadTooltip.spec.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PayloadTooltip } from "./PayloadTooltip";
+
+const monacoThemes = vi.hoisted((): string[] => []);
+
+vi.mock("@/contexts/useTheme", () => ({
+  useTheme: () => ({ preference: "dark", resolvedTheme: "dark", setPreference: () => undefined }),
+}));
+
+vi.mock("@monaco-editor/react", () => ({
+  default: ({ theme, value }: { theme?: string; value?: string }) => {
+    monacoThemes.push(theme ?? "");
+    return <pre data-testid="monaco-editor">{value}</pre>;
+  },
+}));
+
+vi.mock("@tippyjs/react/headless", () => ({
+  default: ({
+    children,
+    render: renderTooltip,
+  }: {
+    children: React.ReactNode;
+    render: (attrs: Record<string, unknown>) => React.ReactNode;
+  }) => (
+    <div>
+      {renderTooltip({})}
+      {children}
+    </div>
+  ),
+}));
+
+describe("PayloadTooltip", () => {
+  it("uses dark tooltip surfaces and the dark Monaco theme", () => {
+    render(
+      <PayloadTooltip title="Payload" value={{ ok: true }}>
+        <span>payload trigger</span>
+      </PayloadTooltip>,
+    );
+
+    expect(screen.getByText("Payload").parentElement?.parentElement?.className).toContain("dark:bg-gray-900");
+    expect(screen.getByText("Payload").className).toContain("dark:text-gray-400");
+    expect(monacoThemes).toContain("vs-dark");
+  });
+
+  it("renders missing text payloads without crashing", () => {
+    render(
+      <PayloadTooltip title="Payload" value={undefined} contentType="text">
+        <span>payload trigger</span>
+      </PayloadTooltip>,
+    );
+
+    expect(screen.getByTestId("monaco-editor")).toHaveTextContent("");
+  });
+});

--- a/web_src/src/ui/componentBase/PayloadTooltip.tsx
+++ b/web_src/src/ui/componentBase/PayloadTooltip.tsx
@@ -1,129 +1,81 @@
 import Tippy from "@tippyjs/react/headless";
 import type { ReactElement } from "react";
 import Editor from "@monaco-editor/react";
+import { useTheme } from "@/contexts/useTheme";
 import "tippy.js/dist/tippy.css";
 
 interface PayloadTooltipProps {
   children: React.ReactNode;
   title: string;
-  value: any;
+  value: unknown;
   contentType?: "json" | "xml" | "text";
 }
 
+interface PayloadEditorProps {
+  contentType: NonNullable<PayloadTooltipProps["contentType"]>;
+  monacoTheme: string;
+  value: unknown;
+}
+
+function stringifyPayloadValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return JSON.stringify(value, null, 2) ?? "";
+}
+
+function payloadLanguage(contentType: PayloadEditorProps["contentType"]): "json" | "xml" | "plaintext" {
+  if (contentType === "xml") {
+    return "xml";
+  }
+
+  if (contentType === "json") {
+    return "json";
+  }
+
+  return "plaintext";
+}
+
+function PayloadEditor({ contentType, monacoTheme, value }: PayloadEditorProps) {
+  const stringValue = stringifyPayloadValue(value);
+  const lineCount = stringValue.split("\n").length;
+  const lineHeight = 19;
+  const calculatedHeight = Math.min(Math.max(lineCount * lineHeight + 10, 100), 350);
+  const language = payloadLanguage(contentType);
+
+  return (
+    <div className="overflow-hidden" style={{ height: `${calculatedHeight}px`, width: "100%", minWidth: "300px" }}>
+      <Editor
+        height="100%"
+        width="100%"
+        defaultLanguage={language}
+        value={stringValue}
+        theme={monacoTheme}
+        options={{
+          readOnly: true,
+          minimap: { enabled: false },
+          fontSize: 12,
+          lineNumbers: "off",
+          wordWrap: "on",
+          folding: language !== "plaintext",
+          scrollBeyondLastLine: false,
+          renderWhitespace: "none",
+          contextmenu: true,
+          cursorStyle: "line",
+          scrollbar: {
+            vertical: "auto",
+            horizontal: "auto",
+          },
+        }}
+      />
+    </div>
+  );
+}
+
 export function PayloadTooltip({ children, title, value, contentType = "json" }: PayloadTooltipProps) {
-  const renderContent = () => {
-    // For JSON objects, use Monaco Editor
-    if (contentType === "json" && typeof value === "object") {
-      const stringValue = JSON.stringify(value, null, 2);
-
-      // Calculate height based on line count (max 350px)
-      const lineCount = stringValue.split("\n").length;
-      const lineHeight = 19; // Monaco's default line height at 12px font
-      const calculatedHeight = Math.min(Math.max(lineCount * lineHeight + 10, 100), 350);
-
-      return (
-        <div className="overflow-hidden" style={{ height: `${calculatedHeight}px`, width: "100%", minWidth: "300px" }}>
-          <Editor
-            height="100%"
-            width="100%"
-            defaultLanguage="json"
-            value={stringValue}
-            theme="vs"
-            options={{
-              readOnly: true,
-              minimap: { enabled: false },
-              fontSize: 12,
-              lineNumbers: "off",
-              wordWrap: "on",
-              folding: true,
-              scrollBeyondLastLine: false,
-              renderWhitespace: "none",
-              contextmenu: true,
-              cursorStyle: "line",
-              scrollbar: {
-                vertical: "auto",
-                horizontal: "auto",
-              },
-            }}
-          />
-        </div>
-      );
-    }
-
-    // For XML, use Monaco Editor with syntax highlighting
-    if (contentType === "xml") {
-      const stringValue = typeof value === "string" ? value : String(value);
-
-      // Calculate height based on line count (max 350px)
-      const lineCount = stringValue.split("\n").length;
-      const lineHeight = 19; // Monaco's default line height at 12px font
-      const calculatedHeight = Math.min(Math.max(lineCount * lineHeight + 10, 100), 350);
-
-      return (
-        <div className="overflow-hidden" style={{ height: `${calculatedHeight}px`, width: "100%", minWidth: "300px" }}>
-          <Editor
-            height="100%"
-            width="100%"
-            defaultLanguage="xml"
-            value={stringValue}
-            theme="vs"
-            options={{
-              readOnly: true,
-              minimap: { enabled: false },
-              fontSize: 12,
-              lineNumbers: "off",
-              wordWrap: "on",
-              folding: true,
-              scrollBeyondLastLine: false,
-              renderWhitespace: "none",
-              contextmenu: true,
-              cursorStyle: "line",
-              scrollbar: {
-                vertical: "auto",
-                horizontal: "auto",
-              },
-            }}
-          />
-        </div>
-      );
-    }
-
-    // For plain text, use Monaco Editor
-    const stringValue = typeof value === "string" ? value : JSON.stringify(value, null, 2);
-
-    // Calculate height based on line count (max 350px)
-    const lineCount = stringValue.split("\n").length;
-    const lineHeight = 19; // Monaco's default line height at 12px font
-    const calculatedHeight = Math.min(Math.max(lineCount * lineHeight + 10, 100), 350);
-
-    return (
-      <div className="overflow-hidden" style={{ height: `${calculatedHeight}px`, width: "100%", minWidth: "300px" }}>
-        <Editor
-          height="100%"
-          width="100%"
-          defaultLanguage="plaintext"
-          value={stringValue}
-          theme="vs"
-          options={{
-            readOnly: true,
-            minimap: { enabled: false },
-            fontSize: 12,
-            lineNumbers: "off",
-            wordWrap: "on",
-            folding: false,
-            scrollBeyondLastLine: false,
-            renderWhitespace: "none",
-            contextmenu: true,
-            cursorStyle: "line",
-            scrollbar: {
-              vertical: "auto",
-              horizontal: "auto",
-            },
-          }}
-        />
-      </div>
-    );
-  };
+  const { resolvedTheme } = useTheme();
+  const monacoTheme = resolvedTheme === "dark" ? "vs-dark" : "vs";
 
   // Use wider tooltip for XML and text content
   const maxWidth = contentType === "xml" || contentType === "text" ? "max-w-[700px]" : "max-w-[500px]";
@@ -133,13 +85,15 @@ export function PayloadTooltip({ children, title, value, contentType = "json" }:
       render={(attrs) => (
         <div
           {...attrs}
-          className={`bg-white border-2 border-gray-200 rounded-md ${maxWidth} max-h-[400px] overflow-auto text-left shadow-lg`}
+          className={`rounded-md border-2 border-gray-200 bg-white ${maxWidth} max-h-[400px] overflow-auto text-left shadow-lg dark:border-gray-700 dark:bg-gray-900`}
           style={{ zIndex: 10000 }}
         >
-          <div className="flex items-center border-b p-2">
-            <span className="font-medium text-gray-500 text-sm">{title}</span>
+          <div className="flex items-center border-b border-gray-200 p-2 dark:border-gray-700">
+            <span className="text-sm font-medium text-gray-500 dark:text-gray-400">{title}</span>
           </div>
-          <div className="p-2">{renderContent()}</div>
+          <div className="p-2">
+            <PayloadEditor contentType={contentType} monacoTheme={monacoTheme} value={value} />
+          </div>
         </div>
       )}
       placement="top"

--- a/web_src/src/ui/componentBase/SpecsTooltip.spec.tsx
+++ b/web_src/src/ui/componentBase/SpecsTooltip.spec.tsx
@@ -49,4 +49,22 @@ describe("SpecsTooltip", () => {
     expect(screen.getByText("workflow_input")).toBeInTheDocument();
     expect(screen.queryByText("undefined")).not.toBeInTheDocument();
   });
+
+  it("includes dark-mode surface classes for metadata tooltips", () => {
+    render(
+      <SpecsTooltip
+        specTitle="input"
+        specValues={[
+          {
+            badges: [{ label: "workflow_input", bgColor: "bg-gray-100", textColor: "text-gray-800" }],
+          },
+        ]}
+      >
+        <span>trigger</span>
+      </SpecsTooltip>,
+    );
+
+    expect(screen.getByText("1 input").parentElement?.parentElement?.className).toContain("dark:bg-gray-900");
+    expect(screen.getByText("1 input").className).toContain("dark:text-gray-400");
+  });
 });

--- a/web_src/src/ui/componentBase/SpecsTooltip.tsx
+++ b/web_src/src/ui/componentBase/SpecsTooltip.tsx
@@ -11,87 +11,89 @@ interface SpecsTooltipProps {
   hideCount?: boolean;
 }
 
+const MAX_BADGE_CHUNK_LENGTH = 120;
+const BADGE_SEPARATOR_REGEX = /[\s,()[\]{}<>:+\-*/=|&.!?]/;
+
+function splitBadgeLabel(label: string): string[] {
+  if (label.length <= MAX_BADGE_CHUNK_LENGTH) {
+    return [label];
+  }
+
+  const chunks: string[] = [];
+  let remaining = label;
+
+  while (remaining.length > MAX_BADGE_CHUNK_LENGTH) {
+    let splitAt = -1;
+    for (let i = MAX_BADGE_CHUNK_LENGTH - 1; i >= 0; i -= 1) {
+      if (BADGE_SEPARATOR_REGEX.test(remaining[i])) {
+        splitAt = i + 1;
+        break;
+      }
+    }
+
+    if (splitAt <= 0) {
+      splitAt = MAX_BADGE_CHUNK_LENGTH;
+    }
+
+    const chunk = remaining.slice(0, splitAt).trim();
+    if (chunk.length > 0) {
+      chunks.push(chunk);
+    }
+
+    remaining = remaining.slice(splitAt).trim();
+  }
+
+  if (remaining.length > 0) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}
+
+function renderBadgeLabel(badge: ComponentBaseSpecValue["badges"][number], badgeIndex: number) {
+  if (!badge) {
+    return [];
+  }
+
+  const badgeLabel = typeof badge.label === "string" ? badge.label.trim() : "";
+  if (badgeLabel.length === 0) {
+    return [];
+  }
+
+  const chunks = splitBadgeLabel(badgeLabel);
+  const shouldStartOnNewLine = badgeLabel.length > MAX_BADGE_CHUNK_LENGTH;
+
+  return chunks.map((chunk, chunkIndex) => (
+    <span
+      key={`${badgeIndex}-${chunkIndex}`}
+      className={`rounded px-2 py-1 font-mono text-xs break-words ${chunkIndex === 0 && shouldStartOnNewLine ? "basis-full" : ""} ${badge.bgColor} ${badge.textColor}`}
+      style={{ wordBreak: "break-word", overflowWrap: "break-word" }}
+    >
+      {chunk}
+    </span>
+  ));
+}
+
 export function SpecsTooltip({ children, specTitle, specValues, tooltipTitle, hideCount }: SpecsTooltipProps) {
   return (
     <Tippy
       render={(attrs) => (
         <div
           {...attrs}
-          className="bg-white outline-1 outline-slate-300 shadow-md rounded-md max-w-[800px] overflow-auto"
+          className="max-w-[800px] overflow-auto rounded-md bg-white shadow-md outline-1 outline-slate-300 dark:bg-gray-900 dark:outline-gray-700"
           style={{ zIndex: 10000, maxHeight: "400px" }}
         >
-          <div className="flex items-center border-b border-slate-300">
-            <span className="font-medium text-gray-500 text-[13px] px-3 py-1.5">
+          <div className="flex items-center border-b border-slate-300 dark:border-gray-700">
+            <span className="px-3 py-1.5 text-[13px] font-medium text-gray-500 dark:text-gray-400">
               {!hideCount ? specValues.length : ""} {tooltipTitle || specTitle}
             </span>
           </div>
           {specValues.map((value, index) => (
             <div
               key={index}
-              className={`flex flex-wrap max-w-[800px] items-start gap-2 p-2 ${index === specValues.length - 1 ? "border-b-0" : "border-b"}`}
+              className={`flex max-w-[800px] flex-wrap items-start gap-2 p-2 ${index === specValues.length - 1 ? "border-b-0" : "border-b border-slate-200 dark:border-gray-800"}`}
             >
-              {value.badges.flatMap((badge, badgeIndex) => {
-                if (!badge) {
-                  return [];
-                }
-
-                const badgeLabel = typeof badge.label === "string" ? badge.label : "";
-                if (badgeLabel.trim().length === 0) {
-                  return [];
-                }
-
-                const maxChunkLength = 120;
-                if (badgeLabel.length <= maxChunkLength) {
-                  return (
-                    <span
-                      key={`${badgeIndex}-0`}
-                      className={`px-2 py-1 rounded text-xs font-mono break-words ${badge.bgColor} ${badge.textColor}`}
-                      style={{ wordBreak: "break-word", overflowWrap: "break-word" }}
-                    >
-                      {badgeLabel}
-                    </span>
-                  );
-                }
-
-                const separatorRegex = /[\s,()[\]{}<>:+\-*/=|&.!?]/;
-                const chunks: string[] = [];
-                let remaining = badgeLabel;
-
-                while (remaining.length > maxChunkLength) {
-                  let splitAt = -1;
-                  for (let i = maxChunkLength - 1; i >= 0; i -= 1) {
-                    if (separatorRegex.test(remaining[i])) {
-                      splitAt = i + 1;
-                      break;
-                    }
-                  }
-
-                  if (splitAt <= 0) {
-                    splitAt = maxChunkLength;
-                  }
-
-                  const chunk = remaining.slice(0, splitAt).trim();
-                  if (chunk.length > 0) {
-                    chunks.push(chunk);
-                  }
-
-                  remaining = remaining.slice(splitAt).trim();
-                }
-
-                if (remaining.length > 0) {
-                  chunks.push(remaining);
-                }
-
-                return chunks.map((chunk, chunkIndex) => (
-                  <span
-                    key={`${badgeIndex}-${chunkIndex}`}
-                    className={`px-2 py-1 rounded text-xs font-mono break-words ${chunkIndex === 0 ? "basis-full" : ""} ${badge.bgColor} ${badge.textColor}`}
-                    style={{ wordBreak: "break-word", overflowWrap: "break-word" }}
-                  >
-                    {chunk}
-                  </span>
-                ));
-              })}
+              {value.badges.flatMap(renderBadgeLabel)}
             </div>
           ))}
         </div>


### PR DESCRIPTION
Fixes #6137
Fixes #6194

## Summary
- Make the shared base `Textarea` readable in dark mode so secret values are visible while creating secrets.
- Apply dark-mode surfaces to the owner setup flow, including required markers and the private network step card.
- Bring metadata/specs and payload tooltips onto dark surfaces, and use the resolved app theme for payload Monaco editors.
- Harden Monaco dark-mode CSS so editor and gutter backgrounds do not flash or remain light in dark mode.

## Validation
- `cd web_src && npm run test -- src/components/Textarea/textarea.spec.tsx src/ui/componentBase/SpecsTooltip.spec.tsx src/ui/componentBase/PayloadTooltip.spec.tsx`
- `make format.js`
- `make pb.gen` (to refresh ignored generated API client files for the local build)
- `make check.lint.ui`
- `make check.build.ui`

Note: local/container `npm install` was needed to restore missing Rolldown optional native bindings before running tests/build; no lockfile changes were included.