### PR TITLE
fix: Resolve schedule and time gate timezones with DST awareness

### DIFF
--- a/pkg/components/timegate/time_gate.go
+++ b/pkg/components/timegate/time_gate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -376,13 +375,12 @@ func (tg *TimeGate) parseTimezone(timezoneStr string) *time.Location {
 		return time.Local
 	}
 
-	offsetHours, err := strconv.ParseFloat(timezoneStr, 64)
+	location, err := configuration.LoadTimezone(timezoneStr)
 	if err != nil {
 		return time.UTC
 	}
-	offsetSeconds := int(offsetHours * 3600)
 
-	return time.FixedZone(fmt.Sprintf("GMT%+.1f", offsetHours), offsetSeconds)
+	return location
 }
 
 func parseTimeString(timeStr string) (int, error) {

--- a/pkg/components/timegate/time_gate_timezone_test.go
+++ b/pkg/components/timegate/time_gate_timezone_test.go
@@ -1,0 +1,65 @@
+package timegate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeGate_ParseTimezone_IANAIdentifierFollowsDST(t *testing.T) {
+	tg := &TimeGate{}
+
+	location := tg.parseTimezone("America/New_York")
+
+	_, winterOffset := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC).In(location).Zone()
+	_, summerOffset := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC).In(location).Zone()
+
+	assert.Equal(t, -5*3600, winterOffset)
+	assert.Equal(t, -4*3600, summerOffset)
+}
+
+func TestTimeGate_OpensInsideWindowDuringDST(t *testing.T) {
+	tg := &TimeGate{}
+
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	spec := Spec{
+		Days:      []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"},
+		TimeRange: "09:00-17:00",
+		Timezone:  "America/New_York",
+	}
+	require.NoError(t, tg.validateSpec(spec))
+
+	startMinutes, endMinutes, err := parseTimeRangeString(spec.TimeRange)
+	require.NoError(t, err)
+
+	//
+	// 13:30 UTC is 09:30 in New York while daylight saving is active, which is
+	// inside the configured window, so the gate must open immediately.
+	//
+	instant := time.Date(2026, 8, 5, 13, 30, 0, 0, time.UTC)
+	now := instant.In(tg.parseTimezone(spec.Timezone))
+
+	next := tg.findNextValidTime(now, spec, startMinutes, endMinutes)
+
+	assert.Equal(t, "09:30", next.In(newYork).Format("15:04"),
+		"gate should open now, not defer to a later window")
+}
+
+func TestTimeGate_ParseTimezone_NumericOffsetStillSupported(t *testing.T) {
+	tg := &TimeGate{}
+
+	_, offset := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC).In(tg.parseTimezone("-5")).Zone()
+	assert.Equal(t, -5*3600, offset)
+}
+
+func TestTimeGate_ParseTimezone_Fallbacks(t *testing.T) {
+	tg := &TimeGate{}
+
+	assert.Equal(t, time.Local, tg.parseTimezone(""))
+	assert.Equal(t, time.Local, tg.parseTimezone("current"))
+	assert.Equal(t, time.UTC, tg.parseTimezone("Mars/Olympus_Mons"))
+}

--- a/pkg/configuration/timezone.go
+++ b/pkg/configuration/timezone.go
@@ -1,0 +1,58 @@
+package configuration
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	// The timezone database is embedded so IANA lookups work in container
+	// images that do not ship the system tzdata package.
+	_ "time/tzdata"
+)
+
+const (
+	minTimezoneOffsetHours = -12
+	maxTimezoneOffsetHours = 14
+)
+
+// LoadTimezone resolves a timezone field value to a *time.Location.
+//
+// IANA identifiers such as "America/New_York" carry daylight saving rules, so
+// they resolve to the correct offset for whichever instant is being evaluated.
+//
+// Numeric offsets such as "-5" or "5.5" are still accepted, because
+// configurations saved before identifiers were supported store them. They
+// resolve to a fixed offset and therefore do not follow daylight saving.
+func LoadTimezone(value string) (*time.Location, error) {
+	if value == "" {
+		return nil, fmt.Errorf("timezone cannot be empty")
+	}
+
+	if offsetHours, err := strconv.ParseFloat(strings.TrimPrefix(value, "+"), 64); err == nil {
+		if offsetHours < minTimezoneOffsetHours || offsetHours > maxTimezoneOffsetHours {
+			return nil, fmt.Errorf("timezone offset must be between -12 and +14 hours, got: %g", offsetHours)
+		}
+
+		if offsetHours != float64(int(offsetHours)) && offsetHours != float64(int(offsetHours))+0.5 {
+			return nil, fmt.Errorf("timezone offset must be a whole number or half hour (e.g., 5.5), got: %g", offsetHours)
+		}
+
+		return time.FixedZone(fmt.Sprintf("GMT%+.1f", offsetHours), int(offsetHours*3600)), nil
+	}
+
+	//
+	// "Local" resolves to whatever timezone the server runs in, which makes the
+	// same configuration behave differently across deployments.
+	//
+	if value == "Local" {
+		return nil, fmt.Errorf("invalid timezone %q: use an IANA identifier like 'America/New_York'", value)
+	}
+
+	location, err := time.LoadLocation(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timezone %q: must be an IANA identifier like 'America/New_York' or a numeric offset like '-5'", value)
+	}
+
+	return location, nil
+}

--- a/pkg/configuration/timezone_test.go
+++ b/pkg/configuration/timezone_test.go
@@ -1,0 +1,77 @@
+package configuration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTimezone_IANAIdentifierFollowsDST(t *testing.T) {
+	location, err := LoadTimezone("America/New_York")
+	require.NoError(t, err)
+
+	winter := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC).In(location)
+	summer := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC).In(location)
+
+	_, winterOffset := winter.Zone()
+	_, summerOffset := summer.Zone()
+
+	assert.Equal(t, -5*3600, winterOffset, "New York is UTC-5 outside daylight saving")
+	assert.Equal(t, -4*3600, summerOffset, "New York is UTC-4 during daylight saving")
+}
+
+func TestLoadTimezone_NumericOffsetStaysFixed(t *testing.T) {
+	//
+	// Numeric offsets are still accepted for configurations saved before IANA
+	// identifiers were supported. They intentionally do not follow DST.
+	//
+	location, err := LoadTimezone("-5")
+	require.NoError(t, err)
+
+	_, offset := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC).In(location).Zone()
+	assert.Equal(t, -5*3600, offset)
+}
+
+func TestLoadTimezone_AcceptsHalfHourAndPlusPrefix(t *testing.T) {
+	location, err := LoadTimezone("5.5")
+	require.NoError(t, err)
+	_, offset := time.Now().In(location).Zone()
+	assert.Equal(t, 5*3600+1800, offset)
+
+	location, err = LoadTimezone("+8")
+	require.NoError(t, err)
+	_, offset = time.Now().In(location).Zone()
+	assert.Equal(t, 8*3600, offset)
+}
+
+func TestLoadTimezone_Invalid(t *testing.T) {
+	for _, tc := range []struct{ name, value string }{
+		{"empty", ""},
+		{"unknown identifier", "Mars/Olympus_Mons"},
+		{"offset below range", "-13"},
+		{"offset above range", "15"},
+		{"quarter hour offset", "5.75"},
+		{"server local", "Local"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadTimezone(tc.value)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestValidateTimezone(t *testing.T) {
+	field := Field{Name: "timezone", Type: FieldTypeTimezone}
+
+	for _, value := range []string{"America/New_York", "Europe/London", "UTC", "-5", "+8", "5.5"} {
+		assert.NoError(t, validateTimezone(field, value), "expected %q to be valid", value)
+	}
+
+	for _, value := range []string{"", "current", "Local", "Mars/Olympus_Mons", "-13", "5.75"} {
+		assert.Error(t, validateTimezone(field, value), "expected %q to be rejected", value)
+	}
+
+	assert.Error(t, validateTimezone(field, 5), "non-string values are rejected")
+}

--- a/pkg/configuration/validation.go
+++ b/pkg/configuration/validation.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -508,27 +507,11 @@ func validateTimezone(_ Field, value any) error {
 	}
 
 	if timezoneStr == "current" {
-		return fmt.Errorf("timezone value 'current' should be replaced with actual timezone offset before submission")
+		return fmt.Errorf("timezone value 'current' should be replaced with an actual timezone before submission")
 	}
 
-	var offsetHours float64
-	var err error
-
-	// Handle cases with or without + prefix
-	cleanTz := strings.TrimPrefix(timezoneStr, "+")
-	offsetHours, err = strconv.ParseFloat(cleanTz, 64)
-	if err != nil {
-		return fmt.Errorf("invalid timezone format: must be a numeric offset like '-5', '0', '5.5', or '+8'")
-	}
-
-	// Check valid range: UTC-12 to UTC+14
-	if offsetHours < -12 || offsetHours > 14 {
-		return fmt.Errorf("timezone offset must be between -12 and +14 hours, got: %g", offsetHours)
-	}
-
-	// Additional validation: only allow .5 decimal for half-hour timezones
-	if offsetHours != float64(int(offsetHours)) && offsetHours != float64(int(offsetHours))+0.5 {
-		return fmt.Errorf("timezone offset must be a whole number or half hour (e.g., 5.5), got: %g", offsetHours)
+	if _, err := LoadTimezone(timezoneStr); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -3,7 +3,6 @@ package schedule
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -656,13 +655,12 @@ func parseTimezone(timezoneStr *string) *time.Location {
 		return time.UTC
 	}
 
-	offsetHours, err := strconv.ParseFloat(*timezoneStr, 64)
+	location, err := configuration.LoadTimezone(*timezoneStr)
 	if err != nil {
 		return time.UTC
 	}
-	offsetSeconds := int(offsetHours * 3600)
 
-	return time.FixedZone(fmt.Sprintf("GMT%+.1f", offsetHours), offsetSeconds)
+	return location
 }
 
 func nextHoursTrigger(interval int, minute int, now time.Time) (*time.Time, error) {

--- a/pkg/triggers/schedule/schedule_timezone_test.go
+++ b/pkg/triggers/schedule/schedule_timezone_test.go
@@ -1,0 +1,61 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimezone_IANAIdentifierFollowsDST(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	identifier := "America/New_York"
+	hour, minute, interval := 9, 0, 1
+
+	config := Configuration{
+		Type:         TypeDays,
+		DaysInterval: &interval,
+		Hour:         &hour,
+		Minute:       &minute,
+		Timezone:     &identifier,
+	}
+
+	//
+	// A daily 09:00 schedule must fire at 09:00 local time on both sides of a
+	// daylight saving transition.
+	//
+	for _, tc := range []struct {
+		name    string
+		instant time.Time
+	}{
+		{"outside daylight saving", time.Date(2026, 1, 15, 3, 0, 0, 0, time.UTC)},
+		{"during daylight saving", time.Date(2026, 8, 5, 3, 0, 0, 0, time.UTC)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			next, err := getNextTrigger(config, tc.instant, nil)
+			require.NoError(t, err)
+			assert.Equal(t, "09:00", next.In(newYork).Format("15:04"))
+		})
+	}
+}
+
+func TestParseTimezone_NumericOffsetStillSupported(t *testing.T) {
+	offset := "-5"
+	location := parseTimezone(&offset)
+
+	_, seconds := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC).In(location).Zone()
+	assert.Equal(t, -5*3600, seconds)
+}
+
+func TestParseTimezone_FallsBackToUTC(t *testing.T) {
+	assert.Equal(t, time.UTC, parseTimezone(nil))
+
+	empty := ""
+	assert.Equal(t, time.UTC, parseTimezone(&empty))
+
+	invalid := "Mars/Olympus_Mons"
+	assert.Equal(t, time.UTC, parseTimezone(&invalid))
+}

--- a/web_src/src/ui/configurationFieldRenderer/TimezoneFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TimezoneFieldRenderer.spec.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConfigurationField } from "@/api-client";
+
+import { TimezoneFieldRenderer } from "./TimezoneFieldRenderer";
+
+const field: ConfigurationField = {
+  name: "timezone",
+  label: "Timezone",
+  type: "timezone",
+};
+
+describe("TimezoneFieldRenderer", () => {
+  it("resolves the 'current' placeholder to the browser timezone identifier", () => {
+    const onChange = vi.fn();
+
+    render(<TimezoneFieldRenderer field={field} value="current" onChange={onChange} />);
+
+    const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    expect(onChange).toHaveBeenCalledWith(resolved);
+    expect(resolved).toMatch(/^[A-Za-z]+(\/[A-Za-z_+-]+)*$/);
+  });
+
+  it("resolves an unset value to the browser timezone identifier", () => {
+    const onChange = vi.fn();
+
+    render(<TimezoneFieldRenderer field={field} value={undefined} onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  });
+
+  it("offers IANA identifiers so daylight saving is applied", () => {
+    render(<TimezoneFieldRenderer field={field} value="America/New_York" onChange={vi.fn()} />);
+
+    const selected = screen.getByText(/America\/New_York/);
+    expect(selected).toBeInTheDocument();
+
+    fireEvent.click(selected);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Europe/Paris" } });
+
+    expect(screen.getByText(/Europe\/Paris/)).toBeInTheDocument();
+  });
+
+  it("keeps a legacy numeric offset selectable", () => {
+    const onChange = vi.fn();
+
+    render(<TimezoneFieldRenderer field={field} value="-5" onChange={onChange} />);
+
+    // The stored value stays put rather than being silently rewritten.
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText(/GMT-5 \(fixed offset\)/)).toBeInTheDocument();
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/TimezoneFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TimezoneFieldRenderer.tsx
@@ -1,85 +1,142 @@
-import React, { useEffect, useRef } from "react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import React, { useEffect, useMemo, useRef } from "react";
+import { AutoCompleteSelect } from "@/components/AutoCompleteSelect/AutoCompleteSelect";
 import type { FieldRendererProps } from "./types";
 import { toTestId } from "@/lib/testID";
 
-// Function to get user's current timezone offset as a string (e.g., "-5", "0", "5.5")
-const getUserTimezoneOffset = (): string => {
-  const offset = -new Date().getTimezoneOffset() / 60;
-  return offset.toString();
-};
-
-// Timezone options with labels and values
-const timezoneOptions = [
-  { label: "GMT-12 (Baker Island)", value: "-12" },
-  { label: "GMT-11 (American Samoa)", value: "-11" },
-  { label: "GMT-10 (Hawaii)", value: "-10" },
-  { label: "GMT-9 (Alaska)", value: "-9" },
-  { label: "GMT-8 (Los Angeles, Vancouver)", value: "-8" },
-  { label: "GMT-7 (Denver, Phoenix)", value: "-7" },
-  { label: "GMT-6 (Chicago, Mexico City)", value: "-6" },
-  { label: "GMT-5 (New York, Toronto)", value: "-5" },
-  { label: "GMT-4 (Santiago, Atlantic)", value: "-4" },
-  { label: "GMT-3 (São Paulo, Buenos Aires)", value: "-3" },
-  { label: "GMT-2 (South Georgia)", value: "-2" },
-  { label: "GMT-1 (Azores)", value: "-1" },
-  { label: "GMT+0 (London, Dublin, UTC)", value: "0" },
-  { label: "GMT+1 (Paris, Berlin, Rome)", value: "1" },
-  { label: "GMT+2 (Cairo, Helsinki, Athens)", value: "2" },
-  { label: "GMT+3 (Moscow, Istanbul, Riyadh)", value: "3" },
-  { label: "GMT+4 (Dubai, Baku)", value: "4" },
-  { label: "GMT+5 (Karachi, Tashkent)", value: "5" },
-  { label: "GMT+5:30 (Mumbai, Delhi)", value: "5.5" },
-  { label: "GMT+6 (Dhaka, Almaty)", value: "6" },
-  { label: "GMT+7 (Bangkok, Jakarta)", value: "7" },
-  { label: "GMT+8 (Beijing, Singapore, Perth)", value: "8" },
-  { label: "GMT+9 (Tokyo, Seoul)", value: "9" },
-  { label: "GMT+9:30 (Adelaide)", value: "9.5" },
-  { label: "GMT+10 (Sydney, Melbourne)", value: "10" },
-  { label: "GMT+11 (Solomon Islands)", value: "11" },
-  { label: "GMT+12 (Auckland, Fiji)", value: "12" },
-  { label: "GMT+13 (Tonga, Samoa)", value: "13" },
-  { label: "GMT+14 (Kiribati)", value: "14" },
+const FALLBACK_TIMEZONES = [
+  "UTC",
+  "America/Anchorage",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/New_York",
+  "America/Phoenix",
+  "America/Sao_Paulo",
+  "America/Toronto",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Melbourne",
+  "Australia/Sydney",
+  "Europe/Berlin",
+  "Europe/Dublin",
+  "Europe/London",
+  "Europe/Madrid",
+  "Europe/Paris",
+  "Pacific/Auckland",
+  "Pacific/Honolulu",
 ];
 
-export const TimezoneFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange }) => {
+/**
+ * Every IANA timezone the browser knows about, falling back to a short list on
+ * engines without Intl.supportedValuesOf.
+ */
+function listTimezones(): string[] {
+  const supportedValuesOf = (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf;
+
+  if (typeof supportedValuesOf === "function") {
+    try {
+      const zones = supportedValuesOf("timeZone");
+      if (zones.length > 0) {
+        return zones;
+      }
+    } catch {
+      // fall through to the static list
+    }
+  }
+
+  return FALLBACK_TIMEZONES;
+}
+
+function getBrowserTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+/**
+ * Current UTC offset for a timezone, e.g. "GMT-4". Shown next to the identifier
+ * so the list stays scannable. It reflects daylight saving, so the same zone can
+ * read differently depending on the time of year.
+ */
+function formatOffset(timeZone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "shortOffset",
+    }).formatToParts(new Date());
+
+    return parts.find((part) => part.type === "timeZoneName")?.value ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Legacy configurations stored a bare UTC offset such as "-5" instead of an
+ * identifier. Those values still work, so they are kept selectable rather than
+ * silently replaced.
+ */
+function isLegacyOffset(value: string): boolean {
+  return /^[+-]?\d+(\.\d+)?$/.test(value);
+}
+
+export const TimezoneFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange, hasError }) => {
   const hasSetDefault = useRef(false);
   const testId = field.name ? toTestId(`field-${field.name}-select`) : undefined;
 
-  // Set user's current timezone as default on first render if no value is present
-  // or if the value is "current" (which signals to use user's timezone)
-  useEffect(() => {
-    if (!hasSetDefault.current && (value === undefined || value === null || value === "current")) {
-      const userTimezone = getUserTimezoneOffset();
-      // Use user's timezone if it matches one of our options, otherwise fallback to "0" (UTC)
-      const defaultTimezone = timezoneOptions.find((tz) => tz.value === userTimezone) ? userTimezone : "0";
+  const options = useMemo(() => {
+    const timezones = listTimezones().map((timeZone) => {
+      const offset = formatOffset(timeZone);
+      const [group] = timeZone.split("/");
 
-      onChange(defaultTimezone);
+      return {
+        value: timeZone,
+        label: offset ? `${timeZone} (${offset})` : timeZone,
+        group: timeZone.includes("/") ? group : "Other",
+      };
+    });
+
+    //
+    // Keep a stored legacy offset visible so opening an existing configuration
+    // does not blank the field.
+    //
+    const current = typeof value === "string" ? value : "";
+    if (current && isLegacyOffset(current)) {
+      timezones.unshift({
+        value: current,
+        label: `GMT${current.startsWith("-") ? current : `+${current.replace("+", "")}`} (fixed offset)`,
+        group: "Other",
+      });
+    }
+
+    return timezones;
+  }, [value]);
+
+  //
+  // "current" is a placeholder the backend rejects, so it is resolved to the
+  // browser's timezone before anything is submitted.
+  //
+  useEffect(() => {
+    if (hasSetDefault.current) return;
+
+    if (value === undefined || value === null || value === "current") {
+      onChange(getBrowserTimezone());
       hasSetDefault.current = true;
     }
-  }, [value, field.defaultValue, onChange]);
+  }, [value, onChange]);
 
-  // Get the display value - if value is "current", show user's timezone
-  const displayValue = (() => {
-    if (value === "current") {
-      const userTimezone = getUserTimezoneOffset();
-      return timezoneOptions.find((tz) => tz.value === userTimezone)?.value ?? "0";
-    }
-    return (value as string) ?? "0";
-  })();
+  const displayValue = typeof value === "string" && value !== "current" ? value : "";
 
   return (
-    <Select value={displayValue} onValueChange={(val) => onChange(val || undefined)}>
-      <SelectTrigger className="w-full" data-testid={testId}>
-        <SelectValue placeholder={`Select ${field.label || field.name}`} />
-      </SelectTrigger>
-      <SelectContent className="max-h-60">
-        {timezoneOptions.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            {option.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <div data-testid={testId}>
+      <AutoCompleteSelect
+        options={options}
+        value={displayValue}
+        onChange={onChange}
+        placeholder={`Select ${field.label || field.name}`}
+        error={hasError}
+      />
+    </div>
   );
 };


### PR DESCRIPTION
## What changed

The timezone dropdown showed city names like **"GMT-5 (New York, Toronto)"** but only saved the number `-5`.

A number never changes. New York is `-5` in winter and `-4` in summer. So schedules and time gates ran an hour late whenever a city was on daylight saving time.

This PR makes them use real timezone names like `America/New_York`, which follow daylight saving correctly.

## Why

A daily 09:00 schedule set to "New York" actually fired at 10:00 New York time from March to November. There was no error and no warning — the settings still said "New York".

**13 of the 29 options** in the dropdown were wrong for part of every year, including New York, London, Paris, Berlin, Sydney, Chicago and Los Angeles.

Two options could never be right at all:

- *"GMT-7 (Denver, Phoenix)"* — Denver observes DST, Phoenix does not
- *"GMT-6 (Chicago, Mexico City)"* — Mexico stopped observing DST in 2022

Fixes #6565

## How

- Added `configuration.LoadTimezone`, one shared helper that turns a stored value into a `*time.Location`. Validation and both callers now use it, so they cannot drift apart.
- `Schedule` and `Time Gate` resolve timezones through that helper instead of building a `time.FixedZone`.
- `validateTimezone` now accepts IANA names as well as numeric offsets.
- The dropdown is now a searchable list of real timezone names, defaulting to the browser's own timezone. It uses `AutoCompleteSelect`, the same component the other field renderers use.
- The timezone database is embedded with a blank `time/tzdata` import, so lookups work in container images that do not ship system tzdata.

## Backward compatibility

Old numeric values like `-5` still work and keep their current fixed-offset behaviour, so no existing configuration breaks and nothing needs migrating.

Those configurations stay on a fixed offset until someone re-picks the timezone. I did not add an automatic migration because mapping an old offset to a real timezone is a guess — `-7` could be Denver or Phoenix, and they behave differently. Happy to add one if you'd prefer a specific mapping.

## Tests

- `pkg/configuration/timezone_test.go` — the helper follows DST for IANA names, keeps numeric offsets fixed, and rejects bad values
- `pkg/triggers/schedule/schedule_timezone_test.go` — a daily 09:00 schedule fires at 09:00 New York time on both sides of a DST change
- `pkg/components/timegate/time_gate_timezone_test.go` — a 09:00-17:00 gate opens immediately when it is 09:30 in New York during DST
- `web_src/src/ui/configurationFieldRenderer/TimezoneFieldRenderer.spec.tsx` — the picker submits IANA names and keeps a stored legacy offset visible

The existing `TestTimezoneHandling` suite still passes unchanged, which confirms numeric offsets behave exactly as before.
