### PR TITLE
fix(ui): restore default link weight and align factories nav icons

### DIFF
--- a/web_src/src/index.css
+++ b/web_src/src/index.css
@@ -10,7 +10,6 @@
 }
 
 a {
-  font-weight: 500;
   text-decoration: inherit;
 }
 

--- a/web_src/src/pages/factories/layout/factoriesNavItems.ts
+++ b/web_src/src/pages/factories/layout/factoriesNavItems.ts
@@ -1,4 +1,4 @@
-import { BarChart3, BookOpen, ClipboardList, LayoutGrid, Rocket, Workflow } from "lucide-react";
+import { BookOpen, ClipboardList, Crosshair, Gauge, LayoutDashboard, Workflow } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import {
   automationsPath,
@@ -22,13 +22,13 @@ export const FACTORIES_NAV_ITEMS: FactoriesNavItem[] = [
   {
     id: "overview",
     label: "Overview",
-    Icon: LayoutGrid,
+    Icon: LayoutDashboard,
     buildHref: factoryOverviewPath,
   },
   {
     id: "missions",
     label: "Missions",
-    Icon: Rocket,
+    Icon: Crosshair,
     buildHref: factoryMissionsPath,
   },
   {
@@ -52,7 +52,7 @@ export const FACTORIES_NAV_ITEMS: FactoriesNavItem[] = [
   {
     id: "velocity",
     label: "Velocity",
-    Icon: BarChart3,
+    Icon: Gauge,
     buildHref: factoryVelocityPath,
   },
 ];

--- a/web_src/src/pages/factories/pages/MissionsPage.tsx
+++ b/web_src/src/pages/factories/pages/MissionsPage.tsx
@@ -1,8 +1,12 @@
-import { Rocket } from "lucide-react";
+import { Crosshair } from "lucide-react";
 import { ComingSoonPage } from "./ComingSoonPage";
 
 export function MissionsPage() {
   return (
-    <ComingSoonPage title="Missions" description="Plan the outcomes your factory delivers over time." Icon={Rocket} />
+    <ComingSoonPage
+      title="Missions"
+      description="Plan the outcomes your factory delivers over time."
+      Icon={Crosshair}
+    />
   );
 }

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -1,4 +1,4 @@
-import { BarChart3 } from "lucide-react";
+import { Gauge } from "lucide-react";
 import { ComingSoonPage } from "./ComingSoonPage";
 
 export function VelocityPage() {
@@ -6,7 +6,7 @@ export function VelocityPage() {
     <ComingSoonPage
       title="Velocity"
       description="Track how quickly work moves through the workspace."
-      Icon={BarChart3}
+      Icon={Gauge}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Remove the global `a { font-weight: 500 }` rule so links inherit normal weight (400) by default and active nav `font-medium` can show a visible weight jump.
- Align factories sidebar/coming-soon icons with the v3 reference: Overview `LayoutDashboard`, Missions `Crosshair`, Velocity `Gauge`.

## Test plan
- [ ] Open factories Storybook nav and confirm inactive items look lighter than the active item
- [ ] Confirm Overview / Missions / Velocity icons match the v3 sidebar
- [ ] Spot-check non-factories links still look correct (no forced medium weight)


Made with [Cursor](https://cursor.com)