### PR TITLE
fix: keep canvas log console from covering the right sidebar

### DIFF
--- a/web_src/src/ui/CanvasLogSidebar/index.tsx
+++ b/web_src/src/ui/CanvasLogSidebar/index.tsx
@@ -8,6 +8,7 @@ import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
 import { countUnacknowledgedErrors } from "@/pages/app/lib/canvas-runs";
 import { ErrorsConsoleContent } from "@/pages/app/ErrorsConsoleContent";
+import { useSidebarLayoutStore } from "@/stores/sidebarLayoutStore";
 
 export type ConsoleTab = "errors" | "warnings";
 export type LogEntryType = "success" | "error" | "warning" | "resolved-error";
@@ -92,6 +93,14 @@ export function CanvasLogSidebar({
   onRunExecutionSelect,
   onAcknowledgeErrors,
 }: CanvasLogSidebarProps) {
+  // Inset the log console from the right so it doesn't slide under the
+  // component/building-blocks sidebar when one is open — those sidebars are
+  // absolutely positioned on top of it (see ui/CanvasPage/index.tsx) and
+  // resize independently via this same shared store.
+  const rightSidebarWidth = useSidebarLayoutStore((state) => state.rightWidth);
+  const isRightSidebarMounted = useSidebarLayoutStore((state) => state.rightMountCount > 0);
+  const rightInset = isRightSidebarMounted ? rightSidebarWidth : 0;
+
   const [internalTab, setInternalTab] = useState<ConsoleTab>("errors");
   const activeTab = controlledTab ?? internalTab;
   const setActiveTab = useCallback(
@@ -235,7 +244,10 @@ export function CanvasLogSidebar({
   const searchPlaceholder = activeTab === "errors" ? "Search errors…" : "Search warnings…";
 
   return (
-    <aside className="ph-no-capture absolute left-0 right-0 bottom-0 z-31 pointer-events-auto">
+    <aside
+      className="ph-no-capture absolute left-0 bottom-0 z-31 pointer-events-auto"
+      style={{ right: rightInset }}
+    >
       <div
         className={cn("flex flex-col border-t bg-white dark:bg-gray-900", appDarkModeClasses.sidebarEdge)}
         style={{ height: sidebarHeight, minHeight, maxHeight }}


### PR DESCRIPTION
## Summary
- `CanvasLogSidebar` (the bottom errors/warnings console) was absolutely positioned with `left-0 right-0`, so it always spanned the full canvas width.
- When the component sidebar or building-blocks sidebar is open on the right, the log console slides underneath it and hides its lower portion (#6472).
- Both right sidebars already publish their width and open/closed state through the shared `useSidebarLayoutStore` (`rightWidth` / `rightMountCount`). This reads that same state in `CanvasLogSidebar` and insets its right edge accordingly when a sidebar is mounted.

## Test plan
- [x] Read through `ui/CanvasPage/index.tsx`, `ui/componentSidebar/index.tsx`, and `ui/BuildingBlocksSidebar/index.tsx` to confirm both right sidebars already source their width from `useSidebarLayoutStore` the same way this PR reads it.
- [ ] Not yet visually verified in a running instance — I don't have the Docker dev stack set up locally. Happy to add a screenshot/recording if a maintainer can point me to a quick way to check, or if this needs adjustment once run.

Fixes #6472