### PR TITLE
fix(ws): avoid deadlock on full-client broadcast

### DIFF
--- a/pkg/public/ws/ws_hub.go
+++ b/pkg/public/ws/ws_hub.go
@@ -111,33 +111,47 @@ func (h *Hub) unregisterClient(client *Client) {
 
 // BroadcastAll sends a message to all connected clients
 func (h *Hub) BroadcastAll(message []byte) {
-	h.mutex.RLock()
-	defer h.mutex.RUnlock()
+	var toUnregister []*Client
 
+	h.mutex.RLock()
 	for client := range h.clients {
 		select {
 		case client.send <- message:
 		default:
-			// If the client's buffer is full, assume it's gone and unregister it
-			h.unregisterClient(client)
+			// If the client's buffer is full, assume it's gone and unregister it.
+			// Do this after releasing the read lock to avoid deadlocking on the
+			// write lock taken by unregisterClient.
+			toUnregister = append(toUnregister, client)
 		}
+	}
+	h.mutex.RUnlock()
+
+	for _, client := range toUnregister {
+		h.unregisterClient(client)
 	}
 }
 
 func (h *Hub) BroadcastToWorkflow(workflowID string, message []byte) {
-	h.mutex.RLock()
-	defer h.mutex.RUnlock()
+	var toUnregister []*Client
 
+	h.mutex.RLock()
 	// Get clients subscribed to this workflow
 	if clients, ok := h.workflowSubscriptions[workflowID]; ok {
 		for client := range clients {
 			select {
 			case client.send <- message:
 			default:
-				// If the client's buffer is full, assume it's gone and unregister it
-				h.unregisterClient(client)
+				// If the client's buffer is full, assume it's gone and unregister it.
+				// Do this after releasing the read lock to avoid deadlocking on the
+				// write lock taken by unregisterClient.
+				toUnregister = append(toUnregister, client)
 			}
 		}
+	}
+	h.mutex.RUnlock()
+
+	for _, client := range toUnregister {
+		h.unregisterClient(client)
 	}
 }
 

--- a/pkg/public/ws/ws_hub_test.go
+++ b/pkg/public/ws/ws_hub_test.go
@@ -1,0 +1,35 @@
+package ws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBroadcastToWorkflowUnregistersFullClientWithoutDeadlocking(t *testing.T) {
+	hub := NewHub()
+	client := &Client{
+		hub:        hub,
+		send:       make(chan []byte, 1),
+		Done:       make(chan struct{}),
+		workflowID: "workflow",
+	}
+	client.send <- []byte("existing")
+
+	hub.registerClient(client)
+
+	done := make(chan struct{})
+	go func() {
+		hub.BroadcastToWorkflow("workflow", []byte("msg"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("broadcast blocked while unregistering a full client")
+	}
+
+	require.Equal(t, 0, hub.WorkflowSubscriberCount("workflow"))
+}


### PR DESCRIPTION
Fixes #5760

This prevents broadcast operations from deadlocking when a client's send buffer is full and the client needs to be unregistered.