### PR TITLE
fix: resync staged draft when returning to live version from history preview

### DIFF
--- a/test/e2e/canvas_version_preview_test.go
+++ b/test/e2e/canvas_version_preview_test.go
@@ -1,0 +1,76 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+)
+
+func TestCanvasVersionPreview(t *testing.T) {
+	t.Run("see current version returns to editable live canvas after previewing history", func(t *testing.T) {
+		steps := &canvasVersionPreviewSteps{t: t}
+		steps.start()
+		steps.givenACanvasWithVersionHistory()
+		steps.whenIEnterEditMode()
+		steps.whenIOpenVersionsSidebar()
+		steps.whenIPreviewTheFirstVersion()
+		steps.thenPreviousVersionPreviewBarIsVisible()
+		steps.whenIClickSeeCurrentVersion()
+		steps.thenEditSessionIsReadyOnLiveVersion()
+	})
+}
+
+type canvasVersionPreviewSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+}
+
+func (s *canvasVersionPreviewSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *canvasVersionPreviewSteps) givenACanvasWithVersionHistory() {
+	s.canvas = shared.NewCanvasSteps("E2E Version Preview", s.t, s.session)
+	s.canvas.Create()
+	s.canvas.Visit()
+	s.session.AssertVisible(q.TestID("canvas-edit-button"))
+
+	s.canvas.EnterEditMode()
+	s.canvas.AddNoop("HistoryNode", models.Position{X: 500, Y: 200})
+	s.canvas.WaitForStagingOnCurrentDraft()
+	s.canvas.ClickOnEmptyCanvasArea()
+	s.canvas.CommitStaging()
+	s.canvas.AssertVersionCountAtLeast(2)
+	s.canvas.ExitEditMode()
+}
+
+func (s *canvasVersionPreviewSteps) whenIEnterEditMode() {
+	s.canvas.EnterEditMode()
+}
+
+func (s *canvasVersionPreviewSteps) whenIOpenVersionsSidebar() {
+	s.canvas.OpenVersionsSidebar()
+}
+
+func (s *canvasVersionPreviewSteps) whenIPreviewTheFirstVersion() {
+	s.canvas.SelectVersionInHistorySidebar("v1")
+}
+
+func (s *canvasVersionPreviewSteps) thenPreviousVersionPreviewBarIsVisible() {
+	s.canvas.AssertPreviewingPreviousVersionBarVisible()
+}
+
+func (s *canvasVersionPreviewSteps) whenIClickSeeCurrentVersion() {
+	s.canvas.ClickSeeCurrentVersionFromPreviewBar()
+}
+
+func (s *canvasVersionPreviewSteps) thenEditSessionIsReadyOnLiveVersion() {
+	s.canvas.AssertEditSessionReady()
+	s.session.AssertText("HistoryNode")
+}

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -246,7 +246,10 @@ func (s *CanvasSteps) AssertEditSessionReady() {
 	s.session.AssertHidden(q.TestID("canvas-mode-floating-bar"))
 	s.waitForEnabledExitEditButton()
 	s.AssertEditModeTabChrome()
-	s.session.AssertVisible(q.TestID("building-blocks-sidebar"))
+	// Building blocks stay collapsed when the canvas already has nodes; edit controls
+	// on the right rail are the reliable signal that live edit mode is active again.
+	s.session.AssertVisible(q.TestID("canvas-add-component-button"))
+	s.AssertStagingActionsVisibleAndDisabled()
 }
 
 func (s *CanvasSteps) waitForVisible(query q.Query, timeout time.Duration) {

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -219,6 +219,36 @@ func (s *CanvasSteps) SelectVersionInHistorySidebar(versionLabel string) {
 	s.session.Sleep(300)
 }
 
+// AssertPreviewingPreviousVersionBarVisible verifies the previous-version preview chrome is shown.
+func (s *CanvasSteps) AssertPreviewingPreviousVersionBarVisible() {
+	s.session.AssertVisible(q.TestID("canvas-mode-floating-bar"))
+	s.session.AssertText("Previewing previous version")
+	s.session.AssertVisible(q.TestID("canvas-mode-floating-bar-action"))
+}
+
+// ClickSeeCurrentVersionFromPreviewBar returns to the live version from previous-version preview.
+func (s *CanvasSteps) ClickSeeCurrentVersionFromPreviewBar() {
+	s.session.Click(q.TestID("canvas-mode-floating-bar-action"))
+}
+
+// WaitForCanvasDraftLoadingToFinish waits for the edit-session draft loading overlay to disappear.
+func (s *CanvasSteps) WaitForCanvasDraftLoadingToFinish() {
+	loading := q.Text("Loading canvas...").Run(s.session)
+	require.Eventually(s.t, func() bool {
+		visible, err := loading.IsVisible()
+		return err == nil && !visible
+	}, 30*time.Second, 200*time.Millisecond, "canvas draft loading overlay did not disappear")
+}
+
+// AssertEditSessionReady verifies the canvas finished bootstrapping an active edit session.
+func (s *CanvasSteps) AssertEditSessionReady() {
+	s.WaitForCanvasDraftLoadingToFinish()
+	s.session.AssertHidden(q.TestID("canvas-mode-floating-bar"))
+	s.waitForEnabledExitEditButton()
+	s.AssertEditModeTabChrome()
+	s.session.AssertVisible(q.TestID("building-blocks-sidebar"))
+}
+
 func (s *CanvasSteps) waitForVisible(query q.Query, timeout time.Duration) {
 	locator := query.Run(s.session)
 	require.Eventually(s.t, func() bool {

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -94,6 +94,7 @@ import { activateCanvasVersionForEditing as applyCanvasVersionForEditing } from 
 import {
   clearLiveEditSessionDraftState,
   clearLiveEditSessionSearchParams,
+  isActiveCanvasVersionCurrentLive,
   resetCommittedLiveCanvasDetail,
 } from "./lib/live-edit-session";
 import { useRefreshLatestLiveCanvasData } from "./useRefreshLatestLiveCanvasData";
@@ -3312,6 +3313,14 @@ export function AppPage() {
     [activateCanvasVersionForEditing, canvasId, organizationId, selectableVersionsById],
   );
 
+  const resyncLiveVersionDraftAfterSwitch = useCallback(
+    async (versionId: string, options?: { preserveStagedLayer?: boolean }) => {
+      handleUseVersion(versionId, options);
+      await resyncStagedEditorState(versionId, { bumpResetNonce: false });
+    },
+    [handleUseVersion, resyncStagedEditorState],
+  );
+
   const handleSeeCurrentVersion = useCallback(() => {
     if (!effectiveLiveCanvasVersionId) {
       showErrorToast("No live version available");
@@ -3319,8 +3328,8 @@ export function AppPage() {
     }
     // Deliberate preview of the current version keeps the edit session open.
     previewingCurrentVersionRef.current = true;
-    handleUseVersion(effectiveLiveCanvasVersionId);
-  }, [effectiveLiveCanvasVersionId, handleUseVersion]);
+    void resyncLiveVersionDraftAfterSwitch(effectiveLiveCanvasVersionId);
+  }, [effectiveLiveCanvasVersionId, resyncLiveVersionDraftAfterSwitch]);
 
   const handleUseVersionFromVersionPanel = useCallback(
     (versionID: string) => {
@@ -3333,16 +3342,33 @@ export function AppPage() {
         }
       }
 
+      const isSelectingLiveVersion = isActiveCanvasVersionCurrentLive({
+        activeCanvasVersionId: versionID,
+        effectiveLiveCanvasVersionId,
+        liveCanvasVersionId,
+      });
+
       // Track when the user deliberately selects the current/live version from
       // the sidebar so the edit session stays open (vs. internal navigation back
       // to live after publish/discard, which must close it).
-      previewingCurrentVersionRef.current =
-        (!!effectiveLiveCanvasVersionId && versionID === effectiveLiveCanvasVersionId) ||
-        (!!liveCanvasVersionId && versionID === liveCanvasVersionId);
+      previewingCurrentVersionRef.current = isSelectingLiveVersion;
+
+      if (editSessionActive && isSelectingLiveVersion) {
+        void resyncLiveVersionDraftAfterSwitch(versionID);
+        return;
+      }
 
       handleUseVersion(versionID);
     },
-    [handleUseVersion, hasEditableVersion, hasLocalSaveActivity, effectiveLiveCanvasVersionId, liveCanvasVersionId],
+    [
+      handleUseVersion,
+      resyncLiveVersionDraftAfterSwitch,
+      hasEditableVersion,
+      hasLocalSaveActivity,
+      editSessionActive,
+      effectiveLiveCanvasVersionId,
+      liveCanvasVersionId,
+    ],
   );
 
   const runInspectionChromeActive = isRunInspectionMode && !editSessionActive && !isEnteringEditSession;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -468,7 +468,10 @@ function CanvasModeFloatingBar({
   onAction: () => void;
 }) {
   return (
-    <div className="pointer-events-none absolute inset-x-0 top-0 z-[19] flex justify-center px-4 pt-3">
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-[19] flex justify-center px-4 pt-3"
+      data-testid="canvas-mode-floating-bar"
+    >
       <div className="pointer-events-auto flex max-w-[min(100vw-2rem,34rem)] items-center gap-2 rounded-full bg-slate-500 py-1.5 pl-3 pr-1.5 shadow-sm dark:bg-gray-800">
         <span className="min-w-0 truncate text-[13px] font-medium text-white dark:text-gray-400">{label}</span>
         <Button
@@ -476,6 +479,7 @@ function CanvasModeFloatingBar({
           variant="outline"
           size="xs"
           className="shrink-0 border-0 shadow-none dark:border dark:border-gray-600/70 dark:shadow-xs"
+          data-testid="canvas-mode-floating-bar-action"
           onClick={onAction}
         >
           {actionLabel}


### PR DESCRIPTION
Fixes https://github.com/superplanehq/superplane/issues/6247

---

- Fix an infinite "Loading canvas..." overlay when leaving a previous-version preview via **See Current Version** (or by selecting the live version in the versions sidebar) during an edit session.
- After switching back to the live version, call `resyncStagedEditorState` so `draftCanvasSpec` is repopulated and the edit bootstrap can complete — matching the flow used when entering edit mode.
- Add an E2E test for the edit → preview v1 → See Current Version path, plus shared canvas step helpers and stable test IDs on the preview floating bar.

## Root cause

Returning to the live version cleared `draftCanvasSpec` and enabled `shouldReadStagedCanvasVersion`, but nothing repopulated draft state. The draft sync effects intentionally skip that path (they defer to `resyncStagedEditorState`), so `isEditBootstrapReady` never became true and the loading overlay never cleared.