### PR TITLE
fix(utils): add unit test for UnmarshalEmbeddedJSON helper (#6359)

### DIFF
--- a/pkg/utils/json_test.go
+++ b/pkg/utils/json_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalEmbeddedJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []byte
+		expected map[string]any
+	}{
+		{
+			name:  "valid json object",
+			input: []byte(`{"key":"value","number":42}`),
+			expected: map[string]any{
+				"key":    "value",
+				"number": float64(42),
+			},
+		},
+		{
+			name:     "empty json object",
+			input:    []byte(`{}`),
+			expected: map[string]any{},
+		},
+		{
+			name:     "invalid json fallback",
+			input:    []byte(`invalid json`),
+			expected: map[string]any{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var once sync.Once
+			var target map[string]any
+			result := UnmarshalEmbeddedJSON(&once, tc.input, &target)
+			assert.Equal(t, tc.expected, result)
+			assert.Equal(t, tc.expected, target)
+		})
+	}
+
+	t.Run("sync.Once prevents re-parsing on subsequent calls", func(t *testing.T) {
+		var once sync.Once
+		var target map[string]any
+
+		firstInput := []byte(`{"initial":"data"}`)
+		firstResult := UnmarshalEmbeddedJSON(&once, firstInput, &target)
+		expectedFirst := map[string]any{"initial": "data"}
+		assert.Equal(t, expectedFirst, firstResult)
+
+		secondInput := []byte(`{"updated":"data"}`)
+		secondResult := UnmarshalEmbeddedJSON(&once, secondInput, &target)
+		assert.Equal(t, expectedFirst, secondResult)
+		assert.Equal(t, expectedFirst, target)
+	})
+}


### PR DESCRIPTION
Closes #6359

## 🐛 What was the issue?
The helper function `UnmarshalEmbeddedJSON` in `pkg/utils/json.go` lacked unit test coverage compared to other utility functions in `pkg/utils` (such as `NormalizeEmail` in `pkg/utils/email_test.go`). 

## 🛠️ What did we fix?
- Added `pkg/utils/json_test.go` with table-driven unit tests for `UnmarshalEmbeddedJSON`.
- Tested parsing valid JSON objects, empty JSON objects, and handling invalid JSON gracefully.
- Tested `sync.Once` single-execution guarantee: verified that a second invocation with different input bytes returns the cached result without re-parsing.
- Followed standard Go `testing` framework and `github.com/stretchr/testify/assert` conventions matching `pkg/utils/email_test.go`.

## 🧪 Testing & Verification
- Validated table-driven test cases asserting exact output match and target map state.
- Validated caching semantics assertion verifying `sync.Once` behavior on repeated function calls.
