### PR TITLE
fix: clarify PagerDuty user email label

### DIFF
--- a/pkg/integrations/pagerduty/acknowledge_incident.go
+++ b/pkg/integrations/pagerduty/acknowledge_incident.go
@@ -77,7 +77,7 @@ func (c *AcknowledgeIncident) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "fromEmail",
-			Label:       "From Email",
+			Label:       "PagerDuty User Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",

--- a/pkg/integrations/pagerduty/annotate_incident.go
+++ b/pkg/integrations/pagerduty/annotate_incident.go
@@ -83,7 +83,7 @@ func (c *AnnotateIncident) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "fromEmail",
-			Label:       "From Email",
+			Label:       "PagerDuty User Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",

--- a/pkg/integrations/pagerduty/create_incident.go
+++ b/pkg/integrations/pagerduty/create_incident.go
@@ -120,7 +120,7 @@ func (c *CreateIncident) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "fromEmail",
-			Label:       "From Email",
+			Label:       "PagerDuty User Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",

--- a/pkg/integrations/pagerduty/escalate_incident.go
+++ b/pkg/integrations/pagerduty/escalate_incident.go
@@ -114,7 +114,7 @@ func (c *EscalateIncident) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "fromEmail",
-			Label:       "From Email",
+			Label:       "PagerDuty User Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",

--- a/pkg/integrations/pagerduty/resolve_incident.go
+++ b/pkg/integrations/pagerduty/resolve_incident.go
@@ -79,7 +79,7 @@ func (c *ResolveIncident) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "fromEmail",
-			Label:       "From Email",
+			Label:       "PagerDuty User Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",

--- a/pkg/integrations/pagerduty/snooze_incident.go
+++ b/pkg/integrations/pagerduty/snooze_incident.go
@@ -100,7 +100,7 @@ func (c *SnoozeIncident) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "fromEmail",
-			Label:       "From Email",
+			Label:       "PagerDuty User Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",

--- a/pkg/integrations/pagerduty/update_incident.go
+++ b/pkg/integrations/pagerduty/update_incident.go
@@ -85,7 +85,7 @@ func (c *UpdateIncident) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "fromEmail",
-			Label:       "From Email",
+			Label:       "PagerDuty User Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",


### PR DESCRIPTION
## What changed
Renamed the PagerDuty action field label from `From Email` to `PagerDuty User Email` across incident actions.

## Why
`From Email` can be interpreted as an email sender address rather than the PagerDuty user performing the action. The new label makes the field purpose clearer while preserving the existing authentication-specific description and behavior.

## How
Updated only the user-facing label. No validation, authentication, or PagerDuty API behavior was changed.

## Tests
- `go test ./...` from `pkg/integrations/pagerduty`

Closes #1898