### PR TITLE
feat: Add GitHub Get File Content action

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -39,6 +39,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Create Review" href="#create-review" description="Submit a pull request review on GitHub" />
   <LinkCard title="Delete Release" href="#delete-release" description="Delete a release from a GitHub repository" />
   <LinkCard title="Get Combined Commit Status" href="#get-combined-commit-status" description="Get the combined GitHub commit status for a commit, branch, or tag" />
+  <LinkCard title="Get File Content" href="#get-file-content" description="Read a file from a GitHub repository" />
   <LinkCard title="Get Issue" href="#get-issue" description="Get a GitHub issue by number" />
   <LinkCard title="Get Release" href="#get-release" description="Get a release from a GitHub repository" />
   <LinkCard title="Get Repository Permission" href="#get-repository-permission" description="Get the role and permission level for a user on a GitHub repository" />
@@ -3183,6 +3184,53 @@ Emits a combined commit status object on the default output channel. The payload
   },
   "timestamp": "2026-01-16T17:56:16.680755501Z",
   "type": "github.combinedCommitStatus"
+}
+```
+
+<a id="get-file-content"></a>
+
+## Get File Content
+
+**Component key:** `github.getFileContent`
+
+The Get File Content component reads a file from a GitHub repository without cloning the repository.
+
+### Use Cases
+
+- **Configuration checks**: Read configuration files before making workflow decisions
+- **Documentation automation**: Retrieve README files or other text documents
+- **Repository comparisons**: Read files from branches, tags, or commits for comparison steps
+- **Agent context**: Provide small repository files to downstream agents or actions
+
+### Configuration
+
+- **Repository**: Select the GitHub repository containing the file
+- **Path**: Path to the file from the repository root (supports expressions)
+- **Ref**: Optional branch name, tag, or commit SHA. When omitted, GitHub uses the repository's default branch.
+
+### Output
+
+Returns the decoded file content together with its name, path, SHA, size, URLs, and the requested ref.
+
+This component reads files only. Directory paths are rejected; use a path that points to a single file.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "content": "# Widget service\n\nConfiguration and deployment notes for the widget service.\n",
+    "download_url": "https://raw.githubusercontent.com/acme/widgets/main/docs/README.md",
+    "html_url": "https://github.com/acme/widgets/blob/main/docs/README.md",
+    "name": "README.md",
+    "path": "docs/README.md",
+    "ref": "main",
+    "sha": "4d4ba9968a4c7c80e25b715bd7522f2c4dc51f3f",
+    "size": 75,
+    "url": "https://api.github.com/repos/acme/widgets/contents/docs/README.md?ref=main"
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.fileContent"
 }
 ```
 

--- a/pkg/integrations/github/capability_mapper.go
+++ b/pkg/integrations/github/capability_mapper.go
@@ -86,6 +86,7 @@ func NewCapabilityMapper() *CapabilityMapper {
 			PermissionContents: {
 				PermissionScope: PermissionScopeRepository,
 				Capabilities: []CapabilityDef{
+					{ReadOnly: true, Action: &contents.GetFileContent{}},
 					{ReadOnly: true, Action: &contents.GetRelease{}},
 					{ReadOnly: true, Trigger: &contents.OnBranchCreated{}},
 					{ReadOnly: true, Trigger: &contents.OnPush{}},

--- a/pkg/integrations/github/capability_mapper_test.go
+++ b/pkg/integrations/github/capability_mapper_test.go
@@ -148,6 +148,14 @@ func Test__CapabilityMapper__NewPermissionSet(t *testing.T) {
 		assert.Equal(t, "read", got["statuses"])
 	})
 
+	t.Run("get file content action requests contents read permission", func(t *testing.T) {
+		t.Parallel()
+
+		ps := m.NewPermissionSet([]string{"github.getFileContent"})
+		got := ps.ForAppManifest()
+		assert.Equal(t, "read", got["contents"])
+	})
+
 	t.Run("check run trigger requests checks read permission", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -242,6 +242,11 @@ func (c *Client) GetCombinedStatus(ctx context.Context, repository string, ref s
 	return c.underlying.Repositories.GetCombinedStatus(ctx, owner, name, ref, opts)
 }
 
+func (c *Client) GetContents(ctx context.Context, repository string, path string, opts *github.RepositoryContentGetOptions) (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
+	owner, name := c.ownerAndName(repository)
+	return c.underlying.Repositories.GetContents(ctx, owner, name, path, opts)
+}
+
 func (c *Client) ListCheckRunsForRef(ctx context.Context, repository string, ref string, opts *github.ListCheckRunsOptions) (*github.ListCheckRunsResults, *github.Response, error) {
 	owner, name := c.ownerAndName(repository)
 	return c.underlying.Checks.ListCheckRunsForRef(ctx, owner, name, ref, opts)

--- a/pkg/integrations/github/components/contents/example.go
+++ b/pkg/integrations/github/components/contents/example.go
@@ -13,6 +13,9 @@ var exampleOutputCreateReleaseBytes []byte
 //go:embed payloads/get_release.json
 var exampleOutputGetReleaseBytes []byte
 
+//go:embed payloads/get_file_content.json
+var exampleOutputGetFileContentBytes []byte
+
 //go:embed payloads/update_release.json
 var exampleOutputUpdateReleaseBytes []byte
 
@@ -36,6 +39,9 @@ var exampleOutputCreateRelease map[string]any
 
 var exampleOutputGetReleaseOnce sync.Once
 var exampleOutputGetRelease map[string]any
+
+var exampleOutputGetFileContentOnce sync.Once
+var exampleOutputGetFileContent map[string]any
 
 var exampleOutputUpdateReleaseOnce sync.Once
 var exampleOutputUpdateRelease map[string]any
@@ -61,6 +67,10 @@ func (c *CreateRelease) ExampleOutput() map[string]any {
 
 func (c *GetRelease) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetReleaseOnce, exampleOutputGetReleaseBytes, &exampleOutputGetRelease)
+}
+
+func (c *GetFileContent) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetFileContentOnce, exampleOutputGetFileContentBytes, &exampleOutputGetFileContent)
 }
 
 func (c *UpdateRelease) ExampleOutput() map[string]any {

--- a/pkg/integrations/github/components/contents/get_file_content.go
+++ b/pkg/integrations/github/components/contents/get_file_content.go
@@ -1,0 +1,219 @@
+package contents
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+)
+
+type GetFileContent struct{}
+
+type GetFileContentConfiguration struct {
+	Repository string `json:"repository" mapstructure:"repository"`
+	Path       string `json:"path" mapstructure:"path"`
+	Ref        string `json:"ref,omitempty" mapstructure:"ref"`
+}
+
+type GetFileContentOutput struct {
+	Content     string `json:"content"`
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	SHA         string `json:"sha"`
+	Size        int    `json:"size"`
+	Ref         string `json:"ref,omitempty"`
+	URL         string `json:"url"`
+	HTMLURL     string `json:"html_url"`
+	DownloadURL string `json:"download_url"`
+}
+
+func (c *GetFileContent) Name() string {
+	return "github.getFileContent"
+}
+
+func (c *GetFileContent) Label() string {
+	return "Get File Content"
+}
+
+func (c *GetFileContent) Description() string {
+	return "Read a file from a GitHub repository"
+}
+
+func (c *GetFileContent) Documentation() string {
+	return `The Get File Content component reads a file from a GitHub repository without cloning the repository.
+
+## Use Cases
+
+- **Configuration checks**: Read configuration files before making workflow decisions
+- **Documentation automation**: Retrieve README files or other text documents
+- **Repository comparisons**: Read files from branches, tags, or commits for comparison steps
+- **Agent context**: Provide small repository files to downstream agents or actions
+
+## Configuration
+
+- **Repository**: Select the GitHub repository containing the file
+- **Path**: Path to the file from the repository root (supports expressions)
+- **Ref**: Optional branch name, tag, or commit SHA. When omitted, GitHub uses the repository's default branch.
+
+## Output
+
+Returns the decoded file content together with its name, path, SHA, size, URLs, and the requested ref.
+
+This component reads files only. Directory paths are rejected; use a path that points to a single file.`
+}
+
+func (c *GetFileContent) Icon() string {
+	return "github"
+}
+
+func (c *GetFileContent) Color() string {
+	return "gray"
+}
+
+func (c *GetFileContent) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetFileContent) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "path",
+			Label:       "File Path",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g., README.md or config/app.yaml",
+			Description: "Path to the file from the repository root",
+		},
+		{
+			Name:        "ref",
+			Label:       "Ref",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Placeholder: "e.g., main, v1.2.3, or a commit SHA",
+			Description: "Optional branch, tag, or commit SHA. Defaults to the repository's default branch.",
+		},
+	}
+}
+
+func (c *GetFileContent) Setup(ctx core.SetupContext) error {
+	var config GetFileContentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if err := validateGetFileContentConfiguration(config); err != nil {
+		return err
+	}
+
+	return common.EnsureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.HTTP,
+		ctx.Configuration,
+	)
+}
+
+func (c *GetFileContent) Execute(ctx core.ExecutionContext) error {
+	var config GetFileContentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if err := validateGetFileContentConfiguration(config); err != nil {
+		return err
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	file, directory, _, err := client.GetContents(
+		context.Background(),
+		config.Repository,
+		config.Path,
+		&github.RepositoryContentGetOptions{Ref: config.Ref},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get file content: %w", err)
+	}
+
+	if file == nil {
+		if directory != nil {
+			return fmt.Errorf("path %q points to a directory; expected a file", config.Path)
+		}
+		return fmt.Errorf("GitHub returned no file content for path %q", config.Path)
+	}
+
+	content, err := file.GetContent()
+	if err != nil {
+		return fmt.Errorf("failed to decode file content: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.fileContent",
+		[]any{GetFileContentOutput{
+			Content:     content,
+			Name:        file.GetName(),
+			Path:        file.GetPath(),
+			SHA:         file.GetSHA(),
+			Size:        file.GetSize(),
+			Ref:         config.Ref,
+			URL:         file.GetURL(),
+			HTMLURL:     file.GetHTMLURL(),
+			DownloadURL: file.GetDownloadURL(),
+		}},
+	)
+}
+
+func validateGetFileContentConfiguration(config GetFileContentConfiguration) error {
+	if config.Repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+	if config.Path == "" {
+		return fmt.Errorf("file path is required")
+	}
+	return nil
+}
+
+func (c *GetFileContent) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetFileContent) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *GetFileContent) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetFileContent) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetFileContent) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetFileContent) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/github/components/contents/get_file_content_test.go
+++ b/pkg/integrations/github/components/contents/get_file_content_test.go
@@ -1,0 +1,143 @@
+package contents
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
+)
+
+func Test__GetFileContent__Setup(t *testing.T) {
+	component := GetFileContent{}
+
+	t.Run("fails when configuration decode fails", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: "not a map"})
+
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+
+	t.Run("requires repository", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"path": "README.md"},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("requires file path", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"repository": "hello"},
+		})
+
+		require.ErrorContains(t, err, "file path is required")
+	})
+}
+
+func Test__GetFileContent__Execute(t *testing.T) {
+	component := GetFileContent{}
+
+	t.Run("fails when configuration decode fails", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration:  "not a map",
+		})
+
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+
+	t.Run("requires repository", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration:  map[string]any{"path": "README.md"},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("requires file path", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration:  map[string]any{"repository": "hello"},
+		})
+
+		require.ErrorContains(t, err, "file path is required")
+	})
+
+	t.Run("reads and emits decoded file content", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"type": "file",
+					"encoding": "base64",
+					"size": 14,
+					"name": "README.md",
+					"path": "docs/README.md",
+					"content": "SGVsbG8sIHdvcmxkIQo=",
+					"sha": "4d4ba9968a4c7c80e25b715bd7522f2c4dc51f3f",
+					"url": "https://api.github.com/repos/testhq/hello/contents/docs/README.md",
+					"html_url": "https://github.com/testhq/hello/blob/main/docs/README.md",
+					"download_url": "https://raw.githubusercontent.com/testhq/hello/main/docs/README.md"
+				}`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"path":       "docs/README.md",
+				"ref":        "main",
+			},
+		})
+
+		require.NoError(t, err)
+		require.True(t, executionState.Passed)
+		require.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		require.Equal(t, "github.fileContent", executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "/repos/testhq/hello/contents/docs/README.md", httpCtx.Requests[0].URL.Path)
+		assert.Equal(t, "main", httpCtx.Requests[0].URL.Query().Get("ref"))
+
+		payload := executionState.Payloads[0].(map[string]any)
+		output := payload["data"].(GetFileContentOutput)
+		assert.Equal(t, "Hello, world!\n", output.Content)
+		assert.Equal(t, "README.md", output.Name)
+		assert.Equal(t, "docs/README.md", output.Path)
+		assert.Equal(t, "4d4ba9968a4c7c80e25b715bd7522f2c4dc51f3f", output.SHA)
+		assert.Equal(t, 14, output.Size)
+		assert.Equal(t, "main", output.Ref)
+	})
+
+	t.Run("rejects directory paths", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `[
+					{"type":"file","name":"one.txt","path":"docs/one.txt","sha":"abc"}
+				]`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"path":       "docs",
+			},
+		})
+
+		require.ErrorContains(t, err, `path "docs" points to a directory; expected a file`)
+	})
+}

--- a/pkg/integrations/github/components/contents/payloads/get_file_content.json
+++ b/pkg/integrations/github/components/contents/payloads/get_file_content.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "content": "# Widget service\n\nConfiguration and deployment notes for the widget service.\n",
+    "name": "README.md",
+    "path": "docs/README.md",
+    "sha": "4d4ba9968a4c7c80e25b715bd7522f2c4dc51f3f",
+    "size": 75,
+    "ref": "main",
+    "url": "https://api.github.com/repos/acme/widgets/contents/docs/README.md?ref=main",
+    "html_url": "https://github.com/acme/widgets/blob/main/docs/README.md",
+    "download_url": "https://raw.githubusercontent.com/acme/widgets/main/docs/README.md"
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.fileContent"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -114,6 +114,7 @@ func (g *GitHub) Actions() []core.Action {
 		&checks.ListCheckRunsForRef{},
 		&actions.RunWorkflow{},
 		&contents.CreateRelease{},
+		&contents.GetFileContent{},
 		&contents.GetRelease{},
 		&contents.UpdateRelease{},
 		&contents.DeleteRelease{},


### PR DESCRIPTION
Implements #4274

## What changed

- Adds the `github.getFileContent` action for reading a single file without cloning the repository.
- Supports repository-relative paths and an optional branch, tag, or commit SHA ref.
- Decodes GitHub base64 content and emits the content with path, SHA, size, URL, HTML URL, download URL, and requested ref metadata.
- Rejects directory paths with a clear error.
- Registers the action with GitHub Contents read permission and generates component documentation with an example output.

## Why

Workflows that only need a small repository file currently have to start a runner or sandbox and clone the whole repository. This action provides a faster, lower-overhead path through the GitHub Contents API.

## Limitations

- This action reads one file at a time; directory listing is out of scope.
- GitHub Contents API file-size and encoding limits still apply.

## Verification

- `go test ./pkg/integrations/github/...`
- `go vet ./pkg/integrations/github/...`
- `go run scripts/check_example_payloads.go`
- `go run scripts/check_configuration_fields.go`
- `make gen.components.docs`

## Demo

The GitHub API request and decoded output are covered by the component unit test using a mocked Contents API response.