### PR TITLE
fix: preserve draft nodes in run app fields

### DIFF
--- a/web_src/src/ui/configurationFieldRenderer/AppCanvasNodeFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AppCanvasNodeFieldRenderer.spec.tsx
@@ -105,6 +105,12 @@ describe("AppCanvasNodeFieldRenderer", () => {
   it("shows only matching nodes for the selected app", async () => {
     render(<ControlledRenderer allValues={{ app: "canvas_target" }} />);
 
+    expect(mockUseCanvas).toHaveBeenCalledWith(
+      "org-1",
+      "canvas_target",
+      expect.objectContaining({ staleTime: Number.POSITIVE_INFINITY }),
+    );
+
     await userEvent.click(screen.getByRole("combobox"));
     expect(screen.getByText("On Run")).toBeInTheDocument();
     expect(screen.queryByText("On Broadcast")).not.toBeInTheDocument();

--- a/web_src/src/ui/configurationFieldRenderer/AppCanvasNodeFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AppCanvasNodeFieldRenderer.tsx
@@ -38,6 +38,10 @@ export function AppCanvasNodeFieldRenderer({
     error,
   } = useCanvas(organizationId, appCanvasId ?? "", {
     enabled: Boolean(appCanvasId),
+    // The canvas detail cache may contain the current edit-session draft.
+    // Treat it as authoritative until the surrounding workflow invalidates it;
+    // a mount-time refetch would replace draft nodes with the live canvas.
+    staleTime: Number.POSITIVE_INFINITY,
   });
 
   const options: AutoCompleteOption[] = useMemo(() => {

--- a/web_src/src/ui/configurationFieldRenderer/RunParametersFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/RunParametersFieldRenderer.spec.tsx
@@ -93,6 +93,12 @@ describe("RunParametersFieldRenderer", () => {
       <ControlledRenderer initialValue={{ message: "hello" }} allValues={{ app: "canvas_target", node: "on-run" }} />,
     );
 
+    expect(mockUseCanvas).toHaveBeenCalledWith(
+      "org-1",
+      "canvas_target",
+      expect.objectContaining({ staleTime: Number.POSITIVE_INFINITY }),
+    );
+
     await waitFor(() => {
       expect(screen.getByTestId("string-field-message")).toBeTruthy();
     });

--- a/web_src/src/ui/configurationFieldRenderer/RunParametersFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/RunParametersFieldRenderer.tsx
@@ -63,6 +63,9 @@ export function RunParametersFieldRenderer({
     error,
   } = useCanvas(organizationId, appId ?? "", {
     enabled: Boolean(appId),
+    // Keep this in sync with the node picker: the cached canvas can include
+    // uncommitted edits that are not present in the live API response yet.
+    staleTime: Number.POSITIVE_INFINITY,
   });
 
   const targetNode = useMemo(() => findTargetNode(canvas?.spec?.nodes, nodeId), [canvas?.spec?.nodes, nodeId]);


### PR DESCRIPTION
## What changed

- Keep cached edit-session canvas data authoritative in the Run App node picker.
- Apply the same query behavior to the run-parameters renderer so parameter definitions also come from the draft.
- Add regression assertions for both fields.

## Why

During an edit session, local canvas updates are written to the canvas detail cache. These fields mounted a fresh `useCanvas` query with the default `staleTime` of zero, which could immediately refetch the published canvas and replace the cached draft. Newly added `onRun` nodes then disappeared from the Run App configuration.

Treating the cached canvas as fresh preserves draft nodes. Uncached target apps still perform their initial fetch, and explicit query invalidations can still refresh the data.

## Testing

- `npm test -- --run src/ui/configurationFieldRenderer/AppCanvasNodeFieldRenderer.spec.tsx src/ui/configurationFieldRenderer/RunParametersFieldRenderer.spec.tsx`
- `npm run build`
- ESLint on the four changed files
- `npm run lint:budget`

Fixes #6240