### PR TITLE
fix: drain canvas websocket bursts in slices instead of one task per message

### DIFF
--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -449,4 +449,30 @@ describe("useCanvasWebsocket", () => {
     expect(onCanvasStagingEvent).toHaveBeenCalledOnce();
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.canvasStaging(testCanvasId))).toHaveLength(0);
   });
+
+  it("drains a burst of messages for one node without a task per message", async () => {
+    const queryClient = new QueryClient();
+    vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    seedInfiniteRuns(queryClient, []);
+
+    renderCanvasWebsocketHook(queryClient);
+
+    const burstSize = 50;
+    for (let i = 0; i < burstSize; i++) {
+      emitWebsocketMessage("execution_created", {
+        id: `execution-${i}`,
+        nodeId: testNodeId,
+        state: "STATE_PENDING",
+        updatedAt: "2026-06-01T12:00:00.000Z",
+        rootEvent: { id: "event-1", nodeId: testNodeId },
+      });
+    }
+
+    await flushMessageQueue();
+
+    expect(nodeExecutionStoreMock.updateNodeExecution).toHaveBeenCalledTimes(burstSize);
+    expect(nodeExecutionStoreMock.updateNodeExecution.mock.calls.map((call) => (call[1] as { id: string }).id)).toEqual(
+      Array.from({ length: burstSize }, (_, i) => `execution-${i}`),
+    );
+  });
 });

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -19,6 +19,9 @@ import { canvasKeys, invalidateStagedCanvasCaches } from "./useCanvasData";
 
 const SOCKET_SERVER_URL = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws/`;
 
+// How long a single drain slice may run before yielding to the browser.
+const QUEUE_SLICE_BUDGET_MS = 8;
+
 type CanvasWebsocketPayload = {
   canvasId: string;
   userId?: string;
@@ -311,12 +314,20 @@ export function useCanvasWebsocket(
       processingNodes.current.add(nodeId);
 
       try {
-        // Process messages in order
+        // Process messages in order, in slices: a burst is applied in one go and
+        // rendered once, and we only yield to the browser between slices so a
+        // long burst cannot block interaction.
         while (queue.length > 0) {
-          const message = queue.shift();
-          if (message) {
-            processMessage(message.data);
-            // Small delay to ensure state updates are applied
+          const sliceStart = performance.now();
+
+          while (queue.length > 0 && performance.now() - sliceStart < QUEUE_SLICE_BUDGET_MS) {
+            const message = queue.shift();
+            if (message) {
+              processMessage(message.data);
+            }
+          }
+
+          if (queue.length > 0) {
             await new Promise((resolve) => setTimeout(resolve, 0));
           }
         }
@@ -328,6 +339,9 @@ export function useCanvasWebsocket(
         if (remainingQueue && remainingQueue.length > 0) {
           // Schedule next processing
           setTimeout(() => processQueue(nodeId), 0);
+        } else {
+          // Drop the empty queue so nodes that stop emitting do not accumulate.
+          messageQueues.current.delete(nodeId);
         }
       }
     },


### PR DESCRIPTION
## What

Drains the canvas websocket's per-node message queue in time slices instead of one message per macrotask.

## Why

Closes #6422.

`processQueue` awaited a `setTimeout(0)` after every message, and messages arriving during a drain were skipped by the `processingNodes` guard and left for the next tick. A burst of N messages for one node therefore needed N timer ticks, each applied in its own task and rendered separately. Browsers clamp nested timers to 4ms, so a 100-message burst — a run fanning out executions, a queue draining, a canvas reconnecting after an outage — took ~0.4s of wall clock before the node caught up with the backend.

The regression test in this PR makes the size of the gap concrete: on `main`, 50 messages emitted for one node leave **2 of 50** applied after a tick.

## How

Apply messages synchronously until an 8ms budget is spent, then yield once so the browser can still paint during a long burst. Per-node ordering is unchanged, and the guard against concurrent drains for the same node stays.

Also drop a node's queue entry once it empties — `messageQueues` previously kept an empty array for every node that had ever emitted, for the lifetime of the canvas.

## Testing

`npx vitest run src/hooks/useCanvasWebsocket.spec.ts` — 15 tests. The new case emits a 50-message burst for one node and asserts all 50 are applied, in order, after a single flush; it fails on `main` with 2 of 50.
