### PR TITLE
fix: rename Merge component label to Join (#3804)

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -36,7 +36,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="HTTP Request" href="#http-request" description="Make HTTP requests" />
   <LinkCard title="If" href="#if" description="Route events based on expression" />
   <LinkCard title="Loop" href="#loop" description="Repeat downstream steps until a condition is met" />
-  <LinkCard title="Merge" href="#merge" description="Merge multiple upstream inputs and forward" />
+  <LinkCard title="Join" href="#merge" description="Wait for all upstream inputs and forward" />
   <LinkCard title="No Operation" href="#no-operation" description="Just pass events through without any additional processing" />
   <LinkCard title="Read Memory" href="#read-memory" description="Find values from canvas memory by namespace and field matches" />
   <LinkCard title="Run App" href="#run-app" description="Run another SuperPlane app and wait for its run to finish" />
@@ -1004,11 +1004,11 @@ The until expression has access to:
 
 <a id="merge"></a>
 
-## Merge
+## Join
 
 **Component key:** `merge`
 
-The Merge component waits for events from all upstream nodes before forwarding a combined result downstream.
+The Join component (formerly Merge) waits for events from all upstream nodes before forwarding a combined result downstream.
 
 ### Use Cases
 
@@ -1019,7 +1019,7 @@ The Merge component waits for events from all upstream nodes before forwarding a
 
 ### How It Works
 
-1. The Merge component waits for events from all distinct upstream source nodes
+1. The Join component waits for events from all distinct upstream source nodes
 2. Once all inputs are received, it emits the combined data to the Success channel
 3. Optional timeout and conditional stop features allow early completion
 

--- a/pkg/components/merge/merge.go
+++ b/pkg/components/merge/merge.go
@@ -84,7 +84,7 @@ type SourceNode struct {
 type Merge struct{}
 
 func (m *Merge) Name() string        { return "merge" }
-func (m *Merge) Label() string       { return "Merge" }
+func (m *Merge) Label() string       { return "Join" }
 func (m *Merge) Description() string { return "Merge multiple upstream inputs and forward" }
 func (m *Merge) Documentation() string {
 	return `The Merge component waits for events from all upstream nodes before forwarding a combined result downstream.

--- a/pkg/components/merge/merge.go
+++ b/pkg/components/merge/merge.go
@@ -14,7 +14,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
-// Merge is a component that passes its input downstream on
+// Merge (labeled "Join" in the UI) is a component that passes its input downstream on
 // different channels based on execution outcome. The queue/worker
 // layer is responsible for aggregating inputs from multiple parents.
 
@@ -85,9 +85,9 @@ type Merge struct{}
 
 func (m *Merge) Name() string        { return "merge" }
 func (m *Merge) Label() string       { return "Join" }
-func (m *Merge) Description() string { return "Merge multiple upstream inputs and forward" }
+func (m *Merge) Description() string { return "Wait for all upstream inputs and forward" }
 func (m *Merge) Documentation() string {
-	return `The Merge component waits for events from all upstream nodes before forwarding a combined result downstream.
+	return `The Join component waits for events from all upstream nodes before forwarding a combined result downstream.
 
 ## Use Cases
 
@@ -98,7 +98,7 @@ func (m *Merge) Documentation() string {
 
 ## How It Works
 
-1. The Merge component waits for events from all distinct upstream source nodes
+1. The Join component waits for events from all distinct upstream source nodes
 2. Once all inputs are received, it emits the combined data to the Success channel
 3. Optional timeout and conditional stop features allow early completion
 

--- a/web_src/src/pages/app/mappers/merge.ts
+++ b/web_src/src/pages/app/mappers/merge.ts
@@ -152,7 +152,7 @@ export const mergeMapper: ComponentBaseMapper = {
       iconColor: getColorClass(context.componentDefinition?.color || "gray"),
       collapsedBackground: getBackgroundColorClass("white"),
       collapsed: context.node.isCollapsed,
-      title: context.node.name || context.componentDefinition?.label || "Merge",
+      title: context.node.name || context.componentDefinition?.label || "Join",
       eventSections: lastExecution ? getMergeEventSections(context.nodes, lastExecution) : undefined,
       includeEmptyState: !lastExecution,
       eventStateMap: MERGE_STATE_MAP,


### PR DESCRIPTION
Closes #3804

## What
Renames the user-facing "Merge" component label to "Join", since the component performs fan-in (waits for all upstream nodes) rather than merging payloads.

## Scope — deliberately minimal
- `Label()` in `pkg/components/merge/merge.go`: "Merge" → "Join"
- UI fallback title in `web_src/src/pages/app/mappers/merge.ts`
- Docs in `Core.mdx`: card title, section heading, and body — with "(formerly Merge)" kept for searchability
- The internal component key `merge` is **unchanged**, so existing canvases, templates, and the `#merge` docs anchor (explicit `<a id>`) keep working
- No tests assert the label string, so no test changes needed

## Context
A draft PR from an agent attempted this in March but was never merged; this is a fresh, minimal take as discussed in the issue.