### PR TITLE
fix: ship Claude Code bash steps as raw user commands

### DIFF
--- a/pkg/components/runner/claude/component.go
+++ b/pkg/components/runner/claude/component.go
@@ -64,7 +64,7 @@ func (c *RunClaudeCode) Documentation() string {
 ## Steps
 Configure an ordered list of **bash** and **prompt** steps:
 
-- **bash** — shell commands (clone a repo, install deps, run tests, push).
+- **bash** — shell commands sourced on the runner (clone a repo, install deps, run tests, push). A failing command stops that step; later steps are skipped.
 - **prompt** — a Claude Code turn. Later prompts continue the same session.
 
 Example:

--- a/pkg/components/runner/claude/component.go
+++ b/pkg/components/runner/claude/component.go
@@ -64,7 +64,7 @@ func (c *RunClaudeCode) Documentation() string {
 ## Steps
 Configure an ordered list of **bash** and **prompt** steps:
 
-- **bash** — shell commands sourced on the runner (clone a repo, install deps, run tests, push). A failing command stops that step; later steps are skipped.
+- **bash** — shell commands (clone a repo, install deps, run tests, push).
 - **prompt** — a Claude Code turn. Later prompts continue the same session.
 
 Example:

--- a/pkg/components/runner/claude/component_test.go
+++ b/pkg/components/runner/claude/component_test.go
@@ -105,10 +105,10 @@ func TestRunClaudeCodeExecuteSendsPerStepCommandsToBroker(t *testing.T) {
 	require.Len(t, req.Files, 6)
 	assert.Equal(t, runScript, requireTaskFile(t, req.Files, "run.js").Content)
 	assert.Contains(t, requireTaskFile(t, req.Files, "prepare.sh").Content, "cd '/tmp'")
-	assert.Equal(t, buildClaudeBashStepScript("git clone https://github.com/acme/widgets.git /tmp/repo"), requireTaskFile(t, req.Files, "steps/01-clone.sh").Content)
+	assert.Equal(t, "git clone https://github.com/acme/widgets.git /tmp/repo", requireTaskFile(t, req.Files, "steps/01-clone.sh").Content)
 	assert.Equal(t, "Fix the failing tests", requireTaskFile(t, req.Files, "prompts/02-fix-tests.txt").Content)
 	assert.Equal(t, "Open a pull request", requireTaskFile(t, req.Files, "prompts/03-open-pr.txt").Content)
-	assert.Equal(t, buildClaudeBashStepScript("git -C /tmp/repo status"), requireTaskFile(t, req.Files, "steps/04-status.sh").Content)
+	assert.Equal(t, "git -C /tmp/repo status", requireTaskFile(t, req.Files, "steps/04-status.sh").Content)
 }
 
 func TestRunClaudeCodeExecuteMigratesLegacyPromptConfig(t *testing.T) {
@@ -164,9 +164,9 @@ func TestRunClaudeCodeExecuteMigratesLegacyPromptConfig(t *testing.T) {
 	}, req.Commands[2])
 	assert.Equal(t, runner.BrokerCommand{Name: "After", Command: `source "$SUPERPLANE_TASK_DIR/steps/03-after.sh"`}, req.Commands[3])
 	require.Len(t, req.Files, 5)
-	assert.Equal(t, buildClaudeBashStepScript("git clone https://github.com/acme/widgets.git /tmp/repo"), requireTaskFile(t, req.Files, "steps/01-setup.sh").Content)
+	assert.Equal(t, "git clone https://github.com/acme/widgets.git /tmp/repo", requireTaskFile(t, req.Files, "steps/01-setup.sh").Content)
 	assert.Equal(t, "implement the issue", requireTaskFile(t, req.Files, "prompts/02-prompt.txt").Content)
-	assert.Equal(t, buildClaudeBashStepScript("git push"), requireTaskFile(t, req.Files, "steps/03-after.sh").Content)
+	assert.Equal(t, "git push", requireTaskFile(t, req.Files, "steps/03-after.sh").Content)
 }
 
 func TestRunClaudeCodeExecuteRequiresAPIKeySecret(t *testing.T) {

--- a/pkg/components/runner/claude/spec.go
+++ b/pkg/components/runner/claude/spec.go
@@ -202,7 +202,7 @@ func buildClaudeCodeStep(stepNumber int, step ClaudeCodeStep, model string) (run
 		scriptName := stepSlug + ".sh"
 		return runner.BrokerTaskFile{
 			Path:    "steps/" + scriptName,
-			Content: buildClaudeBashStepScript(command),
+			Content: command,
 			Mode:    "0644",
 		}, claudeBashStepBrokerCommand(step.Name, scriptName)
 	default:
@@ -220,8 +220,6 @@ func buildClaudeCodeStep(stepNumber int, step ClaudeCodeStep, model string) (run
 }
 
 func claudePrepareScript(workdir string) string {
-	// Safe with set -e: the host runner wraps sourced command_list scripts so
-	// errexit cannot kill the shared PTY before the end marker.
 	var prepare strings.Builder
 	prepare.WriteString("set -euo pipefail\n")
 	prepare.WriteString(": \"${SUPERPLANE_TASK_DIR:?SUPERPLANE_TASK_DIR is required}\"\n")
@@ -242,12 +240,6 @@ func claudePrepareScript(workdir string) string {
 	prepare.WriteString("echo \"node=$(node --version 2>/dev/null)\"\n")
 	prepare.WriteString("echo \"cwd=$(pwd -P)\"\n")
 	return prepare.String()
-}
-
-func buildClaudeBashStepScript(command string) string {
-	// Ship the user command unchanged. Fail-fast and PTY end-marker safety are
-	// owned by the host runner's sourced-script wrap, not by this component.
-	return strings.TrimRight(command, "\n") + "\n"
 }
 
 func claudeBashStepBrokerCommand(stepName, scriptName string) runner.BrokerCommand {
@@ -281,10 +273,6 @@ func claudeStepSlug(stepNumber int, name string) string {
 		slug = "step"
 	}
 	return fmt.Sprintf("%02d-%s", stepNumber, slug)
-}
-
-func claudeStepScriptName(stepNumber int, name string) string {
-	return claudeStepSlug(stepNumber, name) + ".sh"
 }
 
 func slugifyClaudeStepName(name string) string {

--- a/pkg/components/runner/claude/spec.go
+++ b/pkg/components/runner/claude/spec.go
@@ -220,6 +220,8 @@ func buildClaudeCodeStep(stepNumber int, step ClaudeCodeStep, model string) (run
 }
 
 func claudePrepareScript(workdir string) string {
+	// Safe with set -e: the host runner wraps sourced command_list scripts so
+	// errexit cannot kill the shared PTY before the end marker.
 	var prepare strings.Builder
 	prepare.WriteString("set -euo pipefail\n")
 	prepare.WriteString(": \"${SUPERPLANE_TASK_DIR:?SUPERPLANE_TASK_DIR is required}\"\n")
@@ -243,11 +245,9 @@ func claudePrepareScript(workdir string) string {
 }
 
 func buildClaudeBashStepScript(command string) string {
-	var b strings.Builder
-	b.WriteString("set -euo pipefail\n")
-	b.WriteString(strings.TrimRight(command, "\n"))
-	b.WriteString("\n")
-	return b.String()
+	// Ship the user command unchanged. Fail-fast and PTY end-marker safety are
+	// owned by the host runner's sourced-script wrap, not by this component.
+	return strings.TrimRight(command, "\n") + "\n"
 }
 
 func claudeBashStepBrokerCommand(stepName, scriptName string) runner.BrokerCommand {

--- a/pkg/components/runner/claude/spec_test.go
+++ b/pkg/components/runner/claude/spec_test.go
@@ -133,9 +133,9 @@ func TestBuildClaudeCodeBrokerTaskRunsOrderedSteps(t *testing.T) {
 	assert.Contains(t, prepare, "node --version")
 
 	cloneScript := requireTaskFile(t, task.Files, "steps/01-clone-repo.sh").Content
-	assert.Equal(t, buildClaudeBashStepScript("git clone https://github.com/acme/widgets.git repo"), cloneScript)
-	assert.Contains(t, cloneScript, "git clone https://github.com/acme/widgets.git repo\n")
+	assert.Equal(t, "git clone https://github.com/acme/widgets.git repo\n", cloneScript)
 	assert.NotContains(t, cloneScript, "workdir")
+	assert.Contains(t, prepare, "set -euo pipefail\n")
 
 	assert.Equal(t, "Fix auth.py's nil panic", requireTaskFile(t, task.Files, "prompts/02-fix-panic.txt").Content)
 	assert.Equal(t, "Run the tests and fix failures", requireTaskFile(t, task.Files, "prompts/03-fix-tests.txt").Content)
@@ -146,6 +146,13 @@ func TestBuildClaudeCodeBrokerTaskRunsOrderedSteps(t *testing.T) {
 	assert.Contains(t, runScript, "--continue")
 	assert.Contains(t, runScript, "SUPERPLANE_RESULT_FILE")
 	assert.NotContains(t, runScript, "workdir")
+}
+
+func TestBuildClaudeBashStepScriptIsRawUserCommand(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "git clone repo\n", buildClaudeBashStepScript("git clone repo"))
+	assert.Equal(t, "false\necho still\n", buildClaudeBashStepScript("false\necho still\n"))
 }
 
 func TestClaudeStepScriptName(t *testing.T) {

--- a/pkg/components/runner/claude/spec_test.go
+++ b/pkg/components/runner/claude/spec_test.go
@@ -132,10 +132,7 @@ func TestBuildClaudeCodeBrokerTaskRunsOrderedSteps(t *testing.T) {
 	assert.Contains(t, prepare, "claude --version")
 	assert.Contains(t, prepare, "node --version")
 
-	cloneScript := requireTaskFile(t, task.Files, "steps/01-clone-repo.sh").Content
-	assert.Equal(t, "git clone https://github.com/acme/widgets.git repo\n", cloneScript)
-	assert.NotContains(t, cloneScript, "workdir")
-	assert.Contains(t, prepare, "set -euo pipefail\n")
+	assert.Equal(t, "git clone https://github.com/acme/widgets.git repo", requireTaskFile(t, task.Files, "steps/01-clone-repo.sh").Content)
 
 	assert.Equal(t, "Fix auth.py's nil panic", requireTaskFile(t, task.Files, "prompts/02-fix-panic.txt").Content)
 	assert.Equal(t, "Run the tests and fix failures", requireTaskFile(t, task.Files, "prompts/03-fix-tests.txt").Content)
@@ -148,19 +145,12 @@ func TestBuildClaudeCodeBrokerTaskRunsOrderedSteps(t *testing.T) {
 	assert.NotContains(t, runScript, "workdir")
 }
 
-func TestBuildClaudeBashStepScriptIsRawUserCommand(t *testing.T) {
+func TestClaudeStepSlug(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "git clone repo\n", buildClaudeBashStepScript("git clone repo"))
-	assert.Equal(t, "false\necho still\n", buildClaudeBashStepScript("false\necho still\n"))
-}
-
-func TestClaudeStepScriptName(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, "01-clone-repo.sh", claudeStepScriptName(1, "Clone repo"))
-	assert.Equal(t, "02-step.sh", claudeStepScriptName(2, "!!!"))
-	assert.Equal(t, "03-step.sh", claudeStepScriptName(3, "   "))
+	assert.Equal(t, "01-clone-repo", claudeStepSlug(1, "Clone repo"))
+	assert.Equal(t, "02-step", claudeStepSlug(2, "!!!"))
+	assert.Equal(t, "03-step", claudeStepSlug(3, "   "))
 }
 
 func TestShellSingleQuote(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stop wrapping Run Claude Code bash steps with `set -euo pipefail`; ship the user command as-is.
- Keep `set -euo pipefail` in `prepare.sh` now that host runners own fail-fast + end-marker-safe sourcing for `command_list`.
- Document that bash fail-fast / later-step skipping comes from the runner wrap.

Depends on the merged runner PTY sourced-script wrap (exit alias + ERR/`return` + Bash 3 sentinel status).

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/components/runner/claude`
- [x] `make lint`
- [ ] Run a Claude Code canvas with a bash step that fails mid-script and confirm later steps are skipped and the task still completes with a non-zero exit (no hung checkout / missing `cmd_end`)


Made with [Cursor](https://cursor.com)