### PR TITLE
feat: detect CLI/server version skew via response header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,8 @@ COPY protos /app/protos
 COPY api/swagger /app/api/swagger
 COPY rbac /app/rbac
 COPY templates /app/templates
-RUN rm -rf build && go build -o build/superplane cmd/server/main.go
+ARG VERSION="dev"
+RUN rm -rf build && go build -ldflags "-X github.com/superplanehq/superplane/pkg/buildinfo.Version=${VERSION}" -o build/superplane cmd/server/main.go
 
 WORKDIR /app/web_src
 RUN if [ "$FRONTEND_PREBUILT" = "1" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -369,7 +369,7 @@ CLI_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 
 cli.build:
 	$(MAKE) pb.gen
-	$(COMPOSE) exec -e GOOS=$(OS) -e GOARCH=$(ARCH) app bash -c 'go build -ldflags "-X github.com/superplanehq/superplane/pkg/cli.Version=$(CLI_VERSION)" -o build/cli cmd/cli/main.go'
+	$(COMPOSE) exec -e GOOS=$(OS) -e GOARCH=$(ARCH) app bash -c 'go build -ldflags "-X github.com/superplanehq/superplane/pkg/buildinfo.Version=$(CLI_VERSION)" -o build/cli cmd/cli/main.go'
 
 cli.build.m1:
 	$(MAKE) cli.build OS=darwin ARCH=arm64

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,0 +1,15 @@
+// Package buildinfo holds build-time metadata shared by the server and CLI.
+package buildinfo
+
+// Version is the release version of this build.
+// It is set at build time via -ldflags:
+//
+//	go build -ldflags "-X github.com/superplanehq/superplane/pkg/buildinfo.Version=v1.2.3"
+//
+// Defaults to "dev" for development builds.
+var Version = "dev"
+
+// VersionHeader is the HTTP response header the server stamps with Version and
+// the CLI reads back to detect version skew. Kept here so the server and CLI
+// share one definition and cannot drift on the header name.
+const VersionHeader = "X-Superplane-Version"

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
+	"github.com/superplanehq/superplane/pkg/buildinfo"
+	"github.com/superplanehq/superplane/pkg/cli/core"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
@@ -32,14 +35,61 @@ func methodSafeRedirectPolicy() func(*http.Request, []*http.Request) error {
 	}
 }
 
+// serverVersionTransport wraps an http.RoundTripper and remembers the
+// buildinfo.VersionHeader value from the most recent response, so the CLI
+// can detect version skew without a dedicated second request. Transports are
+// safe to share across http.Client instances, so a single package-level
+// instance backs every client the CLI builds.
+type serverVersionTransport struct {
+	next http.RoundTripper
+
+	mu      sync.RWMutex
+	version string
+}
+
+func (t *serverVersionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.next.RoundTrip(req)
+	if err == nil {
+		t.mu.Lock()
+		t.version = resp.Header.Get(buildinfo.VersionHeader)
+		t.mu.Unlock()
+	}
+	return resp, err
+}
+
+var sharedServerVersionTransport = &serverVersionTransport{next: http.DefaultTransport}
+
+// ServerVersion returns the server version reported by the most recent API
+// response, if any response has been received yet. Servers that predate
+// version reporting answer without the header, which is reported as
+// core.ErrServerVersionUnavailable.
+func ServerVersion() (string, error) {
+	sharedServerVersionTransport.mu.RLock()
+	version := sharedServerVersionTransport.version
+	sharedServerVersionTransport.mu.RUnlock()
+
+	if version == "" {
+		return "", core.ErrServerVersionUnavailable
+	}
+	return version, nil
+}
+
+// defaultHTTPClient is used by every API client the CLI builds unless a
+// caller explicitly overrides ClientConfig.HTTPClient, so all of them route
+// through sharedServerVersionTransport and ServerVersion stays accurate.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:       time.Second * 30,
+		CheckRedirect: methodSafeRedirectPolicy(),
+		Transport:     sharedServerVersionTransport,
+	}
+}
+
 func NewClientConfig() *ClientConfig {
 	return &ClientConfig{
-		BaseURL:  GetAPIURL(),
-		APIToken: GetAPIToken(),
-		HTTPClient: &http.Client{
-			Timeout:       time.Second * 30,
-			CheckRedirect: methodSafeRedirectPolicy(),
-		},
+		BaseURL:    GetAPIURL(),
+		APIToken:   GetAPIToken(),
+		HTTPClient: defaultHTTPClient(),
 	}
 }
 
@@ -56,8 +106,9 @@ func NewAPIClient(config *ClientConfig) *openapi_client.APIClient {
 		apiConfig.DefaultHeader["Authorization"] = "Bearer " + config.APIToken
 	}
 
-	if config.HTTPClient != nil {
-		apiConfig.HTTPClient = config.HTTPClient
+	apiConfig.HTTPClient = config.HTTPClient
+	if apiConfig.HTTPClient == nil {
+		apiConfig.HTTPClient = defaultHTTPClient()
 	}
 
 	return openapi_client.NewAPIClient(apiConfig)

--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -49,10 +50,15 @@ func (c *ConnectCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
+	serverVersion, serverVersionErr := ServerVersion()
+
 	if ctx.Renderer.IsText() {
 		return ctx.Renderer.RenderText(func(stdout io.Writer) error {
 			_, err := fmt.Fprintf(stdout, "Connected to %q (%s)\n", orgName, saved.URL)
 			if err != nil {
+				return err
+			}
+			if err := writeServerVersionInfo(stdout, serverVersion, serverVersionErr); err != nil {
 				return err
 			}
 			_, err = fmt.Fprintf(stdout, "%s\n", core.AgentSkillsHint())
@@ -60,11 +66,36 @@ func (c *ConnectCommand) Execute(ctx core.CommandContext) error {
 		})
 	}
 
-	return ctx.Renderer.Render(map[string]any{
+	result := map[string]any{
 		"organization":   orgName,
 		"organizationId": orgID,
 		"url":            baseURL,
-	})
+	}
+	if serverVersionErr == nil {
+		result["serverVersion"] = serverVersion
+	}
+
+	return ctx.Renderer.Render(result)
+}
+
+func writeServerVersionInfo(stdout io.Writer, serverVersion string, serverVersionErr error) error {
+	if errors.Is(serverVersionErr, core.ErrServerVersionUnavailable) {
+		_, err := fmt.Fprintf(stdout,
+			"Server version: unknown (the server predates version reporting). If commands fail with \"not found\", use a CLI release matching your server.\n")
+		return err
+	}
+
+	if _, err := fmt.Fprintf(stdout, "Server version: %s\n", serverVersion); err != nil {
+		return err
+	}
+
+	if !isDevBuild() && serverVersion != "dev" && isNewerVersion(serverVersion, Version) {
+		_, err := fmt.Fprintf(stdout,
+			"Warning: CLI version %s is newer than server version %s. Commands added after %s may fail with \"not found\"; use a matching CLI release for best results.\n",
+			Version, serverVersion, serverVersion)
+		return err
+	}
+	return nil
 }
 
 var connectCmd = &cobra.Command{

--- a/pkg/cli/core/command.go
+++ b/pkg/cli/core/command.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/mattn/go-isatty"
@@ -47,6 +48,12 @@ type BindOptions struct {
 	NewAPIClient        func() *openapi_client.APIClient
 	NewConfigContext    func() ConfigContext
 	DefaultOutputFormat func() string
+	// CLIVersion and ServerVersion feed the version-skew hint that is
+	// appended to "not found" API errors, which on self-hosted servers
+	// usually mean the CLI is newer than the server. Both are optional;
+	// the hint is skipped when either is unset.
+	CLIVersion    string
+	ServerVersion func(ctx context.Context) (string, error)
 }
 
 func NewCommandContext(cmd *cobra.Command, args []string, options BindOptions) (CommandContext, error) {
@@ -95,6 +102,18 @@ func Bind(cmd *cobra.Command, command Command, options BindOptions) {
 			return err
 		}
 
-		return FormatCommandError(command.Execute(ctx))
+		execErr := command.Execute(ctx)
+		formatted := FormatCommandError(execErr)
+		if formatted == nil {
+			return nil
+		}
+
+		// The skew check runs on the raw error because formatting
+		// flattens the API error into a plain string.
+		if hint := VersionSkewHint(ctx.Context, execErr, options); hint != "" {
+			return fmt.Errorf("%s\n%s", formatted.Error(), hint)
+		}
+
+		return formatted
 	}
 }

--- a/pkg/cli/core/semver.go
+++ b/pkg/cli/core/semver.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IsNewerVersion returns true if latest is a newer semver than current.
+// Both may optionally have a "v" prefix.
+func IsNewerVersion(current, latest string) bool {
+	current = strings.TrimPrefix(current, "v")
+	latest = strings.TrimPrefix(latest, "v")
+
+	if current == latest {
+		return false
+	}
+
+	var cMajor, cMinor, cPatch int
+	var lMajor, lMinor, lPatch int
+
+	fmt.Sscanf(current, "%d.%d.%d", &cMajor, &cMinor, &cPatch)
+	fmt.Sscanf(latest, "%d.%d.%d", &lMajor, &lMinor, &lPatch)
+
+	if lMajor != cMajor {
+		return lMajor > cMajor
+	}
+
+	if lMinor != cMinor {
+		return lMinor > cMinor
+	}
+
+	return lPatch > cPatch
+}

--- a/pkg/cli/core/serverversion.go
+++ b/pkg/cli/core/serverversion.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+	"google.golang.org/grpc/codes"
+)
+
+// ErrServerVersionUnavailable means the server answered but does not expose
+// the version endpoint, i.e. it predates version reporting.
+var ErrServerVersionUnavailable = errors.New("server does not report its version")
+
+const serverVersionTimeout = 3 * time.Second
+
+// VersionSkewHint explains "not found" API errors that are typically caused
+// by version skew on self-hosted installations: the CLI calls an endpoint
+// that does not exist on the (older) server. It returns an empty string when
+// the error is not a not-found API error, when versions match, or when the
+// server version cannot be determined reliably.
+func VersionSkewHint(ctx context.Context, err error, options BindOptions) string {
+	if err == nil || options.CLIVersion == "" || options.CLIVersion == "dev" || options.ServerVersion == nil {
+		return ""
+	}
+
+	if !isRouteNotFoundAPIError(err) {
+		return ""
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, serverVersionTimeout)
+	defer cancel()
+
+	serverVersion, versionErr := options.ServerVersion(checkCtx)
+	switch {
+	case errors.Is(versionErr, ErrServerVersionUnavailable):
+		return fmt.Sprintf(
+			"hint: this CLI is %s but the server does not report its version, so it likely predates this command. Use a CLI release matching your server, or upgrade the server.",
+			options.CLIVersion,
+		)
+	case versionErr != nil:
+		return ""
+	case serverVersion != "dev" && IsNewerVersion(serverVersion, options.CLIVersion):
+		return fmt.Sprintf(
+			"hint: CLI version %s is newer than server version %s, so this command's API may not exist on the server yet. Use a matching CLI release, or upgrade the server.",
+			options.CLIVersion, serverVersion,
+		)
+	default:
+		return ""
+	}
+}
+
+// isRouteNotFoundAPIError reports whether the error looks like a missing
+// ROUTE rather than a missing resource. The grpc-gateway answers unknown
+// paths with the generic "Not Found" message, while handlers that miss a
+// resource return descriptive messages such as "canvas not found"; only the
+// former suggests version skew.
+func isRouteNotFoundAPIError(err error) bool {
+	var apiErr *openapi_client.GenericOpenAPIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	if status := extractGoogleRPCStatus(apiErr); status != nil {
+		return codes.Code(status.GetCode()) == codes.NotFound &&
+			strings.EqualFold(strings.TrimSpace(status.GetMessage()), "Not Found")
+	}
+
+	return strings.Contains(apiErr.Error(), "404")
+}

--- a/pkg/cli/core/serverversion_test.go
+++ b/pkg/cli/core/serverversion_test.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+func TestVersionSkewHintForMismatchedVersions(t *testing.T) {
+	err := notFoundAPIError(t)
+
+	hint := VersionSkewHint(context.Background(), err, BindOptions{
+		CLIVersion: "v0.30.0",
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return "v0.26.0", nil
+		},
+	})
+
+	require.Contains(t, hint, "v0.30.0")
+	require.Contains(t, hint, "v0.26.0")
+	require.Contains(t, hint, "matching CLI release")
+}
+
+func TestVersionSkewHintWhenServerVersionUnavailable(t *testing.T) {
+	err := notFoundAPIError(t)
+
+	hint := VersionSkewHint(context.Background(), err, BindOptions{
+		CLIVersion: "v0.30.0",
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return "", ErrServerVersionUnavailable
+		},
+	})
+
+	require.Contains(t, hint, "does not report its version")
+	require.Contains(t, hint, "v0.30.0")
+}
+
+func TestVersionSkewHintSilentWhenServerIsNewer(t *testing.T) {
+	// A server newer than the CLI is not the version-skew case this hint
+	// covers: an older CLI predates the endpoint but a "not found" there is
+	// far more likely a genuine routing issue, not skew.
+	err := notFoundAPIError(t)
+
+	hint := VersionSkewHint(context.Background(), err, BindOptions{
+		CLIVersion: "v0.26.0",
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return "v0.30.0", nil
+		},
+	})
+
+	require.Empty(t, hint)
+}
+
+func TestVersionSkewHintSilentWhenVersionsMatch(t *testing.T) {
+	err := notFoundAPIError(t)
+
+	hint := VersionSkewHint(context.Background(), err, BindOptions{
+		CLIVersion: "v0.30.0",
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return "v0.30.0", nil
+		},
+	})
+
+	require.Empty(t, hint)
+}
+
+func TestVersionSkewHintSilentForNonNotFoundErrors(t *testing.T) {
+	code := int32(3)
+	message := "invalid request"
+	err := runAPICallWithResponse(t, http.StatusBadRequest, "application/json",
+		mustJSON(t, openapi_client.GooglerpcStatus{Code: &code, Message: &message}))
+
+	hint := VersionSkewHint(context.Background(), err, BindOptions{
+		CLIVersion: "v0.30.0",
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return "v0.26.0", nil
+		},
+	})
+
+	require.Empty(t, hint)
+}
+
+func TestVersionSkewHintSilentForDevBuilds(t *testing.T) {
+	err := notFoundAPIError(t)
+
+	hint := VersionSkewHint(context.Background(), err, BindOptions{
+		CLIVersion: "dev",
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return "v0.26.0", nil
+		},
+	})
+
+	require.Empty(t, hint)
+}
+
+func TestVersionSkewHintSilentWhenServerVersionCheckFails(t *testing.T) {
+	err := notFoundAPIError(t)
+
+	hint := VersionSkewHint(context.Background(), err, BindOptions{
+		CLIVersion: "v0.30.0",
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return "", context.DeadlineExceeded
+		},
+	})
+
+	require.Empty(t, hint)
+}
+
+// notFoundAPIError reproduces what a CLI newer than the server receives: the
+// grpc-gateway on the server answers 404 with a google.rpc.Status body.
+func notFoundAPIError(t *testing.T) error {
+	t.Helper()
+
+	code := int32(5)
+	message := "Not Found"
+	return runAPICallWithResponse(t, http.StatusNotFound, "application/json",
+		mustJSON(t, openapi_client.GooglerpcStatus{Code: &code, Message: &message}))
+}
+
+func TestVersionSkewHintSilentForResourceNotFound(t *testing.T) {
+	// A descriptive not-found means the route exists and the resource does
+	// not; version skew is not the cause, so no hint.
+	code := int32(5)
+	message := "canvas not found"
+	err := runAPICallWithResponse(t, http.StatusNotFound, "application/json",
+		mustJSON(t, openapi_client.GooglerpcStatus{Code: &code, Message: &message}))
+
+	hint := VersionSkewHint(context.Background(), err, BindOptions{
+		CLIVersion: "v0.30.0",
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return "v0.26.0", nil
+		},
+	})
+
+	require.Empty(t, hint)
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -106,6 +107,10 @@ func defaultBindOptions() core.BindOptions {
 	return core.BindOptions{
 		NewAPIClient:        DefaultClient,
 		DefaultOutputFormat: GetOutputFormat,
+		CLIVersion:          Version,
+		ServerVersion: func(ctx context.Context) (string, error) {
+			return ServerVersion()
+		},
 		NewConfigContext: func() core.ConfigContext {
 			if context, ok := GetEnvironmentContext(); ok {
 				return NewEnvironmentContext(context)

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -8,11 +8,14 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/buildinfo"
+	"github.com/superplanehq/superplane/pkg/cli/core"
 )
 
-// Version is set at build time via -ldflags.
-// Defaults to "dev" for development builds.
-var Version = "dev"
+// Version is the CLI's release version. It shares buildinfo.Version's
+// -ldflags stamp with the server, so the CLI and server binaries cannot
+// carry drifted version strings from two independently-stamped vars.
+var Version = buildinfo.Version
 
 var updateCheckResult <-chan *updateInfo
 
@@ -146,26 +149,5 @@ func buildUpdateNotice(currentVersion string, release *releaseInfo, goos, goarch
 // isNewerVersion returns true if latest is a newer semver than current.
 // Both may optionally have a "v" prefix.
 func isNewerVersion(current, latest string) bool {
-	current = strings.TrimPrefix(current, "v")
-	latest = strings.TrimPrefix(latest, "v")
-
-	if current == latest {
-		return false
-	}
-
-	var cMajor, cMinor, cPatch int
-	var lMajor, lMinor, lPatch int
-
-	fmt.Sscanf(current, "%d.%d.%d", &cMajor, &cMinor, &cPatch)
-	fmt.Sscanf(latest, "%d.%d.%d", &lMajor, &lMinor, &lPatch)
-
-	if lMajor != cMajor {
-		return lMajor > cMajor
-	}
-
-	if lMinor != cMinor {
-		return lMinor > cMinor
-	}
-
-	return lPatch > cPatch
+	return core.IsNewerVersion(current, latest)
 }

--- a/pkg/public/middleware/version_header.go
+++ b/pkg/public/middleware/version_header.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/superplanehq/superplane/pkg/buildinfo"
+)
+
+func VersionHeaderMiddleware(version string) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(buildinfo.VersionHeader, version)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/buildinfo"
 	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/database"
@@ -378,6 +379,8 @@ func (s *Server) RegisterGRPCGateway(services *grpc.Services) error {
 		w.WriteHeader(http.StatusOK)
 	}).Methods("GET")
 
+	s.Router.HandleFunc("/api/v1/version", serveVersion).Methods("GET")
+
 	s.Router.Handle(
 		"/api/v1/canvases/{canvas_id}/node-executions/{execution_id}/runner-live-logs/session",
 		middleware.OrganizationAuthMiddleware(s.jwt)(http.HandlerFunc(s.handleRunnerLiveLogSession)),
@@ -592,6 +595,7 @@ func (s *Server) InitRouter(additionalMiddlewares ...mux.MiddlewareFunc) {
 			next.ServeHTTP(w, withOtelMetricRoute(r))
 		})
 	})
+	r.Use(middleware.VersionHeaderMiddleware(buildinfo.Version))
 	r.Use(middleware.CriticalHTTPTraceMiddleware(resolveCriticalHTTPRoute))
 	r.Use(otelmux.Middleware(
 		"superplane-public-api",

--- a/pkg/public/version.go
+++ b/pkg/public/version.go
@@ -1,0 +1,20 @@
+package public
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/superplanehq/superplane/pkg/buildinfo"
+)
+
+type versionResponse struct {
+	Version string `json:"version"`
+}
+
+// serveVersion reports the server release version. It is public and
+// unauthenticated so that clients (mainly the CLI) can detect version skew
+// against self-hosted installations before or after authentication.
+func serveVersion(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(versionResponse{Version: buildinfo.Version})
+}

--- a/pkg/public/version_test.go
+++ b/pkg/public/version_test.go
@@ -1,0 +1,29 @@
+package public
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/buildinfo"
+)
+
+func TestServeVersion(t *testing.T) {
+	previous := buildinfo.Version
+	buildinfo.Version = "v9.9.9-test"
+	t.Cleanup(func() { buildinfo.Version = previous })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	rec := httptest.NewRecorder()
+
+	serveVersion(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var payload versionResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	require.Equal(t, "v9.9.9-test", payload.Version)
+}

--- a/release/superplane-image/build.sh
+++ b/release/superplane-image/build.sh
@@ -48,6 +48,7 @@ docker buildx build \
   --push \
   --target runner \
   --cache-from "${DEV_BASE_IMAGE_REPO}:app-latest-${ARCH}" \
+  --build-arg VERSION="${VERSION}" \
   -t "${IMAGE_REPO}:${VERSION}-${ARCH}" \
   -f Dockerfile \
   .


### PR DESCRIPTION
## Summary

- The CLI now reads the `X-Superplane-Version` header the server already stamps on every response, instead of making a dedicated `GET /api/v1/version` request to check for skew.
- A CLI newer than the server calling a route that doesn't exist yet used to surface as a bare "Not Found". This adds a hint pointing at version skew as the likely cause, and a warning on `connect` when the CLI is ahead of the server.

## What changed

- Added a shared `http.RoundTripper` (`serverVersionTransport`) that captures the version header off responses the CLI already makes, removing the need for a second request. Deleted the old `FetchServerVersion` two-request path.
- Defaulted every API client's `HTTPClient` inside `NewAPIClient` rather than requiring each caller to opt in, fixing a bug where the `connect` command built its own `ClientConfig` and silently bypassed the transport.
- Warnings only fire when the CLI is semver-newer than the server (`IsNewerVersion`), not on any difference, and stay silent when either side is a dev build.
- Collapsed `pkg/cli.Version` into `buildinfo.Version` so the CLI and server share one `-ldflags` stamp instead of two that can drift.
- Passed `--build-arg VERSION` in the release image build script, which was missing, so released servers stop reporting `dev`.

## Test plan

- [x] `go test ./pkg/cli/...` — full suite passes, including new `VersionSkewHint`/`IsNewerVersion` tests
- [x] `go test ./pkg/public/ -run TestServeVersion` — passes (other tests in `pkg/public`/`pkg/public/middleware` require the dockerized Postgres and aren't run standalone on host; unaffected by this change)
- [x] Manually verified against local dev server: CLI on a dev build shows `Server version: dev` with no warning
- [x] Manually verified skew warning: built server with a fake older stamped version, confirmed CLI shows "CLI version vX.Y.Z is newer than server version vA.B.C" warning
- [x] Manually verified header capture works across the `connect` command's own client, not just `DefaultClient`