### PR TITLE
docs: add notes for On Branch Created trigger

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -88,6 +88,12 @@ Each branch event includes:
 
 This trigger automatically sets up a GitHub webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.
 
+### Notes
+
+- This trigger fires only when a new branch is created.
+- Branch deletion events are handled separately and do not trigger this event.
+- Existing branches will not trigger this event when the workflow is first configured.
+
 ### Example Data
 
 ```json


### PR DESCRIPTION
## Summary

Adds a **Notes** section to the **On Branch Created** trigger documentation to clarify its behavior.

### Changes
- Document that the trigger fires only when a new branch is created.
- Clarify that branch deletion events are not included.
- Explain that existing branches do not trigger the event when the workflow is first configured.

This makes the documentation more consistent with other trigger pages and helps set clearer expectations for users.