### PR TITLE
feat: add visual file change indicators

### DIFF
--- a/web_src/src/pages/app/files/FileEditor.tsx
+++ b/web_src/src/pages/app/files/FileEditor.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from "react";
 
 import { MarkdownContent } from "../Markdown";
 import { getFileMonacoLanguage } from "./lib/monaco-language";
+import type { FileChangeStatus } from "./types";
 
 const FileMonacoEditor = lazy(() =>
   import("./FileMonacoEditor").then((module) => ({ default: module.FileMonacoEditor })),
@@ -12,7 +13,7 @@ export function FileEditor({
   content,
   canvasId,
   organizationId,
-  deleted,
+  status,
   language,
   loading,
   errorMessage,
@@ -23,7 +24,7 @@ export function FileEditor({
   content: string;
   canvasId?: string;
   organizationId?: string;
-  deleted: boolean;
+  status?: FileChangeStatus;
   language?: string;
   loading: boolean;
   errorMessage?: string;
@@ -46,18 +47,11 @@ export function FileEditor({
     return <div className="p-4 text-sm text-red-600">{errorMessage}</div>;
   }
 
-  if (deleted) {
-    return (
-      <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-slate-500 dark:text-gray-400">
-        File marked for deletion
-      </div>
-    );
-  }
-
   const resolvedLanguage = language ?? getFileMonacoLanguage(path);
   const isMarkdown = resolvedLanguage === "markdown";
+  const deleted = status === "deleted";
 
-  if (disabled && isMarkdown) {
+  if (disabled && isMarkdown && !deleted) {
     return (
       <div className="min-h-0 flex-1 overflow-auto bg-white p-6 dark:bg-gray-900">
         <MarkdownContent
@@ -78,7 +72,14 @@ export function FileEditor({
         </div>
       }
     >
-      <FileMonacoEditor path={path} content={content} language={language} readOnly={disabled} onChange={onChange} />
+      <FileMonacoEditor
+        path={path}
+        content={content}
+        language={language}
+        status={status}
+        readOnly={disabled}
+        onChange={onChange}
+      />
     </Suspense>
   );
 }

--- a/web_src/src/pages/app/files/FileList.tsx
+++ b/web_src/src/pages/app/files/FileList.tsx
@@ -2,7 +2,7 @@ import { Input } from "@/components/ui/input";
 import { useTheme } from "@/contexts/useTheme";
 import { FileTree as TreesFileTree, useFileTree } from "@pierre/trees/react";
 import { useEffect, useMemo, useRef } from "react";
-import type { ContextMenuItem, ContextMenuOpenContext } from "@pierre/trees";
+import type { ContextMenuItem, ContextMenuOpenContext, GitStatusEntry } from "@pierre/trees";
 
 import { getRepositoryFileTreeStyle } from "./types";
 
@@ -19,6 +19,7 @@ export function FileList({
   onNewFileCommit,
   onNewFilePathChange,
   onSelect,
+  gitStatus,
 }: {
   paths: string[];
   selectedPath: string | null;
@@ -32,6 +33,7 @@ export function FileList({
   onNewFileCommit: () => void;
   onNewFilePathChange: (path: string) => void;
   onSelect: (path: string) => void;
+  gitStatus: GitStatusEntry[];
 }) {
   if (loading) {
     return <div className="flex-1 p-4 text-sm text-slate-500 dark:text-gray-400">Loading files...</div>;
@@ -62,6 +64,7 @@ export function FileList({
         readOnlyPaths={readOnlyPaths}
         onDelete={onDelete}
         onSelect={onSelect}
+        gitStatus={gitStatus}
       />
     </div>
   );
@@ -128,6 +131,7 @@ function RepositoryFileTree({
   readOnlyPaths,
   onDelete,
   onSelect,
+  gitStatus,
 }: {
   paths: string[];
   selectedPath: string | null;
@@ -135,6 +139,7 @@ function RepositoryFileTree({
   readOnlyPaths: Set<string>;
   onDelete: (path: string) => void;
   onSelect: (path: string) => void;
+  gitStatus: GitStatusEntry[];
 }) {
   const filePathSetRef = useRef(new Set(paths));
   const readOnlyPathSetRef = useRef(readOnlyPaths);
@@ -163,6 +168,7 @@ function RepositoryFileTree({
 
   const { model } = useFileTree({
     paths,
+    gitStatus,
     density: "compact",
     flattenEmptyDirectories: true,
     icons: { set: "minimal", colored: false },
@@ -173,6 +179,11 @@ function RepositoryFileTree({
       [data-file-tree-virtualized-scroll='true'] {
         scrollbar-gutter: auto;
         padding-inline-end: 0;
+      }
+      [data-item-git-status='deleted'] > [data-item-section='content'] {
+        text-decoration: line-through;
+        text-decoration-color: currentColor;
+        text-decoration-thickness: 1px;
       }
     `,
     onSelectionChange: (selectedPaths) => {
@@ -185,6 +196,10 @@ function RepositoryFileTree({
   useEffect(() => {
     model.resetPaths(paths);
   }, [model, paths]);
+
+  useEffect(() => {
+    model.setGitStatus(gitStatus);
+  }, [gitStatus, model]);
 
   useEffect(() => {
     const selectedPaths = model.getSelectedPaths();

--- a/web_src/src/pages/app/files/FileMonacoEditor.spec.tsx
+++ b/web_src/src/pages/app/files/FileMonacoEditor.spec.tsx
@@ -6,10 +6,49 @@ import { ThemeProvider } from "@/contexts/ThemeProvider";
 
 import { FileMonacoEditor } from "./FileMonacoEditor";
 
+const { deltaDecorations } = vi.hoisted(() => ({
+  deltaDecorations: vi.fn(() => ["decoration-1"]),
+}));
+
 vi.mock("@monaco-editor/react", () => ({
-  Editor: ({ value, onChange }: { value?: string; onChange?: (value: string | undefined) => void }) => (
-    <textarea data-testid="monaco-stub" value={value ?? ""} onChange={(event) => onChange?.(event.target.value)} />
-  ),
+  Editor: ({
+    value,
+    onChange,
+    onMount,
+    options,
+  }: {
+    value?: string;
+    onChange?: (value: string | undefined) => void;
+    onMount?: (editor: unknown, monaco: unknown) => void;
+    options?: { readOnly?: boolean };
+  }) => {
+    onMount?.(
+      {
+        getModel: () => ({ getLineCount: () => 2, getLineMaxColumn: () => 7 }),
+        deltaDecorations,
+        onDidDispose: vi.fn(),
+      },
+      {
+        Range: class {
+          constructor(
+            readonly startLineNumber: number,
+            readonly startColumn: number,
+            readonly endLineNumber: number,
+            readonly endColumn: number,
+          ) {}
+        },
+      },
+    );
+
+    return (
+      <textarea
+        data-testid="monaco-stub"
+        data-read-only={options?.readOnly ? "true" : "false"}
+        value={value ?? ""}
+        onChange={(event) => onChange?.(event.target.value)}
+      />
+    );
+  },
 }));
 
 function ControlledEditorHarness({ initialPath, initialContent }: { initialPath: string; initialContent: string }) {
@@ -42,6 +81,40 @@ function ControlledEditorHarness({ initialPath, initialContent }: { initialPath:
 }
 
 describe("FileMonacoEditor", () => {
+  it("decorates every line with the added or deleted file color", () => {
+    deltaDecorations.mockClear();
+    const { rerender } = render(
+      <ThemeProvider>
+        <FileMonacoEditor path="README.md" content="# readme\n" status="added" readOnly={false} onChange={vi.fn()} />
+      </ThemeProvider>,
+    );
+
+    expect(deltaDecorations).toHaveBeenLastCalledWith(
+      [],
+      [
+        expect.objectContaining({
+          options: expect.objectContaining({ inlineClassName: "!text-green-600 dark:!text-green-400" }),
+        }),
+      ],
+    );
+
+    rerender(
+      <ThemeProvider>
+        <FileMonacoEditor path="README.md" content="# readme\n" status="deleted" readOnly onChange={vi.fn()} />
+      </ThemeProvider>,
+    );
+
+    expect(deltaDecorations).toHaveBeenLastCalledWith(
+      ["decoration-1"],
+      [
+        expect.objectContaining({
+          options: expect.objectContaining({ inlineClassName: "!text-red-600 dark:!text-red-400" }),
+        }),
+      ],
+    );
+    expect(screen.getByTestId("monaco-stub")).toHaveAttribute("data-read-only", "true");
+  });
+
   it("records the first edit after switching back to a file", async () => {
     const user = userEvent.setup();
 

--- a/web_src/src/pages/app/files/FileMonacoEditor.tsx
+++ b/web_src/src/pages/app/files/FileMonacoEditor.tsx
@@ -1,8 +1,9 @@
-import { Editor } from "@monaco-editor/react";
+import { Editor, type OnMount } from "@monaco-editor/react";
 import { useCallback, useEffect, useRef } from "react";
 
 import { useTheme } from "@/contexts/useTheme";
 import { getFileMonacoLanguage } from "./lib/monaco-language";
+import type { FileChangeStatus } from "./types";
 
 const fileEditorOptions = {
   minimap: { enabled: false },
@@ -26,15 +27,53 @@ interface FileMonacoEditorProps {
   path: string;
   content: string;
   language?: string;
+  status?: FileChangeStatus;
   readOnly: boolean;
   onChange: (value: string) => void;
 }
 
-export function FileMonacoEditor({ path, content, language, readOnly, onChange }: FileMonacoEditorProps) {
+type MonacoEditor = Parameters<OnMount>[0];
+type Monaco = Parameters<OnMount>[1];
+type FileDecorationState = {
+  path: string;
+  content: string;
+  status?: FileChangeStatus;
+};
+
+function buildFileContentDecorations(editor: MonacoEditor, monaco: Monaco, status?: FileChangeStatus) {
+  const inlineClassName =
+    status === "added"
+      ? "!text-green-600 dark:!text-green-400"
+      : status === "deleted"
+        ? "!text-red-600 dark:!text-red-400"
+        : undefined;
+  if (!inlineClassName) return [];
+
+  const model = editor.getModel();
+  if (!model) return [];
+
+  const lastLineNumber = model.getLineCount();
+  return [
+    {
+      range: new monaco.Range(1, 1, lastLineNumber, model.getLineMaxColumn(lastLineNumber)),
+      options: {
+        inlineClassName,
+      },
+    },
+  ];
+}
+
+export function FileMonacoEditor({ path, content, language, status, readOnly, onChange }: FileMonacoEditorProps) {
   const { resolvedTheme } = useTheme();
   const monacoTheme = resolvedTheme === "dark" ? "vs-dark" : "vs";
   const suppressNextChangeRef = useRef(false);
   const previousPathRef = useRef(path);
+  const editorRef = useRef<MonacoEditor | null>(null);
+  const monacoRef = useRef<Monaco | null>(null);
+  const decorationIdsRef = useRef<string[]>([]);
+  const currentFileStateRef = useRef<FileDecorationState>({ path, content, status });
+  const decoratedFileStateRef = useRef<FileDecorationState | null>(null);
+  currentFileStateRef.current = { path, content, status };
 
   useEffect(() => {
     if (previousPathRef.current === path) return;
@@ -61,6 +100,48 @@ export function FileMonacoEditor({ path, content, language, readOnly, onChange }
     [content, onChange],
   );
 
+  const applyFileDecorations = useCallback((editor: MonacoEditor, monaco: Monaco) => {
+    const nextState = currentFileStateRef.current;
+    const previousState = decoratedFileStateRef.current;
+    if (
+      previousState?.path === nextState.path &&
+      previousState.content === nextState.content &&
+      previousState.status === nextState.status
+    ) {
+      return;
+    }
+
+    decorationIdsRef.current = editor.deltaDecorations(
+      decorationIdsRef.current,
+      buildFileContentDecorations(editor, monaco, nextState.status),
+    );
+    decoratedFileStateRef.current = nextState;
+  }, []);
+
+  const handleMount = useCallback<OnMount>(
+    (editor, monaco) => {
+      editorRef.current = editor;
+      monacoRef.current = monaco;
+      applyFileDecorations(editor, monaco);
+      editor.onDidDispose(() => {
+        if (editorRef.current !== editor) return;
+        editorRef.current = null;
+        monacoRef.current = null;
+        decorationIdsRef.current = [];
+        decoratedFileStateRef.current = null;
+      });
+    },
+    [applyFileDecorations],
+  );
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    const monaco = monacoRef.current;
+    if (!editor || !monaco) return;
+
+    applyFileDecorations(editor, monaco);
+  }, [applyFileDecorations, content, path, status]);
+
   return (
     <div className="min-h-0 flex-1 bg-white dark:bg-gray-900" data-testid="file-editor">
       <Editor
@@ -70,6 +151,7 @@ export function FileMonacoEditor({ path, content, language, readOnly, onChange }
         value={content}
         theme={monacoTheme}
         onChange={handleChange}
+        onMount={handleMount}
         options={{
           ...fileEditorOptions,
           readOnly,

--- a/web_src/src/pages/app/files/FilesOverlayLayer.spec.tsx
+++ b/web_src/src/pages/app/files/FilesOverlayLayer.spec.tsx
@@ -16,6 +16,7 @@ const repositoryFileContents: Record<string, string> = {
   "notes/scratchpad.json": '{ "hello": "agent" }',
 };
 let stagedPaths: string[] = [];
+let repositoryFileQueryStages: Array<{ path: string; stage: boolean }> = [];
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
@@ -40,11 +41,20 @@ vi.mock("@/hooks/useCanvasData", () => ({
     isLoading: false,
     error: null,
   }),
-  useCanvasRepositoryFile: (_canvasId: string, path: string | null) => ({
-    data: path && repositoryFileContents[path] ? { path, content: repositoryFileContents[path] } : undefined,
-    isLoading: false,
-    error: null,
-  }),
+  useCanvasRepositoryFile: (
+    _canvasId: string,
+    path: string | null,
+    _enabled: boolean,
+    _versionId: string | undefined,
+    stage: boolean,
+  ) => {
+    if (path) repositoryFileQueryStages.push({ path, stage });
+    return {
+      data: path && repositoryFileContents[path] ? { path, content: repositoryFileContents[path] } : undefined,
+      isLoading: false,
+      error: null,
+    };
+  },
   useStageRepositoryFiles: () => ({
     mutate: vi.fn(),
     mutateAsync: vi.fn(),
@@ -71,27 +81,48 @@ vi.mock("@monaco-editor/react", () => ({
 }));
 
 vi.mock("@pierre/trees/react", () => ({
-  FileTree: ({ model }: { model: { paths: string[]; selectPath?: (path: string) => void } }) => (
+  FileTree: ({
+    model,
+    renderContextMenu,
+  }: {
+    model: {
+      paths: string[];
+      gitStatus?: Array<{ path: string; status: string }>;
+      selectPath?: (path: string) => void;
+    };
+    renderContextMenu?: (item: { kind: "file"; path: string }, context: { close: () => void }) => ReactNode;
+  }) => (
     <>
-      {model.paths.map((path) => (
-        <button type="button" key={path} onClick={() => model.selectPath?.(path)}>
-          {path}
-        </button>
-      ))}
+      {model.paths.map((path) => {
+        const status = model.gitStatus?.find((entry) => entry.path === path)?.status;
+
+        return (
+          <div key={path} data-testid={`file-tree-row-${path}`}>
+            <button type="button" data-git-status={status} onClick={() => model.selectPath?.(path)}>
+              {path}
+            </button>
+            {renderContextMenu?.({ kind: "file", path }, { close: vi.fn() })}
+          </div>
+        );
+      })}
     </>
   ),
   useFileTree: ({
     paths,
+    gitStatus,
     onSelectionChange,
   }: {
     paths: string[];
+    gitStatus?: Array<{ path: string; status: string }>;
     onSelectionChange?: (selectedPaths: string[]) => void;
   }) => {
     return {
       model: {
         paths,
+        gitStatus,
         selectPath: (path: string) => onSelectionChange?.([path]),
         resetPaths: vi.fn(),
+        setGitStatus: vi.fn(),
         getSelectedPaths: () => [],
         getItem: () => ({
           select: vi.fn(),
@@ -106,6 +137,7 @@ vi.mock("@pierre/trees/react", () => ({
 describe("FilesOverlayLayer", () => {
   beforeEach(() => {
     stagedPaths = [];
+    repositoryFileQueryStages = [];
     queryClient.clear();
     localStorage.clear();
     useSidebarLayoutStore.getState().hydrateFromStorage();
@@ -141,6 +173,32 @@ describe("FilesOverlayLayer", () => {
     expect(screen.queryByTestId("monaco-stub")).not.toBeInTheDocument();
   });
 
+  it("keeps deleted files visible with committed content and a committed read", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FilesOverlayLayer
+        isFilesMode
+        canvasId="canvas-1"
+        versionId="version-1"
+        isEditing
+        canWrite
+        files={[{ path: "canvas.yaml", content: "canvas: true", language: "yaml" }]}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await user.click(screen.getAllByRole("button", { name: "README.md" })[0]!);
+    await user.click(within(screen.getByTestId("file-tree-row-README.md")).getByRole("menuitem", { name: "Delete" }));
+
+    expect(
+      within(screen.getByTestId("file-tree-row-README.md")).getByRole("button", { name: "README.md" }),
+    ).toHaveAttribute("data-git-status", "deleted");
+    expect(screen.getByTestId("monaco-stub")).toHaveValue("# readme");
+    expect(screen.queryByText("File marked for deletion")).not.toBeInTheDocument();
+    expect(repositoryFileQueryStages.at(-1)).toEqual({ path: "README.md", stage: false });
+  });
+
   it("keeps the first edit after switching away and back to a repository file", async () => {
     const user = userEvent.setup();
 
@@ -163,6 +221,9 @@ describe("FilesOverlayLayer", () => {
 
     await user.click(screen.getAllByRole("button", { name: "README.md" })[0]!);
     await user.type(screen.getByTestId("monaco-stub"), "!");
+    expect(
+      within(screen.getByTestId("file-tree-row-README.md")).getByRole("button", { name: "README.md" }),
+    ).toHaveAttribute("data-git-status", "modified");
 
     await user.click(screen.getAllByRole("button", { name: "canvas.yaml" })[0]!);
     await user.click(screen.getAllByRole("button", { name: "README.md" }).at(-1)!);
@@ -266,6 +327,30 @@ describe("FilesOverlayLayer", () => {
 
     expect(screen.queryByDisplayValue("untitled.txt")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Close untitled.txt" })).not.toBeInTheDocument();
+  });
+
+  it("marks a new file as added", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FilesOverlayLayer
+        isFilesMode
+        canvasId="test-canvas"
+        isEditing
+        canWrite
+        files={[{ path: "canvas.yaml", content: "canvas: true", language: "yaml" }]}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await user.click(screen.getByRole("button", { name: "New file" }));
+    const newFileInput = screen.getByDisplayValue("untitled.txt");
+    await user.clear(newFileInput);
+    await user.type(newFileInput, "notes.txt{Enter}");
+
+    expect(
+      within(screen.getByTestId("file-tree-row-notes.txt")).getByRole("button", { name: "notes.txt" }),
+    ).toHaveAttribute("data-git-status", "added");
   });
 
   it("re-resolves the header actions portal host when entering edit mode", async () => {

--- a/web_src/src/pages/app/files/FilesOverlayLayer.spec.tsx
+++ b/web_src/src/pages/app/files/FilesOverlayLayer.spec.tsx
@@ -10,7 +10,7 @@ import { useSidebarLayoutStore } from "@/stores/sidebarLayoutStore";
 
 import { FilesOverlayLayer } from "./FilesOverlayLayer";
 
-const repositoryFiles = [{ path: "README.md" }];
+let repositoryFiles = [{ path: "README.md" }];
 const repositoryFileContents: Record<string, string> = {
   "README.md": "# readme",
   "notes/scratchpad.json": '{ "hello": "agent" }',
@@ -136,6 +136,7 @@ vi.mock("@pierre/trees/react", () => ({
 
 describe("FilesOverlayLayer", () => {
   beforeEach(() => {
+    repositoryFiles = [{ path: "README.md" }];
     stagedPaths = [];
     repositoryFileQueryStages = [];
     queryClient.clear();
@@ -176,7 +177,7 @@ describe("FilesOverlayLayer", () => {
   it("keeps deleted files visible with committed content and a committed read", async () => {
     const user = userEvent.setup();
 
-    render(
+    const { rerender } = render(
       <FilesOverlayLayer
         isFilesMode
         canvasId="canvas-1"
@@ -197,6 +198,22 @@ describe("FilesOverlayLayer", () => {
     expect(screen.getByTestId("monaco-stub")).toHaveValue("# readme");
     expect(screen.queryByText("File marked for deletion")).not.toBeInTheDocument();
     expect(repositoryFileQueryStages.at(-1)).toEqual({ path: "README.md", stage: false });
+
+    repositoryFiles = [];
+    rerender(
+      <FilesOverlayLayer
+        isFilesMode
+        canvasId="canvas-1"
+        versionId="version-1"
+        isEditing
+        canWrite
+        files={[{ path: "canvas.yaml", content: "canvas: true", language: "yaml" }]}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId("file-tree-row-README.md")).getByRole("button", { name: "README.md" }),
+    ).toHaveAttribute("data-git-status", "deleted");
   });
 
   it("keeps the first edit after switching away and back to a repository file", async () => {

--- a/web_src/src/pages/app/files/FilesView.tsx
+++ b/web_src/src/pages/app/files/FilesView.tsx
@@ -81,6 +81,7 @@ export function FilesView({
           onNewFileCommit={editor.createNewFile}
           onNewFilePathChange={editor.setNewFilePath}
           onSelect={editor.openFile}
+          gitStatus={editor.gitStatus}
         />
       </aside>
 
@@ -99,7 +100,7 @@ export function FilesView({
           content={editor.selectedContent}
           canvasId={canvasId}
           organizationId={organizationId}
-          deleted={editor.selectedIsDeleted}
+          status={editor.selectedFileStatus}
           language={editor.selectedGeneratedFile?.language}
           loading={editor.editorLoading}
           errorMessage={editor.editorErrorMessage}

--- a/web_src/src/pages/app/files/lib/build-files-editor-result.ts
+++ b/web_src/src/pages/app/files/lib/build-files-editor-result.ts
@@ -1,4 +1,5 @@
 import { isWorkflowSpecPath } from "../../lib/workflow-spec-paths";
+import type { GitStatusEntry } from "@pierre/trees";
 import {
   getRepositoryFileListErrorMessage,
   getRepositoryFileListLoading,
@@ -47,6 +48,7 @@ type EditorViewParams = {
   isDiffOpen: boolean;
   setIsDiffOpen: (open: boolean) => void;
   headerActionsHost: HTMLElement | null;
+  gitStatus: GitStatusEntry[];
 };
 
 export function buildFilesEditorResult({
@@ -65,6 +67,7 @@ export function buildFilesEditorResult({
   isDiffOpen,
   setIsDiffOpen,
   headerActionsHost,
+  gitStatus,
 }: EditorViewParams) {
   const selectedChange = tabs.selectedPath ? pending.pendingChangesByPath[tabs.selectedPath] : undefined;
   const selectedSpecDraft =
@@ -75,6 +78,7 @@ export function buildFilesEditorResult({
     selectedChange,
     selectedSpecDraft,
     loadedContentByPath,
+    committedContentByPath,
     selectedPathExistsInRepository: selection.selectedPathExistsInRepository,
     selectedFileQuery: selection.selectedFileQuery,
     canManageRepositoryFiles,
@@ -99,7 +103,7 @@ export function buildFilesEditorResult({
     stagedDiffPaths,
     stagedFileDiffs,
     selectedContent: editorView.selectedContent,
-    selectedIsDeleted: editorView.selectedIsDeleted,
+    selectedFileStatus: selectedChange?.type,
     selectedGeneratedFile: selection.selectedGeneratedFile,
     editorLoading: editorView.editorLoading,
     editorErrorMessage: editorView.editorErrorMessage,
@@ -119,5 +123,6 @@ export function buildFilesEditorResult({
     openFile: tabs.openFile,
     closeTab: tabs.closeTab,
     setNewFilePath: pending.setNewFilePath,
+    gitStatus,
   };
 }

--- a/web_src/src/pages/app/files/lib/files-paths.spec.ts
+++ b/web_src/src/pages/app/files/lib/files-paths.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { getPathValidationError, nextUntitledPath, normalizeFilePath } from "./files-paths";
+import {
+  buildFinalRepositoryPaths,
+  buildRenderableTreePaths,
+  getPathValidationError,
+  nextUntitledPath,
+  normalizeFilePath,
+} from "./files-paths";
 
 describe("files-paths", () => {
   it("normalizes file paths", () => {
@@ -15,5 +21,12 @@ describe("files-paths", () => {
 
   it("detects duplicate paths", () => {
     expect(getPathValidationError(["a.txt", "a.txt"])).toContain("already used");
+  });
+
+  it("keeps deleted files renderable while excluding them from final repository paths", () => {
+    const deletedChange = { type: "deleted" as const, path: "README.md" };
+
+    expect(buildRenderableTreePaths(["README.md"], [deletedChange])).toEqual(["README.md"]);
+    expect(buildFinalRepositoryPaths(["README.md"], [deletedChange])).toEqual([]);
   });
 });

--- a/web_src/src/pages/app/files/lib/files-paths.ts
+++ b/web_src/src/pages/app/files/lib/files-paths.ts
@@ -12,8 +12,7 @@ export function nextUntitledPath(paths: Set<string>): string {
 }
 
 export function buildRenderableTreePaths(repositoryPaths: string[], changes: PendingFileChange[]): string[] {
-  const deletedPaths = new Set(changes.filter((change) => change.type === "deleted").map((change) => change.path));
-  const paths = repositoryPaths.filter((path) => !deletedPaths.has(path));
+  const paths = [...repositoryPaths];
 
   for (const change of changes) {
     if (change.type === "deleted") continue;

--- a/web_src/src/pages/app/files/lib/files-view-state.spec.ts
+++ b/web_src/src/pages/app/files/lib/files-view-state.spec.ts
@@ -49,4 +49,21 @@ describe("getSelectedFileViewState", () => {
 
     expect(view.selectedContent).toBe("name: edited");
   });
+
+  it("shows the committed baseline for a deleted repository file", () => {
+    const view = getSelectedFileViewState({
+      selectedPath: "README.md",
+      selectedChange: { type: "deleted", path: "README.md" },
+      loadedContentByPath: { "README.md": "staged content" },
+      committedContentByPath: { "README.md": "committed content" },
+      selectedPathExistsInRepository: true,
+      selectedFileQuery: { isLoading: false, error: null },
+      canManageRepositoryFiles: true,
+    });
+
+    expect(view.selectedContent).toBe("committed content");
+    expect(view.selectedIsDeleted).toBe(true);
+    expect(view.editorDisabled).toBe(true);
+    expect(view.editorLoading).toBe(false);
+  });
 });

--- a/web_src/src/pages/app/files/lib/files-view-state.ts
+++ b/web_src/src/pages/app/files/lib/files-view-state.ts
@@ -22,6 +22,20 @@ type FilesQueryLike = {
 type SelectedFileQueryLike = {
   isLoading: boolean;
   error: unknown;
+  data?: {
+    path?: string;
+    content?: string;
+  };
+};
+
+type SelectedFileContentOptions = {
+  selectedPath: string | null;
+  selectedGeneratedFile: AppFile | undefined;
+  selectedChange: PendingFileChange | undefined;
+  selectedSpecDraft: string | undefined;
+  selectedFileQuery: SelectedFileQueryLike;
+  loadedContentByPath: Record<string, string>;
+  committedContentByPath: Record<string, string>;
 };
 
 export function getRepositoryFileListLoading(
@@ -57,19 +71,25 @@ export function getRepositoryFileListErrorMessage(
   return undefined;
 }
 
-function resolveSelectedFileContent(
-  selectedPath: string | null,
-  selectedGeneratedFile: AppFile | undefined,
-  selectedChange: PendingFileChange | undefined,
-  selectedSpecDraft: string | undefined,
-  loadedContentByPath: Record<string, string>,
-): string {
+function resolveSelectedFileContent({
+  selectedPath,
+  selectedGeneratedFile,
+  selectedChange,
+  selectedSpecDraft,
+  selectedFileQuery,
+  loadedContentByPath,
+  committedContentByPath,
+}: SelectedFileContentOptions): string {
   if (selectedSpecDraft !== undefined) {
     return selectedSpecDraft;
   }
 
   if (selectedChange?.type === "added" || selectedChange?.type === "modified") {
     return selectedChange.content;
+  }
+
+  if (selectedChange?.type === "deleted" && selectedPath) {
+    return committedContentByPath[selectedPath] ?? selectedFileQuery.data?.content ?? "";
   }
 
   if (selectedGeneratedFile) {
@@ -83,14 +103,21 @@ function resolveSelectedFileContent(
   return loadedContentByPath[selectedPath] ?? "";
 }
 
-function isSelectedFileContentLoaded(
-  selectedPath: string | null,
-  selectedGeneratedFile: AppFile | undefined,
-  selectedPathExistsInRepository: boolean,
-  loadedContentByPath: Record<string, string>,
-): boolean {
+function isSelectedFileContentLoaded({
+  selectedPath,
+  selectedGeneratedFile,
+  selectedChange,
+  selectedPathExistsInRepository,
+  selectedFileQuery,
+  loadedContentByPath,
+  committedContentByPath,
+}: Omit<SelectedFileContentOptions, "selectedSpecDraft"> & { selectedPathExistsInRepository: boolean }): boolean {
   if (selectedGeneratedFile || !selectedPath || !selectedPathExistsInRepository) {
     return true;
+  }
+
+  if (selectedChange?.type === "deleted") {
+    return committedContentByPath[selectedPath] !== undefined || selectedFileQuery.data?.content !== undefined;
   }
 
   return loadedContentByPath[selectedPath] !== undefined;
@@ -102,6 +129,7 @@ export function getSelectedFileViewState({
   selectedChange,
   selectedSpecDraft,
   loadedContentByPath,
+  committedContentByPath = {},
   selectedPathExistsInRepository,
   selectedFileQuery,
   canManageRepositoryFiles,
@@ -111,24 +139,30 @@ export function getSelectedFileViewState({
   selectedChange?: PendingFileChange;
   selectedSpecDraft?: string;
   loadedContentByPath: Record<string, string>;
+  committedContentByPath?: Record<string, string>;
   selectedPathExistsInRepository: boolean;
   selectedFileQuery: SelectedFileQueryLike;
   canManageRepositoryFiles: boolean;
 }) {
   const selectedIsDeleted = selectedChange?.type === "deleted";
-  const selectedContent = resolveSelectedFileContent(
+  const selectedContent = resolveSelectedFileContent({
     selectedPath,
     selectedGeneratedFile,
     selectedChange,
     selectedSpecDraft,
+    selectedFileQuery,
     loadedContentByPath,
-  );
-  const selectedContentLoaded = isSelectedFileContentLoaded(
+    committedContentByPath,
+  });
+  const selectedContentLoaded = isSelectedFileContentLoaded({
     selectedPath,
     selectedGeneratedFile,
+    selectedChange,
     selectedPathExistsInRepository,
+    selectedFileQuery,
     loadedContentByPath,
-  );
+    committedContentByPath,
+  });
   const editorLoading =
     !!selectedGeneratedFile?.loading ||
     (!!selectedPath && selectedPathExistsInRepository && !selectedContentLoaded && selectedFileQuery.isLoading);

--- a/web_src/src/pages/app/files/types.ts
+++ b/web_src/src/pages/app/files/types.ts
@@ -38,6 +38,8 @@ export type PendingFileChange =
       path: string;
     };
 
+export type FileChangeStatus = PendingFileChange["type"];
+
 export const repositoryFileTreeStyle = {
   height: "100%",
   colorScheme: "light",

--- a/web_src/src/pages/app/files/useCatalog.ts
+++ b/web_src/src/pages/app/files/useCatalog.ts
@@ -81,7 +81,9 @@ type UseRepositorySelectedFileQueryOptions = {
   canvasId?: string;
   selectedPath: string | null;
   repositoryPathSet: Set<string>;
+  committedRepositoryPathSet: Set<string>;
   generatedFilesByPath: Map<string, AppFile>;
+  selectedChange?: PendingFileChange;
   versionId?: string;
   stage?: boolean;
 };
@@ -90,18 +92,23 @@ export function useRepositorySelectedFileQuery({
   canvasId,
   selectedPath,
   repositoryPathSet,
+  committedRepositoryPathSet,
   generatedFilesByPath,
+  selectedChange,
   versionId,
   stage = false,
 }: UseRepositorySelectedFileQueryOptions) {
   const selectedGeneratedFile = selectedPath ? generatedFilesByPath.get(selectedPath) : undefined;
-  const selectedPathExistsInRepository = selectedPath ? repositoryPathSet.has(selectedPath) : false;
+  const selectedIsDeleted = selectedChange?.type === "deleted";
+  const selectedPathExistsInRepository = selectedPath
+    ? repositoryPathSet.has(selectedPath) || (selectedIsDeleted && committedRepositoryPathSet.has(selectedPath))
+    : false;
   const selectedFileQuery = useCanvasRepositoryFile(
     canvasId ?? "",
     selectedPath,
     !!selectedPath && selectedPathExistsInRepository && !selectedGeneratedFile,
     versionId,
-    stage,
+    selectedIsDeleted ? false : stage,
   );
 
   return { selectedGeneratedFile, selectedPathExistsInRepository, selectedFileQuery };

--- a/web_src/src/pages/app/files/useCatalog.ts
+++ b/web_src/src/pages/app/files/useCatalog.ts
@@ -49,11 +49,7 @@ export function useRepositoryPathLists(
 ) {
   const repositoryAndPendingPaths = useMemo(() => {
     return Array.from(
-      new Set([
-        ...repositoryPaths,
-        ...stagedRepositoryPaths,
-        ...pendingChanges.filter((change) => change.type === "added").map((change) => change.path),
-      ]),
+      new Set([...repositoryPaths, ...stagedRepositoryPaths, ...pendingChanges.map((change) => change.path)]),
     ).sort();
   }, [pendingChanges, repositoryPaths, stagedRepositoryPaths]);
   const allPaths = useMemo(

--- a/web_src/src/pages/app/files/useEditor.ts
+++ b/web_src/src/pages/app/files/useEditor.ts
@@ -1,5 +1,6 @@
 import { useCanvasStaging } from "@/hooks/useCanvasData";
 import { useEffectiveLeftSidebarWidth } from "@/stores/sidebarLayoutStore";
+import type { GitStatusEntry } from "@pierre/trees";
 import { useMemo, useRef, useState } from "react";
 
 import { buildFilesEditorResult } from "./lib/build-files-editor-result";
@@ -93,12 +94,19 @@ export function useEditor({
 
   const tabs = useFilesTabState(pathLists.allPaths, catalog.generatedPaths, catalog.filesQuery.isLoading);
   openFileRef.current = tabs.openFile;
+  const selectedPendingChange = tabs.selectedPath ? pending.pendingChangesByPath[tabs.selectedPath] : undefined;
+  const gitStatus = useMemo<GitStatusEntry[]>(
+    () => pendingChanges.map((change) => ({ path: change.path, status: change.type })),
+    [pendingChanges],
+  );
 
   const selection = useRepositorySelectedFileQuery({
     canvasId,
     selectedPath: tabs.selectedPath,
     repositoryPathSet: effectiveRepositoryPathSet,
+    committedRepositoryPathSet: catalog.repositoryPathSet,
     generatedFilesByPath: catalog.generatedFilesByPath,
+    selectedChange: selectedPendingChange,
     versionId,
     stage: isEditing,
   });
@@ -164,5 +172,6 @@ export function useEditor({
     isDiffOpen,
     setIsDiffOpen,
     headerActionsHost,
+    gitStatus,
   });
 }


### PR DESCRIPTION
## Summary

- show added, modified, and deleted statuses in the Files tree
- render added files in green and deleted files in red with strikethrough
- retain deleted files in the tree and load their last committed content
- render added/deleted file content with whole-file Monaco decorations
- make deleted file content read-only
- add focused regression coverage for status propagation and deleted-file loading

## Testing

- `make check.format.js`
- `make check.lint.ui`
- `make check.build.ui`
- `make check.test.ui`
- targeted Files-tab tests: 4 files, 18 tests passed
- full frontend suite: 521 files, 3,884 tests passed

Closes #5505
