### PR TITLE
fix: apply the requested timezone when formatting timestamps

### DIFF
--- a/web_src/src/lib/timezone.spec.ts
+++ b/web_src/src/lib/timezone.spec.ts
@@ -11,18 +11,36 @@ describe("timezone", () => {
     vi.useRealTimers();
   });
 
-  it("formats timestamps in the requested timezone", () => {
-    const toLocaleDateStringSpy = vi.spyOn(Date.prototype, "toLocaleDateString").mockReturnValue("Mar 29, 2026, 14:30");
-
+  it("renders the timestamp in the requested timezone, not just labels it", () => {
+    // 14:30 UTC is 10:30 in New York and 23:30 in Tokyo on this date.
     expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "UTC")).toBe("Mar 29, 2026, 14:30 UTC");
-    expect(toLocaleDateStringSpy).toHaveBeenCalledWith("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
+    expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "America/New_York")).toBe(
+      "Mar 29, 2026, 10:30 America/New_York",
+    );
+    expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "Asia/Tokyo")).toBe(
+      "Mar 29, 2026, 23:30 Asia/Tokyo",
+    );
+  });
+
+  it("accepts a Date instance as well as an ISO string", () => {
+    expect(formatTimestampInUserTimezone(new Date("2026-03-29T14:30:00.000Z"), "UTC")).toBe("Mar 29, 2026, 14:30 UTC");
+  });
+
+  it("defaults to the browser timezone when none is given", () => {
+    const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z")).toBe(
+      formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", browserTimezone),
+    );
+  });
+
+  it("falls back to the browser timezone when the timezone is not a valid IANA name", () => {
+    const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    // The backend stores some timezones as numeric offsets, which Intl rejects.
+    expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "-5")).toBe(
+      formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", browserTimezone),
+    );
   });
 
   it("formats relative time in abbreviated and long forms", () => {

--- a/web_src/src/lib/timezone.ts
+++ b/web_src/src/lib/timezone.ts
@@ -9,25 +9,33 @@ function getUserTimezone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
+const TIMESTAMP_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false, // Use 24-hour format instead of AM/PM
+};
+
 /**
  * Format a timestamp to display in user's local timezone
  * @param timestamp - ISO timestamp string or Date object
- * @param userTimezone - Optional user timezone, defaults to browser timezone
+ * @param userTimezone - Optional IANA timezone name, defaults to browser timezone
  * @returns Formatted datetime string
  */
 export function formatTimestampInUserTimezone(timestamp: string | Date, userTimezone?: string): string {
   const timezone = userTimezone || getUserTimezone();
   const date = typeof timestamp === "string" ? new Date(timestamp) : timestamp;
-  const options: Intl.DateTimeFormatOptions = {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false, // Use 24-hour format instead of AM/PM
-  };
 
-  return date.toLocaleDateString("en-US", options) + ` ${timezone}`;
+  try {
+    return `${date.toLocaleDateString("en-US", { ...TIMESTAMP_OPTIONS, timeZone: timezone })} ${timezone}`;
+  } catch {
+    // Intl throws a RangeError on an unrecognized timezone. Fall back to the
+    // browser timezone so one bad value cannot break the surrounding view.
+    const fallback = getUserTimezone();
+    return `${date.toLocaleDateString("en-US", { ...TIMESTAMP_OPTIONS, timeZone: fallback })} ${fallback}`;
+  }
 }
 
 /**


### PR DESCRIPTION
## What

`formatTimestampInUserTimezone` accepts a `userTimezone` argument but never passed it to `Intl`. The timestamp was rendered in the **browser's** local timezone, and the requested zone was only appended as a text label — so the time shown could disagree with the label sitting right next to it.

```ts
const timezone = userTimezone || getUserTimezone();
const options: Intl.DateTimeFormatOptions = {
  month: "short", day: "numeric", year: "numeric",
  hour: "2-digit", minute: "2-digit", hour12: false,
  // no timeZone here
};

return date.toLocaleDateString("en-US", options) + ` ${timezone}`;
```

For a viewer in `Europe/Budapest`, formatting `2026-03-29T14:30:00Z`:

| Requested timezone | Before | After |
| --- | --- | --- |
| `UTC` | `Mar 29, 2026, 16:30 UTC` | `Mar 29, 2026, 14:30 UTC` |
| `America/New_York` | `Mar 29, 2026, 16:30 America/New_York` | `Mar 29, 2026, 10:30 America/New_York` |
| `Asia/Tokyo` | `Mar 29, 2026, 16:30 Asia/Tokyo` | `Mar 29, 2026, 23:30 Asia/Tokyo` |

## Why it went unnoticed

The existing test mocked `toLocaleDateString` and asserted the *options object*, so it passed while the timezone was being dropped — the assertion listed exactly the options that omitted `timeZone`:

```ts
const toLocaleDateStringSpy = vi.spyOn(Date.prototype, "toLocaleDateString").mockReturnValue("Mar 29, 2026, 14:30");
expect(formatTimestampInUserTimezone("2026-03-29T14:30:00.000Z", "UTC")).toBe("Mar 29, 2026, 14:30 UTC");
expect(toLocaleDateStringSpy).toHaveBeenCalledWith("en-US", { /* … no timeZone … */ });
```

The test is now written against the formatted output instead of the call shape, in line with the "test behavior, not implementation details" guidance in `docs/contributing/quality.md`. Reverting `timezone.ts` and re-running the spec fails 3 of the 5 assertions, so the regression is genuinely covered.

## Changes

- Pass `timeZone` through to `toLocaleDateString`.
- Fall back to the browser timezone when the value is not a valid IANA name. `Intl` throws a `RangeError` on unrecognized zones, and this helper is used inline in execution-detail views, so a bad value should not be able to break the surrounding view. This is a realistic input: the `timeGate` component stores timezones as numeric offsets (`"-5"`), which `Intl` rejects.
- Hoist the shared options object to module scope so it is not rebuilt per call.
- Extend `timezone.spec.ts` to cover the requested-timezone, `Date`-input, default, and invalid-timezone paths.

## Compatibility

Every current call site (~30, mostly `pages/app/mappers/**`) omits the second argument, so `timezone` resolves to the browser timezone and passing it explicitly produces byte-identical output. The behavior only changes where an explicit timezone is passed — which was previously wrong.

## Testing

```
npx vitest run src/lib/timezone.spec.ts   # 5 passed
npx vitest run src/lib                    # 235 passed
npx eslint src/lib/timezone.ts src/lib/timezone.spec.ts   # clean
npx prettier --check src/lib/timezone.ts src/lib/timezone.spec.ts   # clean
```

Note: `src/lib/duration.spec.ts` fails 4 assertions on my machine both with and without this change — `formatDuration` formats via `Intl` with the default locale, so it renders in the host locale (`"1 ó és 30 p"` on a Hungarian host) rather than the expected `"1h 30m"`. Pre-existing and unrelated to this PR, but it may be worth pinning a locale in that helper or its spec.
