### PR TITLE
feat: soft-delete factories

### DIFF
--- a/db/migrations/20260804234957_add-deleted-at-to-factories.up.sql
+++ b/db/migrations/20260804234957_add-deleted-at-to-factories.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE factories ADD COLUMN deleted_at TIMESTAMPTZ;
+CREATE INDEX idx_factories_deleted_at ON factories (deleted_at);
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -349,7 +349,8 @@ CREATE TABLE public.factories (
     name text NOT NULL,
     description text DEFAULT ''::text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    deleted_at timestamp with time zone
 );
 
 
@@ -1566,6 +1567,13 @@ CREATE INDEX idx_casbin_rule_v2 ON public.casbin_rule USING btree (v2);
 
 
 --
+-- Name: idx_factories_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_factories_deleted_at ON public.factories USING btree (deleted_at);
+
+
+--
 -- Name: idx_factories_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2586,7 +2594,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260804134504	f
+20260804234957	f
 \.
 
 

--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -37,6 +37,12 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			DomainType:         models.DomainTypeOrganization,
 			ResourcePathParams: []string{IDPathParam},
 		},
+		{Method: "DELETE", Pattern: "/api/v1/factories/{id}"}: {
+			Resource:                     "factories",
+			Action:                       "delete",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureFactories},
+		},
 		{Method: "DELETE", Pattern: "/api/v1/groups/{group_name}"}: {
 			Resource:   "groups",
 			Action:     "delete",

--- a/pkg/grpc/actions/auth/describe_role_test.go
+++ b/pkg/grpc/actions/auth/describe_role_test.go
@@ -22,7 +22,7 @@ func Test_DescribeRole(t *testing.T) {
 		assert.NotNil(t, resp.Role.Spec.InheritedRole)
 		assert.Equal(t, models.RoleOrgAdmin, resp.Role.Metadata.Name)
 		assert.Equal(t, models.RoleOrgViewer, resp.Role.Spec.InheritedRole.Metadata.Name)
-		assert.Len(t, resp.Role.Spec.Permissions, 35)
+		assert.Len(t, resp.Role.Spec.Permissions, 36)
 		assert.Len(t, resp.Role.Spec.InheritedRole.Spec.Permissions, 8)
 		assert.Equal(t, "Admin", resp.Role.Spec.DisplayName)
 		assert.Equal(t, "Viewer", resp.Role.Spec.InheritedRole.Spec.DisplayName)

--- a/pkg/grpc/actions/factories/delete_factory.go
+++ b/pkg/grpc/actions/factories/delete_factory.go
@@ -1,0 +1,33 @@
+package factories
+
+import (
+	"context"
+
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+)
+
+func DeleteFactory(ctx context.Context, organizationID, factoryID string) (*pb.DeleteFactoryResponse, error) {
+	orgID, err := parseOrganizationID(organizationID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to delete factory")
+	}
+
+	id, err := parseFactoryID(factoryID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to delete factory")
+	}
+
+	db := database.DB(ctx)
+	factory, err := models.FindFactory(db, orgID, id)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to delete factory")
+	}
+
+	if err := factory.SoftDelete(db); err != nil {
+		return nil, factoryErrorToStatus(err, "failed to delete factory")
+	}
+
+	return &pb.DeleteFactoryResponse{}, nil
+}

--- a/pkg/grpc/actions/factories/delete_factory_test.go
+++ b/pkg/grpc/actions/factories/delete_factory_test.go
@@ -1,0 +1,85 @@
+package factories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+)
+
+func Test__DeleteFactory(t *testing.T) {
+	r := support.Setup(t)
+
+	t.Run("factory is soft deleted and hidden from list/describe", func(t *testing.T) {
+		originalName := support.RandomName("factory")
+		factory, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, originalName, "desc")
+		require.NoError(t, err)
+
+		_, err = DeleteFactory(context.Background(), r.Organization.ID.String(), factory.ID.String())
+		require.NoError(t, err)
+
+		_, err = models.FindFactory(database.DB(t.Context()), r.Organization.ID, factory.ID)
+		assert.ErrorIs(t, err, models.ErrFactoryNotFound)
+
+		_, err = DescribeFactory(context.Background(), r.Organization.ID.String(), factory.ID.String())
+		code, _, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.NotFound, code)
+
+		listed, err := ListFactories(context.Background(), r.Organization.ID.String())
+		require.NoError(t, err)
+		for _, item := range listed.Factories {
+			assert.NotEqual(t, factory.ID.String(), item.Id)
+		}
+
+		var deleted models.Factory
+		err = database.DB(t.Context()).Unscoped().
+			Where("organization_id = ? AND id = ?", r.Organization.ID, factory.ID).
+			First(&deleted).
+			Error
+		require.NoError(t, err)
+		assert.True(t, deleted.DeletedAt.Valid)
+		assert.Contains(t, deleted.Name, "(deleted-")
+		assert.NotEqual(t, originalName, deleted.Name)
+	})
+
+	t.Run("name can be reused after soft delete", func(t *testing.T) {
+		name := support.RandomName("reuse-factory")
+		factory, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, name, "")
+		require.NoError(t, err)
+
+		_, err = DeleteFactory(context.Background(), r.Organization.ID.String(), factory.ID.String())
+		require.NoError(t, err)
+
+		recreated, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, name, "new")
+		require.NoError(t, err)
+		assert.Equal(t, name, recreated.Name)
+		assert.NotEqual(t, factory.ID, recreated.ID)
+	})
+
+	t.Run("not found -> error", func(t *testing.T) {
+		_, err := DeleteFactory(context.Background(), r.Organization.ID.String(), "00000000-0000-0000-0000-000000000001")
+		code, _, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.NotFound, code)
+	})
+
+	t.Run("already deleted -> not found", func(t *testing.T) {
+		factory, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "")
+		require.NoError(t, err)
+
+		_, err = DeleteFactory(context.Background(), r.Organization.ID.String(), factory.ID.String())
+		require.NoError(t, err)
+
+		_, err = DeleteFactory(context.Background(), r.Organization.ID.String(), factory.ID.String())
+		code, _, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.NotFound, code)
+	})
+}

--- a/pkg/grpc/factory_service.go
+++ b/pkg/grpc/factory_service.go
@@ -36,6 +36,11 @@ func (s *FactoryService) UpdateFactory(ctx context.Context, req *pb.UpdateFactor
 	return actions.UpdateFactory(ctx, organizationID, req)
 }
 
+func (s *FactoryService) DeleteFactory(ctx context.Context, req *pb.DeleteFactoryRequest) (*pb.DeleteFactoryResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return actions.DeleteFactory(ctx, organizationID, req.GetId())
+}
+
 func (s *FactoryService) CreateFactoryLine(ctx context.Context, req *pb.CreateFactoryLineRequest) (*pb.CreateFactoryLineResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 	return actions.CreateFactoryLine(ctx, organizationID, req)

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -25,6 +26,7 @@ type Factory struct {
 	Description    string
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
+	DeletedAt      gorm.DeletedAt `gorm:"index"`
 }
 
 func MapFactoryNameUniqueConstraintError(err error) error {
@@ -87,6 +89,25 @@ func ListFactories(tx *gorm.DB, organizationID uuid.UUID) ([]Factory, error) {
 	}
 
 	return factories, nil
+}
+
+func (f *Factory) SoftDelete(tx *gorm.DB) error {
+	now := time.Now()
+	newName := fmt.Sprintf("%s (deleted-%d)", f.Name, now.Unix())
+
+	err := tx.Model(f).Updates(map[string]any{
+		"name":       newName,
+		"deleted_at": now,
+		"updated_at": now,
+	}).Error
+	if err != nil {
+		return err
+	}
+
+	f.Name = newName
+	f.DeletedAt = gorm.DeletedAt{Time: now, Valid: true}
+	f.UpdatedAt = now
+	return nil
 }
 
 func (f *Factory) Update(tx *gorm.DB, name, description *string) error {

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -72,6 +72,17 @@ service Factories {
     };
   }
 
+  rpc DeleteFactory(DeleteFactoryRequest) returns (DeleteFactoryResponse) {
+    option (google.api.http) = {
+      delete: "/api/v1/factories/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Delete factory";
+      description: "Soft-deletes an existing factory";
+      tags: "Factory";
+    };
+  }
+
   //
   // Factory line APIs
   //
@@ -237,6 +248,12 @@ message UpdateFactoryRequest {
 message UpdateFactoryResponse {
   Factory factory = 1;
 }
+
+message DeleteFactoryRequest {
+  string id = 1;
+}
+
+message DeleteFactoryResponse {}
 
 message Factory {
   message App {

--- a/rbac/rbac_org_policy.csv
+++ b/rbac/rbac_org_policy.csv
@@ -13,6 +13,7 @@ p,/roles/org_admin,/org/*,canvases,update
 p,/roles/org_admin,/org/*,canvases,delete
 p,/roles/org_admin,/org/*,factories,create
 p,/roles/org_admin,/org/*,factories,update
+p,/roles/org_admin,/org/*,factories,delete
 p,/roles/org_admin,/org/*,members,create
 p,/roles/org_admin,/org/*,members,update
 p,/roles/org_admin,/org/*,members,delete

--- a/test/e2e/factories_test.go
+++ b/test/e2e/factories_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	pw "github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/features"
@@ -30,6 +31,26 @@ func TestFactories(t *testing.T) {
 		steps.assertFactoryVisibleOnDetail(updatedName)
 		steps.assertFactorySavedInDB(factory.ID, updatedName, "updated description")
 	})
+
+	t.Run("soft-deleting a factory", func(t *testing.T) {
+		steps := &factorySteps{t: t}
+		name := support.RandomName("factory")
+
+		steps.start()
+		factory := steps.givenFactoryExists(name, "will be deleted")
+		steps.visitFactory(factory.ID)
+		steps.openFactoryActionsMenu()
+		steps.clickDeleteFactory()
+		steps.confirmDeleteFactory()
+		steps.assertRedirectedToFactoriesList()
+		steps.assertFactoryNotVisibleInList(name)
+		steps.assertFactorySoftDeletedInDB(factory.ID, name)
+
+		recreated := steps.givenFactoryExists(name, "reused after delete")
+		require.NotEqual(t, factory.ID, recreated.ID)
+		steps.visitFactoriesList()
+		steps.assertFactoryVisibleInList(name)
+	})
 }
 
 type factorySteps struct {
@@ -48,6 +69,11 @@ func (s *factorySteps) givenFactoryExists(name, description string) *models.Fact
 	factory, err := models.CreateFactory(database.DB(s.t.Context()), s.session.OrgID, name, description)
 	require.NoError(s.t, err)
 	return factory
+}
+
+func (s *factorySteps) visitFactoriesList() {
+	s.session.Visit("/" + s.session.OrgID.String() + "/factories")
+	s.session.Sleep(500)
 }
 
 func (s *factorySteps) visitFactory(factoryID uuid.UUID) {
@@ -93,4 +119,46 @@ func (s *factorySteps) assertFactorySavedInDB(factoryID uuid.UUID, name, descrip
 	require.NoError(s.t, err)
 	require.Equal(s.t, name, factory.Name)
 	require.Equal(s.t, description, factory.Description)
+}
+
+func (s *factorySteps) clickDeleteFactory() {
+	s.session.Click(q.TestID("factory-delete-action"))
+	s.session.Sleep(300)
+}
+
+func (s *factorySteps) confirmDeleteFactory() {
+	s.session.AssertVisible(q.TestID("factory-delete-confirm-button"))
+	s.session.Click(q.TestID("factory-delete-confirm-button"))
+	s.session.Sleep(1000)
+}
+
+func (s *factorySteps) assertRedirectedToFactoriesList() {
+	s.session.WaitForBrowserPath("/" + s.session.OrgID.String() + "/factories")
+}
+
+func (s *factorySteps) assertFactoryVisibleInList(name string) {
+	s.session.AssertText(name)
+}
+
+func (s *factorySteps) assertFactoryNotVisibleInList(name string) {
+	page := s.session.Page()
+	locator := page.GetByText(name, pw.PageGetByTextOptions{Exact: pw.Bool(true)})
+	count, err := locator.Count()
+	require.NoError(s.t, err)
+	require.Zero(s.t, count, "factory %q should not be visible in list", name)
+}
+
+func (s *factorySteps) assertFactorySoftDeletedInDB(factoryID uuid.UUID, originalName string) {
+	_, err := models.FindFactory(database.DB(s.t.Context()), s.session.OrgID, factoryID)
+	require.ErrorIs(s.t, err, models.ErrFactoryNotFound)
+
+	var deleted models.Factory
+	err = database.DB(s.t.Context()).Unscoped().
+		Where("organization_id = ? AND id = ?", s.session.OrgID, factoryID).
+		First(&deleted).
+		Error
+	require.NoError(s.t, err)
+	require.True(s.t, deleted.DeletedAt.Valid)
+	require.Contains(s.t, deleted.Name, "(deleted-")
+	require.NotEqual(s.t, originalName, deleted.Name)
 }

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -211,7 +211,6 @@ export function useDeleteFactory(organizationId: string) {
 
   return useMutation({
     mutationFn: async (factoryId: string) => {
-      queryClient.removeQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
       await factoriesDeleteFactory(
         withOrganizationHeader({
           organizationId,

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -3,6 +3,7 @@ import {
   factoriesCreateFactory,
   factoriesCreateFactoryLine,
   factoriesCreateWorkOrder,
+  factoriesDeleteFactory,
   factoriesDescribeFactory,
   factoriesDescribeWorkOrder,
   factoriesDispatchWorkOrder,
@@ -201,6 +202,27 @@ export function useUpdateFactory(organizationId: string, factoryId: string) {
       queryClient.setQueryData(factoryDetailKey(organizationId, factoryId), factory);
       void queryClient.invalidateQueries({ queryKey: factoryListKey(organizationId) });
       void queryClient.invalidateQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
+    },
+  });
+}
+
+export function useDeleteFactory(organizationId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (factoryId: string) => {
+      queryClient.removeQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
+      await factoriesDeleteFactory(
+        withOrganizationHeader({
+          organizationId,
+          path: { id: factoryId },
+        }),
+      );
+      return factoryId;
+    },
+    onSuccess: (factoryId) => {
+      queryClient.removeQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
+      void queryClient.invalidateQueries({ queryKey: factoryListKey(organizationId) });
     },
   });
 }

--- a/web_src/src/pages/factories/FactoryActionsMenu.tsx
+++ b/web_src/src/pages/factories/FactoryActionsMenu.tsx
@@ -1,0 +1,79 @@
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
+import { MoreVertical, Pencil, Trash2 } from "lucide-react";
+
+interface FactoryActionsMenuProps {
+  permissions: {
+    canUpdate: boolean;
+    canDelete: boolean;
+    loading: boolean;
+  };
+  isDeleting: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function FactoryActionsMenu({ permissions, isDeleting, onEdit, onDelete }: FactoryActionsMenuProps) {
+  const { canUpdate, canDelete, loading } = permissions;
+  const canManage = canUpdate || canDelete;
+
+  if (!canManage) {
+    return (
+      <PermissionTooltip allowed={loading} message="You don't have permission to manage this factory.">
+        <button
+          type="button"
+          className="shrink-0 rounded p-1.5 text-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400"
+          aria-label="Factory actions"
+          disabled
+          data-testid="factory-actions-menu"
+        >
+          <MoreVertical size={24} />
+        </button>
+      </PermissionTooltip>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="shrink-0 rounded p-1.5 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+          aria-label="Factory actions"
+          disabled={isDeleting}
+          data-testid="factory-actions-menu"
+        >
+          <MoreVertical size={24} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <PermissionTooltip allowed={canUpdate} message="You don't have permission to update factories.">
+          <DropdownMenuItem
+            onClick={() => {
+              if (!canUpdate) return;
+              onEdit();
+            }}
+            disabled={!canUpdate}
+            data-testid="factory-edit-action"
+          >
+            <Pencil size={16} />
+            Edit
+          </DropdownMenuItem>
+        </PermissionTooltip>
+        <PermissionTooltip allowed={canDelete} message="You don't have permission to delete factories.">
+          <DropdownMenuItem
+            onClick={() => {
+              if (!canDelete) return;
+              onDelete();
+            }}
+            disabled={!canDelete}
+            data-testid="factory-delete-action"
+          >
+            <Trash2 size={16} />
+            Delete
+          </DropdownMenuItem>
+        </PermissionTooltip>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web_src/src/pages/factories/FactoryDeleteDialog.tsx
+++ b/web_src/src/pages/factories/FactoryDeleteDialog.tsx
@@ -1,0 +1,57 @@
+import { Dialog, DialogActions, DialogDescription, DialogTitle } from "@/components/Dialog/dialog";
+import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { Trash2 } from "lucide-react";
+
+interface FactoryDeleteDialogProps {
+  open: boolean;
+  factoryName: string;
+  canDelete: boolean;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}
+
+export function FactoryDeleteDialog({
+  open,
+  factoryName,
+  canDelete,
+  isDeleting,
+  onClose,
+  onConfirm,
+}: FactoryDeleteDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} size="lg" className="text-left">
+      <DialogTitle className="text-gray-800 dark:text-red-100">Delete "{factoryName}"?</DialogTitle>
+      <DialogDescription className="text-sm text-gray-800 dark:text-gray-400">
+        This cannot be undone. Are you sure you want to continue?
+      </DialogDescription>
+      <DialogActions>
+        <LoadingButton
+          variant="destructive"
+          onClick={() => {
+            void (async () => {
+              try {
+                await onConfirm();
+                onClose();
+              } catch {
+                // Toast handled by caller; keep dialog open for retry.
+              }
+            })();
+          }}
+          disabled={!canDelete}
+          loading={isDeleting}
+          loadingText="Deleting..."
+          className="flex items-center gap-2"
+          data-testid="factory-delete-confirm-button"
+        >
+          <Trash2 size={16} />
+          Delete
+        </LoadingButton>
+        <Button variant="outline" onClick={onClose} disabled={isDeleting}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/factories/FactoryDetailHeader.stories.tsx
+++ b/web_src/src/pages/factories/FactoryDetailHeader.stories.tsx
@@ -5,7 +5,7 @@ import { FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_ID, REFUND_FACTORY } from ".
 import { FactoryDetailHeader } from "./FactoryDetailHeader";
 
 /**
- * Factory detail header: factory name, description, edit action,
+ * Factory detail header: factory name, description, actions menu (edit/delete),
  * and the "New Work Order" CTA (gated by permissions). Doesn't include filters —
  * those live in the work orders panel.
  */
@@ -33,13 +33,16 @@ const baseArgs = {
   workOrdersCount: 3,
   canCreate: true,
   canUpdate: true,
+  canDelete: true,
   permissionsLoading: false,
   createHref,
   isUpdating: false,
+  isDeleting: false,
   onUpdate: async () => undefined,
+  onDelete: async () => undefined,
 };
 
-/** Populated header with a CTA and edit action. */
+/** Populated header with a CTA and manage actions. */
 export const Default: Story = {
   args: baseArgs,
 };
@@ -52,5 +55,6 @@ export const WithoutManagePermission: Story = {
     workOrdersCount: 0,
     canCreate: false,
     canUpdate: false,
+    canDelete: false,
   },
 };

--- a/web_src/src/pages/factories/FactoryDetailHeader.tsx
+++ b/web_src/src/pages/factories/FactoryDetailHeader.tsx
@@ -1,16 +1,14 @@
 import type { FactoriesFactory } from "@/api-client";
-import { Dialog, DialogActions, DialogDescription, DialogTitle } from "@/components/Dialog/dialog";
 import { Icon } from "@/components/Icon";
 import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
-import { LoadingButton } from "@/components/ui/loading-button";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { MoreVertical, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { EditFactoryDialog } from "./EditFactoryDialog";
+import { FactoryActionsMenu } from "./FactoryActionsMenu";
+import { FactoryDeleteDialog } from "./FactoryDeleteDialog";
 
 interface FactoryDetailHeaderProps {
   factory: FactoriesFactory;
@@ -41,7 +39,6 @@ export function FactoryDetailHeader({
 }: FactoryDetailHeaderProps) {
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const canManage = canUpdate || canDelete;
 
   return (
     <>
@@ -51,64 +48,12 @@ export function FactoryDetailHeader({
             <h1 className="min-w-0 text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
               {factory.name}
             </h1>
-            {!canManage ? (
-              <PermissionTooltip
-                allowed={permissionsLoading}
-                message="You don't have permission to manage this factory."
-              >
-                <button
-                  type="button"
-                  className="shrink-0 rounded p-1.5 text-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400"
-                  aria-label="Factory actions"
-                  disabled
-                  data-testid="factory-actions-menu"
-                >
-                  <MoreVertical size={24} />
-                </button>
-              </PermissionTooltip>
-            ) : (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    type="button"
-                    className="shrink-0 rounded p-1.5 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
-                    aria-label="Factory actions"
-                    disabled={isDeleting}
-                    data-testid="factory-actions-menu"
-                  >
-                    <MoreVertical size={24} />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start">
-                  <PermissionTooltip allowed={canUpdate} message="You don't have permission to update factories.">
-                    <DropdownMenuItem
-                      onClick={() => {
-                        if (!canUpdate) return;
-                        setEditOpen(true);
-                      }}
-                      disabled={!canUpdate}
-                      data-testid="factory-edit-action"
-                    >
-                      <Pencil size={16} />
-                      Edit
-                    </DropdownMenuItem>
-                  </PermissionTooltip>
-                  <PermissionTooltip allowed={canDelete} message="You don't have permission to delete factories.">
-                    <DropdownMenuItem
-                      onClick={() => {
-                        if (!canDelete) return;
-                        setDeleteOpen(true);
-                      }}
-                      disabled={!canDelete}
-                      data-testid="factory-delete-action"
-                    >
-                      <Trash2 size={16} />
-                      Delete
-                    </DropdownMenuItem>
-                  </PermissionTooltip>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+            <FactoryActionsMenu
+              permissions={{ canUpdate, canDelete, loading: permissionsLoading }}
+              isDeleting={isDeleting}
+              onEdit={() => setEditOpen(true)}
+              onDelete={() => setDeleteOpen(true)}
+            />
           </div>
           {factory.description?.trim() ? (
             <p className="mt-3 max-w-3xl text-sm leading-relaxed text-gray-500 dark:text-gray-400">
@@ -148,38 +93,14 @@ export function FactoryDetailHeader({
         }}
       />
 
-      <Dialog open={deleteOpen} onClose={() => setDeleteOpen(false)} size="lg" className="text-left">
-        <DialogTitle className="text-gray-800 dark:text-red-100">Delete "{factory.name}"?</DialogTitle>
-        <DialogDescription className="text-sm text-gray-800 dark:text-gray-400">
-          This cannot be undone. Are you sure you want to continue?
-        </DialogDescription>
-        <DialogActions>
-          <LoadingButton
-            variant="destructive"
-            onClick={() => {
-              void (async () => {
-                try {
-                  await onDelete();
-                  setDeleteOpen(false);
-                } catch {
-                  // Toast handled by caller; keep dialog open for retry.
-                }
-              })();
-            }}
-            disabled={!canDelete}
-            loading={isDeleting}
-            loadingText="Deleting..."
-            className="flex items-center gap-2"
-            data-testid="factory-delete-confirm-button"
-          >
-            <Trash2 size={16} />
-            Delete
-          </LoadingButton>
-          <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={isDeleting}>
-            Cancel
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <FactoryDeleteDialog
+        open={deleteOpen}
+        factoryName={factory.name ?? ""}
+        canDelete={canDelete}
+        isDeleting={isDeleting}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={onDelete}
+      />
     </>
   );
 }

--- a/web_src/src/pages/factories/FactoryDetailHeader.tsx
+++ b/web_src/src/pages/factories/FactoryDetailHeader.tsx
@@ -47,7 +47,7 @@ export function FactoryDetailHeader({
     <>
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
-          <div className="flex items-start gap-2">
+          <div className="flex items-center gap-2">
             <h1 className="min-w-0 text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
               {factory.name}
             </h1>
@@ -58,12 +58,12 @@ export function FactoryDetailHeader({
               >
                 <button
                   type="button"
-                  className="mt-1 rounded p-1 text-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400"
+                  className="shrink-0 rounded p-1.5 text-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400"
                   aria-label="Factory actions"
                   disabled
                   data-testid="factory-actions-menu"
                 >
-                  <MoreVertical size={16} />
+                  <MoreVertical size={24} />
                 </button>
               </PermissionTooltip>
             ) : (
@@ -71,12 +71,12 @@ export function FactoryDetailHeader({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="mt-1 rounded p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+                    className="shrink-0 rounded p-1.5 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
                     aria-label="Factory actions"
                     disabled={isDeleting}
                     data-testid="factory-actions-menu"
                   >
-                    <MoreVertical size={16} />
+                    <MoreVertical size={24} />
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start">

--- a/web_src/src/pages/factories/FactoryDetailHeader.tsx
+++ b/web_src/src/pages/factories/FactoryDetailHeader.tsx
@@ -9,7 +9,7 @@ import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { MoreVertical, Pencil, Trash2 } from "lucide-react";
-import { useState, type MouseEvent } from "react";
+import { useState } from "react";
 import { EditFactoryDialog } from "./EditFactoryDialog";
 
 interface FactoryDetailHeaderProps {
@@ -82,8 +82,7 @@ export function FactoryDetailHeader({
                 <DropdownMenuContent align="start">
                   <PermissionTooltip allowed={canUpdate} message="You don't have permission to update factories.">
                     <DropdownMenuItem
-                      onClick={(event: MouseEvent<HTMLElement>) => {
-                        event.preventDefault();
+                      onClick={() => {
                         if (!canUpdate) return;
                         setEditOpen(true);
                       }}
@@ -96,8 +95,7 @@ export function FactoryDetailHeader({
                   </PermissionTooltip>
                   <PermissionTooltip allowed={canDelete} message="You don't have permission to delete factories.">
                     <DropdownMenuItem
-                      onClick={(event: MouseEvent<HTMLElement>) => {
-                        event.preventDefault();
+                      onClick={() => {
                         if (!canDelete) return;
                         setDeleteOpen(true);
                       }}

--- a/web_src/src/pages/factories/FactoryDetailHeader.tsx
+++ b/web_src/src/pages/factories/FactoryDetailHeader.tsx
@@ -1,12 +1,14 @@
 import type { FactoriesFactory } from "@/api-client";
+import { Dialog, DialogActions, DialogDescription, DialogTitle } from "@/components/Dialog/dialog";
 import { Icon } from "@/components/Icon";
 import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { MoreVertical, Pencil } from "lucide-react";
+import { MoreVertical, Pencil, Trash2 } from "lucide-react";
 import { useState, type MouseEvent } from "react";
 import { EditFactoryDialog } from "./EditFactoryDialog";
 
@@ -15,10 +17,13 @@ interface FactoryDetailHeaderProps {
   workOrdersCount: number;
   canCreate: boolean;
   canUpdate: boolean;
+  canDelete: boolean;
   permissionsLoading: boolean;
   createHref: string;
   isUpdating: boolean;
+  isDeleting: boolean;
   onUpdate: (input: { name: string; description: string }) => Promise<void>;
+  onDelete: () => Promise<void>;
 }
 
 export function FactoryDetailHeader({
@@ -26,12 +31,17 @@ export function FactoryDetailHeader({
   workOrdersCount: _workOrdersCount,
   canCreate,
   canUpdate,
+  canDelete,
   permissionsLoading,
   createHref,
   isUpdating,
+  isDeleting,
   onUpdate,
+  onDelete,
 }: FactoryDetailHeaderProps) {
   const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const canManage = canUpdate || canDelete;
 
   return (
     <>
@@ -41,10 +51,10 @@ export function FactoryDetailHeader({
             <h1 className="min-w-0 text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
               {factory.name}
             </h1>
-            {!canUpdate ? (
+            {!canManage ? (
               <PermissionTooltip
                 allowed={permissionsLoading}
-                message="You don't have permission to update this factory."
+                message="You don't have permission to manage this factory."
               >
                 <button
                   type="button"
@@ -63,6 +73,7 @@ export function FactoryDetailHeader({
                     type="button"
                     className="mt-1 rounded p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
                     aria-label="Factory actions"
+                    disabled={isDeleting}
                     data-testid="factory-actions-menu"
                   >
                     <MoreVertical size={16} />
@@ -81,6 +92,20 @@ export function FactoryDetailHeader({
                     >
                       <Pencil size={16} />
                       Edit
+                    </DropdownMenuItem>
+                  </PermissionTooltip>
+                  <PermissionTooltip allowed={canDelete} message="You don't have permission to delete factories.">
+                    <DropdownMenuItem
+                      onClick={(event: MouseEvent<HTMLElement>) => {
+                        event.preventDefault();
+                        if (!canDelete) return;
+                        setDeleteOpen(true);
+                      }}
+                      disabled={!canDelete}
+                      data-testid="factory-delete-action"
+                    >
+                      <Trash2 size={16} />
+                      Delete
                     </DropdownMenuItem>
                   </PermissionTooltip>
                 </DropdownMenuContent>
@@ -124,6 +149,39 @@ export function FactoryDetailHeader({
           setEditOpen(false);
         }}
       />
+
+      <Dialog open={deleteOpen} onClose={() => setDeleteOpen(false)} size="lg" className="text-left">
+        <DialogTitle className="text-gray-800 dark:text-red-100">Delete "{factory.name}"?</DialogTitle>
+        <DialogDescription className="text-sm text-gray-800 dark:text-gray-400">
+          This cannot be undone. Are you sure you want to continue?
+        </DialogDescription>
+        <DialogActions>
+          <LoadingButton
+            variant="destructive"
+            onClick={() => {
+              void (async () => {
+                try {
+                  await onDelete();
+                  setDeleteOpen(false);
+                } catch {
+                  // Toast handled by caller; keep dialog open for retry.
+                }
+              })();
+            }}
+            disabled={!canDelete}
+            loading={isDeleting}
+            loadingText="Deleting..."
+            className="flex items-center gap-2"
+            data-testid="factory-delete-confirm-button"
+          >
+            <Trash2 size={16} />
+            Delete
+          </LoadingButton>
+          <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={isDeleting}>
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }

--- a/web_src/src/pages/factories/FactoryDetailPage.tsx
+++ b/web_src/src/pages/factories/FactoryDetailPage.tsx
@@ -46,10 +46,13 @@ function FactoryDetailPageContent({ organizationId, factoryId }: { organizationI
             workOrdersCount={page.openWorkOrderCount}
             canCreate={page.canCreateWork}
             canUpdate={page.canUpdateFactory}
+            canDelete={page.canDeleteFactory}
             permissionsLoading={page.permissionsLoading}
             createHref={page.createWorkOrderHref}
             isUpdating={page.isUpdatingFactory}
+            isDeleting={page.isDeletingFactory}
             onUpdate={page.handleUpdateFactory}
+            onDelete={page.handleDeleteFactory}
           />
 
           <div className={cn(factoryDetailPanelClassName, "mt-8 grid w-full lg:grid-cols-[minmax(0,1fr)_320px]")}>

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -80,7 +80,9 @@ function factoryDetailRoutes(fixture: FactoriesFixture): FactoriesRoute[] {
     {
       pattern: re("/api/v1/factories/([^/]+)"),
       resolve: (match, method, body) => {
-        const factory = fixture.factories.find((entry) => entry.id === match[1]);
+        const factoryId = match[1];
+        const factoryIndex = fixture.factories.findIndex((entry) => entry.id === factoryId);
+        const factory = factoryIndex >= 0 ? fixture.factories[factoryIndex] : undefined;
 
         if (method === "PUT") {
           if (!factory) return { json: {} };
@@ -92,6 +94,14 @@ function factoryDetailRoutes(fixture: FactoriesFixture): FactoriesRoute[] {
             factory.description = request.description;
           }
           return { json: { factory } };
+        }
+
+        if (method === "DELETE") {
+          if (factoryIndex < 0) return { json: {} };
+          fixture.factories.splice(factoryIndex, 1);
+          delete fixture.workOrdersByFactoryId[factoryId];
+          delete fixture.appsByFactoryId[factoryId];
+          return { json: {} };
         }
 
         return factory ? { json: { factory } } : { json: {} };

--- a/web_src/src/pages/factories/useFactoryDetailActions.tsx
+++ b/web_src/src/pages/factories/useFactoryDetailActions.tsx
@@ -1,5 +1,5 @@
 import { useCreateCanvas } from "@/hooks/useCanvasData";
-import { factoryAppsKey, useDispatchWorkOrder, useUpdateFactory } from "@/hooks/useFactoryData";
+import { factoryAppsKey, useDeleteFactory, useDispatchWorkOrder, useUpdateFactory } from "@/hooks/useFactoryData";
 import { appPath } from "@/lib/appPaths";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
@@ -16,6 +16,7 @@ export function useFactoryDetailActions(
   const dispatchWorkOrder = useDispatchWorkOrder(organizationId, factoryId);
   const createCanvas = useCreateCanvas(organizationId);
   const updateFactory = useUpdateFactory(organizationId, factoryId);
+  const deleteFactory = useDeleteFactory(organizationId);
 
   const handleCreateApp = async (input: { name: string; description: string }) => {
     try {
@@ -48,12 +49,25 @@ export function useFactoryDetailActions(
     showSuccessToast("Factory updated");
   };
 
+  const handleDeleteFactory = async () => {
+    try {
+      await deleteFactory.mutateAsync(factoryId);
+      showSuccessToast("Factory deleted");
+      navigate(`/${organizationId}/factories`);
+    } catch {
+      showErrorToast("Failed to delete factory");
+      throw new Error("Failed to delete factory");
+    }
+  };
+
   return {
     handleCreateApp,
     handleDispatch,
     handleUpdateFactory,
+    handleDeleteFactory,
     isCreateAppSaving: createCanvas.isPending,
     isDispatching: dispatchWorkOrder.isPending,
     isUpdatingFactory: updateFactory.isPending,
+    isDeletingFactory: deleteFactory.isPending,
   };
 }

--- a/web_src/src/pages/factories/useFactoryDetailPage.tsx
+++ b/web_src/src/pages/factories/useFactoryDetailPage.tsx
@@ -87,6 +87,7 @@ export function useFactoryDetailPage(organizationId: string, factoryId: string) 
     isAppsLoading,
     canCreateWork: canAct("factories", "create"),
     canUpdateFactory: canAct("factories", "update"),
+    canDeleteFactory: canAct("factories", "delete"),
     canCreateApps: canAct("canvases", "create"),
     canDispatch: canAct("factories", "update"),
     permissionsLoading,


### PR DESCRIPTION
## Summary
- Soft-delete factories via `deleted_at` + name suffix (frees unique name)
- Add `DeleteFactory` API (`DELETE /api/v1/factories/{id}`), RBAC delete, and detail-page delete UI
- Stacked on #6558 (factory update)

## Test plan
- [ ] Delete factory from detail page; list no longer shows it
- [ ] Recreate factory with same name after soft delete
- [ ] Describe/list hide soft-deleted factories
- [ ] `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories`


Made with [Cursor](https://cursor.com)