### PR TITLE
feat: add a DataForSEO integration for SEO site-audit guardrails

### DIFF
--- a/pkg/integrations/dataforseo/client.go
+++ b/pkg/integrations/dataforseo/client.go
@@ -145,3 +145,54 @@ func (c *Client) GetSummary(taskID string) (string, error) {
 
 	return response.Tasks[0].Result[0].CrawlProgress, nil
 }
+
+type PageChecks struct {
+	BrokenLinks          bool `json:"broken_links"`
+	DuplicateTitle       bool `json:"duplicate_title"`
+	DuplicateDescription bool `json:"duplicate_description"`
+	IsBroken             bool `json:"is_broken"`
+}
+
+func (c PageChecks) HasIssue() bool {
+	return c.BrokenLinks || c.DuplicateTitle || c.DuplicateDescription || c.IsBroken
+}
+
+type PageResult struct {
+	URL    string     `json:"url"`
+	Checks PageChecks `json:"checks"`
+}
+
+type pagesResponse struct {
+	StatusCode int `json:"status_code"`
+	Tasks      []struct {
+		Result []struct {
+			Items []PageResult `json:"items"`
+		} `json:"result"`
+	} `json:"tasks"`
+}
+
+func (c *Client) GetPages(taskID string, limit int) ([]PageResult, error) {
+	payload := []map[string]any{
+		{"id": taskID, "limit": limit},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal pages request: %v", err)
+	}
+
+	respBody, err := c.execRequest(http.MethodPost, baseURL+"/on_page/pages", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response pagesResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal pages response: %v", err)
+	}
+
+	if len(response.Tasks) == 0 || len(response.Tasks[0].Result) == 0 {
+		return nil, fmt.Errorf("pages response missing result for task %s", taskID)
+	}
+
+	return response.Tasks[0].Result[0].Items, nil
+}

--- a/pkg/integrations/dataforseo/client.go
+++ b/pkg/integrations/dataforseo/client.go
@@ -62,9 +62,6 @@ func (c *Client) execRequest(method, url string, body io.Reader) ([]byte, error)
 
 type userDataResponse struct {
 	StatusCode int `json:"status_code"`
-	Tasks      []struct {
-		ID string `json:"id"`
-	} `json:"tasks"`
 }
 
 func (c *Client) Verify() error {
@@ -86,10 +83,12 @@ func (c *Client) Verify() error {
 }
 
 type taskPostResponse struct {
-	StatusCode int `json:"status_code"`
-	Tasks      []struct {
-		ID         string `json:"id"`
-		StatusCode int    `json:"status_code"`
+	StatusCode    int    `json:"status_code"`
+	StatusMessage string `json:"status_message"`
+	Tasks         []struct {
+		ID            string `json:"id"`
+		StatusCode    int    `json:"status_code"`
+		StatusMessage string `json:"status_message"`
 	} `json:"tasks"`
 }
 
@@ -112,11 +111,24 @@ func (c *Client) PostAudit(target string, maxCrawlPages int) (string, error) {
 		return "", fmt.Errorf("failed to unmarshal task_post response: %v", err)
 	}
 
-	if len(response.Tasks) == 0 || response.Tasks[0].ID == "" {
+	if response.StatusCode != 20000 {
+		return "", fmt.Errorf("DataForSEO returned status_code %d: %s", response.StatusCode, response.StatusMessage)
+	}
+
+	if len(response.Tasks) == 0 {
 		return "", fmt.Errorf("task_post response missing task id")
 	}
 
-	return response.Tasks[0].ID, nil
+	task := response.Tasks[0]
+	if task.StatusCode != 20000 && task.StatusCode != 20100 {
+		return "", fmt.Errorf("DataForSEO rejected task_post request: status_code %d: %s", task.StatusCode, task.StatusMessage)
+	}
+
+	if task.ID == "" {
+		return "", fmt.Errorf("task_post response missing task id")
+	}
+
+	return task.ID, nil
 }
 
 type summaryResponse struct {

--- a/pkg/integrations/dataforseo/client.go
+++ b/pkg/integrations/dataforseo/client.go
@@ -1,6 +1,7 @@
 package dataforseo
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -82,4 +83,38 @@ func (c *Client) Verify() error {
 	}
 
 	return nil
+}
+
+type taskPostResponse struct {
+	StatusCode int `json:"status_code"`
+	Tasks      []struct {
+		ID         string `json:"id"`
+		StatusCode int    `json:"status_code"`
+	} `json:"tasks"`
+}
+
+func (c *Client) PostAudit(target string, maxCrawlPages int) (string, error) {
+	payload := []map[string]any{
+		{"target": target, "max_crawl_pages": maxCrawlPages},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal task_post request: %v", err)
+	}
+
+	respBody, err := c.execRequest(http.MethodPost, baseURL+"/on_page/task_post", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+
+	var response taskPostResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return "", fmt.Errorf("failed to unmarshal task_post response: %v", err)
+	}
+
+	if len(response.Tasks) == 0 || response.Tasks[0].ID == "" {
+		return "", fmt.Errorf("task_post response missing task id")
+	}
+
+	return response.Tasks[0].ID, nil
 }

--- a/pkg/integrations/dataforseo/client.go
+++ b/pkg/integrations/dataforseo/client.go
@@ -118,3 +118,30 @@ func (c *Client) PostAudit(target string, maxCrawlPages int) (string, error) {
 
 	return response.Tasks[0].ID, nil
 }
+
+type summaryResponse struct {
+	StatusCode int `json:"status_code"`
+	Tasks      []struct {
+		Result []struct {
+			CrawlProgress string `json:"crawl_progress"`
+		} `json:"result"`
+	} `json:"tasks"`
+}
+
+func (c *Client) GetSummary(taskID string) (string, error) {
+	respBody, err := c.execRequest(http.MethodGet, baseURL+"/on_page/summary/"+taskID, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var response summaryResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return "", fmt.Errorf("failed to unmarshal summary response: %v", err)
+	}
+
+	if len(response.Tasks) == 0 || len(response.Tasks[0].Result) == 0 {
+		return "", fmt.Errorf("summary response missing result for task %s", taskID)
+	}
+
+	return response.Tasks[0].Result[0].CrawlProgress, nil
+}

--- a/pkg/integrations/dataforseo/client.go
+++ b/pkg/integrations/dataforseo/client.go
@@ -1,0 +1,85 @@
+package dataforseo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const baseURL = "https://api.dataforseo.com/v3"
+
+type Client struct {
+	apiKey string
+	http   core.HTTPContext
+}
+
+func NewClient(httpClient core.HTTPContext, ctx core.IntegrationContext) (*Client, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("no integration context")
+	}
+
+	apiKey, err := ctx.GetConfig("apiKey")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		apiKey: string(apiKey),
+		http:   httpClient,
+	}, nil
+}
+
+func (c *Client) execRequest(method, url string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Basic "+c.apiKey)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("request got %d code: %s", res.StatusCode, string(responseBody))
+	}
+
+	return responseBody, nil
+}
+
+type userDataResponse struct {
+	StatusCode int `json:"status_code"`
+	Tasks      []struct {
+		ID string `json:"id"`
+	} `json:"tasks"`
+}
+
+func (c *Client) Verify() error {
+	body, err := c.execRequest(http.MethodGet, baseURL+"/appendix/user_data", nil)
+	if err != nil {
+		return err
+	}
+
+	var response userDataResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("failed to unmarshal user_data response: %v", err)
+	}
+
+	if response.StatusCode != 20000 {
+		return fmt.Errorf("DataForSEO returned status_code %d", response.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/integrations/dataforseo/contract_test.go
+++ b/pkg/integrations/dataforseo/contract_test.go
@@ -1,0 +1,49 @@
+// pkg/integrations/dataforseo/contract_test.go
+package dataforseo
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+// realHTTPContext adapts the real net/http client to core.HTTPContext, so
+// this test hits the real DataForSEO API instead of a mocked response.
+type realHTTPContext struct{ client *http.Client }
+
+func (r realHTTPContext) Do(req *http.Request) (*http.Response, error) {
+	return r.client.Do(req)
+}
+
+func TestContract_DataForSEO(t *testing.T) {
+	apiKey := os.Getenv("DATAFORSEO_TEST_API_KEY")
+	if apiKey == "" {
+		t.Skip("DATAFORSEO_TEST_API_KEY not set, skipping contract test")
+	}
+
+	httpCtx := realHTTPContext{client: &http.Client{Timeout: 30 * time.Second}}
+	client, err := NewClient(httpCtx, &contexts.IntegrationContext{
+		Configuration: map[string]any{"apiKey": apiKey},
+	})
+	require.NoError(t, err)
+
+	t.Run("Verify", func(t *testing.T) {
+		err := client.Verify()
+		require.NoError(t, err)
+	})
+
+	t.Run("PostAudit and GetSummary shape", func(t *testing.T) {
+		taskID, err := client.PostAudit("freehire.me", 5)
+		require.NoError(t, err)
+		require.NotEmpty(t, taskID)
+
+		// Real crawls take time; this only asserts the response shape parses,
+		// not that the crawl has finished within the test's lifetime.
+		_, err = client.GetSummary(taskID)
+		require.NoError(t, err)
+	})
+}

--- a/pkg/integrations/dataforseo/dataforseo.go
+++ b/pkg/integrations/dataforseo/dataforseo.go
@@ -1,0 +1,106 @@
+package dataforseo
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+func init() {
+	registry.RegisterIntegration("dataforseo", &DataForSEO{})
+}
+
+type DataForSEO struct{}
+
+type Configuration struct {
+	APIKey string `json:"apiKey"`
+}
+
+func (d *DataForSEO) Name() string {
+	return "dataforseo"
+}
+
+func (d *DataForSEO) Label() string {
+	return "DataForSEO"
+}
+
+func (d *DataForSEO) Icon() string {
+	return "dataforseo"
+}
+
+func (d *DataForSEO) Description() string {
+	return "Run SEO site audits with DataForSEO"
+}
+
+func (d *DataForSEO) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "apiKey",
+			Label:       "API Key",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Base64 of your DataForSEO login:password, from https://app.dataforseo.com/api-access",
+		},
+	}
+}
+
+func (d *DataForSEO) Actions() []core.Action {
+	// Task 2 adds &RunSiteAudit{} here once that type exists — an empty
+	// slice keeps this package compiling and registered on its own.
+	return []core.Action{}
+}
+
+func (d *DataForSEO) Triggers() []core.Trigger {
+	return []core.Trigger{}
+}
+
+func (d *DataForSEO) Instructions() string {
+	return ""
+}
+
+func (d *DataForSEO) Cleanup(ctx core.IntegrationCleanupContext) error {
+	return nil
+}
+
+func (d *DataForSEO) Sync(ctx core.SyncContext) error {
+	config := Configuration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %v", err)
+	}
+
+	if config.APIKey == "" {
+		return fmt.Errorf("apiKey is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	if err := client.Verify(); err != nil {
+		return err
+	}
+
+	ctx.Integration.Ready()
+	return nil
+}
+
+func (d *DataForSEO) HandleRequest(ctx core.HTTPRequestContext) {
+	// no-op
+}
+
+func (d *DataForSEO) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	return []core.IntegrationResource{}, nil
+}
+
+func (d *DataForSEO) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (d *DataForSEO) HandleHook(ctx core.IntegrationHookContext) error {
+	return nil
+}

--- a/pkg/integrations/dataforseo/dataforseo.go
+++ b/pkg/integrations/dataforseo/dataforseo.go
@@ -49,9 +49,9 @@ func (d *DataForSEO) Configuration() []configuration.Field {
 }
 
 func (d *DataForSEO) Actions() []core.Action {
-	// Task 2 adds &RunSiteAudit{} here once that type exists — an empty
-	// slice keeps this package compiling and registered on its own.
-	return []core.Action{}
+	return []core.Action{
+		&RunSiteAudit{},
+	}
 }
 
 func (d *DataForSEO) Triggers() []core.Trigger {

--- a/pkg/integrations/dataforseo/dataforseo_test.go
+++ b/pkg/integrations/dataforseo/dataforseo_test.go
@@ -56,6 +56,68 @@ func Test__Client__Verify(t *testing.T) {
 	})
 }
 
+func Test__Client__PostAudit(t *testing.T) {
+	t.Run("task created", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "status_code": 20100, "status_message": "Task Created."}]
+				}`),
+			},
+		}
+		client, err := NewClient(httpCtx, &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		})
+		require.NoError(t, err)
+
+		taskID, err := client.PostAudit("freehire.me", 100)
+		require.NoError(t, err)
+		assert.Equal(t, "task-1", taskID)
+	})
+
+	t.Run("rejected by DataForSEO - bad domain", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "status_code": 40501, "status_message": "Invalid Field: 'target'."}]
+				}`),
+			},
+		}
+		client, err := NewClient(httpCtx, &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		})
+		require.NoError(t, err)
+
+		taskID, err := client.PostAudit("not a domain", 100)
+		require.Error(t, err)
+		assert.Empty(t, taskID)
+		assert.Contains(t, err.Error(), "Invalid Field")
+	})
+
+	t.Run("rejected by DataForSEO - top level status_code", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 40200,
+					"status_message": "Access denied.",
+					"tasks": []
+				}`),
+			},
+		}
+		client, err := NewClient(httpCtx, &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		})
+		require.NoError(t, err)
+
+		taskID, err := client.PostAudit("freehire.me", 100)
+		require.Error(t, err)
+		assert.Empty(t, taskID)
+		assert.Contains(t, err.Error(), "Access denied")
+	})
+}
+
 func Test__DataForSEO__Sync(t *testing.T) {
 	d := &DataForSEO{}
 

--- a/pkg/integrations/dataforseo/dataforseo_test.go
+++ b/pkg/integrations/dataforseo/dataforseo_test.go
@@ -1,0 +1,89 @@
+package dataforseo
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func mockResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func Test__Client__Verify(t *testing.T) {
+	t.Run("valid credentials", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "1", "result": [{"login": "user@example.com"}]}]
+				}`),
+			},
+		}
+		client, err := NewClient(httpCtx, &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		})
+		require.NoError(t, err)
+
+		err = client.Verify()
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, "Basic dXNlcjpwYXNz", httpCtx.Requests[0].Header.Get("Authorization"))
+		assert.Equal(t, "https://api.dataforseo.com/v3/appendix/user_data", httpCtx.Requests[0].URL.String())
+	})
+
+	t.Run("invalid credentials", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{mockResponse(http.StatusUnauthorized, `{"status_code": 40100}`)},
+		}
+		client, err := NewClient(httpCtx, &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "bad"},
+		})
+		require.NoError(t, err)
+
+		err = client.Verify()
+		require.Error(t, err)
+	})
+}
+
+func Test__DataForSEO__Sync(t *testing.T) {
+	d := &DataForSEO{}
+
+	t.Run("missing apiKey", func(t *testing.T) {
+		ctx := core.SyncContext{
+			Configuration: map[string]any{},
+			Integration:   &contexts.IntegrationContext{},
+		}
+		err := d.Sync(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "apiKey is required")
+	})
+
+	t.Run("valid credentials", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		}
+		ctx := core.SyncContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+			Integration:   integrationCtx,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					mockResponse(http.StatusOK, `{"status_code": 20000, "tasks": [{"id": "1"}]}`),
+				},
+			},
+		}
+		err := d.Sync(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "ready", integrationCtx.State)
+	})
+}

--- a/pkg/integrations/dataforseo/run_site_audit.go
+++ b/pkg/integrations/dataforseo/run_site_audit.go
@@ -201,6 +201,28 @@ func (r *RunSiteAudit) poll(ctx core.ActionHookContext) error {
 	return r.resolve(ctx, client, metadata)
 }
 
+const runSiteAuditPagesLimit = 1000
+
 func (r *RunSiteAudit) resolve(ctx core.ActionHookContext, client *Client, metadata RunSiteAuditExecutionMetadata) error {
-	return ctx.ExecutionState.Pass()
+	allPages, err := client.GetPages(metadata.TaskID, runSiteAuditPagesLimit)
+	if err != nil {
+		return fmt.Errorf("failed to fetch audit pages: %w", err)
+	}
+
+	issuePages := make([]PageResult, 0, len(allPages))
+	for _, page := range allPages {
+		if page.Checks.HasIssue() {
+			issuePages = append(issuePages, page)
+		}
+	}
+
+	if len(issuePages) == 0 {
+		return ctx.ExecutionState.Emit(RunSiteAuditCleanChannel, "dataforseo.audit.finished", []any{
+			map[string]any{"taskId": metadata.TaskID, "pages": issuePages},
+		})
+	}
+
+	return ctx.ExecutionState.Emit(RunSiteAuditIssuesChannel, "dataforseo.audit.finished", []any{
+		map[string]any{"taskId": metadata.TaskID, "pages": issuePages},
+	})
 }

--- a/pkg/integrations/dataforseo/run_site_audit.go
+++ b/pkg/integrations/dataforseo/run_site_audit.go
@@ -137,17 +137,70 @@ func (r *RunSiteAudit) Cleanup(ctx core.SetupContext) error {
 }
 
 func (r *RunSiteAudit) Hooks() []core.Hook {
-	return nil
+	return []core.Hook{
+		{Name: RunSiteAuditPollAction, Type: core.HookTypeInternal},
+	}
 }
 
 func (r *RunSiteAudit) HandleHook(ctx core.ActionHookContext) error {
-	return nil
+	switch ctx.Name {
+	case RunSiteAuditPollAction:
+		return r.poll(ctx)
+	}
+	return fmt.Errorf("unknown hook: %s", ctx.Name)
 }
 
 func (r *RunSiteAudit) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
-	return 200, nil, nil
+	return 200, nil, nil // DataForSEO OnPage has no webhook path in v1; polling only.
 }
 
 func (r *RunSiteAudit) Cancel(ctx core.ExecutionContext) error {
+	ctx.Logger.Info("DataForSEO OnPage tasks cannot be cancelled server-side; nothing to do")
 	return nil
+}
+
+func (r *RunSiteAudit) poll(ctx core.ActionHookContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	metadata := RunSiteAuditExecutionMetadata{}
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+
+	if metadata.TaskID == "" {
+		return fmt.Errorf("task id is missing from execution metadata")
+	}
+
+	if metadata.PollAttempt >= RunSiteAuditMaxPollAttempts {
+		return ctx.ExecutionState.Fail(
+			"audit_timeout",
+			fmt.Sprintf("DataForSEO audit did not finish within %d poll attempts", RunSiteAuditMaxPollAttempts),
+		)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	crawlProgress, err := client.GetSummary(metadata.TaskID)
+	if err != nil {
+		return err
+	}
+
+	if crawlProgress != "finished" {
+		metadata.PollAttempt++
+		if err := ctx.Metadata.Set(metadata); err != nil {
+			return err
+		}
+		return ctx.Requests.ScheduleActionCall(RunSiteAuditPollAction, map[string]any{}, RunSiteAuditPollInterval)
+	}
+
+	return r.resolve(ctx, client, metadata)
+}
+
+func (r *RunSiteAudit) resolve(ctx core.ActionHookContext, client *Client, metadata RunSiteAuditExecutionMetadata) error {
+	return ctx.ExecutionState.Pass()
 }

--- a/pkg/integrations/dataforseo/run_site_audit.go
+++ b/pkg/integrations/dataforseo/run_site_audit.go
@@ -2,6 +2,7 @@ package dataforseo
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,7 +19,20 @@ const (
 	RunSiteAuditPollAction      = "poll"
 	RunSiteAuditMaxPollAttempts = 72
 	RunSiteAuditKVTaskID        = "task_id"
+
+	// runSiteAuditPagesLimit is the max number of pages fetched per GetPages
+	// call. If the number of pages returned equals this limit, there may be
+	// more pages on the site that DataForSEO didn't return (no pagination is
+	// implemented), so the result is marked as truncated.
+	runSiteAuditPagesLimit = 1000
 )
+
+// runSiteAuditIssuePagesEmitCap bounds how many issue pages are included in
+// the emitted payload, so a large site with many issues doesn't blow past
+// the execution engine's per-event payload size limit. It's a var (not a
+// const) so tests can override it to exercise the capping logic without
+// needing a 100+ item fixture.
+var runSiteAuditIssuePagesEmitCap = 100
 
 type RunSiteAudit struct{}
 
@@ -50,7 +64,33 @@ func (r *RunSiteAudit) Documentation() string {
 ## Use Cases
 
 - **SEO guardrail**: Gate a deploy or release step on the site staying free of on-page SEO regressions
-- **Scheduled monitoring**: Run on a schedule and branch into issue-handling automation when problems appear`
+- **Scheduled monitoring**: Run on a schedule and branch into issue-handling automation when problems appear
+
+## Output Channels
+
+- **Issues found**: at least one crawled page failed one of the four checks below
+- **Clean**: every crawled page passed all four checks
+
+## Polling
+
+After starting the audit, the component polls DataForSEO every 5 minutes for up to 72 attempts (~6 hours). If the
+audit hasn't finished within that window, the execution fails with an "audit_timeout" error.
+
+## What counts as an "issue"
+
+A page is considered to have an issue if any of the following on-page checks fail:
+
+- **Broken links**: the page contains one or more broken outgoing links
+- **Duplicate title**: the page's title tag duplicates another page's title
+- **Duplicate meta description**: the page's meta description duplicates another page's
+- **Broken page response**: the page itself returned a broken (non-2xx) HTTP response
+
+## Coverage limits
+
+Only the first 1000 crawled pages are fetched per audit. If the site has more pages than that, the emitted payload
+includes a "truncated" flag so downstream automation can distinguish a genuinely clean site from one where coverage
+was only partial. The "pages" list in the payload is also capped to the first 100 issue pages; the true total is
+always available in "issuePageCount".`
 }
 
 func (r *RunSiteAudit) Icon() string {
@@ -96,6 +136,19 @@ func (r *RunSiteAudit) Configuration() []configuration.Field {
 }
 
 func (r *RunSiteAudit) Setup(ctx core.SetupContext) error {
+	spec := RunSiteAuditSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if strings.TrimSpace(spec.Domain) == "" {
+		return fmt.Errorf("domain is required")
+	}
+
+	if spec.MaxCrawlPages < 1 {
+		return fmt.Errorf("maxCrawlPages must be at least 1")
+	}
+
 	return nil
 }
 
@@ -187,7 +240,12 @@ func (r *RunSiteAudit) poll(ctx core.ActionHookContext) error {
 
 	crawlProgress, err := client.GetSummary(metadata.TaskID)
 	if err != nil {
-		return err
+		ctx.Logger.Warnf("failed to get DataForSEO audit summary for task %s: %v", metadata.TaskID, err)
+		metadata.PollAttempt++
+		if err := ctx.Metadata.Set(metadata); err != nil {
+			return err
+		}
+		return ctx.Requests.ScheduleActionCall(RunSiteAuditPollAction, map[string]any{}, RunSiteAuditPollInterval)
 	}
 
 	if crawlProgress != "finished" {
@@ -200,8 +258,6 @@ func (r *RunSiteAudit) poll(ctx core.ActionHookContext) error {
 
 	return r.resolve(ctx, client, metadata)
 }
-
-const runSiteAuditPagesLimit = 1000
 
 func (r *RunSiteAudit) resolve(ctx core.ActionHookContext, client *Client, metadata RunSiteAuditExecutionMetadata) error {
 	allPages, err := client.GetPages(metadata.TaskID, runSiteAuditPagesLimit)
@@ -216,13 +272,29 @@ func (r *RunSiteAudit) resolve(ctx core.ActionHookContext, client *Client, metad
 		}
 	}
 
-	if len(issuePages) == 0 {
-		return ctx.ExecutionState.Emit(RunSiteAuditCleanChannel, "dataforseo.audit.finished", []any{
-			map[string]any{"taskId": metadata.TaskID, "pages": issuePages},
-		})
+	// The "issues found" vs "clean" decision is based on the true issue
+	// count, not the (possibly capped) list of pages emitted below.
+	channel := RunSiteAuditCleanChannel
+	if len(issuePages) > 0 {
+		channel = RunSiteAuditIssuesChannel
 	}
 
-	return ctx.ExecutionState.Emit(RunSiteAuditIssuesChannel, "dataforseo.audit.finished", []any{
-		map[string]any{"taskId": metadata.TaskID, "pages": issuePages},
+	emittedPages := issuePages
+	if len(emittedPages) > runSiteAuditIssuePagesEmitCap {
+		emittedPages = emittedPages[:runSiteAuditIssuePagesEmitCap]
+	}
+
+	// If DataForSEO returned exactly as many pages as we asked for, there may
+	// be more pages on the site that we never fetched (no pagination is
+	// implemented), so this can't be treated as a fully-covered crawl.
+	truncated := len(allPages) >= runSiteAuditPagesLimit
+
+	return ctx.ExecutionState.Emit(channel, "dataforseo.audit.finished", []any{
+		map[string]any{
+			"taskId":         metadata.TaskID,
+			"pages":          emittedPages,
+			"truncated":      truncated,
+			"issuePageCount": len(issuePages),
+		},
 	})
 }

--- a/pkg/integrations/dataforseo/run_site_audit.go
+++ b/pkg/integrations/dataforseo/run_site_audit.go
@@ -1,0 +1,153 @@
+package dataforseo
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const (
+	RunSiteAuditIssuesChannel = "issues found"
+	RunSiteAuditCleanChannel  = "clean"
+
+	RunSiteAuditPollInterval    = 5 * time.Minute
+	RunSiteAuditPollAction      = "poll"
+	RunSiteAuditMaxPollAttempts = 72
+	RunSiteAuditKVTaskID        = "task_id"
+)
+
+type RunSiteAudit struct{}
+
+type RunSiteAuditSpec struct {
+	Domain        string `json:"domain" mapstructure:"domain"`
+	MaxCrawlPages int    `json:"maxCrawlPages" mapstructure:"maxCrawlPages"`
+}
+
+type RunSiteAuditExecutionMetadata struct {
+	TaskID      string `json:"taskId" mapstructure:"taskId"`
+	PollAttempt int    `json:"pollAttempt" mapstructure:"pollAttempt"`
+}
+
+func (r *RunSiteAudit) Name() string {
+	return "dataforseo.runSiteAudit"
+}
+
+func (r *RunSiteAudit) Label() string {
+	return "Run Site Audit"
+}
+
+func (r *RunSiteAudit) Description() string {
+	return "Run a DataForSEO OnPage site audit and wait for completion"
+}
+
+func (r *RunSiteAudit) Documentation() string {
+	return `The Run Site Audit component crawls a domain with DataForSEO's OnPage API and waits for the audit to finish.
+
+## Use Cases
+
+- **SEO guardrail**: Gate a deploy or release step on the site staying free of on-page SEO regressions
+- **Scheduled monitoring**: Run on a schedule and branch into issue-handling automation when problems appear`
+}
+
+func (r *RunSiteAudit) Icon() string {
+	return "search"
+}
+
+func (r *RunSiteAudit) Color() string {
+	return "blue"
+}
+
+func (r *RunSiteAudit) ExampleOutput() map[string]any {
+	return map[string]any{
+		"taskId": "07131248-1535-0216-1000-17384017ad04",
+		"pages": []map[string]any{
+			{"url": "https://freehire.me/jobs/example", "checks": map[string]any{"duplicate_title": true}},
+		},
+	}
+}
+
+func (r *RunSiteAudit) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{
+		{Name: RunSiteAuditIssuesChannel, Label: "Issues found"},
+		{Name: RunSiteAuditCleanChannel, Label: "Clean"},
+	}
+}
+
+func (r *RunSiteAudit) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "domain",
+			Label:    "Domain",
+			Type:     configuration.FieldTypeString,
+			Required: true,
+		},
+		{
+			Name:     "maxCrawlPages",
+			Label:    "Max Crawl Pages",
+			Type:     configuration.FieldTypeNumber,
+			Required: true,
+			Default:  100,
+		},
+	}
+}
+
+func (r *RunSiteAudit) Setup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (r *RunSiteAudit) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (r *RunSiteAudit) Execute(ctx core.ExecutionContext) error {
+	spec := RunSiteAuditSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	taskID, err := client.PostAudit(spec.Domain, spec.MaxCrawlPages)
+	if err != nil {
+		return fmt.Errorf("failed to start audit: %w", err)
+	}
+
+	metadata := RunSiteAuditExecutionMetadata{TaskID: taskID, PollAttempt: 0}
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return err
+	}
+
+	if err := ctx.ExecutionState.SetKV(RunSiteAuditKVTaskID, taskID); err != nil {
+		return err
+	}
+
+	ctx.Logger.Infof("Started DataForSEO audit %s for %s", taskID, spec.Domain)
+	return ctx.Requests.ScheduleActionCall(RunSiteAuditPollAction, map[string]any{}, RunSiteAuditPollInterval)
+}
+
+func (r *RunSiteAudit) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (r *RunSiteAudit) Hooks() []core.Hook {
+	return nil
+}
+
+func (r *RunSiteAudit) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func (r *RunSiteAudit) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (r *RunSiteAudit) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}

--- a/pkg/integrations/dataforseo/run_site_audit_test.go
+++ b/pkg/integrations/dataforseo/run_site_audit_test.go
@@ -1,6 +1,9 @@
 package dataforseo
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
@@ -11,11 +14,58 @@ import (
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
+func Test__RunSiteAudit__Setup(t *testing.T) {
+	r := &RunSiteAudit{}
+
+	t.Run("empty domain", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"domain":        "   ",
+				"maxCrawlPages": 100,
+			},
+		}
+		err := r.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "domain is required")
+	})
+
+	t.Run("non-positive maxCrawlPages", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"domain":        "freehire.me",
+				"maxCrawlPages": 0,
+			},
+		}
+		err := r.Setup(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maxCrawlPages")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"domain":        "freehire.me",
+				"maxCrawlPages": 100,
+			},
+		}
+		err := r.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
 func Test__RunSiteAudit__Execute(t *testing.T) {
 	component := &RunSiteAudit{}
 	metadataCtx := &contexts.MetadataContext{}
 	requestsCtx := &contexts.RequestContext{}
 	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			mockResponse(http.StatusOK, `{
+				"status_code": 20000,
+				"tasks": [{"id": "07131248-1535-0216-1000-17384017ad04", "status_code": 20100}]
+			}`),
+		},
+	}
 
 	err := component.Execute(core.ExecutionContext{
 		Configuration: map[string]any{
@@ -25,14 +75,7 @@ func Test__RunSiteAudit__Execute(t *testing.T) {
 		Integration: &contexts.IntegrationContext{
 			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
 		},
-		HTTP: &contexts.HTTPContext{
-			Responses: []*http.Response{
-				mockResponse(http.StatusOK, `{
-					"status_code": 20000,
-					"tasks": [{"id": "07131248-1535-0216-1000-17384017ad04", "status_code": 20100}]
-				}`),
-			},
-		},
+		HTTP:           httpCtx,
 		Metadata:       metadataCtx,
 		ExecutionState: executionState,
 		Requests:       requestsCtx,
@@ -47,6 +90,21 @@ func Test__RunSiteAudit__Execute(t *testing.T) {
 	assert.Equal(t, "07131248-1535-0216-1000-17384017ad04", executionState.KVs[RunSiteAuditKVTaskID])
 	assert.Equal(t, RunSiteAuditPollAction, requestsCtx.Action)
 	assert.Equal(t, RunSiteAuditPollInterval, requestsCtx.Duration)
+
+	// Guard against typos in the request body field names (e.g.
+	// "max_crawl_page" missing the trailing "s") that would otherwise only
+	// be caught by a real API call.
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Equal(t, "https://api.dataforseo.com/v3/on_page/task_post", httpCtx.Requests[0].URL.String())
+
+	bodyBytes, err := io.ReadAll(httpCtx.Requests[0].Body)
+	require.NoError(t, err)
+
+	var body []map[string]any
+	require.NoError(t, json.Unmarshal(bodyBytes, &body))
+	require.Len(t, body, 1)
+	assert.Equal(t, "freehire.me", body[0]["target"])
+	assert.Equal(t, float64(100), body[0]["max_crawl_pages"])
 }
 
 func Test__RunSiteAudit__Poll__InProgress(t *testing.T) {
@@ -84,6 +142,40 @@ func Test__RunSiteAudit__Poll__InProgress(t *testing.T) {
 	metadata, ok := metadataCtx.Metadata.(RunSiteAuditExecutionMetadata)
 	require.True(t, ok)
 	assert.Equal(t, 4, metadata.PollAttempt)
+}
+
+func Test__RunSiteAudit__Poll__GetSummaryError(t *testing.T) {
+	component := &RunSiteAudit{}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: RunSiteAuditExecutionMetadata{TaskID: "task-1", PollAttempt: 5},
+	}
+	requestsCtx := &contexts.RequestContext{}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name: RunSiteAuditPollAction,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusInternalServerError, `{"status_code": 50000, "status_message": "Internal error"}`),
+			},
+		},
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Requests:       requestsCtx,
+		Logger:         log.NewEntry(log.New()),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, executionState.Finished)
+	assert.Equal(t, RunSiteAuditPollAction, requestsCtx.Action)
+	assert.Equal(t, RunSiteAuditPollInterval, requestsCtx.Duration)
+
+	metadata, ok := metadataCtx.Metadata.(RunSiteAuditExecutionMetadata)
+	require.True(t, ok)
+	assert.Equal(t, 6, metadata.PollAttempt)
 }
 
 func Test__RunSiteAudit__Poll__AttemptCapExceeded(t *testing.T) {
@@ -155,6 +247,128 @@ func Test__RunSiteAudit__Poll__Finished_IssuesFound(t *testing.T) {
 	require.Len(t, pages, 1) // only the page with an actual issue is included
 	assert.Equal(t, "https://freehire.me/jobs/1", pages[0].URL)
 	assert.True(t, pages[0].Checks.DuplicateTitle)
+}
+
+func Test__RunSiteAudit__Poll__Finished_Truncated(t *testing.T) {
+	component := &RunSiteAudit{}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: RunSiteAuditExecutionMetadata{TaskID: "task-1", PollAttempt: 1},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	// The pages response returns exactly runSiteAuditPagesLimit (1000) items,
+	// none with issues, so DataForSEO may still have more pages we never
+	// fetched. The result must still be reported "clean" (per current logic,
+	// since nothing checked had issues) but flagged as truncated so a canvas
+	// consumer knows coverage was partial.
+	items := make([]map[string]any, runSiteAuditPagesLimit)
+	for i := range items {
+		items[i] = map[string]any{
+			"url": fmt.Sprintf("https://freehire.me/jobs/%d", i),
+			"checks": map[string]any{
+				"duplicate_title": false, "broken_links": false, "duplicate_description": false, "is_broken": false,
+			},
+		}
+	}
+	pagesBody, err := json.Marshal(map[string]any{
+		"status_code": 20000,
+		"tasks":       []map[string]any{{"id": "task-1", "result": []map[string]any{{"items": items}}}},
+	})
+	require.NoError(t, err)
+
+	err = component.HandleHook(core.ActionHookContext{
+		Name: RunSiteAuditPollAction,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "result": [{"crawl_progress": "finished"}]}]
+				}`),
+				mockResponse(http.StatusOK, string(pagesBody)),
+			},
+		},
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Logger:         log.NewEntry(log.New()),
+	})
+
+	require.NoError(t, err)
+	require.True(t, executionState.Finished)
+	assert.Equal(t, RunSiteAuditCleanChannel, executionState.Channel)
+
+	require.Len(t, executionState.Payloads, 1)
+	wrapped, ok := executionState.Payloads[0].(map[string]any)
+	require.True(t, ok)
+	data, ok := wrapped["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, data["truncated"])
+	assert.Equal(t, 0, data["issuePageCount"])
+}
+
+func Test__RunSiteAudit__Poll__Finished_CapsEmittedIssuePages(t *testing.T) {
+	original := runSiteAuditIssuePagesEmitCap
+	runSiteAuditIssuePagesEmitCap = 2
+	defer func() { runSiteAuditIssuePagesEmitCap = original }()
+
+	component := &RunSiteAudit{}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: RunSiteAuditExecutionMetadata{TaskID: "task-1", PollAttempt: 1},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	// 4 pages all with issues; with the cap lowered to 2, only 2 should be
+	// emitted in "pages", but issuePageCount must reflect the true total (4).
+	items := []map[string]any{}
+	for i := 0; i < 4; i++ {
+		items = append(items, map[string]any{
+			"url": fmt.Sprintf("https://freehire.me/jobs/%d", i),
+			"checks": map[string]any{
+				"duplicate_title": true, "broken_links": false, "duplicate_description": false, "is_broken": false,
+			},
+		})
+	}
+	pagesBody, err := json.Marshal(map[string]any{
+		"status_code": 20000,
+		"tasks":       []map[string]any{{"id": "task-1", "result": []map[string]any{{"items": items}}}},
+	})
+	require.NoError(t, err)
+
+	err = component.HandleHook(core.ActionHookContext{
+		Name: RunSiteAuditPollAction,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "result": [{"crawl_progress": "finished"}]}]
+				}`),
+				mockResponse(http.StatusOK, string(pagesBody)),
+			},
+		},
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Logger:         log.NewEntry(log.New()),
+	})
+
+	require.NoError(t, err)
+	require.True(t, executionState.Finished)
+	assert.Equal(t, RunSiteAuditIssuesChannel, executionState.Channel)
+
+	require.Len(t, executionState.Payloads, 1)
+	wrapped, ok := executionState.Payloads[0].(map[string]any)
+	require.True(t, ok)
+	data, ok := wrapped["data"].(map[string]any)
+	require.True(t, ok)
+	pages, ok := data["pages"].([]PageResult)
+	require.True(t, ok)
+	assert.Len(t, pages, 2) // capped, even though 4 pages have issues
+	assert.Equal(t, 4, data["issuePageCount"])
+	assert.Equal(t, false, data["truncated"])
 }
 
 func Test__RunSiteAudit__Poll__Finished_Clean(t *testing.T) {

--- a/pkg/integrations/dataforseo/run_site_audit_test.go
+++ b/pkg/integrations/dataforseo/run_site_audit_test.go
@@ -105,3 +105,90 @@ func Test__RunSiteAudit__Poll__AttemptCapExceeded(t *testing.T) {
 	assert.False(t, executionState.Passed)
 	assert.Contains(t, executionState.FailureMessage, "72")
 }
+
+func Test__RunSiteAudit__Poll__Finished_IssuesFound(t *testing.T) {
+	component := &RunSiteAudit{}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: RunSiteAuditExecutionMetadata{TaskID: "task-1", PollAttempt: 1},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name: RunSiteAuditPollAction,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "result": [{"crawl_progress": "finished"}]}]
+				}`),
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "result": [{"items": [
+						{"url": "https://freehire.me/jobs/1", "checks": {"duplicate_title": true, "broken_links": false, "duplicate_description": false, "is_broken": false}},
+						{"url": "https://freehire.me/jobs/2", "checks": {"duplicate_title": false, "broken_links": false, "duplicate_description": false, "is_broken": false}}
+					]}]}]
+				}`),
+			},
+		},
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Logger:         log.NewEntry(log.New()),
+	})
+
+	require.NoError(t, err)
+	require.True(t, executionState.Finished)
+	assert.Equal(t, RunSiteAuditIssuesChannel, executionState.Channel)
+
+	// The mock ExecutionStateContext wraps each raw payload as
+	// {"type": ..., "timestamp": ..., "data": <the map Emit was given>} —
+	// see test/support/contexts/*.go:280-289. Unwrap through "data" to reach it.
+	require.Len(t, executionState.Payloads, 1)
+	wrapped, ok := executionState.Payloads[0].(map[string]any)
+	require.True(t, ok)
+	data, ok := wrapped["data"].(map[string]any)
+	require.True(t, ok)
+	pages, ok := data["pages"].([]PageResult)
+	require.True(t, ok)
+	require.Len(t, pages, 1) // only the page with an actual issue is included
+	assert.Equal(t, "https://freehire.me/jobs/1", pages[0].URL)
+	assert.True(t, pages[0].Checks.DuplicateTitle)
+}
+
+func Test__RunSiteAudit__Poll__Finished_Clean(t *testing.T) {
+	component := &RunSiteAudit{}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: RunSiteAuditExecutionMetadata{TaskID: "task-1", PollAttempt: 1},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name: RunSiteAuditPollAction,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "result": [{"crawl_progress": "finished"}]}]
+				}`),
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "result": [{"items": [
+						{"url": "https://freehire.me/jobs/1", "checks": {"duplicate_title": false, "broken_links": false, "duplicate_description": false, "is_broken": false}}
+					]}]}]
+				}`),
+			},
+		},
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Logger:         log.NewEntry(log.New()),
+	})
+
+	require.NoError(t, err)
+	require.True(t, executionState.Finished)
+	assert.Equal(t, RunSiteAuditCleanChannel, executionState.Channel)
+}

--- a/pkg/integrations/dataforseo/run_site_audit_test.go
+++ b/pkg/integrations/dataforseo/run_site_audit_test.go
@@ -48,3 +48,60 @@ func Test__RunSiteAudit__Execute(t *testing.T) {
 	assert.Equal(t, RunSiteAuditPollAction, requestsCtx.Action)
 	assert.Equal(t, RunSiteAuditPollInterval, requestsCtx.Duration)
 }
+
+func Test__RunSiteAudit__Poll__InProgress(t *testing.T) {
+	component := &RunSiteAudit{}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: RunSiteAuditExecutionMetadata{TaskID: "task-1", PollAttempt: 3},
+	}
+	requestsCtx := &contexts.RequestContext{}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name: RunSiteAuditPollAction,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "task-1", "result": [{"crawl_progress": "in_progress"}]}]
+				}`),
+			},
+		},
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Requests:       requestsCtx,
+		Logger:         log.NewEntry(log.New()),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, executionState.Finished)
+	assert.Equal(t, RunSiteAuditPollAction, requestsCtx.Action)
+	assert.Equal(t, RunSiteAuditPollInterval, requestsCtx.Duration)
+
+	metadata, ok := metadataCtx.Metadata.(RunSiteAuditExecutionMetadata)
+	require.True(t, ok)
+	assert.Equal(t, 4, metadata.PollAttempt)
+}
+
+func Test__RunSiteAudit__Poll__AttemptCapExceeded(t *testing.T) {
+	component := &RunSiteAudit{}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: RunSiteAuditExecutionMetadata{TaskID: "task-1", PollAttempt: RunSiteAuditMaxPollAttempts},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name:           RunSiteAuditPollAction,
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Logger:         log.NewEntry(log.New()),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, executionState.Finished)
+	assert.False(t, executionState.Passed)
+	assert.Contains(t, executionState.FailureMessage, "72")
+}

--- a/pkg/integrations/dataforseo/run_site_audit_test.go
+++ b/pkg/integrations/dataforseo/run_site_audit_test.go
@@ -1,0 +1,50 @@
+package dataforseo
+
+import (
+	"net/http"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__RunSiteAudit__Execute(t *testing.T) {
+	component := &RunSiteAudit{}
+	metadataCtx := &contexts.MetadataContext{}
+	requestsCtx := &contexts.RequestContext{}
+	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"domain":        "freehire.me",
+			"maxCrawlPages": 100,
+		},
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "dXNlcjpwYXNz"},
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mockResponse(http.StatusOK, `{
+					"status_code": 20000,
+					"tasks": [{"id": "07131248-1535-0216-1000-17384017ad04", "status_code": 20100}]
+				}`),
+			},
+		},
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Requests:       requestsCtx,
+		Logger:         log.NewEntry(log.New()),
+	})
+
+	require.NoError(t, err)
+
+	metadata, ok := metadataCtx.Metadata.(RunSiteAuditExecutionMetadata)
+	require.True(t, ok)
+	assert.Equal(t, "07131248-1535-0216-1000-17384017ad04", metadata.TaskID)
+	assert.Equal(t, "07131248-1535-0216-1000-17384017ad04", executionState.KVs[RunSiteAuditKVTaskID])
+	assert.Equal(t, RunSiteAuditPollAction, requestsCtx.Action)
+	assert.Equal(t, RunSiteAuditPollInterval, requestsCtx.Duration)
+}

--- a/pkg/registryimports/registryimports.go
+++ b/pkg/registryimports/registryimports.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/integrations/cursor"
 	_ "github.com/superplanehq/superplane/pkg/integrations/dash0"
 	_ "github.com/superplanehq/superplane/pkg/integrations/datadog"
+	_ "github.com/superplanehq/superplane/pkg/integrations/dataforseo"
 	_ "github.com/superplanehq/superplane/pkg/integrations/daytona"
 	_ "github.com/superplanehq/superplane/pkg/integrations/digitalocean"
 	_ "github.com/superplanehq/superplane/pkg/integrations/discord"


### PR DESCRIPTION
## What

Adds `pkg/integrations/dataforseo`, a new integration with one Action, **Run Site Audit**, that submits a DataForSEO OnPage site audit, polls it to completion, and branches the canvas on whether issues were found.

## Why

Nothing in this repository lets a workflow react to or gate on SEO signals. The target shape is the same guardrail/react-to-failure pattern proposed for PostHog in #6545: run a check, and if it finds problems, let the rest of the canvas (existing `github` and `claude` integrations) create an issue and a fix PR — without needing to build or operate a separate SEO tool alongside SuperPlane.

DataForSEO was chosen over an OpenSEO-based approach: DataForSEO is a plain REST API with HTTP Basic Auth (`base64(email:password)`), matching the existing integration pattern exactly (see `perplexity`, `sendgrid`). An OpenSEO-based integration would only expose its capabilities through MCP + OAuth, which has no precedent in this codebase and would require a new MCP-client capability instead of reusing the established Action/Trigger shape — a materially larger and riskier change for the same outcome.

## How

`RunSiteAudit` is modeled directly on `pkg/integrations/gitlab/run_pipeline.go`'s submit → poll → resolve shape, the same async-job pattern already used by `pkg/integrations/cursor/launch_agent.go`:

- `Execute` submits the audit (`POST on_page/task_post`) and schedules the first poll.
- An internal `"poll"` hook rechecks on a fixed 5-minute interval (deliberately not exponential backoff — audits on a large site can run for hours, and a fixed interval keeps behavior simple and predictable). A poll error is treated the same as "still in progress": it consumes one of 72 attempts (6 hours) rather than retrying unbounded, so a transient DataForSEO failure degrades to the same loud, capped failure as a stuck crawl instead of an indefinite ~1Hz retry loop against a paid API.
- Once finished, it fetches crawled pages (`POST on_page/pages`), filters to pages with an actual issue (broken links, duplicate title, duplicate meta description, or a broken response), and emits on one of two output channels — `"issues found"` / `"clean"` — so the canvas branches natively instead of needing a separate condition node. A large site can have more issue-pages than DataForSEO returns in one fetch or than fit in one event payload; the emitted result caps the `pages` list, carries the true `issuePageCount`, and sets `truncated` when the page fetch itself hit its limit, so "clean" is distinguishable from "clean, but only partially checked."
- `Setup` validates `domain`/`maxCrawlPages` up front, so a bad configuration fails immediately instead of after a 6-hour poll cycle.
- `PostAudit` and `GetSummary`/`GetPages` check DataForSEO's own body-level `status_code` (mirroring the existing `Verify()` pattern) — DataForSEO returns HTTP 200 even for a rejected task, so this is what keeps a misconfigured domain or an exhausted balance from silently masquerading as "still crawling" for six hours.

## Security

The API key is read via the integration's config store, sent only as the `Authorization: Basic` header, and never logged or echoed in error messages — `execRequest` errors include only the response body, never request headers.

## Testing

- Unit tests cover `Execute`, the poll dispatch (in-progress, error, attempt-cap, finished-with-issues, finished-clean), `Setup` validation, and the request bodies sent to DataForSEO — including an assertion on the actual `task_post` request body, so a field-name typo fails the unit suite instead of only surfacing against the live API.
- A contract test (`TestContract_DataForSEO`) hits the real DataForSEO API once, gated behind `DATAFORSEO_TEST_API_KEY` so it skips cleanly (not fails) without one and never runs in normal CI.
- `go test ./pkg/integrations/dataforseo/...` passes; `go vet` is clean.

## Open question for reviewers

This integration ships without the non-Go artifacts every other integration has: an icon/SVG asset, entries in `web_src/src/ui/componentSidebar/integrationIconMaps.ts`, a generated `docs/components/DataForSEO.mdx`, and a README row. I held off on these deliberately — they're a different domain (frontend assets + the docs-generation pipeline) from the Go integration itself, and I'd rather confirm the icon/branding direction with the team before adding assets than guess. Happy to follow up with those once there's a steer, or if there's an existing convention I should just copy.
