### PR TITLE
fix: prevent nil-pointer panic when HTTP retries are exhausted on a t…

### DIFF
--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -1129,8 +1129,18 @@ func (e *HTTP) handleRetryRequest(ctx core.ActionHookContext) error {
 	// If we should not retry anymore, fail here.
 	//
 	if metadata.Retry.Attempts >= metadata.Retry.MaxAttempts {
-		if err != nil {
-			return e.processResponse(ctx.Metadata, ctx.ExecutionState, resp, spec)
+		//
+		// No response received (transport error, timeout, DNS): emit a failure
+		// without dereferencing the nil response, mirroring executeRequestWithoutRetry.
+		//
+		if err != nil || resp == nil {
+			return ctx.ExecutionState.Emit(
+				FailureOutputChannel,
+				"http.request.failed",
+				[]any{map[string]any{
+					"error": fmt.Sprintf("error executing request: %v", err),
+				}},
+			)
 		}
 
 		return e.handleRequestFailure(ctx.Metadata, ctx.ExecutionState, resp, err)

--- a/pkg/components/http/http_test.go
+++ b/pkg/components/http/http_test.go
@@ -1084,3 +1084,54 @@ func TestHTTP__CalculateNextRetryDelay(t *testing.T) {
 	assert.Equal(t, 5*time.Second, h.calculateNextRetryDelay(RetryStrategyFixed, 2, 5))
 	assert.Equal(t, 20*time.Second, h.calculateNextRetryDelay(RetryStrategyExponential, 2, 5))
 }
+
+func TestHTTP__HandleHook__RetryRequest_ExhaustedWithNetworkError(t *testing.T) {
+	h := &HTTP{}
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	// retryConfig has maxAttempts=3, so the endpoint is down for the whole
+	// window: Execute (attempt 1) + 3 hook calls, all transport errors, drives
+	// the retry loop to exhaustion with no response ever received.
+	httpCtx := &sequenceHTTPClient{errors: []error{
+		errors.New("connection refused"),
+		errors.New("connection refused"),
+		errors.New("connection refused"),
+		errors.New("connection refused"),
+	}}
+
+	execCtx := core.ExecutionContext{
+		Logger:         log.NewEntry(log.StandardLogger()),
+		Configuration:  retryConfig("https://api.example.com"),
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       &contexts.RequestContext{},
+		HTTP:           httpCtx,
+	}
+
+	require.NoError(t, h.Execute(execCtx))
+
+	// Drive the retry hook to exhaustion. The final call exhausts retries on a
+	// transport error: today it panics; it must emit a failure instead.
+	for i := 0; i < 3; i++ {
+		actionCtx := core.ActionHookContext{
+			Logger:         log.NewEntry(log.StandardLogger()),
+			Name:           "retryRequest",
+			Configuration:  execCtx.Configuration,
+			ExecutionState: stateCtx,
+			Metadata:       metadataCtx,
+			Requests:       &contexts.RequestContext{},
+			HTTP:           httpCtx,
+		}
+		require.NotPanics(t, func() {
+			require.NoError(t, h.HandleHook(actionCtx))
+		})
+	}
+
+	assert.Equal(t, FailureOutputChannel, stateCtx.Channel)
+	assert.Equal(t, "http.request.failed", stateCtx.Type)
+
+	metadata := decodeMetadata(t, metadataCtx)
+	require.NotNil(t, metadata.Retry)
+	assert.Equal(t, 3, metadata.Retry.MaxAttempts)
+}


### PR DESCRIPTION
## What

When an HTTP component has retries enabled and the endpoint is unreachable for the
entire retry window (connection refused, DNS failure, timeout), the component panics
with a nil-pointer dereference instead of emitting a failure event.

## Where

`pkg/components/http/http.go`, `handleRetryRequest`, retry-exhaustion branch:

```go
if metadata.Retry.Attempts >= metadata.Retry.MaxAttempts {
    if err != nil {
        return e.processResponse(ctx.Metadata, ctx.ExecutionState, resp, spec) // resp == nil
    }
    return e.handleRequestFailure(ctx.Metadata, ctx.ExecutionState, resp, err)
}
```

`executeRequest` returns `(nil, err)` on any transport-level failure. On the final retry
attempt, this branch runs with `err != nil` and `resp == nil` and calls `processResponse`,
whose first statement is `defer resp.Body.Close()` — panicking on the nil `*http.Response`.

## Reproduction

Configure an HTTP component with retry enabled (`strategy: fixed`, `maxAttempts: 3`) pointing
at an unreachable host. The initial `Execute` and each `retryRequest` hook fail at the transport
layer; when attempts reach `maxAttempts`, the component panics instead of routing to its failure
output.

## Why it's a bug (not intended behavior)

- The non-retry path `executeRequestWithoutRetry` handles the identical `err != nil` /
  no-response case correctly — it emits `FailureOutputChannel` / `http.request.failed` with
  just `{"error": ...}` and never touches `resp`.
- The adjacent retry-scheduling branch already guards `if resp != nil` before reading
  `resp.StatusCode`/`resp.Body`, so the code elsewhere acknowledges `resp` can be nil here.
- Both callees in the exhaustion branch assume a non-nil response (`processResponse` closes
  `resp.Body`; `handleRequestFailure` reads `resp.StatusCode`), so the branch is unsafe for the
  no-response case by construction.

## Fix

Handle the no-response case explicitly, mirroring `executeRequestWithoutRetry`, and only reach
the response-based failure handler when a response actually exists:

```go
if metadata.Retry.Attempts >= metadata.Retry.MaxAttempts {
    if err != nil || resp == nil {
        return ctx.ExecutionState.Emit(
            FailureOutputChannel,
            "http.request.failed",
            []any{map[string]any{
                "error": fmt.Sprintf("error executing request: %v", err),
            }},
        )
    }
    return e.handleRequestFailure(ctx.Metadata, ctx.ExecutionState, resp, err)
}
```

The exhausted-on-a-non-success-status case (`err == nil`, real `resp`) is unchanged.

## Tests

Adds `TestHTTP__HandleHook__RetryRequest_ExhaustedWithNetworkError`, which drives the retry hook
to exhaustion with a sequence of transport errors and asserts the component emits a terminal
failure (`FailureOutputChannel` / `http.request.failed`) without panicking. The existing retry
tests cover scheduling and success-after-error but not exhaustion-with-error, so this closes the
uncovered path.

Reproduced with the failing test: without the fix, the new test panics with
`runtime error: invalid memory address or nil pointer dereference`; with the fix it emits a
terminal failure. `go test ./pkg/components/http/...` is green with the fix.
