### PR TITLE
fix: keep weekly schedules from skipping a week

### DIFF
--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -734,7 +734,7 @@ func nextWeeksTrigger(interval int, weekDays []string, hour int, minute int, now
 	nextIntervalStart := nowInTZ.AddDate(0, 0, interval*7)
 
 	// start the search on Sunday of the next week
-	nextIntervalStart.Add(-time.Duration(nextIntervalStart.Weekday()) * time.Hour)
+	nextIntervalStart = nextIntervalStart.AddDate(0, 0, -int(nextIntervalStart.Weekday()))
 	for i := 0; i < 7; i++ {
 		checkDate := nextIntervalStart.AddDate(0, 0, i)
 		if validWeekdays[checkDate.Weekday()] {

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -74,6 +74,99 @@ func TestNextMinutesTrigger(t *testing.T) {
 	}
 }
 
+func TestNextWeeksTrigger(t *testing.T) {
+	tests := []struct {
+		name        string
+		interval    int
+		weekDays    []string
+		now         time.Time
+		expectNext  time.Time
+		expectError bool
+	}{
+		{
+			// 2025-01-08 is a Wednesday, so the target week starts on Sunday 2025-01-12.
+			name:       "weekday earlier than the current weekday stays in the target week",
+			interval:   1,
+			weekDays:   []string{"monday"},
+			now:        mustParseTime("2025-01-08T10:00:00Z"),
+			expectNext: mustParseTime("2025-01-13T09:00:00Z"),
+		},
+		{
+			name:       "picks the earliest configured weekday in the target week",
+			interval:   1,
+			weekDays:   []string{"monday", "friday"},
+			now:        mustParseTime("2025-01-08T10:00:00Z"),
+			expectNext: mustParseTime("2025-01-13T09:00:00Z"),
+		},
+		{
+			name:       "Sunday is the first day of the target week",
+			interval:   1,
+			weekDays:   []string{"sunday"},
+			now:        mustParseTime("2025-01-08T10:00:00Z"),
+			expectNext: mustParseTime("2025-01-12T09:00:00Z"),
+		},
+		{
+			name:       "current weekday matches the configured weekday",
+			interval:   1,
+			weekDays:   []string{"wednesday"},
+			now:        mustParseTime("2025-01-08T10:00:00Z"),
+			expectNext: mustParseTime("2025-01-15T09:00:00Z"),
+		},
+		{
+			// Saturday 2025-01-11 + 7 days lands in the week starting Sunday 2025-01-12.
+			name:       "late-in-week start does not skip the following week",
+			interval:   1,
+			weekDays:   []string{"monday"},
+			now:        mustParseTime("2025-01-11T10:00:00Z"),
+			expectNext: mustParseTime("2025-01-13T09:00:00Z"),
+		},
+		{
+			// 2025-01-08 + 14 days is Wednesday 2025-01-22, in the week starting 2025-01-19.
+			name:       "multi-week interval",
+			interval:   2,
+			weekDays:   []string{"monday"},
+			now:        mustParseTime("2025-01-08T10:00:00Z"),
+			expectNext: mustParseTime("2025-01-20T09:00:00Z"),
+		},
+		{
+			name:        "interval below the supported range",
+			interval:    0,
+			weekDays:    []string{"monday"},
+			now:         mustParseTime("2025-01-08T10:00:00Z"),
+			expectError: true,
+		},
+		{
+			name:        "interval above the supported range",
+			interval:    53,
+			weekDays:    []string{"monday"},
+			now:         mustParseTime("2025-01-08T10:00:00Z"),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := nextWeeksTrigger(tt.interval, tt.weekDays, 9, 0, tt.now)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if !result.Equal(tt.expectNext) {
+				t.Errorf("expected next trigger at %v, got %v", tt.expectNext, *result)
+			}
+		})
+	}
+}
+
 func TestGetNextTrigger(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
### What's wrong

`nextWeeksTrigger` means to rewind its search to the Sunday of the target week, but the line that does it throws the result away:

```go
// start the search on Sunday of the next week
nextIntervalStart.Add(-time.Duration(nextIntervalStart.Weekday()) * time.Hour)
```

`time.Time.Add` is pure, so nothing happens — staticcheck flags it as `SA4017`. The units are wrong too: `Weekday()` counts days, not hours, so even assigned it could only ever move a few hours.

So the search actually starts on whatever weekday the schedule was *created* on and only walks forward, which means it can miss the day you asked for and land a week late:

| Created | Configured | Before | After |
| --- | --- | --- | --- |
| Wed 2025-01-08 | `[monday]` | Mon Jan 20 (12 days) | Mon Jan 13 (5 days) |
| Sat 2025-01-11 | `[monday]` | Mon Jan 20 (9 days) | Mon Jan 13 (2 days) |

It only looked right when the schedule happened to be created on the same weekday it fires — which is exactly what the existing `week schedule in GMT-8 timezone (PST)` case does, so the suite never caught it.

What convinced me this is a slip rather than intended behaviour is that the frontend already does it correctly. `web_src/src/pages/app/mappers/schedule.ts` rewinds to Sunday properly, under a comment that says "Match Go backend":

```ts
// Go to start of week (Sunday = 0)
const daysToSubtract = nextIntervalStart.getDay();
nextIntervalStart.setDate(nextIntervalStart.getDate() - daysToSubtract);
```

So the "Next: in …" label on the node currently disagrees with itself — while you're configuring it shows the date from this calculation, and once published it shows the backend's `nextTrigger`, up to a week later. This change makes the two agree.

### The fix

Assign the result, and rewind whole days:

```go
nextIntervalStart = nextIntervalStart.AddDate(0, 0, -int(nextIntervalStart.Weekday()))
```

Added `TestNextWeeksTrigger` covering the weekday-before-today case, Sunday-as-week-start, late-in-week creation, multi-week intervals and the bounds. Five of those fail on `main` and pass with the change. No existing test or expectation is touched, and `./pkg/triggers/...` is green either way.

I checked the obvious risk — that this could schedule something in the past, since `Setup` feeds `time.Until(...)` into `ScheduleActionCall`. It can't: the rewind is at most 6 days against a base of `interval*7`. I ran it over every start weekday × configured weekday × interval 1–4 and the smallest gap is +1s. Steady state is still exactly 7 days (and 14 for `interval: 2`).

One thing this does **not** fix: with several `weekDays` set, the trigger still only fires on one day per week rather than all of them. That's already the case on `main` — this PR only corrects which day gets picked. Happy to open a separate issue for it if you agree it's a bug.
