### PR TITLE
fix: refuse canvas connections that would create a cycle

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/common.go
+++ b/pkg/grpc/actions/canvases/changesets/common.go
@@ -2,6 +2,8 @@ package changesets
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/superplanehq/superplane/pkg/models"
 )
@@ -36,11 +38,13 @@ func CheckForCycles(nodes []models.Node, edges []models.Edge) error {
 		}
 	}
 
-	visited := 0
+	// Kahn's never enqueues a node twice, so tracking which nodes were sorted
+	// leaves exactly the nodes involved in (or downstream of) a cycle behind.
+	sorted := make(map[string]struct{}, len(inDegree))
 	for len(queue) > 0 {
 		current := queue[0]
 		queue = queue[1:]
-		visited++
+		sorted[current] = struct{}{}
 
 		for _, neighbor := range graph[current] {
 			inDegree[neighbor]--
@@ -51,11 +55,106 @@ func CheckForCycles(nodes []models.Node, edges []models.Edge) error {
 	}
 
 	// If we visited all nodes, the graph is acyclic
-	if visited != len(nodes) {
+	if len(sorted) != len(nodes) {
+		remaining := make(map[string]struct{})
+		for _, node := range nodes {
+			if _, ok := sorted[node.ID]; !ok {
+				remaining[node.ID] = struct{}{}
+			}
+		}
+
+		if cycle := findCycle(graph, remaining); len(cycle) > 0 {
+			return fmt.Errorf("graph contains a cycle: %s", describeCycle(nodes, cycle))
+		}
+
 		return fmt.Errorf("graph contains a cycle")
 	}
 
 	return nil
+}
+
+/*
+ * findCycle returns one cycle as an ordered list of node IDs with the entry node
+ * repeated at the end, so the caller can render it as "A -> B -> A". Only nodes
+ * in candidates are traversed, which is the set Kahn's algorithm could not sort.
+ */
+func findCycle(graph map[string][]string, candidates map[string]struct{}) []string {
+	const (
+		unvisited = iota
+		onStack
+		done
+	)
+
+	state := make(map[string]int, len(candidates))
+	stack := []string{}
+	var cycle []string
+
+	var visit func(string) bool
+	visit = func(id string) bool {
+		state[id] = onStack
+		stack = append(stack, id)
+
+		for _, next := range graph[id] {
+			if _, ok := candidates[next]; !ok {
+				continue
+			}
+
+			if state[next] == onStack {
+				for i, node := range stack {
+					if node == next {
+						cycle = append(append([]string{}, stack[i:]...), next)
+						break
+					}
+				}
+
+				return true
+			}
+
+			if state[next] == unvisited && visit(next) {
+				return true
+			}
+		}
+
+		stack = stack[:len(stack)-1]
+		state[id] = done
+		return false
+	}
+
+	// Sort the entry points so the reported cycle is stable across runs.
+	entries := make([]string, 0, len(candidates))
+	for id := range candidates {
+		entries = append(entries, id)
+	}
+	sort.Strings(entries)
+
+	for _, id := range entries {
+		if state[id] == unvisited && visit(id) {
+			return cycle
+		}
+	}
+
+	return nil
+}
+
+func describeCycle(nodes []models.Node, cycle []string) string {
+	names := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		if node.Name != "" {
+			names[node.ID] = node.Name
+		}
+	}
+
+	labels := make([]string, 0, len(cycle))
+	for _, id := range cycle {
+		if name, ok := names[id]; ok {
+			labels = append(labels, name)
+			continue
+		}
+
+		labels = append(labels, id)
+	}
+
+	return strings.Join(labels, " -> ")
 }
 
 func loopNodeIDSet(nodes []models.Node) map[string]struct{} {

--- a/pkg/grpc/actions/canvases/changesets/common_test.go
+++ b/pkg/grpc/actions/canvases/changesets/common_test.go
@@ -35,3 +35,71 @@ func TestCheckForCycles_RejectsCyclesWithoutLoop(t *testing.T) {
 
 	require.Error(t, changesets.CheckForCycles(nodes, edges))
 }
+
+func TestCheckForCycles_NamesTheNodesInTheCycle(t *testing.T) {
+	nodes := []models.Node{
+		{ID: "node-a", Name: "Deploy to Droplet", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+		{ID: "node-b", Name: "Deploy Failed", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+	}
+	edges := []models.Edge{
+		{SourceID: "node-a", TargetID: "node-b", Channel: "default"},
+		{SourceID: "node-b", TargetID: "node-a", Channel: "default"},
+	}
+
+	err := changesets.CheckForCycles(nodes, edges)
+
+	require.Error(t, err)
+	require.Equal(t, "graph contains a cycle: Deploy to Droplet -> Deploy Failed -> Deploy to Droplet", err.Error())
+}
+
+func TestCheckForCycles_NamesLongerCycles(t *testing.T) {
+	nodes := []models.Node{
+		{ID: "a", Name: "Build", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+		{ID: "b", Name: "Test", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+		{ID: "c", Name: "Deploy", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+	}
+	edges := []models.Edge{
+		{SourceID: "a", TargetID: "b", Channel: "default"},
+		{SourceID: "b", TargetID: "c", Channel: "default"},
+		{SourceID: "c", TargetID: "a", Channel: "default"},
+	}
+
+	err := changesets.CheckForCycles(nodes, edges)
+
+	require.Error(t, err)
+	require.Equal(t, "graph contains a cycle: Build -> Test -> Deploy -> Build", err.Error())
+}
+
+func TestCheckForCycles_ReportsUnnamedNodesByID(t *testing.T) {
+	nodes := []models.Node{
+		{ID: "node-a", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+		{ID: "node-b", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+	}
+	edges := []models.Edge{
+		{SourceID: "node-a", TargetID: "node-b", Channel: "default"},
+		{SourceID: "node-b", TargetID: "node-a", Channel: "default"},
+	}
+
+	err := changesets.CheckForCycles(nodes, edges)
+
+	require.Error(t, err)
+	require.Equal(t, "graph contains a cycle: node-a -> node-b -> node-a", err.Error())
+}
+
+func TestCheckForCycles_ReportsOnlyTheCyclicNodes(t *testing.T) {
+	nodes := []models.Node{
+		{ID: "trigger", Name: "Start", Ref: models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}},
+		{ID: "a", Name: "Build", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+		{ID: "b", Name: "Test", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+	}
+	edges := []models.Edge{
+		{SourceID: "trigger", TargetID: "a", Channel: "default"},
+		{SourceID: "a", TargetID: "b", Channel: "default"},
+		{SourceID: "b", TargetID: "a", Channel: "default"},
+	}
+
+	err := changesets.CheckForCycles(nodes, edges)
+
+	require.Error(t, err)
+	require.Equal(t, "graph contains a cycle: Build -> Test -> Build", err.Error())
+}

--- a/web_src/src/ui/CanvasPage/canvasGraphCycles.spec.ts
+++ b/web_src/src/ui/CanvasPage/canvasGraphCycles.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import type { SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import { isLoopNode, wouldCreateCycle } from "./canvasGraphCycles";
+
+function component(id: string, name = "noop"): ComponentsNode {
+  return { id, name: id, type: "TYPE_ACTION", component: name };
+}
+
+function loop(id: string): ComponentsNode {
+  return component(id, "loop");
+}
+
+function trigger(id: string): ComponentsNode {
+  return { id, name: id, type: "TYPE_TRIGGER", component: "start" };
+}
+
+function edge(source: string, target: string) {
+  return { source, target };
+}
+
+describe("isLoopNode", () => {
+  it("identifies loop components", () => {
+    expect(isLoopNode(loop("l"))).toBe(true);
+    expect(isLoopNode(component("a"))).toBe(false);
+    expect(isLoopNode(trigger("t"))).toBe(false);
+  });
+});
+
+describe("wouldCreateCycle", () => {
+  /*
+   * The repro from issue #5773: two regular components, then connecting the
+   * downstream one back to the upstream one.
+   */
+  it("rejects connecting a downstream component back to an upstream one", () => {
+    const nodes = [component("deploy"), component("deploy-failed")];
+    const edges = [edge("deploy", "deploy-failed")];
+
+    expect(wouldCreateCycle(nodes, edges, "deploy-failed", "deploy")).toBe(true);
+  });
+
+  it("allows a connection that keeps the graph acyclic", () => {
+    const nodes = [component("a"), component("b"), component("c")];
+    const edges = [edge("a", "b")];
+
+    expect(wouldCreateCycle(nodes, edges, "b", "c")).toBe(false);
+    expect(wouldCreateCycle(nodes, edges, "a", "c")).toBe(false);
+  });
+
+  it("rejects a component connecting to itself", () => {
+    const nodes = [component("a")];
+
+    expect(wouldCreateCycle(nodes, [], "a", "a")).toBe(true);
+  });
+
+  it("rejects a cycle that closes through intermediate nodes", () => {
+    const nodes = [component("a"), component("b"), component("c"), component("d")];
+    const edges = [edge("a", "b"), edge("b", "c"), edge("c", "d")];
+
+    expect(wouldCreateCycle(nodes, edges, "d", "a")).toBe(true);
+    expect(wouldCreateCycle(nodes, edges, "d", "b")).toBe(true);
+  });
+
+  /*
+   * Mirrors TestCheckForCycles_AllowsFeedbackIntoLoop: feeding a worker's
+   * output back into the loop node it came from is the point of the component.
+   */
+  it("allows feedback into a loop node", () => {
+    const nodes = [trigger("trigger"), loop("loop"), component("worker")];
+    const edges = [edge("trigger", "loop"), edge("loop", "worker")];
+
+    expect(wouldCreateCycle(nodes, edges, "worker", "loop")).toBe(false);
+  });
+
+  it("allows a loop node to connect to itself", () => {
+    const nodes = [loop("loop")];
+
+    expect(wouldCreateCycle(nodes, [], "loop", "loop")).toBe(false);
+  });
+
+  /*
+   * Edges into a loop node are excluded from the graph, exactly as the server
+   * excludes them, so a path that only closes through a loop node's input is
+   * not a cycle for a regular component either.
+   */
+  it("does not treat a path through a loop node's input as reachable", () => {
+    const nodes = [component("a"), loop("loop"), component("worker")];
+    const edges = [edge("a", "loop"), edge("loop", "worker")];
+
+    expect(wouldCreateCycle(nodes, edges, "worker", "a")).toBe(false);
+  });
+
+  it("still rejects cycles among regular components in a canvas that has a loop", () => {
+    const nodes = [loop("loop"), component("a"), component("b")];
+    const edges = [edge("loop", "a"), edge("a", "b")];
+
+    expect(wouldCreateCycle(nodes, edges, "b", "a")).toBe(true);
+  });
+
+  it("ignores edges with a missing endpoint", () => {
+    const nodes = [component("a"), component("b")];
+    const edges = [{ source: "a", target: null }, edge("a", "b")];
+
+    expect(wouldCreateCycle(nodes, edges, "b", "a")).toBe(true);
+  });
+
+  it("returns false when either endpoint is missing", () => {
+    const nodes = [component("a")];
+
+    expect(wouldCreateCycle(nodes, [], "", "a")).toBe(false);
+    expect(wouldCreateCycle(nodes, [], "a", "")).toBe(false);
+  });
+
+  it("terminates on a graph that already contains a cycle", () => {
+    const nodes = [component("a"), component("b"), component("c")];
+    const edges = [edge("a", "b"), edge("b", "a")];
+
+    expect(wouldCreateCycle(nodes, edges, "c", "a")).toBe(false);
+    expect(wouldCreateCycle(nodes, edges, "a", "c")).toBe(false);
+  });
+});

--- a/web_src/src/ui/CanvasPage/canvasGraphCycles.ts
+++ b/web_src/src/ui/CanvasPage/canvasGraphCycles.ts
@@ -1,0 +1,115 @@
+import type { SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+
+/**
+ * The loop component is the one component whose input may close a cycle, which
+ * is what makes iteration expressible on the canvas.
+ */
+const LOOP_COMPONENT_NAME = "loop";
+
+type GraphEdge = {
+  source?: string | null;
+  target?: string | null;
+};
+
+export function isLoopNode(node: ComponentsNode): boolean {
+  return node.component === LOOP_COMPONENT_NAME;
+}
+
+function loopNodeIds(nodes: ComponentsNode[]): Set<string> {
+  const ids = new Set<string>();
+  for (const node of nodes) {
+    if (node.id && isLoopNode(node)) {
+      ids.add(node.id);
+    }
+  }
+
+  return ids;
+}
+
+/**
+ * Builds the adjacency used for cycle detection, leaving out every edge that
+ * points at a loop node for the same reason the server does.
+ */
+function buildAdjacency(edges: readonly GraphEdge[], loopIds: Set<string>): Map<string, string[]> {
+  const outgoing = new Map<string, string[]>();
+
+  for (const edge of edges) {
+    const { source, target } = edge;
+    if (!source || !target || loopIds.has(target)) {
+      continue;
+    }
+
+    const existing = outgoing.get(source);
+    if (existing) {
+      existing.push(target);
+      continue;
+    }
+
+    outgoing.set(source, [target]);
+  }
+
+  return outgoing;
+}
+
+function canReach(outgoing: Map<string, string[]>, from: string, to: string): boolean {
+  const queue = [from];
+  const seen = new Set<string>([from]);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current === to) {
+      return true;
+    }
+
+    for (const next of outgoing.get(current) ?? []) {
+      if (seen.has(next)) {
+        continue;
+      }
+
+      seen.add(next);
+      queue.push(next);
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Reports whether connecting sourceId to targetId would close a cycle.
+ *
+ * This mirrors the server-side check in
+ * pkg/grpc/actions/canvases/changesets/common.go (CheckForCycles): edges whose
+ * *target* is a loop node are left out of the graph entirely, so a loop node's
+ * input may close a cycle while every other component's may not. Keeping the
+ * two rules identical is the point — the canvas should refuse exactly the
+ * connections the server would later reject at publish time, no more and no
+ * less.
+ *
+ * The server runs a topological sort over the whole graph. Here a single edge
+ * is being added to a graph that is already acyclic, so it is enough to ask
+ * whether the target can already reach the source.
+ */
+export function wouldCreateCycle(
+  nodes: ComponentsNode[],
+  edges: readonly GraphEdge[],
+  sourceId: string,
+  targetId: string,
+): boolean {
+  if (!sourceId || !targetId) {
+    return false;
+  }
+
+  const loopIds = loopNodeIds(nodes);
+
+  // The edge being added would itself be excluded from the graph, so it cannot
+  // introduce a cycle no matter what the rest of the graph looks like.
+  if (loopIds.has(targetId)) {
+    return false;
+  }
+
+  if (sourceId === targetId) {
+    return true;
+  }
+
+  return canReach(buildAdjacency(edges, loopIds), targetId, sourceId);
+}

--- a/web_src/src/ui/CanvasPage/index.connectionValidation.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.connectionValidation.spec.tsx
@@ -1,0 +1,200 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render as testingLibraryRender } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+
+const { reactFlowPropsRef } = vi.hoisted(() => ({
+  reactFlowPropsRef: {
+    current: null as null | {
+      children?: ReactNode;
+      isValidConnection?: (connection: { source: string | null; target: string | null }) => boolean;
+      onConnect?: (connection: { source: string | null; target: string | null; sourceHandle: string | null }) => void;
+    },
+  },
+}));
+
+vi.mock("@/sentry", () => ({
+  Sentry: {
+    withScope: (callback: (scope: { setTag: typeof vi.fn; setExtra: typeof vi.fn }) => void) =>
+      callback({ setTag: vi.fn(), setExtra: vi.fn() }),
+    captureException: vi.fn(),
+  },
+}));
+
+vi.mock("@xyflow/react", () => ({
+  Background: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ReactFlow: (props: { children?: ReactNode }) => {
+    reactFlowPropsRef.current = props;
+    return <div>{props.children}</div>;
+  },
+  ReactFlowProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ViewportPortal: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  useOnSelectionChange: vi.fn(),
+  useReactFlow: vi.fn(() => ({
+    fitView: vi.fn().mockResolvedValue(true),
+    screenToFlowPosition: vi.fn((position) => position),
+    getViewport: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+    setViewport: vi.fn(),
+    getInternalNode: vi.fn(),
+    zoomTo: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    getNodes: vi.fn(() => []),
+    getZoom: vi.fn(() => 1),
+  })),
+  useStore: vi.fn((selector: (state: { minZoom: number; maxZoom: number }) => unknown) =>
+    selector({ minZoom: 0.1, maxZoom: 1.5 }),
+  ),
+  useViewport: vi.fn(() => ({ zoom: 1, x: 0, y: 0 })),
+}));
+
+vi.mock("../BuildingBlocksSidebar", () => ({
+  BuildingBlocksSidebar: () => null,
+}));
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useEventExecutions: () => ({ data: { executions: [] }, isLoading: false }),
+}));
+
+vi.mock("../componentSidebar", () => ({
+  ComponentSidebar: () => <div data-testid="live-node-detail-pane-content" />,
+}));
+
+vi.mock("@/components/CanvasToolSidebar", () => ({
+  CanvasToolSidebar: () => null,
+}));
+
+vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
+  useCanvasToolSidebarState: () => ({
+    canvasId: undefined,
+    organizationId: undefined,
+    isEditing: false,
+    readOnly: false,
+    isToolSidebarOpen: false,
+    showToolSidebarToggle: false,
+    handleToolSidebarToggle: vi.fn(),
+    openToolSidebar: vi.fn(),
+    closeToolSidebar: vi.fn(),
+  }),
+}));
+
+vi.mock("./Header", () => ({
+  Header: () => <header data-testid="canvas-header" />,
+}));
+
+import { CanvasPage } from "./index";
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  return testingLibraryRender(ui, { wrapper: Wrapper });
+}
+
+function canvasNode(id: string, label: string, position: number) {
+  return { id, position: { x: position, y: 0 }, data: { label, state: "success", type: "component" } };
+}
+
+const nodes = [canvasNode("deploy", "Deploy to Droplet", 0), canvasNode("deploy-failed", "Deploy Failed", 200)];
+
+const edges = [{ id: "deploy->deploy-failed", source: "deploy", target: "deploy-failed" }];
+
+const workflowNodes: ComponentsNode[] = [
+  { id: "deploy", name: "Deploy to Droplet", type: "TYPE_ACTION", component: "noop" },
+  { id: "deploy-failed", name: "Deploy Failed", type: "TYPE_ACTION", component: "noop" },
+];
+
+function renderCanvas(
+  overrides: {
+    onEdgeCreate?: (sourceId: string, targetId: string, sourceHandle?: string | null) => void;
+  } = {},
+) {
+  render(
+    <MemoryRouter>
+      <CanvasPage
+        title="Canvas"
+        headerMode="default"
+        activeCanvasVersionId="draft-version"
+        isEditing
+        nodes={nodes}
+        edges={edges}
+        workflowNodes={workflowNodes}
+        buildingBlocks={[]}
+        {...overrides}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("CanvasPage connection validation", () => {
+  beforeEach(() => {
+    reactFlowPropsRef.current = null;
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  /*
+   * The repro from issue #5773: Deploy to Droplet -> Deploy Failed already
+   * exists, so wiring Deploy Failed back into Deploy to Droplet is refused
+   * while it is being dragged.
+   */
+  it("refuses a backward connection that would create a cycle", () => {
+    renderCanvas({ onEdgeCreate: vi.fn() });
+
+    const isValidConnection = reactFlowPropsRef.current?.isValidConnection;
+    expect(isValidConnection).toBeDefined();
+    expect(isValidConnection?.({ source: "deploy-failed", target: "deploy" })).toBe(false);
+  });
+
+  it("allows a forward connection", () => {
+    renderCanvas({ onEdgeCreate: vi.fn() });
+
+    expect(reactFlowPropsRef.current?.isValidConnection?.({ source: "deploy", target: "deploy-failed" })).toBe(true);
+  });
+
+  /*
+   * isValidConnection blocks the drag interaction. onConnect re-checks so a
+   * programmatic connection cannot slip an invalid edge past the guard.
+   */
+  it("does not create an edge when onConnect fires for a cycle-forming connection", () => {
+    const onEdgeCreate = vi.fn();
+    renderCanvas({ onEdgeCreate });
+
+    reactFlowPropsRef.current?.onConnect?.({
+      source: "deploy-failed",
+      target: "deploy",
+      sourceHandle: "default",
+    });
+
+    expect(onEdgeCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates an edge when onConnect fires for a valid connection", () => {
+    const onEdgeCreate = vi.fn();
+    renderCanvas({ onEdgeCreate });
+
+    reactFlowPropsRef.current?.onConnect?.({
+      source: "deploy",
+      target: "deploy-failed",
+      sourceHandle: "default",
+    });
+
+    expect(onEdgeCreate).toHaveBeenCalledWith("deploy", "deploy-failed", "default");
+  });
+});

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -97,6 +97,7 @@ import { CustomEdge } from "./CustomEdge";
 import { Header } from "./Header";
 import type { AgentSuggestion } from "./components/AgentSuggestionsHoverCard";
 import { isComponentSidebarVisibleMode } from "./canvasTabHeaderMode";
+import { wouldCreateCycle } from "./canvasGraphCycles";
 import { isCanvasNodeHighlighted, shouldBlankCanvasNodeBody } from "./nodeDimming";
 import { shouldRefitOnInit, stampFittedContentKey } from "./fitView";
 import { RightSideControls } from "./RightSideControls";
@@ -2477,15 +2478,32 @@ function CanvasContent({
   const onAnnotationBlurRef = useRef(onAnnotationBlur);
   onAnnotationBlurRef.current = onAnnotationBlur;
 
+  /*
+   * React Flow asks this for every candidate target while a connection is being
+   * dragged, so an edge the server would reject at publish time can never be
+   * drawn in the first place.
+   */
+  const isValidConnection = useCallback(
+    (connection: Connection | CanvasEdge) => {
+      if (!connection.source || !connection.target) {
+        return true;
+      }
+
+      return !wouldCreateCycle(workflowNodes ?? [], state.edges, connection.source, connection.target);
+    },
+    [workflowNodes, state.edges],
+  );
+
   const handleConnect = useCallback(
     (connection: Connection) => {
       if (isReadOnly) return;
       connectionCompletedRef.current = true;
-      if (onEdgeCreate && connection.source && connection.target) {
-        onEdgeCreate(connection.source, connection.target, connection.sourceHandle);
-      }
+      if (!connection.source || !connection.target) return;
+      if (!isValidConnection(connection)) return;
+
+      onEdgeCreate?.(connection.source, connection.target, connection.sourceHandle);
     },
-    [onEdgeCreate, isReadOnly],
+    [onEdgeCreate, isReadOnly, isValidConnection],
   );
 
   const handleDragOver = useCallback(
@@ -3290,6 +3308,7 @@ function CanvasContent({
             onNodesChange={handleNodesChange}
             onEdgesChange={handleEdgesChange}
             onConnect={isConnectionEditingEnabled ? handleConnect : undefined}
+            isValidConnection={isValidConnection}
             onConnectStart={isConnectionEditingEnabled ? handleConnectStart : undefined}
             onConnectEnd={isConnectionEditingEnabled ? handleConnectEnd : undefined}
             onDragOver={isReadOnly ? undefined : handleDragOver}


### PR DESCRIPTION
Closes #5773.

The canvas let any component's output be wired back into an upstream component's input. The server already rejects this — changesets.CheckForCycles runs a topological sort and only exempts edges whose target is a loop node — but nothing stopped the edge from being drawn and saved. The failure surfaced later, at publish time, as the bare message "graph contains a cycle", naming neither node.

Refuse the connection while it is being dragged. React Flow's isValidConnection is asked for every candidate target, so the invalid edge is never created and the user gets the standard "cannot drop here" affordance at the moment they are reaching for it.

wouldCreateCycle mirrors the server rule deliberately: edges whose target is a loop node are left out of the graph, so a loop node's input may still close a cycle while every other component's may not. The canvas should refuse exactly what the server would reject — no more, no less — so the two implementations are tested against the same cases, including the feedback-into-loop case from TestCheckForCycles_AllowsFeedbackIntoLoop. Only one edge is being added to an already-acyclic graph, so a reachability check is enough where the server runs a full topological sort.

onConnect re-checks before creating the edge. isValidConnection already blocks the drag, but the second check keeps a programmatic connection from slipping an invalid edge past the guard.

The validation reads the nodes and edges CanvasPage already receives, so no new prop is threaded through and pages/app/index.tsx is untouched — that file sits at its recorded max-lines budget.

For the cycles that do reach the server — an older canvas, the API, or the CLI — the publish-time error now names the nodes involved:

    graph contains a cycle: Deploy to Droplet -> Deploy Failed -> Deploy to Droplet

The nodes left unsorted by Kahn's algorithm are exactly those in or downstream of a cycle, so one concrete cycle is extracted from them and rendered in order. Entry points are sorted so the reported cycle is stable across runs. Nodes without a name fall back to their ID, and the message keeps its original prefix.