### PR TITLE
fix: validate admin pagination params

### DIFF
--- a/pkg/public/admin.go
+++ b/pkg/public/admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -64,22 +65,37 @@ type installationSettingsRequest struct {
 	SMTPUseTLS                *bool   `json:"smtp_use_tls"`
 }
 
-func parsePagination(r *http.Request) (search string, limit, offset int) {
+func parsePagination(r *http.Request) (search string, limit, offset int, err error) {
 	search = r.URL.Query().Get("search")
 
 	limit = defaultPageSize
-	if v, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && v > 0 {
-		limit = v
+	if rawLimit := r.URL.Query().Get("limit"); rawLimit != "" {
+		parsedLimit, parseErr := strconv.Atoi(rawLimit)
+		if parseErr != nil {
+			return "", 0, 0, fmt.Errorf("invalid limit: %q is not an integer", rawLimit)
+		}
+		if parsedLimit <= 0 {
+			return "", 0, 0, fmt.Errorf("invalid limit: must be a positive integer")
+		}
+		limit = parsedLimit
 	}
 	if limit > maxPageSize {
 		limit = maxPageSize
 	}
 
-	if v, err := strconv.Atoi(r.URL.Query().Get("offset")); err == nil && v > 0 {
-		offset = v
+	offset = 0
+	if rawOffset := r.URL.Query().Get("offset"); rawOffset != "" {
+		parsedOffset, parseErr := strconv.Atoi(rawOffset)
+		if parseErr != nil {
+			return "", 0, 0, fmt.Errorf("invalid offset: %q is not an integer", rawOffset)
+		}
+		if parsedOffset < 0 {
+			return "", 0, 0, fmt.Errorf("invalid offset: must be a non-negative integer")
+		}
+		offset = parsedOffset
 	}
 
-	return search, limit, offset
+	return search, limit, offset, nil
 }
 
 func parseSorting(r *http.Request) (sortBy, sortDirection string) {
@@ -301,7 +317,11 @@ func resolveBoolField(value *bool, fallback bool) bool {
 // adminListOrganizations returns paginated organizations in the installation.
 // adminListAccounts returns paginated accounts in the installation.
 func (s *Server) adminListAccounts(w http.ResponseWriter, r *http.Request) {
-	search, limit, offset := parsePagination(r)
+	search, limit, offset, err := parsePagination(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	sortBy, sortDirection := parseSorting(r)
 
 	accounts, total, err := models.ListAccounts(search, limit, offset, sortBy, sortDirection)
@@ -349,7 +369,11 @@ func (s *Server) adminListAccounts(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) adminListOrganizations(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	search, limit, offset := parsePagination(r)
+	search, limit, offset, err := parsePagination(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	sortBy, sortDirection := parseSorting(r)
 
 	organizations, total, err := listAllOrganizations(ctx, search, limit, offset, sortBy, sortDirection)
@@ -381,7 +405,11 @@ func (s *Server) adminListCanvases(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	search, limit, offset := parsePagination(r)
+	search, limit, offset, err := parsePagination(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	canvases, total, err := models.ListCanvasesPaginated(orgID, search, limit, offset)
 	if err != nil {
@@ -423,7 +451,11 @@ func (s *Server) adminListOrgUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	search, limit, offset := parsePagination(r)
+	search, limit, offset, err := parsePagination(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	users, total, err := models.ListActiveUsersByOrganization(orgID, search, limit, offset)
 	if err != nil {

--- a/pkg/public/admin_test.go
+++ b/pkg/public/admin_test.go
@@ -118,6 +118,29 @@ func TestAdminListOrganizations(t *testing.T) {
 		assert.Equal(t, 1, page.Limit)
 	})
 
+	t.Run("rejects invalid pagination params", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			path string
+		}{
+			{name: "invalid limit", path: "/admin/api/organizations?limit=abc"},
+			{name: "negative offset", path: "/admin/api/organizations?offset=-10"},
+			{name: "non-positive limit", path: "/admin/api/organizations?limit=0"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				response := execRequest(server, requestParams{
+					method:     "GET",
+					path:       tc.path,
+					authCookie: token,
+				})
+
+				assert.Equal(t, http.StatusBadRequest, response.Code)
+			})
+		}
+	})
+
 	t.Run("unauthenticated request is rejected", func(t *testing.T) {
 		response := execRequest(server, requestParams{
 			method: "GET",


### PR DESCRIPTION
## Summary

Admin list endpoints currently accept malformed pagination query parameters without rejecting them explicitly. This change adds validation to reject invalid `limit` and `offset` values with a `400 Bad Request` response while preserving existing behavior for valid inputs.

## Problem

When clients send invalid pagination parameters such as:
- `?limit=abc` (non-integer)
- `?offset=-10` (negative)
- `?limit=0` (non-positive)

The endpoints silently ignore these values and return `200 OK` with default pagination, which is confusing and makes client-side error handling difficult.

## Solution

- Modified `parsePagination()` to explicitly validate `limit` and `offset` parameters
- Returns error with descriptive message for invalid input
- Updated all four admin list handlers to check for validation errors and return `400 Bad Request`
- Added regression tests covering invalid pagination inputs

## Affected Endpoints

- `GET /admin/api/organizations`
- `GET /admin/api/accounts`
- `GET /admin/api/organizations/{orgId}/canvases`
- `GET /admin/api/organizations/{orgId}/users`

## Validation Rules

- `limit`: Must be a positive integer (> 0). Capped at 200 max page size.
- `offset`: Must be a non-negative integer (>= 0).
- Omitting either param continues to use defaults (limit: 50, offset: 0).

## Testing

- Existing tests for valid pagination continue to pass
- New test cases verify rejection of:
  - Non-integer limit values
  - Negative offset values
  - Zero or negative limit values

## Breaking Changes

None. Valid requests continue to work as before. Only requests with malformed pagination params now receive explicit error responses instead of being silently ignored.