### PR TITLE
feat: add ask agent action to run inspector

### DIFF
--- a/web_src/src/ui/CanvasPage/index.runInspection.sidebar.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.runInspection.sidebar.spec.tsx
@@ -5,10 +5,19 @@ import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "@/contexts/ThemeProvider";
 
-const { fitViewMock, getNodesMock, getViewportMock, reactFlowPropsRef, setViewportMock } = vi.hoisted(() => ({
+const {
+  fitViewMock,
+  getNodesMock,
+  getViewportMock,
+  openCanvasToolSidebarTabMock,
+  reactFlowPropsRef,
+  requestAgentComposerSendMock,
+  setViewportMock,
+} = vi.hoisted(() => ({
   fitViewMock: vi.fn().mockResolvedValue(true),
   getNodesMock: vi.fn<() => Array<{ id: string; position: { x: number; y: number } }>>(() => []),
   getViewportMock: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+  openCanvasToolSidebarTabMock: vi.fn(),
   reactFlowPropsRef: {
     current: null as null | {
       nodes?: unknown;
@@ -16,6 +25,7 @@ const { fitViewMock, getNodesMock, getViewportMock, reactFlowPropsRef, setViewpo
       onInit?: (instance: { setViewport: (viewport: { x: number; y: number; zoom: number }) => void }) => unknown;
     },
   },
+  requestAgentComposerSendMock: vi.fn(),
   setViewportMock: vi.fn(),
 }));
 
@@ -28,6 +38,14 @@ vi.mock("@/sentry", () => ({
       }),
     captureException: vi.fn(),
   },
+}));
+
+vi.mock("@/components/AgentSidebar/composerPrefill", () => ({
+  requestAgentComposerSend: requestAgentComposerSendMock,
+}));
+
+vi.mock("@/components/CanvasToolSidebar/events", () => ({
+  openCanvasToolSidebarTab: openCanvasToolSidebarTabMock,
 }));
 
 vi.mock("@xyflow/react", () => ({
@@ -83,10 +101,12 @@ vi.mock("../Runs/RunInspectorPanel", () => ({
   RunInspectorPanel: ({
     onClose,
     onEditNode,
+    onAskAgentAboutEvent,
     onRerunCreated,
   }: {
     onClose?: () => void;
     onEditNode?: (nodeId: string) => void;
+    onAskAgentAboutEvent?: () => void;
     onRerunCreated?: (eventId: string) => void;
   }) => (
     <div data-testid="run-inspector-panel">
@@ -94,6 +114,11 @@ vi.mock("../Runs/RunInspectorPanel", () => ({
       <button type="button" onClick={() => onEditNode?.("run-node-1")}>
         Edit runtime config
       </button>
+      {onAskAgentAboutEvent ? (
+        <button type="button" onClick={onAskAgentAboutEvent}>
+          Ask agent about this event
+        </button>
+      ) : null}
       <button type="button" onClick={() => onRerunCreated?.("rerun-event-1")}>
         Rerun
       </button>
@@ -107,12 +132,13 @@ vi.mock("@/components/CanvasToolSidebar", () => ({
 
 vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
   useCanvasToolSidebarState: () => ({
-    canvasId: undefined,
-    organizationId: undefined,
+    canvasId: "canvas-1",
+    organizationId: "org-1",
     isEditing: false,
     readOnly: false,
     isToolSidebarOpen: false,
-    showToolSidebarToggle: false,
+    showToolSidebarToggle: true,
+    isAgentEnabled: true,
     handleToolSidebarToggle: vi.fn(),
     openToolSidebar: vi.fn(),
     closeToolSidebar: vi.fn(),
@@ -153,6 +179,8 @@ describe("CanvasPage run inspection sidebar", () => {
     getNodesMock.mockReturnValue([]);
     getViewportMock.mockReset();
     getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
+    openCanvasToolSidebarTabMock.mockClear();
+    requestAgentComposerSendMock.mockClear();
     setViewportMock.mockClear();
     globalThis.ResizeObserver = class {
       observe() {}
@@ -198,6 +226,45 @@ describe("CanvasPage run inspection sidebar", () => {
       expect(screen.getByTestId("run-inspector-panel")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("live-node-detail-pane")).not.toBeInTheDocument();
+  });
+
+  it("queues the root event for the agent and opens the agent sidebar", async () => {
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          canvasId="canvas-1"
+          organizationId="org-1"
+          headerMode="version-live"
+          isRunInspectionMode
+          runNodeDetailNodeId="run-node-1"
+          runNodeDetailCanvasId="canvas-1"
+          runNodeDetailRun={{
+            id: "run-1",
+            rootEvent: {
+              id: "root-event-1",
+              nodeId: "trigger-node",
+              data: { secret: "do-not-send" },
+            },
+          }}
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Ask agent about this event" }));
+
+    expect(requestAgentComposerSendMock).toHaveBeenCalledWith(
+      "canvas-1",
+      expect.stringContaining('event ID "root-event-1"'),
+    );
+    const prompt = requestAgentComposerSendMock.mock.calls[0]?.[1] as string;
+    expect(prompt).not.toContain("do-not-send");
+    expect(openCanvasToolSidebarTabMock).toHaveBeenCalledWith("agent");
   });
 
   it("closes only the right run inspector when the inspector close button is clicked", async () => {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -51,6 +51,7 @@ import type {
   OrganizationsIntegration,
   TriggersTrigger,
 } from "@/api-client";
+import { requestAgentComposerSend } from "@/components/AgentSidebar/composerPrefill";
 import { CanvasRunsSidebar } from "@/components/CanvasRunsSidebar";
 import type { CanvasRunsSidebarState } from "@/components/CanvasRunsSidebar/useCanvasRunsSidebarState";
 import { useCanvasRunsSidebarState } from "@/components/CanvasRunsSidebar/useCanvasRunsSidebarState";
@@ -58,6 +59,7 @@ import { CanvasVersionsSidebar } from "@/components/CanvasVersionsSidebar";
 import type { CanvasVersionsSidebarState } from "@/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState";
 import { useCanvasVersionsSidebarState } from "@/components/CanvasVersionsSidebar/useCanvasVersionsSidebarState";
 import { CanvasToolSidebar } from "@/components/CanvasToolSidebar";
+import { openCanvasToolSidebarTab } from "@/components/CanvasToolSidebar/events";
 import {
   useCanvasToolSidebarState,
   type CanvasToolSidebarState,
@@ -875,6 +877,22 @@ function CanvasPage(props: CanvasPageProps) {
     onAgentStagingReady: props.onAgentStagingReady,
     onAgentStagingCommit: props.onAgentStagingCommit,
   });
+  const agentCanvasId = toolSidebarState.canvasId ?? props.runNodeDetailCanvasId;
+  const rootEventId = props.runNodeDetailRun?.rootEvent?.id;
+
+  const canAskAgentAboutEvent =
+    toolSidebarState.isAgentEnabled && toolSidebarState.showToolSidebarToggle && !!agentCanvasId && !!rootEventId;
+
+  const handleAskAgentAboutEvent = useCallback(() => {
+    if (!canAskAgentAboutEvent || !agentCanvasId || !rootEventId) {
+      return;
+    }
+
+    // Queue the prompt before opening so the composer can flush it after the sidebar mounts.
+    requestAgentComposerSend(agentCanvasId, buildAgentEventInvestigationPrompt(rootEventId));
+    openCanvasToolSidebarTab("agent");
+  }, [agentCanvasId, canAskAgentAboutEvent, rootEventId]);
+
   const runsSidebarBaseState = useCanvasRunsSidebarState(props.canvasId);
   const showRunsSidebar = allowsRunsSidebar(props.headerMode) && props.toolSidebarRunsContent != null;
   const runningRunsCount = useMemo(
@@ -1656,6 +1674,7 @@ function CanvasPage(props: CanvasPageProps) {
                 selectRun: props.onSelectRunFromSidebarEvent,
               })
             }
+            onAskAgentAboutEvent={canAskAgentAboutEvent ? handleAskAgentAboutEvent : undefined}
             factoryContext={props.factoryEmbed}
             onClose={() => props.onRunNodeDetailClose?.()}
           />
@@ -3571,6 +3590,14 @@ function CanvasContent({
       ) : null}
     </div>
   );
+}
+
+function buildAgentEventInvestigationPrompt(eventId: string): string {
+  return [
+    `Investigate the run associated with event ID "${eventId}".`,
+    "Use the SuperPlane runtime tools to inspect that event's executions and explain the current status, failure, or unusual behavior.",
+    "Do not modify the workflow unless I explicitly ask you to.",
+  ].join(" ");
 }
 
 export type { BuildingBlock } from "../BuildingBlocksSidebar";

--- a/web_src/src/ui/Runs/RunInspectorHeader.spec.tsx
+++ b/web_src/src/ui/Runs/RunInspectorHeader.spec.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { CanvasesCanvasRun } from "@/api-client";
 import { RunInspectorHeader } from "./RunInspectorHeader";
 
@@ -12,7 +12,7 @@ const baseRun: CanvasesCanvasRun = {
   createdAt: "2026-05-01T12:00:00Z",
 };
 
-function renderHeader(run: CanvasesCanvasRun) {
+function renderHeader(run: CanvasesCanvasRun, onAskAgentAboutEvent?: () => void) {
   return render(
     <MemoryRouter initialEntries={["/org-1/apps/child-canvas-id?run=child-run-id"]}>
       <RunInspectorHeader
@@ -23,6 +23,7 @@ function renderHeader(run: CanvasesCanvasRun) {
         actionPending={false}
         actionDisabled={false}
         onAction={() => {}}
+        onAskAgentAboutEvent={onAskAgentAboutEvent}
       />
     </MemoryRouter>,
   );
@@ -47,6 +48,30 @@ describe("RunInspectorHeader", () => {
     renderHeader(baseRun);
 
     expect(screen.queryByRole("link", { name: "See parent" })).not.toBeInTheDocument();
+  });
+
+  it("shows and invokes the agent event action when a root event is present", () => {
+    const onAskAgentAboutEvent = vi.fn();
+
+    renderHeader(
+      {
+        ...baseRun,
+        rootEvent: { id: "root-event-id" },
+      },
+      onAskAgentAboutEvent,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Ask agent about this event" }));
+
+    expect(onAskAgentAboutEvent).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Rerun" })).toBeInTheDocument();
+  });
+
+  it("hides the agent event action when the run has no root event", () => {
+    renderHeader(baseRun, vi.fn());
+
+    expect(screen.queryByRole("button", { name: "Ask agent about this event" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Rerun" })).toBeInTheDocument();
   });
 
   it("shows a disabled cancelling action while the run is stopping", () => {

--- a/web_src/src/ui/Runs/RunInspectorHeader.tsx
+++ b/web_src/src/ui/Runs/RunInspectorHeader.tsx
@@ -1,4 +1,4 @@
-import { CornerLeftUp, Loader2 } from "lucide-react";
+import { CornerLeftUp, Loader2, MessageCircle } from "lucide-react";
 import { Link, useParams } from "react-router";
 import type { CanvasesCanvasRun } from "@/api-client";
 import { Timestamp } from "@/components/Timestamp";
@@ -56,6 +56,7 @@ export function RunInspectorHeader({
   actionPending,
   actionDisabled,
   onAction,
+  onAskAgentAboutEvent,
   /** Nested inside a node accordion (factory): drop sticky page chrome styles. */
   embedded = false,
 }: {
@@ -66,6 +67,7 @@ export function RunInspectorHeader({
   actionPending: boolean;
   actionDisabled: boolean;
   onAction: () => void;
+  onAskAgentAboutEvent?: () => void;
   embedded?: boolean;
 }) {
   const { organizationId: routeOrganizationId } = useParams<{ organizationId: string }>();
@@ -77,6 +79,7 @@ export function RunInspectorHeader({
   const actionLabel = getActionLabel(status);
   const actionTooltip = getActionTooltip(status);
   const isStopAction = status === "running";
+  const canAskAgentAboutEvent = !!run.rootEvent?.id && !!onAskAgentAboutEvent;
 
   return (
     <div className={headerChromeClassName(embedded)}>
@@ -114,27 +117,49 @@ export function RunInspectorHeader({
               {stepCount} {stepCount === 1 ? "step" : "steps"}
             </span>
           </div>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="xs"
-                  disabled={actionDisabled || actionPending}
-                  onClick={onAction}
-                  className={cn(
-                    isStopAction &&
-                      "border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-900/70 dark:text-red-300 dark:hover:bg-red-950/50 dark:hover:text-red-200",
-                  )}
-                >
-                  {actionPending ? <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" /> : null}
-                  {actionPending ? `${actionLabel}...` : actionLabel}
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{actionTooltip}</TooltipContent>
-          </Tooltip>
+          <div className="flex shrink-0 items-center gap-1">
+            {canAskAgentAboutEvent ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    className="h-6 w-6 rounded-full p-0"
+                    aria-label="Ask agent about this event"
+                    onClick={onAskAgentAboutEvent}
+                  >
+                    <MessageCircle className="size-3.5" aria-hidden />
+                  </Button>
+                </TooltipTrigger>
+
+                <TooltipContent side="bottom">Ask agent about this event</TooltipContent>
+              </Tooltip>
+            ) : null}
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    disabled={actionDisabled || actionPending}
+                    onClick={onAction}
+                    className={cn(
+                      isStopAction &&
+                        "border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-900/70 dark:text-red-300 dark:hover:bg-red-950/50 dark:hover:text-red-200",
+                    )}
+                  >
+                    {actionPending ? <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" /> : null}
+                    {actionPending ? `${actionLabel}...` : actionLabel}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+
+              <TooltipContent side="bottom">{actionTooltip}</TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       </div>
     </div>

--- a/web_src/src/ui/Runs/RunInspectorPanel.tsx
+++ b/web_src/src/ui/Runs/RunInspectorPanel.tsx
@@ -39,6 +39,7 @@ export interface RunInspectorPanelProps {
   onSelectNode: (nodeId: string) => void;
   onClearSelectedNode?: () => void;
   onEditNode?: (nodeId: string) => void;
+  onAskAgentAboutEvent?: () => void;
   onRerunCreated?: (eventId: string) => void | Promise<void>;
   runNavigation?: { newerRunId?: string | null; olderRunId?: string | null; canNavigateOlder?: boolean } | null;
   onNavigateRun?: (runId: string) => void;
@@ -98,6 +99,7 @@ export function RunInspectorPanel(props: RunInspectorPanelProps) {
         model={model}
         componentIconMap={componentIconMap}
         onEditNode={onEditNode}
+        onAskAgentAboutEvent={props.onAskAgentAboutEvent}
       />
     </aside>
   );
@@ -114,6 +116,7 @@ function RunInspectorPanelBody({
   model,
   componentIconMap,
   onEditNode,
+  onAskAgentAboutEvent,
 }: {
   factoryContext: boolean;
   organizationId?: string;
@@ -121,6 +124,7 @@ function RunInspectorPanelBody({
   model: ReturnType<typeof useRunInspectorPanelModel>;
   componentIconMap: Record<string, string>;
   onEditNode?: (nodeId: string) => void;
+  onAskAgentAboutEvent?: () => void;
 }) {
   if (factoryContext) {
     return (
@@ -150,6 +154,7 @@ function RunInspectorPanelBody({
         onAction={() => (stopping ? model.actions.stop() : model.actions.rerun())}
         actionPending={stopping ? model.actions.stopPending : model.actions.rerunPending}
         actionDisabled={stopping ? model.actions.stopDisabled : !run.rootEvent?.id}
+        onAskAgentAboutEvent={onAskAgentAboutEvent}
       />
       <RunInspectorContent
         errorSummaries={model.errorSummaries}


### PR DESCRIPTION
## Summary

Add an "Ask agent about this event" action to the run inspector:
- Open the existing agent sidebar with an event-specific investigation prompt
- Pass the selected run’s root event ID so the agent can inspect event executions through `read_runtime`
- Hide the action when the run has no root event or agent access is unavailable
- Preserve existing agent conversations without copying event payloads or secrets

<img width="1484" height="800" alt="superplane-showcase" src="https://github.com/user-attachments/assets/2ed4462f-2216-4769-a1f2-1d0bc0fde24f" />

## Related issue

Fixes #5135 

## Test plan

- [ ] Run `cd web_src && npm run test -- RunInspectorHeader.spec.tsx`
- [ ] Open a canvas with a committed and live workflow
- [ ] Trigger a manual run and open the Runs inspector
- [ ] Select a run with a root event
- [ ] Click "Ask agent about this event" butotn
- [ ] Confirm the agent sidebar opens and receives the event-specific investigation context
- [ ] Confirm an existing agent conversation is not deleted or replaced
- [ ] Confirm the prompt contains the event ID but not the raw event payload
- [ ] Confirm runs without a root event do not show the action
- [ ] Run `make format.js`
- [ ] Run `make check.build.ui`
- [ ] Spot-check light/dark mode
