### PR TITLE
fix(home): retry canvas name collisions on app + factory install

### DIFF
--- a/web_src/src/pages/home/FreshOrgLanding.tsx
+++ b/web_src/src/pages/home/FreshOrgLanding.tsx
@@ -107,7 +107,12 @@ export function FreshOrgLanding({
       )}
 
       {installingApp && (
-        <InstallProgressPanel app={installingApp} folder={folder} onClose={() => setInstallingApp(null)} />
+        <InstallProgressPanel
+          app={installingApp}
+          canvasName={installingApp.title}
+          folder={folder}
+          onClose={() => setInstallingApp(null)}
+        />
       )}
 
       {!inFocusedSetup && (

--- a/web_src/src/pages/home/createCanvasWithUniqueName.spec.ts
+++ b/web_src/src/pages/home/createCanvasWithUniqueName.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createCanvasWithUniqueName, MAX_NAME_RETRY_ATTEMPTS } from "./createCanvasWithUniqueName";
+
+const nameCollisionError = () => new Error("Canvas with the same name already exists");
+
+describe("createCanvasWithUniqueName", () => {
+  it("creates with the base name when it is free", async () => {
+    const createCanvas = vi.fn().mockResolvedValue({ canvasId: "id-1" });
+
+    const result = await createCanvasWithUniqueName({
+      title: "Software Factory",
+      existingNames: new Set(),
+      createCanvas,
+    });
+
+    expect(result).toEqual({ canvasId: "id-1", canvasName: "Software Factory" });
+    expect(createCanvas).toHaveBeenCalledTimes(1);
+    expect(createCanvas).toHaveBeenCalledWith("Software Factory");
+  });
+
+  it("retries under a suffixed name when the create call reports a collision", async () => {
+    const createCanvas = vi
+      .fn()
+      .mockRejectedValueOnce(nameCollisionError())
+      .mockResolvedValueOnce({ canvasId: "id-2" });
+
+    const result = await createCanvasWithUniqueName({
+      title: "Software Factory",
+      // Empty client-side cache: the collision is only discovered via the failed create call.
+      existingNames: new Set(),
+      createCanvas,
+    });
+
+    expect(result).toEqual({ canvasId: "id-2", canvasName: "Software Factory (2)" });
+    expect(createCanvas).toHaveBeenNthCalledWith(1, "Software Factory");
+    expect(createCanvas).toHaveBeenNthCalledWith(2, "Software Factory (2)");
+  });
+
+  it("propagates non-collision errors immediately, without retrying", async () => {
+    const createCanvas = vi.fn().mockRejectedValue(new Error("network error"));
+
+    await expect(
+      createCanvasWithUniqueName({ title: "Software Factory", existingNames: new Set(), createCanvas }),
+    ).rejects.toThrow("network error");
+    expect(createCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws once retries are exhausted", async () => {
+    const createCanvas = vi.fn().mockRejectedValue(nameCollisionError());
+
+    await expect(
+      createCanvasWithUniqueName({
+        title: "Software Factory",
+        existingNames: new Set(),
+        createCanvas,
+        failureMessage: "Failed to create factory canvas",
+      }),
+    ).rejects.toThrow("Failed to create factory canvas");
+    expect(createCanvas).toHaveBeenCalledTimes(MAX_NAME_RETRY_ATTEMPTS);
+  });
+
+  it("supports a custom collision predicate for callers whose API uses a different error shape", async () => {
+    const conflictError = Object.assign(new Error("An App with the same name already exists"), { status: 409 });
+    const createCanvas = vi.fn().mockRejectedValueOnce(conflictError).mockResolvedValueOnce({ canvasId: "id-3" });
+
+    const result = await createCanvasWithUniqueName({
+      title: "Slack Notifier",
+      existingNames: new Set(),
+      createCanvas,
+      isNameCollisionError: (error) => error instanceof Error && (error as Error & { status?: number }).status === 409,
+    });
+
+    expect(result).toEqual({ canvasId: "id-3", canvasName: "Slack Notifier (2)" });
+  });
+});

--- a/web_src/src/pages/home/createCanvasWithUniqueName.ts
+++ b/web_src/src/pages/home/createCanvasWithUniqueName.ts
@@ -1,0 +1,49 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { canvasesListCanvases, type CanvasesCanvasSummary } from "@/api-client";
+import { canvasKeys } from "@/hooks/useCanvasData";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+import { isCanvasNameAlreadyExistsError, uniqueCanvasName } from "./uniqueCanvasName";
+
+export const MAX_NAME_RETRY_ATTEMPTS = 20;
+
+export async function listExistingCanvasNames(organizationId: string, queryClient: QueryClient): Promise<string[]> {
+  const cached = queryClient.getQueryData<CanvasesCanvasSummary[]>(canvasKeys.list(organizationId));
+  if (cached) {
+    return cached.map((canvas) => canvas.name).filter((name): name is string => Boolean(name));
+  }
+
+  const response = await canvasesListCanvases(withOrganizationHeader({ organizationId }));
+  return (response.data?.canvases ?? []).map((canvas) => canvas.name).filter((name): name is string => Boolean(name));
+}
+
+/**
+ * Calls `createCanvas` with a name derived from `title`, retrying under a
+ * suffixed name (via uniqueCanvasName) whenever the create call rejects with
+ * a name-collision error. Handles both a stale client-side name cache and a
+ * fresh server-side collision on the same attempt.
+ */
+export async function createCanvasWithUniqueName<T extends { canvasId: string }>(args: {
+  title: string;
+  existingNames: Set<string>;
+  createCanvas: (name: string) => Promise<T>;
+  isNameCollisionError?: (error: unknown) => boolean;
+  failureMessage?: string;
+}): Promise<T & { canvasName: string }> {
+  const isCollision = args.isNameCollisionError ?? isCanvasNameAlreadyExistsError;
+  let canvasName = uniqueCanvasName(args.title, args.existingNames);
+
+  for (let attempt = 0; attempt < MAX_NAME_RETRY_ATTEMPTS; attempt++) {
+    try {
+      const result = await args.createCanvas(canvasName);
+      return { ...result, canvasName };
+    } catch (error) {
+      if (!isCollision(error)) {
+        throw error;
+      }
+      args.existingNames.add(canvasName);
+      canvasName = uniqueCanvasName(args.title, args.existingNames);
+    }
+  }
+
+  throw new Error(args.failureMessage ?? "Failed to create canvas with a unique name");
+}

--- a/web_src/src/pages/home/index.spec.tsx
+++ b/web_src/src/pages/home/index.spec.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CanvasFoldersCanvasFolder, CanvasesCanvasSummary } from "@/api-client";
+import type * as ApiClientModule from "@/api-client";
 import type { ReactNode } from "react";
 import { showErrorToast } from "@/lib/toast";
 
@@ -134,6 +135,16 @@ vi.mock("@/hooks/useCanvasData", () => ({
   useUpdateCanvasFolderMembership,
   useUpdateCanvasPreference,
 }));
+
+// createCanvasWithUniqueName lists existing canvases through this generated client.
+// In jsdom the real client can't resolve the relative "/api/v1/canvases" URL, so stub it.
+vi.mock("@/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof ApiClientModule>();
+  return {
+    ...actual,
+    canvasesListCanvases: vi.fn().mockResolvedValue({ data: { canvases: [] } }),
+  };
+});
 
 import { HomePage } from "./index";
 import { InstallProgressPanel } from "./InstallProgressPanel";
@@ -535,6 +546,8 @@ describe("HomePage canvas folders", () => {
 
   it("opens a folder-scoped installed app when folder membership update fails", async () => {
     const user = userEvent.setup();
+    // createCanvasWithUniqueName lists existing canvases (via canvasesListCanvases, mocked
+    // above) before installing; the raw preview and install calls go through fetch.
     const fetchMock = vi.fn();
     fetchMock
       .mockResolvedValueOnce(new Response(JSON.stringify({ integrations: [], installParams: [] }), { status: 200 }))

--- a/web_src/src/pages/home/useInstallAction.ts
+++ b/web_src/src/pages/home/useInstallAction.ts
@@ -14,6 +14,7 @@ import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { appPath } from "@/lib/appPaths";
 import type { AppEntry } from "./AppDetailModal";
 import { appendCanvasToFolderMembership } from "./canvasFolderMembership";
+import { createCanvasWithUniqueName, listExistingCanvasNames } from "./createCanvasWithUniqueName";
 import type { IntegrationSelections } from "./InstallIntegrationsSection";
 import type { CanvasFolderData } from "./types";
 import type { InstallParam } from "../install/types";
@@ -38,8 +39,20 @@ async function executeInstall(opts: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!response.ok) throw new Error((await response.text()) || "Failed to install");
+  if (!response.ok) {
+    const message = (await response.text()) || "Failed to install";
+    const error = new Error(message) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
   return response.json() as Promise<{ canvasId: string; organizationId: string }>;
+}
+
+// /apps/install returns 409 with an "App"-flavored message (distinct from the
+// "Canvas with the same name already exists" text isCanvasNameAlreadyExistsError
+// checks for), so collisions here are detected by status code instead.
+function isInstallNameCollisionError(error: unknown): boolean {
+  return error instanceof Error && (error as Error & { status?: number }).status === 409;
 }
 
 function prepareAgentSidebar(app: AppEntry, canvasId: string) {
@@ -105,12 +118,20 @@ export function useInstallAction({
       isInstallingRef.current = true;
       setIsInstalling(true);
       try {
-        const result = await executeInstall({
-          repo: app.repo,
-          organizationId,
-          name: canvasName,
-          installParams: !skipParams && installParams.length > 0 ? paramValues : undefined,
-          integrations: integrationSelections,
+        const existingNames = new Set(await listExistingCanvasNames(organizationId, queryClient));
+        const result = await createCanvasWithUniqueName({
+          title: canvasName || generateCanvasName(),
+          existingNames,
+          isNameCollisionError: isInstallNameCollisionError,
+          failureMessage: "Failed to install app",
+          createCanvas: (name) =>
+            executeInstall({
+              repo: app.repo,
+              organizationId,
+              name,
+              installParams: !skipParams && installParams.length > 0 ? paramValues : undefined,
+              integrations: integrationSelections,
+            }),
         });
         if (folder) {
           try {

--- a/web_src/src/pages/home/useInstallFactory.ts
+++ b/web_src/src/pages/home/useInstallFactory.ts
@@ -1,13 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
-import {
-  canvasesCommitCanvasStaging,
-  canvasesInvokeNodeTriggerHook,
-  canvasesListCanvases,
-  canvasesPutCanvasStaging,
-  type CanvasesCanvasSummary,
-} from "@/api-client";
+import { canvasesCommitCanvasStaging, canvasesInvokeNodeTriggerHook, canvasesPutCanvasStaging } from "@/api-client";
 import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { writeCanvasRunsSidebarOpen } from "@/components/CanvasRunsSidebar/useCanvasRunsSidebarState";
 import { usePermissions } from "@/contexts/usePermissions";
@@ -22,6 +16,7 @@ import { encodeRepositoryFileContent } from "@/pages/app/files/lib/repository-fi
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
 
 import { appendCanvasToFolderMembership } from "./canvasFolderMembership";
+import { createCanvasWithUniqueName, listExistingCanvasNames } from "./createCanvasWithUniqueName";
 import {
   buildFactoryRunParameters,
   getFactoryDefinition,
@@ -31,9 +26,6 @@ import {
 } from "./factories";
 import type { IntegrationSelections } from "./homeIntegrationStatus";
 import type { CanvasFolderData } from "./types";
-import { isCanvasNameAlreadyExistsError, uniqueCanvasName } from "./uniqueCanvasName";
-
-const MAX_NAME_RETRY_ATTEMPTS = 20;
 
 export interface InstallFactoryInput {
   factoryId?: string;
@@ -99,50 +91,6 @@ async function materializeAndCommitFactoryTemplate(args: {
   await stageAndCommitFactorySpecs(args.canvasId, canvasYaml, consoleYaml);
 }
 
-async function listExistingCanvasNames(organizationId: string, queryClient: QueryClient) {
-  const cached = queryClient.getQueryData<CanvasesCanvasSummary[]>(canvasKeys.list(organizationId));
-  if (cached) {
-    return cached.map((canvas) => canvas.name).filter((name): name is string => Boolean(name));
-  }
-
-  const response = await canvasesListCanvases(withOrganizationHeader({ organizationId }));
-  return (response.data?.canvases ?? []).map((canvas) => canvas.name).filter((name): name is string => Boolean(name));
-}
-
-async function createCanvasWithUniqueName(args: {
-  title: string;
-  description?: string;
-  existingNames: Set<string>;
-  createCanvas: (input: { name: string; description?: string; method: "ui" }) => Promise<{
-    data?: { canvas?: { metadata?: { id?: string } } };
-  }>;
-}): Promise<{ canvasId: string; canvasName: string }> {
-  let canvasName = uniqueCanvasName(args.title, args.existingNames);
-
-  for (let attempt = 0; attempt < MAX_NAME_RETRY_ATTEMPTS; attempt++) {
-    try {
-      const result = await args.createCanvas({
-        name: canvasName,
-        description: args.description,
-        method: "ui",
-      });
-      const canvasId = result?.data?.canvas?.metadata?.id;
-      if (!canvasId) {
-        throw new Error("Failed to create factory canvas");
-      }
-      return { canvasId, canvasName };
-    } catch (error) {
-      if (!isCanvasNameAlreadyExistsError(error)) {
-        throw error;
-      }
-      args.existingNames.add(canvasName);
-      canvasName = uniqueCanvasName(args.title, args.existingNames);
-    }
-  }
-
-  throw new Error("Failed to create factory canvas");
-}
-
 async function ensureFactoryCanvas(args: {
   pending: { canvasId: string; canvasName: string } | null;
   organizationId: string;
@@ -159,9 +107,16 @@ async function ensureFactoryCanvas(args: {
   const existingNames = new Set(await listExistingCanvasNames(args.organizationId, args.queryClient));
   const created = await createCanvasWithUniqueName({
     title: args.definition.title,
-    description: args.definition.description,
     existingNames,
-    createCanvas: args.createCanvas,
+    failureMessage: "Failed to create factory canvas",
+    createCanvas: async (name) => {
+      const result = await args.createCanvas({ name, description: args.definition.description, method: "ui" });
+      const canvasId = result?.data?.canvas?.metadata?.id;
+      if (!canvasId) {
+        throw new Error("Failed to create factory canvas");
+      }
+      return { canvasId };
+    },
   });
 
   if (args.folder) {


### PR DESCRIPTION


Extract listExistingCanvasNames/createCanvasWithUniqueName from useInstallFactory into a shared, generic helper and reuse it in useInstallAction so app installs retry under a suffixed name on collision (409) instead of failing. Set InstallProgressPanel default name from the app title (#5799).