### PR TITLE
chore: Add unit tests for retry package

### DIFF
--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -1,0 +1,111 @@
+package retry
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__WithConstantWait_SuccessOnFirstAttempt(t *testing.T) {
+	var calls atomic.Int32
+	err := WithConstantWait(func() error {
+		calls.Add(1)
+		return nil
+	}, Options{
+		Task:        "test",
+		MaxAttempts: 3,
+		Wait:        time.Millisecond,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func Test__WithConstantWait_SuccessAfterRetry(t *testing.T) {
+	var calls atomic.Int32
+	err := WithConstantWait(func() error {
+		calls.Add(1)
+		if calls.Load() < 3 {
+			return errors.New("not yet")
+		}
+		return nil
+	}, Options{
+		Task:        "test",
+		MaxAttempts: 5,
+		Wait:        time.Millisecond,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), calls.Load())
+}
+
+func Test__WithConstantWait_ExhaustsRetries(t *testing.T) {
+	const maxAttempts = 3
+	var calls atomic.Int32
+	err := WithConstantWait(func() error {
+		calls.Add(1)
+		return errors.New("always fails")
+	}, Options{
+		Task:        "test",
+		MaxAttempts: maxAttempts,
+		Wait:        time.Millisecond,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "test")
+	assert.Contains(t, err.Error(), "failed after")
+	assert.Contains(t, err.Error(), "always fails")
+	assert.Equal(t, int32(maxAttempts+1), calls.Load())
+}
+
+func Test__WithConstantWait_ZeroAttemptsDefaultsToSingleTry(t *testing.T) {
+	var calls atomic.Int32
+	err := WithConstantWait(func() error {
+		calls.Add(1)
+		return errors.New("fail")
+	}, Options{
+		Task: "test",
+		Wait: time.Millisecond,
+	})
+	require.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func Test__WithConstantWait_InitialDelay(t *testing.T) {
+	start := time.Now()
+	_ = WithConstantWait(func() error { return nil }, Options{
+		Task:         "test",
+		MaxAttempts:  1,
+		InitialDelay: 5 * time.Millisecond,
+	})
+	assert.GreaterOrEqual(t, time.Since(start), 5*time.Millisecond)
+}
+
+func Test__WithConstantWait_VerboseDoesNotPanic(t *testing.T) {
+	err := WithConstantWait(func() error {
+		return errors.New("fail")
+	}, Options{
+		Task:        "test",
+		MaxAttempts: 1,
+		Wait:        time.Millisecond,
+		Verbose:     true,
+	})
+	require.Error(t, err)
+}
+
+func Test__WithConstantWait_ReturnsNilWhenNoError(t *testing.T) {
+	err := WithConstantWait(func() error { return nil }, Options{
+		Task:        "noop",
+		MaxAttempts: 0,
+	})
+	assert.NoError(t, err)
+}
+
+func Test__WithConstantWait_ZeroInitialDelayNoSleep(t *testing.T) {
+	start := time.Now()
+	_ = WithConstantWait(func() error { return nil }, Options{
+		Task: "fast",
+	})
+	assert.WithinDuration(t, start, time.Now(), time.Millisecond)
+}


### PR DESCRIPTION
### **What changed**
Added pkg/retry/retry_test.go with unit tests for the WithConstantWait function.

### **Why**
pkg/retry/ had zero test coverage despite being a core utility used across the codebase.

### **How**
8 table-driven-style test cases covering:

- **SuccessOnFirstAttempt**: Returns nil immediately when the function succeeds
- **SuccessAfterRetry**: Retries and succeeds on the 3rd attempt
- **ExhaustsRetries**: Returns error after MaxAttempts+1 total attempts with task name in the message
- **ZeroAttemptsDefaultsToSingleTry**: With MaxAttempts=0, still tries once before giving up
- **InitialDelay**: Sleeps for the configured InitialDelay before the first call
- **VerboseDoesNotPanic**: Verbose=true logs but doesn't crash
- **ReturnsNilWhenNoError**: Returns nil immediately with MaxAttempts=0 when f() succeeds
- **ZeroInitialDelayNoSleep**: Zero InitialDelay means no sleep before the first call

Style matches the existing convention: white-box package retry, testify/require + testify/assert, Test__ naming, atomic.Int32 for call counters.