### PR TITLE
fix: Make branch work order artifacts linkable

### DIFF
--- a/pkg/components/factory/add_work_order_artifact.go
+++ b/pkg/components/factory/add_work_order_artifact.go
@@ -56,7 +56,7 @@ Supported types:
 
 - **Pull request** (` + "`pr`" + `): requires ` + "`url`" + `; optional ` + "`number`" + ` and ` + "`title`" + `.
 - **Markdown note** (` + "`markdown`" + `): requires ` + "`body`" + `; optional ` + "`title`" + `.
-- **Branch** (` + "`branch`" + `): requires ` + "`name`" + ` (the branch name).
+- **Branch** (` + "`branch`" + `): requires ` + "`name`" + ` (the branch name); optional ` + "`url`" + ` links to the branch.
 
 PR and markdown types accept a free-form ` + "`data`" + ` list of ` + "`{name, value}`" + ` entries that gets merged into the artifact's ` + "`data`" + ` map. Typed inputs take precedence over free-form entries with the same key.
 
@@ -98,6 +98,7 @@ func (c *AddWorkOrderArtifact) OutputChannels(configuration any) []core.OutputCh
 
 func (c *AddWorkOrderArtifact) Configuration() []configuration.Field {
 	prOnly := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"pr"}}}
+	prOrBranch := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"pr", "branch"}}}
 	markdownOnly := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"markdown"}}}
 	branchOnly := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"branch"}}}
 	bothTypes := []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"pr", "markdown"}}}
@@ -132,10 +133,10 @@ func (c *AddWorkOrderArtifact) Configuration() []configuration.Field {
 		{
 			Name:                 "url",
 			Label:                "URL",
-			Description:          "Link to the pull request (must be http or https)",
+			Description:          "Link to the pull request or branch (must be http or https)",
 			Type:                 configuration.FieldTypeString,
 			Required:             false,
-			VisibilityConditions: prOnly,
+			VisibilityConditions: prOrBranch,
 			RequiredConditions: []configuration.RequiredCondition{
 				{Field: "artifactType", Values: []string{"pr"}},
 			},

--- a/pkg/components/factory/factory_components_spec_test.go
+++ b/pkg/components/factory/factory_components_spec_test.go
@@ -335,6 +335,20 @@ func TestAddWorkOrderArtifact_ValidatesConfiguration(t *testing.T) {
 	c := &AddWorkOrderArtifact{}
 	fields := c.Configuration()
 
+	t.Run("shows url for pull requests and branches", func(t *testing.T) {
+		var urlField *configuration.Field
+		for i := range fields {
+			if fields[i].Name == "url" {
+				urlField = &fields[i]
+				break
+			}
+		}
+
+		require.NotNil(t, urlField)
+		assert.Equal(t, []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"pr", "branch"}}}, urlField.VisibilityConditions)
+		assert.Equal(t, []configuration.RequiredCondition{{Field: "artifactType", Values: []string{"pr"}}}, urlField.RequiredConditions)
+	})
+
 	t.Run("requires url for pr", func(t *testing.T) {
 		err := configuration.ValidateConfiguration(fields, map[string]any{
 			"orderId":      "{{ order().id }}",
@@ -405,6 +419,18 @@ func TestAddWorkOrderArtifact_ValidatesConfiguration(t *testing.T) {
 			"orderId":      "{{ order().id }}",
 			"artifactType": "branch",
 			"name":         "feature/refund-retry",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("accepts branch with name and url", func(t *testing.T) {
+		err := configuration.ValidateConfiguration(fields, map[string]any{
+			"orderId":      "{{ order().id }}",
+			"artifactType": "branch",
+			"name":         "feature/refund-retry",
+			"url":          "https://github.com/example/repo/tree/feature/refund-retry",
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/web_src/src/pages/factories/WorkOrderArtifactsList.spec.tsx
+++ b/web_src/src/pages/factories/WorkOrderArtifactsList.spec.tsx
@@ -1,10 +1,14 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { WorkOrderArtifactsList } from "./WorkOrderArtifactsList";
 
+vi.mock("@/pages/app/Markdown", () => ({
+  MarkdownContent: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
 describe("WorkOrderArtifactsList", () => {
-  it("left-aligns linked and markdown artifacts to the same row width", () => {
+  it("left-aligns linked, branch, and markdown artifacts to the same row width", () => {
     render(
       <WorkOrderArtifactsList
         isLoading={false}
@@ -19,18 +23,49 @@ describe("WorkOrderArtifactsList", () => {
             type: "TYPE_MARKDOWN",
             data: { title: "Release note", body: "Ready" },
           },
+          {
+            id: "branch",
+            type: "TYPE_BRANCH",
+            data: {
+              name: "feature/refund-retry",
+              url: "https://github.com/example/repo/tree/feature/refund-retry",
+            },
+          },
         ]}
       />,
     );
 
-    const pullRequest = screen.getByRole("link");
+    const pullRequest = screen.getByRole("link", { name: "#42" });
+    const branch = screen.getByRole("link", { name: "feature/refund-retry" });
     const note = screen.getByRole("button", { name: "Release note" });
 
     expect(pullRequest).toHaveClass("inline-flex", "w-full", "justify-start");
+    expect(branch).toHaveAttribute("href", "https://github.com/example/repo/tree/feature/refund-retry");
+    expect(branch).toHaveAttribute("target", "_blank");
+    expect(branch).toHaveAttribute("rel", "noopener noreferrer");
+    expect(branch).toHaveClass("inline-flex", "w-full", "justify-start");
     expect(note).toHaveClass("inline-flex", "w-full", "justify-start", "p-0");
     expect(note).not.toHaveAttribute("data-slot", "button");
 
     fireEvent.click(note);
     expect(screen.getByRole("dialog").parentElement).toBe(document.body);
+  });
+
+  it("does not link a branch artifact without a URL", () => {
+    render(
+      <WorkOrderArtifactsList
+        isLoading={false}
+        artifacts={[
+          {
+            id: "branch",
+            type: "TYPE_BRANCH",
+            data: { name: "feature/refund-retry" },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("feature/refund-retry")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "feature/refund-retry" })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Allow branch work order artifacts to store a provider URL.
- Link a branch artifact when its URL is safe.
- Keep name-only branch artifacts as plain text.

Fixes #6675

## Test plan

- [x] Run the targeted Go factory component tests with Go 1.26.2.
- [x] Run the work-order artifact React test.
- [x] Check frontend formatting and lint budget.
- [ ] Run the full frontend build after generated API client files are available.
