### PR TITLE
feat: acknowledge factory trigger messages

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -28,6 +28,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 <CardGrid>
   <LinkCard title="Add Issue Assignee" href="#add-issue-assignee" description="Add assignees to a GitHub issue" />
   <LinkCard title="Add Issue Label" href="#add-issue-label" description="Add labels to a GitHub issue" />
+  <LinkCard title="Add Issue Reaction" href="#add-issue-reaction" description="Add a reaction to a GitHub issue" />
   <LinkCard title="Add Pull Request Reviewers" href="#add-pull-request-reviewers" description="Add reviewers to a GitHub pull request" />
   <LinkCard title="Add Reaction" href="#add-reaction" description="Add a reaction to a GitHub comment" />
   <LinkCard title="Create Deployment" href="#create-deployment" description="Create a GitHub deployment for a ref and environment (enables the PR deployment UI)" />
@@ -2061,6 +2062,49 @@ Returns the full list of labels currently on the issue after the addition.
 }
 ```
 
+<a id="add-issue-reaction"></a>
+
+## Add Issue Reaction
+
+**Component key:** `github.addIssueReaction`
+
+The Add Issue Reaction component adds a reaction emoji to a GitHub issue.
+
+### Use Cases
+
+- **Acknowledge instructions**: Add eyes to an issue to indicate automation saw it
+- **Workflow feedback**: React with +1 or rocket on success paths
+- **Fast triage signals**: Show status without posting an extra comment
+
+### Configuration
+
+- **Repository**: Select the GitHub repository
+- **Issue Number**: The issue number to react to (supports expressions)
+- **Reaction**: One of GitHub's supported reaction values
+
+### Output
+
+Returns the created GitHub reaction object, including id, content, user, and timestamp.
+
+Transient GitHub failures (timeouts, rate limits, and 5xx responses) are attempted up to three times using durable scheduled hooks. Permanent configuration and permission errors fail immediately.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "content": "eyes",
+    "created_at": "2026-01-16T17:56:16Z",
+    "id": 1,
+    "user": {
+      "login": "superplane-bot"
+    }
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.reaction"
+}
+```
+
 <a id="add-pull-request-reviewers"></a>
 
 ## Add Pull Request Reviewers
@@ -2157,6 +2201,8 @@ The Add Reaction component adds a reaction emoji to a GitHub comment.
 ### Output
 
 Returns the created GitHub reaction object, including id, content, user, and timestamp.
+
+Transient GitHub failures (timeouts, rate limits, and 5xx responses) are attempted up to three times using durable scheduled hooks. Permanent configuration and permission errors fail immediately.
 
 ### Example Output
 

--- a/pkg/integrations/github/capability_mapper.go
+++ b/pkg/integrations/github/capability_mapper.go
@@ -110,6 +110,7 @@ func NewCapabilityMapper() *CapabilityMapper {
 					{ReadOnly: false, Action: &issues.RemoveIssueAssignee{}},
 					{ReadOnly: false, Action: &issues.AddIssueLabel{}},
 					{ReadOnly: false, Action: &issues.AddIssueAssignee{}},
+					{ReadOnly: false, Action: &issues.AddIssueReaction{}},
 				},
 			},
 			PermissionMetadata: {

--- a/pkg/integrations/github/capability_mapper_test.go
+++ b/pkg/integrations/github/capability_mapper_test.go
@@ -164,6 +164,15 @@ func Test__CapabilityMapper__NewPermissionSet(t *testing.T) {
 		assert.Equal(t, "write", got["pull_requests"])
 	})
 
+	t.Run("issue reaction action requests issues write permission", func(t *testing.T) {
+		t.Parallel()
+
+		ps := m.NewPermissionSet([]string{"github.addIssueReaction"})
+		got := ps.ForAppManifest()
+		assert.Equal(t, "write", got["issues"])
+		assert.NotContains(t, got, "pull_requests")
+	})
+
 	t.Run("mark pull request ready for review action requests pull request write permission", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -175,9 +175,14 @@ func (c *Client) ListBranches(ctx context.Context, repository string, opts *gith
 	return c.underlying.Repositories.ListBranches(ctx, owner, name, opts)
 }
 
-func (c *Client) CreateIssueReaction(ctx context.Context, repository string, commentID int64, content string) (*github.Reaction, *github.Response, error) {
+func (c *Client) CreateIssueCommentReaction(ctx context.Context, repository string, commentID int64, content string) (*github.Reaction, *github.Response, error) {
 	owner, name := c.ownerAndName(repository)
 	return c.underlying.Reactions.CreateIssueCommentReaction(ctx, owner, name, commentID, content)
+}
+
+func (c *Client) CreateIssueReaction(ctx context.Context, repository string, issueNumber int, content string) (*github.Reaction, *github.Response, error) {
+	owner, name := c.ownerAndName(repository)
+	return c.underlying.Reactions.CreateIssueReaction(ctx, owner, name, issueNumber, content)
 }
 
 func (c *Client) CreateReviewCommentReaction(ctx context.Context, repository string, commentID int64, content string) (*github.Reaction, *github.Response, error) {

--- a/pkg/integrations/github/common/reaction.go
+++ b/pkg/integrations/github/common/reaction.go
@@ -1,0 +1,223 @@
+package common
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+const (
+	ReactionRetryHookName = "retryReaction"
+
+	reactionMaxAttempts = 3
+	reactionBaseDelay   = 5 * time.Second
+	reactionMaxDelay    = 5 * time.Minute
+)
+
+var supportedReactionContents = map[string]struct{}{
+	"+1":       {},
+	"-1":       {},
+	"laugh":    {},
+	"confused": {},
+	"heart":    {},
+	"hooray":   {},
+	"rocket":   {},
+	"eyes":     {},
+}
+
+type ReactionOperation func() (*github.Reaction, *github.Response, error)
+
+type reactionRetryMetadata struct {
+	Attempts    int    `json:"attempts" mapstructure:"attempts"`
+	LastError   string `json:"lastError" mapstructure:"lastError"`
+	LastStatus  *int   `json:"lastStatus,omitempty" mapstructure:"lastStatus"`
+	NextRetryAt string `json:"nextRetryAt" mapstructure:"nextRetryAt"`
+}
+
+func ValidateReactionContent(content string) error {
+	if _, ok := supportedReactionContents[content]; !ok {
+		return fmt.Errorf("invalid reaction content: %s", content)
+	}
+
+	return nil
+}
+
+// ExecuteReaction executes an idempotent GitHub reaction request. Transient
+// provider failures are scheduled through the durable action-hook mechanism so
+// the database transaction is not held open while waiting between attempts.
+func ExecuteReaction(ctx core.ExecutionContext, operation ReactionOperation) error {
+	return executeReaction(
+		ctx.Metadata,
+		ctx.Requests,
+		ctx.ExecutionState,
+		operation,
+		1,
+		false,
+	)
+}
+
+func RetryReaction(ctx core.ActionHookContext, operation ReactionOperation) error {
+	if ctx.Name != ReactionRetryHookName {
+		return fmt.Errorf("unknown hook: %s", ctx.Name)
+	}
+
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	var metadata reactionRetryMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return FailReactionHook(ctx, fmt.Errorf("failed to decode reaction retry metadata: %w", err))
+	}
+
+	if metadata.Attempts < 1 || metadata.Attempts >= reactionMaxAttempts {
+		return FailReactionHook(ctx, fmt.Errorf("invalid reaction retry attempt: %d", metadata.Attempts))
+	}
+
+	return executeReaction(
+		ctx.Metadata,
+		ctx.Requests,
+		ctx.ExecutionState,
+		operation,
+		metadata.Attempts+1,
+		true,
+	)
+}
+
+func FailReactionHook(ctx core.ActionHookContext, err error) error {
+	return ctx.ExecutionState.Fail(models.CanvasNodeExecutionResultReasonError, err.Error())
+}
+
+func ReactionHooks() []core.Hook {
+	return []core.Hook{{Name: ReactionRetryHookName, Type: core.HookTypeInternal}}
+}
+
+func executeReaction(
+	metadataCtx core.MetadataWriter,
+	requestCtx core.RequestContext,
+	executionStateCtx core.ExecutionStateContext,
+	operation ReactionOperation,
+	attempt int,
+	finishOnTerminalFailure bool,
+) error {
+	reaction, response, err := operation()
+	if err == nil {
+		return executionStateCtx.Emit(
+			core.DefaultOutputChannel.Name,
+			"github.reaction",
+			[]any{reaction},
+		)
+	}
+
+	if !isTransientReactionError(response) {
+		if finishOnTerminalFailure {
+			return executionStateCtx.Fail(models.CanvasNodeExecutionResultReasonError, err.Error())
+		}
+		return err
+	}
+
+	if attempt >= reactionMaxAttempts {
+		terminalErr := fmt.Errorf("reaction request failed after %d attempts: %w", attempt, err)
+		if finishOnTerminalFailure {
+			return executionStateCtx.Fail(models.CanvasNodeExecutionResultReasonError, terminalErr.Error())
+		}
+		return terminalErr
+	}
+
+	delay := reactionRetryDelay(response, attempt, time.Now())
+	nextRetryAt := time.Now().Add(delay).Format(time.RFC3339)
+	metadata := reactionRetryMetadata{
+		Attempts:    attempt,
+		LastError:   err.Error(),
+		NextRetryAt: nextRetryAt,
+	}
+	if response != nil && response.Response != nil {
+		status := response.StatusCode
+		metadata.LastStatus = &status
+	}
+
+	if err := metadataCtx.Set(metadata); err != nil {
+		return fmt.Errorf("failed to set reaction retry metadata: %w", err)
+	}
+
+	if err := requestCtx.ScheduleActionCall(ReactionRetryHookName, map[string]any{}, delay); err != nil {
+		return fmt.Errorf("failed to schedule reaction retry: %w", err)
+	}
+
+	return nil
+}
+
+func isTransientReactionError(response *github.Response) bool {
+	if response == nil || response.Response == nil {
+		return true
+	}
+
+	status := response.StatusCode
+	if status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= http.StatusInternalServerError {
+		return true
+	}
+
+	if status != http.StatusForbidden {
+		return false
+	}
+
+	headers := response.Header
+	return headers.Get("Retry-After") != "" || headers.Get("X-RateLimit-Remaining") == "0"
+}
+
+func reactionRetryDelay(response *github.Response, attempt int, now time.Time) time.Duration {
+	if response != nil && response.Response != nil {
+		headers := response.Header
+		if delay, ok := parseRetryAfter(headers.Get("Retry-After"), now); ok {
+			return minimumReactionRetryDelay(delay)
+		}
+
+		if reset, err := strconv.ParseInt(headers.Get("X-RateLimit-Reset"), 10, 64); err == nil {
+			return minimumReactionRetryDelay(time.Unix(reset, 0).Sub(now))
+		}
+	}
+
+	delay := reactionBaseDelay * time.Duration(1<<(attempt-1))
+	return clampReactionRetryDelay(delay)
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	retryAt, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+
+	return retryAt.Sub(now), true
+}
+
+func clampReactionRetryDelay(delay time.Duration) time.Duration {
+	delay = minimumReactionRetryDelay(delay)
+
+	if delay > reactionMaxDelay {
+		return reactionMaxDelay
+	}
+
+	return delay
+}
+
+func minimumReactionRetryDelay(delay time.Duration) time.Duration {
+	if delay < time.Second {
+		return time.Second
+	}
+
+	return delay
+}

--- a/pkg/integrations/github/common/reaction_test.go
+++ b/pkg/integrations/github/common/reaction_test.go
@@ -1,0 +1,251 @@
+package common
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__ValidateReactionContent(t *testing.T) {
+	for _, content := range []string{"+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"} {
+		t.Run(content, func(t *testing.T) {
+			require.NoError(t, ValidateReactionContent(content))
+		})
+	}
+
+	require.ErrorContains(t, ValidateReactionContent("thumbs-up"), "invalid reaction content")
+}
+
+func Test__ExecuteReaction__RetriesTransientFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *github.Response
+	}{
+		{name: "network error"},
+		{name: "request timeout", response: reactionResponse(http.StatusRequestTimeout, nil)},
+		{name: "too many requests", response: reactionResponse(http.StatusTooManyRequests, nil)},
+		{name: "internal server error", response: reactionResponse(http.StatusInternalServerError, nil)},
+		{name: "bad gateway", response: reactionResponse(http.StatusBadGateway, nil)},
+		{name: "service unavailable", response: reactionResponse(http.StatusServiceUnavailable, nil)},
+		{name: "gateway timeout", response: reactionResponse(http.StatusGatewayTimeout, nil)},
+		{
+			name: "primary rate limit",
+			response: reactionResponse(http.StatusForbidden, http.Header{
+				"X-Ratelimit-Remaining": []string{"0"},
+			}),
+		},
+		{
+			name: "secondary rate limit",
+			response: reactionResponse(http.StatusForbidden, http.Header{
+				"Retry-After": []string{"17"},
+			}),
+		},
+		{
+			name: "long provider retry window",
+			response: reactionResponse(http.StatusTooManyRequests, http.Header{
+				"Retry-After": []string{"900"},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := &contexts.MetadataContext{}
+			requests := &contexts.RequestContext{}
+			state := &contexts.ExecutionStateContext{}
+
+			err := ExecuteReaction(core.ExecutionContext{
+				Metadata:       metadata,
+				Requests:       requests,
+				ExecutionState: state,
+			}, func() (*github.Reaction, *github.Response, error) {
+				return nil, tt.response, errors.New("provider unavailable")
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, ReactionRetryHookName, requests.Action)
+			assert.GreaterOrEqual(t, requests.Duration, time.Second)
+			assert.False(t, state.Finished)
+
+			if tt.name == "secondary rate limit" {
+				assert.Equal(t, 17*time.Second, requests.Duration)
+			}
+			if tt.name == "long provider retry window" {
+				assert.Equal(t, 15*time.Minute, requests.Duration)
+			}
+		})
+	}
+}
+
+func Test__ExecuteReaction__DoesNotRetryPermanentFailures(t *testing.T) {
+	for _, status := range []int{
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusUnprocessableEntity,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			requests := &contexts.RequestContext{}
+			err := ExecuteReaction(core.ExecutionContext{
+				Metadata:       &contexts.MetadataContext{},
+				Requests:       requests,
+				ExecutionState: &contexts.ExecutionStateContext{},
+			}, func() (*github.Reaction, *github.Response, error) {
+				return nil, reactionResponse(status, nil), errors.New("permanent provider error")
+			})
+
+			require.ErrorContains(t, err, "permanent provider error")
+			assert.Empty(t, requests.Action)
+		})
+	}
+}
+
+func Test__RetryReaction__EventuallySucceeds(t *testing.T) {
+	metadata := &contexts.MetadataContext{}
+	initialRequests := &contexts.RequestContext{}
+	state := &contexts.ExecutionStateContext{}
+
+	require.NoError(t, ExecuteReaction(core.ExecutionContext{
+		Metadata:       metadata,
+		Requests:       initialRequests,
+		ExecutionState: state,
+	}, func() (*github.Reaction, *github.Response, error) {
+		return nil, reactionResponse(http.StatusServiceUnavailable, nil), errors.New("temporary outage")
+	}))
+
+	err := RetryReaction(core.ActionHookContext{
+		Name:           ReactionRetryHookName,
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	}, func() (*github.Reaction, *github.Response, error) {
+		return &github.Reaction{ID: github.Ptr(int64(99)), Content: github.Ptr("eyes")}, reactionResponse(http.StatusCreated, nil), nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, state.Passed)
+	assert.Equal(t, "github.reaction", state.Type)
+	assert.Len(t, state.Payloads, 1)
+}
+
+func Test__RetryReaction__StopsAfterMaximumAttempts(t *testing.T) {
+	metadata := &contexts.MetadataContext{}
+	state := &contexts.ExecutionStateContext{}
+	operation := func() (*github.Reaction, *github.Response, error) {
+		return nil, reactionResponse(http.StatusServiceUnavailable, nil), errors.New("temporary outage")
+	}
+
+	require.NoError(t, ExecuteReaction(core.ExecutionContext{
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	}, operation))
+
+	require.NoError(t, RetryReaction(core.ActionHookContext{
+		Name:           ReactionRetryHookName,
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	}, operation))
+
+	err := RetryReaction(core.ActionHookContext{
+		Name:           ReactionRetryHookName,
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	}, operation)
+
+	require.NoError(t, err)
+	assert.True(t, state.Finished)
+	assert.False(t, state.Passed)
+	assert.Contains(t, state.FailureMessage, "failed after 3 attempts")
+}
+
+func Test__RetryReaction__FinishesOnPermanentProviderFailure(t *testing.T) {
+	metadata := &contexts.MetadataContext{}
+	state := &contexts.ExecutionStateContext{}
+
+	require.NoError(t, ExecuteReaction(core.ExecutionContext{
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	}, func() (*github.Reaction, *github.Response, error) {
+		return nil, reactionResponse(http.StatusServiceUnavailable, nil), errors.New("temporary outage")
+	}))
+
+	err := RetryReaction(core.ActionHookContext{
+		Name:           ReactionRetryHookName,
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	}, func() (*github.Reaction, *github.Response, error) {
+		return nil, reactionResponse(http.StatusForbidden, nil), errors.New("permission denied")
+	})
+
+	require.NoError(t, err)
+	assert.True(t, state.Finished)
+	assert.False(t, state.Passed)
+	assert.Contains(t, state.FailureMessage, "permission denied")
+}
+
+func Test__RetryReaction__FinishesOnInvalidRetryMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		metadata any
+		message  string
+	}{
+		{name: "decode failure", metadata: "not a map", message: "failed to decode reaction retry metadata"},
+		{name: "invalid attempt", metadata: map[string]any{"attempts": 0}, message: "invalid reaction retry attempt"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &contexts.ExecutionStateContext{}
+
+			err := RetryReaction(core.ActionHookContext{
+				Name:           ReactionRetryHookName,
+				Metadata:       &contexts.MetadataContext{Metadata: tt.metadata},
+				ExecutionState: state,
+			}, func() (*github.Reaction, *github.Response, error) {
+				t.Fatal("operation must not run with invalid retry metadata")
+				return nil, nil, nil
+			})
+
+			require.NoError(t, err)
+			assert.True(t, state.Finished)
+			assert.False(t, state.Passed)
+			assert.Contains(t, state.FailureMessage, tt.message)
+		})
+	}
+}
+
+func Test__ExecuteReaction__ReportsSchedulingFailure(t *testing.T) {
+	err := ExecuteReaction(core.ExecutionContext{
+		Metadata:       &contexts.MetadataContext{},
+		Requests:       failingReactionRequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+	}, func() (*github.Reaction, *github.Response, error) {
+		return nil, reactionResponse(http.StatusServiceUnavailable, nil), errors.New("temporary outage")
+	})
+
+	require.ErrorContains(t, err, "failed to schedule reaction retry")
+}
+
+func reactionResponse(status int, headers http.Header) *github.Response {
+	if headers == nil {
+		headers = make(http.Header)
+	}
+
+	return &github.Response{Response: &http.Response{StatusCode: status, Header: headers}}
+}
+
+type failingReactionRequestContext struct{}
+
+func (failingReactionRequestContext) ScheduleActionCall(string, map[string]any, time.Duration) error {
+	return errors.New("scheduler unavailable")
+}

--- a/pkg/integrations/github/components/issues/add_issue_reaction.go
+++ b/pkg/integrations/github/components/issues/add_issue_reaction.go
@@ -1,0 +1,232 @@
+package issues
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+)
+
+type AddIssueReaction struct{}
+
+type AddIssueReactionConfiguration struct {
+	Repository  string `json:"repository" mapstructure:"repository"`
+	IssueNumber string `json:"issueNumber" mapstructure:"issueNumber"`
+	Content     string `json:"content" mapstructure:"content"`
+}
+
+func (c *AddIssueReaction) Name() string {
+	return "github.addIssueReaction"
+}
+
+func (c *AddIssueReaction) Label() string {
+	return "Add Issue Reaction"
+}
+
+func (c *AddIssueReaction) Description() string {
+	return "Add a reaction to a GitHub issue"
+}
+
+func (c *AddIssueReaction) Documentation() string {
+	return `The Add Issue Reaction component adds a reaction emoji to a GitHub issue.
+
+## Use Cases
+
+- **Acknowledge instructions**: Add eyes to an issue to indicate automation saw it
+- **Workflow feedback**: React with +1 or rocket on success paths
+- **Fast triage signals**: Show status without posting an extra comment
+
+## Configuration
+
+- **Repository**: Select the GitHub repository
+- **Issue Number**: The issue number to react to (supports expressions)
+- **Reaction**: One of GitHub's supported reaction values
+
+## Output
+
+Returns the created GitHub reaction object, including id, content, user, and timestamp.
+
+Transient GitHub failures (timeouts, rate limits, and 5xx responses) are attempted up to three times using durable scheduled hooks. Permanent configuration and permission errors fail immediately.`
+}
+
+func (c *AddIssueReaction) Icon() string {
+	return "github"
+}
+
+func (c *AddIssueReaction) Color() string {
+	return "gray"
+}
+
+func (c *AddIssueReaction) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *AddIssueReaction) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "issueNumber",
+			Label:       "Issue Number",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The issue number to react to",
+		},
+		{
+			Name:     "content",
+			Label:    "Reaction",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "eyes",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "+1", Value: "+1"},
+						{Label: "-1", Value: "-1"},
+						{Label: "laugh", Value: "laugh"},
+						{Label: "confused", Value: "confused"},
+						{Label: "heart", Value: "heart"},
+						{Label: "hooray", Value: "hooray"},
+						{Label: "rocket", Value: "rocket"},
+						{Label: "eyes", Value: "eyes"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *AddIssueReaction) Setup(ctx core.SetupContext) error {
+	var config AddIssueReactionConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if strings.TrimSpace(config.Repository) == "" {
+		return errors.New("repository is required")
+	}
+
+	if strings.TrimSpace(config.IssueNumber) == "" {
+		return errors.New("issue number is required")
+	}
+
+	if strings.TrimSpace(config.Content) == "" {
+		return errors.New("reaction content is required")
+	}
+	if err := common.ValidateReactionContent(config.Content); err != nil {
+		return err
+	}
+
+	return common.EnsureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.HTTP,
+		ctx.Configuration,
+	)
+}
+
+func (c *AddIssueReaction) Execute(ctx core.ExecutionContext) error {
+	var config AddIssueReactionConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	issueNumber, err := strconv.Atoi(strings.TrimSpace(config.IssueNumber))
+	if err != nil {
+		return fmt.Errorf("issue number is not a number: %v", err)
+	}
+	if issueNumber <= 0 {
+		return errors.New("issue number must be positive")
+	}
+	if err := common.ValidateReactionContent(config.Content); err != nil {
+		return err
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	err = common.ExecuteReaction(ctx, func() (*github.Reaction, *github.Response, error) {
+		return client.CreateIssueReaction(context.Background(), config.Repository, issueNumber, config.Content)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create issue reaction: %w", err)
+	}
+
+	return nil
+}
+
+func (c *AddIssueReaction) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *AddIssueReaction) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *AddIssueReaction) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *AddIssueReaction) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *AddIssueReaction) Hooks() []core.Hook {
+	return common.ReactionHooks()
+}
+
+func (c *AddIssueReaction) HandleHook(ctx core.ActionHookContext) error {
+	if ctx.Name != common.ReactionRetryHookName {
+		return fmt.Errorf("unknown hook: %s", ctx.Name)
+	}
+
+	var config AddIssueReactionConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return common.FailReactionHook(ctx, fmt.Errorf("failed to decode configuration: %w", err))
+	}
+
+	issueNumber, err := strconv.Atoi(strings.TrimSpace(config.IssueNumber))
+	if err != nil {
+		return common.FailReactionHook(ctx, fmt.Errorf("issue number is not a number: %v", err))
+	}
+	if issueNumber <= 0 {
+		return common.FailReactionHook(ctx, errors.New("issue number must be positive"))
+	}
+	if err := common.ValidateReactionContent(config.Content); err != nil {
+		return common.FailReactionHook(ctx, err)
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return common.FailReactionHook(ctx, fmt.Errorf("failed to initialize GitHub client: %w", err))
+	}
+
+	err = common.RetryReaction(ctx, func() (*github.Reaction, *github.Response, error) {
+		return client.CreateIssueReaction(context.Background(), config.Repository, issueNumber, config.Content)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create issue reaction: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/integrations/github/components/issues/add_issue_reaction_test.go
+++ b/pkg/integrations/github/components/issues/add_issue_reaction_test.go
@@ -1,0 +1,304 @@
+package issues
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
+)
+
+func Test__AddIssueReaction__Setup(t *testing.T) {
+	component := AddIssueReaction{}
+
+	validConfig := func(overrides map[string]any) map[string]any {
+		config := map[string]any{
+			"repository":  "hello",
+			"issueNumber": "42",
+			"content":     "eyes",
+		}
+		for key, value := range overrides {
+			config[key] = value
+		}
+		return config
+	}
+
+	t.Run("repository is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"repository": ""}),
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("issue number is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"issueNumber": ""}),
+		})
+
+		require.ErrorContains(t, err, "issue number is required")
+	})
+
+	t.Run("reaction content is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"content": ""}),
+		})
+
+		require.ErrorContains(t, err, "reaction content is required")
+	})
+
+	t.Run("reaction content must be supported", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"content": "thumbs-up"}),
+		})
+
+		require.ErrorContains(t, err, "invalid reaction content")
+	})
+
+	for _, field := range []string{"repository", "issueNumber", "content"} {
+		t.Run(field+" rejects whitespace-only values", func(t *testing.T) {
+			err := component.Setup(core.SetupContext{
+				Integration:   &contexts.IntegrationContext{},
+				Metadata:      &contexts.MetadataContext{},
+				Configuration: validConfig(map[string]any{field: "   "}),
+			})
+
+			require.ErrorContains(t, err, "required")
+		})
+	}
+}
+
+func Test__AddIssueReaction__Execute(t *testing.T) {
+	component := AddIssueReaction{}
+
+	t.Run("issue number must be numeric", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository":  "hello",
+				"issueNumber": "abc",
+				"content":     "eyes",
+			},
+		})
+
+		require.ErrorContains(t, err, "issue number is not a number")
+	})
+
+	for _, issueNumber := range []string{"0", "-1"} {
+		t.Run("issue number must be positive "+issueNumber, func(t *testing.T) {
+			err := component.Execute(core.ExecutionContext{
+				Integration:    mocks.IntegrationContextForNewSetupFlow(),
+				ExecutionState: &contexts.ExecutionStateContext{},
+				Configuration: map[string]any{
+					"repository":  "hello",
+					"issueNumber": issueNumber,
+					"content":     "eyes",
+				},
+			})
+
+			require.ErrorContains(t, err, "issue number must be positive")
+		})
+	}
+
+	t.Run("reaction content is validated after expressions are resolved", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{}
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository":  "hello",
+				"issueNumber": "42",
+				"content":     "thumbs-up",
+			},
+		})
+
+		require.ErrorContains(t, err, "invalid reaction content")
+		assert.Empty(t, httpCtx.Requests)
+	})
+
+	t.Run("permanent provider errors are not retried", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusUnprocessableEntity, `{"message":"invalid reaction"}`),
+			},
+		}
+		requests := &contexts.RequestContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			Requests:       requests,
+			Metadata:       &contexts.MetadataContext{},
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository":  "hello",
+				"issueNumber": "42",
+				"content":     "eyes",
+			},
+		})
+
+		require.ErrorContains(t, err, "failed to create issue reaction")
+		assert.Empty(t, requests.Action)
+	})
+
+	t.Run("transient provider errors schedule a durable retry", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusServiceUnavailable, `{"message":"temporarily unavailable"}`),
+			},
+		}
+		requests := &contexts.RequestContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			Requests:       requests,
+			Metadata:       &contexts.MetadataContext{},
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository":  "hello",
+				"issueNumber": "42",
+				"content":     "eyes",
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, common.ReactionRetryHookName, requests.Action)
+	})
+
+	for _, status := range []int{http.StatusCreated, http.StatusOK} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			httpCtx := &contexts.HTTPContext{
+				Responses: []*http.Response{
+					mocks.GitHubResponse(status, `{"id": 99, "content": "eyes"}`),
+				},
+			}
+			executionState := &contexts.ExecutionStateContext{}
+
+			err := component.Execute(core.ExecutionContext{
+				Integration:    mocks.IntegrationContextForNewSetupFlow(),
+				HTTP:           httpCtx,
+				Metadata:       &contexts.MetadataContext{},
+				Requests:       &contexts.RequestContext{},
+				ExecutionState: executionState,
+				Configuration: map[string]any{
+					"repository":  "hello",
+					"issueNumber": "42",
+					"content":     "eyes",
+				},
+			})
+
+			require.NoError(t, err)
+			require.Len(t, httpCtx.Requests, 1)
+			assert.Equal(t, http.MethodPost, httpCtx.Requests[0].Method)
+			assert.Equal(t, "/repos/testhq/hello/issues/42/reactions", httpCtx.Requests[0].URL.Path)
+
+			body, err := httpCtx.Requests[0].GetBody()
+			require.NoError(t, err)
+			var requestBody map[string]string
+			require.NoError(t, json.NewDecoder(body).Decode(&requestBody))
+			assert.Equal(t, map[string]string{"content": "eyes"}, requestBody)
+
+			assert.True(t, executionState.Passed)
+			assert.Equal(t, "github.reaction", executionState.Type)
+		})
+	}
+}
+
+func Test__AddIssueReaction__HandleHook(t *testing.T) {
+	component := AddIssueReaction{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			mocks.GitHubResponse(http.StatusServiceUnavailable, `{"message":"temporarily unavailable"}`),
+			mocks.GitHubResponse(http.StatusCreated, `{"id":99,"content":"eyes"}`),
+		},
+	}
+	metadata := &contexts.MetadataContext{}
+	state := &contexts.ExecutionStateContext{}
+	configuration := map[string]any{
+		"repository":  "hello",
+		"issueNumber": "42",
+		"content":     "eyes",
+	}
+
+	require.NoError(t, component.Execute(core.ExecutionContext{
+		Integration:    mocks.IntegrationContextForNewSetupFlow(),
+		HTTP:           httpCtx,
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+		Configuration:  configuration,
+	}))
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name:           common.ReactionRetryHookName,
+		Integration:    mocks.IntegrationContextForNewSetupFlow(),
+		HTTP:           httpCtx,
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+		Configuration:  configuration,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, state.Passed)
+	assert.Equal(t, "github.reaction", state.Type)
+}
+
+func Test__AddIssueReaction__HandleHookFinishesOnPreflightError(t *testing.T) {
+	validConfiguration := map[string]any{
+		"repository":  "hello",
+		"issueNumber": "42",
+		"content":     "eyes",
+	}
+
+	for _, tt := range []struct {
+		name          string
+		configuration any
+		invalidClient bool
+		message       string
+	}{
+		{name: "configuration decode", configuration: "not a map", message: "failed to decode configuration"},
+		{name: "issue number", configuration: map[string]any{"repository": "hello", "issueNumber": "abc", "content": "eyes"}, message: "issue number is not a number"},
+		{name: "reaction content", configuration: map[string]any{"repository": "hello", "issueNumber": "42", "content": "invalid"}, message: "invalid reaction content"},
+		{name: "GitHub client", configuration: validConfiguration, invalidClient: true, message: "failed to initialize GitHub client"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			integration := mocks.IntegrationContextForNewSetupFlow()
+			if tt.invalidClient {
+				integration.CurrentSecrets = nil
+			}
+			state := &contexts.ExecutionStateContext{}
+
+			err := (&AddIssueReaction{}).HandleHook(core.ActionHookContext{
+				Name:           common.ReactionRetryHookName,
+				Integration:    integration,
+				HTTP:           &contexts.HTTPContext{},
+				Metadata:       &contexts.MetadataContext{},
+				Requests:       &contexts.RequestContext{},
+				ExecutionState: state,
+				Configuration:  tt.configuration,
+			})
+
+			require.NoError(t, err)
+			assert.True(t, state.Finished)
+			assert.False(t, state.Passed)
+			assert.Contains(t, state.FailureMessage, tt.message)
+		})
+	}
+}

--- a/pkg/integrations/github/components/issues/example.go
+++ b/pkg/integrations/github/components/issues/example.go
@@ -31,6 +31,9 @@ var exampleDataOnIssueBytes []byte
 //go:embed payloads/add_issue_label.json
 var exampleOutputAddIssueLabelBytes []byte
 
+//go:embed payloads/add_issue_reaction.json
+var exampleOutputAddIssueReactionBytes []byte
+
 //go:embed payloads/remove_issue_label.json
 var exampleOutputRemoveIssueLabelBytes []byte
 
@@ -63,6 +66,9 @@ var exampleDataOnIssue map[string]any
 
 var exampleOutputAddIssueLabelOnce sync.Once
 var exampleOutputAddIssueLabel map[string]any
+
+var exampleOutputAddIssueReactionOnce sync.Once
+var exampleOutputAddIssueReaction map[string]any
 
 var exampleOutputRemoveIssueLabelOnce sync.Once
 var exampleOutputRemoveIssueLabel map[string]any
@@ -103,6 +109,10 @@ func (t *OnIssue) ExampleData() map[string]any {
 
 func (c *AddIssueLabel) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputAddIssueLabelOnce, exampleOutputAddIssueLabelBytes, &exampleOutputAddIssueLabel)
+}
+
+func (c *AddIssueReaction) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputAddIssueReactionOnce, exampleOutputAddIssueReactionBytes, &exampleOutputAddIssueReaction)
 }
 
 func (c *RemoveIssueLabel) ExampleOutput() map[string]any {

--- a/pkg/integrations/github/components/issues/payloads/add_issue_reaction.json
+++ b/pkg/integrations/github/components/issues/payloads/add_issue_reaction.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": 1,
+    "content": "eyes",
+    "user": {
+      "login": "superplane-bot"
+    },
+    "created_at": "2026-01-16T17:56:16Z"
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.reaction"
+}

--- a/pkg/integrations/github/components/pulls/add_reaction.go
+++ b/pkg/integrations/github/components/pulls/add_reaction.go
@@ -60,7 +60,9 @@ func (c *AddReaction) Documentation() string {
 
 ## Output
 
-Returns the created GitHub reaction object, including id, content, user, and timestamp.`
+Returns the created GitHub reaction object, including id, content, user, and timestamp.
+
+Transient GitHub failures (timeouts, rate limits, and 5xx responses) are attempted up to three times using durable scheduled hooks. Permanent configuration and permission errors fail immediately.`
 }
 
 func (c *AddReaction) Icon() string {
@@ -141,7 +143,7 @@ func (c *AddReaction) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	if config.Repository == "" {
+	if strings.TrimSpace(config.Repository) == "" {
 		return errors.New("repository is required")
 	}
 
@@ -149,8 +151,11 @@ func (c *AddReaction) Setup(ctx core.SetupContext) error {
 		return errors.New("comment ID is required")
 	}
 
-	if config.Content == "" {
+	if strings.TrimSpace(config.Content) == "" {
 		return errors.New("reaction content is required")
+	}
+	if err := common.ValidateReactionContent(config.Content); err != nil {
+		return err
 	}
 
 	if config.Target == "" {
@@ -183,31 +188,36 @@ func (c *AddReaction) Execute(ctx core.ExecutionContext) error {
 	if err != nil {
 		return fmt.Errorf("comment ID is not a number: %v", err)
 	}
+	if commentID <= 0 {
+		return errors.New("comment ID must be positive")
+	}
+	if err := common.ValidateReactionContent(config.Content); err != nil {
+		return err
+	}
 
 	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
 	if err != nil {
 		return fmt.Errorf("failed to initialize GitHub client: %w", err)
 	}
 
-	reaction := &github.Reaction{}
 	switch config.Target {
 	case ReactionTargetIssueComment:
-		reaction, _, err = client.CreateIssueReaction(context.Background(), config.Repository, commentID, config.Content)
+		err = common.ExecuteReaction(ctx, func() (*github.Reaction, *github.Response, error) {
+			return client.CreateIssueCommentReaction(context.Background(), config.Repository, commentID, config.Content)
+		})
 		if err != nil {
 			return fmt.Errorf("failed to create issue reaction: %w", err)
 		}
 	case ReactionTargetReviewComment:
-		reaction, _, err = client.CreateReviewCommentReaction(context.Background(), config.Repository, commentID, config.Content)
+		err = common.ExecuteReaction(ctx, func() (*github.Reaction, *github.Response, error) {
+			return client.CreateReviewCommentReaction(context.Background(), config.Repository, commentID, config.Content)
+		})
 		if err != nil {
 			return fmt.Errorf("failed to create review comment reaction: %w", err)
 		}
 	}
 
-	return ctx.ExecutionState.Emit(
-		core.DefaultOutputChannel.Name,
-		"github.reaction",
-		[]any{reaction},
-	)
+	return nil
 }
 
 func (c *AddReaction) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
@@ -258,9 +268,55 @@ func parseCommentID(value string) (int64, error) {
 }
 
 func (c *AddReaction) Hooks() []core.Hook {
-	return []core.Hook{}
+	return common.ReactionHooks()
 }
 
 func (c *AddReaction) HandleHook(ctx core.ActionHookContext) error {
+	if ctx.Name != common.ReactionRetryHookName {
+		return fmt.Errorf("unknown hook: %s", ctx.Name)
+	}
+
+	var config AddReactionConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return common.FailReactionHook(ctx, fmt.Errorf("failed to decode configuration: %w", err))
+	}
+
+	if config.Target != ReactionTargetIssueComment && config.Target != ReactionTargetReviewComment {
+		return common.FailReactionHook(ctx, fmt.Errorf("invalid target: %s", config.Target))
+	}
+
+	commentID, err := parseCommentID(config.CommentID)
+	if err != nil {
+		return common.FailReactionHook(ctx, fmt.Errorf("comment ID is not a number: %v", err))
+	}
+	if commentID <= 0 {
+		return common.FailReactionHook(ctx, errors.New("comment ID must be positive"))
+	}
+	if err := common.ValidateReactionContent(config.Content); err != nil {
+		return common.FailReactionHook(ctx, err)
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return common.FailReactionHook(ctx, fmt.Errorf("failed to initialize GitHub client: %w", err))
+	}
+
+	switch config.Target {
+	case ReactionTargetIssueComment:
+		err = common.RetryReaction(ctx, func() (*github.Reaction, *github.Response, error) {
+			return client.CreateIssueCommentReaction(context.Background(), config.Repository, commentID, config.Content)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create issue reaction: %w", err)
+		}
+	case ReactionTargetReviewComment:
+		err = common.RetryReaction(ctx, func() (*github.Reaction, *github.Response, error) {
+			return client.CreateReviewCommentReaction(context.Background(), config.Repository, commentID, config.Content)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create review comment reaction: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/integrations/github/components/pulls/add_reaction_test.go
+++ b/pkg/integrations/github/components/pulls/add_reaction_test.go
@@ -1,11 +1,15 @@
 package pulls
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
 	contexts "github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
 )
 
 func Test__AddReaction__Setup(t *testing.T) {
@@ -41,6 +45,16 @@ func Test__AddReaction__Setup(t *testing.T) {
 		require.ErrorContains(t, err, "reaction content is required")
 	})
 
+	t.Run("reaction content must be supported", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"target": ReactionTargetIssueComment, "commentId": "42", "content": "thumbs-up", "repository": "hello"},
+		})
+
+		require.ErrorContains(t, err, "invalid reaction content")
+	})
+
 	t.Run("target is required", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Integration:   &contexts.IntegrationContext{},
@@ -60,6 +74,26 @@ func Test__AddReaction__Setup(t *testing.T) {
 
 		require.ErrorContains(t, err, "invalid target")
 	})
+
+	for _, field := range []string{"repository", "commentId", "content"} {
+		t.Run(field+" rejects whitespace-only values", func(t *testing.T) {
+			configuration := map[string]any{
+				"target":     ReactionTargetIssueComment,
+				"commentId":  "42",
+				"content":    "eyes",
+				"repository": "hello",
+			}
+			configuration[field] = "   "
+
+			err := component.Setup(core.SetupContext{
+				Integration:   &contexts.IntegrationContext{},
+				Metadata:      &contexts.MetadataContext{},
+				Configuration: configuration,
+			})
+
+			require.ErrorContains(t, err, "required")
+		})
+	}
 }
 
 func Test__AddReaction__Execute(t *testing.T) {
@@ -95,6 +129,39 @@ func Test__AddReaction__Execute(t *testing.T) {
 		require.ErrorContains(t, err, "comment ID is not a number")
 	})
 
+	t.Run("fails when comment ID is not positive", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    &contexts.IntegrationContext{},
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"target":     ReactionTargetIssueComment,
+				"commentId":  "0",
+				"content":    "eyes",
+				"repository": "hello",
+			},
+		})
+
+		require.ErrorContains(t, err, "comment ID must be positive")
+	})
+
+	t.Run("fails before calling GitHub when reaction content is invalid", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{}
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"target":     ReactionTargetIssueComment,
+				"commentId":  "42",
+				"content":    "thumbs-up",
+				"repository": "hello",
+			},
+		})
+
+		require.ErrorContains(t, err, "invalid reaction content")
+		assert.Empty(t, httpCtx.Requests)
+	})
+
 	t.Run("fails when configuration decode fails", func(t *testing.T) {
 		err := component.Execute(core.ExecutionContext{
 			Integration:    &contexts.IntegrationContext{},
@@ -104,6 +171,122 @@ func Test__AddReaction__Execute(t *testing.T) {
 
 		require.ErrorContains(t, err, "failed to decode configuration")
 	})
+
+	for _, tt := range []struct {
+		name   string
+		target string
+		path   string
+	}{
+		{
+			name:   "issue or PR conversation comment",
+			target: ReactionTargetIssueComment,
+			path:   "/repos/testhq/hello/issues/comments/42/reactions",
+		},
+		{
+			name:   "inline PR review comment",
+			target: ReactionTargetReviewComment,
+			path:   "/repos/testhq/hello/pulls/comments/42/reactions",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			httpCtx := &contexts.HTTPContext{
+				Responses: []*http.Response{
+					mocks.GitHubResponse(http.StatusCreated, `{"id":99,"content":"eyes"}`),
+				},
+			}
+			state := &contexts.ExecutionStateContext{}
+
+			err := component.Execute(core.ExecutionContext{
+				Integration:    mocks.IntegrationContextForNewSetupFlow(),
+				HTTP:           httpCtx,
+				Metadata:       &contexts.MetadataContext{},
+				Requests:       &contexts.RequestContext{},
+				ExecutionState: state,
+				Configuration: map[string]any{
+					"target":     tt.target,
+					"commentId":  "42",
+					"content":    "eyes",
+					"repository": "hello",
+				},
+			})
+
+			require.NoError(t, err)
+			require.Len(t, httpCtx.Requests, 1)
+			assert.Equal(t, tt.path, httpCtx.Requests[0].URL.Path)
+			assert.True(t, state.Passed)
+		})
+	}
+
+	t.Run("transient provider errors schedule a durable retry", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusServiceUnavailable, `{"message":"temporarily unavailable"}`),
+			},
+		}
+		requests := &contexts.RequestContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			Metadata:       &contexts.MetadataContext{},
+			Requests:       requests,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"target":     ReactionTargetIssueComment,
+				"commentId":  "42",
+				"content":    "eyes",
+				"repository": "hello",
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, common.ReactionRetryHookName, requests.Action)
+	})
+}
+
+func Test__AddReaction__HandleHookFinishesOnPreflightError(t *testing.T) {
+	validConfiguration := map[string]any{
+		"target":     ReactionTargetIssueComment,
+		"commentId":  "42",
+		"content":    "eyes",
+		"repository": "hello",
+	}
+
+	for _, tt := range []struct {
+		name          string
+		configuration any
+		invalidClient bool
+		message       string
+	}{
+		{name: "configuration decode", configuration: "not a map", message: "failed to decode configuration"},
+		{name: "target", configuration: map[string]any{"target": "invalid", "commentId": "42", "content": "eyes", "repository": "hello"}, message: "invalid target"},
+		{name: "comment ID", configuration: map[string]any{"target": ReactionTargetIssueComment, "commentId": "abc", "content": "eyes", "repository": "hello"}, message: "comment ID is not a number"},
+		{name: "reaction content", configuration: map[string]any{"target": ReactionTargetIssueComment, "commentId": "42", "content": "invalid", "repository": "hello"}, message: "invalid reaction content"},
+		{name: "GitHub client", configuration: validConfiguration, invalidClient: true, message: "failed to initialize GitHub client"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			integration := mocks.IntegrationContextForNewSetupFlow()
+			if tt.invalidClient {
+				integration.CurrentSecrets = nil
+			}
+			state := &contexts.ExecutionStateContext{}
+
+			err := (&AddReaction{}).HandleHook(core.ActionHookContext{
+				Name:           common.ReactionRetryHookName,
+				Integration:    integration,
+				HTTP:           &contexts.HTTPContext{},
+				Metadata:       &contexts.MetadataContext{},
+				Requests:       &contexts.RequestContext{},
+				ExecutionState: state,
+				Configuration:  tt.configuration,
+			})
+
+			require.NoError(t, err)
+			assert.True(t, state.Finished)
+			assert.False(t, state.Passed)
+			assert.Contains(t, state.FailureMessage, tt.message)
+		})
+	}
 }
 
 func Test__parseCommentID(t *testing.T) {
@@ -123,4 +306,5 @@ func Test__parseCommentID(t *testing.T) {
 		_, err := parseCommentID("3983993590.5")
 		require.ErrorContains(t, err, "value has decimals")
 	})
+
 }

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -119,6 +119,7 @@ func (g *GitHub) Actions() []core.Action {
 		&contents.DeleteRelease{},
 		&issues.AddIssueAssignee{},
 		&issues.AddIssueLabel{},
+		&issues.AddIssueReaction{},
 		&issues.CreateIssue{},
 		&issues.CreateIssueComment{},
 		&issues.UpdateIssueComment{},

--- a/web_src/src/pages/app/mappers/github/index.ts
+++ b/web_src/src/pages/app/mappers/github/index.ts
@@ -96,6 +96,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   addIssueAssignee: baseIssueMapper,
   removeIssueAssignee: baseIssueMapper,
   addReaction: addReactionMapper,
+  addIssueReaction: addReactionMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {

--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import yaml from "js-yaml";
 
 import { getFactoryDefinition } from "./index";
 import {
@@ -100,6 +101,121 @@ spec:
     expect(canvasYaml).not.toContain("install_params.anthropic_api_key");
     expect(canvasYaml).not.toContain("install_params.github_token");
     expect(canvasYaml).not.toContain("REPLACE_ME_WITH_");
+  });
+
+  it("acknowledges every GitHub instruction path with an eyes reaction", () => {
+    const canvas = yaml.load(materializeSoftwareFactory()) as {
+      spec?: {
+        nodes?: Array<{
+          id?: string;
+          component?: string;
+          configuration?: Record<string, unknown>;
+          integration?: { id?: string; name?: string };
+        }>;
+        edges?: Array<{ sourceId?: string; targetId?: string; channel?: string }>;
+      };
+    };
+    const nodesById = new Map((canvas.spec?.nodes ?? []).map((node) => [node.id, node]));
+    const edges = canvas.spec?.edges ?? [];
+
+    expect(nodesById.get("acknowledge-issue-instruction")).toMatchObject({
+      component: "github.addIssueReaction",
+      configuration: {
+        repository: "acme/web",
+        issueNumber: "{{ root().data.issue.number }}",
+        content: "eyes",
+      },
+      integration: { id: "int-1", name: "acme-github" },
+    });
+    expect(nodesById.get("acknowledge-comment-instruction")).toMatchObject({
+      component: "github.addReaction",
+      configuration: {
+        repository: "acme/web",
+        target: "issueComment",
+        commentId: "{{ root().data.comment.id }}",
+        content: "eyes",
+      },
+      integration: { id: "int-1", name: "acme-github" },
+    });
+    expect(nodesById.get("acknowledge-pr-review-comment-instruction")).toMatchObject({
+      component: "github.addReaction",
+      configuration: {
+        repository: "acme/web",
+        target: "reviewComment",
+        commentId: "{{ root().data.comment.id }}",
+        content: "eyes",
+      },
+      integration: { id: "int-1", name: "acme-github" },
+    });
+
+    expect(nodesById.get("assigned-to-agent-filter")).toMatchObject({
+      configuration: {
+        expression: expect.stringContaining("root().data.issue.pull_request == nil"),
+      },
+    });
+    expect(nodesById.get("factory-pr-review-comment-filter")).toMatchObject({
+      configuration: {
+        expression: expect.stringContaining("root().data.comment != nil"),
+      },
+    });
+
+    expect(edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceId: "assigned-to-agent-filter",
+          targetId: "acknowledge-issue-instruction",
+        }),
+        expect.objectContaining({
+          sourceId: "label-is-factory-filter",
+          targetId: "acknowledge-issue-instruction",
+        }),
+        expect.objectContaining({
+          sourceId: "component-node-4m9qti",
+          targetId: "acknowledge-comment-instruction",
+        }),
+        expect.objectContaining({
+          sourceId: "factory-pr-comment-filter",
+          targetId: "acknowledge-comment-instruction",
+        }),
+        expect.objectContaining({
+          sourceId: "factory-pr-comment-filter",
+          targetId: "apply-user-request-claude",
+        }),
+        expect.objectContaining({
+          sourceId: "factory-pr-review-comment-filter",
+          targetId: "acknowledge-pr-review-comment-instruction",
+        }),
+        expect.objectContaining({
+          sourceId: "factory-pr-review-comment-filter",
+          targetId: "apply-user-request-claude",
+        }),
+      ]),
+    );
+
+    expect(edges).not.toContainEqual(
+      expect.objectContaining({
+        sourceId: "on-pr-comment-trigger",
+        targetId: "apply-user-request-claude",
+      }),
+    );
+    expect(edges).not.toContainEqual(
+      expect.objectContaining({
+        sourceId: "on-pr-review-comment-trigger",
+        targetId: "apply-user-request-claude",
+      }),
+    );
+    expect(edges).not.toContainEqual(
+      expect.objectContaining({
+        sourceId: "on-pr-comment-trigger",
+        targetId: "acknowledge-comment-instruction",
+      }),
+    );
+    expect(edges).not.toContainEqual(
+      expect.objectContaining({
+        sourceId: "on-pr-review-comment-trigger",
+        targetId: "acknowledge-pr-review-comment-instruction",
+      }),
+    );
   });
 
   it("materializes console canvasId to the installed canvas", () => {

--- a/web_src/src/pages/home/factories/software-factory/canvas.yaml
+++ b/web_src/src/pages/home/factories/software-factory/canvas.yaml
@@ -54,7 +54,7 @@ spec:
       type: TYPE_ACTION
       component: filter
       configuration:
-        expression: any(root().data.pull_request.labels, {.name == "factory"})
+        expression: root().data.comment != nil && any(root().data.pull_request.labels, {.name == "factory"})
       position:
         x: 672
         'y': 1080
@@ -438,7 +438,7 @@ spec:
       type: TYPE_ACTION
       component: filter
       configuration:
-        expression: root().data.assignee.login == "superplaneagent"
+        expression: root().data.assignee.login == "superplaneagent" && root().data.issue.pull_request == nil
       position:
         x: 552
         'y': -432
@@ -840,10 +840,11 @@ spec:
         text: |-
           ## Main Entrypoint
 
-          Two ways to trigger:
+          Three ways to trigger:
 
-          1/ Mention @superplaneagent
-          2/ Add "factory" label
+          1/ Mention @superplaneagent in an issue or Factory PR
+          2/ Add the "factory" label to an issue
+          3/ Assign an issue to @superplaneagent
       position:
         x: 72
         'y': -744
@@ -1339,6 +1340,44 @@ spec:
         x: 2304
         'y': 380
       isCollapsed: true
+    - id: acknowledge-issue-instruction
+      name: Acknowledge Issue Instruction
+      type: TYPE_ACTION
+      component: github.addIssueReaction
+      configuration:
+        repository: '{{ install_params.repository }}'
+        issueNumber: '{{ root().data.issue.number }}'
+        content: eyes
+      position:
+        x: 1104
+        'y': -432
+      isCollapsed: true
+    - id: acknowledge-comment-instruction
+      name: Acknowledge Comment Instruction
+      type: TYPE_ACTION
+      component: github.addReaction
+      configuration:
+        repository: '{{ install_params.repository }}'
+        target: issueComment
+        commentId: '{{ root().data.comment.id }}'
+        content: eyes
+      position:
+        x: 1104
+        'y': 816
+      isCollapsed: true
+    - id: acknowledge-pr-review-comment-instruction
+      name: Acknowledge PR Review Comment Instruction
+      type: TYPE_ACTION
+      component: github.addReaction
+      configuration:
+        repository: '{{ install_params.repository }}'
+        target: reviewComment
+        commentId: '{{ root().data.comment.id }}'
+        content: eyes
+      position:
+        x: 1104
+        'y': 1080
+      isCollapsed: true
   edges:
     - sourceId: analyze-create-issue
       targetId: create-task-issue
@@ -1348,6 +1387,9 @@ spec:
       channel: passed
     - sourceId: assigned-to-agent-filter
       targetId: runner-create-branch-2
+      channel: default
+    - sourceId: assigned-to-agent-filter
+      targetId: acknowledge-issue-instruction
       channel: default
     - sourceId: ci-green
       targetId: component-node-vwmzg2
@@ -1366,6 +1408,9 @@ spec:
       channel: next
     - sourceId: component-node-4m9qti
       targetId: runner-create-branch-2
+      channel: default
+    - sourceId: component-node-4m9qti
+      targetId: acknowledge-comment-instruction
       channel: default
     - sourceId: component-node-nbf347
       targetId: github-markpullrequestreadyforreview-github-markpullrequestreadyforreview-wie92w
@@ -1394,6 +1439,12 @@ spec:
     - sourceId: factory-pr-comment-filter
       targetId: reopen-followup-memory
       channel: default
+    - sourceId: factory-pr-comment-filter
+      targetId: apply-user-request-claude
+      channel: default
+    - sourceId: factory-pr-comment-filter
+      targetId: acknowledge-comment-instruction
+      channel: default
     - sourceId: factory-pr-merged-filter
       targetId: mark-merged-memory
       channel: default
@@ -1402,6 +1453,12 @@ spec:
       channel: default
     - sourceId: factory-pr-review-comment-filter
       targetId: reopen-followup-memory
+      channel: default
+    - sourceId: factory-pr-review-comment-filter
+      targetId: apply-user-request-claude
+      channel: default
+    - sourceId: factory-pr-review-comment-filter
+      targetId: acknowledge-pr-review-comment-instruction
       channel: default
     - sourceId: fix-ci-claude
       targetId: ci-loop
@@ -1430,6 +1487,9 @@ spec:
     - sourceId: label-is-factory-filter
       targetId: runner-create-branch-2
       channel: default
+    - sourceId: label-is-factory-filter
+      targetId: acknowledge-issue-instruction
+      channel: default
     - sourceId: on-issue-assigned-trigger
       targetId: assigned-to-agent-filter
       channel: default
@@ -1437,13 +1497,7 @@ spec:
       targetId: label-is-factory-filter
       channel: default
     - sourceId: on-pr-comment-trigger
-      targetId: apply-user-request-claude
-      channel: default
-    - sourceId: on-pr-comment-trigger
       targetId: factory-pr-comment-filter
-      channel: default
-    - sourceId: on-pr-review-comment-trigger
-      targetId: apply-user-request-claude
       channel: default
     - sourceId: on-pr-review-comment-trigger
       targetId: factory-pr-review-comment-filter

--- a/web_src/src/pages/home/factories/software-factory/factory.json
+++ b/web_src/src/pages/home/factories/software-factory/factory.json
@@ -5,6 +5,8 @@
   "integrations": ["github", "claude"],
   "componentIntegrations": {
     "github.addIssueLabel": "github",
+    "github.addIssueReaction": "github",
+    "github.addReaction": "github",
     "github.createIssue": "github",
     "github.createIssueComment": "github",
     "github.createPullRequest": "github",


### PR DESCRIPTION
Closes #6375

## What changed

- Add the `github.addIssueReaction` action and register it in the GitHub integration, capability mapper, UI mapper, examples, and generated component documentation.
- Send an `eyes` acknowledgement for every supported Software Factory instruction path:
  - assigning the SuperPlane agent to an issue;
  - adding the `factory` label to an issue;
  - mentioning the agent in an issue comment;
  - mentioning the agent in a Factory pull request conversation;
  - mentioning the agent in an inline Factory pull request review comment.
- Route pull request comments through the Factory filters before invoking either the agent or the acknowledgement action.
- Prevent issue-assignment handling from treating pull requests as regular issues.
- Ignore pull request review submissions that do not contain an inline review comment.

## Why

Factory instructions can take long enough to process that users need immediate confirmation that SuperPlane accepted the request. Previously, the Factory started work silently, making duplicate instructions and uncertainty more likely.

## Reliability and failure handling

GitHub reaction creation is idempotent for the same actor and reaction content, so reaction requests can be retried safely without duplicating workflow side effects.

- Retry network failures, HTTP 408/429, 5xx responses, and rate-limited 403 responses.
- Respect `Retry-After` and `X-RateLimit-Reset` provider hints.
- Use durable action hooks instead of sleeping inside an execution transaction.
- Limit execution to three total attempts with exponential fallback delays.
- Fail immediately for permanent authentication, permission, not-found, validation, and configuration errors.
- Finish retry hooks on invalid configuration, missing integration credentials, corrupt retry metadata, and exhausted attempts so requests cannot remain pending indefinitely.
- Continue propagating metadata persistence, scheduler, and execution-state failures so transactional worker retries remain available.

## Tests

- Added unit coverage for validation, endpoints, payloads, supported reaction values, transient/permanent error classification, provider retry hints, successful recovery, scheduler failures, retry exhaustion, and terminal hook state.
- Added Factory materialization assertions for all acknowledgement paths and safety filters.
- Ran the affected Go packages after the final hook-state hardening:

  ```text
  go test ./pkg/integrations/github/common \
    ./pkg/integrations/github/components/issues \
    ./pkg/integrations/github/components/pulls -count=1
  ```

- Ran the complete backend suite before the final isolated hook-state hardening: 10,793 passed and one unrelated credential-gated Render live test was skipped.
- Ran the focused Factory materialization suite: 8/8 passed.
- Ran backend lint/build and frontend format/lint/production build checks.
- Manually exercised provider failures through a disposable WireMock container on the SuperPlane Docker network:
  - 503 with `Retry-After`, followed by a connection reset, followed by recovery;
  - real client timeout against a delayed response;
  - persistent 503 responses through terminal retry exhaustion;
  - seven matched requests and zero unmatched requests.

## Notes

- This change intentionally handles inline review comments only; review submissions without an inline comment are not Factory instructions.
- Global webhook/work-order deduplication and author authorization policy are broader product concerns and remain outside this issue.
- No breaking changes.
