### PR TITLE
fix: keep canvas log console clear of the open right panel (#6472)

### DIFF
--- a/web_src/src/ui/CanvasLogSidebar/index.tsx
+++ b/web_src/src/ui/CanvasLogSidebar/index.tsx
@@ -33,6 +33,7 @@ export interface LogCounts {
 export interface CanvasLogSidebarProps {
   isOpen: boolean;
   onClose: () => void;
+  rightOffset?: number;
   height?: number;
   defaultHeight?: number;
   minHeight?: number;
@@ -74,6 +75,7 @@ function formatLogTimestamp(value: string) {
 export function CanvasLogSidebar({
   isOpen,
   onClose,
+  rightOffset = 0,
   height,
   defaultHeight = 320,
   minHeight = 240,
@@ -235,7 +237,10 @@ export function CanvasLogSidebar({
   const searchPlaceholder = activeTab === "errors" ? "Search errors…" : "Search warnings…";
 
   return (
-    <aside className="ph-no-capture absolute left-0 right-0 bottom-0 z-31 pointer-events-auto">
+    <aside
+      className="ph-no-capture absolute left-0 bottom-0 z-31 pointer-events-auto"
+      style={{ right: rightOffset }}
+    >
       <div
         className={cn("flex flex-col border-t bg-white dark:bg-gray-900", appDarkModeClasses.sidebarEdge)}
         style={{ height: sidebarHeight, minHeight, maxHeight }}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -808,6 +808,7 @@ function CanvasPage(props: CanvasPageProps) {
   const state = useCanvasState(props);
   const readOnly = props.readOnly ?? false;
   const workflowHeaderMode = normalizeCanvasHeaderMode(props.headerMode);
+  const rightPanelWidth = useSidebarLayoutStore((sidebarState) => sidebarState.rightWidth);
   const [currentTab, setCurrentTab] = useState<"latest" | "settings" | "docs">(() =>
     props.canvasStateMode === "editing" ? "settings" : "latest",
   );
@@ -1384,6 +1385,17 @@ function CanvasPage(props: CanvasPageProps) {
     ],
   );
 
+  // The bottom log console is absolutely positioned across the full canvas width;
+  // offset it by the open right panel's width so it stops beside the panel
+  // instead of sliding underneath it (see #6472).
+  const isRightPanelOpenForLog =
+    (isComponentSidebarVisibleMode(props.headerMode) &&
+      !props.isRunInspectionMode &&
+      !!props.isEditing &&
+      state.componentSidebar.isOpen) ||
+    (!props.hideAddControls && isBuildingBlocksSidebarOpen && !!props.isEditing && allowsBuildingBlocksSidebar(workflowHeaderMode));
+  const logSidebarRightOffset = isRightPanelOpenForLog ? rightPanelWidth : 0;
+
   return (
     <div
       ref={canvasWrapperRef}
@@ -1585,6 +1597,7 @@ function CanvasPage(props: CanvasPageProps) {
                   missingIntegrations={props.missingIntegrations}
                   onConnectIntegration={props.onConnectIntegration}
                   canCreateIntegrations={props.canCreateIntegrations}
+                  logSidebarRightOffset={logSidebarRightOffset}
                 />
               </ReactFlowProvider>
             )}
@@ -2204,6 +2217,7 @@ function CanvasContent({
   missingIntegrations,
   onConnectIntegration,
   canCreateIntegrations,
+  logSidebarRightOffset = 0,
 }: {
   state: CanvasPageState;
   onNodeDelete?: (nodeId: string) => void;
@@ -2260,6 +2274,7 @@ function CanvasContent({
   missingIntegrations?: MissingIntegration[];
   onConnectIntegration?: (integrationName: string) => void;
   canCreateIntegrations?: boolean;
+  logSidebarRightOffset?: number;
 }) {
   const { fitView, screenToFlowPosition, getViewport, getInternalNode, getNodes, setViewport } = useReactFlow();
   const { zoom } = useViewport();
@@ -3517,6 +3532,7 @@ function CanvasContent({
         <CanvasLogSidebar
           isOpen={isLogSidebarOpen}
           onClose={() => setIsLogSidebarOpen(false)}
+          rightOffset={logSidebarRightOffset}
           height={logSidebarHeight}
           onHeightChange={setLogSidebarHeight}
           searchValue={logSearch}


### PR DESCRIPTION
## Summary
Fixes #6472 — opening the bottom errors/warnings log console while the node inspector or building-blocks panel was open caused the log to cover the panel instead of stopping beside it, since the log console was absolutely positioned edge-to-edge (`left-0 right-0`).

- `CanvasLogSidebar` now accepts an optional `rightOffset` prop, applied as an inline `right` style instead of the hardcoded `right-0` class.
- `CanvasPage` computes this offset from the existing sidebar layout store's `rightWidth` whenever the node inspector or building-blocks panel is open, and threads it down through `CanvasContent`.

## Test plan
- [x] `tsc -b` passes with no type errors
- [x] Verified via a temporary Storybook story with a mock right panel: log console now stops at the panel's left edge instead of covering it (screenshot-verified before/after, story removed before commit)
- [x] No regression on the default case (no panel open, log still spans full width)