### PR TITLE
fix: show complete strings in expanded run inspector

### DIFF
--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.spec.tsx
@@ -12,11 +12,12 @@ describe("escapeJsonStringValue", () => {
 });
 
 describe("JsonPayload", () => {
-  it("allows long string values to wrap inside the viewer", () => {
+  it("shows complete long string values in the expanded viewer", () => {
     const longValue = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=".repeat(4);
     const { container } = render(<JsonPayload value={{ content: longValue }} jsonViewStyle={{}} collapsed={false} />);
     const viewer = container.querySelector(".w-json-view-container");
 
     expect(viewer).toHaveClass("json-viewer-wrap-values");
+    expect(viewer).toHaveTextContent(longValue);
   });
 });

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
@@ -128,6 +128,7 @@ export function JsonPayload({
     <JsonView
       value={(value ?? {}) as object}
       collapsed={collapsed}
+      shortenTextAfterLength={collapsed === false ? 0 : undefined}
       style={jsonViewStyle}
       className={jsonViewClassName}
       displayObjectSize={false}


### PR DESCRIPTION
Fixes #6407.

## Summary
- show complete string values in expanded run inspector JSON views
- keep the existing compact-view shortening behavior
- add a regression assertion for long expanded values

## Testing
- focused RunInspectorTimelineCard Vitest suite
- targeted ESLint and Prettier checks
- frontend lint budget