### PR TITLE
docs: clarify Windows/WSL2 setup in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ There are many ways to contribute to SuperPlane:
 Getting started with SuperPlane development is fast. It only takes a couple of
 minutes to set up your local development environment!
 
-### Pre-requisites
+### Prerequisites
 
 The complete development is done inside of Docker, so you don't need any
 programming languages, databases, or other dependencies installed directly on
@@ -32,9 +32,14 @@ your machine. Everything runs in containers managed by Make and Docker.
 
 Before you begin, make sure you have the following:
 
-- You are running MacOS or Linux
+- You are running **macOS**, **Linux**, or **Windows with WSL2** (recommended for Windows)
 - [Make](https://www.gnu.org/software/make/)
-- [Docker](https://www.docker.com/)
+- [Docker](https://www.docker.com/) (Docker Desktop on Windows should use the WSL2 backend)
+
+> **Windows tip:** Clone and run the repo from your WSL2 filesystem (for example
+> `~/projects/superplane`), not from a `/mnt/c/...` path. That keeps Docker volume
+> mounts and file watching reliable. Open the WSL folder in VS Code or Cursor with
+> the Remote - WSL extension if you prefer a GUI editor.
 
 ### Forking and Cloning the Repository
 


### PR DESCRIPTION
## Why

The contributing guide listed only MacOS/Linux, but SuperPlane's Docker-based setup works on Windows via WSL2. New contributors on Windows (like me) benefit from a short, accurate tip so they don't clone into `/mnt/c` and hit broken volume mounts.

Also aligns spelling with the rest of the repo (`macOS`, `Prerequisites`).

## What changed

- `MacOS` → `macOS`
- `Pre-requisites` → `Prerequisites`
- Document Windows + WSL2 + Docker Desktop
- Tip: clone inside the WSL filesystem, not `/mnt/c`

## How to verify

Open `CONTRIBUTING.md` and skim the Prerequisites section — no runtime change.
