### PR TITLE
fix: route widget show expressions through the CEL evaluator

### DIFF
--- a/web_src/src/pages/app/console/widget/showExpression.spec.ts
+++ b/web_src/src/pages/app/console/widget/showExpression.spec.ts
@@ -1,30 +1,162 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { evaluateShow } from "./showExpression";
 
+// Security property: `evaluateShow` never routes the expression through
+// `eval` / `new Function`. Clauses are interpreted by the CEL engine
+// (`@marcbachmann/cel-js` via `celExpr.ts`), which walks its own AST, so
+// widgets imported from untrusted YAML cannot execute arbitrary JS — see
+// the "sandbox escape" test below.
+//
+// Note on `defaultValue` in the newer tests: we deliberately pass the
+// OPPOSITE of the expected result so a silent fail-soft fallback can never
+// masquerade as a correct evaluation.
+
 describe("evaluateShow", () => {
-  it("evaluates string equality", () => {
-    expect(evaluateShow('row.status == "failed"', { status: "failed" })).toBe(true);
-    expect(evaluateShow('row.status == "failed"', { status: "passed" })).toBe(false);
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it("evaluates numeric comparisons", () => {
-    expect(evaluateShow("row.count > 5", { count: 10 })).toBe(true);
-    expect(evaluateShow("row.count > 5", { count: 1 })).toBe(false);
+  describe("legacy expression forms", () => {
+    it("evaluates string equality", () => {
+      expect(evaluateShow('row.status == "failed"', { status: "failed" })).toBe(true);
+      expect(evaluateShow('row.status == "failed"', { status: "passed" })).toBe(false);
+    });
+
+    it("evaluates numeric comparisons", () => {
+      expect(evaluateShow("row.count > 5", { count: 10 })).toBe(true);
+      expect(evaluateShow("row.count > 5", { count: 1 })).toBe(false);
+    });
+
+    it("supports logical operators and parentheses", () => {
+      const row = { status: "failed", retried: true };
+      expect(evaluateShow('(row.status == "failed") && !row.retried', row)).toBe(false);
+      expect(evaluateShow('row.status == "failed" || row.status == "running"', row)).toBe(true);
+    });
+
+    it("returns the default value on parse error", () => {
+      expect(evaluateShow("row.status ===", {}, false)).toBe(false);
+      expect(evaluateShow("totally bogus expression !!!!", {})).toBe(true);
+    });
+
+    it("supports bare field references without `row.` prefix", () => {
+      expect(evaluateShow('status == "ok"', { status: "ok" })).toBe(true);
+    });
+
+    it("supports single-quoted string literals", () => {
+      expect(evaluateShow("status == 'ok'", { status: "ok" }, false)).toBe(true);
+      expect(evaluateShow("status == 'ok'", { status: "bad" }, true)).toBe(false);
+    });
+
+    it("compares against the null literal", () => {
+      expect(evaluateShow("value == null", { value: null }, false)).toBe(true);
+      expect(evaluateShow("value == null", { value: "x" }, true)).toBe(false);
+    });
+
+    it("supports the <=, >=, and != operators", () => {
+      expect(evaluateShow("count <= 5", { count: 5 }, false)).toBe(true);
+      expect(evaluateShow("count >= 5", { count: 4 }, true)).toBe(false);
+      expect(evaluateShow('status != "failed"', { status: "passed" }, false)).toBe(true);
+    });
+
+    it("resolves nested field paths", () => {
+      expect(evaluateShow("a.b.c > 1", { a: { b: { c: 5 } } }, false)).toBe(true);
+    });
+
+    it("treats root identifiers missing from the row as null, not as errors", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // Legacy resolved unknown fields to `undefined`, making comparisons
+      // false; CEL alone would raise "Unknown variable". The adapter binds
+      // unknown roots to `null` so heterogeneous rows keep filtering.
+      expect(evaluateShow('status == "deleted"', {}, true)).toBe(false);
+      expect(evaluateShow('status != "deleted"', {}, false)).toBe(true);
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("coerces numeric strings for ordering comparisons (stringified memory rows)", () => {
+      expect(evaluateShow("count > 5", { count: "10" }, false)).toBe(true);
+      expect(evaluateShow("count > 5", { count: "3" }, true)).toBe(false);
+    });
+
+    it("returns the truthiness of a bare field reference", () => {
+      expect(evaluateShow("count", { count: 3 }, false)).toBe(true);
+      expect(evaluateShow("name", { name: "" }, true)).toBe(false);
+    });
   });
 
-  it("supports logical operators and parentheses", () => {
-    const row = { status: "failed", retried: true };
-    expect(evaluateShow('(row.status == "failed") && !row.retried', row)).toBe(false);
-    expect(evaluateShow('row.status == "failed" || row.status == "running"', row)).toBe(true);
+  describe("CEL surface (issue #6232)", () => {
+    it("evaluates the reported expression: epochMs(createdAt) > (now - 604800) * 1000", () => {
+      const expr = "epochMs(createdAt) > (now - 604800) * 1000";
+      const recent = new Date().toISOString();
+      expect(evaluateShow(expr, { createdAt: recent }, false)).toBe(true);
+      expect(evaluateShow(expr, { createdAt: "2020-01-01T00:00:00Z" }, true)).toBe(false);
+    });
+
+    it("supports arithmetic with + - * / and parentheses", () => {
+      expect(evaluateShow("(a + b) / 2 >= 5", { a: 4, b: 6 }, false)).toBe(true);
+      expect(evaluateShow("(a + b) / 2 >= 5", { a: 1, b: 2 }, true)).toBe(false);
+      expect(evaluateShow("a - b * 2 == -8", { a: 2, b: 5 }, false)).toBe(true);
+    });
+
+    it("supports builtin function calls", () => {
+      expect(evaluateShow('lower(status) == "ok"', { status: "OK" }, false)).toBe(true);
+      expect(evaluateShow('contains(name, "prod")', { name: "prod-eu-1" }, false)).toBe(true);
+      expect(evaluateShow('contains(name, "prod")', { name: "staging" }, true)).toBe(false);
+    });
+
+    it("supports the in operator and ternaries", () => {
+      expect(evaluateShow('status in ["ok", "good"]', { status: "good" }, false)).toBe(true);
+      expect(evaluateShow('status == "ok" ? count > 1 : false', { status: "ok", count: 2 }, false)).toBe(true);
+    });
   });
 
-  it("returns the default value on parse error", () => {
-    expect(evaluateShow("row.status ===", {}, false)).toBe(false);
-    expect(evaluateShow("totally bogus expression !!!!", {})).toBe(true);
+  describe("fail-soft behavior", () => {
+    it("returns defaultValue and warns on syntax errors, never throws", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(evaluateShow("epochMs(", {}, true)).toBe(true);
+      expect(evaluateShow("epochMs(", {}, false)).toBe(false);
+      expect(evaluateShow("a &&& b", { a: true, b: true })).toBe(true);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("returns defaultValue and warns on runtime eval errors", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // Nested key missing below the root: CEL raises "No such key"; the
+      // adapter falls back to defaultValue instead of hiding/throwing.
+      expect(evaluateShow('a.b == "x"', { a: {} }, true)).toBe(true);
+      expect(evaluateShow('a.b == "x"', { a: {} }, false)).toBe(false);
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("returns defaultValue for empty or blank expressions without warning", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(evaluateShow(undefined, {}, true)).toBe(true);
+      expect(evaluateShow("", {}, false)).toBe(false);
+      expect(evaluateShow("   ", {}, true)).toBe(true);
+      expect(warn).not.toHaveBeenCalled();
+    });
   });
 
-  it("supports bare field references without `row.` prefix", () => {
-    expect(evaluateShow('status == "ok"', { status: "ok" })).toBe(true);
+  describe("sandbox", () => {
+    it("cannot escape into JS via constructor chains", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const escape = '("").constructor.constructor("globalThis.__pwned = true")()';
+      expect(evaluateShow(escape, {}, false)).toBe(false);
+      expect((globalThis as Record<string, unknown>).__pwned).toBeUndefined();
+      expect(warn).toHaveBeenCalled();
+    });
+  });
+
+  describe("documented divergences from the legacy evaluator", () => {
+    it("cross-type equality follows CEL (typed) semantics", () => {
+      // The legacy evaluator loosely normalized scalars, so `10 == "10"`
+      // and `true == "true"` were true. CEL equality is typed: values of
+      // different types are simply not equal. Same-type comparisons — the
+      // documented authoring forms — are unaffected.
+      expect(evaluateShow('count == "10"', { count: 10 }, true)).toBe(false);
+      expect(evaluateShow("flag == true", { flag: "true" }, true)).toBe(false);
+      // Same-type equality on stringified rows still works.
+      expect(evaluateShow('count == "10"', { count: "10" }, false)).toBe(true);
+    });
   });
 });

--- a/web_src/src/pages/app/console/widget/showExpression.ts
+++ b/web_src/src/pages/app/console/widget/showExpression.ts
@@ -1,241 +1,138 @@
 /**
- * Tiny expression evaluator for Dashboard widget `show` / row filter clauses.
+ * Dashboard widget `show` / row filter clause evaluation.
  *
- * Intentionally minimal: we support comparisons (`==`, `!=`, `>`, `<`, `>=`,
- * `<=`), logical operators (`&&`, `||`, `!`), parentheses, field paths, and
- * primitive literals (strings, numbers, booleans, `null`). Anything else
- * throws. We never call `eval` or `new Function` so widgets imported from
- * untrusted YAML can't escape the sandbox.
+ * Clauses are bare CEL expressions (no `{{ }}` wrapper) routed through the
+ * same engine as column templates (`celExpr.ts` + the builtins registered in
+ * `celBuiltins.ts`), so comparisons (`==`, `!=`, `>`, `<`, `>=`, `<=`),
+ * logical operators (`&&`, `||`, `!`), parentheses, arithmetic
+ * (`+ - * / %`), function calls (`epochMs(...)`, `lower(...)`, …), the `in`
+ * operator, and ternaries all work — one expression language everywhere.
  *
- * Field paths are evaluated against a single `row` object passed at runtime.
+ * We never call `eval` or `new Function`: `@marcbachmann/cel-js` interprets
+ * its own AST, so widgets imported from untrusted YAML can't escape the
+ * sandbox.
+ *
+ * Sugar preserved from the retired hand-rolled evaluator:
+ * - `row.status` and bare `status` both resolve against the row (a `row`
+ *   binding pointing at the row itself is injected; an actual `row` field on
+ *   the row takes precedence).
+ * - Root identifiers absent from the row are bound to `null` instead of
+ *   raising CEL's "Unknown variable", so `status == "deleted"` is simply
+ *   `false` on rows without a `status` field.
+ * - Any compile or eval error logs a console warning and returns
+ *   `defaultValue`, so widgets remain functional even when authoring
+ *   mistakes are present.
+ *
+ * Known divergence: equality is typed (CEL semantics) — the old evaluator's
+ * loose scalar normalization made `10 == "10"` and `true == "true"` true;
+ * they are now false. Ordering comparisons on stringified rows still work
+ * via `evalExprDetailed`'s numeric-string retry.
  */
 
-import { getValueAtPath } from "./fieldPath";
+import { buildEnv, compileExpr, type CompiledExpr, evalExprDetailed } from "./celExpr";
 
-type Token =
-  | { kind: "number"; value: number }
-  | { kind: "string"; value: string }
-  | { kind: "bool"; value: boolean }
-  | { kind: "null" }
-  | { kind: "ident"; value: string }
-  | { kind: "op"; value: string }
-  | { kind: "lparen" }
-  | { kind: "rparen" };
-
-const OPERATORS = ["==", "!=", ">=", "<=", "&&", "||", "!", ">", "<"];
-
-interface TokenRead {
-  token?: Token;
-  nextIndex: number;
-}
-
-function tokenize(input: string): Token[] {
-  const tokens: Token[] = [];
-  let i = 0;
-  while (i < input.length) {
-    const read = readToken(input, i);
-    if (read.token) tokens.push(read.token);
-    i = read.nextIndex;
-  }
-  return tokens;
-}
-
-function readToken(input: string, index: number): TokenRead {
-  const ch = input[index];
-  if (isWhitespace(ch)) return { nextIndex: index + 1 };
-  if (ch === "(") return { token: { kind: "lparen" }, nextIndex: index + 1 };
-  if (ch === ")") return { token: { kind: "rparen" }, nextIndex: index + 1 };
-  if (ch === '"' || ch === "'") return readStringToken(input, index, ch);
-  if (isNumberStart(input, index)) return readNumberToken(input, index);
-
-  const operator = readOperator(input, index);
-  if (operator) return { token: { kind: "op", value: operator }, nextIndex: index + operator.length };
-  if (isIdentifierStart(ch)) return readIdentifierToken(input, index);
-
-  throw new Error(`Unexpected character '${ch}' in expression: ${input}`);
-}
-
-function readStringToken(input: string, index: number, quote: string): TokenRead {
-  let j = index + 1;
-  let buffer = "";
-  while (j < input.length && input[j] !== quote) {
-    if (input[j] === "\\" && j + 1 < input.length) {
-      buffer += input[j + 1];
-      j += 2;
-      continue;
-    }
-    buffer += input[j];
-    j++;
-  }
-  if (j >= input.length) throw new Error(`Unterminated string in expression: ${input}`);
-  return { token: { kind: "string", value: buffer }, nextIndex: j + 1 };
-}
-
-function readNumberToken(input: string, index: number): TokenRead {
-  let j = index + 1;
-  while (j < input.length && /[0-9.]/.test(input[j])) j++;
-  return { token: { kind: "number", value: Number(input.slice(index, j)) }, nextIndex: j };
-}
-
-function readOperator(input: string, index: number): string | undefined {
-  return OPERATORS.find((op) => input.slice(index, index + op.length) === op);
-}
-
-function readIdentifierToken(input: string, index: number): TokenRead {
-  let j = index + 1;
-  while (j < input.length && /[A-Za-z0-9_.$[\]]/.test(input[j])) j++;
-  const raw = input.slice(index, j);
-  return { token: tokenForIdentifier(raw), nextIndex: j };
-}
-
-function tokenForIdentifier(raw: string): Token {
-  if (raw === "true") return { kind: "bool", value: true };
-  if (raw === "false") return { kind: "bool", value: false };
-  if (raw === "null") return { kind: "null" };
-  return { kind: "ident", value: raw };
-}
-
-function isWhitespace(ch: string | undefined): boolean {
-  return ch === " " || ch === "\t" || ch === "\n";
-}
-
-function isNumberStart(input: string, index: number): boolean {
-  const ch = input[index];
-  return /[0-9]/.test(ch) || (ch === "-" && /[0-9]/.test(input[index + 1] ?? ""));
-}
-
-function isIdentifierStart(ch: string | undefined): boolean {
-  return Boolean(ch && /[A-Za-z_$]/.test(ch));
-}
-
-interface ParserState {
-  index: number;
-  tokens: Token[];
-}
-
-function peek(state: ParserState): Token | undefined {
-  return state.tokens[state.index];
-}
-function consume(state: ParserState): Token {
-  return state.tokens[state.index++];
-}
-
-function parseOr(state: ParserState, row: unknown): unknown {
-  let left = parseAnd(state, row);
-  while (peek(state)?.kind === "op" && (peek(state) as { value: string }).value === "||") {
-    consume(state);
-    const right = parseAnd(state, row);
-    left = Boolean(left) || Boolean(right);
-  }
-  return left;
-}
-
-function parseAnd(state: ParserState, row: unknown): unknown {
-  let left = parseComparison(state, row);
-  while (peek(state)?.kind === "op" && (peek(state) as { value: string }).value === "&&") {
-    consume(state);
-    const right = parseComparison(state, row);
-    left = Boolean(left) && Boolean(right);
-  }
-  return left;
-}
-
-function parseComparison(state: ParserState, row: unknown): unknown {
-  let left = parseUnary(state, row);
-  const cmpOps = new Set(["==", "!=", ">", "<", ">=", "<="]);
-  while (peek(state)?.kind === "op" && cmpOps.has((peek(state) as { value: string }).value)) {
-    const op = (consume(state) as { value: string }).value;
-    const right = parseUnary(state, row);
-    left = compare(op, left, right);
-  }
-  return left;
-}
-
-function parseUnary(state: ParserState, row: unknown): unknown {
-  const tok = peek(state);
-  if (tok?.kind === "op" && tok.value === "!") {
-    consume(state);
-    return !parseUnary(state, row);
-  }
-  return parsePrimary(state, row);
-}
-
-function parsePrimary(state: ParserState, row: unknown): unknown {
-  const tok = consume(state);
-  if (!tok) throw new Error("Unexpected end of expression");
-  if (tok.kind === "lparen") {
-    const inner = parseOr(state, row);
-    const closing = consume(state);
-    if (!closing || closing.kind !== "rparen") throw new Error("Expected closing ')'");
-    return inner;
-  }
-  if (tok.kind === "number" || tok.kind === "bool") return tok.value;
-  if (tok.kind === "null") return null;
-  if (tok.kind === "string") return tok.value;
-  if (tok.kind === "ident") {
-    // `row.foo.bar` and bare `foo.bar` both refer to the row.
-    const path = tok.value.startsWith("row.") ? tok.value.slice(4) : tok.value;
-    return getValueAtPath(row, path);
-  }
-  throw new Error(`Unexpected token: ${JSON.stringify(tok)}`);
-}
-
-function compare(op: string, left: unknown, right: unknown): boolean {
-  switch (op) {
-    case "==":
-      return valuesEqual(left, right);
-    case "!=":
-      return !valuesEqual(left, right);
-    case ">":
-      return (left as number) > (right as number);
-    case "<":
-      return (left as number) < (right as number);
-    case ">=":
-      return (left as number) >= (right as number);
-    case "<=":
-      return (left as number) <= (right as number);
-    default:
-      throw new Error(`Unknown comparison: ${op}`);
-  }
-}
-
-function valuesEqual(left: unknown, right: unknown): boolean {
-  if (left === right) return true;
-  return normalizeComparableScalar(left) === normalizeComparableScalar(right);
-}
-
-function normalizeComparableScalar(value: unknown): unknown {
-  if (typeof value !== "string") return value;
-  const trimmed = value.trim();
-  if (trimmed === "") return value;
-  if (trimmed === "true") return true;
-  if (trimmed === "false") return false;
-  if (trimmed === "null") return null;
-
-  const numberValue = Number(trimmed);
-  return Number.isFinite(numberValue) ? numberValue : value;
+interface CompiledShow {
+  expr: CompiledExpr;
+  roots: string[];
 }
 
 /**
- * Evaluate the given expression against a row context. Returns a boolean (the
- * truthiness of the resulting value). On parse error this logs to console and
- * returns `defaultValue` (defaults to `true`), so widgets remain functional
- * even when authoring mistakes are present.
+ * Compile cache: filters re-evaluate the same clause once per row, and
+ * `Environment.parse` is the expensive step. Cleared wholesale at a size
+ * bound so transient strings typed in the widget editor can't grow it
+ * forever.
+ */
+const COMPILED = new Map<string, CompiledShow>();
+const COMPILED_CACHE_LIMIT = 500;
+
+function compiledFor(source: string): CompiledShow {
+  let entry = COMPILED.get(source);
+  if (!entry) {
+    if (COMPILED.size >= COMPILED_CACHE_LIMIT) COMPILED.clear();
+    entry = { expr: compileExpr(source), roots: rootIdentifiers(source) };
+    COMPILED.set(source, entry);
+  }
+  return entry;
+}
+
+const IDENT_START = /[A-Za-z_]/;
+const IDENT_CHAR = /[A-Za-z0-9_]/;
+
+/**
+ * Names that must never be null-bound as "missing row fields": CEL keywords
+ * and literals, plus the adapter-provided `row` alias and the `now` global
+ * from `buildEnv`.
+ */
+const RESERVED_IDENTIFIERS = new Set(["true", "false", "null", "in", "row", "now"]);
+
+/**
+ * Collect the root identifiers referenced by `source` — identifier tokens
+ * outside string literals that are not preceded by `.` (those are field
+ * selections, not roots). Used to bind missing row fields to `null` so a
+ * clause over a heterogeneous row set degrades to `false` comparisons
+ * instead of "Unknown variable" errors. Function names may be collected
+ * too; binding them is harmless because CEL resolves calls through the
+ * function registry, not the variable context.
+ */
+function rootIdentifiers(source: string): string[] {
+  const roots = new Set<string>();
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '"' || ch === "'") {
+      i = skipStringLiteral(source, i, ch);
+      continue;
+    }
+    if (IDENT_START.test(ch)) {
+      let j = i + 1;
+      while (j < source.length && IDENT_CHAR.test(source[j])) j++;
+      const name = source.slice(i, j);
+      const isRawStringPrefix = name === "r" && (source[j] === '"' || source[j] === "'");
+      if (source[i - 1] !== "." && !isRawStringPrefix && !RESERVED_IDENTIFIERS.has(name)) {
+        roots.add(name);
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+  return [...roots];
+}
+
+/** Skip past a quoted string literal (honoring backslash escapes). */
+function skipStringLiteral(source: string, start: number, quote: string): number {
+  let i = start + 1;
+  while (i < source.length && source[i] !== quote) {
+    i += source[i] === "\\" ? 2 : 1;
+  }
+  return i + 1;
+}
+
+/**
+ * Evaluate the given expression against a row context. Returns a boolean
+ * (the truthiness of the resulting value). On any compile or eval error
+ * this logs to console and returns `defaultValue` (defaults to `true`), so
+ * widgets remain functional even when authoring mistakes are present.
  */
 export function evaluateShow(expression: string | undefined, row: unknown, defaultValue = true): boolean {
   if (!expression || !expression.trim()) return defaultValue;
-  try {
-    const tokens = tokenize(expression);
-    const state: ParserState = { index: 0, tokens };
-    const result = parseOr(state, row);
-    if (state.index < tokens.length) {
-      throw new Error("Trailing tokens after expression");
-    }
-    return Boolean(result);
-  } catch (err) {
-    if (typeof console !== "undefined") {
-      console.warn(`Dashboard widget expression failed: ${(err as Error).message}`);
-    }
-    return defaultValue;
+  const { expr, roots } = compiledFor(expression.trim());
+  if (!expr.ok) return warnAndDefault(expr.error, defaultValue);
+
+  const record = row && typeof row === "object" && !Array.isArray(row) ? (row as Record<string, unknown>) : {};
+  const globals: Record<string, unknown> = { row: record };
+  for (const name of roots) {
+    if (!Object.prototype.hasOwnProperty.call(record, name)) globals[name] = null;
   }
+
+  const result = evalExprDetailed(expr, record, buildEnv(globals));
+  if (!result.ok) return warnAndDefault(result.error, defaultValue);
+  return Boolean(result.value);
+}
+
+function warnAndDefault(message: string, defaultValue: boolean): boolean {
+  if (typeof console !== "undefined") {
+    console.warn(`Dashboard widget expression failed: ${message}`);
+  }
+  return defaultValue;
 }


### PR DESCRIPTION
Closes #6232. Closes #6233 (duplicate).

## Problem

`show:` clauses were parsed by a hand-rolled tokenizer — a second, weaker expression language. Its operator list lacked `+ - * /` and it had no function-call parsing, so `epochMs(createdAt) > (now - 604800) * 1000` failed with *"Unexpected character '-'"* while the identical expression worked inside `{{ }}` templates.

## Fix

Delete the tokenizer; route bare `show:` clauses through the same CEL engine as column templates (`celExpr` + `celBuiltins`). One expression language everywhere (241 → 138 LOC). The adapter preserves the legacy sugar: `row.`-prefix and bare-field resolution, missing root fields bind to `null` instead of raising, fail-soft evaluation (warn + `defaultValue`, never a throw), and compiled expressions are memo-cached for per-row filtering. No `eval`/`new Function` — cel-js interprets its own AST, and a sandbox-escape test proves untrusted YAML can't break out.

## Behavioral changes to be aware of

1. **Equality is now typed** (CEL semantics): the old loose normalization made `10 == "10"` and `true == "true"` match; they no longer do. Ordering comparisons on numeric strings still work. Covered by a dedicated "documented divergences" test block.
2. **Nested missing keys** (`a.b == "x"` with no `b`) now fail-soft to `defaultValue` + warn — matching how `{{ }}` templates already behave — instead of silently comparing `undefined`.
3. `now` works in bare clauses (previously resolved as a missing row field) — the core of #6232.

## Testing

Spec grows 5 → 21 cases, written red-first against the old parser: full legacy parity, the exact production expression from #6232 (true and false fixtures), arithmetic/parens/function calls, `in` + ternary, all fail-soft paths (with `defaultValue` set opposite the expected result so fail-soft can't fake a pass), and the sandbox escape. Full widget directory: **528/528**. `lint:budget` within budget; `tsc -b` clean; prettier-formatted.
