### PR TITLE
fix: correlate factory kanban cards by issue number

### DIFF
--- a/web_src/src/pages/home/factories/software-factory/canvas.yaml
+++ b/web_src/src/pages/home/factories/software-factory/canvas.yaml
@@ -1313,9 +1313,12 @@ spec:
       type: TYPE_ACTION
       component: upsertMemory
       configuration:
+        # Match the card created/updated by Correlate Issue Memory (or create one
+        # for label/assign/mention paths that never ran Submit Task Memory).
+        # Matching on pr_number here would miss that row and insert a duplicate.
         matchList:
-          - name: pr_number
-            value: '{{ $["Open Draft PR"].data.number }}'
+          - name: issue_number
+            value: '{{ root().data.issue.number }}'
         namespace: factory_tasks
         valueList:
           - name: pr_number


### PR DESCRIPTION
## Summary
- Factory console kanban showed two cards for the same task (issue-only + issue+PR) because **Correlate PR Memory** upserted on `pr_number` before that field was set on the existing `factory_tasks` row.
- Match on `issue_number` instead so the draft-PR step updates the card created by Submit/Correlate Issue Memory (and still creates a single card for label/assign/mention paths).

## Test plan
- [ ] Install or update Software Factory from the new-app landing (or re-apply factory canvas YAML)
- [ ] Start a task that creates an issue, then opens a draft PR
- [ ] Confirm the PR pipeline board shows **one** card with both Issue and PR populated
- [ ] Confirm label/assign paths still create a single in-progress card when no prior Submit Task Memory row exists


Made with [Cursor](https://cursor.com)