### PR TITLE
fix: prevent demoting the last organization owner

### DIFF
--- a/pkg/grpc/actions/auth/assign_role.go
+++ b/pkg/grpc/actions/auth/assign_role.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"slices"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
@@ -32,6 +33,18 @@ func AssignRole(ctx context.Context, orgID, domainType, domainID, roleName, user
 
 	if user.IsAPIKey() && roleName == models.RoleOrgOwner {
 		return nil, grpcerrors.InvalidArgument(nil, "API keys cannot be assigned the org_owner role")
+	}
+
+	if domainType == models.DomainTypeOrganization && roleName != models.RoleOrgOwner {
+		ownerIDs, err := authService.GetOrgUsersForRole(ctx, models.RoleOrgOwner, orgID)
+		if err != nil {
+			log.Errorf("Error determining owners for org %s: %v", orgID, err)
+			return nil, grpcerrors.Internal(err, "error determining organization owners")
+		}
+
+		if len(ownerIDs) <= 1 && slices.Contains(ownerIDs, user.ID.String()) {
+			return nil, grpcerrors.FailedPrecondition(nil, "cannot demote the last organization owner")
+		}
 	}
 
 	err = authService.AssignRole(user.ID.String(), roleName, domainID, domainType)

--- a/pkg/grpc/actions/auth/assign_role_test.go
+++ b/pkg/grpc/actions/auth/assign_role_test.go
@@ -83,4 +83,26 @@ func Test_AssignRole(t *testing.T) {
 		assert.Equal(t, codes.InvalidArgument, code)
 		assert.Equal(t, "user not found", msg)
 	})
+
+	t.Run("cannot demote the last organization owner", func(t *testing.T) {
+		adminUser := support.CreateUser(t, r, r.Organization.ID)
+		_, err := AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, adminUser.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+
+		adminCtx := authentication.SetUserIdInMetadata(context.Background(), adminUser.ID.String())
+		_, err = AssignRole(adminCtx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgViewer, r.User.String(), "", r.AuthService)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, code)
+		assert.Equal(t, "cannot demote the last organization owner", msg)
+	})
+
+	t.Run("can demote an organization owner when another owner remains", func(t *testing.T) {
+		secondOwner := support.CreateUser(t, r, r.Organization.ID)
+		_, err := AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgOwner, secondOwner.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+
+		_, err = AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, secondOwner.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+	})
 }

--- a/web_src/src/pages/organization/settings/Members.tsx
+++ b/web_src/src/pages/organization/settings/Members.tsx
@@ -176,13 +176,18 @@ export function Members({ organizationId }: MembersProps) {
 
   const handleRoleChange = async (memberId: string, newRoleName: string) => {
     if (!canUpdateMembers || me?.id === memberId) return;
+    if (ownerIds.has(memberId) && ownerIds.size <= 1 && newRoleName !== "org_owner") {
+      showErrorToast("You must have at least one organization owner.");
+      return;
+    }
+
     try {
       await assignRoleMutation.mutateAsync({
         userId: memberId,
         roleName: newRoleName,
       });
-    } catch {
-      showErrorToast("Failed to update role.");
+    } catch (error) {
+      showErrorToast(getApiErrorMessage(error, "Failed to update role."));
     }
   };
 
@@ -402,11 +407,14 @@ export function Members({ organizationId }: MembersProps) {
                     <TableCell>
                       {(() => {
                         const isSelf = me?.id === member.id;
-                        const roleChangeAllowed = canUpdateMembers && !isSelf;
-                        const tooltipAllowed = roleChangeAllowed || (permissionsLoading && !isSelf);
+                        const isLastOwner = ownerIds.has(member.id) && ownerIds.size <= 1;
+                        const roleChangeAllowed = canUpdateMembers && !isSelf && !isLastOwner;
+                        const tooltipAllowed = roleChangeAllowed || (permissionsLoading && !isSelf && !isLastOwner);
                         const tooltipMessage = isSelf
                           ? "You can't change your own role."
-                          : "You don't have permission to update member roles.";
+                          : isLastOwner
+                            ? "Cannot demote the last organization owner."
+                            : "You don't have permission to update member roles.";
 
                         return (
                           <PermissionTooltip allowed={tooltipAllowed} message={tooltipMessage}>


### PR DESCRIPTION
## Summary
- Block demoting the sole organization owner via the AssignRole API, matching the existing RemoveUser guard
- Disable the role dropdown in Organization Settings → Members when the member is the last owner
- Surface API errors with `getApiErrorMessage` on role change failures
## Problem
The last organization owner could not be removed directly, but could be demoted to Viewer via the role dropdown and then removed — leaving the org with no owner.
## Test plan
- [x] `go test ./pkg/grpc/actions/auth -run Test_AssignRole`
- [x] Manual: as org admin, confirm role dropdown is disabled for the sole owner with tooltip "Cannot demote the last organization owner"
- [x] Manual: confirm demoting an owner still works when another owner remains
- [x] Manual: confirm "Cannot remove last owner" behavior is unchanged

### Before

### Before

| Screenshot | Description |
|---|---|
| ![Remove blocked but role enabled](https://github.com/user-attachments/assets/ff741978-3b8b-47d4-985f-20afc473982d) | The last owner cannot be removed, but the role dropdown stays active — inconsistent guards. |
| ![Owner demoted to Viewer](https://github.com/user-attachments/assets/8c3897c7-463a-485f-a61c-0f29ee768876) | After demoting the sole owner to Viewer, the remove guard no longer applies — org can lose its last owner. |

### After

| Screenshot | Description |
|---|---|
| ![Role change blocked](https://github.com/user-attachments/assets/6aada5eb-f144-4f9f-9f2a-aaa98c3166f1) | Role dropdown is disabled for the last owner with tooltip: "Cannot demote the last organization owner." |

