### PR TITLE
fix: clarify that the GitHub integration organization is a GitHub org

### DIFF
--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -101,9 +101,10 @@ func (g *GitHub) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
 			Name:        "organization",
-			Label:       "Organization",
+			Label:       "GitHub Organization",
 			Type:        configuration.FieldTypeString,
-			Description: "Organization to install the app into. If not specified, the app will be installed into the user's account.",
+			Description: "Name of the GitHub organization to install the app into, as it appears in its URL (for example, github.com/acme-inc). Leave empty to install the app into your personal GitHub account.",
+			Placeholder: "acme-inc",
 		},
 	}
 }

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -103,8 +103,8 @@ func (g *GitHub) Configuration() []configuration.Field {
 			Name:        "organization",
 			Label:       "GitHub Organization",
 			Type:        configuration.FieldTypeString,
-			Description: "Name of the GitHub organization to install the app into, as it appears in its URL (for example, github.com/acme-inc). Leave empty to install the app into your personal GitHub account.",
-			Placeholder: "acme-inc",
+			Description: "Name of the GitHub organization to install the app into, as it appears in its URL (github.com/your-org). Leave empty to install the app into your personal GitHub account.",
+			Placeholder: "your-org",
 		},
 	}
 }

--- a/web_src/src/pages/home/__fixtures__/handlers.ts
+++ b/web_src/src/pages/home/__fixtures__/handlers.ts
@@ -218,9 +218,9 @@ const STORYBOOK_FACTORY_INTEGRATION_DEFINITIONS = [
         name: "organization",
         type: "string",
         description:
-          "Organization to install the app into. If not specified, the app will be installed into the user's account.",
+          "Name of the GitHub organization to install the app into, as it appears in its URL (for example, github.com/acme-inc). Leave empty to install the app into your personal GitHub account.",
         required: false,
-        label: "Organization",
+        label: "GitHub Organization",
         visibilityConditions: [],
         requiredConditions: [],
         sensitive: false,

--- a/web_src/src/pages/home/__fixtures__/handlers.ts
+++ b/web_src/src/pages/home/__fixtures__/handlers.ts
@@ -218,7 +218,7 @@ const STORYBOOK_FACTORY_INTEGRATION_DEFINITIONS = [
         name: "organization",
         type: "string",
         description:
-          "Name of the GitHub organization to install the app into, as it appears in its URL (for example, github.com/acme-inc). Leave empty to install the app into your personal GitHub account.",
+          "Name of the GitHub organization to install the app into, as it appears in its URL (github.com/your-org). Leave empty to install the app into your personal GitHub account.",
         required: false,
         label: "GitHub Organization",
         visibilityConditions: [],


### PR DESCRIPTION
Implements #5031

The GitHub integration setup modal asked for an "Organization" without saying whose. Since
SuperPlane has its own organizations, and the modal is opened from inside one, the field
reads as though it wants the SuperPlane organization rather than the GitHub one.

## Before

- **Label:** Organization
- **Description:** Organization to install the app into. If not specified, the app will be
  installed into the user's account.

Neither mentions GitHub, and "the user's account" is ambiguous in the same way.

## After

- **Label:** GitHub Organization
- **Description:** Name of the GitHub organization to install the app into, as it appears
  in its URL (github.com/your-org). Leave empty to install the app into your personal
  GitHub account.
- **Placeholder:** `your-org`

The label now names the system, the description says where to find the value, and the
placeholder shows the expected shape: a bare org slug rather than a full URL or display
name.

## Also updated

`web_src/src/pages/home/__fixtures__/handlers.ts` carries a copy of this field definition
for Storybook and the org workspace harness. It is updated to match so the mocked
integration definition does not drift from the real one. No spec asserts on this text.

## Notes

Integration-level `Configuration()` fields are not rendered into `docs/components/`, so no
generated docs change; `make check.components.docs` confirms this.

`make check.format.go`, `make check.components.docs`, `make check.configuration.fields`,
`make check.format.js`, `make check.lint.ui`, `make check.build.ui` and
`go test ./pkg/integrations/github/` all pass.
