### PR TITLE
fix: Scope Factory Run Status to Selected Run

### DIFF
--- a/web_src/src/pages/app/buildSidebarRuntimeMaps.ts
+++ b/web_src/src/pages/app/buildSidebarRuntimeMaps.ts
@@ -1,0 +1,41 @@
+type SidebarNodeRuntimeData<TExecution, TQueueItem, TEvent> = {
+  executions: TExecution[];
+  queueItems: TQueueItem[];
+  events: TEvent[];
+  totalInHistoryCount: number;
+  totalInQueueCount: number;
+};
+
+/** Build per-node maps for the component sidebar from live store data. */
+export function buildSidebarRuntimeMaps<TExecution, TQueueItem, TEvent>({
+  nodeId,
+  showNodeRuntimeActivity,
+  nodeData,
+  fallbackEvents,
+}: {
+  nodeId: string;
+  showNodeRuntimeActivity: boolean;
+  nodeData: SidebarNodeRuntimeData<TExecution, TQueueItem, TEvent>;
+  fallbackEvents: TEvent[] | undefined;
+}) {
+  if (!showNodeRuntimeActivity) {
+    return {
+      executionsMap: {} as Record<string, TExecution[]>,
+      queueItemsMap: {} as Record<string, TQueueItem[]>,
+      eventsMap: {} as Record<string, TEvent[]>,
+      totalHistoryCount: 0,
+      totalQueueCount: 0,
+    };
+  }
+
+  return {
+    executionsMap: nodeData.executions.length === 0 ? {} : { [nodeId]: nodeData.executions },
+    queueItemsMap: nodeData.queueItems.length === 0 ? {} : { [nodeId]: nodeData.queueItems.slice().reverse() },
+    eventsMap:
+      nodeData.events.length === 0
+        ? {}
+        : { [nodeId]: nodeData.events.length > 0 ? nodeData.events : (fallbackEvents ?? []) },
+    totalHistoryCount: nodeData.totalInHistoryCount,
+    totalQueueCount: nodeData.totalInQueueCount,
+  };
+}

--- a/web_src/src/pages/app/factoryEmbedCanvasChrome.spec.ts
+++ b/web_src/src/pages/app/factoryEmbedCanvasChrome.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRef } from "react";
+import { resolveFactoryEmbedCanvasChrome } from "./factoryEmbedCanvasChrome";
+
+function buildInput(overrides: Partial<Parameters<typeof resolveFactoryEmbedCanvasChrome>[0]> = {}) {
+  const handleSelectLiveCanvas = vi.fn();
+  const handleBackToRunList = vi.fn();
+  return {
+    input: {
+      factoryEmbed: true,
+      factoryViewOnly: true,
+      factoryOwnedApp: false,
+      headerBanner: null,
+      canUpdateCanvas: false,
+      showBottomStatusControls: false,
+      hideAddControls: false,
+      editSessionActive: false,
+      runInspectionChromeActive: true,
+      handleSelectMemoryMode: vi.fn(),
+      handleSelectConsoleMode: vi.fn(),
+      handleSelectFilesMode: vi.fn(),
+      handleEnterEditModeFromHeader: vi.fn(),
+      handleExitEditSession: vi.fn(),
+      handleSelectLiveCanvas,
+      handleBackToRunList,
+      filesHeaderActionsSlotId: "files-actions",
+      runsHasFitToViewRef: createRef<boolean>(),
+      hasFitToViewRef: createRef<boolean>(),
+      runsViewportRef: createRef<{ x: number; y: number; zoom: number } | undefined>(),
+      viewportRef: createRef<{ x: number; y: number; zoom: number } | undefined>(),
+      selectedRunId: "run-1",
+      selectedRunDetailDismissed: false,
+      runCanvasLoading: false,
+      selectedRun: null,
+      ...overrides,
+    },
+    handleSelectLiveCanvas,
+    handleBackToRunList,
+  };
+}
+
+describe("resolveFactoryEmbedCanvasChrome", () => {
+  it("keeps run scope on factory close instead of clearing to Live", () => {
+    const { input, handleSelectLiveCanvas, handleBackToRunList } = buildInput({ factoryEmbed: true });
+    const chrome = resolveFactoryEmbedCanvasChrome(input);
+
+    expect(chrome.onRunNodeDetailClose).toBe(handleBackToRunList);
+    expect(chrome.onRunNodeDetailClose).not.toBe(handleSelectLiveCanvas);
+    expect(chrome.onBackToLiveCanvas).toBeUndefined();
+  });
+
+  it("uses back-to-run-list close outside factory embed", () => {
+    const { input, handleBackToRunList, handleSelectLiveCanvas } = buildInput({ factoryEmbed: false });
+    const chrome = resolveFactoryEmbedCanvasChrome(input);
+
+    expect(chrome.onRunNodeDetailClose).toBe(handleBackToRunList);
+    expect(chrome.onBackToLiveCanvas).toBe(handleSelectLiveCanvas);
+  });
+});

--- a/web_src/src/pages/app/factoryEmbedCanvasChrome.spec.ts
+++ b/web_src/src/pages/app/factoryEmbedCanvasChrome.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { createRef } from "react";
+import type { RefObject } from "react";
 import { resolveFactoryEmbedCanvasChrome } from "./factoryEmbedCanvasChrome";
+
+function refOf<T>(value: T): RefObject<T> {
+  return { current: value };
+}
 
 function buildInput(overrides: Partial<Parameters<typeof resolveFactoryEmbedCanvasChrome>[0]> = {}) {
   const handleSelectLiveCanvas = vi.fn();
@@ -24,10 +28,10 @@ function buildInput(overrides: Partial<Parameters<typeof resolveFactoryEmbedCanv
       handleSelectLiveCanvas,
       handleBackToRunList,
       filesHeaderActionsSlotId: "files-actions",
-      runsHasFitToViewRef: createRef<boolean>(),
-      hasFitToViewRef: createRef<boolean>(),
-      runsViewportRef: createRef<{ x: number; y: number; zoom: number } | undefined>(),
-      viewportRef: createRef<{ x: number; y: number; zoom: number } | undefined>(),
+      runsHasFitToViewRef: refOf(false),
+      hasFitToViewRef: refOf(false),
+      runsViewportRef: refOf<{ x: number; y: number; zoom: number } | undefined>(undefined),
+      viewportRef: refOf<{ x: number; y: number; zoom: number } | undefined>(undefined),
       selectedRunId: "run-1",
       selectedRunDetailDismissed: false,
       runCanvasLoading: false,

--- a/web_src/src/pages/app/factoryEmbedCanvasChrome.ts
+++ b/web_src/src/pages/app/factoryEmbedCanvasChrome.ts
@@ -68,7 +68,8 @@ function resolveFactoryShellModeProps(input: FactoryEmbedCanvasChromeInput) {
 
 function resolveFactoryRunInspectionProps(input: FactoryEmbedCanvasChromeInput) {
   return {
-    onRunNodeDetailClose: input.factoryEmbed ? input.handleSelectLiveCanvas : input.handleBackToRunList,
+    // Keep ?run= on close so factory canvas stays run-scoped (no stale Live lastExecutions).
+    onRunNodeDetailClose: input.handleBackToRunList,
     onBackToLiveCanvas: input.factoryEmbed ? undefined : input.handleSelectLiveCanvas,
     hasFitToViewRef: input.runInspectionChromeActive ? input.runsHasFitToViewRef : input.hasFitToViewRef,
     isRunInspectionMode: input.runInspectionChromeActive,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -66,7 +66,7 @@ import { DefaultLayoutEngine } from "@/lib/layout";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import { getActiveNoteId, restoreActiveNoteFocus } from "@/ui/annotationComponent/noteFocus";
 import { buildBuildingBlockCategories } from "@/ui/buildingBlocks";
-import type { CanvasNode, NewNodeData, NodeEditData, SidebarData } from "@/ui/CanvasPage";
+import type { CanvasNode, NewNodeData, NodeEditData } from "@/ui/CanvasPage";
 import { CANVAS_SIDEBAR_STORAGE_KEY, CanvasPage, type MissingIntegration } from "@/ui/CanvasPage";
 import { CanvasPageLoadingOverlay } from "@/ui/CanvasPage/CanvasPageLoadingOverlay";
 import { resolveFitViewVersionId } from "@/ui/CanvasPage/fitView";
@@ -135,6 +135,8 @@ import { buildAppFiles } from "./files/lib/app-files";
 import { useDraftVisualDiff } from "./useDraftVisualDiff";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
 import { useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
+import { useVisibleNodeRuntimeMaps } from "./useVisibleNodeRuntimeMaps";
+import { useGetSidebarData } from "./useGetSidebarData";
 import { useRunParticipantFitRequest } from "./useRunParticipantFitRequest";
 import { useAgentNodeFocusRequest, type CanvasFocusRequest } from "./useAgentNodeFocusRequest";
 import { isRunDetailDismissed, useRunsDetailState } from "./useRunsDetailState";
@@ -174,7 +176,6 @@ import {
   isValidRunId,
   prepareCanvasLogNodes,
   prepareData,
-  prepareSidebarData,
   shouldClearRunDetailNode,
 } from "./workflowPageHelpers";
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
@@ -943,23 +944,20 @@ export function AppPage({
 
     return { nodeExecutionsMap: executionsMap, nodeQueueItemsMap: queueItemsMap, nodeEventsMap: eventsMap };
   }, [storeVersion]);
-  const visibleNodeExecutionsMap = useMemo(
-    () => (showLiveActivity ? nodeExecutionsMap : {}),
-    [showLiveActivity, nodeExecutionsMap],
-  );
+  const { showNodeRuntimeActivity, visibleNodeExecutionsMap, visibleNodeQueueItemsMap, visibleNodeEventsMap } =
+    useVisibleNodeRuntimeMaps({
+      showLiveActivity,
+      factoryEmbed,
+      isRunInspectionMode,
+      nodeExecutionsMap,
+      nodeQueueItemsMap,
+      nodeEventsMap,
+    });
   const consoleNodeStatuses = useMemo(
     () => deriveConsoleNodeStatuses(visibleNodeExecutionsMap),
     [visibleNodeExecutionsMap],
   );
   const handleConsoleTriggerNode = useConsoleTriggerNode({ canvasId, canvas: canvas ?? undefined, queryClient });
-  const visibleNodeQueueItemsMap = useMemo(
-    () => (showLiveActivity ? nodeQueueItemsMap : {}),
-    [showLiveActivity, nodeQueueItemsMap],
-  );
-  const visibleNodeEventsMap = useMemo(
-    () => (showLiveActivity ? nodeEventsMap : {}),
-    [showLiveActivity, nodeEventsMap],
-  );
 
   const {
     stagingStale,
@@ -1555,48 +1553,15 @@ export function AppPage({
     triggersLoading,
   ]);
 
-  const getSidebarData = useCallback(
-    (nodeId: string): SidebarData | null => {
-      const node = canvasNodesById.get(nodeId);
-      if (!node) return null;
-
-      // Get current data from store (don't trigger load here - that's done in useEffect)
-      const nodeData = getNodeData(nodeId);
-
-      // Build maps with current node data for sidebar
-      const executionsMap =
-        !showLiveActivity || nodeData.executions.length === 0 ? {} : { [nodeId]: nodeData.executions };
-      const queueItemsMap =
-        !showLiveActivity || nodeData.queueItems.length === 0
-          ? {}
-          : { [nodeId]: nodeData.queueItems.slice().reverse() };
-      const eventsMapForSidebar =
-        !showLiveActivity || nodeData.events.length === 0
-          ? {}
-          : { [nodeId]: nodeData.events.length > 0 ? nodeData.events : visibleNodeEventsMap[nodeId] || [] };
-      const totalHistoryCount = !showLiveActivity ? 0 : nodeData.totalInHistoryCount;
-      const totalQueueCount = !showLiveActivity ? 0 : nodeData.totalInQueueCount;
-
-      const sidebarData = prepareSidebarData(
-        node,
-        canvasNodes,
-        allComponents,
-        allTriggers,
-        executionsMap,
-        queueItemsMap,
-        eventsMapForSidebar,
-        totalHistoryCount,
-        totalQueueCount,
-      );
-
-      // Add loading state to sidebar data
-      return {
-        ...sidebarData,
-        isLoading: nodeData.isLoading,
-      };
-    },
-    [canvasNodes, canvasNodesById, allComponents, allTriggers, visibleNodeEventsMap, showLiveActivity, getNodeData],
-  );
+  const getSidebarData = useGetSidebarData({
+    canvasNodes,
+    canvasNodesById,
+    allComponents,
+    allTriggers,
+    visibleNodeEventsMap,
+    showNodeRuntimeActivity,
+    getNodeData,
+  });
 
   // Trigger data loading when sidebar opens for a node
   const loadSidebarData = useCallback(

--- a/web_src/src/pages/app/resolveShowNodeRuntimeActivity.spec.ts
+++ b/web_src/src/pages/app/resolveShowNodeRuntimeActivity.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveShowNodeRuntimeActivity } from "./resolveShowNodeRuntimeActivity";
+
+describe("resolveShowNodeRuntimeActivity", () => {
+  it("follows showLiveActivity for non-factory canvases", () => {
+    expect(
+      resolveShowNodeRuntimeActivity({
+        showLiveActivity: true,
+        factoryEmbed: false,
+        isRunInspectionMode: false,
+      }),
+    ).toBe(true);
+    expect(
+      resolveShowNodeRuntimeActivity({
+        showLiveActivity: false,
+        factoryEmbed: false,
+        isRunInspectionMode: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides factory Live activity and keeps run-scoped activity", () => {
+    expect(
+      resolveShowNodeRuntimeActivity({
+        showLiveActivity: true,
+        factoryEmbed: true,
+        isRunInspectionMode: false,
+      }),
+    ).toBe(false);
+    expect(
+      resolveShowNodeRuntimeActivity({
+        showLiveActivity: true,
+        factoryEmbed: true,
+        isRunInspectionMode: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/web_src/src/pages/app/resolveShowNodeRuntimeActivity.ts
+++ b/web_src/src/pages/app/resolveShowNodeRuntimeActivity.ts
@@ -1,0 +1,12 @@
+/** Factory Live has no run scope — hide global lastExecutions on the canvas. */
+export function resolveShowNodeRuntimeActivity({
+  showLiveActivity,
+  factoryEmbed,
+  isRunInspectionMode,
+}: {
+  showLiveActivity: boolean;
+  factoryEmbed: boolean;
+  isRunInspectionMode: boolean;
+}): boolean {
+  return showLiveActivity && (!factoryEmbed || isRunInspectionMode);
+}

--- a/web_src/src/pages/app/useGetSidebarData.ts
+++ b/web_src/src/pages/app/useGetSidebarData.ts
@@ -1,0 +1,78 @@
+import { useCallback } from "react";
+import type {
+  ActionsAction,
+  CanvasesCanvasEvent,
+  CanvasesCanvasNodeExecution,
+  CanvasesCanvasNodeQueueItem,
+  SuperplaneComponentsNode as ComponentsNode,
+  TriggersTrigger,
+} from "@/api-client";
+import type { SidebarData } from "@/ui/CanvasPage";
+import { buildSidebarRuntimeMaps } from "./buildSidebarRuntimeMaps";
+import { prepareSidebarData } from "./workflowPageHelpers";
+
+type NodeStoreData = {
+  executions: CanvasesCanvasNodeExecution[];
+  queueItems: CanvasesCanvasNodeQueueItem[];
+  events: CanvasesCanvasEvent[];
+  totalInHistoryCount: number;
+  totalInQueueCount: number;
+  isLoading: boolean;
+};
+
+export function useGetSidebarData({
+  canvasNodes,
+  canvasNodesById,
+  allComponents,
+  allTriggers,
+  visibleNodeEventsMap,
+  showNodeRuntimeActivity,
+  getNodeData,
+}: {
+  canvasNodes: ComponentsNode[];
+  canvasNodesById: Map<string, ComponentsNode>;
+  allComponents: ActionsAction[];
+  allTriggers: TriggersTrigger[];
+  visibleNodeEventsMap: Record<string, CanvasesCanvasEvent[]>;
+  showNodeRuntimeActivity: boolean;
+  getNodeData: (nodeId: string) => NodeStoreData;
+}) {
+  return useCallback(
+    (nodeId: string): SidebarData | null => {
+      const node = canvasNodesById.get(nodeId);
+      if (!node) return null;
+
+      const nodeData = getNodeData(nodeId);
+      const { executionsMap, queueItemsMap, eventsMap, totalHistoryCount, totalQueueCount } = buildSidebarRuntimeMaps({
+        nodeId,
+        showNodeRuntimeActivity,
+        nodeData,
+        fallbackEvents: visibleNodeEventsMap[nodeId],
+      });
+
+      return {
+        ...prepareSidebarData(
+          node,
+          canvasNodes,
+          allComponents,
+          allTriggers,
+          executionsMap,
+          queueItemsMap,
+          eventsMap,
+          totalHistoryCount,
+          totalQueueCount,
+        ),
+        isLoading: nodeData.isLoading,
+      };
+    },
+    [
+      canvasNodes,
+      canvasNodesById,
+      allComponents,
+      allTriggers,
+      visibleNodeEventsMap,
+      showNodeRuntimeActivity,
+      getNodeData,
+    ],
+  );
+}

--- a/web_src/src/pages/app/useVisibleNodeRuntimeMaps.ts
+++ b/web_src/src/pages/app/useVisibleNodeRuntimeMaps.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import { resolveShowNodeRuntimeActivity } from "./resolveShowNodeRuntimeActivity";
+
+export function useVisibleNodeRuntimeMaps<TExec, TQueue, TEvent>({
+  showLiveActivity,
+  factoryEmbed,
+  isRunInspectionMode,
+  nodeExecutionsMap,
+  nodeQueueItemsMap,
+  nodeEventsMap,
+}: {
+  showLiveActivity: boolean;
+  factoryEmbed: boolean;
+  isRunInspectionMode: boolean;
+  nodeExecutionsMap: Record<string, TExec>;
+  nodeQueueItemsMap: Record<string, TQueue>;
+  nodeEventsMap: Record<string, TEvent>;
+}) {
+  const showNodeRuntimeActivity = resolveShowNodeRuntimeActivity({
+    showLiveActivity,
+    factoryEmbed,
+    isRunInspectionMode,
+  });
+
+  const visibleNodeExecutionsMap = useMemo(
+    () => (showNodeRuntimeActivity ? nodeExecutionsMap : {}),
+    [showNodeRuntimeActivity, nodeExecutionsMap],
+  );
+  const visibleNodeQueueItemsMap = useMemo(
+    () => (showNodeRuntimeActivity ? nodeQueueItemsMap : {}),
+    [showNodeRuntimeActivity, nodeQueueItemsMap],
+  );
+  const visibleNodeEventsMap = useMemo(
+    () => (showNodeRuntimeActivity ? nodeEventsMap : {}),
+    [showNodeRuntimeActivity, nodeEventsMap],
+  );
+
+  return {
+    showNodeRuntimeActivity,
+    visibleNodeExecutionsMap,
+    visibleNodeQueueItemsMap,
+    visibleNodeEventsMap,
+  };
+}

--- a/web_src/src/ui/CanvasPage/Block/content.tsx
+++ b/web_src/src/ui/CanvasPage/Block/content.tsx
@@ -45,15 +45,18 @@ function renderFallbackBlock(args: {
   selected: boolean;
   showHeader: boolean | undefined;
   canvasMode: BlockProps["canvasMode"];
+  showRuntimeStatus?: boolean;
   actionProps: ReturnType<typeof getActionProps>;
   dimBodyBelowHeader?: boolean;
 }) {
-  const { data, fallbackTitle, selected, showHeader, canvasMode, actionProps, dimBodyBelowHeader } = args;
+  const { data, fallbackTitle, selected, showHeader, canvasMode, showRuntimeStatus, actionProps, dimBodyBelowHeader } =
+    args;
 
   return (
     <ComponentBase
       {...buildFallbackComponentProps(data, fallbackTitle)}
       canvasMode={canvasMode}
+      showRuntimeStatus={showRuntimeStatus}
       selected={selected}
       showHeader={showHeader}
       dimBodyBelowHeader={dimBodyBelowHeader}
@@ -70,6 +73,7 @@ function AnnotationBlockContent({
   selected,
   showHeader,
   canvasMode,
+  showRuntimeStatus,
   onAnnotationUpdate,
   onAnnotationBlur,
   actionProps,
@@ -80,6 +84,7 @@ function AnnotationBlockContent({
   selected: boolean;
   showHeader?: boolean;
   canvasMode?: BlockProps["canvasMode"];
+  showRuntimeStatus?: boolean;
   onAnnotationUpdate?: BlockProps["onAnnotationUpdate"];
   onAnnotationBlur?: BlockProps["onAnnotationBlur"];
   actionProps: ReturnType<typeof getActionProps>;
@@ -106,6 +111,7 @@ function AnnotationBlockContent({
       selected,
       showHeader,
       canvasMode,
+      showRuntimeStatus,
       actionProps,
       dimBodyBelowHeader,
     });
@@ -132,6 +138,7 @@ function renderBlockByType(args: {
   selected: boolean;
   showHeader?: boolean;
   canvasMode?: BlockProps["canvasMode"];
+  showRuntimeStatus?: boolean;
   onAnnotationUpdate?: BlockProps["onAnnotationUpdate"];
   onAnnotationBlur?: BlockProps["onAnnotationBlur"];
   actionProps: ReturnType<typeof getActionProps>;
@@ -143,6 +150,7 @@ function renderBlockByType(args: {
     selected,
     showHeader,
     canvasMode,
+    showRuntimeStatus,
     onAnnotationUpdate,
     onAnnotationBlur,
     actionProps,
@@ -159,6 +167,7 @@ function renderBlockByType(args: {
           selected,
           showHeader,
           canvasMode,
+          showRuntimeStatus,
           actionProps,
           dimBodyBelowHeader,
         });
@@ -167,6 +176,7 @@ function renderBlockByType(args: {
         <Trigger
           {...getSafeTriggerProps(data)}
           canvasMode={canvasMode}
+          showRuntimeStatus={showRuntimeStatus}
           selected={selected}
           showHeader={showHeader}
           dimBodyBelowHeader={dimBodyBelowHeader}
@@ -181,6 +191,7 @@ function renderBlockByType(args: {
         <ComponentBase
           {...safeComponentProps}
           canvasMode={canvasMode}
+          showRuntimeStatus={showRuntimeStatus}
           selected={selected}
           showHeader={showHeader}
           dimBodyBelowHeader={dimBodyBelowHeader}
@@ -195,6 +206,7 @@ function renderBlockByType(args: {
         <Composite
           {...getSafeCompositeProps(data)}
           canvasMode={canvasMode}
+          showRuntimeStatus={showRuntimeStatus}
           selected={selected}
           showHeader={showHeader}
           dimBodyBelowHeader={dimBodyBelowHeader}
@@ -211,6 +223,7 @@ function renderBlockByType(args: {
           selected={selected}
           showHeader={showHeader}
           canvasMode={canvasMode}
+          showRuntimeStatus={showRuntimeStatus}
           onAnnotationUpdate={onAnnotationUpdate}
           onAnnotationBlur={onAnnotationBlur}
           actionProps={actionProps}
@@ -224,6 +237,7 @@ function renderBlockByType(args: {
         selected,
         showHeader,
         canvasMode,
+        showRuntimeStatus,
         actionProps,
         dimBodyBelowHeader,
       });
@@ -239,6 +253,7 @@ export function BlockContent({
   onDelete,
   showHeader,
   canvasMode,
+  showRuntimeStatus,
   isCompactView,
   onAnnotationUpdate,
   onAnnotationBlur,
@@ -257,6 +272,7 @@ export function BlockContent({
     selected,
     showHeader,
     canvasMode,
+    showRuntimeStatus,
     onAnnotationUpdate,
     onAnnotationBlur,
     actionProps,

--- a/web_src/src/ui/CanvasPage/Block/types.ts
+++ b/web_src/src/ui/CanvasPage/Block/types.ts
@@ -64,6 +64,8 @@ export interface BlockProps extends ComponentActionsProps {
   selected?: boolean;
   showHeader?: boolean;
   canvasMode?: "live" | "edit";
+  /** False on factory Live without a selected run (topology only). */
+  showRuntimeStatus?: boolean;
   onAnnotationUpdate?: (
     nodeId: string,
     updates: { text?: string; color?: string; width?: number; height?: number; x?: number; y?: number },

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -111,6 +111,7 @@ import { shouldRefitOnInit, stampFittedContentKey } from "./fitView";
 import { RightSideControls } from "./RightSideControls";
 import { computeAppendFromNodePlacement } from "./appendFromNodePlacement";
 import { selectCreatedRerun } from "./runInspectionRerunSelection";
+import { resolveRunInspectorOpen } from "./resolveRunInspectorOpen";
 import { useBuildingBlocksShortcut } from "./useBuildingBlocksShortcut";
 import type { CanvasPageState } from "./useCanvasState";
 import { useCanvasState } from "./useCanvasState";
@@ -535,6 +536,7 @@ type CanvasNodeRendererCallbacks = {
   showHeader: boolean;
   hasMultiSelection: boolean;
   canvasMode: "live" | "edit";
+  showRuntimeStatus: boolean;
 };
 
 type CanvasBlockNodeData = CanvasBlockData &
@@ -706,6 +708,7 @@ function buildInteractiveNodeBlockProps(
   return {
     showHeader: callbacks.showHeader && !callbacks.hasMultiSelection,
     canvasMode: callbacks.canvasMode,
+    showRuntimeStatus: callbacks.showRuntimeStatus,
     onAppendFromNode: callbacks.onAppendFromNode,
     onClick: (event) => callbacks.handleNodeClick(nodeId, event),
     onDelete: getNodeAction(callbacks.onNodeDelete, nodeId),
@@ -1318,13 +1321,14 @@ function CanvasPage(props: CanvasPageProps) {
   const showPreviewFloatingBar =
     canvasStateMode === "previewing-previous-version" && !!props.onSeeCurrentVersion && !showRunInspectionFloatingBar;
 
-  // Factory embed opens the inspector on ?run= even before a node is selected;
-  // the factory body prompts "Select a node…" until one is picked.
-  const runInspectorOpen =
-    props.isRunInspectionMode &&
-    !props.isEditing &&
-    !!props.runNodeDetailCanvasId &&
-    (!!props.runNodeDetailRun || !!props.runCanvasLoading);
+  const runInspectorOpen = resolveRunInspectorOpen({
+    isRunInspectionMode: props.isRunInspectionMode,
+    isEditing: props.isEditing,
+    hasCanvasId: !!props.runNodeDetailCanvasId,
+    hasRunOrLoading: !!props.runNodeDetailRun || !!props.runCanvasLoading,
+    factoryEmbed: props.factoryEmbed,
+    selectedNodeId: props.runNodeDetailNodeId,
+  });
 
   const renderInspectorSidebar = useCallback(
     (layout: "sidebar" | "bottom") => (
@@ -1567,6 +1571,7 @@ function CanvasPage(props: CanvasPageProps) {
                 <CanvasContent
                   state={state}
                   factoryId={props.factoryId}
+                  factoryEmbed={props.factoryEmbed}
                   onNodeDelete={handleNodeDelete}
                   onNodesDelete={handleNodesDelete}
                   onDuplicateNodes={props.onDuplicateNodes}
@@ -2194,6 +2199,7 @@ function applySidebarTabOnNodeOpen(
 function CanvasContent({
   state,
   factoryId,
+  factoryEmbed = false,
   onNodeDelete,
   onNodesDelete,
   onDuplicateNodes,
@@ -2245,6 +2251,7 @@ function CanvasContent({
 }: {
   state: CanvasPageState;
   factoryId?: string;
+  factoryEmbed?: boolean;
   onNodeDelete?: (nodeId: string) => void;
   onNodesDelete?: (nodeIds: string[]) => void;
   onDuplicateNodes?: (nodeIds: string[]) => void;
@@ -2926,6 +2933,9 @@ function CanvasContent({
     [getViewport, isReadOnly, isVerticalFlow, onConnectionDropInEmptySpace, setViewport, viewportRef],
   );
 
+  // Factory Live without a run is topology-only — no runtime status footers.
+  const showRuntimeStatus = !factoryEmbed || isRunInspectionMode;
+
   // Store callback handlers in a ref so they can be accessed without being in node data
   const callbacksRef = useRef({
     handleNodeClick,
@@ -2939,6 +2949,7 @@ function CanvasContent({
     showHeader,
     hasMultiSelection,
     canvasMode: isEditMode ? ("edit" as const) : ("live" as const),
+    showRuntimeStatus,
   });
   callbacksRef.current = {
     handleNodeClick,
@@ -2952,6 +2963,7 @@ function CanvasContent({
     showHeader,
     hasMultiSelection,
     canvasMode: isEditMode ? "edit" : "live",
+    showRuntimeStatus,
   };
 
   // Just pass the state nodes directly - callbacks will be added in nodeTypes

--- a/web_src/src/ui/CanvasPage/resolveRunInspectorOpen.spec.ts
+++ b/web_src/src/ui/CanvasPage/resolveRunInspectorOpen.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveRunInspectorOpen } from "./resolveRunInspectorOpen";
+
+describe("resolveRunInspectorOpen", () => {
+  const base = {
+    isRunInspectionMode: true,
+    isEditing: false,
+    hasCanvasId: true,
+    hasRunOrLoading: true,
+  };
+
+  it("opens for non-factory run inspection without a selected node", () => {
+    expect(resolveRunInspectorOpen(base)).toBe(true);
+  });
+
+  it("keeps factory run inspection closed until a node is selected", () => {
+    expect(resolveRunInspectorOpen({ ...base, factoryEmbed: true })).toBe(false);
+    expect(resolveRunInspectorOpen({ ...base, factoryEmbed: true, selectedNodeId: null })).toBe(false);
+    expect(resolveRunInspectorOpen({ ...base, factoryEmbed: true, selectedNodeId: "node-1" })).toBe(true);
+  });
+
+  it("stays closed while editing or outside run inspection", () => {
+    expect(resolveRunInspectorOpen({ ...base, isEditing: true })).toBe(false);
+    expect(resolveRunInspectorOpen({ ...base, isRunInspectionMode: false })).toBe(false);
+    expect(resolveRunInspectorOpen({ ...base, hasRunOrLoading: false })).toBe(false);
+  });
+});

--- a/web_src/src/ui/CanvasPage/resolveRunInspectorOpen.ts
+++ b/web_src/src/ui/CanvasPage/resolveRunInspectorOpen.ts
@@ -1,0 +1,25 @@
+/** Whether the right-hand run inspector panel should mount. */
+export function resolveRunInspectorOpen({
+  isRunInspectionMode,
+  isEditing,
+  hasCanvasId,
+  hasRunOrLoading,
+  factoryEmbed = false,
+  selectedNodeId,
+}: {
+  isRunInspectionMode?: boolean;
+  isEditing?: boolean;
+  hasCanvasId: boolean;
+  hasRunOrLoading: boolean;
+  factoryEmbed?: boolean;
+  selectedNodeId?: string | null;
+}): boolean {
+  if (!isRunInspectionMode || isEditing || !hasCanvasId || !hasRunOrLoading) {
+    return false;
+  }
+  // Factory: keep canvas clear until a node is selected (no empty "Select a node…" panel).
+  if (factoryEmbed && !selectedNodeId) {
+    return false;
+  }
+  return true;
+}

--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -92,6 +92,8 @@ export interface ComponentBaseProps extends ComponentActionsProps {
    * footer design. Non-factory canvases must leave this unset/false.
    */
   isFactoryApp?: boolean;
+  /** False on factory Live without a selected run (topology only). */
+  showRuntimeStatus?: boolean;
 }
 
 export const ComponentBase: React.FC<ComponentBaseProps> = (props) => {
@@ -115,6 +117,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = (props) => {
         onToggleView={props.onToggleView}
         isCompactView={props.isCompactView}
         canvasMode={props.canvasMode}
+        showRuntimeStatus={props.showRuntimeStatus}
       />
     );
   }

--- a/web_src/src/ui/composite/index.tsx
+++ b/web_src/src/ui/composite/index.tsx
@@ -68,6 +68,7 @@ export interface CompositeProps extends ComponentActionsProps {
   dimBodyBelowHeader?: boolean;
   draftDiffStatus?: DraftDiffStatus;
   isFactoryApp?: boolean;
+  showRuntimeStatus?: boolean;
 }
 
 export const Composite: React.FC<CompositeProps> = ({
@@ -93,6 +94,7 @@ export const Composite: React.FC<CompositeProps> = ({
   dimBodyBelowHeader,
   draftDiffStatus,
   isFactoryApp = false,
+  showRuntimeStatus,
   onDuplicate,
   onToggleView,
   onDelete,
@@ -216,6 +218,7 @@ export const Composite: React.FC<CompositeProps> = ({
       dimBodyBelowHeader={dimBodyBelowHeader}
       draftDiffStatus={draftDiffStatus}
       isFactoryApp={isFactoryApp}
+      showRuntimeStatus={showRuntimeStatus}
     />
   );
 };

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.spec.ts
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.spec.ts
@@ -14,4 +14,8 @@ describe("shouldShowFactoryNodeStatusFooter", () => {
   it("hides footer in compact view even when live", () => {
     expect(shouldShowFactoryNodeStatusFooter({ canvasMode: "live", isCompactView: true })).toBe(false);
   });
+
+  it("hides footer when runtime status is suppressed", () => {
+    expect(shouldShowFactoryNodeStatusFooter({ canvasMode: "live", showRuntimeStatus: false })).toBe(false);
+  });
 });

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
@@ -37,6 +37,8 @@ export type FactoryNodeCardProps = {
   isCompactView?: boolean;
   /** Edit mode hides the runtime status footer (no fake Pending). */
   canvasMode?: "live" | "edit";
+  /** False on factory Live without a selected run (topology only). */
+  showRuntimeStatus?: boolean;
 };
 
 function resolveSubtitle(
@@ -104,13 +106,18 @@ export function FactoryNodeCard({
   onToggleView,
   isCompactView,
   canvasMode = "live",
+  showRuntimeStatus = true,
 }: FactoryNodeCardProps) {
   const primarySection = eventSections?.[0];
   const status = normalizeFactoryNodeStatus(primarySection?.eventState);
   const metrics = useFactoryNodeMetrics(status, primarySection);
   const subtitle = resolveSubtitle(metadata, eventSections);
   const badgeText = error?.trim() || warning?.trim() || "";
-  const showStatusFooter = shouldShowFactoryNodeStatusFooter({ canvasMode, isCompactView });
+  const showStatusFooter = shouldShowFactoryNodeStatusFooter({
+    canvasMode,
+    isCompactView,
+    showRuntimeStatus,
+  });
 
   return (
     <div className="group relative" data-view-mode={isCompactView ? "compact" : "expanded"}>

--- a/web_src/src/ui/factoryNodeChrome/shouldShowFactoryNodeStatusFooter.ts
+++ b/web_src/src/ui/factoryNodeChrome/shouldShowFactoryNodeStatusFooter.ts
@@ -1,11 +1,15 @@
-/** Status footer is for live/run views only — not while editing the graph. */
+/** Status footer is for run-scoped / live views only — not edit, compact, or factory topology Live. */
 export function shouldShowFactoryNodeStatusFooter({
   canvasMode,
   isCompactView,
+  showRuntimeStatus = true,
 }: {
   canvasMode?: "live" | "edit";
   isCompactView?: boolean;
+  /** False on factory Live without a selected run (topology only). */
+  showRuntimeStatus?: boolean;
 }): boolean {
+  if (!showRuntimeStatus) return false;
   if (isCompactView) return false;
   if (canvasMode === "edit") return false;
   return true;


### PR DESCRIPTION
## Summary

Factory Live canvases painted each node from canvas-wide `lastExecutions`. That made work-order and automation views show stale status (for example PASSED from a run 6h earlier) on nodes the current run never reached.

This change keeps factory run views scoped to `?run=`, hides runtime status on factory Live, and opens the right inspector only after the user selects a node.

## Test plan

- [ ] From a work order, open a run that has not reached a later node; confirm that node has no PASSED/timestamp from another run
- [ ] Close the run inspector; confirm `?run=` stays and node status stays run-scoped
- [ ] Open factory Live without `?run=`; confirm nodes show topology only (no status footers)
- [ ] Click a node in a factory run; confirm the right inspector opens for that node only
- [ ] `make check.lint.ui` passes


Made with [Cursor](https://cursor.com)