### PR TITLE
fix: support Claude Code OAuth tokens in the runner

### DIFF
--- a/pkg/components/runner/claude/run.js
+++ b/pkg/components/runner/claude/run.js
@@ -48,8 +48,13 @@ async function runPrompt(promptFile, model) {
   const promptCountPath = path.join(sp, "prompt_count");
   const promptCount = Number.parseInt(fs.readFileSync(promptCountPath, "utf8").trim(), 10) || 0;
 
+  // --bare skips keychain reads, which subscription (OAuth) auth needs to
+  // resolve the credential. When a subscription token is present
+  // (ANTHROPIC_AUTH_TOKEN), omit --bare so the login path stays available;
+  // keep it otherwise, where its isolation costs nothing.
+  const bare = process.env.ANTHROPIC_AUTH_TOKEN ? [] : ["--bare"];
   const claudeArgs = [
-    "--bare",
+    ...bare,
     "-p",
     "--output-format",
     "stream-json",

--- a/pkg/components/runner/claude/spec.go
+++ b/pkg/components/runner/claude/spec.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	claudeStepPrompt   = "prompt"
-	claudeStepBash     = "bash"
-	envAnthropicAPIKey = "ANTHROPIC_API_KEY"
+	claudeStepPrompt      = "prompt"
+	claudeStepBash        = "bash"
+	envAnthropicAPIKey    = "ANTHROPIC_API_KEY"
+	envAnthropicAuthToken = "ANTHROPIC_AUTH_TOKEN"
 
 	claudeCredentialsSourceSecret      = "secret"
 	claudeCredentialsSourceIntegration = "integration"
@@ -130,8 +131,9 @@ func validateRunClaudeCodeSpec(spec RunClaudeCodeSpec) error {
 		return err
 	}
 	for i, variable := range spec.Environment {
-		if strings.TrimSpace(variable.Name) == envAnthropicAPIKey {
-			return fmt.Errorf("environment[%d].name cannot be %s; use the Anthropic API Key field", i, envAnthropicAPIKey)
+		name := strings.TrimSpace(variable.Name)
+		if name == envAnthropicAPIKey || name == envAnthropicAuthToken {
+			return fmt.Errorf("environment[%d].name cannot be %s; use the Anthropic API Key field", i, name)
 		}
 	}
 	if spec.ExecutionTimeoutSeconds != 0 {

--- a/pkg/components/runner/claude/spec_test.go
+++ b/pkg/components/runner/claude/spec_test.go
@@ -93,6 +93,22 @@ func TestValidateRunClaudeCodeSpec(t *testing.T) {
 		spec.Steps = []ClaudeCodeStep{{Name: "Echo", Type: claudeStepBash, Command: strPtr("echo hi")}}
 		require.Error(t, validateRunClaudeCodeSpec(spec))
 	})
+
+	t.Run("rejects ANTHROPIC_API_KEY in environment", func(t *testing.T) {
+		spec := valid
+		spec.Environment = []runner.EnvironmentVariable{
+			{Name: envAnthropicAPIKey, ValueSource: runner.EnvironmentValueSourceLiteral, Value: strPtr("sk-ant-api03-x")},
+		}
+		require.Error(t, validateRunClaudeCodeSpec(spec))
+	})
+
+	t.Run("rejects ANTHROPIC_AUTH_TOKEN in environment", func(t *testing.T) {
+		spec := valid
+		spec.Environment = []runner.EnvironmentVariable{
+			{Name: envAnthropicAuthToken, ValueSource: runner.EnvironmentValueSourceLiteral, Value: strPtr("sk-ant-oat01-x")},
+		}
+		require.Error(t, validateRunClaudeCodeSpec(spec))
+	})
 }
 
 func TestBuildClaudeCodeBrokerTaskRunsOrderedSteps(t *testing.T) {

--- a/pkg/integrations/claude/integration_secrets.go
+++ b/pkg/integrations/claude/integration_secrets.go
@@ -7,7 +7,17 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const integrationSecretAnthropicAPIKey = "ANTHROPIC_API_KEY"
+const (
+	integrationSecretAnthropicAPIKey    = "ANTHROPIC_API_KEY"
+	integrationSecretAnthropicAuthToken = "ANTHROPIC_AUTH_TOKEN"
+)
+
+// oauthTokenPrefix identifies a Claude Code OAuth token as opposed to an
+// Anthropic API key. OAuth tokens must reach the CLI as a bearer-style
+// subscription token (ANTHROPIC_AUTH_TOKEN); API keys go to the CLI as
+// ANTHROPIC_API_KEY. The prefix makes the two mutually exclusive, so a single
+// "apiKey" field can accept either.
+const oauthTokenPrefix = "sk-ant-oat"
 
 func (i *Claude) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][]byte, error) {
 	apiKey, err := ctx.Integration.GetConfig("apiKey")
@@ -20,7 +30,15 @@ func (i *Claude) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][
 		return nil, fmt.Errorf("apiKey is required")
 	}
 
+	// Claude Code OAuth tokens must be passed to the CLI as ANTHROPIC_AUTH_TOKEN;
+	// an API key goes into ANTHROPIC_API_KEY. Handing an OAuth token to the
+	// wrong variable makes the CLI reject it with "Invalid API key".
+	secretName := integrationSecretAnthropicAPIKey
+	if strings.HasPrefix(key, oauthTokenPrefix) {
+		secretName = integrationSecretAnthropicAuthToken
+	}
+
 	return map[string][]byte{
-		integrationSecretAnthropicAPIKey: []byte(key),
+		secretName: []byte(key),
 	}, nil
 }

--- a/pkg/integrations/claude/integration_secrets_test.go
+++ b/pkg/integrations/claude/integration_secrets_test.go
@@ -12,13 +12,58 @@ import (
 func TestResolveSecrets(t *testing.T) {
 	t.Parallel()
 
+	tests := []struct {
+		name       string
+		apiKey     string
+		secretName string
+		secret     string
+	}{
+		{
+			name:       "API key is resolved as ANTHROPIC_API_KEY",
+			apiKey:     "sk-ant-api03-abc",
+			secretName: integrationSecretAnthropicAPIKey,
+			secret:     "sk-ant-api03-abc",
+		},
+		{
+			name:       "OAuth token is resolved as ANTHROPIC_AUTH_TOKEN",
+			apiKey:     "sk-ant-oat01-abc",
+			secretName: integrationSecretAnthropicAuthToken,
+			secret:     "sk-ant-oat01-abc",
+		},
+		{
+			name:       "whitespace around the key is trimmed",
+			apiKey:     "  sk-ant-api03-abc  ",
+			secretName: integrationSecretAnthropicAPIKey,
+			secret:     "sk-ant-api03-abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secrets, err := (&Claude{}).ResolveSecrets(core.IntegrationSecretContext{
+				Integration: &contexts.IntegrationContext{
+					Configuration: map[string]any{
+						"apiKey": tt.apiKey,
+					},
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, []byte(tt.secret), secrets[tt.secretName])
+			assert.Len(t, secrets, 1)
+		})
+	}
+}
+
+func TestResolveSecretsRejectsEmptyKey(t *testing.T) {
+	t.Parallel()
+
 	secrets, err := (&Claude{}).ResolveSecrets(core.IntegrationSecretContext{
 		Integration: &contexts.IntegrationContext{
 			Configuration: map[string]any{
-				"apiKey": "sk-ant-test",
+				"apiKey": "   ",
 			},
 		},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, []byte("sk-ant-test"), secrets[integrationSecretAnthropicAPIKey])
+	require.Error(t, err)
+	assert.Nil(t, secrets)
 }


### PR DESCRIPTION
Fixes #6488

## Summary

A Claude Code component configured with a subscription token (a Claude Code OAuth token, `sk-ant-oat...`) cannot run. Two independent causes:

1. **Wrong env var.** The Claude integration hands its credential to the runner as `ANTHROPIC_API_KEY` regardless of the credential kind (`pkg/integrations/claude/integration_secrets.go`), so an OAuth token arrives in the wrong variable and the CLI rejects it with `Invalid API key`. `ResolveSecrets` now picks the variable from the credential kind — OAuth tokens go to `ANTHROPIC_AUTH_TOKEN`, API keys to `ANTHROPIC_API_KEY` — mirroring how the API client chooses its auth header in #6492 (same `sk-ant-oat` prefix detection).
2. **`--bare` blocks the subscription login.** `run.js` always passed `--bare`, whose documented behavior includes skipping keychain reads — the path Claude Code uses to authenticate a subscription token — so the run failed with `Not logged in · Please run /login`. `--bare` is now omitted when a subscription token (`ANTHROPIC_AUTH_TOKEN`) is present, and kept otherwise, where its isolation costs nothing.

Also rejects `ANTHROPIC_AUTH_TOKEN` in the node's user environment list, matching the existing `ANTHROPIC_API_KEY` guard, so runner credentials can only come from the credentials field.

## Notes

- The `oauthTokenPrefix` const defined in `integration_secrets.go` has the same name and value as the one #6492 adds to `client.go` (same package). Whichever PR merges second should drop its copy.
- Out of scope, potential follow-up: the `secret` credentials source in `component.go` still maps any secret to `ANTHROPIC_API_KEY` unconditionally; only the `integration` source benefits from this fix.

## Verification

- `make test` — both packages pass (136 tests, incl. new cases for API key vs OAuth token resolution and env-name validation)
- `make lint`, `make check.build.app` — clean
- `node --check` on `run.js` — clean