### PR TITLE
fix: make weeks schedule fire on all selected weekdays

### DIFF
--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -731,16 +731,28 @@ func nextWeeksTrigger(interval int, weekDays []string, hour int, minute int, now
 		validWeekdays[weekday] = true
 	}
 
-	nextIntervalStart := nowInTZ.AddDate(0, 0, interval*7)
+	// Walk forward from the week that contains `now`, one active week at a time
+	// (an active week every `interval` weeks), and return the first selected
+	// weekday whose trigger time is strictly after `now`. Scanning the current
+	// week first is what lets the schedule fire on every selected weekday rather
+	// than only the first one. https://github.com/superplanehq/superplane/issues/6514
+	weekStart := time.Date(nowInTZ.Year(), nowInTZ.Month(), nowInTZ.Day(), 0, 0, 0, 0, nowInTZ.Location())
+	weekStart = weekStart.AddDate(0, 0, -int(weekStart.Weekday())) // back up to the Sunday that opens the week
 
-	// start the search on Sunday of the next week
-	nextIntervalStart.Add(-time.Duration(nextIntervalStart.Weekday()) * time.Hour)
-	for i := 0; i < 7; i++ {
-		checkDate := nextIntervalStart.AddDate(0, 0, i)
-		if validWeekdays[checkDate.Weekday()] {
-			candidateTime := time.Date(checkDate.Year(), checkDate.Month(), checkDate.Day(), hour, minute, 0, 0, checkDate.Location())
-			utcResult := candidateTime.UTC()
-			return &utcResult, nil
+	// interval is at most 52, so a matching weekday is always found within the
+	// current week or the next active one; the bound is just a safety net.
+	for weekOffset := 0; weekOffset <= 104; weekOffset += interval {
+		weekStartDay := weekStart.AddDate(0, 0, weekOffset*7)
+		for i := 0; i < 7; i++ {
+			day := weekStartDay.AddDate(0, 0, i)
+			if !validWeekdays[day.Weekday()] {
+				continue
+			}
+			candidate := time.Date(day.Year(), day.Month(), day.Day(), hour, minute, 0, 0, nowInTZ.Location())
+			if candidate.After(nowInTZ) {
+				utcResult := candidate.UTC()
+				return &utcResult, nil
+			}
 		}
 	}
 

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -145,7 +145,7 @@ func TestGetNextTrigger(t *testing.T) {
 				Minute:        intPtr(30),
 			},
 			now:        mustParseTime("2025-01-06T10:00:00Z"), // Monday
-			expectNext: mustParseTime("2025-01-17T15:30:00Z"), // Friday of next week
+			expectNext: mustParseTime("2025-01-10T15:30:00Z"), // Friday of the same week
 		},
 		{
 			name: "months configuration",
@@ -387,7 +387,7 @@ func TestTimezoneHandling(t *testing.T) {
 				Timezone:      stringPtr("-8"), // GMT-8 (PST)
 			},
 			now:        mustParseTime("2025-01-06T16:00:00Z"), // Monday 8 AM PST (4 PM UTC)
-			expectNext: mustParseTime("2025-01-13T17:00:00Z"), // Monday 9 AM PST (5 PM UTC) of the next week
+			expectNext: mustParseTime("2025-01-06T17:00:00Z"), // Monday 9 AM PST (5 PM UTC), later the same day
 		},
 		{
 			name: "month schedule in GMT+9 timezone (JST)",
@@ -648,5 +648,86 @@ func TestHandleHookRun(t *testing.T) {
 
 	if eventCtx.Payloads[0].Type != "scheduler.tick" {
 		t.Errorf("expected payload type to be scheduler.tick, got %q", eventCtx.Payloads[0].Type)
+	}
+}
+
+// A weekly schedule configured with several weekdays must fire on every one of
+// them, not just the first. Walking a full week (Mon -> Wed -> Fri -> next Mon)
+// with weekDays=[monday, wednesday, friday] should visit each selected day in
+// turn. See https://github.com/superplanehq/superplane/issues/6514
+func TestNextWeeksTriggerFiresOnAllSelectedWeekdays(t *testing.T) {
+	weekDays := []string{"monday", "wednesday", "friday"}
+
+	tests := []struct {
+		name       string
+		now        time.Time
+		expectNext time.Time
+	}{
+		{
+			name:       "after Monday's run, next is Wednesday of the same week",
+			now:        mustParseTime("2025-01-06T10:00:00Z"), // Monday, after the 09:00 run
+			expectNext: mustParseTime("2025-01-08T09:00:00Z"), // Wednesday
+		},
+		{
+			name:       "after Wednesday's run, next is Friday of the same week",
+			now:        mustParseTime("2025-01-08T10:00:00Z"), // Wednesday, after the 09:00 run
+			expectNext: mustParseTime("2025-01-10T09:00:00Z"), // Friday
+		},
+		{
+			name:       "after Friday's run, next is Monday of the following week",
+			now:        mustParseTime("2025-01-10T10:00:00Z"), // Friday, after the 09:00 run
+			expectNext: mustParseTime("2025-01-13T09:00:00Z"), // next Monday
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := nextWeeksTrigger(1, weekDays, 9, 0, tt.now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !result.Equal(tt.expectNext) {
+				t.Errorf("expected next trigger at %v, got %v", tt.expectNext, result.UTC())
+			}
+		})
+	}
+}
+
+// With an interval greater than 1 the schedule still fires on each selected
+// weekday within an active week, then skips the inactive weeks. Here, every two
+// weeks on [monday, wednesday]: both days of the active week fire, then it jumps
+// straight to the next active week two weeks later.
+func TestNextWeeksTriggerRespectsInterval(t *testing.T) {
+	weekDays := []string{"monday", "wednesday"}
+
+	tests := []struct {
+		name       string
+		now        time.Time
+		expectNext time.Time
+	}{
+		{
+			name:       "Monday's run is followed by Wednesday of the same active week",
+			now:        mustParseTime("2025-01-06T09:00:00Z"), // Monday, right at the run
+			expectNext: mustParseTime("2025-01-08T09:00:00Z"), // Wednesday, same week
+		},
+		{
+			name:       "after the active week, it jumps two weeks ahead",
+			now:        mustParseTime("2025-01-08T09:00:00Z"), // Wednesday, right at the run
+			expectNext: mustParseTime("2025-01-20T09:00:00Z"), // Monday, two weeks later (week skipped)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := nextWeeksTrigger(2, weekDays, 9, 0, tt.now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !result.Equal(tt.expectNext) {
+				t.Errorf("expected next trigger at %v, got %v", tt.expectNext, result.UTC())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

A weekly schedule configured with several weekdays only ever fired on **one** of them. `weekDays: [monday, wednesday, friday]` triggered on Mondays only — the other selected days never fired.

## Why

`nextWeeksTrigger` jumped `interval * 7` days ahead *before* looking for a matching weekday, then returned the first selected weekday in that target week. Because the next trigger is recomputed from the time it just fired, it always landed back on the earliest selected weekday and skipped the rest.

Two smaller bugs lived in the same block:

- The "start the search on Sunday" line called `nextIntervalStart.Add(...)` but discarded the result — `time.Time` is immutable, so the line was a no-op.
- That same line multiplied by `time.Hour` where it meant days.

## How

Reworked `nextWeeksTrigger` to walk forward from the week that contains `now`, one active week at a time (an active week every `interval` weeks), and return the first selected weekday whose trigger time is strictly *after* `now`. Scanning the current week first is what lets the schedule fire on every selected weekday. This also makes weeks consistent with the hours/days triggers, which already fire at the next eligible slot instead of always skipping a full interval.

## Testing

- Added `TestNextWeeksTriggerFiresOnAllSelectedWeekdays` — walks a full week (Mon → Wed → Fri → next Mon) with `weekDays=[monday, wednesday, friday]`.
- Added `TestNextWeeksTriggerRespectsInterval` — an every-two-weeks schedule fires each selected day of the active week, then skips the inactive week.
- Updated two existing tests that encoded the old "always skip a week" behavior to expect the next eligible weekday.
- `go test ./pkg/triggers/schedule/...` passes; `gofmt -s` and `go vet` are clean.

Closes #6514
