### PR TITLE
fix: page through every Hetzner listing so dropdowns show all resources

### DIFF
--- a/pkg/integrations/hetzner/client.go
+++ b/pkg/integrations/hetzner/client.go
@@ -172,6 +172,12 @@ func decodeJSON(r io.Reader, result any) error {
 		return err
 	}
 
+	return decodeValue(raw, result)
+}
+
+// decodeValue decodes an already-parsed JSON value into the target struct,
+// with the same weak typing decodeJSON applies to whole response bodies.
+func decodeValue(value any, result any) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Result:           result,
 		TagName:          "json",
@@ -181,7 +187,60 @@ func decodeJSON(r io.Reader, result any) error {
 		return err
 	}
 
-	return decoder.Decode(raw)
+	return decoder.Decode(value)
+}
+
+// listPerPage is the largest page Hetzner serves. The API defaults to 25 items
+// and caps per_page at 50, so every listing has to follow next_page to the end.
+const listPerPage = 50
+
+type paginationMeta struct {
+	Pagination struct {
+		NextPage *int `json:"next_page"`
+	} `json:"pagination"`
+}
+
+// listAll returns every page of a Hetzner collection endpoint. collection is the
+// key the items arrive under (for example "servers" for /servers), and the
+// walk follows meta.pagination.next_page until the API reports no further page.
+func listAll[T any](c *Client, path, collection string) ([]T, error) {
+	all := []T{}
+	page := 1
+
+	for {
+		resp, err := c.do("GET", fmt.Sprintf("%s?per_page=%d&page=%d", path, listPerPage, page), nil)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, c.parseError(resp)
+		}
+
+		var body map[string]any
+		if err := decodeJSON(resp.Body, &body); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("decode list %s response: %w", collection, err)
+		}
+		resp.Body.Close()
+
+		var items []T
+		if err := decodeValue(body[collection], &items); err != nil {
+			return nil, fmt.Errorf("decode list %s response: %w", collection, err)
+		}
+		all = append(all, items...)
+
+		var meta paginationMeta
+		if err := decodeValue(body["meta"], &meta); err != nil {
+			return nil, fmt.Errorf("decode list %s pagination: %w", collection, err)
+		}
+
+		// next_page is null on the last page. The <= guard keeps a malformed
+		// response from looping forever.
+		if meta.Pagination.NextPage == nil || *meta.Pagination.NextPage <= page {
+			return all, nil
+		}
+		page = *meta.Pagination.NextPage
+	}
 }
 
 func (c *Client) parseError(resp *http.Response) error {
@@ -327,45 +386,13 @@ func (c *Client) CreateServerSnapshot(serverID, description string) (*ImageRespo
 }
 
 func (c *Client) ListServers() ([]ServerResponse, error) {
-	resp, err := c.do("GET", "/servers?per_page=50", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, c.parseError(resp)
-	}
-
-	var out struct {
-		Servers []ServerResponse `json:"servers"`
-	}
-	if err := decodeJSON(resp.Body, &out); err != nil {
-		return nil, fmt.Errorf("decode list servers response: %w", err)
-	}
-	return out.Servers, nil
+	return listAll[ServerResponse](c, "/servers", "servers")
 }
 
 // load balancer actions
 
 func (c *Client) ListLoadBalancers() ([]ServerResponse, error) {
-	resp, err := c.do("GET", "/load_balancers?per_page=50", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, c.parseError(resp)
-	}
-
-	var out struct {
-		LoadBalancers []ServerResponse `json:"load_balancers"`
-	}
-	if err := decodeJSON(resp.Body, &out); err != nil {
-		return nil, fmt.Errorf("decode list load balancers response: %w", err)
-	}
-	return out.LoadBalancers, nil
+	return listAll[ServerResponse](c, "/load_balancers", "load_balancers")
 }
 
 func (c *Client) CreateLoadBalancer(name, loadBalancerType, location, algorithm string) (*ServerResponse, *ActionResponse, error) {
@@ -429,23 +456,7 @@ type ServerTypeResponse struct {
 }
 
 func (c *Client) ListServerTypes() ([]ServerTypeResponse, error) {
-	resp, err := c.do("GET", "/server_types?per_page=50", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, c.parseError(resp)
-	}
-
-	var out struct {
-		ServerTypes []ServerTypeResponse `json:"server_types"`
-	}
-	if err := decodeJSON(resp.Body, &out); err != nil {
-		return nil, fmt.Errorf("decode list server types response: %w", err)
-	}
-	return out.ServerTypes, nil
+	return listAll[ServerTypeResponse](c, "/server_types", "server_types")
 }
 
 // ServerTypeLocationNames returns the location names (e.g. fsn1, nbg1) where the given server type is available.
@@ -498,48 +509,24 @@ type ImageResponse struct {
 }
 
 func (c *Client) ListImages() ([]ImageResponse, error) {
-	all := []ImageResponse{}
-	seen := map[int]struct{}{}
-	page := 1
-
-	for {
-		resp, err := c.do("GET", fmt.Sprintf("/images?per_page=50&page=%d", page), nil)
-		if err != nil {
-			return nil, err
-		}
-		if resp.StatusCode != http.StatusOK {
-			return nil, c.parseError(resp)
-		}
-
-		var out struct {
-			Images []ImageResponse `json:"images"`
-			Meta   struct {
-				Pagination struct {
-					NextPage *int `json:"next_page"`
-				} `json:"pagination"`
-			} `json:"meta"`
-		}
-		if err := decodeJSON(resp.Body, &out); err != nil {
-			resp.Body.Close()
-			return nil, fmt.Errorf("decode list images response: %w", err)
-		}
-		resp.Body.Close()
-
-		for _, img := range out.Images {
-			if _, ok := seen[img.ID]; ok {
-				continue
-			}
-			seen[img.ID] = struct{}{}
-			all = append(all, img)
-		}
-
-		if out.Meta.Pagination.NextPage == nil || *out.Meta.Pagination.NextPage <= page {
-			break
-		}
-		page = *out.Meta.Pagination.NextPage
+	images, err := listAll[ImageResponse](c, "/images", "images")
+	if err != nil {
+		return nil, err
 	}
 
-	return all, nil
+	// A page walk can see the same image twice when the underlying list changes
+	// between requests, so only the first occurrence of an ID is kept.
+	unique := make([]ImageResponse, 0, len(images))
+	seen := map[int]struct{}{}
+	for _, image := range images {
+		if _, ok := seen[image.ID]; ok {
+			continue
+		}
+		seen[image.ID] = struct{}{}
+		unique = append(unique, image)
+	}
+
+	return unique, nil
 }
 
 func (c *Client) GetImage(imageID string) (*ImageResponse, error) {
@@ -607,43 +594,11 @@ func (l *LocationResponse) LocationDisplayName() string {
 }
 
 func (c *Client) ListLocations() ([]LocationResponse, error) {
-	resp, err := c.do("GET", "/locations?per_page=50", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, c.parseError(resp)
-	}
-
-	var out struct {
-		Locations []LocationResponse `json:"locations"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, fmt.Errorf("decode list locations response: %w", err)
-	}
-	return out.Locations, nil
+	return listAll[LocationResponse](c, "/locations", "locations")
 }
 
 func (c *Client) ListFirewalls() ([]FirewallResponse, error) {
-	resp, err := c.do("GET", "/firewalls?per_page=50", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, c.parseError(resp)
-	}
-
-	var out struct {
-		Firewalls []FirewallResponse `json:"firewalls"`
-	}
-	if err := decodeJSON(resp.Body, &out); err != nil {
-		return nil, fmt.Errorf("decode list firewalls response: %w", err)
-	}
-	return out.Firewalls, nil
+	return listAll[FirewallResponse](c, "/firewalls", "firewalls")
 }
 
 func (c *Client) Verify() error {
@@ -667,23 +622,7 @@ type LoadBalancerTypeResponse struct {
 }
 
 func (c *Client) ListLoadBalancerTypes() ([]LoadBalancerTypeResponse, error) {
-	resp, err := c.do("GET", "/load_balancer_types", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, c.parseError(resp)
-	}
-
-	var out struct {
-		LoadBalancerTypes []LoadBalancerTypeResponse `json:"load_balancer_types"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, fmt.Errorf("decode list load balancer types response: %w", err)
-	}
-	return out.LoadBalancerTypes, nil
+	return listAll[LoadBalancerTypeResponse](c, "/load_balancer_types", "load_balancer_types")
 }
 
 // resolveServerID extracts the server ID from the configuration map,

--- a/pkg/integrations/hetzner/client_test.go
+++ b/pkg/integrations/hetzner/client_test.go
@@ -1,0 +1,213 @@
+package hetzner
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func hetznerResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func testClient(responses ...*http.Response) (*Client, *contexts.HTTPContext) {
+	httpCtx := &contexts.HTTPContext{Responses: responses}
+	return &Client{Token: "token", BaseURL: defaultHetznerBaseURL, http: httpCtx}, httpCtx
+}
+
+func requestPaths(t *testing.T, httpCtx *contexts.HTTPContext) []string {
+	t.Helper()
+
+	paths := make([]string, 0, len(httpCtx.Requests))
+	for _, request := range httpCtx.Requests {
+		paths = append(paths, request.URL.Path+"?"+request.URL.RawQuery)
+	}
+	return paths
+}
+
+func TestClient_ListServers_FollowsEveryPage(t *testing.T) {
+	t.Run("collects servers from all pages", func(t *testing.T) {
+		client, httpCtx := testClient(
+			hetznerResponse(200, `{
+				"servers": [{"id": 1, "name": "server-1"}, {"id": 2, "name": "server-2"}],
+				"meta": {"pagination": {"page": 1, "per_page": 50, "next_page": 2, "last_page": 2, "total_entries": 3}}
+			}`),
+			hetznerResponse(200, `{
+				"servers": [{"id": 3, "name": "server-3"}],
+				"meta": {"pagination": {"page": 2, "per_page": 50, "next_page": null, "last_page": 2, "total_entries": 3}}
+			}`),
+		)
+
+		servers, err := client.ListServers()
+
+		require.NoError(t, err)
+		require.Len(t, servers, 3)
+		assert.Equal(t, []string{"server-1", "server-2", "server-3"}, []string{servers[0].Name, servers[1].Name, servers[2].Name})
+		assert.Equal(t, "3", servers[2].ID)
+		assert.Equal(t, []string{
+			"/v1/servers?per_page=50&page=1",
+			"/v1/servers?per_page=50&page=2",
+		}, requestPaths(t, httpCtx))
+	})
+
+	t.Run("stops after a page without a next one", func(t *testing.T) {
+		client, httpCtx := testClient(
+			hetznerResponse(200, `{
+				"servers": [{"id": 1, "name": "server-1"}],
+				"meta": {"pagination": {"page": 1, "per_page": 50, "next_page": null}}
+			}`),
+		)
+
+		servers, err := client.ListServers()
+
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		assert.Len(t, requestPaths(t, httpCtx), 1)
+	})
+
+	t.Run("stops when next_page does not advance", func(t *testing.T) {
+		client, httpCtx := testClient(
+			hetznerResponse(200, `{
+				"servers": [{"id": 1, "name": "server-1"}],
+				"meta": {"pagination": {"page": 1, "per_page": 50, "next_page": 1}}
+			}`),
+		)
+
+		servers, err := client.ListServers()
+
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		assert.Len(t, requestPaths(t, httpCtx), 1)
+	})
+
+	t.Run("surfaces an API error raised on a later page", func(t *testing.T) {
+		client, _ := testClient(
+			hetznerResponse(200, `{
+				"servers": [{"id": 1, "name": "server-1"}],
+				"meta": {"pagination": {"page": 1, "per_page": 50, "next_page": 2}}
+			}`),
+			hetznerResponse(503, `{"error": {"code": "unavailable", "message": "service unavailable"}}`),
+		)
+
+		servers, err := client.ListServers()
+
+		require.Error(t, err)
+		assert.Nil(t, servers)
+		assert.ErrorContains(t, err, "service unavailable")
+	})
+}
+
+func TestClient_ListResources_PaginateEveryCollection(t *testing.T) {
+	t.Run("load balancers", func(t *testing.T) {
+		client, httpCtx := testClient(
+			hetznerResponse(200, `{"load_balancers": [{"id": 1, "name": "lb-1"}], "meta": {"pagination": {"next_page": 2}}}`),
+			hetznerResponse(200, `{"load_balancers": [{"id": 2, "name": "lb-2"}], "meta": {"pagination": {"next_page": null}}}`),
+		)
+
+		loadBalancers, err := client.ListLoadBalancers()
+
+		require.NoError(t, err)
+		require.Len(t, loadBalancers, 2)
+		assert.Equal(t, "/v1/load_balancers?per_page=50&page=2", requestPaths(t, httpCtx)[1])
+	})
+
+	t.Run("firewalls", func(t *testing.T) {
+		client, httpCtx := testClient(
+			hetznerResponse(200, `{"firewalls": [{"id": 1, "name": "firewall-1"}], "meta": {"pagination": {"next_page": 2}}}`),
+			hetznerResponse(200, `{"firewalls": [{"id": 2, "name": "firewall-2"}], "meta": {"pagination": {"next_page": null}}}`),
+		)
+
+		firewalls, err := client.ListFirewalls()
+
+		require.NoError(t, err)
+		require.Len(t, firewalls, 2)
+		assert.Equal(t, 2, firewalls[1].ID)
+		assert.Equal(t, "/v1/firewalls?per_page=50&page=2", requestPaths(t, httpCtx)[1])
+	})
+
+	t.Run("server types", func(t *testing.T) {
+		client, httpCtx := testClient(
+			hetznerResponse(200, `{"server_types": [{"id": 1, "name": "cx22", "cores": 2}], "meta": {"pagination": {"next_page": 2}}}`),
+			hetznerResponse(200, `{"server_types": [{"id": 2, "name": "cpx51", "cores": 16}], "meta": {"pagination": {"next_page": null}}}`),
+		)
+
+		serverTypes, err := client.ListServerTypes()
+
+		require.NoError(t, err)
+		require.Len(t, serverTypes, 2)
+		assert.Equal(t, "cpx51", serverTypes[1].Name)
+		assert.Equal(t, "/v1/server_types?per_page=50&page=2", requestPaths(t, httpCtx)[1])
+	})
+
+	t.Run("load balancer types", func(t *testing.T) {
+		client, httpCtx := testClient(
+			hetznerResponse(200, `{"load_balancer_types": [{"id": 1, "name": "lb11"}], "meta": {"pagination": {"next_page": 2}}}`),
+			hetznerResponse(200, `{"load_balancer_types": [{"id": 2, "name": "lb21"}], "meta": {"pagination": {"next_page": null}}}`),
+		)
+
+		types, err := client.ListLoadBalancerTypes()
+
+		require.NoError(t, err)
+		require.Len(t, types, 2)
+		assert.Equal(t, "lb21", types[1].Name)
+		assert.Equal(t, "/v1/load_balancer_types?per_page=50&page=2", requestPaths(t, httpCtx)[1])
+	})
+
+	t.Run("locations", func(t *testing.T) {
+		client, httpCtx := testClient(
+			hetznerResponse(200, `{"locations": [{"id": 1, "name": "fsn1", "city": "Falkenstein", "country": "DE"}], "meta": {"pagination": {"next_page": 2}}}`),
+			hetznerResponse(200, `{"locations": [{"id": 2, "name": "nbg1", "city": "Nuremberg", "country": "DE"}], "meta": {"pagination": {"next_page": null}}}`),
+		)
+
+		locations, err := client.ListLocations()
+
+		require.NoError(t, err)
+		require.Len(t, locations, 2)
+		assert.Equal(t, "nbg1", locations[1].Name)
+		assert.Equal(t, "/v1/locations?per_page=50&page=2", requestPaths(t, httpCtx)[1])
+	})
+}
+
+func TestClient_ListImages_DropsDuplicatesAcrossPages(t *testing.T) {
+	client, _ := testClient(
+		hetznerResponse(200, `{"images": [{"id": 1, "name": "ubuntu-24.04"}, {"id": 2, "name": "debian-12"}], "meta": {"pagination": {"next_page": 2}}}`),
+		hetznerResponse(200, `{"images": [{"id": 2, "name": "debian-12"}, {"id": 3, "name": "snapshot"}], "meta": {"pagination": {"next_page": null}}}`),
+	)
+
+	images, err := client.ListImages()
+
+	require.NoError(t, err)
+	require.Len(t, images, 3)
+	assert.Equal(t, []int{1, 2, 3}, []int{images[0].ID, images[1].ID, images[2].ID})
+}
+
+func TestClient_ListServers_ReadsEveryPageOfAFullAccount(t *testing.T) {
+	// A single page tops out at 50 entries, which is where the listings used to
+	// stop and hide the rest of the account.
+	first := make([]string, 0, listPerPage)
+	for i := 1; i <= listPerPage; i++ {
+		first = append(first, fmt.Sprintf(`{"id": %d, "name": "server-%d"}`, i, i))
+	}
+
+	client, _ := testClient(
+		hetznerResponse(200, fmt.Sprintf(`{"servers": [%s], "meta": {"pagination": {"page": 1, "next_page": 2}}}`, strings.Join(first, ","))),
+		hetznerResponse(200, `{"servers": [{"id": 51, "name": "server-51"}], "meta": {"pagination": {"page": 2, "next_page": null}}}`),
+	)
+
+	servers, err := client.ListServers()
+
+	require.NoError(t, err)
+	require.Len(t, servers, listPerPage+1)
+	assert.Equal(t, "server-51", servers[listPerPage].Name)
+}

--- a/pkg/integrations/hetzner/hetzner_test.go
+++ b/pkg/integrations/hetzner/hetzner_test.go
@@ -1,0 +1,33 @@
+package hetzner
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func TestHetzner_ListResources_FiltersLocationsByAServerTypeOnALaterPage(t *testing.T) {
+	integration := &Hetzner{}
+
+	// The Location picker narrows to the locations that sell the chosen server
+	// type. Resolving that type reads the server type listing, which used to end
+	// at the first page and leave the filter unapplied.
+	resources, err := integration.ListResources("location", core.ListResourcesContext{
+		HTTP: &contexts.HTTPContext{Responses: []*http.Response{
+			hetznerResponse(200, `{"locations": [{"id": 1, "name": "fsn1", "city": "Falkenstein", "country": "DE"}, {"id": 2, "name": "hil", "city": "Hillsboro", "country": "US"}], "meta": {"pagination": {"next_page": null}}}`),
+			hetznerResponse(200, `{"server_types": [{"id": 1, "name": "cx22", "prices": [{"location": "fsn1"}, {"location": "hil"}]}], "meta": {"pagination": {"next_page": 2}}}`),
+			hetznerResponse(200, `{"server_types": [{"id": 2, "name": "ccx63", "prices": [{"location": "fsn1"}]}], "meta": {"pagination": {"next_page": null}}}`),
+		}},
+		Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiToken": "token"}},
+		Parameters:  map[string]string{"serverType": "ccx63"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "fsn1", resources[0].ID)
+	assert.Equal(t, "Falkenstein, DE (fsn1)", resources[0].Name)
+}


### PR DESCRIPTION
## What changed

`pkg/integrations/hetzner/client.go` now walks every page of the Hetzner Cloud API list endpoints instead of returning only the first one. A `listAll` helper follows `meta.pagination.next_page` until the API reports no further page, and it backs `ListServers`, `ListLoadBalancers`, `ListFirewalls`, `ListServerTypes`, `ListLoadBalancerTypes`, `ListLocations` and `ListImages`.

## Why

The Hetzner Cloud API returns 25 items per page by default and [caps `per_page` at 50](https://docs.hetzner.cloud/reference/cloud#pagination); everything past that is reachable only through `meta.pagination.next_page`.

Every listing except `ListImages` requested a single page and returned it as if it were the whole collection:

```go
func (c *Client) ListServers() ([]ServerResponse, error) {
	resp, err := c.do("GET", "/servers?per_page=50", nil)
	...
}
```

These functions back the integration's resource pickers in `hetzner.go` (`ListResources` for `server`, `load_balancer`, `firewall`, `server_type`, `location`, `load_balancer_type`), so on a project with more than 50 servers the Delete Server / Create Snapshot / Create Server dropdowns silently omit everything after the first 50, with no way for the user to reach them. The same applies to firewalls and load balancers. `ListLoadBalancerTypes` sent no `per_page` at all, so it stopped at the API default of 25.

`ListServerTypes` is also used by `ServerTypeLocationNames`, which filters the Location dropdown to the locations that support the selected server type — a server type on a later page resolved to "server type not found" and the filter was skipped.

`ListImages` already paged correctly; it is the pattern the rest now follow.

## How

`listAll[T]` issues `?per_page=50&page=N` and follows `next_page` until it is `null` (a `next_page <= page` guard keeps a malformed response from looping). Responses are decoded with the existing weak-typed `decodeJSON` path, extracted into `decodeValue` so a parsed body can be decoded per key — Hetzner nests items under a different key per endpoint (`servers`, `firewalls`, …). `ListImages` keeps its de-duplication by ID, since a page walk can see the same image twice when the underlying list changes between requests. Net effect on the file is ~130 fewer lines.

## Tests

New `pkg/integrations/hetzner/client_test.go` (first tests for this client) covers:

- multi-page collection for each listing, asserting both the merged results and the requested URLs
- stopping on `next_page: null` and on a non-advancing `next_page`
- an API error raised on a later page being surfaced rather than swallowed
- a full 50-item first page followed by a second page — the exact shape that used to truncate
- `ListImages` de-duplicating an entry repeated across pages

`hetzner_test.go` adds one case at the picker level: filtering the Location dropdown by a server type that lives on the second page. Before this change the type could not be resolved, so the filter was silently skipped and unsupported locations stayed on the list.

Every test except the `ListImages` one fails against the code as it was before this change.

```
go test ./pkg/integrations/hetzner/...
ok  	github.com/superplanehq/superplane/pkg/integrations/hetzner
```