### PR TITLE
feat: add minimal software factory design

### DIFF
--- a/web_src/src/pages/factory/NewSoftwareFactoryDialog.tsx
+++ b/web_src/src/pages/factory/NewSoftwareFactoryDialog.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { NewFactoryInput } from "./factoryTypes";
+
+interface NewSoftwareFactoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreate: (input: NewFactoryInput) => void;
+}
+
+const emptyFactory: NewFactoryInput = { name: "", description: "" };
+
+export function NewSoftwareFactoryDialog({ open, onOpenChange, onCreate }: NewSoftwareFactoryDialogProps) {
+  const [draft, setDraft] = useState<NewFactoryInput>(emptyFactory);
+
+  useEffect(() => {
+    if (!open) setDraft(emptyFactory);
+  }, [open]);
+
+  const createFactory = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (draft.name.trim().length === 0) return;
+
+      onCreate({
+        name: draft.name.trim(),
+        description: draft.description.trim(),
+      });
+      onOpenChange(false);
+    },
+    [draft, onCreate, onOpenChange],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={createFactory}>
+          <DialogHeader>
+            <DialogTitle>Create Software Factory</DialogTitle>
+            <DialogDescription>
+              Create the workspace first. You can add an Automation and connect repositories afterward.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="mt-5 space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="factory-name">Name</Label>
+              <Input
+                id="factory-name"
+                autoFocus
+                value={draft.name}
+                placeholder="Payments Factory"
+                onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="factory-description">
+                Description <span className="font-normal text-gray-500">Optional</span>
+              </Label>
+              <Textarea
+                id="factory-description"
+                rows={4}
+                value={draft.description}
+                placeholder="What kind of software work should this Factory handle?"
+                onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="mt-6">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={draft.name.trim().length === 0}>
+              Create Factory
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/factory/NewWorkOrderPage.tsx
+++ b/web_src/src/pages/factory/NewWorkOrderPage.tsx
@@ -1,0 +1,149 @@
+import { ArrowLeft, Factory } from "lucide-react";
+import { useCallback, useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { Automation, NewWorkOrderInput, SoftwareFactory } from "./factoryTypes";
+
+interface NewWorkOrderPageProps {
+  factory: SoftwareFactory;
+  automations: Automation[];
+  onCancel: () => void;
+  onCreate: (input: NewWorkOrderInput) => void;
+}
+
+const emptyWorkOrder: NewWorkOrderInput = { title: "", description: "", automationIds: [] };
+
+export function NewWorkOrderPage({ factory, automations, onCancel, onCreate }: NewWorkOrderPageProps) {
+  const [draft, setDraft] = useState<NewWorkOrderInput>(emptyWorkOrder);
+  const canCreate =
+    draft.title.trim().length > 0 && draft.description.trim().length > 0 && draft.automationIds.length > 0;
+
+  const setAutomationSelected = useCallback((automationId: string, selected: boolean) => {
+    setDraft((current) => ({
+      ...current,
+      automationIds: selected
+        ? [...current.automationIds, automationId]
+        : current.automationIds.filter((id) => id !== automationId),
+    }));
+  }, []);
+
+  const createWorkOrder = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!canCreate) return;
+
+      onCreate({
+        title: draft.title.trim(),
+        description: draft.description.trim(),
+        automationIds: draft.automationIds,
+      });
+    },
+    [canCreate, draft, onCreate],
+  );
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-950 dark:bg-gray-950 dark:text-gray-100">
+      <main className="mx-auto w-full max-w-[1040px] px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <Button type="button" variant="ghost" size="sm" className="-ml-3" onClick={onCancel}>
+          <ArrowLeft aria-hidden />
+          {factory.name}
+        </Button>
+
+        <header className="mt-5 border-b border-slate-200 pb-7 dark:border-gray-800">
+          <div className="mb-2 flex items-center gap-2 text-xs font-medium text-slate-500 dark:text-gray-400">
+            <Factory className="size-4" aria-hidden />
+            New Work Order
+          </div>
+          <h1 className="text-2xl font-semibold text-slate-950 dark:text-white">Describe the work</h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 dark:text-gray-400">
+            Capture one concrete software change. The Work Order will remain a draft until it is approved.
+          </p>
+        </header>
+
+        <form className="mt-8" onSubmit={createWorkOrder}>
+          <div className="space-y-3">
+            <Label htmlFor="new-work-order-title">Title</Label>
+            <Input
+              id="new-work-order-title"
+              autoFocus
+              className="h-10 text-base"
+              value={draft.title}
+              placeholder="Add refund reconciliation test"
+              onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))}
+            />
+          </div>
+
+          <div className="mt-6 space-y-3">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <Label htmlFor="new-work-order-description">Description</Label>
+              <span className="text-xs text-slate-400 dark:text-gray-500">Expected outcome and constraints</span>
+            </div>
+            <Textarea
+              id="new-work-order-description"
+              rows={14}
+              className="min-h-80 resize-y text-base leading-7"
+              value={draft.description}
+              placeholder="Describe what should change, why it matters, and anything the Automation must preserve."
+              onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))}
+            />
+          </div>
+
+          <fieldset className="mt-6 border-t border-slate-200 pt-6 dark:border-gray-800">
+            <legend className="text-sm font-medium text-slate-800 dark:text-gray-100">Automations</legend>
+            <p className="mt-2 text-xs leading-5 text-slate-500 dark:text-gray-400">
+              Choose one or more pipelines to process this Work Order after approval.
+            </p>
+
+            {automations.length === 0 ? (
+              <p className="mt-3 rounded-md border border-dashed border-slate-300 px-4 py-3 text-sm text-slate-500 dark:border-gray-700 dark:text-gray-400">
+                No Automations are available.
+              </p>
+            ) : (
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                {automations.map((automation) => {
+                  const checkboxId = `new-work-order-automation-${automation.id}`;
+
+                  return (
+                    <label
+                      key={automation.id}
+                      htmlFor={checkboxId}
+                      className="flex cursor-pointer items-start gap-3 rounded-md border border-slate-200 bg-white px-4 py-3 transition-colors has-[:checked]:border-slate-900 has-[:checked]:bg-slate-50 dark:border-gray-700 dark:bg-gray-900 dark:has-[:checked]:border-gray-300 dark:has-[:checked]:bg-gray-800"
+                    >
+                      <Checkbox
+                        id={checkboxId}
+                        checked={draft.automationIds.includes(automation.id)}
+                        onChange={(event) => setAutomationSelected(automation.id, event.target.checked)}
+                      />
+                      <span className="min-w-0">
+                        <span className="block text-sm font-medium text-slate-950 dark:text-gray-100">
+                          {automation.name}
+                        </span>
+                        <span className="mt-1 block text-xs leading-5 text-slate-500 dark:text-gray-400">
+                          {automation.description}
+                        </span>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </fieldset>
+
+          <footer className="mt-8 flex flex-col-reverse gap-3 border-t border-slate-200 pt-6 dark:border-gray-800 sm:flex-row sm:justify-end">
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canCreate}>
+              Create draft
+            </Button>
+          </footer>
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/web_src/src/pages/factory/SoftwareFactoryPage.spec.tsx
+++ b/web_src/src/pages/factory/SoftwareFactoryPage.spec.tsx
@@ -1,0 +1,231 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { NewWorkOrderPage } from "./NewWorkOrderPage";
+import { SoftwareFactoryPage } from "./SoftwareFactoryPage";
+import { WorkOrderPage } from "./WorkOrderPage";
+import type { Automation, SoftwareFactory, WorkOrder, WorkOrderEvent } from "./factoryTypes";
+
+const factory: SoftwareFactory = {
+  id: "factory-1",
+  name: "Payments Factory",
+  description: "Delegated implementation work for the payments platform.",
+};
+
+const draftWorkOrder: WorkOrder = {
+  id: "wo-1",
+  title: "Add refund reconciliation test",
+  description: "Cover the refund reconciliation path before the next release.",
+  state: "draft",
+  createdByUserId: "user-darko",
+  createdByName: "Darko",
+  createdAt: "2026-07-30T08:00:00Z",
+  updatedAt: "2026-07-30T08:00:00Z",
+  automations: [
+    { id: "automation-1", name: "Implementation pipeline", state: "planned" },
+    { id: "automation-2", name: "Verification pipeline", state: "running" },
+  ],
+};
+
+const automation: Automation = {
+  id: "automation-1",
+  name: "Implementation pipeline",
+  description: "Implements approved Work Orders and opens a pull request.",
+  state: "running",
+  runningCount: 2,
+  queuedCount: 3,
+  lastRunAt: "2026-07-30T07:00:00Z",
+};
+
+const idleAutomation: Automation = {
+  ...automation,
+  id: "automation-2",
+  name: "Verification pipeline",
+  state: "idle",
+  runningCount: 0,
+  queuedCount: 0,
+};
+
+const createdEvent: WorkOrderEvent = {
+  id: "event-1",
+  kind: "created",
+  summary: "Work Order created",
+  actor: "Darko",
+  occurredAt: "2026-07-30T08:00:00Z",
+};
+
+describe("SoftwareFactoryPage", () => {
+  it("keeps Work Orders and Automations on one operational page", () => {
+    const { container } = render(
+      <SoftwareFactoryPage
+        factory={factory}
+        workOrders={[draftWorkOrder]}
+        automations={[automation, idleAutomation]}
+        currentUserId="user-darko"
+        onNewWorkOrder={vi.fn()}
+        onOpenWorkOrder={vi.fn()}
+        onCreateAutomation={vi.fn()}
+        onOpenAutomation={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Work Orders" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open Canvas" })).not.toBeInTheDocument();
+    expect(screen.getByText("Created by Darko")).toBeInTheDocument();
+    expect(screen.getByLabelText("Implementation pipeline: Planned")).toBeInTheDocument();
+    expect(screen.getByLabelText("Verification pipeline: Running")).toBeInTheDocument();
+    expect(screen.getByLabelText("2 running now")).toBeInTheDocument();
+    expect(screen.getByLabelText("3 in queue")).toBeInTheDocument();
+    expect(screen.queryByText("Work Order ready")).not.toBeInTheDocument();
+    expect(screen.queryByText(/nodes?/i)).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Active")).not.toBeInTheDocument();
+    expect(container.querySelector(".lucide-bot")).not.toBeInTheDocument();
+    expect(container.querySelector(".lucide-circle-dashed")).toBeInTheDocument();
+  });
+
+  it("requests the dedicated creation page from New Work Order", async () => {
+    const user = userEvent.setup();
+    const onNewWorkOrder = vi.fn();
+
+    render(
+      <SoftwareFactoryPage
+        factory={factory}
+        workOrders={[draftWorkOrder]}
+        automations={[automation]}
+        currentUserId="user-darko"
+        onNewWorkOrder={onNewWorkOrder}
+        onOpenWorkOrder={vi.fn()}
+        onCreateAutomation={vi.fn()}
+        onOpenAutomation={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "New Work Order" }));
+
+    expect(onNewWorkOrder).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("combines ownership and status filters", async () => {
+    const user = userEvent.setup();
+    const successfulWorkOrder: WorkOrder = {
+      ...draftWorkOrder,
+      id: "wo-2",
+      title: "Fix settlement rounding",
+      state: "successful",
+      createdByUserId: "user-maya",
+    };
+    const runningWorkOrder: WorkOrder = {
+      ...draftWorkOrder,
+      id: "wo-3",
+      title: "Reject unsigned payment webhooks",
+      state: "running",
+    };
+
+    render(
+      <SoftwareFactoryPage
+        factory={factory}
+        workOrders={[draftWorkOrder, successfulWorkOrder, runningWorkOrder]}
+        automations={[automation]}
+        currentUserId="user-darko"
+        onNewWorkOrder={vi.fn()}
+        onOpenWorkOrder={vi.fn()}
+        onCreateAutomation={vi.fn()}
+        onOpenAutomation={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Mine" }));
+
+    expect(screen.getByRole("button", { name: draftWorkOrder.title })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: runningWorkOrder.title })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: successfulWorkOrder.title })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Running" }));
+
+    expect(screen.getByRole("button", { name: runningWorkOrder.title })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: draftWorkOrder.title })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Successful" }));
+
+    expect(screen.getByText("No matching Work Orders")).toBeInTheDocument();
+  });
+});
+
+describe("NewWorkOrderPage", () => {
+  it("creates a draft with the selected Automations", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+
+    render(
+      <NewWorkOrderPage
+        factory={factory}
+        automations={[automation, idleAutomation]}
+        onCancel={vi.fn()}
+        onCreate={onCreate}
+      />,
+    );
+
+    const description = screen.getByLabelText("Description");
+    expect(description).toHaveAttribute("rows", "14");
+
+    await user.type(screen.getByLabelText("Title"), "Prevent duplicate webhook delivery");
+    await user.type(description, "Reuse the delivery key when GitHub retries a webhook.");
+    await user.click(screen.getByRole("checkbox", { name: /Implementation pipeline/ }));
+    await user.click(screen.getByRole("checkbox", { name: /Verification pipeline/ }));
+    await user.click(screen.getByRole("button", { name: "Create draft" }));
+
+    expect(onCreate).toHaveBeenCalledWith({
+      title: "Prevent duplicate webhook delivery",
+      description: "Reuse the delivery key when GitHub retries a webhook.",
+      automationIds: ["automation-1", "automation-2"],
+    });
+  });
+});
+
+describe("WorkOrderPage", () => {
+  it("offers approval only while the Work Order is a draft", async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn();
+
+    render(
+      <WorkOrderPage
+        factory={factory}
+        workOrder={draftWorkOrder}
+        events={[createdEvent]}
+        onBack={vi.fn()}
+        onApprove={onApprove}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Approve and queue" }));
+    expect(onApprove).toHaveBeenCalledOnce();
+  });
+
+  it("shows the produced pull request on a successful Work Order", () => {
+    render(
+      <WorkOrderPage
+        factory={factory}
+        workOrder={{
+          ...draftWorkOrder,
+          state: "successful",
+          primaryPullRequest: {
+            repository: "superplanehq/superplane",
+            number: 6412,
+            url: "https://github.com/superplanehq/superplane/pull/6412",
+          },
+        }}
+        events={[createdEvent]}
+        onBack={vi.fn()}
+        onApprove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "superplanehq/superplane #6412" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve and queue" })).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factory/SoftwareFactoryPage.stories.tsx
+++ b/web_src/src/pages/factory/SoftwareFactoryPage.stories.tsx
@@ -1,0 +1,190 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+import { fn } from "storybook/test";
+
+import { Button } from "@/components/ui/button";
+
+import {
+  draftEvents,
+  implementationAutomation,
+  paymentsFactory,
+  successfulEvents,
+  verificationAutomation,
+  workOrders as fixtureWorkOrders,
+} from "./__fixtures__/minimalFactoryFixtures";
+import type { NewFactoryInput, NewWorkOrderInput, WorkOrder, WorkOrderEvent } from "./factoryTypes";
+import { NewSoftwareFactoryDialog } from "./NewSoftwareFactoryDialog";
+import { NewWorkOrderPage } from "./NewWorkOrderPage";
+import { SoftwareFactoryPage } from "./SoftwareFactoryPage";
+import { WorkOrderPage } from "./WorkOrderPage";
+
+const meta = {
+  title: "Pages/Software Factory Minimal",
+  component: SoftwareFactoryPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof SoftwareFactoryPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const openWorkOrder = fn();
+const openAutomation = fn();
+const createAutomation = fn();
+const factoryAutomations = [implementationAutomation, verificationAutomation];
+
+export const Factory: Story = {
+  render: () => <InteractiveFactoryStory />,
+};
+
+export const NewFactory: Story = {
+  args: {
+    factory: {
+      id: "factory-new",
+      name: "Mobile Factory",
+      description: "Implementation work for the mobile applications.",
+    },
+    workOrders: [],
+    automations: [],
+    currentUserId: "user-darko",
+    onNewWorkOrder: fn(),
+    onOpenWorkOrder: openWorkOrder,
+    onCreateAutomation: createAutomation,
+    onOpenAutomation: openAutomation,
+  },
+};
+
+export const CreateFactory: Story = {
+  render: () => <CreateFactoryStory />,
+};
+
+export const NewWorkOrder: Story = {
+  render: () => (
+    <NewWorkOrderPage factory={paymentsFactory} automations={factoryAutomations} onCancel={fn()} onCreate={fn()} />
+  ),
+};
+
+export const DraftWorkOrder: Story = {
+  render: () => <InteractiveDraftWorkOrderStory />,
+};
+
+export const SuccessfulWorkOrder: Story = {
+  render: () => (
+    <WorkOrderPage
+      factory={paymentsFactory}
+      workOrder={fixtureWorkOrders[3]!}
+      events={successfulEvents}
+      onBack={fn()}
+      onApprove={fn()}
+    />
+  ),
+};
+
+function InteractiveFactoryStory() {
+  const [workOrders, setWorkOrders] = useState(fixtureWorkOrders);
+  const [isCreatingWorkOrder, setIsCreatingWorkOrder] = useState(false);
+
+  const createWorkOrder = useCallback((input: NewWorkOrderInput) => {
+    const createdAt = new Date().toISOString();
+    const selectedAutomations = factoryAutomations
+      .filter((automation) => input.automationIds.includes(automation.id))
+      .map((automation) => ({ id: automation.id, name: automation.name, state: "planned" as const }));
+    setWorkOrders((current) => [
+      {
+        id: `work-order-${current.length + 1}`,
+        title: input.title,
+        description: input.description,
+        state: "draft",
+        createdByUserId: "user-darko",
+        createdByName: "Darko",
+        createdAt,
+        updatedAt: createdAt,
+        automations: selectedAutomations,
+      },
+      ...current,
+    ]);
+    setIsCreatingWorkOrder(false);
+  }, []);
+
+  const openNewWorkOrder = useCallback(() => setIsCreatingWorkOrder(true), []);
+  const cancelNewWorkOrder = useCallback(() => setIsCreatingWorkOrder(false), []);
+
+  if (isCreatingWorkOrder) {
+    return (
+      <NewWorkOrderPage
+        factory={paymentsFactory}
+        automations={factoryAutomations}
+        onCancel={cancelNewWorkOrder}
+        onCreate={createWorkOrder}
+      />
+    );
+  }
+
+  return (
+    <SoftwareFactoryPage
+      factory={paymentsFactory}
+      workOrders={workOrders}
+      automations={factoryAutomations}
+      currentUserId="user-darko"
+      onNewWorkOrder={openNewWorkOrder}
+      onOpenWorkOrder={openWorkOrder}
+      onCreateAutomation={createAutomation}
+      onOpenAutomation={openAutomation}
+    />
+  );
+}
+
+function CreateFactoryStory() {
+  const [isOpen, setIsOpen] = useState(true);
+  const [createdFactory, setCreatedFactory] = useState<NewFactoryInput>();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-100 p-6 dark:bg-gray-950">
+      <div className="text-center">
+        <p className="text-sm text-slate-600 dark:text-gray-300">
+          {createdFactory ? `${createdFactory.name} created` : "Create a first-class Factory workspace."}
+        </p>
+        <Button type="button" className="mt-4" onClick={() => setIsOpen(true)}>
+          New Software Factory
+        </Button>
+      </div>
+      <NewSoftwareFactoryDialog open={isOpen} onOpenChange={setIsOpen} onCreate={setCreatedFactory} />
+    </div>
+  );
+}
+
+function InteractiveDraftWorkOrderStory() {
+  const [workOrder, setWorkOrder] = useState<WorkOrder>(fixtureWorkOrders[0]!);
+  const [events, setEvents] = useState<WorkOrderEvent[]>(draftEvents);
+
+  const approveWorkOrder = useCallback(() => {
+    const occurredAt = new Date().toISOString();
+    setWorkOrder((current) => ({
+      ...current,
+      state: "ready",
+      updatedAt: occurredAt,
+    }));
+    setEvents((current) => [
+      ...current,
+      {
+        id: `event-${current.length + 1}`,
+        kind: "approved",
+        summary: "Approved and moved to ready",
+        actor: "Darko",
+        occurredAt,
+      },
+    ]);
+  }, []);
+
+  return (
+    <WorkOrderPage
+      factory={paymentsFactory}
+      workOrder={workOrder}
+      events={events}
+      onBack={fn()}
+      onApprove={approveWorkOrder}
+    />
+  );
+}

--- a/web_src/src/pages/factory/SoftwareFactoryPage.tsx
+++ b/web_src/src/pages/factory/SoftwareFactoryPage.tsx
@@ -1,0 +1,463 @@
+import {
+  CircleCheck,
+  CircleDashed,
+  CircleX,
+  Clock3,
+  Factory,
+  GitBranch,
+  LoaderCircle,
+  Pause,
+  Plus,
+  Workflow,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { formatTimeAgo } from "@/lib/date";
+import { cn } from "@/lib/utils";
+
+import type {
+  Automation,
+  SoftwareFactory,
+  WorkOrder,
+  WorkOrderAutomation,
+  WorkOrderAutomationState,
+  WorkOrderState,
+} from "./factoryTypes";
+import { WorkOrderStateBadge } from "./WorkOrderStateBadge";
+
+type WorkOrderScope = "all" | "mine";
+type WorkOrderStateFilter = "all" | WorkOrderState;
+
+const stateFilters: Array<{ label: string; value: WorkOrderStateFilter }> = [
+  { label: "All statuses", value: "all" },
+  { label: "Draft", value: "draft" },
+  { label: "Ready", value: "ready" },
+  { label: "Running", value: "running" },
+  { label: "Successful", value: "successful" },
+  { label: "Unsuccessful", value: "unsuccessful" },
+];
+
+const automationStatePresentation: Record<
+  Automation["state"],
+  { label: string; className: string; icon: typeof Workflow }
+> = {
+  idle: { label: "Idle", className: "text-slate-500 dark:text-gray-400", icon: CircleDashed },
+  running: { label: "Running", className: "text-violet-700 dark:text-violet-300", icon: LoaderCircle },
+  paused: { label: "Paused", className: "text-amber-700 dark:text-amber-300", icon: Pause },
+};
+
+const workOrderAutomationPresentation: Record<
+  WorkOrderAutomationState,
+  { label: string; className: string; icon: typeof Workflow }
+> = {
+  planned: { label: "Planned", className: "text-slate-500 dark:text-gray-400", icon: Clock3 },
+  running: { label: "Running", className: "text-violet-700 dark:text-violet-300", icon: LoaderCircle },
+  done: { label: "Done", className: "text-emerald-700 dark:text-emerald-300", icon: CircleCheck },
+  failed: { label: "Failed", className: "text-red-700 dark:text-red-300", icon: CircleX },
+};
+
+interface SoftwareFactoryPageProps {
+  factory: SoftwareFactory;
+  workOrders: WorkOrder[];
+  automations: Automation[];
+  currentUserId: string;
+  onNewWorkOrder: () => void;
+  onOpenWorkOrder: (workOrder: WorkOrder) => void;
+  onCreateAutomation: () => void;
+  onOpenAutomation: (automation: Automation) => void;
+}
+
+export function SoftwareFactoryPage({
+  factory,
+  workOrders,
+  automations,
+  currentUserId,
+  onNewWorkOrder,
+  onOpenWorkOrder,
+  onCreateAutomation,
+  onOpenAutomation,
+}: SoftwareFactoryPageProps) {
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-950 dark:bg-gray-950 dark:text-gray-100">
+      <main className="mx-auto w-full max-w-[1480px] px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <FactoryHeader factory={factory} onNewWorkOrder={onNewWorkOrder} />
+
+        <div className="mt-8 grid items-start gap-8 xl:grid-cols-[minmax(0,1fr)_360px]">
+          <WorkOrdersSection workOrders={workOrders} currentUserId={currentUserId} onOpenWorkOrder={onOpenWorkOrder} />
+          <AutomationsSection
+            automations={automations}
+            onCreateAutomation={onCreateAutomation}
+            onOpenAutomation={onOpenAutomation}
+          />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function FactoryHeader({ factory, onNewWorkOrder }: { factory: SoftwareFactory; onNewWorkOrder: () => void }) {
+  return (
+    <header className="flex flex-col gap-5 border-b border-slate-200 pb-7 dark:border-gray-800 sm:flex-row sm:items-end sm:justify-between">
+      <div className="min-w-0">
+        <div className="mb-2 flex items-center gap-2 text-xs font-medium text-slate-500 dark:text-gray-400">
+          <Factory className="size-4" aria-hidden />
+          Software Factory
+        </div>
+        <h1 className="text-2xl font-semibold text-slate-950 dark:text-white">{factory.name}</h1>
+        {factory.description && (
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-gray-400">{factory.description}</p>
+        )}
+      </div>
+      <Button type="button" onClick={onNewWorkOrder}>
+        <Plus aria-hidden />
+        New Work Order
+      </Button>
+    </header>
+  );
+}
+
+function WorkOrdersSection({
+  workOrders,
+  currentUserId,
+  onOpenWorkOrder,
+}: {
+  workOrders: WorkOrder[];
+  currentUserId: string;
+  onOpenWorkOrder: (workOrder: WorkOrder) => void;
+}) {
+  const [scope, setScope] = useState<WorkOrderScope>("all");
+  const [stateFilter, setStateFilter] = useState<WorkOrderStateFilter>("all");
+  const filteredWorkOrders = useMemo(
+    () =>
+      workOrders.filter(
+        (workOrder) =>
+          (scope === "all" || workOrder.createdByUserId === currentUserId) &&
+          (stateFilter === "all" || workOrder.state === stateFilter),
+      ),
+    [currentUserId, scope, stateFilter, workOrders],
+  );
+  const hasActiveFilters = scope !== "all" || stateFilter !== "all";
+
+  return (
+    <section aria-labelledby="work-orders-heading">
+      <SectionHeading
+        id="work-orders-heading"
+        title="Work Orders"
+        description="The implementation queue for this Factory."
+        count={filteredWorkOrders.length}
+      />
+
+      <WorkOrderFilters
+        scope={scope}
+        stateFilter={stateFilter}
+        onScopeChange={setScope}
+        onStateChange={setStateFilter}
+      />
+
+      {filteredWorkOrders.length === 0 ? (
+        <EmptyWorkOrders filtered={hasActiveFilters} />
+      ) : (
+        <div className="mt-4 overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+          {filteredWorkOrders.map((workOrder, index) => (
+            <WorkOrderRow
+              key={workOrder.id}
+              workOrder={workOrder}
+              hasDivider={index > 0}
+              onOpen={() => onOpenWorkOrder(workOrder)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function WorkOrderFilters({
+  scope,
+  stateFilter,
+  onScopeChange,
+  onStateChange,
+}: {
+  scope: WorkOrderScope;
+  stateFilter: WorkOrderStateFilter;
+  onScopeChange: (scope: WorkOrderScope) => void;
+  onStateChange: (state: WorkOrderStateFilter) => void;
+}) {
+  return (
+    <div className="mt-4 flex flex-col gap-3 border-y border-slate-200 py-3 dark:border-gray-800 lg:flex-row lg:items-center lg:justify-between">
+      <FilterGroup label="Owner">
+        <FilterButton label="All" value="all" selected={scope === "all"} onSelect={onScopeChange} />
+        <FilterButton label="Mine" value="mine" selected={scope === "mine"} onSelect={onScopeChange} />
+      </FilterGroup>
+
+      <FilterGroup label="Status">
+        {stateFilters.map((filter) => (
+          <FilterButton
+            key={filter.value}
+            label={filter.label}
+            value={filter.value}
+            selected={stateFilter === filter.value}
+            onSelect={onStateChange}
+          />
+        ))}
+      </FilterGroup>
+    </div>
+  );
+}
+
+function FilterGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="w-12 text-xs font-medium text-slate-500 dark:text-gray-400 lg:w-auto">{label}</span>
+      <div className="inline-flex flex-wrap gap-1" role="group" aria-label={`${label} filter`}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function FilterButton<T extends string>({
+  label,
+  value,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  value: T;
+  selected: boolean;
+  onSelect: (value: T) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={() => onSelect(value)}
+      className={cn(
+        "h-7 rounded-md px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400",
+        selected
+          ? "bg-slate-900 text-white dark:bg-gray-100 dark:text-gray-950"
+          : "text-slate-600 hover:bg-slate-100 hover:text-slate-950 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function WorkOrderRow({
+  workOrder,
+  hasDivider,
+  onOpen,
+}: {
+  workOrder: WorkOrder;
+  hasDivider: boolean;
+  onOpen: () => void;
+}) {
+  return (
+    <article
+      className={cn(
+        "grid min-h-24 gap-3 px-4 py-4 transition-colors hover:bg-slate-50 dark:hover:bg-gray-800/60 sm:grid-cols-[minmax(0,1fr)_140px] sm:items-center sm:px-5",
+        hasDivider && "border-t border-slate-200 dark:border-gray-800",
+      )}
+    >
+      <div className="min-w-0">
+        <button
+          type="button"
+          onClick={onOpen}
+          className="block max-w-full truncate text-left text-sm font-medium text-slate-950 hover:underline dark:text-gray-100"
+        >
+          {workOrder.title}
+        </button>
+        <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-500 dark:text-gray-400">{workOrder.description}</p>
+        <WorkOrderAutomations automations={workOrder.automations} />
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-gray-500">
+          <span>Created by {workOrder.createdByName}</span>
+          <span>Updated {formatTimeAgo(new Date(workOrder.updatedAt))}</span>
+          {workOrder.primaryPullRequest && (
+            <a
+              href={workOrder.primaryPullRequest.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-blue-700 hover:underline dark:text-blue-400"
+            >
+              <GitBranch className="size-3.5" aria-hidden />
+              {workOrder.primaryPullRequest.repository} #{workOrder.primaryPullRequest.number}
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div className="sm:justify-self-start">
+        <WorkOrderStateBadge state={workOrder.state} />
+      </div>
+    </article>
+  );
+}
+
+function WorkOrderAutomations({ automations }: { automations: WorkOrderAutomation[] }) {
+  if (automations.length === 0) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1.5">
+      {automations.map((automation) => (
+        <WorkOrderAutomationStatus key={automation.id} automation={automation} />
+      ))}
+    </div>
+  );
+}
+
+function WorkOrderAutomationStatus({ automation }: { automation: WorkOrderAutomation }) {
+  const presentation = workOrderAutomationPresentation[automation.state];
+  const StateIcon = presentation.icon;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-xs text-slate-700 dark:text-gray-300"
+      aria-label={`${automation.name}: ${presentation.label}`}
+    >
+      <StateIcon
+        className={cn(
+          "size-3.5",
+          presentation.className,
+          automation.state === "running" && "animate-spin motion-reduce:animate-none",
+        )}
+        aria-hidden
+      />
+      <span>{automation.name}</span>
+      <span className={presentation.className}>· {presentation.label}</span>
+    </span>
+  );
+}
+
+function EmptyWorkOrders({ filtered }: { filtered: boolean }) {
+  return (
+    <div className="mt-4 flex min-h-48 flex-col items-center justify-center rounded-lg border border-dashed border-slate-300 bg-white px-6 text-center dark:border-gray-700 dark:bg-gray-900">
+      <GitBranch className="size-6 text-slate-400" aria-hidden />
+      <p className="mt-3 text-sm font-medium">{filtered ? "No matching Work Orders" : "No Work Orders yet"}</p>
+      <p className="mt-1 max-w-sm text-xs leading-5 text-slate-500 dark:text-gray-400">
+        {filtered
+          ? "Try another owner or status filter."
+          : "Create a draft when you have one concrete software change ready to delegate."}
+      </p>
+    </div>
+  );
+}
+
+function AutomationsSection({
+  automations,
+  onCreateAutomation,
+  onOpenAutomation,
+}: {
+  automations: Automation[];
+  onCreateAutomation: () => void;
+  onOpenAutomation: (automation: Automation) => void;
+}) {
+  return (
+    <section aria-labelledby="automations-heading">
+      <div className="flex items-start justify-between gap-4">
+        <SectionHeading
+          id="automations-heading"
+          title="Automations"
+          description="Canvas workflows that process approved work."
+          count={automations.length}
+        />
+        <Button type="button" size="sm" variant="outline" onClick={onCreateAutomation}>
+          <Plus aria-hidden />
+          New
+        </Button>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {automations.length === 0 ? (
+          <div className="flex min-h-48 flex-col items-center justify-center rounded-lg border border-slate-200 bg-white px-6 text-center dark:border-gray-800 dark:bg-gray-900">
+            <Workflow className="size-6 text-slate-400" aria-hidden />
+            <p className="mt-3 text-sm font-medium">No Automation configured</p>
+            <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-gray-400">
+              Add one Canvas that listens for ready Work Orders.
+            </p>
+            <Button type="button" size="sm" className="mt-4" onClick={onCreateAutomation}>
+              <Plus aria-hidden />
+              New Automation
+            </Button>
+          </div>
+        ) : (
+          automations.map((automation) => (
+            <AutomationRow key={automation.id} automation={automation} onOpen={() => onOpenAutomation(automation)} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function AutomationRow({ automation, onOpen }: { automation: Automation; onOpen: () => void }) {
+  const statePresentation = automationStatePresentation[automation.state];
+  const StateIcon = statePresentation.icon;
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white px-4 py-4 dark:border-gray-800 dark:bg-gray-900">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <button
+            type="button"
+            onClick={onOpen}
+            className="truncate text-left text-sm font-medium text-slate-950 hover:underline dark:text-gray-100"
+          >
+            {automation.name}
+          </button>
+          <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-gray-400">{automation.description}</p>
+        </div>
+        <span
+          className={cn("inline-flex shrink-0 items-center gap-1 text-xs font-medium", statePresentation.className)}
+        >
+          <StateIcon
+            className={cn("size-3.5", automation.state === "running" && "animate-spin motion-reduce:animate-none")}
+            aria-hidden
+          />
+          {statePresentation.label}
+        </span>
+      </div>
+      <dl className="mt-4 grid grid-cols-2 border-t border-slate-100 pt-3 dark:border-gray-800">
+        <AutomationMetric count={automation.runningCount} label="Running now" />
+        <AutomationMetric count={automation.queuedCount} label="In queue" divided />
+      </dl>
+    </article>
+  );
+}
+
+function AutomationMetric({ count, label, divided = false }: { count: number; label: string; divided?: boolean }) {
+  return (
+    <div
+      className={cn(divided && "border-l border-slate-100 pl-4 dark:border-gray-800")}
+      aria-label={`${count} ${label.toLowerCase()}`}
+    >
+      <dt className="text-xs text-slate-500 dark:text-gray-400">{label}</dt>
+      <dd className="mt-1 text-lg font-semibold text-slate-950 dark:text-gray-100">{count}</dd>
+    </div>
+  );
+}
+
+function SectionHeading({
+  id,
+  title,
+  description,
+  count,
+}: {
+  id: string;
+  title: string;
+  description: string;
+  count: number;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <h2 id={id} className="text-base font-semibold text-slate-950 dark:text-gray-100">
+          {title}
+        </h2>
+        <span className="text-xs text-slate-400 dark:text-gray-500">{count}</span>
+      </div>
+      <p className="mt-1 text-xs text-slate-500 dark:text-gray-400">{description}</p>
+    </div>
+  );
+}

--- a/web_src/src/pages/factory/WorkOrderPage.tsx
+++ b/web_src/src/pages/factory/WorkOrderPage.tsx
@@ -1,0 +1,184 @@
+import { ArrowLeft, CheckCircle2, CircleDot, Clock3, Factory, GitPullRequest, ListPlus, XCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { formatTimeAgo } from "@/lib/date";
+import { cn } from "@/lib/utils";
+
+import type { SoftwareFactory, WorkOrder, WorkOrderEvent, WorkOrderEventKind, WorkOrderState } from "./factoryTypes";
+import { WorkOrderStateBadge } from "./WorkOrderStateBadge";
+
+interface WorkOrderPageProps {
+  factory: SoftwareFactory;
+  workOrder: WorkOrder;
+  events: WorkOrderEvent[];
+  onBack: () => void;
+  onApprove: () => void;
+}
+
+export function WorkOrderPage({ factory, workOrder, events, onBack, onApprove }: WorkOrderPageProps) {
+  const isDraft = workOrder.state === "draft";
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-950 dark:bg-gray-950 dark:text-gray-100">
+      <main className="mx-auto w-full max-w-[1040px] px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <Button type="button" variant="ghost" size="sm" className="-ml-3" onClick={onBack}>
+          <ArrowLeft aria-hidden />
+          {factory.name}
+        </Button>
+
+        <header className="mt-5 border-b border-slate-200 pb-7 dark:border-gray-800">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <div className="mb-2 flex items-center gap-2 text-xs font-medium text-slate-500 dark:text-gray-400">
+                <Factory className="size-4" aria-hidden />
+                Work Order
+              </div>
+              <h1 className="text-2xl font-semibold leading-8 text-slate-950 dark:text-white">{workOrder.title}</h1>
+            </div>
+            <WorkOrderStateBadge state={workOrder.state} />
+          </div>
+          <p className="mt-4 max-w-3xl whitespace-pre-wrap text-sm leading-6 text-slate-700 dark:text-gray-300">
+            {workOrder.description}
+          </p>
+          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-slate-500 dark:text-gray-400">
+            <span>Created {formatTimeAgo(new Date(workOrder.createdAt))}</span>
+            {workOrder.automations.length > 0 && (
+              <span>{workOrder.automations.map((automation) => automation.name).join(", ")}</span>
+            )}
+            {workOrder.primaryPullRequest && <PullRequestLink workOrder={workOrder} />}
+          </div>
+        </header>
+
+        {isDraft && (
+          <section className="mt-6 flex flex-col gap-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-4 dark:border-amber-900 dark:bg-amber-950/40 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-sm font-medium text-amber-950 dark:text-amber-200">Ready for your approval</h2>
+              <p className="mt-1 text-xs leading-5 text-amber-800 dark:text-amber-300">
+                Approval makes this Work Order available to the implementation Automation.
+              </p>
+            </div>
+            <Button type="button" size="sm" onClick={onApprove}>
+              <ListPlus aria-hidden />
+              Approve and queue
+            </Button>
+          </section>
+        )}
+
+        <section className="mt-8" aria-labelledby="history-heading">
+          <div className="flex items-end justify-between gap-4">
+            <div>
+              <h2 id="history-heading" className="text-base font-semibold">
+                History
+              </h2>
+              <p className="mt-1 text-xs text-slate-500 dark:text-gray-400">
+                The durable record of this implementation.
+              </p>
+            </div>
+            <span className="text-xs text-slate-400 dark:text-gray-500">
+              {events.length} {events.length === 1 ? "event" : "events"}
+            </span>
+          </div>
+
+          <WorkOrderTimeline events={events} />
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function PullRequestLink({ workOrder }: { workOrder: WorkOrder }) {
+  const pullRequest = workOrder.primaryPullRequest;
+  if (!pullRequest) return null;
+
+  return (
+    <a
+      href={pullRequest.url}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-1.5 font-medium text-blue-700 hover:underline dark:text-blue-400"
+    >
+      <GitPullRequest className="size-3.5" aria-hidden />
+      {pullRequest.repository} #{pullRequest.number}
+    </a>
+  );
+}
+
+const eventPresentation = {
+  created: { icon: Clock3, label: "Created", tone: "text-slate-600 dark:text-gray-300" },
+  approved: { icon: CheckCircle2, label: "Approved", tone: "text-blue-700 dark:text-blue-300" },
+  started: { icon: CircleDot, label: "Automation started", tone: "text-violet-700 dark:text-violet-300" },
+  "pull-request": { icon: GitPullRequest, label: "Pull request", tone: "text-sky-700 dark:text-sky-300" },
+  outcome: { icon: CheckCircle2, label: "Outcome", tone: "text-emerald-700 dark:text-emerald-300" },
+} as const satisfies Record<WorkOrderEventKind, { icon: typeof Clock3; label: string; tone: string }>;
+
+function WorkOrderTimeline({ events }: { events: WorkOrderEvent[] }) {
+  return (
+    <ol className="mt-6">
+      {events.map((event, index) => (
+        <TimelineEvent key={event.id} event={event} isLast={index === events.length - 1} />
+      ))}
+    </ol>
+  );
+}
+
+function TimelineEvent({ event, isLast }: { event: WorkOrderEvent; isLast: boolean }) {
+  const presentation = eventPresentation[event.kind];
+  const EventIcon = outcomeIcon(event) ?? presentation.icon;
+
+  return (
+    <li className="grid grid-cols-[32px_minmax(0,1fr)] gap-3">
+      <div className="flex flex-col items-center">
+        <span
+          className={cn(
+            "z-10 flex size-8 items-center justify-center rounded-full border border-slate-200 bg-white dark:border-gray-700 dark:bg-gray-900",
+            outcomeTone(event) ?? presentation.tone,
+          )}
+        >
+          <EventIcon className="size-4" aria-hidden />
+        </span>
+        {!isLast && <span className="w-px flex-1 bg-slate-200 dark:bg-gray-800" aria-hidden />}
+      </div>
+
+      <article className={cn("min-w-0 pb-7", !isLast && "min-h-24")}>
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+          <div>
+            <span className={cn("text-xs font-medium", outcomeTone(event) ?? presentation.tone)}>
+              {presentation.label}
+            </span>
+            <h3 className="mt-1 text-sm font-medium text-slate-950 dark:text-gray-100">{event.summary}</h3>
+          </div>
+          <time className="text-xs text-slate-400 dark:text-gray-500">{formatTimeAgo(new Date(event.occurredAt))}</time>
+        </div>
+        <p className="mt-1 text-xs text-slate-500 dark:text-gray-400">{event.actor}</p>
+        {event.detail && (
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-gray-300">{event.detail}</p>
+        )}
+        {event.pullRequest && (
+          <a
+            href={event.pullRequest.url}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-blue-700 hover:underline dark:text-blue-400"
+          >
+            <GitPullRequest className="size-4" aria-hidden />
+            {event.pullRequest.repository} #{event.pullRequest.number}
+          </a>
+        )}
+      </article>
+    </li>
+  );
+}
+
+function outcomeIcon(event: WorkOrderEvent) {
+  if (event.kind !== "outcome") return undefined;
+  return event.outcome === "unsuccessful" ? XCircle : CheckCircle2;
+}
+
+function outcomeTone(event: WorkOrderEvent) {
+  if (event.kind !== "outcome") return undefined;
+  return outcomeStateTone(event.outcome ?? "successful");
+}
+
+function outcomeStateTone(state: Extract<WorkOrderState, "successful" | "unsuccessful">) {
+  return state === "successful" ? "text-emerald-700 dark:text-emerald-300" : "text-red-700 dark:text-red-300";
+}

--- a/web_src/src/pages/factory/WorkOrderStateBadge.tsx
+++ b/web_src/src/pages/factory/WorkOrderStateBadge.tsx
@@ -1,0 +1,56 @@
+import { CheckCircle2, CircleDot, Clock3, LoaderCircle, XCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { WorkOrderState } from "./factoryTypes";
+
+const statePresentation = {
+  draft: {
+    label: "Draft",
+    icon: Clock3,
+    className:
+      "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950/50 dark:text-amber-300",
+  },
+  ready: {
+    label: "Ready",
+    icon: CircleDot,
+    className: "border-blue-200 bg-blue-50 text-blue-800 dark:border-blue-900 dark:bg-blue-950/50 dark:text-blue-300",
+  },
+  running: {
+    label: "Running",
+    icon: LoaderCircle,
+    className:
+      "border-violet-200 bg-violet-50 text-violet-800 dark:border-violet-900 dark:bg-violet-950/50 dark:text-violet-300",
+  },
+  successful: {
+    label: "Successful",
+    icon: CheckCircle2,
+    className:
+      "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/50 dark:text-emerald-300",
+  },
+  unsuccessful: {
+    label: "Unsuccessful",
+    icon: XCircle,
+    className: "border-red-200 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300",
+  },
+} as const satisfies Record<WorkOrderState, { label: string; icon: typeof Clock3; className: string }>;
+
+export function WorkOrderStateBadge({ state }: { state: WorkOrderState }) {
+  const presentation = statePresentation[state];
+  const StateIcon = presentation.icon;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border px-2.5 text-xs font-medium",
+        presentation.className,
+      )}
+    >
+      <StateIcon
+        className={cn("size-3.5", state === "running" && "animate-spin motion-reduce:animate-none")}
+        aria-hidden
+      />
+      {presentation.label}
+    </span>
+  );
+}

--- a/web_src/src/pages/factory/__fixtures__/minimalFactoryFixtures.ts
+++ b/web_src/src/pages/factory/__fixtures__/minimalFactoryFixtures.ts
@@ -1,0 +1,163 @@
+import type { Automation, SoftwareFactory, WorkOrder, WorkOrderEvent } from "../factoryTypes";
+
+export const paymentsFactory: SoftwareFactory = {
+  id: "factory-payments",
+  name: "Payments Factory",
+  description:
+    "Delegated implementation work for the payments platform. Approved Work Orders are implemented and delivered as pull requests.",
+};
+
+export const implementationAutomation: Automation = {
+  id: "automation-implementation",
+  name: "Implementation pipeline",
+  description: "Implements approved Work Orders, runs checks, and opens a pull request.",
+  state: "running",
+  runningCount: 2,
+  queuedCount: 3,
+  lastRunAt: "2026-07-30T15:20:00Z",
+};
+
+export const verificationAutomation: Automation = {
+  id: "automation-verification",
+  name: "Verification pipeline",
+  description: "Reviews implementation output, reruns required checks, and records the final outcome.",
+  state: "idle",
+  runningCount: 0,
+  queuedCount: 0,
+  lastRunAt: "2026-07-30T14:42:00Z",
+};
+
+export const workOrders: WorkOrder[] = [
+  {
+    id: "wo-refund-test",
+    title: "Add refund reconciliation test",
+    description: "Cover the refund reconciliation path before the next release. Keep the fixture provider-agnostic.",
+    state: "draft",
+    createdByUserId: "user-darko",
+    createdByName: "Darko",
+    createdAt: "2026-07-30T15:48:00Z",
+    updatedAt: "2026-07-30T15:48:00Z",
+    automations: [
+      { id: implementationAutomation.id, name: implementationAutomation.name, state: "planned" },
+      { id: verificationAutomation.id, name: verificationAutomation.name, state: "planned" },
+    ],
+  },
+  {
+    id: "wo-webhook",
+    title: "Preserve idempotency keys on retries",
+    description: "Keep the original idempotency key when a failed payment request is queued for another attempt.",
+    state: "ready",
+    createdByUserId: "user-maya",
+    createdByName: "Maya Chen",
+    createdAt: "2026-07-30T15:10:00Z",
+    updatedAt: "2026-07-30T16:30:00Z",
+    automations: [
+      { id: implementationAutomation.id, name: implementationAutomation.name, state: "planned" },
+      { id: verificationAutomation.id, name: verificationAutomation.name, state: "planned" },
+    ],
+  },
+  {
+    id: "wo-unsigned-webhook",
+    title: "Reject unsigned payment webhooks",
+    description: "Return 401 when the payment signature header is missing instead of processing the payload.",
+    state: "running",
+    createdByUserId: "user-maya",
+    createdByName: "Maya Chen",
+    createdAt: "2026-07-30T14:30:00Z",
+    updatedAt: "2026-07-30T16:22:00Z",
+    automations: [
+      { id: implementationAutomation.id, name: implementationAutomation.name, state: "running" },
+      { id: verificationAutomation.id, name: verificationAutomation.name, state: "planned" },
+    ],
+  },
+  {
+    id: "wo-rounding",
+    title: "Fix settlement rounding",
+    description: "Round once per settlement so the exported total matches the ledger.",
+    state: "successful",
+    createdByUserId: "user-darko",
+    createdByName: "Darko",
+    automations: [
+      { id: implementationAutomation.id, name: implementationAutomation.name, state: "done" },
+      { id: verificationAutomation.id, name: verificationAutomation.name, state: "done" },
+    ],
+    primaryPullRequest: {
+      repository: "acme/payments-api",
+      number: 1843,
+      url: "https://github.com/acme/payments-api/pull/1843",
+    },
+    createdAt: "2026-07-29T10:00:00Z",
+    updatedAt: "2026-07-30T13:16:00Z",
+  },
+  {
+    id: "wo-ledger",
+    title: "Backfill missing merchant categories",
+    description: "Fill category codes for ledger records imported before the field existed.",
+    state: "unsuccessful",
+    createdByUserId: "user-maya",
+    createdByName: "Maya Chen",
+    createdAt: "2026-07-28T09:00:00Z",
+    updatedAt: "2026-07-29T17:42:00Z",
+    automations: [
+      { id: implementationAutomation.id, name: implementationAutomation.name, state: "done" },
+      { id: verificationAutomation.id, name: verificationAutomation.name, state: "failed" },
+    ],
+  },
+];
+
+export const draftEvents: WorkOrderEvent[] = [
+  {
+    id: "event-created",
+    kind: "created",
+    summary: "Work Order created",
+    actor: "Darko",
+    occurredAt: "2026-07-30T15:48:00Z",
+  },
+];
+
+const settlementPullRequest = {
+  repository: "acme/payments-api",
+  number: 1843,
+  url: "https://github.com/acme/payments-api/pull/1843",
+};
+
+export const successfulEvents: WorkOrderEvent[] = [
+  {
+    id: "event-created",
+    kind: "created",
+    summary: "Work Order created",
+    actor: "Darko",
+    occurredAt: "2026-07-29T10:00:00Z",
+  },
+  {
+    id: "event-approved",
+    kind: "approved",
+    summary: "Approved and moved to ready",
+    actor: "Darko",
+    occurredAt: "2026-07-29T10:12:00Z",
+  },
+  {
+    id: "event-started",
+    kind: "started",
+    summary: "Implementation pipeline picked up the work",
+    actor: "Implementation pipeline",
+    occurredAt: "2026-07-29T10:13:00Z",
+    detail: "The Automation created a branch, changed the settlement calculation, and ran the repository checks.",
+  },
+  {
+    id: "event-pr",
+    kind: "pull-request",
+    summary: "Pull request opened",
+    actor: "Implementation pipeline",
+    occurredAt: "2026-07-30T12:54:00Z",
+    pullRequest: settlementPullRequest,
+  },
+  {
+    id: "event-outcome",
+    kind: "outcome",
+    summary: "Marked successful",
+    actor: "Implementation pipeline",
+    occurredAt: "2026-07-30T13:16:00Z",
+    outcome: "successful",
+  },
+];

--- a/web_src/src/pages/factory/factoryTypes.ts
+++ b/web_src/src/pages/factory/factoryTypes.ts
@@ -1,0 +1,68 @@
+export type WorkOrderState = "draft" | "ready" | "running" | "successful" | "unsuccessful";
+
+export interface PullRequest {
+  repository: string;
+  number: number;
+  url: string;
+}
+
+export interface SoftwareFactory {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export type WorkOrderAutomationState = "planned" | "running" | "done" | "failed";
+
+export interface WorkOrderAutomation {
+  id: string;
+  name: string;
+  state: WorkOrderAutomationState;
+}
+
+export interface WorkOrder {
+  id: string;
+  title: string;
+  description: string;
+  state: WorkOrderState;
+  createdByUserId: string;
+  createdByName: string;
+  createdAt: string;
+  updatedAt: string;
+  automations: WorkOrderAutomation[];
+  primaryPullRequest?: PullRequest;
+}
+
+export interface Automation {
+  id: string;
+  name: string;
+  description: string;
+  state: "idle" | "running" | "paused";
+  runningCount: number;
+  queuedCount: number;
+  lastRunAt?: string;
+}
+
+export type WorkOrderEventKind = "created" | "approved" | "started" | "pull-request" | "outcome";
+
+export interface WorkOrderEvent {
+  id: string;
+  kind: WorkOrderEventKind;
+  summary: string;
+  actor: string;
+  occurredAt: string;
+  detail?: string;
+  pullRequest?: PullRequest;
+  outcome?: Extract<WorkOrderState, "successful" | "unsuccessful">;
+}
+
+export interface NewWorkOrderInput {
+  title: string;
+  description: string;
+  automationIds: string[];
+}
+
+export interface NewFactoryInput {
+  name: string;
+  description: string;
+}


### PR DESCRIPTION
## Summary

- add a minimal Software Factory overview in Storybook with Work Order ownership and status filters
- add New Work Order and Work Order detail flows, including Automation selection
- show Implementation and Verification pipeline capacity plus per-Work Order Automation progress
- include representative fixtures and focused interaction tests for draft, approval, filtering, and creation states

## Why

This provides the smallest UI surface needed to validate the Software Factory workflow: create a Work Order, choose its Automations, track execution state, and understand available pipeline capacity.

## User impact

Design reviewers can exercise the complete minimal workflow in Storybook before it is connected to backend APIs.

## Validation

- `npm run test:run -- src/pages/factory/SoftwareFactoryPage.spec.tsx` (6 tests)
- `npx eslint src/pages/factory`
- `npm run build-storybook`
- desktop and 414 px mobile visual checks
- `git diff --check`