### PR TITLE
fix: handle empty repositories in Software Factory

### DIFF
--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import yaml from "js-yaml";
+
 import { getFactoryDefinition } from "./index";
 import {
   FACTORY_CANVAS_ID_PLACEHOLDER,
@@ -23,6 +25,24 @@ function materializeSoftwareFactory() {
       claude: { id: "int-2", name: "acme-claude", ready: true },
     },
   });
+}
+
+type FactoryCanvasNode = {
+  id?: string;
+  configuration?: { script?: unknown };
+};
+
+// Materializes the Software Factory and returns the generated Create Branch
+// runner script, so regression coverage can assert on its actual behavior
+// instead of substring-matching the whole ~1,400-line template.
+function findCreateBranchScript(canvasYaml: string): string {
+  const doc = yaml.load(canvasYaml) as { spec?: { nodes?: FactoryCanvasNode[] } };
+  const node = doc.spec?.nodes?.find((n) => n.id === "runner-create-branch-2");
+  const script = node?.configuration?.script;
+  if (typeof script !== "string") {
+    throw new Error("runner-create-branch-2 configuration.script not found in materialized canvas");
+  }
+  return script;
 }
 
 describe("materializeFactoryTemplate", () => {
@@ -118,5 +138,41 @@ spec:
       template: "Create Task",
       description: "fix a bug",
     });
+  });
+});
+
+describe("Software Factory Create Branch", () => {
+  it("handles empty repositories when the default branch has no remote ref", () => {
+    const script = findCreateBranchScript(materializeSoftwareFactory());
+
+    // Resolves the configured default branch dynamically; never hardcodes `main`.
+    expect(script).toContain('gh api "repos/${REPO}" --jq .default_branch');
+    expect(script).not.toMatch(/--branch main\b/);
+    expect(script).not.toMatch(/checkout --orphan main\b/);
+    expect(script).not.toMatch(/push -u origin main\b/);
+    expect(script).not.toMatch(/checkout -b main\b/);
+
+    // Lists remote branch refs once so real git failures (auth/network/permission)
+    // are not misclassified as an empty repository.
+    expect(script).toMatch(/git ls-remote --heads "\$GITURL"/);
+    expect(script).toMatch(/Failed to list remote branches/);
+    expect(script).toMatch(/exit 1/);
+
+    // Existing-repository path is preserved: shallow clone of the default branch.
+    expect(script).toMatch(/git clone --depth 1 --branch "\$BASE"/);
+
+    // Empty-repository fallback: clone without --branch, initialize, push base.
+    expect(script).toMatch(/git clone "\$GITURL" "\$WORKDIR"/);
+    expect(script).toMatch(/git checkout --orphan "\$BASE"/);
+    expect(script).toMatch(/git push -u origin "\$BASE"/);
+
+    // Work branch is still created and pushed from the base commit.
+    expect(script).toMatch(/git checkout -b "\$BRANCH"/);
+    expect(script).toMatch(/git push -u origin "\$BRANCH"/);
+
+    // Result JSON contract is unchanged (base = resolved default branch).
+    expect(script).toContain("SUPERPLANE_RESULT_FILE");
+    expect(script).toMatch(/"branch":"%s"/);
+    expect(script).toMatch(/"base":"%s"/);
   });
 });

--- a/web_src/src/pages/home/factories/software-factory/canvas.yaml
+++ b/web_src/src/pages/home/factories/software-factory/canvas.yaml
@@ -771,8 +771,27 @@ spec:
           git config --global user.email "automation@example.com"
           git config --global user.name "Factory Automation"
 
-          git clone --depth 1 --branch "$BASE" "$GITURL" "$WORKDIR"
-          cd "$WORKDIR"
+          # Distinguish a missing default-branch ref (empty repository) from real
+          # git failures, so auth/network/permission errors are not misclassified
+          # as an empty repository. List every remote head once; if the command
+          # itself fails, abort loudly. Only an absent refs/heads/$BASE ref takes
+          # the empty-repository path.
+          REMOTE_HEADS="$(git ls-remote --heads "$GITURL")" || {
+            echo "Failed to list remote branches for ${REPO}" >&2
+            exit 1
+          }
+
+          if printf '%s\n' "$REMOTE_HEADS" | grep -Eq "refs/heads/${BASE}\$"; then
+            git clone --depth 1 --branch "$BASE" "$GITURL" "$WORKDIR"
+            cd "$WORKDIR"
+          else
+            echo "Repository has no ${BASE} branch; initializing empty repository"
+            git clone "$GITURL" "$WORKDIR"
+            cd "$WORKDIR"
+            git checkout --orphan "$BASE"
+            git commit -s --allow-empty -m "chore: initialize ${BASE}"
+            git push -u origin "$BASE"
+          fi
 
           # Create an empty branch off the base: a single empty commit so a draft PR can be opened,
           # with no files added.


### PR DESCRIPTION
## What changed
- Initialize the configured default branch when a Software Factory targets an empty repository.
- Preserve the existing shallow-clone path for repositories that already have a default branch.
- Add focused regression coverage for the generated Create Branch script.

## Why
Empty repositories have a configured default branch name but no corresponding remote branch ref, so `git clone --branch "$BASE"` fails with `fatal: Remote branch ... not found` before the factory can create its work branch or draft PR.

## How
The Create Branch runner now lists remote heads once with `git ls-remote --heads`. If that command itself fails, it exits with a clear error so authentication, network, and permission failures are not misclassified as an empty repository. When the command succeeds but `refs/heads/$BASE` is absent, it clones without `--branch`, creates the configured default branch as an orphan with a signed empty commit, pushes it, then continues through the existing work-branch flow. The configured default branch is resolved dynamically from `gh api repos/$REPO --jq .default_branch`; `main` is never hardcoded. The result JSON contract (`branch`, `base`) is unchanged, so the downstream Open Draft PR node keeps working.

## Testing
- `cd web_src && npm run test:run -- src/pages/home/factories/materializeFactoryTemplate.spec.ts` -> 8 passed (8); the new empty-repository case failed first (TDD red) and passes after the fix.
- `make format.js` -> no unintended changes; only the two intended files in `git status`.
- `make check.lint.ui` -> WITHIN BUDGET 590/591.
- `make check.build.ui` -> built in 6.03s (after `make dev.up && make dev.setup` generated the api-client SDK); also proven build-neutral via an empty before/after `tsc` error diff.
- Manual shell validation on disposable local bare repos, all cases passed:
  - Non-empty repo with a non-main default branch (`develop`): existing path, base and work branch present remotely, result JSON `{"branch":"...","base":"develop"}`.
  - Truly empty repo whose configured default branch (`main`) has no ref: empty path, default branch initialized and pushed, work branch created and pushed.
  - Repo with only a `mainline` branch and `BASE=main`: correctly took the empty path (the end-anchored `refs/heads/$BASE$` match did not false-positive on `refs/heads/mainline`).
  - Missing/unreadable remote: `git ls-remote` failed and the script exited 1, not treated as an empty repository.

Closes #6366