### PR TITLE
fix: show avatar placeholder when image fails to load

### DIFF
--- a/web_src/src/components/Avatar/avatar.tsx
+++ b/web_src/src/components/Avatar/avatar.tsx
@@ -1,6 +1,6 @@
 import * as Headless from "@headlessui/react";
 import clsx from "clsx";
-import React, { forwardRef } from "react";
+import React, { forwardRef, useEffect, useState } from "react";
 import { Link } from "../Link/link";
 
 type AvatarProps = {
@@ -19,6 +19,12 @@ export function Avatar({
   className,
   ...props
 }: AvatarProps & React.ComponentPropsWithoutRef<"span">) {
+  const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [src]);
+
   return (
     <span
       data-slot="avatar"
@@ -44,7 +50,20 @@ export function Avatar({
           </text>
         </svg>
       )}
-      {src && <img className="size-full" src={src} alt={alt} />}
+      {src && !imgError && <img className="size-full" src={src} alt={alt} onError={() => setImgError(true)} />}
+      {!initials && imgError && (
+        <svg
+          className="size-full fill-current p-[5%] select-none"
+          viewBox="0 0 100 100"
+          aria-hidden={alt ? undefined : "true"}
+          aria-label={alt || undefined}
+          role={alt ? "img" : undefined}
+        >
+          {alt && <title>{alt}</title>}
+          <circle cx="50" cy="35" r="18" />
+          <path d="M10,90 C10,65 30,55 50,55 C70,55 90,65 90,90" />
+        </svg>
+      )}
     </span>
   );
 }

--- a/web_src/src/pages/app/console/HtmlBody.tsx
+++ b/web_src/src/pages/app/console/HtmlBody.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo } from "react";
+import { useEffect, useId, useMemo, useRef } from "react";
 import { Loader2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -55,6 +55,37 @@ export function HtmlBody({ body, vars }: { body: string; vars: Record<string, un
     return sanitizeHtml(interpolated, rootId);
   }, [body, vars, rootId]);
 
+  const htmlRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = htmlRef.current;
+    if (!container) return;
+
+    const images = container.querySelectorAll<HTMLImageElement>("img.avatar-image");
+    const cleanups: (() => void)[] = [];
+
+    images.forEach((img) => {
+      const replaceWithFallback = () => {
+        if (!img.isConnected) return;
+        const fallback = document.createElement("span");
+        fallback.className = "avatar avatar-fallback";
+        fallback.textContent = img.getAttribute("title") || "?";
+        img.replaceWith(fallback);
+      };
+
+      // `error` does not bubble; attach handlers directly. Also replace images
+      // that already failed before the listener was attached (cached 404).
+      img.addEventListener("error", replaceWithFallback);
+      cleanups.push(() => img.removeEventListener("error", replaceWithFallback));
+
+      if (img.complete && img.naturalWidth === 0) {
+        replaceWithFallback();
+      }
+    });
+
+    return () => cleanups.forEach((fn) => fn());
+  }, [sanitized]);
+
   if (!sanitized.trim()) return null;
 
   return (
@@ -62,6 +93,7 @@ export function HtmlBody({ body, vars }: { body: string; vars: Record<string, un
     // the sanitized html root uses `dark-mode-disabled` (which opts out of dark:).
     <div className={cn(CONSOLE_LINK_ANCHOR_SELECTOR_CLASSES, CONSOLE_CODE_BADGE_ANCHOR_SELECTOR_CLASSES)}>
       <div
+        ref={htmlRef}
         className={cn("dark-mode-disabled", HTML_ROOT_CLASSES)}
         data-testid="console-html"
         {...{ [HTML_WIDGET_ROOT_ATTR]: rootId }}

--- a/web_src/src/pages/app/console/consoleAvatar.spec.ts
+++ b/web_src/src/pages/app/console/consoleAvatar.spec.ts
@@ -6,6 +6,7 @@ describe("resolveConsoleAvatar", () => {
   it("uses the GitHub avatar for a plain username string", () => {
     expect(resolveConsoleAvatar("forestileao")).toEqual({
       src: "https://github.com/forestileao.png",
+      initials: "F",
       name: "forestileao",
     });
   });
@@ -20,7 +21,16 @@ describe("resolveConsoleAvatar", () => {
   it("uses the GitHub avatar when author.username is present", () => {
     expect(resolveConsoleAvatar({ name: "Pedro Leão", username: "forestileao" }, { name: "Pedro Leão" })).toEqual({
       src: "https://github.com/forestileao.png",
+      initials: "P",
       name: "Pedro Leão",
+    });
+  });
+
+  it("falls back to username initial when author name is empty", () => {
+    expect(resolveConsoleAvatar({ username: "cloud-robot" })).toEqual({
+      src: "https://github.com/cloud-robot.png",
+      initials: "C",
+      name: "cloud-robot",
     });
   });
 

--- a/web_src/src/pages/app/console/consoleAvatar.ts
+++ b/web_src/src/pages/app/console/consoleAvatar.ts
@@ -17,7 +17,11 @@ export function resolveConsoleAvatar(author: unknown, committer?: unknown): Cons
       return { src: username, name: "" };
     }
     if (username) {
-      return { src: `https://github.com/${username}.png`, name: username };
+      return {
+        src: `https://github.com/${username}.png`,
+        initials: firstInitialFromValues(username),
+        name: username,
+      };
     }
   }
 
@@ -27,7 +31,11 @@ export function resolveConsoleAvatar(author: unknown, committer?: unknown): Cons
   const name = coerceToString(authorRecord?.name).trim() || coerceToString(committerRecord?.name).trim() || username;
 
   if (username) {
-    return { src: `https://github.com/${username}.png`, name };
+    return {
+      src: `https://github.com/${username}.png`,
+      initials: firstInitialFromValues(authorRecord?.name, committerRecord?.name, username),
+      name,
+    };
   }
 
   const initials = firstInitialFromValues(

--- a/web_src/src/pages/app/console/markdownInterpolation.spec.ts
+++ b/web_src/src/pages/app/console/markdownInterpolation.spec.ts
@@ -75,6 +75,27 @@ describe("interpolateMarkdownTemplate", () => {
     expect(out).toBe('<div class="avatar avatar-fallback">C</div>');
   });
 
+  it("embeds a fallback initial in title when github username avatar html is rendered", () => {
+    const out = interpolateMarkdownTemplate(
+      "{{ githubAvatarOrInitial(prod.payload.data.head_commit.author, prod.payload.data.head_commit.committer) }}",
+      {
+        prod: {
+          payload: {
+            data: {
+              head_commit: {
+                author: { name: "cloud-robot", username: "cloud-robot" },
+                committer: { name: "cloud-robot" },
+              },
+            },
+          },
+        },
+      },
+    );
+    expect(out).toContain('src="https://github.com/cloud-robot.png"');
+    expect(out).toContain('title="C"');
+    expect(out).toContain('class="avatar avatar-image"');
+  });
+
   it("serializes object values as JSON for inline insertion", () => {
     const out = interpolateMarkdownTemplate("Payload: {{ run.payload }}", { run: { payload: { pr: 7 } } });
     expect(out).toBe('Payload: {"pr":7}');

--- a/web_src/src/pages/app/console/widget/celBuiltins.ts
+++ b/web_src/src/pages/app/console/widget/celBuiltins.ts
@@ -353,7 +353,8 @@ function githubAvatar(author: unknown, committer: unknown): string {
   const committerRecord = asRecord(committer);
   const username = coerceToString(authorRecord?.username).trim();
   if (username) {
-    return `<img class="avatar avatar-image" src="https://github.com/${username}.png" alt="" />`;
+    const initial = initialLetter(authorRecord?.name) || initialLetter(username);
+    return `<img class="avatar avatar-image" src="https://github.com/${username}.png" alt="" title="${initial}" />`;
   }
   const letter = firstInitialFromValues(
     authorRecord?.name,

--- a/web_src/src/pages/app/console/widget/celExpr.spec.ts
+++ b/web_src/src/pages/app/console/widget/celExpr.spec.ts
@@ -488,6 +488,7 @@ describe("celExpr", () => {
           buildEnv(),
         );
         expect(out).toContain('src="https://github.com/forestileao.png"');
+        expect(out).toContain('title="P"');
       });
 
       it("renders an initial badge when author.username is missing", () => {


### PR DESCRIPTION
## What
When a console avatar image URL is missing or returns 404, SuperPlane no longer shows the browser broken-image icon. The UI falls back to initials (preferred) or a simple silhouette placeholder.
## Why
In the console (HTML panels and avatar-backed tables), GitHub avatar URLs for bots/users without a reachable image render as a broken `<img>`. That matches #6235.
## How
- `Avatar`: hide the image on `onError`, keep showing initials when present, and only use a silhouette when there are no initials.
- `resolveConsoleAvatar`: always supply initials alongside GitHub avatar `src` so React avatars can fall back cleanly.
- HTML avatars (`githubAvatarOrInitial`): put the initial in `title`, and replace failed `img.avatar-image` nodes in `HtmlBody` with `span.avatar.avatar-fallback` (including already-failed cached images).
## Related
Fixes #6235
## Testing
- `npm test -- --run consoleAvatar celExpr markdownInterpolation` (111 tests passed)