### PR TITLE
fix(web): never render a negative relative time

### DIFF
--- a/web_src/src/lib/utils.spec.ts
+++ b/web_src/src/lib/utils.spec.ts
@@ -44,6 +44,28 @@ describe("utils", () => {
     expect(calcRelativeTimeFromDiff(172_800_000)).toBe("2d");
   });
 
+  it("never renders a negative duration when the browser clock is behind the server", () => {
+    // `Date.now() - receivedAt` goes negative on clock skew; every unit branch
+    // tests `> 0`, so this used to fall through to raw seconds ("-3s", "-3600s").
+    expect(calcRelativeTimeFromDiff(-3_000)).toBe("0s");
+    expect(calcRelativeTimeFromDiff(-120_000)).toBe("0s");
+    expect(calcRelativeTimeFromDiff(-3_600_000)).toBe("0s");
+  });
+
+  it("falls back to 0s for non-finite diffs", () => {
+    // e.g. an unparseable timestamp yielding NaN, which rendered "NaNs".
+    expect(calcRelativeTimeFromDiff(Number.NaN)).toBe("0s");
+    expect(calcRelativeTimeFromDiff(Number.POSITIVE_INFINITY)).toBe("0s");
+  });
+
+  it("keeps the unit boundaries intact", () => {
+    expect(calcRelativeTimeFromDiff(0)).toBe("0s");
+    expect(calcRelativeTimeFromDiff(999)).toBe("0s");
+    expect(calcRelativeTimeFromDiff(60_000)).toBe("1m");
+    expect(calcRelativeTimeFromDiff(59_999)).toBe("59s");
+    expect(calcRelativeTimeFromDiff(86_400_000)).toBe("1d");
+  });
+
   it("formats timestamps using toLocaleTimeString", () => {
     const toLocaleTimeStringSpy = vi.spyOn(Date.prototype, "toLocaleTimeString").mockReturnValue("14:30");
 

--- a/web_src/src/lib/utils.ts
+++ b/web_src/src/lib/utils.ts
@@ -7,7 +7,15 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const calcRelativeTimeFromDiff = (diff: number) => {
-  const seconds = Math.floor(diff / 1000);
+  // `diff` is normally `Date.now() - <server timestamp>`, so a server clock that
+  // runs ahead of the browser makes it negative. Every unit branch below tests
+  // `> 0`, so a negative diff skipped all of them and fell through to raw
+  // seconds: a running component rendered "-3s", or "-3600s" for a larger skew,
+  // ticking once a second. An elapsed duration can never be negative — clamp it
+  // (and guard NaN/Infinity from an unparseable date) so callers can render the
+  // result verbatim.
+  const safeDiff = Number.isFinite(diff) && diff > 0 ? diff : 0;
+  const seconds = Math.floor(safeDiff / 1000);
   const minutes = Math.floor(seconds / 60);
   const hours = Math.floor(minutes / 60);
   const days = Math.floor(hours / 24);


### PR DESCRIPTION
Problem

calcRelativeTimeFromDiff is called with Date.now() - <server timestamp>, so a server clock running ahead of the browser produces a negative diff. Every unit branch tests > 0, so a negative value skips all of them and falls through to raw seconds — the UI renders -3s, or -3600s for a larger skew, updating every second.

ui/componentBase hits this: liveDuration = Date.now() - receivedAt.getTime() is passed through with only a !== null check. The other two callers (timeLeftCountdown, timegate/countdown) already guard with > 0 / >= 0, which suggests the helper itself should be safe.

Fix

Clamp the diff inside the helper — an elapsed duration can't be negative — and treat non-finite input as 0 (an unparseable date previously rendered NaNs). No API change, no behaviour change for valid input.

Tests

Added to src/lib/utils.spec.ts: negative diffs, non-finite diffs, and the existing unit boundaries. Verified they fail without the fix (expected '-3s' to be '0s') and pass with it — npx vitest run src/lib/utils.spec.ts → 9/9. ESLint error count on the touched files is unchanged (the remaining ones are pre-existing in flattenObject)