### PR TITLE
fix: accept lowercase day and month names in cron validation

### DIFF
--- a/web_src/src/lib/components.spec.ts
+++ b/web_src/src/lib/components.spec.ts
@@ -141,6 +141,40 @@ describe("components value parsing and validation", () => {
     ).toEqual(["Value must not exceed 4"]);
   });
 
+  it("accepts day and month names in either case", () => {
+    // Cron names are case-insensitive for the backend validator
+    // (pkg/configuration/validation.go allows a-z as well as A-Z) and for the
+    // next-run preview in lib/cron.ts, which upper-cases before lookup. The
+    // submission validator has to agree, or a lowercase schedule the server
+    // would happily accept is blocked in the form.
+    const cronField = buildField({ type: "cron" });
+
+    for (const expression of [
+      "0 0 * * mon",
+      "0 0 * * MON",
+      "0 0 * * mon-fri",
+      "0 0 * * sun,sat",
+      "0 0 * jan *",
+      "0 0 * Feb *",
+    ]) {
+      expect(validateFieldForSubmission(cronField, expression)).toEqual([]);
+    }
+  });
+
+  it("still rejects characters that are not valid in a cron expression", () => {
+    const cronField = buildField({ type: "cron" });
+
+    expect(validateFieldForSubmission(cronField, "0 0 * * mon;fri")).toEqual([
+      "Invalid characters. Use only: numbers, *, ,, -, / and day names",
+    ]);
+    expect(validateFieldForSubmission(cronField, "0 0 * * @mon")).toEqual([
+      "Invalid characters. Use only: numbers, *, ,, -, / and day names",
+    ]);
+    expect(validateFieldForSubmission(cronField, "0 0 * * mon_fri")).toEqual([
+      "Invalid characters. Use only: numbers, *, ,, -, / and day names",
+    ]);
+  });
+
   it("parses default values according to field type", () => {
     expect(
       parseDefaultValues([

--- a/web_src/src/lib/components.ts
+++ b/web_src/src/lib/components.ts
@@ -26,8 +26,10 @@ function validateCronExpression(cronExpression: string): string | null {
     return `Expected 5 or 6 fields, got ${parts.length}`;
   }
 
-  // Quick validation with pre-compiled regex for better performance
-  const validChars = /^[0-9*,\-/A-Z]+$/;
+  // Quick validation with pre-compiled regex for better performance.
+  // Day and month names are case-insensitive, matching the backend validator
+  // (pkg/configuration/validation.go) and the preview parser in lib/cron.ts.
+  const validChars = /^[0-9*,\-/a-zA-Z]+$/;
 
   // Use a more efficient approach - validate only the problematic parts
   for (let i = 0; i < parts.length; i++) {


### PR DESCRIPTION
### What's wrong

The cron field in the configuration form rejects lowercase day and month names. `0 0 * * mon` fails validation with *"Invalid characters. Use only: numbers, \*, ,, -, / and day names"*, while `0 0 * * MON` is accepted. The message points at day names while refusing one, so it reads like the user made a typo rather than hit a validator limitation.

### Why it's wrong

Lowercase names are valid everywhere else in the stack:

- `validChars` in `pkg/configuration/validation.go` includes `abcdefghijklmnopqrstuvwxyz` as well as the uppercase range, and `robfig/cron` parses day and month names case-insensitively.
- The next-run preview in `web_src/src/lib/cron.ts` upper-cases the field before looking it up, so it already resolves `mon` correctly.

So the form is the only place saying no — it blocks a schedule the server would accept and the UI's own preview can already parse.

I checked each case against the backend validator rather than assuming:

| expression | backend `validateCron` | form (before) |
| --- | --- | --- |
| `0 0 * * MON` | valid | accepted |
| `0 0 * * mon` | valid | rejected |
| `0 0 * * mon-fri` | valid | rejected |
| `0 0 * jan *` | valid | rejected |
| `0 0 * * sun,sat` | valid | rejected |

Worth noting the backend rejects `@daily` and `?` too (they aren't in its `validChars`), so those stay rejected here — this isn't a general loosening of the rules.

### The change

Widened the character class in `validateCronExpression` from `A-Z` to `a-zA-Z`, which is the same set the backend allows. Nothing else changes: the field-count check, the range checks, and rejection of characters like `@`, `?` and `;` all behave exactly as before.

### Tests

Added two cases to `components.spec.ts` covering both directions — the lowercase expressions above now validate, and invalid characters are still rejected. I confirmed the first test fails against the old regex, so it's a real regression test.

`npx vitest run src/lib` passes (229 tests), and prettier is clean.
