### PR TITLE
fix: enforce API key canvas scope on directly-registered routes

### DIFF
--- a/pkg/authorization/scoped_token_permission.go
+++ b/pkg/authorization/scoped_token_permission.go
@@ -16,8 +16,25 @@ func hasRequiredScopedTokenPermissionForScopes(
 		return true
 	}
 
-	permissions, err := permissionsFromScopedTokenScopes(tokenScopesJSON)
-	if err != nil || len(permissions) == 0 {
+	var scopes []string
+	if err := json.Unmarshal([]byte(tokenScopesJSON), &scopes); err != nil {
+		return false
+	}
+
+	return HasScopedTokenPermission(scopes, pathParams, rule)
+}
+
+// HasScopedTokenPermission reports whether scopes allow rule's resource and
+// action on the resources named by pathParams.
+//
+// AuthorizeHTTP applies this to every route served by the gRPC gateway, reading
+// the scopes back out of the x-Token-Scopes header. Routes registered directly
+// on the router never reach that middleware, so they call this instead. Callers
+// must only reach here with a restricted credential: an empty scope list means
+// "no permissions", not "unrestricted".
+func HasScopedTokenPermission(scopes []string, pathParams map[string]string, rule AuthorizationRule) bool {
+	permissions := jwt.PermissionsFromScopes(scopes)
+	if len(permissions) == 0 {
 		return false
 	}
 

--- a/pkg/public/canvas_scope.go
+++ b/pkg/public/canvas_scope.go
@@ -1,0 +1,58 @@
+package public
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/public/middleware"
+)
+
+//
+// A credential can be restricted to a subset of the organization's canvases:
+// scoped tokens carry their own scopes, and API keys can be created with an
+// explicit canvas list. That restriction lives outside RBAC, so an
+// organization-wide permission check does not see it.
+//
+// grpcGatewayHandler publishes the restriction as x-Token-Scopes and
+// GatewayAuthorizer.AuthorizeHTTP enforces it for every route served by the
+// gRPC gateway. Routes registered directly on the router never pass through
+// either, so they enforce it here instead.
+//
+
+// tokenCanvasScopes returns the canvas restriction carried by the request's
+// credential, or nil when the credential is unrestricted. It mirrors what
+// grpcGatewayHandler writes into x-Token-Scopes.
+func tokenCanvasScopes(ctx context.Context, user *models.User) []string {
+	if claims, ok := middleware.GetScopedTokenClaimsFromContext(ctx); ok {
+		return claims.Scopes
+	}
+
+	if user.HasAPIKeyCanvasScope() {
+		return apiKeyCanvasScopes(user.APIKeyCanvasIDs)
+	}
+
+	return nil
+}
+
+// allowsCanvas reports whether the request's credential may perform action on
+// canvasID. An unrestricted credential is allowed; the caller is still
+// responsible for the RBAC permission check.
+func allowsCanvas(ctx context.Context, user *models.User, canvasID uuid.UUID, action string) bool {
+	scopes := tokenCanvasScopes(ctx, user)
+	if len(scopes) == 0 {
+		return true
+	}
+
+	return authorization.HasScopedTokenPermission(
+		scopes,
+		map[string]string{authorization.CanvasIDPathParam: canvasID.String()},
+		authorization.AuthorizationRule{
+			Resource:           "canvases",
+			Action:             action,
+			DomainType:         models.DomainTypeOrganization,
+			ResourcePathParams: []string{authorization.CanvasIDPathParam},
+		},
+	)
+}

--- a/pkg/public/canvas_scope_route_test.go
+++ b/pkg/public/canvas_scope_route_test.go
@@ -1,0 +1,137 @@
+package public
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+// Routes registered directly on the router do not pass through
+// grpcGatewayHandler or GatewayAuthorizer.AuthorizeHTTP, so the canvas
+// restriction on an API key has to be enforced by the handler itself. Without
+// it, a key restricted to one canvas can act on every canvas in the
+// organization.
+func Test__DirectlyRegisteredCanvasRoutes__EnforceAPIKeyCanvasScope(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	server, err := NewServer(
+		r.Encryptor,
+		r.Registry,
+		jwt.NewSigner("test"),
+		support.NewOIDCProvider(),
+		r.GitProvider,
+		"",
+		"http://localhost",
+		"http://localhost",
+		"test",
+		"/app/templates",
+		r.AuthService,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	registerTestGRPCGateway(
+		t, server, r.AuthService, r.Registry, r.Encryptor,
+		support.NewOIDCProvider(), r.GitProvider, nil,
+	)
+
+	scopedCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	otherCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	//
+	// An API key restricted to scopedCanvas, holding the lowest role that still
+	// grants canvases:read organization-wide.
+	//
+	plainToken, err := crypto.Base64String(64)
+	require.NoError(t, err)
+
+	apiKey, err := models.CreateAPIKey(
+		database.Conn(),
+		r.Organization.ID,
+		"scoped-key",
+		nil,
+		r.User,
+		nil,
+		[]string{scopedCanvas.ID.String()},
+	)
+	require.NoError(t, err)
+
+	apiKey.TokenHash = crypto.HashToken(plainToken)
+	require.NoError(t, database.Conn().Save(apiKey).Error)
+	require.NoError(t, r.AuthService.AssignRole(
+		apiKey.ID.String(),
+		models.RoleOrgViewer,
+		r.Organization.ID.String(),
+		models.DomainTypeOrganization,
+	))
+
+	paths := map[string]func(canvasID string) string{
+		"repository file download": func(canvasID string) string {
+			return "/api/v1/canvases/" + canvasID + "/repository/file?path=README.md"
+		},
+		"runner live log session": func(canvasID string) string {
+			return "/api/v1/canvases/" + canvasID + "/node-executions/" +
+				"00000000-0000-0000-0000-000000000001/runner-live-logs/session"
+		},
+	}
+
+	t.Run("canvas websocket handshake is rejected outside the key's scope", func(t *testing.T) {
+		server.RegisterWebRoutes("/")
+
+		httpServer := httptest.NewServer(server.Router)
+		defer httpServer.Close()
+
+		dialer := websocket.Dialer{}
+		header := http.Header{}
+		header.Set("Authorization", "Bearer "+plainToken)
+
+		conn, response, err := dialer.Dial(
+			"ws"+strings.TrimPrefix(httpServer.URL, "http")+"/ws/"+otherCanvas.ID.String(),
+			header,
+		)
+		if conn != nil {
+			conn.Close()
+		}
+
+		require.Error(t, err, "handshake must not succeed for a canvas outside the key's scope")
+		require.NotNil(t, response)
+		require.Equal(t, http.StatusNotFound, response.StatusCode)
+	})
+
+	for name, path := range paths {
+		t.Run(name+" is forbidden on a canvas outside the key's scope", func(t *testing.T) {
+			response := execRequest(server, requestParams{
+				method:    "GET",
+				path:      path(otherCanvas.ID.String()),
+				authToken: plainToken,
+			})
+
+			require.Equal(t, http.StatusForbidden, response.Code, "body: %s", response.Body.String())
+		})
+
+		t.Run(name+" passes the scope check on the key's own canvas", func(t *testing.T) {
+			response := execRequest(server, requestParams{
+				method:    "GET",
+				path:      path(scopedCanvas.ID.String()),
+				authToken: plainToken,
+			})
+
+			//
+			// The request is expected to fail further in — there is no such file
+			// and no such execution — but it must get past the scope check.
+			//
+			require.NotEqual(t, http.StatusForbidden, response.Code, "body: %s", response.Body.String())
+		})
+	}
+}

--- a/pkg/public/canvas_scope_test.go
+++ b/pkg/public/canvas_scope_test.go
@@ -1,0 +1,87 @@
+package public
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/public/middleware"
+	"gorm.io/datatypes"
+)
+
+func Test__AllowsCanvas(t *testing.T) {
+	scopedCanvas := uuid.New()
+	otherCanvas := uuid.New()
+
+	apiKeyForCanvas := func(canvasIDs ...string) *models.User {
+		return &models.User{
+			ID:              uuid.New(),
+			OrganizationID:  uuid.New(),
+			Type:            models.UserTypeAPIKey,
+			APIKeyCanvasIDs: datatypes.NewJSONSlice(canvasIDs),
+		}
+	}
+
+	t.Run("unrestricted credential is allowed on any canvas", func(t *testing.T) {
+		user := apiKeyForCanvas()
+
+		require.True(t, allowsCanvas(context.Background(), user, scopedCanvas, "read"))
+		require.True(t, allowsCanvas(context.Background(), user, otherCanvas, "read"))
+	})
+
+	t.Run("canvas-restricted API key is allowed on its own canvas", func(t *testing.T) {
+		user := apiKeyForCanvas(scopedCanvas.String())
+
+		for _, action := range []string{"read", "update", "update_version", "delete"} {
+			require.True(t,
+				allowsCanvas(context.Background(), user, scopedCanvas, action),
+				"action %q should be allowed on the scoped canvas", action,
+			)
+		}
+	})
+
+	t.Run("canvas-restricted API key is denied on another canvas", func(t *testing.T) {
+		user := apiKeyForCanvas(scopedCanvas.String())
+
+		for _, action := range []string{"read", "update", "update_version", "delete"} {
+			require.False(t,
+				allowsCanvas(context.Background(), user, otherCanvas, action),
+				"action %q should be denied on a canvas outside the key's scope", action,
+			)
+		}
+	})
+
+	t.Run("scoped token claims are enforced and take precedence", func(t *testing.T) {
+		user := apiKeyForCanvas(otherCanvas.String())
+		ctx := context.WithValue(
+			context.Background(),
+			middleware.ScopedTokenClaimsContextKey,
+			&jwt.ScopedTokenClaims{
+				Scopes: jwt.ScopesFromPermissions([]jwt.Permission{
+					{ResourceType: "canvases", Action: "read", Resources: []string{scopedCanvas.String()}},
+				}),
+			},
+		)
+
+		require.True(t, allowsCanvas(ctx, user, scopedCanvas, "read"))
+		require.False(t, allowsCanvas(ctx, user, otherCanvas, "read"))
+	})
+
+	t.Run("scoped token without a canvases permission is denied", func(t *testing.T) {
+		user := apiKeyForCanvas()
+		ctx := context.WithValue(
+			context.Background(),
+			middleware.ScopedTokenClaimsContextKey,
+			&jwt.ScopedTokenClaims{
+				Scopes: jwt.ScopesFromPermissions([]jwt.Permission{
+					{ResourceType: "secrets", Action: "read"},
+				}),
+			},
+		)
+
+		require.False(t, allowsCanvas(ctx, user, scopedCanvas, "read"))
+	})
+}

--- a/pkg/public/repository_file_download.go
+++ b/pkg/public/repository_file_download.go
@@ -54,6 +54,12 @@ func (s *Server) handleRepositoryFileDownload(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	if !allowsCanvas(ctx, user, canvasID, "read") {
+		log.Warnf("Credential for user %s is not scoped to canvas %s", user.ID.String(), canvasID.String())
+		http.Error(w, "Unauthorized", http.StatusForbidden)
+		return
+	}
+
 	path := r.URL.Query().Get("path")
 	if path == "" {
 		http.Error(w, "path is required", http.StatusBadRequest)

--- a/pkg/public/runner_live_log_session.go
+++ b/pkg/public/runner_live_log_session.go
@@ -47,6 +47,11 @@ func (s *Server) handleRunnerLiveLogSession(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if !allowsCanvas(r.Context(), user, canvasID, "read") {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	access, err := runneraction.ResolveLiveLogAccess(user.OrganizationID, canvasID, executionID)
 	if err != nil {
 		writeRunnerLiveLogSessionError(w, err)

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -1397,6 +1397,11 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !allowsCanvas(r.Context(), user, parsedWorkflowID, "read") {
+		http.Error(w, "canvas not found", http.StatusNotFound)
+		return
+	}
+
 	ws, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		if _, ok := err.(websocket.HandshakeError); !ok {


### PR DESCRIPTION
API keys can be restricted to specific canvases. I noticed that restriction isn't enforced everywhere.

It doesn't live in RBAC — it's published as `x-Token-Scopes` by `grpcGatewayHandler` and checked in `GatewayAuthorizer.AuthorizeHTTP`. That only covers routes served by the gRPC gateway.

Three canvas routes are registered directly on the router, so they never reach it:

- `GET /api/v1/canvases/{canvas_id}/repository/file`
- `GET /api/v1/canvases/{canvas_id}/node-executions/{execution_id}/runner-live-logs/session`
- `GET /ws/{workflowId}`

Each checks only the org-wide `canvases:read` permission, which every `org_viewer` holds and which can't see the canvas restriction. So a key scoped to canvas A can read canvas B's repository files, open a live log session on canvas B, and subscribe to canvas B's event stream.

The gateway sibling of the first route, `repository/files`, already sets `ResourcePathParams: []string{CanvasIDPathParam}` — which suggests the singular download route was meant to be scoped the same way.

## The fix

A small `allowsCanvas` helper derives the credential's restriction exactly the way `grpcGatewayHandler` does, then evaluates it through the existing scoped-token logic — now exported as `authorization.HasScopedTokenPermission` so both paths share one implementation rather than drifting apart.

Unrestricted credentials behave exactly as before, and the RBAC check each handler already does is untouched.

## Tests

The helper is covered directly. All three routes are also exercised with a canvas-restricted API key — the two REST routes over HTTP, and the WebSocket through a real handshake.

I checked that they fail without the fix: the REST routes return 404 from the resource lookup instead of 403, and the WebSocket handshake succeeds instead of being rejected.

`make lint`, `make check.build.app`, `gofmt -s` and the affected test packages all pass.

## Note

Happy to move this to a private channel if you'd rather handle it that way — I couldn't find a `SECURITY.md`, and since this is a scope restriction inside an org rather than a cross-tenant leak, a normal PR seemed reasonable.

A couple of related things I noticed while in here, not covered by this PR: the Telegram webhook handler doesn't verify anything (Telegram's `secret_token` is supported but unused), and Azure's webhook auth returns `nil` when reading the secret fails, where the GCP handler has a comment explaining why that should fail closed. Glad to open follow-ups if useful.
