### PR TITLE
fix: encode Helm database name in Secret

### DIFF
--- a/release/superplane-helm-chart/helm/templates/database.yaml
+++ b/release/superplane-helm-chart/helm/templates/database.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "secrets.database.name" . }}
   namespace: "{{ .Release.Namespace }}"
 data:
-  DB_NAME: superplane
+  DB_NAME: {{ "superplane" | b64enc }}
   DB_HOST: {{ .Values.database.host | b64enc }}
   DB_PORT: {{ .Values.database.port | toString | b64enc }}
   DB_USERNAME: {{ .Values.database.username | b64enc }}


### PR DESCRIPTION
## What changed

Base64-encode the built-in `DB_NAME` value emitted under the Helm chart's Kubernetes `Secret.data` field.

## Why

Kubernetes requires every value under `Secret.data` to be base64-encoded. The chart rendered `DB_NAME: superplane`, so an installation that lets the chart create its database Secret was rejected by the API server with:

```text
Secret in version "v1" cannot be handled as a Secret: illegal base64 data at input byte 8
```

Installations that provide `database.secretName` are unaffected because the chart does not create this Secret in that configuration.

Related to #5983.

## How

Use Helm's existing `b64enc` pattern for `DB_NAME`, matching the other fields in the same Secret. The decoded runtime value remains exactly `superplane`.

## Validation

- Reproduced the API-server rejection from the unmodified rendered chart
- Helm 3.21 lint passed
- Rendered Secret passed Kubernetes server-side dry-run
- Applied the Secret to a local Kind cluster and decoded `DB_NAME` back to `superplane`
- Full no-ingress chart render passed Kubernetes server-side dry-run
- Independent Kubernetes review approved the one-line compatibility and security scope

## Breaking changes

None.
