### PR TITLE
fix: only resync staged draft on See Current Version during edit session

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -3328,8 +3328,12 @@ export function AppPage() {
     }
     // Deliberate preview of the current version keeps the edit session open.
     previewingCurrentVersionRef.current = true;
-    void resyncLiveVersionDraftAfterSwitch(effectiveLiveCanvasVersionId);
-  }, [effectiveLiveCanvasVersionId, resyncLiveVersionDraftAfterSwitch]);
+    if (editSessionActive) {
+      void resyncLiveVersionDraftAfterSwitch(effectiveLiveCanvasVersionId);
+      return;
+    }
+    handleUseVersion(effectiveLiveCanvasVersionId);
+  }, [editSessionActive, effectiveLiveCanvasVersionId, handleUseVersion, resyncLiveVersionDraftAfterSwitch]);
 
   const handleUseVersionFromVersionPanel = useCallback(
     (versionID: string) => {


### PR DESCRIPTION
- Gate `handleSeeCurrentVersion` on `editSessionActive` before calling `resyncLiveVersionDraftAfterSwitch`, matching `handleUseVersionFromVersionPanel`.
- Outside an edit session (e.g. read-only history preview via `?version=`), **See Current Version** now only calls `handleUseVersion`, restoring the committed live graph without running `resyncStagedEditorState`.

## Problem
`resyncLiveVersionDraftAfterSwitch` runs `resyncStagedEditorState`, which fetches staged `canvas.yaml` and merges it into the canvas detail query cache. That is correct while editing the live version, but wrong on a read-only history preview: returning to live should show committed content, not uncommitted staging. The versions sidebar already had this guard; **See Current Version** did not.