### PR TITLE
fix: add GitHub repository access guidance

### DIFF
--- a/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/PropertiesTab.spec.tsx
+++ b/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/PropertiesTab.spec.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PropertiesTab } from "./PropertiesTab";
+
+const installationURL = "https://github.com/organizations/superplanehq/settings/installations/123";
+
+function renderPropertiesTab(integrationProperties: Parameters<typeof PropertiesTab>[0]["integrationProperties"]) {
+  return render(
+    <PropertiesTab
+      integrationProperties={integrationProperties}
+      propertyDrafts={Object.fromEntries(
+        integrationProperties.map((property) => [property.name ?? "", property.value ?? ""]),
+      )}
+      setPropertyDrafts={vi.fn()}
+      canUpdateIntegrations
+      permissionsLoading={false}
+      settingsMutationBusy={false}
+      saveProperty={vi.fn().mockResolvedValue(undefined)}
+      isSavingProperty={() => false}
+    />,
+  );
+}
+
+describe("PropertiesTab", () => {
+  it("links GitHub App integrations to their repository access settings", () => {
+    renderPropertiesTab([
+      {
+        name: "appInstallationURL",
+        label: "GitHub App Installation URL",
+        value: installationURL,
+        editable: false,
+      },
+    ]);
+
+    expect(screen.getByText("Can't find a repository?")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "Manage repository access" });
+    expect(link).toHaveAttribute("href", installationURL);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not show repository access guidance for integrations without an installation URL", () => {
+    renderPropertiesTab([
+      {
+        name: "authMethod",
+        label: "Authentication Method",
+        value: "pat",
+        editable: false,
+      },
+    ]);
+
+    expect(screen.queryByText("Can't find a repository?")).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/PropertiesTab.tsx
+++ b/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/PropertiesTab.tsx
@@ -5,10 +5,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { isUrl } from "@/lib/utils";
-import { Check, Pencil, X } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/ui/alert";
+import { Check, ExternalLink, Pencil, X } from "lucide-react";
 import { DescriptionTooltip } from "./DescriptionTooltip";
 import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
+
+const GITHUB_APP_INSTALLATION_URL_PROPERTY = "appInstallationURL";
 
 export interface PropertiesTabProps {
   integrationProperties: IntegrationProperty[];
@@ -19,6 +22,34 @@ export interface PropertiesTabProps {
   settingsMutationBusy: boolean;
   saveProperty: (propertyName: string, value: string) => Promise<void>;
   isSavingProperty: (propertyName: string | undefined) => boolean;
+}
+
+function GitHubRepositoryAccessHelp({ integrationProperties }: { integrationProperties: IntegrationProperty[] }) {
+  const installationURL =
+    integrationProperties.find((property) => property.name === GITHUB_APP_INSTALLATION_URL_PROPERTY)?.value?.trim() ??
+    "";
+
+  if (!isUrl(installationURL)) {
+    return null;
+  }
+
+  return (
+    <Alert>
+      <AlertTitle>Can't find a repository?</AlertTitle>
+      <AlertDescription className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p>
+          The GitHub App only lists repositories it can access. Update its repository access in GitHub, then return
+          here.
+        </p>
+        <Button asChild variant="outline" size="sm" className="shrink-0">
+          <a href={installationURL} target="_blank" rel="noopener noreferrer">
+            Manage repository access
+            <ExternalLink className="size-3.5" aria-hidden />
+          </a>
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
 }
 
 type PropertyReadonlyDisplayProps = {
@@ -259,6 +290,7 @@ export function PropertiesTab({
 
   return (
     <div className="space-y-4 rounded-lg border border-gray-300 bg-white p-4 dark:border-gray-600 dark:bg-gray-900">
+      <GitHubRepositoryAccessHelp integrationProperties={integrationProperties} />
       {integrationProperties.map((property) => (
         <IntegrationPropertyRow
           key={property.name}


### PR DESCRIPTION
## What changed

- added a “Can’t find a repository?” message to GitHub App integration settings
- linked it to the existing installation URL so it opens the correct GitHub settings
- kept it hidden for PAT integrations and other providers
- added tests for both states

## Why

If a new repo has not been granted to the GitHub App, it currently just looks like the repository picker is broken. The actual fix is in GitHub, but there is nothing in SuperPlane pointing you there.

This gives users a clear way out without changing how repositories are loaded.

## Testing

- `npm run test:run -- src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/PropertiesTab.spec.tsx`
- `eslint src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/PropertiesTab.tsx src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/PropertiesTab.spec.tsx`

Closes #6365