### PR TITLE
docs: mention Windows with WSL2 as supported dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ your machine. Everything runs in containers managed by Make and Docker.
 
 Before you begin, make sure you have the following:
 
-- You are running MacOS or Linux
+- You are running MacOS, Linux, or Windows with WSL2
 - [Make](https://www.gnu.org/software/make/)
 - [Docker](https://www.docker.com/)
 


### PR DESCRIPTION
SuperPlane development runs entirely in Docker, which works fine on Windows via Docker Desktop with the WSL2 backend. Updating the prerequisites so Windows users know they are welcome to contribute.

This is a small docs improvement to broaden the contributor base.