### PR TITLE
feat: improve GitHub integration and owner setup

### DIFF
--- a/pkg/integrations/github/capability_mapper.go
+++ b/pkg/integrations/github/capability_mapper.go
@@ -86,6 +86,7 @@ func NewCapabilityMapper() *CapabilityMapper {
 			PermissionContents: {
 				PermissionScope: PermissionScopeRepository,
 				Capabilities: []CapabilityDef{
+					{ReadOnly: true, Action: &contents.GetFileContent{}},
 					{ReadOnly: true, Action: &contents.GetRelease{}},
 					{ReadOnly: true, Trigger: &contents.OnBranchCreated{}},
 					{ReadOnly: true, Trigger: &contents.OnPush{}},

--- a/pkg/integrations/github/capability_mapper_test.go
+++ b/pkg/integrations/github/capability_mapper_test.go
@@ -100,6 +100,14 @@ func Test__CapabilityMapper__NewPermissionSet(t *testing.T) {
 		assert.Equal(t, uint8(0), ps.Repository[PermissionIssues])
 	})
 
+	t.Run("get file content requests contents read permission", func(t *testing.T) {
+		t.Parallel()
+
+		ps := m.NewPermissionSet([]string{"github.getFileContent"})
+		got := ps.ForAppManifest()
+		assert.Equal(t, "read", got["contents"])
+	})
+
 	t.Run("write capability wins over read for same GitHub permission", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -267,6 +267,11 @@ func (c *Client) GetRepositoryPermissionLevel(ctx context.Context, repository st
 	return c.underlying.Repositories.GetPermissionLevel(ctx, owner, name, username)
 }
 
+func (c *Client) GetContents(ctx context.Context, repository, path string, opts *github.RepositoryContentGetOptions) (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
+	owner, name := c.ownerAndName(repository)
+	return c.underlying.Repositories.GetContents(ctx, owner, name, path, opts)
+}
+
 func (c *Client) CancelWorkflowRun(repository string, workflowRunID int64) (*github.Response, error) {
 	owner, name := c.ownerAndName(repository)
 	return c.underlying.Actions.CancelWorkflowRunByID(context.Background(), owner, name, workflowRunID)

--- a/pkg/integrations/github/components/contents/example.go
+++ b/pkg/integrations/github/components/contents/example.go
@@ -13,6 +13,9 @@ var exampleOutputCreateReleaseBytes []byte
 //go:embed payloads/get_release.json
 var exampleOutputGetReleaseBytes []byte
 
+//go:embed payloads/get_file_content.json
+var exampleOutputGetFileContentBytes []byte
+
 //go:embed payloads/update_release.json
 var exampleOutputUpdateReleaseBytes []byte
 
@@ -36,6 +39,9 @@ var exampleOutputCreateRelease map[string]any
 
 var exampleOutputGetReleaseOnce sync.Once
 var exampleOutputGetRelease map[string]any
+
+var exampleOutputGetFileContentOnce sync.Once
+var exampleOutputGetFileContent map[string]any
 
 var exampleOutputUpdateReleaseOnce sync.Once
 var exampleOutputUpdateRelease map[string]any
@@ -61,6 +67,10 @@ func (c *CreateRelease) ExampleOutput() map[string]any {
 
 func (c *GetRelease) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetReleaseOnce, exampleOutputGetReleaseBytes, &exampleOutputGetRelease)
+}
+
+func (c *GetFileContent) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetFileContentOnce, exampleOutputGetFileContentBytes, &exampleOutputGetFileContent)
 }
 
 func (c *UpdateRelease) ExampleOutput() map[string]any {

--- a/pkg/integrations/github/components/contents/get_file_content.go
+++ b/pkg/integrations/github/components/contents/get_file_content.go
@@ -1,0 +1,219 @@
+package contents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+)
+
+type GetFileContent struct{}
+
+type GetFileContentConfiguration struct {
+	Repository string `mapstructure:"repository"`
+	Path       string `mapstructure:"path"`
+	Ref        string `mapstructure:"ref"`
+}
+
+type GetFileContentOutput struct {
+	Content string `json:"content"`
+	SHA     string `json:"sha"`
+	Path    string `json:"path"`
+	Ref     string `json:"ref"`
+}
+
+func (c *GetFileContent) Name() string {
+	return "github.getFileContent"
+}
+
+func (c *GetFileContent) Label() string {
+	return "Get File Content"
+}
+
+func (c *GetFileContent) Description() string {
+	return "Read a file from a GitHub repository"
+}
+
+func (c *GetFileContent) Documentation() string {
+	return `The Get File Content component reads a file from a GitHub repository.
+
+## Use Cases
+
+- **Configuration checks**: Read configuration before making a workflow decision
+- **File comparisons**: Compare repository content with generated or remote content
+- **Metadata extraction**: Read small source or documentation files without cloning a repository
+
+## Configuration
+
+- **Repository**: Select the GitHub repository
+- **Path**: Repository-relative path to the file
+- **Ref**: Optional branch, tag, or commit SHA. When omitted, GitHub uses the repository's default branch.
+
+## Output
+
+Returns the decoded file content together with its path, blob SHA, and the requested ref.`
+}
+
+func (c *GetFileContent) Icon() string {
+	return "github"
+}
+
+func (c *GetFileContent) Color() string {
+	return "gray"
+}
+
+func (c *GetFileContent) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetFileContent) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "path",
+			Label:       "File Path",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g. config/app.yaml",
+			Description: "Repository-relative path to the file. Supports template variables from previous steps.",
+		},
+		{
+			Name:        "ref",
+			Label:       "Ref",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Placeholder: "e.g. main, v1.0.0, or a commit SHA",
+			Description: "Optional branch, tag, or commit SHA. Defaults to the repository's default branch.",
+		},
+	}
+}
+
+func (c *GetFileContent) Setup(ctx core.SetupContext) error {
+	config, err := decodeGetFileContentConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	if err := validateGetFileContentConfiguration(config); err != nil {
+		return err
+	}
+
+	return common.EnsureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.HTTP,
+		ctx.Configuration,
+	)
+}
+
+func (c *GetFileContent) Execute(ctx core.ExecutionContext) error {
+	config, err := decodeGetFileContentConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	if err := validateGetFileContentConfiguration(config); err != nil {
+		return err
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	file, directory, _, err := client.GetContents(
+		context.Background(),
+		config.Repository,
+		config.Path,
+		&github.RepositoryContentGetOptions{Ref: config.Ref},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get file content: %w", err)
+	}
+
+	if file == nil && len(directory) > 0 {
+		return errors.New("path points to a directory, not a file")
+	}
+
+	if file == nil {
+		return errors.New("GitHub returned no file content")
+	}
+
+	content, err := file.GetContent()
+	if err != nil {
+		return fmt.Errorf("failed to decode file content: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.fileContent",
+		[]any{GetFileContentOutput{
+			Content: content,
+			SHA:     file.GetSHA(),
+			Path:    file.GetPath(),
+			Ref:     config.Ref,
+		}},
+	)
+}
+
+func decodeGetFileContentConfiguration(value any) (GetFileContentConfiguration, error) {
+	var config GetFileContentConfiguration
+	if err := mapstructure.Decode(value, &config); err != nil {
+		return config, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	return config, nil
+}
+
+func validateGetFileContentConfiguration(config GetFileContentConfiguration) error {
+	if config.Repository == "" {
+		return errors.New("repository is required")
+	}
+
+	if config.Path == "" {
+		return errors.New("path is required")
+	}
+
+	return nil
+}
+
+func (c *GetFileContent) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetFileContent) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *GetFileContent) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetFileContent) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetFileContent) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetFileContent) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/github/components/contents/get_file_content_test.go
+++ b/pkg/integrations/github/components/contents/get_file_content_test.go
@@ -1,0 +1,168 @@
+package contents
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
+)
+
+func Test__GetFileContent__Setup(t *testing.T) {
+	component := GetFileContent{}
+
+	t.Run("path is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "hello",
+				"path":       "",
+			},
+		})
+
+		require.ErrorContains(t, err, "path is required")
+	})
+
+	t.Run("stores repository metadata", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+		metadata := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Integration: mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:        httpCtx,
+			Metadata:    metadata,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"path":       "docs/guide.md",
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 1)
+	})
+}
+
+func Test__GetFileContent__Configuration(t *testing.T) {
+	fields := (&GetFileContent{}).Configuration()
+	require.Len(t, fields, 3)
+
+	assert.Equal(t, "repository", fields[0].Name)
+	assert.True(t, fields[0].Required)
+	assert.Equal(t, "path", fields[1].Name)
+	assert.True(t, fields[1].Required)
+	assert.Equal(t, "ref", fields[2].Name)
+	assert.False(t, fields[2].Required)
+}
+
+func Test__GetFileContent__Execute(t *testing.T) {
+	component := GetFileContent{}
+
+	t.Run("gets and decodes a file at a ref", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"type": "file",
+					"encoding": "base64",
+					"name": "guide.md",
+					"path": "docs/guide.md",
+					"sha": "abc123",
+					"content": "IyBHdWlkZQo="
+				}`),
+			},
+		}
+		executionState := &contexts.ExecutionStateContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"path":       "docs/guide.md",
+				"ref":        "feature/docs",
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
+		assert.Equal(t, "/repos/testhq/hello/contents/docs/guide.md", httpCtx.Requests[0].URL.Path)
+		assert.Equal(t, "feature/docs", httpCtx.Requests[0].URL.Query().Get("ref"))
+		assert.Equal(t, "github.fileContent", executionState.Type)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		output := payload["data"].(GetFileContentOutput)
+		assert.Equal(t, "# Guide\n", output.Content)
+		assert.Equal(t, "abc123", output.SHA)
+		assert.Equal(t, "docs/guide.md", output.Path)
+		assert.Equal(t, "feature/docs", output.Ref)
+	})
+
+	t.Run("rejects a directory", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `[
+					{"type": "file", "name": "guide.md", "path": "docs/guide.md", "sha": "abc123"}
+				]`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"path":       "docs",
+			},
+		})
+
+		require.ErrorContains(t, err, "path points to a directory")
+	})
+
+	t.Run("uses the default branch when ref is omitted", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"type": "file",
+					"encoding": "base64",
+					"path": "README.md",
+					"sha": "def456",
+					"content": "IyBTdXBlclBsYW5lCg=="
+				}`),
+			},
+		}
+		executionState := &contexts.ExecutionStateContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository": "hello",
+				"path":       "README.md",
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Empty(t, httpCtx.Requests[0].URL.Query().Get("ref"))
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		output := payload["data"].(GetFileContentOutput)
+		assert.Equal(t, "# SuperPlane\n", output.Content)
+		assert.Empty(t, output.Ref)
+	})
+}

--- a/pkg/integrations/github/components/contents/payloads/get_file_content.json
+++ b/pkg/integrations/github/components/contents/payloads/get_file_content.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "content": "# SuperPlane\n\nAutomate engineering workflows with durable execution.",
+    "sha": "9fceb02d0ae598e95dc970b74767f19372d61af8",
+    "path": "README.md",
+    "ref": "main"
+  },
+  "timestamp": "2026-08-01T12:00:00Z",
+  "type": "github.fileContent"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -101,9 +101,10 @@ func (g *GitHub) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
 			Name:        "organization",
-			Label:       "Organization",
+			Label:       "GitHub organization name",
 			Type:        configuration.FieldTypeString,
-			Description: "Organization to install the app into. If not specified, the app will be installed into the user's account.",
+			Description: "Name of the GitHub organization to install the app into. If left blank, the app will be installed into the user's account.",
+			Placeholder: "e.g. superplanehq",
 		},
 	}
 }
@@ -114,6 +115,7 @@ func (g *GitHub) Actions() []core.Action {
 		&checks.ListCheckRunsForRef{},
 		&actions.RunWorkflow{},
 		&contents.CreateRelease{},
+		&contents.GetFileContent{},
 		&contents.GetRelease{},
 		&contents.UpdateRelease{},
 		&contents.DeleteRelease{},

--- a/pkg/integrations/github/github_test.go
+++ b/pkg/integrations/github/github_test.go
@@ -73,6 +73,14 @@ func Test__GitHub__Sync(t *testing.T) {
 	})
 }
 
+func Test__GitHub__Configuration(t *testing.T) {
+	fields := (&GitHub{}).Configuration()
+	require.Len(t, fields, 1)
+	assert.Equal(t, "GitHub organization name", fields[0].Label)
+	assert.Equal(t, "Name of the GitHub organization to install the app into. If left blank, the app will be installed into the user's account.", fields[0].Description)
+	assert.Equal(t, "e.g. superplanehq", fields[0].Placeholder)
+}
+
 func Test__listInstallationRepositories__paginates_all_pages(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/integrations/github/setup_provider.go
+++ b/pkg/integrations/github/setup_provider.go
@@ -253,7 +253,7 @@ func (g *SetupProvider) FirstStep(ctx core.SetupStepContext) core.SetupStep {
 			},
 			{
 				Name:        common.PropertyOwner,
-				Label:       "User account / organization name",
+				Label:       "GitHub user account / organization name",
 				Type:        configuration.FieldTypeString,
 				Required:    true,
 				Placeholder: "e.g. superplanehq",

--- a/pkg/integrations/github/setup_provider_test.go
+++ b/pkg/integrations/github/setup_provider_test.go
@@ -1,17 +1,28 @@
 package github
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
 
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/integrations/github/common"
 	"github.com/superplanehq/superplane/test/support/contexts"
 	"github.com/superplanehq/superplane/test/support/logger"
 )
+
+func Test__GitHub__SetupProvider__FirstStep(t *testing.T) {
+	step := (&SetupProvider{}).FirstStep(core.SetupStepContext{})
+	ownerFieldIndex := slices.IndexFunc(step.Inputs, func(field configuration.Field) bool {
+		return field.Name == common.PropertyOwner
+	})
+	require.NotEqual(t, -1, ownerFieldIndex)
+	assert.Equal(t, "GitHub user account / organization name", step.Inputs[ownerFieldIndex].Label)
+}
 
 func Test__GitHub__SetupProvider__OnCapabilityUpdate(t *testing.T) {
 	g := &SetupProvider{}

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -130,6 +130,19 @@ func CreateAccountInTransaction(tx *gorm.DB, name, email string) (*Account, erro
 	return account, nil
 }
 
+func CreateInstallationAdminAccount(tx *gorm.DB, name, email string) (*Account, error) {
+	account := &Account{
+		Name:              name,
+		Email:             utils.NormalizeEmail(email),
+		InstallationAdmin: true,
+	}
+	if err := tx.Create(account).Error; err != nil {
+		return nil, err
+	}
+
+	return account, nil
+}
+
 func ListAccounts(search string, limit, offset int, sortBy, sortDirection string) ([]Account, int64, error) {
 	query := database.Conn().Model(&Account{})
 

--- a/pkg/models/account_installation_admin_test.go
+++ b/pkg/models/account_installation_admin_test.go
@@ -21,6 +21,16 @@ func TestInstallationAdmin(t *testing.T) {
 		assert.False(t, account.IsInstallationAdmin())
 	})
 
+	t.Run("installation admin accounts are persisted as admins on creation", func(t *testing.T) {
+		account, err := CreateInstallationAdminAccount(database.Conn(), "Instance Owner", "owner@example.com")
+		require.NoError(t, err)
+		assert.True(t, account.IsInstallationAdmin())
+
+		refreshed, err := FindAccountByID(account.ID.String())
+		require.NoError(t, err)
+		assert.True(t, refreshed.IsInstallationAdmin())
+	})
+
 	t.Run("PromoteToInstallationAdmin sets the flag", func(t *testing.T) {
 		account, err := CreateAccount("Admin Candidate", "candidate@example.com")
 		require.NoError(t, err)

--- a/pkg/public/setup_owner.go
+++ b/pkg/public/setup_owner.go
@@ -61,16 +61,10 @@ func (s *Server) setupOwner(w http.ResponseWriter, r *http.Request) {
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		var err error
 
-		account, err = models.CreateAccountInTransaction(tx, fullName, req.Email)
+		account, err = models.CreateInstallationAdminAccount(tx, fullName, req.Email)
 		if err != nil {
 			return err
 		}
-
-		// The first account is automatically an installation admin
-		if err := tx.Model(account).Update("installation_admin", true).Error; err != nil {
-			return err
-		}
-		account.InstallationAdmin = true
 
 		if err := usage.EnsureAccountWithinLimits(r.Context(), s.usageService, account.ID.String(), &usagepb.AccountState{
 			Organizations: 1,

--- a/pkg/public/setup_owner_test.go
+++ b/pkg/public/setup_owner_test.go
@@ -65,6 +65,30 @@ func TestSetupOwnerIgnoresInstallationSettings(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, response.Code)
 
+	account, err := models.FindAccountByEmail("owner@example.com")
+	require.NoError(t, err)
+	assert.True(t, account.IsInstallationAdmin())
+
+	var accountToken string
+	for _, cookie := range response.Result().Cookies() {
+		if cookie.Name == "account_token" {
+			accountToken = cookie.Value
+			break
+		}
+	}
+	require.NotEmpty(t, accountToken)
+
+	accountResponse := execRequest(server, requestParams{
+		method:     http.MethodGet,
+		path:       "/account",
+		authCookie: accountToken,
+	})
+	require.Equal(t, http.StatusOK, accountResponse.Code)
+
+	var currentAccount AccountResponse
+	require.NoError(t, json.Unmarshal(accountResponse.Body.Bytes(), &currentAccount))
+	assert.True(t, currentAccount.InstallationAdmin)
+
 	metadata, err := models.GetInstallationMetadata(database.Conn())
 	require.NoError(t, err)
 	assert.False(t, metadata.AllowPrivateNetworkAccess)


### PR DESCRIPTION
## Summary

  - add `github.getFileContent` for reading small repository files
  - return decoded content with SHA, path, and ref metadata
  - request GitHub Contents read permission for the new action
  - clarify the GitHub organization-name field in the integration modal
  - create the first-run owner as an installation admin directly during insertion
  - verify the installation-admin flag in both persistence and `/account`

  ## Testing

  - `make format.go`
  - `make lint`
  - `make check.build.app`
  - `make check.example.payloads`
  - `make check.configuration.fields`
  - `make check.models.tx.debt`
  - focused tests for GitHub contents, owner creation, and owner-session responses

  ## Notes

  The reported `installation_admin=false` state from #6406 was not reproduced on current main. The owner-
  creation change nevertheless makes the required role explicit in the initial insert and adds coverage
  through the authenticated account response.

  Fixes #4274
  Fixes #5031
  Addresses #6406
