### PR TITLE
feat: design Software Factory and Work Order pages in Storybook

### DIFF
--- a/web_src/src/pages/factory/FactoryAutomationsTab.tsx
+++ b/web_src/src/pages/factory/FactoryAutomationsTab.tsx
@@ -1,0 +1,101 @@
+import { AlertTriangle, ArrowRight, CircleDot, PauseCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { formatTimeAgo } from "@/lib/date";
+import { cn } from "@/lib/utils";
+import { EmptyState } from "@/ui/emptyState";
+
+import {
+  factoryCardClassName,
+  factoryPanelClassName,
+  mutedTextClassName,
+  sectionTitleClassName,
+} from "./factoryStyles";
+import type { Automation } from "./factoryTypes";
+
+const STATUS_META = {
+  active: { label: "Active", icon: CircleDot, className: "text-emerald-700 dark:text-emerald-400" },
+  paused: { label: "Paused", icon: PauseCircle, className: "text-gray-600 dark:text-gray-300" },
+  error: { label: "Error", icon: AlertTriangle, className: "text-red-700 dark:text-red-400" },
+} as const satisfies Record<Automation["status"], { label: string; icon: typeof CircleDot; className: string }>;
+
+interface FactoryAutomationsTabProps {
+  automations: Automation[];
+  /** PRD: opening an Automation opens the existing Canvas editing experience. */
+  onOpenAutomation: (automation: Automation) => void;
+  onCreateAutomation: () => void;
+}
+
+/**
+ * PRD: a finite operational list, not a canvas gallery. Each row carries enough
+ * context to pick the right Automation — name, description, trigger, status,
+ * current activity, recent success, last run.
+ */
+export function FactoryAutomationsTab({
+  automations,
+  onOpenAutomation,
+  onCreateAutomation,
+}: FactoryAutomationsTabProps) {
+  return (
+    <section className={factoryPanelClassName}>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <h2 className={sectionTitleClassName}>Automations</h2>
+        <Button type="button" size="sm" onClick={onCreateAutomation}>
+          New Automation
+        </Button>
+      </div>
+
+      {automations.length === 0 ? (
+        <EmptyState
+          title="No Automations yet"
+          description="A Factory starts empty. Add an Automation to give it something to run."
+        />
+      ) : (
+        <ul className="flex flex-col gap-2.5">
+          {automations.map((automation) => {
+            const status = STATUS_META[automation.status];
+            const StatusIcon = status.icon;
+            return (
+              <li key={automation.id} className={cn("px-4 py-3", factoryCardClassName)}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2.5">
+                      <button
+                        type="button"
+                        onClick={() => onOpenAutomation(automation)}
+                        className="text-left text-sm font-medium text-slate-900 underline-offset-4 hover:underline dark:text-gray-100"
+                      >
+                        {automation.name}
+                      </button>
+                      <span className={cn("inline-flex items-center gap-1 text-xs font-medium", status.className)}>
+                        <StatusIcon className="size-3.5" aria-hidden />
+                        {status.label}
+                      </span>
+                    </div>
+                    <p className={cn("mt-1 text-sm", mutedTextClassName)}>{automation.description}</p>
+                    {automation.currentActivity && (
+                      <p className="mt-1 text-sm text-blue-800 dark:text-blue-300">{automation.currentActivity}</p>
+                    )}
+                    <div
+                      className={cn("mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs", mutedTextClassName)}
+                    >
+                      <span>Trigger: {automation.trigger}</span>
+                      <span>{Math.round(automation.recentSuccess * 100)}% recent success</span>
+                      <span>Last run {formatTimeAgo(new Date(automation.lastRunAt))}</span>
+                      {/* PRD: Automations in one Factory may span repositories. */}
+                      <span>{automation.repositories.join(", ")}</span>
+                    </div>
+                  </div>
+                  <Button type="button" size="sm" variant="outline" onClick={() => onOpenAutomation(automation)}>
+                    Open canvas
+                    <ArrowRight />
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/web_src/src/pages/factory/FactoryOverviewTab.tsx
+++ b/web_src/src/pages/factory/FactoryOverviewTab.tsx
@@ -1,0 +1,154 @@
+import { CheckCircle2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Sparkline } from "@/pages/app/console/widget/Sparkline";
+import { EmptyState } from "@/ui/emptyState";
+
+import {
+  countPillClassName,
+  factoryCardClassName,
+  factoryPanelClassName,
+  mutedTextClassName,
+  sectionTitleClassName,
+} from "./factoryStyles";
+import type { FactorySummary, WorkOrder } from "./factoryTypes";
+import { workOrderGroup } from "./factoryTypes";
+import { WorkOrderListItem } from "./WorkOrderListItem";
+
+interface FactoryOverviewTabProps {
+  summary: FactorySummary;
+  workOrders: WorkOrder[];
+  onOpenWorkOrder: (workOrder: WorkOrder) => void;
+  onSeeAllWorkOrders: () => void;
+}
+
+/**
+ * PRD: "Overview is the default tab and puts Work Orders requiring attention
+ * before summary metrics and other activity." That ordering is the whole point
+ * of the tab, so blocked work is rendered first — above the metric row.
+ */
+export function FactoryOverviewTab({
+  summary,
+  workOrders,
+  onOpenWorkOrder,
+  onSeeAllWorkOrders,
+}: FactoryOverviewTabProps) {
+  const needsAttention = workOrders.filter((wo) => workOrderGroup(wo) === "needs-attention");
+  const running = workOrders.filter((wo) => workOrderGroup(wo) === "running");
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className={factoryPanelClassName}>
+        <div className="mb-3 flex items-center gap-2">
+          <h2 className={sectionTitleClassName}>Needs attention</h2>
+          {needsAttention.length > 0 && <span className={countPillClassName}>{needsAttention.length}</span>}
+        </div>
+        {needsAttention.length === 0 ? (
+          <EmptyState
+            compact
+            tone="neutral"
+            icon={CheckCircle2}
+            title="Nothing is waiting on you"
+            description="Work Orders appear here when they need a decision, approval, or clarification."
+          />
+        ) : (
+          <ul className="flex flex-col gap-2.5">
+            {needsAttention.map((workOrder) => (
+              <WorkOrderListItem key={workOrder.id} workOrder={workOrder} onOpen={onOpenWorkOrder} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <FactoryMetrics summary={summary} />
+
+      <section className={factoryPanelClassName}>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <h2 className={sectionTitleClassName}>Current activity</h2>
+            {running.length > 0 && <span className={countPillClassName}>{running.length}</span>}
+          </div>
+          <button
+            type="button"
+            onClick={onSeeAllWorkOrders}
+            className={cn("text-xs underline underline-offset-4", mutedTextClassName)}
+          >
+            See all Work Orders
+          </button>
+        </div>
+        {running.length === 0 ? (
+          <EmptyState
+            compact
+            title="No Work Orders running"
+            description="Approved work is picked up by an Automation."
+          />
+        ) : (
+          <ul className="flex flex-col gap-2.5">
+            {running.map((workOrder) => (
+              <WorkOrderListItem key={workOrder.id} workOrder={workOrder} onOpen={onOpenWorkOrder} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+const usd = (value: number) => `$${value.toFixed(2)}`;
+
+/** PRD requires throughput, success rate, active Work Orders and tracked cost. */
+function FactoryMetrics({ summary }: { summary: FactorySummary }) {
+  const cost = summary.trackedCost.tokensUsd + summary.trackedCost.computeUsd;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <MetricTile
+        label="Throughput"
+        value={`${summary.throughput.value}`}
+        caption={summary.throughput.unit}
+        trend={summary.throughput.trend}
+      />
+      <MetricTile
+        label="Success rate"
+        value={`${Math.round(summary.successRate.value * 100)}%`}
+        caption="explicit Work Order outcomes"
+        trend={summary.successRate.trend}
+      />
+      <MetricTile label="Active Work Orders" value={`${summary.activeWorkOrders}`} caption="running or waiting" />
+      <MetricTile
+        label="Tracked cost"
+        value={usd(cost)}
+        caption={`${usd(summary.trackedCost.tokensUsd)} tokens · ${usd(summary.trackedCost.computeUsd)} compute`}
+      />
+    </div>
+  );
+}
+
+function MetricTile({
+  label,
+  value,
+  caption,
+  trend,
+}: {
+  label: string;
+  value: string;
+  caption: string;
+  trend?: number[];
+}) {
+  return (
+    <div className={cn("px-4 py-3.5", factoryCardClassName)}>
+      <p className={cn("text-xs font-medium", mutedTextClassName)}>{label}</p>
+      <div className="mt-1.5 flex items-end justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-2xl font-semibold leading-none text-slate-900 dark:text-gray-100">{value}</p>
+          {/* No truncation: the caption carries the throughput unit, which the
+              PRD leaves open — losing it would make the number ambiguous. */}
+          <p className={cn("mt-1.5 text-xs leading-snug", mutedTextClassName)}>{caption}</p>
+        </div>
+        {trend && trend.length > 0 && (
+          <Sparkline values={trend} width={84} height={28} className="text-slate-300 dark:text-gray-600" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/factory/FactoryVelocityTab.tsx
+++ b/web_src/src/pages/factory/FactoryVelocityTab.tsx
@@ -1,0 +1,232 @@
+import { Info } from "lucide-react";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+import { factoryPanelClassName, mutedTextClassName, sectionTitleClassName } from "./factoryStyles";
+import type { VelocityCohort, VelocityData } from "./factoryTypes";
+
+/**
+ * Two series, assigned in fixed order and never cycled. Blue/amber is the
+ * classic colour-vision-deficiency-safe pair; identity is also carried by the
+ * legend and the row labels, so colour is never the only channel.
+ */
+const SERIES = {
+  human: { label: "Human-authored", fill: "#2563eb", dark: "#60a5fa" },
+  factory: { label: "Factory-authored", fill: "#d97706", dark: "#fbbf24" },
+} as const;
+
+interface FactoryVelocityTabProps {
+  velocity: VelocityData;
+  onSelectRepository: (repository: string) => void;
+}
+
+/**
+ * PRD: the same delivery indicators for Team total, human-authored and
+ * Factory-authored work, "without framing the comparison as a competition".
+ *
+ * That framing decision drives the layout: a plain indicator table with one row
+ * per cohort, no ranking, no winner highlight, no bars racing each other. The
+ * only chart compares the two authored cohorts over time, stacked into the team
+ * total rather than set against one another.
+ */
+export function FactoryVelocityTab({ velocity, onSelectRepository }: FactoryVelocityTabProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className={cn("text-sm", mutedTextClassName)}>Last {velocity.periodDays} days</p>
+        {/* PRD: repository is the filter — never Automation, since several
+            Automations can contribute to one Work Order and repository. */}
+        {/* Not a <label>: the Radix trigger is a button, so the accessible name
+            rides on aria-label rather than a label/control association. */}
+        <div className="flex items-center gap-2 text-sm">
+          <span aria-hidden className={mutedTextClassName}>
+            Repository
+          </span>
+          <Select value={velocity.selectedRepository} onValueChange={onSelectRepository}>
+            <SelectTrigger className="w-64" aria-label="Filter by repository">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {velocity.repositories.map((repository) => (
+                <SelectItem key={repository} value={repository}>
+                  {repository}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <CohortTable cohorts={velocity.cohorts} />
+      <ThroughputOverTime series={velocity.throughputSeries} />
+      <CostBreakdown breakdown={velocity.costBreakdown} />
+    </div>
+  );
+}
+
+const usd = (value: number) => `$${value.toFixed(2)}`;
+
+function CohortTable({ cohorts }: { cohorts: VelocityCohort[] }) {
+  return (
+    <section className={factoryPanelClassName}>
+      <h2 className={cn(sectionTitleClassName, "mb-3")}>Delivery indicators</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[640px] text-sm">
+          <thead>
+            <tr className={cn("border-b border-slate-200 text-left text-xs dark:border-gray-700", mutedTextClassName)}>
+              <th scope="col" className="py-2 pr-4 font-medium">
+                Cohort
+              </th>
+              <th scope="col" className="py-2 pr-4 text-right font-medium">
+                Merged pull requests
+              </th>
+              <th scope="col" className="py-2 pr-4 text-right font-medium">
+                Median cycle time
+              </th>
+              <th scope="col" className="py-2 pr-4 text-right font-medium">
+                Success rate
+              </th>
+              <th scope="col" className="py-2 text-right font-medium">
+                Tracked cost
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 dark:divide-gray-700/70">
+            {cohorts.map((cohort) => (
+              <tr key={cohort.id}>
+                <th scope="row" className="py-2.5 pr-4 text-left font-medium text-slate-900 dark:text-gray-100">
+                  <span className="inline-flex items-center gap-2">
+                    {cohort.id !== "team" && (
+                      <span
+                        aria-hidden
+                        className="size-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: SERIES[cohort.id].fill }}
+                      />
+                    )}
+                    {cohort.label}
+                  </span>
+                </th>
+                <td className="py-2.5 pr-4 text-right tabular-nums text-slate-900 dark:text-gray-100">
+                  {cohort.mergedPullRequests}
+                </td>
+                <td className="py-2.5 pr-4 text-right tabular-nums text-slate-900 dark:text-gray-100">
+                  {cohort.cycleTimeHours}h
+                </td>
+                <td className="py-2.5 pr-4 text-right tabular-nums text-slate-900 dark:text-gray-100">
+                  {Math.round(cohort.successRate * 100)}%
+                </td>
+                <td
+                  className={cn(
+                    "py-2.5 text-right tabular-nums",
+                    cohort.trackedCostUsd === null ? mutedTextClassName : "text-slate-900 dark:text-gray-100",
+                  )}
+                >
+                  {cohort.trackedCostUsd === null ? "Not available" : usd(cohort.trackedCostUsd)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {/* PRD: human work must not read as costing nothing. */}
+      <p className={cn("mt-3 flex items-start gap-1.5 text-xs", mutedTextClassName)}>
+        <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+        Tracked cost covers model tokens and execution compute only. It excludes third-party service charges, and is not
+        available for human-authored work — that is a missing attribution model, not an absence of cost.
+      </p>
+    </section>
+  );
+}
+
+function ThroughputOverTime({ series }: { series: VelocityData["throughputSeries"] }) {
+  const max = Math.max(1, ...series.map((d) => d.human + d.factory));
+  const barWidth = 100 / (series.length * 1.6);
+  const gap = barWidth * 0.6;
+
+  return (
+    <section className={factoryPanelClassName}>
+      <div className="mb-1 flex flex-wrap items-center justify-between gap-3">
+        <h2 className={sectionTitleClassName}>Merged pull requests over time</h2>
+        <ul className="flex items-center gap-4 text-xs">
+          {(["human", "factory"] as const).map((key) => (
+            <li key={key} className={cn("inline-flex items-center gap-1.5", mutedTextClassName)}>
+              <span aria-hidden className="size-2 rounded-full" style={{ backgroundColor: SERIES[key].fill }} />
+              {SERIES[key].label}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <p className={cn("mb-3 text-xs", mutedTextClassName)}>
+        Stacked to the team total — the cohorts sum, they do not compete.
+      </p>
+
+      <div className="overflow-x-auto">
+        <svg
+          viewBox="0 0 100 34"
+          preserveAspectRatio="none"
+          className="h-40 w-full min-w-[560px]"
+          role="img"
+          aria-label="Merged pull requests per day, human-authored and Factory-authored, stacked"
+        >
+          {series.map((day, index) => {
+            const x = index * (barWidth + gap) + gap / 2;
+            const humanHeight = (day.human / max) * 28;
+            const factoryHeight = (day.factory / max) * 28;
+            return (
+              <g key={day.date}>
+                <rect x={x} y={30 - humanHeight} width={barWidth} height={humanHeight} fill={SERIES.human.fill} />
+                <rect
+                  x={x}
+                  y={30 - humanHeight - factoryHeight}
+                  width={barWidth}
+                  height={factoryHeight}
+                  fill={SERIES.factory.fill}
+                />
+              </g>
+            );
+          })}
+          <line
+            x1="0"
+            y1="30.4"
+            x2="100"
+            y2="30.4"
+            stroke="currentColor"
+            strokeWidth="0.15"
+            className="text-slate-300 dark:text-gray-600"
+          />
+        </svg>
+      </div>
+      <div className={cn("mt-1 flex justify-between text-xs", mutedTextClassName)}>
+        <span>{series[0]?.date}</span>
+        <span>{series[series.length - 1]?.date}</span>
+      </div>
+    </section>
+  );
+}
+
+function CostBreakdown({ breakdown }: { breakdown: VelocityData["costBreakdown"] }) {
+  const total = breakdown.tokensUsd + breakdown.computeUsd;
+  const rows = [
+    { label: "Model tokens", value: breakdown.tokensUsd },
+    { label: "Execution compute", value: breakdown.computeUsd },
+  ];
+
+  return (
+    <section className={factoryPanelClassName}>
+      <h2 className={cn(sectionTitleClassName, "mb-3")}>Tracked Factory cost</h2>
+      <ul className="flex flex-col gap-2">
+        {rows.map((row) => (
+          <li key={row.label} className="flex items-center justify-between gap-4 text-sm">
+            <span className={mutedTextClassName}>{row.label}</span>
+            <span className="tabular-nums text-slate-900 dark:text-gray-100">{usd(row.value)}</span>
+          </li>
+        ))}
+        <li className="mt-1 flex items-center justify-between gap-4 border-t border-slate-200 pt-2 text-sm font-medium dark:border-gray-700">
+          <span className="text-slate-900 dark:text-gray-100">Total</span>
+          <span className="tabular-nums text-slate-900 dark:text-gray-100">{usd(total)}</span>
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/web_src/src/pages/factory/FactoryWorkOrdersTab.tsx
+++ b/web_src/src/pages/factory/FactoryWorkOrdersTab.tsx
@@ -1,0 +1,62 @@
+import { CheckCircle2 } from "lucide-react";
+
+import { EmptyState } from "@/ui/emptyState";
+
+import { countPillClassName, factoryPanelClassName, sectionTitleClassName } from "./factoryStyles";
+import type { WorkOrder, WorkOrderGroup } from "./factoryTypes";
+import { workOrderGroup } from "./factoryTypes";
+import { WorkOrderListItem } from "./WorkOrderListItem";
+
+interface FactoryWorkOrdersTabProps {
+  workOrders: WorkOrder[];
+  onOpenWorkOrder: (workOrder: WorkOrder) => void;
+}
+
+/**
+ * PRD: the complete operational queue, grouped into Needs attention → Running →
+ * Recently done → Unsuccessful. The order is fixed: it runs from "blocked on a
+ * human" to "finished", so the top of the page is always the actionable end.
+ */
+const GROUPS: { id: WorkOrderGroup; title: string; empty: string }[] = [
+  {
+    id: "needs-attention",
+    title: "Needs attention",
+    empty: "Nothing is waiting on a decision, approval, or clarification.",
+  },
+  { id: "running", title: "Running", empty: "No Work Orders are moving through Automations." },
+  { id: "recently-done", title: "Recently done", empty: "No Work Orders have been marked successful yet." },
+  { id: "unsuccessful", title: "Unsuccessful", empty: "No Work Orders have been marked unsuccessful." },
+];
+
+export function FactoryWorkOrdersTab({ workOrders, onOpenWorkOrder }: FactoryWorkOrdersTabProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      {GROUPS.map((group) => {
+        const items = workOrders.filter((workOrder) => workOrderGroup(workOrder) === group.id);
+        return (
+          <section key={group.id} className={factoryPanelClassName}>
+            <div className="mb-3 flex items-center gap-2">
+              <h2 className={sectionTitleClassName}>{group.title}</h2>
+              {items.length > 0 && <span className={countPillClassName}>{items.length}</span>}
+            </div>
+            {items.length === 0 ? (
+              <EmptyState
+                compact
+                tone={group.id === "needs-attention" ? "neutral" : "accent"}
+                icon={CheckCircle2}
+                title="Nothing here"
+                description={group.empty}
+              />
+            ) : (
+              <ul className="flex flex-col gap-2.5">
+                {items.map((workOrder) => (
+                  <WorkOrderListItem key={workOrder.id} workOrder={workOrder} onOpen={onOpenWorkOrder} />
+                ))}
+              </ul>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/web_src/src/pages/factory/SoftwareFactoryPage.stories.tsx
+++ b/web_src/src/pages/factory/SoftwareFactoryPage.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { factoryPageData, newFactoryPageData } from "./__fixtures__/factoryFixtures";
+import { SoftwareFactoryPage } from "./SoftwareFactoryPage";
+
+/**
+ * Dedicated page for a Software Factory, designed from
+ * `docs/prd/software-factory.md`.
+ *
+ * A Factory is a first-class resource, not a renamed App — so this is its own
+ * page shell: Factory header, then the four tabs the PRD specifies (Overview,
+ * Work Orders, Automations, Velocity) at the recommended ~1,600px cap.
+ *
+ * All data arrives via props; every story below is a fixture.
+ */
+const meta = {
+  title: "Pages/Software Factory",
+  component: SoftwareFactoryPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof SoftwareFactoryPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const handlers = {
+  onOpenWorkOrder: fn(),
+  onOpenAutomation: fn(),
+  onCreateWorkOrder: fn(),
+  onCreateAutomation: fn(),
+  onSelectRepository: fn(),
+};
+
+/**
+ * Overview is the default tab, and Work Orders needing attention are rendered
+ * *above* the metric row — the PRD's explicit ordering requirement.
+ */
+export const Overview: Story = {
+  args: { data: factoryPageData, defaultTab: "overview", ...handlers },
+};
+
+/** The complete queue: Needs attention → Running → Recently done → Unsuccessful. */
+export const WorkOrders: Story = {
+  args: { data: factoryPageData, defaultTab: "work-orders", ...handlers },
+};
+
+/** A finite operational list; opening one hands off to the existing Canvas editor. */
+export const Automations: Story = {
+  args: { data: factoryPageData, defaultTab: "automations", ...handlers },
+};
+
+/**
+ * Three cohorts, identical indicators, no ranking — the PRD requires the
+ * comparison read neutrally rather than as humans versus the Factory. Human
+ * tracked cost shows "Not available" rather than $0.
+ */
+export const Velocity: Story = {
+  args: { data: factoryPageData, defaultTab: "velocity", ...handlers },
+};
+
+/**
+ * The PRD's "blank by default" creation outcome: a persisted Factory with zero
+ * Automations and no Work Orders, which must still be a coherent page.
+ */
+export const NewFactory: Story = {
+  args: { data: newFactoryPageData, defaultTab: "overview", ...handlers },
+};
+
+/** Operational trouble surfaced in the header, above the tabs. */
+export const Degraded: Story = {
+  args: {
+    ...handlers,
+    defaultTab: "overview",
+    data: {
+      ...factoryPageData,
+      factory: {
+        ...factoryPageData.factory,
+        status: "degraded",
+        statusDetail: "The GitHub connection expired — Automations can commit but cannot open pull requests.",
+      },
+    },
+  },
+};

--- a/web_src/src/pages/factory/SoftwareFactoryPage.tsx
+++ b/web_src/src/pages/factory/SoftwareFactoryPage.tsx
@@ -1,0 +1,173 @@
+import { AlertTriangle, Factory, PauseCircle, ShieldCheck } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+import { FactoryAutomationsTab } from "./FactoryAutomationsTab";
+import { FactoryOverviewTab } from "./FactoryOverviewTab";
+import { FactoryVelocityTab } from "./FactoryVelocityTab";
+import { FactoryWorkOrdersTab } from "./FactoryWorkOrdersTab";
+import { factoryPageWidthClassName, mutedTextClassName } from "./factoryStyles";
+import type { Automation, SoftwareFactory, SoftwareFactoryPageData, WorkOrder } from "./factoryTypes";
+
+/** PRD: Overview is the default of four tabs. */
+export type FactoryTab = "overview" | "work-orders" | "automations" | "velocity";
+
+const TABS: { value: FactoryTab; label: string }[] = [
+  { value: "overview", label: "Overview" },
+  { value: "work-orders", label: "Work Orders" },
+  { value: "automations", label: "Automations" },
+  { value: "velocity", label: "Velocity" },
+];
+
+/**
+ * The shared TabsTrigger renders inactive tabs with `dark:text-muted-foreground`,
+ * which measures 4.38:1 on the dark surface and fails WCAG AA. Corrected here
+ * rather than in the shared component, whose blast radius is every Tabs usage.
+ */
+const inactiveTabContrastClassName = "dark:data-[state=inactive]:text-gray-300";
+
+interface SoftwareFactoryPageProps {
+  data: SoftwareFactoryPageData;
+  /** Uncontrolled default; the real page will read this from the route. */
+  defaultTab?: FactoryTab;
+  onOpenWorkOrder: (workOrder: WorkOrder) => void;
+  onOpenAutomation: (automation: Automation) => void;
+  onCreateWorkOrder: () => void;
+  onCreateAutomation: () => void;
+  onSelectRepository: (repository: string) => void;
+}
+
+/**
+ * Dedicated page for a Software Factory.
+ *
+ * The PRD is emphatic that a Factory is not a renamed App, so this is its own
+ * page shell rather than a reuse of the App detail experience: Factory header,
+ * then the four tabs — Overview, Work Orders, Automations, Velocity.
+ */
+export function SoftwareFactoryPage({
+  data,
+  defaultTab = "overview",
+  onOpenWorkOrder,
+  onOpenAutomation,
+  onCreateWorkOrder,
+  onCreateAutomation,
+  onSelectRepository,
+}: SoftwareFactoryPageProps) {
+  const [tab, setTab] = useState<FactoryTab>(defaultTab);
+  const { factory, summary, workOrders, automations, velocity } = data;
+
+  return (
+    <div className={cn(factoryPageWidthClassName, "py-8")}>
+      <FactoryHeader factory={factory} onCreateWorkOrder={onCreateWorkOrder} />
+
+      <Tabs value={tab} onValueChange={(value) => setTab(value as FactoryTab)} className="mt-6">
+        <TabsList>
+          {TABS.map((entry) => (
+            <TabsTrigger key={entry.value} value={entry.value} className={inactiveTabContrastClassName}>
+              {entry.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="overview" className="mt-6">
+          <FactoryOverviewTab
+            summary={summary}
+            workOrders={workOrders}
+            onOpenWorkOrder={onOpenWorkOrder}
+            onSeeAllWorkOrders={() => setTab("work-orders")}
+          />
+        </TabsContent>
+        <TabsContent value="work-orders" className="mt-6">
+          <FactoryWorkOrdersTab workOrders={workOrders} onOpenWorkOrder={onOpenWorkOrder} />
+        </TabsContent>
+        <TabsContent value="automations" className="mt-6">
+          <FactoryAutomationsTab
+            automations={automations}
+            onOpenAutomation={onOpenAutomation}
+            onCreateAutomation={onCreateAutomation}
+          />
+        </TabsContent>
+        <TabsContent value="velocity" className="mt-6">
+          <FactoryVelocityTab velocity={velocity} onSelectRepository={onSelectRepository} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+const STATUS_META = {
+  healthy: {
+    label: "Healthy",
+    icon: ShieldCheck,
+    className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/70 dark:text-emerald-300",
+  },
+  degraded: {
+    label: "Needs attention",
+    icon: AlertTriangle,
+    className: "bg-amber-100 text-amber-900 dark:bg-amber-950/70 dark:text-amber-300",
+  },
+  paused: {
+    label: "Paused",
+    icon: PauseCircle,
+    className: "bg-slate-200 text-gray-700 dark:bg-slate-900 dark:text-gray-300",
+  },
+} as const satisfies Record<SoftwareFactory["status"], { label: string; icon: typeof ShieldCheck; className: string }>;
+
+/** PRD: name and optional description sit above the tab navigation. */
+function FactoryHeader({ factory, onCreateWorkOrder }: { factory: SoftwareFactory; onCreateWorkOrder: () => void }) {
+  const status = STATUS_META[factory.status];
+  const StatusIcon = status.icon;
+
+  return (
+    <header>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2.5">
+            {/* The Factory badge is what distinguishes this from an App at a glance. */}
+            <span
+              aria-hidden
+              className="flex size-8 items-center justify-center rounded-md bg-slate-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+            >
+              <Factory className="size-4" />
+            </span>
+            <h1 className="text-2xl font-medium text-slate-900 dark:text-gray-100">{factory.name}</h1>
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+                status.className,
+              )}
+            >
+              <StatusIcon className="size-3.5" aria-hidden />
+              {status.label}
+            </span>
+          </div>
+          {factory.description && (
+            <p className={cn("mt-2 max-w-3xl text-sm leading-normal", mutedTextClassName)}>{factory.description}</p>
+          )}
+          <p className={cn("mt-2 text-xs", mutedTextClassName)}>
+            Software Factory · {factory.automationCount} {factory.automationCount === 1 ? "Automation" : "Automations"}
+          </p>
+        </div>
+        <Button type="button" onClick={onCreateWorkOrder}>
+          New Work Order
+        </Button>
+      </div>
+
+      {factory.status !== "healthy" && factory.statusDetail && (
+        <div
+          className={cn(
+            "mt-5 flex items-center gap-2 rounded-lg px-4 py-3 text-sm",
+            "bg-amber-50 text-amber-900 outline outline-amber-200",
+            "dark:bg-amber-950/40 dark:text-amber-200 dark:outline-amber-900/60",
+          )}
+        >
+          <AlertTriangle className="size-4 shrink-0" aria-hidden />
+          {factory.statusDetail}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/web_src/src/pages/factory/WorkOrderChronology.tsx
+++ b/web_src/src/pages/factory/WorkOrderChronology.tsx
@@ -1,0 +1,159 @@
+import {
+  ArrowRightLeft,
+  CheckCircle2,
+  CircleDot,
+  FilePlus2,
+  GitPullRequest,
+  Hammer,
+  HelpCircle,
+  MessageSquare,
+  Navigation,
+  RotateCcw,
+  ThumbsUp,
+  XCircle,
+} from "lucide-react";
+
+import { formatTimeAgo } from "@/lib/date";
+import { cn } from "@/lib/utils";
+
+import { factoryCardClassName, mutedTextClassName } from "./factoryStyles";
+import type { WorkOrderEvent, WorkOrderEventKind } from "./factoryTypes";
+import { PullRequestLink } from "./WorkOrderListItem";
+
+const EVENT_META = {
+  created: { icon: FilePlus2, label: "Created" },
+  approved: { icon: ThumbsUp, label: "Approved" },
+  pickup: { icon: CircleDot, label: "Picked up" },
+  progress: { icon: Hammer, label: "Progress" },
+  conversation: { icon: MessageSquare, label: "Conversation" },
+  decision: { icon: CheckCircle2, label: "Decision" },
+  "approval-request": { icon: HelpCircle, label: "Approval requested" },
+  steering: { icon: Navigation, label: "Steering" },
+  handoff: { icon: ArrowRightLeft, label: "Handoff" },
+  "pull-request": { icon: GitPullRequest, label: "Pull request" },
+  outcome: { icon: CheckCircle2, label: "Outcome" },
+  retry: { icon: RotateCcw, label: "Retry" },
+} as const satisfies Record<WorkOrderEventKind, { icon: typeof FilePlus2; label: string }>;
+
+/** Events that open a new attempt get a visible seam in the rail. */
+const STARTS_ATTEMPT = new Set<WorkOrderEventKind>(["retry"]);
+
+interface WorkOrderChronologyProps {
+  events: WorkOrderEvent[];
+}
+
+/**
+ * PRD: "The page uses a vertical timeline. The oldest event appears at the top
+ * and new events are appended at the bottom." Conversations, decisions,
+ * approvals and steering sit in the same rail as Automation events — the point
+ * of an append-only record is that human input and machine work share one
+ * chronology rather than living in a side panel.
+ */
+export function WorkOrderChronology({ events }: WorkOrderChronologyProps) {
+  return (
+    <ol className="relative">
+      {events.map((event, index) => (
+        <ChronologyRow
+          key={event.id}
+          event={event}
+          isLast={index === events.length - 1}
+          startsAttempt={STARTS_ATTEMPT.has(event.kind)}
+        />
+      ))}
+    </ol>
+  );
+}
+
+function ChronologyRow({
+  event,
+  isLast,
+  startsAttempt,
+}: {
+  event: WorkOrderEvent;
+  isLast: boolean;
+  startsAttempt: boolean;
+}) {
+  const meta = EVENT_META[event.kind];
+  const Icon = meta.icon;
+  const blocking = event.kind === "approval-request" && event.awaitingResponse === true;
+  const failed = event.kind === "outcome" && event.outcome === "unsuccessful";
+
+  return (
+    <li className={cn("relative pl-10", isLast ? "pb-0" : "pb-5")}>
+      {!isLast && (
+        <span aria-hidden className="absolute left-[13px] top-7 bottom-0 w-px bg-slate-200 dark:bg-gray-700" />
+      )}
+      <span
+        aria-hidden
+        className={cn(
+          "absolute left-0 top-0.5 flex size-7 items-center justify-center rounded-full",
+          blocking && "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-300",
+          failed && "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+          !blocking && !failed && "bg-slate-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+        )}
+      >
+        <Icon className="size-3.5" />
+      </span>
+
+      {startsAttempt && (
+        <p className={cn("mb-2 text-xs font-medium uppercase tracking-wide", mutedTextClassName)}>New attempt</p>
+      )}
+
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <span className="text-sm font-medium text-slate-900 dark:text-gray-100">{event.summary}</span>
+        <span className={cn("text-xs", mutedTextClassName)}>{formatTimeAgo(new Date(event.at))}</span>
+      </div>
+
+      <div className={cn("mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs", mutedTextClassName)}>
+        <span>{event.actor.name}</span>
+        {/* An Automation acting as itself would otherwise print its name twice. */}
+        {event.automation && event.automation !== event.actor.name && <span>{event.automation}</span>}
+      </div>
+
+      <EventBody event={event} />
+
+      {event.pullRequest && (
+        <div className={cn("mt-2 text-xs", mutedTextClassName)}>
+          <PullRequestLink pullRequest={event.pullRequest} />
+        </div>
+      )}
+
+      <OutcomeBadge outcome={event.kind === "outcome" ? event.outcome : undefined} />
+    </li>
+  );
+}
+
+/** Conversation text, a decision rationale, or an error body. */
+function EventBody({ event }: { event: WorkOrderEvent }) {
+  if (!event.body) return null;
+  const fromHuman = event.actor.kind === "human";
+  return (
+    <div
+      className={cn(
+        "mt-2 whitespace-pre-wrap px-3.5 py-2.5 text-sm text-slate-900 dark:text-gray-100",
+        fromHuman ? "rounded-lg bg-slate-100 dark:bg-gray-800" : factoryCardClassName,
+      )}
+    >
+      {event.body}
+    </div>
+  );
+}
+
+function OutcomeBadge({ outcome }: { outcome?: "successful" | "unsuccessful" }) {
+  if (!outcome) return null;
+  const successful = outcome === "successful";
+  const Icon = successful ? CheckCircle2 : XCircle;
+  return (
+    <p
+      className={cn(
+        "mt-2 inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium",
+        successful
+          ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/70 dark:text-emerald-300"
+          : "bg-red-100 text-red-800 dark:bg-red-950/70 dark:text-red-300",
+      )}
+    >
+      <Icon className="size-3.5" aria-hidden />
+      Marked {outcome}
+    </p>
+  );
+}

--- a/web_src/src/pages/factory/WorkOrderListItem.tsx
+++ b/web_src/src/pages/factory/WorkOrderListItem.tsx
@@ -1,0 +1,105 @@
+import { AlertTriangle, CheckCircle2, GitPullRequest, Loader2, PenLine, XCircle } from "lucide-react";
+
+import { formatTimeAgo } from "@/lib/date";
+import { cn } from "@/lib/utils";
+
+import { factoryCardClassName, mutedTextClassName } from "./factoryStyles";
+import type { PullRequestRef, WorkOrder, WorkOrderState } from "./factoryTypes";
+
+const STATE_META = {
+  draft: { label: "Draft", icon: PenLine, className: "bg-slate-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300" },
+  ready: {
+    label: "Ready",
+    icon: Loader2,
+    className: "bg-blue-100 text-blue-800 dark:bg-blue-950/70 dark:text-blue-300",
+  },
+  successful: {
+    label: "Successful",
+    icon: CheckCircle2,
+    className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/70 dark:text-emerald-300",
+  },
+  unsuccessful: {
+    label: "Unsuccessful",
+    icon: XCircle,
+    className: "bg-red-100 text-red-800 dark:bg-red-950/70 dark:text-red-300",
+  },
+} as const satisfies Record<WorkOrderState, { label: string; icon: typeof PenLine; className: string }>;
+
+export function WorkOrderStateBadge({ state }: { state: WorkOrderState }) {
+  const meta = STATE_META[state];
+  const Icon = meta.icon;
+  return (
+    <span className={cn("inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium", meta.className)}>
+      <Icon className="size-3.5" aria-hidden />
+      {meta.label}
+    </span>
+  );
+}
+
+export function PullRequestLink({ pullRequest }: { pullRequest: PullRequestRef }) {
+  return (
+    <a
+      href={pullRequest.url}
+      target="_blank"
+      rel="noreferrer"
+      className={cn(
+        "inline-flex items-center gap-1 underline decoration-slate-300 underline-offset-4",
+        "hover:text-slate-900 dark:decoration-gray-600 dark:hover:text-gray-100",
+      )}
+    >
+      <GitPullRequest className="size-3.5" aria-hidden />
+      {pullRequest.repository}#{pullRequest.number}
+    </a>
+  );
+}
+
+interface WorkOrderListItemProps {
+  workOrder: WorkOrder;
+  onOpen: (workOrder: WorkOrder) => void;
+}
+
+/**
+ * One row in a Work Order list. Shared by the Overview and Work Orders tabs so
+ * a Work Order reads identically wherever it appears.
+ */
+export function WorkOrderListItem({ workOrder, onOpen }: WorkOrderListItemProps) {
+  const primaryPullRequest = workOrder.pullRequests[0];
+  const extraPullRequests = workOrder.pullRequests.length - 1;
+
+  return (
+    <li className={cn("px-4 py-3", factoryCardClassName)}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <button
+            type="button"
+            onClick={() => onOpen(workOrder)}
+            className="text-left text-sm font-medium text-slate-900 underline-offset-4 hover:underline dark:text-gray-100"
+          >
+            {workOrder.title}
+          </button>
+
+          {workOrder.attention ? (
+            <p className="mt-1 flex items-start gap-1.5 text-sm text-amber-800 dark:text-amber-300">
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+              {workOrder.attention.reason}
+            </p>
+          ) : (
+            workOrder.activity && <p className={cn("mt-1 text-sm", mutedTextClassName)}>{workOrder.activity}</p>
+          )}
+
+          <div className={cn("mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs", mutedTextClassName)}>
+            {workOrder.currentAutomation && <span>{workOrder.currentAutomation}</span>}
+            {primaryPullRequest && <PullRequestLink pullRequest={primaryPullRequest} />}
+            {extraPullRequests > 0 && <span>+{extraPullRequests} more</span>}
+            <span>
+              {workOrder.attention
+                ? `Waiting ${formatTimeAgo(new Date(workOrder.attention.since), false)}`
+                : `Updated ${formatTimeAgo(new Date(workOrder.updatedAt))}`}
+            </span>
+          </div>
+        </div>
+        <WorkOrderStateBadge state={workOrder.state} />
+      </div>
+    </li>
+  );
+}

--- a/web_src/src/pages/factory/WorkOrderPage.stories.tsx
+++ b/web_src/src/pages/factory/WorkOrderPage.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { workOrderEvents, workOrders } from "./__fixtures__/factoryFixtures";
+import { WorkOrderPage } from "./WorkOrderPage";
+
+/**
+ * Dedicated page for one Work Order, designed from
+ * `docs/prd/software-factory.md`.
+ *
+ * Two parts, in the PRD's order: the work description, which stays visible as
+ * the context for the implementation, then the chronology — "the main
+ * structural model of the page". Oldest event at the top, newest appended at
+ * the bottom, with conversations, decisions, approvals and steering in the same
+ * durable rail as Automation events.
+ */
+const meta = {
+  title: "Pages/Work Order",
+  component: WorkOrderPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof WorkOrderPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const factory = { id: "factory-1", name: "Payments Factory" };
+
+const handlers = {
+  onBackToFactory: fn(),
+  onApprove: fn(),
+  onSteer: fn(),
+  onRetry: fn(),
+};
+
+/**
+ * A draft awaiting approval — nothing has run yet, so the chronology is two
+ * events long and the only action is Approve.
+ */
+export const Draft: Story = {
+  args: {
+    ...handlers,
+    data: {
+      factory,
+      workOrder: workOrders[1],
+      events: workOrderEvents.slice(0, 1),
+    },
+  },
+};
+
+/**
+ * Blocked on a person: the Automation asked a question and stopped. The
+ * approval request carries the accent, because it is the one thing on the page
+ * that needs a human.
+ */
+export const NeedsAttention: Story = {
+  args: {
+    ...handlers,
+    data: {
+      factory,
+      workOrder: workOrders[0],
+      events: workOrderEvents
+        .slice(0, 5)
+        .map((event, index) => (index === 4 ? { ...event, awaitingResponse: true } : event)),
+    },
+  },
+};
+
+/** Mid-flight after the question was answered and the plan narrowed. */
+export const Running: Story = {
+  args: {
+    ...handlers,
+    data: {
+      factory,
+      workOrder: { ...workOrders[2], attention: undefined },
+      events: workOrderEvents.slice(0, 9),
+    },
+  },
+};
+
+/**
+ * The interesting case for an append-only record: the Work Order succeeded,
+ * was reopened after review, and the second attempt is appended below the first
+ * rather than replacing it. "New attempt" marks the seam.
+ */
+export const ReopenedAfterSuccess: Story = {
+  args: {
+    ...handlers,
+    data: {
+      factory,
+      workOrder: {
+        ...workOrders[0],
+        state: "ready",
+        attention: undefined,
+        activity: "Adding a table test for the duplicate path",
+        pullRequests: [
+          {
+            provider: "github",
+            repository: "acme/payments-api",
+            number: 1841,
+            url: "https://github.com/acme/payments-api/pull/1841",
+          },
+        ],
+      },
+      events: workOrderEvents,
+    },
+  },
+};
+
+/** A finished Work Order — the composer gives way to Retry, which appends. */
+export const Successful: Story = {
+  args: {
+    ...handlers,
+    data: {
+      factory,
+      workOrder: {
+        ...workOrders[4],
+        pullRequests: [
+          {
+            provider: "github",
+            repository: "acme/payments-api",
+            number: 1838,
+            url: "https://github.com/acme/payments-api/pull/1838",
+          },
+        ],
+      },
+      events: workOrderEvents.slice(0, 10),
+    },
+  },
+};

--- a/web_src/src/pages/factory/WorkOrderPage.tsx
+++ b/web_src/src/pages/factory/WorkOrderPage.tsx
@@ -1,0 +1,142 @@
+import { AlertTriangle, ChevronLeft } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { formatTimeAgo } from "@/lib/date";
+import { cn } from "@/lib/utils";
+
+import {
+  factoryPanelClassName,
+  mutedTextClassName,
+  sectionTitleClassName,
+  workOrderPageWidthClassName,
+} from "./factoryStyles";
+import type { WorkOrderPageData } from "./factoryTypes";
+import { WorkOrderChronology } from "./WorkOrderChronology";
+import { PullRequestLink, WorkOrderStateBadge } from "./WorkOrderListItem";
+
+interface WorkOrderPageProps {
+  data: WorkOrderPageData;
+  onBackToFactory: () => void;
+  /** PRD: approval appends an event and moves `draft` → `ready`. */
+  onApprove: () => void;
+  /** Steering instructions are durable Work Order Events, not chat. */
+  onSteer: (body: string) => void;
+  onRetry: () => void;
+}
+
+/**
+ * Dedicated page for one Work Order.
+ *
+ * PRD: two primary parts — the work description, which stays visible as the
+ * context for the implementation, then the chronology. The chronology "is the
+ * main structural model of the page", so everything else stays deliberately
+ * light: no side panel competing with the rail, and a narrower reading column
+ * than the Factory page.
+ */
+export function WorkOrderPage({ data, onBackToFactory, onApprove, onSteer, onRetry }: WorkOrderPageProps) {
+  const { factory, workOrder, events } = data;
+  const isDraft = workOrder.state === "draft";
+  const isFinished = workOrder.state === "successful" || workOrder.state === "unsuccessful";
+
+  return (
+    <div className={cn(workOrderPageWidthClassName, "py-8")}>
+      <button
+        type="button"
+        onClick={onBackToFactory}
+        className={cn("inline-flex items-center gap-1 text-xs underline-offset-4 hover:underline", mutedTextClassName)}
+      >
+        <ChevronLeft className="size-3.5" aria-hidden />
+        {factory.name}
+      </button>
+
+      {/* 1. Work description — the requested outcome, kept as context. */}
+      <header className="mt-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <h1 className="text-2xl font-medium text-slate-900 dark:text-gray-100">{workOrder.title}</h1>
+          <WorkOrderStateBadge state={workOrder.state} />
+        </div>
+        <p className="mt-3 whitespace-pre-wrap text-sm leading-relaxed text-slate-900 dark:text-gray-100">
+          {workOrder.description}
+        </p>
+        <div className={cn("mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs", mutedTextClassName)}>
+          <span>Created {formatTimeAgo(new Date(workOrder.createdAt))}</span>
+          {workOrder.currentAutomation && <span>{workOrder.currentAutomation}</span>}
+          {workOrder.pullRequests.map((pullRequest) => (
+            <PullRequestLink key={pullRequest.url} pullRequest={pullRequest} />
+          ))}
+        </div>
+      </header>
+
+      {workOrder.attention && (
+        <div
+          className={cn(
+            "mt-5 flex flex-wrap items-center justify-between gap-3 rounded-lg px-4 py-3",
+            "bg-amber-50 outline outline-amber-200 dark:bg-amber-950/40 dark:outline-amber-900/60",
+          )}
+        >
+          <p className="flex items-center gap-2 text-sm text-amber-900 dark:text-amber-200">
+            <AlertTriangle className="size-4 shrink-0" aria-hidden />
+            {workOrder.attention.reason}
+          </p>
+          {isDraft && (
+            <Button type="button" size="sm" onClick={onApprove}>
+              Approve
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* 2. Chronology — the main structural model of the page. */}
+      <section className={cn("mt-6", factoryPanelClassName)}>
+        <h2 className={cn(sectionTitleClassName, "mb-4")}>History</h2>
+        <WorkOrderChronology events={events} />
+      </section>
+
+      {isFinished ? (
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          <p className={cn("text-xs", mutedTextClassName)}>
+            History is append-only — a retry starts a new attempt and keeps everything above.
+          </p>
+          <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+            Retry Work Order
+          </Button>
+        </div>
+      ) : (
+        <SteeringComposer onSteer={onSteer} />
+      )}
+    </div>
+  );
+}
+
+/** Steering is recorded as a durable event, so it reads as part of the record. */
+function SteeringComposer({ onSteer }: { onSteer: (body: string) => void }) {
+  const [draft, setDraft] = useState("");
+
+  return (
+    <div className="mt-4">
+      <Textarea
+        rows={3}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        placeholder="Add context, answer a question, or redirect the work…"
+        aria-label="Add a steering instruction"
+      />
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <p className={cn("text-xs", mutedTextClassName)}>Appended to the history as a steering event.</p>
+        <Button
+          type="button"
+          size="sm"
+          disabled={draft.trim().length === 0}
+          onClick={() => {
+            onSteer(draft.trim());
+            setDraft("");
+          }}
+        >
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/factory/__fixtures__/factoryFixtures.ts
+++ b/web_src/src/pages/factory/__fixtures__/factoryFixtures.ts
@@ -1,0 +1,342 @@
+import type { Automation, SoftwareFactoryPageData, VelocityData, WorkOrder, WorkOrderEvent } from "../factoryTypes";
+
+const hoursAgo = (hours: number) => new Date(Date.now() - hours * 3_600_000).toISOString();
+const daysAgo = (days: number) => new Date(Date.now() - days * 86_400_000).toISOString();
+
+const pr = (repository: string, number: number) => ({
+  provider: "github" as const,
+  repository,
+  number,
+  url: `https://github.com/${repository}/pull/${number}`,
+});
+
+export const workOrders: WorkOrder[] = [
+  {
+    id: "wo-1",
+    title: "Retry idempotency keys on gateway timeout",
+    description:
+      "Payments occasionally double-charge when the gateway times out and our client retries with a fresh idempotency key. Reuse one key per logical request.",
+    state: "ready",
+    attention: { reason: "Agent is asking whether to change retry behaviour for all callers.", since: hoursAgo(3) },
+    currentAutomation: "Issue to pull request",
+    pullRequests: [],
+    createdAt: hoursAgo(6),
+    updatedAt: hoursAgo(3),
+  },
+  {
+    id: "wo-2",
+    title: "Add refund reconciliation test",
+    description: "Cover the refund reconciliation path — it regressed twice this quarter with no test to catch it.",
+    state: "draft",
+    attention: { reason: "Draft is waiting for approval before an Automation can pick it up.", since: hoursAgo(9) },
+    pullRequests: [],
+    createdAt: hoursAgo(9),
+    updatedAt: hoursAgo(9),
+  },
+  {
+    id: "wo-3",
+    title: "Fix currency rounding in settlement report",
+    description: "Settlement totals drift by cents because rounding happens per line rather than per settlement.",
+    state: "ready",
+    activity: "Waiting for CI on factory/settlement-rounding",
+    currentAutomation: "Issue to pull request",
+    pullRequests: [pr("acme/payments-api", 1843)],
+    createdAt: hoursAgo(5),
+    updatedAt: hoursAgo(1),
+  },
+  {
+    id: "wo-4",
+    title: "Harden webhook signature check",
+    description: "Reject webhooks whose signature header is missing rather than treating them as unsigned.",
+    state: "ready",
+    activity: "Implementing changes",
+    currentAutomation: "Security follow-ups",
+    pullRequests: [],
+    createdAt: hoursAgo(2),
+    updatedAt: hoursAgo(1),
+  },
+  {
+    id: "wo-5",
+    title: "Cache Stripe customer lookups",
+    description: "Customer lookups dominate checkout latency. Add a short-lived cache.",
+    state: "successful",
+    pullRequests: [pr("acme/payments-api", 1838)],
+    createdAt: daysAgo(2),
+    updatedAt: hoursAgo(20),
+  },
+  {
+    id: "wo-6",
+    title: "Migrate ledger export to the new schema",
+    description: "Move the nightly ledger export onto the v2 schema and keep the old columns for one release.",
+    state: "successful",
+    pullRequests: [pr("acme/payments-api", 1829), pr("acme/ledger-service", 412)],
+    createdAt: daysAgo(3),
+    updatedAt: daysAgo(1),
+  },
+  {
+    id: "wo-7",
+    title: "Backfill missing merchant categories",
+    description: "Fill in merchant category codes for records imported before the field existed.",
+    state: "unsuccessful",
+    pullRequests: [],
+    createdAt: daysAgo(4),
+    updatedAt: daysAgo(2),
+  },
+];
+
+export const automations: Automation[] = [
+  {
+    id: "auto-1",
+    name: "Issue to pull request",
+    description: "Picks up factory-labeled issues, implements them, and opens a pull request.",
+    trigger: "GitHub issue labeled `factory`",
+    status: "active",
+    currentActivity: "Running 2 Work Orders",
+    recentSuccess: 0.82,
+    lastRunAt: hoursAgo(1),
+    repositories: ["acme/payments-api"],
+  },
+  {
+    id: "auto-2",
+    name: "Ready Work Order intake",
+    description: "Listens for Work Orders that become ready and routes them to the right implementation Automation.",
+    trigger: "Work Order → ready",
+    status: "active",
+    recentSuccess: 0.96,
+    lastRunAt: hoursAgo(3),
+    repositories: ["acme/payments-api", "acme/ledger-service"],
+  },
+  {
+    id: "auto-3",
+    name: "Security follow-ups",
+    description: "Turns findings from the weekly scan into Work Orders and implements the low-risk ones.",
+    trigger: "Schedule — weekly",
+    status: "active",
+    currentActivity: "Implementing 1 Work Order",
+    recentSuccess: 0.74,
+    lastRunAt: hoursAgo(2),
+    repositories: ["acme/payments-api"],
+  },
+  {
+    id: "auto-4",
+    name: "Ledger schema migration",
+    description: "One-off migration helper for the v2 ledger schema.",
+    trigger: "Manual",
+    status: "paused",
+    recentSuccess: 1,
+    lastRunAt: daysAgo(1),
+    repositories: ["acme/ledger-service"],
+  },
+];
+
+const throughputSeries: VelocityData["throughputSeries"] = [
+  { date: "Jul 15", human: 3, factory: 1 },
+  { date: "Jul 16", human: 2, factory: 2 },
+  { date: "Jul 17", human: 4, factory: 1 },
+  { date: "Jul 18", human: 1, factory: 3 },
+  { date: "Jul 19", human: 0, factory: 0 },
+  { date: "Jul 20", human: 0, factory: 1 },
+  { date: "Jul 21", human: 3, factory: 2 },
+  { date: "Jul 22", human: 2, factory: 3 },
+  { date: "Jul 23", human: 3, factory: 2 },
+  { date: "Jul 24", human: 1, factory: 4 },
+  { date: "Jul 25", human: 2, factory: 3 },
+  { date: "Jul 26", human: 0, factory: 1 },
+  { date: "Jul 27", human: 1, factory: 2 },
+  { date: "Jul 28", human: 2, factory: 4 },
+];
+
+export const velocity: VelocityData = {
+  periodDays: 14,
+  repositories: ["acme/payments-api", "acme/ledger-service"],
+  selectedRepository: "acme/payments-api",
+  cohorts: [
+    {
+      id: "team",
+      label: "Team total",
+      mergedPullRequests: 53,
+      cycleTimeHours: 9,
+      successRate: 0.89,
+      trackedCostUsd: 41.18,
+    },
+    // PRD: human tracked cost is deliberately unavailable, never zero.
+    {
+      id: "human",
+      label: "Human-authored",
+      mergedPullRequests: 24,
+      cycleTimeHours: 14,
+      successRate: 0.92,
+      trackedCostUsd: null,
+    },
+    {
+      id: "factory",
+      label: "Factory-authored",
+      mergedPullRequests: 29,
+      cycleTimeHours: 4,
+      successRate: 0.86,
+      trackedCostUsd: 41.18,
+    },
+  ],
+  throughputSeries,
+  costBreakdown: { tokensUsd: 28.4, computeUsd: 12.78 },
+};
+
+export const factoryPageData: SoftwareFactoryPageData = {
+  factory: {
+    id: "factory-1",
+    name: "Payments Factory",
+    description:
+      "Delegated implementation work for the payments platform. Automations pick up labeled issues, open pull requests, and record the outcome on each Work Order.",
+    status: "healthy",
+    automationCount: automations.length,
+  },
+  summary: {
+    throughput: { value: 29, unit: "Work Orders completed, 14 days", trend: [1, 2, 2, 3, 2, 4, 3, 5, 4, 6, 5, 7] },
+    successRate: { value: 0.86, trend: [4, 5, 4, 5, 6, 5, 6, 6, 7, 6, 7, 8] },
+    activeWorkOrders: 4,
+    trackedCost: { tokensUsd: 28.4, computeUsd: 12.78 },
+  },
+  workOrders,
+  automations,
+  velocity,
+};
+
+/** A Factory immediately after creation — the PRD's "blank by default" state. */
+export const newFactoryPageData: SoftwareFactoryPageData = {
+  factory: {
+    id: "factory-2",
+    name: "Ledger Factory",
+    description: undefined,
+    status: "healthy",
+    automationCount: 0,
+  },
+  summary: {
+    throughput: { value: 0, unit: "Work Orders completed, 14 days", trend: [] },
+    successRate: { value: 0, trend: [] },
+    activeWorkOrders: 0,
+    trackedCost: { tokensUsd: 0, computeUsd: 0 },
+  },
+  workOrders: [],
+  automations: [],
+  velocity: {
+    ...velocity,
+    cohorts: velocity.cohorts.map((cohort) => ({
+      ...cohort,
+      mergedPullRequests: 0,
+      cycleTimeHours: 0,
+      successRate: 0,
+      trackedCostUsd: cohort.id === "human" ? null : 0,
+    })),
+    throughputSeries: throughputSeries.map((day) => ({ ...day, human: 0, factory: 0 })),
+    costBreakdown: { tokensUsd: 0, computeUsd: 0 },
+  },
+};
+
+const agent = { kind: "automation" as const, name: "Issue to pull request" };
+const person = { kind: "human" as const, name: "dana@acme.com" };
+const system = { kind: "system" as const, name: "SuperPlane" };
+
+/** A full attempt that succeeded, then a reopen that appended a second attempt. */
+export const workOrderEvents: WorkOrderEvent[] = [
+  {
+    id: "e1",
+    kind: "created",
+    at: hoursAgo(6),
+    actor: system,
+    summary: "Work Order created from issue #1822",
+    automation: "Issue to pull request",
+  },
+  { id: "e2", kind: "approved", at: hoursAgo(5.6), actor: person, summary: "Approved — moved to ready" },
+  {
+    id: "e3",
+    kind: "pickup",
+    at: hoursAgo(5.5),
+    actor: agent,
+    summary: "Picked up by Issue to pull request",
+    automation: "Issue to pull request",
+  },
+  {
+    id: "e4",
+    kind: "progress",
+    at: hoursAgo(5.2),
+    actor: agent,
+    summary: "Read the gateway client and its retry wrapper",
+    body: "internal/gateway/client.go — retry wrapper generates a fresh key per attempt\ninternal/gateway/idempotency.go — key derived from attempt number",
+    automation: "Issue to pull request",
+  },
+  {
+    id: "e5",
+    kind: "approval-request",
+    at: hoursAgo(4.5),
+    actor: agent,
+    summary: "Asked whether to change retry behaviour for all callers",
+    body: "Reusing one key per logical request means a 409 from the gateway now signals a genuine duplicate rather than a retry artifact. That changes behaviour for every caller. Proceed?",
+    automation: "Issue to pull request",
+  },
+  {
+    id: "e6",
+    kind: "steering",
+    at: hoursAgo(4.2),
+    actor: person,
+    summary: "Answered the question",
+    body: "Yes, reuse the key — but don't touch the retry ceiling, it's tuned for the gateway's rate limit.",
+  },
+  {
+    id: "e7",
+    kind: "decision",
+    at: hoursAgo(4.1),
+    actor: agent,
+    summary: "Scope narrowed to key reuse and 409 handling",
+    automation: "Issue to pull request",
+  },
+  {
+    id: "e8",
+    kind: "progress",
+    at: hoursAgo(3.4),
+    actor: agent,
+    summary: "Implemented key reuse and duplicate handling",
+    automation: "Issue to pull request",
+  },
+  {
+    id: "e9",
+    kind: "pull-request",
+    at: hoursAgo(3),
+    actor: agent,
+    summary: "Opened a pull request",
+    pullRequest: pr("acme/payments-api", 1841),
+    automation: "Issue to pull request",
+  },
+  {
+    id: "e10",
+    kind: "outcome",
+    at: hoursAgo(2.8),
+    actor: agent,
+    summary: "Marked successful",
+    outcome: "successful",
+    automation: "Issue to pull request",
+  },
+  {
+    id: "e11",
+    kind: "retry",
+    at: hoursAgo(1.5),
+    actor: person,
+    summary: "Reopened — review found the 409 path untested",
+    body: "The duplicate branch has no coverage. Reopening rather than filing a follow-up so the history stays in one place.",
+  },
+  {
+    id: "e12",
+    kind: "pickup",
+    at: hoursAgo(1.4),
+    actor: agent,
+    summary: "Picked up again",
+    automation: "Issue to pull request",
+  },
+  {
+    id: "e13",
+    kind: "progress",
+    at: hoursAgo(0.5),
+    actor: agent,
+    summary: "Adding a table test for the duplicate path",
+    automation: "Issue to pull request",
+  },
+];

--- a/web_src/src/pages/factory/factoryStyles.ts
+++ b/web_src/src/pages/factory/factoryStyles.ts
@@ -1,0 +1,32 @@
+import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
+import { cn } from "@/lib/utils";
+
+/**
+ * gray-600/gray-300 rather than the gray-500/gray-400 pairing used elsewhere:
+ * both of those fail WCAG 4.5:1 — 500 on white (4.2:1) and 400 on the raised
+ * dark surface (4.38:1).
+ */
+export const mutedTextClassName = "text-gray-600 dark:text-gray-300";
+
+/** PRD: responsive width with a restrained cap near 1,500–1,600px. */
+export const factoryPageWidthClassName = "mx-auto w-full max-w-[1600px] px-8";
+
+/** PRD: the Work Order chronology may use a narrower reading column. */
+export const workOrderPageWidthClassName = "mx-auto w-full max-w-3xl px-8";
+
+export const factoryPanelClassName = cn(
+  "rounded-lg bg-white p-5 outline outline-slate-950/10",
+  appDarkModeClasses.surfaceRaised,
+  "dark:outline-gray-700/70",
+);
+
+export const factoryCardClassName = cn(
+  "rounded-md bg-white outline outline-slate-950/10",
+  appDarkModeClasses.surfaceRaised,
+  "dark:outline-gray-700/70",
+);
+
+export const sectionTitleClassName = "text-sm font-semibold text-slate-900 dark:text-gray-100";
+
+export const countPillClassName =
+  "inline-flex min-w-5 items-center justify-center rounded-full bg-slate-100 px-1.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300";

--- a/web_src/src/pages/factory/factoryTypes.ts
+++ b/web_src/src/pages/factory/factoryTypes.ts
@@ -1,0 +1,175 @@
+/**
+ * Domain types for the Software Factory experience.
+ *
+ * Modelled directly on `docs/prd/software-factory.md`. Where the PRD leaves a
+ * question open, the type keeps the option open rather than guessing — see the
+ * comments on `trackedCost` and `attention`.
+ */
+
+/** PRD "Work Order Lifecycle" — the four confirmed states. */
+export type WorkOrderState = "draft" | "ready" | "successful" | "unsuccessful";
+
+/**
+ * PRD groups Work Orders into four operational buckets. These are *derived*
+ * from state plus attention/activity, not a fifth and sixth lifecycle state —
+ * the PRD is explicit that only the four states above are confirmed.
+ */
+export type WorkOrderGroup = "needs-attention" | "running" | "recently-done" | "unsuccessful";
+
+export interface PullRequestRef {
+  provider: "github" | "bitbucket";
+  repository: string;
+  number: number;
+  url: string;
+}
+
+/**
+ * Why a Work Order is waiting on a person. The PRD lists this as an open
+ * question ("What actions make a Work Order require attention"), so the reason
+ * is free text rather than a closed enum.
+ */
+export interface WorkOrderAttention {
+  reason: string;
+  since: string;
+}
+
+export interface WorkOrder {
+  id: string;
+  title: string;
+  description: string;
+  state: WorkOrderState;
+  /** Present when the Work Order is blocked on a human decision. */
+  attention?: WorkOrderAttention;
+  /** What an Automation is doing right now; present while work is moving. */
+  activity?: string;
+  /** Automation currently holding the Work Order. */
+  currentAutomation?: string;
+  /**
+   * PRD: the initial interface emphasises one primary pull request, but a Work
+   * Order must be able to retain several (e.g. frontend + backend).
+   */
+  pullRequests: PullRequestRef[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** PRD "Work Order Event" — the durable, append-only chronology. */
+export type WorkOrderEventKind =
+  | "created"
+  | "approved"
+  | "pickup"
+  | "progress"
+  | "conversation"
+  | "decision"
+  | "approval-request"
+  | "steering"
+  | "handoff"
+  | "pull-request"
+  | "outcome"
+  | "retry";
+
+export interface WorkOrderEventActor {
+  kind: "human" | "automation" | "system";
+  name: string;
+}
+
+export interface WorkOrderEvent {
+  id: string;
+  kind: WorkOrderEventKind;
+  at: string;
+  actor: WorkOrderEventActor;
+  /** Human-readable description of what happened — the PRD's minimum field. */
+  summary: string;
+  /** Longer body: a conversation message, a decision rationale, an error. */
+  body?: string;
+  /** Automation that produced the event, when one did. */
+  automation?: string;
+  pullRequest?: PullRequestRef;
+  /** Set on `outcome` events. */
+  outcome?: "successful" | "unsuccessful";
+  /** Set on `approval-request` events still awaiting a response. */
+  awaitingResponse?: boolean;
+}
+
+/** PRD "Automations Tab" — the row's required context. */
+export interface Automation {
+  id: string;
+  name: string;
+  description: string;
+  trigger: string;
+  status: "active" | "paused" | "error";
+  /** What it is doing right now, if anything. */
+  currentActivity?: string;
+  /** Recent success rate, 0–1. */
+  recentSuccess: number;
+  lastRunAt: string;
+  repositories: string[];
+}
+
+export interface FactorySummary {
+  /** PRD leaves the throughput unit open; the label travels with the value. */
+  throughput: { value: number; unit: string; trend: number[] };
+  successRate: { value: number; trend: number[] };
+  activeWorkOrders: number;
+  /** Tracked cost = model tokens + execution compute only. */
+  trackedCost: { tokensUsd: number; computeUsd: number };
+}
+
+export interface SoftwareFactory {
+  id: string;
+  name: string;
+  description?: string;
+  status: "healthy" | "degraded" | "paused";
+  statusDetail?: string;
+  automationCount: number;
+}
+
+/** PRD "Velocity Tab" — same indicators across three cohorts. */
+export interface VelocityCohort {
+  id: "team" | "human" | "factory";
+  label: string;
+  mergedPullRequests: number;
+  /** Median cycle time in hours. */
+  cycleTimeHours: number;
+  successRate: number;
+  /**
+   * `null` means *not available*, which the PRD requires for human-authored
+   * work — it must never read as "humans cost nothing".
+   */
+  trackedCostUsd: number | null;
+}
+
+export interface VelocityData {
+  /** PRD: default period is the last 14 days. */
+  periodDays: number;
+  /** PRD: velocity is filtered by repository, never by Automation. */
+  repositories: string[];
+  selectedRepository: string;
+  cohorts: VelocityCohort[];
+  /** Throughput over time, one bucket per day of the period. */
+  throughputSeries: { date: string; human: number; factory: number }[];
+  costBreakdown: { tokensUsd: number; computeUsd: number };
+}
+
+export interface SoftwareFactoryPageData {
+  factory: SoftwareFactory;
+  summary: FactorySummary;
+  workOrders: WorkOrder[];
+  automations: Automation[];
+  velocity: VelocityData;
+}
+
+export interface WorkOrderPageData {
+  factory: Pick<SoftwareFactory, "id" | "name">;
+  workOrder: WorkOrder;
+  /** Oldest first — the page renders them in this order, top to bottom. */
+  events: WorkOrderEvent[];
+}
+
+/** Derives the PRD's four operational groups from state + attention + activity. */
+export function workOrderGroup(workOrder: WorkOrder): WorkOrderGroup {
+  if (workOrder.attention) return "needs-attention";
+  if (workOrder.state === "unsuccessful") return "unsuccessful";
+  if (workOrder.state === "successful") return "recently-done";
+  return "running";
+}


### PR DESCRIPTION
## What

Storybook design for [`docs/prd/software-factory.md`](https://github.com/superplanehq/superplane/blob/bb0d7cf5eb105c820709b3a2cbbf79714d7980cd/docs/prd/software-factory.md), covering both surfaces the PRD specifies.

**Presentational only.** Every value arrives via props — no hooks, no router, no API coupling — so each state below is a fixture and nothing here constrains the eventual data layer.

| Story | Covers |
|---|---|
| `Pages/Software Factory` | Overview · Work Orders · Automations · Velocity · New Factory · Degraded |
| `Pages/Work Order` | Draft · Needs Attention · Running · Reopened After Success · Successful |

## Design decisions, and the PRD line each answers

**A Factory is not a renamed App.** Its own page shell rather than a reuse of the App detail experience, with a Factory glyph and "Software Factory · N Automations" in the header so the resource type is unambiguous at a glance.

**Overview leads with blocked work.** Work Orders needing attention render *above* the metric row. The PRD states this as the tab's purpose ("puts Work Orders requiring attention before summary metrics"), so it's structural rather than a layout preference.

**Velocity does not stage a competition.** This was the most design-sensitive requirement. The three cohorts sit in a plain indicator table — one row each, identical columns, no ranking, no winner highlight, no bars racing each other. The only chart *stacks* human and Factory output into the team total rather than opposing them. Human tracked cost renders **"Not available"**, never `$0` — the PRD is explicit that human work must not read as costless.

**The chronology is the Work Order page.** Description first as durable context, then a vertical rail, oldest at top. Conversations, decisions, approvals and steering share the rail with Automation events instead of living in a side panel. A reopen appends a **"New attempt"** seam rather than rewriting — that seam is what makes append-only legible rather than merely true.

## Modelling notes

- The four **confirmed lifecycle states** are modelled as states; the four **operational groups** are derived via `workOrderGroup()`. The PRD confirms only four states, so the groupings don't smuggle in extra ones.
- Where the PRD leaves a question open, the types keep it open: `throughput` carries its unit as data (the primary unit is Open Question 20), and `trackedCostUsd` is nullable to distinguish *not attributed* from *zero*.
- `pullRequests` is a list from the start — the interface emphasises one primary PR, but the model must allow several.

## Verification

- `tsc` and `eslint` clean on these files; prettier formatted; lint budget within limits.
- **axe: zero violations in light and dark** across the stories.
- Verified in Storybook at desktop and narrow widths, both themes.

## Two things for reviewers

**1. A shared-component accessibility bug, fixed locally.** `TabsTrigger` in `@/components/ui/tabs.tsx` renders inactive tabs with `dark:text-muted-foreground`, which measures **4.38:1** on the dark surface and fails WCAG AA. That affects *every* Tabs usage in the app, so I corrected it locally here rather than changing a shared component inside a design PR. Worth its own change.

**2. `main` does not currently typecheck.** `tsc -b` fails in `useCanvasData.ts`, `useAgentSuggestionDismissals.ts` and `configurationFieldRenderer/index.tsx` on `dismissedAgentSuggestionIds` and `allowExpressions` — fields absent from the checked-in swagger, so the generated `src/api-client/` needs regenerating (`make pb.gen`). Pre-existing and unrelated to this PR; none of the errors are in `src/pages/factory/`.

## Not included

Routing, navigation placement, and the Factory creation flow. The PRD leaves resource-list placement and creation requirements as open questions, so this PR designs the pages themselves and stops there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)