### PR TITLE
fix: correct E2E setup instructions

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -20,7 +20,7 @@ All e2e tests live under the `test/e2e` directory.
 
 ## How to run e2e tests
 
-Before running the tests, use the same Docker setup as CI (`make dev.up` and `make dev.setup` with both databases). The dev image already includes the Playwright browser binary, so no extra install step is needed:
+Before running the tests, use the same Docker setup as CI (`make dev.up` and `make dev.setup` with both databases). The dev image already includes the Playwright driver and Chromium, so no extra Playwright install step is needed:
 
 ```
 make dev.up

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -20,12 +20,11 @@ All e2e tests live under the `test/e2e` directory.
 
 ## How to run e2e tests
 
-Before running the tests, use the same Docker setup as CI (`make dev.up` and `make dev.setup` with both databases), then install Playwright browsers:
+Before running the tests, use the same Docker setup as CI (`make dev.up` and `make dev.setup` with both databases). The dev image already includes the Playwright browser binary, so no extra install step is needed:
 
 ```
 make dev.up
 DEV_SETUP_DBS="superplane_dev superplane_test" make dev.setup
-make setup.playwright
 ```
 
 To run all e2e tests (takes 20m+):
@@ -40,7 +39,7 @@ To run an individual test:
 make test.e2e FILE=test/e2e/canvas_page_test.go LINE=19
 ```
 
-To run a test from VSCode, set up the following keybindings (cmd+shift+p keybidings):
+To run a test from VS Code, set up the following keybindings:
 
 ```json
   {


### PR DESCRIPTION
This updates the E2E testing guide to match the current setup. The old make setup.playwright command no longer exists, and the docs now point contributors to the Docker-based workflow that already includes the Playwright browser binary in the dev image.