### PR TITLE
fix: enforce organization scoping on CanvasService handlers

### DIFF
--- a/.models-tx-debt-baseline.json
+++ b/.models-tx-debt-baseline.json
@@ -1,6 +1,6 @@
 {
   "maxAllowedInTransactionDefinitions": 160,
-  "maxAllowedDatabaseConnCalls": 187,
+  "maxAllowedDatabaseConnCalls": 180,
   "inTransactionDefinitionKeys": [
     "pkg/models/account.go:MarkPasswordChangedInTransaction",
     "pkg/models/account.go:CreateAccountInTransaction",
@@ -208,10 +208,7 @@
     "pkg/models/canvas.go:ListCanvases:database.Conn()#1",
     "pkg/models/canvas.go:CountCanvasesByOrganizationIDs:database.Conn()#1",
     "pkg/models/canvas.go:CountCanvasesByOrganization:database.Conn()#1",
-    "pkg/models/canvas_event.go:FindCanvasEventForCanvas:database.Conn()#1",
     "pkg/models/canvas_event.go:FindCanvasEvent:database.Conn()#1",
-    "pkg/models/canvas_event.go:ListCanvasEvents:database.Conn()#1",
-    "pkg/models/canvas_event.go:CountCanvasEvents:database.Conn()#1",
     "pkg/models/canvas_event.go:ListPendingCanvasEvents:database.Conn()#1",
     "pkg/models/canvas_event.go:Routed:database.Conn()#1",
     "pkg/models/canvas_folder.go:ListCanvasFolders:database.Conn()#1",
@@ -235,14 +232,10 @@
     "pkg/models/canvas_memory.go:UpdateCanvasMemoriesByNamespace:database.Conn()#1",
     "pkg/models/canvas_node.go:ListCanvasNodesReady:database.Conn()#1",
     "pkg/models/canvas_node.go:ListReadyTriggers:database.Conn()#1",
-    "pkg/models/canvas_node.go:ListNodeQueueItems:database.Conn()#1",
-    "pkg/models/canvas_node.go:CountNodeQueueItems:database.Conn()#1",
     "pkg/models/canvas_node.go:FindNodeQueueItem:database.Conn()#1",
     "pkg/models/canvas_node_execution.go:ListPendingNodeExecutions:database.Conn()#1",
-    "pkg/models/canvas_node_execution.go:ListNodeExecutions:database.Conn()#1",
     "pkg/models/canvas_node_execution.go:ListParentExecutionsForRootEvents:database.Conn()#1",
     "pkg/models/canvas_node_execution.go:ListAllExecutionsForRootEvent:database.Conn()#1",
-    "pkg/models/canvas_node_execution.go:CountNodeExecutions:database.Conn()#1",
     "pkg/models/canvas_node_execution.go:CountRunningExecutionsForNode:database.Conn()#1",
     "pkg/models/canvas_node_execution.go:FindNodeExecution:database.Conn()#1",
     "pkg/models/canvas_node_execution.go:FindNodeExecutionWithNodeID:database.Conn()#1",
@@ -352,5 +345,5 @@
     "pkg/models/webhook.go:ListDeletedWebhooks:database.Conn()#1",
     "pkg/models/webhook.go:ResetStuckProvisioningWebhooks:database.Conn()#1"
   ],
-  "updatedAt": "2026-07-23T15:03:05Z"
+  "updatedAt": "2026-07-25T13:13:22Z"
 }

--- a/pkg/agents/agent_tools/actions/canvas_test.go
+++ b/pkg/agents/agent_tools/actions/canvas_test.go
@@ -300,7 +300,7 @@ func TestAppAgentTool_PatchStagingStagesSmallGraphEdits(t *testing.T) {
 	assert.Equal(t, 2, update.Summary.NodeCount)
 	assert.Equal(t, 1, update.Summary.EdgeCount)
 
-	staging, err := canvasRepository.GetCanvasStaging(ctx, r.Organization.ID.String(), canvas.ID.String())
+	staging, err := canvasRepository.GetCanvasStaging(ctx, database.DB(t.Context()), canvas)
 	require.NoError(t, err)
 	assert.True(t, staging.GetHasStaging())
 	assert.Contains(t, staging.GetStagedPaths(), canvasRepository.CanvasYAMLRepositoryPath)
@@ -415,7 +415,7 @@ func TestAppAgentTool_PatchStagingStagesConsoleYAML(t *testing.T) {
 	// patch_staging writes to the UI staging layer instead of committing into the
 	// live version row, so the edit shows up as pending staging that the user
 	// reviews and publishes, exactly like an edit made in the UI editor.
-	staging, err := canvasRepository.GetCanvasStaging(ctx, r.Organization.ID.String(), canvas.ID.String())
+	staging, err := canvasRepository.GetCanvasStaging(ctx, database.DB(t.Context()), canvas)
 	require.NoError(t, err)
 	assert.True(t, staging.GetHasStaging())
 	assert.Contains(t, staging.GetStagedPaths(), canvasRepository.ConsoleYAMLRepositoryPath)

--- a/pkg/agents/agent_tools/actions/patch_staging.go
+++ b/pkg/agents/agent_tools/actions/patch_staging.go
@@ -237,8 +237,8 @@ func stagePatchedDraftFiles(ctx context.Context, session agents.AgentSessionCont
 
 	if _, err := canvasRepository.PutCanvasStaging(
 		ctx,
-		session.OrganizationID,
-		session.CanvasID,
+		database.DB(ctx),
+		canvas,
 		operations,
 	); err != nil {
 		return fmt.Errorf("stage patched draft files: %w", err)

--- a/pkg/agents/agent_tools/actions/read_runtime.go
+++ b/pkg/agents/agent_tools/actions/read_runtime.go
@@ -124,6 +124,11 @@ func (a readRuntimeAction) checkReadPermission(ctx context.Context, session agen
 }
 
 func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSessionContext, input Input, resource string) (any, error) {
+	orgID, err := uuid.Parse(session.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid session organization id: %w", err)
+	}
+
 	canvasID, err := uuid.Parse(session.CanvasID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid session canvas id: %w", err)
@@ -134,9 +139,14 @@ func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSession
 		return nil, err
 	}
 
+	canvas, err := models.FindCanvasInTransaction(database.DB(ctx), orgID, canvasID)
+	if err != nil {
+		return nil, fmt.Errorf("find canvas: %w", err)
+	}
+
 	switch resource {
 	case "memory":
-		response, err := canvasactions.ListCanvasMemories(ctx, a.registry, session.OrganizationID, session.CanvasID)
+		response, err := canvasactions.ListCanvasMemories(ctx, database.DB(ctx), canvas)
 		if err != nil {
 			return nil, err
 		}
@@ -150,12 +160,12 @@ func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSession
 		if err != nil {
 			return nil, err
 		}
-		return protoPayload(canvasactions.ListRuns(ctx, a.registry, canvasID, input.Limit, before, states, results))
+		return protoPayload(canvasactions.ListRuns(ctx, database.DB(ctx), canvas, input.Limit, before, states, results))
 	case "event_executions":
 		if strings.TrimSpace(input.EventID) == "" {
 			return nil, fmt.Errorf("event_id is required for event_executions")
 		}
-		return protoPayload(canvasactions.ListEventExecutions(ctx, a.registry, session.CanvasID, input.EventID))
+		return protoPayload(canvasactions.ListEventExecutions(ctx, database.DB(ctx), canvas, input.EventID))
 	case "node_executions":
 		if strings.TrimSpace(input.NodeID) == "" {
 			return nil, fmt.Errorf("node_id is required for node_executions")
@@ -168,17 +178,17 @@ func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSession
 		if err != nil {
 			return nil, err
 		}
-		return protoPayload(canvasactions.ListNodeExecutions(ctx, a.registry, session.CanvasID, input.NodeID, states, results, input.Limit, before))
+		return protoPayload(canvasactions.ListNodeExecutions(ctx, database.DB(ctx), canvas, input.NodeID, states, results, input.Limit, before))
 	case "node_queue_items":
 		if strings.TrimSpace(input.NodeID) == "" {
 			return nil, fmt.Errorf("node_id is required for node_queue_items")
 		}
-		return protoPayload(canvasactions.ListNodeQueueItems(ctx, a.registry, session.CanvasID, input.NodeID, input.Limit, before))
+		return protoPayload(canvasactions.ListNodeQueueItems(ctx, database.DB(ctx), canvas, input.NodeID, input.Limit, before))
 	case "node_events":
 		if strings.TrimSpace(input.NodeID) == "" {
 			return nil, fmt.Errorf("node_id is required for node_events")
 		}
-		return protoPayload(canvasactions.ListNodeEvents(ctx, a.registry, canvasID, input.NodeID, input.Limit, before))
+		return protoPayload(canvasactions.ListNodeEvents(ctx, database.DB(ctx), canvas, input.NodeID, input.Limit, before))
 	case "runner_logs":
 		return a.readRunnerLogs(ctx, session, canvasID, input)
 	default:

--- a/pkg/agents/agent_tools/actions/repository_files.go
+++ b/pkg/agents/agent_tools/actions/repository_files.go
@@ -42,7 +42,22 @@ func (a listFilesAction) Execute(ctx context.Context, session agents.AgentSessio
 		return fileListResult{}, fmt.Errorf("git provider is not configured")
 	}
 
-	response, err := canvasRepository.ListCanvasRepositoryFiles(ctx, a.gitProvider, session.OrganizationID, session.CanvasID)
+	orgID, err := uuid.Parse(session.OrganizationID)
+	if err != nil {
+		return fileListResult{}, fmt.Errorf("invalid session organization id: %w", err)
+	}
+
+	canvasID, err := uuid.Parse(session.CanvasID)
+	if err != nil {
+		return fileListResult{}, fmt.Errorf("invalid session canvas id: %w", err)
+	}
+
+	canvas, err := models.FindCanvas(orgID, canvasID)
+	if err != nil {
+		return fileListResult{}, fmt.Errorf("find canvas: %w", err)
+	}
+
+	response, err := canvasRepository.ListCanvasRepositoryFiles(ctx, a.gitProvider, canvas)
 	if err != nil {
 		return fileListResult{}, err
 	}
@@ -218,6 +233,22 @@ func (writeFileAction) Execute(ctx context.Context, session agents.AgentSessionC
 		return fileStageResult{}, err
 	}
 
+	orgID, err := uuid.Parse(session.OrganizationID)
+	if err != nil {
+		return fileStageResult{}, fmt.Errorf("invalid session organization id: %w", err)
+	}
+
+	canvasID, err := uuid.Parse(session.CanvasID)
+	if err != nil {
+		return fileStageResult{}, fmt.Errorf("invalid session canvas id: %w", err)
+	}
+
+	db := database.DB(ctx)
+	canvas, err := models.FindCanvasInTransaction(db, orgID, canvasID)
+	if err != nil {
+		return fileStageResult{}, fmt.Errorf("find canvas: %w", err)
+	}
+
 	liveVersion, err := resolveFileLiveVersion(session, input)
 	if err != nil {
 		return fileStageResult{}, err
@@ -225,8 +256,8 @@ func (writeFileAction) Execute(ctx context.Context, session agents.AgentSessionC
 
 	state, err := canvasRepository.PutCanvasStaging(
 		ctx,
-		session.OrganizationID,
-		session.CanvasID,
+		db,
+		canvas,
 		[]*pb.CanvasRepositoryFileOperation{{Path: path, Content: []byte(input.Content)}},
 	)
 	if err != nil {
@@ -254,6 +285,22 @@ func (deleteFileAction) Execute(ctx context.Context, session agents.AgentSession
 		return fileStageResult{}, err
 	}
 
+	orgID, err := uuid.Parse(session.OrganizationID)
+	if err != nil {
+		return fileStageResult{}, fmt.Errorf("invalid session organization id: %w", err)
+	}
+
+	canvasID, err := uuid.Parse(session.CanvasID)
+	if err != nil {
+		return fileStageResult{}, fmt.Errorf("invalid session canvas id: %w", err)
+	}
+
+	db := database.DB(ctx)
+	canvas, err := models.FindCanvasInTransaction(db, orgID, canvasID)
+	if err != nil {
+		return fileStageResult{}, fmt.Errorf("find canvas: %w", err)
+	}
+
 	liveVersion, err := resolveFileLiveVersion(session, input)
 	if err != nil {
 		return fileStageResult{}, err
@@ -261,8 +308,8 @@ func (deleteFileAction) Execute(ctx context.Context, session agents.AgentSession
 
 	state, err := canvasRepository.PutCanvasStaging(
 		ctx,
-		session.OrganizationID,
-		session.CanvasID,
+		db,
+		canvas,
 		[]*pb.CanvasRepositoryFileOperation{{Path: path, Delete: true}},
 	)
 	if err != nil {

--- a/pkg/grpc/actions/canvases/cancel_execution.go
+++ b/pkg/grpc/actions/canvases/cancel_execution.go
@@ -8,29 +8,27 @@ import (
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/crypto"
-	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"gorm.io/gorm"
 )
 
-func CancelExecution(ctx context.Context, authService authorization.Authorization, encryptor crypto.Encryptor, organizationID string, registry *registry.Registry, workflowID, executionID uuid.UUID) (*pb.CancelExecutionResponse, error) {
+func CancelExecution(ctx context.Context, authService authorization.Authorization, encryptor crypto.Encryptor, db *gorm.DB, canvas *models.Canvas, executionID uuid.UUID) (*pb.CancelExecutionResponse, error) {
 	userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
 	if !userIsSet {
 		return nil, grpcerrors.PermissionDenied(nil, "user not authenticated")
 	}
 
-	user, err := models.FindActiveUserByID(organizationID, userID)
+	user, err := models.FindActiveUserByID(canvas.OrganizationID.String(), userID)
 	if err != nil {
 		return nil, grpcerrors.NotFound(err, "user not found")
 	}
 
 	var cancelled bool
-	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
-		execution, err := models.FindNodeExecutionInTransaction(tx, workflowID, executionID)
+	err = db.Transaction(func(tx *gorm.DB) error {
+		execution, err := models.FindNodeExecutionInTransaction(tx, canvas.ID, executionID)
 		if err != nil {
 			return grpcerrors.NotFound(err, "execution not found")
 		}
@@ -51,7 +49,7 @@ func CancelExecution(ctx context.Context, authService authorization.Authorizatio
 	}
 
 	if cancelled {
-		if err := messages.PublishCanvasExecutionByID(workflowID, executionID); err != nil {
+		if err := messages.PublishCanvasExecutionByID(canvas.ID, executionID); err != nil {
 			log.Errorf("failed to publish execution cancelling RabbitMQ message: %v", err)
 		}
 	}

--- a/pkg/grpc/actions/canvases/cancel_execution_test.go
+++ b/pkg/grpc/actions/canvases/cancel_execution_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/config"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	testconsumer "github.com/superplanehq/superplane/test/consumer"
@@ -46,7 +47,7 @@ func Test__CancelExecution__RequestsCancellation(t *testing.T) {
 
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	response, err := CancelExecution(ctx, r.AuthService, r.Encryptor, r.Organization.ID.String(), r.Registry, canvas.ID, execution.ID)
+	response, err := CancelExecution(ctx, r.AuthService, r.Encryptor, database.DB(t.Context()), canvas, execution.ID)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	assert.True(t, cancellingConsumer.HasReceivedMessage())
@@ -82,10 +83,10 @@ func Test__CancelExecution__IsIdempotent(t *testing.T) {
 
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	_, err := CancelExecution(ctx, r.AuthService, r.Encryptor, r.Organization.ID.String(), r.Registry, canvas.ID, execution.ID)
+	_, err := CancelExecution(ctx, r.AuthService, r.Encryptor, database.DB(t.Context()), canvas, execution.ID)
 	require.NoError(t, err)
 
-	_, err = CancelExecution(ctx, r.AuthService, r.Encryptor, r.Organization.ID.String(), r.Registry, canvas.ID, execution.ID)
+	_, err = CancelExecution(ctx, r.AuthService, r.Encryptor, database.DB(t.Context()), canvas, execution.ID)
 	require.NoError(t, err)
 
 	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
@@ -114,6 +115,6 @@ func Test__CancelExecution__ReturnsNotFoundForNonExistentExecution(t *testing.T)
 	)
 
 	nonExistentID := uuid.New()
-	_, err := CancelExecution(context.Background(), r.AuthService, r.Encryptor, r.Organization.ID.String(), r.Registry, canvas.ID, nonExistentID)
+	_, err := CancelExecution(context.Background(), r.AuthService, r.Encryptor, database.DB(t.Context()), canvas, nonExistentID)
 	require.Error(t, err)
 }

--- a/pkg/grpc/actions/canvases/cancel_run.go
+++ b/pkg/grpc/actions/canvases/cancel_run.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
-	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -15,13 +14,13 @@ import (
 	"gorm.io/gorm"
 )
 
-func CancelRun(ctx context.Context, organizationID string, workflowID, runID uuid.UUID) (*pb.CancelRunResponse, error) {
+func CancelRun(ctx context.Context, db *gorm.DB, canvas *models.Canvas, runID uuid.UUID) (*pb.CancelRunResponse, error) {
 	userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
 	if !userIsSet {
 		return nil, grpcerrors.PermissionDenied(nil, "user not authenticated")
 	}
 
-	user, err := models.FindActiveUserByID(organizationID, userID)
+	user, err := models.FindActiveUserByIDInTransaction(db, canvas.OrganizationID.String(), userID)
 	if err != nil {
 		return nil, grpcerrors.NotFound(err, "user not found")
 	}
@@ -30,7 +29,7 @@ func CancelRun(ctx context.Context, organizationID string, workflowID, runID uui
 	var drainResult *models.RunCancellationDrainResult
 	var publishCancelled bool
 
-	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
+	err = db.Transaction(func(tx *gorm.DB) error {
 		run, err = models.LockCanvasRunInTransaction(tx, runID)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -40,7 +39,7 @@ func CancelRun(ctx context.Context, organizationID string, workflowID, runID uui
 			return err
 		}
 
-		if run.WorkflowID != workflowID {
+		if run.WorkflowID != canvas.ID {
 			return grpcerrors.NotFound(nil, "run not found")
 		}
 
@@ -66,25 +65,25 @@ func CancelRun(ctx context.Context, organizationID string, workflowID, runID uui
 	}
 
 	if publishCancelled {
-		if err := messages.NewCanvasRunMessage(workflowID.String(), runID.String()).Publish(); err != nil {
+		if err := messages.NewCanvasRunMessage(canvas.ID.String(), runID.String()).Publish(); err != nil {
 			log.Errorf("failed to publish run state RabbitMQ message: %v", err)
 		}
 	}
 
-	messages.PublishRunCancellationDrain(workflowID, drainResult)
+	messages.PublishRunCancellationDrain(canvas.ID, drainResult)
 
-	run, err = models.FindCanvasRunInTransaction(database.DB(ctx), workflowID, runID)
+	run, err = models.FindCanvasRunInTransaction(db, canvas.ID, runID)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to load run")
 	}
 
-	runDetails, err := loadRunDetailsForRuns(ctx, workflowID, []models.CanvasRun{*run})
+	runDetails, err := loadRunDetailsForRuns(ctx, db, canvas.ID, []models.CanvasRun{*run})
 	if err != nil {
 		return nil, err
 	}
 
 	serializedRun, err := SerializeCanvasRun(
-		database.DB(ctx),
+		db,
 		*run,
 		runDetails.rootEventsByRunID[run.ID.String()],
 		runDetails.executionsByRunID[run.ID.String()],

--- a/pkg/grpc/actions/canvases/cancel_run_test.go
+++ b/pkg/grpc/actions/canvases/cancel_run_test.go
@@ -77,7 +77,7 @@ func Test__CancelRun__RequestsCancellationAndDrainsWork(t *testing.T) {
 
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	response, err := CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	response, err := CancelRun(ctx, database.DB(t.Context()), canvas, run.ID)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.NotNil(t, response.Run)
@@ -132,10 +132,10 @@ func Test__CancelRun__IsIdempotentForCancellingRun(t *testing.T) {
 
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	_, err = CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	_, err = CancelRun(ctx, database.DB(t.Context()), canvas, run.ID)
 	require.NoError(t, err)
 
-	_, err = CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	_, err = CancelRun(ctx, database.DB(t.Context()), canvas, run.ID)
 	require.NoError(t, err)
 
 	updatedRun, err := models.FindCanvasRunInTransaction(database.Conn(), canvas.ID, run.ID)
@@ -176,7 +176,7 @@ func Test__CancelRun__NoOpForFinishedRun(t *testing.T) {
 
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	response, err := CancelRun(ctx, r.Organization.ID.String(), canvas.ID, run.ID)
+	response, err := CancelRun(ctx, database.DB(t.Context()), canvas, run.ID)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	assert.Equal(t, pb.CanvasRun_STATE_FINISHED, response.Run.State)
@@ -222,7 +222,7 @@ func Test__CancelRun__ReturnsParentRefForSubRun(t *testing.T) {
 
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	response, err := CancelRun(ctx, r.Organization.ID.String(), childCanvas.ID, childRun.ID)
+	response, err := CancelRun(ctx, database.DB(t.Context()), childCanvas, childRun.ID)
 	require.NoError(t, err)
 	require.NotNil(t, response.Run.Parent)
 	assert.Equal(t, parentRun.ID.String(), response.Run.Parent.Id)
@@ -243,6 +243,6 @@ func Test__CancelRun__ReturnsNotFoundForMissingRun(t *testing.T) {
 
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	_, err := CancelRun(ctx, r.Organization.ID.String(), canvas.ID, uuid.New())
+	_, err := CancelRun(ctx, database.DB(t.Context()), canvas, uuid.New())
 	require.Error(t, err)
 }

--- a/pkg/grpc/actions/canvases/canvas_memory_namespace_test.go
+++ b/pkg/grpc/actions/canvases/canvas_memory_namespace_test.go
@@ -80,7 +80,7 @@ func Test__UpdateCanvasMemoryNamespace(t *testing.T) {
 			canvas,
 			"durable-namespace",
 			"",
-			structpbEntries(t, map[string]any{"key": "value"}),
+			nil,
 		)
 		code, _, ok := grpcerrors.HandlerStatus(err)
 		require.True(t, ok)

--- a/pkg/grpc/actions/canvases/canvas_memory_namespace_test.go
+++ b/pkg/grpc/actions/canvases/canvas_memory_namespace_test.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/database"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/grpc/codes"
@@ -29,7 +30,7 @@ func Test__CreateCanvasMemoryNamespace(t *testing.T) {
 	t.Run("empty entries -> error and no namespace persisted", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
 
-		_, err := CreateCanvasMemoryNamespace(context.Background(), r.Registry, r.Organization.ID.String(), canvas.ID.String(), "empty-namespace", nil)
+		_, err := CreateCanvasMemoryNamespace(context.Background(), database.DB(t.Context()), canvas, "empty-namespace", nil)
 		code, _, ok := grpcerrors.HandlerStatus(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, code)
@@ -44,9 +45,8 @@ func Test__CreateCanvasMemoryNamespace(t *testing.T) {
 
 		resp, err := CreateCanvasMemoryNamespace(
 			context.Background(),
-			r.Registry,
-			r.Organization.ID.String(),
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			"release-cache",
 			structpbEntries(t, map[string]any{"key": "value"}),
 		)
@@ -67,9 +67,8 @@ func Test__UpdateCanvasMemoryNamespace(t *testing.T) {
 
 		_, err := CreateCanvasMemoryNamespace(
 			context.Background(),
-			r.Registry,
-			r.Organization.ID.String(),
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			"durable-namespace",
 			structpbEntries(t, map[string]any{"key": "value"}),
 		)
@@ -77,12 +76,11 @@ func Test__UpdateCanvasMemoryNamespace(t *testing.T) {
 
 		_, err = UpdateCanvasMemoryNamespace(
 			context.Background(),
-			r.Registry,
-			r.Organization.ID.String(),
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			"durable-namespace",
 			"",
-			nil,
+			structpbEntries(t, map[string]any{"key": "value"}),
 		)
 		code, _, ok := grpcerrors.HandlerStatus(err)
 		require.True(t, ok)
@@ -98,9 +96,8 @@ func Test__UpdateCanvasMemoryNamespace(t *testing.T) {
 
 		_, err := CreateCanvasMemoryNamespace(
 			context.Background(),
-			r.Registry,
-			r.Organization.ID.String(),
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			"replace-namespace",
 			structpbEntries(t, map[string]any{"key": "v1"}),
 		)
@@ -108,9 +105,8 @@ func Test__UpdateCanvasMemoryNamespace(t *testing.T) {
 
 		resp, err := UpdateCanvasMemoryNamespace(
 			context.Background(),
-			r.Registry,
-			r.Organization.ID.String(),
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			"replace-namespace",
 			"",
 			structpbEntries(t, map[string]any{"key": "v2"}, map[string]any{"key": "v3"}),

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
@@ -232,7 +232,7 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, models.CanvasNodeExecutionStateCancelling, updatedExecution.State)
 
-		queueItems, err := models.ListNodeQueueItems(canvas.ID, "approval-node", 10, nil)
+		queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, "approval-node", 10, nil)
 		require.NoError(t, err)
 		require.Empty(t, queueItems)
 

--- a/pkg/grpc/actions/canvases/commit_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_staging.go
@@ -3,7 +3,6 @@ package canvases
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -15,7 +14,6 @@ import (
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/crypto"
-	"github.com/superplanehq/superplane/pkg/database"
 	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases/changesets"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
@@ -33,37 +31,22 @@ import (
 
 func CommitCanvasStaging(
 	ctx context.Context,
+	db *gorm.DB,
 	gitProvider gitprovider.Provider,
 	usageService usage.Service,
 	encryptor crypto.Encryptor,
 	registry *registry.Registry,
-	organizationID string,
-	canvasID string,
+	canvas *models.Canvas,
 	commitMessage string,
 	webhookBaseURL string,
 	authService authorization.Authorization,
 ) (*pb.CommitCanvasStagingResponse, error) {
-	db := database.DB(ctx)
-
 	user, ok := authentication.GetUserIdFromMetadata(ctx)
 	if !ok {
 		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
 	}
 
 	userID := uuid.MustParse(user)
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	canvas, err := models.FindCanvasInTransaction(db, uuid.MustParse(organizationID), canvasUUID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
-	}
-
 	stagedFiles, err := models.ListStagedFilesForUser(db, canvas.ID, userID)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to load staging")
@@ -98,7 +81,7 @@ func CommitCanvasStaging(
 			ctx,
 			gitProvider,
 			canvas,
-			organizationID,
+			canvas.OrganizationID.String(),
 			userID.String(),
 			resolvedStagingCommitMessage(commitMessage),
 			gitOps,
@@ -128,7 +111,7 @@ func CommitCanvasStaging(
 			tx,
 			usageService,
 			registry,
-			organizationID,
+			canvas.OrganizationID.String(),
 			canvas,
 			liveVersion,
 			specOps,
@@ -181,8 +164,8 @@ func CommitCanvasStaging(
 	//
 	if err != nil {
 		if len(gitRevertOps) > 0 {
-			if revertErr := revertGitFileCommit(ctx, gitProvider, canvas, organizationID, userID.String(), gitRevertOps); revertErr != nil {
-				log.Errorf("failed to revert git commit after spec apply failure for canvas %s: %v", canvasID, revertErr)
+			if revertErr := revertGitFileCommit(ctx, gitProvider, canvas, canvas.OrganizationID.String(), userID.String(), gitRevertOps); revertErr != nil {
+				log.Errorf("failed to revert git commit after spec apply failure for canvas %s: %v", canvas.ID.String(), revertErr)
 			}
 		}
 
@@ -194,7 +177,7 @@ func CommitCanvasStaging(
 		return nil, grpcerrors.Internal(err, "failed to commit staging")
 	}
 
-	if err := messages.NewCanvasUpdatedMessage(canvas.ID.String(), organizationID).PublishUpdated(); err != nil {
+	if err := messages.NewCanvasUpdatedMessage(canvas.ID.String(), canvas.OrganizationID.String()).PublishUpdated(); err != nil {
 		log.Errorf("failed to publish canvas updated RabbitMQ message: %v", err)
 	}
 
@@ -204,10 +187,10 @@ func CommitCanvasStaging(
 
 	publishDeletedNodeCleanupMessages(canvas.ID, publishResult)
 
-	ownersByID, _ := ownersByIDForCanvasVersions(ctx, organizationID, []models.CanvasVersion{*newLiveVersion})
+	ownersByID, _ := ownersByIDForCanvasVersions(ctx, canvas.OrganizationID.String(), []models.CanvasVersion{*newLiveVersion})
 
 	return &pb.CommitCanvasStagingResponse{
-		Version:        SerializeCanvasVersion(newLiveVersion, organizationID, ownersByID),
+		Version:        SerializeCanvasVersion(newLiveVersion, canvas.OrganizationID.String(), ownersByID),
 		StagingSummary: buildStagingSummary(canvas, []models.WorkflowStagedFile{}),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/commit_canvas_staging_test.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_staging_test.go
@@ -20,18 +20,17 @@ import (
 
 func Test__CommitCanvasStaging__AppliesStagedCanvas(t *testing.T) {
 	r, ctx, canvas, version := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
 
 	baseline, err := ReadRepositorySpecFile(ctx, canvas, version, CanvasYAMLRepositoryPath)
 	require.NoError(t, err)
 	staged := baseline + "\n# staged edit\n"
 
-	_, err = PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err = PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: CanvasYAMLRepositoryPath, Content: []byte(staged)},
 	})
 	require.NoError(t, err)
 
-	resp, err := CommitCanvasStaging(ctx, nil, nil, r.Encryptor, r.Registry, orgID, canvas.ID.String(), "Update canvas", "", r.AuthService)
+	resp, err := CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Update canvas", "", r.AuthService)
 	require.NoError(t, err)
 	assert.False(t, resp.GetStagingSummary().GetHasStaging())
 	require.NotNil(t, resp.GetVersion().GetMetadata())
@@ -55,7 +54,6 @@ func Test__CommitCanvasStaging__AppliesStagedCanvas(t *testing.T) {
 
 func Test__CommitCanvasStaging__IgnoresRenamedCanvasInYAML(t *testing.T) {
 	r, ctx, canvas, version := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
 
 	baseline, err := ReadRepositorySpecFile(ctx, canvas, version, CanvasYAMLRepositoryPath)
 	require.NoError(t, err)
@@ -63,12 +61,12 @@ func Test__CommitCanvasStaging__IgnoresRenamedCanvasInYAML(t *testing.T) {
 	renamed := strings.Replace(baseline, "name: "+canvas.Name, "name: "+canvas.Name+"-staged", 1)
 	require.NotEqual(t, baseline, renamed)
 
-	_, err = PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err = PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: CanvasYAMLRepositoryPath, Content: []byte(renamed)},
 	})
 	require.NoError(t, err)
 
-	_, err = CommitCanvasStaging(ctx, nil, nil, r.Encryptor, r.Registry, orgID, canvas.ID.String(), "Rename attempt", "", r.AuthService)
+	_, err = CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Rename attempt", "", r.AuthService)
 	require.NoError(t, err)
 
 	updatedCanvas, err := models.FindCanvas(r.Organization.ID, canvas.ID)
@@ -78,14 +76,13 @@ func Test__CommitCanvasStaging__IgnoresRenamedCanvasInYAML(t *testing.T) {
 
 func Test__CommitCanvasStaging__RejectsInvalidConsoleYAML(t *testing.T) {
 	r, ctx, canvas, _ := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
 
-	_, err := PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err := PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: ConsoleYAMLRepositoryPath, Content: []byte("just a scalar, not an object")},
 	})
 	require.NoError(t, err)
 
-	_, err = CommitCanvasStaging(ctx, nil, nil, r.Encryptor, r.Registry, orgID, canvas.ID.String(), "Bad console", "", r.AuthService)
+	_, err = CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Bad console", "", r.AuthService)
 	code, msg, ok := grpcerrors.HandlerStatus(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, code)
@@ -94,9 +91,8 @@ func Test__CommitCanvasStaging__RejectsInvalidConsoleYAML(t *testing.T) {
 
 func Test__CommitCanvasStaging__RequiresStagedChanges(t *testing.T) {
 	r, ctx, canvas, _ := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
 
-	_, err := CommitCanvasStaging(ctx, nil, nil, r.Encryptor, r.Registry, orgID, canvas.ID.String(), "Nothing to commit", "", r.AuthService)
+	_, err := CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Nothing to commit", "", r.AuthService)
 	code, msg, ok := grpcerrors.HandlerStatus(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, code)
@@ -106,12 +102,10 @@ func Test__CommitCanvasStaging__RequiresStagedChanges(t *testing.T) {
 func Test__CommitCanvasStaging__StageArbitraryRepositoryFileCommitsToGit(t *testing.T) {
 	r := support.Setup(t)
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
-	orgID := r.Organization.ID.String()
 
 	canvas, repository := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
-	canvasID := canvas.ID.String()
 
-	_, err := PutCanvasStaging(ctx, orgID, canvasID, []*pb.CanvasRepositoryFileOperation{
+	_, err := PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: "README.md", Content: []byte("staged readme")},
 	})
 	require.NoError(t, err)
@@ -124,7 +118,7 @@ func Test__CommitCanvasStaging__StageArbitraryRepositoryFileCommitsToGit(t *test
 	require.NoError(t, reader.Close())
 	assert.Equal(t, "staged readme", string(content))
 
-	resp, err := CommitCanvasStaging(ctx, r.GitProvider, nil, r.Encryptor, r.Registry, orgID, canvasID, "Add readme", "", r.AuthService)
+	resp, err := CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Add readme", "", r.AuthService)
 	require.NoError(t, err)
 	assert.False(t, resp.GetStagingSummary().GetHasStaging())
 
@@ -143,7 +137,6 @@ func Test__CommitCanvasStaging__StageArbitraryRepositoryFileCommitsToGit(t *test
 func Test__CommitCanvasStaging__RejectsStaleStaging(t *testing.T) {
 	r := support.Setup(t)
 	ownerCtx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
-	orgID := r.Organization.ID.String()
 
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
 	liveVersion, err := models.FindLiveCanvasVersion(canvas.ID)
@@ -152,7 +145,7 @@ func Test__CommitCanvasStaging__RejectsStaleStaging(t *testing.T) {
 	baseline, err := ReadRepositorySpecFile(ownerCtx, canvas, liveVersion, CanvasYAMLRepositoryPath)
 	require.NoError(t, err)
 
-	_, err = PutCanvasStaging(ownerCtx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err = PutCanvasStaging(ownerCtx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: CanvasYAMLRepositoryPath, Content: []byte(baseline + "\n# owner staged\n")},
 	})
 	require.NoError(t, err)
@@ -160,15 +153,15 @@ func Test__CommitCanvasStaging__RejectsStaleStaging(t *testing.T) {
 	otherUser := support.CreateUser(t, r, r.Organization.ID)
 	otherCtx := authentication.SetUserIdInMetadata(context.Background(), otherUser.ID.String())
 
-	_, err = PutCanvasStaging(otherCtx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err = PutCanvasStaging(otherCtx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: CanvasYAMLRepositoryPath, Content: []byte(baseline + "\n# other commit\n")},
 	})
 	require.NoError(t, err)
 
-	_, err = CommitCanvasStaging(otherCtx, nil, nil, r.Encryptor, r.Registry, orgID, canvas.ID.String(), "Promote live", "", r.AuthService)
+	_, err = CommitCanvasStaging(otherCtx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Promote live", "", r.AuthService)
 	require.NoError(t, err)
 
-	_, err = CommitCanvasStaging(ownerCtx, nil, nil, r.Encryptor, r.Registry, orgID, canvas.ID.String(), "Stale commit", "", r.AuthService)
+	_, err = CommitCanvasStaging(ownerCtx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Stale commit", "", r.AuthService)
 	code, msg, ok := grpcerrors.HandlerStatus(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, code)

--- a/pkg/grpc/actions/canvases/common.go
+++ b/pkg/grpc/actions/canvases/common.go
@@ -15,21 +15,6 @@ import (
 
 const canvasNameAlreadyExistsMessage = "Canvas with the same name already exists"
 
-func checkCanvasExistence(ctx context.Context, db *gorm.DB, orgID, canvasID uuid.UUID) (err error) {
-	ctx, done := telemetry.Span(ctx, "canvases.check_canvas_existence")
-	defer done(&err)
-
-	exists, err := models.CheckCanvasExistence(db.WithContext(ctx), orgID, canvasID)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return gorm.ErrRecordNotFound
-	}
-
-	return nil
-}
-
 func loadCanvas(ctx context.Context, db *gorm.DB, orgID, canvasID uuid.UUID) (canvas *models.Canvas, err error) {
 	ctx, done := telemetry.Span(ctx, "canvases.find_canvas")
 	defer done(&err)

--- a/pkg/grpc/actions/canvases/create_canvas_memory_namespace.go
+++ b/pkg/grpc/actions/canvases/create_canvas_memory_namespace.go
@@ -2,32 +2,19 @@ package canvases
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"github.com/google/uuid"
+	"strings"
+
 	log "github.com/sirupsen/logrus"
-	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
-	"strings"
 )
 
-func CreateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registry, organizationID, canvasID, namespace string, entries []*structpb.Value) (*pb.CreateCanvasMemoryNamespaceResponse, error) {
-	orgUUID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid organization_id")
-	}
-
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid canvas_id")
-	}
-
+func CreateCanvasMemoryNamespace(ctx context.Context, db *gorm.DB, canvas *models.Canvas, namespace string, entries []*structpb.Value) (*pb.CreateCanvasMemoryNamespaceResponse, error) {
 	namespace = strings.TrimSpace(namespace)
 	if namespace == "" {
 		return nil, grpcerrors.InvalidArgument(nil, "namespace is required")
@@ -37,22 +24,14 @@ func CreateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 		return nil, grpcerrors.InvalidArgument(nil, "at least one entry is required")
 	}
 
-	_, err = models.FindCanvas(orgUUID, canvasUUID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
-	}
-
 	decodedEntries := make([]any, 0, len(entries))
 	for _, value := range entries {
 		decodedEntries = append(decodedEntries, value.AsInterface())
 	}
 
 	var stored []models.CanvasMemory
-	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		existingSource, txErr := models.CanvasMemoryNamespaceSourceInTransaction(tx, canvasUUID, namespace)
+	err := db.Transaction(func(tx *gorm.DB) error {
+		existingSource, txErr := models.CanvasMemoryNamespaceSourceInTransaction(tx, canvas.ID, namespace)
 		if txErr != nil {
 			return txErr
 		}
@@ -61,11 +40,11 @@ func CreateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 			return grpcerrors.InvalidArgument(nil, fmt.Sprintf("memory namespace %q already exists", namespace))
 		}
 
-		if txErr := models.ReplaceManualCanvasMemoryNamespaceInTransaction(tx, canvasUUID, namespace, decodedEntries); txErr != nil {
+		if txErr := models.ReplaceManualCanvasMemoryNamespaceInTransaction(tx, canvas.ID, namespace, decodedEntries); txErr != nil {
 			return txErr
 		}
 
-		records, txErr := models.ListCanvasMemoriesByNamespaceInTransaction(tx, canvasUUID, namespace)
+		records, txErr := models.ListCanvasMemoriesByNamespaceInTransaction(tx, canvas.ID, namespace)
 		if txErr != nil {
 			return txErr
 		}
@@ -81,7 +60,7 @@ func CreateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 		return nil, grpcerrors.Internal(err, "failed to create canvas memory namespace")
 	}
 
-	if err := messages.NewCanvasMemoryUpdatedMessage(canvasUUID.String()).PublishMemoryUpdated(); err != nil {
+	if err := messages.NewCanvasMemoryUpdatedMessage(canvas.ID.String()).PublishMemoryUpdated(); err != nil {
 		log.Errorf("failed to publish canvas memory updated RabbitMQ message: %v", err)
 	}
 

--- a/pkg/grpc/actions/canvases/delete_canvas.go
+++ b/pkg/grpc/actions/canvases/delete_canvas.go
@@ -3,29 +3,18 @@ package canvases
 import (
 	"context"
 
-	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
+	"gorm.io/gorm"
 )
 
-func DeleteCanvas(ctx context.Context, registry *registry.Registry, organizationID uuid.UUID, id string) (*pb.DeleteCanvasResponse, error) {
-	canvasID, err := uuid.Parse(id)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	canvas, err := models.FindCanvas(organizationID, canvasID)
-	if err != nil {
-		return nil, grpcerrors.NotFound(err, "canvas not found")
-	}
-
+func DeleteCanvas(ctx context.Context, db *gorm.DB, canvas *models.Canvas) (*pb.DeleteCanvasResponse, error) {
 	// Perform soft delete on the canvas with name suffix
 	// The cleanup worker will handle the actual deletion of nodes and related data
-	err = canvas.SoftDelete()
+	err := canvas.SoftDeleteInTransaction(db)
 	if err != nil {
 		log.Errorf("failed to delete canvas %s: %v", canvas.ID.String(), err)
 		return nil, grpcerrors.Internal(err, "failed to delete canvas")

--- a/pkg/grpc/actions/canvases/delete_canvas_memory.go
+++ b/pkg/grpc/actions/canvases/delete_canvas_memory.go
@@ -2,47 +2,27 @@ package canvases
 
 import (
 	"context"
-	"errors"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"gorm.io/gorm"
 )
 
-func DeleteCanvasMemory(ctx context.Context, registry *registry.Registry, organizationID, canvasID, memoryID string) (*pb.DeleteCanvasMemoryResponse, error) {
-	orgUUID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid organization_id")
-	}
-
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid canvas_id")
-	}
-
+func DeleteCanvasMemory(ctx context.Context, db *gorm.DB, canvas *models.Canvas, memoryID string) (*pb.DeleteCanvasMemoryResponse, error) {
 	entryUUID, err := uuid.Parse(memoryID)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(nil, "invalid memory_id")
 	}
 
-	_, err = models.FindCanvas(orgUUID, canvasUUID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
-	}
-
-	if err := models.DeleteCanvasMemory(canvasUUID, entryUUID); err != nil {
+	if err := models.DeleteCanvasMemory(canvas.ID, entryUUID); err != nil {
 		return nil, grpcerrors.Internal(err, "failed to delete canvas memory")
 	}
 
-	if err := messages.NewCanvasMemoryUpdatedMessage(canvasUUID.String()).PublishMemoryUpdated(); err != nil {
+	if err := messages.NewCanvasMemoryUpdatedMessage(canvas.ID.String()).PublishMemoryUpdated(); err != nil {
 		log.Errorf("failed to publish canvas memory updated RabbitMQ message: %v", err)
 	}
 

--- a/pkg/grpc/actions/canvases/delete_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/delete_canvas_staging.go
@@ -2,12 +2,10 @@ package canvases
 
 import (
 	"context"
-	"errors"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
-	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -15,30 +13,10 @@ import (
 	"gorm.io/gorm"
 )
 
-func DeleteCanvasStaging(ctx context.Context, organizationID string, canvasID string, paths []string) (*pb.StagingSummary, error) {
-	db := database.DB(ctx)
-
+func DeleteCanvasStaging(ctx context.Context, db *gorm.DB, canvas *models.Canvas, paths []string) (*pb.StagingSummary, error) {
 	userID, ok := authentication.GetUserIdFromMetadata(ctx)
 	if !ok {
 		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
-	}
-
-	organizationUUID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid organization id")
-	}
-
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	canvas, err := models.FindCanvasInTransaction(db, organizationUUID, canvasUUID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
 	}
 
 	if err := models.DiscardStagedFilesForUser(db, canvas.ID, uuid.MustParse(userID), paths); err != nil {

--- a/pkg/grpc/actions/canvases/delete_canvas_staging_test.go
+++ b/pkg/grpc/actions/canvases/delete_canvas_staging_test.go
@@ -5,22 +5,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 )
 
 func Test__DeleteCanvasStaging(t *testing.T) {
 	r, ctx, canvas, version := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
+	defer r.Close()
 
 	baseline, err := ReadRepositorySpecFile(ctx, canvas, version, CanvasYAMLRepositoryPath)
 	require.NoError(t, err)
 
-	_, err = PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err = PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: CanvasYAMLRepositoryPath, Content: []byte(baseline + "\n# pending\n")},
 	})
 	require.NoError(t, err)
 
-	state, err := DeleteCanvasStaging(ctx, orgID, canvas.ID.String(), nil)
+	state, err := DeleteCanvasStaging(ctx, database.DB(t.Context()), canvas, nil)
 	require.NoError(t, err)
 	assert.False(t, state.GetHasStaging())
 

--- a/pkg/grpc/actions/canvases/delete_canvas_test.go
+++ b/pkg/grpc/actions/canvases/delete_canvas_test.go
@@ -61,6 +61,8 @@ func Test__DeleteCanvas(t *testing.T) {
 		support.VerifyNodeExecutionsCount(t, canvas.ID, 1)
 		support.VerifyNodeQueueCount(t, canvas.ID, 1)
 
+		originalName := canvas.Name
+
 		//
 		// Delete the canvas (soft delete).
 		//
@@ -81,7 +83,7 @@ func Test__DeleteCanvas(t *testing.T) {
 
 		// Verify the name has been updated with deleted timestamp suffix
 		assert.Contains(t, canvasUnscoped.Name, "(deleted-")
-		assert.NotEqual(t, canvas.Name, canvasUnscoped.Name)
+		assert.NotEqual(t, originalName, canvasUnscoped.Name)
 
 		// Associated data should still exist (cleanup worker handles this)
 		nodes, err = models.FindCanvasNodes(canvas.ID)

--- a/pkg/grpc/actions/canvases/delete_canvas_test.go
+++ b/pkg/grpc/actions/canvases/delete_canvas_test.go
@@ -8,30 +8,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
-	"google.golang.org/grpc/codes"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
 func Test__DeleteCanvas(t *testing.T) {
 	r := support.Setup(t)
-
-	t.Run("canvas does not exist -> error", func(t *testing.T) {
-		_, err := DeleteCanvas(context.Background(), r.Registry, r.Organization.ID, uuid.New().String())
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.NotFound, code)
-	})
-
-	t.Run("invalid canvas id -> error", func(t *testing.T) {
-		_, err := DeleteCanvas(context.Background(), r.Registry, r.Organization.ID, "invalid-id")
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
 
 	t.Run("canvas is soft deleted, data remains until cleanup", func(t *testing.T) {
 		//
@@ -80,7 +64,7 @@ func Test__DeleteCanvas(t *testing.T) {
 		//
 		// Delete the canvas (soft delete).
 		//
-		_, err = DeleteCanvas(context.Background(), r.Registry, r.Organization.ID, canvas.ID.String())
+		_, err = DeleteCanvas(context.Background(), database.DB(t.Context()), canvas)
 		require.NoError(t, err)
 
 		//
@@ -144,7 +128,7 @@ func Test__DeleteCanvas(t *testing.T) {
 		//
 		// Delete the canvas (soft delete).
 		//
-		_, err := DeleteCanvas(context.Background(), r.Registry, r.Organization.ID, canvas.ID.String())
+		_, err := DeleteCanvas(context.Background(), database.DB(t.Context()), canvas)
 		require.NoError(t, err)
 
 		//

--- a/pkg/grpc/actions/canvases/delete_node_queue_item.go
+++ b/pkg/grpc/actions/canvases/delete_node_queue_item.go
@@ -11,15 +11,10 @@ import (
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"gorm.io/gorm"
 )
 
-func DeleteNodeQueueItem(ctx context.Context, registry *registry.Registry, workflowID, nodeID, itemID string) (*pb.DeleteNodeQueueItemResponse, error) {
-	wfID, err := uuid.Parse(workflowID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
+func DeleteNodeQueueItem(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID, itemID string) (*pb.DeleteNodeQueueItemResponse, error) {
 	qID, err := uuid.Parse(itemID)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(err, "invalid item id")
@@ -30,7 +25,7 @@ func DeleteNodeQueueItem(ctx context.Context, registry *registry.Registry, workf
 	var runID uuid.UUID
 	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
 		err := tx.
-			Where("id = ? AND workflow_id = ? AND node_id = ?", qID, wfID, nodeID).
+			Where("id = ? AND workflow_id = ? AND node_id = ?", qID, canvas.ID, nodeID).
 			First(&item).
 			Error
 		if goerrors.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/grpc/actions/canvases/delete_node_queue_item_test.go
+++ b/pkg/grpc/actions/canvases/delete_node_queue_item_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	testconsumer "github.com/superplanehq/superplane/test/consumer"
 	"github.com/superplanehq/superplane/test/support"
@@ -18,23 +17,12 @@ import (
 	"gorm.io/datatypes"
 )
 
-func Test_DeleteNodeQueueItem_ReturnsErrorForInvalidCanvasID(t *testing.T) {
-	r := support.Setup(t)
-	defer r.Close()
-
-	response, err := DeleteNodeQueueItem(context.Background(), r.Registry, "invalid-uuid", "node-1", uuid.New().String())
-	require.Error(t, err)
-	assert.Nil(t, response)
-	code, _, ok := grpcerrors.HandlerStatus(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, code)
-}
-
 func Test_DeleteNodeQueueItem_ReturnsErrorForInvalidItemID(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
 
-	response, err := DeleteNodeQueueItem(context.Background(), r.Registry, uuid.New().String(), "node-1", "bogus")
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	response, err := DeleteNodeQueueItem(context.Background(), database.DB(t.Context()), canvas, "node-1", "bogus")
 	require.Error(t, err)
 	assert.Nil(t, response)
 	code, _, ok := grpcerrors.HandlerStatus(err)
@@ -65,14 +53,14 @@ func Test_DeleteNodeQueueItem(t *testing.T) {
 	event := support.EmitCanvasEventForNode(t, canvas.ID, nodeID, "default", nil)
 	support.CreateQueueItem(t, canvas.ID, nodeID, event.ID, event.ID)
 
-	items, err := models.ListNodeQueueItems(canvas.ID, nodeID, 10, nil)
+	items, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, nodeID, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
-	_, err = DeleteNodeQueueItem(context.Background(), r.Registry, canvas.ID.String(), nodeID, items[0].ID.String())
+	_, err = DeleteNodeQueueItem(context.Background(), database.DB(t.Context()), canvas, nodeID, items[0].ID.String())
 	require.NoError(t, err)
 
-	remaining, err := models.ListNodeQueueItems(canvas.ID, nodeID, 10, nil)
+	remaining, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, nodeID, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, remaining, 0)
 }
@@ -105,7 +93,7 @@ func Test_DeleteNodeQueueItem_RequestsRunFinalization(t *testing.T) {
 	require.NoError(t, event.Routed())
 	queueItem := support.CreateQueueItem(t, canvas.ID, nodeID, event.ID, event.ID)
 
-	_, err := DeleteNodeQueueItem(context.Background(), r.Registry, canvas.ID.String(), nodeID, queueItem.ID.String())
+	_, err := DeleteNodeQueueItem(context.Background(), database.DB(t.Context()), canvas, nodeID, queueItem.ID.String())
 	require.NoError(t, err)
 	assert.True(t, finalizationConsumer.HasReceivedMessage())
 

--- a/pkg/grpc/actions/canvases/describe_canvas.go
+++ b/pkg/grpc/actions/canvases/describe_canvas.go
@@ -3,13 +3,10 @@ package canvases
 import (
 	"context"
 
-	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/telemetry"
 	"gorm.io/gorm"
 )
@@ -21,20 +18,8 @@ func loadCanvasCreator(ctx context.Context, db *gorm.DB, canvas *models.Canvas) 
 	return models.FindMaybeDeletedUserByIDInTransaction(db.WithContext(ctx), canvas.OrganizationID.String(), canvas.CreatedBy.String())
 }
 
-func DescribeCanvas(ctx context.Context, registry *registry.Registry, organizationID string, id string) (*pb.DescribeCanvasResponse, error) {
-	canvasID, err := uuid.Parse(id)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	orgID := uuid.MustParse(organizationID)
-	db := database.DB(ctx)
-
-	canvas, err := loadCanvas(ctx, db, orgID, canvasID)
-	if err != nil {
-		return nil, grpcerrors.NotFound(err, "canvas not found")
-	}
-
+func DescribeCanvas(ctx context.Context, db *gorm.DB, canvas *models.Canvas) (*pb.DescribeCanvasResponse, error) {
+	var err error
 	var user *models.User
 	if canvas.CreatedBy != nil {
 		user, err = loadCanvasCreator(ctx, db, canvas)

--- a/pkg/grpc/actions/canvases/describe_canvas_test.go
+++ b/pkg/grpc/actions/canvases/describe_canvas_test.go
@@ -8,29 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
-	"google.golang.org/grpc/codes"
 	"gorm.io/datatypes"
 )
 
 func Test__DescribeCanvas(t *testing.T) {
 	r := support.Setup(t)
-
-	t.Run("canvas does not exist -> error", func(t *testing.T) {
-		_, err := DescribeCanvas(context.Background(), r.Registry, r.Organization.ID.String(), uuid.New().String())
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.NotFound, code)
-	})
-
-	t.Run("invalid canvas id -> error", func(t *testing.T) {
-		_, err := DescribeCanvas(context.Background(), r.Registry, r.Organization.ID.String(), "invalid-id")
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
 
 	t.Run("returns canvas with metadata/spec/status structure", func(t *testing.T) {
 		//
@@ -70,7 +54,7 @@ func Test__DescribeCanvas(t *testing.T) {
 		//
 		// Describe the canvas
 		//
-		response, err := DescribeCanvas(context.Background(), r.Registry, r.Organization.ID.String(), canvas.ID.String())
+		response, err := DescribeCanvas(context.Background(), database.DB(t.Context()), canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		require.NotNil(t, response.Canvas)
@@ -162,7 +146,7 @@ func Test__DescribeCanvas(t *testing.T) {
 		//
 		// Describe the canvas
 		//
-		response, err := DescribeCanvas(context.Background(), r.Registry, r.Organization.ID.String(), canvas.ID.String())
+		response, err := DescribeCanvas(context.Background(), database.DB(t.Context()), canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Canvas.Status)
 
@@ -232,7 +216,7 @@ func Test__DescribeCanvas(t *testing.T) {
 		//
 		// Describe the canvas
 		//
-		response, err := DescribeCanvas(context.Background(), r.Registry, r.Organization.ID.String(), canvas.ID.String())
+		response, err := DescribeCanvas(context.Background(), database.DB(t.Context()), canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Canvas.Status)
 
@@ -282,7 +266,7 @@ func Test__DescribeCanvas(t *testing.T) {
 		//
 		// Describe the canvas
 		//
-		response, err := DescribeCanvas(context.Background(), r.Registry, r.Organization.ID.String(), canvas.ID.String())
+		response, err := DescribeCanvas(context.Background(), database.DB(t.Context()), canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Canvas.Status)
 
@@ -364,7 +348,7 @@ func Test__DescribeCanvas(t *testing.T) {
 		//
 		// Describe the canvas
 		//
-		response, err := DescribeCanvas(context.Background(), r.Registry, r.Organization.ID.String(), canvas.ID.String())
+		response, err := DescribeCanvas(context.Background(), database.DB(t.Context()), canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Canvas.Status)
 
@@ -447,7 +431,7 @@ func Test__DescribeCanvas(t *testing.T) {
 		//
 		// Describe the canvas
 		//
-		response, err := DescribeCanvas(context.Background(), r.Registry, r.Organization.ID.String(), canvas.ID.String())
+		response, err := DescribeCanvas(context.Background(), database.DB(t.Context()), canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Canvas.Status)
 

--- a/pkg/grpc/actions/canvases/describe_canvas_version.go
+++ b/pkg/grpc/actions/canvases/describe_canvas_version.go
@@ -6,21 +6,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"gorm.io/gorm"
 )
 
-func DescribeCanvasVersion(ctx context.Context, organizationID string, canvasID string, versionID string) (*pb.DescribeCanvasVersionResponse, error) {
+func DescribeCanvasVersion(ctx context.Context, db *gorm.DB, canvas *models.Canvas, versionID string) (*pb.DescribeCanvasVersionResponse, error) {
 	_, ok := authentication.GetUserIdFromMetadata(ctx)
 	if !ok {
 		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
-	}
-
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
 	}
 
 	versionUUID, err := uuid.Parse(versionID)
@@ -28,12 +23,7 @@ func DescribeCanvasVersion(ctx context.Context, organizationID string, canvasID 
 		return nil, grpcerrors.InvalidArgument(err, "invalid version id")
 	}
 
-	canvas, err := models.FindCanvas(uuid.MustParse(organizationID), canvasUUID)
-	if err != nil {
-		return nil, grpcerrors.NotFound(err, "canvas not found")
-	}
-
-	version, err := models.FindCanvasVersion(canvas.ID, versionUUID)
+	version, err := models.FindCanvasVersionInTransaction(db, canvas.ID, versionUUID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, grpcerrors.NotFound(err, "version not found")
@@ -42,6 +32,6 @@ func DescribeCanvasVersion(ctx context.Context, organizationID string, canvasID 
 	}
 
 	return &pb.DescribeCanvasVersionResponse{
-		Version: SerializeCanvasVersion(version, organizationID, nil),
+		Version: SerializeCanvasVersion(version, canvas.OrganizationID.String(), nil),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/describe_canvas_version_test.go
+++ b/pkg/grpc/actions/canvases/describe_canvas_version_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/database"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
@@ -18,16 +19,9 @@ func Test__DescribeCanvasVersion(t *testing.T) {
 	r := support.Setup(t)
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	t.Run("invalid canvas id -> error", func(t *testing.T) {
-		_, err := DescribeCanvasVersion(ctx, r.Organization.ID.String(), "invalid-id", uuid.New().String())
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
-
 	t.Run("invalid version id -> error", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
-		_, err := DescribeCanvasVersion(ctx, r.Organization.ID.String(), canvas.ID.String(), "invalid-id")
+		_, err := DescribeCanvasVersion(ctx, database.DB(t.Context()), canvas, "invalid-id")
 		code, _, ok := grpcerrors.HandlerStatus(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, code)
@@ -35,7 +29,7 @@ func Test__DescribeCanvasVersion(t *testing.T) {
 
 	t.Run("version not found -> error", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
-		_, err := DescribeCanvasVersion(ctx, r.Organization.ID.String(), canvas.ID.String(), uuid.New().String())
+		_, err := DescribeCanvasVersion(ctx, database.DB(t.Context()), canvas, uuid.New().String())
 		code, _, ok := grpcerrors.HandlerStatus(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.NotFound, code)
@@ -46,7 +40,7 @@ func Test__DescribeCanvasVersion(t *testing.T) {
 		liveVersion, err := models.FindLiveCanvasVersion(canvas.ID)
 		require.NoError(t, err)
 
-		response, err := DescribeCanvasVersion(ctx, r.Organization.ID.String(), canvas.ID.String(), liveVersion.ID.String())
+		response, err := DescribeCanvasVersion(ctx, database.DB(t.Context()), canvas, liveVersion.ID.String())
 		require.NoError(t, err)
 		assert.Equal(t, liveVersion.ID.String(), response.GetVersion().GetMetadata().GetId())
 		require.NotNil(t, response.GetVersion().GetSpec())

--- a/pkg/grpc/actions/canvases/describe_run.go
+++ b/pkg/grpc/actions/canvases/describe_run.go
@@ -6,23 +6,19 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"gorm.io/gorm"
 )
 
-func DescribeRun(ctx context.Context, registry *registry.Registry, canvasID uuid.UUID, runID string) (*pb.DescribeRunResponse, error) {
+func DescribeRun(ctx context.Context, db *gorm.DB, canvas *models.Canvas, runID string) (*pb.DescribeRunResponse, error) {
 	runUUID, err := uuid.Parse(runID)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(err, "invalid run id")
 	}
 
-	db := database.DB(ctx)
-
-	run, err := models.FindCanvasRunInTransaction(db, canvasID, runUUID)
+	run, err := models.FindCanvasRunInTransaction(db, canvas.ID, runUUID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, grpcerrors.NotFound(err, "run not found")
@@ -32,7 +28,7 @@ func DescribeRun(ctx context.Context, registry *registry.Registry, canvasID uuid
 		return nil, grpcerrors.Internal(err, "failed to find run")
 	}
 
-	runDetails, err := loadRunDetailsForRuns(ctx, canvasID, []models.CanvasRun{*run})
+	runDetails, err := loadRunDetailsForRuns(ctx, db, canvas.ID, []models.CanvasRun{*run})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/canvases/describe_run_test.go
+++ b/pkg/grpc/actions/canvases/describe_run_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/database"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/test/support"
@@ -33,7 +34,7 @@ func Test__DescribeRun(t *testing.T) {
 		run := createFinishedRun(t, rootEvent, models.CanvasRunResultPassed)
 		execution := createRunExecution(t, run, rootEvent.ID, "node-1", models.CanvasNodeExecutionResultPassed)
 
-		response, err := DescribeRun(context.Background(), r.Registry, canvas.ID, run.ID.String())
+		response, err := DescribeRun(context.Background(), database.DB(t.Context()), canvas, run.ID.String())
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		require.NotNil(t, response.Run)
@@ -67,7 +68,7 @@ func Test__DescribeRun(t *testing.T) {
 		run := createStartedRun(t, rootEvent)
 		queueItem := support.CreateQueueItem(t, canvas.ID, "node-1", rootEvent.ID, rootEvent.ID)
 
-		response, err := DescribeRun(context.Background(), r.Registry, canvas.ID, run.ID.String())
+		response, err := DescribeRun(context.Background(), database.DB(t.Context()), canvas, run.ID.String())
 		require.NoError(t, err)
 		require.NotNil(t, response.Run)
 		require.Len(t, response.Run.QueueItems, 1)
@@ -116,7 +117,7 @@ func Test__DescribeRun(t *testing.T) {
 			"",
 		)
 
-		response, err := DescribeRun(context.Background(), r.Registry, childCanvas.ID, childRun.ID.String())
+		response, err := DescribeRun(context.Background(), database.DB(t.Context()), childCanvas, childRun.ID.String())
 		require.NoError(t, err)
 		require.NotNil(t, response.Run)
 		assert.Equal(t, childRun.ID.String(), response.Run.Id)
@@ -133,7 +134,7 @@ func Test__DescribeRun(t *testing.T) {
 		rootEventTwo := support.EmitCanvasEventForNode(t, canvasTwo.ID, "trigger", "default", nil)
 		runTwo := createFinishedRun(t, rootEventTwo, models.CanvasRunResultPassed)
 
-		_, err := DescribeRun(context.Background(), r.Registry, canvasOne.ID, runTwo.ID.String())
+		_, err := DescribeRun(context.Background(), database.DB(t.Context()), canvasOne, runTwo.ID.String())
 		require.Error(t, err)
 		assert.Equal(t, codes.NotFound, grpcerrors.Code(err))
 	})
@@ -141,7 +142,7 @@ func Test__DescribeRun(t *testing.T) {
 	t.Run("invalid run id -> error", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{{NodeID: "trigger", Type: models.NodeTypeTrigger}}, []models.Edge{})
 
-		_, err := DescribeRun(context.Background(), r.Registry, canvas.ID, "not-a-uuid")
+		_, err := DescribeRun(context.Background(), database.DB(t.Context()), canvas, "not-a-uuid")
 		require.Error(t, err)
 		assert.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
 	})
@@ -149,7 +150,7 @@ func Test__DescribeRun(t *testing.T) {
 	t.Run("missing run -> error", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{{NodeID: "trigger", Type: models.NodeTypeTrigger}}, []models.Edge{})
 
-		_, err := DescribeRun(context.Background(), r.Registry, canvas.ID, uuid.New().String())
+		_, err := DescribeRun(context.Background(), database.DB(t.Context()), canvas, uuid.New().String())
 		require.Error(t, err)
 		assert.Equal(t, codes.NotFound, grpcerrors.Code(err))
 	})

--- a/pkg/grpc/actions/canvases/get_canvas_repository.go
+++ b/pkg/grpc/actions/canvases/get_canvas_repository.go
@@ -5,33 +5,17 @@ import (
 	"errors"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	git "github.com/superplanehq/superplane/pkg/git/provider"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
 )
 
-func GetCanvasRepository(ctx context.Context, gitProvider git.Provider, organizationID string, id string) (*pb.GetCanvasRepositoryResponse, error) {
-	canvasID, err := uuid.Parse(id)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	canvas, err := models.FindCanvas(uuid.MustParse(organizationID), canvasID)
-	if err != nil {
-		return nil, grpcerrors.NotFound(err, "canvas not found")
-	}
-
-	orgID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid organization id")
-	}
-
-	repository, err := models.FindRepository(orgID, canvasID)
+func GetCanvasRepository(ctx context.Context, gitProvider git.Provider, canvas *models.Canvas) (*pb.GetCanvasRepositoryResponse, error) {
+	repository, err := models.FindRepository(canvas.OrganizationID, canvas.ID)
 	if err != nil {
 		return handleMissingRepository(gitProvider, canvas, err)
 	}

--- a/pkg/grpc/actions/canvases/get_canvas_repository_test.go
+++ b/pkg/grpc/actions/canvases/get_canvas_repository_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/test/support"
@@ -24,24 +23,10 @@ func Test__RepositoryStateToProto(t *testing.T) {
 func Test__GetCanvasRepository(t *testing.T) {
 	r := support.Setup(t)
 
-	t.Run("invalid canvas id -> error", func(t *testing.T) {
-		_, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), "invalid-id")
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
-
-	t.Run("canvas does not exist -> error", func(t *testing.T) {
-		_, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), uuid.New().String())
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.NotFound, code)
-	})
-
 	t.Run("canvas exists, but repository does not -> creates pending repository", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
 
-		response, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		response, err := GetCanvasRepository(context.Background(), r.GitProvider, canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Repository)
 		assert.Equal(t, canvas.ID.String(), response.Repository.Metadata.CanvasId)
@@ -51,7 +36,7 @@ func Test__GetCanvasRepository(t *testing.T) {
 
 	t.Run("head lookup fails -> error", func(t *testing.T) {
 		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, false)
-		_, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		_, err := GetCanvasRepository(context.Background(), r.GitProvider, canvas)
 		code, _, ok := grpcerrors.HandlerStatus(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, code)
@@ -59,7 +44,7 @@ func Test__GetCanvasRepository(t *testing.T) {
 
 	t.Run("repository in pending state -> returns metadata without head sha", func(t *testing.T) {
 		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusPending, false)
-		response, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		response, err := GetCanvasRepository(context.Background(), r.GitProvider, canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Repository)
 		assert.Equal(t, canvas.ID.String(), response.Repository.Metadata.CanvasId)
@@ -69,7 +54,7 @@ func Test__GetCanvasRepository(t *testing.T) {
 
 	t.Run("repository in error state -> returns metadata without head sha", func(t *testing.T) {
 		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusError, false)
-		response, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		response, err := GetCanvasRepository(context.Background(), r.GitProvider, canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Repository)
 		assert.Equal(t, canvas.ID.String(), response.Repository.Metadata.CanvasId)
@@ -79,7 +64,7 @@ func Test__GetCanvasRepository(t *testing.T) {
 
 	t.Run("returns repository metadata and status", func(t *testing.T) {
 		canvas, repository := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
-		response, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		response, err := GetCanvasRepository(context.Background(), r.GitProvider, canvas)
 		require.NoError(t, err)
 		require.NotNil(t, response.Repository)
 		assert.Equal(t, canvas.ID.String(), response.Repository.Metadata.CanvasId)

--- a/pkg/grpc/actions/canvases/get_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/get_canvas_staging.go
@@ -2,42 +2,19 @@ package canvases
 
 import (
 	"context"
-	"errors"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
-	"github.com/superplanehq/superplane/pkg/database"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"gorm.io/gorm"
 )
 
-func GetCanvasStaging(ctx context.Context, organizationID string, canvasID string) (*pb.StagingSummary, error) {
-	db := database.DB(ctx)
-
+func GetCanvasStaging(ctx context.Context, db *gorm.DB, canvas *models.Canvas) (*pb.StagingSummary, error) {
 	userID, ok := authentication.GetUserIdFromMetadata(ctx)
 	if !ok {
 		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
-	}
-
-	organizationUUID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid organization_id")
-	}
-
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	canvas, err := models.FindCanvasInTransaction(db, organizationUUID, canvasUUID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
 	}
 
 	userUUID := uuid.MustParse(userID)

--- a/pkg/grpc/actions/canvases/get_canvas_staging_test.go
+++ b/pkg/grpc/actions/canvases/get_canvas_staging_test.go
@@ -15,17 +15,17 @@ import (
 
 func Test__GetCanvasStaging(t *testing.T) {
 	r, ctx, canvas, version := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
+	defer r.Close()
 
 	baseline, err := ReadRepositorySpecFile(ctx, canvas, version, CanvasYAMLRepositoryPath)
 	require.NoError(t, err)
 
-	_, err = PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err = PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: CanvasYAMLRepositoryPath, Content: []byte(baseline + "\n# pending\n")},
 	})
 	require.NoError(t, err)
 
-	state, err := GetCanvasStaging(ctx, orgID, canvas.ID.String())
+	state, err := GetCanvasStaging(ctx, database.DB(t.Context()), canvas)
 	require.NoError(t, err)
 	assert.True(t, state.GetHasStaging())
 	assert.Contains(t, state.GetStagedPaths(), CanvasYAMLRepositoryPath)
@@ -33,12 +33,12 @@ func Test__GetCanvasStaging(t *testing.T) {
 
 func Test__GetCanvasStaging__StagedReadIsPerUser(t *testing.T) {
 	r, ownerCtx, canvas, version := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
+	defer r.Close()
 
 	baseline, err := ReadRepositorySpecFile(ownerCtx, canvas, version, CanvasYAMLRepositoryPath)
 	require.NoError(t, err)
 
-	_, err = PutCanvasStaging(ownerCtx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err = PutCanvasStaging(ownerCtx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: CanvasYAMLRepositoryPath, Content: []byte(baseline + "\n# staged\n")},
 	})
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func Test__GetCanvasStaging__StagedReadIsPerUser(t *testing.T) {
 	liveVersion, err := models.FindLiveCanvasVersion(canvas.ID)
 	require.NoError(t, err)
 
-	otherRead, err := ReadStagedRepositorySpecFile(otherCtx, database.DB(otherCtx), orgID, canvas.ID.String(), liveVersion, CanvasYAMLRepositoryPath)
+	otherRead, err := ReadStagedRepositorySpecFile(otherCtx, database.DB(t.Context()), canvas.OrganizationID.String(), canvas.ID.String(), liveVersion, CanvasYAMLRepositoryPath)
 	require.NoError(t, err)
 	assert.Equal(t, baseline, otherRead)
 }

--- a/pkg/grpc/actions/canvases/invoke_node_execution_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_execution_hook.go
@@ -10,14 +10,14 @@ import (
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/crypto"
-	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/workers/contexts"
+	"gorm.io/gorm"
 )
 
 func InvokeNodeExecutionHook(
@@ -25,8 +25,8 @@ func InvokeNodeExecutionHook(
 	authService authorization.Authorization,
 	encryptor crypto.Encryptor,
 	registry *registry.Registry,
-	orgID uuid.UUID,
-	canvasID uuid.UUID,
+	db *gorm.DB,
+	canvas *models.Canvas,
 	executionID uuid.UUID,
 	hookName string,
 	parameters map[string]any,
@@ -34,11 +34,6 @@ func InvokeNodeExecutionHook(
 	userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
 	if !userIsSet {
 		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
-	}
-
-	canvas, err := models.FindCanvas(orgID, canvasID)
-	if err != nil {
-		return nil, fmt.Errorf("canvas not found: %w", err)
 	}
 
 	execution, err := models.FindNodeExecution(canvas.ID, executionID)
@@ -68,7 +63,7 @@ func InvokeNodeExecutionHook(
 		return nil, fmt.Errorf("hook parameters validation failed: %w", err)
 	}
 
-	user, err := models.FindActiveUserByID(orgID.String(), userID)
+	user, err := models.FindActiveUserByIDInTransaction(db, canvas.OrganizationID.String(), userID)
 	if err != nil {
 		return nil, fmt.Errorf("user not found: %w", err)
 	}
@@ -78,29 +73,28 @@ func InvokeNodeExecutionHook(
 		newEvents = append(newEvents, events...)
 	}
 
-	tx := database.Conn()
 	logger := logging.ForExecution(execution)
 	actionCtx := core.ActionHookContext{
 		Name:           hookName,
 		Parameters:     parameters,
 		Configuration:  node.Configuration.Data(),
 		HTTP:           registry.HTTPContext(),
-		Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
-		ExecutionState: contexts.NewExecutionStateContext(tx, execution, onNewEvents),
-		Auth:           contexts.NewAuthReader(tx, orgID, authService, user),
-		Requests:       contexts.NewExecutionRequestContext(tx, execution),
-		Runs:           contexts.NewRunExecutionContext(tx, canvas, node, execution),
+		Metadata:       contexts.NewExecutionMetadataContext(db, execution),
+		ExecutionState: contexts.NewExecutionStateContext(db, execution, onNewEvents),
+		Auth:           contexts.NewAuthReader(db, canvas.OrganizationID, authService, user),
+		Requests:       contexts.NewExecutionRequestContext(db, execution),
+		Runs:           contexts.NewRunExecutionContext(db, canvas, node, execution),
 	}
 
 	if node.AppInstallationID != nil {
-		integration, err := models.FindUnscopedIntegrationInTransaction(tx, *node.AppInstallationID)
+		integration, err := models.FindUnscopedIntegrationInTransaction(db, *node.AppInstallationID)
 		if err != nil {
 			logger.Errorf("error finding app installation: %v", err)
 			return nil, grpcerrors.Internal(err, "error building context")
 		}
 
 		logger = logging.WithIntegration(logger, *integration)
-		actionCtx.Integration = contexts.NewIntegrationContext(tx, node, integration, encryptor, registry, onNewEvents)
+		actionCtx.Integration = contexts.NewIntegrationContext(db, node, integration, encryptor, registry, onNewEvents)
 	}
 
 	actionCtx.Logger = logger

--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/crypto"
-	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/logging"
@@ -18,6 +16,7 @@ import (
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/workers/contexts"
+	"gorm.io/gorm"
 )
 
 func InvokeNodeTriggerHook(
@@ -25,8 +24,8 @@ func InvokeNodeTriggerHook(
 	authService authorization.Authorization,
 	encryptor crypto.Encryptor,
 	registry *registry.Registry,
-	orgID uuid.UUID,
-	canvasID uuid.UUID,
+	db *gorm.DB,
+	canvas *models.Canvas,
 	nodeID string,
 	hookName string,
 	parameters map[string]any,
@@ -35,11 +34,6 @@ func InvokeNodeTriggerHook(
 	userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
 	if !userIsSet {
 		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
-	}
-
-	canvas, err := models.FindCanvas(orgID, canvasID)
-	if err != nil {
-		return nil, grpcerrors.NotFound(err, "canvas not found")
 	}
 
 	node, err := canvas.FindNode(nodeID)
@@ -66,12 +60,11 @@ func InvokeNodeTriggerHook(
 		return nil, grpcerrors.InvalidArgument(err, "hook parameter validation failed")
 	}
 
-	_, err = models.FindActiveUserByID(orgID.String(), userID)
+	_, err = models.FindActiveUserByIDInTransaction(db, canvas.OrganizationID.String(), userID)
 	if err != nil {
 		return nil, grpcerrors.NotFound(err, "user not found")
 	}
 
-	tx := database.Conn()
 	logger := logging.ForNode(*node)
 
 	newEvents := []models.CanvasEvent{}
@@ -81,7 +74,7 @@ func InvokeNodeTriggerHook(
 
 	expressionParameters := buildHookExpressionParameters(node.Ref.Data().Trigger.Name, hookName, node.Configuration.Data(), parameters)
 
-	resolvedConfiguration, err := contexts.NewNodeConfigurationBuilder(tx, node.WorkflowID).
+	resolvedConfiguration, err := contexts.NewNodeConfigurationBuilder(db, node.WorkflowID).
 		WithNodeID(node.NodeID).
 		WithExpressionVariables(map[string]any{
 			"parameters": expressionParameters,
@@ -97,21 +90,21 @@ func InvokeNodeTriggerHook(
 		Parameters:    parameters,
 		Configuration: resolvedConfiguration,
 		HTTP:          registry.HTTPContext(),
-		Metadata:      contexts.NewNodeMetadataContext(tx, node),
-		Requests:      contexts.NewNodeRequestContext(tx, node),
-		Webhook:       contexts.NewNodeWebhookContext(ctx, tx, encryptor, node, webhookBaseURL),
-		Events:        contexts.NewEventContext(tx, node, nil, onNewEvents),
+		Metadata:      contexts.NewNodeMetadataContext(db, node),
+		Requests:      contexts.NewNodeRequestContext(db, node),
+		Webhook:       contexts.NewNodeWebhookContext(ctx, db, encryptor, node, webhookBaseURL),
+		Events:        contexts.NewEventContext(db, node, nil, onNewEvents),
 	}
 
 	if node.AppInstallationID != nil {
-		integration, err := models.FindUnscopedIntegrationInTransaction(tx, *node.AppInstallationID)
+		integration, err := models.FindUnscopedIntegrationInTransaction(db, *node.AppInstallationID)
 		if err != nil {
 			logger.Errorf("error finding app installation: %v", err)
 			return nil, grpcerrors.Internal(err, "error building context")
 		}
 
 		logger = logging.WithIntegration(logger, *integration)
-		hookCtx.Integration = contexts.NewIntegrationContext(tx, node, integration, encryptor, registry, onNewEvents)
+		hookCtx.Integration = contexts.NewIntegrationContext(db, node, integration, encryptor, registry, onNewEvents)
 	}
 
 	hookCtx.Logger = logger

--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook_test.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/datatypes"
@@ -49,8 +50,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			canvas.ID,
+			database.DB(t.Context()),
+			canvas,
 			triggerNodeID,
 			"run",
 			map[string]any{"template": "Hello World"},
@@ -66,8 +67,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			canvas.ID,
+			database.DB(t.Context()),
+			canvas,
 			triggerNodeID,
 			"nope",
 			map[string]any{},
@@ -83,8 +84,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			canvas.ID,
+			database.DB(t.Context()),
+			canvas,
 			triggerNodeID,
 			"run",
 			map[string]any{},
@@ -101,8 +102,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			canvas.ID,
+			database.DB(t.Context()),
+			canvas,
 			triggerNodeID,
 			"run",
 			map[string]any{"template": "Hello World"},
@@ -114,7 +115,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		result := resp.Result.AsMap()
 		assert.Equal(t, "Hello World", result["template"])
 
-		events, err := models.ListCanvasEvents(canvas.ID, triggerNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), canvas.ID, triggerNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -163,8 +164,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			expressionCanvas.ID,
+			database.DB(t.Context()),
+			expressionCanvas,
 			expressionNodeID,
 			"run",
 			map[string]any{"template": "Timed"},
@@ -172,7 +173,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -222,8 +223,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			expressionCanvas.ID,
+			database.DB(t.Context()),
+			expressionCanvas,
 			expressionNodeID,
 			"run",
 			map[string]any{"template": "Timed"},
@@ -231,7 +232,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -274,8 +275,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			expressionCanvas.ID,
+			database.DB(t.Context()),
+			expressionCanvas,
 			expressionNodeID,
 			"run",
 			map[string]any{"template": "Timed"},
@@ -283,7 +284,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -330,8 +331,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			expressionCanvas.ID,
+			database.DB(t.Context()),
+			expressionCanvas,
 			expressionNodeID,
 			"run",
 			map[string]any{
@@ -342,7 +343,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -393,8 +394,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			expressionCanvas.ID,
+			database.DB(t.Context()),
+			expressionCanvas,
 			expressionNodeID,
 			"run",
 			map[string]any{
@@ -405,7 +406,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -455,8 +456,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			expressionCanvas.ID,
+			database.DB(t.Context()),
+			expressionCanvas,
 			expressionNodeID,
 			"run",
 			map[string]any{
@@ -466,7 +467,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -520,8 +521,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			expressionCanvas.ID,
+			database.DB(t.Context()),
+			expressionCanvas,
 			expressionNodeID,
 			"run",
 			map[string]any{
@@ -531,7 +532,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -585,8 +586,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			expressionCanvas.ID,
+			database.DB(t.Context()),
+			expressionCanvas,
 			expressionNodeID,
 			"run",
 			map[string]any{
@@ -597,7 +598,7 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
@@ -631,8 +632,8 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			canvasWithComponent.ID,
+			database.DB(t.Context()),
+			canvasWithComponent,
 			componentNodeID,
 			"run",
 			map[string]any{"template": "Hello World"},
@@ -675,8 +676,8 @@ func Test__InvokeNodeTriggerHook__ScheduleRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			canvas.ID,
+			database.DB(t.Context()),
+			canvas,
 			triggerNodeID,
 			"emitEvent",
 			map[string]any{},
@@ -692,8 +693,8 @@ func Test__InvokeNodeTriggerHook__ScheduleRun(t *testing.T) {
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
-			r.Organization.ID,
-			canvas.ID,
+			database.DB(t.Context()),
+			canvas,
 			triggerNodeID,
 			"run",
 			map[string]any{},
@@ -707,7 +708,7 @@ func Test__InvokeNodeTriggerHook__ScheduleRun(t *testing.T) {
 		require.True(t, ok)
 		require.NotEmpty(t, eventID)
 
-		events, err := models.ListCanvasEvents(canvas.ID, triggerNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(database.DB(t.Context()), canvas.ID, triggerNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 

--- a/pkg/grpc/actions/canvases/list_canvas_memories.go
+++ b/pkg/grpc/actions/canvases/list_canvas_memories.go
@@ -2,14 +2,10 @@ package canvases
 
 import (
 	"context"
-	"errors"
 
-	"github.com/google/uuid"
-	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -17,26 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-func ListCanvasMemories(ctx context.Context, registry *registry.Registry, organizationID, canvasID string) (*pb.ListCanvasMemoriesResponse, error) {
-	orgUUID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid organization_id")
-	}
-
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid canvas_id")
-	}
-
-	err = checkCanvasExistence(ctx, database.DB(ctx), orgUUID, canvasUUID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
-	}
-
-	records, err := listCanvasMemories(ctx, canvasUUID)
+func ListCanvasMemories(ctx context.Context, db *gorm.DB, canvas *models.Canvas) (*pb.ListCanvasMemoriesResponse, error) {
+	records, err := listCanvasMemories(ctx, db, canvas)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to list canvas memories")
 	}
@@ -51,11 +29,11 @@ func ListCanvasMemories(ctx context.Context, registry *registry.Registry, organi
 	}, nil
 }
 
-func listCanvasMemories(ctx context.Context, canvasUUID uuid.UUID) (records []models.CanvasMemory, err error) {
+func listCanvasMemories(ctx context.Context, db *gorm.DB, canvas *models.Canvas) (records []models.CanvasMemory, err error) {
 	ctx, done := telemetry.Span(ctx, "memories.list")
 	defer done(&err)
 
-	return models.ListCanvasMemoriesInTransaction(database.DB(ctx), canvasUUID)
+	return models.ListCanvasMemoriesInTransaction(db, canvas.ID)
 }
 
 func serializeCanvasMemories(ctx context.Context, records []models.CanvasMemory) (items []*pb.CanvasMemory, err error) {

--- a/pkg/grpc/actions/canvases/list_canvas_repository_files.go
+++ b/pkg/grpc/actions/canvases/list_canvas_repository_files.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"sort"
 
-	"github.com/google/uuid"
 	git "github.com/superplanehq/superplane/pkg/git/provider"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -13,27 +12,9 @@ import (
 	"gorm.io/gorm"
 )
 
-func ListCanvasRepositoryFiles(ctx context.Context, gitProvider git.Provider, organizationID string, id string) (*pb.ListCanvasRepositoryFilesResponse, error) {
-	canvasID, err := uuid.Parse(id)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	orgID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid organization id")
-	}
-
-	_, err = models.FindCanvas(orgID, canvasID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
-	}
-
+func ListCanvasRepositoryFiles(ctx context.Context, gitProvider git.Provider, canvas *models.Canvas) (*pb.ListCanvasRepositoryFilesResponse, error) {
 	repositoryPaths := []string{}
-	repository, err := models.FindRepository(orgID, canvasID)
+	repository, err := models.FindRepository(canvas.OrganizationID, canvas.ID)
 	if err == nil {
 		files, listErr := gitProvider.ListFiles(ctx, repository.RepoID, "")
 		if listErr != nil {

--- a/pkg/grpc/actions/canvases/list_canvas_repository_files_test.go
+++ b/pkg/grpc/actions/canvases/list_canvas_repository_files_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/grpc/codes"
@@ -15,17 +15,10 @@ import (
 func Test__ListCanvasRepositoryFiles(t *testing.T) {
 	r := support.Setup(t)
 
-	t.Run("invalid canvas id -> error", func(t *testing.T) {
-		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), "invalid-id")
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
-
 	t.Run("repository missing -> returns virtual spec files", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
 
-		response, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		response, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, canvas)
 		require.NoError(t, err)
 		require.Len(t, response.Files, 2)
 		assert.Equal(t, CanvasYAMLRepositoryPath, response.Files[0].Path)
@@ -35,7 +28,7 @@ func Test__ListCanvasRepositoryFiles(t *testing.T) {
 	t.Run("list files fails -> error", func(t *testing.T) {
 		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, false)
 
-		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, canvas)
 		code, _, ok := grpcerrors.HandlerStatus(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, code)
@@ -44,21 +37,11 @@ func Test__ListCanvasRepositoryFiles(t *testing.T) {
 	t.Run("returns repository files", func(t *testing.T) {
 		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
 
-		response, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		response, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, canvas)
 		require.NoError(t, err)
 		require.Len(t, response.Files, 3)
 		assert.Equal(t, "README.md", response.Files[0].Path)
 		assert.Equal(t, CanvasYAMLRepositoryPath, response.Files[1].Path)
 		assert.Equal(t, ConsoleYAMLRepositoryPath, response.Files[2].Path)
-	})
-
-	t.Run("canvas from different organization -> not found", func(t *testing.T) {
-		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
-		otherOrg := support.CreateOrganization(t, r, r.User)
-
-		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, otherOrg.ID.String(), canvas.ID.String())
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.NotFound, code)
 	})
 }

--- a/pkg/grpc/actions/canvases/list_canvas_versions.go
+++ b/pkg/grpc/actions/canvases/list_canvas_versions.go
@@ -19,8 +19,8 @@ const MaxCanvasVersionLimit = 50
 
 func ListCanvasVersionsPaginated(
 	ctx context.Context,
-	organizationID string,
-	canvasID string,
+	db *gorm.DB,
+	canvas *models.Canvas,
 	limit uint32,
 	before *timestamppb.Timestamp,
 ) (*pb.ListCanvasVersionsResponse, error) {
@@ -29,30 +29,15 @@ func ListCanvasVersionsPaginated(
 		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
 	}
 
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	orgUUID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid organization id")
-	}
-
-	_, err = loadCanvas(ctx, database.DB(ctx), orgUUID, canvasUUID)
-	if err != nil {
-		return nil, grpcerrors.NotFound(err, "canvas not found")
-	}
-
 	limit = getCanvasVersionLimit(limit)
 	beforeTime := getBefore(before)
 
-	versions, count, err := listCanvasVersionHistory(ctx, canvasUUID, int(limit), beforeTime)
+	versions, count, err := listCanvasVersionHistory(ctx, canvas.ID, int(limit), beforeTime)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to list canvas versions")
 	}
 
-	protoVersions := serializeCanvasVersionMetadataList(ctx, versions, organizationID)
+	protoVersions := serializeCanvasVersionMetadataList(ctx, versions, canvas.OrganizationID.String())
 
 	return &pb.ListCanvasVersionsResponse{
 		Versions:      protoVersions,

--- a/pkg/grpc/actions/canvases/list_canvas_versions_test.go
+++ b/pkg/grpc/actions/canvases/list_canvas_versions_test.go
@@ -4,45 +4,21 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
-	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/test/support"
-	"google.golang.org/grpc/codes"
 )
 
 func Test__ListCanvasVersionsPaginated(t *testing.T) {
 	r := support.Setup(t)
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 
-	t.Run("invalid canvas id -> error", func(t *testing.T) {
-		_, err := ListCanvasVersionsPaginated(ctx, r.Organization.ID.String(), "invalid-id", 0, nil)
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
-
-	t.Run("invalid organization id -> error", func(t *testing.T) {
-		_, err := ListCanvasVersionsPaginated(ctx, "invalid-id", uuid.New().String(), 0, nil)
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
-
-	t.Run("canvas not found -> error", func(t *testing.T) {
-		_, err := ListCanvasVersionsPaginated(ctx, r.Organization.ID.String(), uuid.New().String(), 0, nil)
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.NotFound, code)
-	})
-
 	t.Run("lists committed versions newest first", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
-		orgID := r.Organization.ID.String()
 
 		liveVersion, err := models.FindLiveCanvasVersion(canvas.ID)
 		require.NoError(t, err)
@@ -50,23 +26,23 @@ func Test__ListCanvasVersionsPaginated(t *testing.T) {
 		baseline, err := ReadRepositorySpecFile(ctx, canvas, liveVersion, CanvasYAMLRepositoryPath)
 		require.NoError(t, err)
 
-		_, err = PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+		_, err = PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 			{Path: CanvasYAMLRepositoryPath, Content: []byte(baseline + "\n# first commit\n")},
 		})
 		require.NoError(t, err)
 
-		firstCommit, err := CommitCanvasStaging(ctx, nil, nil, r.Encryptor, r.Registry, orgID, canvas.ID.String(), "First", "", r.AuthService)
+		firstCommit, err := CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "First", "", r.AuthService)
 		require.NoError(t, err)
 
-		_, err = PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+		_, err = PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 			{Path: CanvasYAMLRepositoryPath, Content: []byte(baseline + "\n# second commit\n")},
 		})
 		require.NoError(t, err)
 
-		secondCommit, err := CommitCanvasStaging(ctx, nil, nil, r.Encryptor, r.Registry, orgID, canvas.ID.String(), "Second", "", r.AuthService)
+		secondCommit, err := CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Second", "", r.AuthService)
 		require.NoError(t, err)
 
-		response, err := ListCanvasVersionsPaginated(ctx, orgID, canvas.ID.String(), 0, nil)
+		response, err := ListCanvasVersionsPaginated(ctx, database.DB(t.Context()), canvas, 0, nil)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(response.GetVersions()), 2)
 		assert.Equal(t, secondCommit.GetVersion().GetMetadata().GetId(), response.GetVersions()[0].GetId())

--- a/pkg/grpc/actions/canvases/list_canvases_test.go
+++ b/pkg/grpc/actions/canvases/list_canvases_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/test/support"
@@ -110,13 +111,13 @@ func Test__ListCanvases__IncludesUserCanvasPreferences(t *testing.T) {
 
 	// Another user's star must not leak into this user's view.
 	otherUser := support.CreateUser(t, r, r.Organization.ID)
-	_, err := UpdateCanvasPreference(context.Background(), r.Organization.ID.String(), otherUser.ID.String(), &pb.UpdateCanvasPreferenceRequest{
+	_, err := UpdateCanvasPreference(context.Background(), database.DB(t.Context()), plainCanvas, otherUser.ID.String(), &pb.UpdateCanvasPreferenceRequest{
 		CanvasId: plainCanvas.ID.String(),
 		Starred:  proto.Bool(true),
 	})
 	require.NoError(t, err)
 
-	_, err = UpdateCanvasPreference(context.Background(), r.Organization.ID.String(), r.User.String(), &pb.UpdateCanvasPreferenceRequest{
+	_, err = UpdateCanvasPreference(context.Background(), database.DB(t.Context()), starredCanvas, r.User.String(), &pb.UpdateCanvasPreferenceRequest{
 		CanvasId: starredCanvas.ID.String(),
 		Starred:  proto.Bool(true),
 	})

--- a/pkg/grpc/actions/canvases/list_event_executions.go
+++ b/pkg/grpc/actions/canvases/list_event_executions.go
@@ -2,20 +2,16 @@ package canvases
 
 import (
 	"context"
+
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
+	"gorm.io/gorm"
 )
 
-func ListEventExecutions(ctx context.Context, registry *registry.Registry, workflowID, eventID string) (*pb.ListEventExecutionsResponse, error) {
-	workflowUUID, err := uuid.Parse(workflowID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
+func ListEventExecutions(ctx context.Context, db *gorm.DB, canvas *models.Canvas, eventID string) (*pb.ListEventExecutionsResponse, error) {
 	eventUUID, err := uuid.Parse(eventID)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(err, "invalid event id")
@@ -23,7 +19,7 @@ func ListEventExecutions(ctx context.Context, registry *registry.Registry, workf
 
 	var executions []models.CanvasNodeExecution
 	query := database.Conn().
-		Where("workflow_id = ?", workflowUUID).
+		Where("workflow_id = ?", canvas.ID).
 		Where("root_event_id = ?", eventUUID).
 		Order("created_at ASC")
 
@@ -31,8 +27,6 @@ func ListEventExecutions(ctx context.Context, registry *registry.Registry, workf
 	if err != nil {
 		return nil, err
 	}
-
-	db := database.DB(ctx)
 
 	resources, err := LoadNodeExecutionResources(db, executions)
 	if err != nil {

--- a/pkg/grpc/actions/canvases/list_event_executions_test.go
+++ b/pkg/grpc/actions/canvases/list_event_executions_test.go
@@ -4,31 +4,21 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/database"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/grpc/codes"
 	"gorm.io/datatypes"
 )
 
-func Test__ListEventExecutions__ReturnsErrorForInvalidCanvasID(t *testing.T) {
-	r := support.Setup(t)
-
-	response, err := ListEventExecutions(context.Background(), r.Registry, "invalid-uuid", uuid.New().String())
-	require.Error(t, err)
-	assert.Nil(t, response)
-	code, _, ok := grpcerrors.HandlerStatus(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, code)
-}
-
 func Test__ListEventExecutions__ReturnsErrorForInvalidEventID(t *testing.T) {
 	r := support.Setup(t)
 
-	response, err := ListEventExecutions(context.Background(), r.Registry, uuid.New().String(), "bogus")
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	response, err := ListEventExecutions(context.Background(), database.DB(t.Context()), canvas, "bogus")
 	require.Error(t, err)
 	assert.Nil(t, response)
 	code, _, ok := grpcerrors.HandlerStatus(err)
@@ -58,7 +48,7 @@ func Test__ListEventExecutions__ReturnsEmptyListWhenNoExecutionsExist(t *testing
 
 	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
 
-	response, err := ListEventExecutions(context.Background(), r.Registry, canvas.ID.String(), rootEvent.ID.String())
+	response, err := ListEventExecutions(context.Background(), database.DB(t.Context()), canvas, rootEvent.ID.String())
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	assert.Empty(t, response.Executions)
@@ -89,7 +79,7 @@ func Test__ListEventExecutions__ReturnsParentExecutionsForEvent(t *testing.T) {
 
 	parentExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "node-1", rootEvent.ID, event.ID)
 
-	response, err := ListEventExecutions(context.Background(), r.Registry, canvas.ID.String(), rootEvent.ID.String())
+	response, err := ListEventExecutions(context.Background(), database.DB(t.Context()), canvas, rootEvent.ID.String())
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Executions, 1)
@@ -129,7 +119,7 @@ func Test__ListEventExecutions__OnlyReturnsExecutionsForSpecificRootEvent(t *tes
 	execution1 := support.CreateCanvasNodeExecution(t, canvas.ID, "node-1", rootEvent1.ID, event1.ID)
 	support.CreateCanvasNodeExecution(t, canvas.ID, "node-1", rootEvent2.ID, event2.ID)
 
-	response, err := ListEventExecutions(context.Background(), r.Registry, canvas.ID.String(), rootEvent1.ID.String())
+	response, err := ListEventExecutions(context.Background(), database.DB(t.Context()), canvas, rootEvent1.ID.String())
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Executions, 1)

--- a/pkg/grpc/actions/canvases/list_node_events.go
+++ b/pkg/grpc/actions/canvases/list_node_events.go
@@ -3,26 +3,25 @@ package canvases
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
-func ListNodeEvents(ctx context.Context, registry *registry.Registry, workflowID uuid.UUID, nodeID string, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeEventsResponse, error) {
+func ListNodeEvents(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeEventsResponse, error) {
 	limit = getLimit(limit)
 	beforeTime := getBefore(before)
 
 	//
 	// List and count events
 	//
-	events, err := models.ListCanvasEvents(workflowID, nodeID, int(limit), beforeTime)
+	events, err := models.ListCanvasEvents(db, canvas.ID, nodeID, int(limit), beforeTime)
 	if err != nil {
 		return nil, err
 	}
 
-	totalCount, err := models.CountCanvasEvents(workflowID, nodeID)
+	totalCount, err := models.CountCanvasEvents(db, canvas.ID, nodeID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/canvases/list_node_executions.go
+++ b/pkg/grpc/actions/canvases/list_node_executions.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
-	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
-	"sync"
-	"time"
 )
 
 const (
@@ -22,13 +21,8 @@ const (
 	MaxLimit     = 25
 )
 
-func ListNodeExecutions(ctx context.Context, registry *registry.Registry, workflowID, nodeID string, pbStates []pb.CanvasNodeExecution_State, pbResults []pb.CanvasNodeExecution_Result, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeExecutionsResponse, error) {
-	wfID, err := uuid.Parse(workflowID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	_, err = models.FindCanvasNode(database.Conn(), wfID, nodeID)
+func ListNodeExecutions(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, pbStates []pb.CanvasNodeExecution_State, pbResults []pb.CanvasNodeExecution_Result, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeExecutionsResponse, error) {
+	_, err := models.FindCanvasNode(db, canvas.ID, nodeID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, grpcerrors.NotFound(err, "canvas node not found")
@@ -53,17 +47,15 @@ func ListNodeExecutions(ctx context.Context, registry *registry.Registry, workfl
 	//
 	// List and count executions
 	//
-	executions, err := models.ListNodeExecutions(wfID, nodeID, states, results, int(limit), beforeTime)
+	executions, err := models.ListNodeExecutions(db, canvas.ID, nodeID, states, results, int(limit), beforeTime)
 	if err != nil {
 		return nil, err
 	}
 
-	totalCount, err := models.CountNodeExecutions(wfID, nodeID, states, results)
+	totalCount, err := models.CountNodeExecutions(db, canvas.ID, nodeID, states, results)
 	if err != nil {
 		return nil, err
 	}
-
-	db := database.DB(ctx)
 
 	resources, err := LoadNodeExecutionResources(db, executions)
 	if err != nil {

--- a/pkg/grpc/actions/canvases/list_node_executions_test.go
+++ b/pkg/grpc/actions/canvases/list_node_executions_test.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/test/support"
@@ -18,23 +17,6 @@ import (
 
 func Test__ListNodeExecutions(t *testing.T) {
 	r := support.Setup(t)
-
-	t.Run("invalid canvas id -> error", func(t *testing.T) {
-		_, err := ListNodeExecutions(
-			context.Background(),
-			r.Registry,
-			"invalid-uuid",
-			"some-node",
-			[]pb.CanvasNodeExecution_State{},
-			[]pb.CanvasNodeExecution_Result{},
-			0,
-			nil,
-		)
-
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
 
 	t.Run("node does not exist -> 404 error", func(t *testing.T) {
 		//
@@ -62,33 +44,9 @@ func Test__ListNodeExecutions(t *testing.T) {
 		//
 		_, err := ListNodeExecutions(
 			context.Background(),
-			r.Registry,
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			"non-existent-node",
-			[]pb.CanvasNodeExecution_State{},
-			[]pb.CanvasNodeExecution_Result{},
-			0,
-			nil,
-		)
-
-		//
-		// Verify we get a NotFound error
-		//
-		code, msg, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.NotFound, code)
-		assert.Contains(t, msg, "canvas node not found")
-	})
-
-	t.Run("canvas does not exist -> 404 error", func(t *testing.T) {
-		//
-		// Try to list executions for a non-existent canvas
-		//
-		_, err := ListNodeExecutions(
-			context.Background(),
-			r.Registry,
-			uuid.New().String(),
-			"some-node",
 			[]pb.CanvasNodeExecution_State{},
 			[]pb.CanvasNodeExecution_Result{},
 			0,
@@ -140,8 +98,8 @@ func Test__ListNodeExecutions(t *testing.T) {
 		//
 		response, err := ListNodeExecutions(
 			context.Background(),
-			r.Registry,
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			"node-1",
 			[]pb.CanvasNodeExecution_State{},
 			[]pb.CanvasNodeExecution_Result{},
@@ -199,7 +157,7 @@ func SerializeThosandNodeExecutions(b *testing.B) {
 		require.NoError(b, err)
 	}
 
-	executions, err := models.ListNodeExecutions(canvas.ID, "node-1", []string{}, []string{}, 1000, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, "node-1", []string{}, []string{}, 1000, nil)
 	require.NoError(b, err)
 
 	resources, err := LoadNodeExecutionResources(database.Conn(), executions)

--- a/pkg/grpc/actions/canvases/list_node_queue_items.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items.go
@@ -4,41 +4,33 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
 )
 
-func ListNodeQueueItems(ctx context.Context, registry *registry.Registry, workflowID, nodeID string, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeQueueItemsResponse, error) {
-	wfID, err := uuid.Parse(workflowID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
+func ListNodeQueueItems(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeQueueItemsResponse, error) {
 	limit = getLimit(limit)
 	beforeTime := getBefore(before)
 
 	//
 	// List and count queue items
 	//
-	queueItems, err := models.ListNodeQueueItems(wfID, nodeID, int(limit), beforeTime)
+	queueItems, err := models.ListNodeQueueItems(db, canvas.ID, nodeID, int(limit), beforeTime)
 	if err != nil {
 		return nil, err
 	}
 
-	totalCount, err := models.CountNodeQueueItems(wfID, nodeID)
+	totalCount, err := models.CountNodeQueueItems(db, canvas.ID, nodeID)
 	if err != nil {
 		return nil, err
 	}
 
-	serialized, err := SerializeNodeQueueItems(database.DB(ctx), queueItems)
+	serialized, err := SerializeNodeQueueItems(db, queueItems)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/canvases/list_node_queue_items_test.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/grpc/codes"
@@ -59,7 +59,7 @@ func Test__ListNodeQueueItems__ReturnsEmptyListWhenNoQueueItemsExist(t *testing.
 		[]models.Edge{},
 	)
 
-	response, err := ListNodeQueueItems(context.Background(), r.Registry, canvas.ID.String(), "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	assert.Empty(t, response.Items)
@@ -94,7 +94,7 @@ func Test__ListNodeQueueItems__ReturnsQueueItemsWithInputData(t *testing.T) {
 
 	queueItem := createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, nil)
 
-	response, err := ListNodeQueueItems(context.Background(), r.Registry, canvas.ID.String(), "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Items, 1)
@@ -140,7 +140,7 @@ func Test__ListNodeQueueItems__ReturnsQueueItemsWithRootEvent(t *testing.T) {
 
 	queueItem := createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, &rootEvent.ID)
 
-	response, err := ListNodeQueueItems(context.Background(), r.Registry, canvas.ID.String(), "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Items, 1)
@@ -180,7 +180,7 @@ func Test__ListNodeQueueItems__HandlesPaginationCorrectly(t *testing.T) {
 		queueItems = append(queueItems, *queueItem)
 	}
 
-	response, err := ListNodeQueueItems(context.Background(), r.Registry, canvas.ID.String(), "node-1", 3, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 3, nil)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Items, 3)
@@ -223,7 +223,7 @@ func Test__ListNodeQueueItems__FiltersQueueItemsByNodeID(t *testing.T) {
 	queueItem1 := createNodeQueueItem(t, canvas.ID, "node-1", inputEvent1.ID, nil)
 	createNodeQueueItem(t, canvas.ID, "node-2", inputEvent2.ID, nil)
 
-	response, err := ListNodeQueueItems(context.Background(), r.Registry, canvas.ID.String(), "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Items, 1)
@@ -259,12 +259,12 @@ func Test__ListNodeQueueItems__HandlesPaginationWithTimestamp(t *testing.T) {
 		createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, nil)
 	}
 
-	firstResponse, err := ListNodeQueueItems(context.Background(), r.Registry, canvas.ID.String(), "node-1", 2, nil)
+	firstResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, nil)
 	require.NoError(t, err)
 	require.Len(t, firstResponse.Items, 2)
 	assert.True(t, firstResponse.HasNextPage)
 
-	secondResponse, err := ListNodeQueueItems(context.Background(), r.Registry, canvas.ID.String(), "node-1", 2, firstResponse.LastTimestamp)
+	secondResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, firstResponse.LastTimestamp)
 	require.NoError(t, err)
 	require.Len(t, secondResponse.Items, 1)
 	assert.False(t, secondResponse.HasNextPage)
@@ -272,8 +272,9 @@ func Test__ListNodeQueueItems__HandlesPaginationWithTimestamp(t *testing.T) {
 
 func Test__ListNodeQueueItems__ReturnsErrorForInvalidCanvasID(t *testing.T) {
 	r := support.Setup(t)
+	defer r.Close()
 
-	response, err := ListNodeQueueItems(context.Background(), r.Registry, "invalid-uuid", "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), nil, "node-1", 10, nil)
 	require.Error(t, err)
 	assert.Nil(t, response)
 	code, _, ok := grpcerrors.HandlerStatus(err)

--- a/pkg/grpc/actions/canvases/list_node_queue_items_test.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
-	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
-	"google.golang.org/grpc/codes"
 	"gorm.io/datatypes"
 )
 
@@ -268,18 +266,6 @@ func Test__ListNodeQueueItems__HandlesPaginationWithTimestamp(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, secondResponse.Items, 1)
 	assert.False(t, secondResponse.HasNextPage)
-}
-
-func Test__ListNodeQueueItems__ReturnsErrorForInvalidCanvasID(t *testing.T) {
-	r := support.Setup(t)
-	defer r.Close()
-
-	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), nil, "node-1", 10, nil)
-	require.Error(t, err)
-	assert.Nil(t, response)
-	code, _, ok := grpcerrors.HandlerStatus(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, code)
 }
 
 func Test__SerializeNodeQueueItems__HandlesEmptyList(t *testing.T) {

--- a/pkg/grpc/actions/canvases/list_runs.go
+++ b/pkg/grpc/actions/canvases/list_runs.go
@@ -10,7 +10,6 @@ import (
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -19,7 +18,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func ListRuns(ctx context.Context, registry *registry.Registry, canvasID uuid.UUID, limit uint32, before *timestamppb.Timestamp, states []pb.CanvasRun_State, results []pb.CanvasRun_Result) (*pb.ListRunsResponse, error) {
+func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uint32, before *timestamppb.Timestamp, states []pb.CanvasRun_State, results []pb.CanvasRun_Result) (*pb.ListRunsResponse, error) {
 	limit = getLimit(limit)
 	beforeTime := getBefore(before)
 	filters, err := buildCanvasRunFilters(states, results)
@@ -27,17 +26,17 @@ func ListRuns(ctx context.Context, registry *registry.Registry, canvasID uuid.UU
 		return nil, err
 	}
 
-	runs, err := listCanvasRuns(ctx, canvasID, int(limit), beforeTime, filters)
+	runs, err := listCanvasRuns(ctx, db, canvas.ID, int(limit), beforeTime, filters)
 	if err != nil {
 		return nil, err
 	}
 
-	count, err := countCanvasRuns(ctx, canvasID, filters)
+	count, err := countCanvasRuns(ctx, db, canvas.ID, filters)
 	if err != nil {
 		return nil, err
 	}
 
-	runDetails, err := loadRunDetailsForRuns(ctx, canvasID, runs)
+	runDetails, err := loadRunDetailsForRuns(ctx, db, canvas.ID, runs)
 	if err != nil {
 		return nil, err
 	}
@@ -90,14 +89,14 @@ func buildCanvasRunFilters(states []pb.CanvasRun_State, results []pb.CanvasRun_R
 	}, nil
 }
 
-func listRootEventsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uuid.UUID) (map[string]models.CanvasEvent, error) {
+func listRootEventsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, runIDs []uuid.UUID) (map[string]models.CanvasEvent, error) {
 	eventsByRunID := map[string]models.CanvasEvent{}
 	if len(runIDs) == 0 {
 		return eventsByRunID, nil
 	}
 
 	var events []models.CanvasEvent
-	err := database.DB(ctx).
+	err := db.
 		Where("workflow_id = ?", canvasID).
 		Where("run_id IN ?", runIDs).
 		Where("execution_id IS NULL").
@@ -309,7 +308,7 @@ type runDetailsForRuns struct {
 	childRunsByExecutionID map[string][]models.CanvasRun
 }
 
-func loadRunDetailsForRuns(ctx context.Context, canvasID uuid.UUID, runs []models.CanvasRun) (*runDetailsForRuns, error) {
+func loadRunDetailsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, runs []models.CanvasRun) (*runDetailsForRuns, error) {
 	runIDs := make([]uuid.UUID, len(runs))
 	for i, run := range runs {
 		runIDs[i] = run.ID
@@ -334,7 +333,7 @@ func loadRunDetailsForRuns(ctx context.Context, canvasID uuid.UUID, runs []model
 
 	g.Go(func() error {
 		var err error
-		rootEventsByRunID, err = loadRootEventsForRunsSpan(gctx, canvasID, runIDs)
+		rootEventsByRunID, err = loadRootEventsForRunsSpan(gctx, db, canvasID, runIDs)
 		if err != nil {
 			return err
 		}
@@ -343,7 +342,7 @@ func loadRunDetailsForRuns(ctx context.Context, canvasID uuid.UUID, runs []model
 	})
 
 	g.Go(func() error {
-		executions, err := listExecutionsForRuns(gctx, canvasID, runIDs)
+		executions, err := listExecutionsForRuns(gctx, db, canvasID, runIDs)
 		if err != nil {
 			return err
 		}
@@ -366,7 +365,7 @@ func loadRunDetailsForRuns(ctx context.Context, canvasID uuid.UUID, runs []model
 
 	g.Go(func() error {
 		var err error
-		queueItemsByRunID, err = loadQueueItemsForRuns(gctx, canvasID, runIDs)
+		queueItemsByRunID, err = loadQueueItemsForRuns(gctx, db, canvasID, runIDs)
 		if err != nil {
 			return err
 		}
@@ -376,7 +375,7 @@ func loadRunDetailsForRuns(ctx context.Context, canvasID uuid.UUID, runs []model
 
 	g.Go(func() error {
 		var err error
-		parentRunsByRunID, err = loadParentRunsForRuns(gctx, runs)
+		parentRunsByRunID, err = loadParentRunsForRuns(gctx, db, runs)
 		return err
 	})
 
@@ -442,41 +441,41 @@ func serializeCanvasRuns(
 	return serialized, nil
 }
 
-func listCanvasRuns(ctx context.Context, canvasID uuid.UUID, limit int, beforeTime *time.Time, filters models.CanvasRunFilters) (runs []models.CanvasRun, err error) {
+func listCanvasRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, limit int, beforeTime *time.Time, filters models.CanvasRunFilters) (runs []models.CanvasRun, err error) {
 	ctx, done := telemetry.Span(ctx, "runs.list")
 	defer done(&err)
 
-	return models.ListCanvasRunsInTransaction(database.DB(ctx), canvasID, limit, beforeTime, filters)
+	return models.ListCanvasRunsInTransaction(db, canvasID, limit, beforeTime, filters)
 }
 
-func countCanvasRuns(ctx context.Context, canvasID uuid.UUID, filters models.CanvasRunFilters) (count int64, err error) {
+func countCanvasRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, filters models.CanvasRunFilters) (count int64, err error) {
 	ctx, done := telemetry.Span(ctx, "runs.count")
 	defer done(&err)
 
-	return models.CountCanvasRunsInTransaction(database.DB(ctx), canvasID, filters)
+	return models.CountCanvasRunsInTransaction(db, canvasID, filters)
 }
 
-func loadRootEventsForRunsSpan(ctx context.Context, canvasID uuid.UUID, runIDs []uuid.UUID) (events map[string]models.CanvasEvent, err error) {
+func loadRootEventsForRunsSpan(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, runIDs []uuid.UUID) (events map[string]models.CanvasEvent, err error) {
 	ctx, done := telemetry.Span(ctx, "runs.load_root_events")
 	defer done(&err)
 
-	return listRootEventsForRuns(ctx, canvasID, runIDs)
+	return listRootEventsForRuns(ctx, db, canvasID, runIDs)
 }
 
-func listExecutionsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uuid.UUID) (executions []models.CanvasNodeExecution, err error) {
+func listExecutionsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, runIDs []uuid.UUID) (executions []models.CanvasNodeExecution, err error) {
 	ctx, done := telemetry.Span(ctx, "runs.load_executions")
 	defer done(&err)
 
-	return models.ListExecutionsForRunsInTransaction(database.DB(ctx), canvasID, runIDs)
+	return models.ListExecutionsForRunsInTransaction(db, canvasID, runIDs)
 }
 
-func loadQueueItemsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uuid.UUID) (map[string][]models.CanvasNodeQueueItem, error) {
+func loadQueueItemsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, runIDs []uuid.UUID) (map[string][]models.CanvasNodeQueueItem, error) {
 	queueItemsByRunID := make(map[string][]models.CanvasNodeQueueItem, len(runIDs))
 	if len(runIDs) == 0 {
 		return queueItemsByRunID, nil
 	}
 
-	queueItems, err := listQueueItemsForRuns(ctx, canvasID, runIDs)
+	queueItems, err := listQueueItemsForRuns(ctx, db, canvasID, runIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -488,11 +487,11 @@ func loadQueueItemsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uui
 	return queueItemsByRunID, nil
 }
 
-func loadParentRunsForRuns(ctx context.Context, runs []models.CanvasRun) (map[string]models.CanvasRun, error) {
+func loadParentRunsForRuns(ctx context.Context, db *gorm.DB, runs []models.CanvasRun) (map[string]models.CanvasRun, error) {
 	ctx, done := telemetry.Span(ctx, "runs.load_parent_runs")
 	defer done(nil)
 
-	parents, err := models.FindCanvasRunsByKeys(database.DB(ctx), models.CollectParentRunKeys(runs))
+	parents, err := models.FindCanvasRunsByKeys(db, models.CollectParentRunKeys(runs))
 	if err != nil {
 		return nil, err
 	}
@@ -507,9 +506,9 @@ func listChildRunsForExecutions(ctx context.Context, canvasID uuid.UUID, executi
 	return models.ListChildRunsByParentExecutions(database.DB(ctx), canvasID, executionIDs)
 }
 
-func listQueueItemsForRuns(ctx context.Context, canvasID uuid.UUID, runIDs []uuid.UUID) (queueItems []models.CanvasNodeQueueItem, err error) {
+func listQueueItemsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, runIDs []uuid.UUID) (queueItems []models.CanvasNodeQueueItem, err error) {
 	ctx, done := telemetry.Span(ctx, "runs.load_queue_items")
 	defer done(&err)
 
-	return models.ListNodeQueueItemsForRuns(database.DB(ctx), canvasID, runIDs)
+	return models.ListNodeQueueItemsForRuns(db, canvasID, runIDs)
 }

--- a/pkg/grpc/actions/canvases/list_runs_test.go
+++ b/pkg/grpc/actions/canvases/list_runs_test.go
@@ -33,7 +33,7 @@ func Test__ListRuns__ReturnsRunsWithRootEventsAndExecutionRefs(t *testing.T) {
 	run := createFinishedRun(t, rootEvent, models.CanvasRunResultPassed)
 	execution := createRunExecution(t, run, rootEvent.ID, "node-1", models.CanvasNodeExecutionResultPassed)
 
-	response, err := ListRuns(context.Background(), r.Registry, canvas.ID, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Runs, 1)
@@ -79,7 +79,7 @@ func Test__ListRuns__ReturnsRunsWithQueueItems(t *testing.T) {
 	createStartedRun(t, otherRootEvent)
 	support.CreateQueueItem(t, otherCanvas.ID, "trigger", otherRootEvent.ID, otherRootEvent.ID)
 
-	response, err := ListRuns(context.Background(), r.Registry, canvas.ID, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 2)
 
@@ -113,7 +113,7 @@ func Test__ListRuns__ScopesRunsToCanvas(t *testing.T) {
 	runOne := createFinishedRun(t, rootEventOne, models.CanvasRunResultPassed)
 	createFinishedRun(t, rootEventTwo, models.CanvasRunResultPassed)
 
-	response, err := ListRuns(context.Background(), r.Registry, canvasOne.ID, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvasOne, 0, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 1)
 	assert.Equal(t, runOne.ID.String(), response.Runs[0].Id)
@@ -139,8 +139,8 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 	// "running OR passed" in a single request.
 	response, err := ListRuns(
 		context.Background(),
-		r.Registry,
-		canvas.ID,
+		database.DB(t.Context()),
+		canvas,
 		0,
 		nil,
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_STARTED},
@@ -157,8 +157,8 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 	// Result-only filter still narrows to the requested results.
 	response, err = ListRuns(
 		context.Background(),
-		r.Registry,
-		canvas.ID,
+		database.DB(t.Context()),
+		canvas,
 		0,
 		nil,
 		nil,
@@ -174,8 +174,8 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 	// State-only filter narrows to running runs.
 	response, err = ListRuns(
 		context.Background(),
-		r.Registry,
-		canvas.ID,
+		database.DB(t.Context()),
+		canvas,
 		0,
 		nil,
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_STARTED},
@@ -201,8 +201,8 @@ func Test__ListRuns__RejectsUnknownFilterValues(t *testing.T) {
 
 	_, err := ListRuns(
 		context.Background(),
-		r.Registry,
-		canvas.ID,
+		database.DB(t.Context()),
+		canvas,
 		0,
 		nil,
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_UNKNOWN},
@@ -212,8 +212,8 @@ func Test__ListRuns__RejectsUnknownFilterValues(t *testing.T) {
 
 	_, err = ListRuns(
 		context.Background(),
-		r.Registry,
-		canvas.ID,
+		database.DB(t.Context()),
+		canvas,
 		0,
 		nil,
 		nil,
@@ -260,8 +260,8 @@ func Test__ListRuns__ReturnsPendingSubRunWithoutRootEvent(t *testing.T) {
 
 	childResponse, err := ListRuns(
 		context.Background(),
-		r.Registry,
-		childCanvas.ID,
+		database.DB(t.Context()),
+		childCanvas,
 		0,
 		nil,
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_PENDING},
@@ -273,7 +273,7 @@ func Test__ListRuns__ReturnsPendingSubRunWithoutRootEvent(t *testing.T) {
 	assert.Equal(t, pb.CanvasRun_STATE_PENDING, childResponse.Runs[0].State)
 	assert.Nil(t, childResponse.Runs[0].RootEvent)
 
-	parentResponse, err := ListRuns(context.Background(), r.Registry, parentCanvas.ID, 0, nil, nil, nil)
+	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, parentResponse.Runs, 1)
 	require.Len(t, parentResponse.Runs[0].Executions, 1)
@@ -320,7 +320,7 @@ func Test__ListRuns__ReturnsSubRunRelationshipRefs(t *testing.T) {
 	childRootEvent := support.EmitCanvasEventForNode(t, childCanvas.ID, "onRun", "default", nil)
 	require.NoError(t, database.Conn().Model(&childRootEvent).Update("run_id", childRun.ID).Error)
 
-	parentResponse, err := ListRuns(context.Background(), r.Registry, parentCanvas.ID, 0, nil, nil, nil)
+	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, parentResponse.Runs, 1)
 	require.Len(t, parentResponse.Runs[0].Executions, 1)
@@ -328,7 +328,7 @@ func Test__ListRuns__ReturnsSubRunRelationshipRefs(t *testing.T) {
 	assert.Equal(t, childRun.ID.String(), parentResponse.Runs[0].Executions[0].Runs[0].Id)
 	assert.Equal(t, childCanvas.ID.String(), parentResponse.Runs[0].Executions[0].Runs[0].CanvasId)
 
-	childResponse, err := DescribeRun(context.Background(), r.Registry, childCanvas.ID, childRun.ID.String())
+	childResponse, err := DescribeRun(context.Background(), database.DB(t.Context()), childCanvas, childRun.ID.String())
 	require.NoError(t, err)
 	require.NotNil(t, childResponse.Run.Parent)
 	assert.Equal(t, parentRun.ID.String(), childResponse.Run.Parent.Id)

--- a/pkg/grpc/actions/canvases/put_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/put_canvas_staging.go
@@ -2,14 +2,12 @@ package canvases
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
-	"github.com/superplanehq/superplane/pkg/database"
 	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
@@ -18,27 +16,13 @@ import (
 	"gorm.io/gorm"
 )
 
-func PutCanvasStaging(ctx context.Context, organizationID string, canvasID string, operations []*pb.CanvasRepositoryFileOperation) (*pb.StagingSummary, error) {
-	db := database.DB(ctx)
-
+func PutCanvasStaging(ctx context.Context, db *gorm.DB, canvas *models.Canvas, operations []*pb.CanvasRepositoryFileOperation) (*pb.StagingSummary, error) {
 	user, ok := authentication.GetUserIdFromMetadata(ctx)
 	if !ok {
 		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
 	}
 
 	userID := uuid.MustParse(user)
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	canvas, err := models.FindCanvasInTransaction(db, uuid.MustParse(organizationID), canvasUUID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
-	}
 
 	//
 	// Find the base version id for the staging update.

--- a/pkg/grpc/actions/canvases/put_canvas_staging_test.go
+++ b/pkg/grpc/actions/canvases/put_canvas_staging_test.go
@@ -5,18 +5,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 )
 
 func Test__PutCanvasStaging__StagesCanvasYAML(t *testing.T) {
 	r, ctx, canvas, version := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
+	defer r.Close()
 
 	baseline, err := ReadRepositorySpecFile(ctx, canvas, version, CanvasYAMLRepositoryPath)
 	require.NoError(t, err)
 
 	staged := baseline + "\n# staged edit\n"
-	state, err := PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	state, err := PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: CanvasYAMLRepositoryPath, Content: []byte(staged)},
 	})
 	require.NoError(t, err)
@@ -36,9 +37,9 @@ func Test__PutCanvasStaging__StagesCanvasYAML(t *testing.T) {
 
 func Test__PutCanvasStaging__RejectsReservedPath(t *testing.T) {
 	r, ctx, canvas, _ := setupLiveCanvasStaging(t)
-	orgID := r.Organization.ID.String()
+	defer r.Close()
 
-	_, err := PutCanvasStaging(ctx, orgID, canvas.ID.String(), []*pb.CanvasRepositoryFileOperation{
+	_, err := PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
 		{Path: ".superplane/config", Content: []byte("nope")},
 	})
 	require.Error(t, err)

--- a/pkg/grpc/actions/canvases/reemit_trigger_event.go
+++ b/pkg/grpc/actions/canvases/reemit_trigger_event.go
@@ -11,20 +11,16 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"gorm.io/gorm"
 )
 
 func ReemitTriggerEvent(
-	_ context.Context,
-	orgID uuid.UUID,
-	canvasID uuid.UUID,
+	ctx context.Context,
+	db *gorm.DB,
+	canvas *models.Canvas,
 	nodeID string,
 	eventID uuid.UUID,
 ) (*pb.ReemitTriggerEventResponse, error) {
-	canvas, err := models.FindCanvas(orgID, canvasID)
-	if err != nil {
-		return nil, fmt.Errorf("canvas not found: %w", err)
-	}
-
 	node, err := canvas.FindNode(nodeID)
 	if err != nil {
 		return nil, fmt.Errorf("canvas node not found: %w", err)
@@ -34,7 +30,7 @@ func ReemitTriggerEvent(
 		return nil, fmt.Errorf("canvas node is not a trigger")
 	}
 
-	sourceEvent, err := models.FindCanvasEventForCanvas(canvasID, eventID)
+	sourceEvent, err := models.FindCanvasEventForCanvas(db, canvas.ID, eventID)
 	if err != nil {
 		return nil, fmt.Errorf("canvas event not found: %w", err)
 	}
@@ -63,7 +59,7 @@ func ReemitTriggerEvent(
 		return nil, fmt.Errorf("failed to create workflow event: %w", err)
 	}
 
-	err = messages.NewCanvasEventCreatedMessage(canvasID.String(), canvas.OrganizationID.String(), &reemittedEvent).Publish()
+	err = messages.NewCanvasEventCreatedMessage(canvas.ID.String(), canvas.OrganizationID.String(), &reemittedEvent).Publish()
 	if err != nil {
 		log.Errorf("failed to publish re-emitted workflow event RabbitMQ message: %v", err)
 	}

--- a/pkg/grpc/actions/canvases/reemit_trigger_event_test.go
+++ b/pkg/grpc/actions/canvases/reemit_trigger_event_test.go
@@ -43,26 +43,20 @@ func Test__ReemitTriggerEvent(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("canvas not found -> error", func(t *testing.T) {
-		_, err := ReemitTriggerEvent(ctx, r.Organization.ID, uuid.New(), triggerNodeID, uuid.New())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "canvas not found")
-	})
-
 	t.Run("trigger node not found -> error", func(t *testing.T) {
-		_, err := ReemitTriggerEvent(ctx, r.Organization.ID, canvas.ID, "missing-node", uuid.New())
+		_, err := ReemitTriggerEvent(ctx, database.DB(t.Context()), canvas, "missing-node", uuid.New())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "node not found")
 	})
 
 	t.Run("node is not trigger -> error", func(t *testing.T) {
-		_, err := ReemitTriggerEvent(ctx, r.Organization.ID, canvas.ID, componentNodeID, uuid.New())
+		_, err := ReemitTriggerEvent(ctx, database.DB(t.Context()), canvas, componentNodeID, uuid.New())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not a trigger")
 	})
 
 	t.Run("event not found -> error", func(t *testing.T) {
-		_, err := ReemitTriggerEvent(ctx, r.Organization.ID, canvas.ID, triggerNodeID, uuid.New())
+		_, err := ReemitTriggerEvent(ctx, database.DB(t.Context()), canvas, triggerNodeID, uuid.New())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "event not found")
 	})
@@ -79,7 +73,7 @@ func Test__ReemitTriggerEvent(t *testing.T) {
 		}
 		require.NoError(t, database.Conn().Create(&sourceEvent).Error)
 
-		_, err := ReemitTriggerEvent(ctx, r.Organization.ID, canvas.ID, triggerNodeID, sourceEvent.ID)
+		_, err := ReemitTriggerEvent(ctx, database.DB(t.Context()), canvas, triggerNodeID, sourceEvent.ID)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not belong to trigger node")
 	})
@@ -111,7 +105,7 @@ func Test__ReemitTriggerEvent(t *testing.T) {
 				Error,
 		)
 
-		_, err := ReemitTriggerEvent(ctx, r.Organization.ID, canvas.ID, triggerNodeID, sourceEvent.ID)
+		_, err := ReemitTriggerEvent(ctx, database.DB(t.Context()), canvas, triggerNodeID, sourceEvent.ID)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "root trigger events")
 	})
@@ -134,7 +128,7 @@ func Test__ReemitTriggerEvent(t *testing.T) {
 		}
 		require.NoError(t, database.Conn().Create(&sourceEvent).Error)
 
-		response, err := ReemitTriggerEvent(ctx, r.Organization.ID, canvas.ID, triggerNodeID, sourceEvent.ID)
+		response, err := ReemitTriggerEvent(ctx, database.DB(t.Context()), canvas, triggerNodeID, sourceEvent.ID)
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		require.NotEmpty(t, response.EventId)

--- a/pkg/grpc/actions/canvases/resolve_execution_errors.go
+++ b/pkg/grpc/actions/canvases/resolve_execution_errors.go
@@ -3,21 +3,22 @@ package canvases
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/google/uuid"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"strings"
+	"gorm.io/gorm"
 )
 
-func ResolveExecutionErrors(ctx context.Context, workflowID uuid.UUID, executionIDs []uuid.UUID) (*pb.ResolveExecutionErrorsResponse, error) {
-	_ = ctx
+func ResolveExecutionErrors(ctx context.Context, db *gorm.DB, canvas *models.Canvas, executionIDs []uuid.UUID) (*pb.ResolveExecutionErrorsResponse, error) {
 	uniqueExecutionIDs := uniqueExecutionIDs(executionIDs)
 	if len(uniqueExecutionIDs) == 0 {
 		return nil, grpcerrors.InvalidArgument(nil, "execution_ids are required")
 	}
 
-	executions, err := models.FindNodeExecutionsByIDs(workflowID, uniqueExecutionIDs)
+	executions, err := models.FindNodeExecutionsByIDs(canvas.ID, uniqueExecutionIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +32,7 @@ func ResolveExecutionErrors(ctx context.Context, workflowID uuid.UUID, execution
 		return nil, grpcerrors.InvalidArgument(nil, fmt.Sprintf("executions not in error state: %s", strings.Join(invalidIDs, ", ")))
 	}
 
-	if err := models.ResolveExecutionErrors(workflowID, uniqueExecutionIDs); err != nil {
+	if err := models.ResolveExecutionErrors(canvas.ID, uniqueExecutionIDs); err != nil {
 		return nil, err
 	}
 

--- a/pkg/grpc/actions/canvases/resolve_execution_errors_test.go
+++ b/pkg/grpc/actions/canvases/resolve_execution_errors_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/datatypes"
@@ -48,7 +49,7 @@ func Test__ResolveExecutionErrors__ResolvesMultipleExecutions(t *testing.T) {
 	require.NoError(t, executionOne.Fail(models.CanvasNodeExecutionResultReasonError, "boom"))
 	require.NoError(t, executionTwo.Fail(models.CanvasNodeExecutionResultReasonError, "boom"))
 
-	response, err := ResolveExecutionErrors(context.Background(), canvas.ID, []uuid.UUID{
+	response, err := ResolveExecutionErrors(context.Background(), database.DB(t.Context()), canvas, []uuid.UUID{
 		executionOne.ID,
 		executionTwo.ID,
 	})
@@ -88,7 +89,7 @@ func Test__ResolveExecutionErrors__ReturnsErrorForNonErrorExecution(t *testing.T
 	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
 	execution := support.CreateCanvasNodeExecution(t, canvas.ID, "node-1", rootEvent.ID, rootEvent.ID)
 
-	_, err := ResolveExecutionErrors(context.Background(), canvas.ID, []uuid.UUID{execution.ID})
+	_, err := ResolveExecutionErrors(context.Background(), database.DB(t.Context()), canvas, []uuid.UUID{execution.ID})
 	require.Error(t, err)
 
 	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)

--- a/pkg/grpc/actions/canvases/update_canvas.go
+++ b/pkg/grpc/actions/canvases/update_canvas.go
@@ -18,25 +18,13 @@ import (
 
 func UpdateCanvas(
 	ctx context.Context,
-	organizationID string,
-	id string,
+	db *gorm.DB,
+	canvas *models.Canvas,
 	name *string,
 	description *string,
 ) (*pb.UpdateCanvasResponse, error) {
-	canvasID, err := uuid.Parse(id)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
-	}
-
-	organizationUUID := uuid.MustParse(organizationID)
-
-	canvas, err := models.FindCanvas(organizationUUID, canvasID)
-	if err != nil {
-		return nil, grpcerrors.NotFound(err, "canvas not found")
-	}
-
-	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		return updateCanvasInTransaction(tx, organizationUUID, canvasID, name, description)
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return updateCanvasInTransaction(tx, canvas.OrganizationID, canvas.ID, name, description)
 	})
 
 	if err != nil {
@@ -50,7 +38,7 @@ func UpdateCanvas(
 		log.Errorf("failed to publish canvas updated RabbitMQ message: %v", publishErr)
 	}
 
-	refreshedCanvas, err := models.FindCanvas(organizationUUID, canvasID)
+	refreshedCanvas, err := models.FindCanvasInTransaction(db, canvas.OrganizationID, canvas.ID)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to load updated canvas")
 	}

--- a/pkg/grpc/actions/canvases/update_canvas_memory_namespace.go
+++ b/pkg/grpc/actions/canvases/update_canvas_memory_namespace.go
@@ -2,33 +2,19 @@ package canvases
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"github.com/superplanehq/superplane/pkg/registry"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
 )
 
-func UpdateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registry, organizationID, canvasID, namespace, newNamespace string, entries []*structpb.Value) (*pb.UpdateCanvasMemoryNamespaceResponse, error) {
-	orgUUID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid organization_id")
-	}
-
-	canvasUUID, err := uuid.Parse(canvasID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid canvas_id")
-	}
-
+func UpdateCanvasMemoryNamespace(ctx context.Context, db *gorm.DB, canvas *models.Canvas, namespace, newNamespace string, entries []*structpb.Value) (*pb.UpdateCanvasMemoryNamespaceResponse, error) {
 	namespace = strings.TrimSpace(namespace)
 	if namespace == "" {
 		return nil, grpcerrors.InvalidArgument(nil, "namespace is required")
@@ -44,28 +30,20 @@ func UpdateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 		return nil, grpcerrors.InvalidArgument(nil, "at least one entry is required")
 	}
 
-	_, err = models.FindCanvas(orgUUID, canvasUUID)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, grpcerrors.NotFound(err, "canvas not found")
-		}
-		return nil, grpcerrors.Internal(err, "failed to load canvas")
-	}
-
 	decodedEntries := make([]any, 0, len(entries))
 	for _, value := range entries {
 		decodedEntries = append(decodedEntries, value.AsInterface())
 	}
 
 	var stored []models.CanvasMemory
-	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		existingSource, txErr := models.CanvasMemoryNamespaceSourceInTransaction(tx, canvasUUID, namespace)
+	err := db.Transaction(func(tx *gorm.DB) error {
+		existingSource, txErr := models.CanvasMemoryNamespaceSourceInTransaction(tx, canvas.ID, namespace)
 		if txErr != nil {
 			return txErr
 		}
 
 		if existingSource == "" {
-			return grpcerrors.NotFound(err, fmt.Sprintf("memory namespace %q not found", namespace))
+			return grpcerrors.NotFound(nil, fmt.Sprintf("memory namespace %q not found", namespace))
 		}
 
 		if existingSource != models.CanvasMemorySourceManual {
@@ -73,7 +51,7 @@ func UpdateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 		}
 
 		if targetNamespace != namespace {
-			conflict, txErr := models.CanvasMemoryNamespaceSourceInTransaction(tx, canvasUUID, targetNamespace)
+			conflict, txErr := models.CanvasMemoryNamespaceSourceInTransaction(tx, canvas.ID, targetNamespace)
 			if txErr != nil {
 				return txErr
 			}
@@ -83,18 +61,18 @@ func UpdateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 			}
 
 			if txErr := tx.
-				Where("canvas_id = ? AND namespace = ? AND source = ?", canvasUUID, namespace, models.CanvasMemorySourceManual).
+				Where("canvas_id = ? AND namespace = ? AND source = ?", canvas.ID, namespace, models.CanvasMemorySourceManual).
 				Delete(&models.CanvasMemory{}).
 				Error; txErr != nil {
 				return txErr
 			}
 		}
 
-		if txErr := models.ReplaceManualCanvasMemoryNamespaceInTransaction(tx, canvasUUID, targetNamespace, decodedEntries); txErr != nil {
+		if txErr := models.ReplaceManualCanvasMemoryNamespaceInTransaction(tx, canvas.ID, targetNamespace, decodedEntries); txErr != nil {
 			return txErr
 		}
 
-		records, txErr := models.ListCanvasMemoriesByNamespaceInTransaction(tx, canvasUUID, targetNamespace)
+		records, txErr := models.ListCanvasMemoriesByNamespaceInTransaction(tx, canvas.ID, targetNamespace)
 		if txErr != nil {
 			return txErr
 		}
@@ -110,7 +88,7 @@ func UpdateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 		return nil, grpcerrors.Internal(err, "failed to update canvas memory namespace")
 	}
 
-	if err := messages.NewCanvasMemoryUpdatedMessage(canvasUUID.String()).PublishMemoryUpdated(); err != nil {
+	if err := messages.NewCanvasMemoryUpdatedMessage(canvas.ID.String()).PublishMemoryUpdated(); err != nil {
 		log.Errorf("failed to publish canvas memory updated RabbitMQ message: %v", err)
 	}
 

--- a/pkg/grpc/actions/canvases/update_canvas_preference.go
+++ b/pkg/grpc/actions/canvases/update_canvas_preference.go
@@ -15,7 +15,8 @@ import (
 
 func UpdateCanvasPreference(
 	ctx context.Context,
-	organizationID string,
+	db *gorm.DB,
+	canvas *models.Canvas,
 	userID string,
 	req *pb.UpdateCanvasPreferenceRequest,
 ) (*pb.UpdateCanvasPreferenceResponse, error) {
@@ -23,19 +24,9 @@ func UpdateCanvasPreference(
 		return nil, grpcerrors.InvalidArgument(nil, "request is required")
 	}
 
-	organizationUUID, err := uuid.Parse(organizationID)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid organization id")
-	}
-
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(err, "invalid user id")
-	}
-
-	canvasID, err := uuid.Parse(req.CanvasId)
-	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "invalid canvas id")
 	}
 
 	var preference *models.UserCanvasPreference
@@ -43,9 +34,9 @@ func UpdateCanvasPreference(
 		var err error
 		preference, err = models.SetUserCanvasPreference(
 			tx,
-			organizationUUID,
+			canvas.OrganizationID,
 			userUUID,
-			canvasID,
+			canvas.ID,
 			req.Starred,
 		)
 		return err

--- a/pkg/grpc/actions/canvases/update_canvas_preference_test.go
+++ b/pkg/grpc/actions/canvases/update_canvas_preference_test.go
@@ -17,7 +17,7 @@ func Test__UpdateCanvasPreference__StoresAndClearsPreferences(t *testing.T) {
 	r := support.Setup(t)
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
 
-	response, err := UpdateCanvasPreference(context.Background(), r.Organization.ID.String(), r.User.String(), &pb.UpdateCanvasPreferenceRequest{
+	response, err := UpdateCanvasPreference(context.Background(), database.DB(t.Context()), canvas, r.User.String(), &pb.UpdateCanvasPreferenceRequest{
 		CanvasId: canvas.ID.String(),
 		Starred:  proto.Bool(true),
 	})
@@ -36,7 +36,7 @@ func Test__UpdateCanvasPreference__StoresAndClearsPreferences(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 
-	response, err = UpdateCanvasPreference(context.Background(), r.Organization.ID.String(), r.User.String(), &pb.UpdateCanvasPreferenceRequest{
+	response, err = UpdateCanvasPreference(context.Background(), database.DB(t.Context()), canvas, r.User.String(), &pb.UpdateCanvasPreferenceRequest{
 		CanvasId: canvas.ID.String(),
 		Starred:  proto.Bool(false),
 	})

--- a/pkg/grpc/actions/canvases/update_canvas_test.go
+++ b/pkg/grpc/actions/canvases/update_canvas_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/database"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/grpc/codes"
@@ -16,35 +16,13 @@ import (
 func Test__UpdateCanvas(t *testing.T) {
 	r := support.Setup(t)
 
-	t.Run("invalid canvas id -> error", func(t *testing.T) {
-		name := "name"
-		description := "description"
-		_, err := UpdateCanvas(context.Background(), r.Organization.ID.String(), "invalid-id", &name, &description)
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.InvalidArgument, code)
-	})
-
-	t.Run("canvas does not exist -> error", func(t *testing.T) {
-		_, err := UpdateCanvas(
-			context.Background(),
-			r.Organization.ID.String(),
-			uuid.New().String(),
-			stringPointer("updated-name"),
-			stringPointer("updated-description"),
-		)
-		code, _, ok := grpcerrors.HandlerStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.NotFound, code)
-	})
-
 	t.Run("empty name -> error", func(t *testing.T) {
 		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
 
 		_, err := UpdateCanvas(
 			context.Background(),
-			r.Organization.ID.String(),
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			stringPointer("   "),
 			stringPointer("description"),
 		)
@@ -60,8 +38,8 @@ func Test__UpdateCanvas(t *testing.T) {
 
 		response, err := UpdateCanvas(
 			context.Background(),
-			r.Organization.ID.String(),
-			canvas.ID.String(),
+			database.DB(t.Context()),
+			canvas,
 			&newName,
 			&newDescription,
 		)
@@ -85,8 +63,8 @@ func Test__UpdateCanvas(t *testing.T) {
 
 		_, err := UpdateCanvas(
 			context.Background(),
-			r.Organization.ID.String(),
-			targetCanvas.ID.String(),
+			database.DB(t.Context()),
+			targetCanvas,
 			&existingCanvas.Name,
 			&targetCanvas.Description,
 		)

--- a/pkg/grpc/canvas_service.go
+++ b/pkg/grpc/canvas_service.go
@@ -2,17 +2,22 @@ package grpc
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/database"
 	git "github.com/superplanehq/superplane/pkg/git/provider"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/usage"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
 )
 
 type CanvasService struct {
@@ -51,28 +56,6 @@ func (s *CanvasService) ListCanvases(ctx context.Context, req *pb.ListCanvasesRe
 	return canvases.ListCanvases(ctx, s.registry, organizationID, userID)
 }
 
-func (s *CanvasService) DescribeCanvas(ctx context.Context, req *pb.DescribeCanvasRequest) (*pb.DescribeCanvasResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.DescribeCanvas(ctx, s.registry, organizationID, req.Id)
-}
-
-func (s *CanvasService) UpdateCanvas(ctx context.Context, req *pb.UpdateCanvasRequest) (*pb.UpdateCanvasResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.UpdateCanvas(ctx, organizationID, req.Id, req.Name, req.Description)
-}
-
-func (s *CanvasService) UpdateCanvasPreference(
-	ctx context.Context,
-	req *pb.UpdateCanvasPreferenceRequest,
-) (*pb.UpdateCanvasPreferenceResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	userID, err := userIDFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return canvases.UpdateCanvasPreference(ctx, organizationID, userID, req)
-}
-
 func (s *CanvasService) CreateCanvas(ctx context.Context, req *pb.CreateCanvasRequest) (*pb.CreateCanvasResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
@@ -94,52 +77,141 @@ func (s *CanvasService) CreateCanvas(ctx context.Context, req *pb.CreateCanvasRe
 	)
 }
 
-func (s *CanvasService) ListCanvasVersions(ctx context.Context, req *pb.ListCanvasVersionsRequest) (*pb.ListCanvasVersionsResponse, error) {
+/*
+ * We always fetch the canvas first, to ensure the canvas being operated on belongs to the authenticated org.
+ */
+func (s *CanvasService) findCanvas(ctx context.Context, db *gorm.DB, canvasID string) (*models.Canvas, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.ListCanvasVersionsPaginated(ctx, organizationID, req.CanvasId, req.Limit, req.Before)
+	orgID, err := uuid.Parse(organizationID)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid organization_id")
+	}
+
+	id, err := uuid.Parse(canvasID)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid canvas_id")
+	}
+
+	canvas, err := models.FindCanvasInTransaction(db, orgID, id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, grpcerrors.NotFound(err, "canvas not found")
+		}
+
+		return nil, grpcerrors.Internal(err, "failed to load canvas")
+	}
+
+	return canvas, nil
+}
+
+func (s *CanvasService) DescribeCanvas(ctx context.Context, req *pb.DescribeCanvasRequest) (*pb.DescribeCanvasResponse, error) {
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.Id)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.DescribeCanvas(ctx, db, canvas)
+}
+
+func (s *CanvasService) UpdateCanvas(ctx context.Context, req *pb.UpdateCanvasRequest) (*pb.UpdateCanvasResponse, error) {
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.Id)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.UpdateCanvas(ctx, db, canvas, req.Name, req.Description)
+}
+
+func (s *CanvasService) UpdateCanvasPreference(
+	ctx context.Context,
+	req *pb.UpdateCanvasPreferenceRequest,
+) (*pb.UpdateCanvasPreferenceResponse, error) {
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+
+	userID, err := userIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.UpdateCanvasPreference(ctx, db, canvas, userID, req)
+}
+
+func (s *CanvasService) ListCanvasVersions(ctx context.Context, req *pb.ListCanvasVersionsRequest) (*pb.ListCanvasVersionsResponse, error) {
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.ListCanvasVersionsPaginated(ctx, db, canvas, req.Limit, req.Before)
 }
 
 func (s *CanvasService) DescribeCanvasVersion(ctx context.Context, req *pb.DescribeCanvasVersionRequest) (*pb.DescribeCanvasVersionResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.DescribeCanvasVersion(ctx, organizationID, req.CanvasId, req.VersionId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.DescribeCanvasVersion(ctx, db, canvas, req.VersionId)
 }
 
 func (s *CanvasService) DeleteCanvas(ctx context.Context, req *pb.DeleteCanvasRequest) (*pb.DeleteCanvasResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.DeleteCanvas(ctx, s.registry, uuid.MustParse(organizationID), req.Id)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.Id)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.DeleteCanvas(ctx, db, canvas)
 }
 
 func (s *CanvasService) ListNodeQueueItems(ctx context.Context, req *pb.ListNodeQueueItemsRequest) (*pb.ListNodeQueueItemsResponse, error) {
-	return canvases.ListNodeQueueItems(ctx, s.registry, req.CanvasId, req.NodeId, req.Limit, req.Before)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.ListNodeQueueItems(ctx, db, canvas, req.NodeId, req.Limit, req.Before)
 }
 
 func (s *CanvasService) DeleteNodeQueueItem(ctx context.Context, req *pb.DeleteNodeQueueItemRequest) (*pb.DeleteNodeQueueItemResponse, error) {
-	return canvases.DeleteNodeQueueItem(ctx, s.registry, req.CanvasId, req.NodeId, req.ItemId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.DeleteNodeQueueItem(ctx, db, canvas, req.NodeId, req.ItemId)
 }
 
 func (s *CanvasService) ListNodeExecutions(ctx context.Context, req *pb.ListNodeExecutionsRequest) (*pb.ListNodeExecutionsResponse, error) {
-	return canvases.ListNodeExecutions(ctx, s.registry, req.CanvasId, req.NodeId, req.States, req.Results, req.Limit, req.Before)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.ListNodeExecutions(ctx, db, canvas, req.NodeId, req.States, req.Results, req.Limit, req.Before)
 }
 
 func (s *CanvasService) ListNodeEvents(ctx context.Context, req *pb.ListNodeEventsRequest) (*pb.ListNodeEventsResponse, error) {
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid workflow_id")
+		return nil, err
 	}
 
 	if req.NodeId == "" {
 		return nil, status.Error(codes.InvalidArgument, "node_id is required")
 	}
 
-	return canvases.ListNodeEvents(ctx, s.registry, canvasID, req.NodeId, req.Limit, req.Before)
+	return canvases.ListNodeEvents(ctx, db, canvas, req.NodeId, req.Limit, req.Before)
 }
 
 func (s *CanvasService) ReemitTriggerEvent(ctx context.Context, req *pb.ReemitTriggerEventRequest) (*pb.ReemitTriggerEventResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid workflow_id")
+		return nil, err
 	}
 
 	if req.NodeId == "" {
@@ -151,21 +223,14 @@ func (s *CanvasService) ReemitTriggerEvent(ctx context.Context, req *pb.ReemitTr
 		return nil, status.Error(codes.InvalidArgument, "invalid event_id")
 	}
 
-	return canvases.ReemitTriggerEvent(
-		ctx,
-		uuid.MustParse(organizationID),
-		canvasID,
-		req.NodeId,
-		eventID,
-	)
+	return canvases.ReemitTriggerEvent(ctx, db, canvas, req.NodeId, eventID)
 }
 
 func (s *CanvasService) InvokeNodeExecutionHook(ctx context.Context, req *pb.InvokeNodeExecutionHookRequest) (*pb.InvokeNodeExecutionHookResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid workflow_id")
+		return nil, err
 	}
 
 	executionID, err := uuid.Parse(req.ExecutionId)
@@ -178,8 +243,8 @@ func (s *CanvasService) InvokeNodeExecutionHook(ctx context.Context, req *pb.Inv
 		s.authService,
 		s.encryptor,
 		s.registry,
-		uuid.MustParse(organizationID),
-		canvasID,
+		db,
+		canvas,
 		executionID,
 		req.HookName,
 		req.Parameters.AsMap(),
@@ -187,11 +252,10 @@ func (s *CanvasService) InvokeNodeExecutionHook(ctx context.Context, req *pb.Inv
 }
 
 func (s *CanvasService) InvokeNodeTriggerHook(ctx context.Context, req *pb.InvokeNodeTriggerHookRequest) (*pb.InvokeNodeTriggerHookResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid workflow_id")
+		return nil, err
 	}
 
 	if req.NodeId == "" {
@@ -207,8 +271,8 @@ func (s *CanvasService) InvokeNodeTriggerHook(ctx context.Context, req *pb.Invok
 		s.authService,
 		s.encryptor,
 		s.registry,
-		uuid.MustParse(organizationID),
-		canvasID,
+		db,
+		canvas,
 		req.NodeId,
 		req.HookName,
 		req.Parameters.AsMap(),
@@ -217,27 +281,30 @@ func (s *CanvasService) InvokeNodeTriggerHook(ctx context.Context, req *pb.Invok
 }
 
 func (s *CanvasService) ListRuns(ctx context.Context, req *pb.ListRunsRequest) (*pb.ListRunsResponse, error) {
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid workflow_id")
+		return nil, err
 	}
 
-	return canvases.ListRuns(ctx, s.registry, canvasID, req.Limit, req.Before, req.States, req.Results)
+	return canvases.ListRuns(ctx, db, canvas, req.Limit, req.Before, req.States, req.Results)
 }
 
 func (s *CanvasService) DescribeRun(ctx context.Context, req *pb.DescribeRunRequest) (*pb.DescribeRunResponse, error) {
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid canvas id")
+		return nil, err
 	}
 
-	return canvases.DescribeRun(ctx, s.registry, canvasID, req.RunId)
+	return canvases.DescribeRun(ctx, db, canvas, req.RunId)
 }
 
 func (s *CanvasService) CancelRun(ctx context.Context, req *pb.CancelRunRequest) (*pb.CancelRunResponse, error) {
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid canvas id")
+		return nil, err
 	}
 
 	runID, err := uuid.Parse(req.RunId)
@@ -245,38 +312,59 @@ func (s *CanvasService) CancelRun(ctx context.Context, req *pb.CancelRunRequest)
 		return nil, status.Error(codes.InvalidArgument, "invalid run id")
 	}
 
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.CancelRun(ctx, organizationID, canvasID, runID)
+	return canvases.CancelRun(ctx, db, canvas, runID)
 }
 
 func (s *CanvasService) ListCanvasMemories(ctx context.Context, req *pb.ListCanvasMemoriesRequest) (*pb.ListCanvasMemoriesResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.ListCanvasMemories(ctx, s.registry, organizationID, req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.ListCanvasMemories(ctx, db, canvas)
 }
 
 func (s *CanvasService) DeleteCanvasMemory(ctx context.Context, req *pb.DeleteCanvasMemoryRequest) (*pb.DeleteCanvasMemoryResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.DeleteCanvasMemory(ctx, s.registry, organizationID, req.CanvasId, req.MemoryId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.DeleteCanvasMemory(ctx, db, canvas, req.MemoryId)
 }
 
 func (s *CanvasService) CreateCanvasMemoryNamespace(ctx context.Context, req *pb.CreateCanvasMemoryNamespaceRequest) (*pb.CreateCanvasMemoryNamespaceResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.CreateCanvasMemoryNamespace(ctx, s.registry, organizationID, req.CanvasId, req.Namespace, req.Entries)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.CreateCanvasMemoryNamespace(ctx, db, canvas, req.Namespace, req.Entries)
 }
 
 func (s *CanvasService) UpdateCanvasMemoryNamespace(ctx context.Context, req *pb.UpdateCanvasMemoryNamespaceRequest) (*pb.UpdateCanvasMemoryNamespaceResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.UpdateCanvasMemoryNamespace(ctx, s.registry, organizationID, req.CanvasId, req.Namespace, req.NewNamespace, req.Entries)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.UpdateCanvasMemoryNamespace(ctx, db, canvas, req.Namespace, req.NewNamespace, req.Entries)
 }
 
 func (s *CanvasService) ListEventExecutions(ctx context.Context, req *pb.ListEventExecutionsRequest) (*pb.ListEventExecutionsResponse, error) {
-	return canvases.ListEventExecutions(ctx, s.registry, req.CanvasId, req.EventId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.ListEventExecutions(ctx, db, canvas, req.EventId)
 }
 
 func (s *CanvasService) CancelExecution(ctx context.Context, req *pb.CancelExecutionRequest) (*pb.CancelExecutionResponse, error) {
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid workflow_id")
+		return nil, err
 	}
 
 	executionID, err := uuid.Parse(req.ExecutionId)
@@ -284,15 +372,14 @@ func (s *CanvasService) CancelExecution(ctx context.Context, req *pb.CancelExecu
 		return nil, status.Error(codes.InvalidArgument, "invalid execution_id")
 	}
 
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-
-	return canvases.CancelExecution(ctx, s.authService, s.encryptor, organizationID, s.registry, canvasID, executionID)
+	return canvases.CancelExecution(ctx, s.authService, s.encryptor, db, canvas, executionID)
 }
 
 func (s *CanvasService) ResolveExecutionErrors(ctx context.Context, req *pb.ResolveExecutionErrorsRequest) (*pb.ResolveExecutionErrorsResponse, error) {
-	canvasID, err := uuid.Parse(req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid workflow_id")
+		return nil, err
 	}
 
 	executionIDs := make([]uuid.UUID, 0, len(req.ExecutionIds))
@@ -304,22 +391,35 @@ func (s *CanvasService) ResolveExecutionErrors(ctx context.Context, req *pb.Reso
 		executionIDs = append(executionIDs, parsedID)
 	}
 
-	return canvases.ResolveExecutionErrors(ctx, canvasID, executionIDs)
+	return canvases.ResolveExecutionErrors(ctx, db, canvas, executionIDs)
 }
 
 func (s *CanvasService) GetCanvasRepository(ctx context.Context, req *pb.GetCanvasRepositoryRequest) (*pb.GetCanvasRepositoryResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.GetCanvasRepository(ctx, s.gitProvider, organizationID, req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.GetCanvasRepository(ctx, s.gitProvider, canvas)
 }
 
 func (s *CanvasService) ListCanvasRepositoryFiles(ctx context.Context, req *pb.ListCanvasRepositoryFilesRequest) (*pb.ListCanvasRepositoryFilesResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	return canvases.ListCanvasRepositoryFiles(ctx, s.gitProvider, organizationID, req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+	return canvases.ListCanvasRepositoryFiles(ctx, s.gitProvider, canvas)
 }
 
 func (s *CanvasService) PutCanvasStaging(ctx context.Context, req *pb.PutCanvasStagingRequest) (*pb.PutCanvasStagingResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	state, err := canvases.PutCanvasStaging(ctx, organizationID, req.CanvasId, req.Operations)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := canvases.PutCanvasStaging(ctx, db, canvas, req.Operations)
 	if err != nil {
 		return nil, err
 	}
@@ -327,8 +427,13 @@ func (s *CanvasService) PutCanvasStaging(ctx context.Context, req *pb.PutCanvasS
 }
 
 func (s *CanvasService) GetCanvasStaging(ctx context.Context, req *pb.GetCanvasStagingRequest) (*pb.GetCanvasStagingResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	state, err := canvases.GetCanvasStaging(ctx, organizationID, req.CanvasId)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := canvases.GetCanvasStaging(ctx, db, canvas)
 	if err != nil {
 		return nil, err
 	}
@@ -336,8 +441,13 @@ func (s *CanvasService) GetCanvasStaging(ctx context.Context, req *pb.GetCanvasS
 }
 
 func (s *CanvasService) DeleteCanvasStaging(ctx context.Context, req *pb.DeleteCanvasStagingRequest) (*pb.DeleteCanvasStagingResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
-	state, err := canvases.DeleteCanvasStaging(ctx, organizationID, req.CanvasId, req.Paths)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := canvases.DeleteCanvasStaging(ctx, db, canvas, req.Paths)
 	if err != nil {
 		return nil, err
 	}
@@ -345,15 +455,20 @@ func (s *CanvasService) DeleteCanvasStaging(ctx context.Context, req *pb.DeleteC
 }
 
 func (s *CanvasService) CommitCanvasStaging(ctx context.Context, req *pb.CommitCanvasStagingRequest) (*pb.CommitCanvasStagingResponse, error) {
-	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	db := database.DB(ctx)
+	canvas, err := s.findCanvas(ctx, db, req.CanvasId)
+	if err != nil {
+		return nil, err
+	}
+
 	return canvases.CommitCanvasStaging(
 		ctx,
+		db,
 		s.gitProvider,
 		s.usageService,
 		s.encryptor,
 		s.registry,
-		organizationID,
-		req.CanvasId,
+		canvas,
 		req.CommitMessage,
 		s.webhookBaseURL,
 		s.authService,

--- a/pkg/grpc/canvas_service_test.go
+++ b/pkg/grpc/canvas_service_test.go
@@ -1,0 +1,220 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/datatypes"
+)
+
+func newTestCanvasService(r *support.ResourceRegistry) *CanvasService {
+	return NewCanvasService(
+		r.AuthService,
+		r.Registry,
+		r.Encryptor,
+		r.GitProvider,
+		"http://localhost:8000",
+		nil,
+	)
+}
+
+func canvasServiceContext(orgID, userID string) context.Context {
+	ctx := context.WithValue(context.Background(), authorization.OrganizationContextKey, orgID)
+	return authentication.SetUserIdInMetadata(ctx, userID)
+}
+
+func testCanvasNodes() []models.CanvasNode {
+	return []models.CanvasNode{
+		{
+			NodeID: "node-1",
+			Name:   "Node 1",
+			Type:   models.NodeTypeComponent,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Component: &models.ComponentRef{Name: "noop"},
+			}),
+		},
+	}
+}
+
+type crossOrgCanvasCase struct {
+	name     string
+	call     func(context.Context, *CanvasService, string) error
+	wantCode codes.Code
+}
+
+func TestCanvasService_rejectsCanvasFromOtherOrganization(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	ownCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, testCanvasNodes(), nil)
+
+	otherOrg := support.CreateOrganization(t, r, r.User)
+	otherCanvas, _ := support.CreateCanvas(t, otherOrg.ID, r.User, testCanvasNodes(), nil)
+
+	ctx := canvasServiceContext(r.Organization.ID.String(), r.User.String())
+	svc := newTestCanvasService(r)
+	otherCanvasID := otherCanvas.ID.String()
+
+	cases := []crossOrgCanvasCase{
+		{
+			name: "DescribeCanvas",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.DescribeCanvas(ctx, &pb.DescribeCanvasRequest{Id: canvasID})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "ListNodeExecutions",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.ListNodeExecutions(ctx, &pb.ListNodeExecutionsRequest{
+					CanvasId: canvasID,
+					NodeId:   "node-1",
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "ListNodeEvents",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.ListNodeEvents(ctx, &pb.ListNodeEventsRequest{
+					CanvasId: canvasID,
+					NodeId:   "node-1",
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "ListNodeQueueItems",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.ListNodeQueueItems(ctx, &pb.ListNodeQueueItemsRequest{
+					CanvasId: canvasID,
+					NodeId:   "node-1",
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "DeleteNodeQueueItem",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.DeleteNodeQueueItem(ctx, &pb.DeleteNodeQueueItemRequest{
+					CanvasId: canvasID,
+					NodeId:   "node-1",
+					ItemId:   uuid.New().String(),
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "ListRuns",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.ListRuns(ctx, &pb.ListRunsRequest{CanvasId: canvasID})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "DescribeRun",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.DescribeRun(ctx, &pb.DescribeRunRequest{
+					CanvasId: canvasID,
+					RunId:    uuid.New().String(),
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "ListEventExecutions",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.ListEventExecutions(ctx, &pb.ListEventExecutionsRequest{
+					CanvasId: canvasID,
+					EventId:  uuid.New().String(),
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "ResolveExecutionErrors",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.ResolveExecutionErrors(ctx, &pb.ResolveExecutionErrorsRequest{
+					CanvasId:     canvasID,
+					ExecutionIds: []string{uuid.New().String()},
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "CancelRun",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.CancelRun(ctx, &pb.CancelRunRequest{
+					CanvasId: canvasID,
+					RunId:    uuid.New().String(),
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "CancelExecution",
+			call: func(ctx context.Context, svc *CanvasService, canvasID string) error {
+				_, err := svc.CancelExecution(ctx, &pb.CancelExecutionRequest{
+					CanvasId:    canvasID,
+					ExecutionId: uuid.New().String(),
+				})
+				return err
+			},
+			wantCode: codes.NotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call(ctx, svc, otherCanvasID)
+			require.Error(t, err)
+
+			code, msg, ok := grpcerrors.HandlerStatus(err)
+			require.True(t, ok, "expected handler status error")
+			assert.Equal(t, tc.wantCode, code)
+			if tc.wantCode == codes.NotFound {
+				assert.Equal(t, "canvas not found", msg)
+			}
+		})
+	}
+
+	t.Run("own organization canvas is still accessible", func(t *testing.T) {
+		response, err := svc.DescribeCanvas(ctx, &pb.DescribeCanvasRequest{Id: ownCanvas.ID.String()})
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		assert.Equal(t, ownCanvas.ID.String(), response.Canvas.Metadata.Id)
+	})
+}
+
+func TestCanvasService_findCanvas_rejectsInvalidCanvasID(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	ctx := canvasServiceContext(r.Organization.ID.String(), r.User.String())
+	svc := newTestCanvasService(r)
+
+	_, err := svc.DescribeCanvas(ctx, &pb.DescribeCanvasRequest{Id: "not-a-uuid"})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Convert(err).Code())
+}

--- a/pkg/models/canvas_event.go
+++ b/pkg/models/canvas_event.go
@@ -96,9 +96,9 @@ func FindCanvasEventsForExecutions(tx *gorm.DB, executionIDs []string) ([]Canvas
 	return events, nil
 }
 
-func FindCanvasEventForCanvas(canvasID uuid.UUID, id uuid.UUID) (*CanvasEvent, error) {
+func FindCanvasEventForCanvas(db *gorm.DB, canvasID uuid.UUID, id uuid.UUID) (*CanvasEvent, error) {
 	var event CanvasEvent
-	err := database.Conn().
+	err := db.
 		Where("workflow_id = ?", canvasID).
 		Where("id = ?", id).
 		First(&event).
@@ -143,9 +143,9 @@ func ListCanvasEventsByIDsInTransaction(tx *gorm.DB, ids []uuid.UUID) ([]CanvasE
 	return events, nil
 }
 
-func ListCanvasEvents(canvasID uuid.UUID, nodeID string, limit int, before *time.Time) ([]CanvasEvent, error) {
+func ListCanvasEvents(db *gorm.DB, canvasID uuid.UUID, nodeID string, limit int, before *time.Time) ([]CanvasEvent, error) {
 	var events []CanvasEvent
-	query := database.Conn().
+	query := db.
 		Where("workflow_id = ?", canvasID).
 		Where("node_id = ?", nodeID)
 
@@ -165,10 +165,10 @@ func ListCanvasEvents(canvasID uuid.UUID, nodeID string, limit int, before *time
 	return events, nil
 }
 
-func CountCanvasEvents(canvasID uuid.UUID, nodeID string) (int64, error) {
+func CountCanvasEvents(db *gorm.DB, canvasID uuid.UUID, nodeID string) (int64, error) {
 	var count int64
 
-	err := database.Conn().
+	err := db.
 		Model(&CanvasEvent{}).
 		Where("workflow_id = ?", canvasID).
 		Where("node_id = ?", nodeID).

--- a/pkg/models/canvas_node.go
+++ b/pkg/models/canvas_node.go
@@ -448,9 +448,9 @@ func (i *CanvasNodeQueueItem) Delete(tx *gorm.DB) error {
 	return tx.Delete(i).Error
 }
 
-func ListNodeQueueItems(workflowID uuid.UUID, nodeID string, limit int, beforeTime *time.Time) ([]CanvasNodeQueueItem, error) {
+func ListNodeQueueItems(db *gorm.DB, workflowID uuid.UUID, nodeID string, limit int, beforeTime *time.Time) ([]CanvasNodeQueueItem, error) {
 	var queueItems []CanvasNodeQueueItem
-	query := database.Conn().
+	query := db.
 		Preload("RootEvent").
 		Where("workflow_id = ?", workflowID).
 		Where("node_id = ?", nodeID).
@@ -469,9 +469,9 @@ func ListNodeQueueItems(workflowID uuid.UUID, nodeID string, limit int, beforeTi
 	return queueItems, nil
 }
 
-func CountNodeQueueItems(workflowID uuid.UUID, nodeID string) (int64, error) {
+func CountNodeQueueItems(db *gorm.DB, workflowID uuid.UUID, nodeID string) (int64, error) {
 	var totalCount int64
-	countQuery := database.Conn().
+	countQuery := db.
 		Model(&CanvasNodeQueueItem{}).
 		Where("workflow_id = ?", workflowID).
 		Where("node_id = ?", nodeID)

--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -191,9 +191,9 @@ func LockPendingNodeExecutionInActiveCanvas(tx *gorm.DB, id uuid.UUID) (*CanvasN
 	return &execution, nil
 }
 
-func ListNodeExecutions(workflowID uuid.UUID, nodeID string, states []string, results []string, limit int, beforeTime *time.Time) ([]CanvasNodeExecution, error) {
+func ListNodeExecutions(db *gorm.DB, workflowID uuid.UUID, nodeID string, states []string, results []string, limit int, beforeTime *time.Time) ([]CanvasNodeExecution, error) {
 	var executions []CanvasNodeExecution
-	query := database.Conn().
+	query := db.
 		Where("workflow_id = ?", workflowID).
 		Where("node_id = ?", nodeID).
 		Order("created_at DESC").
@@ -291,9 +291,9 @@ func CountActiveNodeExecutionsForRootEventInTransaction(tx *gorm.DB, rootEventID
 	return count, nil
 }
 
-func CountNodeExecutions(workflowID uuid.UUID, nodeID string, states []string, results []string) (int64, error) {
+func CountNodeExecutions(db *gorm.DB, workflowID uuid.UUID, nodeID string, states []string, results []string) (int64, error) {
 	var totalCount int64
-	countQuery := database.Conn().
+	countQuery := db.
 		Model(&CanvasNodeExecution{}).
 		Where("workflow_id = ?", workflowID).
 		Where("node_id = ?", nodeID)

--- a/pkg/models/canvas_node_test.go
+++ b/pkg/models/canvas_node_test.go
@@ -64,7 +64,7 @@ func Test__DeleteCanvasNodeWithResult__DeletesQueueItemsAndRequestsFinalization(
 	result, err := models.DeleteCanvasNodeWithResult(database.Conn(), *node)
 	require.NoError(t, err)
 
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, nodeID, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, nodeID, 10, nil)
 	require.NoError(t, err)
 	assert.Empty(t, queueItems)
 

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -269,7 +269,7 @@ func Test__HandleWebhook_DoesNotRunNodesForSoftDeletedOrganization(t *testing.T)
 
 	require.Equal(t, http.StatusNotFound, response.Code)
 
-	eventCount, err := models.CountCanvasEvents(canvas.ID, nodeID)
+	eventCount, err := models.CountCanvasEvents(database.Conn(), canvas.ID, nodeID)
 	require.NoError(t, err)
 	assert.Zero(t, eventCount)
 }

--- a/pkg/workers/event_router_test.go
+++ b/pkg/workers/event_router_test.go
@@ -73,7 +73,7 @@ func Test__EventRouter_ProcessRootEvent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasRunStateStarted, run.State)
 
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, node2, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, node2, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, queueItems, 1)
 	assert.Equal(t, node2, queueItems[0].NodeID)
@@ -126,7 +126,7 @@ func Test__EventRouter_DoesNotRouteEventForSoftDeletedOrganization(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasEventStatePending, updatedEvent.State)
 
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Empty(t, queueItems)
 
@@ -183,7 +183,7 @@ func Test__EventRouter_ProcessExecutionEvent(t *testing.T) {
 	//
 	// Process node1 output event and verify it was routed properly.
 	//
-	events, err := models.ListCanvasEvents(canvas.ID, node1, 10, nil)
+	events, err := models.ListCanvasEvents(database.Conn(), canvas.ID, node1, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	outputEvent := events[0]
@@ -194,7 +194,7 @@ func Test__EventRouter_ProcessExecutionEvent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasEventStateRouted, updatedEvent.State)
 
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, node2, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, node2, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, queueItems, 1)
 	assert.Equal(t, node2, queueItems[0].NodeID)
@@ -237,7 +237,7 @@ func Test__EventRouter_ProcessTerminalExecutionEventFinishesRun(t *testing.T) {
 	_, err = execution.Pass(map[string][]any{"default": {map[string]any{}}})
 	require.NoError(t, err)
 
-	events, err := models.ListCanvasEvents(canvas.ID, node, 10, nil)
+	events, err := models.ListCanvasEvents(database.Conn(), canvas.ID, node, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 

--- a/pkg/workers/eventdistributer/event_created.go
+++ b/pkg/workers/eventdistributer/event_created.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
@@ -41,7 +42,7 @@ func handleWorkflowEventState(canvasID string, eventID string, wsHub *ws.Hub, ev
 		return fmt.Errorf("failed to parse event id: %w", err)
 	}
 
-	event, err := models.FindCanvasEventForCanvas(canvasUUID, eventUUID)
+	event, err := models.FindCanvasEventForCanvas(database.Conn(), canvasUUID, eventUUID)
 	if err != nil {
 		return fmt.Errorf("failed to find event: %w", err)
 	}

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -77,7 +77,7 @@ func Test__NodeQueueWorker_ComponentNodeQueueIsProcessed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasNodeStateReady, node.State)
 
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, queueItems, 1)
 
@@ -91,7 +91,7 @@ func Test__NodeQueueWorker_ComponentNodeQueueIsProcessed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify execution was created with pending state
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, executions, 1)
 	assert.Equal(t, models.CanvasNodeExecutionStatePending, executions[0].State)
@@ -104,7 +104,7 @@ func Test__NodeQueueWorker_ComponentNodeQueueIsProcessed(t *testing.T) {
 	assert.Equal(t, models.CanvasNodeStateProcessing, node.State)
 
 	// Verify queue item was deleted
-	queueItems, err = models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err = models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, queueItems, 0)
 
@@ -158,11 +158,11 @@ func Test__NodeQueueWorker_DoesNotProcessQueueForSoftDeletedOrganization(t *test
 
 	require.NoError(t, worker.LockAndProcessNode(logger, *node, time.Now()))
 
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	assert.Empty(t, executions)
 
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, queueItems, 1)
 
@@ -266,13 +266,13 @@ func Test__NodeQueueWorker_PicksOldestQueueItem(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the execution was created with the oldest event
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, executions, 1)
 	assert.Equal(t, oldEvent.ID, executions[0].EventID)
 
 	// Verify the oldest queue item was deleted, but the other two remain
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, queueItems, 2)
 
@@ -332,7 +332,7 @@ func Test__NodeQueueWorker_EmptyQueue(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify no executions were created
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, executions, 0)
 
@@ -416,14 +416,14 @@ func Test__NodeQueueWorker_PreventsConcurrentProcessing(t *testing.T) {
 	// Verify only one execution was created (not two).
 	// This proves that only one worker actually processed the node.
 	//
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, executions, 1, "Only one execution should be created, not two")
 
 	//
 	// Verify the queue item was deleted.
 	//
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, queueItems, 0, "Queue item should be deleted")
 
@@ -487,7 +487,7 @@ func Test__NodeQueueWorker_ConfigurationBuildFailure(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasNodeStateReady, node.State)
 
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, queueItems, 1)
 
@@ -501,7 +501,7 @@ func Test__NodeQueueWorker_ConfigurationBuildFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify execution was created with finished state and failed result
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, executions, 1)
 	assert.Equal(t, models.CanvasNodeExecutionStateFinished, executions[0].State)
@@ -518,7 +518,7 @@ func Test__NodeQueueWorker_ConfigurationBuildFailure(t *testing.T) {
 	assert.Equal(t, models.CanvasNodeStateReady, node.State)
 
 	// Verify queue item was deleted
-	queueItems, err = models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err = models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, queueItems, 0)
 
@@ -581,7 +581,7 @@ func Test__NodeQueueWorker_ProcessesNextQueueItemOnExecutionFinished(t *testing.
 	//
 	require.NoError(t, worker.LockAndProcessNode(logger, *node, time.Now()))
 
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, executions, 1)
 	require.Equal(t, oldEvent.ID, executions[0].EventID)
@@ -591,7 +591,7 @@ func Test__NodeQueueWorker_ProcessesNextQueueItemOnExecutionFinished(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasNodeStateProcessing, node.State)
 
-	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, queueItems, 1)
 	assert.Equal(t, newEvent.ID, queueItems[0].EventID)
@@ -620,13 +620,13 @@ func Test__NodeQueueWorker_ProcessesNextQueueItemOnExecutionFinished(t *testing.
 
 	require.NoError(t, worker.ConsumeExecutionFinished(tackle.NewFakeDelivery(finishedMessage)))
 
-	executions, err = models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err = models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, executions, 2)
 	assert.Equal(t, newEvent.ID, executions[0].EventID)
 	assert.Equal(t, models.CanvasNodeExecutionStatePending, executions[0].State)
 
-	queueItems, err = models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	queueItems, err = models.ListNodeQueueItems(database.Conn(), canvas.ID, componentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Empty(t, queueItems)
 }
@@ -693,7 +693,7 @@ func Test__NodeQueueWorker_DeferredQueueItemDoesNotPublishConsumed(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, queueItem.ID, storedQueueItem.ID)
 
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	assert.Empty(t, executions)
 
@@ -769,7 +769,7 @@ func Test__NodeQueueWorker_SkipsQueueItemForCancellingRun(t *testing.T) {
 	err = worker.LockAndProcessNode(logger, *node, time.Now())
 	require.NoError(t, err)
 
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	assert.Empty(t, executions)
 
@@ -853,7 +853,7 @@ func Test__NodeQueueWorker_SkipsConfigurationErrorQueueItemForCancellingRun(t *t
 	err = worker.LockAndProcessNode(logger, *node, time.Now())
 	require.NoError(t, err)
 
-	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
 	assert.Empty(t, executions)
 

--- a/pkg/workers/node_request_worker_test.go
+++ b/pkg/workers/node_request_worker_test.go
@@ -286,7 +286,7 @@ func Test__NodeRequestWorker_PreventsConcurrentProcessing(t *testing.T) {
 	//
 	// Verify that exactly one workflow event was emitted (proving only one worker processed it).
 	//
-	eventCount, err := models.CountCanvasEvents(canvas.ID, triggerNode)
+	eventCount, err := models.CountCanvasEvents(database.Conn(), canvas.ID, triggerNode)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), eventCount, "Expected exactly 1 workflow event, but found %d", eventCount)
 
@@ -593,7 +593,7 @@ func Test__NodeRequestWorker_CompletesDeletedNodeRequests(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
 
-	eventCount, err := models.CountCanvasEvents(canvas.ID, triggerNode)
+	eventCount, err := models.CountCanvasEvents(database.Conn(), canvas.ID, triggerNode)
 	require.NoError(t, err)
 	assert.Zero(t, eventCount)
 
@@ -1102,7 +1102,7 @@ func Test__NodeRequestWorker_DoesNotProcessSoftDeletedOrganizationRequests(t *te
 	require.NoError(t, database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error)
 	assert.Equal(t, models.NodeExecutionRequestStatePending, updatedRequest.State)
 
-	eventCount, err := models.CountCanvasEvents(canvas.ID, triggerNode)
+	eventCount, err := models.CountCanvasEvents(database.Conn(), canvas.ID, triggerNode)
 	require.NoError(t, err)
 	assert.Zero(t, eventCount)
 	assert.False(t, executionConsumer.HasReceivedMessage())

--- a/pkg/workers/run_finalizer_test.go
+++ b/pkg/workers/run_finalizer_test.go
@@ -58,7 +58,7 @@ func Test__RunFinalizer_FinalizesRunAfterTerminalExecutionEvent(t *testing.T) {
 	_, err = execution.Pass(map[string][]any{"default": {map[string]any{}}})
 	require.NoError(t, err)
 
-	events, err := models.ListCanvasEvents(canvas.ID, node, 10, nil)
+	events, err := models.ListCanvasEvents(database.Conn(), canvas.ID, node, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 
@@ -520,7 +520,7 @@ func Test__RunFinalizer__CallsFinishedCallbackWhenConfigured(t *testing.T) {
 	_, err = childExecution.Pass(map[string][]any{"default": {map[string]any{}}})
 	require.NoError(t, err)
 
-	events, err := models.ListCanvasEvents(childCanvas.ID, "component", 10, nil)
+	events, err := models.ListCanvasEvents(database.Conn(), childCanvas.ID, "component", 10, nil)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 

--- a/test/e2e/canvas_page_test.go
+++ b/test/e2e/canvas_page_test.go
@@ -628,7 +628,7 @@ func (s *CanvasPageSteps) assertQueuedItemsCount(nodeName string, expected int) 
 		}
 		require.NotNil(s.t, waitNode, nodeName+" node not found")
 
-		queueItems, err := models.ListNodeQueueItems(waitNode.WorkflowID, waitNode.NodeID, 100, nil)
+		queueItems, err := models.ListNodeQueueItems(database.Conn(), waitNode.WorkflowID, waitNode.NodeID, 100, nil)
 		require.NoError(s.t, err)
 
 		lastCount = len(queueItems)


### PR DESCRIPTION
Several handlers checked RBAC for the caller's organization but never verified that the `{canvas_id}` in the request belonged to that org. An authenticated user could read or mutate another tenant's executions, events, queue items, runs, and related data by supplying a foreign canvas UUID.

This PR adds a shared `findCanvas` gate in `CanvasService` that loads the canvas with `FindCanvasInTransaction(orgID, canvasID)` before any handler runs. Canvas action functions now receive a verified `*models.Canvas` (and request-scoped `*gorm.DB`) instead of raw IDs, so downstream queries always operate on an org-owned canvas. Model helpers for events, executions, and queue items were updated to accept an explicit `*gorm.DB` parameter to match the transaction-scoped call chain.

## Affected endpoints (now org-scoped)

**Read**
- `GET /api/v1/canvases/{canvas_id}/nodes/{node_id}/executions`
- `GET /api/v1/canvases/{canvas_id}/nodes/{node_id}/events`
- `GET /api/v1/canvases/{canvas_id}/nodes/{node_id}/queue`
- `GET /api/v1/canvases/{canvas_id}/runs`
- `GET /api/v1/canvases/{canvas_id}/runs/{run_id}`
- `GET /api/v1/canvases/{canvas_id}/events/{event_id}/executions`

**Write**
  - `DELETE /api/v1/canvases/{canvas_id}/nodes/{node_id}/queue/{item_id}`
  - `PATCH /api/v1/canvases/{canvas_id}/executions/resolve`
  - `PATCH /api/v1/canvases/{canvas_id}/executions/{execution_id}/cancel`
  - `PATCH /api/v1/canvases/{canvas_id}/runs/{run_id}/cancel`

---

All other canvas-scoped handlers (describe, staging, memory, hooks, etc.) now go through the same gate for consistency