### PR TITLE
fix: ignore edges to unknown nodes in canvas cycle detection

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/common.go
+++ b/pkg/grpc/actions/canvases/changesets/common.go
@@ -8,6 +8,14 @@ import (
 
 // Verify if the workflow is acyclic using
 // topological sort algorithm - kahn's - to detect cycles
+//
+// Edges into a loop component are skipped, so a loop can receive a feedback
+// edge from its own body without that counting as a cycle.
+//
+// Edges are only considered when both of their ends are in nodes. The check
+// below compares the number of visited nodes against len(nodes), so an edge
+// pointing at an id that is not in nodes would otherwise add an entry that
+// skews that count in either direction.
 func CheckForCycles(nodes []models.Node, edges []models.Edge) error {
 	loopNodeIDs := loopNodeIDSet(nodes)
 
@@ -21,6 +29,14 @@ func CheckForCycles(nodes []models.Node, edges []models.Edge) error {
 
 	for _, edge := range edges {
 		if _, isLoopNode := loopNodeIDs[edge.TargetID]; isLoopNode {
+			continue
+		}
+
+		if _, sourceExists := graph[edge.SourceID]; !sourceExists {
+			continue
+		}
+
+		if _, targetExists := graph[edge.TargetID]; !targetExists {
 			continue
 		}
 

--- a/pkg/grpc/actions/canvases/changesets/common_test.go
+++ b/pkg/grpc/actions/canvases/changesets/common_test.go
@@ -35,3 +35,119 @@ func TestCheckForCycles_RejectsCyclesWithoutLoop(t *testing.T) {
 
 	require.Error(t, changesets.CheckForCycles(nodes, edges))
 }
+
+func regularNode(id string) models.Node {
+	return models.Node{ID: id, Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}}
+}
+
+func loopNode(id string) models.Node {
+	return models.Node{ID: id, Ref: models.NodeRef{Component: &models.ComponentRef{Name: "loop"}}}
+}
+
+func edge(source, target string) models.Edge {
+	return models.Edge{SourceID: source, TargetID: target, Channel: "default"}
+}
+
+func TestCheckForCycles(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodes     []models.Node
+		edges     []models.Edge
+		wantCycle bool
+	}{
+		{
+			name:      "linear graph is acyclic",
+			nodes:     []models.Node{regularNode("a"), regularNode("b"), regularNode("c")},
+			edges:     []models.Edge{edge("a", "b"), edge("b", "c")},
+			wantCycle: false,
+		},
+		{
+			name:  "diamond is acyclic",
+			nodes: []models.Node{regularNode("a"), regularNode("b"), regularNode("c"), regularNode("d")},
+			edges: []models.Edge{
+				edge("a", "b"), edge("a", "c"), edge("b", "d"), edge("c", "d"),
+			},
+			wantCycle: false,
+		},
+		{
+			name:      "self loop on a regular component is a cycle",
+			nodes:     []models.Node{regularNode("a")},
+			edges:     []models.Edge{edge("a", "a")},
+			wantCycle: true,
+		},
+		{
+			name:  "feedback edge into a loop node is allowed",
+			nodes: []models.Node{regularNode("trigger"), loopNode("loop"), regularNode("worker")},
+			edges: []models.Edge{
+				edge("trigger", "loop"), edge("loop", "worker"), edge("worker", "loop"),
+			},
+			wantCycle: false,
+		},
+		{
+			name:  "feedback edge from deeper in the loop body is allowed",
+			nodes: []models.Node{loopNode("loop"), regularNode("w1"), regularNode("w2")},
+			edges: []models.Edge{
+				edge("loop", "w1"), edge("w1", "w2"), edge("w2", "loop"),
+			},
+			wantCycle: false,
+		},
+		{
+			// A loop and a single body node, with no separate trigger feeding the
+			// loop. The exemption covers the feedback edge, so this is a loop rather
+			// than a cycle.
+			name:  "loop and its body alone are allowed",
+			nodes: []models.Node{regularNode("a"), loopNode("loop")},
+			edges: []models.Edge{
+				edge("loop", "a"), edge("a", "loop"),
+			},
+			wantCycle: false,
+		},
+		{
+			// The exemption is what makes a loop possible, so it holds however many
+			// nodes the body spans.
+			name:  "loop with a multi node body is allowed",
+			nodes: []models.Node{regularNode("a"), loopNode("loop"), regularNode("b")},
+			edges: []models.Edge{
+				edge("loop", "b"), edge("b", "a"), edge("a", "loop"),
+			},
+			wantCycle: false,
+		},
+		{
+			name:  "cycle between regular components downstream of a loop is a cycle",
+			nodes: []models.Node{loopNode("loop"), regularNode("a"), regularNode("b")},
+			edges: []models.Edge{
+				edge("loop", "a"), edge("a", "b"), edge("b", "a"),
+			},
+			wantCycle: true,
+		},
+		{
+			name:      "edge referencing an unknown node does not report a cycle",
+			nodes:     []models.Node{regularNode("a")},
+			edges:     []models.Edge{edge("a", "ghost")},
+			wantCycle: false,
+		},
+		{
+			// Counting visited nodes and comparing against len(nodes) breaks down
+			// once an edge points at an id that is not in nodes: the unknown target
+			// is visited too, which can pad the count back up to len(nodes) and hide
+			// a real cycle elsewhere in the graph.
+			name:  "unknown node in an edge does not mask a real cycle",
+			nodes: []models.Node{regularNode("a"), regularNode("b"), regularNode("c")},
+			edges: []models.Edge{
+				edge("c", "ghost-1"), edge("c", "ghost-2"), edge("a", "b"), edge("b", "a"),
+			},
+			wantCycle: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := changesets.CheckForCycles(tt.nodes, tt.edges)
+			if tt.wantCycle {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## What changed

`CheckForCycles` now ignores an edge unless both of its ends are present in `nodes`, and the helper gains a test table covering the loop component exemption.

## Why

The check counts how many nodes a Kahn topological sort reaches and compares that against `len(nodes)`. An edge whose target is not in `nodes` still creates an `inDegree` entry for that id, so the sort can visit ids that were never workflow nodes. The two sides then measure different sets, and it breaks in both directions:

- **False positive.** Nodes `{a}`, edge `a -> ghost`. The sort visits `a` and `ghost`, so `visited` is 2 against a `len(nodes)` of 1, and an acyclic graph is reported as a cycle.
- **False negative.** Nodes `{a, b, c}`, edges `c -> ghost-1`, `c -> ghost-2`, `a -> b`, `b -> a`. The two ghosts pad `visited` back up to 3, which matches `len(nodes)`, so the real `a -> b -> a` cycle is accepted.

Both are covered by tests that fail on `main` and pass here.

**Not oversold:** I could not reach either case through the current callers. `CanvasPatcher.addEdge` rejects an edge whose source or target is missing, `deleteNode` removes the edges attached to the node it deletes, and `pkg/yaml` validates every edge before calling this. So this hardens a helper that is correct only because its callers are careful, rather than fixing something users can hit today. It seemed worth closing while the tests were being written, because the failure mode is silent.

## Tests

The helper had two tests. This adds a table covering linear and diamond graphs, a self-loop, the loop exemption with a trigger, a loop and body with no trigger, a multi-node loop body, a cycle between regular components downstream of a loop, and the two unknown-node cases.

The loop exemption is subtler than it looks: skipping every edge into a loop node is exactly what lets a loop receive a feedback edge from its body. I first read it as too broad and tried replacing it with DFS back-edge classification. That was wrong — which edge of a loop counts as the "back" edge depends on where the walk starts, so the same graph gave different verdicts under different node orderings. These tests pin the existing behaviour down instead.

## Related

Found while looking at #5773. This does not fix it: the backend already rejects that report's two-regular-component cycle, which the pre-existing `TestCheckForCycles_RejectsCyclesWithoutLoop` covers. The remaining gap there looks frontend-side — the edge can be drawn, and the user meets `graph contains a cycle` at publish time instead of the connection being refused.

## Note

`pkg/components/loop` exports `ComponentName = "loop"` while `loopNodeIDSet` hardcodes the literal. Left alone to keep this diff on topic.

## Verification

Run locally without the Docker stack:

```
go test ./pkg/grpc/actions/canvases/changesets/ -run TestCheckForCycles -v   # 13 pass
go vet ./pkg/grpc/actions/canvases/changesets/
gofmt -s -l pkg/grpc/actions/canvases/changesets/
revive -formatter friendly -config lint.toml ./pkg/grpc/actions/canvases/changesets/...
go test ./pkg/yaml/...                                                       # other caller
```

With `common.go` reverted, exactly the two unknown-node cases fail; every other case passes on `main` too, since they document existing behaviour.
