### PR TITLE
fix: number config fields snap back to default when cleared

### DIFF
--- a/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.spec.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConfigurationField } from "@/api-client";
+
+import { NumberFieldRenderer } from "./NumberFieldRenderer";
+
+function numberField(overrides: Partial<ConfigurationField> = {}): ConfigurationField {
+  return {
+    name: "timeout",
+    type: "number",
+    label: "Timeout",
+    ...overrides,
+  } as ConfigurationField;
+}
+
+function ControlledNumber({
+  field,
+  initialValue,
+  onChange,
+}: {
+  field: ConfigurationField;
+  initialValue?: unknown;
+  onChange?: (value: unknown) => void;
+}) {
+  const [value, setValue] = useState<unknown>(initialValue);
+  return (
+    <NumberFieldRenderer
+      field={field}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+}
+
+describe("NumberFieldRenderer", () => {
+  it("applies the default value on first render when no value is present", () => {
+    const onChange = vi.fn();
+    render(<ControlledNumber field={numberField({ defaultValue: "3" })} onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith(3);
+    expect(screen.getByRole("spinbutton")).toHaveValue(3);
+  });
+
+  it("renders the current value", () => {
+    render(<ControlledNumber field={numberField()} initialValue={42} />);
+
+    expect(screen.getByRole("spinbutton")).toHaveValue(42);
+  });
+
+  it("emits undefined when the field is cleared", () => {
+    const onChange = vi.fn();
+    render(<ControlledNumber field={numberField({ defaultValue: "3" })} initialValue={3} onChange={onChange} />);
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "" } });
+
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it("stays empty after being cleared instead of snapping back to the default value", () => {
+    render(<ControlledNumber field={numberField({ defaultValue: "3" })} initialValue={3} />);
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "" } });
+
+    expect(screen.getByRole("spinbutton")).toHaveValue(null);
+  });
+
+  it("emits a number when a valid value is typed", () => {
+    const onChange = vi.fn();
+    render(<ControlledNumber field={numberField()} onChange={onChange} />);
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "7" } });
+
+    expect(onChange).toHaveBeenLastCalledWith(7);
+  });
+
+  it("exposes the configured min and max as input attributes", () => {
+    render(<ControlledNumber field={numberField({ typeOptions: { number: { min: 2, max: 4 } } })} />);
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.min).toBe("2");
+    expect(input.max).toBe("4");
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.tsx
@@ -1,12 +1,17 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import type { FieldRendererProps } from "./types";
 
 export const NumberFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange }) => {
   const numberOptions = field.typeOptions?.number;
+  const seededDefaultRef = useRef(false);
 
-  // Set initial value on first render if no value is present but there's a default
+  // Set the default value on mount if no value is present. The guard is armed on
+  // the effect's first run so a later clear (value -> undefined) never re-seeds
+  // the default, which would snap the input back (see issue #6399).
   useEffect(() => {
+    if (seededDefaultRef.current) return;
+    seededDefaultRef.current = true;
     if ((value === undefined || value === null) && field.defaultValue !== undefined) {
       const defaultVal = Number(field.defaultValue);
       if (!isNaN(defaultVal)) {
@@ -18,7 +23,7 @@ export const NumberFieldRenderer: React.FC<FieldRendererProps> = ({ field, value
   return (
     <Input
       type="number"
-      value={(value as string | number) ?? (field.defaultValue as string) ?? ""}
+      value={(value ?? "") as string | number}
       onChange={(e) => {
         const val = e.target.value === "" ? undefined : Number(e.target.value);
         onChange(val);


### PR DESCRIPTION
## Problem

Fixes #6399

Clearing a number configuration field (e.g. a runner timeout) and then typing a new value is impossible: the moment the field becomes empty, the input snaps back to the field's default value.

## Root cause

In `NumberFieldRenderer`:

- `onChange(undefined)` is emitted when the input is cleared, but the render fell back to `field.defaultValue` whenever `value` was `undefined`:

  ```tsx
  value={(value as string | number) ?? (field.defaultValue as string) ?? ""}
  ```

- the seed-default `useEffect` re-armed on every `value -> undefined` transition, re-writing the default through `onChange` after the user cleared the field.

## Fix

- Render `value ?? ""` so a cleared field stays empty.
- Arm the default-seeding `useEffect` on its first run only, so it seeds the default on mount when no value is present but never re-seeds after the user clears the field.

## Tests

Added `NumberFieldRenderer.spec.tsx` covering: default seeding on mount, rendering the current value, emitting `undefined` on clear, staying empty after clear (regression), emitting numbers on input, and min/max attribute propagation.

`npx vitest run src/ui/configurationFieldRenderer/NumberFieldRenderer.spec.tsx` — 6/6 passing.
`npx eslint` and `npx tsc --noEmit` — clean.
