### PR TITLE
fix: number field snaps back to default instead of allowing clear-and…

### DIFF
--- a/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.spec.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ConfigurationField } from "@/api-client";
+import { NumberFieldRenderer } from "./NumberFieldRenderer";
+
+function createNumberField(defaultValue?: string): ConfigurationField {
+  return {
+    name: "minutesBetweenTriggers",
+    label: "Minutes between triggers",
+    type: "number",
+    defaultValue,
+  };
+}
+
+describe("NumberFieldRenderer", () => {
+  it("initializes onChange with the default value once, on mount, when value is undefined", () => {
+    const handleChange = vi.fn();
+
+    const { rerender } = render(
+      <NumberFieldRenderer field={createNumberField("1")} value={undefined} onChange={handleChange} />,
+    );
+
+    // The component signals the resolved default to its (controlling) parent...
+    expect(handleChange).toHaveBeenCalledWith(1);
+
+    // ...and once the parent feeds that value back down as a prop, it's displayed.
+    rerender(<NumberFieldRenderer field={createNumberField("1")} value={1} onChange={handleChange} />);
+    expect(screen.getByRole("spinbutton")).toHaveValue(1);
+  });
+
+  it("renders empty when both value and default value are absent", () => {
+    render(<NumberFieldRenderer field={createNumberField()} value={undefined} onChange={vi.fn()} />);
+
+    expect(screen.getByRole("spinbutton")).toHaveValue(null);
+  });
+
+  it("allows clearing the field and typing a new value without snapping back to the default", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    const { rerender } = render(
+      <NumberFieldRenderer field={createNumberField("1")} value={1} onChange={handleChange} />,
+    );
+
+    const input = screen.getByRole("spinbutton");
+    await user.clear(input);
+
+    // Clearing must emit undefined, not silently re-apply the default.
+    expect(handleChange).toHaveBeenLastCalledWith(undefined);
+
+    // Once the parent re-renders with the now-undefined value, the field
+    // must stay empty (not snap back to the default) so the user can type.
+    rerender(<NumberFieldRenderer field={createNumberField("1")} value={undefined} onChange={handleChange} />);
+    expect(screen.getByRole("spinbutton")).toHaveValue(null);
+
+    await user.type(input, "5");
+
+    expect(handleChange).toHaveBeenLastCalledWith(5);
+  });
+
+  it("does not re-apply the default value on every render once initialized", () => {
+    const handleChange = vi.fn();
+
+    const { rerender } = render(
+      <NumberFieldRenderer field={createNumberField("1")} value={undefined} onChange={handleChange} />,
+    );
+
+    // Initial mount is allowed to apply the default once.
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    handleChange.mockClear();
+
+    // A later render with value still undefined (e.g. after the user cleared
+    // the field) must NOT re-trigger the default-value initialization.
+    rerender(<NumberFieldRenderer field={createNumberField("1")} value={undefined} onChange={handleChange} />);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/NumberFieldRenderer.tsx
@@ -1,24 +1,36 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import type { FieldRendererProps } from "./types";
 
 export const NumberFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange }) => {
   const numberOptions = field.typeOptions?.number;
+  const hasInitialized = useRef(false);
 
-  // Set initial value on first render if no value is present but there's a default
+  // Apply the default value once, on mount, if no value has been set yet.
+  // We deliberately only run this once (guarded by the ref) instead of on
+  // every render where `value` is undefined: without the guard, clearing the
+  // input emits onChange(undefined), which re-triggers this effect and
+  // immediately re-applies the default, so the field snaps back before the
+  // user can type a replacement value.
   useEffect(() => {
+    if (hasInitialized.current) {
+      return;
+    }
+    hasInitialized.current = true;
+
     if ((value === undefined || value === null) && field.defaultValue !== undefined) {
       const defaultVal = Number(field.defaultValue);
       if (!isNaN(defaultVal)) {
         onChange(defaultVal);
       }
     }
-  }, [value, field.defaultValue, onChange]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Input
       type="number"
-      value={(value as string | number) ?? (field.defaultValue as string) ?? ""}
+      value={(value as string | number) ?? ""}
       onChange={(e) => {
         const val = e.target.value === "" ? undefined : Number(e.target.value);
         onChange(val);


### PR DESCRIPTION
…-retype

Number configuration fields could not be cleared and retyped: deleting the current value immediately reverted the field to its default, leaving the spinner arrows as the only way to change it.

Root cause was two-fold in NumberFieldRenderer:
- the default-initialization useEffect ran on every render where `value` was undefined (including right after the user cleared the field, which emits onChange(undefined)), re-applying the default.
- the controlled input's displayed value also fell back to field.defaultValue whenever value was undefined, compounding the snap-back even before the effect fired.

Fix: only apply the default value once, on mount, guarded by a ref instead of the value dependency; and stop falling back to defaultValue in the displayed value, so an explicit clear is shown as an empty field rather than the default.

Closes #6399