### PR TITLE
fix: page keyset listings with a composite (created_at, id) cursor

### DIFF
--- a/pkg/agents/agent_tools/actions/read_runtime.go
+++ b/pkg/agents/agent_tools/actions/read_runtime.go
@@ -160,7 +160,7 @@ func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSession
 		if err != nil {
 			return nil, err
 		}
-		return protoPayload(canvasactions.ListRuns(ctx, database.DB(ctx), canvas, input.Limit, before, states, results))
+		return protoPayload(canvasactions.ListRuns(ctx, database.DB(ctx), canvas, input.Limit, before, input.BeforeID, states, results))
 	case "event_executions":
 		if strings.TrimSpace(input.EventID) == "" {
 			return nil, fmt.Errorf("event_id is required for event_executions")
@@ -178,17 +178,17 @@ func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSession
 		if err != nil {
 			return nil, err
 		}
-		return protoPayload(canvasactions.ListNodeExecutions(ctx, database.DB(ctx), canvas, input.NodeID, states, results, input.Limit, before))
+		return protoPayload(canvasactions.ListNodeExecutions(ctx, database.DB(ctx), canvas, input.NodeID, states, results, input.Limit, before, input.BeforeID))
 	case "node_queue_items":
 		if strings.TrimSpace(input.NodeID) == "" {
 			return nil, fmt.Errorf("node_id is required for node_queue_items")
 		}
-		return protoPayload(canvasactions.ListNodeQueueItems(ctx, database.DB(ctx), canvas, input.NodeID, input.Limit, before))
+		return protoPayload(canvasactions.ListNodeQueueItems(ctx, database.DB(ctx), canvas, input.NodeID, input.Limit, before, input.BeforeID))
 	case "node_events":
 		if strings.TrimSpace(input.NodeID) == "" {
 			return nil, fmt.Errorf("node_id is required for node_events")
 		}
-		return protoPayload(canvasactions.ListNodeEvents(ctx, database.DB(ctx), canvas, input.NodeID, input.Limit, before))
+		return protoPayload(canvasactions.ListNodeEvents(ctx, database.DB(ctx), canvas, input.NodeID, input.Limit, before, input.BeforeID))
 	case "runner_logs":
 		return a.readRunnerLogs(ctx, session, canvasID, input)
 	default:

--- a/pkg/agents/agent_tools/actions/types.go
+++ b/pkg/agents/agent_tools/actions/types.go
@@ -23,6 +23,7 @@ type Input struct {
 	RunID               string            `json:"run_id,omitempty"`
 	Limit               uint32            `json:"limit,omitempty"`
 	Before              string            `json:"before,omitempty"`
+	BeforeID            string            `json:"before_id,omitempty"`
 	States              []string          `json:"states,omitempty"`
 	Results             []string          `json:"results,omitempty"`
 	Path                string            `json:"path,omitempty"`

--- a/pkg/agents/agent_tools/app_agent_tool.go
+++ b/pkg/agents/agent_tools/app_agent_tool.go
@@ -184,6 +184,10 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 				Type:        "string",
 				Description: "For read_runtime paginated resources. RFC3339 timestamp cursor.",
 			},
+			"before_id": {
+				Type:        "string",
+				Description: "For read_runtime paginated resources. Id of the last row of the previous page, echoed back from last_id. Send it with before so rows sharing that timestamp are not skipped.",
+			},
 			"states": {
 				Type:        "array",
 				Description: "For read_runtime resources runs and node_executions. Use started/finished for runs; pending/started/finished for node executions.",

--- a/pkg/grpc/actions/canvases/list_canvas_versions.go
+++ b/pkg/grpc/actions/canvases/list_canvas_versions.go
@@ -2,7 +2,6 @@ package canvases
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
@@ -23,6 +22,7 @@ func ListCanvasVersionsPaginated(
 	canvas *models.Canvas,
 	limit uint32,
 	before *timestamppb.Timestamp,
+	beforeID string,
 ) (*pb.ListCanvasVersionsResponse, error) {
 	_, ok := authentication.GetUserIdFromMetadata(ctx)
 	if !ok {
@@ -30,9 +30,9 @@ func ListCanvasVersionsPaginated(
 	}
 
 	limit = getCanvasVersionLimit(limit)
-	beforeTime := getBefore(before)
+	cursor := getCursor(before, beforeID)
 
-	versions, count, err := listCanvasVersionHistory(ctx, canvas.ID, int(limit), beforeTime)
+	versions, count, err := listCanvasVersionHistory(ctx, canvas.ID, int(limit), cursor)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to list canvas versions")
 	}
@@ -44,6 +44,7 @@ func ListCanvasVersionsPaginated(
 		TotalCount:    uint32(count),
 		HasNextPage:   hasNextPage(len(versions), int(limit), count),
 		LastTimestamp: getLastCanvasVersionTimestamp(versions),
+		LastId:        getLastID(len(versions), func() uuid.UUID { return versions[len(versions)-1].ID }),
 	}, nil
 }
 
@@ -72,13 +73,13 @@ func getLastCanvasVersionTimestamp(versions []models.CanvasVersionMetadata) *tim
 	return timestamppb.New(*lastVersion.CreatedAt)
 }
 
-func listCanvasVersionHistory(ctx context.Context, canvasUUID uuid.UUID, limit int, beforeTime *time.Time) (versions []models.CanvasVersionMetadata, count int64, err error) {
+func listCanvasVersionHistory(ctx context.Context, canvasUUID uuid.UUID, limit int, cursor *models.KeysetCursor) (versions []models.CanvasVersionMetadata, count int64, err error) {
 	ctx, done := telemetry.Span(ctx, "canvases.list_version_history")
 	defer done(&err)
 
 	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
 		var txErr error
-		versions, txErr = models.ListCanvasVersionHistoryInTransaction(tx, canvasUUID, limit, beforeTime)
+		versions, txErr = models.ListCanvasVersionHistoryInTransaction(tx, canvasUUID, limit, cursor)
 		if txErr != nil {
 			return txErr
 		}

--- a/pkg/grpc/actions/canvases/list_canvas_versions_test.go
+++ b/pkg/grpc/actions/canvases/list_canvas_versions_test.go
@@ -42,7 +42,7 @@ func Test__ListCanvasVersionsPaginated(t *testing.T) {
 		secondCommit, err := CommitCanvasStaging(ctx, database.DB(t.Context()), r.GitProvider, nil, r.Encryptor, r.Registry, canvas, "Second", "", r.AuthService)
 		require.NoError(t, err)
 
-		response, err := ListCanvasVersionsPaginated(ctx, database.DB(t.Context()), canvas, 0, nil)
+		response, err := ListCanvasVersionsPaginated(ctx, database.DB(t.Context()), canvas, 0, nil, "")
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(response.GetVersions()), 2)
 		assert.Equal(t, secondCommit.GetVersion().GetMetadata().GetId(), response.GetVersions()[0].GetId())

--- a/pkg/grpc/actions/canvases/list_node_events.go
+++ b/pkg/grpc/actions/canvases/list_node_events.go
@@ -3,20 +3,21 @@ package canvases
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
 )
 
-func ListNodeEvents(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeEventsResponse, error) {
+func ListNodeEvents(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, limit uint32, before *timestamppb.Timestamp, beforeID string) (*pb.ListNodeEventsResponse, error) {
 	limit = getLimit(limit)
-	beforeTime := getBefore(before)
+	cursor := getCursor(before, beforeID)
 
 	//
 	// List and count events
 	//
-	events, err := models.ListCanvasEvents(db, canvas.ID, nodeID, int(limit), beforeTime)
+	events, err := models.ListCanvasEvents(db, canvas.ID, nodeID, int(limit), cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -36,5 +37,6 @@ func ListNodeEvents(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nod
 		TotalCount:    uint32(totalCount),
 		HasNextPage:   hasNextPage(len(events), int(limit), totalCount),
 		LastTimestamp: getLastEventTimestamp(events),
+		LastId:        getLastID(len(events), func() uuid.UUID { return events[len(events)-1].ID }),
 	}, nil
 }

--- a/pkg/grpc/actions/canvases/list_node_executions.go
+++ b/pkg/grpc/actions/canvases/list_node_executions.go
@@ -21,7 +21,7 @@ const (
 	MaxLimit     = 25
 )
 
-func ListNodeExecutions(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, pbStates []pb.CanvasNodeExecution_State, pbResults []pb.CanvasNodeExecution_Result, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeExecutionsResponse, error) {
+func ListNodeExecutions(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, pbStates []pb.CanvasNodeExecution_State, pbResults []pb.CanvasNodeExecution_Result, limit uint32, before *timestamppb.Timestamp, beforeID string) (*pb.ListNodeExecutionsResponse, error) {
 	_, err := models.FindCanvasNode(db, canvas.ID, nodeID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -42,12 +42,12 @@ func ListNodeExecutions(ctx context.Context, db *gorm.DB, canvas *models.Canvas,
 	}
 
 	limit = getLimit(limit)
-	beforeTime := getBefore(before)
+	cursor := getCursor(before, beforeID)
 
 	//
 	// List and count executions
 	//
-	executions, err := models.ListNodeExecutions(db, canvas.ID, nodeID, states, results, int(limit), beforeTime)
+	executions, err := models.ListNodeExecutions(db, canvas.ID, nodeID, states, results, int(limit), cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -72,6 +72,7 @@ func ListNodeExecutions(ctx context.Context, db *gorm.DB, canvas *models.Canvas,
 		TotalCount:    uint32(totalCount),
 		HasNextPage:   hasNextPage(len(executions), int(limit), totalCount),
 		LastTimestamp: getLastExecutionTimestamp(executions),
+		LastId:        getLastID(len(executions), func() uuid.UUID { return executions[len(executions)-1].ID }),
 	}, nil
 }
 
@@ -317,6 +318,34 @@ func getBefore(before *timestamppb.Timestamp) *time.Time {
 	}
 	t := before.AsTime()
 	return &t
+}
+
+// getCursor builds the keyset cursor for a listing request. beforeID is
+// optional: a request that only carries a timestamp pages the way it always
+// has, one that carries both can also cross rows sharing a created_at. An
+// unparseable id is treated as absent rather than an error, so a malformed
+// cursor degrades to the old behavior instead of failing the listing.
+func getCursor(before *timestamppb.Timestamp, beforeID string) *models.KeysetCursor {
+	beforeTime := getBefore(before)
+	if beforeTime == nil {
+		return nil
+	}
+
+	cursor := &models.KeysetCursor{CreatedAt: beforeTime}
+	if id, err := uuid.Parse(beforeID); err == nil {
+		cursor.ID = id
+	}
+
+	return cursor
+}
+
+// getLastID returns the id of the last row of a page, which the client echoes
+// back as before_id on the next request. Empty for an empty page.
+func getLastID(numResults int, last func() uuid.UUID) string {
+	if numResults == 0 {
+		return ""
+	}
+	return last().String()
 }
 
 func hasNextPage(numResults, limit int, totalCount int64) bool {

--- a/pkg/grpc/actions/canvases/list_node_executions_test.go
+++ b/pkg/grpc/actions/canvases/list_node_executions_test.go
@@ -51,6 +51,7 @@ func Test__ListNodeExecutions(t *testing.T) {
 			[]pb.CanvasNodeExecution_Result{},
 			0,
 			nil,
+			"",
 		)
 
 		//
@@ -105,6 +106,7 @@ func Test__ListNodeExecutions(t *testing.T) {
 			[]pb.CanvasNodeExecution_Result{},
 			0,
 			nil,
+			"",
 		)
 
 		//

--- a/pkg/grpc/actions/canvases/list_node_queue_items.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -13,14 +14,14 @@ import (
 	"gorm.io/gorm"
 )
 
-func ListNodeQueueItems(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeQueueItemsResponse, error) {
+func ListNodeQueueItems(ctx context.Context, db *gorm.DB, canvas *models.Canvas, nodeID string, limit uint32, before *timestamppb.Timestamp, beforeID string) (*pb.ListNodeQueueItemsResponse, error) {
 	limit = getLimit(limit)
-	beforeTime := getBefore(before)
+	cursor := getCursor(before, beforeID)
 
 	//
 	// List and count queue items
 	//
-	queueItems, err := models.ListNodeQueueItems(db, canvas.ID, nodeID, int(limit), beforeTime)
+	queueItems, err := models.ListNodeQueueItems(db, canvas.ID, nodeID, int(limit), cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -40,6 +41,7 @@ func ListNodeQueueItems(ctx context.Context, db *gorm.DB, canvas *models.Canvas,
 		TotalCount:    uint32(totalCount),
 		HasNextPage:   hasNextPage(len(queueItems), int(limit), totalCount),
 		LastTimestamp: getLastQueueItemTimestamp(queueItems),
+		LastId:        getLastID(len(queueItems), func() uuid.UUID { return queueItems[len(queueItems)-1].ID }),
 	}, nil
 }
 

--- a/pkg/grpc/actions/canvases/list_node_queue_items_test.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items_test.go
@@ -57,7 +57,7 @@ func Test__ListNodeQueueItems__ReturnsEmptyListWhenNoQueueItemsExist(t *testing.
 		[]models.Edge{},
 	)
 
-	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	assert.Empty(t, response.Items)
@@ -92,7 +92,7 @@ func Test__ListNodeQueueItems__ReturnsQueueItemsWithInputData(t *testing.T) {
 
 	queueItem := createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, nil)
 
-	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Items, 1)
@@ -138,7 +138,7 @@ func Test__ListNodeQueueItems__ReturnsQueueItemsWithRootEvent(t *testing.T) {
 
 	queueItem := createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, &rootEvent.ID)
 
-	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Items, 1)
@@ -178,7 +178,7 @@ func Test__ListNodeQueueItems__HandlesPaginationCorrectly(t *testing.T) {
 		queueItems = append(queueItems, *queueItem)
 	}
 
-	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 3, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 3, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Items, 3)
@@ -221,7 +221,7 @@ func Test__ListNodeQueueItems__FiltersQueueItemsByNodeID(t *testing.T) {
 	queueItem1 := createNodeQueueItem(t, canvas.ID, "node-1", inputEvent1.ID, nil)
 	createNodeQueueItem(t, canvas.ID, "node-2", inputEvent2.ID, nil)
 
-	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil)
+	response, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 10, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Items, 1)
@@ -257,15 +257,106 @@ func Test__ListNodeQueueItems__HandlesPaginationWithTimestamp(t *testing.T) {
 		createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, nil)
 	}
 
-	firstResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, nil)
+	firstResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, nil, "")
 	require.NoError(t, err)
 	require.Len(t, firstResponse.Items, 2)
 	assert.True(t, firstResponse.HasNextPage)
 
-	secondResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, firstResponse.LastTimestamp)
+	secondResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, firstResponse.LastTimestamp, "")
 	require.NoError(t, err)
 	require.Len(t, secondResponse.Items, 1)
 	assert.False(t, secondResponse.HasNextPage)
+}
+
+func Test__ListNodeQueueItems__PaginatesAcrossRowsSharingATimestamp(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "node-1",
+				Name:   "Node 1",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	//
+	// Three items sharing one created_at, the shape a batch insert produces.
+	// Paging two at a time ends page 1 inside the group, so the cursor has to
+	// carry the id to reach the third row - a timestamp alone excludes it.
+	//
+	sharedCreatedAt := time.Now().UTC().Truncate(time.Microsecond)
+	expectedIDs := []string{}
+	for i := 0; i < 3; i++ {
+		inputEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
+		queueItem := createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, nil)
+		require.NoError(t, database.Conn().
+			Model(&models.CanvasNodeQueueItem{}).
+			Where("id = ?", queueItem.ID).
+			Update("created_at", sharedCreatedAt).Error)
+		expectedIDs = append(expectedIDs, queueItem.ID.String())
+	}
+
+	firstResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, nil, "")
+	require.NoError(t, err)
+	require.Len(t, firstResponse.Items, 2)
+	require.NotEmpty(t, firstResponse.LastId)
+
+	secondResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, firstResponse.LastTimestamp, firstResponse.LastId)
+	require.NoError(t, err)
+	require.Len(t, secondResponse.Items, 1)
+
+	returnedIDs := []string{}
+	for _, item := range append(firstResponse.Items, secondResponse.Items...) {
+		returnedIDs = append(returnedIDs, item.Id)
+	}
+	assert.ElementsMatch(t, expectedIDs, returnedIDs, "no row sharing the boundary timestamp may be skipped")
+}
+
+func Test__ListNodeQueueItems__TimestampOnlyCursorKeepsWorking(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "node-1",
+				Name:   "Node 1",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	//
+	// A client that has not been updated sends `before` without `before_id`.
+	// Distinct timestamps, so it still pages the way it always has.
+	//
+	for i := 0; i < 3; i++ {
+		inputEvent := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
+		createNodeQueueItem(t, canvas.ID, "node-1", inputEvent.ID, nil)
+	}
+
+	firstResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, nil, "")
+	require.NoError(t, err)
+	require.Len(t, firstResponse.Items, 2)
+
+	secondResponse, err := ListNodeQueueItems(context.Background(), database.DB(t.Context()), canvas, "node-1", 2, firstResponse.LastTimestamp, "")
+	require.NoError(t, err)
+	require.Len(t, secondResponse.Items, 1)
 }
 
 func Test__SerializeNodeQueueItems__HandlesEmptyList(t *testing.T) {

--- a/pkg/grpc/actions/canvases/list_runs.go
+++ b/pkg/grpc/actions/canvases/list_runs.go
@@ -3,7 +3,6 @@ package canvases
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/database"
@@ -18,15 +17,15 @@ import (
 	"gorm.io/gorm"
 )
 
-func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uint32, before *timestamppb.Timestamp, states []pb.CanvasRun_State, results []pb.CanvasRun_Result) (*pb.ListRunsResponse, error) {
+func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uint32, before *timestamppb.Timestamp, beforeID string, states []pb.CanvasRun_State, results []pb.CanvasRun_Result) (*pb.ListRunsResponse, error) {
 	limit = getLimit(limit)
-	beforeTime := getBefore(before)
+	cursor := getCursor(before, beforeID)
 	filters, err := buildCanvasRunFilters(states, results)
 	if err != nil {
 		return nil, err
 	}
 
-	runs, err := listCanvasRuns(ctx, db, canvas.ID, int(limit), beforeTime, filters)
+	runs, err := listCanvasRuns(ctx, db, canvas.ID, int(limit), cursor, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +58,7 @@ func ListRuns(ctx context.Context, db *gorm.DB, canvas *models.Canvas, limit uin
 		TotalCount:    uint32(count),
 		HasNextPage:   hasNextPage(len(runs), int(limit), count),
 		LastTimestamp: getLastRunTimestamp(runs),
+		LastId:        getLastID(len(runs), func() uuid.UUID { return runs[len(runs)-1].ID }),
 	}, nil
 }
 
@@ -441,11 +441,11 @@ func serializeCanvasRuns(
 	return serialized, nil
 }
 
-func listCanvasRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, limit int, beforeTime *time.Time, filters models.CanvasRunFilters) (runs []models.CanvasRun, err error) {
+func listCanvasRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, limit int, cursor *models.KeysetCursor, filters models.CanvasRunFilters) (runs []models.CanvasRun, err error) {
 	ctx, done := telemetry.Span(ctx, "runs.list")
 	defer done(&err)
 
-	return models.ListCanvasRunsInTransaction(db, canvasID, limit, beforeTime, filters)
+	return models.ListCanvasRunsInTransaction(db, canvasID, limit, cursor, filters)
 }
 
 func countCanvasRuns(ctx context.Context, db *gorm.DB, canvasID uuid.UUID, filters models.CanvasRunFilters) (count int64, err error) {

--- a/pkg/grpc/actions/canvases/list_runs_test.go
+++ b/pkg/grpc/actions/canvases/list_runs_test.go
@@ -33,7 +33,7 @@ func Test__ListRuns__ReturnsRunsWithRootEventsAndExecutionRefs(t *testing.T) {
 	run := createFinishedRun(t, rootEvent, models.CanvasRunResultPassed)
 	execution := createRunExecution(t, run, rootEvent.ID, "node-1", models.CanvasNodeExecutionResultPassed)
 
-	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, "", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.Len(t, response.Runs, 1)
@@ -79,7 +79,7 @@ func Test__ListRuns__ReturnsRunsWithQueueItems(t *testing.T) {
 	createStartedRun(t, otherRootEvent)
 	support.CreateQueueItem(t, otherCanvas.ID, "trigger", otherRootEvent.ID, otherRootEvent.ID)
 
-	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvas, 0, nil, "", nil, nil)
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 2)
 
@@ -113,7 +113,7 @@ func Test__ListRuns__ScopesRunsToCanvas(t *testing.T) {
 	runOne := createFinishedRun(t, rootEventOne, models.CanvasRunResultPassed)
 	createFinishedRun(t, rootEventTwo, models.CanvasRunResultPassed)
 
-	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvasOne, 0, nil, nil, nil)
+	response, err := ListRuns(context.Background(), database.DB(t.Context()), canvasOne, 0, nil, "", nil, nil)
 	require.NoError(t, err)
 	require.Len(t, response.Runs, 1)
 	assert.Equal(t, runOne.ID.String(), response.Runs[0].Id)
@@ -143,6 +143,7 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 		canvas,
 		0,
 		nil,
+		"",
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_STARTED},
 		[]pb.CanvasRun_Result{pb.CanvasRun_RESULT_PASSED},
 	)
@@ -161,6 +162,7 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 		canvas,
 		0,
 		nil,
+		"",
 		nil,
 		[]pb.CanvasRun_Result{pb.CanvasRun_RESULT_FAILED, pb.CanvasRun_RESULT_CANCELLED},
 	)
@@ -178,6 +180,7 @@ func Test__ListRuns__FiltersByStateOrResult(t *testing.T) {
 		canvas,
 		0,
 		nil,
+		"",
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_STARTED},
 		nil,
 	)
@@ -205,6 +208,7 @@ func Test__ListRuns__RejectsUnknownFilterValues(t *testing.T) {
 		canvas,
 		0,
 		nil,
+		"",
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_UNKNOWN},
 		nil,
 	)
@@ -216,6 +220,7 @@ func Test__ListRuns__RejectsUnknownFilterValues(t *testing.T) {
 		canvas,
 		0,
 		nil,
+		"",
 		nil,
 		[]pb.CanvasRun_Result{pb.CanvasRun_RESULT_UNKNOWN},
 	)
@@ -264,6 +269,7 @@ func Test__ListRuns__ReturnsPendingSubRunWithoutRootEvent(t *testing.T) {
 		childCanvas,
 		0,
 		nil,
+		"",
 		[]pb.CanvasRun_State{pb.CanvasRun_STATE_PENDING},
 		nil,
 	)
@@ -273,7 +279,7 @@ func Test__ListRuns__ReturnsPendingSubRunWithoutRootEvent(t *testing.T) {
 	assert.Equal(t, pb.CanvasRun_STATE_PENDING, childResponse.Runs[0].State)
 	assert.Nil(t, childResponse.Runs[0].RootEvent)
 
-	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, nil, nil)
+	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, "", nil, nil)
 	require.NoError(t, err)
 	require.Len(t, parentResponse.Runs, 1)
 	require.Len(t, parentResponse.Runs[0].Executions, 1)
@@ -320,7 +326,7 @@ func Test__ListRuns__ReturnsSubRunRelationshipRefs(t *testing.T) {
 	childRootEvent := support.EmitCanvasEventForNode(t, childCanvas.ID, "onRun", "default", nil)
 	require.NoError(t, database.Conn().Model(&childRootEvent).Update("run_id", childRun.ID).Error)
 
-	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, nil, nil)
+	parentResponse, err := ListRuns(context.Background(), database.DB(t.Context()), parentCanvas, 0, nil, "", nil, nil)
 	require.NoError(t, err)
 	require.Len(t, parentResponse.Runs, 1)
 	require.Len(t, parentResponse.Runs[0].Executions, 1)

--- a/pkg/grpc/actions/factories/list_work_order_events.go
+++ b/pkg/grpc/actions/factories/list_work_order_events.go
@@ -3,8 +3,8 @@ package factories
 import (
 	"context"
 	"encoding/json"
-	"time"
 
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
@@ -34,7 +34,7 @@ func ListWorkOrderEvents(ctx context.Context, organizationID string, req *pb.Lis
 	}
 
 	limit := getWorkOrderEventsLimit(req.GetLimit())
-	before := getWorkOrderEventsBefore(req.GetBefore())
+	cursor := getWorkOrderEventsCursor(req.GetBefore(), req.GetBeforeId())
 
 	db := database.DB(ctx)
 	factory, err := models.FindFactory(db, orgID, factoryID)
@@ -47,7 +47,7 @@ func ListWorkOrderEvents(ctx context.Context, organizationID string, req *pb.Lis
 		return nil, factoryErrorToStatus(err, "failed to list work order events")
 	}
 
-	events, err := order.ListEvents(db, int(limit), before)
+	events, err := order.ListEvents(db, int(limit), cursor)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list work order events")
 	}
@@ -67,6 +67,7 @@ func ListWorkOrderEvents(ctx context.Context, organizationID string, req *pb.Lis
 		TotalCount:    uint32(totalCount),
 		HasNextPage:   hasWorkOrderEventsNextPage(len(events), int(limit), totalCount),
 		LastTimestamp: lastWorkOrderEventTimestamp(events),
+		LastId:        lastWorkOrderEventID(events),
 	}, nil
 }
 
@@ -114,17 +115,35 @@ func getWorkOrderEventsLimit(limit uint32) uint32 {
 	return limit
 }
 
-func getWorkOrderEventsBefore(before *timestamppb.Timestamp) *time.Time {
+// getWorkOrderEventsCursor builds the keyset cursor for the listing. beforeID
+// is optional: without it the cursor cannot cross rows sharing a created_at,
+// which is the behavior clients had before before_id existed.
+func getWorkOrderEventsCursor(before *timestamppb.Timestamp, beforeID string) *models.KeysetCursor {
 	if before == nil {
 		return nil
 	}
 
 	t := before.AsTime()
-	return &t
+	cursor := &models.KeysetCursor{CreatedAt: &t}
+	if id, err := uuid.Parse(beforeID); err == nil {
+		cursor.ID = id
+	}
+
+	return cursor
 }
 
 func hasWorkOrderEventsNextPage(numResults, limit int, totalCount int64) bool {
 	return int64(numResults) >= int64(limit) && int64(numResults) < totalCount
+}
+
+// lastWorkOrderEventID returns the id of the last row of the page, which the
+// client echoes back as before_id on the next request.
+func lastWorkOrderEventID(events []models.FactoryWorkOrderEvent) string {
+	if len(events) == 0 {
+		return ""
+	}
+
+	return events[len(events)-1].ID.String()
 }
 
 func lastWorkOrderEventTimestamp(events []models.FactoryWorkOrderEvent) *timestamppb.Timestamp {

--- a/pkg/grpc/canvas_service.go
+++ b/pkg/grpc/canvas_service.go
@@ -159,7 +159,7 @@ func (s *CanvasService) ListCanvasVersions(ctx context.Context, req *pb.ListCanv
 	if err != nil {
 		return nil, err
 	}
-	return canvases.ListCanvasVersionsPaginated(ctx, db, canvas, req.Limit, req.Before)
+	return canvases.ListCanvasVersionsPaginated(ctx, db, canvas, req.Limit, req.Before, req.BeforeId)
 }
 
 func (s *CanvasService) DescribeCanvasVersion(ctx context.Context, req *pb.DescribeCanvasVersionRequest) (*pb.DescribeCanvasVersionResponse, error) {
@@ -186,7 +186,7 @@ func (s *CanvasService) ListNodeQueueItems(ctx context.Context, req *pb.ListNode
 	if err != nil {
 		return nil, err
 	}
-	return canvases.ListNodeQueueItems(ctx, db, canvas, req.NodeId, req.Limit, req.Before)
+	return canvases.ListNodeQueueItems(ctx, db, canvas, req.NodeId, req.Limit, req.Before, req.BeforeId)
 }
 
 func (s *CanvasService) DeleteNodeQueueItem(ctx context.Context, req *pb.DeleteNodeQueueItemRequest) (*pb.DeleteNodeQueueItemResponse, error) {
@@ -204,7 +204,7 @@ func (s *CanvasService) ListNodeExecutions(ctx context.Context, req *pb.ListNode
 	if err != nil {
 		return nil, err
 	}
-	return canvases.ListNodeExecutions(ctx, db, canvas, req.NodeId, req.States, req.Results, req.Limit, req.Before)
+	return canvases.ListNodeExecutions(ctx, db, canvas, req.NodeId, req.States, req.Results, req.Limit, req.Before, req.BeforeId)
 }
 
 func (s *CanvasService) ListNodeEvents(ctx context.Context, req *pb.ListNodeEventsRequest) (*pb.ListNodeEventsResponse, error) {
@@ -218,7 +218,7 @@ func (s *CanvasService) ListNodeEvents(ctx context.Context, req *pb.ListNodeEven
 		return nil, status.Error(codes.InvalidArgument, "node_id is required")
 	}
 
-	return canvases.ListNodeEvents(ctx, db, canvas, req.NodeId, req.Limit, req.Before)
+	return canvases.ListNodeEvents(ctx, db, canvas, req.NodeId, req.Limit, req.Before, req.BeforeId)
 }
 
 func (s *CanvasService) ReemitTriggerEvent(ctx context.Context, req *pb.ReemitTriggerEventRequest) (*pb.ReemitTriggerEventResponse, error) {
@@ -301,7 +301,7 @@ func (s *CanvasService) ListRuns(ctx context.Context, req *pb.ListRunsRequest) (
 		return nil, err
 	}
 
-	return canvases.ListRuns(ctx, db, canvas, req.Limit, req.Before, req.States, req.Results)
+	return canvases.ListRuns(ctx, db, canvas, req.Limit, req.Before, req.BeforeId, req.States, req.Results)
 }
 
 func (s *CanvasService) DescribeRun(ctx context.Context, req *pb.DescribeRunRequest) (*pb.DescribeRunResponse, error) {

--- a/pkg/models/canvas_event.go
+++ b/pkg/models/canvas_event.go
@@ -143,7 +143,7 @@ func ListCanvasEventsByIDsInTransaction(tx *gorm.DB, ids []uuid.UUID) ([]CanvasE
 	return events, nil
 }
 
-func ListCanvasEvents(db *gorm.DB, canvasID uuid.UUID, nodeID string, limit int, before *time.Time) ([]CanvasEvent, error) {
+func ListCanvasEvents(db *gorm.DB, canvasID uuid.UUID, nodeID string, limit int, cursor *KeysetCursor) ([]CanvasEvent, error) {
 	var events []CanvasEvent
 	query := db.
 		Where("workflow_id = ?", canvasID).
@@ -153,11 +153,9 @@ func ListCanvasEvents(db *gorm.DB, canvasID uuid.UUID, nodeID string, limit int,
 		query = query.Limit(limit)
 	}
 
-	if before != nil {
-		query = query.Where("created_at < ?", before)
-	}
+	query = cursor.Apply(query)
 
-	err := query.Order("created_at DESC").Find(&events).Error
+	err := query.Order("created_at DESC, id DESC").Find(&events).Error
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/canvas_node.go
+++ b/pkg/models/canvas_node.go
@@ -448,18 +448,16 @@ func (i *CanvasNodeQueueItem) Delete(tx *gorm.DB) error {
 	return tx.Delete(i).Error
 }
 
-func ListNodeQueueItems(db *gorm.DB, workflowID uuid.UUID, nodeID string, limit int, beforeTime *time.Time) ([]CanvasNodeQueueItem, error) {
+func ListNodeQueueItems(db *gorm.DB, workflowID uuid.UUID, nodeID string, limit int, cursor *KeysetCursor) ([]CanvasNodeQueueItem, error) {
 	var queueItems []CanvasNodeQueueItem
 	query := db.
 		Preload("RootEvent").
 		Where("workflow_id = ?", workflowID).
 		Where("node_id = ?", nodeID).
-		Order("created_at DESC").
+		Order("created_at DESC, id DESC").
 		Limit(int(limit))
 
-	if beforeTime != nil {
-		query = query.Where("created_at < ?", beforeTime)
-	}
+	query = cursor.Apply(query)
 
 	err := query.Find(&queueItems).Error
 	if err != nil {

--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -191,12 +191,12 @@ func LockPendingNodeExecutionInActiveCanvas(tx *gorm.DB, id uuid.UUID) (*CanvasN
 	return &execution, nil
 }
 
-func ListNodeExecutions(db *gorm.DB, workflowID uuid.UUID, nodeID string, states []string, results []string, limit int, beforeTime *time.Time) ([]CanvasNodeExecution, error) {
+func ListNodeExecutions(db *gorm.DB, workflowID uuid.UUID, nodeID string, states []string, results []string, limit int, cursor *KeysetCursor) ([]CanvasNodeExecution, error) {
 	var executions []CanvasNodeExecution
 	query := db.
 		Where("workflow_id = ?", workflowID).
 		Where("node_id = ?", nodeID).
-		Order("created_at DESC").
+		Order("created_at DESC, id DESC").
 		Limit(int(limit))
 
 	if len(states) > 0 {
@@ -207,9 +207,7 @@ func ListNodeExecutions(db *gorm.DB, workflowID uuid.UUID, nodeID string, states
 		query = query.Where("result IN ?", results)
 	}
 
-	if beforeTime != nil {
-		query = query.Where("created_at < ?", beforeTime)
-	}
+	query = cursor.Apply(query)
 
 	err := query.Find(&executions).Error
 	if err != nil {

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -471,22 +471,19 @@ type CanvasRunFilters struct {
 	Results []string
 }
 
-func ListCanvasRuns(workflowID uuid.UUID, limit int, beforeTime *time.Time, filters CanvasRunFilters) ([]CanvasRun, error) {
-	return ListCanvasRunsInTransaction(database.Conn(), workflowID, limit, beforeTime, filters)
+func ListCanvasRuns(workflowID uuid.UUID, limit int, cursor *KeysetCursor, filters CanvasRunFilters) ([]CanvasRun, error) {
+	return ListCanvasRunsInTransaction(database.Conn(), workflowID, limit, cursor, filters)
 }
 
-func ListCanvasRunsInTransaction(tx *gorm.DB, workflowID uuid.UUID, limit int, beforeTime *time.Time, filters CanvasRunFilters) ([]CanvasRun, error) {
+func ListCanvasRunsInTransaction(tx *gorm.DB, workflowID uuid.UUID, limit int, cursor *KeysetCursor, filters CanvasRunFilters) ([]CanvasRun, error) {
 	var runs []CanvasRun
 	query := tx.
 		Where("workflow_id = ?", workflowID).
-		Order("created_at DESC").
+		Order("created_at DESC, id DESC").
 		Limit(limit)
 
 	query = applyCanvasRunFilters(query, filters)
-
-	if beforeTime != nil {
-		query = query.Where("created_at < ?", beforeTime)
-	}
+	query = cursor.Apply(query)
 
 	err := query.Find(&runs).Error
 	if err != nil {

--- a/pkg/models/canvas_version.go
+++ b/pkg/models/canvas_version.go
@@ -159,7 +159,7 @@ func ListCanvasVersionHistoryInTransaction(
 	tx *gorm.DB,
 	workflowID uuid.UUID,
 	limit int,
-	before *time.Time,
+	cursor *KeysetCursor,
 ) ([]CanvasVersionMetadata, error) {
 	query := tx.
 		Model(&CanvasVersion{}).
@@ -167,9 +167,7 @@ func ListCanvasVersionHistoryInTransaction(
 		Where("workflow_id = ?", workflowID).
 		Order("created_at DESC, id DESC")
 
-	if before != nil {
-		query = query.Where("created_at < ?", *before)
-	}
+	query = cursor.Apply(query)
 
 	if limit > 0 {
 		query = query.Limit(limit)

--- a/pkg/models/factory_work_order.go
+++ b/pkg/models/factory_work_order.go
@@ -356,16 +356,14 @@ func (o *FactoryWorkOrder) ReplaceAssignees(tx *gorm.DB, assigneeIDs []uuid.UUID
 	return tx.Create(&assignees).Error
 }
 
-func (o *FactoryWorkOrder) ListEvents(tx *gorm.DB, limit int, before *time.Time) ([]FactoryWorkOrderEvent, error) {
+func (o *FactoryWorkOrder) ListEvents(tx *gorm.DB, limit int, cursor *KeysetCursor) ([]FactoryWorkOrderEvent, error) {
 	query := tx.Where("work_order_id = ?", o.ID)
 
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
 
-	if before != nil {
-		query = query.Where("created_at < ?", before)
-	}
+	query = cursor.Apply(query)
 
 	var events []FactoryWorkOrderEvent
 	err := query.

--- a/pkg/models/keyset_cursor.go
+++ b/pkg/models/keyset_cursor.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// KeysetCursor addresses a position in a listing ordered by
+// (created_at DESC, id DESC).
+//
+// The id half is what lets the cursor land inside a group of rows sharing a
+// created_at. With a timestamp alone, a page that ends inside such a group
+// leaves a cursor of that timestamp, and "created_at < cursor" then excludes
+// every remaining row of the group - those rows are not duplicated, they are
+// dropped. Equal timestamps are ordinary: batch inserts share one now(), and
+// Postgres stores microsecond precision.
+//
+// ID is optional so that clients sending only a timestamp keep the behavior
+// they have today.
+type KeysetCursor struct {
+	CreatedAt *time.Time
+	ID        uuid.UUID
+}
+
+// Apply adds the cursor's WHERE clause to query. The caller is responsible for
+// ordering by created_at DESC, id DESC - the comparison only pages correctly
+// against that order.
+func (c *KeysetCursor) Apply(query *gorm.DB) *gorm.DB {
+	if c == nil || c.CreatedAt == nil {
+		return query
+	}
+
+	if c.ID == uuid.Nil {
+		return query.Where("created_at < ?", c.CreatedAt)
+	}
+
+	return query.Where("(created_at, id) < (?, ?)", c.CreatedAt, c.ID)
+}

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -507,6 +507,9 @@ message ListCanvasVersionsRequest {
   string canvas_id = 1;
   uint32 limit = 2;
   google.protobuf.Timestamp before = 3;
+  // Id of the last row of the previous page. Echo `last_id` back together
+  // with `before` so rows sharing that timestamp are not skipped.
+  string before_id = 4;
 }
 
 message ListCanvasVersionsResponse {
@@ -514,6 +517,7 @@ message ListCanvasVersionsResponse {
   uint32 total_count = 2;
   bool has_next_page = 3;
   google.protobuf.Timestamp last_timestamp = 4;
+  string last_id = 5;
 }
 
 message DescribeCanvasVersionRequest {
@@ -629,6 +633,9 @@ message ListNodeEventsRequest {
   string node_id = 2;
   uint32 limit = 3;
   google.protobuf.Timestamp before = 4;
+  // Id of the last row of the previous page. Echo `last_id` back together
+  // with `before` so rows sharing that timestamp are not skipped.
+  string before_id = 5;
 }
 
 message ListNodeEventsResponse {
@@ -636,6 +643,7 @@ message ListNodeEventsResponse {
   uint32 total_count = 2;
   bool has_next_page = 3;
   google.protobuf.Timestamp last_timestamp = 4;
+  string last_id = 5;
 }
 
 message ReemitTriggerEventRequest {
@@ -653,6 +661,9 @@ message ListNodeQueueItemsRequest {
   string node_id = 2;
   uint32 limit = 3;
   google.protobuf.Timestamp before = 4;
+  // Id of the last row of the previous page. Echo `last_id` back together
+  // with `before` so rows sharing that timestamp are not skipped.
+  string before_id = 5;
 }
 
 message ListNodeQueueItemsResponse {
@@ -660,6 +671,7 @@ message ListNodeQueueItemsResponse {
   uint32 total_count = 2;
   bool has_next_page = 3;
   google.protobuf.Timestamp last_timestamp = 4;
+  string last_id = 5;
 }
 
 message DeleteNodeQueueItemRequest {
@@ -677,6 +689,9 @@ message ListNodeExecutionsRequest {
   repeated CanvasNodeExecution.Result results = 4;
   uint32 limit = 5;
   google.protobuf.Timestamp before = 6;
+  // Id of the last row of the previous page. Echo `last_id` back together
+  // with `before` so rows sharing that timestamp are not skipped.
+  string before_id = 7;
 }
 
 message ListNodeExecutionsResponse {
@@ -684,6 +699,7 @@ message ListNodeExecutionsResponse {
   uint32 total_count = 2;
   bool has_next_page = 3;
   google.protobuf.Timestamp last_timestamp = 4;
+  string last_id = 5;
 }
 
 //
@@ -783,6 +799,9 @@ message ListRunsRequest {
   google.protobuf.Timestamp before = 3;
   repeated CanvasRun.State states = 4;
   repeated CanvasRun.Result results = 5;
+  // Id of the last row of the previous page. Echo `last_id` back together
+  // with `before` so rows sharing that timestamp are not skipped.
+  string before_id = 6;
 }
 
 message ListRunsResponse {
@@ -790,6 +809,7 @@ message ListRunsResponse {
   uint32 total_count = 2;
   bool has_next_page = 3;
   google.protobuf.Timestamp last_timestamp = 4;
+  string last_id = 5;
 }
 
 message DescribeRunRequest {

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -496,6 +496,9 @@ message ListWorkOrderEventsRequest {
   string order_id = 2;
   uint32 limit = 3;
   google.protobuf.Timestamp before = 4;
+  // Id of the last row of the previous page. Echo `last_id` back together
+  // with `before` so rows sharing that timestamp are not skipped.
+  string before_id = 5;
 }
 
 message ListWorkOrderEventsResponse {
@@ -503,6 +506,7 @@ message ListWorkOrderEventsResponse {
   uint32 total_count = 2;
   bool has_next_page = 3;
   google.protobuf.Timestamp last_timestamp = 4;
+  string last_id = 5;
 }
 
 message WorkOrderEvent {


### PR DESCRIPTION
The canvas and factory listings paged with a bare created_at cursor and a strict "created_at < ?". When rows share a created_at, a page that ends inside that group leaves the group's timestamp as the cursor, and the next page excludes every remaining row of the group - those rows are not duplicated, they are dropped. Equal timestamps are ordinary rather than unlucky: batch inserts share one now(), and Postgres stores microsecond precision.

Adds a shared models.KeysetCursor carrying both halves of the ordering key and applying "(created_at, id) < (?, ?)", the shape agent_session_message.go already uses. All six listings now order by created_at DESC, id DESC to match.

The API cursor gains an additive, optional before_id on each request and last_id on each response, mirroring agents.proto. A cursor without an id falls back to the old timestamp-only comparison, so clients that have not been updated keep the behavior they have today. The read_runtime agent tool gets the same before_id input.

Verified against Postgres: the new regression test fails on the old comparison with page 2 returning 0 of the 3 rows sharing a timestamp, and passes with the composite cursor. A second test covers the timestamp-only path that older clients use.

Fixes #6627