### PR TITLE
fix: request full pages when listing DigitalOcean droplets and droplet snapshots

### DIFF
--- a/pkg/integrations/digitalocean/client.go
+++ b/pkg/integrations/digitalocean/client.go
@@ -327,7 +327,7 @@ type DOAction struct {
 
 // ListDroplets retrieves all droplets in the account
 func (c *Client) ListDroplets() ([]Droplet, error) {
-	url := fmt.Sprintf("%s/droplets", c.BaseURL)
+	url := fmt.Sprintf("%s/droplets?per_page=200", c.BaseURL)
 	responseBody, err := c.execRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -922,7 +922,7 @@ type Snapshot struct {
 
 // GetDropletSnapshots lists snapshots for a given droplet
 func (c *Client) GetDropletSnapshots(dropletID int) ([]Snapshot, error) {
-	url := fmt.Sprintf("%s/droplets/%d/snapshots", c.BaseURL, dropletID)
+	url := fmt.Sprintf("%s/droplets/%d/snapshots?per_page=200", c.BaseURL, dropletID)
 	responseBody, err := c.execRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/integrations/digitalocean/create_snapshot_test.go
+++ b/pkg/integrations/digitalocean/create_snapshot_test.go
@@ -244,6 +244,11 @@ func Test__CreateSnapshot__HandleHook(t *testing.T) {
 		assert.True(t, executionState.Passed)
 		assert.Equal(t, "default", executionState.Channel)
 		assert.Equal(t, "digitalocean.snapshot.created", executionState.Type)
+
+		// The API defaults to 20 items per page; the snapshot lookup must ask
+		// for more, or droplets with many snapshots miss the one just created.
+		require.Len(t, httpContext.Requests, 2)
+		assert.Contains(t, httpContext.Requests[1].URL.RawQuery, "per_page=200")
 	})
 
 	t.Run("action still in-progress -> schedules another poll", func(t *testing.T) {

--- a/pkg/integrations/digitalocean/list_resources_test.go
+++ b/pkg/integrations/digitalocean/list_resources_test.go
@@ -58,6 +58,11 @@ func Test__ListResources__Droplets(t *testing.T) {
 		assert.Equal(t, "12345678", resources[0].ID)
 		assert.Equal(t, "db-server-01", resources[1].Name)
 		assert.Equal(t, "87654321", resources[1].ID)
+
+		// The API defaults to 20 items per page; without an explicit per_page,
+		// accounts with more than 20 droplets get a silently truncated list.
+		require.Len(t, httpContext.Requests, 1)
+		assert.Contains(t, httpContext.Requests[0].URL.RawQuery, "per_page=200")
 	})
 
 	t.Run("API error -> returns error", func(t *testing.T) {


### PR DESCRIPTION
## What

`ListDroplets` and `GetDropletSnapshots` were the only two list calls in the DigitalOcean client that did not pass `per_page`. The DigitalOcean API defaults to **20 items per page** (max 200), so both calls silently truncated.

## User-visible impact

- Any component with a droplet picker (Manage Droplet Power, Create Snapshot, alert-policy scoping) shows at most **20 droplets** — the rest are unselectable, with no error.
- `ListGPUDroplets` filters GPU droplets **client-side from that same truncated list**, so on a busy account the GPU picker can be empty even when GPU droplets exist.
- After **Create Snapshot** completes, the snapshot lookup (`GetDropletSnapshots`) has the same 20-item cap and can miss the snapshot it just created on droplets with a long snapshot history.

## Why this shape

Every sibling list method in `client.go` already passes `per_page=200` (19 occurrences — `ListImages`, `ListSizes`, `ListSSHKeys`, `ListVPCs`, `ListApps`, …). These two were the stragglers; the fix brings them in line with the file's own convention.

## Tests

Regression assertions on the recorded mock requests: the droplet listing and the post-snapshot lookup must carry `per_page=200`. Both fail against the previous URLs (verified red before the fix, green after).

```
go build ./pkg/integrations/digitalocean/   # ok
go vet   ./pkg/integrations/digitalocean/   # ok
go test  ./pkg/integrations/digitalocean/ -run "Test__ListResources__Droplets|Test__CreateSnapshot"   # PASS
```

---

Found by running a catalog of integration-client failure-class checks (the "one sibling missing the parameter the other nineteen pass" pattern) against the codebase. Same family as #6624, different vendor and mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
