### PR TITLE
fix: flip AutoCompleteInput dropdown above cursor when viewport space…

### DIFF
--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -144,6 +144,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
     }>({ top: 0, left: 0 });
     const [previewMode, setPreviewMode] = useState(false);
     const dropdownWidth = 350;
+    const dropdownHeight = 300;
     const previousWordLength = useRef<number>(0);
     const previousInputValue = useRef<string>(value);
     const highlightedIndexRef = useRef(highlightedIndex);
@@ -975,6 +976,8 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
         calculateDropdownPosition({
           cursor,
           viewportWidth: window.innerWidth,
+          viewportHeight: window.innerHeight,
+          dropdownHeight,
           dropdownWidth,
           valuePreviewWidth,
           showValuePreview,

--- a/web_src/src/components/AutoCompleteInput/dropdownPosition.ts
+++ b/web_src/src/components/AutoCompleteInput/dropdownPosition.ts
@@ -2,21 +2,23 @@ type ScreenPoint = {
   x: number;
   y: number;
 };
-
 type DropdownPositionInput = {
   cursor: ScreenPoint;
   viewportWidth: number;
+  viewportHeight: number;
   dropdownWidth: number;
+  dropdownHeight: number;
   valuePreviewWidth: number;
   showValuePreview: boolean;
   edgePadding?: number;
   gap?: number;
 };
-
 export function calculateDropdownPosition({
   cursor,
   viewportWidth,
+  viewportHeight,
   dropdownWidth,
+  dropdownHeight,
   valuePreviewWidth,
   showValuePreview,
   edgePadding = 16,
@@ -25,17 +27,26 @@ export function calculateDropdownPosition({
   const spaceOnRight = viewportWidth - cursor.x - edgePadding;
   const spaceOnLeft = cursor.x - edgePadding;
   const shouldFlipLeft = spaceOnRight < dropdownWidth && spaceOnLeft >= dropdownWidth;
-
   let left: number;
   if (shouldFlipLeft) {
     left = showValuePreview ? cursor.x - dropdownWidth - valuePreviewWidth : cursor.x - dropdownWidth;
   } else {
     left = showValuePreview ? cursor.x - valuePreviewWidth : cursor.x;
   }
-
   const totalWidth = showValuePreview ? dropdownWidth + valuePreviewWidth : dropdownWidth;
+
+  const spaceBelow = viewportHeight - cursor.y - gap - edgePadding;
+  const spaceAbove = cursor.y - gap - edgePadding;
+  const shouldFlipAbove = spaceBelow < dropdownHeight && spaceAbove >= dropdownHeight;
+  let top: number;
+  if (shouldFlipAbove) {
+    top = cursor.y - gap - dropdownHeight;
+  } else {
+    top = cursor.y + gap;
+  }
+
   return {
-    top: cursor.y + gap,
+    top: Math.max(edgePadding, Math.min(top, viewportHeight - dropdownHeight - edgePadding)),
     left: Math.max(edgePadding, Math.min(left, viewportWidth - totalWidth - edgePadding)),
   };
 }


### PR DESCRIPTION
Fixes #6483

The AutoCompleteInput dropdown only ever positioned itself below the
cursor, so it could get clipped when the input was near the bottom of
the viewport.

This adds vertical space calculation to calculateDropdownPosition,
mirroring the existing horizontal flip logic: if there isn't enough
room below the cursor, the dropdown now flips above it instead, and
its position is clamped within the viewport bounds either way.