### PR TITLE
fix: clarify GitHub org name in integration setup microcopy

### DIFF
--- a/pkg/integrations/github/setup_provider.go
+++ b/pkg/integrations/github/setup_provider.go
@@ -234,26 +234,27 @@ func (g *SetupProvider) FirstStep(ctx core.SetupStepContext) core.SetupStep {
 	return core.SetupStep{
 		Type:  core.SetupStepTypeInputs,
 		Name:  SetupStepSelectOwner,
-		Label: "Select the user account / organization",
+		Label: "Select the GitHub user account or organization",
 		Inputs: []configuration.Field{
 			{
 				Name:     common.PropertyOwnerType,
-				Label:    "Owner Type",
+				Label:    "GitHub owner type",
 				Type:     configuration.FieldTypeSelect,
 				Required: true,
 				Default:  common.OwnerTypeUser,
 				TypeOptions: &configuration.TypeOptions{
 					Select: &configuration.SelectTypeOptions{
 						Options: []configuration.FieldOption{
-							{Label: "User Account", Value: common.OwnerTypeUser},
-							{Label: "Organization", Value: common.OwnerTypeOrganization},
+							{Label: "GitHub user account", Value: common.OwnerTypeUser},
+							{Label: "GitHub organization", Value: common.OwnerTypeOrganization},
 						},
 					},
 				},
 			},
 			{
 				Name:        common.PropertyOwner,
-				Label:       "User account / organization name",
+				Label:       "GitHub username or organization name",
+				Description: "The GitHub account or organization that owns the repositories — not your SuperPlane organization.",
 				Type:        configuration.FieldTypeString,
 				Required:    true,
 				Placeholder: "e.g. superplanehq",

--- a/pkg/integrations/github/setup_provider_test.go
+++ b/pkg/integrations/github/setup_provider_test.go
@@ -13,6 +13,30 @@ import (
 	"github.com/superplanehq/superplane/test/support/logger"
 )
 
+func Test__GitHub__SetupProvider__FirstStep(t *testing.T) {
+	step := (&SetupProvider{}).FirstStep(core.SetupStepContext{})
+
+	assert.Equal(t, SetupStepSelectOwner, step.Name)
+	assert.Equal(t, "Select the GitHub user account or organization", step.Label)
+	require.Len(t, step.Inputs, 2)
+
+	ownerType := step.Inputs[0]
+	assert.Equal(t, common.PropertyOwnerType, ownerType.Name)
+	assert.Equal(t, "GitHub owner type", ownerType.Label)
+	require.NotNil(t, ownerType.TypeOptions)
+	require.NotNil(t, ownerType.TypeOptions.Select)
+	require.Len(t, ownerType.TypeOptions.Select.Options, 2)
+	assert.Equal(t, "GitHub user account", ownerType.TypeOptions.Select.Options[0].Label)
+	assert.Equal(t, common.OwnerTypeUser, ownerType.TypeOptions.Select.Options[0].Value)
+	assert.Equal(t, "GitHub organization", ownerType.TypeOptions.Select.Options[1].Label)
+	assert.Equal(t, common.OwnerTypeOrganization, ownerType.TypeOptions.Select.Options[1].Value)
+
+	owner := step.Inputs[1]
+	assert.Equal(t, common.PropertyOwner, owner.Name)
+	assert.Equal(t, "GitHub username or organization name", owner.Label)
+	assert.Contains(t, owner.Description, "not your SuperPlane organization")
+}
+
 func Test__GitHub__SetupProvider__OnCapabilityUpdate(t *testing.T) {
 	g := &SetupProvider{}
 	log := logger.DiscardLogger()


### PR DESCRIPTION
## Summary
- Clarifies GitHub integration setup microcopy so the owner field is explicitly a GitHub username/organization.
- Adds a description noting this is not the SuperPlane organization.
- Adds a unit test covering the first setup step labels.

## Why
Users could confuse the field with their SuperPlane organization name.

Fixes #5031

## Screenshots
### Before
<img width="1919" height="942" alt="Captura de tela 2026-08-03 101103" src="https://github.com/user-attachments/assets/8ab21263-3a81-49a4-b58f-d7f3097aed9d" />

### After
<img width="1919" height="940" alt="Captura de tela 2026-08-03 101748" src="https://github.com/user-attachments/assets/19145769-e723-4f01-b613-846378a0639a" />
