### PR TITLE
feat: add Kubernetes lifecycle probes

### DIFF
--- a/pkg/public/middleware/logging.go
+++ b/pkg/public/middleware/logging.go
@@ -57,7 +57,7 @@ func LoggingMiddleware(logger *log.Logger) mux.MiddlewareFunc {
 					panic(recovered)
 				}
 
-				if shouldCaptureHTTPError(status) {
+				if shouldCaptureHTTPError(r.URL.Path, status) {
 					captureHTTPError(r, status)
 				}
 			}()
@@ -81,7 +81,7 @@ func captureHTTPPanic(r *http.Request, status int, recovered any) {
 	})
 }
 
-// shouldCaptureHTTPError reports whether a response status code represents a
+// shouldCaptureHTTPError reports whether a response represents a
 // server-side error worth forwarding to Sentry.
 //
 // We only capture true server errors (5xx) and deliberately skip status codes
@@ -94,8 +94,15 @@ func captureHTTPPanic(r *http.Request, status int, recovered any) {
 //     by clients hitting the wrong endpoint and should not create Sentry
 //     issues.
 //   - 505 HTTP Version Not Supported is likewise a client-caused mismatch.
-func shouldCaptureHTTPError(status int) bool {
+//   - /ready returns 503 when a required dependency is temporarily unavailable.
+//     Kubernetes acts on that signal, so reporting every probe failure to Sentry
+//     would create noise without identifying a new application defect.
+func shouldCaptureHTTPError(path string, status int) bool {
 	if status < http.StatusInternalServerError {
+		return false
+	}
+
+	if path == "/ready" {
 		return false
 	}
 

--- a/pkg/public/middleware/logging_test.go
+++ b/pkg/public/middleware/logging_test.go
@@ -9,28 +9,32 @@ import (
 
 func TestShouldCaptureHTTPError(t *testing.T) {
 	t.Run("captures real 5xx server errors", func(t *testing.T) {
-		assert.True(t, shouldCaptureHTTPError(http.StatusInternalServerError))
-		assert.True(t, shouldCaptureHTTPError(http.StatusBadGateway))
-		assert.True(t, shouldCaptureHTTPError(http.StatusServiceUnavailable))
-		assert.True(t, shouldCaptureHTTPError(http.StatusGatewayTimeout))
+		assert.True(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusInternalServerError))
+		assert.True(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusBadGateway))
+		assert.True(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusServiceUnavailable))
+		assert.True(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusGatewayTimeout))
 	})
 
 	t.Run("skips non-5xx responses", func(t *testing.T) {
-		assert.False(t, shouldCaptureHTTPError(http.StatusOK))
-		assert.False(t, shouldCaptureHTTPError(http.StatusNotFound))
-		assert.False(t, shouldCaptureHTTPError(http.StatusUnauthorized))
-		assert.False(t, shouldCaptureHTTPError(http.StatusTeapot))
-		assert.False(t, shouldCaptureHTTPError(499))
+		assert.False(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusOK))
+		assert.False(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusNotFound))
+		assert.False(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusUnauthorized))
+		assert.False(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusTeapot))
+		assert.False(t, shouldCaptureHTTPError("/api/v1/canvases", 499))
+	})
+
+	t.Run("skips expected readiness failures", func(t *testing.T) {
+		assert.False(t, shouldCaptureHTTPError("/ready", http.StatusServiceUnavailable))
 	})
 
 	t.Run("skips 501 Not Implemented", func(t *testing.T) {
 		// grpc-gateway responds with 501 when a route exists but the HTTP
 		// method has no mapping (e.g. POST /api/v1/triggers/start). That is a
 		// client-caused error, not a server bug, so we should not spam Sentry.
-		assert.False(t, shouldCaptureHTTPError(http.StatusNotImplemented))
+		assert.False(t, shouldCaptureHTTPError("/api/v1/triggers/start", http.StatusNotImplemented))
 	})
 
 	t.Run("skips 505 HTTP Version Not Supported", func(t *testing.T) {
-		assert.False(t, shouldCaptureHTTPError(http.StatusHTTPVersionNotSupported))
+		assert.False(t, shouldCaptureHTTPError("/api/v1/canvases", http.StatusHTTPVersionNotSupported))
 	})
 }

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -1170,13 +1169,18 @@ func checkDatabaseReadiness(ctx context.Context) error {
 }
 
 func newCachedReadinessCheck(check func(context.Context) error, cacheDuration time.Duration) func(context.Context) error {
-	var mutex sync.Mutex
+	checkToken := make(chan struct{}, 1)
+	checkToken <- struct{}{}
 	var checkedAt time.Time
 	var checkErr error
 
 	return func(ctx context.Context) error {
-		mutex.Lock()
-		defer mutex.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-checkToken:
+		}
+		defer func() { checkToken <- struct{}{} }()
 
 		if err := ctx.Err(); err != nil {
 			return err

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -71,6 +72,9 @@ const (
 
 	// The size of the stage execution outputs can be up to 4k
 	MaxExecutionOutputsSize = 4 * 1024
+
+	readinessCheckTimeout       = time.Second
+	readinessCheckCacheDuration = time.Second
 )
 
 var errUsageServiceUnavailable = errors.New("usage service unavailable")
@@ -93,6 +97,7 @@ type Server struct {
 	authHandler           *authentication.Handler
 	isDev                 bool
 	usageService          usage.Service
+	checkReadiness        func(context.Context) error
 }
 
 // WebsocketHub returns the websocket hub for this server
@@ -199,6 +204,7 @@ func NewServer(
 		encryptor:             encryptor,
 		jwt:                   jwtSigner,
 		usageService:          usageService,
+		checkReadiness:        newCachedReadinessCheck(checkDatabaseReadiness, readinessCheckCacheDuration),
 		oidcProvider:          oidcProvider,
 		registry:              registry,
 		authService:           authorizationService,
@@ -625,6 +631,7 @@ func (s *Server) InitRouter(additionalMiddlewares ...mux.MiddlewareFunc) {
 
 	// Health check
 	publicRoute.HandleFunc("/health", s.HealthCheck).Methods("GET")
+	publicRoute.HandleFunc("/ready", s.ReadinessCheck).Methods("GET")
 	publicRoute.HandleFunc("/api/v1/setup-owner", s.setupOwner).Methods("POST")
 
 	// OIDC discovery endpoints
@@ -1150,6 +1157,67 @@ func (s *Server) listAccountOrganizations(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) HealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func checkDatabaseReadiness(ctx context.Context) error {
+	sqlDB, err := database.DB(ctx).DB()
+	if err != nil {
+		return err
+	}
+
+	return sqlDB.PingContext(ctx)
+}
+
+func newCachedReadinessCheck(check func(context.Context) error, cacheDuration time.Duration) func(context.Context) error {
+	var mutex sync.Mutex
+	var checkedAt time.Time
+	var checkErr error
+
+	return func(ctx context.Context) error {
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if !checkedAt.IsZero() && time.Since(checkedAt) < cacheDuration {
+			return checkErr
+		}
+
+		// A readiness request may be canceled when its client disconnects. The
+		// shared dependency check must still finish so that one canceled client
+		// cannot poison the cached result for Kubernetes probes. Preserve the
+		// caller's values and deadline while detaching cancellation.
+		checkCtx := context.WithoutCancel(ctx)
+		if deadline, ok := ctx.Deadline(); ok {
+			var cancel context.CancelFunc
+			checkCtx, cancel = context.WithDeadline(checkCtx, deadline)
+			defer cancel()
+		}
+
+		checkErr = check(checkCtx)
+		checkedAt = time.Now()
+		return checkErr
+	}
+}
+
+func (s *Server) ReadinessCheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	if s.checkReadiness == nil {
+		http.Error(w, "Service unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), readinessCheckTimeout)
+	defer cancel()
+
+	if err := s.checkReadiness(ctx); err != nil {
+		http.Error(w, "Service unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -256,10 +256,17 @@ func Test__CachedReadinessCheck(t *testing.T) {
 			secondResult <- check(ctx)
 		}()
 		cancel()
+
+		select {
+		case err := <-secondResult:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(250 * time.Millisecond):
+			t.Fatal("canceled readiness waiter did not return while a check was active")
+		}
+
 		close(release)
 
 		require.NoError(t, <-firstResult)
-		require.ErrorIs(t, <-secondResult, context.Canceled)
 		require.EqualValues(t, 1, calls.Load())
 	})
 

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -109,6 +110,190 @@ func Test__HealthCheckEndpoint(t *testing.T) {
 	})
 
 	require.Equal(t, 200, response.Code)
+}
+
+func Test__ReadinessCheckEndpoint(t *testing.T) {
+	authService, err := authorization.NewAuthService()
+	require.NoError(t, err)
+
+	registry, err := registry.NewRegistry(&crypto.NoOpEncryptor{}, registry.HTTPOptions{})
+	require.NoError(t, err)
+	signer := jwt.NewSigner("test")
+	oidcProvider := support.NewOIDCProvider()
+	gitProvider := inmemory.NewProvider()
+	server, err := NewServer(&crypto.NoOpEncryptor{}, registry, signer, oidcProvider, gitProvider, "", "", "", "test", "/app/templates", authService, nil, false)
+	require.NoError(t, err)
+
+	t.Run("returns OK when PostgreSQL is reachable", func(t *testing.T) {
+		server.checkReadiness = func(ctx context.Context) error {
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok, "readiness checks must be bounded")
+			require.LessOrEqual(t, time.Until(deadline), time.Second)
+			return nil
+		}
+
+		response := execRequest(server, requestParams{
+			method: http.MethodGet,
+			path:   "/ready",
+		})
+
+		require.Equal(t, http.StatusOK, response.Code)
+		require.Equal(t, "no-store", response.Header().Get("Cache-Control"))
+		require.Empty(t, response.Body.String())
+	})
+
+	t.Run("returns a generic unavailable response when PostgreSQL is unreachable", func(t *testing.T) {
+		server.checkReadiness = func(context.Context) error {
+			return errors.New("dial postgres://admin:secret@database")
+		}
+
+		response := execRequest(server, requestParams{
+			method: http.MethodGet,
+			path:   "/ready",
+		})
+
+		require.Equal(t, http.StatusServiceUnavailable, response.Code)
+		require.Equal(t, "no-store", response.Header().Get("Cache-Control"))
+		require.Equal(t, "Service unavailable\n", response.Body.String())
+		require.NotContains(t, response.Body.String(), "admin")
+		require.NotContains(t, response.Body.String(), "secret")
+	})
+
+	t.Run("keeps liveness independent from PostgreSQL", func(t *testing.T) {
+		server.checkReadiness = func(context.Context) error {
+			return errors.New("database unavailable")
+		}
+
+		response := execRequest(server, requestParams{
+			method: http.MethodGet,
+			path:   "/health",
+		})
+
+		require.Equal(t, http.StatusOK, response.Code)
+	})
+
+	t.Run("fails closed when the readiness checker is unavailable", func(t *testing.T) {
+		server.checkReadiness = nil
+
+		response := execRequest(server, requestParams{
+			method: http.MethodGet,
+			path:   "/ready",
+		})
+
+		require.Equal(t, http.StatusServiceUnavailable, response.Code)
+		require.Equal(t, "no-store", response.Header().Get("Cache-Control"))
+		require.Equal(t, "Service unavailable\n", response.Body.String())
+	})
+}
+
+func Test__CachedReadinessCheck(t *testing.T) {
+	t.Run("coalesces concurrent checks and caches the result", func(t *testing.T) {
+		expectedErr := errors.New("database unavailable")
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var calls atomic.Int32
+
+		check := newCachedReadinessCheck(func(ctx context.Context) error {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+
+			select {
+			case <-release:
+				return expectedErr
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}, time.Second)
+
+		const callers = 32
+		results := make(chan error, callers)
+		for i := 0; i < callers; i++ {
+			go func() {
+				results <- check(context.Background())
+			}()
+		}
+
+		<-started
+		close(release)
+
+		for i := 0; i < callers; i++ {
+			require.ErrorIs(t, <-results, expectedErr)
+		}
+		require.EqualValues(t, 1, calls.Load())
+
+		require.ErrorIs(t, check(context.Background()), expectedErr)
+		require.EqualValues(t, 1, calls.Load())
+	})
+
+	t.Run("does not return a cached result to a canceled caller", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		firstResult := make(chan error, 1)
+		secondResult := make(chan error, 1)
+		var calls atomic.Int32
+
+		check := newCachedReadinessCheck(func(ctx context.Context) error {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}, time.Second)
+
+		go func() {
+			firstResult <- check(context.Background())
+		}()
+		<-started
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			secondResult <- check(ctx)
+		}()
+		cancel()
+		close(release)
+
+		require.NoError(t, <-firstResult)
+		require.ErrorIs(t, <-secondResult, context.Canceled)
+		require.EqualValues(t, 1, calls.Load())
+	})
+
+	t.Run("does not cache a leading caller cancellation", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		firstResult := make(chan error, 1)
+		var calls atomic.Int32
+
+		check := newCachedReadinessCheck(func(ctx context.Context) error {
+			calls.Add(1)
+			close(started)
+
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}, time.Second)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		go func() {
+			firstResult <- check(ctx)
+		}()
+		<-started
+
+		cancel()
+		close(release)
+
+		require.NoError(t, <-firstResult)
+		require.NoError(t, check(context.Background()))
+		require.EqualValues(t, 1, calls.Load())
+	})
 }
 
 func Test__OpenAPIEndpoints(t *testing.T) {

--- a/release/superplane-helm-chart/helm/README.md
+++ b/release/superplane-helm-chart/helm/README.md
@@ -1,0 +1,16 @@
+# SuperPlane Helm chart
+
+## API health endpoints
+
+The API exposes two unauthenticated, minimal health endpoints for cluster probes:
+
+| Endpoint | Contract | Helm consumers |
+| --- | --- | --- |
+| `GET /health` | Process liveness. Returns `200` while the HTTP server can respond and does not check external dependencies. | Startup and liveness probes |
+| `GET /ready` | Traffic readiness. Returns `200` when PostgreSQL responds within one second, otherwise a generic `503`. Concurrent checks are coalesced and the result is reused per API process for one second. | Readiness probe and GCE/ALB backend health checks |
+
+Readiness responses use `Cache-Control: no-store` and never include database errors or connection details. Internal one-second result reuse bounds probe traffic to at most one PostgreSQL ping per API process per second; it can delay a readiness transition by at most that same interval.
+
+The startup probe allows up to 22.5 minutes for the API to start before Kubernetes applies liveness and readiness probes. This covers the entrypoint's two separate migration-lock waits of up to ten minutes each, leaving 2.5 minutes of headroom for migrations and server startup. During a PostgreSQL outage, `/health` stays healthy so Kubernetes does not restart a live process, while `/ready` removes the pod from service traffic. The pod becomes ready again automatically after PostgreSQL recovers.
+
+RabbitMQ, SuperGit, and external integrations are intentionally not part of API readiness so their outages do not remove partially functional API capacity. Requests that depend on an unavailable service can still fail and should be covered by dependency-specific monitoring; those dependencies are not pod-admission signals.

--- a/release/superplane-helm-chart/helm/templates/api.yaml
+++ b/release/superplane-helm-chart/helm/templates/api.yaml
@@ -138,18 +138,27 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
             periodSeconds: 10
             timeoutSeconds: 2
             failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /
+              path: /ready
               port: http
             periodSeconds: 10
             timeoutSeconds: 2
             failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+            # docker-entrypoint.sh acquires separate migration locks for schema
+            # and data migrations. Cover both ten-minute waits plus headroom.
+            failureThreshold: 270
           securityContext:
             privileged: false
             readOnlyRootFilesystem: true

--- a/release/superplane-helm-chart/helm/templates/ingress.yaml
+++ b/release/superplane-helm-chart/helm/templates/ingress.yaml
@@ -39,6 +39,7 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: {{ $ssl.alb.certName | required "ingress.ssl.alb.certName is required when ingress.className is 'alb'." }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/healthcheck-path: /ready
     {{- end }}
 spec:
 {{- if ne $className "gce" }}
@@ -104,6 +105,6 @@ spec:
     timeoutSec: 10
     port: 8000
     type: HTTP
-    requestPath: /health
+    requestPath: /ready
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What changed

- Add a dependency-aware `GET /ready` endpoint while keeping `GET /health` as process liveness.
- Bound PostgreSQL readiness checks to one second, coalesce concurrent checks, and reuse each result for one second per API process.
- Return only a generic `503 Service unavailable` response with `Cache-Control: no-store` when readiness fails.
- Configure Helm startup, liveness, readiness, GCE BackendConfig, and AWS ALB health checks with the correct endpoint for each lifecycle signal.
- Document the health contracts, startup budget, and intentionally excluded dependencies in the Helm chart.

## Why

The chart previously probed `/` for both liveness and readiness. That does not distinguish a live API process from one that should temporarily stop receiving traffic because PostgreSQL is unavailable. It can also cause restarts during recoverable dependency outages.

This change gives Kubernetes and supported ingress controllers explicit, minimal lifecycle signals while avoiding restart loops and probe-driven database amplification.

Fixes #5980.

## How

- `/health` remains dependency-independent and is used for startup and liveness.
- `/ready` verifies PostgreSQL with a bounded check and is used for pod and ingress traffic readiness.
- A one-second in-process cache and request coalescing cap readiness traffic at one PostgreSQL ping per API process per second.
- Canceled waiters return immediately through their request context while the shared check finishes; leading-client cancellation cannot poison the cache, and the caller deadline is still preserved.
- Expected `/ready` failures are excluded from Sentry noise without suppressing other `503` responses.
- The startup probe allows 22.5 minutes because the entrypoint can wait on two separate ten-minute migration locks, plus startup headroom.

## Validation

- `make check.format.go lint check.build.app`
- `make test` — 10,675 tests; 1 skipped; command passed
- Focused readiness concurrency/cancellation tests repeated 100 times
- Helm 3.21 lint and rendered-manifest checks for default, GCE, AWS ALB, and no-ingress configurations
- Three-node Kind installation with two API replicas spread across both workers:
  - healthy PostgreSQL: `/health` 200, `/ready` 200, both endpoints ready
  - PostgreSQL outage: `/health` 200, `/ready` generic 503, both endpoints removed, zero API restarts
  - PostgreSQL recovery: both original pods became ready again, zero API restarts
- Security-focused review verified bounded/coalesced database checks, generic failure responses, cancellation handling, and exact-path Sentry suppression

The Kind proof validates the installed chart locally. Provider-specific EKS/ALB and GKE/GCE behavior still depends on their controllers and was validated by manifest rendering rather than a live cloud rollout.

## Breaking changes

None.
