### PR TITLE
fix: prevent duplicate edges between the same nodes

### DIFF
--- a/pkg/grpc/actions/canvases/commit_canvas_staging_test.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_staging_test.go
@@ -2,6 +2,7 @@ package canvases
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -87,6 +88,45 @@ func Test__CommitCanvasStaging__RejectsInvalidConsoleYAML(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, code)
 	assert.Contains(t, msg, "invalid console yaml")
+}
+
+func Test__CommitCanvasStaging__RejectsDuplicateEdges(t *testing.T) {
+	r, ctx, canvas, _ := setupLiveCanvasStaging(t)
+
+	staged := `apiVersion: v1
+kind: Canvas
+metadata:
+  name: ` + canvas.Name + `
+spec:
+  nodes:
+    - id: node-1
+      name: Source
+      type: TYPE_ACTION
+      component: http
+    - id: node-2
+      name: Target
+      type: TYPE_ACTION
+      component: noop
+  edges:
+    - sourceId: node-1
+      targetId: node-2
+      channel: success
+    - sourceId: node-1
+      targetId: node-2
+      channel: success
+`
+
+	_, err := PutCanvasStaging(ctx, database.DB(t.Context()), canvas, []*pb.CanvasRepositoryFileOperation{
+		{Path: CanvasYAMLRepositoryPath, Content: []byte(staged)},
+	})
+	require.NoError(t, err)
+
+	_, err = CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Duplicate edges", "", r.AuthService)
+	code, msg, ok := grpcerrors.HandlerStatus(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, code)
+	assert.Contains(t, msg, "invalid canvas yaml")
+	assert.Contains(t, errors.Unwrap(err).Error(), "duplicate edge from node-1 to node-2 on channel success")
 }
 
 func Test__CommitCanvasStaging__RequiresStagedChanges(t *testing.T) {

--- a/pkg/yaml/canvas.go
+++ b/pkg/yaml/canvas.go
@@ -377,6 +377,8 @@ func (c *Canvas) Parse(registry *registry.Registry, orgID string) ([]models.Node
 	//
 	// Validate edges
 	//
+	edgeKeys := make(map[string]bool)
+
 	for i, edge := range c.Spec.Edges {
 		if edge.SourceID == "" || edge.TargetID == "" {
 			return nil, nil, fmt.Errorf("edge %d: source and target are required", i)
@@ -401,6 +403,15 @@ func (c *Canvas) Parse(registry *registry.Registry, orgID string) ([]models.Node
 		if nodeTypeByID[edge.TargetID] == NodeTypeWidget {
 			return nil, nil, fmt.Errorf("edge %d: widget nodes cannot be used as target nodes", i)
 		}
+
+		edgeKey := edge.SourceID + "|" + edge.TargetID + "|" + c.Spec.Edges[i].Channel
+		if edgeKeys[edgeKey] {
+			return nil, nil, fmt.Errorf(
+				"edge %d: duplicate edge from %s to %s on channel %s",
+				i, edge.SourceID, edge.TargetID, c.Spec.Edges[i].Channel,
+			)
+		}
+		edgeKeys[edgeKey] = true
 
 		if err := changesets.ValidateSourceNodeOutputChannel(
 			registry,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -164,6 +164,7 @@ import { syncRunInspectionViewportTransition } from "./lib/run-inspection-viewpo
 import {
   clearRunDetailNodeSearchParams,
   buildCanvasLogEntries,
+  edgeExists,
   getCanvasLogNodesSignature,
   getNodeAnalyticsProps,
   getRunningRunsCount,
@@ -2705,11 +2706,15 @@ export function AppPage() {
 
       // Save snapshot before making changes
 
+      const channel = sourceHandle || "default";
+
+      if (edgeExists(canvas.spec?.edges, sourceId, targetId, channel)) return;
+
       // Create the new edge
       const newEdge: ComponentsEdge = {
         sourceId,
         targetId,
-        channel: sourceHandle || "default",
+        channel,
       };
 
       analytics.edgeCreate(organizationId);

--- a/web_src/src/pages/app/workflowPageHelpers.spec.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   NO_INCOMING_CONNECTIONS_WARNING,
   clearRunDetailNodeSearchParams,
+  edgeExists,
   isValidRunId,
   prepareCanvasLogNodes,
   shouldClearRunDetailNode,
@@ -235,5 +236,29 @@ describe("prepareCanvasLogNodes", () => {
     );
 
     expect(logNodes).toEqual([source, target]);
+  });
+});
+
+describe("edgeExists", () => {
+  const edges = [
+    makeEdge({ sourceId: "source", targetId: "target", channel: "success" }),
+    makeEdge({ sourceId: "source", targetId: "other", channel: "default" }),
+  ];
+
+  it("detects an already connected source, target and channel", () => {
+    expect(edgeExists(edges, "source", "target", "success")).toBe(true);
+  });
+
+  it("allows the same nodes on a different channel", () => {
+    expect(edgeExists(edges, "source", "target", "failure")).toBe(false);
+  });
+
+  it("allows a new target", () => {
+    expect(edgeExists(edges, "source", "new-target", "success")).toBe(false);
+  });
+
+  it("treats a canvas without edges as unconnected", () => {
+    expect(edgeExists(undefined, "source", "target", "default")).toBe(false);
+    expect(edgeExists([], "source", "target", "default")).toBe(false);
   });
 });

--- a/web_src/src/pages/app/workflowPageHelpers.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.ts
@@ -293,6 +293,17 @@ export function prepareEdge(edge: ComponentsEdge): CanvasEdge {
   };
 }
 
+export function edgeExists(
+  edges: ComponentsEdge[] | undefined,
+  sourceId: string,
+  targetId: string,
+  channel: string,
+): boolean {
+  return (edges || []).some(
+    (edge) => edge.sourceId === sourceId && edge.targetId === targetId && edge.channel === channel,
+  );
+}
+
 export function prepareSidebarData(
   node: ComponentsNode,
   nodes: ComponentsNode[],


### PR DESCRIPTION
## Summary

- Connecting two nodes that are already connected on the same channel creates a second, identical edge.
- Edges are keyed by source/target/channel, so the duplicate is invisible: it renders on top of the original, and deleting the connection removes both at once.
- The event router fans out one execution per matching outgoing edge, so the duplicate runs the target node twice for every source event — double deploys, double notifications, doubled runner minutes.

Repro on `main`: connect A → B, then drag the same two handles again. Nothing appears to change (only a React duplicate-key warning in the console), but the committed spec now holds two identical edges and one trigger produces two executions ~50ms apart.

## How

- `handleEdgeCreate` skips the connection when the edge already exists, so reconnecting the same handles is a no-op.
- `Canvas.Parse` rejects duplicate edges, alongside the existing duplicate-node-id check, so the API, CLI and agent paths can't introduce them either. Omitted and explicit `default` channels are compared after normalization.

The changeset patcher was already safe here — it stores edges in a map keyed by source/target/channel — so only the YAML path needed the guard.

## Test plan

- [x] `make test PKG_TEST_PACKAGES="./pkg/yaml ./pkg/grpc/actions/canvases/..."`
- [x] UI unit tests for the new `edgeExists` helper
- [x] Manually: reconnecting the same handles no longer stages a change; one trigger click produces one execution (two before)
