### PR TITLE
fix: show one Lines board card per work order

### DIFF
--- a/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
@@ -12,8 +12,12 @@ function order(id: string, title: string, executions: FactoriesWorkOrder["execut
   return { id, title, state: "STATE_OPEN", executions };
 }
 
+function workOrderIds(board: ReturnType<typeof buildLinePhaseBoard>): string[] {
+  return board.flatMap((column) => column.runs.map((run) => run.workOrderId));
+}
+
 describe("buildLinePhaseBoard", () => {
-  it("returns one column per step with all runs newest first", () => {
+  it("returns one column per step with current-step cards newest first", () => {
     const orders: FactoriesWorkOrder[] = [
       order("wo-a", "Alpha", [
         {
@@ -79,6 +83,88 @@ describe("buildLinePhaseBoard", () => {
     expect(board[1].runs).toEqual([]);
     expect(board[1].tick).toBeNull();
     expect(board[2].runs).toEqual([]);
+    expect(workOrderIds(board)).toEqual(["wo-b", "wo-c", "wo-a", "wo-d"]);
+  });
+
+  it("places a multi-step work order only in its furthest active step", () => {
+    const orders = [
+      order("wo-progress", "Progressing", [
+        {
+          id: "e-plan",
+          line: { id: "line-1", name: "poc" },
+          step: "plan",
+          state: "STATE_FINISHED",
+          result: "RESULT_PASSED",
+          createdAt: "2026-08-11T10:00:00.000Z",
+          updatedAt: "2026-08-11T10:00:00.000Z",
+        },
+        {
+          id: "e-build",
+          line: { id: "line-1", name: "poc" },
+          step: "build",
+          state: "STATE_FINISHED",
+          result: "RESULT_PASSED",
+          createdAt: "2026-08-11T11:00:00.000Z",
+          updatedAt: "2026-08-11T11:00:00.000Z",
+        },
+        {
+          id: "e-demo",
+          line: { id: "line-1", name: "poc" },
+          step: "demo",
+          state: "STATE_STARTED",
+          createdAt: "2026-08-11T12:00:00.000Z",
+          updatedAt: "2026-08-11T12:30:00.000Z",
+        },
+      ]),
+    ];
+
+    const board = buildLinePhaseBoard(LINE, orders);
+
+    expect(board[0].runs).toEqual([]);
+    expect(board[1].runs).toEqual([]);
+    expect(board[2].runs).toHaveLength(1);
+    expect(board[2].runs[0]).toMatchObject({
+      workOrderId: "wo-progress",
+      title: "Progressing",
+      executionId: "e-demo",
+    });
+    expect(board[2].tick).toBe("running");
+    expect(workOrderIds(board)).toEqual(["wo-progress"]);
+  });
+
+  it("places a failed mid-line work order only on the failed step", () => {
+    const orders = [
+      order("wo-fail", "Failing", [
+        {
+          id: "e-plan",
+          line: { id: "line-1", name: "poc" },
+          step: "plan",
+          state: "STATE_FINISHED",
+          result: "RESULT_PASSED",
+          createdAt: "2026-08-11T09:00:00.000Z",
+          updatedAt: "2026-08-11T09:00:00.000Z",
+        },
+        {
+          id: "e-fail",
+          line: { id: "line-1", name: "poc" },
+          step: "build",
+          state: "STATE_FINISHED",
+          result: "RESULT_FAILED",
+          createdAt: "2026-08-11T10:00:00.000Z",
+          updatedAt: "2026-08-11T10:00:00.000Z",
+        },
+      ]),
+    ];
+
+    const board = buildLinePhaseBoard(LINE, orders);
+
+    expect(board[0].runs).toEqual([]);
+    expect(board[1].runs).toHaveLength(1);
+    expect(board[1].runs[0]).toMatchObject({ workOrderId: "wo-fail", executionId: "e-fail" });
+    expect(resolvePhaseRunStatus(board[1].runs[0].execution)).toEqual({ kind: "failed", label: "Failed" });
+    expect(board[1].tick).toBeNull();
+    expect(board[2].runs).toEqual([]);
+    expect(workOrderIds(board)).toEqual(["wo-fail"]);
   });
 
   it("includes the step app id for configure navigation", () => {

--- a/web_src/src/pages/factories/lib/linePhaseRuns.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.ts
@@ -91,43 +91,71 @@ function collectCurrentRunsByStep(
   }
 
   const runsByStep = new Map<string, LinePhaseRunCard[]>();
-
   for (const order of workOrders) {
-    if (!order.id) {
-      continue;
-    }
-
-    const lineExecutions = (order.executions ?? []).filter(
-      (execution) => execution.line?.id === lineId && Boolean(execution.step) && stepIndexByName.has(execution.step!),
-    );
-    if (lineExecutions.length === 0) {
-      continue;
-    }
-
-    const currentExecution = pickCurrentLineExecution(lineExecutions, stepIndexByName);
-    if (!currentExecution?.step) {
-      continue;
-    }
-
-    const card: LinePhaseRunCard = {
-      executionId: currentExecution.id ?? `${order.id}-${currentExecution.step}-${currentExecution.createdAt ?? ""}`,
-      workOrderId: order.id,
-      title: order.title?.trim() || "Untitled work order",
-      execution: currentExecution,
-    };
-    const existing = runsByStep.get(currentExecution.step);
-    if (existing) {
-      existing.push(card);
-    } else {
-      runsByStep.set(currentExecution.step, [card]);
-    }
+    appendCurrentRunForOrder(order, lineId, stepIndexByName, runsByStep);
   }
-
   for (const runs of runsByStep.values()) {
     runs.sort(compareRunsNewestFirst);
   }
-
   return runsByStep;
+}
+
+function appendCurrentRunForOrder(
+  order: FactoriesWorkOrder,
+  lineId: string,
+  stepIndexByName: Map<string, number>,
+  runsByStep: Map<string, LinePhaseRunCard[]>,
+): void {
+  if (!order.id) {
+    return;
+  }
+
+  const lineExecutions = (order.executions ?? []).filter(
+    (execution) => execution.line?.id === lineId && execution.step != null && stepIndexByName.has(execution.step),
+  );
+  if (lineExecutions.length === 0) {
+    return;
+  }
+
+  const currentExecution = pickCurrentLineExecution(lineExecutions, stepIndexByName);
+  if (!currentExecution?.step) {
+    return;
+  }
+
+  const card: LinePhaseRunCard = {
+    executionId: currentExecution.id ?? `${order.id}-${currentExecution.step}-${currentExecution.createdAt ?? ""}`,
+    workOrderId: order.id,
+    title: order.title?.trim() || "Untitled work order",
+    execution: currentExecution,
+  };
+  const existing = runsByStep.get(currentExecution.step);
+  if (existing) {
+    existing.push(card);
+    return;
+  }
+  runsByStep.set(currentExecution.step, [card]);
+}
+
+function executionTimestamp(execution: FactoriesWorkOrderExecution): number {
+  return Date.parse(execution.updatedAt ?? execution.createdAt ?? "") || 0;
+}
+
+function isPreferableCurrentExecution(
+  candidate: FactoriesWorkOrderExecution,
+  incumbent: FactoriesWorkOrderExecution,
+  stepIndexByName: Map<string, number>,
+): boolean {
+  const candidateStep = stepIndexByName.get(candidate.step ?? "") ?? -1;
+  const incumbentStep = stepIndexByName.get(incumbent.step ?? "") ?? -1;
+  if (candidateStep !== incumbentStep) {
+    return candidateStep > incumbentStep;
+  }
+  const candidateTime = executionTimestamp(candidate);
+  const incumbentTime = executionTimestamp(incumbent);
+  if (candidateTime !== incumbentTime) {
+    return candidateTime > incumbentTime;
+  }
+  return (candidate.id ?? "") > (incumbent.id ?? "");
 }
 
 function pickCurrentLineExecution(
@@ -137,24 +165,14 @@ function pickCurrentLineExecution(
   const active = executions.filter(isActiveWorkOrderExecution);
   const candidates = active.length > 0 ? active : executions;
   let best: FactoriesWorkOrderExecution | null = null;
-  let bestStepIndex = -1;
-  let bestTime = -1;
 
   for (const execution of candidates) {
     const stepIndex = stepIndexByName.get(execution.step ?? "") ?? -1;
     if (stepIndex < 0) {
       continue;
     }
-    const time = Date.parse(execution.updatedAt ?? execution.createdAt ?? "") || 0;
-    if (
-      !best ||
-      stepIndex > bestStepIndex ||
-      (stepIndex === bestStepIndex && time > bestTime) ||
-      (stepIndex === bestStepIndex && time === bestTime && (execution.id ?? "") > (best.id ?? ""))
-    ) {
+    if (!best || isPreferableCurrentExecution(execution, best, stepIndexByName)) {
       best = execution;
-      bestStepIndex = stepIndex;
-      bestTime = time;
     }
   }
 

--- a/web_src/src/pages/factories/lib/linePhaseRuns.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.ts
@@ -23,9 +23,9 @@ export type LinePhaseColumn = {
 export const LINE_PHASE_RUNS_PAGE_SIZE = 3;
 
 /**
- * Builds the Lines detail board: one column per line step, each with every
- * canvas-run execution for that step (matched by line id + step name), newest
- * first. The detail UI pages these into a scrollable column.
+ * Builds the Lines detail board: one column per line step. Each work order
+ * appears once, in the column for its current (furthest active, else furthest
+ * finished) step on this line — newest cards first within a column.
  */
 export function buildLinePhaseBoard(line: FactoriesFactoryLine, workOrders: FactoriesWorkOrder[]): LinePhaseColumn[] {
   const lineId = line.id;
@@ -34,7 +34,7 @@ export function buildLinePhaseBoard(line: FactoriesFactoryLine, workOrders: Fact
     return [];
   }
 
-  const runsByStep = collectRunsByStep(lineId, workOrders);
+  const runsByStep = collectCurrentRunsByStep(lineId, steps, workOrders);
 
   return steps.map((step, stepIndex) => {
     const stepName = step.name?.trim() || `Phase ${stepIndex + 1}`;
@@ -78,29 +78,48 @@ export function resolvePhaseRunStatus(execution: FactoriesWorkOrderExecution): {
   return { kind: "idle", label: "Unknown" };
 }
 
-function collectRunsByStep(lineId: string, workOrders: FactoriesWorkOrder[]): Map<string, LinePhaseRunCard[]> {
+function collectCurrentRunsByStep(
+  lineId: string,
+  steps: NonNullable<FactoriesFactoryLine["steps"]>,
+  workOrders: FactoriesWorkOrder[],
+): Map<string, LinePhaseRunCard[]> {
+  const stepIndexByName = new Map<string, number>();
+  for (const [index, step] of steps.entries()) {
+    if (step.name) {
+      stepIndexByName.set(step.name, index);
+    }
+  }
+
   const runsByStep = new Map<string, LinePhaseRunCard[]>();
 
   for (const order of workOrders) {
     if (!order.id) {
       continue;
     }
-    for (const execution of order.executions ?? []) {
-      if (execution.line?.id !== lineId || !execution.step) {
-        continue;
-      }
-      const card: LinePhaseRunCard = {
-        executionId: execution.id ?? `${order.id}-${execution.step}-${execution.createdAt ?? ""}`,
-        workOrderId: order.id,
-        title: order.title?.trim() || "Untitled work order",
-        execution,
-      };
-      const existing = runsByStep.get(execution.step);
-      if (existing) {
-        existing.push(card);
-      } else {
-        runsByStep.set(execution.step, [card]);
-      }
+
+    const lineExecutions = (order.executions ?? []).filter(
+      (execution) => execution.line?.id === lineId && Boolean(execution.step) && stepIndexByName.has(execution.step!),
+    );
+    if (lineExecutions.length === 0) {
+      continue;
+    }
+
+    const currentExecution = pickCurrentLineExecution(lineExecutions, stepIndexByName);
+    if (!currentExecution?.step) {
+      continue;
+    }
+
+    const card: LinePhaseRunCard = {
+      executionId: currentExecution.id ?? `${order.id}-${currentExecution.step}-${currentExecution.createdAt ?? ""}`,
+      workOrderId: order.id,
+      title: order.title?.trim() || "Untitled work order",
+      execution: currentExecution,
+    };
+    const existing = runsByStep.get(currentExecution.step);
+    if (existing) {
+      existing.push(card);
+    } else {
+      runsByStep.set(currentExecution.step, [card]);
     }
   }
 
@@ -109,6 +128,37 @@ function collectRunsByStep(lineId: string, workOrders: FactoriesWorkOrder[]): Ma
   }
 
   return runsByStep;
+}
+
+function pickCurrentLineExecution(
+  executions: FactoriesWorkOrderExecution[],
+  stepIndexByName: Map<string, number>,
+): FactoriesWorkOrderExecution | null {
+  const active = executions.filter(isActiveWorkOrderExecution);
+  const candidates = active.length > 0 ? active : executions;
+  let best: FactoriesWorkOrderExecution | null = null;
+  let bestStepIndex = -1;
+  let bestTime = -1;
+
+  for (const execution of candidates) {
+    const stepIndex = stepIndexByName.get(execution.step ?? "") ?? -1;
+    if (stepIndex < 0) {
+      continue;
+    }
+    const time = Date.parse(execution.updatedAt ?? execution.createdAt ?? "") || 0;
+    if (
+      !best ||
+      stepIndex > bestStepIndex ||
+      (stepIndex === bestStepIndex && time > bestTime) ||
+      (stepIndex === bestStepIndex && time === bestTime && (execution.id ?? "") > (best.id ?? ""))
+    ) {
+      best = execution;
+      bestStepIndex = stepIndex;
+      bestTime = time;
+    }
+  }
+
+  return best;
 }
 
 function compareRunsNewestFirst(left: LinePhaseRunCard, right: LinePhaseRunCard): number {


### PR DESCRIPTION
## Summary
- Lines phase board now places each work order once, in the column for its furthest current step (prefer active executions, else furthest finished).
- Passed/failed labels come from that single execution; phase ticks still aggregate only cards left in the column.
- Specs cover multi-step progress, mid-line failure, and unique `workOrderId` across the board.

## Test plan
- [x] `npx vitest run src/pages/factories/lib/linePhaseRuns.spec.ts` (in app container)
- [ ] Manual: Bugs (or any) line — each WO title appears once; progressing WOs only under their active phase


Made with [Cursor](https://cursor.com)