### PR TITLE
fix: require org auth for widgets catalog endpoints

### DIFF
--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -288,6 +288,16 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			Action:     "read",
 			DomainType: models.DomainTypeOrganization,
 		},
+		{Method: "GET", Pattern: "/api/v1/widgets"}: {
+			Resource:   "org",
+			Action:     "read",
+			DomainType: models.DomainTypeOrganization,
+		},
+		{Method: "GET", Pattern: "/api/v1/widgets/{name}"}: {
+			Resource:   "org",
+			Action:     "read",
+			DomainType: models.DomainTypeOrganization,
+		},
 		{Method: "PATCH", Pattern: "/api/v1/canvas-folders/{id}/position"}: {
 			Resource:   "canvases",
 			Action:     "update",

--- a/pkg/authorization/interceptor_test.go
+++ b/pkg/authorization/interceptor_test.go
@@ -295,6 +295,40 @@ func TestDefaultAuthorizationRulesAreKeyedByHTTPRoute(t *testing.T) {
 	assert.Equal(t, []string{IDPathParam}, rule.ResourcePathParams)
 }
 
+func TestWidgetCatalogRoutesRequireOrgRead(t *testing.T) {
+	rules := DefaultAuthorizationRules()
+	routes := []HTTPRoute{
+		{Method: http.MethodGet, Pattern: "/api/v1/widgets"},
+		{Method: http.MethodGet, Pattern: "/api/v1/widgets/{name}"},
+	}
+
+	for _, route := range routes {
+		rule, ok := rules[route]
+		require.True(t, ok, route.String())
+		assert.Equal(t, "org", rule.Resource)
+		assert.Equal(t, "read", rule.Action)
+		assert.Equal(t, models.DomainTypeOrganization, rule.DomainType)
+	}
+}
+
+func TestGatewayAuthorizerRequiresAuthForWidgetCatalogRoutes(t *testing.T) {
+	authorizer := NewGatewayAuthorizer(actionPermissionChecker{})
+	routes := []HTTPRoute{
+		{Method: http.MethodGet, Pattern: "/api/v1/widgets"},
+		{Method: http.MethodGet, Pattern: "/api/v1/widgets/{name}"},
+	}
+
+	for _, route := range routes {
+		_, err := authorizer.AuthorizeHTTP(
+			context.Background(),
+			httptestRequest(t, nil),
+			route,
+			map[string]string{},
+		)
+		require.Error(t, err, route.String())
+	}
+}
+
 func httptestRequest(t *testing.T, headers map[string]string) *http.Request {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Add `org:read` gateway auth rules for `GET /api/v1/widgets` and `GET /api/v1/widgets/{name}`, matching actions/triggers.
- Unlisted routes previously skipped Casbin and scoped-token checks; widgets already required login via `protectedGRPCHandler`.
- Add regression tests for rule presence and unauthenticated rejection.

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/authorization` (95 tests passed)