### PR TITLE
feat(web): Give lost pages a proper flight plan

### DIFF
--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -11,6 +11,7 @@ import "./App.css";
 // Import pages
 import AuthGuard from "./components/AuthGuard";
 import { GlobalCommandPalette } from "./components/GlobalCommandPalette";
+import { NotFoundPage } from "./components/NotFoundPage";
 import { RequireExperimentalFeature } from "./components/RequireExperimentalFeature";
 import { AccountProvider } from "./contexts/AccountProvider";
 import { ThemeProvider } from "./contexts/ThemeProvider";
@@ -215,7 +216,16 @@ function AppRouter() {
               </Route>
 
               {/* Catch-all route */}
-              <Route path="*" element={<Navigate to="/" />} />
+              <Route
+                path="*"
+                element={
+                  <NotFoundPage
+                    description="This plane has left the control plane."
+                    actionLabel="Return to the hangar"
+                    showFlightAnimation
+                  />
+                }
+              />
             </Routes>
           </SetupGuard>
         </div>

--- a/web_src/src/components/NotFoundPage.css
+++ b/web_src/src/components/NotFoundPage.css
@@ -1,0 +1,33 @@
+.not-found-page__plane {
+  animation: not-found-page-flight 5s ease-in-out infinite;
+  filter: drop-shadow(0 3px 4px rgb(15 23 42 / 0.16));
+  will-change: transform, opacity;
+}
+
+@keyframes not-found-page-flight {
+  0% {
+    opacity: 0;
+    transform: translate3d(-2rem, 0.8rem, 0) rotate(-8deg);
+  }
+
+  12%,
+  88% {
+    opacity: 1;
+  }
+
+  45% {
+    transform: translate3d(8.5rem, -1rem, 0) rotate(5deg);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(19rem, 0.25rem, 0) rotate(-5deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .not-found-page__plane {
+    animation: none;
+    transform: translate3d(8.5rem, -1rem, 0) rotate(5deg);
+  }
+}

--- a/web_src/src/components/NotFoundPage.spec.tsx
+++ b/web_src/src/components/NotFoundPage.spec.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NotFoundPage } from "./NotFoundPage";
+
+describe("NotFoundPage", () => {
+  it("renders the flight-themed missing page", () => {
+    render(
+      <NotFoundPage
+        description="This plane has left the control plane."
+        actionLabel="Return to the hangar"
+        showFlightAnimation
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "404" })).toBeInTheDocument();
+    expect(screen.getByText("This plane has left the control plane.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Return to the SuperPlane home page" })).toHaveAttribute("href", "/");
+    expect(screen.getByTestId("flight-path-illustration")).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/web_src/src/components/NotFoundPage.stories.tsx
+++ b/web_src/src/components/NotFoundPage.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { NotFoundPage } from "./NotFoundPage";
+
+const meta: Meta<typeof NotFoundPage> = {
+  title: "Components/NotFoundPage",
+  component: NotFoundPage,
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+type Story = StoryObj<typeof NotFoundPage>;
+
+export const FlightPlan: Story = {
+  args: {
+    description: "This plane has left the control plane.",
+    actionLabel: "Return to the hangar",
+    showFlightAnimation: true,
+  },
+};

--- a/web_src/src/components/NotFoundPage.tsx
+++ b/web_src/src/components/NotFoundPage.tsx
@@ -1,29 +1,59 @@
-import { FileQuestion } from "lucide-react";
+import { Cloud, FileQuestion, Plane } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import "./NotFoundPage.css";
 
 interface NotFoundPageProps {
   title?: string;
   description?: string;
+  actionLabel?: string;
+  showFlightAnimation?: boolean;
 }
 
 export function NotFoundPage({
   title = "404",
   description = "The page you’re looking for doesn’t exist.",
+  actionLabel = "Go Home",
+  showFlightAnimation = false,
 }: NotFoundPageProps) {
-  const handleGoHome = () => {
-    window.location.href = "/";
-  };
-
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
-      <div className="flex items-center justify-center w-12 h-12 rounded-md bg-orange-100 text-yellow-700">
-        <FileQuestion className="w-5 h-5" />
-      </div>
+      {showFlightAnimation ? (
+        <FlightPathIllustration />
+      ) : (
+        <div className="flex items-center justify-center w-12 h-12 rounded-md bg-orange-100 text-yellow-700">
+          <FileQuestion className="w-5 h-5" />
+        </div>
+      )}
       <h1 className="mt-4 text-3xl font-semibold text-gray-800">{title}</h1>
       <p className="mt-2 text-sm text-gray-500 max-w-md">{description}</p>
-      <Button variant="outline" className="mt-6" onClick={handleGoHome}>
-        Go Home
+      <Button asChild variant="outline" className="mt-6">
+        <a href="/" aria-label="Return to the SuperPlane home page">
+          {actionLabel}
+        </a>
       </Button>
+    </div>
+  );
+}
+
+function FlightPathIllustration() {
+  return (
+    <div
+      className="relative h-20 w-full max-w-80 overflow-hidden text-orange-500"
+      aria-hidden="true"
+      data-testid="flight-path-illustration"
+    >
+      <Cloud className="absolute left-8 top-8 h-5 w-5 text-slate-200" fill="currentColor" />
+      <Cloud className="absolute right-7 top-2 h-7 w-7 text-slate-100" fill="currentColor" />
+      <svg className="absolute inset-0 h-full w-full" viewBox="0 0 320 80" fill="none">
+        <path
+          d="M8 58 C72 58 72 20 136 20 C200 20 200 58 312 34"
+          className="stroke-slate-300"
+          strokeWidth="1.5"
+          strokeDasharray="5 7"
+          strokeLinecap="round"
+        />
+      </svg>
+      <Plane className="not-found-page__plane absolute left-0 top-8 h-7 w-7 fill-orange-100" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Unknown routes redirect users to the home page without an explanation. This change gives lost users a clear route back to SuperPlane.

This change adds:

- “This plane has left the control plane.” empty-state copy.
- A “Return to the hangar” home action.
- A lightweight plane animation with a reduced-motion fallback.
- A Storybook story and a focused component test.

No aircraft—or production workflows—were harmed.

## Preview

![SuperPlane 404 page with an orange plane following a dashed route](https://raw.githubusercontent.com/chazzaoui/superplane/pr-preview-404-flight-plan/.github/pr-previews/404-flight-plan.png)

The plane follows the dashed route. The page shows a static plane when the user enables reduced motion.

## Test plan

- [x] Run `npm run test:run -- src/components/NotFoundPage.spec.tsx`.
- [x] Run `npm run lint:budget`.
- [x] Run targeted ESLint and Prettier checks.
- [ ] Run `npm run build` after Docker generates the API client.

The full UI build needs the generated API client. The local Docker daemon was not available for that generation step.
