### PR TITLE
fix: stop factory Configure update-depth loop

### DIFF
--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -15,5 +15,5 @@
     "max-lines": 3668,
     "complexity": 198
   },
-  "updatedAt": "2026-08-12T12:23:31.749Z"
+  "updatedAt": "2026-08-12T12:42:43.213Z"
 }

--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -12,8 +12,8 @@
     "no-eslint-disable-next-line": 3
   },
   "maxAllowedMetricMaximumByRule": {
-    "max-lines": 3687,
+    "max-lines": 3668,
     "complexity": 198
   },
-  "updatedAt": "2026-08-12T05:37:11.993Z"
+  "updatedAt": "2026-08-12T12:23:31.749Z"
 }

--- a/web_src/src/pages/app/factoryConfigureEnterSession.ts
+++ b/web_src/src/pages/app/factoryConfigureEnterSession.ts
@@ -1,0 +1,99 @@
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+
+export type FactoryConfigureEnterDeps = {
+  activateCanvasVersionForEditing: (
+    versionId: string,
+    version: CanvasesCanvasVersion,
+    options?: { preserveStagedLayer?: boolean },
+  ) => void;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"] | null>>;
+  previewingCurrentVersionRef: MutableRefObject<boolean>;
+  resyncStagedEditorState: (
+    versionId: string,
+    options?: { bumpResetNonce?: boolean; preferCachedStagedSpec?: boolean },
+  ) => Promise<void>;
+  setDraftCanvasSpec: Dispatch<SetStateAction<CanvasesCanvas["spec"] | null>>;
+  setEditSessionActive: Dispatch<SetStateAction<boolean>>;
+  setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
+};
+
+type StartFactoryConfigureEnterOptions = {
+  visitId: number;
+  configureVersionId: string;
+  version: CanvasesCanvasVersion;
+  liveCanvasRef: MutableRefObject<CanvasesCanvas | null | undefined>;
+  configureVisitIdRef: MutableRefObject<number>;
+  inFlightVisitIdRef: MutableRefObject<number | null>;
+  editEnabledVisitIdRef: MutableRefObject<number | null>;
+  deps: FactoryConfigureEnterDeps;
+};
+
+/** Seed draft + await staged resync for one Configure visit. Returns cancel cleanup. */
+export function startFactoryConfigureEnter({
+  visitId,
+  configureVersionId,
+  version,
+  liveCanvasRef,
+  configureVisitIdRef,
+  inFlightVisitIdRef,
+  editEnabledVisitIdRef,
+  deps,
+}: StartFactoryConfigureEnterOptions) {
+  // Seed draft from the live version directly — do not wait on the versions
+  // list (handleUseVersion), which often left Configure with no activeVersionId.
+  const immediateSpec = liveCanvasRef.current?.spec ?? version.spec ?? { nodes: [], edges: [] };
+  const versionForEdit: CanvasesCanvasVersion = {
+    ...version,
+    metadata: {
+      ...version.metadata,
+      id: configureVersionId,
+    },
+    spec: immediateSpec,
+  };
+
+  let cancelled = false;
+  const {
+    activateCanvasVersionForEditing: activate,
+    draftCanvasSpecsRef: specsRef,
+    previewingCurrentVersionRef: previewingRef,
+    resyncStagedEditorState: resync,
+    setDraftCanvasSpec: setDraft,
+    setEditSessionActive: setEditActive,
+    setLastSavedWorkflowSnapshot: setSnapshot,
+  } = deps;
+
+  previewingRef.current = true;
+  activate(configureVersionId, versionForEdit, { preserveStagedLayer: true });
+  specsRef.current.set(configureVersionId, immediateSpec);
+  setDraft(immediateSpec);
+
+  // Await staged resync before enabling edit so a late applyStagedSpec cannot
+  // wipe edits typed against the immediate seed.
+  void (async () => {
+    try {
+      await resync(configureVersionId, { bumpResetNonce: false });
+    } catch {
+      // Keep the immediate live/committed spec so Configure stays usable.
+    }
+    if (cancelled || configureVisitIdRef.current !== visitId) {
+      return;
+    }
+    editEnabledVisitIdRef.current = visitId;
+    inFlightVisitIdRef.current = null;
+    setEditActive(true);
+    const canvas = liveCanvasRef.current;
+    if (canvas) {
+      const spec = specsRef.current.get(configureVersionId) ?? immediateSpec;
+      setSnapshot({ ...canvas, spec });
+    }
+  })();
+
+  return () => {
+    cancelled = true;
+    // Strict Mode remount: allow retry only when edit never enabled for visit.
+    if (editEnabledVisitIdRef.current !== visitId && inFlightVisitIdRef.current === visitId) {
+      inFlightVisitIdRef.current = null;
+    }
+  };
+}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -407,6 +407,8 @@ export function AppPage({
     isMemoryMode: urlViewFlags.isMemoryMode,
   });
   const [draftCanvasSpec, setDraftCanvasSpec] = useState<CanvasesCanvas["spec"] | null>(null);
+  const draftCanvasSpecRef = useRef(draftCanvasSpec);
+  draftCanvasSpecRef.current = draftCanvasSpec;
   const draftSpecToRender = draftCanvasSpec ?? selectedCanvasVersion?.spec ?? null;
   const {
     committedBaselinesForEdit,
@@ -3283,7 +3285,9 @@ export function AppPage({
         options,
         liveCanvasVersionId,
         queryClient,
-        draftCanvasSpec,
+        // Read latest draft via ref so this callback identity stays stable across
+        // Configure seeding (setDraftCanvasSpec) and does not re-trigger enter effects.
+        draftCanvasSpec: draftCanvasSpecRef.current,
         draftCanvasSpecsRef,
         activeCanvasVersionIdRef,
         lastAppliedVersionSnapshotRef,
@@ -3301,7 +3305,6 @@ export function AppPage({
       canvasId,
       liveCanvasVersionId,
       queryClient,
-      draftCanvasSpec,
       liveCanvasVersion,
       liveCanvas,
       clearPendingAutoSaveWork,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -98,13 +98,13 @@ import {
   syncLoadedVersionToCanvasDetail,
   isHistoricalVersionSpecLoading,
 } from "./lib/resolve-canvas-for-view";
-import { activateCanvasVersionForEditing as applyCanvasVersionForEditing } from "./lib/canvas-version-activation";
 import {
   clearLiveEditSessionDraftState,
   clearLiveEditSessionSearchParams,
   isActiveCanvasVersionCurrentLive,
   resetCommittedLiveCanvasDetail,
 } from "./lib/live-edit-session";
+import { useActivateCanvasVersionForEditing } from "./useActivateCanvasVersionForEditing";
 import { useRefreshLatestLiveCanvasData } from "./useRefreshLatestLiveCanvasData";
 import type { CanvasVersionListItem } from "./lib/canvas-versions";
 import { canvasVersionShell, sortVersionsDesc } from "./lib/canvas-versions";
@@ -407,8 +407,6 @@ export function AppPage({
     isMemoryMode: urlViewFlags.isMemoryMode,
   });
   const [draftCanvasSpec, setDraftCanvasSpec] = useState<CanvasesCanvas["spec"] | null>(null);
-  const draftCanvasSpecRef = useRef(draftCanvasSpec);
-  draftCanvasSpecRef.current = draftCanvasSpec;
   const draftSpecToRender = draftCanvasSpec ?? selectedCanvasVersion?.spec ?? null;
   const {
     committedBaselinesForEdit,
@@ -3275,44 +3273,24 @@ export function AppPage({
     await handleResetStaging();
   }, [handleResetStaging]);
 
-  const activateCanvasVersionForEditing = useCallback(
-    (versionID: string, version: CanvasesCanvasVersion, options?: { preserveStagedLayer?: boolean }) =>
-      applyCanvasVersionForEditing({
-        organizationId,
-        canvasId,
-        versionID,
-        version,
-        options,
-        liveCanvasVersionId,
-        queryClient,
-        // Read latest draft via ref so this callback identity stays stable across
-        // Configure seeding (setDraftCanvasSpec) and does not re-trigger enter effects.
-        draftCanvasSpec: draftCanvasSpecRef.current,
-        draftCanvasSpecsRef,
-        activeCanvasVersionIdRef,
-        lastAppliedVersionSnapshotRef,
-        liveCanvasVersion,
-        liveCanvas,
-        clearPendingAutoSaveWork,
-        setDraftCanvasSpec,
-        setActiveCanvasVersion,
-        setLastSavedWorkflowSnapshot,
-        setSearchParams,
-        initializeFromWorkflow,
-      }),
-    [
-      organizationId,
-      canvasId,
-      liveCanvasVersionId,
-      queryClient,
-      liveCanvasVersion,
-      liveCanvas,
-      clearPendingAutoSaveWork,
-      setLastSavedWorkflowSnapshot,
-      setSearchParams,
-      initializeFromWorkflow,
-    ],
-  );
+  const activateCanvasVersionForEditing = useActivateCanvasVersionForEditing({
+    organizationId,
+    canvasId,
+    liveCanvasVersionId,
+    queryClient,
+    draftCanvasSpec,
+    draftCanvasSpecsRef,
+    activeCanvasVersionIdRef,
+    lastAppliedVersionSnapshotRef,
+    liveCanvasVersion,
+    liveCanvas,
+    clearPendingAutoSaveWork,
+    setDraftCanvasSpec,
+    setActiveCanvasVersion,
+    setLastSavedWorkflowSnapshot,
+    setSearchParams,
+    initializeFromWorkflow,
+  });
 
   const handleUseVersion = useCallback(
     (versionID: string, options?: { preserveStagedLayer?: boolean }) => {

--- a/web_src/src/pages/app/lib/canvas-version-activation.spec.ts
+++ b/web_src/src/pages/app/lib/canvas-version-activation.spec.ts
@@ -43,4 +43,34 @@ describe("activateCanvasVersionForEditing", () => {
     expect(next.get("node")).toBeNull();
     expect(next.get("version")).toBeNull();
   });
+
+  it("returns the same searchParams instance when activation is a no-op rewrite", () => {
+    const setSearchParams = vi.fn();
+    const current = new URLSearchParams("configure=1&from=automations");
+
+    activateCanvasVersionForEditing({
+      organizationId: "org-1",
+      canvasId: "canvas-1",
+      versionID: "version-live",
+      version: { metadata: { id: "version-live" }, spec: {} },
+      options: { preserveStagedLayer: true },
+      liveCanvasVersionId: "version-live",
+      queryClient: {
+        cancelQueries: vi.fn(),
+      } as never,
+      draftCanvasSpec: null,
+      draftCanvasSpecsRef: { current: new Map() },
+      activeCanvasVersionIdRef: { current: "" },
+      lastAppliedVersionSnapshotRef: { current: "" },
+      clearPendingAutoSaveWork: vi.fn(),
+      setDraftCanvasSpec: vi.fn(),
+      setActiveCanvasVersion: vi.fn(),
+      setLastSavedWorkflowSnapshot: vi.fn(),
+      setSearchParams,
+      initializeFromWorkflow: vi.fn(),
+    });
+
+    const updater = setSearchParams.mock.calls[0]?.[0] as (current: URLSearchParams) => URLSearchParams;
+    expect(updater(current)).toBe(current);
+  });
 });

--- a/web_src/src/pages/app/lib/canvas-version-activation.ts
+++ b/web_src/src/pages/app/lib/canvas-version-activation.ts
@@ -188,14 +188,18 @@ export function activateCanvasVersionForEditing({
   setLastSavedWorkflowSnapshot(null);
 
   setSearchParams((current) => {
-    const next = new URLSearchParams(current);
+    const next = clearRunInspectionSearchParams(new URLSearchParams(current));
     next.delete("branch");
     if (isCurrentLive) {
       next.delete("version");
     } else {
       next.set("version", versionID);
     }
-    return clearRunInspectionSearchParams(next);
+    // Same query string → keep current instance so React Router skips a no-op navigation.
+    if (next.toString() === current.toString()) {
+      return current;
+    }
+    return next;
   });
 
   if (!preserveStagedLayer) {

--- a/web_src/src/pages/app/useActivateCanvasVersionForEditing.ts
+++ b/web_src/src/pages/app/useActivateCanvasVersionForEditing.ts
@@ -1,0 +1,93 @@
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import type { QueryClient } from "@tanstack/react-query";
+import { useCallback, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import type { SetURLSearchParams } from "react-router-dom";
+
+import { activateCanvasVersionForEditing as applyCanvasVersionForEditing } from "./lib/canvas-version-activation";
+
+type UseActivateCanvasVersionForEditingOptions = {
+  organizationId?: string;
+  canvasId?: string;
+  liveCanvasVersionId?: string;
+  queryClient: QueryClient;
+  draftCanvasSpec: CanvasesCanvas["spec"] | null;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"] | null>>;
+  activeCanvasVersionIdRef: MutableRefObject<string>;
+  lastAppliedVersionSnapshotRef: MutableRefObject<string>;
+  liveCanvasVersion?: CanvasesCanvasVersion | null;
+  liveCanvas?: CanvasesCanvas | null;
+  clearPendingAutoSaveWork: () => void;
+  setDraftCanvasSpec: Dispatch<SetStateAction<CanvasesCanvas["spec"] | null>>;
+  setActiveCanvasVersion: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
+  setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
+  setSearchParams: SetURLSearchParams;
+  initializeFromWorkflow: (canvas: CanvasesCanvas) => void;
+};
+
+/**
+ * Stable activate helper — reads draftCanvasSpec via ref so Configure seeding
+ * does not recreate the callback and re-trigger enter effects.
+ */
+export function useActivateCanvasVersionForEditing({
+  organizationId,
+  canvasId,
+  liveCanvasVersionId,
+  queryClient,
+  draftCanvasSpec,
+  draftCanvasSpecsRef,
+  activeCanvasVersionIdRef,
+  lastAppliedVersionSnapshotRef,
+  liveCanvasVersion,
+  liveCanvas,
+  clearPendingAutoSaveWork,
+  setDraftCanvasSpec,
+  setActiveCanvasVersion,
+  setLastSavedWorkflowSnapshot,
+  setSearchParams,
+  initializeFromWorkflow,
+}: UseActivateCanvasVersionForEditingOptions) {
+  const draftCanvasSpecRef = useRef(draftCanvasSpec);
+  draftCanvasSpecRef.current = draftCanvasSpec;
+
+  return useCallback(
+    (versionID: string, version: CanvasesCanvasVersion, options?: { preserveStagedLayer?: boolean }) =>
+      applyCanvasVersionForEditing({
+        organizationId,
+        canvasId,
+        versionID,
+        version,
+        options,
+        liveCanvasVersionId,
+        queryClient,
+        draftCanvasSpec: draftCanvasSpecRef.current,
+        draftCanvasSpecsRef,
+        activeCanvasVersionIdRef,
+        lastAppliedVersionSnapshotRef,
+        liveCanvasVersion: liveCanvasVersion ?? undefined,
+        liveCanvas,
+        clearPendingAutoSaveWork,
+        setDraftCanvasSpec,
+        setActiveCanvasVersion,
+        setLastSavedWorkflowSnapshot,
+        setSearchParams,
+        initializeFromWorkflow,
+      }),
+    [
+      organizationId,
+      canvasId,
+      liveCanvasVersionId,
+      queryClient,
+      draftCanvasSpecsRef,
+      activeCanvasVersionIdRef,
+      lastAppliedVersionSnapshotRef,
+      liveCanvasVersion,
+      liveCanvas,
+      clearPendingAutoSaveWork,
+      setDraftCanvasSpec,
+      setActiveCanvasVersion,
+      setLastSavedWorkflowSnapshot,
+      setSearchParams,
+      initializeFromWorkflow,
+    ],
+  );
+}

--- a/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
@@ -83,10 +83,11 @@ describe("useFactoryConfigureEnter", () => {
     expect(resyncStagedEditorState).toHaveBeenCalledTimes(1);
 
     await act(async () => {
+      // New liveCanvas object identity (as after setQueryData), same shape.
       rerender({
         liveCanvas: {
           metadata: { id: "canvas-1", liveVersionId: "version-live" },
-          spec: { nodes: [{ name: "n1" }], edges: [] },
+          spec: { nodes: [], edges: [] },
         },
       });
     });

--- a/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
@@ -126,4 +126,38 @@ describe("useFactoryConfigureEnter", () => {
 
     expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(2);
   });
+
+  it("does not re-enter Configure when editSessionActive clears during save exit", async () => {
+    const activateCanvasVersionForEditing = vi.fn();
+    const setEditSessionActive = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ editSessionActive, factoryConfigure }: { editSessionActive: boolean; factoryConfigure: boolean }) =>
+        useFactoryConfigureEnter(
+          baseOptions({
+            editSessionActive,
+            factoryConfigure,
+            activateCanvasVersionForEditing,
+            setEditSessionActive,
+          }),
+        ),
+      { initialProps: { editSessionActive: false, factoryConfigure: true } },
+    );
+
+    await waitFor(() => {
+      expect(setEditSessionActive).toHaveBeenCalledWith(true);
+    });
+    expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender({ editSessionActive: true, factoryConfigure: true });
+    });
+    // Save path: flushSync clears edit while configure=1 still present.
+    await act(async () => {
+      rerender({ editSessionActive: false, factoryConfigure: true });
+    });
+
+    expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(1);
+    expect(setEditSessionActive).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useFactoryConfigureEnter } from "./useFactoryConfigureEnter";
+
+describe("useFactoryConfigureEnter", () => {
+  it("does not re-enter Configure when activateCanvasVersionForEditing identity changes before edit is enabled", async () => {
+    const activateCanvasVersionForEditing = vi.fn();
+    const setDraftCanvasSpec = vi.fn();
+    const setEditSessionActive = vi.fn();
+    const resyncStagedEditorState = vi.fn(() => new Promise<void>(() => {}));
+
+    const { rerender } = renderHook(
+      ({ activate }: { activate: typeof activateCanvasVersionForEditing }) =>
+        useFactoryConfigureEnter({
+          factoryConfigure: true,
+          editSessionActive: false,
+          setEditSessionActive,
+          canStageCanvasVersion: true,
+          canvasLoading: false,
+          liveCanvasVersionLoading: false,
+          liveCanvasVersionId: "version-live",
+          liveCanvasVersion: { metadata: { id: "version-live" }, spec: { nodes: [], edges: [] } },
+          liveCanvas: { metadata: { id: "canvas-1", liveVersionId: "version-live" }, spec: { nodes: [], edges: [] } },
+          previewingCurrentVersionRef: { current: false },
+          activateCanvasVersionForEditing: activate,
+          draftCanvasSpecsRef: { current: new Map() },
+          setDraftCanvasSpec,
+          resyncStagedEditorState,
+          setLastSavedWorkflowSnapshot: vi.fn(),
+        }),
+      { initialProps: { activate: activateCanvasVersionForEditing } },
+    );
+
+    expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(1);
+
+    const nextActivate = vi.fn();
+    await act(async () => {
+      rerender({ activate: nextActivate });
+    });
+
+    expect(nextActivate).not.toHaveBeenCalled();
+    expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a fresh Configure enter after leaving configure mode", async () => {
+    const activateCanvasVersionForEditing = vi.fn();
+    const resyncStagedEditorState = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = renderHook(
+      ({ factoryConfigure }: { factoryConfigure: boolean }) =>
+        useFactoryConfigureEnter({
+          factoryConfigure,
+          editSessionActive: false,
+          setEditSessionActive: vi.fn(),
+          canStageCanvasVersion: true,
+          canvasLoading: false,
+          liveCanvasVersionLoading: false,
+          liveCanvasVersionId: "version-live",
+          liveCanvasVersion: { metadata: { id: "version-live" }, spec: { nodes: [], edges: [] } },
+          liveCanvas: { metadata: { id: "canvas-1", liveVersionId: "version-live" }, spec: { nodes: [], edges: [] } },
+          previewingCurrentVersionRef: { current: false },
+          activateCanvasVersionForEditing,
+          draftCanvasSpecsRef: { current: new Map() },
+          setDraftCanvasSpec: vi.fn(),
+          resyncStagedEditorState,
+          setLastSavedWorkflowSnapshot: vi.fn(),
+        }),
+      { initialProps: { factoryConfigure: true } },
+    );
+
+    expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender({ factoryConfigure: false });
+    });
+    await act(async () => {
+      rerender({ factoryConfigure: true });
+    });
+
+    expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.spec.ts
@@ -1,34 +1,42 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { useFactoryConfigureEnter } from "./useFactoryConfigureEnter";
 
+function baseOptions(overrides: Partial<Parameters<typeof useFactoryConfigureEnter>[0]> = {}) {
+  return {
+    factoryConfigure: true,
+    editSessionActive: false,
+    setEditSessionActive: vi.fn(),
+    canStageCanvasVersion: true,
+    canvasLoading: false,
+    liveCanvasVersionLoading: false,
+    liveCanvasVersionId: "version-live",
+    liveCanvasVersion: { metadata: { id: "version-live" }, spec: { nodes: [], edges: [] } },
+    liveCanvas: { metadata: { id: "canvas-1", liveVersionId: "version-live" }, spec: { nodes: [], edges: [] } },
+    previewingCurrentVersionRef: { current: false },
+    activateCanvasVersionForEditing: vi.fn(),
+    draftCanvasSpecsRef: { current: new Map() },
+    setDraftCanvasSpec: vi.fn(),
+    resyncStagedEditorState: vi.fn().mockResolvedValue(undefined),
+    setLastSavedWorkflowSnapshot: vi.fn(),
+    ...overrides,
+  };
+}
+
 describe("useFactoryConfigureEnter", () => {
   it("does not re-enter Configure when activateCanvasVersionForEditing identity changes before edit is enabled", async () => {
     const activateCanvasVersionForEditing = vi.fn();
-    const setDraftCanvasSpec = vi.fn();
-    const setEditSessionActive = vi.fn();
     const resyncStagedEditorState = vi.fn(() => new Promise<void>(() => {}));
 
     const { rerender } = renderHook(
       ({ activate }: { activate: typeof activateCanvasVersionForEditing }) =>
-        useFactoryConfigureEnter({
-          factoryConfigure: true,
-          editSessionActive: false,
-          setEditSessionActive,
-          canStageCanvasVersion: true,
-          canvasLoading: false,
-          liveCanvasVersionLoading: false,
-          liveCanvasVersionId: "version-live",
-          liveCanvasVersion: { metadata: { id: "version-live" }, spec: { nodes: [], edges: [] } },
-          liveCanvas: { metadata: { id: "canvas-1", liveVersionId: "version-live" }, spec: { nodes: [], edges: [] } },
-          previewingCurrentVersionRef: { current: false },
-          activateCanvasVersionForEditing: activate,
-          draftCanvasSpecsRef: { current: new Map() },
-          setDraftCanvasSpec,
-          resyncStagedEditorState,
-          setLastSavedWorkflowSnapshot: vi.fn(),
-        }),
+        useFactoryConfigureEnter(
+          baseOptions({
+            activateCanvasVersionForEditing: activate,
+            resyncStagedEditorState,
+          }),
+        ),
       { initialProps: { activate: activateCanvasVersionForEditing } },
     );
 
@@ -43,29 +51,67 @@ describe("useFactoryConfigureEnter", () => {
     expect(activateCanvasVersionForEditing).toHaveBeenCalledTimes(1);
   });
 
+  it("does not cancel Configure enter when liveCanvas identity changes mid-resync", async () => {
+    const setEditSessionActive = vi.fn();
+    let resolveResync!: () => void;
+    const resyncStagedEditorState = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveResync = resolve;
+        }),
+    );
+
+    const { rerender } = renderHook(
+      ({ liveCanvas }: { liveCanvas: NonNullable<Parameters<typeof useFactoryConfigureEnter>[0]["liveCanvas"]> }) =>
+        useFactoryConfigureEnter(
+          baseOptions({
+            liveCanvas,
+            setEditSessionActive,
+            resyncStagedEditorState,
+          }),
+        ),
+      {
+        initialProps: {
+          liveCanvas: {
+            metadata: { id: "canvas-1", liveVersionId: "version-live" },
+            spec: { nodes: [], edges: [] },
+          },
+        },
+      },
+    );
+
+    expect(resyncStagedEditorState).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender({
+        liveCanvas: {
+          metadata: { id: "canvas-1", liveVersionId: "version-live" },
+          spec: { nodes: [{ name: "n1" }], edges: [] },
+        },
+      });
+    });
+
+    await act(async () => {
+      resolveResync();
+    });
+
+    await waitFor(() => {
+      expect(setEditSessionActive).toHaveBeenCalledWith(true);
+    });
+    expect(resyncStagedEditorState).toHaveBeenCalledTimes(1);
+  });
+
   it("allows a fresh Configure enter after leaving configure mode", async () => {
     const activateCanvasVersionForEditing = vi.fn();
-    const resyncStagedEditorState = vi.fn().mockResolvedValue(undefined);
 
     const { rerender } = renderHook(
       ({ factoryConfigure }: { factoryConfigure: boolean }) =>
-        useFactoryConfigureEnter({
-          factoryConfigure,
-          editSessionActive: false,
-          setEditSessionActive: vi.fn(),
-          canStageCanvasVersion: true,
-          canvasLoading: false,
-          liveCanvasVersionLoading: false,
-          liveCanvasVersionId: "version-live",
-          liveCanvasVersion: { metadata: { id: "version-live" }, spec: { nodes: [], edges: [] } },
-          liveCanvas: { metadata: { id: "canvas-1", liveVersionId: "version-live" }, spec: { nodes: [], edges: [] } },
-          previewingCurrentVersionRef: { current: false },
-          activateCanvasVersionForEditing,
-          draftCanvasSpecsRef: { current: new Map() },
-          setDraftCanvasSpec: vi.fn(),
-          resyncStagedEditorState,
-          setLastSavedWorkflowSnapshot: vi.fn(),
-        }),
+        useFactoryConfigureEnter(
+          baseOptions({
+            factoryConfigure,
+            activateCanvasVersionForEditing,
+          }),
+        ),
       { initialProps: { factoryConfigure: true } },
     );
 

--- a/web_src/src/pages/app/useFactoryConfigureEnter.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.ts
@@ -1,6 +1,8 @@
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { useEffect, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 
+import { startFactoryConfigureEnter, type FactoryConfigureEnterDeps } from "./factoryConfigureEnterSession";
+
 type UseFactoryConfigureEnterOptions = {
   factoryConfigure: boolean;
   editSessionActive: boolean;
@@ -12,17 +14,10 @@ type UseFactoryConfigureEnterOptions = {
   liveCanvasVersion?: CanvasesCanvasVersion | null;
   liveCanvas?: CanvasesCanvas | null;
   previewingCurrentVersionRef: MutableRefObject<boolean>;
-  activateCanvasVersionForEditing: (
-    versionId: string,
-    version: CanvasesCanvasVersion,
-    options?: { preserveStagedLayer?: boolean },
-  ) => void;
+  activateCanvasVersionForEditing: FactoryConfigureEnterDeps["activateCanvasVersionForEditing"];
   draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"] | null>>;
   setDraftCanvasSpec: Dispatch<SetStateAction<CanvasesCanvas["spec"] | null>>;
-  resyncStagedEditorState: (
-    versionId: string,
-    options?: { bumpResetNonce?: boolean; preferCachedStagedSpec?: boolean },
-  ) => Promise<void>;
+  resyncStagedEditorState: FactoryConfigureEnterDeps["resyncStagedEditorState"];
   setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
 };
 
@@ -51,7 +46,7 @@ export function useFactoryConfigureEnter({
   liveCanvasRef.current = liveCanvas;
   const liveCanvasVersionRef = useRef(liveCanvasVersion);
   liveCanvasVersionRef.current = liveCanvasVersion;
-  const enterDepsRef = useRef({
+  const enterDepsRef = useRef<FactoryConfigureEnterDeps>({
     activateCanvasVersionForEditing,
     draftCanvasSpecsRef,
     previewingCurrentVersionRef,
@@ -110,62 +105,16 @@ export function useFactoryConfigureEnter({
     }
 
     inFlightVisitIdRef.current = visitId;
-    // Seed draft from the live version directly — do not wait on the versions
-    // list (handleUseVersion), which often left Configure with no activeVersionId.
-    const immediateSpec = liveCanvasRef.current?.spec ?? version.spec ?? { nodes: [], edges: [] };
-    const versionForEdit: CanvasesCanvasVersion = {
-      ...version,
-      metadata: {
-        ...version.metadata,
-        id: liveCanvasVersionId,
-      },
-      spec: immediateSpec,
-    };
-    const configureVersionId = liveCanvasVersionId;
-    let cancelled = false;
-    const {
-      activateCanvasVersionForEditing: activate,
-      draftCanvasSpecsRef: specsRef,
-      previewingCurrentVersionRef: previewingRef,
-      resyncStagedEditorState: resync,
-      setDraftCanvasSpec: setDraft,
-      setEditSessionActive: setEditActive,
-      setLastSavedWorkflowSnapshot: setSnapshot,
-    } = enterDepsRef.current;
-
-    previewingRef.current = true;
-    activate(configureVersionId, versionForEdit, { preserveStagedLayer: true });
-    specsRef.current.set(configureVersionId, immediateSpec);
-    setDraft(immediateSpec);
-
-    // Await staged resync before enabling edit so a late applyStagedSpec cannot
-    // wipe edits typed against the immediate seed.
-    void (async () => {
-      try {
-        await resync(configureVersionId, { bumpResetNonce: false });
-      } catch {
-        // Keep the immediate live/committed spec so Configure stays usable.
-      }
-      if (cancelled || configureVisitIdRef.current !== visitId) {
-        return;
-      }
-      editEnabledVisitIdRef.current = visitId;
-      inFlightVisitIdRef.current = null;
-      setEditActive(true);
-      const canvas = liveCanvasRef.current;
-      if (canvas) {
-        const spec = specsRef.current.get(configureVersionId) ?? immediateSpec;
-        setSnapshot({ ...canvas, spec });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      // Strict Mode remount: allow retry only when edit never enabled for visit.
-      if (editEnabledVisitIdRef.current !== visitId && inFlightVisitIdRef.current === visitId) {
-        inFlightVisitIdRef.current = null;
-      }
-    };
+    return startFactoryConfigureEnter({
+      visitId,
+      configureVersionId: liveCanvasVersionId,
+      version,
+      liveCanvasRef,
+      configureVisitIdRef,
+      inFlightVisitIdRef,
+      editEnabledVisitIdRef,
+      deps: enterDepsRef.current,
+    });
   }, [
     canStageCanvasVersion,
     canvasLoading,

--- a/web_src/src/pages/app/useFactoryConfigureEnter.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.ts
@@ -45,10 +45,35 @@ export function useFactoryConfigureEnter({
   setLastSavedWorkflowSnapshot,
 }: UseFactoryConfigureEnterOptions) {
   const factoryConfigureEnterStartedRef = useRef(false);
+  // Keep latest callbacks/refs so enter effect does not re-fire when their
+  // identities churn after setDraftCanvasSpec / version activation.
+  const enterDepsRef = useRef({
+    activateCanvasVersionForEditing,
+    draftCanvasSpecsRef,
+    previewingCurrentVersionRef,
+    resyncStagedEditorState,
+    setDraftCanvasSpec,
+    setEditSessionActive,
+    setLastSavedWorkflowSnapshot,
+  });
+  enterDepsRef.current = {
+    activateCanvasVersionForEditing,
+    draftCanvasSpecsRef,
+    previewingCurrentVersionRef,
+    resyncStagedEditorState,
+    setDraftCanvasSpec,
+    setEditSessionActive,
+    setLastSavedWorkflowSnapshot,
+  };
 
   useEffect(() => {
     if (!factoryConfigure) {
       factoryConfigureEnterStartedRef.current = false;
+    }
+  }, [factoryConfigure]);
+
+  useEffect(() => {
+    if (!factoryConfigure) {
       return;
     }
     if (factoryConfigureEnterStartedRef.current || editSessionActive) {
@@ -75,53 +100,53 @@ export function useFactoryConfigureEnter({
     };
     const configureVersionId = liveCanvasVersionId;
     let cancelled = false;
-    let editEnabled = false;
+    const {
+      activateCanvasVersionForEditing: activate,
+      draftCanvasSpecsRef: specsRef,
+      previewingCurrentVersionRef: previewingRef,
+      resyncStagedEditorState: resync,
+      setDraftCanvasSpec: setDraft,
+      setEditSessionActive: setEditActive,
+      setLastSavedWorkflowSnapshot: setSnapshot,
+    } = enterDepsRef.current;
 
-    previewingCurrentVersionRef.current = true;
-    activateCanvasVersionForEditing(configureVersionId, versionForEdit, { preserveStagedLayer: true });
-    draftCanvasSpecsRef.current.set(configureVersionId, immediateSpec);
-    setDraftCanvasSpec(immediateSpec);
+    previewingRef.current = true;
+    activate(configureVersionId, versionForEdit, { preserveStagedLayer: true });
+    specsRef.current.set(configureVersionId, immediateSpec);
+    setDraft(immediateSpec);
 
     // Await staged resync before enabling edit so a late applyStagedSpec cannot
     // wipe edits typed against the immediate seed.
     void (async () => {
       try {
-        await resyncStagedEditorState(configureVersionId, { bumpResetNonce: false });
+        await resync(configureVersionId, { bumpResetNonce: false });
       } catch {
         // Keep the immediate live/committed spec so Configure stays usable.
       }
       if (cancelled) {
         return;
       }
-      editEnabled = true;
-      setEditSessionActive(true);
+      setEditActive(true);
       if (liveCanvas) {
-        const spec = draftCanvasSpecsRef.current.get(configureVersionId) ?? immediateSpec;
-        setLastSavedWorkflowSnapshot({ ...liveCanvas, spec });
+        const spec = specsRef.current.get(configureVersionId) ?? immediateSpec;
+        setSnapshot({ ...liveCanvas, spec });
       }
     })();
 
     return () => {
+      // Cancel in-flight resync only. Do NOT reset enterStarted here — unstable
+      // callback identity (e.g. activateCanvasVersionForEditing after setDraft)
+      // would re-enter Configure and spam setSearchParams / ReactFlow setEdges.
       cancelled = true;
-      if (!editEnabled) {
-        factoryConfigureEnterStartedRef.current = false;
-      }
     };
   }, [
-    activateCanvasVersionForEditing,
     canStageCanvasVersion,
     canvasLoading,
-    draftCanvasSpecsRef,
     editSessionActive,
     factoryConfigure,
     liveCanvas,
     liveCanvasVersion,
     liveCanvasVersionId,
     liveCanvasVersionLoading,
-    previewingCurrentVersionRef,
-    resyncStagedEditorState,
-    setDraftCanvasSpec,
-    setEditSessionActive,
-    setLastSavedWorkflowSnapshot,
   ]);
 }

--- a/web_src/src/pages/app/useFactoryConfigureEnter.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.ts
@@ -70,6 +70,22 @@ export function useFactoryConfigureEnter({
     setLastSavedWorkflowSnapshot,
   };
 
+  // Per Configure visit: bump when leaving so a later visit can seed again.
+  // Once edit enables for a visit, save/exit must not re-seed while URL still
+  // has configure=1 (handleCommittedVersionId clears editSessionActive first).
+  const configureVisitIdRef = useRef(0);
+  const inFlightVisitIdRef = useRef<number | null>(null);
+  const editEnabledVisitIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (factoryConfigure) {
+      return;
+    }
+    configureVisitIdRef.current += 1;
+    inFlightVisitIdRef.current = null;
+    editEnabledVisitIdRef.current = null;
+  }, [factoryConfigure]);
+
   useEffect(() => {
     if (!factoryConfigure || editSessionActive) {
       return;
@@ -81,11 +97,19 @@ export function useFactoryConfigureEnter({
       return;
     }
 
+    const visitId = configureVisitIdRef.current;
+    // Save/discard can clear editSessionActive while configure=1 is still set.
+    // Never re-seed that same Configure visit.
+    if (editEnabledVisitIdRef.current === visitId || inFlightVisitIdRef.current === visitId) {
+      return;
+    }
+
     const version = liveCanvasVersionRef.current;
     if (!version) {
       return;
     }
 
+    inFlightVisitIdRef.current = visitId;
     // Seed draft from the live version directly — do not wait on the versions
     // list (handleUseVersion), which often left Configure with no activeVersionId.
     const immediateSpec = liveCanvasRef.current?.spec ?? version.spec ?? { nodes: [], edges: [] };
@@ -122,9 +146,11 @@ export function useFactoryConfigureEnter({
       } catch {
         // Keep the immediate live/committed spec so Configure stays usable.
       }
-      if (cancelled) {
+      if (cancelled || configureVisitIdRef.current !== visitId) {
         return;
       }
+      editEnabledVisitIdRef.current = visitId;
+      inFlightVisitIdRef.current = null;
       setEditActive(true);
       const canvas = liveCanvasRef.current;
       if (canvas) {
@@ -135,6 +161,10 @@ export function useFactoryConfigureEnter({
 
     return () => {
       cancelled = true;
+      // Strict Mode remount: allow retry only when edit never enabled for visit.
+      if (editEnabledVisitIdRef.current !== visitId && inFlightVisitIdRef.current === visitId) {
+        inFlightVisitIdRef.current = null;
+      }
     };
   }, [
     canStageCanvasVersion,

--- a/web_src/src/pages/app/useFactoryConfigureEnter.ts
+++ b/web_src/src/pages/app/useFactoryConfigureEnter.ts
@@ -44,9 +44,13 @@ export function useFactoryConfigureEnter({
   resyncStagedEditorState,
   setLastSavedWorkflowSnapshot,
 }: UseFactoryConfigureEnterOptions) {
-  const factoryConfigureEnterStartedRef = useRef(false);
-  // Keep latest callbacks/refs so enter effect does not re-fire when their
-  // identities churn after setDraftCanvasSpec / version activation.
+  // Latest values via refs so the enter effect deps stay stable. Unstable
+  // callback/query identities must not re-fire enter (update-depth loop), and
+  // resync setQueryData must not cancel the in-flight path before edit enables.
+  const liveCanvasRef = useRef(liveCanvas);
+  liveCanvasRef.current = liveCanvas;
+  const liveCanvasVersionRef = useRef(liveCanvasVersion);
+  liveCanvasVersionRef.current = liveCanvasVersion;
   const enterDepsRef = useRef({
     activateCanvasVersionForEditing,
     draftCanvasSpecsRef,
@@ -67,33 +71,28 @@ export function useFactoryConfigureEnter({
   };
 
   useEffect(() => {
-    if (!factoryConfigure) {
-      factoryConfigureEnterStartedRef.current = false;
-    }
-  }, [factoryConfigure]);
-
-  useEffect(() => {
-    if (!factoryConfigure) {
+    if (!factoryConfigure || editSessionActive) {
       return;
     }
-    if (factoryConfigureEnterStartedRef.current || editSessionActive) {
-      return;
-    }
-    if (!canStageCanvasVersion || !liveCanvasVersionId || !liveCanvasVersion) {
+    if (!canStageCanvasVersion || !liveCanvasVersionId) {
       return;
     }
     if (canvasLoading || liveCanvasVersionLoading) {
       return;
     }
 
-    factoryConfigureEnterStartedRef.current = true;
+    const version = liveCanvasVersionRef.current;
+    if (!version) {
+      return;
+    }
+
     // Seed draft from the live version directly — do not wait on the versions
     // list (handleUseVersion), which often left Configure with no activeVersionId.
-    const immediateSpec = liveCanvas?.spec ?? liveCanvasVersion.spec ?? { nodes: [], edges: [] };
+    const immediateSpec = liveCanvasRef.current?.spec ?? version.spec ?? { nodes: [], edges: [] };
     const versionForEdit: CanvasesCanvasVersion = {
-      ...liveCanvasVersion,
+      ...version,
       metadata: {
-        ...liveCanvasVersion.metadata,
+        ...version.metadata,
         id: liveCanvasVersionId,
       },
       spec: immediateSpec,
@@ -127,16 +126,14 @@ export function useFactoryConfigureEnter({
         return;
       }
       setEditActive(true);
-      if (liveCanvas) {
+      const canvas = liveCanvasRef.current;
+      if (canvas) {
         const spec = specsRef.current.get(configureVersionId) ?? immediateSpec;
-        setSnapshot({ ...liveCanvas, spec });
+        setSnapshot({ ...canvas, spec });
       }
     })();
 
     return () => {
-      // Cancel in-flight resync only. Do NOT reset enterStarted here — unstable
-      // callback identity (e.g. activateCanvasVersionForEditing after setDraft)
-      // would re-enter Configure and spam setSearchParams / ReactFlow setEdges.
       cancelled = true;
     };
   }, [
@@ -144,8 +141,6 @@ export function useFactoryConfigureEnter({
     canvasLoading,
     editSessionActive,
     factoryConfigure,
-    liveCanvas,
-    liveCanvasVersion,
     liveCanvasVersionId,
     liveCanvasVersionLoading,
   ]);


### PR DESCRIPTION
## Summary
- Fixes production `Maximum update depth exceeded` on factory Configure (`?configure=1&from=automations`) — Sentry PRODUCTION-8S / #7667542012
- `useFactoryConfigureEnter` no longer resets its enter guard on effect cleanup when unstable callback identities change mid-enter
- `activateCanvasVersionForEditing` reads `draftCanvasSpec` from a ref so seeding draft does not recreate the callback
- Version activation `setSearchParams` returns the current instance when the query string is unchanged (avoids no-op navigation spam)

## Test plan
- [x] `vitest` `useFactoryConfigureEnter.spec.ts` + `canvas-version-activation.spec.ts`
- [x] Open a factory automation Configure URL (`?configure=1&from=automations`) and confirm canvas loads without freeze / React #185
- [x] Leave Configure and re-enter — session still seeds correctly
- [x] Non-factory app edit/version switch still clears run params as before


Made with [Cursor](https://cursor.com)