### PR TITLE
fix: skip null canvas.yaml nodes during parse

### DIFF
--- a/web_src/src/pages/app/lib/canvas-yaml-staging.spec.ts
+++ b/web_src/src/pages/app/lib/canvas-yaml-staging.spec.ts
@@ -89,6 +89,33 @@ spec:
     });
   });
 
+  it("skips null or non-object node entries instead of throwing", () => {
+    const yamlText = `apiVersion: v1
+kind: Canvas
+metadata:
+  name: Incomplete nodes
+spec:
+  nodes:
+    -
+    - id: wait-1
+      name: Wait
+      component: wait
+    - not-a-node
+    - []
+  edges: []
+`;
+
+    const spec = parseCanvasYamlToSpec(yamlText);
+    expect(spec).not.toBeNull();
+    expect(spec?.nodes).toHaveLength(1);
+    expect(spec?.nodes?.[0]).toMatchObject({
+      id: "wait-1",
+      name: "Wait",
+      component: "wait",
+      type: "TYPE_ACTION",
+    });
+  });
+
   it("quotes position y keys when exporting yaml", () => {
     const workflow: CanvasesCanvas = {
       ...sampleWorkflow,

--- a/web_src/src/pages/app/lib/canvas-yaml-staging.ts
+++ b/web_src/src/pages/app/lib/canvas-yaml-staging.ts
@@ -87,9 +87,15 @@ export function parseCanvasYamlToSpec(text: string): CanvasesCanvas["spec"] | nu
   }
 
   return {
-    nodes: (spec.nodes ?? []).map(normalizeCanvasYamlNode),
+    // YAML list items can be null while editing (e.g. "- "). Skip non-objects so
+    // autosave/import does not crash on incomplete canvas.yaml documents.
+    nodes: (spec.nodes ?? []).filter(isCanvasYamlNode).map(normalizeCanvasYamlNode),
     edges: spec.edges ?? [],
   };
+}
+
+function isCanvasYamlNode(node: unknown): node is ComponentsNode {
+  return node != null && typeof node === "object" && !Array.isArray(node);
 }
 
 function normalizeCanvasYamlPosition(position: ComponentsNode["position"]): ComponentsNode["position"] {


### PR DESCRIPTION
## Summary
- Prevent `parseCanvasYamlToSpec` from crashing when `spec.nodes` contains null or non-object entries (common while editing incomplete YAML list items in Monaco).
- Add a regression test covering null, string, and array node entries.

Fixes #6617

## Test plan
- [x] `npx vitest run src/pages/app/lib/canvas-yaml-staging.spec.ts`
- [x] Confirmed incomplete YAML list item (`-`) parses as `null` and no longer throws on destructure
- [ ] `make format.js && make check.lint.ui && make check.build.ui` (Docker not available in contributor environment)