### PR TITLE
fix: emit a Bitbucket push event for every matching ref

### DIFF
--- a/docs/components/Bitbucket.mdx
+++ b/docs/components/Bitbucket.mdx
@@ -53,6 +53,10 @@ Each push event includes:
 - **push.changes**: Array of reference changes with new/old commit details
 - **actor**: Information about who pushed
 
+A single push can update more than one ref at once (for example `git push --all`, or
+pushing a branch and a tag together). One event is emitted per updated ref that matches
+the configured refs, and `push.changes` holds only the ref that triggered the event.
+
 ### Webhook Setup
 
 This trigger automatically sets up a Bitbucket webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.

--- a/pkg/integrations/bitbucket/on_push.go
+++ b/pkg/integrations/bitbucket/on_push.go
@@ -3,6 +3,7 @@ package bitbucket
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 
@@ -51,6 +52,10 @@ Each push event includes:
 - **repository**: Repository information
 - **push.changes**: Array of reference changes with new/old commit details
 - **actor**: Information about who pushed
+
+A single push can update more than one ref at once (for example ` + "`git push --all`" + `, or
+pushing a branch and a tag together). One event is emitted per updated ref that matches
+the configured refs, and ` + "`push.changes`" + ` holds only the ref that triggered the event.
 
 ## Webhook Setup
 
@@ -170,7 +175,10 @@ func (p *OnPush) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webho
 	}
 
 	//
-	// Extract the ref from the push changes and filter.
+	// A single push can update several refs at once - for example
+	// `git push --all`, or pushing a branch and a tag together.
+	// Bitbucket reports each one as an entry in `push.changes`,
+	// so every change is filtered and emitted on its own.
 	//
 	config := OnPushConfiguration{}
 	err = mapstructure.Decode(ctx.Configuration, &config)
@@ -178,18 +186,20 @@ func (p *OnPush) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webho
 		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	ref := extractRef(data)
-	if ref == "" {
-		return http.StatusOK, nil, nil
-	}
+	for _, change := range extractChanges(data) {
+		ref := extractRef(change)
+		if ref == "" {
+			continue
+		}
 
-	if !configuration.MatchesAnyPredicate(config.Refs, ref) {
-		return http.StatusOK, nil, nil
-	}
+		if !configuration.MatchesAnyPredicate(config.Refs, ref) {
+			continue
+		}
 
-	err = ctx.Events.Emit("bitbucket.push", data)
-	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Errorf("error emitting event: %v", err)
+		err = ctx.Events.Emit("bitbucket.push", payloadForChange(data, change))
+		if err != nil {
+			return http.StatusInternalServerError, nil, fmt.Errorf("error emitting event: %v", err)
+		}
 	}
 
 	return http.StatusOK, nil, nil
@@ -199,24 +209,51 @@ func (p *OnPush) Cleanup(ctx core.TriggerContext) error {
 	return nil
 }
 
-// extractRef extracts the ref name from a Bitbucket push payload.
-func extractRef(data map[string]any) string {
+// extractChanges returns the ref changes carried by a Bitbucket push payload.
+func extractChanges(data map[string]any) []map[string]any {
 	push, ok := data["push"].(map[string]any)
 	if !ok {
-		return ""
+		return nil
 	}
 
-	changes, ok := push["changes"].([]any)
-	if !ok || len(changes) == 0 {
-		return ""
-	}
-
-	firstChange, ok := changes[0].(map[string]any)
+	rawChanges, ok := push["changes"].([]any)
 	if !ok {
-		return ""
+		return nil
 	}
 
-	newRef, ok := firstChange["new"].(map[string]any)
+	changes := make([]map[string]any, 0, len(rawChanges))
+	for _, rawChange := range rawChanges {
+		change, ok := rawChange.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		changes = append(changes, change)
+	}
+
+	return changes
+}
+
+// payloadForChange returns the push payload narrowed down to a single ref change,
+// so that `push.changes` always describes the ref that triggered the event.
+func payloadForChange(data map[string]any, change map[string]any) map[string]any {
+	push, ok := data["push"].(map[string]any)
+	if !ok {
+		return data
+	}
+
+	narrowedPush := maps.Clone(push)
+	narrowedPush["changes"] = []any{change}
+
+	payload := maps.Clone(data)
+	payload["push"] = narrowedPush
+
+	return payload
+}
+
+// extractRef extracts the ref name from a single Bitbucket push change.
+func extractRef(change map[string]any) string {
+	newRef, ok := change["new"].(map[string]any)
 	if !ok {
 		return ""
 	}

--- a/pkg/integrations/bitbucket/on_push_test.go
+++ b/pkg/integrations/bitbucket/on_push_test.go
@@ -258,20 +258,62 @@ func Test__OnPush__HandleWebhook(t *testing.T) {
 		require.Equal(t, 1, eventContext.Count())
 		assert.Equal(t, "bitbucket.push", eventContext.Payloads[0].Type)
 	})
+
+	t.Run("matching ref is not the first change -> event is emitted", func(t *testing.T) {
+		body := []byte(`{"push":{"changes":[
+			{"new":{"type":"branch","name":"feature-1"}},
+			{"new":{"type":"branch","name":"main"}}
+		]}}`)
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(pushWebhookRequest(body, "refs/heads/main", eventContext))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		require.Equal(t, 1, eventContext.Count())
+		assert.Equal(t, "refs/heads/main", refOfEmittedPayload(t, eventContext.Payloads[0].Data))
+	})
+
+	t.Run("several matching refs -> one event per matching ref", func(t *testing.T) {
+		body := []byte(`{"push":{"changes":[
+			{"new":{"type":"branch","name":"main"}},
+			{"new":{"type":"branch","name":"feature-1"}},
+			{"new":{"type":"tag","name":"v1.2.3"}}
+		]}}`)
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(pushWebhookRequest(body, "refs/heads/main", eventContext,
+			configuration.Predicate{Type: configuration.PredicateTypeEquals, Value: "refs/tags/v1.2.3"},
+		))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		require.Equal(t, 2, eventContext.Count())
+		assert.Equal(t, "refs/heads/main", refOfEmittedPayload(t, eventContext.Payloads[0].Data))
+		assert.Equal(t, "refs/tags/v1.2.3", refOfEmittedPayload(t, eventContext.Payloads[1].Data))
+	})
+
+	t.Run("no matching ref among several changes -> no event is emitted", func(t *testing.T) {
+		body := []byte(`{"push":{"changes":[
+			{"new":{"type":"branch","name":"feature-1"}},
+			{"new":{"type":"branch","name":"feature-2"}}
+		]}}`)
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(pushWebhookRequest(body, "refs/heads/main", eventContext))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
 }
 
 func Test__ExtractRef(t *testing.T) {
 	t.Run("extracts branch ref", func(t *testing.T) {
 		ref := extractRef(map[string]any{
-			"push": map[string]any{
-				"changes": []any{
-					map[string]any{
-						"new": map[string]any{
-							"type": "branch",
-							"name": "main",
-						},
-					},
-				},
+			"new": map[string]any{
+				"type": "branch",
+				"name": "main",
 			},
 		})
 
@@ -280,15 +322,9 @@ func Test__ExtractRef(t *testing.T) {
 
 	t.Run("extracts tag ref", func(t *testing.T) {
 		ref := extractRef(map[string]any{
-			"push": map[string]any{
-				"changes": []any{
-					map[string]any{
-						"new": map[string]any{
-							"type": "tag",
-							"name": "v1.2.3",
-						},
-					},
-				},
+			"new": map[string]any{
+				"type": "tag",
+				"name": "v1.2.3",
 			},
 		})
 
@@ -297,19 +333,124 @@ func Test__ExtractRef(t *testing.T) {
 
 	t.Run("missing ref returns empty string", func(t *testing.T) {
 		ref := extractRef(map[string]any{
-			"push": map[string]any{
-				"changes": []any{
-					map[string]any{
-						"new": map[string]any{
-							"type": "branch",
-						},
-					},
-				},
+			"new": map[string]any{
+				"type": "branch",
 			},
 		})
 
 		assert.Empty(t, ref)
 	})
+
+	t.Run("deleted ref returns empty string", func(t *testing.T) {
+		ref := extractRef(map[string]any{
+			"new": nil,
+			"old": map[string]any{
+				"type": "branch",
+				"name": "main",
+			},
+		})
+
+		assert.Empty(t, ref)
+	})
+}
+
+func Test__ExtractChanges(t *testing.T) {
+	t.Run("no push key returns no changes", func(t *testing.T) {
+		assert.Empty(t, extractChanges(map[string]any{}))
+	})
+
+	t.Run("changes is not a list returns no changes", func(t *testing.T) {
+		assert.Empty(t, extractChanges(map[string]any{
+			"push": map[string]any{"changes": "not-a-list"},
+		}))
+	})
+
+	t.Run("returns every change and skips malformed ones", func(t *testing.T) {
+		changes := extractChanges(map[string]any{
+			"push": map[string]any{
+				"changes": []any{
+					map[string]any{"new": map[string]any{"type": "branch", "name": "main"}},
+					"not-a-change",
+					map[string]any{"new": map[string]any{"type": "tag", "name": "v1.2.3"}},
+				},
+			},
+		})
+
+		require.Len(t, changes, 2)
+		assert.Equal(t, "refs/heads/main", extractRef(changes[0]))
+		assert.Equal(t, "refs/tags/v1.2.3", extractRef(changes[1]))
+	})
+}
+
+func Test__PayloadForChange(t *testing.T) {
+	t.Run("keeps the rest of the payload and narrows changes to one", func(t *testing.T) {
+		tagChange := map[string]any{"new": map[string]any{"type": "tag", "name": "v1.2.3"}}
+		data := map[string]any{
+			"actor":      map[string]any{"nickname": "johndoe"},
+			"repository": map[string]any{"name": "my-repo"},
+			"push": map[string]any{
+				"changes": []any{
+					map[string]any{"new": map[string]any{"type": "branch", "name": "main"}},
+					tagChange,
+				},
+			},
+		}
+
+		payload := payloadForChange(data, tagChange)
+
+		assert.Equal(t, data["actor"], payload["actor"])
+		assert.Equal(t, data["repository"], payload["repository"])
+		assert.Equal(t, []any{tagChange}, payload["push"].(map[string]any)["changes"])
+	})
+
+	t.Run("does not modify the original payload", func(t *testing.T) {
+		tagChange := map[string]any{"new": map[string]any{"type": "tag", "name": "v1.2.3"}}
+		originalChanges := []any{
+			map[string]any{"new": map[string]any{"type": "branch", "name": "main"}},
+			tagChange,
+		}
+		data := map[string]any{
+			"push": map[string]any{"changes": originalChanges},
+		}
+
+		payloadForChange(data, tagChange)
+
+		assert.Equal(t, originalChanges, data["push"].(map[string]any)["changes"])
+	})
+}
+
+// pushWebhookRequest builds a signed repo:push request for a trigger listening on refs.
+func pushWebhookRequest(body []byte, ref string, events *contexts.EventContext, extraRefs ...configuration.Predicate) core.WebhookRequestContext {
+	headers := http.Header{}
+	headers.Set("X-Event-Key", "repo:push")
+	headers.Set("X-Hub-Signature", "sha256="+signBitbucketPayload("test-secret", body))
+
+	refs := append(
+		[]configuration.Predicate{{Type: configuration.PredicateTypeEquals, Value: ref}},
+		extraRefs...,
+	)
+
+	return core.WebhookRequestContext{
+		Body:    body,
+		Headers: headers,
+		Webhook: &contexts.NodeWebhookContext{Secret: "test-secret"},
+		Configuration: map[string]any{
+			"repository": "hello",
+			"refs":       refs,
+		},
+		Events: events,
+	}
+}
+
+// refOfEmittedPayload returns the ref described by an emitted push payload.
+func refOfEmittedPayload(t *testing.T, payload any) string {
+	data, ok := payload.(map[string]any)
+	require.True(t, ok)
+
+	changes := extractChanges(data)
+	require.Len(t, changes, 1)
+
+	return extractRef(changes[0])
 }
 
 func signBitbucketPayload(secret string, body []byte) string {


### PR DESCRIPTION
## Problem

A Bitbucket `repo:push` webhook carries an **array** of ref changes in `push.changes`. A single push can update several refs at once — `git push --all`, pushing a branch and a tag together, or any client that batches ref updates into one push.

`bitbucket.onPush` only ever looked at `push.changes[0]` ([`on_push.go`](https://github.com/superplanehq/superplane/blob/main/pkg/integrations/bitbucket/on_push.go#L200-L215)):

```go
firstChange, ok := changes[0].(map[string]any)
```

Two consequences:

1. **Events are silently dropped.** If the ref matching the trigger's `refs` predicate isn't first in the array, `extractRef` returns the *other* ref, the predicate doesn't match, and the handler returns `200 OK` without emitting. Nothing is logged — to the user the workflow just never fires, intermittently, depending on the ordering Bitbucket happened to send.
2. **The payload can describe the wrong ref.** When the matching ref *is* present but not first, downstream expressions reading `$.push.changes[0]` get a different ref than the one that satisfied the trigger.

The existing tests only ever used single-element `changes` arrays, so neither case was covered.

## Fix

Filter every entry in `push.changes` against the configured refs and emit one event per match. Each emitted payload keeps `actor`, `repository` and the rest of the envelope intact, with `push.changes` narrowed to the single change that triggered it — so `push.changes[0]` always describes the ref that fired the workflow.

This follows the existing multi-event webhook pattern in the codebase (`sendgrid.onEmailEvent` emits one event per entry in a batched webhook body).

### Behavior change

A push updating N matching refs now emits N events instead of 1. That matches the semantics users expect and mirrors GitHub, which delivers one push webhook per ref. Pushes updating a single ref — the overwhelmingly common case — are unaffected.

Deleted refs (`new: null`) are still skipped, as before.

## Tests

Added to `pkg/integrations/bitbucket/on_push_test.go`:

- matching ref is not the first change → event **is** emitted (fails on `main`)
- several matching refs → one event per matching ref, each carrying its own ref (fails on `main`)
- no matching ref among several changes → no event emitted
- `extractChanges` skips malformed entries; handles missing/non-list `changes`
- `payloadForChange` preserves the envelope and does not mutate the original payload
- deleted ref returns an empty ref

Verified the two regression tests fail against the previous first-change-only behavior and pass with the fix.

```
$ go test ./pkg/integrations/bitbucket/...
ok  	github.com/superplanehq/superplane/pkg/integrations/bitbucket	0.411s
```

`gofmt -s` and `go vet` are clean on the package.

## Docs

Updated the `On Push` trigger `Documentation()` to describe the multi-ref behavior, and synced `docs/components/Bitbucket.mdx` accordingly.

## Note on the video requirement

[`integration-prs.md`](https://github.com/superplanehq/superplane/blob/main/docs/contributing/integration-prs.md) asks for a demo video on integration PRs. This is a bug fix to an existing trigger rather than a new integration or component, and the behavior is covered by regression tests that demonstrably fail on `main` — so there's no new setup or user flow to show. Happy to record one if you'd still like it.