### PR TITLE
fix: reject oversized installation files

### DIFF
--- a/pkg/installation/fetch.go
+++ b/pkg/installation/fetch.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	canvasFileName  = "canvas.yaml"
-	consoleFileName = "console.yaml"
+	canvasFileName           = "canvas.yaml"
+	consoleFileName          = "console.yaml"
+	maxInstallationFileBytes = 2 << 20
 )
 
 // errFileNotFound is returned (wrapped) by fetchURL when the upstream
@@ -127,9 +128,12 @@ func fetchURL(rawURL string) ([]byte, error) {
 		return nil, fmt.Errorf("fetch %s: unexpected status %d", rawURL, response.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(response.Body, 2<<20))
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxInstallationFileBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", rawURL, err)
+	}
+	if len(body) > maxInstallationFileBytes {
+		return nil, fmt.Errorf("read %s: file exceeds 2 MiB limit", rawURL)
 	}
 
 	return body, nil

--- a/pkg/installation/fetch_test.go
+++ b/pkg/installation/fetch_test.go
@@ -82,3 +82,29 @@ func TestRawFileURLBuildsExpectedPath(t *testing.T) {
 		rawFileURL(repo, "main", consoleFileName),
 	)
 }
+
+func TestFetchURLFileSizeLimit(t *testing.T) {
+	const rawURL = "https://raw.githubusercontent.com/acme/demo/main/canvas.yaml"
+	const maxFileSize = 2 << 20
+
+	t.Run("accepts a file at the limit", func(t *testing.T) {
+		body := strings.Repeat("x", maxFileSize)
+		stubHTTP(t, map[string]stubResponse{
+			rawURL: {status: http.StatusOK, body: body},
+		})
+
+		result, err := fetchURL(rawURL)
+		require.NoError(t, err)
+		assert.Len(t, result, maxFileSize)
+	})
+
+	t.Run("rejects a file over the limit", func(t *testing.T) {
+		stubHTTP(t, map[string]stubResponse{
+			rawURL: {status: http.StatusOK, body: strings.Repeat("x", maxFileSize+1)},
+		})
+
+		_, err := fetchURL(rawURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds 2 MiB limit")
+	})
+}


### PR DESCRIPTION
## What changed

- Name the existing 2 MiB limit for remotely fetched installation files.
- Read one byte beyond the limit so oversized `canvas.yaml` and `console.yaml` files can be detected.
- Return a clear error instead of passing a silently truncated document to the YAML parser.
- Cover both the exact-limit and over-limit boundaries with regression tests.

## Why

`fetchURL` previously wrapped the response body with `io.LimitReader(..., 2<<20)`. `LimitReader` stops at that boundary without reporting whether more data remains, so a file larger than 2 MiB was returned as if the fetch had succeeded.

Depending on where the truncation landed, installation could then parse incomplete configuration or surface a misleading YAML error. Reading at most one additional byte preserves the memory bound while making the size violation explicit.

## Impact

Files up to and including 2 MiB continue to work. Larger installation files now fail deterministically with an actionable size-limit error.

## Validation

- Added `TestFetchURLFileSizeLimit` for the exact boundary and the first rejected byte.
- `gofmt -s` reports no formatting differences.
- `git diff --check` passes.
- `go test ./pkg/installation -run TestFetchURLFileSizeLimit -count=1` could not compile in this checkout because generated `pkg/protos` files are absent and Docker, required by the repository's codegen workflow, is unavailable on the host.
