### PR TITLE
feat: expand Bitbucket with pull request and build status components

### DIFF
--- a/docs/components/Bitbucket.mdx
+++ b/docs/components/Bitbucket.mdx
@@ -9,7 +9,21 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 ## Triggers
 
 <CardGrid>
+  <LinkCard title="On Commit Status" href="#on-commit-status" description="Listen to Bitbucket build statuses, including Bitbucket Pipelines results" />
+  <LinkCard title="On Pull Request Comment" href="#on-pull-request-comment" description="Listen to comments on Bitbucket pull requests" />
+  <LinkCard title="On Pull Request" href="#on-pull-request" description="Listen to Bitbucket pull request events" />
   <LinkCard title="On Push" href="#on-push" description="Listen to Bitbucket push events" />
+</CardGrid>
+
+## Actions
+
+<CardGrid>
+  <LinkCard title="Create Pull Request Comment" href="#create-pull-request-comment" description="Post a comment on a Bitbucket pull request" />
+  <LinkCard title="Create Pull Request" href="#create-pull-request" description="Open a new pull request in a Bitbucket repository" />
+  <LinkCard title="Get Commit Status" href="#get-commit-status" description="Read the build statuses reported on a Bitbucket commit" />
+  <LinkCard title="Merge Pull Request" href="#merge-pull-request" description="Merge an open pull request in a Bitbucket repository" />
+  <LinkCard title="Publish Commit Status" href="#publish-commit-status" description="Report a build status on a Bitbucket commit" />
+  <LinkCard title="Update Pull Request" href="#update-pull-request" description="Update an existing pull request in a Bitbucket repository" />
 </CardGrid>
 
 ## Instructions
@@ -26,6 +40,468 @@ To configure Bitbucket with SuperPlane:
    - Create a workspace access token.
 
 - **Copy the token** and your workspace slug (for example: `my-workspace`) below.
+
+<a id="on-commit-status"></a>
+
+## On Commit Status
+
+**Trigger key:** `bitbucket.onCommitStatus`
+
+The On Commit Status trigger starts a workflow execution when a build status is reported on a commit.
+
+Bitbucket Pipelines reports every pipeline result through the build status API, so this trigger is how a
+canvas reacts to a pipeline finishing. External CI systems that publish statuses to Bitbucket — including
+SuperPlane's own **Publish Commit Status** component — fire this trigger too.
+
+### Use Cases
+
+- **Deploy on green**: Start a deployment when the build for a commit reports `SUCCESSFUL`
+- **Fail fast**: Open an incident or notify a channel when a build reports `FAILED`
+- **Release gating**: Wait for a specific build key, such as `integration-tests`, before promoting a build
+
+### Configuration
+
+- **Repository** (required): The Bitbucket repository to monitor
+- **States** (required): Which build states should start a run. Default: Successful and Failed.
+- **Keys** (optional): Only fire for statuses whose key matches, e.g. `integration-tests`. Leave empty to accept every key.
+- **Refs** (optional): Only fire for statuses reported on a matching branch or tag. Leave empty to accept any ref.
+
+### Event Data
+
+Each event includes:
+- **commit_status**: The status, including `key`, `name`, `state`, `url`, `refname` and `links`
+- **repository**: Repository information
+- **actor**: The user or app that reported the status
+
+Common expression paths:
+- Build state: `root().data.commit_status.state`
+- Build key: `root().data.commit_status.key`
+- Build URL: `root().data.commit_status.url`
+- Branch: `root().data.commit_status.refname`
+
+The commit the status belongs to is referenced by `root().data.commit_status.links.commit.href`; its
+last path segment is the commit hash.
+
+### Webhook Setup
+
+This trigger automatically sets up a Bitbucket webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.
+
+### Example Data
+
+```json
+{
+  "data": {
+    "actor": {
+      "display_name": "John Doe",
+      "links": {
+        "avatar": {
+          "href": "https://bitbucket.org/account/johndoe/avatar/"
+        },
+        "html": {
+          "href": "https://bitbucket.org/johndoe/"
+        }
+      },
+      "nickname": "johndoe",
+      "type": "user",
+      "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}"
+    },
+    "commit_status": {
+      "created_on": "2024-01-15T10:24:03.118093+00:00",
+      "description": "Pipeline succeeded",
+      "key": "BITBUCKETPIPELINE",
+      "links": {
+        "commit": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/commit/709d658dc5b6d6afcd46049c2f332ee3f515a67d"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/commit/709d658dc5b6d6afcd46049c2f332ee3f515a67d/statuses/build/BITBUCKETPIPELINE"
+        }
+      },
+      "name": "Pipeline #128 for main",
+      "refname": "main",
+      "state": "SUCCESSFUL",
+      "type": "build",
+      "updated_on": "2024-01-15T10:29:57.774502+00:00",
+      "url": "https://bitbucket.org/my-workspace/my-repo/pipelines/results/128"
+    },
+    "repository": {
+      "full_name": "my-workspace/my-repo",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo"
+        }
+      },
+      "name": "my-repo",
+      "type": "repository",
+      "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}"
+    }
+  },
+  "timestamp": "2024-01-15T10:30:00Z",
+  "type": "bitbucket.commitStatus"
+}
+```
+
+<a id="on-pull-request-comment"></a>
+
+## On Pull Request Comment
+
+**Trigger key:** `bitbucket.onPRComment`
+
+The On Pull Request Comment trigger starts a workflow execution when someone comments on a Bitbucket pull request.
+
+### Use Cases
+
+- **ChatOps**: Let reviewers run a workflow by commenting `/deploy` or `/preview` on a pull request
+- **Agent hand-off**: Send a comment to a coding agent and post the result back on the pull request
+- **Review tracking**: Notify a channel when a discussion starts on an open pull request
+
+### Configuration
+
+- **Repository** (required): The Bitbucket repository to monitor
+- **Actions** (required): Which comment events to listen for. Default: Created.
+- **Content Filter** (optional): Regex pattern the comment body must match, e.g. `^/deploy`. Leave empty to accept every comment.
+
+### Event Data
+
+Each event includes:
+- **comment**: The comment, including `id` and `content.raw`
+- **pullrequest**: The pull request the comment belongs to
+- **repository**: Repository information
+- **actor**: The user that wrote the comment
+
+Common expression paths:
+- Comment body: `root().data.comment.content.raw`
+- Comment author: `root().data.actor.display_name`
+- Pull request ID: `root().data.pullrequest.id`
+- Source branch: `root().data.pullrequest.source.branch.name`
+
+### Webhook Setup
+
+This trigger automatically sets up a Bitbucket webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.
+
+### Example Data
+
+```json
+{
+  "data": {
+    "actor": {
+      "display_name": "John Doe",
+      "links": {
+        "avatar": {
+          "href": "https://bitbucket.org/account/johndoe/avatar/"
+        },
+        "html": {
+          "href": "https://bitbucket.org/johndoe/"
+        }
+      },
+      "nickname": "johndoe",
+      "type": "user",
+      "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}"
+    },
+    "comment": {
+      "content": {
+        "html": "\u003cp\u003e/deploy staging\u003c/p\u003e",
+        "markup": "markdown",
+        "raw": "/deploy staging"
+      },
+      "created_on": "2024-01-15T10:31:12.884401+00:00",
+      "deleted": false,
+      "id": 481902337,
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo/pull-requests/42/_/diff#comment-481902337"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments/481902337"
+        }
+      },
+      "type": "pullrequest_comment",
+      "updated_on": "2024-01-15T10:31:12.884401+00:00",
+      "user": {
+        "display_name": "John Doe",
+        "links": {
+          "avatar": {
+            "href": "https://bitbucket.org/account/johndoe/avatar/"
+          },
+          "html": {
+            "href": "https://bitbucket.org/johndoe/"
+          }
+        },
+        "nickname": "johndoe",
+        "type": "user",
+        "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}"
+      }
+    },
+    "pullrequest": {
+      "author": {
+        "display_name": "John Doe",
+        "links": {
+          "avatar": {
+            "href": "https://bitbucket.org/account/johndoe/avatar/"
+          },
+          "html": {
+            "href": "https://bitbucket.org/johndoe/"
+          }
+        },
+        "nickname": "johndoe",
+        "type": "user",
+        "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}"
+      },
+      "close_source_branch": true,
+      "comment_count": 0,
+      "created_on": "2024-01-15T10:28:41.153217+00:00",
+      "description": "Adds the login page and wires it to the session API.",
+      "destination": {
+        "branch": {
+          "name": "main"
+        },
+        "commit": {
+          "hash": "1f4b0c6d9a2e5f8b3c7d0e1a4b6c9d2e5f8a1b3c",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo/commits/1f4b0c6d9a2e5f8b3c7d0e1a4b6c9d2e5f8a1b3c"
+            }
+          },
+          "type": "commit"
+        },
+        "repository": {
+          "full_name": "my-workspace/my-repo",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo"
+            }
+          },
+          "name": "my-repo",
+          "type": "repository",
+          "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}"
+        }
+      },
+      "draft": false,
+      "id": 42,
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo/pull-requests/42"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42"
+        }
+      },
+      "participants": [],
+      "reviewers": [],
+      "source": {
+        "branch": {
+          "name": "feature/login-page"
+        },
+        "commit": {
+          "hash": "709d658dc5b6d6afcd46049c2f332ee3f515a67d",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo/commits/709d658dc5b6d6afcd46049c2f332ee3f515a67d"
+            }
+          },
+          "type": "commit"
+        },
+        "repository": {
+          "full_name": "my-workspace/my-repo",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo"
+            }
+          },
+          "name": "my-repo",
+          "type": "repository",
+          "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}"
+        }
+      },
+      "state": "OPEN",
+      "task_count": 0,
+      "title": "feat: add login page",
+      "type": "pullrequest",
+      "updated_on": "2024-01-15T10:28:41.153217+00:00"
+    },
+    "repository": {
+      "full_name": "my-workspace/my-repo",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo"
+        }
+      },
+      "name": "my-repo",
+      "type": "repository",
+      "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}"
+    }
+  },
+  "timestamp": "2024-01-15T10:30:00Z",
+  "type": "bitbucket.pullRequestComment"
+}
+```
+
+<a id="on-pull-request"></a>
+
+## On Pull Request
+
+**Trigger key:** `bitbucket.onPullRequest`
+
+The On Pull Request trigger starts a workflow execution when a pull request changes state in a Bitbucket repository.
+
+### Use Cases
+
+- **Preview environments**: Provision an ephemeral environment when a pull request is opened, and tear it down when it is merged or declined
+- **Review automation**: Run checks, ask an agent for a review, or notify a channel when a pull request is opened or updated
+- **Merge gates**: React to approvals and change requests to drive a deployment decision
+- **Release automation**: Start a deploy when a pull request targeting `main` is merged
+
+### Configuration
+
+- **Repository** (required): The Bitbucket repository to monitor
+- **Actions** (required): Which pull request events to listen for. Default: Opened.
+- **Target Branches** (optional): Only fire when the pull request targets a matching branch. Leave empty to accept every target branch.
+
+### Event Data
+
+Each event includes:
+- **pullrequest**: The full pull request, including `id`, `title`, `state`, `source`, `destination` and `links`
+- **repository**: Repository information
+- **actor**: The user that triggered the event
+- **approval** / **changes_request**: Present on approval and change-request events
+
+Common expression paths:
+- Pull request ID: `root().data.pullrequest.id`
+- Title: `root().data.pullrequest.title`
+- State: `root().data.pullrequest.state`
+- Source branch: `root().data.pullrequest.source.branch.name`
+- Target branch: `root().data.pullrequest.destination.branch.name`
+- Head commit: `root().data.pullrequest.source.commit.hash`
+- Pull request URL: `root().data.pullrequest.links.html.href`
+
+Note that Bitbucket reports the merged state as the `fulfilled` action and the declined state as `rejected`.
+
+### Webhook Setup
+
+This trigger automatically sets up a Bitbucket webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.
+
+### Example Data
+
+```json
+{
+  "data": {
+    "actor": {
+      "display_name": "John Doe",
+      "links": {
+        "avatar": {
+          "href": "https://bitbucket.org/account/johndoe/avatar/"
+        },
+        "html": {
+          "href": "https://bitbucket.org/johndoe/"
+        }
+      },
+      "nickname": "johndoe",
+      "type": "user",
+      "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}"
+    },
+    "pullrequest": {
+      "author": {
+        "display_name": "John Doe",
+        "links": {
+          "avatar": {
+            "href": "https://bitbucket.org/account/johndoe/avatar/"
+          },
+          "html": {
+            "href": "https://bitbucket.org/johndoe/"
+          }
+        },
+        "nickname": "johndoe",
+        "type": "user",
+        "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}"
+      },
+      "close_source_branch": true,
+      "comment_count": 0,
+      "created_on": "2024-01-15T10:28:41.153217+00:00",
+      "description": "Adds the login page and wires it to the session API.",
+      "destination": {
+        "branch": {
+          "name": "main"
+        },
+        "commit": {
+          "hash": "1f4b0c6d9a2e5f8b3c7d0e1a4b6c9d2e5f8a1b3c",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo/commits/1f4b0c6d9a2e5f8b3c7d0e1a4b6c9d2e5f8a1b3c"
+            }
+          },
+          "type": "commit"
+        },
+        "repository": {
+          "full_name": "my-workspace/my-repo",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo"
+            }
+          },
+          "name": "my-repo",
+          "type": "repository",
+          "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}"
+        }
+      },
+      "draft": false,
+      "id": 42,
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo/pull-requests/42"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42"
+        }
+      },
+      "participants": [],
+      "reviewers": [],
+      "source": {
+        "branch": {
+          "name": "feature/login-page"
+        },
+        "commit": {
+          "hash": "709d658dc5b6d6afcd46049c2f332ee3f515a67d",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo/commits/709d658dc5b6d6afcd46049c2f332ee3f515a67d"
+            }
+          },
+          "type": "commit"
+        },
+        "repository": {
+          "full_name": "my-workspace/my-repo",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo"
+            }
+          },
+          "name": "my-repo",
+          "type": "repository",
+          "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}"
+        }
+      },
+      "state": "OPEN",
+      "task_count": 0,
+      "title": "feat: add login page",
+      "type": "pullrequest",
+      "updated_on": "2024-01-15T10:28:41.153217+00:00"
+    },
+    "repository": {
+      "full_name": "my-workspace/my-repo",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo"
+        }
+      },
+      "name": "my-repo",
+      "type": "repository",
+      "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}"
+    }
+  },
+  "timestamp": "2024-01-15T10:30:00Z",
+  "type": "bitbucket.pullRequest"
+}
+```
 
 <a id="on-push"></a>
 
@@ -154,6 +630,693 @@ This trigger automatically sets up a Bitbucket webhook when configured. The webh
   },
   "timestamp": "2024-01-15T10:30:00Z",
   "type": "bitbucket.push"
+}
+```
+
+<a id="create-pull-request-comment"></a>
+
+## Create Pull Request Comment
+
+**Component key:** `bitbucket.createPRComment`
+
+The Create Pull Request Comment component posts a comment on a Bitbucket pull request.
+
+### Use Cases
+
+- **Preview environment URLs**: Post the URL of the environment provisioned for the pull request
+- **Agent output**: Return the result of a review or a test run to the people looking at the pull request
+- **Deployment feedback**: Report which environment the branch was deployed to, and when
+
+### Configuration
+
+- **Repository** (required): The repository containing the pull request
+- **Pull Request ID** (required): The numeric ID of the pull request (supports expressions)
+- **Body** (required): The comment body, in Markdown. Supports expressions.
+
+### Permissions
+
+The token needs the `pullrequest:write` scope on the repository.
+
+### Output
+
+The component emits the created comment, including:
+- **id**: The comment ID
+- **content.raw**: The Markdown that was posted
+- **links.html.href**: The URL of the comment on the pull request
+
+### Example Output
+
+```json
+{
+  "data": {
+    "content": {
+      "html": "\u003cp\u003ePreview environment is up: \u003ca href=\"https://pr-42.preview.superplane.dev\"\u003ehttps://pr-42.preview.superplane.dev\u003c/a\u003e\u003c/p\u003e",
+      "markup": "markdown",
+      "raw": "Preview environment is up: https://pr-42.preview.superplane.dev"
+    },
+    "created_on": "2026-08-11T09:41:03.774219+00:00",
+    "deleted": false,
+    "id": 481902337,
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/pull-requests/42/_/diff#comment-481902337"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42/comments/481902337"
+      }
+    },
+    "updated_on": "2026-08-11T09:41:03.774219+00:00",
+    "user": {
+      "account_id": "712020:1f6a0d7c-5d54-4b1e-9a4f-6c2f9e0a7b31",
+      "display_name": "Anthony Foussette",
+      "nickname": "anthony",
+      "uuid": "{6b0b1d0e-6a1f-4f2f-9a2b-2f1d3a9c7e21}"
+    }
+  },
+  "timestamp": "2026-08-11T09:41:03.812905Z",
+  "type": "bitbucket.pullRequestComment"
+}
+```
+
+<a id="create-pull-request"></a>
+
+## Create Pull Request
+
+**Component key:** `bitbucket.createPullRequest`
+
+The Create Pull Request component opens a new pull request in a Bitbucket repository.
+
+### Use Cases
+
+- **Automated fixes**: An agent pushes a fix to a branch and opens a pull request for human review
+- **Dependency updates**: Open a pull request when a dependency bump or changelog is generated
+- **Release automation**: Promote a release branch into `main` through a reviewable pull request
+
+### Configuration
+
+- **Repository** (required): The repository where the pull request is opened
+- **Source Branch** (required): The branch holding the changes (supports expressions)
+- **Target Branch** (optional): The branch to merge into. Leave empty to use the repository's main branch.
+- **Title** (required): The title of the pull request
+- **Description** (optional): The pull request description, in Markdown
+- **Reviewers** (optional): Workspace members to request a review from
+- **Close Source Branch** (optional): Delete the source branch once the pull request is merged
+
+### Permissions
+
+The token needs the `pullrequest:write` scope on the repository.
+
+### Output
+
+The component emits the created pull request, including:
+- **id**: The pull request number used by every other Bitbucket component
+- **state**: `OPEN` for a freshly created pull request
+- **source.branch.name** and **destination.branch.name**: The branches involved
+- **links.html.href**: The URL to open the pull request in Bitbucket
+
+### Example Output
+
+```json
+{
+  "data": {
+    "author": {
+      "account_id": "712020:1f6a0d7c-5d54-4b1e-9a4f-6c2f9e0a7b31",
+      "display_name": "Anthony Foussette",
+      "nickname": "anthony",
+      "uuid": "{6b0b1d0e-6a1f-4f2f-9a2b-2f1d3a9c7e21}"
+    },
+    "close_source_branch": true,
+    "comment_count": 0,
+    "created_on": "2026-08-11T09:14:22.512345+00:00",
+    "description": "Adds the login page and wires it to the session API.",
+    "destination": {
+      "branch": {
+        "name": "main"
+      },
+      "commit": {
+        "hash": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          }
+        }
+      },
+      "repository": {
+        "full_name": "superplane/web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        },
+        "name": "web",
+        "slug": "web",
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}"
+      }
+    },
+    "draft": false,
+    "id": 42,
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/pull-requests/42"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42"
+      }
+    },
+    "reviewers": [
+      {
+        "account_id": "712020:9c4e1b77-2a3d-4e58-b0c1-7f8a2d5e6c04",
+        "display_name": "Marta Silva",
+        "nickname": "marta",
+        "uuid": "{2a5f7c88-91b4-4f0a-8c62-1e7d9b0a4f13}"
+      }
+    ],
+    "source": {
+      "branch": {
+        "name": "feature/login-page"
+      },
+      "commit": {
+        "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          }
+        }
+      },
+      "repository": {
+        "full_name": "superplane/web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        },
+        "name": "web",
+        "slug": "web",
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}"
+      }
+    },
+    "state": "OPEN",
+    "task_count": 0,
+    "title": "Add login page",
+    "updated_on": "2026-08-11T09:14:22.512345+00:00"
+  },
+  "timestamp": "2026-08-11T09:14:22.618432Z",
+  "type": "bitbucket.pullRequest"
+}
+```
+
+<a id="get-commit-status"></a>
+
+## Get Commit Status
+
+**Component key:** `bitbucket.getCommitStatus`
+
+The Get Commit Status component reads every build status reported on a commit and rolls them into a
+single verdict, so a workflow can decide whether a commit is safe to ship.
+
+### Use Cases
+
+- **Deploy gates**: Check that every build on the commit is green before promoting it
+- **Release readiness**: Verify a release candidate has passed all required checks
+- **Diagnostics**: Attach the list of failing checks to an incident or a pull request comment
+
+### Configuration
+
+- **Repository** (required): The repository containing the commit
+- **Commit** (required): The full commit hash to read (supports expressions)
+
+### Output
+
+The component emits an aggregate over the commit's build statuses:
+- **commit**: The commit that was read
+- **state**: The combined verdict, see the table below
+- **total_count**: How many statuses were reported on the commit
+- **statuses**: Every individual status, in the order Bitbucket returned them
+
+#### How the combined state is decided
+
+The combined state is the most severe individual state, in this order:
+
+| Combined state | When |
+| --- | --- |
+| `FAILED` | At least one status failed |
+| `STOPPED` | No failures, but at least one build was stopped |
+| `INPROGRESS` | Nothing failed or stopped, but at least one build is still running |
+| `SUCCESSFUL` | Every status succeeded |
+| `NO_STATUS` | The commit carries no build status at all |
+
+`NO_STATUS` is not a Bitbucket value — it exists so a gate can tell "nothing ran yet" apart from
+"everything passed", which are very different answers when deciding to deploy.
+
+### Permissions
+
+The token needs the `repository` read scope.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "commit": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+    "state": "SUCCESSFUL",
+    "statuses": [
+      {
+        "commit": {
+          "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+            },
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+            }
+          }
+        },
+        "created_on": "2026-08-11T11:02:44.118093+00:00",
+        "description": "Pipeline succeeded",
+        "key": "BITBUCKETPIPELINE",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses/build/BITBUCKETPIPELINE"
+          }
+        },
+        "name": "Pipeline #128 for main",
+        "refname": "main",
+        "state": "SUCCESSFUL",
+        "type": "build",
+        "updated_on": "2026-08-11T11:09:31.774502+00:00",
+        "url": "https://bitbucket.org/superplane/web/pipelines/results/128"
+      },
+      {
+        "commit": {
+          "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+            },
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+            }
+          }
+        },
+        "created_on": "2026-08-11T11:24:18.402117+00:00",
+        "description": "Deployed to production",
+        "key": "superplane-deploy",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses/build/superplane-deploy"
+          }
+        },
+        "name": "SuperPlane deploy",
+        "refname": "main",
+        "state": "SUCCESSFUL",
+        "type": "build",
+        "updated_on": "2026-08-11T11:31:52.660984+00:00",
+        "url": "https://app.superplane.com/canvases/web-delivery/runs/8f2c1a44"
+      }
+    ],
+    "total_count": 2
+  },
+  "timestamp": "2026-08-11T11:32:10.559274Z",
+  "type": "bitbucket.commitStatuses"
+}
+```
+
+<a id="merge-pull-request"></a>
+
+## Merge Pull Request
+
+**Component key:** `bitbucket.mergePullRequest`
+
+The Merge Pull Request component merges an open Bitbucket pull request.
+
+### Use Cases
+
+- **Policy-gated merges**: Merge only after approvals, a green build and a manual approval step have all passed
+- **Auto-merge**: Merge dependency or changelog pull requests once CI reports success
+- **Release trains**: Merge a batch of ready pull requests as part of a coordinated release
+
+### Configuration
+
+- **Repository** (required): The repository containing the pull request
+- **Pull Request ID** (required): The numeric ID of the pull request (supports expressions)
+- **Merge Strategy** (required): How the merge is performed. Default: Merge commit.
+- **Message** (optional): The merge commit message. Leave empty to let Bitbucket generate it.
+- **Close Source Branch** (optional): Delete the source branch after merging
+
+#### Merge strategies
+
+| Strategy | Behaviour |
+| --- | --- |
+| **Merge commit** | Creates a merge commit, keeping the full branch history |
+| **Squash** | Combines every commit on the branch into a single commit |
+| **Fast forward** | Moves the target branch pointer, and fails if the branch has diverged |
+
+### Permissions
+
+The token needs the `pullrequest:write` scope, and the account must be allowed to write to the
+target branch. Branch restrictions, unresolved merge checks and merge conflicts all make this component fail
+with the reason reported by Bitbucket.
+
+### Output
+
+The component emits the merged pull request, including:
+- **state**: `MERGED`
+- **merge_commit.hash**: The commit created by the merge
+- **closed_by**: The account the merge was performed as
+
+If Bitbucket queues the merge asynchronously — which happens on very large repositories — the component
+fails rather than reporting a merge that has not completed.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "author": {
+      "account_id": "712020:1f6a0d7c-5d54-4b1e-9a4f-6c2f9e0a7b31",
+      "display_name": "Anthony Foussette",
+      "nickname": "anthony",
+      "uuid": "{6b0b1d0e-6a1f-4f2f-9a2b-2f1d3a9c7e21}"
+    },
+    "close_source_branch": true,
+    "closed_by": {
+      "account_id": "712020:9c4e1b77-2a3d-4e58-b0c1-7f8a2d5e6c04",
+      "display_name": "Marta Silva",
+      "nickname": "marta",
+      "uuid": "{2a5f7c88-91b4-4f0a-8c62-1e7d9b0a4f13}"
+    },
+    "comment_count": 3,
+    "created_on": "2026-08-11T09:14:22.512345+00:00",
+    "description": "Adds the login page and wires it to the session API.",
+    "destination": {
+      "branch": {
+        "name": "main"
+      },
+      "commit": {
+        "hash": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          }
+        }
+      },
+      "repository": {
+        "full_name": "superplane/web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        },
+        "name": "web",
+        "slug": "web",
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}"
+      }
+    },
+    "draft": false,
+    "id": 42,
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/pull-requests/42"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42"
+      }
+    },
+    "merge_commit": {
+      "hash": "7ab3c9d1e5f28046b1c3a7d9e2b4c6d8e0f1a2b3",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/superplane/web/commits/7ab3c9d1e5f28046b1c3a7d9e2b4c6d8e0f1a2b3"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/7ab3c9d1e5f28046b1c3a7d9e2b4c6d8e0f1a2b3"
+        }
+      }
+    },
+    "reviewers": [
+      {
+        "account_id": "712020:9c4e1b77-2a3d-4e58-b0c1-7f8a2d5e6c04",
+        "display_name": "Marta Silva",
+        "nickname": "marta",
+        "uuid": "{2a5f7c88-91b4-4f0a-8c62-1e7d9b0a4f13}"
+      }
+    ],
+    "source": {
+      "branch": {
+        "name": "feature/login-page"
+      },
+      "commit": {
+        "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          }
+        }
+      },
+      "repository": {
+        "full_name": "superplane/web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        },
+        "name": "web",
+        "slug": "web",
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}"
+      }
+    },
+    "state": "MERGED",
+    "task_count": 0,
+    "title": "Add login page",
+    "updated_on": "2026-08-11T11:20:05.104773+00:00"
+  },
+  "timestamp": "2026-08-11T11:20:05.211640Z",
+  "type": "bitbucket.pullRequest"
+}
+```
+
+<a id="publish-commit-status"></a>
+
+## Publish Commit Status
+
+**Component key:** `bitbucket.publishCommitStatus`
+
+The Publish Commit Status component reports a build status on a Bitbucket commit, so the result of a
+SuperPlane workflow shows up next to the commit and on any pull request that contains it.
+
+### Use Cases
+
+- **Make SuperPlane a required check**: Publish `INPROGRESS` when a workflow starts and `SUCCESSFUL` or `FAILED` when it finishes, then require that key in a Bitbucket branch restriction
+- **Surface external results**: Report the outcome of a security scan, a load test or a manual approval directly on the commit
+- **Close the loop on deploys**: Mark the commit that reached production
+
+### Configuration
+
+- **Repository** (required): The repository containing the commit
+- **Commit** (required): The full commit hash to report on (supports expressions)
+- **Key** (required): A stable identifier for this check, e.g. `superplane-deploy`. Publishing again with the same key updates the existing status instead of adding a new one.
+- **Name** (optional): The human-readable name shown in Bitbucket. Defaults to the key.
+- **State** (required): The build state to report
+- **URL** (optional): A link to the run, so people can click through from Bitbucket
+- **Description** (optional): A short explanation shown next to the status
+
+### Permissions
+
+The token needs the `repository:write` scope on the repository.
+
+### Output
+
+The component emits the published status, including `key`, `state`, `url` and `refname`.
+
+Publishing a status fires the **On Commit Status** trigger, so be careful not to point that trigger at the
+same key this component writes — it would run the workflow again.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "commit": {
+      "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+        }
+      }
+    },
+    "created_on": "2026-08-11T11:24:18.402117+00:00",
+    "description": "Deployed to production",
+    "key": "superplane-deploy",
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses/build/superplane-deploy"
+      }
+    },
+    "name": "SuperPlane deploy",
+    "refname": "main",
+    "state": "SUCCESSFUL",
+    "type": "build",
+    "updated_on": "2026-08-11T11:31:52.660984+00:00",
+    "url": "https://app.superplane.com/canvases/web-delivery/runs/8f2c1a44"
+  },
+  "timestamp": "2026-08-11T11:31:52.704318Z",
+  "type": "bitbucket.commitStatus"
+}
+```
+
+<a id="update-pull-request"></a>
+
+## Update Pull Request
+
+**Component key:** `bitbucket.updatePullRequest`
+
+The Update Pull Request component modifies an existing Bitbucket pull request: its title, description, target branch, reviewers, or whether the source branch is deleted on merge.
+
+### Use Cases
+
+- **Progress reporting**: Rewrite the description as a workflow advances, so the pull request always shows current state
+- **Retargeting**: Move a pull request onto a different release branch
+- **Review routing**: Assign reviewers based on which files changed
+
+### Configuration
+
+- **Repository** (required): The repository containing the pull request
+- **Pull Request ID** (required): The numeric ID of the pull request (supports expressions)
+- **Title** (toggle): New title for the pull request
+- **Description** (toggle): New description for the pull request
+- **Target Branch** (toggle): Retarget the pull request onto a different branch
+- **Reviewers** (toggle): Workspace members to request a review from. Replaces the existing reviewers; selecting none clears them.
+- **Close Source Branch** (toggle): Whether the source branch is deleted when the pull request merges
+
+Each field besides Repository and Pull Request ID is toggled on individually, so only the fields you enable are sent. At least one must be enabled. Bitbucket rejects a blank title, so Title must have a value when enabled.
+
+### Permissions
+
+The token needs the `pullrequest:write` scope on the repository.
+
+### Output
+
+The component emits the updated pull request, in the same shape as **Create Pull Request**.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "author": {
+      "account_id": "712020:1f6a0d7c-5d54-4b1e-9a4f-6c2f9e0a7b31",
+      "display_name": "Anthony Foussette",
+      "nickname": "anthony",
+      "uuid": "{6b0b1d0e-6a1f-4f2f-9a2b-2f1d3a9c7e21}"
+    },
+    "close_source_branch": true,
+    "comment_count": 3,
+    "created_on": "2026-08-11T09:14:22.512345+00:00",
+    "description": "Adds the login page, wires it to the session API and covers it with tests.",
+    "destination": {
+      "branch": {
+        "name": "main"
+      },
+      "commit": {
+        "hash": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          }
+        }
+      },
+      "repository": {
+        "full_name": "superplane/web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        },
+        "name": "web",
+        "slug": "web",
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}"
+      }
+    },
+    "draft": false,
+    "id": 42,
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/pull-requests/42"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42"
+      }
+    },
+    "reviewers": [
+      {
+        "account_id": "712020:9c4e1b77-2a3d-4e58-b0c1-7f8a2d5e6c04",
+        "display_name": "Marta Silva",
+        "nickname": "marta",
+        "uuid": "{2a5f7c88-91b4-4f0a-8c62-1e7d9b0a4f13}"
+      }
+    ],
+    "source": {
+      "branch": {
+        "name": "feature/login-page"
+      },
+      "commit": {
+        "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          }
+        }
+      },
+      "repository": {
+        "full_name": "superplane/web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        },
+        "name": "web",
+        "slug": "web",
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}"
+      }
+    },
+    "state": "OPEN",
+    "task_count": 0,
+    "title": "Add login page and session handling",
+    "updated_on": "2026-08-11T10:02:47.881204+00:00"
+  },
+  "timestamp": "2026-08-11T10:02:47.925118Z",
+  "type": "bitbucket.pullRequest"
 }
 ```
 

--- a/pkg/grpc/actions/run_title_defaults.go
+++ b/pkg/grpc/actions/run_title_defaults.go
@@ -30,6 +30,9 @@ var defaultRunTitleExpressions = map[string]string{
 	"azure.onVirtualMachineRestarted":   "{{ root().data.subject }}",
 	"azure.onVirtualMachineStarted":     "{{ root().data.subject }}",
 	"azure.onVirtualMachineStopped":     "{{ root().data.subject }}",
+	"bitbucket.onCommitStatus":          "{{ root().data.commit_status.name }} {{ root().data.commit_status.state }}",
+	"bitbucket.onPRComment":             "#{{ root().data.pullrequest.id }} - {{ root().data.pullrequest.title }}",
+	"bitbucket.onPullRequest":           "#{{ root().data.pullrequest.id }} - {{ root().data.pullrequest.title }}",
 	"bitbucket.onPush":                  "{{ root().data.push.changes[0].new.name }}",
 	"circleci.onWorkflowCompleted":      "{{ root().data.workflow.name }}",
 

--- a/pkg/integrations/bitbucket/bitbucket.go
+++ b/pkg/integrations/bitbucket/bitbucket.go
@@ -120,12 +120,22 @@ func (b *Bitbucket) Configuration() []configuration.Field {
 }
 
 func (b *Bitbucket) Actions() []core.Action {
-	return []core.Action{}
+	return []core.Action{
+		&CreatePullRequest{},
+		&UpdatePullRequest{},
+		&MergePullRequest{},
+		&CreatePRComment{},
+		&PublishCommitStatus{},
+		&GetCommitStatus{},
+	}
 }
 
 func (b *Bitbucket) Triggers() []core.Trigger {
 	return []core.Trigger{
 		&OnPush{},
+		&OnPullRequest{},
+		&OnPRComment{},
+		&OnCommitStatus{},
 	}
 }
 

--- a/pkg/integrations/bitbucket/client.go
+++ b/pkg/integrations/bitbucket/client.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
@@ -250,4 +253,369 @@ func (c *Client) DeleteWebhook(workspace, repoSlug, webhookUID string) error {
 	}
 
 	return nil
+}
+
+//
+// Pull requests, comments and build statuses.
+//
+
+type Link struct {
+	Href string `json:"href,omitempty" mapstructure:"href"`
+}
+
+type ResourceLinks struct {
+	Self Link `json:"self" mapstructure:"self"`
+	HTML Link `json:"html" mapstructure:"html"`
+}
+
+type Account struct {
+	UUID        string `json:"uuid,omitempty" mapstructure:"uuid"`
+	AccountID   string `json:"account_id,omitempty" mapstructure:"account_id"`
+	DisplayName string `json:"display_name,omitempty" mapstructure:"display_name"`
+	Nickname    string `json:"nickname,omitempty" mapstructure:"nickname"`
+}
+
+// AccountRef identifies a user in write requests. Bitbucket accepts the UUID
+// (wrapped in braces) or the account_id, but not the display name.
+type AccountRef struct {
+	UUID string `json:"uuid"`
+}
+
+type Branch struct {
+	Name string `json:"name" mapstructure:"name"`
+}
+
+type Commit struct {
+	Hash  string        `json:"hash,omitempty" mapstructure:"hash"`
+	Links ResourceLinks `json:"links,omitempty" mapstructure:"links"`
+}
+
+type PullRequestEndpoint struct {
+	Branch     Branch      `json:"branch" mapstructure:"branch"`
+	Commit     *Commit     `json:"commit,omitempty" mapstructure:"commit"`
+	Repository *Repository `json:"repository,omitempty" mapstructure:"repository"`
+}
+
+type PullRequest struct {
+	ID                int                 `json:"id" mapstructure:"id"`
+	Title             string              `json:"title" mapstructure:"title"`
+	Description       string              `json:"description" mapstructure:"description"`
+	State             string              `json:"state" mapstructure:"state"`
+	Draft             bool                `json:"draft" mapstructure:"draft"`
+	CreatedOn         string              `json:"created_on" mapstructure:"created_on"`
+	UpdatedOn         string              `json:"updated_on" mapstructure:"updated_on"`
+	CloseSourceBranch bool                `json:"close_source_branch" mapstructure:"close_source_branch"`
+	CommentCount      int                 `json:"comment_count" mapstructure:"comment_count"`
+	TaskCount         int                 `json:"task_count" mapstructure:"task_count"`
+	Reason            string              `json:"reason,omitempty" mapstructure:"reason"`
+	Author            *Account            `json:"author,omitempty" mapstructure:"author"`
+	ClosedBy          *Account            `json:"closed_by,omitempty" mapstructure:"closed_by"`
+	Reviewers         []Account           `json:"reviewers,omitempty" mapstructure:"reviewers"`
+	Participants      []Participant       `json:"participants,omitempty" mapstructure:"participants"`
+	Source            PullRequestEndpoint `json:"source" mapstructure:"source"`
+	Destination       PullRequestEndpoint `json:"destination" mapstructure:"destination"`
+	MergeCommit       *Commit             `json:"merge_commit,omitempty" mapstructure:"merge_commit"`
+	Links             ResourceLinks       `json:"links" mapstructure:"links"`
+}
+
+type Participant struct {
+	User           *Account `json:"user,omitempty" mapstructure:"user"`
+	Role           string   `json:"role,omitempty" mapstructure:"role"`
+	Approved       bool     `json:"approved" mapstructure:"approved"`
+	State          string   `json:"state,omitempty" mapstructure:"state"`
+	ParticipatedOn string   `json:"participated_on,omitempty" mapstructure:"participated_on"`
+}
+
+type CommentContent struct {
+	Raw    string `json:"raw" mapstructure:"raw"`
+	Markup string `json:"markup,omitempty" mapstructure:"markup"`
+	HTML   string `json:"html,omitempty" mapstructure:"html"`
+}
+
+type PullRequestComment struct {
+	ID        int            `json:"id" mapstructure:"id"`
+	CreatedOn string         `json:"created_on" mapstructure:"created_on"`
+	UpdatedOn string         `json:"updated_on" mapstructure:"updated_on"`
+	Deleted   bool           `json:"deleted" mapstructure:"deleted"`
+	Content   CommentContent `json:"content" mapstructure:"content"`
+	User      *Account       `json:"user,omitempty" mapstructure:"user"`
+	Links     ResourceLinks  `json:"links" mapstructure:"links"`
+}
+
+type CommitStatus struct {
+	Key         string        `json:"key" mapstructure:"key"`
+	Name        string        `json:"name,omitempty" mapstructure:"name"`
+	State       string        `json:"state" mapstructure:"state"`
+	URL         string        `json:"url,omitempty" mapstructure:"url"`
+	Description string        `json:"description,omitempty" mapstructure:"description"`
+	Type        string        `json:"type,omitempty" mapstructure:"type"`
+	Refname     string        `json:"refname,omitempty" mapstructure:"refname"`
+	CreatedOn   string        `json:"created_on,omitempty" mapstructure:"created_on"`
+	UpdatedOn   string        `json:"updated_on,omitempty" mapstructure:"updated_on"`
+	Commit      *Commit       `json:"commit,omitempty" mapstructure:"commit"`
+	Links       ResourceLinks `json:"links,omitempty" mapstructure:"links"`
+}
+
+type CreatePullRequestRequest struct {
+	Title             string               `json:"title"`
+	Description       string               `json:"description,omitempty"`
+	Source            PullRequestEndpoint  `json:"source"`
+	Destination       *PullRequestEndpoint `json:"destination,omitempty"`
+	CloseSourceBranch bool                 `json:"close_source_branch"`
+	Reviewers         []AccountRef         `json:"reviewers,omitempty"`
+}
+
+// UpdatePullRequestRequest only serializes the fields the user actually filled in.
+// Bitbucket treats a present key as an overwrite, so sending a zero value would
+// silently wipe the title, description or reviewer list.
+type UpdatePullRequestRequest struct {
+	Title             *string              `json:"title,omitempty"`
+	Description       *string              `json:"description,omitempty"`
+	Destination       *PullRequestEndpoint `json:"destination,omitempty"`
+	CloseSourceBranch *bool                `json:"close_source_branch,omitempty"`
+	Reviewers         *[]AccountRef        `json:"reviewers,omitempty"`
+}
+
+type MergePullRequestRequest struct {
+	Type              string `json:"type"`
+	Message           string `json:"message,omitempty"`
+	MergeStrategy     string `json:"merge_strategy,omitempty"`
+	CloseSourceBranch *bool  `json:"close_source_branch,omitempty"`
+}
+
+type commitStatusesResponse struct {
+	Values []CommitStatus `json:"values"`
+	Next   string         `json:"next"`
+}
+
+// doJSON runs an authenticated request against the Bitbucket API. A nil body skips
+// the request payload; a nil out skips response decoding, for endpoints that answer
+// with no content.
+func (c *Client) doJSON(method, requestURL string, body any, out any, expectedStatuses ...int) error {
+	var payload io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("error marshaling request body: %w", err)
+		}
+
+		payload = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequest(method, requestURL, payload)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	c.setAuthHeaders(req)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("error executing request: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %w", err)
+	}
+
+	if !slices.Contains(expectedStatuses, resp.StatusCode) {
+		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if out == nil {
+		return nil
+	}
+
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("error decoding response: %w", err)
+	}
+
+	return nil
+}
+
+func repositoryURL(workspace, repoSlug string) string {
+	return fmt.Sprintf("%s/repositories/%s/%s", baseURL, url.PathEscape(workspace), url.PathEscape(repoSlug))
+}
+
+func pullRequestURL(workspace, repoSlug string, pullRequestID int) string {
+	return fmt.Sprintf("%s/pullrequests/%d", repositoryURL(workspace, repoSlug), pullRequestID)
+}
+
+func (c *Client) CreatePullRequest(workspace, repoSlug string, request *CreatePullRequestRequest) (*PullRequest, error) {
+	var pullRequest PullRequest
+	err := c.doJSON(
+		http.MethodPost,
+		fmt.Sprintf("%s/pullrequests", repositoryURL(workspace, repoSlug)),
+		request,
+		&pullRequest,
+		http.StatusOK, http.StatusCreated,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &pullRequest, nil
+}
+
+func (c *Client) GetPullRequest(workspace, repoSlug string, pullRequestID int) (*PullRequest, error) {
+	var pullRequest PullRequest
+	err := c.doJSON(
+		http.MethodGet,
+		pullRequestURL(workspace, repoSlug, pullRequestID),
+		nil,
+		&pullRequest,
+		http.StatusOK,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &pullRequest, nil
+}
+
+func (c *Client) UpdatePullRequest(workspace, repoSlug string, pullRequestID int, request *UpdatePullRequestRequest) (*PullRequest, error) {
+	var pullRequest PullRequest
+	err := c.doJSON(
+		http.MethodPut,
+		pullRequestURL(workspace, repoSlug, pullRequestID),
+		request,
+		&pullRequest,
+		http.StatusOK,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &pullRequest, nil
+}
+
+func (c *Client) MergePullRequest(workspace, repoSlug string, pullRequestID int, request *MergePullRequestRequest) (*PullRequest, error) {
+	var pullRequest PullRequest
+	err := c.doJSON(
+		http.MethodPost,
+		fmt.Sprintf("%s/merge", pullRequestURL(workspace, repoSlug, pullRequestID)),
+		request,
+		&pullRequest,
+		http.StatusOK, http.StatusCreated, http.StatusAccepted,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// On a slow merge Bitbucket answers 202 with a polling task rather than the pull
+	// request, which decodes into an empty struct. Report that instead of emitting a
+	// pull request payload that says nothing was merged.
+	if pullRequest.ID == 0 {
+		return nil, fmt.Errorf("bitbucket queued the merge asynchronously and did not return the merged pull request")
+	}
+
+	return &pullRequest, nil
+}
+
+func (c *Client) CreatePullRequestComment(workspace, repoSlug string, pullRequestID int, raw string) (*PullRequestComment, error) {
+	var comment PullRequestComment
+	err := c.doJSON(
+		http.MethodPost,
+		fmt.Sprintf("%s/comments", pullRequestURL(workspace, repoSlug, pullRequestID)),
+		map[string]any{"content": map[string]any{"raw": raw}},
+		&comment,
+		http.StatusOK, http.StatusCreated,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &comment, nil
+}
+
+func (c *Client) PublishCommitStatus(workspace, repoSlug, commit string, status *CommitStatus) (*CommitStatus, error) {
+	var published CommitStatus
+	err := c.doJSON(
+		http.MethodPost,
+		fmt.Sprintf("%s/commit/%s/statuses/build", repositoryURL(workspace, repoSlug), url.PathEscape(commit)),
+		status,
+		&published,
+		http.StatusOK, http.StatusCreated,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &published, nil
+}
+
+func (c *Client) ListCommitStatuses(workspace, repoSlug, commit string) ([]CommitStatus, error) {
+	next := fmt.Sprintf("%s/commit/%s/statuses?pagelen=100", repositoryURL(workspace, repoSlug), url.PathEscape(commit))
+	statuses := []CommitStatus{}
+
+	for next != "" {
+		var page commitStatusesResponse
+		if err := c.doJSON(http.MethodGet, next, nil, &page, http.StatusOK); err != nil {
+			return nil, err
+		}
+
+		statuses = append(statuses, page.Values...)
+		next = page.Next
+	}
+
+	return statuses, nil
+}
+
+// ListWorkspaceMembers backs the reviewer picker so users select real accounts
+// instead of typing Bitbucket UUIDs by hand.
+func (c *Client) ListWorkspaceMembers(workspace string) ([]Account, error) {
+	type membership struct {
+		User Account `json:"user"`
+	}
+
+	type membershipsResponse struct {
+		Values []membership `json:"values"`
+		Next   string       `json:"next"`
+	}
+
+	next := fmt.Sprintf("%s/workspaces/%s/members?pagelen=100", baseURL, url.PathEscape(workspace))
+	members := []Account{}
+
+	for next != "" {
+		var page membershipsResponse
+		if err := c.doJSON(http.MethodGet, next, nil, &page, http.StatusOK); err != nil {
+			return nil, err
+		}
+
+		for _, value := range page.Values {
+			members = append(members, value.User)
+		}
+
+		next = page.Next
+	}
+
+	return members, nil
+}
+
+// parsePullRequestID accepts the numeric ID Bitbucket uses for pull requests. The
+// value usually arrives from an expression, so it can be a string or a number.
+func parsePullRequestID(value string) (int, error) {
+	id, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("pull request ID %q is not a number", value)
+	}
+
+	if id <= 0 {
+		return 0, fmt.Errorf("pull request ID must be greater than zero")
+	}
+
+	return id, nil
 }

--- a/pkg/integrations/bitbucket/common.go
+++ b/pkg/integrations/bitbucket/common.go
@@ -2,10 +2,34 @@ package bitbucket
 
 import (
 	"fmt"
+	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/crypto"
+)
+
+const (
+	ResourceTypeRepository = "repository"
+	ResourceTypeMember     = "member"
+)
+
+// Build states accepted by the Bitbucket commit status API.
+const (
+	StateInProgress = "INPROGRESS"
+	StateSuccessful = "SUCCESSFUL"
+	StateFailed     = "FAILED"
+	StateStopped    = "STOPPED"
+)
+
+// Merge strategies accepted by the Bitbucket pull request merge API.
+const (
+	MergeStrategyMergeCommit = "merge_commit"
+	MergeStrategySquash      = "squash"
+	MergeStrategyFastForward = "fast_forward"
 )
 
 type NodeMetadata struct {
@@ -72,4 +96,129 @@ func repositoryMetadataMatches(repo RepositoryMetadata, repository string) bool 
 
 func repositoryMatches(repo Repository, repository string) bool {
 	return repo.FullName == repository || repo.Name == repository || repo.Slug == repository || repo.UUID == repository
+}
+
+// integrationClient builds a Bitbucket client and returns the integration metadata
+// alongside it, since every API path is scoped to the connected workspace.
+func integrationClient(httpCtx core.HTTPContext, integration core.IntegrationContext) (*Client, *Metadata, error) {
+	var metadata Metadata
+	if err := mapstructure.Decode(integration.GetMetadata(), &metadata); err != nil {
+		return nil, nil, fmt.Errorf("failed to decode integration metadata: %w", err)
+	}
+
+	if metadata.Workspace == nil {
+		return nil, nil, fmt.Errorf("integration is missing workspace metadata")
+	}
+
+	client, err := NewClient(metadata.AuthType, httpCtx, integration)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	return client, &metadata, nil
+}
+
+// repositoryTarget holds everything a component needs to call the Bitbucket API.
+type repositoryTarget struct {
+	Client     *Client
+	Workspace  string
+	Repository string
+}
+
+// resolveRepositoryTarget turns the repository the user picked — which may be a
+// UUID, a slug, a name or a full name — into the slug the API expects. The lookup
+// result is cached in the node metadata by ensureRepoInMetadata, so repeated
+// executions do not re-list the workspace repositories.
+func resolveRepositoryTarget(httpCtx core.HTTPContext, metadataCtx core.MetadataWriter, integration core.IntegrationContext, repository string) (*repositoryTarget, error) {
+	client, metadata, err := integrationClient(httpCtx, integration)
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := ensureRepoInMetadata(httpCtx, metadataCtx, integration, repository)
+	if err != nil {
+		return nil, err
+	}
+
+	return &repositoryTarget{
+		Client:     client,
+		Workspace:  metadata.Workspace.Slug,
+		Repository: repo.Slug,
+	}, nil
+}
+
+// verifyWebhookSignature checks the X-Hub-Signature header Bitbucket sends with every
+// delivery, and returns the status code the webhook should be answered with on failure.
+func verifyWebhookSignature(ctx core.WebhookRequestContext) (int, error) {
+	signature := ctx.Headers.Get("X-Hub-Signature")
+	if signature == "" {
+		return http.StatusForbidden, fmt.Errorf("missing X-Hub-Signature header")
+	}
+
+	signature = strings.TrimPrefix(signature, "sha256=")
+	if signature == "" {
+		return http.StatusForbidden, fmt.Errorf("invalid signature format")
+	}
+
+	secret, err := ctx.Webhook.GetSecret()
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error getting webhook secret")
+	}
+
+	if err := crypto.VerifySignature(secret, ctx.Body, signature); err != nil {
+		return http.StatusForbidden, fmt.Errorf("invalid signature")
+	}
+
+	return http.StatusOK, nil
+}
+
+// repositoryField builds the repository picker shared by every Bitbucket component.
+func repositoryField() configuration.Field {
+	return configuration.Field{
+		Name:     "repository",
+		Label:    "Repository",
+		Type:     configuration.FieldTypeIntegrationResource,
+		Required: true,
+		TypeOptions: &configuration.TypeOptions{
+			Resource: &configuration.ResourceTypeOptions{
+				Type:           ResourceTypeRepository,
+				UseNameAsValue: true,
+			},
+		},
+	}
+}
+
+// commitField builds the commit selector shared by the build status components.
+func commitField() configuration.Field {
+	return configuration.Field{
+		Name:        "commit",
+		Label:       "Commit",
+		Type:        configuration.FieldTypeString,
+		Required:    true,
+		Placeholder: "{{ root().data.pullrequest.source.commit.hash }}",
+		Description: "The full commit hash to report on",
+	}
+}
+
+func isValidCommitStatusState(state string) bool {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case StateInProgress, StateSuccessful, StateFailed, StateStopped:
+		return true
+	default:
+		return false
+	}
+}
+
+// pullRequestIDField builds the pull request selector shared by the pull request
+// actions. It is a string rather than a number because the value almost always comes
+// from an expression over a trigger payload.
+func pullRequestIDField() configuration.Field {
+	return configuration.Field{
+		Name:        "pullRequestId",
+		Label:       "Pull Request ID",
+		Type:        configuration.FieldTypeString,
+		Required:    true,
+		Placeholder: "42 or {{ root().data.pullrequest.id }}",
+		Description: "The numeric ID of the pull request",
+	}
 }

--- a/pkg/integrations/bitbucket/create_pr_comment.go
+++ b/pkg/integrations/bitbucket/create_pr_comment.go
@@ -1,0 +1,167 @@
+package bitbucket
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_create_pr_comment.json
+var exampleOutputCreatePRComment []byte
+
+type CreatePRComment struct{}
+
+type CreatePRCommentConfiguration struct {
+	Repository    string `json:"repository" mapstructure:"repository"`
+	PullRequestID string `json:"pullRequestId" mapstructure:"pullRequestId"`
+	Body          string `json:"body" mapstructure:"body"`
+}
+
+func (c *CreatePRComment) Name() string {
+	return "bitbucket.createPRComment"
+}
+
+func (c *CreatePRComment) Label() string {
+	return "Create Pull Request Comment"
+}
+
+func (c *CreatePRComment) Description() string {
+	return "Post a comment on a Bitbucket pull request"
+}
+
+func (c *CreatePRComment) Documentation() string {
+	return `The Create Pull Request Comment component posts a comment on a Bitbucket pull request.
+
+## Use Cases
+
+- **Preview environment URLs**: Post the URL of the environment provisioned for the pull request
+- **Agent output**: Return the result of a review or a test run to the people looking at the pull request
+- **Deployment feedback**: Report which environment the branch was deployed to, and when
+
+## Configuration
+
+- **Repository** (required): The repository containing the pull request
+- **Pull Request ID** (required): The numeric ID of the pull request (supports expressions)
+- **Body** (required): The comment body, in Markdown. Supports expressions.
+
+## Permissions
+
+The token needs the ` + "`pullrequest:write`" + ` scope on the repository.
+
+## Output
+
+The component emits the created comment, including:
+- **id**: The comment ID
+- **content.raw**: The Markdown that was posted
+- **links.html.href**: The URL of the comment on the pull request`
+}
+
+func (c *CreatePRComment) Icon() string {
+	return "bitbucket"
+}
+
+func (c *CreatePRComment) Color() string {
+	return "blue"
+}
+
+func (c *CreatePRComment) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreatePRComment) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputCreatePRComment, &example); err != nil {
+		return map[string]any{}
+	}
+
+	return example
+}
+
+func (c *CreatePRComment) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		pullRequestIDField(),
+		{
+			Name:        "body",
+			Label:       "Body",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Description: "The comment body, in Markdown",
+		},
+	}
+}
+
+func (c *CreatePRComment) Setup(ctx core.SetupContext) error {
+	config := CreatePRCommentConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.PullRequestID == "" {
+		return fmt.Errorf("pull request ID is required")
+	}
+
+	if config.Body == "" {
+		return fmt.Errorf("body is required")
+	}
+
+	_, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	return err
+}
+
+func (c *CreatePRComment) Execute(ctx core.ExecutionContext) error {
+	config := CreatePRCommentConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	pullRequestID, err := parsePullRequestID(config.PullRequestID)
+	if err != nil {
+		return err
+	}
+
+	target, err := resolveRepositoryTarget(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	comment, err := target.Client.CreatePullRequestComment(target.Workspace, target.Repository, pullRequestID, config.Body)
+	if err != nil {
+		return fmt.Errorf("failed to create pull request comment: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"bitbucket.pullRequestComment",
+		[]any{comment},
+	)
+}
+
+func (c *CreatePRComment) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreatePRComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *CreatePRComment) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreatePRComment) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreatePRComment) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreatePRComment) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/bitbucket/create_pr_comment_test.go
+++ b/pkg/integrations/bitbucket/create_pr_comment_test.go
@@ -1,0 +1,87 @@
+package bitbucket
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const createdCommentResponse = `{
+  "id": 481902337,
+  "content": {"raw": "Preview environment is up", "markup": "markdown"},
+  "links": {"html": {"href": "https://bitbucket.org/superplane/web/pull-requests/42/_/diff#comment-481902337"}}
+}`
+
+func Test__CreatePRComment__Setup(t *testing.T) {
+	action := &CreatePRComment{}
+
+	t.Run("pull request ID is required", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository": testRepositoryName,
+			"body":       "hello",
+		}))
+
+		require.ErrorContains(t, err, "pull request ID is required")
+	})
+
+	t.Run("body is required", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+		}))
+
+		require.ErrorContains(t, err, "body is required")
+	})
+
+	t.Run("valid configuration is accepted", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"body":          "Preview environment is up",
+		}))
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreatePRComment__Execute(t *testing.T) {
+	action := &CreatePRComment{}
+
+	t.Run("comment is posted and emitted", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"body":          "Preview environment is up",
+		}, jsonResponse(http.StatusCreated, createdCommentResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		require.Len(t, fixture.HTTP.Requests, 1)
+		request := fixture.HTTP.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42/comments", request.URL.String())
+
+		body := requestBody(t, request)
+		assert.Equal(t, "Preview environment is up", body["content"].(map[string]any)["raw"])
+
+		comment := emittedPayload[*PullRequestComment](t, fixture.ExecutionState, 0)
+		assert.Equal(t, 481902337, comment.ID)
+		assert.Equal(t, "Preview environment is up", comment.Content.Raw)
+		assert.Equal(t, "bitbucket.pullRequestComment", fixture.ExecutionState.Type)
+	})
+
+	t.Run("API error is reported", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"body":          "Preview environment is up",
+		}, jsonResponse(http.StatusNotFound, `{"error":{"message":"pull request not found"}}`))
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "failed to create pull request comment")
+		require.ErrorContains(t, err, "pull request not found")
+	})
+}

--- a/pkg/integrations/bitbucket/create_pull_request.go
+++ b/pkg/integrations/bitbucket/create_pull_request.go
@@ -1,0 +1,250 @@
+package bitbucket
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_create_pull_request.json
+var exampleOutputCreatePullRequest []byte
+
+type CreatePullRequest struct{}
+
+type CreatePullRequestConfiguration struct {
+	Repository        string   `json:"repository" mapstructure:"repository"`
+	SourceBranch      string   `json:"sourceBranch" mapstructure:"sourceBranch"`
+	TargetBranch      string   `json:"targetBranch" mapstructure:"targetBranch"`
+	Title             string   `json:"title" mapstructure:"title"`
+	Description       string   `json:"description" mapstructure:"description"`
+	Reviewers         []string `json:"reviewers" mapstructure:"reviewers"`
+	CloseSourceBranch bool     `json:"closeSourceBranch" mapstructure:"closeSourceBranch"`
+}
+
+func (c *CreatePullRequest) Name() string {
+	return "bitbucket.createPullRequest"
+}
+
+func (c *CreatePullRequest) Label() string {
+	return "Create Pull Request"
+}
+
+func (c *CreatePullRequest) Description() string {
+	return "Open a new pull request in a Bitbucket repository"
+}
+
+func (c *CreatePullRequest) Documentation() string {
+	return `The Create Pull Request component opens a new pull request in a Bitbucket repository.
+
+## Use Cases
+
+- **Automated fixes**: An agent pushes a fix to a branch and opens a pull request for human review
+- **Dependency updates**: Open a pull request when a dependency bump or changelog is generated
+- **Release automation**: Promote a release branch into ` + "`main`" + ` through a reviewable pull request
+
+## Configuration
+
+- **Repository** (required): The repository where the pull request is opened
+- **Source Branch** (required): The branch holding the changes (supports expressions)
+- **Target Branch** (optional): The branch to merge into. Leave empty to use the repository's main branch.
+- **Title** (required): The title of the pull request
+- **Description** (optional): The pull request description, in Markdown
+- **Reviewers** (optional): Workspace members to request a review from
+- **Close Source Branch** (optional): Delete the source branch once the pull request is merged
+
+## Permissions
+
+The token needs the ` + "`pullrequest:write`" + ` scope on the repository.
+
+## Output
+
+The component emits the created pull request, including:
+- **id**: The pull request number used by every other Bitbucket component
+- **state**: ` + "`OPEN`" + ` for a freshly created pull request
+- **source.branch.name** and **destination.branch.name**: The branches involved
+- **links.html.href**: The URL to open the pull request in Bitbucket`
+}
+
+func (c *CreatePullRequest) Icon() string {
+	return "bitbucket"
+}
+
+func (c *CreatePullRequest) Color() string {
+	return "blue"
+}
+
+func (c *CreatePullRequest) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreatePullRequest) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputCreatePullRequest, &example); err != nil {
+		return map[string]any{}
+	}
+
+	return example
+}
+
+func (c *CreatePullRequest) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		{
+			Name:        "sourceBranch",
+			Label:       "Source Branch",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "feature/login-page or {{ root().data.push.changes[0].new.name }}",
+			Description: "The branch that holds the changes",
+		},
+		{
+			Name:        "targetBranch",
+			Label:       "Target Branch",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Placeholder: "main",
+			Description: "The branch to merge into. Leave empty to use the repository's main branch.",
+		},
+		{
+			Name:     "title",
+			Label:    "Title",
+			Type:     configuration.FieldTypeString,
+			Required: true,
+		},
+		{
+			Name:     "description",
+			Label:    "Description",
+			Type:     configuration.FieldTypeText,
+			Required: false,
+		},
+		{
+			Name:        "reviewers",
+			Label:       "Reviewers",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Workspace members to request a review from",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:  ResourceTypeMember,
+					Multi: true,
+				},
+			},
+		},
+		{
+			Name:        "closeSourceBranch",
+			Label:       "Close Source Branch",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Description: "Delete the source branch when the pull request is merged",
+		},
+	}
+}
+
+func (c *CreatePullRequest) Setup(ctx core.SetupContext) error {
+	config := CreatePullRequestConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.SourceBranch == "" {
+		return fmt.Errorf("source branch is required")
+	}
+
+	if config.Title == "" {
+		return fmt.Errorf("title is required")
+	}
+
+	_, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	return err
+}
+
+func (c *CreatePullRequest) Execute(ctx core.ExecutionContext) error {
+	config := CreatePullRequestConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	target, err := resolveRepositoryTarget(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	request := &CreatePullRequestRequest{
+		Title:             config.Title,
+		Description:       config.Description,
+		Source:            PullRequestEndpoint{Branch: Branch{Name: normalizeBranch(config.SourceBranch)}},
+		CloseSourceBranch: config.CloseSourceBranch,
+		Reviewers:         accountRefs(config.Reviewers),
+	}
+
+	// Bitbucket falls back to the repository main branch when no destination is sent,
+	// so an empty target branch stays absent from the payload rather than becoming "".
+	if targetBranch := normalizeBranch(config.TargetBranch); targetBranch != "" {
+		request.Destination = &PullRequestEndpoint{Branch: Branch{Name: targetBranch}}
+	}
+
+	pullRequest, err := target.Client.CreatePullRequest(target.Workspace, target.Repository, request)
+	if err != nil {
+		return fmt.Errorf("failed to create pull request: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"bitbucket.pullRequest",
+		[]any{pullRequest},
+	)
+}
+
+func (c *CreatePullRequest) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreatePullRequest) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *CreatePullRequest) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreatePullRequest) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreatePullRequest) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreatePullRequest) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+// normalizeBranch accepts both a plain branch name and a full ref, because branch
+// values often come from a push event where the ref is spelled refs/heads/<name>.
+func normalizeBranch(branch string) string {
+	return strings.TrimPrefix(strings.TrimSpace(branch), "refs/heads/")
+}
+
+func accountRefs(accounts []string) []AccountRef {
+	refs := make([]AccountRef, 0, len(accounts))
+	for _, account := range accounts {
+		account = strings.TrimSpace(account)
+		if account == "" {
+			continue
+		}
+
+		refs = append(refs, AccountRef{UUID: account})
+	}
+
+	if len(refs) == 0 {
+		return nil
+	}
+
+	return refs
+}

--- a/pkg/integrations/bitbucket/create_pull_request_test.go
+++ b/pkg/integrations/bitbucket/create_pull_request_test.go
@@ -1,0 +1,179 @@
+package bitbucket
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+const createdPullRequestResponse = `{
+  "id": 42,
+  "title": "Add login page",
+  "state": "OPEN",
+  "source": {"branch": {"name": "feature/login-page"}},
+  "destination": {"branch": {"name": "main"}},
+  "links": {"html": {"href": "https://bitbucket.org/superplane/web/pull-requests/42"}}
+}`
+
+func Test__CreatePullRequest__Setup(t *testing.T) {
+	action := &CreatePullRequest{}
+
+	t.Run("source branch is required", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository": testRepositoryName,
+			"title":      "Add login page",
+		}))
+
+		require.ErrorContains(t, err, "source branch is required")
+	})
+
+	t.Run("title is required", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":   testRepositoryName,
+			"sourceBranch": "feature/login-page",
+		}))
+
+		require.ErrorContains(t, err, "title is required")
+	})
+
+	t.Run("valid configuration is accepted", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":   testRepositoryName,
+			"sourceBranch": "feature/login-page",
+			"title":        "Add login page",
+		}))
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreatePullRequest__Execute(t *testing.T) {
+	action := &CreatePullRequest{}
+
+	t.Run("pull request is created and emitted", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":        testRepositoryName,
+			"sourceBranch":      "feature/login-page",
+			"targetBranch":      "main",
+			"title":             "Add login page",
+			"description":       "Adds the login page.",
+			"closeSourceBranch": true,
+			"reviewers":         []string{"{reviewer-uuid}"},
+		}, jsonResponse(http.StatusCreated, createdPullRequestResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		require.Len(t, fixture.HTTP.Requests, 1)
+		request := fixture.HTTP.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests", request.URL.String())
+
+		body := requestBody(t, request)
+		assert.Equal(t, "Add login page", body["title"])
+		assert.Equal(t, "Adds the login page.", body["description"])
+		assert.Equal(t, true, body["close_source_branch"])
+		assert.Equal(t, "feature/login-page", body["source"].(map[string]any)["branch"].(map[string]any)["name"])
+		assert.Equal(t, "main", body["destination"].(map[string]any)["branch"].(map[string]any)["name"])
+
+		reviewers := body["reviewers"].([]any)
+		require.Len(t, reviewers, 1)
+		assert.Equal(t, "{reviewer-uuid}", reviewers[0].(map[string]any)["uuid"])
+
+		assert.True(t, fixture.ExecutionState.Passed)
+		assert.Equal(t, "bitbucket.pullRequest", fixture.ExecutionState.Type)
+		require.Len(t, fixture.ExecutionState.Payloads, 1)
+		pullRequest := emittedPayload[*PullRequest](t, fixture.ExecutionState, 0)
+		assert.Equal(t, 42, pullRequest.ID)
+		assert.Equal(t, "OPEN", pullRequest.State)
+		assert.Equal(t, "https://bitbucket.org/superplane/web/pull-requests/42", pullRequest.Links.HTML.Href)
+	})
+
+	// Bitbucket falls back to the repository main branch when no destination is sent,
+	// so an empty target branch must stay out of the payload entirely.
+	t.Run("empty target branch is omitted from the payload", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":   testRepositoryName,
+			"sourceBranch": "feature/login-page",
+			"title":        "Add login page",
+		}, jsonResponse(http.StatusCreated, createdPullRequestResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		body := requestBody(t, fixture.HTTP.Requests[0])
+		_, present := body["destination"]
+		assert.False(t, present)
+	})
+
+	// Branch values commonly come from a push event, where the ref is a full refs/heads path.
+	t.Run("a full ref is accepted as a branch name", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":   testRepositoryName,
+			"sourceBranch": "refs/heads/feature/login-page",
+			"targetBranch": "refs/heads/main",
+			"title":        "Add login page",
+		}, jsonResponse(http.StatusCreated, createdPullRequestResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		body := requestBody(t, fixture.HTTP.Requests[0])
+		assert.Equal(t, "feature/login-page", body["source"].(map[string]any)["branch"].(map[string]any)["name"])
+		assert.Equal(t, "main", body["destination"].(map[string]any)["branch"].(map[string]any)["name"])
+	})
+
+	t.Run("API error is reported", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":   testRepositoryName,
+			"sourceBranch": "feature/login-page",
+			"title":        "Add login page",
+		}, jsonResponse(http.StatusBadRequest, `{"error":{"message":"source branch does not exist"}}`))
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "failed to create pull request")
+		require.ErrorContains(t, err, "source branch does not exist")
+	})
+
+	t.Run("integration without workspace metadata is reported", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":   testRepositoryName,
+			"sourceBranch": "feature/login-page",
+			"title":        "Add login page",
+		})
+
+		fixture.Context.Integration = &contexts.IntegrationContext{
+			Configuration: map[string]any{"token": "token"},
+			Metadata:      Metadata{AuthType: AuthTypeWorkspaceAccessToken},
+		}
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "integration is missing workspace metadata")
+	})
+}
+
+func Test__NormalizeBranch(t *testing.T) {
+	assert.Equal(t, "main", normalizeBranch("main"))
+	assert.Equal(t, "main", normalizeBranch("refs/heads/main"))
+	assert.Equal(t, "main", normalizeBranch("  main  "))
+	assert.Equal(t, "release/2026-08", normalizeBranch("refs/heads/release/2026-08"))
+	assert.Empty(t, normalizeBranch(""))
+}
+
+func Test__AccountRefs(t *testing.T) {
+	t.Run("blank entries are dropped", func(t *testing.T) {
+		refs := accountRefs([]string{"{a}", "", "  ", "{b}"})
+		require.Len(t, refs, 2)
+		assert.Equal(t, "{a}", refs[0].UUID)
+		assert.Equal(t, "{b}", refs[1].UUID)
+	})
+
+	// A nil slice keeps the key out of the JSON payload, which is what "do not touch
+	// the reviewers" means to the Bitbucket API.
+	t.Run("no accounts yields nil", func(t *testing.T) {
+		assert.Nil(t, accountRefs(nil))
+		assert.Nil(t, accountRefs([]string{"", " "}))
+	})
+}

--- a/pkg/integrations/bitbucket/example.go
+++ b/pkg/integrations/bitbucket/example.go
@@ -16,3 +16,33 @@ var exampleDataOnPush map[string]any
 func (t *OnPush) ExampleData() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleDataOnPushOnce, exampleDataOnPushBytes, &exampleDataOnPush)
 }
+
+//go:embed example_data_on_pull_request.json
+var exampleDataOnPullRequestBytes []byte
+
+var exampleDataOnPullRequestOnce sync.Once
+var exampleDataOnPullRequest map[string]any
+
+func (p *OnPullRequest) ExampleData() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleDataOnPullRequestOnce, exampleDataOnPullRequestBytes, &exampleDataOnPullRequest)
+}
+
+//go:embed example_data_on_pr_comment.json
+var exampleDataOnPRCommentBytes []byte
+
+var exampleDataOnPRCommentOnce sync.Once
+var exampleDataOnPRComment map[string]any
+
+func (c *OnPRComment) ExampleData() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleDataOnPRCommentOnce, exampleDataOnPRCommentBytes, &exampleDataOnPRComment)
+}
+
+//go:embed example_data_on_commit_status.json
+var exampleDataOnCommitStatusBytes []byte
+
+var exampleDataOnCommitStatusOnce sync.Once
+var exampleDataOnCommitStatus map[string]any
+
+func (s *OnCommitStatus) ExampleData() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleDataOnCommitStatusOnce, exampleDataOnCommitStatusBytes, &exampleDataOnCommitStatus)
+}

--- a/pkg/integrations/bitbucket/example_data_on_commit_status.json
+++ b/pkg/integrations/bitbucket/example_data_on_commit_status.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "actor": {
+      "display_name": "John Doe",
+      "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}",
+      "type": "user",
+      "nickname": "johndoe",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/johndoe/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/johndoe/avatar/"
+        }
+      }
+    },
+    "repository": {
+      "type": "repository",
+      "full_name": "my-workspace/my-repo",
+      "name": "my-repo",
+      "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo"
+        }
+      }
+    },
+    "commit_status": {
+      "type": "build",
+      "key": "BITBUCKETPIPELINE",
+      "name": "Pipeline #128 for main",
+      "state": "SUCCESSFUL",
+      "url": "https://bitbucket.org/my-workspace/my-repo/pipelines/results/128",
+      "description": "Pipeline succeeded",
+      "refname": "main",
+      "created_on": "2024-01-15T10:24:03.118093+00:00",
+      "updated_on": "2024-01-15T10:29:57.774502+00:00",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/commit/709d658dc5b6d6afcd46049c2f332ee3f515a67d/statuses/build/BITBUCKETPIPELINE"
+        },
+        "commit": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/commit/709d658dc5b6d6afcd46049c2f332ee3f515a67d"
+        }
+      }
+    }
+  },
+  "timestamp": "2024-01-15T10:30:00Z",
+  "type": "bitbucket.commitStatus"
+}

--- a/pkg/integrations/bitbucket/example_data_on_pr_comment.json
+++ b/pkg/integrations/bitbucket/example_data_on_pr_comment.json
@@ -1,0 +1,152 @@
+{
+  "data": {
+    "actor": {
+      "display_name": "John Doe",
+      "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}",
+      "type": "user",
+      "nickname": "johndoe",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/johndoe/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/johndoe/avatar/"
+        }
+      }
+    },
+    "repository": {
+      "type": "repository",
+      "full_name": "my-workspace/my-repo",
+      "name": "my-repo",
+      "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo"
+        }
+      }
+    },
+    "pullrequest": {
+      "type": "pullrequest",
+      "id": 42,
+      "title": "feat: add login page",
+      "description": "Adds the login page and wires it to the session API.",
+      "state": "OPEN",
+      "draft": false,
+      "created_on": "2024-01-15T10:28:41.153217+00:00",
+      "updated_on": "2024-01-15T10:28:41.153217+00:00",
+      "close_source_branch": true,
+      "comment_count": 0,
+      "task_count": 0,
+      "author": {
+        "display_name": "John Doe",
+        "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}",
+        "type": "user",
+        "nickname": "johndoe",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/johndoe/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/johndoe/avatar/"
+          }
+        }
+      },
+      "reviewers": [],
+      "participants": [],
+      "source": {
+        "branch": {
+          "name": "feature/login-page"
+        },
+        "commit": {
+          "type": "commit",
+          "hash": "709d658dc5b6d6afcd46049c2f332ee3f515a67d",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo/commits/709d658dc5b6d6afcd46049c2f332ee3f515a67d"
+            }
+          }
+        },
+        "repository": {
+          "type": "repository",
+          "full_name": "my-workspace/my-repo",
+          "name": "my-repo",
+          "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo"
+            }
+          }
+        }
+      },
+      "destination": {
+        "branch": {
+          "name": "main"
+        },
+        "commit": {
+          "type": "commit",
+          "hash": "1f4b0c6d9a2e5f8b3c7d0e1a4b6c9d2e5f8a1b3c",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo/commits/1f4b0c6d9a2e5f8b3c7d0e1a4b6c9d2e5f8a1b3c"
+            }
+          }
+        },
+        "repository": {
+          "type": "repository",
+          "full_name": "my-workspace/my-repo",
+          "name": "my-repo",
+          "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo"
+            }
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42"
+        },
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo/pull-requests/42"
+        }
+      }
+    },
+    "comment": {
+      "type": "pullrequest_comment",
+      "id": 481902337,
+      "created_on": "2024-01-15T10:31:12.884401+00:00",
+      "updated_on": "2024-01-15T10:31:12.884401+00:00",
+      "deleted": false,
+      "content": {
+        "raw": "/deploy staging",
+        "markup": "markdown",
+        "html": "<p>/deploy staging</p>"
+      },
+      "user": {
+        "display_name": "John Doe",
+        "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}",
+        "type": "user",
+        "nickname": "johndoe",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/johndoe/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/johndoe/avatar/"
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments/481902337"
+        },
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo/pull-requests/42/_/diff#comment-481902337"
+        }
+      }
+    }
+  },
+  "timestamp": "2024-01-15T10:30:00Z",
+  "type": "bitbucket.pullRequestComment"
+}

--- a/pkg/integrations/bitbucket/example_data_on_pull_request.json
+++ b/pkg/integrations/bitbucket/example_data_on_pull_request.json
@@ -1,0 +1,118 @@
+{
+  "data": {
+    "actor": {
+      "display_name": "John Doe",
+      "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}",
+      "type": "user",
+      "nickname": "johndoe",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/johndoe/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/johndoe/avatar/"
+        }
+      }
+    },
+    "repository": {
+      "type": "repository",
+      "full_name": "my-workspace/my-repo",
+      "name": "my-repo",
+      "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo"
+        }
+      }
+    },
+    "pullrequest": {
+      "type": "pullrequest",
+      "id": 42,
+      "title": "feat: add login page",
+      "description": "Adds the login page and wires it to the session API.",
+      "state": "OPEN",
+      "draft": false,
+      "created_on": "2024-01-15T10:28:41.153217+00:00",
+      "updated_on": "2024-01-15T10:28:41.153217+00:00",
+      "close_source_branch": true,
+      "comment_count": 0,
+      "task_count": 0,
+      "author": {
+        "display_name": "John Doe",
+        "uuid": "{d301aafa-d676-4ee0-a3f1-8b94c681feaa}",
+        "type": "user",
+        "nickname": "johndoe",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/johndoe/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/johndoe/avatar/"
+          }
+        }
+      },
+      "reviewers": [],
+      "participants": [],
+      "source": {
+        "branch": {
+          "name": "feature/login-page"
+        },
+        "commit": {
+          "type": "commit",
+          "hash": "709d658dc5b6d6afcd46049c2f332ee3f515a67d",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo/commits/709d658dc5b6d6afcd46049c2f332ee3f515a67d"
+            }
+          }
+        },
+        "repository": {
+          "type": "repository",
+          "full_name": "my-workspace/my-repo",
+          "name": "my-repo",
+          "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo"
+            }
+          }
+        }
+      },
+      "destination": {
+        "branch": {
+          "name": "main"
+        },
+        "commit": {
+          "type": "commit",
+          "hash": "1f4b0c6d9a2e5f8b3c7d0e1a4b6c9d2e5f8a1b3c",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo/commits/1f4b0c6d9a2e5f8b3c7d0e1a4b6c9d2e5f8a1b3c"
+            }
+          }
+        },
+        "repository": {
+          "type": "repository",
+          "full_name": "my-workspace/my-repo",
+          "name": "my-repo",
+          "uuid": "{b7f10c3a-2a1e-4c36-af54-7e818f3b6e1d}",
+          "links": {
+            "html": {
+              "href": "https://bitbucket.org/my-workspace/my-repo"
+            }
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42"
+        },
+        "html": {
+          "href": "https://bitbucket.org/my-workspace/my-repo/pull-requests/42"
+        }
+      }
+    }
+  },
+  "timestamp": "2024-01-15T10:30:00Z",
+  "type": "bitbucket.pullRequest"
+}

--- a/pkg/integrations/bitbucket/example_output_create_pr_comment.json
+++ b/pkg/integrations/bitbucket/example_output_create_pr_comment.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "id": 481902337,
+    "created_on": "2026-08-11T09:41:03.774219+00:00",
+    "updated_on": "2026-08-11T09:41:03.774219+00:00",
+    "deleted": false,
+    "content": {
+      "raw": "Preview environment is up: https://pr-42.preview.superplane.dev",
+      "markup": "markdown",
+      "html": "<p>Preview environment is up: <a href=\"https://pr-42.preview.superplane.dev\">https://pr-42.preview.superplane.dev</a></p>"
+    },
+    "user": {
+      "uuid": "{6b0b1d0e-6a1f-4f2f-9a2b-2f1d3a9c7e21}",
+      "account_id": "712020:1f6a0d7c-5d54-4b1e-9a4f-6c2f9e0a7b31",
+      "display_name": "Anthony Foussette",
+      "nickname": "anthony"
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42/comments/481902337"
+      },
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/pull-requests/42/_/diff#comment-481902337"
+      }
+    }
+  },
+  "timestamp": "2026-08-11T09:41:03.812905Z",
+  "type": "bitbucket.pullRequestComment"
+}

--- a/pkg/integrations/bitbucket/example_output_create_pull_request.json
+++ b/pkg/integrations/bitbucket/example_output_create_pull_request.json
@@ -1,0 +1,92 @@
+{
+  "data": {
+    "id": 42,
+    "title": "Add login page",
+    "description": "Adds the login page and wires it to the session API.",
+    "state": "OPEN",
+    "draft": false,
+    "created_on": "2026-08-11T09:14:22.512345+00:00",
+    "updated_on": "2026-08-11T09:14:22.512345+00:00",
+    "close_source_branch": true,
+    "comment_count": 0,
+    "task_count": 0,
+    "author": {
+      "uuid": "{6b0b1d0e-6a1f-4f2f-9a2b-2f1d3a9c7e21}",
+      "account_id": "712020:1f6a0d7c-5d54-4b1e-9a4f-6c2f9e0a7b31",
+      "display_name": "Anthony Foussette",
+      "nickname": "anthony"
+    },
+    "reviewers": [
+      {
+        "uuid": "{2a5f7c88-91b4-4f0a-8c62-1e7d9b0a4f13}",
+        "account_id": "712020:9c4e1b77-2a3d-4e58-b0c1-7f8a2d5e6c04",
+        "display_name": "Marta Silva",
+        "nickname": "marta"
+      }
+    ],
+    "source": {
+      "branch": {
+        "name": "feature/login-page"
+      },
+      "commit": {
+        "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          },
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          }
+        }
+      },
+      "repository": {
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}",
+        "name": "web",
+        "full_name": "superplane/web",
+        "slug": "web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        }
+      }
+    },
+    "destination": {
+      "branch": {
+        "name": "main"
+      },
+      "commit": {
+        "hash": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          },
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          }
+        }
+      },
+      "repository": {
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}",
+        "name": "web",
+        "full_name": "superplane/web",
+        "slug": "web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        }
+      }
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42"
+      },
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/pull-requests/42"
+      }
+    }
+  },
+  "timestamp": "2026-08-11T09:14:22.618432Z",
+  "type": "bitbucket.pullRequest"
+}

--- a/pkg/integrations/bitbucket/example_output_get_commit_status.json
+++ b/pkg/integrations/bitbucket/example_output_get_commit_status.json
@@ -1,0 +1,71 @@
+{
+  "data": {
+    "commit": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+    "state": "SUCCESSFUL",
+    "total_count": 2,
+    "statuses": [
+      {
+        "key": "BITBUCKETPIPELINE",
+        "name": "Pipeline #128 for main",
+        "state": "SUCCESSFUL",
+        "url": "https://bitbucket.org/superplane/web/pipelines/results/128",
+        "description": "Pipeline succeeded",
+        "type": "build",
+        "refname": "main",
+        "created_on": "2026-08-11T11:02:44.118093+00:00",
+        "updated_on": "2026-08-11T11:09:31.774502+00:00",
+        "commit": {
+          "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+            },
+            "html": {
+              "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+            }
+          }
+        },
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses/build/BITBUCKETPIPELINE"
+          },
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          }
+        }
+      },
+      {
+        "key": "superplane-deploy",
+        "name": "SuperPlane deploy",
+        "state": "SUCCESSFUL",
+        "url": "https://app.superplane.com/canvases/web-delivery/runs/8f2c1a44",
+        "description": "Deployed to production",
+        "type": "build",
+        "refname": "main",
+        "created_on": "2026-08-11T11:24:18.402117+00:00",
+        "updated_on": "2026-08-11T11:31:52.660984+00:00",
+        "commit": {
+          "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+            },
+            "html": {
+              "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+            }
+          }
+        },
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses/build/superplane-deploy"
+          },
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          }
+        }
+      }
+    ]
+  },
+  "timestamp": "2026-08-11T11:32:10.559274Z",
+  "type": "bitbucket.commitStatuses"
+}

--- a/pkg/integrations/bitbucket/example_output_merge_pull_request.json
+++ b/pkg/integrations/bitbucket/example_output_merge_pull_request.json
@@ -1,0 +1,109 @@
+{
+  "data": {
+    "id": 42,
+    "title": "Add login page",
+    "description": "Adds the login page and wires it to the session API.",
+    "state": "MERGED",
+    "draft": false,
+    "created_on": "2026-08-11T09:14:22.512345+00:00",
+    "updated_on": "2026-08-11T11:20:05.104773+00:00",
+    "close_source_branch": true,
+    "comment_count": 3,
+    "task_count": 0,
+    "author": {
+      "uuid": "{6b0b1d0e-6a1f-4f2f-9a2b-2f1d3a9c7e21}",
+      "account_id": "712020:1f6a0d7c-5d54-4b1e-9a4f-6c2f9e0a7b31",
+      "display_name": "Anthony Foussette",
+      "nickname": "anthony"
+    },
+    "reviewers": [
+      {
+        "uuid": "{2a5f7c88-91b4-4f0a-8c62-1e7d9b0a4f13}",
+        "account_id": "712020:9c4e1b77-2a3d-4e58-b0c1-7f8a2d5e6c04",
+        "display_name": "Marta Silva",
+        "nickname": "marta"
+      }
+    ],
+    "source": {
+      "branch": {
+        "name": "feature/login-page"
+      },
+      "commit": {
+        "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          },
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          }
+        }
+      },
+      "repository": {
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}",
+        "name": "web",
+        "full_name": "superplane/web",
+        "slug": "web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        }
+      }
+    },
+    "destination": {
+      "branch": {
+        "name": "main"
+      },
+      "commit": {
+        "hash": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          },
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          }
+        }
+      },
+      "repository": {
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}",
+        "name": "web",
+        "full_name": "superplane/web",
+        "slug": "web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        }
+      }
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42"
+      },
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/pull-requests/42"
+      }
+    },
+    "closed_by": {
+      "uuid": "{2a5f7c88-91b4-4f0a-8c62-1e7d9b0a4f13}",
+      "account_id": "712020:9c4e1b77-2a3d-4e58-b0c1-7f8a2d5e6c04",
+      "display_name": "Marta Silva",
+      "nickname": "marta"
+    },
+    "merge_commit": {
+      "hash": "7ab3c9d1e5f28046b1c3a7d9e2b4c6d8e0f1a2b3",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/7ab3c9d1e5f28046b1c3a7d9e2b4c6d8e0f1a2b3"
+        },
+        "html": {
+          "href": "https://bitbucket.org/superplane/web/commits/7ab3c9d1e5f28046b1c3a7d9e2b4c6d8e0f1a2b3"
+        }
+      }
+    }
+  },
+  "timestamp": "2026-08-11T11:20:05.211640Z",
+  "type": "bitbucket.pullRequest"
+}

--- a/pkg/integrations/bitbucket/example_output_publish_commit_status.json
+++ b/pkg/integrations/bitbucket/example_output_publish_commit_status.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "key": "superplane-deploy",
+    "name": "SuperPlane deploy",
+    "state": "SUCCESSFUL",
+    "url": "https://app.superplane.com/canvases/web-delivery/runs/8f2c1a44",
+    "description": "Deployed to production",
+    "type": "build",
+    "refname": "main",
+    "created_on": "2026-08-11T11:24:18.402117+00:00",
+    "updated_on": "2026-08-11T11:31:52.660984+00:00",
+    "commit": {
+      "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+        },
+        "html": {
+          "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+        }
+      }
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses/build/superplane-deploy"
+      },
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+      }
+    }
+  },
+  "timestamp": "2026-08-11T11:31:52.704318Z",
+  "type": "bitbucket.commitStatus"
+}

--- a/pkg/integrations/bitbucket/example_output_update_pull_request.json
+++ b/pkg/integrations/bitbucket/example_output_update_pull_request.json
@@ -1,0 +1,92 @@
+{
+  "data": {
+    "id": 42,
+    "title": "Add login page and session handling",
+    "description": "Adds the login page, wires it to the session API and covers it with tests.",
+    "state": "OPEN",
+    "draft": false,
+    "created_on": "2026-08-11T09:14:22.512345+00:00",
+    "updated_on": "2026-08-11T10:02:47.881204+00:00",
+    "close_source_branch": true,
+    "comment_count": 3,
+    "task_count": 0,
+    "author": {
+      "uuid": "{6b0b1d0e-6a1f-4f2f-9a2b-2f1d3a9c7e21}",
+      "account_id": "712020:1f6a0d7c-5d54-4b1e-9a4f-6c2f9e0a7b31",
+      "display_name": "Anthony Foussette",
+      "nickname": "anthony"
+    },
+    "reviewers": [
+      {
+        "uuid": "{2a5f7c88-91b4-4f0a-8c62-1e7d9b0a4f13}",
+        "account_id": "712020:9c4e1b77-2a3d-4e58-b0c1-7f8a2d5e6c04",
+        "display_name": "Marta Silva",
+        "nickname": "marta"
+      }
+    ],
+    "source": {
+      "branch": {
+        "name": "feature/login-page"
+      },
+      "commit": {
+        "hash": "9fec847784abb10b2fa567ee63b85bd238955d0e",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          },
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/9fec847784abb10b2fa567ee63b85bd238955d0e"
+          }
+        }
+      },
+      "repository": {
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}",
+        "name": "web",
+        "full_name": "superplane/web",
+        "slug": "web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        }
+      }
+    },
+    "destination": {
+      "branch": {
+        "name": "main"
+      },
+      "commit": {
+        "hash": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          },
+          "html": {
+            "href": "https://bitbucket.org/superplane/web/commits/c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0"
+          }
+        }
+      },
+      "repository": {
+        "uuid": "{4f2b8a1c-3d6e-4a5b-9c8d-0e1f2a3b4c5d}",
+        "name": "web",
+        "full_name": "superplane/web",
+        "slug": "web",
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/superplane/web"
+          }
+        }
+      }
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42"
+      },
+      "html": {
+        "href": "https://bitbucket.org/superplane/web/pull-requests/42"
+      }
+    }
+  },
+  "timestamp": "2026-08-11T10:02:47.925118Z",
+  "type": "bitbucket.pullRequest"
+}

--- a/pkg/integrations/bitbucket/get_commit_status.go
+++ b/pkg/integrations/bitbucket/get_commit_status.go
@@ -1,0 +1,224 @@
+package bitbucket
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_get_commit_status.json
+var exampleOutputGetCommitStatus []byte
+
+// StateNoStatus is reported when a commit carries no build status at all. Bitbucket
+// has no such value; it exists so a gate can tell "nothing ran" apart from "it passed".
+const StateNoStatus = "NO_STATUS"
+
+type GetCommitStatus struct{}
+
+type GetCommitStatusConfiguration struct {
+	Repository string `json:"repository" mapstructure:"repository"`
+	Commit     string `json:"commit" mapstructure:"commit"`
+}
+
+// CombinedCommitStatus rolls every build status on a commit into a single verdict, so a
+// workflow can gate on one field instead of walking the list itself.
+type CombinedCommitStatus struct {
+	Commit     string         `json:"commit"`
+	State      string         `json:"state"`
+	TotalCount int            `json:"total_count"`
+	Statuses   []CommitStatus `json:"statuses"`
+}
+
+func (g *GetCommitStatus) Name() string {
+	return "bitbucket.getCommitStatus"
+}
+
+func (g *GetCommitStatus) Label() string {
+	return "Get Commit Status"
+}
+
+func (g *GetCommitStatus) Description() string {
+	return "Read the build statuses reported on a Bitbucket commit"
+}
+
+func (g *GetCommitStatus) Documentation() string {
+	return `The Get Commit Status component reads every build status reported on a commit and rolls them into a
+single verdict, so a workflow can decide whether a commit is safe to ship.
+
+## Use Cases
+
+- **Deploy gates**: Check that every build on the commit is green before promoting it
+- **Release readiness**: Verify a release candidate has passed all required checks
+- **Diagnostics**: Attach the list of failing checks to an incident or a pull request comment
+
+## Configuration
+
+- **Repository** (required): The repository containing the commit
+- **Commit** (required): The full commit hash to read (supports expressions)
+
+## Output
+
+The component emits an aggregate over the commit's build statuses:
+- **commit**: The commit that was read
+- **state**: The combined verdict, see the table below
+- **total_count**: How many statuses were reported on the commit
+- **statuses**: Every individual status, in the order Bitbucket returned them
+
+### How the combined state is decided
+
+The combined state is the most severe individual state, in this order:
+
+| Combined state | When |
+| --- | --- |
+| ` + "`FAILED`" + ` | At least one status failed |
+| ` + "`STOPPED`" + ` | No failures, but at least one build was stopped |
+| ` + "`INPROGRESS`" + ` | Nothing failed or stopped, but at least one build is still running |
+| ` + "`SUCCESSFUL`" + ` | Every status succeeded |
+| ` + "`NO_STATUS`" + ` | The commit carries no build status at all |
+
+` + "`NO_STATUS`" + ` is not a Bitbucket value — it exists so a gate can tell "nothing ran yet" apart from
+"everything passed", which are very different answers when deciding to deploy.
+
+## Permissions
+
+The token needs the ` + "`repository`" + ` read scope.`
+}
+
+func (g *GetCommitStatus) Icon() string {
+	return "bitbucket"
+}
+
+func (g *GetCommitStatus) Color() string {
+	return "blue"
+}
+
+func (g *GetCommitStatus) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (g *GetCommitStatus) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputGetCommitStatus, &example); err != nil {
+		return map[string]any{}
+	}
+
+	return example
+}
+
+func (g *GetCommitStatus) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		commitField(),
+	}
+}
+
+func (g *GetCommitStatus) Setup(ctx core.SetupContext) error {
+	config := GetCommitStatusConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Commit == "" {
+		return fmt.Errorf("commit is required")
+	}
+
+	_, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	return err
+}
+
+func (g *GetCommitStatus) Execute(ctx core.ExecutionContext) error {
+	config := GetCommitStatusConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	commit := strings.TrimSpace(config.Commit)
+	if commit == "" {
+		return fmt.Errorf("commit is required")
+	}
+
+	target, err := resolveRepositoryTarget(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	statuses, err := target.Client.ListCommitStatuses(target.Workspace, target.Repository, commit)
+	if err != nil {
+		return fmt.Errorf("failed to get commit statuses: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"bitbucket.commitStatuses",
+		[]any{
+			CombinedCommitStatus{
+				Commit:     commit,
+				State:      combineCommitStatusStates(statuses),
+				TotalCount: len(statuses),
+				Statuses:   statuses,
+			},
+		},
+	)
+}
+
+func (g *GetCommitStatus) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (g *GetCommitStatus) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (g *GetCommitStatus) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (g *GetCommitStatus) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (g *GetCommitStatus) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (g *GetCommitStatus) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+// combineCommitStatusStates reports the most severe state on the commit. A stopped
+// build ranks above a running one because a cancelled build will never turn green,
+// and an unknown state is treated as a failure rather than silently passing a gate.
+func combineCommitStatusStates(statuses []CommitStatus) string {
+	if len(statuses) == 0 {
+		return StateNoStatus
+	}
+
+	var stopped, inProgress bool
+
+	for _, status := range statuses {
+		switch strings.ToUpper(strings.TrimSpace(status.State)) {
+		case StateSuccessful:
+		case StateStopped:
+			stopped = true
+		case StateInProgress:
+			inProgress = true
+		default:
+			return StateFailed
+		}
+	}
+
+	switch {
+	case stopped:
+		return StateStopped
+	case inProgress:
+		return StateInProgress
+	default:
+		return StateSuccessful
+	}
+}

--- a/pkg/integrations/bitbucket/get_commit_status_test.go
+++ b/pkg/integrations/bitbucket/get_commit_status_test.go
@@ -1,0 +1,107 @@
+package bitbucket
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__GetCommitStatus__Setup(t *testing.T) {
+	action := &GetCommitStatus{}
+
+	t.Run("commit is required", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository": testRepositoryName,
+		}))
+
+		require.ErrorContains(t, err, "commit is required")
+	})
+
+	t.Run("valid configuration is accepted", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository": testRepositoryName,
+			"commit":     "9fec847784abb10b2fa567ee63b85bd238955d0e",
+		}))
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__GetCommitStatus__Execute(t *testing.T) {
+	action := &GetCommitStatus{}
+
+	config := map[string]any{
+		"repository": testRepositoryName,
+		"commit":     "9fec847784abb10b2fa567ee63b85bd238955d0e",
+	}
+
+	t.Run("statuses are aggregated and emitted", func(t *testing.T) {
+		fixture := newExecutionFixture(config, jsonResponse(http.StatusOK, `{
+			"values": [
+				{"key": "BITBUCKETPIPELINE", "state": "SUCCESSFUL", "refname": "main"},
+				{"key": "security-scan", "state": "FAILED", "refname": "main"}
+			]
+		}`))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		require.Len(t, fixture.HTTP.Requests, 1)
+		request := fixture.HTTP.Requests[0]
+		assert.Equal(t, http.MethodGet, request.Method)
+		assert.Equal(
+			t,
+			"https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses?pagelen=100",
+			request.URL.String(),
+		)
+
+		combined := emittedPayload[CombinedCommitStatus](t, fixture.ExecutionState, 0)
+		assert.Equal(t, "9fec847784abb10b2fa567ee63b85bd238955d0e", combined.Commit)
+		assert.Equal(t, StateFailed, combined.State)
+		assert.Equal(t, 2, combined.TotalCount)
+		require.Len(t, combined.Statuses, 2)
+		assert.Equal(t, "bitbucket.commitStatuses", fixture.ExecutionState.Type)
+	})
+
+	// A commit with no build status must not read as a pass, or a deploy gate would
+	// let through code that was never built.
+	t.Run("a commit with no statuses reports NO_STATUS", func(t *testing.T) {
+		fixture := newExecutionFixture(config, jsonResponse(http.StatusOK, `{"values": []}`))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		combined := emittedPayload[CombinedCommitStatus](t, fixture.ExecutionState, 0)
+		assert.Equal(t, StateNoStatus, combined.State)
+		assert.Equal(t, 0, combined.TotalCount)
+		assert.Empty(t, combined.Statuses)
+	})
+
+	t.Run("every page is followed", func(t *testing.T) {
+		fixture := newExecutionFixture(
+			config,
+			jsonResponse(http.StatusOK, `{
+				"values": [{"key": "BITBUCKETPIPELINE", "state": "SUCCESSFUL"}],
+				"next": "https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses?page=2"
+			}`),
+			jsonResponse(http.StatusOK, `{"values": [{"key": "security-scan", "state": "SUCCESSFUL"}]}`),
+		)
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		assert.Len(t, fixture.HTTP.Requests, 2)
+
+		combined := emittedPayload[CombinedCommitStatus](t, fixture.ExecutionState, 0)
+		assert.Equal(t, StateSuccessful, combined.State)
+		assert.Equal(t, 2, combined.TotalCount)
+	})
+
+	t.Run("API error is reported", func(t *testing.T) {
+		fixture := newExecutionFixture(config, jsonResponse(http.StatusNotFound, `{"error":{"message":"commit not found"}}`))
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "failed to get commit statuses")
+		require.ErrorContains(t, err, "commit not found")
+	})
+}

--- a/pkg/integrations/bitbucket/list_resources.go
+++ b/pkg/integrations/bitbucket/list_resources.go
@@ -3,23 +3,24 @@ package bitbucket
 import (
 	"fmt"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
 func (b *Bitbucket) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
-	if resourceType != "repository" {
+	switch resourceType {
+	case ResourceTypeRepository:
+		return b.listRepositories(resourceType, ctx)
+	case ResourceTypeMember:
+		return b.listMembers(resourceType, ctx)
+	default:
 		return []core.IntegrationResource{}, nil
 	}
+}
 
-	metadata := Metadata{}
-	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &metadata); err != nil {
-		return nil, fmt.Errorf("failed to decode integration metadata: %w", err)
-	}
-
-	client, err := NewClient(metadata.AuthType, ctx.HTTP, ctx.Integration)
+func (b *Bitbucket) listRepositories(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	client, metadata, err := integrationClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create client: %w", err)
+		return nil, err
 	}
 
 	repositories, err := client.ListRepositories(metadata.Workspace.Slug)
@@ -33,6 +34,44 @@ func (b *Bitbucket) ListResources(resourceType string, ctx core.ListResourcesCon
 			Type: resourceType,
 			Name: repo.FullName,
 			ID:   repo.UUID,
+		})
+	}
+
+	return resources, nil
+}
+
+// listMembers backs the reviewer pickers. The resource ID is the account UUID, which
+// is what the Bitbucket API expects when setting reviewers on a pull request.
+func (b *Bitbucket) listMembers(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	client, metadata, err := integrationClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	members, err := client.ListWorkspaceMembers(metadata.Workspace.Slug)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workspace members: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(members))
+	for _, member := range members {
+		if member.UUID == "" {
+			continue
+		}
+
+		name := member.DisplayName
+		if name == "" {
+			name = member.Nickname
+		}
+
+		if name == "" {
+			name = member.UUID
+		}
+
+		resources = append(resources, core.IntegrationResource{
+			Type: resourceType,
+			Name: name,
+			ID:   member.UUID,
 		})
 	}
 

--- a/pkg/integrations/bitbucket/merge_pull_request.go
+++ b/pkg/integrations/bitbucket/merge_pull_request.go
@@ -1,0 +1,219 @@
+package bitbucket
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_merge_pull_request.json
+var exampleOutputMergePullRequest []byte
+
+type MergePullRequest struct{}
+
+type MergePullRequestConfiguration struct {
+	Repository        string `json:"repository" mapstructure:"repository"`
+	PullRequestID     string `json:"pullRequestId" mapstructure:"pullRequestId"`
+	MergeStrategy     string `json:"mergeStrategy" mapstructure:"mergeStrategy"`
+	Message           string `json:"message" mapstructure:"message"`
+	CloseSourceBranch bool   `json:"closeSourceBranch" mapstructure:"closeSourceBranch"`
+}
+
+func (m *MergePullRequest) Name() string {
+	return "bitbucket.mergePullRequest"
+}
+
+func (m *MergePullRequest) Label() string {
+	return "Merge Pull Request"
+}
+
+func (m *MergePullRequest) Description() string {
+	return "Merge an open pull request in a Bitbucket repository"
+}
+
+func (m *MergePullRequest) Documentation() string {
+	return `The Merge Pull Request component merges an open Bitbucket pull request.
+
+## Use Cases
+
+- **Policy-gated merges**: Merge only after approvals, a green build and a manual approval step have all passed
+- **Auto-merge**: Merge dependency or changelog pull requests once CI reports success
+- **Release trains**: Merge a batch of ready pull requests as part of a coordinated release
+
+## Configuration
+
+- **Repository** (required): The repository containing the pull request
+- **Pull Request ID** (required): The numeric ID of the pull request (supports expressions)
+- **Merge Strategy** (required): How the merge is performed. Default: Merge commit.
+- **Message** (optional): The merge commit message. Leave empty to let Bitbucket generate it.
+- **Close Source Branch** (optional): Delete the source branch after merging
+
+### Merge strategies
+
+| Strategy | Behaviour |
+| --- | --- |
+| **Merge commit** | Creates a merge commit, keeping the full branch history |
+| **Squash** | Combines every commit on the branch into a single commit |
+| **Fast forward** | Moves the target branch pointer, and fails if the branch has diverged |
+
+## Permissions
+
+The token needs the ` + "`pullrequest:write`" + ` scope, and the account must be allowed to write to the
+target branch. Branch restrictions, unresolved merge checks and merge conflicts all make this component fail
+with the reason reported by Bitbucket.
+
+## Output
+
+The component emits the merged pull request, including:
+- **state**: ` + "`MERGED`" + `
+- **merge_commit.hash**: The commit created by the merge
+- **closed_by**: The account the merge was performed as
+
+If Bitbucket queues the merge asynchronously — which happens on very large repositories — the component
+fails rather than reporting a merge that has not completed.`
+}
+
+func (m *MergePullRequest) Icon() string {
+	return "bitbucket"
+}
+
+func (m *MergePullRequest) Color() string {
+	return "blue"
+}
+
+func (m *MergePullRequest) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (m *MergePullRequest) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputMergePullRequest, &example); err != nil {
+		return map[string]any{}
+	}
+
+	return example
+}
+
+func (m *MergePullRequest) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		pullRequestIDField(),
+		{
+			Name:     "mergeStrategy",
+			Label:    "Merge Strategy",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  MergeStrategyMergeCommit,
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Merge commit", Value: MergeStrategyMergeCommit},
+						{Label: "Squash", Value: MergeStrategySquash},
+						{Label: "Fast forward", Value: MergeStrategyFastForward},
+					},
+				},
+			},
+		},
+		{
+			Name:        "message",
+			Label:       "Message",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Description: "The merge commit message. Leave empty to let Bitbucket generate it.",
+		},
+		{
+			Name:        "closeSourceBranch",
+			Label:       "Close Source Branch",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Description: "Delete the source branch after merging",
+		},
+	}
+}
+
+func (m *MergePullRequest) Setup(ctx core.SetupContext) error {
+	config := MergePullRequestConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.PullRequestID == "" {
+		return fmt.Errorf("pull request ID is required")
+	}
+
+	switch config.MergeStrategy {
+	case "", MergeStrategyMergeCommit, MergeStrategySquash, MergeStrategyFastForward:
+	default:
+		return fmt.Errorf("unsupported merge strategy %q", config.MergeStrategy)
+	}
+
+	_, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	return err
+}
+
+func (m *MergePullRequest) Execute(ctx core.ExecutionContext) error {
+	config := MergePullRequestConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	pullRequestID, err := parsePullRequestID(config.PullRequestID)
+	if err != nil {
+		return err
+	}
+
+	target, err := resolveRepositoryTarget(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	request := &MergePullRequestRequest{
+		Type:          "pullrequest",
+		Message:       config.Message,
+		MergeStrategy: config.MergeStrategy,
+	}
+
+	if config.CloseSourceBranch {
+		request.CloseSourceBranch = &config.CloseSourceBranch
+	}
+
+	pullRequest, err := target.Client.MergePullRequest(target.Workspace, target.Repository, pullRequestID, request)
+	if err != nil {
+		return fmt.Errorf("failed to merge pull request: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"bitbucket.pullRequest",
+		[]any{pullRequest},
+	)
+}
+
+func (m *MergePullRequest) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (m *MergePullRequest) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (m *MergePullRequest) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (m *MergePullRequest) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (m *MergePullRequest) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (m *MergePullRequest) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/bitbucket/merge_pull_request_test.go
+++ b/pkg/integrations/bitbucket/merge_pull_request_test.go
@@ -1,0 +1,111 @@
+package bitbucket
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const mergedPullRequestResponse = `{
+  "id": 42,
+  "title": "Add login page",
+  "state": "MERGED",
+  "merge_commit": {"hash": "7ab3c9d1e5f28046b1c3a7d9e2b4c6d8e0f1a2b3"},
+  "source": {"branch": {"name": "feature/login-page"}},
+  "destination": {"branch": {"name": "main"}}
+}`
+
+func Test__MergePullRequest__Setup(t *testing.T) {
+	action := &MergePullRequest{}
+
+	t.Run("pull request ID is required", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"mergeStrategy": MergeStrategySquash,
+		}))
+
+		require.ErrorContains(t, err, "pull request ID is required")
+	})
+
+	t.Run("unsupported merge strategy is rejected", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"mergeStrategy": "rebase",
+		}))
+
+		require.ErrorContains(t, err, `unsupported merge strategy "rebase"`)
+	})
+
+	t.Run("valid configuration is accepted", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"mergeStrategy": MergeStrategySquash,
+		}))
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__MergePullRequest__Execute(t *testing.T) {
+	action := &MergePullRequest{}
+
+	t.Run("pull request is merged and emitted", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":        testRepositoryName,
+			"pullRequestId":     "42",
+			"mergeStrategy":     MergeStrategySquash,
+			"message":           "Release 2026.08",
+			"closeSourceBranch": true,
+		}, jsonResponse(http.StatusOK, mergedPullRequestResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		require.Len(t, fixture.HTTP.Requests, 1)
+		request := fixture.HTTP.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42/merge", request.URL.String())
+
+		body := requestBody(t, request)
+		assert.Equal(t, "pullrequest", body["type"])
+		assert.Equal(t, MergeStrategySquash, body["merge_strategy"])
+		assert.Equal(t, "Release 2026.08", body["message"])
+		assert.Equal(t, true, body["close_source_branch"])
+
+		pullRequest := emittedPayload[*PullRequest](t, fixture.ExecutionState, 0)
+		assert.Equal(t, "MERGED", pullRequest.State)
+		require.NotNil(t, pullRequest.MergeCommit)
+		assert.Equal(t, "7ab3c9d1e5f28046b1c3a7d9e2b4c6d8e0f1a2b3", pullRequest.MergeCommit.Hash)
+	})
+
+	// Bitbucket answers 202 with a polling task on slow merges. Reporting that as a
+	// success would tell the canvas a merge happened when it has not.
+	t.Run("an asynchronously queued merge fails instead of reporting success", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"mergeStrategy": MergeStrategyMergeCommit,
+		}, jsonResponse(http.StatusAccepted, `{"type":"pullrequest_merge_task","status":{"state":"PENDING"}}`))
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "queued the merge asynchronously")
+		assert.False(t, fixture.ExecutionState.Passed)
+	})
+
+	t.Run("a merge conflict is reported", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"mergeStrategy": MergeStrategyFastForward,
+		}, jsonResponse(http.StatusBadRequest, `{"error":{"message":"branch has diverged"}}`))
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "failed to merge pull request")
+		require.ErrorContains(t, err, "branch has diverged")
+	})
+}

--- a/pkg/integrations/bitbucket/on_commit_status.go
+++ b/pkg/integrations/bitbucket/on_commit_status.go
@@ -1,0 +1,236 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+// Bitbucket Pipelines — and any external CI reporting through the build status API —
+// surface their result as a commit status, so this is the trigger that tells a canvas
+// a build finished.
+var commitStatusEventTypes = []string{"repo:commit_status_created", "repo:commit_status_updated"}
+
+var commitStatusStates = []configuration.FieldOption{
+	{Label: "In progress", Value: StateInProgress},
+	{Label: "Successful", Value: StateSuccessful},
+	{Label: "Failed", Value: StateFailed},
+	{Label: "Stopped", Value: StateStopped},
+}
+
+type OnCommitStatus struct{}
+
+type OnCommitStatusConfiguration struct {
+	Repository string                    `json:"repository" mapstructure:"repository"`
+	States     []string                  `json:"states" mapstructure:"states"`
+	Keys       []configuration.Predicate `json:"keys" mapstructure:"keys"`
+	Refs       []configuration.Predicate `json:"refs" mapstructure:"refs"`
+}
+
+func (s *OnCommitStatus) Name() string {
+	return "bitbucket.onCommitStatus"
+}
+
+func (s *OnCommitStatus) Label() string {
+	return "On Commit Status"
+}
+
+func (s *OnCommitStatus) Description() string {
+	return "Listen to Bitbucket build statuses, including Bitbucket Pipelines results"
+}
+
+func (s *OnCommitStatus) Documentation() string {
+	return `The On Commit Status trigger starts a workflow execution when a build status is reported on a commit.
+
+Bitbucket Pipelines reports every pipeline result through the build status API, so this trigger is how a
+canvas reacts to a pipeline finishing. External CI systems that publish statuses to Bitbucket — including
+SuperPlane's own **Publish Commit Status** component — fire this trigger too.
+
+## Use Cases
+
+- **Deploy on green**: Start a deployment when the build for a commit reports ` + "`SUCCESSFUL`" + `
+- **Fail fast**: Open an incident or notify a channel when a build reports ` + "`FAILED`" + `
+- **Release gating**: Wait for a specific build key, such as ` + "`integration-tests`" + `, before promoting a build
+
+## Configuration
+
+- **Repository** (required): The Bitbucket repository to monitor
+- **States** (required): Which build states should start a run. Default: Successful and Failed.
+- **Keys** (optional): Only fire for statuses whose key matches, e.g. ` + "`integration-tests`" + `. Leave empty to accept every key.
+- **Refs** (optional): Only fire for statuses reported on a matching branch or tag. Leave empty to accept any ref.
+
+## Event Data
+
+Each event includes:
+- **commit_status**: The status, including ` + "`key`" + `, ` + "`name`" + `, ` + "`state`" + `, ` + "`url`" + `, ` + "`refname`" + ` and ` + "`links`" + `
+- **repository**: Repository information
+- **actor**: The user or app that reported the status
+
+Common expression paths:
+- Build state: ` + "`root().data.commit_status.state`" + `
+- Build key: ` + "`root().data.commit_status.key`" + `
+- Build URL: ` + "`root().data.commit_status.url`" + `
+- Branch: ` + "`root().data.commit_status.refname`" + `
+
+The commit the status belongs to is referenced by ` + "`root().data.commit_status.links.commit.href`" + `; its
+last path segment is the commit hash.
+
+## Webhook Setup
+
+This trigger automatically sets up a Bitbucket webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.`
+}
+
+func (s *OnCommitStatus) Icon() string {
+	return "bitbucket"
+}
+
+func (s *OnCommitStatus) Color() string {
+	return "blue"
+}
+
+func (s *OnCommitStatus) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		{
+			Name:        "states",
+			Label:       "States",
+			Type:        configuration.FieldTypeMultiSelect,
+			Required:    true,
+			Default:     []string{StateSuccessful, StateFailed},
+			Description: "Which build states should start a run",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: commitStatusStates,
+				},
+			},
+		},
+		{
+			Name:        "keys",
+			Label:       "Keys",
+			Type:        configuration.FieldTypeAnyPredicateList,
+			Required:    false,
+			Description: "Only fire for build statuses whose key matches. Leave empty to accept any key.",
+			TypeOptions: &configuration.TypeOptions{
+				AnyPredicateList: &configuration.AnyPredicateListTypeOptions{
+					Operators: configuration.AllPredicateOperators,
+				},
+			},
+		},
+		{
+			Name:        "refs",
+			Label:       "Refs",
+			Type:        configuration.FieldTypeAnyPredicateList,
+			Required:    false,
+			Description: "Only fire for build statuses reported on a matching branch or tag. Leave empty to accept any ref.",
+			TypeOptions: &configuration.TypeOptions{
+				AnyPredicateList: &configuration.AnyPredicateListTypeOptions{
+					Operators: configuration.AllPredicateOperators,
+				},
+			},
+		},
+	}
+}
+
+func (s *OnCommitStatus) Setup(ctx core.TriggerContext) error {
+	config := OnCommitStatusConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if len(config.States) == 0 {
+		return fmt.Errorf("at least one state is required")
+	}
+
+	for _, state := range config.States {
+		known := slices.ContainsFunc(commitStatusStates, func(option configuration.FieldOption) bool {
+			return option.Value == state
+		})
+
+		if !known {
+			return fmt.Errorf("unsupported build state %q", state)
+		}
+	}
+
+	repo, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	return ctx.Integration.RequestWebhook(WebhookConfiguration{
+		EventTypes:     commitStatusEventTypes,
+		RepositorySlug: repo.Slug,
+	})
+}
+
+func (s *OnCommitStatus) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (s *OnCommitStatus) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (s *OnCommitStatus) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	config := OnCommitStatusConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	eventKey := ctx.Headers.Get("X-Event-Key")
+	if eventKey == "" {
+		return http.StatusBadRequest, nil, fmt.Errorf("missing X-Event-Key header")
+	}
+
+	if !slices.Contains(commitStatusEventTypes, eventKey) {
+		return http.StatusOK, nil, nil
+	}
+
+	if code, err := verifyWebhookSignature(ctx); err != nil {
+		return code, nil, err
+	}
+
+	data := map[string]any{}
+	if err := json.Unmarshal(ctx.Body, &data); err != nil {
+		return http.StatusBadRequest, nil, fmt.Errorf("error parsing request body: %v", err)
+	}
+
+	status, ok := data["commit_status"].(map[string]any)
+	if !ok {
+		return http.StatusOK, nil, nil
+	}
+
+	state, _ := status["state"].(string)
+	if !slices.Contains(config.States, strings.ToUpper(strings.TrimSpace(state))) {
+		return http.StatusOK, nil, nil
+	}
+
+	if len(config.Keys) > 0 {
+		key, _ := status["key"].(string)
+		if !configuration.MatchesAnyPredicate(config.Keys, key) {
+			return http.StatusOK, nil, nil
+		}
+	}
+
+	if len(config.Refs) > 0 {
+		refname, _ := status["refname"].(string)
+		if !configuration.MatchesAnyPredicate(config.Refs, refname) {
+			return http.StatusOK, nil, nil
+		}
+	}
+
+	if err := ctx.Events.Emit("bitbucket.commitStatus", data); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("error emitting event: %v", err)
+	}
+
+	return http.StatusOK, nil, nil
+}
+
+func (s *OnCommitStatus) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}

--- a/pkg/integrations/bitbucket/on_commit_status_test.go
+++ b/pkg/integrations/bitbucket/on_commit_status_test.go
@@ -1,0 +1,229 @@
+package bitbucket
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__OnCommitStatus__Setup(t *testing.T) {
+	trigger := &OnCommitStatus{}
+	metadata := Metadata{
+		AuthType:  AuthTypeWorkspaceAccessToken,
+		Workspace: &WorkspaceMetadata{Slug: "superplane"},
+	}
+
+	integrationContext := func() *contexts.IntegrationContext {
+		return &contexts.IntegrationContext{
+			Configuration: map[string]any{"token": "token"},
+			Metadata:      metadata,
+		}
+	}
+
+	t.Run("at least one state is required", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: integrationContext(),
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"states":     []string{},
+			},
+		})
+
+		require.ErrorContains(t, err, "at least one state is required")
+	})
+
+	t.Run("unsupported state is rejected", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: integrationContext(),
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"states":     []string{"GREEN"},
+			},
+		})
+
+		require.ErrorContains(t, err, `unsupported build state "GREEN"`)
+	})
+
+	t.Run("both commit status events are requested", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"values":[{"uuid":"{hello}","name":"hello","full_name":"superplane/hello","slug":"hello"}]}`,
+					)),
+				},
+			},
+		}
+		integrationCtx := integrationContext()
+
+		require.NoError(t, trigger.Setup(core.TriggerContext{
+			HTTP:        httpCtx,
+			Integration: integrationCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"states":     []string{StateSuccessful},
+			},
+		}))
+
+		require.Len(t, integrationCtx.WebhookRequests, 1)
+		webhookRequest, ok := integrationCtx.WebhookRequests[0].(WebhookConfiguration)
+		require.True(t, ok)
+		assert.Equal(t, []string{"repo:commit_status_created", "repo:commit_status_updated"}, webhookRequest.EventTypes)
+	})
+}
+
+func Test__OnCommitStatus__HandleWebhook(t *testing.T) {
+	trigger := &OnCommitStatus{}
+
+	handle := func(eventKey string, body []byte, config map[string]any) (int, *contexts.EventContext, error) {
+		headers := http.Header{}
+		headers.Set("X-Event-Key", eventKey)
+		headers.Set("X-Hub-Signature", "sha256="+signBitbucketPayload("test-secret", body))
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Body:          body,
+			Headers:       headers,
+			Webhook:       &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Configuration: config,
+			Events:        eventContext,
+		})
+
+		return code, eventContext, err
+	}
+
+	successOnly := map[string]any{
+		"repository": "hello",
+		"states":     []string{StateSuccessful},
+	}
+
+	t.Run("selected state -> event is emitted", func(t *testing.T) {
+		body := []byte(`{"commit_status":{"key":"BITBUCKETPIPELINE","state":"SUCCESSFUL","refname":"main"}}`)
+
+		code, eventContext, err := handle("repo:commit_status_updated", body, successOnly)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		require.Equal(t, 1, eventContext.Count())
+		assert.Equal(t, "bitbucket.commitStatus", eventContext.Payloads[0].Type)
+	})
+
+	t.Run("state that was not selected -> event is not emitted", func(t *testing.T) {
+		body := []byte(`{"commit_status":{"key":"BITBUCKETPIPELINE","state":"INPROGRESS","refname":"main"}}`)
+
+		code, eventContext, err := handle("repo:commit_status_updated", body, successOnly)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("payload without a commit status -> event is not emitted", func(t *testing.T) {
+		code, eventContext, err := handle("repo:commit_status_created", []byte(`{}`), successOnly)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("key filter is applied", func(t *testing.T) {
+		config := map[string]any{
+			"repository": "hello",
+			"states":     []string{StateSuccessful},
+			"keys": []configuration.Predicate{
+				{Type: configuration.PredicateTypeEquals, Value: "integration-tests"},
+			},
+		}
+
+		body := []byte(`{"commit_status":{"key":"BITBUCKETPIPELINE","state":"SUCCESSFUL","refname":"main"}}`)
+		code, eventContext, err := handle("repo:commit_status_updated", body, config)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+
+		body = []byte(`{"commit_status":{"key":"integration-tests","state":"SUCCESSFUL","refname":"main"}}`)
+		code, eventContext, err = handle("repo:commit_status_updated", body, config)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, eventContext.Count())
+	})
+
+	t.Run("ref filter is applied", func(t *testing.T) {
+		config := map[string]any{
+			"repository": "hello",
+			"states":     []string{StateSuccessful},
+			"refs": []configuration.Predicate{
+				{Type: configuration.PredicateTypeEquals, Value: "main"},
+			},
+		}
+
+		body := []byte(`{"commit_status":{"key":"BITBUCKETPIPELINE","state":"SUCCESSFUL","refname":"feature-1"}}`)
+		code, eventContext, err := handle("repo:commit_status_updated", body, config)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+}
+
+func Test__CombineCommitStatusStates(t *testing.T) {
+	t.Run("no statuses is not a pass", func(t *testing.T) {
+		assert.Equal(t, StateNoStatus, combineCommitStatusStates(nil))
+	})
+
+	t.Run("all successful", func(t *testing.T) {
+		assert.Equal(t, StateSuccessful, combineCommitStatusStates([]CommitStatus{
+			{State: StateSuccessful},
+			{State: StateSuccessful},
+		}))
+	})
+
+	t.Run("a failure outranks everything", func(t *testing.T) {
+		assert.Equal(t, StateFailed, combineCommitStatusStates([]CommitStatus{
+			{State: StateSuccessful},
+			{State: StateInProgress},
+			{State: StateStopped},
+			{State: StateFailed},
+		}))
+	})
+
+	t.Run("a stopped build outranks a running one", func(t *testing.T) {
+		assert.Equal(t, StateStopped, combineCommitStatusStates([]CommitStatus{
+			{State: StateSuccessful},
+			{State: StateInProgress},
+			{State: StateStopped},
+		}))
+	})
+
+	t.Run("a running build outranks a successful one", func(t *testing.T) {
+		assert.Equal(t, StateInProgress, combineCommitStatusStates([]CommitStatus{
+			{State: StateSuccessful},
+			{State: StateInProgress},
+		}))
+	})
+
+	// An unknown state must never let a deploy gate through.
+	t.Run("an unrecognized state is treated as a failure", func(t *testing.T) {
+		assert.Equal(t, StateFailed, combineCommitStatusStates([]CommitStatus{
+			{State: StateSuccessful},
+			{State: "SOMETHING_NEW"},
+		}))
+	})
+}

--- a/pkg/integrations/bitbucket/on_pr_comment.go
+++ b/pkg/integrations/bitbucket/on_pr_comment.go
@@ -1,0 +1,228 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"slices"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+var pullRequestCommentActions = []configuration.FieldOption{
+	{Label: "Created", Value: "comment_created"},
+	{Label: "Updated", Value: "comment_updated"},
+	{Label: "Deleted", Value: "comment_deleted"},
+}
+
+type OnPRComment struct{}
+
+type OnPRCommentConfiguration struct {
+	Repository    string   `json:"repository" mapstructure:"repository"`
+	Actions       []string `json:"actions" mapstructure:"actions"`
+	ContentFilter string   `json:"contentFilter" mapstructure:"contentFilter"`
+}
+
+func (c *OnPRComment) Name() string {
+	return "bitbucket.onPRComment"
+}
+
+func (c *OnPRComment) Label() string {
+	return "On Pull Request Comment"
+}
+
+func (c *OnPRComment) Description() string {
+	return "Listen to comments on Bitbucket pull requests"
+}
+
+func (c *OnPRComment) Documentation() string {
+	return `The On Pull Request Comment trigger starts a workflow execution when someone comments on a Bitbucket pull request.
+
+## Use Cases
+
+- **ChatOps**: Let reviewers run a workflow by commenting ` + "`/deploy`" + ` or ` + "`/preview`" + ` on a pull request
+- **Agent hand-off**: Send a comment to a coding agent and post the result back on the pull request
+- **Review tracking**: Notify a channel when a discussion starts on an open pull request
+
+## Configuration
+
+- **Repository** (required): The Bitbucket repository to monitor
+- **Actions** (required): Which comment events to listen for. Default: Created.
+- **Content Filter** (optional): Regex pattern the comment body must match, e.g. ` + "`^/deploy`" + `. Leave empty to accept every comment.
+
+## Event Data
+
+Each event includes:
+- **comment**: The comment, including ` + "`id`" + ` and ` + "`content.raw`" + `
+- **pullrequest**: The pull request the comment belongs to
+- **repository**: Repository information
+- **actor**: The user that wrote the comment
+
+Common expression paths:
+- Comment body: ` + "`root().data.comment.content.raw`" + `
+- Comment author: ` + "`root().data.actor.display_name`" + `
+- Pull request ID: ` + "`root().data.pullrequest.id`" + `
+- Source branch: ` + "`root().data.pullrequest.source.branch.name`" + `
+
+## Webhook Setup
+
+This trigger automatically sets up a Bitbucket webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.`
+}
+
+func (c *OnPRComment) Icon() string {
+	return "bitbucket"
+}
+
+func (c *OnPRComment) Color() string {
+	return "blue"
+}
+
+func (c *OnPRComment) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		{
+			Name:        "actions",
+			Label:       "Actions",
+			Type:        configuration.FieldTypeMultiSelect,
+			Required:    true,
+			Default:     []string{"comment_created"},
+			Description: "Which comment events should start a run",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: pullRequestCommentActions,
+				},
+			},
+		},
+		{
+			Name:        "contentFilter",
+			Label:       "Content Filter",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Placeholder: "e.g., /deploy",
+			Description: "Optional regex pattern to filter comments by content",
+		},
+	}
+}
+
+func (c *OnPRComment) Setup(ctx core.TriggerContext) error {
+	config := OnPRCommentConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if len(config.Actions) == 0 {
+		return fmt.Errorf("at least one action is required")
+	}
+
+	for _, action := range config.Actions {
+		known := slices.ContainsFunc(pullRequestCommentActions, func(option configuration.FieldOption) bool {
+			return option.Value == action
+		})
+
+		if !known {
+			return fmt.Errorf("unsupported comment action %q", action)
+		}
+	}
+
+	if config.ContentFilter != "" {
+		if _, err := regexp.Compile(config.ContentFilter); err != nil {
+			return fmt.Errorf("invalid content filter pattern: %w", err)
+		}
+	}
+
+	repo, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	return ctx.Integration.RequestWebhook(WebhookConfiguration{
+		EventTypes:     pullRequestEventTypes(config.Actions),
+		RepositorySlug: repo.Slug,
+	})
+}
+
+func (c *OnPRComment) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *OnPRComment) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (c *OnPRComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	config := OnPRCommentConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	eventKey := ctx.Headers.Get("X-Event-Key")
+	if eventKey == "" {
+		return http.StatusBadRequest, nil, fmt.Errorf("missing X-Event-Key header")
+	}
+
+	if !slices.Contains(pullRequestEventTypes(config.Actions), eventKey) {
+		return http.StatusOK, nil, nil
+	}
+
+	if code, err := verifyWebhookSignature(ctx); err != nil {
+		return code, nil, err
+	}
+
+	data := map[string]any{}
+	if err := json.Unmarshal(ctx.Body, &data); err != nil {
+		return http.StatusBadRequest, nil, fmt.Errorf("error parsing request body: %v", err)
+	}
+
+	matched, err := c.matchesContentFilter(config.ContentFilter, data)
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	if !matched {
+		ctx.Logger.Info("Comment does not match the content filter - ignoring")
+		return http.StatusOK, nil, nil
+	}
+
+	if err := ctx.Events.Emit("bitbucket.pullRequestComment", data); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("error emitting event: %v", err)
+	}
+
+	return http.StatusOK, nil, nil
+}
+
+func (c *OnPRComment) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}
+
+// matchesContentFilter checks the comment body against the regex filter. An empty
+// filter always matches, and a comment delivered without a body never does.
+func (c *OnPRComment) matchesContentFilter(filter string, data map[string]any) (bool, error) {
+	if filter == "" {
+		return true, nil
+	}
+
+	comment, ok := data["comment"].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+
+	content, ok := comment["content"].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+
+	raw, ok := content["raw"].(string)
+	if !ok {
+		return false, nil
+	}
+
+	matched, err := regexp.MatchString(filter, raw)
+	if err != nil {
+		return false, fmt.Errorf("invalid content filter pattern: %w", err)
+	}
+
+	return matched, nil
+}

--- a/pkg/integrations/bitbucket/on_pr_comment_test.go
+++ b/pkg/integrations/bitbucket/on_pr_comment_test.go
@@ -1,0 +1,200 @@
+package bitbucket
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__OnPRComment__Setup(t *testing.T) {
+	trigger := &OnPRComment{}
+	metadata := Metadata{
+		AuthType:  AuthTypeWorkspaceAccessToken,
+		Workspace: &WorkspaceMetadata{Slug: "superplane"},
+	}
+
+	integrationContext := func() *contexts.IntegrationContext {
+		return &contexts.IntegrationContext{
+			Configuration: map[string]any{"token": "token"},
+			Metadata:      metadata,
+		}
+	}
+
+	t.Run("at least one action is required", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: integrationContext(),
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"actions":    []string{},
+			},
+		})
+
+		require.ErrorContains(t, err, "at least one action is required")
+	})
+
+	t.Run("unsupported action is rejected", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: integrationContext(),
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"actions":    []string{"comment_exploded"},
+			},
+		})
+
+		require.ErrorContains(t, err, `unsupported comment action "comment_exploded"`)
+	})
+
+	t.Run("invalid content filter is rejected", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: integrationContext(),
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository":    "hello",
+				"actions":       []string{"comment_created"},
+				"contentFilter": "[unclosed",
+			},
+		})
+
+		require.ErrorContains(t, err, "invalid content filter pattern")
+	})
+
+	t.Run("webhook is requested for every selected action", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"values":[{"uuid":"{hello}","name":"hello","full_name":"superplane/hello","slug":"hello"}]}`,
+					)),
+				},
+			},
+		}
+		integrationCtx := integrationContext()
+
+		require.NoError(t, trigger.Setup(core.TriggerContext{
+			HTTP:        httpCtx,
+			Integration: integrationCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"actions":    []string{"comment_created", "comment_updated"},
+			},
+		}))
+
+		require.Len(t, integrationCtx.WebhookRequests, 1)
+		webhookRequest, ok := integrationCtx.WebhookRequests[0].(WebhookConfiguration)
+		require.True(t, ok)
+		assert.Equal(t, []string{"pullrequest:comment_created", "pullrequest:comment_updated"}, webhookRequest.EventTypes)
+	})
+}
+
+func Test__OnPRComment__HandleWebhook(t *testing.T) {
+	trigger := &OnPRComment{}
+
+	handle := func(body []byte, config map[string]any) (int, *contexts.EventContext, error) {
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "pullrequest:comment_created")
+		headers.Set("X-Hub-Signature", "sha256="+signBitbucketPayload("test-secret", body))
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Body:          body,
+			Headers:       headers,
+			Webhook:       &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Configuration: config,
+			Events:        eventContext,
+		})
+
+		return code, eventContext, err
+	}
+
+	baseConfig := map[string]any{
+		"repository": "hello",
+		"actions":    []string{"comment_created"},
+	}
+
+	t.Run("comment matching the filter -> event is emitted", func(t *testing.T) {
+		config := map[string]any{
+			"repository":    "hello",
+			"actions":       []string{"comment_created"},
+			"contentFilter": "^/deploy",
+		}
+
+		code, eventContext, err := handle([]byte(`{"comment":{"content":{"raw":"/deploy staging"}}}`), config)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		require.Equal(t, 1, eventContext.Count())
+		assert.Equal(t, "bitbucket.pullRequestComment", eventContext.Payloads[0].Type)
+	})
+
+	t.Run("comment not matching the filter -> event is not emitted", func(t *testing.T) {
+		config := map[string]any{
+			"repository":    "hello",
+			"actions":       []string{"comment_created"},
+			"contentFilter": "^/deploy",
+		}
+
+		code, eventContext, err := handle([]byte(`{"comment":{"content":{"raw":"looks good to me"}}}`), config)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("no filter -> every comment is emitted", func(t *testing.T) {
+		code, eventContext, err := handle([]byte(`{"comment":{"content":{"raw":"looks good to me"}}}`), baseConfig)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, eventContext.Count())
+	})
+
+	t.Run("comment without a body never matches a filter", func(t *testing.T) {
+		config := map[string]any{
+			"repository":    "hello",
+			"actions":       []string{"comment_created"},
+			"contentFilter": "^/deploy",
+		}
+
+		code, eventContext, err := handle([]byte(`{"comment":{}}`), config)
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("deleted comment event is dropped when not selected", func(t *testing.T) {
+		body := []byte(`{"comment":{"content":{"raw":"gone"}}}`)
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "pullrequest:comment_deleted")
+		headers.Set("X-Hub-Signature", "sha256="+signBitbucketPayload("test-secret", body))
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Body:          body,
+			Headers:       headers,
+			Webhook:       &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Configuration: baseConfig,
+			Events:        eventContext,
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+}

--- a/pkg/integrations/bitbucket/on_pull_request.go
+++ b/pkg/integrations/bitbucket/on_pull_request.go
@@ -1,0 +1,256 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+// Bitbucket publishes every pull request state change under its own event key, so an
+// action filter maps one-to-one onto the webhook events we subscribe to.
+const pullRequestEventPrefix = "pullrequest:"
+
+var pullRequestActions = []configuration.FieldOption{
+	{Label: "Opened", Value: "created"},
+	{Label: "Updated", Value: "updated"},
+	{Label: "Merged", Value: "fulfilled"},
+	{Label: "Declined", Value: "rejected"},
+	{Label: "Approved", Value: "approved"},
+	{Label: "Approval removed", Value: "unapproved"},
+	{Label: "Changes requested", Value: "changes_request_created"},
+	{Label: "Changes request removed", Value: "changes_request_removed"},
+}
+
+type OnPullRequest struct{}
+
+type OnPullRequestConfiguration struct {
+	Repository     string                    `json:"repository" mapstructure:"repository"`
+	Actions        []string                  `json:"actions" mapstructure:"actions"`
+	TargetBranches []configuration.Predicate `json:"targetBranches" mapstructure:"targetBranches"`
+}
+
+func (p *OnPullRequest) Name() string {
+	return "bitbucket.onPullRequest"
+}
+
+func (p *OnPullRequest) Label() string {
+	return "On Pull Request"
+}
+
+func (p *OnPullRequest) Description() string {
+	return "Listen to Bitbucket pull request events"
+}
+
+func (p *OnPullRequest) Documentation() string {
+	return `The On Pull Request trigger starts a workflow execution when a pull request changes state in a Bitbucket repository.
+
+## Use Cases
+
+- **Preview environments**: Provision an ephemeral environment when a pull request is opened, and tear it down when it is merged or declined
+- **Review automation**: Run checks, ask an agent for a review, or notify a channel when a pull request is opened or updated
+- **Merge gates**: React to approvals and change requests to drive a deployment decision
+- **Release automation**: Start a deploy when a pull request targeting ` + "`main`" + ` is merged
+
+## Configuration
+
+- **Repository** (required): The Bitbucket repository to monitor
+- **Actions** (required): Which pull request events to listen for. Default: Opened.
+- **Target Branches** (optional): Only fire when the pull request targets a matching branch. Leave empty to accept every target branch.
+
+## Event Data
+
+Each event includes:
+- **pullrequest**: The full pull request, including ` + "`id`" + `, ` + "`title`" + `, ` + "`state`" + `, ` + "`source`" + `, ` + "`destination`" + ` and ` + "`links`" + `
+- **repository**: Repository information
+- **actor**: The user that triggered the event
+- **approval** / **changes_request**: Present on approval and change-request events
+
+Common expression paths:
+- Pull request ID: ` + "`root().data.pullrequest.id`" + `
+- Title: ` + "`root().data.pullrequest.title`" + `
+- State: ` + "`root().data.pullrequest.state`" + `
+- Source branch: ` + "`root().data.pullrequest.source.branch.name`" + `
+- Target branch: ` + "`root().data.pullrequest.destination.branch.name`" + `
+- Head commit: ` + "`root().data.pullrequest.source.commit.hash`" + `
+- Pull request URL: ` + "`root().data.pullrequest.links.html.href`" + `
+
+Note that Bitbucket reports the merged state as the ` + "`fulfilled`" + ` action and the declined state as ` + "`rejected`" + `.
+
+## Webhook Setup
+
+This trigger automatically sets up a Bitbucket webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.`
+}
+
+func (p *OnPullRequest) Icon() string {
+	return "bitbucket"
+}
+
+func (p *OnPullRequest) Color() string {
+	return "blue"
+}
+
+func (p *OnPullRequest) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		{
+			Name:        "actions",
+			Label:       "Actions",
+			Type:        configuration.FieldTypeMultiSelect,
+			Required:    true,
+			Default:     []string{"created"},
+			Description: "Which pull request events should start a run",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: pullRequestActions,
+				},
+			},
+		},
+		{
+			Name:        "targetBranches",
+			Label:       "Target Branches",
+			Type:        configuration.FieldTypeAnyPredicateList,
+			Required:    false,
+			Description: "Only fire for pull requests targeting a matching branch. Leave empty to accept any target branch.",
+			TypeOptions: &configuration.TypeOptions{
+				AnyPredicateList: &configuration.AnyPredicateListTypeOptions{
+					Operators: configuration.AllPredicateOperators,
+				},
+			},
+		},
+	}
+}
+
+func (p *OnPullRequest) Setup(ctx core.TriggerContext) error {
+	config := OnPullRequestConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if len(config.Actions) == 0 {
+		return fmt.Errorf("at least one action is required")
+	}
+
+	if err := validatePullRequestActions(config.Actions); err != nil {
+		return err
+	}
+
+	repo, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	return ctx.Integration.RequestWebhook(WebhookConfiguration{
+		EventTypes:     pullRequestEventTypes(config.Actions),
+		RepositorySlug: repo.Slug,
+	})
+}
+
+func (p *OnPullRequest) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (p *OnPullRequest) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (p *OnPullRequest) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	config := OnPullRequestConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	//
+	// Verify the event type. Webhooks are shared between triggers on the same
+	// repository, so deliveries for other event families are simply ignored.
+	//
+	eventKey := ctx.Headers.Get("X-Event-Key")
+	if eventKey == "" {
+		return http.StatusBadRequest, nil, fmt.Errorf("missing X-Event-Key header")
+	}
+
+	if !slices.Contains(pullRequestEventTypes(config.Actions), eventKey) {
+		return http.StatusOK, nil, nil
+	}
+
+	//
+	// Verify the webhook signature.
+	//
+	if code, err := verifyWebhookSignature(ctx); err != nil {
+		return code, nil, err
+	}
+
+	//
+	// Parse the webhook payload.
+	//
+	data := map[string]any{}
+	if err := json.Unmarshal(ctx.Body, &data); err != nil {
+		return http.StatusBadRequest, nil, fmt.Errorf("error parsing request body: %v", err)
+	}
+
+	if len(config.TargetBranches) > 0 {
+		targetBranch := pullRequestTargetBranch(data)
+		if targetBranch == "" || !configuration.MatchesAnyPredicate(config.TargetBranches, targetBranch) {
+			return http.StatusOK, nil, nil
+		}
+	}
+
+	if err := ctx.Events.Emit("bitbucket.pullRequest", data); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("error emitting event: %v", err)
+	}
+
+	return http.StatusOK, nil, nil
+}
+
+func (p *OnPullRequest) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func pullRequestEventTypes(actions []string) []string {
+	eventTypes := make([]string, 0, len(actions))
+	for _, action := range actions {
+		eventTypes = append(eventTypes, pullRequestEventPrefix+action)
+	}
+
+	return eventTypes
+}
+
+func validatePullRequestActions(actions []string) error {
+	for _, action := range actions {
+		known := slices.ContainsFunc(pullRequestActions, func(option configuration.FieldOption) bool {
+			return option.Value == action
+		})
+
+		if !known {
+			return fmt.Errorf("unsupported pull request action %q", action)
+		}
+	}
+
+	return nil
+}
+
+// pullRequestTargetBranch reads the destination branch out of a pull request payload.
+func pullRequestTargetBranch(data map[string]any) string {
+	pullRequest, ok := data["pullrequest"].(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	destination, ok := pullRequest["destination"].(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	branch, ok := destination["branch"].(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	name, _ := branch["name"].(string)
+	return strings.TrimSpace(name)
+}

--- a/pkg/integrations/bitbucket/on_pull_request_test.go
+++ b/pkg/integrations/bitbucket/on_pull_request_test.go
@@ -1,0 +1,290 @@
+package bitbucket
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__OnPullRequest__Setup(t *testing.T) {
+	trigger := &OnPullRequest{}
+	metadata := Metadata{
+		AuthType: AuthTypeWorkspaceAccessToken,
+		Workspace: &WorkspaceMetadata{
+			Slug: "superplane",
+		},
+	}
+
+	t.Run("at least one action is required", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"token": "token"}, Metadata: metadata},
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"actions":    []string{},
+			},
+		})
+
+		require.ErrorContains(t, err, "at least one action is required")
+	})
+
+	t.Run("unsupported action is rejected", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"token": "token"}, Metadata: metadata},
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"actions":    []string{"exploded"},
+			},
+		})
+
+		require.ErrorContains(t, err, `unsupported pull request action "exploded"`)
+	})
+
+	t.Run("repository is required", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"token": "token"}, Metadata: metadata},
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "",
+				"actions":    []string{"created"},
+			},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("webhook is requested for every selected action", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"values":[{"uuid":"{hello}","name":"hello","full_name":"superplane/hello","slug":"hello"}]}`,
+					)),
+				},
+			},
+		}
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"token": "token"},
+			Metadata:      metadata,
+		}
+
+		require.NoError(t, trigger.Setup(core.TriggerContext{
+			HTTP:        httpCtx,
+			Integration: integrationCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"actions":    []string{"created", "fulfilled"},
+			},
+		}))
+
+		require.Len(t, integrationCtx.WebhookRequests, 1)
+		webhookRequest, ok := integrationCtx.WebhookRequests[0].(WebhookConfiguration)
+		require.True(t, ok)
+		assert.Equal(t, []string{"pullrequest:created", "pullrequest:fulfilled"}, webhookRequest.EventTypes)
+		assert.Equal(t, "hello", webhookRequest.RepositorySlug)
+	})
+}
+
+func Test__OnPullRequest__HandleWebhook(t *testing.T) {
+	trigger := &OnPullRequest{}
+
+	configurationFor := func(actions []string, targetBranches []configuration.Predicate) map[string]any {
+		config := map[string]any{
+			"repository": "hello",
+			"actions":    actions,
+		}
+
+		if targetBranches != nil {
+			config["targetBranches"] = targetBranches
+		}
+
+		return config
+	}
+
+	t.Run("no X-Event-Key -> 400", func(t *testing.T) {
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Headers:       http.Header{},
+			Configuration: configurationFor([]string{"created"}, nil),
+		})
+
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.ErrorContains(t, err, "missing X-Event-Key header")
+	})
+
+	// Webhooks are shared across triggers on the same repository, so a push delivery
+	// reaching this trigger must be dropped without touching the signature or payload.
+	t.Run("event belongs to another trigger -> 200", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "repo:push")
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Headers:       headers,
+			Events:        eventContext,
+			Configuration: configurationFor([]string{"created"}, nil),
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("action is not selected -> 200", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "pullrequest:rejected")
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Headers:       headers,
+			Events:        eventContext,
+			Configuration: configurationFor([]string{"created", "fulfilled"}, nil),
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("invalid signature -> 403", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "pullrequest:created")
+		headers.Set("X-Hub-Signature", "sha256=invalid")
+
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Body:          []byte(`{}`),
+			Headers:       headers,
+			Webhook:       &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Configuration: configurationFor([]string{"created"}, nil),
+		})
+
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.ErrorContains(t, err, "invalid signature")
+	})
+
+	t.Run("invalid body -> 400", func(t *testing.T) {
+		body := []byte("{")
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "pullrequest:created")
+		headers.Set("X-Hub-Signature", "sha256="+signBitbucketPayload("test-secret", body))
+
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Body:          body,
+			Headers:       headers,
+			Webhook:       &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Configuration: configurationFor([]string{"created"}, nil),
+			Events:        &contexts.EventContext{},
+		})
+
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.ErrorContains(t, err, "error parsing request body")
+	})
+
+	t.Run("target branch does not match -> event is not emitted", func(t *testing.T) {
+		body := []byte(`{"pullrequest":{"id":42,"destination":{"branch":{"name":"develop"}}}}`)
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "pullrequest:created")
+		headers.Set("X-Hub-Signature", "sha256="+signBitbucketPayload("test-secret", body))
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:  log.NewEntry(log.New()),
+			Body:    body,
+			Headers: headers,
+			Webhook: &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Configuration: configurationFor([]string{"created"}, []configuration.Predicate{
+				{Type: configuration.PredicateTypeEquals, Value: "main"},
+			}),
+			Events: eventContext,
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("target branch matches -> event is emitted", func(t *testing.T) {
+		body := []byte(`{"pullrequest":{"id":42,"destination":{"branch":{"name":"main"}}}}`)
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "pullrequest:created")
+		headers.Set("X-Hub-Signature", "sha256="+signBitbucketPayload("test-secret", body))
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:  log.NewEntry(log.New()),
+			Body:    body,
+			Headers: headers,
+			Webhook: &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Configuration: configurationFor([]string{"created"}, []configuration.Predicate{
+				{Type: configuration.PredicateTypeEquals, Value: "main"},
+			}),
+			Events: eventContext,
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		require.Equal(t, 1, eventContext.Count())
+		assert.Equal(t, "bitbucket.pullRequest", eventContext.Payloads[0].Type)
+	})
+
+	t.Run("no target branch filter -> every target branch is accepted", func(t *testing.T) {
+		body := []byte(`{"pullrequest":{"id":7,"destination":{"branch":{"name":"release/2026-08"}}}}`)
+		headers := http.Header{}
+		headers.Set("X-Event-Key", "pullrequest:fulfilled")
+		headers.Set("X-Hub-Signature", "sha256="+signBitbucketPayload("test-secret", body))
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Logger:        log.NewEntry(log.New()),
+			Body:          body,
+			Headers:       headers,
+			Webhook:       &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Configuration: configurationFor([]string{"fulfilled"}, nil),
+			Events:        eventContext,
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, eventContext.Count())
+	})
+}
+
+func Test__PullRequestTargetBranch(t *testing.T) {
+	t.Run("reads the destination branch", func(t *testing.T) {
+		branch := pullRequestTargetBranch(map[string]any{
+			"pullrequest": map[string]any{
+				"destination": map[string]any{
+					"branch": map[string]any{"name": "main"},
+				},
+			},
+		})
+
+		assert.Equal(t, "main", branch)
+	})
+
+	t.Run("missing destination returns empty string", func(t *testing.T) {
+		assert.Empty(t, pullRequestTargetBranch(map[string]any{"pullrequest": map[string]any{}}))
+	})
+
+	t.Run("missing pull request returns empty string", func(t *testing.T) {
+		assert.Empty(t, pullRequestTargetBranch(map[string]any{}))
+	})
+}

--- a/pkg/integrations/bitbucket/on_push.go
+++ b/pkg/integrations/bitbucket/on_push.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/crypto"
 )
 
 type OnPush struct{}
@@ -67,18 +65,7 @@ func (p *OnPush) Color() string {
 
 func (p *OnPush) Configuration() []configuration.Field {
 	return []configuration.Field{
-		{
-			Name:     "repository",
-			Label:    "Repository",
-			Type:     configuration.FieldTypeIntegrationResource,
-			Required: true,
-			TypeOptions: &configuration.TypeOptions{
-				Resource: &configuration.ResourceTypeOptions{
-					Type:           "repository",
-					UseNameAsValue: true,
-				},
-			},
-		},
+		repositoryField(),
 		{
 			Name:     "refs",
 			Label:    "Refs",
@@ -141,30 +128,15 @@ func (p *OnPush) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webho
 	//
 	// Verify the webhook signature.
 	//
-	signature := ctx.Headers.Get("X-Hub-Signature")
-	if signature == "" {
-		return http.StatusForbidden, nil, fmt.Errorf("missing X-Hub-Signature header")
-	}
-
-	signature = strings.TrimPrefix(signature, "sha256=")
-	if signature == "" {
-		return http.StatusForbidden, nil, fmt.Errorf("invalid signature format")
-	}
-
-	secret, err := ctx.Webhook.GetSecret()
-	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Errorf("error getting webhook secret")
-	}
-
-	if err := crypto.VerifySignature(secret, ctx.Body, signature); err != nil {
-		return http.StatusForbidden, nil, fmt.Errorf("invalid signature")
+	if code, err := verifyWebhookSignature(ctx); err != nil {
+		return code, nil, err
 	}
 
 	//
 	// Parse the webhook payload.
 	//
 	data := map[string]any{}
-	err = json.Unmarshal(ctx.Body, &data)
+	err := json.Unmarshal(ctx.Body, &data)
 	if err != nil {
 		return http.StatusBadRequest, nil, fmt.Errorf("error parsing request body: %v", err)
 	}

--- a/pkg/integrations/bitbucket/publish_commit_status.go
+++ b/pkg/integrations/bitbucket/publish_commit_status.go
@@ -1,0 +1,231 @@
+package bitbucket
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_publish_commit_status.json
+var exampleOutputPublishCommitStatus []byte
+
+type PublishCommitStatus struct{}
+
+type PublishCommitStatusConfiguration struct {
+	Repository  string `json:"repository" mapstructure:"repository"`
+	Commit      string `json:"commit" mapstructure:"commit"`
+	Key         string `json:"key" mapstructure:"key"`
+	Name        string `json:"name" mapstructure:"name"`
+	State       string `json:"state" mapstructure:"state"`
+	URL         string `json:"url" mapstructure:"url"`
+	Description string `json:"description" mapstructure:"description"`
+}
+
+func (p *PublishCommitStatus) Name() string {
+	return "bitbucket.publishCommitStatus"
+}
+
+func (p *PublishCommitStatus) Label() string {
+	return "Publish Commit Status"
+}
+
+func (p *PublishCommitStatus) Description() string {
+	return "Report a build status on a Bitbucket commit"
+}
+
+func (p *PublishCommitStatus) Documentation() string {
+	return `The Publish Commit Status component reports a build status on a Bitbucket commit, so the result of a
+SuperPlane workflow shows up next to the commit and on any pull request that contains it.
+
+## Use Cases
+
+- **Make SuperPlane a required check**: Publish ` + "`INPROGRESS`" + ` when a workflow starts and ` + "`SUCCESSFUL`" + ` or ` + "`FAILED`" + ` when it finishes, then require that key in a Bitbucket branch restriction
+- **Surface external results**: Report the outcome of a security scan, a load test or a manual approval directly on the commit
+- **Close the loop on deploys**: Mark the commit that reached production
+
+## Configuration
+
+- **Repository** (required): The repository containing the commit
+- **Commit** (required): The full commit hash to report on (supports expressions)
+- **Key** (required): A stable identifier for this check, e.g. ` + "`superplane-deploy`" + `. Publishing again with the same key updates the existing status instead of adding a new one.
+- **Name** (optional): The human-readable name shown in Bitbucket. Defaults to the key.
+- **State** (required): The build state to report
+- **URL** (optional): A link to the run, so people can click through from Bitbucket
+- **Description** (optional): A short explanation shown next to the status
+
+## Permissions
+
+The token needs the ` + "`repository:write`" + ` scope on the repository.
+
+## Output
+
+The component emits the published status, including ` + "`key`" + `, ` + "`state`" + `, ` + "`url`" + ` and ` + "`refname`" + `.
+
+Publishing a status fires the **On Commit Status** trigger, so be careful not to point that trigger at the
+same key this component writes — it would run the workflow again.`
+}
+
+func (p *PublishCommitStatus) Icon() string {
+	return "bitbucket"
+}
+
+func (p *PublishCommitStatus) Color() string {
+	return "blue"
+}
+
+func (p *PublishCommitStatus) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (p *PublishCommitStatus) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputPublishCommitStatus, &example); err != nil {
+		return map[string]any{}
+	}
+
+	return example
+}
+
+func (p *PublishCommitStatus) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		commitField(),
+		{
+			Name:        "key",
+			Label:       "Key",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "superplane-deploy",
+			Description: "A stable identifier for this check. Publishing again with the same key updates the existing status.",
+		},
+		{
+			Name:        "name",
+			Label:       "Name",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "The name shown in Bitbucket. Defaults to the key.",
+		},
+		{
+			Name:     "state",
+			Label:    "State",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  StateInProgress,
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: commitStatusStates,
+				},
+			},
+		},
+		{
+			Name:        "url",
+			Label:       "URL",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "A link people can follow from Bitbucket back to this run",
+		},
+		{
+			Name:        "description",
+			Label:       "Description",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "A short explanation shown next to the status",
+		},
+	}
+}
+
+func (p *PublishCommitStatus) Setup(ctx core.SetupContext) error {
+	config := PublishCommitStatusConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Commit == "" {
+		return fmt.Errorf("commit is required")
+	}
+
+	if config.Key == "" {
+		return fmt.Errorf("key is required")
+	}
+
+	if config.State == "" {
+		return fmt.Errorf("state is required")
+	}
+
+	if !isValidCommitStatusState(config.State) {
+		return fmt.Errorf("unsupported build state %q", config.State)
+	}
+
+	_, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	return err
+}
+
+func (p *PublishCommitStatus) Execute(ctx core.ExecutionContext) error {
+	config := PublishCommitStatusConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	commit := strings.TrimSpace(config.Commit)
+	if commit == "" {
+		return fmt.Errorf("commit is required")
+	}
+
+	target, err := resolveRepositoryTarget(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	name := config.Name
+	if name == "" {
+		name = config.Key
+	}
+
+	published, err := target.Client.PublishCommitStatus(target.Workspace, target.Repository, commit, &CommitStatus{
+		Key:         config.Key,
+		Name:        name,
+		State:       strings.ToUpper(strings.TrimSpace(config.State)),
+		URL:         config.URL,
+		Description: config.Description,
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to publish commit status: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"bitbucket.commitStatus",
+		[]any{published},
+	)
+}
+
+func (p *PublishCommitStatus) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (p *PublishCommitStatus) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (p *PublishCommitStatus) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (p *PublishCommitStatus) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (p *PublishCommitStatus) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (p *PublishCommitStatus) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/bitbucket/publish_commit_status_test.go
+++ b/pkg/integrations/bitbucket/publish_commit_status_test.go
@@ -1,0 +1,143 @@
+package bitbucket
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const publishedCommitStatusResponse = `{
+  "key": "superplane-deploy",
+  "name": "SuperPlane deploy",
+  "state": "SUCCESSFUL",
+  "url": "https://app.superplane.com/runs/8f2c1a44",
+  "refname": "main"
+}`
+
+func Test__PublishCommitStatus__Setup(t *testing.T) {
+	action := &PublishCommitStatus{}
+
+	base := func() map[string]any {
+		return map[string]any{
+			"repository": testRepositoryName,
+			"commit":     "9fec847784abb10b2fa567ee63b85bd238955d0e",
+			"key":        "superplane-deploy",
+			"state":      StateSuccessful,
+		}
+	}
+
+	t.Run("commit is required", func(t *testing.T) {
+		config := base()
+		config["commit"] = ""
+
+		require.ErrorContains(t, action.Setup(newSetupContext(config)), "commit is required")
+	})
+
+	t.Run("key is required", func(t *testing.T) {
+		config := base()
+		config["key"] = ""
+
+		require.ErrorContains(t, action.Setup(newSetupContext(config)), "key is required")
+	})
+
+	t.Run("state is required", func(t *testing.T) {
+		config := base()
+		config["state"] = ""
+
+		require.ErrorContains(t, action.Setup(newSetupContext(config)), "state is required")
+	})
+
+	t.Run("unsupported state is rejected", func(t *testing.T) {
+		config := base()
+		config["state"] = "GREEN"
+
+		require.ErrorContains(t, action.Setup(newSetupContext(config)), `unsupported build state "GREEN"`)
+	})
+
+	t.Run("valid configuration is accepted", func(t *testing.T) {
+		require.NoError(t, action.Setup(newSetupContext(base())))
+	})
+}
+
+func Test__PublishCommitStatus__Execute(t *testing.T) {
+	action := &PublishCommitStatus{}
+
+	t.Run("status is published and emitted", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":  testRepositoryName,
+			"commit":      "9fec847784abb10b2fa567ee63b85bd238955d0e",
+			"key":         "superplane-deploy",
+			"name":        "SuperPlane deploy",
+			"state":       StateSuccessful,
+			"url":         "https://app.superplane.com/runs/8f2c1a44",
+			"description": "Deployed to production",
+		}, jsonResponse(http.StatusCreated, publishedCommitStatusResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		require.Len(t, fixture.HTTP.Requests, 1)
+		request := fixture.HTTP.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(
+			t,
+			"https://api.bitbucket.org/2.0/repositories/superplane/web/commit/9fec847784abb10b2fa567ee63b85bd238955d0e/statuses/build",
+			request.URL.String(),
+		)
+
+		body := requestBody(t, request)
+		assert.Equal(t, "superplane-deploy", body["key"])
+		assert.Equal(t, "SuperPlane deploy", body["name"])
+		assert.Equal(t, StateSuccessful, body["state"])
+		assert.Equal(t, "Deployed to production", body["description"])
+
+		status := emittedPayload[*CommitStatus](t, fixture.ExecutionState, 0)
+		assert.Equal(t, "superplane-deploy", status.Key)
+		assert.Equal(t, StateSuccessful, status.State)
+		assert.Equal(t, "bitbucket.commitStatus", fixture.ExecutionState.Type)
+	})
+
+	t.Run("name defaults to the key", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository": testRepositoryName,
+			"commit":     "9fec847784abb10b2fa567ee63b85bd238955d0e",
+			"key":        "superplane-deploy",
+			"state":      StateInProgress,
+		}, jsonResponse(http.StatusCreated, publishedCommitStatusResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		body := requestBody(t, fixture.HTTP.Requests[0])
+		assert.Equal(t, "superplane-deploy", body["name"])
+	})
+
+	// The commit usually arrives from an expression, which can resolve to whitespace.
+	t.Run("a blank commit is reported before any request is made", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository": testRepositoryName,
+			"commit":     "   ",
+			"key":        "superplane-deploy",
+			"state":      StateSuccessful,
+		})
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "commit is required")
+		assert.Empty(t, fixture.HTTP.Requests)
+	})
+
+	t.Run("API error is reported", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository": testRepositoryName,
+			"commit":     "9fec847784abb10b2fa567ee63b85bd238955d0e",
+			"key":        "superplane-deploy",
+			"state":      StateSuccessful,
+		}, jsonResponse(http.StatusForbidden, `{"error":{"message":"write access required"}}`))
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "failed to publish commit status")
+		require.ErrorContains(t, err, "write access required")
+	})
+}

--- a/pkg/integrations/bitbucket/test_helpers_test.go
+++ b/pkg/integrations/bitbucket/test_helpers_test.go
@@ -1,0 +1,123 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+const (
+	testWorkspace      = "superplane"
+	testRepositorySlug = "web"
+	testRepositoryName = "superplane/web"
+)
+
+func testIntegrationMetadata() Metadata {
+	return Metadata{
+		AuthType: AuthTypeWorkspaceAccessToken,
+		Workspace: &WorkspaceMetadata{
+			UUID: "{workspace-uuid}",
+			Name: "SuperPlane",
+			Slug: testWorkspace,
+		},
+	}
+}
+
+// testNodeMetadata pre-resolves the repository the way Setup() does, so Execute()
+// tests only need to mock the API call under test.
+func testNodeMetadata() NodeMetadata {
+	return NodeMetadata{
+		Repository: &RepositoryMetadata{
+			UUID:     "{repository-uuid}",
+			Name:     "web",
+			FullName: testRepositoryName,
+			Slug:     testRepositorySlug,
+		},
+	}
+}
+
+func jsonResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+type executionFixture struct {
+	Context        core.ExecutionContext
+	HTTP           *contexts.HTTPContext
+	ExecutionState *contexts.ExecutionStateContext
+}
+
+func newExecutionFixture(config map[string]any, responses ...*http.Response) executionFixture {
+	httpCtx := &contexts.HTTPContext{Responses: responses}
+	executionState := &contexts.ExecutionStateContext{}
+
+	return executionFixture{
+		HTTP:           httpCtx,
+		ExecutionState: executionState,
+		Context: core.ExecutionContext{
+			Logger:         log.NewEntry(log.New()),
+			HTTP:           httpCtx,
+			Configuration:  config,
+			Metadata:       &contexts.MetadataContext{Metadata: testNodeMetadata()},
+			ExecutionState: executionState,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"token": "token"},
+				Metadata:      testIntegrationMetadata(),
+			},
+		},
+	}
+}
+
+func newSetupContext(config map[string]any, responses ...*http.Response) core.SetupContext {
+	return core.SetupContext{
+		Logger:        log.NewEntry(log.New()),
+		HTTP:          &contexts.HTTPContext{Responses: responses},
+		Configuration: config,
+		Metadata:      &contexts.MetadataContext{Metadata: testNodeMetadata()},
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"token": "token"},
+			Metadata:      testIntegrationMetadata(),
+		},
+	}
+}
+
+// emittedPayload unwraps the {type, timestamp, data} envelope the execution state puts
+// around every emitted payload.
+func emittedPayload[T any](t *testing.T, state *contexts.ExecutionStateContext, index int) T {
+	t.Helper()
+
+	require.Greater(t, len(state.Payloads), index)
+
+	wrapper, ok := state.Payloads[index].(map[string]any)
+	require.True(t, ok, "payload is not an envelope")
+
+	payload, ok := wrapper["data"].(T)
+	require.True(t, ok, "payload data has an unexpected type: %T", wrapper["data"])
+
+	return payload
+}
+
+// requestBody decodes the JSON payload of a recorded request. The fake HTTP context
+// never reads the body, so it is still available to assert on.
+func requestBody(t *testing.T, request *http.Request) map[string]any {
+	t.Helper()
+
+	require.NotNil(t, request.Body)
+
+	raw, err := io.ReadAll(request.Body)
+	require.NoError(t, err)
+
+	body := map[string]any{}
+	require.NoError(t, json.Unmarshal(raw, &body))
+
+	return body
+}

--- a/pkg/integrations/bitbucket/update_pull_request.go
+++ b/pkg/integrations/bitbucket/update_pull_request.go
@@ -1,0 +1,291 @@
+package bitbucket
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+//go:embed example_output_update_pull_request.json
+var exampleOutputUpdatePullRequest []byte
+
+type UpdatePullRequest struct{}
+
+type UpdatePullRequestConfiguration struct {
+	Repository        string   `json:"repository" mapstructure:"repository"`
+	PullRequestID     string   `json:"pullRequestId" mapstructure:"pullRequestId"`
+	Title             string   `json:"title" mapstructure:"title"`
+	Description       string   `json:"description" mapstructure:"description"`
+	TargetBranch      string   `json:"targetBranch" mapstructure:"targetBranch"`
+	Reviewers         []string `json:"reviewers" mapstructure:"reviewers"`
+	CloseSourceBranch bool     `json:"closeSourceBranch" mapstructure:"closeSourceBranch"`
+}
+
+// updatePullRequestToggles tracks which optional fields were explicitly turned on via
+// their UI toggle, independent of whether the decoded value ended up empty - clearing
+// a field (toggled on, empty value) must still be sent, unlike a field that was never
+// toggled on. See gitlab/update_merge_request.go for the same pattern.
+type updatePullRequestToggles struct {
+	Title             bool
+	Description       bool
+	TargetBranch      bool
+	Reviewers         bool
+	CloseSourceBranch bool
+}
+
+func newUpdatePullRequestToggles(raw map[string]any) updatePullRequestToggles {
+	enabled := func(field string) bool {
+		value, ok := raw[field]
+		return ok && value != nil
+	}
+
+	return updatePullRequestToggles{
+		Title:             enabled("title"),
+		Description:       enabled("description"),
+		TargetBranch:      enabled("targetBranch"),
+		Reviewers:         enabled("reviewers"),
+		CloseSourceBranch: enabled("closeSourceBranch"),
+	}
+}
+
+func (t updatePullRequestToggles) hasUpdates() bool {
+	return t.Title || t.Description || t.TargetBranch || t.Reviewers || t.CloseSourceBranch
+}
+
+func (u *UpdatePullRequest) Name() string {
+	return "bitbucket.updatePullRequest"
+}
+
+func (u *UpdatePullRequest) Label() string {
+	return "Update Pull Request"
+}
+
+func (u *UpdatePullRequest) Description() string {
+	return "Update an existing pull request in a Bitbucket repository"
+}
+
+func (u *UpdatePullRequest) Documentation() string {
+	return `The Update Pull Request component modifies an existing Bitbucket pull request: its title, description, target branch, reviewers, or whether the source branch is deleted on merge.
+
+## Use Cases
+
+- **Progress reporting**: Rewrite the description as a workflow advances, so the pull request always shows current state
+- **Retargeting**: Move a pull request onto a different release branch
+- **Review routing**: Assign reviewers based on which files changed
+
+## Configuration
+
+- **Repository** (required): The repository containing the pull request
+- **Pull Request ID** (required): The numeric ID of the pull request (supports expressions)
+- **Title** (toggle): New title for the pull request
+- **Description** (toggle): New description for the pull request
+- **Target Branch** (toggle): Retarget the pull request onto a different branch
+- **Reviewers** (toggle): Workspace members to request a review from. Replaces the existing reviewers; selecting none clears them.
+- **Close Source Branch** (toggle): Whether the source branch is deleted when the pull request merges
+
+Each field besides Repository and Pull Request ID is toggled on individually, so only the fields you enable are sent. At least one must be enabled. Bitbucket rejects a blank title, so Title must have a value when enabled.
+
+## Permissions
+
+The token needs the ` + "`pullrequest:write`" + ` scope on the repository.
+
+## Output
+
+The component emits the updated pull request, in the same shape as **Create Pull Request**.`
+}
+
+func (u *UpdatePullRequest) Icon() string {
+	return "bitbucket"
+}
+
+func (u *UpdatePullRequest) Color() string {
+	return "blue"
+}
+
+func (u *UpdatePullRequest) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (u *UpdatePullRequest) ExampleOutput() map[string]any {
+	var example map[string]any
+	if err := json.Unmarshal(exampleOutputUpdatePullRequest, &example); err != nil {
+		return map[string]any{}
+	}
+
+	return example
+}
+
+func (u *UpdatePullRequest) Configuration() []configuration.Field {
+	return []configuration.Field{
+		repositoryField(),
+		pullRequestIDField(),
+		{
+			Name:      "title",
+			Label:     "Title",
+			Type:      configuration.FieldTypeString,
+			Required:  false,
+			Togglable: true,
+		},
+		{
+			Name:      "description",
+			Label:     "Description",
+			Type:      configuration.FieldTypeText,
+			Required:  false,
+			Togglable: true,
+		},
+		{
+			Name:        "targetBranch",
+			Label:       "Target Branch",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Togglable:   true,
+			Description: "Retarget the pull request onto a different branch",
+		},
+		{
+			Name:        "reviewers",
+			Label:       "Reviewers",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Togglable:   true,
+			Description: "Workspace members to request a review from. Replaces the existing reviewers; selecting none clears them.",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:  ResourceTypeMember,
+					Multi: true,
+				},
+			},
+		},
+		{
+			Name:        "closeSourceBranch",
+			Label:       "Close Source Branch",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Togglable:   true,
+			Description: "Whether the source branch is deleted when the pull request merges",
+		},
+	}
+}
+
+func (u *UpdatePullRequest) Setup(ctx core.SetupContext) error {
+	config := UpdatePullRequestConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.PullRequestID == "" {
+		return fmt.Errorf("pull request ID is required")
+	}
+
+	raw, ok := ctx.Configuration.(map[string]any)
+	if !ok {
+		return fmt.Errorf("failed to decode configuration")
+	}
+
+	toggles := newUpdatePullRequestToggles(raw)
+	if !toggles.hasUpdates() {
+		return fmt.Errorf("at least one field to update is required")
+	}
+
+	// Bitbucket rejects an empty title, so an enabled-but-blank title is a
+	// configuration error rather than a request we should let fail at runtime.
+	if toggles.Title && config.Title == "" {
+		return fmt.Errorf("title cannot be empty when it is enabled")
+	}
+
+	if toggles.TargetBranch && normalizeBranch(config.TargetBranch) == "" {
+		return fmt.Errorf("target branch cannot be empty when it is enabled")
+	}
+
+	_, err := ensureRepoInMetadata(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	return err
+}
+
+func (u *UpdatePullRequest) Execute(ctx core.ExecutionContext) error {
+	config := UpdatePullRequestConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	raw, ok := ctx.Configuration.(map[string]any)
+	if !ok {
+		return fmt.Errorf("failed to decode configuration")
+	}
+
+	pullRequestID, err := parsePullRequestID(config.PullRequestID)
+	if err != nil {
+		return err
+	}
+
+	target, err := resolveRepositoryTarget(ctx.HTTP, ctx.Metadata, ctx.Integration, config.Repository)
+	if err != nil {
+		return err
+	}
+
+	toggles := newUpdatePullRequestToggles(raw)
+	request := &UpdatePullRequestRequest{}
+
+	if toggles.Title {
+		request.Title = &config.Title
+	}
+
+	if toggles.Description {
+		request.Description = &config.Description
+	}
+
+	if toggles.TargetBranch {
+		request.Destination = &PullRequestEndpoint{Branch: Branch{Name: normalizeBranch(config.TargetBranch)}}
+	}
+
+	if toggles.Reviewers {
+		reviewers := accountRefs(config.Reviewers)
+		if reviewers == nil {
+			reviewers = []AccountRef{}
+		}
+
+		request.Reviewers = &reviewers
+	}
+
+	if toggles.CloseSourceBranch {
+		request.CloseSourceBranch = &config.CloseSourceBranch
+	}
+
+	pullRequest, err := target.Client.UpdatePullRequest(target.Workspace, target.Repository, pullRequestID, request)
+	if err != nil {
+		return fmt.Errorf("failed to update pull request: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"bitbucket.pullRequest",
+		[]any{pullRequest},
+	)
+}
+
+func (u *UpdatePullRequest) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (u *UpdatePullRequest) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (u *UpdatePullRequest) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (u *UpdatePullRequest) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (u *UpdatePullRequest) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (u *UpdatePullRequest) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/bitbucket/update_pull_request_test.go
+++ b/pkg/integrations/bitbucket/update_pull_request_test.go
@@ -1,0 +1,157 @@
+package bitbucket
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const updatedPullRequestResponse = `{
+  "id": 42,
+  "title": "Add login page and session handling",
+  "state": "OPEN",
+  "source": {"branch": {"name": "feature/login-page"}},
+  "destination": {"branch": {"name": "main"}}
+}`
+
+func Test__UpdatePullRequest__Setup(t *testing.T) {
+	action := &UpdatePullRequest{}
+
+	t.Run("pull request ID is required", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository": testRepositoryName,
+			"title":      "New title",
+		}))
+
+		require.ErrorContains(t, err, "pull request ID is required")
+	})
+
+	t.Run("at least one field to update is required", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+		}))
+
+		require.ErrorContains(t, err, "at least one field to update is required")
+	})
+
+	t.Run("an enabled but blank title is rejected", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"title":         "",
+		}))
+
+		require.ErrorContains(t, err, "title cannot be empty when it is enabled")
+	})
+
+	t.Run("an enabled but blank target branch is rejected", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"targetBranch":  "",
+		}))
+
+		require.ErrorContains(t, err, "target branch cannot be empty when it is enabled")
+	})
+
+	// Clearing the description is a legitimate update, unlike clearing the title.
+	t.Run("an enabled but blank description is accepted", func(t *testing.T) {
+		err := action.Setup(newSetupContext(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"description":   "",
+		}))
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__UpdatePullRequest__Execute(t *testing.T) {
+	action := &UpdatePullRequest{}
+
+	t.Run("only the enabled fields are sent", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"title":         "Add login page and session handling",
+		}, jsonResponse(http.StatusOK, updatedPullRequestResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		require.Len(t, fixture.HTTP.Requests, 1)
+		request := fixture.HTTP.Requests[0]
+		assert.Equal(t, http.MethodPut, request.Method)
+		assert.Equal(t, "https://api.bitbucket.org/2.0/repositories/superplane/web/pullrequests/42", request.URL.String())
+
+		body := requestBody(t, request)
+		assert.Equal(t, "Add login page and session handling", body["title"])
+
+		// Fields that were never toggled on must stay out of the payload, otherwise
+		// Bitbucket would overwrite them with a zero value.
+		for _, field := range []string{"description", "destination", "reviewers", "close_source_branch"} {
+			_, present := body[field]
+			assert.False(t, present, "%s should not be sent", field)
+		}
+
+		pullRequest := emittedPayload[*PullRequest](t, fixture.ExecutionState, 0)
+		assert.Equal(t, "Add login page and session handling", pullRequest.Title)
+	})
+
+	t.Run("clearing the description sends an empty string", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"description":   "",
+		}, jsonResponse(http.StatusOK, updatedPullRequestResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		body := requestBody(t, fixture.HTTP.Requests[0])
+		description, present := body["description"]
+		require.True(t, present)
+		assert.Equal(t, "", description)
+	})
+
+	t.Run("clearing the reviewers sends an empty list", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "42",
+			"reviewers":     []string{},
+		}, jsonResponse(http.StatusOK, updatedPullRequestResponse))
+
+		require.NoError(t, action.Execute(fixture.Context))
+
+		body := requestBody(t, fixture.HTTP.Requests[0])
+		reviewers, present := body["reviewers"]
+		require.True(t, present)
+		assert.Empty(t, reviewers)
+	})
+
+	t.Run("a non-numeric pull request ID is reported", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "not-a-number",
+			"title":         "New title",
+		})
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, `pull request ID "not-a-number" is not a number`)
+		assert.Empty(t, fixture.HTTP.Requests)
+	})
+
+	t.Run("a zero pull request ID is reported", func(t *testing.T) {
+		fixture := newExecutionFixture(map[string]any{
+			"repository":    testRepositoryName,
+			"pullRequestId": "0",
+			"title":         "New title",
+		})
+
+		err := action.Execute(fixture.Context)
+
+		require.ErrorContains(t, err, "pull request ID must be greater than zero")
+	})
+}

--- a/web_src/src/pages/app/mappers/bitbucket/base.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/base.ts
@@ -1,0 +1,58 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import { getColorClass, getBackgroundColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import bitbucketIcon from "@/assets/icons/integrations/bitbucket.svg";
+import type { MetadataItem } from "@/ui/metadataList";
+import type { NodeInfo, ComponentDefinition, ExecutionInfo } from "../types";
+import type { NodeMetadata } from "./types";
+import { buildBitbucketExecutionSubtitle } from "./utils";
+
+export function baseProps(
+  nodes: NodeInfo[],
+  node: NodeInfo,
+  componentDefinition: ComponentDefinition,
+  lastExecutions: ExecutionInfo[],
+): ComponentBaseProps {
+  const lastExecution = lastExecutions.length > 0 ? lastExecutions[0] : null;
+  const componentName = componentDefinition.name || node.componentName || "unknown";
+
+  return {
+    iconSrc: bitbucketIcon,
+    iconColor: getColorClass(componentDefinition.color),
+    collapsedBackground: getBackgroundColorClass(componentDefinition.color),
+    collapsed: node.isCollapsed,
+    title: node.name || componentDefinition.label || componentDefinition.name || "Unnamed component",
+    eventSections: lastExecution ? baseEventSections(nodes, lastExecution, componentName) : undefined,
+    metadata: metadataList(node),
+    includeEmptyState: !lastExecution,
+    eventStateMap: getStateMap(componentName),
+  };
+}
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as unknown as NodeMetadata;
+  const repository = nodeMetadata?.repository;
+
+  if (repository) {
+    metadata.push({ icon: "book", label: repository.full_name || repository.name || "" });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventState: getState(componentName)(execution),
+      eventSubtitle: buildBitbucketExecutionSubtitle(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/app/mappers/bitbucket/commit_status_actions.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/commit_status_actions.ts
@@ -1,0 +1,88 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
+import { formatTimestamp } from "../utils";
+import { baseProps } from "./base";
+import type { CombinedCommitStatus, CommitStatus } from "./types";
+import { addDetailIfPresent, buildBitbucketExecutionSubtitle, defaultOutput, shortHash } from "./utils";
+
+export const publishCommitStatusMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const output = defaultOutput<CommitStatus>(context.execution.outputs);
+
+    if (output) {
+      return `${output.data.key || ""} ${output.data.state || ""}`.trim();
+    }
+
+    return buildBitbucketExecutionSubtitle(context.execution, "Status Published");
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const output = defaultOutput<CommitStatus>(context.execution.outputs);
+
+    if (!output) {
+      return {};
+    }
+
+    const status = output.data;
+    const details: Record<string, string> = {
+      "Published At": formatTimestamp(status.updated_on || status.created_on, output.timestamp),
+    };
+
+    addDetailIfPresent(details, "Key", status.key);
+    addDetailIfPresent(details, "Name", status.name);
+    addDetailIfPresent(details, "State", status.state);
+    addDetailIfPresent(details, "Ref", status.refname);
+    addDetailIfPresent(details, "Commit", shortHash(status.commit?.hash));
+    addDetailIfPresent(details, "URL", status.url);
+
+    return details;
+  },
+};
+
+export const getCommitStatusMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const output = defaultOutput<CombinedCommitStatus>(context.execution.outputs);
+
+    if (output) {
+      const total = output.data.total_count ?? 0;
+      return `${output.data.state || ""} (${total} ${total === 1 ? "check" : "checks"})`.trim();
+    }
+
+    return buildBitbucketExecutionSubtitle(context.execution, "Statuses Retrieved");
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const output = defaultOutput<CombinedCommitStatus>(context.execution.outputs);
+
+    if (!output) {
+      return {};
+    }
+
+    const combined = output.data;
+    const details: Record<string, string> = {};
+
+    addDetailIfPresent(details, "Commit", shortHash(combined.commit));
+    addDetailIfPresent(details, "Combined State", combined.state);
+    addDetailIfPresent(details, "Checks", combined.total_count);
+
+    // List the failing checks by name, since that is what a human reading a blocked
+    // deploy actually needs to see.
+    const failing = (combined.statuses || []).filter(
+      (status) => status.state === "FAILED" || status.state === "STOPPED",
+    );
+    if (failing.length > 0) {
+      details["Not Passing"] = failing.map((status) => status.key || status.name || "unknown").join(", ");
+    }
+
+    return details;
+  },
+};

--- a/web_src/src/pages/app/mappers/bitbucket/index.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/index.ts
@@ -1,6 +1,38 @@
-import type { TriggerRenderer } from "../types";
+import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
+import { buildActionStateRegistry } from "../utils";
+import { getCommitStatusMapper, publishCommitStatusMapper } from "./commit_status_actions";
+import { onCommitStatusTriggerRenderer } from "./on_commit_status";
+import { onPRCommentTriggerRenderer } from "./on_pr_comment";
+import { onPullRequestTriggerRenderer } from "./on_pull_request";
 import { onPushTriggerRenderer } from "./on_push";
+import {
+  createPRCommentMapper,
+  createPullRequestMapper,
+  mergePullRequestMapper,
+  updatePullRequestMapper,
+} from "./pull_request_actions";
+
+export const eventStateRegistry: Record<string, EventStateRegistry> = {
+  createPullRequest: buildActionStateRegistry("created"),
+  updatePullRequest: buildActionStateRegistry("updated"),
+  mergePullRequest: buildActionStateRegistry("merged"),
+  createPRComment: buildActionStateRegistry("created"),
+  publishCommitStatus: buildActionStateRegistry("published"),
+  getCommitStatus: buildActionStateRegistry("retrieved"),
+};
+
+export const componentMappers: Record<string, ComponentBaseMapper> = {
+  createPullRequest: createPullRequestMapper,
+  updatePullRequest: updatePullRequestMapper,
+  mergePullRequest: mergePullRequestMapper,
+  createPRComment: createPRCommentMapper,
+  publishCommitStatus: publishCommitStatusMapper,
+  getCommitStatus: getCommitStatusMapper,
+};
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
   onPush: onPushTriggerRenderer,
+  onPullRequest: onPullRequestTriggerRenderer,
+  onPRComment: onPRCommentTriggerRenderer,
+  onCommitStatus: onCommitStatusTriggerRenderer,
 };

--- a/web_src/src/pages/app/mappers/bitbucket/on_commit_status.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/on_commit_status.ts
@@ -1,0 +1,119 @@
+import { getColorClass, getBackgroundColorClass } from "@/lib/colors";
+import type React from "react";
+import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
+import bitbucketIcon from "@/assets/icons/integrations/bitbucket.svg";
+import type { TriggerProps } from "@/ui/trigger";
+import type { MetadataItem } from "@/ui/metadataList";
+import type { CommitStatusEvent, NodeMetadata } from "./types";
+import type { Predicate } from "../utils";
+import { formatPredicate } from "../utils";
+import { buildBitbucketSubtitle } from "./utils";
+
+export interface OnCommitStatusConfiguration {
+  repository?: string;
+  states?: string[];
+  keys?: Predicate[];
+  refs?: Predicate[];
+}
+
+const STATE_LABELS: Record<string, string> = {
+  INPROGRESS: "In progress",
+  SUCCESSFUL: "Successful",
+  FAILED: "Failed",
+  STOPPED: "Stopped",
+};
+
+function formatState(state: string): string {
+  return STATE_LABELS[state] || state;
+}
+
+function statusTitle(event?: CommitStatusEvent): string {
+  const status = event?.commit_status;
+  if (!status) {
+    return "";
+  }
+
+  return `${status.name || status.key || ""} ${formatState(status.state || "")}`.trim();
+}
+
+function statusSubtitle(event?: CommitStatusEvent): string {
+  return event?.commit_status?.refname || "";
+}
+
+function metadataItems(metadata: NodeMetadata, configuration: OnCommitStatusConfiguration): MetadataItem[] {
+  const items: MetadataItem[] = [];
+  const repository = metadata?.repository;
+
+  if (repository) {
+    items.push({ icon: "book", label: repository.full_name || repository.name || "" });
+  }
+
+  if (configuration?.states?.length) {
+    items.push({ icon: "activity", label: configuration.states.map(formatState).join(", ") });
+  }
+
+  if (configuration?.keys?.length) {
+    items.push({ icon: "hash", label: configuration.keys.map(formatPredicate).join(", ") });
+  }
+
+  if (configuration?.refs?.length) {
+    items.push({ icon: "funnel", label: configuration.refs.map(formatPredicate).join(", ") });
+  }
+
+  return items;
+}
+
+/**
+ * Renderer for the "bitbucket.onCommitStatus" trigger
+ */
+export const onCommitStatusTriggerRenderer: TriggerRenderer = {
+  getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
+    const eventData = context.event?.data as CommitStatusEvent;
+
+    return {
+      title: statusTitle(eventData),
+      subtitle: buildBitbucketSubtitle(statusSubtitle(eventData), context.event?.createdAt),
+    };
+  },
+
+  getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
+    const eventData = context.event?.data as CommitStatusEvent;
+    const status = eventData?.commit_status;
+
+    return {
+      Key: status?.key || "",
+      Name: status?.name || "",
+      State: status?.state || "",
+      Ref: status?.refname || "",
+      URL: status?.url || "",
+    };
+  },
+
+  getTriggerProps: (context: TriggerRendererContext) => {
+    const { node, definition, lastEvent } = context;
+    const metadata = node.metadata as unknown as NodeMetadata;
+    const configuration = node.configuration as unknown as OnCommitStatusConfiguration;
+
+    const props: TriggerProps = {
+      title: node.name || definition.label || "Unnamed trigger",
+      iconSrc: bitbucketIcon,
+      iconColor: getColorClass(definition.color),
+      collapsedBackground: getBackgroundColorClass(definition.color),
+      metadata: metadataItems(metadata, configuration),
+    };
+
+    if (lastEvent) {
+      const eventData = lastEvent.data as CommitStatusEvent;
+
+      props.lastEventData = {
+        title: statusTitle(eventData),
+        subtitle: buildBitbucketSubtitle(statusSubtitle(eventData), lastEvent.createdAt),
+        receivedAt: new Date(lastEvent.createdAt!),
+        state: "triggered",
+        eventId: lastEvent.id!,
+      };
+    }
+
+    return props;
+  },
+};

--- a/web_src/src/pages/app/mappers/bitbucket/on_pr_comment.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/on_pr_comment.ts
@@ -1,0 +1,111 @@
+import { getColorClass, getBackgroundColorClass } from "@/lib/colors";
+import type React from "react";
+import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
+import bitbucketIcon from "@/assets/icons/integrations/bitbucket.svg";
+import type { TriggerProps } from "@/ui/trigger";
+import type { NodeMetadata, PullRequestCommentEvent } from "./types";
+import { buildBitbucketSubtitle } from "./utils";
+
+export interface OnPRCommentConfiguration {
+  repository?: string;
+  actions?: string[];
+  contentFilter?: string;
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  comment_created: "Created",
+  comment_updated: "Updated",
+  comment_deleted: "Deleted",
+};
+
+function formatAction(action: string): string {
+  return ACTION_LABELS[action] || action;
+}
+
+function commentTitle(event?: PullRequestCommentEvent): string {
+  return event?.comment?.content?.raw?.trim() || "";
+}
+
+function commentSubtitle(event?: PullRequestCommentEvent): string {
+  const pullRequest = event?.pullrequest;
+  if (!pullRequest?.id) {
+    return event?.actor?.display_name || "";
+  }
+
+  return `#${pullRequest.id} ${pullRequest.title || ""}`.trim();
+}
+
+/**
+ * Renderer for the "bitbucket.onPRComment" trigger
+ */
+export const onPRCommentTriggerRenderer: TriggerRenderer = {
+  getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
+    const eventData = context.event?.data as PullRequestCommentEvent;
+
+    return {
+      title: commentTitle(eventData),
+      subtitle: buildBitbucketSubtitle(commentSubtitle(eventData), context.event?.createdAt),
+    };
+  },
+
+  getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
+    const eventData = context.event?.data as PullRequestCommentEvent;
+
+    return {
+      Comment: commentTitle(eventData),
+      Author: eventData?.actor?.display_name || "",
+      "Pull Request": eventData?.pullrequest?.id ? `#${eventData.pullrequest.id}` : "",
+      Title: eventData?.pullrequest?.title || "",
+    };
+  },
+
+  getTriggerProps: (context: TriggerRendererContext) => {
+    const { node, definition, lastEvent } = context;
+    const metadata = node.metadata as unknown as NodeMetadata;
+    const configuration = node.configuration as unknown as OnPRCommentConfiguration;
+    const metadataItems = [];
+
+    if (metadata?.repository) {
+      metadataItems.push({
+        icon: "book",
+        label: metadata.repository.full_name || metadata.repository.name || "",
+      });
+    }
+
+    if (configuration?.actions?.length) {
+      metadataItems.push({
+        icon: "activity",
+        label: configuration.actions.map(formatAction).join(", "),
+      });
+    }
+
+    if (configuration?.contentFilter) {
+      metadataItems.push({
+        icon: "funnel",
+        label: configuration.contentFilter,
+      });
+    }
+
+    const props: TriggerProps = {
+      title: node.name || definition.label || "Unnamed trigger",
+      iconSrc: bitbucketIcon,
+      iconColor: getColorClass(definition.color),
+      collapsedBackground: getBackgroundColorClass(definition.color),
+      metadata: metadataItems,
+    };
+
+    if (lastEvent) {
+      const eventData = lastEvent.data as PullRequestCommentEvent;
+
+      props.lastEventData = {
+        title: commentTitle(eventData),
+        subtitle: buildBitbucketSubtitle(commentSubtitle(eventData), lastEvent.createdAt),
+        receivedAt: new Date(lastEvent.createdAt!),
+        state: "triggered",
+        eventId: lastEvent.id!,
+      };
+    }
+
+    return props;
+  },
+};

--- a/web_src/src/pages/app/mappers/bitbucket/on_pull_request.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/on_pull_request.ts
@@ -1,0 +1,138 @@
+import { getColorClass, getBackgroundColorClass } from "@/lib/colors";
+import type React from "react";
+import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
+import bitbucketIcon from "@/assets/icons/integrations/bitbucket.svg";
+import type { TriggerProps } from "@/ui/trigger";
+import type { NodeMetadata, PullRequest, PullRequestEvent } from "./types";
+import type { Predicate } from "../utils";
+import { formatPredicate } from "../utils";
+import { buildBitbucketSubtitle } from "./utils";
+
+export interface OnPullRequestConfiguration {
+  repository?: string;
+  actions?: string[];
+  targetBranches?: Predicate[];
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  created: "Opened",
+  updated: "Updated",
+  fulfilled: "Merged",
+  rejected: "Declined",
+  approved: "Approved",
+  unapproved: "Approval removed",
+  changes_request_created: "Changes requested",
+  changes_request_removed: "Changes request removed",
+};
+
+function formatAction(action: string): string {
+  return ACTION_LABELS[action] || action;
+}
+
+function pullRequestTitle(event?: PullRequestEvent): string {
+  const pullRequest = event?.pullrequest;
+  if (!pullRequest) {
+    return "";
+  }
+
+  return `#${pullRequest.id ?? ""} ${pullRequest.title || ""}`.trim();
+}
+
+function branchNames(pullRequest?: PullRequest): { source: string; target: string } {
+  return {
+    source: pullRequest?.source?.branch?.name ?? "",
+    target: pullRequest?.destination?.branch?.name ?? "",
+  };
+}
+
+function pullRequestSubtitle(event?: PullRequestEvent): string {
+  const { source, target } = branchNames(event?.pullrequest);
+
+  if (source && target) {
+    return `${source} → ${target}`;
+  }
+
+  return source || target;
+}
+
+function pullRequestEventValues(event?: PullRequestEvent): Record<string, string> {
+  const pullRequest = event?.pullrequest;
+  const branches = branchNames(pullRequest);
+
+  return {
+    "Pull Request": pullRequest?.id ? `#${pullRequest.id}` : "",
+    Title: pullRequest?.title ?? "",
+    State: pullRequest?.state ?? "",
+    Source: branches.source,
+    Target: branches.target,
+    Author: event?.actor?.display_name ?? "",
+  };
+}
+
+/**
+ * Renderer for the "bitbucket.onPullRequest" trigger
+ */
+export const onPullRequestTriggerRenderer: TriggerRenderer = {
+  getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
+    const eventData = context.event?.data as PullRequestEvent;
+
+    return {
+      title: pullRequestTitle(eventData),
+      subtitle: buildBitbucketSubtitle(pullRequestSubtitle(eventData), context.event?.createdAt),
+    };
+  },
+
+  getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
+    return pullRequestEventValues(context.event?.data as PullRequestEvent);
+  },
+
+  getTriggerProps: (context: TriggerRendererContext) => {
+    const { node, definition, lastEvent } = context;
+    const metadata = node.metadata as unknown as NodeMetadata;
+    const configuration = node.configuration as unknown as OnPullRequestConfiguration;
+    const metadataItems = [];
+
+    if (metadata?.repository) {
+      metadataItems.push({
+        icon: "book",
+        label: metadata.repository.full_name || metadata.repository.name || "",
+      });
+    }
+
+    if (configuration?.actions?.length) {
+      metadataItems.push({
+        icon: "activity",
+        label: configuration.actions.map(formatAction).join(", "),
+      });
+    }
+
+    if (configuration?.targetBranches?.length) {
+      metadataItems.push({
+        icon: "funnel",
+        label: configuration.targetBranches.map(formatPredicate).join(", "),
+      });
+    }
+
+    const props: TriggerProps = {
+      title: node.name || definition.label || "Unnamed trigger",
+      iconSrc: bitbucketIcon,
+      iconColor: getColorClass(definition.color),
+      collapsedBackground: getBackgroundColorClass(definition.color),
+      metadata: metadataItems,
+    };
+
+    if (lastEvent) {
+      const eventData = lastEvent.data as PullRequestEvent;
+
+      props.lastEventData = {
+        title: pullRequestTitle(eventData),
+        subtitle: buildBitbucketSubtitle(pullRequestSubtitle(eventData), lastEvent.createdAt),
+        receivedAt: new Date(lastEvent.createdAt!),
+        state: "triggered",
+        eventId: lastEvent.id!,
+      };
+    }
+
+    return props;
+  },
+};

--- a/web_src/src/pages/app/mappers/bitbucket/pull_request_actions.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/pull_request_actions.ts
@@ -1,0 +1,91 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
+import { formatTimestamp } from "../utils";
+import { baseProps } from "./base";
+import type { PullRequest, PullRequestComment } from "./types";
+import { addDetailIfPresent, buildBitbucketExecutionSubtitle, defaultOutput, shortHash } from "./utils";
+
+/**
+ * The three pull request write components emit the same payload, so they share a
+ * mapper and only differ in the wording used when there is nothing to show yet.
+ */
+function pullRequestMapper(fallbackLabel: string): ComponentBaseMapper {
+  return {
+    props(context: ComponentBaseContext): ComponentBaseProps {
+      return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    },
+
+    subtitle(context: SubtitleContext): string | React.ReactNode {
+      const output = defaultOutput<PullRequest>(context.execution.outputs);
+
+      if (output) {
+        return `#${output.data.id ?? ""} ${output.data.title || ""}`.trim();
+      }
+
+      return buildBitbucketExecutionSubtitle(context.execution, fallbackLabel);
+    },
+
+    getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+      const output = defaultOutput<PullRequest>(context.execution.outputs);
+
+      if (!output) {
+        return {};
+      }
+
+      const pullRequest = output.data;
+      const details: Record<string, string> = {
+        "Created At": formatTimestamp(pullRequest.created_on, output.timestamp),
+        "Pull Request": pullRequest.id ? `#${pullRequest.id} ${pullRequest.title || ""}`.trim() : "-",
+      };
+
+      addDetailIfPresent(details, "Pull Request URL", pullRequest.links?.html?.href);
+      addDetailIfPresent(details, "Source Branch", pullRequest.source?.branch?.name);
+      addDetailIfPresent(details, "Target Branch", pullRequest.destination?.branch?.name);
+      addDetailIfPresent(details, "State", pullRequest.state);
+      addDetailIfPresent(details, "Merge Commit", shortHash(pullRequest.merge_commit?.hash));
+      addDetailIfPresent(details, "Closed By", pullRequest.closed_by?.display_name);
+
+      return details;
+    },
+  };
+}
+
+export const createPullRequestMapper = pullRequestMapper("Pull Request Created");
+export const updatePullRequestMapper = pullRequestMapper("Pull Request Updated");
+export const mergePullRequestMapper = pullRequestMapper("Pull Request Merged");
+
+export const createPRCommentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const output = defaultOutput<PullRequestComment>(context.execution.outputs);
+
+    if (output) {
+      return output.data.content?.raw?.trim() || "Comment Created";
+    }
+
+    return buildBitbucketExecutionSubtitle(context.execution, "Comment Created");
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const output = defaultOutput<PullRequestComment>(context.execution.outputs);
+
+    if (!output) {
+      return {};
+    }
+
+    const comment = output.data;
+    const details: Record<string, string> = {
+      "Created At": formatTimestamp(comment.created_on, output.timestamp),
+    };
+
+    addDetailIfPresent(details, "Comment", comment.content?.raw?.trim());
+    addDetailIfPresent(details, "Comment URL", comment.links?.html?.href);
+    addDetailIfPresent(details, "Author", comment.user?.display_name);
+
+    return details;
+  },
+};

--- a/web_src/src/pages/app/mappers/bitbucket/types.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/types.ts
@@ -6,3 +6,93 @@ export interface NodeMetadata {
     slug?: string;
   };
 }
+
+export interface BitbucketAccount {
+  uuid?: string;
+  account_id?: string;
+  display_name?: string;
+  nickname?: string;
+}
+
+export interface BitbucketLinks {
+  self?: { href?: string };
+  html?: { href?: string };
+  commit?: { href?: string };
+}
+
+export interface BitbucketEndpoint {
+  branch?: { name?: string };
+  commit?: { hash?: string; links?: BitbucketLinks };
+  repository?: { name?: string; full_name?: string };
+}
+
+export interface PullRequest {
+  id?: number;
+  title?: string;
+  description?: string;
+  state?: string;
+  draft?: boolean;
+  created_on?: string;
+  updated_on?: string;
+  close_source_branch?: boolean;
+  comment_count?: number;
+  task_count?: number;
+  reason?: string;
+  author?: BitbucketAccount;
+  closed_by?: BitbucketAccount;
+  reviewers?: BitbucketAccount[];
+  source?: BitbucketEndpoint;
+  destination?: BitbucketEndpoint;
+  merge_commit?: { hash?: string };
+  links?: BitbucketLinks;
+}
+
+export interface PullRequestComment {
+  id?: number;
+  created_on?: string;
+  updated_on?: string;
+  deleted?: boolean;
+  content?: { raw?: string; markup?: string; html?: string };
+  user?: BitbucketAccount;
+  links?: BitbucketLinks;
+}
+
+export interface CommitStatus {
+  key?: string;
+  name?: string;
+  state?: string;
+  url?: string;
+  description?: string;
+  type?: string;
+  refname?: string;
+  created_on?: string;
+  updated_on?: string;
+  commit?: { hash?: string };
+  links?: BitbucketLinks;
+}
+
+export interface CombinedCommitStatus {
+  commit?: string;
+  state?: string;
+  total_count?: number;
+  statuses?: CommitStatus[];
+}
+
+/** Payload of the bitbucket.onPullRequest trigger. */
+export interface PullRequestEvent {
+  actor?: BitbucketAccount;
+  repository?: { name?: string; full_name?: string };
+  pullrequest?: PullRequest;
+}
+
+/** Payload of the bitbucket.onPRComment trigger. */
+export interface PullRequestCommentEvent extends PullRequestEvent {
+  comment?: PullRequestComment;
+}
+
+/** Payload of the bitbucket.onCommitStatus trigger. */
+export interface CommitStatusEvent {
+  actor?: BitbucketAccount;
+  repository?: { name?: string; full_name?: string };
+  commit_status?: CommitStatus;
+}

--- a/web_src/src/pages/app/mappers/bitbucket/utils.ts
+++ b/web_src/src/pages/app/mappers/bitbucket/utils.ts
@@ -1,0 +1,32 @@
+import { buildSubtitle, buildExecutionSubtitle } from "../utils";
+import type { OutputPayload } from "../types";
+
+export const buildBitbucketSubtitle = buildSubtitle;
+export const buildBitbucketExecutionSubtitle = buildExecutionSubtitle;
+
+/** Shorten a commit hash for display, leaving expression placeholders intact. */
+export function shortHash(hash?: string): string {
+  if (!hash) {
+    return "";
+  }
+
+  return hash.includes("{{") ? hash : hash.slice(0, 7);
+}
+
+/** Read the first payload emitted on the default output channel. */
+export function defaultOutput<T>(outputs: unknown): { data: T; timestamp?: string } | undefined {
+  const channels = outputs as { default?: OutputPayload[] } | undefined;
+  const payload = channels?.default?.[0];
+
+  if (!payload?.data) {
+    return undefined;
+  }
+
+  return { data: payload.data as T, timestamp: payload.timestamp };
+}
+
+export function addDetailIfPresent(details: Record<string, string>, label: string, value?: string | number) {
+  if (value !== undefined && value !== null && value !== "") {
+    details[label] = String(value);
+  }
+}

--- a/web_src/src/pages/app/mappers/index.ts
+++ b/web_src/src/pages/app/mappers/index.ts
@@ -136,7 +136,11 @@ import {
   triggerRenderers as awsTriggerRenderers,
   eventStateRegistry as awsEventStateRegistry,
 } from "./aws";
-import { triggerRenderers as bitbucketTriggerRenderers } from "./bitbucket/index";
+import {
+  componentMappers as bitbucketComponentMappers,
+  triggerRenderers as bitbucketTriggerRenderers,
+  eventStateRegistry as bitbucketEventStateRegistry,
+} from "./bitbucket/index";
 import { componentMappers as coolifyComponentMappers } from "./coolify/index";
 import { componentMappers as hetznerComponentMappers } from "./hetzner/index";
 import {
@@ -318,6 +322,7 @@ const componentBaseMappers: Record<string, ComponentBaseMapper> = {
 };
 
 const appMappers: Record<string, Record<string, ComponentBaseMapper>> = {
+  bitbucket: bitbucketComponentMappers,
   cloudflare: cloudflareComponentMappers,
   cloudsmith: cloudsmithComponentMappers,
   digitalocean: digitaloceanComponentMappers,
@@ -417,6 +422,7 @@ const appTriggerRenderers: Record<string, Record<string, TriggerRenderer>> = {
 };
 
 const appEventStateRegistries: Record<string, Record<string, EventStateRegistry>> = {
+  bitbucket: bitbucketEventStateRegistry,
   cloudflare: cloudflareEventStateRegistry,
   cloudsmith: cloudsmithEventStateRegistry,
   digitalocean: digitaloceanEventStateRegistry,


### PR DESCRIPTION
# feat: expand Bitbucket with pull request and build status components

## What changed

The Bitbucket integration shipped with **one trigger (`onPush`) and zero actions**. This adds the pull request lifecycle and build statuses — 3 triggers and 6 actions.

**Triggers**

| Component | What it does |
| --- | --- |
| `bitbucket.onPullRequest` | Opened / updated / merged / declined / approved / unapproved / changes requested / changes request removed, with an optional target-branch filter |
| `bitbucket.onPRComment` | Comment created / updated / deleted, with a regex content filter (`^/deploy` → ChatOps) |
| `bitbucket.onCommitStatus` | Build statuses, which is how Bitbucket Pipelines reports results. Filterable by state, key and ref |

**Actions**

| Component | What it does |
| --- | --- |
| `bitbucket.createPullRequest` | Open a PR, with reviewers picked from workspace members |
| `bitbucket.updatePullRequest` | Retitle, re-describe, retarget, set reviewers |
| `bitbucket.mergePullRequest` | Merge with `merge_commit` / `squash` / `fast_forward` |
| `bitbucket.createPRComment` | Post a comment on a PR |
| `bitbucket.publishCommitStatus` | Report a build status, so SuperPlane can be a required check |
| `bitbucket.getCommitStatus` | Read all statuses on a commit and roll them into one verdict |

## Why

The use cases at the top of the README — PR preview environments, policy-gated production deploys, release trains — are all impossible on Bitbucket today. The engine can see a push and nothing else: it cannot read, comment on, gate, or merge a Bitbucket pull request.

For scale: GitHub has 29 actions / 12 triggers, GitLab 28 / 13, Bitbucket 0 / 1.

## How

The scaffolding was already there — `client.go` (both auth modes), `webhook_handler.go` (event types are already configuration-driven), `ensureRepoInMetadata`, and the repository picker. This builds on all of it rather than adding a parallel path.

Notable decisions, each of which could reasonably have gone another way:

- **`updatePullRequest` uses the `Togglable` field pattern** from `gitlab/update_merge_request.go`. Bitbucket treats a present JSON key as an overwrite, so sending a zero value for an untouched field would silently wipe a title or a reviewer list. Only fields the user explicitly enabled are sent. Clearing the description is a legitimate update; clearing the title is not, and is rejected at `Setup()` because Bitbucket rejects it at runtime.

- **`getCommitStatus` aggregates** rather than returning a raw list, mirroring GitHub's combined status. Precedence is `FAILED` > `STOPPED` > `INPROGRESS` > `SUCCESSFUL`. Two deliberate choices: a commit with no statuses reports `NO_STATUS` rather than passing, because "nothing ran" and "everything passed" are very different answers when deciding to deploy; and an unrecognized state is treated as a failure rather than being ignored.

- **`mergePullRequest` fails on Bitbucket's 202 response.** On large repositories Bitbucket queues the merge and returns a polling task instead of the pull request. Emitting that would tell the canvas a merge happened when it has not, so the component reports the queued merge as an error.

- **Bitbucket Issues are deliberately excluded.** Atlassian is replacing them with Jira, which is exactly why #3163 was closed. Pipelines actions (`runPipeline`, `getPipeline`) are also left out — they are a coherent follow-up rather than more surface area on this PR.

- **Shared helpers instead of copy-paste.** The `X-Hub-Signature` verification in `on_push.go` moved to `verifyWebhookSignature()` in `common.go` and is reused by all four triggers; the repository and pull-request-ID fields are shared field builders. `on_push.go` behaviour is unchanged, and its existing tests prove it.

One thing worth flagging: **Bitbucket delivers each pull request action as its own event key** (`pullrequest:approved`, `pullrequest:fulfilled`, …), unlike GitLab which sends a single `merge_requests` hook and requires deriving the finer-grained action. That means the action filter maps one-to-one onto the webhook events we subscribe to — no equivalent of GitLab's `mergeRequestDerivedActions` heuristics is needed, and a webhook only carries the events a trigger actually asked for.

## Testing

- **26 test functions / 102 subtests**, all passing. Unit tests cover `Setup()` and `Execute()`/`HandleWebhook()` on every component: missing required fields, unsupported enum values, event filtering, signature failures, API errors, pagination, and the aggregation precedence table.
- `go vet` clean, `gofmt` clean.
- ESLint clean on the new frontend files; `npm run lint:budget` passes at **593/593** (the repo sits exactly on its ceiling, so the new trigger renderers were refactored to add zero complexity warnings).
All of the following were run against the project's own tooling and pass:

| Check | Result |
| --- | --- |
| `go test ./pkg/integrations/bitbucket/... ./pkg/grpc/actions/` | ok |
| `go vet` on the touched packages | clean |
| `make check.components.docs` | no diff |
| `make check.example.payloads` | pass |
| `make check.configuration.fields` | pass |
| `tsc -b` (whole project) | 0 errors |
| `vitest run` (211 files, 1571 tests) | all pass |
| `npm run lint:budget` | 593/593, within budget |

## Screenshots / video

<!-- Video goes here before review — see docs/contributing/bounties.md -->

## Related

Opened as a draft while the demo recording is produced.

I did not claim an existing ticket for this — there is no `[Bitbucket] Expand integration` issue yet. Happy to open one and follow the usual ticket-first flow if you prefer, and equally happy to split this into two PRs (triggers, then actions) if that reviews more easily.
