### PR TITLE
feat: improve Software Factory starting-task prompts and labels

### DIFF
--- a/web_src/src/pages/home/FactorySetupPanel.tsx
+++ b/web_src/src/pages/home/FactorySetupPanel.tsx
@@ -6,7 +6,7 @@ import { useOrganizationId } from "@/hooks/useOrganizationId";
 import { cn } from "@/lib/utils";
 import { IntegrationResourceFieldRenderer } from "@/ui/configurationFieldRenderer/IntegrationResourceFieldRenderer";
 import { SecretPickerFieldRenderer } from "@/ui/configurationFieldRenderer/SecretPickerFieldRenderer";
-import { Bug, FilePenLine, TestTube2, type LucideIcon } from "lucide-react";
+import { Bug, FilePenLine, TestTube2, Workflow, type LucideIcon } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import { getFactoryDefinition, type FactoryDefinition, type FactoryStartingTask } from "./factories";
@@ -16,9 +16,10 @@ import { homeInstallPanelClassName } from "./homePageStyles";
 import type { InstallParam } from "../install/types";
 
 const STARTING_TASK_ICONS: Record<string, { icon: LucideIcon; iconClassName: string }> = {
+  "improve-agents-md": { icon: FilePenLine, iconClassName: "text-violet-500" },
+  "improve-ci": { icon: Workflow, iconClassName: "text-sky-500" },
   "unit-test": { icon: TestTube2, iconClassName: "text-amber-500" },
   "fix-bug": { icon: Bug, iconClassName: "text-red-500" },
-  "improve-agents-md": { icon: FilePenLine, iconClassName: "text-violet-500" },
 };
 
 function normalizeResourceValue(val: string | string[] | undefined): string {

--- a/web_src/src/pages/home/FreshOrgLanding.smoke.spec.tsx
+++ b/web_src/src/pages/home/FreshOrgLanding.smoke.spec.tsx
@@ -54,8 +54,15 @@ describe("FreshOrgLanding", () => {
     expect(within(panel).queryByText("GitHub token secret")).not.toBeInTheDocument();
     expect(within(panel).getByText("Choose starting task")).toBeInTheDocument();
 
-    const taskButtons = within(panel).getAllByRole("button", { name: /^(improve agents\.md|write test|fix bug)$/i });
-    expect(taskButtons.map((button) => button.textContent)).toEqual(["Improve AGENTS.md", "Write test", "Fix bug"]);
+    const taskButtons = within(panel).getAllByRole("button", {
+      name: /^(improve agents\.md|improve test coverage|find and fix a bug|set up or improve ci)$/i,
+    });
+    expect(taskButtons.map((button) => button.textContent)).toEqual([
+      "Improve AGENTS.md",
+      "Improve test coverage",
+      "Find and fix a bug",
+      "Set up or improve CI",
+    ]);
     expect(within(panel).getByRole("button", { name: /^improve agents\.md$/i })).toHaveAttribute(
       "aria-pressed",
       "true",
@@ -67,21 +74,23 @@ describe("FreshOrgLanding", () => {
   it("keeps a starting task selected when the same button is clicked again", async () => {
     const { user, panel } = await openFactorySetup();
 
+    const agentsPrompt =
+      "Improve AGENTS.md for this repo (create it if missing).\n\n- Review the repository to understand layout, build/test, and conventions\n- Cover build/test, key packages, and repo-specific guidance\n- Keep useful guidance; remove generic or outdated advice\n- One focused pass only — do not rewrite unrelated docs";
+    const writeTestPrompt =
+      "Add one focused unit test.\n\n- Review the repository to find core logic and existing test patterns\n- Target a single untested helper or pure function in core logic\n- Use existing test tooling and patterns — do not add a new framework\n- Keep the change as small as possible\n- If there is no test tooling: add only the minimal setup for the primary language, just enough to run that one test";
+
     const promptField = within(panel).getByLabelText(/^Prompt$/i);
     expect(promptField).toHaveAttribute("readonly");
-    expect(promptField).toHaveValue(
-      "Review the existing AGENTS.md and improve it to help coding agents work more effectively in this repository. Make the guidance specific to this codebase, preserving useful instructions and removing outdated or generic ones. If AGENTS.md doesn't exist, create it.",
-    );
+    expect(promptField).toHaveValue(agentsPrompt);
 
-    await user.click(within(panel).getByRole("button", { name: /^write test$/i }));
-    expect(promptField).toHaveValue(
-      "Scan the codebase to understand its main business logic. Then identify ONE untested function related to this business logic and write a single focused, useful unit test for it. Cover the main execution path and follow existing test patterns. Ensure the test passes.",
+    await user.click(within(panel).getByRole("button", { name: /^improve test coverage$/i }));
+    expect(promptField).toHaveValue(writeTestPrompt);
+    await user.click(within(panel).getByRole("button", { name: /^improve test coverage$/i }));
+    expect(within(panel).getByRole("button", { name: /^improve test coverage$/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
     );
-    await user.click(within(panel).getByRole("button", { name: /^write test$/i }));
-    expect(within(panel).getByRole("button", { name: /^write test$/i })).toHaveAttribute("aria-pressed", "true");
-    expect(within(panel).getByLabelText(/^Prompt$/i)).toHaveValue(
-      "Scan the codebase to understand its main business logic. Then identify ONE untested function related to this business logic and write a single focused, useful unit test for it. Cover the main execution path and follow existing test patterns. Ensure the test passes.",
-    );
+    expect(within(panel).getByLabelText(/^Prompt$/i)).toHaveValue(writeTestPrompt);
   });
 
   it("opens GitHub capability setup in a new tab from Connect", async () => {

--- a/web_src/src/pages/home/factories/software-factory/factory.json
+++ b/web_src/src/pages/home/factories/software-factory/factory.json
@@ -21,17 +21,22 @@
     {
       "id": "improve-agents-md",
       "label": "Improve AGENTS.md",
-      "prompt": "Review the existing AGENTS.md and improve it to help coding agents work more effectively in this repository. Make the guidance specific to this codebase, preserving useful instructions and removing outdated or generic ones. If AGENTS.md doesn't exist, create it."
+      "prompt": "Improve AGENTS.md for this repo (create it if missing).\n\n- Review the repository to understand layout, build/test, and conventions\n- Cover build/test, key packages, and repo-specific guidance\n- Keep useful guidance; remove generic or outdated advice\n- One focused pass only — do not rewrite unrelated docs"
     },
     {
       "id": "unit-test",
-      "label": "Write test",
-      "prompt": "Scan the codebase to understand its main business logic. Then identify ONE untested function related to this business logic and write a single focused, useful unit test for it. Cover the main execution path and follow existing test patterns. Ensure the test passes."
+      "label": "Improve test coverage",
+      "prompt": "Add one focused unit test.\n\n- Review the repository to find core logic and existing test patterns\n- Target a single untested helper or pure function in core logic\n- Use existing test tooling and patterns — do not add a new framework\n- Keep the change as small as possible\n- If there is no test tooling: add only the minimal setup for the primary language, just enough to run that one test"
     },
     {
       "id": "fix-bug",
-      "label": "Fix bug",
-      "prompt": "Scan through the codebase to identify bugs that look important or impactful. Focus on issues that could affect functionality, performance, or user experience. Once you find a significant bug, create a new branch, implement a fix, write or update tests as needed, and commit the changes with a clear description."
+      "label": "Find and fix a bug",
+      "prompt": "Fix one high-confidence bug.\n\n- Review the repository to find concrete defects\n- Prefer real defects: wrong logic, clear edge-case failure, or broken error handling\n- Skip style nits and speculative issues\n- Minimal fix only; add/update a test only if tests already exist in that area\n- If no clear bug: fix a correctness footgun (e.g. missing nil/empty check) — do not invent one\n- No broad refactors"
+    },
+    {
+      "id": "improve-ci",
+      "label": "Set up or improve CI",
+      "prompt": "Improve CI for this repo.\n\n- Review the repository to detect the existing CI system from config (Actions, CircleCI, Buildkite, Semaphore, Travis, etc.) — do not assume GitHub Actions\n- If CI exists: one small improvement (caching, triggers, clearer jobs, or an obvious gap)\n- If none exists: add a minimal starter for the host that best matches this repo\n- Prefer the simplest existing check/test/lint command; else a checkout + toolchain smoke step\n- No deploy jobs, secrets, or paid third-party services"
     }
   ],
   "run": {


### PR DESCRIPTION
## Summary
- Rewrite factory starting-task prompts as short, list-style briefs that start by reviewing the repository
- Add a **Set up or improve CI** task (detect existing CI; no GitHub Actions / GitLab assumptions)
- Clarify chip labels: Improve test coverage, Find and fix a bug, Set up or improve CI

## Test plan
- [ ] Open Storybook **Pages/HomePage → Fresh Org**, click **Setup Factory**
- [ ] Confirm task order: Improve AGENTS.md → Improve test coverage → Find and fix a bug → Set up or improve CI
- [ ] Confirm each prompt includes a “Review the repository…” bullet and updates when switching tasks
- [ ] Run `cd web_src && npm test -- --run src/pages/home/FreshOrgLanding.smoke.spec.tsx`


Made with [Cursor](https://cursor.com)