### PR TITLE
feat: configure timeout when triggering runs in other apps

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -1062,7 +1062,14 @@ The Read Memory component looks up values from canvas-level memory storage.
 
 **Component key:** `runApp`
 
-Run another SuperPlane app and wait for its run to finish
+Run another SuperPlane app and wait for its run to finish.
+
+### Configuration
+
+- **App**: The SuperPlane app to invoke
+- **Node**: The On Run trigger in the target app
+- **Parameters**: Values passed to the target app's On Run trigger
+- **Timeout**: Maximum wait time in seconds for the child run (default 3600). When the timeout expires before the child run finishes, the child run is cancelled and the parent continues through the Failed output channel.
 
 ### Example Output
 

--- a/pkg/components/messages/run_app.go
+++ b/pkg/components/messages/run_app.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -10,8 +11,12 @@ import (
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
-const PassedOutputChannel = "passed"
-const FailedOutputChannel = "failed"
+const (
+	PassedOutputChannel         = "passed"
+	FailedOutputChannel         = "failed"
+	ActionRunTimeout            = "onRunTimeout"
+	defaultRunAppTimeoutSeconds = 3600
+)
 
 type RunApp struct{}
 
@@ -23,10 +28,12 @@ type RunAppConfiguration struct {
 	App        string         `json:"app" mapstructure:"app"`
 	Node       string         `json:"node" mapstructure:"node"`
 	Parameters map[string]any `json:"parameters" mapstructure:"parameters"`
+	Timeout    *int           `json:"timeout,omitempty" mapstructure:"timeout,omitempty"`
 }
 
 type runAppExecutionMetadata struct {
-	Run *RunMetadata `json:"run" mapstructure:"run"`
+	Run        *RunMetadata `json:"run" mapstructure:"run"`
+	TimedOutAt *string      `json:"timedOutAt,omitempty" mapstructure:"timedOutAt,omitempty"`
 }
 
 type RunMetadata struct {
@@ -67,7 +74,14 @@ func (c *RunApp) Icon() string {
 }
 
 func (c *RunApp) Documentation() string {
-	return "Run another SuperPlane app and wait for its run to finish"
+	return `Run another SuperPlane app and wait for its run to finish.
+
+## Configuration
+
+- **App**: The SuperPlane app to invoke
+- **Node**: The On Run trigger in the target app
+- **Parameters**: Values passed to the target app's On Run trigger
+- **Timeout**: Maximum wait time in seconds for the child run (default 3600). When the timeout expires before the child run finishes, the child run is cancelled and the parent continues through the Failed output channel.`
 }
 
 func (c *RunApp) Description() string {
@@ -139,6 +153,19 @@ func (c *RunApp) Configuration() []configuration.Field {
 			Description: "The run parameters to pass to the target app",
 			Type:        configuration.FieldTypeRunParameters,
 			Required:    true,
+		},
+		{
+			Name:        "timeout",
+			Label:       "Timeout",
+			Type:        configuration.FieldTypeNumber,
+			Description: "Maximum time to wait for the child run in seconds (default 3600)",
+			Required:    false,
+			Default:     "3600",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { min := 1; return &min }(),
+				},
+			},
 		},
 	}
 }
@@ -234,16 +261,24 @@ func (c *RunApp) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("run app: create run: %w", err)
 	}
 
-	return ctx.Metadata.Set(runAppExecutionMetadata{
+	executionMetadata := runAppExecutionMetadata{
 		Run: &RunMetadata{
 			ID: run.ID.String(),
 		},
-	})
+	}
+
+	timeoutSeconds := runAppTimeoutSeconds(config.Timeout)
+	if err := ctx.Requests.ScheduleActionCall(ActionRunTimeout, map[string]any{}, time.Duration(timeoutSeconds)*time.Second); err != nil {
+		return fmt.Errorf("run app: schedule timeout: %w", err)
+	}
+
+	return ctx.Metadata.Set(executionMetadata)
 }
 
 func (c *RunApp) Hooks() []core.Hook {
 	return []core.Hook{
 		{Name: "onRunFinished", Type: core.HookTypeInternal},
+		{Name: ActionRunTimeout, Type: core.HookTypeInternal},
 	}
 }
 
@@ -251,12 +286,37 @@ func (c *RunApp) HandleHook(ctx core.ActionHookContext) error {
 	switch ctx.Name {
 	case "onRunFinished":
 		return c.handleRunFinished(ctx)
+	case ActionRunTimeout:
+		return c.handleRunTimeout(ctx)
 	default:
 		return fmt.Errorf("run app: unknown hook %s", ctx.Name)
 	}
 }
 
+func (c *RunApp) handleRunTimeout(ctx core.ActionHookContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	executionMetadata := runAppExecutionMetadata{}
+	err := mapstructure.Decode(ctx.Metadata.Get(), &executionMetadata)
+	if err != nil {
+		return fmt.Errorf("run app: decode execution metadata: %w", err)
+	}
+
+	executionMetadata.TimedOutAt = stringPtr(time.Now().UTC().Format(time.RFC3339))
+	if err := ctx.Metadata.Set(executionMetadata); err != nil {
+		return fmt.Errorf("run app: set execution metadata: %w", err)
+	}
+
+	return ctx.Runs.Cancel()
+}
+
 func (c *RunApp) handleRunFinished(ctx core.ActionHookContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
 	callback, err := core.DecodeRunFinishedCallback(ctx.Parameters)
 	if err != nil {
 		return fmt.Errorf("run app: decode run finished callback: %w", err)
@@ -290,10 +350,7 @@ func (c *RunApp) handleRunFinished(ctx core.ActionHookContext) error {
 		})
 	}
 
-	errMessage := ""
-	if callback.Run.Error != nil {
-		errMessage = *callback.Run.Error
-	}
+	errMessage := runAppFailureMessage(executionMetadata, ctx.Configuration, callback.Run.Error)
 
 	err = ctx.Metadata.Set(runAppExecutionMetadata{
 		Run: &RunMetadata{
@@ -301,6 +358,7 @@ func (c *RunApp) handleRunFinished(ctx core.ActionHookContext) error {
 			Result: callback.Run.Result,
 			Error:  &errMessage,
 		},
+		TimedOutAt: executionMetadata.TimedOutAt,
 	})
 
 	if err != nil {
@@ -328,4 +386,33 @@ func (c *RunApp) Cancel(ctx core.ExecutionContext) error {
 
 func (c *RunApp) Cleanup(ctx core.SetupContext) error {
 	return nil
+}
+
+func runAppFailureMessage(executionMetadata runAppExecutionMetadata, configuration any, runError *string) string {
+	if executionMetadata.TimedOutAt != nil && *executionMetadata.TimedOutAt != "" {
+		config := RunAppConfiguration{}
+		if err := mapstructure.Decode(configuration, &config); err != nil {
+			return "timed out"
+		}
+
+		return fmt.Sprintf("timed out after %ds", runAppTimeoutSeconds(config.Timeout))
+	}
+
+	if runError != nil {
+		return *runError
+	}
+
+	return ""
+}
+
+func runAppTimeoutSeconds(timeout *int) int {
+	if timeout == nil || *timeout <= 0 {
+		return defaultRunAppTimeoutSeconds
+	}
+
+	return *timeout
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/pkg/components/messages/run_app.go
+++ b/pkg/components/messages/run_app.go
@@ -31,6 +31,14 @@ type RunAppConfiguration struct {
 	Timeout    *int           `json:"timeout,omitempty" mapstructure:"timeout,omitempty"`
 }
 
+func (c *RunAppConfiguration) TimeoutDuration() time.Duration {
+	if c.Timeout == nil || *c.Timeout <= 0 {
+		return time.Duration(defaultRunAppTimeoutSeconds) * time.Second
+	}
+
+	return time.Duration(*c.Timeout) * time.Second
+}
+
 type runAppExecutionMetadata struct {
 	Run *RunMetadata `json:"run" mapstructure:"run"`
 }
@@ -266,8 +274,7 @@ func (c *RunApp) Execute(ctx core.ExecutionContext) error {
 		},
 	}
 
-	timeoutSeconds := runAppTimeoutSeconds(config.Timeout)
-	if err := ctx.Requests.ScheduleActionCall(ActionRunTimeout, map[string]any{}, time.Duration(timeoutSeconds)*time.Second); err != nil {
+	if err := ctx.Requests.ScheduleActionCall(ActionRunTimeout, map[string]any{}, config.TimeoutDuration()); err != nil {
 		return fmt.Errorf("run app: schedule timeout: %w", err)
 	}
 
@@ -332,7 +339,10 @@ func (c *RunApp) handleRunFinished(ctx core.ActionHookContext) error {
 		})
 	}
 
-	errMessage := runAppFailureMessage(ctx.Configuration, callback.Run.Result, callback.Run.Error)
+	errMessage := ""
+	if callback.Run.Error != nil {
+		errMessage = *callback.Run.Error
+	}
 
 	err = ctx.Metadata.Set(runAppExecutionMetadata{
 		Run: &RunMetadata{
@@ -367,29 +377,4 @@ func (c *RunApp) Cancel(ctx core.ExecutionContext) error {
 
 func (c *RunApp) Cleanup(ctx core.SetupContext) error {
 	return nil
-}
-
-func runAppFailureMessage(configuration any, runResult string, runError *string) string {
-	if runResult == core.RunResultCancelled {
-		config := RunAppConfiguration{}
-		if err := mapstructure.Decode(configuration, &config); err != nil {
-			return "timed out"
-		}
-
-		return fmt.Sprintf("timed out after %ds", runAppTimeoutSeconds(config.Timeout))
-	}
-
-	if runError != nil {
-		return *runError
-	}
-
-	return ""
-}
-
-func runAppTimeoutSeconds(timeout *int) int {
-	if timeout == nil || *timeout <= 0 {
-		return defaultRunAppTimeoutSeconds
-	}
-
-	return *timeout
 }

--- a/pkg/components/messages/run_app.go
+++ b/pkg/components/messages/run_app.go
@@ -32,8 +32,7 @@ type RunAppConfiguration struct {
 }
 
 type runAppExecutionMetadata struct {
-	Run        *RunMetadata `json:"run" mapstructure:"run"`
-	TimedOutAt *string      `json:"timedOutAt,omitempty" mapstructure:"timedOutAt,omitempty"`
+	Run *RunMetadata `json:"run" mapstructure:"run"`
 }
 
 type RunMetadata struct {
@@ -298,17 +297,6 @@ func (c *RunApp) handleRunTimeout(ctx core.ActionHookContext) error {
 		return nil
 	}
 
-	executionMetadata := runAppExecutionMetadata{}
-	err := mapstructure.Decode(ctx.Metadata.Get(), &executionMetadata)
-	if err != nil {
-		return fmt.Errorf("run app: decode execution metadata: %w", err)
-	}
-
-	executionMetadata.TimedOutAt = stringPtr(time.Now().UTC().Format(time.RFC3339))
-	if err := ctx.Metadata.Set(executionMetadata); err != nil {
-		return fmt.Errorf("run app: set execution metadata: %w", err)
-	}
-
 	return ctx.Runs.Cancel()
 }
 
@@ -320,12 +308,6 @@ func (c *RunApp) handleRunFinished(ctx core.ActionHookContext) error {
 	callback, err := core.DecodeRunFinishedCallback(ctx.Parameters)
 	if err != nil {
 		return fmt.Errorf("run app: decode run finished callback: %w", err)
-	}
-
-	executionMetadata := runAppExecutionMetadata{}
-	err = mapstructure.Decode(ctx.Metadata.Get(), &executionMetadata)
-	if err != nil {
-		return fmt.Errorf("run app: decode execution metadata: %w", err)
 	}
 
 	if callback.Run.Result == core.RunResultPassed {
@@ -350,7 +332,7 @@ func (c *RunApp) handleRunFinished(ctx core.ActionHookContext) error {
 		})
 	}
 
-	errMessage := runAppFailureMessage(executionMetadata, ctx.Configuration, callback.Run.Error)
+	errMessage := runAppFailureMessage(ctx.Configuration, callback.Run.Result, callback.Run.Error)
 
 	err = ctx.Metadata.Set(runAppExecutionMetadata{
 		Run: &RunMetadata{
@@ -358,7 +340,6 @@ func (c *RunApp) handleRunFinished(ctx core.ActionHookContext) error {
 			Result: callback.Run.Result,
 			Error:  &errMessage,
 		},
-		TimedOutAt: executionMetadata.TimedOutAt,
 	})
 
 	if err != nil {
@@ -388,8 +369,8 @@ func (c *RunApp) Cleanup(ctx core.SetupContext) error {
 	return nil
 }
 
-func runAppFailureMessage(executionMetadata runAppExecutionMetadata, configuration any, runError *string) string {
-	if executionMetadata.TimedOutAt != nil && *executionMetadata.TimedOutAt != "" {
+func runAppFailureMessage(configuration any, runResult string, runError *string) string {
+	if runResult == core.RunResultCancelled {
 		config := RunAppConfiguration{}
 		if err := mapstructure.Decode(configuration, &config); err != nil {
 			return "timed out"
@@ -411,8 +392,4 @@ func runAppTimeoutSeconds(timeout *int) int {
 	}
 
 	return *timeout
-}
-
-func stringPtr(value string) *string {
-	return &value
 }

--- a/pkg/components/messages/run_app_test.go
+++ b/pkg/components/messages/run_app_test.go
@@ -9,15 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/models"
-	"github.com/superplanehq/superplane/pkg/workers/contexts"
-	"github.com/superplanehq/superplane/test/support"
-	"gorm.io/datatypes"
-	"gorm.io/gorm"
+	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
-func TestRunAppFailureMessage(t *testing.T) {
+func Test__RunApp__FailureMessage(t *testing.T) {
 	timedOutAt := "2026-07-20T12:00:00Z"
 	assert.Equal(t, "timed out after 30s", runAppFailureMessage(runAppExecutionMetadata{
 		TimedOutAt: &timedOutAt,
@@ -31,7 +26,7 @@ func TestRunAppFailureMessage(t *testing.T) {
 	assert.Equal(t, "", runAppFailureMessage(runAppExecutionMetadata{}, nil, nil))
 }
 
-func TestRunAppTimeoutSeconds(t *testing.T) {
+func Test__RunApp__TimeoutSeconds(t *testing.T) {
 	defaultTimeout := runAppTimeoutSeconds(nil)
 	assert.Equal(t, defaultRunAppTimeoutSeconds, defaultTimeout)
 
@@ -42,385 +37,167 @@ func TestRunAppTimeoutSeconds(t *testing.T) {
 	assert.Equal(t, 120, runAppTimeoutSeconds(&custom))
 }
 
-func TestRunAppExecuteSchedulesTimeoutWhenConfigured(t *testing.T) {
-	r := support.Setup(t)
-	defer r.Close()
-
-	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{
-			{NodeID: "trigger", Type: models.NodeTypeTrigger},
-			{
-				NodeID: "runApp",
-				Name:   "Run App",
-				Type:   models.NodeTypeComponent,
-				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
-			},
+func Test__RunApp__Execute__SchedulesConfiguredTimeout(t *testing.T) {
+	childAppID := uuid.New()
+	runID := uuid.New()
+	requests := &contexts.RequestContext{}
+	executionMetadata := &contexts.MetadataContext{}
+	nodeMetadata := &contexts.MetadataContext{
+		Metadata: RunAppMetadata{
+			App:  &AppMetadata{ID: childAppID.String(), Name: "Child App"},
+			Node: &CanvasNodeMetadata{ID: "onRun", Name: "On Run"},
 		},
-		nil,
-	)
+	}
+	runs := &contexts.RunExecutionContext{CreateRunID: runID}
 
-	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
-		nil,
-	)
-
-	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
-	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
-
-	requests := &scheduledRunAppRequestContext{}
-	timeout := 45
-
-	err := database.Conn().Transaction(func(tx *gorm.DB) error {
-		parentNodes[1].Metadata = datatypes.NewJSONType(map[string]any{
-			"app": map[string]any{
-				"id":   childCanvas.ID.String(),
-				"name": "Child App",
-			},
-			"node": map[string]any{
-				"id":   "onRun",
-				"name": "On Run",
-			},
-		})
-
-		return (&RunApp{}).Execute(core.ExecutionContext{
-			WorkflowID: parentCanvas.ID.String(),
-			Configuration: map[string]any{
-				"app":        childCanvas.ID.String(),
-				"node":       "onRun",
-				"parameters": map[string]any{},
-				"timeout":    timeout,
-			},
-			Metadata:     contexts.NewExecutionMetadataContext(tx, execution),
-			NodeMetadata: contexts.NewNodeMetadataContext(tx, &parentNodes[1]),
-			Requests:     requests,
-			Runs:         contexts.NewRunExecutionContext(tx, parentCanvas, &parentNodes[1], execution),
-		})
+	err := (&RunApp{}).Execute(core.ExecutionContext{
+		WorkflowID: "parent-workflow",
+		CanvasName: "Parent App",
+		Configuration: map[string]any{
+			"app":        childAppID.String(),
+			"node":       "onRun",
+			"parameters": map[string]any{},
+			"timeout":    45,
+		},
+		Metadata:     executionMetadata,
+		NodeMetadata: nodeMetadata,
+		Requests:     requests,
+		Runs:         runs,
 	})
 	require.NoError(t, err)
-	require.True(t, requests.called)
-	assert.Equal(t, ActionRunTimeout, requests.actionName)
-	assert.Equal(t, 45*time.Second, requests.interval)
 
-	var metadata runAppExecutionMetadata
-	require.NoError(t, mapstructureDecodeExecutionMetadata(t, execution, &metadata))
+	assert.Equal(t, ActionRunTimeout, requests.Action)
+	assert.Equal(t, 45*time.Second, requests.Duration)
+
+	metadata := decodeRunAppExecutionMetadata(t, executionMetadata)
 	require.NotNil(t, metadata.Run)
-	assert.NotEmpty(t, metadata.Run.ID)
+	assert.Equal(t, runID.String(), metadata.Run.ID)
+	assert.Nil(t, metadata.TimedOutAt)
+
+	require.NotNil(t, runs.LastCreateParams)
+	assert.Equal(t, childAppID.String(), runs.LastCreateParams.App)
+	assert.Equal(t, "onRun", runs.LastCreateParams.Node)
+	require.Len(t, runs.LastCreateParams.Callbacks, 2)
+}
+
+func Test__RunApp__Execute__SchedulesDefaultTimeout(t *testing.T) {
+	childAppID := uuid.New()
+	requests := &contexts.RequestContext{}
+	executionMetadata := &contexts.MetadataContext{}
+	nodeMetadata := &contexts.MetadataContext{
+		Metadata: RunAppMetadata{
+			App:  &AppMetadata{ID: childAppID.String(), Name: "Child App"},
+			Node: &CanvasNodeMetadata{ID: "onRun", Name: "On Run"},
+		},
+	}
+
+	err := (&RunApp{}).Execute(core.ExecutionContext{
+		WorkflowID: "parent-workflow",
+		CanvasName: "Parent App",
+		Configuration: map[string]any{
+			"app":        childAppID.String(),
+			"node":       "onRun",
+			"parameters": map[string]any{},
+		},
+		Metadata:     executionMetadata,
+		NodeMetadata: nodeMetadata,
+		Requests:     requests,
+		Runs:         &contexts.RunExecutionContext{},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionRunTimeout, requests.Action)
+	assert.Equal(t, time.Duration(defaultRunAppTimeoutSeconds)*time.Second, requests.Duration)
+}
+
+func Test__RunApp__HandleRunTimeout__CancelsChildRun(t *testing.T) {
+	childRunID := uuid.New().String()
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: runAppExecutionMetadata{
+			Run: &RunMetadata{ID: childRunID},
+		},
+	}
+	runs := &contexts.RunExecutionContext{}
+
+	err := (&RunApp{}).handleRunTimeout(core.ActionHookContext{
+		Metadata:       metadataCtx,
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Runs:           runs,
+	})
+	require.NoError(t, err)
+	assert.True(t, runs.CancelCalled)
+
+	metadata := decodeRunAppExecutionMetadata(t, metadataCtx)
+	require.NotNil(t, metadata.TimedOutAt)
+	assert.NotEmpty(t, *metadata.TimedOutAt)
+	assert.Equal(t, childRunID, metadata.Run.ID)
+}
+
+func Test__RunApp__HandleRunTimeout__NoOpWhenFinished(t *testing.T) {
+	childRunID := uuid.New().String()
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: runAppExecutionMetadata{
+			Run: &RunMetadata{ID: childRunID},
+		},
+	}
+	runs := &contexts.RunExecutionContext{}
+
+	err := (&RunApp{}).handleRunTimeout(core.ActionHookContext{
+		Metadata:       metadataCtx,
+		ExecutionState: &contexts.ExecutionStateContext{Finished: true},
+		Runs:           runs,
+	})
+	require.NoError(t, err)
+	assert.False(t, runs.CancelCalled)
+
+	metadata := decodeRunAppExecutionMetadata(t, metadataCtx)
 	assert.Nil(t, metadata.TimedOutAt)
 }
 
-func TestRunAppExecuteSchedulesDefaultTimeout(t *testing.T) {
-	r := support.Setup(t)
-	defer r.Close()
-
-	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{
-			{NodeID: "trigger", Type: models.NodeTypeTrigger},
-			{
-				NodeID: "runApp",
-				Name:   "Run App",
-				Type:   models.NodeTypeComponent,
-				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
-			},
-		},
-		nil,
-	)
-
-	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
-		nil,
-	)
-
-	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
-	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
-
-	requests := &scheduledRunAppRequestContext{}
-
-	err := database.Conn().Transaction(func(tx *gorm.DB) error {
-		parentNodes[1].Metadata = datatypes.NewJSONType(map[string]any{
-			"app": map[string]any{
-				"id":   childCanvas.ID.String(),
-				"name": "Child App",
-			},
-			"node": map[string]any{
-				"id":   "onRun",
-				"name": "On Run",
-			},
-		})
-
-		return (&RunApp{}).Execute(core.ExecutionContext{
-			WorkflowID: parentCanvas.ID.String(),
-			Configuration: map[string]any{
-				"app":        childCanvas.ID.String(),
-				"node":       "onRun",
-				"parameters": map[string]any{},
-			},
-			Metadata:     contexts.NewExecutionMetadataContext(tx, execution),
-			NodeMetadata: contexts.NewNodeMetadataContext(tx, &parentNodes[1]),
-			Requests:     requests,
-			Runs:         contexts.NewRunExecutionContext(tx, parentCanvas, &parentNodes[1], execution),
-		})
-	})
-	require.NoError(t, err)
-	require.True(t, requests.called)
-	assert.Equal(t, ActionRunTimeout, requests.actionName)
-	assert.Equal(t, time.Duration(defaultRunAppTimeoutSeconds)*time.Second, requests.interval)
-}
-
-func TestRunAppHandleRunTimeoutCancelsChildRun(t *testing.T) {
-	r := support.Setup(t)
-	defer r.Close()
-
-	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{
-			{NodeID: "trigger", Type: models.NodeTypeTrigger},
-			{
-				NodeID: "runApp",
-				Type:   models.NodeTypeComponent,
-				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
-			},
-		},
-		nil,
-	)
-	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
-		nil,
-	)
-
-	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
-	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
-	childRun := createRunAppChildRunRecord(t, childCanvas.ID, "onRun", parentRun.ID, parentCanvas.ID, execution.ID)
-
-	err := database.Conn().Transaction(func(tx *gorm.DB) error {
-		metadataCtx := contexts.NewExecutionMetadataContext(tx, execution)
-		require.NoError(t, metadataCtx.Set(runAppExecutionMetadata{
-			Run: &RunMetadata{
-				ID: childRun.ID.String(),
-			},
-		}))
-
-		return (&RunApp{}).handleRunTimeout(core.ActionHookContext{
-			Metadata:       metadataCtx,
-			ExecutionState: contexts.NewExecutionStateContext(tx, execution, nil),
-			Runs:           contexts.NewRunExecutionContext(tx, parentCanvas, &parentNodes[1], execution),
-		})
-	})
-	require.NoError(t, err)
-
-	updatedChild, err := models.FindCanvasRunInTransaction(database.Conn(), childCanvas.ID, childRun.ID)
-	require.NoError(t, err)
-	assert.Equal(t, models.CanvasRunStateCancelling, updatedChild.State)
-
-	var metadata runAppExecutionMetadata
-	require.NoError(t, mapstructureDecodeExecutionMetadata(t, execution, &metadata))
-	require.NotNil(t, metadata.TimedOutAt)
-	assert.NotEmpty(t, *metadata.TimedOutAt)
-}
-
-func TestRunAppHandleRunTimeoutNoOpWhenFinished(t *testing.T) {
-	r := support.Setup(t)
-	defer r.Close()
-
-	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{
-			{NodeID: "trigger", Type: models.NodeTypeTrigger},
-			{
-				NodeID: "runApp",
-				Type:   models.NodeTypeComponent,
-				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
-			},
-		},
-		nil,
-	)
-	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
-		nil,
-	)
-
-	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
-	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
-	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
-		"state":  models.CanvasNodeExecutionStateFinished,
-		"result": models.CanvasNodeExecutionResultPassed,
-	}).Error)
-
-	childRun := createRunAppChildRunRecord(t, childCanvas.ID, "onRun", parentRun.ID, parentCanvas.ID, execution.ID)
-
-	err := database.Conn().Transaction(func(tx *gorm.DB) error {
-		metadataCtx := contexts.NewExecutionMetadataContext(tx, execution)
-		require.NoError(t, metadataCtx.Set(runAppExecutionMetadata{
-			Run: &RunMetadata{ID: childRun.ID.String()},
-		}))
-
-		return (&RunApp{}).handleRunTimeout(core.ActionHookContext{
-			Metadata:       metadataCtx,
-			ExecutionState: contexts.NewExecutionStateContext(tx, execution, nil),
-			Runs:           contexts.NewRunExecutionContext(tx, parentCanvas, &parentNodes[1], execution),
-		})
-	})
-	require.NoError(t, err)
-
-	updatedChild, err := models.FindCanvasRunInTransaction(database.Conn(), childCanvas.ID, childRun.ID)
-	require.NoError(t, err)
-	assert.Equal(t, models.CanvasRunStatePending, updatedChild.State)
-}
-
-func TestRunAppHandleRunFinishedUsesTimeoutMessage(t *testing.T) {
-	r := support.Setup(t)
-	defer r.Close()
-
-	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
-		[]models.CanvasNode{
-			{NodeID: "trigger", Type: models.NodeTypeTrigger},
-			{
-				NodeID: "runApp",
-				Type:   models.NodeTypeComponent,
-				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
-			},
-		},
-		nil,
-	)
-
-	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
-	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
-
-	var emittedChannel string
-	err := database.Conn().Transaction(func(tx *gorm.DB) error {
-		metadataCtx := contexts.NewExecutionMetadataContext(tx, execution)
-		timedOutAt := time.Now().UTC().Format(time.RFC3339)
-		require.NoError(t, metadataCtx.Set(runAppExecutionMetadata{
-			Run: &RunMetadata{
-				ID: uuid.New().String(),
-			},
+func Test__RunApp__HandleRunFinished__EmitsFailedWithTimeoutMessage(t *testing.T) {
+	timedOutAt := time.Now().UTC().Format(time.RFC3339)
+	childRunID := uuid.New()
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: runAppExecutionMetadata{
+			Run:        &RunMetadata{ID: childRunID.String()},
 			TimedOutAt: &timedOutAt,
-		}))
+		},
+	}
+	execState := &contexts.ExecutionStateContext{}
 
-		execState := contexts.NewExecutionStateContext(tx, execution, func(events []models.CanvasEvent) {
-			require.Len(t, events, 1)
-			emittedChannel = events[0].Channel
-		})
+	params, err := core.NewRunFinishedCallback(core.NewRun(
+		childRunID,
+		uuid.New(),
+		core.RunResultCancelled,
+		nil,
+	)).ToParameters()
+	require.NoError(t, err)
 
-		params, err := core.NewRunFinishedCallback(core.NewRun(
-			uuid.New(),
-			uuid.New(),
-			core.RunResultCancelled,
-			nil,
-		)).ToParameters()
-		require.NoError(t, err)
-
-		return (&RunApp{}).handleRunFinished(core.ActionHookContext{
-			Metadata:       metadataCtx,
-			ExecutionState: execState,
-			Parameters:     params,
-			Configuration: map[string]any{
-				"timeout": 5,
-			},
-		})
+	err = (&RunApp{}).handleRunFinished(core.ActionHookContext{
+		Metadata:       metadataCtx,
+		ExecutionState: execState,
+		Parameters:     params,
+		Configuration: map[string]any{
+			"timeout": 5,
+		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, FailedOutputChannel, emittedChannel)
 
-	updatedExecution, err := models.FindNodeExecution(parentCanvas.ID, execution.ID)
-	require.NoError(t, err)
-	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
+	assert.Equal(t, FailedOutputChannel, execState.Channel)
+	assert.True(t, execState.Finished)
 
-	var metadata runAppExecutionMetadata
-	require.NoError(t, mapstructureDecodeExecutionMetadata(t, updatedExecution, &metadata))
+	metadata := decodeRunAppExecutionMetadata(t, metadataCtx)
 	require.NotNil(t, metadata.Run)
 	require.NotNil(t, metadata.Run.Error)
 	assert.Equal(t, "timed out after 5s", *metadata.Run.Error)
+	assert.Equal(t, core.RunResultCancelled, metadata.Run.Result)
+	assert.Equal(t, &timedOutAt, metadata.TimedOutAt)
 }
 
-type scheduledRunAppRequestContext struct {
-	called     bool
-	actionName string
-	interval   time.Duration
-}
-
-func (s *scheduledRunAppRequestContext) ScheduleActionCall(actionName string, parameters map[string]any, interval time.Duration) error {
-	s.called = true
-	s.actionName = actionName
-	s.interval = interval
-	return nil
-}
-
-func createRunAppRunRecord(t *testing.T, workflowID uuid.UUID, nodeID string, parentRunID *uuid.UUID) *models.CanvasRun {
+func decodeRunAppExecutionMetadata(t *testing.T, metadataCtx *contexts.MetadataContext) runAppExecutionMetadata {
 	t.Helper()
 
-	now := time.Now()
-	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), workflowID)
-	require.NoError(t, err)
-
-	run := models.CanvasRun{
-		ID:          uuid.New(),
-		WorkflowID:  workflowID,
-		NodeID:      nodeID,
-		VersionID:   liveVersion.ID,
-		ParentRunID: parentRunID,
-		State:       models.CanvasRunStateStarted,
-		CreatedAt:   &now,
-		UpdatedAt:   &now,
-	}
-	require.NoError(t, database.Conn().Create(&run).Error)
-	return &run
-}
-
-func createRunAppChildRunRecord(
-	t *testing.T,
-	workflowID uuid.UUID,
-	nodeID string,
-	parentRunID uuid.UUID,
-	parentWorkflowID uuid.UUID,
-	parentExecutionID uuid.UUID,
-) *models.CanvasRun {
-	t.Helper()
-
-	now := time.Now()
-	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), workflowID)
-	require.NoError(t, err)
-
-	run := models.CanvasRun{
-		ID:                uuid.New(),
-		WorkflowID:        workflowID,
-		NodeID:            nodeID,
-		VersionID:         liveVersion.ID,
-		ParentRunID:       &parentRunID,
-		ParentWorkflowID:  &parentWorkflowID,
-		ParentExecutionID: &parentExecutionID,
-		State:             models.CanvasRunStatePending,
-		CreatedAt:         &now,
-		UpdatedAt:         &now,
-	}
-	require.NoError(t, database.Conn().Create(&run).Error)
-	return &run
-}
-
-func createRunAppExecutionRecord(t *testing.T, workflowID, runID uuid.UUID, nodeID string) *models.CanvasNodeExecution {
-	t.Helper()
-
-	rootEvent := support.EmitCanvasEventForNode(t, workflowID, nodeID, "default", nil)
-	execution := support.CreateCanvasNodeExecution(t, workflowID, nodeID, rootEvent.ID, rootEvent.ID)
-	execution.RunID = runID
-	require.NoError(t, database.Conn().Save(execution).Error)
-	return execution
-}
-
-func mapstructureDecodeExecutionMetadata(t *testing.T, execution *models.CanvasNodeExecution, target any) error {
-	t.Helper()
-
-	updated, err := models.FindNodeExecution(execution.WorkflowID, execution.ID)
-	require.NoError(t, err)
-
-	return mapstructureDecode(updated.Metadata.Data(), target)
-}
-
-func mapstructureDecode(input any, target any) error {
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		Result:  target,
-		TagName: "mapstructure",
-	})
-	if err != nil {
-		return err
-	}
-
-	return decoder.Decode(input)
+	var metadata runAppExecutionMetadata
+	require.NoError(t, mapstructure.Decode(metadataCtx.Get(), &metadata))
+	return metadata
 }

--- a/pkg/components/messages/run_app_test.go
+++ b/pkg/components/messages/run_app_test.go
@@ -1,0 +1,426 @@
+package messages
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/workers/contexts"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+func TestRunAppFailureMessage(t *testing.T) {
+	timedOutAt := "2026-07-20T12:00:00Z"
+	assert.Equal(t, "timed out after 30s", runAppFailureMessage(runAppExecutionMetadata{
+		TimedOutAt: &timedOutAt,
+	}, map[string]any{"timeout": 30}, nil))
+	assert.Equal(t, "timed out after 3600s", runAppFailureMessage(runAppExecutionMetadata{
+		TimedOutAt: &timedOutAt,
+	}, map[string]any{}, nil))
+
+	runError := "child failed"
+	assert.Equal(t, "child failed", runAppFailureMessage(runAppExecutionMetadata{}, nil, &runError))
+	assert.Equal(t, "", runAppFailureMessage(runAppExecutionMetadata{}, nil, nil))
+}
+
+func TestRunAppTimeoutSeconds(t *testing.T) {
+	defaultTimeout := runAppTimeoutSeconds(nil)
+	assert.Equal(t, defaultRunAppTimeoutSeconds, defaultTimeout)
+
+	zero := 0
+	assert.Equal(t, defaultRunAppTimeoutSeconds, runAppTimeoutSeconds(&zero))
+
+	custom := 120
+	assert.Equal(t, 120, runAppTimeoutSeconds(&custom))
+}
+
+func TestRunAppExecuteSchedulesTimeoutWhenConfigured(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{
+				NodeID: "runApp",
+				Name:   "Run App",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
+			},
+		},
+		nil,
+	)
+
+	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
+		nil,
+	)
+
+	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
+	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
+
+	requests := &scheduledRunAppRequestContext{}
+	timeout := 45
+
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		parentNodes[1].Metadata = datatypes.NewJSONType(map[string]any{
+			"app": map[string]any{
+				"id":   childCanvas.ID.String(),
+				"name": "Child App",
+			},
+			"node": map[string]any{
+				"id":   "onRun",
+				"name": "On Run",
+			},
+		})
+
+		return (&RunApp{}).Execute(core.ExecutionContext{
+			WorkflowID: parentCanvas.ID.String(),
+			Configuration: map[string]any{
+				"app":        childCanvas.ID.String(),
+				"node":       "onRun",
+				"parameters": map[string]any{},
+				"timeout":    timeout,
+			},
+			Metadata:     contexts.NewExecutionMetadataContext(tx, execution),
+			NodeMetadata: contexts.NewNodeMetadataContext(tx, &parentNodes[1]),
+			Requests:     requests,
+			Runs:         contexts.NewRunExecutionContext(tx, parentCanvas, &parentNodes[1], execution),
+		})
+	})
+	require.NoError(t, err)
+	require.True(t, requests.called)
+	assert.Equal(t, ActionRunTimeout, requests.actionName)
+	assert.Equal(t, 45*time.Second, requests.interval)
+
+	var metadata runAppExecutionMetadata
+	require.NoError(t, mapstructureDecodeExecutionMetadata(t, execution, &metadata))
+	require.NotNil(t, metadata.Run)
+	assert.NotEmpty(t, metadata.Run.ID)
+	assert.Nil(t, metadata.TimedOutAt)
+}
+
+func TestRunAppExecuteSchedulesDefaultTimeout(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{
+				NodeID: "runApp",
+				Name:   "Run App",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
+			},
+		},
+		nil,
+	)
+
+	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
+		nil,
+	)
+
+	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
+	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
+
+	requests := &scheduledRunAppRequestContext{}
+
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		parentNodes[1].Metadata = datatypes.NewJSONType(map[string]any{
+			"app": map[string]any{
+				"id":   childCanvas.ID.String(),
+				"name": "Child App",
+			},
+			"node": map[string]any{
+				"id":   "onRun",
+				"name": "On Run",
+			},
+		})
+
+		return (&RunApp{}).Execute(core.ExecutionContext{
+			WorkflowID: parentCanvas.ID.String(),
+			Configuration: map[string]any{
+				"app":        childCanvas.ID.String(),
+				"node":       "onRun",
+				"parameters": map[string]any{},
+			},
+			Metadata:     contexts.NewExecutionMetadataContext(tx, execution),
+			NodeMetadata: contexts.NewNodeMetadataContext(tx, &parentNodes[1]),
+			Requests:     requests,
+			Runs:         contexts.NewRunExecutionContext(tx, parentCanvas, &parentNodes[1], execution),
+		})
+	})
+	require.NoError(t, err)
+	require.True(t, requests.called)
+	assert.Equal(t, ActionRunTimeout, requests.actionName)
+	assert.Equal(t, time.Duration(defaultRunAppTimeoutSeconds)*time.Second, requests.interval)
+}
+
+func TestRunAppHandleRunTimeoutCancelsChildRun(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{
+				NodeID: "runApp",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
+			},
+		},
+		nil,
+	)
+	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
+		nil,
+	)
+
+	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
+	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
+	childRun := createRunAppChildRunRecord(t, childCanvas.ID, "onRun", parentRun.ID, parentCanvas.ID, execution.ID)
+
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		metadataCtx := contexts.NewExecutionMetadataContext(tx, execution)
+		require.NoError(t, metadataCtx.Set(runAppExecutionMetadata{
+			Run: &RunMetadata{
+				ID: childRun.ID.String(),
+			},
+		}))
+
+		return (&RunApp{}).handleRunTimeout(core.ActionHookContext{
+			Metadata:       metadataCtx,
+			ExecutionState: contexts.NewExecutionStateContext(tx, execution, nil),
+			Runs:           contexts.NewRunExecutionContext(tx, parentCanvas, &parentNodes[1], execution),
+		})
+	})
+	require.NoError(t, err)
+
+	updatedChild, err := models.FindCanvasRunInTransaction(database.Conn(), childCanvas.ID, childRun.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateCancelling, updatedChild.State)
+
+	var metadata runAppExecutionMetadata
+	require.NoError(t, mapstructureDecodeExecutionMetadata(t, execution, &metadata))
+	require.NotNil(t, metadata.TimedOutAt)
+	assert.NotEmpty(t, *metadata.TimedOutAt)
+}
+
+func TestRunAppHandleRunTimeoutNoOpWhenFinished(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{
+				NodeID: "runApp",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
+			},
+		},
+		nil,
+	)
+	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
+		nil,
+	)
+
+	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
+	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
+	require.NoError(t, database.Conn().Model(execution).Updates(map[string]any{
+		"state":  models.CanvasNodeExecutionStateFinished,
+		"result": models.CanvasNodeExecutionResultPassed,
+	}).Error)
+
+	childRun := createRunAppChildRunRecord(t, childCanvas.ID, "onRun", parentRun.ID, parentCanvas.ID, execution.ID)
+
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		metadataCtx := contexts.NewExecutionMetadataContext(tx, execution)
+		require.NoError(t, metadataCtx.Set(runAppExecutionMetadata{
+			Run: &RunMetadata{ID: childRun.ID.String()},
+		}))
+
+		return (&RunApp{}).handleRunTimeout(core.ActionHookContext{
+			Metadata:       metadataCtx,
+			ExecutionState: contexts.NewExecutionStateContext(tx, execution, nil),
+			Runs:           contexts.NewRunExecutionContext(tx, parentCanvas, &parentNodes[1], execution),
+		})
+	})
+	require.NoError(t, err)
+
+	updatedChild, err := models.FindCanvasRunInTransaction(database.Conn(), childCanvas.ID, childRun.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStatePending, updatedChild.State)
+}
+
+func TestRunAppHandleRunFinishedUsesTimeoutMessage(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{
+				NodeID: "runApp",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
+			},
+		},
+		nil,
+	)
+
+	parentRun := createRunAppRunRecord(t, parentCanvas.ID, "trigger", nil)
+	execution := createRunAppExecutionRecord(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
+
+	var emittedChannel string
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		metadataCtx := contexts.NewExecutionMetadataContext(tx, execution)
+		timedOutAt := time.Now().UTC().Format(time.RFC3339)
+		require.NoError(t, metadataCtx.Set(runAppExecutionMetadata{
+			Run: &RunMetadata{
+				ID: uuid.New().String(),
+			},
+			TimedOutAt: &timedOutAt,
+		}))
+
+		execState := contexts.NewExecutionStateContext(tx, execution, func(events []models.CanvasEvent) {
+			require.Len(t, events, 1)
+			emittedChannel = events[0].Channel
+		})
+
+		params, err := core.NewRunFinishedCallback(core.NewRun(
+			uuid.New(),
+			uuid.New(),
+			core.RunResultCancelled,
+			nil,
+		)).ToParameters()
+		require.NoError(t, err)
+
+		return (&RunApp{}).handleRunFinished(core.ActionHookContext{
+			Metadata:       metadataCtx,
+			ExecutionState: execState,
+			Parameters:     params,
+			Configuration: map[string]any{
+				"timeout": 5,
+			},
+		})
+	})
+	require.NoError(t, err)
+	assert.Equal(t, FailedOutputChannel, emittedChannel)
+
+	updatedExecution, err := models.FindNodeExecution(parentCanvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
+
+	var metadata runAppExecutionMetadata
+	require.NoError(t, mapstructureDecodeExecutionMetadata(t, updatedExecution, &metadata))
+	require.NotNil(t, metadata.Run)
+	require.NotNil(t, metadata.Run.Error)
+	assert.Equal(t, "timed out after 5s", *metadata.Run.Error)
+}
+
+type scheduledRunAppRequestContext struct {
+	called     bool
+	actionName string
+	interval   time.Duration
+}
+
+func (s *scheduledRunAppRequestContext) ScheduleActionCall(actionName string, parameters map[string]any, interval time.Duration) error {
+	s.called = true
+	s.actionName = actionName
+	s.interval = interval
+	return nil
+}
+
+func createRunAppRunRecord(t *testing.T, workflowID uuid.UUID, nodeID string, parentRunID *uuid.UUID) *models.CanvasRun {
+	t.Helper()
+
+	now := time.Now()
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), workflowID)
+	require.NoError(t, err)
+
+	run := models.CanvasRun{
+		ID:          uuid.New(),
+		WorkflowID:  workflowID,
+		NodeID:      nodeID,
+		VersionID:   liveVersion.ID,
+		ParentRunID: parentRunID,
+		State:       models.CanvasRunStateStarted,
+		CreatedAt:   &now,
+		UpdatedAt:   &now,
+	}
+	require.NoError(t, database.Conn().Create(&run).Error)
+	return &run
+}
+
+func createRunAppChildRunRecord(
+	t *testing.T,
+	workflowID uuid.UUID,
+	nodeID string,
+	parentRunID uuid.UUID,
+	parentWorkflowID uuid.UUID,
+	parentExecutionID uuid.UUID,
+) *models.CanvasRun {
+	t.Helper()
+
+	now := time.Now()
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), workflowID)
+	require.NoError(t, err)
+
+	run := models.CanvasRun{
+		ID:                uuid.New(),
+		WorkflowID:        workflowID,
+		NodeID:            nodeID,
+		VersionID:         liveVersion.ID,
+		ParentRunID:       &parentRunID,
+		ParentWorkflowID:  &parentWorkflowID,
+		ParentExecutionID: &parentExecutionID,
+		State:             models.CanvasRunStatePending,
+		CreatedAt:         &now,
+		UpdatedAt:         &now,
+	}
+	require.NoError(t, database.Conn().Create(&run).Error)
+	return &run
+}
+
+func createRunAppExecutionRecord(t *testing.T, workflowID, runID uuid.UUID, nodeID string) *models.CanvasNodeExecution {
+	t.Helper()
+
+	rootEvent := support.EmitCanvasEventForNode(t, workflowID, nodeID, "default", nil)
+	execution := support.CreateCanvasNodeExecution(t, workflowID, nodeID, rootEvent.ID, rootEvent.ID)
+	execution.RunID = runID
+	require.NoError(t, database.Conn().Save(execution).Error)
+	return execution
+}
+
+func mapstructureDecodeExecutionMetadata(t *testing.T, execution *models.CanvasNodeExecution, target any) error {
+	t.Helper()
+
+	updated, err := models.FindNodeExecution(execution.WorkflowID, execution.ID)
+	require.NoError(t, err)
+
+	return mapstructureDecode(updated.Metadata.Data(), target)
+}
+
+func mapstructureDecode(input any, target any) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:  target,
+		TagName: "mapstructure",
+	})
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}

--- a/pkg/components/messages/run_app_test.go
+++ b/pkg/components/messages/run_app_test.go
@@ -126,7 +126,7 @@ func Test__RunApp__HandleRunTimeout__NoOpWhenFinished(t *testing.T) {
 	assert.Equal(t, childRunID, metadata.Run.ID)
 }
 
-func Test__RunApp__HandleRunFinished__EmitsFailedWithTimeoutMessage(t *testing.T) {
+func Test__RunApp__HandleRunFinished__EmitsFailedWhenCancelled(t *testing.T) {
 	childRunID := uuid.New()
 	metadataCtx := &contexts.MetadataContext{
 		Metadata: runAppExecutionMetadata{
@@ -147,9 +147,6 @@ func Test__RunApp__HandleRunFinished__EmitsFailedWithTimeoutMessage(t *testing.T
 		Metadata:       metadataCtx,
 		ExecutionState: execState,
 		Parameters:     params,
-		Configuration: map[string]any{
-			"timeout": 5,
-		},
 	})
 	require.NoError(t, err)
 
@@ -158,9 +155,9 @@ func Test__RunApp__HandleRunFinished__EmitsFailedWithTimeoutMessage(t *testing.T
 
 	metadata := decodeRunAppExecutionMetadata(t, metadataCtx)
 	require.NotNil(t, metadata.Run)
-	require.NotNil(t, metadata.Run.Error)
-	assert.Equal(t, "timed out after 5s", *metadata.Run.Error)
 	assert.Equal(t, core.RunResultCancelled, metadata.Run.Result)
+	require.NotNil(t, metadata.Run.Error)
+	assert.Empty(t, *metadata.Run.Error)
 }
 
 func decodeRunAppExecutionMetadata(t *testing.T, metadataCtx *contexts.MetadataContext) runAppExecutionMetadata {

--- a/pkg/components/messages/run_app_test.go
+++ b/pkg/components/messages/run_app_test.go
@@ -13,17 +13,12 @@ import (
 )
 
 func Test__RunApp__FailureMessage(t *testing.T) {
-	timedOutAt := "2026-07-20T12:00:00Z"
-	assert.Equal(t, "timed out after 30s", runAppFailureMessage(runAppExecutionMetadata{
-		TimedOutAt: &timedOutAt,
-	}, map[string]any{"timeout": 30}, nil))
-	assert.Equal(t, "timed out after 3600s", runAppFailureMessage(runAppExecutionMetadata{
-		TimedOutAt: &timedOutAt,
-	}, map[string]any{}, nil))
+	assert.Equal(t, "timed out after 30s", runAppFailureMessage(map[string]any{"timeout": 30}, core.RunResultCancelled, nil))
+	assert.Equal(t, "timed out after 3600s", runAppFailureMessage(map[string]any{}, core.RunResultCancelled, nil))
 
 	runError := "child failed"
-	assert.Equal(t, "child failed", runAppFailureMessage(runAppExecutionMetadata{}, nil, &runError))
-	assert.Equal(t, "", runAppFailureMessage(runAppExecutionMetadata{}, nil, nil))
+	assert.Equal(t, "child failed", runAppFailureMessage(nil, core.RunResultFailed, &runError))
+	assert.Equal(t, "", runAppFailureMessage(nil, core.RunResultFailed, nil))
 }
 
 func Test__RunApp__TimeoutSeconds(t *testing.T) {
@@ -72,7 +67,6 @@ func Test__RunApp__Execute__SchedulesConfiguredTimeout(t *testing.T) {
 	metadata := decodeRunAppExecutionMetadata(t, executionMetadata)
 	require.NotNil(t, metadata.Run)
 	assert.Equal(t, runID.String(), metadata.Run.ID)
-	assert.Nil(t, metadata.TimedOutAt)
 
 	require.NotNil(t, runs.LastCreateParams)
 	assert.Equal(t, childAppID.String(), runs.LastCreateParams.App)
@@ -128,8 +122,6 @@ func Test__RunApp__HandleRunTimeout__CancelsChildRun(t *testing.T) {
 	assert.True(t, runs.CancelCalled)
 
 	metadata := decodeRunAppExecutionMetadata(t, metadataCtx)
-	require.NotNil(t, metadata.TimedOutAt)
-	assert.NotEmpty(t, *metadata.TimedOutAt)
 	assert.Equal(t, childRunID, metadata.Run.ID)
 }
 
@@ -151,16 +143,14 @@ func Test__RunApp__HandleRunTimeout__NoOpWhenFinished(t *testing.T) {
 	assert.False(t, runs.CancelCalled)
 
 	metadata := decodeRunAppExecutionMetadata(t, metadataCtx)
-	assert.Nil(t, metadata.TimedOutAt)
+	assert.Equal(t, childRunID, metadata.Run.ID)
 }
 
 func Test__RunApp__HandleRunFinished__EmitsFailedWithTimeoutMessage(t *testing.T) {
-	timedOutAt := time.Now().UTC().Format(time.RFC3339)
 	childRunID := uuid.New()
 	metadataCtx := &contexts.MetadataContext{
 		Metadata: runAppExecutionMetadata{
-			Run:        &RunMetadata{ID: childRunID.String()},
-			TimedOutAt: &timedOutAt,
+			Run: &RunMetadata{ID: childRunID.String()},
 		},
 	}
 	execState := &contexts.ExecutionStateContext{}
@@ -191,7 +181,6 @@ func Test__RunApp__HandleRunFinished__EmitsFailedWithTimeoutMessage(t *testing.T
 	require.NotNil(t, metadata.Run.Error)
 	assert.Equal(t, "timed out after 5s", *metadata.Run.Error)
 	assert.Equal(t, core.RunResultCancelled, metadata.Run.Result)
-	assert.Equal(t, &timedOutAt, metadata.TimedOutAt)
 }
 
 func decodeRunAppExecutionMetadata(t *testing.T, metadataCtx *contexts.MetadataContext) runAppExecutionMetadata {

--- a/pkg/components/messages/run_app_test.go
+++ b/pkg/components/messages/run_app_test.go
@@ -12,26 +12,6 @@ import (
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
-func Test__RunApp__FailureMessage(t *testing.T) {
-	assert.Equal(t, "timed out after 30s", runAppFailureMessage(map[string]any{"timeout": 30}, core.RunResultCancelled, nil))
-	assert.Equal(t, "timed out after 3600s", runAppFailureMessage(map[string]any{}, core.RunResultCancelled, nil))
-
-	runError := "child failed"
-	assert.Equal(t, "child failed", runAppFailureMessage(nil, core.RunResultFailed, &runError))
-	assert.Equal(t, "", runAppFailureMessage(nil, core.RunResultFailed, nil))
-}
-
-func Test__RunApp__TimeoutSeconds(t *testing.T) {
-	defaultTimeout := runAppTimeoutSeconds(nil)
-	assert.Equal(t, defaultRunAppTimeoutSeconds, defaultTimeout)
-
-	zero := 0
-	assert.Equal(t, defaultRunAppTimeoutSeconds, runAppTimeoutSeconds(&zero))
-
-	custom := 120
-	assert.Equal(t, 120, runAppTimeoutSeconds(&custom))
-}
-
 func Test__RunApp__Execute__SchedulesConfiguredTimeout(t *testing.T) {
 	childAppID := uuid.New()
 	runID := uuid.New()

--- a/pkg/core/hooks.go
+++ b/pkg/core/hooks.go
@@ -34,6 +34,7 @@ type ActionHookContext struct {
 	Integration    IntegrationContext
 	Secrets        SecretsContext
 	Files          RepositoryFilesContext
+	Runs           RunExecutionContext
 }
 
 /*

--- a/pkg/grpc/actions/canvases/invoke_node_execution_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_execution_hook.go
@@ -89,6 +89,7 @@ func InvokeNodeExecutionHook(
 		ExecutionState: contexts.NewExecutionStateContext(tx, execution, onNewEvents),
 		Auth:           contexts.NewAuthReader(tx, orgID, authService, user),
 		Requests:       contexts.NewExecutionRequestContext(tx, execution),
+		Runs:           contexts.NewRunExecutionContext(tx, canvas, node, execution),
 	}
 
 	if node.AppInstallationID != nil {

--- a/pkg/workers/execution_terminator.go
+++ b/pkg/workers/execution_terminator.go
@@ -165,7 +165,7 @@ func (w *ExecutionTerminator) LockAndCancelExecution(execution models.CanvasNode
 	logger := logging.WithExecution(w.logger, &execution)
 
 	finished := false
-	cancelledChildRuns := []cancelledChildRun{}
+	runCancellations := &RunCancellationNotifier{}
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		execution, err := models.LockCancellingNodeExecutionInActiveCanvas(tx, execution.ID)
 		if err != nil {
@@ -178,12 +178,9 @@ func (w *ExecutionTerminator) LockAndCancelExecution(execution models.CanvasNode
 			return err
 		}
 
-		outcomes, err := w.cancelComponent(tx, logger, canvas, execution)
-		if err != nil {
+		if err := w.cancelComponent(tx, logger, canvas, execution, runCancellations); err != nil {
 			return err
 		}
-
-		cancelledChildRuns = append(cancelledChildRuns, outcomes...)
 
 		err = execution.CancelInTransaction(tx, execution.CancelledBy)
 		if err != nil {
@@ -206,9 +203,7 @@ func (w *ExecutionTerminator) LockAndCancelExecution(execution models.CanvasNode
 		return nil
 	}
 
-	for _, cancelled := range cancelledChildRuns {
-		publishCancelledChildRun(cancelled.workflowID, cancelled.runID, cancelled.drainResult)
-	}
+	runCancellations.Publish()
 
 	if err := messages.PublishCanvasExecutionByID(execution.WorkflowID, execution.ID); err != nil {
 		w.logger.Errorf("failed to publish execution finished RabbitMQ message: %v", err)
@@ -217,47 +212,33 @@ func (w *ExecutionTerminator) LockAndCancelExecution(execution models.CanvasNode
 	return nil
 }
 
-type cancelledChildRun struct {
-	workflowID  uuid.UUID
-	runID       uuid.UUID
-	drainResult *models.RunCancellationDrainResult
-}
-
-func publishCancelledChildRun(workflowID, runID uuid.UUID, drainResult *models.RunCancellationDrainResult) {
-	messages.PublishRunCancellationDrain(workflowID, drainResult)
-
-	if err := messages.NewCanvasRunMessage(workflowID.String(), runID.String()).Publish(); err != nil {
-		log.Errorf("failed to publish run state RabbitMQ message: %v", err)
-	}
-}
-
 func (w *ExecutionTerminator) cancelComponent(
 	tx *gorm.DB,
 	logger *log.Entry,
 	canvas *models.Canvas,
 	execution *models.CanvasNodeExecution,
-) ([]cancelledChildRun, error) {
+	runCancellations *RunCancellationNotifier,
+) error {
 	node, err := models.FindUnscopedCanvasNode(tx, execution.WorkflowID, execution.NodeID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if node.Type != models.NodeTypeComponent {
-		return nil, nil
+		return nil
 	}
 
 	ref := node.Ref.Data()
 	if ref.Component == nil {
-		return nil, nil
+		return nil
 	}
 
 	action, err := w.registry.GetAction(ref.Component.Name)
 	if err != nil {
 		log.Errorf("action %s not found: %v", ref.Component.Name, err)
-		return nil, err
+		return err
 	}
 
-	cancelledChildRuns := []cancelledChildRun{}
 	orgUUID := canvas.OrganizationID
 
 	ctx := core.ExecutionContext{
@@ -274,21 +255,14 @@ func (w *ExecutionTerminator) cancelComponent(
 		Requests:       contexts.NewExecutionRequestContext(tx, execution),
 		Auth:           contexts.NewAuthReader(tx, orgUUID, w.authService, nil),
 		CanvasMemory:   contexts.NewCanvasMemoryContext(tx, execution.WorkflowID),
-		Runs: contexts.NewRunExecutionContext(tx, canvas, node, execution).
-			WithRunCancelled(func(workflowID, runID uuid.UUID, drainResult *models.RunCancellationDrainResult) {
-				cancelledChildRuns = append(cancelledChildRuns, cancelledChildRun{
-					workflowID:  workflowID,
-					runID:       runID,
-					drainResult: drainResult,
-				})
-			}),
+		Runs:           runCancellations.Bind(contexts.NewRunExecutionContext(tx, canvas, node, execution)),
 	}
 
 	if node.AppInstallationID != nil {
 		integration, err := models.FindUnscopedIntegrationInTransaction(tx, *node.AppInstallationID)
 		if err != nil {
 			logger.Errorf("error finding app installation: %v", err)
-			return nil, err
+			return err
 		}
 
 		logger = logging.WithIntegration(logger, *integration)
@@ -300,5 +274,5 @@ func (w *ExecutionTerminator) cancelComponent(
 		logger.Errorf("failed to cancel component execution %s: %v", execution.ID, err)
 	}
 
-	return cancelledChildRuns, nil
+	return nil
 }

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -99,10 +99,12 @@ func (w *NodeRequestWorker) LockAndProcessRequest(request models.CanvasNodeReque
 		newEvents = append(newEvents, events...)
 	}
 
+	runCancellations := &RunCancellationNotifier{}
+
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		r, err := models.LockNodeRequest(tx, request.ID)
 		if err == nil {
-			return w.processRequest(logger, tx, r, onNewEvents)
+			return w.processRequest(logger, tx, r, onNewEvents, runCancellations)
 		}
 
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -123,24 +125,26 @@ func (w *NodeRequestWorker) LockAndProcessRequest(request models.CanvasNodeReque
 		messages.PublishCanvasEventCreatedMessage(&event)
 	}
 
+	runCancellations.Publish()
+
 	return nil
 }
 
-func (w *NodeRequestWorker) processRequest(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent)) error {
+func (w *NodeRequestWorker) processRequest(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent), runCancellations *RunCancellationNotifier) error {
 	switch request.Type {
 	case models.NodeRequestTypeInvokeAction:
-		return w.invokeHook(logger, tx, request, onNewEvents)
+		return w.invokeHook(logger, tx, request, onNewEvents, runCancellations)
 	}
 
 	return fmt.Errorf("unsupported node execution request type %s", request.Type)
 }
 
-func (w *NodeRequestWorker) invokeHook(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent)) error {
+func (w *NodeRequestWorker) invokeHook(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent), runCancellations *RunCancellationNotifier) error {
 	if request.ExecutionID == nil {
 		return w.invokeNodeHook(logger, tx, request, onNewEvents)
 	}
 
-	return w.invokeComponentHook(logger, tx, request, onNewEvents)
+	return w.invokeComponentHook(logger, tx, request, onNewEvents, runCancellations)
 }
 
 func (w *NodeRequestWorker) invokeNodeHook(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent)) error {
@@ -296,7 +300,7 @@ func (w *NodeRequestWorker) invokeNodeComponentHook(logger *log.Entry, tx *gorm.
 	return request.Complete(tx)
 }
 
-func (w *NodeRequestWorker) invokeComponentHook(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent)) error {
+func (w *NodeRequestWorker) invokeComponentHook(logger *log.Entry, tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent), runCancellations *RunCancellationNotifier) error {
 	if request.ExecutionID == nil {
 		return fmt.Errorf("execution id is required for component hook")
 	}
@@ -311,7 +315,7 @@ func (w *NodeRequestWorker) invokeComponentHook(logger *log.Entry, tx *gorm.DB, 
 		return request.Complete(tx)
 	}
 
-	return w.invokeExecutionComponentHook(logger, tx, request, execution, onNewEvents)
+	return w.invokeExecutionComponentHook(logger, tx, request, execution, onNewEvents, runCancellations)
 }
 
 func (w *NodeRequestWorker) invokeExecutionComponentHook(
@@ -320,6 +324,7 @@ func (w *NodeRequestWorker) invokeExecutionComponentHook(
 	request *models.CanvasNodeRequest,
 	execution *models.CanvasNodeExecution,
 	onNewEvents func([]models.CanvasEvent),
+	runCancellations *RunCancellationNotifier,
 ) error {
 	node, err := models.FindUnscopedCanvasNode(tx, execution.WorkflowID, execution.NodeID)
 	if err != nil {
@@ -365,6 +370,7 @@ func (w *NodeRequestWorker) invokeExecutionComponentHook(
 		Auth:           contexts.NewAuthReader(tx, workflow.OrganizationID, w.authService, nil),
 		Secrets:        contexts.NewSecretsContext(tx, workflow.OrganizationID, w.encryptor),
 		Files:          contexts.NewRepositoryFilesContextInTransaction(w.gitProvider, execution.WorkflowID, tx),
+		Runs:           runCancellations.Bind(contexts.NewRunExecutionContext(tx, workflow, node, execution)),
 	}
 
 	if node.AppInstallationID != nil {

--- a/pkg/workers/run_callback_dispatcher.go
+++ b/pkg/workers/run_callback_dispatcher.go
@@ -244,6 +244,11 @@ func (d *RunCallbackDispatcher) dispatchActionHook(
 		return fmt.Errorf("get action: %w", err)
 	}
 
+	parentCanvas, err := models.FindCanvasWithoutOrgScopeInTransaction(d.tx, execution.WorkflowID)
+	if err != nil {
+		return fmt.Errorf("find parent canvas: %w", err)
+	}
+
 	err = action.HandleHook(core.ActionHookContext{
 		Name:           callback.Hook,
 		Logger:         logging.ForNode(*node),
@@ -252,6 +257,7 @@ func (d *RunCallbackDispatcher) dispatchActionHook(
 		Metadata:       contexts.NewExecutionMetadataContext(d.tx, execution),
 		ExecutionState: contexts.NewExecutionStateContext(d.tx, execution, d.eventCollector),
 		Requests:       contexts.NewExecutionRequestContext(d.tx, execution),
+		Runs:           contexts.NewRunExecutionContext(d.tx, parentCanvas, node, execution),
 		Parameters:     params,
 	})
 	if err != nil {

--- a/pkg/workers/run_cancellation_notifier.go
+++ b/pkg/workers/run_cancellation_notifier.go
@@ -1,0 +1,52 @@
+package workers
+
+import (
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/workers/contexts"
+)
+
+// RunCancellationOutcome records a child run cancellation performed during a transaction.
+type RunCancellationOutcome struct {
+	WorkflowID  uuid.UUID
+	RunID       uuid.UUID
+	DrainResult *models.RunCancellationDrainResult
+}
+
+// RunCancellationNotifier collects child run cancellations during a database transaction
+// so callers can publish RabbitMQ messages after the transaction commits.
+type RunCancellationNotifier struct {
+	Outcomes []RunCancellationOutcome
+}
+
+func (n *RunCancellationNotifier) Bind(ctx *contexts.RunExecutionContext) *contexts.RunExecutionContext {
+	if n == nil {
+		return ctx
+	}
+
+	return ctx.WithRunCancelled(n.record)
+}
+
+func (n *RunCancellationNotifier) Publish() {
+	if n == nil {
+		return
+	}
+
+	for _, outcome := range n.Outcomes {
+		messages.PublishRunCancellationDrain(outcome.WorkflowID, outcome.DrainResult)
+
+		if err := messages.NewCanvasRunMessage(outcome.WorkflowID.String(), outcome.RunID.String()).Publish(); err != nil {
+			log.Errorf("failed to publish run state RabbitMQ message: %v", err)
+		}
+	}
+}
+
+func (n *RunCancellationNotifier) record(workflowID, runID uuid.UUID, drainResult *models.RunCancellationDrainResult) {
+	n.Outcomes = append(n.Outcomes, RunCancellationOutcome{
+		WorkflowID:  workflowID,
+		RunID:       runID,
+		DrainResult: drainResult,
+	})
+}

--- a/pkg/workers/run_cancellation_notifier_test.go
+++ b/pkg/workers/run_cancellation_notifier_test.go
@@ -1,0 +1,128 @@
+package workers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/workers/contexts"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+)
+
+func TestRunCancellationNotifier_BindCollectsCancelledChildRuns(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	parentCanvas, parentNodes := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{
+				NodeID: "runApp",
+				Name:   "Run App",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
+			},
+		},
+		nil,
+	)
+
+	childCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User,
+		[]models.CanvasNode{{NodeID: "onRun", Type: models.NodeTypeTrigger}},
+		nil,
+	)
+
+	parentRun := createCancellationTestRun(t, parentCanvas.ID, "trigger", nil)
+	execution := createCancellationTestExecution(t, parentCanvas.ID, parentRun.ID, parentNodes[1].NodeID)
+	require.NoError(t, execution.RequestCancellation(database.Conn(), &r.User))
+
+	execution, err := models.FindNodeExecution(parentCanvas.ID, execution.ID)
+	require.NoError(t, err)
+
+	childRun := createCancellationTestChildRun(t, childCanvas.ID, "onRun", parentRun.ID, parentCanvas.ID, execution.ID, models.CanvasRunStatePending)
+
+	notifier := &RunCancellationNotifier{}
+	ctx := notifier.Bind(contexts.NewRunExecutionContext(database.Conn(), parentCanvas, &parentNodes[1], execution))
+	require.NoError(t, ctx.Cancel())
+
+	require.Len(t, notifier.Outcomes, 1)
+	assert.Equal(t, childCanvas.ID, notifier.Outcomes[0].WorkflowID)
+	assert.Equal(t, childRun.ID, notifier.Outcomes[0].RunID)
+	require.NotNil(t, notifier.Outcomes[0].DrainResult)
+}
+
+func TestRunCancellationNotifier_PublishNilIsNoOp(t *testing.T) {
+	var notifier *RunCancellationNotifier
+	require.NotPanics(t, notifier.Publish)
+}
+
+func TestRunCancellationNotifier_BindNilIsNoOp(t *testing.T) {
+	ctx := (*RunCancellationNotifier)(nil).Bind(contexts.NewRunExecutionContext(nil, nil, nil, nil))
+	require.NotNil(t, ctx)
+}
+
+func createCancellationTestRun(t *testing.T, workflowID uuid.UUID, nodeID string, parentRunID *uuid.UUID) *models.CanvasRun {
+	t.Helper()
+
+	now := time.Now()
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), workflowID)
+	require.NoError(t, err)
+
+	run := models.CanvasRun{
+		ID:          uuid.New(),
+		WorkflowID:  workflowID,
+		NodeID:      nodeID,
+		VersionID:   liveVersion.ID,
+		ParentRunID: parentRunID,
+		State:       models.CanvasRunStateStarted,
+		CreatedAt:   &now,
+		UpdatedAt:   &now,
+	}
+	require.NoError(t, database.Conn().Create(&run).Error)
+	return &run
+}
+
+func createCancellationTestChildRun(
+	t *testing.T,
+	workflowID uuid.UUID,
+	nodeID string,
+	parentRunID uuid.UUID,
+	parentWorkflowID uuid.UUID,
+	parentExecutionID uuid.UUID,
+	state string,
+) *models.CanvasRun {
+	t.Helper()
+
+	now := time.Now()
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), workflowID)
+	require.NoError(t, err)
+
+	run := models.CanvasRun{
+		ID:                uuid.New(),
+		WorkflowID:        workflowID,
+		NodeID:            nodeID,
+		VersionID:         liveVersion.ID,
+		ParentRunID:       &parentRunID,
+		ParentWorkflowID:  &parentWorkflowID,
+		ParentExecutionID: &parentExecutionID,
+		State:             state,
+		CreatedAt:         &now,
+		UpdatedAt:         &now,
+	}
+	require.NoError(t, database.Conn().Create(&run).Error)
+	return &run
+}
+
+func createCancellationTestExecution(t *testing.T, workflowID, runID uuid.UUID, nodeID string) *models.CanvasNodeExecution {
+	t.Helper()
+
+	rootEvent := support.EmitCanvasEventForNode(t, workflowID, nodeID, "default", nil)
+	execution := support.CreateCanvasNodeExecution(t, workflowID, nodeID, rootEvent.ID, rootEvent.ID)
+	execution.RunID = runID
+	require.NoError(t, database.Conn().Save(execution).Error)
+	return execution
+}

--- a/test/e2e/run_app_test.go
+++ b/test/e2e/run_app_test.go
@@ -338,8 +338,10 @@ func (s *runAppSteps) thenTheParentRunAppExecutionReportsTimeoutWithin(within ti
 		}
 
 		metadata := runAppExecutionMetadataFromExecution(execution)
-		if metadata.TimedOutAt != nil && *metadata.TimedOutAt != "" &&
-			metadata.Run != nil && metadata.Run.Error != nil && *metadata.Run.Error == expectedError {
+		if metadata.Run != nil &&
+			metadata.Run.Result == models.CanvasRunResultCancelled &&
+			metadata.Run.Error != nil &&
+			*metadata.Run.Error == expectedError {
 			return
 		}
 
@@ -351,20 +353,19 @@ func (s *runAppSteps) thenTheParentRunAppExecutionReportsTimeoutWithin(within ti
 	require.Equal(s.t, models.CanvasNodeExecutionStateFinished, executions[0].State)
 
 	metadata := runAppExecutionMetadataFromExecution(executions[0])
-	require.NotNil(s.t, metadata.TimedOutAt)
-	require.NotEmpty(s.t, *metadata.TimedOutAt)
 	require.NotNil(s.t, metadata.Run)
+	require.Equal(s.t, models.CanvasRunResultCancelled, metadata.Run.Result)
 	require.NotNil(s.t, metadata.Run.Error)
 	require.Equal(s.t, expectedError, *metadata.Run.Error)
 }
 
 type runAppExecutionMetadata struct {
-	Run        *runAppRunMetadata `mapstructure:"run"`
-	TimedOutAt *string            `mapstructure:"timedOutAt"`
+	Run *runAppRunMetadata `mapstructure:"run"`
 }
 
 type runAppRunMetadata struct {
-	Error *string `mapstructure:"error"`
+	Result string  `mapstructure:"result"`
+	Error  *string `mapstructure:"error"`
 }
 
 func runAppExecutionMetadataFromExecution(execution models.CanvasNodeExecution) runAppExecutionMetadata {

--- a/test/e2e/run_app_test.go
+++ b/test/e2e/run_app_test.go
@@ -19,6 +19,7 @@ const (
 	runAppChildOnRunNodeID   = "on-run-trigger"
 	runAppChildDoneNodeID    = "child-done"
 	runAppChildFailNodeID    = "child-fail"
+	runAppChildWaitNodeID    = "child-wait"
 	runAppParentStartNodeID  = "start-trigger"
 	runAppParentRunAppNodeID = "run-app"
 	runAppParentOutputNodeID = "parent-output"
@@ -59,6 +60,17 @@ func TestRunApp(t *testing.T) {
 		steps.whenTheParentManualTriggerRuns()
 		steps.thenTheChildRunFinishedWithResult(models.CanvasRunResultFailed)
 		steps.thenTheChildRunResultMessageContains("field 'message' is required")
+		steps.thenTheParentOutputNodeFinished()
+		steps.thenTheParentRunFinishedWithResult(models.CanvasRunResultPassed)
+	})
+
+	t.Run("timeout cancels child run and routes parent through failed output", func(t *testing.T) {
+		steps := &runAppSteps{t: t}
+		steps.start()
+		steps.givenChildAppWithOnRunAndLongWait()
+		steps.givenParentAppCallingChildOnFailedWithTimeout(map[string]any{}, 2)
+		steps.whenTheParentManualTriggerRuns()
+		steps.thenTheChildRunFinishedWithResult(models.CanvasRunResultCancelled)
 		steps.thenTheParentOutputNodeFinished()
 		steps.thenTheParentRunFinishedWithResult(models.CanvasRunResultPassed)
 	})
@@ -146,15 +158,46 @@ func (s *runAppSteps) givenChildAppWithRequiredOnRunParameter() {
 	})
 }
 
+func (s *runAppSteps) givenChildAppWithOnRunAndLongWait() {
+	s.childCanvas = s.createChildCanvas(childCanvasOptions{
+		name: "Run App Child Slow",
+		onRunParameters: []any{
+			map[string]any{
+				"type":     "string",
+				"name":     "message",
+				"label":    "Message",
+				"required": false,
+			},
+		},
+		targetNode: childTargetNodeSpec{
+			id:   runAppChildWaitNodeID,
+			name: "Wait",
+			ref: models.NodeRef{
+				Component: &models.ComponentRef{Name: "wait"},
+			},
+			configuration: map[string]any{
+				"mode":    "interval",
+				"waitFor": 120,
+				"unit":    "seconds",
+			},
+		},
+	})
+}
+
 func (s *runAppSteps) givenParentAppCallingChildOnPassed(parameters map[string]any) {
-	s.givenParentAppCallingChild("passed", parameters)
+	s.givenParentAppCallingChild("passed", parameters, nil)
 }
 
 func (s *runAppSteps) givenParentAppCallingChildOnFailed(parameters map[string]any) {
-	s.givenParentAppCallingChild("failed", parameters)
+	s.givenParentAppCallingChild("failed", parameters, nil)
 }
 
-func (s *runAppSteps) givenParentAppCallingChild(runAppOutputChannel string, parameters map[string]any) {
+func (s *runAppSteps) givenParentAppCallingChildOnFailedWithTimeout(parameters map[string]any, timeoutSeconds int) {
+	timeout := timeoutSeconds
+	s.givenParentAppCallingChild("failed", parameters, &timeout)
+}
+
+func (s *runAppSteps) givenParentAppCallingChild(runAppOutputChannel string, parameters map[string]any, timeoutSeconds *int) {
 	require.NotNil(s.t, s.childCanvas, "child canvas must exist before creating parent canvas")
 
 	user, err := models.FindMaybeDeletedUserByEmail(s.session.OrgID.String(), s.session.Account.Email)
@@ -179,11 +222,17 @@ func (s *runAppSteps) givenParentAppCallingChild(runAppOutputChannel string, par
 			Ref: datatypes.NewJSONType(models.NodeRef{
 				Component: &models.ComponentRef{Name: "runApp"},
 			}),
-			Configuration: datatypes.NewJSONType(map[string]any{
-				"app":        s.childCanvas.ID.String(),
-				"node":       runAppChildOnRunNodeID,
-				"parameters": parameters,
-			}),
+			Configuration: datatypes.NewJSONType(func() map[string]any {
+				config := map[string]any{
+					"app":        s.childCanvas.ID.String(),
+					"node":       runAppChildOnRunNodeID,
+					"parameters": parameters,
+				}
+				if timeoutSeconds != nil {
+					config["timeout"] = *timeoutSeconds
+				}
+				return config
+			}()),
 			Metadata: datatypes.NewJSONType(map[string]any{
 				"app": map[string]any{
 					"id":   s.childCanvas.ID.String(),

--- a/test/e2e/run_app_test.go
+++ b/test/e2e/run_app_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -75,7 +74,7 @@ func TestRunApp(t *testing.T) {
 		steps.givenParentAppCallingChildOnFailedWithTimeout(map[string]any{}, 2)
 		steps.whenTheParentManualTriggerRuns()
 		steps.thenTheChildRunFinishedWithResultWithin(runAppTimeoutFlowDeadline, models.CanvasRunResultCancelled)
-		steps.thenTheParentRunAppExecutionReportsTimeoutWithin(steps.remainingWithin(runAppTimeoutFlowDeadline), 2)
+		steps.thenTheParentRunAppExecutionReportsCancelledWithin(steps.remainingWithin(runAppTimeoutFlowDeadline))
 		steps.thenTheParentOutputNodeFinishedWithin(steps.remainingWithin(runAppTimeoutFlowDeadline))
 		steps.thenTheParentRunFinishedWithResultWithin(steps.remainingWithin(runAppTimeoutFlowDeadline), models.CanvasRunResultPassed)
 	})
@@ -320,9 +319,8 @@ func (s *runAppSteps) thenTheParentRunFinishedWithResultWithin(within time.Durat
 	require.Equal(s.t, expected, parentRun.Result)
 }
 
-func (s *runAppSteps) thenTheParentRunAppExecutionReportsTimeoutWithin(within time.Duration, timeoutSeconds int) {
+func (s *runAppSteps) thenTheParentRunAppExecutionReportsCancelledWithin(within time.Duration) {
 	deadline := time.Now().Add(within)
-	expectedError := fmt.Sprintf("timed out after %ds", timeoutSeconds)
 
 	for time.Now().Before(deadline) {
 		executions := s.parentCanvas.GetExecutionsForNode("Run Child")
@@ -338,10 +336,7 @@ func (s *runAppSteps) thenTheParentRunAppExecutionReportsTimeoutWithin(within ti
 		}
 
 		metadata := runAppExecutionMetadataFromExecution(execution)
-		if metadata.Run != nil &&
-			metadata.Run.Result == models.CanvasRunResultCancelled &&
-			metadata.Run.Error != nil &&
-			*metadata.Run.Error == expectedError {
+		if metadata.Run != nil && metadata.Run.Result == models.CanvasRunResultCancelled {
 			return
 		}
 
@@ -355,8 +350,6 @@ func (s *runAppSteps) thenTheParentRunAppExecutionReportsTimeoutWithin(within ti
 	metadata := runAppExecutionMetadataFromExecution(executions[0])
 	require.NotNil(s.t, metadata.Run)
 	require.Equal(s.t, models.CanvasRunResultCancelled, metadata.Run.Result)
-	require.NotNil(s.t, metadata.Run.Error)
-	require.Equal(s.t, expectedError, *metadata.Run.Error)
 }
 
 type runAppExecutionMetadata struct {

--- a/test/e2e/run_app_test.go
+++ b/test/e2e/run_app_test.go
@@ -2,9 +2,11 @@ package e2e
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -14,6 +16,8 @@ import (
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
+
+const runAppTimeoutFlowDeadline = 10 * time.Second
 
 const (
 	runAppChildOnRunNodeID   = "on-run-trigger"
@@ -70,9 +74,10 @@ func TestRunApp(t *testing.T) {
 		steps.givenChildAppWithOnRunAndLongWait()
 		steps.givenParentAppCallingChildOnFailedWithTimeout(map[string]any{}, 2)
 		steps.whenTheParentManualTriggerRuns()
-		steps.thenTheChildRunFinishedWithResult(models.CanvasRunResultCancelled)
-		steps.thenTheParentOutputNodeFinished()
-		steps.thenTheParentRunFinishedWithResult(models.CanvasRunResultPassed)
+		steps.thenTheChildRunFinishedWithResultWithin(runAppTimeoutFlowDeadline, models.CanvasRunResultCancelled)
+		steps.thenTheParentRunAppExecutionReportsTimeoutWithin(steps.remainingWithin(runAppTimeoutFlowDeadline), 2)
+		steps.thenTheParentOutputNodeFinishedWithin(steps.remainingWithin(runAppTimeoutFlowDeadline))
+		steps.thenTheParentRunFinishedWithResultWithin(steps.remainingWithin(runAppTimeoutFlowDeadline), models.CanvasRunResultPassed)
 	})
 }
 
@@ -82,6 +87,8 @@ type runAppSteps struct {
 
 	childCanvas  *models.Canvas
 	parentCanvas *shared.CanvasSteps
+
+	triggeredAt time.Time
 }
 
 func (s *runAppSteps) start() {
@@ -270,11 +277,24 @@ func (s *runAppSteps) givenParentAppCallingChild(runAppOutputChannel string, par
 }
 
 func (s *runAppSteps) whenTheParentManualTriggerRuns() {
+	s.triggeredAt = time.Now()
 	s.parentCanvas.EmitManualTrigger("Start")
 }
 
+func (s *runAppSteps) remainingWithin(total time.Duration) time.Duration {
+	require.False(s.t, s.triggeredAt.IsZero(), "parent trigger must run before checking remaining timeout")
+
+	remaining := total - time.Since(s.triggeredAt)
+	require.Positivef(s.t, remaining, "expected workflow step to finish within %s", total)
+	return remaining
+}
+
 func (s *runAppSteps) thenTheChildRunFinishedWithResult(expected string) {
-	childRun := s.waitForChildRunFinished(90 * time.Second)
+	s.thenTheChildRunFinishedWithResultWithin(90*time.Second, expected)
+}
+
+func (s *runAppSteps) thenTheChildRunFinishedWithResultWithin(within time.Duration, expected string) {
+	childRun := s.waitForChildRunFinished(within)
 	require.Equal(s.t, expected, childRun.Result)
 }
 
@@ -284,12 +304,73 @@ func (s *runAppSteps) thenTheChildRunResultMessageContains(expected string) {
 }
 
 func (s *runAppSteps) thenTheParentOutputNodeFinished() {
-	s.parentCanvas.WaitForExecution("Output", models.CanvasNodeExecutionStateFinished, 90*time.Second)
+	s.thenTheParentOutputNodeFinishedWithin(90 * time.Second)
+}
+
+func (s *runAppSteps) thenTheParentOutputNodeFinishedWithin(within time.Duration) {
+	s.parentCanvas.WaitForExecution("Output", models.CanvasNodeExecutionStateFinished, within)
 }
 
 func (s *runAppSteps) thenTheParentRunFinishedWithResult(expected string) {
-	parentRun := s.waitForParentRunFinished(90 * time.Second)
+	s.thenTheParentRunFinishedWithResultWithin(90*time.Second, expected)
+}
+
+func (s *runAppSteps) thenTheParentRunFinishedWithResultWithin(within time.Duration, expected string) {
+	parentRun := s.waitForParentRunFinished(within)
 	require.Equal(s.t, expected, parentRun.Result)
+}
+
+func (s *runAppSteps) thenTheParentRunAppExecutionReportsTimeoutWithin(within time.Duration, timeoutSeconds int) {
+	deadline := time.Now().Add(within)
+	expectedError := fmt.Sprintf("timed out after %ds", timeoutSeconds)
+
+	for time.Now().Before(deadline) {
+		executions := s.parentCanvas.GetExecutionsForNode("Run Child")
+		if len(executions) == 0 {
+			time.Sleep(300 * time.Millisecond)
+			continue
+		}
+
+		execution := executions[0]
+		if execution.State != models.CanvasNodeExecutionStateFinished {
+			time.Sleep(300 * time.Millisecond)
+			continue
+		}
+
+		metadata := runAppExecutionMetadataFromExecution(execution)
+		if metadata.TimedOutAt != nil && *metadata.TimedOutAt != "" &&
+			metadata.Run != nil && metadata.Run.Error != nil && *metadata.Run.Error == expectedError {
+			return
+		}
+
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	executions := s.parentCanvas.GetExecutionsForNode("Run Child")
+	require.NotEmpty(s.t, executions, "expected run app execution")
+	require.Equal(s.t, models.CanvasNodeExecutionStateFinished, executions[0].State)
+
+	metadata := runAppExecutionMetadataFromExecution(executions[0])
+	require.NotNil(s.t, metadata.TimedOutAt)
+	require.NotEmpty(s.t, *metadata.TimedOutAt)
+	require.NotNil(s.t, metadata.Run)
+	require.NotNil(s.t, metadata.Run.Error)
+	require.Equal(s.t, expectedError, *metadata.Run.Error)
+}
+
+type runAppExecutionMetadata struct {
+	Run        *runAppRunMetadata `mapstructure:"run"`
+	TimedOutAt *string            `mapstructure:"timedOutAt"`
+}
+
+type runAppRunMetadata struct {
+	Error *string `mapstructure:"error"`
+}
+
+func runAppExecutionMetadataFromExecution(execution models.CanvasNodeExecution) runAppExecutionMetadata {
+	var metadata runAppExecutionMetadata
+	_ = mapstructure.Decode(execution.Metadata.Data(), &metadata)
+	return metadata
 }
 
 func (s *runAppSteps) waitForParentRunFinished(timeout time.Duration) *models.CanvasRun {

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -680,3 +680,34 @@ func (c *AppContext) Unsubscribe() error {
 	c.UnsubscribeCalls++
 	return nil
 }
+
+type RunExecutionContext struct {
+	CreateRunID      uuid.UUID
+	CreateErr        error
+	CancelErr        error
+	CancelCalled     bool
+	LastCreateParams *core.RunCreationParams
+}
+
+func (c *RunExecutionContext) Create(params core.RunCreationParams) (*core.Run, error) {
+	if c.CreateErr != nil {
+		return nil, c.CreateErr
+	}
+
+	runID := c.CreateRunID
+	if runID == uuid.Nil {
+		runID = uuid.New()
+	}
+
+	c.LastCreateParams = &params
+
+	return &core.Run{
+		ID:    runID,
+		AppID: uuid.MustParse(params.App),
+	}, nil
+}
+
+func (c *RunExecutionContext) Cancel() error {
+	c.CancelCalled = true
+	return c.CancelErr
+}

--- a/web_src/src/pages/app/mappers/runApp.spec.ts
+++ b/web_src/src/pages/app/mappers/runApp.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { runAppMapper, runAppStateFunction } from "./runApp";
+import type { ExecutionInfo, NodeInfo } from "./types";
+
+function buildRunAppExecution(overrides: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: overrides.metadata ?? {},
+    configuration: {},
+    ...overrides,
+  } as ExecutionInfo;
+}
+
+describe("runAppStateFunction", () => {
+  it("shows failed when the child run timed out", () => {
+    expect(
+      runAppStateFunction(
+        buildRunAppExecution({
+          metadata: {
+            timedOutAt: "2026-07-20T12:00:00Z",
+            run: { id: "child-run", result: "cancelled", error: "timed out after 2s" },
+          },
+        }),
+      ),
+    ).toBe("failed");
+  });
+
+  it("shows failed when the child run was cancelled", () => {
+    expect(
+      runAppStateFunction(
+        buildRunAppExecution({
+          metadata: {
+            run: { id: "child-run", result: "cancelled" },
+          },
+        }),
+      ),
+    ).toBe("failed");
+  });
+
+  it("shows success when the child run passed", () => {
+    expect(
+      runAppStateFunction(
+        buildRunAppExecution({
+          metadata: {
+            run: { id: "child-run", result: "passed" },
+          },
+        }),
+      ),
+    ).toBe("success");
+  });
+});
+
+describe("runAppMapper.props metadata", () => {
+  it("omits timeout metadata when timeout is not configured", () => {
+    const node: NodeInfo = {
+      id: "run-app",
+      name: "Run Child",
+      componentName: "runApp",
+      isCollapsed: false,
+      configuration: {
+        app: "child-app-id",
+        node: "on-run",
+        parameters: {},
+      },
+      metadata: {
+        app: { id: "child-app-id", name: "Child App" },
+        node: { id: "on-run", name: "On Run" },
+      },
+    };
+
+    const props = runAppMapper.props({
+      node,
+      nodes: [node],
+      componentDefinition: { name: "runApp", label: "Run App", icon: "play", color: "gray" },
+      lastExecutions: [],
+    });
+
+    expect(props.metadata).toEqual([
+      { icon: "layout-grid", label: "Child App" },
+      { icon: "workflow", label: "On Run" },
+    ]);
+  });
+
+  it("includes configured timeout in metadata", () => {
+    const node: NodeInfo = {
+      id: "run-app",
+      name: "Run Child",
+      componentName: "runApp",
+      isCollapsed: false,
+      configuration: {
+        app: "child-app-id",
+        node: "on-run",
+        parameters: {},
+        timeout: 3600,
+      },
+      metadata: {
+        app: { id: "child-app-id", name: "Child App" },
+        node: { id: "on-run", name: "On Run" },
+      },
+    };
+
+    const props = runAppMapper.props({
+      node,
+      nodes: [node],
+      componentDefinition: { name: "runApp", label: "Run App", icon: "play", color: "gray" },
+      lastExecutions: [],
+    });
+
+    expect(props.metadata).toEqual([
+      { icon: "layout-grid", label: "Child App" },
+      { icon: "workflow", label: "On Run" },
+      { icon: "clock", label: "1h" },
+    ]);
+  });
+
+  it("formats non-default configured timeout values", () => {
+    const node: NodeInfo = {
+      id: "run-app",
+      name: "Run Child",
+      componentName: "runApp",
+      isCollapsed: false,
+      configuration: {
+        app: "child-app-id",
+        node: "on-run",
+        parameters: {},
+        timeout: 120,
+      },
+      metadata: {
+        app: { id: "child-app-id", name: "Child App" },
+        node: { id: "on-run", name: "On Run" },
+      },
+    };
+
+    const props = runAppMapper.props({
+      node,
+      nodes: [node],
+      componentDefinition: { name: "runApp", label: "Run App", icon: "play", color: "gray" },
+      lastExecutions: [],
+    });
+
+    expect(props.metadata?.at(-1)).toEqual({ icon: "clock", label: "2m" });
+  });
+});

--- a/web_src/src/pages/app/mappers/runApp.spec.ts
+++ b/web_src/src/pages/app/mappers/runApp.spec.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import { runAppMapper, runAppStateFunction } from "./runApp";
-import type { ExecutionInfo, NodeInfo } from "./types";
+import type { ComponentBaseContext, ComponentDefinition, ExecutionInfo, NodeInfo } from "./types";
+
+const defaultDefinition: ComponentDefinition = {
+  name: "runApp",
+  label: "Run App",
+  description: "",
+  icon: "play",
+  color: "gray",
+};
 
 function buildRunAppExecution(overrides: Partial<ExecutionInfo>): ExecutionInfo {
   return {
@@ -17,13 +25,23 @@ function buildRunAppExecution(overrides: Partial<ExecutionInfo>): ExecutionInfo 
   } as ExecutionInfo;
 }
 
+function buildContext(node: NodeInfo): ComponentBaseContext {
+  return {
+    nodes: [node],
+    node,
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: { id: "user-1", name: "Test User", email: "test@example.com", roles: [], groups: [] },
+    actions: { invokeNodeExecutionHook: async () => {} },
+  };
+}
+
 describe("runAppStateFunction", () => {
   it("shows failed when the child run timed out", () => {
     expect(
       runAppStateFunction(
         buildRunAppExecution({
           metadata: {
-            timedOutAt: "2026-07-20T12:00:00Z",
             run: { id: "child-run", result: "cancelled", error: "timed out after 2s" },
           },
         }),
@@ -74,12 +92,7 @@ describe("runAppMapper.props metadata", () => {
       },
     };
 
-    const props = runAppMapper.props({
-      node,
-      nodes: [node],
-      componentDefinition: { name: "runApp", label: "Run App", icon: "play", color: "gray" },
-      lastExecutions: [],
-    });
+    const props = runAppMapper.props(buildContext(node));
 
     expect(props.metadata).toEqual([
       { icon: "layout-grid", label: "Child App" },
@@ -105,12 +118,7 @@ describe("runAppMapper.props metadata", () => {
       },
     };
 
-    const props = runAppMapper.props({
-      node,
-      nodes: [node],
-      componentDefinition: { name: "runApp", label: "Run App", icon: "play", color: "gray" },
-      lastExecutions: [],
-    });
+    const props = runAppMapper.props(buildContext(node));
 
     expect(props.metadata).toEqual([
       { icon: "layout-grid", label: "Child App" },
@@ -137,12 +145,7 @@ describe("runAppMapper.props metadata", () => {
       },
     };
 
-    const props = runAppMapper.props({
-      node,
-      nodes: [node],
-      componentDefinition: { name: "runApp", label: "Run App", icon: "play", color: "gray" },
-      lastExecutions: [],
-    });
+    const props = runAppMapper.props(buildContext(node));
 
     expect(props.metadata?.at(-1)).toEqual({ icon: "clock", label: "Timeout: 2m" });
   });

--- a/web_src/src/pages/app/mappers/runApp.spec.ts
+++ b/web_src/src/pages/app/mappers/runApp.spec.ts
@@ -115,7 +115,7 @@ describe("runAppMapper.props metadata", () => {
     expect(props.metadata).toEqual([
       { icon: "layout-grid", label: "Child App" },
       { icon: "workflow", label: "On Run" },
-      { icon: "clock", label: "1h" },
+      { icon: "clock", label: "Timeout: 1h" },
     ]);
   });
 
@@ -144,6 +144,6 @@ describe("runAppMapper.props metadata", () => {
       lastExecutions: [],
     });
 
-    expect(props.metadata?.at(-1)).toEqual({ icon: "clock", label: "2m" });
+    expect(props.metadata?.at(-1)).toEqual({ icon: "clock", label: "Timeout: 2m" });
   });
 });

--- a/web_src/src/pages/app/mappers/runApp.ts
+++ b/web_src/src/pages/app/mappers/runApp.ts
@@ -2,6 +2,7 @@ import type { CanvasesCanvasRunRef } from "@/api-client";
 import type { ComponentBaseProps, EventSection, EventState } from "@/ui/componentBase";
 import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { formatDuration } from "@/lib/duration";
 import { appRunPath } from "@/lib/appPaths";
 import type { MetadataItem } from "@/ui/metadataList";
 import { getState, getStateMap, getTriggerRenderer } from ".";
@@ -21,6 +22,13 @@ type RunAppMetadata = {
   node?: NodeMetadata;
 };
 
+type RunAppConfiguration = {
+  app?: string;
+  node?: string;
+  parameters?: Record<string, unknown>;
+  timeout?: number;
+};
+
 type NodeMetadata = {
   id?: string;
   name?: string;
@@ -33,6 +41,7 @@ type AppMetadata = {
 
 type RunAppExecutionMetadata = {
   run?: RunMetadata;
+  timedOutAt?: string;
 };
 
 type RunMetadata = {
@@ -61,9 +70,17 @@ export const runAppStateFunction: StateFunction = (execution: ExecutionInfo): Ev
   }
 
   const metadata = execution.metadata as RunAppExecutionMetadata;
-  const runResult = metadata?.run?.result;
-  if (runResult === "failed") {
+  if (metadata?.timedOutAt) {
     return "failed";
+  }
+
+  const runResult = metadata?.run?.result;
+  if (runResult === "failed" || runResult === "cancelled") {
+    return "failed";
+  }
+
+  if (runResult === "passed") {
+    return "success";
   }
 
   return "success";
@@ -162,12 +179,22 @@ function resolveChildRun(
 function runAppMetadataList(node: NodeInfo): MetadataItem[] {
   const metadataList: MetadataItem[] = [];
   const metadata = node.metadata as RunAppMetadata | undefined;
+  const configuration = node.configuration as RunAppConfiguration | undefined;
+
   if (metadata?.app) {
     metadataList.push({ icon: "layout-grid", label: metadata.app.name });
   }
 
   if (metadata?.node) {
     metadataList.push({ icon: "workflow", label: metadata.node.name });
+  }
+
+  const timeout = configuration?.timeout;
+  if (timeout && timeout > 0) {
+    metadataList.push({
+      icon: "clock",
+      label: formatDuration(timeout * 1000) || `${timeout}s`,
+    });
   }
 
   return metadataList;

--- a/web_src/src/pages/app/mappers/runApp.ts
+++ b/web_src/src/pages/app/mappers/runApp.ts
@@ -41,7 +41,6 @@ type AppMetadata = {
 
 type RunAppExecutionMetadata = {
   run?: RunMetadata;
-  timedOutAt?: string;
 };
 
 type RunMetadata = {
@@ -70,10 +69,6 @@ export const runAppStateFunction: StateFunction = (execution: ExecutionInfo): Ev
   }
 
   const metadata = execution.metadata as RunAppExecutionMetadata;
-  if (metadata?.timedOutAt) {
-    return "failed";
-  }
-
   const runResult = metadata?.run?.result;
   if (runResult === "failed" || runResult === "cancelled") {
     return "failed";

--- a/web_src/src/pages/app/mappers/runApp.ts
+++ b/web_src/src/pages/app/mappers/runApp.ts
@@ -193,7 +193,7 @@ function runAppMetadataList(node: NodeInfo): MetadataItem[] {
   if (timeout && timeout > 0) {
     metadataList.push({
       icon: "clock",
-      label: formatDuration(timeout * 1000) || `${timeout}s`,
+      label: `Timeout: ${formatDuration(timeout * 1000) || `${timeout}s`}`,
     });
   }
 


### PR DESCRIPTION
- Adds configurable runApp component timeout (default 1h) that cancels the child run via ctx.Runs.Cancel() and fails the parent on child completion.
- Introduces RunCancellationNotifier to make publishing cancellation drains easier for workers.
- New E2E to verify the new behavior