### PR TITLE
fix: weeks schedule fires on only one of the selected weekdays

### DIFF
--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -723,28 +723,54 @@ func nextWeeksTrigger(interval int, weekDays []string, hour int, minute int, now
 
 	// Find next occurrence of any of the specified weekdays
 	validWeekdays := make(map[time.Weekday]bool)
+	var parsedWeekdays []time.Weekday
 	for _, dayStr := range weekDays {
 		weekday, err := parseWeekday(dayStr)
 		if err != nil {
 			return nil, err
 		}
-		validWeekdays[weekday] = true
-	}
-
-	nextIntervalStart := nowInTZ.AddDate(0, 0, interval*7)
-
-	// start the search on Sunday of the next week
-	nextIntervalStart.Add(-time.Duration(nextIntervalStart.Weekday()) * time.Hour)
-	for i := 0; i < 7; i++ {
-		checkDate := nextIntervalStart.AddDate(0, 0, i)
-		if validWeekdays[checkDate.Weekday()] {
-			candidateTime := time.Date(checkDate.Year(), checkDate.Month(), checkDate.Day(), hour, minute, 0, 0, checkDate.Location())
-			utcResult := candidateTime.UTC()
-			return &utcResult, nil
+		if !validWeekdays[weekday] {
+			validWeekdays[weekday] = true
+			parsedWeekdays = append(parsedWeekdays, weekday)
 		}
 	}
 
-	return nil, fmt.Errorf("no valid weekday found")
+	if len(parsedWeekdays) == 0 {
+		return nil, fmt.Errorf("no valid weekday specified")
+	}
+
+	// Get start of the current week (Sunday at 00:00:00)
+	currentWeekSunday := nowInTZ.AddDate(0, 0, -int(nowInTZ.Weekday()))
+	currentWeekSunday = time.Date(currentWeekSunday.Year(), currentWeekSunday.Month(), currentWeekSunday.Day(), 0, 0, 0, 0, currentWeekSunday.Location())
+
+	var nextTrigger *time.Time
+
+	for _, weekday := range parsedWeekdays {
+		// Calculate the candidate time in the current week (Week 0)
+		candidateTime := currentWeekSunday.AddDate(0, 0, int(weekday))
+		candidateTime = time.Date(candidateTime.Year(), candidateTime.Month(), candidateTime.Day(), hour, minute, 0, 0, candidateTime.Location())
+
+		var occurrence time.Time
+		if candidateTime.After(nowInTZ) {
+			// If it's in the future of the current week, next occurrence is this week (0 weeks added)
+			occurrence = candidateTime
+		} else {
+			// Otherwise, it is in a future week (interval weeks added)
+			occurrence = candidateTime.AddDate(0, 0, interval*7)
+		}
+
+		if nextTrigger == nil || occurrence.Before(*nextTrigger) {
+			temp := occurrence
+			nextTrigger = &temp
+		}
+	}
+
+	if nextTrigger == nil {
+		return nil, fmt.Errorf("no valid weekday found")
+	}
+
+	utcResult := nextTrigger.UTC()
+	return &utcResult, nil
 }
 
 func nextMonthsTrigger(interval int, dayOfMonth int, hour int, minute int, now time.Time) (*time.Time, error) {

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -145,7 +145,43 @@ func TestGetNextTrigger(t *testing.T) {
 				Minute:        intPtr(30),
 			},
 			now:        mustParseTime("2025-01-06T10:00:00Z"), // Monday
-			expectNext: mustParseTime("2025-01-17T15:30:00Z"), // Friday of next week
+			expectNext: mustParseTime("2025-01-10T15:30:00Z"), // Friday of current week
+		},
+		{
+			name: "weeks configuration with multiple weekdays - same week run",
+			config: Configuration{
+				Type:          TypeWeeks,
+				WeeksInterval: intPtr(1),
+				WeekDays:      []string{"monday", "wednesday"},
+				Hour:          intPtr(9),
+				Minute:        intPtr(0),
+			},
+			now:        mustParseTime("2025-01-06T10:00:00Z"), // Monday 10 AM UTC
+			expectNext: mustParseTime("2025-01-08T09:00:00Z"), // Wednesday of current week at 9 AM UTC
+		},
+		{
+			name: "weeks configuration with multiple weekdays - next week run",
+			config: Configuration{
+				Type:          TypeWeeks,
+				WeeksInterval: intPtr(1),
+				WeekDays:      []string{"monday", "wednesday"},
+				Hour:          intPtr(9),
+				Minute:        intPtr(0),
+			},
+			now:        mustParseTime("2025-01-08T10:00:00Z"), // Wednesday 10 AM UTC
+			expectNext: mustParseTime("2025-01-13T09:00:00Z"), // Monday of next week at 9 AM UTC
+		},
+		{
+			name: "weeks configuration with multiple weekdays and interval > 1",
+			config: Configuration{
+				Type:          TypeWeeks,
+				WeeksInterval: intPtr(2),
+				WeekDays:      []string{"monday", "wednesday"},
+				Hour:          intPtr(9),
+				Minute:        intPtr(0),
+			},
+			now:        mustParseTime("2025-01-08T10:00:00Z"), // Wednesday 10 AM UTC of Week 0
+			expectNext: mustParseTime("2025-01-20T09:00:00Z"), // Monday of Week 2 at 9 AM UTC
 		},
 		{
 			name: "months configuration",
@@ -387,7 +423,7 @@ func TestTimezoneHandling(t *testing.T) {
 				Timezone:      stringPtr("-8"), // GMT-8 (PST)
 			},
 			now:        mustParseTime("2025-01-06T16:00:00Z"), // Monday 8 AM PST (4 PM UTC)
-			expectNext: mustParseTime("2025-01-13T17:00:00Z"), // Monday 9 AM PST (5 PM UTC) of the next week
+			expectNext: mustParseTime("2025-01-06T17:00:00Z"), // Monday 9 AM PST (5 PM UTC) of the current week
 		},
 		{
 			name: "month schedule in GMT+9 timezone (JST)",


### PR DESCRIPTION
This PR resolves an issue where a weekly schedule configured with multiple weekdays (e.g. `["monday", "wednesday"]`) would only fire on one of the weekdays and skip the others. 

The Problem:

The previous implementation of `nextWeeksTrigger` in `pkg/triggers/schedule/schedule.go` immediately shifted the search window forward by `interval * 7` days. Consequently, once a weekday trigger fired (e.g., Monday), the scheduler would jump past any remaining weekdays in the current week (e.g., Wednesday) and look only in the next interval. Additionally, it contained an ineffectual `time.Add` call where the return value was discarded.

The Solution:
Refactored `nextWeeksTrigger` to correctly iterate over all configured weekdays:
1. Calculates the candidate execution time for each weekday in the current week (starting Sunday at 00:00:00).
2. If the candidate time is strictly in the future of the current execution time, it schedules it for the current week (0 weeks added).
3. If the candidate time has already passed, it schedules it for `interval` weeks in the future.
4. Selects the minimum of all calculated candidate trigger times.

Verification:
- Updated the existing timezone and schedule test expectations to match the correct non-skipping future-run logic.
- Added comprehensive new test cases covering:
  - Multi-weekday triggering in the same week (e.g. Mon -> Wed).
  - Multi-weekday triggering across week boundaries (e.g. Wed -> next Mon).
  - Multi-weekday triggering with custom intervals (e.g. `interval=2`).
- Ran and verified that all tests passed successfully:
  ```bash
  go test ./pkg/triggers/schedule