### PR TITLE
fix: fail agent sessions whose provider stream exceeds the turn deadline

### DIFF
--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -42,6 +42,11 @@ var errCustomToolResultsRequired = errors.New("custom tool results required")
 var errAgentStreamAlreadyLocked = errors.New("agent stream already in progress")
 var errSessionAlreadyReset = errors.New("agent session no longer streaming")
 
+// errStreamAborted means the worker itself is going away mid-turn, so the turn
+// has no outcome to record. It is distinct from the turn's own deadline
+// expiring, which is a real failure the user needs to see.
+var errStreamAborted = errors.New("agent stream aborted before the turn finished")
+
 var publishAgentRunFinished = func(session *models.AgentSession, evt agents.ProviderEvent, idempotencyKey string) error {
 	return messages.NewAgentRunFinishedMessage(
 		session.OrganizationID.String(),
@@ -381,11 +386,32 @@ func (w *AgentStreamWorker) handleLocked(parentCtx context.Context, req messages
 	}
 
 	for {
+		//
+		// Without this the loop can only exit through a turn's return value, so
+		// a shutdown between turns would start another one.
+		//
+		if parentCtx.Err() != nil {
+			log.WithField("session_id", sessionID).Info("agent stream: worker shutting down, not starting another turn")
+			return nil
+		}
+
 		turnStartedAt := session.UpdatedAt
 		publish(messages.AgentSessionEventMessage{Event: "stream_started", Status: models.AgentSessionStatusStreaming})
 
 		streamErr := w.streamProviderTurn(parentCtx, session, publish)
 		closeOpenTools(sessionID, publish)
+
+		//
+		// The worker is going away, so this turn has no outcome to record.
+		// Leave the row streaming on purpose: its heartbeat stops here, so
+		// FailStuckStreamingSessions reclaims it once the grace period passes.
+		// Marking it idle or failed would strand or misreport a turn that
+		// another replica may still be able to finish.
+		//
+		if errors.Is(streamErr, errStreamAborted) {
+			log.WithField("session_id", sessionID).Info("agent stream: worker shut down mid-turn, leaving session for recovery")
+			return nil
+		}
 
 		if streamErr != nil {
 			// Conditional on turnStartedAt so a stream that errors out
@@ -459,6 +485,28 @@ func (w *AgentStreamWorker) streamProviderTurn(
 		if errors.Is(err, errSessionAlreadyReset) {
 			return nil
 		}
+
+		//
+		// A cancelled context here means one of two very different things, and
+		// collapsing them loses the turn. If the parent is gone the worker is
+		// shutting down and the turn simply has no outcome. Otherwise it was
+		// our own agentStreamTimeout firing, which is a genuine failure: the
+		// provider never emits ProviderEventTurnCompleted, so nothing else in
+		// this path will ever record one.
+		//
+		if err != nil && isContextCancel(err) {
+			if parentCtx.Err() != nil {
+				return errStreamAborted
+			}
+			if streamErr == nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					streamErr = fmt.Errorf("agent stream exceeded the %s turn deadline", agentStreamTimeout)
+				} else {
+					streamErr = fmt.Errorf("agent stream was cancelled before the turn finished: %w", err)
+				}
+			}
+		}
+
 		if streamErr == nil && err != nil && !isContextCancel(err) {
 			streamErr = err
 		}
@@ -467,6 +515,9 @@ func (w *AgentStreamWorker) streamProviderTurn(
 		}
 
 		if err := w.executeAndSendCustomToolResults(ctx, session, customTools, publish); err != nil {
+			if isContextCancel(err) && parentCtx.Err() != nil {
+				return errStreamAborted
+			}
 			return err
 		}
 	}

--- a/pkg/workers/agent_stream_worker_test.go
+++ b/pkg/workers/agent_stream_worker_test.go
@@ -629,6 +629,64 @@ func TestAgentStreamWorker_MarksFailedOnSessionError(t *testing.T) {
 	assert.Equal(t, models.AgentSessionStatusFailed, refreshed.Status)
 }
 
+// A turn cut short by agentStreamTimeout never sees ProviderEventTurnCompleted,
+// so nothing downstream publishes a terminal event. Recording it as a completed
+// turn leaves the session idle and the UI waiting forever.
+func TestAgentStreamWorker_FailsSessionWhenTurnDeadlineExpires(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	session := mustCreateSession(t, r, canvas.ID)
+
+	provider := &scriptedProvider{
+		name: testProvider,
+		err:  context.DeadlineExceeded,
+	}
+
+	w := workers.NewAgentStreamWorker(provider, "amqp://ignored")
+	body, _ := json.Marshal(messages.AgentStreamRequest{SessionID: session.ID.String()})
+	require.NoError(t, w.Handle(context.Background(), body))
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusFailed, refreshed.Status,
+		"a turn cut short by its deadline must be reported as failed, not recorded as a completed turn")
+}
+
+// Shutdown is not a turn outcome. The row has to stay streaming so
+// FailStuckStreamingSessions can reclaim it — that sweeper only looks at
+// streaming rows, so marking it idle here would strand the session forever.
+func TestAgentStreamWorker_LeavesSessionStreamingWhenWorkerShutsDown(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	session := mustCreateSession(t, r, canvas.ID)
+
+	provider := &scriptedProvider{
+		name:        testProvider,
+		streamReady: make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+
+	w := workers.NewAgentStreamWorker(provider, "amqp://ignored")
+	body, _ := json.Marshal(messages.AgentStreamRequest{SessionID: session.ID.String()})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Handle(ctx, body)
+	}()
+	<-provider.streamReady
+
+	cancel()
+	require.NoError(t, <-done)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status,
+		"a turn interrupted by shutdown has no outcome to record; the session must stay recoverable")
+}
+
 func TestAgentStreamWorker_SkipsUnknownProvider(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()


### PR DESCRIPTION
Fixes #6462

## What

A provider turn cut short by `agentStreamTimeout` is now reported as a failure instead of being recorded as a completed turn. A turn interrupted by worker shutdown is left alone so it stays recoverable.

## Why

`isContextCancel` matches `context.DeadlineExceeded` as well as `context.Canceled`, and `streamProviderTurn` uses it to decide whether the stream's error is worth keeping:

```go
if streamErr == nil && err != nil && !isContextCancel(err) {
	streamErr = err
}
return streamErr        // nil after a deadline — looks exactly like success
```

But `streamProviderTurn` is itself the thing that imposes that deadline (`ws:443`, `agentStreamTimeout = 15m`). So when a turn runs long, the error it produces is discarded and `handleLocked` takes the success path, marking the session `idle`.

Nothing publishes a terminal event on that path. `turn_completed` comes only from `handleProviderEvent` on `agents.ProviderEventTurnCompleted`, and the deadline kills the stream before the provider emits it. The frontend transitions status only on `stream_started` / `turn_completed` / `session_failed` (`useAgentSessionWebsocket.ts:20-31`), so the chat sits on "thinking" indefinitely.

It also can't be cleaned up. `FailStuckStreamingSessions` only scans rows still in `streaming`, and this one is now `idle` — so the sweeper never sees it. Only a page reload clears the UI, and the partial output is accepted as a finished turn.

Long-running turns are this worker's whole purpose, so this fires on the core use case.

## How

The cancelled-context case was doing the work of three different situations. They're now separated:

| Cause | Outcome |
|---|---|
| Our own turn deadline | `streamErr` set → session `failed`, `session_failed` published |
| Parent context cancelled (shutdown) | New `errStreamAborted` → return without touching status, so the row stays `streaming` and the sweeper reclaims it |
| User Stop | Unchanged — already handled by `errSessionAlreadyReset` |

**The `handleLocked` loop guard is part of the fix, not a drive-by.** That loop never checked `parentCtx`, which is invisible today precisely *because* cancellation returns nil. Making the deadline a failure without it would turn every rolling deploy into a burst of sessions marked `failed`. The two changes have to land together.

Worth noting: the existing `isContextCancel` guard looks like it protects the user-Stop path, but it doesn't — `InterruptSession` is a DB write and never cancels the worker's context. Stop is handled separately. So the guard was only ever swallowing the deadline.

## Tests

Both new tests fail against `main`:

```
--- FAIL: TestAgentStreamWorker_FailsSessionWhenTurnDeadlineExpires
    expected: "failed"
    actual  : "idle"
    a turn cut short by its deadline must be reported as failed, not recorded as a completed turn

--- FAIL: TestAgentStreamWorker_LeavesSessionStreamingWhenWorkerShutsDown
    expected: "streaming"
    actual  : "idle"
    a turn interrupted by shutdown has no outcome to record; the session must stay recoverable
```

and pass with the fix. The existing agent-stream tests — normal turn ends `idle` with `turn_completed`, user Stop exits without overwriting the status, follow-up turns continue — are unchanged and still pass.

## Not included

Three unrelated things turned up while tracing this; noted in the issue and happy to send them separately rather than widen this PR:

- `go eventDistributer.Start()` (`pkg/server/server.go:411`) discards its error, so a bad RabbitMQ URL silently kills every websocket fan-out with no log line.
- `EventRouter.StartRabbitMQConsumer` takes a `ctx` it never reads, so the goroutine outlives shutdown.
- ~15 reconnect loops sleep a flat 5s with no jitter or cap.
