### PR TITLE
docs: fix broken links to Integrations Board

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,6 @@ When `make dev.server` reports the app as healthy, open SuperPlane at [http://lo
 - **[Component Implementation](docs/contributing/component-implementations.md)** — Step-by-step instructions for creating new components or triggers
 - **[Component Customization](docs/contributing/component-customization.md)** — Guide for customizing existing components or building behaviors
 - **[Templates](docs/contributing/templates.md)** — Guide for creating and adding new workflow templates
-- **[Integrations Board](https://github.com/orgs/superplanehq/projects/2/views/17)** — View all integration-related work on the SuperPlane Board
+- **[Integrations Board](https://github.com/orgs/superplanehq/projects/2)** — View all integration-related work on the SuperPlane Board
 - **[Integration bounties](docs/contributing/bounties.md)** — How to claim, work on, and get paid for bounties via BountyHub; review and dispute process
 - **[Connecting to Third-Party Services during Development](docs/contributing/connecting-to-3rdparty-services-from-development.md)**

--- a/docs/contributing/building-an-integration.md
+++ b/docs/contributing/building-an-integration.md
@@ -8,7 +8,7 @@ High-level steps to add a new integration to SuperPlane.
 
 Choose the integration you want to build and **claim the existing issue by commenting on it** so we know you’re working on it.
 
-See: [Integrations Board](https://github.com/orgs/superplanehq/projects/2/views/19).
+See: [Integrations Board](https://github.com/orgs/superplanehq/projects/2).
 
 ## 2. Research the connection method
 


### PR DESCRIPTION
The links pointing to the Integrations Board on views 17 and 19 were returning 'This view no longer exists' errors. This PR updates both CONTRIBUTING.md and building-an-integration.md to point directly to the main SuperPlane project board.