### PR TITLE
fix: clarify PagerDuty From Email field copy

### DIFF
--- a/docs/components/PagerDuty.mdx
+++ b/docs/components/PagerDuty.mdx
@@ -317,7 +317,7 @@ The Acknowledge Incident component acknowledges an existing PagerDuty incident.
 ### Configuration
 
 - **Incident ID**: The ID of the incident to acknowledge (e.g., A12BC34567...)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ### Behavior
 
@@ -429,7 +429,7 @@ The Annotate Incident component adds a note to an existing PagerDuty incident.
 
 - **Incident ID**: The ID of the incident to annotate (e.g., A12BC34567...)
 - **Content**: The note content to add to the incident (supports expressions)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ### Output
 
@@ -542,7 +542,7 @@ The Create Incident component creates a new incident in PagerDuty.
 - **Description**: Additional details about the incident (optional, supports expressions)
 - **Urgency**: Incident urgency level (high or low)
 - **Service**: Select the PagerDuty service to create the incident in
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ### Output
 
@@ -672,7 +672,7 @@ Escalating an incident moves it to a higher level, notifying the responders at t
 
 - **Incident ID**: The ID of the incident to escalate (e.g., A12BC34567...)
 - **Escalation Level**: The level to escalate to (1-10). This is the level number within the incident's current escalation policy.
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ### Output
 
@@ -1091,7 +1091,7 @@ The Resolve Incident component resolves an existing PagerDuty incident.
 ### Configuration
 
 - **Incident ID**: The ID of the incident to resolve (e.g., A12BC34567...)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 - **Resolution Notes**: Optional notes about the resolution (saved to incident description)
 
 ### Behavior
@@ -1192,7 +1192,7 @@ The Snooze Incident component temporarily pauses notifications for an acknowledg
 
 - **Incident ID**: The ID of the incident to snooze (must be in acknowledged state)
 - **Duration**: How long to snooze the incident (1 hour, 4 hours, 8 hours, or 24 hours)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ### Behavior
 
@@ -1304,7 +1304,7 @@ The Update Incident component modifies an existing PagerDuty incident.
 ### Configuration
 
 - **Incident ID**: The ID of the incident to update (e.g., A12BC34567...)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 - **Status**: Update incident status (acknowledged, resolved)
 - **Priority**: Update incident priority (select from available priorities)
 - **Title**: Update incident title (optional, supports expressions)

--- a/pkg/integrations/pagerduty/acknowledge_incident.go
+++ b/pkg/integrations/pagerduty/acknowledge_incident.go
@@ -42,7 +42,7 @@ func (c *AcknowledgeIncident) Documentation() string {
 ## Configuration
 
 - **Incident ID**: The ID of the incident to acknowledge (e.g., A12BC34567...)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ## Behavior
 
@@ -80,7 +80,7 @@ func (c *AcknowledgeIncident) Configuration() []configuration.Field {
 			Label:       "From Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",
+			Description: "Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.",
 			Placeholder: "user@example.com",
 		},
 	}

--- a/pkg/integrations/pagerduty/annotate_incident.go
+++ b/pkg/integrations/pagerduty/annotate_incident.go
@@ -45,7 +45,7 @@ func (c *AnnotateIncident) Documentation() string {
 
 - **Incident ID**: The ID of the incident to annotate (e.g., A12BC34567...)
 - **Content**: The note content to add to the incident (supports expressions)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ## Output
 
@@ -86,7 +86,7 @@ func (c *AnnotateIncident) Configuration() []configuration.Field {
 			Label:       "From Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",
+			Description: "Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.",
 			Placeholder: "user@example.com",
 		},
 	}

--- a/pkg/integrations/pagerduty/create_incident.go
+++ b/pkg/integrations/pagerduty/create_incident.go
@@ -49,7 +49,7 @@ func (c *CreateIncident) Documentation() string {
 - **Description**: Additional details about the incident (optional, supports expressions)
 - **Urgency**: Incident urgency level (high or low)
 - **Service**: Select the PagerDuty service to create the incident in
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ## Output
 
@@ -123,7 +123,7 @@ func (c *CreateIncident) Configuration() []configuration.Field {
 			Label:       "From Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",
+			Description: "Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.",
 			Placeholder: "user@example.com",
 		},
 	}

--- a/pkg/integrations/pagerduty/escalate_incident.go
+++ b/pkg/integrations/pagerduty/escalate_incident.go
@@ -59,7 +59,7 @@ Escalating an incident moves it to a higher level, notifying the responders at t
 
 - **Incident ID**: The ID of the incident to escalate (e.g., A12BC34567...)
 - **Escalation Level**: The level to escalate to (1-10). This is the level number within the incident's current escalation policy.
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ## Output
 
@@ -117,7 +117,7 @@ func (c *EscalateIncident) Configuration() []configuration.Field {
 			Label:       "From Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",
+			Description: "Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.",
 			Placeholder: "user@example.com",
 		},
 	}

--- a/pkg/integrations/pagerduty/resolve_incident.go
+++ b/pkg/integrations/pagerduty/resolve_incident.go
@@ -43,7 +43,7 @@ func (c *ResolveIncident) Documentation() string {
 ## Configuration
 
 - **Incident ID**: The ID of the incident to resolve (e.g., A12BC34567...)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 - **Resolution Notes**: Optional notes about the resolution (saved to incident description)
 
 ## Behavior
@@ -82,7 +82,7 @@ func (c *ResolveIncident) Configuration() []configuration.Field {
 			Label:       "From Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",
+			Description: "Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.",
 			Placeholder: "user@example.com",
 		},
 		{

--- a/pkg/integrations/pagerduty/snooze_incident.go
+++ b/pkg/integrations/pagerduty/snooze_incident.go
@@ -45,7 +45,7 @@ func (c *SnoozeIncident) Documentation() string {
 
 - **Incident ID**: The ID of the incident to snooze (must be in acknowledged state)
 - **Duration**: How long to snooze the incident (1 hour, 4 hours, 8 hours, or 24 hours)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 
 ## Behavior
 
@@ -103,7 +103,7 @@ func (c *SnoozeIncident) Configuration() []configuration.Field {
 			Label:       "From Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",
+			Description: "Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.",
 			Placeholder: "user@example.com",
 		},
 	}

--- a/pkg/integrations/pagerduty/update_incident.go
+++ b/pkg/integrations/pagerduty/update_incident.go
@@ -48,7 +48,7 @@ func (c *UpdateIncident) Documentation() string {
 ## Configuration
 
 - **Incident ID**: The ID of the incident to update (e.g., A12BC34567...)
-- **From Email**: Email address of a valid PagerDuty user (required for App OAuth, optional for API tokens)
+- **From Email**: Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.
 - **Status**: Update incident status (acknowledged, resolved)
 - **Priority**: Update incident priority (select from available priorities)
 - **Title**: Update incident title (optional, supports expressions)
@@ -88,7 +88,7 @@ func (c *UpdateIncident) Configuration() []configuration.Field {
 			Label:       "From Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",
+			Description: "Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth or an account-scoped API token; optional with a user-scoped API token, which already identifies the user.",
 			Placeholder: "user@example.com",
 		},
 		{


### PR DESCRIPTION
Implements #1898

The From Email field on the PagerDuty components was confusing, and the two places that
describe it disagreed with each other.

The field description said:

> Email address of a valid PagerDuty user. Required for App OAuth and account-level API
> tokens, optional for user-level API tokens.

while the generated component docs said:

> required for App OAuth, optional for API tokens

So the docs told users the field is optional for API tokens, while the field itself said
it is required for account-level ones. Neither explained what the value is actually used
for, or why the requirement depends on the token.

## What it actually does

The value is sent as PagerDuty's `From` header, which identifies the user an action is
performed as. A user-scoped API token already identifies a user, so the header is
optional there. App OAuth and account-scoped tokens have no user attached, so PagerDuty
needs it.

## New copy

> Email of the PagerDuty user to act as, sent as the From header. Required with App OAuth
> or an account-scoped API token; optional with a user-scoped API token, which already
> identifies the user.

Applied to all seven components that expose the field (create, update, acknowledge,
resolve, escalate, snooze, annotate), so the field description and the docs now match.
`docs/components/PagerDuty.mdx` is regenerated with `make gen.components.docs`.

## Deliberately unchanged

The **From Email** label is kept as-is. It mirrors the `From` header it maps to, and
renaming it would change a field users may already recognise; the description seemed the
right place to carry the explanation. Happy to relabel if you would prefer.

`Required: false` on the field is also unchanged: the requirement is conditional on the
auth type, which the schema cannot express, so it stays optional and the copy explains
when it is needed.

## Checks

`make check.format.go`, `make check.components.docs`, `make check.configuration.fields`,
`make check.example.payloads` and `go test ./pkg/integrations/pagerduty/` all pass.
