### PR TITLE
fix: fail stalled loop executions

### DIFF
--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -88,6 +88,11 @@ type CanvasNodeExecution struct {
 	Configuration datatypes.JSONType[map[string]any]
 }
 
+type CanvasRunActiveExecution struct {
+	CanvasNodeExecution
+	NodeComponentName string `gorm:"column:node_component_name"`
+}
+
 func (e *CanvasNodeExecution) TableName() string {
 	return "workflow_node_executions"
 }
@@ -225,6 +230,34 @@ func ListActiveNodeExecutions(tx *gorm.DB, workflowID uuid.UUID, nodeID string) 
 		Where("workflow_id = ?", workflowID).
 		Where("node_id = ?", nodeID).
 		Where("state IN ?", CanvasNodeExecutionActiveStates).
+		Find(&executions).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return executions, nil
+}
+
+func ListActiveCanvasRunExecutions(tx *gorm.DB, runID uuid.UUID) ([]CanvasRunActiveExecution, error) {
+	var executions []CanvasRunActiveExecution
+	err := tx.
+		Table("workflow_node_executions").
+		Select(`
+			workflow_node_executions.*,
+			workflow_nodes.ref #>> '{component,name}' AS node_component_name
+		`).
+		Joins(`
+			INNER JOIN workflow_nodes
+				ON workflow_nodes.workflow_id = workflow_node_executions.workflow_id
+				AND workflow_nodes.node_id = workflow_node_executions.node_id
+				AND workflow_nodes.deleted_at IS NULL
+		`).
+		Where("workflow_node_executions.run_id = ?", runID).
+		Where("workflow_node_executions.state IN ?", []string{
+			CanvasNodeExecutionStatePending,
+			CanvasNodeExecutionStateStarted,
+		}).
 		Find(&executions).
 		Error
 	if err != nil {

--- a/pkg/workers/run_finalizer.go
+++ b/pkg/workers/run_finalizer.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/telemetry"
 	"google.golang.org/protobuf/proto"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -27,6 +28,8 @@ const (
 
 	runFinalizerReasonAlreadyFinished = "already_finished"
 	runFinalizerReasonOpenWork        = "open_work"
+
+	loopComponentName = "loop"
 )
 
 type RunFinalizer struct {
@@ -286,10 +289,11 @@ func (w *RunFinalizer) finalizeRun(workflowID, runID uuid.UUID, trigger string) 
 	})
 
 	var finalized bool
+	var updatedExecutionIDs []uuid.UUID
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		var skipReason string
 		var err error
-		finalized, skipReason, err = w.maybeFinalizeRun(tx, runID, trigger)
+		finalized, updatedExecutionIDs, skipReason, err = w.maybeFinalizeRun(tx, runID, trigger)
 		if skipReason != "" {
 			outcome = executorOutcomeSkipped
 			reason = skipReason
@@ -302,6 +306,12 @@ func (w *RunFinalizer) finalizeRun(workflowID, runID uuid.UUID, trigger string) 
 		outcome = executorOutcomeFailed
 		reason = classifyProcessError(err)
 		return err
+	}
+
+	for _, executionID := range updatedExecutionIDs {
+		if err := messages.PublishCanvasExecutionByID(workflowID, executionID); err != nil {
+			w.logger.WithError(err).Warnf("Failed to publish execution state message for execution %s", executionID)
+		}
 	}
 
 	if !finalized {
@@ -317,19 +327,34 @@ func (w *RunFinalizer) finalizeRun(workflowID, runID uuid.UUID, trigger string) 
 	return nil
 }
 
-func (w *RunFinalizer) maybeFinalizeRun(tx *gorm.DB, runID uuid.UUID, trigger string) (bool, string, error) {
+func (w *RunFinalizer) maybeFinalizeRun(tx *gorm.DB, runID uuid.UUID, trigger string) (bool, []uuid.UUID, string, error) {
 	run, err := models.LockCanvasRunInTransaction(tx, runID)
 	if err != nil {
-		return false, "", err
+		return false, nil, "", err
 	}
 
 	if run.State == models.CanvasRunStateFinished {
-		return false, runFinalizerReasonAlreadyFinished, nil
+		return false, nil, runFinalizerReasonAlreadyFinished, nil
 	}
 
 	openWork, err := models.FindOpenCanvasRunWorkInTransaction(tx, runID)
 	if err != nil {
-		return false, "", err
+		return false, nil, "", err
+	}
+
+	var updatedExecutionIDs []uuid.UUID
+	if openWork.HasActiveExecutions && !openWork.HasQueueItems && !openWork.HasPendingEvents {
+		updatedExecutionIDs, err = w.failStalledLoopExecutions(tx, runID)
+		if err != nil {
+			return false, nil, "", err
+		}
+
+		if len(updatedExecutionIDs) > 0 {
+			openWork, err = models.FindOpenCanvasRunWorkInTransaction(tx, runID)
+			if err != nil {
+				return false, nil, "", err
+			}
+		}
 	}
 
 	if openWork.HasActiveExecutions || openWork.HasQueueItems || openWork.HasPendingEvents {
@@ -338,15 +363,15 @@ func (w *RunFinalizer) maybeFinalizeRun(tx *gorm.DB, runID uuid.UUID, trigger st
 			// LIMIT N. Bump updated_at here so a run that is still open is pushed to
 			// the back of the queue instead of being retried on every tick.
 			now := time.Now()
-			return false, runFinalizerReasonOpenWork, tx.Model(run).Update("updated_at", &now).Error
+			return false, updatedExecutionIDs, runFinalizerReasonOpenWork, tx.Model(run).Update("updated_at", &now).Error
 		}
 
-		return false, runFinalizerReasonOpenWork, nil
+		return false, updatedExecutionIDs, runFinalizerReasonOpenWork, nil
 	}
 
 	result, err := models.CalculateCanvasRunResultInTransaction(tx, runID)
 	if err != nil {
-		return false, "", err
+		return false, nil, "", err
 	}
 
 	now := time.Now()
@@ -360,8 +385,68 @@ func (w *RunFinalizer) maybeFinalizeRun(tx *gorm.DB, runID uuid.UUID, trigger st
 		Error
 
 	if err != nil {
-		return false, "", err
+		return false, nil, "", err
 	}
 
-	return true, "", nil
+	return true, updatedExecutionIDs, "", nil
+}
+
+func (w *RunFinalizer) failStalledLoopExecutions(tx *gorm.DB, runID uuid.UUID) ([]uuid.UUID, error) {
+	activeExecutions, err := models.ListActiveCanvasRunExecutions(tx, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(activeExecutions) == 0 {
+		return nil, nil
+	}
+
+	loopExecutions := make([]models.CanvasNodeExecution, 0, len(activeExecutions))
+	for _, execution := range activeExecutions {
+		if execution.NodeComponentName != loopComponentName {
+			return nil, nil
+		}
+
+		if loopExecutionIsWaitingBetweenIterations(execution.CanvasNodeExecution) {
+			return nil, nil
+		}
+
+		loopExecutions = append(loopExecutions, execution.CanvasNodeExecution)
+	}
+
+	failedExecutionIDs := make([]uuid.UUID, 0, len(loopExecutions))
+	for i := range loopExecutions {
+		if err := failStalledLoopExecution(tx, &loopExecutions[i]); err != nil {
+			return nil, err
+		}
+		failedExecutionIDs = append(failedExecutionIDs, loopExecutions[i].ID)
+	}
+
+	return failedExecutionIDs, nil
+}
+
+func loopExecutionIsWaitingBetweenIterations(execution models.CanvasNodeExecution) bool {
+	waiting, _ := execution.Metadata.Data()["waitingBetweenIterations"].(bool)
+	return waiting
+}
+
+func failStalledLoopExecution(tx *gorm.DB, execution *models.CanvasNodeExecution) error {
+	metadata := execution.Metadata.Data()
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+
+	metadata["active"] = false
+	metadata["waitingBetweenIterations"] = false
+	execution.Metadata = datatypes.NewJSONType(metadata)
+	if err := tx.Model(execution).Update("metadata", execution.Metadata).Error; err != nil {
+		return err
+	}
+
+	_, err := execution.FailInTransaction(
+		tx,
+		models.CanvasNodeExecutionResultReasonError,
+		"loop cannot reach the loop conclusion because all downstream work has reached a terminal state",
+	)
+	return err
 }

--- a/pkg/workers/run_finalizer_test.go
+++ b/pkg/workers/run_finalizer_test.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/protobuf/proto"
+	"gorm.io/datatypes"
 )
 
 func Test__RunFinalizer_FinalizesRunAfterTerminalExecutionEvent(t *testing.T) {
@@ -155,6 +156,204 @@ func Test__RunFinalizer_DoesNotFinalizeRunWithOpenWork(t *testing.T) {
 	updatedRun, err := models.FindCanvasRunByRootEventInTransaction(database.Conn(), event.ID)
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasRunStateStarted, updatedRun.State)
+}
+
+func Test__RunFinalizer_FailsStalledLoopExecution(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	finalizer := NewRunFinalizer(amqpURL)
+	r := support.Setup(t)
+
+	trigger := "trigger-1"
+	loopNode := "loop-1"
+	bodyNode := "body-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: trigger, Type: models.NodeTypeTrigger},
+			{
+				NodeID: loopNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "loop"}}),
+			},
+			{NodeID: bodyNode, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: trigger, TargetID: loopNode, Channel: "default"},
+			{SourceID: loopNode, TargetID: bodyNode, Channel: "next"},
+			{SourceID: bodyNode, TargetID: loopNode, Channel: "default"},
+		},
+	)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, trigger, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), event)
+	require.NoError(t, err)
+	require.NoError(t, event.Routed())
+
+	loopExecution := support.CreateCanvasNodeExecution(t, canvas.ID, loopNode, event.ID, event.ID)
+	loopExecution.RunID = run.ID
+	require.NoError(t, database.Conn().Model(loopExecution).Updates(map[string]any{
+		"run_id": run.ID,
+		"state":  models.CanvasNodeExecutionStateStarted,
+		"metadata": datatypes.NewJSONType(map[string]any{
+			"active":                   true,
+			"waitingBetweenIterations": false,
+		}),
+	}).Error)
+
+	bodyExecution := support.CreateCanvasNodeExecution(t, canvas.ID, bodyNode, event.ID, event.ID)
+	bodyExecution.RunID = run.ID
+	require.NoError(t, database.Conn().Model(bodyExecution).Updates(map[string]any{
+		"run_id":         run.ID,
+		"state":          models.CanvasNodeExecutionStateFinished,
+		"result":         models.CanvasNodeExecutionResultFailed,
+		"result_reason":  models.CanvasNodeExecutionResultReasonError,
+		"result_message": "body failed",
+	}).Error)
+
+	require.NoError(t, finalizer.finalizeRun(canvas.ID, run.ID, runFinalizerTriggerExecutionFinished))
+
+	updatedRun, err := models.FindCanvasRunByRootEventInTransaction(database.Conn(), event.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
+	assert.Equal(t, models.CanvasRunResultFailed, updatedRun.Result)
+	assert.NotNil(t, updatedRun.FinishedAt)
+
+	updatedLoopExecution, err := models.FindNodeExecutionInTransaction(database.Conn(), canvas.ID, loopExecution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedLoopExecution.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultFailed, updatedLoopExecution.Result)
+	assert.Equal(t, models.CanvasNodeExecutionResultReasonError, updatedLoopExecution.ResultReason)
+	assert.Contains(t, updatedLoopExecution.ResultMessage, "cannot reach the loop conclusion")
+	assert.False(t, updatedLoopExecution.Metadata.Data()["active"].(bool))
+}
+
+func Test__RunFinalizer_DoesNotFailLoopExecutionWithOtherActiveExecution(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	finalizer := NewRunFinalizer(amqpURL)
+	r := support.Setup(t)
+
+	trigger := "trigger-1"
+	loopNode := "loop-1"
+	activeNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: trigger, Type: models.NodeTypeTrigger},
+			{
+				NodeID: loopNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "loop"}}),
+			},
+			{NodeID: activeNode, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: trigger, TargetID: loopNode, Channel: "default"},
+			{SourceID: trigger, TargetID: activeNode, Channel: "default"},
+		},
+	)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, trigger, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), event)
+	require.NoError(t, err)
+	require.NoError(t, event.Routed())
+
+	loopExecution := support.CreateCanvasNodeExecution(t, canvas.ID, loopNode, event.ID, event.ID)
+	loopExecution.RunID = run.ID
+	require.NoError(t, database.Conn().Model(loopExecution).Updates(map[string]any{
+		"run_id": run.ID,
+		"state":  models.CanvasNodeExecutionStateStarted,
+		"metadata": datatypes.NewJSONType(map[string]any{
+			"active":                   true,
+			"waitingBetweenIterations": false,
+		}),
+	}).Error)
+
+	activeExecution := support.CreateCanvasNodeExecution(t, canvas.ID, activeNode, event.ID, event.ID)
+	activeExecution.RunID = run.ID
+	require.NoError(t, database.Conn().Model(activeExecution).Updates(map[string]any{
+		"run_id": run.ID,
+		"state":  models.CanvasNodeExecutionStateStarted,
+	}).Error)
+
+	finalized, updatedExecutionIDs, skipReason, err := finalizer.maybeFinalizeRun(
+		database.Conn(),
+		run.ID,
+		runFinalizerTriggerExecutionFinished,
+	)
+	require.NoError(t, err)
+	assert.False(t, finalized)
+	assert.Equal(t, runFinalizerReasonOpenWork, skipReason)
+	assert.Empty(t, updatedExecutionIDs)
+
+	updatedRun, err := models.FindCanvasRunByRootEventInTransaction(database.Conn(), event.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateStarted, updatedRun.State)
+
+	updatedLoopExecution, err := models.FindNodeExecutionInTransaction(database.Conn(), canvas.ID, loopExecution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateStarted, updatedLoopExecution.State)
+
+	updatedActiveExecution, err := models.FindNodeExecutionInTransaction(database.Conn(), canvas.ID, activeExecution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateStarted, updatedActiveExecution.State)
+}
+
+func Test__RunFinalizer_DoesNotFailLoopWaitingBetweenIterations(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	finalizer := NewRunFinalizer(amqpURL)
+	r := support.Setup(t)
+
+	trigger := "trigger-1"
+	loopNode := "loop-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: trigger, Type: models.NodeTypeTrigger},
+			{
+				NodeID: loopNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "loop"}}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: trigger, TargetID: loopNode, Channel: "default"},
+		},
+	)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, trigger, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), event)
+	require.NoError(t, err)
+	require.NoError(t, event.Routed())
+
+	loopExecution := support.CreateCanvasNodeExecution(t, canvas.ID, loopNode, event.ID, event.ID)
+	loopExecution.RunID = run.ID
+	require.NoError(t, database.Conn().Model(loopExecution).Updates(map[string]any{
+		"run_id": run.ID,
+		"state":  models.CanvasNodeExecutionStateStarted,
+		"metadata": datatypes.NewJSONType(map[string]any{
+			"active":                   true,
+			"waitingBetweenIterations": true,
+		}),
+	}).Error)
+
+	require.NoError(t, finalizer.finalizeRun(canvas.ID, run.ID, runFinalizerTriggerSweep))
+
+	updatedRun, err := models.FindCanvasRunByRootEventInTransaction(database.Conn(), event.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateStarted, updatedRun.State)
+
+	updatedLoopExecution, err := models.FindNodeExecutionInTransaction(database.Conn(), canvas.ID, loopExecution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateStarted, updatedLoopExecution.State)
 }
 
 func Test__RunFinalizer_SweepTouchesUpdatedAtWhenRunHasOpenWork(t *testing.T) {

--- a/test/e2e/loop_test.go
+++ b/test/e2e/loop_test.go
@@ -1,0 +1,178 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/workers/contexts"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+)
+
+func TestLoopComponent(t *testing.T) {
+	t.Run("routes feedback into done", func(t *testing.T) {
+		steps := &loopSteps{t: t}
+		steps.start()
+		steps.givenLoopCanvasWithBody("noop", map[string]any{}, "default")
+		steps.whenManualTriggerRuns()
+		steps.thenRunFinishes(models.CanvasRunResultPassed)
+		steps.thenLoopExecutionFinishes(models.CanvasNodeExecutionResultPassed)
+		steps.thenNodeExecutes("Done")
+	})
+
+	t.Run("fails when body cannot return feedback", func(t *testing.T) {
+		steps := &loopSteps{t: t}
+		steps.start()
+		steps.givenLoopCanvasWithBody("filter", map[string]any{"expression": "false"}, "default")
+		steps.whenManualTriggerRuns()
+		steps.thenNodeExecutes("Body")
+		steps.thenRunFinishes(models.CanvasRunResultFailed)
+		steps.thenLoopExecutionFinishes(models.CanvasNodeExecutionResultFailed)
+	})
+}
+
+type loopSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *models.Canvas
+	run     *models.CanvasRun
+}
+
+func (s *loopSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *loopSteps) givenLoopCanvasWithBody(bodyComponent string, bodyConfiguration map[string]any, bodyFeedbackChannel string) {
+	user, err := models.FindMaybeDeletedUserByEmail(s.session.OrgID.String(), s.session.Account.Email)
+	require.NoError(s.t, err)
+
+	canvas, _ := support.CreateCanvas(
+		s.t,
+		s.session.OrgID,
+		user.ID,
+		[]models.CanvasNode{
+			triggerNode("start-trigger", "Start"),
+			componentNode("loop", "Loop", "loop", map[string]any{
+				"untilExpression": "false",
+				"maxIterations":   1,
+			}),
+			componentNode("body", "Body", bodyComponent, bodyConfiguration),
+			componentNode("done", "Done", "noop", map[string]any{}),
+		},
+		[]models.Edge{
+			{SourceID: "start-trigger", TargetID: "loop", Channel: "default"},
+			{SourceID: "loop", TargetID: "body", Channel: "next"},
+			{SourceID: "body", TargetID: "loop", Channel: bodyFeedbackChannel},
+			{SourceID: "loop", TargetID: "done", Channel: "done"},
+		},
+	)
+
+	s.canvas = canvas
+}
+
+func triggerNode(id, name string) models.CanvasNode {
+	return models.CanvasNode{
+		NodeID: id,
+		Name:   name,
+		Type:   models.NodeTypeTrigger,
+		Ref: datatypes.NewJSONType(models.NodeRef{
+			Trigger: &models.TriggerRef{Name: "start"},
+		}),
+		Configuration: datatypes.NewJSONType(map[string]any{}),
+	}
+}
+
+func componentNode(id, name, component string, configuration map[string]any) models.CanvasNode {
+	return models.CanvasNode{
+		NodeID: id,
+		Name:   name,
+		Type:   models.NodeTypeComponent,
+		Ref: datatypes.NewJSONType(models.NodeRef{
+			Component: &models.ComponentRef{Name: component},
+		}),
+		Configuration: datatypes.NewJSONType(configuration),
+	}
+}
+
+func (s *loopSteps) whenManualTriggerRuns() {
+	node, err := models.FindCanvasNode(database.Conn(), s.canvas.ID, "start-trigger")
+	require.NoError(s.t, err)
+
+	eventContext := contexts.NewEventContext(database.Conn(), node, func(events []models.CanvasEvent) {
+		for i := range events {
+			require.NoError(s.t, messages.PublishCanvasEventCreatedMessage(&events[i]))
+		}
+	})
+
+	require.NoError(s.t, eventContext.Emit("manual.run", map[string]any{"source": "e2e"}))
+}
+
+func (s *loopSteps) thenRunFinishes(result string) {
+	var run models.CanvasRun
+	require.Eventually(s.t, func() bool {
+		err := database.Conn().
+			Where("workflow_id = ?", s.canvas.ID).
+			Order("created_at DESC").
+			First(&run).
+			Error
+		if err != nil {
+			return false
+		}
+
+		return run.State == models.CanvasRunStateFinished && run.Result == result
+	}, 30*time.Second, 300*time.Millisecond)
+
+	s.run = &run
+}
+
+func (s *loopSteps) thenLoopExecutionFinishes(result string) {
+	execution := s.waitForNodeExecution("loop", models.CanvasNodeExecutionStateFinished)
+	require.Equal(s.t, result, execution.Result)
+	if result == models.CanvasNodeExecutionResultFailed {
+		require.Contains(s.t, execution.ResultMessage, "cannot reach the loop conclusion")
+	}
+}
+
+func (s *loopSteps) thenNodeExecutes(nodeID string) {
+	s.waitForNodeExecution(nodeIDFromName(nodeID), models.CanvasNodeExecutionStateFinished)
+}
+
+func (s *loopSteps) waitForNodeExecution(nodeID, state string) models.CanvasNodeExecution {
+	var execution models.CanvasNodeExecution
+	require.Eventually(s.t, func() bool {
+		query := database.Conn().
+			Where("workflow_id = ?", s.canvas.ID).
+			Where("node_id = ?", nodeID).
+			Order("created_at DESC")
+		if s.run != nil {
+			query = query.Where("run_id = ?", s.run.ID)
+		}
+
+		err := query.First(&execution).Error
+		if err != nil {
+			return false
+		}
+
+		return execution.State == state
+	}, 30*time.Second, 300*time.Millisecond)
+
+	return execution
+}
+
+func nodeIDFromName(name string) string {
+	switch name {
+	case "Body":
+		return "body"
+	case "Done":
+		return "done"
+	default:
+		return name
+	}
+}


### PR DESCRIPTION
## Summary
- Fail loop executions when they are the only remaining open work and no queued item or pending event can move the run forward.
- Publish the failed loop execution update after finalization so subscribers see the component leave the running state.
- Add unit and E2E coverage for stalled loop failure, waiting-between-iterations behavior, and the normal loop `done` path.

Fixes #6200.

## Validation
- `make format.go`
- `make test PKG_TEST_PACKAGES=./pkg/workers`
- `make test.e2e.single FILE=test/e2e/loop_test.go LINE=17`
- `make test.e2e` (target exited 0; gotestsum reran an unrelated Agent E2E flake and it passed on rerun)
- `make check.lint.ui`
- `make lint`
- `make check.build.app`
