### PR TITLE
fix: keep Select controlled on empty string values

### DIFF
--- a/web_src/src/pages/app/console/MarkdownVariableSourceControls.tsx
+++ b/web_src/src/pages/app/console/MarkdownVariableSourceControls.tsx
@@ -59,7 +59,7 @@ export function MemorySourceControls({
       <div className="space-y-1">
         <Label className="text-[11px] font-medium text-slate-600">Namespace</Label>
         <Select
-          value={source.namespace || undefined}
+          value={source.namespace}
           onValueChange={(value) => onChange({ ...source, namespace: value })}
         >
           <SelectTrigger className="h-7 text-[12px]" data-testid="markdown-variable-memory-namespace">

--- a/web_src/src/pages/factories/FactoryLineStepEditor.tsx
+++ b/web_src/src/pages/factories/FactoryLineStepEditor.tsx
@@ -50,7 +50,7 @@ export function FactoryLineStepEditor({
         <div className={cn("space-y-2", stepFieldClassName)}>
           <Label htmlFor={`factory-line-step-app-${index}`}>App</Label>
           <Select
-            value={step.appId || undefined}
+            value={step.appId}
             onValueChange={(appId) => onChange({ ...step, appId, entrypoint: "" })}
           >
             <SelectTrigger id={`factory-line-step-app-${index}`} className={stepFieldClassName}>
@@ -69,7 +69,7 @@ export function FactoryLineStepEditor({
         <div className={cn("space-y-2", stepFieldClassName)}>
           <Label htmlFor={`factory-line-step-entrypoint-${index}`}>Trigger</Label>
           <Select
-            value={step.entrypoint || undefined}
+            value={step.entrypoint}
             onValueChange={(entrypoint) => onChange({ ...step, entrypoint })}
             disabled={!step.appId || canvasLoading}
           >


### PR DESCRIPTION
## Summary

- Fix `Select` components that flip between controlled and uncontrolled when their underlying value changes between an empty string and a real string, causing React's "component is changing from uncontrolled to controlled" warning.
- `FactoryLineStepEditor` passed `step.appId || undefined` and `step.entrypoint || undefined` as the `Select` `value` - since `DraftStep.appId`/`entrypoint` default to `""`, the `||` coerced that empty string to `undefined`, flipping the prop between `undefined` and a string as the user picked an app/trigger.
- `MarkdownVariableSourceControls` had the same pattern for `source.namespace || undefined`.
- Fix: pass the string directly (`step.appId`, `step.entrypoint`, `source.namespace`) so `Select` stays controlled for its entire lifecycle.
- Swept the rest of `web_src/src` for the same `value={x || undefined}` / `value={x ?? undefined}` / ternary-to-undefined patterns feeding a controlled component - no other occurrences found.

Fixes #6618

## Test plan

- Manually exercised the Factory line step editor: added a step, selected an app, then a trigger, then switched apps again — no controlled/uncontrolled console warning.
- Manually exercised the Markdown variable memory source namespace select — same check.
- `npx vitest run` on the affected areas (no behavior change to test, purely a prop-value fix).
