### PR TITLE
fix: strip .git from GitHub repo URLs with a trailing slash

### DIFF
--- a/pkg/installation/repo.go
+++ b/pkg/installation/repo.go
@@ -23,8 +23,8 @@ func ParseRepository(raw string) (*Repository, error) {
 
 	trimmed = strings.TrimPrefix(trimmed, "https://")
 	trimmed = strings.TrimPrefix(trimmed, "http://")
-	trimmed = strings.TrimSuffix(trimmed, ".git")
 	trimmed = strings.Trim(trimmed, "/")
+	trimmed = strings.TrimSuffix(trimmed, ".git")
 
 	if strings.HasPrefix(trimmed, "github.com/") {
 		trimmed = strings.TrimPrefix(trimmed, "github.com/")

--- a/pkg/installation/repo_test.go
+++ b/pkg/installation/repo_test.go
@@ -27,6 +27,27 @@ func TestParseRepository(t *testing.T) {
 		_, err := ParseRepository("github.com/widget")
 		require.Error(t, err)
 	})
+
+	t.Run("strips .git suffix", func(t *testing.T) {
+		repo, err := ParseRepository("https://github.com/acme/widgets.git")
+		require.NoError(t, err)
+		assert.Equal(t, "acme", repo.Owner)
+		assert.Equal(t, "widgets", repo.Name)
+	})
+
+	t.Run("strips .git before trailing slash", func(t *testing.T) {
+		repo, err := ParseRepository("https://github.com/acme/widgets.git/")
+		require.NoError(t, err)
+		assert.Equal(t, "acme", repo.Owner)
+		assert.Equal(t, "widgets", repo.Name)
+	})
+
+	t.Run("strips .git before multiple trailing slashes", func(t *testing.T) {
+		repo, err := ParseRepository("https://github.com/acme/widgets.git///")
+		require.NoError(t, err)
+		assert.Equal(t, "acme", repo.Owner)
+		assert.Equal(t, "widgets", repo.Name)
+	})
 }
 
 func TestDefaultInstallationName(t *testing.T) {

--- a/web_src/src/lib/githubRepo.spec.ts
+++ b/web_src/src/lib/githubRepo.spec.ts
@@ -19,6 +19,27 @@ describe("parseGitHubRepoParam", () => {
   it("returns null for invalid values", () => {
     expect(parseGitHubRepoParam("github.com/only-owner")).toBeNull();
   });
+
+  it("strips .git before trailing slash", () => {
+    expect(parseGitHubRepoParam("https://github.com/acme/widgets.git/")).toEqual({
+      owner: "acme",
+      repo: "widgets",
+    });
+  });
+
+  it("strips .git before multiple trailing slashes", () => {
+    expect(parseGitHubRepoParam("https://github.com/acme/widgets.git///")).toEqual({
+      owner: "acme",
+      repo: "widgets",
+    });
+  });
+
+  it("strips trailing slash with no scheme", () => {
+    expect(parseGitHubRepoParam("github.com/acme/widgets/")).toEqual({
+      owner: "acme",
+      repo: "widgets",
+    });
+  });
 });
 
 describe("formatGitHubRepoParam", () => {

--- a/web_src/src/lib/githubRepo.ts
+++ b/web_src/src/lib/githubRepo.ts
@@ -5,8 +5,8 @@ export function parseGitHubRepoParam(raw: string | null | undefined): { owner: s
   }
 
   trimmed = trimmed.replace(/^https?:\/\//i, "");
-  trimmed = trimmed.replace(/\.git$/i, "");
   trimmed = trimmed.replace(/^\/+|\/+$/g, "");
+  trimmed = trimmed.replace(/\.git$/i, "");
 
   if (/^github\.com\//i.test(trimmed)) {
     trimmed = trimmed.slice("github.com/".length);


### PR DESCRIPTION
## What

`parseGitHubRepoParam` (`web_src/src/lib/githubRepo.ts`) and `ParseRepository` (`pkg/installation/repo.go`) both stripped the `.git` clone suffix **before** trimming a trailing slash, so a GitHub clone URL with a trailing slash kept `.git` in the repo name:

| input | before | after |
|---|---|---|
| `https://github.com/acme/widgets.git/` | `widgets.git` | `widgets` |
| `https://github.com/acme/widgets.git///` | `widgets.git` | `widgets` |

## Why

Clone URLs include `.git` and are commonly pasted with a trailing slash. The mis-parse resolved app install/preview to a non-existent repository name. The existing tests already assert `.git` is stripped for the no-trailing-slash case, so this is a normalization bug, not a behavior change.

## How

Trim leading/trailing slashes **before** stripping the `.git` suffix in both the frontend and backend parsers (a two-line reorder each). Added regression tests on both sides covering trailing and multiple-trailing slashes.

## Tests

- Frontend: `vitest run src/lib/githubRepo.spec.ts` → **7 passed**
- Backend: `go test ./pkg/installation -run TestParseRepository` → **6 subtests passed**
