### PR TITLE
fix: add empty states and create CTAs to integration and secret pickers

### DIFF
--- a/test/e2e/integration_dropdown_empty_state_test.go
+++ b/test/e2e/integration_dropdown_empty_state_test.go
@@ -1,0 +1,366 @@
+package e2e
+
+// -----------------------------------------------------------------------------
+// Empty integration dropdown — desired behavior.
+//
+// Components with a FieldTypeIntegration configuration field (e.g. the
+// "Run Claude Code" runner) render the Integration picker from the org's
+// connected integrations (IntegrationFieldRenderer.tsx). Before the fix, zero
+// matching integrations produced a popover with zero items: an empty ~128x10px
+// sliver positioned below the viewport (at y=1440 on the 1440px-high test
+// viewport), so the dropdown looked completely dead.
+//
+// With the fix (mirroring SecretPickerFieldRenderer):
+//  1. a user who can create integrations sees a "Connect an integration" CTA
+//     item, so the popover has content and opens on screen. On type-filtered
+//     fields (claude credentials) the CTA opens IntegrationCreateDialog in
+//     place — the canvas stays put and creation auto-selects the integration;
+//  2. on unfiltered fields ("Environment from" -> Integration) there is no
+//     single provider to create, so the CTA opens integration settings in a
+//     NEW tab and the canvas URL does not change;
+//  3. with a ready github integration connected, the unfiltered dropdown lists
+//     it alongside the CTA.
+// -----------------------------------------------------------------------------
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pw "github.com/mxschmitt/playwright-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+)
+
+const integrationConnectOptionSelector = `[role="listbox"] [data-testid="integration-picker-connect-option"]`
+const secretAddNewOptionSelector = `[role="listbox"] [data-testid="secret-field-add-new-option"]`
+
+func TestIntegrationDropdownEmptyState(t *testing.T) {
+	t.Run("the empty claude-filtered credentials dropdown opens on screen with a connect CTA that opens the create dialog in place", func(t *testing.T) {
+		steps := &integrationDropdownEmptyStateSteps{t: t}
+		steps.start()
+		steps.givenACanvasExists()
+		steps.whenIAddAClaudeCodeRunnerBlock()
+		steps.whenISetCredentialsSourceToIntegration()
+		steps.whenIOpenTheCredentialsIntegrationDropdown()
+		steps.thenTheDropdownPopoverIsOnScreenWithTheConnectCTA("integration-dropdown-fixed-1-cta-visible")
+		steps.whenIClickTheConnectCTA()
+		steps.thenTheCreateIntegrationDialogOpensInPlace("integration-dropdown-fixed-4-dialog-open")
+		steps.whenISubmitTheClaudeDialogWithADummyAPIKey()
+		steps.thenTheDialogClosesAndTheCreatedIntegrationIsSelected()
+		steps.thenTheIntegrationExistsInErrorState("claude")
+	})
+
+	t.Run("the empty environment-from secret dropdown offers an add-new CTA", func(t *testing.T) {
+		steps := &integrationDropdownEmptyStateSteps{t: t}
+		steps.start()
+		steps.givenACanvasExists()
+		steps.whenIAddAClaudeCodeRunnerBlock()
+		steps.whenIAddAnEnvironmentFromSource()
+		steps.whenISwitchTheEnvironmentFromSourceToSecret()
+		steps.whenIOpenTheEnvironmentFromSecretDropdown()
+		steps.thenTheSecretDropdownPopoverIsOnScreenWithTheAddNewCTA("secret-dropdown-fixed-1-add-new-visible")
+	})
+
+	t.Run("the empty environment-from integration dropdown opens on screen with a connect CTA that opens settings in a new tab", func(t *testing.T) {
+		steps := &integrationDropdownEmptyStateSteps{t: t}
+		steps.start()
+		steps.givenACanvasExists()
+		steps.whenIAddAClaudeCodeRunnerBlock()
+		steps.whenIAddAnEnvironmentFromSource()
+		steps.whenIOpenTheEnvironmentFromIntegrationDropdown()
+		steps.thenTheDropdownPopoverIsOnScreenWithTheConnectCTA("env-from-fixed-2-cta-visible")
+		steps.thenClickingTheConnectCTAOpensIntegrationSettingsInANewTab()
+	})
+
+	t.Run("with a ready github integration the unfiltered dropdown lists it alongside the connect CTA", func(t *testing.T) {
+		steps := &integrationDropdownEmptyStateSteps{t: t}
+		steps.start()
+		steps.givenAReadyGithubIntegrationExists("gh-e2e-integration")
+		steps.givenACanvasExists()
+		steps.whenIAddAClaudeCodeRunnerBlock()
+		steps.whenIAddAnEnvironmentFromSource()
+		steps.whenIOpenTheEnvironmentFromIntegrationDropdown()
+		steps.thenTheDropdownListsTheIntegrationAndTheConnectCTA("gh-e2e-integration", "integration-dropdown-fixed-3-populated-lists-github")
+	})
+}
+
+type integrationDropdownEmptyStateSteps struct {
+	t         *testing.T
+	session   *session.TestSession
+	canvas    *shared.CanvasSteps
+	canvasURL string
+}
+
+func (s *integrationDropdownEmptyStateSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+// givenAReadyGithubIntegrationExists reuses the established pattern from
+// settings_permission_guards_test.go: create the installation row directly
+// and mark it ready.
+func (s *integrationDropdownEmptyStateSteps) givenAReadyGithubIntegrationExists(name string) {
+	integration, err := models.CreateIntegration(uuid.New(), s.session.OrgID, "github", name, nil)
+	require.NoError(s.t, err)
+	require.NoError(s.t, database.Conn().Model(integration).Update("state", models.IntegrationStateReady).Error)
+}
+
+func (s *integrationDropdownEmptyStateSteps) givenACanvasExists() {
+	s.canvas = shared.NewCanvasSteps("Integration Dropdown Empty State", s.t, s.session)
+	s.canvas.Create()
+	s.canvas.EnterEditMode()
+}
+
+func (s *integrationDropdownEmptyStateSteps) whenIAddAClaudeCodeRunnerBlock() {
+	s.canvas.OpenBuildingBlockCategory("Runners")
+	s.canvas.AddBuildingBlockByTestID("building-block-runnerclaudecode", models.Position{X: 700, Y: 250})
+
+	// The component sidebar for the dropped block should now be open.
+	s.session.AssertVisible(q.TestID("node-name-input"))
+}
+
+func (s *integrationDropdownEmptyStateSteps) whenISetCredentialsSourceToIntegration() {
+	// credentials.source select (object sub-fields keep their bare names).
+	sourceSelect := q.TestID("field-source-select")
+	s.session.AssertVisible(sourceSelect)
+	s.session.Click(sourceSelect)
+	s.session.Click(q.Locator(`div[role="option"]:has-text("Integration")`))
+	s.session.Sleep(300)
+}
+
+func (s *integrationDropdownEmptyStateSteps) whenIOpenTheCredentialsIntegrationDropdown() {
+	s.openIntegrationDropdown(`[data-testid="integration-field-integration"] button`)
+}
+
+// whenIAddAnEnvironmentFromSource clicks "Add Source" under "Environment from",
+// which adds a list item whose Source sub-select defaults to "Integration",
+// making the item's Integration select visible immediately.
+func (s *integrationDropdownEmptyStateSteps) whenIAddAnEnvironmentFromSource() {
+	s.session.Click(q.Locator(`button:has-text("Add Source")`))
+	s.session.AssertVisible(q.TestID("list-item-row"))
+	s.session.Sleep(300)
+}
+
+func (s *integrationDropdownEmptyStateSteps) whenIOpenTheEnvironmentFromIntegrationDropdown() {
+	s.openIntegrationDropdown(`[data-testid="list-item-row"] [data-testid="integration-field-integration"] button`)
+}
+
+func (s *integrationDropdownEmptyStateSteps) whenISwitchTheEnvironmentFromSourceToSecret() {
+	itemSourceSelect := q.Locator(`[data-testid="list-item-row"] [data-testid="field-source-select"]`)
+	s.session.AssertVisible(itemSourceSelect)
+	s.session.Click(itemSourceSelect)
+	s.session.Click(q.Locator(`div[role="option"]:has-text("Secret")`))
+	s.session.Sleep(300)
+}
+
+func (s *integrationDropdownEmptyStateSteps) whenIOpenTheEnvironmentFromSecretDropdown() {
+	field := q.Locator(`[data-testid="list-item-row"] [data-testid="secret-field-secret"] button`)
+	s.session.AssertVisible(field)
+
+	// Wait for the secrets query to finish loading (the trigger shows
+	// "Loading secrets..." while pending).
+	trigger := field.Run(s.session)
+	require.Eventually(s.t, func() bool {
+		text, err := trigger.InnerText()
+		return err == nil && !strings.Contains(text, "Loading secrets")
+	}, 15*time.Second, 200*time.Millisecond, "secret select should finish loading")
+
+	require.NoError(s.t, trigger.Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
+	s.session.Sleep(300)
+}
+
+// whenISubmitTheClaudeDialogWithADummyAPIKey fills the (sensitive, hence
+// password-typed) API Key field with a bogus key and submits the dialog.
+func (s *integrationDropdownEmptyStateSteps) whenISubmitTheClaudeDialogWithADummyAPIKey() {
+	apiKeyInput := s.session.Page().Locator(`[role="dialog"] input[type="password"]`).First()
+	require.NoError(s.t, apiKeyInput.Fill("sk-ant-dummy-e2e-key"))
+	s.takeNamedScreenshot("claude-dialog-submit-1-filled")
+	s.session.Click(q.Locator(`[role="dialog"] button:has-text("Connect")`))
+}
+
+// thenTheDialogClosesAndTheCreatedIntegrationIsSelected documents the server
+// behavior with a bogus key: CreateIntegration runs the claude Sync (key
+// verification) synchronously, stores the integration in state "error", but
+// still returns success — so the dialog closes and the created installation is
+// auto-selected in the field.
+func (s *integrationDropdownEmptyStateSteps) thenTheDialogClosesAndTheCreatedIntegrationIsSelected() {
+	dialog := s.session.Page().Locator(`[role="dialog"]`)
+	require.Eventually(s.t, func() bool {
+		count, err := dialog.Count()
+		return err == nil && count == 0
+	}, 45*time.Second, 500*time.Millisecond, "the create dialog should close after submit")
+
+	trigger := s.session.Page().Locator(`[data-testid="integration-field-integration"] button`)
+	require.Eventually(s.t, func() bool {
+		text, err := trigger.InnerText()
+		return err == nil && strings.Contains(text, "claude")
+	}, 10*time.Second, 200*time.Millisecond, "the created integration should be auto-selected in the field")
+
+	s.takeNamedScreenshot("claude-dialog-submit-2-auto-selected")
+}
+
+func (s *integrationDropdownEmptyStateSteps) thenTheIntegrationExistsInErrorState(name string) {
+	require.Eventually(s.t, func() bool {
+		integration, err := models.FindIntegrationByName(database.Conn(), s.session.OrgID, name)
+		return err == nil && integration.State == models.IntegrationStateError && integration.StateDescription != ""
+	}, 30*time.Second, 500*time.Millisecond,
+		"the claude integration should exist in error state after the bogus-key sync")
+}
+
+func (s *integrationDropdownEmptyStateSteps) openIntegrationDropdown(triggerSelector string) {
+	field := q.Locator(triggerSelector)
+	s.session.AssertVisible(field)
+
+	// Wait for the integrations query to finish loading (the trigger shows
+	// "Loading integrations..." while pending).
+	trigger := field.Run(s.session)
+	require.Eventually(s.t, func() bool {
+		text, err := trigger.InnerText()
+		return err == nil && !strings.Contains(text, "Loading integrations")
+	}, 15*time.Second, 200*time.Millisecond, "integration select should finish loading")
+
+	require.NoError(s.t, trigger.Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
+	s.session.Sleep(300)
+}
+
+// thenTheDropdownPopoverIsOnScreenWithTheConnectCTA asserts the fix: the open
+// popover contains the connect CTA and sits fully inside the viewport. Before
+// the fix the empty popover was a 128x10px sliver at (0, 1440) — below the
+// 2560x1440 test viewport — so the dropdown appeared dead.
+func (s *integrationDropdownEmptyStateSteps) thenTheDropdownPopoverIsOnScreenWithTheConnectCTA(screenshotName string) {
+	s.assertPopoverOnScreenWithCTA(integrationConnectOptionSelector,
+		"connect CTA should be visible in the open integration dropdown", screenshotName)
+}
+
+// thenTheSecretDropdownPopoverIsOnScreenWithTheAddNewCTA is the secret-field
+// variant of the same assertion (SecretFieldRenderer had the identical bug).
+func (s *integrationDropdownEmptyStateSteps) thenTheSecretDropdownPopoverIsOnScreenWithTheAddNewCTA(screenshotName string) {
+	s.assertPopoverOnScreenWithCTA(secretAddNewOptionSelector,
+		"add-new CTA should be visible in the open secret dropdown", screenshotName)
+}
+
+func (s *integrationDropdownEmptyStateSteps) assertPopoverOnScreenWithCTA(
+	ctaSelector string,
+	ctaDescription string,
+	screenshotName string,
+) {
+	listbox := q.Locator(`[role="listbox"]`).Run(s.session)
+	require.NoError(s.t, listbox.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(10000),
+	}), "dropdown popover should open")
+
+	cta := s.session.Page().Locator(ctaSelector)
+	require.NoError(s.t, cta.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(10000),
+	}), ctaDescription)
+
+	s.takeNamedScreenshot(screenshotName)
+
+	box, err := listbox.BoundingBox()
+	require.NoError(s.t, err)
+	require.NotNil(s.t, box)
+	viewport := s.session.Page().ViewportSize()
+	require.NotNil(s.t, viewport)
+	s.t.Logf("INTEGRATION DROPDOWN POPOVER: %.0fx%.0f at (%.0f, %.0f), viewport %dx%d",
+		box.Width, box.Height, box.X, box.Y, viewport.Width, viewport.Height)
+
+	require.GreaterOrEqual(s.t, box.X, 0.0, "popover should not overflow the left viewport edge")
+	require.GreaterOrEqual(s.t, box.Y, 0.0, "popover should not overflow the top viewport edge")
+	require.LessOrEqual(s.t, box.X+box.Width, float64(viewport.Width), "popover should not overflow the right viewport edge")
+	require.LessOrEqual(s.t, box.Y+box.Height, float64(viewport.Height), "popover should not overflow the bottom viewport edge")
+	require.GreaterOrEqual(s.t, box.Height, 30.0, "popover should have real content, not a collapsed sliver")
+}
+
+func (s *integrationDropdownEmptyStateSteps) whenIClickTheConnectCTA() {
+	s.canvasURL = s.session.Page().URL()
+	s.session.Click(q.Locator(integrationConnectOptionSelector))
+}
+
+// thenTheCreateIntegrationDialogOpensInPlace asserts the type-filtered CTA
+// opens IntegrationCreateDialog inside the canvas page: no navigation, and the
+// component sidebar stays mounted behind the dialog.
+func (s *integrationDropdownEmptyStateSteps) thenTheCreateIntegrationDialogOpensInPlace(screenshotName string) {
+	dialog := s.session.Page().Locator(`[role="dialog"]:has-text("Configure Claude")`)
+	require.NoError(s.t, dialog.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(10000),
+	}), "the Configure Claude dialog should open in place")
+
+	require.Equal(s.t, s.canvasURL, s.session.Page().URL(),
+		"opening the create dialog should not navigate away from the canvas")
+	s.session.AssertVisible(q.TestID("node-name-input"))
+
+	s.takeNamedScreenshot(screenshotName)
+}
+
+// thenClickingTheConnectCTAOpensIntegrationSettingsInANewTab asserts the
+// unfiltered CTA opens /:orgId/settings/integrations in a new tab while the
+// canvas page stays put.
+func (s *integrationDropdownEmptyStateSteps) thenClickingTheConnectCTAOpensIntegrationSettingsInANewTab() {
+	canvasURL := s.session.Page().URL()
+
+	popup, err := s.session.Page().ExpectPopup(func() error {
+		return s.session.Page().Locator(integrationConnectOptionSelector).Click()
+	})
+	require.NoError(s.t, err, "clicking the connect CTA should open a new tab")
+	require.NoError(s.t, popup.WaitForLoadState())
+	require.True(s.t, strings.HasSuffix(popup.URL(), "/settings/integrations"),
+		"new tab should open integration settings, got %s", popup.URL())
+	s.takeNamedScreenshotOfPage(popup, "env-from-fixed-3-settings-new-tab")
+	require.NoError(s.t, popup.Close())
+
+	require.Equal(s.t, canvasURL, s.session.Page().URL(), "the canvas page should stay put")
+}
+
+func (s *integrationDropdownEmptyStateSteps) thenTheDropdownListsTheIntegrationAndTheConnectCTA(name string, screenshotName string) {
+	listbox := q.Locator(`[role="listbox"]`).Run(s.session)
+	require.NoError(s.t, listbox.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(10000),
+	}), "integration dropdown popover should open")
+
+	// Exactly two options: the ready github integration and the connect CTA.
+	options := s.session.Page().Locator(`[role="listbox"] [role="option"]`)
+	require.Eventually(s.t, func() bool {
+		count, err := options.Count()
+		return err == nil && count == 2
+	}, 10*time.Second, 200*time.Millisecond, "dropdown should list the ready github integration and the connect CTA")
+
+	text, err := listbox.InnerText()
+	require.NoError(s.t, err)
+	require.Contains(s.t, text, name)
+
+	cta := s.session.Page().Locator(integrationConnectOptionSelector)
+	visible, err := cta.IsVisible()
+	require.NoError(s.t, err)
+	require.True(s.t, visible, "connect CTA should be listed after the existing integrations")
+
+	s.takeNamedScreenshot(screenshotName)
+}
+
+func (s *integrationDropdownEmptyStateSteps) takeNamedScreenshot(name string) {
+	s.takeNamedScreenshotOfPage(s.session.Page(), name)
+}
+
+func (s *integrationDropdownEmptyStateSteps) takeNamedScreenshotOfPage(page pw.Page, name string) {
+	path := fmt.Sprintf("/app/tmp/screenshots/%s.png", name)
+	s.t.Logf("Taking screenshot: %s", path)
+	if _, err := page.Screenshot(pw.PageScreenshotOptions{
+		Path:     pw.String(path),
+		FullPage: pw.Bool(true),
+		Type:     pw.ScreenshotTypePng,
+	}); err != nil {
+		s.t.Logf("screenshot error: %v", err)
+	}
+}

--- a/web_src/src/ui/configurationFieldRenderer/IntegrationFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/IntegrationFieldRenderer.spec.tsx
@@ -3,11 +3,44 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigurationField, OrganizationsIntegration } from "@/api-client";
-import { useConnectedIntegrations } from "@/hooks/useIntegrations";
+import { useAvailableIntegrations, useConnectedIntegrations, useCreateIntegration } from "@/hooks/useIntegrations";
+import { usePermissions } from "@/contexts/usePermissions";
 import { IntegrationFieldRenderer, type IntegrationRefValue } from "./IntegrationFieldRenderer";
+
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
 
 vi.mock("@/hooks/useIntegrations", () => ({
   useConnectedIntegrations: vi.fn(),
+  useAvailableIntegrations: vi.fn(),
+  useCreateIntegration: vi.fn(),
+}));
+
+vi.mock("@/contexts/usePermissions", () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock("@/ui/IntegrationCreateDialog", () => ({
+  IntegrationCreateDialog: ({
+    open,
+    integrationDefinition,
+    onCreated,
+  }: {
+    open: boolean;
+    integrationDefinition?: { name?: string } | null;
+    onCreated?: (integrationId: string, instanceName: string) => void;
+  }) =>
+    open ? (
+      <div data-testid="integration-create-dialog">
+        <span>{integrationDefinition?.name}</span>
+        <button type="button" onClick={() => onCreated?.("int_claude_new", "my-new-claude")}>
+          finish-connect
+        </button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/ui/componentSidebar/integrationIcons", () => ({
@@ -45,6 +78,30 @@ function createIntegrations(): OrganizationsIntegration[] {
   ];
 }
 
+function mockIntegrationsHook(integrations: OrganizationsIntegration[] = createIntegrations()) {
+  vi.mocked(useConnectedIntegrations).mockReturnValue({
+    data: integrations,
+    isLoading: false,
+    error: null,
+  } as ReturnType<typeof useConnectedIntegrations>);
+}
+
+function mockPermissions(canCreate: boolean) {
+  vi.mocked(usePermissions).mockReturnValue({
+    canAct: (resource: string, action: string) => canCreate && resource === "integrations" && action === "create",
+  } as unknown as ReturnType<typeof usePermissions>);
+}
+
+function mockIntegrationCatalogHooks() {
+  vi.mocked(useAvailableIntegrations).mockReturnValue({
+    data: [{ name: "claude", label: "Claude" }],
+  } as ReturnType<typeof useAvailableIntegrations>);
+  vi.mocked(useCreateIntegration).mockReturnValue({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+  } as unknown as ReturnType<typeof useCreateIntegration>);
+}
+
 function createField(): ConfigurationField {
   return {
     name: "integration",
@@ -77,11 +134,11 @@ describe("IntegrationFieldRenderer", () => {
   });
 
   beforeEach(() => {
-    vi.mocked(useConnectedIntegrations).mockReturnValue({
-      data: createIntegrations(),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useConnectedIntegrations>);
+    vi.clearAllMocks();
+    mockIntegrationsHook();
+    mockPermissions(true);
+    mockIntegrationCatalogHooks();
+    vi.spyOn(window, "open").mockReturnValue(null);
   });
 
   it("renders ready integrations and stores installation name on selection", async () => {
@@ -150,5 +207,126 @@ describe("IntegrationFieldRenderer", () => {
     await user.click(screen.getByRole("combobox"));
     expect(await screen.findByText("my-semaphore")).toBeInTheDocument();
     expect(screen.getByTestId("integration-icon-semaphore")).toBeInTheDocument();
+  });
+
+  it("disables the picker when there are no integrations and connect is not allowed", () => {
+    mockIntegrationsHook([]);
+    mockPermissions(false);
+
+    render(
+      <IntegrationFieldRenderer
+        field={createField()}
+        isRequired
+        value={undefined}
+        onChange={() => {}}
+        organizationId="org_123"
+      />,
+    );
+
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(screen.getByText("No integrations available")).toBeInTheDocument();
+    expect(screen.getByText(/Connect an integration in Organization settings first/i)).toBeInTheDocument();
+  });
+
+  it("opens integration settings in a new tab when an unfiltered field has no integrations", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockIntegrationsHook([]);
+
+    render(
+      <IntegrationFieldRenderer
+        field={createField()}
+        isRequired
+        value={undefined}
+        onChange={onChange}
+        organizationId="org_123"
+      />,
+    );
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).not.toBeDisabled();
+    await user.click(trigger);
+    await user.click(await screen.findByRole("option", { name: /connect an integration/i }));
+
+    expect(window.open).toHaveBeenCalledWith("/org_123/settings/integrations", "_blank", "noopener,noreferrer");
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("opens the create dialog inline for a type-filtered field and selects the created integration", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockIntegrationsHook([]);
+
+    render(
+      <IntegrationFieldRenderer
+        field={{
+          ...createField(),
+          typeOptions: {
+            integration: {
+              integration: "claude",
+            },
+          },
+        }}
+        isRequired
+        value={undefined}
+        onChange={onChange}
+        organizationId="org_123"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: /connect an integration/i }));
+
+    expect(await screen.findByTestId("integration-create-dialog")).toBeInTheDocument();
+    expect(window.open).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "finish-connect" }));
+    expect(onChange).toHaveBeenCalledWith({ name: "my-new-claude" });
+  });
+
+  it("names the integration type when a filter leaves no integrations and connect is not allowed", () => {
+    mockPermissions(false);
+
+    render(
+      <IntegrationFieldRenderer
+        field={{
+          ...createField(),
+          typeOptions: {
+            integration: {
+              integration: "claude",
+            },
+          },
+        }}
+        isRequired
+        value={undefined}
+        onChange={() => {}}
+        organizationId="org_123"
+      />,
+    );
+
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(screen.getByText("No Claude integrations available")).toBeInTheDocument();
+  });
+
+  it("keeps listing ready integrations and offers connect after a separator when integrations exist", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <IntegrationFieldRenderer
+        field={createField()}
+        isRequired
+        value={undefined}
+        onChange={() => {}}
+        organizationId="org_123"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(await screen.findByText("github")).toBeInTheDocument();
+    expect(screen.getByText("my-semaphore")).toBeInTheDocument();
+    expect(screen.getByTestId("integration-picker-connect-option")).toBeInTheDocument();
   });
 });

--- a/web_src/src/ui/configurationFieldRenderer/IntegrationFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/IntegrationFieldRenderer.tsx
@@ -1,8 +1,12 @@
-import { useMemo } from "react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ConfigurationField, OrganizationsIntegration } from "@/api-client";
-import { useConnectedIntegrations } from "@/hooks/useIntegrations";
+import { useAvailableIntegrations, useConnectedIntegrations, useCreateIntegration } from "@/hooks/useIntegrations";
+import { usePermissions } from "@/contexts/usePermissions";
+import { getIntegrationTypeDisplayName } from "@/lib/integrationDisplayName";
 import { toTestId } from "@/lib/testID";
+import { IntegrationCreateDialog } from "@/ui/IntegrationCreateDialog";
 import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
 
 export type IntegrationRefValue = { name: string } | undefined;
@@ -17,6 +21,7 @@ interface IntegrationFieldRendererProps {
 }
 
 const CLEAR_OPTION_VALUE = "__none__";
+const CONNECT_OPTION_VALUE = "__connect_new__";
 
 function getIntegrationTypeFilter(field: ConfigurationField): string | undefined {
   return field.typeOptions?.integration?.integration?.trim() || undefined;
@@ -65,6 +70,116 @@ function IntegrationOptionLabel({ integration }: { integration: OrganizationsInt
   );
 }
 
+function getEmptyPlaceholder(integrationType: string | undefined): string {
+  const integrationTypeLabel = integrationType ? getIntegrationTypeDisplayName(undefined, integrationType) : "";
+  return integrationTypeLabel ? `No ${integrationTypeLabel} integrations available` : "No integrations available";
+}
+
+function IntegrationPickerEmptyState({
+  field,
+  integrationType,
+}: {
+  field: ConfigurationField;
+  integrationType: string | undefined;
+}) {
+  return (
+    <div data-testid={toTestId(`integration-field-${field.name}`)} className="space-y-2">
+      <Select value="" disabled>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder={getEmptyPlaceholder(integrationType)} />
+        </SelectTrigger>
+      </Select>
+      <p className="text-xs text-gray-500 dark:text-gray-400">Connect an integration in Organization settings first.</p>
+    </div>
+  );
+}
+
+function IntegrationPickerOptions({
+  isRequired,
+  options,
+  canConnect,
+}: {
+  isRequired: boolean;
+  options: OrganizationsIntegration[];
+  canConnect: boolean;
+}) {
+  return (
+    <>
+      {!isRequired ? <SelectItem value={CLEAR_OPTION_VALUE}>None</SelectItem> : null}
+      {options.map((integration) => {
+        const name = getInstallationName(integration);
+        return (
+          <SelectItem key={name} value={name}>
+            <IntegrationOptionLabel integration={integration} />
+          </SelectItem>
+        );
+      })}
+      {canConnect ? (
+        <>
+          {options.length > 0 ? <SelectSeparator /> : null}
+          <SelectItem value={CONNECT_OPTION_VALUE} data-testid="integration-picker-connect-option">
+            <span className="flex items-center gap-1.5 text-blue-600 dark:text-blue-400">
+              <Plus className="size-3" />
+              Connect an integration
+            </span>
+          </SelectItem>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Inline connect flow for type-filtered fields, wired the same way the
+ * component sidebar wires IntegrationCreateDialog for its "+ Connect another
+ * instance" option. Unfiltered fields never open this dialog (there is no
+ * single integration type to create).
+ */
+function ConnectIntegrationDialog({
+  open,
+  onOpenChange,
+  organizationId,
+  integrationType,
+  enabled,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  integrationType: string | undefined;
+  enabled: boolean;
+  onCreated: (installationName: string) => void;
+}) {
+  const canConnectInline = Boolean(integrationType) && enabled;
+  const { data: availableIntegrationDefinitions = [] } = useAvailableIntegrations({ enabled: canConnectInline });
+  const createIntegrationMutation = useCreateIntegration(organizationId, "node_configuration");
+  const integrationDefinition = useMemo(
+    () => availableIntegrationDefinitions.find((definition) => definition.name === integrationType),
+    [availableIntegrationDefinitions, integrationType],
+  );
+
+  if (!canConnectInline) {
+    return null;
+  }
+
+  return (
+    <IntegrationCreateDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      integrationDefinition={integrationDefinition}
+      organizationId={organizationId}
+      onCreateIntegration={async (payload) => {
+        const result = await createIntegrationMutation.mutateAsync(payload);
+        return result.data;
+      }}
+      onReset={() => createIntegrationMutation.reset()}
+      defaultName={integrationDefinition?.name ?? ""}
+      integrationHomeHref={`/${organizationId}/settings/integrations`}
+      onCreated={(_integrationId, instanceName) => onCreated(instanceName)}
+    />
+  );
+}
+
 export function IntegrationFieldRenderer({
   field,
   isRequired,
@@ -74,7 +189,21 @@ export function IntegrationFieldRenderer({
   readOnly = false,
 }: IntegrationFieldRendererProps) {
   const integrationType = getIntegrationTypeFilter(field);
+  const { canAct } = usePermissions();
+  const canConnectIntegrations = canAct("integrations", "create");
+  const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
   const { data: integrations = [], isLoading, error } = useConnectedIntegrations(organizationId);
+
+  // Type-filtered fields connect the provider in place; unfiltered fields have
+  // no single provider to create, so they open integration settings in a new
+  // tab and the canvas stays put.
+  const openConnectFlow = () => {
+    if (integrationType) {
+      setIsConnectDialogOpen(true);
+      return;
+    }
+    window.open(`/${organizationId}/settings/integrations`, "_blank", "noopener,noreferrer");
+  };
 
   const options = useMemo(
     () =>
@@ -110,6 +239,10 @@ export function IntegrationFieldRenderer({
     );
   }
 
+  if (options.length === 0 && !canConnectIntegrations) {
+    return <IntegrationPickerEmptyState field={field} integrationType={integrationType} />;
+  }
+
   const placeholder = isRequired ? (field.placeholder ?? "Select integration") : "None";
 
   return (
@@ -117,6 +250,11 @@ export function IntegrationFieldRenderer({
       <Select
         value={selectedName || (isRequired ? "" : CLEAR_OPTION_VALUE)}
         onValueChange={(nextValue) => {
+          if (nextValue === CONNECT_OPTION_VALUE) {
+            openConnectFlow();
+            return;
+          }
+
           if (nextValue === CLEAR_OPTION_VALUE) {
             onChange(undefined);
             return;
@@ -138,17 +276,17 @@ export function IntegrationFieldRenderer({
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
-          {!isRequired ? <SelectItem value={CLEAR_OPTION_VALUE}>None</SelectItem> : null}
-          {options.map((integration) => {
-            const name = getInstallationName(integration);
-            return (
-              <SelectItem key={name} value={name}>
-                <IntegrationOptionLabel integration={integration} />
-              </SelectItem>
-            );
-          })}
+          <IntegrationPickerOptions isRequired={isRequired} options={options} canConnect={canConnectIntegrations} />
         </SelectContent>
       </Select>
+      <ConnectIntegrationDialog
+        open={isConnectDialogOpen}
+        onOpenChange={setIsConnectDialogOpen}
+        organizationId={organizationId}
+        integrationType={integrationType}
+        enabled={canConnectIntegrations}
+        onCreated={(installationName) => onChange({ name: installationName })}
+      />
     </div>
   );
 }

--- a/web_src/src/ui/configurationFieldRenderer/SecretFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/SecretFieldRenderer.spec.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigurationField, SuperplaneSecretsSecret } from "@/api-client";
+import { useSecrets } from "@/hooks/useSecrets";
+import { usePermissions } from "@/contexts/usePermissions";
+import { SecretFieldRenderer, type SecretRefValue } from "./SecretFieldRenderer";
+
+vi.mock("@/hooks/useSecrets", () => ({
+  useSecrets: vi.fn(),
+}));
+
+vi.mock("@/contexts/usePermissions", () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock("@/ui/CreateSecretDialog", () => ({
+  CreateSecretDialog: ({ open, onCreated }: { open: boolean; onCreated?: (created: { name?: string }) => void }) =>
+    open ? (
+      <div data-testid="create-secret-dialog">
+        <button type="button" onClick={() => onCreated?.({ name: "created-secret" })}>
+          finish-create
+        </button>
+      </div>
+    ) : null,
+}));
+
+function createSecrets(): SuperplaneSecretsSecret[] {
+  return [{ metadata: { id: "1", name: "ssh-password" } }, { metadata: { id: "2", name: "github-token" } }];
+}
+
+function mockSecretsHook(secrets: SuperplaneSecretsSecret[] = createSecrets()) {
+  vi.mocked(useSecrets).mockReturnValue({
+    data: secrets,
+    isLoading: false,
+    error: null,
+  } as unknown as ReturnType<typeof useSecrets>);
+}
+
+function mockPermissions(canCreate: boolean) {
+  vi.mocked(usePermissions).mockReturnValue({
+    canAct: (resource: string, action: string) => canCreate && resource === "secrets" && action === "create",
+  } as unknown as ReturnType<typeof usePermissions>);
+}
+
+function createField(): ConfigurationField {
+  return {
+    name: "secret",
+    type: "secret",
+    label: "Secret",
+    placeholder: "Select secret",
+  };
+}
+
+function ControlledSecretFieldRenderer({ initialValue }: { initialValue: SecretRefValue }) {
+  const [value, setValue] = React.useState<SecretRefValue>(initialValue);
+
+  return (
+    <SecretFieldRenderer field={createField()} isRequired value={value} onChange={setValue} organizationId="org_123" />
+  );
+}
+
+describe("SecretFieldRenderer", () => {
+  beforeAll(() => {
+    Element.prototype.hasPointerCapture ??= () => false;
+    Element.prototype.setPointerCapture ??= () => {};
+    Element.prototype.releasePointerCapture ??= () => {};
+    Element.prototype.scrollIntoView ??= () => {};
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSecretsHook();
+    mockPermissions(true);
+  });
+
+  it("lists the organization secrets and stores the secret name on selection", async () => {
+    const user = userEvent.setup();
+    let latestValue: SecretRefValue;
+
+    render(
+      <SecretFieldRenderer
+        field={createField()}
+        isRequired
+        value={undefined}
+        onChange={(value) => {
+          latestValue = value;
+        }}
+        organizationId="org_123"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "github-token" }));
+
+    expect(latestValue!).toEqual({ secret: "github-token" });
+  });
+
+  it("disables the picker when there are no secrets and create is not allowed", () => {
+    mockSecretsHook([]);
+    mockPermissions(false);
+
+    render(
+      <SecretFieldRenderer
+        field={createField()}
+        isRequired
+        value={undefined}
+        onChange={() => {}}
+        organizationId="org_123"
+      />,
+    );
+
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(screen.getByText("No secrets available")).toBeInTheDocument();
+    expect(screen.getByText(/Create a secret in Organization settings first/i)).toBeInTheDocument();
+  });
+
+  it("opens the create dialog when there are no secrets and selects the created secret", async () => {
+    const user = userEvent.setup();
+    mockSecretsHook([]);
+
+    render(<ControlledSecretFieldRenderer initialValue={undefined} />);
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).not.toBeDisabled();
+    await user.click(trigger);
+    await user.click(await screen.findByRole("option", { name: /add a new secret/i }));
+
+    expect(await screen.findByTestId("create-secret-dialog")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "finish-create" }));
+    expect(screen.getByRole("combobox")).toHaveTextContent("created-secret");
+  });
+
+  it("keeps listing secrets and offers add-new after a separator when secrets exist", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SecretFieldRenderer
+        field={createField()}
+        isRequired
+        value={undefined}
+        onChange={() => {}}
+        organizationId="org_123"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(await screen.findByText("ssh-password")).toBeInTheDocument();
+    expect(screen.getByText("github-token")).toBeInTheDocument();
+    expect(screen.getByTestId("secret-field-add-new-option")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/SecretFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/SecretFieldRenderer.tsx
@@ -1,8 +1,11 @@
-import { useMemo } from "react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ConfigurationField, SuperplaneSecretsSecret } from "@/api-client";
 import { useSecrets } from "@/hooks/useSecrets";
+import { usePermissions } from "@/contexts/usePermissions";
 import { toTestId } from "@/lib/testID";
+import { CreateSecretDialog, type CreatedSecretSummary } from "@/ui/CreateSecretDialog";
 
 export type SecretRefValue = { secret: string } | undefined;
 
@@ -16,10 +19,61 @@ interface SecretFieldRendererProps {
 }
 
 const CLEAR_OPTION_VALUE = "__none__";
+const ADD_NEW_OPTION_VALUE = "__add_new__";
 const DOMAIN_TYPE_ORG = "DOMAIN_TYPE_ORGANIZATION" as const;
 
 function getSecretName(secret: SuperplaneSecretsSecret): string {
   return secret.metadata?.name ?? secret.metadata?.id ?? "";
+}
+
+function displaySelectValue(value: string, allowClear: boolean) {
+  if (value.length > 0) return value;
+  return allowClear ? CLEAR_OPTION_VALUE : "";
+}
+
+function SecretFieldEmptyState({ field }: { field: ConfigurationField }) {
+  return (
+    <div data-testid={toTestId(`secret-field-${field.name}`)} className="space-y-2">
+      <Select value="" disabled>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="No secrets available" />
+        </SelectTrigger>
+      </Select>
+      <p className="text-xs text-gray-500 dark:text-gray-400">Create a secret in Organization settings first.</p>
+    </div>
+  );
+}
+
+function SecretFieldOptions({
+  isRequired,
+  options,
+  canCreate,
+}: {
+  isRequired: boolean;
+  options: string[];
+  canCreate: boolean;
+}) {
+  return (
+    <>
+      {!isRequired ? <SelectItem value={CLEAR_OPTION_VALUE}>None</SelectItem> : null}
+      {options.map((option) => (
+        <SelectItem key={option} value={option}>
+          {option}
+        </SelectItem>
+      ))}
+      {canCreate ? (
+        <>
+          {options.length > 0 ? <SelectSeparator /> : null}
+          <SelectItem value={ADD_NEW_OPTION_VALUE} data-testid="secret-field-add-new-option">
+            <span className="flex items-center gap-1.5 text-blue-600 dark:text-blue-400">
+              <Plus className="size-3" />
+              Add a new secret
+            </span>
+          </SelectItem>
+        </>
+      ) : null}
+    </>
+  );
 }
 
 export function SecretFieldRenderer({
@@ -30,6 +84,9 @@ export function SecretFieldRenderer({
   organizationId,
   readOnly = false,
 }: SecretFieldRendererProps) {
+  const { canAct } = usePermissions();
+  const canCreateSecrets = canAct("secrets", "create");
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
   const { data: secrets = [], isLoading, error } = useSecrets(organizationId, DOMAIN_TYPE_ORG, organizationId);
 
   const options = useMemo(
@@ -42,6 +99,12 @@ export function SecretFieldRenderer({
   );
 
   const selectedValue = value?.secret ?? "";
+
+  const handleSecretCreated = (created: CreatedSecretSummary) => {
+    if (created.name) {
+      onChange({ secret: created.name });
+    }
+  };
 
   if (error) {
     return (
@@ -63,13 +126,22 @@ export function SecretFieldRenderer({
     );
   }
 
+  if (options.length === 0 && !canCreateSecrets) {
+    return <SecretFieldEmptyState field={field} />;
+  }
+
   const placeholder = isRequired ? (field.placeholder ?? "Select secret") : "None";
 
   return (
     <div data-testid={toTestId(`secret-field-${field.name}`)}>
       <Select
-        value={selectedValue || (isRequired ? "" : CLEAR_OPTION_VALUE)}
+        value={displaySelectValue(selectedValue, !isRequired)}
         onValueChange={(nextValue) => {
+          if (nextValue === ADD_NEW_OPTION_VALUE) {
+            setIsCreateOpen(true);
+            return;
+          }
+
           if (nextValue === CLEAR_OPTION_VALUE) {
             onChange(undefined);
             return;
@@ -80,17 +152,22 @@ export function SecretFieldRenderer({
         disabled={readOnly}
       >
         <SelectTrigger className="w-full">
-          <SelectValue placeholder={placeholder} />
+          {/* Render the stored name directly so a just-created secret shows
+              before the secrets query refetches (mirrors IntegrationFieldRenderer). */}
+          <SelectValue placeholder={placeholder}>{selectedValue || undefined}</SelectValue>
         </SelectTrigger>
         <SelectContent>
-          {!isRequired ? <SelectItem value={CLEAR_OPTION_VALUE}>None</SelectItem> : null}
-          {options.map((option) => (
-            <SelectItem key={option} value={option}>
-              {option}
-            </SelectItem>
-          ))}
+          <SecretFieldOptions isRequired={isRequired} options={options} canCreate={canCreateSecrets} />
         </SelectContent>
       </Select>
+      {canCreateSecrets ? (
+        <CreateSecretDialog
+          open={isCreateOpen}
+          onOpenChange={setIsCreateOpen}
+          organizationId={organizationId}
+          onCreated={handleSecretCreated}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
**What:** Three configuration-field pickers rendered a dead dropdown when they had no options: `IntegrationFieldRenderer` (`integration` fields, e.g. the Claude Code runner's Credentials → Integration), the same renderer for unfiltered fields (runner "Environment from" → Integration), and `SecretFieldRenderer` (`secret` fields, e.g. "Environment from" → Secret). With zero matching options the popover rendered with no items — measuring ~128×10px and positioned off-screen below the viewport — so clicking the dropdown visibly did nothing. No message, no way forward. Found while evaluating the product with a fresh account and no integrations/secrets connected.

**Why:** For the Claude runner's type-filtered credentials dropdown there is *no* populated state reachable until a Claude integration exists, so a new user hits a dropdown that appears broken with zero guidance — on the exact path the product showcases.

**How:** Mirrors the existing `SecretPickerFieldRenderer` pattern (the sibling that already solved this):
- With create permission (`canAct("integrations"/"secrets", "create")`): a "+ Connect an integration" / "+ Add a new secret" item.
  - Type-filtered integration fields open `IntegrationCreateDialog` **inline** — the same wiring the component sidebar's "Connect another instance" card uses — and auto-select the created integration.
  - Unfiltered integration fields have no single provider to create, so the CTA opens the integrations settings in a **new tab**, preserving canvas context. (Happy to change either mechanism if you prefer one over the other.)
  - The secret CTA opens `CreateSecretDialog` inline and auto-selects, exactly like the secret-key picker.
- Without create permission: a disabled select ("No Claude integrations available" / "No secrets available") with a short hint.

**Tests:** unit specs for all states of both renderers; E2E subtests assert the popover is on-screen with the CTA for all three dropdowns, the inline dialog opens with the canvas URL unchanged, the new-tab popup is intercepted, and a populated dropdown still lists integrations. One E2E subtest submits the Claude dialog against the real server with a dummy key and asserts the observed server behavior end-to-end (creation succeeds with the integration in `error` state, and the field auto-selects it).
