### PR TITLE
feat: support broker task files on create-task

### DIFF
--- a/pkg/components/runner/broker.go
+++ b/pkg/components/runner/broker.go
@@ -93,11 +93,19 @@ type brokerCreateTaskRequest struct {
 	Commands                []BrokerCommand             `json:"commands,omitempty"`
 	SetupCommands           []string                    `json:"setup_commands,omitempty"`
 	Environment             []BrokerEnvironmentVariable `json:"environment,omitempty"`
+	Files                   []BrokerTaskFile            `json:"files,omitempty"`
 	WebhookURL              string                      `json:"webhook_url"`
 	WebhookPayloadSizeLimit int                         `json:"webhook_payload_size_limit"`
 	ExecutionMode           string                      `json:"execution_mode,omitempty"`
 	DockerImage             string                      `json:"docker_image,omitempty"`
 	ExecutionTimeoutSeconds *int                        `json:"execution_timeout_seconds,omitempty"`
+}
+
+// BrokerTaskFile is materialized under SUPERPLANE_TASK_DIR before execution.
+type BrokerTaskFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+	Mode    string `json:"mode,omitempty"`
 }
 
 // BrokerCommand is one command_list entry. JSON is a plain string when Name is
@@ -180,6 +188,7 @@ type CreateTaskParams struct {
 	WebhookURL              string
 	WebhookPayloadSizeLimit int
 	Environment             []BrokerEnvironmentVariable
+	Files                   []BrokerTaskFile
 	ExecutionMode           string
 	DockerImage             string
 	TimeoutSeconds          int // 0 = DefaultExecutionTimeoutSeconds
@@ -213,6 +222,7 @@ func (b *BrokerClient) CreateTask(p CreateTaskParams) (string, error) {
 		Commands:                p.Commands,
 		SetupCommands:           p.SetupCommands,
 		Environment:             p.Environment,
+		Files:                   p.Files,
 		WebhookURL:              p.WebhookURL,
 		WebhookPayloadSizeLimit: webhookPayloadSizeLimit,
 		ExecutionMode:           mode,

--- a/pkg/components/runner/broker_task_file_test.go
+++ b/pkg/components/runner/broker_task_file_test.go
@@ -1,0 +1,32 @@
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrokerCreateTaskRequestIncludesFiles(t *testing.T) {
+	t.Parallel()
+
+	req := brokerCreateTaskRequest{
+		FleetID:    "e1-large-amd64",
+		Commands:   []BrokerCommand{{Command: `cat "$SUPERPLANE_TASK_DIR/hi.txt"`}},
+		Files:      []BrokerTaskFile{{Path: "hi.txt", Content: "hello", Mode: "0644"}},
+		WebhookURL: "https://example/hook",
+	}
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+	files, ok := got["files"].([]any)
+	require.True(t, ok)
+	require.Len(t, files, 1)
+	file := files[0].(map[string]any)
+	assert.Equal(t, "hi.txt", file["path"])
+	assert.Equal(t, "hello", file["content"])
+	assert.Equal(t, "0644", file["mode"])
+}


### PR DESCRIPTION
## Summary
- Add `BrokerTaskFile` and optional `files` on create-task requests
- Wire `CreateTaskParams.Files` through the SuperPlane broker client
- Pair with runner [PR #78](https://github.com/superplanehq/runner/pull/78) (`SUPERPLANE_TASK_DIR`)

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/components/runner`
- [ ] Deploy matching task-broker/runner before clients send `files`


Made with [Cursor](https://cursor.com)