### PR TITLE
fix: exponential backoff with jitter for websocket reconnects

### DIFF
--- a/web_src/src/hooks/useAgentSessionWebsocket.ts
+++ b/web_src/src/hooks/useAgentSessionWebsocket.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useWebSocket } from "@/lib/reactUseWebsocket";
+import { getWebsocketReconnectInterval } from "@/lib/websocketReconnect";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { upsertAgentMessageInCache } from "./useAgentChats";
 import type { AgentMessage, AgentSessionWebsocketEvent } from "@/components/CanvasToolSidebar/types";
@@ -113,7 +114,7 @@ export function useAgentSessionWebsocket(
     {
       shouldReconnect: () => true,
       reconnectAttempts: Number.POSITIVE_INFINITY,
-      reconnectInterval: 3000,
+      reconnectInterval: getWebsocketReconnectInterval,
       heartbeat: false,
       share: false,
       onMessage,

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useWebSocket } from "@/lib/reactUseWebsocket";
+import { getWebsocketReconnectInterval } from "@/lib/websocketReconnect";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type {
   CanvasesCanvasNodeExecution,
@@ -400,7 +401,7 @@ export function useCanvasWebsocket(
       shouldReconnect: () => true,
       reconnectAttempts: Number.POSITIVE_INFINITY,
       heartbeat: false,
-      reconnectInterval: 3000,
+      reconnectInterval: getWebsocketReconnectInterval,
       onOpen: handleWebSocketOpen,
       onError: () => {},
       onClose: () => {},

--- a/web_src/src/lib/websocketReconnect.spec.ts
+++ b/web_src/src/lib/websocketReconnect.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getWebsocketReconnectInterval } from "@/lib/websocketReconnect";
+
+describe("getWebsocketReconnectInterval", () => {
+  const originalRandom = Math.random;
+
+  afterEach(() => {
+    Math.random = originalRandom;
+  });
+
+  it("reconnects the first attempt in about a second", () => {
+    Math.random = () => 0;
+    expect(getWebsocketReconnectInterval(1)).toBe(500);
+
+    Math.random = () => 1;
+    expect(getWebsocketReconnectInterval(1)).toBe(1000);
+  });
+
+  it("doubles the delay window with each attempt", () => {
+    Math.random = () => 0;
+    expect(getWebsocketReconnectInterval(1)).toBe(500);
+    expect(getWebsocketReconnectInterval(2)).toBe(1000);
+    expect(getWebsocketReconnectInterval(3)).toBe(2000);
+    expect(getWebsocketReconnectInterval(4)).toBe(4000);
+  });
+
+  it("caps the delay at 30s and never grows further on sustained outages", () => {
+    Math.random = () => 1;
+    expect(getWebsocketReconnectInterval(6)).toBe(30000);
+    expect(getWebsocketReconnectInterval(20)).toBe(30000);
+    expect(getWebsocketReconnectInterval(1000)).toBe(30000);
+  });
+
+  it("spreads simultaneous clients instead of retrying in lockstep", () => {
+    const seen = new Set<number>();
+    for (let i = 0; i < 50; i++) {
+      seen.add(getWebsocketReconnectInterval(4));
+    }
+    // With real randomness, 50 draws from a continuous range should not all
+    // collapse onto the same value the way a fixed interval would.
+    expect(seen.size).toBeGreaterThan(1);
+  });
+
+  it("never returns a delay below the guaranteed minimum for a given attempt", () => {
+    Math.random = () => 0;
+    const attempt = 5; // exponential delay = 16000ms
+    expect(getWebsocketReconnectInterval(attempt)).toBe(8000);
+  });
+});

--- a/web_src/src/lib/websocketReconnect.ts
+++ b/web_src/src/lib/websocketReconnect.ts
@@ -1,0 +1,22 @@
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30000;
+
+/**
+ * Exponential backoff with jitter for websocket reconnect attempts.
+ *
+ * Meant to be passed directly as `reconnectInterval` to react-use-websocket,
+ * which calls it with the 1-indexed attempt number and waits the returned
+ * number of milliseconds before retrying. The attempt counter resets on
+ * `onopen`, so a brief blip still reconnects in about a second while a
+ * sustained outage backs off to a 30s cap instead of retrying every 3s
+ * forever.
+ *
+ * Jitter is "equal jitter" (half fixed, half random) rather than full jitter
+ * so clients that were disconnected by the same event don't stay phase-locked
+ * and slam the backend in the same instant once it recovers, while still
+ * guaranteeing a minimum spacing between attempts at each backoff step.
+ */
+export function getWebsocketReconnectInterval(attemptNumber: number): number {
+  const exponentialDelay = Math.min(BASE_DELAY_MS * 2 ** (attemptNumber - 1), MAX_DELAY_MS);
+  return exponentialDelay / 2 + Math.random() * (exponentialDelay / 2);
+}


### PR DESCRIPTION
## What's wrong

Both `useCanvasWebsocket` and `useAgentSessionWebsocket` reconnect on a fixed 3s timer with no upper bound on attempts. While `/ws/` is unreachable (a deploy, a restart, a network partition), every open canvas and agent session retries ~20 times a minute for the entire outage. Because the interval is a constant with no jitter, clients disconnected by the same event stay phase-locked and arrive together the moment the backend comes back up — the load lands exactly when the backend is least able to absorb it.

A tab left open overnight against a down backend makes ~1200 connection attempts an hour, forever.

## What changed

Added a shared `getWebsocketReconnectInterval()` (`web_src/src/lib/websocketReconnect.ts`) used by both hooks in place of the fixed `3000`:

- Exponential backoff starting at ~1s, doubling each attempt, capped at 30s.
- Equal jitter (half fixed, half random) so clients disconnected by the same event spread out across the backoff window instead of retrying in lockstep.
- `react-use-websocket` resets its attempt counter on `onopen`, so a brief blip still reconnects in about a second — only a sustained outage backs off.

## Testing

Added `web_src/src/lib/websocketReconnect.spec.ts` covering: first-attempt timing (~1s), exponential growth per attempt, the 30s cap holding on sustained outages, and that jitter actually produces varied delays instead of a fixed value. All 5 tests pass.

Also ran the full project typecheck (`tsc -b --noEmit`) — the two modified hook files and the two new files have zero errors. (Note: a fresh clone has ~500 pre-existing, unrelated errors from a missing generated `@/api-client` module, which per the Makefile requires the backend running in Docker to generate — unrelated to this change and present before it.)

Small, standalone fix — happy to adjust the backoff curve or jitter strategy if the team prefers a different shape.

Fixes #6421