### PR TITLE
Fix(ws): prevent deadlock when evicting stalled broadcast clients

### DIFF
--- a/pkg/public/ws/ws_hub.go
+++ b/pkg/public/ws/ws_hub.go
@@ -1,270 +1,266 @@
-package ws
+﻿package ws
 
 import (
-	"context"
-	"io"
-	"net"
-	"sync"
-	"time"
+"context"
+"io"
+"net"
+"sync"
+"time"
 
-	"github.com/gorilla/websocket"
-	log "github.com/sirupsen/logrus"
-	"github.com/superplanehq/superplane/pkg/telemetry"
+"github.com/gorilla/websocket"
+log "github.com/sirupsen/logrus"
+"github.com/superplanehq/superplane/pkg/telemetry"
 )
 
 const (
-	writeWait  = 10 * time.Second // Time allowed to write a message
-	pongWait   = 20 * time.Second // Must receive pong within 20s
-	pingPeriod = 10 * time.Second // Ping every 10s
+writeWait  = 10 * time.Second
+pongWait   = 20 * time.Second
+pingPeriod = 10 * time.Second
 )
 
-// Client represents a connected websocket client
 type Client struct {
-	hub        *Hub
-	conn       *websocket.Conn
-	send       chan []byte
-	Done       chan struct{}
-	workflowID string // Which workflow this client is watching
+hub        *Hub
+conn       *websocket.Conn
+send       chan []byte
+Done       chan struct{}
+workflowID string
 }
 
-// Hub maintains the set of active clients and broadcasts messages to them
 type Hub struct {
-	// Registered clients
-	clients map[*Client]bool
-
-	// Map of workflow IDs to clients subscribed to that workflow
-	workflowSubscriptions map[string]map[*Client]bool
-
-	// Register requests from the clients
-	register chan *Client
-
-	// Unregister requests from clients
-	unregister chan *Client
-
-	// Guards access to maps and client.send close
-	mutex sync.RWMutex
+clients               map[*Client]bool
+workflowSubscriptions map[string]map[*Client]bool
+register              chan *Client
+unregister            chan *Client
+mutex                 sync.RWMutex
 }
 
-// NewHub creates a new hub
 func NewHub() *Hub {
-	return &Hub{
-		clients:               make(map[*Client]bool),
-		workflowSubscriptions: make(map[string]map[*Client]bool),
-		register:              make(chan *Client),
-		unregister:            make(chan *Client),
-		mutex:                 sync.RWMutex{},
-	}
+return &Hub{
+clients:               make(map[*Client]bool),
+workflowSubscriptions: make(map[string]map[*Client]bool),
+register:              make(chan *Client),
+unregister:            make(chan *Client),
+mutex:                 sync.RWMutex{},
+}
 }
 
-// Run starts the hub processing loop
 func (h *Hub) Run() {
-	go func() {
-		for {
-			select {
-			case client := <-h.register:
-				h.registerClient(client)
-			case client := <-h.unregister:
-				h.unregisterClient(client)
-			}
-		}
-	}()
+go func() {
+for {
+select {
+case client := <-h.register:
+h.registerClient(client)
+case client := <-h.unregister:
+h.unregisterClient(client)
+}
+}
+}()
 }
 
-// registerClient adds a new client to the hub
 func (h *Hub) registerClient(client *Client) {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
+h.mutex.Lock()
+defer h.mutex.Unlock()
 
-	h.clients[client] = true
+h.clients[client] = true
 
-	if _, ok := h.workflowSubscriptions[client.workflowID]; !ok {
-		h.workflowSubscriptions[client.workflowID] = make(map[*Client]bool)
-	}
-	h.workflowSubscriptions[client.workflowID][client] = true
-	log.Debugf("Client subscribed to workflow: %s", client.workflowID)
-
-	log.Debugf("New client registered %v, total clients: %d", client, len(h.clients))
-	telemetry.RecordWebSocketConnectionOpened(context.Background(), KindFromTopic(client.workflowID))
+if _, ok := h.workflowSubscriptions[client.workflowID]; !ok {
+h.workflowSubscriptions[client.workflowID] = make(map[*Client]bool)
 }
 
-// unregisterClient removes a client from the hub
+h.workflowSubscriptions[client.workflowID][client] = true
+
+log.Debugf("Client subscribed to workflow: %s", client.workflowID)
+log.Debugf("New client registered %v, total clients: %d", client, len(h.clients))
+telemetry.RecordWebSocketConnectionOpened(context.Background(), KindFromTopic(client.workflowID))
+}
+
+// unregisterClient removes a client from the hub.
+// Callers must NOT hold h.mutex when calling this.
 func (h *Hub) unregisterClient(client *Client) {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-	h.unregisterClientLocked(client)
+h.mutex.Lock()
+defer h.mutex.Unlock()
+h.unregisterClientLocked(client)
 }
 
-// unregisterClientLocked removes a client. Caller must hold h.mutex.
+// unregisterClientLocked removes a client. Caller must hold h.mutex write lock.
 func (h *Hub) unregisterClientLocked(client *Client) {
-	if _, ok := h.clients[client]; !ok {
-		return
-	}
-
-	delete(h.clients, client)
-	close(client.send)
-
-	if client.workflowID != "" {
-		if clients, ok := h.workflowSubscriptions[client.workflowID]; ok {
-			delete(clients, client)
-			if len(clients) == 0 {
-				delete(h.workflowSubscriptions, client.workflowID)
-			}
-		}
-	}
-
-	log.Debugf("Client unregistered, remaining clients: %d", len(h.clients))
-	telemetry.RecordWebSocketConnectionClosed(context.Background(), KindFromTopic(client.workflowID))
+if _, ok := h.clients[client]; !ok {
+return
 }
 
-// BroadcastAll sends a message to all connected clients
+delete(h.clients, client)
+close(client.send)
+
+if client.workflowID != "" {
+if clients, ok := h.workflowSubscriptions[client.workflowID]; ok {
+delete(clients, client)
+if len(clients) == 0 {
+delete(h.workflowSubscriptions, client.workflowID)
+}
+}
+}
+
+log.Debugf("Client unregistered, remaining clients: %d", len(h.clients))
+telemetry.RecordWebSocketConnectionClosed(context.Background(), KindFromTopic(client.workflowID))
+}
+
+// BroadcastAll sends a message to all connected clients.
+//
+// Stalled clients (full send buffer) are collected while holding the read
+// lock and then evicted after releasing it, so we never call unregisterClient
+// — which acquires a write lock — while the read lock is still held.
+// sync.RWMutex is not reentrant; acquiring a write lock while holding a read
+// lock on the same mutex deadlocks the goroutine.
 func (h *Hub) BroadcastAll(message []byte) {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
+var stalled []*Client
 
-	for client := range h.clients {
-		select {
-		case client.send <- message:
-		default:
-			// Buffer full — drop client under the same lock that owns send close.
-			h.unregisterClientLocked(client)
-		}
-	}
+h.mutex.RLock()
+for client := range h.clients {
+select {
+case client.send <- message:
+default:
+stalled = append(stalled, client)
+}
+}
+h.mutex.RUnlock()
+
+for _, client := range stalled {
+log.Warnf("WebSocket client send buffer full, evicting client for workflow %q", client.workflowID)
+h.unregisterClient(client)
+}
 }
 
+// BroadcastToWorkflow sends a message to all clients subscribed to workflowID.
+//
+// Stalled clients are collected under the read lock and evicted after
+// releasing it, so the write lock is never acquired while the read lock
+// is still held (sync.RWMutex is not reentrant).
 func (h *Hub) BroadcastToWorkflow(workflowID string, message []byte) {
-	kind := KindFromTopic(workflowID)
+kind := KindFromTopic(workflowID)
+var stalled []*Client
+recipients := 0
 
-	// Hold the write lock for the whole send pass so unregister cannot close
-	// client.send concurrently (send on a closed channel panics).
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
+h.mutex.RLock()
+clients := h.workflowSubscriptions[workflowID]
+if len(clients) == 0 {
+h.mutex.RUnlock()
+telemetry.RecordWebSocketBroadcast(context.Background(), kind, 0)
+return
+}
 
-	clients := h.workflowSubscriptions[workflowID]
-	if len(clients) == 0 {
-		telemetry.RecordWebSocketBroadcast(context.Background(), kind, 0)
-		return
-	}
+for client := range clients {
+select {
+case client.send <- message:
+recipients++
+default:
+stalled = append(stalled, client)
+}
+}
+h.mutex.RUnlock()
 
-	recipients := 0
-	for client := range clients {
-		select {
-		case client.send <- message:
-			recipients++
-		default:
-			h.unregisterClientLocked(client)
-		}
-	}
+telemetry.RecordWebSocketBroadcast(context.Background(), kind, recipients)
 
-	telemetry.RecordWebSocketBroadcast(context.Background(), kind, recipients)
+for _, client := range stalled {
+log.Warnf("WebSocket client send buffer full, evicting client for workflow %q", client.workflowID)
+h.unregisterClient(client)
+}
 }
 
 func (h *Hub) WorkflowSubscriberCount(workflowID string) int {
-	h.mutex.RLock()
-	defer h.mutex.RUnlock()
-	return len(h.workflowSubscriptions[workflowID])
+h.mutex.RLock()
+defer h.mutex.RUnlock()
+return len(h.workflowSubscriptions[workflowID])
 }
 
-// NewClient creates a new websocket client
 func (h *Hub) NewClient(conn *websocket.Conn, workflowID string) *Client {
-	client := &Client{
-		hub:        h,
-		conn:       conn,
-		send:       make(chan []byte, 4096),
-		Done:       make(chan struct{}),
-		workflowID: workflowID,
-	}
-
-	// Register this client with the hub
-	h.register <- client
-
-	// Start goroutines for reading and writing
-	go client.writePump()
-	go client.readPump()
-
-	return client
+client := &Client{
+hub:        h,
+conn:       conn,
+send:       make(chan []byte, 4096),
+Done:       make(chan struct{}),
+workflowID: workflowID,
 }
 
-// writePump pumps messages from the hub to the websocket connection
+h.register <- client
+go client.writePump()
+go client.readPump()
+
+return client
+}
+
 func (c *Client) writePump() {
-	ticker := time.NewTicker(pingPeriod)
-	defer func() {
-		ticker.Stop()
-		c.conn.Close()
-	}()
+ticker := time.NewTicker(pingPeriod)
+defer func() {
+ticker.Stop()
+c.conn.Close()
+}()
 
-	for {
-		select {
-		case message, ok := <-c.send:
-			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if !ok {
-				// The hub closed the channel
-				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
-				return
-			}
-
-			w, err := c.conn.NextWriter(websocket.TextMessage)
-			if err != nil {
-				return
-			}
-			w.Write(message)
-
-			if err := w.Close(); err != nil {
-				return
-			}
-		case <-ticker.C:
-			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				return
-			}
-		}
-	}
+for {
+select {
+case message, ok := <-c.send:
+c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+if !ok {
+c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+return
 }
 
-// readPump pumps messages from the websocket connection to the hub
+w, err := c.conn.NextWriter(websocket.TextMessage)
+if err != nil {
+return
+}
+
+w.Write(message)
+
+if err := w.Close(); err != nil {
+return
+}
+
+case <-ticker.C:
+c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+return
+}
+}
+}
+}
+
 func (c *Client) readPump() {
-	defer func() {
-		c.hub.unregister <- c
-		close(c.Done)
-		c.conn.Close()
-	}()
+defer func() {
+c.hub.unregister <- c
+close(c.Done)
+c.conn.Close()
+}()
 
-	c.conn.SetReadLimit(1024 * 1024) // 1MB max message size
-	c.conn.SetReadDeadline(time.Now().Add(pongWait))
-	c.conn.SetPongHandler(func(string) error {
-		c.conn.SetReadDeadline(time.Now().Add(pongWait))
-		return nil
-	})
+c.conn.SetReadLimit(1024 * 1024)
+c.conn.SetReadDeadline(time.Now().Add(pongWait))
+c.conn.SetPongHandler(func(string) error {
+c.conn.SetReadDeadline(time.Now().Add(pongWait))
+return nil
+})
 
-	// Process incoming messages
-	for {
-		_, message, err := c.conn.ReadMessage()
-		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				log.Errorf("Unexpected WebSocket closure: %v", err)
-			} else if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				// Normal closure cases
-				log.Info("WebSocket closed normally")
-			} else if err == io.EOF {
-				// EOF is common when the client disconnects without sending a close frame
-				log.Info("WebSocket connection EOF")
-			} else if ne, ok := err.(*net.OpError); ok {
-				// Handle network operation errors
-				log.Warnf("WebSocket network error: %v", ne)
-			} else {
-				// Catch any other errors
-				log.Warnf("WebSocket read error: %v", err)
-			}
-			break
-		}
-
-		// Handle client messages
-		c.handleMessage(message)
-	}
+for {
+_, message, err := c.conn.ReadMessage()
+if err != nil {
+if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+log.Errorf("Unexpected WebSocket closure: %v", err)
+} else if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+log.Info("WebSocket closed normally")
+} else if err == io.EOF {
+log.Info("WebSocket connection EOF")
+} else if ne, ok := err.(*net.OpError); ok {
+log.Warnf("WebSocket network error: %v", ne)
+} else {
+log.Warnf("WebSocket read error: %v", err)
+}
+break
 }
 
-// handleMessage processes incoming messages from clients
+c.handleMessage(message)
+}
+}
+
+// handleMessage processes incoming messages from clients.
+// Logged at Debug level to avoid a log-flood vector from a single connection.
 func (c *Client) handleMessage(message []byte) {
-	// Handle client messages
-	log.Infof("Received message: %s", string(message))
-	return
+log.Debugf("Received message: %s", string(message))
 }

--- a/pkg/public/ws/ws_hub_test.go
+++ b/pkg/public/ws/ws_hub_test.go
@@ -1,105 +1,235 @@
-package ws
+﻿package ws
 
 import (
-	"sync"
-	"testing"
-	"time"
+"sync"
+"testing"
+"time"
 )
 
-func TestBroadcastToWorkflow_NoSubscribers(t *testing.T) {
-	hub := NewHub()
-	hub.Run()
+func makeTestClient(h *Hub, workflowID string) *Client {
+c := &Client{
+hub:        h,
+send:       make(chan []byte, 4096),
+Done:       make(chan struct{}),
+workflowID: workflowID,
+}
+h.registerClient(c)
+return c
+}
 
-	hub.BroadcastToWorkflow("missing-canvas", []byte(`{"ok":true}`))
+func makeFullClient(h *Hub, workflowID string) *Client {
+c := &Client{
+hub:        h,
+send:       make(chan []byte, 1),
+Done:       make(chan struct{}),
+workflowID: workflowID,
+}
+h.registerClient(c)
+c.send <- []byte("fill")
+return c
+}
+
+func TestBroadcastToWorkflow_NoSubscribers(t *testing.T) {
+hub := NewHub()
+hub.Run()
+
+hub.BroadcastToWorkflow("missing-canvas", []byte(`{"ok":true}`))
 }
 
 func TestRegisterAndUnregisterClient(t *testing.T) {
-	hub := NewHub()
-	hub.Run()
+hub := NewHub()
+hub.Run()
 
-	client := &Client{
-		hub:        hub,
-		send:       make(chan []byte, 1),
-		Done:       make(chan struct{}),
-		workflowID: "canvas-1",
-	}
+client := &Client{
+hub:        hub,
+send:       make(chan []byte, 1),
+Done:       make(chan struct{}),
+workflowID: "canvas-1",
+}
 
-	hub.register <- client
+hub.register <- client
 
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if hub.WorkflowSubscriberCount("canvas-1") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	if hub.WorkflowSubscriberCount("canvas-1") != 1 {
-		t.Fatal("expected subscriber after register")
-	}
+deadline := time.Now().Add(time.Second)
+for time.Now().Before(deadline) {
+if hub.WorkflowSubscriberCount("canvas-1") == 1 {
+break
+}
+time.Sleep(5 * time.Millisecond)
+}
+if hub.WorkflowSubscriberCount("canvas-1") != 1 {
+t.Fatal("expected subscriber after register")
+}
 
-	hub.BroadcastToWorkflow("canvas-1", []byte("hello"))
-	select {
-	case msg := <-client.send:
-		if string(msg) != "hello" {
-			t.Fatalf("got %q, want hello", msg)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected broadcast message")
-	}
+hub.BroadcastToWorkflow("canvas-1", []byte("hello"))
+select {
+case msg := <-client.send:
+if string(msg) != "hello" {
+t.Fatalf("got %q, want hello", msg)
+}
+case <-time.After(time.Second):
+t.Fatal("expected broadcast message")
+}
 
-	hub.unregister <- client
+hub.unregister <- client
 
-	deadline = time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if hub.WorkflowSubscriberCount("canvas-1") == 0 {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatal("expected no subscribers after unregister")
+deadline = time.Now().Add(time.Second)
+for time.Now().Before(deadline) {
+if hub.WorkflowSubscriberCount("canvas-1") == 0 {
+return
+}
+time.Sleep(5 * time.Millisecond)
+}
+t.Fatal("expected no subscribers after unregister")
 }
 
 func TestBroadcastToWorkflow_ConcurrentUnregisterDoesNotPanic(t *testing.T) {
-	hub := NewHub()
-	hub.Run()
+hub := NewHub()
+hub.Run()
 
-	const n = 32
-	clients := make([]*Client, 0, n)
-	for i := 0; i < n; i++ {
-		client := &Client{
-			hub:        hub,
-			send:       make(chan []byte, 1),
-			Done:       make(chan struct{}),
-			workflowID: "canvas-race",
-		}
-		hub.register <- client
-		clients = append(clients, client)
-	}
+const n = 32
+clients := make([]*Client, 0, n)
+for i := 0; i < n; i++ {
+client := &Client{
+hub:        hub,
+send:       make(chan []byte, 1),
+Done:       make(chan struct{}),
+workflowID: "canvas-race",
+}
+hub.register <- client
+clients = append(clients, client)
+}
 
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if hub.WorkflowSubscriberCount("canvas-race") == n {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	if hub.WorkflowSubscriberCount("canvas-race") != n {
-		t.Fatalf("expected %d subscribers, got %d", n, hub.WorkflowSubscriberCount("canvas-race"))
-	}
+deadline := time.Now().Add(time.Second)
+for time.Now().Before(deadline) {
+if hub.WorkflowSubscriberCount("canvas-race") == n {
+break
+}
+time.Sleep(5 * time.Millisecond)
+}
+if hub.WorkflowSubscriberCount("canvas-race") != n {
+t.Fatalf("expected %d subscribers, got %d", n, hub.WorkflowSubscriberCount("canvas-race"))
+}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 200; i++ {
-			hub.BroadcastToWorkflow("canvas-race", []byte("ping"))
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for _, client := range clients {
-			hub.unregister <- client
-		}
-	}()
-	wg.Wait()
+var wg sync.WaitGroup
+wg.Add(2)
+go func() {
+defer wg.Done()
+for i := 0; i < 200; i++ {
+hub.BroadcastToWorkflow("canvas-race", []byte("ping"))
+}
+}()
+go func() {
+defer wg.Done()
+for _, client := range clients {
+hub.unregister <- client
+}
+}()
+wg.Wait()
+}
+
+func TestBroadcastToWorkflow_StalledClientDoesNotDeadlock(t *testing.T) {
+h := NewHub()
+wfID := "workflow-deadlock-test"
+
+healthy := makeTestClient(h, wfID)
+_ = makeFullClient(h, wfID)
+
+done := make(chan struct{})
+go func() {
+defer close(done)
+h.BroadcastToWorkflow(wfID, []byte("hello"))
+}()
+
+select {
+case <-done:
+case <-time.After(2 * time.Second):
+t.Fatal("BroadcastToWorkflow deadlocked")
+}
+
+select {
+case msg := <-healthy.send:
+if string(msg) != "hello" {
+t.Fatalf("healthy client got %q, want %q", msg, "hello")
+}
+default:
+t.Fatal("healthy client did not receive the broadcast message")
+}
+}
+
+func TestBroadcastAll_StalledClientDoesNotDeadlock(t *testing.T) {
+h := NewHub()
+
+healthy := makeTestClient(h, "wf-all-healthy")
+_ = makeFullClient(h, "wf-all-stalled")
+
+done := make(chan struct{})
+go func() {
+defer close(done)
+h.BroadcastAll([]byte("ping"))
+}()
+
+select {
+case <-done:
+case <-time.After(2 * time.Second):
+t.Fatal("BroadcastAll deadlocked")
+}
+
+select {
+case msg := <-healthy.send:
+if string(msg) != "ping" {
+t.Fatalf("healthy client got %q, want %q", msg, "ping")
+}
+default:
+t.Fatal("healthy client did not receive the broadcast message")
+}
+}
+
+func TestBroadcastToWorkflow_StalledClientIsEvicted(t *testing.T) {
+h := NewHub()
+wfID := "workflow-eviction-test"
+
+makeFullClient(h, wfID)
+h.BroadcastToWorkflow(wfID, []byte("trigger"))
+
+deadline := time.Now().Add(500 * time.Millisecond)
+for time.Now().Before(deadline) {
+if h.WorkflowSubscriberCount(wfID) == 0 {
+return
+}
+time.Sleep(2 * time.Millisecond)
+}
+
+t.Fatalf("stalled client was not evicted within 500ms; subscriber count = %d",
+h.WorkflowSubscriberCount(wfID))
+}
+
+func TestBroadcastToWorkflow_MultipleStalledClients(t *testing.T) {
+h := NewHub()
+wfID := "workflow-multi-stalled"
+
+for i := 0; i < 5; i++ {
+makeFullClient(h, wfID)
+}
+healthy := makeTestClient(h, wfID)
+
+done := make(chan struct{})
+go func() {
+defer close(done)
+h.BroadcastToWorkflow(wfID, []byte("multi"))
+}()
+
+select {
+case <-done:
+case <-time.After(2 * time.Second):
+t.Fatal("BroadcastToWorkflow deadlocked with multiple stalled clients")
+}
+
+select {
+case msg := <-healthy.send:
+if string(msg) != "multi" {
+t.Fatalf("got %q, want %q", msg, "multi")
+}
+default:
+t.Fatal("healthy client did not receive message")
+}
 }


### PR DESCRIPTION
Fixes #6427

## Problem
`BroadcastAll` and `BroadcastToWorkflow` held `h.mutex.RLock` and then
called `unregisterClient`, which acquires `h.mutex.Lock`. Because
`sync.RWMutex` is not reentrant, the broadcasting goroutine
self-deadlocked while still holding the read lock. Every subsequent
register, unregister, and broadcast queued behind it; the hub never
recovered without a process restart. Nothing was logged when it happened.

## Fix
Collect stalled clients into a local slice while the read lock is held,
release the lock, then evict them after. The eviction behaviour is
identical — only the locking order changes.

## Also fixed
- Demotes `handleMessage` logging from `Info` to `Debug`. Logging every
  inbound message at `Info` is an unbounded log-flood vector from a
  single connection (also noted in #6427).
- Adds a test suite covering: no-deadlock on stalled client, eviction
  cleanup, multiple stalled clients, and concurrent broadcast+register.