### PR TITLE
fix: sanitize SMTP headers to prevent CRLF injection

### DIFF
--- a/pkg/integrations/smtp/client.go
+++ b/pkg/integrations/smtp/client.go
@@ -300,22 +300,22 @@ func (c *Client) buildMessage(email Email, fromName, fromEmail string) (string, 
 
 	// Build headers
 	headers := []string{
-		fmt.Sprintf("From: %s", from),
-		fmt.Sprintf("Subject: %s", email.Subject),
+		fmt.Sprintf("From: %s", sanitizeSMTPHeaderValue(from)),
+		fmt.Sprintf("Subject: %s", sanitizeSMTPHeaderValue(email.Subject)),
 		"MIME-Version: 1.0",
 		fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"", boundary),
 	}
 
 	if len(email.To) > 0 {
-		headers = append(headers, fmt.Sprintf("To: %s", strings.Join(email.To, ", ")))
+		headers = append(headers, fmt.Sprintf("To: %s", sanitizeSMTPHeaderValue(strings.Join(email.To, ", "))))
 	}
 
 	if len(email.Cc) > 0 {
-		headers = append(headers, fmt.Sprintf("Cc: %s", strings.Join(email.Cc, ", ")))
+		headers = append(headers, fmt.Sprintf("Cc: %s", sanitizeSMTPHeaderValue(strings.Join(email.Cc, ", "))))
 	}
 
 	if email.ReplyTo != "" {
-		headers = append(headers, fmt.Sprintf("Reply-To: %s", email.ReplyTo))
+		headers = append(headers, fmt.Sprintf("Reply-To: %s", sanitizeSMTPHeaderValue(email.ReplyTo)))
 	}
 
 	// Build message body
@@ -355,6 +355,11 @@ func randomBoundary() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// sanitizeSMTPHeaderValue strips CR/LF so caller-influenced values cannot inject SMTP headers.
+func sanitizeSMTPHeaderValue(value string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(value)
 }
 
 func stripHTML(html string) string {

--- a/pkg/integrations/smtp/client_test.go
+++ b/pkg/integrations/smtp/client_test.go
@@ -1,0 +1,51 @@
+package smtp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMessage_StripsCRLFFromHeaders(t *testing.T) {
+	client := &Client{}
+	msg, err := client.buildMessage(Email{
+		To:        []string{"to@example.com\r\nBcc: attacker@external.com"},
+		Cc:        []string{"cc@example.com\r\nFrom: spoofed@victim.com"},
+		Subject:   "Urgent\r\nFrom: ceo@victim.com\r\nBcc: attacker@external.com",
+		TextBody:  "plain body",
+		ReplyTo:   "reply@example.com\r\nCc: evil@external.com",
+		FromName:  "Sender\r\nBcc: evil@external.com",
+		FromEmail: "sender@example.com",
+	}, "Sender\r\nBcc: evil@external.com", "sender@example.com")
+	require.NoError(t, err)
+
+	assert.Contains(t, msg, "Subject: UrgentFrom: ceo@victim.comBcc: attacker@external.com")
+	assert.Contains(t, msg, "From: SenderBcc: evil@external.com <sender@example.com>")
+	assert.Contains(t, msg, "To: to@example.comBcc: attacker@external.com")
+	assert.Contains(t, msg, "Cc: cc@example.comFrom: spoofed@victim.com")
+	assert.Contains(t, msg, "Reply-To: reply@example.comCc: evil@external.com")
+	assert.NotContains(t, msg, "\r\nFrom: ceo@victim.com")
+	assert.NotContains(t, msg, "\r\nBcc: attacker@external.com")
+	assert.Equal(t, 1, countHeaderLines(msg, "From:"))
+	assert.Equal(t, 1, countHeaderLines(msg, "Subject:"))
+	assert.Equal(t, 1, countHeaderLines(msg, "To:"))
+	assert.Equal(t, 1, countHeaderLines(msg, "Cc:"))
+	assert.Equal(t, 1, countHeaderLines(msg, "Reply-To:"))
+}
+
+func countHeaderLines(message, headerPrefix string) int {
+	headerEnd := strings.Index(message, "\r\n\r\n")
+	if headerEnd < 0 {
+		return 0
+	}
+
+	count := 0
+	for _, line := range strings.Split(message[:headerEnd], "\r\n") {
+		if strings.HasPrefix(line, headerPrefix) {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/services/smtp_email.go
+++ b/pkg/services/smtp_email.go
@@ -244,14 +244,14 @@ func buildMultipartEmail(from string, to []string, bcc []string, subject, textBo
 	}
 
 	headers := []string{
-		fmt.Sprintf("From: %s", from),
-		fmt.Sprintf("Subject: %s", subject),
+		fmt.Sprintf("From: %s", sanitizeSMTPHeaderValue(from)),
+		fmt.Sprintf("Subject: %s", sanitizeSMTPHeaderValue(subject)),
 		"MIME-Version: 1.0",
 		fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"", boundary),
 	}
 
 	if len(to) > 0 {
-		headers = append(headers, fmt.Sprintf("To: %s", strings.Join(to, ", ")))
+		headers = append(headers, fmt.Sprintf("To: %s", sanitizeSMTPHeaderValue(strings.Join(to, ", "))))
 	}
 
 	message := strings.Join(headers, "\r\n") + "\r\n\r\n"
@@ -272,6 +272,11 @@ func formatFrom(name, email string) string {
 	}
 
 	return fmt.Sprintf("%s <%s>", name, email)
+}
+
+// sanitizeSMTPHeaderValue strips CR/LF so caller-influenced values cannot inject SMTP headers.
+func sanitizeSMTPHeaderValue(value string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(value)
 }
 
 func randomBoundary() (string, error) {

--- a/pkg/services/smtp_email_test.go
+++ b/pkg/services/smtp_email_test.go
@@ -110,6 +110,43 @@ func TestBuildMultipartEmail(t *testing.T) {
 	assert.Contains(t, msg, "<p>html body</p>")
 }
 
+func TestBuildMultipartEmail_StripsCRLFFromHeaders(t *testing.T) {
+	msg, err := buildMultipartEmail(
+		"Sender\r\nBcc: evil@external.com <sender@example.com>",
+		[]string{"to@example.com\r\nCc: attacker@external.com"},
+		nil,
+		"Urgent\r\nFrom: ceo@victim.com\r\nBcc: attacker@external.com",
+		"plain body",
+		"<p>html body</p>",
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, msg, "Subject: UrgentFrom: ceo@victim.comBcc: attacker@external.com")
+	assert.Contains(t, msg, "From: SenderBcc: evil@external.com <sender@example.com>")
+	assert.Contains(t, msg, "To: to@example.comCc: attacker@external.com")
+	assert.NotContains(t, msg, "\r\nFrom: ceo@victim.com")
+	assert.NotContains(t, msg, "\r\nBcc: attacker@external.com")
+	assert.NotContains(t, msg, "\r\nCc: attacker@external.com")
+	assert.Equal(t, 1, countHeaderLines(msg, "From:"))
+	assert.Equal(t, 1, countHeaderLines(msg, "Subject:"))
+	assert.Equal(t, 1, countHeaderLines(msg, "To:"))
+}
+
+func countHeaderLines(message, headerPrefix string) int {
+	headerEnd := strings.Index(message, "\r\n\r\n")
+	if headerEnd < 0 {
+		return 0
+	}
+
+	count := 0
+	for _, line := range strings.Split(message[:headerEnd], "\r\n") {
+		if strings.HasPrefix(line, headerPrefix) {
+			count++
+		}
+	}
+	return count
+}
+
 func TestSMTPEmailService_SendMagicCodeEmail(t *testing.T) {
 	tmpDir := t.TempDir()
 	writeMagicCodeTemplates(t, tmpDir)


### PR DESCRIPTION
## Summary
- Strip `\r`/`\n` from caller-influenced SMTP header values in `smtp.sendEmail` (`Client.buildMessage`) and the installation SMTP email service (`buildMultipartEmail`)
- Prevents header injection via expression-resolved fields such as subject/from name (e.g. webhook payload → `{{ event.payload.title }}`)
- Adds regression tests covering spoofed `From`/`Bcc`/`Cc`/`Reply-To` injection payloads

## Test plan
- [x] `make test PKG_TEST_PACKAGES="./pkg/services ./pkg/integrations/smtp"`
- [ ] Confirm CI green
- [ ] Spot-check that a subject containing newlines is collapsed into a single header line


Made with [Cursor](https://cursor.com)