### PR TITLE
fix: block org role and group privilege escalation

### DIFF
--- a/pkg/grpc/actions/auth/add_user_to_group.go
+++ b/pkg/grpc/actions/auth/add_user_to_group.go
@@ -2,12 +2,19 @@ package auth
 
 import (
 	"context"
+
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	pbGroups "github.com/superplanehq/superplane/pkg/protos/groups"
 )
 
 func AddUserToGroup(ctx context.Context, orgID, domainType, domainID, userID, userEmail, groupName string, authService authorization.Authorization) (*pbGroups.AddUserToGroupResponse, error) {
+	requesterID, ok := authentication.GetUserIdFromMetadata(ctx)
+	if !ok {
+		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
+	}
+
 	if groupName == "" {
 		return nil, grpcerrors.InvalidArgument(nil, "group name must be specified")
 	}
@@ -15,6 +22,15 @@ func AddUserToGroup(ctx context.Context, orgID, domainType, domainID, userID, us
 	user, err := FindUser(orgID, userID, userEmail)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(nil, "user not found")
+	}
+
+	groupRole, err := authService.GetGroupRole(ctx, domainID, domainType, groupName)
+	if err != nil {
+		return nil, grpcerrors.NotFound(err, "group not found")
+	}
+
+	if err := ensureCanGrantRole(ctx, authService, requesterID, domainType, domainID, groupRole); err != nil {
+		return nil, err
 	}
 
 	err = authService.AddUserToGroup(domainID, domainType, user.ID.String(), groupName)

--- a/pkg/grpc/actions/auth/add_user_to_group_test.go
+++ b/pkg/grpc/actions/auth/add_user_to_group_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/protos/users"
@@ -16,7 +17,7 @@ import (
 
 func Test_AddUserToGroup(t *testing.T) {
 	r := support.Setup(t)
-	ctx := context.Background()
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 	orgID := r.Organization.ID.String()
 
 	groupName := support.RandomName("test-group")

--- a/pkg/grpc/actions/auth/assign_role.go
+++ b/pkg/grpc/actions/auth/assign_role.go
@@ -34,6 +34,14 @@ func AssignRole(ctx context.Context, orgID, domainType, domainID, roleName, user
 		return nil, grpcerrors.InvalidArgument(nil, "API keys cannot be assigned the org_owner role")
 	}
 
+	if err := ensureNotDemotingLastOwner(ctx, authService, orgID, user.ID.String(), roleName); err != nil {
+		return nil, err
+	}
+
+	if err := ensureCanGrantRole(ctx, authService, requesterID, domainType, domainID, roleName); err != nil {
+		return nil, err
+	}
+
 	err = authService.AssignRole(user.ID.String(), roleName, domainID, domainType)
 	if err != nil {
 		log.Errorf("Error assigning role %s to %s: %v", roleName, user.ID.String(), err)

--- a/pkg/grpc/actions/auth/assign_role_test.go
+++ b/pkg/grpc/actions/auth/assign_role_test.go
@@ -83,4 +83,56 @@ func Test_AssignRole(t *testing.T) {
 		assert.Equal(t, codes.InvalidArgument, code)
 		assert.Equal(t, "user not found", msg)
 	})
+
+	t.Run("admin cannot assign org_owner", func(t *testing.T) {
+		admin := support.CreateUser(t, r, r.Organization.ID)
+		_, err := AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, admin.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+
+		target := support.CreateUser(t, r, r.Organization.ID)
+		adminCtx := authentication.SetUserIdInMetadata(context.Background(), admin.ID.String())
+		_, err = AssignRole(adminCtx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgOwner, target.ID.String(), "", r.AuthService)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, code)
+		assert.Equal(t, "cannot assign a role with permissions you do not have", msg)
+	})
+
+	t.Run("admin can assign org_admin", func(t *testing.T) {
+		admin := support.CreateUser(t, r, r.Organization.ID)
+		_, err := AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, admin.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+
+		target := support.CreateUser(t, r, r.Organization.ID)
+		adminCtx := authentication.SetUserIdInMetadata(context.Background(), admin.ID.String())
+		resp, err := AssignRole(adminCtx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, target.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("cannot demote the last organization owner", func(t *testing.T) {
+		admin := support.CreateUser(t, r, r.Organization.ID)
+		_, err := AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, admin.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+
+		adminCtx := authentication.SetUserIdInMetadata(context.Background(), admin.ID.String())
+		_, err = AssignRole(adminCtx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgViewer, r.User.String(), "", r.AuthService)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, code)
+		assert.Equal(t, "cannot demote the last organization owner", msg)
+
+		secondOwner := support.CreateUser(t, r, r.Organization.ID)
+		_, err = AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgOwner, secondOwner.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+
+		_, err = AssignRole(adminCtx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, secondOwner.ID.String(), "", r.AuthService)
+		require.NoError(t, err)
+
+		_, err = AssignRole(adminCtx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgViewer, r.User.String(), "", r.AuthService)
+		code, msg, ok = grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, code)
+		assert.Equal(t, "cannot demote the last organization owner", msg)
+	})
 }

--- a/pkg/grpc/actions/auth/create_group.go
+++ b/pkg/grpc/actions/auth/create_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
@@ -12,6 +13,11 @@ import (
 )
 
 func CreateGroup(ctx context.Context, domainType, domainID string, group *pb.Group, authService authorization.Authorization) (*pb.CreateGroupResponse, error) {
+	requesterID, ok := authentication.GetUserIdFromMetadata(ctx)
+	if !ok {
+		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
+	}
+
 	if group == nil {
 		return nil, grpcerrors.InvalidArgument(nil, "group must be specified")
 	}
@@ -30,6 +36,10 @@ func CreateGroup(ctx context.Context, domainType, domainID string, group *pb.Gro
 
 	if group.Spec.Role == "" {
 		return nil, grpcerrors.InvalidArgument(nil, "role must be specified")
+	}
+
+	if err := ensureCanGrantRole(ctx, authService, requesterID, domainType, domainID, group.Spec.Role); err != nil {
+		return nil, err
 	}
 
 	var displayName string

--- a/pkg/grpc/actions/auth/create_group_test.go
+++ b/pkg/grpc/actions/auth/create_group_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/groups"
 	"github.com/superplanehq/superplane/test/support"
@@ -13,7 +14,7 @@ import (
 
 func Test_CreateGroup(t *testing.T) {
 	r := support.Setup(t)
-	ctx := context.Background()
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 	orgID := r.Organization.ID.String()
 
 	t.Run("successful group creation", func(t *testing.T) {

--- a/pkg/grpc/actions/auth/create_role.go
+++ b/pkg/grpc/actions/auth/create_role.go
@@ -5,12 +5,18 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	pb "github.com/superplanehq/superplane/pkg/protos/roles"
 )
 
 func CreateRole(ctx context.Context, domainType string, domainID string, role *pb.Role, authService authorization.Authorization) (*pb.CreateRoleResponse, error) {
+	requesterID, ok := authentication.GetUserIdFromMetadata(ctx)
+	if !ok {
+		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
+	}
+
 	if role == nil {
 		return nil, grpcerrors.InvalidArgument(nil, "role must be specified")
 	}
@@ -31,19 +37,26 @@ func CreateRole(ctx context.Context, domainType string, domainID string, role *p
 		return nil, grpcerrors.InvalidArgument(nil, "role permissions must be specified")
 	}
 
-	permissions := make([]*authorization.Permission, len(role.Spec.Permissions))
-	for i, perm := range role.Spec.Permissions {
-		permissions[i] = &authorization.Permission{
+	permissions := make([]*authorization.Permission, 0, len(role.Spec.Permissions))
+	for _, perm := range role.Spec.Permissions {
+		if perm == nil {
+			continue
+		}
+		permissions = append(permissions, &authorization.Permission{
 			Resource:   perm.Resource,
 			Action:     perm.Action,
 			DomainType: domainType,
-		}
+		})
 	}
 
 	for _, permission := range permissions {
 		if !authService.IsValidPermission(domainType, permission) {
 			return nil, grpcerrors.InvalidArgument(nil, fmt.Sprintf("invalid permission: %s %s", permission.Resource, permission.Action))
 		}
+	}
+
+	if err := ensureCanGrantPermissions(ctx, authService, requesterID, domainID, permissions); err != nil {
+		return nil, err
 	}
 
 	var displayName, description string
@@ -67,10 +80,14 @@ func CreateRole(ctx context.Context, domainType string, domainID string, role *p
 	}
 
 	if role.Spec.InheritedRole != nil && role.Spec.InheritedRole.Metadata != nil && role.Spec.InheritedRole.Metadata.Name != "" {
-		inheritedRoleDef, err := authService.GetRoleDefinition(ctx, role.Spec.InheritedRole.Metadata.Name, domainType, domainID)
+		inheritedName := role.Spec.InheritedRole.Metadata.Name
+		inheritedRoleDef, err := authService.GetRoleDefinition(ctx, inheritedName, domainType, domainID)
 		if err != nil {
-			log.Errorf("failed to get inherited role %s: %v", role.Spec.InheritedRole.Metadata.Name, err)
+			log.Errorf("failed to get inherited role %s: %v", inheritedName, err)
 			return nil, grpcerrors.InvalidArgument(nil, "inherited role not found")
+		}
+		if err := ensureCanGrantRole(ctx, authService, requesterID, domainType, domainID, inheritedName); err != nil {
+			return nil, err
 		}
 		roleDefinition.InheritsFrom = inheritedRoleDef
 	}

--- a/pkg/grpc/actions/auth/create_role_test.go
+++ b/pkg/grpc/actions/auth/create_role_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/models"
 	pbAuth "github.com/superplanehq/superplane/pkg/protos/authorization"
 	pb "github.com/superplanehq/superplane/pkg/protos/roles"
@@ -14,7 +15,7 @@ import (
 
 func Test_CreateRole(t *testing.T) {
 	r := support.Setup(t)
-	ctx := context.Background()
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 	orgID := r.Organization.ID.String()
 	canvasPath := "canvases"
 

--- a/pkg/grpc/actions/auth/role_ceiling.go
+++ b/pkg/grpc/actions/auth/role_ceiling.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"context"
+	"slices"
+
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func ensureCanGrantRole(
+	ctx context.Context,
+	authService authorization.Authorization,
+	requesterID, domainType, domainID, roleName string,
+) error {
+	permissions, err := authService.GetRolePermissions(ctx, roleName, domainType, domainID)
+	if err != nil {
+		return grpcerrors.InvalidArgument(err, "role not found")
+	}
+
+	return ensureCanGrantPermissions(ctx, authService, requesterID, domainID, permissions)
+}
+
+func ensureCanGrantPermissions(
+	ctx context.Context,
+	authService authorization.Authorization,
+	requesterID, domainID string,
+	permissions []*authorization.Permission,
+) error {
+	for _, permission := range permissions {
+		if permission == nil {
+			continue
+		}
+
+		allowed, err := authService.CheckOrganizationPermission(
+			ctx,
+			requesterID,
+			domainID,
+			permission.Resource,
+			permission.Action,
+		)
+		if err != nil {
+			return grpcerrors.Internal(err, "failed to check permissions")
+		}
+		if !allowed {
+			return grpcerrors.PermissionDenied(nil, "cannot assign a role with permissions you do not have")
+		}
+	}
+
+	return nil
+}
+
+func ensureNotDemotingLastOwner(
+	ctx context.Context,
+	authService authorization.Authorization,
+	orgID, targetUserID, newRoleName string,
+) error {
+	if newRoleName == models.RoleOrgOwner {
+		return nil
+	}
+
+	ownerIDs, err := authService.GetOrgUsersForRole(ctx, models.RoleOrgOwner, orgID)
+	if err != nil {
+		return grpcerrors.Internal(err, "error determining organization owners")
+	}
+
+	if len(ownerIDs) <= 1 && slices.Contains(ownerIDs, targetUserID) {
+		return grpcerrors.FailedPrecondition(nil, "cannot demote the last organization owner")
+	}
+
+	return nil
+}

--- a/pkg/grpc/actions/auth/role_privilege_escalation_test.go
+++ b/pkg/grpc/actions/auth/role_privilege_escalation_test.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+	pbAuth "github.com/superplanehq/superplane/pkg/protos/authorization"
+	pb "github.com/superplanehq/superplane/pkg/protos/groups"
+	pbRoles "github.com/superplanehq/superplane/pkg/protos/roles"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+)
+
+func Test_RolePrivilegeEscalationGuards(t *testing.T) {
+	r := support.Setup(t)
+	ownerCtx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	orgID := r.Organization.ID.String()
+
+	admin := support.CreateUser(t, r, r.Organization.ID)
+	_, err := AssignRole(ownerCtx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, admin.ID.String(), "", r.AuthService)
+	require.NoError(t, err)
+	adminCtx := authentication.SetUserIdInMetadata(context.Background(), admin.ID.String())
+
+	t.Run("admin cannot create group with org_owner role", func(t *testing.T) {
+		_, err := CreateGroup(adminCtx, models.DomainTypeOrganization, orgID, &pb.Group{
+			Metadata: &pb.Group_Metadata{Name: "owner-group"},
+			Spec:     &pb.Group_Spec{Role: models.RoleOrgOwner, DisplayName: "Owner Group"},
+		}, r.AuthService)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, code)
+		assert.Equal(t, "cannot assign a role with permissions you do not have", msg)
+	})
+
+	t.Run("admin cannot update group role to org_owner", func(t *testing.T) {
+		_, err := CreateGroup(ownerCtx, models.DomainTypeOrganization, orgID, &pb.Group{
+			Metadata: &pb.Group_Metadata{Name: "admin-group"},
+			Spec:     &pb.Group_Spec{Role: models.RoleOrgAdmin, DisplayName: "Admin Group"},
+		}, r.AuthService)
+		require.NoError(t, err)
+
+		_, err = UpdateGroup(adminCtx, models.DomainTypeOrganization, orgID, "admin-group", &pb.Group_Spec{
+			Role: models.RoleOrgOwner,
+		}, r.AuthService)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, code)
+		assert.Equal(t, "cannot assign a role with permissions you do not have", msg)
+	})
+
+	t.Run("admin cannot add user to org_owner group", func(t *testing.T) {
+		_, err := CreateGroup(ownerCtx, models.DomainTypeOrganization, orgID, &pb.Group{
+			Metadata: &pb.Group_Metadata{Name: "owners"},
+			Spec:     &pb.Group_Spec{Role: models.RoleOrgOwner, DisplayName: "Owners"},
+		}, r.AuthService)
+		require.NoError(t, err)
+
+		target := support.CreateUser(t, r, r.Organization.ID)
+		_, err = AddUserToGroup(adminCtx, orgID, models.DomainTypeOrganization, orgID, target.ID.String(), "", "owners", r.AuthService)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, code)
+		assert.Equal(t, "cannot assign a role with permissions you do not have", msg)
+	})
+
+	t.Run("admin cannot create role with owner-only permission", func(t *testing.T) {
+		_, err := CreateRole(adminCtx, models.DomainTypeOrganization, orgID, &pbRoles.Role{
+			Metadata: &pbRoles.Role_Metadata{Name: "almost-owner"},
+			Spec: &pbRoles.Role_Spec{
+				DisplayName: "Almost Owner",
+				Permissions: []*pbAuth.Permission{
+					{Resource: "org", Action: "delete", DomainType: pbAuth.DomainType_DOMAIN_TYPE_ORGANIZATION},
+				},
+			},
+		}, r.AuthService)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, code)
+		assert.Equal(t, "cannot assign a role with permissions you do not have", msg)
+	})
+
+	t.Run("admin cannot create role inheriting org_owner", func(t *testing.T) {
+		_, err := CreateRole(adminCtx, models.DomainTypeOrganization, orgID, &pbRoles.Role{
+			Metadata: &pbRoles.Role_Metadata{Name: "inherits-owner"},
+			Spec: &pbRoles.Role_Spec{
+				DisplayName: "Inherits Owner",
+				Permissions: []*pbAuth.Permission{
+					{Resource: "canvases", Action: "read", DomainType: pbAuth.DomainType_DOMAIN_TYPE_ORGANIZATION},
+				},
+				InheritedRole: &pbRoles.Role{
+					Metadata: &pbRoles.Role_Metadata{Name: models.RoleOrgOwner},
+				},
+			},
+		}, r.AuthService)
+		code, msg, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, code)
+		assert.Equal(t, "cannot assign a role with permissions you do not have", msg)
+	})
+
+	t.Run("admin can create role with admin-level permissions", func(t *testing.T) {
+		resp, err := CreateRole(adminCtx, models.DomainTypeOrganization, orgID, &pbRoles.Role{
+			Metadata: &pbRoles.Role_Metadata{Name: "canvas-editor"},
+			Spec: &pbRoles.Role_Spec{
+				DisplayName: "Canvas Editor",
+				Permissions: []*pbAuth.Permission{
+					{Resource: "canvases", Action: "read", DomainType: pbAuth.DomainType_DOMAIN_TYPE_ORGANIZATION},
+					{Resource: "canvases", Action: "update", DomainType: pbAuth.DomainType_DOMAIN_TYPE_ORGANIZATION},
+				},
+			},
+		}, r.AuthService)
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+}

--- a/pkg/grpc/actions/auth/update_group.go
+++ b/pkg/grpc/actions/auth/update_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
@@ -13,6 +14,11 @@ import (
 )
 
 func UpdateGroup(ctx context.Context, domainType string, domainID string, groupName string, groupSpec *pb.Group_Spec, authService authorization.Authorization) (*pb.UpdateGroupResponse, error) {
+	requesterID, ok := authentication.GetUserIdFromMetadata(ctx)
+	if !ok {
+		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
+	}
+
 	if groupName == "" {
 		return nil, grpcerrors.InvalidArgument(nil, "group name must be specified")
 	}
@@ -49,6 +55,12 @@ func UpdateGroup(ctx context.Context, domainType string, domainID string, groupN
 	if groupSpec != nil {
 		if groupSpec.Role != "" {
 			updatingRole = groupSpec.Role
+		}
+
+		if updatingRole != currentRole {
+			if err := ensureCanGrantRole(ctx, authService, requesterID, domainType, domainID, updatingRole); err != nil {
+				return nil, err
+			}
 		}
 
 		err = authService.UpdateGroup(domainID, domainType, groupName, updatingRole, displayName, description)

--- a/pkg/grpc/actions/auth/update_group_test.go
+++ b/pkg/grpc/actions/auth/update_group_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/groups"
 	"github.com/superplanehq/superplane/test/support"
@@ -14,7 +15,7 @@ import (
 
 func TestUpdateGroup(t *testing.T) {
 	r := support.Setup(t)
-	ctx := context.Background()
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 	orgID := r.Organization.ID.String()
 
 	t.Run("successful role update", func(t *testing.T) {

--- a/pkg/grpc/actions/auth/update_role.go
+++ b/pkg/grpc/actions/auth/update_role.go
@@ -5,14 +5,24 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	pb "github.com/superplanehq/superplane/pkg/protos/roles"
 )
 
 func UpdateRole(ctx context.Context, domainType string, domainID string, roleName string, roleSpec *pb.Role_Spec, authService authorization.Authorization) (*pb.UpdateRoleResponse, error) {
+	requesterID, ok := authentication.GetUserIdFromMetadata(ctx)
+	if !ok {
+		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
+	}
+
 	if roleName == "" {
 		return nil, grpcerrors.InvalidArgument(nil, "role name must be specified")
+	}
+
+	if roleSpec == nil {
+		return nil, grpcerrors.InvalidArgument(nil, "role spec must be specified")
 	}
 
 	_, err := authService.GetRoleDefinition(ctx, roleName, domainType, domainID)
@@ -22,8 +32,11 @@ func UpdateRole(ctx context.Context, domainType string, domainID string, roleNam
 	}
 
 	permissions := []*authorization.Permission{}
-	if roleSpec != nil && roleSpec.Permissions != nil {
+	if roleSpec.Permissions != nil {
 		for _, perm := range roleSpec.Permissions {
+			if perm == nil {
+				continue
+			}
 			permissions = append(permissions, &authorization.Permission{
 				Resource:   perm.Resource,
 				Action:     perm.Action,
@@ -38,8 +51,12 @@ func UpdateRole(ctx context.Context, domainType string, domainID string, roleNam
 		}
 	}
 
+	if err := ensureCanGrantPermissions(ctx, authService, requesterID, domainID, permissions); err != nil {
+		return nil, err
+	}
+
 	var displayName, description string
-	if roleSpec != nil && (roleSpec.DisplayName != "" || roleSpec.Description != "") {
+	if roleSpec.DisplayName != "" || roleSpec.Description != "" {
 		displayName = roleSpec.DisplayName
 		if displayName == "" {
 			displayName = roleName
@@ -56,10 +73,14 @@ func UpdateRole(ctx context.Context, domainType string, domainID string, roleNam
 	}
 
 	if roleSpec.InheritedRole != nil && roleSpec.InheritedRole.Metadata != nil && roleSpec.InheritedRole.Metadata.Name != "" {
-		inheritedRoleDef, err := authService.GetRoleDefinition(ctx, roleSpec.InheritedRole.Metadata.Name, domainType, domainID)
+		inheritedName := roleSpec.InheritedRole.Metadata.Name
+		inheritedRoleDef, err := authService.GetRoleDefinition(ctx, inheritedName, domainType, domainID)
 		if err != nil {
-			log.Errorf("failed to get inherited role %s: %v", roleSpec.InheritedRole.Metadata.Name, err)
+			log.Errorf("failed to get inherited role %s: %v", inheritedName, err)
 			return nil, grpcerrors.InvalidArgument(nil, "inherited role not found")
+		}
+		if err := ensureCanGrantRole(ctx, authService, requesterID, domainType, domainID, inheritedName); err != nil {
+			return nil, err
 		}
 		roleDefinition.InheritsFrom = inheritedRoleDef
 	}

--- a/pkg/grpc/actions/auth/update_role_test.go
+++ b/pkg/grpc/actions/auth/update_role_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/models"
 	pbAuth "github.com/superplanehq/superplane/pkg/protos/authorization"
@@ -15,7 +16,7 @@ import (
 
 func Test_UpdateRole(t *testing.T) {
 	r := support.Setup(t)
-	ctx := context.Background()
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 	orgID := r.Organization.ID.String()
 	canvasPath := "canvases"
 	secretPath := "secrets"


### PR DESCRIPTION
Require requesters to already hold permissions before assigning roles, creating/updating groups or custom roles, or adding users to elevated groups, and refuse demoting the last organization owner.