### PR TITLE
fix: leave failed integration hooks pending for retry

### DIFF
--- a/pkg/workers/integration_request_worker.go
+++ b/pkg/workers/integration_request_worker.go
@@ -218,17 +218,24 @@ func (w *IntegrationRequestWorker) invokeIntegrationAction(request *models.Integ
 		HTTP:            w.registry.HTTPContext(),
 	}
 
-	if err := hookProvider.HandleHook(hookCtx); err != nil {
-		logger.Errorf("error handling action: %v", err)
+	hookErr := hookProvider.HandleHook(hookCtx)
+	if hookErr != nil {
+		logger.Errorf("error handling action: %v", hookErr)
 	}
 
 	//
-	// Phase 3: persist instance state and complete the claimed request.
+	// Phase 3: persist instance state. Only complete the request when the hook
+	// succeeded - otherwise leave it pending so the lease can expire and another
+	// worker (or this one) can retry.
 	//
 	return database.Conn().Transaction(func(tx *gorm.DB) error {
 		if err := tx.Save(integration).Error; err != nil {
 			logger.Errorf("failed to save integration %s: %v", integration.ID, err)
 			return fmt.Errorf("failed to save integration: %w", err)
+		}
+
+		if hookErr != nil {
+			return hookErr
 		}
 
 		return request.Complete(tx)

--- a/pkg/workers/integration_request_worker_test.go
+++ b/pkg/workers/integration_request_worker_test.go
@@ -458,15 +458,16 @@ func Test__AppInstallationRequestWorker_InvokeHookError(t *testing.T) {
 	request := &requests[0]
 
 	//
-	// Process request
+	// Process request - HandleHook failure must not complete the request so the
+	// lease can expire and the worker can retry.
 	//
-	require.NoError(t, worker.LockAndProcessRequest(*request))
+	require.Error(t, worker.LockAndProcessRequest(*request))
 
 	//
-	// Reload request, verify it was completed, even though the action failed.
+	// Reload request, verify it stayed pending despite the action failure.
 	//
 	request, err = integration.GetRequest(request.ID.String())
 	require.NoError(t, err)
-	assert.Equal(t, models.IntegrationRequestStateCompleted, request.State)
+	assert.Equal(t, models.IntegrationRequestStatePending, request.State)
 	assert.True(t, hookCalled)
 }


### PR DESCRIPTION
Do not Complete invoke-action requests after HandleHook errors so the lease can expire and the worker can retry the action.