### PR TITLE
feat: add content filter to Linear on issue comment trigger

### DIFF
--- a/docs/components/Linear.mdx
+++ b/docs/components/Linear.mdx
@@ -137,7 +137,7 @@ updated or deleted on an issue in a Linear team.
 
 ### Use Cases
 
-- **Run a command** when someone comments a keyword on an issue
+- **Run a command** when someone comments a keyword like `/deploy` on an issue
 - **Sync discussion** to another tool when a comment is added
 - **Notify a channel** when an issue gets new activity
 
@@ -145,6 +145,8 @@ updated or deleted on an issue in a Linear team.
 
 - **Team** (required): Linear team to monitor
 - **Actions** (required): Which comment actions to listen for (created, updated, deleted). Default: created.
+- **Content Filter** (optional): Only trigger for comments whose body matches one of these predicates.
+  A comment delivered without a body never matches.
 
 ### Outputs
 

--- a/docs/components/Linear.mdx
+++ b/docs/components/Linear.mdx
@@ -145,8 +145,8 @@ updated or deleted on an issue in a Linear team.
 
 - **Team** (required): Linear team to monitor
 - **Actions** (required): Which comment actions to listen for (created, updated, deleted). Default: created.
-- **Content Filter** (optional): Only trigger for comments whose body matches one of these predicates.
-  A comment delivered without a body never matches.
+- **Content Filter** (optional): Regex pattern to filter comments by content, e.g. `/deploy` to
+  only trigger on comments containing "/deploy". A comment delivered without a body never matches.
 
 ### Outputs
 

--- a/pkg/integrations/linear/on_issue_comment.go
+++ b/pkg/integrations/linear/on_issue_comment.go
@@ -16,9 +16,9 @@ import (
 type OnIssueComment struct{}
 
 type OnIssueCommentConfiguration struct {
-	Team          string                    `json:"team" mapstructure:"team"`
-	Actions       []string                  `json:"actions" mapstructure:"actions"`
-	ContentFilter []configuration.Predicate `json:"contentFilter" mapstructure:"contentFilter"`
+	Team          string   `json:"team" mapstructure:"team"`
+	Actions       []string `json:"actions" mapstructure:"actions"`
+	ContentFilter string   `json:"contentFilter" mapstructure:"contentFilter"`
 }
 
 func (i *OnIssueComment) Name() string {
@@ -47,8 +47,8 @@ updated or deleted on an issue in a Linear team.
 
 - **Team** (required): Linear team to monitor
 - **Actions** (required): Which comment actions to listen for (created, updated, deleted). Default: created.
-- **Content Filter** (optional): Only trigger for comments whose body matches one of these predicates.
-  A comment delivered without a body never matches.
+- **Content Filter** (optional): Regex pattern to filter comments by content, e.g. ` + "`/deploy`" + ` to
+  only trigger on comments containing "/deploy". A comment delivered without a body never matches.
 
 ## Outputs
 
@@ -104,14 +104,10 @@ func (i *OnIssueComment) Configuration() []configuration.Field {
 		{
 			Name:        "contentFilter",
 			Label:       "Content Filter",
-			Type:        configuration.FieldTypeAnyPredicateList,
+			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Only trigger for comments whose body matches one of these predicates",
-			TypeOptions: &configuration.TypeOptions{
-				AnyPredicateList: &configuration.AnyPredicateListTypeOptions{
-					Operators: configuration.AllPredicateOperators,
-				},
-			},
+			Placeholder: "e.g., /deploy",
+			Description: "Optional regex pattern to filter comments by content",
 		},
 	}
 }
@@ -134,17 +130,9 @@ func (i *OnIssueComment) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("at least one action is required")
 	}
 
-	//
-	// Predicate evaluation swallows regex errors and never matches, so reject an
-	// uncompilable pattern here instead of saving a silently dead trigger.
-	//
-	for _, predicate := range config.ContentFilter {
-		if predicate.Type != configuration.PredicateTypeMatches {
-			continue
-		}
-
-		if _, err := regexp.Compile(predicate.Value); err != nil {
-			return fmt.Errorf("invalid content filter pattern %q: %w", predicate.Value, err)
+	if config.ContentFilter != "" {
+		if _, err := regexp.Compile(config.ContentFilter); err != nil {
+			return fmt.Errorf("invalid content filter pattern: %w", err)
 		}
 	}
 
@@ -204,7 +192,13 @@ func (i *OnIssueComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *co
 		return http.StatusOK, nil, nil
 	}
 
-	if len(config.ContentFilter) > 0 && !i.matchesContentFilter(ctx.Logger, data, config.ContentFilter) {
+	matched, err := i.matchesContentFilter(config.ContentFilter, data)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	if !matched {
+		ctx.Logger.Info("Comment does not match the content filter - ignoring")
 		return http.StatusOK, nil, nil
 	}
 
@@ -233,21 +227,27 @@ func (i *OnIssueComment) whitelistedAction(logger *log.Entry, data map[string]an
 	return true
 }
 
-func (i *OnIssueComment) matchesContentFilter(logger *log.Entry, data map[string]any, predicates []configuration.Predicate) bool {
+// matchesContentFilter checks the comment body against the regex filter. An empty
+// filter always matches, and a comment delivered without a body never does.
+func (i *OnIssueComment) matchesContentFilter(filter string, data map[string]any) (bool, error) {
+	if filter == "" {
+		return true, nil
+	}
+
 	comment, ok := data["data"].(map[string]any)
 	if !ok {
-		return false
+		return false, nil
 	}
 
 	body, ok := comment["body"].(string)
 	if !ok {
-		return false
+		return false, nil
 	}
 
-	if !configuration.MatchesAnyPredicate(predicates, body) {
-		logger.Infof("Comment body does not match the content filter: %v", predicates)
-		return false
+	matched, err := regexp.MatchString(filter, body)
+	if err != nil {
+		return false, fmt.Errorf("invalid content filter pattern: %w", err)
 	}
 
-	return true
+	return matched, nil
 }

--- a/pkg/integrations/linear/on_issue_comment.go
+++ b/pkg/integrations/linear/on_issue_comment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
 
 	"github.com/mitchellh/mapstructure"
@@ -15,8 +16,9 @@ import (
 type OnIssueComment struct{}
 
 type OnIssueCommentConfiguration struct {
-	Team    string   `json:"team" mapstructure:"team"`
-	Actions []string `json:"actions" mapstructure:"actions"`
+	Team          string                    `json:"team" mapstructure:"team"`
+	Actions       []string                  `json:"actions" mapstructure:"actions"`
+	ContentFilter []configuration.Predicate `json:"contentFilter" mapstructure:"contentFilter"`
 }
 
 func (i *OnIssueComment) Name() string {
@@ -37,7 +39,7 @@ updated or deleted on an issue in a Linear team.
 
 ## Use Cases
 
-- **Run a command** when someone comments a keyword on an issue
+- **Run a command** when someone comments a keyword like ` + "`/deploy`" + ` on an issue
 - **Sync discussion** to another tool when a comment is added
 - **Notify a channel** when an issue gets new activity
 
@@ -45,6 +47,8 @@ updated or deleted on an issue in a Linear team.
 
 - **Team** (required): Linear team to monitor
 - **Actions** (required): Which comment actions to listen for (created, updated, deleted). Default: created.
+- **Content Filter** (optional): Only trigger for comments whose body matches one of these predicates.
+  A comment delivered without a body never matches.
 
 ## Outputs
 
@@ -97,6 +101,18 @@ func (i *OnIssueComment) Configuration() []configuration.Field {
 				},
 			},
 		},
+		{
+			Name:        "contentFilter",
+			Label:       "Content Filter",
+			Type:        configuration.FieldTypeAnyPredicateList,
+			Required:    false,
+			Description: "Only trigger for comments whose body matches one of these predicates",
+			TypeOptions: &configuration.TypeOptions{
+				AnyPredicateList: &configuration.AnyPredicateListTypeOptions{
+					Operators: configuration.AllPredicateOperators,
+				},
+			},
+		},
 	}
 }
 
@@ -116,6 +132,20 @@ func (i *OnIssueComment) Setup(ctx core.TriggerContext) error {
 	//
 	if len(config.Actions) == 0 {
 		return fmt.Errorf("at least one action is required")
+	}
+
+	//
+	// Predicate evaluation swallows regex errors and never matches, so reject an
+	// uncompilable pattern here instead of saving a silently dead trigger.
+	//
+	for _, predicate := range config.ContentFilter {
+		if predicate.Type != configuration.PredicateTypeMatches {
+			continue
+		}
+
+		if _, err := regexp.Compile(predicate.Value); err != nil {
+			return fmt.Errorf("invalid content filter pattern %q: %w", predicate.Value, err)
+		}
 	}
 
 	team, err := requireTeam(ctx.Integration, config.Team)
@@ -174,6 +204,10 @@ func (i *OnIssueComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *co
 		return http.StatusOK, nil, nil
 	}
 
+	if len(config.ContentFilter) > 0 && !i.matchesContentFilter(ctx.Logger, data, config.ContentFilter) {
+		return http.StatusOK, nil, nil
+	}
+
 	if err := ctx.Events.Emit(CommentPayloadType, data); err != nil {
 		return http.StatusInternalServerError, nil, fmt.Errorf("error emitting event: %v", err)
 	}
@@ -193,6 +227,25 @@ func (i *OnIssueComment) whitelistedAction(logger *log.Entry, data map[string]an
 
 	if !slices.Contains(allowedActions, action) {
 		logger.Infof("Action %s is not in the allowed list: %v", action, allowedActions)
+		return false
+	}
+
+	return true
+}
+
+func (i *OnIssueComment) matchesContentFilter(logger *log.Entry, data map[string]any, predicates []configuration.Predicate) bool {
+	comment, ok := data["data"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	body, ok := comment["body"].(string)
+	if !ok {
+		return false
+	}
+
+	if !configuration.MatchesAnyPredicate(predicates, body) {
+		logger.Infof("Comment body does not match the content filter: %v", predicates)
 		return false
 	}
 

--- a/pkg/integrations/linear/on_issue_comment_test.go
+++ b/pkg/integrations/linear/on_issue_comment_test.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
@@ -28,8 +29,18 @@ func commentEvent(action string) map[string]any {
 	}
 }
 
+func commentEventWithBody(action, body string) map[string]any {
+	event := commentEvent(action)
+	event["data"].(map[string]any)["body"] = body
+	return event
+}
+
 func commentConfig() map[string]any {
 	return map[string]any{"team": "t1", "actions": []string{"create"}}
+}
+
+func commentConfigWithFilter(predicates []configuration.Predicate) map[string]any {
+	return map[string]any{"team": "t1", "actions": []string{"create"}, "contentFilter": predicates}
 }
 
 // signedCommentRequest signs the body and sets the Comment event header, since
@@ -83,6 +94,26 @@ func Test__OnIssueComment__Setup(t *testing.T) {
 		})
 
 		require.ErrorContains(t, err, "at least one action is required")
+	})
+
+	t.Run("invalid content filter pattern -> error", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			Integration:   integrationWithTeam(),
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: commentConfigWithFilter([]configuration.Predicate{{Type: configuration.PredicateTypeMatches, Value: "["}}),
+		})
+
+		require.ErrorContains(t, err, "invalid content filter pattern")
+	})
+
+	t.Run("valid content filter is accepted", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			Integration:   integrationWithTeam(),
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: commentConfigWithFilter([]configuration.Predicate{{Type: configuration.PredicateTypeMatches, Value: "^/deploy"}}),
+		})
+
+		require.NoError(t, err)
 	})
 
 	t.Run("requests a comment webhook scoped to the team", func(t *testing.T) {
@@ -207,6 +238,68 @@ func Test__OnIssueComment__HandleWebhook__FiltersActions(t *testing.T) {
 		assert.Equal(t, http.StatusOK, code)
 		require.NoError(t, err)
 		assert.Equal(t, 1, events.Count())
+	})
+}
+
+func Test__OnIssueComment__HandleWebhook__FiltersContent(t *testing.T) {
+	trigger := &OnIssueComment{}
+	deployFilter := []configuration.Predicate{{Type: configuration.PredicateTypeMatches, Value: "^/deploy"}}
+
+	t.Run("matching body is emitted", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		body := commentEventWithBody("create", "/deploy staging")
+		ctx := signedCommentRequest(t, body, commentConfigWithFilter(deployFilter), events)
+
+		code, _, err := trigger.HandleWebhook(ctx)
+		assert.Equal(t, http.StatusOK, code)
+		require.NoError(t, err)
+		assert.Equal(t, 1, events.Count())
+	})
+
+	t.Run("non-matching body is ignored", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		ctx := signedCommentRequest(t, commentEvent("create"), commentConfigWithFilter(deployFilter), events)
+
+		code, _, err := trigger.HandleWebhook(ctx)
+		assert.Equal(t, http.StatusOK, code)
+		require.NoError(t, err)
+		assert.Zero(t, events.Count())
+	})
+
+	t.Run("equals predicate matches the exact body", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		filter := []configuration.Predicate{{Type: configuration.PredicateTypeEquals, Value: "/deploy"}}
+		body := commentEventWithBody("create", "/deploy")
+		ctx := signedCommentRequest(t, body, commentConfigWithFilter(filter), events)
+
+		code, _, err := trigger.HandleWebhook(ctx)
+		assert.Equal(t, http.StatusOK, code)
+		require.NoError(t, err)
+		assert.Equal(t, 1, events.Count())
+	})
+
+	t.Run("comment without a body does not match", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		body := commentEvent("remove")
+		delete(body["data"].(map[string]any), "body")
+		config := map[string]any{"team": "t1", "actions": []string{"remove"}, "contentFilter": deployFilter}
+		ctx := signedCommentRequest(t, body, config, events)
+
+		code, _, err := trigger.HandleWebhook(ctx)
+		assert.Equal(t, http.StatusOK, code)
+		require.NoError(t, err)
+		assert.Zero(t, events.Count())
+	})
+
+	t.Run("filter is not reached for unselected actions", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		body := commentEventWithBody("update", "/deploy staging")
+		ctx := signedCommentRequest(t, body, commentConfigWithFilter(deployFilter), events)
+
+		code, _, err := trigger.HandleWebhook(ctx)
+		assert.Equal(t, http.StatusOK, code)
+		require.NoError(t, err)
+		assert.Zero(t, events.Count())
 	})
 }
 

--- a/pkg/integrations/linear/on_issue_comment_test.go
+++ b/pkg/integrations/linear/on_issue_comment_test.go
@@ -7,7 +7,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
@@ -39,8 +38,8 @@ func commentConfig() map[string]any {
 	return map[string]any{"team": "t1", "actions": []string{"create"}}
 }
 
-func commentConfigWithFilter(predicates []configuration.Predicate) map[string]any {
-	return map[string]any{"team": "t1", "actions": []string{"create"}, "contentFilter": predicates}
+func commentConfigWithFilter(filter string) map[string]any {
+	return map[string]any{"team": "t1", "actions": []string{"create"}, "contentFilter": filter}
 }
 
 // signedCommentRequest signs the body and sets the Comment event header, since
@@ -100,7 +99,7 @@ func Test__OnIssueComment__Setup(t *testing.T) {
 		err := trigger.Setup(core.TriggerContext{
 			Integration:   integrationWithTeam(),
 			Metadata:      &contexts.MetadataContext{},
-			Configuration: commentConfigWithFilter([]configuration.Predicate{{Type: configuration.PredicateTypeMatches, Value: "["}}),
+			Configuration: commentConfigWithFilter("[invalid(regex"),
 		})
 
 		require.ErrorContains(t, err, "invalid content filter pattern")
@@ -110,7 +109,7 @@ func Test__OnIssueComment__Setup(t *testing.T) {
 		err := trigger.Setup(core.TriggerContext{
 			Integration:   integrationWithTeam(),
 			Metadata:      &contexts.MetadataContext{},
-			Configuration: commentConfigWithFilter([]configuration.Predicate{{Type: configuration.PredicateTypeMatches, Value: "^/deploy"}}),
+			Configuration: commentConfigWithFilter("^/deploy"),
 		})
 
 		require.NoError(t, err)
@@ -243,12 +242,11 @@ func Test__OnIssueComment__HandleWebhook__FiltersActions(t *testing.T) {
 
 func Test__OnIssueComment__HandleWebhook__FiltersContent(t *testing.T) {
 	trigger := &OnIssueComment{}
-	deployFilter := []configuration.Predicate{{Type: configuration.PredicateTypeMatches, Value: "^/deploy"}}
 
 	t.Run("matching body is emitted", func(t *testing.T) {
 		events := &contexts.EventContext{}
 		body := commentEventWithBody("create", "/deploy staging")
-		ctx := signedCommentRequest(t, body, commentConfigWithFilter(deployFilter), events)
+		ctx := signedCommentRequest(t, body, commentConfigWithFilter("^/deploy"), events)
 
 		code, _, err := trigger.HandleWebhook(ctx)
 		assert.Equal(t, http.StatusOK, code)
@@ -258,7 +256,7 @@ func Test__OnIssueComment__HandleWebhook__FiltersContent(t *testing.T) {
 
 	t.Run("non-matching body is ignored", func(t *testing.T) {
 		events := &contexts.EventContext{}
-		ctx := signedCommentRequest(t, commentEvent("create"), commentConfigWithFilter(deployFilter), events)
+		ctx := signedCommentRequest(t, commentEvent("create"), commentConfigWithFilter("^/deploy"), events)
 
 		code, _, err := trigger.HandleWebhook(ctx)
 		assert.Equal(t, http.StatusOK, code)
@@ -266,11 +264,20 @@ func Test__OnIssueComment__HandleWebhook__FiltersContent(t *testing.T) {
 		assert.Zero(t, events.Count())
 	})
 
-	t.Run("equals predicate matches the exact body", func(t *testing.T) {
+	t.Run("pattern matches anywhere in the body", func(t *testing.T) {
 		events := &contexts.EventContext{}
-		filter := []configuration.Predicate{{Type: configuration.PredicateTypeEquals, Value: "/deploy"}}
-		body := commentEventWithBody("create", "/deploy")
-		ctx := signedCommentRequest(t, body, commentConfigWithFilter(filter), events)
+		body := commentEventWithBody("create", "please /deploy staging now")
+		ctx := signedCommentRequest(t, body, commentConfigWithFilter("/deploy"), events)
+
+		code, _, err := trigger.HandleWebhook(ctx)
+		assert.Equal(t, http.StatusOK, code)
+		require.NoError(t, err)
+		assert.Equal(t, 1, events.Count())
+	})
+
+	t.Run("empty filter emits every comment", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		ctx := signedCommentRequest(t, commentEvent("create"), commentConfigWithFilter(""), events)
 
 		code, _, err := trigger.HandleWebhook(ctx)
 		assert.Equal(t, http.StatusOK, code)
@@ -282,7 +289,7 @@ func Test__OnIssueComment__HandleWebhook__FiltersContent(t *testing.T) {
 		events := &contexts.EventContext{}
 		body := commentEvent("remove")
 		delete(body["data"].(map[string]any), "body")
-		config := map[string]any{"team": "t1", "actions": []string{"remove"}, "contentFilter": deployFilter}
+		config := map[string]any{"team": "t1", "actions": []string{"remove"}, "contentFilter": "^/deploy"}
 		ctx := signedCommentRequest(t, body, config, events)
 
 		code, _, err := trigger.HandleWebhook(ctx)
@@ -291,10 +298,20 @@ func Test__OnIssueComment__HandleWebhook__FiltersContent(t *testing.T) {
 		assert.Zero(t, events.Count())
 	})
 
+	t.Run("invalid pattern -> bad request", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		ctx := signedCommentRequest(t, commentEvent("create"), commentConfigWithFilter("[invalid(regex"), events)
+
+		code, _, err := trigger.HandleWebhook(ctx)
+		assert.Equal(t, http.StatusBadRequest, code)
+		require.ErrorContains(t, err, "invalid content filter pattern")
+		assert.Zero(t, events.Count())
+	})
+
 	t.Run("filter is not reached for unselected actions", func(t *testing.T) {
 		events := &contexts.EventContext{}
 		body := commentEventWithBody("update", "/deploy staging")
-		ctx := signedCommentRequest(t, body, commentConfigWithFilter(deployFilter), events)
+		ctx := signedCommentRequest(t, body, commentConfigWithFilter("^/deploy"), events)
 
 		code, _, err := trigger.HandleWebhook(ctx)
 		assert.Equal(t, http.StatusOK, code)

--- a/web_src/src/pages/app/mappers/linear/on_issue_comment.spec.ts
+++ b/web_src/src/pages/app/mappers/linear/on_issue_comment.spec.ts
@@ -140,6 +140,37 @@ describe("onIssueCommentTriggerRenderer.getTriggerProps", () => {
     expect(props.metadata?.[0]).toEqual({ icon: "users", label: "t1" });
   });
 
+  it("renders the content filter after the selected actions", () => {
+    const props = onIssueCommentTriggerRenderer.getTriggerProps(
+      buildTriggerContext({
+        node: {
+          configuration: {
+            team: "t1",
+            actions: ["create"],
+            contentFilter: [{ type: "matches", value: "^/deploy" }],
+          },
+          metadata: { team: { id: "t1", key: "ENG", name: "Engineering" } },
+        },
+      }),
+    );
+
+    expect(props.metadata?.[1]).toEqual({ icon: "funnel", label: "Created" });
+    expect(props.metadata?.[2]).toEqual({ icon: "funnel", label: "Filter: ~^/deploy" });
+  });
+
+  it("omits the content filter when it is not configured", () => {
+    const props = onIssueCommentTriggerRenderer.getTriggerProps(
+      buildTriggerContext({
+        node: {
+          configuration: { team: "t1", actions: ["create"] },
+          metadata: { team: { id: "t1", key: "ENG", name: "Engineering" } },
+        },
+      }),
+    );
+
+    expect(props.metadata).toHaveLength(2);
+  });
+
   it("surfaces the last event when one exists", () => {
     const props = onIssueCommentTriggerRenderer.getTriggerProps(
       buildTriggerContext({

--- a/web_src/src/pages/app/mappers/linear/on_issue_comment.spec.ts
+++ b/web_src/src/pages/app/mappers/linear/on_issue_comment.spec.ts
@@ -144,18 +144,14 @@ describe("onIssueCommentTriggerRenderer.getTriggerProps", () => {
     const props = onIssueCommentTriggerRenderer.getTriggerProps(
       buildTriggerContext({
         node: {
-          configuration: {
-            team: "t1",
-            actions: ["create"],
-            contentFilter: [{ type: "matches", value: "^/deploy" }],
-          },
+          configuration: { team: "t1", actions: ["create"], contentFilter: "^/deploy" },
           metadata: { team: { id: "t1", key: "ENG", name: "Engineering" } },
         },
       }),
     );
 
     expect(props.metadata?.[1]).toEqual({ icon: "funnel", label: "Created" });
-    expect(props.metadata?.[2]).toEqual({ icon: "funnel", label: "Filter: ~^/deploy" });
+    expect(props.metadata?.[2]).toEqual({ icon: "funnel", label: "Filter: ^/deploy" });
   });
 
   it("omits the content filter when it is not configured", () => {

--- a/web_src/src/pages/app/mappers/linear/on_issue_comment.ts
+++ b/web_src/src/pages/app/mappers/linear/on_issue_comment.ts
@@ -5,7 +5,7 @@ import type { TriggerProps } from "@/ui/trigger";
 import type { MetadataItem } from "@/ui/metadataList";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import { formatTimestampInUserTimezone } from "@/lib/timezone";
-import { stringOrDash } from "../utils";
+import { formatPredicate, stringOrDash } from "../utils";
 import { addTeamMetadata, getIssueLabel, getUserLabel } from "./utils";
 import type { LinearCommentWebhookEvent, LinearNodeMetadata, OnIssueCommentConfiguration } from "./types";
 
@@ -58,6 +58,13 @@ export const onIssueCommentTriggerRenderer: TriggerRenderer = {
       metadataItems.push({
         icon: "funnel",
         label: configuration.actions.map((action) => actionLabel(action)).join(", "),
+      });
+    }
+
+    if (configuration?.contentFilter && configuration.contentFilter.length > 0) {
+      metadataItems.push({
+        icon: "funnel",
+        label: `Filter: ${configuration.contentFilter.map((predicate) => formatPredicate(predicate)).join(", ")}`,
       });
     }
 

--- a/web_src/src/pages/app/mappers/linear/on_issue_comment.ts
+++ b/web_src/src/pages/app/mappers/linear/on_issue_comment.ts
@@ -5,7 +5,7 @@ import type { TriggerProps } from "@/ui/trigger";
 import type { MetadataItem } from "@/ui/metadataList";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import { formatTimestampInUserTimezone } from "@/lib/timezone";
-import { formatPredicate, stringOrDash } from "../utils";
+import { stringOrDash } from "../utils";
 import { addTeamMetadata, getIssueLabel, getUserLabel } from "./utils";
 import type { LinearCommentWebhookEvent, LinearNodeMetadata, OnIssueCommentConfiguration } from "./types";
 
@@ -61,10 +61,10 @@ export const onIssueCommentTriggerRenderer: TriggerRenderer = {
       });
     }
 
-    if (configuration?.contentFilter && configuration.contentFilter.length > 0) {
+    if (configuration?.contentFilter) {
       metadataItems.push({
         icon: "funnel",
-        label: `Filter: ${configuration.contentFilter.map((predicate) => formatPredicate(predicate)).join(", ")}`,
+        label: `Filter: ${configuration.contentFilter}`,
       });
     }
 

--- a/web_src/src/pages/app/mappers/linear/types.ts
+++ b/web_src/src/pages/app/mappers/linear/types.ts
@@ -115,6 +115,7 @@ export interface OnIssueLabelConfiguration {
 export interface OnIssueCommentConfiguration {
   team?: string;
   actions?: string[];
+  contentFilter?: Predicate[];
 }
 
 export interface GetIssueConfiguration {

--- a/web_src/src/pages/app/mappers/linear/types.ts
+++ b/web_src/src/pages/app/mappers/linear/types.ts
@@ -115,7 +115,7 @@ export interface OnIssueLabelConfiguration {
 export interface OnIssueCommentConfiguration {
   team?: string;
   actions?: string[];
-  contentFilter?: Predicate[];
+  contentFilter?: string;
 }
 
 export interface GetIssueConfiguration {


### PR DESCRIPTION
## What changed

This PR fixes the Linear `onIssueComment` trigger only being filterable by action, by adding an optional **Content Filter** that matches against the comment body.

## How

- Uses a regex string to filter comments on issues.

## Related issues

closes https://github.com/superplanehq/superplane/issues/6533

## Demo

[Screencast from 2026-08-04 14-31-08.webm](https://github.com/user-attachments/assets/5440be09-1214-4fb9-a36b-e1b9b08a4c3c)
