### PR TITLE
fix: stop example payloads from advertising fields that are never emitted

### DIFF
--- a/pkg/components/http/example_output.json
+++ b/pkg/components/http/example_output.json
@@ -1,7 +1,6 @@
 {
   "data": {
     "status": 200,
-    "error": "Error to read request body: EOF",
     "headers": {
       "Content-Type": ["application/json"]
     },

--- a/pkg/integrations/aws/ec2/example_output_deregister_image.json
+++ b/pkg/integrations/aws/ec2/example_output_deregister_image.json
@@ -1,9 +1,10 @@
 {
   "data": {
     "requestId": "req-deregister",
-    "imageId": "ami-07f0e4f3e9c123abc",
-    "region": "us-east-1",
-    "deregistered": true
+    "image": {
+      "imageId": "ami-07f0e4f3e9c123abc"
+    },
+    "deletedSnapshots": ["snap-0a1b2c3d4e5f67890"]
   },
   "timestamp": "2026-02-19T09:10:00Z",
   "type": "aws.ec2.image.deregistered"

--- a/pkg/integrations/aws/ec2/example_output_disable_image.json
+++ b/pkg/integrations/aws/ec2/example_output_disable_image.json
@@ -1,9 +1,9 @@
 {
   "data": {
     "requestId": "req-disable",
-    "imageId": "ami-07f0e4f3e9c123abc",
-    "region": "us-east-1",
-    "disabled": true
+    "image": {
+      "imageId": "ami-07f0e4f3e9c123abc"
+    }
   },
   "timestamp": "2026-02-19T09:30:00Z",
   "type": "aws.ec2.image.disabled"

--- a/pkg/integrations/aws/ec2/example_output_disable_image_deprecation.json
+++ b/pkg/integrations/aws/ec2/example_output_disable_image_deprecation.json
@@ -1,9 +1,9 @@
 {
   "data": {
     "requestId": "req-disable-deprecation",
-    "imageId": "ami-07f0e4f3e9c123abc",
-    "region": "us-east-1",
-    "deprecationEnabled": false
+    "image": {
+      "imageId": "ami-07f0e4f3e9c123abc"
+    }
   },
   "timestamp": "2026-02-19T09:50:00Z",
   "type": "aws.ec2.image.deprecationDisabled"

--- a/pkg/integrations/aws/ec2/example_output_enable_image.json
+++ b/pkg/integrations/aws/ec2/example_output_enable_image.json
@@ -1,9 +1,9 @@
 {
   "data": {
     "requestId": "req-enable",
-    "imageId": "ami-07f0e4f3e9c123abc",
-    "region": "us-east-1",
-    "enabled": true
+    "image": {
+      "imageId": "ami-07f0e4f3e9c123abc"
+    }
   },
   "timestamp": "2026-02-19T09:20:00Z",
   "type": "aws.ec2.image.enabled"

--- a/pkg/integrations/aws/ec2/example_output_enable_image_deprecation.json
+++ b/pkg/integrations/aws/ec2/example_output_enable_image_deprecation.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "requestId": "req-enable-deprecation",
-    "imageId": "ami-07f0e4f3e9c123abc",
-    "region": "us-east-1",
     "deprecateAt": "2026-04-01T00:00:00Z",
-    "deprecationEnabled": true
+    "image": {
+      "imageId": "ami-07f0e4f3e9c123abc"
+    }
   },
   "timestamp": "2026-02-19T09:40:00Z",
   "type": "aws.ec2.image.deprecationEnabled"

--- a/pkg/integrations/circleci/example_output_run_pipeline.json
+++ b/pkg/integrations/circleci/example_output_run_pipeline.json
@@ -1,1 +1,1 @@
-{"data":{"pipeline":{"id":"1285fe1d-d3a6-44fc-8886-8979558254c4","number":130,"created_at":"2021-09-01T22:49:03.544Z"},"workflows":[{"id":"fda08377-fe7e-46b1-8992-3a7aaecac9c3","name":"build-test-deploy","status":"success"}]},"timestamp":"2021-09-01T22:49:34.317Z","type":"circleci.workflow.completed"}
+{"data":{"pipeline":{"id":"1285fe1d-d3a6-44fc-8886-8979558254c4","number":130,"created_at":"2021-09-01T22:49:03.544Z"}},"timestamp":"2021-09-01T22:49:34.317Z","type":"circleci.workflow.completed"}

--- a/pkg/lint/examplepayloads/checker.go
+++ b/pkg/lint/examplepayloads/checker.go
@@ -74,6 +74,14 @@ var coreTriggerNames = map[string]bool{
 	"start": true,
 }
 
+// dataCheckExemptions lists nodes whose example documents fields that no single
+// Emit call spells out — a third-party webhook body forwarded verbatim, say —
+// and are therefore exempt from the phantom-field check. Keys use exampleKey.
+//
+// Reach for this when the example is right and the analysis cannot prove it.
+// Deleting a field users can legitimately read is the wrong way out.
+var dataCheckExemptions = map[string]bool{}
+
 type exampleRecord struct {
 	Name    string
 	Kind    nodeKind
@@ -117,6 +125,20 @@ type packageAnalyzer struct {
 	typeMetas    map[string]typeMeta
 	summaryCache map[string]summary
 	summarizing  map[string]bool
+
+	// mutations of the method currently being walked, keyed by local variable.
+	currentMutations *mutations
+}
+
+// mutations records how a function body changes its local map variables after
+// they are first assigned. Inference reads only the initial assignment, so
+// these two facts decide whether the resulting schema can be trusted to list
+// every key the payload may carry.
+type mutations struct {
+	// keys added through v["name"] = …, anywhere in the body.
+	addedKeys map[string]map[string]bool
+	// variables whose key set can no longer be claimed complete.
+	inexact map[string]bool
 }
 
 func Run() ([]Issue, error) {
@@ -137,7 +159,7 @@ func Run() ([]Issue, error) {
 	var issues []Issue
 	for _, pkg := range pkgs {
 		analyzer := newPackageAnalyzer(pkg)
-		typeIssues, specs := analyzer.collectEmitSpecs()
+		typeIssues, specs, shared := analyzer.collectEmitSpecs()
 		issues = append(issues, typeIssues...)
 
 		for _, meta := range analyzer.typeMetas {
@@ -159,7 +181,7 @@ func Run() ([]Issue, error) {
 			}
 
 			issues = append(issues, validateExampleEnvelope(example)...)
-			issues = append(issues, validateExampleAgainstSpecs(example, specs[key])...)
+			issues = append(issues, validateExampleAgainstSpecs(example, specs[key], shared)...)
 		}
 	}
 
@@ -173,7 +195,13 @@ func Run() ([]Issue, error) {
 		if issues[i].Kind != issues[j].Kind {
 			return issues[i].Kind < issues[j].Kind
 		}
-		return issues[i].Name < issues[j].Name
+		if issues[i].Name != issues[j].Name {
+			return issues[i].Name < issues[j].Name
+		}
+		// One example can raise several issues that share every field above,
+		// and package order comes from a map, so the message settles the tie
+		// to keep CI output identical between runs.
+		return issues[i].Message < issues[j].Message
 	})
 
 	return issues, nil
@@ -390,7 +418,10 @@ func (a *packageAnalyzer) collectGenDecl(genDecl *ast.GenDecl) {
 	}
 }
 
-func (a *packageAnalyzer) collectEmitSpecs() ([]Issue, map[string][]emitSpec) {
+// collectEmitSpecs returns the Emit calls made by each component's own methods,
+// plus the ones made by package-level helpers. Helper calls describe a shape but
+// say nothing about which component owns a payload type, so they are kept apart.
+func (a *packageAnalyzer) collectEmitSpecs() ([]Issue, map[string][]emitSpec, []emitSpec) {
 	specs := map[string][]emitSpec{}
 	var issues []Issue
 
@@ -414,14 +445,231 @@ func (a *packageAnalyzer) collectEmitSpecs() ([]Issue, map[string][]emitSpec) {
 					continue
 				}
 
-				methodSpecs := a.collectEmitSpecsFromBlock(fn.Body, map[string]schema{})
 				key := exampleKey(meta.Kind, meta.Name)
-				specs[key] = append(specs[key], methodSpecs...)
+				specs[key] = append(specs[key], a.emitSpecsIn(fn)...)
 			}
 		}
 	}
 
-	return issues, specs
+	shared := a.sharedEmitSpecs()
+	a.stepDownUnreadEmitters(specs, shared)
+
+	return issues, specs, shared
+}
+
+func (a *packageAnalyzer) emitSpecsIn(fn *ast.FuncDecl) []emitSpec {
+	a.currentMutations = a.collectMutations(fn.Body)
+	defer func() { a.currentMutations = nil }()
+
+	return a.collectEmitSpecsFromBlock(fn.Body, map[string]schema{})
+}
+
+func (a *packageAnalyzer) sharedEmitSpecs() []emitSpec {
+	var shared []emitSpec
+
+	for _, file := range a.pkg.Syntax {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+
+			if fn.Recv != nil {
+				if _, ok := a.typeMetas[receiverTypeName(fn.Recv.List[0].Type)]; ok {
+					continue
+				}
+			}
+
+			shared = append(shared, a.emitSpecsIn(fn)...)
+		}
+	}
+
+	return shared
+}
+
+// stepDownUnreadEmitters clears exactness wherever an Emit still escaped the
+// walker — inside a closure, or with a payload type that is not a constant.
+// Claiming a complete key set from only the calls we managed to read is what
+// would let the checker call a legitimate field phantom.
+//
+// An unread Emit outside a component method cannot be tied to one component, so
+// every component in that package steps down.
+func (a *packageAnalyzer) stepDownUnreadEmitters(specs map[string][]emitSpec, shared []emitSpec) {
+	read := map[token.Position]bool{}
+	for _, list := range specs {
+		for _, spec := range list {
+			read[spec.Position] = true
+		}
+	}
+
+	for _, spec := range shared {
+		read[spec.Position] = true
+	}
+
+	unreadOwners := map[string]bool{}
+	packageWide := false
+
+	for _, file := range a.pkg.Syntax {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+
+			owner := ""
+			if fn.Recv != nil {
+				owner = receiverTypeName(fn.Recv.List[0].Type)
+			}
+
+			if !a.hasUnreadEmit(fn.Body, read) {
+				continue
+			}
+
+			if _, ok := a.typeMetas[owner]; !ok {
+				packageWide = true
+				continue
+			}
+
+			unreadOwners[owner] = true
+		}
+	}
+
+	for recvType, meta := range a.typeMetas {
+		if !packageWide && !unreadOwners[recvType] {
+			continue
+		}
+
+		key := exampleKey(meta.Kind, meta.Name)
+		for i := range specs[key] {
+			specs[key][i].Data.Exact = false
+		}
+	}
+
+	if !packageWide {
+		return
+	}
+
+	for i := range shared {
+		shared[i].Data.Exact = false
+	}
+}
+
+func (a *packageAnalyzer) hasUnreadEmit(body *ast.BlockStmt, read map[token.Position]bool) bool {
+	unread := false
+
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !isEmitCall(call) {
+			return true
+		}
+
+		if !read[a.pkg.Fset.Position(call.Pos())] {
+			unread = true
+		}
+
+		return true
+	})
+
+	return unread
+}
+
+// collectMutations walks the entire body, including conditional and loop
+// branches. The spec walker clones its environment per branch, so a key added
+// inside an if or switch is otherwise lost by the time Emit is reached.
+func (a *packageAnalyzer) collectMutations(body *ast.BlockStmt) *mutations {
+	m := &mutations{
+		addedKeys: map[string]map[string]bool{},
+		inexact:   map[string]bool{},
+	}
+
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.AssignStmt:
+			for _, lhs := range n.Lhs {
+				a.recordIndexAssign(m, lhs)
+			}
+		case *ast.CallExpr:
+			recordEscapes(m, n)
+		}
+
+		return true
+	})
+
+	return m
+}
+
+func (a *packageAnalyzer) recordIndexAssign(m *mutations, lhs ast.Expr) {
+	indexExpr, ok := lhs.(*ast.IndexExpr)
+	if !ok {
+		return
+	}
+
+	base, ok := indexExpr.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+
+	key, ok := a.stringLiteral(indexExpr.Index)
+	if !ok {
+		// A computed key can add anything, so the key set stops being known.
+		m.inexact[base.Name] = true
+		return
+	}
+
+	if m.addedKeys[base.Name] == nil {
+		m.addedKeys[base.Name] = map[string]bool{}
+	}
+
+	m.addedKeys[base.Name][key] = true
+}
+
+// recordEscapes marks variables passed to another call. Helpers commonly enrich
+// a payload map in place, and that call is invisible to schema inference.
+func recordEscapes(m *mutations, call *ast.CallExpr) {
+	if isEmitCall(call) {
+		return
+	}
+
+	for _, arg := range call.Args {
+		ident, ok := arg.(*ast.Ident)
+		if !ok {
+			continue
+		}
+
+		m.inexact[ident.Name] = true
+	}
+}
+
+// apply folds the recorded mutations into the schema inferred from the
+// variable's initial assignment.
+func (m *mutations) apply(data schema, name string) schema {
+	if data.Kind != schemaObject {
+		return data
+	}
+
+	if m.inexact[name] {
+		data.Exact = false
+	}
+
+	added := m.addedKeys[name]
+	if len(added) == 0 {
+		return data
+	}
+
+	fields := make(map[string]schema, len(data.Fields)+len(added))
+	for key, value := range data.Fields {
+		fields[key] = value
+	}
+
+	for key := range added {
+		if _, ok := fields[key]; !ok {
+			fields[key] = schema{Kind: schemaUnknown}
+		}
+	}
+
+	data.Fields = fields
+
+	return data
 }
 
 func (a *packageAnalyzer) collectEmitSpecsFromBlock(block *ast.BlockStmt, env map[string]schema) []emitSpec {
@@ -469,8 +717,19 @@ func (a *packageAnalyzer) collectEmitSpecsFromStmt(stmt ast.Stmt, env map[string
 			}
 		}
 		return specs
+	case *ast.AssignStmt:
+		// Components commonly emit as `err = ctx.…Emit(…)` before inspecting
+		// err, so the payload of an assigned Emit counts like any other.
+		var specs []emitSpec
+		for _, rhs := range s.Rhs {
+			if spec, ok := a.emitSpecFromCall(rhs, env); ok {
+				specs = append(specs, spec)
+			}
+		}
+		return specs
 	case *ast.IfStmt:
 		var specs []emitSpec
+		specs = append(specs, a.collectEmitSpecsFromStmt(s.Init, cloneEnv(env))...)
 		specs = append(specs, a.collectEmitSpecsFromBlock(s.Body, cloneEnv(env))...)
 		if elseBlock, ok := s.Else.(*ast.BlockStmt); ok {
 			specs = append(specs, a.collectEmitSpecsFromBlock(elseBlock, cloneEnv(env))...)
@@ -506,8 +765,7 @@ func (a *packageAnalyzer) emitSpecFromCall(expr ast.Expr, env map[string]schema)
 		return emitSpec{}, false
 	}
 
-	selector, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok || selector.Sel.Name != "Emit" {
+	if !isEmitCall(call) {
 		return emitSpec{}, false
 	}
 
@@ -520,7 +778,7 @@ func (a *packageAnalyzer) emitSpecFromCall(expr ast.Expr, env map[string]schema)
 
 		return emitSpec{
 			PayloadType: payloadType,
-			Data:        a.inferExpr(call.Args[1], env),
+			Data:        a.withMutations(a.inferExpr(call.Args[1], env), call.Args[1]),
 			Position:    a.pkg.Fset.Position(call.Pos()),
 		}, true
 	case 3:
@@ -531,12 +789,54 @@ func (a *packageAnalyzer) emitSpecFromCall(expr ast.Expr, env map[string]schema)
 
 		return emitSpec{
 			PayloadType: payloadType,
-			Data:        a.inferPayloadList(call.Args[2], env),
+			Data:        a.withMutations(a.inferPayloadList(call.Args[2], env), call.Args[2]),
 			Position:    a.pkg.Fset.Position(call.Pos()),
 		}, true
 	}
 
 	return emitSpec{}, false
+}
+
+func isEmitCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "Emit"
+}
+
+// withMutations adjusts a payload schema by what the surrounding method does to
+// the variable it came from. Inline literals reference no variable and are left
+// untouched.
+func (a *packageAnalyzer) withMutations(data schema, expr ast.Expr) schema {
+	if a.currentMutations == nil {
+		return data
+	}
+
+	for _, name := range payloadVarNames(expr) {
+		data = a.currentMutations.apply(data, name)
+	}
+
+	return data
+}
+
+// payloadVarNames returns the variables a payload argument refers to, unwrapping
+// the []any{…} wrapper the three-argument Emit form uses. A list carrying
+// several payloads contributes each of them, since the schemas were merged and
+// any one of them can make the key set incomplete.
+func payloadVarNames(expr ast.Expr) []string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return []string{e.Name}
+	case *ast.ParenExpr:
+		return payloadVarNames(e.X)
+	case *ast.CompositeLit:
+		var names []string
+		for _, elt := range e.Elts {
+			names = append(names, payloadVarNames(elt)...)
+		}
+
+		return names
+	}
+
+	return nil
 }
 
 func (a *packageAnalyzer) inferPayloadList(expr ast.Expr, env map[string]schema) schema {
@@ -1071,13 +1371,18 @@ func validateExampleEnvelope(example exampleRecord) []Issue {
 	return issues
 }
 
-func validateExampleAgainstSpecs(example exampleRecord, specs []emitSpec) []Issue {
+// validateExampleAgainstSpecs checks an example against the Emit calls of its
+// own component. Shared specs come from package-level helpers, so they widen the
+// known shape of a payload type but never define which types a component emits —
+// counting them as its vocabulary would accuse unrelated components in the same
+// package of declaring the wrong type.
+func validateExampleAgainstSpecs(example exampleRecord, specs []emitSpec, shared []emitSpec) []Issue {
 	if len(specs) == 0 {
 		return nil
 	}
 
 	var payloadTypes []string
-	typeMatched := false
+	var matched []emitSpec
 	exampleType, _ := example.Payload["type"].(string)
 	for _, spec := range specs {
 		payloadTypes = append(payloadTypes, spec.PayloadType)
@@ -1085,11 +1390,10 @@ func validateExampleAgainstSpecs(example exampleRecord, specs []emitSpec) []Issu
 			continue
 		}
 
-		typeMatched = true
-		break
+		matched = append(matched, spec)
 	}
 
-	if !typeMatched {
+	if len(matched) == 0 {
 		return []Issue{{
 			Name:    example.Name,
 			Kind:    example.Kind,
@@ -1097,7 +1401,109 @@ func validateExampleAgainstSpecs(example exampleRecord, specs []emitSpec) []Issu
 		}}
 	}
 
-	return nil
+	position := matched[0].Position
+
+	for _, spec := range shared {
+		if spec.PayloadType == exampleType {
+			matched = append(matched, spec)
+		}
+	}
+
+	return validateExampleData(example, mergeEmitSchemas(matched), position)
+}
+
+// mergeEmitSchemas combines every Emit call that publishes the same payload
+// type, since a component may emit one type from several places. A call the
+// analyzer could not read says nothing about the full key set, so the result
+// stops being exact.
+func mergeEmitSchemas(specs []emitSpec) schema {
+	if len(specs) == 0 {
+		return schema{Kind: schemaUnknown}
+	}
+
+	merged := specs[0].Data
+	exact := merged.Kind != schemaUnknown
+
+	for _, spec := range specs[1:] {
+		if spec.Data.Kind == schemaUnknown {
+			exact = false
+		}
+
+		merged = mergeSchema(merged, spec.Data)
+	}
+
+	if !exact {
+		merged.Exact = false
+	}
+
+	return merged
+}
+
+// validateExampleData reports fields an example advertises that the component
+// never emits. Users write expressions from these examples, so a field that
+// cannot exist at runtime silently resolves to nothing.
+//
+// It reports only when the inferred schema is known to list every key the
+// payload can carry. A payload returned by a client call, enriched by a helper,
+// or keyed dynamically offers no such guarantee and is left alone.
+func validateExampleData(example exampleRecord, data schema, position token.Position) []Issue {
+	if dataCheckExemptions[exampleKey(example.Kind, example.Name)] {
+		return nil
+	}
+
+	if data.Kind != schemaObject || !data.Exact || len(data.Fields) == 0 {
+		return nil
+	}
+
+	raw, ok := example.Payload["data"]
+	if !ok {
+		return nil
+	}
+
+	fields, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var phantom []string
+	for key := range fields {
+		if _, ok := data.Fields[key]; !ok {
+			phantom = append(phantom, key)
+		}
+	}
+
+	sort.Strings(phantom)
+
+	emitted := make([]string, 0, len(data.Fields))
+	for key := range data.Fields {
+		emitted = append(emitted, key)
+	}
+	sort.Strings(emitted)
+
+	issues := make([]Issue, 0, len(phantom))
+	for _, key := range phantom {
+		issues = append(issues, Issue{
+			Name: example.Name,
+			Kind: example.Kind,
+			Path: relativePath(position.Filename),
+			Line: position.Line,
+			Message: fmt.Sprintf(
+				"example advertises data.%s, but this Emit sends only [%s]; drop it from the example payload or emit it",
+				key, strings.Join(emitted, " "),
+			),
+		})
+	}
+
+	return issues
+}
+
+func relativePath(path string) string {
+	relative, err := filepath.Rel(repoRoot(), path)
+	if err != nil {
+		return path
+	}
+
+	return relative
 }
 
 func mergeSchema(left, right schema) schema {

--- a/pkg/lint/examplepayloads/checker_test.go
+++ b/pkg/lint/examplepayloads/checker_test.go
@@ -1,6 +1,14 @@
 package examplepayloads
 
-import "testing"
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestRun(t *testing.T) {
 	issues, err := Run()
@@ -11,4 +19,352 @@ func TestRun(t *testing.T) {
 	for _, issue := range issues {
 		t.Errorf("%s", issue.String())
 	}
+}
+
+// emitSpecsFor parses a single-file package and returns the Emit specs
+// collected for the action it declares.
+func emitSpecsFor(t *testing.T, body string) []emitSpec {
+	t.Helper()
+
+	source := `package example
+
+type Widget struct{}
+
+func (w *Widget) Name() string { return "widget" }
+
+func (w *Widget) ExampleOutput() map[string]any { return nil }
+
+func (w *Widget) Execute(ctx Context) error {
+` + body + `
+}
+`
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "widget.go", source, parser.AllErrors)
+	require.NoError(t, err)
+
+	analyzer := newPackageAnalyzer(&loadedPackage{
+		ImportPath: "example",
+		Dir:        ".",
+		Fset:       fset,
+		Syntax:     []*ast.File{file},
+	})
+
+	issues, specs, _ := analyzer.collectEmitSpecs()
+	require.Empty(t, issues)
+
+	return specs[exampleKey(nodeKindAction, "widget")]
+}
+
+// emitSpecsForSource is emitSpecsFor for sources that need declarations outside
+// the component method, such as package-level emitting helpers.
+func emitSpecsForSource(t *testing.T, source string) ([]emitSpec, []emitSpec) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "widget.go", source, parser.AllErrors)
+	require.NoError(t, err)
+
+	analyzer := newPackageAnalyzer(&loadedPackage{
+		ImportPath: "example",
+		Dir:        ".",
+		Fset:       fset,
+		Syntax:     []*ast.File{file},
+	})
+
+	issues, specs, shared := analyzer.collectEmitSpecs()
+	require.Empty(t, issues)
+
+	return specs[exampleKey(nodeKindAction, "widget")], shared
+}
+
+const widgetPreamble = `package example
+
+type Widget struct{}
+
+func (w *Widget) Name() string { return "widget" }
+
+func (w *Widget) ExampleOutput() map[string]any { return nil }
+`
+
+// An Emit written as `err = ctx.Emit(...)` is an assignment, not an expression
+// or a return. Missing that shape once made the checker judge a component by a
+// fraction of its Emit calls and report real fields as phantom.
+func TestEmitAssignedToAVariableIsCollected(t *testing.T) {
+	specs := emitSpecsFor(t, `
+	var err error
+	payload := map[string]any{"fromAssignment": 1}
+	err = ctx.Emit("widget.done", payload)
+	return err`)
+
+	require.Len(t, specs, 1)
+	assert.Contains(t, specs[0].Data.Fields, "fromAssignment")
+}
+
+func TestEmitInsideAClosureStepsDownExactness(t *testing.T) {
+	specs, _ := emitSpecsForSource(t, widgetPreamble+`
+func (w *Widget) Execute(ctx Context) error {
+	ctx.Later(func() {
+		_ = ctx.Emit("widget.done", map[string]any{"fromClosure": 1})
+	})
+	return ctx.Emit("widget.done", map[string]any{"id": 1})
+}
+`)
+
+	require.NotEmpty(t, specs)
+	for _, spec := range specs {
+		assert.False(t, spec.Data.Exact, "an Emit the walker cannot attribute must disable phantom reporting")
+	}
+}
+
+func TestEmitInAPackageLevelHelperIsCollectedAsShared(t *testing.T) {
+	own, shared := emitSpecsForSource(t, widgetPreamble+`
+func (w *Widget) Execute(ctx Context) error {
+	return ctx.Emit("widget.done", map[string]any{"id": 1})
+}
+
+func emitFailure(ctx Context) error {
+	return ctx.Emit("widget.done", map[string]any{"failure": 1})
+}
+`)
+
+	require.Len(t, own, 1)
+	require.Len(t, shared, 1)
+	assert.Contains(t, shared[0].Data.Fields, "failure")
+	assert.NotContains(t, own[0].Data.Fields, "failure",
+		"a helper Emit is not owned by the component; it only widens the shape")
+}
+
+// A helper Emit widens the known shape, so a field only that helper sends must
+// not be reported against a component that shares the payload type.
+func TestSharedHelperFieldIsNotPhantom(t *testing.T) {
+	example := exampleRecord{
+		Name: "widget",
+		Kind: nodeKindAction,
+		Payload: map[string]any{
+			"type": "widget.done",
+			"data": map[string]any{"id": 1, "failure": "boom"},
+		},
+	}
+
+	own := []emitSpec{{
+		PayloadType: "widget.done",
+		Data:        schema{Kind: schemaObject, Exact: true, Fields: map[string]schema{"id": {Kind: schemaNumber}}},
+	}}
+
+	shared := []emitSpec{{
+		PayloadType: "widget.done",
+		Data:        schema{Kind: schemaObject, Exact: true, Fields: map[string]schema{"failure": {Kind: schemaString}}},
+	}}
+
+	assert.Empty(t, validateExampleAgainstSpecs(example, own, shared))
+}
+
+// Shared specs must not widen the set of payload types a component declares, or
+// unrelated components in the same package get accused of the wrong type.
+func TestSharedSpecsDoNotDefineAComponentsPayloadTypes(t *testing.T) {
+	example := exampleRecord{
+		Name:    "widget",
+		Kind:    nodeKindAction,
+		Payload: map[string]any{"type": "widget.done", "data": map[string]any{}},
+	}
+
+	shared := []emitSpec{{PayloadType: "other.thing"}}
+
+	assert.Empty(t, validateExampleAgainstSpecs(example, nil, shared),
+		"a component with no Emit of its own stays unchecked")
+}
+
+func TestMergeEmitSchemasHandlesNoSpecs(t *testing.T) {
+	assert.Equal(t, schemaUnknown, mergeEmitSchemas(nil).Kind)
+}
+
+func TestExemptNodeIsNotChecked(t *testing.T) {
+	key := exampleKey(nodeKindAction, "widget")
+	dataCheckExemptions[key] = true
+	defer delete(dataCheckExemptions, key)
+
+	example := exampleRecord{
+		Name: "widget",
+		Kind: nodeKindAction,
+		Payload: map[string]any{
+			"type": "widget.done",
+			"data": map[string]any{"documentedElsewhere": true},
+		},
+	}
+
+	data := schema{
+		Kind:   schemaObject,
+		Exact:  true,
+		Fields: map[string]schema{"id": {Kind: schemaNumber}},
+	}
+
+	assert.Empty(t, validateExampleData(example, data, token.Position{}))
+}
+
+func TestKeysAddedInsideAConditionalStayInTheSchema(t *testing.T) {
+	specs := emitSpecsFor(t, `
+	payload := map[string]any{"pipeline": 1}
+	if ctx.Ready {
+		payload["workflow"] = 2
+	}
+	return ctx.Emit("widget.done", payload)`)
+
+	require.Len(t, specs, 1)
+	assert.True(t, specs[0].Data.Exact, "a fully readable payload stays exact")
+	assert.Contains(t, specs[0].Data.Fields, "pipeline")
+	assert.Contains(t, specs[0].Data.Fields, "workflow", "the branch key must survive the per-branch env clone")
+}
+
+func TestPayloadHandedToAHelperIsNotExact(t *testing.T) {
+	specs := emitSpecsFor(t, `
+	payload := map[string]any{"id": 1}
+	enrich(ctx, payload)
+	return ctx.Emit("widget.done", payload)`)
+
+	require.Len(t, specs, 1)
+	assert.False(t, specs[0].Data.Exact, "a helper may add keys the analyzer cannot see")
+}
+
+func TestPayloadWithAComputedKeyIsNotExact(t *testing.T) {
+	specs := emitSpecsFor(t, `
+	payload := map[string]any{"id": 1}
+	payload[ctx.Key] = 2
+	return ctx.Emit("widget.done", payload)`)
+
+	require.Len(t, specs, 1)
+	assert.False(t, specs[0].Data.Exact, "a computed key can add anything")
+}
+
+func TestInlinePayloadLiteralIsExact(t *testing.T) {
+	specs := emitSpecsFor(t, `
+	return ctx.Emit("widget.done", map[string]any{"id": 1})`)
+
+	require.Len(t, specs, 1)
+	assert.True(t, specs[0].Data.Exact)
+	assert.Contains(t, specs[0].Data.Fields, "id")
+}
+
+func TestMergeEmitSchemasUnionsFields(t *testing.T) {
+	merged := mergeEmitSchemas([]emitSpec{
+		{Data: schema{Kind: schemaObject, Exact: true, Fields: map[string]schema{"a": {Kind: schemaNumber}}}},
+		{Data: schema{Kind: schemaObject, Exact: true, Fields: map[string]schema{"b": {Kind: schemaNumber}}}},
+	})
+
+	assert.True(t, merged.Exact)
+	assert.Contains(t, merged.Fields, "a")
+	assert.Contains(t, merged.Fields, "b")
+}
+
+func TestMergeEmitSchemasDropsExactnessOnUnreadableCall(t *testing.T) {
+	merged := mergeEmitSchemas([]emitSpec{
+		{Data: schema{Kind: schemaObject, Exact: true, Fields: map[string]schema{"a": {Kind: schemaNumber}}}},
+		{Data: schema{Kind: schemaUnknown}},
+	})
+
+	assert.False(t, merged.Exact, "an unreadable Emit says nothing about the full key set")
+}
+
+func TestValidateExampleDataReportsPhantomFields(t *testing.T) {
+	example := exampleRecord{
+		Name: "widget",
+		Kind: nodeKindAction,
+		Payload: map[string]any{
+			"type": "widget.done",
+			"data": map[string]any{"id": 1, "region": "us-east-1"},
+		},
+	}
+
+	data := schema{
+		Kind:   schemaObject,
+		Exact:  true,
+		Fields: map[string]schema{"id": {Kind: schemaNumber}},
+	}
+
+	issues := validateExampleData(example, data, token.Position{})
+
+	require.Len(t, issues, 1)
+	assert.Contains(t, issues[0].Message, "data.region")
+}
+
+func TestValidateExampleDataAcceptsAMatchingExample(t *testing.T) {
+	example := exampleRecord{
+		Name: "widget",
+		Kind: nodeKindAction,
+		Payload: map[string]any{
+			"type": "widget.done",
+			"data": map[string]any{"id": 1},
+		},
+	}
+
+	data := schema{
+		Kind:   schemaObject,
+		Exact:  true,
+		Fields: map[string]schema{"id": {Kind: schemaNumber}},
+	}
+
+	assert.Empty(t, validateExampleData(example, data, token.Position{}))
+}
+
+func TestValidateExampleDataStaysSilentWhenTheSchemaIsNotExact(t *testing.T) {
+	example := exampleRecord{
+		Name: "widget",
+		Kind: nodeKindAction,
+		Payload: map[string]any{
+			"type": "widget.done",
+			"data": map[string]any{"anything": true},
+		},
+	}
+
+	data := schema{
+		Kind:   schemaObject,
+		Exact:  false,
+		Fields: map[string]schema{"id": {Kind: schemaNumber}},
+	}
+
+	assert.Empty(t, validateExampleData(example, data, token.Position{}),
+		"an inexact schema must never accuse a field of being phantom")
+}
+
+func TestValidateExampleAgainstSpecsMergesSitesSharingAType(t *testing.T) {
+	example := exampleRecord{
+		Name: "widget",
+		Kind: nodeKindAction,
+		Payload: map[string]any{
+			"type": "widget.done",
+			"data": map[string]any{"passed": true, "failed": true},
+		},
+	}
+
+	specs := []emitSpec{
+		{
+			PayloadType: "widget.done",
+			Data:        schema{Kind: schemaObject, Exact: true, Fields: map[string]schema{"passed": {Kind: schemaBool}}},
+		},
+		{
+			PayloadType: "widget.done",
+			Data:        schema{Kind: schemaObject, Exact: true, Fields: map[string]schema{"failed": {Kind: schemaBool}}},
+		},
+	}
+
+	assert.Empty(t, validateExampleAgainstSpecs(example, specs, nil),
+		"a field emitted by any site sharing the type is not phantom")
+}
+
+func TestValidateExampleAgainstSpecsReportsAnUnknownType(t *testing.T) {
+	example := exampleRecord{
+		Name: "widget",
+		Kind: nodeKindAction,
+		Payload: map[string]any{
+			"type": "widget.missing",
+			"data": map[string]any{},
+		},
+	}
+
+	specs := []emitSpec{{PayloadType: "widget.done"}}
+
+	issues := validateExampleAgainstSpecs(example, specs, nil)
+
+	require.Len(t, issues, 1)
+	assert.Contains(t, issues[0].Message, "does not match any Emit(...) payload type")
 }


### PR DESCRIPTION
## What

Activates the data-shape half of the example-payload lint and corrects the 17 phantom fields it surfaces across 7 examples.

Closes #3797.

## Why

Components declare an example payload, and users read it when writing expressions. `pkg/lint/examplepayloads` already inferred the shape of the data passed to each `Emit(...)` and stored it on `emitSpec.Data`, but only the payload `type` string was ever compared — the inferred shape was never read. A field an example advertises that no `Emit` sends resolves to nothing at runtime, with no warning anywhere.

The `http` component is the most visible case: both `http.request.finished` sites send `{status, headers, body}`, while the example also promised `error`, which exists only on the failure payload. The five AWS EC2 image actions advertised a flat `{imageId, region, …}` where the components nest the image under `data.image`, and `circleci.runPipeline` advertised `workflows`, which it fetches but never emits.

The issue asks for a mechanism that keeps these accurate over time, not another round of manual corrections.

## How

Comparing an example against the inferred shape is only sound when that shape is known to list every key a payload can carry, so most of this change establishes that guarantee:

- `Emit` written as `err = ctx.…Emit(…)`, or in an `if` initialiser, is now collected. It was invisible before, which made a component look narrower than it is and would have reported real fields as phantom.
- `Emit` in a package-level helper is collected as a shared spec. It widens the known shape of a payload type without joining the set of types its component declares.
- Any `Emit` still unattributable — inside a closure, or with a non-constant payload type — clears exactness for the affected component, so the check goes quiet rather than guessing.
- Keys added through `v["k"] = …` inside a branch are unioned into the shape, while a payload handed to another call or keyed dynamically is no longer treated as complete.
- Sites sharing a payload type are merged instead of first-match-wins.

## Scope

Deliberately narrow, to keep the gate trustworthy:

- Only top-level `data` keys are compared.
- Only one direction is reported: fields an example claims but never receives. Fields a component emits without documenting are left alone, since `omitempty` drops them routinely and flagging those would be noise.
- `dataCheckExemptions` gives maintainers a one-line exit when an example is right and the analysis cannot prove it, following the existing `coreTriggerNames` pattern.

## Verification

- `make check.example.payloads` and `make lint` both pass.
- 19 tests in `pkg/lint/examplepayloads`, covering each statement shape the collector must not miss.
- Reverting any of the 7 payload fixes reproduces its findings; output is byte-identical across runs.
- Both commits pass CI independently, so the history stays bisectable.