### PR TITLE
fix: handle unavailable factory line triggers

### DIFF
--- a/web_src/src/pages/factories/FactoryLineStepEditor.spec.tsx
+++ b/web_src/src/pages/factories/FactoryLineStepEditor.spec.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FactoryApp } from "@/api-client";
+import { useCanvas } from "@/hooks/useCanvasData";
+
+import { FactoryLineStepEditor } from "./FactoryLineStepEditor";
+import type { DraftStep } from "./lib/factoryLineFormShared";
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useCanvas: vi.fn(),
+}));
+
+const mockUseCanvas = vi.mocked(useCanvas);
+
+const app: FactoryApp = { id: "app-1", name: "Deploy App" };
+const apps = [app];
+const appById = new Map([[app.id!, app]]);
+
+function step(overrides: Partial<DraftStep> = {}): DraftStep {
+  return { name: "step", appId: "app-1", entrypoint: "", ...overrides };
+}
+
+function renderEditor(draftStep: DraftStep) {
+  return render(
+    <FactoryLineStepEditor
+      organizationId="org-1"
+      index={0}
+      step={draftStep}
+      apps={apps}
+      appById={appById}
+      onChange={vi.fn()}
+    />,
+  );
+}
+
+function triggerSelectTrigger() {
+  return screen.getByLabelText("Trigger");
+}
+
+describe("FactoryLineStepEditor trigger states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a load-error message and disables the trigger select when the canvas request fails", () => {
+    mockUseCanvas.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("network error"),
+    } as unknown as ReturnType<typeof useCanvas>);
+
+    renderEditor(step());
+
+    expect(screen.getByText("Failed to load triggers for this app.")).toBeInTheDocument();
+    expect(screen.queryByText("Deploy App has no triggers yet.")).not.toBeInTheDocument();
+    expect(triggerSelectTrigger()).toHaveAttribute("data-disabled");
+  });
+
+  it("shows the existing empty-state message when the canvas genuinely has no triggers", () => {
+    mockUseCanvas.mockReturnValue({
+      data: { id: "canvas-1", spec: { nodes: [] } },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCanvas>);
+
+    renderEditor(step());
+
+    expect(screen.getByText("Deploy App has no triggers yet.")).toBeInTheDocument();
+  });
+
+  it("flags a saved entrypoint that is no longer present in the loaded canvas", () => {
+    mockUseCanvas.mockReturnValue({
+      data: {
+        id: "canvas-1",
+        spec: { nodes: [{ id: "build", name: "Build", type: "TYPE_TRIGGER" }] },
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCanvas>);
+
+    renderEditor(step({ entrypoint: "deploy" }));
+
+    expect(
+      screen.getByText("The selected trigger is no longer available. Choose another trigger."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no warning once triggers load normally and the saved entrypoint is still present", () => {
+    mockUseCanvas.mockReturnValue({
+      data: {
+        id: "canvas-1",
+        spec: { nodes: [{ id: "deploy", name: "Deploy", type: "TYPE_TRIGGER" }] },
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCanvas>);
+
+    renderEditor(step({ entrypoint: "deploy" }));
+
+    expect(screen.queryByText("Failed to load triggers for this app.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deploy App has no triggers yet.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("The selected trigger is no longer available. Choose another trigger."),
+    ).not.toBeInTheDocument();
+    expect(triggerSelectTrigger()).not.toHaveAttribute("data-disabled");
+  });
+});

--- a/web_src/src/pages/factories/FactoryLineStepEditor.tsx
+++ b/web_src/src/pages/factories/FactoryLineStepEditor.tsx
@@ -11,6 +11,22 @@ import { LineStepEditorShell } from "./FactoryLineStepFlow";
 
 const stepFieldClassName = "w-full min-w-0";
 
+function getTriggerMessage(state: {
+  appId: string;
+  appName: string;
+  canvasLoading: boolean;
+  canvasLoadFailed: boolean;
+  triggerCount: number;
+  selectedTriggerMissing: boolean;
+}): string | null {
+  const { appId, appName, canvasLoading, canvasLoadFailed, triggerCount, selectedTriggerMissing } = state;
+  if (!appId) return null;
+  if (canvasLoadFailed) return "Failed to load triggers for this app.";
+  if (!canvasLoading && triggerCount === 0) return `${appName} has no triggers yet.`;
+  if (selectedTriggerMissing) return "The selected trigger is no longer available. Choose another trigger.";
+  return null;
+}
+
 interface FactoryLineStepEditorProps {
   organizationId: string;
   index: number;
@@ -28,10 +44,27 @@ export function FactoryLineStepEditor({
   appById,
   onChange,
 }: FactoryLineStepEditorProps) {
-  const { data: canvas, isLoading: canvasLoading } = useCanvas(organizationId, step.appId, {
+  const {
+    data: canvas,
+    isLoading: canvasLoading,
+    error: canvasError,
+  } = useCanvas(organizationId, step.appId, {
     enabled: Boolean(step.appId),
   });
   const triggers = useMemo(() => listTriggerNodes(canvas), [canvas]);
+
+  const canvasLoadFailed = Boolean(canvasError && !canvas);
+  const selectedTriggerMissing = Boolean(
+    canvas && step.entrypoint && !triggers.some((trigger) => trigger.id === step.entrypoint),
+  );
+  const triggerMessage = getTriggerMessage({
+    appId: step.appId,
+    appName: appById.get(step.appId)?.name ?? "This app",
+    canvasLoading,
+    canvasLoadFailed,
+    triggerCount: triggers.length,
+    selectedTriggerMissing,
+  });
 
   return (
     <LineStepEditorShell>
@@ -71,7 +104,7 @@ export function FactoryLineStepEditor({
           <Select
             value={step.entrypoint || undefined}
             onValueChange={(entrypoint) => onChange({ ...step, entrypoint })}
-            disabled={!step.appId || canvasLoading}
+            disabled={!step.appId || canvasLoading || canvasLoadFailed}
           >
             <SelectTrigger id={`factory-line-step-entrypoint-${index}`} className={stepFieldClassName}>
               <SelectValue placeholder={canvasLoading ? "Loading triggers…" : "Select trigger"} />
@@ -84,11 +117,7 @@ export function FactoryLineStepEditor({
               ))}
             </SelectContent>
           </Select>
-          {step.appId && !canvasLoading && triggers.length === 0 ? (
-            <p className="text-xs text-amber-700 dark:text-amber-300">
-              {appById.get(step.appId)?.name ?? "This app"} has no triggers yet.
-            </p>
-          ) : null}
+          {triggerMessage ? <p className="text-xs text-amber-700 dark:text-amber-300">{triggerMessage}</p> : null}
         </div>
       </div>
     </LineStepEditorShell>


### PR DESCRIPTION
## Summary

While reviewing the factory line trigger selection flow, I noticed that canvas
loading failures are currently treated as an empty trigger list, which can make
the UI report that an app has no triggers when the canvas request actually
failed. The trigger Select was also left enabled in that case, since it was
only disabled while no app was selected or while the request was loading.

Separately, an existing Factory Line's saved `entrypoint` is validated against
the *current* canvas, so if a trigger is later removed from the app, the editor
silently kept the stale value selected with no indication anything was wrong.

This change keeps loading, error, empty and invalid-saved-trigger states
distinct without changing the underlying Factory Line draft data (a stale
saved value is never auto-cleared — that stays a save-time/backend concern).

## Test plan

- Added `FactoryLineStepEditor.spec.tsx` covering: canvas load error (message +
  disabled Select), genuine empty-trigger state, stale saved entrypoint, and
  the normal loaded case.
- `npx vitest run` (project-wide) — all existing tests still pass.
- `npx eslint` / `npm run lint:budget` — within budget.
- `npx prettier --check` — clean.