### PR TITLE
feat: support Claude Code OAuth tokens in the Claude integration

### DIFF
--- a/docs/components/Claude.mdx
+++ b/docs/components/Claude.mdx
@@ -20,6 +20,10 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 To get new Claude API key, go to [platform.claude.com](https://platform.claude.com).
 
+## Claude Code OAuth tokens
+
+The API Key field also accepts a Claude Code OAuth token (`sk-ant-oat…`, from `claude setup-token`), which bills against a Claude subscription instead of API credits. Such a token carries inference scope only, so it covers **Text Prompt** and nothing else: **Run Agent**, **Run Code Agent**, **Create Batch Message**, file attachments, and usage reports all need a regular API key and fail with a scope error otherwise.
+
 ## Files & artifacts
 
 The Files API is in beta: SuperPlane enables it per request via the `anthropic-beta` header, so no console toggle is needed and a standard API key suffices. Files and sessions are scoped to the API key's workspace. For **Run Managed Agent** artifacts, the agent must save its deliverables under `/mnt/session/outputs/`.

--- a/docs/components/Claude.mdx
+++ b/docs/components/Claude.mdx
@@ -22,7 +22,9 @@ To get new Claude API key, go to [platform.claude.com](https://platform.claude.c
 
 ## Claude Code OAuth tokens
 
-The API Key field also accepts a Claude Code OAuth token (`sk-ant-oat…`, from `claude setup-token`), which bills against a Claude subscription instead of API credits. Such a token carries inference scope only, so it covers **Text Prompt** and nothing else: **Run Agent**, **Run Code Agent**, **Create Batch Message**, file attachments, and usage reports all need a regular API key and fail with a scope error otherwise.
+The API Key field also accepts a Claude Code OAuth token (`sk-ant-oat…`, from `claude setup-token`), which bills against a Claude subscription instead of API credits.
+
+Such a token carries inference scope only. It covers **Text Prompt**, and it is also what the **Run Claude Code** component needs to run the CLI on a subscription. Everything that touches workspace resources — **Run Agent**, **Run Code Agent**, **Create Batch Message**, file attachments, and usage reports — still requires a regular API key and fails with a scope error otherwise.
 
 ## Files & artifacts
 

--- a/pkg/components/runner/claude/run.js
+++ b/pkg/components/runner/claude/run.js
@@ -48,8 +48,12 @@ async function runPrompt(promptFile, model) {
   const promptCountPath = path.join(sp, "prompt_count");
   const promptCount = Number.parseInt(fs.readFileSync(promptCountPath, "utf8").trim(), 10) || 0;
 
+  // --bare skips keychain reads, which is also how Claude Code authenticates a
+  // subscription token: with the flag set, CLAUDE_CODE_OAUTH_TOKEN is ignored
+  // and the run fails with "Not logged in". Keep the flag for API-key runs,
+  // where its isolation is free.
   const claudeArgs = [
-    "--bare",
+    ...(process.env.CLAUDE_CODE_OAUTH_TOKEN ? [] : ["--bare"]),
     "-p",
     "--output-format",
     "stream-json",

--- a/pkg/integrations/claude/claude.go
+++ b/pkg/integrations/claude/claude.go
@@ -47,7 +47,7 @@ func (i *Claude) Configuration() []configuration.Field {
 			Label:       "API Key",
 			Type:        configuration.FieldTypeString,
 			Sensitive:   true,
-			Description: "Claude API key",
+			Description: "Claude API key, or a Claude Code OAuth token for Text Prompt only.",
 			Required:    true,
 		},
 		{
@@ -77,6 +77,10 @@ func (i *Claude) Triggers() []core.Trigger {
 
 func (i *Claude) Instructions() string {
 	return `To get new Claude API key, go to [platform.claude.com](https://platform.claude.com).
+
+## Claude Code OAuth tokens
+
+The API Key field also accepts a Claude Code OAuth token (` + "`sk-ant-oat…`" + `, from ` + "`claude setup-token`" + `), which bills against a Claude subscription instead of API credits. Such a token carries inference scope only, so it covers **Text Prompt** and nothing else: **Run Agent**, **Run Code Agent**, **Create Batch Message**, file attachments, and usage reports all need a regular API key and fail with a scope error otherwise.
 
 ## Files & artifacts
 

--- a/pkg/integrations/claude/claude.go
+++ b/pkg/integrations/claude/claude.go
@@ -80,7 +80,9 @@ func (i *Claude) Instructions() string {
 
 ## Claude Code OAuth tokens
 
-The API Key field also accepts a Claude Code OAuth token (` + "`sk-ant-oat…`" + `, from ` + "`claude setup-token`" + `), which bills against a Claude subscription instead of API credits. Such a token carries inference scope only, so it covers **Text Prompt** and nothing else: **Run Agent**, **Run Code Agent**, **Create Batch Message**, file attachments, and usage reports all need a regular API key and fail with a scope error otherwise.
+The API Key field also accepts a Claude Code OAuth token (` + "`sk-ant-oat…`" + `, from ` + "`claude setup-token`" + `), which bills against a Claude subscription instead of API credits.
+
+Such a token carries inference scope only. It covers **Text Prompt**, and it is also what the **Run Claude Code** component needs to run the CLI on a subscription. Everything that touches workspace resources — **Run Agent**, **Run Code Agent**, **Create Batch Message**, file attachments, and usage reports — still requires a regular API key and fails with a scope error otherwise.
 
 ## Files & artifacts
 

--- a/pkg/integrations/claude/client.go
+++ b/pkg/integrations/claude/client.go
@@ -28,6 +28,9 @@ const (
 	// model — and any server-side tools like code execution — finish, which
 	// regularly takes longer than the platform's default request timeout.
 	generationTimeout = 5 * time.Minute
+	// oauthTokenPrefix marks a Claude Code OAuth token, which the API rejects on
+	// x-api-key and expects as a bearer token instead.
+	oauthTokenPrefix = "sk-ant-oat"
 )
 
 type Client struct {
@@ -260,7 +263,7 @@ func (c *Client) UploadFile(content io.Reader, filename, contentType string) (st
 		return "", fmt.Errorf("build upload request: %w", err)
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("x-api-key", c.APIKey)
+	setAuthHeader(req, c.APIKey)
 	req.Header.Set("anthropic-version", anthropicVersionValue)
 	req.Header.Set("anthropic-beta", anthropicFilesBeta)
 
@@ -349,6 +352,18 @@ func (c *Client) doRequest(method, URL string, body io.Reader, apiKey, beta stri
 	return c.doRequestCtx(context.Background(), method, URL, body, apiKey, beta)
 }
 
+// setAuthHeader picks the header the credential is valid for. OAuth tokens only
+// authenticate against inference endpoints, so actions beyond Text Prompt still
+// fail — with the API's own scope error.
+func setAuthHeader(req *http.Request, token string) {
+	if strings.HasPrefix(token, oauthTokenPrefix) {
+		req.Header.Set("Authorization", "Bearer "+token)
+		return
+	}
+
+	req.Header.Set("x-api-key", token)
+}
+
 func (c *Client) doRequestCtx(ctx context.Context, method, URL string, body io.Reader, apiKey, beta string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, method, URL, body)
 	if err != nil {
@@ -357,7 +372,7 @@ func (c *Client) doRequestCtx(ctx context.Context, method, URL string, body io.R
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("x-api-key", apiKey)
+	setAuthHeader(req, apiKey)
 	req.Header.Set("anthropic-version", anthropicVersionValue)
 	if beta != "" {
 		req.Header.Set("anthropic-beta", beta)

--- a/pkg/integrations/claude/client_test.go
+++ b/pkg/integrations/claude/client_test.go
@@ -212,6 +212,57 @@ func TestClient_CreateMessage(t *testing.T) {
 	}
 }
 
+func TestClient_AuthHeader(t *testing.T) {
+	tests := []struct {
+		name          string
+		token         string
+		expectedKey   string
+		expectedValue string
+		emptyHeader   string
+	}{
+		{
+			name:          "API key uses x-api-key",
+			token:         "sk-ant-api03-secret",
+			expectedKey:   "x-api-key",
+			expectedValue: "sk-ant-api03-secret",
+			emptyHeader:   "Authorization",
+		},
+		{
+			name:          "OAuth token uses bearer authorization",
+			token:         "sk-ant-oat01-secret",
+			expectedKey:   "Authorization",
+			expectedValue: "Bearer sk-ant-oat01-secret",
+			emptyHeader:   "x-api-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpCtx := &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+					},
+				},
+			}
+
+			client := &Client{
+				APIKey:  tt.token,
+				BaseURL: defaultBaseURL,
+				http:    httpCtx,
+			}
+
+			require.NoError(t, client.Verify())
+			require.Len(t, httpCtx.Requests, 1)
+
+			sent := httpCtx.Requests[0]
+			assert.Equal(t, tt.expectedValue, sent.Header.Get(tt.expectedKey))
+			assert.Empty(t, sent.Header.Get(tt.emptyHeader))
+		})
+	}
+}
+
 func TestClient_ErrorHandling(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/pkg/integrations/claude/integration_secrets.go
+++ b/pkg/integrations/claude/integration_secrets.go
@@ -7,7 +7,12 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const integrationSecretAnthropicAPIKey = "ANTHROPIC_API_KEY"
+const (
+	integrationSecretAnthropicAPIKey = "ANTHROPIC_API_KEY"
+	// Claude Code reads a subscription token from this variable. The same token
+	// in ANTHROPIC_API_KEY is rejected as an invalid key.
+	integrationSecretClaudeCodeOAuthToken = "CLAUDE_CODE_OAUTH_TOKEN"
+)
 
 func (i *Claude) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][]byte, error) {
 	apiKey, err := ctx.Integration.GetConfig("apiKey")
@@ -18,6 +23,12 @@ func (i *Claude) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][
 	key := strings.TrimSpace(string(apiKey))
 	if key == "" {
 		return nil, fmt.Errorf("apiKey is required")
+	}
+
+	if strings.HasPrefix(key, oauthTokenPrefix) {
+		return map[string][]byte{
+			integrationSecretClaudeCodeOAuthToken: []byte(key),
+		}, nil
 	}
 
 	return map[string][]byte{

--- a/pkg/integrations/claude/integration_secrets_test.go
+++ b/pkg/integrations/claude/integration_secrets_test.go
@@ -22,3 +22,21 @@ func TestResolveSecrets(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("sk-ant-test"), secrets[integrationSecretAnthropicAPIKey])
 }
+
+func TestResolveSecrets_OAuthToken(t *testing.T) {
+	t.Parallel()
+
+	secrets, err := (&Claude{}).ResolveSecrets(core.IntegrationSecretContext{
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "sk-ant-oat01-test",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Claude Code reads a subscription token from its own variable; handing it
+	// over as ANTHROPIC_API_KEY makes the CLI reject it as an invalid key.
+	assert.Equal(t, []byte("sk-ant-oat01-test"), secrets[integrationSecretClaudeCodeOAuthToken])
+	assert.NotContains(t, secrets, integrationSecretAnthropicAPIKey)
+}


### PR DESCRIPTION
Fixes #6487, Fixes #6488

## What

Lets the Claude integration authenticate with a Claude Code OAuth token (`sk-ant-oat…`, issued by `claude setup-token`) in addition to a regular API key, so work can bill against a Claude subscription instead of API credits.

Two places had to change, because the token is rejected in two different ways.

**HTTP requests.** The API returns `authentication_error: invalid x-api-key` when an OAuth token is sent in `x-api-key`; it expects `Authorization: Bearer`. `setAuthHeader` now picks the header from the credential prefix, and both request paths (`doRequestCtx` and the multipart `UploadFile`) go through it.

**Runner credentials.** `ResolveSecrets` handed every credential to runners as `ANTHROPIC_API_KEY`, so the Claude Code CLI rejected an OAuth token with `Invalid API key`. It now passes a subscription token as `CLAUDE_CODE_OAUTH_TOKEN` instead.

Fixing those two was still not enough for the **Run Claude Code** component: `run.js` passes `--bare`, whose documented behavior includes skipping keychain reads — the same path the CLI uses to authenticate a subscription token — so the run failed with `Not logged in · Please run /login`. The flag is now omitted when a subscription token is present and kept otherwise, where its isolation costs nothing.

## Why

A Claude subscription is the cheaper path for teams already paying for one, and Claude Code is explicitly designed to run on `CLAUDE_CODE_OAUTH_TOKEN` in CI. Before this change the integration accepted such a token in the form, reported the connection as healthy, and then failed at run time.

## Scope of what a subscription token can do

Verified against the live API — the token carries inference scope only:

| Endpoint | Result |
|---|---|
| `GET /models` (connection check, model list) | 200 |
| `POST /messages` (Text Prompt) | 200 |
| `GET /messages/batches` | 403 — needs `user:batch` / `user:developer` / `workspace:*` |
| `GET /files` | 404 |
| `GET /agents` | 401 |
| `GET /environments` | 403 — needs `org:sessions:*` / `user:developer` |

So Text Prompt and Run Claude Code work; Run Agent, Run Code Agent, Create Batch Message, file attachments and usage reports still require an API key. Those actions surface the API's own scope error rather than a local pre-check, which keeps the diff small and the message accurate. The integration's instructions say this explicitly, and the generated component docs are regenerated.

## Design note

The credential type is detected by prefix (`sk-ant-oat`) rather than an explicit selector field, because the two credential kinds are mutually exclusive and the prefix already distinguishes them — no new configuration field, no migration for existing integrations. The trade-off is that the prefix is an undocumented contract: if it ever changes, detection fails silently and the token goes back to `x-api-key`.

## Testing

- `TestClient_AuthHeader` covers both credential kinds and both headers
- `TestResolveSecrets_OAuthToken` covers the runner environment variable
- `make lint`, `make check.build.app`, `make check.components.docs`, `go test ./pkg/integrations/claude/...` all pass
- End-to-end against the live API with a real subscription token: connection check, model list and a Text Prompt all succeed; a full **Run Claude Code** workflow ran to completion (12 turns, 65s) and opened a GitHub issue

Note that `anthropic-beta: oauth-2025-04-20` turned out not to be required for these endpoints, so beta headers are untouched.
