### PR TITLE
fix: fire daily and monthly schedules in the current period when still ahead

### DIFF
--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -701,8 +701,14 @@ func nextDaysTrigger(interval int, hour int, minute int, now time.Time) (*time.T
 
 	nowInTZ := now
 
-	nextTrigger := nowInTZ.AddDate(0, 0, interval)
-	nextTrigger = time.Date(nextTrigger.Year(), nextTrigger.Month(), nextTrigger.Day(), hour, minute, 0, 0, nextTrigger.Location())
+	// Occurrence of the specified time today (same pattern as nextHoursTrigger).
+	nextTrigger := time.Date(nowInTZ.Year(), nowInTZ.Month(), nowInTZ.Day(), hour, minute, 0, 0, nowInTZ.Location())
+
+	// If that occurrence is still in the future, fire today.
+	// Otherwise (the time has already passed), advance by the configured interval.
+	if !nextTrigger.After(nowInTZ) {
+		nextTrigger = nextTrigger.AddDate(0, 0, interval)
+	}
 
 	utcResult := nextTrigger.UTC()
 	return &utcResult, nil
@@ -762,9 +768,16 @@ func nextMonthsTrigger(interval int, dayOfMonth int, hour int, minute int, now t
 	}
 
 	nowInTZ := now
-	nextTriggerMonths := interval
-	nextTrigger := nowInTZ.AddDate(0, nextTriggerMonths, 0)
-	nextTrigger = time.Date(nextTrigger.Year(), nextTrigger.Month(), dayOfMonth, hour, minute, 0, 0, nextTrigger.Location())
+
+	// Occurrence of the specified day/time this month (same pattern as nextHoursTrigger).
+	nextTrigger := time.Date(nowInTZ.Year(), nowInTZ.Month(), dayOfMonth, hour, minute, 0, 0, nowInTZ.Location())
+
+	// If that occurrence is still in the future, fire this month.
+	// Otherwise (the day/time has already passed), advance by the configured interval.
+	if !nextTrigger.After(nowInTZ) {
+		advanced := nowInTZ.AddDate(0, interval, 0)
+		nextTrigger = time.Date(advanced.Year(), advanced.Month(), dayOfMonth, hour, minute, 0, 0, advanced.Location())
+	}
 
 	utcResult := nextTrigger.UTC()
 	return &utcResult, nil

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -125,7 +125,7 @@ func TestGetNextTrigger(t *testing.T) {
 			expectNext: mustParseTime("2025-01-01T11:45:00Z"),
 		},
 		{
-			name: "days configuration",
+			name: "days configuration (time not yet passed, fires today)",
 			config: Configuration{
 				Type:         TypeDays,
 				DaysInterval: intPtr(1),
@@ -133,7 +133,40 @@ func TestGetNextTrigger(t *testing.T) {
 				Minute:       intPtr(30),
 			},
 			now:        mustParseTime("2025-01-01T10:00:00Z"),
+			expectNext: mustParseTime("2025-01-01T14:30:00Z"),
+		},
+		{
+			name: "days configuration (time already passed, fires next interval)",
+			config: Configuration{
+				Type:         TypeDays,
+				DaysInterval: intPtr(1),
+				Hour:         intPtr(14),
+				Minute:       intPtr(30),
+			},
+			now:        mustParseTime("2025-01-01T16:00:00Z"),
 			expectNext: mustParseTime("2025-01-02T14:30:00Z"),
+		},
+		{
+			name: "days configuration (exactly at trigger time, fires next interval)",
+			config: Configuration{
+				Type:         TypeDays,
+				DaysInterval: intPtr(1),
+				Hour:         intPtr(14),
+				Minute:       intPtr(30),
+			},
+			now:        mustParseTime("2025-01-01T14:30:00Z"),
+			expectNext: mustParseTime("2025-01-02T14:30:00Z"),
+		},
+		{
+			name: "days configuration with interval > 1 (time not yet passed, fires today)",
+			config: Configuration{
+				Type:         TypeDays,
+				DaysInterval: intPtr(3),
+				Hour:         intPtr(9),
+				Minute:       intPtr(0),
+			},
+			now:        mustParseTime("2025-01-01T08:00:00Z"),
+			expectNext: mustParseTime("2025-01-01T09:00:00Z"),
 		},
 		{
 			name: "weeks configuration",
@@ -148,7 +181,7 @@ func TestGetNextTrigger(t *testing.T) {
 			expectNext: mustParseTime("2025-01-17T15:30:00Z"), // Friday of next week
 		},
 		{
-			name: "months configuration",
+			name: "months configuration (day not yet passed, fires this month)",
 			config: Configuration{
 				Type:           TypeMonths,
 				MonthsInterval: intPtr(1),
@@ -157,6 +190,30 @@ func TestGetNextTrigger(t *testing.T) {
 				Minute:         intPtr(30),
 			},
 			now:        mustParseTime("2025-01-01T10:00:00Z"),
+			expectNext: mustParseTime("2025-01-15T14:30:00Z"),
+		},
+		{
+			name: "months configuration (day already passed, fires next interval)",
+			config: Configuration{
+				Type:           TypeMonths,
+				MonthsInterval: intPtr(1),
+				DayOfMonth:     intPtr(15),
+				Hour:           intPtr(14),
+				Minute:         intPtr(30),
+			},
+			now:        mustParseTime("2025-01-20T10:00:00Z"),
+			expectNext: mustParseTime("2025-02-15T14:30:00Z"),
+		},
+		{
+			name: "months configuration (exactly at trigger time, fires next interval)",
+			config: Configuration{
+				Type:           TypeMonths,
+				MonthsInterval: intPtr(1),
+				DayOfMonth:     intPtr(15),
+				Hour:           intPtr(14),
+				Minute:         intPtr(30),
+			},
+			now:        mustParseTime("2025-01-15T14:30:00Z"),
 			expectNext: mustParseTime("2025-02-15T14:30:00Z"),
 		},
 		{
@@ -365,7 +422,7 @@ func TestTimezoneHandling(t *testing.T) {
 			expectNext: mustParseTime("2025-01-01T07:01:00Z"), // 4:01 AM GMT-3 (7:01 AM UTC), minute 1 not yet passed
 		},
 		{
-			name: "day schedule in GMT+5 timezone",
+			name: "day schedule in GMT+5 timezone (time not yet passed, fires today)",
 			config: Configuration{
 				Type:         TypeDays,
 				DaysInterval: intPtr(1),
@@ -374,7 +431,7 @@ func TestTimezoneHandling(t *testing.T) {
 				Timezone:     stringPtr("5"), // GMT+5
 			},
 			now:        mustParseTime("2025-01-01T08:00:00Z"), // 1 PM GMT+5 (8 AM UTC)
-			expectNext: mustParseTime("2025-01-02T09:30:00Z"), // 2:30 PM GMT+5 (9:30 AM UTC)
+			expectNext: mustParseTime("2025-01-01T09:30:00Z"), // 2:30 PM GMT+5 same day (9:30 AM UTC)
 		},
 		{
 			name: "week schedule in GMT-8 timezone (PST)",
@@ -390,7 +447,7 @@ func TestTimezoneHandling(t *testing.T) {
 			expectNext: mustParseTime("2025-01-13T17:00:00Z"), // Monday 9 AM PST (5 PM UTC) of the next week
 		},
 		{
-			name: "month schedule in GMT+9 timezone (JST)",
+			name: "month schedule in GMT+9 timezone (JST, day not yet passed, fires this month)",
 			config: Configuration{
 				Type:           TypeMonths,
 				MonthsInterval: intPtr(1),
@@ -400,7 +457,7 @@ func TestTimezoneHandling(t *testing.T) {
 				Timezone:       stringPtr("9"), // GMT+9 (JST)
 			},
 			now:        mustParseTime("2025-01-01T02:00:00Z"), // Jan 1st 11 AM JST (2 AM UTC)
-			expectNext: mustParseTime("2025-02-15T03:00:00Z"), // Jan 15th Noon JST (3 AM UTC) of the next month
+			expectNext: mustParseTime("2025-01-15T03:00:00Z"), // Jan 15th Noon JST (3 AM UTC) of the current month
 		},
 		{
 			name: "minutes schedule timezone should not affect calculation",

--- a/web_src/src/pages/app/mappers/schedule.ts
+++ b/web_src/src/pages/app/mappers/schedule.ts
@@ -144,12 +144,14 @@ function calculateNextTrigger(configuration: ScheduleConfiguration, referenceNex
 
       if (minute < 0 || minute > 59) return null;
 
-      // Match Go backend: start with current time in timezone + interval, set minute
+      // Match Go backend: occurrence in the current hour; advance only if it has passed
       const nextTriggerInTZ = new Date(nowInTZ);
-      nextTriggerInTZ.setHours(nextTriggerInTZ.getHours() + interval);
       nextTriggerInTZ.setMinutes(minute);
       nextTriggerInTZ.setSeconds(0);
       nextTriggerInTZ.setMilliseconds(0);
+      if (nextTriggerInTZ <= nowInTZ) {
+        nextTriggerInTZ.setHours(nextTriggerInTZ.getHours() + interval);
+      }
 
       return new Date(nextTriggerInTZ.getTime() - timezoneOffsetMs);
     }
@@ -164,13 +166,15 @@ function calculateNextTrigger(configuration: ScheduleConfiguration, referenceNex
 
       if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
 
-      // Match Go backend: add interval days in timezone, set time
+      // Match Go backend: occurrence today; advance only if it has passed
       const nextTriggerInTZ = new Date(nowInTZ);
-      nextTriggerInTZ.setDate(nextTriggerInTZ.getDate() + interval);
       nextTriggerInTZ.setHours(hour);
       nextTriggerInTZ.setMinutes(minute);
       nextTriggerInTZ.setSeconds(0);
       nextTriggerInTZ.setMilliseconds(0);
+      if (nextTriggerInTZ <= nowInTZ) {
+        nextTriggerInTZ.setDate(nextTriggerInTZ.getDate() + interval);
+      }
 
       return new Date(nextTriggerInTZ.getTime());
     }
@@ -244,14 +248,22 @@ function calculateNextTrigger(configuration: ScheduleConfiguration, referenceNex
 
       if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
 
-      // Match Go backend: add interval months in timezone, set day/hour/minute
+      // Match Go backend: occurrence this month; advance only if it has passed
       const nextTriggerInTZ = new Date(nowInTZ);
-      nextTriggerInTZ.setMonth(nextTriggerInTZ.getMonth() + interval);
       nextTriggerInTZ.setDate(dayOfMonth);
       nextTriggerInTZ.setHours(hour);
       nextTriggerInTZ.setMinutes(minute);
       nextTriggerInTZ.setSeconds(0);
       nextTriggerInTZ.setMilliseconds(0);
+      if (nextTriggerInTZ <= nowInTZ) {
+        const advanced = new Date(nowInTZ);
+        advanced.setMonth(advanced.getMonth() + interval);
+        nextTriggerInTZ.setFullYear(advanced.getFullYear(), advanced.getMonth(), dayOfMonth);
+        nextTriggerInTZ.setHours(hour);
+        nextTriggerInTZ.setMinutes(minute);
+        nextTriggerInTZ.setSeconds(0);
+        nextTriggerInTZ.setMilliseconds(0);
+      }
 
       return new Date(nextTriggerInTZ.getTime());
     }


### PR DESCRIPTION
## Summary

- Daily and monthly schedules no longer skip the current period when the configured time is still ahead (same rule hours already use after #6231).
- Example: "every day at 14:30" created at 10:00 now fires today at 14:30, not tomorrow.
- Example: "every month on the 15th" created on the 1st now fires this month on the 15th, not next month.
- UI next-run preview for hours/days/months matches the backend (hours preview was still always advancing by the interval).

## Why

`nextHoursTrigger` was fixed in #6231 to fire in the current hour when the minute has not passed. `nextDaysTrigger` and `nextMonthsTrigger` still always added a full interval first, so the first run was systematically late by up to one day or one month. Cron already resolved the next same-day occurrence. Docs advertise "Daily at 9 AM" and "First of every month", which users reasonably expect in the current period when that time is still ahead.

## Changes

- `pkg/triggers/schedule/schedule.go`: apply the same-period pattern to days and months.
- `pkg/triggers/schedule/schedule_test.go`: cover not-yet-passed, already-passed, and exact-time cases for both.
- `web_src/src/pages/app/mappers/schedule.ts`: keep the node "Next" label in sync with the backend for hours, days, and months.

## Test plan

- [x] `make test PKG_TEST_PACKAGES=./pkg/triggers/schedule` (47 tests passed)
- [ ] Create a days schedule for later today; confirm first fire is today
- [ ] Create a months schedule for a later day this month; confirm first fire is this month
- [ ] After a fire, confirm the next arm jumps by the configured interval
- [ ] Confirm the node "Next" label matches the backend `nextTrigger` after publish