### PR TITLE
docs: fix SuperPlane product name casing

### DIFF
--- a/docs/components/Cloudsmith.mdx
+++ b/docs/components/Cloudsmith.mdx
@@ -38,7 +38,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 SuperPlane authenticates to Cloudsmith using a service account API key, which is not tied to an individual user.
 
 1. In the Cloudsmith web dashboard, go to the **Accounts** tab and click on **Services**
-2. Click on **New Service**. Give the service a name like **Superplane** and optional description. Assign the **Manager** role to the service.
+2. Click on **New Service**. Give the service a name like **SuperPlane** and optional description. Assign the **Manager** role to the service.
 3. Click on **Create Service** and copy the generated API key.
 4. Paste the API key below.
 5. To give the service access to any repository, click on your Repository and then **Settings** → **Access control → Privileges for specific services**, and add the service with the **Admin** privilege.

--- a/docs/components/Dash0.mdx
+++ b/docs/components/Dash0.mdx
@@ -31,7 +31,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Instructions
 
-To connect Dash0 to Superplane:
+To connect Dash0 to SuperPlane:
 
 1. Go to **Settings → Auth Tokens → + Add** to create a new API token.
 2. Give the token a name, grant it access to the Default or all Datasets, all Signal types, and all Permissions.

--- a/docs/components/SMTP.mdx
+++ b/docs/components/SMTP.mdx
@@ -59,7 +59,7 @@ Returns metadata about the sent email including recipients and subject.
     "cc": [],
     "fromEmail": "sender@example.com",
     "sentAt": "2025-01-21T12:00:00Z",
-    "subject": "Hello from Superplane",
+    "subject": "Hello from SuperPlane",
     "success": true,
     "to": [
       "recipient@example.com"

--- a/pkg/integrations/smtp/example_output_send_email.json
+++ b/pkg/integrations/smtp/example_output_send_email.json
@@ -3,7 +3,7 @@
     "success": true,
     "to": ["recipient@example.com"],
     "cc": [],
-    "subject": "Hello from Superplane",
+    "subject": "Hello from SuperPlane",
     "sentAt": "2025-01-21T12:00:00Z",
     "fromEmail": "sender@example.com"
   },


### PR DESCRIPTION
## What changed
- corrected the SuperPlane product-name casing in the Cloudsmith, Dash0, and SMTP component documentation
- kept the SMTP example output fixture aligned with the published documentation

## Why
The repository contribution guide requires the user-facing product name to be written as `SuperPlane`. These examples still used `Superplane`, creating inconsistent copy across component guides.

## Validation
- parsed `pkg/integrations/smtp/example_output_send_email.json` successfully
- ran `git diff --check`
- searched the touched component documentation for remaining user-facing casing mismatches; remaining `SuperplaneTestAlert` values are example identifiers and were intentionally left unchanged
