### PR TITLE
fix: stop the run inspector JSON viewer from truncating long string values

### DIFF
--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.spec.tsx
@@ -19,4 +19,12 @@ describe("JsonPayload", () => {
 
     expect(viewer).toHaveClass("json-viewer-wrap-values");
   });
+
+  it("renders long string values in full instead of truncating them", () => {
+    const longValue = "error executing request dial tcp connection blocked by policy rule policy-1234567890-abcdefghij";
+    const { container } = render(<JsonPayload value={{ error: longValue }} jsonViewStyle={{}} collapsed={false} />);
+
+    expect(container.textContent).toContain(longValue);
+    expect(container.textContent).not.toContain("...");
+  });
 });

--- a/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
+++ b/web_src/src/ui/Runs/RunInspectorTimelineCard.tsx
@@ -132,6 +132,7 @@ export function JsonPayload({
       className={jsonViewClassName}
       displayObjectSize={false}
       enableClipboard={false}
+      shortenTextAfterLength={0}
     >
       <JsonView.String
         render={({ children, ...props }, { type, value: stringValue }) => {

--- a/web_src/src/ui/Runs/RunNodeDetailTabSection.spec.tsx
+++ b/web_src/src/ui/Runs/RunNodeDetailTabSection.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { ThemeContext, type ThemeContextType } from "@/contexts/themeContextState";
+import { RunNodeDetailTabSection } from "./RunNodeDetailTabSection";
+import type { RunNodeDetailTabData } from "./types";
+
+const themeValue: ThemeContextType = {
+  preference: "light",
+  resolvedTheme: "light",
+  setPreference: () => {},
+};
+
+function renderWithTheme(ui: ReactElement) {
+  return render(<ThemeContext.Provider value={themeValue}>{ui}</ThemeContext.Provider>);
+}
+
+describe("RunNodeDetailTabSection", () => {
+  it("renders long payload string values in full instead of truncating them", () => {
+    // Quote-free so the JSON-escaped rendering matches the raw value exactly.
+    const longError =
+      "error executing request: dial tcp 10.0.0.1:443 connect: connection blocked by policy rule policy-1234567890-abcdefghij";
+    const tabData = { payload: { error: longError } } as unknown as RunNodeDetailTabData;
+
+    renderWithTheme(
+      <RunNodeDetailTabSection
+        activeTab="payload"
+        tabData={tabData}
+        hasDetailsSection={false}
+        hasPayload
+        hasConfig={false}
+        headerEventBadge={null}
+        onSelectTab={() => {}}
+      />,
+    );
+
+    // The default @uiw/react-json-view truncates string values after 30 chars
+    // with an ellipsis, dropping the tail of the error. Assert the whole value
+    // is present so the failure message stays readable in the inspector.
+    expect(screen.getByText(longError)).toBeInTheDocument();
+  });
+});

--- a/web_src/src/ui/Runs/RunNodeDetailTabSection.tsx
+++ b/web_src/src/ui/Runs/RunNodeDetailTabSection.tsx
@@ -1,9 +1,9 @@
-import JsonView from "@uiw/react-json-view";
 import React from "react";
 import { useTheme } from "@/contexts/useTheme";
 import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
-import { getJsonViewStyle, jsonViewClassName } from "@/lib/jsonViewTheme";
+import { getJsonViewStyle } from "@/lib/jsonViewTheme";
 import { cn, resolveIcon } from "@/lib/utils";
+import { JsonPayload } from "./RunInspectorTimelineCard";
 import { RunNodeDetailDetailsView } from "./RunNodeDetailDetailsView";
 import { RUN_NODE_ICON_SIZE } from "./RunNodeIcon";
 import type { RunNodeDetailTabData, RunNodeDetailTabKey } from "./types";
@@ -75,24 +75,10 @@ export function RunNodeDetailTabSection({
           />
         ) : null}
         {activeTab === "payload" && hasPayload ? (
-          <JsonView
-            value={tabData?.payload as object}
-            collapsed={2}
-            style={jsonViewStyle}
-            className={jsonViewClassName}
-            displayObjectSize={false}
-            enableClipboard={false}
-          />
+          <JsonPayload value={tabData?.payload} jsonViewStyle={jsonViewStyle} collapsed={2} />
         ) : null}
         {activeTab === "configuration" && hasConfig ? (
-          <JsonView
-            value={tabData?.configuration as object}
-            collapsed={2}
-            style={jsonViewStyle}
-            className={jsonViewClassName}
-            displayObjectSize={false}
-            enableClipboard={false}
-          />
+          <JsonPayload value={tabData?.configuration} jsonViewStyle={jsonViewStyle} collapsed={2} />
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
Fixes #6407.

### Problem

The run inspector's **Payload** and **Config** tabs render a raw `@uiw/react-json-view`, which defaults to `shortenTextAfterLength={30}`. Any string value longer than 30 characters is cut off with an ellipsis, so a failed execution whose payload is one long string — e.g. `{"data":{"error":"error executing request: Get \"…\": dial tcp …: connection blocked: …"}}` — renders the `error` as `error executing request: Get \"...` with no way to read it in place. The only workarounds were the Copy button or querying `workflow_events` directly.

### Root cause

The inspector already has a shared `JsonPayload` renderer that wraps long values, but it never disabled the library's shortening, so it truncated too — and the Payload/Config tabs didn't use it; they rendered a bare `<JsonView>`.

### Fix

- Set `shortenTextAfterLength={0}` on `JsonPayload` so the full value is rendered and wrapped. This also fixes the same truncation in the four other views that already share `JsonPayload` (runtime config, step timeline, runner logs, input chain).
- Route the Payload/Config tabs through `JsonPayload` instead of a bare `<JsonView>`.

### Tests

- `RunInspectorTimelineCard.spec.tsx`: assert `JsonPayload` renders a long value in full (no `...`).
- `RunNodeDetailTabSection.spec.tsx` (new): assert a long payload error string renders in full in the Payload tab.

Both fail on `main` (value comes back truncated) and pass with the fix. `tsc -b` and `eslint` are clean.