### PR TITLE
fix: prevent websocket hub deadlock when a client send buffer fills

### DIFF
--- a/pkg/public/ws/ws_hub.go
+++ b/pkg/public/ws/ws_hub.go
@@ -109,36 +109,52 @@ func (h *Hub) unregisterClient(client *Client) {
 	}
 }
 
-// BroadcastAll sends a message to all connected clients
-func (h *Hub) BroadcastAll(message []byte) {
-	h.mutex.RLock()
-	defer h.mutex.RUnlock()
+// deliver sends the message to every client, returning the ones whose buffer
+// was full. The caller must release h.mutex before dropping them: eviction
+// takes the write lock, and sync.RWMutex is not reentrant, so evicting while
+// still holding the read lock deadlocks the broadcast permanently.
+func (h *Hub) deliver(clients map[*Client]bool, message []byte) []*Client {
+	var stalled []*Client
 
-	for client := range h.clients {
+	for client := range clients {
 		select {
 		case client.send <- message:
 		default:
-			// If the client's buffer is full, assume it's gone and unregister it
-			h.unregisterClient(client)
+			stalled = append(stalled, client)
 		}
 	}
+
+	return stalled
+}
+
+// dropStalled unregisters clients that stopped reading. Must be called without
+// holding h.mutex.
+func (h *Hub) dropStalled(clients []*Client) {
+	for _, client := range clients {
+		log.Warnf("Dropping client subscribed to workflow %s: send buffer full", client.workflowID)
+		h.unregisterClient(client)
+	}
+}
+
+// BroadcastAll sends a message to all connected clients
+func (h *Hub) BroadcastAll(message []byte) {
+	h.mutex.RLock()
+	stalled := h.deliver(h.clients, message)
+	h.mutex.RUnlock()
+
+	h.dropStalled(stalled)
 }
 
 func (h *Hub) BroadcastToWorkflow(workflowID string, message []byte) {
 	h.mutex.RLock()
-	defer h.mutex.RUnlock()
-
+	var stalled []*Client
 	// Get clients subscribed to this workflow
 	if clients, ok := h.workflowSubscriptions[workflowID]; ok {
-		for client := range clients {
-			select {
-			case client.send <- message:
-			default:
-				// If the client's buffer is full, assume it's gone and unregister it
-				h.unregisterClient(client)
-			}
-		}
+		stalled = h.deliver(clients, message)
 	}
+	h.mutex.RUnlock()
+
+	h.dropStalled(stalled)
 }
 
 func (h *Hub) WorkflowSubscriberCount(workflowID string) int {

--- a/pkg/public/ws/ws_hub_test.go
+++ b/pkg/public/ws/ws_hub_test.go
@@ -1,0 +1,161 @@
+package ws
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient builds a client without a websocket connection. None of the
+// broadcast paths touch conn, and a client with an unbuffered send channel and
+// no reader always takes the "buffer full" branch, which is what these tests
+// exercise.
+func newTestClient(hub *Hub, workflowID string, sendBuffer int) *Client {
+	return &Client{
+		hub:        hub,
+		send:       make(chan []byte, sendBuffer),
+		Done:       make(chan struct{}),
+		workflowID: workflowID,
+	}
+}
+
+// registerTestClients registers clients and waits for the hub loop to pick them
+// up, since sending on the register channel only hands the client over.
+func registerTestClients(t *testing.T, hub *Hub, clients ...*Client) {
+	t.Helper()
+
+	expected := map[string]int{}
+	for _, client := range clients {
+		hub.register <- client
+		expected[client.workflowID]++
+	}
+
+	require.Eventually(t, func() bool {
+		for workflowID, count := range expected {
+			if hub.WorkflowSubscriberCount(workflowID) != count {
+				return false
+			}
+		}
+		return true
+	}, time.Second, time.Millisecond, "clients were never registered")
+}
+
+// requireNoReturnAfterTimeout fails if fn has not returned in time. A hang here
+// is the failure being guarded against, not a slow test: evicting a client from
+// inside a broadcast used to take the write lock while the read lock was still
+// held, and sync.RWMutex is not reentrant.
+func requireNoDeadlock(t *testing.T, fn func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("broadcast never returned: the hub deadlocked while evicting a stalled client")
+	}
+}
+
+func TestBroadcastToWorkflowDoesNotDeadlockOnFullClientBuffer(t *testing.T) {
+	hub := NewHub()
+	hub.Run()
+
+	registerTestClients(t, hub, newTestClient(hub, "workflow-1", 0))
+
+	requireNoDeadlock(t, func() {
+		hub.BroadcastToWorkflow("workflow-1", []byte("tick"))
+	})
+}
+
+func TestBroadcastAllDoesNotDeadlockOnFullClientBuffer(t *testing.T) {
+	hub := NewHub()
+	hub.Run()
+
+	registerTestClients(t, hub, newTestClient(hub, "workflow-1", 0))
+
+	requireNoDeadlock(t, func() {
+		hub.BroadcastAll([]byte("tick"))
+	})
+}
+
+func TestBroadcastToWorkflowDropsStalledClientAndKeepsHealthyOnes(t *testing.T) {
+	hub := NewHub()
+	hub.Run()
+
+	healthy := newTestClient(hub, "workflow-1", 1)
+	stalled := newTestClient(hub, "workflow-1", 0)
+	registerTestClients(t, hub, healthy, stalled)
+
+	requireNoDeadlock(t, func() {
+		hub.BroadcastToWorkflow("workflow-1", []byte("tick"))
+	})
+
+	assert.Equal(t, []byte("tick"), <-healthy.send)
+	assert.Equal(t, 1, hub.WorkflowSubscriberCount("workflow-1"))
+
+	hub.mutex.RLock()
+	defer hub.mutex.RUnlock()
+	assert.True(t, hub.clients[healthy], "healthy client should stay registered")
+	assert.False(t, hub.clients[stalled], "stalled client should have been dropped")
+}
+
+func TestBroadcastToWorkflowIgnoresOtherWorkflows(t *testing.T) {
+	hub := NewHub()
+	hub.Run()
+
+	subscriber := newTestClient(hub, "workflow-1", 1)
+	other := newTestClient(hub, "workflow-2", 1)
+	registerTestClients(t, hub, subscriber, other)
+
+	hub.BroadcastToWorkflow("workflow-1", []byte("tick"))
+
+	assert.Equal(t, []byte("tick"), <-subscriber.send)
+	assert.Empty(t, other.send, "clients watching another workflow should not receive the message")
+}
+
+// Two broadcasters can race to evict the same stalled client. Eviction closes
+// the client's send channel, so it has to stay idempotent or the second one
+// panics.
+func TestConcurrentBroadcastsDropSameStalledClientSafely(t *testing.T) {
+	hub := NewHub()
+	hub.Run()
+
+	registerTestClients(t, hub, newTestClient(hub, "workflow-1", 0))
+
+	var broadcasts sync.WaitGroup
+	for range 8 {
+		broadcasts.Add(1)
+		go func() {
+			defer broadcasts.Done()
+			hub.BroadcastToWorkflow("workflow-1", []byte("tick"))
+		}()
+	}
+
+	requireNoDeadlock(t, broadcasts.Wait)
+	assert.Equal(t, 0, hub.WorkflowSubscriberCount("workflow-1"))
+}
+
+func TestUnregisterClientIsIdempotent(t *testing.T) {
+	hub := NewHub()
+	client := newTestClient(hub, "workflow-1", 0)
+
+	hub.mutex.Lock()
+	hub.clients[client] = true
+	hub.workflowSubscriptions["workflow-1"] = map[*Client]bool{client: true}
+	hub.mutex.Unlock()
+
+	hub.unregisterClient(client)
+
+	assert.NotPanics(t, func() {
+		hub.unregisterClient(client)
+	}, "unregistering twice must not close the send channel twice")
+
+	assert.Equal(t, 0, hub.WorkflowSubscriberCount("workflow-1"))
+}


### PR DESCRIPTION
Fixes #6427

## What

`BroadcastAll` and `BroadcastToWorkflow` no longer evict clients while holding the hub's read lock. Delivery and eviction are split: `deliver` collects the clients whose send buffer is full under the read lock, and `dropStalled` unregisters them once the lock is released.

## Why

Both broadcast methods took `h.mutex.RLock()` and then called `unregisterClient` from inside the delivery loop, which takes `h.mutex.Lock()`. `sync.RWMutex` is not reentrant, so the broadcasting goroutine blocked on itself forever — while still holding the read lock. Every later register, unregister and broadcast queued behind it, and the hub never recovered.

Any client that stops draining its `send` channel (cap 4096) triggers it: a backgrounded browser tab, or a stalled TCP connection where `writePump` blocks on its 10s write deadline while the buffer fills.

All six event distributors fan out through this hub, so a single stalled client permanently froze canvas updates, run and execution status, and agent sessions for **every user on that pod**, until the process restarted — with nothing logged.

```
goroutine 11 [sync.RWMutex.Lock]:
sync.(*RWMutex).Lock(...)
ws.(*Hub).unregisterClient(...)  pkg/public/ws/ws_hub.go:89
ws.(*Hub).BroadcastToWorkflow(...)  pkg/public/ws/ws_hub.go:138
```

## How

The write lock is now only ever taken with no read lock held. Note the deliberate use of an explicit `RUnlock` rather than `defer` — the eviction has to happen after the read lock is released.

Eviction behaviour is unchanged: a client whose buffer is full is still dropped, and it now logs a warning instead of failing silently. No API, schema or frontend change.

Two broadcasters can race to drop the same client, and eviction closes the client's `send` channel. That stays safe on the existing registration guard in `unregisterClient` (`if _, ok := h.clients[client]; ok`), which makes it idempotent — so no second close path was added. `TestConcurrentBroadcastsDropSameStalledClientSafely` covers that case with 8 concurrent broadcasters.

## Tests

This package had no tests, so this adds the first ones. The three deadlock tests hang against `main` and pass with the fix:

```
$ go test -race -count=1 ./pkg/public/ws/...   # before
--- FAIL: TestBroadcastToWorkflowDoesNotDeadlockOnFullClientBuffer (5.00s)
--- FAIL: TestBroadcastAllDoesNotDeadlockOnFullClientBuffer (5.01s)
--- FAIL: TestBroadcastToWorkflowDropsStalledClientAndKeepsHealthyOnes (5.01s)
--- FAIL: TestConcurrentBroadcastsDropSameStalledClientSafely (5.01s)

$ go test -race -count=1 ./pkg/public/ws/...   # after
ok      github.com/superplanehq/superplane/pkg/public/ws 1.013s
```

`gofmt`, `go vet` and `revive -config lint.toml` are clean on the package.

## Not included

`handleMessage` (`ws_hub.go:249`) logs every inbound client message at `Info` with a 1 MB read limit, which is an unbounded log-flood vector from one connection. Left out to keep this PR to the deadlock — happy to send it separately.
