### PR TITLE
feat: add Software Factory project homepage

### DIFF
--- a/web_src/src/pages/home/FactoryHomePage.stories.tsx
+++ b/web_src/src/pages/home/FactoryHomePage.stories.tsx
@@ -1,0 +1,218 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { FactoryHomePage } from "./FactoryHomePage";
+import type { FactoryHomeData, FactoryStartingTask } from "./factoryHomeTypes";
+
+/**
+ * Project homepage for an installed Software Factory — where `Pages/HomePage →
+ * Fresh Org` lands once **Setup Factory** finishes.
+ *
+ * Section order is deliberate: work blocked on a person first, then what the
+ * agents are doing right now, then the outcome telemetry and audit trail that
+ * say whether the factory earns more autonomy. All data arrives via props, so
+ * every state below is a fixture rather than a live backend.
+ */
+const meta = {
+  title: "Pages/Factory Home",
+  component: FactoryHomePage,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof FactoryHomePage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+
+const startingTasks: FactoryStartingTask[] = [
+  {
+    id: "fix-bug",
+    label: "Find and fix a bug",
+    description: "Scan for a high-confidence defect and ship a minimal fix.",
+  },
+  {
+    id: "unit-test",
+    label: "Improve test coverage",
+    description: "Add one focused test to untested core logic.",
+  },
+  {
+    id: "improve-ci",
+    label: "Set up or improve CI",
+    description: "One small improvement to the existing pipeline.",
+  },
+  {
+    id: "improve-agents-md",
+    label: "Improve AGENTS.md",
+    description: "Refresh repo conventions so future runs start better informed.",
+  },
+];
+
+const baseData: FactoryHomeData = {
+  project: {
+    name: "Payments API",
+    description:
+      "Agents pick up factory-labeled issues, open pull requests, and babysit CI until the checks are green.",
+    repository: "acme/payments-api",
+    repositoryUrl: "https://github.com/acme/payments-api",
+    defaultBranch: "main",
+    owner: "Platform team",
+    health: "healthy",
+    integrations: [
+      { id: "github", label: "GitHub", connected: true },
+      { id: "claude", label: "Claude", connected: true },
+    ],
+  },
+  startingTasks,
+  needsReview: [
+    {
+      id: "review-1",
+      title: "Retry idempotency keys on gateway timeout",
+      reason: "Agent finished and requested review before merge.",
+      waitingSince: minutesAgo(42),
+      pullRequest: { number: 1841, url: "https://github.com/acme/payments-api/pull/1841" },
+    },
+    {
+      id: "review-2",
+      title: "Add refund reconciliation test",
+      reason: "Touches a protected path — merge needs an approver.",
+      waitingSince: minutesAgo(190),
+      pullRequest: { number: 1839, url: "https://github.com/acme/payments-api/pull/1839" },
+    },
+  ],
+  inFlight: [
+    {
+      id: "run-1",
+      title: "Fix currency rounding in settlement report",
+      status: "running",
+      stage: "Waiting on CI",
+      branch: "factory/settlement-rounding",
+      startedAt: minutesAgo(11),
+      pullRequest: { number: 1843, url: "https://github.com/acme/payments-api/pull/1843" },
+    },
+    {
+      id: "run-2",
+      title: "Improve AGENTS.md",
+      status: "running",
+      stage: "Writing changes",
+      branch: "factory/agents-md-refresh",
+      startedAt: minutesAgo(3),
+    },
+    {
+      id: "run-3",
+      title: "Harden webhook signature check",
+      status: "failed",
+      stage: "CI failed — agent retrying",
+      branch: "factory/webhook-signature",
+      startedAt: minutesAgo(58),
+      pullRequest: { number: 1840, url: "https://github.com/acme/payments-api/pull/1840" },
+    },
+  ],
+  outcomes: [
+    {
+      id: "merged",
+      label: "Pull requests merged",
+      value: "34",
+      delta: "+9",
+      deltaPeriod: "prior 14 days",
+      betterDirection: "up",
+      trend: [1, 2, 2, 3, 2, 4, 3, 5, 4, 6, 5, 7],
+    },
+    {
+      id: "lead-time",
+      label: "Issue to merge",
+      value: "3h 12m",
+      delta: "-41m",
+      deltaPeriod: "prior 14 days",
+      betterDirection: "down",
+      trend: [8, 7, 7, 6, 6, 5, 5, 4, 4, 4, 3, 3],
+    },
+    {
+      id: "first-pass",
+      label: "Merged without rework",
+      value: "72%",
+      delta: "+6%",
+      deltaPeriod: "prior 14 days",
+      betterDirection: "up",
+      trend: [4, 5, 4, 5, 6, 5, 6, 6, 7, 6, 7, 8],
+    },
+    {
+      id: "review-wait",
+      label: "Median review wait",
+      value: "48m",
+      delta: "+12m",
+      deltaPeriod: "prior 14 days",
+      betterDirection: "down",
+      trend: [3, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 7],
+    },
+  ],
+  activity: [
+    { id: "a1", summary: "Merged #1838 — cache Stripe customer lookups", actor: "Factory agent", at: minutesAgo(26) },
+    { id: "a2", summary: "Opened #1843 — fix currency rounding", actor: "Factory agent", at: minutesAgo(64) },
+    { id: "a3", summary: "Approved #1836", actor: "dana@acme.com", at: minutesAgo(133) },
+    { id: "a4", summary: "Closed #1830 — superseded by #1836", actor: "Factory agent", at: minutesAgo(410) },
+  ],
+};
+
+/** Spies so every interaction is visible in the Actions panel. */
+const handlers = {
+  onStartTask: fn(),
+  onOpenRun: fn(),
+  onOpenReview: fn(),
+  onResolveHealth: fn(),
+};
+
+/** Steady state: agents mid-flight, two pull requests parked on a human. */
+export const Default: Story = {
+  args: { data: baseData, ...handlers },
+};
+
+/**
+ * The moment after **Setup Factory** completes — nothing has run yet, so every
+ * panel shows its empty state and the only meaningful action is starting a task.
+ */
+export const FirstDay: Story = {
+  args: {
+    ...handlers,
+    data: {
+      ...baseData,
+      needsReview: [],
+      inFlight: [],
+      activity: [],
+      outcomes: baseData.outcomes.map((metric) => ({
+        ...metric,
+        value: "—",
+        delta: undefined,
+        deltaPeriod: undefined,
+        trend: undefined,
+      })),
+    },
+  },
+};
+
+/**
+ * Error state with a resolution path: the GitHub connection expired, so runs
+ * cannot open pull requests until someone reconnects it.
+ */
+export const NeedsAttention: Story = {
+  args: {
+    ...handlers,
+    data: {
+      ...baseData,
+      project: {
+        ...baseData.project,
+        health: "degraded",
+        healthDetail: "The GitHub connection expired — agents can commit but cannot open pull requests.",
+        integrations: [
+          { id: "github", label: "GitHub", connected: false },
+          { id: "claude", label: "Claude", connected: true },
+        ],
+      },
+      inFlight: baseData.inFlight.map((run) =>
+        run.status === "running" ? { ...run, status: "failed" as const, stage: "Blocked — no GitHub access" } : run,
+      ),
+    },
+  },
+};

--- a/web_src/src/pages/home/FactoryHomePage.tsx
+++ b/web_src/src/pages/home/FactoryHomePage.tsx
@@ -1,0 +1,418 @@
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  ExternalLink,
+  GitBranch,
+  GitPullRequest,
+  PauseCircle,
+  Plug,
+  ShieldCheck,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
+import { formatTimeAgo } from "@/lib/date";
+import { cn } from "@/lib/utils";
+import { Sparkline } from "@/pages/app/console/widget/Sparkline";
+import { EmptyState } from "@/ui/emptyState";
+import { RunStatusBadge } from "@/ui/Runs/RunStatusBadge";
+
+import type {
+  FactoryActivityEntry,
+  FactoryHomeData,
+  FactoryOutcomeMetric,
+  FactoryProject,
+  FactoryPullRequest,
+  FactoryReviewItem,
+  FactoryRun,
+  FactoryStartingTask,
+} from "./factoryHomeTypes";
+import {
+  homeCardTitleClassName,
+  homeListCardClassName,
+  homePageTitleClassName,
+  homePanelTitleClassName,
+  homeTagClassName,
+} from "./homePageStyles";
+
+/**
+ * Steps up from the gray-500/gray-400 pairing used elsewhere on Home: both fail
+ * 4.5:1 — 500 on white (4.2:1) and 400 on the raised dark surface (4.38:1).
+ */
+const mutedTextClassName = "text-gray-600 dark:text-gray-300";
+const panelClassName = cn(
+  "rounded-lg bg-white p-5 outline outline-slate-950/10",
+  appDarkModeClasses.surfaceRaised,
+  "dark:outline-gray-700/70",
+);
+/** Sparklines support the value in a stat tile; they never compete with it. */
+const sparklineClassName = "text-slate-300 dark:text-gray-600";
+
+interface FactoryHomePageProps {
+  data: FactoryHomeData;
+  onStartTask: (task: FactoryStartingTask) => void;
+  onOpenRun: (run: FactoryRun) => void;
+  onOpenReview: (item: FactoryReviewItem) => void;
+  /** Invoked from the health banner when the factory needs attention. */
+  onResolveHealth: () => void;
+}
+
+/**
+ * Homepage for a Software Factory scoped to one project.
+ *
+ * Section order follows what an operator needs in descending urgency: work that
+ * is blocked on a person, work the agents are doing right now, then the outcome
+ * telemetry and audit trail that say whether the factory is worth trusting.
+ */
+export function FactoryHomePage({ data, onStartTask, onOpenRun, onOpenReview, onResolveHealth }: FactoryHomePageProps) {
+  const { project, startingTasks, needsReview, inFlight, outcomes, activity } = data;
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-8 py-10">
+      <FactoryHeader project={project} onResolveHealth={onResolveHealth} />
+      <OutcomesRow metrics={outcomes} />
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="flex flex-col gap-6 lg:col-span-2">
+          <NeedsReviewPanel items={needsReview} onOpenReview={onOpenReview} />
+          <InFlightPanel runs={inFlight} onOpenRun={onOpenRun} />
+          <ActivityPanel entries={activity} />
+        </div>
+        <div className="flex flex-col gap-6">
+          <StartTaskPanel tasks={startingTasks} onStartTask={onStartTask} />
+          <FactorySetupPanel project={project} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const HEALTH_META = {
+  healthy: {
+    label: "Factory healthy",
+    icon: ShieldCheck,
+    badgeClassName: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/70 dark:text-emerald-300",
+  },
+  degraded: {
+    label: "Needs attention",
+    icon: AlertTriangle,
+    badgeClassName: "bg-amber-100 text-amber-800 dark:bg-amber-950/70 dark:text-amber-300",
+  },
+  paused: {
+    label: "Paused",
+    icon: PauseCircle,
+    badgeClassName: "bg-slate-200 text-gray-700 dark:bg-slate-900 dark:text-gray-300",
+  },
+} as const;
+
+function FactoryHeader({ project, onResolveHealth }: { project: FactoryProject; onResolveHealth: () => void }) {
+  const health = HEALTH_META[project.health];
+  const HealthIcon = health.icon;
+
+  return (
+    <header>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <h1 className={cn(homePageTitleClassName, "text-2xl")}>{project.name}</h1>
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+                health.badgeClassName,
+              )}
+            >
+              <HealthIcon className="size-3.5" aria-hidden />
+              {health.label}
+            </span>
+          </div>
+          <p className={cn("mt-2 max-w-2xl text-sm leading-normal", mutedTextClassName)}>{project.description}</p>
+          <div className={cn("mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs", mutedTextClassName)}>
+            <a
+              href={project.repositoryUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 underline decoration-slate-300 underline-offset-4 hover:text-slate-900 dark:decoration-gray-600 dark:hover:text-gray-100"
+            >
+              {project.repository}
+              <ExternalLink className="size-3" aria-hidden />
+            </a>
+            <span className="inline-flex items-center gap-1.5">
+              <GitBranch className="size-3.5" aria-hidden />
+              {project.defaultBranch}
+            </span>
+            <span>Owned by {project.owner}</span>
+          </div>
+        </div>
+      </div>
+
+      {project.health !== "healthy" && project.healthDetail && (
+        <div
+          className={cn(
+            "mt-5 flex flex-wrap items-center justify-between gap-3 rounded-lg px-4 py-3",
+            "bg-amber-50 outline outline-amber-200 dark:bg-amber-950/40 dark:outline-amber-900/60",
+          )}
+        >
+          <p className="flex items-center gap-2 text-sm text-amber-900 dark:text-amber-200">
+            <AlertTriangle className="size-4 shrink-0" aria-hidden />
+            {project.healthDetail}
+          </p>
+          <Button type="button" size="sm" variant="outline" onClick={onResolveHealth}>
+            Fix now
+          </Button>
+        </div>
+      )}
+    </header>
+  );
+}
+
+function OutcomesRow({ metrics }: { metrics: FactoryOutcomeMetric[] }) {
+  if (metrics.length === 0) return null;
+
+  return (
+    <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {metrics.map((metric) => (
+        <OutcomeTile key={metric.id} metric={metric} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Stat tile: label, value, signed delta against a named period, supporting
+ * sparkline. The delta's sign carries the direction so color is never the only
+ * channel saying whether the movement is good.
+ */
+function OutcomeTile({ metric }: { metric: FactoryOutcomeMetric }) {
+  const improving = metric.delta?.startsWith(metric.betterDirection === "up" ? "+" : "-");
+  const deltaToneClassName = improving ? "text-emerald-700 dark:text-emerald-400" : "text-red-700 dark:text-red-400";
+
+  return (
+    <div className={cn("px-4 py-3.5", homeListCardClassName)}>
+      <p className={cn("text-xs font-medium", mutedTextClassName)}>{metric.label}</p>
+      <div className="mt-1.5 flex items-end justify-between gap-3">
+        <div>
+          <p className="text-2xl font-semibold leading-none text-slate-900 dark:text-gray-100">{metric.value}</p>
+          {metric.delta && (
+            <p className="mt-1.5 text-xs">
+              <span className={cn("font-medium", deltaToneClassName)}>{metric.delta}</span>
+              {metric.deltaPeriod && <span className={mutedTextClassName}> vs {metric.deltaPeriod}</span>}
+            </p>
+          )}
+        </div>
+        {metric.trend && metric.trend.length > 0 && (
+          <Sparkline values={metric.trend} width={92} height={30} className={sparklineClassName} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PanelHeading({ title, count }: { title: string; count?: number }) {
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      <h2 className={homePanelTitleClassName}>{title}</h2>
+      {count !== undefined && count > 0 && <span className={homeTagClassName}>{count}</span>}
+    </div>
+  );
+}
+
+function PullRequestLink({ pullRequest }: { pullRequest: FactoryPullRequest }) {
+  return (
+    <a
+      href={pullRequest.url}
+      target="_blank"
+      rel="noreferrer"
+      className={cn(
+        "inline-flex items-center gap-1 underline decoration-slate-300 underline-offset-4",
+        "hover:text-slate-900 dark:decoration-gray-600 dark:hover:text-gray-100",
+      )}
+    >
+      <GitPullRequest className="size-3.5" aria-hidden />#{pullRequest.number}
+    </a>
+  );
+}
+
+function NeedsReviewPanel({
+  items,
+  onOpenReview,
+}: {
+  items: FactoryReviewItem[];
+  onOpenReview: (item: FactoryReviewItem) => void;
+}) {
+  return (
+    <section className={panelClassName}>
+      <PanelHeading title="Waiting on you" count={items.length} />
+      {items.length === 0 ? (
+        <EmptyState
+          compact
+          tone="neutral"
+          icon={CheckCircle2}
+          title="Nothing is blocked"
+          description="Agents will park work here when they need a decision."
+        />
+      ) : (
+        <ul className="flex flex-col gap-2.5">
+          {items.map((item) => (
+            <li key={item.id} className={cn("px-3.5 py-3", homeListCardClassName)}>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className={homeCardTitleClassName}>{item.title}</p>
+                  <p className={cn("mt-1 text-sm", mutedTextClassName)}>{item.reason}</p>
+                  <div className={cn("mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs", mutedTextClassName)}>
+                    <span>Waiting {formatTimeAgo(new Date(item.waitingSince), false)}</span>
+                    {item.pullRequest && <PullRequestLink pullRequest={item.pullRequest} />}
+                  </div>
+                </div>
+                <Button type="button" size="sm" onClick={() => onOpenReview(item)}>
+                  Review
+                  <ArrowRight />
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function InFlightPanel({ runs, onOpenRun }: { runs: FactoryRun[]; onOpenRun: (run: FactoryRun) => void }) {
+  return (
+    <section className={panelClassName}>
+      <PanelHeading title="In flight" count={runs.length} />
+      {runs.length === 0 ? (
+        <EmptyState
+          compact
+          icon={GitBranch}
+          title="No agents working"
+          description="Start a task to put the factory to work."
+        />
+      ) : (
+        <ul className="flex flex-col gap-2.5">
+          {runs.map((run) => (
+            <li key={run.id} className={cn("px-3.5 py-3", homeListCardClassName)}>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  {/*
+                   * Only the title opens the run. Making the whole row a button
+                   * would nest the pull-request link inside it, which is invalid.
+                   */}
+                  <button
+                    type="button"
+                    onClick={() => onOpenRun(run)}
+                    className={cn(homeCardTitleClassName, "text-left hover:underline underline-offset-4")}
+                  >
+                    {run.title}
+                  </button>
+                  <div className={cn("mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs", mutedTextClassName)}>
+                    <span>{run.stage}</span>
+                    <span className="inline-flex items-center gap-1.5">
+                      <GitBranch className="size-3.5" aria-hidden />
+                      {run.branch}
+                    </span>
+                    {run.pullRequest && <PullRequestLink pullRequest={run.pullRequest} />}
+                    <span>Started {formatTimeAgo(new Date(run.startedAt))}</span>
+                  </div>
+                </div>
+                <RunStatusBadge status={run.status} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function StartTaskPanel({
+  tasks,
+  onStartTask,
+}: {
+  tasks: FactoryStartingTask[];
+  onStartTask: (task: FactoryStartingTask) => void;
+}) {
+  return (
+    <section className={panelClassName}>
+      <PanelHeading title="Start a task" />
+      <p className={cn("-mt-1 mb-3 text-xs leading-normal", mutedTextClassName)}>
+        Each task runs as one small, reviewable change ending in a pull request.
+      </p>
+      <ul className="flex flex-col gap-2">
+        {tasks.map((task) => (
+          <li key={task.id}>
+            <button
+              type="button"
+              onClick={() => onStartTask(task)}
+              className={cn("group w-full px-3.5 py-2.5 text-left", homeListCardClassName)}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-medium text-slate-900 dark:text-gray-100">{task.label}</p>
+                <ArrowRight
+                  className="size-4 shrink-0 text-gray-400 transition-transform group-hover:translate-x-0.5"
+                  aria-hidden
+                />
+              </div>
+              <p className={cn("mt-0.5 text-xs leading-normal", mutedTextClassName)}>{task.description}</p>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function FactorySetupPanel({ project }: { project: FactoryProject }) {
+  return (
+    <section className={panelClassName}>
+      <PanelHeading title="Connections" />
+      <ul className="flex flex-col gap-2">
+        {project.integrations.map((integration) => (
+          <li key={integration.id} className="flex items-center justify-between gap-3 text-sm">
+            <span className="inline-flex items-center gap-2 text-slate-900 dark:text-gray-100">
+              <Plug className="size-3.5 text-gray-400" aria-hidden />
+              {integration.label}
+            </span>
+            {integration.connected ? (
+              <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                <CheckCircle2 className="size-3.5" aria-hidden />
+                Connected
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="size-3.5" aria-hidden />
+                Not connected
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ActivityPanel({ entries }: { entries: FactoryActivityEntry[] }) {
+  return (
+    <section className={panelClassName}>
+      <PanelHeading title="Recent activity" />
+      {entries.length === 0 ? (
+        <EmptyState
+          compact
+          icon={GitBranch}
+          title="No activity yet"
+          description="Runs will show up here as they finish."
+        />
+      ) : (
+        <ul className={cn("flex flex-col divide-y divide-slate-100 text-sm", "dark:divide-gray-700/70")}>
+          {entries.map((entry) => (
+            <li key={entry.id} className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 py-2.5">
+              <p className="text-slate-900 dark:text-gray-100">
+                {entry.summary} <span className={mutedTextClassName}>by {entry.actor}</span>
+              </p>
+              <span className={cn("text-xs", mutedTextClassName)}>{formatTimeAgo(new Date(entry.at))}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/web_src/src/pages/home/factoryHomeTypes.ts
+++ b/web_src/src/pages/home/factoryHomeTypes.ts
@@ -1,0 +1,91 @@
+import type { ComponentProps } from "react";
+
+import type { RunStatusBadge } from "@/ui/Runs/RunStatusBadge";
+
+export type FactoryRunStatus = ComponentProps<typeof RunStatusBadge>["status"];
+
+/** Overall health of the factory for a project, driving the header state. */
+export type FactoryHealth = "healthy" | "degraded" | "paused";
+
+export interface FactoryIntegration {
+  id: string;
+  label: string;
+  connected: boolean;
+}
+
+/** Identity and ownership block — who owns this factory and what it acts on. */
+export interface FactoryProject {
+  name: string;
+  description: string;
+  repository: string;
+  repositoryUrl: string;
+  defaultBranch: string;
+  owner: string;
+  health: FactoryHealth;
+  /** Shown when health is not `healthy`, with the action that resolves it. */
+  healthDetail?: string;
+  integrations: FactoryIntegration[];
+}
+
+/** A prompt the factory can be kicked off with, mirroring `factory.json`. */
+export interface FactoryStartingTask {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface FactoryPullRequest {
+  number: number;
+  url: string;
+}
+
+/** An agent run currently moving through the factory. */
+export interface FactoryRun {
+  id: string;
+  title: string;
+  status: FactoryRunStatus;
+  /** Human-readable pipeline position, e.g. "Opening pull request". */
+  stage: string;
+  branch: string;
+  startedAt: string;
+  pullRequest?: FactoryPullRequest;
+}
+
+/** A run parked waiting on a person — the factory's approval queue. */
+export interface FactoryReviewItem {
+  id: string;
+  title: string;
+  /** Why it stopped, e.g. "Agent requested approval to merge". */
+  reason: string;
+  waitingSince: string;
+  pullRequest?: FactoryPullRequest;
+}
+
+export interface FactoryOutcomeMetric {
+  id: string;
+  label: string;
+  value: string;
+  /** Signed change against `deltaPeriod`, e.g. "+12%". Omit when not comparable. */
+  delta?: string;
+  deltaPeriod?: string;
+  /** Which direction of `delta` counts as an improvement. */
+  betterDirection: "up" | "down";
+  /** Omit before the factory has enough history — a flat line would imply zeroes. */
+  trend?: number[];
+}
+
+export interface FactoryActivityEntry {
+  id: string;
+  summary: string;
+  actor: string;
+  at: string;
+}
+
+export interface FactoryHomeData {
+  project: FactoryProject;
+  startingTasks: FactoryStartingTask[];
+  needsReview: FactoryReviewItem[];
+  inFlight: FactoryRun[];
+  outcomes: FactoryOutcomeMetric[];
+  activity: FactoryActivityEntry[];
+}


### PR DESCRIPTION
## What

Adds a per-project homepage for an installed Software Factory — the surface a user lands on after **Setup Factory** completes on the `Pages/HomePage → Fresh Org` landing. Today that flow installs the factory and drops you into the canvas; this is the missing "here is your factory" view.

Three new files under `web_src/src/pages/home/`:

| File | Role |
|---|---|
| `FactoryHomePage.tsx` | The page. Presentational — every value arrives via props. |
| `factoryHomeTypes.ts` | The data contract the page expects. |
| `FactoryHomePage.stories.tsx` | `Pages/Factory Home` — Default, First Day, Needs Attention. |

## Why this shape

Section order is descending urgency rather than chronology:

1. **Waiting on you** — runs parked on a human decision. A blocked agent is the most expensive thing on the page, so it sits above everything.
2. **In flight** — active runs with stage, branch, PR, and status.
3. **Outcomes** — a four-tile KPI row: PRs merged, issue-to-merge, merged-without-rework, median review wait.
4. **Recent activity** — the audit trail.

The rail carries **Start a task** (the four prompts from `factories/software-factory/factory.json`) and **Connections**.

This follows the four layers an agentic dashboard needs to surface — real-time task status, approval workflow, outcome telemetry, governance log — with the header block (identity, ownership, repo, default branch) borrowed from Backstage entity-page convention. The metric selection is deliberate: the 2025 DORA finding is that AI amplifies throughput *at the cost of stability* when the foundation is weak, so throughput is paired with rework rate and review wait rather than presented alone. The page should answer whether the factory has earned more autonomy, not just what it did.

## Notes for reviewers

- **No API coupling.** The page takes a `FactoryHomeData` prop and nothing else — no hooks, no router, no query client. Wiring it to real endpoints is deliberately a separate change, since several of these metrics have no backing API yet.
- **Contrast tokens deviate from Home on purpose.** Muted text uses `gray-600` / `dark:gray-300` instead of the `gray-500` / `dark:gray-400` pairing used elsewhere in `homePageStyles.ts`. Both of those fail 4.5:1 — 500 on white measures 4.2:1, and 400 on the raised dark surface measures 4.38:1. Worth deciding whether the shared tokens should move too; I did not change them here.
- **Verified with axe:** zero violations in both light and dark themes across the stories. The in-flight row deliberately makes only the title clickable rather than the whole card, because wrapping the row in a button nests the pull-request link inside it.
- `FirstDay` omits sparklines entirely rather than drawing flat zeroes, which would read as real data.

## Testing

`tsc -b`, `eslint`, and `prettier --check` clean on the new files; `lint:budget` within budget. Verified visually in Storybook in both themes. The full `vitest` suite was not run — the change adds only new files and touches no existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)