### PR TITLE
fix: bundle Monaco workers locally

### DIFF
--- a/web_src/package-lock.json
+++ b/web_src/package-lock.json
@@ -62,6 +62,7 @@
         "lodash.debounce": "^4.0.8",
         "lucide-react": "^0.545.0",
         "mermaid": "^11.15.0",
+        "monaco-editor": "^0.55.1",
         "posthog-js": "^1.399.2",
         "react": "^19.1.0",
         "react-day-picker": "^9.11.0",
@@ -11776,7 +11777,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12776,7 +12776,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"

--- a/web_src/package.json
+++ b/web_src/package.json
@@ -77,6 +77,7 @@
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.545.0",
     "mermaid": "^11.15.0",
+    "monaco-editor": "^0.55.1",
     "posthog-js": "^1.399.2",
     "react": "^19.1.0",
     "react-day-picker": "^9.11.0",

--- a/web_src/src/lib/configureMonaco.spec.ts
+++ b/web_src/src/lib/configureMonaco.spec.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loaderConfig = vi.hoisted(() => vi.fn());
+const workerConstructors = vi.hoisted(() => {
+  class EditorWorker {}
+  class JsonWorker {}
+  class CssWorker {}
+  class HtmlWorker {}
+  class TypeScriptWorker {}
+
+  return { EditorWorker, JsonWorker, CssWorker, HtmlWorker, TypeScriptWorker };
+});
+
+vi.mock("@monaco-editor/react", () => ({ loader: { config: loaderConfig } }));
+vi.mock("monaco-editor", () => ({ editor: {} }));
+vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker", () => ({ default: workerConstructors.EditorWorker }));
+vi.mock("monaco-editor/esm/vs/language/json/json.worker?worker", () => ({ default: workerConstructors.JsonWorker }));
+vi.mock("monaco-editor/esm/vs/language/css/css.worker?worker", () => ({ default: workerConstructors.CssWorker }));
+vi.mock("monaco-editor/esm/vs/language/html/html.worker?worker", () => ({ default: workerConstructors.HtmlWorker }));
+vi.mock("monaco-editor/esm/vs/language/typescript/ts.worker?worker", () => ({
+  default: workerConstructors.TypeScriptWorker,
+}));
+
+import * as monaco from "monaco-editor";
+import { configureMonaco } from "./configureMonaco";
+
+describe("configureMonaco", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.MonacoEnvironment = undefined;
+    configureMonaco();
+  });
+
+  afterEach(() => {
+    globalThis.MonacoEnvironment = undefined;
+  });
+
+  it("gives the React loader the bundled Monaco instance", () => {
+    expect(loaderConfig).toHaveBeenCalledWith({ monaco });
+  });
+
+  it.each([
+    ["json", workerConstructors.JsonWorker],
+    ["css", workerConstructors.CssWorker],
+    ["scss", workerConstructors.CssWorker],
+    ["less", workerConstructors.CssWorker],
+    ["html", workerConstructors.HtmlWorker],
+    ["handlebars", workerConstructors.HtmlWorker],
+    ["razor", workerConstructors.HtmlWorker],
+    ["typescript", workerConstructors.TypeScriptWorker],
+    ["javascript", workerConstructors.TypeScriptWorker],
+    ["python", workerConstructors.EditorWorker],
+  ])("uses the bundled worker for %s", (label, WorkerConstructor) => {
+    const worker = globalThis.MonacoEnvironment?.getWorker?.("worker-id", label);
+
+    expect(worker).toBeInstanceOf(WorkerConstructor);
+  });
+});

--- a/web_src/src/lib/configureMonaco.ts
+++ b/web_src/src/lib/configureMonaco.ts
@@ -1,0 +1,31 @@
+import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import CssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import HtmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+function createMonacoWorker(label: string): Worker {
+  if (label === "json") {
+    return new JsonWorker();
+  }
+  if (label === "css" || label === "scss" || label === "less") {
+    return new CssWorker();
+  }
+  if (label === "html" || label === "handlebars" || label === "razor") {
+    return new HtmlWorker();
+  }
+  if (label === "typescript" || label === "javascript") {
+    return new TypeScriptWorker();
+  }
+  return new EditorWorker();
+}
+
+export function configureMonaco(): void {
+  globalThis.MonacoEnvironment = {
+    getWorker: (_workerId, label) => createMonacoWorker(label),
+  };
+
+  loader.config({ monaco });
+}

--- a/web_src/src/main.tsx
+++ b/web_src/src/main.tsx
@@ -8,7 +8,9 @@ import { setupApiInterceptor } from "./lib/api-interceptor.ts";
 import { Sentry } from "./sentry.ts";
 import "./posthog.ts";
 import { ErrorPage } from "./components/ErrorPage.tsx";
+import { configureMonaco } from "./lib/configureMonaco.ts";
 
+configureMonaco();
 // Setup the API interceptor to handle 401 responses
 setupApiInterceptor();
 


### PR DESCRIPTION
## Summary

- configure `@monaco-editor/react` to use the Monaco ESM build shipped with the UI
- route editor, JSON, CSS, HTML, and TypeScript language services to Vite-bundled web workers
- initialize the local Monaco configuration before the React application starts
- cover the loader configuration and every worker route with unit tests

## Why

The React wrapper defaults to Monaco's AMD build on jsDelivr. That leaves self-hosted installations dependent on an external worker script, which fails when the CDN is unavailable or blocked. Using Monaco's documented Vite integration keeps both the editor runtime and its workers inside the SuperPlane build.

Fixes #5831

## Validation

- `npx eslint src/main.tsx src/lib/configureMonaco.ts src/lib/configureMonaco.spec.ts`
- `npm run format:check`
- `npm run lint:budget`
- `npm run test:run -- src/lib/configureMonaco.spec.ts src/lib/monaco.spec.ts` (16 tests)
- targeted TypeScript check for the new configuration and tests
- isolated Vite production build, confirming five local worker assets are emitted

The full UI build could not be completed in this checkout because the generated `web_src/src/api-client` directory is absent and Docker is not available to run the repository's generation workflow.
