### PR TITLE
fix: keep the caret inside an auto-wrapped expression

### DIFF
--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { AutoCompleteInput } from "./AutoCompleteInput";
 import { calculateDropdownPosition } from "./dropdownPosition";
@@ -225,5 +226,75 @@ describe("AutoCompleteInput fullHeight mode", () => {
     // Auto-resize should still set an inline height.
     expect(input.style.height).not.toBe("");
     expect(input.className).not.toContain("h-full");
+  });
+});
+
+describe("AutoCompleteInput expression auto-wrapping", () => {
+  const renderControlledInput = (onValueChange?: (next: string) => void) => {
+    const Wrapper = () => {
+      const [value, setValue] = useState("");
+      return (
+        <AutoCompleteInput
+          aria-label="Pull request ID"
+          exampleObj={{ __root: { data: { pullrequest: { id: 42 } } } }}
+          value={value}
+          onChange={(next) => {
+            setValue(next);
+            onValueChange?.(next);
+          }}
+          placeholder="42 or {{ root().data.pullrequest.id }}"
+          startWord="{{"
+          prefix="{{ "
+          suffix=" }}"
+        />
+      );
+    };
+
+    render(<Wrapper />);
+    return screen.getByRole("textbox", { name: "Pull request ID" }) as HTMLTextAreaElement;
+  };
+
+  it("wraps the typed start word into an empty expression", () => {
+    const input = renderControlledInput();
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "{", selectionStart: 1 } });
+    fireEvent.change(input, { target: { value: "{{", selectionStart: 2 } });
+
+    expect(input.value).toBe("{{  }}");
+  });
+
+  // Regression: the caret used to be restored in a requestAnimationFrame, which raced
+  // the controlled re-render that rewrites the textarea value. The caret ended up after
+  // the closing braces, so everything typed next landed outside the expression and the
+  // component was saved with an empty expression body.
+  it("leaves the caret inside the expression it just wrapped", () => {
+    const input = renderControlledInput();
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "{", selectionStart: 1 } });
+    fireEvent.change(input, { target: { value: "{{", selectionStart: 2 } });
+
+    expect(input.selectionStart).toBe(3);
+    expect(input.selectionEnd).toBe(3);
+  });
+
+  it("keeps what the user types next inside the expression", () => {
+    let latestValue = "";
+    const input = renderControlledInput((next) => {
+      latestValue = next;
+    });
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "{", selectionStart: 1 } });
+    fireEvent.change(input, { target: { value: "{{", selectionStart: 2 } });
+
+    // Type the expression body at the caret the component restored.
+    const caret = input.selectionStart ?? 0;
+    const body = "root().data.pullrequest.id";
+    const typed = `${input.value.slice(0, caret)}${body}${input.value.slice(caret)}`;
+    fireEvent.change(input, { target: { value: typed, selectionStart: caret + body.length } });
+
+    expect(latestValue).toBe("{{ root().data.pullrequest.id }}");
   });
 });

--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -1,4 +1,13 @@
-import React, { useState, useEffect, useRef, forwardRef, useImperativeHandle, useCallback, useMemo } from "react";
+import React, {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  forwardRef,
+  useImperativeHandle,
+  useCallback,
+  useMemo,
+} from "react";
 import { createPortal } from "react-dom";
 import { twMerge } from "tailwind-merge";
 import type { Suggestion } from "./core";
@@ -146,6 +155,8 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
     const dropdownWidth = 350;
     const previousWordLength = useRef<number>(0);
     const previousInputValue = useRef<string>(value);
+    // Caret offset to restore once the next render has written the new value to the DOM.
+    const pendingCaretRef = useRef<number | null>(null);
     const highlightedIndexRef = useRef(highlightedIndex);
     const suggestionListKeyRef = useRef("");
     const suggestionItemsRef = useRef<Array<ReturnType<typeof getSuggestions>[number]>>([]);
@@ -1152,6 +1163,21 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       return () => document.removeEventListener("mousedown", handleClickOutside);
     }, []);
 
+    // The textarea is controlled, so React rewrites its value on every render and the
+    // browser drops the caret at the end. Any caret we want to place after changing the
+    // value has to be applied once that rewrite has landed in the DOM, which is what
+    // this layout effect does - scheduling it earlier (in a callback or an animation
+    // frame) races the render and the caret snaps back to the end.
+    useLayoutEffect(() => {
+      const caret = pendingCaretRef.current;
+      if (caret === null) {
+        return;
+      }
+
+      pendingCaretRef.current = null;
+      inputRef.current?.setSelectionRange(caret, caret);
+    }, [inputValue]);
+
     const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       const newValue = e.target.value;
       const cursorPosition = e.target.selectionStart ?? newValue.length;
@@ -1175,14 +1201,13 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
         !isAllowedToSuggest(inputValue, cursorPosition)
       ) {
         const composedValue = `${newValue.slice(0, start)}${prefix || ""}${suffix || ""}${newValue.slice(start + word.length)}`;
+        const cursorTarget = start + (prefix || "").length;
         setInputValue(composedValue);
         onChange?.(composedValue);
+        setCursorPosition(cursorTarget);
         setSuggestions([]);
         setIsOpen(false);
-        requestAnimationFrame(() => {
-          const cursorTarget = start + (prefix || "").length;
-          inputRef.current?.setSelectionRange(cursorTarget, cursorTarget);
-        });
+        pendingCaretRef.current = cursorTarget;
         return;
       }
 


### PR DESCRIPTION
# fix: keep the caret inside an auto-wrapped expression

## What happens today

Typing `{{` in a configuration field wraps it into `{{  }}` and is meant to leave the caret between the braces, ready for the expression body. It doesn't — the caret ends up **after** the closing braces, so everything typed next lands outside the expression.

Typing `{{ root().data.pullrequest.id }}` naturally, left to right, produces:

```
{{  }} root().data.pullrequest.id
```

The field looks almost right at a glance, so it's easy to miss. The node is then saved with an empty expression and fails at setup:

```
field "pullRequestId": expression "{{  }}": expression body is empty
```

I hit this while configuring a component and spent a while assuming I had mistyped it.

## Reproducing

1. Open any component with an expression-capable field
2. Click the field and type `{{ root().data.foo }}` normally
3. The stored value is `{{  }} root().data.foo`, and the node reports `expression body is empty`

Worth noting: this is **not** a fast-typing artifact. I checked with a full two-second pause between `{{` and the body — the caret is still lost.

## Cause

`AutoCompleteInput`'s textarea is controlled. On the auto-wrap path the caret was restored inside a `requestAnimationFrame`:

```ts
setInputValue(composedValue);
onChange?.(composedValue);
requestAnimationFrame(() => {
  const cursorTarget = start + (prefix || "").length;
  inputRef.current?.setSelectionRange(cursorTarget, cursorTarget);
});
```

That frame races the re-render that rewrites the textarea's `value`. When React commits after the frame, the browser moves the caret to the end of the new value and the restore is silently undone.

## Fix

Record the intended caret offset in a ref and apply it in a `useLayoutEffect` keyed on the value, so it runs once the DOM already holds the new text. That removes the race rather than re-timing it.

## Scope

The suggestion-commit path (`applySuggestion`) uses the same `requestAnimationFrame` + `setSelectionRange` pattern. I left it alone: I could not get it to misbehave, and I would rather not change code I have not been able to break. Happy to fold it in if you would prefer both paths to use the same mechanism.

## Testing

Three tests added to `AutoCompleteInput.spec.tsx`, driving the component as a controlled input the way the field renderers do:

- the start word is wrapped into an empty expression
- the caret is left between the braces — **fails on `main`**
- what the user types next lands inside the expression — **fails on `main`**

Verified both directions: the two regression tests fail before the fix and pass after.

| Check | Result |
| --- | --- |
| `vitest run src/components/AutoCompleteInput/` | 38 passed |
| `tsc -b` (whole project) | 0 errors |
| `npm run lint:budget` | 593/593, within budget |

Full-suite note: `vitest run` reports 36 files / 318 tests failing on my machine, but the identical set fails on an unmodified checkout — they look environment-related (localStorage/DOM specs) and none touch this component. My change moves the suite from 3725 to 3728 passing tests and breaks nothing.
