### PR TITLE
fix: resolve schedule and time gate timezones with DST-aware IANA identifiers (#6565)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,13 @@
 package main
 
-import "github.com/superplanehq/superplane/pkg/server"
+import (
+	// Embed the IANA timezone database into the binary so time.LoadLocation works
+	// even in containers that don't ship the system tzdata package. This is required
+	// for schedules and time gates to resolve DST-aware IANA identifiers.
+	_ "time/tzdata"
+
+	"github.com/superplanehq/superplane/pkg/server"
+)
 
 func main() {
 	server.Start()

--- a/pkg/components/timegate/dst_test.go
+++ b/pkg/components/timegate/dst_test.go
@@ -1,0 +1,44 @@
+package timegate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A time gate configured for a named city must interpret its window in that
+// city's wall-clock time all year, across DST transitions. Previously the picker
+// submitted a numeric offset that became a time.FixedZone with no DST rules, so
+// a business-hours window was effectively shifted an hour during DST. See issue
+// #6565. At 2026-08-05T13:30:00Z it is 09:30 in New York, inside a 09:00-17:00
+// gate.
+func TestTimeGate_ParseTimezone_AppliesDST(t *testing.T) {
+	tg := &TimeGate{}
+	loc := tg.parseTimezone("America/New_York")
+
+	instant := time.Date(2026, 8, 5, 13, 30, 0, 0, time.UTC)
+	got := instant.In(loc).Format("15:04")
+	assert.Equal(t, "09:30", got, "summer instant should be 09:30 in New York (EDT, offset -4h)")
+
+	winter := time.Date(2026, 1, 15, 13, 30, 0, 0, time.UTC)
+	assert.Equal(t, "08:30", winter.In(loc).Format("15:04"), "winter instant should be 08:30 in New York (EST, offset -5h)")
+}
+
+// A bare numeric offset is still honoured as a genuine fixed zone for backward
+// compatibility with configs saved before IANA identifiers were introduced.
+func TestTimeGate_ParseTimezone_NumericOffsetRemainsFixed(t *testing.T) {
+	tg := &TimeGate{}
+	loc := tg.parseTimezone("-5")
+
+	_, offsetSeconds := time.Date(2026, 8, 5, 12, 0, 0, 0, loc).Zone()
+	assert.Equal(t, -5*3600, offsetSeconds)
+}
+
+// Empty and "current" resolve to UTC rather than the server's local zone, so the
+// same config behaves identically regardless of the host's TZ setting.
+func TestTimeGate_ParseTimezone_EmptyAndCurrentAreUTC(t *testing.T) {
+	tg := &TimeGate{}
+	assert.Equal(t, time.UTC, tg.parseTimezone(""))
+	assert.Equal(t, time.UTC, tg.parseTimezone("current"))
+}

--- a/pkg/components/timegate/time_gate.go
+++ b/pkg/components/timegate/time_gate.go
@@ -372,17 +372,27 @@ func (tg *TimeGate) isExcludedDate(date time.Time, excludedDates map[string]stru
 }
 
 func (tg *TimeGate) parseTimezone(timezoneStr string) *time.Location {
+	// Empty and "current" fall back to UTC rather than the server's local zone, so
+	// the same config behaves identically regardless of the host's TZ setting.
 	if timezoneStr == "" || timezoneStr == "current" {
-		return time.Local
-	}
-
-	offsetHours, err := strconv.ParseFloat(timezoneStr, 64)
-	if err != nil {
 		return time.UTC
 	}
-	offsetSeconds := int(offsetHours * 3600)
 
-	return time.FixedZone(fmt.Sprintf("GMT%+.1f", offsetHours), offsetSeconds)
+	// Preferred form: an IANA identifier (e.g. "America/New_York"), resolved with
+	// LoadLocation so that DST rules are applied for the instant being evaluated.
+	if loc, err := time.LoadLocation(timezoneStr); err == nil {
+		return loc
+	}
+
+	// Backward compatibility: a bare numeric offset is treated as a genuine fixed
+	// zone. This stays correct for non-DST regions and for anyone who deliberately
+	// wants a fixed offset, and keeps existing configs working until they are re-saved.
+	if offsetHours, err := strconv.ParseFloat(strings.TrimPrefix(timezoneStr, "+"), 64); err == nil {
+		offsetSeconds := int(offsetHours * 3600)
+		return time.FixedZone(fmt.Sprintf("GMT%+.1f", offsetHours), offsetSeconds)
+	}
+
+	return time.UTC
 }
 
 func parseTimeString(timeStr string) (int, error) {

--- a/pkg/configuration/validation.go
+++ b/pkg/configuration/validation.go
@@ -508,17 +508,22 @@ func validateTimezone(_ Field, value any) error {
 	}
 
 	if timezoneStr == "current" {
-		return fmt.Errorf("timezone value 'current' should be replaced with actual timezone offset before submission")
+		return fmt.Errorf("timezone value 'current' should be replaced with an actual timezone before submission")
 	}
 
-	var offsetHours float64
-	var err error
+	// Preferred form: an IANA identifier (e.g. "America/New_York"). Validate it by
+	// loading it, which is also what the consumers do at evaluation time so that DST
+	// rules apply.
+	if _, err := time.LoadLocation(timezoneStr); err == nil {
+		return nil
+	}
 
-	// Handle cases with or without + prefix
+	// Backward compatibility: a bare numeric offset is still accepted as a fixed zone.
+	// Handle cases with or without + prefix.
 	cleanTz := strings.TrimPrefix(timezoneStr, "+")
-	offsetHours, err = strconv.ParseFloat(cleanTz, 64)
+	offsetHours, err := strconv.ParseFloat(cleanTz, 64)
 	if err != nil {
-		return fmt.Errorf("invalid timezone format: must be a numeric offset like '-5', '0', '5.5', or '+8'")
+		return fmt.Errorf("invalid timezone: must be an IANA identifier like 'America/New_York' or a numeric offset like '-5', '0', '5.5', or '+8'")
 	}
 
 	// Check valid range: UTC-12 to UTC+14

--- a/pkg/triggers/schedule/dst_test.go
+++ b/pkg/triggers/schedule/dst_test.go
@@ -1,0 +1,62 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+)
+
+// A daily schedule configured for a named city must fire at the configured
+// wall-clock time in that city all year, across DST transitions. Previously the
+// picker submitted a numeric offset that became a time.FixedZone with no DST
+// rules, so summer instants fired an hour late. See issue #6565.
+func TestSchedule_DailyJobFiresOnTimeAcrossDST(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("loading America/New_York: %v", err)
+	}
+
+	hour, minute, interval := 9, 0, 1
+	tz := "America/New_York"
+
+	config := Configuration{
+		Type:         TypeDays,
+		DaysInterval: &interval,
+		Hour:         &hour,
+		Minute:       &minute,
+		Timezone:     &tz,
+	}
+
+	tests := []struct {
+		label   string
+		instant time.Time
+	}{
+		{"winter (EST)", time.Date(2026, 1, 15, 3, 0, 0, 0, time.UTC)},
+		{"summer (EDT)", time.Date(2026, 8, 5, 3, 0, 0, 0, time.UTC)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.label, func(t *testing.T) {
+			next, err := getNextTrigger(config, tc.instant, nil)
+			if err != nil {
+				t.Fatalf("getNextTrigger: %v", err)
+			}
+
+			got := next.In(newYork).Format("15:04")
+			if got != "09:00" {
+				t.Errorf("configured 09:00 New York time, but fired at %s", got)
+			}
+		})
+	}
+}
+
+// A bare numeric offset is still honoured as a genuine fixed zone for backward
+// compatibility with configs saved before IANA identifiers were introduced.
+func TestSchedule_NumericOffsetRemainsFixed(t *testing.T) {
+	offset := "-5"
+	loc := parseTimezone(&offset)
+
+	_, offsetSeconds := time.Date(2026, 8, 5, 12, 0, 0, 0, loc).Zone()
+	if offsetSeconds != -5*3600 {
+		t.Errorf("expected fixed -5h (%d s), got %d s", -5*3600, offsetSeconds)
+	}
+}

--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -656,13 +656,21 @@ func parseTimezone(timezoneStr *string) *time.Location {
 		return time.UTC
 	}
 
-	offsetHours, err := strconv.ParseFloat(*timezoneStr, 64)
-	if err != nil {
-		return time.UTC
+	// Preferred form: an IANA identifier (e.g. "America/New_York"), resolved with
+	// LoadLocation so that DST rules are applied for the instant being evaluated.
+	if loc, err := time.LoadLocation(*timezoneStr); err == nil {
+		return loc
 	}
-	offsetSeconds := int(offsetHours * 3600)
 
-	return time.FixedZone(fmt.Sprintf("GMT%+.1f", offsetHours), offsetSeconds)
+	// Backward compatibility: a bare numeric offset is treated as a genuine fixed
+	// zone. This stays correct for non-DST regions and for anyone who deliberately
+	// wants a fixed offset, and keeps existing configs working until they are re-saved.
+	if offsetHours, err := strconv.ParseFloat(strings.TrimPrefix(*timezoneStr, "+"), 64); err == nil {
+		offsetSeconds := int(offsetHours * 3600)
+		return time.FixedZone(fmt.Sprintf("GMT%+.1f", offsetHours), offsetSeconds)
+	}
+
+	return time.UTC
 }
 
 func nextHoursTrigger(interval int, minute int, now time.Time) (*time.Time, error) {

--- a/web_src/src/ui/configurationFieldRenderer/TimezoneFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TimezoneFieldRenderer.tsx
@@ -1,71 +1,79 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { FieldRendererProps } from "./types";
 import { toTestId } from "@/lib/testID";
 
-// Function to get user's current timezone offset as a string (e.g., "-5", "0", "5.5")
-const getUserTimezoneOffset = (): string => {
-  const offset = -new Date().getTimezoneOffset() / 60;
-  return offset.toString();
+// The user's current IANA timezone identifier (e.g. "America/New_York").
+// This carries DST rules, unlike a bare numeric offset.
+const getUserTimezone = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
 };
 
-// Timezone options with labels and values
-const timezoneOptions = [
-  { label: "GMT-12 (Baker Island)", value: "-12" },
-  { label: "GMT-11 (American Samoa)", value: "-11" },
-  { label: "GMT-10 (Hawaii)", value: "-10" },
-  { label: "GMT-9 (Alaska)", value: "-9" },
-  { label: "GMT-8 (Los Angeles, Vancouver)", value: "-8" },
-  { label: "GMT-7 (Denver, Phoenix)", value: "-7" },
-  { label: "GMT-6 (Chicago, Mexico City)", value: "-6" },
-  { label: "GMT-5 (New York, Toronto)", value: "-5" },
-  { label: "GMT-4 (Santiago, Atlantic)", value: "-4" },
-  { label: "GMT-3 (São Paulo, Buenos Aires)", value: "-3" },
-  { label: "GMT-2 (South Georgia)", value: "-2" },
-  { label: "GMT-1 (Azores)", value: "-1" },
-  { label: "GMT+0 (London, Dublin, UTC)", value: "0" },
-  { label: "GMT+1 (Paris, Berlin, Rome)", value: "1" },
-  { label: "GMT+2 (Cairo, Helsinki, Athens)", value: "2" },
-  { label: "GMT+3 (Moscow, Istanbul, Riyadh)", value: "3" },
-  { label: "GMT+4 (Dubai, Baku)", value: "4" },
-  { label: "GMT+5 (Karachi, Tashkent)", value: "5" },
-  { label: "GMT+5:30 (Mumbai, Delhi)", value: "5.5" },
-  { label: "GMT+6 (Dhaka, Almaty)", value: "6" },
-  { label: "GMT+7 (Bangkok, Jakarta)", value: "7" },
-  { label: "GMT+8 (Beijing, Singapore, Perth)", value: "8" },
-  { label: "GMT+9 (Tokyo, Seoul)", value: "9" },
-  { label: "GMT+9:30 (Adelaide)", value: "9.5" },
-  { label: "GMT+10 (Sydney, Melbourne)", value: "10" },
-  { label: "GMT+11 (Solomon Islands)", value: "11" },
-  { label: "GMT+12 (Auckland, Fiji)", value: "12" },
-  { label: "GMT+13 (Tonga, Samoa)", value: "13" },
-  { label: "GMT+14 (Kiribati)", value: "14" },
-];
+// The full list of IANA timezone identifiers supported by the runtime.
+const getTimezoneIdentifiers = (): string[] => {
+  try {
+    const supportedValuesOf = (Intl as unknown as { supportedValuesOf?: (key: string) => string[] })
+      .supportedValuesOf;
+    if (typeof supportedValuesOf === "function") {
+      const zones = supportedValuesOf("timeZone");
+      // Intl doesn't always include "UTC"; make sure it's selectable.
+      return zones.includes("UTC") ? zones : ["UTC", ...zones];
+    }
+  } catch {
+    // Fall through to the minimal fallback below.
+  }
+  return ["UTC"];
+};
+
+// Build a human-friendly label showing the identifier and its current offset,
+// e.g. "America/New_York (GMT-04:00)".
+const formatTimezoneLabel = (identifier: string): string => {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: identifier,
+      timeZoneName: "shortOffset",
+    }).formatToParts(new Date());
+    const offset = parts.find((p) => p.type === "timeZoneName")?.value;
+    const name = identifier.replace(/_/g, " ");
+    return offset ? `${name} (${offset})` : name;
+  } catch {
+    return identifier.replace(/_/g, " ");
+  }
+};
 
 export const TimezoneFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange }) => {
   const hasSetDefault = useRef(false);
   const testId = field.name ? toTestId(`field-${field.name}-select`) : undefined;
 
-  // Set user's current timezone as default on first render if no value is present
-  // or if the value is "current" (which signals to use user's timezone)
+  const timezoneOptions = useMemo(
+    () => getTimezoneIdentifiers().map((identifier) => ({ label: formatTimezoneLabel(identifier), value: identifier })),
+    [],
+  );
+
+  // Set the user's current timezone as the default on first render if no value is
+  // present or if the value is "current" (which signals to use the user's timezone).
   useEffect(() => {
     if (!hasSetDefault.current && (value === undefined || value === null || value === "current")) {
-      const userTimezone = getUserTimezoneOffset();
-      // Use user's timezone if it matches one of our options, otherwise fallback to "0" (UTC)
-      const defaultTimezone = timezoneOptions.find((tz) => tz.value === userTimezone) ? userTimezone : "0";
+      const userTimezone = getUserTimezone();
+      // Use the user's timezone if it's one of our options, otherwise fall back to UTC.
+      const defaultTimezone = timezoneOptions.some((tz) => tz.value === userTimezone) ? userTimezone : "UTC";
 
       onChange(defaultTimezone);
       hasSetDefault.current = true;
     }
-  }, [value, field.defaultValue, onChange]);
+  }, [value, field.defaultValue, onChange, timezoneOptions]);
 
-  // Get the display value - if value is "current", show user's timezone
+  // Get the display value - if value is "current", show the user's timezone.
   const displayValue = (() => {
     if (value === "current") {
-      const userTimezone = getUserTimezoneOffset();
-      return timezoneOptions.find((tz) => tz.value === userTimezone)?.value ?? "0";
+      const userTimezone = getUserTimezone();
+      return timezoneOptions.some((tz) => tz.value === userTimezone) ? userTimezone : "UTC";
     }
-    return (value as string) ?? "0";
+    return (value as string) ?? "UTC";
   })();
 
   return (


### PR DESCRIPTION
[#6565](https://github.com/superplanehq/superplane/issues/6565) | [Artifacts](https://cloud.humanlayer.com/tasks/019feb91-72d2-7ff5-9766-baf5ec5a85b0/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/019feb91-72d2-7ff5-9766-baf5ec5a85b0)

## What problems was I solving

The timezone picker offered city-labelled options (e.g. *"GMT-5 (New York, Toronto)"*) but submitted a **bare numeric UTC offset** (`-5`). Both consumers — the Schedule trigger and the Time Gate component — turned that offset into a `time.FixedZone`, a zone that by definition never observes daylight saving time.

The result: **13 of the 29 picker options were wrong for part of every year.** A schedule pinned to `02:00` in New York actually fired at `03:00` from March through November; a `09:00-17:00` Time Gate business-hours window was effectively `10:00-18:00`. There was no error and no warning — the config still read "GMT-5 (New York, Toronto)", the run history looked on-time by its own reckoning, and the drift appeared and disappeared twice a year on DST boundaries, making it very hard to attribute to the timezone setting.

Two related silent failures were in scope too:
- Both `parseTimezone` functions swallowed parse failures and fell back to UTC with no signal.
- Time Gate's `parseTimezone` mapped `""` and `"current"` to `time.Local` — the *server's* timezone, so the same config could behave differently depending on the host's `TZ`.

**After this PR:** a schedule or gate configured for a named city runs at the configured wall-clock time in that city, all year, across DST transitions.

## What user-facing changes did I ship

- [web_src/src/ui/configurationFieldRenderer/TimezoneFieldRenderer.tsx](https://github.com/superplanehq/superplane/pull/6613/files#diff-e1adac7db711c531fa7df93af854660b76cacd647f54c0e70406ea8e30527a82) — The picker now lists real **IANA timezone identifiers** (`Intl.supportedValuesOf('timeZone')`) instead of a hardcoded list of numeric offsets, each labelled with its current offset (e.g. `America/New York (GMT-04:00)`). The default is derived from the user's actual IANA zone via `Intl.DateTimeFormat().resolvedOptions().timeZone`.
- [pkg/configuration/validation.go](https://github.com/superplanehq/superplane/pull/6613/files#diff-040d1835e2fafe281fbef517e7e2c676f489deef1a8a0d897c24edd3279d5f40) — Validation now accepts an IANA identifier (validated by loading it) as well as the legacy numeric offset; the error message reflects both forms.
- Schedules and Time Gates configured for DST-observing cities now fire/open at the correct local wall-clock time year-round.

## How I implemented it

The fix stores IANA identifiers and resolves them with `time.LoadLocation`, which applies the correct DST rules for the instant being evaluated, while keeping backward compatibility with numeric offsets already persisted in existing configs.

### Frontend

- [TimezoneFieldRenderer.tsx](https://github.com/superplanehq/superplane/pull/6613/files#diff-e1adac7db711c531fa7df93af854660b76cacd647f54c0e70406ea8e30527a82) — Replaced `getUserTimezoneOffset()` (which returned a numeric offset string) with `getUserTimezone()` returning the IANA identifier. Added `getTimezoneIdentifiers()` (guards for runtimes without `Intl.supportedValuesOf`, always includes `UTC`) and `formatTimezoneLabel()` (renders `identifier (shortOffset)`). Options are built with `useMemo`; defaults and the display value fall back to `"UTC"` instead of `"0"`.

### Backend

- [pkg/triggers/schedule/schedule.go](https://github.com/superplanehq/superplane/pull/6613/files#diff-345c02fcc4cf14bc9a36be38e21f38bb63d5a5328a3e19569ae2acd140814583) — `parseTimezone` now tries `time.LoadLocation` first; on failure it falls back to treating a bare numeric offset as a genuine `time.FixedZone` (backward compat), and only then to UTC.
- [pkg/components/timegate/time_gate.go](https://github.com/superplanehq/superplane/pull/6613/files#diff-19f403828b6f818d01afad229ff8af69f1fbd5b1086d266fa9cd37eefe1bb8ca) — Same `LoadLocation`-first logic. Additionally, `""` and `"current"` now resolve to `time.UTC` rather than `time.Local`, so behaviour no longer depends on the server's `TZ`.
- [pkg/configuration/validation.go](https://github.com/superplanehq/superplane/pull/6613/files#diff-040d1835e2fafe281fbef517e7e2c676f489deef1a8a0d897c24edd3279d5f40) — `validateTimezone` accepts an IANA identifier by loading it, and still accepts a numeric offset in the UTC-12…UTC+14 range for backward compatibility.
- [cmd/server/main.go](https://github.com/superplanehq/superplane/pull/6613/files#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98e) — Added a blank `_ "time/tzdata"` import so the IANA timezone database is **embedded in the binary**. This makes `time.LoadLocation` work even in containers that don't ship the system tzdata package.

### Tests

- [pkg/triggers/schedule/dst_test.go](https://github.com/superplanehq/superplane/pull/6613/files#diff-c211a0e7816a57923850de23eb1b8003f6b80025b675ef711f1924b7af014cba) — Asserts a daily `09:00` `America/New_York` schedule fires at `09:00` local in both winter (EST) and summer (EDT); plus a test that a bare `-5` offset stays a genuine fixed zone.
- [pkg/components/timegate/dst_test.go](https://github.com/superplanehq/superplane/pull/6613/files#diff-270a2b7fe4f841a0b1eb75008628e0ccf48bd3edbcbc0172553106fda16172e3) — Asserts `parseTimezone("America/New_York")` yields 09:30 (summer) / 08:30 (winter) for a `13:30Z` instant, that a numeric offset stays fixed, and that `""`/`"current"` map to UTC.

## Deviations from the plan

No plan file was found in the task directory (only `ticket.md`). The implementation follows the **suggested fix** outlined in the issue:

- ✅ `TimezoneFieldRenderer` submits IANA identifiers via `Intl.supportedValuesOf`/`resolvedOptions().timeZone`.
- ✅ `validateTimezone` accepts and loads an identifier.
- ✅ Both `parseTimezone` functions use `time.LoadLocation`, with `_ "time/tzdata"` embedded.
- ✅ Numeric offsets kept working for backward compatibility.
- ✅ Time Gate's `""`/`"current"` no longer resolves to the server's local zone (now UTC).

**Not included:** a data migration mapping the 24 previously-stored numeric offsets to representative IANA identifiers. The issue itself notes this "can't be exact for the ambiguous ones like `-7` (Denver vs Phoenix)." Existing numeric configs keep their current fixed-offset behaviour until re-saved, which is safe and non-breaking; a migration can be considered separately.

## How to verify it

### Automated Tests

```bash
go test ./pkg/triggers/schedule/ ./pkg/components/timegate/ ./pkg/configuration/
```

### Manual Testing

```bash
git fetch origin fix/6565-dst-aware-timezones
git checkout fix/6565-dst-aware-timezones
```

- [ ] Open a Schedule trigger config, open the timezone picker — confirm it lists IANA identifiers with current offsets, defaulting to your local zone.
- [ ] Configure a daily schedule for `America/New_York` at `09:00` and confirm the computed next-trigger is `09:00` New York time in both a winter and a summer instant.
- [ ] Configure a Time Gate `09:00-17:00` for `America/New_York` and confirm it opens at 09:00 local during DST (not 10:00).
- [ ] Confirm an existing config with a numeric offset (e.g. `-5`) still loads and behaves as a fixed offset.

## Description for the changelog

Schedule and Time Gate timezones now use DST-aware IANA identifiers (e.g. `America/New_York`), so time-based automation fires at the correct local wall-clock time year-round.
