### PR TITLE
feat: restyle Lines canvas nodes for light/dark theme

### DIFF
--- a/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
+++ b/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
@@ -1,11 +1,12 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState, type ReactNode } from "react";
 import { MemoryRouter, Navigate, Outlet, Route, Routes, useSearchParams } from "react-router-dom";
 
 import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { RequireExperimentalFeature } from "@/components/RequireExperimentalFeature";
 import { AccountProvider } from "@/contexts/AccountProvider";
 import { PermissionsProvider } from "@/contexts/PermissionsProvider";
+import { ThemeContext } from "@/contexts/themeContextState";
 import { ThemeProvider } from "@/contexts/ThemeProvider";
 import { agentChatKeys } from "@/hooks/useAgentChats";
 import { FEATURE_FACTORIES } from "@/lib/experimentalFeatures";
@@ -257,7 +258,7 @@ export function OrgWorkspaceHarness({
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
+      <OptionalThemeProvider>
         <TooltipProvider delayDuration={150}>
           <div className="h-dvh w-full overflow-auto">
             <MemoryRouter initialEntries={[initialPath]}>
@@ -267,7 +268,16 @@ export function OrgWorkspaceHarness({
             </MemoryRouter>
           </div>
         </TooltipProvider>
-      </ThemeProvider>
+      </OptionalThemeProvider>
     </QueryClientProvider>
   );
+}
+
+/** Prefer Storybook's toolbar theme when already provided; otherwise mount ThemeProvider. */
+function OptionalThemeProvider({ children }: { children: ReactNode }) {
+  const inheritedTheme = useContext(ThemeContext);
+  if (inheritedTheme) {
+    return children;
+  }
+  return <ThemeProvider>{children}</ThemeProvider>;
 }

--- a/web_src/src/pages/factories/pages/WorkOrderCanvas.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderCanvas.tsx
@@ -16,6 +16,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Check, Circle, Loader2, X as XIcon, X } from "lucide-react";
+import { useTheme } from "@/contexts/useTheme";
 import githubIcon from "@/assets/icons/integrations/github.svg";
 import slackIcon from "@/assets/icons/integrations/slack.svg";
 import superplaneIcon from "@/assets/superplane.svg";
@@ -102,13 +103,13 @@ function portsForNode(nodeId: string, edges: Edge[]): NodePorts {
 function statusBadgeClass(status: StepStatus) {
   switch (normalizeStatus(status)) {
     case "passed":
-      return "border-[#15803d] bg-[#dcfce7] text-[#166534]";
+      return "border-[#15803d] bg-[#dcfce7] text-[#166534] dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200";
     case "running":
-      return "border-[#2563eb] bg-[#dbeafe] text-[#1d4ed8]";
+      return "border-[#2563eb] bg-[#dbeafe] text-[#1d4ed8] dark:border-blue-500/30 dark:bg-blue-500/10 dark:text-blue-200";
     case "failed":
-      return "border-[#b91c1c] bg-[#fee2e2] text-[#991b1b]";
+      return "border-[#b91c1c] bg-[#fee2e2] text-[#991b1b] dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-200";
     case "pending":
-      return "border-[#737373] bg-[#f3f3f3] text-[#525252]";
+      return "border-[#737373] bg-[#f3f3f3] text-[#525252] dark:border-border dark:bg-muted dark:text-muted-foreground";
   }
 }
 
@@ -170,23 +171,28 @@ function StatusGlyph({ status, className }: { status: StepStatus; className?: st
     );
   }
   if (normalized === "running") {
-    return <Loader2 className={cn(iconClass, "animate-spin text-[#2563eb]")} aria-hidden />;
+    return <Loader2 className={cn(iconClass, "animate-spin text-[#2563eb] dark:text-blue-300")} aria-hidden />;
   }
-  return <Circle className={cn(iconClass, "text-[#a3a3a3]")} strokeWidth={1.75} aria-hidden />;
+  return <Circle className={cn(iconClass, "text-[#a3a3a3] dark:text-muted-foreground")} strokeWidth={1.75} aria-hidden />;
+}
+
+function statusStripClass(status: StepStatus): string {
+  switch (normalizeStatus(status)) {
+    case "passed":
+      return "border-[#dcfce7] bg-[#f0fdf4] text-[#166534] dark:border-emerald-500/20 dark:bg-emerald-500/10 dark:text-emerald-300";
+    case "failed":
+      return "border-[#fecaca] bg-[#fef2f2] text-[#991b1b] dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-300";
+    case "running":
+      return "border-[#bfdbfe] bg-[#eff6ff] text-[#1d4ed8] dark:border-blue-500/20 dark:bg-blue-500/10 dark:text-blue-300";
+    case "pending":
+      return "border-[#e5e5e5] bg-[#fafafa] text-[#737373] dark:border-border dark:bg-muted dark:text-muted-foreground";
+  }
 }
 
 /** Tinted status strip: glyph + label left, duration right. */
 function NodeStatusFooter({ status, metrics }: { status: StepStatus; metrics: string | null }) {
-  const normalized = normalizeStatus(status);
-  const stripClass = {
-    passed: "border-[#dcfce7] bg-[#f0fdf4] text-[#166534]",
-    failed: "border-[#fecaca] bg-[#fef2f2] text-[#991b1b]",
-    running: "border-[#bfdbfe] bg-[#eff6ff] text-[#1d4ed8]",
-    pending: "border-[#e5e5e5] bg-[#fafafa] text-[#737373]",
-  }[normalized];
-
   return (
-    <div className={cn("flex items-center justify-between gap-2 border-t px-3.5 py-2", stripClass)}>
+    <div className={cn("flex items-center justify-between gap-2 border-t px-3.5 py-2", statusStripClass(status))}>
       <span className="inline-flex items-center gap-1.5 text-[11px] font-medium">
         <StatusGlyph status={status} />
         {statusLabel(status)}
@@ -196,7 +202,7 @@ function NodeStatusFooter({ status, metrics }: { status: StepStatus; metrics: st
   );
 }
 
-/** White card: icon + component name + tinted status footer. */
+/** Card: icon + component name + tinted status footer. */
 function StackNodeShell({
   data,
   selected,
@@ -211,30 +217,31 @@ function StackNodeShell({
   const metrics = nodeFooterMetrics(data.details);
   const description = nodeDescription(data);
   const iconSrc = providerIconSrc(data.provider);
+  const monoIcon = data.provider === "github" || data.provider === "superplane";
 
   return (
     <div
       className={cn(
-        "cursor-pointer overflow-hidden rounded-2xl border border-[#e8e8e8] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04),0_4px_12px_rgba(15,23,42,0.04)]",
+        "cursor-pointer overflow-hidden rounded-2xl border border-border bg-card shadow-[0_1px_2px_rgba(15,23,42,0.04),0_4px_12px_rgba(15,23,42,0.04)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.35)]",
         widthClass,
-        selected && "border-[#c7c7c7] shadow-[0_0_0_3px_rgba(15,23,42,0.06)]",
+        selected && "border-ring shadow-[0_0_0_3px_rgba(15,23,42,0.06)] dark:shadow-[0_0_0_3px_rgba(163,163,163,0.25)]",
       )}
     >
       <div className="px-3.5 pt-3.5 pb-3">
         <div className="flex items-start gap-2.5">
-          <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-[#f0f0f0] bg-[#fafafa]">
+          <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted">
             <img
               src={iconSrc}
               alt=""
-              className={cn("size-4", data.provider === "superplane" && "opacity-90")}
+              className={cn("size-4", monoIcon ? "opacity-90 dark:invert" : null)}
             />
           </span>
           <div className="min-w-0 flex-1">
-            <div className="text-[14px] leading-snug font-semibold tracking-[-0.015em] text-[#171717]">
+            <div className="text-[14px] leading-snug font-semibold tracking-[-0.015em] text-card-foreground">
               {data.componentName}
             </div>
             {description ? (
-              <p className="mt-0.5 text-[12px] leading-snug text-[#737373]">{description}</p>
+              <p className="mt-0.5 text-[12px] leading-snug text-muted-foreground">{description}</p>
             ) : null}
           </div>
         </div>
@@ -247,7 +254,7 @@ function StackNodeShell({
 }
 
 const HANDLE_CLASS =
-  "!size-2.5 !rounded-[3px] !border !border-[#d4d4d4] !bg-white !shadow-none";
+  "!size-2.5 !rounded-[3px] !border !border-border !bg-card !shadow-none";
 
 function StepNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
   const ports = data.ports;
@@ -279,8 +286,29 @@ const nodeTypes = {
 
 const MAIN_X = 120;
 const SIDE_X = 520;
-const EDGE_STYLE = { stroke: "#cbd5e1", strokeWidth: 1.5 };
 const EDGE_TYPE = "default";
+
+function edgePalette(isDark: boolean) {
+  if (isDark) {
+    return {
+      default: { stroke: "#4a4740", strokeWidth: 1.5 },
+      running: { stroke: "#818cf8", strokeWidth: 1.5 },
+      failed: { stroke: "#f87171", strokeWidth: 1.5 },
+    };
+  }
+  return {
+    default: { stroke: "#cbd5e1", strokeWidth: 1.5 },
+    running: { stroke: "#818cf8", strokeWidth: 1.5 },
+    failed: { stroke: "#fca5a5", strokeWidth: 1.5 },
+  };
+}
+
+function backgroundColors(isDark: boolean) {
+  if (isDark) {
+    return { gap: 22, size: 1, color: "#33312b", bgColor: "#14120b" };
+  }
+  return { gap: 22, size: 1, color: "#e5e7eb", bgColor: "#f9fafb" };
+}
 
 function step(
   id: string,
@@ -585,7 +613,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "out",
       target: "open-draft-pr",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-pr-plan",
@@ -593,7 +621,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "out",
       target: "write-plan",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-plan-comment",
@@ -601,7 +629,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "side",
       target: "action-comment",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-plan-notify",
@@ -609,7 +637,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "side",
       target: "action-notify-start",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-plan-label",
@@ -617,7 +645,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "side",
       target: "action-label",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-plan-correlate",
@@ -625,7 +653,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "side",
       target: "action-correlate",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-plan-impl",
@@ -633,7 +661,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "out",
       target: "implementation",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-impl-mark-plan",
@@ -641,7 +669,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "side",
       target: "action-mark-plan",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-impl-babysit",
@@ -650,7 +678,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       target: "babysit",
       type: EDGE_TYPE,
       animated: true,
-      style: { ...EDGE_STYLE, stroke: "#818cf8" },
+      data: { tone: "running" },
     },
     {
       id: "e-babysit-mark",
@@ -658,7 +686,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "side",
       target: "action-mark-impl",
       type: EDGE_TYPE,
-      style: EDGE_STYLE,
+      data: { tone: "default" },
     },
     {
       id: "e-babysit-notify-fail",
@@ -666,7 +694,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "side",
       target: "action-notify-fail",
       type: EDGE_TYPE,
-      style: { ...EDGE_STYLE, stroke: "#fca5a5" },
+      data: { tone: "failed" },
     },
     {
       id: "e-babysit-fail-memory",
@@ -674,7 +702,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       sourceHandle: "side",
       target: "action-mark-fail-memory",
       type: EDGE_TYPE,
-      style: { ...EDGE_STYLE, stroke: "#fca5a5" },
+      data: { tone: "failed" },
     },
   ];
 
@@ -698,7 +726,7 @@ function StepDetailSidebar({ node, onClose }: { node: Node<StepNodeData>; onClos
   const { details } = data;
 
   return (
-    <aside className="flex h-full w-[320px] shrink-0 flex-col border-l border-border bg-[#f7f7f7]">
+    <aside className="flex h-full w-[320px] shrink-0 flex-col border-l border-border bg-muted">
       <div className="flex items-start justify-between gap-3 border-b border-border px-4 py-3">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
@@ -790,6 +818,11 @@ function StepDetailSidebar({ node, onClose }: { node: Node<StepNodeData>; onClos
 }
 
 export function WorkOrderCanvas({ editable = false }: { editable?: boolean } = {}) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+  const palette = useMemo(() => edgePalette(isDark), [isDark]);
+  const background = useMemo(() => backgroundColors(isDark), [isDark]);
+
   const initialGraph = useMemo(() => buildWorkflowGraph(editable), [editable]);
   const [nodes, , onNodesChange] = useNodesState(initialGraph.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialGraph.edges);
@@ -811,6 +844,18 @@ export function WorkOrderCanvas({ editable = false }: { editable?: boolean } = {
     [nodes, edges, selectedId, editable],
   );
 
+  const displayEdges = useMemo(
+    () =>
+      edges.map((edge) => {
+        const tone = (edge.data as { tone?: "default" | "running" | "failed" } | undefined)?.tone ?? "default";
+        return {
+          ...edge,
+          style: palette[tone],
+        };
+      }),
+    [edges, palette],
+  );
+
   const onNodeClick = useCallback<NodeMouseHandler>((_event, node) => {
     setSelectedId(node.id);
   }, []);
@@ -827,13 +872,14 @@ export function WorkOrderCanvas({ editable = false }: { editable?: boolean } = {
           {
             ...connection,
             type: EDGE_TYPE,
-            style: EDGE_STYLE,
+            data: { tone: "default" },
+            style: palette.default,
           },
           current,
         ),
       );
     },
-    [editable, setEdges],
+    [editable, setEdges, palette.default],
   );
 
   return (
@@ -841,7 +887,7 @@ export function WorkOrderCanvas({ editable = false }: { editable?: boolean } = {
       <div className="min-h-0 min-w-0 flex-1">
         <ReactFlow
           nodes={displayNodes}
-          edges={edges}
+          edges={displayEdges}
           nodeTypes={nodeTypes}
           fitView
           fitViewOptions={{ padding: 0.18 }}
@@ -856,12 +902,13 @@ export function WorkOrderCanvas({ editable = false }: { editable?: boolean } = {
           panOnScroll
           zoomOnScroll
           proOptions={{ hideAttribution: true }}
-          defaultEdgeOptions={{ type: EDGE_TYPE, style: EDGE_STYLE }}
+          defaultEdgeOptions={{ type: EDGE_TYPE, style: palette.default }}
+          colorMode={isDark ? "dark" : "light"}
         >
-          <Background gap={22} size={1} color="#e5e7eb" bgColor="#f9fafb" />
+          <Background gap={background.gap} size={background.size} color={background.color} bgColor={background.bgColor} />
           <Controls
             showInteractive={false}
-            className="!overflow-hidden !rounded-xl !border !border-[#e5e7eb] !bg-white !shadow-[0_1px_3px_rgba(15,23,42,0.06)]"
+            className="!overflow-hidden !rounded-xl !border !border-border !bg-card !shadow-[0_1px_3px_rgba(15,23,42,0.06)]"
           />
         </ReactFlow>
       </div>

--- a/web_src/src/pages/factories/pages/WorkOrderCanvas.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderCanvas.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import {
   Background,
   Controls,
   Handle,
-  MarkerType,
   Position,
   ReactFlow,
   addEdge,
@@ -16,10 +15,42 @@ import {
   type NodeMouseHandler,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { X } from "lucide-react";
+import { Check, Circle, Loader2, X as XIcon, X } from "lucide-react";
+import githubIcon from "@/assets/icons/integrations/github.svg";
+import slackIcon from "@/assets/icons/integrations/slack.svg";
+import superplaneIcon from "@/assets/superplane.svg";
 import { cn } from "@/lib/utils";
 
 type StepStatus = "passed" | "created" | "success" | "running" | "failed" | "pending";
+type ComponentProvider = "github" | "slack" | "superplane";
+
+function normalizeStatus(status: StepStatus): "passed" | "failed" | "running" | "pending" {
+  switch (status) {
+    case "passed":
+    case "created":
+    case "success":
+      return "passed";
+    case "failed":
+      return "failed";
+    case "running":
+      return "running";
+    case "pending":
+      return "pending";
+  }
+}
+
+function statusLabel(status: StepStatus) {
+  switch (normalizeStatus(status)) {
+    case "passed":
+      return "Passed";
+    case "failed":
+      return "Failed";
+    case "running":
+      return "Running";
+    case "pending":
+      return "Pending";
+  }
+}
 
 type StepDetail = {
   startedAt?: string;
@@ -33,7 +64,11 @@ type StepDetail = {
 };
 
 type StepNodeData = {
+  /** Human step label (sidebar / instance name). */
   title: string;
+  /** Component type shown in the node header with the provider icon. */
+  componentName: string;
+  provider: ComponentProvider;
   status: StepStatus;
   kind: "step" | "action";
   detail?: string;
@@ -43,10 +78,8 @@ type StepNodeData = {
 };
 
 function statusBadgeClass(status: StepStatus) {
-  switch (status) {
+  switch (normalizeStatus(status)) {
     case "passed":
-    case "created":
-    case "success":
       return "border-[#15803d] bg-[#dcfce7] text-[#166534]";
     case "running":
       return "border-[#2563eb] bg-[#dbeafe] text-[#1d4ed8]";
@@ -57,103 +90,159 @@ function statusBadgeClass(status: StepStatus) {
   }
 }
 
-function statusLabel(status: StepStatus) {
-  switch (status) {
-    case "passed":
-      return "PASSED";
-    case "created":
-      return "CREATED";
-    case "success":
-      return "SUCCESS";
-    case "running":
-      return "RUNNING";
-    case "failed":
-      return "FAILED";
-    case "pending":
-      return "PENDING";
-  }
-}
-
 function statusSentence(status: StepStatus) {
-  switch (status) {
+  switch (normalizeStatus(status)) {
     case "passed":
       return "Completed successfully.";
-    case "created":
-      return "Resource created and ready.";
-    case "success":
-      return "Finished with success.";
-    case "running":
-      return "Currently executing.";
     case "failed":
       return "Failed and stopped.";
+    case "running":
+      return "Currently executing.";
     case "pending":
       return "Waiting to start.";
   }
 }
 
-function StepNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
+function nodeFooterMetrics(details: StepDetail): string | null {
+  const { startedAt, finishedAt, duration } = details;
+  if (duration) return duration;
+  if (startedAt && finishedAt) return `${startedAt} → ${finishedAt}`;
+  if (startedAt) return startedAt;
+  if (finishedAt) return finishedAt;
+  return null;
+}
+
+function providerIconSrc(provider: ComponentProvider): string {
+  switch (provider) {
+    case "github":
+      return githubIcon;
+    case "slack":
+      return slackIcon;
+    case "superplane":
+      return superplaneIcon;
+  }
+}
+
+function nodeDescription(data: StepNodeData): string | null {
+  if (data.detail) return data.detail;
+  if (data.title !== data.componentName) return data.title;
+  return null;
+}
+
+function StatusGlyph({ status, className }: { status: StepStatus; className?: string }) {
+  const normalized = normalizeStatus(status);
+  const iconClass = cn("size-3.5 shrink-0", className);
+
+  if (normalized === "passed") {
+    return (
+      <span className={cn("flex size-4 shrink-0 items-center justify-center rounded-full bg-[#16a34a] text-white", className)}>
+        <Check className="size-2.5" strokeWidth={3} />
+      </span>
+    );
+  }
+  if (normalized === "failed") {
+    return (
+      <span className={cn("flex size-4 shrink-0 items-center justify-center rounded-full bg-[#dc2626] text-white", className)}>
+        <XIcon className="size-2.5" strokeWidth={3} />
+      </span>
+    );
+  }
+  if (normalized === "running") {
+    return <Loader2 className={cn(iconClass, "animate-spin text-[#2563eb]")} aria-hidden />;
+  }
+  return <Circle className={cn(iconClass, "text-[#a3a3a3]")} strokeWidth={1.75} aria-hidden />;
+}
+
+/** Tinted status strip: glyph + label left, duration right. */
+function NodeStatusFooter({ status, metrics }: { status: StepStatus; metrics: string | null }) {
+  const normalized = normalizeStatus(status);
+  const stripClass = {
+    passed: "border-[#dcfce7] bg-[#f0fdf4] text-[#166534]",
+    failed: "border-[#fecaca] bg-[#fef2f2] text-[#991b1b]",
+    running: "border-[#bfdbfe] bg-[#eff6ff] text-[#1d4ed8]",
+    pending: "border-[#e5e5e5] bg-[#fafafa] text-[#737373]",
+  }[normalized];
+
+  return (
+    <div className={cn("flex items-center justify-between gap-2 border-t px-3.5 py-2", stripClass)}>
+      <span className="inline-flex items-center gap-1.5 text-[11px] font-medium">
+        <StatusGlyph status={status} />
+        {statusLabel(status)}
+      </span>
+      <span className="font-mono text-[11px] tabular-nums opacity-80">{metrics ?? "—"}</span>
+    </div>
+  );
+}
+
+/** All-white StackAI-style card: icon + component name + status footer. */
+function StackNodeShell({
+  data,
+  selected,
+  widthClass,
+  children,
+}: {
+  data: StepNodeData;
+  selected?: boolean;
+  widthClass: string;
+  children?: ReactNode;
+}) {
+  const metrics = nodeFooterMetrics(data.details);
+  const description = nodeDescription(data);
+  const iconSrc = providerIconSrc(data.provider);
+
   return (
     <div
       className={cn(
-        "w-[300px] cursor-pointer rounded-lg border-2 bg-white px-4 py-3 shadow-[0_1px_2px_rgba(38,37,30,0.08)]",
-        data.status === "running" && "border-[#2563eb] bg-[#eff6ff]",
-        data.status === "pending" && "border-[#a3a3a3] bg-[#f7f7f7]",
-        data.status !== "running" && data.status !== "pending" && "border-[#26251e]",
-        selected && "ring-2 ring-[#2563eb] ring-offset-2",
+        "cursor-pointer overflow-hidden rounded-2xl border border-[#e8e8e8] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04),0_4px_12px_rgba(15,23,42,0.04)]",
+        widthClass,
+        selected && "border-[#c7c7c7] shadow-[0_0_0_3px_rgba(15,23,42,0.06)]",
       )}
     >
-      <Handle type="target" position={Position.Top} className="!size-2.5 !border-2 !border-[#525252] !bg-white" />
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 text-[14px] font-semibold tracking-[-0.01em] text-foreground">{data.title}</div>
-        <span
-          className={cn(
-            "shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-[0.04em]",
-            statusBadgeClass(data.status),
-          )}
-        >
-          {statusLabel(data.status)}
-        </span>
-      </div>
-      {data.detail ? <p className="mt-2 truncate font-mono text-[11px] text-[#525252]">{data.detail}</p> : null}
-      {data.meta?.length ? (
-        <div className="mt-2 space-y-1">
-          {data.meta.map((line) => (
-            <p key={line} className="text-[12px] leading-snug text-[#525252]">
-              {line}
-            </p>
-          ))}
+      <div className="px-3.5 pt-3.5 pb-3">
+        <div className="flex items-start gap-2.5">
+          <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-[#f0f0f0] bg-[#fafafa]">
+            <img
+              src={iconSrc}
+              alt=""
+              className={cn("size-4", data.provider === "superplane" && "opacity-90")}
+            />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="text-[14px] leading-snug font-semibold tracking-[-0.015em] text-[#171717]">
+              {data.componentName}
+            </div>
+            {description ? (
+              <p className="mt-0.5 text-[12px] leading-snug text-[#737373]">{description}</p>
+            ) : null}
+          </div>
         </div>
-      ) : null}
-      {data.showLogs ? <div className="mt-3 text-[12px] font-medium text-[#2563eb]">View logs</div> : null}
-      <Handle
-        id="out"
-        type="source"
-        position={Position.Bottom}
-        className="!size-2.5 !border-2 !border-[#525252] !bg-white"
-      />
-      <Handle
-        id="side"
-        type="source"
-        position={Position.Right}
-        className="!top-1/2 !size-2.5 !border-2 !border-[#525252] !bg-white"
-      />
+        {children}
+      </div>
+
+      <NodeStatusFooter status={data.status} metrics={metrics} />
+    </div>
+  );
+}
+
+const HANDLE_CLASS =
+  "!size-2.5 !rounded-[3px] !border !border-[#d4d4d4] !bg-white !shadow-none";
+
+function StepNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
+  return (
+    <div className="relative">
+      <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
+      <StackNodeShell data={data} selected={selected} widthClass="w-[280px]" />
+      <Handle id="out" type="source" position={Position.Bottom} className={HANDLE_CLASS} />
+      <Handle id="side" type="source" position={Position.Right} className={cn(HANDLE_CLASS, "!top-1/2")} />
     </div>
   );
 }
 
 function ActionNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
   return (
-    <div
-      className={cn(
-        "w-[220px] cursor-pointer rounded-md border-2 border-[#737373] bg-[#f7f7f7] px-3 py-2.5",
-        selected && "ring-2 ring-[#2563eb] ring-offset-2",
-      )}
-    >
-      <Handle type="target" position={Position.Left} className="!size-2 !border-2 !border-[#525252] !bg-white" />
-      <div className="truncate font-mono text-[11px] tracking-[-0.01em] text-foreground">{data.title}</div>
-      <div className="mt-1 text-[10px] font-medium tracking-[0.04em] text-muted-foreground">
-        {statusLabel(data.status)}
-      </div>
+    <div className="relative">
+      <Handle type="target" position={Position.Left} className={HANDLE_CLASS} />
+      <StackNodeShell data={data} selected={selected} widthClass="w-[260px]" />
     </div>
   );
 }
@@ -165,7 +254,8 @@ const nodeTypes = {
 
 const MAIN_X = 120;
 const SIDE_X = 520;
-const EDGE_STYLE = { stroke: "#94a3b8", strokeWidth: 1.5 };
+const EDGE_STYLE = { stroke: "#cbd5e1", strokeWidth: 1.5 };
+const EDGE_TYPE = "default";
 
 function step(
   id: string,
@@ -204,6 +294,8 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       { x: MAIN_X, y: 0 },
       {
         title: "Create Branch",
+        componentName: "Create Branch",
+        provider: "github",
         status: "passed",
         detail: "feat/invite-poc · a3f91c2",
         showLogs: true,
@@ -221,9 +313,11 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     step(
       "open-draft-pr",
-      { x: MAIN_X, y: 170 },
+      { x: MAIN_X, y: 200 },
       {
         title: "Open Draft PR",
+        componentName: "Create Pull Request",
+        provider: "github",
         status: "created",
         detail: "PR #148 · Draft",
         details: {
@@ -240,11 +334,13 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     step(
       "write-plan",
-      { x: MAIN_X, y: 340 },
+      { x: MAIN_X, y: 400 },
       {
         title: "Write Plan",
+        componentName: "Agent",
+        provider: "superplane",
         status: "passed",
-        detail: "plan.md · 12 steps",
+        detail: "Write Plan · plan.md · 12 steps",
         showLogs: true,
         details: {
           startedAt: "14:02:25",
@@ -260,10 +356,12 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     action(
       "action-comment",
-      { x: SIDE_X, y: 300 },
+      { x: SIDE_X, y: 280 },
       {
-        title: "github.createIssueComment",
-        status: "passed",
+        title: "Post plan comment",
+        componentName: "Create Issue Comment",
+        provider: "github",
+        status: "failed",
         detail: "comment · #8841",
         details: {
           startedAt: "14:03:42",
@@ -271,19 +369,21 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
           duration: "1s",
           agent: "github-worker",
           attempt: "1 / 1",
-          output: "Posted plan summary on issue #8841.",
-          logs: ["Rendered markdown comment", "Posted via Issues API"],
+          output: "GitHub API returned 403: Resource not accessible by integration.",
+          logs: ["Rendered markdown comment", "Posted via Issues API", "Received 403 Forbidden"],
           inputs: ["issue: #8841"],
         },
       },
     ),
     action(
       "action-notify-start",
-      { x: SIDE_X, y: 350 },
+      { x: SIDE_X, y: 440 },
       {
         title: "Notify work started",
+        componentName: "Send Text Message",
+        provider: "slack",
         status: "passed",
-        detail: "slack · #factory",
+        detail: "#factory · work started",
         details: {
           startedAt: "14:03:43",
           finishedAt: "14:03:44",
@@ -298,9 +398,11 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     action(
       "action-label",
-      { x: SIDE_X, y: 400 },
+      { x: SIDE_X, y: 600 },
       {
-        title: "github.addIssueLabel",
+        title: "Add in-progress label",
+        componentName: "Add Issue Label",
+        provider: "github",
         status: "passed",
         detail: "label · in-progress",
         details: {
@@ -317,9 +419,11 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     action(
       "action-correlate",
-      { x: SIDE_X, y: 450 },
+      { x: SIDE_X, y: 760 },
       {
         title: "Correlate PR Memory",
+        componentName: "Add Memory",
+        provider: "superplane",
         status: "passed",
         detail: "memory · pr-148",
         details: {
@@ -336,11 +440,13 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     step(
       "implementation",
-      { x: MAIN_X, y: 560 },
+      { x: MAIN_X, y: 900 },
       {
         title: "Implementation",
+        componentName: "Agent",
+        provider: "superplane",
         status: "running",
-        detail: "commits · 4 files",
+        detail: "Implementation · commits · 4 files",
         showLogs: true,
         details: {
           startedAt: "14:03:47",
@@ -360,9 +466,11 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     action(
       "action-mark-plan",
-      { x: SIDE_X, y: 590 },
+      { x: SIDE_X, y: 920 },
       {
         title: "Mark Plan Done",
+        componentName: "Update Work Order Status",
+        provider: "superplane",
         status: "pending",
         detail: "waits on implementation",
         details: {
@@ -375,10 +483,13 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     step(
       "babysit",
-      { x: MAIN_X, y: 780 },
+      { x: MAIN_X, y: 1200 },
       {
         title: "Babysit",
+        componentName: "Babysit",
+        provider: "superplane",
         status: "pending",
+        detail: "Software Factory · Timeout: 1h",
         meta: ["Software Factory", "Start Babysitting", "Timeout: 1h"],
         details: {
           agent: "software-factory",
@@ -391,9 +502,11 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     action(
       "action-mark-impl",
-      { x: SIDE_X, y: 760 },
+      { x: SIDE_X, y: 1180 },
       {
         title: "Mark Implementation Done",
+        componentName: "Update Work Order Status",
+        provider: "superplane",
         status: "pending",
         detail: "on babysit passed",
         details: {
@@ -406,11 +519,13 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     action(
       "action-notify-fail",
-      { x: SIDE_X, y: 810 },
+      { x: SIDE_X, y: 1340 },
       {
         title: "Notify work failed",
+        componentName: "Send Text Message",
+        provider: "slack",
         status: "pending",
-        detail: "on babysit failed",
+        detail: "#factory · on babysit failed",
         details: {
           agent: "notifier",
           attempt: "—",
@@ -421,9 +536,11 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
     ),
     action(
       "action-mark-fail-memory",
-      { x: SIDE_X, y: 860 },
+      { x: SIDE_X, y: 1500 },
       {
         title: "Mark Implementation Failed Memory",
+        componentName: "Add Memory",
+        provider: "superplane",
         status: "pending",
         detail: "on babysit failed",
         details: {
@@ -442,33 +559,23 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       source: "create-branch",
       sourceHandle: "out",
       target: "open-draft-pr",
-      type: "smoothstep",
-      label: "passed",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
-      markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14, color: "#94a3b8" },
-      labelStyle: { fill: "#737373", fontSize: 11 },
-      labelBgStyle: { fill: "#ffffff" },
-      labelBgPadding: [4, 6] as [number, number],
     },
     {
       id: "e-pr-plan",
       source: "open-draft-pr",
       sourceHandle: "out",
       target: "write-plan",
-      type: "smoothstep",
-      label: "passed",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
-      markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14, color: "#94a3b8" },
-      labelStyle: { fill: "#737373", fontSize: 11 },
-      labelBgStyle: { fill: "#ffffff" },
-      labelBgPadding: [4, 6] as [number, number],
     },
     {
       id: "e-plan-comment",
       source: "write-plan",
       sourceHandle: "side",
       target: "action-comment",
-      type: "smoothstep",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
     },
     {
@@ -476,7 +583,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       source: "write-plan",
       sourceHandle: "side",
       target: "action-notify-start",
-      type: "smoothstep",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
     },
     {
@@ -484,7 +591,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       source: "write-plan",
       sourceHandle: "side",
       target: "action-label",
-      type: "smoothstep",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
     },
     {
@@ -492,7 +599,7 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       source: "write-plan",
       sourceHandle: "side",
       target: "action-correlate",
-      type: "smoothstep",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
     },
     {
@@ -500,20 +607,15 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       source: "write-plan",
       sourceHandle: "out",
       target: "implementation",
-      type: "smoothstep",
-      label: "passed",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
-      markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14, color: "#94a3b8" },
-      labelStyle: { fill: "#737373", fontSize: 11 },
-      labelBgStyle: { fill: "#ffffff" },
-      labelBgPadding: [4, 6] as [number, number],
     },
     {
       id: "e-impl-mark-plan",
       source: "implementation",
       sourceHandle: "side",
       target: "action-mark-plan",
-      type: "smoothstep",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
     },
     {
@@ -521,50 +623,33 @@ function buildWorkflowGraph(editable = false): { nodes: Node<StepNodeData>[]; ed
       source: "implementation",
       sourceHandle: "out",
       target: "babysit",
-      type: "smoothstep",
-      label: "passed",
+      type: EDGE_TYPE,
       animated: true,
-      style: { ...EDGE_STYLE, stroke: "#3b82f6" },
-      markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14, color: "#3b82f6" },
-      labelStyle: { fill: "#737373", fontSize: 11 },
-      labelBgStyle: { fill: "#ffffff" },
-      labelBgPadding: [4, 6] as [number, number],
+      style: { ...EDGE_STYLE, stroke: "#818cf8" },
     },
     {
       id: "e-babysit-mark",
       source: "babysit",
       sourceHandle: "side",
       target: "action-mark-impl",
-      type: "smoothstep",
-      label: "passed",
+      type: EDGE_TYPE,
       style: EDGE_STYLE,
-      labelStyle: { fill: "#737373", fontSize: 11 },
-      labelBgStyle: { fill: "#ffffff" },
-      labelBgPadding: [4, 6] as [number, number],
     },
     {
       id: "e-babysit-notify-fail",
       source: "babysit",
       sourceHandle: "side",
       target: "action-notify-fail",
-      type: "smoothstep",
-      label: "failed",
-      style: { ...EDGE_STYLE, stroke: "#f87171" },
-      labelStyle: { fill: "#b91c1c", fontSize: 11 },
-      labelBgStyle: { fill: "#ffffff" },
-      labelBgPadding: [4, 6] as [number, number],
+      type: EDGE_TYPE,
+      style: { ...EDGE_STYLE, stroke: "#fca5a5" },
     },
     {
       id: "e-babysit-fail-memory",
       source: "babysit",
       sourceHandle: "side",
       target: "action-mark-fail-memory",
-      type: "smoothstep",
-      label: "failed",
-      style: { ...EDGE_STYLE, stroke: "#f87171" },
-      labelStyle: { fill: "#b91c1c", fontSize: 11 },
-      labelBgStyle: { fill: "#ffffff" },
-      labelBgPadding: [4, 6] as [number, number],
+      type: EDGE_TYPE,
+      style: { ...EDGE_STYLE, stroke: "#fca5a5" },
     },
   ];
 
@@ -591,8 +676,15 @@ function StepDetailSidebar({ node, onClose }: { node: Node<StepNodeData>; onClos
     <aside className="flex h-full w-[320px] shrink-0 flex-col border-l border-border bg-[#f7f7f7]">
       <div className="flex items-start justify-between gap-3 border-b border-border px-4 py-3">
         <div className="min-w-0">
-          <div className="text-[11px] font-medium tracking-[0.04em] text-muted-foreground">
-            {data.kind === "action" ? "Action" : "Step"}
+          <div className="flex items-center gap-2">
+            <img
+              src={providerIconSrc(data.provider)}
+              alt=""
+              className="size-3.5 shrink-0"
+            />
+            <div className="text-[11px] font-medium tracking-[0.04em] text-muted-foreground">
+              {data.componentName}
+            </div>
           </div>
           <h3 className="mt-1 text-[14px] font-semibold tracking-[-0.01em] text-foreground">{data.title}</h3>
         </div>
@@ -705,9 +797,8 @@ export function WorkOrderCanvas({ editable = false }: { editable?: boolean } = {
         addEdge(
           {
             ...connection,
-            type: "smoothstep",
+            type: EDGE_TYPE,
             style: EDGE_STYLE,
-            markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14, color: "#94a3b8" },
           },
           current,
         ),
@@ -736,12 +827,12 @@ export function WorkOrderCanvas({ editable = false }: { editable?: boolean } = {
           panOnScroll
           zoomOnScroll
           proOptions={{ hideAttribution: true }}
-          defaultEdgeOptions={{ type: "smoothstep" }}
+          defaultEdgeOptions={{ type: EDGE_TYPE, style: EDGE_STYLE }}
         >
-          <Background gap={20} size={1} color="#e5e5e5" />
+          <Background gap={22} size={1} color="#e5e7eb" bgColor="#f9fafb" />
           <Controls
             showInteractive={false}
-            className="!overflow-hidden !rounded-md !border !border-border !bg-background !shadow-none"
+            className="!overflow-hidden !rounded-xl !border !border-[#e5e7eb] !bg-white !shadow-[0_1px_3px_rgba(15,23,42,0.06)]"
           />
         </ReactFlow>
       </div>

--- a/web_src/src/pages/factories/pages/WorkOrderCanvas.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderCanvas.tsx
@@ -63,6 +63,12 @@ type StepDetail = {
   inputs?: string[];
 };
 
+type NodePorts = {
+  target?: boolean;
+  out?: boolean;
+  side?: boolean;
+};
+
 type StepNodeData = {
   /** Human step label (sidebar / instance name). */
   title: string;
@@ -75,7 +81,23 @@ type StepNodeData = {
   meta?: string[];
   showLogs?: boolean;
   details: StepDetail;
+  /** Which connection handles are in use (derived from edges). */
+  ports?: NodePorts;
 };
+
+function portsForNode(nodeId: string, edges: Edge[]): NodePorts {
+  let target = false;
+  let out = false;
+  let side = false;
+  for (const edge of edges) {
+    if (edge.target === nodeId) target = true;
+    if (edge.source === nodeId) {
+      if (edge.sourceHandle === "side") side = true;
+      else out = true;
+    }
+  }
+  return { target, out, side };
+}
 
 function statusBadgeClass(status: StepStatus) {
   switch (normalizeStatus(status)) {
@@ -174,7 +196,7 @@ function NodeStatusFooter({ status, metrics }: { status: StepStatus; metrics: st
   );
 }
 
-/** All-white StackAI-style card: icon + component name + status footer. */
+/** White card: icon + component name + tinted status footer. */
 function StackNodeShell({
   data,
   selected,
@@ -228,12 +250,15 @@ const HANDLE_CLASS =
   "!size-2.5 !rounded-[3px] !border !border-[#d4d4d4] !bg-white !shadow-none";
 
 function StepNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
+  const ports = data.ports;
   return (
     <div className="relative">
-      <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
+      {ports?.target ? <Handle type="target" position={Position.Top} className={HANDLE_CLASS} /> : null}
       <StackNodeShell data={data} selected={selected} widthClass="w-[280px]" />
-      <Handle id="out" type="source" position={Position.Bottom} className={HANDLE_CLASS} />
-      <Handle id="side" type="source" position={Position.Right} className={cn(HANDLE_CLASS, "!top-1/2")} />
+      {ports?.out ? <Handle id="out" type="source" position={Position.Bottom} className={HANDLE_CLASS} /> : null}
+      {ports?.side ? (
+        <Handle id="side" type="source" position={Position.Right} className={cn(HANDLE_CLASS, "!top-1/2")} />
+      ) : null}
     </div>
   );
 }
@@ -241,7 +266,7 @@ function StepNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
 function ActionNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
   return (
     <div className="relative">
-      <Handle type="target" position={Position.Left} className={HANDLE_CLASS} />
+      {data.ports?.target ? <Handle type="target" position={Position.Left} className={HANDLE_CLASS} /> : null}
       <StackNodeShell data={data} selected={selected} widthClass="w-[260px]" />
     </div>
   );
@@ -778,8 +803,12 @@ export function WorkOrderCanvas({ editable = false }: { editable?: boolean } = {
         ...node,
         selected: node.id === selectedId,
         draggable: editable,
+        data: {
+          ...node.data,
+          ports: portsForNode(node.id, edges),
+        },
       })),
-    [nodes, selectedId, editable],
+    [nodes, edges, selectedId, editable],
   );
 
   const onNodeClick = useCallback<NodeMouseHandler>((_event, node) => {


### PR DESCRIPTION
## Summary
- Restyle Lines/work-order React Flow nodes as white (token-based) cards with provider icons, detail lines, and tinted status footers
- Hide unused connection handles and drop edge arrows for a cleaner graph
- Make the canvas follow light/dark theme (semantic tokens + React Flow `colorMode`/edges/background), including Storybook’s toolbar by not nesting a shadowing `ThemeProvider`

## Test plan
- [ ] Open Storybook → Factories/Pages/Lines → Configure phase
- [ ] Confirm node cards, status strips (Passed/Failed/Running/Pending), and edges look correct in light mode
- [ ] Toggle Storybook Light/Dark and confirm nodes, edges, background, and React Flow chrome update together
- [ ] Confirm unused handles are hidden and only connected ports show
- [ ] Spot-check selecting a node opens the detail sidebar with expected styling


Made with [Cursor](https://cursor.com)