### PR TITLE
fix: resolve schedule next-run preview correctly and without a minute-by-minute scan

### DIFF
--- a/web_src/src/lib/cron.spec.ts
+++ b/web_src/src/lib/cron.spec.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { getNextCronExecution } from "@/lib/cron";
+import { getNextCronExecution, getNextCronExecutions } from "@/lib/cron";
+
+function format(date: Date | null | undefined): string {
+  if (!date) {
+    return "none";
+  }
+
+  const pad = (value: number) => value.toString().padStart(2, "0");
+
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(
+    date.getMinutes(),
+  )}:${pad(date.getSeconds())}`;
+}
 
 describe("cron", () => {
   it("finds the next execution for a 5-field expression", () => {
@@ -14,7 +26,7 @@ describe("cron", () => {
     expect(nextExecution?.getMinutes()).toBe(5);
   });
 
-  it("supports 6-field expressions by ignoring the seconds field", () => {
+  it("supports 6-field expressions including the seconds field", () => {
     const fromTime = new Date(2026, 2, 29, 10, 4, 30);
     const nextExecution = getNextCronExecution("0 10 11 * * *", fromTime);
 
@@ -22,6 +34,10 @@ describe("cron", () => {
     expect(nextExecution?.getDate()).toBe(29);
     expect(nextExecution?.getHours()).toBe(11);
     expect(nextExecution?.getMinutes()).toBe(10);
+    expect(nextExecution?.getSeconds()).toBe(0);
+
+    expect(format(getNextCronExecution("30 * * * * *", new Date(2026, 2, 29, 10, 4, 10)))).toBe("2026-03-29 10:04:30");
+    expect(format(getNextCronExecution("30 * * * * *", new Date(2026, 2, 29, 10, 4, 30)))).toBe("2026-03-29 10:05:30");
   });
 
   it("supports named weekdays and months", () => {
@@ -36,7 +52,108 @@ describe("cron", () => {
     expect(nextExecution?.getMinutes()).toBe(0);
   });
 
-  it("returns null for invalid cron field counts", () => {
-    expect(getNextCronExecution("* * *", new Date("2026-03-29T10:04:30.000Z"))).toBeNull();
+  it("resolves schedules that are more than a year away", () => {
+    // Feb 29 only exists on leap years; the next one after 2026 is in 2028.
+    expect(format(getNextCronExecution("0 0 29 2 *", new Date(2026, 2, 1, 0, 0, 0)))).toBe("2028-02-29 00:00:00");
+    expect(format(getNextCronExecution("0 0 1 1 *", new Date(2026, 0, 2, 10, 0, 0)))).toBe("2027-01-01 00:00:00");
+  });
+
+  it("returns null for schedules that never fire", () => {
+    expect(getNextCronExecution("0 0 30 2 *", new Date(2026, 0, 1, 0, 0, 0))).toBeNull();
+  });
+
+  it("returns null for invalid expressions", () => {
+    const fromTime = new Date(2026, 2, 29, 10, 4, 30);
+
+    expect(getNextCronExecution("* * *", fromTime)).toBeNull();
+    expect(getNextCronExecution("", fromTime)).toBeNull();
+    expect(getNextCronExecution("70 * * * *", fromTime)).toBeNull();
+    expect(getNextCronExecution("* 25 * * *", fromTime)).toBeNull();
+    expect(getNextCronExecution("0 0 * * 7", fromTime)).toBeNull();
+    expect(getNextCronExecution("*/0 * * * *", fromTime)).toBeNull();
+    expect(getNextCronExecution("*/abc * * * *", fromTime)).toBeNull();
+    expect(getNextCronExecution("10-5 * * * *", fromTime)).toBeNull();
+    expect(getNextCronExecution("0 0 * FOO *", fromTime)).toBeNull();
+  });
+
+  it("supports lists, ranges and steps", () => {
+    const fromTime = new Date(2026, 2, 29, 10, 4, 30);
+
+    expect(format(getNextCronExecution("0 9,17 * * *", fromTime))).toBe("2026-03-29 17:00:00");
+    expect(format(getNextCronExecution("*/15 * * * *", fromTime))).toBe("2026-03-29 10:15:00");
+    // A step on a single value runs from that value to the end of the range,
+    // so `5/15` fires at :05, :20, :35 and :50.
+    expect(format(getNextCronExecution("5/15 * * * *", fromTime))).toBe("2026-03-29 10:05:00");
+    expect(format(getNextCronExecution("5/15 * * * *", new Date(2026, 2, 29, 10, 5, 0)))).toBe("2026-03-29 10:20:00");
+    expect(format(getNextCronExecution("0 8-10 * * *", new Date(2026, 2, 29, 8, 30, 0)))).toBe("2026-03-29 09:00:00");
+  });
+
+  it("treats ? like a wildcard", () => {
+    const fromTime = new Date(2026, 2, 29, 10, 4, 30);
+
+    expect(format(getNextCronExecution("0 12 ? * *", fromTime))).toBe("2026-03-29 12:00:00");
+  });
+
+  it("matches either day-of-month or weekday when both are restricted", () => {
+    // The next Friday (Apr 3) comes before the 13th, and either field matching
+    // is enough.
+    expect(format(getNextCronExecution("0 0 13 * FRI", new Date(2026, 3, 1, 0, 0, 0)))).toBe("2026-04-03 00:00:00");
+  });
+
+  it("requires both day fields to match when one of them is a wildcard", () => {
+    // Plain `*` day-of-month: the weekday has to match too.
+    expect(format(getNextCronExecution("0 0 * * MON", new Date(2026, 3, 1, 0, 0, 0)))).toBe("2026-04-06 00:00:00");
+    // A step makes the field restricted, so either field matching is enough:
+    // `*/2` covers the odd days, and Apr 3 is one of them.
+    expect(format(getNextCronExecution("0 0 */2 * MON", new Date(2026, 3, 1, 0, 0, 0)))).toBe("2026-04-03 00:00:00");
+  });
+
+  it("returns a series of upcoming executions", () => {
+    const executions = getNextCronExecutions("0 9 * * MON-FRI", new Date(2026, 3, 2, 12, 0, 0), 4);
+
+    expect(executions.map(format)).toEqual([
+      "2026-04-03 09:00:00",
+      "2026-04-06 09:00:00",
+      "2026-04-07 09:00:00",
+      "2026-04-08 09:00:00",
+    ]);
+  });
+
+  // Expectations captured from the backend scheduler
+  // (github.com/robfig/cron/v3, the parser used by pkg/triggers/schedule).
+  it.each([
+    ["5 10 * * *", new Date(2026, 2, 29, 10, 4, 30), "2026-03-29 10:05:00"],
+    ["0 10 11 * * *", new Date(2026, 2, 29, 10, 4, 30), "2026-03-29 11:10:00"],
+    ["30 * * * * *", new Date(2026, 2, 29, 10, 4, 30), "2026-03-29 10:05:30"],
+    ["0 9 * APR MON", new Date(2026, 2, 29, 10, 4, 30), "2026-04-06 09:00:00"],
+    ["0 9,17 * * *", new Date(2026, 2, 29, 10, 4, 30), "2026-03-29 17:00:00"],
+    ["*/15 * * * *", new Date(2026, 2, 29, 10, 4, 30), "2026-03-29 10:15:00"],
+    ["5/15 * * * *", new Date(2026, 2, 29, 10, 4, 30), "2026-03-29 10:05:00"],
+    ["0 8-10 * * *", new Date(2026, 2, 29, 8, 30, 0), "2026-03-29 09:00:00"],
+    ["0 12 ? * *", new Date(2026, 2, 29, 10, 4, 30), "2026-03-29 12:00:00"],
+    ["0 0 13 * FRI", new Date(2026, 3, 1, 0, 0, 0), "2026-04-03 00:00:00"],
+    ["0 0 */2 * MON", new Date(2026, 3, 1, 0, 0, 0), "2026-04-03 00:00:00"],
+    ["0 9 * * MON-FRI", new Date(2026, 3, 2, 12, 0, 0), "2026-04-03 09:00:00"],
+    ["0 0 29 2 *", new Date(2026, 2, 1, 0, 0, 0), "2028-02-29 00:00:00"],
+    ["0 0 1 1 *", new Date(2026, 0, 2, 10, 0, 0), "2027-01-01 00:00:00"],
+    ["0 0 30 2 *", new Date(2026, 0, 1, 0, 0, 0), "none"],
+    ["70 * * * *", new Date(2026, 2, 29, 10, 4, 30), "none"],
+    ["* 25 * * *", new Date(2026, 2, 29, 10, 4, 30), "none"],
+    ["0 0 * * 7", new Date(2026, 2, 29, 10, 4, 30), "none"],
+    ["*/0 * * * *", new Date(2026, 2, 29, 10, 4, 30), "none"],
+    ["10-5 * * * *", new Date(2026, 2, 29, 10, 4, 30), "none"],
+  ])("matches the backend scheduler for %s", (expression, fromTime, expected) => {
+    expect(format(getNextCronExecution(expression, fromTime))).toBe(expected);
+  });
+
+  it("resolves schedules without scanning minute by minute", () => {
+    const start = performance.now();
+    for (let i = 0; i < 200; i++) {
+      getNextCronExecution("0 0 29 2 *", new Date(2026, 0, 1, 0, 0, 0));
+      getNextCronExecution("0 0 30 2 *", new Date(2026, 0, 1, 0, 0, 0));
+    }
+
+    // The previous minute-by-minute scan took ~60ms for a single one of these.
+    expect(performance.now() - start).toBeLessThan(1000);
   });
 });

--- a/web_src/src/lib/cron.ts
+++ b/web_src/src/lib/cron.ts
@@ -1,196 +1,343 @@
 /**
- * Simple cron parser for browser environment
- * Supports both 5-field and 6-field cron expressions
+ * Cron parser for the browser, kept in sync with the backend scheduler
+ * (github.com/robfig/cron/v3) so the "next run" previewed in the UI matches the
+ * time the backend will actually fire.
+ *
+ * Supports 5-field (minute hour day month weekday) and 6-field
+ * (second minute hour day month weekday) expressions with `*`, `?`, ranges,
+ * steps, lists, and month/weekday names.
  */
 
+const MAX_SEARCH_YEARS = 5;
+
+const WEEKDAY_NAMES: Record<string, number> = {
+  SUN: 0,
+  SUNDAY: 0,
+  MON: 1,
+  MONDAY: 1,
+  TUE: 2,
+  TUESDAY: 2,
+  WED: 3,
+  WEDNESDAY: 3,
+  THU: 4,
+  THURSDAY: 4,
+  FRI: 5,
+  FRIDAY: 5,
+  SAT: 6,
+  SATURDAY: 6,
+};
+
+const MONTH_NAMES: Record<string, number> = {
+  JAN: 1,
+  JANUARY: 1,
+  FEB: 2,
+  FEBRUARY: 2,
+  MAR: 3,
+  MARCH: 3,
+  APR: 4,
+  APRIL: 4,
+  MAY: 5,
+  JUN: 6,
+  JUNE: 6,
+  JUL: 7,
+  JULY: 7,
+  AUG: 8,
+  AUGUST: 8,
+  SEP: 9,
+  SEPTEMBER: 9,
+  OCT: 10,
+  OCTOBER: 10,
+  NOV: 11,
+  NOVEMBER: 11,
+  DEC: 12,
+  DECEMBER: 12,
+};
+
+interface FieldSpec {
+  min: number;
+  max: number;
+  names?: Record<string, number>;
+}
+
+const SECOND_FIELD: FieldSpec = { min: 0, max: 59 };
+const MINUTE_FIELD: FieldSpec = { min: 0, max: 59 };
+const HOUR_FIELD: FieldSpec = { min: 0, max: 23 };
+const DAY_OF_MONTH_FIELD: FieldSpec = { min: 1, max: 31 };
+const MONTH_FIELD: FieldSpec = { min: 1, max: 12, names: MONTH_NAMES };
+const WEEKDAY_FIELD: FieldSpec = { min: 0, max: 6, names: WEEKDAY_NAMES };
+
+interface ParsedField {
+  /** Allowed values, ascending. */
+  values: number[];
+  /** True when the field was written as `*` or `?`, with or without a step. */
+  isWildcard: boolean;
+}
+
+export interface CronSchedule {
+  seconds: number[];
+  minutes: number[];
+  hours: number[];
+  daysOfMonth: ParsedField;
+  months: number[];
+  daysOfWeek: ParsedField;
+}
+
+/**
+ * Parse a cron expression into the values each field allows.
+ * Returns null when the expression is not one the backend would accept.
+ */
+export function parseCronExpression(cronExpression: string): CronSchedule | null {
+  const fields = cronExpression.trim().split(/\s+/).filter(Boolean);
+
+  let second = "0";
+  let minute: string, hour: string, day: string, month: string, weekday: string;
+
+  if (fields.length === 5) {
+    [minute, hour, day, month, weekday] = fields;
+  } else if (fields.length === 6) {
+    [second, minute, hour, day, month, weekday] = fields;
+  } else {
+    return null;
+  }
+
+  const seconds = parseField(second, SECOND_FIELD);
+  const minutes = parseField(minute, MINUTE_FIELD);
+  const hours = parseField(hour, HOUR_FIELD);
+  const daysOfMonth = parseField(day, DAY_OF_MONTH_FIELD);
+  const months = parseField(month, MONTH_FIELD);
+  const daysOfWeek = parseField(weekday, WEEKDAY_FIELD);
+
+  if (!seconds || !minutes || !hours || !daysOfMonth || !months || !daysOfWeek) {
+    return null;
+  }
+
+  return {
+    seconds: seconds.values,
+    minutes: minutes.values,
+    hours: hours.values,
+    daysOfMonth,
+    months: months.values,
+    daysOfWeek,
+  };
+}
+
+/**
+ * The next time the expression fires strictly after `fromTime`, in local time.
+ * Returns null for invalid expressions and for expressions with no occurrence
+ * within the search horizon.
+ */
 export function getNextCronExecution(cronExpression: string, fromTime: Date): Date | null {
-  try {
-    const fields = cronExpression.trim().split(/\s+/);
+  const [next] = getNextCronExecutions(cronExpression, fromTime, 1);
 
-    // Support both 5-field and 6-field formats
-    let minute: string, hour: string, day: string, month: string, weekday: string;
+  return next ?? null;
+}
 
-    if (fields.length === 5) {
-      // 5-field: minute hour day month weekday
-      [minute, hour, day, month, weekday] = fields;
-    } else if (fields.length === 6) {
-      // 6-field: second minute hour day month weekday (ignore seconds for simplicity)
-      [, minute, hour, day, month, weekday] = fields;
-    } else {
-      return null;
+/**
+ * The next `count` times the expression fires, ascending. Returns fewer entries
+ * (possibly none) when the schedule has no further occurrence in the horizon.
+ */
+export function getNextCronExecutions(cronExpression: string, fromTime: Date, count: number): Date[] {
+  const schedule = parseCronExpression(cronExpression);
+  if (!schedule || count < 1 || Number.isNaN(fromTime.getTime())) {
+    return [];
+  }
+
+  const executions: Date[] = [];
+  let cursor = fromTime;
+
+  for (let i = 0; i < count; i++) {
+    const next = findNextExecution(schedule, cursor);
+    if (!next) {
+      break;
     }
 
-    // Validate that weekday field doesn't contain spaces (common error)
-    if (weekday.includes(" ")) {
-      return null;
+    executions.push(next);
+    cursor = next;
+  }
+
+  return executions;
+}
+
+function findNextExecution(schedule: CronSchedule, fromTime: Date): Date | null {
+  // Occurrences are strictly after fromTime, at second granularity.
+  const searchStart = new Date(fromTime.getTime());
+  searchStart.setMilliseconds(0);
+  searchStart.setSeconds(searchStart.getSeconds() + 1);
+
+  const lastYear = fromTime.getFullYear() + MAX_SEARCH_YEARS;
+  const day = new Date(searchStart.getFullYear(), searchStart.getMonth(), searchStart.getDate());
+  let notBefore: Date | null = searchStart;
+
+  while (day.getFullYear() <= lastYear) {
+    if (matchesDay(schedule, day)) {
+      const execution = firstExecutionOnDay(schedule, day, notBefore);
+      if (execution) {
+        return execution;
+      }
     }
 
-    // Start from next minute
-    const nextTime = new Date(fromTime);
-    nextTime.setSeconds(0);
-    nextTime.setMilliseconds(0);
-    nextTime.setMinutes(nextTime.getMinutes() + 1);
+    notBefore = null;
+    day.setDate(day.getDate() + 1);
+    // Keep the cursor on midnight even across DST transitions.
+    day.setHours(0, 0, 0, 0);
+  }
 
-    // Search for next valid time (limit search to avoid infinite loops)
-    const maxIterations = 366 * 24 * 60; // 1 year worth of minutes
-    let iterations = 0;
+  return null;
+}
 
-    while (iterations < maxIterations) {
-      if (cronMatches(minute, hour, day, month, weekday, nextTime)) {
-        return nextTime;
+function matchesDay(schedule: CronSchedule, day: Date): boolean {
+  if (!schedule.months.includes(day.getMonth() + 1)) {
+    return false;
+  }
+
+  const dayOfMonthMatches = schedule.daysOfMonth.values.includes(day.getDate());
+  const dayOfWeekMatches = schedule.daysOfWeek.values.includes(day.getDay());
+
+  // Same rule as the backend: when either field is a wildcard both must match,
+  // otherwise a match in either field is enough.
+  if (schedule.daysOfMonth.isWildcard || schedule.daysOfWeek.isWildcard) {
+    return dayOfMonthMatches && dayOfWeekMatches;
+  }
+
+  return dayOfMonthMatches || dayOfWeekMatches;
+}
+
+function firstExecutionOnDay(schedule: CronSchedule, day: Date, notBefore: Date | null): Date | null {
+  const earliestHour = notBefore ? notBefore.getHours() : 0;
+  const earliestMinute = notBefore ? notBefore.getMinutes() : 0;
+  const earliestSecond = notBefore ? notBefore.getSeconds() : 0;
+
+  for (const hour of schedule.hours) {
+    if (hour < earliestHour) {
+      continue;
+    }
+
+    for (const minute of schedule.minutes) {
+      if (hour === earliestHour && minute < earliestMinute) {
+        continue;
       }
 
-      nextTime.setMinutes(nextTime.getMinutes() + 1);
-      iterations++;
+      for (const second of schedule.seconds) {
+        if (hour === earliestHour && minute === earliestMinute && second < earliestSecond) {
+          continue;
+        }
+
+        return new Date(day.getFullYear(), day.getMonth(), day.getDate(), hour, minute, second, 0);
+      }
+    }
+  }
+
+  return null;
+}
+
+function parseField(field: string, spec: FieldSpec): ParsedField | null {
+  const values = new Set<number>();
+  let isWildcard = false;
+
+  for (const entry of field.split(",")) {
+    const parsed = parseFieldEntry(entry.trim(), spec);
+    if (!parsed) {
+      return null;
     }
 
+    isWildcard = isWildcard || parsed.isWildcard;
+    for (const value of parsed.values) {
+      values.add(value);
+    }
+  }
+
+  if (values.size === 0) {
     return null;
-  } catch {
+  }
+
+  return { values: [...values].sort((a, b) => a - b), isWildcard };
+}
+
+function parseFieldEntry(entry: string, spec: FieldSpec): ParsedField | null {
+  if (!entry) {
     return null;
   }
-}
 
-function cronMatches(minute: string, hour: string, day: string, month: string, weekday: string, date: Date): boolean {
-  // Check minute (0-59)
-  if (!matchesCronField(minute, date.getMinutes(), 0, 59)) return false;
-
-  // Check hour (0-23)
-  if (!matchesCronField(hour, date.getHours(), 0, 23)) return false;
-
-  // Check month (1-12, but JS Date uses 0-11)
-  if (!matchesCronField(month, date.getMonth() + 1, 1, 12)) return false;
-
-  // Handle day of month vs day of week logic
-  const dayMatches = matchesCronField(day, date.getDate(), 1, 31);
-  const weekdayMatches = matchesCronField(weekday, date.getDay(), 0, 6);
-
-  // If both day and weekday are wildcards, match
-  if (day === "*" && weekday === "*") {
-    return true;
-  }
-  // If only day is wildcard, check weekday
-  else if (day === "*") {
-    return weekdayMatches;
-  }
-  // If only weekday is wildcard, check day
-  else if (weekday === "*") {
-    return dayMatches;
-  }
-  // If both are specified, either can match (OR logic)
-  else {
-    return dayMatches || weekdayMatches;
-  }
-}
-
-function matchesCronField(field: string, value: number, min: number, max: number): boolean {
-  if (field === "*") return true;
-
-  // Handle comma-separated values (1,2,3 or MON,TUE,WED)
-  if (field.includes(",")) {
-    return field.split(",").some((f) => matchesCronField(f.trim(), value, min, max));
+  const [rangePart, stepPart, ...rest] = entry.split("/");
+  if (rest.length > 0) {
+    return null;
   }
 
-  // Handle step values (*/5, 2-10/3, MON-FRI/2)
-  if (field.includes("/")) {
-    const [range, step] = field.split("/");
-    const stepNum = parseInt(step);
+  let step = 1;
+  if (stepPart !== undefined) {
+    if (!/^\d+$/.test(stepPart)) {
+      return null;
+    }
 
-    if (range === "*") {
-      return (value - min) % stepNum === 0;
-    } else if (range.includes("-")) {
-      const [start, end] = parseRange(range, min, max);
-      if (start === -1 || end === -1) return false;
-      return value >= start && value <= end && (value - start) % stepNum === 0;
-    } else {
-      const start = parseValue(range, min, max);
-      if (start === -1) return false;
-      return value >= start && (value - start) % stepNum === 0;
+    step = Number(stepPart);
+    if (step < 1) {
+      return null;
     }
   }
 
-  // Handle ranges (2-5 or MON-FRI)
-  if (field.includes("-")) {
-    const [start, end] = parseRange(field, min, max);
-    if (start === -1 || end === -1) return false;
-    return value >= start && value <= end;
+  const range = parseRange(rangePart, spec, stepPart !== undefined);
+  if (!range) {
+    return null;
   }
 
-  // Handle single values (including named days)
-  const parsedValue = parseValue(field, min, max);
-  return parsedValue !== -1 && parsedValue === value;
+  const values: number[] = [];
+  for (let value = range.start; value <= range.end; value += step) {
+    values.push(value);
+  }
+
+  // Like the backend, a step larger than 1 makes the field restricted even when
+  // it was written as `*` or `?`.
+  return { values, isWildcard: range.isWildcard && step === 1 };
 }
 
-function parseValue(field: string, min: number, max: number): number {
-  // Handle weekday names (only when min=0, max=6 for weekdays)
-  if (min === 0 && max === 6) {
-    const weekdayNames: Record<string, number> = {
-      SUN: 0,
-      SUNDAY: 0,
-      MON: 1,
-      MONDAY: 1,
-      TUE: 2,
-      TUESDAY: 2,
-      WED: 3,
-      WEDNESDAY: 3,
-      THU: 4,
-      THURSDAY: 4,
-      FRI: 5,
-      FRIDAY: 5,
-      SAT: 6,
-      SATURDAY: 6,
-    };
-
-    const upperField = field.toUpperCase();
-    if (upperField in weekdayNames) {
-      return weekdayNames[upperField];
-    }
-  }
-
-  // Handle month names (only when min=1, max=12 for months)
-  if (min === 1 && max === 12) {
-    const monthNames: Record<string, number> = {
-      JAN: 1,
-      JANUARY: 1,
-      FEB: 2,
-      FEBRUARY: 2,
-      MAR: 3,
-      MARCH: 3,
-      APR: 4,
-      APRIL: 4,
-      MAY: 5,
-      JUN: 6,
-      JUNE: 6,
-      JUL: 7,
-      JULY: 7,
-      AUG: 8,
-      AUGUST: 8,
-      SEP: 9,
-      SEPTEMBER: 9,
-      OCT: 10,
-      OCTOBER: 10,
-      NOV: 11,
-      NOVEMBER: 11,
-      DEC: 12,
-      DECEMBER: 12,
-    };
-
-    const upperField = field.toUpperCase();
-    if (upperField in monthNames) {
-      return monthNames[upperField];
-    }
-  }
-
-  // Handle numeric values
-  const numValue = parseInt(field);
-  if (isNaN(numValue)) return -1;
-
-  return numValue >= min && numValue <= max ? numValue : -1;
+interface FieldRange {
+  start: number;
+  end: number;
+  isWildcard: boolean;
 }
 
-function parseRange(range: string, min: number, max: number): [number, number] {
-  const [startStr, endStr] = range.split("-");
-  const start = parseValue(startStr, min, max);
-  const end = parseValue(endStr, min, max);
+function parseRange(rangePart: string, spec: FieldSpec, hasStep: boolean): FieldRange | null {
+  if (rangePart === "*" || rangePart === "?") {
+    return { start: spec.min, end: spec.max, isWildcard: true };
+  }
 
-  return [start, end];
+  const bounds = rangePart.split("-");
+  if (bounds.length > 2) {
+    return null;
+  }
+
+  const start = parseValue(bounds[0], spec);
+  if (start === null) {
+    return null;
+  }
+
+  if (bounds.length === 1) {
+    // `5/15` reads as "from 5 to the end of the range, every 15".
+    return { start, end: hasStep ? spec.max : start, isWildcard: false };
+  }
+
+  const end = parseValue(bounds[1], spec);
+  if (end === null || end < start) {
+    return null;
+  }
+
+  return { start, end, isWildcard: false };
+}
+
+function parseValue(value: string, spec: FieldSpec): number | null {
+  const named = spec.names?.[value.toUpperCase()];
+  if (named !== undefined) {
+    return named;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (parsed < spec.min || parsed > spec.max) {
+    return null;
+  }
+
+  return parsed;
 }


### PR DESCRIPTION
## What

Rewrites the browser cron parser (`web_src/src/lib/cron.ts`) that powers the schedule trigger's "next run" preview.

## Why

Closes #6420.

The old implementation searched minute by minute and stopped after `366 * 24 * 60` iterations, so:

- **Schedules further out than a year never resolved.** `0 0 29 2 *` (a leap-day schedule the backend accepts and fires on 2028-02-29) previewed as `-`.
- **Each lookup cost ~60ms on the render path.** `formatNextTrigger()` runs inside `getTriggerProps()`, so every re-render of every schedule node paid for a ~527k-iteration scan for yearly schedules and for expressions with no upcoming occurrence. Canvases re-render on every websocket event.

It also drifted from the backend scheduler (`pkg/triggers/schedule`, parsing with `github.com/robfig/cron/v3`): the seconds field of 6-field expressions was dropped, `?` was rejected, invalid fields (`70 * * * *`, `*/0`, `10-5`) scanned for a year before returning `null`, and `*/2` in the day-of-month field was treated as a wildcard, which flips the day-of-month/day-of-week rule (`0 0 */2 * MON` previewed 2026-04-13; the backend fires 2026-04-03).

## How

Expand each field into its allowed values once, then walk candidate **days** rather than candidate minutes, over a five-year horizon. Lookups are now microseconds, leap-day schedules resolve, and invalid expressions are rejected during parsing instead of after a full scan.

The parser now mirrors robfig's rules: seconds are honoured in 6-field expressions, `?` behaves like `*`, ranges/steps/lists/names are validated against each field's bounds, and a step greater than 1 clears the wildcard flag so the day-of-month/day-of-week OR rule applies exactly as it does on the backend.

`getNextCronExecutions(expression, from, count)` is exposed alongside the existing single-shot helper; `getNextCronExecution` is now a thin wrapper over it.

## Testing

`npx vitest run src/lib/cron.spec.ts` — 32 tests. The expectations in `matches the backend scheduler for …` are the literal output of `cron.NewParser(...).Parse(expr).Next(from)` from `github.com/robfig/cron/v3`, captured for 20 expressions (including the invalid ones) so the two implementations can be compared directly.
