### PR TITLE
fix: allow clearing and retyping number configuration fields

### DIFF
--- a/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.spec.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConfigurationField } from "@/api-client";
+
+import { NumberFieldRenderer } from "./NumberFieldRenderer";
+
+function numberField(overrides: Partial<ConfigurationField> = {}): ConfigurationField {
+  return {
+    name: "minutes",
+    type: "number",
+    label: "Minutes between triggers",
+    ...overrides,
+  } as ConfigurationField;
+}
+
+/** Renders the field the way forms do: the parent owns the value. */
+function ControlledHarness({
+  field,
+  initialValue,
+  onChangeSpy,
+}: {
+  field: ConfigurationField;
+  initialValue?: unknown;
+  onChangeSpy: (value: unknown) => void;
+}) {
+  const [value, setValue] = useState<unknown>(initialValue);
+  return (
+    <NumberFieldRenderer
+      field={field}
+      value={value}
+      onChange={(next) => {
+        onChangeSpy(next);
+        setValue(next);
+      }}
+    />
+  );
+}
+
+describe("NumberFieldRenderer", () => {
+  it("initializes an empty value from the field default on mount", () => {
+    const onChange = vi.fn();
+    render(<ControlledHarness field={numberField({ defaultValue: "1" })} onChangeSpy={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith(1);
+    expect(screen.getByRole("spinbutton")).toHaveValue(1);
+  });
+
+  it("lets the user clear the field without snapping back to the default", () => {
+    const onChange = vi.fn();
+    render(<ControlledHarness field={numberField({ defaultValue: "1" })} onChangeSpy={onChange} />);
+
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "" } });
+
+    // The cleared state must survive: no effect may re-apply the default mid-edit.
+    expect(input).toHaveValue(null);
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it("lets the user clear and type a new number (the spinner must not be the only way)", () => {
+    const onChange = vi.fn();
+    render(<ControlledHarness field={numberField({ defaultValue: "1" })} onChangeSpy={onChange} />);
+
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.change(input, { target: { value: "5" } });
+
+    expect(input).toHaveValue(5);
+    expect(onChange).toHaveBeenLastCalledWith(5);
+  });
+
+  it("syncs an external value change into the input", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<NumberFieldRenderer field={numberField()} value={7} onChange={onChange} />);
+    expect(screen.getByRole("spinbutton")).toHaveValue(7);
+
+    rerender(<NumberFieldRenderer field={numberField()} value={42} onChange={onChange} />);
+    expect(screen.getByRole("spinbutton")).toHaveValue(42);
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.tsx
@@ -1,27 +1,57 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import type { FieldRendererProps } from "./types";
 
 export const NumberFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange }) => {
   const numberOptions = field.typeOptions?.number;
 
-  // Set initial value on first render if no value is present but there's a default
+  // The input's text is kept as a local draft so a transiently empty field is
+  // allowed while the user edits: clearing must not snap back to the default.
+  const [draft, setDraft] = useState<string>(() =>
+    value !== undefined && value !== null
+      ? String(value)
+      : field.defaultValue !== undefined
+        ? String(field.defaultValue)
+        : "",
+  );
+
+  // The last value this component reported upward. Lets the sync effect below
+  // distinguish our own echoes from genuinely external value changes.
+  const lastEmitted = useRef<unknown>(value);
+
+  // Apply the field default ONCE on mount when no value is present. Running
+  // this on every undefined value would fight the user clearing the field.
+  const initialized = useRef(false);
   useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
     if ((value === undefined || value === null) && field.defaultValue !== undefined) {
       const defaultVal = Number(field.defaultValue);
       if (!isNaN(defaultVal)) {
+        lastEmitted.current = defaultVal;
         onChange(defaultVal);
       }
     }
   }, [value, field.defaultValue, onChange]);
 
+  // External value changes (form reset, YAML edit, template apply) sync into
+  // the draft; our own emitted values do not, so mid-edit state is preserved.
+  useEffect(() => {
+    if (value === lastEmitted.current) return;
+    lastEmitted.current = value;
+    setDraft(value === undefined || value === null ? "" : String(value));
+  }, [value]);
+
   return (
     <Input
       type="number"
-      value={(value as string | number) ?? (field.defaultValue as string) ?? ""}
+      value={draft}
       onChange={(e) => {
-        const val = e.target.value === "" ? undefined : Number(e.target.value);
-        onChange(val);
+        const raw = e.target.value;
+        setDraft(raw);
+        const parsed = raw === "" ? undefined : Number(raw);
+        lastEmitted.current = parsed;
+        onChange(parsed);
       }}
       placeholder={field.placeholder || ""}
       min={numberOptions?.min}


### PR DESCRIPTION
Closes #6399

## Problem

The default-value effect in `NumberFieldRenderer` re-applied `field.defaultValue` on every render where the value was `undefined` — including the moment a user cleared the input to type a new number. The field snapped back to the default before the new value could be entered, leaving the spinner arrows as the only way to change any number configuration field (shared renderer → affects all components' forms).

## Fix

- Keep the input text as a **local draft** so a transiently empty field survives editing.
- Apply the field default **once on mount** only, instead of on every `undefined` value.
- Sync genuinely **external** value changes (form reset, YAML edit, template apply) into the draft while ignoring the component's own emitted echoes (tracked via a `lastEmitted` ref).

## Testing

- Adds the renderer's first spec (`NumberFieldRenderer.spec.tsx`), 4 cases: default initialization on mount · clear without snap-back (regression for #6399) · retype after clear · external value sync.
- Full `configurationFieldRenderer` suite: 77/77 passing.
- `npm run lint:budget` within budget; prettier-formatted.
- Manually verified in the dev instance: the Schedule trigger's "Minutes between triggers" can now be cleared and retyped.
