### PR TITLE
fix: url path-escape parameters in Bitbucket client API requests

### DIFF
--- a/pkg/integrations/bitbucket/client.go
+++ b/pkg/integrations/bitbucket/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
@@ -88,8 +89,8 @@ type Workspace struct {
 }
 
 func (c *Client) GetWorkspace(workspaceSlug string) (*Workspace, error) {
-	url := fmt.Sprintf("%s/workspaces/%s", baseURL, workspaceSlug)
-	req, err := http.NewRequest("GET", url, nil)
+	apiURL := fmt.Sprintf("%s/workspaces/%s", baseURL, url.PathEscape(workspaceSlug))
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
@@ -123,11 +124,11 @@ func (c *Client) GetWorkspace(workspaceSlug string) (*Workspace, error) {
 }
 
 func (c *Client) ListRepositories(workspace string) ([]Repository, error) {
-	url := fmt.Sprintf("%s/repositories/%s?pagelen=100", baseURL, workspace)
+	apiURL := fmt.Sprintf("%s/repositories/%s?pagelen=100", baseURL, url.PathEscape(workspace))
 	repositories := []Repository{}
 
-	for url != "" {
-		req, err := http.NewRequest("GET", url, nil)
+	for apiURL != "" {
+		req, err := http.NewRequest("GET", apiURL, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error creating request: %w", err)
 		}
@@ -157,7 +158,7 @@ func (c *Client) ListRepositories(workspace string) ([]Repository, error) {
 		}
 
 		repositories = append(repositories, repoResponse.Values...)
-		url = repoResponse.Next
+		apiURL = repoResponse.Next
 	}
 
 	return repositories, nil
@@ -178,7 +179,7 @@ type BitbucketHookResponse struct {
 }
 
 func (c *Client) CreateWebhook(workspace, repoSlug, webhookURL, secret string, events []string) (*BitbucketHookResponse, error) {
-	url := fmt.Sprintf("%s/repositories/%s/%s/hooks", baseURL, workspace, repoSlug)
+	apiURL := fmt.Sprintf("%s/repositories/%s/%s/hooks", baseURL, url.PathEscape(workspace), url.PathEscape(repoSlug))
 
 	hookReq := BitbucketHookRequest{
 		Description: "SuperPlane",
@@ -193,7 +194,7 @@ func (c *Client) CreateWebhook(workspace, repoSlug, webhookURL, secret string, e
 		return nil, fmt.Errorf("error marshaling webhook request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	req, err := http.NewRequest("POST", apiURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
@@ -228,9 +229,9 @@ func (c *Client) CreateWebhook(workspace, repoSlug, webhookURL, secret string, e
 }
 
 func (c *Client) DeleteWebhook(workspace, repoSlug, webhookUID string) error {
-	url := fmt.Sprintf("%s/repositories/%s/%s/hooks/%s", baseURL, workspace, repoSlug, webhookUID)
+	apiURL := fmt.Sprintf("%s/repositories/%s/%s/hooks/%s", baseURL, url.PathEscape(workspace), url.PathEscape(repoSlug), url.PathEscape(webhookUID))
 
-	req, err := http.NewRequest("DELETE", url, nil)
+	req, err := http.NewRequest("DELETE", apiURL, nil)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}

--- a/pkg/integrations/bitbucket/client_test.go
+++ b/pkg/integrations/bitbucket/client_test.go
@@ -1,0 +1,109 @@
+package bitbucket
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Client__PathEscaping(t *testing.T) {
+	t.Run("GetWorkspace path escapes workspace slug", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"uuid":"{workspace-uuid}","name":"My Workspace","slug":"my workspace"}`)),
+				},
+			},
+		}
+
+		client := &Client{
+			AuthType: AuthTypeWorkspaceAccessToken,
+			Token:    "token",
+			HTTP:     httpCtx,
+		}
+
+		workspace, err := client.GetWorkspace("my workspace")
+		require.NoError(t, err)
+		assert.Equal(t, "My Workspace", workspace.Name)
+
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "https://api.bitbucket.org/2.0/workspaces/my%20workspace", httpCtx.Requests[0].URL.String())
+	})
+
+	t.Run("ListRepositories path escapes workspace", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"uuid":"{repo-uuid}","name":"repo","full_name":"my workspace/repo","slug":"repo"}]}`)),
+				},
+			},
+		}
+
+		client := &Client{
+			AuthType: AuthTypeWorkspaceAccessToken,
+			Token:    "token",
+			HTTP:     httpCtx,
+		}
+
+		repos, err := client.ListRepositories("my workspace")
+		require.NoError(t, err)
+		require.Len(t, repos, 1)
+
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "https://api.bitbucket.org/2.0/repositories/my%20workspace?pagelen=100", httpCtx.Requests[0].URL.String())
+	})
+
+	t.Run("CreateWebhook path escapes workspace and repo slug", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"uuid":"{hook-uuid}","url":"https://example.com","active":true}`)),
+				},
+			},
+		}
+
+		client := &Client{
+			AuthType: AuthTypeWorkspaceAccessToken,
+			Token:    "token",
+			HTTP:     httpCtx,
+		}
+
+		hook, err := client.CreateWebhook("my workspace", "my repo", "https://example.com", "secret", []string{"repo:push"})
+		require.NoError(t, err)
+		assert.Equal(t, "{hook-uuid}", hook.UUID)
+
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "https://api.bitbucket.org/2.0/repositories/my%20workspace/my%20repo/hooks", httpCtx.Requests[0].URL.String())
+	})
+
+	t.Run("DeleteWebhook path escapes workspace, repo slug, and webhook UID", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNoContent,
+					Body:       io.NopCloser(strings.NewReader("")),
+				},
+			},
+		}
+
+		client := &Client{
+			AuthType: AuthTypeWorkspaceAccessToken,
+			Token:    "token",
+			HTTP:     httpCtx,
+		}
+
+		err := client.DeleteWebhook("my workspace", "my repo", "{hook uuid}")
+		require.NoError(t, err)
+
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "https://api.bitbucket.org/2.0/repositories/my%20workspace/my%20repo/hooks/%7Bhook%20uuid%7D", httpCtx.Requests[0].URL.String())
+	})
+}


### PR DESCRIPTION
## Summary

This PR ensures all dynamic path parameters (`workspace`, `repoSlug`, `webhookUID`, and `workspaceSlug`) constructed in Bitbucket REST API request URLs are safely URL path-escaped using `net/url`. It also renames local `url` string variables to `apiURL` to eliminate package name shadowing.

## Motivation

In `pkg/integrations/bitbucket/client.go`, dynamic values like workspace slugs or repository names were interpolated directly into raw format strings. If any workspace slug or repository name contains characters with special meaning in URL path components (e.g. spaces, special symbols, or slashes), API calls to Bitbucket would fail or construct invalid request URIs. 

Path-escaping API parameters aligns the Bitbucket integration with the established standards followed across all other integrations in the SuperPlane codebase (such as GitLab, Sentry, Cloudsmith, and Claude).

## Changes Made

- **`pkg/integrations/bitbucket/client.go`**:
  - Imported standard library `"net/url"`.
  - Wrapped `workspaceSlug`, `workspace`, `repoSlug`, and `webhookUID` in `url.PathEscape(...)` across `GetWorkspace`, `ListRepositories`, `CreateWebhook`, and `DeleteWebhook`.
  - Renamed local string variable declarations from `url` to `apiURL` to prevent shadowing the `"net/url"` package name.
- **`pkg/integrations/bitbucket/client_test.go`**:
  - Added comprehensive unit tests asserting that special characters in path parameters are properly URL-escaped when constructing HTTP requests.

## Testing Performed

- Added unit test cases (`Test__Client__PathEscaping`) in `pkg/integrations/bitbucket/client_test.go` covering `GetWorkspace`, `ListRepositories`, `CreateWebhook`, and `DeleteWebhook`.
- Verified that requested HTTP URLs carry expected percent-encoded path segments (e.g., `my%20workspace`, `%7Bhook%20uuid%7D`).

## Screenshots

*N/A — Backend / integration API client change only.*
