### PR TITLE
feat: support named broker command_list entries

### DIFF
--- a/pkg/components/runner/broker.go
+++ b/pkg/components/runner/broker.go
@@ -90,7 +90,7 @@ type brokerCreateTaskRequest struct {
 	RunMode                 string                      `json:"run_mode,omitempty"`
 	Script                  string                      `json:"script,omitempty"`
 	MessageChain            json.RawMessage             `json:"message_chain,omitempty"`
-	Commands                []string                    `json:"commands,omitempty"`
+	Commands                []BrokerCommand             `json:"commands,omitempty"`
 	SetupCommands           []string                    `json:"setup_commands,omitempty"`
 	Environment             []BrokerEnvironmentVariable `json:"environment,omitempty"`
 	WebhookURL              string                      `json:"webhook_url"`
@@ -98,6 +98,63 @@ type brokerCreateTaskRequest struct {
 	ExecutionMode           string                      `json:"execution_mode,omitempty"`
 	DockerImage             string                      `json:"docker_image,omitempty"`
 	ExecutionTimeoutSeconds *int                        `json:"execution_timeout_seconds,omitempty"`
+}
+
+// BrokerCommand is one command_list entry. JSON is a plain string when Name is
+// empty, or {"name","command"} when Name is set (task-broker accepts both).
+type BrokerCommand struct {
+	Name    string `json:"name,omitempty"`
+	Command string `json:"command"`
+}
+
+func (c BrokerCommand) MarshalJSON() ([]byte, error) {
+	name := strings.TrimSpace(c.Name)
+	command := strings.TrimSpace(c.Command)
+	if name == "" {
+		return json.Marshal(command)
+	}
+	return json.Marshal(struct {
+		Name    string `json:"name"`
+		Command string `json:"command"`
+	}{Name: name, Command: command})
+}
+
+func (c *BrokerCommand) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		*c = BrokerCommand{}
+		return nil
+	}
+	if data[0] == '"' {
+		var command string
+		if err := json.Unmarshal(data, &command); err != nil {
+			return err
+		}
+		*c = BrokerCommand{Command: strings.TrimSpace(command)}
+		return nil
+	}
+	var raw struct {
+		Name    string `json:"name"`
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*c = BrokerCommand{Name: strings.TrimSpace(raw.Name), Command: strings.TrimSpace(raw.Command)}
+	return nil
+}
+
+// BrokerCommandsFromLines adapts plain shell lines into unnamed broker commands.
+func BrokerCommandsFromLines(lines []string) []BrokerCommand {
+	out := make([]BrokerCommand, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		out = append(out, BrokerCommand{Command: line})
+	}
+	return out
 }
 
 // BrokerEnvironmentVariable is forwarded to the task broker as JSON.
@@ -118,7 +175,7 @@ type CreateTaskParams struct {
 	RunMode                 string
 	Script                  string
 	MessageChain            json.RawMessage
-	Commands                []string
+	Commands                []BrokerCommand
 	SetupCommands           []string
 	WebhookURL              string
 	WebhookPayloadSizeLimit int

--- a/pkg/components/runner/broker_command_test.go
+++ b/pkg/components/runner/broker_command_test.go
@@ -1,0 +1,51 @@
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrokerCommandJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unnamed command marshals as a plain string", func(t *testing.T) {
+		b, err := json.Marshal(BrokerCommand{Command: "echo hi"})
+		require.NoError(t, err)
+		assert.JSONEq(t, `"echo hi"`, string(b))
+
+		var got BrokerCommand
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.Equal(t, BrokerCommand{Command: "echo hi"}, got)
+	})
+
+	t.Run("named command marshals as an object", func(t *testing.T) {
+		b, err := json.Marshal(BrokerCommand{Name: "Clone", Command: "git clone …"})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"Clone","command":"git clone …"}`, string(b))
+
+		var got BrokerCommand
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.Equal(t, BrokerCommand{Name: "Clone", Command: "git clone …"}, got)
+	})
+
+	t.Run("legacy string array still unmarshals", func(t *testing.T) {
+		var commands []BrokerCommand
+		require.NoError(t, json.Unmarshal([]byte(`["echo a","echo b"]`), &commands))
+		assert.Equal(t, []BrokerCommand{
+			{Command: "echo a"},
+			{Command: "echo b"},
+		}, commands)
+	})
+}
+
+func TestBrokerCommandsFromLines(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []BrokerCommand{
+		{Command: "echo a"},
+		{Command: "echo b"},
+	}, BrokerCommandsFromLines([]string{"  echo a  ", "", "echo b"}))
+}

--- a/pkg/components/runner/run_commands.go
+++ b/pkg/components/runner/run_commands.go
@@ -305,7 +305,7 @@ func (c *Runner) Execute(ctx core.ExecutionContext) error {
 	mode := normalizeExecutionMode(spec.ExecutionMode)
 	params := CreateTaskParams{
 		MachineType:    spec.MachineType,
-		Commands:       cmds,
+		Commands:       BrokerCommandsFromLines(cmds),
 		WebhookURL:     webhookURL,
 		Environment:    environment,
 		ExecutionMode:  mode,

--- a/pkg/components/runner/run_commands_test.go
+++ b/pkg/components/runner/run_commands_test.go
@@ -446,7 +446,7 @@ func TestRunnerExecuteSendsEnvironmentToBroker(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &req))
 
 	assert.Equal(t, testRunnerMachineType, req.FleetID)
-	assert.Equal(t, []string{"echo hello"}, req.Commands)
+	assert.Equal(t, []BrokerCommand{{Command: "echo hello"}}, req.Commands)
 	assert.Equal(t, config.MaxWebhookPayloadSize, req.WebhookPayloadSizeLimit)
 }
 


### PR DESCRIPTION
## Summary
- Add `BrokerCommand` with JSON that marshals unnamed commands as plain strings and named commands as `{name, command}` objects
- Keep legacy `commands: ["echo hi"]` create-task payloads working
- Wire Run Shell Commands through `BrokerCommandsFromLines` so existing callers stay string-compatible on the wire

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/components/runner`
- [ ] Confirm task-broker/runner that accepts named commands is deployed (or paired) before clients send `{name, command}` objects
- [ ] Smoke: create a Run Shell Commands task and verify broker still accepts commands


Made with [Cursor](https://cursor.com)