### PR TITLE
feat: add canvas and org IDs to runner task labels

### DIFF
--- a/pkg/components/runner/origin_labels.go
+++ b/pkg/components/runner/origin_labels.go
@@ -4,12 +4,21 @@ import "github.com/superplanehq/superplane/pkg/core"
 
 // OriginLabelsForTask are optional labels for task-broker metrics / Dash0 alerts.
 func OriginLabelsForTask(ctx core.ExecutionContext) map[string]string {
+	canvasID := ctx.WorkflowID
+	organizationID := ctx.OrganizationID
 	canvas := ctx.CanvasName
 	node := ctx.NodeName
-	if canvas == "" && node == "" {
+	if canvasID == "" && organizationID == "" && canvas == "" && node == "" {
 		return nil
 	}
-	labels := make(map[string]string, 2)
+
+	labels := make(map[string]string, 4)
+	if canvasID != "" {
+		labels["canvas_id"] = canvasID
+	}
+	if organizationID != "" {
+		labels["organization_id"] = organizationID
+	}
 	if canvas != "" {
 		labels["canvas_name"] = canvas
 	}

--- a/pkg/components/runner/origin_labels_test.go
+++ b/pkg/components/runner/origin_labels_test.go
@@ -1,0 +1,42 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+func TestOriginLabelsForTask(t *testing.T) {
+	t.Run("returns nil when no origin fields are set", func(t *testing.T) {
+		assert.Nil(t, OriginLabelsForTask(core.ExecutionContext{}))
+	})
+
+	t.Run("includes only non-empty origin fields", func(t *testing.T) {
+		labels := OriginLabelsForTask(core.ExecutionContext{
+			WorkflowID:     "canvas-1",
+			OrganizationID: "org-1",
+			CanvasName:     "release-train",
+			NodeName:       "Run commands",
+		})
+
+		assert.Equal(t, map[string]string{
+			"canvas_id":       "canvas-1",
+			"organization_id": "org-1",
+			"canvas_name":     "release-train",
+			"node_name":       "Run commands",
+		}, labels)
+	})
+
+	t.Run("omits blank fields", func(t *testing.T) {
+		labels := OriginLabelsForTask(core.ExecutionContext{
+			WorkflowID: "canvas-1",
+			NodeName:   "Run commands",
+		})
+
+		assert.Equal(t, map[string]string{
+			"canvas_id": "canvas-1",
+			"node_name": "Run commands",
+		}, labels)
+	})
+}

--- a/pkg/components/runner/run_commands_test.go
+++ b/pkg/components/runner/run_commands_test.go
@@ -410,8 +410,10 @@ func TestRunnerExecuteSendsEnvironmentToBroker(t *testing.T) {
 	component := &Runner{}
 
 	err := component.Execute(core.ExecutionContext{
-		CanvasName: "release-train",
-		NodeName:   "Run commands",
+		WorkflowID:     "canvas-1",
+		OrganizationID: "org-1",
+		CanvasName:     "release-train",
+		NodeName:       "Run commands",
 		Configuration: map[string]any{
 			"machine_type": testRunnerMachineType,
 			"commands":     "echo hello",
@@ -451,8 +453,10 @@ func TestRunnerExecuteSendsEnvironmentToBroker(t *testing.T) {
 	assert.Equal(t, []BrokerCommand{{Command: "echo hello"}}, req.Commands)
 	assert.Equal(t, config.MaxWebhookPayloadSize, req.WebhookPayloadSizeLimit)
 	assert.Equal(t, map[string]string{
-		"canvas_name": "release-train",
-		"node_name":   "Run commands",
+		"canvas_id":       "canvas-1",
+		"organization_id": "org-1",
+		"canvas_name":     "release-train",
+		"node_name":       "Run commands",
 	}, req.Labels)
 }
 


### PR DESCRIPTION
copies the approach of #6363 