### PR TITLE
fix: deny unmatched gateway routes without auth rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,9 @@ Cross-cutting rules when extending the backend:
   `cmd/server/main.go` and update the docker compose files with any new
   environment variables.
 - After adding new API endpoints, ensure they are covered in
-  `pkg/authorization/interceptor.go`.
+  `pkg/authorization/gateway_auth_rules.go` (deny-by-default; unmatched gateway
+  routes are rejected). The coverage test
+  `TestDefaultAuthorizationRulesCoverAllProtoHTTPRoutes` enforces this.
 
 Further reading:
 

--- a/pkg/authorization/gateway_auth_coverage_test.go
+++ b/pkg/authorization/gateway_auth_coverage_test.go
@@ -1,0 +1,136 @@
+package authorization
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultAuthorizationRulesCoverAllProtoHTTPRoutes(t *testing.T) {
+	protosDir := findProtosDir(t)
+	protoRoutes, err := listProtoHTTPRoutes(protosDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, protoRoutes)
+
+	rules := DefaultAuthorizationRules()
+	var missing []string
+	for _, route := range protoRoutes {
+		if _, ok := rules[route]; !ok {
+			missing = append(missing, route.String())
+		}
+	}
+
+	assert.Empty(t, missing, "gateway auth rules missing for proto HTTP routes:\n%s", strings.Join(missing, "\n"))
+}
+
+func findProtosDir(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, "protos")
+		if isProtoSourceDir(candidate) {
+			return candidate
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find protos/ directory with .proto sources from %s", cwd)
+		}
+		dir = parent
+	}
+}
+
+func isProtoSourceDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".proto") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func listProtoHTTPRoutes(protosDir string) ([]HTTPRoute, error) {
+	entries, err := os.ReadDir(protosDir)
+	if err != nil {
+		return nil, err
+	}
+
+	optionStart := regexp.MustCompile(`option\s*\(\s*google\.api\.http\s*\)\s*=\s*\{`)
+	methodPath := regexp.MustCompile(`(?i)\b(get|post|put|patch|delete)\s*:\s*"([^"]+)"`)
+
+	seen := map[HTTPRoute]struct{}{}
+	var routes []HTTPRoute
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".proto") {
+			continue
+		}
+
+		content, err := os.ReadFile(filepath.Join(protosDir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		text := string(content)
+
+		for _, start := range optionStart.FindAllStringIndex(text, -1) {
+			block, ok := extractBraceBlock(text, start[1]-1)
+			if !ok {
+				continue
+			}
+			for _, match := range methodPath.FindAllStringSubmatch(block, -1) {
+				route := HTTPRoute{
+					Method:  strings.ToUpper(match[1]),
+					Pattern: match[2],
+				}
+				if _, exists := seen[route]; exists {
+					continue
+				}
+				seen[route] = struct{}{}
+				routes = append(routes, route)
+			}
+		}
+	}
+
+	return routes, nil
+}
+
+func extractBraceBlock(text string, openIdx int) (string, bool) {
+	if openIdx < 0 || openIdx >= len(text) || text[openIdx] != '{' {
+		return "", false
+	}
+
+	depth := 0
+	for i := openIdx; i < len(text); i++ {
+		switch text[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return text[openIdx : i+1], true
+			}
+		}
+	}
+
+	return "", false
+}

--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -213,6 +213,11 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			Action:     "read",
 			DomainType: models.DomainTypeOrganization,
 		},
+		{Method: "GET", Pattern: "/api/v1/me"}: {
+			Resource:   "org",
+			Action:     "read",
+			DomainType: models.DomainTypeOrganization,
+		},
 		{Method: "GET", Pattern: "/api/v1/organizations/{id}"}: {
 			Resource:   "org",
 			Action:     "read",
@@ -285,6 +290,16 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 		},
 		{Method: "GET", Pattern: "/api/v1/users"}: {
 			Resource:   "members",
+			Action:     "read",
+			DomainType: models.DomainTypeOrganization,
+		},
+		{Method: "GET", Pattern: "/api/v1/widgets"}: {
+			Resource:   "org",
+			Action:     "read",
+			DomainType: models.DomainTypeOrganization,
+		},
+		{Method: "GET", Pattern: "/api/v1/widgets/{name}"}: {
+			Resource:   "org",
 			Action:     "read",
 			DomainType: models.DomainTypeOrganization,
 		},
@@ -429,6 +444,14 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 		{Method: "POST", Pattern: "/api/v1/groups/{group_name}/users"}: {
 			Resource:   "groups",
 			Action:     "update",
+			DomainType: models.DomainTypeOrganization,
+		},
+		{Method: "POST", Pattern: "/api/v1/invite-links/{token}/accept"}: {
+			AccountAuthenticated: true,
+		},
+		{Method: "POST", Pattern: "/api/v1/me/token"}: {
+			Resource:   "org",
+			Action:     "read",
 			DomainType: models.DomainTypeOrganization,
 		},
 		{Method: "POST", Pattern: "/api/v1/organizations/{id}/integrations"}: {

--- a/pkg/authorization/gateway_authorizer.go
+++ b/pkg/authorization/gateway_authorizer.go
@@ -33,8 +33,18 @@ func (a *GatewayAuthorizer) AuthorizeHTTP(
 	route HTTPRoute,
 	pathParams map[string]string,
 ) (context.Context, error) {
-	rule, requiresAuth := a.rules[route]
-	if !requiresAuth {
+	rule, ok := a.rules[route]
+	if !ok {
+		log.Errorf("No authorization rule for route %s", route)
+		return nil, status.Error(codes.NotFound, "Not found")
+	}
+
+	if rule.AccountAuthenticated {
+		if firstHTTPHeader(r, "x-account-id") == "" {
+			log.Errorf("Account not found in request headers")
+			return nil, status.Error(codes.NotFound, "Not found")
+		}
+
 		return withAuthorizedContext(ctx, pathParams, ""), nil
 	}
 

--- a/pkg/authorization/http_route_match_test.go
+++ b/pkg/authorization/http_route_match_test.go
@@ -38,6 +38,24 @@ func TestMatchHTTPRoute(t *testing.T) {
 		{
 			method: http.MethodGet,
 			path:   "/api/v1/me",
+			want:   HTTPRoute{Method: http.MethodGet, Pattern: "/api/v1/me"},
+			wantOK: true,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/api/v1/widgets",
+			want:   HTTPRoute{Method: http.MethodGet, Pattern: "/api/v1/widgets"},
+			wantOK: true,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/api/v1/invite-links/some-token/accept",
+			want:   HTTPRoute{Method: http.MethodPost, Pattern: "/api/v1/invite-links/{token}/accept"},
+			wantOK: true,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/api/v1/unregistered-route",
 			wantOK: false,
 		},
 	}

--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -20,7 +20,11 @@ type AuthorizationRule struct {
 	ResourcePathParams []string
 	// LegacyActions keeps persisted grants working during permission migrations.
 	// Prefer Action for new checks, and scope legacy actions to the smallest route set possible.
-	LegacyActions                []string
+	LegacyActions []string
+	// AccountAuthenticated allows account-scoped routes that must not require org membership
+	// or RBAC (for example accepting an invite before the account joins the organization).
+	// When set, AuthorizeHTTP requires x-account-id and skips org permission checks.
+	AccountAuthenticated         bool
 	RequiredExperimentalFeatures []string
 }
 

--- a/pkg/authorization/interceptor_test.go
+++ b/pkg/authorization/interceptor_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/models"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestResourceIDsFromPathParams(t *testing.T) {
@@ -246,6 +248,94 @@ func TestPermissionsFromScopedTokenScopes(t *testing.T) {
 		assert.Equal(t, "read", permissions[0].Action)
 		assert.Equal(t, []string{"canvas-123"}, permissions[0].Resources)
 	})
+}
+
+func TestGatewayAuthorizerDeniesRoutesWithoutAuthorizationRule(t *testing.T) {
+	authorizer := NewGatewayAuthorizer(allowingPermissionChecker{})
+	r := httptestRequest(t, map[string]string{
+		"x-user-id":         "22222222-2222-4222-8222-222222222222",
+		"x-organization-id": "11111111-1111-4111-8111-111111111111",
+	})
+
+	_, err := authorizer.AuthorizeHTTP(
+		context.Background(),
+		r,
+		HTTPRoute{Method: http.MethodGet, Pattern: "/api/v1/unregistered-route"},
+		map[string]string{},
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestGatewayAuthorizerAllowsMeAndWidgetsWithOrgRead(t *testing.T) {
+	authorizer := NewGatewayAuthorizer(actionPermissionChecker{
+		"org:read": true,
+	})
+	organizationID := "11111111-1111-4111-8111-111111111111"
+	r := httptestRequest(t, map[string]string{
+		"x-user-id":         "22222222-2222-4222-8222-222222222222",
+		"x-organization-id": organizationID,
+	})
+
+	routes := []HTTPRoute{
+		{Method: http.MethodGet, Pattern: "/api/v1/me"},
+		{Method: http.MethodPost, Pattern: "/api/v1/me/token"},
+		{Method: http.MethodGet, Pattern: "/api/v1/widgets"},
+		{Method: http.MethodGet, Pattern: "/api/v1/widgets/{name}"},
+	}
+
+	for _, route := range routes {
+		t.Run(route.String(), func(t *testing.T) {
+			rule, ok := DefaultAuthorizationRules()[route]
+			require.True(t, ok)
+			assert.Equal(t, "org", rule.Resource)
+			assert.Equal(t, "read", rule.Action)
+
+			ctx, err := authorizer.AuthorizeHTTP(context.Background(), r, route, map[string]string{"name": "markdown"})
+			require.NoError(t, err)
+			assert.Equal(t, organizationID, ctx.Value(OrganizationContextKey))
+		})
+	}
+}
+
+func TestGatewayAuthorizerRejectsScopedTokenForMeToken(t *testing.T) {
+	authorizer := NewGatewayAuthorizer(actionPermissionChecker{
+		"org:read": true,
+	})
+	r := httptestRequest(t, map[string]string{
+		"x-user-id":         "22222222-2222-4222-8222-222222222222",
+		"x-organization-id": "11111111-1111-4111-8111-111111111111",
+		"x-token-scopes":    marshalScopes(t, []string{"canvases:read:canvas-123"}),
+	})
+
+	_, err := authorizer.AuthorizeHTTP(
+		context.Background(),
+		r,
+		HTTPRoute{Method: http.MethodPost, Pattern: "/api/v1/me/token"},
+		map[string]string{},
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestGatewayAuthorizerAllowsAccountAuthenticatedInviteAccept(t *testing.T) {
+	authorizer := NewGatewayAuthorizer(denyingPermissionChecker{})
+	route := HTTPRoute{Method: http.MethodPost, Pattern: "/api/v1/invite-links/{token}/accept"}
+
+	rule, ok := DefaultAuthorizationRules()[route]
+	require.True(t, ok)
+	assert.True(t, rule.AccountAuthenticated)
+
+	r := httptestRequest(t, map[string]string{
+		"x-account-id": "33333333-3333-4333-8333-333333333333",
+	})
+	_, err := authorizer.AuthorizeHTTP(context.Background(), r, route, map[string]string{"token": "tok"})
+	require.NoError(t, err)
+
+	rMissing := httptestRequest(t, map[string]string{})
+	_, err = authorizer.AuthorizeHTTP(context.Background(), rMissing, route, map[string]string{"token": "tok"})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 func TestGatewayAuthorizerSetsOrganizationContext(t *testing.T) {

--- a/pkg/grpc/gateway_authorization_middleware.go
+++ b/pkg/grpc/gateway_authorization_middleware.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func GatewayAuthorizationMiddleware(
@@ -12,9 +14,9 @@ func GatewayAuthorizationMiddleware(
 ) runtime.Middleware {
 	return func(next runtime.HandlerFunc) runtime.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
-			route, requiresAuth := authorizer.RouteFromRequest(r)
-			if !requiresAuth {
-				next(w, r.WithContext(authorization.WithPathParams(r.Context(), pathParams)), pathParams)
+			route, ok := authorizer.RouteFromRequest(r)
+			if !ok {
+				writeGatewayHTTPError(r.Context(), w, status.Error(codes.NotFound, "Not found"))
 				return
 			}
 

--- a/pkg/grpc/gateway_authorization_middleware_test.go
+++ b/pkg/grpc/gateway_authorization_middleware_test.go
@@ -84,3 +84,35 @@ func TestGatewayAuthorizationMiddlewareReturnsNotFoundWhenPermissionDenied(t *te
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Equal(t, "Not found", body["message"])
 }
+
+func TestGatewayAuthorizationMiddlewareDeniesUnmatchedRoutes(t *testing.T) {
+	t.Parallel()
+
+	authorizer := authorization.NewGatewayAuthorizer(allowingPermissionChecker{})
+	middleware := GatewayAuthorizationMiddleware(authorizer)
+
+	called := false
+	handler := middleware(func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
+		called = true
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/unregistered-route", nil)
+	r.Header.Set("x-user-id", "22222222-2222-4222-8222-222222222222")
+	r.Header.Set("x-organization-id", "11111111-1111-4111-8111-111111111111")
+
+	rec := httptest.NewRecorder()
+	handler(rec, r, nil)
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "Not found", body["message"])
+}
+
+type allowingPermissionChecker struct{}
+
+func (allowingPermissionChecker) CheckOrganizationPermission(_ context.Context, _, _, _, _ string) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
Fail closed when a gRPC-gateway route is missing from DefaultAuthorizationRules, add explicit org:read rules for /me and /widgets, and cover invite accept via account auth so proto HTTP coverage stays complete.