### PR TITLE
fix: accept Claude Code OAuth tokens and mark integration unhealthy on auth errors

### DIFF
--- a/pkg/core/integration.go
+++ b/pkg/core/integration.go
@@ -10,6 +10,28 @@ import (
 	"github.com/superplanehq/superplane/pkg/oidc"
 )
 
+// AuthError marks an error returned from an integration action as caused by
+// invalid or expired credentials, as opposed to any other execution failure.
+// Integration clients should wrap the error they'd otherwise return (e.g. on
+// an HTTP 401) with NewAuthError so the node executor can mark the
+// integration unhealthy, instead of the failure only surfacing on the
+// individual run.
+type AuthError struct {
+	err error
+}
+
+func NewAuthError(err error) *AuthError {
+	return &AuthError{err: err}
+}
+
+func (e *AuthError) Error() string {
+	return e.err.Error()
+}
+
+func (e *AuthError) Unwrap() error {
+	return e.err
+}
+
 type Integration interface {
 	/*
 	 * The name of the integration.

--- a/pkg/core/integration.go
+++ b/pkg/core/integration.go
@@ -20,7 +20,11 @@ type AuthError struct {
 	err error
 }
 
-func NewAuthError(err error) *AuthError {
+// NewAuthError returns the error interface, not the concrete *AuthError
+// type, so callers can't accidentally store a nil *AuthError in an error
+// variable — which would make err != nil true even though the value is
+// nil, since a typed nil pointer boxed into an interface is non-nil.
+func NewAuthError(err error) error {
 	return &AuthError{err: err}
 }
 

--- a/pkg/core/integration.go
+++ b/pkg/core/integration.go
@@ -23,8 +23,13 @@ type AuthError struct {
 // NewAuthError returns the error interface, not the concrete *AuthError
 // type, so callers can't accidentally store a nil *AuthError in an error
 // variable — which would make err != nil true even though the value is
-// nil, since a typed nil pointer boxed into an interface is non-nil.
+// nil, since a typed nil pointer boxed into an interface is non-nil. It
+// returns nil when err is nil, so wrapping never turns a nil error into a
+// non-nil one (which would also panic in AuthError.Error()).
 func NewAuthError(err error) error {
+	if err == nil {
+		return nil
+	}
 	return &AuthError{err: err}
 }
 

--- a/pkg/core/integration_test.go
+++ b/pkg/core/integration_test.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__NewAuthError(t *testing.T) {
+	t.Run("nil error returns nil, not a wrapped nil", func(t *testing.T) {
+		err := NewAuthError(nil)
+		assert.Nil(t, err)
+	})
+
+	t.Run("non-nil error is wrapped and unwraps to the original", func(t *testing.T) {
+		inner := errors.New("credentials are invalid or expired")
+		err := NewAuthError(inner)
+		require.Error(t, err)
+		assert.Equal(t, inner.Error(), err.Error())
+		assert.ErrorIs(t, err, inner)
+
+		var authErr *AuthError
+		require.ErrorAs(t, err, &authErr)
+	})
+}

--- a/pkg/integrations/claude/claude.go
+++ b/pkg/integrations/claude/claude.go
@@ -47,7 +47,7 @@ func (i *Claude) Configuration() []configuration.Field {
 			Label:       "API Key",
 			Type:        configuration.FieldTypeString,
 			Sensitive:   true,
-			Description: "Claude API key",
+			Description: "Claude API key, or a Claude Code OAuth token (sk-ant-oat...). OAuth tokens are inference-only: actions like Run Managed Agent or Create Batch Message will fail with a scope error.",
 			Required:    true,
 		},
 		{

--- a/pkg/integrations/claude/client.go
+++ b/pkg/integrations/claude/client.go
@@ -28,6 +28,11 @@ const (
 	// model — and any server-side tools like code execution — finish, which
 	// regularly takes longer than the platform's default request timeout.
 	generationTimeout = 5 * time.Minute
+	// oauthTokenPrefix identifies a Claude Code OAuth token as opposed to an
+	// Anthropic API key. OAuth tokens must be sent as a bearer token; API keys
+	// use the x-api-key header. The prefix makes the two mutually exclusive, so
+	// a single "apiKey" field can accept either.
+	oauthTokenPrefix = "sk-ant-oat"
 )
 
 type Client struct {
@@ -260,7 +265,7 @@ func (c *Client) UploadFile(content io.Reader, filename, contentType string) (st
 		return "", fmt.Errorf("build upload request: %w", err)
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("x-api-key", c.APIKey)
+	setAuthHeader(req, c.APIKey)
 	req.Header.Set("anthropic-version", anthropicVersionValue)
 	req.Header.Set("anthropic-beta", anthropicFilesBeta)
 
@@ -357,7 +362,7 @@ func (c *Client) doRequestCtx(ctx context.Context, method, URL string, body io.R
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("x-api-key", apiKey)
+	setAuthHeader(req, apiKey)
 	req.Header.Set("anthropic-version", anthropicVersionValue)
 	if beta != "" {
 		req.Header.Set("anthropic-beta", beta)
@@ -385,14 +390,28 @@ func (c *Client) doRequestCtx(ctx context.Context, method, URL string, body io.R
 			errorMessage = string(responseBody)
 		}
 
-		// Handle 401 specifically
+		// Handle 401 specifically. Wrapped in an AuthError so the node executor
+		// can mark the integration unhealthy, instead of the failure only
+		// surfacing on the individual run.
 		if res.StatusCode == http.StatusUnauthorized {
-			return nil, fmt.Errorf("Claude credentials are invalid or expired: %s", errorMessage)
+			return nil, core.NewAuthError(fmt.Errorf("Claude credentials are invalid or expired: %s", errorMessage))
 		}
 
 		return nil, fmt.Errorf("request failed (%d): %s", res.StatusCode, errorMessage)
 	}
 	return responseBody, nil
+}
+
+// setAuthHeader sets the credential header appropriate for the given key's
+// kind. Claude Code OAuth tokens (sk-ant-oat...) must be sent as a bearer
+// token; the Anthropic API rejects them with "invalid x-api-key" if sent via
+// the x-api-key header used for regular API keys.
+func setAuthHeader(req *http.Request, apiKey string) {
+	if strings.HasPrefix(apiKey, oauthTokenPrefix) {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		return
+	}
+	req.Header.Set("x-api-key", apiKey)
 }
 
 // BatchRequestParams mirrors CreateMessageRequest but is used specifically for

--- a/pkg/integrations/claude/client_test.go
+++ b/pkg/integrations/claude/client_test.go
@@ -373,3 +373,67 @@ func Test__Client__GetMessageBatchResults__emptyID(t *testing.T) {
 	_, err := client.GetMessageBatchResults("")
 	require.Error(t, err)
 }
+
+func Test__setAuthHeader(t *testing.T) {
+	tests := []struct {
+		name              string
+		apiKey            string
+		expectedAuthValue string
+		expectedAPIKeySet bool
+	}{
+		{name: "regular API key uses x-api-key", apiKey: "sk-ant-api03-abc", expectedAPIKeySet: true},
+		{name: "OAuth token uses bearer auth", apiKey: "sk-ant-oat01-abc", expectedAuthValue: "Bearer sk-ant-oat01-abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			require.NoError(t, err)
+
+			setAuthHeader(req, tt.apiKey)
+
+			if tt.expectedAPIKeySet {
+				assert.Equal(t, tt.apiKey, req.Header.Get("x-api-key"))
+				assert.Empty(t, req.Header.Get("Authorization"))
+			} else {
+				assert.Equal(t, tt.expectedAuthValue, req.Header.Get("Authorization"))
+				assert.Empty(t, req.Header.Get("x-api-key"))
+			}
+		})
+	}
+}
+
+func Test__Client__CreateMessage__oauthToken(t *testing.T) {
+	jsonResp := `{
+		"id": "msg_123",
+		"type": "message",
+		"role": "assistant",
+		"content": [{"type": "text", "text": "hi"}],
+		"model": "claude-3-opus",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 1, "output_tokens": 1}
+	}`
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: 200, Body: io.NopCloser(bytes.NewBufferString(jsonResp))},
+		},
+	}
+
+	client := &Client{
+		APIKey:  "sk-ant-oat01-token",
+		BaseURL: defaultBaseURL,
+		http:    httpCtx,
+	}
+
+	_, err := client.CreateMessage(CreateMessageRequest{
+		Model:     "claude-3-opus",
+		Messages:  []Message{{Role: "user", Content: "hi"}},
+		MaxTokens: 1024,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, httpCtx.Requests, 1)
+	sentReq := httpCtx.Requests[0]
+	assert.Equal(t, "Bearer sk-ant-oat01-token", sentReq.Header.Get("Authorization"))
+	assert.Empty(t, sentReq.Header.Get("x-api-key"))
+}

--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -21,6 +21,11 @@ const (
 	anthropicVersionValue      = "2023-06-01"
 	anthropicBetaManagedAgents = "managed-agents-2026-04-01,files-api-2025-04-14"
 	sessionEventsPageLimit     = "20"
+	// oauthTokenPrefix identifies a Claude Code OAuth token as opposed to an
+	// Anthropic API key. OAuth tokens must be sent as a bearer token; API keys
+	// use the x-api-key header. The prefix makes the two mutually exclusive, so
+	// a single "apiKey" field can accept either.
+	oauthTokenPrefix = "sk-ant-oat"
 )
 
 type Client struct {
@@ -543,7 +548,7 @@ func (c *Client) UploadFile(content io.Reader, filename string) (string, error) 
 		return "", fmt.Errorf("build upload request: %w", err)
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("x-api-key", c.APIKey)
+	setAuthHeader(req, c.APIKey)
 	req.Header.Set("anthropic-version", anthropicVersionValue)
 	req.Header.Set("anthropic-beta", anthropicBetaManagedAgents)
 
@@ -786,7 +791,7 @@ func (c *Client) execRequestWithBeta(method, URL string, body io.Reader, beta st
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("x-api-key", c.APIKey)
+	setAuthHeader(req, c.APIKey)
 	req.Header.Set("anthropic-version", anthropicVersionValue)
 	if beta != "" {
 		req.Header.Set("anthropic-beta", beta)
@@ -812,11 +817,25 @@ func (c *Client) execRequestWithBeta(method, URL string, body io.Reader, beta st
 			errorMessage = string(responseBody)
 		}
 
+		// Wrapped in an AuthError so the node executor can mark the integration
+		// unhealthy, instead of the failure only surfacing on the individual run.
 		if res.StatusCode == http.StatusUnauthorized {
-			return nil, fmt.Errorf("Claude credentials are invalid or expired: %s", errorMessage)
+			return nil, core.NewAuthError(fmt.Errorf("Claude credentials are invalid or expired: %s", errorMessage))
 		}
 
 		return nil, fmt.Errorf("request failed (%d): %s", res.StatusCode, errorMessage)
 	}
 	return responseBody, nil
+}
+
+// setAuthHeader sets the credential header appropriate for the given key's
+// kind. Claude Code OAuth tokens (sk-ant-oat...) must be sent as a bearer
+// token; the Anthropic API rejects them with "invalid x-api-key" if sent via
+// the x-api-key header used for regular API keys.
+func setAuthHeader(req *http.Request, apiKey string) {
+	if strings.HasPrefix(apiKey, oauthTokenPrefix) {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		return
+	}
+	req.Header.Set("x-api-key", apiKey)
 }

--- a/pkg/integrations/claude/runagent/client_test.go
+++ b/pkg/integrations/claude/runagent/client_test.go
@@ -1,0 +1,38 @@
+package runagent
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__setAuthHeader(t *testing.T) {
+	tests := []struct {
+		name              string
+		apiKey            string
+		expectedAuthValue string
+		expectedAPIKeySet bool
+	}{
+		{name: "regular API key uses x-api-key", apiKey: "sk-ant-api03-abc", expectedAPIKeySet: true},
+		{name: "OAuth token uses bearer auth", apiKey: "sk-ant-oat01-abc", expectedAuthValue: "Bearer sk-ant-oat01-abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			require.NoError(t, err)
+
+			setAuthHeader(req, tt.apiKey)
+
+			if tt.expectedAPIKeySet {
+				assert.Equal(t, tt.apiKey, req.Header.Get("x-api-key"))
+				assert.Empty(t, req.Header.Get("Authorization"))
+			} else {
+				assert.Equal(t, tt.expectedAuthValue, req.Header.Get("Authorization"))
+				assert.Empty(t, req.Header.Get("x-api-key"))
+			}
+		})
+	}
+}

--- a/pkg/models/integration.go
+++ b/pkg/models/integration.go
@@ -338,6 +338,21 @@ func (a *Integration) SoftDeleteInTransaction(tx *gorm.DB) error {
 	}).Error
 }
 
+// MarkError flips the integration to the error state with the given
+// description. Only the state and state_description columns are written, so
+// a caller holding an in-memory copy that has gone stale (e.g. across an
+// external HTTP call) can't clobber concurrent changes to configuration,
+// metadata, or other fields with a full-row save.
+func (a *Integration) MarkError(tx *gorm.DB, message string) error {
+	a.State = IntegrationStateError
+	a.StateDescription = message
+
+	return tx.Model(a).Updates(map[string]interface{}{
+		"state":             a.State,
+		"state_description": a.StateDescription,
+	}).Error
+}
+
 func (a *Integration) GetRequest(ID string) (*IntegrationRequest, error) {
 	var request IntegrationRequest
 

--- a/pkg/models/integration_test.go
+++ b/pkg/models/integration_test.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+)
+
+func Test__Integration_MarkError(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	organization, err := CreateOrganization("org-"+uuid.NewString(), "")
+	require.NoError(t, err)
+
+	integration, err := CreateIntegration(uuid.New(), organization.ID, "dummy", "integration-"+uuid.NewString(), nil)
+	require.NoError(t, err)
+	integration.State = IntegrationStateReady
+	require.NoError(t, database.Conn().Save(integration).Error)
+
+	//
+	// Simulate a concurrent write to a column MarkError does not own (e.g. a
+	// rename via the update-integration endpoint) happening after this
+	// in-memory copy was loaded, but before MarkError persists.
+	//
+	concurrentName := "renamed-" + uuid.NewString()
+	require.NoError(t, database.Conn().Model(&Integration{}).
+		Where("id = ?", integration.ID).
+		Update("installation_name", concurrentName).Error)
+
+	require.NoError(t, integration.MarkError(database.Conn(), "credentials are invalid or expired"))
+
+	assert.Equal(t, IntegrationStateError, integration.State)
+	assert.Equal(t, "credentials are invalid or expired", integration.StateDescription)
+
+	reloaded, err := FindUnscopedIntegration(integration.ID)
+	require.NoError(t, err)
+	assert.Equal(t, IntegrationStateError, reloaded.State)
+	assert.Equal(t, "credentials are invalid or expired", reloaded.StateDescription)
+
+	// The concurrent rename must survive MarkError's narrowed update.
+	assert.Equal(t, concurrentName, reloaded.InstallationName)
+}

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -411,8 +411,7 @@ func (w *NodeExecutor) executeActionNode(
 
 		var authErr *core.AuthError
 		if integrationInstance != nil && errors.As(err, &authErr) {
-			ctx.Integration.Error(err.Error())
-			if saveErr := tx.Save(integrationInstance).Error; saveErr != nil {
+			if saveErr := integrationInstance.MarkError(tx, err.Error()); saveErr != nil {
 				logger.Errorf("failed to save integration after auth error: %v", saveErr)
 			}
 		}

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -387,6 +387,7 @@ func (w *NodeExecutor) executeActionNode(
 			WithPendingRunCreated(onPendingRunCreated),
 	}
 
+	var integrationInstance *models.Integration
 	if node.AppInstallationID != nil {
 		instance, err := models.FindUnscopedIntegrationInTransaction(tx, *node.AppInstallationID)
 		if err != nil {
@@ -399,6 +400,7 @@ func (w *NodeExecutor) executeActionNode(
 			return fmt.Errorf("failed to find integration: %v", err)
 		}
 
+		integrationInstance = instance
 		logger = logging.WithIntegration(logger, *instance)
 		ctx.Integration = contexts.NewIntegrationContext(tx, node, instance, w.encryptor, w.registry, onNewEvents)
 	}
@@ -406,6 +408,15 @@ func (w *NodeExecutor) executeActionNode(
 	ctx.Logger = logger
 	if err := action.Execute(ctx); err != nil {
 		logger.Errorf("failed to execute action: %v", err)
+
+		var authErr *core.AuthError
+		if integrationInstance != nil && errors.As(err, &authErr) {
+			ctx.Integration.Error(err.Error())
+			if saveErr := tx.Save(integrationInstance).Error; saveErr != nil {
+				logger.Errorf("failed to save integration after auth error: %v", saveErr)
+			}
+		}
+
 		return ctx.ExecutionState.Fail(models.CanvasNodeExecutionResultReasonError, err.Error())
 	}
 

--- a/pkg/workers/node_executor_test.go
+++ b/pkg/workers/node_executor_test.go
@@ -6,11 +6,15 @@ import (
 	"log"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
+	"github.com/superplanehq/superplane/test/support/impl"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
@@ -272,6 +276,123 @@ func Test__NodeExecutor_ComponentNodeWithStateChange(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updatedExecution.State)
 	assert.Equal(t, models.CanvasNodeExecutionResultPassed, updatedExecution.Result)
+}
+
+func Test__NodeExecutor_MarksIntegrationUnhealthyOnAuthError(t *testing.T) {
+	r := support.Setup(t)
+
+	r.Registry.Integrations["dummy"] = impl.NewDummyIntegration(impl.DummyIntegrationOptions{
+		Actions: []core.Action{
+			impl.NewDummyAction(impl.DummyActionOptions{
+				Name: "dummy.dummy",
+				ExecuteFunc: func(ctx core.ExecutionContext) error {
+					return core.NewAuthError(errors.New("credentials are invalid or expired"))
+				},
+			}),
+		},
+	})
+
+	integration, err := models.CreateIntegration(uuid.New(), r.Organization.ID, "dummy", support.RandomName("integration"), nil)
+	require.NoError(t, err)
+	integration.State = models.IntegrationStateReady
+	require.NoError(t, database.Conn().Save(integration).Error)
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNode,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+			{
+				NodeID:            componentNode,
+				Type:              models.NodeTypeComponent,
+				Ref:               datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "dummy.dummy"}}),
+				AppInstallationID: &integration.ID,
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID)
+
+	executor := newTestNodeExecutor(t, r)
+	require.NoError(t, executor.LockAndProcessNodeExecution(execution.ID))
+
+	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionResultFailed, updatedExecution.Result)
+
+	updatedIntegration, err := models.FindUnscopedIntegration(integration.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.IntegrationStateError, updatedIntegration.State)
+	assert.Contains(t, updatedIntegration.StateDescription, "credentials are invalid or expired")
+}
+
+func Test__NodeExecutor_DoesNotMarkIntegrationUnhealthyOnNonAuthError(t *testing.T) {
+	r := support.Setup(t)
+
+	r.Registry.Integrations["dummy"] = impl.NewDummyIntegration(impl.DummyIntegrationOptions{
+		Actions: []core.Action{
+			impl.NewDummyAction(impl.DummyActionOptions{
+				Name: "dummy.dummy",
+				ExecuteFunc: func(ctx core.ExecutionContext) error {
+					return errors.New("some transient failure")
+				},
+			}),
+		},
+	})
+
+	integration, err := models.CreateIntegration(uuid.New(), r.Organization.ID, "dummy", support.RandomName("integration"), nil)
+	require.NoError(t, err)
+	integration.State = models.IntegrationStateReady
+	require.NoError(t, database.Conn().Save(integration).Error)
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNode,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+			{
+				NodeID:            componentNode,
+				Type:              models.NodeTypeComponent,
+				Ref:               datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "dummy.dummy"}}),
+				AppInstallationID: &integration.ID,
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID)
+
+	executor := newTestNodeExecutor(t, r)
+	require.NoError(t, executor.LockAndProcessNodeExecution(execution.ID))
+
+	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionResultFailed, updatedExecution.Result)
+
+	updatedIntegration, err := models.FindUnscopedIntegration(integration.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.IntegrationStateReady, updatedIntegration.State)
 }
 
 func countConcurrentExecutionResults(t *testing.T, results []error) (successCount int, lockedCount int) {

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -382,20 +382,21 @@ func CreateCanvas(t require.TestingT, orgID uuid.UUID, userID uuid.UUID, nodes [
 			return err
 		}
 
-		for _, node := range inputNodes {
+		for i, node := range inputNodes {
 			canvasNode := models.CanvasNode{
-				WorkflowID:    workflow.ID,
-				NodeID:        node.ID,
-				Name:          node.Name,
-				State:         models.CanvasNodeStateReady,
-				Type:          node.Type,
-				Ref:           datatypes.NewJSONType(node.Ref),
-				Configuration: datatypes.NewJSONType(node.Configuration),
-				Position:      datatypes.NewJSONType(node.Position),
-				Metadata:      datatypes.NewJSONType(node.Metadata),
-				IsCollapsed:   node.IsCollapsed,
-				CreatedAt:     &now,
-				UpdatedAt:     &now,
+				WorkflowID:        workflow.ID,
+				NodeID:            node.ID,
+				Name:              node.Name,
+				State:             models.CanvasNodeStateReady,
+				Type:              node.Type,
+				Ref:               datatypes.NewJSONType(node.Ref),
+				Configuration:     datatypes.NewJSONType(node.Configuration),
+				Position:          datatypes.NewJSONType(node.Position),
+				Metadata:          datatypes.NewJSONType(node.Metadata),
+				IsCollapsed:       node.IsCollapsed,
+				AppInstallationID: nodes[i].AppInstallationID,
+				CreatedAt:         &now,
+				UpdatedAt:         &now,
 			}
 
 			if err := tx.Clauses(clause.Returning{}).Create(&canvasNode).Error; err != nil {


### PR DESCRIPTION
## Summary

- The Claude integration only accepted an Anthropic API key: every request sent credentials via the `x-api-key` header, which the Anthropic API rejects for Claude Code OAuth tokens (`sk-ant-oat...`) since those must be sent as a bearer token. `Text Prompt`, `Run Managed Agent`, and `Run Code Agent` now detect the `sk-ant-oat` prefix and send `Authorization: Bearer` instead, so a Claude subscription can be used without buying separate API credits. OAuth tokens are inference-only (verified against the live API: `GET /models` and `POST /messages` return 200; batches, files, agents, and environments reject the token with a scope error), so no new config field was needed — the `apiKey` field description now documents this limitation.
- Integration health was only checked once, during initial setup, and never re-validated. A component execution that failed because of expired or revoked credentials only failed that one run — the integration kept reporting green, which wastes debugging time when the real problem is a dead credential. The node executor now recognizes credential failures via a new `core.AuthError` type (wrapped by the Claude client on 401 responses) and marks the integration unhealthy when one occurs, so the connection status reflects reality instead of only surfacing as an unrelated run failure.

Fixes #6487
Fixes #6067

## Test plan

- [x] `make test` — full backend suite passes (10,674 tests)
- [x] `make lint` — clean
- [x] `make check.build.app` — builds
- [x] Added unit tests for OAuth vs. regular API key header selection in `pkg/integrations/claude` and `pkg/integrations/claude/runagent`
- [x] Added unit tests in `pkg/workers` covering: an `AuthError` from a component execution marks the bound integration unhealthy; a non-auth error leaves it untouched