### PR TITLE
fix: autocomplete dropdown viewport overflow

### DIFF
--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
@@ -4,11 +4,14 @@ import { AutoCompleteInput } from "./AutoCompleteInput";
 import { calculateDropdownPosition } from "./dropdownPosition";
 
 describe("calculateDropdownPosition", () => {
-  it("anchors the dropdown top to the cursor y coordinate", () => {
+  it("anchors the dropdown top to the cursor y coordinate when there is room below", () => {
     const position = calculateDropdownPosition({
       cursor: { x: 120, y: 240 },
+      cursorTop: 220,
       viewportWidth: 1000,
+      viewportHeight: 800,
       dropdownWidth: 350,
+      dropdownHeight: 244,
       valuePreviewWidth: 200,
       showValuePreview: false,
     });
@@ -16,11 +19,30 @@ describe("calculateDropdownPosition", () => {
     expect(position.top).toBe(244);
   });
 
+  it("flips the dropdown above the cursor when there is not enough room below", () => {
+    const position = calculateDropdownPosition({
+      cursor: { x: 120, y: 720 },
+      cursorTop: 700,
+      viewportWidth: 1000,
+      viewportHeight: 800,
+      dropdownWidth: 350,
+      dropdownHeight: 244,
+      valuePreviewWidth: 200,
+      showValuePreview: false,
+    });
+
+    // Should flip above: cursorTop(700) - gap(4) - dropdownHeight(244) = 452
+    expect(position.top).toBe(452);
+  });
+
   it("keeps the dropdown inside the viewport horizontally", () => {
     const position = calculateDropdownPosition({
       cursor: { x: 980, y: 80 },
+      cursorTop: 60,
       viewportWidth: 1000,
+      viewportHeight: 800,
       dropdownWidth: 350,
+      dropdownHeight: 244,
       valuePreviewWidth: 200,
       showValuePreview: false,
     });

--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -979,8 +979,11 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       setDropdownPosition(
         calculateDropdownPosition({
           cursor,
+          cursorTop: markerRect.top - input.scrollTop,
           viewportWidth: window.innerWidth,
+          viewportHeight: window.innerHeight,
           dropdownWidth,
+          dropdownHeight: SUGGESTION_LIST_MAX_HEIGHT_PX,
           valuePreviewWidth,
           showValuePreview,
         }),

--- a/web_src/src/components/AutoCompleteInput/dropdownPosition.ts
+++ b/web_src/src/components/AutoCompleteInput/dropdownPosition.ts
@@ -5,8 +5,12 @@ type ScreenPoint = {
 
 type DropdownPositionInput = {
   cursor: ScreenPoint;
+  /** Top edge of the cursor character in viewport coordinates (for flip-above). */
+  cursorTop: number;
   viewportWidth: number;
+  viewportHeight: number;
   dropdownWidth: number;
+  dropdownHeight: number;
   valuePreviewWidth: number;
   showValuePreview: boolean;
   edgePadding?: number;
@@ -15,13 +19,17 @@ type DropdownPositionInput = {
 
 export function calculateDropdownPosition({
   cursor,
+  cursorTop,
   viewportWidth,
+  viewportHeight,
   dropdownWidth,
+  dropdownHeight,
   valuePreviewWidth,
   showValuePreview,
   edgePadding = 16,
   gap = 4,
 }: DropdownPositionInput) {
+  // Horizontal placement
   const spaceOnRight = viewportWidth - cursor.x - edgePadding;
   const spaceOnLeft = cursor.x - edgePadding;
   const shouldFlipLeft = spaceOnRight < dropdownWidth && spaceOnLeft >= dropdownWidth;
@@ -34,8 +42,16 @@ export function calculateDropdownPosition({
   }
 
   const totalWidth = showValuePreview ? dropdownWidth + valuePreviewWidth : dropdownWidth;
-  return {
-    top: cursor.y + gap,
-    left: Math.max(edgePadding, Math.min(left, viewportWidth - totalWidth - edgePadding)),
-  };
+  left = Math.max(edgePadding, Math.min(left, viewportWidth - totalWidth - edgePadding));
+
+  // Vertical placement — flip above the cursor when there isn't enough room below
+  const spaceBelow = viewportHeight - cursor.y - edgePadding;
+  const spaceAbove = cursorTop - edgePadding;
+  const shouldFlipAbove = spaceBelow < dropdownHeight && spaceAbove >= dropdownHeight;
+
+  const top = shouldFlipAbove
+    ? Math.max(edgePadding, cursorTop - gap - dropdownHeight)
+    : Math.min(cursor.y + gap, viewportHeight - dropdownHeight - edgePadding);
+
+  return { top, left };
 }


### PR DESCRIPTION
## Summary

Fixes #6483

- dropdownPosition.ts: Added cursorTop, viewportHeight, and dropdownHeight parameters. The function now checks if there's enough vertical space below (spaceBelow < dropdownHeight) and flips the dropdown above the cursor when needed, while clamping to viewport edges in both directions.
- AutoCompleteInput.tsx: Updated measureCursorPixelPosition to pass cursorTop: markerRect.top - input.scrollTop, viewportHeight: window.innerHeight, and dropdownHeight: SUGGESTION_LIST_MAX_HEIGHT_PX to calculateDropdownPosition.
- AutoCompleteInput.spec.tsx: Updated existing tests with the new required params and added a test for the flip-above behavior.