### PR TITLE
fix: bound HTTP requests in Slack, Discord, and Telegram clients

### DIFF
--- a/pkg/integrations/discord/client.go
+++ b/pkg/integrations/discord/client.go
@@ -10,11 +10,36 @@ import (
 	"net/textproto"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
 const discordAPIBase = "https://discord.com/api/v10"
+
+const (
+	// requestTimeout bounds a single Discord API call. http.DefaultClient has no
+	// timeout, so without this a stalled connection blocks the worker running
+	// the component forever.
+	requestTimeout = 30 * time.Second
+
+	// uploadTimeout is the budget for multipart message uploads, which carry up
+	// to maxMessageFiles attachments of maxMessageFileSize each and so need more
+	// room than a plain JSON call.
+	uploadTimeout = 2 * time.Minute
+
+	// maxResponseSize bounds how much of an API response we buffer in memory.
+	// The largest response we ask for is a 100-message channel page, which stays
+	// well below this. Attachment downloads are bounded separately by
+	// maxMessageFileSize.
+	maxResponseSize = 4 * 1024 * 1024 // 4MB
+)
+
+// Clients are shared by all requests so connections are reused across calls.
+var (
+	httpClient       = &http.Client{Timeout: requestTimeout}
+	uploadHTTPClient = &http.Client{Timeout: uploadTimeout}
+)
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
@@ -274,15 +299,19 @@ func (c *Client) CreateMessageWithFiles(channelID string, req CreateMessageReque
 	httpReq.Header.Set("Authorization", fmt.Sprintf("Bot %s", c.BotToken))
 	httpReq.Header.Set("Content-Type", writer.FormDataContentType())
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := uploadHTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if len(responseBody) > maxResponseSize {
+		return nil, fmt.Errorf("response too large: exceeds maximum size of %d bytes", maxResponseSize)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -355,15 +384,19 @@ func (c *Client) doRequest(method, endpoint string, body io.Reader) ([]byte, err
 	req.Header.Set("Authorization", fmt.Sprintf("Bot %s", c.BotToken))
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if len(responseBody) > maxResponseSize {
+		return nil, fmt.Errorf("response too large: exceeds maximum size of %d bytes", maxResponseSize)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/pkg/integrations/discord/client_test.go
+++ b/pkg/integrations/discord/client_test.go
@@ -1,0 +1,25 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__HTTPClient__IsBounded(t *testing.T) {
+	t.Run("shared clients have a request timeout", func(t *testing.T) {
+		assert.Equal(t, requestTimeout, httpClient.Timeout)
+		assert.Positive(t, httpClient.Timeout, "requests must not be able to hang forever")
+
+		assert.Equal(t, uploadTimeout, uploadHTTPClient.Timeout)
+		assert.Positive(t, uploadHTTPClient.Timeout, "uploads must not be able to hang forever")
+	})
+
+	t.Run("uploads get more time than plain API calls", func(t *testing.T) {
+		assert.Greater(t, uploadHTTPClient.Timeout, httpClient.Timeout)
+	})
+
+	t.Run("response size limit is set", func(t *testing.T) {
+		assert.Positive(t, maxResponseSize)
+	})
+}

--- a/pkg/integrations/slack/client.go
+++ b/pkg/integrations/slack/client.go
@@ -7,9 +7,25 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
+
+const (
+	// requestTimeout bounds a single Slack API call. http.DefaultClient has no
+	// timeout, so without this a stalled connection blocks the worker running
+	// the component forever.
+	requestTimeout = 30 * time.Second
+
+	// maxResponseSize bounds how much of a response we buffer in memory. Slack
+	// API responses are far smaller than this (conversations.list pages at 100
+	// channels), so the cap only guards against a runaway response.
+	maxResponseSize = 4 * 1024 * 1024 // 4MB
+)
+
+// httpClient is shared by all requests so connections are reused across calls.
+var httpClient = &http.Client{Timeout: requestTimeout}
 
 type Client struct {
 	BotToken string
@@ -176,16 +192,19 @@ func (c *Client) execRequest(method, URL string, body io.Reader) ([]byte, error)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.BotToken))
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %v", err)
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %v", err)
+	}
+
+	if len(responseBody) > maxResponseSize {
+		return nil, fmt.Errorf("response too large: exceeds maximum size of %d bytes", maxResponseSize)
 	}
 
 	return responseBody, nil

--- a/pkg/integrations/slack/client_test.go
+++ b/pkg/integrations/slack/client_test.go
@@ -1,0 +1,18 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__HTTPClient__IsBounded(t *testing.T) {
+	t.Run("shared client has a request timeout", func(t *testing.T) {
+		assert.Equal(t, requestTimeout, httpClient.Timeout)
+		assert.Positive(t, httpClient.Timeout, "requests must not be able to hang forever")
+	})
+
+	t.Run("response size limit is set", func(t *testing.T) {
+		assert.Positive(t, maxResponseSize)
+	})
+}

--- a/pkg/integrations/telegram/client.go
+++ b/pkg/integrations/telegram/client.go
@@ -6,11 +6,27 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
 const telegramAPIBase = "https://api.telegram.org/bot"
+
+const (
+	// requestTimeout bounds a single Telegram Bot API call. http.DefaultClient
+	// has no timeout, so without this a stalled connection blocks the worker
+	// running the component forever.
+	requestTimeout = 30 * time.Second
+
+	// maxResponseSize bounds how much of a response we buffer in memory. Bot API
+	// responses are far smaller than this, so the cap only guards against a
+	// runaway response.
+	maxResponseSize = 4 * 1024 * 1024 // 4MB
+)
+
+// httpClient is shared by all requests so connections are reused across calls.
+var httpClient = &http.Client{Timeout: requestTimeout}
 
 type Client struct {
 	BotToken string
@@ -205,15 +221,19 @@ func (c *Client) doRequest(method, endpoint string, body io.Reader) ([]byte, err
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if len(responseBody) > maxResponseSize {
+		return nil, fmt.Errorf("response too large: exceeds maximum size of %d bytes", maxResponseSize)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/pkg/integrations/telegram/client_test.go
+++ b/pkg/integrations/telegram/client_test.go
@@ -1,0 +1,18 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__HTTPClient__IsBounded(t *testing.T) {
+	t.Run("shared client has a request timeout", func(t *testing.T) {
+		assert.Equal(t, requestTimeout, httpClient.Timeout)
+		assert.Positive(t, httpClient.Timeout, "requests must not be able to hang forever")
+	})
+
+	t.Run("response size limit is set", func(t *testing.T) {
+		assert.Positive(t, maxResponseSize)
+	})
+}


### PR DESCRIPTION
## What changed
- Slack, Discord, and Telegram API clients now issue requests through a shared `http.Client` with a timeout instead of `http.DefaultClient` (Discord/Telegram) or a per-request `&http.Client{}` (Slack).
- Response bodies in those three clients are read through `io.LimitReader` with an explicit "too large" error instead of an unbounded `io.ReadAll`.
- Discord's multipart upload path (`CreateMessageWithFiles`) gets its own client with a longer timeout.
- Added a small `client_test.go` per package guarding that these clients keep a non-zero timeout.

## Why
`http.DefaultClient` and a zero-value `http.Client` have **no timeout at all**. If Slack, Discord, or Telegram stops responding mid-request — a blackholed connection, a stalled body — the worker goroutine running the component blocks forever with nothing to recover it. Every other integration that talks to a third-party API over raw `net/http` already sets one (`teams`, `azure`, ...).

The unbounded `io.ReadAll` is the same class of problem for memory: `dash0`, `grafana`, `newrelic`, `prometheus`, and Discord's own attachment download in `FetchFile` all cap reads with `io.LimitReader`. These three clients were the outliers.

## How
### Backend
- `pkg/integrations/{slack,discord,telegram}/client.go`: added a `requestTimeout` (30s) and `maxResponseSize` (4MB) constant per package, plus a package-level `httpClient` so connections are reused across calls rather than a fresh client per request.
- Discord additionally defines `uploadTimeout` (2m) and `uploadHTTPClient`, because a message can carry up to `maxMessageFiles` (10) attachments of `maxMessageFileSize` (8MB) each and would otherwise be strangled by the 30s budget. The two clients are kept distinct so a slow upload can't silently widen the deadline for ordinary API calls.
- The 4MB response cap is well above anything these APIs return for the calls made here — the largest is Discord's 100-message channel page and Slack's `conversations.list`.

The request/response handling is otherwise unchanged, so error strings and status handling stay as they were.

## Notes
I was unable to run `make lint` / `make test` locally (no Docker on this machine), so this relies on CI for verification. The change is mechanical, but a maintainer may want to confirm the Discord upload timeout is sized sensibly for their traffic.
