### PR TITLE
feat: add Storybook-only Factories wiki wireframe

### DIFF
--- a/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
+++ b/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ComponentType } from "react";
 import { MemoryRouter, Navigate, Outlet, Route, Routes } from "react-router-dom";
 
 import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
@@ -64,6 +64,11 @@ function fixtureFetchState(): FixtureFetchState {
   return state;
 }
 
+/** Storybook-only route swaps. App routes ignore this. */
+export interface OrgWorkspacePageOverrides {
+  wiki?: ComponentType;
+}
+
 export interface OrgWorkspaceHarnessProps {
   /** Where to land when the story mounts. */
   startAt?: "home" | "app";
@@ -82,6 +87,8 @@ export interface OrgWorkspaceHarnessProps {
   factoriesFixture?: FactoriesFixture;
   /** Storybook-only: seed post-install Agent improvement suggestions for the canvas. */
   agentSuggestions?: AgentSuggestion[];
+  /** Storybook-only: replace selected factory page elements (e.g. wiki wireframe). */
+  pageOverrides?: OrgWorkspacePageOverrides;
 }
 
 interface FixtureFetchOptions {
@@ -145,7 +152,9 @@ function factoryRoute(element: React.ReactNode) {
   return <RequireExperimentalFeature featureId={FEATURE_FACTORIES}>{element}</RequireExperimentalFeature>;
 }
 
-function OrgWorkspaceRoutes() {
+function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePageOverrides }) {
+  const WikiRoutePage = pageOverrides?.wiki ?? WikiPage;
+
   return (
     <Routes>
       <Route
@@ -165,7 +174,7 @@ function OrgWorkspaceRoutes() {
             <Route index element={<Navigate to="overview" replace />} />
             <Route path="overview" element={<OverviewPage />} />
             <Route path="missions" element={<MissionsPage />} />
-            <Route path="wiki" element={<WikiPage />} />
+            <Route path="wiki" element={<WikiRoutePage />} />
             <Route path="velocity" element={<VelocityPage />} />
             <Route path="work-orders">
               <Route index element={<WorkOrdersPage />} />
@@ -219,6 +228,7 @@ export function OrgWorkspaceHarness({
   appFixture,
   factoriesFixture,
   agentSuggestions,
+  pageOverrides,
 }: OrgWorkspaceHarnessProps) {
   const { orgId, canvasId } = resolveWorkspaceIds(homeFixture, appFixture, factoriesFixture);
   useOrgWorkspaceFixtureFetch({
@@ -251,7 +261,7 @@ export function OrgWorkspaceHarness({
           <div className="h-dvh w-full overflow-auto">
             <MemoryRouter initialEntries={[initialPath]}>
               <AccountProvider>
-                <OrgWorkspaceRoutes />
+                <OrgWorkspaceRoutes pageOverrides={pageOverrides} />
               </AccountProvider>
             </MemoryRouter>
           </div>

--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.tsx
@@ -1,4 +1,4 @@
-import { OrgWorkspaceHarness } from "@/pages/__fixtures__/OrgWorkspaceHarness";
+import { OrgWorkspaceHarness, type OrgWorkspacePageOverrides } from "@/pages/__fixtures__/OrgWorkspaceHarness";
 import type { HomePageFixture } from "@/pages/home/__fixtures__/handlers";
 import { defaultHomePageFixture } from "@/pages/home/__fixtures__/homePageResponses";
 
@@ -9,6 +9,8 @@ interface FactoriesHarnessProps {
   pathSuffix?: string;
   /** Fixture backing the factories API. Defaults to the populated Refunds Factory dataset. */
   factoriesFixture?: FactoriesFixture;
+  /** Storybook-only: replace selected factory page elements (e.g. wiki wireframe). */
+  pageOverrides?: OrgWorkspacePageOverrides;
 }
 
 /**
@@ -19,6 +21,7 @@ interface FactoriesHarnessProps {
 export function FactoriesHarness({
   pathSuffix = "workspaces",
   factoriesFixture = defaultFactoriesFixture,
+  pageOverrides,
 }: FactoriesHarnessProps) {
   const homeFixture: HomePageFixture = {
     ...defaultHomePageFixture,
@@ -37,6 +40,7 @@ export function FactoriesHarness({
       pathSuffix={pathSuffix}
       homeFixture={homeFixture}
       factoriesFixture={factoriesFixture}
+      pageOverrides={pageOverrides}
     />
   );
 }

--- a/web_src/src/pages/factories/pages/Wiki.stories.tsx
+++ b/web_src/src/pages/factories/pages/Wiki.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
+import { defaultFactoriesFixture, PRIMARY_FACTORY_ID } from "../__fixtures__/factoryPageResponses";
+import { WikiWireframe } from "./wiki/WikiWireframe";
+import { WIKI_DOCUMENTS_DEFAULT } from "./wiki/wikiMocks";
+
+/**
+ * Storybook-only wiki wireframe inside FactoriesLayout.
+ * The app `/wiki` route still renders Coming Soon.
+ */
+const meta = {
+  title: "Factories/Pages/Wiki",
+  parameters: { layout: "fullscreen" },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const wikiPath = `workspaces/${PRIMARY_FACTORY_ID}/wiki`;
+
+function DefaultWikiWireframe() {
+  return <WikiWireframe />;
+}
+
+function EmptyWikiWireframe() {
+  return <WikiWireframe initialDocuments={[]} />;
+}
+
+function EditingWikiWireframe() {
+  return <WikiWireframe initialDocuments={WIKI_DOCUMENTS_DEFAULT} startEditing />;
+}
+
+export const Default: Story = {
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={wikiPath}
+      factoriesFixture={defaultFactoriesFixture}
+      pageOverrides={{ wiki: DefaultWikiWireframe }}
+    />
+  ),
+};
+
+export const Empty: Story = {
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={wikiPath}
+      factoriesFixture={defaultFactoriesFixture}
+      pageOverrides={{ wiki: EmptyWikiWireframe }}
+    />
+  ),
+};
+
+export const Editing: Story = {
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={wikiPath}
+      factoriesFixture={defaultFactoriesFixture}
+      pageOverrides={{ wiki: EditingWikiWireframe }}
+    />
+  ),
+};

--- a/web_src/src/pages/factories/pages/Wiki.stories.tsx
+++ b/web_src/src/pages/factories/pages/Wiki.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import { defaultFactoriesFixture, PRIMARY_FACTORY_ID } from "../__fixtures__/factoryPageResponses";
 import { WikiWireframe } from "./wiki/WikiWireframe";
-import { WIKI_DOCUMENTS_DEFAULT } from "./wiki/wikiMocks";
+import { WIKI_DOCUMENTS_DEFAULT, WIKI_DOCUMENTS_REFRESHED } from "./wiki/wikiMocks";
 
 /**
  * Storybook-only wiki wireframe inside FactoriesLayout.
@@ -21,15 +21,21 @@ type Story = StoryObj<typeof meta>;
 const wikiPath = `workspaces/${PRIMARY_FACTORY_ID}/wiki`;
 
 function DefaultWikiWireframe() {
-  return <WikiWireframe />;
+  return <WikiWireframe initialDocuments={WIKI_DOCUMENTS_DEFAULT} refreshedDocuments={WIKI_DOCUMENTS_REFRESHED} />;
 }
 
 function EmptyWikiWireframe() {
-  return <WikiWireframe initialDocuments={[]} />;
+  return <WikiWireframe initialDocuments={[]} refreshedDocuments={WIKI_DOCUMENTS_REFRESHED} />;
 }
 
 function EditingWikiWireframe() {
-  return <WikiWireframe initialDocuments={WIKI_DOCUMENTS_DEFAULT} startEditing />;
+  return (
+    <WikiWireframe
+      initialDocuments={WIKI_DOCUMENTS_DEFAULT}
+      refreshedDocuments={WIKI_DOCUMENTS_REFRESHED}
+      startEditing
+    />
+  );
 }
 
 export const Default: Story = {

--- a/web_src/src/pages/factories/pages/wiki/WikiWireframe.tsx
+++ b/web_src/src/pages/factories/pages/wiki/WikiWireframe.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { ChevronRight, FileText, Folder } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -209,6 +209,65 @@ function WikiDocumentPane({
   return <WikiDocumentReader document={selected} onEdit={onStartEdit} />;
 }
 
+function WikiWireframeHeader({ refreshing, onRefresh }: { refreshing: boolean; onRefresh: () => void }) {
+  return (
+    <header className="flex shrink-0 items-end justify-between gap-4 border-b border-border bg-background px-8 py-6">
+      <div className="min-w-0">
+        <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
+          Wiki
+        </Heading>
+        <p className={cn("mt-1", factoryPageSubtitleClassName)}>
+          Shared product context — intent, architecture, and delivery notes for people and Planner.
+        </p>
+      </div>
+      <Button type="button" variant="outline" size="sm" className="shrink-0" disabled={refreshing} onClick={onRefresh}>
+        {refreshing ? "Refreshing…" : "Refresh knowledge"}
+      </Button>
+    </header>
+  );
+}
+
+function WikiTreeAside({
+  documents,
+  tree,
+  selectedId,
+  expanded,
+  onToggle,
+  onSelect,
+}: {
+  documents: WikiDocument[];
+  tree: WikiTreeNode[];
+  selectedId: string | null;
+  expanded: Set<string>;
+  onToggle: (path: string) => void;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <aside className="flex w-[240px] shrink-0 flex-col border-r border-border bg-muted/40">
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+        {documents.length === 0 ? (
+          <p className="px-2 text-[13px] text-muted-foreground">No documents yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-0.5">
+            {tree.map((node) => (
+              <TreeNode
+                key={node.kind === "folder" ? `folder:${node.name}` : node.document.id}
+                node={node}
+                depth={0}
+                path={node.name}
+                selectedId={selectedId}
+                expanded={expanded}
+                onToggle={onToggle}
+                onSelect={onSelect}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}
+
 /**
  * Storybook-only wiki wireframe (v3 parity). Not mounted on the app `/wiki` route.
  * Mock corpora must be passed from stories — this component holds no sample documents.
@@ -221,21 +280,25 @@ export function WikiWireframe({
   const initialSelected = initialDocuments[0] ?? null;
   const [documents, setDocuments] = useState<WikiDocument[]>(initialDocuments);
   const [selectedId, setSelectedId] = useState<string | null>(initialSelected?.id ?? null);
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-  const [treeReady, setTreeReady] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(wikiFolderPaths(buildWikiTree(initialDocuments))),
+  );
   const [editing, setEditing] = useState(startEditing);
   const [draftTitle, setDraftTitle] = useState(initialSelected?.title ?? "");
   const [draftContent, setDraftContent] = useState(initialSelected?.content ?? "");
   const [refreshing, setRefreshing] = useState(false);
+  const refreshTimeoutRef = useRef<number | null>(null);
 
   const tree = useMemo(() => buildWikiTree(documents), [documents]);
   const selected = documents.find((doc) => doc.id === selectedId) ?? null;
 
   useEffect(() => {
-    if (treeReady || tree.length === 0) return;
-    setExpanded(new Set(wikiFolderPaths(tree)));
-    setTreeReady(true);
-  }, [tree, treeReady]);
+    return () => {
+      if (refreshTimeoutRef.current !== null) {
+        window.clearTimeout(refreshTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!selected) {
@@ -248,94 +311,41 @@ export function WikiWireframe({
     if (!startEditing) setEditing(false);
   }, [selected, startEditing]);
 
-  function toggleFolder(path: string) {
-    setExpanded((current) => {
-      const next = new Set(current);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      return next;
-    });
-  }
-
-  function saveEdit() {
-    if (!selected) return;
-    setDocuments((current) =>
-      current.map((doc) =>
-        doc.id === selected.id ? { ...doc, title: draftTitle.trim() || doc.title, content: draftContent } : doc,
-      ),
-    );
-    setEditing(false);
-  }
-
-  function cancelEdit() {
-    if (!selected) {
-      setEditing(false);
-      return;
-    }
-    setDraftTitle(selected.title);
-    setDraftContent(selected.content);
-    setEditing(false);
-  }
-
-  function refreshKnowledge() {
-    if (refreshing) return;
-    setRefreshing(true);
-    window.setTimeout(() => {
-      setDocuments(refreshedDocuments);
-      setSelectedId(refreshedDocuments[0]?.id ?? null);
-      setExpanded(new Set());
-      setTreeReady(false);
-      setEditing(false);
-      setRefreshing(false);
-    }, 800);
-  }
-
   return (
     <div className="flex h-screen min-h-0 flex-col" data-testid="wiki-wireframe">
-      <header className="flex shrink-0 items-end justify-between gap-4 border-b border-border bg-background px-8 py-6">
-        <div className="min-w-0">
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            Wiki
-          </Heading>
-          <p className={cn("mt-1", factoryPageSubtitleClassName)}>
-            Shared product context — intent, architecture, and delivery notes for people and Planner.
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="shrink-0"
-          disabled={refreshing}
-          onClick={refreshKnowledge}
-        >
-          {refreshing ? "Refreshing…" : "Refresh knowledge"}
-        </Button>
-      </header>
+      <WikiWireframeHeader
+        refreshing={refreshing}
+        onRefresh={() => {
+          if (refreshing) return;
+          setRefreshing(true);
+          refreshTimeoutRef.current = window.setTimeout(() => {
+            refreshTimeoutRef.current = null;
+            const nextTree = buildWikiTree(refreshedDocuments);
+            setDocuments(refreshedDocuments);
+            setSelectedId(refreshedDocuments[0]?.id ?? null);
+            setExpanded(new Set(wikiFolderPaths(nextTree)));
+            setEditing(false);
+            setRefreshing(false);
+          }, 800);
+        }}
+      />
 
       <div className="flex min-h-0 flex-1">
-        <aside className="flex w-[240px] shrink-0 flex-col border-r border-border bg-muted/40">
-          <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
-            {documents.length === 0 ? (
-              <p className="px-2 text-[13px] text-muted-foreground">No documents yet.</p>
-            ) : (
-              <ul className="flex flex-col gap-0.5">
-                {tree.map((node) => (
-                  <TreeNode
-                    key={node.kind === "folder" ? `folder:${node.name}` : node.document.id}
-                    node={node}
-                    depth={0}
-                    path={node.name}
-                    selectedId={selectedId}
-                    expanded={expanded}
-                    onToggle={toggleFolder}
-                    onSelect={setSelectedId}
-                  />
-                ))}
-              </ul>
-            )}
-          </div>
-        </aside>
+        <WikiTreeAside
+          documents={documents}
+          tree={tree}
+          selectedId={selectedId}
+          expanded={expanded}
+          onToggle={(path) => {
+            setExpanded((current) => {
+              const next = new Set(current);
+              if (next.has(path)) next.delete(path);
+              else next.add(path);
+              return next;
+            });
+          }}
+          onSelect={setSelectedId}
+        />
 
         <section className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
           <WikiDocumentPane
@@ -345,8 +355,24 @@ export function WikiWireframe({
             draftContent={draftContent}
             onDraftTitleChange={setDraftTitle}
             onDraftContentChange={setDraftContent}
-            onCancelEdit={cancelEdit}
-            onSaveEdit={saveEdit}
+            onCancelEdit={() => {
+              if (selected) {
+                setDraftTitle(selected.title);
+                setDraftContent(selected.content);
+              }
+              setEditing(false);
+            }}
+            onSaveEdit={() => {
+              if (!selected) return;
+              setDocuments((current) =>
+                current.map((doc) =>
+                  doc.id === selected.id
+                    ? { ...doc, title: draftTitle.trim() || doc.title, content: draftContent }
+                    : doc,
+                ),
+              );
+              setEditing(false);
+            }}
             onStartEdit={() => setEditing(true)}
           />
         </section>

--- a/web_src/src/pages/factories/pages/wiki/WikiWireframe.tsx
+++ b/web_src/src/pages/factories/pages/wiki/WikiWireframe.tsx
@@ -9,17 +9,13 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { factoryPageSubtitleClassName, factoryPageTitleClassName } from "../factoryPageLayoutStyles";
-import {
-  buildWikiTree,
-  wikiFolderPaths,
-  WIKI_DOCUMENTS_DEFAULT,
-  WIKI_DOCUMENTS_REFRESHED,
-  type WikiDocument,
-  type WikiTreeNode,
-} from "./wikiMocks";
+import { buildWikiTree, wikiFolderPaths, type WikiDocument, type WikiTreeNode } from "./wikiMocks";
 
 export type WikiWireframeProps = {
+  /** Documents shown when the wireframe mounts. Supplied by stories — no baked-in fixtures. */
   initialDocuments?: WikiDocument[];
+  /** Corpus swapped in by “Refresh knowledge”. Supplied by stories. */
+  refreshedDocuments?: WikiDocument[];
   /** Story helper — start in edit mode when a doc is selected. */
   startEditing?: boolean;
 };
@@ -103,17 +99,133 @@ function TreeNode({
   );
 }
 
+function WikiDocumentEditor({
+  document,
+  draftTitle,
+  draftContent,
+  onDraftTitleChange,
+  onDraftContentChange,
+  onCancel,
+  onSave,
+}: {
+  document: WikiDocument;
+  draftTitle: string;
+  draftContent: string;
+  onDraftTitleChange: (value: string) => void;
+  onDraftContentChange: (value: string) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-[720px] flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <Input
+            value={draftTitle}
+            onChange={(event) => onDraftTitleChange(event.target.value)}
+            aria-label="Document title"
+            className="h-9 text-[15px] font-medium"
+          />
+          <p className="mt-1 text-[12px] text-muted-foreground">{document.path}</p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="button" size="sm" onClick={onSave}>
+            Save
+          </Button>
+        </div>
+      </div>
+      <Textarea
+        value={draftContent}
+        onChange={(event) => onDraftContentChange(event.target.value)}
+        aria-label="Document content"
+        spellCheck={false}
+        className="min-h-[420px] resize-y font-mono text-[13px] leading-relaxed"
+      />
+    </div>
+  );
+}
+
+function WikiDocumentReader({ document, onEdit }: { document: WikiDocument; onEdit: () => void }) {
+  return (
+    <div className="mx-auto w-full max-w-[720px]">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-foreground">{document.title}</h2>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">{document.path}</p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={onEdit}>
+          Edit
+        </Button>
+      </div>
+      <div className="prose-wiki text-[13px] leading-relaxed text-foreground [&_code]:rounded [&_code]:bg-accent [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[12px] [&_h1]:mb-3 [&_h1]:text-[22px] [&_h1]:font-semibold [&_h1]:tracking-[-0.02em] [&_h2]:mt-5 [&_h2]:mb-2 [&_h2]:text-[15px] [&_h2]:font-semibold [&_li]:my-0.5 [&_p]:my-2 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-border [&_pre]:bg-accent/40 [&_pre]:p-3 [&_pre]:text-[12px] [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5">
+        <Markdown remarkPlugins={[remarkGfm]}>{document.content}</Markdown>
+      </div>
+    </div>
+  );
+}
+
+function WikiDocumentPane({
+  selected,
+  editing,
+  draftTitle,
+  draftContent,
+  onDraftTitleChange,
+  onDraftContentChange,
+  onCancelEdit,
+  onSaveEdit,
+  onStartEdit,
+}: {
+  selected: WikiDocument | null;
+  editing: boolean;
+  draftTitle: string;
+  draftContent: string;
+  onDraftTitleChange: (value: string) => void;
+  onDraftContentChange: (value: string) => void;
+  onCancelEdit: () => void;
+  onSaveEdit: () => void;
+  onStartEdit: () => void;
+}) {
+  if (!selected) {
+    return <p className="text-[13px] text-muted-foreground">Select a document to read or edit.</p>;
+  }
+
+  if (editing) {
+    return (
+      <WikiDocumentEditor
+        document={selected}
+        draftTitle={draftTitle}
+        draftContent={draftContent}
+        onDraftTitleChange={onDraftTitleChange}
+        onDraftContentChange={onDraftContentChange}
+        onCancel={onCancelEdit}
+        onSave={onSaveEdit}
+      />
+    );
+  }
+
+  return <WikiDocumentReader document={selected} onEdit={onStartEdit} />;
+}
+
 /**
  * Storybook-only wiki wireframe (v3 parity). Not mounted on the app `/wiki` route.
+ * Mock corpora must be passed from stories — this component holds no sample documents.
  */
-export function WikiWireframe({ initialDocuments = WIKI_DOCUMENTS_DEFAULT, startEditing = false }: WikiWireframeProps) {
+export function WikiWireframe({
+  initialDocuments = [],
+  refreshedDocuments = [],
+  startEditing = false,
+}: WikiWireframeProps) {
+  const initialSelected = initialDocuments[0] ?? null;
   const [documents, setDocuments] = useState<WikiDocument[]>(initialDocuments);
-  const [selectedId, setSelectedId] = useState<string | null>(initialDocuments[0]?.id ?? null);
+  const [selectedId, setSelectedId] = useState<string | null>(initialSelected?.id ?? null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [treeReady, setTreeReady] = useState(false);
   const [editing, setEditing] = useState(startEditing);
-  const [draftTitle, setDraftTitle] = useState("");
-  const [draftContent, setDraftContent] = useState("");
+  const [draftTitle, setDraftTitle] = useState(initialSelected?.title ?? "");
+  const [draftContent, setDraftContent] = useState(initialSelected?.content ?? "");
   const [refreshing, setRefreshing] = useState(false);
 
   const tree = useMemo(() => buildWikiTree(documents), [documents]);
@@ -155,12 +267,22 @@ export function WikiWireframe({ initialDocuments = WIKI_DOCUMENTS_DEFAULT, start
     setEditing(false);
   }
 
+  function cancelEdit() {
+    if (!selected) {
+      setEditing(false);
+      return;
+    }
+    setDraftTitle(selected.title);
+    setDraftContent(selected.content);
+    setEditing(false);
+  }
+
   function refreshKnowledge() {
     if (refreshing) return;
     setRefreshing(true);
     window.setTimeout(() => {
-      setDocuments(WIKI_DOCUMENTS_REFRESHED);
-      setSelectedId(WIKI_DOCUMENTS_REFRESHED[0]?.id ?? null);
+      setDocuments(refreshedDocuments);
+      setSelectedId(refreshedDocuments[0]?.id ?? null);
       setExpanded(new Set());
       setTreeReady(false);
       setEditing(false);
@@ -216,62 +338,17 @@ export function WikiWireframe({ initialDocuments = WIKI_DOCUMENTS_DEFAULT, start
         </aside>
 
         <section className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
-          {!selected ? (
-            <p className="text-[13px] text-muted-foreground">Select a document to read or edit.</p>
-          ) : editing ? (
-            <div className="mx-auto flex w-full max-w-[720px] flex-col gap-3">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1">
-                  <Input
-                    value={draftTitle}
-                    onChange={(event) => setDraftTitle(event.target.value)}
-                    aria-label="Document title"
-                    className="h-9 text-[15px] font-medium"
-                  />
-                  <p className="mt-1 text-[12px] text-muted-foreground">{selected.path}</p>
-                </div>
-                <div className="flex shrink-0 gap-2">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setDraftTitle(selected.title);
-                      setDraftContent(selected.content);
-                      setEditing(false);
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                  <Button type="button" size="sm" onClick={saveEdit}>
-                    Save
-                  </Button>
-                </div>
-              </div>
-              <Textarea
-                value={draftContent}
-                onChange={(event) => setDraftContent(event.target.value)}
-                aria-label="Document content"
-                spellCheck={false}
-                className="min-h-[420px] resize-y font-mono text-[13px] leading-relaxed"
-              />
-            </div>
-          ) : (
-            <div className="mx-auto w-full max-w-[720px]">
-              <div className="mb-4 flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-foreground">{selected.title}</h2>
-                  <p className="mt-0.5 text-[12px] text-muted-foreground">{selected.path}</p>
-                </div>
-                <Button type="button" variant="outline" size="sm" onClick={() => setEditing(true)}>
-                  Edit
-                </Button>
-              </div>
-              <div className="prose-wiki text-[13px] leading-relaxed text-foreground [&_code]:rounded [&_code]:bg-accent [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[12px] [&_h1]:mb-3 [&_h1]:text-[22px] [&_h1]:font-semibold [&_h1]:tracking-[-0.02em] [&_h2]:mt-5 [&_h2]:mb-2 [&_h2]:text-[15px] [&_h2]:font-semibold [&_li]:my-0.5 [&_p]:my-2 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-border [&_pre]:bg-accent/40 [&_pre]:p-3 [&_pre]:text-[12px] [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5">
-                <Markdown remarkPlugins={[remarkGfm]}>{selected.content}</Markdown>
-              </div>
-            </div>
-          )}
+          <WikiDocumentPane
+            selected={selected}
+            editing={editing}
+            draftTitle={draftTitle}
+            draftContent={draftContent}
+            onDraftTitleChange={setDraftTitle}
+            onDraftContentChange={setDraftContent}
+            onCancelEdit={cancelEdit}
+            onSaveEdit={saveEdit}
+            onStartEdit={() => setEditing(true)}
+          />
         </section>
       </div>
     </div>

--- a/web_src/src/pages/factories/pages/wiki/WikiWireframe.tsx
+++ b/web_src/src/pages/factories/pages/wiki/WikiWireframe.tsx
@@ -1,0 +1,279 @@
+import { Heading } from "@/components/Heading/heading";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { ChevronRight, FileText, Folder } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { factoryPageSubtitleClassName, factoryPageTitleClassName } from "../factoryPageLayoutStyles";
+import {
+  buildWikiTree,
+  wikiFolderPaths,
+  WIKI_DOCUMENTS_DEFAULT,
+  WIKI_DOCUMENTS_REFRESHED,
+  type WikiDocument,
+  type WikiTreeNode,
+} from "./wikiMocks";
+
+export type WikiWireframeProps = {
+  initialDocuments?: WikiDocument[];
+  /** Story helper — start in edit mode when a doc is selected. */
+  startEditing?: boolean;
+};
+
+function TreeNode({
+  node,
+  depth,
+  path,
+  selectedId,
+  expanded,
+  onToggle,
+  onSelect,
+}: {
+  node: WikiTreeNode;
+  depth: number;
+  path: string;
+  selectedId: string | null;
+  expanded: Set<string>;
+  onToggle: (path: string) => void;
+  onSelect: (id: string) => void;
+}) {
+  if (node.kind === "file") {
+    const active = selectedId === node.document.id;
+    return (
+      <li>
+        <button
+          type="button"
+          title={node.document.path}
+          onClick={() => onSelect(node.document.id)}
+          className={cn(
+            "flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left text-[13px]",
+            active ? "bg-sidebar-accent text-foreground" : "text-foreground/80 hover:bg-sidebar-accent/70",
+          )}
+          style={{ paddingLeft: 8 + depth * 12 }}
+        >
+          <span className="size-3.5 shrink-0" aria-hidden />
+          <FileText className="size-3.5 shrink-0 opacity-70" strokeWidth={1.75} />
+          <span className="truncate">{node.name}</span>
+        </button>
+      </li>
+    );
+  }
+
+  const open = expanded.has(path);
+  return (
+    <li>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => onToggle(path)}
+        className="flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left text-[13px] text-foreground/80 hover:bg-sidebar-accent/70"
+        style={{ paddingLeft: 8 + depth * 12 }}
+      >
+        <ChevronRight
+          className={cn("size-3.5 shrink-0 opacity-70 transition-transform", open && "rotate-90")}
+          strokeWidth={1.75}
+        />
+        <Folder className="size-3.5 shrink-0 opacity-70" strokeWidth={1.75} />
+        <span className="truncate">{node.name}</span>
+      </button>
+      {open ? (
+        <ul>
+          {node.children.map((child) => {
+            const childPath = child.kind === "folder" ? `${path}/${child.name}` : path;
+            return (
+              <TreeNode
+                key={child.kind === "folder" ? `folder:${childPath}` : child.document.id}
+                node={child}
+                depth={depth + 1}
+                path={child.kind === "folder" ? childPath : path}
+                selectedId={selectedId}
+                expanded={expanded}
+                onToggle={onToggle}
+                onSelect={onSelect}
+              />
+            );
+          })}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * Storybook-only wiki wireframe (v3 parity). Not mounted on the app `/wiki` route.
+ */
+export function WikiWireframe({ initialDocuments = WIKI_DOCUMENTS_DEFAULT, startEditing = false }: WikiWireframeProps) {
+  const [documents, setDocuments] = useState<WikiDocument[]>(initialDocuments);
+  const [selectedId, setSelectedId] = useState<string | null>(initialDocuments[0]?.id ?? null);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [treeReady, setTreeReady] = useState(false);
+  const [editing, setEditing] = useState(startEditing);
+  const [draftTitle, setDraftTitle] = useState("");
+  const [draftContent, setDraftContent] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+
+  const tree = useMemo(() => buildWikiTree(documents), [documents]);
+  const selected = documents.find((doc) => doc.id === selectedId) ?? null;
+
+  useEffect(() => {
+    if (treeReady || tree.length === 0) return;
+    setExpanded(new Set(wikiFolderPaths(tree)));
+    setTreeReady(true);
+  }, [tree, treeReady]);
+
+  useEffect(() => {
+    if (!selected) {
+      setDraftTitle("");
+      setDraftContent("");
+      return;
+    }
+    setDraftTitle(selected.title);
+    setDraftContent(selected.content);
+    if (!startEditing) setEditing(false);
+  }, [selected, startEditing]);
+
+  function toggleFolder(path: string) {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  function saveEdit() {
+    if (!selected) return;
+    setDocuments((current) =>
+      current.map((doc) =>
+        doc.id === selected.id ? { ...doc, title: draftTitle.trim() || doc.title, content: draftContent } : doc,
+      ),
+    );
+    setEditing(false);
+  }
+
+  function refreshKnowledge() {
+    if (refreshing) return;
+    setRefreshing(true);
+    window.setTimeout(() => {
+      setDocuments(WIKI_DOCUMENTS_REFRESHED);
+      setSelectedId(WIKI_DOCUMENTS_REFRESHED[0]?.id ?? null);
+      setExpanded(new Set());
+      setTreeReady(false);
+      setEditing(false);
+      setRefreshing(false);
+    }, 800);
+  }
+
+  return (
+    <div className="flex h-screen min-h-0 flex-col" data-testid="wiki-wireframe">
+      <header className="flex shrink-0 items-end justify-between gap-4 border-b border-border bg-background px-8 py-6">
+        <div className="min-w-0">
+          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
+            Wiki
+          </Heading>
+          <p className={cn("mt-1", factoryPageSubtitleClassName)}>
+            Shared product context — intent, architecture, and delivery notes for people and Planner.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          disabled={refreshing}
+          onClick={refreshKnowledge}
+        >
+          {refreshing ? "Refreshing…" : "Refresh knowledge"}
+        </Button>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <aside className="flex w-[240px] shrink-0 flex-col border-r border-border bg-muted/40">
+          <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+            {documents.length === 0 ? (
+              <p className="px-2 text-[13px] text-muted-foreground">No documents yet.</p>
+            ) : (
+              <ul className="flex flex-col gap-0.5">
+                {tree.map((node) => (
+                  <TreeNode
+                    key={node.kind === "folder" ? `folder:${node.name}` : node.document.id}
+                    node={node}
+                    depth={0}
+                    path={node.name}
+                    selectedId={selectedId}
+                    expanded={expanded}
+                    onToggle={toggleFolder}
+                    onSelect={setSelectedId}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </aside>
+
+        <section className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
+          {!selected ? (
+            <p className="text-[13px] text-muted-foreground">Select a document to read or edit.</p>
+          ) : editing ? (
+            <div className="mx-auto flex w-full max-w-[720px] flex-col gap-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <Input
+                    value={draftTitle}
+                    onChange={(event) => setDraftTitle(event.target.value)}
+                    aria-label="Document title"
+                    className="h-9 text-[15px] font-medium"
+                  />
+                  <p className="mt-1 text-[12px] text-muted-foreground">{selected.path}</p>
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setDraftTitle(selected.title);
+                      setDraftContent(selected.content);
+                      setEditing(false);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button type="button" size="sm" onClick={saveEdit}>
+                    Save
+                  </Button>
+                </div>
+              </div>
+              <Textarea
+                value={draftContent}
+                onChange={(event) => setDraftContent(event.target.value)}
+                aria-label="Document content"
+                spellCheck={false}
+                className="min-h-[420px] resize-y font-mono text-[13px] leading-relaxed"
+              />
+            </div>
+          ) : (
+            <div className="mx-auto w-full max-w-[720px]">
+              <div className="mb-4 flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-foreground">{selected.title}</h2>
+                  <p className="mt-0.5 text-[12px] text-muted-foreground">{selected.path}</p>
+                </div>
+                <Button type="button" variant="outline" size="sm" onClick={() => setEditing(true)}>
+                  Edit
+                </Button>
+              </div>
+              <div className="prose-wiki text-[13px] leading-relaxed text-foreground [&_code]:rounded [&_code]:bg-accent [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[12px] [&_h1]:mb-3 [&_h1]:text-[22px] [&_h1]:font-semibold [&_h1]:tracking-[-0.02em] [&_h2]:mt-5 [&_h2]:mb-2 [&_h2]:text-[15px] [&_h2]:font-semibold [&_li]:my-0.5 [&_p]:my-2 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-border [&_pre]:bg-accent/40 [&_pre]:p-3 [&_pre]:text-[12px] [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5">
+                <Markdown remarkPlugins={[remarkGfm]}>{selected.content}</Markdown>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/wiki/wikiMocks.ts
+++ b/web_src/src/pages/factories/pages/wiki/wikiMocks.ts
@@ -60,9 +60,7 @@ export function buildWikiTree(documents: WikiDocument[]): WikiTreeNode[] {
   function freeze(nodes: Map<string, MutableNode>): WikiTreeNode[] {
     return Array.from(nodes.values())
       .map((node) =>
-        node.kind === "folder"
-          ? { kind: "folder" as const, name: node.name, children: freeze(node.children) }
-          : node,
+        node.kind === "folder" ? { kind: "folder" as const, name: node.name, children: freeze(node.children) } : node,
       )
       .sort(compareNodes);
   }

--- a/web_src/src/pages/factories/pages/wiki/wikiMocks.ts
+++ b/web_src/src/pages/factories/pages/wiki/wikiMocks.ts
@@ -1,0 +1,506 @@
+export type WikiDocument = {
+  id: string;
+  path: string;
+  title: string;
+  content: string;
+};
+
+export type WikiTreeFile = {
+  kind: "file";
+  name: string;
+  document: WikiDocument;
+};
+
+export type WikiTreeFolder = {
+  kind: "folder";
+  name: string;
+  children: WikiTreeNode[];
+};
+
+export type WikiTreeNode = WikiTreeFile | WikiTreeFolder;
+
+function compareNodes(left: WikiTreeNode, right: WikiTreeNode): number {
+  if (left.kind !== right.kind) return left.kind === "file" ? -1 : 1;
+  return left.name.localeCompare(right.name);
+}
+
+export function buildWikiTree(documents: WikiDocument[]): WikiTreeNode[] {
+  type MutableFolder = {
+    kind: "folder";
+    name: string;
+    children: Map<string, MutableNode>;
+  };
+  type MutableNode = WikiTreeFile | MutableFolder;
+
+  const root = new Map<string, MutableNode>();
+
+  for (const document of documents) {
+    const parts = document.path.split("/").filter(Boolean);
+    if (parts.length === 0) continue;
+
+    let current = root;
+    for (let index = 0; index < parts.length; index += 1) {
+      const part = parts[index];
+      const isFile = index === parts.length - 1;
+      if (isFile) {
+        current.set(part, { kind: "file", name: part, document });
+        continue;
+      }
+      const existing = current.get(part);
+      if (existing?.kind === "folder") {
+        current = existing.children;
+        continue;
+      }
+      const folder: MutableFolder = { kind: "folder", name: part, children: new Map() };
+      current.set(part, folder);
+      current = folder.children;
+    }
+  }
+
+  function freeze(nodes: Map<string, MutableNode>): WikiTreeNode[] {
+    return Array.from(nodes.values())
+      .map((node) =>
+        node.kind === "folder"
+          ? { kind: "folder" as const, name: node.name, children: freeze(node.children) }
+          : node,
+      )
+      .sort(compareNodes);
+  }
+
+  return freeze(root);
+}
+
+export function wikiFolderPaths(nodes: WikiTreeNode[], prefix = ""): string[] {
+  const paths: string[] = [];
+  for (const node of nodes) {
+    if (node.kind !== "folder") continue;
+    const path = prefix ? `${prefix}/${node.name}` : node.name;
+    paths.push(path, ...wikiFolderPaths(node.children, path));
+  }
+  return paths;
+}
+
+export const WIKI_DOCUMENTS_DEFAULT: WikiDocument[] = [
+  {
+    id: "overview",
+    path: "overview.md",
+    title: "Overview",
+    content: `# SuperPlane
+
+SuperPlane is an open source automation engine for AI-driven engineering.
+
+It orchestrates workflows across Git, LLMs, CI/CD, observability, incident tools, and infrastructure — with durable execution, approvals, and an operational UI.
+
+## What it does
+
+- Version apps in git (\`canvas.yaml\`, \`console.yaml\`) with guardrails for agents and humans
+- Run event-driven, multi-step workflows that outgrow a single script or CI job
+- Give each app a console dashboard backed by live memory, runs, and executions
+
+## Status
+
+Beta. Self-host the core engine or use [SuperPlane Cloud](https://app.superplane.com). Docs: [docs.superplane.com](https://docs.superplane.com).
+
+## Example use cases
+
+- PR preview environments
+- Policy-gated production deploy
+- Progressive delivery (10% → 50% → 100%)
+- Multi-repo release trains
+- First-five-minutes incident triage
+`,
+  },
+  {
+    id: "team",
+    path: "team.md",
+    title: "Team",
+    content: `# Team
+
+## Roles in the product
+
+- **Operators** — design canvases, approve gated steps, run consoles day to day
+- **App agents** — per-app assistants that help design workflows and debug runs
+- **External coding agents** — CLI and [skills](https://github.com/superplanehq/skills) under the same RBAC
+
+## Ownership
+
+Apps are git-backed deployable units. Humans own approvals and policy; agents operate inside those guardrails.
+
+## Community
+
+- GitHub: [superplanehq/superplane](https://github.com/superplanehq/superplane)
+- Discord: [discord.superplane.com](https://discord.superplane.com)
+`,
+  },
+  {
+    id: "feat-apps-canvases",
+    path: "features/apps-and-canvases.md",
+    title: "Apps and canvases",
+    content: `# Apps and canvases
+
+An **app** is a deployable unit: workflow graph, console UI, app-scoped memory, and deterministic execution. It is versioned in git via \`canvas.yaml\` and \`console.yaml\`.
+
+A **canvas** is a graph of steps and dependencies. One canvas can express multiple workflows and run them concurrently.
+
+## How runs start
+
+Incoming events match triggers and start runs with the event payload as input. Steps are components (triggers or actions), built-in or integration-backed.
+`,
+  },
+  {
+    id: "feat-components",
+    path: "features/components-and-integrations.md",
+    title: "Components and integrations",
+    content: `# Components and integrations
+
+Each canvas node is a **component**: a trigger or an action that performs one task (deploy, open an incident, notify, wait, require approval, call an LLM, etc.).
+
+Integrations ship triggers and actions for tools teams already use:
+
+- AI & LLM — Claude, Cursor, OpenAI, …
+- Version control & CI/CD — GitHub, GitLab, Semaphore, CircleCI, …
+- Cloud & infra — AWS, GCP, Azure, Cloudflare, …
+- Observability — Datadog, Grafana, Sentry, Prometheus, …
+- Incident & comms — PagerDuty, Rootly, Slack, Teams, …
+
+Full catalog: [docs.superplane.com/components](https://docs.superplane.com/components/).
+`,
+  },
+  {
+    id: "feat-console",
+    path: "features/console.md",
+    title: "Console",
+    content: `# Console
+
+Each app can define an operational **console**: a dynamic grid of panels in \`console.yaml\`.
+
+Typical panel jobs:
+
+- KPIs, tables, and charts from memory and run data
+- Runbooks and pinned canvas nodes
+- Workflow controls for operators
+
+Consoles are the day-2 surface for watching and steering durable workflows without leaving SuperPlane.
+`,
+  },
+  {
+    id: "feat-memory",
+    path: "features/memory.md",
+    title: "Memory",
+    content: `# Memory
+
+**Memory** is app-scoped (and canvas-aware) JSON storage that persists across runs.
+
+Use it to hold shared state workflows and consoles need between executions — evidence packs, ship-set readiness, rollout percentages, operator notes — without bolting on an external store for every app.
+`,
+  },
+  {
+    id: "feat-agents",
+    path: "features/agents-and-operators.md",
+    title: "Agents and operators",
+    content: `# Agents and operators
+
+## Built-in app agent
+
+Each app includes an agent that helps design workflows and debug runs inside the same RBAC as human operators.
+
+## External agents
+
+CLI and SuperPlane skills let coding agents interact with apps programmatically. All paths share access control, secrets, and approval gates.
+
+## Operators
+
+Humans approve policy gates, inspect consoles, and intervene when a durable run needs a decision.
+`,
+  },
+  {
+    id: "feat-runs",
+    path: "features/runs.md",
+    title: "Runs and durable execution",
+    content: `# Runs and durable execution
+
+A **run** is one execution of a workflow path on a canvas. SuperPlane tracks runs, run items, and payloads across restarts.
+
+## Why it matters
+
+- Failed steps can resume without custom retry glue
+- Approvals and waits are first-class steps, not out-of-band tickets
+- Execution stays deterministic so humans and AI share the same guardrails
+
+Event → trigger match → run → durable step progression.
+`,
+  },
+  {
+    id: "arch-backend",
+    path: "architecture/backend.md",
+    title: "Backend",
+    content: `# Backend
+
+Go service exposing a **gRPC** API with a REST/OpenAPI gateway.
+
+## Layout
+
+- \`cmd/\` — server, workers, CLI entrypoints
+- \`pkg/grpc/actions\` — gRPC API implementation
+- \`pkg/models\` — database models (explicit \`*gorm.DB\` / tx first)
+- \`pkg/workers\` — background workers
+- \`protos/\` — API definitions; codegen via \`make pb.gen\`
+- \`db/\` — structure and migrations
+
+## Infra
+
+PostgreSQL for state, RabbitMQ for messaging. Dev and many installs run via Docker Compose.
+`,
+  },
+  {
+    id: "arch-frontend",
+    path: "architecture/frontend.md",
+    title: "Frontend",
+    content: `# Frontend
+
+TypeScript + React app in \`web_src/\`, built with Vite.
+
+- Generated API client: \`web_src/src/api-client/\` (from \`make pb.gen\`)
+- Integration UI mappers: \`web_src/src/pages/app/mappers/<integration>/\`
+- Shared non-React helpers live in \`web_src/src/lib/\` (not \`utils/\`)
+
+Local UI after \`make dev.server\`: [http://localhost:8000](http://localhost:8000). See \`web_src/AGENTS.md\` for UI-specific conventions.
+`,
+  },
+  {
+    id: "arch-execution",
+    path: "architecture/execution-and-workers.md",
+    title: "Execution and workers",
+    content: `# Execution and workers
+
+Durable execution is carried by Go workers under \`pkg/workers\`, started from \`cmd/server\`.
+
+Workers consume RabbitMQ messages, advance run items, call integration actions, and persist progress in PostgreSQL so runs survive process restarts.
+
+When adding a worker: register startup in \`cmd/server/main.go\` and update compose env as needed.
+`,
+  },
+  {
+    id: "arch-integrations",
+    path: "architecture/integrations.md",
+    title: "Integrations package layout",
+    content: `# Integrations package layout
+
+Integration implementations live under \`pkg/integrations/<integration>/\`.
+
+UI configuration mappers for the same provider live under \`web_src/src/pages/app/mappers/<integration>/\`.
+
+Authoring guidance:
+
+- [docs/contributing/component-implementations.md](https://github.com/superplanehq/superplane/blob/main/docs/contributing/component-implementations.md)
+- [docs/contributing/component-design.md](https://github.com/superplanehq/superplane/blob/main/docs/contributing/component-design.md)
+`,
+  },
+  {
+    id: "dev-local",
+    path: "development/local-setup.md",
+    title: "Local setup",
+    content: `# Local setup
+
+Dev is Docker-based. You need Docker Compose; Go and Node run inside containers.
+
+\`\`\`bash
+make dev.up      # app, db, rabbitmq (first build ~3–5 min)
+make dev.setup   # npm, Go modules, protos, migrate DB
+make dev.server  # API (air) + Vite; UI on :8000
+\`\`\`
+
+Health: \`http://localhost:8000/health\`. First UI load prompts owner setup (\`OWNER_SETUP_ENABLED=yes\`).
+
+## Demo container (no source checkout)
+
+\`\`\`bash
+docker pull ghcr.io/superplanehq/superplane-demo:stable
+docker run --rm -p 3000:3000 -v spdata:/app/data -ti ghcr.io/superplanehq/superplane-demo:stable
+\`\`\`
+`,
+  },
+  {
+    id: "dev-testing",
+    path: "development/testing.md",
+    title: "Testing",
+    content: `# Testing
+
+\`\`\`bash
+make test                                          # Go unit/integration
+make test PKG_TEST_PACKAGES=./pkg/workers          # targeted
+make test.e2e                                      # end-to-end
+E2E_TEST_PACKAGES=./test/e2e/workflows make test.e2e
+\`\`\`
+
+After Go changes: \`make format.go\`, then \`make lint && make check.build.app\`.
+
+After JS/TS changes: \`make format.js\`, then \`make check.build.ui\`.
+
+E2E authoring notes live in \`docs/contributing/e2e-tests.md\`.
+`,
+  },
+  {
+    id: "dev-contributing",
+    path: "development/contributing.md",
+    title: "Contributing",
+    content: `# Contributing
+
+- Read root \`AGENTS.md\` and \`CONTRIBUTING.md\`; UI work also reads \`web_src/AGENTS.md\`
+- PR titles: Conventional Commits with \`feat:\`, \`fix:\`, \`chore:\`, or \`docs:\`
+- Commits need DCO sign-off (\`git commit -s\`)
+- Never hand-edit generated clients, OpenAPI, or migration files — use \`make pb.gen\` and \`make db.migration.create\`
+- Application name in user-facing text: **SuperPlane** (not "Superplane")
+
+License: Apache 2.0.
+`,
+  },
+];
+
+/** Second corpus shown after a simulated “Refresh knowledge”. */
+export const WIKI_DOCUMENTS_REFRESHED: WikiDocument[] = [
+  {
+    id: "overview-r",
+    path: "overview.md",
+    title: "Overview",
+    content: `# SuperPlane
+
+Refreshed from [superplanehq/superplane](https://github.com/superplanehq/superplane).
+
+Open source automation engine for AI-driven engineering: git-backed apps, durable canvas runs, consoles, and integrations across Git, LLM, CI/CD, observability, and incident tools.
+
+Self-host or use Cloud at [app.superplane.com](https://app.superplane.com). Docs at [docs.superplane.com](https://docs.superplane.com).
+`,
+  },
+  {
+    id: "team-r",
+    path: "team.md",
+    title: "Team",
+    content: `# Team
+
+Regenerated from CONTRIBUTING and community links.
+
+Maintainers accept focused PRs with DCO sign-off. Operators and agents share RBAC; secrets stay encrypted. Join Discord for questions: [discord.superplane.com](https://discord.superplane.com).
+`,
+  },
+  {
+    id: "feat-apps-canvases-r",
+    path: "features/apps-and-canvases.md",
+    title: "Apps and canvases",
+    content: `# Apps and canvases
+
+Updated: apps remain the git-versioned unit (\`canvas.yaml\` + \`console.yaml\`). Canvases are dependency graphs; one canvas may host concurrent workflows with shared memory and approvals.
+`,
+  },
+  {
+    id: "feat-components-r",
+    path: "features/components-and-integrations.md",
+    title: "Components and integrations",
+    content: `# Components and integrations
+
+Catalog spans AI, VCS/CI, cloud, observability, incident, and messaging providers. Missing a provider? Open an issue on the SuperPlane repo. Implementation packages: \`pkg/integrations/<name>/\`.
+`,
+  },
+  {
+    id: "feat-console-r",
+    path: "features/console.md",
+    title: "Console",
+    content: `# Console
+
+Console grids bind to memory, runs, and executions. Prefer operational panels (KPIs, runbooks, pinned nodes, controls) over one-off dashboards outside the app.
+`,
+  },
+  {
+    id: "feat-memory-r",
+    path: "features/memory.md",
+    title: "Memory",
+    content: `# Memory
+
+App-scoped JSON that survives across runs. Consoles and canvas steps read/write the same store so progressive delivery state and incident evidence packs stay in-product.
+`,
+  },
+  {
+    id: "feat-agents-r",
+    path: "features/agents-and-operators.md",
+    title: "Agents and operators",
+    content: `# Agents and operators
+
+Per-app agent for design and run debug; CLI/skills for external coding agents. Same RBAC and approval gates on every path.
+`,
+  },
+  {
+    id: "feat-runs-r",
+    path: "features/runs.md",
+    title: "Runs and durable execution",
+    content: `# Runs and durable execution
+
+Runs, run items, and payloads are persisted; workers resume failed steps. Approvals and waits are canvas nodes, not sidecar process.
+`,
+  },
+  {
+    id: "arch-backend-r",
+    path: "architecture/backend.md",
+    title: "Backend",
+    content: `# Backend
+
+Go + gRPC (+ OpenAPI gateway). Key packages: \`pkg/grpc/actions\`, \`pkg/models\`, \`pkg/workers\`, \`pkg/integrations\`. State in PostgreSQL; messaging via RabbitMQ.
+`,
+  },
+  {
+    id: "arch-frontend-r",
+    path: "architecture/frontend.md",
+    title: "Frontend",
+    content: `# Frontend
+
+\`web_src/\` Vite + React. Do not hand-edit \`web_src/src/api-client/\` — regenerate with \`make pb.gen\`. UI conventions: \`web_src/AGENTS.md\`.
+`,
+  },
+  {
+    id: "arch-repo-r",
+    path: "architecture/repo-layout.md",
+    title: "Repo layout",
+    content: `# Repo layout
+
+\`\`\`
+cmd/        Go entrypoints
+pkg/        gRPC, models, workers, integrations
+web_src/    React/Vite UI
+protos/     API definitions
+db/         migrations
+docs/       contributing docs
+test/       backend + e2e
+\`\`\`
+
+Makefile is the task entrypoint for setup, codegen, lint, and tests.
+`,
+  },
+  {
+    id: "dev-local-r",
+    path: "development/local-setup.md",
+    title: "Local setup",
+    content: `# Local setup
+
+\`make dev.up\` → \`make dev.setup\` → \`make dev.server\`.
+
+Re-run \`dev.setup\` when protos, Go modules, or frontend deps change. Corrupt Go module cache: \`make dev.clean.go.cache\` then \`make dev.setup.go\`.
+`,
+  },
+  {
+    id: "dev-testing-r",
+    path: "development/testing.md",
+    title: "Testing",
+    content: `# Testing
+
+\`make test\` for Go; \`make test.e2e\` for end-to-end. Point \`PKG_TEST_PACKAGES\` / \`E2E_TEST_PACKAGES\` at a package for a faster loop. CI runs on Semaphore.
+`,
+  },
+  {
+    id: "dev-contributing-r",
+    path: "development/contributing.md",
+    title: "Contributing",
+    content: `# Contributing
+
+Use \`make db.migration.create NAME=<name>\` for schema changes (never hand-write migrations). After protos: \`make pb.gen\` and \`make check.proto.field.numbers\`. PR prefix must be \`feat:\` / \`fix:\` / \`chore:\` / \`docs:\` with DCO.
+`,
+  },
+];


### PR DESCRIPTION
## Summary
- Port the v3 Wiki UI into Factories Storybook as a local wireframe (file tree, markdown reader/editor, Refresh knowledge) with mock corpora.
- Add Storybook-only `pageOverrides` on the org/factories harnesses so Wiki stories mount inside FactoriesLayout without changing the app `/wiki` Coming Soon route.
- Add `Factories/Pages/Wiki` stories: Default, Empty, and Editing.

## Test plan
- [ ] Open Storybook `Factories/Pages/Wiki` → Default and confirm Factories sidebar + wiki tree/reader render
- [ ] Confirm Empty and Editing variants behave as expected (no docs / edit mode)
- [ ] Confirm `Factories/Pages/Coming Soon` → Wiki still shows Coming Soon
- [ ] Confirm app route `/wiki` is unchanged (Coming Soon) when factories feature is enabled


Made with [Cursor](https://cursor.com)