### PR TITLE
fix: record failed executions for invalid nodes

### DIFF
--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"golang.org/x/sync/semaphore"
@@ -17,6 +18,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/telemetry"
+	"github.com/superplanehq/superplane/pkg/workers/contexts"
 )
 
 type EventRouter struct {
@@ -170,6 +172,7 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 
 	var createdQueueItems []models.CanvasNodeQueueItem
 	var runID uuid.UUID
+	messageCollector := NewMessageCollector(event.WorkflowID, logger)
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		lockedEvent, err := models.LockCanvasEvent(tx, event.ID)
 		if err != nil {
@@ -179,7 +182,7 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 			return nil
 		}
 
-		createdQueueItems, runID, err = w.processEvent(tx, logger, lockedEvent)
+		createdQueueItems, runID, err = w.processEvent(tx, logger, lockedEvent, messageCollector)
 		if err != nil {
 			outcome = executorOutcomeFailed
 			reason = classifyProcessError(err)
@@ -196,6 +199,8 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 	if outcome == executorOutcomeSkipped {
 		return nil
 	}
+
+	messageCollector.Publish()
 
 	if len(createdQueueItems) > 0 {
 		for _, queueItem := range createdQueueItems {
@@ -233,7 +238,12 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 	return nil
 }
 
-func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models.CanvasEvent) ([]models.CanvasNodeQueueItem, uuid.UUID, error) {
+func (w *EventRouter) processEvent(
+	tx *gorm.DB,
+	logger *log.Entry,
+	event *models.CanvasEvent,
+	collector *MessageCollector,
+) ([]models.CanvasNodeQueueItem, uuid.UUID, error) {
 	canvas, err := models.FindCanvasWithoutOrgScopeInTransaction(tx, event.WorkflowID)
 	if err != nil {
 		return nil, uuid.Nil, err
@@ -245,7 +255,7 @@ func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models
 	}
 
 	if event.ExecutionID == nil {
-		return w.processRootEvent(tx, canvas, liveEdges, event)
+		return w.processRootEvent(tx, canvas, liveEdges, event, collector)
 	}
 
 	execution, err := models.FindNodeExecutionInTransaction(tx, event.WorkflowID, *event.ExecutionID)
@@ -253,7 +263,7 @@ func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models
 		return nil, uuid.Nil, err
 	}
 
-	queueItems, err := w.processExecutionEvent(tx, logger, canvas, liveEdges, execution, event)
+	queueItems, err := w.processExecutionEvent(tx, logger, canvas, liveEdges, execution, event, collector)
 	return queueItems, execution.RunID, err
 }
 
@@ -268,7 +278,13 @@ func findOutgoingEdges(edges []models.Edge, sourceID string, channel string) []m
 	return matches
 }
 
-func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, edges []models.Edge, event *models.CanvasEvent) ([]models.CanvasNodeQueueItem, uuid.UUID, error) {
+func (w *EventRouter) processRootEvent(
+	tx *gorm.DB,
+	canvas *models.Canvas,
+	edges []models.Edge,
+	event *models.CanvasEvent,
+	collector *MessageCollector,
+) ([]models.CanvasNodeQueueItem, uuid.UUID, error) {
 	now := time.Now()
 
 	w.logger.Infof("Processing root event %s", event.ID)
@@ -303,6 +319,17 @@ func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, edges
 		}
 
 		if targetNode.State == models.CanvasNodeStateError {
+			if err := w.recordInvalidTargetExecution(
+				tx,
+				targetNode,
+				event.ID,
+				run.ID,
+				event,
+				collector,
+			); err != nil {
+				return nil, uuid.Nil, err
+			}
+
 			continue
 		}
 
@@ -337,6 +364,7 @@ func (w *EventRouter) processExecutionEvent(
 	edges []models.Edge,
 	execution *models.CanvasNodeExecution,
 	event *models.CanvasEvent,
+	collector *MessageCollector,
 ) ([]models.CanvasNodeQueueItem, error) {
 	run, err := models.FindCanvasRunInTransaction(tx, execution.WorkflowID, execution.RunID)
 	if err != nil {
@@ -364,6 +392,17 @@ func (w *EventRouter) processExecutionEvent(
 		}
 
 		if targetNode.State == models.CanvasNodeStateError {
+			if err := w.recordInvalidTargetExecution(
+				tx,
+				targetNode,
+				execution.RootEventID,
+				execution.RunID,
+				event,
+				collector,
+			); err != nil {
+				return nil, err
+			}
+
 			continue
 		}
 
@@ -388,4 +427,48 @@ func (w *EventRouter) processExecutionEvent(
 	}
 
 	return createdQueueItems, nil
+}
+
+func (w *EventRouter) recordInvalidTargetExecution(
+	tx *gorm.DB,
+	node *models.CanvasNode,
+	rootEventID uuid.UUID,
+	runID uuid.UUID,
+	event *models.CanvasEvent,
+	collector *MessageCollector,
+) error {
+	resultMessage := "node configuration is invalid"
+	if node.StateReason != nil && strings.TrimSpace(*node.StateReason) != "" {
+		resultMessage = *node.StateReason
+	}
+
+	now := time.Now()
+	execution := models.CanvasNodeExecution{
+		WorkflowID:          node.WorkflowID,
+		NodeID:              node.NodeID,
+		RootEventID:         rootEventID,
+		RunID:               runID,
+		EventID:             event.ID,
+		PreviousExecutionID: event.ExecutionID,
+		State:               models.CanvasNodeExecutionStateFinished,
+		Configuration:       node.Configuration,
+		Result:              models.CanvasNodeExecutionResultFailed,
+		ResultReason:        models.CanvasNodeExecutionResultReasonError,
+		ResultMessage:       resultMessage,
+		CreatedAt:           &now,
+		UpdatedAt:           &now,
+	}
+
+	if err := tx.Create(&execution).Error; err != nil {
+		return err
+	}
+
+	w.logger.WithFields(log.Fields{
+		"node_id":      node.NodeID,
+		"execution_id": execution.ID,
+	}).Warn("Recording failed execution for invalid target node")
+
+	contexts.DispatchOnError(tx, &execution, collector.OnNewEvents)
+	collector.AddExecutionID(&execution.ID)
+	return nil
 }

--- a/pkg/workers/event_router_test.go
+++ b/pkg/workers/event_router_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/triggers/onerror"
 	testconsumer "github.com/superplanehq/superplane/test/consumer"
 	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
 )
 
 func Test__EventRouter_ProcessRootEvent(t *testing.T) {
@@ -83,6 +85,171 @@ func Test__EventRouter_ProcessRootEvent(t *testing.T) {
 	assert.True(t, queueConsumer.HasReceivedMessage())
 	assert.True(t, runConsumer.HasReceivedMessage())
 	assert.False(t, terminalEventConsumer.HasReceivedMessage())
+}
+
+func Test__EventRouter_InvalidTargetFromRootEventCreatesFailedExecution(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	router := NewEventRouter(amqpURL)
+	logger := log.NewEntry(log.New())
+	r := support.Setup(t)
+	defer r.Close()
+
+	triggerNodeID := "trigger-1"
+	invalidNodeID := "invalid-component"
+	onErrorNodeID := "on-error"
+	stateReason := "field 'timeoutSeconds': must be a number"
+	configuration := map[string]any{"timeoutSeconds": "10"}
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: triggerNodeID, Type: models.NodeTypeTrigger},
+			{
+				NodeID:        invalidNodeID,
+				Name:          "Invalid HTTP Request",
+				Type:          models.NodeTypeComponent,
+				Configuration: datatypes.NewJSONType(configuration),
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "http"},
+				}),
+			},
+			{
+				NodeID: onErrorNodeID,
+				Name:   "On Error",
+				Type:   models.NodeTypeTrigger,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Trigger: &models.TriggerRef{Name: onerror.TriggerName},
+				}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNodeID, TargetID: invalidNodeID, Channel: "default"},
+		},
+	)
+	require.NoError(t, database.Conn().
+		Model(&models.CanvasNode{}).
+		Where("workflow_id = ? AND node_id = ?", canvas.ID, invalidNodeID).
+		Updates(map[string]any{
+			"state":        models.CanvasNodeStateError,
+			"state_reason": stateReason,
+		}).Error)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, triggerNodeID, "default", nil)
+	require.NoError(t, router.LockAndProcessEvent(logger, *event, time.Now()))
+
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, invalidNodeID, nil, nil, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, executions, 1)
+
+	execution := executions[0]
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, execution.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultFailed, execution.Result)
+	assert.Equal(t, models.CanvasNodeExecutionResultReasonError, execution.ResultReason)
+	assert.Equal(t, stateReason, execution.ResultMessage)
+	assert.Equal(t, configuration, execution.Configuration.Data())
+	assert.Equal(t, event.ID, execution.RootEventID)
+	assert.Equal(t, event.ID, execution.EventID)
+	assert.Nil(t, execution.PreviousExecutionID)
+
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, invalidNodeID, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, queueItems)
+
+	updatedEvent, err := models.FindCanvasEvent(event.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasEventStateRouted, updatedEvent.State)
+
+	onErrorEvents, err := models.ListCanvasEvents(database.Conn(), canvas.ID, onErrorNodeID, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, onErrorEvents, 1)
+
+	run, err := models.FindCanvasRunByRootEventInTransaction(database.Conn(), event.ID)
+	require.NoError(t, err)
+	require.NoError(t, NewRunFinalizer(amqpURL, r.Registry).finalizeRun(canvas.ID, run.ID, runFinalizerTriggerEventTerminal))
+
+	updatedRun, err := models.FindCanvasRunByRootEventInTransaction(database.Conn(), event.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateFinished, updatedRun.State)
+	assert.Equal(t, models.CanvasRunResultFailed, updatedRun.Result)
+}
+
+func Test__EventRouter_InvalidTargetFromExecutionEventCreatesFailedExecution(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	router := NewEventRouter(amqpURL)
+	logger := log.NewEntry(log.New())
+	r := support.Setup(t)
+	defer r.Close()
+
+	triggerNodeID := "trigger-1"
+	sourceNodeID := "component-1"
+	invalidNodeID := "invalid-component"
+	stateReason := "integration is not configured"
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: triggerNodeID, Type: models.NodeTypeTrigger},
+			{NodeID: sourceNodeID, Type: models.NodeTypeComponent},
+			{
+				NodeID: invalidNodeID,
+				Type:   models.NodeTypeComponent,
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNodeID, TargetID: sourceNodeID, Channel: "default"},
+			{SourceID: sourceNodeID, TargetID: invalidNodeID, Channel: "default"},
+		},
+	)
+	require.NoError(t, database.Conn().
+		Model(&models.CanvasNode{}).
+		Where("workflow_id = ? AND node_id = ?", canvas.ID, invalidNodeID).
+		Updates(map[string]any{
+			"state":        models.CanvasNodeStateError,
+			"state_reason": stateReason,
+		}).Error)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNodeID, "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(database.Conn(), rootEvent)
+	require.NoError(t, err)
+	require.NoError(t, rootEvent.Routed())
+
+	previousExecution := support.CreateCanvasNodeExecution(t, canvas.ID, sourceNodeID, rootEvent.ID, rootEvent.ID)
+	previousExecution.RunID = run.ID
+	require.NoError(t, database.Conn().Save(previousExecution).Error)
+	_, err = previousExecution.Pass(map[string][]any{"default": {map[string]any{"ok": true}}})
+	require.NoError(t, err)
+
+	events, err := models.ListCanvasEvents(database.Conn(), canvas.ID, sourceNodeID, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	outputEvent := events[0]
+
+	require.NoError(t, router.LockAndProcessEvent(logger, outputEvent, time.Now()))
+
+	executions, err := models.ListNodeExecutions(database.Conn(), canvas.ID, invalidNodeID, nil, nil, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, executions, 1)
+
+	execution := executions[0]
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, execution.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultFailed, execution.Result)
+	assert.Equal(t, models.CanvasNodeExecutionResultReasonError, execution.ResultReason)
+	assert.Equal(t, stateReason, execution.ResultMessage)
+	assert.Equal(t, rootEvent.ID, execution.RootEventID)
+	assert.Equal(t, run.ID, execution.RunID)
+	assert.Equal(t, outputEvent.ID, execution.EventID)
+	require.NotNil(t, execution.PreviousExecutionID)
+	assert.Equal(t, previousExecution.ID, *execution.PreviousExecutionID)
+
+	queueItems, err := models.ListNodeQueueItems(database.Conn(), canvas.ID, invalidNodeID, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, queueItems)
 }
 
 func Test__EventRouter_DoesNotRouteEventForSoftDeletedOrganization(t *testing.T) {


### PR DESCRIPTION
Closes #4440.

## What changed

- Record a finished, failed execution when an event reaches a node whose configuration is invalid.
- Preserve the run, root event, input event, previous execution, configuration, and node validation message on that execution.
- Publish the execution state after the routing transaction commits.
- Dispatch the standard `On Error` trigger path for the recorded failure.
- Continue routing valid sibling branches while leaving the invalid node out of the execution queue.

## Why

The event router previously skipped targets in `CanvasNodeStateError`. The input event was marked as routed, but the invalid node never appeared in the execution trace. A run could therefore stop without explaining which node rejected the event or why.

This change makes that terminal condition durable and visible. Runs whose only target is invalid can finalize as failed, and users can see the node's validation error in the run inspector.

The change deliberately does not emit a component-specific failure channel. Invalid nodes have not started their component implementation, so they use the canvas-wide `On Error` mechanism instead.

## Testing

- `go test ./pkg/workers -run 'Test__EventRouter_InvalidTarget' -count=1`
- `go test -race ./pkg/workers -run 'Test__EventRouter_InvalidTarget' -count=1`
- `go test ./pkg/workers/... -run '^$'`
- `go vet ./pkg/workers/...`

Regression coverage includes both root-trigger routing and downstream execution-event routing, run finalization, `On Error` dispatch, event linkage, preserved configuration/error details, and absence of queue items for invalid nodes.
