### PR TITLE
fix: configure installation admin for owner account during setup

### DIFF
--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -120,6 +120,20 @@ func CreateAccount(name, email string) (*Account, error) {
 	return CreateAccountInTransaction(database.Conn(), name, email)
 }
 
+func CreateInstallationAdminAccountInTransaction(tx *gorm.DB, name, email string) (*Account, error) {
+	account := &Account{
+		Name:              name,
+		Email:             utils.NormalizeEmail(email),
+		InstallationAdmin: true,
+	}
+	err := tx.Create(account).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
+}
+
 func CreateAccountInTransaction(tx *gorm.DB, name, email string) (*Account, error) {
 	account := &Account{Name: name, Email: utils.NormalizeEmail(email)}
 	err := tx.Create(account).Error

--- a/pkg/models/account_installation_admin_test.go
+++ b/pkg/models/account_installation_admin_test.go
@@ -21,6 +21,21 @@ func TestInstallationAdmin(t *testing.T) {
 		assert.False(t, account.IsInstallationAdmin())
 	})
 
+	t.Run("installation admin account creation sets the flag", func(t *testing.T) {
+		var account *Account
+		err := database.Conn().Transaction(func(tx *gorm.DB) error {
+			var txErr error
+			account, txErr = CreateInstallationAdminAccountInTransaction(tx, "Owner User", "owner@example.com")
+			return txErr
+		})
+		require.NoError(t, err)
+		assert.True(t, account.IsInstallationAdmin())
+
+		refreshed, err := FindAccountByID(account.ID.String())
+		require.NoError(t, err)
+		assert.True(t, refreshed.IsInstallationAdmin())
+	})
+
 	t.Run("PromoteToInstallationAdmin sets the flag", func(t *testing.T) {
 		account, err := CreateAccount("Admin Candidate", "candidate@example.com")
 		require.NoError(t, err)

--- a/pkg/public/setup_owner.go
+++ b/pkg/public/setup_owner.go
@@ -61,16 +61,10 @@ func (s *Server) setupOwner(w http.ResponseWriter, r *http.Request) {
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		var err error
 
-		account, err = models.CreateAccountInTransaction(tx, fullName, req.Email)
+		account, err = models.CreateInstallationAdminAccountInTransaction(tx, fullName, req.Email)
 		if err != nil {
 			return err
 		}
-
-		// The first account is automatically an installation admin
-		if err := tx.Model(account).Update("installation_admin", true).Error; err != nil {
-			return err
-		}
-		account.InstallationAdmin = true
 
 		if err := usage.EnsureAccountWithinLimits(r.Context(), s.usageService, account.ID.String(), &usagepb.AccountState{
 			Organizations: 1,

--- a/pkg/public/setup_owner_test.go
+++ b/pkg/public/setup_owner_test.go
@@ -65,6 +65,10 @@ func TestSetupOwnerIgnoresInstallationSettings(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, response.Code)
 
+	account, err := models.FindAccountByEmail("owner@example.com")
+	require.NoError(t, err)
+	assert.True(t, account.IsInstallationAdmin())
+
 	metadata, err := models.GetInstallationMetadata(database.Conn())
 	require.NoError(t, err)
 	assert.False(t, metadata.AllowPrivateNetworkAccess)

--- a/test/e2e/owner_setup_test.go
+++ b/test/e2e/owner_setup_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/public/middleware"
@@ -21,6 +22,7 @@ func TestOwnerSetupFlow(t *testing.T) {
 		steps.visitSetupPage()
 		steps.fillInOwnerDetailsAndSubmit("owner@example.com", "Owner", "User", "Password1")
 		steps.assertOwnerAndOrganizationCreated()
+		steps.assertOwnerAccountIsInstallationAdmin("owner@example.com")
 		steps.assertRedirectedToOrganizationHome()
 		steps.assertOwnerSetupIsNoLongerRequired()
 	})
@@ -33,6 +35,7 @@ func TestOwnerSetupFlow(t *testing.T) {
 		steps.visitSetupPage()
 		steps.fillInOwnerDetailsAndSubmit("owner@example.com", "Owner", "User", "Password1")
 		steps.assertOwnerAndOrganizationCreated()
+		steps.assertOwnerAccountIsInstallationAdmin("owner@example.com")
 		steps.assertRedirectedToOrganizationHome()
 		steps.clearCookies()
 		steps.visitLoginPage()
@@ -134,6 +137,12 @@ func (s *ownerSetupSteps) assertOwnerAndOrganizationCreated() {
 func (s *ownerSetupSteps) assertRedirectedToOrganizationHome() {
 	currentURL := s.session.Page().URL()
 	assert.Contains(s.t, currentURL, "/"+s.orgID, "expected to be redirected to organization home")
+}
+
+func (s *ownerSetupSteps) assertOwnerAccountIsInstallationAdmin(email string) {
+	account, err := models.FindAccountByEmail(email)
+	require.NoError(s.t, err)
+	assert.True(s.t, account.IsInstallationAdmin(), "owner account should be an installation admin")
 }
 
 func (s *ownerSetupSteps) assertOwnerSetupIsNoLongerRequired() {


### PR DESCRIPTION
## Summary

Fixes an owner-setup bug where the first account could end up **not** being an installation admin, which prevented access to Installation Admin UI routes (including private network access settings).

This change ensures the owner account created during `/setup` is created as an installation admin at insert time.

## Problem

On fresh instances, users could complete the owner setup flow and get an account with:

- `accounts.installation_admin = false`

As a result:

- “Installation Admin” did not appear in the org menu
- `/admin/installation-settings` redirected away from admin pages
- no UI path existed to enable **Private network access**
- self-hosters had to use a manual SQL workaround:
  `UPDATE installation_metadata SET allow_private_network_access = true;`

## What changed

### Backend behavior

- Added `CreateInstallationAdminAccountInTransaction(...)` in `pkg/models/account.go`
  - Creates an account with `InstallationAdmin: true` in a single insert.
- Updated owner setup handler in `pkg/public/setup_owner.go`
  - Replaced:
    - create account as regular user + follow-up `UPDATE installation_admin = true`
  - With:
    - direct creation via `CreateInstallationAdminAccountInTransaction(...)`

This removes reliance on a second write and makes the setup intent explicit.

## Tests added / updated

### Unit / handler tests

- `pkg/public/setup_owner_test.go`
  - Added assertion that account created by `/api/v1/setup-owner` is installation admin.

- `pkg/models/account_installation_admin_test.go`
  - Added coverage verifying `CreateInstallationAdminAccountInTransaction(...)` sets and persists `installation_admin = true`.

### E2E tests

- `test/e2e/owner_setup_test.go`
  - Added helper `assertOwnerAccountIsInstallationAdmin(...)`
  - Called in both owner setup flow scenarios to assert setup-created owner is an installation admin.

## User impact

After this change, a fresh-instance owner created via `/setup` can access installation-level settings from the UI immediately, including the private network access toggle needed for private-IP HTTP targets.

## Notes

- No schema changes.
- No generated files touched.