### PR TITLE
fix: handle empty repositories in factory Create Branch step

### DIFF
--- a/web_src/src/pages/home/factories/software-factory/canvas.yaml
+++ b/web_src/src/pages/home/factories/software-factory/canvas.yaml
@@ -771,8 +771,21 @@ spec:
           git config --global user.email "automation@example.com"
           git config --global user.name "Factory Automation"
 
-          git clone --depth 1 --branch "$BASE" "$GITURL" "$WORKDIR"
-          cd "$WORKDIR"
+          # Empty repositories have no refs yet: GitHub still reports a default
+          # branch name for them, but cloning it fails with "Remote branch not
+          # found". Initialize the base branch with an empty commit so it can be
+          # cloned and branched from.
+          if [ -z "$(git ls-remote --heads "$GITURL")" ]; then
+            echo "Repository is empty - initializing ${BASE} with an empty commit."
+            git clone "$GITURL" "$WORKDIR"
+            cd "$WORKDIR"
+            git symbolic-ref HEAD "refs/heads/${BASE}"
+            git commit -s --allow-empty -m "chore: initialize ${BASE}"
+            git push -u origin "$BASE"
+          else
+            git clone --depth 1 --branch "$BASE" "$GITURL" "$WORKDIR"
+            cd "$WORKDIR"
+          fi
 
           # Create an empty branch off the base: a single empty commit so a draft PR can be opened,
           # with no files added.


### PR DESCRIPTION
## Problem

Fixes #6366. The Software Factory's **Create Branch** step fails on empty repositories with:

```
fatal: Remote branch main not found in upstream origin
```

## Root cause

The step resolves the default branch via the GitHub API and shallow-clones it:

```bash
BASE="$(gh api "repos/${REPO}" --jq .default_branch)"
git clone --depth 1 --branch "$BASE" "$GITURL" "$WORKDIR"
```

For an **empty** repository, GitHub still reports a `default_branch` (it's a repo *setting*), but no ref exists yet — so cloning that branch fails with exit 128 and the factory run stops.

## Fix

Detect the empty-repository case upfront — `git ls-remote --heads` returns nothing when the repo has no refs — and initialize the base branch with an empty signed commit before branching (option 1 from the issue):

```bash
if [ -z "$(git ls-remote --heads "$GITURL")" ]; then
  git clone "$GITURL" "$WORKDIR"
  cd "$WORKDIR"
  git symbolic-ref HEAD "refs/heads/${BASE}"
  git commit -s --allow-empty -m "chore: initialize ${BASE}"
  git push -u origin "$BASE"
else
  git clone --depth 1 --branch "$BASE" "$GITURL" "$WORKDIR"   # unchanged
  cd "$WORKDIR"
fi
```

`git symbolic-ref HEAD` points the unborn HEAD at the API-reported default branch regardless of the local `init.defaultBranch`, so the initialized branch always matches what GitHub expects.

## Verification

Extracted the actual script from the template and ran it against local bare repositories:

- **Old script + empty repo** → reproduces the exact reported error (`fatal: Remote branch main not found in upstream origin`).
- **Fixed script + empty repo** → initializes `main`, pushes the `fix/<slug>-…` branch, and writes the same result payload:
  ```
  refs: main, fix/fix-the-bug-<ts>-<rand>
  {"branch":"fix/fix-the-bug-…","base":"main",…}
  ```
- **Fixed script + non-empty repo** → identical behavior to before (shallow clone path untouched).

Also validated the modified `canvas.yaml` parses and the embedded script passes `bash -n`.

The downstream Implementation/Checkout steps clone `$BRANCH` (which exists once this step pushes it), so no other template changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)