### PR TITLE
fix: state that profile settings and API tokens are per organization

### DIFF
--- a/web_src/src/pages/organization/settings/Profile.tsx
+++ b/web_src/src/pages/organization/settings/Profile.tsx
@@ -87,9 +87,13 @@ export function Profile() {
 
   return (
     <div className="pt-6 max-w-none">
-      <Heading level={2} className="text-lg font-medium text-left text-gray-800 dark:text-white mb-4">
+      <Heading level={2} className="text-lg font-medium text-left text-gray-800 dark:text-white mb-0">
         Profile Information
       </Heading>
+      <Text className="text-gray-800 text-left dark:text-gray-400 text-sm mb-4">
+        Your profile and API token belong to this organization. If you are a member of more than one, each organization
+        has its own profile and its own token.
+      </Text>
       <div className="space-y-6">
         {/* Profile Section */}
         <div className={settingsCardClassName}>
@@ -147,7 +151,9 @@ export function Profile() {
           API Token
         </Heading>
         <Text className="text-gray-800 text-left dark:text-gray-400 text-sm">
-          Use this token to authenticate API requests to SuperPlane. Keep your token secure and do not share it.
+          Use this token to authenticate API requests to SuperPlane for this organization. It does not grant access to
+          any other organization you belong to. Regenerating it invalidates the previous token for this organization
+          only. Keep your token secure and do not share it.
         </Text>
 
         {/* API Token Section */}


### PR DESCRIPTION
Implements #3973

Nothing on the profile settings page indicated that what it shows is scoped to the
organization you are currently in, and that includes the API token.

## Why it matters

Users are stored per organization. `FindActiveUserByID` filters on both `id` and
`organization_id`, and the `users` table carries an `organization_id` column, so somebody
who belongs to two organizations has two user records. The consequences visible on this
page:

- The **User ID** shown differs between organizations for the same person.
- The **API token** authenticates against one organization only. `RegenerateToken` loads
  the user with `FindActiveUserByID(orgID, userID)` and updates the token hash on that
  record, so regenerating rotates the token for the current organization and leaves tokens
  in other organizations untouched.

The old copy said only "Use this token to authenticate API requests to SuperPlane", which
reads as though the token is account-wide.

## Changes

A line under **Profile Information**:

> Your profile and API token belong to this organization. If you are a member of more than
> one, each organization has its own profile and its own token.

And the API token description now states the scope and what regenerating actually affects:

> Use this token to authenticate API requests to SuperPlane for this organization. It does
> not grant access to any other organization you belong to. Regenerating it invalidates the
> previous token for this organization only. Keep your token secure and do not share it.

Copy only, no behaviour change.

## Notes

The wording says "this organization" rather than naming it. The page has the organization
id available but not the name, and fetching it only for a sentence seemed a poor trade for
a copy fix. Happy to add the name if you would prefer it to be explicit.

`make check.format.js`, `make check.lint.ui` and `make check.build.ui` pass. No spec or
story asserts on the previous strings.
