### PR TITLE
fix: detect Telegram bot mentions using UTF-16 entity offsets

### DIFF
--- a/pkg/integrations/telegram/telegram.go
+++ b/pkg/integrations/telegram/telegram.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf16"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -179,22 +180,7 @@ func (t *Telegram) HandleRequest(ctx core.HTTPRequestContext) {
 		}
 	}
 
-	isMention := false
-	botUsername := "@" + metadata.Username
-
-	// Check for mentions in entities
-	for _, entity := range update.Message.Entities {
-		if entity.Type == "mention" {
-			// Extract the mentioned username from the message text
-			mentionedText := update.Message.Text[entity.Offset : entity.Offset+entity.Length]
-			if strings.EqualFold(mentionedText, botUsername) {
-				isMention = true
-				break
-			}
-		}
-	}
-
-	if !isMention {
+	if !mentionsBot(update.Message, metadata.Username) {
 		ctx.Response.WriteHeader(200)
 		return
 	}
@@ -261,6 +247,38 @@ func (t *Telegram) HandleRequest(ctx core.HTTPRequestContext) {
 	}
 
 	ctx.Response.WriteHeader(200)
+}
+
+// mentionsBot reports whether one of the message's mention entities names the bot.
+//
+// Telegram counts entity offsets and lengths in UTF-16 code units, so the text is
+// converted before slicing. Indexing the Go string directly misplaces the slice as
+// soon as an earlier character is not a single UTF-8 byte, which silently loses the
+// mention.
+func mentionsBot(message *TelegramMessage, botUsername string) bool {
+	if botUsername == "" {
+		return false
+	}
+
+	mention := "@" + botUsername
+	text := utf16.Encode([]rune(message.Text))
+
+	for _, entity := range message.Entities {
+		if entity.Type != "mention" {
+			continue
+		}
+
+		if entity.Offset < 0 || entity.Length < 0 || entity.Offset+entity.Length > len(text) {
+			continue
+		}
+
+		mentioned := string(utf16.Decode(text[entity.Offset : entity.Offset+entity.Length]))
+		if strings.EqualFold(mentioned, mention) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (t *Telegram) Cleanup(ctx core.IntegrationCleanupContext) error {

--- a/pkg/integrations/telegram/telegram_test.go
+++ b/pkg/integrations/telegram/telegram_test.go
@@ -1,0 +1,159 @@
+package telegram
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Telegram__MentionsBot(t *testing.T) {
+	t.Run("bot mentioned -> true", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "@mybot hello!",
+			Entities: []MessageEntity{{Type: "mention", Offset: 0, Length: 6}},
+		}
+
+		assert.True(t, mentionsBot(message, "mybot"))
+	})
+
+	t.Run("bot mentioned with different casing -> true", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "@MyBot hello!",
+			Entities: []MessageEntity{{Type: "mention", Offset: 0, Length: 6}},
+		}
+
+		assert.True(t, mentionsBot(message, "mybot"))
+	})
+
+	t.Run("another bot mentioned -> false", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "@otherbot hello!",
+			Entities: []MessageEntity{{Type: "mention", Offset: 0, Length: 9}},
+		}
+
+		assert.False(t, mentionsBot(message, "mybot"))
+	})
+
+	t.Run("non-mention entity -> false", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "/start@mybot",
+			Entities: []MessageEntity{{Type: "bot_command", Offset: 0, Length: 12}},
+		}
+
+		assert.False(t, mentionsBot(message, "mybot"))
+	})
+
+	t.Run("bot without a username -> false", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "@mybot hello!",
+			Entities: []MessageEntity{{Type: "mention", Offset: 0, Length: 6}},
+		}
+
+		assert.False(t, mentionsBot(message, ""))
+	})
+
+	//
+	// Telegram reports offsets in UTF-16 code units, so every character before the
+	// mention that is not a single UTF-8 byte shifts a byte-indexed slice.
+	//
+	t.Run("mention after a multi-byte character -> true", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "héllo @mybot",
+			Entities: []MessageEntity{{Type: "mention", Offset: 6, Length: 6}},
+		}
+
+		assert.True(t, mentionsBot(message, "mybot"))
+	})
+
+	t.Run("mention after an emoji -> true", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "👋 @mybot",
+			Entities: []MessageEntity{{Type: "mention", Offset: 3, Length: 6}},
+		}
+
+		assert.True(t, mentionsBot(message, "mybot"))
+	})
+
+	t.Run("mention after a CJK character -> true", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "こんにちは @mybot",
+			Entities: []MessageEntity{{Type: "mention", Offset: 6, Length: 6}},
+		}
+
+		assert.True(t, mentionsBot(message, "mybot"))
+	})
+
+	t.Run("entity out of range -> false", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "hi",
+			Entities: []MessageEntity{{Type: "mention", Offset: 0, Length: 100}},
+		}
+
+		assert.False(t, mentionsBot(message, "mybot"))
+	})
+
+	t.Run("negative entity offset -> false", func(t *testing.T) {
+		message := &TelegramMessage{
+			Text:     "@mybot",
+			Entities: []MessageEntity{{Type: "mention", Offset: -1, Length: 6}},
+		}
+
+		assert.False(t, mentionsBot(message, "mybot"))
+	})
+}
+
+func Test__Telegram__HandleRequest(t *testing.T) {
+	integration := &Telegram{}
+
+	handle := func(t *testing.T, body string) *httptest.ResponseRecorder {
+		t.Helper()
+
+		request := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/test/events", bytes.NewBufferString(body))
+		recorder := httptest.NewRecorder()
+
+		integration.HandleRequest(core.HTTPRequestContext{
+			Logger:   logrus.NewEntry(logrus.New()),
+			Request:  request,
+			Response: recorder,
+			Integration: &contexts.IntegrationContext{
+				Metadata: map[string]any{"botId": float64(42), "username": "mybot"},
+			},
+		})
+
+		return recorder
+	}
+
+	t.Run("invalid body -> 400", func(t *testing.T) {
+		assert.Equal(t, http.StatusBadRequest, handle(t, "not json").Code)
+	})
+
+	t.Run("update without a message -> 200", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, handle(t, `{"update_id": 1}`).Code)
+	})
+
+	t.Run("message without a mention -> 200", func(t *testing.T) {
+		body := `{"update_id": 1, "message": {"message_id": 1, "text": "hello", "chat": {"id": 1, "type": "group"}}}`
+
+		assert.Equal(t, http.StatusOK, handle(t, body).Code)
+	})
+
+	t.Run("entity out of range -> 200", func(t *testing.T) {
+		body := `{
+			"update_id": 1,
+			"message": {
+				"message_id": 1,
+				"text": "hi",
+				"chat": {"id": 1, "type": "group"},
+				"entities": [{"type": "mention", "offset": 0, "length": 100}]
+			}
+		}`
+
+		assert.Equal(t, http.StatusOK, handle(t, body).Code)
+	})
+}


### PR DESCRIPTION
## What changed

`Telegram.HandleRequest` decided whether a message mentioned the bot by slicing the message text with the entity's `offset` and `length`:

```go
mentionedText := update.Message.Text[entity.Offset : entity.Offset+entity.Length]
```

Telegram counts entity offsets and lengths in **UTF-16 code units**, not bytes. This converts the text to UTF-16 before slicing, bounds-checks the entity, and moves the check into a `mentionsBot` helper (mirroring `hasBotMention` in the Teams integration) so it can be tested directly.

## Why

Go string indexing is byte-based, so every character before the mention that is not a single UTF-8 byte shifts the slice. The extracted text then never matches the bot username, `isMention` stays false, and `telegram.onMention` silently does not fire — no error, no log line.

Running the old and new logic over the same inputs:

| message | entity | old | new |
| --- | --- | --- | --- |
| `@mybot hello!` | offset 0, len 6 | ✅ true | ✅ true |
| `héllo @mybot` | offset 6, len 6 | ❌ false | ✅ true |
| `👋 @mybot` | offset 3, len 6 | ❌ false | ✅ true |
| `こんにちは @mybot` | offset 6, len 6 | ❌ false | ✅ true |
| `hi` | offset 0, len 100 | 💥 `slice bounds out of range [:100] with length 2` | ✅ false |

Any group whose members write in a non-Latin script, or just send an emoji before the mention, gets a trigger that never fires. The last row is the same expression with an entity that overruns the text: byte length is always ≤ UTF-16 length for real Telegram payloads, but a malformed update panics the webhook handler, so the new helper bounds-checks the entity and skips it.

## How

- `mentionsBot(message, botUsername)` encodes `message.Text` with `utf16.Encode`, validates `offset`/`length` against the encoded length, and compares the decoded slice with `@<username>` using `strings.EqualFold` (unchanged casing behaviour).
- An empty bot username returns false rather than matching a bare `@`.

## Tests

New `pkg/integrations/telegram/telegram_test.go`:

- `Test__Telegram__MentionsBot` — ASCII, mixed casing, another bot, non-mention entity type, empty bot username, and the three multi-byte regressions above, plus out-of-range and negative offsets.
- `Test__Telegram__HandleRequest` — invalid body → 400; no message, no mention, and an out-of-range entity → 200 (the last one panicked before this change).

`gofmt`, `go vet` and `go test ./pkg/integrations/telegram/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWnN6TauLMRFWAq24ZZeK5