### PR TITLE
feat: notify organization owners when a member joins

### DIFF
--- a/pkg/grpc/actions/messages/organization_member_joined.go
+++ b/pkg/grpc/actions/messages/organization_member_joined.go
@@ -1,0 +1,22 @@
+package messages
+
+import "encoding/json"
+
+const OrganizationMemberJoinedRoutingKey = "organization-member-joined"
+
+type OrganizationMemberJoinedMessage struct {
+	ToEmail          string `json:"to_email"`
+	OrganizationID   string `json:"organization_id"`
+	OrganizationName string `json:"organization_name"`
+	MemberEmail      string `json:"member_email"`
+	MemberName       string `json:"member_name,omitempty"`
+}
+
+func (m OrganizationMemberJoinedMessage) Publish() error {
+	body, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	return Publish(CanvasExchange, OrganizationMemberJoinedRoutingKey, body)
+}

--- a/pkg/grpc/actions/organizations/accept_invite_link.go
+++ b/pkg/grpc/actions/organizations/accept_invite_link.go
@@ -3,9 +3,11 @@ package organizations
 import (
 	"context"
 	"errors"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	usagepb "github.com/superplanehq/superplane/pkg/protos/usage"
@@ -13,6 +15,9 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
 )
+
+type memberJoinedPublisher func(messages.OrganizationMemberJoinedMessage) error
+type eligibleOwnerLister func(*gorm.DB, string, []string) ([]models.User, error)
 
 func AcceptInviteLink(ctx context.Context, authService authorization.Authorization, accountID string, token string) (*structpb.Struct, error) {
 	return AcceptInviteLinkWithUsage(ctx, authService, nil, accountID, token)
@@ -22,6 +27,20 @@ func AcceptInviteLinkWithUsage(
 	ctx context.Context,
 	authService authorization.Authorization,
 	usageService usage.Service,
+	accountID string,
+	token string,
+) (*structpb.Struct, error) {
+	return acceptInviteLinkWithUsage(ctx, authService, usageService, func(message messages.OrganizationMemberJoinedMessage) error {
+		return message.Publish()
+	}, models.ListActiveHumanUsersByIDs, accountID, token)
+}
+
+func acceptInviteLinkWithUsage(
+	ctx context.Context,
+	authService authorization.Authorization,
+	usageService usage.Service,
+	publish memberJoinedPublisher,
+	listOwners eligibleOwnerLister,
 	accountID string,
 	token string,
 ) (*structpb.Struct, error) {
@@ -110,7 +129,43 @@ func AcceptInviteLinkWithUsage(
 		return nil, grpcerrors.Internal(err, "failed to accept invite")
 	}
 
+	notifyOrganizationOwnersOfJoinedMember(ctx, authService, publish, listOwners, org, user)
+
 	return inviteLinkAcceptResponse(org.ID.String(), org.Name, statusValue)
+}
+
+func notifyOrganizationOwnersOfJoinedMember(
+	ctx context.Context,
+	authService authorization.Authorization,
+	publish memberJoinedPublisher,
+	listOwners eligibleOwnerLister,
+	organization *models.Organization,
+	member *models.User,
+) {
+	ownerIDs, err := authService.GetOrgUsersForRole(ctx, models.RoleOrgOwner, organization.ID.String())
+	if err != nil {
+		log.Errorf("failed to resolve organization owners for member join notification: %v", err)
+		return
+	}
+
+	owners, err := listOwners(database.DB(ctx), organization.ID.String(), ownerIDs)
+	if err != nil {
+		log.Errorf("failed to load organization owners for member join notification: %v", err)
+		return
+	}
+
+	for _, owner := range owners {
+		message := messages.OrganizationMemberJoinedMessage{
+			ToEmail:          owner.GetEmail(),
+			OrganizationID:   organization.ID.String(),
+			OrganizationName: organization.Name,
+			MemberEmail:      member.GetEmail(),
+			MemberName:       member.Name,
+		}
+		if err := publish(message); err != nil {
+			log.Errorf("failed to publish member join notification for organization %s and owner %s: %v", organization.ID, owner.ID, err)
+		}
+	}
 }
 
 func inviteLinkAcceptResponse(organizationID, organizationName, statusValue string) (*structpb.Struct, error) {

--- a/pkg/grpc/actions/organizations/accept_invite_link_test.go
+++ b/pkg/grpc/actions/organizations/accept_invite_link_test.go
@@ -2,11 +2,13 @@ package organizations
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	usagepb "github.com/superplanehq/superplane/pkg/protos/usage"
@@ -81,5 +83,184 @@ func Test__AcceptInviteLinkWithUsage(t *testing.T) {
 		require.NotNil(t, response)
 		assert.Empty(t, service.checkOrganizationCalls)
 		assert.Equal(t, "already_member", response.Fields["status"].GetStringValue())
+	})
+}
+
+func TestNotifyOrganizationOwnersOfJoinedMember(t *testing.T) {
+	r := support.Setup(t)
+	memberEmail := "alex@example.com"
+	member := &models.User{Name: "Alex", Email: &memberEmail}
+	var published []messages.OrganizationMemberJoinedMessage
+
+	notifyOrganizationOwnersOfJoinedMember(
+		context.Background(),
+		r.AuthService,
+		func(message messages.OrganizationMemberJoinedMessage) error {
+			published = append(published, message)
+			return nil
+		},
+		func(_ *gorm.DB, organizationID string, ownerIDs []string) ([]models.User, error) {
+			require.Equal(t, r.Organization.ID.String(), organizationID)
+			require.Contains(t, ownerIDs, r.UserModel.ID.String())
+			return []models.User{*r.UserModel}, nil
+		},
+		r.Organization,
+		member,
+	)
+
+	require.Len(t, published, 1)
+	assert.Equal(t, r.UserModel.GetEmail(), published[0].ToEmail)
+	assert.Equal(t, "Alex", published[0].MemberName)
+	assert.Equal(t, "alex@example.com", published[0].MemberEmail)
+}
+
+func TestAcceptInviteLinkPublishesOrganizationMemberJoinedNotifications(t *testing.T) {
+	t.Run("publishes one message for each eligible owner after a new member joins", func(t *testing.T) {
+		r := support.Setup(t)
+		secondOwnerAccount, err := models.CreateAccount("second-owner@example.com", "Second Owner")
+		require.NoError(t, err)
+		secondOwner, err := models.CreateUser(r.Organization.ID, secondOwnerAccount.ID, secondOwnerAccount.Email, secondOwnerAccount.Name)
+		require.NoError(t, err)
+		require.NoError(t, r.AuthService.AssignRole(secondOwner.ID.String(), models.RoleOrgOwner, r.Organization.ID.String(), models.DomainTypeOrganization))
+		invitee, err := models.CreateAccount("invitee@example.com", "Invitee")
+		require.NoError(t, err)
+		inviteLink, err := models.FindInviteLinkByOrganizationID(database.DB(t.Context()), r.Organization.ID.String())
+		require.NoError(t, err)
+
+		var published []messages.OrganizationMemberJoinedMessage
+		response, err := acceptInviteLinkWithUsage(
+			context.Background(),
+			r.AuthService,
+			nil,
+			func(message messages.OrganizationMemberJoinedMessage) error {
+				published = append(published, message)
+				return nil
+			},
+			models.ListActiveHumanUsersByIDs,
+			invitee.ID.String(),
+			inviteLink.Token.String(),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "joined", response.Fields["status"].GetStringValue())
+		require.Len(t, published, 2)
+		assert.ElementsMatch(t, []string{r.UserModel.GetEmail(), secondOwner.GetEmail()}, []string{published[0].ToEmail, published[1].ToEmail})
+		for _, message := range published {
+			assert.Equal(t, r.Organization.ID.String(), message.OrganizationID)
+			assert.Equal(t, r.Organization.Name, message.OrganizationName)
+			assert.Equal(t, invitee.Email, message.MemberEmail)
+			assert.Equal(t, invitee.Name, message.MemberName)
+		}
+
+		_, err = models.FindActiveUserByEmail(r.Organization.ID.String(), invitee.Email)
+		require.NoError(t, err)
+	})
+
+	t.Run("publishes for a restored member", func(t *testing.T) {
+		r := support.Setup(t)
+		invitee, err := models.CreateAccount("restored@example.com", "Restored")
+		require.NoError(t, err)
+		deletedUser, err := models.CreateUser(r.Organization.ID, invitee.ID, invitee.Email, invitee.Name)
+		require.NoError(t, err)
+		require.NoError(t, deletedUser.Delete())
+		inviteLink, err := models.FindInviteLinkByOrganizationID(database.DB(t.Context()), r.Organization.ID.String())
+		require.NoError(t, err)
+
+		var published []messages.OrganizationMemberJoinedMessage
+		response, err := acceptInviteLinkWithUsage(
+			context.Background(),
+			r.AuthService,
+			nil,
+			func(message messages.OrganizationMemberJoinedMessage) error {
+				published = append(published, message)
+				return nil
+			},
+			models.ListActiveHumanUsersByIDs,
+			invitee.ID.String(),
+			inviteLink.Token.String(),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "joined", response.Fields["status"].GetStringValue())
+		require.Len(t, published, 1)
+		assert.Equal(t, r.UserModel.GetEmail(), published[0].ToEmail)
+
+		_, err = models.FindActiveUserByEmail(r.Organization.ID.String(), invitee.Email)
+		require.NoError(t, err)
+	})
+
+	t.Run("does not publish for an already active member", func(t *testing.T) {
+		r := support.Setup(t)
+		inviteLink, err := models.FindInviteLinkByOrganizationID(database.DB(t.Context()), r.Organization.ID.String())
+		require.NoError(t, err)
+
+		response, err := acceptInviteLinkWithUsage(
+			context.Background(),
+			r.AuthService,
+			nil,
+			func(messages.OrganizationMemberJoinedMessage) error {
+				t.Fatal("already-active membership must not publish a notification")
+				return nil
+			},
+			func(*gorm.DB, string, []string) ([]models.User, error) {
+				t.Fatal("already-active membership must not resolve owners")
+				return nil, nil
+			},
+			r.Account.ID.String(),
+			inviteLink.Token.String(),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "already_member", response.Fields["status"].GetStringValue())
+	})
+
+	t.Run("keeps the membership when publication fails", func(t *testing.T) {
+		r := support.Setup(t)
+		invitee, err := models.CreateAccount("publisher-error@example.com", "Publisher Error")
+		require.NoError(t, err)
+		inviteLink, err := models.FindInviteLinkByOrganizationID(database.DB(t.Context()), r.Organization.ID.String())
+		require.NoError(t, err)
+
+		response, err := acceptInviteLinkWithUsage(
+			context.Background(),
+			r.AuthService,
+			nil,
+			func(messages.OrganizationMemberJoinedMessage) error {
+				return errors.New("rabbitmq unavailable")
+			},
+			models.ListActiveHumanUsersByIDs,
+			invitee.ID.String(),
+			inviteLink.Token.String(),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "joined", response.Fields["status"].GetStringValue())
+
+		_, err = models.FindActiveUserByEmail(r.Organization.ID.String(), invitee.Email)
+		require.NoError(t, err)
+	})
+
+	t.Run("keeps the membership when owner lookup fails", func(t *testing.T) {
+		r := support.Setup(t)
+		invitee, err := models.CreateAccount("owner-lookup-error@example.com", "Owner Lookup Error")
+		require.NoError(t, err)
+		inviteLink, err := models.FindInviteLinkByOrganizationID(database.DB(t.Context()), r.Organization.ID.String())
+		require.NoError(t, err)
+
+		response, err := acceptInviteLinkWithUsage(
+			context.Background(),
+			r.AuthService,
+			nil,
+			func(messages.OrganizationMemberJoinedMessage) error {
+				t.Fatal("owner lookup failure must not publish a notification")
+				return nil
+			},
+			func(*gorm.DB, string, []string) ([]models.User, error) {
+				return nil, errors.New("database unavailable")
+			},
+			invitee.ID.String(),
+			inviteLink.Token.String(),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "joined", response.Fields["status"].GetStringValue())
+
+		_, err = models.FindActiveUserByEmail(r.Organization.ID.String(), invitee.Email)
+		require.NoError(t, err)
 	})
 }

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -169,6 +169,28 @@ func FindUsersByIDsInOrganization(db *gorm.DB, orgID string, ids []string) ([]Us
 	return users, err
 }
 
+// ListActiveHumanUsersByIDs returns active human users in an organization with usable email addresses.
+func ListActiveHumanUsersByIDs(db *gorm.DB, organizationID string, userIDs []string) ([]User, error) {
+	if len(userIDs) == 0 {
+		return []User{}, nil
+	}
+
+	var users []User
+	err := db.
+		Where("organization_id = ?", organizationID).
+		Where("id IN ?", userIDs).
+		Where("type = ?", UserTypeHuman).
+		Where("email IS NOT NULL AND TRIM(email) <> ''").
+		Order("id").
+		Find(&users).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return users, nil
+}
+
 func FindUnscopedUserByID(id string) (*User, error) {
 	var user User
 	userUUID, err := uuid.Parse(id)

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 )
@@ -25,4 +26,42 @@ func TestFindFirstHumanUserByOrganizationSkipsDeletedUsers(t *testing.T) {
 	user, err := models.FindFirstHumanUserByOrganization(r.Organization.ID.String())
 	require.NoError(t, err)
 	assert.Equal(t, secondUser.ID, user.ID)
+}
+
+func TestListActiveHumanUsersByIDs(t *testing.T) {
+	r := support.Setup(t)
+
+	eligibleAccount, err := models.CreateAccount("eligible@example.com", "Eligible")
+	require.NoError(t, err)
+	eligibleUser, err := models.CreateUser(r.Organization.ID, eligibleAccount.ID, eligibleAccount.Email, eligibleAccount.Name)
+	require.NoError(t, err)
+
+	deletedAccount, err := models.CreateAccount("deleted@example.com", "Deleted")
+	require.NoError(t, err)
+	deletedUser, err := models.CreateUser(r.Organization.ID, deletedAccount.ID, deletedAccount.Email, deletedAccount.Name)
+	require.NoError(t, err)
+	require.NoError(t, deletedUser.Delete())
+
+	apiKey, err := models.CreateAPIKey(database.DB(t.Context()), r.Organization.ID, "Bot", nil, r.UserModel.ID, nil, nil)
+	require.NoError(t, err)
+
+	blankEmail := "   "
+	blankEmailUser := &models.User{
+		OrganizationID: r.Organization.ID,
+		Email:          &blankEmail,
+		Name:           "Blank Email",
+		Type:           models.UserTypeHuman,
+	}
+	require.NoError(t, database.DB(t.Context()).Create(blankEmailUser).Error)
+
+	users, err := models.ListActiveHumanUsersByIDs(database.DB(t.Context()), r.Organization.ID.String(), []string{
+		r.UserModel.ID.String(), eligibleUser.ID.String(), deletedUser.ID.String(), apiKey.ID.String(), blankEmailUser.ID.String(),
+	})
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	assert.ElementsMatch(t, []string{r.UserModel.ID.String(), eligibleUser.ID.String()}, []string{users[0].ID.String(), users[1].ID.String()})
+
+	users, err = models.ListActiveHumanUsersByIDs(database.DB(t.Context()), r.Organization.ID.String(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, users)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -335,6 +335,9 @@ func startEmailConsumersWithService(rabbitMQURL string, emailService services.Em
 	log.Println("Starting Magic Code Email Consumer")
 	magicCodeEmailConsumer := workers.NewMagicCodeEmailConsumer(rabbitMQURL, emailService, baseURL)
 	go magicCodeEmailConsumer.Start()
+	log.Println("Starting Organization Member Joined Email Consumer")
+	organizationMemberJoinedEmailConsumer := workers.NewOrganizationMemberJoinedEmailConsumer(rabbitMQURL, emailService, baseURL)
+	go organizationMemberJoinedEmailConsumer.Start()
 }
 
 func buildGRPCServices(

--- a/pkg/services/email.go
+++ b/pkg/services/email.go
@@ -14,11 +14,39 @@ import (
 
 type EmailService interface {
 	SendMagicCodeEmail(toEmail, code, magicLink string) error
+	SendOrganizationMemberJoinedEmail(toEmail, memberName, memberEmail, organizationName, settingsURL string) error
 }
 
 type MagicCodeTemplateData struct {
 	Code      string
 	MagicLink string
+}
+
+type OrganizationMemberJoinedTemplateData struct {
+	MemberName       string
+	MemberEmail      string
+	OrganizationName string
+	SettingsURL      string
+}
+
+func organizationMemberJoinedEmailContent(templateDir, memberName, memberEmail, organizationName, settingsURL string) (string, string, string, error) {
+	memberName = strings.TrimSpace(memberName)
+	if memberName == "" {
+		memberName = memberEmail
+	}
+
+	data := OrganizationMemberJoinedTemplateData{
+		MemberName: memberName, MemberEmail: memberEmail, OrganizationName: organizationName, SettingsURL: settingsURL,
+	}
+	textBody, err := renderEmailTemplate(templateDir, "organization_member_joined.txt", data)
+	if err != nil {
+		return "", "", "", fmt.Errorf("render member joined text template: %w", err)
+	}
+	htmlBody, err := renderEmailTemplate(templateDir, "organization_member_joined.html", data)
+	if err != nil {
+		return "", "", "", fmt.Errorf("render member joined HTML template: %w", err)
+	}
+	return fmt.Sprintf("%s joined %s on SuperPlane", memberName, organizationName), textBody, htmlBody, nil
 }
 
 type ResendEmailService struct {
@@ -70,6 +98,15 @@ func (s *ResendEmailService) SendMagicCodeEmail(toEmail, code, magicLink string)
 
 	log.Infof("Magic code email sent successfully to %s (ID: %s)", toEmail, response.Id)
 	return nil
+}
+
+func (s *ResendEmailService) SendOrganizationMemberJoinedEmail(toEmail, memberName, memberEmail, organizationName, settingsURL string) error {
+	subject, textBody, htmlBody, err := organizationMemberJoinedEmailContent(s.templateDir, memberName, memberEmail, organizationName, settingsURL)
+	if err != nil {
+		return err
+	}
+	_, err = s.client.Emails.Send(&resend.SendEmailRequest{From: fmt.Sprintf("%s <%s>", s.fromName, s.fromEmail), To: []string{toEmail}, Subject: subject, Text: textBody, Html: htmlBody})
+	return err
 }
 
 func (s *ResendEmailService) renderTemplate(templateName string, data any) (string, error) {

--- a/pkg/services/noop_email.go
+++ b/pkg/services/noop_email.go
@@ -8,15 +8,46 @@ type SentMagicCodeEmail struct {
 	MagicLink string
 }
 
+type SentOrganizationMemberJoinedEmail struct {
+	ToEmail          string
+	MemberName       string
+	MemberEmail      string
+	OrganizationName string
+	SettingsURL      string
+}
+
 type NoopEmailService struct {
-	mu              sync.Mutex
-	magicCodeEmails []SentMagicCodeEmail
+	mu                             sync.Mutex
+	magicCodeEmails                []SentMagicCodeEmail
+	organizationMemberJoinedEmails []SentOrganizationMemberJoinedEmail
 }
 
 func NewNoopEmailService() *NoopEmailService {
 	return &NoopEmailService{
-		magicCodeEmails: []SentMagicCodeEmail{},
+		magicCodeEmails:                []SentMagicCodeEmail{},
+		organizationMemberJoinedEmails: []SentOrganizationMemberJoinedEmail{},
 	}
+}
+
+func (s *NoopEmailService) SendOrganizationMemberJoinedEmail(toEmail, memberName, memberEmail, organizationName, settingsURL string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.organizationMemberJoinedEmails = append(s.organizationMemberJoinedEmails, SentOrganizationMemberJoinedEmail{
+		ToEmail:          toEmail,
+		MemberName:       memberName,
+		MemberEmail:      memberEmail,
+		OrganizationName: organizationName,
+		SettingsURL:      settingsURL,
+	})
+	return nil
+}
+
+func (s *NoopEmailService) SentOrganizationMemberJoinedEmails() []SentOrganizationMemberJoinedEmail {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	emails := make([]SentOrganizationMemberJoinedEmail, len(s.organizationMemberJoinedEmails))
+	copy(emails, s.organizationMemberJoinedEmails)
+	return emails
 }
 
 func (s *NoopEmailService) SendMagicCodeEmail(toEmail, code, magicLink string) error {
@@ -45,4 +76,5 @@ func (s *NoopEmailService) Reset() {
 	defer s.mu.Unlock()
 
 	s.magicCodeEmails = []SentMagicCodeEmail{}
+	s.organizationMemberJoinedEmails = []SentOrganizationMemberJoinedEmail{}
 }

--- a/pkg/services/smtp_email.go
+++ b/pkg/services/smtp_email.go
@@ -158,6 +158,18 @@ func (s *SMTPEmailService) SendMagicCodeEmail(toEmail, code, magicLink string) e
 	return s.sendEmail(settings, []string{toEmail}, nil, subject, plainTextContent, htmlContent)
 }
 
+func (s *SMTPEmailService) SendOrganizationMemberJoinedEmail(toEmail, memberName, memberEmail, organizationName, settingsURL string) error {
+	settings, err := s.settingsProvider.GetSMTPSettings(context.Background())
+	if err != nil {
+		return err
+	}
+	subject, textBody, htmlBody, err := organizationMemberJoinedEmailContent(s.templateDir, memberName, memberEmail, organizationName, settingsURL)
+	if err != nil {
+		return err
+	}
+	return s.sendEmail(settings, []string{toEmail}, nil, subject, textBody, htmlBody)
+}
+
 func (s *SMTPEmailService) renderTemplate(templateName string, data any) (string, error) {
 	return renderEmailTemplate(s.templateDir, templateName, data)
 }

--- a/pkg/services/smtp_email_test.go
+++ b/pkg/services/smtp_email_test.go
@@ -193,6 +193,66 @@ func TestSMTPEmailService_SendMagicCodeEmail(t *testing.T) {
 	assert.True(t, strings.Contains(message, "<p>Code 123456</p>"))
 }
 
+func TestSMTPEmailService_SendOrganizationMemberJoinedEmail(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeOrganizationMemberJoinedTemplates(t, tmpDir)
+
+	service := NewSMTPEmailService(&fakeSettingsProvider{settings: &SMTPSettings{
+		Host:      "superplane-mailpit",
+		Port:      1025,
+		FromName:  "SuperPlane",
+		FromEmail: "notifications@superplane.local",
+	}}, tmpDir)
+
+	fakeClient := &fakeSMTPClient{extensions: map[string]bool{}}
+	originalDial := smtpDial
+	smtpDial = func(addr string) (smtpClient, error) {
+		assert.Equal(t, "superplane-mailpit:1025", addr)
+		return fakeClient, nil
+	}
+	t.Cleanup(func() {
+		smtpDial = originalDial
+	})
+
+	err := service.SendOrganizationMemberJoinedEmail(
+		"owner@example.com",
+		"",
+		"alex@example.com",
+		"Example Organization",
+		"https://app.superplane.test/org-1/settings/members",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "notifications@superplane.local", fakeClient.mailFrom)
+	assert.Equal(t, []string{"owner@example.com"}, fakeClient.rcpt)
+	assert.False(t, fakeClient.startedTLS)
+	assert.False(t, fakeClient.authCalled)
+	message := fakeClient.message.String()
+	assert.Contains(t, message, "Subject: alex@example.com joined Example Organization on SuperPlane")
+	assert.Contains(t, message, "alex@example.com (alex@example.com) joined Example Organization")
+	assert.Contains(t, message, "https://app.superplane.test/org-1/settings/members")
+}
+
+func TestOrganizationMemberJoinedEmailContentEscapesHTML(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeOrganizationMemberJoinedTemplates(t, tmpDir)
+
+	subject, textBody, htmlBody, err := organizationMemberJoinedEmailContent(
+		tmpDir,
+		"<Alex & Sam>",
+		"alex@example.com",
+		"Demo <Production>",
+		"https://app.superplane.test/org-1/settings/members?tab=all&sort=name",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "<Alex & Sam> joined Demo <Production> on SuperPlane", subject)
+	assert.Contains(t, textBody, "<Alex & Sam> (alex@example.com) joined Demo <Production>")
+	assert.Contains(t, htmlBody, "&lt;Alex &amp; Sam&gt;")
+	assert.Contains(t, htmlBody, "Demo &lt;Production&gt;")
+	assert.Contains(t, htmlBody, "tab=all&amp;sort=name")
+}
+
 func TestRenderEmailTemplate(t *testing.T) {
 	tmpDir := t.TempDir()
 	templateDir := filepath.Join(tmpDir, "email")
@@ -258,4 +318,13 @@ func writeMagicCodeTemplates(t *testing.T, root string) {
 	require.NoError(t, os.MkdirAll(templateDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "magic_code.txt"), []byte("Code {{.Code}}\n{{.MagicLink}}"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "magic_code.html"), []byte("<p>Code {{.Code}}</p><a href=\"{{.MagicLink}}\">Open</a>"), 0o644))
+}
+
+func writeOrganizationMemberJoinedTemplates(t *testing.T, root string) {
+	t.Helper()
+
+	templateDir := filepath.Join(root, "email")
+	require.NoError(t, os.MkdirAll(templateDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "organization_member_joined.txt"), []byte("{{.MemberName}} ({{.MemberEmail}}) joined {{.OrganizationName}}\n{{.SettingsURL}}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "organization_member_joined.html"), []byte("<p>{{.MemberName}} ({{.MemberEmail}}) joined {{.OrganizationName}}</p><a href=\"{{.SettingsURL}}\">Manage</a>"), 0o644))
 }

--- a/pkg/workers/email_worker_metrics.go
+++ b/pkg/workers/email_worker_metrics.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	emailTypeMagicCode = "magic_code"
+	emailTypeMagicCode                = "magic_code"
+	emailTypeOrganizationMemberJoined = "organization_member_joined"
 
 	emailWorkerReasonInvalidMessage = "invalid_message"
 	emailWorkerReasonSendError      = "send_error"

--- a/pkg/workers/magic_code_email_consumer_test.go
+++ b/pkg/workers/magic_code_email_consumer_test.go
@@ -80,3 +80,7 @@ func (s *failingEmailService) SendInvitationEmail(_, _, _, _ string) error {
 func (s *failingEmailService) SendMagicCodeEmail(_, _, _ string) error {
 	return s.err
 }
+
+func (s *failingEmailService) SendOrganizationMemberJoinedEmail(_, _, _, _, _ string) error {
+	return s.err
+}

--- a/pkg/workers/organization_member_joined_email_consumer.go
+++ b/pkg/workers/organization_member_joined_email_consumer.go
@@ -1,0 +1,97 @@
+package workers
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/renderedtext/go-tackle"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/logging"
+	"github.com/superplanehq/superplane/pkg/services"
+)
+
+const OrganizationMemberJoinedEmailServiceName = "superplane." + messages.CanvasExchange + "." + messages.OrganizationMemberJoinedRoutingKey + ".worker-consumer"
+
+type OrganizationMemberJoinedEmailConsumer struct {
+	Consumer     *tackle.Consumer
+	RabbitMQURL  string
+	EmailService services.EmailService
+	BaseURL      string
+}
+
+func NewOrganizationMemberJoinedEmailConsumer(rabbitMQURL string, emailService services.EmailService, baseURL string) *OrganizationMemberJoinedEmailConsumer {
+	logger := logging.NewTackleLogger(log.StandardLogger().WithFields(log.Fields{
+		"consumer": "organization_member_joined_email",
+	}))
+
+	consumer := tackle.NewConsumer()
+	consumer.SetLogger(logger)
+	return &OrganizationMemberJoinedEmailConsumer{
+		Consumer:     consumer,
+		RabbitMQURL:  rabbitMQURL,
+		EmailService: emailService,
+		BaseURL:      baseURL,
+	}
+}
+
+func (c *OrganizationMemberJoinedEmailConsumer) Start() {
+	options := tackle.Options{
+		URL:            c.RabbitMQURL,
+		ConnectionName: MagicCodeEmailConnectionName,
+		Service:        OrganizationMemberJoinedEmailServiceName,
+		RemoteExchange: messages.CanvasExchange,
+		RoutingKey:     messages.OrganizationMemberJoinedRoutingKey,
+	}
+
+	for {
+		log.Infof("Connecting to RabbitMQ queue for %s events", messages.OrganizationMemberJoinedRoutingKey)
+
+		err := c.Consumer.Start(&options, c.Consume)
+		if err != nil {
+			log.WithError(err).Errorf("Error consuming messages from %s", messages.OrganizationMemberJoinedRoutingKey)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		log.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.OrganizationMemberJoinedRoutingKey)
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (c *OrganizationMemberJoinedEmailConsumer) Stop() { c.Consumer.Stop() }
+
+func (c *OrganizationMemberJoinedEmailConsumer) Consume(delivery tackle.Delivery) error {
+	start := time.Now()
+	outcome, reason := executorOutcomeSuccess, executorReasonNone
+	defer func() { recordEmailWorkerProcessing(start, emailTypeOrganizationMemberJoined, outcome, reason) }()
+
+	var data messages.OrganizationMemberJoinedMessage
+	if err := json.Unmarshal(delivery.Body(), &data); err != nil {
+		log.WithError(err).Warn("Discarding malformed organization member joined email message")
+		outcome, reason = executorOutcomeSkipped, emailWorkerReasonInvalidMessage
+		return nil
+	}
+	data.ToEmail, data.OrganizationID, data.OrganizationName, data.MemberEmail = strings.TrimSpace(data.ToEmail), strings.TrimSpace(data.OrganizationID), strings.TrimSpace(data.OrganizationName), strings.TrimSpace(data.MemberEmail)
+	if data.ToEmail == "" || data.OrganizationID == "" || data.OrganizationName == "" || data.MemberEmail == "" {
+		log.WithField("organization_id", data.OrganizationID).Warn("Discarding incomplete organization member joined email message")
+		outcome, reason = executorOutcomeSkipped, emailWorkerReasonInvalidMessage
+		return nil
+	}
+	settingsURL, err := url.JoinPath(c.BaseURL, data.OrganizationID, "settings", "members")
+	if err != nil {
+		log.WithError(err).WithField("organization_id", data.OrganizationID).Error("Failed to build organization member settings URL")
+		outcome, reason = executorOutcomeFailed, emailWorkerReasonSendError
+		return err
+	}
+	if err := c.EmailService.SendOrganizationMemberJoinedEmail(data.ToEmail, strings.TrimSpace(data.MemberName), data.MemberEmail, data.OrganizationName, settingsURL); err != nil {
+		log.WithError(err).WithField("organization_id", data.OrganizationID).Error("Failed to send organization member joined email")
+		outcome, reason = executorOutcomeFailed, emailWorkerReasonSendError
+		return err
+	}
+
+	log.WithField("organization_id", data.OrganizationID).Info("Sent organization member joined email")
+	return nil
+}

--- a/pkg/workers/organization_member_joined_email_consumer_test.go
+++ b/pkg/workers/organization_member_joined_email_consumer_test.go
@@ -1,0 +1,119 @@
+package workers
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/renderedtext/go-tackle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/services"
+)
+
+func TestOrganizationMemberJoinedEmailConsumer(t *testing.T) {
+	consumer := NewOrganizationMemberJoinedEmailConsumer("amqp://localhost:5672", services.NewNoopEmailService(), "https://app.superplane.test/")
+
+	t.Run("sends the owner a member management link", func(t *testing.T) {
+		emailService := services.NewNoopEmailService()
+		consumer.EmailService = emailService
+
+		require.NoError(t, consumer.Consume(tackle.NewFakeDelivery(memberJoinedPayload(t, messages.OrganizationMemberJoinedMessage{
+			ToEmail: "owner@example.com", OrganizationID: "org-1", OrganizationName: "Example Organization", MemberEmail: "alex@example.com", MemberName: "Alex",
+		}))))
+
+		emails := emailService.SentOrganizationMemberJoinedEmails()
+		require.Len(t, emails, 1)
+		assert.Equal(t, "owner@example.com", emails[0].ToEmail)
+		assert.Equal(t, "https://app.superplane.test/org-1/settings/members", emails[0].SettingsURL)
+	})
+
+	t.Run("uses the member email when the member name is blank", func(t *testing.T) {
+		emailService := services.NewNoopEmailService()
+		consumer.EmailService = emailService
+
+		require.NoError(t, consumer.Consume(tackle.NewFakeDelivery(memberJoinedPayload(t, messages.OrganizationMemberJoinedMessage{
+			ToEmail:          "owner@example.com",
+			OrganizationID:   "org-1",
+			OrganizationName: "Example Organization",
+			MemberEmail:      "alex@example.com",
+			MemberName:       "   ",
+		}))))
+
+		emails := emailService.SentOrganizationMemberJoinedEmails()
+		require.Len(t, emails, 1)
+		assert.Equal(t, "", emails[0].MemberName)
+		assert.Equal(t, "alex@example.com", emails[0].MemberEmail)
+	})
+
+	t.Run("discards malformed messages", func(t *testing.T) {
+		emailService := services.NewNoopEmailService()
+		consumer.EmailService = emailService
+
+		require.NoError(t, consumer.Consume(tackle.NewFakeDelivery([]byte("{"))))
+		assert.Empty(t, emailService.SentOrganizationMemberJoinedEmails())
+	})
+
+	t.Run("discards incomplete messages", func(t *testing.T) {
+		emailService := services.NewNoopEmailService()
+		consumer.EmailService = emailService
+		require.NoError(t, consumer.Consume(tackle.NewFakeDelivery(memberJoinedPayload(t, messages.OrganizationMemberJoinedMessage{
+			ToEmail:          "   ",
+			OrganizationID:   "org-1",
+			OrganizationName: "Example Organization",
+			MemberEmail:      "alex@example.com",
+		}))))
+		assert.Empty(t, emailService.SentOrganizationMemberJoinedEmails())
+	})
+
+	t.Run("returns email delivery errors for retry", func(t *testing.T) {
+		consumer.EmailService = &failingMemberJoinedEmailService{err: errors.New("smtp unavailable")}
+		err := consumer.Consume(tackle.NewFakeDelivery(memberJoinedPayload(t, messages.OrganizationMemberJoinedMessage{
+			ToEmail: "owner@example.com", OrganizationID: "org-1", OrganizationName: "Example Organization", MemberEmail: "alex@example.com",
+		})))
+		require.ErrorContains(t, err, "smtp unavailable")
+	})
+}
+
+func TestOrganizationMemberJoinedEmailPipeline(t *testing.T) {
+	rabbitMQURL := "amqp://guest:guest@rabbitmq:5672/superplane_test"
+	t.Setenv("RABBITMQ_URL", rabbitMQURL)
+
+	emailService := services.NewNoopEmailService()
+	consumer := NewOrganizationMemberJoinedEmailConsumer(rabbitMQURL, emailService, "https://app.superplane.test")
+	go consumer.Start()
+	t.Cleanup(consumer.Stop)
+
+	require.Eventually(t, func() bool {
+		return consumer.Consumer.State == tackle.StateListening
+	}, 10*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, (messages.OrganizationMemberJoinedMessage{
+		ToEmail:          "owner@example.com",
+		OrganizationID:   "org-1",
+		OrganizationName: "Example Organization",
+		MemberEmail:      "alex@example.com",
+		MemberName:       "Alex",
+	}).Publish())
+
+	require.Eventually(t, func() bool {
+		return len(emailService.SentOrganizationMemberJoinedEmails()) == 1
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+func memberJoinedPayload(t *testing.T, message messages.OrganizationMemberJoinedMessage) []byte {
+	t.Helper()
+	payload, err := json.Marshal(message)
+	require.NoError(t, err)
+	return payload
+}
+
+type failingMemberJoinedEmailService struct{ err error }
+
+func (s *failingMemberJoinedEmailService) SendMagicCodeEmail(_, _, _ string) error { return s.err }
+
+func (s *failingMemberJoinedEmailService) SendOrganizationMemberJoinedEmail(_, _, _, _, _ string) error {
+	return s.err
+}

--- a/templates/email/organization_member_joined.html
+++ b/templates/email/organization_member_joined.html
@@ -1,0 +1,2 @@
+<p><strong>{{.MemberName}}</strong> ({{.MemberEmail}}) joined <strong>{{.OrganizationName}}</strong> on SuperPlane.</p>
+<p><a href="{{.SettingsURL}}">Manage organization members</a></p>

--- a/templates/email/organization_member_joined.txt
+++ b/templates/email/organization_member_joined.txt
@@ -1,0 +1,3 @@
+{{.MemberName}} ({{.MemberEmail}}) joined {{.OrganizationName}} on SuperPlane.
+
+Manage organization members: {{.SettingsURL}}

--- a/test/e2e/organization_member_joined_email_mailpit_test.go
+++ b/test/e2e/organization_member_joined_email_mailpit_test.go
@@ -1,0 +1,305 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	organizations "github.com/superplanehq/superplane/pkg/grpc/actions/organizations"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/workers"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gorm.io/gorm"
+)
+
+const (
+	mailpitURL                   = "http://superplane-mailpit:8025"
+	rabbitMQManagementURL        = "http://rabbitmq:15672"
+	organizationMemberQueueVHost = "superplane_test"
+)
+
+// TestOrganizationMemberJoinedEmailMailpit exercises the complete notification
+// path without mocks: accepting an invite publishes to RabbitMQ, the running
+// email consumer sends via SMTP, and Mailpit exposes the delivered message.
+func TestOrganizationMemberJoinedEmailMailpit(t *testing.T) {
+	mailpit := newMailpitClient(mailpitURL)
+	purgeOrganizationMemberJoinedQueues(t)
+	mailpit.Clear(t)
+	t.Cleanup(func() {
+		purgeOrganizationMemberJoinedQueues(t)
+		mailpit.Clear(t)
+		require.NoError(t, models.DeleteEmailSettings(models.EmailProviderSMTP))
+	})
+
+	r := support.Setup(t)
+	ownerEmail := setOwnerEmail(t, r)
+	configureTestSMTP(t, "superplane-mailpit", 1025)
+
+	invite := inviteLinkForOrganization(t, r.Organization.ID.String())
+	member := createInvitationAccount(t, "member")
+	response := acceptInvite(t, r, member, invite.Token.String())
+	require.Equal(t, "joined", response.Fields["status"].GetStringValue())
+
+	settingsURL := fmt.Sprintf("%s/%s/settings/members", ctx.baseURL, r.Organization.ID)
+	first := mailpit.WaitForMemberJoinedCount(t, ownerEmail, member.Email, 1, 15*time.Second)
+	assertMemberJoinedEmail(t, mailpit, first, ownerEmail, member, r.Organization.Name, settingsURL)
+
+	response = acceptInvite(t, r, member, invite.Token.String())
+	require.Equal(t, "already_member", response.Fields["status"].GetStringValue())
+	mailpit.AssertMemberJoinedCountRemains(t, ownerEmail, member.Email, 1, 2*time.Second)
+
+	memberUser, err := models.FindActiveUserByEmail(r.Organization.ID.String(), member.Email)
+	require.NoError(t, err)
+	_, err = organizations.RemoveUser(context.Background(), r.AuthService, r.Organization.ID.String(), memberUser.ID.String())
+	require.NoError(t, err)
+
+	response = acceptInvite(t, r, member, invite.Token.String())
+	require.Equal(t, "joined", response.Fields["status"].GetStringValue())
+	second := mailpit.WaitForMemberJoinedCount(t, ownerEmail, member.Email, 2, 15*time.Second)
+	assertMemberJoinedEmail(t, mailpit, second, ownerEmail, member, r.Organization.Name, settingsURL)
+
+	// A refused SMTP connection must not make invite acceptance fail. Restore the
+	// Mailpit configuration afterwards so the delayed RabbitMQ retry drains.
+	configureTestSMTP(t, "127.0.0.1", 1)
+	failedDeliveryMember := createInvitationAccount(t, "delivery-failure")
+	response = acceptInvite(t, r, failedDeliveryMember, invite.Token.String())
+	require.Equal(t, "joined", response.Fields["status"].GetStringValue())
+	_, err = models.FindActiveUserByEmail(r.Organization.ID.String(), failedDeliveryMember.Email)
+	require.NoError(t, err)
+	mailpit.AssertMemberJoinedCountRemains(t, ownerEmail, failedDeliveryMember.Email, 0, time.Second)
+
+	configureTestSMTP(t, "superplane-mailpit", 1025)
+	third := mailpit.WaitForMemberJoinedCount(t, ownerEmail, failedDeliveryMember.Email, 1, 20*time.Second)
+	assertMemberJoinedEmail(t, mailpit, third, ownerEmail, failedDeliveryMember, r.Organization.Name, settingsURL)
+}
+
+func acceptInvite(t *testing.T, r *support.ResourceRegistry, account *models.Account, token string) *structpb.Struct {
+	t.Helper()
+	response, err := organizations.AcceptInviteLinkWithUsage(t.Context(), r.AuthService, nil, account.ID.String(), token)
+	require.NoError(t, err)
+	return response
+}
+
+func configureTestSMTP(t *testing.T, host string, port int) {
+	t.Helper()
+	require.NoError(t, models.UpsertEmailSettings(&models.EmailSettings{
+		Provider:      models.EmailProviderSMTP,
+		SMTPHost:      host,
+		SMTPPort:      port,
+		SMTPFromName:  "SuperPlane",
+		SMTPFromEmail: "notifications@superplane.local",
+		SMTPUseTLS:    false,
+	}))
+}
+
+func setOwnerEmail(t *testing.T, r *support.ResourceRegistry) string {
+	t.Helper()
+	email := support.RandomName("owner") + "@superplane.local"
+	tx := database.DB(t.Context())
+	require.NoError(t, tx.Model(r.Account).Update("email", email).Error)
+	require.NoError(t, tx.Model(r.UserModel).Update("email", email).Error)
+	r.Account.Email = email
+	return email
+}
+
+func inviteLinkForOrganization(t *testing.T, organizationID string) *models.OrganizationInviteLink {
+	t.Helper()
+	invite, err := models.FindInviteLinkByOrganizationID(database.DB(t.Context()), organizationID)
+	if err == nil {
+		return invite
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		require.NoError(t, err)
+	}
+
+	invite, err = models.CreateInviteLink(database.DB(t.Context()), mustUUID(t, organizationID))
+	require.NoError(t, err)
+	return invite
+}
+
+func createInvitationAccount(t *testing.T, prefix string) *models.Account {
+	t.Helper()
+	name := support.RandomName(prefix)
+	account, err := models.CreateAccount(name, name+"@superplane.local")
+	require.NoError(t, err)
+	return account
+}
+
+func mustUUID(t *testing.T, value string) uuid.UUID {
+	t.Helper()
+	id, err := uuid.Parse(value)
+	require.NoError(t, err)
+	return id
+}
+
+type mailpitClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+type mailpitMailbox struct {
+	Messages []mailpitMessage `json:"messages"`
+}
+
+type mailpitMessage struct {
+	ID      string           `json:"ID"`
+	From    mailpitAddress   `json:"From"`
+	To      []mailpitAddress `json:"To"`
+	Subject string           `json:"Subject"`
+	Text    string           `json:"Text"`
+	HTML    string           `json:"HTML"`
+}
+
+type mailpitAddress struct {
+	Address string `json:"Address"`
+}
+
+func newMailpitClient(baseURL string) *mailpitClient {
+	return &mailpitClient{baseURL: baseURL, client: &http.Client{Timeout: 5 * time.Second}}
+}
+
+func (c *mailpitClient) Clear(t *testing.T) {
+	t.Helper()
+	mailbox := c.Messages(t)
+	if len(mailbox) == 0 {
+		return
+	}
+
+	ids := make([]string, 0, len(mailbox))
+	for _, message := range mailbox {
+		ids = append(ids, message.ID)
+	}
+	payload, err := json.Marshal(map[string][]string{"IDs": ids})
+	require.NoError(t, err)
+	response := c.do(t, http.MethodDelete, "/api/v1/messages", bytes.NewReader(payload), http.StatusOK)
+	response.Body.Close()
+}
+
+func (c *mailpitClient) WaitForMemberJoinedCount(t *testing.T, ownerEmail, memberEmail string, want int, timeout time.Duration) []mailpitMessage {
+	t.Helper()
+	var messages []mailpitMessage
+	require.Eventually(t, func() bool {
+		messages = c.MemberJoinedMessages(t, ownerEmail, memberEmail)
+		return len(messages) == want
+	}, timeout, 100*time.Millisecond)
+	return messages
+}
+
+func (c *mailpitClient) AssertMemberJoinedCountRemains(t *testing.T, ownerEmail, memberEmail string, want int, duration time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		require.Len(t, c.MemberJoinedMessages(t, ownerEmail, memberEmail), want)
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func (c *mailpitClient) MemberJoinedMessages(t *testing.T, ownerEmail, memberEmail string) []mailpitMessage {
+	t.Helper()
+	var matches []mailpitMessage
+	for _, summary := range c.Messages(t) {
+		if len(summary.To) != 1 || summary.To[0].Address != ownerEmail || !strings.Contains(strings.ToLower(summary.Subject), "joined") {
+			continue
+		}
+		message := c.Message(t, summary.ID)
+		if strings.Contains(message.Text, memberEmail) {
+			matches = append(matches, summary)
+		}
+	}
+	return matches
+}
+
+func (c *mailpitClient) Messages(t *testing.T) []mailpitMessage {
+	t.Helper()
+	response := mailpitMailbox{}
+	c.doJSON(t, http.MethodGet, "/api/v1/messages", nil, http.StatusOK, &response)
+	return response.Messages
+}
+
+func (c *mailpitClient) Message(t *testing.T, id string) mailpitMessage {
+	t.Helper()
+	response := mailpitMessage{}
+	c.doJSON(t, http.MethodGet, "/api/v1/message/"+url.PathEscape(id), nil, http.StatusOK, &response)
+	return response
+}
+
+func (c *mailpitClient) doJSON(t *testing.T, method, path string, body io.Reader, expectedStatus int, destination any) {
+	t.Helper()
+	response := c.do(t, method, path, body, expectedStatus)
+	defer response.Body.Close()
+	require.NoError(t, json.NewDecoder(response.Body).Decode(destination))
+}
+
+func (c *mailpitClient) do(t *testing.T, method, path string, body io.Reader, expectedStatus int) *http.Response {
+	t.Helper()
+	request, err := http.NewRequestWithContext(context.Background(), method, c.baseURL+path, body)
+	require.NoError(t, err)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := c.client.Do(request)
+	require.NoError(t, err)
+	if response.StatusCode != expectedStatus {
+		defer response.Body.Close()
+		content, readErr := io.ReadAll(response.Body)
+		require.NoError(t, readErr)
+		require.Equalf(t, expectedStatus, response.StatusCode, "Mailpit %s %s response: %s", method, path, content)
+	}
+	return response
+}
+
+func assertMemberJoinedEmail(t *testing.T, mailpit *mailpitClient, summaries []mailpitMessage, ownerEmail string, member *models.Account, organizationName, settingsURL string) {
+	t.Helper()
+	var message mailpitMessage
+	found := false
+	for _, summary := range summaries {
+		candidate := mailpit.Message(t, summary.ID)
+		if strings.Contains(candidate.Text, member.Email) {
+			message = candidate
+			found = true
+			break
+		}
+	}
+	require.Truef(t, found, "Mailpit did not contain an email for member %s", member.Email)
+	require.Equal(t, "notifications@superplane.local", message.From.Address)
+	require.Len(t, message.To, 1)
+	require.Equal(t, ownerEmail, message.To[0].Address)
+	require.Contains(t, strings.ToLower(message.Subject), "joined")
+	require.Contains(t, message.Subject, organizationName)
+	require.NotEmpty(t, message.Text)
+	require.NotEmpty(t, message.HTML)
+	for _, content := range []string{message.Text, message.HTML} {
+		require.Contains(t, content, member.Name)
+		require.Contains(t, content, member.Email)
+		require.Contains(t, content, organizationName)
+		require.Contains(t, content, settingsURL)
+	}
+}
+
+func purgeOrganizationMemberJoinedQueues(t *testing.T) {
+	t.Helper()
+	queue := workers.OrganizationMemberJoinedEmailServiceName + "." + messages.OrganizationMemberJoinedRoutingKey
+	for _, name := range []string{queue, queue + ".delay.10", queue + ".dead"} {
+		endpoint := fmt.Sprintf("%s/api/queues/%s/%s/contents", rabbitMQManagementURL, organizationMemberQueueVHost, url.PathEscape(name))
+		request, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, endpoint, nil)
+		require.NoError(t, err)
+		request.SetBasicAuth("guest", "guest")
+		response, err := http.DefaultClient.Do(request)
+		require.NoError(t, err)
+		response.Body.Close()
+		require.Contains(t, []int{http.StatusNoContent, http.StatusNotFound}, response.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3910.

Sends an email to organization owners when a user joins through an invite link.

## What changed

- Publish a typed `organization-member-joined` RabbitMQ message after membership is committed.
- Notify eligible organization owners.
- Support new and restored members.
- Skip already-active members.
- Add SMTP, Resend, no-op support, templates, metrics, and tests.
- Keep membership successful even if notification delivery fails.

## Verification

Tested the full flow:

```text
Accept invite
→ owner lookup
→ RabbitMQ
→ email worker
→ SMTP
→ Mailpit
````

Passed:

* organization action tests: 101
* model tests: 92
* worker tests: 174
* service tests: 8
* Mailpit E2E test
* lint
* backend build
* `git diff --check`

Local verification used Docker Compose with PostgreSQL, RabbitMQ, SuperGit, the SuperPlane app, and Mailpit:

```bash
make dev.up

docker run -d \
  --name superplane-mailpit \
  --network superplane_default \
  -p 8025:8025 \
  axllent/mailpit
```

The E2E test verifies:

* the owner receives the email;
* member and organization details are correct;
* the Members settings link is included;
* no duplicate email is sent for an already-active member;
* restored membership sends another notification;
* SMTP failure does not roll back membership.

## Screenshots

### Member-joined email delivered through Mailpit

<img width="3072" height="1922" alt="Screenshot From 2026-07-31 22-45-42" src="https://github.com/user-attachments/assets/d819a1bf-afbd-40b0-9e76-a786a20d1fd1" />


### Invited user added as an active Viewer
<img width="3072" height="1922" alt="Screenshot From 2026-07-31 22-12-12" src="https://github.com/user-attachments/assets/35c3c45c-8eee-4121-9ea5-a90bc1e20c8f" />




