### PR TITLE
fix: enforce canvas read and scope checks on custom HTTP/WS

### DIFF
--- a/pkg/authorization/canvas_access.go
+++ b/pkg/authorization/canvas_access.go
@@ -1,0 +1,48 @@
+package authorization
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+)
+
+// CheckCanvasAccess verifies organization permission for a canvas-scoped action and
+// enforces canvas allowlists from scoped JWT scopes and/or API-key canvas IDs.
+// Empty scopedScopes and empty apiKeyCanvasIDs mean the caller is not canvas-scoped.
+func CheckCanvasAccess(
+	ctx context.Context,
+	auth organizationPermissionChecker,
+	userID, orgID, canvasID, resource, action string,
+	scopedScopes []string,
+	apiKeyCanvasIDs []string,
+) (bool, error) {
+	allowed, err := checkOrganizationPermission(ctx, auth, userID, orgID, resource, action)
+	if err != nil || !allowed {
+		return allowed, err
+	}
+
+	if len(apiKeyCanvasIDs) > 0 && !slices.Contains(apiKeyCanvasIDs, canvasID) {
+		return false, nil
+	}
+
+	if len(scopedScopes) == 0 {
+		return true, nil
+	}
+
+	scopesJSON, err := json.Marshal(scopedScopes)
+	if err != nil {
+		return false, err
+	}
+
+	rule := AuthorizationRule{
+		Resource:           resource,
+		Action:             action,
+		ResourcePathParams: []string{CanvasIDPathParam},
+	}
+	pathParams := map[string]string{CanvasIDPathParam: canvasID}
+	if !hasRequiredScopedTokenPermissionForScopes(string(scopesJSON), pathParams, rule) {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/authorization/canvas_access_test.go
+++ b/pkg/authorization/canvas_access_test.go
@@ -1,0 +1,128 @@
+package authorization
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCanvasAccess(t *testing.T) {
+	userID := "22222222-2222-4222-8222-222222222222"
+	orgID := "11111111-1111-4111-8111-111111111111"
+	canvasA := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	canvasB := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+	t.Run("denies when organization permission is missing", func(t *testing.T) {
+		allowed, err := CheckCanvasAccess(
+			context.Background(),
+			denyingPermissionChecker{},
+			userID,
+			orgID,
+			canvasA,
+			"canvases",
+			"read",
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
+
+	t.Run("allows unscoped caller with organization permission", func(t *testing.T) {
+		allowed, err := CheckCanvasAccess(
+			context.Background(),
+			allowingPermissionChecker{},
+			userID,
+			orgID,
+			canvasA,
+			"canvases",
+			"read",
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("denies API key scoped to a different canvas", func(t *testing.T) {
+		allowed, err := CheckCanvasAccess(
+			context.Background(),
+			allowingPermissionChecker{},
+			userID,
+			orgID,
+			canvasB,
+			"canvases",
+			"read",
+			nil,
+			[]string{canvasA},
+		)
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
+
+	t.Run("allows API key scoped to the requested canvas", func(t *testing.T) {
+		allowed, err := CheckCanvasAccess(
+			context.Background(),
+			allowingPermissionChecker{},
+			userID,
+			orgID,
+			canvasA,
+			"canvases",
+			"read",
+			nil,
+			[]string{canvasA},
+		)
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("denies scoped token for a different canvas", func(t *testing.T) {
+		allowed, err := CheckCanvasAccess(
+			context.Background(),
+			allowingPermissionChecker{},
+			userID,
+			orgID,
+			canvasB,
+			"canvases",
+			"read",
+			[]string{"canvases:read:" + canvasA},
+			nil,
+		)
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
+
+	t.Run("allows scoped token for the requested canvas", func(t *testing.T) {
+		allowed, err := CheckCanvasAccess(
+			context.Background(),
+			allowingPermissionChecker{},
+			userID,
+			orgID,
+			canvasA,
+			"canvases",
+			"read",
+			[]string{"canvases:read:" + canvasA},
+			nil,
+		)
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("denies scoped token missing canvases read action", func(t *testing.T) {
+		allowed, err := CheckCanvasAccess(
+			context.Background(),
+			allowingPermissionChecker{},
+			userID,
+			orgID,
+			canvasA,
+			"canvases",
+			"read",
+			[]string{"canvases:update:" + canvasA},
+			nil,
+		)
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
+}

--- a/pkg/public/canvas_access.go
+++ b/pkg/public/canvas_access.go
@@ -1,0 +1,34 @@
+package public
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/public/middleware"
+)
+
+func (s *Server) authorizeCanvasRead(ctx context.Context, user *models.User, canvasID uuid.UUID) (bool, error) {
+	var scopes []string
+	if claims, ok := middleware.GetScopedTokenClaimsFromContext(ctx); ok && claims != nil {
+		scopes = claims.Scopes
+	}
+
+	var apiKeyCanvasIDs []string
+	if user.HasAPIKeyCanvasScope() {
+		apiKeyCanvasIDs = append(apiKeyCanvasIDs, user.APIKeyCanvasIDs...)
+	}
+
+	return authorization.CheckCanvasAccess(
+		ctx,
+		s.authService,
+		user.ID.String(),
+		user.OrganizationID.String(),
+		canvasID.String(),
+		"canvases",
+		"read",
+		scopes,
+		apiKeyCanvasIDs,
+	)
+}

--- a/pkg/public/canvas_access_handlers_test.go
+++ b/pkg/public/canvas_access_handlers_test.go
@@ -1,0 +1,123 @@
+package public
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestAuthorizeCanvasRead_APIKeyCanvasScope(t *testing.T) {
+	r := support.Setup(t)
+	signer := jwt.NewSigner("test")
+	server, err := NewServer(
+		r.Encryptor,
+		r.Registry,
+		signer,
+		support.NewOIDCProvider(),
+		r.GitProvider,
+		"",
+		"http://localhost",
+		"http://localhost",
+		"test",
+		"/app/templates",
+		r.AuthService,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	registerTestGRPCGateway(t, server, r.AuthService, r.Registry, r.Encryptor, support.NewOIDCProvider(), r.GitProvider, nil)
+
+	canvasA, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+	canvasB, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+
+	rawToken, err := crypto.Base64String(32)
+	require.NoError(t, err)
+	description := "scoped key"
+	apiKey, err := models.CreateAPIKey(
+		database.Conn(),
+		r.Organization.ID,
+		"scoped-download-key",
+		&description,
+		r.User,
+		nil,
+		[]string{canvasA.ID.String()},
+	)
+	require.NoError(t, err)
+	require.NoError(t, apiKey.UpdateTokenHash(crypto.HashToken(rawToken)))
+	require.NoError(t, r.AuthService.AssignRole(apiKey.ID.String(), models.RoleOrgViewer, r.Organization.ID.String(), models.DomainTypeOrganization))
+
+	downloadWithAPIKey := func(canvasID string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(
+			http.MethodGet,
+			fmt.Sprintf("/api/v1/canvases/%s/repository/file?path=README.md", canvasID),
+			nil,
+		)
+		req.Header.Set("Authorization", "Bearer "+rawToken)
+		rec := httptest.NewRecorder()
+		server.Router.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("denies download for canvas outside API key scope", func(t *testing.T) {
+		response := downloadWithAPIKey(canvasB.ID.String())
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("allows download for canvas inside API key scope", func(t *testing.T) {
+		response := downloadWithAPIKey(canvasA.ID.String())
+		assert.NotEqual(t, http.StatusForbidden, response.Code)
+		assert.NotEqual(t, http.StatusUnauthorized, response.Code)
+	})
+}
+
+func TestHandleWebSocket_RequiresCanvasRead(t *testing.T) {
+	r := support.Setup(t)
+	signer := jwt.NewSigner("test")
+	server, err := NewServer(
+		r.Encryptor,
+		r.Registry,
+		signer,
+		support.NewOIDCProvider(),
+		r.GitProvider,
+		"",
+		"http://localhost",
+		"http://localhost",
+		"test",
+		"/app/templates",
+		r.AuthService,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	registerTestGRPCGateway(t, server, r.AuthService, r.Registry, r.Encryptor, support.NewOIDCProvider(), r.GitProvider, nil)
+	server.RegisterWebRoutes("")
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	restrictedAccount, err := models.CreateAccount("ws-restricted@example.com", "WS Restricted")
+	require.NoError(t, err)
+	_, err = models.CreateUser(r.Organization.ID, restrictedAccount.ID, restrictedAccount.Email, restrictedAccount.Name)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/ws/%s", canvas.ID.String()), nil)
+	req.Header.Set("x-organization-id", r.Organization.ID.String())
+	token, err := authentication.GenerateAccountToken(signer, restrictedAccount.ID.String(), time.Now(), time.Hour)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+
+	rec := httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/pkg/public/repository_file_download.go
+++ b/pkg/public/repository_file_download.go
@@ -41,7 +41,7 @@ func (s *Server) handleRepositoryFileDownload(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	allowed, err := s.checkRepositoryReadPermission(ctx, user)
+	allowed, err := s.authorizeCanvasRead(ctx, user, canvasID)
 	if err != nil {
 		log.Errorf("Failed to check permission: %v", err)
 		http.Error(w, "Unauthorized", http.StatusForbidden)
@@ -90,18 +90,6 @@ func (s *Server) handleRepositoryFileDownload(w http.ResponseWriter, r *http.Req
 		log.Errorf("Failed to copy file: %v", err)
 		http.Error(w, "Failed to copy file", http.StatusInternalServerError)
 	}
-}
-
-func (s *Server) checkRepositoryReadPermission(ctx context.Context, user *models.User) (allowed bool, err error) {
-	ctx, done := telemetry.Span(ctx, "repository.check_permission")
-	defer done(&err)
-
-	return s.authService.CheckOrganizationPermission(ctx,
-		user.ID.String(),
-		user.OrganizationID.String(),
-		"canvases",
-		"read",
-	)
 }
 
 func (s *Server) findFileReader(ctx context.Context, db *gorm.DB, r *http.Request, user *models.User, canvas *models.Canvas, path string) (reader io.ReadCloser, err error) {

--- a/pkg/public/runner_live_log_session.go
+++ b/pkg/public/runner_live_log_session.go
@@ -20,21 +20,6 @@ func (s *Server) handleRunnerLiveLogSession(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	allowed, err := s.authService.CheckOrganizationPermission(r.Context(),
-		user.ID.String(),
-		user.OrganizationID.String(),
-		"canvases",
-		"read",
-	)
-	if err != nil {
-		http.Error(w, "Authorization check failed", http.StatusInternalServerError)
-		return
-	}
-	if !allowed {
-		http.Error(w, "Forbidden", http.StatusForbidden)
-		return
-	}
-
 	vars := mux.Vars(r)
 	canvasID, err := uuid.Parse(strings.TrimSpace(vars["canvas_id"]))
 	if err != nil {
@@ -44,6 +29,16 @@ func (s *Server) handleRunnerLiveLogSession(w http.ResponseWriter, r *http.Reque
 	executionID, err := uuid.Parse(strings.TrimSpace(vars["execution_id"]))
 	if err != nil {
 		http.Error(w, "Invalid execution id", http.StatusBadRequest)
+		return
+	}
+
+	allowed, err := s.authorizeCanvasRead(r.Context(), user, canvasID)
+	if err != nil {
+		http.Error(w, "Authorization check failed", http.StatusInternalServerError)
+		return
+	}
+	if !allowed {
+		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -1397,6 +1397,17 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	allowed, err := s.authorizeCanvasRead(r.Context(), user, parsedWorkflowID)
+	if err != nil {
+		log.Errorf("Failed to check canvas websocket permission: %v", err)
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+	if !allowed {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	ws, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		if _, ok := err.(websocket.HandshakeError); !ok {


### PR DESCRIPTION
Require canvases:read plus scoped JWT / API-key canvas allowlists for canvas WebSocket, repository file download, and runner live-log session handlers.