### PR TITLE
chore: Add agent skills for PR text and UI copy

### DIFF
--- a/.agents/skills/commit-and-pr-messages/SKILL.md
+++ b/.agents/skills/commit-and-pr-messages/SKILL.md
@@ -3,8 +3,9 @@ name: commit-and-pr-messages
 description: >-
   Write Git commit messages and pull request titles/descriptions using the
   Chris Beams / Tim Pope conventions (subject/body split, ~50-char subject,
-  imperative mood, why-not-how body). Use when creating commits, drafting or
-  editing PR descriptions, writing PR titles, or when the user asks for help
+  imperative mood, why-not-how body) plus ASD-STE100 Simplified Technical
+  English for bodies and PR descriptions. Use when creating commits, drafting
+  or editing PR descriptions, writing PR titles, or when the user asks for help
   with commit/PR wording, changelogs from commits, or git history style.
 ---
 
@@ -16,6 +17,11 @@ Write history that future readers can scan, search, and trust. A diff shows
 Based on [How to Write a Git Commit Message](https://cbea.ms/git-commit/)
 (Chris Beams) and [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 (Tim Pope), adapted for SuperPlane's Conventional Commits + DCO requirements.
+
+**Language:** Write commit bodies, PR titles (after the type prefix), and PR
+descriptions in ASD-STE100 Simplified Technical English style. Follow
+[simplified-technical-english](../simplified-technical-english/SKILL.md)
+before you finalize wording.
 
 ## When to use
 
@@ -84,27 +90,30 @@ PR titles are the public subject line for a whole change set.
 
 Treat the PR body like an expanded commit body for reviewers and future
 maintainers. Lead with purpose; do not narrate the diff file-by-file.
+Write the Summary and Test plan in STE
+([simplified-technical-english](../simplified-technical-english/SKILL.md)).
 
 ### Required shape
 
 ```markdown
 ## Summary
 
-<2–4 sentences or bullets: what problem this solves and why this change
-exists. Focus on motivation and user/system impact, not implementation
-tour.>
+<2–4 short STE sentences or bullets: what problem this solves and why this
+change exists. Max 25 words per descriptive sentence. Focus on motivation
+and user/system impact, not implementation tourism.>
 
 ## Test plan
 
-- [ ] <Concrete verification steps a reviewer can run>
+- [ ] <STE procedural step: max 20 words, one instruction, imperative>
 - [ ] <Edge cases or regressions worth checking>
 ```
 
 ### Writing rules for the Summary
 
+- **STE first.** Short sentences, active voice, no contractions, no slang.
 - **Why over how.** State the before/after behavior and the reason for the
   change. Mention approach only when it is non-obvious or risky.
-- **Imperative / present orientation.** Describe what the PR *does*
+- **Present / imperative orientation.** Describe what the PR *does*
   (`Adds…`, `Fixes…`, `Removes…`), not a diary of what you did yesterday.
 - **Scannable.** Short paragraphs or bullets; no wall of implementation notes
   that duplicate the diff.
@@ -127,6 +136,7 @@ Before submitting a PR description, confirm:
 
 - [ ] Title completes: *If merged, this PR will ________.*
 - [ ] Summary explains **why**, not a file list
+- [ ] Summary and Test plan obey STE sentence limits and style
 - [ ] Test plan has actionable checks
 - [ ] No trailing period / non-imperative mush in the title
 - [ ] Body would still make sense months later without the author present

--- a/.agents/skills/commit-and-pr-messages/SKILL.md
+++ b/.agents/skills/commit-and-pr-messages/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: commit-and-pr-messages
+description: >-
+  Write Git commit messages and pull request titles/descriptions using the
+  Chris Beams / Tim Pope conventions (subject/body split, ~50-char subject,
+  imperative mood, why-not-how body). Use when creating commits, drafting or
+  editing PR descriptions, writing PR titles, or when the user asks for help
+  with commit/PR wording, changelogs from commits, or git history style.
+---
+
+# Commit and PR Messages
+
+Write history that future readers can scan, search, and trust. A diff shows
+*what* changed; the message must explain *why*.
+
+Based on [How to Write a Git Commit Message](https://cbea.ms/git-commit/)
+(Chris Beams) and [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+(Tim Pope), adapted for SuperPlane's Conventional Commits + DCO requirements.
+
+## When to use
+
+- Creating or amending a commit message
+- Opening or updating a pull request (title and body)
+- Reviewing whether a PR description is useful to reviewers
+
+## Commit messages — seven rules
+
+1. **Separate subject from body with a blank line.**
+2. **Limit the subject line to ~50 characters** (72 hard max). Prefer the
+   Conventional Commits prefix used by this repo (`feat:`, `fix:`, `chore:`,
+   `docs:`) plus a short imperative summary; keep the whole subject readable.
+3. **Capitalize the subject line** after the optional type prefix
+   (`feat: Add canvas console filters`).
+4. **Do not end the subject line with a period.**
+5. **Use the imperative mood in the subject line** — as if completing:
+   *If applied, this commit will ________.*
+   Prefer `Fix`, `Add`, `Remove`, `Refactor` over `Fixed`, `Adds`, `Fixing`.
+6. **Wrap the body at 72 characters.**
+7. **Use the body to explain what and why, not how.** The code shows how.
+   Cover motivation, prior behavior, trade-offs, and non-obvious side effects.
+
+### Model commit
+
+```text
+Capitalized, short (50 chars or less) summary
+
+More detailed explanatory text, if necessary. Wrap it to about 72
+characters or so. The blank line after the subject is mandatory when a
+body is present.
+
+Explain the problem this commit solves and why this approach was chosen.
+Leave mechanical how-details to the diff unless the approach is surprising.
+
+Further paragraphs come after blank lines.
+
+- Bullet points are okay
+
+Resolves: #123
+```
+
+### SuperPlane commit extras
+
+- Include a DCO trailer: `Signed-off-by: Name <email>` (use `git commit -s`).
+- One logical change per commit when practical; if the subject is hard to
+  write, the commit may be doing too much.
+- Issue/PR references belong at the end of the body, not stuffed into the
+  subject.
+
+## Pull request titles
+
+PR titles are the public subject line for a whole change set.
+
+- Follow Conventional Commits with a release-type prefix CI enforces:
+  `feat:`, `fix:`, `chore:`, or `docs:`.
+- After the prefix, write an imperative, capitalized summary with no trailing
+  period — same mood test as commits.
+- Keep the title scannable; put nuance in the body, not a novel in the title.
+
+**Good:** `feat: Add empty-state copy for connected integrations`  
+**Weak:** `feat: Updated some stuff for onboarding`  
+**Weak:** `Fixed the bug.`
+
+## Pull request descriptions
+
+Treat the PR body like an expanded commit body for reviewers and future
+maintainers. Lead with purpose; do not narrate the diff file-by-file.
+
+### Required shape
+
+```markdown
+## Summary
+
+<2–4 sentences or bullets: what problem this solves and why this change
+exists. Focus on motivation and user/system impact, not implementation
+tour.>
+
+## Test plan
+
+- [ ] <Concrete verification steps a reviewer can run>
+- [ ] <Edge cases or regressions worth checking>
+```
+
+### Writing rules for the Summary
+
+- **Why over how.** State the before/after behavior and the reason for the
+  change. Mention approach only when it is non-obvious or risky.
+- **Imperative / present orientation.** Describe what the PR *does*
+  (`Adds…`, `Fixes…`, `Removes…`), not a diary of what you did yesterday.
+- **Scannable.** Short paragraphs or bullets; no wall of implementation notes
+  that duplicate the diff.
+- **Honest scope.** Call out follow-ups, known gaps, or intentional
+  non-goals when relevant.
+- **Link context.** Reference issues (`Closes #123`) when they exist; do not
+  invent ticket IDs.
+
+### Avoid
+
+- Subject-only PRs with an empty or placeholder body when the change needs
+  context
+- Restating every file touched (`Updated Foo.tsx, Bar.go, …`)
+- Past-tense changelog dumping with no problem statement
+- Marketing or hype language
+
+### Quick quality check
+
+Before submitting a PR description, confirm:
+
+- [ ] Title completes: *If merged, this PR will ________.*
+- [ ] Summary explains **why**, not a file list
+- [ ] Test plan has actionable checks
+- [ ] No trailing period / non-imperative mush in the title
+- [ ] Body would still make sense months later without the author present

--- a/.agents/skills/simplified-technical-english/SKILL.md
+++ b/.agents/skills/simplified-technical-english/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: simplified-technical-english
+description: >-
+  Write user-facing and reviewer-facing technical text in ASD-STE100 Simplified
+  Technical English style. Use when drafting PR descriptions, commit message
+  bodies, UI copy, docs, error messages, procedures, onboarding text, or any
+  product wording that must stay clear for non-native readers.
+---
+
+# Simplified Technical English (ASD-STE100)
+
+Write clear, unambiguous technical English. Prefer STE writing rules over clever
+or idiomatic phrasing.
+
+This skill applies **STE writing rules** (grammar and style). It does **not**
+embed the copyrighted STE dictionary (~900 approved words). Use simple words
+with one clear meaning; use SuperPlane **technical nouns/verbs** for product
+terms. For full dictionary compliance, consult the official standard:
+[ASD-STE100](https://asd-ste100.org/).
+
+Source: ASD-STE100 Issue 9 (January 2025), Standard for technical documentation.
+ASD owns the STE trademark and standard; this skill is an operational distillation
+for agents, not a substitute for the official document.
+
+## When this applies
+
+| Text | STE mode |
+| --- | --- |
+| PR description Summary and Test plan | Descriptive + procedural |
+| Commit message **body** | Descriptive |
+| UI labels, buttons, helper text, empty states, errors, confirmations | Procedural / short descriptive |
+| Docs, runbooks, onboarding steps | Procedural and/or descriptive |
+
+**Exceptions (do not rewrite these into STE):**
+
+- Conventional Commits type prefixes (`feat:`, `fix:`, …)
+- Code identifiers, API paths, proto names, log lines, and quoted error codes
+- Proper nouns and product names (`SuperPlane`, `GitHub`, `PostgreSQL`)
+- Issue IDs and DCO trailers
+
+## Core rules (must follow)
+
+### Words
+
+1. Prefer plain words with **one meaning**. Do not use synonyms for the same idea
+   in the same surface (`start` vs `begin` vs `initiate` — pick one and keep it).
+2. Keep **one technical noun per concept**. Use SuperPlane vocabulary
+   consistently: `canvas`, `organization`, `integration`, `component`, `trigger`,
+   `run`, `approval`, `console`. Spell the product **SuperPlane**.
+3. Do not use slang, idioms, humor, or jargon that the reader cannot act on.
+4. Use **American English** spelling.
+5. Prefer verbs for actions. Do not hide actions in nouns
+   (`Create a connection`, not `Perform connection creation`).
+6. Keep multi-word technical nouns to **three words or fewer** when you invent
+   a phrase (`deploy approval step`, not `production deploy approval workflow step`).
+
+### Verbs and voice
+
+1. Prefer these forms: infinitive, **imperative**, simple present, simple past,
+   simple future (`will`), past participle as adjective.
+2. Avoid complex constructions: progressive (`is creating`), perfect
+   (`has created`), and stacked auxiliaries when a simple form works.
+3. Use the **active voice**. Use passive only in descriptive text when the actor
+   is unknown.
+4. Instructions and button labels use the **imperative** (`Connect GitHub`,
+   `Delete the canvas`).
+
+### Sentences
+
+1. Write short, clear sentences. Do not omit necessary words or use contractions
+   to fake brevity (`do not`, not `don't`; `cannot`, not `can't`).
+2. **Procedures / instructions / test steps:** maximum **20 words** per sentence.
+   One instruction per sentence unless two actions occur at the same time.
+3. **Descriptions** (PR Summary, explanatory UI, notes): maximum **25 words**
+   per sentence.
+4. One topic per paragraph; keep paragraphs short (about six sentences or fewer).
+5. Use a vertical list when a sentence would list many items or steps.
+6. Give information gradually: problem or goal first, then necessary detail.
+
+### Procedural pattern
+
+When the reader must do something (test plan, UI steps, recovery text):
+
+```text
+If the condition is true, do the action.
+```
+
+- Put the condition first when the reader must know it before acting.
+- Separate condition and command with a comma.
+- Name the object and the outcome (`Delete "Deploy to production".`).
+
+## SuperPlane technical nouns (approved for UI and PRs)
+
+Use these as stable technical nouns. Do not invent synonyms for the same thing:
+
+- SuperPlane
+- organization
+- canvas
+- integration
+- component
+- trigger
+- run
+- approval
+- console
+- factory (Factories product surfaces)
+- work order (Factories)
+
+Code-only names (package paths, worker names, proto messages, table names) stay
+out of user-facing copy.
+
+## Before / after
+
+**Weak (not STE):**  
+`We've basically reworked how the onboarding bits kinda wire up integrations and stuff so it's nicer.`
+
+**STE:**  
+`This change updates the onboarding flow for integrations.`  
+`The new flow shows connection status and the next required step.`
+
+**Weak PR test step:**  
+`Just make sure everything still works when you click around connecting GitHub and then going back.`
+
+**STE test step:**  
+`- [ ] Connect GitHub from the onboarding screen.`  
+`- [ ] Confirm the status shows Connected.`  
+`- [ ] Go back one step and confirm the status stays Connected.`
+
+**Weak UI:**  
+`Oops! Something went wrong on our end.`
+
+**STE UI:**  
+`SuperPlane could not connect to GitHub.`  
+`Check your credentials and try again.`
+
+## Quality checklist
+
+- [ ] Sentences stay within 20 words (instructions) or 25 words (descriptions)
+- [ ] Active voice; imperative for commands
+- [ ] No contractions, slang, idioms, or hype
+- [ ] One term per concept; SuperPlane vocabulary is consistent
+- [ ] Lists used when steps or items would crowd a sentence
+- [ ] PR/commit text explains **why** without narrative filler
+- [ ] UI text states the action, object, and outcome
+
+## Related skills
+
+- PR titles, commit subjects, and PR structure:
+  [commit-and-pr-messages](../commit-and-pr-messages/SKILL.md)
+- UI microcopy patterns:
+  [ui-copy](../ui-copy/SKILL.md)

--- a/.agents/skills/ui-copy/SKILL.md
+++ b/.agents/skills/ui-copy/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   microcopy, button labels, link text, form labels, helper text, empty states,
   error messages, confirmation dialogs, onboarding text, notifications, or
   user-facing product wording — including when designing or implementing UI.
+  Applies ASD-STE100 Simplified Technical English style.
 ---
 
 # UI Copy
@@ -15,27 +16,33 @@ is done. The product is speaking to someone who is trying to complete a task.
 Adapted from Operately's [ui-copy skill](https://github.com/operately/operately/blob/main/.agents/skills/ui-copy/SKILL.md)
 for SuperPlane product vocabulary.
 
+**Language:** Write all user-facing strings in ASD-STE100 Simplified Technical
+English style. Follow
+[simplified-technical-english](../simplified-technical-english/SKILL.md)
+together with this skill. If UX tone and STE conflict, choose the clearer STE
+wording.
+
 ## Workflow
 
 1. Identify the user's current goal, screen state, and likely concern.
 2. Find nearby existing copy and match the product vocabulary, casing, tense, and tone.
-3. Draft the clearest version first. Prefer plain, specific, task-oriented language over personality.
-4. Tighten the copy until every word has a job.
+3. Draft the clearest STE version first. Prefer plain, specific, task-oriented language over personality.
+4. Tighten the copy until every word has a job (≤20 words for instructions, ≤25 for descriptions).
 5. Check that buttons, links, errors, and helper text set accurate expectations.
 6. If changing existing copy, scan adjacent screens or components for terms that should stay consistent.
 
 ## Principles
 
 - Treat words as UI. Real copy belongs in early designs, prototypes, and implementation; do not rely on placeholder text when the wording affects comprehension, trust, or layout.
-- Clarity beats brevity and personality. Short is good only when it remains specific. Cute, clever, or branded wording is acceptable only after the action is unmistakable.
+- Clarity beats brevity and personality. Short is good only when it remains specific. Do not use cute, clever, or branded wording when it can hide the action.
 - Write for the user in this moment. Ask what they are trying to do, what they need to know now, what can wait, and whether they need reassurance.
 - Be honest and concrete. Avoid marketing adjectives, hype, vague promises, and copy that tells users how to feel.
-- Use plain language. Avoid jargon, unexplained acronyms, idioms, internal names, and technical error codes unless the user can act on them.
-- Prefer active voice, present tense, and specific verbs: `Create`, `Save`, `Archive`, `Invite`, `Download`, `Connect`.
+- Use STE plain language. Avoid jargon, unexplained acronyms, idioms, contractions, internal names, and technical error codes unless the user can act on them.
+- Prefer active voice, imperative or simple present, and specific verbs: `Create`, `Save`, `Archive`, `Invite`, `Download`, `Connect`.
 - Keep copy scannable. Use short sentences, front-load important words, and reveal advanced detail only when needed.
 - Keep vocabulary consistent. Do not alternate between terms like `canvas`, `workflow`, and `pipeline` unless the product treats them as different concepts.
 - Match the platform and interaction. Use `tap` for touch surfaces and `click` only where pointer interaction is the assumption.
-- Use humor sparingly. Never use humor in repetitive, high-friction, high-risk, error, payment, privacy, or destructive flows.
+- Do not use humor in UI copy. Never use humor in high-friction, high-risk, error, payment, privacy, or destructive flows.
 
 ## Product Vocabulary
 
@@ -99,8 +106,9 @@ For success messages, confirm the completed action without hype:
 - Does the copy help the user complete the current task?
 - Is the primary action named with a specific verb?
 - Could the user understand it without reading surrounding body text?
+- Does the wording obey STE limits (≤20 words for instructions, ≤25 for descriptions)?
 - Is any word internal, technical, vague, promotional, or trying too hard?
-- Is the tone appropriate for the situation's risk, friction, or emotion?
+- Are contractions, slang, idioms, or humor absent?
 - Are terms, casing, and point of view consistent with nearby UI?
 - Is detail progressively disclosed instead of shown all at once?
 - Does the copy still fit small screens and common localization expansion?

--- a/.agents/skills/ui-copy/SKILL.md
+++ b/.agents/skills/ui-copy/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: ui-copy
+description: >-
+  Use when writing, editing, reviewing, or replacing UI copy, UX writing,
+  microcopy, button labels, link text, form labels, helper text, empty states,
+  error messages, confirmation dialogs, onboarding text, notifications, or
+  user-facing product wording — including when designing or implementing UI.
+---
+
+# UI Copy
+
+Write interface copy as part of the design, not as decoration after the layout
+is done. The product is speaking to someone who is trying to complete a task.
+
+Adapted from Operately's [ui-copy skill](https://github.com/operately/operately/blob/main/.agents/skills/ui-copy/SKILL.md)
+for SuperPlane product vocabulary.
+
+## Workflow
+
+1. Identify the user's current goal, screen state, and likely concern.
+2. Find nearby existing copy and match the product vocabulary, casing, tense, and tone.
+3. Draft the clearest version first. Prefer plain, specific, task-oriented language over personality.
+4. Tighten the copy until every word has a job.
+5. Check that buttons, links, errors, and helper text set accurate expectations.
+6. If changing existing copy, scan adjacent screens or components for terms that should stay consistent.
+
+## Principles
+
+- Treat words as UI. Real copy belongs in early designs, prototypes, and implementation; do not rely on placeholder text when the wording affects comprehension, trust, or layout.
+- Clarity beats brevity and personality. Short is good only when it remains specific. Cute, clever, or branded wording is acceptable only after the action is unmistakable.
+- Write for the user in this moment. Ask what they are trying to do, what they need to know now, what can wait, and whether they need reassurance.
+- Be honest and concrete. Avoid marketing adjectives, hype, vague promises, and copy that tells users how to feel.
+- Use plain language. Avoid jargon, unexplained acronyms, idioms, internal names, and technical error codes unless the user can act on them.
+- Prefer active voice, present tense, and specific verbs: `Create`, `Save`, `Archive`, `Invite`, `Download`, `Connect`.
+- Keep copy scannable. Use short sentences, front-load important words, and reveal advanced detail only when needed.
+- Keep vocabulary consistent. Do not alternate between terms like `canvas`, `workflow`, and `pipeline` unless the product treats them as different concepts.
+- Match the platform and interaction. Use `tap` for touch surfaces and `click` only where pointer interaction is the assumption.
+- Use humor sparingly. Never use humor in repetitive, high-friction, high-risk, error, payment, privacy, or destructive flows.
+
+## Product Vocabulary
+
+Some names exist only in code, schemas, and internal discussion. Never put them in UI copy — placeholders, labels, empty states, errors, confirmations, notifications, or help text.
+
+- The product name is **SuperPlane** (capital S, capital P). Never write `Superplane` or `superplane` in user-facing copy.
+- Prefer established product terms already used in the UI: `canvas`, `organization`, `integration`, `component`, `trigger`, `run`, `approval`, `console`. Do not invent synonyms for the same concept.
+- Do not expose internal package paths, proto message names, worker names, or DB table names in UI strings.
+- When in doubt, match copy on a nearby screen rather than inventing a new term.
+
+## Buttons
+
+Buttons should describe the action or outcome. A user should not be surprised by what happens after clicking.
+
+- Prefer `Create canvas` over `Submit`.
+- Prefer `Save and continue` over `Next` when the next step matters.
+- Prefer `Delete integration` and `Keep integration` over `OK` and `Cancel` in destructive confirmations.
+- Prefer `Connect GitHub` over `Continue` when the next step is a specific connection.
+- Avoid vague commitment language when a lower-pressure action is accurate.
+
+Use short helper text near a high-commitment button when it answers a likely concern:
+
+- `You can change this later.`
+- `Only organization admins can see this.`
+- `This will not start a run yet.`
+
+## Links
+
+Links can carry more context than buttons, but they still need to be descriptive when scanned out of context.
+
+- Prefer `View run history` over `Learn more`.
+- Prefer `Download the CSV report` over `Download`.
+- Prefer `See organization permissions` over `Details`.
+
+Use `Learn more` only when the destination is genuinely broad and the surrounding heading already makes the topic obvious.
+
+## States And Messages
+
+For empty states, say what is missing and offer the next useful action:
+
+- Weak: `No results.`
+- Better: `No matching canvases. Try a different filter or create a canvas.`
+
+For errors, explain what happened in user terms and give a recovery path:
+
+- Weak: `System error #2234.`
+- Better: `We could not connect to GitHub. Check your credentials and try again.`
+
+For confirmations, name the object, consequence, and escape path:
+
+- Weak: `Are you sure?`
+- Better: `Delete "Deploy to production"? This removes the canvas for everyone.`
+
+For success messages, confirm the completed action without hype:
+
+- Weak: `Awesome! Your amazing update was successful.`
+- Better: `Canvas updated.`
+
+## Review Checklist
+
+- Does the copy help the user complete the current task?
+- Is the primary action named with a specific verb?
+- Could the user understand it without reading surrounding body text?
+- Is any word internal, technical, vague, promotional, or trying too hard?
+- Is the tone appropriate for the situation's risk, friction, or emotion?
+- Are terms, casing, and point of view consistent with nearby UI?
+- Is detail progressively disclosed instead of shown all at once?
+- Does the copy still fit small screens and common localization expansion?
+- Is the product name spelled **SuperPlane** wherever it appears?
+
+## Source Distillation
+
+This skill distills principles from:
+
+- Julie Chabin, `Good UI can't fix bad copy`
+- John Zeratsky, `Five principles for great interface copywriting`
+- Nick Babich, `16 Rules of Effective UX Writing`
+- Tobias van Schneider, `Writing UX copy for buttons and links`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,9 @@
 Guidance for AI coding agents and human contributors working in this repository.
 Read this top-to-bottom: what the project is, how to set it up, how to build and
 test, the conventions to follow, what not to touch, and how to submit changes.
-For UI-specific work, also read [web_src/AGENTS.md](web_src/AGENTS.md) and
-[.agents/skills/ui-copy/SKILL.md](.agents/skills/ui-copy/SKILL.md).
+For UI-specific work, also read [web_src/AGENTS.md](web_src/AGENTS.md),
+[.agents/skills/ui-copy/SKILL.md](.agents/skills/ui-copy/SKILL.md), and
+[.agents/skills/simplified-technical-english/SKILL.md](.agents/skills/simplified-technical-english/SKILL.md).
 
 ## Project Overview
 
@@ -258,14 +259,20 @@ encodes the Chris Beams / Tim Pope conventions (imperative subject, ~50-char
 summary, blank line before body, wrap at 72, explain why not how) plus
 SuperPlane's CI and DCO rules.
 
+Write commit bodies, PR descriptions, UI copy, and other reviewer/user-facing
+technical text in ASD-STE100 Simplified Technical English style. Follow
+[.agents/skills/simplified-technical-english/SKILL.md](.agents/skills/simplified-technical-english/SKILL.md)
+(short sentences, active voice, imperative instructions, stable terminology; no
+contractions, slang, or idioms).
+
 - PR titles must follow Conventional Commits with a release-type prefix that CI
   enforces: `feat:`, `fix:`, `chore:`, or `docs:`. After the prefix, use an
   imperative, capitalized summary with no trailing period
   (e.g. `feat: Add empty-state copy for integrations`).
 - PR descriptions must explain **why** the change exists (problem, motivation,
-  user/system impact), not narrate the diff. Use a short Summary plus a
-  concrete Test plan checklist. Avoid empty or placeholder bodies when context
-  matters.
+  user/system impact), not narrate the diff. Use a short STE Summary plus a
+  concrete STE Test plan checklist. Avoid empty or placeholder bodies when
+  context matters.
 - Commit subjects use the same imperative style; put motivation and trade-offs
   in the body. Separate subject and body with a blank line; wrap the body at
   72 characters.
@@ -277,7 +284,8 @@ SuperPlane's CI and DCO rules.
   - Protos: `make pb.gen` and `make check.proto.field.numbers`.
 
 For user-facing UI strings while designing or implementing frontend work, follow
-[.agents/skills/ui-copy/SKILL.md](.agents/skills/ui-copy/SKILL.md).
+[.agents/skills/ui-copy/SKILL.md](.agents/skills/ui-copy/SKILL.md) together with
+the STE skill above.
 
 ## Cursor Cloud Environment Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 Guidance for AI coding agents and human contributors working in this repository.
 Read this top-to-bottom: what the project is, how to set it up, how to build and
 test, the conventions to follow, what not to touch, and how to submit changes.
-For UI-specific work, also read [web_src/AGENTS.md](web_src/AGENTS.md).
+For UI-specific work, also read [web_src/AGENTS.md](web_src/AGENTS.md) and
+[.agents/skills/ui-copy/SKILL.md](.agents/skills/ui-copy/SKILL.md).
 
 ## Project Overview
 
@@ -251,14 +252,32 @@ _ = HardDeleteCanvasNode(tx, node.OrganizationID, node.ID)
 
 ## Commit & Pull Request Guidelines
 
+Follow [.agents/skills/commit-and-pr-messages/SKILL.md](.agents/skills/commit-and-pr-messages/SKILL.md)
+for commit subjects/bodies and for every PR title and description. That skill
+encodes the Chris Beams / Tim Pope conventions (imperative subject, ~50-char
+summary, blank line before body, wrap at 72, explain why not how) plus
+SuperPlane's CI and DCO rules.
+
 - PR titles must follow Conventional Commits with a release-type prefix that CI
-  enforces: `feat:`, `fix:`, `chore:`, or `docs:`.
+  enforces: `feat:`, `fix:`, `chore:`, or `docs:`. After the prefix, use an
+  imperative, capitalized summary with no trailing period
+  (e.g. `feat: Add empty-state copy for integrations`).
+- PR descriptions must explain **why** the change exists (problem, motivation,
+  user/system impact), not narrate the diff. Use a short Summary plus a
+  concrete Test plan checklist. Avoid empty or placeholder bodies when context
+  matters.
+- Commit subjects use the same imperative style; put motivation and trade-offs
+  in the body. Separate subject and body with a blank line; wrap the body at
+  72 characters.
 - All commits must include a DCO sign-off trailer
   (`Signed-off-by: Name <email>`). Use `git commit -s` (or `git commit --amend -s`).
 - Before submitting, run the checks relevant to your change:
   - Backend: `make format.go`, `make lint`, `make check.build.app`, `make test`.
   - Frontend: `make format.js`, `make check.build.ui`.
   - Protos: `make pb.gen` and `make check.proto.field.numbers`.
+
+For user-facing UI strings while designing or implementing frontend work, follow
+[.agents/skills/ui-copy/SKILL.md](.agents/skills/ui-copy/SKILL.md).
 
 ## Cursor Cloud Environment Notes
 

--- a/web_src/AGENTS.md
+++ b/web_src/AGENTS.md
@@ -4,7 +4,9 @@ This document captures the architecture principles, patterns, and workflow for d
 
 For user-facing labels, buttons, empty states, errors, confirmations, and other
 product wording, follow [../.agents/skills/ui-copy/SKILL.md](../.agents/skills/ui-copy/SKILL.md)
-— write real copy as part of the design, not placeholder text after layout.
+and [../.agents/skills/simplified-technical-english/SKILL.md](../.agents/skills/simplified-technical-english/SKILL.md)
+— write real ASD-STE100-style copy as part of the design, not placeholder text
+after layout.
 
 ## Architecture Principles
 

--- a/web_src/AGENTS.md
+++ b/web_src/AGENTS.md
@@ -2,6 +2,10 @@
 
 This document captures the architecture principles, patterns, and workflow for developing components for SuperPlane.
 
+For user-facing labels, buttons, empty states, errors, confirmations, and other
+product wording, follow [../.agents/skills/ui-copy/SKILL.md](../.agents/skills/ui-copy/SKILL.md)
+— write real copy as part of the design, not placeholder text after layout.
+
 ## Architecture Principles
 
 ### Component Design


### PR DESCRIPTION
## Summary

This change adds agent skills for commit messages, pull request descriptions, and UI copy.
Agents must write reviewer text and product text in ASD-STE100 Simplified Technical English style.
`AGENTS.md` and `web_src/AGENTS.md` point to these skills.

## Test plan

- [ ] Open `.agents/skills/commit-and-pr-messages/SKILL.md` and confirm PR title and body rules.
- [ ] Open `.agents/skills/simplified-technical-english/SKILL.md` and confirm sentence limits.
- [ ] Open `.agents/skills/ui-copy/SKILL.md` and confirm it requires the STE skill.
- [ ] Confirm `AGENTS.md` links to all three skills.
- [ ] Ask an agent to draft a sample PR description and confirm STE style.


Made with [Cursor](https://cursor.com)