### PR TITLE
feat: add my runs filter

### DIFF
--- a/db/migrations/20260729075407_add-canvas-run-triggered-by.up.sql
+++ b/db/migrations/20260729075407_add-canvas-run-triggered-by.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE canvas_runs
+    ADD COLUMN IF NOT EXISTS triggered_by uuid REFERENCES users(id);
+
+CREATE INDEX IF NOT EXISTS idx_canvas_runs_workflow_triggered_by_created_at
+    ON canvas_runs (workflow_id, triggered_by, created_at DESC)
+    WHERE triggered_by IS NOT NULL;

--- a/pkg/agents/agent_tools/actions/read_runtime.go
+++ b/pkg/agents/agent_tools/actions/read_runtime.go
@@ -160,7 +160,7 @@ func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSession
 		if err != nil {
 			return nil, err
 		}
-		return protoPayload(canvasactions.ListRuns(ctx, database.DB(ctx), canvas, input.Limit, before, states, results))
+		return protoPayload(canvasactions.ListRuns(ctx, database.DB(ctx), canvas, input.Limit, before, states, results, ""))
 	case "event_executions":
 		if strings.TrimSpace(input.EventID) == "" {
 			return nil, fmt.Errorf("event_id is required for event_executions")

--- a/pkg/grpc/actions/canvases/cancel_run.go
+++ b/pkg/grpc/actions/canvases/cancel_run.go
@@ -88,6 +88,7 @@ func CancelRun(ctx context.Context, db *gorm.DB, canvas *models.Canvas, runID uu
 		runDetails.rootEventsByRunID[run.ID.String()],
 		runDetails.executionsByRunID[run.ID.String()],
 		runDetails.queueItemsByRunID[run.ID.String()],
+		runDetails.triggeredByUsersByID,
 		parentRunForDescribe(runDetails.parentRunsByRunID, run.ID.String()),
 		map[string][]models.CanvasRun{},
 	)

--- a/pkg/grpc/actions/canvases/describe_run.go
+++ b/pkg/grpc/actions/canvases/describe_run.go
@@ -39,6 +39,7 @@ func DescribeRun(ctx context.Context, db *gorm.DB, canvas *models.Canvas, runID 
 		runDetails.rootEventsByRunID[run.ID.String()],
 		runDetails.executionsByRunID[run.ID.String()],
 		runDetails.queueItemsByRunID[run.ID.String()],
+		runDetails.triggeredByUsersByID,
 		parentRunForDescribe(runDetails.parentRunsByRunID, run.ID.String()),
 		runDetails.childRunsByExecutionID,
 	)

--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/configuration"
@@ -74,53 +75,83 @@ func InvokeNodeTriggerHook(
 
 	expressionParameters := buildHookExpressionParameters(node.Ref.Data().Trigger.Name, hookName, node.Configuration.Data(), parameters)
 
-	resolvedConfiguration, err := contexts.NewNodeConfigurationBuilder(db, node.WorkflowID).
-		WithNodeID(node.NodeID).
-		WithExpressionVariables(map[string]any{
-			"parameters": expressionParameters,
-		}).
-		WithConfigurationFields(hookProvider.Configuration()).
-		Build(contexts.WithoutRunTitleConfiguration(node.Configuration.Data()))
+	userUUID, err := uuid.Parse(userID)
 	if err != nil {
-		return nil, grpcerrors.InvalidArgument(err, "failed to resolve trigger configuration")
+		return nil, grpcerrors.Unauthenticated(err, "user not authenticated")
 	}
 
-	hookCtx := core.TriggerHookContext{
-		Name:          hookName,
-		Parameters:    parameters,
-		Configuration: resolvedConfiguration,
-		HTTP:          registry.HTTPContext(),
-		Metadata:      contexts.NewNodeMetadataContext(db, node),
-		Requests:      contexts.NewNodeRequestContext(db, node),
-		Webhook:       contexts.NewNodeWebhookContext(ctx, db, encryptor, node, webhookBaseURL),
-		Events:        contexts.NewEventContext(db, node, nil, onNewEvents),
-	}
+	shouldRecordTriggeredBy := node.Ref.Data().Trigger.Name == "start" && hookName == "run" ||
+		node.Ref.Data().Trigger.Name == "schedule" && hookName == "run"
 
-	if node.AppInstallationID != nil {
-		integration, err := models.FindUnscopedIntegrationInTransaction(db, *node.AppInstallationID)
+	var hookResult map[string]any
+	err = db.Transaction(func(tx *gorm.DB) error {
+		resolvedConfiguration, err := contexts.NewNodeConfigurationBuilder(tx, node.WorkflowID).
+			WithNodeID(node.NodeID).
+			WithExpressionVariables(map[string]any{
+				"parameters": expressionParameters,
+			}).
+			WithConfigurationFields(hookProvider.Configuration()).
+			Build(contexts.WithoutRunTitleConfiguration(node.Configuration.Data()))
 		if err != nil {
-			logger.Errorf("error finding app installation: %v", err)
-			return nil, grpcerrors.Internal(err, "error building context")
+			return grpcerrors.InvalidArgument(err, "failed to resolve trigger configuration")
 		}
 
-		logger = logging.WithIntegration(logger, *integration)
-		hookCtx.Integration = contexts.NewIntegrationContext(db, node, integration, encryptor, registry, onNewEvents)
-	}
+		var run *models.CanvasRun
+		if shouldRecordTriggeredBy {
+			run, err = models.CreateCanvasRunInTransaction(tx, canvas.ID, node.NodeID, models.CanvasRunStateStarted, "")
+			if err != nil {
+				return err
+			}
 
-	hookCtx.Logger = logger
-	result, err := hookProvider.HandleHook(hookCtx)
+			if err := tx.Model(run).Update("triggered_by", userUUID).Error; err != nil {
+				return err
+			}
+
+			run.TriggeredBy = &userUUID
+		}
+
+		hookCtx := core.TriggerHookContext{
+			Name:          hookName,
+			Parameters:    parameters,
+			Configuration: resolvedConfiguration,
+			HTTP:          registry.HTTPContext(),
+			Metadata:      contexts.NewNodeMetadataContext(tx, node),
+			Requests:      contexts.NewNodeRequestContext(tx, node),
+			Webhook:       contexts.NewNodeWebhookContext(ctx, tx, encryptor, node, webhookBaseURL),
+			Events:        contexts.NewEventContext(tx, node, run, onNewEvents),
+		}
+
+		if node.AppInstallationID != nil {
+			integration, err := models.FindUnscopedIntegrationInTransaction(tx, *node.AppInstallationID)
+			if err != nil {
+				logger.Errorf("error finding app installation: %v", err)
+				return grpcerrors.Internal(err, "error building context")
+			}
+
+			logger = logging.WithIntegration(logger, *integration)
+			hookCtx.Integration = contexts.NewIntegrationContext(tx, node, integration, encryptor, registry, onNewEvents)
+		}
+
+		hookCtx.Logger = logger
+		hookResult, err = hookProvider.HandleHook(hookCtx)
+		if err != nil {
+			logger.Errorf("trigger hook %q execution failed: %v", hookName, err)
+			return grpcerrors.InvalidArgument(err, "hook execution failed")
+		}
+
+		return nil
+	})
 	if err != nil {
-		logger.Errorf("trigger hook %q execution failed: %v", hookName, err)
-		return nil, grpcerrors.InvalidArgument(err, "hook execution failed")
+		return nil, err
 	}
 
 	if len(newEvents) > 0 {
-		if result == nil {
-			result = map[string]any{}
+		if hookResult == nil {
+			hookResult = map[string]any{}
 		}
 
-		if _, exists := result["event_id"]; !exists {
-			result["event_id"] = newEvents[0].ID.String()
+		if _, exists := hookResult["event_id"]; !exists {
+			hookResult["event_id"] = newEvents[0].ID.String()
 		}
 	}
 
@@ -129,7 +160,7 @@ func InvokeNodeTriggerHook(
 	}
 
 	// Convert result to protobuf struct
-	resultStruct, err := newStructpbStruct(result)
+	resultStruct, err := newStructpbStruct(hookResult)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to create result struct")
 	}

--- a/pkg/grpc/actions/canvases/list_runs.go
+++ b/pkg/grpc/actions/canvases/list_runs.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -18,10 +19,29 @@ import (
 	"gorm.io/gorm"
 )
 
-func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uint32, before *timestamppb.Timestamp, states []pb.CanvasRun_State, results []pb.CanvasRun_Result) (*pb.ListRunsResponse, error) {
+func ListRuns(
+	ctx context.Context,
+	db *gorm.DB,
+	canvas *models.Canvas,
+	limit uint32,
+	before *timestamppb.Timestamp,
+	states []pb.CanvasRun_State,
+	results []pb.CanvasRun_Result,
+	triggeredByUserID string,
+) (*pb.ListRunsResponse, error) {
+	if triggeredByUserID != "" {
+		userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
+		if !userIsSet {
+			return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
+		}
+		if userID != triggeredByUserID {
+			return nil, grpcerrors.PermissionDenied(nil, "cannot filter runs for another user")
+		}
+	}
+
 	limit = getLimit(limit)
 	beforeTime := getBefore(before)
-	filters, err := buildCanvasRunFilters(states, results)
+	filters, err := buildCanvasRunFilters(states, results, triggeredByUserID)
 	if err != nil {
 		return nil, err
 	}
@@ -47,6 +67,7 @@ func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uin
 		runDetails.rootEventsByRunID,
 		runDetails.executionsByRunID,
 		runDetails.queueItemsByRunID,
+		runDetails.triggeredByUsersByID,
 		runDetails.parentRunsByRunID,
 		runDetails.childRunsByExecutionID,
 	)
@@ -62,7 +83,11 @@ func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uin
 	}, nil
 }
 
-func buildCanvasRunFilters(states []pb.CanvasRun_State, results []pb.CanvasRun_Result) (models.CanvasRunFilters, error) {
+func buildCanvasRunFilters(
+	states []pb.CanvasRun_State,
+	results []pb.CanvasRun_Result,
+	triggeredByUserID string,
+) (models.CanvasRunFilters, error) {
 	modelStates := make([]string, 0, len(states))
 	for _, state := range states {
 		modelState, err := ProtoRunStateToModel(state)
@@ -83,9 +108,19 @@ func buildCanvasRunFilters(states []pb.CanvasRun_State, results []pb.CanvasRun_R
 		modelResults = append(modelResults, modelResult)
 	}
 
+	var triggeredByUUID *uuid.UUID
+	if triggeredByUserID != "" {
+		id, err := uuid.Parse(triggeredByUserID)
+		if err != nil {
+			return models.CanvasRunFilters{}, grpcerrors.InvalidArgument(err, "invalid triggered_by_user_id")
+		}
+		triggeredByUUID = &id
+	}
+
 	return models.CanvasRunFilters{
-		States:  modelStates,
-		Results: modelResults,
+		States:      modelStates,
+		Results:     modelResults,
+		TriggeredBy: triggeredByUUID,
 	}, nil
 }
 
@@ -119,6 +154,7 @@ func SerializeCanvasRuns(
 	rootEventsByRunID map[string]models.CanvasEvent,
 	executionsByRunID map[string][]models.CanvasNodeExecution,
 	queueItemsByRunID map[string][]models.CanvasNodeQueueItem,
+	triggeredByUsersByID map[uuid.UUID]models.User,
 	parentRunsByRunID map[string]models.CanvasRun,
 	childRunsByExecutionID map[string][]models.CanvasRun,
 ) ([]*pb.CanvasRun, error) {
@@ -136,6 +172,7 @@ func SerializeCanvasRuns(
 			executionsByRunID[run.ID.String()],
 			queueItemsByRunID[run.ID.String()],
 			inputEvents,
+			triggeredByUsersByID,
 			parentRunsByRunID[run.ID.String()],
 			childRunsByExecutionID,
 		)
@@ -155,6 +192,7 @@ func SerializeCanvasRun(
 	rootEvent models.CanvasEvent,
 	executions []models.CanvasNodeExecution,
 	queueItems []models.CanvasNodeQueueItem,
+	triggeredByUsersByID map[uuid.UUID]models.User,
 	parentRun *models.CanvasRun,
 	childRunsByExecutionID map[string][]models.CanvasRun,
 ) (*pb.CanvasRun, error) {
@@ -168,7 +206,16 @@ func SerializeCanvasRun(
 		parent = *parentRun
 	}
 
-	return serializeCanvasRunWithQueueItemInputs(run, rootEvent, executions, queueItems, inputEvents, parent, childRunsByExecutionID)
+	return serializeCanvasRunWithQueueItemInputs(
+		run,
+		rootEvent,
+		executions,
+		queueItems,
+		inputEvents,
+		triggeredByUsersByID,
+		parent,
+		childRunsByExecutionID,
+	)
 }
 
 func serializeCanvasRunWithQueueItemInputs(
@@ -177,6 +224,7 @@ func serializeCanvasRunWithQueueItemInputs(
 	executions []models.CanvasNodeExecution,
 	queueItems []models.CanvasNodeQueueItem,
 	inputEvents []models.CanvasEvent,
+	triggeredByUsersByID map[uuid.UUID]models.User,
 	parentRun models.CanvasRun,
 	childRunsByExecutionID map[string][]models.CanvasRun,
 ) (*pb.CanvasRun, error) {
@@ -227,7 +275,24 @@ func serializeCanvasRunWithQueueItemInputs(
 		serialized.CancelledAt = timestamppb.New(*run.CancelledAt)
 	}
 
+	if run.TriggeredBy != nil {
+		serialized.TriggeredBy = triggeredByRef(run.TriggeredBy, triggeredByUsersByID)
+	}
+
 	return serialized, nil
+}
+
+func triggeredByRef(id *uuid.UUID, users map[uuid.UUID]models.User) *pb.UserRef {
+	if id == nil {
+		return nil
+	}
+
+	name := "Unknown"
+	if user, ok := users[*id]; ok && user.Name != "" {
+		name = user.Name
+	}
+
+	return &pb.UserRef{Id: id.String(), Name: name}
 }
 
 func queueItemsForRuns(runs []models.CanvasRun, queueItemsByRunID map[string][]models.CanvasNodeQueueItem) []models.CanvasNodeQueueItem {
@@ -304,6 +369,7 @@ type runDetailsForRuns struct {
 	rootEventsByRunID      map[string]models.CanvasEvent
 	executionsByRunID      map[string][]models.CanvasNodeExecution
 	queueItemsByRunID      map[string][]models.CanvasNodeQueueItem
+	triggeredByUsersByID   map[uuid.UUID]models.User
 	parentRunsByRunID      map[string]models.CanvasRun
 	childRunsByExecutionID map[string][]models.CanvasRun
 }
@@ -319,6 +385,7 @@ func loadRunDetailsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID,
 			rootEventsByRunID:      map[string]models.CanvasEvent{},
 			executionsByRunID:      map[string][]models.CanvasNodeExecution{},
 			queueItemsByRunID:      map[string][]models.CanvasNodeQueueItem{},
+			triggeredByUsersByID:   map[uuid.UUID]models.User{},
 			parentRunsByRunID:      map[string]models.CanvasRun{},
 			childRunsByExecutionID: map[string][]models.CanvasRun{},
 		}, nil
@@ -327,6 +394,7 @@ func loadRunDetailsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID,
 	var rootEventsByRunID map[string]models.CanvasEvent
 	var executionsByRunID map[string][]models.CanvasNodeExecution
 	var queueItemsByRunID map[string][]models.CanvasNodeQueueItem
+	var triggeredByUsersByID map[uuid.UUID]models.User
 	var parentRunsByRunID map[string]models.CanvasRun
 	var childRunsByExecutionID map[string][]models.CanvasRun
 	g, gctx := errgroup.WithContext(ctx)
@@ -379,6 +447,21 @@ func loadRunDetailsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID,
 		return err
 	})
 
+	g.Go(func() error {
+		ids := triggeredByIDs(runs)
+		users, err := models.FindMaybeDeletedUsersByIDs(db, ids)
+		if err != nil {
+			return err
+		}
+
+		triggeredByUsersByID = make(map[uuid.UUID]models.User, len(users))
+		for _, user := range users {
+			triggeredByUsersByID[user.ID] = user
+		}
+
+		return nil
+	})
+
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
@@ -387,9 +470,28 @@ func loadRunDetailsForRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID,
 		rootEventsByRunID:      rootEventsByRunID,
 		executionsByRunID:      executionsByRunID,
 		queueItemsByRunID:      queueItemsByRunID,
+		triggeredByUsersByID:   triggeredByUsersByID,
 		parentRunsByRunID:      parentRunsByRunID,
 		childRunsByExecutionID: childRunsByExecutionID,
 	}, nil
+}
+
+func triggeredByIDs(runs []models.CanvasRun) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(runs))
+	seen := make(map[uuid.UUID]struct{}, len(runs))
+
+	for _, run := range runs {
+		if run.TriggeredBy == nil {
+			continue
+		}
+		if _, ok := seen[*run.TriggeredBy]; ok {
+			continue
+		}
+		seen[*run.TriggeredBy] = struct{}{}
+		ids = append(ids, *run.TriggeredBy)
+	}
+
+	return ids
 }
 
 func groupExecutionsByRunID(executions []models.CanvasNodeExecution, runCount int) map[string][]models.CanvasNodeExecution {
@@ -415,6 +517,7 @@ func serializeCanvasRuns(
 	rootEventsByRunID map[string]models.CanvasEvent,
 	executionsByRunID map[string][]models.CanvasNodeExecution,
 	queueItemsByRunID map[string][]models.CanvasNodeQueueItem,
+	triggeredByUsersByID map[uuid.UUID]models.User,
 	parentRunsByRunID map[string]models.CanvasRun,
 	childRunsByExecutionID map[string][]models.CanvasRun,
 ) (serialized []*pb.CanvasRun, err error) {
@@ -427,6 +530,7 @@ func serializeCanvasRuns(
 		rootEventsByRunID,
 		executionsByRunID,
 		queueItemsByRunID,
+		triggeredByUsersByID,
 		parentRunsByRunID,
 		childRunsByExecutionID,
 	)

--- a/pkg/grpc/actions/canvases/list_runs_test.go
+++ b/pkg/grpc/actions/canvases/list_runs_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
@@ -33,7 +34,7 @@ func Test__ListRuns__ReturnsRunsWithRootEventsAndExecutionRefs(t *testing.T) {
 	run := createFinishedRun(t, rootEvent, models.CanvasRunResultPassed)
 	execution := createRunExecution(t, run, rootEvent.ID, "node-1", models.CanvasNodeExecutionResultPassed)
 
-	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, nil, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Runs, 1)
@@ -79,7 +80,7 @@ func Test__ListRuns__ReturnsRunsWithQueueItems(t *testing.T) {
 	createStartedRun(t, otherRootEvent)
 	support.CreateQueueItem(t, otherCanvas.ID, "trigger", otherRootEvent.ID, otherRootEvent.ID)
 
-	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, nil, nil, "")
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 2)
 
@@ -113,7 +114,7 @@ func Test__ListRuns__ScopesRunsToCanvas(t *testing.T) {
 	runOne := createFinishedRun(t, rootEventOne, models.CanvasRunResultPassed)
 	createFinishedRun(t, rootEventTwo, models.CanvasRunResultPassed)
 
-	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvasOne, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvasOne, 0, nil, nil, nil, "")
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 1)
 	assert.Equal(t, runOne.ID.String(), response.Runs[0].Id)
@@ -145,6 +146,7 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 		nil,
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_STARTED},
 		[]pb.CanvasRun_Result{pb.CanvasRun_RESULT_PASSED},
+		"",
 	)
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 2)
@@ -163,6 +165,7 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 		nil,
 		nil,
 		[]pb.CanvasRun_Result{pb.CanvasRun_RESULT_FAILED, pb.CanvasRun_RESULT_CANCELLED},
+		"",
 	)
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 2)
@@ -180,11 +183,33 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 		nil,
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_STARTED},
 		nil,
+		"",
 	)
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 1)
 	assert.Equal(t, startedRun.ID.String(), response.Runs[0].Id)
 	assert.Equal(t, uint32(1), response.TotalCount)
+}
+
+func Test__ListRuns__FiltersByTriggeredByUser(t *testing.T) {
+	r := support.Setup(t)
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{{NodeID: "trigger", Type: models.NodeTypeTrigger}}, []models.Edge{})
+
+	rootEventOne := support.EmitCanvasEventForNode(t, canvas.ID, "trigger", "default", nil)
+	runOne := createFinishedRun(t, rootEventOne, models.CanvasRunResultPassed)
+	require.NoError(t, database.Conn().Model(runOne).Update("triggered_by", r.User).Error)
+
+	rootEventTwo := support.EmitCanvasEventForNode(t, canvas.ID, "trigger", "default", nil)
+	_ = createFinishedRun(t, rootEventTwo, models.CanvasRunResultPassed)
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	response, err := ListRuns(ctx, database.DB(t.Context()), canvas, 0, nil, nil, nil, r.User.String())
+	require.NoError(t, err)
+	require.Len(t, response.Runs, 1)
+	assert.Equal(t, runOne.ID.String(), response.Runs[0].Id)
+
+	_, err = ListRuns(ctx, database.DB(t.Context()), canvas, 0, nil, nil, nil, uuid.NewString())
+	require.Error(t, err)
 }
 
 func Test__RunStateMapping__Pending(t *testing.T) {
@@ -207,6 +232,7 @@ func Test__ListRuns__RejectsUnknownFilterValues(t *testing.T) {
 		nil,
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_UNKNOWN},
 		nil,
+		"",
 	)
 	require.Error(t, err)
 
@@ -218,6 +244,7 @@ func Test__ListRuns__RejectsUnknownFilterValues(t *testing.T) {
 		nil,
 		nil,
 		[]pb.CanvasRun_Result{pb.CanvasRun_RESULT_UNKNOWN},
+		"",
 	)
 	require.Error(t, err)
 }
@@ -266,6 +293,7 @@ func Test__ListRuns__ReturnsPendingSubRunWithoutRootEvent(t *testing.T) {
 		nil,
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_PENDING},
 		nil,
+		"",
 	)
 	require.NoError(t, err)
 	require.Len(t, childResponse.Runs, 1)
@@ -273,7 +301,7 @@ func Test__ListRuns__ReturnsPendingSubRunWithoutRootEvent(t *testing.T) {
 	assert.Equal(t, pb.CanvasRun_STATE_PENDING, childResponse.Runs[0].State)
 	assert.Nil(t, childResponse.Runs[0].RootEvent)
 
-	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, nil, nil)
+	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, nil, nil, "")
 	require.NoError(t, err)
 	require.Len(t, parentResponse.Runs, 1)
 	require.Len(t, parentResponse.Runs[0].Executions, 1)
@@ -320,7 +348,7 @@ func Test__ListRuns__ReturnsSubRunRelationshipRefs(t *testing.T) {
 	childRootEvent := support.EmitCanvasEventForNode(t, childCanvas.ID, "onRun", "default", nil)
 	require.NoError(t, database.Conn().Model(&childRootEvent).Update("run_id", childRun.ID).Error)
 
-	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, nil, nil)
+	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, nil, nil, "")
 	require.NoError(t, err)
 	require.Len(t, parentResponse.Runs, 1)
 	require.Len(t, parentResponse.Runs[0].Executions, 1)

--- a/pkg/grpc/canvas_service.go
+++ b/pkg/grpc/canvas_service.go
@@ -287,7 +287,7 @@ func (s *CanvasService) ListRuns(ctx context.Context, req *pb.ListRunsRequest) (
 		return nil, err
 	}
 
-	return canvases.ListRuns(ctx, db, canvas, req.Limit, req.Before, req.States, req.Results)
+	return canvases.ListRuns(ctx, db, canvas, req.Limit, req.Before, req.States, req.Results, req.TriggeredByUserId)
 }
 
 func (s *CanvasService) DescribeRun(ctx context.Context, req *pb.DescribeRunRequest) (*pb.DescribeRunResponse, error) {

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -45,6 +45,7 @@ type CanvasRun struct {
 	UpdatedAt         *time.Time
 	CancelledAt       *time.Time
 	CancelledBy       *uuid.UUID
+	TriggeredBy       *uuid.UUID
 	FinishedAt        *time.Time
 }
 
@@ -438,8 +439,9 @@ func oldestCanvasRunsFirst(tx *gorm.DB) *gorm.DB {
 }
 
 type CanvasRunFilters struct {
-	States  []string
-	Results []string
+	States      []string
+	Results     []string
+	TriggeredBy *uuid.UUID
 }
 
 func ListCanvasRuns(workflowID uuid.UUID, limit int, beforeTime *time.Time, filters CanvasRunFilters) ([]CanvasRun, error) {
@@ -488,6 +490,10 @@ func CountCanvasRunsInTransaction(tx *gorm.DB, workflowID uuid.UUID, filters Can
 }
 
 func applyCanvasRunFilters(query *gorm.DB, filters CanvasRunFilters) *gorm.DB {
+	if filters.TriggeredBy != nil {
+		query = query.Where("triggered_by = ?", *filters.TriggeredBy)
+	}
+
 	hasStates := len(filters.States) > 0
 	hasResults := len(filters.Results) > 0
 

--- a/pkg/workers/eventdistributer/run.go
+++ b/pkg/workers/eventdistributer/run.go
@@ -116,7 +116,7 @@ func handleRunState(workflowID string, runID string, wsHub *ws.Hub) error {
 		return err
 	}
 
-	serializedRun, err := canvases.SerializeCanvasRun(db, *run, rootEvent, executions, queueItems, nil, map[string][]models.CanvasRun{})
+	serializedRun, err := canvases.SerializeCanvasRun(db, *run, rootEvent, executions, queueItems, map[uuid.UUID]models.User{}, nil, map[string][]models.CanvasRun{})
 	if err != nil {
 		return fmt.Errorf("failed to serialize run: %w", err)
 	}

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -780,6 +780,7 @@ message ListRunsRequest {
   google.protobuf.Timestamp before = 3;
   repeated CanvasRun.State states = 4;
   repeated CanvasRun.Result results = 5;
+  string triggered_by_user_id = 6;
 }
 
 message ListRunsResponse {
@@ -901,6 +902,7 @@ message CanvasRun {
   repeated CanvasNodeQueueItem queue_items = 11;
   google.protobuf.Timestamp cancelled_at = 12;
   CanvasRunRef parent = 13;
+  UserRef triggered_by = 14;
 }
 
 message CanvasRunRef {

--- a/web_src/src/components/CanvasToolSidebar/RunFiltersPopover.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunFiltersPopover.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import { RunStatusFilterSection, RunTriggerFilterSection, type TriggerOption } from "@/ui/Runs/RunFilterSections";
@@ -11,26 +12,31 @@ export type { TriggerOption };
 interface RunFiltersPopoverProps {
   selectedStatuses: Set<RunStatusFilter>;
   selectedTriggerIds: Set<string>;
+  myRunsOnly: boolean;
   triggerOptions: TriggerOption[];
   onToggleStatus: (status: RunStatusFilter) => void;
   onClearStatuses: () => void;
   onToggleTrigger: (triggerId: string) => void;
   onClearTriggers: () => void;
+  onMyRunsOnlyChange: (enabled: boolean) => void;
 }
 
 export function RunFiltersPopover({
   selectedStatuses,
   selectedTriggerIds,
+  myRunsOnly,
   triggerOptions,
   onToggleStatus,
   onClearStatuses,
   onToggleTrigger,
   onClearTriggers,
+  onMyRunsOnlyChange,
 }: RunFiltersPopoverProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const hasMyRunsFilter = myRunsOnly;
   const hasStatusFilter = selectedStatuses.size > 0;
   const hasTriggerFilter = selectedTriggerIds.size > 0;
-  const totalFilters = selectedTriggerIds.size + selectedStatuses.size;
+  const totalFilters = selectedTriggerIds.size + selectedStatuses.size + (hasMyRunsFilter ? 1 : 0);
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
@@ -41,7 +47,7 @@ export function RunFiltersPopover({
           size="icon-xs"
           className={cn(
             "relative shrink-0 hover:bg-gray-100 dark:hover:bg-gray-800",
-            hasTriggerFilter || hasStatusFilter
+            hasTriggerFilter || hasStatusFilter || hasMyRunsFilter
               ? "text-sky-700 hover:bg-sky-100 dark:text-indigo-300 dark:hover:bg-gray-800"
               : "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200",
           )}
@@ -49,7 +55,7 @@ export function RunFiltersPopover({
           title="Filter runs"
         >
           <ListFilter className="size-3.5 shrink-0" aria-hidden />
-          {hasTriggerFilter || hasStatusFilter ? (
+          {hasTriggerFilter || hasStatusFilter || hasMyRunsFilter ? (
             <span className="absolute -right-0.5 -top-0.5 flex h-3 min-w-3 items-center justify-center rounded-full bg-sky-500 px-0.5 text-[8px] font-semibold leading-none text-white dark:bg-indigo-300 dark:text-indigo-950">
               {totalFilters}
             </span>
@@ -61,6 +67,12 @@ export function RunFiltersPopover({
         className="w-64 border-slate-950/20 bg-white p-0 shadow-md dark:border-gray-800/70 dark:bg-gray-900"
         sideOffset={4}
       >
+        <div className="border-b border-slate-950/10 dark:border-gray-800/70">
+          <label className="flex cursor-pointer items-center gap-2 px-3 py-2 text-[12px] text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800">
+            <Checkbox checked={myRunsOnly} onChange={() => onMyRunsOnlyChange(!myRunsOnly)} className="size-3.5" />
+            <span className="min-w-0 truncate">My runs</span>
+          </label>
+        </div>
         <RunStatusFilterSection
           selectedStatuses={selectedStatuses}
           onToggleStatus={onToggleStatus}

--- a/web_src/src/components/CanvasToolSidebar/RunsTabListView.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabListView.tsx
@@ -30,6 +30,7 @@ interface RunsTabListViewProps {
   hasAnyFilter: boolean;
   selectedStatuses: Set<RunStatusFilter>;
   selectedTriggerIds: Set<string>;
+  myRunsOnly: boolean;
   searchQuery: string;
   triggerOptions: TriggerOption[];
   onToggleStatus: (status: RunStatusFilter) => void;
@@ -37,6 +38,7 @@ interface RunsTabListViewProps {
   onToggleTrigger: (triggerId: string) => void;
   onClearTriggers: () => void;
   onSearchQueryChange: (query: string) => void;
+  onMyRunsOnlyChange: (enabled: boolean) => void;
 }
 
 export function RunsTabListView({
@@ -56,6 +58,7 @@ export function RunsTabListView({
   hasAnyFilter,
   selectedStatuses,
   selectedTriggerIds,
+  myRunsOnly,
   searchQuery,
   triggerOptions,
   onToggleStatus,
@@ -63,6 +66,7 @@ export function RunsTabListView({
   onToggleTrigger,
   onClearTriggers,
   onSearchQueryChange,
+  onMyRunsOnlyChange,
 }: RunsTabListViewProps) {
   return (
     <div
@@ -73,6 +77,7 @@ export function RunsTabListView({
       <RunsToolbar
         selectedStatuses={selectedStatuses}
         selectedTriggerIds={selectedTriggerIds}
+        myRunsOnly={myRunsOnly}
         searchQuery={searchQuery}
         triggerOptions={triggerOptions}
         onToggleStatus={onToggleStatus}
@@ -80,6 +85,7 @@ export function RunsTabListView({
         onToggleTrigger={onToggleTrigger}
         onClearTriggers={onClearTriggers}
         onSearchQueryChange={onSearchQueryChange}
+        onMyRunsOnlyChange={onMyRunsOnlyChange}
       />
 
       <div

--- a/web_src/src/components/CanvasToolSidebar/RunsTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabPanel.tsx
@@ -148,6 +148,7 @@ export function RunsTabPanelContent({
           hasAnyFilter={filterState.hasAnyFilter}
           selectedStatuses={filterState.selectedStatuses}
           selectedTriggerIds={filterState.selectedTriggerIds}
+          myRunsOnly={filterState.myRunsOnly}
           searchQuery={filterState.searchQuery}
           triggerOptions={filterState.triggerOptions}
           onToggleStatus={filterState.toggleStatus}
@@ -155,6 +156,7 @@ export function RunsTabPanelContent({
           onToggleTrigger={filterState.toggleTrigger}
           onClearTriggers={filterState.clearTriggers}
           onSearchQueryChange={filterState.setSearchQuery}
+          onMyRunsOnlyChange={filterState.setMyRunsOnly}
         />
       </div>
     </div>

--- a/web_src/src/components/CanvasToolSidebar/RunsToolbar.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsToolbar.tsx
@@ -9,6 +9,7 @@ import { RUNS_SIDEBAR_ROW_CLASS } from "./runsSidebarRowLayout";
 interface RunsToolbarProps {
   selectedStatuses: Set<RunStatusFilter>;
   selectedTriggerIds: Set<string>;
+  myRunsOnly: boolean;
   searchQuery: string;
   triggerOptions: TriggerOption[];
   onToggleStatus: (status: RunStatusFilter) => void;
@@ -16,11 +17,13 @@ interface RunsToolbarProps {
   onToggleTrigger: (triggerId: string) => void;
   onClearTriggers: () => void;
   onSearchQueryChange: (query: string) => void;
+  onMyRunsOnlyChange: (enabled: boolean) => void;
 }
 
 export function RunsToolbar({
   selectedStatuses,
   selectedTriggerIds,
+  myRunsOnly,
   searchQuery,
   triggerOptions,
   onToggleStatus,
@@ -28,6 +31,7 @@ export function RunsToolbar({
   onToggleTrigger,
   onClearTriggers,
   onSearchQueryChange,
+  onMyRunsOnlyChange,
 }: RunsToolbarProps) {
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     onSearchQueryChange(event.target.value);
@@ -62,11 +66,13 @@ export function RunsToolbar({
       <RunFiltersPopover
         selectedStatuses={selectedStatuses}
         selectedTriggerIds={selectedTriggerIds}
+        myRunsOnly={myRunsOnly}
         triggerOptions={triggerOptions}
         onToggleStatus={onToggleStatus}
         onClearStatuses={onClearStatuses}
         onToggleTrigger={onToggleTrigger}
         onClearTriggers={onClearTriggers}
+        onMyRunsOnlyChange={onMyRunsOnlyChange}
       />
     </div>
   );

--- a/web_src/src/components/CanvasToolSidebar/filterPersistence.ts
+++ b/web_src/src/components/CanvasToolSidebar/filterPersistence.ts
@@ -5,16 +5,17 @@ export const RUNS_SIDEBAR_FILTERS_STORAGE_KEY = "runs-sidebar-filters";
 export type PersistedFilters = {
   statuses: Set<RunStatusFilter>;
   triggerIds: Set<string>;
+  myRunsOnly: boolean;
 };
 
 export function loadPersistedFilters(): PersistedFilters {
-  if (typeof window === "undefined") return { statuses: new Set(), triggerIds: new Set() };
+  if (typeof window === "undefined") return { statuses: new Set(), triggerIds: new Set(), myRunsOnly: false };
 
   try {
     const raw = window.localStorage.getItem(RUNS_SIDEBAR_FILTERS_STORAGE_KEY);
-    if (!raw) return { statuses: new Set(), triggerIds: new Set() };
+    if (!raw) return { statuses: new Set(), triggerIds: new Set(), myRunsOnly: false };
 
-    const parsed = JSON.parse(raw) as { statuses?: unknown; triggerIds?: unknown };
+    const parsed = JSON.parse(raw) as { statuses?: unknown; triggerIds?: unknown; myRunsOnly?: unknown };
     const validStatuses = new Set<RunStatusFilter>(RUN_STATUS_FILTER_OPTIONS.map((option) => option.id));
     const statuses = new Set<RunStatusFilter>(
       Array.isArray(parsed.statuses)
@@ -29,10 +30,11 @@ export function loadPersistedFilters(): PersistedFilters {
         ? parsed.triggerIds.filter((triggerId: unknown): triggerId is string => typeof triggerId === "string")
         : [],
     );
+    const myRunsOnly = typeof parsed.myRunsOnly === "boolean" ? parsed.myRunsOnly : false;
 
-    return { statuses, triggerIds };
+    return { statuses, triggerIds, myRunsOnly };
   } catch {
-    return { statuses: new Set(), triggerIds: new Set() };
+    return { statuses: new Set(), triggerIds: new Set(), myRunsOnly: false };
   }
 }
 
@@ -44,6 +46,7 @@ export function savePersistedFilters(filters: PersistedFilters): void {
       JSON.stringify({
         statuses: Array.from(filters.statuses),
         triggerIds: Array.from(filters.triggerIds),
+        myRunsOnly: filters.myRunsOnly,
       }),
     );
   } catch {

--- a/web_src/src/components/CanvasToolSidebar/useRunFilters.ts
+++ b/web_src/src/components/CanvasToolSidebar/useRunFilters.ts
@@ -11,11 +11,19 @@ interface UseRunFiltersParams {
   workflowNodes: ComponentsNode[];
   componentIconMap: Record<string, string>;
   onStatusFiltersChange?: (filters: RunStatusFilter[]) => void;
+  onMyRunsOnlyChange?: (enabled: boolean) => void;
 }
 
-export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusFiltersChange }: UseRunFiltersParams) {
+export function useRunFilters({
+  runs,
+  workflowNodes,
+  componentIconMap,
+  onStatusFiltersChange,
+  onMyRunsOnlyChange,
+}: UseRunFiltersParams) {
   const [selectedTriggerIds, setSelectedTriggerIds] = useState<Set<string>>(() => loadPersistedFilters().triggerIds);
   const [selectedStatuses, setSelectedStatuses] = useState<Set<RunStatusFilter>>(() => loadPersistedFilters().statuses);
+  const [myRunsOnly, setMyRunsOnly] = useState<boolean>(() => loadPersistedFilters().myRunsOnly);
   const [searchQuery, setSearchQuery] = useState("");
 
   const nodeMap = useMemo(() => buildNodeMap(workflowNodes), [workflowNodes]);
@@ -36,8 +44,9 @@ export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusF
 
   useEffect(() => {
     onStatusFiltersChange?.(Array.from(selectedStatuses));
-    savePersistedFilters({ statuses: selectedStatuses, triggerIds: selectedTriggerIds });
-  }, [selectedStatuses, selectedTriggerIds, onStatusFiltersChange]);
+    onMyRunsOnlyChange?.(myRunsOnly);
+    savePersistedFilters({ statuses: selectedStatuses, triggerIds: selectedTriggerIds, myRunsOnly });
+  }, [selectedStatuses, selectedTriggerIds, myRunsOnly, onStatusFiltersChange, onMyRunsOnlyChange]);
 
   useEffect(() => {
     if (triggerOptions.length === 0) return;
@@ -79,11 +88,12 @@ export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusF
   );
 
   const hasSearchFilter = searchQuery.trim().length > 0;
-  const hasAnyFilter = selectedTriggerIds.size > 0 || selectedStatuses.size > 0 || hasSearchFilter;
+  const hasAnyFilter = myRunsOnly || selectedTriggerIds.size > 0 || selectedStatuses.size > 0 || hasSearchFilter;
 
   const clearFilters = useCallback(() => {
     setSelectedStatuses(new Set());
     setSelectedTriggerIds(new Set());
+    setMyRunsOnly(false);
     setSearchQuery("");
   }, []);
 
@@ -108,6 +118,7 @@ export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusF
   return {
     selectedStatuses,
     selectedTriggerIds,
+    myRunsOnly,
     searchQuery,
     triggerOptions,
     filteredRuns,
@@ -118,6 +129,7 @@ export function useRunFilters({ runs, workflowNodes, componentIconMap, onStatusF
     clearFilters,
     toggleStatus,
     toggleTrigger,
+    setMyRunsOnly,
     clearStatuses: () => setSelectedStatuses(new Set()),
     clearTriggers: () => setSelectedTriggerIds(new Set()),
   };

--- a/web_src/src/hooks/canvasInfiniteCache.spec.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.spec.ts
@@ -38,11 +38,13 @@ describe("parseRunsFiltersFromQueryKey", () => {
     const queryKey = canvasKeys.infiniteRuns("canvas-1", {
       states: ["STATE_STARTED"],
       results: ["RESULT_FAILED", "RESULT_CANCELLED"],
+      triggeredByUserId: "user-1",
     });
 
     expect(parseRunsFiltersFromQueryKey(queryKey)).toEqual({
       states: ["STATE_STARTED"],
       results: ["RESULT_FAILED", "RESULT_CANCELLED"],
+      triggeredByUserId: "user-1",
     });
   });
 
@@ -56,10 +58,17 @@ describe("runMatchesFilters", () => {
     const run = makeRun({ state: "STATE_FINISHED", result: "RESULT_PASSED" });
 
     expect(runMatchesFilters(run, {})).toBe(true);
+    expect(runMatchesFilters(run, { triggeredByUserId: "user-1" })).toBe(false);
     expect(runMatchesFilters(run, { states: ["STATE_FINISHED"] })).toBe(true);
     expect(runMatchesFilters(run, { results: ["RESULT_PASSED"] })).toBe(true);
     expect(runMatchesFilters(run, { states: ["STATE_STARTED"] })).toBe(false);
     expect(runMatchesFilters(run, { results: ["RESULT_FAILED"] })).toBe(false);
+  });
+
+  it("matches runs against triggered-by filters", () => {
+    const run = makeRun({ triggeredBy: { id: "user-1", name: "Me" } });
+    expect(runMatchesFilters(run, { triggeredByUserId: "user-1" })).toBe(true);
+    expect(runMatchesFilters(run, { triggeredByUserId: "user-2" })).toBe(false);
   });
 });
 

--- a/web_src/src/hooks/canvasInfiniteCache.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.ts
@@ -66,6 +66,15 @@ export function parseRunsFiltersFromQueryKey(queryKey: readonly unknown[]): Canv
   const filters: CanvasRunsFilters = {};
   let index = infiniteIndex + 1;
 
+  if (queryKey[index] === "triggeredByUserId") {
+    index += 1;
+    const value = queryKey[index];
+    if (typeof value === "string" && value.length > 0) {
+      filters.triggeredByUserId = value;
+    }
+    index += 1;
+  }
+
   if (queryKey[index] === "states") {
     index += 1;
     const states: CanvasesCanvasRunState[] = [];
@@ -94,6 +103,10 @@ export function parseRunsFiltersFromQueryKey(queryKey: readonly unknown[]): Canv
 }
 
 export function runMatchesFilters(run: CanvasesCanvasRun, filters: CanvasRunsFilters): boolean {
+  if (filters.triggeredByUserId && run.triggeredBy?.id !== filters.triggeredByUserId) {
+    return false;
+  }
+
   if (filters.states?.length && (!run.state || !filters.states.includes(run.state))) {
     return false;
   }

--- a/web_src/src/hooks/useCanvasData.spec.ts
+++ b/web_src/src/hooks/useCanvasData.spec.ts
@@ -149,6 +149,7 @@ describe("useInfiniteCanvasRuns", () => {
         useInfiniteCanvasRuns("canvas-1", {
           states: ["STATE_FINISHED"],
           results: ["RESULT_FAILED", "RESULT_CANCELLED"],
+          triggeredByUserId: "user-1",
         }),
       {
         wrapper: createWrapper(queryClient),
@@ -163,6 +164,7 @@ describe("useInfiniteCanvasRuns", () => {
             limit: 25,
             states: ["STATE_FINISHED"],
             results: ["RESULT_FAILED", "RESULT_CANCELLED"],
+            triggeredByUserId: "user-1",
           },
         }),
       );

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -159,6 +159,7 @@ export const canvasKeys = {
       ...canvasKeys.runs(),
       canvasId,
       "infinite",
+      ...(filters?.triggeredByUserId ? ["triggeredByUserId", filters.triggeredByUserId] : []),
       ...(filters?.states?.length ? ["states", ...filters.states] : []),
       ...(filters?.results?.length ? ["results", ...filters.results] : []),
     ] as const,
@@ -1034,6 +1035,7 @@ export const useDeleteCanvas = (organizationId: string) => {
 export type CanvasRunsFilters = {
   states?: CanvasesCanvasRunState[];
   results?: CanvasesCanvasRunResult[];
+  triggeredByUserId?: string;
 };
 
 export const useDescribeRun = (canvasId: string, runId: string | null, enabled = true) => {
@@ -1101,6 +1103,7 @@ export const useInfiniteCanvasRuns = (canvasId: string, filters: CanvasRunsFilte
             limit,
             ...(filters.states?.length ? { states: filters.states } : {}),
             ...(filters.results?.length ? { results: filters.results } : {}),
+            ...(filters.triggeredByUserId ? { triggeredByUserId: filters.triggeredByUserId } : {}),
             ...(pageParam ? { before: pageParam } : {}),
           },
         }),

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -432,9 +432,16 @@ export function AppPage() {
   const canvasNodes = canvas?.spec?.nodes ?? EMPTY_CANVAS_SPEC_ITEMS;
 
   const [runStatusFilters, setRunStatusFilters] = useState<RunStatusFilter[]>([]);
+  const [myRunsOnly, setMyRunsOnly] = useState(false);
   const runApiFilters = useMemo(
-    () => (isRunInspectionMode && selectedRunId ? {} : statusFiltersToApiFilters(runStatusFilters)),
-    [isRunInspectionMode, selectedRunId, runStatusFilters],
+    () => {
+      if (isRunInspectionMode && selectedRunId) return {};
+      const base = statusFiltersToApiFilters(runStatusFilters);
+      if (!myRunsOnly) return base;
+      if (!me?.id) return base;
+      return { ...base, triggeredByUserId: me.id };
+    },
+    [isRunInspectionMode, selectedRunId, runStatusFilters, myRunsOnly, me?.id],
   );
   const infiniteRunsQuery = useInfiniteCanvasRuns(canvasId!, runApiFilters, showLiveActivity);
   const infiniteLogRunsQuery = useInfiniteCanvasRuns(canvasId!, {}, isViewingLiveVersion);
@@ -508,6 +515,7 @@ export function AppPage() {
     workflowNodes: canvasNodes,
     componentIconMap,
     onStatusFiltersChange: setRunStatusFilters,
+    onMyRunsOnlyChange: setMyRunsOnly,
   });
   const {
     data: canvasMemoryEntries = [],

--- a/web_src/src/pages/app/useRunSidebarNavigationState.ts
+++ b/web_src/src/pages/app/useRunSidebarNavigationState.ts
@@ -11,6 +11,7 @@ interface UseRunSidebarNavigationStateParams {
   workflowNodes: ComponentsNode[];
   componentIconMap: Record<string, string>;
   onStatusFiltersChange: (filters: RunStatusFilter[]) => void;
+  onMyRunsOnlyChange: (enabled: boolean) => void;
 }
 
 export function useRunSidebarNavigationState({
@@ -20,8 +21,9 @@ export function useRunSidebarNavigationState({
   workflowNodes,
   componentIconMap,
   onStatusFiltersChange,
+  onMyRunsOnlyChange,
 }: UseRunSidebarNavigationStateParams) {
-  const runFilterState = useRunFilters({ runs, workflowNodes, componentIconMap, onStatusFiltersChange });
+  const runFilterState = useRunFilters({ runs, workflowNodes, componentIconMap, onStatusFiltersChange, onMyRunsOnlyChange });
   const runNavigation = useMemo(
     () =>
       getRunSidebarNavigation(runFilterState.orderedRuns, selectedRunId, {


### PR DESCRIPTION
## Summary
- Track the authenticated SuperPlane user on manually triggered canvas runs.
- Add a “My runs” filter for runs triggered by the current user.
- Exclude webhook and automatic schedule runs from the user-triggered filter.

Fixes #6377

## Testing
- `make dev.setup.go`
- `make check.proto.field.numbers`
- `make check.build.app`
- `make format.go`
- `git diff --check`