### PR TITLE
fix: support custom roles for API keys

### DIFF
--- a/pkg/authorization/casbin_adapter.go
+++ b/pkg/authorization/casbin_adapter.go
@@ -14,7 +14,7 @@ func newCasbinAdapter(db *gorm.DB) (*gormadapter.Adapter, error) {
 	return gormadapter.NewTransactionalAdapterByDB(db)
 }
 
-// newCasbinFilteredAdapter creates a filtered Casbin adapter for read paths without AutoMigrate.
+// newCasbinFilteredAdapter creates a filtered Casbin adapter without AutoMigrate.
 func newCasbinFilteredAdapter(db *gorm.DB) (*gormadapter.Adapter, error) {
 	return gormadapter.NewFilteredAdapterByDB(db, "", casbinRuleTable)
 }

--- a/pkg/authorization/errors.go
+++ b/pkg/authorization/errors.go
@@ -1,0 +1,11 @@
+package authorization
+
+import "errors"
+
+var (
+	// ErrRoleNotFound indicates that a role does not exist in the requested domain.
+	ErrRoleNotFound = errors.New("role not found")
+
+	// ErrRoleNotAssignable indicates that a role cannot be assigned to the requested subject.
+	ErrRoleNotAssignable = errors.New("role not assignable")
+)

--- a/pkg/authorization/interface.go
+++ b/pkg/authorization/interface.go
@@ -26,8 +26,8 @@ type GroupManager interface {
 
 // Role management interface
 type RoleManager interface {
-	AssignRole(userID, role, domainID string, domainType string) error
-	RemoveRole(userID, role, domainID string, domainType string) error
+	AssignRole(db *gorm.DB, userID, role, domainID string, domainType string) error
+	RemoveRole(db *gorm.DB, userID, role, domainID string, domainType string) error
 	GetOrgUsersForRole(ctx context.Context, role string, orgID string) ([]string, error)
 }
 

--- a/pkg/authorization/service.go
+++ b/pkg/authorization/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/casbin/casbin/v2"
@@ -1191,7 +1192,7 @@ func (a *AuthService) validateRoleAssignment(
 	if err != nil {
 		return fmt.Errorf("failed to get inherited roles for %s: %w", roleName, err)
 	}
-	if contains(inheritedRoles, prefixRoleName(models.RoleOrgOwner)) {
+	if slices.Contains(inheritedRoles, prefixRoleName(models.RoleOrgOwner)) {
 		return fmt.Errorf("%w: %s inherits %s", ErrRoleNotAssignable, roleName, models.RoleOrgOwner)
 	}
 

--- a/pkg/authorization/service.go
+++ b/pkg/authorization/service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -125,6 +126,15 @@ func policyFiltersForDomain(domainType, domainID string) []gormadapter.Filter {
 	}
 }
 
+func exactPolicyFiltersForDomain(domainType, domainID string) []gormadapter.Filter {
+	domain := prefixDomain(domainType, domainID)
+
+	return []gormadapter.Filter{
+		{Ptype: []string{"p"}, V1: []string{domain}},
+		{Ptype: []string{"g"}, V2: []string{domain}},
+	}
+}
+
 func (a *AuthService) newReadEnforcer(ctx context.Context, filters []gormadapter.Filter) (casbin.IEnforcer, error) {
 	adapter, err := newCasbinFilteredAdapter(database.DB(ctx))
 	if err != nil {
@@ -146,6 +156,34 @@ func (a *AuthService) newReadEnforcer(ctx context.Context, filters []gormadapter
 	if err := a.loadDefaultPoliciesOn(enforcer); err != nil {
 		return nil, fmt.Errorf("failed to load default policies: %w", err)
 	}
+
+	return enforcer, nil
+}
+
+func (a *AuthService) newWriteEnforcer(tx *gorm.DB, domainType, domainID string) (casbin.IEnforcer, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("database handle is required")
+	}
+
+	adapter, err := newCasbinFilteredAdapter(tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create casbin adapter: %w", err)
+	}
+
+	enforcer, err := casbin.NewEnforcer(a.casbinModel.Copy(), adapter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create casbin enforcer: %w", err)
+	}
+
+	enforcer.EnableAutoSave(false)
+	enforcer.AddNamedDomainMatchingFunc("g", "keyMatch", util.KeyMatch)
+	if err := enforcer.LoadFilteredPolicy(exactPolicyFiltersForDomain(domainType, domainID)); err != nil {
+		return nil, fmt.Errorf("failed to load filtered policy: %w", err)
+	}
+	if err := a.loadDefaultPoliciesOn(enforcer); err != nil {
+		return nil, fmt.Errorf("failed to load default policies: %w", err)
+	}
+	enforcer.EnableAutoSave(true)
 
 	return enforcer, nil
 }
@@ -492,34 +530,42 @@ func (a *AuthService) GetGroupRole(ctx context.Context, domainID string, domainT
 	return role, nil
 }
 
-func (a *AuthService) AssignRole(userID, role, domainID string, domainType string) error {
-	adapter := a.enforcer.GetAdapter().(*gormadapter.Adapter)
+func (a *AuthService) AssignRole(db *gorm.DB, userID, role, domainID string, domainType string) error {
+	if db == nil {
+		return fmt.Errorf("database handle is required")
+	}
 
-	return adapter.Transaction(a.enforcer, func(enforcerTx casbin.IEnforcer) error {
-		return a.assignRoleWithEnforcer(enforcerTx, userID, role, domainID, domainType)
+	return db.Transaction(func(tx *gorm.DB) error {
+		var subject *models.User
+		if domainType == models.DomainTypeOrganization {
+			user, err := models.FindActiveUserByIDInTransaction(tx, domainID, userID)
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("failed to load role subject: %w", err)
+			}
+			if err == nil {
+				subject = user
+			}
+		}
+
+		enforcer, err := a.newWriteEnforcer(tx, domainType, domainID)
+		if err != nil {
+			return err
+		}
+
+		return a.assignRoleWithEnforcer(subject, enforcer, userID, role, domainID, domainType)
 	})
 }
 
-func (a *AuthService) assignRoleWithEnforcer(enforcer casbin.IEnforcer, userID, role, domainID, domainType string) error {
+func (a *AuthService) assignRoleWithEnforcer(
+	subject *models.User,
+	enforcer casbin.IEnforcer,
+	userID, role, domainID, domainType string,
+) error {
 	domain := prefixDomain(domainType, domainID)
 	prefixedRole := prefixRoleName(role)
 
-	// Check if it's a default role
-	validRoles := map[string][]string{
-		models.DomainTypeOrganization: {models.RoleOrgViewer, models.RoleOrgAdmin, models.RoleOrgOwner},
-	}
-
-	isValidDefaultRole := false
-	if roles, exists := validRoles[domainType]; exists {
-		isValidDefaultRole = contains(roles, role)
-	}
-
-	// If not a default role, check if it's a custom role that exists
-	if !isValidDefaultRole {
-		policies, _ := enforcer.GetFilteredPolicy(0, prefixedRole, domain)
-		if len(policies) == 0 {
-			return fmt.Errorf("invalid role %s for domain type %s", role, domainType)
-		}
+	if err := a.validateRoleAssignment(subject, enforcer, role, domainID, domainType); err != nil {
+		return err
 	}
 
 	prefixedUserID := prefixUserID(userID)
@@ -532,7 +578,7 @@ func (a *AuthService) assignRoleWithEnforcer(enforcer casbin.IEnforcer, userID, 
 		if strings.HasPrefix(existingRole[1], "/roles/") {
 			_, err := enforcer.RemoveGroupingPolicy(prefixedUserID, existingRole[1], domain)
 			if err != nil {
-				log.Warnf("failed to remove existing role %s for user %s: %v", existingRole[1], userID, err)
+				return fmt.Errorf("failed to remove existing role %s for user %s: %w", existingRole[1], userID, err)
 			}
 		}
 	}
@@ -549,11 +595,16 @@ func (a *AuthService) assignRoleWithEnforcer(enforcer casbin.IEnforcer, userID, 
 	return nil
 }
 
-func (a *AuthService) RemoveRole(userID, role, domainID string, domainType string) error {
+func (a *AuthService) RemoveRole(db *gorm.DB, userID, role, domainID string, domainType string) error {
+	enforcer, err := a.newWriteEnforcer(db, domainType, domainID)
+	if err != nil {
+		return err
+	}
+
 	domain := prefixDomain(domainType, domainID)
 	prefixedRole := prefixRoleName(role)
 	prefixedUserID := prefixUserID(userID)
-	ruleRemoved, err := a.enforcer.RemoveGroupingPolicy(prefixedUserID, prefixedRole, domain)
+	ruleRemoved, err := enforcer.RemoveGroupingPolicy(prefixedUserID, prefixedRole, domain)
 	if err != nil {
 		return fmt.Errorf("failed to remove role: %w", err)
 	}
@@ -615,7 +666,7 @@ func (a *AuthService) SetupOrganization(tx *gorm.DB, orgID, ownerID string) erro
 		//
 		// Setup the organization owner
 		//
-		err = a.assignRoleWithEnforcer(enforcerTx, ownerID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
+		err = a.assignRoleWithEnforcer(nil, enforcerTx, ownerID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
 		if err != nil {
 			return fmt.Errorf("failed to assign organization owner: %w", err)
 		}
@@ -636,23 +687,15 @@ func (a *AuthService) SetupOrganization(tx *gorm.DB, orgID, ownerID string) erro
 func (a *AuthService) DestroyOrganization(tx *gorm.DB, orgID string) error {
 	domain := prefixDomain(models.DomainTypeOrganization, orgID)
 
-	db := a.enforcer.GetAdapter().(*gormadapter.Adapter)
-	err := db.Transaction(a.enforcer, func(enforcerTx casbin.IEnforcer) error {
-		_, err := a.enforcer.RemoveFilteredGroupingPolicy(2, domain)
-		if err != nil {
-			return fmt.Errorf("failed to remove organization roles: %w", err)
-		}
-
-		_, err = a.enforcer.RemoveFilteredPolicy(1, domain)
-		if err != nil {
-			return fmt.Errorf("failed to remove organization policies: %w", err)
-		}
-
-		return nil
-	})
-
+	enforcer, err := a.newWriteEnforcer(tx, models.DomainTypeOrganization, orgID)
 	if err != nil {
-		return fmt.Errorf("failed to remove policies for %s: %w", orgID, err)
+		return fmt.Errorf("failed to load policies for %s: %w", orgID, err)
+	}
+	if _, err := enforcer.RemoveFilteredGroupingPolicy(2, domain); err != nil {
+		return fmt.Errorf("failed to remove organization roles: %w", err)
+	}
+	if _, err := enforcer.RemoveFilteredPolicy(1, domain); err != nil {
+		return fmt.Errorf("failed to remove organization policies: %w", err)
 	}
 
 	err = models.DeleteMetadataForOrganization(tx, models.DomainTypeOrganization, orgID)
@@ -1102,6 +1145,57 @@ func (a *AuthService) roleExistsInDomain(roleName, domain string) bool {
 	}
 
 	return false
+}
+
+func (a *AuthService) validateRoleAssignment(
+	subject *models.User,
+	enforcer casbin.IEnforcer,
+	roleName, domainID, domainType string,
+) error {
+	if err := models.ValidateDomainType(domainType); err != nil {
+		return err
+	}
+
+	domain := prefixDomain(domainType, domainID)
+	prefixedRole := prefixRoleName(roleName)
+	if !a.IsDefaultRole(roleName, domainType) {
+		policies, err := enforcer.GetFilteredPolicy(0, prefixedRole, domain)
+		if err != nil {
+			return fmt.Errorf("failed to get policies for role %s: %w", roleName, err)
+		}
+
+		inherits, err := enforcer.GetFilteredGroupingPolicy(0, prefixedRole, "", domain)
+		if err != nil {
+			return fmt.Errorf("failed to get inheritance for role %s: %w", roleName, err)
+		}
+		hasInheritance := false
+		for _, policy := range inherits {
+			if len(policy) >= 3 && strings.HasPrefix(policy[1], "/roles/") {
+				hasInheritance = true
+				break
+			}
+		}
+		if len(policies) == 0 && !hasInheritance {
+			return fmt.Errorf("%w: %s", ErrRoleNotFound, roleName)
+		}
+	}
+
+	if subject == nil || !subject.IsAPIKey() {
+		return nil
+	}
+	if roleName == models.RoleOrgOwner {
+		return fmt.Errorf("%w: %s", ErrRoleNotAssignable, roleName)
+	}
+
+	inheritedRoles, err := enforcer.GetImplicitRolesForUser(prefixedRole, domain)
+	if err != nil {
+		return fmt.Errorf("failed to get inherited roles for %s: %w", roleName, err)
+	}
+	if contains(inheritedRoles, prefixRoleName(models.RoleOrgOwner)) {
+		return fmt.Errorf("%w: %s inherits %s", ErrRoleNotAssignable, roleName, models.RoleOrgOwner)
+	}
+
+	return nil
 }
 
 func (a *AuthService) getRolePermissions(enforcer casbin.IEnforcer, roleName, domain, domainType string) []*Permission {

--- a/pkg/authorization/service_test.go
+++ b/pkg/authorization/service_test.go
@@ -35,7 +35,7 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 	orgPath := "org"
 
 	t.Run("org owner has all permissions", func(t *testing.T) {
-		err := r.AuthService.AssignRole(database.Conn(), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.DB(t.Context()), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Should have all canvas permissions (inherited from admin)
@@ -71,7 +71,7 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 
 	t.Run("org admin has limited permissions", func(t *testing.T) {
 		adminID := uuid.New().String()
-		err := r.AuthService.AssignRole(database.Conn(), adminID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.DB(t.Context()), adminID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Should have canvas management permissions
@@ -107,7 +107,7 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 
 	t.Run("org viewer has only read permissions", func(t *testing.T) {
 		viewerID := uuid.New().String()
-		err := r.AuthService.AssignRole(database.Conn(), viewerID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.DB(t.Context()), viewerID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Should have canvas read permission
@@ -138,7 +138,7 @@ func Test__AuthService_RoleManagement(t *testing.T) {
 
 	t.Run("assign and remove roles", func(t *testing.T) {
 		// Assign role
-		err := r.AuthService.AssignRole(database.Conn(), userID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.DB(t.Context()), userID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Verify role assignment
@@ -155,7 +155,7 @@ func Test__AuthService_RoleManagement(t *testing.T) {
 		assert.True(t, allowed)
 
 		// Remove role
-		err = r.AuthService.RemoveRole(database.Conn(), userID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
+		err = r.AuthService.RemoveRole(database.DB(t.Context()), userID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Verify role removal
@@ -169,7 +169,7 @@ func Test__AuthService_RoleManagement(t *testing.T) {
 	})
 
 	t.Run("invalid role assignment", func(t *testing.T) {
-		err := r.AuthService.AssignRole(database.Conn(), userID, "invalid_role", orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.DB(t.Context()), userID, "invalid_role", orgID, models.DomainTypeOrganization)
 		assert.ErrorIs(t, err, authorization.ErrRoleNotFound)
 	})
 }
@@ -338,11 +338,11 @@ func Test__AuthService_DuplicateAssignments(t *testing.T) {
 
 	t.Run("duplicate role assignment is idempotent", func(t *testing.T) {
 		// First assignment
-		err := r.AuthService.AssignRole(database.Conn(), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.DB(t.Context()), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Duplicate assignment should not error
-		err = r.AuthService.AssignRole(database.Conn(), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
+		err = r.AuthService.AssignRole(database.DB(t.Context()), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Should still have the role only once
@@ -379,9 +379,9 @@ func Test__AuthService_PermissionBoundaries(t *testing.T) {
 		adminID := uuid.New().String()
 
 		// Assign roles
-		err := r.AuthService.AssignRole(database.Conn(), viewerID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.DB(t.Context()), viewerID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
-		err = r.AuthService.AssignRole(database.Conn(), adminID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
+		err = r.AuthService.AssignRole(database.DB(t.Context()), adminID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Check org update permission

--- a/pkg/authorization/service_test.go
+++ b/pkg/authorization/service_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/gorm"
 )
 
 func Test__AuthService_BasicPermissions(t *testing.T) {
@@ -32,7 +35,7 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 	orgPath := "org"
 
 	t.Run("org owner has all permissions", func(t *testing.T) {
-		err := r.AuthService.AssignRole(userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.Conn(), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Should have all canvas permissions (inherited from admin)
@@ -68,7 +71,7 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 
 	t.Run("org admin has limited permissions", func(t *testing.T) {
 		adminID := uuid.New().String()
-		err := r.AuthService.AssignRole(adminID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.Conn(), adminID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Should have canvas management permissions
@@ -104,7 +107,7 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 
 	t.Run("org viewer has only read permissions", func(t *testing.T) {
 		viewerID := uuid.New().String()
-		err := r.AuthService.AssignRole(viewerID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.Conn(), viewerID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Should have canvas read permission
@@ -135,7 +138,7 @@ func Test__AuthService_RoleManagement(t *testing.T) {
 
 	t.Run("assign and remove roles", func(t *testing.T) {
 		// Assign role
-		err := r.AuthService.AssignRole(userID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.Conn(), userID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Verify role assignment
@@ -152,7 +155,7 @@ func Test__AuthService_RoleManagement(t *testing.T) {
 		assert.True(t, allowed)
 
 		// Remove role
-		err = r.AuthService.RemoveRole(userID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
+		err = r.AuthService.RemoveRole(database.Conn(), userID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Verify role removal
@@ -166,10 +169,68 @@ func Test__AuthService_RoleManagement(t *testing.T) {
 	})
 
 	t.Run("invalid role assignment", func(t *testing.T) {
-		err := r.AuthService.AssignRole(userID, "invalid_role", orgID, models.DomainTypeOrganization)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid role")
+		err := r.AuthService.AssignRole(database.Conn(), userID, "invalid_role", orgID, models.DomainTypeOrganization)
+		assert.ErrorIs(t, err, authorization.ErrRoleNotFound)
 	})
+}
+
+func Test__AuthService_CustomRoleWritesUseCallerDatabase(t *testing.T) {
+	r := support.Setup(t)
+	orgID := r.Organization.ID.String()
+	otherOrganization := support.CreateOrganization(t, r, r.User)
+	assigner := support.AuthService(t)
+	remover := support.AuthService(t)
+	roleName := "automation-viewer"
+
+	require.NoError(t, r.AuthService.CreateCustomRole(orgID, &authorization.RoleDefinition{
+		Name:         roleName,
+		DomainType:   models.DomainTypeOrganization,
+		InheritsFrom: &authorization.RoleDefinition{Name: models.RoleOrgViewer},
+	}))
+
+	userID := uuid.NewString()
+	tx := database.DB(t.Context()).Begin()
+	require.NoError(t, tx.Error)
+	require.NoError(t, assigner.AssignRole(tx, userID, roleName, orgID, models.DomainTypeOrganization))
+	require.EqualValues(t, 1, countRoleAssignment(t, tx, userID, roleName, orgID))
+	require.NoError(t, tx.Rollback().Error)
+	require.Zero(t, countRoleAssignment(t, database.DB(t.Context()), userID, roleName, orgID))
+
+	require.NoError(t, assigner.AssignRole(database.DB(t.Context()), userID, roleName, orgID, models.DomainTypeOrganization))
+	require.EqualValues(t, 1, countRoleAssignment(t, database.DB(t.Context()), userID, roleName, orgID))
+	require.NoError(t, remover.RemoveRole(database.DB(t.Context()), userID, roleName, orgID, models.DomainTypeOrganization))
+	require.Zero(t, countRoleAssignment(t, database.DB(t.Context()), userID, roleName, orgID))
+
+	err := assigner.AssignRole(database.DB(t.Context()), userID, roleName, otherOrganization.ID.String(), models.DomainTypeOrganization)
+	require.ErrorIs(t, err, authorization.ErrRoleNotFound)
+}
+
+func Test__AuthService_DestroyOrganizationUsesFreshCallerDatabase(t *testing.T) {
+	r := support.Setup(t)
+	orgID := r.Organization.ID.String()
+	destroyer := support.AuthService(t)
+	userID := uuid.NewString()
+	require.NoError(t, r.AuthService.AssignRole(database.DB(t.Context()), userID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization))
+
+	tx := database.DB(t.Context()).Begin()
+	require.NoError(t, tx.Error)
+	require.NoError(t, destroyer.DestroyOrganization(tx, orgID))
+	require.Zero(t, countRoleAssignment(t, tx, userID, models.RoleOrgViewer, orgID))
+	require.NoError(t, tx.Rollback().Error)
+
+	require.EqualValues(t, 1, countRoleAssignment(t, database.DB(t.Context()), userID, models.RoleOrgViewer, orgID))
+}
+
+func countRoleAssignment(t *testing.T, db *gorm.DB, userID, roleName, orgID string) int64 {
+	t.Helper()
+
+	var count int64
+	require.NoError(t, db.Table("casbin_rule").
+		Where("ptype = ? AND v0 = ? AND v1 = ? AND v2 = ?", "g", "/users/"+userID, "/roles/"+roleName, "/org/"+orgID).
+		Count(&count).
+		Error)
+
+	return count
 }
 
 func Test__AuthService_GroupManagement(t *testing.T) {
@@ -277,11 +338,11 @@ func Test__AuthService_DuplicateAssignments(t *testing.T) {
 
 	t.Run("duplicate role assignment is idempotent", func(t *testing.T) {
 		// First assignment
-		err := r.AuthService.AssignRole(userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.Conn(), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Duplicate assignment should not error
-		err = r.AuthService.AssignRole(userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
+		err = r.AuthService.AssignRole(database.Conn(), userID, models.RoleOrgOwner, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Should still have the role only once
@@ -318,9 +379,9 @@ func Test__AuthService_PermissionBoundaries(t *testing.T) {
 		adminID := uuid.New().String()
 
 		// Assign roles
-		err := r.AuthService.AssignRole(viewerID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
+		err := r.AuthService.AssignRole(database.Conn(), viewerID, models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
-		err = r.AuthService.AssignRole(adminID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
+		err = r.AuthService.AssignRole(database.Conn(), adminID, models.RoleOrgAdmin, orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		// Check org update permission

--- a/pkg/grpc/actions/apikeys/create_api_key.go
+++ b/pkg/grpc/actions/apikeys/create_api_key.go
@@ -2,6 +2,7 @@ package apikeys
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -36,17 +37,13 @@ func CreateAPIKey(ctx context.Context, req *pb.CreateAPIKeyRequest, authService 
 		return nil, grpcerrors.InvalidArgument(nil, "name is required")
 	}
 
-	validRoles := map[string]bool{
-		models.RoleOrgAdmin:  true,
-		models.RoleOrgViewer: true,
-	}
-
-	if req.Role == "" {
+	role := strings.TrimSpace(req.Role)
+	if role == "" {
 		return nil, grpcerrors.InvalidArgument(nil, "role is required")
 	}
 
-	if !validRoles[req.Role] {
-		return nil, grpcerrors.InvalidArgument(nil, "invalid role for API key; must be org_admin or org_viewer")
+	if role == models.RoleOrgOwner {
+		return nil, grpcerrors.InvalidArgument(nil, "API keys cannot be assigned the org_owner role")
 	}
 
 	orgUUID, err := uuid.Parse(orgID)
@@ -99,11 +96,14 @@ func CreateAPIKey(ctx context.Context, req *pb.CreateAPIKeyRequest, authService 
 			return txErr
 		}
 
-		txErr = authService.AssignRole(apiKey.ID.String(), req.Role, orgID, models.DomainTypeOrganization)
+		txErr = authService.AssignRole(tx, apiKey.ID.String(), role, orgID, models.DomainTypeOrganization)
 		return txErr
 	})
 
 	if err != nil {
+		if errors.Is(err, authorization.ErrRoleNotFound) || errors.Is(err, authorization.ErrRoleNotAssignable) {
+			return nil, grpcerrors.InvalidArgument(err, "role cannot be assigned to an API key")
+		}
 		return nil, grpcerrors.Internal(err, "failed to create API key")
 	}
 

--- a/pkg/grpc/actions/apikeys/create_api_key_test.go
+++ b/pkg/grpc/actions/apikeys/create_api_key_test.go
@@ -166,7 +166,7 @@ func countAPIKeyRoleAssignment(t *testing.T, userID, roleName, orgID string) int
 	t.Helper()
 
 	var count int64
-	require.NoError(t, database.Conn().Table("casbin_rule").
+	require.NoError(t, database.DB(t.Context()).Table("casbin_rule").
 		Where("ptype = ? AND v0 = ? AND v1 = ? AND v2 = ?", "g", "/users/"+userID, "/roles/"+roleName, "/org/"+orgID).
 		Count(&count).
 		Error)
@@ -178,7 +178,7 @@ func countAPIKeys(t *testing.T, orgID string) int64 {
 	t.Helper()
 
 	var count int64
-	require.NoError(t, database.Conn().Unscoped().Model(&models.User{}).
+	require.NoError(t, database.DB(t.Context()).Unscoped().Model(&models.User{}).
 		Where("organization_id = ? AND type = ?", orgID, models.UserTypeAPIKey).
 		Count(&count).
 		Error)

--- a/pkg/grpc/actions/apikeys/create_api_key_test.go
+++ b/pkg/grpc/actions/apikeys/create_api_key_test.go
@@ -2,10 +2,12 @@ package apikeys
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/database"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -14,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 func TestCreateAPIKeyStoresExpirationAndCanvasScope(t *testing.T) {
@@ -50,6 +53,137 @@ func TestCreateAPIKeyRejectsInvalidCanvasScope(t *testing.T) {
 
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
+}
+
+func TestCreateAPIKeyAcceptsCustomRole(t *testing.T) {
+	r := support.Setup(t)
+	roleName := "ci-deployer"
+	require.NoError(t, r.AuthService.CreateCustomRole(r.Organization.ID.String(), &authorization.RoleDefinition{
+		Name:       roleName,
+		DomainType: models.DomainTypeOrganization,
+		Permissions: []*authorization.Permission{
+			{Resource: "canvases", Action: "create", DomainType: models.DomainTypeOrganization},
+		},
+	}))
+
+	response, err := CreateAPIKey(apiKeyContext(r), &pb.CreateAPIKeyRequest{
+		Name: "ci-bot",
+		Role: roleName,
+	}, r.AuthService)
+	require.NoError(t, err)
+	require.NotEmpty(t, response.Token)
+	require.EqualValues(t, 1, countAPIKeyRoleAssignment(t, response.ApiKey.Id, roleName, r.Organization.ID.String()))
+}
+
+func TestCreateAPIKeyAcceptsInheritanceOnlyCustomRole(t *testing.T) {
+	r := support.Setup(t)
+	roleName := "read-only-agent"
+	require.NoError(t, r.AuthService.CreateCustomRole(r.Organization.ID.String(), &authorization.RoleDefinition{
+		Name:         roleName,
+		DomainType:   models.DomainTypeOrganization,
+		InheritsFrom: &authorization.RoleDefinition{Name: models.RoleOrgViewer},
+	}))
+
+	response, err := CreateAPIKey(apiKeyContext(r), &pb.CreateAPIKeyRequest{
+		Name: "read-only-bot",
+		Role: roleName,
+	}, r.AuthService)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, countAPIKeyRoleAssignment(t, response.ApiKey.Id, roleName, r.Organization.ID.String()))
+}
+
+func TestCreateAPIKeyRejectsUnavailableRoles(t *testing.T) {
+	tests := []struct {
+		name string
+		role string
+	}{
+		{name: "blank", role: "   "},
+		{name: "owner", role: models.RoleOrgOwner},
+		{name: "unknown", role: "missing-role"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := support.Setup(t)
+			_, err := CreateAPIKey(apiKeyContext(r), &pb.CreateAPIKeyRequest{
+				Name: "invalid-role-bot",
+				Role: tt.role,
+			}, r.AuthService)
+
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
+			require.Zero(t, countAPIKeys(t, r.Organization.ID.String()))
+		})
+	}
+}
+
+func TestCreateAPIKeyRejectsOwnerDerivedCustomRole(t *testing.T) {
+	r := support.Setup(t)
+	roleName := "owner-derived"
+	require.NoError(t, r.AuthService.CreateCustomRole(r.Organization.ID.String(), &authorization.RoleDefinition{
+		Name:         roleName,
+		DomainType:   models.DomainTypeOrganization,
+		InheritsFrom: &authorization.RoleDefinition{Name: models.RoleOrgOwner},
+	}))
+
+	_, err := CreateAPIKey(apiKeyContext(r), &pb.CreateAPIKeyRequest{
+		Name: "owner-derived-bot",
+		Role: roleName,
+	}, r.AuthService)
+
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
+	require.Zero(t, countAPIKeys(t, r.Organization.ID.String()))
+}
+
+func TestCreateAPIKeyRollsBackWhenRoleAssignmentFails(t *testing.T) {
+	r := support.Setup(t)
+	authService := &failingAssignRoleAuthorization{
+		Authorization: r.AuthService,
+		err:           errors.New("authorization database unavailable"),
+	}
+
+	_, err := CreateAPIKey(apiKeyContext(r), &pb.CreateAPIKeyRequest{
+		Name: "rollback-bot",
+		Role: models.RoleOrgViewer,
+	}, authService)
+
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, grpcerrors.Code(err))
+	require.Zero(t, countAPIKeys(t, r.Organization.ID.String()))
+}
+
+type failingAssignRoleAuthorization struct {
+	authorization.Authorization
+	err error
+}
+
+func (a *failingAssignRoleAuthorization) AssignRole(_ *gorm.DB, _, _, _, _ string) error {
+	return a.err
+}
+
+func countAPIKeyRoleAssignment(t *testing.T, userID, roleName, orgID string) int64 {
+	t.Helper()
+
+	var count int64
+	require.NoError(t, database.Conn().Table("casbin_rule").
+		Where("ptype = ? AND v0 = ? AND v1 = ? AND v2 = ?", "g", "/users/"+userID, "/roles/"+roleName, "/org/"+orgID).
+		Count(&count).
+		Error)
+
+	return count
+}
+
+func countAPIKeys(t *testing.T, orgID string) int64 {
+	t.Helper()
+
+	var count int64
+	require.NoError(t, database.Conn().Unscoped().Model(&models.User{}).
+		Where("organization_id = ? AND type = ?", orgID, models.UserTypeAPIKey).
+		Count(&count).
+		Error)
+
+	return count
 }
 
 func apiKeyContext(r *support.ResourceRegistry) context.Context {

--- a/pkg/grpc/actions/apikeys/delete_api_key.go
+++ b/pkg/grpc/actions/apikeys/delete_api_key.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/api_keys"
@@ -41,7 +42,7 @@ func DeleteAPIKey(ctx context.Context, req *pb.DeleteAPIKeyRequest, authService 
 		log.Errorf("Error determining roles for API key %s: %v", user.ID, err)
 	} else {
 		for _, role := range roles {
-			err = authService.RemoveRole(user.ID.String(), role.Name, orgID, models.DomainTypeOrganization)
+			err = authService.RemoveRole(database.DB(ctx), user.ID.String(), role.Name, orgID, models.DomainTypeOrganization)
 			if err != nil {
 				log.Errorf("Error removing role %s for API key %s: %v", role.Name, user.ID, err)
 			}

--- a/pkg/grpc/actions/auth/assign_role.go
+++ b/pkg/grpc/actions/auth/assign_role.go
@@ -2,10 +2,12 @@ package auth
 
 import (
 	"context"
+	"errors"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/roles"
@@ -34,9 +36,12 @@ func AssignRole(ctx context.Context, orgID, domainType, domainID, roleName, user
 		return nil, grpcerrors.InvalidArgument(nil, "API keys cannot be assigned the org_owner role")
 	}
 
-	err = authService.AssignRole(user.ID.String(), roleName, domainID, domainType)
+	err = authService.AssignRole(database.DB(ctx), user.ID.String(), roleName, domainID, domainType)
 	if err != nil {
 		log.Errorf("Error assigning role %s to %s: %v", roleName, user.ID.String(), err)
+		if errors.Is(err, authorization.ErrRoleNotFound) || errors.Is(err, authorization.ErrRoleNotAssignable) {
+			return nil, grpcerrors.InvalidArgument(err, "invalid role")
+		}
 		return nil, grpcerrors.Internal(err, "failed to assign role")
 	}
 

--- a/pkg/grpc/actions/auth/assign_role_test.go
+++ b/pkg/grpc/actions/auth/assign_role_test.go
@@ -66,6 +66,12 @@ func Test_AssignRole(t *testing.T) {
 		assert.Equal(t, "invalid role", msg)
 	})
 
+	t.Run("invalid request - unknown role", func(t *testing.T) {
+		newUser := support.CreateUser(t, r, r.Organization.ID)
+		_, err := AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, "missing-role", newUser.ID.String(), "", r.AuthService)
+		assert.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
+	})
+
 	t.Run("invalid request - missing user identifier", func(t *testing.T) {
 		_, err := AssignRole(ctx, orgID, models.DomainTypeOrganization, orgID, models.RoleOrgAdmin, "", "", r.AuthService)
 		assert.Error(t, err)

--- a/pkg/grpc/actions/auth/delete_role.go
+++ b/pkg/grpc/actions/auth/delete_role.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/organizations"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -91,7 +92,7 @@ func removeUsersForDeletedRole(ctx context.Context, authService authorization.Au
 				continue
 			}
 			if grpcerrors.Code(err) == codes.NotFound {
-				err = authService.RemoveRole(userID, roleName, domainID, domainType)
+				err = authService.RemoveRole(database.DB(ctx), userID, roleName, domainID, domainType)
 			}
 			if err != nil {
 				log.Errorf("failed to remove user %s for role %s: %v", userID, roleName, err)
@@ -100,7 +101,7 @@ func removeUsersForDeletedRole(ctx context.Context, authService authorization.Au
 			continue
 		}
 
-		if err := authService.RemoveRole(userID, roleName, domainID, domainType); err != nil {
+		if err := authService.RemoveRole(database.DB(ctx), userID, roleName, domainID, domainType); err != nil {
 			log.Errorf("failed to remove role %s for user %s: %v", roleName, userID, err)
 			return grpcerrors.Internal(err, "failed to remove role for user")
 		}

--- a/pkg/grpc/actions/auth/delete_role_test.go
+++ b/pkg/grpc/actions/auth/delete_role_test.go
@@ -98,7 +98,7 @@ func Test_DeleteRole(t *testing.T) {
 		require.NoError(t, err)
 
 		userID := uuid.New().String()
-		err = r.AuthService.AssignRole(database.Conn(), userID, "test-role-with-users", orgID, models.DomainTypeOrganization)
+		err = r.AuthService.AssignRole(database.DB(t.Context()), userID, "test-role-with-users", orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		resp, err := DeleteRole(ctx, models.DomainTypeOrganization, orgID, "test-role-with-users", r.AuthService)
@@ -135,7 +135,7 @@ func Test_DeleteRole(t *testing.T) {
 		user, err := models.CreateUser(r.Organization.ID, account.ID, account.Email, account.Name)
 		require.NoError(t, err)
 
-		err = r.AuthService.AssignRole(database.Conn(), user.ID.String(), "test-role-only-users", orgID, models.DomainTypeOrganization)
+		err = r.AuthService.AssignRole(database.DB(t.Context()), user.ID.String(), "test-role-only-users", orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		resp, err := DeleteRole(ctx, models.DomainTypeOrganization, orgID, "test-role-only-users", r.AuthService)

--- a/pkg/grpc/actions/auth/delete_role_test.go
+++ b/pkg/grpc/actions/auth/delete_role_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 )
@@ -97,7 +98,7 @@ func Test_DeleteRole(t *testing.T) {
 		require.NoError(t, err)
 
 		userID := uuid.New().String()
-		err = r.AuthService.AssignRole(userID, "test-role-with-users", orgID, models.DomainTypeOrganization)
+		err = r.AuthService.AssignRole(database.Conn(), userID, "test-role-with-users", orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		resp, err := DeleteRole(ctx, models.DomainTypeOrganization, orgID, "test-role-with-users", r.AuthService)
@@ -134,7 +135,7 @@ func Test_DeleteRole(t *testing.T) {
 		user, err := models.CreateUser(r.Organization.ID, account.ID, account.Email, account.Name)
 		require.NoError(t, err)
 
-		err = r.AuthService.AssignRole(user.ID.String(), "test-role-only-users", orgID, models.DomainTypeOrganization)
+		err = r.AuthService.AssignRole(database.Conn(), user.ID.String(), "test-role-only-users", orgID, models.DomainTypeOrganization)
 		require.NoError(t, err)
 
 		resp, err := DeleteRole(ctx, models.DomainTypeOrganization, orgID, "test-role-only-users", r.AuthService)

--- a/pkg/grpc/actions/me/get_user_test.go
+++ b/pkg/grpc/actions/me/get_user_test.go
@@ -23,7 +23,7 @@ func Test_ListUserPermissions(t *testing.T) {
 	//
 	// Assign viewer role to user, and prepare context with user ID and organization ID
 	//
-	require.NoError(t, r.AuthService.AssignRole(database.Conn(), r.User.String(), models.RoleOrgViewer, orgID, models.DomainTypeOrganization))
+	require.NoError(t, r.AuthService.AssignRole(database.DB(t.Context()), r.User.String(), models.RoleOrgViewer, orgID, models.DomainTypeOrganization))
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
 		metadata.Pairs(

--- a/pkg/grpc/actions/me/get_user_test.go
+++ b/pkg/grpc/actions/me/get_user_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -22,7 +23,7 @@ func Test_ListUserPermissions(t *testing.T) {
 	//
 	// Assign viewer role to user, and prepare context with user ID and organization ID
 	//
-	require.NoError(t, r.AuthService.AssignRole(r.User.String(), models.RoleOrgViewer, orgID, models.DomainTypeOrganization))
+	require.NoError(t, r.AuthService.AssignRole(database.Conn(), r.User.String(), models.RoleOrgViewer, orgID, models.DomainTypeOrganization))
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
 		metadata.Pairs(

--- a/pkg/grpc/actions/organizations/accept_invite_link.go
+++ b/pkg/grpc/actions/organizations/accept_invite_link.go
@@ -100,7 +100,7 @@ func AcceptInviteLinkWithUsage(
 		}
 	}
 
-	err = authService.AssignRole(user.ID.String(), models.RoleOrgViewer, org.ID.String(), models.DomainTypeOrganization)
+	err = authService.AssignRole(tx, user.ID.String(), models.RoleOrgViewer, org.ID.String(), models.DomainTypeOrganization)
 	if err != nil {
 		tx.Rollback()
 		return nil, grpcerrors.Internal(err, "failed to accept invite")

--- a/pkg/grpc/actions/organizations/auth_service_test.go
+++ b/pkg/grpc/actions/organizations/auth_service_test.go
@@ -10,11 +10,11 @@ type mockAuthService struct {
 	Error error
 }
 
-func (m *mockAuthService) AssignRole(userID, role, domainID string, domainType string) error {
+func (m *mockAuthService) AssignRole(db *gorm.DB, userID, role, domainID string, domainType string) error {
 	if m.Error != nil {
 		return m.Error
 	}
-	return m.Authorization.AssignRole(userID, role, domainID, domainType)
+	return m.Authorization.AssignRole(db, userID, role, domainID, domainType)
 }
 
 func (m *mockAuthService) DestroyOrganization(tx *gorm.DB, orgID string) error {

--- a/pkg/grpc/actions/organizations/remove_user.go
+++ b/pkg/grpc/actions/organizations/remove_user.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/organizations"
@@ -38,7 +39,7 @@ func RemoveUser(ctx context.Context, authService authorization.Authorization, or
 	}
 
 	for _, role := range roles {
-		err = authService.RemoveRole(user.ID.String(), role.Name, orgID, models.DomainTypeOrganization)
+		err = authService.RemoveRole(database.DB(ctx), user.ID.String(), role.Name, orgID, models.DomainTypeOrganization)
 		if err != nil {
 			log.Errorf("Error removing role %s for %s: %v", role.Name, user.ID.String(), err)
 			return nil, grpcerrors.Internal(err, "error removing role")

--- a/test/e2e/api_keys_test.go
+++ b/test/e2e/api_keys_test.go
@@ -342,7 +342,7 @@ func (s *apiKeySteps) loginAsViewer() {
 	authService, err := authorization.NewAuthService()
 	require.NoError(s.t, err)
 
-	err = authService.AssignRole(database.Conn(), viewerUser.ID.String(), models.RoleOrgViewer, s.session.OrgID.String(), models.DomainTypeOrganization)
+	err = authService.AssignRole(database.DB(s.t.Context()), viewerUser.ID.String(), models.RoleOrgViewer, s.session.OrgID.String(), models.DomainTypeOrganization)
 	require.NoError(s.t, err)
 
 	s.session.Account = viewerAccount

--- a/test/e2e/api_keys_test.go
+++ b/test/e2e/api_keys_test.go
@@ -42,6 +42,21 @@ func TestAPIKeys(t *testing.T) {
 		steps.assertAPIKeySavedInDB("admin-bot", "Admin automation", models.RoleOrgAdmin)
 	})
 
+	t.Run("creating an API key with a custom role", func(t *testing.T) {
+		steps := &apiKeySteps{t: t}
+		steps.start()
+		roleName := steps.givenCustomRoleExists("Release Bot")
+		steps.visitAPIKeysPage()
+		steps.clickCreateAPIKey()
+		steps.fillName("release-bot")
+		steps.fillDescription("Custom role automation")
+		steps.selectRole("Release Bot")
+		steps.submitCreate()
+		steps.assertTokenDisplayed()
+		steps.dismissTokenModal()
+		steps.assertAPIKeySavedInDB("release-bot", "Custom role automation", roleName)
+	})
+
 	t.Run("viewing API keys in the list", func(t *testing.T) {
 		steps := &apiKeySteps{t: t}
 		steps.start()
@@ -344,6 +359,22 @@ func (s *apiKeySteps) assertEditButtonDisabled() {
 
 func (s *apiKeySteps) assertDeleteButtonDisabled() {
 	s.session.AssertDisabled(q.TestID("api-key-detail-delete"))
+}
+
+func (s *apiKeySteps) givenCustomRoleExists(displayName string) string {
+	roleName := support.RandomName("api-key-role")
+	authService, err := authorization.NewAuthService()
+	require.NoError(s.t, err)
+	require.NoError(s.t, authService.CreateCustomRole(s.session.OrgID.String(), &authorization.RoleDefinition{
+		Name:        roleName,
+		DisplayName: displayName,
+		DomainType:  models.DomainTypeOrganization,
+		Permissions: []*authorization.Permission{
+			{Resource: "canvases", Action: "read", DomainType: models.DomainTypeOrganization},
+		},
+	}))
+
+	return roleName
 }
 
 // givenAPIKeyExists creates an API key directly in the DB for test setup.

--- a/test/e2e/api_keys_test.go
+++ b/test/e2e/api_keys_test.go
@@ -327,7 +327,7 @@ func (s *apiKeySteps) loginAsViewer() {
 	authService, err := authorization.NewAuthService()
 	require.NoError(s.t, err)
 
-	err = authService.AssignRole(viewerUser.ID.String(), models.RoleOrgViewer, s.session.OrgID.String(), models.DomainTypeOrganization)
+	err = authService.AssignRole(database.Conn(), viewerUser.ID.String(), models.RoleOrgViewer, s.session.OrgID.String(), models.DomainTypeOrganization)
 	require.NoError(s.t, err)
 
 	s.session.Account = viewerAccount

--- a/test/e2e/canvas_multi_user_staging_test.go
+++ b/test/e2e/canvas_multi_user_staging_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
@@ -80,7 +81,7 @@ func (s *canvasMultiUserStagingSteps) createCollaborator() (*models.Account, uui
 
 	authService, err := authorization.NewAuthService()
 	require.NoError(s.t, err)
-	err = authService.AssignRole(user.ID.String(), models.RoleOrgAdmin, s.session.OrgID.String(), models.DomainTypeOrganization)
+	err = authService.AssignRole(database.Conn(), user.ID.String(), models.RoleOrgAdmin, s.session.OrgID.String(), models.DomainTypeOrganization)
 	require.NoError(s.t, err)
 
 	return account, user.ID

--- a/test/e2e/canvas_multi_user_staging_test.go
+++ b/test/e2e/canvas_multi_user_staging_test.go
@@ -81,7 +81,7 @@ func (s *canvasMultiUserStagingSteps) createCollaborator() (*models.Account, uui
 
 	authService, err := authorization.NewAuthService()
 	require.NoError(s.t, err)
-	err = authService.AssignRole(database.Conn(), user.ID.String(), models.RoleOrgAdmin, s.session.OrgID.String(), models.DomainTypeOrganization)
+	err = authService.AssignRole(database.DB(s.t.Context()), user.ID.String(), models.RoleOrgAdmin, s.session.OrgID.String(), models.DomainTypeOrganization)
 	require.NoError(s.t, err)
 
 	return account, user.ID

--- a/test/e2e/canvas_permission_guards_test.go
+++ b/test/e2e/canvas_permission_guards_test.go
@@ -181,7 +181,7 @@ func createAccountForRole(t *testing.T, sess *session.TestSession, label, roleNa
 	authService, err := authorization.NewAuthService()
 	require.NoError(t, err)
 
-	err = authService.AssignRole(database.Conn(), user.ID.String(), roleName, sess.OrgID.String(), models.DomainTypeOrganization)
+	err = authService.AssignRole(database.DB(t.Context()), user.ID.String(), roleName, sess.OrgID.String(), models.DomainTypeOrganization)
 	require.NoError(t, err)
 
 	return account

--- a/test/e2e/canvas_permission_guards_test.go
+++ b/test/e2e/canvas_permission_guards_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/models"
 	q "github.com/superplanehq/superplane/test/e2e/queries"
@@ -180,7 +181,7 @@ func createAccountForRole(t *testing.T, sess *session.TestSession, label, roleNa
 	authService, err := authorization.NewAuthService()
 	require.NoError(t, err)
 
-	err = authService.AssignRole(user.ID.String(), roleName, sess.OrgID.String(), models.DomainTypeOrganization)
+	err = authService.AssignRole(database.Conn(), user.ID.String(), roleName, sess.OrgID.String(), models.DomainTypeOrganization)
 	require.NoError(t, err)
 
 	return account

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -216,7 +216,7 @@ func CreateUser(t *testing.T, r *ResourceRegistry, organizationID uuid.UUID) *mo
 	require.NoError(t, err)
 	user, err := models.CreateUser(organizationID, account.ID, account.Name, account.Email)
 	require.NoError(t, err)
-	err = r.AuthService.AssignRole(database.Conn(), user.ID.String(), models.RoleOrgViewer, organizationID.String(), models.DomainTypeOrganization)
+	err = r.AuthService.AssignRole(database.DB(t.Context()), user.ID.String(), models.RoleOrgViewer, organizationID.String(), models.DomainTypeOrganization)
 	require.NoError(t, err)
 	return user
 }

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -216,7 +216,7 @@ func CreateUser(t *testing.T, r *ResourceRegistry, organizationID uuid.UUID) *mo
 	require.NoError(t, err)
 	user, err := models.CreateUser(organizationID, account.ID, account.Name, account.Email)
 	require.NoError(t, err)
-	err = r.AuthService.AssignRole(user.ID.String(), models.RoleOrgViewer, organizationID.String(), models.DomainTypeOrganization)
+	err = r.AuthService.AssignRole(database.Conn(), user.ID.String(), models.RoleOrgViewer, organizationID.String(), models.DomainTypeOrganization)
 	require.NoError(t, err)
 	return user
 }

--- a/web_src/src/pages/organization/settings/ApiKeyCreationDialogs.tsx
+++ b/web_src/src/pages/organization/settings/ApiKeyCreationDialogs.tsx
@@ -1,0 +1,300 @@
+import { Icon } from "@/components/Icon";
+import { Textarea } from "@/components/Textarea/textarea";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { useCreateAPIKey } from "@/hooks/useApiKeys";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import { CopyButton } from "@/ui/CopyButton";
+import { KeyRound } from "lucide-react";
+import type { Dispatch, SetStateAction } from "react";
+import { settingsModalClassName } from "./settingsPageStyles";
+
+type AccessMode = "organization" | "canvas";
+
+interface CreateApiKeyFormState {
+  isCreateModalOpen: boolean;
+  name: string;
+  setName: Dispatch<SetStateAction<string>>;
+  description: string;
+  setDescription: Dispatch<SetStateAction<string>>;
+  role: string;
+  setRole: Dispatch<SetStateAction<string>>;
+  expiresAt: string;
+  setExpiresAt: Dispatch<SetStateAction<string>>;
+  accessMode: AccessMode;
+  setAccessMode: Dispatch<SetStateAction<AccessMode>>;
+  selectedCanvasIds: string[];
+  newToken: string | null;
+  createMutation: ReturnType<typeof useCreateAPIKey>;
+  handleCloseCreateModal: () => void;
+  handleCreate: () => Promise<void>;
+  handleTokenModalClose: () => void;
+  toggleCanvas: (canvasId: string) => void;
+}
+
+interface RoleQueryStatusProps {
+  isLoading: boolean;
+  isFetching: boolean;
+  hasError: boolean;
+  onRetry: () => void;
+}
+
+interface CreateApiKeyFieldsProps {
+  form: CreateApiKeyFormState;
+  canvases: ReadonlyArray<{ id?: string; name?: string }>;
+  assignableRoles: ReadonlyArray<{ name: string; label: string }>;
+  roleQueryStatus: RoleQueryStatusProps;
+}
+
+function RoleQueryStatus({ isLoading, isFetching, hasError, onRetry }: RoleQueryStatusProps) {
+  if (isLoading) {
+    return (
+      <p role="status" aria-live="polite" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        Loading custom roles...
+      </p>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <div role="alert" className="mt-1 flex items-center gap-2 text-xs text-amber-700 dark:text-amber-300">
+        <span>Custom roles could not be loaded. Available options may be incomplete.</span>
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto p-0 text-xs text-current"
+          onClick={onRetry}
+          disabled={isFetching}
+        >
+          {isFetching ? "Retrying..." : "Retry"}
+        </Button>
+      </div>
+    );
+  }
+
+  if (isFetching) {
+    return (
+      <p role="status" aria-live="polite" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        Refreshing custom roles...
+      </p>
+    );
+  }
+
+  return null;
+}
+
+function CreateApiKeyFields({ form, canvases, assignableRoles, roleQueryStatus }: CreateApiKeyFieldsProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <Label className="text-gray-800 dark:text-gray-100 mb-2">
+          Name <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          type="text"
+          value={form.name}
+          onChange={(event) => form.setName(event.target.value)}
+          placeholder="e.g., ci-deploy-bot"
+          required
+          data-testid="api-key-create-name"
+        />
+      </div>
+      <div>
+        <Label className="text-gray-800 dark:text-gray-100 mb-2">Description</Label>
+        <Textarea
+          value={form.description}
+          onChange={(event) => form.setDescription(event.target.value)}
+          placeholder="What is this API key used for?"
+          rows={3}
+          data-testid="api-key-create-description"
+        />
+      </div>
+      <div>
+        <Label className="text-gray-800 dark:text-gray-100 mb-2">
+          Role <span className="text-red-500">*</span>
+        </Label>
+        <Select value={form.role} onValueChange={form.setRole}>
+          <SelectTrigger className="w-full" data-testid="api-key-create-role">
+            <SelectValue placeholder="Select a role" />
+          </SelectTrigger>
+          <SelectContent>
+            {assignableRoles.map((role) => (
+              <SelectItem key={role.name} value={role.name}>
+                {role.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Determines what this API key can do within its access scope.
+        </p>
+        <RoleQueryStatus {...roleQueryStatus} />
+      </div>
+      <div>
+        <Label className="text-gray-800 dark:text-gray-100 mb-2">Access</Label>
+        <Select value={form.accessMode} onValueChange={(value) => form.setAccessMode(value as AccessMode)}>
+          <SelectTrigger className="w-full" data-testid="api-key-create-access-mode">
+            <SelectValue placeholder="Select access" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="organization">Organization-wide</SelectItem>
+            <SelectItem value="canvas">Selected apps</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      {form.accessMode === "canvas" && (
+        <div>
+          <Label className="text-gray-800 dark:text-gray-100 mb-2">
+            Apps <span className="text-red-500">*</span>
+          </Label>
+          <div className="max-h-44 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-700">
+            {canvases.map((canvas) => {
+              const canvasId = canvas.id || "";
+              return (
+                <label
+                  key={canvasId}
+                  className="flex items-center gap-2 border-b border-gray-100 px-3 py-2 text-sm last:border-b-0 dark:border-gray-800"
+                >
+                  <Checkbox
+                    checked={form.selectedCanvasIds.includes(canvasId)}
+                    onChange={() => form.toggleCanvas(canvasId)}
+                    data-testid="api-key-create-canvas"
+                  />
+                  <span className="text-gray-800 dark:text-gray-100">{canvas.name || "Unnamed"}</span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      )}
+      <div>
+        <Label className="text-gray-800 dark:text-gray-100 mb-2">Expiration</Label>
+        <Input
+          type="datetime-local"
+          value={form.expiresAt}
+          onChange={(event) => form.setExpiresAt(event.target.value)}
+          data-testid="api-key-create-expires-at"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function CreateApiKeyModal(props: CreateApiKeyFieldsProps) {
+  const { form } = props;
+  if (!form.isCreateModalOpen || form.newToken) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className={cn(settingsModalClassName, "max-w-lg")}>
+        <form
+          className="p-6"
+          onSubmit={(event) => {
+            event.preventDefault();
+            form.handleCreate();
+          }}
+          data-testid="api-key-create-form"
+        >
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center gap-3">
+              <KeyRound className="w-6 h-6 text-gray-500 dark:text-gray-400" />
+              <h3 className="text-base font-semibold text-gray-800 dark:text-gray-100">Create API Key</h3>
+            </div>
+            <button
+              type="button"
+              onClick={form.handleCloseCreateModal}
+              className="text-gray-500 hover:text-gray-800 dark:hover:text-gray-300"
+              disabled={form.createMutation.isPending}
+            >
+              <Icon name="x" size="sm" />
+            </button>
+          </div>
+
+          <CreateApiKeyFields {...props} />
+
+          <div className="flex justify-start gap-3 mt-6">
+            <LoadingButton
+              type="submit"
+              disabled={!form.name?.trim()}
+              loading={form.createMutation.isPending}
+              loadingText="Creating..."
+              className="flex items-center gap-2"
+              data-testid="api-key-create-submit"
+            >
+              Create
+            </LoadingButton>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={form.handleCloseCreateModal}
+              disabled={form.createMutation.isPending}
+            >
+              Cancel
+            </Button>
+          </div>
+
+          {form.createMutation.isError && (
+            <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+              <p className="text-sm text-red-800 dark:text-red-200">
+                Failed to create: {getApiErrorMessage(form.createMutation.error)}
+              </p>
+            </div>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export function CreatedApiKeyModal({ form }: { form: CreateApiKeyFormState }) {
+  if (!form.isCreateModalOpen || !form.newToken) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className={cn(settingsModalClassName, "max-w-lg")}>
+        <div className="p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <KeyRound className="h-6 w-6 text-green-600 dark:text-green-400" />
+            <h3 className="text-base font-semibold text-gray-800 dark:text-gray-100">API Key Created</h3>
+          </div>
+
+          <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md mb-4">
+            <p className="text-sm text-amber-800 dark:text-amber-200">
+              Copy this token now. You won't be able to see it again.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2 ph-no-capture">
+            <Input
+              readOnly
+              value={form.newToken}
+              className="flex-1 font-mono text-sm bg-gray-50 dark:bg-gray-800"
+              data-testid="api-key-token-display"
+            />
+            <CopyButton
+              variant="button"
+              text={form.newToken}
+              data-testid="api-key-token-copy"
+              onCopyError={() => showErrorToast("Failed to copy token")}
+            >
+              Copy
+            </CopyButton>
+          </div>
+
+          <div className="flex justify-start mt-6">
+            <Button onClick={form.handleTokenModalClose} data-testid="api-key-token-done">
+              Done
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/organization/settings/ApiKeys.tsx
+++ b/web_src/src/pages/organization/settings/ApiKeys.tsx
@@ -29,6 +29,51 @@ interface APIKeysProps {
 
 type AccessMode = "organization" | "canvas";
 
+interface RoleQueryStatusProps {
+  isLoading: boolean;
+  isFetching: boolean;
+  hasError: boolean;
+  onRetry: () => void;
+}
+
+function RoleQueryStatus({ isLoading, isFetching, hasError, onRetry }: RoleQueryStatusProps) {
+  if (isLoading) {
+    return (
+      <p role="status" aria-live="polite" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        Loading custom roles...
+      </p>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <div role="alert" className="mt-1 flex items-center gap-2 text-xs text-amber-700 dark:text-amber-300">
+        <span>Custom roles could not be loaded. Available options may be incomplete.</span>
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto p-0 text-xs text-current"
+          onClick={onRetry}
+          disabled={isFetching}
+        >
+          {isFetching ? "Retrying..." : "Retry"}
+        </Button>
+      </div>
+    );
+  }
+
+  if (isFetching) {
+    return (
+      <p role="status" aria-live="polite" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        Refreshing custom roles...
+      </p>
+    );
+  }
+
+  return null;
+}
+
 function toApiTimestamp(localValue: string) {
   if (!localValue) return undefined;
   return new Date(localValue).toISOString();
@@ -146,7 +191,13 @@ export function APIKeys({ organizationId }: APIKeysProps) {
 
   const { data: apiKeys = [], isLoading } = useAPIKeys(organizationId);
   const { data: canvases = [] } = useCanvases(organizationId);
-  const { data: roles = [] } = useOrganizationRoles(organizationId);
+  const {
+    data: roles = [],
+    isLoading: rolesLoading,
+    isFetching: rolesFetching,
+    isError: rolesLoadFailed,
+    refetch: refetchRoles,
+  } = useOrganizationRoles(organizationId);
   const deleteMutation = useDeleteAPIKey(organizationId);
   const form = useCreateApiKeyForm(organizationId, canCreate);
 
@@ -154,8 +205,8 @@ export function APIKeys({ organizationId }: APIKeysProps) {
     const reserved = new Set(["org_owner", "org_viewer", "org_admin"]);
     const customRoles = roles
       .flatMap((role) => {
-        const name = role.metadata?.name?.trim();
-        if (!name || reserved.has(name)) return [];
+        const name = role.metadata?.name;
+        if (!name || name !== name.trim() || reserved.has(name)) return [];
         return [{ name, label: role.spec?.displayName?.trim() || name }];
       })
       .sort((a, b) => a.label.localeCompare(b.label) || a.name.localeCompare(b.name));
@@ -302,6 +353,12 @@ export function APIKeys({ organizationId }: APIKeysProps) {
                   <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                     Determines what this API key can do within its access scope.
                   </p>
+                  <RoleQueryStatus
+                    isLoading={rolesLoading}
+                    isFetching={rolesFetching}
+                    hasError={rolesLoadFailed}
+                    onRetry={() => void refetchRoles()}
+                  />
                 </div>
                 <div>
                   <Label className="text-gray-800 dark:text-gray-100 mb-2">Access</Label>

--- a/web_src/src/pages/organization/settings/ApiKeys.tsx
+++ b/web_src/src/pages/organization/settings/ApiKeys.tsx
@@ -16,10 +16,11 @@ import { settingsModalClassName, settingsTableCardClassName } from "./settingsPa
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { KeyRound } from "lucide-react";
 import { CopyButton } from "@/ui/CopyButton";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAPIKeys, useCreateAPIKey, useDeleteAPIKey } from "@/hooks/useApiKeys";
 import { useCanvases } from "@/hooks/useCanvasData";
+import { useOrganizationRoles } from "@/hooks/useOrganizationData";
 import { ApiKeysContent } from "./ApiKeysContent";
 
 interface APIKeysProps {
@@ -145,8 +146,22 @@ export function APIKeys({ organizationId }: APIKeysProps) {
 
   const { data: apiKeys = [], isLoading } = useAPIKeys(organizationId);
   const { data: canvases = [] } = useCanvases(organizationId);
+  const { data: roles = [] } = useOrganizationRoles(organizationId);
   const deleteMutation = useDeleteAPIKey(organizationId);
   const form = useCreateApiKeyForm(organizationId, canCreate);
+
+  const assignableRoles = useMemo(() => {
+    const reserved = new Set(["org_owner", "org_viewer", "org_admin"]);
+    const customRoles = roles
+      .flatMap((role) => {
+        const name = role.metadata?.name?.trim();
+        if (!name || reserved.has(name)) return [];
+        return [{ name, label: role.spec?.displayName?.trim() || name }];
+      })
+      .sort((a, b) => a.label.localeCompare(b.label) || a.name.localeCompare(b.name));
+
+    return [{ name: "org_viewer", label: "Viewer" }, { name: "org_admin", label: "Admin" }, ...customRoles];
+  }, [roles]);
 
   useReportPageReady(!isLoading && !permissionsLoading);
 
@@ -277,8 +292,11 @@ export function APIKeys({ organizationId }: APIKeysProps) {
                       <SelectValue placeholder="Select a role" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="org_viewer">Viewer</SelectItem>
-                      <SelectItem value="org_admin">Admin</SelectItem>
+                      {assignableRoles.map((role) => (
+                        <SelectItem key={role.name} value={role.name}>
+                          {role.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                   <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">

--- a/web_src/src/pages/organization/settings/ApiKeys.tsx
+++ b/web_src/src/pages/organization/settings/ApiKeys.tsx
@@ -3,76 +3,23 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
-import { LoadingButton } from "@/components/ui/loading-button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/Textarea/textarea";
-import { Checkbox } from "@/components/ui/checkbox";
 import { usePermissions } from "@/contexts/usePermissions";
 import { getApiErrorMessage } from "@/lib/errors";
-import { cn } from "@/lib/utils";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
-import { settingsModalClassName, settingsTableCardClassName } from "./settingsPageStyles";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { KeyRound } from "lucide-react";
-import { CopyButton } from "@/ui/CopyButton";
+import { settingsTableCardClassName } from "./settingsPageStyles";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAPIKeys, useCreateAPIKey, useDeleteAPIKey } from "@/hooks/useApiKeys";
 import { useCanvases } from "@/hooks/useCanvasData";
 import { useOrganizationRoles } from "@/hooks/useOrganizationData";
 import { ApiKeysContent } from "./ApiKeysContent";
+import { CreateApiKeyModal, CreatedApiKeyModal } from "./ApiKeyCreationDialogs";
 
 interface APIKeysProps {
   organizationId: string;
 }
 
 type AccessMode = "organization" | "canvas";
-
-interface RoleQueryStatusProps {
-  isLoading: boolean;
-  isFetching: boolean;
-  hasError: boolean;
-  onRetry: () => void;
-}
-
-function RoleQueryStatus({ isLoading, isFetching, hasError, onRetry }: RoleQueryStatusProps) {
-  if (isLoading) {
-    return (
-      <p role="status" aria-live="polite" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-        Loading custom roles...
-      </p>
-    );
-  }
-
-  if (hasError) {
-    return (
-      <div role="alert" className="mt-1 flex items-center gap-2 text-xs text-amber-700 dark:text-amber-300">
-        <span>Custom roles could not be loaded. Available options may be incomplete.</span>
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          className="h-auto p-0 text-xs text-current"
-          onClick={onRetry}
-          disabled={isFetching}
-        >
-          {isFetching ? "Retrying..." : "Retry"}
-        </Button>
-      </div>
-    );
-  }
-
-  if (isFetching) {
-    return (
-      <p role="status" aria-live="polite" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-        Refreshing custom roles...
-      </p>
-    );
-  }
-
-  return null;
-}
 
 function toApiTimestamp(localValue: string) {
   if (!localValue) return undefined;
@@ -284,203 +231,18 @@ export function APIKeys({ organizationId }: APIKeysProps) {
           />
         </div>
       </div>
-      {form.isCreateModalOpen && !form.newToken && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className={cn(settingsModalClassName, "max-w-lg")}>
-            <form
-              className="p-6"
-              onSubmit={(e) => {
-                e.preventDefault();
-                form.handleCreate();
-              }}
-              data-testid="api-key-create-form"
-            >
-              <div className="flex items-center justify-between mb-6">
-                <div className="flex items-center gap-3">
-                  <KeyRound className="w-6 h-6 text-gray-500 dark:text-gray-400" />
-                  <h3 className="text-base font-semibold text-gray-800 dark:text-gray-100">Create API Key</h3>
-                </div>
-                <button
-                  type="button"
-                  onClick={form.handleCloseCreateModal}
-                  className="text-gray-500 hover:text-gray-800 dark:hover:text-gray-300"
-                  disabled={form.createMutation.isPending}
-                >
-                  <Icon name="x" size="sm" />
-                </button>
-              </div>
-
-              <div className="space-y-4">
-                <div>
-                  <Label className="text-gray-800 dark:text-gray-100 mb-2">
-                    Name <span className="text-red-500">*</span>
-                  </Label>
-                  <Input
-                    type="text"
-                    value={form.name}
-                    onChange={(e) => form.setName(e.target.value)}
-                    placeholder="e.g., ci-deploy-bot"
-                    required
-                    data-testid="api-key-create-name"
-                  />
-                </div>
-                <div>
-                  <Label className="text-gray-800 dark:text-gray-100 mb-2">Description</Label>
-                  <Textarea
-                    value={form.description}
-                    onChange={(e) => form.setDescription(e.target.value)}
-                    placeholder="What is this API key used for?"
-                    rows={3}
-                    data-testid="api-key-create-description"
-                  />
-                </div>
-                <div>
-                  <Label className="text-gray-800 dark:text-gray-100 mb-2">
-                    Role <span className="text-red-500">*</span>
-                  </Label>
-                  <Select value={form.role} onValueChange={form.setRole}>
-                    <SelectTrigger className="w-full" data-testid="api-key-create-role">
-                      <SelectValue placeholder="Select a role" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {assignableRoles.map((role) => (
-                        <SelectItem key={role.name} value={role.name}>
-                          {role.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Determines what this API key can do within its access scope.
-                  </p>
-                  <RoleQueryStatus
-                    isLoading={rolesLoading}
-                    isFetching={rolesFetching}
-                    hasError={rolesLoadFailed}
-                    onRetry={() => void refetchRoles()}
-                  />
-                </div>
-                <div>
-                  <Label className="text-gray-800 dark:text-gray-100 mb-2">Access</Label>
-                  <Select value={form.accessMode} onValueChange={(value) => form.setAccessMode(value as AccessMode)}>
-                    <SelectTrigger className="w-full" data-testid="api-key-create-access-mode">
-                      <SelectValue placeholder="Select access" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="organization">Organization-wide</SelectItem>
-                      <SelectItem value="canvas">Selected apps</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                {form.accessMode === "canvas" && (
-                  <div>
-                    <Label className="text-gray-800 dark:text-gray-100 mb-2">
-                      Apps <span className="text-red-500">*</span>
-                    </Label>
-                    <div className="max-h-44 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-700">
-                      {canvases.map((canvas) => {
-                        const canvasId = canvas.id || "";
-                        return (
-                          <label
-                            key={canvasId}
-                            className="flex items-center gap-2 border-b border-gray-100 px-3 py-2 text-sm last:border-b-0 dark:border-gray-800"
-                          >
-                            <Checkbox
-                              checked={form.selectedCanvasIds.includes(canvasId)}
-                              onChange={() => form.toggleCanvas(canvasId)}
-                              data-testid="api-key-create-canvas"
-                            />
-                            <span className="text-gray-800 dark:text-gray-100">{canvas.name || "Unnamed"}</span>
-                          </label>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
-                <div>
-                  <Label className="text-gray-800 dark:text-gray-100 mb-2">Expiration</Label>
-                  <Input
-                    type="datetime-local"
-                    value={form.expiresAt}
-                    onChange={(e) => form.setExpiresAt(e.target.value)}
-                    data-testid="api-key-create-expires-at"
-                  />
-                </div>
-              </div>
-
-              <div className="flex justify-start gap-3 mt-6">
-                <LoadingButton
-                  type="submit"
-                  disabled={!form.name?.trim()}
-                  loading={form.createMutation.isPending}
-                  loadingText="Creating..."
-                  className="flex items-center gap-2"
-                  data-testid="api-key-create-submit"
-                >
-                  Create
-                </LoadingButton>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={form.handleCloseCreateModal}
-                  disabled={form.createMutation.isPending}
-                >
-                  Cancel
-                </Button>
-              </div>
-
-              {form.createMutation.isError && (
-                <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
-                  <p className="text-sm text-red-800 dark:text-red-200">
-                    Failed to create: {getApiErrorMessage(form.createMutation.error)}
-                  </p>
-                </div>
-              )}
-            </form>
-          </div>
-        </div>
-      )}
-      {form.isCreateModalOpen && form.newToken && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className={cn(settingsModalClassName, "max-w-lg")}>
-            <div className="p-6">
-              <div className="flex items-center gap-3 mb-4">
-                <KeyRound className="h-6 w-6 text-green-600 dark:text-green-400" />
-                <h3 className="text-base font-semibold text-gray-800 dark:text-gray-100">API Key Created</h3>
-              </div>
-
-              <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md mb-4">
-                <p className="text-sm text-amber-800 dark:text-amber-200">
-                  Copy this token now. You won't be able to see it again.
-                </p>
-              </div>
-
-              <div className="flex items-center gap-2 ph-no-capture">
-                <Input
-                  readOnly
-                  value={form.newToken}
-                  className="flex-1 font-mono text-sm bg-gray-50 dark:bg-gray-800"
-                  data-testid="api-key-token-display"
-                />
-                <CopyButton
-                  variant="button"
-                  text={form.newToken}
-                  data-testid="api-key-token-copy"
-                  onCopyError={() => showErrorToast("Failed to copy token")}
-                >
-                  Copy
-                </CopyButton>
-              </div>
-
-              <div className="flex justify-start mt-6">
-                <Button onClick={form.handleTokenModalClose} data-testid="api-key-token-done">
-                  Done
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <CreateApiKeyModal
+        form={form}
+        canvases={canvases}
+        assignableRoles={assignableRoles}
+        roleQueryStatus={{
+          isLoading: rolesLoading,
+          isFetching: rolesFetching,
+          hasError: rolesLoadFailed,
+          onRetry: () => void refetchRoles(),
+        }}
+      />
+      <CreatedApiKeyModal form={form} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #4674.

API-key creation currently limits role selection to Viewer and Admin, preventing organization custom roles from being assigned.

This PR:

- Lists custom organization roles in the API-key creation form.
- Keeps Viewer and Admin available if custom roles cannot be loaded.
- Excludes malformed roles and the reserved Owner role.
- Supports direct-permission and inheritance-only custom roles.
- Rejects roles that directly or indirectly inherit `org_owner`.
- Makes API-key creation, token-hash storage, and role assignment atomic.
- Uses a fresh organization-filtered Casbin enforcer bound to the caller's database transaction.
- Returns `InvalidArgument` for unavailable roles while preserving infrastructure failures as `Internal`.
- Uses the database-fresh path for role removal so API-key deletion can clean up assignments.

## Why

The previous implementation hardcoded `org_viewer` and `org_admin` in both the frontend and backend.

The existing role-assignment path also relied on process-level Casbin state. That state can be stale when a custom role is created by another application instance, and the Casbin assignment was not part of the API-key database transaction.

## Frontend

- Reuses the existing organization roles query and existing UI components.
- Adds deterministic custom-role sorting and display-name fallback.
- Provides loading, refreshing, error, and retry feedback.
- Keeps the existing Viewer default.
- Extracts the creation dialogs to keep functions within the repository ESLint limits.

## Tests

Added coverage for:

- Direct-permission custom roles.
- Inheritance-only custom roles.
- Multi-instance role creation and assignment.
- Blank, unknown, cross-organization, and Owner roles.
- Custom roles inheriting Owner.
- Transaction rollback without orphaned API keys or Casbin assignments.
- Role removal through a fresh authorization instance.
- End-to-end custom-role selection and API-key creation.

Validation performed:

- [x] Backend build
- [x] 295 affected backend tests
- [x] Custom-role API-key E2E test
- [x] Frontend production build
- [x] Frontend ESLint and lint-budget checks
- [x] Formatting and `git diff --check`

## Impact

- No database migration.
- No protobuf or generated-client changes.
- No model-schema changes.
- Existing `AssignRole` and `RemoveRole` callers now provide an explicit database handle.
- The change does not introduce locking against concurrent custom-role deletion; that remains outside this issue.