### PR TITLE
feat: make integrations settings list keyboard navigable

### DIFF
--- a/web_src/src/hooks/useListKeyboardNavigation.spec.ts
+++ b/web_src/src/hooks/useListKeyboardNavigation.spec.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useListKeyboardNavigation } from "./useListKeyboardNavigation";
+
+function keyEvent(key: string, init: Partial<KeyboardEvent> = {}) {
+  return {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    ...init,
+  } as unknown as React.KeyboardEvent<HTMLElement>;
+}
+
+describe("useListKeyboardNavigation", () => {
+  it("starts on the first item and moves down", () => {
+    const { result } = renderHook(() => useListKeyboardNavigation({ itemCount: 3 }));
+
+    expect(result.current.activeIndex).toBe(0);
+
+    act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+    expect(result.current.activeIndex).toBe(1);
+  });
+
+  it("wraps from the last item to the first and back", () => {
+    const { result } = renderHook(() => useListKeyboardNavigation({ itemCount: 2 }));
+
+    act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+    act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+    expect(result.current.activeIndex).toBe(0);
+
+    act(() => result.current.handleKeyDown(keyEvent("ArrowUp")));
+    expect(result.current.activeIndex).toBe(1);
+  });
+
+  it("jumps to the first and last item with Home and End", () => {
+    const { result } = renderHook(() => useListKeyboardNavigation({ itemCount: 5 }));
+
+    act(() => result.current.handleKeyDown(keyEvent("End")));
+    expect(result.current.activeIndex).toBe(4);
+
+    act(() => result.current.handleKeyDown(keyEvent("Home")));
+    expect(result.current.activeIndex).toBe(0);
+  });
+
+  it("activates the highlighted item on Enter", () => {
+    const onActivate = vi.fn();
+    const { result } = renderHook(() => useListKeyboardNavigation({ itemCount: 3, onActivate }));
+
+    act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+    act(() => result.current.handleKeyDown(keyEvent("Enter")));
+
+    expect(onActivate).toHaveBeenCalledWith(1);
+  });
+
+  it("ignores navigation keys pressed with a modifier so global shortcuts still work", () => {
+    const onActivate = vi.fn();
+    const { result } = renderHook(() => useListKeyboardNavigation({ itemCount: 3, onActivate }));
+
+    const event = keyEvent("ArrowDown", { metaKey: true });
+    act(() => result.current.handleKeyDown(event));
+
+    expect(result.current.activeIndex).toBe(0);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("reports an empty list as having no active item", () => {
+    const onActivate = vi.fn();
+    const { result } = renderHook(() => useListKeyboardNavigation({ itemCount: 0, onActivate }));
+
+    expect(result.current.activeIndex).toBe(-1);
+
+    act(() => result.current.handleKeyDown(keyEvent("Enter")));
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it("clamps the active index when the list shrinks under it", () => {
+    const { rerender, result } = renderHook(({ itemCount }) => useListKeyboardNavigation({ itemCount }), {
+      initialProps: { itemCount: 5 },
+    });
+
+    act(() => result.current.handleKeyDown(keyEvent("End")));
+    expect(result.current.activeIndex).toBe(4);
+
+    rerender({ itemCount: 2 });
+    expect(result.current.activeIndex).toBe(1);
+  });
+
+  it("leaves unrelated keys alone", () => {
+    const { result } = renderHook(() => useListKeyboardNavigation({ itemCount: 3 }));
+
+    const event = keyEvent("a");
+    act(() => result.current.handleKeyDown(event));
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(result.current.activeIndex).toBe(0);
+  });
+});

--- a/web_src/src/hooks/useListKeyboardNavigation.ts
+++ b/web_src/src/hooks/useListKeyboardNavigation.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from "react";
+import type { KeyboardEvent } from "react";
+
+interface UseListKeyboardNavigationOptions {
+  /** Number of items currently rendered in the list. */
+  itemCount: number;
+  /** Called with the highlighted index when the user presses Enter. */
+  onActivate?: (index: number) => void;
+}
+
+interface ListKeyboardNavigation {
+  /** Index of the highlighted item, or -1 when the list is empty. */
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+  handleKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+}
+
+const NO_ACTIVE_INDEX = -1;
+
+/**
+ * Drives a highlighted row from a search input: Arrow keys move the highlight,
+ * Home/End jump to the ends, and Enter activates the highlighted item. Keeps
+ * focus where it is so a filter input stays typable while navigating.
+ *
+ * Events carrying a modifier are ignored so application-level shortcuts
+ * (e.g. the global command palette on Cmd+/) keep working.
+ */
+export function useListKeyboardNavigation({
+  itemCount,
+  onActivate,
+}: UseListKeyboardNavigationOptions): ListKeyboardNavigation {
+  const [activeIndex, setActiveIndex] = useState(itemCount > 0 ? 0 : NO_ACTIVE_INDEX);
+
+  useEffect(() => {
+    setActiveIndex((current) => {
+      if (itemCount === 0) return NO_ACTIVE_INDEX;
+      if (current < 0) return 0;
+      return Math.min(current, itemCount - 1);
+    });
+  }, [itemCount]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (itemCount === 0) return;
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          setActiveIndex((current) => (current + 1) % itemCount);
+          return;
+        case "ArrowUp":
+          event.preventDefault();
+          setActiveIndex((current) => (current - 1 + itemCount) % itemCount);
+          return;
+        case "Home":
+          event.preventDefault();
+          setActiveIndex(0);
+          return;
+        case "End":
+          event.preventDefault();
+          setActiveIndex(itemCount - 1);
+          return;
+        case "Enter":
+          if (activeIndex < 0 || !onActivate) return;
+          event.preventDefault();
+          onActivate(activeIndex);
+          return;
+        default:
+          return;
+      }
+    },
+    [activeIndex, itemCount, onActivate],
+  );
+
+  return { activeIndex, setActiveIndex, handleKeyDown };
+}

--- a/web_src/src/pages/organization/settings/IntegrationCatalogRow.spec.tsx
+++ b/web_src/src/pages/organization/settings/IntegrationCatalogRow.spec.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { OrganizationsIntegration } from "@/api-client";
+import { IntegrationCatalogRow, type IntegrationCatalogEntry } from "./IntegrationCatalogRow";
+
+vi.mock("@/ui/componentSidebar/integrationIcons", () => ({
+  IntegrationIcon: ({ integrationName }: { integrationName?: string }) => (
+    <span data-testid={`icon-${integrationName ?? "unknown"}`} />
+  ),
+}));
+
+function instance(state: string | undefined, name = "cursor"): OrganizationsIntegration {
+  return {
+    metadata: { id: `id-${name}-${state ?? "none"}`, name, integrationName: "cursor" },
+    status: state ? { state } : {},
+  };
+}
+
+function entry(overrides: Partial<IntegrationCatalogEntry> = {}): IntegrationCatalogEntry {
+  return {
+    providerName: "cursor",
+    providerLabel: "Cursor",
+    integrationDef: { name: "cursor", label: "Cursor", description: "Build workflows with Cursor" },
+    instances: [],
+    ...overrides,
+  };
+}
+
+function renderRow(overrides: Partial<IntegrationCatalogEntry> = {}, props: Record<string, unknown> = {}) {
+  return render(
+    <ul>
+      <IntegrationCatalogRow
+        entry={entry(overrides)}
+        isActive={false}
+        canCreateIntegrations
+        canUpdateIntegrations
+        permissionsLoading={false}
+        onConnect={vi.fn()}
+        onConfigure={vi.fn()}
+        rowRef={vi.fn()}
+        {...props}
+      />
+    </ul>,
+  );
+}
+
+describe("IntegrationCatalogRow", () => {
+  it("renders the provider with its connect action", () => {
+    renderRow();
+
+    expect(screen.getByRole("heading", { name: "Cursor" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+  });
+
+  it("marks the row as current when highlighted", () => {
+    renderRow({}, { isActive: true });
+
+    expect(screen.getByRole("listitem")).toHaveAttribute("aria-current", "true");
+  });
+
+  it("shows a single status badge per connected instance", () => {
+    renderRow({ instances: [instance("ready")] });
+
+    expect(screen.getByText("1 connected instance")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("cursor")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["ready", "Ready"],
+    ["error", "Error"],
+    ["pending", "Pending"],
+    [undefined, "Unknown"],
+  ])("labels the %s state as %s", (state, expected) => {
+    renderRow({ instances: [instance(state)] });
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it("pluralises the connected instance count", () => {
+    renderRow({ instances: [instance("ready", "one"), instance("ready", "two")] });
+
+    expect(screen.getByText("2 connected instances")).toBeInTheDocument();
+  });
+
+  it("configures the instance that was clicked", async () => {
+    const user = userEvent.setup();
+    const onConfigure = vi.fn();
+    const connected = instance("ready");
+
+    renderRow({ instances: [connected] }, { onConfigure });
+    await user.click(screen.getByRole("button", { name: "Configure" }));
+
+    expect(onConfigure).toHaveBeenCalledWith(connected);
+  });
+
+  it("disables connecting when the provider is no longer available", () => {
+    renderRow({ integrationDef: null });
+
+    expect(screen.getByRole("button", { name: "Unavailable" })).toBeDisabled();
+  });
+});

--- a/web_src/src/pages/organization/settings/IntegrationCatalogRow.tsx
+++ b/web_src/src/pages/organization/settings/IntegrationCatalogRow.tsx
@@ -1,0 +1,185 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { cn } from "@/lib/utils";
+import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
+import type { IntegrationsIntegrationDefinition, OrganizationsIntegration } from "@/api-client";
+import { settingsPanelClassName } from "./settingsPageStyles";
+
+export interface IntegrationCatalogEntry {
+  providerName: string;
+  providerLabel: string;
+  integrationDef: IntegrationsIntegrationDefinition | null;
+  instances: OrganizationsIntegration[];
+}
+
+interface IntegrationCatalogRowProps {
+  entry: IntegrationCatalogEntry;
+  isActive: boolean;
+  canCreateIntegrations: boolean;
+  canUpdateIntegrations: boolean;
+  permissionsLoading: boolean;
+  onConnect: (integration: IntegrationsIntegrationDefinition) => void;
+  onConfigure: (integration: OrganizationsIntegration) => void;
+  rowRef: (node: HTMLLIElement | null) => void;
+}
+
+interface StatusTone {
+  badge: string;
+  dot: string;
+}
+
+const STATUS_TONES: Record<"ready" | "error" | "pending", StatusTone> = {
+  ready: {
+    badge:
+      "border-green-200 bg-green-50 text-green-700 dark:border-green-500/20 dark:bg-green-500/10 dark:text-green-300",
+    dot: "bg-green-500",
+  },
+  error: {
+    badge: "border-red-200 bg-red-50 text-red-700 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-300",
+    dot: "bg-red-500",
+  },
+  pending: {
+    badge:
+      "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-300",
+    dot: "bg-amber-500",
+  },
+};
+
+function statusTone(state: string | undefined): StatusTone {
+  if (state === "ready") return STATUS_TONES.ready;
+  if (state === "error") return STATUS_TONES.error;
+  return STATUS_TONES.pending;
+}
+
+function ConnectedInstanceRow({
+  integration,
+  isFirst,
+  canUpdateIntegrations,
+  permissionsLoading,
+  onConfigure,
+}: {
+  integration: OrganizationsIntegration;
+  isFirst: boolean;
+  canUpdateIntegrations: boolean;
+  permissionsLoading: boolean;
+  onConfigure: (integration: OrganizationsIntegration) => void;
+}) {
+  const state = integration.status?.state;
+  const statusLabel = state ? state.charAt(0).toUpperCase() + state.slice(1) : "Unknown";
+  const tone = statusTone(state);
+
+  return (
+    <div
+      className={cn("flex items-center gap-3 py-2 border-t border-gray-200 dark:border-gray-700/70", isFirst && "mt-1")}
+    >
+      <p className="min-w-0 truncate text-sm font-medium text-gray-800 dark:text-gray-100">
+        {integration.metadata?.name}
+      </p>
+      <Badge variant="secondary" className={cn("gap-1.5", tone.badge)}>
+        <span className={cn("size-1.5 rounded-full", tone.dot)} aria-hidden="true" />
+        {statusLabel}
+      </Badge>
+      <div className="ml-auto flex items-center gap-4">
+        <PermissionTooltip
+          allowed={canUpdateIntegrations || permissionsLoading}
+          message="You don't have permission to update integrations."
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              if (!canUpdateIntegrations) return;
+              onConfigure(integration);
+            }}
+            disabled={!canUpdateIntegrations}
+          >
+            Configure
+          </Button>
+        </PermissionTooltip>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A single provider in the integrations catalog. `isActive` reflects the
+ * keyboard highlight driven by the filter input, not focus.
+ */
+export function IntegrationCatalogRow({
+  entry,
+  isActive,
+  canCreateIntegrations,
+  canUpdateIntegrations,
+  permissionsLoading,
+  onConnect,
+  onConfigure,
+  rowRef,
+}: IntegrationCatalogRowProps) {
+  const connectedCount = entry.instances.length;
+
+  return (
+    <li
+      ref={rowRef}
+      data-integration-row={entry.providerName}
+      aria-current={isActive ? "true" : undefined}
+      className={cn(settingsPanelClassName, "scroll-mt-4", isActive && "ring-2 ring-blue-500/70 dark:ring-blue-400/70")}
+    >
+      <div className="p-4 flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex h-8 w-8 items-center justify-center">
+            <IntegrationIcon
+              integrationName={entry.providerName}
+              iconSlug={entry.integrationDef?.icon}
+              className="w-8 h-8 text-gray-500 dark:text-gray-400"
+            />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100">{entry.providerLabel}</h3>
+            {entry.integrationDef?.description ? (
+              <p className="mt-0.5 text-sm text-gray-800 dark:text-gray-400">{entry.integrationDef.description}</p>
+            ) : null}
+          </div>
+        </div>
+        <PermissionTooltip
+          allowed={Boolean(entry.integrationDef) && (canCreateIntegrations || permissionsLoading)}
+          message={
+            entry.integrationDef
+              ? "You don't have permission to connect integrations."
+              : "This integration provider is no longer available for new connections."
+          }
+        >
+          <Button
+            variant="default"
+            size="sm"
+            onClick={() => {
+              if (!entry.integrationDef) return;
+              onConnect(entry.integrationDef);
+            }}
+            className="self-start"
+            disabled={!entry.integrationDef || !canCreateIntegrations}
+          >
+            {entry.integrationDef ? "Connect" : "Unavailable"}
+          </Button>
+        </PermissionTooltip>
+      </div>
+      {connectedCount > 0 ? (
+        <div className="pr-4 pb-4 pl-[60px]">
+          <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+            {connectedCount} connected instance{connectedCount === 1 ? "" : "s"}
+          </p>
+          {entry.instances.map((integration, index) => (
+            <ConnectedInstanceRow
+              key={integration.metadata?.id}
+              integration={integration}
+              isFirst={index === 0}
+              canUpdateIntegrations={canUpdateIntegrations}
+              permissionsLoading={permissionsLoading}
+              onConfigure={onConfigure}
+            />
+          ))}
+        </div>
+      ) : null}
+    </li>
+  );
+}

--- a/web_src/src/pages/organization/settings/Integrations.spec.tsx
+++ b/web_src/src/pages/organization/settings/Integrations.spec.tsx
@@ -1,0 +1,240 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IntegrationsIntegrationDefinition, OrganizationsIntegration } from "@/api-client";
+import {
+  useAvailableIntegrations,
+  useConnectedIntegrations,
+  useCreateIntegration,
+} from "../../../hooks/useIntegrations";
+import { Integrations } from "./Integrations";
+
+vi.mock("../../../hooks/useIntegrations", () => ({
+  useAvailableIntegrations: vi.fn(),
+  useConnectedIntegrations: vi.fn(),
+  useCreateIntegration: vi.fn(),
+}));
+
+vi.mock("@/contexts/usePermissions", () => ({
+  usePermissions: () => ({ canAct: () => true, isLoading: false }),
+}));
+
+vi.mock("@/posthog", () => ({
+  isPostHogEnabled: false,
+  posthog: { getSurveys: vi.fn() },
+}));
+
+vi.mock("@/ui/componentSidebar/integrationIcons", () => ({
+  IntegrationIcon: ({ integrationName }: { integrationName?: string }) => (
+    <span data-testid={`icon-${integrationName ?? "unknown"}`} />
+  ),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  analytics: { integrationConnectStart: vi.fn(), integrationRequested: vi.fn() },
+}));
+
+function definition(name: string, label: string): IntegrationsIntegrationDefinition {
+  return { name, label, description: `${label} description`, configuration: [] };
+}
+
+function instance(id: string, provider: string, name: string): OrganizationsIntegration {
+  return {
+    metadata: { id, name, integrationName: provider },
+    status: { state: "ready" },
+  };
+}
+
+const AVAILABLE = [
+  definition("github", "GitHub"),
+  definition("gitlab", "GitLab"),
+  definition("slack", "Slack"),
+  definition("datadog", "Datadog"),
+];
+
+function renderPage(connected: OrganizationsIntegration[] = []) {
+  vi.mocked(useAvailableIntegrations).mockReturnValue({
+    data: AVAILABLE,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useAvailableIntegrations>);
+  vi.mocked(useConnectedIntegrations).mockReturnValue({
+    data: connected,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useConnectedIntegrations>);
+  vi.mocked(useCreateIntegration).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  } as unknown as ReturnType<typeof useCreateIntegration>);
+
+  return render(
+    <MemoryRouter>
+      <Integrations organizationId="org-1" />
+    </MemoryRouter>,
+  );
+}
+
+function activeRowName() {
+  const active = document.querySelector('[data-integration-row][aria-current="true"]');
+  return active?.getAttribute("data-integration-row");
+}
+
+describe("Integrations settings page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("connected / available split", () => {
+    it("separates connected providers from the rest, with counts", () => {
+      renderPage([instance("i1", "github", "my-github")]);
+
+      const connectedSection = screen.getByRole("region", { name: /connected/i });
+      const availableSection = screen.getByRole("region", { name: /available/i });
+
+      expect(within(connectedSection).getByText("GitHub")).toBeInTheDocument();
+      expect(within(connectedSection).queryByText("Slack")).not.toBeInTheDocument();
+      expect(within(availableSection).getByText("Slack")).toBeInTheDocument();
+
+      expect(screen.getByRole("region", { name: /connected \(1\)/i })).toBeInTheDocument();
+      expect(screen.getByRole("region", { name: /available \(3\)/i })).toBeInTheDocument();
+    });
+
+    it("hides the connected section when nothing is connected", () => {
+      renderPage();
+
+      expect(screen.queryByRole("region", { name: /connected/i })).not.toBeInTheDocument();
+      expect(screen.getByRole("region", { name: /available \(4\)/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("filtering", () => {
+    it("narrows the list and announces how many match", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.type(screen.getByPlaceholderText(/filter integrations/i), "git");
+
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.getByText("GitLab")).toBeInTheDocument();
+      expect(screen.queryByText("Slack")).not.toBeInTheDocument();
+      expect(screen.getByRole("status")).toHaveTextContent("2 of 4 integrations");
+    });
+
+    it("clears the query on Escape", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const input = screen.getByPlaceholderText(/filter integrations/i);
+      await user.type(input, "git");
+      expect(input).toHaveValue("git");
+
+      await user.keyboard("{Escape}");
+      expect(input).toHaveValue("");
+      expect(screen.getByText("Slack")).toBeInTheDocument();
+    });
+  });
+
+  describe("keyboard navigation", () => {
+    it("focuses the filter input when pressing /", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const input = screen.getByPlaceholderText(/filter integrations/i);
+      input.blur();
+      expect(input).not.toHaveFocus();
+
+      await user.keyboard("/");
+
+      expect(input).toHaveFocus();
+      expect(input).toHaveValue("");
+    });
+
+    it("shows no highlight until the keyboard is used", () => {
+      renderPage([instance("i1", "github", "my-github")]);
+
+      screen.getByPlaceholderText(/filter integrations/i).focus();
+
+      expect(activeRowName()).toBeUndefined();
+    });
+
+    it("does not highlight rows on hover", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.hover(screen.getByText("Slack"));
+
+      expect(activeRowName()).toBeUndefined();
+    });
+
+    it("moves the highlight with the arrow keys", async () => {
+      const user = userEvent.setup();
+      renderPage([instance("i1", "github", "my-github")]);
+
+      const input = screen.getByPlaceholderText(/filter integrations/i);
+      input.focus();
+
+      // The first press reveals the highlight in place rather than skipping a row.
+      await user.keyboard("{ArrowDown}");
+      expect(activeRowName()).toBe("github");
+
+      await user.keyboard("{ArrowDown}");
+      expect(activeRowName()).toBe("datadog");
+
+      await user.keyboard("{ArrowUp}");
+      expect(activeRowName()).toBe("github");
+    });
+
+    it("hides the highlight again when the filter is cleared", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const input = screen.getByPlaceholderText(/filter integrations/i);
+      await user.type(input, "git");
+      expect(activeRowName()).toBe("github");
+
+      await user.keyboard("{Escape}");
+      expect(activeRowName()).toBeUndefined();
+    });
+
+    it("does not connect anything when Enter is pressed with no visible highlight", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      screen.getByPlaceholderText(/filter integrations/i).focus();
+      await user.keyboard("{Enter}");
+
+      expect(screen.queryByRole("heading", { name: /^connect /i })).not.toBeInTheDocument();
+    });
+
+    it("connects the highlighted integration on Enter", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const input = screen.getByPlaceholderText(/filter integrations/i);
+      input.focus();
+      await user.keyboard("slack");
+
+      expect(activeRowName()).toBe("slack");
+
+      await user.keyboard("{Enter}");
+
+      expect(screen.getByRole("heading", { name: /connect slack/i })).toBeInTheDocument();
+    });
+
+    it("highlights the first match again after the query changes", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const input = screen.getByPlaceholderText(/filter integrations/i);
+      input.focus();
+
+      await user.keyboard("{ArrowDown}{ArrowDown}");
+      await user.type(input, "git");
+
+      expect(activeRowName()).toBe("github");
+    });
+  });
+});

--- a/web_src/src/pages/organization/settings/Integrations.tsx
+++ b/web_src/src/pages/organization/settings/Integrations.tsx
@@ -1,7 +1,9 @@
 import { Loader2, Plug, Search, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useListKeyboardNavigation } from "@/hooks/useListKeyboardNavigation";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import {
   useAvailableIntegrations,
@@ -11,10 +13,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { PermissionTooltip } from "@/components/PermissionGate";
 import { usePermissions } from "@/contexts/usePermissions";
 import { ConfigurationFieldRenderer } from "../../../ui/configurationFieldRenderer";
-import type { IntegrationsIntegrationDefinition } from "../../../api-client/types.gen";
+import type { IntegrationsIntegrationDefinition, OrganizationsIntegration } from "../../../api-client/types.gen";
+import { IntegrationCatalogRow } from "./IntegrationCatalogRow";
 import { getApiErrorMessage } from "@/lib/errors";
 import { getUsageLimitNotice, getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { getIntegrationTypeDisplayName } from "@/lib/integrationDisplayName";
@@ -32,10 +34,15 @@ import {
   settingsEmptyStateIconClassName,
   settingsEmptyStateTitleClassName,
   settingsModalClassName,
-  settingsPanelClassName,
 } from "./settingsPageStyles";
 
 const INTEGRATION_SURVEY_NAME = "Integration Survey";
+
+const NAVIGATION_KEYS = ["ArrowDown", "ArrowUp", "Home", "End"];
+
+function filterCountLabel(matching: number, total: number, isFiltering: boolean): string {
+  return isFiltering ? `${matching} of ${total} integrations` : `${total} integrations`;
+}
 
 interface IntegrationsProps {
   organizationId: string;
@@ -50,6 +57,9 @@ export function Integrations({ organizationId }: IntegrationsProps) {
   const [configuration, setConfiguration] = useState<Record<string, unknown>>({});
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
+  // The highlight is a keyboard affordance only: it appears while filtering or
+  // once the arrow keys are used, and never follows the pointer.
+  const [highlightVisible, setHighlightVisible] = useState(false);
   const [isIntegrationSurveyActive, setIsIntegrationSurveyActive] = useState(false);
   const canCreateIntegrations = canAct("integrations", "create");
   const canUpdateIntegrations = canAct("integrations", "update");
@@ -170,41 +180,125 @@ export function Integrations({ organizationId }: IntegrationsProps) {
     });
   }, [filterQuery, integrationCatalog]);
 
+  // Connected providers are shown in their own section above the rest. The
+  // flattened order is what the arrow keys walk, so the highlight moves through
+  // both sections as one list.
+  const { connectedItems, availableItems, orderedItems } = useMemo(() => {
+    const connected = filteredIntegrationCatalog.filter((item) => item.instances.length > 0);
+    const available = filteredIntegrationCatalog.filter((item) => item.instances.length === 0);
+    return { connectedItems: connected, availableItems: available, orderedItems: [...connected, ...available] };
+  }, [filteredIntegrationCatalog]);
+
   const selectedInstructions = useMemo(() => {
     return selectedIntegration?.instructions?.trim() ?? "";
   }, [selectedIntegration?.instructions]);
 
-  const getNextIntegrationName = (baseName?: string) => {
-    const normalizedBaseName = baseName?.trim() || "integration";
-    if (!integrationNames.has(normalizedBaseName)) {
-      return normalizedBaseName;
-    }
+  const getNextIntegrationName = useCallback(
+    (baseName?: string) => {
+      const normalizedBaseName = baseName?.trim() || "integration";
+      if (!integrationNames.has(normalizedBaseName)) {
+        return normalizedBaseName;
+      }
 
-    let suffix = 2;
-    let candidate = `${normalizedBaseName}-${suffix}`;
-    while (integrationNames.has(candidate)) {
-      suffix += 1;
-      candidate = `${normalizedBaseName}-${suffix}`;
-    }
+      let suffix = 2;
+      let candidate = `${normalizedBaseName}-${suffix}`;
+      while (integrationNames.has(candidate)) {
+        suffix += 1;
+        candidate = `${normalizedBaseName}-${suffix}`;
+      }
 
-    return candidate;
-  };
+      return candidate;
+    },
+    [integrationNames],
+  );
 
-  const handleConnectClick = (integration: IntegrationsIntegrationDefinition) => {
-    if (!canCreateIntegrations) return;
+  const handleConnectClick = useCallback(
+    (integration: IntegrationsIntegrationDefinition) => {
+      if (!canCreateIntegrations) return;
 
-    if (isCapabilityBasedIntegrationDefinition(integration)) {
-      if (!integration.name) return;
-      analytics.integrationConnectStart(integration.name, "integrations_page", organizationId);
-      navigate(`/${organizationId}/settings/integrations/${integration.name}/setup`);
+      if (isCapabilityBasedIntegrationDefinition(integration)) {
+        if (!integration.name) return;
+        analytics.integrationConnectStart(integration.name, "integrations_page", organizationId);
+        navigate(`/${organizationId}/settings/integrations/${integration.name}/setup`);
+        return;
+      }
+
+      setSelectedIntegration(integration);
+      setIntegrationName(getNextIntegrationName(integration.name));
+      setConfiguration({});
+      setIsModalOpen(true);
+      analytics.integrationConnectStart(integration.name ?? "", "integrations_page", organizationId);
+    },
+    [canCreateIntegrations, getNextIntegrationName, navigate, organizationId],
+  );
+
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const rowRefs = useRef<Array<HTMLLIElement | null>>([]);
+
+  const handleActivateRow = useCallback(
+    (index: number) => {
+      // Never act on a highlight the user cannot see.
+      if (!highlightVisible) return;
+      const integrationDef = orderedItems[index]?.integrationDef;
+      if (!integrationDef) return;
+      handleConnectClick(integrationDef);
+    },
+    [handleConnectClick, highlightVisible, orderedItems],
+  );
+
+  const { activeIndex, setActiveIndex, handleKeyDown } = useListKeyboardNavigation({
+    itemCount: orderedItems.length,
+    onActivate: handleActivateRow,
+  });
+
+  // Keep the highlighted row on screen while arrowing through a long catalog.
+  useEffect(() => {
+    if (!highlightVisible || activeIndex < 0) return;
+    rowRefs.current[activeIndex]?.scrollIntoView?.({ block: "nearest" });
+  }, [activeIndex, highlightVisible]);
+
+  // `/` jumps to the filter, matching the convention used across the app. The
+  // global command palette owns the modified variants, so ignore those here.
+  useEffect(() => {
+    const focusFilter = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "/" || event.metaKey || event.ctrlKey || event.altKey) return;
+
+      const target = event.target as HTMLElement | null;
+      const tagName = target?.tagName;
+      if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT" || target?.isContentEditable) {
+        return;
+      }
+
+      event.preventDefault();
+      searchInputRef.current?.focus();
+    };
+
+    document.addEventListener("keydown", focusFilter);
+    return () => document.removeEventListener("keydown", focusFilter);
+  }, []);
+
+  const handleFilterKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      if (filterQuery.length === 0) {
+        searchInputRef.current?.blur();
+        return;
+      }
+      event.preventDefault();
+      setFilterQuery("");
+      setActiveIndex(0);
+      setHighlightVisible(false);
       return;
     }
 
-    setSelectedIntegration(integration);
-    setIntegrationName(getNextIntegrationName(integration.name));
-    setConfiguration({});
-    setIsModalOpen(true);
-    analytics.integrationConnectStart(integration.name ?? "", "integrations_page", organizationId);
+    // The first arrow press reveals the highlight where it already sits rather
+    // than skipping the top result.
+    if (!highlightVisible && NAVIGATION_KEYS.includes(event.key)) {
+      event.preventDefault();
+      setHighlightVisible(true);
+      return;
+    }
+
+    handleKeyDown(event);
   };
   const handleConnect = async () => {
     if (!canCreateIntegrations) return;
@@ -242,6 +336,23 @@ export function Integrations({ organizationId }: IntegrationsProps) {
     createIntegrationMutation.reset();
   };
 
+  const handleConfigureClick = useCallback(
+    (integration: OrganizationsIntegration) => {
+      const providerName = integration.metadata?.integrationName;
+      if (providerName && integration.status?.setupState?.currentStep) {
+        navigate(`/${organizationId}/settings/integrations/${providerName}/setup`, {
+          state: { integrationId: integration.metadata?.id },
+        });
+        return;
+      }
+
+      navigate(`/${organizationId}/settings/integrations/${integration.metadata?.id}`, {
+        state: { tab: "configuration" },
+      });
+    },
+    [navigate, organizationId],
+  );
+
   const createIntegrationNotice = createIntegrationMutation.isError
     ? getUsageLimitNotice(createIntegrationMutation.error, organizationId)
     : null;
@@ -258,19 +369,32 @@ export function Integrations({ organizationId }: IntegrationsProps) {
 
   return (
     <div className="pt-6">
-      <div className="relative mb-4">
+      <div className="relative mb-2">
         <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400" />
         <Input
+          ref={searchInputRef}
           type="text"
           value={filterQuery}
-          onChange={(e) => setFilterQuery(e.target.value)}
+          onChange={(e) => {
+            setFilterQuery(e.target.value);
+            setActiveIndex(0);
+            setHighlightVisible(e.target.value.trim().length > 0);
+          }}
+          onKeyDown={handleFilterKeyDown}
           placeholder="Filter integrations..."
           className="pl-9 pr-9"
+          autoFocus
+          aria-describedby="integration-filter-count"
         />
         {filterQuery.length > 0 ? (
           <button
             type="button"
-            onClick={() => setFilterQuery("")}
+            onClick={() => {
+              setFilterQuery("");
+              setActiveIndex(0);
+              setHighlightVisible(false);
+              searchInputRef.current?.focus();
+            }}
             className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
             aria-label="Clear filter"
           >
@@ -278,6 +402,18 @@ export function Integrations({ organizationId }: IntegrationsProps) {
           </button>
         ) : null}
       </div>
+      <p
+        id="integration-filter-count"
+        role="status"
+        aria-live="polite"
+        className="mb-4 text-xs text-gray-500 dark:text-gray-400"
+      >
+        {filterCountLabel(orderedItems.length, integrationCatalog.length, filterQuery.trim().length > 0)}
+        <span className="sr-only">
+          {" "}
+          Use the arrow keys to move between integrations and press Enter to connect the highlighted one.
+        </span>
+      </p>
       {filteredIntegrationCatalog.length === 0 ? (
         <div className="py-12 text-center">
           <Plug className={cn("mx-auto mb-2 h-6 w-6", settingsEmptyStateIconClassName)} />
@@ -298,128 +434,46 @@ export function Integrations({ organizationId }: IntegrationsProps) {
           ) : null}
         </div>
       ) : (
-        <div className="space-y-4">
-          {filteredIntegrationCatalog.map((item) => {
-            const connectedCount = item.instances.length;
-
-            return (
-              <div key={item.providerName} className={settingsPanelClassName}>
-                <div className="p-4 flex items-start justify-between gap-4">
-                  <div className="flex items-start gap-3">
-                    <div className="mt-0.5 flex h-8 w-8 items-center justify-center">
-                      <IntegrationIcon
-                        integrationName={item.providerName}
-                        iconSlug={item.integrationDef?.icon}
-                        className="w-8 h-8 text-gray-500 dark:text-gray-400"
-                      />
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100">{item.providerLabel}</h3>
-                      {item.integrationDef?.description ? (
-                        <p className="mt-0.5 text-sm text-gray-800 dark:text-gray-400">
-                          {item.integrationDef?.description}
-                        </p>
-                      ) : null}
-                    </div>
-                  </div>
-                  <PermissionTooltip
-                    allowed={Boolean(item.integrationDef) && (canCreateIntegrations || permissionsLoading)}
-                    message={
-                      item.integrationDef
-                        ? "You don't have permission to connect integrations."
-                        : "This integration provider is no longer available for new connections."
-                    }
-                  >
-                    <Button
-                      variant="default"
-                      size="sm"
-                      onClick={() => {
-                        if (!item.integrationDef) return;
-                        handleConnectClick(item.integrationDef);
-                      }}
-                      className="self-start"
-                      disabled={!item.integrationDef || !canCreateIntegrations}
-                    >
-                      {item.integrationDef ? "Connect" : "Unavailable"}
-                    </Button>
-                  </PermissionTooltip>
+        <div className="space-y-8">
+          {[
+            { title: "Connected", items: connectedItems, offset: 0 },
+            { title: "Available", items: availableItems, offset: connectedItems.length },
+          ]
+            .filter((section) => section.items.length > 0)
+            .map((section) => (
+              <section key={section.title} aria-label={`${section.title} (${section.items.length})`}>
+                <div className="mb-3 flex items-center gap-3">
+                  <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    {section.title}
+                  </h2>
+                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700/50 dark:text-gray-300">
+                    {section.items.length}
+                  </span>
+                  <div className="h-px flex-1 bg-gray-200 dark:bg-gray-700/70" />
                 </div>
-                {item.instances.length > 0 ? (
-                  <div className="pr-4 pb-4 pl-[60px]">
-                    <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-                      {connectedCount} connected instance{connectedCount === 1 ? "" : "s"}
-                    </p>
-                    {item.instances.map((integration, index) => {
-                      const integrationDisplayName = integration.metadata?.name;
-                      const statusLabel = integration.status?.state
-                        ? integration.status.state.charAt(0).toUpperCase() + integration.status.state.slice(1)
-                        : "Unknown";
+                <ul className="space-y-4">
+                  {section.items.map((item, indexInSection) => {
+                    const flatIndex = section.offset + indexInSection;
 
-                      return (
-                        <div
-                          key={integration.metadata?.id}
-                          className={`flex items-center gap-2 py-1.5 border-t border-gray-200 dark:border-gray-700/70 ${index === 0 ? "mt-1" : ""}`}
-                        >
-                          <Plug
-                            className={`w-4 h-4 shrink-0 ${
-                              integration.status?.state === "ready"
-                                ? "text-green-500"
-                                : integration.status?.state === "error"
-                                  ? "text-red-500"
-                                  : "text-amber-600"
-                            }`}
-                          />
-                          <span
-                            className={cn(
-                              "inline-flex w-16 items-center justify-start rounded text-xs font-medium",
-                              integration.status?.state === "ready"
-                                ? "bg-white text-green-500 dark:bg-green-300 dark:text-green-950"
-                                : integration.status?.state === "error"
-                                  ? "bg-white text-red-500 dark:bg-red-300 dark:text-red-950"
-                                  : "bg-white text-amber-600 dark:bg-amber-300 dark:text-amber-950",
-                            )}
-                          >
-                            {statusLabel}
-                          </span>
-                          <p className="text-sm font-medium text-gray-800 dark:text-gray-100 truncate">
-                            {integrationDisplayName}
-                          </p>
-                          <div className="ml-auto flex items-center gap-4">
-                            <PermissionTooltip
-                              allowed={canUpdateIntegrations || permissionsLoading}
-                              message="You don't have permission to update integrations."
-                            >
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => {
-                                  if (!canUpdateIntegrations) return;
-                                  const providerName = integration.metadata?.integrationName;
-                                  if (providerName && integration.status?.setupState?.currentStep) {
-                                    navigate(`/${organizationId}/settings/integrations/${providerName}/setup`, {
-                                      state: { integrationId: integration.metadata?.id },
-                                    });
-                                    return;
-                                  }
-
-                                  navigate(`/${organizationId}/settings/integrations/${integration.metadata?.id}`, {
-                                    state: { tab: "configuration" },
-                                  });
-                                }}
-                                disabled={!canUpdateIntegrations}
-                              >
-                                Configure
-                              </Button>
-                            </PermissionTooltip>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ) : null}
-              </div>
-            );
-          })}
+                    return (
+                      <IntegrationCatalogRow
+                        key={item.providerName}
+                        entry={item}
+                        isActive={highlightVisible && flatIndex === activeIndex}
+                        canCreateIntegrations={canCreateIntegrations}
+                        canUpdateIntegrations={canUpdateIntegrations}
+                        permissionsLoading={permissionsLoading}
+                        onConnect={handleConnectClick}
+                        onConfigure={handleConfigureClick}
+                        rowRef={(node) => {
+                          rowRefs.current[flatIndex] = node;
+                        }}
+                      />
+                    );
+                  })}
+                </ul>
+              </section>
+            ))}
           {isIntegrationSurveyActive ? (
             <p className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
               Can't find your integration?{" "}
@@ -434,7 +488,6 @@ export function Integrations({ organizationId }: IntegrationsProps) {
           ) : null}
         </div>
       )}
-
       {/* Connect Modal */}
       {isModalOpen &&
         selectedIntegration &&


### PR DESCRIPTION
## What changed

The organization **Settings → Integrations** list is now navigable entirely from the keyboard, and connected providers are visually separated from the rest.

- **Keyboard navigation** — the filter input autofocuses, `/` refocuses it from anywhere on the page, arrow keys move a highlight through the results, and <kbd>Enter</kbd> connects the highlighted provider. <kbd>Esc</kbd> clears the filter.
- **Connected / Available split** — the catalog is grouped into two labelled sections with counts, instead of one flat list.
- **Status badge** — the per-instance status indicator was restyled and de-duplicated.

## Why

The page renders all 48 integration providers as a flat list of cards. Two problems follow from that:

1. **It is impractical to use from the keyboard.** Every card has a Connect button, and every connected instance adds a Configure button, so reaching the last provider takes 50+ <kbd>Tab</kbd> presses. The only filter affordance was a plain text input with no shortcut and no autofocus.
2. **It is hard to scan.** Connected providers were sorted to the top but had no visual boundary, so there was nothing to distinguish "the 3 things I use" from "the 45 things I don't".

The list markup also had no list semantics (nested `div`s) and gave no feedback about how many results a filter matched.

Separately, the connected-instance status indicator showed the same information twice — a coloured plug icon *and* a status pill — and the pill used `bg-white` at a fixed `w-16` with left-aligned text, which rendered as a white box with dead space inside it, sitting on a grey card.

## How

**`useListKeyboardNavigation`** (new hook, `web_src/src/hooks/`) drives a highlighted index from a search input: arrow keys with wraparound, Home/End, Enter to activate, and clamping when the list shrinks under the cursor. It ignores events carrying a modifier so the global command palette keeps `Cmd+/` and `Cmd+K`.

The highlight is deliberately **keyboard-only** — it never follows the pointer. It appears while filtering or once the arrow keys are used, and the first arrow press reveals it in place rather than skipping the top result.

**`IntegrationCatalogRow`** (new component) was extracted out of the page so the row markup and its connected-instance list live on their own. The status indicator now uses the shared `Badge` primitive with a small colour dot, sized to its content, with light/dark tones for ready / error / pending.

Both sections are walked by the arrow keys as one continuous list, so the highlight moves from the last connected provider into the first available one.

Accessibility: rows are a real `<ul>`/`<li>`, sections are labelled `region`s, the highlighted row carries `aria-current`, and a `role="status"` live region announces "N of 48 integrations" as you filter.

## Demo

https://github.com/user-attachments/assets/27eb4e22-c25c-467f-b42b-80492bdce306

## Testing

30 new tests across three spec files:

| File | Covers |
| --- | --- |
| `useListKeyboardNavigation.spec.ts` | arrow/Home/End/Enter, wraparound, modifier passthrough, clamping, empty list |
| `Integrations.spec.tsx` | section split and counts, filtering, `/` shortcut, highlight visibility rules, Enter behaviour |
| `IntegrationCatalogRow.spec.tsx` | status labels for ready/error/pending/unknown, instance pluralisation, connect/configure actions |

```bash
make check.build.ui
docker compose -f docker-compose.dev.yml exec app bash -lc "cd web_src && npx vitest run"
```

The ESLint budget is unchanged — the extraction keeps this branch at 590/591, one under the existing baseline, so no `lint:baseline:update` was needed.

## Notes for reviewers

1. **Highlight uses `aria-current` rather than a full combobox/listbox pattern.** ARIA's `role="option"` should not wrap interactive children, and each row contains a Connect button plus a Configure button per connected instance. Rather than restructure the row to satisfy the pattern, the list keeps plain list semantics and the highlight is exposed via `aria-current` with a live-region count. Happy to revisit if you'd prefer the full pattern.

2. **Enter does nothing when no highlight is visible.** Otherwise pressing Enter on an unfiltered list would open the Connect modal for whatever row sat invisibly at index 0 — an action with no visible cause. There's a test pinning this.