### PR TITLE
fix: prevent connections to deleted (ghost) canvas nodes

### DIFF
--- a/test/e2e/ghost_node_connection_test.go
+++ b/test/e2e/ghost_node_connection_test.go
@@ -1,0 +1,256 @@
+package e2e
+
+// -----------------------------------------------------------------------------
+// Regression spec for issue #6417 ("Deleted components can still connect and
+// be connected to").
+//
+// On a draft canvas, a node deleted from the draft but still present on the
+// live version renders as a "removed" ghost via the draft visual diff. React
+// Flow completes connections by handle proximity, so dropping a connection
+// drag near the ghost's handle used to create an edge to the deleted node.
+// The staged canvas.yaml then referenced a missing node and committing failed
+// with the generic "invalid canvas yaml" error.
+//
+// This spec asserts the fixed behavior: the drop is silently rejected, no
+// edge to the deleted node is staged, and the draft commits successfully.
+// -----------------------------------------------------------------------------
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	pw "github.com/mxschmitt/playwright-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+)
+
+func TestGhostNodeConnection(t *testing.T) {
+	t.Run("a connection dropped on a deleted ghost node is rejected and the draft still commits", func(t *testing.T) {
+		steps := &ghostNodeConnectionSteps{t: t}
+		steps.start()
+		steps.givenACommittedCanvasWithTwoConnectedNodes()
+		steps.whenIDeleteTheSecondNodeInTheDraft()
+		steps.thenTheDeletedNodeRendersAsAGhost("ghost-node-fixed-1-ghost-visible")
+		steps.whenIDragAConnectionFromTheLiveNodeToTheGhostNode()
+		steps.thenNoEdgeToTheDeletedNodeIsStaged()
+		steps.thenTheDraftCommitsSuccessfully("ghost-node-fixed-4-commit-succeeded")
+	})
+
+	t.Run("a connection dragged out of a deleted ghost node output handle cannot stage a ghost edge", func(t *testing.T) {
+		steps := &ghostNodeConnectionSteps{t: t}
+		steps.start()
+		steps.givenACommittedChainWithAMiddleNode()
+		steps.whenIDeleteTheSecondNodeInTheDraft()
+		steps.thenTheDeletedNodeRendersAsAGhost("ghost-node-fixed-5-output-ghost-visible")
+		steps.whenIDragFromTheGhostOutputHandleIntoEmptySpaceAndPickAComponent()
+		steps.thenNoEdgeTouchingTheDeletedNodeIsStaged()
+		steps.thenTheDraftCommitsSuccessfully("ghost-node-fixed-5-commit-succeeded")
+	})
+}
+
+type ghostNodeConnectionSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+
+	liveNodeID  string // node id of "First" (manual trigger, kept in draft)
+	ghostNodeID string // node id of "Second" (noop, deleted from draft)
+}
+
+func (s *ghostNodeConnectionSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *ghostNodeConnectionSteps) givenACommittedCanvasWithTwoConnectedNodes() {
+	s.canvas = shared.NewCanvasSteps("Ghost Node Connection", s.t, s.session)
+	s.canvas.Create()
+	s.canvas.EnterEditMode()
+
+	s.canvas.AddManualTrigger("First", models.Position{X: 500, Y: 200})
+	s.canvas.AddNoop("Second", models.Position{X: 1100, Y: 200})
+	s.canvas.Connect("First", "Second")
+	s.canvas.Save()
+	s.canvas.CommitAndPublish()
+
+	// Resolve stable node ids from the committed live version.
+	live, err := models.FindLiveCanvasVersion(s.canvas.WorkflowID)
+	require.NoError(s.t, err)
+	for _, node := range live.Nodes {
+		switch node.Name {
+		case "First":
+			s.liveNodeID = node.ID
+		case "Second":
+			s.ghostNodeID = node.ID
+		}
+	}
+	require.NotEmpty(s.t, s.liveNodeID, "live version should contain node First")
+	require.NotEmpty(s.t, s.ghostNodeID, "live version should contain node Second")
+}
+
+func (s *ghostNodeConnectionSteps) givenACommittedChainWithAMiddleNode() {
+	s.canvas = shared.NewCanvasSteps("Ghost Node Output Handle", s.t, s.session)
+	s.canvas.Create()
+	s.canvas.EnterEditMode()
+
+	s.canvas.AddManualTrigger("First", models.Position{X: 500, Y: 200})
+	s.canvas.AddNoop("Second", models.Position{X: 1000, Y: 200})
+	s.canvas.AddNoop("Third", models.Position{X: 1500, Y: 200})
+	s.canvas.Connect("First", "Second")
+	s.canvas.Connect("Second", "Third")
+	s.canvas.Save()
+	s.canvas.CommitAndPublish()
+
+	// Resolve stable node ids from the committed live version.
+	live, err := models.FindLiveCanvasVersion(s.canvas.WorkflowID)
+	require.NoError(s.t, err)
+	for _, node := range live.Nodes {
+		switch node.Name {
+		case "First":
+			s.liveNodeID = node.ID
+		case "Second":
+			s.ghostNodeID = node.ID
+		}
+	}
+	require.NotEmpty(s.t, s.liveNodeID, "live version should contain node First")
+	require.NotEmpty(s.t, s.ghostNodeID, "live version should contain node Second")
+}
+
+func (s *ghostNodeConnectionSteps) whenIDeleteTheSecondNodeInTheDraft() {
+	s.canvas.EnterEditMode()
+
+	nodeHeader := q.TestID("node", "Second", "header")
+	deleteButton := q.Locator(`.react-flow__node:has([data-testid="node-second-header"]) [data-testid="node-action-delete"]`)
+	s.session.HoverOver(nodeHeader)
+	s.session.Sleep(100)
+	s.session.Click(deleteButton)
+
+	// Wait until the staged draft no longer contains the deleted node.
+	require.Eventually(s.t, func() bool {
+		nodes, _ := s.canvas.DraftEffectiveSpec()
+		for _, node := range nodes {
+			if node.ID == s.ghostNodeID {
+				return false
+			}
+		}
+		return len(nodes) > 0
+	}, 15*time.Second, 200*time.Millisecond, "deleted node should be removed from the staged draft spec")
+}
+
+func (s *ghostNodeConnectionSteps) thenTheDeletedNodeRendersAsAGhost(screenshotName string) {
+	// Draft visual diff renders the deleted node as a ghost ("REMOVED" badge).
+	// Diff X-Ray and "Show deleted nodes" both default to enabled.
+	ghostNode := q.Locator(`.react-flow__node[data-id="` + s.ghostNodeID + `"]`)
+	s.session.AssertVisible(ghostNode)
+	s.session.AssertText("REMOVED")
+	s.takeNamedScreenshot(screenshotName)
+}
+
+func (s *ghostNodeConnectionSteps) whenIDragAConnectionFromTheLiveNodeToTheGhostNode() {
+	// The ghost's own handles are pointer-events:none, so a connection cannot
+	// START on the ghost. But React Flow completes connections by handle
+	// proximity, so dragging from a live handle and releasing on the ghost's
+	// (visually rendered) target handle used to create the connection.
+	sourceHandle := q.Locator(`.react-flow__node[data-id="` + s.liveNodeID + `"] .react-flow__handle-right`)
+	targetHandle := q.Locator(`.react-flow__node[data-id="` + s.ghostNodeID + `"] .react-flow__handle-left`)
+
+	s.session.DragAndDrop(sourceHandle, targetHandle, 6, 6)
+	s.session.Sleep(500)
+	s.takeNamedScreenshot("ghost-node-fixed-2-after-drag")
+}
+
+func (s *ghostNodeConnectionSteps) thenNoEdgeToTheDeletedNodeIsStaged() {
+	require.Never(s.t, func() bool {
+		_, edges := s.canvas.DraftEffectiveSpec()
+		for _, edge := range edges {
+			if edge.SourceID == s.liveNodeID && edge.TargetID == s.ghostNodeID {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 200*time.Millisecond,
+		"the draft must not stage an edge pointing at the deleted (ghost) node")
+
+	s.takeNamedScreenshot("ghost-node-fixed-3-no-ghost-edge")
+}
+
+func (s *ghostNodeConnectionSteps) whenIDragFromTheGhostOutputHandleIntoEmptySpaceAndPickAComponent() {
+	// The ghost still renders its output handle (it anchors the removed
+	// edges), and every handle carries an enlarged ::before hit area. Dragging
+	// out of that hit area and dropping in empty space used to open the
+	// building-block picker and stage a placeholder edge whose source is the
+	// deleted node.
+	sourceHandle := q.Locator(`.react-flow__node[data-id="` + s.ghostNodeID + `"] .react-flow__handle-right`)
+	emptySpace := q.TestID("rf__wrapper")
+
+	s.session.DragAndDrop(sourceHandle, emptySpace, 500, 550)
+	s.session.Sleep(500)
+	s.takeNamedScreenshot("ghost-node-fixed-5-after-empty-space-drop")
+
+	// Mirror the user's full path whenever the picker opens (the broken
+	// behavior); with the fix the drag never starts, so it never appears.
+	sidebar := q.TestID("building-blocks-sidebar").Run(s.session)
+	pickerOpened := false
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if visible, _ := sidebar.IsVisible(); visible {
+			pickerOpened = true
+			break
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	s.t.Logf("building-block picker opened after ghost drag: %v", pickerOpened)
+
+	if pickerOpened {
+		s.canvas.OpenBuildingBlockCategory("Debugging")
+		s.session.Click(q.TestID("building-block-noop"))
+		s.session.Sleep(500)
+	}
+}
+
+func (s *ghostNodeConnectionSteps) thenNoEdgeTouchingTheDeletedNodeIsStaged() {
+	require.Never(s.t, func() bool {
+		_, edges := s.canvas.DraftEffectiveSpec()
+		for _, edge := range edges {
+			if edge.SourceID == s.ghostNodeID || edge.TargetID == s.ghostNodeID {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 200*time.Millisecond,
+		"the draft must not stage an edge referencing the deleted (ghost) node")
+
+	s.takeNamedScreenshot("ghost-node-fixed-5-no-ghost-edge")
+}
+
+func (s *ghostNodeConnectionSteps) thenTheDraftCommitsSuccessfully(screenshotName string) {
+	// CommitStaging waits for the staged files to clear, which only happens
+	// when the API accepts the commit.
+	s.canvas.CommitAndPublish()
+
+	content, err := s.session.Page().Content()
+	require.NoError(s.t, err)
+	require.NotContains(s.t, content, "invalid canvas yaml",
+		"committing the draft must not fail with the generic invalid canvas yaml error")
+
+	s.canvas.AssertLiveVersionLacksNode("Second")
+	s.takeNamedScreenshot(screenshotName)
+}
+
+func (s *ghostNodeConnectionSteps) takeNamedScreenshot(name string) {
+	path := fmt.Sprintf("/app/tmp/screenshots/%s.png", name)
+	s.t.Logf("Taking screenshot: %s", path)
+	if _, err := s.session.Page().Screenshot(pw.PageScreenshotOptions{
+		Path:     pw.String(path),
+		FullPage: pw.Bool(true),
+		Type:     pw.ScreenshotTypePng,
+	}); err != nil {
+		s.t.Logf("screenshot error: %v", err)
+	}
+}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -2566,8 +2566,11 @@ export function AppPage() {
         },
       };
 
+      // Never stage an edge from a node that is not part of the draft (e.g. a
+      // removed ghost node) — mirrors the handleEdgeCreate guard.
+      const draftNodeIds = new Set((latestWorkflow.spec?.nodes || []).map((node) => node.id));
       const newEdge =
-        data.sourceNodeId && data.sourceHandleId !== undefined
+        data.sourceNodeId && data.sourceHandleId !== undefined && draftNodeIds.has(data.sourceNodeId)
           ? ({
               sourceId: data.sourceNodeId,
               targetId: newNodeId,
@@ -2702,6 +2705,12 @@ export function AppPage() {
   const handleEdgeCreate = useCallback(
     async (sourceId: string, targetId: string, sourceHandle?: string | null) => {
       if (!canvas || !organizationId || !canvasId) return;
+
+      // React Flow completes connections by handle proximity, so a drop can
+      // still reference a node that is not part of the draft (e.g. a removed
+      // ghost node). Never stage an edge with a missing endpoint.
+      const nodeIds = new Set((canvas.spec?.nodes || []).map((node) => node.id));
+      if (!nodeIds.has(sourceId) || !nodeIds.has(targetId)) return;
 
       // Save snapshot before making changes
 

--- a/web_src/src/pages/app/useDraftVisualDiff.spec.ts
+++ b/web_src/src/pages/app/useDraftVisualDiff.spec.ts
@@ -1,0 +1,48 @@
+import { QueryClient } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ActionsAction, CanvasesCanvasVersion } from "@/api-client";
+import { makeCanvas, makeComponentsNode, makeEdge } from "@/test/factories";
+import { useDraftVisualDiff } from "./useDraftVisualDiff";
+
+const noopComponent = {
+  name: "noop",
+  label: "Noop",
+  icon: "circle",
+  outputChannels: [{ name: "default" }],
+} as ActionsAction;
+
+function renderDraftVisualDiffWithRemovedNode() {
+  const keptNode = makeComponentsNode({ id: "node-1", name: "First" });
+  const removedNode = makeComponentsNode({ id: "node-2", name: "Second" });
+  const liveCanvasVersion = {
+    spec: {
+      nodes: [keptNode, removedNode],
+      edges: [makeEdge({ sourceId: "node-1", targetId: "node-2" })],
+    },
+  } as CanvasesCanvasVersion;
+
+  return renderHook(() =>
+    useDraftVisualDiff({
+      isViewingDraftVersion: true,
+      canvas: makeCanvas({ spec: { nodes: [keptNode], edges: [] } }),
+      liveCanvasVersion,
+      preparedNodes: [{ id: "node-1", position: { x: 0, y: 0 }, data: {} }],
+      preparedEdges: [],
+      allTriggers: [],
+      allComponents: [noopComponent],
+      canvasId: "canvas-1",
+      queryClient: new QueryClient(),
+    }),
+  );
+}
+
+describe("useDraftVisualDiff", () => {
+  it("renders removed nodes as ghosts that cannot be connected", () => {
+    const { result } = renderDraftVisualDiffWithRemovedNode();
+
+    const ghost = result.current.nodes.find((node) => node.id === "node-2");
+    expect(ghost?.data._draftDiffStatus).toBe("removed");
+    expect(ghost?.connectable).toBe(false);
+  });
+});

--- a/web_src/src/pages/app/useDraftVisualDiff.ts
+++ b/web_src/src/pages/app/useDraftVisualDiff.ts
@@ -175,6 +175,7 @@ export function useDraftVisualDiff({
         ...prepared,
         draggable: false,
         selectable: false,
+        connectable: false,
         data: {
           ...prepared.data,
           _draftDiffStatus: "removed",

--- a/web_src/src/ui/CanvasPage/Block.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block.spec.tsx
@@ -192,6 +192,37 @@ describe("Block fallback rendering", () => {
     expect(screen.getByTestId("handle-source-default")).toHaveAttribute("data-pointer-events", "none");
   });
 
+  it("marks removed ghost nodes so their handles lose the enlarged hit area", () => {
+    const { container } = render(
+      <Block
+        canvasMode="edit"
+        nodeId="ghost-node"
+        data={{
+          label: "Removed Component",
+          state: "pending",
+          type: "component",
+          outputChannels: ["default"],
+          component: {
+            title: "Removed Component",
+            iconSlug: "box",
+            collapsed: false,
+          },
+          _draftDiffStatus: "removed",
+          _allEdges: [
+            {
+              source: "ghost-node",
+              sourceHandle: "default",
+              target: "next-node",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(container.firstChild).toHaveClass("sp-block-removed");
+    expect(screen.getByTestId("handle-source-default")).toHaveAttribute("data-pointer-events", "none");
+  });
+
   it("shows an append connector button for end nodes in edit mode", () => {
     const onAppendFromNode = vi.fn();
 

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -80,7 +80,7 @@ export const Block = React.memo(function Block(props: BlockProps) {
       className={cn(
         "group/block relative w-fit",
         shouldFade && !shouldBlankBody && "opacity-30",
-        isRemoved && "pointer-events-none opacity-50",
+        isRemoved && "sp-block-removed pointer-events-none opacity-50",
       )}
       onClick={(e) => props.onClick?.(e)}
     >

--- a/web_src/src/ui/CanvasPage/canvas-reset.css
+++ b/web_src/src/ui/CanvasPage/canvas-reset.css
@@ -135,6 +135,13 @@
   pointer-events: none;
 }
 
+/* Removed ghost nodes are tombstones: without this, the enlarged hit area
+   above re-enables pointer events on handles whose own pointer-events are
+   disabled, letting connection drags start from a deleted node. */
+.sp-canvas .sp-block-removed .react-flow__handle::before {
+  pointer-events: none;
+}
+
 .sp-canvas .react-flow__handle:not(.sp-append-source-hitbox):hover,
 .sp-canvas .react-flow__handle.sp-append-source-hitbox:hover {
   border-color: var(--sp-handle-border-hover) !important;

--- a/web_src/src/ui/CanvasPage/connectionValidity.spec.ts
+++ b/web_src/src/ui/CanvasPage/connectionValidity.spec.ts
@@ -1,0 +1,64 @@
+import type { Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+import { isConnectableCanvasNode, isValidCanvasConnection } from "./connectionValidity";
+
+function makeNode(overrides: Partial<Node> = {}): Node {
+  return {
+    id: "node-1",
+    position: { x: 0, y: 0 },
+    data: {},
+    ...overrides,
+  };
+}
+
+const connection = { source: "node-1", target: "node-2", sourceHandle: "default", targetHandle: null };
+
+describe("isValidCanvasConnection", () => {
+  it("allows a connection between two regular nodes", () => {
+    const nodes = [makeNode({ id: "node-1" }), makeNode({ id: "node-2" })];
+
+    expect(isValidCanvasConnection(nodes, connection)).toBe(true);
+  });
+
+  it("rejects a connection targeting a non-connectable node", () => {
+    const nodes = [makeNode({ id: "node-1" }), makeNode({ id: "node-2", connectable: false })];
+
+    expect(isValidCanvasConnection(nodes, connection)).toBe(false);
+  });
+
+  it("rejects a connection targeting a removed ghost node", () => {
+    const nodes = [makeNode({ id: "node-1" }), makeNode({ id: "node-2", data: { _draftDiffStatus: "removed" } })];
+
+    expect(isValidCanvasConnection(nodes, connection)).toBe(false);
+  });
+
+  it("rejects a connection starting from a removed ghost node", () => {
+    const nodes = [makeNode({ id: "node-1", data: { _draftDiffStatus: "removed" } }), makeNode({ id: "node-2" })];
+
+    expect(isValidCanvasConnection(nodes, connection)).toBe(false);
+  });
+
+  it("rejects a connection whose endpoint is not on the canvas", () => {
+    const nodes = [makeNode({ id: "node-1" })];
+
+    expect(isValidCanvasConnection(nodes, connection)).toBe(false);
+  });
+});
+
+describe("isConnectableCanvasNode", () => {
+  it("allows a regular node", () => {
+    expect(isConnectableCanvasNode([makeNode()], "node-1")).toBe(true);
+  });
+
+  it("rejects a node marked not connectable", () => {
+    expect(isConnectableCanvasNode([makeNode({ connectable: false })], "node-1")).toBe(false);
+  });
+
+  it("rejects a removed ghost node", () => {
+    expect(isConnectableCanvasNode([makeNode({ data: { _draftDiffStatus: "removed" } })], "node-1")).toBe(false);
+  });
+
+  it("rejects a node that is not on the canvas", () => {
+    expect(isConnectableCanvasNode([], "node-1")).toBe(false);
+  });
+});

--- a/web_src/src/ui/CanvasPage/connectionValidity.ts
+++ b/web_src/src/ui/CanvasPage/connectionValidity.ts
@@ -1,0 +1,21 @@
+import type { Connection, Edge, Node } from "@xyflow/react";
+
+/**
+ * React Flow completes connections by handle proximity, so a drag can be
+ * dropped onto a handle of a node that must not accept connections — e.g. a
+ * "removed" ghost node rendered by the draft visual diff for a node deleted
+ * from the draft. Only allow connections whose endpoints are both connectable
+ * nodes currently on the canvas.
+ */
+export function isValidCanvasConnection(nodes: Node[], connection: Connection | Edge): boolean {
+  return isConnectableCanvasNode(nodes, connection.source) && isConnectableCanvasNode(nodes, connection.target);
+}
+
+export function isConnectableCanvasNode(nodes: Node[], nodeId: string): boolean {
+  const node = nodes.find((candidate) => candidate.id === nodeId);
+  if (!node || node.connectable === false) {
+    return false;
+  }
+
+  return node.data._draftDiffStatus !== "removed";
+}

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -238,7 +238,7 @@ describe("CanvasPage connection drop", () => {
     expect(screen.queryByText("Version history")).not.toBeInTheDocument();
   });
 
-  it("does not close the building blocks sidebar from the pane click that follows a connection drop", () => {
+  it("does not close the building blocks sidebar from the pane click that follows a connection drop", async () => {
     const onPlaceholderAdd = vi.fn(() => new Promise<string>(() => {}));
 
     render(
@@ -246,7 +246,24 @@ describe("CanvasPage connection drop", () => {
         <CanvasPage
           title="Canvas"
           headerMode="version-live"
-          nodes={[]}
+          nodes={[
+            {
+              id: "source",
+              position: { x: 100, y: 200 },
+              width: 240,
+              data: {
+                label: "Source",
+                state: "pending",
+                type: "component",
+                outputChannels: ["default"],
+                component: {
+                  title: "Source",
+                  iconSlug: "box",
+                  collapsed: false,
+                },
+              },
+            },
+          ]}
           edges={[]}
           buildingBlocks={[]}
           isEditing={true}
@@ -257,6 +274,9 @@ describe("CanvasPage connection drop", () => {
       </MemoryRouter>,
     );
 
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("canvas-add-component-button"));
+    });
     expect(screen.getByTestId("building-blocks-sidebar")).toBeInTheDocument();
 
     act(() => {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -97,6 +97,7 @@ import { CustomEdge } from "./CustomEdge";
 import { Header } from "./Header";
 import type { AgentSuggestion } from "./components/AgentSuggestionsHoverCard";
 import { isComponentSidebarVisibleMode } from "./canvasTabHeaderMode";
+import { isConnectableCanvasNode, isValidCanvasConnection } from "./connectionValidity";
 import { isCanvasNodeHighlighted, shouldBlankCanvasNodeBody } from "./nodeDimming";
 import { shouldRefitOnInit, stampFittedContentKey } from "./fitView";
 import { RightSideControls } from "./RightSideControls";
@@ -962,6 +963,9 @@ function CanvasPage(props: CanvasPageProps) {
     async (position: { x: number; y: number }, sourceConnection: { nodeId: string; handleId: string | null }) => {
       if (readOnly) return;
       if (!sourceConnection || !props.onPlaceholderAdd) return;
+      // Never grow the canvas out of a node that cannot accept connections,
+      // e.g. a removed ghost node rendered by the draft visual diff.
+      if (!isConnectableCanvasNode(state.nodes || [], sourceConnection.nodeId)) return;
 
       // Save placeholder immediately to backend
       const placeholderId = await props.onPlaceholderAdd({
@@ -2482,6 +2486,11 @@ function CanvasContent({
     [onEdgeCreate, isReadOnly],
   );
 
+  const isValidConnection = useCallback(
+    (connection: Connection | CanvasEdge) => isValidCanvasConnection(stateRef.current.nodes || [], connection),
+    [],
+  );
+
   const handleDragOver = useCallback(
     (event: React.DragEvent) => {
       if (isReadOnly) return;
@@ -3284,6 +3293,7 @@ function CanvasContent({
             onNodesChange={handleNodesChange}
             onEdgesChange={handleEdgesChange}
             onConnect={isConnectionEditingEnabled ? handleConnect : undefined}
+            isValidConnection={isValidConnection}
             onConnectStart={isConnectionEditingEnabled ? handleConnectStart : undefined}
             onConnectEnd={isConnectionEditingEnabled ? handleConnectEnd : undefined}
             onDragOver={isReadOnly ? undefined : handleDragOver}


### PR DESCRIPTION
Fixes #6417

**What:** Nodes deleted from a draft canvas render as "removed" ghosts via the draft visual diff, but could still participate in new connections. Dragging a connection out of a ghost's output handle (or dropping one onto a ghost) staged an edge referencing a node absent from the draft; **Commit** then failed with a generic `invalid canvas yaml` toast and no pointer to the offending edge. This PR makes ghost nodes true tombstones: connections can neither start from nor land on them, through any path.

**Why:** The failure is silent state corruption from the user's point of view — the canvas accepts the edge, autosaves it into staging, and only the commit fails, with a message that doesn't identify the cause.

**How — three findings, four defensive layers:**
1. Ghost nodes now carry `connectable: false` (`useDraftVisualDiff`).
2. A new `isValidCanvasConnection` predicate is wired as React Flow's `isValidConnection`. This is the key enforcement: React Flow v12 completes connections by **handle proximity** (`connectionRadius`), not DOM hit-testing, so `pointer-events: none` on ghost handles never prevented drops landing on them.
3. The enlarged 30×30 handle hit-area (`.react-flow__handle::before`, which sets `pointer-events: auto` and therefore escapes both existing `pointer-events: none` layers on ghosts) is disabled for removed nodes — this is what allowed drags to *start* on a ghost.
4. The two programmatic edge-creation paths — `handleEdgeCreate` and the drag-to-empty-space → placeholder flow (`handlePlaceholderAdd`), which builds its edge inline and consults neither `onConnect` nor `isValidConnection` — both refuse endpoints that are not connectable draft nodes.

Rejection is silent (the drag line snaps back), matching standard React Flow behavior.

**Tests:** unit specs for the ghost flags and the connection predicate; a new E2E spec covering both user paths (drop-onto-ghost, and drag-out-of-ghost → empty-space → building-block picker), each verified failing before the fix. Existing connection E2E specs unchanged and green.

**Out of scope, noted:** the backend produces a precise error (`edge N: target node X not found`, `pkg/yaml/canvas.go`) that `commit_canvas_staging.go` masks into the generic `invalid canvas yaml`; surfacing it would improve debuggability for other invalid-yaml cases but touches sanitized error paths, so it's left as a possible follow-up.
