### PR TITLE
feat: update factory name and description

### DIFF
--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -561,6 +561,12 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			DomainType:         models.DomainTypeOrganization,
 			ResourcePathParams: []string{CanvasIDPathParam},
 		},
+		{Method: "PUT", Pattern: "/api/v1/factories/{id}"}: {
+			Resource:                     "factories",
+			Action:                       "update",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureFactories},
+		},
 		{Method: "PUT", Pattern: "/api/v1/canvases/{id}"}: {
 			Resource:           "canvases",
 			Action:             "update",

--- a/pkg/grpc/actions/factories/errors.go
+++ b/pkg/grpc/actions/factories/errors.go
@@ -12,6 +12,8 @@ func factoryErrorToStatus(err error, internalMessage string) error {
 	switch {
 	case errors.Is(err, models.ErrFactoryNameAlreadyExists):
 		return grpcerrors.AlreadyExists(err, "factory with the same name already exists")
+	case errors.Is(err, models.ErrFactoryNameRequired):
+		return grpcerrors.InvalidArgument(err, "factory name is required")
 	case errors.Is(err, models.ErrFactoryNotFound):
 		return grpcerrors.NotFound(err, "factory not found")
 	case errors.Is(err, models.ErrFactoryWorkOrderNotFound):

--- a/pkg/grpc/actions/factories/update_factory.go
+++ b/pkg/grpc/actions/factories/update_factory.go
@@ -1,0 +1,40 @@
+package factories
+
+import (
+	"context"
+
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+)
+
+func UpdateFactory(ctx context.Context, organizationID string, req *pb.UpdateFactoryRequest) (*pb.UpdateFactoryResponse, error) {
+	orgID, err := parseOrganizationID(organizationID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory")
+	}
+
+	id, err := parseFactoryID(req.GetId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory")
+	}
+
+	db := database.DB(ctx)
+	factory, err := models.FindFactory(db, orgID, id)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory")
+	}
+
+	if err := factory.Update(db, req.Name, req.Description); err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory")
+	}
+
+	lines, err := factory.ListLines(db)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory")
+	}
+
+	return &pb.UpdateFactoryResponse{
+		Factory: serializeFactoryWithLines(factory, lines),
+	}, nil
+}

--- a/pkg/grpc/actions/factories/update_factory_test.go
+++ b/pkg/grpc/actions/factories/update_factory_test.go
@@ -1,0 +1,83 @@
+package factories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+)
+
+func Test__UpdateFactory(t *testing.T) {
+	r := support.Setup(t)
+
+	t.Run("empty name -> error", func(t *testing.T) {
+		factory, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "desc")
+		require.NoError(t, err)
+
+		emptyName := "   "
+		_, err = UpdateFactory(context.Background(), r.Organization.ID.String(), &pb.UpdateFactoryRequest{
+			Id:   factory.ID.String(),
+			Name: &emptyName,
+		})
+		code, _, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, code)
+	})
+
+	t.Run("updates factory metadata", func(t *testing.T) {
+		factory, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "old desc")
+		require.NoError(t, err)
+
+		newName := support.RandomName("updated-factory")
+		newDescription := "Factory description updated"
+
+		response, err := UpdateFactory(context.Background(), r.Organization.ID.String(), &pb.UpdateFactoryRequest{
+			Id:          factory.ID.String(),
+			Name:        &newName,
+			Description: &newDescription,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, response.Factory)
+		assert.Equal(t, factory.ID.String(), response.Factory.Id)
+		assert.Equal(t, newName, response.Factory.Name)
+		assert.Equal(t, newDescription, response.Factory.Description)
+
+		updated, err := models.FindFactory(database.DB(t.Context()), r.Organization.ID, factory.ID)
+		require.NoError(t, err)
+		assert.Equal(t, newName, updated.Name)
+		assert.Equal(t, newDescription, updated.Description)
+	})
+
+	t.Run("duplicate name -> error", func(t *testing.T) {
+		existing, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "")
+		require.NoError(t, err)
+		target, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "")
+		require.NoError(t, err)
+
+		_, err = UpdateFactory(context.Background(), r.Organization.ID.String(), &pb.UpdateFactoryRequest{
+			Id:   target.ID.String(),
+			Name: &existing.Name,
+		})
+		code, _, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, code)
+	})
+
+	t.Run("not found -> error", func(t *testing.T) {
+		name := support.RandomName("missing")
+		_, err := UpdateFactory(context.Background(), r.Organization.ID.String(), &pb.UpdateFactoryRequest{
+			Id:   "00000000-0000-0000-0000-000000000001",
+			Name: &name,
+		})
+		code, _, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.NotFound, code)
+	})
+}

--- a/pkg/grpc/factory_service.go
+++ b/pkg/grpc/factory_service.go
@@ -31,6 +31,11 @@ func (s *FactoryService) DescribeFactory(ctx context.Context, req *pb.DescribeFa
 	return actions.DescribeFactory(ctx, organizationID, req.GetId())
 }
 
+func (s *FactoryService) UpdateFactory(ctx context.Context, req *pb.UpdateFactoryRequest) (*pb.UpdateFactoryResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return actions.UpdateFactory(ctx, organizationID, req)
+}
+
 func (s *FactoryService) CreateFactoryLine(ctx context.Context, req *pb.CreateFactoryLineRequest) (*pb.CreateFactoryLineResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 	return actions.CreateFactoryLine(ctx, organizationID, req)

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -14,6 +14,7 @@ import (
 const factoryNameUniqueConstraint = "factories_organization_id_name_key"
 
 var ErrFactoryNameAlreadyExists = errors.New("factory name already exists")
+var ErrFactoryNameRequired = errors.New("factory name is required")
 var ErrFactoryNotFound = errors.New("factory not found")
 var ErrFactoryWorkOrderTitleRequired = errors.New("title is required")
 
@@ -86,6 +87,50 @@ func ListFactories(tx *gorm.DB, organizationID uuid.UUID) ([]Factory, error) {
 	}
 
 	return factories, nil
+}
+
+func (f *Factory) Update(tx *gorm.DB, name, description *string) error {
+	updates := map[string]any{}
+
+	if name != nil {
+		nextName := strings.TrimSpace(*name)
+		if nextName == "" {
+			return ErrFactoryNameRequired
+		}
+		if f.Name != nextName {
+			updates["name"] = nextName
+		}
+	}
+
+	if description != nil && f.Description != *description {
+		updates["description"] = *description
+	}
+
+	if len(updates) == 0 {
+		return nil
+	}
+
+	now := time.Now()
+	updates["updated_at"] = now
+
+	err := MapFactoryNameUniqueConstraintError(
+		tx.Model(f).
+			Where("organization_id = ? AND id = ?", f.OrganizationID, f.ID).
+			Updates(updates).
+			Error,
+	)
+	if err != nil {
+		return err
+	}
+
+	if nextName, ok := updates["name"].(string); ok {
+		f.Name = nextName
+	}
+	if nextDescription, ok := updates["description"].(string); ok {
+		f.Description = nextDescription
+	}
+	f.UpdatedAt = now
+	return nil
 }
 
 func (f *Factory) ListCanvases(tx *gorm.DB) ([]Canvas, error) {

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -60,6 +60,18 @@ service Factories {
     };
   }
 
+  rpc UpdateFactory(UpdateFactoryRequest) returns (UpdateFactoryResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/factories/{id}"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Update factory";
+      description: "Updates factory metadata";
+      tags: "Factory";
+    };
+  }
+
   //
   // Factory line APIs
   //
@@ -213,6 +225,16 @@ message DescribeFactoryRequest {
 }
 
 message DescribeFactoryResponse {
+  Factory factory = 1;
+}
+
+message UpdateFactoryRequest {
+  string id = 1;
+  optional string name = 2;
+  optional string description = 3;
+}
+
+message UpdateFactoryResponse {
   Factory factory = 1;
 }
 

--- a/test/e2e/factories_test.go
+++ b/test/e2e/factories_test.go
@@ -1,0 +1,96 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/features"
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestFactories(t *testing.T) {
+	t.Run("updating factory name and description", func(t *testing.T) {
+		steps := &factorySteps{t: t}
+		originalName := support.RandomName("factory")
+		updatedName := support.RandomName("factory-updated")
+
+		steps.start()
+		factory := steps.givenFactoryExists(originalName, "original description")
+		steps.visitFactory(factory.ID)
+		steps.openFactoryActionsMenu()
+		steps.clickEditFactory()
+		steps.fillEditFactoryName(updatedName)
+		steps.fillEditFactoryDescription("updated description")
+		steps.submitEditFactory()
+		steps.assertFactoryVisibleOnDetail(updatedName)
+		steps.assertFactorySavedInDB(factory.ID, updatedName, "updated description")
+	})
+}
+
+type factorySteps struct {
+	t       *testing.T
+	session *session.TestSession
+}
+
+func (s *factorySteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+	require.NoError(s.t, models.EnableExperimentalFeature(s.session.OrgID, features.FeatureFactories))
+}
+
+func (s *factorySteps) givenFactoryExists(name, description string) *models.Factory {
+	factory, err := models.CreateFactory(database.DB(s.t.Context()), s.session.OrgID, name, description)
+	require.NoError(s.t, err)
+	return factory
+}
+
+func (s *factorySteps) visitFactory(factoryID uuid.UUID) {
+	s.session.Visit("/" + s.session.OrgID.String() + "/factories/" + factoryID.String())
+	s.session.Sleep(500)
+}
+
+func (s *factorySteps) openFactoryActionsMenu() {
+	s.session.Click(q.TestID("factory-actions-menu"))
+	s.session.Sleep(300)
+}
+
+func (s *factorySteps) clickEditFactory() {
+	s.session.Click(q.TestID("factory-edit-action"))
+	s.session.Sleep(300)
+}
+
+func (s *factorySteps) fillEditFactoryName(name string) {
+	page := s.session.Page()
+	err := page.GetByTestId("edit-factory-name-input").Fill(name)
+	require.NoError(s.t, err)
+	s.session.Sleep(200)
+}
+
+func (s *factorySteps) fillEditFactoryDescription(description string) {
+	page := s.session.Page()
+	err := page.GetByTestId("edit-factory-description-input").Fill(description)
+	require.NoError(s.t, err)
+	s.session.Sleep(200)
+}
+
+func (s *factorySteps) submitEditFactory() {
+	s.session.Click(q.TestID("factory-edit-save-button"))
+	s.session.Sleep(1000)
+}
+
+func (s *factorySteps) assertFactoryVisibleOnDetail(name string) {
+	s.session.AssertText(name)
+}
+
+func (s *factorySteps) assertFactorySavedInDB(factoryID uuid.UUID, name, description string) {
+	factory, err := models.FindFactory(database.DB(s.t.Context()), s.session.OrgID, factoryID)
+	require.NoError(s.t, err)
+	require.Equal(s.t, name, factory.Name)
+	require.Equal(s.t, description, factory.Description)
+}

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -10,6 +10,7 @@ import {
   factoriesListFactoryApps,
   factoriesListWorkOrderEvents,
   factoriesListWorkOrders,
+  factoriesUpdateFactory,
   factoriesUpdateFactoryLine,
   factoriesUpdateWorkOrderAssignees,
 } from "@/api-client";
@@ -172,6 +173,34 @@ export function useCreateFactory(organizationId: string) {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: factoryListKey(organizationId) });
+    },
+  });
+}
+
+export function useUpdateFactory(organizationId: string, factoryId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: { name?: string; description?: string }) => {
+      const response = await factoriesUpdateFactory(
+        withOrganizationHeader({
+          organizationId,
+          path: { id: factoryId },
+          body: {
+            name: input.name,
+            description: input.description,
+          },
+        }),
+      );
+      if (!response.data?.factory) {
+        throw new Error("Failed to update factory");
+      }
+      return response.data.factory;
+    },
+    onSuccess: (factory) => {
+      queryClient.setQueryData(factoryDetailKey(organizationId, factoryId), factory);
+      void queryClient.invalidateQueries({ queryKey: factoryListKey(organizationId) });
+      void queryClient.invalidateQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
     },
   });
 }

--- a/web_src/src/pages/factories/EditFactoryDialog.tsx
+++ b/web_src/src/pages/factories/EditFactoryDialog.tsx
@@ -1,0 +1,140 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { Textarea } from "@/components/ui/textarea";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast } from "@/lib/toast";
+import { useEffect, useState } from "react";
+
+const MAX_NAME_LENGTH = 128;
+const MAX_DESCRIPTION_LENGTH = 500;
+
+interface EditFactoryDialogProps {
+  open: boolean;
+  initialName: string;
+  initialDescription?: string;
+  isSaving: boolean;
+  onClose: () => void;
+  onSave: (input: { name: string; description: string }) => Promise<void>;
+}
+
+export function EditFactoryDialog({
+  open,
+  initialName,
+  initialDescription = "",
+  isSaving,
+  onClose,
+  onSave,
+}: EditFactoryDialogProps) {
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState(initialDescription);
+  const [nameError, setNameError] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setName(initialName);
+      setDescription(initialDescription);
+      setNameError("");
+    }
+  }, [open, initialDescription, initialName]);
+
+  const handleClose = () => {
+    if (isSaving) {
+      return;
+    }
+    onClose();
+  };
+
+  const handleSave = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError("Name is required");
+      return;
+    }
+
+    try {
+      await onSave({
+        name: trimmedName,
+        description: description.trim(),
+      });
+    } catch (error) {
+      const message = getApiErrorMessage(error, "Failed to update factory");
+      showErrorToast(message);
+      if (message.toLowerCase().includes("already") || message.toLowerCase().includes("exists")) {
+        setNameError("A factory with this name already exists");
+      }
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          handleClose();
+        }
+      }}
+    >
+      <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit factory</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="edit-factory-name-input">Name</Label>
+            <Input
+              id="edit-factory-name-input"
+              data-testid="edit-factory-name-input"
+              value={name}
+              onChange={(event) => {
+                if (event.target.value.length <= MAX_NAME_LENGTH) {
+                  setName(event.target.value);
+                }
+                if (nameError) {
+                  setNameError("");
+                }
+              }}
+              maxLength={MAX_NAME_LENGTH}
+              autoFocus
+            />
+            {nameError ? <p className="text-xs text-red-600">{nameError}</p> : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-factory-description-input">Description</Label>
+            <Textarea
+              id="edit-factory-description-input"
+              data-testid="edit-factory-description-input"
+              value={description}
+              onChange={(event) => {
+                if (event.target.value.length <= MAX_DESCRIPTION_LENGTH) {
+                  setDescription(event.target.value);
+                }
+              }}
+              maxLength={MAX_DESCRIPTION_LENGTH}
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="flex-row justify-start gap-3 sm:justify-start">
+          <LoadingButton
+            onClick={() => void handleSave()}
+            disabled={!name.trim()}
+            loading={isSaving}
+            loadingText="Saving..."
+            data-testid="factory-edit-save-button"
+          >
+            Save
+          </LoadingButton>
+          <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/factories/FactoryDetailHeader.stories.tsx
+++ b/web_src/src/pages/factories/FactoryDetailHeader.stories.tsx
@@ -5,9 +5,9 @@ import { FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_ID, REFUND_FACTORY } from ".
 import { FactoryDetailHeader } from "./FactoryDetailHeader";
 
 /**
- * Factory detail header: factory name, description, and the "New Work Order"
- * CTA (gated by permissions). Doesn't include filters — those live in the
- * work orders panel.
+ * Factory detail header: factory name, description, edit action,
+ * and the "New Work Order" CTA (gated by permissions). Doesn't include filters —
+ * those live in the work orders panel.
  */
 const meta = {
   title: "Factories/FactoryDetailHeader",
@@ -28,25 +28,29 @@ type Story = StoryObj<typeof meta>;
 
 const createHref = `/${FACTORIES_ORGANIZATION_ID}/factories/${PRIMARY_FACTORY_ID}/orders/new`;
 
-/** Populated header with a CTA. */
-export const Default: Story = {
-  args: {
-    factory: REFUND_FACTORY,
-    workOrdersCount: 3,
-    canCreate: true,
-    permissionsLoading: false,
-    createHref,
-  },
+const baseArgs = {
+  factory: REFUND_FACTORY,
+  workOrdersCount: 3,
+  canCreate: true,
+  canUpdate: true,
+  permissionsLoading: false,
+  createHref,
+  isUpdating: false,
+  onUpdate: async () => undefined,
 };
 
-/** Read-only viewer — CTA disabled with a tooltip. */
-export const WithoutCreatePermission: Story = {
-  name: "Without Create Permission",
+/** Populated header with a CTA and edit action. */
+export const Default: Story = {
+  args: baseArgs,
+};
+
+/** Read-only viewer — CTA and actions disabled with tooltips. */
+export const WithoutManagePermission: Story = {
+  name: "Without Manage Permission",
   args: {
-    factory: REFUND_FACTORY,
+    ...baseArgs,
     workOrdersCount: 0,
     canCreate: false,
-    permissionsLoading: false,
-    createHref,
+    canUpdate: false,
   },
 };

--- a/web_src/src/pages/factories/FactoryDetailHeader.tsx
+++ b/web_src/src/pages/factories/FactoryDetailHeader.tsx
@@ -5,50 +5,125 @@ import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
+import { MoreVertical, Pencil } from "lucide-react";
+import { useState, type MouseEvent } from "react";
+import { EditFactoryDialog } from "./EditFactoryDialog";
 
 interface FactoryDetailHeaderProps {
   factory: FactoriesFactory;
   workOrdersCount: number;
   canCreate: boolean;
+  canUpdate: boolean;
   permissionsLoading: boolean;
   createHref: string;
+  isUpdating: boolean;
+  onUpdate: (input: { name: string; description: string }) => Promise<void>;
 }
 
 export function FactoryDetailHeader({
   factory,
   workOrdersCount: _workOrdersCount,
   canCreate,
+  canUpdate,
   permissionsLoading,
   createHref,
+  isUpdating,
+  onUpdate,
 }: FactoryDetailHeaderProps) {
+  const [editOpen, setEditOpen] = useState(false);
+
   return (
-    <div className="flex flex-wrap items-start justify-between gap-4">
-      <div className="min-w-0 flex-1">
-        <h1 className="text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">{factory.name}</h1>
-        {factory.description?.trim() ? (
-          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-gray-500 dark:text-gray-400">
-            {factory.description.trim()}
-          </p>
-        ) : null}
+    <>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start gap-2">
+            <h1 className="min-w-0 text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+              {factory.name}
+            </h1>
+            {!canUpdate ? (
+              <PermissionTooltip
+                allowed={permissionsLoading}
+                message="You don't have permission to update this factory."
+              >
+                <button
+                  type="button"
+                  className="mt-1 rounded p-1 text-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400"
+                  aria-label="Factory actions"
+                  disabled
+                  data-testid="factory-actions-menu"
+                >
+                  <MoreVertical size={16} />
+                </button>
+              </PermissionTooltip>
+            ) : (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="mt-1 rounded p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+                    aria-label="Factory actions"
+                    data-testid="factory-actions-menu"
+                  >
+                    <MoreVertical size={16} />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  <PermissionTooltip allowed={canUpdate} message="You don't have permission to update factories.">
+                    <DropdownMenuItem
+                      onClick={(event: MouseEvent<HTMLElement>) => {
+                        event.preventDefault();
+                        if (!canUpdate) return;
+                        setEditOpen(true);
+                      }}
+                      disabled={!canUpdate}
+                      data-testid="factory-edit-action"
+                    >
+                      <Pencil size={16} />
+                      Edit
+                    </DropdownMenuItem>
+                  </PermissionTooltip>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+          {factory.description?.trim() ? (
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-gray-500 dark:text-gray-400">
+              {factory.description.trim()}
+            </p>
+          ) : null}
+        </div>
+
+        <PermissionTooltip
+          allowed={canCreate || permissionsLoading}
+          message="You don't have permission to create work orders."
+        >
+          <Button
+            type="button"
+            asChild
+            disabled={!canCreate}
+            className={cn(appDarkModeClasses.primaryAction)}
+            data-testid="work-order-list-create-button"
+          >
+            <Link href={createHref}>
+              <Icon name="plus" />
+              New Work Order
+            </Link>
+          </Button>
+        </PermissionTooltip>
       </div>
 
-      <PermissionTooltip
-        allowed={canCreate || permissionsLoading}
-        message="You don't have permission to create work orders."
-      >
-        <Button
-          type="button"
-          asChild
-          disabled={!canCreate}
-          className={cn(appDarkModeClasses.primaryAction)}
-          data-testid="work-order-list-create-button"
-        >
-          <Link href={createHref}>
-            <Icon name="plus" />
-            New Work Order
-          </Link>
-        </Button>
-      </PermissionTooltip>
-    </div>
+      <EditFactoryDialog
+        open={editOpen}
+        initialName={factory.name ?? ""}
+        initialDescription={factory.description ?? ""}
+        isSaving={isUpdating}
+        onClose={() => setEditOpen(false)}
+        onSave={async (input) => {
+          await onUpdate(input);
+          setEditOpen(false);
+        }}
+      />
+    </>
   );
 }

--- a/web_src/src/pages/factories/FactoryDetailPage.tsx
+++ b/web_src/src/pages/factories/FactoryDetailPage.tsx
@@ -45,8 +45,11 @@ function FactoryDetailPageContent({ organizationId, factoryId }: { organizationI
             factory={page.factory}
             workOrdersCount={page.openWorkOrderCount}
             canCreate={page.canCreateWork}
+            canUpdate={page.canUpdateFactory}
             permissionsLoading={page.permissionsLoading}
             createHref={page.createWorkOrderHref}
+            isUpdating={page.isUpdatingFactory}
+            onUpdate={page.handleUpdateFactory}
           />
 
           <div className={cn(factoryDetailPanelClassName, "mt-8 grid w-full lg:grid-cols-[minmax(0,1fr)_320px]")}>

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -79,8 +79,21 @@ function factoryDetailRoutes(fixture: FactoriesFixture): FactoriesRoute[] {
   return [
     {
       pattern: re("/api/v1/factories/([^/]+)"),
-      resolve: (match) => {
+      resolve: (match, method, body) => {
         const factory = fixture.factories.find((entry) => entry.id === match[1]);
+
+        if (method === "PUT") {
+          if (!factory) return { json: {} };
+          const request = (body ?? {}) as RequestBody;
+          if (typeof request.name === "string" && request.name.trim()) {
+            factory.name = request.name.trim();
+          }
+          if (typeof request.description === "string") {
+            factory.description = request.description;
+          }
+          return { json: { factory } };
+        }
+
         return factory ? { json: { factory } } : { json: {} };
       },
     },

--- a/web_src/src/pages/factories/useFactoryDetailActions.tsx
+++ b/web_src/src/pages/factories/useFactoryDetailActions.tsx
@@ -1,5 +1,5 @@
 import { useCreateCanvas } from "@/hooks/useCanvasData";
-import { factoryAppsKey, useDispatchWorkOrder } from "@/hooks/useFactoryData";
+import { factoryAppsKey, useDispatchWorkOrder, useUpdateFactory } from "@/hooks/useFactoryData";
 import { appPath } from "@/lib/appPaths";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
@@ -15,6 +15,7 @@ export function useFactoryDetailActions(
   const queryClient = useQueryClient();
   const dispatchWorkOrder = useDispatchWorkOrder(organizationId, factoryId);
   const createCanvas = useCreateCanvas(organizationId);
+  const updateFactory = useUpdateFactory(organizationId, factoryId);
 
   const handleCreateApp = async (input: { name: string; description: string }) => {
     try {
@@ -42,10 +43,17 @@ export function useFactoryDetailActions(
     showSuccessToast(`Dispatched to ${lineName}.`);
   };
 
+  const handleUpdateFactory = async (input: { name: string; description: string }) => {
+    await updateFactory.mutateAsync(input);
+    showSuccessToast("Factory updated");
+  };
+
   return {
     handleCreateApp,
     handleDispatch,
+    handleUpdateFactory,
     isCreateAppSaving: createCanvas.isPending,
     isDispatching: dispatchWorkOrder.isPending,
+    isUpdatingFactory: updateFactory.isPending,
   };
 }


### PR DESCRIPTION
## Summary
- Add `UpdateFactory` API (`PUT /api/v1/factories/{id}`) for name and description
- Wire model update, auth, gRPC action, and factory detail edit UI

## Test plan
- [ ] Update factory name/description from detail page
- [ ] Empty name rejected; duplicate name returns already exists
- [ ] `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories`


Made with [Cursor](https://cursor.com)