### PR TITLE
fix: promote artifact data fields on order()

### DIFF
--- a/docs/design/factory.md
+++ b/docs/design/factory.md
@@ -52,7 +52,10 @@ current run (`id`, `title`, `description`, `factory_id`, `state`, `result`,
 `source`) and returns `nil` when the run is not attached to a work order.
 `order().artifacts` is a list field loaded lazily only when the expression
 references it (e.g. `none(order().artifacts, {#.type == "pr"})`).
-`root().data.work_order` remains the onRun snapshot and does not include
+Each artifact exposes `id`, `type`, nested `data`, and the `data` keys
+promoted onto the artifact itself (`title`, `body`, `url`, …) so filters like
+`find(order().artifacts, {.type == "markdown" and .title == "PLAN.md"}).body`
+work. `root().data.work_order` remains the onRun snapshot and does not include
 artifacts.
 
 ## Work order lifecycle

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -1108,11 +1108,26 @@ func artifactExpressionPayload(artifact *models.FactoryWorkOrderArtifact) (map[s
 		}
 	}
 
-	return map[string]any{
+	normalizedData := normalizeExpressionValue(data)
+	payload := map[string]any{
 		"id":   artifact.ID.String(),
 		"type": artifact.Type,
-		"data": normalizeExpressionValue(data),
-	}, nil
+		"data": normalizedData,
+	}
+
+	// Promote data keys onto the artifact so expressions can use
+	// find(order().artifacts, {.type == "markdown" and .title == "PLAN.md"}).body
+	// without nesting under .data. Reserved keys keep the artifact identity.
+	if dataMap, ok := normalizedData.(map[string]any); ok {
+		for key, value := range dataMap {
+			if key == "id" || key == "type" || key == "data" {
+				continue
+			}
+			payload[key] = value
+		}
+	}
+
+	return payload, nil
 }
 
 func (b *NodeConfigurationBuilder) buildRunURL(run *models.CanvasRun) (string, error) {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -260,7 +260,7 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 
 	markdownArtifact, err := order.CreateArtifact(database.Conn(), models.FactoryWorkOrderArtifactParams{
 		Type: models.FactoryWorkOrderArtifactTypeMarkdown,
-		Data: map[string]any{"body": "notes from implement"},
+		Data: map[string]any{"body": "notes from implement", "title": "PLAN.md"},
 	})
 	require.NoError(t, err)
 
@@ -347,6 +347,11 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "https://github.com/org/repo/pull/7", prURL)
 
+		// Data keys are also promoted onto the artifact for ergonomic filters.
+		promotedURL, err := builder.ResolveExpression(`order().artifacts[0].url`)
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/org/repo/pull/7", promotedURL)
+
 		bracketType, err := builder.ResolveExpression(`order()["artifacts"][0]["type"]`)
 		require.NoError(t, err)
 		assert.Equal(t, models.FactoryWorkOrderArtifactTypePR, bracketType)
@@ -359,6 +364,16 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "notes from implement", body)
 		assert.Equal(t, markdownArtifact.ID.String(), mustResolveString(t, builder, `order().artifacts[1].id`))
+
+		promotedBody, err := builder.ResolveExpression(`order().artifacts[1].body`)
+		require.NoError(t, err)
+		assert.Equal(t, "notes from implement", promotedBody)
+
+		planBody, err := builder.ResolveExpression(
+			`find(order().artifacts, {.type == "markdown" and .title == "PLAN.md"}).body`,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "notes from implement", planBody)
 	})
 
 	t.Run("none and any over artifact types", func(t *testing.T) {

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -114,8 +114,8 @@ export const EXPR_FUNCTIONS: readonly ExprFunction[] = [
     name: "order",
     snippet: "order().",
     description:
-      "Returns the work order for this run when dispatched from a factory, exposing id, title, description, factory_id, state, result, source, and artifacts (loaded when accessed).",
-    example: 'none(order().artifacts, {#.type == "pr"})',
+      "Returns the work order for this run when dispatched from a factory, exposing id, title, description, factory_id, state, result, source, and artifacts (loaded when accessed; data fields like title/body/url are promoted onto each artifact).",
+    example: 'find(order().artifacts, {.type == "markdown" and .title == "PLAN.md"}).body',
   },
   // String
   {

--- a/web_src/src/pages/app/buildAutocompleteExampleObj.ts
+++ b/web_src/src/pages/app/buildAutocompleteExampleObj.ts
@@ -98,7 +98,16 @@ function buildOrderExample(): Record<string, unknown> {
       {
         id: "c3d4e5f6-a7b8-9012-cdef-123456789012",
         type: "pr",
+        url: "https://github.com/org/repo/pull/7",
+        number: 7,
         data: { url: "https://github.com/org/repo/pull/7", number: 7 },
+      },
+      {
+        id: "d4e5f6a7-b8c9-0123-def0-234567890123",
+        type: "markdown",
+        title: "PLAN.md",
+        body: "# Plan",
+        data: { title: "PLAN.md", body: "# Plan" },
       },
     ],
   };


### PR DESCRIPTION
## Summary
- Promote each work-order artifact's `data` keys (`title`, `body`, `url`, …) onto the artifact map returned by `order().artifacts`
- Unblocks expressions like `find(order().artifacts, {.type == "markdown" and .title == "PLAN.md"}).body` that previously got `nil` because those fields lived only under `.data`
- Nested `.data.*` access still works; reserved keys `id`/`type`/`data` are not overwritten

## Test plan
- [x] `go test ./pkg/workers/contexts -run OrderFunction` including Lucas's `find(...).body` expression
- [ ] Smoke on a factory run with a markdown artifact titled `PLAN.md`


Made with [Cursor](https://cursor.com)