### PR TITLE
fix: Use theme colors for input selection so dark mode stays readable

### DIFF
--- a/web_src/src/App.css
+++ b/web_src/src/App.css
@@ -382,10 +382,31 @@
     @apply bg-background text-foreground;
   }
 
+  /*
+   * `Highlight`/`HighlightText` are OS-level system colors: they follow the
+   * operating system's appearance, not this app's `.dark` class. With the app
+   * in dark mode on a light-themed OS, the pair resolves to a light background
+   * with dark text and the selection loses all contrast.
+   *
+   * The composer is the worst case. Its `<textarea>` is `text-transparent` —
+   * the visible glyphs come from the backdrop underneath (see MentionTextarea /
+   * BackdropContent), which is never itself selected. So in dark mode the
+   * backdrop's light text sat over the light system highlight, and recoloring
+   * the textarea's own (invisible) text could not rescue it. Here the highlight
+   * background carries the contrast; the text color still matters for ordinary
+   * inputs, whose glyphs really are painted by the field.
+   */
   input:focus::selection,
   textarea:focus::selection {
-    background-color: Highlight;
-    color: HighlightText;
+    background-color: theme("colors.blue.200");
+    color: theme("colors.slate.900");
+  }
+
+  /* Dark, saturated highlight so the backdrop's light text stays legible. */
+  .dark input:focus::selection,
+  .dark textarea:focus::selection {
+    background-color: theme("colors.blue.800");
+    color: theme("colors.gray.50");
   }
 }
 


### PR DESCRIPTION
## What changed

`input:focus::selection` and `textarea:focus::selection` in `web_src/src/App.css` no longer use the `Highlight`/`HighlightText` system colors. They now use theme colors, with a `.dark` override.

## Why

Those two are OS-level system colors — they follow the operating system's appearance, not this app's `.dark` class. Dark mode here is class-based and independent of the OS (`@custom-variant dark`), so running the app in dark mode on a light-themed OS resolved the pair to a light background with dark text, and the selection lost all contrast.

The agent composer is where this shows up worst, and it explains why the two earlier attempts (#6373, #6379) did not resolve it. `MentionTextarea`'s `<textarea>` is `text-transparent`: the visible glyphs are painted by `BackdropContent` underneath, which is never itself selected. `HighlightText` was recoloring text that nobody can see, while the backdrop's light dark-mode text stayed sitting over the light system highlight. No `selection:text-*` utility on the textarea can fix that — only the highlight background can carry the contrast.

## How

Both rules keep their original shape and location in `@layer base`; only the values change.

- Light mode — `blue.200` background, `slate.900` text.
- Dark mode — `blue.800` background, `gray.50` text. Dark and saturated, so the backdrop's `dark:text-gray-100` stays legible on top of it.

The text color is kept because it still matters for ordinary inputs, whose glyphs really are painted by the field.

Contrast ratio for the composer's selected text (backdrop `gray-100` over the highlight):

| | Before | After |
|---|---|---|
| Dark mode | 1.10:1 | **7.93:1** (WCAG AAA) |
| Light mode | — | **12.56:1** |

## Testing

- `vitest run src/components/AgentSidebar/` — 70 tests pass across 13 files.
- Tailwind compiles both rules as expected, including the `.dark` override.
- Two pre-existing failures in the suite (`RichMessage.spec.tsx`, `RubricWidget.spec.tsx`) come from the generated `@/api-client/sdk.gen` being absent in a plain clone; I confirmed they fail identically on an unmodified checkout.

I did not run Prettier over the file — it reports pre-existing formatting differences in `App.css` on `main`, and reformatting would have buried this change in unrelated noise. I did verify Prettier leaves the lines I touched untouched.

Fixes #6372