### PR TITLE
feat: check for CLI updates once per day

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,9 +8,7 @@ import (
 )
 
 func main() {
-	if cli.ShouldStartUpdateCheck(os.Args[1:]) {
-		cli.StartUpdateCheck()
-	}
+	cli.MaybeStartUpdateCheck(os.Args[1:])
 	err := cli.RootCmd.Execute()
 	cli.PrintUpdateNotice()
 	if err != nil {

--- a/pkg/cli/update_check.go
+++ b/pkg/cli/update_check.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+)
+
+const (
+	// ConfigKeyLastUpdateCheck stores, in the CLI configuration file, when the
+	// last check for a newer release was attempted.
+	ConfigKeyLastUpdateCheck = "lastUpdateCheck"
+
+	// updateCheckInterval is the minimum time between two update checks.
+	updateCheckInterval = 24 * time.Hour
+)
+
+// MaybeStartUpdateCheck starts the background update check when the command
+// warrants one and the previous check is older than updateCheckInterval.
+//
+// The timestamp is recorded before the check runs rather than after it
+// succeeds, so a failing or slow endpoint cannot cause every subsequent
+// command to retry it.
+func MaybeStartUpdateCheck(args []string) {
+	if !ShouldStartUpdateCheck(args) {
+		return
+	}
+
+	configFile := configFileFromArgs(args)
+	if !shouldCheckForUpdates(configFile, time.Now()) {
+		return
+	}
+
+	// A failure to persist the timestamp only means the next command checks
+	// again. It is not worth interrupting the user's command over.
+	_ = recordUpdateCheck(configFile, time.Now())
+
+	StartUpdateCheck()
+}
+
+// configFileFromArgs resolves the configuration file the same way initConfig
+// does. It cannot read the parsed --config flag, because the update check runs
+// before Cobra executes the command, so the raw arguments are scanned instead.
+// An empty string means the path could not be determined.
+func configFileFromArgs(args []string) string {
+	for i, arg := range args {
+		if value, found := strings.CutPrefix(arg, "--config="); found {
+			return value
+		}
+
+		if arg == "--config" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/.superplane.yaml", home)
+}
+
+// shouldCheckForUpdates reports whether updateCheckInterval has elapsed since
+// the last recorded check. It fails open: when the timestamp is missing,
+// unreadable or malformed, a check is allowed.
+func shouldCheckForUpdates(configFile string, now time.Time) bool {
+	if configFile == "" {
+		return true
+	}
+
+	config := viper.New()
+	config.SetConfigFile(configFile)
+	if err := config.ReadInConfig(); err != nil {
+		return true
+	}
+
+	lastCheck := config.GetTime(ConfigKeyLastUpdateCheck)
+	if lastCheck.IsZero() {
+		return true
+	}
+
+	// A timestamp in the future means a clock change or a hand-edited file.
+	// Treat it as due rather than blocking checks until it passes.
+	if lastCheck.After(now) {
+		return true
+	}
+
+	return now.Sub(lastCheck) >= updateCheckInterval
+}
+
+// recordUpdateCheck stores now as the moment the last update check ran.
+//
+// It uses an isolated viper instance so the global configuration the commands
+// read later is left untouched, and reads the file first so existing keys are
+// preserved on write.
+func recordUpdateCheck(configFile string, now time.Time) error {
+	if configFile == "" {
+		return fmt.Errorf("no configuration file to record the update check in")
+	}
+
+	config := viper.New()
+	config.SetConfigFile(configFile)
+
+	// A missing or empty file is fine — the key is written into a new one.
+	_ = config.ReadInConfig()
+
+	config.Set(ConfigKeyLastUpdateCheck, now.UTC().Format(time.RFC3339))
+	if err := config.WriteConfigAs(configFile); err != nil {
+		return fmt.Errorf("failed to record update check: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cli/update_check.go
+++ b/pkg/cli/update_check.go
@@ -105,7 +105,7 @@ func recordUpdateCheck(configFile string, now time.Time) error {
 	config := viper.New()
 	config.SetConfigFile(configFile)
 
-	// A missing or empty file is fine — the key is written into a new one.
+	// A missing or empty file is fine; the key is written into a new one.
 	_ = config.ReadInConfig()
 
 	config.Set(ConfigKeyLastUpdateCheck, now.UTC().Format(time.RFC3339))

--- a/pkg/cli/update_check_test.go
+++ b/pkg/cli/update_check_test.go
@@ -142,7 +142,7 @@ func TestRecordUpdateCheckRoundTrips(t *testing.T) {
 }
 
 func TestRecordUpdateCheckPreservesExistingKeys(t *testing.T) {
-	path := writeConfigFile(t, "output: json\ncurrentContext: acme\n")
+	path := writeConfigFile(t, "output: json\ncurrentContext: my-org\n")
 
 	if err := recordUpdateCheck(path, time.Now()); err != nil {
 		t.Fatalf("recordUpdateCheck: %v", err)
@@ -155,11 +155,11 @@ func TestRecordUpdateCheckPreservesExistingKeys(t *testing.T) {
 	}
 
 	if got := config.GetString(ConfigKeyOutput); got != "json" {
-		t.Fatalf("output = %q, want %q — existing keys must survive the write", got, "json")
+		t.Fatalf("output = %q, want %q; existing keys must survive the write", got, "json")
 	}
 
-	if got := config.GetString(ConfigKeyCurrentContext); got != "acme" {
-		t.Fatalf("currentContext = %q, want %q — existing keys must survive the write", got, "acme")
+	if got := config.GetString(ConfigKeyCurrentContext); got != "my-org" {
+		t.Fatalf("currentContext = %q, want %q; existing keys must survive the write", got, "my-org")
 	}
 
 	if config.GetTime(ConfigKeyLastUpdateCheck).IsZero() {

--- a/pkg/cli/update_check_test.go
+++ b/pkg/cli/update_check_test.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+func writeConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), ".superplane.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	return path
+}
+
+func TestConfigFileFromArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{name: "--config with separate value", args: []string{"apps", "list", "--config", "/tmp/a.yaml"}, expected: "/tmp/a.yaml"},
+		{name: "--config= inline value", args: []string{"apps", "--config=/tmp/b.yaml"}, expected: "/tmp/b.yaml"},
+		{name: "--config as last arg has no value", args: []string{"apps", "--config"}, expected: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := configFileFromArgs(test.args)
+
+			if test.expected == "" {
+				// Falls through to the home directory default, which must at
+				// least not return the flag itself.
+				if result == "--config" {
+					t.Fatalf("configFileFromArgs(%v) returned the flag name", test.args)
+				}
+				return
+			}
+
+			if result != test.expected {
+				t.Fatalf("configFileFromArgs(%v) = %q, want %q", test.args, result, test.expected)
+			}
+		})
+	}
+}
+
+func TestConfigFileFromArgsDefaultsToHomeConfig(t *testing.T) {
+	result := configFileFromArgs([]string{"apps", "list"})
+
+	if filepath.Base(result) != ".superplane.yaml" {
+		t.Fatalf("configFileFromArgs default = %q, want a path ending in .superplane.yaml", result)
+	}
+}
+
+func TestShouldCheckForUpdates(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		contents string
+		expected bool
+	}{
+		{
+			name:     "no timestamp recorded -> due",
+			contents: "output: text\n",
+			expected: true,
+		},
+		{
+			name:     "checked just now -> not due",
+			contents: "lastUpdateCheck: " + now.Add(-1*time.Minute).UTC().Format(time.RFC3339) + "\n",
+			expected: false,
+		},
+		{
+			name:     "checked 23 hours ago -> not due",
+			contents: "lastUpdateCheck: " + now.Add(-23*time.Hour).UTC().Format(time.RFC3339) + "\n",
+			expected: false,
+		},
+		{
+			name:     "checked 25 hours ago -> due",
+			contents: "lastUpdateCheck: " + now.Add(-25*time.Hour).UTC().Format(time.RFC3339) + "\n",
+			expected: true,
+		},
+		{
+			name:     "timestamp in the future -> due",
+			contents: "lastUpdateCheck: " + now.Add(48*time.Hour).UTC().Format(time.RFC3339) + "\n",
+			expected: true,
+		},
+		{
+			name:     "malformed timestamp -> due",
+			contents: "lastUpdateCheck: not-a-timestamp\n",
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeConfigFile(t, test.contents)
+
+			if result := shouldCheckForUpdates(path, now); result != test.expected {
+				t.Fatalf("shouldCheckForUpdates() = %v, want %v", result, test.expected)
+			}
+		})
+	}
+}
+
+func TestShouldCheckForUpdatesWhenConfigIsMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	if !shouldCheckForUpdates(missing, time.Now()) {
+		t.Fatal("a missing config file should not block the update check")
+	}
+
+	if !shouldCheckForUpdates("", time.Now()) {
+		t.Fatal("an unresolvable config path should not block the update check")
+	}
+}
+
+func TestRecordUpdateCheckRoundTrips(t *testing.T) {
+	path := writeConfigFile(t, "output: text\n")
+	now := time.Now()
+
+	if err := recordUpdateCheck(path, now); err != nil {
+		t.Fatalf("recordUpdateCheck: %v", err)
+	}
+
+	// The freshly recorded timestamp must suppress the next check.
+	if shouldCheckForUpdates(path, now) {
+		t.Fatal("update check should not be due immediately after being recorded")
+	}
+
+	// And it must become due again once the interval has elapsed.
+	if !shouldCheckForUpdates(path, now.Add(updateCheckInterval+time.Minute)) {
+		t.Fatal("update check should be due again after the interval elapses")
+	}
+}
+
+func TestRecordUpdateCheckPreservesExistingKeys(t *testing.T) {
+	path := writeConfigFile(t, "output: json\ncurrentContext: acme\n")
+
+	if err := recordUpdateCheck(path, time.Now()); err != nil {
+		t.Fatalf("recordUpdateCheck: %v", err)
+	}
+
+	config := viper.New()
+	config.SetConfigFile(path)
+	if err := config.ReadInConfig(); err != nil {
+		t.Fatalf("read back config: %v", err)
+	}
+
+	if got := config.GetString(ConfigKeyOutput); got != "json" {
+		t.Fatalf("output = %q, want %q — existing keys must survive the write", got, "json")
+	}
+
+	if got := config.GetString(ConfigKeyCurrentContext); got != "acme" {
+		t.Fatalf("currentContext = %q, want %q — existing keys must survive the write", got, "acme")
+	}
+
+	if config.GetTime(ConfigKeyLastUpdateCheck).IsZero() {
+		t.Fatal("lastUpdateCheck was not written")
+	}
+}
+
+func TestRecordUpdateCheckCreatesMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".superplane.yaml")
+
+	if err := recordUpdateCheck(path, time.Now()); err != nil {
+		t.Fatalf("recordUpdateCheck on a missing file: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("config file was not created: %v", err)
+	}
+}
+
+func TestRecordUpdateCheckWithoutPath(t *testing.T) {
+	if err := recordUpdateCheck("", time.Now()); err == nil {
+		t.Fatal("expected an error when no configuration file can be resolved")
+	}
+}


### PR DESCRIPTION
Implements #5000

The CLI checked GitHub for a newer release on every command. This limits that to once
per day, using the `lastUpdateCheck` key in `.superplane.yaml` as suggested in the issue.

## How it works

`MaybeStartUpdateCheck` replaces the `ShouldStartUpdateCheck` + `StartUpdateCheck` pair in
`cmd/cli/main.go`. It keeps the existing argument-based rules (no check for `help`,
`version`, `completion`, `upgrade`, or dev builds) and adds the time-based gate on top.

Two decisions worth calling out:

**The timestamp is written before the check runs, not after it succeeds.** If the endpoint
is slow or unreachable, recording only successes would mean every subsequent command
retried it, which is exactly the behaviour this issue is about. Recording the attempt bounds the
request rate to once per day regardless of the outcome.

**The config path is resolved from `os.Args` rather than from viper.** `initConfig` is
registered through `cobra.OnInitialize`, so the global viper instance is not populated
until `RootCmd.Execute()` runs, which is after the update check starts. `configFileFromArgs`
therefore mirrors what `initConfig` does: honour `--config` / `--config=`, otherwise
`$HOME/.superplane.yaml`.

Reads and writes go through an isolated `viper.New()` instance so the global configuration
the commands later read is untouched, and the file is read before writing so existing keys
survive.

## Failure behaviour

Every failure path fails open, so the update notice degrades rather than the CLI breaking:

- config file missing, unreadable, or path unresolvable → check proceeds
- timestamp absent or malformed → check proceeds
- timestamp in the future (clock change or hand-edited file) → check proceeds rather than
  blocking checks until that time passes
- writing the timestamp fails → ignored; the next command simply checks again

## Tests

`pkg/cli/update_check_test.go` covers argument parsing for both `--config` forms and the
home-directory default, the 23h/25h boundary either side of the interval, missing,
malformed and future timestamps, a record-then-read round trip, preservation of existing
config keys across the write, and creation of a missing config file.

`make check.format.go`, `make check.build.app`, `make lint` and `make test
PKG_TEST_PACKAGES=./pkg/cli` all pass locally.
