### PR TITLE
fix: simplify AWS EC2 create machine disk configuration options

### DIFF
--- a/pkg/integrations/aws/ec2/create_instance.go
+++ b/pkg/integrations/aws/ec2/create_instance.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultRootVolumeSizeGiB  = 8
+	defaultVolumeSizeGiB      = 8
 	defaultRootVolumeType     = "gp3"
 	defaultWaitTimeoutSeconds = 300
 	maxWaitTimeoutSeconds     = 1800
@@ -26,6 +26,7 @@ const (
 	securityGroupModeExisting = "existing"
 	createInstanceCreated     = "created"
 	createInstanceFailed      = "failed"
+	volumeIopsDescription     = "Provisioned IOPS for io1 or io2 volume types"
 )
 
 var rootVolumeTypeOptions = []configuration.FieldOption{
@@ -423,7 +424,6 @@ func (c *CreateInstance) Configuration() []configuration.Field {
 			Label:       "Configure Root Volume",
 			Type:        configuration.FieldTypeBool,
 			Required:    false,
-			Togglable:   true,
 			Default:     false,
 			Description: "Override the AMI root volume size and type",
 		},
@@ -443,7 +443,7 @@ func (c *CreateInstance) Configuration() []configuration.Field {
 			Label:       "Volume Size (GiB)",
 			Type:        configuration.FieldTypeNumber,
 			Required:    false,
-			Default:     defaultRootVolumeSizeGiB,
+			Default:     defaultVolumeSizeGiB,
 			Description: "Root volume size in GiB",
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{Field: "configureRootVolume", Values: []string{"true"}},
@@ -481,7 +481,7 @@ func (c *CreateInstance) Configuration() []configuration.Field {
 			Label:       "Volume IOPS",
 			Type:        configuration.FieldTypeNumber,
 			Required:    false,
-			Description: "Provisioned IOPS for io1 or io2 volume types. io1 minimum 100, maximum 64000; io2 minimum 100, maximum 256000.",
+			Description: volumeIopsDescription,
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{Field: "configureRootVolume", Values: []string{"true"}},
 				{Field: "volumeType", Values: []string{"io1", "io2"}},
@@ -693,7 +693,7 @@ func (c *CreateInstance) Execute(ctx core.ExecutionContext) error {
 
 		volumeSize := config.VolumeSizeGiB
 		if volumeSize < 1 {
-			volumeSize = defaultRootVolumeSizeGiB
+			volumeSize = defaultVolumeSizeGiB
 		}
 
 		volumeType := strings.TrimSpace(config.VolumeType)
@@ -1074,6 +1074,7 @@ func blockDeviceFieldSchema() []configuration.Field {
 			Label:       "Volume Size (GiB)",
 			Type:        configuration.FieldTypeNumber,
 			Required:    true,
+			Default:     defaultVolumeSizeGiB,
 			TypeOptions: &configuration.TypeOptions{Number: &configuration.NumberTypeOptions{Min: intPtr(1)}},
 		},
 		{
@@ -1091,7 +1092,7 @@ func blockDeviceFieldSchema() []configuration.Field {
 			Label:       "Volume IOPS",
 			Type:        configuration.FieldTypeNumber,
 			Required:    false,
-			Description: "Provisioned IOPS for io1 or io2 volume types",
+			Description: volumeIopsDescription,
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{Field: "volumeType", Values: []string{"io1", "io2"}},
 			},

--- a/pkg/integrations/aws/ec2/create_instance_test.go
+++ b/pkg/integrations/aws/ec2/create_instance_test.go
@@ -147,8 +147,22 @@ func Test__CreateInstance__ConfigurationIncludesProductionLaunchFields(t *testin
 	blockDevices := findConfigurationField(t, fields, "additionalBlockDevices")
 	require.NotNil(t, blockDevices.TypeOptions)
 	require.NotNil(t, blockDevices.TypeOptions.List)
-	assert.Contains(t, configurationFieldNames(blockDevices.TypeOptions.List.ItemDefinition.Schema), "deviceName")
-	assert.Contains(t, configurationFieldNames(blockDevices.TypeOptions.List.ItemDefinition.Schema), "kmsKeyId")
+	blockDeviceSchema := blockDevices.TypeOptions.List.ItemDefinition.Schema
+	assert.Contains(t, configurationFieldNames(blockDeviceSchema), "deviceName")
+	assert.Contains(t, configurationFieldNames(blockDeviceSchema), "kmsKeyId")
+
+	configureRootVolume := findConfigurationField(t, fields, "configureRootVolume")
+	assert.Equal(t, configuration.FieldTypeBool, configureRootVolume.Type)
+	assert.False(t, configureRootVolume.Togglable)
+
+	rootSize := findConfigurationField(t, fields, "volumeSizeGiB")
+	additionalSize := findConfigurationField(t, blockDeviceSchema, "volumeSizeGiB")
+	assert.Equal(t, defaultVolumeSizeGiB, rootSize.Default)
+	assert.Equal(t, defaultVolumeSizeGiB, additionalSize.Default)
+
+	rootIops := findConfigurationField(t, fields, "volumeIops")
+	additionalIops := findConfigurationField(t, blockDeviceSchema, "volumeIops")
+	assert.Equal(t, rootIops.Description, additionalIops.Description)
 
 	timeout := findConfigurationField(t, fields, "waitForRunningTimeoutSeconds")
 	require.NotNil(t, timeout.TypeOptions)


### PR DESCRIPTION
## What changed

This PR fixes the confusing "Configure Root Volume" double-toggle and related disk-option inconsistencies in the AWS EC2 Create Instance component.

## How

- Made `configureRootVolume` a plain boolean (removed `Togglable`) so a single switch reveals the root-volume fields, matching the sibling `Encrypt Root Volume` field.
- Gave additional block-device Volume Size the same 8 GiB default as the root volume (renamed `defaultRootVolumeSizeGiB` → `defaultVolumeSizeGiB`).
- Aligned the Volume IOPS help text between the root volume and additional block devices.

[Screencast from 2026-07-28 14-44-41.webm](https://github.com/user-attachments/assets/1d75887d-886b-4427-b2b5-a809ecdd505e)

## Related issues

Closes https://github.com/superplanehq/superplane/issues/5869
