### PR TITLE
chore: load canvas versions with DescribeCanvasVersion

### DIFF
--- a/pkg/grpc/actions/canvases/commit_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_staging.go
@@ -207,7 +207,7 @@ func CommitCanvasStaging(
 	ownersByID, _ := ownersByIDForCanvasVersions(ctx, organizationID, []models.CanvasVersion{*newLiveVersion})
 
 	return &pb.CommitCanvasStagingResponse{
-		Version:        SerializeCanvasVersionMetadata(newLiveVersion, organizationID, ownersByID),
+		Version:        SerializeCanvasVersion(newLiveVersion, organizationID, ownersByID),
 		StagingSummary: buildStagingSummary(canvas, []models.WorkflowStagedFile{}),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/commit_canvas_staging_test.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_staging_test.go
@@ -35,6 +35,13 @@ func Test__CommitCanvasStaging__AppliesStagedCanvas(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, resp.GetStagingSummary().GetHasStaging())
 	require.NotNil(t, resp.GetVersion().GetMetadata())
+	require.NotNil(t, resp.GetVersion().GetSpec())
+
+	committedVersion, err := models.FindLiveCanvasVersion(canvas.ID)
+	require.NoError(t, err)
+	assert.Equal(t, committedVersion.ID.String(), resp.GetVersion().GetMetadata().GetId())
+	assert.Len(t, resp.GetVersion().GetSpec().GetNodes(), len(committedVersion.Nodes))
+	assert.Len(t, resp.GetVersion().GetSpec().GetEdges(), len(committedVersion.Edges))
 
 	updatedCanvas, err := models.FindCanvas(r.Organization.ID, canvas.ID)
 	require.NoError(t, err)

--- a/pkg/grpc/actions/canvases/describe_canvas_version.go
+++ b/pkg/grpc/actions/canvases/describe_canvas_version.go
@@ -42,6 +42,6 @@ func DescribeCanvasVersion(ctx context.Context, organizationID string, canvasID 
 	}
 
 	return &pb.DescribeCanvasVersionResponse{
-		Version: SerializeCanvasVersionMetadata(version, organizationID, nil),
+		Version: SerializeCanvasVersion(version, organizationID, nil),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/describe_canvas_version_test.go
+++ b/pkg/grpc/actions/canvases/describe_canvas_version_test.go
@@ -41,7 +41,7 @@ func Test__DescribeCanvasVersion(t *testing.T) {
 		assert.Equal(t, codes.NotFound, code)
 	})
 
-	t.Run("returns version metadata", func(t *testing.T) {
+	t.Run("returns version metadata and spec", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
 		liveVersion, err := models.FindLiveCanvasVersion(canvas.ID)
 		require.NoError(t, err)
@@ -49,5 +49,8 @@ func Test__DescribeCanvasVersion(t *testing.T) {
 		response, err := DescribeCanvasVersion(ctx, r.Organization.ID.String(), canvas.ID.String(), liveVersion.ID.String())
 		require.NoError(t, err)
 		assert.Equal(t, liveVersion.ID.String(), response.GetVersion().GetMetadata().GetId())
+		require.NotNil(t, response.GetVersion().GetSpec())
+		assert.Len(t, response.GetVersion().GetSpec().GetNodes(), len(liveVersion.Nodes))
+		assert.Len(t, response.GetVersion().GetSpec().GetEdges(), len(liveVersion.Edges))
 	})
 }

--- a/pkg/grpc/actions/canvases/serialization.go
+++ b/pkg/grpc/actions/canvases/serialization.go
@@ -26,6 +26,11 @@ func SerializeCanvas(
 		canvasFolderID = canvas.CanvasFolderID.String()
 	}
 
+	liveVersionID := ""
+	if canvas.LiveVersionID != nil {
+		liveVersionID = canvas.LiveVersionID.String()
+	}
+
 	return &pb.Canvas{
 		Metadata: &pb.Canvas_Metadata{
 			Id:             canvas.ID.String(),
@@ -36,6 +41,7 @@ func SerializeCanvas(
 			UpdatedAt:      timestamppb.New(*canvas.UpdatedAt),
 			CreatedBy:      createdBy,
 			FolderId:       canvasFolderID,
+			LiveVersionId:  liveVersionID,
 		},
 		Spec: &pb.Canvas_Spec{
 			Nodes: actions.NodesToProto(liveVersion.Nodes),

--- a/pkg/grpc/actions/canvases/version_serialization.go
+++ b/pkg/grpc/actions/canvases/version_serialization.go
@@ -50,13 +50,6 @@ func SerializeCanvasVersion(version *models.CanvasVersion, organizationID string
 	}
 }
 
-func SerializeCanvasVersionMetadata(version *models.CanvasVersion, organizationID string, ownersByID map[string]*models.User) *pb.CanvasVersion {
-	full := SerializeCanvasVersion(version, organizationID, ownersByID)
-	return &pb.CanvasVersion{
-		Metadata: full.GetMetadata(),
-	}
-}
-
 func canvasVersionOwnerRef(organizationID, ownerID string, ownersByID map[string]*models.User) *pb.UserRef {
 	ownerName := ""
 	if ownersByID != nil {

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -170,7 +170,7 @@ service Canvases {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Describe canvas version";
-      description: "Returns one canvas version by ID";
+      description: "Returns one canvas version by ID, including its workflow spec";
       tags: "CanvasVersion";
     };
   }
@@ -586,6 +586,7 @@ message Canvas {
     google.protobuf.Timestamp updated_at = 6;
     UserRef created_by = 7;
     string folder_id = 8;
+    string live_version_id = 9;
   }
 
   message Spec {

--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -1,19 +1,19 @@
 {
-  "maxAllowedTotalIssues": 594,
+  "maxAllowedTotalIssues": 591,
   "maxAllowedByRule": {
     "complexity": 208,
-    "@typescript-eslint/no-explicit-any": 153,
+    "@typescript-eslint/no-explicit-any": 152,
     "@typescript-eslint/no-non-null-asserted-optional-chain": 78,
     "max-lines-per-function": 64,
-    "max-statements": 62,
+    "max-statements": 60,
     "max-lines": 15,
     "max-depth": 6,
     "max-params": 5,
     "no-eslint-disable-next-line": 3
   },
   "maxAllowedMetricMaximumByRule": {
-    "max-lines": 3817,
-    "complexity": 198
+    "max-lines": 3761,
+    "complexity": 196
   },
-  "updatedAt": "2026-07-09T19:14:38.365Z"
+  "updatedAt": "2026-07-24T21:26:30.754Z"
 }

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -34,7 +34,7 @@ const { sendMutation, resetMutation, chatState, chatRefetch } = vi.hoisted(() =>
 
 vi.mock("@/hooks/useCanvasData", () => ({
   useCanvas: () => ({ data: { spec: { nodes: [] } } }),
-  useCanvasVersions: () => ({ data: [] }),
+  useDescribeCanvasVersion: () => ({ data: undefined }),
   useCanvasVersion: () => ({ data: null }),
   useInfiniteCanvasRuns: () => ({ data: { pages: [] } }),
 }));

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -137,9 +137,8 @@ export const canvasKeys = {
   versionDetails: () => [...canvasKeys.versions(), "detail"] as const,
   versionDetail: (canvasId: string, versionId: string) =>
     [...canvasKeys.versionDetails(), canvasId, versionId] as const,
-  versionDescribePrefix: (canvasId: string) => [...canvasKeys.versions(), canvasId, "describe"] as const,
   versionDescribe: (canvasId: string, versionId: string) =>
-    [...canvasKeys.versionDescribePrefix(canvasId), versionId] as const,
+    [...canvasKeys.versions(), canvasId, "describe", versionId] as const,
   // Canvas-scoped staging reads. Staging belongs to the canvas/user, not a version.
   stagedCanvasSpec: (canvasId: string) => [...canvasKeys.all, "stagedCanvasSpec", canvasId] as const,
   canvasStaging: (canvasId: string) => [...canvasKeys.versions(), "staging", canvasId] as const,
@@ -372,6 +371,7 @@ export const useDescribeCanvasVersion = (
       return response.data?.version;
     },
     enabled: !!canvasId && !!versionId && enabled,
+    staleTime: Number.POSITIVE_INFINITY,
   });
 };
 
@@ -527,7 +527,6 @@ export const useUpdateCanvas = (organizationId: string, canvasId: string) => {
     onSuccess: (response, variables) => {
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
 
       const updatedCanvas = response?.data?.canvas;
@@ -944,7 +943,6 @@ export const useUpdateCanvasVersion = (canvasId: string) => {
       }
 
       if (!version) {
-        queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
         queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
         return;
       }

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -55,7 +55,7 @@ import { registerLocalStagingWrite } from "../lib/canvasStagingEcho";
 import { analytics } from "../lib/analytics";
 import {
   canvasVersionWithSpecFromYaml,
-  fetchCommittedCanvasVersionWithSpec,
+  fetchCanvasVersionWithSpec,
   fetchStagedCanvasVersionWithSpec,
   fetchCanvasStagingSummary,
   fetchConsoleSpecFromRepository,
@@ -133,11 +133,13 @@ export const canvasKeys = {
   details: () => [...canvasKeys.all, "detail"] as const,
   detail: (orgId: string, id: string) => [...canvasKeys.details(), orgId, id] as const,
   versions: () => [...canvasKeys.all, "versions"] as const,
-  versionList: (canvasId: string) => [...canvasKeys.versions(), canvasId] as const,
   versionHistory: (canvasId: string) => [...canvasKeys.versions(), canvasId, "history"] as const,
   versionDetails: () => [...canvasKeys.versions(), "detail"] as const,
   versionDetail: (canvasId: string, versionId: string) =>
     [...canvasKeys.versionDetails(), canvasId, versionId] as const,
+  versionDescribePrefix: (canvasId: string) => [...canvasKeys.versions(), canvasId, "describe"] as const,
+  versionDescribe: (canvasId: string, versionId: string) =>
+    [...canvasKeys.versionDescribePrefix(canvasId), versionId] as const,
   // Canvas-scoped staging reads. Staging belongs to the canvas/user, not a version.
   stagedCanvasSpec: (canvasId: string) => [...canvasKeys.all, "stagedCanvasSpec", canvasId] as const,
   canvasStaging: (canvasId: string) => [...canvasKeys.versions(), "staging", canvasId] as const,
@@ -354,19 +356,22 @@ export const useCanvas = (organizationId: string, canvasId: string, options: Use
   });
 };
 
-export const useCanvasVersions = (organizationId: string, canvasId: string) => {
+export const useDescribeCanvasVersion = (
+  canvasId: string,
+  versionId: string | undefined,
+  enabled = true,
+) => {
   return useQuery({
-    queryKey: canvasKeys.versionList(canvasId),
+    queryKey: canvasKeys.versionDescribe(canvasId, versionId ?? ""),
     queryFn: async () => {
-      const response = await canvasesListCanvasVersions(
+      const response = await canvasesDescribeCanvasVersion(
         withOrganizationHeader({
-          path: { canvasId },
-          query: { limit: 1 },
+          path: { canvasId, versionId: versionId! },
         }),
       );
-      return response.data?.versions || [];
+      return response.data?.version;
     },
-    enabled: !!organizationId && !!canvasId,
+    enabled: !!canvasId && !!versionId && enabled,
   });
 };
 
@@ -407,7 +412,7 @@ export const useInfiniteCanvasLiveVersions = (
 export const useCanvasVersion = (organizationId: string, canvasId: string, versionId: string, enabled = true) => {
   return useQuery({
     queryKey: canvasKeys.versionDetail(canvasId, versionId),
-    queryFn: async () => fetchCommittedCanvasVersionWithSpec(canvasId, versionId),
+    queryFn: async () => fetchCanvasVersionWithSpec(canvasId, versionId),
     enabled: !!organizationId && !!canvasId && !!versionId && enabled,
     staleTime: Number.POSITIVE_INFINITY,
   });
@@ -478,18 +483,20 @@ export const useCreateCanvas = (organizationId: string) => {
       if (response?.data?.canvas?.metadata?.id) {
         const canvasId = response.data.canvas.metadata.id;
         queryClient.setQueryData(canvasKeys.detail(organizationId, canvasId), response.data.canvas);
-        void queryClient.prefetchQuery({
-          queryKey: canvasKeys.versionList(canvasId),
-          queryFn: async () => {
-            const listResponse = await canvasesListCanvasVersions(
-              withOrganizationHeader({
-                path: { canvasId },
-                query: { limit: 1 },
-              }),
-            );
-            return listResponse.data?.versions || [];
-          },
-        });
+        const liveVersionId = response.data?.canvas?.metadata?.liveVersionId;
+        if (liveVersionId) {
+          void queryClient.prefetchQuery({
+            queryKey: canvasKeys.versionDescribe(canvasId, liveVersionId),
+            queryFn: async () => {
+              const describeResponse = await canvasesDescribeCanvasVersion(
+                withOrganizationHeader({
+                  path: { canvasId, versionId: liveVersionId },
+                }),
+              );
+              return describeResponse.data?.version;
+            },
+          });
+        }
         analytics.canvasCreate(
           canvasId,
           organizationId,
@@ -520,7 +527,7 @@ export const useUpdateCanvas = (organizationId: string, canvasId: string) => {
     onSuccess: (response, variables) => {
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
+      queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
 
       const updatedCanvas = response?.data?.canvas;
@@ -937,7 +944,7 @@ export const useUpdateCanvasVersion = (canvasId: string) => {
       }
 
       if (!version) {
-        queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
+        queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
         queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
         return;
       }

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -355,11 +355,7 @@ export const useCanvas = (organizationId: string, canvasId: string, options: Use
   });
 };
 
-export const useDescribeCanvasVersion = (
-  canvasId: string,
-  versionId: string | undefined,
-  enabled = true,
-) => {
+export const useDescribeCanvasVersion = (canvasId: string, versionId: string | undefined, enabled = true) => {
   return useQuery({
     queryKey: canvasKeys.versionDescribe(canvasId, versionId ?? ""),
     queryFn: async () => {

--- a/web_src/src/hooks/useCanvasStagingResync.ts
+++ b/web_src/src/hooks/useCanvasStagingResync.ts
@@ -104,9 +104,9 @@ export function useCanvasStagingResync(options: UseCanvasStagingResyncOptions) {
         const versionShell = queryClient.getQueryData<CanvasesCanvasVersion>(
           canvasKeys.versionDetail(canvasId, versionId),
         ) ??
-          queryClient
-            .getQueryData<CanvasesCanvasVersion[]>(canvasKeys.versionList(canvasId))
-            ?.find((item) => item.metadata?.id === versionId) ?? { metadata: { id: versionId } };
+          queryClient.getQueryData<CanvasesCanvasVersion>(canvasKeys.versionDescribe(canvasId, versionId)) ?? {
+            metadata: { id: versionId },
+          };
 
         const stagedCanvasSpecKey = canvasKeys.stagedCanvasSpec(canvasId);
         const cachedStaged = preferCachedStagedSpec

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -359,7 +359,7 @@ describe("useCanvasWebsocket", () => {
     });
 
     expect(onCanvasLifecycleEvent).toHaveBeenCalledWith({ canvasId: testCanvasId }, "canvas_updated");
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.versionList(testCanvasId))).toHaveLength(0);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.versionDescribePrefix(testCanvasId))).toHaveLength(0);
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.consoleAll(testCanvasId))).toHaveLength(0);
   });
 

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -359,7 +359,6 @@ describe("useCanvasWebsocket", () => {
     });
 
     expect(onCanvasLifecycleEvent).toHaveBeenCalledWith({ canvasId: testCanvasId }, "canvas_updated");
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.versionDescribePrefix(testCanvasId))).toHaveLength(0);
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.consoleAll(testCanvasId))).toHaveLength(0);
   });
 

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -80,7 +80,6 @@ export function useCanvasWebsocket(
 
       if (eventName === "canvas_deleted") {
         queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
-        queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
         return;
       }
 

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -80,7 +80,7 @@ export function useCanvasWebsocket(
 
       if (eventName === "canvas_deleted") {
         queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
-        queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
+        queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
         return;
       }
 

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -319,10 +319,10 @@ export function AppPage() {
     refetchOnReconnect: false,
     refetchOnMount: false,
   });
-  const liveVersionIdFromCanvas = liveCanvas?.metadata?.liveVersionId;
+  const liveCanvasVersionId = liveCanvas?.metadata?.liveVersionId;
   const { data: liveCanvasVersion, isLoading: liveCanvasVersionLoading } = useDescribeCanvasVersion(
     canvasId!,
-    liveVersionIdFromCanvas,
+    liveCanvasVersionId,
   );
   const canvasLiveVersionsQuery = useInfiniteCanvasLiveVersions(organizationId!, canvasId!, true);
   const paginatedVersions = useMemo(
@@ -337,22 +337,11 @@ export function AppPage() {
       if (!id) return;
       indexedVersions.set(id, version);
     });
-    const liveId = liveCanvasVersion?.metadata?.id;
-    if (liveId && !indexedVersions.has(liveId)) {
-      indexedVersions.set(liveId, liveCanvasVersion);
-    }
     return indexedVersions;
-  }, [paginatedVersions, liveCanvasVersion]);
+  }, [paginatedVersions]);
   const hasMoreLiveVersions = canvasLiveVersionsQuery.hasNextPage || false;
   const isLoadingMoreLiveVersions = canvasLiveVersionsQuery.isFetchingNextPage;
-  const liveCanvasVersionId = liveVersionIdFromCanvas ?? liveCanvasVersion?.metadata?.id;
-  const isLiveVersionLoading = canvasLoading || (!!liveVersionIdFromCanvas && liveCanvasVersionLoading);
-  const effectiveLiveCanvasVersionId = liveCanvasVersionId;
-  const refreshLatestLiveCanvasData = useRefreshLatestLiveCanvasData(
-    organizationId,
-    canvasId,
-    effectiveLiveCanvasVersionId,
-  );
+  const refreshLatestLiveCanvasData = useRefreshLatestLiveCanvasData(organizationId, canvasId, liveCanvasVersionId);
   const {
     activeCanvasVersionId,
     shouldReadStagedCanvasVersionFlag,
@@ -372,7 +361,6 @@ export function AppPage() {
     editSessionActive,
     isEnteringEditSession,
     activeCanvasVersion,
-    effectiveLiveCanvasVersionId,
     liveCanvasVersionId,
     selectableVersionsById,
     isRunInspectionMode,
@@ -789,9 +777,7 @@ export function AppPage() {
     }
 
     const requestedVersionId = requestedVersion.metadata?.id || "";
-    const isCurrentLive =
-      (!!effectiveLiveCanvasVersionId && requestedVersionId === effectiveLiveCanvasVersionId) ||
-      requestedVersionId === liveCanvasVersionId;
+    const isCurrentLive = requestedVersionId === liveCanvasVersionId;
 
     if (isCurrentLive) {
       setActiveCanvasVersion(null);
@@ -823,7 +809,6 @@ export function AppPage() {
     searchParams,
     currentUserId,
     liveCanvasVersionId,
-    effectiveLiveCanvasVersionId,
     setSearchParams,
     queryClient,
     organizationId,
@@ -3187,7 +3172,7 @@ export function AppPage() {
         return false;
       }
 
-      const versionId = activeCanvasVersionId || effectiveLiveCanvasVersionId || "";
+      const versionId = activeCanvasVersionId || liveCanvasVersionId || "";
       if (!versionId) {
         return false;
       }
@@ -3223,7 +3208,7 @@ export function AppPage() {
       organizationId,
       canvasId,
       activeCanvasVersionId,
-      effectiveLiveCanvasVersionId,
+      liveCanvasVersionId,
       queryClient,
       commitCanvasStagingMutation,
       ensureVersionActionDraftReady,
@@ -3245,7 +3230,6 @@ export function AppPage() {
         versionID,
         version,
         options,
-        effectiveLiveCanvasVersionId,
         liveCanvasVersionId,
         queryClient,
         draftCanvasSpec,
@@ -3264,7 +3248,6 @@ export function AppPage() {
     [
       organizationId,
       canvasId,
-      effectiveLiveCanvasVersionId,
       liveCanvasVersionId,
       queryClient,
       draftCanvasSpec,
@@ -3303,18 +3286,18 @@ export function AppPage() {
   );
 
   const handleSeeCurrentVersion = useCallback(() => {
-    if (!effectiveLiveCanvasVersionId) {
+    if (!liveCanvasVersionId) {
       showErrorToast("No live version available");
       return;
     }
     // Deliberate preview of the current version keeps the edit session open.
     previewingCurrentVersionRef.current = true;
     if (editSessionActive) {
-      void resyncLiveVersionDraftAfterSwitch(effectiveLiveCanvasVersionId);
+      void resyncLiveVersionDraftAfterSwitch(liveCanvasVersionId);
       return;
     }
-    handleUseVersion(effectiveLiveCanvasVersionId);
-  }, [editSessionActive, effectiveLiveCanvasVersionId, handleUseVersion, resyncLiveVersionDraftAfterSwitch]);
+    handleUseVersion(liveCanvasVersionId);
+  }, [editSessionActive, liveCanvasVersionId, handleUseVersion, resyncLiveVersionDraftAfterSwitch]);
 
   const handleUseVersionFromVersionPanel = useCallback(
     (versionID: string) => {
@@ -3329,7 +3312,6 @@ export function AppPage() {
 
       const isSelectingLiveVersion = isActiveCanvasVersionCurrentLive({
         activeCanvasVersionId: versionID,
-        effectiveLiveCanvasVersionId,
         liveCanvasVersionId,
       });
 
@@ -3351,7 +3333,6 @@ export function AppPage() {
       hasEditableVersion,
       hasLocalSaveActivity,
       editSessionActive,
-      effectiveLiveCanvasVersionId,
       liveCanvasVersionId,
     ],
   );
@@ -3378,7 +3359,7 @@ export function AppPage() {
     organizationId,
     canvasId,
     canUpdateCanvas: canStageCanvasVersion,
-    effectiveLiveCanvasVersionId,
+    liveCanvasVersionId,
     selectableVersionsById,
     handleUseVersion,
     resyncStagedEditorState,
@@ -3388,7 +3369,7 @@ export function AppPage() {
   });
 
   handleRemoteStagingUpdatedRef.current = async () => {
-    const targetVersionId = effectiveLiveCanvasVersionId;
+    const targetVersionId = liveCanvasVersionId;
     if (!targetVersionId || !canvasId) {
       return;
     }
@@ -3414,19 +3395,19 @@ export function AppPage() {
   };
 
   const handleAgentStagingReady = useCallback(async (): Promise<boolean> => {
-    if (!effectiveLiveCanvasVersionId) {
+    if (!liveCanvasVersionId) {
       return false;
     }
 
     if (editSessionActive && isViewingCurrentLiveVersion) {
-      await resyncStagedEditorState(effectiveLiveCanvasVersionId, { bumpResetNonce: false });
+      await resyncStagedEditorState(liveCanvasVersionId, { bumpResetNonce: false });
       return true;
     }
 
     return enterLiveEditSession();
   }, [
     editSessionActive,
-    effectiveLiveCanvasVersionId,
+    liveCanvasVersionId,
     enterLiveEditSession,
     isViewingCurrentLiveVersion,
     resyncStagedEditorState,
@@ -3465,8 +3446,8 @@ export function AppPage() {
       return;
     }
 
-    if (!effectiveLiveCanvasVersionId || !liveCanvasVersion) {
-      if (isLiveVersionLoading) {
+    if (!liveCanvasVersionId || !liveCanvasVersion) {
+      if (canvasLoading || liveCanvasVersionLoading) {
         return;
       }
       showErrorToast("No live version available");
@@ -3486,9 +3467,10 @@ export function AppPage() {
     canvasId,
     canStageCanvasVersion,
     editSessionActive,
-    effectiveLiveCanvasVersionId,
+    liveCanvasVersionId,
     liveCanvasVersion,
-    isLiveVersionLoading,
+    canvasLoading,
+    liveCanvasVersionLoading,
     enterLiveEditSession,
     refreshLatestLiveCanvasData,
     setSearchParams,
@@ -3702,7 +3684,7 @@ export function AppPage() {
       hasEditableVersion,
       canUpdateCanvas: canStageCanvasVersion,
       canvas,
-      liveVersionLoading: isLiveVersionLoading,
+      liveVersionLoading: canvasLoading || liveCanvasVersionLoading,
       handlePlaceholderAdd,
       searchParams,
     },
@@ -3714,10 +3696,10 @@ export function AppPage() {
   const handleExitEditSession = useCallback(() => {
     setEditSessionActive(false);
     clearRunInspectionForEdit();
-    if (effectiveLiveCanvasVersionId) {
-      handleUseVersion(effectiveLiveCanvasVersionId);
+    if (liveCanvasVersionId) {
+      handleUseVersion(liveCanvasVersionId);
     }
-  }, [clearRunInspectionForEdit, effectiveLiveCanvasVersionId, handleUseVersion]);
+  }, [clearRunInspectionForEdit, liveCanvasVersionId, handleUseVersion]);
 
   const handleRunCanvasNodeClick = useCallback(
     (nodeId: string) => {
@@ -4079,7 +4061,7 @@ export function AppPage() {
   const toolSidebarVersionsContent = renderCanvasVersionsSidebarPanel({
     isOpen: showVersionsSidebar,
     scrollPersistenceKey: canvasId,
-    liveCanvasVersionId: effectiveLiveCanvasVersionId,
+    liveCanvasVersionId: liveCanvasVersionId,
     liveCanvasVersion,
     selectedCanvasVersion,
     liveVersions,
@@ -4202,7 +4184,7 @@ export function AppPage() {
           buildingBlocks={buildingBlocks}
           isEditing={isEditing}
           activeCanvasVersionId={activeCanvasVersionId}
-          liveCanvasVersionId={effectiveLiveCanvasVersionId}
+          liveCanvasVersionId={liveCanvasVersionId}
           onAgentStagingReady={handleAgentStagingReady}
           onAgentStagingCommit={whenAllowed(canUpdateCanvas, handleAgentSidebarStagingCommit)}
           onNodeAdd={!isReadOnly ? handleNodeAdd : undefined}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -320,7 +320,7 @@ export function AppPage() {
     refetchOnMount: false,
   });
   const liveVersionIdFromCanvas = liveCanvas?.metadata?.liveVersionId;
-  const { data: describedLiveVersion, isLoading: describedLiveVersionLoading } = useDescribeCanvasVersion(
+  const { data: liveCanvasVersion, isLoading: liveCanvasVersionLoading } = useDescribeCanvasVersion(
     canvasId!,
     liveVersionIdFromCanvas,
   );
@@ -329,49 +329,25 @@ export function AppPage() {
     () => (canvasLiveVersionsQuery.data?.pages || []).flatMap((page) => page?.versions || []),
     [canvasLiveVersionsQuery.data?.pages],
   );
-  const liveCanvasVersion = useMemo(() => {
-    if (paginatedVersions.length > 0) return paginatedVersions[0];
-    return describedLiveVersion;
-  }, [paginatedVersions, describedLiveVersion]);
-  const visibleCanvasVersions = useMemo(() => {
-    const versionMap = new Map<string, CanvasesCanvasVersion>();
-    const addVersion = (version: CanvasesCanvasVersion) => {
-      const versionID = version.metadata?.id;
-      if (!versionID || versionMap.has(versionID)) return;
-      versionMap.set(versionID, version);
-    };
-    if (describedLiveVersion) {
-      addVersion(describedLiveVersion);
-    }
-    paginatedVersions.forEach(addVersion);
-    return Array.from(versionMap.values());
-  }, [describedLiveVersion, paginatedVersions]);
-  const liveVersions = useMemo(() => sortVersionsDesc(visibleCanvasVersions), [visibleCanvasVersions]);
+  const liveVersions = useMemo(() => sortVersionsDesc(paginatedVersions), [paginatedVersions]);
   const selectableVersionsById = useMemo(() => {
     const indexedVersions = new Map<string, CanvasesCanvasVersion>();
-    visibleCanvasVersions.forEach((version) => {
+    paginatedVersions.forEach((version) => {
       const id = version.metadata?.id;
       if (!id) return;
       indexedVersions.set(id, version);
     });
+    const liveId = liveCanvasVersion?.metadata?.id;
+    if (liveId && !indexedVersions.has(liveId)) {
+      indexedVersions.set(liveId, liveCanvasVersion);
+    }
     return indexedVersions;
-  }, [visibleCanvasVersions]);
+  }, [paginatedVersions, liveCanvasVersion]);
   const hasMoreLiveVersions = canvasLiveVersionsQuery.hasNextPage || false;
   const isLoadingMoreLiveVersions = canvasLiveVersionsQuery.isFetchingNextPage;
-  const liveCanvasVersionId = liveCanvasVersion?.metadata?.id;
-  const isLiveVersionLoading =
-    canvasLoading || (!!liveVersionIdFromCanvas && describedLiveVersionLoading);
-  const effectiveLiveCanvasVersionId = useMemo(() => {
-    if (liveCanvasVersionId) {
-      return liveCanvasVersionId;
-    }
-
-    if (liveVersionIdFromCanvas) {
-      return liveVersionIdFromCanvas;
-    }
-
-    return paginatedVersions[0]?.metadata?.id;
-  }, [liveCanvasVersionId, liveVersionIdFromCanvas, paginatedVersions]);
+  const liveCanvasVersionId = liveVersionIdFromCanvas ?? liveCanvasVersion?.metadata?.id;
+  const isLiveVersionLoading = canvasLoading || (!!liveVersionIdFromCanvas && liveCanvasVersionLoading);
+  const effectiveLiveCanvasVersionId = liveCanvasVersionId;
   const refreshLatestLiveCanvasData = useRefreshLatestLiveCanvasData(
     organizationId,
     canvasId,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -32,7 +32,7 @@ import {
   canvasKeys,
   useCanvas,
   useCanvasMemoryEntries,
-  useCanvasVersions,
+  useDescribeCanvasVersion,
   useCreateCanvasMemoryNamespace,
   useDeleteCanvasMemoryEntry,
   useUpdateCanvasMemoryNamespace,
@@ -319,7 +319,11 @@ export function AppPage() {
     refetchOnReconnect: false,
     refetchOnMount: false,
   });
-  const { data: canvasVersions = [], isLoading: canvasVersionsLoading } = useCanvasVersions(organizationId!, canvasId!);
+  const liveVersionIdFromCanvas = liveCanvas?.metadata?.liveVersionId;
+  const { data: describedLiveVersion, isLoading: describedLiveVersionLoading } = useDescribeCanvasVersion(
+    canvasId!,
+    liveVersionIdFromCanvas,
+  );
   const canvasLiveVersionsQuery = useInfiniteCanvasLiveVersions(organizationId!, canvasId!, true);
   const paginatedVersions = useMemo(
     () => (canvasLiveVersionsQuery.data?.pages || []).flatMap((page) => page?.versions || []),
@@ -327,8 +331,8 @@ export function AppPage() {
   );
   const liveCanvasVersion = useMemo(() => {
     if (paginatedVersions.length > 0) return paginatedVersions[0];
-    return canvasVersions[0];
-  }, [paginatedVersions, canvasVersions]);
+    return describedLiveVersion;
+  }, [paginatedVersions, describedLiveVersion]);
   const visibleCanvasVersions = useMemo(() => {
     const versionMap = new Map<string, CanvasesCanvasVersion>();
     const addVersion = (version: CanvasesCanvasVersion) => {
@@ -336,10 +340,12 @@ export function AppPage() {
       if (!versionID || versionMap.has(versionID)) return;
       versionMap.set(versionID, version);
     };
-    canvasVersions.forEach(addVersion);
+    if (describedLiveVersion) {
+      addVersion(describedLiveVersion);
+    }
     paginatedVersions.forEach(addVersion);
     return Array.from(versionMap.values());
-  }, [canvasVersions, paginatedVersions]);
+  }, [describedLiveVersion, paginatedVersions]);
   const liveVersions = useMemo(() => sortVersionsDesc(visibleCanvasVersions), [visibleCanvasVersions]);
   const selectableVersionsById = useMemo(() => {
     const indexedVersions = new Map<string, CanvasesCanvasVersion>();
@@ -353,19 +359,19 @@ export function AppPage() {
   const hasMoreLiveVersions = canvasLiveVersionsQuery.hasNextPage || false;
   const isLoadingMoreLiveVersions = canvasLiveVersionsQuery.isFetchingNextPage;
   const liveCanvasVersionId = liveCanvasVersion?.metadata?.id;
-  const isLiveVersionLoading = canvasVersionsLoading || canvasLiveVersionsQuery.isLoading;
+  const isLiveVersionLoading =
+    canvasLoading || (!!liveVersionIdFromCanvas && describedLiveVersionLoading);
   const effectiveLiveCanvasVersionId = useMemo(() => {
     if (liveCanvasVersionId) {
       return liveCanvasVersionId;
     }
 
-    const fromPaginated = paginatedVersions[0]?.metadata?.id;
-    if (fromPaginated) {
-      return fromPaginated;
+    if (liveVersionIdFromCanvas) {
+      return liveVersionIdFromCanvas;
     }
 
-    return canvasVersions[0]?.metadata?.id;
-  }, [liveCanvasVersionId, paginatedVersions, canvasVersions]);
+    return paginatedVersions[0]?.metadata?.id;
+  }, [liveCanvasVersionId, liveVersionIdFromCanvas, paginatedVersions]);
   const refreshLatestLiveCanvasData = useRefreshLatestLiveCanvasData(
     organizationId,
     canvasId,
@@ -876,7 +882,7 @@ export function AppPage() {
       return;
     }
 
-    queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
+    queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
     if (isViewingLiveVersion) {
       queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
@@ -4007,7 +4013,7 @@ export function AppPage() {
     setRemoteCanvasUpdatePending(false);
     setLastSavedWorkflowSnapshot(null);
 
-    await queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
+    await queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
     if (isViewingLiveVersion) {
       await queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
       await queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -858,7 +858,6 @@ export function AppPage() {
       return;
     }
 
-    queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
     if (isViewingLiveVersion) {
       queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
@@ -3989,7 +3988,6 @@ export function AppPage() {
     setRemoteCanvasUpdatePending(false);
     setLastSavedWorkflowSnapshot(null);
 
-    await queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId) });
     if (isViewingLiveVersion) {
       await queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
       await queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });

--- a/web_src/src/pages/app/lib/canvas-version-activation.spec.ts
+++ b/web_src/src/pages/app/lib/canvas-version-activation.spec.ts
@@ -12,7 +12,6 @@ describe("activateCanvasVersionForEditing", () => {
       versionID: "version-live",
       version: { metadata: { id: "version-live" }, spec: {} },
       options: { preserveStagedLayer: true },
-      effectiveLiveCanvasVersionId: "version-live",
       liveCanvasVersionId: "version-live",
       queryClient: {
         cancelQueries: vi.fn(),

--- a/web_src/src/pages/app/lib/canvas-version-activation.ts
+++ b/web_src/src/pages/app/lib/canvas-version-activation.ts
@@ -75,15 +75,8 @@ export function refreshLiveCanvasAfterVersionSelection({
 
 type DraftSpec = CanvasesCanvas["spec"] | null;
 
-function isCurrentLiveVersion(
-  versionId: string,
-  effectiveLiveCanvasVersionId?: string,
-  liveCanvasVersionId?: string,
-): boolean {
-  return (
-    (!!effectiveLiveCanvasVersionId && versionId === effectiveLiveCanvasVersionId) ||
-    (!!liveCanvasVersionId && versionId === liveCanvasVersionId)
-  );
+function isCurrentLiveVersion(versionId: string, liveCanvasVersionId?: string): boolean {
+  return !!liveCanvasVersionId && versionId === liveCanvasVersionId;
 }
 
 function stashDraftSpecForPreviousVersion({
@@ -129,7 +122,6 @@ export function activateCanvasVersionForEditing({
   versionID,
   version,
   options,
-  effectiveLiveCanvasVersionId,
   liveCanvasVersionId,
   queryClient,
   draftCanvasSpec,
@@ -150,7 +142,6 @@ export function activateCanvasVersionForEditing({
   versionID: string;
   version: CanvasesCanvasVersion;
   options?: { preserveStagedLayer?: boolean };
-  effectiveLiveCanvasVersionId?: string;
   liveCanvasVersionId?: string;
   queryClient: QueryClient;
   draftCanvasSpec: DraftSpec;
@@ -171,7 +162,7 @@ export function activateCanvasVersionForEditing({
   }
 
   const versionId = version.metadata?.id || "";
-  const isCurrentLive = isCurrentLiveVersion(versionId, effectiveLiveCanvasVersionId, liveCanvasVersionId);
+  const isCurrentLive = isCurrentLiveVersion(versionId, liveCanvasVersionId);
   const preserveStagedLayer = !!options?.preserveStagedLayer && isCurrentLive;
 
   clearPendingAutoSaveWork();

--- a/web_src/src/pages/app/lib/commit-staging-flow.spec.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.spec.ts
@@ -48,8 +48,7 @@ describe("executeCommitStaging", () => {
     expect(onCommittedVersionId).toHaveBeenCalledWith("version-2");
     expect(callOrder[0]).toBe("exit-edit");
     expect(callOrder.indexOf("invalidate")).toBeGreaterThan(0);
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-2"), committedVersion);
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "version-2"), committedVersion);
+    expect(setQueryData).not.toHaveBeenCalled();
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: canvasKeys.detail("org-1", "canvas-1"),
       refetchType: "all",

--- a/web_src/src/pages/app/lib/commit-staging-flow.spec.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.spec.ts
@@ -7,8 +7,12 @@ import { executeCommitStaging } from "./commit-staging-flow";
 
 describe("executeCommitStaging", () => {
   it("exits edit before invalidating caches and clears local editor state", async () => {
+    const committedVersion = {
+      metadata: { id: "version-2" },
+      spec: { nodes: [], edges: [] },
+    };
     const commitCanvasStagingMutation = {
-      mutateAsync: vi.fn().mockResolvedValue({ version: { metadata: { id: "version-2" } } }),
+      mutateAsync: vi.fn().mockResolvedValue({ version: committedVersion }),
     };
     const draftCanvasSpecsRef = { current: new Map([["version-1", { nodes: [], edges: [] }]]) };
     const setDraftCanvasSpec = vi.fn();
@@ -20,9 +24,10 @@ describe("executeCommitStaging", () => {
     const invalidateQueries = vi.fn().mockImplementation(async () => {
       callOrder.push("invalidate");
     });
+    const setQueryData = vi.fn();
     const cancelQueries = vi.fn().mockResolvedValue(undefined);
     const removeQueries = vi.fn();
-    const queryClient = { invalidateQueries, cancelQueries, removeQueries } as unknown as QueryClient;
+    const queryClient = { invalidateQueries, setQueryData, cancelQueries, removeQueries } as unknown as QueryClient;
 
     const result = await executeCommitStaging({
       organizationId: "org-1",
@@ -43,12 +48,10 @@ describe("executeCommitStaging", () => {
     expect(onCommittedVersionId).toHaveBeenCalledWith("version-2");
     expect(callOrder[0]).toBe("exit-edit");
     expect(callOrder.indexOf("invalidate")).toBeGreaterThan(0);
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-2"), committedVersion);
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "version-2"), committedVersion);
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: canvasKeys.detail("org-1", "canvas-1"),
-      refetchType: "all",
-    });
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: canvasKeys.versionDescribePrefix("canvas-1"),
       refetchType: "all",
     });
     expect(invalidateQueries).toHaveBeenCalledWith({

--- a/web_src/src/pages/app/lib/commit-staging-flow.spec.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.spec.ts
@@ -48,7 +48,7 @@ describe("executeCommitStaging", () => {
       refetchType: "all",
     });
     expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: canvasKeys.versionList("canvas-1"),
+      queryKey: canvasKeys.versionDescribePrefix("canvas-1"),
       refetchType: "all",
     });
     expect(invalidateQueries).toHaveBeenCalledWith({

--- a/web_src/src/pages/app/lib/commit-staging-flow.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.ts
@@ -1,11 +1,27 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
-import type { CanvasesCanvas } from "@/api-client";
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { cancelCanvasVersionQueries, canvasKeys, removeCanvasVersionScopedQueries } from "@/hooks/useCanvasData";
 
-type CommitMutation = { mutateAsync: (commitMessage: string) => Promise<{ version?: { metadata?: { id?: string } } }> };
+type CommitMutation = {
+  mutateAsync: (commitMessage: string) => Promise<{ version?: CanvasesCanvasVersion }>;
+};
 type DraftSpec = CanvasesCanvas["spec"] | null;
+
+function seedCommittedVersionCaches(
+  queryClient: QueryClient,
+  canvasId: string,
+  committedVersion?: CanvasesCanvasVersion,
+) {
+  const versionId = committedVersion?.metadata?.id;
+  if (!versionId || !committedVersion) {
+    return;
+  }
+
+  queryClient.setQueryData(canvasKeys.versionDescribe(canvasId, versionId), committedVersion);
+  queryClient.setQueryData(canvasKeys.versionDetail(canvasId, versionId), committedVersion);
+}
 
 async function invalidatePostCommitCaches(
   queryClient: QueryClient,
@@ -19,7 +35,6 @@ async function invalidatePostCommitCaches(
 
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId), refetchType: "all" }),
-    queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.stagedCanvasSpec(canvasId), refetchType: "all" }),
@@ -60,13 +75,16 @@ async function applyPostCommitCacheUpdates({
   canvasId,
   previousVersionId,
   committedVersionId,
+  committedVersion,
 }: {
   queryClient: QueryClient;
   organizationId: string;
   canvasId: string;
   previousVersionId: string;
   committedVersionId: string;
+  committedVersion?: CanvasesCanvasVersion;
 }) {
+  seedCommittedVersionCaches(queryClient, canvasId, committedVersion);
   await removeStaleVersionQueriesAfterCommit(queryClient, canvasId, previousVersionId, committedVersionId);
   await invalidatePostCommitCaches(queryClient, organizationId, canvasId);
 }
@@ -112,9 +130,11 @@ export async function executeCommitStaging({
   const releaseCanvasUpdatedEcho = registerIgnoredCanvasUpdatedEcho?.();
   const previousVersionId = activeCanvasVersionId;
   let committedVersionId = activeCanvasVersionId;
+  let committedVersion: CanvasesCanvasVersion | undefined;
   try {
     const response = await commitCanvasStagingMutation.mutateAsync(commitMessage);
-    committedVersionId = response?.version?.metadata?.id || activeCanvasVersionId;
+    committedVersion = response?.version;
+    committedVersionId = committedVersion?.metadata?.id || activeCanvasVersionId;
   } catch (error) {
     releaseCanvasUpdatedEcho?.();
     throw error;
@@ -133,6 +153,7 @@ export async function executeCommitStaging({
       canvasId,
       previousVersionId,
       committedVersionId,
+      committedVersion,
     });
   }
 

--- a/web_src/src/pages/app/lib/commit-staging-flow.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.ts
@@ -19,7 +19,7 @@ async function invalidatePostCommitCaches(
 
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId), refetchType: "all" }),
-    queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId), refetchType: "all" }),
+    queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(canvasId), refetchType: "all" }),
     queryClient.invalidateQueries({ queryKey: canvasKeys.stagedCanvasSpec(canvasId), refetchType: "all" }),

--- a/web_src/src/pages/app/lib/commit-staging-flow.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.ts
@@ -9,20 +9,6 @@ type CommitMutation = {
 };
 type DraftSpec = CanvasesCanvas["spec"] | null;
 
-function seedCommittedVersionCaches(
-  queryClient: QueryClient,
-  canvasId: string,
-  committedVersion?: CanvasesCanvasVersion,
-) {
-  const versionId = committedVersion?.metadata?.id;
-  if (!versionId || !committedVersion) {
-    return;
-  }
-
-  queryClient.setQueryData(canvasKeys.versionDescribe(canvasId, versionId), committedVersion);
-  queryClient.setQueryData(canvasKeys.versionDetail(canvasId, versionId), committedVersion);
-}
-
 async function invalidatePostCommitCaches(
   queryClient: QueryClient,
   organizationId: string,
@@ -75,16 +61,13 @@ async function applyPostCommitCacheUpdates({
   canvasId,
   previousVersionId,
   committedVersionId,
-  committedVersion,
 }: {
   queryClient: QueryClient;
   organizationId: string;
   canvasId: string;
   previousVersionId: string;
   committedVersionId: string;
-  committedVersion?: CanvasesCanvasVersion;
 }) {
-  seedCommittedVersionCaches(queryClient, canvasId, committedVersion);
   await removeStaleVersionQueriesAfterCommit(queryClient, canvasId, previousVersionId, committedVersionId);
   await invalidatePostCommitCaches(queryClient, organizationId, canvasId);
 }
@@ -130,11 +113,9 @@ export async function executeCommitStaging({
   const releaseCanvasUpdatedEcho = registerIgnoredCanvasUpdatedEcho?.();
   const previousVersionId = activeCanvasVersionId;
   let committedVersionId = activeCanvasVersionId;
-  let committedVersion: CanvasesCanvasVersion | undefined;
   try {
     const response = await commitCanvasStagingMutation.mutateAsync(commitMessage);
-    committedVersion = response?.version;
-    committedVersionId = committedVersion?.metadata?.id || activeCanvasVersionId;
+    committedVersionId = response?.version?.metadata?.id || activeCanvasVersionId;
   } catch (error) {
     releaseCanvasUpdatedEcho?.();
     throw error;
@@ -153,7 +134,6 @@ export async function executeCommitStaging({
       canvasId,
       previousVersionId,
       committedVersionId,
-      committedVersion,
     });
   }
 

--- a/web_src/src/pages/app/lib/live-edit-session.spec.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.spec.ts
@@ -13,7 +13,6 @@ describe("shouldReadStagedCanvasVersion", () => {
       shouldReadStagedCanvasVersion({
         editSessionActive: true,
         activeCanvasVersionId: "live-version",
-        effectiveLiveCanvasVersionId: "live-version",
         liveCanvasVersionId: "live-version",
       }),
     ).toBe(true);
@@ -24,7 +23,6 @@ describe("shouldReadStagedCanvasVersion", () => {
       shouldReadStagedCanvasVersion({
         editSessionActive: false,
         activeCanvasVersionId: "live-version",
-        effectiveLiveCanvasVersionId: "live-version",
         liveCanvasVersionId: "live-version",
       }),
     ).toBe(false);
@@ -35,7 +33,6 @@ describe("shouldReadStagedCanvasVersion", () => {
       shouldReadStagedCanvasVersion({
         editSessionActive: true,
         activeCanvasVersionId: "old-version",
-        effectiveLiveCanvasVersionId: "live-version",
         liveCanvasVersionId: "live-version",
       }),
     ).toBe(false);
@@ -114,7 +111,6 @@ describe("isViewingCurrentLiveCanvasVersion", () => {
           metadata: { id: "old-live-version" },
           spec: { nodes: [], edges: [] },
         },
-        effectiveLiveCanvasVersionId: "new-live-version",
         liveCanvasVersionId: "new-live-version",
       }),
     ).toBe(true);
@@ -128,7 +124,6 @@ describe("isViewingCurrentLiveCanvasVersion", () => {
           metadata: { id: "old-version" },
           spec: { nodes: [], edges: [] },
         },
-        effectiveLiveCanvasVersionId: "new-live-version",
         liveCanvasVersionId: "new-live-version",
       }),
     ).toBe(false);

--- a/web_src/src/pages/app/lib/live-edit-session.ts
+++ b/web_src/src/pages/app/lib/live-edit-session.ts
@@ -8,41 +8,28 @@ import { clearComponentSidebarSearchParams } from "../viewState";
 
 export function isActiveCanvasVersionCurrentLive({
   activeCanvasVersionId,
-  effectiveLiveCanvasVersionId,
   liveCanvasVersionId,
 }: {
   activeCanvasVersionId: string;
-  effectiveLiveCanvasVersionId?: string;
   liveCanvasVersionId?: string;
 }): boolean {
-  if (!activeCanvasVersionId) {
+  if (!activeCanvasVersionId || !liveCanvasVersionId) {
     return false;
   }
 
-  return (
-    (!!effectiveLiveCanvasVersionId && activeCanvasVersionId === effectiveLiveCanvasVersionId) ||
-    (!!liveCanvasVersionId && activeCanvasVersionId === liveCanvasVersionId)
-  );
+  return activeCanvasVersionId === liveCanvasVersionId;
 }
 
 export function isViewingCurrentLiveCanvasVersion({
   activeCanvasVersionId,
   selectedCanvasVersion,
-  effectiveLiveCanvasVersionId,
   liveCanvasVersionId,
 }: {
   activeCanvasVersionId: string;
   selectedCanvasVersion: CanvasesCanvasVersion | null;
-  effectiveLiveCanvasVersionId?: string;
   liveCanvasVersionId?: string;
 }): boolean {
-  if (
-    isActiveCanvasVersionCurrentLive({
-      activeCanvasVersionId,
-      effectiveLiveCanvasVersionId,
-      liveCanvasVersionId,
-    })
-  ) {
+  if (isActiveCanvasVersionCurrentLive({ activeCanvasVersionId, liveCanvasVersionId })) {
     return true;
   }
 
@@ -50,11 +37,7 @@ export function isViewingCurrentLiveCanvasVersion({
     return true;
   }
 
-  const selectedVersionId = selectedCanvasVersion.metadata?.id;
-  return (
-    (!!effectiveLiveCanvasVersionId && selectedVersionId === effectiveLiveCanvasVersionId) ||
-    selectedVersionId === liveCanvasVersionId
-  );
+  return selectedCanvasVersion.metadata?.id === liveCanvasVersionId;
 }
 
 function isStagedCanvasVersionForActiveVersion(
@@ -133,20 +116,13 @@ export function resolveSelectedCanvasVersion({
 export function shouldReadStagedCanvasVersion({
   editSessionActive,
   activeCanvasVersionId,
-  effectiveLiveCanvasVersionId,
   liveCanvasVersionId,
 }: {
   editSessionActive: boolean;
   activeCanvasVersionId: string;
-  effectiveLiveCanvasVersionId?: string;
   liveCanvasVersionId?: string;
 }): boolean {
-  return (
-    editSessionActive &&
-    !!activeCanvasVersionId &&
-    ((!!effectiveLiveCanvasVersionId && activeCanvasVersionId === effectiveLiveCanvasVersionId) ||
-      activeCanvasVersionId === liveCanvasVersionId)
-  );
+  return editSessionActive && !!activeCanvasVersionId && activeCanvasVersionId === liveCanvasVersionId;
 }
 
 type LiveEditSessionDraftRefs = {

--- a/web_src/src/pages/app/lib/repository-spec-files.ts
+++ b/web_src/src/pages/app/lib/repository-spec-files.ts
@@ -107,16 +107,6 @@ export async function fetchCanvasVersionWithSpec(
   return describeResponse.data?.version;
 }
 
-// fetchLiveCanvasVersionWithSpec loads the current live version by id. Callers
-// should pass canvas.metadata.liveVersionId so a stale active version id does
-// not load the wrong row.
-export async function fetchLiveCanvasVersionWithSpec(
-  canvasId: string,
-  liveVersionId: string,
-): Promise<CanvasesCanvasVersion | undefined> {
-  return fetchCanvasVersionWithSpec(canvasId, liveVersionId);
-}
-
 export type ConsoleSpecData = {
   panels: NonNullable<ReturnType<typeof dematerializeConsoleSpec>>["panels"];
   layout: NonNullable<ReturnType<typeof dematerializeConsoleSpec>>["layout"];

--- a/web_src/src/pages/app/lib/repository-spec-files.ts
+++ b/web_src/src/pages/app/lib/repository-spec-files.ts
@@ -1,7 +1,6 @@
 import {
   canvasesDescribeCanvasVersion,
   canvasesGetCanvasStaging,
-  canvasesListCanvasVersions,
   type CanvasesCanvasVersion,
   type CanvasesStagingSummary,
 } from "@/api-client";
@@ -11,10 +10,7 @@ import { dematerializeCanvasSpec, dematerializeConsoleSpec } from "./workflow-sp
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "./workflow-spec-paths";
 import { isNotFoundError } from "../workflowPageHelpers";
 
-// Confirms whether a canvas version still exists. Used to distinguish a deleted
-// version from an incidental repository-file 404, since fetchCommittedCanvasVersionWithSpec
-// loads the version and its canvas.yaml in parallel. A non-404 describe error is
-// treated as "exists" so the original failure is surfaced as transient.
+// Confirms whether a canvas version still exists via DescribeCanvasVersion.
 export async function canvasVersionExists(canvasId: string, versionId: string): Promise<boolean> {
   try {
     const response = await canvasesDescribeCanvasVersion(withOrganizationHeader({ path: { canvasId, versionId } }));
@@ -96,10 +92,10 @@ export async function fetchStagedCanvasVersionWithSpec(
   return canvasVersionWithSpecFromYaml(versionMetadata, canvasYaml);
 }
 
-// fetchCommittedCanvasVersionWithSpec reads immutable committed content for a
-// specific version. Versions never change after publish, so callers should cache
-// aggressively and avoid invalidating these reads.
-export async function fetchCommittedCanvasVersionWithSpec(
+// fetchCanvasVersionWithSpec loads a version from DescribeCanvasVersion, including
+// nodes and edges from the version row. Versions never change after publish, so
+// callers should cache aggressively and avoid invalidating these reads.
+export async function fetchCanvasVersionWithSpec(
   canvasId: string,
   versionId: string,
 ): Promise<CanvasesCanvasVersion | undefined> {
@@ -108,46 +104,17 @@ export async function fetchCommittedCanvasVersionWithSpec(
       path: { canvasId, versionId },
     }),
   );
-
-  try {
-    const canvasYaml = await fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH, versionId, false);
-    return canvasVersionWithSpecFromYaml(describeResponse.data?.version, canvasYaml);
-  } catch (error) {
-    // Committed yaml reads are live-version-only. Historical versions keep their
-    // graph on the version row returned by the list API.
-    const listResponse = await canvasesListCanvasVersions(
-      withOrganizationHeader({
-        path: { canvasId },
-        query: { limit: 50 },
-      }),
-    );
-    const listVersion = listResponse.data?.versions?.find((item) => item.metadata?.id === versionId);
-    if (listVersion?.spec) {
-      return listVersion;
-    }
-
-    throw error;
-  }
+  return describeResponse.data?.version;
 }
 
-// fetchLiveCommittedCanvasVersionWithSpec loads the current live version's
-// committed canvas.yaml without pinning a version_id on the repository read.
-// After a remote commit the previously-active version id is stale, but the live
-// file endpoint still resolves to the new live version automatically.
-export async function fetchLiveCommittedCanvasVersionWithSpec(
+// fetchLiveCanvasVersionWithSpec loads the current live version by id. Callers
+// should pass canvas.metadata.liveVersionId so a stale active version id does
+// not load the wrong row.
+export async function fetchLiveCanvasVersionWithSpec(
   canvasId: string,
+  liveVersionId: string,
 ): Promise<CanvasesCanvasVersion | undefined> {
-  const [listResponse, canvasYaml] = await Promise.all([
-    canvasesListCanvasVersions(
-      withOrganizationHeader({
-        path: { canvasId },
-        query: { limit: 1 },
-      }),
-    ),
-    fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH),
-  ]);
-
-  return canvasVersionWithSpecFromYaml(listResponse.data?.versions?.[0], canvasYaml);
+  return fetchCanvasVersionWithSpec(canvasId, liveVersionId);
 }
 
 export type ConsoleSpecData = {

--- a/web_src/src/pages/app/lib/reset-staging-flow.ts
+++ b/web_src/src/pages/app/lib/reset-staging-flow.ts
@@ -4,7 +4,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { canvasKeys } from "@/hooks/useCanvasData";
 
-import { restoreCommittedCanvasDraftState } from "./sync-committed-canvas-draft";
+import { restoreCanvasDraftState } from "./sync-canvas-draft";
 
 type DiscardMutation = { mutateAsync: (input: undefined) => Promise<unknown> };
 type DraftSpec = CanvasesCanvas["spec"] | null;
@@ -39,7 +39,7 @@ export async function executeResetStaging({
   cancelPendingCanvasSaves?.();
   consoleMutationGenerationRef.current += 1;
   await discardCanvasStagingMutation.mutateAsync(undefined);
-  await restoreCommittedCanvasDraftState({
+  await restoreCanvasDraftState({
     organizationId,
     canvasId,
     activeCanvasVersionId,

--- a/web_src/src/pages/app/lib/sync-canvas-draft.spec.ts
+++ b/web_src/src/pages/app/lib/sync-canvas-draft.spec.ts
@@ -4,12 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
-import { syncCommittedCanvasDraftState, syncCommittedConsoleCaches } from "./sync-committed-canvas-draft";
-import { fetchCommittedCanvasVersionWithSpec, fetchLiveCommittedCanvasVersionWithSpec } from "./repository-spec-files";
+import { syncCanvasDraftState, syncConsoleCaches } from "./sync-canvas-draft";
+import { fetchCanvasVersionWithSpec, fetchLiveCanvasVersionWithSpec } from "./repository-spec-files";
 
 vi.mock("./repository-spec-files", () => ({
-  fetchCommittedCanvasVersionWithSpec: vi.fn(),
-  fetchLiveCommittedCanvasVersionWithSpec: vi.fn(),
+  fetchCanvasVersionWithSpec: vi.fn(),
+  fetchLiveCanvasVersionWithSpec: vi.fn(),
 }));
 
 vi.mock("@/hooks/useCanvasData", async (importOriginal) => {
@@ -24,32 +24,34 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("syncCommittedCanvasDraftState", () => {
-  it("reloads committed canvas spec into staged and detail caches", async () => {
-    const committedVersion: CanvasesCanvasVersion = {
+describe("syncCanvasDraftState", () => {
+  it("reloads canvas spec into staged and detail caches", async () => {
+    const version: CanvasesCanvasVersion = {
       metadata: { id: "version-1" },
       spec: {
         nodes: [{ id: "node-1", name: "Trigger", type: "TYPE_TRIGGER" }],
         edges: [],
       },
     };
-    vi.mocked(fetchCommittedCanvasVersionWithSpec).mockResolvedValue(committedVersion);
+    vi.mocked(fetchCanvasVersionWithSpec).mockResolvedValue(version);
 
     const setQueryData = vi.fn();
     const queryClient = { setQueryData } as unknown as QueryClient;
 
-    const result = await syncCommittedCanvasDraftState({
+    const result = await syncCanvasDraftState({
       queryClient,
       organizationId: "org-1",
       canvasId: "canvas-1",
       versionId: "version-1",
     });
 
-    expect(result).toEqual(committedVersion);
-    expect(fetchCommittedCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1", "version-1");
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.stagedCanvasSpec("canvas-1"), committedVersion);
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "version-1"), committedVersion);
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionList("canvas-1"), expect.any(Function));
+    expect(result).toEqual(version);
+    expect(fetchCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1", "version-1");
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.stagedCanvasSpec("canvas-1"), version);
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "version-1"), version);
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-1"), {
+      metadata: { id: "version-1" },
+    });
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.detail("org-1", "canvas-1"), expect.any(Function));
 
     const detailKey = JSON.stringify(canvasKeys.detail("org-1", "canvas-1"));
@@ -67,48 +69,49 @@ describe("syncCommittedCanvasDraftState", () => {
       }),
     ).toEqual({
       metadata: { id: "canvas-1" },
-      spec: committedVersion.spec,
+      spec: version.spec,
     });
   });
 
-  it("prepends a new committed version when the version list cache is empty", async () => {
-    const committedVersion: CanvasesCanvasVersion = {
+  it("updates the live version describe cache when the version list cache is empty", async () => {
+    const version: CanvasesCanvasVersion = {
       metadata: { id: "version-2" },
       spec: { nodes: [], edges: [] },
     };
-    vi.mocked(fetchCommittedCanvasVersionWithSpec).mockResolvedValue(committedVersion);
+    vi.mocked(fetchCanvasVersionWithSpec).mockResolvedValue(version);
 
     const setQueryData = vi.fn();
     const queryClient = { setQueryData } as unknown as QueryClient;
 
-    await syncCommittedCanvasDraftState({
+    await syncCanvasDraftState({
       queryClient,
       organizationId: "org-1",
       canvasId: "canvas-1",
       versionId: "version-2",
     });
 
-    const updateVersionList = setQueryData.mock.calls.find(
-      ([key]) => JSON.stringify(key) === JSON.stringify(canvasKeys.versionList("canvas-1")),
-    )?.[1] as (current: CanvasesCanvasVersion[] | undefined) => CanvasesCanvasVersion[] | undefined;
-
-    expect(updateVersionList(undefined)).toEqual([committedVersion]);
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-2"), {
+      metadata: { id: "version-2" },
+    });
   });
 
-  it("loads the live committed version when the requested version id is stale", async () => {
-    const committedVersion: CanvasesCanvasVersion = {
+  it("loads the live version when the requested version id is stale", async () => {
+    const version: CanvasesCanvasVersion = {
       metadata: { id: "live-version-2" },
       spec: {
         nodes: [{ id: "node-1", name: "Trigger", type: "TYPE_TRIGGER" }],
         edges: [],
       },
     };
-    vi.mocked(fetchLiveCommittedCanvasVersionWithSpec).mockResolvedValue(committedVersion);
+    vi.mocked(fetchLiveCanvasVersionWithSpec).mockResolvedValue(version);
 
     const setQueryData = vi.fn();
-    const queryClient = { setQueryData } as unknown as QueryClient;
+    const getQueryData = vi.fn().mockReturnValue({
+      metadata: { id: "canvas-1", liveVersionId: "live-version-2" },
+    });
+    const queryClient = { setQueryData, getQueryData } as unknown as QueryClient;
 
-    const result = await syncCommittedCanvasDraftState({
+    const result = await syncCanvasDraftState({
       queryClient,
       organizationId: "org-1",
       canvasId: "canvas-1",
@@ -116,22 +119,22 @@ describe("syncCommittedCanvasDraftState", () => {
       resolveLiveVersion: true,
     });
 
-    expect(result).toEqual(committedVersion);
-    expect(fetchLiveCommittedCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1");
-    expect(fetchCommittedCanvasVersionWithSpec).not.toHaveBeenCalled();
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "live-version-2"), committedVersion);
+    expect(result).toEqual(version);
+    expect(fetchLiveCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1", "live-version-2");
+    expect(fetchCanvasVersionWithSpec).not.toHaveBeenCalled();
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "live-version-2"), version);
   });
 });
 
-describe("syncCommittedConsoleCaches", () => {
-  it("invalidates staged console cache when committed console.yaml is missing or unparsable", async () => {
+describe("syncConsoleCaches", () => {
+  it("invalidates staged console cache when console.yaml is missing or unparsable", async () => {
     vi.mocked(fetchCanvasConsoleData).mockResolvedValue(undefined);
 
     const invalidateQueries = vi.fn().mockResolvedValue(undefined);
     const setQueryData = vi.fn();
     const queryClient = { invalidateQueries, setQueryData } as unknown as QueryClient;
 
-    await syncCommittedConsoleCaches({
+    await syncConsoleCaches({
       queryClient,
       canvasId: "canvas-1",
       versionId: "version-1",

--- a/web_src/src/pages/app/lib/sync-canvas-draft.spec.ts
+++ b/web_src/src/pages/app/lib/sync-canvas-draft.spec.ts
@@ -5,11 +5,10 @@ import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
 import { syncCanvasDraftState, syncConsoleCaches } from "./sync-canvas-draft";
-import { fetchCanvasVersionWithSpec, fetchLiveCanvasVersionWithSpec } from "./repository-spec-files";
+import { fetchCanvasVersionWithSpec } from "./repository-spec-files";
 
 vi.mock("./repository-spec-files", () => ({
   fetchCanvasVersionWithSpec: vi.fn(),
-  fetchLiveCanvasVersionWithSpec: vi.fn(),
 }));
 
 vi.mock("@/hooks/useCanvasData", async (importOriginal) => {
@@ -71,7 +70,7 @@ describe("syncCanvasDraftState", () => {
     });
   });
 
-  it("updates the live version describe cache when the version list cache is empty", async () => {
+  it("updates the version describe cache for the requested version id", async () => {
     const version: CanvasesCanvasVersion = {
       metadata: { id: "version-2" },
       spec: { nodes: [], edges: [] },
@@ -89,36 +88,6 @@ describe("syncCanvasDraftState", () => {
     });
 
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-2"), version);
-  });
-
-  it("loads the live version when the requested version id is stale", async () => {
-    const version: CanvasesCanvasVersion = {
-      metadata: { id: "live-version-2" },
-      spec: {
-        nodes: [{ id: "node-1", name: "Trigger", type: "TYPE_TRIGGER" }],
-        edges: [],
-      },
-    };
-    vi.mocked(fetchLiveCanvasVersionWithSpec).mockResolvedValue(version);
-
-    const setQueryData = vi.fn();
-    const getQueryData = vi.fn().mockReturnValue({
-      metadata: { id: "canvas-1", liveVersionId: "live-version-2" },
-    });
-    const queryClient = { setQueryData, getQueryData } as unknown as QueryClient;
-
-    const result = await syncCanvasDraftState({
-      queryClient,
-      organizationId: "org-1",
-      canvasId: "canvas-1",
-      versionId: "stale-version-1",
-      resolveLiveVersion: true,
-    });
-
-    expect(result).toEqual(version);
-    expect(fetchLiveCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1", "live-version-2");
-    expect(fetchCanvasVersionWithSpec).not.toHaveBeenCalled();
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "live-version-2"), version);
   });
 });
 

--- a/web_src/src/pages/app/lib/sync-canvas-draft.spec.ts
+++ b/web_src/src/pages/app/lib/sync-canvas-draft.spec.ts
@@ -49,9 +49,7 @@ describe("syncCanvasDraftState", () => {
     expect(fetchCanvasVersionWithSpec).toHaveBeenCalledWith("canvas-1", "version-1");
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.stagedCanvasSpec("canvas-1"), version);
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDetail("canvas-1", "version-1"), version);
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-1"), {
-      metadata: { id: "version-1" },
-    });
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-1"), version);
     expect(setQueryData).toHaveBeenCalledWith(canvasKeys.detail("org-1", "canvas-1"), expect.any(Function));
 
     const detailKey = JSON.stringify(canvasKeys.detail("org-1", "canvas-1"));
@@ -90,9 +88,7 @@ describe("syncCanvasDraftState", () => {
       versionId: "version-2",
     });
 
-    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-2"), {
-      metadata: { id: "version-2" },
-    });
+    expect(setQueryData).toHaveBeenCalledWith(canvasKeys.versionDescribe("canvas-1", "version-2"), version);
   });
 
   it("loads the live version when the requested version id is stale", async () => {

--- a/web_src/src/pages/app/lib/sync-canvas-draft.ts
+++ b/web_src/src/pages/app/lib/sync-canvas-draft.ts
@@ -4,9 +4,9 @@ import type { Dispatch, SetStateAction } from "react";
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
-import { fetchCommittedCanvasVersionWithSpec, fetchLiveCommittedCanvasVersionWithSpec } from "./repository-spec-files";
+import { fetchCanvasVersionWithSpec, fetchLiveCanvasVersionWithSpec } from "./repository-spec-files";
 
-export async function syncCommittedConsoleCaches({
+export async function syncConsoleCaches({
   queryClient,
   canvasId,
   versionId,
@@ -22,11 +22,11 @@ export async function syncCommittedConsoleCaches({
   }
 
   queryClient.setQueryData(canvasKeys.console(canvasId, versionId), consoleData);
-  // After commit, staging is cleared — mirror the committed console in the staged cache.
+  // After commit, staging is cleared — mirror the published console in the staged cache.
   queryClient.setQueryData(canvasKeys.stagedConsole(canvasId), consoleData);
 }
 
-export async function syncCommittedCanvasDraftState({
+export async function syncCanvasDraftState({
   queryClient,
   organizationId,
   canvasId,
@@ -41,33 +41,29 @@ export async function syncCommittedCanvasDraftState({
   resolveLiveVersion?: boolean;
   skipVersionListUpdate?: boolean;
 }): Promise<CanvasesCanvasVersion | undefined> {
-  const committedVersion = resolveLiveVersion
-    ? await fetchLiveCommittedCanvasVersionWithSpec(canvasId)
-    : await fetchCommittedCanvasVersionWithSpec(canvasId, versionId);
-  if (!committedVersion) {
+  const version = resolveLiveVersion
+    ? await fetchLiveCanvasVersionWithSpec(
+        canvasId,
+        queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId))?.metadata
+          ?.liveVersionId ?? versionId,
+      )
+    : await fetchCanvasVersionWithSpec(canvasId, versionId);
+  if (!version) {
     return undefined;
   }
 
-  const cacheVersionId = committedVersion.metadata?.id ?? versionId;
+  const cacheVersionId = version.metadata?.id ?? versionId;
 
-  queryClient.setQueryData(canvasKeys.stagedCanvasSpec(canvasId), committedVersion);
-  queryClient.setQueryData(canvasKeys.versionDetail(canvasId, cacheVersionId), committedVersion);
+  queryClient.setQueryData(canvasKeys.stagedCanvasSpec(canvasId), version);
+  queryClient.setQueryData(canvasKeys.versionDetail(canvasId, cacheVersionId), version);
 
-  if (!skipVersionListUpdate) {
-    queryClient.setQueryData(canvasKeys.versionList(canvasId), (current: CanvasesCanvasVersion[] | undefined) => {
-      const existing = current ?? [];
-      const index = existing.findIndex((item) => item.metadata?.id === cacheVersionId);
-      if (index === -1) {
-        return [committedVersion, ...existing];
-      }
-
-      return existing.map((item) =>
-        item.metadata?.id === cacheVersionId ? { ...item, spec: committedVersion.spec } : item,
-      );
+  if (!skipVersionListUpdate && version.metadata) {
+    queryClient.setQueryData(canvasKeys.versionDescribe(canvasId, cacheVersionId), {
+      metadata: version.metadata,
     });
   }
 
-  if (committedVersion.spec) {
+  if (version.spec) {
     queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
       if (!current) {
         return current;
@@ -75,17 +71,17 @@ export async function syncCommittedCanvasDraftState({
 
       return {
         ...current,
-        spec: { ...current.spec, ...committedVersion.spec },
+        spec: { ...current.spec, ...version.spec },
       };
     });
   }
 
-  return committedVersion;
+  return version;
 }
 
 type DraftSpec = CanvasesCanvas["spec"] | null;
 
-export async function restoreCommittedCanvasDraftState({
+export async function restoreCanvasDraftState({
   organizationId,
   canvasId,
   activeCanvasVersionId,
@@ -110,23 +106,23 @@ export async function restoreCommittedCanvasDraftState({
     return;
   }
 
-  const committedVersion = await syncCommittedCanvasDraftState({
+  const version = await syncCanvasDraftState({
     queryClient,
     organizationId,
     canvasId,
     versionId: activeCanvasVersionId,
   });
 
-  if (!committedVersion?.spec) {
+  if (!version?.spec) {
     draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
     setDraftCanvasSpec(null);
     return;
   }
 
-  draftCanvasSpecsRef.current.set(activeCanvasVersionId, committedVersion.spec);
-  setDraftCanvasSpec(committedVersion.spec);
+  draftCanvasSpecsRef.current.set(activeCanvasVersionId, version.spec);
+  setDraftCanvasSpec(version.spec);
   setActiveCanvasVersion?.((current) =>
-    current?.metadata?.id === activeCanvasVersionId ? { ...current, spec: committedVersion.spec } : current,
+    current?.metadata?.id === activeCanvasVersionId ? { ...current, spec: version.spec } : current,
   );
-  onCanvasDraftRestoredToCommitted?.(committedVersion);
+  onCanvasDraftRestoredToCommitted?.(version);
 }

--- a/web_src/src/pages/app/lib/sync-canvas-draft.ts
+++ b/web_src/src/pages/app/lib/sync-canvas-draft.ts
@@ -4,7 +4,7 @@ import type { Dispatch, SetStateAction } from "react";
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
-import { fetchCanvasVersionWithSpec, fetchLiveCanvasVersionWithSpec } from "./repository-spec-files";
+import { fetchCanvasVersionWithSpec } from "./repository-spec-files";
 
 export async function syncConsoleCaches({
   queryClient,
@@ -31,23 +31,13 @@ export async function syncCanvasDraftState({
   organizationId,
   canvasId,
   versionId,
-  resolveLiveVersion = false,
-  skipVersionListUpdate = false,
 }: {
   queryClient: QueryClient;
   organizationId: string;
   canvasId: string;
   versionId: string;
-  resolveLiveVersion?: boolean;
-  skipVersionListUpdate?: boolean;
 }): Promise<CanvasesCanvasVersion | undefined> {
-  const version = resolveLiveVersion
-    ? await fetchLiveCanvasVersionWithSpec(
-        canvasId,
-        queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId))?.metadata
-          ?.liveVersionId ?? versionId,
-      )
-    : await fetchCanvasVersionWithSpec(canvasId, versionId);
+  const version = await fetchCanvasVersionWithSpec(canvasId, versionId);
   if (!version) {
     return undefined;
   }
@@ -57,7 +47,7 @@ export async function syncCanvasDraftState({
   queryClient.setQueryData(canvasKeys.stagedCanvasSpec(canvasId), version);
   queryClient.setQueryData(canvasKeys.versionDetail(canvasId, cacheVersionId), version);
 
-  if (!skipVersionListUpdate && version.metadata) {
+  if (version.metadata) {
     queryClient.setQueryData(canvasKeys.versionDescribe(canvasId, cacheVersionId), version);
   }
 

--- a/web_src/src/pages/app/lib/sync-canvas-draft.ts
+++ b/web_src/src/pages/app/lib/sync-canvas-draft.ts
@@ -58,9 +58,7 @@ export async function syncCanvasDraftState({
   queryClient.setQueryData(canvasKeys.versionDetail(canvasId, cacheVersionId), version);
 
   if (!skipVersionListUpdate && version.metadata) {
-    queryClient.setQueryData(canvasKeys.versionDescribe(canvasId, cacheVersionId), {
-      metadata: version.metadata,
-    });
+    queryClient.setQueryData(canvasKeys.versionDescribe(canvasId, cacheVersionId), version);
   }
 
   if (version.spec) {

--- a/web_src/src/pages/app/mappers/incident/setSigningSecretSection.tsx
+++ b/web_src/src/pages/app/mappers/incident/setSigningSecretSection.tsx
@@ -19,7 +19,7 @@ import { registerLocalStagingWrite } from "@/lib/canvasStagingEcho";
 import { canvasKeys } from "@/hooks/useCanvasData";
 import { useCanvasId } from "@/hooks/useCanvasId";
 import { encodeRepositoryFileContent } from "../../files/lib/repository-files";
-import { fetchCommittedCanvasVersionWithSpec } from "../../lib/repository-spec-files";
+import { fetchCanvasVersionWithSpec } from "../../lib/repository-spec-files";
 import { materializeCanvasSpec } from "../../lib/workflow-spec-files";
 import { CANVAS_YAML_PATH } from "../../lib/workflow-spec-paths";
 
@@ -113,7 +113,7 @@ export function SetSigningSecretSection({ nodeId }: { nodeId: string }) {
 
       const freshVersion = await queryClient.fetchQuery({
         queryKey: canvasKeys.versionDetail(canvasId, versionId),
-        queryFn: async () => fetchCommittedCanvasVersionWithSpec(canvasId, versionId),
+        queryFn: async () => fetchCanvasVersionWithSpec(canvasId, versionId),
       });
 
       if (!freshVersion) {

--- a/web_src/src/pages/app/useCanvasEditVersionState.ts
+++ b/web_src/src/pages/app/useCanvasEditVersionState.ts
@@ -16,7 +16,6 @@ type UseCanvasEditVersionStateOptions = {
   editSessionActive: boolean;
   isEnteringEditSession: boolean;
   activeCanvasVersion: CanvasesCanvasVersion | null;
-  effectiveLiveCanvasVersionId?: string;
   liveCanvasVersionId?: string;
   selectableVersionsById: Map<string, CanvasesCanvasVersion>;
   isRunInspectionMode: boolean;
@@ -29,7 +28,6 @@ export function useCanvasEditVersionState({
   editSessionActive,
   isEnteringEditSession,
   activeCanvasVersion,
-  effectiveLiveCanvasVersionId,
   liveCanvasVersionId,
   selectableVersionsById,
   isRunInspectionMode,
@@ -39,7 +37,6 @@ export function useCanvasEditVersionState({
   const shouldReadStagedCanvasVersionFlag = shouldReadStagedCanvasVersion({
     editSessionActive,
     activeCanvasVersionId,
-    effectiveLiveCanvasVersionId,
     liveCanvasVersionId,
   });
   const stagedVersionMetadataShell = activeCanvasVersion ?? selectableVersionsById.get(activeCanvasVersionId) ?? null;
@@ -97,7 +94,6 @@ export function useCanvasEditVersionState({
   const isViewingCurrentLiveVersion = isViewingCurrentLiveCanvasVersion({
     activeCanvasVersionId,
     selectedCanvasVersion,
-    effectiveLiveCanvasVersionId,
     liveCanvasVersionId,
   });
   const isEditing = editSessionActive && isViewingCurrentLiveVersion;

--- a/web_src/src/pages/app/useCanvasLifecycleEventHandlers.ts
+++ b/web_src/src/pages/app/useCanvasLifecycleEventHandlers.ts
@@ -42,7 +42,7 @@ export function useCanvasLifecycleEventHandlers({
 
   const invalidateLiveVersionData = useCallback(
     (targetCanvasId: string) => {
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(targetCanvasId) });
+      queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(targetCanvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(targetCanvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(targetCanvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.console(targetCanvasId, undefined) });

--- a/web_src/src/pages/app/useCanvasLifecycleEventHandlers.ts
+++ b/web_src/src/pages/app/useCanvasLifecycleEventHandlers.ts
@@ -42,7 +42,6 @@ export function useCanvasLifecycleEventHandlers({
 
   const invalidateLiveVersionData = useCallback(
     (targetCanvasId: string) => {
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionDescribePrefix(targetCanvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(targetCanvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.canvasStaging(targetCanvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.console(targetCanvasId, undefined) });

--- a/web_src/src/pages/app/useCommittedDraftBaselines.ts
+++ b/web_src/src/pages/app/useCommittedDraftBaselines.ts
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 import type { ConsoleLayoutItem, ConsolePanel } from "@/hooks/useCanvasData";
 
-import { fetchCommittedCanvasVersionWithSpec } from "./lib/repository-spec-files";
+import { fetchCanvasVersionWithSpec } from "./lib/repository-spec-files";
 
 export type CommittedDraftBaselines = {
   canvasSpec?: CanvasesCanvas["spec"];
@@ -50,7 +50,7 @@ export function useCommittedDraftBaselines({
     void Promise.all([
       queryClient.fetchQuery({
         queryKey: canvasKeys.versionDetail(canvasId, versionId),
-        queryFn: () => fetchCommittedCanvasVersionWithSpec(canvasId, versionId),
+        queryFn: () => fetchCanvasVersionWithSpec(canvasId, versionId),
         staleTime: Number.POSITIVE_INFINITY,
       }),
       queryClient.fetchQuery({

--- a/web_src/src/pages/app/useEnterLiveEditSession.ts
+++ b/web_src/src/pages/app/useEnterLiveEditSession.ts
@@ -4,7 +4,7 @@ type UseEnterLiveEditSessionOptions = {
   organizationId?: string;
   canvasId?: string;
   canUpdateCanvas: boolean;
-  effectiveLiveCanvasVersionId?: string;
+  liveCanvasVersionId?: string;
   selectableVersionsById: Map<string, unknown>;
   handleUseVersion: (versionId: string, options?: { preserveStagedLayer?: boolean }) => void;
   resyncStagedEditorState: (
@@ -20,7 +20,7 @@ export function useEnterLiveEditSession({
   organizationId,
   canvasId,
   canUpdateCanvas,
-  effectiveLiveCanvasVersionId,
+  liveCanvasVersionId,
   selectableVersionsById,
   handleUseVersion,
   resyncStagedEditorState,
@@ -40,19 +40,19 @@ export function useEnterLiveEditSession({
         return false;
       }
 
-      if (!effectiveLiveCanvasVersionId) {
+      if (!liveCanvasVersionId) {
         return false;
       }
 
-      if (!selectableVersionsById.has(effectiveLiveCanvasVersionId)) {
+      if (!selectableVersionsById.has(liveCanvasVersionId)) {
         return false;
       }
 
       setIsEnteringEditSession(true);
       try {
         previewingCurrentVersionRef.current = true;
-        handleUseVersion(effectiveLiveCanvasVersionId, { preserveStagedLayer: true });
-        await resyncStagedEditorState(effectiveLiveCanvasVersionId, {
+        handleUseVersion(liveCanvasVersionId, { preserveStagedLayer: true });
+        await resyncStagedEditorState(liveCanvasVersionId, {
           bumpResetNonce: false,
         });
         setEditSessionActive(true);
@@ -72,7 +72,7 @@ export function useEnterLiveEditSession({
     organizationId,
     canvasId,
     canUpdateCanvas,
-    effectiveLiveCanvasVersionId,
+    liveCanvasVersionId,
     selectableVersionsById,
     handleUseVersion,
     resyncStagedEditorState,

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
@@ -44,7 +44,7 @@ describe("useRefreshLatestLiveCanvasData", () => {
     });
 
     expectInvalidation(invalidateQueries, canvasKeys.detail("org-1", "canvas-1"));
-    expectInvalidation(invalidateQueries, canvasKeys.versionList("canvas-1"), { exact: true });
+    expectInvalidation(invalidateQueries, canvasKeys.versionDescribePrefix("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.versionHistory("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.canvasStaging("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", "live-version-1"), { exact: true });
@@ -111,7 +111,7 @@ describe("useRefreshLatestLiveCanvasData", () => {
     });
 
     expectInvalidation(invalidateQueries, canvasKeys.detail("org-1", "canvas-1"));
-    expectInvalidation(invalidateQueries, canvasKeys.versionList("canvas-1"), { exact: true });
+    expectInvalidation(invalidateQueries, canvasKeys.versionDescribePrefix("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.versionHistory("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.canvasStaging("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", "published-version"), { exact: true });

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
@@ -44,7 +44,6 @@ describe("useRefreshLatestLiveCanvasData", () => {
     });
 
     expectInvalidation(invalidateQueries, canvasKeys.detail("org-1", "canvas-1"));
-    expectInvalidation(invalidateQueries, canvasKeys.versionDescribePrefix("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.versionHistory("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.canvasStaging("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", "live-version-1"), { exact: true });
@@ -111,7 +110,6 @@ describe("useRefreshLatestLiveCanvasData", () => {
     });
 
     expectInvalidation(invalidateQueries, canvasKeys.detail("org-1", "canvas-1"));
-    expectInvalidation(invalidateQueries, canvasKeys.versionDescribePrefix("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.versionHistory("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.canvasStaging("canvas-1"));
     expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", "published-version"), { exact: true });

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
@@ -27,8 +27,7 @@ export function useRefreshLatestLiveCanvasData(
           refetchType: "all",
         }),
         queryClient.invalidateQueries({
-          queryKey: canvasKeys.versionList(canvasId),
-          exact: true,
+          queryKey: canvasKeys.versionDescribePrefix(canvasId),
           refetchType: "all",
         }),
         queryClient.invalidateQueries({

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
@@ -10,7 +10,7 @@ export type RefreshLatestLiveCanvasDataOptions = {
 export function useRefreshLatestLiveCanvasData(
   organizationId: string | undefined,
   canvasId: string | undefined,
-  effectiveLiveCanvasVersionId: string | undefined,
+  liveCanvasVersionId: string | undefined,
 ) {
   const queryClient = useQueryClient();
 
@@ -20,7 +20,7 @@ export function useRefreshLatestLiveCanvasData(
         return;
       }
 
-      const liveVersionId = options?.liveVersionId ?? effectiveLiveCanvasVersionId;
+      const liveVersionId = options?.liveVersionId ?? liveCanvasVersionId;
       const invalidations: Array<Promise<unknown>> = [
         queryClient.invalidateQueries({
           queryKey: canvasKeys.detail(organizationId, canvasId),
@@ -56,6 +56,6 @@ export function useRefreshLatestLiveCanvasData(
 
       await Promise.all(invalidations);
     },
-    [organizationId, canvasId, queryClient, effectiveLiveCanvasVersionId],
+    [organizationId, canvasId, queryClient, liveCanvasVersionId],
   );
 }

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
@@ -27,10 +27,6 @@ export function useRefreshLatestLiveCanvasData(
           refetchType: "all",
         }),
         queryClient.invalidateQueries({
-          queryKey: canvasKeys.versionDescribePrefix(canvasId),
-          refetchType: "all",
-        }),
-        queryClient.invalidateQueries({
           queryKey: canvasKeys.versionHistory(canvasId),
           refetchType: "all",
         }),


### PR DESCRIPTION
- Add `live_version_id` to canvas metadata so the UI can describe the live version without calling the version history list.
- Return full workflow spec (nodes/edges) from `DescribeCanvasVersion` and `CommitCanvasStagingResponse`; remove metadata-only serialization.
- Replace `GET /versions?limit=1` with `useDescribeCanvasVersion` for live version metadata on the canvas page.
- Load version spec from `DescribeCanvasVersion` only — drop the parallel `/repository/file` fetch and the list-API fallback.
- Update React Query cache keys from `versionList` to `versionDescribe`, and rename version-fetch helpers (`fetchCanvasVersionWithSpec`, etc.).
