### PR TITLE
docs: fix Cursor skill repository links

### DIFF
--- a/.cursor/skills/superplane-integration-research/SKILL.md
+++ b/.cursor/skills/superplane-integration-research/SKILL.md
@@ -19,6 +19,6 @@ You are a **research helper**, usability-oriented. You help the user understand 
 
 - **Brief, conversational.** A few sentences or 2–3 bullets. One finding per turn, then ask what they want next.
 - **No slop.** No formal headers, no "comprehensive overview." Talk like a colleague.
-- **Existing integrations:** From [docs/components/](docs/components/) or [docs.superplane.com](https://docs.superplane.com). If the tool is similar to one we have (e.g. Railway ↔ Render), mention it in one line and use it as a pattern for components.
+- **Existing integrations:** From [docs/components/](../../../docs/components/) or [docs.superplane.com](https://docs.superplane.com). If the tool is similar to one we have (e.g. Railway ↔ Render), mention it in one line and use it as a pattern for components.
 
 When they're ready to lock in: short summary = what the tool is for, suggested components (one line each). Optionally one line on "connection looks like X—engineers can detail it." Don't make connection the main output.

--- a/.cursor/skills/superplane-issue-logger/SKILL.md
+++ b/.cursor/skills/superplane-issue-logger/SKILL.md
@@ -7,7 +7,7 @@ description: When researching, classifying, drafting, or logging general SuperPl
 
 Use this skill when a user describes an improvement, bug, or request in natural language. You will: (1) research and understand it in SuperPlane context, (2) classify issue type, (3) propose title and body in `tmp/pm_logger`, and (4) optionally create the issue on GitHub with correct labels.
 
-Reference: [docs/contributing/](docs/contributing/) (issue-tracking, quality, pull-requests, etc.), [https://docs.superplane.com/](https://docs.superplane.com/) when relevant.
+Reference: [docs/contributing/](../../../docs/contributing/) (issue-tracking, quality, pull-requests, etc.), [https://docs.superplane.com/](https://docs.superplane.com/) when relevant.
 
 ---
 
@@ -33,7 +33,7 @@ Map the user's description to exactly one of:
 - **Bug vs papercut**: If it breaks a flow or blocks usage → **bug**. If it's annoying or inconsistent but workable → **papercut**.
 - **Enhancement vs feature**: Improves something that already exists → **enhancement**. Adds net-new capability → **feature**.
 
-Align with [issue-tracking](docs/contributing/issue-tracking.md) (Bugs, Papercuts, Enhancements views on the SuperPlane Board).
+Align with [issue-tracking](../../../docs/contributing/issue-tracking.md) (Bugs, Papercuts, Enhancements views on the SuperPlane Board).
 
 ---
 


### PR DESCRIPTION
## What changed

- Correct repository-relative links in the integration research skill
- Correct contributing and issue-tracking links in the issue logger skill

## Why

The previous paths were resolved from each skill directory, so they pointed to nonexistent `.cursor/skills/.../docs` locations instead of the repository documentation.

## Validation

- Verified each relative target exists from its Markdown file
- Ran `git diff --check`

No runtime behavior changes.