### PR TITLE
feat(ui): show user avatars in factory pages

### DIFF
--- a/web_src/src/hooks/useOrgUserLookup.ts
+++ b/web_src/src/hooks/useOrgUserLookup.ts
@@ -1,0 +1,17 @@
+import { useOrganizationUsers } from "@/hooks/useOrganizationData";
+import { buildOrgUserDisplayMap, createOrgUserDisplayLookup, type OrgUserDisplayLookup } from "@/lib/orgUserDisplay";
+import { useMemo } from "react";
+
+export function useOrgUserLookup(organizationId: string): {
+  resolveUser: OrgUserDisplayLookup;
+  isLoading: boolean;
+} {
+  const { data: users = [], isLoading } = useOrganizationUsers(organizationId);
+
+  const resolveUser = useMemo(() => {
+    const usersById = buildOrgUserDisplayMap(users);
+    return createOrgUserDisplayLookup(usersById);
+  }, [users]);
+
+  return { resolveUser, isLoading };
+}

--- a/web_src/src/lib/orgUserDisplay.spec.ts
+++ b/web_src/src/lib/orgUserDisplay.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import type { SuperplaneUsersUser } from "@/api-client";
+
+import {
+  buildOrgUserDisplayMap,
+  getOrgUserDisplayFromUser,
+  getUserInitials,
+  resolveOrgUserDisplay,
+} from "./orgUserDisplay";
+
+describe("orgUserDisplay", () => {
+  it("derives initials from display name", () => {
+    expect(getUserInitials("Alex Reviewer")).toBe("AR");
+  });
+
+  it("maps list users response fields to display data", () => {
+    const user: SuperplaneUsersUser = {
+      metadata: { id: "user-1", email: "alex@example.com" },
+      spec: { displayName: "Alex Reviewer" },
+      status: {
+        accountProviders: [{ avatarUrl: "https://example.com/alex.png" }],
+      },
+    };
+
+    expect(getOrgUserDisplayFromUser(user)).toEqual({
+      id: "user-1",
+      name: "Alex Reviewer",
+      initials: "AR",
+      avatarUrl: "https://example.com/alex.png",
+    });
+  });
+
+  it("falls back to order-provided names when a user is missing from the roster", () => {
+    const usersById = buildOrgUserDisplayMap([]);
+
+    expect(resolveOrgUserDisplay(usersById, "missing-user", "Jamie Operator")).toEqual({
+      id: "missing-user",
+      name: "Jamie Operator",
+      initials: "JO",
+    });
+  });
+});

--- a/web_src/src/lib/orgUserDisplay.ts
+++ b/web_src/src/lib/orgUserDisplay.ts
@@ -1,0 +1,78 @@
+import type { SuperplaneUsersUser } from "@/api-client";
+
+export const UNKNOWN_ORG_USER_NAME = "Unknown member";
+
+export interface OrgUserDisplay {
+  id: string;
+  name: string;
+  initials: string;
+  avatarUrl?: string;
+}
+
+export type OrgUserDisplayLookup = (userId: string | undefined, fallbackName?: string) => OrgUserDisplay | null;
+
+export function getUserInitials(name: string): string {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function getOrgUserDisplayFromUser(user: SuperplaneUsersUser): OrgUserDisplay | null {
+  const id = user.metadata?.id;
+  if (!id) {
+    return null;
+  }
+
+  const name = user.spec?.displayName?.trim() || user.metadata?.email?.trim() || UNKNOWN_ORG_USER_NAME;
+
+  return {
+    id,
+    name,
+    initials: getUserInitials(name),
+    avatarUrl: user.status?.accountProviders?.[0]?.avatarUrl,
+  };
+}
+
+export function buildOrgUserDisplayMap(users: SuperplaneUsersUser[]): Map<string, OrgUserDisplay> {
+  const map = new Map<string, OrgUserDisplay>();
+
+  for (const user of users) {
+    const display = getOrgUserDisplayFromUser(user);
+    if (display) {
+      map.set(display.id, display);
+    }
+  }
+
+  return map;
+}
+
+export function resolveOrgUserDisplay(
+  usersById: Map<string, OrgUserDisplay>,
+  userId: string | undefined,
+  fallbackName?: string,
+): OrgUserDisplay | null {
+  if (!userId) {
+    return null;
+  }
+
+  const fromMap = usersById.get(userId);
+  if (fromMap) {
+    return fromMap;
+  }
+
+  const name = fallbackName?.trim() || UNKNOWN_ORG_USER_NAME;
+
+  return {
+    id: userId,
+    name,
+    initials: getUserInitials(name),
+  };
+}
+
+export function createOrgUserDisplayLookup(usersById: Map<string, OrgUserDisplay>): OrgUserDisplayLookup {
+  return (userId, fallbackName) => resolveOrgUserDisplay(usersById, userId, fallbackName);
+}

--- a/web_src/src/pages/factories/OrgUserReference.tsx
+++ b/web_src/src/pages/factories/OrgUserReference.tsx
@@ -1,0 +1,52 @@
+import { Avatar } from "@/components/Avatar/avatar";
+import type { OrgUserDisplay } from "@/lib/orgUserDisplay";
+import { UNKNOWN_ORG_USER_NAME } from "@/lib/orgUserDisplay";
+import { cn } from "@/lib/utils";
+
+const avatarSizeClass = {
+  xs: "size-5",
+  sm: "size-6",
+  md: "size-8",
+} as const;
+
+interface OrgUserReferenceProps {
+  display: OrgUserDisplay | null;
+  size?: keyof typeof avatarSizeClass;
+  showName?: boolean;
+  emphasizeName?: boolean;
+  nameClassName?: string;
+  className?: string;
+}
+
+export function OrgUserReference({
+  display,
+  size = "sm",
+  showName = true,
+  emphasizeName = false,
+  nameClassName,
+  className,
+}: OrgUserReferenceProps) {
+  const resolvedDisplay = display ?? {
+    id: "unknown",
+    name: UNKNOWN_ORG_USER_NAME,
+    initials: "?",
+  };
+
+  return (
+    <span className={cn("inline-flex min-w-0 items-center gap-1.5", className)}>
+      <Avatar
+        src={resolvedDisplay.avatarUrl}
+        initials={resolvedDisplay.initials}
+        alt={resolvedDisplay.name}
+        className={avatarSizeClass[size]}
+      />
+      {showName ? (
+        <span
+          className={cn("truncate text-gray-900 dark:text-gray-100", emphasizeName && "font-semibold", nameClassName)}
+        >
+          {resolvedDisplay.name}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/web_src/src/pages/factories/WorkOrderActivityTimeline.tsx
+++ b/web_src/src/pages/factories/WorkOrderActivityTimeline.tsx
@@ -2,9 +2,10 @@ import { Text } from "@/components/Text/text";
 import type { FactoriesWorkOrder, FactoriesWorkOrderEvent, FactoriesWorkOrderExecution } from "@/api-client";
 import { Link } from "@/components/Link/link";
 import { useOrganizationUsers } from "@/hooks/useOrganizationData";
+import type { OrgUserDisplayLookup } from "@/lib/orgUserDisplay";
 import { formatTimeAgo } from "@/lib/date";
 import { cn } from "@/lib/utils";
-import { useMemo } from "react";
+import { Fragment, useMemo, type ReactNode } from "react";
 import {
   Check,
   CircleDashed,
@@ -18,6 +19,7 @@ import {
 } from "lucide-react";
 import {
   buildWorkOrderTimelineView,
+  buildWorkOrderUserDisplayLookup,
   buildWorkOrderUserNameLookup,
   formatStepExecutionDuration,
   type WorkOrderTimelineEvent,
@@ -25,6 +27,7 @@ import {
   type WorkOrderTimelineStep,
 } from "./lib/workOrderTimelineEvents";
 import { getWorkOrderExecutionDisplayMeta, getWorkOrderExecutionRunHref } from "./lib/workOrderExecutions";
+import { OrgUserReference } from "./OrgUserReference";
 
 interface WorkOrderTimelineProps {
   organizationId: string;
@@ -51,6 +54,7 @@ export function WorkOrderActivityTimeline({
 }: WorkOrderTimelineProps) {
   const { data: users = [] } = useOrganizationUsers(organizationId);
   const resolveUserName = useMemo(() => buildWorkOrderUserNameLookup(users, order), [users, order]);
+  const resolveUserDisplay = useMemo(() => buildWorkOrderUserDisplayLookup(users, order), [users, order]);
   const pendingView = renderTimelinePendingView({ events, eventsError, isLoading, onRetryEvents });
 
   if (pendingView) {
@@ -59,7 +63,7 @@ export function WorkOrderActivityTimeline({
 
   const timeline = buildWorkOrderTimelineView(events, resolveUserName);
 
-  if (timeline.events.length === 0 && !timeline.closedLabel) {
+  if (timeline.events.length === 0) {
     return <TimelineActivityEmpty />;
   }
 
@@ -67,6 +71,7 @@ export function WorkOrderActivityTimeline({
     <WorkOrderTimelineList
       timeline={timeline}
       organizationId={organizationId}
+      resolveUserDisplay={resolveUserDisplay}
       hasMoreEvents={hasMoreEvents}
       isLoadingMoreEvents={isLoadingMoreEvents}
       onLoadMoreEvents={onLoadMoreEvents}
@@ -124,12 +129,14 @@ function TimelineActivityEmpty() {
 function WorkOrderTimelineList({
   timeline,
   organizationId,
+  resolveUserDisplay,
   hasMoreEvents,
   isLoadingMoreEvents,
   onLoadMoreEvents,
 }: {
   timeline: ReturnType<typeof buildWorkOrderTimelineView>;
   organizationId: string;
+  resolveUserDisplay: OrgUserDisplayLookup;
   hasMoreEvents: boolean;
   isLoadingMoreEvents: boolean;
   onLoadMoreEvents?: () => void;
@@ -154,21 +161,10 @@ function WorkOrderTimelineList({
           key={event.id}
           event={event}
           organizationId={organizationId}
-          isLast={index === timeline.events.length - 1 && !timeline.closedLabel}
+          resolveUserDisplay={resolveUserDisplay}
+          isLast={index === timeline.events.length - 1}
         />
       ))}
-
-      {timeline.closedLabel && timeline.closedAt ? (
-        <li className="relative flex gap-4 pb-2 pl-8">
-          <TimelineMarker icon={CircleDot} className="text-gray-400" />
-          <div className="min-w-0 flex-1 pb-8">
-            <p className="text-sm text-gray-900 dark:text-gray-100">{timeline.closedLabel}</p>
-            <time className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
-              {formatTimeAgo(new Date(timeline.closedAt))}
-            </time>
-          </div>
-        </li>
-      ) : null}
     </ol>
   );
 }
@@ -176,35 +172,42 @@ function WorkOrderTimelineList({
 function TimelineItem({
   event,
   organizationId,
+  resolveUserDisplay,
   isLast,
 }: {
   event: WorkOrderTimelineEvent;
   organizationId: string;
+  resolveUserDisplay: OrgUserDisplayLookup;
   isLast: boolean;
 }) {
-  const { icon: Icon, markerClassName } = getTimelineEventPresentation(event.kind);
-  const isUserActionEvent = event.kind === "created" || event.kind === "assigned";
-  const isCreatedEvent = event.kind === "created";
+  const { icon: Icon } = getTimelineEventPresentation(event.kind);
+  const isUserActionEvent = event.kind === "created" || event.kind === "assigned" || event.kind === "closed";
+  const actorDisplay = resolveUserDisplay(event.actorUserId, event.actorName);
+  const showSomeoneFallback = (event.kind === "created" || event.kind === "closed") && !actorDisplay;
 
   return (
     <li className="relative flex gap-4 pl-8">
       {!isLast ? (
         <span className="absolute left-[11px] top-6 bottom-0 w-px bg-gray-200 dark:bg-gray-700/70" aria-hidden />
       ) : null}
-      <TimelineMarker icon={Icon} className={markerClassName} />
+      <TimelineMarker icon={Icon} />
       <div className={cn("min-w-0 flex-1", isLast ? "pb-2" : "pb-8")}>
         {isUserActionEvent ? (
-          <p className="text-sm text-gray-900 dark:text-gray-100">
-            {event.actorName ? (
-              <>
-                <span className="font-semibold">{event.actorName}</span>{" "}
-              </>
-            ) : isCreatedEvent ? (
-              <>
-                <span className="font-semibold">Someone</span>{" "}
-              </>
+          <p className="flex flex-wrap items-center gap-x-1 gap-y-1 text-sm text-gray-900 dark:text-gray-100">
+            {actorDisplay ? (
+              <OrgUserReference display={actorDisplay} size="sm" emphasizeName />
+            ) : showSomeoneFallback ? (
+              <span className="font-semibold">Someone</span>
             ) : null}
-            {event.title}
+            {event.kind === "assigned" && event.assigneeChange ? (
+              <AssigneeChangeDescription
+                actorUserId={event.actorUserId}
+                assigneeChange={event.assigneeChange}
+                resolveUserDisplay={resolveUserDisplay}
+              />
+            ) : (
+              <span>{event.title}</span>
+            )}
           </p>
         ) : (
           <>
@@ -225,6 +228,117 @@ function TimelineItem({
         ) : null}
       </div>
     </li>
+  );
+}
+
+function AssigneeChangeDescription({
+  actorUserId,
+  assigneeChange,
+  resolveUserDisplay,
+}: {
+  actorUserId?: string;
+  assigneeChange: NonNullable<WorkOrderTimelineEvent["assigneeChange"]>;
+  resolveUserDisplay: OrgUserDisplayLookup;
+}) {
+  const { assignedUserIds, unassignedUserIds } = assigneeChange;
+  const parts: ReactNode[] = [];
+
+  const assignedDescription = buildAssignedChangeDescription(actorUserId, assignedUserIds, resolveUserDisplay);
+  if (assignedDescription) {
+    parts.push(<span key="assigned">{assignedDescription}</span>);
+  }
+
+  if (unassignedUserIds.length > 0) {
+    parts.push(
+      <span key="unassigned" className="inline-flex flex-wrap items-center gap-x-1 gap-y-1">
+        unassigned <InlineUserList userIds={unassignedUserIds} resolveUserDisplay={resolveUserDisplay} />
+      </span>,
+    );
+  }
+
+  if (parts.length === 0) {
+    return <span>updated assignees</span>;
+  }
+
+  return (
+    <>
+      {parts.map((part, index) => (
+        <Fragment key={index}>
+          {index > 0 ? <span> and </span> : null}
+          {part}
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+function buildAssignedChangeDescription(
+  actorUserId: string | undefined,
+  assignedUserIds: string[],
+  resolveUserDisplay: OrgUserDisplayLookup,
+): ReactNode | null {
+  if (assignedUserIds.length === 0) {
+    return null;
+  }
+
+  const assignedOthers = actorUserId ? assignedUserIds.filter((userId) => userId !== actorUserId) : assignedUserIds;
+  const selfAssigned = Boolean(actorUserId && assignedUserIds.includes(actorUserId));
+
+  if (selfAssigned && assignedOthers.length === 0) {
+    return <span>self-assigned</span>;
+  }
+
+  if (selfAssigned && assignedOthers.length > 0) {
+    return (
+      <span className="inline-flex flex-wrap items-center gap-x-1 gap-y-1">
+        self-assigned and assigned <InlineUserList userIds={assignedOthers} resolveUserDisplay={resolveUserDisplay} />
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-x-1 gap-y-1">
+      assigned <InlineUserList userIds={assignedUserIds} resolveUserDisplay={resolveUserDisplay} />
+    </span>
+  );
+}
+
+function InlineUserList({
+  userIds,
+  resolveUserDisplay,
+}: {
+  userIds: string[];
+  resolveUserDisplay: OrgUserDisplayLookup;
+}) {
+  if (userIds.length === 0) {
+    return null;
+  }
+
+  if (userIds.length === 1) {
+    return <OrgUserReference display={resolveUserDisplay(userIds[0])} size="sm" emphasizeName />;
+  }
+
+  if (userIds.length === 2) {
+    return (
+      <>
+        <OrgUserReference display={resolveUserDisplay(userIds[0])} size="sm" emphasizeName />
+        <span> and </span>
+        <OrgUserReference display={resolveUserDisplay(userIds[1])} size="sm" emphasizeName />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {userIds.slice(0, -1).map((userId, index) => (
+        <Fragment key={userId}>
+          {index > 0 ? <span>, </span> : null}
+          <OrgUserReference display={resolveUserDisplay(userId)} size="sm" emphasizeName />
+        </Fragment>
+      ))}
+      <span>, and </span>
+      <OrgUserReference display={resolveUserDisplay(userIds[userIds.length - 1])} size="sm" emphasizeName />
+    </>
   );
 }
 
@@ -289,15 +403,10 @@ function StepStatusIcon({ execution }: { execution: FactoriesWorkOrderExecution 
   return <CircleDashed className={cn(iconClassName, "text-gray-400")} aria-label={meta.label} />;
 }
 
-function TimelineMarker({ icon: Icon, className }: { icon: typeof UserRound; className?: string }) {
+function TimelineMarker({ icon: Icon }: { icon: typeof UserRound }) {
   return (
-    <span
-      className={cn(
-        "absolute left-0 flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white dark:border-gray-700/70 dark:bg-gray-900",
-        className,
-      )}
-    >
-      <Icon className="h-3.5 w-3.5" aria-hidden />
+    <span className="absolute left-0 flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white dark:border-gray-700/70 dark:bg-gray-900">
+      <Icon className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" aria-hidden />
     </span>
   );
 }
@@ -306,14 +415,15 @@ type TimelineMarkerIcon = typeof UserRound;
 
 function getTimelineEventPresentation(kind: WorkOrderTimelineEventKind): {
   icon: TimelineMarkerIcon;
-  markerClassName: string;
 } {
   switch (kind) {
     case "created":
-      return { icon: UserRound, markerClassName: "text-gray-500" };
+      return { icon: UserRound };
     case "assigned":
-      return { icon: UsersRound, markerClassName: "text-sky-500" };
+      return { icon: UsersRound };
     case "dispatched":
-      return { icon: GitBranch, markerClassName: "text-violet-500" };
+      return { icon: GitBranch };
+    case "closed":
+      return { icon: CircleDot };
   }
 }

--- a/web_src/src/pages/factories/WorkOrderAssigneePicker.tsx
+++ b/web_src/src/pages/factories/WorkOrderAssigneePicker.tsx
@@ -1,5 +1,7 @@
 import { Checkbox } from "@/components/ui/checkbox";
+import { Avatar } from "@/components/Avatar/avatar";
 import { useOrganizationUsers } from "@/hooks/useOrganizationData";
+import { buildOrgUserDisplayMap, getUserInitials, resolveOrgUserDisplay } from "@/lib/orgUserDisplay";
 import { cn } from "@/lib/utils";
 import { useMemo } from "react";
 
@@ -20,17 +22,27 @@ export function WorkOrderAssigneePicker({
 }: WorkOrderAssigneePickerProps) {
   const { data: users = [], isLoading } = useOrganizationUsers(organizationId);
 
-  const userOptions = useMemo(
-    () =>
-      users
-        .filter((user) => user.metadata?.id)
-        .map((user) => ({
-          id: user.metadata!.id!,
-          label: user.metadata?.email || user.spec?.displayName || user.metadata!.id!,
-        }))
-        .sort((left, right) => left.label.localeCompare(right.label)),
-    [users],
-  );
+  const userOptions = useMemo(() => {
+    const usersById = buildOrgUserDisplayMap(users);
+
+    return users
+      .filter((user) => user.metadata?.id)
+      .map((user) => {
+        const id = user.metadata!.id!;
+        const display = resolveOrgUserDisplay(usersById, id) ?? {
+          id,
+          name: user.metadata?.email || id,
+          initials: getUserInitials(user.metadata?.email || id),
+        };
+
+        return {
+          id,
+          label: display.name,
+          display,
+        };
+      })
+      .sort((left, right) => left.label.localeCompare(right.label));
+  }, [users]);
 
   const toggleUser = (userId: string, checked: boolean) => {
     if (disabled) {
@@ -78,6 +90,12 @@ export function WorkOrderAssigneePicker({
                 checked={checked}
                 disabled={disabled}
                 onChange={(event) => toggleUser(user.id, event.target.checked)}
+              />
+              <Avatar
+                src={user.display.avatarUrl}
+                initials={user.display.initials}
+                alt={user.display.name}
+                className="size-6"
               />
               <span className="text-sm text-gray-900 dark:text-gray-100">{user.label}</span>
             </label>

--- a/web_src/src/pages/factories/WorkOrderAssigneesField.tsx
+++ b/web_src/src/pages/factories/WorkOrderAssigneesField.tsx
@@ -1,6 +1,8 @@
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
+import { useOrgUserLookup } from "@/hooks/useOrgUserLookup";
 import { Settings2 } from "lucide-react";
+import { OrgUserReference } from "./OrgUserReference";
 import { WorkOrderAssigneesPopover } from "./WorkOrderAssigneesPopover";
 
 interface WorkOrderAssigneesFieldProps {
@@ -20,6 +22,8 @@ export function WorkOrderAssigneesField({
   isSaving,
   onSave,
 }: WorkOrderAssigneesFieldProps) {
+  const { resolveUser } = useOrgUserLookup(organizationId);
+
   return (
     <section>
       <div className="flex items-center justify-between gap-2">
@@ -48,11 +52,15 @@ export function WorkOrderAssigneesField({
         </PermissionTooltip>
       </div>
 
-      {assigneeNames.length > 0 ? (
-        <ul className="mt-2 space-y-1">
-          {assigneeNames.map((name) => (
-            <li key={name} className="text-sm text-gray-700 dark:text-gray-300">
-              {name}
+      {assigneeIds.length > 0 ? (
+        <ul className="mt-2 space-y-2">
+          {assigneeIds.map((assigneeId, index) => (
+            <li key={assigneeId}>
+              <OrgUserReference
+                display={resolveUser(assigneeId, assigneeNames[index])}
+                size="md"
+                nameClassName="text-sm text-gray-700 dark:text-gray-300"
+              />
             </li>
           ))}
         </ul>

--- a/web_src/src/pages/factories/WorkOrderCard.stories.tsx
+++ b/web_src/src/pages/factories/WorkOrderCard.stories.tsx
@@ -13,8 +13,8 @@ import {
 import { WorkOrderCard } from "./WorkOrderCard";
 
 /**
- * Single work order row: status badge, title, author/updated meta, and a
- * compact execution list beneath. Open orders also expose a dispatch popover.
+ * Single work order row: status badge, title, creator/assignee avatars, updated meta,
+ * and a compact execution list beneath. Open orders also expose a dispatch popover.
  */
 const meta = {
   title: "Factories/WorkOrderCard",

--- a/web_src/src/pages/factories/WorkOrderCard.tsx
+++ b/web_src/src/pages/factories/WorkOrderCard.tsx
@@ -2,12 +2,14 @@ import type { FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useOrgUserLookup } from "@/hooks/useOrgUserLookup";
 import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/lib/date";
 import { Forward, Loader2 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { DispatchWorkOrderPopover } from "./DispatchWorkOrderPopover";
 import { factoryWorkOrderRowClassName } from "./lib/factoryPageStyles";
+import { OrgUserReference } from "./OrgUserReference";
 import { WorkOrderExecutionsList } from "./WorkOrderExecutionsList";
 import { getWorkOrderDisplayStatus, getWorkOrderDisplayStatusMeta } from "./lib/workOrderProgress";
 
@@ -30,12 +32,16 @@ export function WorkOrderCard({
   isDispatching = false,
   onDispatch,
 }: WorkOrderCardProps) {
+  const { resolveUser } = useOrgUserLookup(organizationId);
   const displayStatus = getWorkOrderDisplayStatus(order);
   const statusMeta = getWorkOrderDisplayStatusMeta(displayStatus);
   const updatedAt = order.updatedAt ?? order.createdAt;
   const timeLabel = updatedAt ? formatTimeAgo(new Date(updatedAt)) : "—";
   const href = order.id ? `${factoryHref}/orders/${order.id}` : factoryHref;
-  const authorLabel = order.createdBy?.name?.trim() || "Unknown";
+  const creatorDisplay = resolveUser(order.createdBy?.id, order.createdBy?.name);
+  const assigneeDisplays = (order.assignees ?? [])
+    .filter((assignee) => assignee.id)
+    .map((assignee) => resolveUser(assignee.id, assignee.name));
   const showDispatch = order.state === "STATE_OPEN" && onDispatch && order.id;
 
   return (
@@ -60,8 +66,9 @@ export function WorkOrderCard({
               ) : null}
               {statusMeta.label}
             </Badge>
-            <div className="flex min-w-0 flex-wrap items-center gap-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
               <h3 className="min-w-0 text-base font-semibold text-gray-900 dark:text-gray-100">{order.title}</h3>
+              <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">Updated {timeLabel}</span>
               {showDispatch ? (
                 <div className="pointer-events-auto">
                   <PermissionTooltip allowed={canDispatch} message="You don't have permission to dispatch work orders.">
@@ -90,8 +97,26 @@ export function WorkOrderCard({
           </div>
 
           <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
-            <span>Created by {authorLabel}</span>
-            <span>Updated {timeLabel}</span>
+            <span className="inline-flex items-center gap-1.5">
+              Creator:
+              <OrgUserReference display={creatorDisplay} size="md" showName={false} />
+            </span>
+            {assigneeDisplays.length > 0 ? (
+              <span className="inline-flex items-center gap-1.5">
+                Assignees:
+                <span className="inline-flex items-center -space-x-1">
+                  {assigneeDisplays.map((display, index) => (
+                    <OrgUserReference
+                      key={display?.id ?? index}
+                      display={display}
+                      size="md"
+                      showName={false}
+                      className="rounded-full ring-2 ring-white dark:ring-gray-900"
+                    />
+                  ))}
+                </span>
+              </span>
+            ) : null}
           </div>
         </div>
 

--- a/web_src/src/pages/factories/lib/workOrderTimelineEvents.ts
+++ b/web_src/src/pages/factories/lib/workOrderTimelineEvents.ts
@@ -5,10 +5,18 @@ import type {
   SuperplaneUsersUser,
 } from "@/api-client";
 import { formatDuration } from "@/lib/duration";
+import {
+  buildOrgUserDisplayMap,
+  createOrgUserDisplayLookup,
+  resolveOrgUserDisplay,
+  type OrgUserDisplay,
+  type OrgUserDisplayLookup,
+} from "@/lib/orgUserDisplay";
 import { buildWorkOrderTimelineViewFromEvents } from "./workOrderTimelineFromEvents";
 
-export type WorkOrderTimelineEventKind = "created" | "dispatched" | "assigned";
+export type WorkOrderTimelineEventKind = "created" | "dispatched" | "assigned" | "closed";
 export type UserNameLookup = (userId: string | undefined) => string | undefined;
+export type { OrgUserDisplayLookup };
 
 export interface WorkOrderTimelineStep {
   id: string;
@@ -20,11 +28,18 @@ export interface WorkOrderTimelineStep {
   execution: FactoriesWorkOrderExecution;
 }
 
+export interface WorkOrderTimelineAssigneeChange {
+  assignedUserIds: string[];
+  unassignedUserIds: string[];
+}
+
 export interface WorkOrderTimelineEvent {
   id: string;
   kind: WorkOrderTimelineEventKind;
   at: string;
+  actorUserId?: string;
   actorName?: string;
+  assigneeChange?: WorkOrderTimelineAssigneeChange;
   title: string;
   lineName?: string;
   steps?: WorkOrderTimelineStep[];
@@ -32,14 +47,20 @@ export interface WorkOrderTimelineEvent {
 
 export interface WorkOrderTimelineViewModel {
   events: WorkOrderTimelineEvent[];
-  closedLabel: string | null;
-  closedAt: string | null;
 }
 
 export function buildWorkOrderUserNameLookup(users: SuperplaneUsersUser[], order: FactoriesWorkOrder): UserNameLookup {
-  const namesById = collectOrgUserNames(users);
-  addOrderFallbackNames(namesById, order);
-  return createUserNameResolver(namesById);
+  const resolveUserDisplay = buildWorkOrderUserDisplayLookup(users, order);
+  return (userId) => resolveUserDisplay(userId)?.name;
+}
+
+export function buildWorkOrderUserDisplayLookup(
+  users: SuperplaneUsersUser[],
+  order: FactoriesWorkOrder,
+): OrgUserDisplayLookup {
+  const usersById = buildOrgUserDisplayMap(users);
+  addOrderFallbackNames(usersById, order);
+  return createOrgUserDisplayLookup(usersById);
 }
 
 export function buildWorkOrderTimelineView(
@@ -63,36 +84,22 @@ export function formatStepExecutionDuration(step: WorkOrderTimelineStep): string
   return formatted || null;
 }
 
-function collectOrgUserNames(users: SuperplaneUsersUser[]): Map<string, string> {
-  const namesById = new Map<string, string>();
-
-  for (const user of users) {
-    registerUserName(namesById, user.metadata?.id, user.spec?.displayName?.trim() || user.metadata?.email?.trim());
-  }
-
-  return namesById;
-}
-
-function addOrderFallbackNames(namesById: Map<string, string>, order: FactoriesWorkOrder): void {
-  registerUserName(namesById, order.createdBy?.id, order.createdBy?.name);
+function addOrderFallbackNames(usersById: Map<string, OrgUserDisplay>, order: FactoriesWorkOrder): void {
+  registerOrderUserFallback(usersById, order.createdBy?.id, order.createdBy?.name);
 
   for (const assignee of order.assignees ?? []) {
-    registerUserName(namesById, assignee.id, assignee.name);
+    registerOrderUserFallback(usersById, assignee.id, assignee.name);
   }
 }
 
-function registerUserName(namesById: Map<string, string>, id: string | undefined, name: string | undefined): void {
-  if (id && name?.trim()) {
-    namesById.set(id, name.trim());
+function registerOrderUserFallback(
+  usersById: Map<string, OrgUserDisplay>,
+  id: string | undefined,
+  name: string | undefined,
+): void {
+  if (!id || usersById.has(id) || !name?.trim()) {
+    return;
   }
-}
 
-function createUserNameResolver(namesById: Map<string, string>): UserNameLookup {
-  return (userId) => {
-    if (!userId) {
-      return undefined;
-    }
-
-    return namesById.get(userId);
-  };
+  usersById.set(id, resolveOrgUserDisplay(new Map(), id, name)!);
 }

--- a/web_src/src/pages/factories/lib/workOrderTimelineFromEvents.spec.ts
+++ b/web_src/src/pages/factories/lib/workOrderTimelineFromEvents.spec.ts
@@ -37,4 +37,38 @@ describe("buildWorkOrderTimelineViewFromEvents", () => {
     expect(step?.execution?.state).toBe("STATE_FINISHED");
     expect(step?.execution?.result).toBe("RESULT_PASSED");
   });
+
+  it("describes self-assignment when the actor assigns only themselves", () => {
+    const view = buildWorkOrderTimelineViewFromEvents([
+      {
+        timestamp: "2026-08-04T12:00:00.000Z",
+        type: "order.assignees.updated",
+        event: {
+          user: { id: "user-1" },
+          assigned: [{ id: "user-1" }],
+        },
+      },
+    ]);
+
+    expect(view.events[0]?.title).toBe("self-assigned");
+  });
+
+  it("includes the closing user on closed events", () => {
+    const view = buildWorkOrderTimelineViewFromEvents([
+      {
+        timestamp: "2026-08-04T12:00:00.000Z",
+        type: "order.closed",
+        event: {
+          user: { id: "user-1" },
+          result: "completed",
+        },
+      },
+    ]);
+
+    expect(view.events[0]).toMatchObject({
+      kind: "closed",
+      actorUserId: "user-1",
+      title: "closed as completed",
+    });
+  });
 });

--- a/web_src/src/pages/factories/lib/workOrderTimelineFromEvents.ts
+++ b/web_src/src/pages/factories/lib/workOrderTimelineFromEvents.ts
@@ -5,6 +5,7 @@ import type {
   FactoriesWorkOrderExecutionState,
 } from "@/api-client";
 import { formatWorkOrderResult } from "./workOrderPresentation";
+import { UNKNOWN_ORG_USER_NAME } from "@/lib/orgUserDisplay";
 import type {
   UserNameLookup,
   WorkOrderTimelineEvent,
@@ -12,7 +13,7 @@ import type {
   WorkOrderTimelineViewModel,
 } from "./workOrderTimelineEvents";
 
-const UNKNOWN_MEMBER_LABEL = "Unknown member";
+const UNKNOWN_MEMBER_LABEL = UNKNOWN_ORG_USER_NAME;
 
 interface EventUserRef {
   id?: string;
@@ -53,8 +54,6 @@ interface EventPayload extends LineStepExecutionPayload {
 interface TimelineBuildState {
   events: WorkOrderTimelineEvent[];
   dispatchBatchByLine: Map<string, WorkOrderTimelineEvent>;
-  closedLabel: string | null;
-  closedAt: string | null;
 }
 
 interface DispatchBatchContext {
@@ -116,15 +115,13 @@ export function buildWorkOrderTimelineViewFromEvents(
     applyApiEventToTimeline(state, index, apiEvent, resolveUserName);
   }
 
-  return { events: state.events, closedLabel: state.closedLabel, closedAt: state.closedAt };
+  return { events: state.events };
 }
 
 function createTimelineBuildState(): TimelineBuildState {
   return {
     events: [],
     dispatchBatchByLine: new Map(),
-    closedLabel: null,
-    closedAt: null,
   };
 }
 
@@ -151,7 +148,7 @@ function applyApiEventToTimeline(
       appendStepExecutionEvent(toDispatchBatchContext(state), payload, at, "step.execution.finished");
       return;
     case "order.closed":
-      applyOrderClosedState(state, payload, at);
+      appendClosedEvent(state.events, index, payload, at, resolveUserName);
   }
 }
 
@@ -173,6 +170,7 @@ function appendOpenedEvent(
     id: `opened-${index}`,
     kind: "created",
     at,
+    actorUserId: payload.user?.id,
     actorName: resolveUserDisplayName(payload.user?.id, resolveUserName),
     title: "opened this work order",
   });
@@ -189,18 +187,36 @@ function appendAssigneesUpdatedEvent(
     id: `assignees-updated-${index}`,
     kind: "assigned",
     at,
+    actorUserId: payload.user?.id,
     actorName: resolveUserDisplayName(payload.user?.id, resolveUserName),
+    assigneeChange: {
+      assignedUserIds: (payload.assigned ?? []).map((user) => user.id).filter((id): id is string => Boolean(id)),
+      unassignedUserIds: (payload.unassigned ?? []).map((user) => user.id).filter((id): id is string => Boolean(id)),
+    },
     title: describeAssigneesUpdated(payload, resolveUserName),
   });
 }
 
-function applyOrderClosedState(state: TimelineBuildState, payload: EventPayload, at: string): void {
+function appendClosedEvent(
+  events: WorkOrderTimelineEvent[],
+  index: number,
+  payload: EventPayload,
+  at: string,
+  resolveUserName?: UserNameLookup,
+): void {
   const closedResult = payload.result ?? payload.order?.result;
   const result = formatWorkOrderResult(
     closedResult === "completed" ? "RESULT_COMPLETED" : closedResult === "rejected" ? "RESULT_REJECTED" : undefined,
   );
-  state.closedLabel = result ? `Closed as ${result.toLowerCase()}` : "Closed";
-  state.closedAt = at;
+
+  events.push({
+    id: `closed-${index}`,
+    kind: "closed",
+    at,
+    actorUserId: payload.user?.id,
+    actorName: resolveUserDisplayName(payload.user?.id, resolveUserName),
+    title: result ? `closed as ${result.toLowerCase()}` : "closed this work order",
+  });
 }
 
 function resolveUserDisplayName(userId: string | undefined, resolveUserName?: UserNameLookup): string | undefined {
@@ -212,12 +228,26 @@ function resolveUserDisplayName(userId: string | undefined, resolveUserName?: Us
 }
 
 function describeAssigneesUpdated(payload: EventPayload, resolveUserName?: UserNameLookup): string {
-  const assignedNames = formatEventUserNames(payload.assigned, resolveUserName);
+  const actorId = payload.user?.id;
+  const assignedIds = (payload.assigned ?? []).map((user) => user.id).filter((id): id is string => Boolean(id));
+  const assignedOthers = actorId ? assignedIds.filter((userId) => userId !== actorId) : assignedIds;
+  const selfAssigned = Boolean(actorId && assignedIds.includes(actorId));
   const unassignedNames = formatEventUserNames(payload.unassigned, resolveUserName);
   const parts: string[] = [];
 
-  if (assignedNames) {
-    parts.push(`assigned ${assignedNames}`);
+  if (selfAssigned && assignedOthers.length === 0) {
+    parts.push("self-assigned");
+  } else if (selfAssigned && assignedOthers.length > 0) {
+    const otherNames = formatEventUserNames(
+      assignedOthers.map((id) => ({ id })),
+      resolveUserName,
+    );
+    parts.push(otherNames ? `self-assigned and assigned ${otherNames}` : "self-assigned");
+  } else {
+    const assignedNames = formatEventUserNames(payload.assigned, resolveUserName);
+    if (assignedNames) {
+      parts.push(`assigned ${assignedNames}`);
+    }
   }
 
   if (unassignedNames) {


### PR DESCRIPTION
- Resolve factory work order user references through `usersListUsers` and render them with avatars across the factory detail list, work order detail sidebar, assignee picker, and activity timeline.
- Update work order cards to show compact **Creator:** / **Assignees:** avatar groups (no names), with **Updated** moved next to the title.
- Improve the activity timeline with user avatars on created, assignee-change, and closed events; neutral timeline markers; **self-assigned** copy when the actor assigns themselves; and a fix for closed events missing the closing user.