### PR TITLE
fix(schedule): fire on every selected weekday in a weeks schedule

### DIFF
--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -731,14 +731,30 @@ func nextWeeksTrigger(interval int, weekDays []string, hour int, minute int, now
 		validWeekdays[weekday] = true
 	}
 
-	nextIntervalStart := nowInTZ.AddDate(0, 0, interval*7)
+	if len(validWeekdays) == 0 {
+		return nil, fmt.Errorf("weekDays must contain at least one day")
+	}
 
-	// start the search on Sunday of the next week
-	nextIntervalStart.Add(-time.Duration(nextIntervalStart.Weekday()) * time.Hour)
-	for i := 0; i < 7; i++ {
-		checkDate := nextIntervalStart.AddDate(0, 0, i)
-		if validWeekdays[checkDate.Weekday()] {
+	// Walk forward from the Sunday of the current week and return the first selected weekday
+	// whose scheduled time is still ahead of now. Weeks are visited in interval steps, so an
+	// interval of 2 skips the week in between while still firing on every selected day of
+	// the weeks it does visit.
+	//
+	// The previous version jumped a whole interval away from now before searching, which
+	// landed on the same weekday as now and returned it, so only one of the selected days
+	// ever fired. It also meant to rewind to Sunday but discarded the result of Add (and
+	// scaled the offset in hours rather than days), so the rewind never happened.
+	weekStart := nowInTZ.AddDate(0, 0, -int(nowInTZ.Weekday()))
+	for weekOffset := 0; weekOffset <= interval; weekOffset += interval {
+		for i := 0; i < 7; i++ {
+			checkDate := weekStart.AddDate(0, 0, weekOffset*7+i)
+			if !validWeekdays[checkDate.Weekday()] {
+				continue
+			}
 			candidateTime := time.Date(checkDate.Year(), checkDate.Month(), checkDate.Day(), hour, minute, 0, 0, checkDate.Location())
+			if !candidateTime.After(nowInTZ) {
+				continue
+			}
 			utcResult := candidateTime.UTC()
 			return &utcResult, nil
 		}

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -650,3 +650,104 @@ func TestHandleHookRun(t *testing.T) {
 		t.Errorf("expected payload type to be scheduler.tick, got %q", eventCtx.Payloads[0].Type)
 	}
 }
+
+func TestNextWeeksTriggerFiresOnEverySelectedWeekday(t *testing.T) {
+	// weekDays is a multi-select and the node label reads the days back to the user, so a
+	// weeks schedule has to fire on all of them. Walking the fire/re-arm loop is what shows
+	// it: a single call could look right while the loop still returns one day per week.
+	tests := []struct {
+		name     string
+		interval int
+		weekDays []string
+		start    time.Time
+		expect   []time.Time
+	}{
+		{
+			name:     "every week on monday, wednesday and friday",
+			interval: 1,
+			weekDays: []string{"monday", "wednesday", "friday"},
+			start:    time.Date(2026, 1, 7, 12, 0, 0, 0, time.UTC), // wednesday, after 09:00
+			expect: []time.Time{
+				time.Date(2026, 1, 9, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 12, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 14, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 16, 9, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			// The component's own docs advertise this one: "Weekdays at 2 PM".
+			name:     "every week on weekdays",
+			interval: 1,
+			weekDays: []string{"monday", "tuesday", "wednesday", "thursday", "friday"},
+			start:    time.Date(2026, 1, 7, 12, 0, 0, 0, time.UTC),
+			expect: []time.Time{
+				time.Date(2026, 1, 8, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 9, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 12, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 13, 9, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			// Interval 2 keeps every selected day of the weeks it visits and skips the week
+			// in between: it fires in the weeks of Jan 4, Jan 18 and Feb 1.
+			name:     "every two weeks on monday and friday",
+			interval: 2,
+			weekDays: []string{"monday", "friday"},
+			start:    time.Date(2026, 1, 7, 12, 0, 0, 0, time.UTC),
+			expect: []time.Time{
+				time.Date(2026, 1, 9, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 19, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 23, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 2, 2, 9, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:     "a single selected day still runs weekly",
+			interval: 1,
+			weekDays: []string{"monday"},
+			start:    time.Date(2026, 1, 7, 12, 0, 0, 0, time.UTC),
+			expect: []time.Time{
+				time.Date(2026, 1, 12, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 19, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 26, 9, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := tt.start
+			for i, want := range tt.expect {
+				got, err := nextWeeksTrigger(tt.interval, tt.weekDays, 9, 0, now)
+				if err != nil {
+					t.Fatalf("fire %d: unexpected error: %v", i+1, err)
+				}
+				if !got.Equal(want) {
+					t.Fatalf("fire %d: expected %s, got %s",
+						i+1, want.Format(time.RFC3339), got.Format(time.RFC3339))
+				}
+				now = *got
+			}
+		})
+	}
+}
+
+func TestNextWeeksTriggerNeverReturnsThePast(t *testing.T) {
+	// The trigger re-arms from the time it just fired, so a candidate that is not strictly
+	// after now would make the scheduler fire the same instant forever.
+	now := time.Date(2026, 1, 7, 12, 0, 0, 0, time.UTC) // wednesday, past 09:00
+	got, err := nextWeeksTrigger(1, []string{"wednesday"}, 9, 0, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.After(now) {
+		t.Errorf("expected a time after %s, got %s",
+			now.Format(time.RFC3339), got.Format(time.RFC3339))
+	}
+}
+
+func TestNextWeeksTriggerRejectsEmptyWeekDays(t *testing.T) {
+	if _, err := nextWeeksTrigger(1, nil, 9, 0, time.Now()); err == nil {
+		t.Error("expected an error when no weekday is selected")
+	}
+}

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -144,8 +144,12 @@ func TestGetNextTrigger(t *testing.T) {
 				Hour:          intPtr(15),
 				Minute:        intPtr(30),
 			},
-			now:        mustParseTime("2025-01-06T10:00:00Z"), // Monday
-			expectNext: mustParseTime("2025-01-17T15:30:00Z"), // Friday of next week
+			now: mustParseTime("2025-01-06T10:00:00Z"), // Monday
+			// This Friday, not the one after. Skipping a whole interval before the first
+			// fire is the same off-by-a-week that made a multi-day schedule collapse onto
+			// one day: it can only hold if the search always starts an interval away from
+			// now, which is what kept the other selected days from ever running.
+			expectNext: mustParseTime("2025-01-10T15:30:00Z"), // Friday of the same week
 		},
 		{
 			name: "months configuration",
@@ -386,8 +390,10 @@ func TestTimezoneHandling(t *testing.T) {
 				Minute:        intPtr(0),       // on the hour
 				Timezone:      stringPtr("-8"), // GMT-8 (PST)
 			},
-			now:        mustParseTime("2025-01-06T16:00:00Z"), // Monday 8 AM PST (4 PM UTC)
-			expectNext: mustParseTime("2025-01-13T17:00:00Z"), // Monday 9 AM PST (5 PM UTC) of the next week
+			now: mustParseTime("2025-01-06T16:00:00Z"), // Monday 8 AM PST (4 PM UTC)
+			// One hour later, not a week later. Someone who sets up "every Monday at 9 AM"
+			// at 8 AM on a Monday means today.
+			expectNext: mustParseTime("2025-01-06T17:00:00Z"), // Monday 9 AM PST (5 PM UTC), same day
 		},
 		{
 			name: "month schedule in GMT+9 timezone (JST)",


### PR DESCRIPTION
Fixes #6514.

## The bug

`weekDays` is a multi-select, but a `weeks` schedule only ever fired on one day per week. Two defects in `nextWeeksTrigger`, and they compound:

**1. The search started an interval away from `now`.**

```go
nextIntervalStart := nowInTZ.AddDate(0, 0, interval*7)
```

Adding `interval*7` days lands on the same weekday as `now`, and the loop below matched that day first and returned it. With `weekDays: [monday, wednesday, friday]` created on a Wednesday, every fire was a Wednesday, so monday and friday never ran.

**2. The rewind to Sunday never happened.**

```go
// start the search on Sunday of the next week
nextIntervalStart.Add(-time.Duration(nextIntervalStart.Weekday()) * time.Hour)
```

`Add` returns a new `time.Time` rather than mutating the receiver, and the result is discarded, so this line has no effect. The offset was also scaled in hours rather than days, so even assigned it would have moved the clock by a few hours instead of rewinding to Sunday.

## The fix

The search now walks forward from the Sunday of the current week and returns the first selected weekday whose scheduled time is still ahead of `now`, visiting weeks in `interval` steps. An interval of 2 skips the week in between and still fires on every selected day of the weeks it does visit.

Walking the fire/re-arm loop is what shows the fix, and it is how the tests are written: a single call can look correct while the loop still yields one day per week.

```
weekDays=[monday wednesday friday], interval=1, hour=9, created Wed 2026-01-07
    before: Wed 01-14, Wed 01-21, Wed 01-28   (monday and friday never fire)
    after:  Fri 01-09, Mon 01-12, Wed 01-14, Fri 01-16
```

An empty `weekDays` is now rejected up front, instead of reaching the generic `no valid weekday found` after a pointless seven-day scan.

## Heads up: two existing expectations changed

This is a visible behaviour change, so it is a separate commit rather than something buried in the fix.

| test | `now` | `weekDays` | was | now |
|---|---|---|---|---|
| `TestGetNextTrigger/weeks configuration` | Mon 2025-01-06 10:00 | `[friday]` | Fri 01-17 | Fri 01-10 |
| `TestTimezoneHandling/week schedule in GMT-8` | Mon 08:00 PST | `[monday]` at 09:00 PST | Mon of next week | same day, 09:00 |

Both encoded a full-interval wait before the *first* fire. That can only hold if the search always starts an interval away from `now`, which is precisely what kept the other selected days from ever running, so the two cannot both be true. The second one also reads as user-hostile on its own: someone who sets up "every Monday at 9 AM" at 8 AM on a Monday means today, not next week.

If you would rather keep the skip-the-first-week semantics, say so and I will rework this around it, though I do not think it can coexist with multi-day firing in a stateless next-trigger function.

## Verification

`go test ./pkg/triggers/schedule/` passes, including the four re-arm scenarios (every-week multi-day, the weekdays example from the component docs, interval 2, and a single day for regression), plus never-return-the-past and empty-weekDays. `go vet` is clean on the package.
