### PR TITLE
fix: show node configuration when no runs exist

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -3731,13 +3731,19 @@ export function AppPage() {
 
   const handleLiveCanvasNodeClick = useCallback(
     (nodeId: string) => {
-      if (isRunInspectionMode || isEditing || !liveSidebarRunLookupEnabled) return;
+      if (isRunInspectionMode || isEditing || !liveSidebarRunLookupEnabled) return false;
+      // With no runs to inspect, let CanvasPage open the node's read-only
+      // configuration instead of starting a lookup that cannot succeed.
+      if (logRunsData.runs.length === 0) return false;
 
       const lookupId = liveCanvasNodeClickLookupRef.current + 1;
       liveCanvasNodeClickLookupRef.current = lookupId;
 
       const cachedRunId = resolveCachedNodeRunId(nodeId, canvasNodesById.get(nodeId), resolveRunIdForSidebarEvent);
-      if (cachedRunId) return handleSelectRunFromSidebarEvent(cachedRunId, { nodeId });
+      if (cachedRunId) {
+        handleSelectRunFromSidebarEvent(cachedRunId, { nodeId });
+        return true;
+      }
 
       void (async () => {
         try {
@@ -3752,6 +3758,7 @@ export function AppPage() {
           console.error("Failed to inspect latest node run", error);
         }
       })();
+      return true;
     },
     [
       canvasNodesById,
@@ -3762,6 +3769,7 @@ export function AppPage() {
       liveSidebarRunLookupEnabled,
       resolveLatestNodeRunLookupEvent,
       resolveRunIdForSidebarEvent,
+      logRunsData.runs.length,
     ],
   );
 

--- a/web_src/src/ui/CanvasPage/index.runInspection.sidebar.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.sidebar.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render as testingLibraryRender, screen, waitFor, fireEvent } from "@testing-library/react";
+import { act, render as testingLibraryRender, screen, waitFor, fireEvent } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -70,7 +70,9 @@ vi.mock("@/hooks/useCanvasData", () => ({
 }));
 
 vi.mock("../componentSidebar", () => ({
-  ComponentSidebar: () => <div data-testid="live-node-detail-pane-content" />,
+  ComponentSidebar: ({ currentTab }: { currentTab?: string }) => (
+    <div data-testid="live-node-detail-pane-content" data-current-tab={currentTab} />
+  ),
 }));
 
 vi.mock("../Runs/RunInspectorPanel", () => ({
@@ -456,5 +458,58 @@ describe("CanvasPage run inspection sidebar", () => {
     );
 
     expect(screen.queryByTestId("run-inspector-panel")).not.toBeInTheDocument();
+  });
+
+  it("opens node configuration when live run inspection cannot handle the click", async () => {
+    const onNodeClick = vi.fn(() => false);
+    const sidebarData = {
+      title: "Node without runs",
+      iconSrc: "",
+      iconSlug: "box",
+      latestEvents: [],
+      nextInQueueEvents: [],
+      totalInQueueCount: 0,
+      totalInHistoryCount: 0,
+      isLoading: false,
+    };
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={[
+            {
+              id: "node-without-runs",
+              position: { x: 0, y: 0 },
+              data: {
+                label: "Node without runs",
+                state: "pending",
+                type: "component",
+              },
+            },
+          ]}
+          edges={[]}
+          buildingBlocks={[]}
+          workflowNodes={[{ id: "node-without-runs", type: "TYPE_ACTION", name: "Node without runs" }]}
+          getSidebarData={() => sidebarData}
+          onNodeClick={onNodeClick}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+        />
+      </MemoryRouter>,
+    );
+
+    const nodes = reactFlowPropsRef.current?.nodes as Array<{
+      data: { _callbacksRef?: { current?: { handleNodeClick?: (nodeId: string) => void } } };
+    }>;
+
+    act(() => {
+      nodes[0].data._callbacksRef?.current?.handleNodeClick?.("node-without-runs");
+    });
+
+    expect(onNodeClick).toHaveBeenCalledWith("node-without-runs");
+    const sidebar = await screen.findByTestId("live-node-detail-pane-content");
+    expect(sidebar).toHaveAttribute("data-current-tab", "settings");
   });
 });

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -289,7 +289,8 @@ export interface CanvasPageProps {
   ) => void;
   onAnnotationBlur?: () => void;
   getCustomField?: (nodeId: string, integration?: OrganizationsIntegration) => (() => React.ReactNode) | null;
-  onNodeClick?: (nodeId: string) => void;
+  /** Return false when the host cannot inspect a run so the configuration sidebar opens instead. */
+  onNodeClick?: (nodeId: string) => void | boolean;
   integrations?: OrganizationsIntegration[];
   onEdgeCreate?: (sourceId: string, targetId: string, sourceHandle?: string | null) => void;
   onNodeDelete?: (nodeId: string) => void;
@@ -1591,7 +1592,9 @@ function CanvasPage(props: CanvasPageProps) {
                 />
               </ReactFlowProvider>
             )}
-            {isComponentSidebarVisibleMode(props.headerMode) && !props.isRunInspectionMode && props.isEditing
+            {isComponentSidebarVisibleMode(props.headerMode) &&
+            !props.isRunInspectionMode &&
+            state.componentSidebar.isOpen
               ? renderInspectorSidebar("sidebar")
               : null}
           </div>
@@ -2237,7 +2240,7 @@ function CanvasContent({
   fitViewContentKey?: string;
   lastFittedContentKeyRef?: React.MutableRefObject<string | null>;
   onPendingConnectionNodeClick?: (nodeId: string) => void;
-  onNodeClick?: (nodeId: string) => void;
+  onNodeClick?: (nodeId: string) => void | boolean;
   workflowNodes?: ComponentsNode[];
   setCurrentTab?: (tab: "latest" | "settings" | "docs") => void;
   showBottomStatusControls?: boolean;
@@ -2432,15 +2435,20 @@ function CanvasContent({
         onPendingConnectionNodeClick(nodeId);
       } else if (isPlaceholder && onPendingConnectionNodeClick) {
         onPendingConnectionNodeClick(nodeId);
-      } else if (onNodeClick) {
-        onNodeClick(nodeId);
       } else {
-        const wasSidebarOpen = stateRef.current.componentSidebar.isOpen;
-        stateRef.current.componentSidebar.open(nodeId);
+        const liveClickHandled = onNodeClick?.(nodeId);
+        if (!onNodeClick || liveClickHandled === false) {
+          const wasSidebarOpen = stateRef.current.componentSidebar.isOpen;
+          stateRef.current.componentSidebar.open(nodeId);
 
-        const nodeData = clickedNode?.data as NodeConfigurationWarningData;
-        applySidebarTabOnNodeOpen(setCurrentTab, wasSidebarOpen, shouldOpenSidebarSettingsTab(nodeData, isEditMode));
-        onBuildingBlocksSidebarToggle?.(false);
+          const nodeData = clickedNode?.data as NodeConfigurationWarningData;
+          applySidebarTabOnNodeOpen(
+            setCurrentTab,
+            wasSidebarOpen,
+            liveClickHandled === false || shouldOpenSidebarSettingsTab(nodeData, isEditMode),
+          );
+          onBuildingBlocksSidebarToggle?.(false);
+        }
       }
 
       stateRef.current.setNodes((nodes) =>


### PR DESCRIPTION
## Summary

- let live node clicks fall back to the existing read-only configuration sidebar when no run can be resolved
- open the Configuration tab directly for that fallback
- preserve normal live run-inspection behavior when runs exist

## Root cause

The live click handler swallowed node clicks when an application had no runs, and the live component sidebar was hard-gated to edit mode.

## Testing

- CanvasPage run-inspection/sidebar suite: 8/8 passing
- ESLint: changed CanvasPage source and regression test passing
- TypeScript build passing
- Vite production build passing

Closes #6074