### PR TITLE
test: cover file path helpers

### DIFF
--- a/pkg/services/files/file_reader_test.go
+++ b/pkg/services/files/file_reader_test.go
@@ -1,0 +1,45 @@
+package files
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizePath(t *testing.T) {
+	testCases := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{name: "keeps relative path", path: "workflows/release.yaml", expected: "workflows/release.yaml"},
+		{name: "trims surrounding whitespace", path: "  workflows/release.yaml  ", expected: "workflows/release.yaml"},
+		{name: "removes leading separators", path: "///workflows/release.yaml", expected: "workflows/release.yaml"},
+		{name: "normalizes windows separators", path: `\workflows\release.yaml`, expected: "workflows/release.yaml"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, NormalizePath(testCase.path))
+		})
+	}
+}
+
+func TestIsSpecFilePath(t *testing.T) {
+	testCases := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{name: "canvas spec", path: CanvasYAMLPath, expected: true},
+		{name: "console spec", path: ConsoleYAMLPath, expected: true},
+		{name: "nested canvas filename", path: "examples/canvas.yaml", expected: false},
+		{name: "other yaml file", path: "workflow.yaml", expected: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, IsSpecFilePath(testCase.path))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Add table-driven coverage for `NormalizePath`, including whitespace, leading separators, and Windows-style separators.
- Add coverage for `IsSpecFilePath`, including both supported spec files and non-spec paths.

## Why

These helpers decide how file paths are normalized and whether a file is read from the canvas specification or the repository. Focused tests make those boundary cases explicit and protect the current behavior during future file-service changes.

## Impact

No production behavior changes. This adds regression coverage only.

## Validation

- `make test PKG_TEST_PACKAGES=./pkg/services/files` — 10 tests passed.
