### PR TITLE
fix: parse every signature in the PagerDuty signature header

### DIFF
--- a/pkg/integrations/pagerduty/common.go
+++ b/pkg/integrations/pagerduty/common.go
@@ -1,5 +1,56 @@
 package pagerduty
 
+import (
+	"crypto/hmac"
+	"fmt"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/crypto"
+)
+
+// PagerDuty signs a delivery with every active secret, so a rotation in progress produces
+// a handful of signatures at most. Bounding the scan keeps an oversized header cheap to reject.
+const maxWebhookSignatures = 32
+
 type NodeMetadata struct {
 	Service *Service `json:"service"`
+}
+
+// parseWebhookSignatures returns the v1 signatures carried by the X-PagerDuty-Signature header.
+//
+// The header holds one or more comma-separated signatures, because PagerDuty signs each delivery
+// with every secret that is currently active for the subscription.
+func parseWebhookSignatures(header string) []string {
+	signatures := []string{}
+
+	remaining := header
+	for range maxWebhookSignatures {
+		if remaining == "" {
+			break
+		}
+
+		candidate, rest, _ := strings.Cut(remaining, ",")
+		remaining = rest
+
+		if value, found := strings.CutPrefix(strings.TrimSpace(candidate), "v1="); found {
+			signatures = append(signatures, value)
+		}
+	}
+
+	return signatures
+}
+
+// verifyWebhookSignatures reports whether any of the signatures matches the body.
+//
+// The body is hashed once and compared against each signature, so a delivery carrying several
+// signatures costs no more to verify than one carrying a single signature.
+func verifyWebhookSignatures(signatures []string, secret []byte, body []byte) error {
+	expected := []byte(crypto.Sign(secret, body))
+	for _, signature := range signatures {
+		if hmac.Equal(expected, []byte(signature)) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid signature")
 }

--- a/pkg/integrations/pagerduty/common_test.go
+++ b/pkg/integrations/pagerduty/common_test.go
@@ -1,0 +1,76 @@
+package pagerduty
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superplanehq/superplane/pkg/crypto"
+)
+
+func Test__parseWebhookSignatures(t *testing.T) {
+	t.Run("single signature", func(t *testing.T) {
+		assert.Equal(t, []string{"abc"}, parseWebhookSignatures("v1=abc"))
+	})
+
+	t.Run("several signatures, as sent while a secret is being rotated", func(t *testing.T) {
+		assert.Equal(t, []string{"abc", "def"}, parseWebhookSignatures("v1=abc,v1=def"))
+	})
+
+	t.Run("other signature versions are ignored", func(t *testing.T) {
+		assert.Equal(t, []string{"abc"}, parseWebhookSignatures("v2=zzz,v1=abc"))
+	})
+
+	t.Run("surrounding whitespace is tolerated", func(t *testing.T) {
+		assert.Equal(t, []string{"abc", "def"}, parseWebhookSignatures("v1=abc, v1=def"))
+	})
+
+	t.Run("header without a v1 signature", func(t *testing.T) {
+		assert.Empty(t, parseWebhookSignatures("garbage"))
+		assert.Empty(t, parseWebhookSignatures("v2=abc"))
+		assert.Empty(t, parseWebhookSignatures(""))
+	})
+
+	t.Run("an oversized header is not scanned indefinitely", func(t *testing.T) {
+		header := strings.TrimSuffix(strings.Repeat("v1=abc,", 100_000), ",")
+		assert.Len(t, parseWebhookSignatures(header), maxWebhookSignatures)
+	})
+}
+
+func Test__verifyWebhookSignatures(t *testing.T) {
+	secret := []byte("test-secret")
+	body := []byte(`{"event":{"event_type":"incident.triggered"}}`)
+	valid := crypto.Sign(secret, body)
+	other := crypto.Sign([]byte("rotated-secret"), body)
+
+	t.Run("single valid signature", func(t *testing.T) {
+		assert.NoError(t, verifyWebhookSignatures([]string{valid}, secret, body))
+	})
+
+	t.Run("matching signature listed second", func(t *testing.T) {
+		assert.NoError(t, verifyWebhookSignatures([]string{other, valid}, secret, body))
+	})
+
+	t.Run("matching signature listed first", func(t *testing.T) {
+		assert.NoError(t, verifyWebhookSignatures([]string{valid, other}, secret, body))
+	})
+
+	t.Run("no signature matches", func(t *testing.T) {
+		err := verifyWebhookSignatures([]string{other}, secret, body)
+		assert.ErrorContains(t, err, "invalid signature")
+	})
+
+	t.Run("body must match the signed payload", func(t *testing.T) {
+		err := verifyWebhookSignatures([]string{valid}, secret, []byte("tampered"))
+		assert.ErrorContains(t, err, "invalid signature")
+	})
+
+	t.Run("forged signatures are rejected", func(t *testing.T) {
+		for i := range 100 {
+			forged := crypto.Sign([]byte(fmt.Sprintf("guess-%d", i)), body)
+			err := verifyWebhookSignatures([]string{forged}, secret, body)
+			assert.ErrorContains(t, err, "invalid signature")
+		}
+	})
+}

--- a/pkg/integrations/pagerduty/on_incident.go
+++ b/pkg/integrations/pagerduty/on_incident.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
-	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/crypto"
 )
 
 type OnIncident struct{}
@@ -193,9 +191,8 @@ func (t *OnIncident) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.W
 		return http.StatusForbidden, nil, fmt.Errorf("missing signature")
 	}
 
-	// Extract version and signature value (format: v1=<signature>)
-	parts := strings.SplitN(signature, "=", 2)
-	if len(parts) != 2 || parts[0] != "v1" {
+	signatures := parseWebhookSignatures(signature)
+	if len(signatures) == 0 {
 		return http.StatusForbidden, nil, fmt.Errorf("invalid signature format")
 	}
 
@@ -204,9 +201,8 @@ func (t *OnIncident) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.W
 		return http.StatusInternalServerError, nil, fmt.Errorf("error getting secret: %v", err)
 	}
 
-	// Verify signature using HMAC SHA256
-	if err := crypto.VerifySignature(secret, ctx.Body, parts[1]); err != nil {
-		return http.StatusForbidden, nil, fmt.Errorf("invalid signature: %v", err)
+	if err := verifyWebhookSignatures(signatures, secret, ctx.Body); err != nil {
+		return http.StatusForbidden, nil, err
 	}
 
 	// Parse webhook payload

--- a/pkg/integrations/pagerduty/on_incident_annotated.go
+++ b/pkg/integrations/pagerduty/on_incident_annotated.go
@@ -6,12 +6,10 @@ import (
 	"log"
 	"net/http"
 	"regexp"
-	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/crypto"
 )
 
 type OnIncidentAnnotated struct{}
@@ -158,10 +156,9 @@ func (t *OnIncidentAnnotated) HandleWebhook(ctx core.WebhookRequestContext) (int
 		return http.StatusForbidden, nil, fmt.Errorf("missing signature")
 	}
 
-	// Extract version and signature value (format: v1=<signature>)
-	parts := strings.SplitN(signature, "=", 2)
-	if len(parts) != 2 || parts[0] != "v1" {
-		log.Printf("[OnIncidentAnnotated] Invalid signature format: %s", signature)
+	signatures := parseWebhookSignatures(signature)
+	if len(signatures) == 0 {
+		log.Printf("[OnIncidentAnnotated] Invalid signature format")
 		return http.StatusForbidden, nil, fmt.Errorf("invalid signature format")
 	}
 
@@ -171,10 +168,9 @@ func (t *OnIncidentAnnotated) HandleWebhook(ctx core.WebhookRequestContext) (int
 		return http.StatusInternalServerError, nil, fmt.Errorf("error getting secret: %v", err)
 	}
 
-	// Verify signature using HMAC SHA256
-	if err := crypto.VerifySignature(secret, ctx.Body, parts[1]); err != nil {
-		log.Printf("[OnIncidentAnnotated] Invalid signature: %v", err)
-		return http.StatusForbidden, nil, fmt.Errorf("invalid signature: %v", err)
+	if err := verifyWebhookSignatures(signatures, secret, ctx.Body); err != nil {
+		log.Printf("[OnIncidentAnnotated] Invalid signature")
+		return http.StatusForbidden, nil, err
 	}
 
 	log.Printf("[OnIncidentAnnotated] Signature verified successfully")

--- a/pkg/integrations/pagerduty/on_incident_status_update.go
+++ b/pkg/integrations/pagerduty/on_incident_status_update.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/crypto"
 )
 
 type OnIncidentStatusUpdate struct{}
@@ -151,10 +149,9 @@ func (t *OnIncidentStatusUpdate) HandleWebhook(ctx core.WebhookRequestContext) (
 		return http.StatusForbidden, nil, fmt.Errorf("missing signature")
 	}
 
-	// Extract version and signature value (format: v1=<signature>)
-	parts := strings.SplitN(signature, "=", 2)
-	if len(parts) != 2 || parts[0] != "v1" {
-		log.Printf("[OnIncidentStatusUpdate] Invalid signature format: %s", signature)
+	signatures := parseWebhookSignatures(signature)
+	if len(signatures) == 0 {
+		log.Printf("[OnIncidentStatusUpdate] Invalid signature format")
 		return http.StatusForbidden, nil, fmt.Errorf("invalid signature format")
 	}
 
@@ -164,10 +161,9 @@ func (t *OnIncidentStatusUpdate) HandleWebhook(ctx core.WebhookRequestContext) (
 		return http.StatusInternalServerError, nil, fmt.Errorf("error getting secret: %v", err)
 	}
 
-	// Verify signature using HMAC SHA256
-	if err := crypto.VerifySignature(secret, ctx.Body, parts[1]); err != nil {
-		log.Printf("[OnIncidentStatusUpdate] Invalid signature: %v", err)
-		return http.StatusForbidden, nil, fmt.Errorf("invalid signature: %v", err)
+	if err := verifyWebhookSignatures(signatures, secret, ctx.Body); err != nil {
+		log.Printf("[OnIncidentStatusUpdate] Invalid signature")
+		return http.StatusForbidden, nil, err
 	}
 
 	log.Printf("[OnIncidentStatusUpdate] Signature verified successfully")

--- a/pkg/integrations/pagerduty/on_incident_test.go
+++ b/pkg/integrations/pagerduty/on_incident_test.go
@@ -128,6 +128,29 @@ func Test__OnIncident__HandleWebhook(t *testing.T) {
 		assert.Equal(t, 0, eventContext.Count())
 	})
 
+	t.Run("signature from a secret rotation -> event is emitted", func(t *testing.T) {
+		body := []byte(`{"event":{"event_type":"incident.triggered","agent":{"id":"agent-1"},"data":{"id":"incident-1","urgency":"high"}}}`)
+		secret := "test-secret"
+
+		// While a secret is being rotated, PagerDuty signs the delivery with every active
+		// secret and sends the signatures comma-separated in a single header.
+		headers := http.Header{}
+		headers.Set("X-PagerDuty-Signature", "v1="+signatureFor("previous-secret", body)+",v1="+signatureFor(secret, body))
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:          body,
+			Headers:       headers,
+			Configuration: validConfig,
+			Webhook:       &contexts.NodeWebhookContext{Secret: secret},
+			Events:        eventContext,
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, eventContext.Count())
+	})
+
 	t.Run("valid signature -> event is emitted", func(t *testing.T) {
 		body := []byte(`{"event":{"event_type":"incident.triggered","agent":{"id":"agent-1"},"data":{"id":"incident-1","urgency":"high"}}}`)
 		secret := "test-secret"


### PR DESCRIPTION
### What's wrong

`X-PagerDuty-Signature` can carry more than one signature, comma-separated — PagerDuty signs a delivery with every secret currently active for the subscription:

```
X-PagerDuty-Signature: v1=f03de6f6…,v1=130dcacb…
```

The three incident triggers parse it like this:

```go
parts := strings.SplitN(signature, "=", 2)
...
crypto.VerifySignature(secret, ctx.Body, parts[1])
```

For the header above `parts[1]` is `"f03de6f6…,v1=130dcacb…"` — the first signature with the rest of the header glued onto it. No secret produces that HMAC, so a delivery carrying more than one signature is rejected with a 403 and the event is dropped.

[PagerDuty's verification steps](https://developer.pagerduty.com/docs/verifying-webhook-signatures) ([source](https://github.com/PagerDuty/developer-docs/blob/main/docs/webhooks/04-Signatures.md)) describe the intended handling:

> The `X-PagerDuty-Signature` header included with each webhook event delivery contains one or more signatures. Multiple signatures may be present to allow for a zero-downtime secret rotation.

> **Step 1**: … Split the signatures which are separated by the `,` character. Select only signatures which are version `v1` and remove the `v1=` prefix.

> If at least one of the signatures matches, the webhook should be considered a trusted and authentic request.

Their own Go SDK does exactly that in [`webhookv3`](https://github.com/PagerDuty/go-pagerduty/blob/master/webhookv3/webhookv3.go) — split on commas, compute the digest once, compare against each.

To be upfront about scope: I have not seen PagerDuty send a multi-signature header to SuperPlane, and I couldn't find a way for a user to trigger a rotation — `PUT /webhook_subscriptions/{id}` "does not support updating the `delivery_method`", and the UI doesn't expose it. So this is about matching the documented contract rather than a failure I can point at in production. It seemed worth doing anyway, since the header format is documented, we store whatever secret PagerDuty hands us at subscription time, and the failure mode if it ever happens is every delivery silently 403ing.

### The fix

Parse the header into its `v1` signatures, hash the body once, accept if any matches. All three triggers had their own copy of the parsing, so it moves to `common.go`.

A few things I kept an eye on while doing it:

- **Cost doesn't scale with signature count.** Hashing once instead of per-signature means a delivery with many signatures costs the same as one with a single signature. A 100k-entry header against a 512KB body verifies in ~400µs; re-hashing per candidate would have been ~33s. The candidate count is also bounded.
- **Ordering is unchanged.** The format check still runs before `GetSecret()`, so a malformed header is still rejected with 403 without touching the secret store.
- **Only genuine matches are newly accepted.** I diffed the outcome against the current implementation across a matrix of headers: the only two that change are multi-signature deliveries carrying a valid HMAC. Malformed, wrong-version, empty, and forged headers all return exactly what they return today.

Tests cover the parsing (multiple signatures in either order, other versions, whitespace, oversized headers) and the verification (match in either position, tampered body, 100 forged signatures), plus an end-to-end case through `HandleWebhook` that fails on `main` with `403 invalid signature` and passes here.

Happy to drop this if you'd rather not touch signature verification without a reproduction from the field.
