### PR TITLE
fix: advance the agent survey with Enter in the custom answer input

### DIFF
--- a/web_src/src/components/AgentSidebar/widgets/SurveyWidget.spec.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/SurveyWidget.spec.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SurveyWidget, type SurveyQuestion } from "./SurveyWidget";
+
+const questions: SurveyQuestion[] = [
+  { prompt: "What do you want to automate?", options: ["Deploys"], hasInput: true },
+  { prompt: "How often does it run?", options: ["Daily"], hasInput: true },
+];
+
+describe("SurveyWidget", () => {
+  it("advances to the next question when Enter is pressed in the custom answer input", () => {
+    render(<SurveyWidget questions={questions} />);
+
+    const input = screen.getByPlaceholderText("Type your own answer...");
+    fireEvent.change(input, { target: { value: "Release notes" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText("How often does it run?")).toBeTruthy();
+    expect(screen.getByText("2/2")).toBeTruthy();
+  });
+
+  it("submits the survey when Enter is pressed on the last question", () => {
+    const onAction = vi.fn();
+    render(<SurveyWidget questions={questions} onAction={onAction} />);
+
+    const input = screen.getByPlaceholderText("Type your own answer...");
+    fireEvent.change(input, { target: { value: "Release notes" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    fireEvent.change(screen.getByPlaceholderText("Type your own answer..."), { target: { value: "Every hour" } });
+    fireEvent.keyDown(screen.getByPlaceholderText("Type your own answer..."), { key: "Enter" });
+
+    expect(onAction).toHaveBeenCalledWith(
+      "What do you want to automate? → Release notes\nHow often does it run? → Every hour",
+    );
+  });
+
+  it("ignores Enter while an IME composition is in progress", () => {
+    render(<SurveyWidget questions={questions} />);
+
+    const input = screen.getByPlaceholderText("Type your own answer...");
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+    expect(screen.getByText("What do you want to automate?")).toBeTruthy();
+    expect(screen.getByText("1/2")).toBeTruthy();
+  });
+});

--- a/web_src/src/components/AgentSidebar/widgets/SurveyWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/SurveyWidget.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ChangeEvent } from "react";
+import { useCallback, useState, type ChangeEvent, type KeyboardEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -70,6 +70,23 @@ export function SurveyWidget({ questions, onAction }: SurveyWidgetProps) {
     onAction?.(parts.join("\n"));
   }, [answers, onAction, questions, submitted]);
 
+  const handleCustomInputKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key !== "Enter") return;
+      if ("isComposing" in event.nativeEvent && event.nativeEvent.isComposing) return;
+
+      event.preventDefault();
+
+      if (currentIndex === questions.length - 1) {
+        handleSubmit();
+        return;
+      }
+
+      handleNext();
+    },
+    [currentIndex, handleNext, handleSubmit, questions.length],
+  );
+
   if (!questions.length || submitted) return null;
 
   const current = questions[currentIndex];
@@ -108,20 +125,14 @@ export function SurveyWidget({ questions, onAction }: SurveyWidgetProps) {
 
         {/* Custom input option */}
         {current.hasInput && (
-          <div className="mt-1 flex items-center gap-2">
-            <input
-              type="text"
-              placeholder="Type your own answer..."
-              value={customInputs[currentIndex]}
-              onChange={handleCustomInputChange}
-              className={cn(
-                "flex-1 rounded border px-3 py-2 text-xs outline-none transition-colors dark:text-gray-100 dark:placeholder:text-gray-500",
-                customInputs[currentIndex] && answers[currentIndex] === customInputs[currentIndex].trim()
-                  ? "border-slate-400 bg-slate-50 ring-1 ring-slate-300 dark:border-gray-500 dark:bg-gray-700 dark:ring-gray-600"
-                  : "border-slate-200 bg-white focus:border-slate-400 dark:border-gray-700 dark:bg-gray-900 dark:focus:border-gray-500",
-              )}
-            />
-          </div>
+          <SurveyCustomInput
+            value={customInputs[currentIndex]}
+            selected={
+              Boolean(customInputs[currentIndex]) && answers[currentIndex] === customInputs[currentIndex].trim()
+            }
+            onChange={handleCustomInputChange}
+            onKeyDown={handleCustomInputKeyDown}
+          />
         )}
       </div>
 
@@ -227,6 +238,36 @@ function SurveyOptionButton({
       </span>
       {option}
     </Button>
+  );
+}
+
+function SurveyCustomInput({
+  value,
+  selected,
+  onChange,
+  onKeyDown,
+}: {
+  value: string;
+  selected: boolean;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+}) {
+  return (
+    <div className="mt-1 flex items-center gap-2">
+      <input
+        type="text"
+        placeholder="Type your own answer..."
+        value={value}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        className={cn(
+          "flex-1 rounded border px-3 py-2 text-xs outline-none transition-colors dark:text-gray-100 dark:placeholder:text-gray-500",
+          selected
+            ? "border-slate-400 bg-slate-50 ring-1 ring-slate-300 dark:border-gray-500 dark:bg-gray-700 dark:ring-gray-600"
+            : "border-slate-200 bg-white focus:border-slate-400 dark:border-gray-700 dark:bg-gray-900 dark:focus:border-gray-500",
+        )}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
The free-text input in the agent sidebar's survey widget only had an `onChange` handler, so
answering a question required moving to the "Next" / "Continue" button for every step. It isn't
inside a `<form>`, so Enter did nothing at all.

Enter in that input now does what the footer button does: advance to the next question, or submit
on the last one. It's a no-op while an IME composition is active, following the same
`nativeEvent.isComposing` check `ChatComposer` uses. Added `SurveyWidget.spec.tsx` covering all
three paths.

The custom input is now a `SurveyCustomInput` sub-component, matching how `SurveyStepDots`,
`SurveyOptionButton` and `SurveyNavigation` are already split out in that file. That part isn't
cosmetic: the eslint budget is at exactly 65/65 for `max-lines-per-function`, and the handler
inline pushed `SurveyWidget` one line over the limit, which fails `npm run lint:budget`. Markup and
behaviour are unchanged.

Part of #5269. I left the CMD+Tab half of that issue alone — Cmd+Tab is the macOS app switcher and
Ctrl+Tab is reserved by the browser, so the page never receives the keydown, and choosing a
different chord is a product call.

Verified with `npx vitest run src/components/AgentSidebar/widgets/SurveyWidget.spec.tsx` (3 passed),
`npx eslint` and `npx prettier --check` on both files, and `npm run lint:budget` (within budget).
I couldn't run `make check.build.ui` — it needs `web_src/src/api-client/`, which is generated by
`make pb.gen` and isn't in the tree here.
