### PR TITLE
docs: fix README security links

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ SuperPlane integrates with the tools you already use. Each integration provides 
 
 ## Security
 
-- **RBAC** and **API keys** for programmatic access — see [access control](https://docs.superplane.com/concepts/access-control/) and [API keys](https://docs.superplane.com/concepts/service-accounts/)
-- **Secrets** stored encrypted — see [secrets](https://docs.superplane.com/concepts/secrets/)
+- **RBAC** and **API keys** for programmatic access — see [access control](https://docs.superplane.com/security/access-control/) and [API keys](https://docs.superplane.com/security/api-keys/)
+- **Secrets** stored encrypted — see [secrets](https://docs.superplane.com/security/secrets/)
 
 ## Production installation
 


### PR DESCRIPTION
## Summary

Fix the broken security documentation links in the repository README.

The README currently points readers to outdated `/concepts/` documentation routes. The security documentation has moved under the `/security/` section of the SuperPlane docs.

## Broken links

The README currently uses:

- `https://docs.superplane.com/concepts/access-control/`
- `https://docs.superplane.com/concepts/service-accounts/`
- `https://docs.superplane.com/concepts/secrets/`

## Updated links

This PR replaces them with the current documentation routes:

- Access control / RBAC  
  `https://docs.superplane.com/security/access-control/`

- API keys  
  `https://docs.superplane.com/security/api-keys/`

- Secrets  
  `https://docs.superplane.com/security/secrets/`

## Why

The Security section of the README is intended to direct users to SuperPlane’s documentation for RBAC, programmatic access, and secret management.

Because the existing links point to outdated routes, users can be sent away from the relevant documentation. This change restores those navigation paths and aligns the README with the current structure of the SuperPlane documentation site.

## Scope

This PR changes only the three documentation URLs in `README.md`.

No application code, documentation content, generated files, or configuration files are modified.

## Validation

Completed locally:

```text
git diff -- README.md
git diff --check
git diff --cached
git diff --check --cached
```

Result: passed.