### PR TITLE
fix: flip AutoCompleteInput suggestions above caret near viewport edge

### DIFF
--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
@@ -4,11 +4,13 @@ import { AutoCompleteInput } from "./AutoCompleteInput";
 import { calculateDropdownPosition } from "./dropdownPosition";
 
 describe("calculateDropdownPosition", () => {
-  it("anchors the dropdown top to the cursor y coordinate", () => {
+  it("anchors the dropdown top below the cursor when there is room", () => {
     const position = calculateDropdownPosition({
       cursor: { x: 120, y: 240 },
       viewportWidth: 1000,
+      viewportHeight: 800,
       dropdownWidth: 350,
+      dropdownHeight: 244,
       valuePreviewWidth: 200,
       showValuePreview: false,
     });
@@ -20,12 +22,45 @@ describe("calculateDropdownPosition", () => {
     const position = calculateDropdownPosition({
       cursor: { x: 980, y: 80 },
       viewportWidth: 1000,
+      viewportHeight: 800,
       dropdownWidth: 350,
+      dropdownHeight: 244,
       valuePreviewWidth: 200,
       showValuePreview: false,
     });
 
     expect(position.left).toBe(630);
+  });
+
+  it("flips the dropdown above the caret when there is not enough room below", () => {
+    const position = calculateDropdownPosition({
+      cursor: { x: 120, y: 760 },
+      viewportWidth: 1000,
+      viewportHeight: 800,
+      dropdownWidth: 350,
+      dropdownHeight: 244,
+      valuePreviewWidth: 200,
+      showValuePreview: false,
+      cursorHeight: 20,
+    });
+
+    // caret top (760 - 20) minus the gap (4) minus the dropdown height (244).
+    expect(position.top).toBe(492);
+  });
+
+  it("keeps the dropdown within the viewport vertically when neither side fits", () => {
+    const position = calculateDropdownPosition({
+      cursor: { x: 120, y: 190 },
+      viewportWidth: 1000,
+      viewportHeight: 200,
+      dropdownWidth: 350,
+      dropdownHeight: 244,
+      valuePreviewWidth: 200,
+      showValuePreview: false,
+    });
+
+    // Clamped to the top edge padding since the dropdown is taller than the viewport.
+    expect(position.top).toBe(16);
   });
 });
 

--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -975,9 +975,12 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
         calculateDropdownPosition({
           cursor,
           viewportWidth: window.innerWidth,
+          viewportHeight: window.innerHeight,
           dropdownWidth,
+          dropdownHeight: SUGGESTION_LIST_MAX_HEIGHT_PX,
           valuePreviewWidth,
           showValuePreview,
+          cursorHeight: markerRect.height,
         }),
       );
     }, [inputValue, cursorPosition, dropdownWidth, showValuePreview]);

--- a/web_src/src/components/AutoCompleteInput/dropdownPosition.ts
+++ b/web_src/src/components/AutoCompleteInput/dropdownPosition.ts
@@ -6,9 +6,12 @@ type ScreenPoint = {
 type DropdownPositionInput = {
   cursor: ScreenPoint;
   viewportWidth: number;
+  viewportHeight: number;
   dropdownWidth: number;
+  dropdownHeight: number;
   valuePreviewWidth: number;
   showValuePreview: boolean;
+  cursorHeight?: number;
   edgePadding?: number;
   gap?: number;
 };
@@ -16,9 +19,12 @@ type DropdownPositionInput = {
 export function calculateDropdownPosition({
   cursor,
   viewportWidth,
+  viewportHeight,
   dropdownWidth,
+  dropdownHeight,
   valuePreviewWidth,
   showValuePreview,
+  cursorHeight = 0,
   edgePadding = 16,
   gap = 4,
 }: DropdownPositionInput) {
@@ -33,9 +39,18 @@ export function calculateDropdownPosition({
     left = showValuePreview ? cursor.x - valuePreviewWidth : cursor.x;
   }
 
+  // Flip the dropdown above the caret when there isn't enough room below it and
+  // the space above is larger. `cursor.y` is the bottom of the caret, so we
+  // clear the caret's own line (`cursorHeight`) before stacking upwards.
+  const spaceBelow = viewportHeight - cursor.y - edgePadding;
+  const spaceAbove = cursor.y - cursorHeight - edgePadding;
+  const shouldFlipUp = spaceBelow < dropdownHeight && spaceAbove > spaceBelow;
+
+  const top = shouldFlipUp ? cursor.y - cursorHeight - gap - dropdownHeight : cursor.y + gap;
+
   const totalWidth = showValuePreview ? dropdownWidth + valuePreviewWidth : dropdownWidth;
   return {
-    top: cursor.y + gap,
+    top: Math.max(edgePadding, Math.min(top, viewportHeight - dropdownHeight - edgePadding)),
     left: Math.max(edgePadding, Math.min(left, viewportWidth - totalWidth - edgePadding)),
   };
 }


### PR DESCRIPTION
The suggestions dropdown only ever positioned itself below the caret (top: cursor.y + gap), so typing near the bottom of the viewport pushed the list off-screen. Horizontal overflow was already handled by flipping left/right; this adds the equivalent vertical behavior.

calculateDropdownPosition now accepts the viewport height, dropdown height, and caret height. It flips the dropdown above the caret when there is not enough room below and more room above, and clamps the result within the viewport as a final safeguard. The caller passes window.innerHeight, the existing SUGGESTION_LIST_MAX_HEIGHT_PX constant, and the measured caret height.

Fixes #6483