### PR TITLE
fix: improve global command palette dark theme for search results

### DIFF
--- a/web_src/src/components/GlobalCommandPalette/index.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.tsx
@@ -19,7 +19,7 @@ function CommandPaletteDialog({ model }: { model: CommandPaletteModel }) {
       onOpenChange={pageProps.handleOpenChange}
       title="Command Palette"
       description="Search apps, settings, and commands."
-      className="top-[12vh] max-h-[min(760px,80vh)] w-[calc(100vw-2rem)] max-w-3xl translate-y-0 overflow-hidden rounded-xl border border-slate-200 bg-white p-0 shadow-2xl sm:top-[14vh]"
+      className="top-[12vh] max-h-[min(760px,80vh)] w-[calc(100vw-2rem)] max-w-3xl translate-y-0 overflow-hidden rounded-xl border-border bg-popover p-0 text-popover-foreground shadow-2xl sm:top-[14vh]"
       showCloseButton={false}
     >
       <CommandInput

--- a/web_src/src/components/GlobalCommandPalette/items.tsx
+++ b/web_src/src/components/GlobalCommandPalette/items.tsx
@@ -15,17 +15,17 @@ export function ActionItem({ action }: { action: PaletteAction }) {
       disabled={action.disabled}
       onSelect={action.onSelect}
       className={cn(
-        "min-h-14 cursor-pointer rounded-lg border border-transparent px-3 py-2.5 data-[selected=true]:border-slate-200 data-[selected=true]:bg-slate-100",
+        "min-h-14 cursor-pointer rounded-lg border border-transparent px-3 py-2.5 data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground",
         action.disabled && "cursor-not-allowed",
       )}
     >
-      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-slate-100 text-slate-600">
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
         <Icon className="h-4 w-4" />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-medium text-slate-900">{action.label}</span>
+        <span className="block truncate text-sm font-medium text-foreground">{action.label}</span>
         {action.description ? (
-          <span className="block truncate text-xs text-slate-500">{action.description}</span>
+          <span className="block truncate text-xs text-muted-foreground">{action.description}</span>
         ) : null}
       </span>
       {action.shortcut ? <CommandShortcut>{action.shortcut}</CommandShortcut> : null}
@@ -43,20 +43,20 @@ export function PageItem({ action, onSelect }: { action: PalettePageAction; onSe
       disabled={action.disabled}
       onSelect={onSelect}
       className={cn(
-        "min-h-14 cursor-pointer rounded-lg border border-transparent px-3 py-2.5 data-[selected=true]:border-slate-200 data-[selected=true]:bg-slate-100",
+        "min-h-14 cursor-pointer rounded-lg border border-transparent px-3 py-2.5 data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground",
         action.disabled && "cursor-not-allowed",
       )}
     >
-      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-slate-100 text-slate-600">
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
         <Icon className="h-4 w-4" />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-medium text-slate-900">{action.label}</span>
+        <span className="block truncate text-sm font-medium text-foreground">{action.label}</span>
         {action.description ? (
-          <span className="block truncate text-xs text-slate-500">{action.description}</span>
+          <span className="block truncate text-xs text-muted-foreground">{action.description}</span>
         ) : null}
       </span>
-      <ChevronRight className="h-4 w-4 text-slate-400" />
+      <ChevronRight className="h-4 w-4 text-muted-foreground" />
     </CommandItem>
   );
 }
@@ -68,10 +68,10 @@ export function NestedPage({ children, onBack }: { children: ReactNode; onBack: 
         <CommandItem
           value="back return previous"
           onSelect={onBack}
-          className="min-h-11 cursor-pointer rounded-lg px-3 py-2 data-[selected=true]:bg-slate-100"
+          className="min-h-11 cursor-pointer rounded-lg px-3 py-2 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground"
         >
-          <ArrowLeft className="h-4 w-4 text-slate-500" />
-          <span className="text-sm font-medium text-slate-700">Back to commands</span>
+          <ArrowLeft className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium text-foreground">Back to commands</span>
         </CommandItem>
       </CommandGroup>
       <CommandSeparator className="my-2" />
@@ -98,8 +98,8 @@ export function CanvasListItems({
   if (canvasesLoading) {
     return (
       <CommandItem disabled value="loading canvases" className="min-h-12 rounded-lg px-3 py-2.5">
-        <FileText className="h-4 w-4 text-slate-400" />
-        <span className="text-sm text-slate-500">Loading canvases...</span>
+        <FileText className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm text-muted-foreground">Loading canvases...</span>
       </CommandItem>
     );
   }
@@ -107,8 +107,8 @@ export function CanvasListItems({
   if (canvases.length === 0) {
     return (
       <CommandItem disabled value="no canvases" className="min-h-12 rounded-lg px-3 py-2.5">
-        <FileText className="h-4 w-4 text-slate-400" />
-        <span className="text-sm text-slate-500">{emptyLabel}</span>
+        <FileText className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm text-muted-foreground">{emptyLabel}</span>
       </CommandItem>
     );
   }

--- a/web_src/src/components/GlobalCommandPalette/pages.tsx
+++ b/web_src/src/components/GlobalCommandPalette/pages.tsx
@@ -89,8 +89,8 @@ function DefaultView(props: CommandPalettePageProps) {
         {props.expandedSection === "apps" ? (
           <>
             <CommandItem value="back-from-apps" onSelect={props.onCollapse} className="cursor-pointer">
-              <ChevronLeft className="mr-2 size-4 shrink-0 text-slate-400" />
-              <span className="text-slate-500">Back</span>
+              <ChevronLeft className="mr-2 size-4 shrink-0 text-muted-foreground" />
+              <span className="text-muted-foreground">Back</span>
             </CommandItem>
             <ExpandedAppList {...props.canvasListProps} />
           </>
@@ -98,15 +98,15 @@ function DefaultView(props: CommandPalettePageProps) {
           <CommandItem value="search-apps" onSelect={props.onExpandApps} className="cursor-pointer">
             <Palette className="mr-2 size-4 shrink-0" />
             <span className="flex-1">Apps</span>
-            <ChevronRight className="ml-auto size-4 shrink-0 text-slate-400" />
+            <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
           </CommandItem>
         )}
 
         {props.expandedSection === "integrations" ? (
           <>
             <CommandItem value="back-from-integrations" onSelect={props.onCollapse} className="cursor-pointer">
-              <ChevronLeft className="mr-2 size-4 shrink-0 text-slate-400" />
-              <span className="text-slate-500">Back</span>
+              <ChevronLeft className="mr-2 size-4 shrink-0 text-muted-foreground" />
+              <span className="text-muted-foreground">Back</span>
             </CommandItem>
             <ExpandedIntegrationList
               integrations={props.integrations}
@@ -120,7 +120,7 @@ function DefaultView(props: CommandPalettePageProps) {
           <CommandItem value="connected-integrations" onSelect={props.onExpandIntegrations} className="cursor-pointer">
             <Plug className="mr-2 size-4 shrink-0" />
             <span className="flex-1">Integrations</span>
-            <ChevronRight className="ml-auto size-4 shrink-0 text-slate-400" />
+            <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
           </CommandItem>
         )}
 
@@ -197,8 +197,8 @@ function ExpandedIntegrationList({
         </CommandItem>
       ))}
       <CommandItem value="connect-new-integration" onSelect={onConnectNew} className="cursor-pointer">
-        <Plus className="mr-2 size-4 shrink-0 text-slate-400" />
-        <span className="text-slate-500">Connect new integration...</span>
+        <Plus className="mr-2 size-4 shrink-0 text-muted-foreground" />
+        <span className="text-muted-foreground">Connect new integration...</span>
       </CommandItem>
     </>
   );


### PR DESCRIPTION
- Replace hardcoded light-theme colors (`bg-white`, `slate-*`) in the global command palette with semantic design tokens (`bg-popover`, `bg-accent`, `text-foreground`, `text-muted-foreground`, etc.)
- Fix poor contrast in dark mode when searching, where selected list items used light gray backgrounds on a dark dialog
- Align palette list item styling across search results, navigation items, and canvas/integration lists