### PR TITLE
fix: classify incomplete GitHub webhook setup

### DIFF
--- a/pkg/core/integration_setup_provider.go
+++ b/pkg/core/integration_setup_provider.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"errors"
+
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/configuration"
@@ -162,6 +164,8 @@ type IntegrationPropertyStorage interface {
 type IntegrationSecretStorageReader interface {
 	Get(name string) (string, error)
 }
+
+var ErrIntegrationSecretNotFound = errors.New("integration secret not found")
 
 /*
  * Secrets are sensitive information managed by the integration.

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -236,6 +237,12 @@ func (g *GitHub) findWebhookSecret(ctx core.HTTPRequestContext) (string, error) 
 func (g *GitHub) handleWebhook(ctx core.HTTPRequestContext) {
 	webhookSecret, err := g.findWebhookSecret(ctx)
 	if err != nil {
+		if !ctx.Integration.LegacySetup() && errors.Is(err, core.ErrIntegrationSecretNotFound) {
+			ctx.Logger.Warn("GitHub webhook secret is missing for incomplete setup")
+			ctx.Response.WriteHeader(http.StatusNotFound)
+			return
+		}
+
 		ctx.Logger.Errorf("Error finding webhook secret: %v", err)
 		ctx.Response.WriteHeader(http.StatusInternalServerError)
 		return

--- a/pkg/integrations/github/webhook_handler_test.go
+++ b/pkg/integrations/github/webhook_handler_test.go
@@ -1,13 +1,20 @@
 package github
 
 import (
+	"bytes"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
@@ -176,6 +183,66 @@ func Test__GitHubWebhookHandler__Cleanup(t *testing.T) {
 	})
 }
 
+func Test__GitHub__HandleWebhook(t *testing.T) {
+	t.Run("returns not found when new setup flow is missing app webhook secret", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		integration := mocks.IntegrationContextForNewSetupFlow()
+		delete(integration.CurrentSecrets, common.SecretAppWebhookSecret)
+
+		(&GitHub{}).handleWebhook(githubWebhookRequestContext(recorder, integration, []byte("{}")))
+
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+		assert.NotContains(t, recorder.Body.String(), common.SecretAppWebhookSecret)
+	})
+
+	t.Run("keeps invalid signature status when new setup flow has app webhook secret", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		integration := mocks.IntegrationContextForNewSetupFlow()
+		require.NoError(t, integration.SetSecret(common.SecretAppWebhookSecret, []byte("webhook-secret")))
+
+		(&GitHub{}).handleWebhook(githubWebhookRequestContext(recorder, integration, []byte("{}")))
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("keeps legacy missing webhook secret behavior", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		integration := mocks.IntegrationContextForLegacySetupFlow(githubPrivateKeyPEM(t))
+
+		(&GitHub{}).handleWebhook(githubWebhookRequestContext(recorder, integration, []byte("{}")))
+
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	})
+
+	t.Run("keeps unexpected new setup secret retrieval failures as internal errors", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		integration := &failingSecretIntegrationContext{
+			IntegrationContext: mocks.IntegrationContextForNewSetupFlow(),
+			err:                errors.New("storage unavailable"),
+		}
+
+		(&GitHub{}).handleWebhook(githubWebhookRequestContext(recorder, integration, []byte("{}")))
+
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	})
+
+	t.Run("keeps malformed payload behavior", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		secret := "webhook-secret"
+		body := []byte("not-json")
+		integration := mocks.IntegrationContextForNewSetupFlow()
+		require.NoError(t, integration.SetSecret(common.SecretAppWebhookSecret, []byte(secret)))
+
+		ctx := githubWebhookRequestContext(recorder, integration, body)
+		ctx.Request.Header.Set("X-GitHub-Event", "installation")
+		ctx.Request.Header.Set("X-Hub-Signature-256", githubSignature(secret, body))
+
+		(&GitHub{}).handleWebhook(ctx)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+}
+
 func githubPrivateKeyPEM(t *testing.T) []byte {
 	t.Helper()
 
@@ -186,4 +253,56 @@ func githubPrivateKeyPEM(t *testing.T) []byte {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
+}
+
+func githubWebhookRequestContext(
+	recorder *httptest.ResponseRecorder,
+	integration core.IntegrationContext,
+	body []byte,
+) core.HTTPRequestContext {
+	return core.HTTPRequestContext{
+		Logger:      logrus.NewEntry(logrus.New()),
+		Request:     httptest.NewRequest(http.MethodPost, "/api/v1/integrations/test/webhook", bytes.NewReader(body)),
+		Response:    recorder,
+		Integration: integration,
+	}
+}
+
+func githubSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+type failingSecretIntegrationContext struct {
+	*contexts.IntegrationContext
+	err error
+}
+
+func (c *failingSecretIntegrationContext) Secrets() core.IntegrationSecretStorage {
+	return failingSecretStorage{err: c.err}
+}
+
+type failingSecretStorage struct {
+	err error
+}
+
+func (s failingSecretStorage) Get(string) (string, error) {
+	return "", s.err
+}
+
+func (s failingSecretStorage) Delete(string) error {
+	return s.err
+}
+
+func (s failingSecretStorage) Create(core.IntegrationSecretDefinition) error {
+	return s.err
+}
+
+func (s failingSecretStorage) CreateMany([]core.IntegrationSecretDefinition) error {
+	return s.err
+}
+
+func (s failingSecretStorage) Update(string, string) error {
+	return s.err
 }

--- a/pkg/workers/contexts/integration_secret_storage.go
+++ b/pkg/workers/contexts/integration_secret_storage.go
@@ -54,7 +54,7 @@ func (s *IntegrationSecretStorage) findSecret(name string) (*models.IntegrationS
 		}
 	}
 
-	return nil, fmt.Errorf("secret %s not found", name)
+	return nil, fmt.Errorf("secret %s: %w", name, core.ErrIntegrationSecretNotFound)
 }
 
 func (s *IntegrationSecretStorage) Get(name string) (string, error) {

--- a/pkg/workers/contexts/integration_secret_storage_test.go
+++ b/pkg/workers/contexts/integration_secret_storage_test.go
@@ -1,6 +1,7 @@
 package contexts
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -38,7 +39,31 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 		value, err = storage.Get("missing")
 		require.Error(t, err)
 		assert.Empty(t, value)
-		assert.Contains(t, err.Error(), "secret missing not found")
+		assert.ErrorIs(t, err, core.ErrIntegrationSecretNotFound)
+	})
+
+	t.Run("does not classify database failures as missing secrets", func(t *testing.T) {
+		tx := database.Conn().Begin()
+		require.NoError(t, tx.Rollback().Error)
+
+		storage := NewIntegrationSecretStorage(tx, crypto.NewNoOpEncryptor(), integration)
+		_, err := storage.Get("token")
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, core.ErrIntegrationSecretNotFound))
+	})
+
+	t.Run("does not classify decryption failures as missing secrets", func(t *testing.T) {
+		seedContextIntegrationSecret(t, integration, "encrypted-token", "not-encrypted")
+
+		storage := NewIntegrationSecretStorage(
+			database.Conn(),
+			crypto.NewAESGCMEncryptor([]byte("0123456789abcdef0123456789abcdef")),
+			integration,
+		)
+
+		_, err := storage.Get("encrypted-token")
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, core.ErrIntegrationSecretNotFound))
 	})
 
 	t.Run("creates and persists secrets", func(t *testing.T) {
@@ -124,7 +149,7 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 
 		err = storage.Update("missing", "value")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "secret missing not found")
+		assert.ErrorIs(t, err, core.ErrIntegrationSecretNotFound)
 	})
 
 	t.Run("deletes cached and persisted secrets", func(t *testing.T) {
@@ -133,7 +158,7 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 
 		_, err := storage.Get("many-two")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "secret many-two not found")
+		assert.ErrorIs(t, err, core.ErrIntegrationSecretNotFound)
 
 		var count int64
 		err = database.Conn().
@@ -146,7 +171,7 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 
 		err = storage.Delete("missing")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "secret missing not found")
+		assert.ErrorIs(t, err, core.ErrIntegrationSecretNotFound)
 	})
 }
 

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -502,7 +502,7 @@ type IntegrationSecretStorage struct {
 func (s *IntegrationSecretStorage) Get(name string) (string, error) {
 	v, ok := s.parentContext.CurrentSecrets[name]
 	if !ok {
-		return "", fmt.Errorf("secret not found: %s", name)
+		return "", fmt.Errorf("secret %s: %w", name, core.ErrIntegrationSecretNotFound)
 	}
 
 	return string(v.Value), nil


### PR DESCRIPTION
Fixes #5850.

## What

Classify a missing `appWebhookSecret` in the newer GitHub App setup flow as an incomplete integration setup rather than an internal server failure.

The webhook handler now:

* returns HTTP 404 when the newer setup flow has no persisted `appWebhookSecret`;
* preserves HTTP 500 for secret-storage, database, and decryption failures;
* preserves the existing behavior for legacy integrations;
* preserves existing invalid-signature and malformed-payload handling;
* logs incomplete setup at warning level without exposing secret names or values.

## Why

`handleWebhook` previously returned HTTP 500 for every error produced while retrieving the webhook secret.

For newer GitHub App integrations, that combined materially different failure classes:

1. the required webhook secret was never persisted because setup did not complete;
2. the secret store or database failed;
3. the stored secret could not be decrypted.

Only the first case represents incomplete setup. The other cases remain internal failures and continue returning HTTP 500.

## Design

This change introduces `core.ErrIntegrationSecretNotFound` at the integration secret-storage boundary.

The production and test-support storage implementations wrap this sentinel only when the requested secret does not exist. Callers can therefore use `errors.Is` without matching human-readable error strings or confusing absence with database and decryption failures.

The HTTP behavior change remains specific to the non-legacy GitHub webhook path. The legacy `common.FindSecret` behavior is unchanged.

## Behavior

| Scenario                               | Before | After |
| -------------------------------------- | -----: | ----: |
| New setup missing `appWebhookSecret`   |    500 |   404 |
| New setup secret query/storage failure |    500 |   500 |
| New setup secret decryption failure    |    500 |   500 |
| Legacy missing webhook secret          |    500 |   500 |
| Present secret with invalid signature  |    400 |   400 |
| Valid signature with malformed payload |    400 |   400 |

## Tests added

The tests cover:

* missing-secret errors satisfying `errors.Is(err, core.ErrIntegrationSecretNotFound)`;
* storage/query failures not being classified as missing secrets;
* decryption failures not being classified as missing secrets;
* missing `appWebhookSecret` in the newer setup flow returning 404;
* generic response content without secret names;
* unexpected retrieval failures retaining HTTP 500;
* legacy missing-secret behavior remaining unchanged;
* invalid signatures and malformed payloads retaining HTTP 400.

## Scope

This PR does not change:

* legacy secret lookup semantics;
* generated files or API contracts;
* migrations;
* frontend behavior;
* webhook signature validation;
* malformed-payload handling.

## Validation

Completed locally:

```text
git diff --check
```

Result: passed.

The repository’s prescribed formatting, test, and lint commands could not run locally because this environment does not currently have Docker or Go installed:

```text
make format.go
make test PKG_TEST_PACKAGES=./pkg/integrations/github
make test PKG_TEST_PACKAGES=./pkg/workers/contexts
make lint
go test ./pkg/integrations/github ./pkg/workers/contexts
```

I am opening this as a draft so the repository CI can validate compilation, formatting, tests, and linting. I will address any CI failures before marking it ready for review.

## Review note

HTTP 404 is intentionally localized to the incomplete newer-setup condition. If HTTP 400 better matches the project’s intended webhook semantics, changing it requires only the handler status and corresponding test expectation.