### PR TITLE
fix: format timestamps in the requested timezone

### DIFF
--- a/web_src/src/lib/timezone.spec.ts
+++ b/web_src/src/lib/timezone.spec.ts
@@ -12,10 +12,19 @@ describe("timezone", () => {
   });
 
   it("formats timestamps in the requested timezone", () => {
-    const toLocaleDateStringSpy = vi.spyOn(Date.prototype, "toLocaleDateString").mockReturnValue("Mar 29, 2026, 14:30");
-
     expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "UTC")).toBe("Mar 29, 2026, 14:30 UTC");
-    expect(toLocaleDateStringSpy).toHaveBeenCalledWith("en-US", {
+    expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "America/New_York")).toBe(
+      "Mar 29, 2026, 10:30 America/New_York",
+    );
+  });
+
+  it("formats timestamps for GMT offset labels", () => {
+    expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "GMT+2")).toBe("Mar 29, 2026, 16:30 GMT+2");
+    expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "GMT-5:30")).toBe("Mar 29, 2026, 09:00 GMT-5:30");
+  });
+
+  it("falls back to the browser timezone for unknown timezones", () => {
+    const inBrowserTimezone = new Date("2026-03-29T14:30:00.000Z").toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
       year: "numeric",
@@ -23,6 +32,10 @@ describe("timezone", () => {
       minute: "2-digit",
       hour12: false,
     });
+
+    expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "Not/AZone")).toBe(
+      `${inBrowserTimezone} Not/AZone`,
+    );
   });
 
   it("formats relative time in abbreviated and long forms", () => {

--- a/web_src/src/lib/timezone.ts
+++ b/web_src/src/lib/timezone.ts
@@ -9,6 +9,29 @@ function getUserTimezone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
+const DATE_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false, // Use 24-hour format instead of AM/PM
+};
+
+/**
+ * Intl accepts IANA names ("America/New_York") and offsets in "+HH:MM" form, but
+ * not the "GMT+2" label callers use for schedule timezones, so normalize those.
+ */
+function toIntlTimezone(timezone: string): string {
+  const offset = /^(?:GMT|UTC)([+-])(\d{1,2})(?::?(\d{2}))?$/i.exec(timezone.trim());
+  if (!offset) {
+    return timezone;
+  }
+
+  const [, sign, hours, minutes = "00"] = offset;
+  return `${sign}${hours.padStart(2, "0")}:${minutes}`;
+}
+
 /**
  * Format a timestamp to display in user's local timezone
  * @param timestamp - ISO timestamp string or Date object
@@ -18,16 +41,17 @@ function getUserTimezone(): string {
 export function formatTimestampInUserTimezone(timestamp: string | Date, userTimezone?: string): string {
   const timezone = userTimezone || getUserTimezone();
   const date = typeof timestamp === "string" ? new Date(timestamp) : timestamp;
-  const options: Intl.DateTimeFormatOptions = {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false, // Use 24-hour format instead of AM/PM
-  };
 
-  return date.toLocaleDateString("en-US", options) + ` ${timezone}`;
+  let formatted: string;
+  try {
+    formatted = date.toLocaleDateString("en-US", { ...DATE_TIME_FORMAT, timeZone: toIntlTimezone(timezone) });
+  } catch {
+    // Unrecognized timezone identifier — fall back to the browser's timezone
+    // rather than dropping the timestamp entirely.
+    formatted = date.toLocaleDateString("en-US", DATE_TIME_FORMAT);
+  }
+
+  return `${formatted} ${timezone}`;
 }
 
 /**


### PR DESCRIPTION
## What changed

`formatTimestampInUserTimezone` in `web_src/src/lib/timezone.ts` now actually formats the timestamp in the timezone it is given.

## Why

The function accepted a `userTimezone` argument but never passed it to `Intl`. It formatted the timestamp in the **browser's** timezone and then appended the **requested** timezone as a label, so the displayed time and its label disagreed.

On a browser in UTC+3:

```js
formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "UTC")
// before: "Mar 29, 2026, 17:30 UTC"   <- off by 3 hours, wrong label
// after:  "Mar 29, 2026, 14:30 UTC"
```

The user-visible impact is on schedule triggers. `web_src/src/pages/app/mappers/schedule.ts` builds a `GMT±H` label from the schedule's configured timezone and passes it in, so a schedule's next trigger time was rendered in the viewer's local timezone while being labeled with the schedule's timezone.

## How

- Pass `timeZone` into the `toLocaleDateString` options so the rendered time matches the label.
- Add `toIntlTimezone`, because `Intl` rejects the `"GMT+2"` label form the schedule mapper produces (`RangeError: Invalid time zone specified: GMT+2`). It normalizes `GMT|UTC±H[:MM]` to the `"+HH:MM"` offset form `Intl` accepts, and passes IANA names through unchanged.
- Wrap the call in `try`/`catch` so an unrecognized timezone identifier degrades to browser-local formatting rather than throwing and blanking the timestamp.

## Tests

The existing test asserted the buggy behavior — it mocked `toLocaleDateString` and explicitly checked that no `timeZone` was passed, despite being named "formats timestamps in the requested timezone". It has been replaced with assertions covering IANA names, `GMT` offset labels, and the unknown-timezone fallback.

Verified with `npx vitest run src/lib`: 40 files, 229 tests pass. Reverting only `timezone.ts` and re-running makes two of the new assertions fail with exactly the buggy output, confirming they cover the regression.

`prettier --check` and `eslint` pass on both files.
