### PR TITLE
fix: use POST for Coolify deploy and lifecycle actions

### DIFF
--- a/docs/components/Coolify.mdx
+++ b/docs/components/Coolify.mdx
@@ -21,7 +21,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 **Setup steps:**
 
 1. **Base URL:** Use your Coolify instance URL (for example `https://coolify.example.com` for self-hosted, or `https://app.coolify.io` for Coolify Cloud).
-2. **API Token:** In Coolify, go to **Keys & Tokens → API tokens**, click **Create new token**, give it a name, select the required permissions (read + write), and copy the generated token.
+2. **API Token:** In Coolify, go to **Keys & Tokens → API tokens**, click **Create new token**, give it a name, select the **read** and **deploy** permissions (deploying and controlling applications/services requires `deploy`, not `write`), and copy the generated token.
 3. The API token is **team-scoped** — SuperPlane will see all applications and services available to that team.
 
 <a id="control-application"></a>
@@ -34,7 +34,7 @@ The Control Application component invokes a lifecycle operation on a Coolify app
 
 ### How It Works
 
-1. Calls `GET /api/v1/applications/{uuid}/{operation}` on the configured Coolify instance
+1. Calls `POST /api/v1/applications/{uuid}/{operation}` on the configured Coolify instance
 2. Emits the API confirmation message on the default output channel
 
 ### Configuration
@@ -66,7 +66,7 @@ The Control Service component invokes a lifecycle operation on a Coolify service
 
 ### How It Works
 
-1. Calls `GET /api/v1/services/{uuid}/{operation}` on the configured Coolify instance
+1. Calls `POST /api/v1/services/{uuid}/{operation}` on the configured Coolify instance
 2. Emits the API confirmation message on the default output channel
 
 ### Configuration
@@ -98,7 +98,7 @@ The Deploy Application component queues a deployment for a Coolify application. 
 
 ### How It Works
 
-1. Calls `GET /api/v1/deploy?uuid={uuid}&force={force}` on the configured Coolify instance
+1. Calls `POST /api/v1/deploy?uuid={uuid}&force={force}` on the configured Coolify instance
 2. Emits the queued deployment metadata (deployment UUID, message) on the default output channel and finishes immediately
 
 ### Configuration

--- a/pkg/integrations/coolify/client.go
+++ b/pkg/integrations/coolify/client.go
@@ -242,7 +242,7 @@ func (c *Client) ControlService(uuid string, op LifecycleOperation) (*LifecycleR
 }
 
 func (c *Client) lifecycle(path string, op LifecycleOperation) (*LifecycleResponse, error) {
-	resp, err := c.do(http.MethodGet, path, nil)
+	resp, err := c.do(http.MethodPost, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func (c *Client) Deploy(applicationUUID string, force bool) (*DeployResponse, er
 		query.Set("force", "true")
 	}
 
-	resp, err := c.do(http.MethodGet, "/deploy", query)
+	resp, err := c.do(http.MethodPost, "/deploy", query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/integrations/coolify/control_application.go
+++ b/pkg/integrations/coolify/control_application.go
@@ -36,7 +36,7 @@ func (c *ControlApplication) Documentation() string {
 
 ## How It Works
 
-1. Calls ` + "`GET /api/v1/applications/{uuid}/{operation}`" + ` on the configured Coolify instance
+1. Calls ` + "`POST /api/v1/applications/{uuid}/{operation}`" + ` on the configured Coolify instance
 2. Emits the API confirmation message on the default output channel
 
 ## Configuration

--- a/pkg/integrations/coolify/control_application_test.go
+++ b/pkg/integrations/coolify/control_application_test.go
@@ -77,7 +77,7 @@ func Test__Coolify_ControlApplication__Execute(t *testing.T) {
 		assert.Equal(t, "Application restarting.", data["message"])
 
 		require.Len(t, httpCtx.Requests, 1)
-		assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
+		assert.Equal(t, http.MethodPost, httpCtx.Requests[0].Method)
 		assert.Equal(t, "https://coolify.example.com/api/v1/applications/abc123/restart", httpCtx.Requests[0].URL.String())
 	})
 

--- a/pkg/integrations/coolify/control_service.go
+++ b/pkg/integrations/coolify/control_service.go
@@ -36,7 +36,7 @@ func (c *ControlService) Documentation() string {
 
 ## How It Works
 
-1. Calls ` + "`GET /api/v1/services/{uuid}/{operation}`" + ` on the configured Coolify instance
+1. Calls ` + "`POST /api/v1/services/{uuid}/{operation}`" + ` on the configured Coolify instance
 2. Emits the API confirmation message on the default output channel
 
 ## Configuration

--- a/pkg/integrations/coolify/control_service_test.go
+++ b/pkg/integrations/coolify/control_service_test.go
@@ -68,6 +68,7 @@ func Test__Coolify_ControlService__Execute(t *testing.T) {
 		assert.Equal(t, "Service starting.", data["message"])
 
 		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, http.MethodPost, httpCtx.Requests[0].Method)
 		assert.Equal(t, "https://coolify.example.com/api/v1/services/svc1/start", httpCtx.Requests[0].URL.String())
 	})
 }

--- a/pkg/integrations/coolify/coolify.go
+++ b/pkg/integrations/coolify/coolify.go
@@ -47,7 +47,7 @@ func (c *Coolify) Instructions() string {
 **Setup steps:**
 
 1. **Base URL:** Use your Coolify instance URL (for example ` + "`https://coolify.example.com`" + ` for self-hosted, or ` + "`https://app.coolify.io`" + ` for Coolify Cloud).
-2. **API Token:** In Coolify, go to **Keys & Tokens → API tokens**, click **Create new token**, give it a name, select the required permissions (read + write), and copy the generated token.
+2. **API Token:** In Coolify, go to **Keys & Tokens → API tokens**, click **Create new token**, give it a name, select the **read** and **deploy** permissions (deploying and controlling applications/services requires ` + "`deploy`" + `, not ` + "`write`" + `), and copy the generated token.
 3. The API token is **team-scoped** — SuperPlane will see all applications and services available to that team.
 `
 }
@@ -67,7 +67,7 @@ func (c *Coolify) Configuration() []configuration.Field {
 			Type:        configuration.FieldTypeString,
 			Required:    true,
 			Sensitive:   true,
-			Description: "Coolify API token (Keys & Tokens → API tokens) with read and write permissions",
+			Description: "Coolify API token (Keys & Tokens → API tokens) with read and deploy permissions",
 		},
 	}
 }

--- a/pkg/integrations/coolify/deploy_application.go
+++ b/pkg/integrations/coolify/deploy_application.go
@@ -36,7 +36,7 @@ func (c *DeployApplication) Documentation() string {
 
 ## How It Works
 
-1. Calls ` + "`GET /api/v1/deploy?uuid={uuid}&force={force}`" + ` on the configured Coolify instance
+1. Calls ` + "`POST /api/v1/deploy?uuid={uuid}&force={force}`" + ` on the configured Coolify instance
 2. Emits the queued deployment metadata (deployment UUID, message) on the default output channel and finishes immediately
 
 ## Configuration

--- a/pkg/integrations/coolify/deploy_application_test.go
+++ b/pkg/integrations/coolify/deploy_application_test.go
@@ -64,7 +64,7 @@ func Test__Coolify_DeployApplication__Execute(t *testing.T) {
 		assert.Equal(t, "Deployments queued.", data["message"])
 
 		require.Len(t, httpCtx.Requests, 1)
-		assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
+		assert.Equal(t, http.MethodPost, httpCtx.Requests[0].Method)
 
 		request := httpCtx.Requests[0]
 		assert.Equal(t, "/api/v1/deploy", request.URL.Path)


### PR DESCRIPTION
## Summary

`coolify.deployApplication`, `coolify.controlApplication`, and `coolify.controlService` all send their requests with `GET`. Current Coolify (`main` and the `v4.2.0` tag) has moved these routes to POST-only — the GET routes now hit a stub that returns `405 Method Not Allowed`. This PR switches all three to `POST` and corrects the setup instructions, which asked for the wrong token permission.

Fixes #6624

## Why

All three write-side Coolify actions currently fail on every execution against a current Coolify instance, including the restarts advertised by the shipped "Coolify Watcher" app template. This is a full, silent breakage of the integration's only state-changing actions with no workaround available in the product UI.

## Changes

- `pkg/integrations/coolify/client.go`: `lifecycle()` (backs `controlApplication`/`controlService`) and `Deploy()` now send `POST` instead of `GET`. No other change is needed — Coolify reads `uuid`/`force` via Laravel's request-input helpers, which merge the query string on POST too, and POST has been accepted on these routes since at least Coolify v4.1.0 (only GET was dropped), so this is an unconditional switch with no version detection or fallback required.
- `control_application.go`, `control_service.go`, `deploy_application.go`: updated the `Documentation()` strings that describe the HTTP call each component makes.
- `coolify.go`: corrected `Instructions()` and the `apiToken` field description. These routes are gated on Coolify's `deploy` ability, not `write` — a token created by following the old instructions verbatim would still get a 403 after the method fix.
- `docs/components/Coolify.mdx`: regenerated via `go run scripts/generate_components_docs.go` to reflect the above (read-only actions — `listApplications`/`listServices`/credential `Verify()` — are untouched and still use GET).
- Test updates: flipped the `http.MethodGet` assertions to `http.MethodPost` in `control_application_test.go` and `deploy_application_test.go`, and added a method assertion to `control_service_test.go`, which previously only checked the URL. `list_applications_test.go` is unchanged and keeps asserting `MethodGet` as the guard that read routes were left alone.

## Testing

Ran inside the project's Docker dev container (Go 1.26.2):

- `go test ./pkg/integrations/coolify/... -v` — all tests pass, including the flipped method assertions
- `go test ./pkg/integrations/... -p 1` — full integrations suite passes, no regressions elsewhere
- `gofmt -s -l pkg/integrations/coolify/` — clean
- `revive -formatter friendly -config lint.toml -exclude ./tmp/... ./pkg/integrations/coolify/...` — clean
- `go build cmd/server/main.go` — builds
- `go run scripts/check_example_payloads.go` — clean
- `go run scripts/check_configuration_fields.go` — clean
- `go run scripts/generate_components_docs.go` — regenerated `docs/components/`; diffed against the working tree to confirm only `Coolify.mdx` changed, and that only in the expected three lines plus the instructions text

## Notes / Trade-offs

- No backward-compatibility fallback to GET was added, since Coolify has accepted POST on these routes since v4.1.0 and the GET path is confirmed broken on current versions — keeping both would just mask the 405 case.
- I could not verify end-to-end against a live Coolify instance; verification here is at the HTTP-client/unit-test level (method + URL assertions against a mocked transport), matching how the rest of the integration's test suite is written.