### PR TITLE
fix: stop paginated listings reporting a page that does not exist

### DIFF
--- a/pkg/grpc/actions/canvases/list_canvas_versions.go
+++ b/pkg/grpc/actions/canvases/list_canvas_versions.go
@@ -32,17 +32,19 @@ func ListCanvasVersionsPaginated(
 	limit = getCanvasVersionLimit(limit)
 	beforeTime := getBefore(before)
 
-	versions, count, err := listCanvasVersionHistory(ctx, canvas.ID, int(limit), beforeTime)
+	versions, count, err := listCanvasVersionHistory(ctx, canvas.ID, int(limit)+1, beforeTime)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to list canvas versions")
 	}
+
+	versions, hasNext := trimPage(versions, int(limit))
 
 	protoVersions := serializeCanvasVersionMetadataList(ctx, versions, canvas.OrganizationID.String())
 
 	return &pb.ListCanvasVersionsResponse{
 		Versions:      protoVersions,
 		TotalCount:    uint32(count),
-		HasNextPage:   hasNextPage(len(versions), int(limit), count),
+		HasNextPage:   hasNext,
 		LastTimestamp: getLastCanvasVersionTimestamp(versions),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/list_node_events.go
+++ b/pkg/grpc/actions/canvases/list_node_events.go
@@ -16,10 +16,12 @@ func ListNodeEvents(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nod
 	//
 	// List and count events
 	//
-	events, err := models.ListCanvasEvents(db, canvas.ID, nodeID, int(limit), beforeTime)
+	events, err := models.ListCanvasEvents(db, canvas.ID, nodeID, int(limit)+1, beforeTime)
 	if err != nil {
 		return nil, err
 	}
+
+	events, hasNext := trimPage(events, int(limit))
 
 	totalCount, err := models.CountCanvasEvents(db, canvas.ID, nodeID)
 	if err != nil {
@@ -34,7 +36,7 @@ func ListNodeEvents(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nod
 	return &pb.ListNodeEventsResponse{
 		Events:        serialized,
 		TotalCount:    uint32(totalCount),
-		HasNextPage:   hasNextPage(len(events), int(limit), totalCount),
+		HasNextPage:   hasNext,
 		LastTimestamp: getLastEventTimestamp(events),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/list_node_executions.go
+++ b/pkg/grpc/actions/canvases/list_node_executions.go
@@ -47,10 +47,12 @@ func ListNodeExecutions(ctx context.Context, db *gorm.DB, canvas *models.Canvas,
 	//
 	// List and count executions
 	//
-	executions, err := models.ListNodeExecutions(db, canvas.ID, nodeID, states, results, int(limit), beforeTime)
+	executions, err := models.ListNodeExecutions(db, canvas.ID, nodeID, states, results, int(limit)+1, beforeTime)
 	if err != nil {
 		return nil, err
 	}
+
+	executions, hasNext := trimPage(executions, int(limit))
 
 	totalCount, err := models.CountNodeExecutions(db, canvas.ID, nodeID, states, results)
 	if err != nil {
@@ -70,7 +72,7 @@ func ListNodeExecutions(ctx context.Context, db *gorm.DB, canvas *models.Canvas,
 	return &pb.ListNodeExecutionsResponse{
 		Executions:    serialized,
 		TotalCount:    uint32(totalCount),
-		HasNextPage:   hasNextPage(len(executions), int(limit), totalCount),
+		HasNextPage:   hasNext,
 		LastTimestamp: getLastExecutionTimestamp(executions),
 	}, nil
 }
@@ -319,8 +321,19 @@ func getBefore(before *timestamppb.Timestamp) *time.Time {
 	return &t
 }
 
-func hasNextPage(numResults, limit int, totalCount int64) bool {
-	return int64(numResults) >= int64(limit) && int64(numResults) < totalCount
+// trimPage takes a page fetched with one extra row (limit+1), drops that extra
+// row and reports whether more rows follow the page.
+//
+// Fetching the extra row is what makes the answer exact. These listings page by
+// timestamp cursor while their totals count every row, so a full page and a
+// total larger than it do not imply anything is left after the cursor: with 4
+// rows over pages of 2, the second page is full and final at the same time.
+func trimPage[T any](rows []T, limit int) ([]T, bool) {
+	if limit > 0 && len(rows) > limit {
+		return rows[:limit], true
+	}
+
+	return rows, false
 }
 
 func executionIDs(executions []models.CanvasNodeExecution) []string {

--- a/pkg/grpc/actions/canvases/list_node_queue_items.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items.go
@@ -20,10 +20,12 @@ func ListNodeQueueItems(ctx context.Context, db *gorm.DB, canvas *models.Canvas,
 	//
 	// List and count queue items
 	//
-	queueItems, err := models.ListNodeQueueItems(db, canvas.ID, nodeID, int(limit), beforeTime)
+	queueItems, err := models.ListNodeQueueItems(db, canvas.ID, nodeID, int(limit)+1, beforeTime)
 	if err != nil {
 		return nil, err
 	}
+
+	queueItems, hasNext := trimPage(queueItems, int(limit))
 
 	totalCount, err := models.CountNodeQueueItems(db, canvas.ID, nodeID)
 	if err != nil {
@@ -38,7 +40,7 @@ func ListNodeQueueItems(ctx context.Context, db *gorm.DB, canvas *models.Canvas,
 	return &pb.ListNodeQueueItemsResponse{
 		Items:         serialized,
 		TotalCount:    uint32(totalCount),
-		HasNextPage:   hasNextPage(len(queueItems), int(limit), totalCount),
+		HasNextPage:   hasNext,
 		LastTimestamp: getLastQueueItemTimestamp(queueItems),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/list_node_queue_items_test.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items_test.go
@@ -268,6 +268,50 @@ func Test__ListNodeQueueItems__HandlesPaginationWithTimestamp(t *testing.T) {
 	assert.False(t, secondResponse.HasNextPage)
 }
 
+func Test__ListNodeQueueItems__LastPageIsFull(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "node-1",
+				Name:   "Node 1",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	//
+	// Four items over pages of two: the second page is full and is also the
+	// last one, so it must not advertise a page that does not exist.
+	//
+	for i := 0; i < 4; i++ {
+		inputEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
+		createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, nil)
+	}
+
+	firstResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, nil)
+	require.NoError(t, err)
+	require.Len(t, firstResponse.Items, 2)
+	assert.True(t, firstResponse.HasNextPage)
+
+	secondResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, firstResponse.LastTimestamp)
+	require.NoError(t, err)
+	require.Len(t, secondResponse.Items, 2)
+	assert.False(t, secondResponse.HasNextPage)
+
+	thirdResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, secondResponse.LastTimestamp)
+	require.NoError(t, err)
+	assert.Empty(t, thirdResponse.Items)
+}
+
 func Test__SerializeNodeQueueItems__HandlesEmptyList(t *testing.T) {
 	result, err := SerializeNodeQueueItems(database.Conn(), []models.CanvasNodeQueueItem{})
 	require.NoError(t, err)

--- a/pkg/grpc/actions/canvases/list_runs.go
+++ b/pkg/grpc/actions/canvases/list_runs.go
@@ -26,10 +26,12 @@ func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uin
 		return nil, err
 	}
 
-	runs, err := listCanvasRuns(ctx, db, canvas.ID, int(limit), beforeTime, filters)
+	runs, err := listCanvasRuns(ctx, db, canvas.ID, int(limit)+1, beforeTime, filters)
 	if err != nil {
 		return nil, err
 	}
+
+	runs, hasNext := trimPage(runs, int(limit))
 
 	count, err := countCanvasRuns(ctx, db, canvas.ID, filters)
 	if err != nil {
@@ -57,7 +59,7 @@ func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uin
 	return &pb.ListRunsResponse{
 		Runs:          serialized,
 		TotalCount:    uint32(count),
-		HasNextPage:   hasNextPage(len(runs), int(limit), count),
+		HasNextPage:   hasNext,
 		LastTimestamp: getLastRunTimestamp(runs),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/pagination_test.go
+++ b/pkg/grpc/actions/canvases/pagination_test.go
@@ -1,0 +1,33 @@
+package canvases
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__TrimPage(t *testing.T) {
+	t.Run("no sentinel row means the page is the last one", func(t *testing.T) {
+		rows, hasNext := trimPage([]int{1, 2}, 2)
+		assert.Equal(t, []int{1, 2}, rows)
+		assert.False(t, hasNext)
+	})
+
+	t.Run("a sentinel row means more rows follow and is not returned", func(t *testing.T) {
+		rows, hasNext := trimPage([]int{1, 2, 3}, 2)
+		assert.Equal(t, []int{1, 2}, rows)
+		assert.True(t, hasNext)
+	})
+
+	t.Run("partial page", func(t *testing.T) {
+		rows, hasNext := trimPage([]int{1}, 2)
+		assert.Equal(t, []int{1}, rows)
+		assert.False(t, hasNext)
+	})
+
+	t.Run("empty page", func(t *testing.T) {
+		rows, hasNext := trimPage([]int{}, 2)
+		assert.Empty(t, rows)
+		assert.False(t, hasNext)
+	})
+}

--- a/pkg/grpc/actions/factories/list_work_order_events.go
+++ b/pkg/grpc/actions/factories/list_work_order_events.go
@@ -47,10 +47,12 @@ func ListWorkOrderEvents(ctx context.Context, organizationID string, req *pb.Lis
 		return nil, factoryErrorToStatus(err, "failed to list work order events")
 	}
 
-	events, err := order.ListEvents(db, int(limit), before)
+	events, err := order.ListEvents(db, int(limit)+1, before)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work order events")
 	}
+
+	events, hasNext := trimWorkOrderEventsPage(events, int(limit))
 
 	totalCount, err := order.CountEvents(db)
 	if err != nil {
@@ -65,7 +67,7 @@ func ListWorkOrderEvents(ctx context.Context, organizationID string, req *pb.Lis
 	return &pb.ListWorkOrderEventsResponse{
 		Events:        serialized,
 		TotalCount:    uint32(totalCount),
-		HasNextPage:   hasWorkOrderEventsNextPage(len(events), int(limit), totalCount),
+		HasNextPage:   hasNext,
 		LastTimestamp: lastWorkOrderEventTimestamp(events),
 	}, nil
 }
@@ -123,8 +125,16 @@ func getWorkOrderEventsBefore(before *timestamppb.Timestamp) *time.Time {
 	return &t
 }
 
-func hasWorkOrderEventsNextPage(numResults, limit int, totalCount int64) bool {
-	return int64(numResults) >= int64(limit) && int64(numResults) < totalCount
+// trimWorkOrderEventsPage drops the extra row fetched alongside the page
+// (limit+1) and reports whether more events follow it. Events are paged by
+// timestamp cursor while the total counts every event, so a full page is not
+// on its own evidence that anything remains after the cursor.
+func trimWorkOrderEventsPage(events []models.FactoryWorkOrderEvent, limit int) ([]models.FactoryWorkOrderEvent, bool) {
+	if limit > 0 && len(events) > limit {
+		return events[:limit], true
+	}
+
+	return events, false
 }
 
 func lastWorkOrderEventTimestamp(events []models.FactoryWorkOrderEvent) *timestamppb.Timestamp {

--- a/pkg/grpc/actions/factories/list_work_order_events_test.go
+++ b/pkg/grpc/actions/factories/list_work_order_events_test.go
@@ -1,0 +1,39 @@
+package factories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func Test__TrimWorkOrderEventsPage(t *testing.T) {
+	events := func(n int) []models.FactoryWorkOrderEvent {
+		result := make([]models.FactoryWorkOrderEvent, n)
+		return result
+	}
+
+	t.Run("full page with no extra row is the last page", func(t *testing.T) {
+		page, hasNext := trimWorkOrderEventsPage(events(2), 2)
+		assert.Len(t, page, 2)
+		assert.False(t, hasNext)
+	})
+
+	t.Run("extra row means more events follow and is not returned", func(t *testing.T) {
+		page, hasNext := trimWorkOrderEventsPage(events(3), 2)
+		assert.Len(t, page, 2)
+		assert.True(t, hasNext)
+	})
+
+	t.Run("partial page", func(t *testing.T) {
+		page, hasNext := trimWorkOrderEventsPage(events(1), 2)
+		assert.Len(t, page, 1)
+		assert.False(t, hasNext)
+	})
+
+	t.Run("empty page", func(t *testing.T) {
+		page, hasNext := trimWorkOrderEventsPage(events(0), 2)
+		assert.Empty(t, page)
+		assert.False(t, hasNext)
+	})
+}


### PR DESCRIPTION
Closes #6622

## Problem

Every cursor-paginated listing reports `hasNextPage: true` on its **last page** whenever the number of rows is an exact multiple of the page size, so clients follow the cursor and get an empty page back.

`hasNextPage` decided the question by comparing the size of the page just returned against a total that counts every row:

```go
func hasNextPage(numResults, limit int, totalCount int64) bool {
	return int64(numResults) >= int64(limit) && int64(numResults) < totalCount
}
```

Those two numbers describe different things. Pagination is keyset-based (`WHERE created_at < before`) and none of the `Count*` functions take the cursor, so `totalCount` says nothing about what remains after it. A full page is not evidence that anything is left — with 4 rows over pages of 2, the second page is full and final at the same time.

## Fix

Fetch one row beyond the page and let its presence answer the question. The extra row is dropped before the page is serialized, so `LastTimestamp` still points at the last row actually returned and the next cursor cannot skip anything.

```go
func trimPage[T any](rows []T, limit int) ([]T, bool) {
	if limit > 0 && len(rows) > limit {
		return rows[:limit], true
	}

	return rows, false
}
```

No extra count query, and no changes to the model layer. In `ListRuns` the trim happens before run details are loaded, so the extra row costs nothing downstream.

Applied to all six affected listings — the five canvas ones sharing the helper, plus the identical copy in `factories/list_work_order_events.go`:

| Listing | Call site |
| --- | --- |
| Runs | `list_runs.go` |
| Node executions | `list_node_executions.go` |
| Queue items | `list_node_queue_items.go` |
| Node events | `list_node_events.go` |
| Canvas versions | `list_canvas_versions.go` |
| Work order events | `factories/list_work_order_events.go` |

## User-visible effect

`hasNextPage` feeds the UI directly: `hasMore` for the runs infinite scroll (`RunsTabPanel.tsx`) and `canNavigateOlder` for the run sidebar (`runsSidebarNavigation.ts`). With exactly 50 runs at the default limit, the sidebar's "older run" arrow stayed enabled at the true end of history and led nowhere.

## Tests

`Test__ListNodeQueueItems__LastPageIsFull` covers the case that was wrong end to end — 4 rows over pages of 2, asserting the second page is full, reports no next page, and that a third page is empty. It fails on `main` and passes here.

The existing `Test__ListNodeQueueItems__HandlesPaginationWithTimestamp` uses 3 rows over pages of 2, so its last page is partial — the one shape the old comparison got right, which is why this went unnoticed. Both tests now sit side by side.

Unit coverage for the trim helpers is in `pagination_test.go` and `factories/list_work_order_events_test.go` (full page, page with extra row, partial page, empty page).

## Verification

Run against a local stack (`make dev.up && make dev.setup && make dev.server`):

- `go test ./pkg/grpc/actions/... -count=1 -p 1` — all packages pass
- `make lint` — clean
- `make format.go` — applied

## Note on a related latent issue

While tracing this I noticed the cursor is a bare timestamp while rows are ordered by `created_at`, so rows sharing a `created_at` across a page boundary are skipped. I could only trigger it by forcing identical timestamps; 200 sequential inserts produced 0 collisions, since `created_at` is microsecond-precision and set per row. I've left it out of this PR rather than widen the change on a problem I can't show biting in practice — noted in #6622 in case you'd like it pursued separately.
