### PR TITLE
fix: restrict cross-app references between org and factory apps

### DIFF
--- a/pkg/workers/contexts/app_context.go
+++ b/pkg/workers/contexts/app_context.go
@@ -52,34 +52,58 @@ func (c *AppContext) GetNode(app, node string) (*core.CanvasNode, error) {
 
 func (c *AppContext) getAppByID(id uuid.UUID) (*core.App, error) {
 	otherApp, err := models.FindCanvasInTransaction(c.tx, c.canvas.OrganizationID, id)
-	if err == nil {
-		return &core.App{
-			ID:   otherApp.ID.String(),
-			Name: otherApp.Name,
-		}, nil
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, core.ErrNotFound
+		}
+
+		return nil, err
 	}
 
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, core.ErrNotFound
+	if err := c.validateFactoryOwnedAppReference(c.canvas, otherApp); err != nil {
+		return nil, err
 	}
 
-	return nil, err
+	return &core.App{
+		ID:   otherApp.ID.String(),
+		Name: otherApp.Name,
+	}, nil
 }
 
 func (c *AppContext) getAppByName(name string) (*core.App, error) {
 	otherApp, err := models.FindCanvasByNameInTransaction(c.tx, name, c.canvas.OrganizationID)
-	if err == nil {
-		return &core.App{
-			ID:   otherApp.ID.String(),
-			Name: otherApp.Name,
-		}, nil
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, core.ErrNotFound
+		}
+
+		return nil, err
 	}
 
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, core.ErrNotFound
+	if err := c.validateFactoryOwnedAppReference(c.canvas, otherApp); err != nil {
+		return nil, err
 	}
 
-	return nil, err
+	return &core.App{
+		ID:   otherApp.ID.String(),
+		Name: otherApp.Name,
+	}, nil
+}
+
+func (c *AppContext) validateFactoryOwnedAppReference(caller, target *models.Canvas) error {
+	if caller.FactoryID == nil {
+		if target.FactoryID != nil {
+			return fmt.Errorf("app %q is owned by a factory", target.Name)
+		}
+
+		return nil
+	}
+
+	if target.FactoryID == nil || *target.FactoryID != *caller.FactoryID {
+		return fmt.Errorf("app %q is not owned by this factory", target.Name)
+	}
+
+	return nil
 }
 
 func (c *AppContext) Subscribe(id string) error {

--- a/pkg/workers/contexts/app_context_test.go
+++ b/pkg/workers/contexts/app_context_test.go
@@ -59,6 +59,91 @@ func Test__AppContext__Get(t *testing.T) {
 	})
 }
 
+func Test__AppContext__Get__factoryOwnedApps(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	factory, err := models.CreateFactory(database.Conn(), r.Organization.ID, support.RandomName("factory"), "")
+	require.NoError(t, err)
+	factoryID := factory.ID
+
+	factoryListenerCanvas, factoryListenerNodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "run-app",
+				Name:   "Run App",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
+				Configuration: datatypes.NewJSONType(map[string]any{
+					"app": "",
+				}),
+			},
+		},
+		nil,
+	)
+	require.NoError(t, database.Conn().Model(factoryListenerCanvas).Update("factory_id", factoryID).Error)
+	factoryListenerCanvas.FactoryID = &factoryID
+
+	factorySourceCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	require.NoError(t, database.Conn().Model(factorySourceCanvas).Update("factory_id", factoryID).Error)
+
+	orgCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	ctx := NewAppContext(database.Conn(), factoryListenerCanvas, &factoryListenerNodes[0])
+
+	t.Run("allows another app owned by the same factory", func(t *testing.T) {
+		app, err := ctx.Get(factorySourceCanvas.ID.String())
+		require.NoError(t, err)
+		assert.Equal(t, factorySourceCanvas.ID.String(), app.ID)
+	})
+
+	t.Run("rejects org apps outside the factory", func(t *testing.T) {
+		app, err := ctx.Get(orgCanvas.ID.String())
+		require.ErrorContains(t, err, "not owned by this factory")
+		assert.Nil(t, app)
+	})
+}
+
+func Test__AppContext__Get__rejectsFactoryAppsFromOrgApps(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	factory, err := models.CreateFactory(database.Conn(), r.Organization.ID, support.RandomName("factory"), "")
+	require.NoError(t, err)
+	factoryID := factory.ID
+
+	orgListenerCanvas, orgListenerNodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "run-app",
+				Name:   "Run App",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "runApp"}}),
+				Configuration: datatypes.NewJSONType(map[string]any{
+					"app": "",
+				}),
+			},
+		},
+		nil,
+	)
+
+	factorySourceCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	require.NoError(t, database.Conn().Model(factorySourceCanvas).Update("factory_id", factoryID).Error)
+
+	ctx := NewAppContext(database.Conn(), orgListenerCanvas, &orgListenerNodes[0])
+
+	t.Run("rejects factory-owned apps", func(t *testing.T) {
+		app, err := ctx.Get(factorySourceCanvas.ID.String())
+		require.ErrorContains(t, err, "owned by a factory")
+		assert.Nil(t, app)
+	})
+}
+
 func Test__AppContext__Subscribe(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()

--- a/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.spec.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ConfigurationField } from "@/api-client";
-import { useCanvases } from "@/hooks/useCanvasData";
+import { useCanvas, useCanvases } from "@/hooks/useCanvasData";
+import { useFactoryApps } from "@/hooks/useFactoryData";
 
 import { AppFieldRenderer } from "./AppFieldRenderer";
 
@@ -14,9 +15,16 @@ vi.mock("react-router-dom", () => ({
 
 vi.mock("@/hooks/useCanvasData", () => ({
   useCanvases: vi.fn(),
+  useCanvas: vi.fn(),
+}));
+
+vi.mock("@/hooks/useFactoryData", () => ({
+  useFactoryApps: vi.fn(),
 }));
 
 const mockUseCanvases = vi.mocked(useCanvases);
+const mockUseCanvas = vi.mocked(useCanvas);
+const mockUseFactoryApps = vi.mocked(useFactoryApps);
 
 function appField(overrides: Partial<ConfigurationField> = {}): ConfigurationField {
   return {
@@ -44,6 +52,18 @@ function ControlledRenderer({
 }
 
 beforeEach(() => {
+  mockUseCanvas.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  } as ReturnType<typeof useCanvas>);
+
+  mockUseFactoryApps.mockReturnValue({
+    data: [],
+    isLoading: false,
+    error: null,
+  } as ReturnType<typeof useFactoryApps>);
+
   mockUseCanvases.mockReturnValue({
     data: [
       { id: "canvas_current", name: "Current App" },
@@ -89,5 +109,43 @@ describe("AppFieldRenderer", () => {
     await userEvent.click(screen.getByText("Billing Alerts"));
 
     expect(screen.getByTestId("current-value")).toHaveTextContent("canvas_billing");
+  });
+
+  it("lists factory apps when configuring on a factory-owned canvas", async () => {
+    mockUseCanvas.mockReturnValue({
+      data: {
+        metadata: {
+          factoryId: "factory_refunds",
+        },
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useCanvas>);
+
+    mockUseFactoryApps.mockReturnValue({
+      data: [
+        { id: "canvas_current", name: "Current Factory App" },
+        { id: "canvas_planner", name: "Refund Planner" },
+      ],
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useFactoryApps>);
+
+    render(
+      <ControlledRenderer
+        field={appField({
+          typeOptions: {
+            app: {
+              allowSelf: true,
+            },
+          },
+        })}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("combobox"));
+    expect(screen.getByText("Current Factory App")).toBeInTheDocument();
+    expect(screen.getByText("Refund Planner")).toBeInTheDocument();
+    expect(screen.queryByText("Billing Alerts")).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.spec.tsx
@@ -62,7 +62,7 @@ beforeEach(() => {
     data: [],
     isLoading: false,
     error: null,
-  } as ReturnType<typeof useFactoryApps>);
+  } as unknown as ReturnType<typeof useFactoryApps>);
 
   mockUseCanvases.mockReturnValue({
     data: [
@@ -102,15 +102,6 @@ describe("AppFieldRenderer", () => {
     expect(screen.getByText("Current App")).toBeInTheDocument();
   });
 
-  it("stores the selected app id", async () => {
-    render(<ControlledRenderer />);
-
-    await userEvent.click(screen.getByRole("combobox"));
-    await userEvent.click(screen.getByText("Billing Alerts"));
-
-    expect(screen.getByTestId("current-value")).toHaveTextContent("canvas_billing");
-  });
-
   it("lists factory apps when configuring on a factory-owned canvas", async () => {
     mockUseCanvas.mockReturnValue({
       data: {
@@ -129,7 +120,7 @@ describe("AppFieldRenderer", () => {
       ],
       isLoading: false,
       error: null,
-    } as ReturnType<typeof useFactoryApps>);
+    } as unknown as ReturnType<typeof useFactoryApps>);
 
     render(
       <ControlledRenderer
@@ -146,6 +137,41 @@ describe("AppFieldRenderer", () => {
     await userEvent.click(screen.getByRole("combobox"));
     expect(screen.getByText("Current Factory App")).toBeInTheDocument();
     expect(screen.getByText("Refund Planner")).toBeInTheDocument();
+    expect(screen.queryByText("Billing Alerts")).not.toBeInTheDocument();
+  });
+
+  it("stores the selected app id", async () => {
+    render(<ControlledRenderer />);
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByText("Billing Alerts"));
+
+    expect(screen.getByTestId("current-value")).toHaveTextContent("canvas_billing");
+  });
+
+  it("waits for the current canvas before showing org apps", () => {
+    mockUseCanvas.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useCanvas>);
+
+    render(<ControlledRenderer />);
+
+    expect(screen.getByText("Loading apps...")).toBeInTheDocument();
+    expect(screen.queryByText("Billing Alerts")).not.toBeInTheDocument();
+  });
+
+  it("shows an error when the current canvas fails to load", () => {
+    mockUseCanvas.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Canvas unavailable"),
+    } as ReturnType<typeof useCanvas>);
+
+    render(<ControlledRenderer />);
+
+    expect(screen.getByText("Failed to load apps: Canvas unavailable")).toBeInTheDocument();
     expect(screen.queryByText("Billing Alerts")).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.tsx
@@ -3,7 +3,8 @@ import { useParams } from "react-router-dom";
 import { AutoCompleteSelect, type AutoCompleteOption } from "@/components/AutoCompleteSelect";
 import { Select, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { ConfigurationField } from "@/api-client";
-import { useCanvases } from "@/hooks/useCanvasData";
+import { useCanvas, useCanvases } from "@/hooks/useCanvasData";
+import { useFactoryApps } from "@/hooks/useFactoryData";
 import { toTestId } from "@/lib/testID";
 
 interface AppFieldRendererProps {
@@ -14,43 +15,67 @@ interface AppFieldRendererProps {
   readOnly?: boolean;
 }
 
+type AppOptionSource = {
+  id?: string;
+  name?: string;
+};
+
+function buildAppOptions(
+  apps: AppOptionSource[] | undefined,
+  allowSelf: boolean,
+  currentAppId: string | undefined,
+): AutoCompleteOption[] {
+  if (!apps?.length) {
+    return [];
+  }
+
+  return apps
+    .filter((app) => {
+      if (!app.id || !app.name) {
+        return false;
+      }
+
+      if (!allowSelf && app.id === currentAppId) {
+        return false;
+      }
+
+      return true;
+    })
+    .map((app) => ({
+      value: app.id!,
+      label: app.name!,
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label));
+}
+
 export function AppFieldRenderer({ field, value, onChange, organizationId, readOnly = false }: AppFieldRendererProps) {
   const { appId: currentAppId } = useParams<{ appId?: string }>();
-  const { data: canvases, isLoading, error } = useCanvases(organizationId);
+  const { data: currentCanvas } = useCanvas(organizationId, currentAppId ?? "", {
+    enabled: Boolean(currentAppId),
+    staleTime: Infinity,
+  });
+  const factoryId = currentCanvas?.metadata?.factoryId;
   const allowSelf = field.typeOptions?.app?.allowSelf ?? false;
 
-  const options: AutoCompleteOption[] = useMemo(() => {
-    if (!canvases?.length) {
-      return [];
-    }
+  const orgCanvasesQuery = useCanvases(organizationId);
+  const factoryAppsQuery = useFactoryApps(organizationId, factoryId ?? "");
 
-    return canvases
-      .filter((canvas) => {
-        if (!canvas.id || !canvas.name) {
-          return false;
-        }
+  const isFactoryContext = Boolean(factoryId);
+  const { data: apps, isLoading, error } = isFactoryContext ? factoryAppsQuery : orgCanvasesQuery;
 
-        if (!allowSelf && canvas.id === currentAppId) {
-          return false;
-        }
-
-        return true;
-      })
-      .map((canvas) => ({
-        value: canvas.id!,
-        label: canvas.name!,
-      }))
-      .sort((left, right) => left.label.localeCompare(right.label));
-  }, [allowSelf, canvases, currentAppId]);
+  const options = useMemo(
+    () => buildAppOptions(apps, allowSelf, currentAppId),
+    [allowSelf, apps, currentAppId],
+  );
 
   const selectedValue = useMemo(() => {
     if (!value) {
       return "";
     }
 
-    const matchedCanvas = canvases?.find((canvas) => canvas.id === value || canvas.name === value);
-    return matchedCanvas?.id ?? value;
-  }, [canvases, value]);
+    const matchedApp = apps?.find((app) => app.id === value || app.name === value);
+    return matchedApp?.id ?? value;
+  }, [apps, value]);
 
   if (error) {
     return (
@@ -81,9 +106,13 @@ export function AppFieldRenderer({ field, value, onChange, organizationId, readO
           </SelectTrigger>
         </Select>
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          {allowSelf
-            ? "Select an app in this organization to invoke."
-            : "Create another app in this organization to subscribe to its events."}
+          {isFactoryContext
+            ? allowSelf
+              ? "Select another app in this factory to invoke."
+              : "Create another app in this factory to subscribe to its events."
+            : allowSelf
+              ? "Select an app in this organization to invoke."
+              : "Create another app in this organization to subscribe to its events."}
         </p>
       </div>
     );

--- a/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.tsx
@@ -20,6 +20,13 @@ type AppOptionSource = {
   name?: string;
 };
 
+type AppFieldSources = {
+  apps: AppOptionSource[] | undefined;
+  isLoading: boolean;
+  error: unknown;
+  isFactoryContext: boolean;
+};
+
 function buildAppOptions(
   apps: AppOptionSource[] | undefined,
   allowSelf: boolean,
@@ -48,74 +55,101 @@ function buildAppOptions(
     .sort((left, right) => left.label.localeCompare(right.label));
 }
 
-export function AppFieldRenderer({ field, value, onChange, organizationId, readOnly = false }: AppFieldRendererProps) {
-  const { appId: currentAppId } = useParams<{ appId?: string }>();
+function resolveSelectedAppValue(apps: AppOptionSource[] | undefined, value: string | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  const matchedApp = apps?.find((app) => app.id === value || app.name === value);
+  return matchedApp?.id ?? value;
+}
+
+function getEmptyStateMessage(isFactoryContext: boolean, allowSelf: boolean): string {
+  if (isFactoryContext) {
+    return allowSelf
+      ? "Select another app in this factory to invoke."
+      : "Create another app in this factory to subscribe to its events.";
+  }
+
+  return allowSelf
+    ? "Select an app in this organization to invoke."
+    : "Create another app in this organization to subscribe to its events.";
+}
+
+function useAppFieldSources(organizationId: string, currentAppId: string | undefined): AppFieldSources {
   const { data: currentCanvas } = useCanvas(organizationId, currentAppId ?? "", {
     enabled: Boolean(currentAppId),
     staleTime: Infinity,
   });
   const factoryId = currentCanvas?.metadata?.factoryId;
-  const allowSelf = field.typeOptions?.app?.allowSelf ?? false;
+  const isFactoryContext = Boolean(factoryId);
 
   const orgCanvasesQuery = useCanvases(organizationId);
   const factoryAppsQuery = useFactoryApps(organizationId, factoryId ?? "");
+  const activeQuery = isFactoryContext ? factoryAppsQuery : orgCanvasesQuery;
 
-  const isFactoryContext = Boolean(factoryId);
-  const { data: apps, isLoading, error } = isFactoryContext ? factoryAppsQuery : orgCanvasesQuery;
+  return {
+    apps: activeQuery.data,
+    isLoading: activeQuery.isLoading,
+    error: activeQuery.error,
+    isFactoryContext,
+  };
+}
 
-  const options = useMemo(
-    () => buildAppOptions(apps, allowSelf, currentAppId),
-    [allowSelf, apps, currentAppId],
+function AppFieldLoadError({ error }: { error: unknown }) {
+  const message = error instanceof Error ? error.message : "Unknown error";
+
+  return <div className="text-sm text-red-500 dark:text-red-400">Failed to load apps: {message}</div>;
+}
+
+function AppFieldLoading({ fieldName }: { fieldName: string | undefined }) {
+  return (
+    <div data-testid={toTestId(`app-field-${fieldName}`)}>
+      <Select value="" disabled>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Loading apps..." />
+        </SelectTrigger>
+      </Select>
+    </div>
+  );
+}
+
+function AppFieldEmpty({ fieldName, message }: { fieldName: string | undefined; message: string }) {
+  return (
+    <div data-testid={toTestId(`app-field-${fieldName}`)} className="space-y-2">
+      <Select value="" disabled>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="No apps available" />
+        </SelectTrigger>
+      </Select>
+      <p className="text-xs text-gray-500 dark:text-gray-400">{message}</p>
+    </div>
+  );
+}
+
+export function AppFieldRenderer({ field, value, onChange, organizationId, readOnly = false }: AppFieldRendererProps) {
+  const { appId: currentAppId } = useParams<{ appId?: string }>();
+  const allowSelf = field.typeOptions?.app?.allowSelf ?? false;
+  const { apps, isLoading, error, isFactoryContext } = useAppFieldSources(organizationId, currentAppId);
+
+  const options = useMemo(() => buildAppOptions(apps, allowSelf, currentAppId), [allowSelf, apps, currentAppId]);
+
+  const selectedValue = useMemo(() => resolveSelectedAppValue(apps, value), [apps, value]);
+  const emptyStateMessage = useMemo(
+    () => getEmptyStateMessage(isFactoryContext, allowSelf),
+    [allowSelf, isFactoryContext],
   );
 
-  const selectedValue = useMemo(() => {
-    if (!value) {
-      return "";
-    }
-
-    const matchedApp = apps?.find((app) => app.id === value || app.name === value);
-    return matchedApp?.id ?? value;
-  }, [apps, value]);
-
   if (error) {
-    return (
-      <div className="text-sm text-red-500 dark:text-red-400">
-        Failed to load apps: {error instanceof Error ? error.message : "Unknown error"}
-      </div>
-    );
+    return <AppFieldLoadError error={error} />;
   }
 
   if (isLoading) {
-    return (
-      <div data-testid={toTestId(`app-field-${field.name}`)}>
-        <Select value="" disabled>
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Loading apps..." />
-          </SelectTrigger>
-        </Select>
-      </div>
-    );
+    return <AppFieldLoading fieldName={field.name} />;
   }
 
   if (options.length === 0) {
-    return (
-      <div data-testid={toTestId(`app-field-${field.name}`)} className="space-y-2">
-        <Select value="" disabled>
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="No apps available" />
-          </SelectTrigger>
-        </Select>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
-          {isFactoryContext
-            ? allowSelf
-              ? "Select another app in this factory to invoke."
-              : "Create another app in this factory to subscribe to its events."
-            : allowSelf
-              ? "Select an app in this organization to invoke."
-              : "Create another app in this organization to subscribe to its events."}
-        </p>
-      </div>
-    );
+    return <AppFieldEmpty fieldName={field.name} message={emptyStateMessage} />;
   }
 
   return (

--- a/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AppFieldRenderer.tsx
@@ -77,15 +77,36 @@ function getEmptyStateMessage(isFactoryContext: boolean, allowSelf: boolean): st
 }
 
 function useAppFieldSources(organizationId: string, currentAppId: string | undefined): AppFieldSources {
-  const { data: currentCanvas } = useCanvas(organizationId, currentAppId ?? "", {
-    enabled: Boolean(currentAppId),
+  const needsCanvasContext = Boolean(currentAppId);
+  const canvasQuery = useCanvas(organizationId, currentAppId ?? "", {
+    enabled: needsCanvasContext,
     staleTime: Infinity,
   });
-  const factoryId = currentCanvas?.metadata?.factoryId;
+
+  const factoryId = canvasQuery.data?.metadata?.factoryId;
   const isFactoryContext = Boolean(factoryId);
 
   const orgCanvasesQuery = useCanvases(organizationId);
   const factoryAppsQuery = useFactoryApps(organizationId, factoryId ?? "");
+
+  if (needsCanvasContext && canvasQuery.isLoading) {
+    return {
+      apps: undefined,
+      isLoading: true,
+      error: null,
+      isFactoryContext: false,
+    };
+  }
+
+  if (needsCanvasContext && canvasQuery.error) {
+    return {
+      apps: undefined,
+      isLoading: false,
+      error: canvasQuery.error,
+      isFactoryContext: false,
+    };
+  }
+
   const activeQuery = isFactoryContext ? factoryAppsQuery : orgCanvasesQuery;
 
   return {


### PR DESCRIPTION
For factory-owned apps, the app-related components - runApp, onBroadcast - should only be able to reference other apps in the same factory. And for regular apps, only other regular apps can be used.

#### AppFieldRenderer

When configuring a component on a factory-owned canvas, load app options from useFactoryApps instead of useCanvases (which excludes factory apps). Detects factory context via the current canvas's metadata.factoryId.

#### AppContext

Before returning an app, validate it:
- Factory apps may only reference other apps in the same factory
- Org apps may only reference other org apps (not factory-owned apps)