### PR TITLE
Ona devcontainer and automations setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "SuperPlane",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker": {
+      "moby": false
+    }
+  },
+  "forwardPorts": [8000]
+}

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,0 +1,34 @@
+services:
+  superplane:
+    name: SuperPlane
+    triggeredBy:
+      - manual
+      - postEnvironmentStart
+    commands:
+      start: |
+        make dev.up
+        make dev.server
+        gitpod environment port open 8000 --dont-wait --admission creator_only --name superplane
+        make dev.logs
+      ready: curl -sf http://localhost:8000/health
+
+tasks:
+  install-dependencies:
+    name: Install dependencies
+    triggeredBy:
+      - manual
+      - postDevcontainerStart
+      - prebuild
+    command: |
+      make dev.up
+      make dev.setup
+
+  build:
+    name: Build
+    triggeredBy:
+      - manual
+    dependsOn:
+      - install-dependencies
+    command: |
+      make check.build.app
+      make check.build.ui


### PR DESCRIPTION
## Description

This PR configures the repository's development environment with a [Dev Container](https://containers.dev/) and [Ona tasks/services](https://ona.com/docs/ona/configuration/tasks-and-services/overview).

A Dev Container is a checked-in environment definition that describes the container image, runtimes, tools, and editor configuration needed to work in this repository. Ona tasks and services are checked-in automations in `.ona/automations.yaml`: tasks run repeatable one-shot workflows such as dependency installation, checks, and builds, while services run long-lived development processes such as app servers, preview servers, or databases.

This is useful to merge because it makes environment startup and common development workflows reproducible for contributors and agents, instead of relying on local machine state or undocumented setup steps.

Ona automated this setup while creating or tuning the project so future development starts faster and the repository is easier to work on in new environments.