### PR TITLE
fix: use registryimports in integrations count script

### DIFF
--- a/scripts/integrations/main.go
+++ b/scripts/integrations/main.go
@@ -2,16 +2,22 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/registry"
-
-	// Import server to auto-register all integrations, components, and triggers via init().
-	_ "github.com/superplanehq/superplane/pkg/server"
+	"github.com/superplanehq/superplane/pkg/registryimports"
 )
 
+var _ = registryimports.Loaded
+
 func main() {
-	reg, _ := registry.NewRegistry(crypto.NewNoOpEncryptor(), registry.HTTPOptions{})
+	reg, err := registry.NewRegistry(crypto.NewNoOpEncryptor(), registry.HTTPOptions{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	integrations := reg.ListIntegrations()
 	coreActions := reg.ListActions()
 	coreTriggers := reg.ListTriggers()
@@ -26,6 +32,7 @@ func main() {
 	triggersCount := len(coreTriggers) + integrationTriggers
 	componentsCount := actionsCount + triggersCount
 
+	// +1 counts built-in "Core" components alongside registered integrations.
 	integrationsCount := len(integrations) + 1
 
 	fmt.Printf("Integrations: %d\n", integrationsCount)


### PR DESCRIPTION
## Summary
- Fix `scripts/integrations/main.go` so it runs without a full protobuf/codegen setup by importing `pkg/registryimports` instead of `pkg/server`.
- Handle registry construction errors instead of ignoring them.

## Test plan
- [x] `go run ./scripts/integrations/main.go` prints integration/component counts

Made with [Cursor](https://cursor.com)