### PR TITLE
feat: add Github updatePullRequest component

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -3337,14 +3337,6 @@ At least one field must be toggled on.
 
 **Replace Assignees** and **Replace Labels** replace the pull request's full set when toggled on, including replacing it with an empty list to clear all assignees or labels.
 
-### Out of scope
-
-The following pull request operations have their own dedicated components:
-
-- Marking a draft pull request ready for review: use Mark Pull Request Ready for Review
-- Adding reviewers: use Add Pull Request Reviewers
-- Merging: use Merge Pull Request
-
 ### Output
 
 Returns the updated pull request object with all current information.

--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -3329,14 +3329,13 @@ The Update Pull Request component updates an existing pull request in a GitHub r
 
 - **Repository**: Select the GitHub repository containing the pull request
 - **Pull Request Number**: Pull request number to update. Supports expressions.
-- **Title**: New title for the pull request (optional; leaves the title unchanged if empty)
-- **Body**: New body/description for the pull request (optional; leaves the body unchanged if empty)
-- **State**: Change the pull request state to "open" or "closed" (optional; unset leaves the state unchanged)
-- **Base Branch**: Retarget the pull request onto a different base branch (optional)
-- **Assignees**: Non-empty list replaces the full set of assignees on the pull request (optional)
-- **Labels**: Non-empty list replaces the full set of labels on the pull request (optional)
+- **Title**, **Body**, **State**, **Base Branch**, **Replace Assignees**, **Replace Labels**: each field has its own toggle. Only toggled-on fields are changed; toggled-off fields are left untouched on the pull request.
 
-At least one of title, body, state, base, assignees, or labels is required.
+At least one field must be toggled on.
+
+### Replacing labels and assignees
+
+**Replace Assignees** and **Replace Labels** replace the pull request's full set when toggled on, including replacing it with an empty list to clear all assignees or labels.
 
 ### Out of scope
 
@@ -3349,7 +3348,7 @@ The following pull request operations have their own dedicated components:
 ### Implementation notes
 
 - Title, body, state, and base are updated through GitHub's Pulls API.
-- Assignees and labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue.
+- Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue.
 - GitHub ignores a base branch change in the same request that sets the state to "closed".
 
 ### Output

--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -3372,6 +3372,7 @@ Returns the updated pull request object with all current information.
       "ref": "release"
     },
     "body": "Adds the new feature described in the linked issue.",
+    "comments_url": "https://api.github.com/repos/acme/widgets/issues/42/comments",
     "created_at": "2026-04-22T10:00:00Z",
     "draft": false,
     "head": {
@@ -3380,12 +3381,15 @@ Returns the updated pull request object with all current information.
     },
     "html_url": "https://github.com/acme/widgets/pull/42",
     "id": 1234567890,
+    "issue_url": "https://api.github.com/repos/acme/widgets/issues/42",
     "labels": [
       {
         "color": "a2eeef",
         "name": "enhancement"
       }
     ],
+    "locked": false,
+    "node_id": "PR_kwDOABCD12MAAAABCDEFGH",
     "number": 42,
     "state": "open",
     "title": "Add new feature",

--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -3347,9 +3347,9 @@ The following pull request operations have their own dedicated components:
 
 ### Implementation notes
 
-- Title, body, state, and base are updated through GitHub's Pulls API.
-- Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue.
-- GitHub ignores a base branch change in the same request that sets the state to "closed".
+- Title, body, state, and base are updated through GitHub's Pulls API. Base is sent in its own request before title/body/state, so toggling on both a retarget and a close in the same run applies both instead of GitHub silently dropping the retarget.
+- Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue. A leading "@" on an assignee username is stripped automatically.
+- GitHub rejects retargeting a pull request that is already closed - if the pull request is closed from a previous run, toggle it open again before retargeting.
 
 ### Output
 

--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -52,6 +52,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Run Workflow" href="#run-workflow" description="Run GitHub Actions workflow" />
   <LinkCard title="Update Issue" href="#update-issue" description="Update a GitHub issue" />
   <LinkCard title="Update Issue Comment" href="#update-issue-comment" description="Update an existing comment on a GitHub issue or pull request" />
+  <LinkCard title="Update Pull Request" href="#update-pull-request" description="Update a pull request's title, body, state, base branch, labels, or assignees in a GitHub repository" />
   <LinkCard title="Update Release" href="#update-release" description="Update an existing release in a GitHub repository" />
 </CardGrid>
 
@@ -3306,6 +3307,98 @@ Returns the updated comment object including comment ID, URL, body, and timestam
   },
   "timestamp": "2026-01-16T18:30:00.680755501Z",
   "type": "github.issueComment"
+}
+```
+
+<a id="update-pull-request"></a>
+
+## Update Pull Request
+
+**Component key:** `github.updatePullRequest`
+
+The Update Pull Request component updates an existing pull request in a GitHub repository. Use it instead of Update Issue when the change is about a pull request - GitHub models a pull request's title, body, state, labels, and assignees on its underlying issue, but "Update Issue" is confusing to reach for when working with pull requests.
+
+### Use Cases
+
+- **Retitle/rebody automation**: Update a pull request's title or description as a workflow progresses
+- **Open/close automation**: Close a pull request when it is superseded, or reopen one automatically
+- **Retargeting**: Change the base branch a pull request merges into
+- **Label and assignee management**: Replace a pull request's labels or assignees from a workflow
+
+### Configuration
+
+- **Repository**: Select the GitHub repository containing the pull request
+- **Pull Request Number**: Pull request number to update. Supports expressions.
+- **Title**: New title for the pull request (optional; leaves the title unchanged if empty)
+- **Body**: New body/description for the pull request (optional; leaves the body unchanged if empty)
+- **State**: Change the pull request state to "open" or "closed" (optional; unset leaves the state unchanged)
+- **Base Branch**: Retarget the pull request onto a different base branch (optional)
+- **Assignees**: Non-empty list replaces the full set of assignees on the pull request (optional)
+- **Labels**: Non-empty list replaces the full set of labels on the pull request (optional)
+
+At least one of title, body, state, base, assignees, or labels is required.
+
+### Out of scope
+
+The following pull request operations have their own dedicated components:
+
+- Marking a draft pull request ready for review: use Mark Pull Request Ready for Review
+- Adding reviewers: use Add Pull Request Reviewers
+- Merging: use Merge Pull Request
+
+### Implementation notes
+
+- Title, body, state, and base are updated through GitHub's Pulls API.
+- Assignees and labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue.
+- GitHub ignores a base branch change in the same request that sets the state to "closed".
+
+### Output
+
+Returns the updated pull request object with all current information.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "assignees": [
+      {
+        "html_url": "https://github.com/octocat",
+        "id": 1,
+        "login": "octocat"
+      }
+    ],
+    "base": {
+      "label": "acme:release",
+      "ref": "release"
+    },
+    "body": "Adds the new feature described in the linked issue.",
+    "created_at": "2026-04-22T10:00:00Z",
+    "draft": false,
+    "head": {
+      "label": "acme:feature-branch",
+      "ref": "feature-branch"
+    },
+    "html_url": "https://github.com/acme/widgets/pull/42",
+    "id": 1234567890,
+    "labels": [
+      {
+        "color": "a2eeef",
+        "name": "enhancement"
+      }
+    ],
+    "number": 42,
+    "state": "open",
+    "title": "Add new feature",
+    "updated_at": "2026-04-22T11:15:00Z",
+    "user": {
+      "html_url": "https://github.com/octocat",
+      "id": 1,
+      "login": "octocat"
+    }
+  },
+  "timestamp": "2026-04-22T11:15:00.000000000Z",
+  "type": "github.pullRequest"
 }
 ```
 

--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -3347,9 +3347,9 @@ The following pull request operations have their own dedicated components:
 
 ### Implementation notes
 
-- Title, body, state, and base are updated through GitHub's Pulls API. Base is sent in its own request before title/body/state, so toggling on both a retarget and a close in the same run applies both instead of GitHub silently dropping the retarget.
+- Title, body, state, and base are updated through GitHub's Pulls API. Base is always sent in its own request, separate from title/body/state, since GitHub silently drops a base change bundled with a request that also closes the pull request. When both are toggled on, the order adapts to the direction: reopening happens before the retarget (a closed pull request can't be retargeted), and closing happens after it.
 - Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue. A leading "@" on an assignee username is stripped automatically.
-- GitHub rejects retargeting a pull request that is already closed - if the pull request is closed from a previous run, toggle it open again before retargeting.
+- GitHub rejects retargeting a pull request that is already closed and state isn't being toggled on in the same run - toggle state to "open" alongside the retarget, or run it in a separate step after reopening.
 
 ### Output
 

--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -3345,12 +3345,6 @@ The following pull request operations have their own dedicated components:
 - Adding reviewers: use Add Pull Request Reviewers
 - Merging: use Merge Pull Request
 
-### Implementation notes
-
-- Title, body, state, and base are updated through GitHub's Pulls API. Base is always sent in its own request, separate from title/body/state, since GitHub silently drops a base change bundled with a request that also closes the pull request. When both are toggled on, the order adapts to the direction: reopening happens before the retarget (a closed pull request can't be retargeted), and closing happens after it.
-- Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue. A leading "@" on an assignee username is stripped automatically.
-- GitHub rejects retargeting a pull request that is already closed and state isn't being toggled on in the same run - toggle state to "open" alongside the retarget, or run it in a separate step after reopening.
-
 ### Output
 
 Returns the updated pull request object with all current information.

--- a/pkg/integrations/github/capability_mapper.go
+++ b/pkg/integrations/github/capability_mapper.go
@@ -136,6 +136,7 @@ func NewCapabilityMapper() *CapabilityMapper {
 					{ReadOnly: false, Action: &pulls.MergePullRequest{}},
 					{ReadOnly: false, Action: &pulls.MarkPullRequestReadyForReview{}},
 					{ReadOnly: false, Action: &pulls.AddPullRequestReviewers{}},
+					{ReadOnly: false, Action: &pulls.UpdatePullRequest{}},
 				},
 			},
 		},

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -172,6 +172,10 @@ func (c *Client) GetPullRequest(ctx context.Context, repository string, pullNumb
 	return c.underlying.PullRequests.Get(ctx, c.owner, repository, pullNumber)
 }
 
+func (c *Client) EditPullRequest(ctx context.Context, repository string, pullNumber int, pullRequest *github.PullRequest) (*github.PullRequest, *github.Response, error) {
+	return c.underlying.PullRequests.Edit(ctx, c.owner, repository, pullNumber, pullRequest)
+}
+
 // MarkPullRequestReadyForReview takes a pull request out of the draft state.
 // GitHub exposes this only through the GraphQL API, so it is the one pull
 // request operation that cannot delegate to the REST client. It takes the pull

--- a/pkg/integrations/github/components/pulls/example.go
+++ b/pkg/integrations/github/components/pulls/example.go
@@ -34,6 +34,9 @@ var exampleOutputAddPullRequestReviewersBytes []byte
 //go:embed payloads/mark_pull_request_ready_for_review.json
 var exampleOutputMarkPullRequestReadyForReviewBytes []byte
 
+//go:embed payloads/update_pull_request.json
+var exampleOutputUpdatePullRequestBytes []byte
+
 var exampleOutputAddReactionOnce sync.Once
 var exampleOutputAddReaction map[string]any
 
@@ -51,6 +54,9 @@ var exampleOutputAddPullRequestReviewers map[string]any
 
 var exampleOutputMarkPullRequestReadyForReviewOnce sync.Once
 var exampleOutputMarkPullRequestReadyForReview map[string]any
+
+var exampleOutputUpdatePullRequestOnce sync.Once
+var exampleOutputUpdatePullRequest map[string]any
 
 var exampleDataOnPullRequestOnce sync.Once
 var exampleDataOnPullRequest map[string]any
@@ -122,5 +128,13 @@ func (c *MarkPullRequestReadyForReview) ExampleOutput() map[string]any {
 		&exampleOutputMarkPullRequestReadyForReviewOnce,
 		exampleOutputMarkPullRequestReadyForReviewBytes,
 		&exampleOutputMarkPullRequestReadyForReview,
+	)
+}
+
+func (c *UpdatePullRequest) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputUpdatePullRequestOnce,
+		exampleOutputUpdatePullRequestBytes,
+		&exampleOutputUpdatePullRequest,
 	)
 }

--- a/pkg/integrations/github/components/pulls/payloads/update_pull_request.json
+++ b/pkg/integrations/github/components/pulls/payloads/update_pull_request.json
@@ -1,0 +1,41 @@
+{
+  "data": {
+    "id": 1234567890,
+    "number": 42,
+    "title": "Add new feature",
+    "body": "Adds the new feature described in the linked issue.",
+    "state": "open",
+    "draft": false,
+    "html_url": "https://github.com/acme/widgets/pull/42",
+    "created_at": "2026-04-22T10:00:00Z",
+    "updated_at": "2026-04-22T11:15:00Z",
+    "labels": [
+      {
+        "name": "enhancement",
+        "color": "a2eeef"
+      }
+    ],
+    "assignees": [
+      {
+        "login": "octocat",
+        "id": 1,
+        "html_url": "https://github.com/octocat"
+      }
+    ],
+    "head": {
+      "ref": "feature-branch",
+      "label": "acme:feature-branch"
+    },
+    "base": {
+      "ref": "release",
+      "label": "acme:release"
+    },
+    "user": {
+      "login": "octocat",
+      "id": 1,
+      "html_url": "https://github.com/octocat"
+    }
+  },
+  "timestamp": "2026-04-22T11:15:00.000000000Z",
+  "type": "github.pullRequest"
+}

--- a/pkg/integrations/github/components/pulls/payloads/update_pull_request.json
+++ b/pkg/integrations/github/components/pulls/payloads/update_pull_request.json
@@ -1,12 +1,16 @@
 {
   "data": {
     "id": 1234567890,
+    "node_id": "PR_kwDOABCD12MAAAABCDEFGH",
     "number": 42,
     "title": "Add new feature",
     "body": "Adds the new feature described in the linked issue.",
     "state": "open",
+    "locked": false,
     "draft": false,
     "html_url": "https://github.com/acme/widgets/pull/42",
+    "issue_url": "https://api.github.com/repos/acme/widgets/issues/42",
+    "comments_url": "https://api.github.com/repos/acme/widgets/issues/42/comments",
     "created_at": "2026-04-22T10:00:00Z",
     "updated_at": "2026-04-22T11:15:00Z",
     "labels": [

--- a/pkg/integrations/github/components/pulls/update_pull_request.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request.go
@@ -332,6 +332,17 @@ func validateUpdatePullRequestConfiguration(config UpdatePullRequestConfiguratio
 		return errors.New("pull request number is required")
 	}
 
+	// Unlike body, an empty title or base is never a valid "clear" instruction:
+	// GitHub rejects an empty pull request title outright, and an empty base
+	// branch cannot resolve to a real branch to retarget onto.
+	if config.Title != nil && strings.TrimSpace(*config.Title) == "" {
+		return errors.New("title cannot be empty")
+	}
+
+	if config.Base != nil && strings.TrimSpace(*config.Base) == "" {
+		return errors.New("base branch cannot be empty")
+	}
+
 	if err := validatePullRequestState(config.State); err != nil {
 		return err
 	}

--- a/pkg/integrations/github/components/pulls/update_pull_request.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request.go
@@ -1,0 +1,421 @@
+package pulls
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+)
+
+const (
+	pullRequestStateOpen   = "open"
+	pullRequestStateClosed = "closed"
+)
+
+type UpdatePullRequest struct{}
+
+type UpdatePullRequestConfiguration struct {
+	Repository string   `mapstructure:"repository" json:"repository"`
+	PullNumber any      `mapstructure:"pullNumber" json:"pullNumber"`
+	Title      string   `mapstructure:"title" json:"title"`
+	Body       string   `mapstructure:"body" json:"body"`
+	State      string   `mapstructure:"state" json:"state"`
+	Base       string   `mapstructure:"base" json:"base"`
+	Assignees  []string `mapstructure:"assignees" json:"assignees"`
+	Labels     []string `mapstructure:"labels" json:"labels"`
+}
+
+type updatePullRequestInput struct {
+	Repository string
+	PullNumber int
+	Title      string
+	Body       string
+	State      string
+	Base       string
+	Assignees  []string
+	Labels     []string
+}
+
+func (c *UpdatePullRequest) Name() string {
+	return "github.updatePullRequest"
+}
+
+func (c *UpdatePullRequest) Label() string {
+	return "Update Pull Request"
+}
+
+func (c *UpdatePullRequest) Description() string {
+	return "Update a pull request's title, body, state, base branch, labels, or assignees in a GitHub repository"
+}
+
+func (c *UpdatePullRequest) Documentation() string {
+	return `The Update Pull Request component updates an existing pull request in a GitHub repository. Use it instead of Update Issue when the change is about a pull request - GitHub models a pull request's title, body, state, labels, and assignees on its underlying issue, but "Update Issue" is confusing to reach for when working with pull requests.
+
+## Use Cases
+
+- **Retitle/rebody automation**: Update a pull request's title or description as a workflow progresses
+- **Open/close automation**: Close a pull request when it is superseded, or reopen one automatically
+- **Retargeting**: Change the base branch a pull request merges into
+- **Label and assignee management**: Replace a pull request's labels or assignees from a workflow
+
+## Configuration
+
+- **Repository**: Select the GitHub repository containing the pull request
+- **Pull Request Number**: Pull request number to update. Supports expressions.
+- **Title**: New title for the pull request (optional; leaves the title unchanged if empty)
+- **Body**: New body/description for the pull request (optional; leaves the body unchanged if empty)
+- **State**: Change the pull request state to "open" or "closed" (optional; unset leaves the state unchanged)
+- **Base Branch**: Retarget the pull request onto a different base branch (optional)
+- **Assignees**: Non-empty list replaces the full set of assignees on the pull request (optional)
+- **Labels**: Non-empty list replaces the full set of labels on the pull request (optional)
+
+At least one of title, body, state, base, assignees, or labels is required.
+
+## Out of scope
+
+The following pull request operations have their own dedicated components:
+
+- Marking a draft pull request ready for review: use Mark Pull Request Ready for Review
+- Adding reviewers: use Add Pull Request Reviewers
+- Merging: use Merge Pull Request
+
+## Implementation notes
+
+- Title, body, state, and base are updated through GitHub's Pulls API.
+- Assignees and labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue.
+- GitHub ignores a base branch change in the same request that sets the state to "closed".
+
+## Output
+
+Returns the updated pull request object with all current information.`
+}
+
+func (c *UpdatePullRequest) Icon() string {
+	return "github"
+}
+
+func (c *UpdatePullRequest) Color() string {
+	return "gray"
+}
+
+func (c *UpdatePullRequest) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *UpdatePullRequest) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "pullNumber",
+			Label:       "Pull Request Number",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "42 or {{event.data.pull_request.number}}",
+			Description: "Pull request number to update. Supports expressions.",
+		},
+		{
+			Name:        "title",
+			Label:       "Title",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "New title for the pull request. Leave empty to keep the current title.",
+		},
+		{
+			Name:        "body",
+			Label:       "Body",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Description: "New body for the pull request. Leave empty to keep the current body.",
+		},
+		{
+			Name:        "state",
+			Label:       "State",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Description: "Change the pull request state. Leave unset to keep the current state.",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Open", Value: pullRequestStateOpen},
+						{Label: "Closed", Value: pullRequestStateClosed},
+					},
+				},
+			},
+		},
+		{
+			Name:        "base",
+			Label:       "Base Branch",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Retarget the pull request onto a different base branch. Must live in the selected repository.",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "branch",
+					UseNameAsValue: true,
+					Parameters: []configuration.ParameterRef{
+						{Name: "repository", ValueFrom: &configuration.ParameterValueFrom{Field: "repository"}},
+					},
+				},
+			},
+		},
+		{
+			Name:        "assignees",
+			Label:       "Assignees",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Non-empty list replaces the full set of assignees on the pull request.",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Assignee",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+		{
+			Name:        "labels",
+			Label:       "Labels",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Non-empty list replaces the full set of labels on the pull request.",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Label",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *UpdatePullRequest) Setup(ctx core.SetupContext) error {
+	var config UpdatePullRequestConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if err := validateUpdatePullRequestSetup(config); err != nil {
+		return err
+	}
+
+	return common.EnsureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.HTTP,
+		ctx.Configuration,
+	)
+}
+
+func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
+	var config UpdatePullRequestConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	input, err := buildUpdatePullRequestInput(config)
+	if err != nil {
+		return err
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	//
+	// Title, body, state, and base are updated through the Pulls API.
+	//
+	if input.hasPullRequestFields() {
+		pullRequestUpdate := &github.PullRequest{}
+
+		if input.Title != "" {
+			pullRequestUpdate.Title = &input.Title
+		}
+
+		if input.Body != "" {
+			pullRequestUpdate.Body = &input.Body
+		}
+
+		if input.State != "" {
+			pullRequestUpdate.State = &input.State
+		}
+
+		if input.Base != "" {
+			pullRequestUpdate.Base = &github.PullRequestBranch{Ref: &input.Base}
+		}
+
+		if _, _, err := client.EditPullRequest(context.Background(), input.Repository, input.PullNumber, pullRequestUpdate); err != nil {
+			return fmt.Errorf("failed to update pull request: %w", explainGitHubError(err))
+		}
+	}
+
+	//
+	// GitHub models a pull request's labels and assignees on its underlying
+	// issue, so those are updated through the Issues API instead.
+	//
+	if input.hasIssueFields() {
+		issueRequest := &github.IssueRequest{}
+
+		if len(input.Assignees) > 0 {
+			issueRequest.Assignees = &input.Assignees
+		}
+
+		if len(input.Labels) > 0 {
+			issueRequest.Labels = &input.Labels
+		}
+
+		if _, _, err := client.EditIssue(context.Background(), input.Repository, input.PullNumber, issueRequest); err != nil {
+			return fmt.Errorf("failed to update pull request labels/assignees: %w", explainGitHubError(err))
+		}
+	}
+
+	//
+	// The Issues API response does not carry the full pull request shape, so
+	// the pull request is re-fetched to emit an up-to-date object either way.
+	//
+	pullRequest, _, err := client.GetPullRequest(context.Background(), input.Repository, input.PullNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get pull request: %w", explainGitHubError(err))
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.pullRequest",
+		[]any{pullRequest},
+	)
+}
+
+func (c *UpdatePullRequest) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *UpdatePullRequest) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *UpdatePullRequest) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *UpdatePullRequest) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func (c *UpdatePullRequest) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *UpdatePullRequest) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func validateUpdatePullRequestSetup(config UpdatePullRequestConfiguration) error {
+	if strings.TrimSpace(config.Repository) == "" {
+		return errors.New("repository is required")
+	}
+
+	if pullNumberText(config.PullNumber) == "" {
+		return errors.New("pull request number is required")
+	}
+
+	if err := validatePullRequestState(config.State); err != nil {
+		return err
+	}
+
+	if err := validateAtLeastOneUpdateField(config); err != nil {
+		return err
+	}
+
+	if common.IsExpression(pullNumberText(config.PullNumber)) {
+		return nil
+	}
+
+	_, err := parsePullNumber(config.PullNumber)
+	return err
+}
+
+func buildUpdatePullRequestInput(config UpdatePullRequestConfiguration) (*updatePullRequestInput, error) {
+	if strings.TrimSpace(config.Repository) == "" {
+		return nil, errors.New("repository is required")
+	}
+
+	pullNumber, err := parsePullNumber(config.PullNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validatePullRequestState(config.State); err != nil {
+		return nil, err
+	}
+
+	if err := validateAtLeastOneUpdateField(config); err != nil {
+		return nil, err
+	}
+
+	return &updatePullRequestInput{
+		Repository: strings.TrimSpace(config.Repository),
+		PullNumber: pullNumber,
+		Title:      config.Title,
+		Body:       config.Body,
+		State:      strings.TrimSpace(config.State),
+		Base:       strings.TrimSpace(config.Base),
+		Assignees:  config.Assignees,
+		Labels:     config.Labels,
+	}, nil
+}
+
+func validatePullRequestState(state string) error {
+	trimmed := strings.TrimSpace(state)
+	if trimmed == "" {
+		return nil
+	}
+
+	switch trimmed {
+	case pullRequestStateOpen, pullRequestStateClosed:
+		return nil
+	default:
+		return errors.New("state must be one of: open, closed")
+	}
+}
+
+func validateAtLeastOneUpdateField(config UpdatePullRequestConfiguration) error {
+	if strings.TrimSpace(config.Title) != "" ||
+		strings.TrimSpace(config.Body) != "" ||
+		strings.TrimSpace(config.State) != "" ||
+		strings.TrimSpace(config.Base) != "" ||
+		len(config.Assignees) > 0 ||
+		len(config.Labels) > 0 {
+		return nil
+	}
+
+	return errors.New("at least one of title, body, state, base, assignees, or labels is required")
+}
+
+func (i *updatePullRequestInput) hasPullRequestFields() bool {
+	return i.Title != "" || i.Body != "" || i.State != "" || i.Base != ""
+}
+
+func (i *updatePullRequestInput) hasIssueFields() bool {
+	return len(i.Assignees) > 0 || len(i.Labels) > 0
+}

--- a/pkg/integrations/github/components/pulls/update_pull_request.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request.go
@@ -66,14 +66,6 @@ At least one field must be toggled on.
 
 **Replace Assignees** and **Replace Labels** replace the pull request's full set when toggled on, including replacing it with an empty list to clear all assignees or labels.
 
-## Out of scope
-
-The following pull request operations have their own dedicated components:
-
-- Marking a draft pull request ready for review: use Mark Pull Request Ready for Review
-- Adding reviewers: use Add Pull Request Reviewers
-- Merging: use Merge Pull Request
-
 ## Output
 
 Returns the updated pull request object with all current information.`

--- a/pkg/integrations/github/components/pulls/update_pull_request.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request.go
@@ -22,25 +22,14 @@ const (
 type UpdatePullRequest struct{}
 
 type UpdatePullRequestConfiguration struct {
-	Repository string   `mapstructure:"repository" json:"repository"`
-	PullNumber any      `mapstructure:"pullNumber" json:"pullNumber"`
-	Title      string   `mapstructure:"title" json:"title"`
-	Body       string   `mapstructure:"body" json:"body"`
-	State      string   `mapstructure:"state" json:"state"`
-	Base       string   `mapstructure:"base" json:"base"`
-	Assignees  []string `mapstructure:"assignees" json:"assignees"`
-	Labels     []string `mapstructure:"labels" json:"labels"`
-}
-
-type updatePullRequestInput struct {
-	Repository string
-	PullNumber int
-	Title      string
-	Body       string
-	State      string
-	Base       string
-	Assignees  []string
-	Labels     []string
+	Repository string    `mapstructure:"repository" json:"repository"`
+	PullNumber any       `mapstructure:"pullNumber" json:"pullNumber"`
+	Title      *string   `mapstructure:"title" json:"title"`
+	Body       *string   `mapstructure:"body" json:"body"`
+	State      *string   `mapstructure:"state" json:"state"`
+	Base       *string   `mapstructure:"base" json:"base"`
+	Assignees  *[]string `mapstructure:"assignees" json:"assignees"`
+	Labels     *[]string `mapstructure:"labels" json:"labels"`
 }
 
 func (c *UpdatePullRequest) Name() string {
@@ -69,14 +58,13 @@ func (c *UpdatePullRequest) Documentation() string {
 
 - **Repository**: Select the GitHub repository containing the pull request
 - **Pull Request Number**: Pull request number to update. Supports expressions.
-- **Title**: New title for the pull request (optional; leaves the title unchanged if empty)
-- **Body**: New body/description for the pull request (optional; leaves the body unchanged if empty)
-- **State**: Change the pull request state to "open" or "closed" (optional; unset leaves the state unchanged)
-- **Base Branch**: Retarget the pull request onto a different base branch (optional)
-- **Assignees**: Non-empty list replaces the full set of assignees on the pull request (optional)
-- **Labels**: Non-empty list replaces the full set of labels on the pull request (optional)
+- **Title**, **Body**, **State**, **Base Branch**, **Replace Assignees**, **Replace Labels**: each field has its own toggle. Only toggled-on fields are changed; toggled-off fields are left untouched on the pull request.
 
-At least one of title, body, state, base, assignees, or labels is required.
+At least one field must be toggled on.
+
+## Replacing labels and assignees
+
+**Replace Assignees** and **Replace Labels** replace the pull request's full set when toggled on, including replacing it with an empty list to clear all assignees or labels.
 
 ## Out of scope
 
@@ -89,7 +77,7 @@ The following pull request operations have their own dedicated components:
 ## Implementation notes
 
 - Title, body, state, and base are updated through GitHub's Pulls API.
-- Assignees and labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue.
+- Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue.
 - GitHub ignores a base branch change in the same request that sets the state to "closed".
 
 ## Output
@@ -136,21 +124,24 @@ func (c *UpdatePullRequest) Configuration() []configuration.Field {
 			Label:       "Title",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "New title for the pull request. Leave empty to keep the current title.",
+			Togglable:   true,
+			Description: "New title for the pull request.",
 		},
 		{
 			Name:        "body",
 			Label:       "Body",
 			Type:        configuration.FieldTypeText,
 			Required:    false,
-			Description: "New body for the pull request. Leave empty to keep the current body.",
+			Togglable:   true,
+			Description: "New body for the pull request.",
 		},
 		{
 			Name:        "state",
 			Label:       "State",
 			Type:        configuration.FieldTypeSelect,
 			Required:    false,
-			Description: "Change the pull request state. Leave unset to keep the current state.",
+			Togglable:   true,
+			Description: "Change the pull request state.",
 			TypeOptions: &configuration.TypeOptions{
 				Select: &configuration.SelectTypeOptions{
 					Options: []configuration.FieldOption{
@@ -165,6 +156,7 @@ func (c *UpdatePullRequest) Configuration() []configuration.Field {
 			Label:       "Base Branch",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    false,
+			Togglable:   true,
 			Description: "Retarget the pull request onto a different base branch. Must live in the selected repository.",
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
@@ -178,10 +170,11 @@ func (c *UpdatePullRequest) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "assignees",
-			Label:       "Assignees",
+			Label:       "Replace Assignees",
 			Type:        configuration.FieldTypeList,
 			Required:    false,
-			Description: "Non-empty list replaces the full set of assignees on the pull request.",
+			Togglable:   true,
+			Description: "Replace the pull request's assignees with this list. An empty list clears all assignees.",
 			TypeOptions: &configuration.TypeOptions{
 				List: &configuration.ListTypeOptions{
 					ItemLabel: "Assignee",
@@ -193,10 +186,11 @@ func (c *UpdatePullRequest) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "labels",
-			Label:       "Labels",
+			Label:       "Replace Labels",
 			Type:        configuration.FieldTypeList,
 			Required:    false,
-			Description: "Non-empty list replaces the full set of labels on the pull request.",
+			Togglable:   true,
+			Description: "Replace the pull request's labels with this list. An empty list clears all labels.",
 			TypeOptions: &configuration.TypeOptions{
 				List: &configuration.ListTypeOptions{
 					ItemLabel: "Label",
@@ -215,8 +209,14 @@ func (c *UpdatePullRequest) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	if err := validateUpdatePullRequestSetup(config); err != nil {
+	if err := validateUpdatePullRequestConfiguration(config); err != nil {
 		return err
+	}
+
+	if !common.IsExpression(pullNumberText(config.PullNumber)) {
+		if _, err := parsePullNumber(config.PullNumber); err != nil {
+			return err
+		}
 	}
 
 	return common.EnsureRepoInMetadata(
@@ -233,7 +233,12 @@ func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	input, err := buildUpdatePullRequestInput(config)
+	if err := validateUpdatePullRequestConfiguration(config); err != nil {
+		return err
+	}
+
+	repository := strings.TrimSpace(config.Repository)
+	pullNumber, err := parsePullNumber(config.PullNumber)
 	if err != nil {
 		return err
 	}
@@ -246,26 +251,19 @@ func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
 	//
 	// Title, body, state, and base are updated through the Pulls API.
 	//
-	if input.hasPullRequestFields() {
-		pullRequestUpdate := &github.PullRequest{}
-
-		if input.Title != "" {
-			pullRequestUpdate.Title = &input.Title
+	if hasPullRequestFields(config) {
+		pullRequestUpdate := &github.PullRequest{
+			Title: config.Title,
+			Body:  config.Body,
+			State: config.State,
 		}
 
-		if input.Body != "" {
-			pullRequestUpdate.Body = &input.Body
+		if config.Base != nil {
+			base := strings.TrimSpace(*config.Base)
+			pullRequestUpdate.Base = &github.PullRequestBranch{Ref: &base}
 		}
 
-		if input.State != "" {
-			pullRequestUpdate.State = &input.State
-		}
-
-		if input.Base != "" {
-			pullRequestUpdate.Base = &github.PullRequestBranch{Ref: &input.Base}
-		}
-
-		if _, _, err := client.EditPullRequest(context.Background(), input.Repository, input.PullNumber, pullRequestUpdate); err != nil {
+		if _, _, err := client.EditPullRequest(context.Background(), repository, pullNumber, pullRequestUpdate); err != nil {
 			return fmt.Errorf("failed to update pull request: %w", explainGitHubError(err))
 		}
 	}
@@ -274,18 +272,13 @@ func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
 	// GitHub models a pull request's labels and assignees on its underlying
 	// issue, so those are updated through the Issues API instead.
 	//
-	if input.hasIssueFields() {
-		issueRequest := &github.IssueRequest{}
-
-		if len(input.Assignees) > 0 {
-			issueRequest.Assignees = &input.Assignees
+	if hasIssueFields(config) {
+		issueRequest := &github.IssueRequest{
+			Assignees: config.Assignees,
+			Labels:    config.Labels,
 		}
 
-		if len(input.Labels) > 0 {
-			issueRequest.Labels = &input.Labels
-		}
-
-		if _, _, err := client.EditIssue(context.Background(), input.Repository, input.PullNumber, issueRequest); err != nil {
+		if _, _, err := client.EditIssue(context.Background(), repository, pullNumber, issueRequest); err != nil {
 			return fmt.Errorf("failed to update pull request labels/assignees: %w", explainGitHubError(err))
 		}
 	}
@@ -294,7 +287,7 @@ func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
 	// The Issues API response does not carry the full pull request shape, so
 	// the pull request is re-fetched to emit an up-to-date object either way.
 	//
-	pullRequest, _, err := client.GetPullRequest(context.Background(), input.Repository, input.PullNumber)
+	pullRequest, _, err := client.GetPullRequest(context.Background(), repository, pullNumber)
 	if err != nil {
 		return fmt.Errorf("failed to get pull request: %w", explainGitHubError(err))
 	}
@@ -330,7 +323,7 @@ func (c *UpdatePullRequest) Cleanup(ctx core.SetupContext) error {
 	return nil
 }
 
-func validateUpdatePullRequestSetup(config UpdatePullRequestConfiguration) error {
+func validateUpdatePullRequestConfiguration(config UpdatePullRequestConfiguration) error {
 	if strings.TrimSpace(config.Repository) == "" {
 		return errors.New("repository is required")
 	}
@@ -343,55 +336,15 @@ func validateUpdatePullRequestSetup(config UpdatePullRequestConfiguration) error
 		return err
 	}
 
-	if err := validateAtLeastOneUpdateField(config); err != nil {
-		return err
-	}
+	return validateAtLeastOneUpdateField(config)
+}
 
-	if common.IsExpression(pullNumberText(config.PullNumber)) {
+func validatePullRequestState(state *string) error {
+	if state == nil {
 		return nil
 	}
 
-	_, err := parsePullNumber(config.PullNumber)
-	return err
-}
-
-func buildUpdatePullRequestInput(config UpdatePullRequestConfiguration) (*updatePullRequestInput, error) {
-	if strings.TrimSpace(config.Repository) == "" {
-		return nil, errors.New("repository is required")
-	}
-
-	pullNumber, err := parsePullNumber(config.PullNumber)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := validatePullRequestState(config.State); err != nil {
-		return nil, err
-	}
-
-	if err := validateAtLeastOneUpdateField(config); err != nil {
-		return nil, err
-	}
-
-	return &updatePullRequestInput{
-		Repository: strings.TrimSpace(config.Repository),
-		PullNumber: pullNumber,
-		Title:      config.Title,
-		Body:       config.Body,
-		State:      strings.TrimSpace(config.State),
-		Base:       strings.TrimSpace(config.Base),
-		Assignees:  config.Assignees,
-		Labels:     config.Labels,
-	}, nil
-}
-
-func validatePullRequestState(state string) error {
-	trimmed := strings.TrimSpace(state)
-	if trimmed == "" {
-		return nil
-	}
-
-	switch trimmed {
+	switch strings.TrimSpace(*state) {
 	case pullRequestStateOpen, pullRequestStateClosed:
 		return nil
 	default:
@@ -399,23 +352,23 @@ func validatePullRequestState(state string) error {
 	}
 }
 
+// validateAtLeastOneUpdateField requires at least one togglable field to be
+// toggled on. A field counts as toggled on when its key is present in the
+// submitted configuration (decoded as a non-nil pointer), regardless of
+// whether its value is empty - an empty list for assignees/labels is a valid
+// "clear" instruction, not an unset field.
 func validateAtLeastOneUpdateField(config UpdatePullRequestConfiguration) error {
-	if strings.TrimSpace(config.Title) != "" ||
-		strings.TrimSpace(config.Body) != "" ||
-		strings.TrimSpace(config.State) != "" ||
-		strings.TrimSpace(config.Base) != "" ||
-		len(config.Assignees) > 0 ||
-		len(config.Labels) > 0 {
+	if hasPullRequestFields(config) || hasIssueFields(config) {
 		return nil
 	}
 
 	return errors.New("at least one of title, body, state, base, assignees, or labels is required")
 }
 
-func (i *updatePullRequestInput) hasPullRequestFields() bool {
-	return i.Title != "" || i.Body != "" || i.State != "" || i.Base != ""
+func hasPullRequestFields(config UpdatePullRequestConfiguration) bool {
+	return config.Title != nil || config.Body != nil || config.State != nil || config.Base != nil
 }
 
-func (i *updatePullRequestInput) hasIssueFields() bool {
-	return len(i.Assignees) > 0 || len(i.Labels) > 0
+func hasIssueFields(config UpdatePullRequestConfiguration) bool {
+	return config.Assignees != nil || config.Labels != nil
 }

--- a/pkg/integrations/github/components/pulls/update_pull_request.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request.go
@@ -76,9 +76,9 @@ The following pull request operations have their own dedicated components:
 
 ## Implementation notes
 
-- Title, body, state, and base are updated through GitHub's Pulls API. Base is sent in its own request before title/body/state, so toggling on both a retarget and a close in the same run applies both instead of GitHub silently dropping the retarget.
+- Title, body, state, and base are updated through GitHub's Pulls API. Base is always sent in its own request, separate from title/body/state, since GitHub silently drops a base change bundled with a request that also closes the pull request. When both are toggled on, the order adapts to the direction: reopening happens before the retarget (a closed pull request can't be retargeted), and closing happens after it.
 - Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue. A leading "@" on an assignee username is stripped automatically.
-- GitHub rejects retargeting a pull request that is already closed - if the pull request is closed from a previous run, toggle it open again before retargeting.
+- GitHub rejects retargeting a pull request that is already closed and state isn't being toggled on in the same run - toggle state to "open" alongside the retarget, or run it in a separate step after reopening.
 
 ## Output
 
@@ -255,28 +255,45 @@ func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
 		return nil
 	}
 
-	//
-	// Base is sent in its own request, before title/body/state: GitHub's Pulls
-	// API silently drops a base change bundled with a request that also closes
-	// the pull request, and separately rejects retargeting a pull request that
-	// is already closed. Applying the retarget first, while the pull request
-	// is still in its current state, avoids both.
-	//
+	// Base is always sent in its own request, separate from title/body/state:
+	// GitHub's Pulls API silently drops a base change bundled with a request
+	// that also closes the pull request, and separately rejects retargeting a
+	// pull request that is closed. Whether the base request runs before or
+	// after the title/body/state request depends on which direction the pull
+	// request is moving: reopening must happen before the retarget (since a
+	// closed pull request can't be retargeted), while closing must happen
+	// after it (since retargeting is silently dropped from a closing request).
+	var baseUpdate *github.PullRequest
 	if config.Base != nil {
 		base := strings.TrimSpace(*config.Base)
-		if err := editPullRequest(&github.PullRequest{Base: &github.PullRequestBranch{Ref: &base}}); err != nil {
-			return err
-		}
+		baseUpdate = &github.PullRequest{Base: &github.PullRequestBranch{Ref: &base}}
 	}
 
+	var titleBodyStateUpdate *github.PullRequest
 	if config.Title != nil || config.Body != nil || config.State != nil {
-		update := &github.PullRequest{
+		titleBodyStateUpdate = &github.PullRequest{
 			Title: config.Title,
 			Body:  config.Body,
 			State: config.State,
 		}
+	}
 
-		if err := editPullRequest(update); err != nil {
+	reopening := config.State != nil && strings.TrimSpace(*config.State) == pullRequestStateOpen
+
+	if reopening && titleBodyStateUpdate != nil {
+		if err := editPullRequest(titleBodyStateUpdate); err != nil {
+			return err
+		}
+	}
+
+	if baseUpdate != nil {
+		if err := editPullRequest(baseUpdate); err != nil {
+			return err
+		}
+	}
+
+	if !reopening && titleBodyStateUpdate != nil {
+		if err := editPullRequest(titleBodyStateUpdate); err != nil {
 			return err
 		}
 	}

--- a/pkg/integrations/github/components/pulls/update_pull_request.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request.go
@@ -289,6 +289,17 @@ func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
 	// issue, so those are updated through the Issues API instead.
 	//
 	if hasIssueFields(config) {
+		// The Issues API succeeds on any issue number, whether or not it's
+		// actually a pull request. When no Pulls API call happened above,
+		// nothing has confirmed pullNumber refers to a pull request yet, so
+		// check first rather than mutating a plain issue's labels/assignees
+		// only to fail once the pull request re-fetch below 404s.
+		if titleBodyStateUpdate == nil && baseUpdate == nil {
+			if _, _, err := client.GetPullRequest(context.Background(), repository, pullNumber); err != nil {
+				return fmt.Errorf("failed to get pull request: %w", explainGitHubError(err))
+			}
+		}
+
 		issueRequest := &github.IssueRequest{
 			Labels: config.Labels,
 		}

--- a/pkg/integrations/github/components/pulls/update_pull_request.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request.go
@@ -76,9 +76,9 @@ The following pull request operations have their own dedicated components:
 
 ## Implementation notes
 
-- Title, body, state, and base are updated through GitHub's Pulls API.
-- Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue.
-- GitHub ignores a base branch change in the same request that sets the state to "closed".
+- Title, body, state, and base are updated through GitHub's Pulls API. Base is sent in its own request before title/body/state, so toggling on both a retarget and a close in the same run applies both instead of GitHub silently dropping the retarget.
+- Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue. A leading "@" on an assignee username is stripped automatically.
+- GitHub rejects retargeting a pull request that is already closed - if the pull request is closed from a previous run, toggle it open again before retargeting.
 
 ## Output
 
@@ -248,23 +248,36 @@ func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to initialize GitHub client: %w", err)
 	}
 
+	editPullRequest := func(update *github.PullRequest) error {
+		if _, _, err := client.EditPullRequest(context.Background(), repository, pullNumber, update); err != nil {
+			return fmt.Errorf("failed to update pull request: %w", explainGitHubError(err))
+		}
+		return nil
+	}
+
 	//
-	// Title, body, state, and base are updated through the Pulls API.
+	// Base is sent in its own request, before title/body/state: GitHub's Pulls
+	// API silently drops a base change bundled with a request that also closes
+	// the pull request, and separately rejects retargeting a pull request that
+	// is already closed. Applying the retarget first, while the pull request
+	// is still in its current state, avoids both.
 	//
-	if hasPullRequestFields(config) {
-		pullRequestUpdate := &github.PullRequest{
+	if config.Base != nil {
+		base := strings.TrimSpace(*config.Base)
+		if err := editPullRequest(&github.PullRequest{Base: &github.PullRequestBranch{Ref: &base}}); err != nil {
+			return err
+		}
+	}
+
+	if config.Title != nil || config.Body != nil || config.State != nil {
+		update := &github.PullRequest{
 			Title: config.Title,
 			Body:  config.Body,
 			State: config.State,
 		}
 
-		if config.Base != nil {
-			base := strings.TrimSpace(*config.Base)
-			pullRequestUpdate.Base = &github.PullRequestBranch{Ref: &base}
-		}
-
-		if _, _, err := client.EditPullRequest(context.Background(), repository, pullNumber, pullRequestUpdate); err != nil {
-			return fmt.Errorf("failed to update pull request: %w", explainGitHubError(err))
+		if err := editPullRequest(update); err != nil {
+			return err
 		}
 	}
 
@@ -274,8 +287,12 @@ func (c *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
 	//
 	if hasIssueFields(config) {
 		issueRequest := &github.IssueRequest{
-			Assignees: config.Assignees,
-			Labels:    config.Labels,
+			Labels: config.Labels,
+		}
+
+		if config.Assignees != nil {
+			assignees := common.SanitizeAssignees(*config.Assignees)
+			issueRequest.Assignees = &assignees
 		}
 
 		if _, _, err := client.EditIssue(context.Background(), repository, pullNumber, issueRequest); err != nil {

--- a/pkg/integrations/github/components/pulls/update_pull_request.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request.go
@@ -74,12 +74,6 @@ The following pull request operations have their own dedicated components:
 - Adding reviewers: use Add Pull Request Reviewers
 - Merging: use Merge Pull Request
 
-## Implementation notes
-
-- Title, body, state, and base are updated through GitHub's Pulls API. Base is always sent in its own request, separate from title/body/state, since GitHub silently drops a base change bundled with a request that also closes the pull request. When both are toggled on, the order adapts to the direction: reopening happens before the retarget (a closed pull request can't be retargeted), and closing happens after it.
-- Replace Assignees and Replace Labels are updated through GitHub's Issues API, since GitHub models a pull request's labels and assignees on its underlying issue. A leading "@" on an assignee username is stripped automatically.
-- GitHub rejects retargeting a pull request that is already closed and state isn't being toggled on in the same run - toggle state to "open" alongside the retarget, or run it in a separate step after reopening.
-
 ## Output
 
 Returns the updated pull request object with all current information.`

--- a/pkg/integrations/github/components/pulls/update_pull_request_test.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request_test.go
@@ -423,6 +423,47 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		assert.Equal(t, "release", requestBody["base"])
 	})
 
+	t.Run("retargeting and closing together are sent as two separate requests", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				updatedPullRequestResponse(),
+				updatedPullRequestResponse(),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"base":       "release",
+				"state":      "closed",
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 3)
+
+		baseRequest := httpCtx.Requests[0]
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", baseRequest.URL.Path)
+		baseBody := readJSONBody(t, baseRequest)
+		assert.Equal(t, "release", baseBody["base"])
+		assert.NotContains(t, baseBody, "state")
+
+		stateRequest := httpCtx.Requests[1]
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", stateRequest.URL.Path)
+		stateBody := readJSONBody(t, stateRequest)
+		assert.Equal(t, "closed", stateBody["state"])
+		assert.NotContains(t, stateBody, "base")
+
+		getRequest := httpCtx.Requests[2]
+		assert.Equal(t, http.MethodGet, getRequest.Method)
+	})
+
 	t.Run("updates labels and assignees through the Issues API", func(t *testing.T) {
 		executionState := &contexts.ExecutionStateContext{}
 		httpCtx := &contexts.HTTPContext{
@@ -465,6 +506,30 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		getRequest := httpCtx.Requests[1]
 		assert.Equal(t, http.MethodGet, getRequest.Method)
 		assert.Equal(t, "/repos/testhq/hello/pulls/42", getRequest.URL.Path)
+	})
+
+	t.Run("strips a leading @ from assignee usernames", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{"id": 101, "number": 42}`),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"assignees":  []string{"@octocat"},
+			},
+		})
+
+		require.NoError(t, err)
+		requestBody := readJSONBody(t, httpCtx.Requests[0])
+		assert.Equal(t, []any{"octocat"}, requestBody["assignees"])
 	})
 
 	t.Run("labels toggled on with an empty list clears all labels", func(t *testing.T) {

--- a/pkg/integrations/github/components/pulls/update_pull_request_test.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request_test.go
@@ -1,0 +1,467 @@
+package pulls
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
+)
+
+func updatedPullRequestResponse() *http.Response {
+	return mocks.GitHubResponse(http.StatusOK, `{
+		"id": 1234567890,
+		"number": 42,
+		"title": "Updated title",
+		"state": "closed",
+		"draft": false,
+		"html_url": "https://github.com/testhq/hello/pull/42"
+	}`)
+}
+
+func Test__UpdatePullRequest__Setup(t *testing.T) {
+	component := UpdatePullRequest{}
+
+	validConfig := func(overrides map[string]any) map[string]any {
+		config := map[string]any{
+			"repository": "hello",
+			"pullNumber": "42",
+			"title":      "Updated title",
+		}
+		for key, value := range overrides {
+			config[key] = value
+		}
+		return config
+	}
+
+	t.Run("repository is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"repository": ""}),
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("pull request number is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"pullNumber": ""}),
+		})
+
+		require.ErrorContains(t, err, "pull request number is required")
+	})
+
+	t.Run("literal pull request number must be positive", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"pullNumber": "0"}),
+		})
+
+		require.ErrorContains(t, err, "pull request number must be a positive integer")
+	})
+
+	t.Run("state must be open or closed", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"state": "merged"}),
+		})
+
+		require.ErrorContains(t, err, "state must be one of: open, closed")
+	})
+
+	t.Run("at least one field to update is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+			},
+		})
+
+		require.ErrorContains(t, err, "at least one of title, body, state, base, assignees, or labels is required")
+	})
+
+	t.Run("valid configuration is accepted", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Integration:   mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:          httpCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(nil),
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("expression pull request number is accepted at setup", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Integration: mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:        httpCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{
+				"pullNumber": `{{$["github.onPullRequest"].data.pull_request.number}}`,
+			}),
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("labels alone are a valid configuration", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Integration: mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:        httpCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"labels":     []string{"bug"},
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__UpdatePullRequest__Execute(t *testing.T) {
+	component := UpdatePullRequest{}
+
+	t.Run("fails when configuration decode fails", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration:  "not a map",
+		})
+
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+
+	t.Run("repository is required", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "",
+				"pullNumber": "42",
+				"title":      "Updated title",
+			},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("pull request number must be positive", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "-1",
+				"title":      "Updated title",
+			},
+		})
+
+		require.ErrorContains(t, err, "pull request number must be a positive integer")
+	})
+
+	t.Run("state must be open or closed", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"state":      "merged",
+			},
+		})
+
+		require.ErrorContains(t, err, "state must be one of: open, closed")
+	})
+
+	t.Run("at least one field to update is required", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+			},
+		})
+
+		require.ErrorContains(t, err, "at least one of title, body, state, base, assignees, or labels is required")
+	})
+
+	t.Run("updates title, body, and state through the Pulls API", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				updatedPullRequestResponse(),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"title":      "Updated title",
+				"body":       "Updated body",
+				"state":      "closed",
+			},
+		})
+
+		require.NoError(t, err)
+		require.True(t, executionState.Passed)
+		require.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		require.Equal(t, "github.pullRequest", executionState.Type)
+		require.Len(t, httpCtx.Requests, 2)
+
+		editRequest := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodPatch, editRequest.Method)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", editRequest.URL.Path)
+
+		requestBody := readJSONBody(t, editRequest)
+		assert.Equal(t, "Updated title", requestBody["title"])
+		assert.Equal(t, "Updated body", requestBody["body"])
+		assert.Equal(t, "closed", requestBody["state"])
+
+		getRequest := httpCtx.Requests[1]
+		assert.Equal(t, http.MethodGet, getRequest.Method)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", getRequest.URL.Path)
+
+		payload := executionState.Payloads[0].(map[string]any)
+		pullRequest := payload["data"].(*github.PullRequest)
+		assert.Equal(t, "Updated title", pullRequest.GetTitle())
+		assert.Equal(t, "closed", pullRequest.GetState())
+	})
+
+	t.Run("retargets the base branch through the Pulls API", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				updatedPullRequestResponse(),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"base":       "release",
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 2)
+
+		editRequest := httpCtx.Requests[0]
+		requestBody := readJSONBody(t, editRequest)
+		assert.Equal(t, "release", requestBody["base"])
+	})
+
+	t.Run("updates labels and assignees through the Issues API", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 101,
+					"number": 42,
+					"title": "Add new feature",
+					"state": "open",
+					"labels": [{"name": "bug"}],
+					"assignees": [{"login": "octocat"}]
+				}`),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"labels":     []string{"bug"},
+				"assignees":  []string{"octocat"},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 2)
+
+		issueRequest := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodPatch, issueRequest.Method)
+		assert.Equal(t, "/repos/testhq/hello/issues/42", issueRequest.URL.Path)
+
+		requestBody := readJSONBody(t, issueRequest)
+		assert.Equal(t, []any{"bug"}, requestBody["labels"])
+		assert.Equal(t, []any{"octocat"}, requestBody["assignees"])
+
+		getRequest := httpCtx.Requests[1]
+		assert.Equal(t, http.MethodGet, getRequest.Method)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", getRequest.URL.Path)
+	})
+
+	t.Run("only calls the Pulls API when no labels or assignees are set", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				updatedPullRequestResponse(),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"title":      "Updated title",
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 2)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[0].URL.Path)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[1].URL.Path)
+	})
+
+	t.Run("only calls the Issues API when no title, body, state, or base are set", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{"id": 101, "number": 42}`),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"labels":     []string{"bug"},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 2)
+		assert.Equal(t, "/repos/testhq/hello/issues/42", httpCtx.Requests[0].URL.Path)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[1].URL.Path)
+	})
+
+	t.Run("fails when the Pulls API returns an error", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusUnprocessableEntity, `{"message": "Validation Failed"}`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"title":      "Updated title",
+			},
+		})
+
+		require.ErrorContains(t, err, "failed to update pull request")
+		require.ErrorContains(t, err, "Validation Failed")
+	})
+
+	t.Run("fails when the Issues API returns an error", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusUnprocessableEntity, `{"message": "Validation Failed"}`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"labels":     []string{"bug"},
+			},
+		})
+
+		require.ErrorContains(t, err, "failed to update pull request labels/assignees")
+		require.ErrorContains(t, err, "Validation Failed")
+	})
+
+	t.Run("fails when the pull request cannot be re-fetched", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				updatedPullRequestResponse(),
+				mocks.GitHubResponse(http.StatusNotFound, `{"message": "Not Found"}`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"title":      "Updated title",
+			},
+		})
+
+		require.ErrorContains(t, err, "failed to get pull request")
+		require.ErrorContains(t, err, "Not Found")
+	})
+}

--- a/pkg/integrations/github/components/pulls/update_pull_request_test.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request_test.go
@@ -509,6 +509,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		executionState := &contexts.ExecutionStateContext{}
 		httpCtx := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				updatedPullRequestResponse(),
 				mocks.GitHubResponse(http.StatusOK, `{
 					"id": 101,
 					"number": 42,
@@ -534,9 +535,13 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Len(t, httpCtx.Requests, 2)
+		require.Len(t, httpCtx.Requests, 3)
 
-		issueRequest := httpCtx.Requests[0]
+		precheckRequest := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodGet, precheckRequest.Method)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", precheckRequest.URL.Path)
+
+		issueRequest := httpCtx.Requests[1]
 		assert.Equal(t, http.MethodPatch, issueRequest.Method)
 		assert.Equal(t, "/repos/testhq/hello/issues/42", issueRequest.URL.Path)
 
@@ -544,7 +549,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		assert.Equal(t, []any{"bug"}, requestBody["labels"])
 		assert.Equal(t, []any{"octocat"}, requestBody["assignees"])
 
-		getRequest := httpCtx.Requests[1]
+		getRequest := httpCtx.Requests[2]
 		assert.Equal(t, http.MethodGet, getRequest.Method)
 		assert.Equal(t, "/repos/testhq/hello/pulls/42", getRequest.URL.Path)
 	})
@@ -552,6 +557,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 	t.Run("strips a leading @ from assignee usernames", func(t *testing.T) {
 		httpCtx := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				updatedPullRequestResponse(),
 				mocks.GitHubResponse(http.StatusOK, `{"id": 101, "number": 42}`),
 				updatedPullRequestResponse(),
 			},
@@ -569,13 +575,14 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		requestBody := readJSONBody(t, httpCtx.Requests[0])
+		requestBody := readJSONBody(t, httpCtx.Requests[1])
 		assert.Equal(t, []any{"octocat"}, requestBody["assignees"])
 	})
 
 	t.Run("labels toggled on with an empty list clears all labels", func(t *testing.T) {
 		httpCtx := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				updatedPullRequestResponse(),
 				mocks.GitHubResponse(http.StatusOK, `{"id": 101, "number": 42, "labels": []}`),
 				updatedPullRequestResponse(),
 			},
@@ -593,7 +600,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		requestBody := readJSONBody(t, httpCtx.Requests[0])
+		requestBody := readJSONBody(t, httpCtx.Requests[1])
 		assert.Equal(t, []any{}, requestBody["labels"])
 	})
 
@@ -625,6 +632,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 	t.Run("only calls the Issues API when title, body, state, and base are not toggled on", func(t *testing.T) {
 		httpCtx := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				updatedPullRequestResponse(),
 				mocks.GitHubResponse(http.StatusOK, `{"id": 101, "number": 42}`),
 				updatedPullRequestResponse(),
 			},
@@ -642,9 +650,10 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Len(t, httpCtx.Requests, 2)
-		assert.Equal(t, "/repos/testhq/hello/issues/42", httpCtx.Requests[0].URL.Path)
-		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[1].URL.Path)
+		require.Len(t, httpCtx.Requests, 3)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[0].URL.Path)
+		assert.Equal(t, "/repos/testhq/hello/issues/42", httpCtx.Requests[1].URL.Path)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[2].URL.Path)
 	})
 
 	t.Run("fails when the Pulls API returns an error", func(t *testing.T) {
@@ -672,6 +681,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 	t.Run("fails when the Issues API returns an error", func(t *testing.T) {
 		httpCtx := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				updatedPullRequestResponse(),
 				mocks.GitHubResponse(http.StatusUnprocessableEntity, `{"message": "Validation Failed"}`),
 			},
 		}
@@ -689,6 +699,30 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 
 		require.ErrorContains(t, err, "failed to update pull request labels/assignees")
 		require.ErrorContains(t, err, "Validation Failed")
+	})
+
+	t.Run("fails without mutating the issue when pullNumber is not a pull request", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusNotFound, `{"message": "Not Found"}`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"labels":     []string{"bug"},
+			},
+		})
+
+		require.ErrorContains(t, err, "failed to get pull request")
+		require.ErrorContains(t, err, "Not Found")
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[0].URL.Path)
 	})
 
 	t.Run("fails when the pull request cannot be re-fetched", func(t *testing.T) {

--- a/pkg/integrations/github/components/pulls/update_pull_request_test.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request_test.go
@@ -464,6 +464,47 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		assert.Equal(t, http.MethodGet, getRequest.Method)
 	})
 
+	t.Run("reopening and retargeting together reopens before the retarget", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				updatedPullRequestResponse(),
+				updatedPullRequestResponse(),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"base":       "release",
+				"state":      "open",
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 3)
+
+		stateRequest := httpCtx.Requests[0]
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", stateRequest.URL.Path)
+		stateBody := readJSONBody(t, stateRequest)
+		assert.Equal(t, "open", stateBody["state"])
+		assert.NotContains(t, stateBody, "base")
+
+		baseRequest := httpCtx.Requests[1]
+		assert.Equal(t, "/repos/testhq/hello/pulls/42", baseRequest.URL.Path)
+		baseBody := readJSONBody(t, baseRequest)
+		assert.Equal(t, "release", baseBody["base"])
+		assert.NotContains(t, baseBody, "state")
+
+		getRequest := httpCtx.Requests[2]
+		assert.Equal(t, http.MethodGet, getRequest.Method)
+	})
+
 	t.Run("updates labels and assignees through the Issues API", func(t *testing.T) {
 		executionState := &contexts.ExecutionStateContext{}
 		httpCtx := &contexts.HTTPContext{

--- a/pkg/integrations/github/components/pulls/update_pull_request_test.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request_test.go
@@ -68,7 +68,7 @@ func Test__UpdatePullRequest__Setup(t *testing.T) {
 		require.ErrorContains(t, err, "pull request number must be a positive integer")
 	})
 
-	t.Run("state must be open or closed", func(t *testing.T) {
+	t.Run("state toggled on must be open or closed", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Integration:   &contexts.IntegrationContext{},
 			Metadata:      &contexts.MetadataContext{},
@@ -78,7 +78,21 @@ func Test__UpdatePullRequest__Setup(t *testing.T) {
 		require.ErrorContains(t, err, "state must be one of: open, closed")
 	})
 
-	t.Run("at least one field to update is required", func(t *testing.T) {
+	t.Run("state toggled on with an empty value is rejected", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"state":      "",
+			},
+		})
+
+		require.ErrorContains(t, err, "state must be one of: open, closed")
+	})
+
+	t.Run("no field toggled on is rejected", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Integration: &contexts.IntegrationContext{},
 			Metadata:    &contexts.MetadataContext{},
@@ -135,7 +149,7 @@ func Test__UpdatePullRequest__Setup(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("labels alone are a valid configuration", func(t *testing.T) {
+	t.Run("labels toggled on alone are a valid configuration", func(t *testing.T) {
 		httpCtx := &contexts.HTTPContext{
 			Responses: []*http.Response{
 				mocks.GitHubResponse(http.StatusOK, `{
@@ -154,6 +168,31 @@ func Test__UpdatePullRequest__Setup(t *testing.T) {
 				"repository": "hello",
 				"pullNumber": "42",
 				"labels":     []string{"bug"},
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("labels toggled on with an empty list is a valid configuration", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Integration: mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:        httpCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"labels":     []string{},
 			},
 		})
 
@@ -202,7 +241,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		require.ErrorContains(t, err, "pull request number must be a positive integer")
 	})
 
-	t.Run("state must be open or closed", func(t *testing.T) {
+	t.Run("state toggled on must be open or closed", func(t *testing.T) {
 		err := component.Execute(core.ExecutionContext{
 			Integration:    mocks.IntegrationContextForNewSetupFlow(),
 			ExecutionState: &contexts.ExecutionStateContext{},
@@ -216,7 +255,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		require.ErrorContains(t, err, "state must be one of: open, closed")
 	})
 
-	t.Run("at least one field to update is required", func(t *testing.T) {
+	t.Run("no field toggled on is rejected", func(t *testing.T) {
 		err := component.Execute(core.ExecutionContext{
 			Integration:    mocks.IntegrationContextForNewSetupFlow(),
 			ExecutionState: &contexts.ExecutionStateContext{},
@@ -274,6 +313,30 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		pullRequest := payload["data"].(*github.PullRequest)
 		assert.Equal(t, "Updated title", pullRequest.GetTitle())
 		assert.Equal(t, "closed", pullRequest.GetState())
+	})
+
+	t.Run("body toggled on with an empty value clears the body", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				updatedPullRequestResponse(),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"body":       "",
+			},
+		})
+
+		require.NoError(t, err)
+		requestBody := readJSONBody(t, httpCtx.Requests[0])
+		assert.Equal(t, "", requestBody["body"])
 	})
 
 	t.Run("retargets the base branch through the Pulls API", func(t *testing.T) {
@@ -348,7 +411,31 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		assert.Equal(t, "/repos/testhq/hello/pulls/42", getRequest.URL.Path)
 	})
 
-	t.Run("only calls the Pulls API when no labels or assignees are set", func(t *testing.T) {
+	t.Run("labels toggled on with an empty list clears all labels", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{"id": 101, "number": 42, "labels": []}`),
+				updatedPullRequestResponse(),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"labels":     []string{},
+			},
+		})
+
+		require.NoError(t, err)
+		requestBody := readJSONBody(t, httpCtx.Requests[0])
+		assert.Equal(t, []any{}, requestBody["labels"])
+	})
+
+	t.Run("only calls the Pulls API when labels or assignees are not toggled on", func(t *testing.T) {
 		httpCtx := &contexts.HTTPContext{
 			Responses: []*http.Response{
 				updatedPullRequestResponse(),
@@ -373,7 +460,7 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		assert.Equal(t, "/repos/testhq/hello/pulls/42", httpCtx.Requests[1].URL.Path)
 	})
 
-	t.Run("only calls the Issues API when no title, body, state, or base are set", func(t *testing.T) {
+	t.Run("only calls the Issues API when title, body, state, and base are not toggled on", func(t *testing.T) {
 		httpCtx := &contexts.HTTPContext{
 			Responses: []*http.Response{
 				mocks.GitHubResponse(http.StatusOK, `{"id": 101, "number": 42}`),

--- a/pkg/integrations/github/components/pulls/update_pull_request_test.go
+++ b/pkg/integrations/github/components/pulls/update_pull_request_test.go
@@ -92,6 +92,34 @@ func Test__UpdatePullRequest__Setup(t *testing.T) {
 		require.ErrorContains(t, err, "state must be one of: open, closed")
 	})
 
+	t.Run("title toggled on with an empty value is rejected", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"title":      "",
+			},
+		})
+
+		require.ErrorContains(t, err, "title cannot be empty")
+	})
+
+	t.Run("base toggled on with an empty value is rejected", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"base":       "",
+			},
+		})
+
+		require.ErrorContains(t, err, "base branch cannot be empty")
+	})
+
 	t.Run("no field toggled on is rejected", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Integration: &contexts.IntegrationContext{},
@@ -253,6 +281,34 @@ func Test__UpdatePullRequest__Execute(t *testing.T) {
 		})
 
 		require.ErrorContains(t, err, "state must be one of: open, closed")
+	})
+
+	t.Run("title toggled on with an empty value is rejected", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"title":      "",
+			},
+		})
+
+		require.ErrorContains(t, err, "title cannot be empty")
+	})
+
+	t.Run("base toggled on with an empty value is rejected", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "42",
+				"base":       "",
+			},
+		})
+
+		require.ErrorContains(t, err, "base branch cannot be empty")
 	})
 
 	t.Run("no field toggled on is rejected", func(t *testing.T) {

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -132,6 +132,7 @@ func (g *GitHub) Actions() []core.Action {
 		&pulls.MergePullRequest{},
 		&pulls.MarkPullRequestReadyForReview{},
 		&pulls.AddPullRequestReviewers{},
+		&pulls.UpdatePullRequest{},
 		&pulls.AddReaction{},
 		&statuses.GetCombinedCommitStatus{},
 		&statuses.PublishCommitStatus{},

--- a/web_src/src/pages/app/mappers/github/index.ts
+++ b/web_src/src/pages/app/mappers/github/index.ts
@@ -28,6 +28,7 @@ import { createPullRequestMapper } from "./create_pull_request";
 import { mergePullRequestMapper } from "./merge_pull_request";
 import { markPullRequestReadyForReviewMapper } from "./mark_pull_request_ready_for_review";
 import { addPullRequestReviewersMapper } from "./add_pull_request_reviewers";
+import { updatePullRequestMapper } from "./update_pull_request";
 import { getWorkflowUsageMapper } from "./get_workflow_usage";
 import { labelsMapper } from "./labels";
 import { addReactionMapper } from "./add_reaction";
@@ -47,6 +48,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   mergePullRequest: buildActionStateRegistry("merged"),
   markPullRequestReadyForReview: buildActionStateRegistry("marked ready"),
   addPullRequestReviewers: buildActionStateRegistry("added"),
+  updatePullRequest: buildActionStateRegistry("updated"),
   publishCommitStatus: buildActionStateRegistry("published"),
   createDeployment: buildActionStateRegistry("created"),
   createDeploymentStatus: buildActionStateRegistry("created"),
@@ -76,6 +78,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   mergePullRequest: mergePullRequestMapper,
   markPullRequestReadyForReview: markPullRequestReadyForReviewMapper,
   addPullRequestReviewers: addPullRequestReviewersMapper,
+  updatePullRequest: updatePullRequestMapper,
   runWorkflow: runWorkflowMapper,
   publishCommitStatus: publishCommitStatusMapper,
   createDeployment: createDeploymentMapper,

--- a/web_src/src/pages/app/mappers/github/update_pull_request.spec.ts
+++ b/web_src/src/pages/app/mappers/github/update_pull_request.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { updatePullRequestMapper } from "./update_pull_request";
+
+describe("updatePullRequestMapper", () => {
+  it("shows the updated pull request details", () => {
+    const details = updatePullRequestMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          repository: "hello",
+          pullNumber: "42",
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                number: 42,
+                title: "Updated title",
+                state: "closed",
+                html_url: "https://github.com/testhq/hello/pull/42",
+                base: { ref: "release" },
+                labels: [{ name: "bug" }],
+                assignees: [{ login: "octocat" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Created At": expect.any(String),
+      Repository: "hello",
+      "Pull Request": "#42",
+      "Pull Request URL": "https://github.com/testhq/hello/pull/42",
+      Title: "Updated title",
+      State: "closed",
+      "Base Branch": "release",
+      Labels: "bug",
+      Assignees: "octocat",
+    });
+  });
+
+  it("falls back to a dash when there is no output yet", () => {
+    const details = updatePullRequestMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: { repository: "hello", pullNumber: "42" },
+        outputs: {},
+      }),
+    );
+
+    expect(details).toEqual({
+      "Created At": expect.any(String),
+      Repository: "hello",
+      "Pull Request": "#42",
+      "Pull Request URL": "https://github.com/testhq/hello/pull/42",
+      Title: "-",
+      State: "-",
+      "Base Branch": "-",
+      Labels: "-",
+      Assignees: "-",
+    });
+  });
+
+  it("shows repository and pull request number in node metadata", () => {
+    const context = buildDetailsContext({});
+    const props = updatePullRequestMapper.props({
+      nodes: context.nodes,
+      node: context.node,
+      componentDefinition: {
+        name: "github.updatePullRequest",
+        label: "Update Pull Request",
+        description: "",
+        icon: "github",
+        color: "gray",
+      },
+      lastExecutions: [],
+      currentUser: undefined,
+      actions: { invokeNodeExecutionHook: async () => {} },
+    });
+
+    expect(props.metadata).toEqual([
+      { icon: "book", label: "hello" },
+      { icon: "git-pull-request", label: "#42" },
+    ]);
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Update pull request",
+    componentName: "github.updatePullRequest",
+    isCollapsed: false,
+    configuration: {
+      repository: "hello",
+      pullNumber: "42",
+    },
+    metadata: {
+      repository: {
+        id: "123456",
+        name: "hello",
+        url: "https://github.com/testhq/hello",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/github/update_pull_request.ts
+++ b/web_src/src/pages/app/mappers/github/update_pull_request.ts
@@ -1,0 +1,129 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { stringOrDash } from "../utils";
+import { baseProps } from "./base";
+import type { BaseNodeMetadata } from "./types";
+import { buildGithubExecutionSubtitle } from "./utils";
+
+interface UpdatePullRequestConfiguration {
+  repository?: string;
+  pullNumber?: string | number;
+}
+
+interface PullRequestOutput {
+  number?: number;
+  title?: string;
+  state?: string;
+  html_url?: string;
+  base?: {
+    ref?: string;
+  };
+  labels?: { name: string }[];
+  assignees?: { login: string }[];
+}
+
+export const updatePullRequestMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as UpdatePullRequestConfiguration | undefined) ?? {};
+    const metadata = (context.node.metadata as BaseNodeMetadata | undefined) ?? ({} as BaseNodeMetadata);
+
+    const repository = metadata?.repository?.name || configuration.repository;
+    const metadataItems: MetadataItem[] = [];
+
+    if (repository) {
+      metadataItems.push({ icon: "book", label: repository });
+    }
+
+    if (configuration.pullNumber !== undefined && configuration.pullNumber !== "") {
+      metadataItems.push({ icon: "git-pull-request", label: formatPullRequestNumber(configuration.pullNumber) });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGithubExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const configuration = updatePullRequestConfiguration(context);
+    const pullRequest = updatePullRequestOutput(context);
+    const repositoryURL = repositoryUrl(context);
+    const pullNumber = configuration.pullNumber ?? pullRequest?.number;
+
+    return {
+      "Created At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+      Repository: stringOrDash(configuration.repository || repositoryName(context)),
+      "Pull Request": formatPullRequestNumber(pullNumber),
+      "Pull Request URL": stringOrDash(pullRequest?.html_url || pullRequestUrl(repositoryURL, pullNumber)),
+      Title: stringOrDash(pullRequest?.title),
+      State: stringOrDash(pullRequest?.state),
+      "Base Branch": stringOrDash(pullRequest?.base?.ref),
+      Labels: formatList(pullRequest?.labels?.map((label) => label.name)),
+      Assignees: formatList(pullRequest?.assignees?.map((assignee) => assignee.login)),
+    };
+  },
+};
+
+function updatePullRequestConfiguration(context: ExecutionDetailsContext): UpdatePullRequestConfiguration {
+  return (
+    ((context.execution.configuration || context.node.configuration || {}) as
+      | UpdatePullRequestConfiguration
+      | undefined) || {}
+  );
+}
+
+function updatePullRequestOutput(context: ExecutionDetailsContext): PullRequestOutput | undefined {
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  return outputs?.default?.[0]?.data as PullRequestOutput | undefined;
+}
+
+function repositoryName(context: ExecutionDetailsContext): string | undefined {
+  const metadata = context.node.metadata as BaseNodeMetadata | undefined;
+  return metadata?.repository?.name;
+}
+
+function repositoryUrl(context: ExecutionDetailsContext): string | undefined {
+  const metadata = context.node.metadata as BaseNodeMetadata | undefined;
+  return metadata?.repository?.url;
+}
+
+function formatPullRequestNumber(value: string | number | undefined): string {
+  if (value === undefined || value === "") {
+    return "-";
+  }
+
+  const text = String(value);
+  return text.startsWith("#") ? text : `#${text}`;
+}
+
+function pullRequestUrl(
+  repositoryURL: string | undefined,
+  pullNumber: string | number | undefined,
+): string | undefined {
+  if (!repositoryURL || pullNumber === undefined || pullNumber === "") {
+    return undefined;
+  }
+
+  return `${repositoryURL}/pull/${String(pullNumber).replace(/^#/, "")}`;
+}
+
+function formatList(values: string[] | undefined): string {
+  if (!values || values.length === 0) {
+    return "-";
+  }
+
+  return values.join(", ");
+}


### PR DESCRIPTION
Resolves: #6244

## What changed

Added a new GitHub action component, `github.updatePullRequest`, plus its frontend node mapper:

- **`github.updatePullRequest`** (Update Pull Request) — updates a pull request's title, body, state, base branch, labels, or assignees. 

## Why

There was no clear way to update a pull request from a workflow without reaching for `Update Issue`, which technically works (GitHub models a PR on its underlying issue) but is confusing to find and use for PR-specific changes like retargeting a base branch. `github.updatePullRequest` gives automations a dedicated action to retitle/rebody, open/close, retarget, or replace labels/assignees on a PR, matching the existing `github.mergePullRequest` / `github.markPullRequestReadyForReview` naming and config conventions.

## How

### Backend

Extended `pkg/integrations/github/`:

- `components/pulls/update_pull_request.go` — `github.updatePullRequest` action. Config: `repository`, `pullNumber` (required); `title`, `body`, `state` (open/closed), `base` (branch resource), `assignees`, `labels`
- `common/client.go` — added the `EditPullRequest` wrapper around the Pulls API.
- `capability_mapper.go` / `github.go` — registered the new action under the existing `PermissionPullRequests` permission.
- `components/pulls/example.go` + new `payloads/update_pull_request.json` fixture.
- `docs/components/GitHub.mdx` regenerated via `make gen.components.docs`.

Added backend tests covering Setup/Execute validation, the Pulls-API-only vs. Issues-API-only call paths, error propagation from both APIs, and the togglable "empty value clears the field" behavior (`update_pull_request_test.go`).

### Frontend

Added `web_src/src/pages/app/mappers/github/update_pull_request.ts` + spec, registered in `mappers/github/index.ts`. The node shows the repository and pull request number as a metadata badge (so it's visible before the node has ever run), and surfaces title/state/base branch/labels/assignees as execution details after it runs — mirroring `merge_pull_request.ts` / `mark_pull_request_ready_for_review.ts` for execution details and GitLab's `accept_merge_request.ts` / `approve_merge_request.ts` for the node metadata badge.

## Config page
<img width="1693" height="851" alt="image" src="https://github.com/user-attachments/assets/e849cfa0-187e-4b87-9b8b-29dc312f2b5f" />
