### PR TITLE
fix: keep selected agent composer text readable in dark mode

### DIFF
--- a/web_src/src/components/AgentSidebar/MentionTextarea.spec.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.spec.tsx
@@ -40,6 +40,12 @@ describe("MentionTextarea", () => {
     expect(textarea.style.overflowY).toBe("hidden");
   });
 
+  it("keeps selected glyphs transparent so the backdrop stays the visible text (issue #6372)", () => {
+    const { textarea } = renderTextarea("hello");
+
+    expect(textarea.className).toContain("selection:text-transparent");
+  });
+
   it("caps height and syncs internal scroll with the backdrop", () => {
     const mention: InsertedMention = {
       id: "node-1",

--- a/web_src/src/components/AgentSidebar/MentionTextarea.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.tsx
@@ -121,7 +121,7 @@ export function MentionTextarea({
           composerTextMetrics,
           "outline-none ring-0 focus-visible:border-0 focus-visible:ring-0 focus-visible:outline-none",
           "placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
-          "text-transparent caret-slate-900 selection:bg-blue-200/50 dark:caret-gray-100 dark:selection:bg-blue-500/30",
+          "text-transparent caret-slate-900 selection:bg-blue-200/50 selection:text-transparent dark:caret-gray-100 dark:selection:bg-blue-500/30",
           "dark:bg-transparent",
         )}
         onKeyDown={onKeyDown}


### PR DESCRIPTION
Fixes #6372

Before
<img width="3600" height="280" alt="image-1785434430381" src="https://github.com/user-attachments/assets/c78d93dd-9d12-42f9-8f9b-56a3b0a8b52a" />

After
<img width="3600" height="280" alt="image-1785434435577" src="https://github.com/user-attachments/assets/2c4555b6-9972-499f-b90f-ff11cb0ca687" />
