### PR TITLE
feat: push factory work-order updates over websocket

### DIFF
--- a/pkg/grpc/actions/factories/close_work_order.go
+++ b/pkg/grpc/actions/factories/close_work_order.go
@@ -6,9 +6,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
+	factoryevents "github.com/superplanehq/superplane/pkg/models/factory"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
@@ -58,12 +60,16 @@ func CloseWorkOrder(ctx context.Context, organizationID string, req *pb.CloseWor
 	logger = logging.WithWorkOrder(logger, *order)
 	order, err = order.Close(db, result, &closedBy)
 	if err != nil {
+		logger.WithError(err).Error("close work order failed")
 		return nil, factoryErrorToStatus(err, "failed to close work order")
 	}
 
-	if err != nil {
-		logger.WithError(err).Error("close work order failed")
-		return nil, factoryErrorToStatus(err, "failed to close work order")
+	if err := messages.PublishFactoryWorkOrderUpdated(
+		factory.ID.String(),
+		order.ID.String(),
+		factoryevents.EventTypeOrderClosed,
+	); err != nil {
+		logger.WithError(err).Warnf("Failed to publish factory work order updated for order %s", order.ID)
 	}
 
 	order, err = factory.FindWorkOrder(db, orderID)

--- a/pkg/grpc/actions/factories/create_work_order.go
+++ b/pkg/grpc/actions/factories/create_work_order.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
+	factoryevents "github.com/superplanehq/superplane/pkg/models/factory"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
 
@@ -52,6 +55,14 @@ func CreateWorkOrder(ctx context.Context, organizationID string, req *pb.CreateW
 	order, err := factory.CreateWorkOrder(db, title, req.GetDescription(), &createdByID, assigneeIDs)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create work order")
+	}
+
+	if err := messages.PublishFactoryWorkOrderUpdated(
+		factory.ID.String(),
+		order.ID.String(),
+		factoryevents.EventTypeOrderOpened,
+	); err != nil {
+		log.WithError(err).Warnf("Failed to publish factory work order updated for order %s", order.ID)
 	}
 
 	serialized, err := loadAndSerializeWorkOrder(ctx, order)

--- a/pkg/grpc/actions/factories/dispatch_work_order.go
+++ b/pkg/grpc/actions/factories/dispatch_work_order.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
+	factoryevents "github.com/superplanehq/superplane/pkg/models/factory"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 	"gorm.io/gorm"
 )
@@ -91,6 +92,14 @@ func DispatchWorkOrder(ctx context.Context, organizationID string, req *pb.Dispa
 		if err := messages.NewCanvasRunMessage(pendingRun.WorkflowID.String(), pendingRun.ID.String()).PublishPending(); err != nil {
 			logger.WithError(err).Errorf("Error publishing pending canvas run message: %v", err)
 		}
+	}
+
+	if err := messages.PublishFactoryWorkOrderUpdated(
+		factoryID.String(),
+		order.ID.String(),
+		factoryevents.EventTypeLineStepExecutionCreated,
+	); err != nil {
+		logger.WithError(err).Warnf("Failed to publish factory work order updated for order %s", order.ID)
 	}
 
 	serialized, err := loadAndSerializeWorkOrder(ctx, order)

--- a/pkg/grpc/actions/factories/update_work_order_assignees.go
+++ b/pkg/grpc/actions/factories/update_work_order_assignees.go
@@ -4,10 +4,13 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
+	factoryevents "github.com/superplanehq/superplane/pkg/models/factory"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 	"gorm.io/gorm"
 )
@@ -63,6 +66,14 @@ func UpdateWorkOrderAssignees(
 	})
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update work order assignees")
+	}
+
+	if err := messages.PublishFactoryWorkOrderUpdated(
+		factoryID.String(),
+		orderID.String(),
+		factoryevents.EventTypeOrderAssigneesUpdated,
+	); err != nil {
+		log.WithError(err).Warnf("Failed to publish factory work order updated for order %s", orderID)
 	}
 
 	factory, err := models.FindFactory(tx, orgID, factoryID)

--- a/pkg/grpc/actions/messages/factory_work_order.go
+++ b/pkg/grpc/actions/messages/factory_work_order.go
@@ -1,0 +1,34 @@
+package messages
+
+import (
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	// FactoryWorkOrderUpdatedRoutingKey: factory mutations / run fan-out -> EventDistributer -> websocket clients.
+	FactoryWorkOrderUpdatedRoutingKey = "factory-work-order-updated"
+)
+
+type FactoryWorkOrderUpdatedMessage struct {
+	message *pb.FactoryWorkOrderUpdatedMessage
+}
+
+func NewFactoryWorkOrderUpdatedMessage(factoryID, orderID, reason string) FactoryWorkOrderUpdatedMessage {
+	return FactoryWorkOrderUpdatedMessage{
+		message: &pb.FactoryWorkOrderUpdatedMessage{
+			FactoryId: factoryID,
+			OrderId:   orderID,
+			Reason:    reason,
+			Timestamp: timestamppb.Now(),
+		},
+	}
+}
+
+func (m FactoryWorkOrderUpdatedMessage) Publish() error {
+	return Publish(CanvasExchange, FactoryWorkOrderUpdatedRoutingKey, toBytes(m.message))
+}
+
+func PublishFactoryWorkOrderUpdated(factoryID, orderID, reason string) error {
+	return NewFactoryWorkOrderUpdatedMessage(factoryID, orderID, reason).Publish()
+}

--- a/pkg/public/factory_ws.go
+++ b/pkg/public/factory_ws.go
@@ -1,0 +1,84 @@
+package public
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/features"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/public/middleware"
+	"github.com/superplanehq/superplane/pkg/public/ws"
+	"github.com/superplanehq/superplane/pkg/telemetry"
+	"github.com/superplanehq/superplane/pkg/workers/eventdistributer"
+)
+
+// handleFactoryWebSocket authenticates an org member and verifies the factory
+// belongs to that organization before subscribing to work-order updates.
+func (s *Server) handleFactoryWebSocket(w http.ResponseWriter, r *http.Request) {
+	user, ok := middleware.GetUserFromContext(r.Context())
+	if !ok {
+		telemetry.RecordWebSocketConnectionOutcome(
+			r.Context(),
+			ws.KindFactory,
+			telemetry.WebSocketConnectionOutcomeAuthError,
+		)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	factoryID, err := uuid.Parse(mux.Vars(r)["factoryId"])
+	if err != nil {
+		telemetry.RecordWebSocketConnectionOutcome(
+			r.Context(),
+			ws.KindFactory,
+			telemetry.WebSocketConnectionOutcomeAuthError,
+		)
+		http.Error(w, "invalid factory id", http.StatusBadRequest)
+		return
+	}
+
+	enabled, err := models.HasExperimentalFeature(user.OrganizationID, features.FeatureFactories)
+	if err != nil {
+		http.Error(w, "failed to load organization", http.StatusInternalServerError)
+		return
+	}
+	if !enabled {
+		telemetry.RecordWebSocketConnectionOutcome(
+			r.Context(),
+			ws.KindFactory,
+			telemetry.WebSocketConnectionOutcomeAuthError,
+		)
+		http.Error(w, "factories are not enabled", http.StatusForbidden)
+		return
+	}
+
+	if _, err := models.FindFactory(database.DB(r.Context()), user.OrganizationID, factoryID); err != nil {
+		telemetry.RecordWebSocketConnectionOutcome(
+			r.Context(),
+			ws.KindFactory,
+			telemetry.WebSocketConnectionOutcomeAuthError,
+		)
+		http.Error(w, "factory not found", http.StatusNotFound)
+		return
+	}
+
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		telemetry.RecordWebSocketConnectionOutcome(
+			r.Context(),
+			ws.KindFactory,
+			telemetry.WebSocketConnectionOutcomeUpgradeError,
+		)
+		if _, ok := err.(websocket.HandshakeError); !ok {
+			log.WithError(err).Error("failed to upgrade factory websocket")
+		}
+		return
+	}
+
+	client := s.wsHub.NewClient(conn, eventdistributer.FactoryWebsocketTopic(factoryID.String()))
+	<-client.Done
+}

--- a/pkg/public/factory_ws_test.go
+++ b/pkg/public/factory_ws_test.go
@@ -1,0 +1,60 @@
+package public
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/features"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestFactoryWebSocketRequiresFactoriesFeature(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	server, _, token := setupTestServer(r, t)
+
+	factory, err := models.CreateFactory(database.Conn(), r.Organization.ID, "ws-factory", "desc")
+	require.NoError(t, err)
+
+	response := execRequest(server, requestParams{
+		method:     http.MethodGet,
+		path:       "/ws/factories/" + factory.ID.String() + "?organization_id=" + r.Organization.ID.String(),
+		authCookie: token,
+	})
+
+	assert.Equal(t, http.StatusForbidden, response.Code)
+}
+
+func TestFactoryWebSocketRequiresExistingFactory(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	server, _, token := setupTestServer(r, t)
+	require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, features.FeatureFactories))
+
+	response := execRequest(server, requestParams{
+		method:     http.MethodGet,
+		path:       "/ws/factories/11111111-1111-1111-1111-111111111111?organization_id=" + r.Organization.ID.String(),
+		authCookie: token,
+	})
+
+	assert.Equal(t, http.StatusNotFound, response.Code)
+}
+
+func TestFactoryWebSocketRejectsInvalidFactoryID(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	server, _, token := setupTestServer(r, t)
+	require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, features.FeatureFactories))
+
+	response := execRequest(server, requestParams{
+		method:     http.MethodGet,
+		path:       "/ws/factories/not-a-uuid?organization_id=" + r.Organization.ID.String(),
+		authCookie: token,
+	})
+
+	assert.Equal(t, http.StatusBadRequest, response.Code)
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -533,7 +533,7 @@ func (s *Server) RegisterOpenAPIHandler() {
 	log.Infof("Raw API JSON available at %s", swaggerFilesPath+"/superplane.swagger.json")
 }
 
-// RegisterWebSocketRoutes registers canvas and agent-session WebSocket endpoints.
+// RegisterWebSocketRoutes registers canvas, agent-session, and factory WebSocket endpoints.
 func (s *Server) RegisterWebSocketRoutes() {
 	log.Info("Registering websocket routes")
 
@@ -551,6 +551,13 @@ func (s *Server) RegisterWebSocketRoutes() {
 		"/ws/agents/sessions/{sessionId}",
 		middleware.OrganizationAuthMiddleware(s.jwt).
 			Middleware(http.HandlerFunc(s.handleAgentSessionWebSocket)),
+	)
+
+	// Factory WebSocket: org-scoped work-order updates for a single factory.
+	s.Router.Handle(
+		"/ws/factories/{factoryId}",
+		middleware.OrganizationAuthMiddleware(s.jwt).
+			Middleware(http.HandlerFunc(s.handleFactoryWebSocket)),
 	)
 }
 

--- a/pkg/public/ws/kind.go
+++ b/pkg/public/ws/kind.go
@@ -3,17 +3,23 @@ package ws
 import "strings"
 
 const (
-	KindCanvas = "canvas"
-	KindAgent  = "agent"
+	KindCanvas  = "canvas"
+	KindAgent   = "agent"
+	KindFactory = "factory"
 
 	// AgentSessionTopicPrefix is shared with eventdistributer topic keys.
 	AgentSessionTopicPrefix = "agent-session:"
+	// FactoryTopicPrefix is shared with eventdistributer topic keys.
+	FactoryTopicPrefix = "factory:"
 )
 
 // KindFromTopic maps a hub subscription key to a low-cardinality kind label.
 func KindFromTopic(topic string) string {
 	if strings.HasPrefix(topic, AgentSessionTopicPrefix) {
 		return KindAgent
+	}
+	if strings.HasPrefix(topic, FactoryTopicPrefix) {
+		return KindFactory
 	}
 	return KindCanvas
 }

--- a/pkg/public/ws/kind_test.go
+++ b/pkg/public/ws/kind_test.go
@@ -9,9 +9,12 @@ func TestKindFromTopic(t *testing.T) {
 	}{
 		{topic: "agent-session:abc", want: KindAgent},
 		{topic: "agent-session:", want: KindAgent},
+		{topic: "factory:abc", want: KindFactory},
+		{topic: "factory:", want: KindFactory},
 		{topic: "11111111-1111-1111-1111-111111111111", want: KindCanvas},
 		{topic: "", want: KindCanvas},
 		{topic: "agent-sessions:nope", want: KindCanvas},
+		{topic: "factories:nope", want: KindCanvas},
 	}
 
 	for _, tt := range tests {

--- a/pkg/workers/contexts/factory_context.go
+++ b/pkg/workers/contexts/factory_context.go
@@ -6,13 +6,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/models"
+	factoryevents "github.com/superplanehq/superplane/pkg/models/factory"
 	"gorm.io/gorm"
 )
 
 type FactoryContext struct {
-	tx        *gorm.DB
-	canvas    *models.Canvas
-	execution *models.CanvasNodeExecution
+	tx                 *gorm.DB
+	canvas             *models.Canvas
+	execution          *models.CanvasNodeExecution
+	onWorkOrderUpdated func(factoryID, orderID, reason string)
 }
 
 func NewFactoryContext(tx *gorm.DB, canvas *models.Canvas, execution *models.CanvasNodeExecution) *FactoryContext {
@@ -21,6 +23,11 @@ func NewFactoryContext(tx *gorm.DB, canvas *models.Canvas, execution *models.Can
 		canvas:    canvas,
 		execution: execution,
 	}
+}
+
+func (c *FactoryContext) WithWorkOrderUpdated(callback func(factoryID, orderID, reason string)) *FactoryContext {
+	c.onWorkOrderUpdated = callback
+	return c
 }
 
 func (c *FactoryContext) CreateWorkOrder(params core.WorkOrderParams) (*core.WorkOrder, error) {
@@ -48,6 +55,10 @@ func (c *FactoryContext) CreateWorkOrder(params core.WorkOrderParams) (*core.Wor
 	workOrder, err := factory.CreateWorkOrder(c.tx, params.Title, params.Description, nil, []uuid.UUID{})
 	if err != nil {
 		return nil, err
+	}
+
+	if c.onWorkOrderUpdated != nil {
+		c.onWorkOrderUpdated(factory.ID.String(), workOrder.ID.String(), factoryevents.EventTypeOrderOpened)
 	}
 
 	return &core.WorkOrder{

--- a/pkg/workers/event_distributer.go
+++ b/pkg/workers/event_distributer.go
@@ -62,6 +62,7 @@ func (e *EventDistributer) Start() error {
 		{messages.CanvasExchange, messages.CanvasDeletedRoutingKey, e.createHandler(eventdistributer.HandleCanvasDeleted)},
 		{messages.CanvasExchange, messages.CanvasMemoryUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasMemoryUpdated)},
 		{messages.CanvasExchange, messages.AgentSessionEventRoutingKey, e.createHandler(eventdistributer.HandleAgentSessionEvent)},
+		{messages.CanvasExchange, messages.FactoryWorkOrderUpdatedRoutingKey, e.createHandler(eventdistributer.HandleFactoryWorkOrderUpdated)},
 	}
 
 	for _, routingKey := range messages.ExecutionRoutingKeys {

--- a/pkg/workers/eventdistributer/factory_work_order.go
+++ b/pkg/workers/eventdistributer/factory_work_order.go
@@ -1,0 +1,64 @@
+package eventdistributer
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/pkg/public/ws"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	FactoryTopicPrefix    = "factory:"
+	WorkOrderUpdatedEvent = "work_order_updated"
+)
+
+// FactoryWebsocketTopic is the hub key shared by publisher and subscriber.
+func FactoryWebsocketTopic(factoryID string) string {
+	return FactoryTopicPrefix + factoryID
+}
+
+type factoryWorkOrderUpdatedPayload struct {
+	FactoryID string `json:"factoryId"`
+	OrderID   string `json:"orderId,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type factoryWorkOrderWebsocketEvent struct {
+	Event   string                         `json:"event"`
+	Payload factoryWorkOrderUpdatedPayload `json:"payload"`
+}
+
+func HandleFactoryWorkOrderUpdated(messageBody []byte, wsHub *ws.Hub) error {
+	pbMsg := &pb.FactoryWorkOrderUpdatedMessage{}
+	if err := proto.Unmarshal(messageBody, pbMsg); err != nil {
+		return fmt.Errorf("failed to unmarshal factory work order updated: %w", err)
+	}
+
+	return BroadcastFactoryWorkOrderUpdated(wsHub, pbMsg)
+}
+
+func BroadcastFactoryWorkOrderUpdated(wsHub *ws.Hub, msg *pb.FactoryWorkOrderUpdatedMessage) error {
+	if msg == nil || msg.FactoryId == "" {
+		return fmt.Errorf("missing factoryId in factory work order updated")
+	}
+
+	payload, err := json.Marshal(factoryWorkOrderWebsocketEvent{
+		Event: WorkOrderUpdatedEvent,
+		Payload: factoryWorkOrderUpdatedPayload{
+			FactoryID: msg.FactoryId,
+			OrderID:   msg.OrderId,
+			Reason:    msg.Reason,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal factory work order websocket event: %w", err)
+	}
+
+	topic := FactoryWebsocketTopic(msg.FactoryId)
+	wsHub.BroadcastToWorkflow(topic, payload)
+	log.Debugf("Broadcasted work_order_updated to factory %s (order %s, reason %s)", msg.FactoryId, msg.OrderId, msg.Reason)
+	return nil
+}

--- a/pkg/workers/eventdistributer/factory_work_order_test.go
+++ b/pkg/workers/eventdistributer/factory_work_order_test.go
@@ -1,0 +1,97 @@
+package eventdistributer_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/pkg/public/ws"
+	"github.com/superplanehq/superplane/pkg/workers/eventdistributer"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestFactoryWebsocketTopic_IsStable(t *testing.T) {
+	assert.Equal(t, "factory:abc", eventdistributer.FactoryWebsocketTopic("abc"))
+}
+
+func TestHandleFactoryWorkOrderUpdated_RejectsMalformedPayload(t *testing.T) {
+	hub := ws.NewHub()
+	hub.Run()
+	require.Error(t, eventdistributer.HandleFactoryWorkOrderUpdated([]byte("not protobuf"), hub))
+}
+
+func TestHandleFactoryWorkOrderUpdated_RejectsMissingFactoryID(t *testing.T) {
+	hub := ws.NewHub()
+	hub.Run()
+	payload, err := proto.Marshal(&pb.FactoryWorkOrderUpdatedMessage{
+		OrderId: "order-1",
+		Reason:  "order.opened",
+	})
+	require.NoError(t, err)
+	require.Error(t, eventdistributer.HandleFactoryWorkOrderUpdated(payload, hub))
+}
+
+func TestHandleFactoryWorkOrderUpdated_BroadcastsToTopicSubscribers(t *testing.T) {
+	hub := ws.NewHub()
+	hub.Run()
+
+	factoryID := "11111111-1111-1111-1111-111111111111"
+	orderID := "22222222-2222-2222-2222-222222222222"
+	topic := eventdistributer.FactoryWebsocketTopic(factoryID)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+		hub.NewClient(conn, topic)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	wsURL := "ws://" + u.Host
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.Eventually(t, func() bool {
+		return hub.WorkflowSubscriberCount(topic) == 1
+	}, 2*time.Second, 5*time.Millisecond, "subscriber never registered on hub")
+
+	payload, err := proto.Marshal(&pb.FactoryWorkOrderUpdatedMessage{
+		FactoryId: factoryID,
+		OrderId:   orderID,
+		Reason:    "order.opened",
+	})
+	require.NoError(t, err)
+	require.NoError(t, eventdistributer.HandleFactoryWorkOrderUpdated(payload, hub))
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	var got struct {
+		Event   string `json:"event"`
+		Payload struct {
+			FactoryID string `json:"factoryId"`
+			OrderID   string `json:"orderId"`
+			Reason    string `json:"reason"`
+		} `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, eventdistributer.WorkOrderUpdatedEvent, got.Event)
+	assert.Equal(t, factoryID, got.Payload.FactoryID)
+	assert.Equal(t, orderID, got.Payload.OrderID)
+	assert.Equal(t, "order.opened", got.Payload.Reason)
+}

--- a/pkg/workers/eventdistributer/run.go
+++ b/pkg/workers/eventdistributer/run.go
@@ -2,6 +2,7 @@ package eventdistributer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -10,6 +11,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	factoriespb "github.com/superplanehq/superplane/pkg/protos/factories"
 	"github.com/superplanehq/superplane/pkg/public/ws"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -137,7 +139,27 @@ func handleRunState(workflowID string, runID string, wsHub *ws.Hub) error {
 	wsHub.BroadcastToWorkflow(workflowID, event)
 	log.Debugf("Broadcasted %s event to workflow %s", eventName, workflowID)
 
+	broadcastFactoryWorkOrderForRun(wsHub, runUUID, eventName)
+
 	return nil
+}
+
+func broadcastFactoryWorkOrderForRun(wsHub *ws.Hub, runID uuid.UUID, reason string) {
+	execution, err := models.FindWorkOrderExecutionByRunID(database.Conn(), runID)
+	if err != nil {
+		if !errors.Is(err, models.ErrFactoryWorkOrderExecutionNotFound) {
+			log.WithError(err).Warnf("Failed to look up factory work order execution for run %s", runID)
+		}
+		return
+	}
+
+	if err := BroadcastFactoryWorkOrderUpdated(wsHub, &factoriespb.FactoryWorkOrderUpdatedMessage{
+		FactoryId: execution.FactoryID.String(),
+		OrderId:   execution.WorkOrderID.String(),
+		Reason:    reason,
+	}); err != nil {
+		log.WithError(err).Warnf("Failed to broadcast factory work order update for run %s", runID)
+	}
 }
 
 func marshalCanvasRunJSON(run *pb.CanvasRun) ([]byte, error) {

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -235,6 +235,20 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 		})
 	}
 
+	type pendingFactoryWorkOrderUpdate struct {
+		factoryID string
+		orderID   string
+		reason    string
+	}
+	pendingFactoryWorkOrderUpdates := []pendingFactoryWorkOrderUpdate{}
+	onFactoryWorkOrderUpdated := func(factoryID, orderID, reason string) {
+		pendingFactoryWorkOrderUpdates = append(pendingFactoryWorkOrderUpdates, pendingFactoryWorkOrderUpdate{
+			factoryID: factoryID,
+			orderID:   orderID,
+			reason:    reason,
+		})
+	}
+
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		//
 		// Try to lock the execution record for update.
@@ -271,7 +285,7 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 		}
 
 		metricComponent = node.ComponentName()
-		processErr := w.executeActionNode(tx, execution, node, onNewEvents, onMemoryChanged, onPendingRunCreated)
+		processErr := w.executeActionNode(tx, execution, node, onNewEvents, onMemoryChanged, onPendingRunCreated, onFactoryWorkOrderUpdated)
 		if processErr != nil {
 			metricOutcome = executorOutcomeFailed
 			metricReason = classifyAttemptFailure(processErr, execution)
@@ -306,6 +320,12 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 		}
 	}
 
+	for _, update := range pendingFactoryWorkOrderUpdates {
+		if err := messages.PublishFactoryWorkOrderUpdated(update.factoryID, update.orderID, update.reason); err != nil {
+			w.logger.Errorf("failed to publish factory work order updated RabbitMQ message: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -316,6 +336,7 @@ func (w *NodeExecutor) executeActionNode(
 	onNewEvents func([]models.CanvasEvent),
 	onMemoryChanged func(uuid.UUID),
 	onPendingRunCreated func(workflowID, runID uuid.UUID),
+	onFactoryWorkOrderUpdated func(factoryID, orderID, reason string),
 ) error {
 	logger := logging.WithExecution(
 		logging.WithNode(w.logger, *node),
@@ -384,7 +405,8 @@ func (w *NodeExecutor) executeActionNode(
 		OIDC:        w.oidcProvider,
 		Apps:        contexts.NewAppExecutionContext(tx, workflow, node, execution),
 		Runs:        contexts.NewRunExecutionContext(tx, workflow, node, execution).WithPendingRunCreated(onPendingRunCreated),
-		Factory:     contexts.NewFactoryContext(tx, workflow, execution),
+		Factory: contexts.NewFactoryContext(tx, workflow, execution).
+			WithWorkOrderUpdated(onFactoryWorkOrderUpdated),
 	}
 
 	if node.AppInstallationID != nil {

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -470,3 +470,11 @@ message WorkOrderEvent {
   string type = 2;
   google.protobuf.Struct event = 3;
 }
+
+// Internal AMQP message for factory work-order websocket fan-out.
+message FactoryWorkOrderUpdatedMessage {
+  string factory_id = 1;
+  string order_id = 2;
+  string reason = 3;
+  google.protobuf.Timestamp timestamp = 4;
+}

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -24,37 +24,46 @@ import type {
   FactoryLineStep,
 } from "@/api-client";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
-import { hasActiveWorkOrderExecution } from "@/pages/factories/lib/workOrderExecutions";
 import {
   getWorkOrderEventsNextPageParam,
   WORK_ORDER_EVENTS_PAGE_LIMIT,
 } from "@/pages/factories/lib/workOrderEventsPagination";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-const WORK_ORDER_POLL_INTERVAL_MS = 5_000;
+export const factoryQueryKeys = {
+  list: (organizationId: string) => ["factories", organizationId] as const,
+  detail: (organizationId: string, factoryId: string) => ["factories", organizationId, factoryId] as const,
+  workOrders: (organizationId: string, factoryId: string) =>
+    ["factories", organizationId, factoryId, "work-orders"] as const,
+  workOrderDetail: (organizationId: string, factoryId: string, orderId: string) =>
+    ["factories", organizationId, factoryId, "work-orders", orderId] as const,
+  workOrderEvents: (organizationId: string, factoryId: string, orderId: string) =>
+    ["factories", organizationId, factoryId, "work-orders", orderId, "events"] as const,
+  apps: (organizationId: string, factoryId: string) => ["factories", organizationId, factoryId, "apps"] as const,
+};
 
 function factoryListKey(organizationId: string) {
-  return ["factories", organizationId] as const;
+  return factoryQueryKeys.list(organizationId);
 }
 
 function factoryDetailKey(organizationId: string, factoryId: string) {
-  return ["factories", organizationId, factoryId] as const;
+  return factoryQueryKeys.detail(organizationId, factoryId);
 }
 
 function workOrdersKey(organizationId: string, factoryId: string) {
-  return ["factories", organizationId, factoryId, "work-orders"] as const;
+  return factoryQueryKeys.workOrders(organizationId, factoryId);
 }
 
 function workOrderDetailKey(organizationId: string, factoryId: string, orderId: string) {
-  return ["factories", organizationId, factoryId, "work-orders", orderId] as const;
+  return factoryQueryKeys.workOrderDetail(organizationId, factoryId, orderId);
 }
 
 function workOrderEventsKey(organizationId: string, factoryId: string, orderId: string) {
-  return ["factories", organizationId, factoryId, "work-orders", orderId, "events"] as const;
+  return factoryQueryKeys.workOrderEvents(organizationId, factoryId, orderId);
 }
 
 export function factoryAppsKey(organizationId: string, factoryId: string) {
-  return ["factories", organizationId, factoryId, "apps"] as const;
+  return factoryQueryKeys.apps(organizationId, factoryId);
 }
 
 export function useFactories(organizationId: string, enabled = true) {
@@ -100,10 +109,6 @@ export function useFactoryWorkOrders(organizationId: string, factoryId: string) 
       return response.data?.orders ?? [];
     },
     enabled: Boolean(organizationId && factoryId),
-    refetchInterval: (query) =>
-      query.state.data?.some((order) => hasActiveWorkOrderExecution(order.executions))
-        ? WORK_ORDER_POLL_INTERVAL_MS
-        : false,
   });
 }
 
@@ -123,10 +128,6 @@ export function useWorkOrder(organizationId: string, factoryId: string, orderId:
       return response.data.order;
     },
     enabled: Boolean(organizationId && factoryId && orderId),
-    refetchInterval: (query) =>
-      query.state.data && hasActiveWorkOrderExecution(query.state.data.executions)
-        ? WORK_ORDER_POLL_INTERVAL_MS
-        : false,
   });
 }
 
@@ -149,7 +150,6 @@ export function useWorkOrderEvents(organizationId: string, factoryId: string, or
     getNextPageParam: getWorkOrderEventsNextPageParam,
     initialPageParam: undefined as string | undefined,
     enabled: Boolean(organizationId && factoryId && orderId),
-    refetchInterval: WORK_ORDER_POLL_INTERVAL_MS,
   });
 }
 

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -109,6 +109,8 @@ export function useFactoryWorkOrders(organizationId: string, factoryId: string) 
       return response.data?.orders ?? [];
     },
     enabled: Boolean(organizationId && factoryId),
+    // Live via websocket; remount must refetch instead of serving 5m global stale cache.
+    staleTime: 0,
   });
 }
 
@@ -128,6 +130,7 @@ export function useWorkOrder(organizationId: string, factoryId: string, orderId:
       return response.data.order;
     },
     enabled: Boolean(organizationId && factoryId && orderId),
+    staleTime: 0,
   });
 }
 
@@ -150,6 +153,7 @@ export function useWorkOrderEvents(organizationId: string, factoryId: string, or
     getNextPageParam: getWorkOrderEventsNextPageParam,
     initialPageParam: undefined as string | undefined,
     enabled: Boolean(organizationId && factoryId && orderId),
+    staleTime: 0,
   });
 }
 

--- a/web_src/src/hooks/useFactoryWebsocket.spec.ts
+++ b/web_src/src/hooks/useFactoryWebsocket.spec.ts
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createElement, type ReactNode } from "react";
+import { factoryQueryKeys } from "@/hooks/useFactoryData";
+
+const { useWebSocketMock } = vi.hoisted(() => ({
+  useWebSocketMock: vi.fn(),
+}));
+
+vi.mock("react-use-websocket", () => ({
+  default: useWebSocketMock,
+}));
+
+import { useFactoryWebsocket } from "@/hooks/useFactoryWebsocket";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function lastCall() {
+  const call = useWebSocketMock.mock.calls.at(-1);
+  if (!call) throw new Error("useWebSocket was not invoked");
+  return call;
+}
+
+function renderFactoryWebsocket(organizationId = "org-1", factoryId = "factory-1") {
+  const queryClient = new QueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  renderHook(() => useFactoryWebsocket(organizationId, factoryId), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children),
+  });
+  return { queryClient, invalidateSpy };
+}
+
+function emit(payload: unknown) {
+  const [, options] = lastCall();
+  const onMessage = options.onMessage as (e: MessageEvent<unknown>) => void;
+  act(() => {
+    onMessage(
+      new MessageEvent("message", {
+        data: JSON.stringify(payload),
+      }),
+    );
+  });
+}
+
+describe("useFactoryWebsocket", () => {
+  it("connects to the per-factory WebSocket URL with org id", () => {
+    renderFactoryWebsocket();
+    const [url, , enabled] = lastCall();
+    expect(url).toContain("/ws/factories/factory-1");
+    expect(url).toContain("organization_id=org-1");
+    expect(enabled).toBe(true);
+  });
+
+  it("disables the connection when factory id is missing", () => {
+    const queryClient = new QueryClient();
+    renderHook(() => useFactoryWebsocket("org-1", ""), {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+    const [url, , enabled] = lastCall();
+    expect(url).toBeNull();
+    expect(enabled).toBe(false);
+  });
+
+  it("invalidates work-order list on work_order_updated", () => {
+    const { invalidateSpy } = renderFactoryWebsocket();
+    emit({
+      event: "work_order_updated",
+      payload: { factoryId: "factory-1", orderId: "order-1", reason: "order.opened" },
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: factoryQueryKeys.workOrders("org-1", "factory-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: factoryQueryKeys.workOrderDetail("org-1", "factory-1", "order-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: factoryQueryKeys.workOrderEvents("org-1", "factory-1", "order-1"),
+    });
+  });
+
+  it("ignores events for a different factory", () => {
+    const { invalidateSpy } = renderFactoryWebsocket();
+    invalidateSpy.mockClear();
+    emit({
+      event: "work_order_updated",
+      payload: { factoryId: "other-factory", orderId: "order-1" },
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("invalidates work-order queries on reconnect", () => {
+    const { invalidateSpy } = renderFactoryWebsocket();
+    invalidateSpy.mockClear();
+    const [, options] = lastCall();
+    const onOpen = options.onOpen as () => void;
+    act(() => {
+      onOpen();
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: factoryQueryKeys.workOrders("org-1", "factory-1"),
+    });
+  });
+});

--- a/web_src/src/hooks/useFactoryWebsocket.spec.ts
+++ b/web_src/src/hooks/useFactoryWebsocket.spec.ts
@@ -94,11 +94,17 @@ describe("useFactoryWebsocket", () => {
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
-  it("invalidates work-order queries on reconnect", () => {
+  it("skips invalidation on the first open and invalidates on reconnect", () => {
     const { invalidateSpy } = renderFactoryWebsocket();
     invalidateSpy.mockClear();
     const [, options] = lastCall();
     const onOpen = options.onOpen as () => void;
+
+    act(() => {
+      onOpen();
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
     act(() => {
       onOpen();
     });

--- a/web_src/src/hooks/useFactoryWebsocket.ts
+++ b/web_src/src/hooks/useFactoryWebsocket.ts
@@ -1,0 +1,97 @@
+import { useCallback } from "react";
+import { useWebSocket } from "@/lib/reactUseWebsocket";
+import { useQueryClient } from "@tanstack/react-query";
+import { factoryQueryKeys } from "./useFactoryData";
+
+const SOCKET_SERVER_URL = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws/factories/`;
+
+type FactoryWorkOrderUpdatedPayload = {
+  factoryId?: string;
+  orderId?: string;
+  reason?: string;
+};
+
+type FactoryWebsocketMessage = {
+  event?: string;
+  payload?: FactoryWorkOrderUpdatedPayload;
+};
+
+function parseFactoryEvent(event: MessageEvent<unknown>): FactoryWebsocketMessage | null {
+  try {
+    return JSON.parse(event.data as string) as FactoryWebsocketMessage;
+  } catch (error) {
+    console.warn("factory ws: failed to parse message", error);
+    return null;
+  }
+}
+
+export function invalidateFactoryWorkOrderQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  organizationId: string,
+  factoryId: string,
+  orderId?: string,
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: factoryQueryKeys.workOrders(organizationId, factoryId),
+  });
+
+  if (!orderId) {
+    return;
+  }
+
+  void queryClient.invalidateQueries({
+    queryKey: factoryQueryKeys.workOrderDetail(organizationId, factoryId, orderId),
+  });
+  void queryClient.invalidateQueries({
+    queryKey: factoryQueryKeys.workOrderEvents(organizationId, factoryId, orderId),
+  });
+}
+
+export function useFactoryWebsocket(organizationId: string, factoryId: string, enabled = true): void {
+  const queryClient = useQueryClient();
+
+  const invalidate = useCallback(
+    (orderId?: string) => {
+      if (!organizationId || !factoryId) {
+        return;
+      }
+      invalidateFactoryWorkOrderQueries(queryClient, organizationId, factoryId, orderId);
+    },
+    [queryClient, organizationId, factoryId],
+  );
+
+  const onMessage = useCallback(
+    (event: MessageEvent<unknown>) => {
+      const data = parseFactoryEvent(event);
+      if (!data || data.event !== "work_order_updated") {
+        return;
+      }
+      if (data.payload?.factoryId && data.payload.factoryId !== factoryId) {
+        return;
+      }
+      invalidate(data.payload?.orderId);
+    },
+    [factoryId, invalidate],
+  );
+
+  const onOpen = useCallback(() => {
+    // Catch updates missed while disconnected; WS is the only push channel.
+    invalidate();
+  }, [invalidate]);
+
+  const url = organizationId && factoryId ? `${SOCKET_SERVER_URL}${factoryId}?organization_id=${organizationId}` : null;
+
+  useWebSocket(
+    url,
+    {
+      shouldReconnect: () => true,
+      reconnectAttempts: Number.POSITIVE_INFINITY,
+      reconnectInterval: 3000,
+      heartbeat: false,
+      share: false,
+      onMessage,
+      onOpen,
+    },
+    enabled && url !== null,
+  );
+}

--- a/web_src/src/hooks/useFactoryWebsocket.ts
+++ b/web_src/src/hooks/useFactoryWebsocket.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useWebSocket } from "@/lib/reactUseWebsocket";
 import { useQueryClient } from "@tanstack/react-query";
 import { factoryQueryKeys } from "./useFactoryData";
@@ -49,6 +49,7 @@ export function invalidateFactoryWorkOrderQueries(
 
 export function useFactoryWebsocket(organizationId: string, factoryId: string, enabled = true): void {
   const queryClient = useQueryClient();
+  const hasConnectedOnce = useRef(false);
 
   const invalidate = useCallback(
     (orderId?: string) => {
@@ -75,6 +76,11 @@ export function useFactoryWebsocket(organizationId: string, factoryId: string, e
   );
 
   const onOpen = useCallback(() => {
+    if (!hasConnectedOnce.current) {
+      hasConnectedOnce.current = true;
+      return;
+    }
+
     // Catch updates missed while disconnected; WS is the only push channel.
     invalidate();
   }, [invalidate]);

--- a/web_src/src/pages/factories/useFactoryDetailPage.tsx
+++ b/web_src/src/pages/factories/useFactoryDetailPage.tsx
@@ -1,5 +1,6 @@
 import { usePermissions } from "@/contexts/usePermissions";
 import { useFactory, useFactoryApps, useFactoryWorkOrders } from "@/hooks/useFactoryData";
+import { useFactoryWebsocket } from "@/hooks/useFactoryWebsocket";
 import { useMe } from "@/hooks/useMe";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
@@ -24,6 +25,7 @@ export function useFactoryDetailPage(organizationId: string, factoryId: string) 
   const [statusFilter, setStatusFilter] = useState<WorkOrderStatusFilter>("open");
 
   const { data: factory, isLoading: factoryLoading, error: factoryError } = useFactory(organizationId, factoryId);
+  useFactoryWebsocket(organizationId, factoryId);
   const {
     data: workOrders = [],
     isLoading: ordersLoading,

--- a/web_src/src/pages/factories/useWorkOrderDetailPage.tsx
+++ b/web_src/src/pages/factories/useWorkOrderDetailPage.tsx
@@ -1,5 +1,6 @@
 import { usePermissions } from "@/contexts/usePermissions";
 import { useFactory, useWorkOrder, useWorkOrderEvents } from "@/hooks/useFactoryData";
+import { useFactoryWebsocket } from "@/hooks/useFactoryWebsocket";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { useMemo } from "react";
@@ -13,6 +14,7 @@ export function useWorkOrderDetailPage(organizationId: string, factoryId: string
   const { canAct, isLoading: permissionsLoading } = usePermissions();
 
   const { data: factory, isLoading: factoryLoading, error: factoryError } = useFactory(organizationId, factoryId);
+  useFactoryWebsocket(organizationId, factoryId);
   const { data: order, isLoading: orderLoading, error: orderError } = useWorkOrder(organizationId, factoryId, orderId);
   const eventsQuery = useWorkOrderEvents(organizationId, factoryId, orderId);
   const events = useMemo(() => flattenWorkOrderEventsPages(eventsQuery.data?.pages), [eventsQuery.data?.pages]);


### PR DESCRIPTION
## Summary
- Add factory-scoped websocket (`/ws/factories/{factoryId}`) that fans out work-order lifecycle and run-state updates via EventDistributer
- Publish protobuf `FactoryWorkOrderUpdatedMessage` on create/close/assignees/dispatch, and from canvas run handler when a run is tied to a work-order execution
- Replace frontend 5s polling with `useFactoryWebsocket` invalidating React Query caches on push and reconnect

## Test plan
- [ ] Open a factory work-orders page; create/close/reassign an order and confirm list updates without waiting ~5s
- [ ] Dispatch a work order and confirm execution state advances live on list + detail
- [ ] Confirm work-order events timeline updates while detail page is open
- [ ] With factories feature disabled, websocket connect returns 403
- [ ] Unit tests: `./pkg/workers/eventdistributer`, `./pkg/public`, `useFactoryWebsocket.spec.ts`


Made with [Cursor](https://cursor.com)