### PR TITLE
fix: reject reserved and .git paths case-insensitively

### DIFF
--- a/pkg/git/provider/common.go
+++ b/pkg/git/provider/common.go
@@ -24,12 +24,23 @@ func NormalizePath(value string) (string, error) {
 	}
 
 	for _, segment := range strings.Split(normalized, "/") {
-		if segment == "" || segment == "." || segment == ".." || segment == ".git" {
+		if segment == "" || segment == "." || segment == ".." || strings.EqualFold(segment, ".git") {
 			return "", ErrInvalidPath
 		}
 	}
 
 	return normalized, nil
+}
+
+// IsReservedPath reports whether an already normalized path points at the
+// directory SuperPlane reserves for itself.
+//
+// The comparison ignores case because git checkouts on case-insensitive
+// filesystems (macOS, Windows) resolve ".SuperPlane" and ".superplane" to the
+// same directory, so a case variant would otherwise land in the reserved one.
+func IsReservedPath(normalized string) bool {
+	lowered := strings.ToLower(normalized)
+	return lowered == ReservedSuperPlanePath || strings.HasPrefix(lowered, ReservedSuperPlanePath+"/")
 }
 
 func ValidateUserPath(value string) (string, error) {
@@ -38,7 +49,7 @@ func ValidateUserPath(value string) (string, error) {
 		return "", err
 	}
 
-	if normalized == ReservedSuperPlanePath || strings.HasPrefix(normalized, ReservedSuperPlanePath+"/") {
+	if IsReservedPath(normalized) {
 		return "", ErrReservedPath
 	}
 

--- a/pkg/git/provider/common_test.go
+++ b/pkg/git/provider/common_test.go
@@ -34,3 +34,80 @@ func TestValidateCommitOperationsUsesNormalizedPathInErrors(t *testing.T) {
 
 	require.ErrorContains(t, err, `content is required for "dir/file.txt"`)
 }
+
+func TestNormalizePathRejectsGitDirectoryInAnyCase(t *testing.T) {
+	for _, path := range []string{
+		".git/config",
+		".GIT/config",
+		".Git/config",
+		"dir/.giT/hooks/pre-commit",
+		".git",
+		".GIT",
+	} {
+		t.Run(path, func(t *testing.T) {
+			_, err := NormalizePath(path)
+			require.ErrorIs(t, err, ErrInvalidPath)
+		})
+	}
+}
+
+func TestNormalizePathAllowsNamesThatMerelyContainGit(t *testing.T) {
+	for _, path := range []string{
+		".gitignore",
+		".github/workflows/ci.yml",
+		"dir/git/file.txt",
+	} {
+		t.Run(path, func(t *testing.T) {
+			normalized, err := NormalizePath(path)
+			require.NoError(t, err)
+			require.Equal(t, path, normalized)
+		})
+	}
+}
+
+func TestValidateUserPathRejectsReservedPathInAnyCase(t *testing.T) {
+	for _, path := range []string{
+		".superplane",
+		".SuperPlane",
+		".SUPERPLANE",
+		".superplane/config",
+		".SuperPlane/config",
+		"/.SUPERPLANE//nested/config",
+	} {
+		t.Run(path, func(t *testing.T) {
+			_, err := ValidateUserPath(path)
+			require.ErrorIs(t, err, ErrReservedPath)
+		})
+	}
+}
+
+func TestValidateUserPathAllowsNamesThatMerelyStartWithReservedPrefix(t *testing.T) {
+	for _, path := range []string{
+		".superplane-notes.md",
+		".SuperPlaneConfig",
+		"dir/.superplane/config",
+	} {
+		t.Run(path, func(t *testing.T) {
+			normalized, err := ValidateUserPath(path)
+			require.NoError(t, err)
+			require.Equal(t, path, normalized)
+		})
+	}
+}
+
+func TestIsReservedPath(t *testing.T) {
+	for path, reserved := range map[string]bool{
+		".superplane":        true,
+		".SuperPlane":        true,
+		".superplane/config": true,
+		".SUPERPLANE/config": true,
+		".superplane-notes":  false,
+		"dir/.superplane":    false,
+		"superplane/config":  false,
+		"":                   false,
+	} {
+		t.Run(path, func(t *testing.T) {
+			require.Equal(t, reserved, IsReservedPath(path))
+		})
+	}
+}

--- a/pkg/grpc/actions/canvases/put_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/put_canvas_staging.go
@@ -3,7 +3,6 @@ package canvases
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -41,8 +40,7 @@ func PutCanvasStaging(ctx context.Context, db *gorm.DB, canvas *models.Canvas, o
 		if normalized == "" {
 			return nil, grpcerrors.InvalidArgument(nil, "file path is required")
 		}
-		if normalized == gitprovider.ReservedSuperPlanePath ||
-			strings.HasPrefix(normalized, gitprovider.ReservedSuperPlanePath+"/") {
+		if gitprovider.IsReservedPath(normalized) {
 			return nil, grpcerrors.InvalidArgument(nil, fmt.Sprintf("path %q is reserved for SuperPlane", operation.GetPath()))
 		}
 


### PR DESCRIPTION
## What changed

`NormalizePath` and `ValidateUserPath` in `pkg/git/provider/common.go` compared path segments against `.git` and `.superplane` with exact string equality, so any case variant bypassed both guards:

```go
// before
segment == ".git"
normalized == ReservedSuperPlanePath || strings.HasPrefix(normalized, ReservedSuperPlanePath+"/")
```

`.GIT/config` and `.SuperPlane/config` were accepted as ordinary user paths.

Both comparisons are now case-insensitive, and the reserved-directory check moved into a shared `IsReservedPath` helper.

## Why

These two guards exist specifically to keep user-supplied file operations out of the repository's git metadata and out of the directory SuperPlane reserves for itself (`provider.go` states the intent: *"Users should not be able to create files in this directory"*).

On case-insensitive filesystems — macOS and Windows, both of which developers check repositories out on — `.GIT`, `.Git`, and `.SuperPlane` resolve to the same directories as their lowercase forms. A path that passes validation as an innocuous-looking name therefore lands in the very directory the check was meant to protect. git itself rejects `.git` in any case for the same reason.

## How

- `NormalizePath` uses `strings.EqualFold(segment, ".git")`.
- New exported `IsReservedPath(normalized string) bool` lowercases before matching the reserved prefix; `ValidateUserPath` delegates to it.
- `PutCanvasStaging` in `pkg/grpc/actions/canvases/put_canvas_staging.go` had its own inline copy of the reserved-path comparison, with the same case-sensitivity gap. It now calls the shared helper, so the two sites can't drift apart again.

Names that merely *start with* the reserved prefix are still allowed (`.superplane-notes.md`, `.gitignore`, `.github/`) — covered by tests.

## Tests

Added to `pkg/git/provider/common_test.go`:

- `TestNormalizePathRejectsGitDirectoryInAnyCase`
- `TestNormalizePathAllowsNamesThatMerelyContainGit`
- `TestValidateUserPathRejectsReservedPathInAnyCase`
- `TestValidateUserPathAllowsNamesThatMerelyStartWithReservedPrefix`
- `TestIsReservedPath`

I confirmed these fail against the previous implementation and pass with the fix:

```
$ go test ./pkg/git/...
?       github.com/superplanehq/superplane/pkg/git               [no test files]
?       github.com/superplanehq/superplane/pkg/git/codestorage   [no test files]
ok      github.com/superplanehq/superplane/pkg/git/inmemory      0.500s
ok      github.com/superplanehq/superplane/pkg/git/provider      0.497s
ok      github.com/superplanehq/superplane/pkg/git/supergit      0.899s
```

`gofmt` and `go vet` are clean on the touched packages.

## Note for reviewers

While tracing the second call site I noticed `normalizeRepositoryFilePath` (`pkg/grpc/actions/canvases/repository_spec_files.go`) only trims and swaps separators — it does not run `path.Clean`. So a staged path like `./.superplane/config` still slips past the reserved-path check on that endpoint, independently of casing. That looked like a separate fix with a wider blast radius (it also feeds the spec-file read path), so I left it out of this PR rather than widen the scope. Happy to follow up if you'd like it addressed.