### PR TITLE
fix: Correct canvas mode tabbar colors in dark mode editing state

### DIFF
--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
@@ -112,11 +112,17 @@ describe("CanvasModeToggle", () => {
 
     const tabList = screen.getByRole("navigation", { name: "Canvas view" });
     expect(tabList.className).toContain("bg-orange-200");
+    expect(tabList.className).toContain("dark:bg-orange-950");
     const activeTab = screen.getByRole("link", { name: "Canvas (editing)" });
     expect(activeTab.className).toContain("bg-white");
     expect(activeTab.className).toContain("shadow-sm");
     expect(activeTab.className).toContain("font-medium");
     expect(activeTab.className).not.toContain("font-bold");
+    // Dark edit mode uses a cream pill, so the shared gray values must be dropped.
+    expect(activeTab.className).toContain("dark:bg-orange-200");
+    expect(activeTab.className).toContain("dark:text-orange-950");
+    expect(activeTab.className).not.toContain("dark:bg-gray-400");
+    expect(activeTab.className).not.toContain("dark:bg-gray-800");
     expect(screen.getByTestId("canvas-view-mode-live-uncommitted-dot")).toHaveClass("bg-orange-500");
     expect(screen.getByTestId("canvas-view-mode-console-uncommitted-dot")).toHaveClass("bg-orange-500");
   });
@@ -139,6 +145,7 @@ describe("CanvasModeToggle", () => {
 
     const consoleTab = screen.getByRole("link", { name: "Console" });
     expect(consoleTab.className).toContain("text-orange-950/80");
+    expect(consoleTab.className).toContain("dark:text-orange-200/80");
 
     expect(screen.getByTestId("canvas-view-mode-live-committed-dot")).toHaveClass("bg-blue-500");
   });

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -1,6 +1,6 @@
 import { appPath } from "@/lib/appPaths";
 import { isNormalClick } from "@/lib/linkHelpers";
-import { segmentedNavTabClassName } from "@/lib/segmentedNav";
+import { SEGMENTED_NAV_TAB_ACTIVE_CLASSES, segmentedNavTabClassName } from "@/lib/segmentedNav";
 import { cn } from "@/lib/utils";
 import { Link, useParams } from "react-router-dom";
 
@@ -48,17 +48,17 @@ function modeToTab(mode: string): string {
 
 /** Edit-mode nav background tinted to match edit-session chrome. */
 function editingNavClassName(): string {
-  return "bg-orange-200";
+  return "bg-orange-200 dark:bg-orange-950";
 }
 
 /** Edit-mode inactive tab text on the orange nav track. */
 function editingInactiveClassName(): string {
-  return "bg-transparent text-orange-950/80 hover:text-orange-950 transition-none";
+  return "bg-transparent text-orange-950/80 hover:text-orange-950 dark:text-orange-200/80 dark:hover:text-orange-200 transition-none";
 }
 
-/** Active edit tab — white pill on the orange nav track in light mode. */
+/** Active edit tab — white pill in light mode, cream in dark; gray would clash with the orange track. */
 function editingActiveClassName(): string {
-  return "rounded-full bg-white text-gray-800 shadow-sm dark:bg-gray-800 dark:text-gray-100 dark:shadow-none";
+  return cn(SEGMENTED_NAV_TAB_ACTIVE_CLASSES, "dark:bg-orange-200 dark:text-orange-950");
 }
 
 function tabClasses(selected: string, value: string, editing: boolean) {


### PR DESCRIPTION
## What changed

The editing state of the canvas mode tabbar (`CanvasModeToggle`) rendered light-mode colors when the app was in dark mode. This adds the missing dark variants and moves the active pill onto the shared segmented-nav constant.

## Screenshots

Dark mode, editing state:

| Before | After |
|---|---|
| <img width="285" height="95" alt="before" src="https://github.com/user-attachments/assets/b4f9e7ee-8a41-4112-8422-0a20647a1a4b" /> | <img width="276" height="92" alt="after" src="https://github.com/user-attachments/assets/a0a97671-80a0-4313-9fd5-3a093361ad15" />|

## Why

Two things were wrong, both only visible in dark mode while editing.

The nav track had no dark variant at all. `editingNavClassName()` returned a bare `bg-orange-200`, so dark mode rendered the light-mode value and the editing track looked the same in both themes.

The active pill also inverted between states. The normal state uses `dark:bg-gray-400`, the lightest surface in the control. The editing state used `dark:bg-gray-800`, the darkest. Entering edit mode flipped the pill from lightest to darkest and put a cool gray pill on a warm track.

Neither reproduces in light mode.

## How

| Element | Before | After |
|---|---|---|
| Nav track | `bg-orange-200` | `bg-orange-200 dark:bg-orange-950` |
| Inactive tab text | `text-orange-950/80` | plus `dark:text-orange-200/80` and hover |
| Active pill | inline literal with `dark:bg-gray-800` | `cn(SEGMENTED_NAV_TAB_ACTIVE_CLASSES, "dark:bg-orange-200 dark:text-orange-950")` |

### Why the pill isn't identical in both themes

Light mode keeps a white pill in both states because white works on the `slate-100` and `orange-200` tracks alike. Dark mode can't do the same: keeping `gray-400` would put a cool gray pill on the warm `orange-950` track, which is the clash this PR is fixing.

Happy to freeze the pill instead if you'd rather have strict symmetry.

### One light-mode change

Reusing `SEGMENTED_NAV_TAB_ACTIVE_CLASSES` also moves the light-mode active pill text from `text-gray-800` to `text-slate-900`, matching the non-editing state. It's the only change outside dark mode, and I can pin the old value if you'd rather keep this strictly dark-mode-only.

## Testing

Extended `CanvasModeToggle.spec.tsx` to cover the dark-mode classes in both states, including negative assertions that the old `dark:bg-gray-400` and `dark:bg-gray-800` values are gone.

```
✓ src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx (10 tests) 213ms
  Test Files  1 passed (1)
       Tests  10 passed (10)
```

## Breaking changes

None. Visual only, scoped to `CanvasModeToggle`.