### PR TITLE
fix: keep sidebar clear when expression tip and description both appear

### DIFF
--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
@@ -71,6 +71,26 @@ describe("AutoCompleteInput preview toggle", () => {
 
     expect(screen.getByRole("button", { name: "Preview title" })).toBeInTheDocument();
   });
+
+  it("hides the expression tip when quickTip is null", () => {
+    render(
+      <AutoCompleteInput
+        exampleObj={{ __root: { data: { name: "DCO" } } }}
+        value=""
+        onChange={vi.fn()}
+        placeholder="{{ root().data.foo }}"
+        startWord="{{"
+        prefix="{{ "
+        suffix=" }}"
+        showValuePreview
+        quickTip={null}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Preview" })).toBeInTheDocument();
+    expect(screen.queryByText(/to write/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Tip:/i)).not.toBeInTheDocument();
+  });
 });
 
 describe("AutoCompleteInput suggestions", () => {

--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -21,7 +21,13 @@ export interface AutoCompleteInputProps extends Omit<React.ComponentPropsWithout
   noExampleObjectText?: string;
   showValuePreview?: boolean;
   valuePreviewLabel?: string;
-  quickTip?: string;
+  /**
+   * Tip shown on the right of the bottom bar.
+   * - `string`: render this tip
+   * - `null`: hide the tip (also skips the default expression tip)
+   * - omitted/`undefined`: keep the default "Use {{ ... }}" tip
+   */
+  quickTip?: string | null;
   expressionMode?: "wrapped" | "raw";
   /** Labels of suggestions to hide (e.g., ["$", "previous"] to restrict to root() only). */
   excludedSuggestions?: string[];
@@ -1371,7 +1377,9 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
     const shouldShowValuePreview = showValuePreview && highlightedIndex >= 0;
 
     const showPreviewToggle = showValuePreview;
-    const showBottomBar = showPreviewToggle || (isFocused && !!quickTip);
+    const hasCustomQuickTip = typeof quickTip === "string" && quickTip.length > 0;
+    const hideQuickTip = quickTip === null || quickTip === "";
+    const showBottomBar = showPreviewToggle || (isFocused && hasCustomQuickTip);
 
     return (
       <div
@@ -1466,7 +1474,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
             {...rest}
           />
         </span>
-        {/* Bottom bar with preview toggle and quickTip — rendered in normal flow so it
+        {/* Bottom bar with preview toggle and quickTip - rendered in normal flow so it
             never overlaps the input regardless of the parent layout (grid, flex, etc.) */}
         {showBottomBar && (
           <div className="flex items-center justify-between mt-1 px-0.5">
@@ -1492,31 +1500,35 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
             ) : (
               <span />
             )}
-            {/* QuickTip - right side */}
-            <span className="flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-gray-400">
-              {quickTip
-                ? renderQuickTip(quickTip)
-                : [
-                    "Use ",
-                    <code
-                      key="default-tip"
-                      className="bg-slate-100 dark:bg-gray-700 px-1 py-0.5 rounded text-gray-700 dark:text-gray-300"
-                    >
-                      {"{{"}
-                    </code>,
-                    " to write ",
-                    <a
-                      key="expr-link"
-                      href="https://expr-lang.org/docs/language-definition"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 dark:text-blue-400 hover:underline"
-                    >
-                      expr
-                    </a>,
-                    " expressions",
-                  ]}
-            </span>
+            {/* QuickTip - right side. null/"" hides the tip; undefined keeps the default. */}
+            {!hideQuickTip ? (
+              <span className="flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-gray-400">
+                {hasCustomQuickTip
+                  ? renderQuickTip(quickTip)
+                  : [
+                      "Use ",
+                      <code
+                        key="default-tip"
+                        className="bg-slate-100 dark:bg-gray-700 px-1 py-0.5 rounded text-gray-700 dark:text-gray-300"
+                      >
+                        {"{{"}
+                      </code>,
+                      " to write ",
+                      <a
+                        key="expr-link"
+                        href="https://expr-lang.org/docs/language-definition"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        expr
+                      </a>,
+                      " expressions",
+                    ]}
+              </span>
+            ) : (
+              <span />
+            )}
           </div>
         )}
 

--- a/web_src/src/ui/configurationFieldRenderer/AnyPredicateListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AnyPredicateListFieldRenderer.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { FieldRendererProps } from "./types";
 import { AutoCompleteInput } from "@/components/AutoCompleteInput/AutoCompleteInput";
+import { resolveExpressionQuickTip } from "./expressionQuickTip";
 
 interface Predicate {
   type: string;
@@ -69,7 +70,7 @@ export const AnyPredicateListFieldRenderer: React.FC<FieldRendererProps> = ({
                 suffix=" }}"
                 inputSize="md"
                 showValuePreview
-                quickTip="Tip: type `{{` to start an expression."
+                quickTip={resolveExpressionQuickTip(field, allowExpressions)}
                 className=""
               />
             ) : (

--- a/web_src/src/ui/configurationFieldRenderer/ExpressionFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ExpressionFieldRenderer.tsx
@@ -3,6 +3,7 @@ import { Input } from "@/components/ui/input";
 import { AutoCompleteInput } from "@/components/AutoCompleteInput/AutoCompleteInput";
 import type { FieldRendererProps } from "./types";
 import { toTestId } from "@/lib/testID";
+import { resolveExpressionQuickTip } from "./expressionQuickTip";
 
 export const ExpressionFieldRenderer: React.FC<FieldRendererProps> = ({
   field,
@@ -48,7 +49,7 @@ export const ExpressionFieldRenderer: React.FC<FieldRendererProps> = ({
       expressionMode="raw"
       inputSize="md"
       showValuePreview
-      quickTip="Tip: type `$` to browse node payloads."
+      quickTip={resolveExpressionQuickTip(field, allowExpressions)}
       className=""
       data-testid={toTestId(`expression-field-${field.name}`)}
     />

--- a/web_src/src/ui/configurationFieldRenderer/FieldDescriptionTooltip.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/FieldDescriptionTooltip.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
+
+export type FieldDescriptionTooltipProps = {
+  title: string;
+  description: string;
+  /** Optional expression tip kept available when the inline quick tip is hidden. */
+  expressionTip?: string;
+};
+
+export function FieldDescriptionTooltip({ title, description, expressionTip }: FieldDescriptionTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          aria-label={`About ${title}`}
+        >
+          <Info className="size-4 shrink-0" aria-hidden />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs space-y-1.5 text-balance">
+        <p>{description}</p>
+        {expressionTip ? <p>{expressionTip}</p> : null}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web_src/src/ui/configurationFieldRenderer/IntegrationResourceFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/IntegrationResourceFieldRenderer.tsx
@@ -8,6 +8,7 @@ import type { ConfigurationField } from "../../api-client";
 import { useIntegrationResources } from "@/hooks/useIntegrations";
 import { toTestId } from "@/lib/testID";
 import { type RefObject, useEffect, useMemo, useState } from "react";
+import { resolveExpressionQuickTip } from "./expressionQuickTip";
 
 interface IntegrationResourceFieldRendererProps {
   field: ConfigurationField;
@@ -230,7 +231,7 @@ export const IntegrationResourceFieldRenderer = ({
         suffix=" }}"
         inputSize="md"
         showValuePreview
-        quickTip="Tip: type {{ to start an expression."
+        quickTip={resolveExpressionQuickTip(field, allowExpressions ?? false)}
         className=""
       />
     );

--- a/web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx
@@ -3,6 +3,7 @@ import { Input } from "@/components/ui/input";
 import { AutoCompleteInput } from "@/components/AutoCompleteInput/AutoCompleteInput";
 import type { FieldRendererProps } from "./types";
 import { toTestId } from "@/lib/testID";
+import { resolveExpressionQuickTip } from "./expressionQuickTip";
 
 export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
   field,
@@ -70,7 +71,7 @@ export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
       inputSize="md"
       showValuePreview
       valuePreviewLabel={valuePreviewLabel}
-      quickTip="Tip: type `{{` to start an expression."
+      quickTip={resolveExpressionQuickTip(field, allowExpressions)}
       className=""
       data-testid={toTestId(`string-field-${field.name}`)}
       excludedSuggestions={excludedSuggestions}

--- a/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
@@ -11,6 +11,7 @@ import { toTestId } from "@/lib/testID";
 import { useTheme } from "@/contexts/useTheme";
 import { SimpleTooltip } from "../componentSidebar/SimpleTooltip";
 import { useMonacoExpressionAutocomplete } from "./useMonacoExpressionAutocomplete";
+import { resolveExpressionQuickTip } from "./expressionQuickTip";
 
 const PLAIN_TEXT_MIN_HEIGHT_PX = 120;
 
@@ -98,7 +99,7 @@ const PlainTextFieldRenderer: React.FC<FieldRendererProps> = ({
       minHeight={PLAIN_TEXT_MIN_HEIGHT_PX}
       showValuePreview
       valuePreviewLabel={valuePreviewLabel}
-      quickTip="Tip: type `{{` to start an expression."
+      quickTip={resolveExpressionQuickTip(field, allowExpressions)}
       excludedSuggestions={excludedSuggestions}
       data-testid={toTestId(testId)}
     />
@@ -141,7 +142,7 @@ const PlainTextFieldRenderer: React.FC<FieldRendererProps> = ({
               inputSize="md"
               showValuePreview
               valuePreviewLabel={valuePreviewLabel}
-              quickTip="Tip: type `{{` to start an expression."
+              quickTip={resolveExpressionQuickTip(field, allowExpressions)}
               excludedSuggestions={excludedSuggestions}
               fullHeight
               data-testid={toTestId(`${testId}-modal-input`)}

--- a/web_src/src/ui/configurationFieldRenderer/expressionQuickTip.spec.ts
+++ b/web_src/src/ui/configurationFieldRenderer/expressionQuickTip.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXPRESSION_DOUBLE_BRACE_TIP,
+  EXPRESSION_PAYLOAD_TIP,
+  expressionQuickTipForField,
+  fieldShowsExpressionQuickTip,
+  resolveExpressionQuickTip,
+} from "./expressionQuickTip";
+
+describe("fieldShowsExpressionQuickTip", () => {
+  it("is true for expression-capable field types when expressions are allowed", () => {
+    expect(fieldShowsExpressionQuickTip({ type: "string" }, true)).toBe(true);
+    expect(fieldShowsExpressionQuickTip({ type: "text" }, true)).toBe(true);
+    expect(fieldShowsExpressionQuickTip({ type: "expression" }, true)).toBe(true);
+    expect(fieldShowsExpressionQuickTip({ type: "any-predicate-list" }, true)).toBe(true);
+    expect(fieldShowsExpressionQuickTip({ type: "integration-resource" }, true)).toBe(true);
+  });
+
+  it("is false when expressions are disabled or the field type has no tip", () => {
+    expect(fieldShowsExpressionQuickTip({ type: "string" }, false)).toBe(false);
+    expect(fieldShowsExpressionQuickTip({ type: "boolean" }, true)).toBe(false);
+    expect(fieldShowsExpressionQuickTip({ type: "number" }, true)).toBe(false);
+  });
+});
+
+describe("resolveExpressionQuickTip", () => {
+  it("returns the double-brace tip for string fields without a description", () => {
+    expect(resolveExpressionQuickTip({ type: "string" }, true)).toBe(EXPRESSION_DOUBLE_BRACE_TIP);
+  });
+
+  it("returns the payload tip for expression fields without a description", () => {
+    expect(resolveExpressionQuickTip({ type: "expression" }, true)).toBe(EXPRESSION_PAYLOAD_TIP);
+  });
+
+  it("returns null when the field already has a description", () => {
+    expect(
+      resolveExpressionQuickTip({ type: "string", description: "Choose a repository." }, true),
+    ).toBeNull();
+  });
+
+  it("returns undefined when the field cannot show an expression tip", () => {
+    expect(resolveExpressionQuickTip({ type: "boolean" }, true)).toBeUndefined();
+    expect(resolveExpressionQuickTip({ type: "string" }, false)).toBeUndefined();
+  });
+});
+
+describe("expressionQuickTipForField", () => {
+  it("picks the tip text by field type", () => {
+    expect(expressionQuickTipForField({ type: "expression" })).toBe(EXPRESSION_PAYLOAD_TIP);
+    expect(expressionQuickTipForField({ type: "string" })).toBe(EXPRESSION_DOUBLE_BRACE_TIP);
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/expressionQuickTip.ts
+++ b/web_src/src/ui/configurationFieldRenderer/expressionQuickTip.ts
@@ -1,0 +1,44 @@
+import type { ConfigurationField } from "@/api-client";
+
+export const EXPRESSION_DOUBLE_BRACE_TIP = "Tip: type `{{` to start an expression.";
+export const EXPRESSION_PAYLOAD_TIP = "Tip: type `$` to browse node payloads.";
+
+/** Field types that render an AutoCompleteInput expression quick tip. */
+export function fieldShowsExpressionQuickTip(
+  field: Pick<ConfigurationField, "type">,
+  allowExpressions: boolean,
+): boolean {
+  if (!allowExpressions) return false;
+
+  switch (field.type) {
+    case "string":
+    case "text":
+    case "expression":
+    case "any-predicate-list":
+    case "integration-resource":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function expressionQuickTipForField(field: Pick<ConfigurationField, "type">): string {
+  if (field.type === "expression") {
+    return EXPRESSION_PAYLOAD_TIP;
+  }
+  return EXPRESSION_DOUBLE_BRACE_TIP;
+}
+
+/**
+ * Resolve the AutoCompleteInput `quickTip` prop for expression-capable fields.
+ * Returns `null` when the field already has a description so the tip can move
+ * into a label tooltip instead of stacking under the description.
+ */
+export function resolveExpressionQuickTip(
+  field: Pick<ConfigurationField, "type" | "description">,
+  allowExpressions: boolean,
+): string | null | undefined {
+  if (!fieldShowsExpressionQuickTip(field, allowExpressions)) return undefined;
+  if (field.description) return null;
+  return expressionQuickTipForField(field);
+}

--- a/web_src/src/ui/configurationFieldRenderer/index.spec.ts
+++ b/web_src/src/ui/configurationFieldRenderer/index.spec.ts
@@ -1,9 +1,12 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ConfigurationField } from "@/api-client";
 import { describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/ui/tooltip";
 import { ConfigurationFieldRenderer } from "./index";
 import { buildTemplateParametersAutocompleteObject } from "./templateParametersAutocomplete";
+import { EXPRESSION_DOUBLE_BRACE_TIP } from "./expressionQuickTip";
 
 const runTitleField: ConfigurationField = {
   name: "customName",
@@ -14,43 +17,111 @@ const runTitleField: ConfigurationField = {
   placeholder: "{{ root().data.context }}",
 };
 
+function renderConfigurationField(props: React.ComponentProps<typeof ConfigurationFieldRenderer>) {
+  return render(
+    React.createElement(TooltipProvider, {
+      delayDuration: 0,
+      children: React.createElement(ConfigurationFieldRenderer, props),
+    }),
+  );
+}
+
 describe("ConfigurationFieldRenderer run title copy", () => {
-  it("explains disabled trigger run title customization", () => {
-    render(
-      React.createElement(ConfigurationFieldRenderer, {
-        allowExpressions: true,
-        field: runTitleField,
-        value: null,
-        onChange: vi.fn(),
-        autocompleteExampleObj: { __root: { data: { context: "ci/build" } } },
-      }),
-    );
+  it("explains disabled trigger run title customization in a label tooltip", async () => {
+    const user = userEvent.setup();
+    renderConfigurationField({
+      allowExpressions: true,
+      field: runTitleField,
+      value: null,
+      onChange: vi.fn(),
+      autocompleteExampleObj: { __root: { data: { context: "ci/build" } } },
+    });
 
     expect(screen.getByText("Customize run title")).toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
+        "This trigger starts a run when an event arrives. By default, SuperPlane names the run from the event payload.",
+      ),
+    ).not.toBeInTheDocument();
+
+    await user.hover(screen.getByRole("button", { name: "About Customize run title" }));
+    expect(
+      await screen.findByText(
         "This trigger starts a run when an event arrives. By default, SuperPlane names the run from the event payload.",
       ),
     ).toBeInTheDocument();
   });
 
-  it("explains enabled trigger run title customization", () => {
-    render(
-      React.createElement(ConfigurationFieldRenderer, {
-        allowExpressions: true,
-        field: runTitleField,
-        value: "{{ root().data.context }}",
-        onChange: vi.fn(),
-        autocompleteExampleObj: { __root: { data: { context: "ci/build" } } },
-      }),
-    );
+  it("explains enabled trigger run title customization in a label tooltip", async () => {
+    const user = userEvent.setup();
+    renderConfigurationField({
+      allowExpressions: true,
+      field: runTitleField,
+      value: "{{ root().data.context }}",
+      onChange: vi.fn(),
+      autocompleteExampleObj: { __root: { data: { context: "ci/build" } } },
+    });
 
+    expect(screen.getByRole("button", { name: "Preview title" })).toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
+        "Set the title for runs started by this trigger. Use root().data to reference fields from the trigger event.",
+      ),
+    ).not.toBeInTheDocument();
+
+    await user.hover(screen.getByRole("button", { name: "About Customize run title" }));
+    expect(
+      await screen.findByText(
         "Set the title for runs started by this trigger. Use root().data to reference fields from the trigger event.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Preview title" })).toBeInTheDocument();
+    expect(screen.getByText(EXPRESSION_DOUBLE_BRACE_TIP)).toBeInTheDocument();
+  });
+});
+
+describe("ConfigurationFieldRenderer tip and description layout", () => {
+  it("keeps the description inline when expressions are not allowed", () => {
+    const field: ConfigurationField = {
+      name: "repo",
+      type: "string",
+      label: "Repository",
+      description: "GitHub repository to watch.",
+    };
+
+    renderConfigurationField({
+      allowExpressions: false,
+      field,
+      value: "acme/app",
+      onChange: vi.fn(),
+    });
+
+    expect(screen.getByText("GitHub repository to watch.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "About Repository" })).not.toBeInTheDocument();
+  });
+
+  it("moves description into a tooltip for expression fields that also show a tip", async () => {
+    const user = userEvent.setup();
+    const field: ConfigurationField = {
+      name: "branch",
+      type: "string",
+      label: "Branch",
+      description: "Branch name or expression.",
+    };
+
+    renderConfigurationField({
+      allowExpressions: true,
+      field,
+      value: "main",
+      onChange: vi.fn(),
+      autocompleteExampleObj: { __root: { data: {} } },
+    });
+
+    expect(screen.queryByText("Branch name or expression.")).not.toBeInTheDocument();
+    expect(screen.queryByText(EXPRESSION_DOUBLE_BRACE_TIP)).not.toBeInTheDocument();
+
+    await user.hover(screen.getByRole("button", { name: "About Branch" }));
+    expect(await screen.findByText("Branch name or expression.")).toBeInTheDocument();
+    expect(screen.getByText(EXPRESSION_DOUBLE_BRACE_TIP)).toBeInTheDocument();
   });
 });
 

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -9,6 +9,8 @@ import { getRunTitlePresentation, RUN_TITLE_EXCLUDED_SUGGESTIONS } from "./runTi
 import { ReadonlyConfigurationField } from "./ReadonlyFieldRenderer";
 import { ConfigurationFieldInput } from "./ConfigurationFieldInput";
 import { buildReadonlyExpressionPreview } from "./expressionPreview";
+import { FieldDescriptionTooltip } from "./FieldDescriptionTooltip";
+import { expressionQuickTipForField, fieldShowsExpressionQuickTip } from "./expressionQuickTip";
 
 const REQUIRED_FIELD_BADGE_CLASS =
   "ml-2 inline-flex items-center rounded border border-orange-300 px-1 py-0.5 text-[10px] uppercase tracking-wide leading-none text-orange-500 bg-orange-50 dark:border-orange-400/50 dark:bg-orange-950/30 dark:text-orange-300";
@@ -269,6 +271,12 @@ export const ConfigurationFieldRenderer = ({
   // so fall back to the field name whenever the label is blank.
   const fieldLabel = runTitlePresentation?.label || field.label || field.name;
   const fieldDescription = runTitlePresentation?.description ?? field.description;
+  // When an expression quick tip would stack under the field description, move the
+  // description (and tip) into a label tooltip so the sidebar stays readable.
+  const showDescriptionInTooltip = Boolean(
+    fieldDescription && fieldShowsExpressionQuickTip(field, fieldAllowsExpressions),
+  );
+  const expressionTipForTooltip = showDescriptionInTooltip ? expressionQuickTipForField(field) : undefined;
 
   const commonProps = {
     field,
@@ -427,6 +435,13 @@ export const ConfigurationFieldRenderer = ({
               <span className={REQUIRED_FIELD_BADGE_CLASS}>Required</span>
             )}
         </Label>
+        {showDescriptionInTooltip && fieldDescription ? (
+          <FieldDescriptionTooltip
+            title={fieldLabel}
+            description={fieldDescription}
+            expressionTip={expressionTipForTooltip}
+          />
+        ) : null}
         <div ref={labelRightRef} className="ml-auto shrink-0" />
       </div>
       {isEnabled && (
@@ -449,8 +464,8 @@ export const ConfigurationFieldRenderer = ({
         </div>
       )}
 
-      {/* Display field description */}
-      {fieldDescription && (
+      {/* Display field description inline when it is not moved into the label tooltip */}
+      {fieldDescription && !showDescriptionInTooltip && (
         <p className="text-xs text-gray-500 dark:text-gray-400 text-left leading-normal">{fieldDescription}</p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Fixes #2529 by hiding the inline expression quick tip when a configuration field already has a description, so the tip and description no longer stack in the component sidebar.
- Moves the field description (and the expression tip) into a label info tooltip for expression-capable fields, matching the cleaner hover-based approach discussed on the issue.
- Updates `AutoCompleteInput` so `quickTip={null}` can fully hide the tip instead of falling back to the default expression hint.

## Test plan
- [ ] Open a component config field that supports expressions and has a description (for example a string/text field with help text).
- [ ] Confirm the description is no longer shown as a paragraph under the input; it appears via the info icon next to the label.
- [ ] Hover the info icon and confirm both the description and the expression tip are visible in the tooltip.
- [ ] Focus the input and confirm the bottom bar no longer stacks a tip under the description.
- [ ] Open an expression field with no description and confirm the inline tip still appears as before.
- [ ] Run targeted UI tests: `npm test -- --run src/ui/configurationFieldRenderer/expressionQuickTip.spec.ts src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx`