### PR TITLE
feat: Add GitLab Add and Remove Issue Assignee components

### DIFF
--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -27,6 +27,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="Accept Merge Request" href="#accept-merge-request" description="Merge an open GitLab merge request" />
+  <LinkCard title="Add Issue Assignee" href="#add-issue-assignee" description="Add assignees to a GitLab issue" />
   <LinkCard title="Add Issue Label" href="#add-issue-label" description="Add labels to a GitLab issue" />
   <LinkCard title="Add Merge Request Reviewers" href="#add-merge-request-reviewers" description="Add reviewers to a GitLab merge request" />
   <LinkCard title="Add Reaction" href="#add-reaction" description="Add an award emoji reaction to a GitLab merge request or comment" />
@@ -48,6 +49,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Get Test Report Summary" href="#get-test-report-summary" description="Get GitLab pipeline test report summary" />
   <LinkCard title="Mark Merge Request Ready for Review" href="#mark-merge-request-ready-for-review" description="Take a draft merge request out of the draft state in a GitLab project" />
   <LinkCard title="Publish Commit Status" href="#publish-commit-status" description="Publish a build/CI status on a GitLab commit" />
+  <LinkCard title="Remove Issue Assignee" href="#remove-issue-assignee" description="Remove assignees from a GitLab issue" />
   <LinkCard title="Remove Merge Request Reviewers" href="#remove-merge-request-reviewers" description="Remove reviewers from a GitLab merge request" />
   <LinkCard title="Run Pipeline" href="#run-pipeline" description="Run a GitLab pipeline and wait for completion" />
   <LinkCard title="Update Issue" href="#update-issue" description="Update an existing GitLab issue" />
@@ -1320,6 +1322,88 @@ Returns the merged merge request object, including state, merge commit SHA, sour
   },
   "timestamp": "2026-02-13T11:16:17.520Z",
   "type": "gitlab.mergeRequest"
+}
+```
+
+<a id="add-issue-assignee"></a>
+
+## Add Issue Assignee
+
+**Component key:** `gitlab.addIssueAssignee`
+
+The Add Issue Assignee component adds one or more assignees to an existing GitLab issue. Existing assignees are kept.
+
+### Use Cases
+
+- **Auto-assignment**: Automatically assign issues to team members based on workflow triggers
+- **Escalation**: Add an additional assignee when an issue requires attention from a specific person
+- **On-call routing**: Assign issues to the current on-call engineer
+
+### Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to add assignees to (supports expressions)
+- **Assignees** (required): Users to assign the issue to. These are added to any existing assignees.
+
+### Permissions
+
+The connected user needs at least the **Developer** role on the project to change assignees.
+
+### Output
+
+Returns the updated issue object, including its full assignee list and URL.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "assignees": [
+      {
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+        "id": 1,
+        "name": "Administrator",
+        "state": "active",
+        "username": "root",
+        "web_url": "http://gitlab.example.com/root"
+      },
+      {
+        "avatar_url": "https://www.gravatar.com/avatar/def456?s=80\u0026d=identicon",
+        "id": 30,
+        "name": "Alex Morgan",
+        "state": "active",
+        "username": "amorgan",
+        "web_url": "http://gitlab.example.com/amorgan"
+      }
+    ],
+    "author": {
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+      "id": 1,
+      "name": "Administrator",
+      "state": "active",
+      "username": "root",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "closed_at": null,
+    "closed_by": null,
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "description": "This is an example issue updated via SuperPlane",
+    "due_date": null,
+    "id": 1,
+    "iid": 1,
+    "labels": [
+      "bug",
+      "urgent"
+    ],
+    "milestone": null,
+    "project_id": 3,
+    "state": "opened",
+    "title": "Example Issue",
+    "updated_at": "2023-01-01T10:05:00.000Z",
+    "web_url": "http://gitlab.example.com/gitlab-org/gitlab-test/issues/1"
+  },
+  "timestamp": "2023-01-01T10:05:00.000Z",
+  "type": "gitlab.updateIssue"
 }
 ```
 
@@ -2934,6 +3018,80 @@ Returns the created commit status object.
   },
   "timestamp": "2026-02-13T18:04:12.000Z",
   "type": "gitlab.commitStatus"
+}
+```
+
+<a id="remove-issue-assignee"></a>
+
+## Remove Issue Assignee
+
+**Component key:** `gitlab.removeIssueAssignee`
+
+The Remove Issue Assignee component removes one or more assignees from an existing GitLab issue. Assignees that are not listed are kept.
+
+### Use Cases
+
+- **Automated cleanup**: Remove an assignee once their involvement is no longer needed
+- **Reassignment**: Remove an assignee before adding a different one as part of a workflow
+- **Rotation**: Drop an out-of-office assignee from an open issue
+
+### Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to remove assignees from (supports expressions)
+- **Assignees** (required): Users to remove from the issue's assignees. Assignees not listed are kept.
+
+### Permissions
+
+The connected user needs at least the **Developer** role on the project to change assignees.
+
+### Output
+
+Returns the updated issue object, including its remaining assignee list and URL.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "assignees": [
+      {
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+        "id": 1,
+        "name": "Administrator",
+        "state": "active",
+        "username": "root",
+        "web_url": "http://gitlab.example.com/root"
+      }
+    ],
+    "author": {
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+      "id": 1,
+      "name": "Administrator",
+      "state": "active",
+      "username": "root",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "closed_at": null,
+    "closed_by": null,
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "description": "This is an example issue updated via SuperPlane",
+    "due_date": null,
+    "id": 1,
+    "iid": 1,
+    "labels": [
+      "bug",
+      "urgent"
+    ],
+    "milestone": null,
+    "project_id": 3,
+    "state": "opened",
+    "title": "Example Issue",
+    "updated_at": "2023-01-01T10:05:00.000Z",
+    "web_url": "http://gitlab.example.com/gitlab-org/gitlab-test/issues/1"
+  },
+  "timestamp": "2023-01-01T10:05:00.000Z",
+  "type": "gitlab.updateIssue"
 }
 ```
 

--- a/pkg/integrations/gitlab/add_issue_assignee.go
+++ b/pkg/integrations/gitlab/add_issue_assignee.go
@@ -1,0 +1,203 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_add_issue_assignee.json
+var exampleOutputAddIssueAssignee []byte
+
+type AddIssueAssignee struct{}
+
+type AddIssueAssigneeConfiguration struct {
+	Project   string   `mapstructure:"project"`
+	IssueIID  string   `mapstructure:"issueIid"`
+	Assignees []string `mapstructure:"assignees"`
+}
+
+func (c *AddIssueAssignee) Name() string {
+	return "gitlab.addIssueAssignee"
+}
+
+func (c *AddIssueAssignee) Label() string {
+	return "Add Issue Assignee"
+}
+
+func (c *AddIssueAssignee) Description() string {
+	return "Add assignees to a GitLab issue"
+}
+
+func (c *AddIssueAssignee) Documentation() string {
+	return `The Add Issue Assignee component adds one or more assignees to an existing GitLab issue. Existing assignees are kept.
+
+## Use Cases
+
+- **Auto-assignment**: Automatically assign issues to team members based on workflow triggers
+- **Escalation**: Add an additional assignee when an issue requires attention from a specific person
+- **On-call routing**: Assign issues to the current on-call engineer
+
+## Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to add assignees to (supports expressions)
+- **Assignees** (required): Users to assign the issue to. These are added to any existing assignees.
+
+## Permissions
+
+The connected user needs at least the **Developer** role on the project to change assignees.
+
+## Output
+
+Returns the updated issue object, including its full assignee list and URL.`
+}
+
+func (c *AddIssueAssignee) Icon() string {
+	return "gitlab"
+}
+
+func (c *AddIssueAssignee) Color() string {
+	return "orange"
+}
+
+func (c *AddIssueAssignee) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *AddIssueAssignee) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputAddIssueAssignee, &example); err != nil {
+		return map[string]any{}
+	}
+	return example
+}
+
+func (c *AddIssueAssignee) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "project",
+			Label:    "Project",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeProject,
+				},
+			},
+		},
+		{
+			Name:        "issueIid",
+			Label:       "Issue IID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "1 or {{event.data.object_attributes.iid}}",
+			Description: "The internal ID (IID) of the issue to add assignees to",
+		},
+		{
+			Name:     "assignees",
+			Label:    "Assignees",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:  ResourceTypeMember,
+					Multi: true,
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "project",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "project"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *AddIssueAssignee) Setup(ctx core.SetupContext) error {
+	var config AddIssueAssigneeConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Project == "" {
+		return fmt.Errorf("project is required")
+	}
+
+	if config.IssueIID == "" {
+		return fmt.Errorf("issue IID is required")
+	}
+
+	if len(config.Assignees) == 0 {
+		return fmt.Errorf("at least one assignee is required")
+	}
+
+	return ensureProjectInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		config.Project,
+	)
+}
+
+func (c *AddIssueAssignee) Execute(ctx core.ExecutionContext) error {
+	var config AddIssueAssigneeConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitLab client: %w", err)
+	}
+
+	issue, err := client.GetIssue(context.Background(), config.Project, config.IssueIID)
+	if err != nil {
+		return fmt.Errorf("failed to get issue: %w", err)
+	}
+
+	assigneeIDs := mergeAssigneeIDs(assigneeIDsOf(issue), parseUserIDs(config.Assignees))
+
+	updated, err := client.UpdateIssue(context.Background(), config.Project, config.IssueIID, &UpdateIssueRequest{
+		AssigneeIDs: &assigneeIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add issue assignees: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gitlab.updateIssue",
+		[]any{updated},
+	)
+}
+
+func (c *AddIssueAssignee) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *AddIssueAssignee) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *AddIssueAssignee) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *AddIssueAssignee) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *AddIssueAssignee) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *AddIssueAssignee) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gitlab/add_issue_assignee_test.go
+++ b/pkg/integrations/gitlab/add_issue_assignee_test.go
@@ -1,0 +1,182 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__AddIssueAssignee__Setup(t *testing.T) {
+	c := &AddIssueAssignee{}
+
+	t.Run("missing project", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"issueIid":  "1",
+				"assignees": []string{"30"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("missing issue IID", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"assignees": []string{"30"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issue IID is required")
+	})
+
+	t.Run("missing assignees", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one assignee is required")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"30"},
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__AddIssueAssignee__Execute(t *testing.T) {
+	c := &AddIssueAssignee{}
+
+	integration := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"authType":    AuthTypePersonalAccessToken,
+			"groupId":     "123",
+			"accessToken": "pat",
+			"baseUrl":     "https://gitlab.com",
+		},
+	}
+
+	t.Run("adds assignees to existing ones", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"31"},
+			},
+			Integration: integration,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{
+						"id": 1,
+						"iid": 1,
+						"project_id": 123,
+						"title": "Example Issue",
+						"state": "opened",
+						"assignees": [{"id": 30, "username": "amorgan", "name": "Alex Morgan"}],
+						"web_url": "https://gitlab.com/my-group/my-project/-/issues/1"
+					}`),
+					GitlabMockResponse(http.StatusOK, `{
+						"id": 1,
+						"iid": 1,
+						"project_id": 123,
+						"title": "Example Issue",
+						"state": "opened",
+						"assignees": [
+							{"id": 30, "username": "amorgan", "name": "Alex Morgan"},
+							{"id": 31, "username": "schen", "name": "Sam Chen"}
+						],
+						"web_url": "https://gitlab.com/my-group/my-project/-/issues/1"
+					}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		assert.Equal(t, "gitlab.updateIssue", executionState.Type)
+
+		var issue Issue
+		payloadBytes, _ := json.Marshal(payload["data"])
+		json.Unmarshal(payloadBytes, &issue)
+
+		require.Len(t, issue.Assignees, 2)
+		assert.Equal(t, 30, issue.Assignees[0].ID)
+		assert.Equal(t, 31, issue.Assignees[1].ID)
+	})
+
+	t.Run("fails when issue cannot be fetched", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"31"},
+			},
+			Integration: integration,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusNotFound, `{"message": "404 Not found"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get issue")
+	})
+
+	t.Run("fails when update fails", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"31"},
+			},
+			Integration: integration,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{"id": 1, "iid": 1, "assignees": []}`),
+					GitlabMockResponse(http.StatusForbidden, `{"message": "403 Forbidden"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to add issue assignees")
+	})
+}

--- a/pkg/integrations/gitlab/common.go
+++ b/pkg/integrations/gitlab/common.go
@@ -235,6 +235,53 @@ func removeReviewerIDs(existing, remove []int) []int {
 	return result
 }
 
+// assigneeIDsOf returns the user IDs of an issue's current assignees.
+func assigneeIDsOf(issue *Issue) []int {
+	ids := make([]int, 0, len(issue.Assignees))
+	for _, a := range issue.Assignees {
+		ids = append(ids, a.ID)
+	}
+	return ids
+}
+
+// mergeAssigneeIDs returns the union of existing and added IDs, preserving the
+// existing order and appending new IDs that are not already present.
+func mergeAssigneeIDs(existing, add []int) []int {
+	seen := make(map[int]struct{}, len(existing))
+	result := make([]int, 0, len(existing)+len(add))
+	for _, id := range existing {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	for _, id := range add {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result
+}
+
+// removeAssigneeIDs returns the existing IDs with any of the given IDs removed.
+func removeAssigneeIDs(existing, remove []int) []int {
+	toRemove := make(map[int]struct{}, len(remove))
+	for _, id := range remove {
+		toRemove[id] = struct{}{}
+	}
+	result := make([]int, 0, len(existing))
+	for _, id := range existing {
+		if _, ok := toRemove[id]; ok {
+			continue
+		}
+		result = append(result, id)
+	}
+	return result
+}
+
 func normalizePipelineRef(ref string) string {
 	if strings.HasPrefix(ref, "refs/heads/") {
 		return strings.TrimPrefix(ref, "refs/heads/")

--- a/pkg/integrations/gitlab/example_output_add_issue_assignee.json
+++ b/pkg/integrations/gitlab/example_output_add_issue_assignee.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "id": 1,
+    "iid": 1,
+    "project_id": 3,
+    "title": "Example Issue",
+    "description": "This is an example issue updated via SuperPlane",
+    "state": "opened",
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "updated_at": "2023-01-01T10:05:00.000Z",
+    "closed_at": null,
+    "closed_by": null,
+    "labels": ["bug", "urgent"],
+    "milestone": null,
+    "assignees": [
+      {
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/root"
+      },
+      {
+        "id": 30,
+        "name": "Alex Morgan",
+        "username": "amorgan",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/def456?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/amorgan"
+      }
+    ],
+    "author": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "due_date": null,
+    "web_url": "http://gitlab.example.com/gitlab-org/gitlab-test/issues/1"
+  },
+  "timestamp": "2023-01-01T10:05:00.000Z",
+  "type": "gitlab.updateIssue"
+}

--- a/pkg/integrations/gitlab/example_output_remove_issue_assignee.json
+++ b/pkg/integrations/gitlab/example_output_remove_issue_assignee.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "id": 1,
+    "iid": 1,
+    "project_id": 3,
+    "title": "Example Issue",
+    "description": "This is an example issue updated via SuperPlane",
+    "state": "opened",
+    "created_at": "2023-01-01T10:00:00.000Z",
+    "updated_at": "2023-01-01T10:05:00.000Z",
+    "closed_at": null,
+    "closed_by": null,
+    "labels": ["bug", "urgent"],
+    "milestone": null,
+    "assignees": [
+      {
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/root"
+      }
+    ],
+    "author": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "due_date": null,
+    "web_url": "http://gitlab.example.com/gitlab-org/gitlab-test/issues/1"
+  },
+  "timestamp": "2023-01-01T10:05:00.000Z",
+  "type": "gitlab.updateIssue"
+}

--- a/pkg/integrations/gitlab/gitlab.go
+++ b/pkg/integrations/gitlab/gitlab.go
@@ -187,6 +187,8 @@ func (g *GitLab) Actions() []core.Action {
 		&CreateIssueComment{},
 		&UpdateIssueComment{},
 		&AddIssueLabel{},
+		&AddIssueAssignee{},
+		&RemoveIssueAssignee{},
 		&MarkMergeRequestReadyForReview{},
 		&CreateRelease{},
 		&UpdateRelease{},

--- a/pkg/integrations/gitlab/remove_issue_assignee.go
+++ b/pkg/integrations/gitlab/remove_issue_assignee.go
@@ -1,0 +1,203 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_remove_issue_assignee.json
+var exampleOutputRemoveIssueAssignee []byte
+
+type RemoveIssueAssignee struct{}
+
+type RemoveIssueAssigneeConfiguration struct {
+	Project   string   `mapstructure:"project"`
+	IssueIID  string   `mapstructure:"issueIid"`
+	Assignees []string `mapstructure:"assignees"`
+}
+
+func (c *RemoveIssueAssignee) Name() string {
+	return "gitlab.removeIssueAssignee"
+}
+
+func (c *RemoveIssueAssignee) Label() string {
+	return "Remove Issue Assignee"
+}
+
+func (c *RemoveIssueAssignee) Description() string {
+	return "Remove assignees from a GitLab issue"
+}
+
+func (c *RemoveIssueAssignee) Documentation() string {
+	return `The Remove Issue Assignee component removes one or more assignees from an existing GitLab issue. Assignees that are not listed are kept.
+
+## Use Cases
+
+- **Automated cleanup**: Remove an assignee once their involvement is no longer needed
+- **Reassignment**: Remove an assignee before adding a different one as part of a workflow
+- **Rotation**: Drop an out-of-office assignee from an open issue
+
+## Configuration
+
+- **Project** (required): The GitLab project containing the issue
+- **Issue IID** (required): The internal ID (IID) of the issue to remove assignees from (supports expressions)
+- **Assignees** (required): Users to remove from the issue's assignees. Assignees not listed are kept.
+
+## Permissions
+
+The connected user needs at least the **Developer** role on the project to change assignees.
+
+## Output
+
+Returns the updated issue object, including its remaining assignee list and URL.`
+}
+
+func (c *RemoveIssueAssignee) Icon() string {
+	return "gitlab"
+}
+
+func (c *RemoveIssueAssignee) Color() string {
+	return "orange"
+}
+
+func (c *RemoveIssueAssignee) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *RemoveIssueAssignee) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputRemoveIssueAssignee, &example); err != nil {
+		return map[string]any{}
+	}
+	return example
+}
+
+func (c *RemoveIssueAssignee) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "project",
+			Label:    "Project",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeProject,
+				},
+			},
+		},
+		{
+			Name:        "issueIid",
+			Label:       "Issue IID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "1 or {{event.data.object_attributes.iid}}",
+			Description: "The internal ID (IID) of the issue to remove assignees from",
+		},
+		{
+			Name:     "assignees",
+			Label:    "Assignees",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:  ResourceTypeMember,
+					Multi: true,
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "project",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "project"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *RemoveIssueAssignee) Setup(ctx core.SetupContext) error {
+	var config RemoveIssueAssigneeConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Project == "" {
+		return fmt.Errorf("project is required")
+	}
+
+	if config.IssueIID == "" {
+		return fmt.Errorf("issue IID is required")
+	}
+
+	if len(config.Assignees) == 0 {
+		return fmt.Errorf("at least one assignee is required")
+	}
+
+	return ensureProjectInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		config.Project,
+	)
+}
+
+func (c *RemoveIssueAssignee) Execute(ctx core.ExecutionContext) error {
+	var config RemoveIssueAssigneeConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitLab client: %w", err)
+	}
+
+	issue, err := client.GetIssue(context.Background(), config.Project, config.IssueIID)
+	if err != nil {
+		return fmt.Errorf("failed to get issue: %w", err)
+	}
+
+	assigneeIDs := removeAssigneeIDs(assigneeIDsOf(issue), parseUserIDs(config.Assignees))
+
+	updated, err := client.UpdateIssue(context.Background(), config.Project, config.IssueIID, &UpdateIssueRequest{
+		AssigneeIDs: &assigneeIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to remove issue assignees: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gitlab.updateIssue",
+		[]any{updated},
+	)
+}
+
+func (c *RemoveIssueAssignee) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *RemoveIssueAssignee) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *RemoveIssueAssignee) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *RemoveIssueAssignee) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *RemoveIssueAssignee) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *RemoveIssueAssignee) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gitlab/remove_issue_assignee_test.go
+++ b/pkg/integrations/gitlab/remove_issue_assignee_test.go
@@ -1,0 +1,181 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__RemoveIssueAssignee__Setup(t *testing.T) {
+	c := &RemoveIssueAssignee{}
+
+	t.Run("missing project", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"issueIid":  "1",
+				"assignees": []string{"30"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("missing issue IID", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"assignees": []string{"30"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issue IID is required")
+	})
+
+	t.Run("missing assignees", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":  "123",
+				"issueIid": "1",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one assignee is required")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"30"},
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{
+					Projects: []ProjectMetadata{
+						{ID: 123, Name: "repo", URL: "http://repo"},
+					},
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+		err := c.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__RemoveIssueAssignee__Execute(t *testing.T) {
+	c := &RemoveIssueAssignee{}
+
+	integration := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"authType":    AuthTypePersonalAccessToken,
+			"groupId":     "123",
+			"accessToken": "pat",
+			"baseUrl":     "https://gitlab.com",
+		},
+	}
+
+	t.Run("removes assignee and keeps the rest", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"31"},
+			},
+			Integration: integration,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{
+						"id": 1,
+						"iid": 1,
+						"project_id": 123,
+						"title": "Example Issue",
+						"state": "opened",
+						"assignees": [
+							{"id": 30, "username": "amorgan", "name": "Alex Morgan"},
+							{"id": 31, "username": "schen", "name": "Sam Chen"}
+						],
+						"web_url": "https://gitlab.com/my-group/my-project/-/issues/1"
+					}`),
+					GitlabMockResponse(http.StatusOK, `{
+						"id": 1,
+						"iid": 1,
+						"project_id": 123,
+						"title": "Example Issue",
+						"state": "opened",
+						"assignees": [{"id": 30, "username": "amorgan", "name": "Alex Morgan"}],
+						"web_url": "https://gitlab.com/my-group/my-project/-/issues/1"
+					}`),
+				},
+			},
+			ExecutionState: executionState,
+		}
+
+		err := c.Execute(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)
+		assert.Equal(t, "gitlab.updateIssue", executionState.Type)
+
+		var issue Issue
+		payloadBytes, _ := json.Marshal(payload["data"])
+		json.Unmarshal(payloadBytes, &issue)
+
+		require.Len(t, issue.Assignees, 1)
+		assert.Equal(t, 30, issue.Assignees[0].ID)
+	})
+
+	t.Run("fails when issue cannot be fetched", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"31"},
+			},
+			Integration: integration,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusNotFound, `{"message": "404 Not found"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get issue")
+	})
+
+	t.Run("fails when update fails", func(t *testing.T) {
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"project":   "123",
+				"issueIid":  "1",
+				"assignees": []string{"31"},
+			},
+			Integration: integration,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					GitlabMockResponse(http.StatusOK, `{"id": 1, "iid": 1, "assignees": []}`),
+					GitlabMockResponse(http.StatusForbidden, `{"message": "403 Forbidden"}`),
+				},
+			},
+		}
+
+		err := c.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to remove issue assignees")
+	})
+}

--- a/web_src/src/pages/app/mappers/gitlab/add_issue_assignee.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/add_issue_assignee.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { addIssueAssigneeMapper } from "./add_issue_assignee";
+
+describe("addIssueAssigneeMapper", () => {
+  it("shows updated issue assignee details", () => {
+    const details = addIssueAssigneeMapper.getExecutionDetails(
+      buildDetailsContext({
+        outputs: {
+          default: [
+            {
+              type: "gitlab.updateIssue",
+              timestamp: "2023-01-01T10:05:00.000Z",
+              data: {
+                id: 1,
+                iid: 1,
+                project_id: 123,
+                title: "Example Issue",
+                state: "opened",
+                updated_at: "2023-01-01T10:05:00.000Z",
+                assignees: [
+                  { id: 30, username: "amorgan", name: "Alex Morgan", state: "active", avatar_url: "", web_url: "" },
+                  { id: 31, username: "schen", name: "Sam Chen", state: "active", avatar_url: "", web_url: "" },
+                ],
+                web_url: "https://gitlab.com/my-group/my-project/-/issues/1",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Updated At": expect.any(String),
+      Issue: "#1 Example Issue",
+      "Issue URL": "https://gitlab.com/my-group/my-project/-/issues/1",
+      Assignees: "@amorgan, @schen",
+      State: "opened",
+    });
+  });
+
+  it("shows the timestamp first and at most 6 details", () => {
+    const details = addIssueAssigneeMapper.getExecutionDetails(
+      buildDetailsContext({
+        outputs: {
+          default: [
+            {
+              type: "gitlab.updateIssue",
+              timestamp: "2023-01-01T10:05:00.000Z",
+              data: {
+                id: 1,
+                iid: 1,
+                title: "Example Issue",
+                state: "opened",
+                updated_at: "2023-01-01T10:05:00.000Z",
+                assignees: [
+                  { id: 30, username: "amorgan", name: "Alex Morgan", state: "active", avatar_url: "", web_url: "" },
+                ],
+                web_url: "https://gitlab.com/my-group/my-project/-/issues/1",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const keys = Object.keys(details);
+    expect(keys[0]).toBe("Updated At");
+    expect(keys.length).toBeLessThanOrEqual(6);
+  });
+
+  it("shows None when there are no assignees left", () => {
+    const details = addIssueAssigneeMapper.getExecutionDetails(
+      buildDetailsContext({
+        outputs: {
+          default: [
+            {
+              type: "gitlab.updateIssue",
+              timestamp: "2023-01-01T10:05:00.000Z",
+              data: { id: 1, iid: 1, title: "Example Issue", state: "opened", assignees: [] },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details["Assignees"]).toBe("None");
+  });
+
+  it("handles missing outputs", () => {
+    const details = addIssueAssigneeMapper.getExecutionDetails(buildDetailsContext({ outputs: {} }));
+
+    expect(details).toEqual({});
+  });
+
+  it("shows project and issue IID in node metadata", () => {
+    const context = buildDetailsContext({});
+    const props = addIssueAssigneeMapper.props({
+      nodes: context.nodes,
+      node: context.node,
+      componentDefinition: {
+        name: "gitlab.addIssueAssignee",
+        label: "Add Issue Assignee",
+        description: "",
+        icon: "gitlab",
+        color: "orange",
+      },
+      lastExecutions: [],
+      currentUser: undefined,
+      actions: { invokeNodeExecutionHook: async () => {} },
+    });
+
+    expect(props.metadata).toEqual([
+      { icon: "book", label: "felixgateru/hello-world" },
+      { icon: "circle-dot", label: "#1" },
+    ]);
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Add Issue Assignee",
+    componentName: "gitlab.addIssueAssignee",
+    isCollapsed: false,
+    configuration: {
+      project: "123",
+      issueIid: "1",
+    },
+    metadata: {
+      project: {
+        id: 123,
+        name: "felixgateru/hello-world",
+        url: "https://gitlab.com/felixgateru/hello-world",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/gitlab/add_issue_assignee.ts
+++ b/web_src/src/pages/app/mappers/gitlab/add_issue_assignee.ts
@@ -1,0 +1,58 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import type { GitLabNodeMetadata, Issue } from "./types";
+import { buildGitlabExecutionSubtitle } from "./utils";
+import { buildAssigneeDetails } from "./assignee_utils";
+
+interface AddIssueAssigneeConfiguration {
+  project?: string;
+  issueIid?: string;
+}
+
+export const addIssueAssigneeMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as AddIssueAssigneeConfiguration | undefined) ?? {};
+    const metadata = (context.node.metadata as GitLabNodeMetadata | undefined) ?? ({} as GitLabNodeMetadata);
+
+    const project = metadata?.project?.name || configuration.project;
+    const metadataItems: MetadataItem[] = [];
+
+    if (project) {
+      metadataItems.push({ icon: "book", label: project });
+    }
+
+    if (configuration.issueIid) {
+      metadataItems.push({ icon: "circle-dot", label: `#${configuration.issueIid}` });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGitlabExecutionSubtitle(context.execution, "Assignee Added");
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const payload = outputs?.default?.[0];
+
+    if (!payload?.data) {
+      return {};
+    }
+
+    return buildAssigneeDetails(payload.data as Issue, payload.timestamp);
+  },
+};

--- a/web_src/src/pages/app/mappers/gitlab/assignee_utils.ts
+++ b/web_src/src/pages/app/mappers/gitlab/assignee_utils.ts
@@ -1,0 +1,32 @@
+import { formatTimestamp } from "../utils";
+import type { Issue } from "./types";
+
+// buildAssigneeDetails renders the shared details for the add/remove assignee
+// components: the timestamp is always first, followed by the issue, its link,
+// the current assignees and state. Kept to at most 6 items.
+export function buildAssigneeDetails(issue: Issue, payloadTimestamp?: string): Record<string, string> {
+  const details: Record<string, string> = {
+    "Updated At": formatTimestamp(issue.updated_at, payloadTimestamp),
+    Issue: issue.iid ? `#${issue.iid} ${issue.title || ""}`.trim() : "-",
+  };
+
+  addDetailIfPresent(details, "Issue URL", issue.web_url);
+  details["Assignees"] = formatAssignees(issue);
+  addDetailIfPresent(details, "State", issue.state);
+
+  return details;
+}
+
+function formatAssignees(issue: Issue): string {
+  const assignees = (issue.assignees ?? [])
+    .map((assignee) => (assignee.username ? `@${assignee.username}` : assignee.name))
+    .filter(Boolean);
+
+  return assignees.length > 0 ? assignees.join(", ") : "None";
+}
+
+function addDetailIfPresent(details: Record<string, string>, label: string, value?: string) {
+  if (value) {
+    details[label] = value;
+  }
+}

--- a/web_src/src/pages/app/mappers/gitlab/index.ts
+++ b/web_src/src/pages/app/mappers/gitlab/index.ts
@@ -2,6 +2,8 @@ import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from ".
 import { buildActionStateRegistry } from "../utils";
 import { acceptMergeRequestMapper } from "./accept_merge_request";
 import { addIssueLabelMapper } from "./add_issue_label";
+import { addIssueAssigneeMapper } from "./add_issue_assignee";
+import { removeIssueAssigneeMapper } from "./remove_issue_assignee";
 import { addMergeRequestReviewersMapper } from "./add_merge_request_reviewers";
 import { addReactionMapper } from "./add_reaction";
 import { approveMergeRequestMapper } from "./approve_merge_request";
@@ -60,6 +62,8 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createIssueComment: buildActionStateRegistry("created"),
   updateIssueComment: buildActionStateRegistry("updated"),
   addIssueLabel: buildActionStateRegistry("added"),
+  addIssueAssignee: buildActionStateRegistry("updated"),
+  removeIssueAssignee: buildActionStateRegistry("updated"),
   markMergeRequestReadyForReview: buildActionStateRegistry("marked ready"),
   createRelease: buildActionStateRegistry("created"),
   updateRelease: buildActionStateRegistry("updated"),
@@ -91,6 +95,8 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIssueComment: createIssueCommentMapper,
   updateIssueComment: updateIssueCommentMapper,
   addIssueLabel: addIssueLabelMapper,
+  addIssueAssignee: addIssueAssigneeMapper,
+  removeIssueAssignee: removeIssueAssigneeMapper,
   markMergeRequestReadyForReview: markMergeRequestReadyForReviewMapper,
   createRelease: createReleaseMapper,
   updateRelease: updateReleaseMapper,

--- a/web_src/src/pages/app/mappers/gitlab/remove_issue_assignee.spec.ts
+++ b/web_src/src/pages/app/mappers/gitlab/remove_issue_assignee.spec.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { removeIssueAssigneeMapper } from "./remove_issue_assignee";
+
+describe("removeIssueAssigneeMapper", () => {
+  it("shows updated issue assignee details after removal", () => {
+    const details = removeIssueAssigneeMapper.getExecutionDetails(
+      buildDetailsContext({
+        outputs: {
+          default: [
+            {
+              type: "gitlab.updateIssue",
+              timestamp: "2023-01-01T10:05:00.000Z",
+              data: {
+                id: 1,
+                iid: 1,
+                project_id: 123,
+                title: "Example Issue",
+                state: "opened",
+                updated_at: "2023-01-01T10:05:00.000Z",
+                assignees: [
+                  { id: 30, username: "amorgan", name: "Alex Morgan", state: "active", avatar_url: "", web_url: "" },
+                ],
+                web_url: "https://gitlab.com/my-group/my-project/-/issues/1",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Updated At": expect.any(String),
+      Issue: "#1 Example Issue",
+      "Issue URL": "https://gitlab.com/my-group/my-project/-/issues/1",
+      Assignees: "@amorgan",
+      State: "opened",
+    });
+  });
+
+  it("shows the timestamp first and at most 6 details", () => {
+    const details = removeIssueAssigneeMapper.getExecutionDetails(
+      buildDetailsContext({
+        outputs: {
+          default: [
+            {
+              type: "gitlab.updateIssue",
+              timestamp: "2023-01-01T10:05:00.000Z",
+              data: {
+                id: 1,
+                iid: 1,
+                title: "Example Issue",
+                state: "opened",
+                updated_at: "2023-01-01T10:05:00.000Z",
+                assignees: [
+                  { id: 30, username: "amorgan", name: "Alex Morgan", state: "active", avatar_url: "", web_url: "" },
+                ],
+                web_url: "https://gitlab.com/my-group/my-project/-/issues/1",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const keys = Object.keys(details);
+    expect(keys[0]).toBe("Updated At");
+    expect(keys.length).toBeLessThanOrEqual(6);
+  });
+
+  it("shows None when there are no assignees left", () => {
+    const details = removeIssueAssigneeMapper.getExecutionDetails(
+      buildDetailsContext({
+        outputs: {
+          default: [
+            {
+              type: "gitlab.updateIssue",
+              timestamp: "2023-01-01T10:05:00.000Z",
+              data: { id: 1, iid: 1, title: "Example Issue", state: "opened", assignees: [] },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details["Assignees"]).toBe("None");
+  });
+
+  it("handles missing outputs", () => {
+    const details = removeIssueAssigneeMapper.getExecutionDetails(buildDetailsContext({ outputs: {} }));
+
+    expect(details).toEqual({});
+  });
+
+  it("shows project and issue IID in node metadata", () => {
+    const context = buildDetailsContext({});
+    const props = removeIssueAssigneeMapper.props({
+      nodes: context.nodes,
+      node: context.node,
+      componentDefinition: {
+        name: "gitlab.removeIssueAssignee",
+        label: "Remove Issue Assignee",
+        description: "",
+        icon: "gitlab",
+        color: "orange",
+      },
+      lastExecutions: [],
+      currentUser: undefined,
+      actions: { invokeNodeExecutionHook: async () => {} },
+    });
+
+    expect(props.metadata).toEqual([
+      { icon: "book", label: "felixgateru/hello-world" },
+      { icon: "circle-dot", label: "#1" },
+    ]);
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Remove Issue Assignee",
+    componentName: "gitlab.removeIssueAssignee",
+    isCollapsed: false,
+    configuration: {
+      project: "123",
+      issueIid: "1",
+    },
+    metadata: {
+      project: {
+        id: 123,
+        name: "felixgateru/hello-world",
+        url: "https://gitlab.com/felixgateru/hello-world",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/gitlab/remove_issue_assignee.ts
+++ b/web_src/src/pages/app/mappers/gitlab/remove_issue_assignee.ts
@@ -1,0 +1,58 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import type { GitLabNodeMetadata, Issue } from "./types";
+import { buildGitlabExecutionSubtitle } from "./utils";
+import { buildAssigneeDetails } from "./assignee_utils";
+
+interface RemoveIssueAssigneeConfiguration {
+  project?: string;
+  issueIid?: string;
+}
+
+export const removeIssueAssigneeMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    const configuration = (context.node.configuration as RemoveIssueAssigneeConfiguration | undefined) ?? {};
+    const metadata = (context.node.metadata as GitLabNodeMetadata | undefined) ?? ({} as GitLabNodeMetadata);
+
+    const project = metadata?.project?.name || configuration.project;
+    const metadataItems: MetadataItem[] = [];
+
+    if (project) {
+      metadataItems.push({ icon: "book", label: project });
+    }
+
+    if (configuration.issueIid) {
+      metadataItems.push({ icon: "circle-dot", label: `#${configuration.issueIid}` });
+    }
+
+    return {
+      ...props,
+      metadata: metadataItems.length > 0 ? metadataItems : props.metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGitlabExecutionSubtitle(context.execution, "Assignee Removed");
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const payload = outputs?.default?.[0];
+
+    if (!payload?.data) {
+      return {};
+    }
+
+    return buildAssigneeDetails(payload.data as Issue, payload.timestamp);
+  },
+};


### PR DESCRIPTION
## What changed

Adds two new GitLab integration components — **`gitlab.addIssueAssignee`** and **`gitlab.removeIssueAssignee`** — that add/remove assignees on a GitLab issue while **preserving existing assignees** (additive semantics).

- Backend: `pkg/integrations/gitlab/{add,remove}_issue_assignee.go` + tests + example output JSON, plus three helpers in `common.go` (`assigneeIDsOf`, `mergeAssigneeIDs`, `removeAssigneeIDs`), registered in `gitlab.go` `Actions()`.
- Frontend: mappers in `web_src/src/pages/app/mappers/gitlab/{add,remove}_issue_assignee.ts` + `assignee_utils.ts` + specs, registered in the GitLab `index.ts`.

## Why

GitLab's existing `gitlab.updateIssue` component already sets assignees, but it **replaces the full assignee list** — assigning Carol would drop Alice and Bob. There was no way to add an assignee without clobbering the others, which blocks common workflows like auto-assignment on triage, escalation routing, and on-call addition.

These new components use a **fetch → merge/remove → write** flow so existing assignees are kept, mirroring the behavior GitHub already ships (`github.addIssueAssignee`).

## How

Mirrors the existing `addMergeRequestReviewers` / `removeMergeRequestReviewers` pair, which solves the identical problem (GitLab has no additive API parameter for assignees, just as it doesn't for reviewers):

1. `client.GetIssue(project, issueIID)` — read the current assignees
2. `mergeAssigneeIDs(existingIDs, newIDs)` (add) or `removeAssigneeIDs(existingIDs, removeIDs)` (remove)
3. `client.UpdateIssue(...)` with the combined `assignee_ids` — a full PUT, same as `updateIssue`
4. Emit the updated issue on the default output channel

The `assignees` field is a multi-select integration resource of type `member` scoped to the chosen project, so the picker shows real project members and yields their user IDs.

## Manual verification

Tested end-to-end against a real gitlab.com project: connected the integration via PAT, configured both components against a live issue, and confirmed the assignee was added/removed correctly on the GitLab side. (Video attached below.)

## Demo

https://github.com/user-attachments/assets/450aa499-896c-4c3c-a8b4-8a6e4e1fb619



<!-- Drag-and-drop the screen recording here; it uploads to GitHub's attachment CDN and renders inline. -->

## Checklist

- [x] Follows existing integration patterns (`addMergeRequestReviewers`/`removeMergeRequestReviewers`)
- [x] Unit tests for both components (Setup + Execute, incl. fetch-failure and update-failure paths)
- [x] Frontend mapper specs (5 tests each)
- [x] Component docs regenerated (`docs/components/GitLab.mdx`)
- [x] DCO sign-off on the commit
