### PR TITLE
feat: send inspected components to Agent

### DIFF
--- a/web_src/src/components/AgentSidebar/ChatComposer.tsx
+++ b/web_src/src/components/AgentSidebar/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { AgentMode } from "./agentMode";
 import { ComposerToolbar } from "./ComposerToolbar";
 import { useMentions } from "./useMentions";
@@ -11,6 +11,11 @@ import { mimeToApiImageMediaType, type AgentOutgoingImage } from "@/components/C
 import type { SuperplaneComponentsNode } from "@/api-client";
 import type { CanvasesCanvasRun } from "@/api-client";
 import { useFlushAgentComposerSend } from "./useFlushAgentComposerSend";
+import {
+  consumeAgentComposerPrefill,
+  subscribeAgentComposerPrefill,
+  type AgentComposerPrefill,
+} from "./composerPrefill";
 
 type ChatComposerProps = {
   canvasId: string;
@@ -114,7 +119,7 @@ function useComposerController({ canvasId, onSend, sendPending, nodes, runs }: C
   const backdropRef = useRef<HTMLDivElement>(null);
   const mentionKeyboardRef = useRef<((e: React.KeyboardEvent) => boolean) | null>(null);
   const mentionsApi = useMentions();
-  const { value, setValue, showDropdown, filter, setCursorPos, getMarkdown, mentions, isEmpty } = mentionsApi;
+  const { value, setValue, showDropdown, filter, setCursorPos, getMarkdown, mentions, isEmpty, prefill } = mentionsApi;
   const { images, addFiles, removeImage, clear: clearImages } = useImageAttachments();
 
   const candidates = useMentionCandidates(nodes, runs, filter, showDropdown);
@@ -185,6 +190,24 @@ function useComposerController({ canvasId, onSend, sendPending, nodes, runs }: C
   const handleToolbarSend = useStableCallback(() => {
     void handleSend();
   });
+
+  const applyPrefill = useCallback(
+    (composerPrefill: AgentComposerPrefill) => {
+      prefill(composerPrefill.text, composerPrefill.mentions);
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    },
+    [prefill, textareaRef],
+  );
+
+  useEffect(() => {
+    const flush = () => {
+      const prefill = consumeAgentComposerPrefill(canvasId);
+      if (prefill) applyPrefill(prefill);
+    };
+    flush();
+    const unsubscribe = subscribeAgentComposerPrefill(flush);
+    return unsubscribe;
+  }, [applyPrefill, canvasId]);
 
   return {
     textareaRef,

--- a/web_src/src/components/AgentSidebar/composerPrefill.spec.ts
+++ b/web_src/src/components/AgentSidebar/composerPrefill.spec.ts
@@ -1,8 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  clearAgentComposerPrefill,
   clearAgentComposerSend,
+  consumeAgentComposerPrefill,
   consumeAgentComposerSend,
   peekAgentComposerSend,
+  requestAgentComposerPrefill,
   requestAgentComposerSend,
 } from "./composerPrefill";
 
@@ -11,6 +14,8 @@ const canvasB = "canvas-b";
 
 afterEach(() => {
   clearAgentComposerSend();
+  clearAgentComposerPrefill();
+  vi.restoreAllMocks();
 });
 
 describe("composerPrefill", () => {
@@ -43,5 +48,29 @@ describe("composerPrefill", () => {
     requestAgentComposerSend(canvasA, "   ");
     requestAgentComposerSend("", "hello");
     expect(peekAgentComposerSend(canvasA)).toBeNull();
+  });
+
+  it("keeps node context as a separate prefill from the auto-send queue", () => {
+    requestAgentComposerPrefill(canvasA, {
+      text: "How can I improve @Deploy?",
+      mentions: [{ type: "node", id: "deploy", label: "Deploy" }],
+    });
+
+    expect(consumeAgentComposerPrefill(canvasA)).toEqual({
+      text: "How can I improve @Deploy?",
+      mentions: [{ type: "node", id: "deploy", label: "Deploy" }],
+    });
+    expect(peekAgentComposerSend(canvasA)).toBeNull();
+  });
+
+  it("does not inject stale node context later", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValueOnce(1_000).mockReturnValue(11_001);
+    requestAgentComposerPrefill(canvasA, {
+      text: "How can I improve @Deploy?",
+      mentions: [{ type: "node", id: "deploy", label: "Deploy" }],
+    });
+
+    expect(consumeAgentComposerPrefill(canvasA)).toBeNull();
+    now.mockRestore();
   });
 });

--- a/web_src/src/components/AgentSidebar/composerPrefill.ts
+++ b/web_src/src/components/AgentSidebar/composerPrefill.ts
@@ -1,9 +1,12 @@
+import type { MentionItem } from "./useMentions";
+
 /**
  * Window event + FIFO pending buffer so suggestions can send even if the Agent
  * composer mounts after the sidebar opens, including multiple rapid clicks.
  * Entries are canvas-scoped so SPA navigation cannot flush a prompt into the wrong chat.
  */
 export const AGENT_SEND_COMPOSER_EVENT = "agent:send-composer";
+export const AGENT_PREFILL_COMPOSER_EVENT = "agent:prefill-composer";
 
 type PendingSend = {
   canvasId: string;
@@ -11,6 +14,16 @@ type PendingSend = {
 };
 
 const pendingSends: PendingSend[] = [];
+
+export type AgentComposerPrefill = {
+  text: string;
+  mentions: MentionItem[];
+};
+
+type PendingPrefill = AgentComposerPrefill & { canvasId: string; requestedAt: number };
+
+const pendingPrefills: PendingPrefill[] = [];
+const PREFILL_TTL_MS = 10_000;
 
 export function requestAgentComposerSend(canvasId: string, text: string) {
   const trimmed = text.trim();
@@ -57,4 +70,42 @@ export function subscribeAgentComposerSend(onFlush: () => void): () => void {
 
   window.addEventListener(AGENT_SEND_COMPOSER_EVENT, listener);
   return () => window.removeEventListener(AGENT_SEND_COMPOSER_EVENT, listener);
+}
+
+export function requestAgentComposerPrefill(canvasId: string, prefill: AgentComposerPrefill) {
+  const text = prefill.text.trim();
+  if (!canvasId || !text) return;
+
+  pendingPrefills.push({ canvasId, text, mentions: prefill.mentions, requestedAt: Date.now() });
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(AGENT_PREFILL_COMPOSER_EVENT));
+}
+
+export function consumeAgentComposerPrefill(canvasId: string): AgentComposerPrefill | null {
+  if (!canvasId) return null;
+  while (true) {
+    const index = pendingPrefills.findIndex((item) => item.canvasId === canvasId);
+    if (index < 0) return null;
+    const pending = pendingPrefills.splice(index, 1)[0];
+    if (pending && Date.now() - pending.requestedAt <= PREFILL_TTL_MS) {
+      return { text: pending.text, mentions: pending.mentions };
+    }
+  }
+}
+
+export function clearAgentComposerPrefill(canvasId?: string) {
+  if (!canvasId) {
+    pendingPrefills.length = 0;
+    return;
+  }
+  for (let index = pendingPrefills.length - 1; index >= 0; index -= 1) {
+    if (pendingPrefills[index]?.canvasId === canvasId) pendingPrefills.splice(index, 1);
+  }
+}
+
+export function subscribeAgentComposerPrefill(onPrefill: () => void): () => void {
+  if (typeof window === "undefined") return () => undefined;
+
+  window.addEventListener(AGENT_PREFILL_COMPOSER_EVENT, onPrefill);
+  return () => window.removeEventListener(AGENT_PREFILL_COMPOSER_EVENT, onPrefill);
 }

--- a/web_src/src/components/AgentSidebar/useMentions.spec.ts
+++ b/web_src/src/components/AgentSidebar/useMentions.spec.ts
@@ -3,6 +3,57 @@ import { describe, expect, it } from "vitest";
 import { useMentions } from "./useMentions";
 
 describe("useMentions", () => {
+  it("prefills a tracked node mention without serializing it until send", () => {
+    const { result } = renderHook(() => useMentions());
+
+    act(() => {
+      result.current.prefill("How can I improve @Deploy?", [{ type: "node", id: "deploy", label: "Deploy" }]);
+    });
+
+    expect(result.current.value).toBe("How can I improve @Deploy?");
+    expect(result.current.getMarkdown()).toBe("How can I improve [Deploy](node:deploy)?");
+  });
+
+  it("preserves an existing draft when adding node context", () => {
+    const { result } = renderHook(() => useMentions());
+
+    act(() => {
+      result.current.setValue("Please focus on reliability.");
+    });
+    act(() => {
+      result.current.prefill("How can I improve @Deploy?", [{ type: "node", id: "deploy", label: "Deploy" }]);
+    });
+
+    expect(result.current.value).toBe("Please focus on reliability.\nHow can I improve @Deploy?");
+    expect(result.current.getMarkdown()).toBe("Please focus on reliability.\nHow can I improve [Deploy](node:deploy)?");
+  });
+
+  it("tracks repeated prefilled labels one-to-one", () => {
+    const { result } = renderHook(() => useMentions());
+
+    act(() => {
+      result.current.prefill("Compare @Deploy with @Deploy.", [
+        { type: "node", id: "deploy-a", label: "Deploy" },
+        { type: "node", id: "deploy-b", label: "Deploy" },
+      ]);
+    });
+
+    expect(result.current.getMarkdown()).toBe("Compare [Deploy](node:deploy-a) with [Deploy](node:deploy-b).");
+  });
+
+  it("does not confuse labels that are prefixes of each other", () => {
+    const { result } = renderHook(() => useMentions());
+
+    act(() => {
+      result.current.prefill("Compare @Deploy with @Deployment.", [
+        { type: "node", id: "deploy", label: "Deploy" },
+        { type: "node", id: "deployment", label: "Deployment" },
+      ]);
+    });
+
+    expect(result.current.getMarkdown()).toBe("Compare [Deploy](node:deploy) with [Deployment](node:deployment).");
+  });
+
   describe("detectTrigger (via hook)", () => {
     it("no trigger when no @ present", () => {
       const { result } = renderHook(() => useMentions());

--- a/web_src/src/components/AgentSidebar/useMentions.ts
+++ b/web_src/src/components/AgentSidebar/useMentions.ts
@@ -41,6 +41,8 @@ export interface UseMentionsReturn {
   setCursorPos: (pos: number) => void;
   /** Insert a mention at the current trigger position. Returns the new cursor position. */
   insertMention: (item: MentionItem) => number;
+  /** Add text and tracked mentions to the composer without sending. */
+  prefill: (text: string, items: MentionItem[]) => void;
   /** Get the serialized markdown output for sending */
   getMarkdown: () => string;
   /** All tracked mentions */
@@ -90,6 +92,42 @@ function pruneMentions(text: string, mentions: InsertedMention[]): InsertedMenti
     const expected = `@${m.label}`;
     return text.slice(m.startIndex, m.startIndex + expected.length) === expected;
   });
+}
+
+function findMentionOccurrence(text: string, displayText: string, fromIndex: number): number {
+  let searchIndex = fromIndex;
+  while (searchIndex < text.length) {
+    const startIndex = text.indexOf(displayText, searchIndex);
+    if (startIndex < 0) return -1;
+    const startsAtBoundary = startIndex === 0 || /\s/.test(text[startIndex - 1] ?? "");
+    const endIndex = startIndex + displayText.length;
+    const endsAtBoundary = endIndex === text.length || /[\s.,!?;:()[\]{}]/.test(text[endIndex] ?? "");
+    if (startsAtBoundary && endsAtBoundary) return startIndex;
+    searchIndex = startIndex + displayText.length;
+  }
+  return -1;
+}
+
+function appendMentionPrefill(
+  value: string,
+  mentions: InsertedMention[],
+  text: string,
+  items: MentionItem[],
+): { value: string; mentions: InsertedMention[] } {
+  const separator = value && !value.endsWith("\n") ? "\n" : "";
+  const prefillStart = value.length + separator.length;
+  const nextSearchByLabel = new Map<string, number>();
+  const trackedMentions = items.flatMap((item) => {
+    const displayText = `@${item.label}`;
+    const relativeStart = findMentionOccurrence(text, displayText, nextSearchByLabel.get(displayText) ?? 0);
+    if (relativeStart < 0) return [];
+    nextSearchByLabel.set(displayText, relativeStart + displayText.length);
+    return [{ ...item, displayText, startIndex: prefillStart + relativeStart }];
+  });
+  return {
+    value: `${value}${separator}${text}`,
+    mentions: [...pruneMentions(value, mentions), ...trackedMentions],
+  };
 }
 
 export function useMentions(): UseMentionsReturn {
@@ -163,6 +201,17 @@ export function useMentions(): UseMentionsReturn {
     [value, cursorPos, trigger.start],
   );
 
+  const prefill = useCallback(
+    (text: string, items: MentionItem[]) => {
+      const next = appendMentionPrefill(value, mentions, text, items);
+      setRawValue(next.value);
+      setCursorPos(next.value.length);
+      setMentions(next.mentions);
+      setDismissed(true);
+    },
+    [mentions, value],
+  );
+
   const getMarkdown = useCallback(() => {
     const sorted = [...mentions].sort((a, b) => b.startIndex - a.startIndex);
     let result = value;
@@ -208,6 +257,7 @@ export function useMentions(): UseMentionsReturn {
     cursorPos,
     setCursorPos: setCursorPosWrapped,
     insertMention,
+    prefill,
     getMarkdown,
     mentions,
     isEmpty,

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -1,5 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearAgentComposerPrefill,
+  consumeAgentComposerPrefill,
+  requestAgentComposerPrefill,
+} from "@/components/AgentSidebar/composerPrefill";
 import { useCanvasToolSidebarState } from "./useCanvasToolSidebarState";
 
 const featureFlags = vi.hoisted(() => ({ enabled: false }));
@@ -51,6 +56,7 @@ describe("useCanvasToolSidebarState", () => {
   beforeEach(() => {
     featureFlags.enabled = false;
     window.localStorage.clear();
+    clearAgentComposerPrefill();
   });
 
   it("invokes onBeforeClose when toggling from open to closed", () => {
@@ -66,6 +72,19 @@ describe("useCanvasToolSidebarState", () => {
 
     expect(onBeforeClose).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+  });
+
+  it("clears queued component context when the sidebar closes", () => {
+    window.localStorage.setItem("canvasAgentSidebarOpen:canvas-a", "true");
+    requestAgentComposerPrefill("canvas-a", {
+      text: "Review @Deploy",
+      mentions: [{ type: "node", id: "deploy", label: "Deploy" }],
+    });
+    render(<Harness onBeforeClose={vi.fn()} canvasId="canvas-a" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+
+    expect(consumeAgentComposerPrefill("canvas-a")).toBeNull();
   });
 
   it("toggles the tool sidebar on Cmd/Ctrl+B outside editable fields", () => {

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { persistAgentMode, readInitialAgentMode, type AgentMode } from "@/components/AgentSidebar/agentMode";
+import { clearAgentComposerPrefill } from "@/components/AgentSidebar/composerPrefill";
 import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
 import type { CanvasPageHeaderMode } from "@/pages/app/viewState";
 
@@ -98,10 +99,12 @@ export function useCanvasToolSidebarState({
     setAgentUnavailableCanvasId(undefined);
   }, [canvasId]);
 
+  useEffect(() => () => clearAgentComposerPrefill(canvasId), [canvasId]);
+
   const persistOpen = useCallback(
     (open: boolean) => {
-      if (typeof window === "undefined") return;
-      window.localStorage.setItem(canvasAgentSidebarOpenStorageKey(canvasId), open ? "true" : "false");
+      if (!open) clearAgentComposerPrefill(canvasId);
+      writeCanvasAgentSidebarOpen(canvasId ?? "", open);
     },
     [canvasId],
   );
@@ -117,12 +120,13 @@ export function useCanvasToolSidebarState({
   }, [persistOpen]);
 
   const handleToolSidebarToggle = useCallback(() => {
-    if (isToolSidebarOpen) onBeforeClose?.();
-
-    const next = !isToolSidebarOpen;
-    setIsToolSidebarOpen(next);
-    persistOpen(next);
-  }, [isToolSidebarOpen, onBeforeClose, persistOpen]);
+    if (isToolSidebarOpen) {
+      onBeforeClose?.();
+      closeToolSidebar();
+      return;
+    }
+    openToolSidebar();
+  }, [closeToolSidebar, isToolSidebarOpen, onBeforeClose, openToolSidebar]);
 
   const switchAgentMode = useCallback((mode: AgentMode) => {
     setAgentMode(mode);
@@ -133,6 +137,7 @@ export function useCanvasToolSidebarState({
   // provider isn't configured on this instance. Hiding the toggle and closing
   // the panel avoids advertising a chat that can never work (issue #5803).
   const markAgentUnavailable = useCallback(() => {
+    clearAgentComposerPrefill(canvasId);
     setAgentUnavailableCanvasId(canvasId);
   }, [canvasId]);
 
@@ -145,9 +150,10 @@ export function useCanvasToolSidebarState({
 
   useEffect(() => {
     if ((!agentEnabled && !forceEnable) || hideCanvasToolSidebar) {
+      clearAgentComposerPrefill(canvasId);
       setIsToolSidebarOpen(false);
     }
-  }, [agentEnabled, forceEnable, hideCanvasToolSidebar]);
+  }, [agentEnabled, canvasId, forceEnable, hideCanvasToolSidebar]);
 
   const showToolSidebarToggle = (agentEnabled || forceEnable) && !hideCanvasToolSidebar;
 

--- a/web_src/src/ui/CanvasPage/index.runInspection.sidebar.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.sidebar.spec.tsx
@@ -5,10 +5,20 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "@/contexts/ThemeProvider";
 
-const { fitViewMock, getNodesMock, getViewportMock, reactFlowPropsRef, setViewportMock } = vi.hoisted(() => ({
+const {
+  fitViewMock,
+  getNodesMock,
+  getViewportMock,
+  openToolSidebarMock,
+  prefillMock,
+  reactFlowPropsRef,
+  setViewportMock,
+} = vi.hoisted(() => ({
   fitViewMock: vi.fn().mockResolvedValue(true),
   getNodesMock: vi.fn<() => Array<{ id: string; position: { x: number; y: number } }>>(() => []),
   getViewportMock: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+  openToolSidebarMock: vi.fn(),
+  prefillMock: vi.fn(),
   reactFlowPropsRef: {
     current: null as null | {
       nodes?: unknown;
@@ -17,6 +27,10 @@ const { fitViewMock, getNodesMock, getViewportMock, reactFlowPropsRef, setViewpo
     },
   },
   setViewportMock: vi.fn(),
+}));
+
+vi.mock("@/components/AgentSidebar/composerPrefill", () => ({
+  requestAgentComposerPrefill: prefillMock,
 }));
 
 vi.mock("@/sentry", () => ({
@@ -78,10 +92,12 @@ vi.mock("../Runs/RunInspectorPanel", () => ({
     onClose,
     onEditNode,
     onRerunCreated,
+    onAskAgentAboutNode,
   }: {
     onClose?: () => void;
     onEditNode?: (nodeId: string) => void;
     onRerunCreated?: (eventId: string) => void;
+    onAskAgentAboutNode?: (nodeId: string, nodeName: string) => void;
   }) => (
     <div data-testid="run-inspector-panel">
       <button type="button" aria-label="Close" onClick={onClose} />
@@ -90,6 +106,9 @@ vi.mock("../Runs/RunInspectorPanel", () => ({
       </button>
       <button type="button" onClick={() => onRerunCreated?.("rerun-event-1")}>
         Rerun
+      </button>
+      <button type="button" onClick={() => onAskAgentAboutNode?.("run-node-1", "Run node")}>
+        Ask Agent
       </button>
     </div>
   ),
@@ -106,9 +125,11 @@ vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
     isEditing: false,
     readOnly: false,
     isToolSidebarOpen: false,
-    showToolSidebarToggle: false,
+    showToolSidebarToggle: true,
+    isAgentEnabled: true,
+    agentUnavailable: false,
     handleToolSidebarToggle: vi.fn(),
-    openToolSidebar: vi.fn(),
+    openToolSidebar: openToolSidebarMock,
     closeToolSidebar: vi.fn(),
   }),
 }));
@@ -148,6 +169,8 @@ describe("CanvasPage run inspection sidebar", () => {
     getViewportMock.mockReset();
     getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
     setViewportMock.mockClear();
+    openToolSidebarMock.mockClear();
+    prefillMock.mockClear();
     globalThis.ResizeObserver = class {
       observe() {}
       unobserve() {}
@@ -155,11 +178,12 @@ describe("CanvasPage run inspection sidebar", () => {
     };
   });
 
-  it("shows the right run inspector during run inspection even when the live node inspector would be open", async () => {
+  it("shows the run inspector and sends its node context to Agent", async () => {
     render(
       <MemoryRouter>
         <CanvasPage
           title="Canvas"
+          canvasId="canvas-1"
           headerMode="version-live"
           isRunInspectionMode
           initialSidebar={{ isOpen: true, nodeId: "run-node-1" }}
@@ -192,6 +216,13 @@ describe("CanvasPage run inspection sidebar", () => {
       expect(screen.getByTestId("run-inspector-panel")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("live-node-detail-pane")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Ask Agent" }));
+    expect(prefillMock).toHaveBeenCalledWith("canvas-1", {
+      text: "How can I improve @Run node?",
+      mentions: [{ type: "node", id: "run-node-1", label: "Run node" }],
+    });
+    expect(openToolSidebarMock).toHaveBeenCalledOnce();
   });
 
   it("closes only the right run inspector when the inspector close button is clicked", async () => {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -56,6 +56,7 @@ import { CanvasVersionsSidebar } from "@/components/CanvasVersionsSidebar";
 import type { CanvasVersionsSidebarState } from "@/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState";
 import { useCanvasVersionsSidebarState } from "@/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState";
 import { CanvasToolSidebar } from "@/components/CanvasToolSidebar";
+import { requestAgentComposerPrefill } from "@/components/AgentSidebar/composerPrefill";
 import {
   useCanvasToolSidebarState,
   type CanvasToolSidebarState,
@@ -859,6 +860,25 @@ function CanvasPage(props: CanvasPageProps) {
     onAgentStagingReady: props.onAgentStagingReady,
     onAgentStagingCommit: props.onAgentStagingCommit,
   });
+  const { openToolSidebar } = toolSidebarState;
+  const canAskAgent =
+    Boolean(props.canvasId) &&
+    toolSidebarState.isAgentEnabled &&
+    toolSidebarState.showToolSidebarToggle &&
+    !toolSidebarState.agentUnavailable;
+  const handleAskAgentAboutNode = useCallback(
+    (nodeId: string, nodeName?: string) => {
+      if (!canAskAgent) return;
+      const resolvedNode = props.workflowNodes?.find((node) => node.id === nodeId);
+      const label = nodeName?.trim() || resolvedNode?.name?.trim() || nodeId;
+      requestAgentComposerPrefill(props.canvasId ?? "", {
+        text: `How can I improve @${label}?`,
+        mentions: [{ type: "node", id: nodeId, label }],
+      });
+      openToolSidebar();
+    },
+    [canAskAgent, openToolSidebar, props.canvasId, props.workflowNodes],
+  );
   const runsSidebarBaseState = useCanvasRunsSidebarState(props.canvasId);
   const showRunsSidebar = allowsRunsSidebar(props.headerMode) && props.toolSidebarRunsContent != null;
   const runningRunsCount = useMemo(
@@ -1045,8 +1065,7 @@ function CanvasPage(props: CanvasPageProps) {
             configuration: defaultConfiguration,
             position: pendingNode.position,
             sourceConnection: pendingNode.data.sourceConnection as
-              | { nodeId: string; handleId: string | null }
-              | undefined,
+              { nodeId: string; handleId: string | null } | undefined,
             integrationName: block.integrationName,
           });
 
@@ -1342,6 +1361,7 @@ function CanvasPage(props: CanvasPageProps) {
         canReadIntegrations={props.canReadIntegrations}
         canCreateIntegrations={props.canCreateIntegrations}
         canUpdateIntegrations={props.canUpdateIntegrations}
+        onAskAgentAboutNode={canAskAgent ? handleAskAgentAboutNode : undefined}
       />
     ),
     [
@@ -1381,6 +1401,8 @@ function CanvasPage(props: CanvasPageProps) {
       props.workflowNodes,
       readOnly,
       state,
+      handleAskAgentAboutNode,
+      canAskAgent,
     ],
   );
 
@@ -1635,6 +1657,7 @@ function CanvasPage(props: CanvasPageProps) {
               })
             }
             onClose={() => props.onRunNodeDetailClose?.()}
+            onAskAgentAboutNode={canAskAgent ? handleAskAgentAboutNode : undefined}
           />
         ) : runInspectorOpen ? (
           <RunInspectorLoadingPanel onClose={() => props.onRunNodeDetailClose?.()} />
@@ -1694,6 +1717,7 @@ function Sidebar({
   canReadIntegrations,
   canCreateIntegrations,
   canUpdateIntegrations,
+  onAskAgentAboutNode,
   layout = "sidebar",
 }: {
   layout?: "sidebar" | "bottom";
@@ -1741,6 +1765,7 @@ function Sidebar({
   canReadIntegrations?: boolean;
   canCreateIntegrations?: boolean;
   canUpdateIntegrations?: boolean;
+  onAskAgentAboutNode?: (nodeId: string, nodeName?: string) => void;
 }) {
   const sidebarData = useMemo(() => {
     if (!state.componentSidebar.selectedNodeId || !getSidebarData) {
@@ -1903,6 +1928,11 @@ function Sidebar({
       resolveRunId={resolveRunId}
       fetchRunId={fetchRunId}
       onSelectRun={onSelectRun}
+      onAskAgentAboutNode={
+        state.componentSidebar.selectedNodeId
+          ? () => onAskAgentAboutNode?.(state.componentSidebar.selectedNodeId!, editingNodeData?.nodeName)
+          : undefined
+      }
     />
   );
 }

--- a/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
+++ b/web_src/src/ui/Runs/RunInspectorNodeAccordion.tsx
@@ -1,5 +1,5 @@
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Sparkles } from "lucide-react";
 import { useEffect, useRef, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { formatMinutesSecondsDuration } from "@/lib/duration";
@@ -26,6 +26,7 @@ export function RunInspectorNodeAccordion({
   errorScrollRequestId,
   onErrorScrolled,
   onSelectSection,
+  onAskAgentAboutNode,
 }: {
   section: RunInspectorNodeSection;
   componentIconMap: Record<string, string>;
@@ -40,6 +41,7 @@ export function RunInspectorNodeAccordion({
   errorScrollRequestId?: number | null;
   onErrorScrolled?: () => void;
   onSelectSection: (sectionValue: string) => void;
+  onAskAgentAboutNode?: (nodeId: string, nodeName: string) => void;
 }) {
   const iconSrc = getHeaderIconSrc(section.workflowNode?.component);
   const iconSlug = section.workflowNode?.component ? componentIconMap[section.workflowNode.component] : undefined;
@@ -110,6 +112,7 @@ export function RunInspectorNodeAccordion({
           </span>
         </NodeHeaderButton>
         <NodeActions section={section} actions={actions} currentUser={currentUser} />
+        <AskAgentAboutNodeButton section={section} onAskAgentAboutNode={onAskAgentAboutNode} />
         <NodeMetadata section={section} onRerun={onRerun} rerunPending={rerunPending} />
       </AccordionPrimitive.Header>
       {section.isQueued ? null : (
@@ -126,6 +129,33 @@ export function RunInspectorNodeAccordion({
         </AccordionContent>
       )}
     </AccordionItem>
+  );
+}
+
+function AskAgentAboutNodeButton({
+  section,
+  onAskAgentAboutNode,
+}: {
+  section: RunInspectorNodeSection;
+  onAskAgentAboutNode?: (nodeId: string, nodeName: string) => void;
+}) {
+  if (!onAskAgentAboutNode) return null;
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-7 w-7 shrink-0 p-0"
+      aria-label={`Ask Agent about ${section.nodeName}`}
+      title={`Ask Agent about ${section.nodeName}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        onAskAgentAboutNode(section.nodeId, section.nodeName);
+      }}
+    >
+      <Sparkles className="h-3.5 w-3.5" aria-hidden />
+    </Button>
   );
 }
 

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.fixtures.tsx
@@ -82,6 +82,7 @@ export function renderInspector({
   runNavigation,
   onNavigateRun,
   onNavigateOlder,
+  onAskAgentAboutNode,
   run: inspectedRun = run,
   workflowNodes: inspectedWorkflowNodes = workflowNodes,
   componentDefinitions: inspectedComponentDefinitions = componentDefinitions,
@@ -96,6 +97,7 @@ export function renderInspector({
   runNavigation?: { newerRunId?: string | null; olderRunId?: string | null; canNavigateOlder?: boolean } | null;
   onNavigateRun?: (runId: string) => void;
   onNavigateOlder?: () => void;
+  onAskAgentAboutNode?: (nodeId: string, nodeName: string) => void;
   run?: CanvasesCanvasRun;
   workflowNodes?: SuperplaneComponentsNode[];
   componentDefinitions?: ActionsAction[];
@@ -146,6 +148,7 @@ export function renderInspector({
             runNavigation={runNavigation}
             onNavigateRun={onNavigateRun}
             onNavigateOlder={onNavigateOlder}
+            onAskAgentAboutNode={onAskAgentAboutNode}
             onClose={onClose}
           />
         </ThemeProvider>

--- a/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.spec.tsx
@@ -101,6 +101,19 @@ afterEach(() => {
 });
 
 describe("RunInspectorPanel", () => {
+  it("offers the selected run component to Agent without toggling the accordion", () => {
+    const onAskAgentAboutNode = vi.fn();
+    renderInspector({ selectedNodeId: "action-2", onAskAgentAboutNode });
+
+    const accordionTrigger = screen.getByRole("button", { name: /^Save Assessment/ });
+    expect(accordionTrigger).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Ask Agent about Save Assessment" }));
+
+    expect(onAskAgentAboutNode).toHaveBeenCalledWith("action-2", "Save Assessment");
+    expect(accordionTrigger).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("renders the selected node accordion with backend-provided output sections", () => {
     renderInspector({ selectedNodeId: "action-2" });
 

--- a/web_src/src/ui/Runs/RunInspectorPanel.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.tsx
@@ -41,6 +41,7 @@ export interface RunInspectorPanelProps {
   onNavigateRun?: (runId: string) => void;
   onNavigateOlder?: () => void;
   onClose: () => void;
+  onAskAgentAboutNode?: (nodeId: string, nodeName: string) => void;
 }
 
 type AccountFallback = {
@@ -122,6 +123,7 @@ export function RunInspectorPanel(props: RunInspectorPanelProps) {
         currentUser={model.resolvedCurrentUser}
         errorScrollRequest={model.errorScrollRequest}
         onErrorScrolled={model.clearErrorScrollRequest}
+        onAskAgentAboutNode={props.onAskAgentAboutNode}
       />
     </aside>
   );
@@ -226,6 +228,7 @@ function RunInspectorContent({
   currentUser,
   errorScrollRequest,
   onErrorScrolled,
+  onAskAgentAboutNode,
 }: {
   errorSummaries: RunInspectorErrorSummary[];
   status: keyof typeof RUN_STATUS_META;
@@ -244,6 +247,7 @@ function RunInspectorContent({
   currentUser: RunInspectorCurrentUser | undefined;
   errorScrollRequest: { nodeId: string; requestId: number } | null;
   onErrorScrolled: () => void;
+  onAskAgentAboutNode?: (nodeId: string, nodeName: string) => void;
 }) {
   return (
     <RunInspectorStepsList
@@ -264,6 +268,7 @@ function RunInspectorContent({
       currentUser={currentUser}
       errorScrollRequest={errorScrollRequest}
       onErrorScrolled={onErrorScrolled}
+      onAskAgentAboutNode={onAskAgentAboutNode}
     />
   );
 }

--- a/web_src/src/ui/Runs/RunInspectorStepsList.tsx
+++ b/web_src/src/ui/Runs/RunInspectorStepsList.tsx
@@ -25,6 +25,7 @@ export function RunInspectorStepsList({
   currentUser,
   errorScrollRequest,
   onErrorScrolled,
+  onAskAgentAboutNode,
 }: {
   errorSummaries: RunInspectorErrorSummary[];
   status: keyof typeof RUN_STATUS_META;
@@ -43,6 +44,7 @@ export function RunInspectorStepsList({
   currentUser?: RunInspectorCurrentUser;
   errorScrollRequest?: { nodeId: string; requestId: number } | null;
   onErrorScrolled?: () => void;
+  onAskAgentAboutNode?: (nodeId: string, nodeName: string) => void;
 }) {
   return (
     <div className="min-h-0 flex-1 overflow-y-auto" data-testid="run-panel-step-list">
@@ -86,6 +88,7 @@ export function RunInspectorStepsList({
               errorScrollRequestId={errorScrollRequest?.nodeId === section.nodeId ? errorScrollRequest.requestId : null}
               onErrorScrolled={onErrorScrolled}
               onSelectSection={onValueChange}
+              onAskAgentAboutNode={onAskAgentAboutNode}
             />
           ))}
         </Accordion>

--- a/web_src/src/ui/componentSidebar/index.spec.tsx
+++ b/web_src/src/ui/componentSidebar/index.spec.tsx
@@ -244,4 +244,20 @@ describe("ComponentSidebar", () => {
       expect(onTabChange).toHaveBeenCalledWith("settings");
     });
   });
+
+  it("keeps the Agent and close actions accessible and independent", () => {
+    const onAskAgentAboutNode = vi.fn();
+    const onClose = vi.fn();
+    renderSidebar({ nodeId: "deploy", onAskAgentAboutNode, onClose });
+
+    const action = screen.getByRole("button", { name: "Ask Agent about this component" });
+    expect(action).toHaveAttribute("title", "Ask Agent about this component");
+    fireEvent.click(action);
+
+    expect(onAskAgentAboutNode).toHaveBeenCalledOnce();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close component details" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
 });

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -2,7 +2,7 @@ import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { cn, resolveIcon } from "@/lib/utils";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
-import { Check, Copy, X } from "lucide-react";
+import { Check, Copy, Sparkles, X } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { useAvailableIntegrations, useCreateIntegration } from "@/hooks/useIntegrations";
@@ -155,6 +155,7 @@ interface ComponentSidebarProps {
   resolveRunId?: (event: SidebarEvent) => string | null;
   fetchRunId?: (event: SidebarEvent) => Promise<string | null>;
   onSelectRun?: (runId: string, options?: { nodeId?: string }) => void;
+  onAskAgentAboutNode?: () => void;
 }
 
 export const ComponentSidebar = ({
@@ -218,6 +219,7 @@ export const ComponentSidebar = ({
   resolveRunId,
   fetchRunId,
   onSelectRun,
+  onAskAgentAboutNode,
 }: ComponentSidebarProps) => {
   const isBottomLayout = layout === "bottom";
   const sidebarWidth = useSidebarLayoutStore((state) => state.rightWidth);
@@ -532,8 +534,29 @@ export const ComponentSidebar = ({
                 <h3 className="truncate text-[13px] font-medium text-gray-900 dark:text-gray-100">{nodeName}</h3>
               </div>
               <div className="flex shrink-0 items-stretch">
+                {onAskAgentAboutNode && nodeId ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0"
+                    aria-label="Ask Agent about this component"
+                    title="Ask Agent about this component"
+                    onClick={onAskAgentAboutNode}
+                  >
+                    <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                  </Button>
+                ) : null}
                 <div className="flex items-center px-1">
-                  <Button type="button" variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => onClose?.()}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0"
+                    aria-label="Close component details"
+                    title="Close component details"
+                    onClick={() => onClose?.()}
+                  >
                     <X className="size-3.5" />
                   </Button>
                 </div>
@@ -566,13 +589,32 @@ export const ComponentSidebar = ({
                     </div>
                   )}
                 </div>
-                {null}
-              </div>
-              <div
-                onClick={() => onClose?.()}
-                className="absolute top-3 right-2 w-6 h-6 hover:bg-slate-950/5 rounded-full flex items-center justify-center cursor-pointer leading-none dark:hover:bg-gray-800/50"
-              >
-                <X size={16} />
+                <div className="flex shrink-0 items-center gap-1">
+                  {onAskAgentAboutNode && nodeId ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0"
+                      aria-label="Ask Agent about this component"
+                      title="Ask Agent about this component"
+                      onClick={onAskAgentAboutNode}
+                    >
+                      <Sparkles className="h-4 w-4" aria-hidden />
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    aria-label="Close component details"
+                    title="Close component details"
+                    onClick={() => onClose?.()}
+                  >
+                    <X className="size-4" />
+                  </Button>
+                </div>
               </div>
             </div>
           )}


### PR DESCRIPTION
## What

Adds an **Ask Agent** action to inspected canvas components, including components shown in run inspection.

The action opens the Agent sidebar and prefills the composer with a structured node mention. It does not send the message automatically, so the user can refine the question before spending tokens.

Fixes #6376

## Why

Component inspection already gives users the context they need to identify a node, but moving that context into Agent required manual copy and explanation. This change makes that handoff one click while preserving user control over the final prompt.

## How

- Adds accessible Ask Agent actions to the component sidebar and run inspector node headers.
- Reuses the existing mention and `NodeChip` serialization path instead of introducing a parallel context format.
- Queues composer prefills by canvas so the action also works while the Agent sidebar is mounting.
- Preserves existing composer drafts and tracked mentions when appending component context.
- Expires and clears unconsumed prefills on sidebar close, canvas changes, or Agent setup failure.
- Exposes the action only when Agent is enabled, available, visible, and the canvas has an ID.
- Keeps the Agent and close actions as independent accessible buttons.

## Testing

Passed locally:

- `npm run test:run`: 521 files, 3,888 tests passed.
- Focused interaction suite: 6 files, 82 tests passed.
- `npm run lint:budget`: within budget at 590/591.
- ESLint on all changed files: 0 errors.
- Prettier check and `git diff --check`.
- Independent read-only Codex review: clean after addressing stale-prefill and mention-offset edge cases.

Environment limitations:

- `npm run build` reaches TypeScript but is blocked by existing errors in `CanvasYamlDiffModal.spec.tsx` where `oldFile` and `newFile` are considered nullable. The same two errors reproduce with this feature diff stashed.
- Visual validation was not available locally because the installed Docker CLI does not support `docker compose`; the `docker-compose` fallback built the services but RabbitMQ remained unhealthy.
