### PR TITLE
feat: add GitLab getPipelineMinutesUsage component

### DIFF
--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -2556,6 +2556,7 @@ This action calls GitLab's GraphQL API, which requires the connected user to hav
 - Returns usage for the current calendar month
 - Includes a per-project breakdown of minutes and shared runner duration
 - When Projects are selected, only usage for those projects is included in the totals
+- If the integration's Group is a subgroup, usage is reported for its root group, since GitLab only tracks compute minutes at the root namespace
 
 ### Configuration
 

--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -43,6 +43,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Get Issue" href="#get-issue" description="Fetch a single GitLab issue by its IID" />
   <LinkCard title="Get Latest Pipeline" href="#get-latest-pipeline" description="Get the latest GitLab pipeline for a project" />
   <LinkCard title="Get Pipeline" href="#get-pipeline" description="Get a GitLab pipeline" />
+  <LinkCard title="Get Pipeline Minutes Usage" href="#get-pipeline-minutes-usage" description="Retrieve CI/CD compute (pipeline) minutes usage for the connected GitLab namespace" />
   <LinkCard title="Get Release" href="#get-release" description="Get a release from a GitLab project" />
   <LinkCard title="Get Test Report Summary" href="#get-test-report-summary" description="Get GitLab pipeline test report summary" />
   <LinkCard title="Mark Merge Request Ready for Review" href="#mark-merge-request-ready-for-review" description="Take a draft merge request out of the draft state in a GitLab project" />
@@ -2535,6 +2536,82 @@ Returns pipeline data including status, ref, SHA, and pipeline URL.
   },
   "timestamp": "2026-02-13T18:00:10.000Z",
   "type": "gitlab.pipeline"
+}
+```
+
+<a id="get-pipeline-minutes-usage"></a>
+
+## Get Pipeline Minutes Usage
+
+**Component key:** `gitlab.getPipelineMinutesUsage`
+
+The Get Pipeline Minutes Usage component retrieves CI/CD compute minutes usage for the current calendar month, for the namespace configured on the connected GitLab integration (its group, or the personal namespace if no group is set).
+
+### Prerequisites
+
+This action calls GitLab's GraphQL API, which requires the connected user to have access to the namespace's usage quota data (at least the Owner role for groups).
+
+### Behavior
+
+- Returns usage for the current calendar month
+- Includes a per-project breakdown of minutes and shared runner duration
+- When Projects are selected, only usage for those projects is included in the totals
+
+### Configuration
+
+- **Projects** (optional, multiselect): Limit the per-project breakdown and totals to specific projects. Leave empty to include all projects with usage.
+
+### Output
+
+Returns:
+- `month`: The usage month name, e.g. "July"
+- `monthIso8601`: The usage month as an ISO date, e.g. "2026-07-01"
+- `minutes`: Total compute minutes used
+- `sharedRunnersDuration`: Total shared runner duration, in seconds
+- `projects`: Per-project breakdown (minutes, shared runner duration, and project details)
+
+### Use Cases
+
+- **Billing monitoring**: Track CI/CD minutes usage against the namespace's quota
+- **Cost control**: Alert when usage approaches a budget threshold
+- **Usage reporting**: Generate periodic usage reports
+
+### References
+
+- [GitLab compute minutes](https://docs.gitlab.com/ci/pipelines/compute_minutes/)
+
+### Example Output
+
+```json
+{
+  "data": {
+    "minutes": 245,
+    "month": "July",
+    "monthIso8601": "2026-07-01",
+    "projects": [
+      {
+        "minutes": 180,
+        "project": {
+          "fullPath": "felixgateru/hello-world",
+          "id": "gid://gitlab/Project/80508544",
+          "name": "hello-world"
+        },
+        "sharedRunnersDuration": 10800
+      },
+      {
+        "minutes": 65,
+        "project": {
+          "fullPath": "felixgateru/another-project",
+          "id": "gid://gitlab/Project/80508999",
+          "name": "another-project"
+        },
+        "sharedRunnersDuration": 3900
+      }
+    ],
+    "sharedRunnersDuration": 14700
+  },
+  "timestamp": "2026-07-01T00:00:00.000000000Z",
+  "type": "gitlab.pipelineMinutesUsage"
 }
 ```
 

--- a/pkg/integrations/gitlab/client.go
+++ b/pkg/integrations/gitlab/client.go
@@ -1775,7 +1775,7 @@ type CiMinutesProjectUsage struct {
 	Project               *CiMinutesProjectRef `json:"project"`
 }
 
-const ciMinutesUsageQuery = `
+const ciMinutesNamespaceUsageQuery = `
 query($namespaceId: NamespaceID, $date: Date) {
   ciMinutesUsage(namespaceId: $namespaceId, date: $date) {
     nodes {
@@ -1785,7 +1785,11 @@ query($namespaceId: NamespaceID, $date: Date) {
       sharedRunnersDuration
     }
   }
-  ciMinutesProjectMonthlyUsage(namespaceId: $namespaceId, date: $date) {
+}`
+
+const ciMinutesProjectUsageQuery = `
+query($namespaceId: NamespaceID, $date: Date, $after: String) {
+  ciMinutesProjectMonthlyUsage(namespaceId: $namespaceId, date: $date, first: 100, after: $after) {
     nodes {
       minutes
       sharedRunnersDuration
@@ -1795,15 +1799,28 @@ query($namespaceId: NamespaceID, $date: Date) {
         fullPath
       }
     }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
   }
 }`
 
-type ciMinutesUsageResponse struct {
+type ciMinutesNamespaceUsageResponse struct {
 	CiMinutesUsage struct {
 		Nodes []CiMinutesNamespaceUsage `json:"nodes"`
 	} `json:"ciMinutesUsage"`
+}
+
+type graphQLPageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+type ciMinutesProjectUsageResponse struct {
 	CiMinutesProjectMonthlyUsage struct {
-		Nodes []CiMinutesProjectUsage `json:"nodes"`
+		Nodes    []CiMinutesProjectUsage `json:"nodes"`
+		PageInfo graphQLPageInfo         `json:"pageInfo"`
 	} `json:"ciMinutesProjectMonthlyUsage"`
 }
 
@@ -1814,15 +1831,50 @@ func (c *Client) GetCiMinutesUsage(ctx context.Context, namespaceGID *string, da
 		variables["namespaceId"] = *namespaceGID
 	}
 
-	var resp ciMinutesUsageResponse
-	if err := c.graphQL(ctx, ciMinutesUsageQuery, variables, &resp); err != nil {
+	var namespaceResp ciMinutesNamespaceUsageResponse
+	if err := c.graphQL(ctx, ciMinutesNamespaceUsageQuery, variables, &namespaceResp); err != nil {
 		return nil, nil, err
 	}
 
 	var usage CiMinutesNamespaceUsage
-	if len(resp.CiMinutesUsage.Nodes) > 0 {
-		usage = resp.CiMinutesUsage.Nodes[0]
+	if len(namespaceResp.CiMinutesUsage.Nodes) > 0 {
+		usage = namespaceResp.CiMinutesUsage.Nodes[0]
 	}
 
-	return &usage, resp.CiMinutesProjectMonthlyUsage.Nodes, nil
+	projects, err := c.getAllCiMinutesProjectUsage(ctx, variables)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &usage, projects, nil
+}
+
+// getAllCiMinutesProjectUsage pages through the full per-project usage breakdown, since GitLab caps each response at 100 nodes.
+func (c *Client) getAllCiMinutesProjectUsage(ctx context.Context, baseVariables map[string]any) ([]CiMinutesProjectUsage, error) {
+	var allProjects []CiMinutesProjectUsage
+	after := ""
+
+	for {
+		variables := make(map[string]any, len(baseVariables)+1)
+		for k, v := range baseVariables {
+			variables[k] = v
+		}
+		if after != "" {
+			variables["after"] = after
+		}
+
+		var resp ciMinutesProjectUsageResponse
+		if err := c.graphQL(ctx, ciMinutesProjectUsageQuery, variables, &resp); err != nil {
+			return nil, err
+		}
+
+		allProjects = append(allProjects, resp.CiMinutesProjectMonthlyUsage.Nodes...)
+
+		if !resp.CiMinutesProjectMonthlyUsage.PageInfo.HasNextPage {
+			break
+		}
+		after = resp.CiMinutesProjectMonthlyUsage.PageInfo.EndCursor
+	}
+
+	return allProjects, nil
 }

--- a/pkg/integrations/gitlab/client.go
+++ b/pkg/integrations/gitlab/client.go
@@ -1825,7 +1825,7 @@ type ciMinutesProjectUsageResponse struct {
 	} `json:"ciMinutesProjectMonthlyUsage"`
 }
 
-// GetCiMinutesUsage returns a namespace's CI/CD minutes usage for the given month with a per-project breakdown; a nil namespaceGID queries the current user's personal namespace.
+// GetCiMinutesUsage returns a namespace's CI/CD minutes usage for the given month with a per-project breakdown, a nil namespaceGID for the current user's personal namespace, and a nil usage if GitLab has no namespace-level record for that month.
 func (c *Client) GetCiMinutesUsage(ctx context.Context, namespaceGID *string, date string) (*CiMinutesNamespaceUsage, []CiMinutesProjectUsage, error) {
 	variables := map[string]any{"date": date}
 	if namespaceGID != nil {
@@ -1837,9 +1837,9 @@ func (c *Client) GetCiMinutesUsage(ctx context.Context, namespaceGID *string, da
 		return nil, nil, err
 	}
 
-	var usage CiMinutesNamespaceUsage
+	var usage *CiMinutesNamespaceUsage
 	if len(namespaceResp.CiMinutesUsage.Nodes) > 0 {
-		usage = namespaceResp.CiMinutesUsage.Nodes[0]
+		usage = &namespaceResp.CiMinutesUsage.Nodes[0]
 	}
 
 	projects, err := c.getAllCiMinutesProjectUsage(ctx, variables)
@@ -1847,7 +1847,7 @@ func (c *Client) GetCiMinutesUsage(ctx context.Context, namespaceGID *string, da
 		return nil, nil, err
 	}
 
-	return &usage, projects, nil
+	return usage, projects, nil
 }
 
 // getAllCiMinutesProjectUsage pages through the full per-project usage breakdown, since GitLab caps each response at 100 nodes.

--- a/pkg/integrations/gitlab/client.go
+++ b/pkg/integrations/gitlab/client.go
@@ -1726,7 +1726,8 @@ func (c *Client) graphQL(ctx context.Context, query string, variables map[string
 }
 
 type Group struct {
-	ID int `json:"id"`
+	ID       int    `json:"id"`
+	FullPath string `json:"full_path"`
 }
 
 // GetGroup fetches a single group by numeric ID or full path.

--- a/pkg/integrations/gitlab/client.go
+++ b/pkg/integrations/gitlab/client.go
@@ -1670,3 +1670,159 @@ func readResponseBody(resp *http.Response) string {
 	}
 	return string(body)
 }
+
+type graphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+type graphQLError struct {
+	Message string `json:"message"`
+}
+
+type graphQLResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []graphQLError  `json:"errors,omitempty"`
+}
+
+// graphQL executes a query against GitLab's GraphQL API and decodes the "data" field into out.
+func (c *Client) graphQL(ctx context.Context, query string, variables map[string]any, out any) error {
+	body, err := json.Marshal(graphQLRequest{Query: query, Variables: variables})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	apiURL := fmt.Sprintf("%s/api/graphql", c.baseURL)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("graphql request failed: status %d, response: %s", resp.StatusCode, readResponseBody(resp))
+	}
+
+	var gqlResp graphQLResponse
+	if err := json.NewDecoder(resp.Body).Decode(&gqlResp); err != nil {
+		return fmt.Errorf("failed to decode graphql response: %v", err)
+	}
+
+	if len(gqlResp.Errors) > 0 {
+		return fmt.Errorf("graphql error: %s", gqlResp.Errors[0].Message)
+	}
+
+	if out == nil {
+		return nil
+	}
+
+	return json.Unmarshal(gqlResp.Data, out)
+}
+
+type Group struct {
+	ID int `json:"id"`
+}
+
+// GetGroup fetches a single group by numeric ID or full path.
+func (c *Client) GetGroup(groupID string) (*Group, error) {
+	apiURL := fmt.Sprintf("%s/api/%s/groups/%s", c.baseURL, apiVersion, url.PathEscape(groupID))
+
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get group: status %d, response: %s", resp.StatusCode, readResponseBody(resp))
+	}
+
+	var group Group
+	if err := json.NewDecoder(resp.Body).Decode(&group); err != nil {
+		return nil, fmt.Errorf("failed to decode group: %v", err)
+	}
+
+	return &group, nil
+}
+
+type CiMinutesNamespaceUsage struct {
+	Month                 string `json:"month"`
+	MonthIso8601          string `json:"monthIso8601"`
+	Minutes               int    `json:"minutes"`
+	SharedRunnersDuration int    `json:"sharedRunnersDuration"`
+}
+
+type CiMinutesProjectRef struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	FullPath string `json:"fullPath"`
+}
+
+type CiMinutesProjectUsage struct {
+	Minutes               int                  `json:"minutes"`
+	SharedRunnersDuration int                  `json:"sharedRunnersDuration"`
+	Project               *CiMinutesProjectRef `json:"project"`
+}
+
+const ciMinutesUsageQuery = `
+query($namespaceId: NamespaceID, $date: Date) {
+  ciMinutesUsage(namespaceId: $namespaceId, date: $date) {
+    nodes {
+      month
+      monthIso8601
+      minutes
+      sharedRunnersDuration
+    }
+  }
+  ciMinutesProjectMonthlyUsage(namespaceId: $namespaceId, date: $date) {
+    nodes {
+      minutes
+      sharedRunnersDuration
+      project {
+        id
+        name
+        fullPath
+      }
+    }
+  }
+}`
+
+type ciMinutesUsageResponse struct {
+	CiMinutesUsage struct {
+		Nodes []CiMinutesNamespaceUsage `json:"nodes"`
+	} `json:"ciMinutesUsage"`
+	CiMinutesProjectMonthlyUsage struct {
+		Nodes []CiMinutesProjectUsage `json:"nodes"`
+	} `json:"ciMinutesProjectMonthlyUsage"`
+}
+
+// GetCiMinutesUsage returns a namespace's CI/CD minutes usage for the given month with a per-project breakdown; a nil namespaceGID queries the current user's personal namespace.
+func (c *Client) GetCiMinutesUsage(ctx context.Context, namespaceGID *string, date string) (*CiMinutesNamespaceUsage, []CiMinutesProjectUsage, error) {
+	variables := map[string]any{"date": date}
+	if namespaceGID != nil {
+		variables["namespaceId"] = *namespaceGID
+	}
+
+	var resp ciMinutesUsageResponse
+	if err := c.graphQL(ctx, ciMinutesUsageQuery, variables, &resp); err != nil {
+		return nil, nil, err
+	}
+
+	var usage CiMinutesNamespaceUsage
+	if len(resp.CiMinutesUsage.Nodes) > 0 {
+		usage = resp.CiMinutesUsage.Nodes[0]
+	}
+
+	return &usage, resp.CiMinutesProjectMonthlyUsage.Nodes, nil
+}

--- a/pkg/integrations/gitlab/client_test.go
+++ b/pkg/integrations/gitlab/client_test.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -1877,5 +1878,161 @@ func Test__Client__GetCommit(t *testing.T) {
 		_, err := client.GetCommit(context.Background(), "456", "abc123")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get commit")
+	})
+}
+
+func Test__Client__GetGroup(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusOK, `{"id": 123}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		result, err := client.GetGroup("my-org/my-subgroup")
+
+		require.NoError(t, err)
+		assert.Equal(t, 123, result.ID)
+
+		require.Len(t, mockClient.Requests, 1)
+		assert.Equal(t, http.MethodGet, mockClient.Requests[0].Method)
+		assert.Equal(t, "https://gitlab.com/api/v4/groups/my-org%2Fmy-subgroup", mockClient.Requests[0].URL.String())
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusNotFound, `{"message": "404 Group Not Found"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, err := client.GetGroup("123")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get group")
+	})
+}
+
+func Test__Client__GetCiMinutesUsage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusOK, `{
+					"data": {
+						"ciMinutesUsage": {
+							"nodes": [{"month": "July", "monthIso8601": "2026-07-01", "minutes": 245, "sharedRunnersDuration": 14700}]
+						},
+						"ciMinutesProjectMonthlyUsage": {
+							"nodes": [
+								{"minutes": 180, "sharedRunnersDuration": 10800, "project": {"id": "gid://gitlab/Project/1", "name": "hello-world", "fullPath": "felixgateru/hello-world"}}
+							]
+						}
+					}
+				}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		namespaceGID := "gid://gitlab/Group/123"
+		usage, projects, err := client.GetCiMinutesUsage(context.Background(), &namespaceGID, "2026-07-01")
+
+		require.NoError(t, err)
+		assert.Equal(t, "July", usage.Month)
+		assert.Equal(t, 245, usage.Minutes)
+
+		require.Len(t, projects, 1)
+		assert.Equal(t, "hello-world", projects[0].Project.Name)
+
+		require.Len(t, mockClient.Requests, 1)
+		assert.Equal(t, http.MethodPost, mockClient.Requests[0].Method)
+		assert.Equal(t, "https://gitlab.com/api/graphql", mockClient.Requests[0].URL.String())
+
+		body, _ := io.ReadAll(mockClient.Requests[0].Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+		variables := reqBody["variables"].(map[string]any)
+		assert.Equal(t, namespaceGID, variables["namespaceId"])
+		assert.Equal(t, "2026-07-01", variables["date"])
+	})
+
+	t.Run("omits namespaceId variable for personal namespace", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusOK, `{"data": {"ciMinutesUsage": {"nodes": []}, "ciMinutesProjectMonthlyUsage": {"nodes": []}}}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, _, err := client.GetCiMinutesUsage(context.Background(), nil, "2026-07-01")
+		require.NoError(t, err)
+
+		body, _ := io.ReadAll(mockClient.Requests[0].Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+		variables := reqBody["variables"].(map[string]any)
+		assert.NotContains(t, variables, "namespaceId")
+	})
+
+	t.Run("graphql error", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusOK, `{"errors": [{"message": "not authorized to read usage"}]}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, _, err := client.GetCiMinutesUsage(context.Background(), nil, "2026-07-01")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not authorized to read usage")
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusInternalServerError, `{"message": "internal error"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, _, err := client.GetCiMinutesUsage(context.Background(), nil, "2026-07-01")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "graphql request failed")
 	})
 }

--- a/pkg/integrations/gitlab/client_test.go
+++ b/pkg/integrations/gitlab/client_test.go
@@ -1934,11 +1934,16 @@ func Test__Client__GetCiMinutesUsage(t *testing.T) {
 					"data": {
 						"ciMinutesUsage": {
 							"nodes": [{"month": "July", "monthIso8601": "2026-07-01", "minutes": 245, "sharedRunnersDuration": 14700}]
-						},
+						}
+					}
+				}`),
+				GitlabMockResponse(http.StatusOK, `{
+					"data": {
 						"ciMinutesProjectMonthlyUsage": {
 							"nodes": [
 								{"minutes": 180, "sharedRunnersDuration": 10800, "project": {"id": "gid://gitlab/Project/1", "name": "hello-world", "fullPath": "felixgateru/hello-world"}}
-							]
+							],
+							"pageInfo": {"hasNextPage": false, "endCursor": ""}
 						}
 					}
 				}`),
@@ -1962,9 +1967,11 @@ func Test__Client__GetCiMinutesUsage(t *testing.T) {
 		require.Len(t, projects, 1)
 		assert.Equal(t, "hello-world", projects[0].Project.Name)
 
-		require.Len(t, mockClient.Requests, 1)
-		assert.Equal(t, http.MethodPost, mockClient.Requests[0].Method)
-		assert.Equal(t, "https://gitlab.com/api/graphql", mockClient.Requests[0].URL.String())
+		require.Len(t, mockClient.Requests, 2)
+		for _, req := range mockClient.Requests {
+			assert.Equal(t, http.MethodPost, req.Method)
+			assert.Equal(t, "https://gitlab.com/api/graphql", req.URL.String())
+		}
 
 		body, _ := io.ReadAll(mockClient.Requests[0].Body)
 		var reqBody map[string]any
@@ -1974,10 +1981,56 @@ func Test__Client__GetCiMinutesUsage(t *testing.T) {
 		assert.Equal(t, "2026-07-01", variables["date"])
 	})
 
+	t.Run("pages through more than one page of project usage", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusOK, `{"data": {"ciMinutesUsage": {"nodes": [{"month": "July"}]}}}`),
+				GitlabMockResponse(http.StatusOK, `{
+					"data": {
+						"ciMinutesProjectMonthlyUsage": {
+							"nodes": [{"minutes": 100, "project": {"id": "gid://gitlab/Project/1", "name": "project-1"}}],
+							"pageInfo": {"hasNextPage": true, "endCursor": "cursor-1"}
+						}
+					}
+				}`),
+				GitlabMockResponse(http.StatusOK, `{
+					"data": {
+						"ciMinutesProjectMonthlyUsage": {
+							"nodes": [{"minutes": 50, "project": {"id": "gid://gitlab/Project/2", "name": "project-2"}}],
+							"pageInfo": {"hasNextPage": false, "endCursor": ""}
+						}
+					}
+				}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, projects, err := client.GetCiMinutesUsage(context.Background(), nil, "2026-07-01")
+		require.NoError(t, err)
+
+		require.Len(t, projects, 2, "must follow pageInfo.hasNextPage and return every page, not just the first 100")
+		assert.Equal(t, "project-1", projects[0].Project.Name)
+		assert.Equal(t, "project-2", projects[1].Project.Name)
+
+		require.Len(t, mockClient.Requests, 3)
+		body, _ := io.ReadAll(mockClient.Requests[2].Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+		variables := reqBody["variables"].(map[string]any)
+		assert.Equal(t, "cursor-1", variables["after"], "the second page request must pass the previous page's endCursor")
+	})
+
 	t.Run("omits namespaceId variable for personal namespace", func(t *testing.T) {
 		mockClient := &contexts.HTTPContext{
 			Responses: []*http.Response{
-				GitlabMockResponse(http.StatusOK, `{"data": {"ciMinutesUsage": {"nodes": []}, "ciMinutesProjectMonthlyUsage": {"nodes": []}}}`),
+				GitlabMockResponse(http.StatusOK, `{"data": {"ciMinutesUsage": {"nodes": []}}}`),
+				GitlabMockResponse(http.StatusOK, `{"data": {"ciMinutesProjectMonthlyUsage": {"nodes": [], "pageInfo": {"hasNextPage": false, "endCursor": ""}}}}`),
 			},
 		}
 
@@ -1991,11 +2044,13 @@ func Test__Client__GetCiMinutesUsage(t *testing.T) {
 		_, _, err := client.GetCiMinutesUsage(context.Background(), nil, "2026-07-01")
 		require.NoError(t, err)
 
-		body, _ := io.ReadAll(mockClient.Requests[0].Body)
-		var reqBody map[string]any
-		json.Unmarshal(body, &reqBody)
-		variables := reqBody["variables"].(map[string]any)
-		assert.NotContains(t, variables, "namespaceId")
+		for _, req := range mockClient.Requests {
+			body, _ := io.ReadAll(req.Body)
+			var reqBody map[string]any
+			json.Unmarshal(body, &reqBody)
+			variables := reqBody["variables"].(map[string]any)
+			assert.NotContains(t, variables, "namespaceId")
+		}
 	})
 
 	t.Run("graphql error", func(t *testing.T) {
@@ -2020,6 +2075,26 @@ func Test__Client__GetCiMinutesUsage(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		mockClient := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusInternalServerError, `{"message": "internal error"}`),
+			},
+		}
+
+		client := &Client{
+			baseURL:    "https://gitlab.com",
+			token:      "token",
+			authType:   AuthTypePersonalAccessToken,
+			httpClient: mockClient,
+		}
+
+		_, _, err := client.GetCiMinutesUsage(context.Background(), nil, "2026-07-01")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "graphql request failed")
+	})
+
+	t.Run("project usage page failure", func(t *testing.T) {
+		mockClient := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				GitlabMockResponse(http.StatusOK, `{"data": {"ciMinutesUsage": {"nodes": [{"month": "July"}]}}}`),
 				GitlabMockResponse(http.StatusInternalServerError, `{"message": "internal error"}`),
 			},
 		}

--- a/pkg/integrations/gitlab/client_test.go
+++ b/pkg/integrations/gitlab/client_test.go
@@ -1885,7 +1885,7 @@ func Test__Client__GetGroup(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mockClient := &contexts.HTTPContext{
 			Responses: []*http.Response{
-				GitlabMockResponse(http.StatusOK, `{"id": 123}`),
+				GitlabMockResponse(http.StatusOK, `{"id": 123, "full_path": "my-org/my-subgroup"}`),
 			},
 		}
 
@@ -1900,6 +1900,7 @@ func Test__Client__GetGroup(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, 123, result.ID)
+		assert.Equal(t, "my-org/my-subgroup", result.FullPath)
 
 		require.Len(t, mockClient.Requests, 1)
 		assert.Equal(t, http.MethodGet, mockClient.Requests[0].Method)

--- a/pkg/integrations/gitlab/example_output_get_pipeline_minutes_usage.json
+++ b/pkg/integrations/gitlab/example_output_get_pipeline_minutes_usage.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "month": "July",
+    "monthIso8601": "2026-07-01",
+    "minutes": 245,
+    "sharedRunnersDuration": 14700,
+    "projects": [
+      {
+        "minutes": 180,
+        "sharedRunnersDuration": 10800,
+        "project": {
+          "id": "gid://gitlab/Project/80508544",
+          "name": "hello-world",
+          "fullPath": "felixgateru/hello-world"
+        }
+      },
+      {
+        "minutes": 65,
+        "sharedRunnersDuration": 3900,
+        "project": {
+          "id": "gid://gitlab/Project/80508999",
+          "name": "another-project",
+          "fullPath": "felixgateru/another-project"
+        }
+      }
+    ]
+  },
+  "timestamp": "2026-07-01T00:00:00.000000000Z",
+  "type": "gitlab.pipelineMinutesUsage"
+}

--- a/pkg/integrations/gitlab/get_pipeline_minutes_usage.go
+++ b/pkg/integrations/gitlab/get_pipeline_minutes_usage.go
@@ -150,20 +150,23 @@ func (c *GetPipelineMinutesUsage) Execute(ctx core.ExecutionContext) error {
 		projects = filterProjectsUsage(projects, config.Projects)
 	}
 
-	result := PipelineMinutesUsageResult{
-		Month:                 usage.Month,
-		MonthIso8601:          usage.MonthIso8601,
-		Minutes:               usage.Minutes,
-		SharedRunnersDuration: usage.SharedRunnersDuration,
-		Projects:              projects,
+	result := PipelineMinutesUsageResult{Projects: projects}
+	if usage != nil {
+		result.Month = usage.Month
+		result.MonthIso8601 = usage.MonthIso8601
+		result.Minutes = usage.Minutes
+		result.SharedRunnersDuration = usage.SharedRunnersDuration
 	}
 
-	if len(config.Projects) > 0 {
-		result.Minutes = 0
-		result.SharedRunnersDuration = 0
-		for _, p := range projects {
-			result.Minutes += p.Minutes
-			result.SharedRunnersDuration += p.SharedRunnersDuration
+	// Recompute totals from the per-project breakdown whenever the namespace record is missing or a project filter narrows it, so totals never silently disagree with what's shown.
+	if usage == nil || len(config.Projects) > 0 {
+		result.Minutes, result.SharedRunnersDuration = sumProjectUsage(projects)
+	}
+
+	if usage == nil {
+		result.MonthIso8601 = date
+		if parsed, err := time.Parse("2006-01-02", date); err == nil {
+			result.Month = parsed.Format("January")
 		}
 	}
 
@@ -196,6 +199,15 @@ func resolveNamespaceGID(client *Client) (*string, error) {
 
 	gid := fmt.Sprintf("gid://gitlab/Group/%d", group.ID)
 	return &gid, nil
+}
+
+// sumProjectUsage totals minutes and shared runner duration across a per-project usage breakdown.
+func sumProjectUsage(projects []CiMinutesProjectUsage) (minutes, sharedRunnersDuration int) {
+	for _, p := range projects {
+		minutes += p.Minutes
+		sharedRunnersDuration += p.SharedRunnersDuration
+	}
+	return minutes, sharedRunnersDuration
 }
 
 // filterProjectsUsage keeps only the usage entries for projects whose numeric ID is in selected.

--- a/pkg/integrations/gitlab/get_pipeline_minutes_usage.go
+++ b/pkg/integrations/gitlab/get_pipeline_minutes_usage.go
@@ -56,6 +56,7 @@ This action calls GitLab's GraphQL API, which requires the connected user to hav
 - Returns usage for the current calendar month
 - Includes a per-project breakdown of minutes and shared runner duration
 - When Projects are selected, only usage for those projects is included in the totals
+- If the integration's Group is a subgroup, usage is reported for its root group, since GitLab only tracks compute minutes at the root namespace
 
 ## Configuration
 
@@ -182,6 +183,15 @@ func resolveNamespaceGID(client *Client) (*string, error) {
 	group, err := client.GetGroup(client.groupID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve group: %w", err)
+	}
+
+	// GitLab tracks compute minutes on the root namespace only, so a subgroup's own ID would resolve to a namespace with no usage records.
+	rootPath, _, isSubgroup := strings.Cut(group.FullPath, "/")
+	if isSubgroup {
+		group, err = client.GetGroup(rootPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve root group: %w", err)
+		}
 	}
 
 	gid := fmt.Sprintf("gid://gitlab/Group/%d", group.ID)

--- a/pkg/integrations/gitlab/get_pipeline_minutes_usage.go
+++ b/pkg/integrations/gitlab/get_pipeline_minutes_usage.go
@@ -1,0 +1,236 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_get_pipeline_minutes_usage.json
+var exampleOutputGetPipelineMinutesUsage []byte
+
+type GetPipelineMinutesUsage struct{}
+
+type GetPipelineMinutesUsageConfiguration struct {
+	Projects []string `mapstructure:"projects"`
+}
+
+type PipelineMinutesUsageResult struct {
+	Month                 string                  `json:"month"`
+	MonthIso8601          string                  `json:"monthIso8601"`
+	Minutes               int                     `json:"minutes"`
+	SharedRunnersDuration int                     `json:"sharedRunnersDuration"`
+	Projects              []CiMinutesProjectUsage `json:"projects"`
+}
+
+func (c *GetPipelineMinutesUsage) Name() string {
+	return "gitlab.getPipelineMinutesUsage"
+}
+
+func (c *GetPipelineMinutesUsage) Label() string {
+	return "Get Pipeline Minutes Usage"
+}
+
+func (c *GetPipelineMinutesUsage) Description() string {
+	return "Retrieve CI/CD compute (pipeline) minutes usage for the connected GitLab namespace"
+}
+
+func (c *GetPipelineMinutesUsage) Documentation() string {
+	return `The Get Pipeline Minutes Usage component retrieves CI/CD compute minutes usage for the current calendar month, for the namespace configured on the connected GitLab integration (its group, or the personal namespace if no group is set).
+
+## Prerequisites
+
+This action calls GitLab's GraphQL API, which requires the connected user to have access to the namespace's usage quota data (at least the Owner role for groups).
+
+## Behavior
+
+- Returns usage for the current calendar month
+- Includes a per-project breakdown of minutes and shared runner duration
+- When Projects are selected, only usage for those projects is included in the totals
+
+## Configuration
+
+- **Projects** (optional, multiselect): Limit the per-project breakdown and totals to specific projects. Leave empty to include all projects with usage.
+
+## Output
+
+Returns:
+- ` + "`month`" + `: The usage month name, e.g. "July"
+- ` + "`monthIso8601`" + `: The usage month as an ISO date, e.g. "2026-07-01"
+- ` + "`minutes`" + `: Total compute minutes used
+- ` + "`sharedRunnersDuration`" + `: Total shared runner duration, in seconds
+- ` + "`projects`" + `: Per-project breakdown (minutes, shared runner duration, and project details)
+
+## Use Cases
+
+- **Billing monitoring**: Track CI/CD minutes usage against the namespace's quota
+- **Cost control**: Alert when usage approaches a budget threshold
+- **Usage reporting**: Generate periodic usage reports
+
+## References
+
+- [GitLab compute minutes](https://docs.gitlab.com/ci/pipelines/compute_minutes/)`
+}
+
+func (c *GetPipelineMinutesUsage) Icon() string {
+	return "gitlab"
+}
+
+func (c *GetPipelineMinutesUsage) Color() string {
+	return "orange"
+}
+
+func (c *GetPipelineMinutesUsage) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetPipelineMinutesUsage) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputGetPipelineMinutesUsage, &example); err != nil {
+		return map[string]any{}
+	}
+	return example
+}
+
+func (c *GetPipelineMinutesUsage) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "projects",
+			Label:       "Projects",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Limit the per-project breakdown and totals to specific projects. Leave empty to include all projects with usage.",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:  ResourceTypeProject,
+					Multi: true,
+				},
+			},
+		},
+	}
+}
+
+func (c *GetPipelineMinutesUsage) Setup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetPipelineMinutesUsage) Execute(ctx core.ExecutionContext) error {
+	var config GetPipelineMinutesUsageConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitLab client: %w", err)
+	}
+
+	namespaceGID, err := resolveNamespaceGID(client)
+	if err != nil {
+		return err
+	}
+
+	date := time.Now().Format("2006-01") + "-01"
+	usage, projects, err := client.GetCiMinutesUsage(context.Background(), namespaceGID, date)
+	if err != nil {
+		return fmt.Errorf("failed to get pipeline minutes usage: %w", err)
+	}
+
+	if len(config.Projects) > 0 {
+		projects = filterProjectsUsage(projects, config.Projects)
+	}
+
+	result := PipelineMinutesUsageResult{
+		Month:                 usage.Month,
+		MonthIso8601:          usage.MonthIso8601,
+		Minutes:               usage.Minutes,
+		SharedRunnersDuration: usage.SharedRunnersDuration,
+		Projects:              projects,
+	}
+
+	if len(config.Projects) > 0 {
+		result.Minutes = 0
+		result.SharedRunnersDuration = 0
+		for _, p := range projects {
+			result.Minutes += p.Minutes
+			result.SharedRunnersDuration += p.SharedRunnersDuration
+		}
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gitlab.pipelineMinutesUsage",
+		[]any{result},
+	)
+}
+
+// resolveNamespaceGID turns the connected integration's configured group into a GraphQL namespace ID, or nil to use the current user's personal namespace.
+func resolveNamespaceGID(client *Client) (*string, error) {
+	if client.groupID == "" {
+		return nil, nil
+	}
+
+	group, err := client.GetGroup(client.groupID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve group: %w", err)
+	}
+
+	gid := fmt.Sprintf("gid://gitlab/Group/%d", group.ID)
+	return &gid, nil
+}
+
+// filterProjectsUsage keeps only the usage entries for projects whose numeric ID is in selected.
+func filterProjectsUsage(projects []CiMinutesProjectUsage, selected []string) []CiMinutesProjectUsage {
+	filtered := make([]CiMinutesProjectUsage, 0, len(projects))
+	for _, p := range projects {
+		if p.Project == nil {
+			continue
+		}
+		if slices.Contains(selected, globalIDSuffix(p.Project.ID)) {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
+}
+
+// globalIDSuffix extracts the trailing numeric ID from a GitLab GraphQL Global ID, e.g. "gid://gitlab/Project/123" -> "123".
+func globalIDSuffix(gid string) string {
+	idx := strings.LastIndex(gid, "/")
+	if idx == -1 {
+		return gid
+	}
+	return gid[idx+1:]
+}
+
+func (c *GetPipelineMinutesUsage) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetPipelineMinutesUsage) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *GetPipelineMinutesUsage) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetPipelineMinutesUsage) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetPipelineMinutesUsage) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetPipelineMinutesUsage) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gitlab/get_pipeline_minutes_usage_test.go
+++ b/pkg/integrations/gitlab/get_pipeline_minutes_usage_test.go
@@ -96,7 +96,7 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 			},
 			HTTP: &contexts.HTTPContext{
 				Responses: []*http.Response{
-					GitlabMockResponse(http.StatusOK, `{"id": 456}`),
+					GitlabMockResponse(http.StatusOK, `{"id": 456, "full_path": "my-org"}`),
 					GitlabMockResponse(http.StatusOK, ciMinutesNamespaceUsageResponseBody()),
 					GitlabMockResponse(http.StatusOK, ciMinutesProjectUsageResponseBody()),
 				},
@@ -108,7 +108,7 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
-		require.Len(t, httpCtx.Requests, 3)
+		require.Len(t, httpCtx.Requests, 3, "a root group must not trigger a second group lookup")
 		assert.Equal(t, "https://gitlab.com/api/v4/groups/my-org", httpCtx.Requests[0].URL.String())
 
 		for _, req := range httpCtx.Requests[1:] {
@@ -117,6 +117,46 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 			json.Unmarshal(body, &reqBody)
 			variables := reqBody["variables"].(map[string]any)
 			assert.Equal(t, "gid://gitlab/Group/456", variables["namespaceId"])
+		}
+	})
+
+	t.Run("success - resolves a subgroup to its root group, since minutes are only tracked there", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+					"groupId":     "my-org/my-subgroup",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{"id": 789, "full_path": "my-org/my-subgroup"}`),
+					GitlabMockResponse(http.StatusOK, `{"id": 456, "full_path": "my-org"}`),
+					GitlabMockResponse(http.StatusOK, ciMinutesNamespaceUsageResponseBody()),
+					GitlabMockResponse(http.StatusOK, ciMinutesProjectUsageResponseBody()),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		require.Len(t, httpCtx.Requests, 4)
+		assert.Equal(t, "https://gitlab.com/api/v4/groups/my-org%2Fmy-subgroup", httpCtx.Requests[0].URL.String())
+		assert.Equal(t, "https://gitlab.com/api/v4/groups/my-org", httpCtx.Requests[1].URL.String())
+
+		for _, req := range httpCtx.Requests[2:] {
+			body, _ := io.ReadAll(req.Body)
+			var reqBody map[string]any
+			json.Unmarshal(body, &reqBody)
+			variables := reqBody["variables"].(map[string]any)
+			assert.Equal(t, "gid://gitlab/Group/456", variables["namespaceId"], "must use the root group's ID (456), not the subgroup's own ID (789)")
 		}
 	})
 

--- a/pkg/integrations/gitlab/get_pipeline_minutes_usage_test.go
+++ b/pkg/integrations/gitlab/get_pipeline_minutes_usage_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -194,6 +195,41 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 		assert.Equal(t, "hello-world", result.Projects[0].Project.Name)
 		assert.Equal(t, 180, result.Minutes, "totals must reflect only the selected project")
 		assert.Equal(t, 10800, result.SharedRunnersDuration)
+	})
+
+	t.Run("falls back to summed project usage when the namespace has no record for the month", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{"data": {"ciMinutesUsage": {"nodes": []}}}`),
+					GitlabMockResponse(http.StatusOK, ciMinutesProjectUsageResponseBody()),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		payload := executionState.Payloads[0].(map[string]any)
+		var result PipelineMinutesUsageResult
+		payloadBytes, _ := json.Marshal(payload["data"])
+		json.Unmarshal(payloadBytes, &result)
+
+		require.Len(t, result.Projects, 2)
+		assert.Equal(t, 245, result.Minutes, "totals must be summed from project usage, not silently left at zero")
+		assert.Equal(t, 14700, result.SharedRunnersDuration)
+		assert.NotEmpty(t, result.Month, "month must be derived from the query date, not left blank")
+		assert.Equal(t, time.Now().Format("2006-01")+"-01", result.MonthIso8601)
 	})
 
 	t.Run("failure", func(t *testing.T) {

--- a/pkg/integrations/gitlab/get_pipeline_minutes_usage_test.go
+++ b/pkg/integrations/gitlab/get_pipeline_minutes_usage_test.go
@@ -1,0 +1,192 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func ciMinutesUsageResponseBody() string {
+	return `{
+		"data": {
+			"ciMinutesUsage": {
+				"nodes": [{"month": "July", "monthIso8601": "2026-07-01", "minutes": 245, "sharedRunnersDuration": 14700}]
+			},
+			"ciMinutesProjectMonthlyUsage": {
+				"nodes": [
+					{"minutes": 180, "sharedRunnersDuration": 10800, "project": {"id": "gid://gitlab/Project/1", "name": "hello-world", "fullPath": "felixgateru/hello-world"}},
+					{"minutes": 65, "sharedRunnersDuration": 3900, "project": {"id": "gid://gitlab/Project/2", "name": "other-project", "fullPath": "felixgateru/other-project"}}
+				]
+			}
+		}
+	}`
+}
+
+func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
+	c := &GetPipelineMinutesUsage{}
+
+	t.Run("success - personal namespace", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, ciMinutesUsageResponseBody()),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		assert.Equal(t, "gitlab.pipelineMinutesUsage", executionState.Type)
+
+		var result PipelineMinutesUsageResult
+		payloadBytes, _ := json.Marshal(payload["data"])
+		json.Unmarshal(payloadBytes, &result)
+
+		assert.Equal(t, "July", result.Month)
+		assert.Equal(t, 245, result.Minutes)
+		assert.Equal(t, 14700, result.SharedRunnersDuration)
+		require.Len(t, result.Projects, 2)
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "https://gitlab.com/api/graphql", httpCtx.Requests[0].URL.String())
+	})
+
+	t.Run("success - resolves group to a namespace GID first", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+					"groupId":     "my-org",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{"id": 456}`),
+					GitlabMockResponse(http.StatusOK, ciMinutesUsageResponseBody()),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		require.Len(t, httpCtx.Requests, 2)
+		assert.Equal(t, "https://gitlab.com/api/v4/groups/my-org", httpCtx.Requests[0].URL.String())
+
+		body, _ := io.ReadAll(httpCtx.Requests[1].Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+		variables := reqBody["variables"].(map[string]any)
+		assert.Equal(t, "gid://gitlab/Group/456", variables["namespaceId"])
+	})
+
+	t.Run("filters projects and recomputes totals when selected", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"projects": []string{"1"},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, ciMinutesUsageResponseBody()),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		payload := executionState.Payloads[0].(map[string]any)
+		var result PipelineMinutesUsageResult
+		payloadBytes, _ := json.Marshal(payload["data"])
+		json.Unmarshal(payloadBytes, &result)
+
+		require.Len(t, result.Projects, 1)
+		assert.Equal(t, "hello-world", result.Projects[0].Project.Name)
+		assert.Equal(t, 180, result.Minutes, "totals must reflect only the selected project")
+		assert.Equal(t, 10800, result.SharedRunnersDuration)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{"errors": [{"message": "not authorized to read usage"}]}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get pipeline minutes usage")
+		assert.Contains(t, err.Error(), "not authorized to read usage")
+	})
+
+	t.Run("group resolution failure", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"authType":    AuthTypePersonalAccessToken,
+					"accessToken": "pat",
+					"baseUrl":     "https://gitlab.com",
+					"groupId":     "my-org",
+				},
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusNotFound, `{"message": "404 Group Not Found"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to resolve group")
+
+		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
+		assert.Len(t, httpCtx.Requests, 1, "must not attempt the usage query if group resolution failed")
+	})
+}

--- a/pkg/integrations/gitlab/get_pipeline_minutes_usage_test.go
+++ b/pkg/integrations/gitlab/get_pipeline_minutes_usage_test.go
@@ -12,17 +12,25 @@ import (
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
-func ciMinutesUsageResponseBody() string {
+func ciMinutesNamespaceUsageResponseBody() string {
 	return `{
 		"data": {
 			"ciMinutesUsage": {
 				"nodes": [{"month": "July", "monthIso8601": "2026-07-01", "minutes": 245, "sharedRunnersDuration": 14700}]
-			},
+			}
+		}
+	}`
+}
+
+func ciMinutesProjectUsageResponseBody() string {
+	return `{
+		"data": {
 			"ciMinutesProjectMonthlyUsage": {
 				"nodes": [
 					{"minutes": 180, "sharedRunnersDuration": 10800, "project": {"id": "gid://gitlab/Project/1", "name": "hello-world", "fullPath": "felixgateru/hello-world"}},
 					{"minutes": 65, "sharedRunnersDuration": 3900, "project": {"id": "gid://gitlab/Project/2", "name": "other-project", "fullPath": "felixgateru/other-project"}}
-				]
+				],
+				"pageInfo": {"hasNextPage": false, "endCursor": ""}
 			}
 		}
 	}`
@@ -44,7 +52,8 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 			},
 			HTTP: &contexts.HTTPContext{
 				Responses: []*http.Response{
-					GitlabMockResponse(http.StatusOK, ciMinutesUsageResponseBody()),
+					GitlabMockResponse(http.StatusOK, ciMinutesNamespaceUsageResponseBody()),
+					GitlabMockResponse(http.StatusOK, ciMinutesProjectUsageResponseBody()),
 				},
 			},
 			ExecutionState: executionState,
@@ -67,8 +76,10 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 		require.Len(t, result.Projects, 2)
 
 		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
-		require.Len(t, httpCtx.Requests, 1)
-		assert.Equal(t, "https://gitlab.com/api/graphql", httpCtx.Requests[0].URL.String())
+		require.Len(t, httpCtx.Requests, 2)
+		for _, req := range httpCtx.Requests {
+			assert.Equal(t, "https://gitlab.com/api/graphql", req.URL.String())
+		}
 	})
 
 	t.Run("success - resolves group to a namespace GID first", func(t *testing.T) {
@@ -86,7 +97,8 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 			HTTP: &contexts.HTTPContext{
 				Responses: []*http.Response{
 					GitlabMockResponse(http.StatusOK, `{"id": 456}`),
-					GitlabMockResponse(http.StatusOK, ciMinutesUsageResponseBody()),
+					GitlabMockResponse(http.StatusOK, ciMinutesNamespaceUsageResponseBody()),
+					GitlabMockResponse(http.StatusOK, ciMinutesProjectUsageResponseBody()),
 				},
 			},
 			ExecutionState: executionState,
@@ -96,14 +108,16 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 		require.NoError(t, err)
 
 		httpCtx := ctx.HTTP.(*contexts.HTTPContext)
-		require.Len(t, httpCtx.Requests, 2)
+		require.Len(t, httpCtx.Requests, 3)
 		assert.Equal(t, "https://gitlab.com/api/v4/groups/my-org", httpCtx.Requests[0].URL.String())
 
-		body, _ := io.ReadAll(httpCtx.Requests[1].Body)
-		var reqBody map[string]any
-		json.Unmarshal(body, &reqBody)
-		variables := reqBody["variables"].(map[string]any)
-		assert.Equal(t, "gid://gitlab/Group/456", variables["namespaceId"])
+		for _, req := range httpCtx.Requests[1:] {
+			body, _ := io.ReadAll(req.Body)
+			var reqBody map[string]any
+			json.Unmarshal(body, &reqBody)
+			variables := reqBody["variables"].(map[string]any)
+			assert.Equal(t, "gid://gitlab/Group/456", variables["namespaceId"])
+		}
 	})
 
 	t.Run("filters projects and recomputes totals when selected", func(t *testing.T) {
@@ -121,7 +135,8 @@ func Test__GetPipelineMinutesUsage__Execute(t *testing.T) {
 			},
 			HTTP: &contexts.HTTPContext{
 				Responses: []*http.Response{
-					GitlabMockResponse(http.StatusOK, ciMinutesUsageResponseBody()),
+					GitlabMockResponse(http.StatusOK, ciMinutesNamespaceUsageResponseBody()),
+					GitlabMockResponse(http.StatusOK, ciMinutesProjectUsageResponseBody()),
 				},
 			},
 			ExecutionState: executionState,

--- a/pkg/integrations/gitlab/gitlab.go
+++ b/pkg/integrations/gitlab/gitlab.go
@@ -194,6 +194,7 @@ func (g *GitLab) Actions() []core.Action {
 		&DeleteRelease{},
 		&GetCommitStatus{},
 		&PublishCommitStatus{},
+		&GetPipelineMinutesUsage{},
 	}
 }
 

--- a/web_src/src/pages/app/mappers/gitlab/get_pipeline_minutes_usage.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/get_pipeline_minutes_usage.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { getPipelineMinutesUsageMapper } from "./get_pipeline_minutes_usage";
+
+describe("getPipelineMinutesUsageMapper", () => {
+  it("shows pipeline minutes usage details", () => {
+    const details = getPipelineMinutesUsageMapper.getExecutionDetails(
+      buildDetailsContext({
+        outputs: {
+          default: [
+            {
+              data: {
+                month: "July",
+                monthIso8601: "2026-07-01",
+                minutes: 245,
+                sharedRunnersDuration: 14700,
+                projects: [
+                  { minutes: 180, sharedRunnersDuration: 10800, project: { name: "hello-world" } },
+                  { minutes: 65, sharedRunnersDuration: 3900, project: { name: "other-project" } },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      Month: "July",
+      "Minutes Used": "245",
+      "Shared Runners Duration": "14700s",
+      Projects: "hello-world, other-project",
+    });
+  });
+
+  it("handles missing outputs", () => {
+    const details = getPipelineMinutesUsageMapper.getExecutionDetails(
+      buildDetailsContext({
+        outputs: {},
+      }),
+    );
+
+    expect(details).toEqual({});
+  });
+
+  it("shows the selected project count in node metadata", () => {
+    const context = buildDetailsContext({});
+    context.node.configuration = { projects: ["1", "2"] };
+
+    const props = getPipelineMinutesUsageMapper.props({
+      nodes: context.nodes,
+      node: context.node,
+      componentDefinition: {
+        name: "gitlab.getPipelineMinutesUsage",
+        label: "Get Pipeline Minutes Usage",
+        description: "",
+        icon: "gitlab",
+        color: "orange",
+      },
+      lastExecutions: [],
+      currentUser: undefined,
+      actions: { invokeNodeExecutionHook: async () => {} },
+    });
+
+    expect(props.metadata).toEqual([{ icon: "book", label: "2 project(s)" }]);
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Get Pipeline Minutes Usage",
+    componentName: "gitlab.getPipelineMinutesUsage",
+    isCollapsed: false,
+    configuration: {},
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/gitlab/get_pipeline_minutes_usage.ts
+++ b/web_src/src/pages/app/mappers/gitlab/get_pipeline_minutes_usage.ts
@@ -1,0 +1,68 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import type { PipelineMinutesUsage } from "./types";
+import { buildGitlabExecutionSubtitle } from "./utils";
+
+interface GetPipelineMinutesUsageConfiguration {
+  projects?: string[];
+}
+
+export const getPipelineMinutesUsageMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as GetPipelineMinutesUsageConfiguration | undefined) ?? {};
+    const metadataItems: MetadataItem[] = [];
+
+    if (configuration.projects && configuration.projects.length > 0) {
+      metadataItems.push({ icon: "book", label: `${configuration.projects.length} project(s)` });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const usage = outputs?.default?.[0]?.data as PipelineMinutesUsage | undefined;
+    if (usage) {
+      return `${usage.minutes} min (${usage.month})`;
+    }
+    return buildGitlabExecutionSubtitle(context.execution, "Pipeline Minutes Usage Retrieved");
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const details: Record<string, string> = {};
+
+    if (!outputs?.default || outputs.default.length === 0) {
+      return details;
+    }
+
+    const usage = outputs.default[0].data as PipelineMinutesUsage;
+    if (!usage) {
+      return details;
+    }
+
+    details["Month"] = usage.month || "-";
+    details["Minutes Used"] = typeof usage.minutes === "number" ? String(usage.minutes) : "-";
+    details["Shared Runners Duration"] =
+      typeof usage.sharedRunnersDuration === "number" ? `${usage.sharedRunnersDuration}s` : "-";
+
+    if (usage.projects && usage.projects.length > 0) {
+      details["Projects"] = usage.projects.map((p) => p.project?.name).filter(Boolean).join(", ");
+    }
+
+    return details;
+  },
+};

--- a/web_src/src/pages/app/mappers/gitlab/get_pipeline_minutes_usage.ts
+++ b/web_src/src/pages/app/mappers/gitlab/get_pipeline_minutes_usage.ts
@@ -60,7 +60,10 @@ export const getPipelineMinutesUsageMapper: ComponentBaseMapper = {
       typeof usage.sharedRunnersDuration === "number" ? `${usage.sharedRunnersDuration}s` : "-";
 
     if (usage.projects && usage.projects.length > 0) {
-      details["Projects"] = usage.projects.map((p) => p.project?.name).filter(Boolean).join(", ");
+      details["Projects"] = usage.projects
+        .map((p) => p.project?.name)
+        .filter(Boolean)
+        .join(", ");
     }
 
     return details;

--- a/web_src/src/pages/app/mappers/gitlab/index.ts
+++ b/web_src/src/pages/app/mappers/gitlab/index.ts
@@ -17,6 +17,7 @@ import { createReleaseMapper } from "./create_release";
 import { updateReleaseMapper } from "./update_release";
 import { getReleaseMapper } from "./get_release";
 import { deleteReleaseMapper } from "./delete_release";
+import { getPipelineMinutesUsageMapper } from "./get_pipeline_minutes_usage";
 import { getIssueMapper } from "./get_issue";
 import { getCommitStatusMapper } from "./get_commit_status";
 import { publishCommitStatusMapper } from "./publish_commit_status";
@@ -66,6 +67,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   deleteRelease: buildActionStateRegistry("deleted"),
   getCommitStatus: buildActionStateRegistry("retrieved"),
   publishCommitStatus: buildActionStateRegistry("published"),
+  getPipelineMinutesUsage: buildActionStateRegistry("retrieved"),
 };
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
@@ -96,6 +98,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   deleteRelease: deleteReleaseMapper,
   getCommitStatus: getCommitStatusMapper,
   publishCommitStatus: publishCommitStatusMapper,
+  getPipelineMinutesUsage: getPipelineMinutesUsageMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {

--- a/web_src/src/pages/app/mappers/gitlab/types.ts
+++ b/web_src/src/pages/app/mappers/gitlab/types.ts
@@ -238,3 +238,23 @@ export interface Release {
   evidence_sha?: string;
   _links?: ReleaseLinks;
 }
+
+export interface PipelineMinutesUsageProjectRef {
+  id: string;
+  name: string;
+  fullPath: string;
+}
+
+export interface PipelineMinutesUsageProject {
+  minutes: number;
+  sharedRunnersDuration: number;
+  project?: PipelineMinutesUsageProjectRef;
+}
+
+export interface PipelineMinutesUsage {
+  month: string;
+  monthIso8601: string;
+  minutes: number;
+  sharedRunnersDuration: number;
+  projects: PipelineMinutesUsageProject[];
+}


### PR DESCRIPTION
Related to #6281

## What changed

Adds `gitlab.getPipelineMinutesUsage`, mirroring `github.getWorkflowUsage`, plus its frontend mapper.

## Why

GitHub's usage-monitoring component had no GitLab equivalent, even though GitLab tracks CI/CD compute minutes the same way. This lets a canvas track and alert on GitLab minutes usage the same way it already can for GitHub.

## How

### Backend

The component resolves the connected integration's configured group (or falls back to the personal namespace) and queries the current month's compute minutes usage with a per-project breakdown, optionally filtered down to selected projects. GitLab only exposes this data through GraphQL, not REST, so `client.go` gained a small generic GraphQL POST helper plus a `GetGroup` REST call used to turn a configured group path/ID into the GraphQL namespace ID it needs. Covered by unit tests and live-tested against a real GitLab account through a canvas app.

### Frontend

Added a matching mapper showing month, minutes used, shared runner duration, and the per-project breakdown, following the existing GitLab mapper pattern, with spec tests.