### PR TITLE
fix: finalize terminal runner log sections

### DIFF
--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.spec.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.spec.tsx
@@ -6,6 +6,8 @@ import { LiveLogStreamView } from "./LiveLogStreamView";
 const useLiveLogStreamMock = vi.fn();
 
 vi.mock("./useLiveLogStream", () => ({
+  terminalCommandStatusForExecution: vi.fn(() => null),
+  terminalTimeMsForExecution: vi.fn(() => null),
   useLiveLogStream: (...args: unknown[]) => useLiveLogStreamMock(...args),
 }));
 

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
@@ -3,13 +3,15 @@ import { useEffect, useState } from "react";
 import { cn } from "../../../lib/utils";
 import type { ExecutionInfo } from "../../../pages/app/mappers/types";
 import { isExecutionInFlight, type CommandSection } from "./types";
-import { useLiveLogStream } from "./useLiveLogStream";
+import { terminalCommandStatusForExecution, terminalTimeMsForExecution, useLiveLogStream } from "./useLiveLogStream";
 
 export function LiveLogStreamView({ execution }: { execution: ExecutionInfo }) {
   const executionInFlight = isExecutionInFlight(execution);
   const { sections, orphanLines, error, isStreaming, toggleSection, scrollRef } = useLiveLogStream(
     execution.id,
     executionInFlight,
+    terminalCommandStatusForExecution(execution),
+    terminalTimeMsForExecution(execution),
   );
   const hasAnyLogs = orphanLines.length > 0 || sections.length > 0;
   const lastSectionIndex = sections.length - 1;

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import type { ExecutionInfo } from "../../../pages/app/mappers/types";
+import { isExecutionInFlight } from "./types";
+
+function execution(state: ExecutionInfo["state"]): ExecutionInfo {
+  return {
+    id: "execution-1",
+    createdAt: "2026-07-22T15:46:48.000Z",
+    updatedAt: "2026-07-22T15:54:58.000Z",
+    state,
+    result: "RESULT_UNKNOWN",
+    resultReason: "RESULT_REASON_ERROR",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+  } as ExecutionInfo;
+}
+
+describe("runner live log execution state", () => {
+  it("treats pending, started, and cancelling executions as log-active", () => {
+    expect(isExecutionInFlight(execution("STATE_PENDING"))).toBe(true);
+    expect(isExecutionInFlight(execution("STATE_STARTED"))).toBe(true);
+    expect(isExecutionInFlight(execution("STATE_CANCELLING"))).toBe(true);
+  });
+
+  it("treats finished executions as no longer in flight", () => {
+    expect(isExecutionInFlight(execution("STATE_FINISHED"))).toBe(false);
+  });
+});

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
@@ -7,7 +7,9 @@ export type RunnerLiveLogDialogProps = {
 };
 
 export function isExecutionInFlight(execution: ExecutionInfo): boolean {
-  return execution.state === "STATE_PENDING" || execution.state === "STATE_STARTED";
+  return (
+    execution.state === "STATE_PENDING" || execution.state === "STATE_STARTED" || execution.state === "STATE_CANCELLING"
+  );
 }
 
 export type LiveLogRecord =

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { ExecutionInfo } from "../../../pages/app/mappers/types";
+import type { LogState } from "./types";
+import {
+  finalizeRunningCommandSections,
+  terminalCommandStatusForExecution,
+  terminalTimeMsForExecution,
+} from "./useLiveLogStream";
+
+function baseLogState(): LogState {
+  return {
+    sections: [
+      {
+        index: 0,
+        text: "completed",
+        lines: [],
+        status: "passed",
+        duration_ms: 100,
+        started_at: 1_000,
+        collapsed: true,
+      },
+      {
+        index: 1,
+        text: "Set up DevEnv",
+        lines: ["docker compose up"],
+        status: "running",
+        duration_ms: null,
+        started_at: 2_000,
+        collapsed: false,
+      },
+    ],
+    orphanLines: [],
+    error: null,
+    isStreaming: false,
+  };
+}
+
+function execution(overrides: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "execution-1",
+    createdAt: "2026-07-22T15:46:48.000Z",
+    updatedAt: "2026-07-22T15:54:58.000Z",
+    state: "STATE_FINISHED",
+    result: "RESULT_FAILED",
+    resultReason: "RESULT_REASON_ERROR",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  } as ExecutionInfo;
+}
+
+describe("runner live log state", () => {
+  it("finalizes unfinished command sections when a terminal execution failed", () => {
+    const finalized = finalizeRunningCommandSections(baseLogState(), "failed", 5_000);
+
+    expect(finalized.sections[0]).toMatchObject({ status: "passed", duration_ms: 100 });
+    expect(finalized.sections[1]).toMatchObject({
+      status: "failed",
+      duration_ms: 3_000,
+      collapsed: false,
+    });
+  });
+
+  it("collapses unfinished command sections when a terminal execution passed", () => {
+    const finalized = finalizeRunningCommandSections(baseLogState(), "passed", 5_000);
+
+    expect(finalized.sections[1]).toMatchObject({
+      status: "passed",
+      duration_ms: 3_000,
+      collapsed: true,
+    });
+  });
+
+  it("maps terminal execution result to command status", () => {
+    expect(terminalCommandStatusForExecution(execution({ result: "RESULT_PASSED" }))).toBe("passed");
+    expect(terminalCommandStatusForExecution(execution({ result: "RESULT_FAILED" }))).toBe("failed");
+    expect(terminalCommandStatusForExecution(execution({ result: "RESULT_CANCELLED" }))).toBe("failed");
+    expect(
+      terminalCommandStatusForExecution(execution({ state: "STATE_STARTED", result: "RESULT_UNKNOWN" })),
+    ).toBeNull();
+  });
+
+  it("uses the execution update time as the terminal command timestamp", () => {
+    expect(terminalTimeMsForExecution(execution({ updatedAt: "2026-07-22T15:54:58.000Z" }))).toBe(
+      Date.parse("2026-07-22T15:54:58.000Z"),
+    );
+  });
+
+  it("does not expose a terminal command timestamp while execution is in flight", () => {
+    expect(
+      terminalTimeMsForExecution(
+        execution({
+          state: "STATE_CANCELLING",
+          result: "RESULT_UNKNOWN",
+          updatedAt: "2026-07-22T15:54:58.000Z",
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -1,9 +1,10 @@
 import { useCanvasId } from "@/hooks/useCanvasId";
 import { useOrganizationId } from "@/hooks/useOrganizationId";
-import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from "react";
 import { LiveLogStream, type LiveLogStreamHandlers } from "./liveLogStream";
 import type { CommandSection, LogState } from "./types";
 import { useScrollToBottom } from "./useScrollToBottom";
+import type { ExecutionInfo } from "../../../pages/app/mappers/types";
 
 const RECONNECT_DELAY_MS = 2000;
 
@@ -16,6 +17,58 @@ const initialLogState: LogState = {
 
 function hasRunningCommand(state: LogState): boolean {
   return state.sections.some((section) => section.status === "running");
+}
+
+export function terminalCommandStatusForExecution(execution: ExecutionInfo): "passed" | "failed" | null {
+  if (execution.state !== "STATE_FINISHED") {
+    return null;
+  }
+
+  return execution.result === "RESULT_PASSED" ? "passed" : "failed";
+}
+
+export function terminalTimeMsForExecution(execution: ExecutionInfo): number | null {
+  if (execution.state !== "STATE_FINISHED") {
+    return null;
+  }
+
+  const timestamp = execution.updatedAt || execution.createdAt;
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function finalizeRunningCommandSections(
+  state: LogState,
+  status: "passed" | "failed",
+  endedAtMs: number | null,
+): LogState {
+  if (!hasRunningCommand(state)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    sections: state.sections.map((section) => {
+      if (section.status !== "running") {
+        return section;
+      }
+
+      return {
+        ...section,
+        status,
+        duration_ms: commandSectionFinalDuration(section, endedAtMs),
+        collapsed: status === "passed",
+      };
+    }),
+  };
+}
+
+function commandSectionFinalDuration(section: CommandSection, endedAtMs: number | null): number {
+  if (section.started_at === null || endedAtMs === null) {
+    return section.duration_ms ?? 0;
+  }
+
+  return Math.max(0, endedAtMs - section.started_at);
 }
 
 function applyStreamFailure(state: LogState, message: string, executionInFlight: boolean): LogState {
@@ -165,8 +218,9 @@ type LiveLogSessionParams = {
   canvasId: string;
   executionId: string;
   executionInFlight: boolean;
+  terminalCommandStatus: "passed" | "failed" | null;
+  terminalAtMs: number | null;
   sessionAbort: AbortController;
-  stateRef: { current: LogState };
   setState: Dispatch<SetStateAction<LogState>>;
   setActiveStream: (stream: LiveLogStream | null) => void;
 };
@@ -176,8 +230,9 @@ async function runLiveLogSession({
   canvasId,
   executionId,
   executionInFlight,
+  terminalCommandStatus,
+  terminalAtMs,
   sessionAbort,
-  stateRef,
   setState,
   setActiveStream,
 }: LiveLogSessionParams): Promise<void> {
@@ -206,7 +261,10 @@ async function runLiveLogSession({
       return;
     }
 
-    if (!executionInFlight && !hasRunningCommand(stateRef.current)) {
+    if (!executionInFlight) {
+      if (terminalCommandStatus) {
+        setState((prev) => finalizeRunningCommandSections(prev, terminalCommandStatus, terminalAtMs));
+      }
       return;
     }
 
@@ -226,12 +284,15 @@ async function runLiveLogSession({
   }
 }
 
-export function useLiveLogStream(executionId: string, executionInFlight: boolean) {
+export function useLiveLogStream(
+  executionId: string,
+  executionInFlight: boolean,
+  terminalCommandStatus: "passed" | "failed" | null,
+  terminalAtMs: number | null,
+) {
   const organizationId = useOrganizationId();
   const canvasId = useCanvasId();
   const [state, setState] = useState<LogState>(() => ({ ...initialLogState, isStreaming: true }));
-  const stateRef = useRef(state);
-  stateRef.current = state;
 
   const scrollTrigger = useMemo(() => {
     const lineCount = state.sections.reduce((count, section) => count + section.lines.length, 0);
@@ -270,8 +331,9 @@ export function useLiveLogStream(executionId: string, executionInFlight: boolean
       canvasId,
       executionId,
       executionInFlight,
+      terminalCommandStatus,
+      terminalAtMs,
       sessionAbort,
-      stateRef,
       setState,
       setActiveStream: (stream) => {
         activeStream = stream;
@@ -286,7 +348,7 @@ export function useLiveLogStream(executionId: string, executionInFlight: boolean
       sessionAbort.abort();
       activeStream?.stop();
     };
-  }, [organizationId, canvasId, executionId, executionInFlight]);
+  }, [organizationId, canvasId, executionId, executionInFlight, terminalCommandStatus, terminalAtMs]);
 
   return { ...state, toggleSection, scrollRef };
 }

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CanvasesCanvasNodeExecution } from "@/api-client";
+import type * as LiveLogStreamModule from "@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream";
 import { renderInspector, runnerExecution, runnerNode, workflowNodes } from "./RunInspectorPanel.spec.fixtures";
 
 let mockedExecutions: CanvasesCanvasNodeExecution[] = [runnerExecution];
@@ -21,7 +22,8 @@ vi.mock("@/hooks/useMe", () => ({
   useMe: () => ({ data: null }),
 }));
 
-vi.mock("@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream", () => ({
+vi.mock("@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream", async (importOriginal) => ({
+  ...(await importOriginal<typeof LiveLogStreamModule>()),
   useLiveLogStream: (...args: unknown[]) => useLiveLogStreamMock(...args),
 }));
 
@@ -69,7 +71,12 @@ describe("RunInspector runner logs", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Logs.*Run Bash/i }));
 
-    expect(useLiveLogStreamMock).toHaveBeenCalledWith("execution-runner-1", false);
+    expect(useLiveLogStreamMock).toHaveBeenCalledWith(
+      "execution-runner-1",
+      false,
+      "passed",
+      Date.parse("2026-05-01T12:00:55Z"),
+    );
     expect(screen.getByText(/\$ npm run build/)).toBeInTheDocument();
     expect(screen.getByText(/vite build/)).toBeInTheDocument();
     expect(JSON.parse(localStorage.getItem("superplane.runInspector.internalAccordions") || "{}")).toMatchObject({

--- a/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
+++ b/web_src/src/ui/Runs/RunInspectorRunnerLogs.tsx
@@ -1,7 +1,11 @@
 import type { CanvasesCanvasNodeExecution } from "@/api-client";
 import { buildExecutionInfo } from "@/pages/app/utils";
 import { isExecutionInFlight } from "@/ui/CanvasPage/RunnerLiveLogDialog/types";
-import { useLiveLogStream } from "@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream";
+import {
+  terminalCommandStatusForExecution,
+  terminalTimeMsForExecution,
+  useLiveLogStream,
+} from "@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream";
 import { EmptySectionText, TimelineAccordionCard } from "./RunInspectorTimelineCard";
 import type { StatusPill } from "./RunInspectorTimelineTypes";
 import type { RunInspectorNodeSection } from "./types";
@@ -38,6 +42,8 @@ function RunnerLogsTerminal({ execution }: { execution: CanvasesCanvasNodeExecut
   const { sections, orphanLines, error, isStreaming, scrollRef } = useLiveLogStream(
     executionInfo.id,
     executionInFlight,
+    terminalCommandStatusForExecution(executionInfo),
+    terminalTimeMsForExecution(executionInfo),
   );
   const lines = runnerLogLines(orphanLines, sections);
   const isWaiting = lines.length === 0 && !error && (executionInFlight || isStreaming);


### PR DESCRIPTION
## Summary
- finalize unfinished runner log command sections when the execution is already terminal
- stop terminal log durations at the execution update timestamp instead of continuing to tick from browser time
- apply the same terminal log handling in the runner log dialog and run inspector logs

## Why
A failed runner task can end without a matching cmd_end record in the task log stream. The UI was reconstructing that open command as RUNNING forever whenever logs were opened, even though the broker task and EC2 runner were already terminal.

## Verification
- npm test -- --run src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.spec.ts
- make format.js
- make check.build.ui
- git diff --check