### PR TITLE
fix: include runner task error in finished payload

### DIFF
--- a/pkg/components/runner/run_bash_test.go
+++ b/pkg/components/runner/run_bash_test.go
@@ -149,3 +149,23 @@ func TestRunBashProcessTaskStatusIncludesResult(t *testing.T) {
 	wrapped := state.Payloads[0].(map[string]any)
 	assert.Equal(t, RunBashFinishedEventType, wrapped["type"])
 }
+
+func TestRunBashProcessTaskStatusIncludesError(t *testing.T) {
+	t.Parallel()
+
+	state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	exit := 1
+	task := &Task{
+		Status:   "failed",
+		ExitCode: &exit,
+		Error:    "runner lost before completion",
+	}
+	require.NoError(t, processBrokerTaskStatus(state, task, RunBashFinishedEventType))
+	require.Equal(t, FailedOutputChannel, state.Channel)
+
+	wrapped := state.Payloads[0].(map[string]any)
+	data := wrapped["data"].(map[string]any)
+	assert.Equal(t, "failed", data["status"])
+	assert.Equal(t, 1, data["exit_code"])
+	assert.Equal(t, "runner lost before completion", data["error"])
+}

--- a/pkg/components/runner/runner_task_lifecycle.go
+++ b/pkg/components/runner/runner_task_lifecycle.go
@@ -110,6 +110,9 @@ func processBrokerTaskStatus(state core.ExecutionStateContext, task *Task, finis
 	}
 
 	out := map[string]any{"status": task.Status, "exit_code": task.effectiveExitCode()}
+	if errMsg := strings.TrimSpace(task.Error); errMsg != "" {
+		out["error"] = errMsg
+	}
 	if v := brokerResultAsAny(task.Result); v != nil {
 		out["result"] = v
 	}


### PR DESCRIPTION
## Summary
- include broker task `error` in runner finished event payloads when present
- keep `status` and `exit_code` unchanged for compatibility
- add coverage for runnerBash failed output carrying `runner lost before completion`

## Test Plan
- go test ./pkg/components/runner