### PR TITLE
fix: return error on workspace limit usage reached on runManagedAgent and runCodeAgent

### DIFF
--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -64,11 +64,19 @@ type ManagedSession struct {
 type ManagedSessionEvent struct {
 	Type    string                       `json:"type"`
 	Content []ManagedSessionContentBlock `json:"content"`
+	Error   *SessionEventError           `json:"error,omitempty"`
 }
 
 type ManagedSessionContentBlock struct {
 	Type string `json:"type"`
 	Text string `json:"text,omitempty"`
+}
+
+// SessionEventError is the error payload carried by a session.error event,
+// e.g. when the workspace has hit its Anthropic usage/credit limit mid-session.
+type SessionEventError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
 }
 
 // sessionResourceBody is a file resource mounted into the session.
@@ -308,6 +316,11 @@ type SessionMessages struct {
 	// ExpectsArtifacts is true when the session events mention the outputs
 	// directory, i.e. the agent (very likely) wrote deliverables.
 	ExpectsArtifacts bool
+	// Err is set from the most recent session.error event, if any. A terminal
+	// session with Err set produced no real result (e.g. the workspace hit its
+	// Anthropic usage/credit limit mid-session) and should be treated as a
+	// failed run rather than emitted as a passing one.
+	Err *SessionEventError
 }
 
 func (c *Client) GetSessionMessages(sessionID string) (*SessionMessages, error) {
@@ -330,11 +343,16 @@ func (c *Client) GetSessionMessages(sessionID string) (*SessionMessages, error) 
 	}
 	result.ExpectsArtifacts = c.sawSessionOutputs
 
-	// Check for terminal event (events are in desc order, so status_idle is first)
+	// Check for a terminal event and the most recent session.error, if any
+	// (events are in desc order, so the first match of each is the latest).
 	for _, e := range allEvents {
-		if e.Type == "session.status_idle" || e.Type == "session.status_terminated" {
+		switch e.Type {
+		case "session.status_idle", "session.status_terminated":
 			result.Complete = true
-			break
+		case "session.error":
+			if result.Err == nil {
+				result.Err = sessionEventErrorFrom(e)
+			}
 		}
 	}
 
@@ -434,18 +452,35 @@ func lastAgentMessageFromEvents(events []ManagedSessionEvent) string {
 		if event.Type != "agent.message" && event.Type != "assistant.message" {
 			continue
 		}
-
-		parts := []string{}
-		for _, block := range event.Content {
-			if block.Type == "text" && strings.TrimSpace(block.Text) != "" {
-				parts = append(parts, block.Text)
-			}
-		}
-		if len(parts) > 0 {
-			return strings.Join(parts, "\n")
+		if text := textFromBlocks(event.Content); text != "" {
+			return text
 		}
 	}
 	return ""
+}
+
+func textFromBlocks(blocks []ManagedSessionContentBlock) string {
+	parts := []string{}
+	for _, block := range blocks {
+		if block.Type == "text" && strings.TrimSpace(block.Text) != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// sessionEventErrorFrom extracts the error carried by a session.error event.
+// The event may carry a structured `error` object, or (like agent.message)
+// describe the failure as a text content block; either is accepted since the
+// exact shape isn't documented for this beta event type.
+func sessionEventErrorFrom(e ManagedSessionEvent) *SessionEventError {
+	if e.Error != nil && (e.Error.Message != "" || e.Error.Type != "") {
+		return e.Error
+	}
+	if text := textFromBlocks(e.Content); text != "" {
+		return &SessionEventError{Message: text}
+	}
+	return &SessionEventError{Message: "the session reported an error"}
 }
 
 func managedSessionEventTypes(events []ManagedSessionEvent) string {

--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -72,8 +72,7 @@ type ManagedSessionContentBlock struct {
 	Text string `json:"text,omitempty"`
 }
 
-// SessionEventError is the error payload carried by a session.error event,
-// e.g. when the workspace has hit its Anthropic usage/credit limit mid-session.
+// SessionEventError is the error payload carried by a session.error event.
 type SessionEventError struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
@@ -316,10 +315,7 @@ type SessionMessages struct {
 	// ExpectsArtifacts is true when the session events mention the outputs
 	// directory, i.e. the agent (very likely) wrote deliverables.
 	ExpectsArtifacts bool
-	// Err is set from the most recent session.error event, if any. A terminal
-	// session with Err set produced no real result (e.g. the workspace hit its
-	// Anthropic usage/credit limit mid-session) and should be treated as a
-	// failed run rather than emitted as a passing one.
+	// Err is set when the session ended with an unrecovered session.error.
 	Err *SessionEventError
 }
 
@@ -343,14 +339,17 @@ func (c *Client) GetSessionMessages(sessionID string) (*SessionMessages, error) 
 	}
 	result.ExpectsArtifacts = c.sawSessionOutputs
 
-	// Check for a terminal event and the most recent session.error, if any
-	// (events are in desc order, so the first match of each is the latest).
+	// session.error is recoverable and only fatal if no later session.status_idle superseded it (events are in desc order, so status_idle is seen first when it did).
+	recovered := false
 	for _, e := range allEvents {
 		switch e.Type {
-		case "session.status_idle", "session.status_terminated":
+		case "session.status_idle":
+			result.Complete = true
+			recovered = true
+		case "session.status_terminated":
 			result.Complete = true
 		case "session.error":
-			if result.Err == nil {
+			if result.Err == nil && !recovered {
 				result.Err = sessionEventErrorFrom(e)
 			}
 		}
@@ -469,10 +468,7 @@ func textFromBlocks(blocks []ManagedSessionContentBlock) string {
 	return strings.Join(parts, "\n")
 }
 
-// sessionEventErrorFrom extracts the error carried by a session.error event.
-// The event may carry a structured `error` object, or (like agent.message)
-// describe the failure as a text content block; either is accepted since the
-// exact shape isn't documented for this beta event type.
+// sessionEventErrorFrom extracts the error carried by a session.error event, from either a structured `error` object or a text content block.
 func sessionEventErrorFrom(e ManagedSessionEvent) *SessionEventError {
 	if e.Error != nil && (e.Error.Message != "" || e.Error.Type != "") {
 		return e.Error

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -92,6 +92,16 @@ func (a *RunAgent) handleTerminalSession(ctx core.ActionHookContext, client *Cli
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}
 
+	if sm != nil && sm.Err != nil {
+		ctx.Logger.Errorf("Managed session %s failed: %s", metadata.Session.ID, sm.Err.Message)
+		mergeSessionIntoMetadata(metadata, sess)
+		_ = ctx.Metadata.Set(*metadata)
+		reclaimSession(client, metadata.Session.ID, persist, ctx.Logger)
+		cleanupUploadedFilesFromHook(client, ctx, ctx.Logger.Warnf)
+		cleanupManagedVaultFromHook(client, ctx, ctx.Logger.Warnf)
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("managed agent session failed: %s", sm.Err.Message))
+	}
+
 	out := buildOutputFromSessionMessages(sess.Status, metadata.Session.ID, sm)
 	if sm != nil {
 		// Only trust structured output once events are confirmed complete —

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -389,6 +389,14 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		sm, err := client.GetSessionMessagesWithRetry(session.ID, finalMessageReads, finalMessageDelay)
 		if err != nil {
 			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v. Scheduling poll.", session.ID, err)
+		} else if sm != nil && sm.Complete && sm.Err != nil {
+			ctx.Logger.Errorf("Managed session %s failed: %s", session.ID, sm.Err.Message)
+			mergeSessionIntoMetadata(&metadata, refreshed)
+			_ = ctx.Metadata.Set(metadata)
+			reclaimSession(client, session.ID, spec.PersistSession, ctx.Logger)
+			cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
+			cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
+			return fmt.Errorf("managed agent session failed: %s", sm.Err.Message)
 		} else if sm != nil && sm.Complete {
 			out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
 			applyStructuredOutput(&out, refreshed.Status, schema)

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -387,9 +387,10 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 
 	if refreshed != nil && isSessionTerminal(refreshed.Status) {
 		sm, err := client.GetSessionMessagesWithRetry(session.ID, finalMessageReads, finalMessageDelay)
-		if err != nil {
+		switch {
+		case err != nil:
 			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v. Scheduling poll.", session.ID, err)
-		} else if sm != nil && sm.Complete && sm.Err != nil {
+		case sm != nil && sm.Complete && sm.Err != nil:
 			ctx.Logger.Errorf("Managed session %s failed: %s", session.ID, sm.Err.Message)
 			mergeSessionIntoMetadata(&metadata, refreshed)
 			_ = ctx.Metadata.Set(metadata)
@@ -397,7 +398,7 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 			cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
 			cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 			return fmt.Errorf("managed agent session failed: %s", sm.Err.Message)
-		} else if sm != nil && sm.Complete {
+		case sm != nil && sm.Complete:
 			out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
 			applyStructuredOutput(&out, refreshed.Status, schema)
 			out.Artifacts = CollectSessionArtifacts(client, session.ID, sm.ExpectsArtifacts, ctx.Logger.Warnf)
@@ -405,14 +406,13 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 				cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 				return emitErr
 			}
-			// Persist terminal status only after successful emit
 			mergeSessionIntoMetadata(&metadata, refreshed)
 			_ = ctx.Metadata.Set(metadata)
 			reclaimSession(client, session.ID, spec.PersistSession, ctx.Logger)
 			cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
 			cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 			return nil
-		} else {
+		default:
 			ctx.Logger.Warnf("Events not complete for session %s after retries. Scheduling poll.", session.ID)
 		}
 	}

--- a/pkg/integrations/claude/runagent/run_agent_test.go
+++ b/pkg/integrations/claude/runagent/run_agent_test.go
@@ -273,7 +273,6 @@ func Test__RunAgent__Execute__syncIdle(t *testing.T) {
 	assert.Equal(t, "sess_1", httpContext.Requests[4].URL.Query().Get("scope_id"))
 }
 
-// An unrecovered session.error must fail the run rather than pass with an empty message.
 func Test__RunAgent__Execute__syncSessionError(t *testing.T) {
 	a := &RunAgent{}
 	httpContext := &contexts.HTTPContext{
@@ -282,7 +281,7 @@ func Test__RunAgent__Execute__syncSessionError(t *testing.T) {
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"terminated"}`))},
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
-			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, // delete session
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
 		},
 	}
 	integrationCtx := &contexts.IntegrationContext{
@@ -475,14 +474,13 @@ func Test__RunAgent__poll__terminal(t *testing.T) {
 	assert.Equal(t, "# Report\n", out.Artifacts[0].Content)
 }
 
-// An unrecovered session.error must fail the execution via ExecutionState.Fail during polling too.
 func Test__RunAgent__poll__sessionErrorFailsExecution(t *testing.T) {
 	a := &RunAgent{}
 	httpContext := &contexts.HTTPContext{
 		Responses: []*http.Response{
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"terminated"}`))},
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
-			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, // delete session
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
 		},
 	}
 	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}}
@@ -987,7 +985,6 @@ func Test__SessionMessages__ExpectsArtifacts(t *testing.T) {
 	})
 }
 
-// A session.error is recoverable: a later session.status_idle means the session finished normally and Err must not be set.
 func Test__GetSessionMessages__recoveredSessionErrorIsNotFatal(t *testing.T) {
 	httpCtx := &contexts.HTTPContext{
 		Responses: []*http.Response{
@@ -1002,7 +999,6 @@ func Test__GetSessionMessages__recoveredSessionErrorIsNotFatal(t *testing.T) {
 	assert.Equal(t, "Done after retry", sm.LastMessage)
 }
 
-// An unrecovered session.error (no later session.status_idle) must set Err.
 func Test__GetSessionMessages__unrecoveredSessionErrorIsFatal(t *testing.T) {
 	httpCtx := &contexts.HTTPContext{
 		Responses: []*http.Response{

--- a/pkg/integrations/claude/runagent/run_agent_test.go
+++ b/pkg/integrations/claude/runagent/run_agent_test.go
@@ -273,6 +273,44 @@ func Test__RunAgent__Execute__syncIdle(t *testing.T) {
 	assert.Equal(t, "sess_1", httpContext.Requests[4].URL.Query().Get("scope_id"))
 }
 
+// A session.error event means the session produced no real result (e.g. the
+// workspace hit its Anthropic usage/credit limit); the run must fail rather
+// than pass with an empty message.
+func Test__RunAgent__Execute__syncSessionError(t *testing.T) {
+	a := &RunAgent{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"running"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_idle"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, // delete session
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{"apiKey": "sk-test"},
+	}
+	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	execCtx := core.ExecutionContext{
+		ID:             uuid.New(),
+		Configuration:  map[string]any{"agent": "ag_1", "environmentId": "ev_1", "prompt": "Hello"},
+		HTTP:           httpContext,
+		Integration:    integrationCtx,
+		Metadata:       &contexts.MetadataContext{},
+		ExecutionState: executionState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	err := a.Execute(execCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Workspace usage limit reached")
+	assert.False(t, executionState.Finished, "the worker (not Execute itself) fails the execution")
+
+	_, deleted := sessionCalls(httpContext)
+	assert.True(t, deleted, "a failed session must still be reclaimed")
+}
+
 func Test__RunAgent__Execute__structuredOutput(t *testing.T) {
 	a := &RunAgent{}
 	agentMessage := "Here is the result.\n\n```json\n{\"summary\": \"looks good\"}\n```\n"
@@ -437,6 +475,47 @@ func Test__RunAgent__poll__terminal(t *testing.T) {
 	assert.Equal(t, "file_out1", out.Artifacts[0].FileID)
 	assert.Equal(t, "text", out.Artifacts[0].Encoding)
 	assert.Equal(t, "# Report\n", out.Artifacts[0].Content)
+}
+
+// A session.error event surfaced during polling must fail the execution
+// (via ExecutionState.Fail), not emit a passing payload with an empty message.
+func Test__RunAgent__poll__sessionErrorFailsExecution(t *testing.T) {
+	a := &RunAgent{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_idle"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, // delete session
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}}
+	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	metadataCtx := &contexts.MetadataContext{
+		Metadata: ExecutionMetadata{
+			Session: &SessionMetadata{ID: "sess_1", Status: "running"},
+		},
+	}
+	hookCtx := core.ActionHookContext{
+		Name:           "poll",
+		Parameters:     map[string]any{"attempt": float64(1), "errors": float64(0)},
+		HTTP:           httpContext,
+		Integration:    integrationCtx,
+		Metadata:       metadataCtx,
+		ExecutionState: executionState,
+		Logger:         logrus.NewEntry(logrus.New()),
+		Requests:       &contexts.RequestContext{},
+	}
+
+	err := a.HandleHook(hookCtx)
+	require.NoError(t, err)
+	require.True(t, executionState.Finished)
+	assert.False(t, executionState.Passed)
+	assert.Equal(t, "error", executionState.FailureReason)
+	assert.Contains(t, executionState.FailureMessage, "Workspace usage limit reached")
+	assert.Empty(t, executionState.Payloads, "no payload should be emitted for a failed session")
+
+	_, deleted := sessionCalls(httpContext)
+	assert.True(t, deleted, "a failed session must still be reclaimed")
 }
 
 func Test__RunAgent__poll__structuredOutput(t *testing.T) {

--- a/pkg/integrations/claude/runagent/run_agent_test.go
+++ b/pkg/integrations/claude/runagent/run_agent_test.go
@@ -273,17 +273,15 @@ func Test__RunAgent__Execute__syncIdle(t *testing.T) {
 	assert.Equal(t, "sess_1", httpContext.Requests[4].URL.Query().Get("scope_id"))
 }
 
-// A session.error event means the session produced no real result (e.g. the
-// workspace hit its Anthropic usage/credit limit); the run must fail rather
-// than pass with an empty message.
+// An unrecovered session.error must fail the run rather than pass with an empty message.
 func Test__RunAgent__Execute__syncSessionError(t *testing.T) {
 	a := &RunAgent{}
 	httpContext := &contexts.HTTPContext{
 		Responses: []*http.Response{
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"running"}`))},
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
-			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))},
-			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_idle"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"terminated"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, // delete session
 		},
 	}
@@ -477,14 +475,13 @@ func Test__RunAgent__poll__terminal(t *testing.T) {
 	assert.Equal(t, "# Report\n", out.Artifacts[0].Content)
 }
 
-// A session.error event surfaced during polling must fail the execution
-// (via ExecutionState.Fail), not emit a passing payload with an empty message.
+// An unrecovered session.error must fail the execution via ExecutionState.Fail during polling too.
 func Test__RunAgent__poll__sessionErrorFailsExecution(t *testing.T) {
 	a := &RunAgent{}
 	httpContext := &contexts.HTTPContext{
 		Responses: []*http.Response{
-			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))},
-			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_idle"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"terminated"}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, // delete session
 		},
 	}
@@ -988,6 +985,36 @@ func Test__SessionMessages__ExpectsArtifacts(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, sm.ExpectsArtifacts)
 	})
+}
+
+// A session.error is recoverable: a later session.status_idle means the session finished normally and Err must not be set.
+func Test__GetSessionMessages__recoveredSessionErrorIsNotFatal(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_idle"},{"type":"agent.message","content":[{"type":"text","text":"Done after retry"}]},{"type":"session.error","error":{"type":"overloaded_error","message":"temporarily overloaded"}},{"type":"user.message","content":[{"type":"text","text":"Hello"}]}]}`))},
+		},
+	}
+	client := &Client{APIKey: "k", BaseURL: defaultBaseURL, http: httpCtx}
+	sm, err := client.GetSessionMessages("sess_1")
+	require.NoError(t, err)
+	assert.True(t, sm.Complete)
+	assert.Nil(t, sm.Err)
+	assert.Equal(t, "Done after retry", sm.LastMessage)
+}
+
+// An unrecovered session.error (no later session.status_idle) must set Err.
+func Test__GetSessionMessages__unrecoveredSessionErrorIsFatal(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`))},
+		},
+	}
+	client := &Client{APIKey: "k", BaseURL: defaultBaseURL, http: httpCtx}
+	sm, err := client.GetSessionMessages("sess_1")
+	require.NoError(t, err)
+	assert.True(t, sm.Complete)
+	require.NotNil(t, sm.Err)
+	assert.Equal(t, "Workspace usage limit reached", sm.Err.Message)
 }
 
 func Test__CollectSessionArtifacts__retryOnlyWhenExpected(t *testing.T) {

--- a/pkg/integrations/claude/runcodeagent/monitor.go
+++ b/pkg/integrations/claude/runcodeagent/monitor.go
@@ -141,6 +141,14 @@ func (a *RunCodeAgent) handleTerminalSession(ctx core.ActionHookContext, client 
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}
 
+	if sm != nil && sm.Err != nil {
+		ctx.Logger.Errorf("Session %s failed: %s", meta.Session.ID, sm.Err.Message)
+		mergeSessionIntoMetadata(meta, sess)
+		_ = ctx.Metadata.Set(*meta)
+		a.teardown(client, meta, false, persist, ctx.Logger.Warnf)
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("code agent session failed: %s", sm.Err.Message))
+	}
+
 	out := buildOutput(sess.Status, meta.Session.ID, meta.Branch, sm, meta.PrURL)
 	// Past the poll budget the events may still be unavailable (sm == nil);
 	// emit what we have and only look for artifacts when events were read.

--- a/pkg/integrations/claude/runcodeagent/run_code_agent.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent.go
@@ -398,6 +398,14 @@ func (a *RunCodeAgent) emitIfTerminal(ctx core.ExecutionContext, client *runagen
 		return false, nil
 	}
 
+	if sm.Err != nil {
+		ctx.Logger.Errorf("Session %s failed: %s", meta.Session.ID, sm.Err.Message)
+		mergeSessionIntoMetadata(meta, session)
+		_ = ctx.Metadata.Set(*meta)
+		a.teardown(client, meta, false, spec.PersistSession, ctx.Logger.Warnf)
+		return true, fmt.Errorf("code agent session failed: %s", sm.Err.Message)
+	}
+
 	out := buildOutput(session.Status, meta.Session.ID, meta.Branch, sm, meta.PrURL)
 	applyStructuredOutput(&out, session.Status, schema)
 	out.Artifacts = runagent.CollectSessionArtifacts(client, meta.Session.ID, sm.ExpectsArtifacts, ctx.Logger.Warnf)

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -253,6 +253,64 @@ func Test__RunCodeAgent__Execute__repositoryMode_schedulesPoll(t *testing.T) {
 	assert.Contains(t, string(body), "do the thing")
 }
 
+// A session.error event means the session produced no real result (e.g. the
+// workspace hit its Anthropic usage/credit limit); the run must fail rather
+// than pass with an empty message, and every provisioned resource must still
+// be reclaimed.
+func Test__RunCodeAgent__Execute__sessionErrorFailsAndReclaims(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"agent_1"}`),                // create agent
+		resp(`{"id":"env_1"}`),                  // create environment
+		resp(`{"id":"vault_1"}`),                // create vault
+		resp(`{}`),                              // add GITHUB_TOKEN credential
+		resp(`{"id":"sess_1","status":"idle"}`), // create session
+		resp(`{}`),                              // send message
+		resp(`{"id":"sess_1","status":"idle"}`), // get session (fast-path check)
+		resp(`{"data":[{"type":"session.status_idle"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`), // get session events
+		resp(`{}`), // teardown: delete session
+		resp(`{}`), // teardown: delete environment
+		resp(`{}`), // teardown: delete vault
+		resp(`{}`), // teardown: archive agent
+	}}
+	metadataCtx := &contexts.MetadataContext{}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	execCtx := core.ExecutionContext{
+		ID:             uuid.New(),
+		Configuration:  repoConfig(),
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Secrets:        &contexts.SecretsContext{Values: map[string][]byte{"gh/token": []byte("ghp_123")}},
+		Metadata:       metadataCtx,
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	err := a.Execute(execCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Workspace usage limit reached")
+	assert.False(t, execState.Finished, "the worker (not Execute itself) fails the execution")
+
+	var sessionDeleted, envDeleted, vaultDeleted, agentArchived bool
+	for _, r := range httpCtx.Requests {
+		switch {
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/sessions/sess_1"):
+			sessionDeleted = true
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/environments/env_1"):
+			envDeleted = true
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/vaults/vault_1"):
+			vaultDeleted = true
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/agents/agent_1/archive"):
+			agentArchived = true
+		}
+	}
+	assert.True(t, sessionDeleted, "session should be deleted")
+	assert.True(t, envDeleted, "environment should be deleted")
+	assert.True(t, vaultDeleted, "vault should be deleted")
+	assert.True(t, agentArchived, "agent should be archived")
+}
+
 func Test__RunCodeAgent__Execute__structuredOutputInPrompt(t *testing.T) {
 	a := &RunCodeAgent{}
 	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
@@ -439,6 +497,36 @@ func Test__RunCodeAgent__poll__terminalExtractsPR(t *testing.T) {
 	assert.Equal(t, "migration-notes.md", out.Artifacts[0].Filename)
 	assert.Equal(t, "text", out.Artifacts[0].Encoding)
 	assert.Equal(t, "# Migration notes\n", out.Artifacts[0].Content)
+}
+
+// A session.error event surfaced during polling must fail the execution
+// (via ExecutionState.Fail), not emit a passing payload with an empty message.
+func Test__RunCodeAgent__poll__sessionErrorFailsExecution(t *testing.T) {
+	a := &RunCodeAgent{}
+	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
+		resp(`{"id":"sess_1","status":"idle"}`),
+		resp(`{"data":[{"type":"session.status_idle"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`),
+		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), // teardown
+	}}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	hookCtx := core.ActionHookContext{
+		Name:           "poll",
+		Parameters:     map[string]any{"attempt": float64(1), "errors": float64(0)},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}},
+		Metadata:       terminalMeta(),
+		ExecutionState: execState,
+		Requests:       &contexts.RequestContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	err := a.HandleHook(hookCtx)
+	require.NoError(t, err)
+	require.True(t, execState.Finished)
+	assert.False(t, execState.Passed)
+	assert.Equal(t, "error", execState.FailureReason)
+	assert.Contains(t, execState.FailureMessage, "Workspace usage limit reached")
+	assert.Empty(t, execState.Payloads, "no payload should be emitted for a failed session")
 }
 
 func Test__RunCodeAgent__poll__structuredOutput(t *testing.T) {

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -253,22 +253,21 @@ func Test__RunCodeAgent__Execute__repositoryMode_schedulesPoll(t *testing.T) {
 	assert.Contains(t, string(body), "do the thing")
 }
 
-// An unrecovered session.error must fail the run and reclaim every provisioned resource.
 func Test__RunCodeAgent__Execute__sessionErrorFailsAndReclaims(t *testing.T) {
 	a := &RunCodeAgent{}
 	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
-		resp(`{"id":"agent_1"}`),                // create agent
-		resp(`{"id":"env_1"}`),                  // create environment
-		resp(`{"id":"vault_1"}`),                // create vault
-		resp(`{}`),                              // add GITHUB_TOKEN credential
-		resp(`{"id":"sess_1","status":"terminated"}`), // create session
-		resp(`{}`),                                    // send message
-		resp(`{"id":"sess_1","status":"terminated"}`), // get session (fast-path check)
-		resp(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`), // get session events
-		resp(`{}`), // teardown: delete session
-		resp(`{}`), // teardown: delete environment
-		resp(`{}`), // teardown: delete vault
-		resp(`{}`), // teardown: archive agent
+		resp(`{"id":"agent_1"}`),
+		resp(`{"id":"env_1"}`),
+		resp(`{"id":"vault_1"}`),
+		resp(`{}`),
+		resp(`{"id":"sess_1","status":"terminated"}`),
+		resp(`{}`),
+		resp(`{"id":"sess_1","status":"terminated"}`),
+		resp(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`),
+		resp(`{}`),
+		resp(`{}`),
+		resp(`{}`),
+		resp(`{}`),
 	}}
 	metadataCtx := &contexts.MetadataContext{}
 	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
@@ -496,13 +495,12 @@ func Test__RunCodeAgent__poll__terminalExtractsPR(t *testing.T) {
 	assert.Equal(t, "# Migration notes\n", out.Artifacts[0].Content)
 }
 
-// An unrecovered session.error must fail the execution via ExecutionState.Fail during polling too.
 func Test__RunCodeAgent__poll__sessionErrorFailsExecution(t *testing.T) {
 	a := &RunCodeAgent{}
 	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
 		resp(`{"id":"sess_1","status":"terminated"}`),
 		resp(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`),
-		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), // teardown
+		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`),
 	}}
 	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 	hookCtx := core.ActionHookContext{

--- a/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
+++ b/pkg/integrations/claude/runcodeagent/run_code_agent_test.go
@@ -253,10 +253,7 @@ func Test__RunCodeAgent__Execute__repositoryMode_schedulesPoll(t *testing.T) {
 	assert.Contains(t, string(body), "do the thing")
 }
 
-// A session.error event means the session produced no real result (e.g. the
-// workspace hit its Anthropic usage/credit limit); the run must fail rather
-// than pass with an empty message, and every provisioned resource must still
-// be reclaimed.
+// An unrecovered session.error must fail the run and reclaim every provisioned resource.
 func Test__RunCodeAgent__Execute__sessionErrorFailsAndReclaims(t *testing.T) {
 	a := &RunCodeAgent{}
 	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
@@ -264,10 +261,10 @@ func Test__RunCodeAgent__Execute__sessionErrorFailsAndReclaims(t *testing.T) {
 		resp(`{"id":"env_1"}`),                  // create environment
 		resp(`{"id":"vault_1"}`),                // create vault
 		resp(`{}`),                              // add GITHUB_TOKEN credential
-		resp(`{"id":"sess_1","status":"idle"}`), // create session
-		resp(`{}`),                              // send message
-		resp(`{"id":"sess_1","status":"idle"}`), // get session (fast-path check)
-		resp(`{"data":[{"type":"session.status_idle"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`), // get session events
+		resp(`{"id":"sess_1","status":"terminated"}`), // create session
+		resp(`{}`),                                    // send message
+		resp(`{"id":"sess_1","status":"terminated"}`), // get session (fast-path check)
+		resp(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`), // get session events
 		resp(`{}`), // teardown: delete session
 		resp(`{}`), // teardown: delete environment
 		resp(`{}`), // teardown: delete vault
@@ -499,13 +496,12 @@ func Test__RunCodeAgent__poll__terminalExtractsPR(t *testing.T) {
 	assert.Equal(t, "# Migration notes\n", out.Artifacts[0].Content)
 }
 
-// A session.error event surfaced during polling must fail the execution
-// (via ExecutionState.Fail), not emit a passing payload with an empty message.
+// An unrecovered session.error must fail the execution via ExecutionState.Fail during polling too.
 func Test__RunCodeAgent__poll__sessionErrorFailsExecution(t *testing.T) {
 	a := &RunCodeAgent{}
 	httpCtx := &contexts.HTTPContext{Responses: []*http.Response{
-		resp(`{"id":"sess_1","status":"idle"}`),
-		resp(`{"data":[{"type":"session.status_idle"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`),
+		resp(`{"id":"sess_1","status":"terminated"}`),
+		resp(`{"data":[{"type":"session.status_terminated"},{"type":"session.error","error":{"type":"usage_limit_error","message":"Workspace usage limit reached"}}]}`),
 		resp(`{}`), resp(`{}`), resp(`{}`), resp(`{}`), // teardown
 	}}
 	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}


### PR DESCRIPTION
## What changed
`claude.runAgent` (Run Managed Agent) and `claude.runCodeAgent` (Run Code Agent) now fail the execution when the underlying Managed Agents session reports a `session.error` event

## Why
- Closes #6204.

## How
### Backend
- `pkg/integrations/claude/runagent/client.go`: `ManagedSessionEvent` now captures an optional `error` object; `GetSessionMessages` records the most recent `session.error` event on the new `SessionMessages.Err` field.
