### PR TITLE
feat: add branch artifact type for factory work orders

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -23,7 +23,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="Add Memory" href="#add-memory" description="Add a namespaced JSON value to canvas memory" />
-  <LinkCard title="Add Work Order Artifact" href="#add-work-order-artifact" description="Attach a typed artifact (PR or markdown) to a work order" />
+  <LinkCard title="Add Work Order Artifact" href="#add-work-order-artifact" description="Attach a typed artifact (PR, markdown note, or branch) to a work order" />
   <LinkCard title="Add Work Order Comment" href="#add-work-order-comment" description="Append a comment to a work order timeline" />
   <LinkCard title="Approval" href="#approval" description="Collect approvals on events" />
   <LinkCard title="Broadcast Message" href="#broadcast-message" description="Broadcast a message to other SuperPlane apps" />
@@ -434,8 +434,9 @@ Supported types:
 
 - **Pull request** (`pr`): requires `url`; optional `number` and `title`.
 - **Markdown note** (`markdown`): requires `body`; optional `title`.
+- **Branch** (`branch`): requires `name` (the branch name).
 
-Both types accept a free-form `data` list of `{name, value}` entries that gets merged into the artifact's `data` map. Typed inputs take precedence over free-form entries with the same key. This component can only be used in factory-owned apps.
+PR and markdown types accept a free-form `data` list of `{name, value}` entries that gets merged into the artifact's `data` map. Typed inputs take precedence over free-form entries with the same key. This component can only be used in factory-owned apps.
 
 ### Example Output
 

--- a/pkg/components/factory/add_work_order_artifact.go
+++ b/pkg/components/factory/add_work_order_artifact.go
@@ -31,6 +31,7 @@ type AddWorkOrderArtifactConfiguration struct {
 	Number       string              `json:"number" mapstructure:"number"`
 	Title        string              `json:"title" mapstructure:"title"`
 	Body         string              `json:"body" mapstructure:"body"`
+	Name         string              `json:"name" mapstructure:"name"`
 	Data         []ArtifactDataEntry `json:"data" mapstructure:"data"`
 }
 
@@ -43,7 +44,7 @@ func (c *AddWorkOrderArtifact) Label() string {
 }
 
 func (c *AddWorkOrderArtifact) Description() string {
-	return "Attach a typed artifact (PR or markdown) to a work order"
+	return "Attach a typed artifact (PR, markdown note, or branch) to a work order"
 }
 
 func (c *AddWorkOrderArtifact) Documentation() string {
@@ -53,8 +54,9 @@ Supported types:
 
 - **Pull request** (` + "`pr`" + `): requires ` + "`url`" + `; optional ` + "`number`" + ` and ` + "`title`" + `.
 - **Markdown note** (` + "`markdown`" + `): requires ` + "`body`" + `; optional ` + "`title`" + `.
+- **Branch** (` + "`branch`" + `): requires ` + "`name`" + ` (the branch name).
 
-Both types accept a free-form ` + "`data`" + ` list of ` + "`{name, value}`" + ` entries that gets merged into the artifact's ` + "`data`" + ` map. Typed inputs take precedence over free-form entries with the same key. This component can only be used in factory-owned apps.`
+PR and markdown types accept a free-form ` + "`data`" + ` list of ` + "`{name, value}`" + ` entries that gets merged into the artifact's ` + "`data`" + ` map. Typed inputs take precedence over free-form entries with the same key. This component can only be used in factory-owned apps.`
 }
 
 func (c *AddWorkOrderArtifact) Icon() string {
@@ -91,7 +93,9 @@ func (c *AddWorkOrderArtifact) OutputChannels(configuration any) []core.OutputCh
 func (c *AddWorkOrderArtifact) Configuration() []configuration.Field {
 	prOnly := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"pr"}}}
 	markdownOnly := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"markdown"}}}
+	branchOnly := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"branch"}}}
 	bothTypes := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"pr", "markdown"}}}
+	withMetadata := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"pr", "markdown"}}}
 
 	return []configuration.Field{
 		{
@@ -106,6 +110,7 @@ func (c *AddWorkOrderArtifact) Configuration() []configuration.Field {
 					Options: []configuration.FieldOption{
 						{Label: "Pull Request", Value: "pr"},
 						{Label: "Markdown", Value: "markdown"},
+						{Label: "Branch", Value: "branch"},
 					},
 				},
 			},
@@ -141,6 +146,17 @@ func (c *AddWorkOrderArtifact) Configuration() []configuration.Field {
 			},
 		},
 		{
+			Name:                 "name",
+			Label:                "Name",
+			Description:          "Branch name (e.g. feature/refund-retry)",
+			Type:                 configuration.FieldTypeString,
+			Required:             false,
+			VisibilityConditions: branchOnly,
+			RequiredConditions: []configuration.RequiredCondition{
+				{Field: "artifactType", Values: []string{"branch"}},
+			},
+		},
+		{
 			Name:                 "title",
 			Label:                "Title",
 			Description:          "Optional artifact title",
@@ -154,7 +170,7 @@ func (c *AddWorkOrderArtifact) Configuration() []configuration.Field {
 			Description:          "Extra name/value pairs merged into the artifact's data map (typed fields above take precedence on name collisions)",
 			Type:                 configuration.FieldTypeList,
 			Required:             false,
-			VisibilityConditions: bothTypes,
+			VisibilityConditions: withMetadata,
 			TypeOptions: &configuration.TypeOptions{
 				List: &configuration.ListTypeOptions{
 					ItemLabel: "Entry",
@@ -235,6 +251,7 @@ func buildArtifactData(config AddWorkOrderArtifactConfiguration) map[string]any 
 		"number": config.Number,
 		"title":  config.Title,
 		"body":   config.Body,
+		"name":   config.Name,
 	}
 
 	for key, value := range typed {

--- a/pkg/components/factory/factory_components_spec_test.go
+++ b/pkg/components/factory/factory_components_spec_test.go
@@ -174,6 +174,15 @@ func TestAddWorkOrderArtifact_ValidatesConfiguration(t *testing.T) {
 		}
 	})
 
+	t.Run("requires name for branch", func(t *testing.T) {
+		err := configuration.ValidateConfiguration(fields, map[string]any{
+			"artifactType": "branch",
+		})
+		if err == nil {
+			t.Fatal("expected error for branch without name")
+		}
+	})
+
 	t.Run("accepts valid pr", func(t *testing.T) {
 		err := configuration.ValidateConfiguration(fields, map[string]any{
 			"artifactType": "pr",
@@ -191,6 +200,16 @@ func TestAddWorkOrderArtifact_ValidatesConfiguration(t *testing.T) {
 			"artifactType": "markdown",
 			"body":         "investigation notes",
 			"title":        "Design notes",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("accepts branch with name", func(t *testing.T) {
+		err := configuration.ValidateConfiguration(fields, map[string]any{
+			"artifactType": "branch",
+			"name":         "feature/refund-retry",
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/pkg/grpc/actions/factories/list_work_order_artifacts.go
+++ b/pkg/grpc/actions/factories/list_work_order_artifacts.go
@@ -101,6 +101,8 @@ func artifactTypeToProto(t string) pb.WorkOrderArtifact_Type {
 		return pb.WorkOrderArtifact_TYPE_PR
 	case models.FactoryWorkOrderArtifactTypeMarkdown:
 		return pb.WorkOrderArtifact_TYPE_MARKDOWN
+	case models.FactoryWorkOrderArtifactTypeBranch:
+		return pb.WorkOrderArtifact_TYPE_BRANCH
 	default:
 		return pb.WorkOrderArtifact_TYPE_UNSPECIFIED
 	}
@@ -112,6 +114,8 @@ func artifactTypeFromProto(t pb.WorkOrderArtifact_Type) (string, bool) {
 		return models.FactoryWorkOrderArtifactTypePR, true
 	case pb.WorkOrderArtifact_TYPE_MARKDOWN:
 		return models.FactoryWorkOrderArtifactTypeMarkdown, true
+	case pb.WorkOrderArtifact_TYPE_BRANCH:
+		return models.FactoryWorkOrderArtifactTypeBranch, true
 	}
 	return "", false
 }

--- a/pkg/models/factory/events.go
+++ b/pkg/models/factory/events.go
@@ -29,6 +29,7 @@ const (
 const (
 	ArtifactTypePR       = "pr"
 	ArtifactTypeMarkdown = "markdown"
+	ArtifactTypeBranch   = "branch"
 )
 
 // Events

--- a/pkg/models/factory_work_order_artifact.go
+++ b/pkg/models/factory_work_order_artifact.go
@@ -18,6 +18,7 @@ import (
 const (
 	FactoryWorkOrderArtifactTypePR       = factory.ArtifactTypePR
 	FactoryWorkOrderArtifactTypeMarkdown = factory.ArtifactTypeMarkdown
+	FactoryWorkOrderArtifactTypeBranch   = factory.ArtifactTypeBranch
 )
 
 var (
@@ -66,6 +67,10 @@ func (o *FactoryWorkOrder) CreateArtifact(
 	case FactoryWorkOrderArtifactTypeMarkdown:
 		if extractArtifactString(params.Data, "body") == "" {
 			return nil, fmt.Errorf("%w: markdown artifacts require data.body", ErrFactoryWorkOrderArtifactInvalid)
+		}
+	case FactoryWorkOrderArtifactTypeBranch:
+		if extractArtifactString(params.Data, "name") == "" {
+			return nil, fmt.Errorf("%w: branch artifacts require data.name", ErrFactoryWorkOrderArtifactInvalid)
 		}
 	default:
 		return nil, fmt.Errorf("%w: unknown artifact type %q", ErrFactoryWorkOrderArtifactInvalid, params.Type)
@@ -138,7 +143,7 @@ func (o *FactoryWorkOrder) ListArtifacts(tx *gorm.DB) ([]FactoryWorkOrderArtifac
 // IsValidWorkOrderArtifactType reports whether CreateArtifact accepts t.
 func IsValidWorkOrderArtifactType(t string) bool {
 	switch t {
-	case FactoryWorkOrderArtifactTypePR, FactoryWorkOrderArtifactTypeMarkdown:
+	case FactoryWorkOrderArtifactTypePR, FactoryWorkOrderArtifactTypeMarkdown, FactoryWorkOrderArtifactTypeBranch:
 		return true
 	}
 	return false

--- a/pkg/models/factory_work_order_test.go
+++ b/pkg/models/factory_work_order_test.go
@@ -298,6 +298,21 @@ func TestFactoryWorkOrder_CreateArtifact(t *testing.T) {
 		assert.ErrorIs(t, err, ErrFactoryWorkOrderArtifactInvalid)
 	})
 
+	t.Run("branch requires data.name", func(t *testing.T) {
+		_, err := order.CreateArtifact(database.Conn(), FactoryWorkOrderArtifactParams{
+			Type: FactoryWorkOrderArtifactTypeBranch,
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFactoryWorkOrderArtifactInvalid)
+
+		_, err = order.CreateArtifact(database.Conn(), FactoryWorkOrderArtifactParams{
+			Type: FactoryWorkOrderArtifactTypeBranch,
+			Data: map[string]any{"name": "   "},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrFactoryWorkOrderArtifactInvalid)
+	})
+
 	t.Run("markdown rejects non-http(s) data.url", func(t *testing.T) {
 		cases := []string{
 			"javascript:alert(1)",
@@ -366,6 +381,28 @@ func TestFactoryWorkOrder_CreateArtifact(t *testing.T) {
 		require.NotNil(t, payload.Artifact)
 		assert.Equal(t, FactoryWorkOrderArtifactTypeMarkdown, payload.Artifact.Type)
 		assert.Equal(t, "Design notes", payload.Artifact.Data["title"])
+	})
+
+	t.Run("creates branch and emits event", func(t *testing.T) {
+		artifact, err := order.CreateArtifact(database.Conn(), FactoryWorkOrderArtifactParams{
+			Type: FactoryWorkOrderArtifactTypeBranch,
+			Data: map[string]any{
+				"name": "feature/refund-retry",
+			},
+			CreatedBy: &userID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, artifact)
+		assert.Equal(t, FactoryWorkOrderArtifactTypeBranch, artifact.Type)
+
+		events, err := order.ListEvents(database.Conn(), 10, nil)
+		require.NoError(t, err)
+
+		artifactEvent := findEventOfType(t, events, factory.EventTypeOrderArtifactAdded)
+		var payload factory.WorkOrderArtifactAdded
+		require.NoError(t, json.Unmarshal(artifactEvent.Data, &payload))
+		require.NotNil(t, payload.Artifact)
+		assert.Equal(t, "feature/refund-retry", payload.Artifact.Data["name"])
 	})
 
 	// A markdown artifact with no data.url must succeed — the http(s)

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -564,6 +564,7 @@ message WorkOrderArtifact {
     TYPE_UNSPECIFIED = 0;
     TYPE_PR = 1;
     TYPE_MARKDOWN = 2;
+    TYPE_BRANCH = 3;
   }
 
   string id = 1;

--- a/web_src/src/pages/factories/WorkOrderArtifactsPanel.tsx
+++ b/web_src/src/pages/factories/WorkOrderArtifactsPanel.tsx
@@ -1,11 +1,12 @@
 import type { FactoriesWorkOrderArtifact } from "@/api-client";
 import { formatTimeAgo } from "@/lib/date";
 import { safeExternalUrl } from "@/lib/safeExternalUrl";
-import { ExternalLink, FileText, GitPullRequest } from "lucide-react";
+import { ExternalLink, FileText, GitBranch, GitPullRequest } from "lucide-react";
 import { useState } from "react";
 
 import {
   extractArtifactMarkdownBody,
+  extractArtifactName,
   extractArtifactTitle,
   extractArtifactUrl,
   formatPrArtifactLabel,
@@ -45,13 +46,12 @@ export function WorkOrderArtifactsPanel({ artifacts, isLoading, error }: WorkOrd
 }
 
 function WorkOrderArtifactRow({ artifact }: { artifact: FactoriesWorkOrderArtifact }) {
-  const isPr = artifact.type === "TYPE_PR";
   const data = toDataRecord(artifact.data);
   const title = extractArtifactTitle(data);
 
   return (
     <li className="rounded-md border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700/70 dark:bg-gray-900/40">
-      {isPr ? <PrArtifactRow data={data} title={title} /> : <MarkdownArtifactRow data={data} title={title} />}
+      <ArtifactRowContent type={artifact.type} data={data} title={title} />
 
       <p className="mt-1 text-xs text-gray-500 dark:text-gray-500">
         {artifact.createdBy?.name ? `${artifact.createdBy.name} · ` : ""}
@@ -59,6 +59,26 @@ function WorkOrderArtifactRow({ artifact }: { artifact: FactoriesWorkOrderArtifa
       </p>
     </li>
   );
+}
+
+function ArtifactRowContent({
+  type,
+  data,
+  title,
+}: {
+  type: FactoriesWorkOrderArtifact["type"];
+  data: Record<string, unknown> | undefined;
+  title: string | undefined;
+}) {
+  switch (type) {
+    case "TYPE_PR":
+      return <PrArtifactRow data={data} title={title} />;
+    case "TYPE_BRANCH":
+      return <BranchArtifactRow data={data} />;
+    case "TYPE_MARKDOWN":
+    default:
+      return <MarkdownArtifactRow data={data} title={title} />;
+  }
 }
 
 function PrArtifactRow({ data, title }: { data: Record<string, unknown> | undefined; title: string | undefined }) {
@@ -82,6 +102,17 @@ function PrArtifactRow({ data, title }: { data: Record<string, unknown> | undefi
       ) : (
         <span className="min-w-0 truncate font-medium text-gray-900 dark:text-gray-100">{label}</span>
       )}
+    </div>
+  );
+}
+
+function BranchArtifactRow({ data }: { data: Record<string, unknown> | undefined }) {
+  const label = extractArtifactName(data) || "Branch";
+
+  return (
+    <div className="flex items-center gap-2">
+      <GitBranch className="h-4 w-4 text-sky-500" aria-hidden />
+      <span className="min-w-0 truncate font-medium text-gray-900 dark:text-gray-100">{label}</span>
     </div>
   );
 }

--- a/web_src/src/pages/factories/__fixtures__/factoryPageEventFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageEventFixtures.ts
@@ -149,7 +149,7 @@ function artifactAddedEvent(
   at: string,
   artifact: {
     id: string;
-    type: "pr" | "markdown";
+    type: "pr" | "markdown" | "branch";
     data?: Record<string, unknown>;
   },
   actor: { id: string } | null = { id: STORYBOOK_ME_USER_ID },

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -302,6 +302,15 @@ export const OPEN_WORK_ORDER_ARTIFACTS: FactoriesWorkOrderArtifact[] = [
     createdBy: { id: REVIEWER_USER.id, name: REVIEWER_USER.name },
     createdAt: HOUR_AGO,
   },
+  {
+    id: "art-branch-1",
+    type: "TYPE_BRANCH",
+    data: {
+      name: "feature/refund-retry",
+    },
+    createdBy: { id: REVIEWER_USER.id, name: REVIEWER_USER.name },
+    createdAt: HOUR_AGO,
+  },
 ];
 
 export const DEFAULT_WORK_ORDERS: FactoriesWorkOrder[] = [

--- a/web_src/src/pages/factories/lib/workOrderArtifact.spec.ts
+++ b/web_src/src/pages/factories/lib/workOrderArtifact.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   extractArtifactMarkdownBody,
+  extractArtifactName,
   extractArtifactTitle,
   extractArtifactUrl,
   formatPrArtifactLabel,
@@ -73,5 +74,18 @@ describe("extractArtifactTitle", () => {
     expect(extractArtifactTitle({})).toBeUndefined();
     expect(extractArtifactTitle({ title: "" })).toBeUndefined();
     expect(extractArtifactTitle({ title: "  " })).toBeUndefined();
+  });
+});
+
+describe("extractArtifactName", () => {
+  it("returns data.name when present", () => {
+    expect(extractArtifactName({ name: "feature/refund-retry" })).toBe("feature/refund-retry");
+  });
+
+  it("returns undefined for missing / blank names", () => {
+    expect(extractArtifactName(undefined)).toBeUndefined();
+    expect(extractArtifactName({})).toBeUndefined();
+    expect(extractArtifactName({ name: "" })).toBeUndefined();
+    expect(extractArtifactName({ name: "  " })).toBeUndefined();
   });
 });

--- a/web_src/src/pages/factories/lib/workOrderArtifact.ts
+++ b/web_src/src/pages/factories/lib/workOrderArtifact.ts
@@ -38,6 +38,10 @@ export function extractArtifactTitle(data: ArtifactData): string | undefined {
   return extractArtifactField(data, "title");
 }
 
+export function extractArtifactName(data: ArtifactData): string | undefined {
+  return extractArtifactField(data, "name");
+}
+
 function extractArtifactField(data: ArtifactData, key: string): string | undefined {
   if (!data) {
     return undefined;

--- a/web_src/src/pages/factories/lib/workOrderTimelineFromEvents.ts
+++ b/web_src/src/pages/factories/lib/workOrderTimelineFromEvents.ts
@@ -1,6 +1,6 @@
 import type { FactoriesWorkOrderEvent, FactoriesWorkOrderResult } from "@/api-client";
 import { formatWorkOrderResult } from "./workOrderPresentation";
-import { extractArtifactTitle, extractArtifactUrl } from "./workOrderArtifact";
+import { extractArtifactName, extractArtifactTitle, extractArtifactUrl } from "./workOrderArtifact";
 import { UNKNOWN_ORG_USER_NAME } from "@/lib/orgUserDisplay";
 import type {
   UserNameLookup,
@@ -315,6 +315,7 @@ function appendArtifactEvent(
 const ARTIFACT_KIND_SHORT_LABEL: Record<string, string> = {
   pr: "PR",
   markdown: "note",
+  branch: "branch",
 };
 
 function formatArtifactKindShort(type: string | undefined): string {
@@ -325,7 +326,8 @@ function formatArtifactKindShort(type: string | undefined): string {
 }
 
 function describeArtifactAdded(artifact: EventArtifactPayload): string {
-  const label = extractArtifactTitle(artifact.data) || extractArtifactUrl(artifact.data);
+  const label =
+    extractArtifactTitle(artifact.data) || extractArtifactUrl(artifact.data) || extractArtifactName(artifact.data);
   const type = formatArtifactKindShort(artifact.type);
   return label ? `attached ${type}: ${label}` : `attached ${type}`;
 }

--- a/web_src/src/pages/factories/timeline/ArtifactTimelineBody.tsx
+++ b/web_src/src/pages/factories/timeline/ArtifactTimelineBody.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, FileText, GitPullRequest } from "lucide-react";
+import { ExternalLink, FileText, GitBranch, GitPullRequest } from "lucide-react";
 import { useState } from "react";
 
 import type { OrgUserDisplayLookup } from "@/lib/orgUserDisplay";
@@ -7,6 +7,7 @@ import { safeExternalUrl } from "@/lib/safeExternalUrl";
 import { OrgUserReference } from "../OrgUserReference";
 import {
   extractArtifactMarkdownBody,
+  extractArtifactName,
   extractArtifactTitle,
   extractArtifactUrl,
   formatPrArtifactLabel,
@@ -28,7 +29,6 @@ export function ArtifactTimelineBody({
     return null;
   }
 
-  const isPr = artifact.type === "pr";
   const title = extractArtifactTitle(artifact.data);
 
   return (
@@ -39,14 +39,22 @@ export function ArtifactTimelineBody({
         automationActor={event.actorAutomation}
       />
       <div className="mt-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 dark:border-gray-700/70 dark:bg-gray-900/40 dark:text-gray-200">
-        {isPr ? (
-          <PrArtifactBody artifact={artifact} title={title} />
-        ) : (
-          <MarkdownArtifactBody artifact={artifact} title={title} />
-        )}
+        <ArtifactBodyContent artifact={artifact} title={title} />
       </div>
     </div>
   );
+}
+
+function ArtifactBodyContent({ artifact, title }: { artifact: WorkOrderTimelineArtifact; title: string | undefined }) {
+  switch (artifact.type) {
+    case "pr":
+      return <PrArtifactBody artifact={artifact} title={title} />;
+    case "branch":
+      return <BranchArtifactBody artifact={artifact} />;
+    case "markdown":
+    default:
+      return <MarkdownArtifactBody artifact={artifact} title={title} />;
+  }
 }
 
 function PrArtifactBody({ artifact, title }: { artifact: WorkOrderTimelineArtifact; title: string | undefined }) {
@@ -68,6 +76,17 @@ function PrArtifactBody({ artifact, title }: { artifact: WorkOrderTimelineArtifa
       <span className="truncate">{label}</span>
       <ExternalLink className="h-3 w-3 shrink-0" aria-hidden />
     </a>
+  );
+}
+
+function BranchArtifactBody({ artifact }: { artifact: WorkOrderTimelineArtifact }) {
+  const label = extractArtifactName(artifact.data) || "Branch";
+
+  return (
+    <p className="inline-flex max-w-full items-center gap-2 font-medium">
+      <GitBranch className="h-4 w-4 text-sky-500" aria-hidden />
+      <span className="truncate">{label}</span>
+    </p>
   );
 }
 

--- a/web_src/src/pages/factories/timeline/authorLabels.ts
+++ b/web_src/src/pages/factories/timeline/authorLabels.ts
@@ -30,6 +30,7 @@ export function formatAutomationLabel(nodeName: string | undefined, appName: str
 const ARTIFACT_KIND_LONG_LABEL: Record<string, string> = {
   pr: "pull request",
   markdown: "note",
+  branch: "branch",
 };
 
 export function formatArtifactKindLong(type: string | null | undefined): string {


### PR DESCRIPTION
  - Adds a new `branch` factory work order artifact type that stores a single branch name in `data.name`.
  - Extends the **Add Work Order Artifact** canvas component with a Branch type and required Name field.
  - Renders branch artifacts in the work order artifacts panel and timeline (GitBranch icon + branch name).