### PR TITLE
feat: add async run cancellation

### DIFF
--- a/.models-tx-debt-baseline.json
+++ b/.models-tx-debt-baseline.json
@@ -1,6 +1,6 @@
 {
-  "maxAllowedInTransactionDefinitions": 168,
-  "maxAllowedDatabaseConnCalls": 192,
+  "maxAllowedInTransactionDefinitions": 165,
+  "maxAllowedDatabaseConnCalls": 191,
   "inTransactionDefinitionKeys": [
     "pkg/models/account.go:MarkPasswordChangedInTransaction",
     "pkg/models/account.go:CreateAccountInTransaction",
@@ -88,13 +88,10 @@
     "pkg/models/canvas_run.go:FindCanvasRunByRootEventInTransaction",
     "pkg/models/canvas_run.go:FindOrCreateCanvasRunForRootEventInTransaction",
     "pkg/models/canvas_run.go:CreateCanvasRunInTransaction",
-    "pkg/models/canvas_run.go:ListStartedCanvasRunsInTransaction",
     "pkg/models/canvas_run.go:ListCanvasRunsInTransaction",
     "pkg/models/canvas_run.go:CountCanvasRunsInTransaction",
     "pkg/models/canvas_run.go:ListExecutionsForRunsInTransaction",
     "pkg/models/canvas_run.go:LockCanvasRunInTransaction",
-    "pkg/models/canvas_run.go:FindOpenCanvasRunWorkInTransaction",
-    "pkg/models/canvas_run.go:CalculateCanvasRunResultInTransaction",
     "pkg/models/canvas_version.go:FindCanvasVersionInTransaction",
     "pkg/models/canvas_version.go:FindVersionByCommitSHAInTransaction",
     "pkg/models/canvas_version.go:FindCanvasVersionsByIDsInTransaction",
@@ -265,7 +262,6 @@
     "pkg/models/canvas_node_execution.go:Cancel:database.Conn()#1",
     "pkg/models/canvas_node_execution.go:GetOutputs:database.Conn()#1",
     "pkg/models/canvas_node_request.go:ListNodeRequests:database.Conn()#1",
-    "pkg/models/canvas_run.go:ListStartedCanvasRuns:database.Conn()#1",
     "pkg/models/canvas_run.go:ListCanvasRuns:database.Conn()#1",
     "pkg/models/canvas_run.go:CountCanvasRuns:database.Conn()#1",
     "pkg/models/canvas_version.go:FindCanvasVersion:database.Conn()#1",
@@ -365,5 +361,5 @@
     "pkg/models/webhook.go:ListDeletedWebhooks:database.Conn()#1",
     "pkg/models/webhook.go:ResetStuckProvisioningWebhooks:database.Conn()#1"
   ],
-  "updatedAt": "2026-07-06T20:09:19Z"
+  "updatedAt": "2026-07-17T03:07:38Z"
 }

--- a/db/migrations/20260717021445_add-run-cancellation-columns.up.sql
+++ b/db/migrations/20260717021445_add-run-cancellation-columns.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE workflow_runs
+    ADD COLUMN IF NOT EXISTS cancelled_at timestamp without time zone,
+    ADD COLUMN IF NOT EXISTS cancelled_by uuid REFERENCES users(id);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_cancelling ON workflow_runs (cancelled_at)
+    WHERE state = 'cancelling';

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -672,7 +672,9 @@ CREATE TABLE public.workflow_runs (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     finished_at timestamp without time zone,
-    version_id uuid NOT NULL
+    version_id uuid NOT NULL,
+    cancelled_at timestamp without time zone,
+    cancelled_by uuid
 );
 
 
@@ -1579,6 +1581,13 @@ CREATE INDEX idx_workflow_nodes_state ON public.workflow_nodes USING btree (stat
 
 
 --
+-- Name: idx_workflow_runs_cancelling; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_workflow_runs_cancelling ON public.workflow_runs USING btree (cancelled_at) WHERE ((state)::text = 'cancelling'::text);
+
+
+--
 -- Name: idx_workflow_runs_version_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2094,6 +2103,14 @@ ALTER TABLE ONLY public.workflow_nodes
 
 
 --
+-- Name: workflow_runs workflow_runs_cancelled_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_runs
+    ADD CONSTRAINT workflow_runs_cancelled_by_fkey FOREIGN KEY (cancelled_by) REFERENCES public.users(id);
+
+
+--
 -- Name: workflow_runs workflow_runs_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2205,7 +2222,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260716230544	f
+20260717021445	f
 \.
 
 

--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -163,6 +163,12 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			DomainType:         models.DomainTypeOrganization,
 			ResourcePathParams: []string{CanvasIDPathParam},
 		},
+		{Method: "PATCH", Pattern: "/api/v1/canvases/{canvas_id}/runs/{run_id}/cancel"}: {
+			Resource:           "canvases",
+			Action:             "update",
+			DomainType:         models.DomainTypeOrganization,
+			ResourcePathParams: []string{CanvasIDPathParam},
+		},
 		{Method: "GET", Pattern: "/api/v1/canvases/{canvas_id}/versions"}: {
 			Resource:           "canvases",
 			Action:             "read",

--- a/pkg/grpc/actions/canvases/cancel_run.go
+++ b/pkg/grpc/actions/canvases/cancel_run.go
@@ -1,0 +1,129 @@
+package canvases
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"gorm.io/gorm"
+)
+
+func CancelRun(ctx context.Context, organizationID string, workflowID, runID uuid.UUID) (*pb.CancelRunResponse, error) {
+	userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
+	if !userIsSet {
+		return nil, grpcerrors.PermissionDenied(nil, "user not authenticated")
+	}
+
+	user, err := models.FindActiveUserByID(organizationID, userID)
+	if err != nil {
+		return nil, grpcerrors.NotFound(err, "user not found")
+	}
+
+	var run *models.CanvasRun
+	var drainResult *models.RunCancellationDrainResult
+	var publishCancelled bool
+
+	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
+		run, err = models.LockCanvasRunInTransaction(tx, runID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return grpcerrors.NotFound(err, "run not found")
+			}
+
+			return err
+		}
+
+		if run.WorkflowID != workflowID {
+			return grpcerrors.NotFound(nil, "run not found")
+		}
+
+		if run.State == models.CanvasRunStateFinished {
+			return nil
+		}
+
+		if run.State != models.CanvasRunStateCancelling {
+			if err := run.MarkAsCancelling(tx, &user.ID); err != nil {
+				return err
+			}
+
+			publishCancelled = true
+		}
+
+		drainResult, err = run.DrainForCancellation(tx, &user.ID)
+		return err
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if publishCancelled {
+		if err := messages.NewCanvasRunMessage(workflowID.String(), runID.String()).Publish(); err != nil {
+			log.Errorf("failed to publish run state RabbitMQ message: %v", err)
+		}
+	}
+
+	publishRunCancellationDrain(workflowID, drainResult)
+
+	run, err = models.FindCanvasRunInTransaction(database.DB(ctx), workflowID, runID)
+	if err != nil {
+		return nil, grpcerrors.Internal(err, "failed to load run")
+	}
+
+	runDetails, err := loadRunDetailsForRuns(ctx, workflowID, []uuid.UUID{run.ID})
+	if err != nil {
+		return nil, err
+	}
+
+	serializedRun, err := SerializeCanvasRun(
+		database.DB(ctx),
+		*run,
+		runDetails.rootEventsByRunID[run.ID.String()],
+		runDetails.executionsByRunID[run.ID.String()],
+		runDetails.queueItemsByRunID[run.ID.String()],
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.CancelRunResponse{
+		Run: serializedRun,
+	}, nil
+}
+
+func publishRunCancellationDrain(workflowID uuid.UUID, drainResult *models.RunCancellationDrainResult) {
+	if drainResult == nil {
+		return
+	}
+
+	for _, executionID := range drainResult.RequestedExecutionIDs {
+		if err := messages.PublishCanvasExecutionByID(workflowID, executionID); err != nil {
+			log.Errorf("failed to publish execution cancelling RabbitMQ message: %v", err)
+		}
+	}
+
+	for _, queueItem := range drainResult.DeletedQueueItems {
+		message := messages.NewCanvasQueueItemDeletedMessage(
+			workflowID.String(),
+			queueItem.ID.String(),
+			queueItem.NodeID,
+			queueItem.RunID.String(),
+		)
+		if err := message.PublishDeleted(); err != nil {
+			log.Errorf("failed to publish queue item deleted RabbitMQ message: %v", err)
+		}
+	}
+
+	for _, event := range drainResult.SupersededEvents {
+		if err := messages.PublishEventTerminal(event.WorkflowID, event.RunID, event.ID); err != nil {
+			log.Errorf("failed to publish event terminal RabbitMQ message: %v", err)
+		}
+	}
+}

--- a/pkg/grpc/actions/canvases/cancel_run.go
+++ b/pkg/grpc/actions/canvases/cancel_run.go
@@ -48,16 +48,27 @@ func CancelRun(ctx context.Context, organizationID string, workflowID, runID uui
 			return nil
 		}
 
-		if run.State != models.CanvasRunStateCancelling {
-			if err := run.MarkAsCancelling(tx, &user.ID); err != nil {
-				return err
-			}
-
-			publishCancelled = true
+		drainResult, err = run.DrainForCancellation(tx, &user.ID)
+		if err != nil {
+			return err
 		}
 
-		drainResult, err = run.DrainForCancellation(tx, &user.ID)
-		return err
+		if run.State == models.CanvasRunStateCancelling {
+			return nil
+		}
+
+		publishCancelled = true
+
+		//
+		// If drain results are expected, we mark the run as cancelling,
+		// and let RunFinalizer do its job, moving it to cancelled state when everything is done.
+		// Otherwise, we can mark it as cancelled immediately.
+		//
+		if !drainResult.Empty() {
+			return run.MarkAsCancelling(tx, &user.ID)
+		} else {
+			return run.MarkAsCancelled(tx, &user.ID)
+		}
 	})
 
 	if err != nil {

--- a/pkg/grpc/actions/canvases/cancel_run.go
+++ b/pkg/grpc/actions/canvases/cancel_run.go
@@ -58,17 +58,7 @@ func CancelRun(ctx context.Context, organizationID string, workflowID, runID uui
 		}
 
 		publishCancelled = true
-
-		//
-		// If drain results are expected, we mark the run as cancelling,
-		// and let RunFinalizer do its job, moving it to cancelled state when everything is done.
-		// Otherwise, we can mark it as cancelled immediately.
-		//
-		if !drainResult.Empty() {
-			return run.MarkAsCancelling(tx, &user.ID)
-		} else {
-			return run.MarkAsCancelled(tx, &user.ID)
-		}
+		return run.MarkAsCancelling(tx, &user.ID)
 	})
 
 	if err != nil {

--- a/pkg/grpc/actions/canvases/cancel_run.go
+++ b/pkg/grpc/actions/canvases/cancel_run.go
@@ -70,7 +70,7 @@ func CancelRun(ctx context.Context, organizationID string, workflowID, runID uui
 		}
 	}
 
-	publishRunCancellationDrain(workflowID, drainResult)
+	messages.PublishRunCancellationDrain(workflowID, drainResult)
 
 	run, err = models.FindCanvasRunInTransaction(database.DB(ctx), workflowID, runID)
 	if err != nil {
@@ -96,28 +96,4 @@ func CancelRun(ctx context.Context, organizationID string, workflowID, runID uui
 	return &pb.CancelRunResponse{
 		Run: serializedRun,
 	}, nil
-}
-
-func publishRunCancellationDrain(workflowID uuid.UUID, drainResult *models.RunCancellationDrainResult) {
-	if drainResult == nil {
-		return
-	}
-
-	for _, executionID := range drainResult.RequestedExecutionIDs {
-		if err := messages.PublishCanvasExecutionByID(workflowID, executionID); err != nil {
-			log.Errorf("failed to publish execution cancelling RabbitMQ message: %v", err)
-		}
-	}
-
-	for _, queueItem := range drainResult.DeletedQueueItems {
-		if err := messages.NewCanvasQueueItemMessage(queueItem).PublishDeleted(); err != nil {
-			log.Errorf("failed to publish queue item deleted RabbitMQ message: %v", err)
-		}
-	}
-
-	for _, event := range drainResult.SupersededEvents {
-		if err := messages.PublishEventTerminal(event.WorkflowID, event.RunID, event.ID); err != nil {
-			log.Errorf("failed to publish event terminal RabbitMQ message: %v", err)
-		}
-	}
 }

--- a/pkg/grpc/actions/canvases/cancel_run.go
+++ b/pkg/grpc/actions/canvases/cancel_run.go
@@ -110,13 +110,7 @@ func publishRunCancellationDrain(workflowID uuid.UUID, drainResult *models.RunCa
 	}
 
 	for _, queueItem := range drainResult.DeletedQueueItems {
-		message := messages.NewCanvasQueueItemDeletedMessage(
-			workflowID.String(),
-			queueItem.ID.String(),
-			queueItem.NodeID,
-			queueItem.RunID.String(),
-		)
-		if err := message.PublishDeleted(); err != nil {
+		if err := messages.NewCanvasQueueItemMessage(queueItem).PublishDeleted(); err != nil {
 			log.Errorf("failed to publish queue item deleted RabbitMQ message: %v", err)
 		}
 	}

--- a/pkg/grpc/actions/canvases/cancel_run_test.go
+++ b/pkg/grpc/actions/canvases/cancel_run_test.go
@@ -99,6 +99,63 @@ func Test__CancelRun__RequestsCancellationAndDrainsWork(t *testing.T) {
 	assert.Zero(t, queueItemCount)
 }
 
+func Test__CancelRun__CancelsImmediatelyWhenNothingToDrain(t *testing.T) {
+	r := support.Setup(t)
+
+	amqpURL, _ := config.RabbitMQURL()
+	runConsumer := testconsumer.New(amqpURL, messages.CanvasRunRoutingKey)
+	runConsumer.Start()
+	defer runConsumer.Stop()
+
+	executionCancellingConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionCancellingRoutingKey)
+	executionCancellingConsumer.Start()
+	defer executionCancellingConsumer.Stop()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "node-1",
+				Name:   "Node 1",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
+	require.NoError(t, err)
+	require.NoError(t, rootEvent.Routed())
+	require.Equal(t, models.CanvasRunStateStarted, run.State)
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+
+	response, err := CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.NotNil(t, response.Run)
+	assert.Equal(t, pb.CanvasRun_STATE_FINISHED, response.Run.State)
+	assert.Equal(t, pb.CanvasRun_RESULT_CANCELLED, response.Run.Result)
+	assert.True(t, runConsumer.HasReceivedMessage())
+	assert.False(t, executionCancellingConsumer.HasReceivedMessage())
+
+	updatedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
+	assert.Equal(t, models.CanvasRunResultCancelled, updatedRun.Result)
+	assert.NotNil(t, updatedRun.CancelledAt)
+	assert.NotNil(t, updatedRun.FinishedAt)
+	assert.NotNil(t, updatedRun.CancelledBy)
+	assert.Equal(t, r.User, *updatedRun.CancelledBy)
+	assert.NotNil(t, response.Run.FinishedAt)
+}
+
 func Test__CancelRun__IsIdempotentForCancellingRun(t *testing.T) {
 	r := support.Setup(t)
 

--- a/pkg/grpc/actions/canvases/cancel_run_test.go
+++ b/pkg/grpc/actions/canvases/cancel_run_test.go
@@ -99,63 +99,6 @@ func Test__CancelRun__RequestsCancellationAndDrainsWork(t *testing.T) {
 	assert.Zero(t, queueItemCount)
 }
 
-func Test__CancelRun__CancelsImmediatelyWhenNothingToDrain(t *testing.T) {
-	r := support.Setup(t)
-
-	amqpURL, _ := config.RabbitMQURL()
-	runConsumer := testconsumer.New(amqpURL, messages.CanvasRunRoutingKey)
-	runConsumer.Start()
-	defer runConsumer.Stop()
-
-	executionCancellingConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionCancellingRoutingKey)
-	executionCancellingConsumer.Start()
-	defer executionCancellingConsumer.Stop()
-
-	canvas, _ := support.CreateCanvas(
-		t,
-		r.Organization.ID,
-		r.User,
-		[]models.CanvasNode{
-			{
-				NodeID: "node-1",
-				Name:   "Node 1",
-				Type:   models.NodeTypeComponent,
-				Ref: datatypes.NewJSONType(models.NodeRef{
-					Component: &models.ComponentRef{Name: "noop"},
-				}),
-			},
-		},
-		[]models.Edge{},
-	)
-
-	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
-	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
-	require.NoError(t, err)
-	require.NoError(t, rootEvent.Routed())
-	require.Equal(t, models.CanvasRunStateStarted, run.State)
-
-	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
-
-	response, err := CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
-	require.NoError(t, err)
-	require.NotNil(t, response)
-	require.NotNil(t, response.Run)
-	assert.Equal(t, pb.CanvasRun_STATE_FINISHED, response.Run.State)
-	assert.Equal(t, pb.CanvasRun_RESULT_CANCELLED, response.Run.Result)
-	assert.True(t, runConsumer.HasReceivedMessage())
-	assert.False(t, executionCancellingConsumer.HasReceivedMessage())
-
-	updatedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
-	require.NoError(t, err)
-	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
-	assert.Equal(t, models.CanvasRunResultCancelled, updatedRun.Result)
-	assert.NotNil(t, updatedRun.CancelledAt)
-	assert.NotNil(t, updatedRun.FinishedAt)
-	assert.NotNil(t, updatedRun.CancelledBy)
-	assert.Equal(t, r.User, *updatedRun.CancelledBy)
-	assert.NotNil(t, response.Run.FinishedAt)
-}
-
 func Test__CancelRun__IsIdempotentForCancellingRun(t *testing.T) {
 	r := support.Setup(t)
 

--- a/pkg/grpc/actions/canvases/cancel_run_test.go
+++ b/pkg/grpc/actions/canvases/cancel_run_test.go
@@ -1,0 +1,200 @@
+package canvases
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/config"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	testconsumer "github.com/superplanehq/superplane/test/consumer"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+)
+
+func Test__CancelRun__RequestsCancellationAndDrainsWork(t *testing.T) {
+	r := support.Setup(t)
+
+	amqpURL, _ := config.RabbitMQURL()
+	runConsumer := testconsumer.New(amqpURL, messages.CanvasRunRoutingKey)
+	runConsumer.Start()
+	defer runConsumer.Stop()
+
+	executionCancellingConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionCancellingRoutingKey)
+	executionCancellingConsumer.Start()
+	defer executionCancellingConsumer.Stop()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "node-1",
+				Name:   "Node 1",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+			{
+				NodeID: "node-2",
+				Name:   "Node 2",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
+	require.NoError(t, err)
+	require.NoError(t, rootEvent.Routed())
+
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, "node-1", rootEvent.ID, rootEvent.ID)
+	execution.RunID = run.ID
+	execution.State = models.CanvasNodeExecutionStateStarted
+	require.NoError(t, database.Conn().Save(execution).Error)
+
+	queueItem := models.CanvasNodeQueueItem{
+		WorkflowID:  canvas.ID,
+		NodeID:      "node-2",
+		RootEventID: rootEvent.ID,
+		RunID:       run.ID,
+		EventID:     rootEvent.ID,
+	}
+	require.NoError(t, database.Conn().Create(&queueItem).Error)
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+
+	response, err := CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.NotNil(t, response.Run)
+	assert.Equal(t, pb.CanvasRun_STATE_CANCELLING, response.Run.State)
+	assert.True(t, runConsumer.HasReceivedMessage())
+	assert.True(t, executionCancellingConsumer.HasReceivedMessage())
+
+	updatedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateCancelling, updatedRun.State)
+	assert.NotNil(t, updatedRun.CancelledAt)
+
+	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateCancelling, updatedExecution.State)
+
+	var queueItemCount int64
+	require.NoError(t, database.Conn().Model(&models.CanvasNodeQueueItem{}).Where("run_id = ?", run.ID).Count(&queueItemCount).Error)
+	assert.Zero(t, queueItemCount)
+}
+
+func Test__CancelRun__IsIdempotentForCancellingRun(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "node-1",
+				Name:   "Node 1",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
+	require.NoError(t, err)
+
+	now := time.Now()
+	require.NoError(t, database.Conn().Model(run).Updates(map[string]any{
+		"state":        models.CanvasRunStateCancelling,
+		"cancelled_at": now,
+		"cancelled_by": r.User,
+	}).Error)
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+
+	_, err = CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	require.NoError(t, err)
+
+	_, err = CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	require.NoError(t, err)
+
+	updatedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateCancelling, updatedRun.State)
+}
+
+func Test__CancelRun__NoOpForFinishedRun(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "node-1",
+				Name:   "Node 1",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
+	require.NoError(t, err)
+
+	finishedAt := time.Now()
+	require.NoError(t, database.Conn().Model(run).Updates(map[string]any{
+		"state":       models.CanvasRunStateFinished,
+		"result":      models.CanvasRunResultPassed,
+		"finished_at": finishedAt,
+	}).Error)
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+
+	response, err := CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, pb.CanvasRun_STATE_FINISHED, response.Run.State)
+}
+
+func Test__CancelRun__ReturnsNotFoundForMissingRun(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{},
+		[]models.Edge{},
+	)
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+
+	_, err := CancelRun(ctx, r.Organization.ID.String(), canvas.ID, uuid.New())
+	require.Error(t, err)
+}

--- a/pkg/grpc/actions/canvases/commit_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_staging.go
@@ -224,13 +224,7 @@ func publishDeletedNodeCleanupMessages(canvasID uuid.UUID, result changesets.Can
 			continue
 		}
 
-		message := messages.NewCanvasQueueItemDeletedMessage(
-			canvasID.String(),
-			queueItem.ID.String(),
-			queueItem.NodeID,
-			queueItem.RunID.String(),
-		)
-		if err := message.PublishDeleted(); err != nil {
+		if err := messages.NewCanvasQueueItemMessage(queueItem).PublishDeleted(); err != nil {
 			log.Errorf("failed to publish deleted queue item RabbitMQ message: %v", err)
 		}
 	}

--- a/pkg/grpc/actions/canvases/delete_node_queue_item.go
+++ b/pkg/grpc/actions/canvases/delete_node_queue_item.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -25,9 +25,10 @@ func DeleteNodeQueueItem(ctx context.Context, registry *registry.Registry, workf
 		return nil, grpcerrors.InvalidArgument(err, "invalid item id")
 	}
 
+	var item models.CanvasNodeQueueItem
+
 	var runID uuid.UUID
 	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
-		var item models.CanvasNodeQueueItem
 		err := tx.
 			Where("id = ? AND workflow_id = ? AND node_id = ?", qID, wfID, nodeID).
 			First(&item).
@@ -52,8 +53,7 @@ func DeleteNodeQueueItem(ctx context.Context, registry *registry.Registry, workf
 	}
 
 	if runID != uuid.Nil {
-		message := messages.NewCanvasQueueItemDeletedMessage(wfID.String(), qID.String(), nodeID, runID.String())
-		if err := message.PublishDeleted(); err != nil {
+		if err := messages.NewCanvasQueueItemMessage(item).PublishDeleted(); err != nil {
 			log.Errorf("failed to publish queue item deleted RabbitMQ message: %v", err)
 		}
 	}

--- a/pkg/grpc/actions/canvases/list_runs.go
+++ b/pkg/grpc/actions/canvases/list_runs.go
@@ -201,6 +201,10 @@ func serializeCanvasRunWithQueueItemInputs(
 		serialized.FinishedAt = timestamppb.New(*run.FinishedAt)
 	}
 
+	if run.CancelledAt != nil {
+		serialized.CancelledAt = timestamppb.New(*run.CancelledAt)
+	}
+
 	return serialized, nil
 }
 
@@ -222,6 +226,8 @@ func ProtoRunStateToModel(state pb.CanvasRun_State) (string, error) {
 	switch state {
 	case pb.CanvasRun_STATE_STARTED:
 		return models.CanvasRunStateStarted, nil
+	case pb.CanvasRun_STATE_CANCELLING:
+		return models.CanvasRunStateCancelling, nil
 	case pb.CanvasRun_STATE_FINISHED:
 		return models.CanvasRunStateFinished, nil
 	default:
@@ -246,6 +252,8 @@ func RunStateToProto(state string) pb.CanvasRun_State {
 	switch state {
 	case models.CanvasRunStateStarted:
 		return pb.CanvasRun_STATE_STARTED
+	case models.CanvasRunStateCancelling:
+		return pb.CanvasRun_STATE_CANCELLING
 	case models.CanvasRunStateFinished:
 		return pb.CanvasRun_STATE_FINISHED
 	default:

--- a/pkg/grpc/actions/messages/queue_item.go
+++ b/pkg/grpc/actions/messages/queue_item.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -15,27 +16,23 @@ type CanvasQueueItemMessage struct {
 	message *pb.CanvasNodeQueueItemMessage
 }
 
-func NewCanvasQueueItemMessage(canvasId string, queueItemID, nodeID string) CanvasQueueItemMessage {
+func NewCanvasQueueItemMessage(queueItem models.CanvasNodeQueueItem) CanvasQueueItemMessage {
 	return CanvasQueueItemMessage{
 		message: &pb.CanvasNodeQueueItemMessage{
-			Id:        queueItemID,
-			CanvasId:  canvasId,
-			NodeId:    nodeID,
+			Id:        queueItem.ID.String(),
+			CanvasId:  queueItem.WorkflowID.String(),
+			NodeId:    queueItem.NodeID,
+			RunId:     queueItem.RunID.String(),
 			Timestamp: timestamppb.Now(),
 		},
 	}
 }
 
-func NewCanvasQueueItemDeletedMessage(canvasID, queueItemID, nodeID, runID string) CanvasQueueItemMessage {
-	message := NewCanvasQueueItemMessage(canvasID, queueItemID, nodeID)
-	message.message.RunId = runID
-	return message
+func (m CanvasQueueItemMessage) PublishConsumed() error {
+	return Publish(CanvasExchange, CanvasQueueItemConsumedRoutingKey, toBytes(m.message))
 }
 
-func (m CanvasQueueItemMessage) Publish(consumed bool) error {
-	if consumed {
-		return Publish(CanvasExchange, CanvasQueueItemConsumedRoutingKey, toBytes(m.message))
-	}
+func (m CanvasQueueItemMessage) PublishCreated() error {
 	return Publish(CanvasExchange, CanvasQueueItemCreatedRoutingKey, toBytes(m.message))
 }
 

--- a/pkg/grpc/actions/messages/run.go
+++ b/pkg/grpc/actions/messages/run.go
@@ -11,7 +11,7 @@ type CanvasRunMessage struct {
 	message *pb.CanvasRunMessage
 }
 
-func NewCanvasRunMessage(canvasID string, runID string) CanvasRunMessage {
+func NewCanvasRunMessage(canvasID, runID string) CanvasRunMessage {
 	return CanvasRunMessage{
 		message: &pb.CanvasRunMessage{
 			Id:        runID,

--- a/pkg/grpc/actions/messages/run_cancellation.go
+++ b/pkg/grpc/actions/messages/run_cancellation.go
@@ -1,0 +1,31 @@
+package messages
+
+import (
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func PublishRunCancellationDrain(workflowID uuid.UUID, drainResult *models.RunCancellationDrainResult) {
+	if drainResult == nil {
+		return
+	}
+
+	for _, executionID := range drainResult.RequestedExecutionIDs {
+		if err := PublishCanvasExecutionByID(workflowID, executionID); err != nil {
+			log.Errorf("failed to publish execution cancelling RabbitMQ message: %v", err)
+		}
+	}
+
+	for _, queueItem := range drainResult.DeletedQueueItems {
+		if err := NewCanvasQueueItemMessage(queueItem).PublishDeleted(); err != nil {
+			log.Errorf("failed to publish queue item deleted RabbitMQ message: %v", err)
+		}
+	}
+
+	for _, event := range drainResult.SupersededEvents {
+		if err := PublishEventTerminal(event.WorkflowID, event.RunID, event.ID); err != nil {
+			log.Errorf("failed to publish event terminal RabbitMQ message: %v", err)
+		}
+	}
+}

--- a/pkg/grpc/canvas_service.go
+++ b/pkg/grpc/canvas_service.go
@@ -234,6 +234,21 @@ func (s *CanvasService) DescribeRun(ctx context.Context, req *pb.DescribeRunRequ
 	return canvases.DescribeRun(ctx, s.registry, canvasID, req.RunId)
 }
 
+func (s *CanvasService) CancelRun(ctx context.Context, req *pb.CancelRunRequest) (*pb.CancelRunResponse, error) {
+	canvasID, err := uuid.Parse(req.CanvasId)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid canvas id")
+	}
+
+	runID, err := uuid.Parse(req.RunId)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid run id")
+	}
+
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvases.CancelRun(ctx, organizationID, canvasID, runID)
+}
+
 func (s *CanvasService) ListCanvasMemories(ctx context.Context, req *pb.ListCanvasMemoriesRequest) (*pb.ListCanvasMemoriesResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 	return canvases.ListCanvasMemories(ctx, s.registry, organizationID, req.CanvasId)

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -60,3 +60,10 @@ func WithWebhook(logger *log.Entry, webhook models.Webhook) *log.Entry {
 		"webhook_id": webhook.ID,
 	})
 }
+
+func WithRun(logger *log.Entry, run models.CanvasRun) *log.Entry {
+	return logger.WithFields(log.Fields{
+		"run_id":      run.ID,
+		"workflow_id": run.WorkflowID,
+	})
+}

--- a/pkg/models/canvas_node.go
+++ b/pkg/models/canvas_node.go
@@ -539,7 +539,7 @@ func cancelActiveExecutionsForDeletedNode(tx *gorm.DB, workflowID uuid.UUID, nod
 		return DeleteCanvasNodeResult{}, err
 	}
 
-	cancelledExecutionIDs, err := cancelNodeExecutions(tx, executions)
+	cancelledExecutionIDs, err := cancelNodeExecutions(tx, executions, nil)
 	if err != nil {
 		return DeleteCanvasNodeResult{}, err
 	}
@@ -574,7 +574,7 @@ func deleteQueueItemsForNode(tx *gorm.DB, workflowID uuid.UUID, nodeID string) (
 	return deletedQueueItems, nil
 }
 
-func cancelNodeExecutions(tx *gorm.DB, executions []CanvasNodeExecution) ([]uuid.UUID, error) {
+func cancelNodeExecutions(tx *gorm.DB, executions []CanvasNodeExecution, cancelledBy *uuid.UUID) ([]uuid.UUID, error) {
 	requestedCancellationIDs := make([]uuid.UUID, 0, len(executions))
 
 	for i := range executions {
@@ -583,7 +583,7 @@ func cancelNodeExecutions(tx *gorm.DB, executions []CanvasNodeExecution) ([]uuid
 			continue
 		}
 
-		if err := execution.RequestCancellation(tx, nil); err != nil {
+		if err := execution.RequestCancellation(tx, cancelledBy); err != nil {
 			return nil, err
 		}
 

--- a/pkg/models/canvas_node.go
+++ b/pkg/models/canvas_node.go
@@ -562,7 +562,7 @@ func cancelActiveExecutionsForDeletedNode(tx *gorm.DB, workflowID uuid.UUID, nod
 func deleteQueueItemsForNode(tx *gorm.DB, workflowID uuid.UUID, nodeID string) ([]CanvasNodeQueueItem, error) {
 	var deletedQueueItems []CanvasNodeQueueItem
 	err := tx.
-		Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}, {Name: "node_id"}, {Name: "run_id"}}}).
+		Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}, {Name: "node_id"}, {Name: "run_id"}, {Name: "workflow_id"}}}).
 		Where("workflow_id = ?", workflowID).
 		Where("node_id = ?", nodeID).
 		Delete(&deletedQueueItems).

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -350,10 +350,6 @@ type RunCancellationDrainResult struct {
 	SupersededEvents      []CanvasEvent
 }
 
-func (r *RunCancellationDrainResult) Empty() bool {
-	return len(r.RequestedExecutionIDs) == 0 && len(r.DeletedQueueItems) == 0 && len(r.SupersededEvents) == 0
-}
-
 func (r *CanvasRun) DrainForCancellation(tx *gorm.DB, cancelledBy *uuid.UUID) (*RunCancellationDrainResult, error) {
 	executions, err := r.ListExecutionsInStates(tx, []string{CanvasNodeExecutionStatePending, CanvasNodeExecutionStateStarted})
 	if err != nil {

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -409,7 +409,7 @@ func (r *CanvasRun) ListExecutionsInStates(tx *gorm.DB, states []string) ([]Canv
 func (r *CanvasRun) DeleteQueueItems(tx *gorm.DB) ([]CanvasNodeQueueItem, error) {
 	var deletedQueueItems []CanvasNodeQueueItem
 	err := tx.
-		Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}, {Name: "node_id"}, {Name: "run_id"}}}).
+		Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}, {Name: "node_id"}, {Name: "run_id"}, {Name: "workflow_id"}}}).
 		Where("workflow_id = ?", r.WorkflowID).
 		Where("run_id = ?", r.ID).
 		Delete(&deletedQueueItems).

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -350,6 +350,10 @@ type RunCancellationDrainResult struct {
 	SupersededEvents      []CanvasEvent
 }
 
+func (r *RunCancellationDrainResult) Empty() bool {
+	return len(r.RequestedExecutionIDs) == 0 && len(r.DeletedQueueItems) == 0 && len(r.SupersededEvents) == 0
+}
+
 func (r *CanvasRun) DrainForCancellation(tx *gorm.DB, cancelledBy *uuid.UUID) (*RunCancellationDrainResult, error) {
 	executions, err := r.ListExecutionsInStates(tx, []string{CanvasNodeExecutionStatePending, CanvasNodeExecutionStateStarted})
 	if err != nil {
@@ -448,6 +452,27 @@ func (r *CanvasRun) MarkAsCancelling(tx *gorm.DB, cancelledBy *uuid.UUID) error 
 			"state":        CanvasRunStateCancelling,
 			"cancelled_at": &now,
 			"cancelled_by": cancelledBy,
+			"updated_at":   &now,
+		}).
+		Error
+}
+
+func (r *CanvasRun) MarkAsCancelled(tx *gorm.DB, cancelledBy *uuid.UUID) error {
+	now := time.Now()
+	r.State = CanvasRunStateFinished
+	r.Result = CanvasRunResultCancelled
+	r.CancelledAt = &now
+	r.CancelledBy = cancelledBy
+	r.FinishedAt = &now
+	r.UpdatedAt = &now
+
+	return tx.Model(r).
+		Updates(map[string]any{
+			"state":        CanvasRunStateFinished,
+			"result":       CanvasRunResultCancelled,
+			"cancelled_at": &now,
+			"cancelled_by": cancelledBy,
+			"finished_at":  &now,
 			"updated_at":   &now,
 		}).
 		Error

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -456,24 +456,3 @@ func (r *CanvasRun) MarkAsCancelling(tx *gorm.DB, cancelledBy *uuid.UUID) error 
 		}).
 		Error
 }
-
-func (r *CanvasRun) MarkAsCancelled(tx *gorm.DB, cancelledBy *uuid.UUID) error {
-	now := time.Now()
-	r.State = CanvasRunStateFinished
-	r.Result = CanvasRunResultCancelled
-	r.CancelledAt = &now
-	r.CancelledBy = cancelledBy
-	r.FinishedAt = &now
-	r.UpdatedAt = &now
-
-	return tx.Model(r).
-		Updates(map[string]any{
-			"state":        CanvasRunStateFinished,
-			"result":       CanvasRunResultCancelled,
-			"cancelled_at": &now,
-			"cancelled_by": cancelledBy,
-			"finished_at":  &now,
-			"updated_at":   &now,
-		}).
-		Error
-}

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -123,11 +123,26 @@ func CreateCanvasRunInTransaction(tx *gorm.DB, workflowID uuid.UUID, state, resu
 	return run, nil
 }
 
-func ListCanvasRunsInState(db *gorm.DB, state string, limit int) ([]CanvasRun, error) {
+func ListStartedCanvasRuns(db *gorm.DB, limit int) ([]CanvasRun, error) {
 	var runs []CanvasRun
 	err := db.
-		Where("state = ?", state).
+		Where("state = ?", CanvasRunStateStarted).
 		Order("updated_at ASC").
+		Limit(limit).
+		Find(&runs).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return runs, nil
+}
+
+func ListCancellingCanvasRuns(db *gorm.DB, limit int) ([]CanvasRun, error) {
+	var runs []CanvasRun
+	err := db.
+		Where("state = ?", CanvasRunStateCancelling).
+		Order("cancelled_at DESC").
 		Limit(limit).
 		Find(&runs).
 		Error

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	CanvasRunStateStarted  = "started"
-	CanvasRunStateFinished = "finished"
+	CanvasRunStateStarted    = "started"
+	CanvasRunStateCancelling = "cancelling"
+	CanvasRunStateFinished   = "finished"
 
 	CanvasRunResultPassed    = "passed"
 	CanvasRunResultFailed    = "failed"
@@ -24,14 +25,16 @@ const (
 )
 
 type CanvasRun struct {
-	ID         uuid.UUID `gorm:"primaryKey;default:uuid_generate_v4()"`
-	WorkflowID uuid.UUID
-	VersionID  uuid.UUID
-	State      string
-	Result     string
-	CreatedAt  *time.Time
-	UpdatedAt  *time.Time
-	FinishedAt *time.Time
+	ID          uuid.UUID `gorm:"primaryKey;default:uuid_generate_v4()"`
+	WorkflowID  uuid.UUID
+	VersionID   uuid.UUID
+	State       string
+	Result      string
+	CancelledAt *time.Time
+	CancelledBy *uuid.UUID
+	CreatedAt   *time.Time
+	UpdatedAt   *time.Time
+	FinishedAt  *time.Time
 }
 
 func (r *CanvasRun) TableName() string {
@@ -120,14 +123,10 @@ func CreateCanvasRunInTransaction(tx *gorm.DB, workflowID uuid.UUID, state, resu
 	return run, nil
 }
 
-func ListStartedCanvasRuns(limit int) ([]CanvasRun, error) {
-	return ListStartedCanvasRunsInTransaction(database.Conn(), limit)
-}
-
-func ListStartedCanvasRunsInTransaction(tx *gorm.DB, limit int) ([]CanvasRun, error) {
+func ListCanvasRunsInState(db *gorm.DB, state string, limit int) ([]CanvasRun, error) {
 	var runs []CanvasRun
-	err := tx.
-		Where("state = ?", CanvasRunStateStarted).
+	err := db.
+		Where("state = ?", state).
 		Order("updated_at ASC").
 		Limit(limit).
 		Find(&runs).
@@ -248,7 +247,7 @@ type OpenCanvasRunWork struct {
 	HasPendingEvents    bool
 }
 
-func FindOpenCanvasRunWorkInTransaction(tx *gorm.DB, runID uuid.UUID) (*OpenCanvasRunWork, error) {
+func (r *CanvasRun) FindOpenWork(tx *gorm.DB) (*OpenCanvasRunWork, error) {
 	var result OpenCanvasRunWork
 	err := tx.Raw(`
 		SELECT
@@ -270,12 +269,12 @@ func FindOpenCanvasRunWorkInTransaction(tx *gorm.DB, runID uuid.UUID) (*OpenCanv
 				AND state = ?
 			) AS has_pending_events
 	`,
-		runID,
+		r.ID,
 		CanvasNodeExecutionStatePending,
 		CanvasNodeExecutionStateStarted,
 		CanvasNodeExecutionStateCancelling,
-		runID,
-		runID,
+		r.ID,
+		r.ID,
 		CanvasEventStatePending,
 	).Scan(&result).Error
 	if err != nil {
@@ -285,7 +284,11 @@ func FindOpenCanvasRunWorkInTransaction(tx *gorm.DB, runID uuid.UUID) (*OpenCanv
 	return &result, nil
 }
 
-func CalculateCanvasRunResultInTransaction(tx *gorm.DB, runID uuid.UUID) (string, error) {
+func (r *CanvasRun) CalculateResult(tx *gorm.DB) (string, error) {
+	if r.State == CanvasRunStateCancelling {
+		return CanvasRunResultCancelled, nil
+	}
+
 	var result struct {
 		HasFailed    bool
 		HasCancelled bool
@@ -306,9 +309,9 @@ func CalculateCanvasRunResultInTransaction(tx *gorm.DB, runID uuid.UUID) (string
 				AND result = ?
 			) AS has_cancelled
 	`,
-		runID,
+		r.ID,
 		CanvasNodeExecutionResultFailed,
-		runID,
+		r.ID,
 		CanvasNodeExecutionResultCancelled,
 	).Scan(&result).Error
 	if err != nil {
@@ -324,4 +327,113 @@ func CalculateCanvasRunResultInTransaction(tx *gorm.DB, runID uuid.UUID) (string
 	}
 
 	return CanvasRunResultPassed, nil
+}
+
+type RunCancellationDrainResult struct {
+	RequestedExecutionIDs []uuid.UUID
+	DeletedQueueItems     []CanvasNodeQueueItem
+	SupersededEvents      []CanvasEvent
+}
+
+func (r *CanvasRun) DrainForCancellation(tx *gorm.DB, cancelledBy *uuid.UUID) (*RunCancellationDrainResult, error) {
+	executions, err := r.ListExecutionsInStates(tx, []string{CanvasNodeExecutionStatePending, CanvasNodeExecutionStateStarted})
+	if err != nil {
+		return nil, err
+	}
+
+	requestedExecutionIDs, err := cancelNodeExecutions(tx, executions, cancelledBy)
+	if err != nil {
+		return nil, err
+	}
+
+	deletedQueueItems, err := r.DeleteQueueItems(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	supersededEvents, err := r.SupersedePendingEvents(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunCancellationDrainResult{
+		RequestedExecutionIDs: requestedExecutionIDs,
+		DeletedQueueItems:     deletedQueueItems,
+		SupersededEvents:      supersededEvents,
+	}, nil
+}
+
+func (r *CanvasRun) SupersedePendingEvents(tx *gorm.DB) ([]CanvasEvent, error) {
+	var events []CanvasEvent
+	err := tx.
+		Where("run_id = ?", r.ID).
+		Where("state = ?", CanvasEventStatePending).
+		Find(&events).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	if len(events) == 0 {
+		return events, nil
+	}
+
+	err = tx.
+		Model(&CanvasEvent{}).
+		Where("run_id = ?", r.ID).
+		Where("state = ?", CanvasEventStatePending).
+		Update("state", CanvasEventStateRouted).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return events, nil
+}
+
+func (r *CanvasRun) ListExecutionsInStates(tx *gorm.DB, states []string) ([]CanvasNodeExecution, error) {
+	var executions []CanvasNodeExecution
+	err := tx.
+		Where("workflow_id = ?", r.WorkflowID).
+		Where("run_id = ?", r.ID).
+		Where("state IN ?", states).
+		Find(&executions).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return executions, nil
+}
+
+func (r *CanvasRun) DeleteQueueItems(tx *gorm.DB) ([]CanvasNodeQueueItem, error) {
+	var deletedQueueItems []CanvasNodeQueueItem
+	err := tx.
+		Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}, {Name: "node_id"}, {Name: "run_id"}}}).
+		Where("workflow_id = ?", r.WorkflowID).
+		Where("run_id = ?", r.ID).
+		Delete(&deletedQueueItems).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return deletedQueueItems, nil
+}
+
+func (r *CanvasRun) MarkAsCancelling(tx *gorm.DB, cancelledBy *uuid.UUID) error {
+	now := time.Now()
+	r.State = CanvasRunStateCancelling
+	r.CancelledAt = &now
+	r.CancelledBy = cancelledBy
+	r.UpdatedAt = &now
+
+	return tx.Model(r).
+		Updates(map[string]any{
+			"state":        CanvasRunStateCancelling,
+			"cancelled_at": &now,
+			"cancelled_by": cancelledBy,
+			"updated_at":   &now,
+		}).
+		Error
 }

--- a/pkg/models/canvas_run_test.go
+++ b/pkg/models/canvas_run_test.go
@@ -14,7 +14,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func Test__FindOpenCanvasRunWorkInTransaction__PendingOutputEvent(t *testing.T) {
+func Test__CanvasRun__FindOpenWork__PendingOutputEvent(t *testing.T) {
 	run, execution := setupRunWithExecution(t)
 
 	_, err := execution.Pass(map[string][]any{
@@ -22,7 +22,8 @@ func Test__FindOpenCanvasRunWorkInTransaction__PendingOutputEvent(t *testing.T) 
 	})
 	require.NoError(t, err)
 
-	openWork := findOpenCanvasRunWork(t, run.ID)
+	openWork, err := run.FindOpenWork(database.DB(t.Context()))
+	require.NoError(t, err)
 	assert.True(t, openWork.HasPendingEvents)
 	assert.False(t, openWork.HasActiveExecutions)
 	assert.False(t, openWork.HasQueueItems)
@@ -35,13 +36,14 @@ func Test__FindOpenCanvasRunWorkInTransaction__PendingOutputEvent(t *testing.T) 
 	assert.Equal(t, run.ID, outputEvent.RunID)
 
 	require.NoError(t, outputEvent.Routed())
-	openWork = findOpenCanvasRunWork(t, run.ID)
+	openWork, err = run.FindOpenWork(database.DB(t.Context()))
+	require.NoError(t, err)
 	assert.False(t, openWork.HasPendingEvents)
 	assert.False(t, openWork.HasActiveExecutions)
 	assert.False(t, openWork.HasQueueItems)
 }
 
-func Test__FindOpenCanvasRunWorkInTransaction__QueueItem(t *testing.T) {
+func Test__CanvasRun__FindOpenWork__QueueItem(t *testing.T) {
 	run, execution := setupRunWithExecution(t)
 	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
 		"state":      models.CanvasNodeExecutionStateFinished,
@@ -53,19 +55,21 @@ func Test__FindOpenCanvasRunWorkInTransaction__QueueItem(t *testing.T) {
 	queueItem.RunID = run.ID
 	require.NoError(t, database.Conn().Save(queueItem).Error)
 
-	openWork := findOpenCanvasRunWork(t, run.ID)
+	openWork, err := run.FindOpenWork(database.DB(t.Context()))
+	require.NoError(t, err)
 	assert.True(t, openWork.HasQueueItems)
 	assert.False(t, openWork.HasActiveExecutions)
 	assert.False(t, openWork.HasPendingEvents)
 
 	require.NoError(t, queueItem.Delete(database.Conn()))
-	openWork = findOpenCanvasRunWork(t, run.ID)
+	openWork, err = run.FindOpenWork(database.DB(t.Context()))
+	require.NoError(t, err)
 	assert.False(t, openWork.HasQueueItems)
 	assert.False(t, openWork.HasActiveExecutions)
 	assert.False(t, openWork.HasPendingEvents)
 }
 
-func Test__FindOpenCanvasRunWorkInTransaction__ActiveExecution(t *testing.T) {
+func Test__CanvasRun__FindOpenWork__ActiveExecution(t *testing.T) {
 	run, execution := setupRunWithExecution(t)
 
 	for _, state := range []string{
@@ -77,14 +81,15 @@ func Test__FindOpenCanvasRunWorkInTransaction__ActiveExecution(t *testing.T) {
 			"updated_at": time.Now(),
 		}).Error)
 
-		openWork := findOpenCanvasRunWork(t, run.ID)
+		openWork, err := run.FindOpenWork(database.DB(t.Context()))
+		require.NoError(t, err)
 		assert.True(t, openWork.HasActiveExecutions, "expected active execution for state %s", state)
 		assert.False(t, openWork.HasQueueItems)
 		assert.False(t, openWork.HasPendingEvents)
 	}
 }
 
-func Test__CalculateCanvasRunResultInTransaction__FailedTakesPrecedenceOverCancelled(t *testing.T) {
+func Test__CanvasRun__CalculateResult__FailedTakesPrecedenceOverCancelled(t *testing.T) {
 	run, execution := setupRunWithExecution(t)
 	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
 		"state":      models.CanvasNodeExecutionStateFinished,
@@ -99,11 +104,12 @@ func Test__CalculateCanvasRunResultInTransaction__FailedTakesPrecedenceOverCance
 		"updated_at": time.Now(),
 	}).Error)
 
-	result := calculateCanvasRunResult(t, run.ID)
+	result, err := run.CalculateResult(database.DB(t.Context()))
+	require.NoError(t, err)
 	assert.Equal(t, models.CanvasRunResultFailed, result)
 }
 
-func Test__CalculateCanvasRunResultInTransaction__Cancelled(t *testing.T) {
+func Test__CanvasRun__CalculateResult__Cancelled(t *testing.T) {
 	run, execution := setupRunWithExecution(t)
 	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
 		"state":      models.CanvasNodeExecutionStateFinished,
@@ -111,11 +117,12 @@ func Test__CalculateCanvasRunResultInTransaction__Cancelled(t *testing.T) {
 		"updated_at": time.Now(),
 	}).Error)
 
-	result := calculateCanvasRunResult(t, run.ID)
+	result, err := run.CalculateResult(database.DB(t.Context()))
+	require.NoError(t, err)
 	assert.Equal(t, models.CanvasRunResultCancelled, result)
 }
 
-func Test__CalculateCanvasRunResultInTransaction__Passed(t *testing.T) {
+func Test__CanvasRun__CalculateResult__Passed(t *testing.T) {
 	run, execution := setupRunWithExecution(t)
 	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
 		"state":      models.CanvasNodeExecutionStateFinished,
@@ -123,7 +130,8 @@ func Test__CalculateCanvasRunResultInTransaction__Passed(t *testing.T) {
 		"updated_at": time.Now(),
 	}).Error)
 
-	result := calculateCanvasRunResult(t, run.ID)
+	result, err := run.CalculateResult(database.DB(t.Context()))
+	require.NoError(t, err)
 	assert.Equal(t, models.CanvasRunResultPassed, result)
 }
 
@@ -235,16 +243,4 @@ func createExecutionForRun(t *testing.T, run *models.CanvasRun, rootEventID uuid
 	}
 	require.NoError(t, database.Conn().Create(&execution).Error)
 	return &execution
-}
-
-func findOpenCanvasRunWork(t *testing.T, runID uuid.UUID) *models.OpenCanvasRunWork {
-	openWork, err := models.FindOpenCanvasRunWorkInTransaction(database.Conn(), runID)
-	require.NoError(t, err)
-	return openWork
-}
-
-func calculateCanvasRunResult(t *testing.T, runID uuid.UUID) string {
-	result, err := models.CalculateCanvasRunResultInTransaction(database.Conn(), runID)
-	require.NoError(t, err)
-	return result
 }

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -199,11 +199,7 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 
 	if len(createdQueueItems) > 0 {
 		for _, queueItem := range createdQueueItems {
-			messages.NewCanvasQueueItemMessage(
-				event.WorkflowID.String(),
-				queueItem.ID.String(),
-				queueItem.NodeID,
-			).Publish(false)
+			messages.NewCanvasQueueItemMessage(queueItem).PublishCreated()
 		}
 	}
 

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -291,6 +291,14 @@ func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, edges
 		return nil, uuid.Nil, err
 	}
 
+	if run.State == models.CanvasRunStateCancelling {
+		if err := event.RoutedInTransaction(tx); err != nil {
+			return nil, uuid.Nil, err
+		}
+
+		return nil, run.ID, nil
+	}
+
 	var queueItems []models.CanvasNodeQueueItem
 	for _, edge := range outgoingEdges {
 		targetNode, err := models.FindCanvasNode(tx, canvas.ID, edge.TargetID)
@@ -334,8 +342,20 @@ func (w *EventRouter) processExecutionEvent(
 	execution *models.CanvasNodeExecution,
 	event *models.CanvasEvent,
 ) ([]models.CanvasNodeQueueItem, error) {
-	now := time.Now()
+	run, err := models.FindCanvasRunInTransaction(tx, execution.WorkflowID, execution.RunID)
+	if err != nil {
+		return nil, err
+	}
 
+	if run.State == models.CanvasRunStateCancelling {
+		if err := event.RoutedInTransaction(tx); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+
+	now := time.Now()
 	logger = logging.WithExecution(logger, execution)
 	w.logger.Infof("Processing event")
 

--- a/pkg/workers/eventdistributer/run.go
+++ b/pkg/workers/eventdistributer/run.go
@@ -22,8 +22,9 @@ type RunStateWebsocketEvent struct {
 }
 
 const (
-	RunStartedEvent  = "run_started"
-	RunFinishedEvent = "run_finished"
+	RunStartedEvent    = "run_started"
+	RunCancellingEvent = "run_cancelling"
+	RunFinishedEvent   = "run_finished"
 )
 
 func HandleCanvasRun(messageBody []byte, wsHub *ws.Hub) error {
@@ -41,6 +42,8 @@ func runStateToWsEvent(runState string) string {
 	switch runState {
 	case models.CanvasRunStateStarted:
 		return RunStartedEvent
+	case models.CanvasRunStateCancelling:
+		return RunCancellingEvent
 	case models.CanvasRunStateFinished:
 		return RunFinishedEvent
 	default:

--- a/pkg/workers/eventdistributer/run_test.go
+++ b/pkg/workers/eventdistributer/run_test.go
@@ -11,6 +11,7 @@ import (
 
 func Test__RunStateToWsEvent(t *testing.T) {
 	assert.Equal(t, RunStartedEvent, runStateToWsEvent(models.CanvasRunStateStarted))
+	assert.Equal(t, RunCancellingEvent, runStateToWsEvent(models.CanvasRunStateCancelling))
 	assert.Equal(t, RunFinishedEvent, runStateToWsEvent(models.CanvasRunStateFinished))
 	assert.Empty(t, runStateToWsEvent("unknown"))
 }

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -309,6 +309,26 @@ func (w *NodeQueueWorker) processNodeQueueItem(tx *gorm.DB, logger *log.Entry, n
 		return err
 	}
 
+	//
+	// Check if the run is cancelling.
+	// If it is, we should not create new executions,
+	// and instead, delete the queue item and return.
+	//
+	run, err := models.FindCanvasRunInTransaction(tx, item.WorkflowID, item.RunID)
+	if err != nil {
+		return err
+	}
+
+	if run.State == models.CanvasRunStateCancelling {
+		if err := tx.Delete(item).Error; err != nil {
+			return err
+		}
+
+		logger.Infof("Skipping queue item for cancelling run %s", item.RunID)
+		collector.AddQueueItemDeleted(item)
+		return nil
+	}
+
 	ctx, err := contexts.BuildProcessQueueContext(
 		w.registry.HTTPContextInTransaction(tx),
 		tx,
@@ -340,26 +360,6 @@ func (w *NodeQueueWorker) processNodeQueueItem(tx *gorm.DB, logger *log.Entry, n
 		//
 		logger.Errorf("Error building configuration for node execution: %v", configErr.Error())
 		return w.handleNodeConfigurationError(tx, configErr, collector)
-	}
-
-	//
-	// Check if the run is cancelling.
-	// If it is, we should not create new executions,
-	// and instead, delete the queue item and return.
-	//
-	run, err := models.FindCanvasRunInTransaction(tx, item.WorkflowID, item.RunID)
-	if err != nil {
-		return err
-	}
-
-	if run.State == models.CanvasRunStateCancelling {
-		if err := tx.Delete(item).Error; err != nil {
-			return err
-		}
-
-		logger.Infof("Skipping queue item for cancelling run %s", item.RunID)
-		collector.AddQueueItemDeleted(item)
-		return nil
 	}
 
 	switch node.Type {

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -262,14 +262,13 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 		)
 	}()
 
-	var executionIDs []*uuid.UUID
-	var queueItem *models.CanvasNodeQueueItem
-
 	newEvents := []models.CanvasEvent{}
 	onNewEvents := func(events []models.CanvasEvent) {
 		newEvents = append(newEvents, events...)
 	}
 
+	var executionIDs []*uuid.UUID
+	var queueItem *models.CanvasNodeQueueItem
 	var run *models.CanvasRun
 
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
@@ -281,7 +280,7 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 			return nil
 		}
 
-		queueItem, err := node.FirstQueueItem(tx)
+		item, err := node.FirstQueueItem(tx)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil
@@ -290,13 +289,14 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 			return err
 		}
 
-		r, err := models.FindCanvasRunInTransaction(tx, queueItem.WorkflowID, queueItem.RunID)
+		r, err := models.FindCanvasRunInTransaction(tx, item.WorkflowID, item.RunID)
 		if err != nil {
 			return err
 		}
 
 		run = r
-		executionIDs, err = w.processNodeQueueItem(tx, logger, n, queueItem, run, onNewEvents)
+		queueItem = item
+		executionIDs, err = w.processNodeQueueItem(tx, logger, n, item, run, onNewEvents)
 		if err != nil {
 			metricOutcome = executorOutcomeFailed
 			metricReason = classifyProcessError(err)

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -262,14 +262,7 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 		)
 	}()
 
-	newEvents := []models.CanvasEvent{}
-	onNewEvents := func(events []models.CanvasEvent) {
-		newEvents = append(newEvents, events...)
-	}
-
-	var executionIDs []*uuid.UUID
-	var queueItem *models.CanvasNodeQueueItem
-	var run *models.CanvasRun
+	messageCollector := NewMessageCollector(node.WorkflowID, logger)
 
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		n, err := models.LockCanvasNode(tx, node.WorkflowID, node.NodeID)
@@ -280,32 +273,11 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 			return nil
 		}
 
-		item, err := node.FirstQueueItem(tx)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil
-			}
-
-			return err
-		}
-
-		r, err := models.FindCanvasRunInTransaction(tx, item.WorkflowID, item.RunID)
-		if err != nil {
-			return err
-		}
-
-		run = r
-		queueItem = item
-		var queueItemRemoved bool
-		executionIDs, queueItemRemoved, err = w.processNodeQueueItem(tx, logger, n, item, run, onNewEvents)
+		err = w.processNodeQueueItem(tx, logger, n, messageCollector)
 		if err != nil {
 			metricOutcome = executorOutcomeFailed
 			metricReason = classifyProcessError(err)
 			return err
-		}
-
-		if !queueItemRemoved {
-			queueItem = nil
 		}
 
 		return nil
@@ -315,75 +287,38 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 		return err
 	}
 
-	//
-	// Send RabbitMQ messages about what changed inside of the transaction
-	//
-	if len(executionIDs) > 0 {
-		for _, executionID := range executionIDs {
-			if executionID == nil {
-				continue
-			}
-
-			if err := messages.PublishCanvasExecutionByID(node.WorkflowID, *executionID); err != nil {
-				logger.Errorf("Error publishing execution state: %v", err)
-			}
-		}
-	}
-
-	for _, event := range newEvents {
-		messages.PublishCanvasEventCreatedMessage(&event)
-	}
-
-	if queueItem == nil {
-		return nil
-	}
-
-	//
-	// Queue item consumed messages are used by the NodeExecutor
-	//
-	if run.State != models.CanvasRunStateCancelling {
-		err := messages.NewCanvasQueueItemMessage(*queueItem).PublishConsumed()
-		if err != nil {
-			logger.Errorf("Error publishing queue item consumed message: %v", err)
-		}
-	} else {
-		err := messages.NewCanvasQueueItemMessage(*queueItem).PublishDeleted()
-		if err != nil {
-			logger.Errorf("Error publishing queue item deleted message: %v", err)
-		}
-	}
-
+	messageCollector.Publish()
 	return nil
 }
 
-func (w *NodeQueueWorker) processNodeQueueItem(
-	tx *gorm.DB,
-	logger *log.Entry,
-	node *models.CanvasNode,
-	queueItem *models.CanvasNodeQueueItem,
-	run *models.CanvasRun,
-	onNewEvents func([]models.CanvasEvent),
-) ([]*uuid.UUID, bool, error) {
-	if run.State == models.CanvasRunStateCancelling {
-		if err := tx.Delete(queueItem).Error; err != nil {
-			return nil, false, err
+func (w *NodeQueueWorker) processNodeQueueItem(tx *gorm.DB, logger *log.Entry, node *models.CanvasNode, collector *MessageCollector) error {
+	item, err := node.FirstQueueItem(tx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
 		}
 
-		logger.Infof("Skipping queue item for cancelling run %s", queueItem.RunID)
-		return nil, true, nil
+		return err
 	}
 
-	logger = logging.WithQueueItem(logger, *queueItem)
+	logger = logging.WithQueueItem(logger, *item)
 	logger.Info("Processing queue item")
 
 	configFields, err := w.configurationFieldsForNode(node)
 	if err != nil {
-		return nil, false, err
+		return err
 	}
 
-	repoFiles := contexts.NewRepositoryFilesContext(w.gitProvider, queueItem.WorkflowID)
+	ctx, err := contexts.BuildProcessQueueContext(
+		w.registry.HTTPContextInTransaction(tx),
+		tx,
+		node,
+		item,
+		configFields,
+		collector.OnNewEvents,
+		contexts.NewRepositoryFilesContext(w.gitProvider, item.WorkflowID),
+	)
 
-	ctx, err := contexts.BuildProcessQueueContext(w.registry.HTTPContextInTransaction(tx), tx, node, queueItem, configFields, onNewEvents, repoFiles)
 	if err != nil {
 
 		//
@@ -392,7 +327,7 @@ func (w *NodeQueueWorker) processNodeQueueItem(
 		//
 		var configErr *contexts.ConfigurationBuildError
 		if !errors.As(err, &configErr) {
-			return nil, false, err
+			return err
 		}
 
 		//
@@ -404,32 +339,51 @@ func (w *NodeQueueWorker) processNodeQueueItem(
 		// we create a failed execution and delete the queue item.
 		//
 		logger.Errorf("Error building configuration for node execution: %v", configErr.Error())
-		executions, err := w.handleNodeConfigurationError(tx, configErr, onNewEvents)
-		if err != nil {
-			return nil, false, err
-		}
-
-		return executions, true, nil
+		return w.handleNodeConfigurationError(tx, configErr, collector)
 	}
 
-	var executionID *uuid.UUID
+	//
+	// Check if the run is cancelling.
+	// If it is, we should not create new executions,
+	// and instead, delete the queue item and return.
+	//
+	run, err := models.FindCanvasRunInTransaction(tx, item.WorkflowID, item.RunID)
+	if err != nil {
+		return err
+	}
+
+	if run.State == models.CanvasRunStateCancelling {
+		if err := tx.Delete(item).Error; err != nil {
+			return err
+		}
+
+		logger.Infof("Skipping queue item for cancelling run %s", item.RunID)
+		collector.AddQueueItemDeleted(item)
+		return nil
+	}
+
 	switch node.Type {
 	case models.NodeTypeComponent:
 		/*
 		 * For component nodes, delegate to the component's ProcessQueueItem implementation to handle
 		 * the processing.
 		 */
-		executionID, err = w.processComponentNode(ctx, node)
+		err = w.processComponentNode(ctx, node, collector)
 	default:
-		return nil, false, fmt.Errorf("unsupported node type: %s", node.Type)
+		return fmt.Errorf("unsupported node type: %s", node.Type)
 	}
 
 	if errors.Is(err, core.ErrQueueItemDeferred) {
 		logger.Info("Queue item deferred")
-		return nil, false, nil
+		return nil
 	}
 
-	return []*uuid.UUID{executionID}, true, err
+	if err != nil {
+		return err
+	}
+
+	collector.AddQueueItemConsumed(item)
+	return nil
 }
 
 func (w *NodeQueueWorker) configurationFieldsForNode(node *models.CanvasNode) ([]configuration.Field, error) {
@@ -451,26 +405,34 @@ func (w *NodeQueueWorker) configurationFieldsForNode(node *models.CanvasNode) ([
 	}
 }
 
-func (w *NodeQueueWorker) processComponentNode(ctx *core.ProcessQueueContext, node *models.CanvasNode) (*uuid.UUID, error) {
+func (w *NodeQueueWorker) processComponentNode(ctx *core.ProcessQueueContext, node *models.CanvasNode, collector *MessageCollector) error {
 	ref := node.Ref.Data()
 
 	if ref.Component == nil || ref.Component.Name == "" {
-		return nil, fmt.Errorf("node %s has no component reference", node.NodeID)
+		return fmt.Errorf("node %s has no component reference", node.NodeID)
 	}
 
 	action, err := w.registry.GetAction(ref.Component.Name)
 	if err != nil {
-		return nil, fmt.Errorf("action %s not found: %w", ref.Component.Name, err)
+		return fmt.Errorf("action %s not found: %w", ref.Component.Name, err)
 	}
 
-	return action.ProcessQueueItem(*ctx)
+	executionID, err := action.ProcessQueueItem(*ctx)
+	if err != nil {
+		return err
+	}
+
+	collector.AddExecutionID(executionID)
+	return nil
 }
 
-func (w *NodeQueueWorker) handleNodeConfigurationError(tx *gorm.DB, configErr *contexts.ConfigurationBuildError, onNewEvents func([]models.CanvasEvent)) ([]*uuid.UUID, error) {
+func (w *NodeQueueWorker) handleNodeConfigurationError(tx *gorm.DB, configErr *contexts.ConfigurationBuildError, collector *MessageCollector) error {
 	err := configErr.QueueItem.Delete(tx)
 	if err != nil {
-		return nil, err
+		return err
 	}
+
+	collector.AddQueueItemConsumed(configErr.QueueItem)
 
 	now := time.Now()
 	execution := models.CanvasNodeExecution{
@@ -491,13 +453,83 @@ func (w *NodeQueueWorker) handleNodeConfigurationError(tx *gorm.DB, configErr *c
 
 	err = tx.Create(&execution).Error
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	//
 	// The errored node could not execute, so notify the canvas' On Error nodes.
 	//
-	contexts.DispatchOnError(tx, &execution, onNewEvents)
+	contexts.DispatchOnError(tx, &execution, collector.OnNewEvents)
+	collector.AddExecutionID(&execution.ID)
+	return nil
+}
 
-	return []*uuid.UUID{&execution.ID}, nil
+/*
+ * To avoid using return values to keep track of which messages need to be published
+ * when the transaction is committed, we use a collector.
+ */
+type MessageCollector struct {
+	workflowID         uuid.UUID
+	logger             *log.Entry
+	executionIDs       []*uuid.UUID
+	events             []models.CanvasEvent
+	queueItemsConsumed []*models.CanvasNodeQueueItem
+	queueItemsDeleted  []*models.CanvasNodeQueueItem
+}
+
+func NewMessageCollector(workflowID uuid.UUID, logger *log.Entry) *MessageCollector {
+	return &MessageCollector{
+		workflowID:         workflowID,
+		logger:             logger,
+		events:             make([]models.CanvasEvent, 0),
+		executionIDs:       make([]*uuid.UUID, 0),
+		queueItemsConsumed: make([]*models.CanvasNodeQueueItem, 0),
+		queueItemsDeleted:  make([]*models.CanvasNodeQueueItem, 0),
+	}
+}
+
+func (c *MessageCollector) AddExecutionID(id *uuid.UUID) {
+	c.executionIDs = append(c.executionIDs, id)
+}
+
+func (c *MessageCollector) AddQueueItemConsumed(item *models.CanvasNodeQueueItem) {
+	c.queueItemsConsumed = append(c.queueItemsConsumed, item)
+}
+
+func (c *MessageCollector) AddQueueItemDeleted(item *models.CanvasNodeQueueItem) {
+	c.queueItemsDeleted = append(c.queueItemsDeleted, item)
+}
+
+func (c *MessageCollector) OnNewEvents(events []models.CanvasEvent) {
+	c.events = append(c.events, events...)
+}
+
+func (c *MessageCollector) Publish() {
+	for _, executionID := range c.executionIDs {
+		if executionID == nil {
+			continue
+		}
+
+		if err := messages.PublishCanvasExecutionByID(c.workflowID, *executionID); err != nil {
+			c.logger.Errorf("Error publishing execution state: %v", err)
+		}
+	}
+
+	for _, event := range c.events {
+		messages.PublishCanvasEventCreatedMessage(&event)
+	}
+
+	for _, queueItem := range c.queueItemsConsumed {
+		err := messages.NewCanvasQueueItemMessage(*queueItem).PublishConsumed()
+		if err != nil {
+			c.logger.Errorf("Error publishing queue item consumed message: %v", err)
+		}
+	}
+
+	for _, queueItem := range c.queueItemsDeleted {
+		err := messages.NewCanvasQueueItemMessage(*queueItem).PublishDeleted()
+		if err != nil {
+			c.logger.Errorf("Error publishing queue item deleted message: %v", err)
+		}
+	}
 }

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -264,12 +264,13 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 
 	var executionIDs []*uuid.UUID
 	var queueItem *models.CanvasNodeQueueItem
-	var deletedQueueItem *models.CanvasNodeQueueItem
 
 	newEvents := []models.CanvasEvent{}
 	onNewEvents := func(events []models.CanvasEvent) {
 		newEvents = append(newEvents, events...)
 	}
+
+	var run *models.CanvasRun
 
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		n, err := models.LockCanvasNode(tx, node.WorkflowID, node.NodeID)
@@ -280,7 +281,22 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 			return nil
 		}
 
-		executionIDs, queueItem, deletedQueueItem, err = w.processNode(tx, logger, n, onNewEvents)
+		queueItem, err := node.FirstQueueItem(tx)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+
+			return err
+		}
+
+		r, err := models.FindCanvasRunInTransaction(tx, queueItem.WorkflowID, queueItem.RunID)
+		if err != nil {
+			return err
+		}
+
+		run = r
+		executionIDs, err = w.processNodeQueueItem(tx, logger, n, queueItem, run, onNewEvents)
 		if err != nil {
 			metricOutcome = executorOutcomeFailed
 			metricReason = classifyProcessError(err)
@@ -290,70 +306,66 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 		return nil
 	})
 
-	if err == nil {
-		if len(executionIDs) > 0 {
-			for _, executionID := range executionIDs {
-				if executionID == nil {
-					continue
-				}
+	if err != nil {
+		return err
+	}
 
-				if err := messages.PublishCanvasExecutionByID(node.WorkflowID, *executionID); err != nil {
-					logger.Errorf("Error publishing execution state: %v", err)
-				}
+	//
+	// Send RabbitMQ messages about what changed inside of the transaction
+	//
+	if len(executionIDs) > 0 {
+		for _, executionID := range executionIDs {
+			if executionID == nil {
+				continue
 			}
-		}
 
-		if queueItem != nil {
-			messages.NewCanvasQueueItemMessage(
-				queueItem.WorkflowID.String(),
-				queueItem.ID.String(),
-				queueItem.NodeID,
-			).Publish(true)
-		}
-
-		if deletedQueueItem != nil {
-			message := messages.NewCanvasQueueItemDeletedMessage(
-				node.WorkflowID.String(),
-				deletedQueueItem.ID.String(),
-				deletedQueueItem.NodeID,
-				deletedQueueItem.RunID.String(),
-			)
-			if err := message.PublishDeleted(); err != nil {
-				logger.Errorf("Error publishing queue item deleted message: %v", err)
+			if err := messages.PublishCanvasExecutionByID(node.WorkflowID, *executionID); err != nil {
+				logger.Errorf("Error publishing execution state: %v", err)
 			}
-		}
-
-		for _, event := range newEvents {
-			messages.PublishCanvasEventCreatedMessage(&event)
 		}
 	}
 
-	return err
+	for _, event := range newEvents {
+		messages.PublishCanvasEventCreatedMessage(&event)
+	}
+
+	if queueItem == nil {
+		return nil
+	}
+
+	//
+	// Queue item consumed messages are used by the NodeExecutor
+	//
+	if run.State != models.CanvasRunStateCancelling {
+		err := messages.NewCanvasQueueItemMessage(*queueItem).PublishConsumed()
+		if err != nil {
+			logger.Errorf("Error publishing queue item consumed message: %v", err)
+		}
+	} else {
+		err := messages.NewCanvasQueueItemMessage(*queueItem).PublishDeleted()
+		if err != nil {
+			logger.Errorf("Error publishing queue item deleted message: %v", err)
+		}
+	}
+
+	return nil
 }
 
-func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *models.CanvasNode, onNewEvents func([]models.CanvasEvent)) ([]*uuid.UUID, *models.CanvasNodeQueueItem, *models.CanvasNodeQueueItem, error) {
-	queueItem, err := node.FirstQueueItem(tx)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil, nil, nil
-		}
-
-		return nil, nil, nil, err
-	}
-
-	run, err := models.FindCanvasRunInTransaction(tx, queueItem.WorkflowID, queueItem.RunID)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
+func (w *NodeQueueWorker) processNodeQueueItem(
+	tx *gorm.DB,
+	logger *log.Entry,
+	node *models.CanvasNode,
+	queueItem *models.CanvasNodeQueueItem,
+	run *models.CanvasRun,
+	onNewEvents func([]models.CanvasEvent),
+) ([]*uuid.UUID, error) {
 	if run.State == models.CanvasRunStateCancelling {
-		deletedItem := *queueItem
 		if err := tx.Delete(queueItem).Error; err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 
 		logger.Infof("Skipping queue item for cancelling run %s", queueItem.RunID)
-		return nil, nil, &deletedItem, nil
+		return nil, nil
 	}
 
 	logger = logging.WithQueueItem(logger, *queueItem)
@@ -361,7 +373,7 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 
 	configFields, err := w.configurationFieldsForNode(node)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	repoFiles := contexts.NewRepositoryFilesContext(w.gitProvider, queueItem.WorkflowID)
@@ -375,7 +387,7 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 		//
 		var configErr *contexts.ConfigurationBuildError
 		if !errors.As(err, &configErr) {
-			return nil, nil, nil, err
+			return nil, err
 		}
 
 		//
@@ -389,10 +401,10 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 		logger.Errorf("Error building configuration for node execution: %v", configErr.Error())
 		executions, err := w.handleNodeConfigurationError(tx, configErr, onNewEvents)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 
-		return executions, queueItem, nil, nil
+		return executions, nil
 	}
 
 	var executionID *uuid.UUID
@@ -404,15 +416,15 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 		 */
 		executionID, err = w.processComponentNode(ctx, node)
 	default:
-		return nil, nil, nil, fmt.Errorf("unsupported node type: %s", node.Type)
+		return nil, fmt.Errorf("unsupported node type: %s", node.Type)
 	}
 
 	if errors.Is(err, core.ErrQueueItemDeferred) {
 		logger.Info("Queue item deferred")
-		return nil, nil, nil, nil
+		return nil, nil
 	}
 
-	return []*uuid.UUID{executionID}, queueItem, nil, err
+	return []*uuid.UUID{executionID}, err
 }
 
 func (w *NodeQueueWorker) configurationFieldsForNode(node *models.CanvasNode) ([]configuration.Field, error) {

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -264,6 +264,7 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 
 	var executionIDs []*uuid.UUID
 	var queueItem *models.CanvasNodeQueueItem
+	var deletedQueueItem *models.CanvasNodeQueueItem
 
 	newEvents := []models.CanvasEvent{}
 	onNewEvents := func(events []models.CanvasEvent) {
@@ -279,7 +280,7 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 			return nil
 		}
 
-		executionIDs, queueItem, err = w.processNode(tx, logger, n, onNewEvents)
+		executionIDs, queueItem, deletedQueueItem, err = w.processNode(tx, logger, n, onNewEvents)
 		if err != nil {
 			metricOutcome = executorOutcomeFailed
 			metricReason = classifyProcessError(err)
@@ -310,6 +311,18 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 			).Publish(true)
 		}
 
+		if deletedQueueItem != nil {
+			message := messages.NewCanvasQueueItemDeletedMessage(
+				node.WorkflowID.String(),
+				deletedQueueItem.ID.String(),
+				deletedQueueItem.NodeID,
+				deletedQueueItem.RunID.String(),
+			)
+			if err := message.PublishDeleted(); err != nil {
+				logger.Errorf("Error publishing queue item deleted message: %v", err)
+			}
+		}
+
 		for _, event := range newEvents {
 			messages.PublishCanvasEventCreatedMessage(&event)
 		}
@@ -318,14 +331,29 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 	return err
 }
 
-func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *models.CanvasNode, onNewEvents func([]models.CanvasEvent)) ([]*uuid.UUID, *models.CanvasNodeQueueItem, error) {
+func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *models.CanvasNode, onNewEvents func([]models.CanvasEvent)) ([]*uuid.UUID, *models.CanvasNodeQueueItem, *models.CanvasNodeQueueItem, error) {
 	queueItem, err := node.FirstQueueItem(tx)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil, nil
+			return nil, nil, nil, nil
 		}
 
-		return nil, nil, err
+		return nil, nil, nil, err
+	}
+
+	run, err := models.FindCanvasRunInTransaction(tx, queueItem.WorkflowID, queueItem.RunID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if run.State == models.CanvasRunStateCancelling {
+		deletedItem := *queueItem
+		if err := tx.Delete(queueItem).Error; err != nil {
+			return nil, nil, nil, err
+		}
+
+		logger.Infof("Skipping queue item for cancelling run %s", queueItem.RunID)
+		return nil, nil, &deletedItem, nil
 	}
 
 	logger = logging.WithQueueItem(logger, *queueItem)
@@ -333,7 +361,7 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 
 	configFields, err := w.configurationFieldsForNode(node)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	repoFiles := contexts.NewRepositoryFilesContext(w.gitProvider, queueItem.WorkflowID)
@@ -347,7 +375,7 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 		//
 		var configErr *contexts.ConfigurationBuildError
 		if !errors.As(err, &configErr) {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		//
@@ -361,10 +389,10 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 		logger.Errorf("Error building configuration for node execution: %v", configErr.Error())
 		executions, err := w.handleNodeConfigurationError(tx, configErr, onNewEvents)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
-		return executions, queueItem, nil
+		return executions, queueItem, nil, nil
 	}
 
 	var executionID *uuid.UUID
@@ -376,15 +404,15 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 		 */
 		executionID, err = w.processComponentNode(ctx, node)
 	default:
-		return nil, nil, fmt.Errorf("unsupported node type: %s", node.Type)
+		return nil, nil, nil, fmt.Errorf("unsupported node type: %s", node.Type)
 	}
 
 	if errors.Is(err, core.ErrQueueItemDeferred) {
 		logger.Info("Queue item deferred")
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
-	return []*uuid.UUID{executionID}, queueItem, err
+	return []*uuid.UUID{executionID}, queueItem, nil, err
 }
 
 func (w *NodeQueueWorker) configurationFieldsForNode(node *models.CanvasNode) ([]configuration.Field, error) {

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -296,11 +296,16 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 
 		run = r
 		queueItem = item
-		executionIDs, err = w.processNodeQueueItem(tx, logger, n, item, run, onNewEvents)
+		var queueItemRemoved bool
+		executionIDs, queueItemRemoved, err = w.processNodeQueueItem(tx, logger, n, item, run, onNewEvents)
 		if err != nil {
 			metricOutcome = executorOutcomeFailed
 			metricReason = classifyProcessError(err)
 			return err
+		}
+
+		if !queueItemRemoved {
+			queueItem = nil
 		}
 
 		return nil
@@ -358,14 +363,14 @@ func (w *NodeQueueWorker) processNodeQueueItem(
 	queueItem *models.CanvasNodeQueueItem,
 	run *models.CanvasRun,
 	onNewEvents func([]models.CanvasEvent),
-) ([]*uuid.UUID, error) {
+) ([]*uuid.UUID, bool, error) {
 	if run.State == models.CanvasRunStateCancelling {
 		if err := tx.Delete(queueItem).Error; err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		logger.Infof("Skipping queue item for cancelling run %s", queueItem.RunID)
-		return nil, nil
+		return nil, true, nil
 	}
 
 	logger = logging.WithQueueItem(logger, *queueItem)
@@ -373,7 +378,7 @@ func (w *NodeQueueWorker) processNodeQueueItem(
 
 	configFields, err := w.configurationFieldsForNode(node)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	repoFiles := contexts.NewRepositoryFilesContext(w.gitProvider, queueItem.WorkflowID)
@@ -387,7 +392,7 @@ func (w *NodeQueueWorker) processNodeQueueItem(
 		//
 		var configErr *contexts.ConfigurationBuildError
 		if !errors.As(err, &configErr) {
-			return nil, err
+			return nil, false, err
 		}
 
 		//
@@ -401,10 +406,10 @@ func (w *NodeQueueWorker) processNodeQueueItem(
 		logger.Errorf("Error building configuration for node execution: %v", configErr.Error())
 		executions, err := w.handleNodeConfigurationError(tx, configErr, onNewEvents)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
-		return executions, nil
+		return executions, true, nil
 	}
 
 	var executionID *uuid.UUID
@@ -416,15 +421,15 @@ func (w *NodeQueueWorker) processNodeQueueItem(
 		 */
 		executionID, err = w.processComponentNode(ctx, node)
 	default:
-		return nil, fmt.Errorf("unsupported node type: %s", node.Type)
+		return nil, false, fmt.Errorf("unsupported node type: %s", node.Type)
 	}
 
 	if errors.Is(err, core.ErrQueueItemDeferred) {
 		logger.Info("Queue item deferred")
-		return nil, nil
+		return nil, false, nil
 	}
 
-	return []*uuid.UUID{executionID}, err
+	return []*uuid.UUID{executionID}, true, err
 }
 
 func (w *NodeQueueWorker) configurationFieldsForNode(node *models.CanvasNode) ([]configuration.Field, error) {

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -10,12 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/config"
+	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"github.com/superplanehq/superplane/pkg/registry"
 	testconsumer "github.com/superplanehq/superplane/test/consumer"
 	"github.com/superplanehq/superplane/test/support"
+	"github.com/superplanehq/superplane/test/support/impl"
 	"google.golang.org/protobuf/proto"
 	"gorm.io/datatypes"
 )
@@ -626,4 +629,74 @@ func Test__NodeQueueWorker_ProcessesNextQueueItemOnExecutionFinished(t *testing.
 	queueItems, err = models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Empty(t, queueItems)
+}
+
+func Test__NodeQueueWorker_DeferredQueueItemDoesNotPublishConsumed(t *testing.T) {
+	componentName := "defer_queue_item_" + uuid.New().String()
+	registry.RegisterAction(componentName, impl.NewDummyAction(impl.DummyActionOptions{
+		Name: componentName,
+		ProcessQueueFunc: func(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+			if err := ctx.DeferQueueItem(); err != nil {
+				return nil, err
+			}
+			return nil, core.ErrQueueItemDeferred
+		},
+	}))
+
+	r := support.Setup(t)
+	defer r.Close()
+
+	amqpURL, _ := config.RabbitMQURL()
+	worker := NewNodeQueueWorker(r.Registry, r.GitProvider, amqpURL)
+	logger := log.NewEntry(log.New())
+
+	executionConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionPendingRoutingKey)
+	queueConsumedConsumer := testconsumer.New(amqpURL, messages.CanvasQueueItemConsumedRoutingKey)
+	executionConsumer.Start()
+	queueConsumedConsumer.Start()
+	defer executionConsumer.Stop()
+	defer queueConsumedConsumer.Stop()
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNode,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: componentName}}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	queueItem := support.CreateQueueItem(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID)
+
+	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
+	require.NoError(t, err)
+
+	err = worker.LockAndProcessNode(logger, *node, time.Now())
+	require.NoError(t, err)
+
+	storedQueueItem, err := models.FindNodeQueueItem(canvas.ID, queueItem.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queueItem.ID, storedQueueItem.ID)
+
+	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, executions)
+
+	assert.False(t, executionConsumer.HasReceivedMessage())
+	assert.False(t, queueConsumedConsumer.HasReceivedMessage())
 }

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -700,3 +700,84 @@ func Test__NodeQueueWorker_DeferredQueueItemDoesNotPublishConsumed(t *testing.T)
 	assert.False(t, executionConsumer.HasReceivedMessage())
 	assert.False(t, queueConsumedConsumer.HasReceivedMessage())
 }
+
+func Test__NodeQueueWorker_SkipsQueueItemForCancellingRun(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	amqpURL, _ := config.RabbitMQURL()
+	worker := NewNodeQueueWorker(r.Registry, r.GitProvider, amqpURL)
+	logger := log.NewEntry(log.New())
+
+	executionConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionPendingRoutingKey)
+	queueConsumedConsumer := testconsumer.New(amqpURL, messages.CanvasQueueItemConsumedRoutingKey)
+	queueDeletedConsumer := testconsumer.New(amqpURL, messages.CanvasQueueItemDeletedRoutingKey)
+	executionConsumer.Start()
+	queueConsumedConsumer.Start()
+	queueDeletedConsumer.Start()
+	defer executionConsumer.Stop()
+	defer queueConsumedConsumer.Stop()
+	defer queueDeletedConsumer.Stop()
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNode,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
+	require.NoError(t, err)
+
+	now := time.Now()
+	queueItem := models.CanvasNodeQueueItem{
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		RootEventID: rootEvent.ID,
+		RunID:       run.ID,
+		EventID:     rootEvent.ID,
+		CreatedAt:   &now,
+	}
+	require.NoError(t, database.Conn().Create(&queueItem).Error)
+
+	require.NoError(t, database.Conn().Model(run).Updates(map[string]any{
+		"state":        models.CanvasRunStateCancelling,
+		"cancelled_at": now,
+		"cancelled_by": r.User,
+	}).Error)
+
+	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
+	require.NoError(t, err)
+
+	err = worker.LockAndProcessNode(logger, *node, time.Now())
+	require.NoError(t, err)
+
+	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, executions)
+
+	var queueItemCount int64
+	require.NoError(t, database.Conn().Model(&models.CanvasNodeQueueItem{}).Where("id = ?", queueItem.ID).Count(&queueItemCount).Error)
+	assert.Zero(t, queueItemCount)
+
+	assert.False(t, executionConsumer.HasReceivedMessage())
+	assert.False(t, queueConsumedConsumer.HasReceivedMessage())
+	assert.True(t, queueDeletedConsumer.HasReceivedMessage())
+}

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -781,3 +781,91 @@ func Test__NodeQueueWorker_SkipsQueueItemForCancellingRun(t *testing.T) {
 	assert.False(t, queueConsumedConsumer.HasReceivedMessage())
 	assert.True(t, queueDeletedConsumer.HasReceivedMessage())
 }
+
+func Test__NodeQueueWorker_SkipsConfigurationErrorQueueItemForCancellingRun(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	amqpURL, _ := config.RabbitMQURL()
+	worker := NewNodeQueueWorker(r.Registry, r.GitProvider, amqpURL)
+	logger := log.NewEntry(log.New())
+
+	executionFinishedConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionFinishedRoutingKey)
+	queueConsumedConsumer := testconsumer.New(amqpURL, messages.CanvasQueueItemConsumedRoutingKey)
+	queueDeletedConsumer := testconsumer.New(amqpURL, messages.CanvasQueueItemDeletedRoutingKey)
+	executionFinishedConsumer.Start()
+	queueConsumedConsumer.Start()
+	queueDeletedConsumer.Start()
+	defer executionFinishedConsumer.Stop()
+	defer queueConsumedConsumer.Stop()
+	defer queueDeletedConsumer.Stop()
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNode,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+				Configuration: datatypes.NewJSONType(map[string]any{
+					"field": "{{ $[\"nonexistent-node\"].data }}",
+				}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
+	require.NoError(t, err)
+
+	now := time.Now()
+	queueItem := models.CanvasNodeQueueItem{
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		RootEventID: rootEvent.ID,
+		RunID:       run.ID,
+		EventID:     rootEvent.ID,
+		CreatedAt:   &now,
+	}
+	require.NoError(t, database.Conn().Create(&queueItem).Error)
+
+	require.NoError(t, database.Conn().Model(run).Updates(map[string]any{
+		"state":        models.CanvasRunStateCancelling,
+		"cancelled_at": now,
+		"cancelled_by": r.User,
+	}).Error)
+
+	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
+	require.NoError(t, err)
+
+	err = worker.LockAndProcessNode(logger, *node, time.Now())
+	require.NoError(t, err)
+
+	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, executions)
+
+	var queueItemCount int64
+	require.NoError(t, database.Conn().Model(&models.CanvasNodeQueueItem{}).Where("id = ?", queueItem.ID).Count(&queueItemCount).Error)
+	assert.Zero(t, queueItemCount)
+
+	node, err = models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeStateReady, node.State)
+
+	assert.False(t, executionFinishedConsumer.HasReceivedMessage())
+	assert.False(t, queueConsumedConsumer.HasReceivedMessage())
+	assert.True(t, queueDeletedConsumer.HasReceivedMessage())
+}

--- a/pkg/workers/run_finalizer.go
+++ b/pkg/workers/run_finalizer.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -67,48 +68,96 @@ func (w *RunFinalizer) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			runs, err := models.ListCanvasRunsInState(database.Conn(), models.CanvasRunStateStarted, startedRunsSweepLimit)
-			if err != nil {
-				w.logger.Errorf("Error listing started runs: %v", err)
-				continue
-			}
-
-			telemetry.RecordRunFinalizerRunsCount(context.Background(), len(runs))
-
-			for _, run := range runs {
-				if err := w.finalizeRun(run.WorkflowID, run.ID, runFinalizerTriggerSweep); err != nil {
-					w.logger.WithFields(log.Fields{
-						"workflow_id": run.WorkflowID,
-						"run_id":      run.ID,
-					}).Errorf("Error finalizing run from sweep: %v", err)
-				}
-			}
-
-			cancellingRuns, err := models.ListCanvasRunsInState(database.Conn(), models.CanvasRunStateCancelling, startedRunsSweepLimit)
-			if err != nil {
-				w.logger.Errorf("Error listing cancelling runs: %v", err)
-				continue
-			}
-
-			for _, run := range cancellingRuns {
-				logger := logging.WithRun(w.logger, run)
-
-				err := database.Conn().Transaction(func(tx *gorm.DB) error {
-					_, err := run.DrainForCancellation(tx, run.CancelledBy)
-					return err
-				})
-
-				if err != nil {
-					logger.WithError(err).Errorf("Error draining cancelling run from sweep: %v", err)
-					continue
-				}
-
-				if err := w.finalizeRun(run.WorkflowID, run.ID, runFinalizerTriggerSweep); err != nil {
-					logger.WithError(err).Errorf("Error finalizing cancelling run from sweep: %v", err)
-				}
-			}
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				w.sweepStartedRuns()
+			}()
+			go func() {
+				defer wg.Done()
+				w.sweepCancellingRuns()
+			}()
+			wg.Wait()
 
 			telemetry.RecordRunFinalizerTickDuration(context.Background(), time.Since(tickStart))
+		}
+	}
+}
+
+func (w *RunFinalizer) sweepStartedRuns() error {
+	runs, err := models.ListCanvasRunsInState(database.Conn(), models.CanvasRunStateStarted, startedRunsSweepLimit)
+	if err != nil {
+		w.logger.Errorf("Error listing started runs: %v", err)
+		return err
+	}
+
+	telemetry.RecordRunFinalizerRunsCount(context.Background(), len(runs))
+
+	for _, run := range runs {
+		if err := w.finalizeRun(run.WorkflowID, run.ID, runFinalizerTriggerSweep); err != nil {
+			logger := logging.WithRun(w.logger, run)
+			logger.WithError(err).Errorf("Error finalizing run from sweep: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (w *RunFinalizer) sweepCancellingRuns() error {
+	cancellingRuns, err := models.ListCanvasRunsInState(database.Conn(), models.CanvasRunStateCancelling, startedRunsSweepLimit)
+	if err != nil {
+		w.logger.Errorf("Error listing cancelling runs: %v", err)
+		return err
+	}
+
+	for _, run := range cancellingRuns {
+		logger := logging.WithRun(w.logger, run)
+
+		var cancellationResult *models.RunCancellationDrainResult
+		err := database.Conn().Transaction(func(tx *gorm.DB) error {
+			result, err := run.DrainForCancellation(tx, run.CancelledBy)
+			if err != nil {
+				return err
+			}
+
+			cancellationResult = result
+			return nil
+		})
+
+		if err != nil {
+			logger.WithError(err).Errorf("Error draining cancelling run from sweep: %v", err)
+			continue
+		}
+
+		if cancellationResult != nil {
+			w.publishRunCancellationDrainMessages(run.WorkflowID, cancellationResult)
+		}
+
+		if err := w.finalizeRun(run.WorkflowID, run.ID, runFinalizerTriggerSweep); err != nil {
+			logger.WithError(err).Errorf("Error finalizing cancelling run from sweep: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (w *RunFinalizer) publishRunCancellationDrainMessages(workflowID uuid.UUID, result *models.RunCancellationDrainResult) {
+	for _, executionID := range result.RequestedExecutionIDs {
+		if err := messages.PublishCanvasExecutionByID(workflowID, executionID); err != nil {
+			log.Errorf("failed to publish execution cancelling RabbitMQ message: %v", err)
+		}
+	}
+
+	for _, queueItem := range result.DeletedQueueItems {
+		if err := messages.NewCanvasQueueItemMessage(queueItem).PublishDeleted(); err != nil {
+			log.Errorf("failed to publish queue item deleted RabbitMQ message: %v", err)
+		}
+	}
+
+	for _, event := range result.SupersededEvents {
+		if err := messages.PublishEventTerminal(event.WorkflowID, event.RunID, event.ID); err != nil {
+			log.Errorf("failed to publish event terminal RabbitMQ message: %v", err)
 		}
 	}
 }

--- a/pkg/workers/run_finalizer.go
+++ b/pkg/workers/run_finalizer.go
@@ -86,7 +86,7 @@ func (w *RunFinalizer) Start(ctx context.Context) {
 }
 
 func (w *RunFinalizer) sweepStartedRuns() error {
-	runs, err := models.ListCanvasRunsInState(database.Conn(), models.CanvasRunStateStarted, startedRunsSweepLimit)
+	runs, err := models.ListStartedCanvasRuns(database.Conn(), startedRunsSweepLimit)
 	if err != nil {
 		w.logger.Errorf("Error listing started runs: %v", err)
 		return err
@@ -105,7 +105,7 @@ func (w *RunFinalizer) sweepStartedRuns() error {
 }
 
 func (w *RunFinalizer) sweepCancellingRuns() error {
-	cancellingRuns, err := models.ListCanvasRunsInState(database.Conn(), models.CanvasRunStateCancelling, startedRunsSweepLimit)
+	cancellingRuns, err := models.ListCancellingCanvasRuns(database.Conn(), startedRunsSweepLimit)
 	if err != nil {
 		w.logger.Errorf("Error listing cancelling runs: %v", err)
 		return err
@@ -131,7 +131,7 @@ func (w *RunFinalizer) sweepCancellingRuns() error {
 		}
 
 		if cancellationResult != nil {
-			w.publishRunCancellationDrainMessages(run.WorkflowID, cancellationResult)
+			messages.PublishRunCancellationDrain(run.WorkflowID, cancellationResult)
 		}
 
 		if err := w.finalizeRun(run.WorkflowID, run.ID, runFinalizerTriggerSweep); err != nil {
@@ -140,26 +140,6 @@ func (w *RunFinalizer) sweepCancellingRuns() error {
 	}
 
 	return nil
-}
-
-func (w *RunFinalizer) publishRunCancellationDrainMessages(workflowID uuid.UUID, result *models.RunCancellationDrainResult) {
-	for _, executionID := range result.RequestedExecutionIDs {
-		if err := messages.PublishCanvasExecutionByID(workflowID, executionID); err != nil {
-			log.Errorf("failed to publish execution cancelling RabbitMQ message: %v", err)
-		}
-	}
-
-	for _, queueItem := range result.DeletedQueueItems {
-		if err := messages.NewCanvasQueueItemMessage(queueItem).PublishDeleted(); err != nil {
-			log.Errorf("failed to publish queue item deleted RabbitMQ message: %v", err)
-		}
-	}
-
-	for _, event := range result.SupersededEvents {
-		if err := messages.PublishEventTerminal(event.WorkflowID, event.RunID, event.ID); err != nil {
-			log.Errorf("failed to publish event terminal RabbitMQ message: %v", err)
-		}
-	}
 }
 
 func (w *RunFinalizer) startQueueItemDeletedConsumer(ctx context.Context) {

--- a/pkg/workers/run_finalizer.go
+++ b/pkg/workers/run_finalizer.go
@@ -386,7 +386,7 @@ func (w *RunFinalizer) maybeFinalizeRun(tx *gorm.DB, runID uuid.UUID, trigger st
 	}
 
 	if openWork.HasActiveExecutions || openWork.HasQueueItems || openWork.HasPendingEvents {
-		if trigger == runFinalizerTriggerSweep {
+		if trigger == runFinalizerTriggerSweep && run.State != models.CanvasRunStateCancelling {
 			// The started-run sweep loads candidates with ORDER BY updated_at ASC
 			// LIMIT N. Bump updated_at here so a run that is still open is pushed to
 			// the back of the queue instead of being retried on every tick.

--- a/pkg/workers/run_finalizer.go
+++ b/pkg/workers/run_finalizer.go
@@ -67,7 +67,7 @@ func (w *RunFinalizer) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			runs, err := models.ListStartedCanvasRuns(startedRunsSweepLimit)
+			runs, err := models.ListCanvasRunsInState(database.Conn(), models.CanvasRunStateStarted, startedRunsSweepLimit)
 			if err != nil {
 				w.logger.Errorf("Error listing started runs: %v", err)
 				continue
@@ -81,6 +81,30 @@ func (w *RunFinalizer) Start(ctx context.Context) {
 						"workflow_id": run.WorkflowID,
 						"run_id":      run.ID,
 					}).Errorf("Error finalizing run from sweep: %v", err)
+				}
+			}
+
+			cancellingRuns, err := models.ListCanvasRunsInState(database.Conn(), models.CanvasRunStateCancelling, startedRunsSweepLimit)
+			if err != nil {
+				w.logger.Errorf("Error listing cancelling runs: %v", err)
+				continue
+			}
+
+			for _, run := range cancellingRuns {
+				logger := logging.WithRun(w.logger, run)
+
+				err := database.Conn().Transaction(func(tx *gorm.DB) error {
+					_, err := run.DrainForCancellation(tx, run.CancelledBy)
+					return err
+				})
+
+				if err != nil {
+					logger.WithError(err).Errorf("Error draining cancelling run from sweep: %v", err)
+					continue
+				}
+
+				if err := w.finalizeRun(run.WorkflowID, run.ID, runFinalizerTriggerSweep); err != nil {
+					logger.WithError(err).Errorf("Error finalizing cancelling run from sweep: %v", err)
 				}
 			}
 
@@ -327,7 +351,7 @@ func (w *RunFinalizer) maybeFinalizeRun(tx *gorm.DB, runID uuid.UUID, trigger st
 		return false, runFinalizerReasonAlreadyFinished, nil
 	}
 
-	openWork, err := models.FindOpenCanvasRunWorkInTransaction(tx, runID)
+	openWork, err := run.FindOpenWork(tx)
 	if err != nil {
 		return false, "", err
 	}
@@ -344,7 +368,7 @@ func (w *RunFinalizer) maybeFinalizeRun(tx *gorm.DB, runID uuid.UUID, trigger st
 		return false, runFinalizerReasonOpenWork, nil
 	}
 
-	result, err := models.CalculateCanvasRunResultInTransaction(tx, runID)
+	result, err := run.CalculateResult(tx)
 	if err != nil {
 		return false, "", err
 	}

--- a/pkg/workers/run_finalizer_test.go
+++ b/pkg/workers/run_finalizer_test.go
@@ -209,3 +209,45 @@ func Test__RunFinalizer_SweepTouchesUpdatedAtWhenRunHasOpenWork(t *testing.T) {
 	assert.True(t, touchedRun.UpdatedAt.After(staleUpdatedAt))
 	assert.Equal(t, models.CanvasRunStateStarted, touchedRun.State)
 }
+
+func Test__RunFinalizer_FinalizesCancellingRunWithForcedCancelledResult(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	finalizer := NewRunFinalizer(amqpURL)
+	r := support.Setup(t)
+
+	node := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: node, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{},
+	)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, node, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), event)
+	require.NoError(t, err)
+	require.NoError(t, event.Routed())
+
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, node, event.ID, event.ID)
+	execution.RunID = run.ID
+	require.NoError(t, database.Conn().Save(execution).Error)
+	require.NoError(t, execution.Cancel(nil))
+
+	now := time.Now()
+	require.NoError(t, database.Conn().Model(run).Updates(map[string]any{
+		"state":        models.CanvasRunStateCancelling,
+		"cancelled_at": now,
+		"cancelled_by": r.User,
+	}).Error)
+
+	require.NoError(t, finalizer.finalizeRun(canvas.ID, run.ID, runFinalizerTriggerExecutionFinished))
+
+	updatedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
+	assert.Equal(t, models.CanvasRunResultCancelled, updatedRun.Result)
+}

--- a/pkg/workers/run_finalizer_test.go
+++ b/pkg/workers/run_finalizer_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	testconsumer "github.com/superplanehq/superplane/test/consumer"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/protobuf/proto"
 )
@@ -250,4 +252,171 @@ func Test__RunFinalizer_FinalizesCancellingRunWithForcedCancelledResult(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
 	assert.Equal(t, models.CanvasRunResultCancelled, updatedRun.Result)
+}
+
+func Test__RunFinalizer_SweepCancellingRuns_FinalizesWhenNoOpenWork(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	finalizer := NewRunFinalizer(amqpURL)
+	r := support.Setup(t)
+
+	node := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: node, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{},
+	)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, node, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), event)
+	require.NoError(t, err)
+	require.NoError(t, event.Routed())
+
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, node, event.ID, event.ID)
+	execution.RunID = run.ID
+	require.NoError(t, database.Conn().Save(execution).Error)
+	require.NoError(t, execution.Cancel(nil))
+
+	now := time.Now()
+	require.NoError(t, database.Conn().Model(run).Updates(map[string]any{
+		"state":        models.CanvasRunStateCancelling,
+		"cancelled_at": now,
+		"cancelled_by": r.User,
+	}).Error)
+
+	require.NoError(t, finalizer.sweepCancellingRuns())
+
+	updatedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
+	assert.Equal(t, models.CanvasRunResultCancelled, updatedRun.Result)
+	assert.NotNil(t, updatedRun.FinishedAt)
+}
+
+func Test__RunFinalizer_SweepCancellingRuns_DrainsOpenWorkAndPublishesMessages(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	finalizer := NewRunFinalizer(amqpURL)
+	r := support.Setup(t)
+
+	executionCancellingConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionCancellingRoutingKey)
+	executionCancellingConsumer.Start()
+	defer executionCancellingConsumer.Stop()
+
+	queueItemDeletedConsumer := testconsumer.New(amqpURL, messages.CanvasQueueItemDeletedRoutingKey)
+	queueItemDeletedConsumer.Start()
+	defer queueItemDeletedConsumer.Stop()
+
+	node := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: node, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{},
+	)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, node, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), event)
+	require.NoError(t, err)
+	require.NoError(t, event.Routed())
+
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, node, event.ID, event.ID)
+	execution.RunID = run.ID
+	execution.State = models.CanvasNodeExecutionStateStarted
+	require.NoError(t, database.Conn().Save(execution).Error)
+
+	now := time.Now()
+	queueItem := models.CanvasNodeQueueItem{
+		WorkflowID:  canvas.ID,
+		NodeID:      node,
+		RootEventID: event.ID,
+		RunID:       run.ID,
+		EventID:     event.ID,
+		CreatedAt:   &now,
+	}
+	require.NoError(t, database.Conn().Create(&queueItem).Error)
+
+	require.NoError(t, database.Conn().Model(run).Updates(map[string]any{
+		"state":        models.CanvasRunStateCancelling,
+		"cancelled_at": now,
+		"cancelled_by": r.User,
+	}).Error)
+
+	require.NoError(t, finalizer.sweepCancellingRuns())
+
+	assert.True(t, executionCancellingConsumer.HasReceivedMessage())
+	assert.True(t, queueItemDeletedConsumer.HasReceivedMessage())
+
+	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateCancelling, updatedExecution.State)
+
+	var queueItemCount int64
+	require.NoError(t, database.Conn().Model(&models.CanvasNodeQueueItem{}).Where("run_id = ?", run.ID).Count(&queueItemCount).Error)
+	assert.Zero(t, queueItemCount)
+
+	updatedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateCancelling, updatedRun.State)
+
+	require.NoError(t, execution.Cancel(nil))
+
+	require.NoError(t, finalizer.sweepCancellingRuns())
+
+	updatedRun, err = models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
+	assert.Equal(t, models.CanvasRunResultCancelled, updatedRun.Result)
+	assert.NotNil(t, updatedRun.FinishedAt)
+}
+
+func Test__RunFinalizer_SweepCancellingRuns_DoesNotBumpUpdatedAtWhenStillOpenAfterDrain(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	finalizer := NewRunFinalizer(amqpURL)
+	r := support.Setup(t)
+
+	node := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: node, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{},
+	)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, node, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), event)
+	require.NoError(t, err)
+	require.NoError(t, event.Routed())
+
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, node, event.ID, event.ID)
+	execution.RunID = run.ID
+	execution.State = models.CanvasNodeExecutionStateStarted
+	require.NoError(t, database.Conn().Save(execution).Error)
+
+	staleUpdatedAt := time.Now().Add(-time.Hour)
+	now := time.Now()
+	require.NoError(t, database.Conn().Model(run).Updates(map[string]any{
+		"state":        models.CanvasRunStateCancelling,
+		"cancelled_at": now,
+		"cancelled_by": r.User,
+		"updated_at":   staleUpdatedAt,
+	}).Error)
+
+	require.NoError(t, finalizer.sweepCancellingRuns())
+
+	unchangedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, staleUpdatedAt.Unix(), unchangedRun.UpdatedAt.Unix())
+	assert.Equal(t, models.CanvasRunStateCancelling, unchangedRun.State)
 }

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -311,6 +311,18 @@ service Canvases {
     };
   }
 
+  rpc CancelRun(CancelRunRequest) returns (CancelRunResponse) {
+    option (google.api.http) = {
+      patch: "/api/v1/canvases/{canvas_id}/runs/{run_id}/cancel"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Cancel a run";
+      description: "Requests cancellation of a run and its active work";
+      tags: "CanvasRun";
+    };
+  }
+
   rpc ListCanvasMemories(ListCanvasMemoriesRequest) returns (ListCanvasMemoriesResponse) {
     option (google.api.http) = {
       get: "/api/v1/canvases/{canvas_id}/memory"
@@ -781,6 +793,15 @@ message DescribeRunResponse {
   CanvasRun run = 1;
 }
 
+message CancelRunRequest {
+  string canvas_id = 1;
+  string run_id = 2;
+}
+
+message CancelRunResponse {
+  CanvasRun run = 1;
+}
+
 message CanvasMemory {
   enum Source {
     SOURCE_UNKNOWN = 0;
@@ -851,6 +872,7 @@ message CanvasRun {
     STATE_UNKNOWN = 0;
     STATE_STARTED = 1;
     STATE_FINISHED = 2;
+    STATE_CANCELLING = 3;
   }
 
   enum Result {
@@ -871,6 +893,7 @@ message CanvasRun {
   google.protobuf.Timestamp finished_at = 9;
   string version_id = 10;
   repeated CanvasNodeQueueItem queue_items = 11;
+  google.protobuf.Timestamp cancelled_at = 12;
 }
 
 message ListEventExecutionsRequest {

--- a/web_src/src/hooks/canvasInfiniteCache.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.ts
@@ -44,7 +44,8 @@ export function reuseCachedInfiniteRunsPage(
 const RUN_STATE_ORDER: Record<CanvasesCanvasRunState, number> = {
   STATE_UNKNOWN: 0,
   STATE_STARTED: 1,
-  STATE_FINISHED: 2,
+  STATE_CANCELLING: 2,
+  STATE_FINISHED: 3,
 };
 
 const EXECUTION_STATE_ORDER: Record<string, number> = {

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -235,6 +235,7 @@ export function useCanvasWebsocket(
           }
           break;
         case "run_started":
+        case "run_cancelling":
         case "run_finished": {
           const run = payload as CanvasesCanvasRun;
           if (!run.canvasId || run.canvasId !== canvasId) {

--- a/web_src/src/pages/app/mappers/timegate/index.tsx
+++ b/web_src/src/pages/app/mappers/timegate/index.tsx
@@ -117,8 +117,8 @@ export const TIME_GATE_STATE_MAP: EventStateMap = {
   cancelling: {
     icon: "refresh-cw",
     textColor: "text-gray-800",
-    backgroundColor: "bg-sky-100",
-    badgeColor: "bg-blue-500",
+    backgroundColor: "bg-amber-100",
+    badgeColor: "bg-amber-500",
     label: "Cancelling",
   },
   waiting: {

--- a/web_src/src/pages/app/mappers/wait/index.tsx
+++ b/web_src/src/pages/app/mappers/wait/index.tsx
@@ -124,8 +124,8 @@ export const WAIT_STATE_MAP: EventStateMap = {
   cancelling: {
     icon: "refresh-cw",
     textColor: "text-gray-800",
-    backgroundColor: "bg-sky-100",
-    badgeColor: "bg-blue-500",
+    backgroundColor: "bg-amber-100",
+    badgeColor: "bg-amber-500",
     label: "Cancelling",
   },
   finished: {

--- a/web_src/src/ui/Runs/RunInspectorHeader.tsx
+++ b/web_src/src/ui/Runs/RunInspectorHeader.tsx
@@ -9,6 +9,28 @@ import { calculateRunDuration } from "./runNodeDetailModel";
 import { getRunStatus } from "./runPresentation";
 import { RunStatusBadge } from "./RunStatusBadge";
 
+function getActionTooltip(status: string) {
+  switch (status) {
+    case "running":
+      return "Stop all running steps and cancel queued ones";
+    case "cancelling":
+      return "Cancelling all running steps and cancelling queued ones";
+    default:
+      return "Restart this whole run from trigger event";
+  }
+}
+
+function getActionLabel(status: string) {
+  switch (status) {
+    case "running":
+      return "Stop";
+    case "cancelling":
+      return "Cancelling";
+    default:
+      return "Rerun";
+  }
+}
+
 export function RunInspectorHeader({
   run,
   title,
@@ -27,11 +49,9 @@ export function RunInspectorHeader({
   const status = getRunStatus(run);
   const duration = calculateRunDuration(run);
   const durationText = duration !== null ? formatMinutesSecondsDuration(duration) : "";
-  const actionLabel = status === "running" ? "Stop" : "Rerun";
-  const actionTooltip =
-    status === "running"
-      ? "Stop all running steps and cancel queued ones"
-      : "Restart this whole run from trigger event";
+  const actionLabel = getActionLabel(status);
+  const actionTooltip = getActionTooltip(status);
+  const isStopAction = status === "running";
 
   return (
     <div className="sticky top-0 z-20 border-b border-slate-950/10 bg-white px-4 py-4 dark:border-gray-800 dark:bg-gray-950">
@@ -70,7 +90,7 @@ export function RunInspectorHeader({
                   disabled={actionDisabled || actionPending}
                   onClick={onAction}
                   className={cn(
-                    status === "running" &&
+                    isStopAction &&
                       "border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-900/70 dark:text-red-300 dark:hover:bg-red-950/50 dark:hover:text-red-200",
                   )}
                 >

--- a/web_src/src/ui/Runs/RunInspectorPanel.queued.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.queued.spec.tsx
@@ -281,27 +281,6 @@ describe("RunInspectorPanel queued steps", () => {
   it("renders queued steps and allows stop while executions are loading", async () => {
     mockedExecutions = [];
     mockedExecutionsLoading = true;
-    describeRunMock.mockResolvedValueOnce({
-      data: {
-        run: {
-          executions: [
-            {
-              id: "execution-ref-running",
-              nodeId: "action-2",
-              state: "STATE_STARTED",
-            },
-          ],
-          queueItems: [
-            {
-              id: "queue-approval",
-              nodeId: "approval-1",
-              rootEvent: { id: "event-running", nodeId: "trigger-1" },
-              input: { request: "approve deploy" },
-            },
-          ],
-        },
-      },
-    });
 
     renderInspector({
       run: {
@@ -335,24 +314,19 @@ describe("RunInspectorPanel queued steps", () => {
     fireEvent.click(stopButton);
 
     await waitFor(() => {
-      expect(cancelExecutionMock).toHaveBeenCalledWith(
+      expect(cancelRunMock).toHaveBeenCalledWith(
         expect.objectContaining({
           path: {
             canvasId: "canvas-1",
-            executionId: "execution-ref-running",
-          },
-        }),
-      );
-      expect(deleteNodeQueueItemMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: {
-            canvasId: "canvas-1",
-            nodeId: "approval-1",
-            itemId: "queue-approval",
+            runId: "run-running",
           },
         }),
       );
     });
+
+    expect(cancelRunMock).toHaveBeenCalledTimes(1);
+    expect(cancelExecutionMock).not.toHaveBeenCalled();
+    expect(deleteNodeQueueItemMock).not.toHaveBeenCalled();
   });
 
   it("cancels a queued step from the node accordion header", async () => {

--- a/web_src/src/ui/Runs/RunInspectorPanel.queued.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.queued.spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as ApiClient from "@/api-client";
 import type { CanvasesCanvasNodeExecution, SuperplaneMeUser } from "@/api-client";
-import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { showSuccessToast } from "@/lib/toast";
 import { executions, renderInspector, runningExecutions, runningRun } from "./RunInspectorPanel.spec.fixtures";
 
 let mockedExecutions = executions;
@@ -19,6 +19,7 @@ vi.mock("@uiw/react-json-view", () => ({
 
 const reemitTriggerEventMock = vi.fn();
 const cancelExecutionMock = vi.fn();
+const cancelRunMock = vi.fn();
 const invokeExecutionHookMock = vi.fn();
 const describeRunMock = vi.fn();
 const listNodeQueueItemsMock = vi.fn();
@@ -30,6 +31,7 @@ vi.mock("@/api-client", async (importOriginal) => {
     ...actual,
     canvasesReemitTriggerEvent: (...args: unknown[]) => reemitTriggerEventMock(...args),
     canvasesCancelExecution: (...args: unknown[]) => cancelExecutionMock(...args),
+    canvasesCancelRun: (...args: unknown[]) => cancelRunMock(...args),
     canvasesInvokeNodeExecutionHook: (...args: unknown[]) => invokeExecutionHookMock(...args),
     canvasesDescribeRun: (...args: unknown[]) => describeRunMock(...args),
     canvasesListNodeQueueItems: (...args: unknown[]) => listNodeQueueItemsMock(...args),
@@ -83,6 +85,7 @@ beforeEach(() => {
   mockedMe = null;
   reemitTriggerEventMock.mockResolvedValue({});
   cancelExecutionMock.mockResolvedValue({});
+  cancelRunMock.mockResolvedValue({});
   invokeExecutionHookMock.mockResolvedValue({});
   describeRunMock.mockResolvedValue({ data: { run: { queueItems: [] } } });
   listNodeQueueItemsMock.mockResolvedValue({ data: { items: [] } });
@@ -132,30 +135,8 @@ describe("RunInspectorPanel queued steps", () => {
     expect(screen.getByRole("button", { name: /Output/i })).toBeInTheDocument();
   });
 
-  it("stops running executions and queued items for the inspected run", async () => {
+  it("requests run cancellation from the stop action", async () => {
     mockedExecutions = runningExecutions;
-    describeRunMock.mockResolvedValueOnce({
-      data: {
-        run: {
-          executions: [
-            {
-              id: "execution-running",
-              nodeId: "action-2",
-              state: "STATE_STARTED",
-            },
-          ],
-          queueItems: [
-            {
-              id: "queue-1",
-              nodeId: "action-2",
-              rootEvent: { id: "event-running" },
-              input: { approval: "pending" },
-              createdAt: "2026-05-01T12:00:04Z",
-            },
-          ],
-        },
-      },
-    });
 
     renderInspector({
       run: {
@@ -175,74 +156,44 @@ describe("RunInspectorPanel queued steps", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
 
     await waitFor(() => {
-      expect(cancelExecutionMock).toHaveBeenCalledWith(
+      expect(cancelRunMock).toHaveBeenCalledWith(
         expect.objectContaining({
           path: {
             canvasId: "canvas-1",
-            executionId: "execution-running",
-          },
-        }),
-      );
-      expect(deleteNodeQueueItemMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: {
-            canvasId: "canvas-1",
-            nodeId: "action-2",
-            itemId: "queue-1",
+            runId: "run-running",
           },
         }),
       );
     });
 
-    expect(deleteNodeQueueItemMock).toHaveBeenCalledTimes(1);
+    expect(cancelRunMock).toHaveBeenCalledTimes(1);
+    expect(cancelExecutionMock).not.toHaveBeenCalled();
+    expect(deleteNodeQueueItemMock).not.toHaveBeenCalled();
   });
 
-  it("stops queued items that are fresher than the inspected run cache", async () => {
+  it("requests run cancellation even when cached queue items are stale", async () => {
     mockedExecutions = executions;
-    describeRunMock.mockResolvedValueOnce({
-      data: {
-        run: {
-          queueItems: [
-            {
-              id: "fresh-queue-1",
-              nodeId: "action-2",
-              rootEvent: { id: "event-running" },
-              input: { approval: "pending" },
-            },
-          ],
-        },
-      },
-    });
 
     renderInspector({ run: { ...runningRun, queueItems: [] } });
 
     fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
 
     await waitFor(() => {
-      expect(deleteNodeQueueItemMock).toHaveBeenCalledWith(
+      expect(cancelRunMock).toHaveBeenCalledWith(
         expect.objectContaining({
           path: {
             canvasId: "canvas-1",
-            nodeId: "action-2",
-            itemId: "fresh-queue-1",
+            runId: "run-running",
           },
         }),
       );
     });
 
-    expect(describeRunMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        path: {
-          canvasId: "canvas-1",
-          runId: "run-running",
-        },
-      }),
-    );
-    expect(deleteNodeQueueItemMock).toHaveBeenCalledTimes(1);
-    expect(listNodeQueueItemsMock).not.toHaveBeenCalled();
+    expect(describeRunMock).not.toHaveBeenCalled();
+    expect(cancelRunMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not stop stale cached queued items when the fresh run has none", async () => {
+  it("requests run cancellation when cached queue items remain on the run", async () => {
     mockedExecutions = [];
 
     renderInspector({
@@ -262,16 +213,13 @@ describe("RunInspectorPanel queued steps", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
 
     await waitFor(() => {
-      expect(describeRunMock).toHaveBeenCalled();
+      expect(cancelRunMock).toHaveBeenCalled();
     });
 
-    expect(deleteNodeQueueItemMock).not.toHaveBeenCalled();
-    expect(cancelExecutionMock).not.toHaveBeenCalled();
-    expect(showErrorToast).not.toHaveBeenCalledWith("Failed to stop run");
-    expect(showSuccessToast).not.toHaveBeenCalledWith("Run stopped");
+    expect(showSuccessToast).toHaveBeenCalledWith("Run stopped");
   });
 
-  it("does not stop stale cached running execution refs when the fresh run has none", async () => {
+  it("requests run cancellation when cached running execution refs remain on the run", async () => {
     mockedExecutions = [];
 
     renderInspector({
@@ -291,13 +239,10 @@ describe("RunInspectorPanel queued steps", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "Stop" })[0]);
 
     await waitFor(() => {
-      expect(describeRunMock).toHaveBeenCalled();
+      expect(cancelRunMock).toHaveBeenCalled();
     });
 
-    expect(cancelExecutionMock).not.toHaveBeenCalled();
-    expect(deleteNodeQueueItemMock).not.toHaveBeenCalled();
-    expect(showErrorToast).not.toHaveBeenCalledWith("Failed to stop run");
-    expect(showSuccessToast).not.toHaveBeenCalledWith("Run stopped");
+    expect(showSuccessToast).toHaveBeenCalledWith("Run stopped");
   });
 
   it("renders queued items as non-expandable queued rows", () => {

--- a/web_src/src/ui/Runs/RunInspectorPanel.queued.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.queued.spec.tsx
@@ -2,7 +2,6 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as ApiClient from "@/api-client";
 import type { CanvasesCanvasNodeExecution, SuperplaneMeUser } from "@/api-client";
-import { showSuccessToast } from "@/lib/toast";
 import { executions, renderInspector, runningExecutions, runningRun } from "./RunInspectorPanel.spec.fixtures";
 
 let mockedExecutions = executions;
@@ -215,8 +214,6 @@ describe("RunInspectorPanel queued steps", () => {
     await waitFor(() => {
       expect(cancelRunMock).toHaveBeenCalled();
     });
-
-    expect(showSuccessToast).toHaveBeenCalledWith("Run stopped");
   });
 
   it("requests run cancellation when cached running execution refs remain on the run", async () => {
@@ -241,8 +238,6 @@ describe("RunInspectorPanel queued steps", () => {
     await waitFor(() => {
       expect(cancelRunMock).toHaveBeenCalled();
     });
-
-    expect(showSuccessToast).toHaveBeenCalledWith("Run stopped");
   });
 
   it("renders queued items as non-expandable queued rows", () => {

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
@@ -230,6 +230,12 @@ export const runningRun: CanvasesCanvasRun = {
   },
 };
 
+export const cancellingRun: CanvasesCanvasRun = {
+  ...runningRun,
+  id: "run-cancelling",
+  state: "STATE_CANCELLING",
+};
+
 export const workflowNodes: SuperplaneComponentsNode[] = [
   {
     id: "trigger-1",

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -9,6 +9,7 @@ import {
   renderInteractiveInspector,
   runningExecutions,
   runningRun,
+  cancellingRun,
 } from "./RunInspectorPanel.spec.fixtures";
 let mockedExecutions = executions;
 let mockedExecutionsLoading = false;
@@ -517,6 +518,16 @@ describe("RunInspectorPanel", () => {
     expect(screen.getByRole("button", { name: /Await Approval/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+  });
+
+  it("shows a disabled cancelling action while the run is stopping", () => {
+    mockedExecutions = runningExecutions;
+
+    renderInspector({ run: cancellingRun });
+
+    expect(screen.getByLabelText("Cancelling")).toBeInTheDocument();
+    const headerAction = screen.getByRole("button", { name: "Cancelling" });
+    expect(headerAction).toBeDisabled();
   });
 
   it("keeps the stop action disabled while executions are loading", () => {

--- a/web_src/src/ui/Runs/RunInspectorPanel.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.tsx
@@ -92,9 +92,21 @@ export function RunInspectorPanel(props: RunInspectorPanelProps) {
         run={run}
         title={model.presentation.title}
         stepCount={model.sections.length || run.executions?.length || 0}
-        onAction={() => (model.presentation.status === "running" ? model.actions.stop() : model.actions.rerun())}
-        actionPending={model.presentation.status === "running" ? model.actions.stopPending : model.actions.rerunPending}
-        actionDisabled={model.presentation.status === "running" ? model.actions.stopDisabled : !run.rootEvent?.id}
+        onAction={() =>
+          model.presentation.status === "running" || model.presentation.status === "cancelling"
+            ? model.actions.stop()
+            : model.actions.rerun()
+        }
+        actionPending={
+          model.presentation.status === "running" || model.presentation.status === "cancelling"
+            ? model.actions.stopPending
+            : model.actions.rerunPending
+        }
+        actionDisabled={
+          model.presentation.status === "running" || model.presentation.status === "cancelling"
+            ? model.actions.stopDisabled
+            : !run.rootEvent?.id
+        }
       />
 
       <RunInspectorContent

--- a/web_src/src/ui/Runs/runPresentation.ts
+++ b/web_src/src/ui/Runs/runPresentation.ts
@@ -117,11 +117,15 @@ function getExecutionStatusLabel(execution: CanvasesCanvasNodeExecutionRef) {
 export function getExecutionStatus(execution: CanvasesCanvasNodeExecutionRef) {
   const statusLabel = getExecutionStatusLabel(execution);
 
-  if (
-    execution.state === "STATE_STARTED" ||
-    execution.state === "STATE_PENDING" ||
-    execution.state === "STATE_CANCELLING"
-  ) {
+  if (execution.state === "STATE_CANCELLING") {
+    return {
+      label: statusLabel,
+      className: "bg-amber-50 text-amber-800 ring-amber-200",
+      dotClassName: "bg-amber-500 animate-pulse",
+    };
+  }
+
+  if (execution.state === "STATE_STARTED" || execution.state === "STATE_PENDING") {
     return {
       label: statusLabel,
       className: "bg-blue-50 text-blue-700 ring-blue-200",

--- a/web_src/src/ui/Runs/runPresentation.ts
+++ b/web_src/src/ui/Runs/runPresentation.ts
@@ -14,7 +14,7 @@ import { RUN_STATUS_FILTER_IDS, type RunStatusFilter } from "./runStatusFilterVo
 
 export type { RunStatusFilter };
 export type RunResultFilter = Exclude<RunStatusFilter, "running">;
-export type RunStatusKey = RunStatusFilter | "unknown";
+export type RunStatusKey = RunStatusFilter | "cancelling" | "unknown";
 
 const RUN_STATUS_FILTER_OPTION_META: Record<RunStatusFilter, { label: string; dotClassName: string }> = {
   running: { label: "Running", dotClassName: "bg-blue-500" },
@@ -31,6 +31,12 @@ export const RUN_STATUS_META = {
     label: "Running",
     badgeClassName: "bg-blue-100 text-blue-700 dark:bg-blue-950/70 dark:text-blue-300",
     dotClassName: "bg-blue-500 animate-pulse",
+    icon: Clock,
+  },
+  cancelling: {
+    label: "Cancelling",
+    badgeClassName: "bg-amber-100 text-amber-800 dark:bg-amber-950/70 dark:text-amber-300",
+    dotClassName: "bg-amber-500 animate-pulse",
     icon: Clock,
   },
   failed: {
@@ -81,7 +87,7 @@ export function statusFiltersToApiFilters(filters: RunStatusFilter[]): {
     cancelled: "RESULT_CANCELLED",
   };
 
-  const states: CanvasesCanvasRunState[] = filters.includes("running") ? ["STATE_STARTED"] : [];
+  const states: CanvasesCanvasRunState[] = filters.includes("running") ? ["STATE_STARTED", "STATE_CANCELLING"] : [];
   const results = filters
     .filter((filter): filter is RunResultFilter => filter !== "running")
     .map((filter) => resultByFilter[filter]);
@@ -90,6 +96,7 @@ export function statusFiltersToApiFilters(filters: RunStatusFilter[]): {
 }
 
 export function getRunStatus(run: CanvasesCanvasRun): RunStatusKey {
+  if (run.state === "STATE_CANCELLING") return "cancelling";
   if (run.state === "STATE_STARTED") return "running";
   if (run.result === "RESULT_FAILED") return "failed";
   if (run.result === "RESULT_CANCELLED") return "cancelled";

--- a/web_src/src/ui/Runs/runStatusTriggerFilter.ts
+++ b/web_src/src/ui/Runs/runStatusTriggerFilter.ts
@@ -50,7 +50,8 @@ export function runMatchesStatusTriggerFilters(
   const statuses = filters.statuses;
   if (statuses && statuses.length > 0) {
     const status = getRunStatus(run);
-    if (status === "unknown" || !statuses.includes(status)) return false;
+    const filterStatus = status === "cancelling" ? "running" : status;
+    if (filterStatus === "unknown" || !statuses.includes(filterStatus)) return false;
   }
 
   const triggers = filters.triggers;

--- a/web_src/src/ui/Runs/useRunInspectorActions.ts
+++ b/web_src/src/ui/Runs/useRunInspectorActions.ts
@@ -157,7 +157,7 @@ function useStopMutation({
   return useMutation({
     mutationFn: async () => {
       if (!runId) {
-        return false;
+        return;
       }
 
       await canvasesCancelRun(
@@ -168,13 +168,9 @@ function useStopMutation({
           },
         }),
       );
-      return true;
     },
-    onSuccess: async (stoppedWork) => {
+    onSuccess: async () => {
       await refreshRunQueries();
-      if (stoppedWork) {
-        showSuccessToast("Run stopped");
-      }
     },
     onError: (error) => {
       console.error("Failed to stop run", error);

--- a/web_src/src/ui/Runs/useRunInspectorActions.ts
+++ b/web_src/src/ui/Runs/useRunInspectorActions.ts
@@ -2,8 +2,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import {
   canvasesCancelExecution,
+  canvasesCancelRun,
   canvasesDeleteNodeQueueItem,
-  canvasesDescribeRun,
   canvasesInvokeNodeExecutionHook,
   canvasesReemitTriggerEvent,
   type CanvasesCanvasRun,
@@ -63,8 +63,6 @@ export function useRunInspectorActions({
   const stopMutation = useStopMutation({
     canvasId,
     runId: run.id ?? null,
-    runningExecutionIds,
-    queuedItems,
     refreshRunQueries,
   });
   const stopNodeMutation = useStopNodeMutation({ canvasId, refreshRunQueries });
@@ -78,6 +76,7 @@ export function useRunInspectorActions({
     stopPending: stopMutation.isPending,
     stopDisabled:
       stopMutation.isPending ||
+      run.state === "STATE_CANCELLING" ||
       (runningExecutionIds.length === 0 &&
         queuedItems.length === 0 &&
         (executionsLoading || !run.rootEvent?.id || !hasLoadedActionSection)),
@@ -149,28 +148,26 @@ function useRerunMutation({
 function useStopMutation({
   canvasId,
   runId,
-  runningExecutionIds,
-  queuedItems,
   refreshRunQueries,
 }: {
   canvasId: string;
   runId: string | null;
-  runningExecutionIds: string[];
-  queuedItems: QueuedItemReference[];
   refreshRunQueries: () => Promise<void>;
 }) {
   return useMutation({
     mutationFn: async () => {
-      const workToStop = runId ? await fetchRunWorkForStop(canvasId, runId) : { runningExecutionIds, queuedItems };
-
-      if (workToStop.runningExecutionIds.length === 0 && workToStop.queuedItems.length === 0) {
+      if (!runId) {
         return false;
       }
 
-      await Promise.all([
-        ...workToStop.runningExecutionIds.map((executionId) => cancelExecution(canvasId, executionId)),
-        ...workToStop.queuedItems.map((item) => deleteQueuedItem(canvasId, item.nodeId, item.itemId)),
-      ]);
+      await canvasesCancelRun(
+        withOrganizationHeader({
+          path: {
+            canvasId,
+            runId,
+          },
+        }),
+      );
       return true;
     },
     onSuccess: async (stoppedWork) => {
@@ -283,20 +280,6 @@ async function deleteQueuedItem(canvasId: string, nodeId: string, itemId: string
   );
 }
 
-async function fetchRunWorkForStop(canvasId: string, runId: string): Promise<StopRunWork> {
-  const response = await canvasesDescribeRun(
-    withOrganizationHeader({
-      path: { canvasId, runId },
-    }),
-  );
-
-  const run = response.data?.run;
-  return {
-    runningExecutionIds: runningExecutionIdsFromRun(run),
-    queuedItems: run?.queueItems?.filter(hasQueueItemIdentity).map(toQueuedItemReference) ?? [],
-  };
-}
-
 function invokeExecutionHook(canvasId: string) {
   return async ({
     executionId,
@@ -331,22 +314,6 @@ type QueuedItemReference = {
   nodeId: string;
   itemId: string;
 };
-
-type StopRunWork = {
-  runningExecutionIds: string[];
-  queuedItems: QueuedItemReference[];
-};
-
-function runningExecutionIdsFromRun(run: CanvasesCanvasRun | undefined): string[] {
-  const ids: string[] = [];
-  for (const executionRef of run?.executions ?? []) {
-    if (executionRef.id && executionRef.state === "STATE_STARTED") {
-      ids.push(executionRef.id);
-    }
-  }
-
-  return ids;
-}
 
 function hasQueueItemIdentity(
   queueItem: NonNullable<CanvasesCanvasRun["queueItems"]>[number],

--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -204,8 +204,8 @@ export const DEFAULT_EVENT_STATE_MAP: EventStateMap = {
   cancelling: {
     icon: "refresh-cw",
     textColor: "text-gray-800",
-    backgroundColor: "bg-sky-100",
-    badgeColor: "bg-blue-500",
+    backgroundColor: "bg-amber-100",
+    badgeColor: "bg-amber-500",
     label: "Cancelling",
   },
 };


### PR DESCRIPTION
Fixes https://github.com/superplanehq/superplane/issues/6196

---

- Adds CancelRun API to mark runs as cancelling, drain pending queue items/events, and request termination of in-flight executions.
- Extends run finalizer and node queue worker to skip work for cancelling runs and publish canvas-queue-item-deleted when items are dropped.
- UI: stop action in run inspector, Cancelling status styling (amber, matching run badge), and websocket handling for run_cancelling.