### PR TITLE
fix: back off websocket reconnects instead of retrying every 3s forever

### DIFF
--- a/web_src/src/hooks/useAgentSessionWebsocket.spec.ts
+++ b/web_src/src/hooks/useAgentSessionWebsocket.spec.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createElement, type ReactNode } from "react";
 import { agentChatKeys, type AgentMessagesPage } from "@/hooks/useAgentChats";
+import { WEBSOCKET_RECONNECT_MAX_MS } from "@/lib/websocketReconnect";
 
 const { useWebSocketMock } = vi.hoisted(() => ({
   useWebSocketMock: vi.fn(),
@@ -194,6 +195,16 @@ describe("useAgentSessionWebsocket", () => {
     emit("session_notice", { sessionId: "session-1", error: "transient provider error" });
     expect(onNotice).toHaveBeenCalledWith("transient provider error");
     expect(onStatus).not.toHaveBeenCalled();
+  });
+
+  it("backs off between reconnect attempts", () => {
+    render({});
+    const [, options] = lastCall();
+    const reconnectInterval = options.reconnectInterval as (attempt: number) => number;
+
+    expect(typeof reconnectInterval).toBe("function");
+    expect(reconnectInterval(5)).toBeGreaterThan(reconnectInterval(0));
+    expect(reconnectInterval(100)).toBeLessThanOrEqual(WEBSOCKET_RECONNECT_MAX_MS);
   });
 
   it("ignores malformed payloads without crashing", () => {

--- a/web_src/src/hooks/useAgentSessionWebsocket.ts
+++ b/web_src/src/hooks/useAgentSessionWebsocket.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from "react";
 import { useWebSocket } from "@/lib/reactUseWebsocket";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { upsertAgentMessageInCache } from "./useAgentChats";
+import { getWebsocketReconnectDelay } from "@/lib/websocketReconnect";
 import type { AgentMessage, AgentSessionWebsocketEvent } from "@/components/CanvasToolSidebar/types";
 
 function parseAgentEvent(event: MessageEvent<unknown>): AgentSessionWebsocketEvent | null {
@@ -113,7 +114,7 @@ export function useAgentSessionWebsocket(
     {
       shouldReconnect: () => true,
       reconnectAttempts: Number.POSITIVE_INFINITY,
-      reconnectInterval: 3000,
+      reconnectInterval: getWebsocketReconnectDelay,
       heartbeat: false,
       share: false,
       onMessage,

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -5,6 +5,7 @@ import { createElement } from "react";
 import type { ReactNode } from "react";
 import type { CanvasesCanvasRun } from "@/api-client";
 import { canvasKeys } from "@/hooks/useCanvasData";
+import { WEBSOCKET_RECONNECT_MAX_MS } from "@/lib/websocketReconnect";
 import type { InfiniteRunsPage } from "@/hooks/canvasInfiniteCache";
 
 const { useWebSocketMock, nodeExecutionStoreMock } = vi.hoisted(() => ({
@@ -448,5 +449,19 @@ describe("useCanvasWebsocket", () => {
 
     expect(onCanvasStagingEvent).toHaveBeenCalledOnce();
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.canvasStaging(testCanvasId))).toHaveLength(0);
+  });
+
+  it("backs off between reconnect attempts", () => {
+    renderCanvasWebsocketHook(new QueryClient());
+
+    const options = useWebSocketMock.mock.calls.at(-1)?.[1] as {
+      reconnectInterval?: number | ((attempt: number) => number);
+    };
+
+    expect(typeof options.reconnectInterval).toBe("function");
+
+    const reconnectInterval = options.reconnectInterval as (attempt: number) => number;
+    expect(reconnectInterval(5)).toBeGreaterThan(reconnectInterval(0));
+    expect(reconnectInterval(100)).toBeLessThanOrEqual(WEBSOCKET_RECONNECT_MAX_MS);
   });
 });

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -8,6 +8,7 @@ import type {
   CanvasesCanvasRun,
 } from "@/api-client";
 import { useNodeExecutionStore } from "@/stores/nodeExecutionStore";
+import { getWebsocketReconnectDelay } from "@/lib/websocketReconnect";
 import {
   parseRunsFiltersFromQueryKey,
   upsertExecutionIntoInfiniteRunsData,
@@ -400,7 +401,7 @@ export function useCanvasWebsocket(
       shouldReconnect: () => true,
       reconnectAttempts: Number.POSITIVE_INFINITY,
       heartbeat: false,
-      reconnectInterval: 3000,
+      reconnectInterval: getWebsocketReconnectDelay,
       onOpen: handleWebSocketOpen,
       onError: () => {},
       onClose: () => {},

--- a/web_src/src/lib/websocketReconnect.spec.ts
+++ b/web_src/src/lib/websocketReconnect.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  WEBSOCKET_RECONNECT_BASE_MS,
+  WEBSOCKET_RECONNECT_MAX_MS,
+  getWebsocketReconnectDelay,
+} from "@/lib/websocketReconnect";
+
+describe("getWebsocketReconnectDelay", () => {
+  it("backs off exponentially", () => {
+    const noJitter = () => 0;
+
+    expect(getWebsocketReconnectDelay(0, noJitter)).toBe(WEBSOCKET_RECONNECT_BASE_MS / 2);
+    expect(getWebsocketReconnectDelay(1, noJitter)).toBe(WEBSOCKET_RECONNECT_BASE_MS);
+    expect(getWebsocketReconnectDelay(2, noJitter)).toBe(WEBSOCKET_RECONNECT_BASE_MS * 2);
+    expect(getWebsocketReconnectDelay(3, noJitter)).toBe(WEBSOCKET_RECONNECT_BASE_MS * 4);
+  });
+
+  it("retries quickly on the first attempts", () => {
+    // A short blip should not leave the canvas stale for long.
+    expect(getWebsocketReconnectDelay(0, () => 1)).toBeLessThanOrEqual(WEBSOCKET_RECONNECT_BASE_MS);
+    expect(getWebsocketReconnectDelay(1, () => 1)).toBeLessThanOrEqual(2 * WEBSOCKET_RECONNECT_BASE_MS);
+  });
+
+  it("caps the delay", () => {
+    for (const attempt of [10, 50, 1_000, Number.MAX_SAFE_INTEGER]) {
+      expect(getWebsocketReconnectDelay(attempt, () => 1)).toBe(WEBSOCKET_RECONNECT_MAX_MS);
+      expect(getWebsocketReconnectDelay(attempt, () => 0)).toBe(WEBSOCKET_RECONNECT_MAX_MS / 2);
+    }
+  });
+
+  it("jitters so that clients do not retry in lockstep", () => {
+    const delays = new Set<number>();
+    for (let i = 0; i < 200; i++) {
+      delays.add(getWebsocketReconnectDelay(3));
+    }
+
+    expect(delays.size).toBeGreaterThan(50);
+    for (const delay of delays) {
+      expect(delay).toBeGreaterThanOrEqual(WEBSOCKET_RECONNECT_BASE_MS * 4);
+      expect(delay).toBeLessThanOrEqual(WEBSOCKET_RECONNECT_BASE_MS * 8);
+    }
+  });
+
+  it("never returns a negative or non-finite delay", () => {
+    for (const attempt of [-5, Number.NaN, Number.POSITIVE_INFINITY, 0.5]) {
+      const delay = getWebsocketReconnectDelay(attempt);
+
+      expect(Number.isFinite(delay)).toBe(true);
+      expect(delay).toBeGreaterThan(0);
+      expect(delay).toBeLessThanOrEqual(WEBSOCKET_RECONNECT_MAX_MS);
+    }
+  });
+});

--- a/web_src/src/lib/websocketReconnect.ts
+++ b/web_src/src/lib/websocketReconnect.ts
@@ -1,0 +1,28 @@
+/**
+ * Reconnect pacing for the app's websockets.
+ *
+ * Every open canvas and agent session reconnects when the backend restarts, so
+ * a fixed interval makes all of them retry in lockstep for as long as the
+ * backend is unavailable. Delays grow exponentially up to a cap and carry
+ * jitter, which spreads the retries out and keeps a slow restart from being
+ * hammered by every open tab.
+ */
+
+export const WEBSOCKET_RECONNECT_BASE_MS = 1_000;
+export const WEBSOCKET_RECONNECT_MAX_MS = 30_000;
+
+/**
+ * Delay before the next reconnect attempt, in milliseconds.
+ *
+ * `attempt` is zero-based: 0 is the first retry after a connection drops. The
+ * counter resets once a connection opens, so a short blip still reconnects
+ * quickly.
+ */
+export function getWebsocketReconnectDelay(attempt: number, random: () => number = Math.random): number {
+  const safeAttempt = Number.isFinite(attempt) ? Math.max(0, Math.floor(attempt)) : 0;
+  const exponential = Math.min(WEBSOCKET_RECONNECT_BASE_MS * 2 ** safeAttempt, WEBSOCKET_RECONNECT_MAX_MS);
+
+  // Half of the delay is fixed and half is jittered, so retries stay bounded
+  // while still being spread across clients.
+  return Math.round(exponential / 2 + (exponential / 2) * random());
+}


### PR DESCRIPTION
## What

Adds a shared reconnect policy for the app's websockets and uses it in both hooks.

## Why

Closes #6421.

`useCanvasWebsocket` and `useAgentSessionWebsocket` both reconnect with `reconnectInterval: 3000` and `reconnectAttempts: Number.POSITIVE_INFINITY`. While `/ws/` is unreachable — a deploy, a restart, a network partition — every open canvas and agent session retries 20 times a minute for the whole outage, with no upper bound: a tab left open overnight makes ~1200 attempts an hour.

Because the interval is a constant with no jitter, clients disconnected by the same event stay phase-locked, so the retries land together — including the first ones after the backend comes back up.

## How

`web_src/src/lib/websocketReconnect.ts` exports `getWebsocketReconnectDelay(attempt)`: exponential backoff from 1s, capped at 30s, with half the delay fixed and half jittered so clients spread out as an outage continues. Both hooks pass it as `reconnectInterval`, which `react-use-websocket` accepts as a function of the attempt number.

`react-use-websocket` resets that counter in its `onopen` handler, so a short blip still reconnects in about a second — only a sustained outage backs off.

## Testing

`npx vitest run src/lib/websocketReconnect.spec.ts src/hooks/useCanvasWebsocket.spec.ts src/hooks/useAgentSessionWebsocket.spec.ts` — 30 tests. Covers the backoff curve, the cap, jitter spread, non-finite/negative attempt numbers, and that both hooks register a backing-off `reconnectInterval`.
