### PR TITLE
feat: WO routing using workspace key and number

### DIFF
--- a/test/e2e/factories_test.go
+++ b/test/e2e/factories_test.go
@@ -22,7 +22,7 @@ func TestFactories(t *testing.T) {
 
 		steps.start()
 		factory := steps.givenFactoryExists(originalName, "original description")
-		steps.visitFactorySettings(factory.ID)
+		steps.visitFactorySettings(factory)
 		steps.fillFactorySettingsName(updatedName)
 		steps.fillFactorySettingsDescription("updated description")
 		steps.submitFactorySettings()
@@ -36,7 +36,7 @@ func TestFactories(t *testing.T) {
 
 		steps.start()
 		factory := steps.givenFactoryExists(name, "will be deleted")
-		steps.visitFactorySettings(factory.ID)
+		steps.visitFactorySettings(factory)
 		steps.clickDeleteFactory()
 		steps.confirmDeleteFactory()
 		steps.assertRedirectedToFactoriesList()
@@ -73,9 +73,9 @@ func (s *factorySteps) visitFactoriesList() {
 	s.session.Sleep(500)
 }
 
-func (s *factorySteps) visitFactorySettings(factoryID uuid.UUID) {
-	s.session.Visit("/" + s.session.OrgID.String() + "/workspaces/" + factoryID.String() + "/settings/general")
-	s.session.Sleep(500)
+func (s *factorySteps) visitFactorySettings(factory *models.Factory) {
+	s.session.Visit("/" + s.session.OrgID.String() + "/workspaces/" + factory.Key + "/settings/general")
+	s.session.AssertVisible(q.TestID("factory-settings-name"))
 }
 
 func (s *factorySteps) fillFactorySettingsName(name string) {

--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -34,6 +34,7 @@ import {
   FactorySettingsLayout,
   FactorySettingsSoonPage,
   FACTORY_SETTINGS_NAV_ITEMS,
+  LegacyWorkOrderDetailRedirect,
   LinesPage,
   MissionsPage,
   OverviewPage,
@@ -162,7 +163,7 @@ function AppRouter() {
                     element={withAuthPermissionAndFactoriesFeature(FactoriesIndexPage, "factories", "read")}
                   />
                   <Route
-                    path=":factoryId"
+                    path=":factoryKey"
                     element={withAuthPermissionAndFactoriesFeature(FactoriesLayout, "factories", "read")}
                   >
                     <Route index element={<Navigate to="overview" replace />} />
@@ -173,8 +174,10 @@ function AppRouter() {
                     <Route path="work-orders">
                       <Route index element={<WorkOrdersPage />} />
                       <Route path="new" element={<CreateWorkOrderPageGate />} />
-                      <Route path=":orderId" element={<WorkOrderDetailPage />} />
+                      {/* Legacy `/work-orders/:orderId` bookmark shape — redirects to `/work-order/:number`. */}
+                      <Route path=":orderId" element={<LegacyWorkOrderDetailRedirect />} />
                     </Route>
+                    <Route path="work-order/:orderNumber" element={<WorkOrderDetailPage />} />
                     <Route path="lines">
                       <Route index element={<LinesPage />} />
                       <Route path="new" element={<FactoryLineEditPageGate />} />
@@ -191,7 +194,7 @@ function AppRouter() {
                     <Route path="settings/*" element={<Navigate to={FACTORY_SETTINGS_NAV_ITEMS[0].id} replace />} />
                   </Route>
                   <Route
-                    path=":factoryId/settings"
+                    path=":factoryKey/settings"
                     element={withAuthPermissionAndFactoriesFeature(FactorySettingsLayout, "factories", "read")}
                   >
                     <Route index element={<Navigate to={FACTORY_SETTINGS_NAV_ITEMS[0].id} replace />} />
@@ -263,23 +266,23 @@ function FactoryLineEditPageGate() {
 }
 
 function LegacyAutomationsNewLineRedirect() {
-  const { organizationId, factoryId } = useParams<{ organizationId: string; factoryId: string }>();
-  if (!organizationId || !factoryId) {
+  const { organizationId, factoryKey } = useParams<{ organizationId: string; factoryKey: string }>();
+  if (!organizationId || !factoryKey) {
     return <Navigate to="/" replace />;
   }
-  return <Navigate to={createFactoryLinePath(organizationId, factoryId)} replace />;
+  return <Navigate to={createFactoryLinePath(organizationId, factoryKey)} replace />;
 }
 
 function LegacyAutomationsLineEditRedirect() {
-  const { organizationId, factoryId, lineId } = useParams<{
+  const { organizationId, factoryKey, lineId } = useParams<{
     organizationId: string;
-    factoryId: string;
+    factoryKey: string;
     lineId: string;
   }>();
-  if (!organizationId || !factoryId || !lineId) {
+  if (!organizationId || !factoryKey || !lineId) {
     return <Navigate to="/" replace />;
   }
-  return <Navigate to={editFactoryLinePath(organizationId, factoryId, lineId)} replace />;
+  return <Navigate to={editFactoryLinePath(organizationId, factoryKey, lineId)} replace />;
 }
 
 function LegacyCanvasRedirect({ settings = false }: { settings?: boolean }) {

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -235,6 +235,9 @@ export function useDeleteFactory(organizationId: string) {
       return factoryId;
     },
     onSuccess: (factoryId) => {
+      queryClient.setQueryData<FactoriesFactory[]>(factoryListKey(organizationId), (current) =>
+        (current ?? []).filter((factory) => factory.id !== factoryId),
+      );
       queryClient.removeQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
       void queryClient.invalidateQueries({ queryKey: factoryListKey(organizationId) });
     },

--- a/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
+++ b/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
@@ -25,6 +25,7 @@ import {
   FactorySettingsLayout,
   FactorySettingsSoonPage,
   FACTORY_SETTINGS_NAV_ITEMS,
+  LegacyWorkOrderDetailRedirect,
   LinesPage,
   MissionsPage,
   OverviewPage,
@@ -162,23 +163,23 @@ function factoryRoute(element: React.ReactNode) {
 }
 
 function HarnessLegacyAutomationsNewLineRedirect() {
-  const { organizationId, factoryId } = useParams<{ organizationId: string; factoryId: string }>();
-  if (!organizationId || !factoryId) {
+  const { organizationId, factoryKey } = useParams<{ organizationId: string; factoryKey: string }>();
+  if (!organizationId || !factoryKey) {
     return <Navigate to="/" replace />;
   }
-  return <Navigate to={createFactoryLinePath(organizationId, factoryId)} replace />;
+  return <Navigate to={createFactoryLinePath(organizationId, factoryKey)} replace />;
 }
 
 function HarnessLegacyAutomationsLineEditRedirect() {
-  const { organizationId, factoryId, lineId } = useParams<{
+  const { organizationId, factoryKey, lineId } = useParams<{
     organizationId: string;
-    factoryId: string;
+    factoryKey: string;
     lineId: string;
   }>();
-  if (!organizationId || !factoryId || !lineId) {
+  if (!organizationId || !factoryKey || !lineId) {
     return <Navigate to="/" replace />;
   }
-  return <Navigate to={editFactoryLinePath(organizationId, factoryId, lineId)} replace />;
+  return <Navigate to={editFactoryLinePath(organizationId, factoryKey, lineId)} replace />;
 }
 
 function OptionalOnboardingGate({ enabled }: { enabled: boolean }) {
@@ -209,7 +210,7 @@ function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePag
         <Route path="apps/:appId" element={<AppPage />} />
         <Route path="workspaces">
           <Route index element={factoryRoute(<FactoriesIndexPage />)} />
-          <Route path=":factoryId" element={factoryRoute(<FactoriesLayout />)}>
+          <Route path=":factoryKey" element={factoryRoute(<FactoriesLayout />)}>
             <Route element={<OptionalOnboardingGate enabled={onboardingEnabled} />}>
               <Route index element={<Navigate to="overview" replace />} />
               {OnboardingRoutePage ? <Route path="onboarding" element={<OnboardingRoutePage />} /> : null}
@@ -220,8 +221,9 @@ function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePag
               <Route path="work-orders">
                 <Route index element={<WorkOrdersPage />} />
                 <Route path="new" element={<CreateWorkOrderPage />} />
-                <Route path=":orderId" element={<WorkOrderDetailPage />} />
+                <Route path=":orderId" element={<LegacyWorkOrderDetailRedirect />} />
               </Route>
+              <Route path="work-order/:orderNumber" element={<WorkOrderDetailPage />} />
               <Route path="lines">
                 <Route index element={<LinesPage />} />
                 <Route path="new" element={<FactoryLineEditPage />} />
@@ -239,7 +241,7 @@ function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePag
               <Route path="apps/:appId" element={<FactoryAppCanvasPage />} />
             </Route>
           </Route>
-          <Route path=":factoryId/settings" element={factoryRoute(<FactorySettingsLayout />)}>
+          <Route path=":factoryKey/settings" element={factoryRoute(<FactorySettingsLayout />)}>
             <Route index element={<Navigate to={FACTORY_SETTINGS_NAV_ITEMS[0].id} replace />} />
             <Route path="general" element={<FactorySettingsGeneralPage />} />
             {FACTORY_SETTINGS_NAV_ITEMS.filter((item) => item.id !== "general").map((item) => (

--- a/web_src/src/pages/factories/FactoriesIndexPage.tsx
+++ b/web_src/src/pages/factories/FactoriesIndexPage.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { CreateFactoryDialog } from "./CreateFactoryDialog";
 import { factoryDetailPath, factoryOnboardingPath } from "./lib/factoryPagePaths";
-import { pickInitialFactoryId, readLastVisitedFactory } from "./lib/lastVisitedFactory";
+import { pickInitialFactory, readLastVisitedFactory } from "./lib/lastVisitedFactory";
 import { useFactoriesThemeClass } from "./lib/useFactoriesThemeClass";
 import { useOnboardingStorybook } from "./pages/onboarding/useOnboardingStorybook";
 
@@ -62,10 +62,10 @@ function FactoriesIndexPageContent({ organizationId }: { organizationId: string 
   }
 
   const lastVisited = account?.id ? readLastVisitedFactory(account.id, organizationId) : null;
-  const targetFactoryId = pickInitialFactoryId(factories, lastVisited);
+  const targetFactory = pickInitialFactory(factories, lastVisited);
 
-  if (targetFactoryId) {
-    return <Navigate to={factoryDetailPath(organizationId, targetFactoryId)} replace />;
+  if (targetFactory?.key) {
+    return <Navigate to={factoryDetailPath(organizationId, targetFactory.key)} replace />;
   }
 
   const canCreate = canAct("factories", "create");
@@ -74,18 +74,18 @@ function FactoriesIndexPageContent({ organizationId }: { organizationId: string 
     // Let CreateFactoryDialog catch failures so duplicate-name inline errors work.
     const factory = await createFactory.mutateAsync(input);
     setCreateOpen(false);
-    if (!factory.id) {
+    if (!factory.key) {
       return;
     }
-    if (storybookOnboarding) {
+    if (storybookOnboarding && factory.id) {
       storybookOnboarding.beginOnboarding({
         workspaceId: factory.id,
         workspaceName: factory.name || input.name,
       });
-      navigate(factoryOnboardingPath(organizationId, factory.id));
+      navigate(factoryOnboardingPath(organizationId, factory.key));
       return;
     }
-    navigate(factoryDetailPath(organizationId, factory.id));
+    navigate(factoryDetailPath(organizationId, factory.key));
   };
 
   return (

--- a/web_src/src/pages/factories/WorkOrderActivityTimeline.stories.tsx
+++ b/web_src/src/pages/factories/WorkOrderActivityTimeline.stories.tsx
@@ -8,7 +8,7 @@ import {
   FACTORIES_ORGANIZATION_ID,
   FAILED_WORK_ORDER,
   OPEN_WORK_ORDER,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   RUNNING_WORK_ORDER,
 } from "./__fixtures__/factoryPageResponses";
 import {
@@ -34,7 +34,7 @@ const meta = {
   component: WorkOrderActivityTimeline,
   parameters: { layout: "padded" },
   args: {
-    factoryId: PRIMARY_FACTORY_ID,
+    factoryKey: PRIMARY_FACTORY_KEY,
   },
   decorators: [
     (Story) => (

--- a/web_src/src/pages/factories/WorkOrderActivityTimeline.tsx
+++ b/web_src/src/pages/factories/WorkOrderActivityTimeline.tsx
@@ -340,7 +340,9 @@ function CommentEventBody({
   const comment = event.comment;
   if (!comment) return null;
   const isAutomation = (comment.authorKind ?? "").toLowerCase() === "automation";
-  const runHref = getWorkOrderRunHref(organizationId, factoryKey, event.sourceAppId, event.sourceRunId, { orderNumber });
+  const runHref = getWorkOrderRunHref(organizationId, factoryKey, event.sourceAppId, event.sourceRunId, {
+    orderNumber,
+  });
 
   return (
     <>
@@ -446,7 +448,12 @@ function UserActionEventDescription({
             resolveUserDisplay={resolveUserDisplay}
           />
         ) : hasSourceRun ? (
-          <SourceRunAttribution event={event} organizationId={organizationId} factoryKey={factoryKey} orderNumber={orderNumber} />
+          <SourceRunAttribution
+            event={event}
+            organizationId={organizationId}
+            factoryKey={factoryKey}
+            orderNumber={orderNumber}
+          />
         ) : (
           <span>{event.title}</span>
         )}
@@ -473,7 +480,9 @@ function SourceRunAttribution({
   factoryKey: string;
   orderNumber?: string;
 }) {
-  const runHref = getWorkOrderRunHref(organizationId, factoryKey, event.sourceAppId, event.sourceRunId, { orderNumber });
+  const runHref = getWorkOrderRunHref(organizationId, factoryKey, event.sourceAppId, event.sourceRunId, {
+    orderNumber,
+  });
   const connector = event.kind === "created" ? "from" : "via";
   return (
     <span className="inline-flex flex-wrap items-baseline gap-x-1">

--- a/web_src/src/pages/factories/WorkOrderActivityTimeline.tsx
+++ b/web_src/src/pages/factories/WorkOrderActivityTimeline.tsx
@@ -31,7 +31,7 @@ import { AssigneeChangeDescription } from "./workOrderTimelineAssignee";
 
 interface WorkOrderTimelineProps {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   order: FactoriesWorkOrder;
   events?: FactoriesWorkOrderEvent[];
   eventsError?: Error | null;
@@ -46,7 +46,7 @@ interface WorkOrderTimelineProps {
 
 export function WorkOrderActivityTimeline({
   organizationId,
-  factoryId,
+  factoryKey,
   order,
   events,
   eventsError = null,
@@ -81,8 +81,8 @@ export function WorkOrderActivityTimeline({
       ) : (
         <TimelineEventsList
           organizationId={organizationId}
-          factoryId={factoryId}
-          orderId={order.id}
+          factoryKey={factoryKey}
+          orderNumber={order.number}
           events={timeline.events}
           resolveUserDisplay={resolveUserDisplay}
           hasMoreEvents={hasMoreEvents}
@@ -102,8 +102,8 @@ export function WorkOrderActivityTimeline({
 
 interface TimelineEventsListProps {
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   events: WorkOrderTimelineEvent[];
   resolveUserDisplay: OrgUserDisplayLookup;
   hasMoreEvents: boolean;
@@ -113,8 +113,8 @@ interface TimelineEventsListProps {
 
 function TimelineEventsList({
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   events,
   resolveUserDisplay,
   hasMoreEvents,
@@ -146,8 +146,8 @@ function TimelineEventsList({
               key={event.id}
               event={event}
               organizationId={organizationId}
-              factoryId={factoryId}
-              orderId={orderId}
+              factoryKey={factoryKey}
+              orderNumber={orderNumber}
               resolveUserDisplay={resolveUserDisplay}
               isLatestDispatch={index === latestDispatchIndex}
             />
@@ -229,15 +229,15 @@ const AVATAR_MARKER_KINDS: WorkOrderTimelineEventKind[] = [
 function TimelineItem({
   event,
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   resolveUserDisplay,
   isLatestDispatch,
 }: {
   event: WorkOrderTimelineEvent;
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   resolveUserDisplay: OrgUserDisplayLookup;
   isLatestDispatch: boolean;
 }) {
@@ -246,8 +246,8 @@ function TimelineItem({
       <DispatchTimelineItem
         event={event}
         organizationId={organizationId}
-        factoryId={factoryId}
-        orderId={orderId}
+        factoryKey={factoryKey}
+        orderNumber={orderNumber}
         isLatestDispatch={isLatestDispatch}
       />
     );
@@ -267,8 +267,8 @@ function TimelineItem({
           <TimelineItemBody
             event={event}
             organizationId={organizationId}
-            factoryId={factoryId}
-            orderId={orderId}
+            factoryKey={factoryKey}
+            orderNumber={orderNumber}
             resolveUserDisplay={resolveUserDisplay}
           />
         </div>
@@ -280,14 +280,14 @@ function TimelineItem({
 function TimelineItemBody({
   event,
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   resolveUserDisplay,
 }: {
   event: WorkOrderTimelineEvent;
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   resolveUserDisplay: OrgUserDisplayLookup;
 }) {
   const actorDisplay = resolveUserDisplay(event.actorUserId, event.actorName);
@@ -300,8 +300,8 @@ function TimelineItemBody({
         actorDisplay={actorDisplay}
         timeLabel={timeLabel}
         organizationId={organizationId}
-        factoryId={factoryId}
-        orderId={orderId}
+        factoryKey={factoryKey}
+        orderNumber={orderNumber}
       />
     );
   }
@@ -314,8 +314,8 @@ function TimelineItemBody({
     <UserActionEventDescription
       event={event}
       organizationId={organizationId}
-      factoryId={factoryId}
-      orderId={orderId}
+      factoryKey={factoryKey}
+      orderNumber={orderNumber}
       resolveUserDisplay={resolveUserDisplay}
       timeLabel={timeLabel}
     />
@@ -327,20 +327,20 @@ function CommentEventBody({
   actorDisplay,
   timeLabel,
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
 }: {
   event: WorkOrderTimelineEvent;
   actorDisplay: OrgUserDisplay | null;
   timeLabel: string;
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
 }) {
   const comment = event.comment;
   if (!comment) return null;
   const isAutomation = (comment.authorKind ?? "").toLowerCase() === "automation";
-  const runHref = getWorkOrderRunHref(organizationId, factoryId, event.sourceAppId, event.sourceRunId, { orderId });
+  const runHref = getWorkOrderRunHref(organizationId, factoryKey, event.sourceAppId, event.sourceRunId, { orderNumber });
 
   return (
     <>
@@ -410,15 +410,15 @@ const SOMEONE_FALLBACK_KINDS: WorkOrderTimelineEventKind[] = ["created", "status
 function UserActionEventDescription({
   event,
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   resolveUserDisplay,
   timeLabel,
 }: {
   event: WorkOrderTimelineEvent;
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   resolveUserDisplay: OrgUserDisplayLookup;
   timeLabel: string;
 }) {
@@ -446,7 +446,7 @@ function UserActionEventDescription({
             resolveUserDisplay={resolveUserDisplay}
           />
         ) : hasSourceRun ? (
-          <SourceRunAttribution event={event} organizationId={organizationId} factoryId={factoryId} orderId={orderId} />
+          <SourceRunAttribution event={event} organizationId={organizationId} factoryKey={factoryKey} orderNumber={orderNumber} />
         ) : (
           <span>{event.title}</span>
         )}
@@ -465,15 +465,15 @@ function UserActionEventDescription({
 function SourceRunAttribution({
   event,
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
 }: {
   event: WorkOrderTimelineEvent;
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
 }) {
-  const runHref = getWorkOrderRunHref(organizationId, factoryId, event.sourceAppId, event.sourceRunId, { orderId });
+  const runHref = getWorkOrderRunHref(organizationId, factoryKey, event.sourceAppId, event.sourceRunId, { orderNumber });
   const connector = event.kind === "created" ? "from" : "via";
   return (
     <span className="inline-flex flex-wrap items-baseline gap-x-1">

--- a/web_src/src/pages/factories/WorkOrderDetailLoadedView.stories.tsx
+++ b/web_src/src/pages/factories/WorkOrderDetailLoadedView.stories.tsx
@@ -11,7 +11,7 @@ import {
   FAILED_WORK_ORDER,
   OPEN_WORK_ORDER,
   OPEN_WORK_ORDER_ARTIFACTS,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   REFUND_FACTORY_LINES,
   RUNNING_WORK_ORDER,
 } from "./__fixtures__/factoryPageResponses";
@@ -43,7 +43,7 @@ const meta = {
   decorators: [
     (Story) => (
       <ComponentStoryShell
-        initialPath={`/${FACTORIES_ORGANIZATION_ID}/workspaces/${PRIMARY_FACTORY_ID}`}
+        initialPath={`/${FACTORIES_ORGANIZATION_ID}/workspaces/${PRIMARY_FACTORY_KEY}`}
         className="min-h-screen w-full bg-gray-50 dark:bg-gray-950"
       >
         <Story />
@@ -65,7 +65,7 @@ function buildLoadedViewArgs(order: FactoriesWorkOrder, overrides: BuildLoadedVi
   const derived = getWorkOrderDetailDerived(order);
   return {
     organizationId: FACTORIES_ORGANIZATION_ID,
-    factoryId: PRIMARY_FACTORY_ID,
+    factoryKey: PRIMARY_FACTORY_KEY,
     order,
     events: overrides.events ?? [],
     artifacts: overrides.artifacts ?? [],

--- a/web_src/src/pages/factories/WorkOrderDetailLoadedView.tsx
+++ b/web_src/src/pages/factories/WorkOrderDetailLoadedView.tsx
@@ -16,7 +16,7 @@ import type { WorkOrderDisplayStatus } from "./lib/workOrderProgress";
 
 interface WorkOrderDetailLoadedViewProps {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   order: FactoriesWorkOrder;
   events?: FactoriesWorkOrderEvent[];
   eventsError?: Error | null;
@@ -58,7 +58,7 @@ interface WorkOrderDetailLoadedViewProps {
 
 export function WorkOrderDetailLoadedView({
   organizationId,
-  factoryId,
+  factoryKey,
   order,
   events,
   eventsError,
@@ -127,7 +127,7 @@ export function WorkOrderDetailLoadedView({
             <div className="mt-4">
               <WorkOrderActivityTimeline
                 organizationId={organizationId}
-                factoryId={factoryId}
+                factoryKey={factoryKey}
                 order={order}
                 events={events}
                 eventsError={eventsError}
@@ -151,7 +151,7 @@ export function WorkOrderDetailLoadedView({
         <aside className="mt-1 lg:sticky lg:top-16 lg:self-start">
           <WorkOrderDetailSidebar
             organizationId={organizationId}
-            factoryId={factoryId}
+            factoryKey={factoryKey}
             order={order}
             artifacts={artifacts}
             isArtifactsLoading={isArtifactsLoading}

--- a/web_src/src/pages/factories/WorkOrderDetailSidebar.tsx
+++ b/web_src/src/pages/factories/WorkOrderDetailSidebar.tsx
@@ -7,7 +7,7 @@ import type { WorkOrderDisplayStatus } from "./lib/workOrderProgress";
 
 interface WorkOrderDetailSidebarProps {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   order: FactoriesWorkOrder;
   artifacts: FactoriesWorkOrderArtifact[];
   isArtifactsLoading: boolean;
@@ -31,7 +31,7 @@ interface WorkOrderDetailSidebarProps {
 /** Work order overview, factory lines, and artifacts. */
 export function WorkOrderDetailSidebar({
   organizationId,
-  factoryId,
+  factoryKey,
   order,
   artifacts,
   isArtifactsLoading,
@@ -67,7 +67,7 @@ export function WorkOrderDetailSidebar({
 
       <WorkOrderSidebarFactoryLines
         organizationId={organizationId}
-        factoryId={factoryId}
+        factoryKey={factoryKey}
         canEditFactoryLines={canEditFactoryLines}
         executions={order.executions ?? []}
         factoryLines={factoryLines}

--- a/web_src/src/pages/factories/WorkOrderExecutionsList.stories.tsx
+++ b/web_src/src/pages/factories/WorkOrderExecutionsList.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ComponentStoryShell } from "./__fixtures__/ComponentStoryShell";
 import {
   FACTORIES_ORGANIZATION_ID,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   RUNNING_WORK_ORDER,
   CLOSED_WORK_ORDER,
 } from "./__fixtures__/factoryPageResponses";
@@ -35,7 +35,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     organizationId: FACTORIES_ORGANIZATION_ID,
-    factoryId: PRIMARY_FACTORY_ID,
+    factoryKey: PRIMARY_FACTORY_KEY,
     executions: RUNNING_WORK_ORDER.executions,
     variant: "default",
   },
@@ -45,7 +45,7 @@ export const Default: Story = {
 export const Compact: Story = {
   args: {
     organizationId: FACTORIES_ORGANIZATION_ID,
-    factoryId: PRIMARY_FACTORY_ID,
+    factoryKey: PRIMARY_FACTORY_KEY,
     executions: CLOSED_WORK_ORDER.executions,
     variant: "compact",
   },
@@ -55,7 +55,7 @@ export const Compact: Story = {
 export const Inline: Story = {
   args: {
     organizationId: FACTORIES_ORGANIZATION_ID,
-    factoryId: PRIMARY_FACTORY_ID,
+    factoryKey: PRIMARY_FACTORY_KEY,
     executions: CLOSED_WORK_ORDER.executions,
     variant: "inline",
   },
@@ -65,7 +65,7 @@ export const Inline: Story = {
 export const Empty: Story = {
   args: {
     organizationId: FACTORIES_ORGANIZATION_ID,
-    factoryId: PRIMARY_FACTORY_ID,
+    factoryKey: PRIMARY_FACTORY_KEY,
     executions: [],
     variant: "default",
   },

--- a/web_src/src/pages/factories/WorkOrderExecutionsList.tsx
+++ b/web_src/src/pages/factories/WorkOrderExecutionsList.tsx
@@ -13,8 +13,8 @@ import {
 
 interface WorkOrderExecutionsListProps {
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   executions?: FactoriesWorkOrderExecution[];
   variant?: "default" | "compact" | "inline";
   emptyMessage?: string;
@@ -22,8 +22,8 @@ interface WorkOrderExecutionsListProps {
 
 export function WorkOrderExecutionsList({
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   executions,
   variant = "default",
   emptyMessage = "No line runs yet. Dispatch this work order to a line to start execution.",
@@ -44,8 +44,8 @@ export function WorkOrderExecutionsList({
             <CompactExecutionRow
               key={execution.id ?? `${group.lineId}-${execution.step}-${index}`}
               organizationId={organizationId}
-              factoryId={factoryId}
-              orderId={orderId}
+              factoryKey={factoryKey}
+              orderNumber={orderNumber}
               execution={execution}
             />
           )),
@@ -61,8 +61,8 @@ export function WorkOrderExecutionsList({
           <CompactLineGroup
             key={group.lineId}
             organizationId={organizationId}
-            factoryId={factoryId}
-            orderId={orderId}
+            factoryKey={factoryKey}
+            orderNumber={orderNumber}
             group={group}
           />
         ))}
@@ -82,8 +82,8 @@ export function WorkOrderExecutionsList({
               <ExecutionRow
                 key={execution.id ?? `${group.lineId}-${execution.step}-${index}`}
                 organizationId={organizationId}
-                factoryId={factoryId}
-                orderId={orderId}
+                factoryKey={factoryKey}
+                orderNumber={orderNumber}
                 execution={execution}
               />
             ))}
@@ -96,13 +96,13 @@ export function WorkOrderExecutionsList({
 
 function CompactLineGroup({
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   group,
 }: {
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   group: WorkOrderExecutionLineGroup;
 }) {
   return (
@@ -113,8 +113,8 @@ function CompactLineGroup({
           <CompactExecutionRow
             key={execution.id ?? `${group.lineId}-${execution.step}-${index}`}
             organizationId={organizationId}
-            factoryId={factoryId}
-            orderId={orderId}
+            factoryKey={factoryKey}
+            orderNumber={orderNumber}
             execution={execution}
           />
         ))}
@@ -125,18 +125,18 @@ function CompactLineGroup({
 
 function CompactExecutionRow({
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   execution,
 }: {
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   execution: FactoriesWorkOrderExecution;
 }) {
   const meta = getWorkOrderExecutionDisplayMeta(execution);
   const stepLabel = execution.step?.trim() || "Unnamed step";
-  const runHref = getWorkOrderExecutionRunHref(organizationId, factoryId, execution, { orderId });
+  const runHref = getWorkOrderExecutionRunHref(organizationId, factoryKey, execution, { orderNumber });
 
   return (
     <li className="flex min-w-0 items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
@@ -147,19 +147,19 @@ function CompactExecutionRow({
 
 function ExecutionRow({
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   execution,
 }: {
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   execution: FactoriesWorkOrderExecution;
 }) {
   const meta = getWorkOrderExecutionDisplayMeta(execution);
   const stepLabel = execution.step?.trim() || "Unnamed step";
   const appName = execution.run?.appName?.trim();
-  const runHref = getWorkOrderExecutionRunHref(organizationId, factoryId, execution, { orderId });
+  const runHref = getWorkOrderExecutionRunHref(organizationId, factoryKey, execution, { orderNumber });
 
   return (
     <li className="px-4 py-3">

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -14,6 +14,11 @@ export const FACTORIES_ORGANIZATION_ID = "3ee1aa47-3a60-4c1f-b645-0b9859ab91f8";
 export const PRIMARY_FACTORY_ID = "factory-refunds";
 export const EMPTY_FACTORY_ID = "factory-payments";
 
+/** Workspace key for `PRIMARY_FACTORY_ID` — routes use this, not the raw id. */
+export const PRIMARY_FACTORY_KEY = "RF";
+/** Workspace key for `EMPTY_FACTORY_ID` — routes use this, not the raw id. */
+export const EMPTY_FACTORY_KEY = "PF";
+
 export const STORYBOOK_ME_USER_ID = "storybook-user";
 export const STORYBOOK_ME_USER_NAME = "Storybook User";
 export const STORYBOOK_ME_USER_EMAIL = "storybook@superplane.dev";

--- a/web_src/src/pages/factories/index.ts
+++ b/web_src/src/pages/factories/index.ts
@@ -9,6 +9,7 @@ export {
   FactorySettingsLayout,
   FactorySettingsSoonPage,
   FACTORY_SETTINGS_NAV_ITEMS,
+  LegacyWorkOrderDetailRedirect,
   LinesPage,
   MissionsPage,
   OverviewPage,

--- a/web_src/src/pages/factories/layout/FactoriesLayout.stories.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesLayout.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
-import { defaultFactoriesFixture, PRIMARY_FACTORY_ID } from "../__fixtures__/factoryPageResponses";
+import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
 import { FactoriesLayout } from "./FactoriesLayout";
 
 /**
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/overview`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/overview`}
       factoriesFixture={defaultFactoriesFixture}
     />
   ),

--- a/web_src/src/pages/factories/layout/FactoriesLayout.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesLayout.tsx
@@ -8,8 +8,9 @@ import { useOrganization } from "@/hooks/useOrganizationData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { AlertTriangle } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { Outlet, useNavigate, useParams } from "react-router";
+import { Navigate, Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { CreateFactoryDialog } from "../CreateFactoryDialog";
+import { factoryRouteNeedsCanonicalRedirect, replaceFactoryKeySegment, resolveFactoryByKey } from "../lib/factoryKeyResolution";
 import { factoryDetailPath, factoryListPath, factoryOnboardingPath } from "../lib/factoryPagePaths";
 import { clearLastVisitedFactory, recordLastVisitedFactory } from "../lib/lastVisitedFactory";
 import { useFactoriesThemeClass } from "../lib/useFactoriesThemeClass";
@@ -22,23 +23,72 @@ import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 const MAX_RECENT_WORK_ORDERS = 5;
 
 export function FactoriesLayout() {
-  const { organizationId, factoryId } = useParams<{ organizationId: string; factoryId: string }>();
+  const { organizationId, factoryKey } = useParams<{ organizationId: string; factoryKey: string }>();
 
-  if (!organizationId || !factoryId) {
+  if (!organizationId || !factoryKey) {
     return null;
   }
 
-  return <FactoriesLayoutContent organizationId={organizationId} factoryId={factoryId} />;
+  return <FactoriesLayoutResolver organizationId={organizationId} factoryKey={factoryKey} />;
 }
 
-function FactoriesLayoutContent({ organizationId, factoryId }: { organizationId: string; factoryId: string }) {
+/**
+ * Resolves the `:factoryKey` route segment to a real factory before handing
+ * off to `FactoriesLayoutContent`. Keeps the id/key resolution — and its
+ * loading/not-found/redirect states — out of the main layout body.
+ */
+function FactoriesLayoutResolver({ organizationId, factoryKey }: { organizationId: string; factoryKey: string }) {
+  const location = useLocation();
+  const {
+    data: factories = [],
+    isLoading: factoriesLoading,
+    isFetching: factoriesFetching,
+  } = useFactories(organizationId);
+  // `isFetching` (not just `isLoading`) so a just-created workspace — whose
+  // list invalidation is still in flight when we navigate to its new key —
+  // shows the loading state instead of flashing "workspace not found".
+  const resolution = resolveFactoryByKey(factories, factoryKey, factoriesLoading || factoriesFetching);
+
+  if (factoryRouteNeedsCanonicalRedirect(resolution, factoryKey)) {
+    const target = replaceFactoryKeySegment(location.pathname, organizationId, factoryKey, resolution.factory!.key!);
+    return <Navigate to={`${target}${location.search}`} replace />;
+  }
+
+  if (resolution.status === "not-found") {
+    return <FactoriesLayoutError organizationId={organizationId} />;
+  }
+
+  if (resolution.status === "loading" || !resolution.factory?.id) {
+    return <FactoriesLayoutLoading />;
+  }
+
+  return (
+    <FactoriesLayoutContent
+      organizationId={organizationId}
+      factoryId={resolution.factory.id}
+      factoryKey={resolution.factory.key ?? factoryKey}
+      factories={factories}
+    />
+  );
+}
+
+function FactoriesLayoutContent({
+  organizationId,
+  factoryId,
+  factoryKey,
+  factories,
+}: {
+  organizationId: string;
+  factoryId: string;
+  factoryKey: string;
+  factories: FactoriesFactory[];
+}) {
   useFactoriesThemeClass();
   const navigate = useNavigate();
   const { account } = useAccount();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const [createFactoryOpen, setCreateFactoryOpen] = useState(false);
 
-  const { data: factories = [] } = useFactories(organizationId);
   const { data: organization } = useOrganization(organizationId);
   const { data: factory, error: factoryError } = useFactory(organizationId, factoryId);
   useFactoryWebsocket(organizationId, factoryId);
@@ -71,28 +121,29 @@ function FactoriesLayoutContent({ organizationId, factoryId }: { organizationId:
     () => ({
       organizationId,
       factoryId,
+      factoryKey,
       factory: factory ?? null,
       factories,
     }),
-    [organizationId, factoryId, factory, factories],
+    [organizationId, factoryId, factoryKey, factory, factories],
   );
 
   const handleCreateFactory = async (input: { name: string; description: string; key: string }) => {
     // Let CreateFactoryDialog catch failures so duplicate-name inline errors work.
     const created = await createFactory.mutateAsync(input);
     setCreateFactoryOpen(false);
-    if (!created.id) {
+    if (!created.key) {
       return;
     }
-    if (storybookOnboarding) {
+    if (storybookOnboarding && created.id) {
       storybookOnboarding.beginOnboarding({
         workspaceId: created.id,
         workspaceName: created.name || input.name,
       });
-      navigate(factoryOnboardingPath(organizationId, created.id));
+      navigate(factoryOnboardingPath(organizationId, created.key));
       return;
     }
-    navigate(factoryDetailPath(organizationId, created.id));
+    navigate(factoryDetailPath(organizationId, created.key));
   };
 
   if (factoryError) {
@@ -114,7 +165,7 @@ function FactoriesLayoutContent({ organizationId, factoryId }: { organizationId:
         {hideSidebar ? null : (
           <FactoriesSidebar
             organizationId={organizationId}
-            factoryId={factoryId}
+            factoryKey={factoryKey}
             factory={factory}
             factories={factories}
             organizationName={organization?.metadata?.name ?? ""}
@@ -145,7 +196,7 @@ function FactoriesLayoutContent({ organizationId, factoryId }: { organizationId:
 
 interface FactoriesSidebarProps {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   factory: FactoriesFactory;
   factories: FactoriesFactory[];
   organizationName: string;
@@ -161,7 +212,7 @@ interface FactoriesSidebarProps {
 
 function FactoriesSidebar({
   organizationId,
-  factoryId,
+  factoryKey,
   factory,
   factories,
   organizationName,
@@ -189,7 +240,7 @@ function FactoriesSidebar({
         onCreateFactory={onOpenCreateFactory}
       />
       <div className="flex-1 overflow-y-auto">
-        <FactoriesNav organizationId={organizationId} factoryId={factoryId} recentWorkOrders={recentWorkOrders} />
+        <FactoriesNav organizationId={organizationId} factoryKey={factoryKey} recentWorkOrders={recentWorkOrders} />
       </div>
       <SidebarUserMenu
         organizationId={organizationId}

--- a/web_src/src/pages/factories/layout/FactoriesLayout.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesLayout.tsx
@@ -10,7 +10,11 @@ import { AlertTriangle } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Navigate, Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { CreateFactoryDialog } from "../CreateFactoryDialog";
-import { factoryRouteNeedsCanonicalRedirect, replaceFactoryKeySegment, resolveFactoryByKey } from "../lib/factoryKeyResolution";
+import {
+  factoryRouteNeedsCanonicalRedirect,
+  replaceFactoryKeySegment,
+  resolveFactoryByKey,
+} from "../lib/factoryKeyResolution";
 import { factoryDetailPath, factoryListPath, factoryOnboardingPath } from "../lib/factoryPagePaths";
 import { clearLastVisitedFactory, recordLastVisitedFactory } from "../lib/lastVisitedFactory";
 import { useFactoriesThemeClass } from "../lib/useFactoriesThemeClass";

--- a/web_src/src/pages/factories/layout/FactoriesNav.stories.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesNav.stories.tsx
@@ -5,7 +5,7 @@ import { withFactoriesTheme } from "../__fixtures__/factoriesStoryTheme";
 import {
   DEFAULT_WORK_ORDERS,
   FACTORIES_ORGANIZATION_ID,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
 } from "../__fixtures__/factoryPageResponses";
 import { FactoriesNav } from "./FactoriesNav";
 
@@ -16,7 +16,7 @@ const meta = {
   decorators: [
     (Story) => (
       <ComponentStoryShell
-        initialPath={`/${FACTORIES_ORGANIZATION_ID}/workspaces/${PRIMARY_FACTORY_ID}/overview`}
+        initialPath={`/${FACTORIES_ORGANIZATION_ID}/workspaces/${PRIMARY_FACTORY_KEY}/overview`}
         className="min-h-[420px] w-[240px] border-r border-sidebar-border bg-sidebar"
       >
         <Story />
@@ -33,7 +33,7 @@ type Story = StoryObj<typeof meta>;
 export const WithRecents: Story = {
   args: {
     organizationId: FACTORIES_ORGANIZATION_ID,
-    factoryId: PRIMARY_FACTORY_ID,
+    factoryKey: PRIMARY_FACTORY_KEY,
     recentWorkOrders: DEFAULT_WORK_ORDERS.slice(0, 5),
   },
 };
@@ -41,7 +41,7 @@ export const WithRecents: Story = {
 export const NoRecents: Story = {
   args: {
     organizationId: FACTORIES_ORGANIZATION_ID,
-    factoryId: PRIMARY_FACTORY_ID,
+    factoryKey: PRIMARY_FACTORY_KEY,
     recentWorkOrders: [],
   },
 };

--- a/web_src/src/pages/factories/layout/FactoriesNav.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesNav.tsx
@@ -7,7 +7,7 @@ import { FACTORIES_NAV_ITEMS } from "./factoriesNavItems";
 
 interface FactoriesNavProps {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   recentWorkOrders: FactoriesWorkOrder[];
 }
 
@@ -22,13 +22,13 @@ const RECENT_STATUS_DOT_CLASS: Record<WorkOrderDisplayStatus, string> = {
   cancelled: "bg-[color:var(--status-cancelled-dot)]",
 };
 
-export function FactoriesNav({ organizationId, factoryId, recentWorkOrders }: FactoriesNavProps) {
+export function FactoriesNav({ organizationId, factoryKey, recentWorkOrders }: FactoriesNavProps) {
   return (
     <nav className="flex flex-1 flex-col gap-4 px-2 pt-2 pb-4" data-testid="factories-nav">
       <ul className="flex flex-col gap-0.5">
         {FACTORIES_NAV_ITEMS.map((item) => {
           const Icon = item.Icon;
-          const href = item.buildHref(organizationId, factoryId);
+          const href = item.buildHref(organizationId, factoryKey);
 
           return (
             <li key={item.id}>
@@ -57,7 +57,7 @@ export function FactoriesNav({ organizationId, factoryId, recentWorkOrders }: Fa
           </p>
           <ul className="flex flex-col gap-0.5">
             {recentWorkOrders.map((order) => {
-              if (!order.id) {
+              if (!order.id || order.number === undefined) {
                 return null;
               }
               const status = getWorkOrderDisplayStatus(order);
@@ -66,7 +66,7 @@ export function FactoriesNav({ organizationId, factoryId, recentWorkOrders }: Fa
               return (
                 <li key={order.id}>
                   <NavLink
-                    to={workOrderDetailPath(organizationId, factoryId, order.id)}
+                    to={workOrderDetailPath(organizationId, factoryKey, order.number)}
                     className={({ isActive }) =>
                       cn(
                         "group block rounded-md px-2.5 py-1.5 text-[13px] tracking-[-0.01em] text-foreground/80 hover:bg-sidebar-accent hover:text-foreground",

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.tsx
@@ -33,7 +33,7 @@ export function WorkspaceSwitcher({
   onCreateFactory,
 }: WorkspaceSwitcherProps) {
   const navigate = useNavigate();
-  const settingsHref = factory.id ? factorySettingsPath(organizationId, factory.id) : "#";
+  const settingsHref = factory.key ? factorySettingsPath(organizationId, factory.key) : "#";
 
   return (
     <div className="flex items-center gap-0.5 px-2 pt-3 pb-1" data-testid="factories-workspace-switcher">
@@ -79,7 +79,7 @@ export function WorkspaceSwitcher({
           <DropdownMenuLabel>Switch workspace</DropdownMenuLabel>
           {factories.map((entry) => {
             const isCurrent = entry.id === factory.id;
-            const targetHref = entry.id ? factoryDetailPath(organizationId, entry.id) : "";
+            const targetHref = entry.key ? factoryDetailPath(organizationId, entry.key) : "";
             return (
               <DropdownMenuItem
                 key={entry.id}

--- a/web_src/src/pages/factories/layout/factoriesLayoutContext.ts
+++ b/web_src/src/pages/factories/layout/factoriesLayoutContext.ts
@@ -3,7 +3,10 @@ import { createContext, useContext } from "react";
 
 export interface FactoriesLayoutContextValue {
   organizationId: string;
+  /** Real database id — use for API calls, mutations, and the websocket subscription. */
   factoryId: string;
+  /** Canonical workspace key (e.g. `SP`) — use for building links. */
+  factoryKey: string;
   factory: FactoriesFactory | null;
   factories: FactoriesFactory[];
 }

--- a/web_src/src/pages/factories/layout/factoriesNavItems.ts
+++ b/web_src/src/pages/factories/layout/factoriesNavItems.ts
@@ -15,7 +15,7 @@ export interface FactoriesNavItem {
   id: FactoriesNavKind;
   label: string;
   Icon: LucideIcon;
-  buildHref: (organizationId: string, factoryId: string) => string;
+  buildHref: (organizationId: string, factoryKey: string) => string;
 }
 
 export const FACTORIES_NAV_ITEMS: FactoriesNavItem[] = [

--- a/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
@@ -52,6 +52,29 @@ describe("resolveFactoryAppBackNav", () => {
       href: "/org/workspaces/fac/work-orders",
     });
   });
+
+  it("returns work order detail when only a legacy orderId is present", () => {
+    expect(
+      resolveFactoryAppBackNav("org", "fac", { from: "work-order", orderId: "order-2", orderTitle: "Ship things" }),
+    ).toEqual({
+      label: "Ship things",
+      href: "/org/workspaces/fac/work-order/order-2",
+    });
+  });
+
+  it("prefers orderNumber over a legacy orderId", () => {
+    expect(
+      resolveFactoryAppBackNav("org", "fac", {
+        from: "work-order",
+        orderNumber: "42",
+        orderId: "order-2",
+        orderTitle: "Fix things",
+      }),
+    ).toEqual({
+      label: "Fix things",
+      href: "/org/workspaces/fac/work-order/42",
+    });
+  });
 });
 
 describe("factoryAppPath", () => {

--- a/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
@@ -36,6 +36,22 @@ describe("resolveFactoryAppBackNav", () => {
       href: "/org/workspaces/fac/overview",
     });
   });
+
+  it("returns work order detail when orderNumber present", () => {
+    expect(
+      resolveFactoryAppBackNav("org", "fac", { from: "work-order", orderNumber: "42", orderTitle: "Fix things" }),
+    ).toEqual({
+      label: "Fix things",
+      href: "/org/workspaces/fac/work-order/42",
+    });
+  });
+
+  it("falls back to Work Orders list when from=work-order but orderNumber missing", () => {
+    expect(resolveFactoryAppBackNav("org", "fac", { from: "work-order" })).toEqual({
+      label: "Work Orders",
+      href: "/org/workspaces/fac/work-orders",
+    });
+  });
 });
 
 describe("factoryAppPath", () => {

--- a/web_src/src/pages/factories/lib/factoryAppNav.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.ts
@@ -26,6 +26,8 @@ export function resolveFactoryAppBackNav(
     appName?: string | null;
     lineId?: string | null;
     orderNumber?: string | null;
+    /** Legacy app-canvas query param; used when `orderNumber` is absent. */
+    orderId?: string | null;
     lineName?: string | null;
     orderTitle?: string | null;
   },
@@ -53,10 +55,11 @@ export function resolveFactoryAppBackNav(
   }
 
   if (from === "work-order") {
-    if (options.orderNumber) {
+    const orderRef = options.orderNumber || options.orderId;
+    if (orderRef) {
       return {
         label: options.orderTitle?.trim() || "Work Orders",
-        href: workOrderDetailPath(organizationId, factoryKey, options.orderNumber),
+        href: workOrderDetailPath(organizationId, factoryKey, orderRef),
       };
     }
     return { label: "Work Orders", href: workOrdersPath(organizationId, factoryKey) };

--- a/web_src/src/pages/factories/lib/factoryAppNav.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.ts
@@ -19,13 +19,13 @@ export type FactoryAppBackNav = {
  */
 export function resolveFactoryAppBackNav(
   organizationId: string,
-  factoryId: string,
+  factoryKey: string,
   options: {
     from?: string | null;
     appId?: string | null;
     appName?: string | null;
     lineId?: string | null;
-    orderId?: string | null;
+    orderNumber?: string | null;
     lineName?: string | null;
     orderTitle?: string | null;
   },
@@ -36,31 +36,31 @@ export function resolveFactoryAppBackNav(
     if (options.appId) {
       return {
         label: options.appName?.trim() || "Automations",
-        href: automationDetailPath(organizationId, factoryId, options.appId),
+        href: automationDetailPath(organizationId, factoryKey, options.appId),
       };
     }
-    return { label: "Automations", href: automationsPath(organizationId, factoryId) };
+    return { label: "Automations", href: automationsPath(organizationId, factoryKey) };
   }
 
   if (from === "lines") {
     if (options.lineId) {
       return {
         label: options.lineName?.trim() || "All lines",
-        href: factoryLineDetailPath(organizationId, factoryId, options.lineId),
+        href: factoryLineDetailPath(organizationId, factoryKey, options.lineId),
       };
     }
-    return { label: "All lines", href: linesPath(organizationId, factoryId) };
+    return { label: "All lines", href: linesPath(organizationId, factoryKey) };
   }
 
   if (from === "work-order") {
-    if (options.orderId) {
+    if (options.orderNumber) {
       return {
         label: options.orderTitle?.trim() || "Work Orders",
-        href: workOrderDetailPath(organizationId, factoryId, options.orderId),
+        href: workOrderDetailPath(organizationId, factoryKey, options.orderNumber),
       };
     }
-    return { label: "Work Orders", href: workOrdersPath(organizationId, factoryId) };
+    return { label: "Work Orders", href: workOrdersPath(organizationId, factoryKey) };
   }
 
-  return { label: "Overview", href: factoryOverviewPath(organizationId, factoryId) };
+  return { label: "Overview", href: factoryOverviewPath(organizationId, factoryKey) };
 }

--- a/web_src/src/pages/factories/lib/factoryKeyResolution.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryKeyResolution.spec.ts
@@ -29,6 +29,18 @@ describe("resolveFactoryByKey", () => {
     expect(resolution).toEqual({ status: "found", factory: FACTORIES[1], matchedBy: "id" });
   });
 
+  it("does not treat a UUID as a workspace key even when its letters match a key", () => {
+    const uuid = "abcde000-0000-4000-8000-000000000000";
+    const factories: FactoriesFactory[] = [
+      { id: "factory-letters", key: "ABCDE", name: "Letters" },
+      { id: uuid, key: "SP", name: "Superplane" },
+    ];
+
+    const resolution = resolveFactoryByKey(factories, uuid, false);
+
+    expect(resolution).toEqual({ status: "found", factory: factories[1], matchedBy: "id" });
+  });
+
   it("returns not-found once loaded and nothing matches", () => {
     expect(resolveFactoryByKey(FACTORIES, "nope", false)).toEqual({
       status: "not-found",

--- a/web_src/src/pages/factories/lib/factoryKeyResolution.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryKeyResolution.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { FactoriesFactory } from "@/api-client";
-import { factoryRouteNeedsCanonicalRedirect, replaceFactoryKeySegment, resolveFactoryByKey } from "./factoryKeyResolution";
+import {
+  factoryRouteNeedsCanonicalRedirect,
+  replaceFactoryKeySegment,
+  resolveFactoryByKey,
+} from "./factoryKeyResolution";
 
 const FACTORIES: FactoriesFactory[] = [
   { id: "factory-1", key: "SP", name: "Superplane" },
@@ -66,9 +70,9 @@ describe("factoryRouteNeedsCanonicalRedirect", () => {
 
 describe("replaceFactoryKeySegment", () => {
   it("swaps the factory key segment and keeps the rest of the path", () => {
-    expect(replaceFactoryKeySegment("/org-1/workspaces/factory-2/work-orders/order-1", "org-1", "factory-2", "RF")).toBe(
-      "/org-1/workspaces/RF/work-orders/order-1",
-    );
+    expect(
+      replaceFactoryKeySegment("/org-1/workspaces/factory-2/work-orders/order-1", "org-1", "factory-2", "RF"),
+    ).toBe("/org-1/workspaces/RF/work-orders/order-1");
   });
 
   it("keeps the workspace root when there is no trailing path", () => {

--- a/web_src/src/pages/factories/lib/factoryKeyResolution.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryKeyResolution.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { FactoriesFactory } from "@/api-client";
+import { factoryRouteNeedsCanonicalRedirect, replaceFactoryKeySegment, resolveFactoryByKey } from "./factoryKeyResolution";
+
+const FACTORIES: FactoriesFactory[] = [
+  { id: "factory-1", key: "SP", name: "Superplane" },
+  { id: "factory-2", key: "RF", name: "Refunds" },
+];
+
+describe("resolveFactoryByKey", () => {
+  it("matches an exact key", () => {
+    const resolution = resolveFactoryByKey(FACTORIES, "SP", false);
+    expect(resolution).toEqual({ status: "found", factory: FACTORIES[0], matchedBy: "key" });
+  });
+
+  it("matches a key case-insensitively", () => {
+    const resolution = resolveFactoryByKey(FACTORIES, "sp", false);
+    expect(resolution.status).toBe("found");
+    expect(resolution.factory).toBe(FACTORIES[0]);
+    expect(resolution.matchedBy).toBe("key");
+  });
+
+  it("falls back to a legacy id match when no key matches", () => {
+    const resolution = resolveFactoryByKey(FACTORIES, "factory-2", false);
+    expect(resolution).toEqual({ status: "found", factory: FACTORIES[1], matchedBy: "id" });
+  });
+
+  it("returns not-found once loaded and nothing matches", () => {
+    expect(resolveFactoryByKey(FACTORIES, "nope", false)).toEqual({
+      status: "not-found",
+      factory: null,
+      matchedBy: null,
+    });
+  });
+
+  it("returns loading instead of not-found while the list is still fetching", () => {
+    expect(resolveFactoryByKey([], "SP", true)).toEqual({ status: "loading", factory: null, matchedBy: null });
+  });
+
+  it("returns not-found for an empty route segment once loaded", () => {
+    expect(resolveFactoryByKey(FACTORIES, undefined, false).status).toBe("not-found");
+  });
+});
+
+describe("factoryRouteNeedsCanonicalRedirect", () => {
+  it("is false for an exact key match", () => {
+    const resolution = resolveFactoryByKey(FACTORIES, "SP", false);
+    expect(factoryRouteNeedsCanonicalRedirect(resolution, "SP")).toBe(false);
+  });
+
+  it("is true for a case mismatch", () => {
+    const resolution = resolveFactoryByKey(FACTORIES, "sp", false);
+    expect(factoryRouteNeedsCanonicalRedirect(resolution, "sp")).toBe(true);
+  });
+
+  it("is true for a legacy id match", () => {
+    const resolution = resolveFactoryByKey(FACTORIES, "factory-2", false);
+    expect(factoryRouteNeedsCanonicalRedirect(resolution, "factory-2")).toBe(true);
+  });
+
+  it("is false when nothing resolved", () => {
+    const resolution = resolveFactoryByKey(FACTORIES, "nope", false);
+    expect(factoryRouteNeedsCanonicalRedirect(resolution, "nope")).toBe(false);
+  });
+});
+
+describe("replaceFactoryKeySegment", () => {
+  it("swaps the factory key segment and keeps the rest of the path", () => {
+    expect(replaceFactoryKeySegment("/org-1/workspaces/factory-2/work-orders/order-1", "org-1", "factory-2", "RF")).toBe(
+      "/org-1/workspaces/RF/work-orders/order-1",
+    );
+  });
+
+  it("keeps the workspace root when there is no trailing path", () => {
+    expect(replaceFactoryKeySegment("/org-1/workspaces/sp", "org-1", "sp", "SP")).toBe("/org-1/workspaces/SP");
+  });
+});

--- a/web_src/src/pages/factories/lib/factoryKeyResolution.ts
+++ b/web_src/src/pages/factories/lib/factoryKeyResolution.ts
@@ -1,0 +1,83 @@
+import type { FactoriesFactory } from "@/api-client";
+import { normalizeWorkspaceKey } from "./workspaceKey";
+
+export type FactoryResolutionStatus = "loading" | "found" | "not-found";
+
+export interface FactoryResolution {
+  status: FactoryResolutionStatus;
+  factory: FactoriesFactory | null;
+  /**
+   * How the match was made. `"key"` covers both an exact and a
+   * case-insensitive match on `factory.key`; `"id"` is the legacy fallback
+   * for old links that still carry the raw database id. Callers use this
+   * (via `factoryRouteNeedsCanonicalRedirect`) to send the browser to the
+   * canonical `key` URL instead of rendering under a stale/legacy segment.
+   */
+  matchedBy: "key" | "id" | null;
+}
+
+const LOADING: FactoryResolution = { status: "loading", factory: null, matchedBy: null };
+const NOT_FOUND: FactoryResolution = { status: "not-found", factory: null, matchedBy: null };
+
+/**
+ * Resolves the `:factoryKey` route segment to a `FactoriesFactory` using the
+ * already-fetched workspace list (no extra network round trip). Matches the
+ * workspace `key` case-insensitively first, then falls back to `id` so old
+ * UUID-based links keep working.
+ *
+ * Returns `"loading"` (rather than `"not-found"`) whenever the list hasn't
+ * resolved yet, so callers don't flash an error state on every deep link.
+ */
+export function resolveFactoryByKey(
+  factories: FactoriesFactory[],
+  routeKey: string | undefined,
+  isLoading: boolean,
+): FactoryResolution {
+  if (!routeKey) {
+    return isLoading ? LOADING : NOT_FOUND;
+  }
+
+  const normalizedRouteKey = normalizeWorkspaceKey(routeKey);
+  const byKey = normalizedRouteKey
+    ? factories.find((factory) => Boolean(factory.key) && normalizeWorkspaceKey(factory.key!) === normalizedRouteKey)
+    : undefined;
+  if (byKey) {
+    return { status: "found", factory: byKey, matchedBy: "key" };
+  }
+
+  const byId = factories.find((factory) => Boolean(factory.id) && factory.id === routeKey);
+  if (byId) {
+    return { status: "found", factory: byId, matchedBy: "id" };
+  }
+
+  return isLoading ? LOADING : NOT_FOUND;
+}
+
+/**
+ * True when the route segment does not already match the canonical
+ * `factory.key` exactly — a legacy id, a lowercase/mixed-case key, or any
+ * other non-canonical spelling. Callers `<Navigate replace>` to the
+ * canonical URL in this case instead of rendering the page.
+ */
+export function factoryRouteNeedsCanonicalRedirect(resolution: FactoryResolution, routeKey: string): boolean {
+  return resolution.status === "found" && Boolean(resolution.factory?.key) && resolution.factory!.key !== routeKey;
+}
+
+/**
+ * Swaps a stale `:factoryKey` route segment (a legacy id or a non-canonical
+ * spelling of the key) for the canonical key, leaving the rest of the path
+ * untouched so deep links under the workspace (work orders, lines, apps...)
+ * keep working after the redirect.
+ */
+export function replaceFactoryKeySegment(
+  pathname: string,
+  organizationId: string,
+  routeKey: string,
+  canonicalKey: string,
+): string {
+  const prefix = `/${organizationId}/workspaces/${routeKey}`;
+  if (!pathname.startsWith(prefix)) {
+    return `/${organizationId}/workspaces/${canonicalKey}`;
+  }
+  return `/${organizationId}/workspaces/${canonicalKey}${pathname.slice(prefix.length)}`;
+}

--- a/web_src/src/pages/factories/lib/factoryKeyResolution.ts
+++ b/web_src/src/pages/factories/lib/factoryKeyResolution.ts
@@ -1,5 +1,5 @@
 import type { FactoriesFactory } from "@/api-client";
-import { normalizeWorkspaceKey } from "./workspaceKey";
+import { isValidWorkspaceKey } from "./workspaceKey";
 
 export type FactoryResolutionStatus = "loading" | "found" | "not-found";
 
@@ -37,12 +37,12 @@ export function resolveFactoryByKey(
     return isLoading ? LOADING : NOT_FOUND;
   }
 
-  const normalizedRouteKey = normalizeWorkspaceKey(routeKey);
-  const byKey = normalizedRouteKey
-    ? factories.find((factory) => Boolean(factory.key) && normalizeWorkspaceKey(factory.key!) === normalizedRouteKey)
-    : undefined;
-  if (byKey) {
-    return { status: "found", factory: byKey, matchedBy: "key" };
+  const candidateKey = routeKey.toUpperCase();
+  if (isValidWorkspaceKey(candidateKey)) {
+    const byKey = factories.find((factory) => Boolean(factory.key) && factory.key!.toUpperCase() === candidateKey);
+    if (byKey) {
+      return { status: "found", factory: byKey, matchedBy: "key" };
+    }
   }
 
   const byId = factories.find((factory) => Boolean(factory.id) && factory.id === routeKey);

--- a/web_src/src/pages/factories/lib/factoryLineNavigation.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryLineNavigation.spec.ts
@@ -4,7 +4,7 @@ import { factoryLineDestinationPath } from "./factoryLineNavigation";
 
 const destination = {
   organizationId: "organization",
-  factoryId: "factory",
+  factoryKey: "factory",
   lineId: "line",
 };
 

--- a/web_src/src/pages/factories/lib/factoryLineNavigation.ts
+++ b/web_src/src/pages/factories/lib/factoryLineNavigation.ts
@@ -2,14 +2,14 @@ import { editFactoryLinePath, factoryLineDetailPath } from "./factoryPagePaths";
 
 interface FactoryLineDestination {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   lineId: string;
   canEdit: boolean;
 }
 
 export function factoryLineDestinationPath({
   organizationId,
-  factoryId,
+  factoryKey,
   lineId,
   canEdit,
 }: FactoryLineDestination): string | undefined {
@@ -17,7 +17,7 @@ export function factoryLineDestinationPath({
     return undefined;
   }
   if (canEdit) {
-    return editFactoryLinePath(organizationId, factoryId, lineId);
+    return editFactoryLinePath(organizationId, factoryKey, lineId);
   }
-  return factoryLineDetailPath(organizationId, factoryId, lineId);
+  return factoryLineDetailPath(organizationId, factoryKey, lineId);
 }

--- a/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  factoryAppConfigurePath,
+  factoryAppPath,
+  factoryDetailPath,
+  legacyWorkOrderDetailPath,
+  workOrderDetailPath,
+  workOrdersPath,
+} from "./factoryPagePaths";
+
+describe("factoryDetailPath", () => {
+  it("builds the workspace URL from the workspace key", () => {
+    expect(factoryDetailPath("org-1", "SP")).toBe("/org-1/workspaces/SP");
+  });
+});
+
+describe("workOrderDetailPath", () => {
+  it("builds the canonical permalink from the workspace key and work order number", () => {
+    expect(workOrderDetailPath("org-1", "SP", 42)).toBe("/org-1/workspaces/SP/work-order/42");
+  });
+
+  it("accepts the number as a string", () => {
+    expect(workOrderDetailPath("org-1", "SP", "42")).toBe("/org-1/workspaces/SP/work-order/42");
+  });
+
+  it("is a sibling of, not nested under, the plural work-orders list path", () => {
+    expect(workOrderDetailPath("org-1", "SP", "42")).not.toContain(workOrdersPath("org-1", "SP"));
+  });
+});
+
+describe("legacyWorkOrderDetailPath", () => {
+  it("builds the old id-based shape for back-compat redirects", () => {
+    expect(legacyWorkOrderDetailPath("org-1", "SP", "order-uuid")).toBe("/org-1/workspaces/SP/work-orders/order-uuid");
+  });
+});
+
+describe("factoryAppPath", () => {
+  it("encodes orderNumber (not orderId) in the query string", () => {
+    expect(factoryAppPath("org-1", "SP", "app-1", { from: "work-order", orderNumber: "42" })).toBe(
+      "/org-1/workspaces/SP/apps/app-1?from=work-order&orderNumber=42",
+    );
+  });
+});
+
+describe("factoryAppConfigurePath", () => {
+  it("adds configure=1", () => {
+    expect(factoryAppConfigurePath("org-1", "SP", "app-1")).toBe("/org-1/workspaces/SP/apps/app-1?configure=1");
+  });
+});

--- a/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
@@ -3,6 +3,7 @@ import {
   factoryAppConfigurePath,
   factoryAppPath,
   factoryDetailPath,
+  factorySettingsGeneralPathAfterKeyChange,
   legacyWorkOrderDetailPath,
   workOrderDetailPath,
   workOrdersPath,
@@ -39,6 +40,16 @@ describe("factoryAppPath", () => {
     expect(factoryAppPath("org-1", "SP", "app-1", { from: "work-order", orderNumber: "42" })).toBe(
       "/org-1/workspaces/SP/apps/app-1?from=work-order&orderNumber=42",
     );
+  });
+});
+
+describe("factorySettingsGeneralPathAfterKeyChange", () => {
+  it("returns the General settings URL when the key changes", () => {
+    expect(factorySettingsGeneralPathAfterKeyChange("org-1", "RF", "AB")).toBe("/org-1/workspaces/AB/settings/general");
+  });
+
+  it("returns null when the key does not change", () => {
+    expect(factorySettingsGeneralPathAfterKeyChange("org-1", "RF", "RF")).toBeNull();
   });
 });
 

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -2,52 +2,71 @@ export function factoryListPath(organizationId: string) {
   return `/${organizationId}/workspaces`;
 }
 
-export function factoryDetailPath(organizationId: string, factoryId: string) {
-  return `${factoryListPath(organizationId)}/${factoryId}`;
+export function factoryDetailPath(organizationId: string, factoryKey: string) {
+  return `${factoryListPath(organizationId)}/${factoryKey}`;
 }
 
-export function factoryOverviewPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/overview`;
+export function factoryOverviewPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/overview`;
 }
 
-export function factoryOnboardingPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/onboarding`;
+export function factoryOnboardingPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/onboarding`;
 }
 
-export function workOrdersPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/work-orders`;
+export function workOrdersPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/work-orders`;
 }
 
-export function createWorkOrderPath(organizationId: string, factoryId: string) {
-  return `${workOrdersPath(organizationId, factoryId)}/new`;
+export function createWorkOrderPath(organizationId: string, factoryKey: string) {
+  return `${workOrdersPath(organizationId, factoryKey)}/new`;
 }
 
-export function workOrderDetailPath(organizationId: string, factoryId: string, orderId: string) {
-  return `${workOrdersPath(organizationId, factoryId)}/${orderId}`;
+/**
+ * Canonical work order permalink: `/{organizationId}/workspaces/{factoryKey}/work-order/{orderNumber}`
+ * (singular segment, sibling of `work-orders`). `orderNumber` is the
+ * factory-scoped sequence number (`FactoriesWorkOrder.number`), not the
+ * database id — see `legacyWorkOrderDetailPath` for the old id-based shape.
+ */
+export function workOrderDetailPath(
+  organizationId: string,
+  factoryKey: string,
+  orderNumber: string | number,
+) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/work-order/${orderNumber}`;
 }
 
-export function linesPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/lines`;
+/**
+ * Old id-based work order URL shape, kept around only so the legacy
+ * redirect route can compare against it / build test fixtures. New code
+ * should always call `workOrderDetailPath`.
+ */
+export function legacyWorkOrderDetailPath(organizationId: string, factoryKey: string, orderId: string) {
+  return `${workOrdersPath(organizationId, factoryKey)}/${orderId}`;
 }
 
-export function createFactoryLinePath(organizationId: string, factoryId: string) {
-  return `${linesPath(organizationId, factoryId)}/new`;
+export function linesPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/lines`;
 }
 
-export function factoryLineDetailPath(organizationId: string, factoryId: string, lineId: string) {
-  return `${linesPath(organizationId, factoryId)}/${lineId}`;
+export function createFactoryLinePath(organizationId: string, factoryKey: string) {
+  return `${linesPath(organizationId, factoryKey)}/new`;
 }
 
-export function editFactoryLinePath(organizationId: string, factoryId: string, lineId: string) {
-  return `${linesPath(organizationId, factoryId)}/${lineId}/edit`;
+export function factoryLineDetailPath(organizationId: string, factoryKey: string, lineId: string) {
+  return `${linesPath(organizationId, factoryKey)}/${lineId}`;
 }
 
-export function automationsPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/automations`;
+export function editFactoryLinePath(organizationId: string, factoryKey: string, lineId: string) {
+  return `${linesPath(organizationId, factoryKey)}/${lineId}/edit`;
 }
 
-export function automationDetailPath(organizationId: string, factoryId: string, appId: string) {
-  return `${automationsPath(organizationId, factoryId)}/${appId}`;
+export function automationsPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/automations`;
+}
+
+export function automationDetailPath(organizationId: string, factoryKey: string, appId: string) {
+  return `${automationsPath(organizationId, factoryKey)}/${appId}`;
 }
 
 export type FactoryAppNavFrom = "automations" | "lines" | "work-order" | "overview";
@@ -55,7 +74,8 @@ export type FactoryAppNavFrom = "automations" | "lines" | "work-order" | "overvi
 export type FactoryAppNavOptions = {
   from?: FactoryAppNavFrom;
   lineId?: string;
-  orderId?: string;
+  /** Work order `number` (route identifier), not the database id. */
+  orderNumber?: string;
   runId?: string;
   /**
    * Open factory-shell Configure chrome. Uses `configure=1` (not `edit=1`) so
@@ -81,8 +101,8 @@ function buildFactoryAppSearchParams(options?: FactoryAppNavOptions): string {
   if (options.lineId) {
     params.set("lineId", options.lineId);
   }
-  if (options.orderId) {
-    params.set("orderId", options.orderId);
+  if (options.orderNumber) {
+    params.set("orderNumber", options.orderNumber);
   }
   const qs = params.toString();
   return qs ? `?${qs}` : "";
@@ -90,48 +110,48 @@ function buildFactoryAppSearchParams(options?: FactoryAppNavOptions): string {
 
 export function factoryAppConfigurePath(
   organizationId: string,
-  factoryId: string,
+  factoryKey: string,
   appId: string,
   options?: Omit<FactoryAppNavOptions, "configure" | "runId">,
 ) {
-  return factoryAppPath(organizationId, factoryId, appId, { ...options, configure: true });
+  return factoryAppPath(organizationId, factoryKey, appId, { ...options, configure: true });
 }
 
 export function factoryAppPath(
   organizationId: string,
-  factoryId: string,
+  factoryKey: string,
   appId: string,
   options?: FactoryAppNavOptions,
 ) {
-  return `${factoryDetailPath(organizationId, factoryId)}/apps/${appId}${buildFactoryAppSearchParams(options)}`;
+  return `${factoryDetailPath(organizationId, factoryKey)}/apps/${appId}${buildFactoryAppSearchParams(options)}`;
 }
 
 export function factoryAppRunPath(
   organizationId: string,
-  factoryId: string,
+  factoryKey: string,
   appId: string,
   runId: string,
   options?: Omit<FactoryAppNavOptions, "runId">,
 ) {
-  return factoryAppPath(organizationId, factoryId, appId, { ...options, runId });
+  return factoryAppPath(organizationId, factoryKey, appId, { ...options, runId });
 }
 
-export function factorySettingsPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/settings`;
+export function factorySettingsPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/settings`;
 }
 
-export function factorySettingsSectionPath(organizationId: string, factoryId: string, section: string) {
-  return `${factorySettingsPath(organizationId, factoryId)}/${section}`;
+export function factorySettingsSectionPath(organizationId: string, factoryKey: string, section: string) {
+  return `${factorySettingsPath(organizationId, factoryKey)}/${section}`;
 }
 
-export function factoryMissionsPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/missions`;
+export function factoryMissionsPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/missions`;
 }
 
-export function factoryWikiPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/wiki`;
+export function factoryWikiPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/wiki`;
 }
 
-export function factoryVelocityPath(organizationId: string, factoryId: string) {
-  return `${factoryDetailPath(organizationId, factoryId)}/velocity`;
+export function factoryVelocityPath(organizationId: string, factoryKey: string) {
+  return `${factoryDetailPath(organizationId, factoryKey)}/velocity`;
 }

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -28,11 +28,7 @@ export function createWorkOrderPath(organizationId: string, factoryKey: string) 
  * factory-scoped sequence number (`FactoriesWorkOrder.number`), not the
  * database id — see `legacyWorkOrderDetailPath` for the old id-based shape.
  */
-export function workOrderDetailPath(
-  organizationId: string,
-  factoryKey: string,
-  orderNumber: string | number,
-) {
+export function workOrderDetailPath(organizationId: string, factoryKey: string, orderNumber: string | number) {
   return `${factoryDetailPath(organizationId, factoryKey)}/work-order/${orderNumber}`;
 }
 

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -140,6 +140,18 @@ export function factorySettingsSectionPath(organizationId: string, factoryKey: s
   return `${factorySettingsPath(organizationId, factoryKey)}/${section}`;
 }
 
+/** Settings General URL after a workspace key change, or `null` when the key did not change. */
+export function factorySettingsGeneralPathAfterKeyChange(
+  organizationId: string,
+  previousKey: string,
+  nextKey: string,
+): string | null {
+  if (!nextKey || nextKey === previousKey) {
+    return null;
+  }
+  return factorySettingsSectionPath(organizationId, nextKey, "general");
+}
+
 export function factoryMissionsPath(organizationId: string, factoryKey: string) {
   return `${factoryDetailPath(organizationId, factoryKey)}/missions`;
 }

--- a/web_src/src/pages/factories/lib/lastVisitedFactory.spec.ts
+++ b/web_src/src/pages/factories/lib/lastVisitedFactory.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { pickInitialFactory } from "./lastVisitedFactory";
+
+const FACTORIES = [
+  { id: "factory-1", key: "AA" },
+  { id: "factory-2", key: "BB" },
+];
+
+describe("pickInitialFactory", () => {
+  it("prefers the last-visited factory when it still exists", () => {
+    expect(pickInitialFactory(FACTORIES, "factory-2")).toBe(FACTORIES[1]);
+  });
+
+  it("falls back to the first factory when there is no last-visited match", () => {
+    expect(pickInitialFactory(FACTORIES, "missing")).toBe(FACTORIES[0]);
+    expect(pickInitialFactory(FACTORIES, null)).toBe(FACTORIES[0]);
+  });
+
+  it("returns null when there are no factories", () => {
+    expect(pickInitialFactory([], "factory-1")).toBeNull();
+  });
+});

--- a/web_src/src/pages/factories/lib/lastVisitedFactory.ts
+++ b/web_src/src/pages/factories/lib/lastVisitedFactory.ts
@@ -49,17 +49,30 @@ export function readLastVisitedFactory(accountId: string, organizationId: string
   return readAll()[accountId]?.[organizationId] ?? null;
 }
 
-export function pickInitialFactoryId(factories: { id?: string }[], lastVisitedFactoryId: string | null): string | null {
-  const knownIds = factories.map((factory) => factory.id).filter((id): id is string => Boolean(id));
-  if (knownIds.length === 0) {
+/**
+ * Picks which workspace to land on from the factories list, preferring the
+ * last-visited one (matched by the real `id`, which is what gets persisted —
+ * see `recordLastVisitedFactory`). Returns the whole factory (not just the
+ * id) so the caller can redirect to its `key`, the canonical routing
+ * identifier.
+ */
+export function pickInitialFactory<T extends { id?: string }>(
+  factories: T[],
+  lastVisitedFactoryId: string | null,
+): T | null {
+  const known = factories.filter((factory) => Boolean(factory.id));
+  if (known.length === 0) {
     return null;
   }
 
-  if (lastVisitedFactoryId && knownIds.includes(lastVisitedFactoryId)) {
-    return lastVisitedFactoryId;
+  if (lastVisitedFactoryId) {
+    const lastVisited = known.find((factory) => factory.id === lastVisitedFactoryId);
+    if (lastVisited) {
+      return lastVisited;
+    }
   }
 
-  return knownIds[0];
+  return known[0];
 }
 
 export function recordLastVisitedFactory(accountId: string, organizationId: string, factoryId: string): void {

--- a/web_src/src/pages/factories/lib/linePhaseRuns.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.ts
@@ -6,6 +6,8 @@ export type LinePhaseTick = "running" | "waiting" | "queued" | "failed" | null;
 export type LinePhaseRunCard = {
   executionId: string;
   workOrderId: string;
+  /** Work order's factory-scoped sequence number, for building the permalink. */
+  workOrderNumber: string | undefined;
   title: string;
   execution: FactoriesWorkOrderExecution;
 };
@@ -125,6 +127,7 @@ function appendCurrentRunForOrder(
   const card: LinePhaseRunCard = {
     executionId: currentExecution.id ?? `${order.id}-${currentExecution.step}-${currentExecution.createdAt ?? ""}`,
     workOrderId: order.id,
+    workOrderNumber: order.number,
     title: order.title?.trim() || "Untitled work order",
     execution: currentExecution,
   };

--- a/web_src/src/pages/factories/lib/workOrderExecutions.ts
+++ b/web_src/src/pages/factories/lib/workOrderExecutions.ts
@@ -69,28 +69,28 @@ const EXECUTION_RESULT_META: Record<
  */
 export function getWorkOrderRunHref(
   organizationId: string,
-  factoryId: string,
+  factoryKey: string,
   appId: string | undefined,
   runId: string | undefined,
-  options?: { orderId?: string },
+  options?: { orderNumber?: string },
 ): string | null {
   if (!appId || !runId) {
     return null;
   }
 
-  return factoryAppRunPath(organizationId, factoryId, appId, runId, {
+  return factoryAppRunPath(organizationId, factoryKey, appId, runId, {
     from: "work-order",
-    orderId: options?.orderId,
+    orderNumber: options?.orderNumber,
   });
 }
 
 export function getWorkOrderExecutionRunHref(
   organizationId: string,
-  factoryId: string,
+  factoryKey: string,
   execution: FactoriesWorkOrderExecution,
-  options?: { orderId?: string },
+  options?: { orderNumber?: string },
 ): string | null {
-  return getWorkOrderRunHref(organizationId, factoryId, execution.run?.appId, execution.run?.id, options);
+  return getWorkOrderRunHref(organizationId, factoryKey, execution.run?.appId, execution.run?.id, options);
 }
 
 export function getExecutionStepTimestamp(execution: FactoriesWorkOrderExecution): string {

--- a/web_src/src/pages/factories/lib/workOrderNumberResolution.spec.ts
+++ b/web_src/src/pages/factories/lib/workOrderNumberResolution.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { FactoriesWorkOrder } from "@/api-client";
+import {
+  canonicalWorkOrderNumber,
+  resolveWorkOrderByNumber,
+  workOrderRouteNeedsCanonicalRedirect,
+} from "./workOrderNumberResolution";
+
+const ORDERS: FactoriesWorkOrder[] = [
+  { id: "order-1", number: "42", key: "SP-42", title: "Fix things" },
+  { id: "order-2", number: "7", key: "SP-7", title: "Ship things" },
+];
+
+describe("resolveWorkOrderByNumber", () => {
+  it("matches an exact number", () => {
+    const resolution = resolveWorkOrderByNumber(ORDERS, "42", false);
+    expect(resolution).toEqual({ status: "found", order: ORDERS[0], matchedBy: "number" });
+  });
+
+  it("tolerates leading zeros", () => {
+    const resolution = resolveWorkOrderByNumber(ORDERS, "007", false);
+    expect(resolution.status).toBe("found");
+    expect(resolution.order).toBe(ORDERS[1]);
+    expect(resolution.matchedBy).toBe("number");
+  });
+
+  it("falls back to a legacy id match when the segment isn't numeric", () => {
+    const resolution = resolveWorkOrderByNumber(ORDERS, "order-2", false);
+    expect(resolution).toEqual({ status: "found", order: ORDERS[1], matchedBy: "id" });
+  });
+
+  it("returns not-found once loaded and nothing matches", () => {
+    expect(resolveWorkOrderByNumber(ORDERS, "999", false)).toEqual({
+      status: "not-found",
+      order: null,
+      matchedBy: null,
+    });
+  });
+
+  it("returns loading instead of not-found while the list is still fetching", () => {
+    expect(resolveWorkOrderByNumber([], "42", true)).toEqual({ status: "loading", order: null, matchedBy: null });
+  });
+
+  it("rejects zero and negative numbers", () => {
+    expect(resolveWorkOrderByNumber(ORDERS, "0", false).status).toBe("not-found");
+    expect(resolveWorkOrderByNumber(ORDERS, "-1", false).status).toBe("not-found");
+  });
+});
+
+describe("workOrderRouteNeedsCanonicalRedirect", () => {
+  it("is false for an exact number match", () => {
+    const resolution = resolveWorkOrderByNumber(ORDERS, "42", false);
+    expect(workOrderRouteNeedsCanonicalRedirect(resolution, "42")).toBe(false);
+  });
+
+  it("is true for a leading-zero number", () => {
+    const resolution = resolveWorkOrderByNumber(ORDERS, "007", false);
+    expect(workOrderRouteNeedsCanonicalRedirect(resolution, "007")).toBe(true);
+  });
+
+  it("is true for a legacy id match", () => {
+    const resolution = resolveWorkOrderByNumber(ORDERS, "order-2", false);
+    expect(workOrderRouteNeedsCanonicalRedirect(resolution, "order-2")).toBe(true);
+  });
+});
+
+describe("canonicalWorkOrderNumber", () => {
+  it("returns the numeric string for a resolved order", () => {
+    expect(canonicalWorkOrderNumber(ORDERS[0])).toBe("42");
+  });
+
+  it("returns null when there is no order or number", () => {
+    expect(canonicalWorkOrderNumber(null)).toBeNull();
+    expect(canonicalWorkOrderNumber({ id: "x" })).toBeNull();
+  });
+});

--- a/web_src/src/pages/factories/lib/workOrderNumberResolution.ts
+++ b/web_src/src/pages/factories/lib/workOrderNumberResolution.ts
@@ -1,0 +1,87 @@
+import type { FactoriesWorkOrder } from "@/api-client";
+
+export type WorkOrderResolutionStatus = "loading" | "found" | "not-found";
+
+export interface WorkOrderResolution {
+  status: WorkOrderResolutionStatus;
+  order: FactoriesWorkOrder | null;
+  /**
+   * How the match was made. `"number"` is the canonical route identifier;
+   * `"id"` is the legacy fallback for old links that carry the raw database
+   * id. See `workOrderRouteNeedsCanonicalRedirect`.
+   */
+  matchedBy: "number" | "id" | null;
+}
+
+const LOADING: WorkOrderResolution = { status: "loading", order: null, matchedBy: null };
+const NOT_FOUND: WorkOrderResolution = { status: "not-found", order: null, matchedBy: null };
+
+function parsePositiveInteger(value: string): number | null {
+  if (!/^\d+$/.test(value.trim())) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+/**
+ * Resolves the `:orderNumber` route segment to a `FactoriesWorkOrder` using
+ * the already-fetched work orders list (same query the sidebar's "recent
+ * orders" section uses — no extra network round trip on a warm workspace).
+ * Matches the factory-scoped `number` first (tolerating leading zeros, e.g.
+ * `007` -> `7`), then falls back to `id` so old permalinks keep working.
+ *
+ * Returns `"loading"` (rather than `"not-found"`) whenever the list hasn't
+ * resolved yet, so callers don't flash an error state on every deep link.
+ */
+export function resolveWorkOrderByNumber(
+  orders: FactoriesWorkOrder[],
+  routeNumber: string | undefined,
+  isLoading: boolean,
+): WorkOrderResolution {
+  if (!routeNumber) {
+    return isLoading ? LOADING : NOT_FOUND;
+  }
+
+  const parsedNumber = parsePositiveInteger(routeNumber);
+  if (parsedNumber !== null) {
+    const byNumber = orders.find((order) => {
+      if (order.number === undefined || order.number === null || order.number === "") {
+        return false;
+      }
+      return Number(order.number) === parsedNumber;
+    });
+    if (byNumber) {
+      return { status: "found", order: byNumber, matchedBy: "number" };
+    }
+  }
+
+  const byId = orders.find((order) => Boolean(order.id) && order.id === routeNumber);
+  if (byId) {
+    return { status: "found", order: byId, matchedBy: "id" };
+  }
+
+  return isLoading ? LOADING : NOT_FOUND;
+}
+
+/**
+ * True when the route segment does not already match the canonical
+ * `order.number` exactly — a legacy id, a leading-zero-padded number, or
+ * any other non-canonical spelling. Callers `<Navigate replace>` to the
+ * canonical URL in this case instead of rendering the page.
+ */
+export function workOrderRouteNeedsCanonicalRedirect(resolution: WorkOrderResolution, routeNumber: string): boolean {
+  if (resolution.status !== "found" || !resolution.order || resolution.order.number === undefined) {
+    return false;
+  }
+  return String(Number(resolution.order.number)) !== routeNumber;
+}
+
+/** Canonical route identifier for a resolved work order, or `null`. */
+export function canonicalWorkOrderNumber(order: FactoriesWorkOrder | null): string | null {
+  if (!order || order.number === undefined || order.number === null || order.number === "") {
+    return null;
+  }
+  const parsed = Number(order.number);
+  return Number.isFinite(parsed) ? String(parsed) : null;
+}

--- a/web_src/src/pages/factories/pages/Automations.stories.tsx
+++ b/web_src/src/pages/factories/pages/Automations.stories.tsx
@@ -9,7 +9,7 @@ import {
   FACTORIES_ORGANIZATION_ID,
   HOUR_AGO,
   LAST_WEEK,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   REFUND_FACTORY_APPS,
   TWO_HOURS_AGO,
 } from "../__fixtures__/factoryPageResponses";
@@ -28,7 +28,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const automationsPath = `workspaces/${PRIMARY_FACTORY_ID}/automations`;
+const automationsPath = `workspaces/${PRIMARY_FACTORY_KEY}/automations`;
 const implementerAppId = REFUND_FACTORY_APPS[1]?.id ?? "app-refund-implementer";
 
 const implementerCanvasRunsFixture: CanvasAppFixture = {

--- a/web_src/src/pages/factories/pages/AutomationsPage.tsx
+++ b/web_src/src/pages/factories/pages/AutomationsPage.tsx
@@ -21,7 +21,7 @@ export function AutomationsPage() {
     return (
       <AutomationsLegacyRedirect
         organizationId={model.organizationId}
-        factoryId={model.factoryId}
+        factoryKey={model.factoryKey}
         factoryLoaded={Boolean(model.factory)}
         legacyLineId={model.legacyLineId}
       />
@@ -69,7 +69,7 @@ export function AutomationsPage() {
       >
         <AutomationsPageBody
           organizationId={model.organizationId}
-          factoryId={model.factoryId}
+          factoryKey={model.factoryKey}
           apps={model.apps}
           workOrders={model.workOrders}
           appsLoading={model.appsLoading}

--- a/web_src/src/pages/factories/pages/ComingSoon.stories.tsx
+++ b/web_src/src/pages/factories/pages/ComingSoon.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
-import { defaultFactoriesFixture, PRIMARY_FACTORY_ID } from "../__fixtures__/factoryPageResponses";
+import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
 import { MissionsPage } from "./MissionsPage";
 import { VelocityPage } from "./VelocityPage";
 import { WikiPage } from "./WikiPage";
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 export const Missions: Story = {
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/missions`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/missions`}
       factoriesFixture={defaultFactoriesFixture}
     />
   ),
@@ -30,7 +30,7 @@ export const Missions: Story = {
 export const Wiki: Story = {
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/wiki`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/wiki`}
       factoriesFixture={defaultFactoriesFixture}
       pageOverrides={{ wiki: WikiPage }}
     />
@@ -40,7 +40,7 @@ export const Wiki: Story = {
 export const Velocity: Story = {
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/velocity`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/velocity`}
       factoriesFixture={defaultFactoriesFixture}
     />
   ),

--- a/web_src/src/pages/factories/pages/CreateWorkOrder.stories.tsx
+++ b/web_src/src/pages/factories/pages/CreateWorkOrder.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
-import { defaultFactoriesFixture, PRIMARY_FACTORY_ID } from "../__fixtures__/factoryPageResponses";
+import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
 import { CreateWorkOrderPage } from "./CreateWorkOrderPage";
 
 /**
@@ -17,7 +17,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const createPath = `workspaces/${PRIMARY_FACTORY_ID}/work-orders/new`;
+const createPath = `workspaces/${PRIMARY_FACTORY_KEY}/work-orders/new`;
 
 export const Empty: Story = {
   render: () => <FactoriesHarness pathSuffix={createPath} factoriesFixture={defaultFactoriesFixture} />,

--- a/web_src/src/pages/factories/pages/CreateWorkOrderPage.tsx
+++ b/web_src/src/pages/factories/pages/CreateWorkOrderPage.tsx
@@ -64,7 +64,9 @@ export function CreateWorkOrderPage() {
         description: description.trim(),
         assigneeIds,
       });
-      navigate(order.number !== undefined ? workOrderDetailPath(organizationId, factoryKey, order.number) : workOrdersHref);
+      navigate(
+        order.number !== undefined ? workOrderDetailPath(organizationId, factoryKey, order.number) : workOrdersHref,
+      );
     } catch (error) {
       showErrorToast(getApiErrorMessage(error, "Failed to create work order"));
     }

--- a/web_src/src/pages/factories/pages/CreateWorkOrderPage.tsx
+++ b/web_src/src/pages/factories/pages/CreateWorkOrderPage.tsx
@@ -28,7 +28,7 @@ const MAX_TITLE_LENGTH = 256;
 const MAX_DESCRIPTION_LENGTH = 5000;
 
 export function CreateWorkOrderPage() {
-  const { organizationId, factoryId, factory } = useFactoriesLayout();
+  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
   const navigate = useNavigate();
   const createWorkOrder = useCreateWorkOrder(organizationId, factoryId);
   const { data: users = [] } = useOrganizationUsers(organizationId);
@@ -40,7 +40,7 @@ export function CreateWorkOrderPage() {
 
   usePageTitle(["New Work Order", factory?.name ?? "Workspace"]);
 
-  const workOrdersHref = workOrdersPath(organizationId, factoryId);
+  const workOrdersHref = workOrdersPath(organizationId, factoryKey);
 
   const selectedAssigneeLabels = useMemo(() => {
     const labelById = new Map(
@@ -64,7 +64,7 @@ export function CreateWorkOrderPage() {
         description: description.trim(),
         assigneeIds,
       });
-      navigate(order.id ? workOrderDetailPath(organizationId, factoryId, order.id) : workOrdersHref);
+      navigate(order.number !== undefined ? workOrderDetailPath(organizationId, factoryKey, order.number) : workOrdersHref);
     } catch (error) {
       showErrorToast(getApiErrorMessage(error, "Failed to create work order"));
     }

--- a/web_src/src/pages/factories/pages/FactoryAppCanvas.stories.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvas.stories.tsx
@@ -6,6 +6,7 @@ import {
   defaultFactoriesFixture,
   FACTORIES_ORGANIZATION_ID,
   PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   REFUND_FACTORY_APPS,
 } from "../__fixtures__/factoryPageResponses";
 import { FactoryAppCanvasPage } from "./FactoryAppCanvasPage";
@@ -53,7 +54,7 @@ export const FromAutomations: Story = {
   name: "From Automations",
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/apps/${plannerApp.id}?from=automations`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/apps/${plannerApp.id}?from=automations`}
       factoriesFixture={defaultFactoriesFixture}
       appFixture={factoryOwnedCanvasFixture()}
     />
@@ -64,7 +65,7 @@ export const ConfigureEditMode: Story = {
   name: "Configure edit mode",
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/apps/${plannerApp.id}?configure=1&from=automations`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/apps/${plannerApp.id}?configure=1&from=automations`}
       factoriesFixture={defaultFactoriesFixture}
       appFixture={factoryOwnedCanvasFixture()}
     />
@@ -75,7 +76,7 @@ export const WithRun: Story = {
   name: "With run query",
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/apps/${plannerApp.id}?from=automations&run=${defaultCanvasAppFixture.publishedRunId ?? "run-1"}`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/apps/${plannerApp.id}?from=automations&run=${defaultCanvasAppFixture.publishedRunId ?? "run-1"}`}
       factoriesFixture={defaultFactoriesFixture}
       appFixture={factoryOwnedCanvasFixture()}
     />

--- a/web_src/src/pages/factories/pages/FactoryAppCanvasPage.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvasPage.tsx
@@ -12,7 +12,7 @@ export function FactoryAppCanvasPage() {
   const model = useFactoryAppCanvasPageModel();
 
   if (model.shouldRedirect) {
-    return <FactoryAppCanvasRedirect organizationId={model.organizationId} factoryId={model.factoryId} />;
+    return <FactoryAppCanvasRedirect organizationId={model.organizationId} factoryKey={model.factoryKey} />;
   }
 
   return (

--- a/web_src/src/pages/factories/pages/FactoryLineEdit.stories.tsx
+++ b/web_src/src/pages/factories/pages/FactoryLineEdit.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
   defaultFactoriesFixture,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   REFUND_FACTORY_LINES,
 } from "../__fixtures__/factoryPageResponses";
 import { FactoryLineEditPage } from "./FactoryLineEditPage";
@@ -26,7 +26,7 @@ export const NewLine: Story = {
   name: "New line",
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/lines/new`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/new`}
       factoriesFixture={defaultFactoriesFixture}
     />
   ),
@@ -39,7 +39,7 @@ export const EditLine: Story = {
     const line = REFUND_FACTORY_LINES[0];
     return (
       <FactoriesHarness
-        pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/lines/${line.id}/edit`}
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}/edit`}
         factoriesFixture={defaultFactoriesFixture}
       />
     );

--- a/web_src/src/pages/factories/pages/FactoryLineEditPage.tsx
+++ b/web_src/src/pages/factories/pages/FactoryLineEditPage.tsx
@@ -18,7 +18,7 @@ import {
 import { cn } from "@/lib/utils";
 
 export function FactoryLineEditPage() {
-  const { organizationId, factoryId, factory } = useFactoriesLayout();
+  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
   const { canAct } = usePermissions();
   const { lineId } = useParams<{ lineId?: string }>();
 
@@ -34,8 +34,8 @@ export function FactoryLineEditPage() {
     return factory?.lines?.find((entry) => entry.id === lineId) ?? null;
   }, [factory?.lines, isCreate, lineId]);
 
-  const linesHref = linesPath(organizationId, factoryId);
-  const returnHref = line?.id ? factoryLineDetailPath(organizationId, factoryId, line.id) : linesHref;
+  const linesHref = linesPath(organizationId, factoryKey);
+  const returnHref = line?.id ? factoryLineDetailPath(organizationId, factoryKey, line.id) : linesHref;
   const actions = useFactoryLineEditActions(organizationId, factoryId, returnHref, isCreate, lineId);
 
   const pageTitleBase = resolvePageTitleBase(isCreate, line?.name);

--- a/web_src/src/pages/factories/pages/Lines.stories.tsx
+++ b/web_src/src/pages/factories/pages/Lines.stories.tsx
@@ -4,7 +4,7 @@ import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
   defaultFactoriesFixture,
   emptyFactoriesFixture,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   REFUND_FACTORY_LINES,
 } from "../__fixtures__/factoryPageResponses";
 import { LinesPage } from "./LinesPage";
@@ -22,7 +22,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const linesListPath = `workspaces/${PRIMARY_FACTORY_ID}/lines`;
+const linesListPath = `workspaces/${PRIMARY_FACTORY_KEY}/lines`;
 
 export const Populated: Story = {
   render: () => <FactoriesHarness pathSuffix={linesListPath} factoriesFixture={defaultFactoriesFixture} />,
@@ -39,7 +39,7 @@ export const LineDetail: Story = {
     const line = REFUND_FACTORY_LINES[0];
     return (
       <FactoriesHarness
-        pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/lines/${line.id}`}
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}`}
         factoriesFixture={defaultFactoriesFixture}
       />
     );

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -38,7 +38,7 @@ import {
 } from "./factoryPageLayoutStyles";
 
 export function LinesPage() {
-  const { organizationId, factoryId, factory } = useFactoriesLayout();
+  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const { lineId: routeLineId } = useParams<{ lineId: string }>();
   const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
@@ -51,7 +51,7 @@ export function LinesPage() {
   );
 
   if (routeLineId && factory && !selectedLine) {
-    return <Navigate to={linesPath(organizationId, factoryId)} replace />;
+    return <Navigate to={linesPath(organizationId, factoryKey)} replace />;
   }
 
   return (
@@ -72,7 +72,7 @@ export function LinesPage() {
             message="You don't have permission to create lines."
           >
             <Button type="button" variant="outline" asChild disabled={!canUpdate} data-testid="lines-create-button">
-              <Link href={canUpdate ? createFactoryLinePath(organizationId, factoryId) : "#"}>
+              <Link href={canUpdate ? createFactoryLinePath(organizationId, factoryKey) : "#"}>
                 <Plus className="h-3.5 w-3.5" aria-hidden />
                 Add line
               </Link>
@@ -85,7 +85,7 @@ export function LinesPage() {
         {selectedLine ? (
           <LineDetail
             organizationId={organizationId}
-            factoryId={factoryId}
+            factoryKey={factoryKey}
             line={selectedLine}
             workOrders={workOrders}
             canUpdate={canUpdate}
@@ -93,7 +93,7 @@ export function LinesPage() {
         ) : lines.length === 0 ? (
           <EmptyLinesState
             organizationId={organizationId}
-            factoryId={factoryId}
+            factoryKey={factoryKey}
             canUpdate={canUpdate || permissionsLoading}
           />
         ) : (
@@ -107,7 +107,7 @@ export function LinesPage() {
                 <li key={line.id}>
                   <LineCard
                     line={line}
-                    href={factoryLineDetailPath(organizationId, factoryId, line.id)}
+                    href={factoryLineDetailPath(organizationId, factoryKey, line.id)}
                     ticks={board.map((column) => column.tick)}
                   />
                 </li>
@@ -122,25 +122,25 @@ export function LinesPage() {
 
 function LineDetail({
   organizationId,
-  factoryId,
+  factoryKey,
   line,
   workOrders,
   canUpdate,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   line: FactoriesFactoryLine;
   workOrders: FactoriesWorkOrder[];
   canUpdate: boolean;
 }) {
   const steps = line.steps ?? [];
-  const editHref = line.id ? editFactoryLinePath(organizationId, factoryId, line.id) : "#";
+  const editHref = line.id ? editFactoryLinePath(organizationId, factoryKey, line.id) : "#";
   const board = useMemo(() => buildLinePhaseBoard(line, workOrders ?? []), [line, workOrders]);
 
   return (
     <div data-testid="lines-detail">
       <Link
-        href={linesPath(organizationId, factoryId)}
+        href={linesPath(organizationId, factoryKey)}
         className="mb-3 inline-flex items-center gap-1.5 text-[13px] text-muted-foreground hover:text-foreground"
         data-testid="lines-back-to-list"
       >
@@ -178,7 +178,7 @@ function LineDetail({
           No phases yet. Edit this line to add app-driven phases.
         </p>
       ) : (
-        <PhaseBoard organizationId={organizationId} factoryId={factoryId} lineId={line.id} columns={board} />
+        <PhaseBoard organizationId={organizationId} factoryKey={factoryKey} lineId={line.id} columns={board} />
       )}
     </div>
   );
@@ -249,12 +249,12 @@ const MAX_PHASE_COLUMNS_PER_ROW = 3;
 
 function PhaseBoard({
   organizationId,
-  factoryId,
+  factoryKey,
   lineId,
   columns,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   lineId?: string;
   columns: LinePhaseColumn[];
 }) {
@@ -270,7 +270,7 @@ function PhaseBoard({
         <PhaseColumn
           key={`${column.stepIndex}-${column.stepName}`}
           organizationId={organizationId}
-          factoryId={factoryId}
+          factoryKey={factoryKey}
           lineId={lineId}
           column={column}
         />
@@ -281,12 +281,12 @@ function PhaseBoard({
 
 function PhaseColumn({
   organizationId,
-  factoryId,
+  factoryKey,
   lineId,
   column,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   lineId?: string;
   column: LinePhaseColumn;
 }) {
@@ -313,7 +313,7 @@ function PhaseColumn({
   const navigate = useNavigate();
   const visibleRuns = column.runs.slice(0, Math.min(visibleCount, totalRuns));
   const configureHref = column.appId
-    ? factoryAppConfigurePath(organizationId, factoryId, column.appId, { from: "lines", lineId })
+    ? factoryAppConfigurePath(organizationId, factoryKey, column.appId, { from: "lines", lineId })
     : null;
 
   return (
@@ -361,7 +361,7 @@ function PhaseColumn({
         ) : (
           visibleRuns.map((run) => (
             <li key={run.executionId}>
-              <PhaseRunCard organizationId={organizationId} factoryId={factoryId} lineId={lineId} run={run} />
+              <PhaseRunCard organizationId={organizationId} factoryKey={factoryKey} lineId={lineId} run={run} />
             </li>
           ))
         )}
@@ -372,12 +372,12 @@ function PhaseColumn({
 
 function PhaseRunCard({
   organizationId,
-  factoryId,
+  factoryKey,
   lineId,
   run,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   lineId?: string;
   run: LinePhaseRunCard;
 }) {
@@ -386,8 +386,10 @@ function PhaseRunCard({
   const runId = run.execution.run?.id;
   const href =
     appId && runId
-      ? factoryAppRunPath(organizationId, factoryId, appId, runId, { from: "lines", lineId })
-      : workOrderDetailPath(organizationId, factoryId, run.workOrderId);
+      ? factoryAppRunPath(organizationId, factoryKey, appId, runId, { from: "lines", lineId })
+      : run.workOrderNumber !== undefined
+        ? workOrderDetailPath(organizationId, factoryKey, run.workOrderNumber)
+        : linesPath(organizationId, factoryKey);
   const timestamp = run.execution.updatedAt ?? run.execution.createdAt;
   const timeLabel = timestamp ? formatTimeAgo(new Date(timestamp), false) : null;
 
@@ -426,11 +428,11 @@ function PhaseTickDot({ tick }: { tick: LinePhaseTick }) {
 
 function EmptyLinesState({
   organizationId,
-  factoryId,
+  factoryKey,
   canUpdate,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   canUpdate: boolean;
 }) {
   return (
@@ -444,7 +446,7 @@ function EmptyLinesState({
         Lines define how work orders flow through your apps.
       </p>
       <Button type="button" asChild className="mt-6" disabled={!canUpdate}>
-        <Link href={canUpdate ? createFactoryLinePath(organizationId, factoryId) : "#"}>
+        <Link href={canUpdate ? createFactoryLinePath(organizationId, factoryKey) : "#"}>
           <Plus className="h-3.5 w-3.5" aria-hidden />
           Add line
         </Link>

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -370,6 +370,23 @@ function PhaseColumn({
   );
 }
 
+function phaseRunCardHref(
+  organizationId: string,
+  factoryKey: string,
+  lineId: string | undefined,
+  run: LinePhaseRunCard,
+): string {
+  const appId = run.execution.run?.appId;
+  const runId = run.execution.run?.id;
+  if (appId && runId) {
+    return factoryAppRunPath(organizationId, factoryKey, appId, runId, { from: "lines", lineId });
+  }
+  if (run.workOrderNumber !== undefined) {
+    return workOrderDetailPath(organizationId, factoryKey, run.workOrderNumber);
+  }
+  return linesPath(organizationId, factoryKey);
+}
+
 function PhaseRunCard({
   organizationId,
   factoryKey,
@@ -382,14 +399,7 @@ function PhaseRunCard({
   run: LinePhaseRunCard;
 }) {
   const status = resolvePhaseRunStatus(run.execution);
-  const appId = run.execution.run?.appId;
-  const runId = run.execution.run?.id;
-  const href =
-    appId && runId
-      ? factoryAppRunPath(organizationId, factoryKey, appId, runId, { from: "lines", lineId })
-      : run.workOrderNumber !== undefined
-        ? workOrderDetailPath(organizationId, factoryKey, run.workOrderNumber)
-        : linesPath(organizationId, factoryKey);
+  const href = phaseRunCardHref(organizationId, factoryKey, lineId, run);
   const timestamp = run.execution.updatedAt ?? run.execution.createdAt;
   const timeLabel = timestamp ? formatTimeAgo(new Date(timestamp), false) : null;
 

--- a/web_src/src/pages/factories/pages/Onboarding.stories.tsx
+++ b/web_src/src/pages/factories/pages/Onboarding.stories.tsx
@@ -5,6 +5,7 @@ import {
   defaultFactoriesFixture,
   emptyFactoriesFixture,
   PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
 } from "../__fixtures__/factoryPageResponses";
 import { ONBOARDING_AVAILABLE_REPOS } from "./onboarding/onboardingMocks";
 import { OnboardingWireframe } from "./onboarding/OnboardingWireframe";
@@ -23,7 +24,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const factoryBase = `workspaces/${PRIMARY_FACTORY_ID}`;
+const factoryBase = `workspaces/${PRIMARY_FACTORY_KEY}`;
 
 const pendingSeed = {
   pending: { workspaceId: PRIMARY_FACTORY_ID, workspaceName: "Refunds Factory" },

--- a/web_src/src/pages/factories/pages/Overview.stories.tsx
+++ b/web_src/src/pages/factories/pages/Overview.stories.tsx
@@ -4,7 +4,7 @@ import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
   defaultFactoriesFixture,
   emptyWorkOrdersFactoriesFixture,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
 } from "../__fixtures__/factoryPageResponses";
 import { OverviewPage } from "./OverviewPage";
 
@@ -22,7 +22,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const overviewPath = `workspaces/${PRIMARY_FACTORY_ID}/overview`;
+const overviewPath = `workspaces/${PRIMARY_FACTORY_KEY}/overview`;
 
 export const Populated: Story = {
   render: () => <FactoriesHarness pathSuffix={overviewPath} factoriesFixture={defaultFactoriesFixture} />,

--- a/web_src/src/pages/factories/pages/OverviewPage.tsx
+++ b/web_src/src/pages/factories/pages/OverviewPage.tsx
@@ -20,7 +20,7 @@ import {
 const MAX_ROWS = 8;
 
 export function OverviewPage() {
-  const { organizationId, factoryId, factory } = useFactoriesLayout();
+  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
   const {
     data: workOrders = [],
     isLoading: workOrdersLoading,
@@ -54,12 +54,12 @@ export function OverviewPage() {
         <div className="grid gap-6 lg:grid-cols-2">
           <WorkOrdersOverviewCard
             organizationId={organizationId}
-            factoryId={factoryId}
+            factoryKey={factoryKey}
             orders={recentOrders}
             isLoading={workOrdersLoading}
             error={workOrdersError}
           />
-          <LinesOverviewCard organizationId={organizationId} factoryId={factoryId} lines={lines} />
+          <LinesOverviewCard organizationId={organizationId} factoryKey={factoryKey} lines={lines} />
         </div>
       </div>
     </>
@@ -68,13 +68,13 @@ export function OverviewPage() {
 
 function WorkOrdersOverviewCard({
   organizationId,
-  factoryId,
+  factoryKey,
   orders,
   isLoading,
   error,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   orders: FactoriesWorkOrder[];
   isLoading: boolean;
   error: Error | null;
@@ -87,7 +87,7 @@ function WorkOrdersOverviewCard({
           <p className="text-[12px] text-muted-foreground">Recent activity by status.</p>
         </div>
         <Link
-          to={workOrdersPath(organizationId, factoryId)}
+          to={workOrdersPath(organizationId, factoryKey)}
           className="text-[12px] font-medium text-muted-foreground hover:text-foreground"
           data-testid="overview-work-orders-view-all"
         >
@@ -107,7 +107,8 @@ function WorkOrdersOverviewCard({
             {orders.map((order) => {
               const status = getWorkOrderDisplayStatus(order);
               const statusMeta = getWorkOrderDisplayStatusMeta(status);
-              const href = order.id ? workOrderDetailPath(organizationId, factoryId, order.id) : "#";
+              const href =
+                order.number !== undefined ? workOrderDetailPath(organizationId, factoryKey, order.number) : "#";
               const updatedAt = order.updatedAt ?? order.createdAt;
               const timeLabel = updatedAt ? formatTimeAgo(new Date(updatedAt)) : "—";
               return (
@@ -150,11 +151,11 @@ function WorkOrdersOverviewCard({
 
 function LinesOverviewCard({
   organizationId,
-  factoryId,
+  factoryKey,
   lines,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   lines: FactoriesFactoryLine[];
 }) {
   return (
@@ -165,7 +166,7 @@ function LinesOverviewCard({
           <p className="text-[12px] text-muted-foreground">Lines and their steps.</p>
         </div>
         <Link
-          to={linesPath(organizationId, factoryId)}
+          to={linesPath(organizationId, factoryKey)}
           className="text-[12px] font-medium text-muted-foreground hover:text-foreground"
           data-testid="overview-lines-view-all"
         >
@@ -179,7 +180,7 @@ function LinesOverviewCard({
         <ul>
           {lines.map((line) => {
             const stepsCount = line.steps?.length ?? 0;
-            const href = line.id ? factoryLineDetailPath(organizationId, factoryId, line.id) : "#";
+            const href = line.id ? factoryLineDetailPath(organizationId, factoryKey, line.id) : "#";
             return (
               <li key={line.id ?? line.name} className="border-b border-border/60 last:border-b-0">
                 <Link

--- a/web_src/src/pages/factories/pages/Wiki.stories.tsx
+++ b/web_src/src/pages/factories/pages/Wiki.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
-import { defaultFactoriesFixture, PRIMARY_FACTORY_ID } from "../__fixtures__/factoryPageResponses";
+import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
 import { WikiWireframe } from "./wiki/WikiWireframe";
 import { WIKI_DOCUMENTS_DEFAULT, WIKI_DOCUMENTS_REFRESHED } from "./wiki/wikiMocks";
 
@@ -18,7 +18,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const wikiPath = `workspaces/${PRIMARY_FACTORY_ID}/wiki`;
+const wikiPath = `workspaces/${PRIMARY_FACTORY_KEY}/wiki`;
 
 function EmptyWikiWireframe() {
   return <WikiWireframe initialDocuments={[]} refreshedDocuments={WIKI_DOCUMENTS_REFRESHED} />;

--- a/web_src/src/pages/factories/pages/WorkOrderCanvas.stories.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderCanvas.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
   defaultFactoriesFixture,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   REFUND_FACTORY_LINES,
 } from "../__fixtures__/factoryPageResponses";
 import { WorkOrderCanvas } from "./WorkOrderCanvas";
@@ -30,7 +30,7 @@ export const ConfigurePhase: Story = {
     return (
       <FactoriesHarness
         enableOnboarding={false}
-        pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/lines/${line.id}/phases/${phase}/configure`}
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}/phases/${phase}/configure`}
         factoriesFixture={defaultFactoriesFixture}
       />
     );

--- a/web_src/src/pages/factories/pages/WorkOrderDetail.stories.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderDetail.stories.tsx
@@ -4,7 +4,7 @@ import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
   defaultFactoriesFixture,
   OPEN_WORK_ORDER,
-  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
   RUNNING_WORK_ORDER,
   CLOSED_WORK_ORDER,
 } from "../__fixtures__/factoryPageResponses";
@@ -24,8 +24,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-function detailPath(orderId?: string) {
-  return `workspaces/${PRIMARY_FACTORY_ID}/work-orders/${orderId ?? OPEN_WORK_ORDER.id}`;
+function detailPath(orderNumber?: string) {
+  return `workspaces/${PRIMARY_FACTORY_KEY}/work-order/${orderNumber ?? OPEN_WORK_ORDER.number}`;
 }
 
 export const Open: Story = {
@@ -34,12 +34,12 @@ export const Open: Story = {
 
 export const Running: Story = {
   render: () => (
-    <FactoriesHarness pathSuffix={detailPath(RUNNING_WORK_ORDER.id)} factoriesFixture={defaultFactoriesFixture} />
+    <FactoriesHarness pathSuffix={detailPath(RUNNING_WORK_ORDER.number)} factoriesFixture={defaultFactoriesFixture} />
   ),
 };
 
 export const Closed: Story = {
   render: () => (
-    <FactoriesHarness pathSuffix={detailPath(CLOSED_WORK_ORDER.id)} factoriesFixture={defaultFactoriesFixture} />
+    <FactoriesHarness pathSuffix={detailPath(CLOSED_WORK_ORDER.number)} factoriesFixture={defaultFactoriesFixture} />
   ),
 };

--- a/web_src/src/pages/factories/pages/WorkOrderDetailPage.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderDetailPage.tsx
@@ -1,35 +1,106 @@
 import { usePermissions } from "@/contexts/usePermissions";
-import { useFactory, useWorkOrder, useWorkOrderArtifacts, useWorkOrderEvents } from "@/hooks/useFactoryData";
+import { useFactory, useFactoryWorkOrders, useWorkOrder, useWorkOrderArtifacts, useWorkOrderEvents } from "@/hooks/useFactoryData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 import { useMemo } from "react";
-import { Navigate, useParams } from "react-router";
+import { Navigate, useLocation, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
-import { workOrdersPath } from "../lib/factoryPagePaths";
+import { workOrderDetailPath, workOrdersPath } from "../lib/factoryPagePaths";
 import { flattenWorkOrderEventsPages } from "../lib/workOrderEventsPagination";
 import { getWorkOrderDetailDerived } from "../lib/workOrderProgress";
+import {
+  resolveWorkOrderByNumber,
+  workOrderRouteNeedsCanonicalRedirect,
+  type WorkOrderResolution,
+} from "../lib/workOrderNumberResolution";
 import { useWorkOrderDetailActions } from "../useWorkOrderDetailActions";
 import { WorkOrderDetailLoadedView } from "../WorkOrderDetailLoadedView";
 import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
 
 export function WorkOrderDetailPage() {
-  const { orderId } = useParams<{ orderId: string }>();
-  const { organizationId, factoryId } = useFactoriesLayout();
+  const { orderNumber } = useParams<{ orderNumber: string }>();
+  const { organizationId, factoryId, factoryKey } = useFactoriesLayout();
+  const location = useLocation();
+  const {
+    data: workOrders = [],
+    isLoading: workOrdersLoading,
+    isFetching: workOrdersFetching,
+  } = useFactoryWorkOrders(organizationId, factoryId);
 
-  if (!orderId) {
+  if (!orderNumber) {
     return null;
   }
 
-  return <WorkOrderDetailPageContent organizationId={organizationId} factoryId={factoryId} orderId={orderId} />;
+  // `isFetching` (not just `isLoading`) so a just-created work order — whose
+  // list invalidation is still in flight when we navigate to its permalink —
+  // shows the loading state instead of bouncing back to the list.
+  const resolution = resolveWorkOrderByNumber(workOrders, orderNumber, workOrdersLoading || workOrdersFetching);
+
+  if (workOrderRouteNeedsCanonicalRedirect(resolution, orderNumber) && resolution.order?.number !== undefined) {
+    const canonicalHref = workOrderDetailPath(organizationId, factoryKey, String(Number(resolution.order.number)));
+    return <Navigate to={`${canonicalHref}${location.search}`} replace />;
+  }
+
+  if (resolution.status === "not-found") {
+    return <Navigate to={workOrdersPath(organizationId, factoryKey)} replace />;
+  }
+
+  if (resolution.status === "loading" || !resolution.order?.id) {
+    return (
+      <div className={factoryContentBodyClassName}>
+        <p className="text-[13px] text-muted-foreground">Loading work order…</p>
+      </div>
+    );
+  }
+
+  return (
+    <WorkOrderDetailPageContent
+      organizationId={organizationId}
+      factoryId={factoryId}
+      factoryKey={factoryKey}
+      orderId={resolution.order.id}
+    />
+  );
+}
+
+/** Legacy `/work-orders/:orderId` bookmarks redirect to the canonical `/work-order/:number` permalink. */
+export function LegacyWorkOrderDetailRedirect() {
+  const { orderId } = useParams<{ orderId: string }>();
+  const { organizationId, factoryId, factoryKey } = useFactoriesLayout();
+  const location = useLocation();
+  const { data: workOrders = [], isLoading, isFetching } = useFactoryWorkOrders(organizationId, factoryId);
+
+  if (!orderId) {
+    return <Navigate to={workOrdersPath(organizationId, factoryKey)} replace />;
+  }
+
+  const resolution: WorkOrderResolution = resolveWorkOrderByNumber(workOrders, orderId, isLoading || isFetching);
+
+  if (resolution.status === "loading") {
+    return (
+      <div className={factoryContentBodyClassName}>
+        <p className="text-[13px] text-muted-foreground">Loading work order…</p>
+      </div>
+    );
+  }
+
+  if (resolution.status === "not-found" || resolution.order?.number === undefined) {
+    return <Navigate to={workOrdersPath(organizationId, factoryKey)} replace />;
+  }
+
+  const canonicalHref = workOrderDetailPath(organizationId, factoryKey, String(Number(resolution.order.number)));
+  return <Navigate to={`${canonicalHref}${location.search}`} replace />;
 }
 
 function WorkOrderDetailPageContent({
   organizationId,
   factoryId,
+  factoryKey,
   orderId,
 }: {
   organizationId: string;
   factoryId: string;
+  factoryKey: string;
   orderId: string;
 }) {
   const { canAct, isLoading: permissionsLoading } = usePermissions();
@@ -45,7 +116,7 @@ function WorkOrderDetailPageContent({
 
   usePageTitle([order?.title ?? "Work Order", factory?.name ?? "Workspace"]);
 
-  const workOrdersHref = workOrdersPath(organizationId, factoryId);
+  const workOrdersHref = workOrdersPath(organizationId, factoryKey);
 
   if (shouldRedirectAfterError({ factoryLoading, factoryError, orderLoading, orderError })) {
     return <Navigate to={workOrdersHref} replace />;
@@ -69,7 +140,7 @@ function WorkOrderDetailPageContent({
       derived={derived}
       factoryLines={factory.lines ?? []}
       organizationId={organizationId}
-      factoryId={factoryId}
+      factoryKey={factoryKey}
       events={events}
       eventsQuery={eventsQuery}
       artifactsQuery={artifactsQuery}
@@ -97,7 +168,7 @@ interface LoadedWorkOrderDetailProps {
   derived: ReturnType<typeof getWorkOrderDetailDerived>;
   factoryLines: FactoriesFactoryLine[];
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   events: ReturnType<typeof flattenWorkOrderEventsPages>;
   eventsQuery: ReturnType<typeof useWorkOrderEvents>;
   artifactsQuery: ReturnType<typeof useWorkOrderArtifacts>;
@@ -112,7 +183,7 @@ function LoadedWorkOrderDetail({
   derived,
   factoryLines,
   organizationId,
-  factoryId,
+  factoryKey,
   events,
   eventsQuery,
   artifactsQuery,
@@ -124,7 +195,7 @@ function LoadedWorkOrderDetail({
   return (
     <WorkOrderDetailLoadedView
       organizationId={organizationId}
-      factoryId={factoryId}
+      factoryKey={factoryKey}
       order={order}
       events={events}
       eventsError={eventsQuery.error ?? null}

--- a/web_src/src/pages/factories/pages/WorkOrderDetailPage.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderDetailPage.tsx
@@ -1,5 +1,11 @@
 import { usePermissions } from "@/contexts/usePermissions";
-import { useFactory, useFactoryWorkOrders, useWorkOrder, useWorkOrderArtifacts, useWorkOrderEvents } from "@/hooks/useFactoryData";
+import {
+  useFactory,
+  useFactoryWorkOrders,
+  useWorkOrder,
+  useWorkOrderArtifacts,
+  useWorkOrderEvents,
+} from "@/hooks/useFactoryData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 import { useMemo } from "react";

--- a/web_src/src/pages/factories/pages/WorkOrders.stories.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrders.stories.tsx
@@ -2,8 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
-  EMPTY_FACTORY_ID,
-  PRIMARY_FACTORY_ID,
+  EMPTY_FACTORY_KEY,
+  PRIMARY_FACTORY_KEY,
   defaultFactoriesFixture,
   emptyWorkOrdersFactoriesFixture,
 } from "../__fixtures__/factoryPageResponses";
@@ -24,8 +24,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const workOrdersPath = `workspaces/${PRIMARY_FACTORY_ID}/work-orders`;
-const emptyWorkspacePath = `workspaces/${EMPTY_FACTORY_ID}/work-orders`;
+const workOrdersPath = `workspaces/${PRIMARY_FACTORY_KEY}/work-orders`;
+const emptyWorkspacePath = `workspaces/${EMPTY_FACTORY_KEY}/work-orders`;
 
 /** Populated dataset. Default layout is Board and default scope is All. */
 export const Populated: Story = {

--- a/web_src/src/pages/factories/pages/WorkOrdersPage.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrdersPage.tsx
@@ -21,7 +21,7 @@ import { Heading } from "@/components/Heading/heading";
  * loaded view can assume a populated payload.
  */
 export function WorkOrdersPage() {
-  const { organizationId, factoryId, factory } = useFactoriesLayout();
+  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const { data: me } = useMe(false);
 
@@ -87,7 +87,7 @@ export function WorkOrdersPage() {
   return (
     <WorkOrdersLoadedView
       organizationId={organizationId}
-      factoryId={factoryId}
+      factoryKey={factoryKey}
       factory={factory}
       factoryLines={factory.lines ?? []}
       workOrders={workOrders}

--- a/web_src/src/pages/factories/pages/automationsPageBody.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageBody.tsx
@@ -3,7 +3,7 @@ import { AutomationDetail, AutomationsPageList, EmptyAutomationsState } from "./
 
 type AutomationsPageBodyProps = {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   apps: FactoryApp[];
   workOrders: Parameters<typeof AutomationsPageList>[0]["workOrders"];
   appsLoading: boolean;
@@ -14,7 +14,7 @@ type AutomationsPageBodyProps = {
 
 export function AutomationsPageBody({
   organizationId,
-  factoryId,
+  factoryKey,
   apps,
   workOrders,
   appsLoading,
@@ -26,12 +26,12 @@ export function AutomationsPageBody({
     return <p className="text-[13px] text-muted-foreground">Loading automations…</p>;
   }
   if (selectedApp) {
-    return <AutomationDetail organizationId={organizationId} factoryId={factoryId} app={selectedApp} />;
+    return <AutomationDetail organizationId={organizationId} factoryKey={factoryKey} app={selectedApp} />;
   }
   if (apps.length === 0) {
     return <EmptyAutomationsState canCreate={canCreate} onCreate={onCreate} />;
   }
   return (
-    <AutomationsPageList organizationId={organizationId} factoryId={factoryId} apps={apps} workOrders={workOrders} />
+    <AutomationsPageList organizationId={organizationId} factoryKey={factoryKey} apps={apps} workOrders={workOrders} />
   );
 }

--- a/web_src/src/pages/factories/pages/automationsPageParts.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.tsx
@@ -24,11 +24,11 @@ import {
 
 export function AutomationDetail({
   organizationId,
-  factoryId,
+  factoryKey,
   app,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   app: FactoryApp;
 }) {
   const canvasId = app.id ?? "";
@@ -43,7 +43,7 @@ export function AutomationDetail({
   const status = resolveFactoryAutomationStatusFromCanvasRuns(canvasRuns);
   const runs = useMemo(() => listFactoryAutomationRuns(canvasRuns), [canvasRuns]);
   const configureHref = canvasId
-    ? factoryAppConfigurePath(organizationId, factoryId, canvasId, { from: "automations" })
+    ? factoryAppConfigurePath(organizationId, factoryKey, canvasId, { from: "automations" })
     : "#";
 
   const runsScrollRef = useRef<HTMLUListElement>(null);
@@ -66,7 +66,7 @@ export function AutomationDetail({
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="automations-detail">
       <Link
-        href={automationsPath(organizationId, factoryId)}
+        href={automationsPath(organizationId, factoryKey)}
         className="mb-3 inline-flex shrink-0 items-center gap-1.5 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
         data-testid="automations-detail-back"
       >
@@ -106,7 +106,7 @@ export function AutomationDetail({
             <>
               {runs.map((run) => (
                 <li key={run.runId}>
-                  <AutomationRunCard organizationId={organizationId} factoryId={factoryId} appId={canvasId} run={run} />
+                  <AutomationRunCard organizationId={organizationId} factoryKey={factoryKey} appId={canvasId} run={run} />
                 </li>
               ))}
               {isFetchingNextPage ? (
@@ -122,16 +122,16 @@ export function AutomationDetail({
 
 function AutomationRunCard({
   organizationId,
-  factoryId,
+  factoryKey,
   appId,
   run,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   appId: string;
   run: FactoryAutomationRunCard;
 }) {
-  const href = factoryAppRunPath(organizationId, factoryId, appId, run.runId, { from: "automations" });
+  const href = factoryAppRunPath(organizationId, factoryKey, appId, run.runId, { from: "automations" });
   const timestamp = run.updatedAt ?? run.finishedAt ?? run.createdAt;
   const timeLabel =
     run.tick === "queued" && !timestamp ? "next" : timestamp ? formatTimeAgo(new Date(timestamp), false) : null;
@@ -251,12 +251,12 @@ export function EmptyAutomationsState({ canCreate, onCreate }: { canCreate: bool
 
 export function AutomationsPageList({
   organizationId,
-  factoryId,
+  factoryKey,
   apps,
   workOrders,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   apps: FactoryApp[];
   workOrders: Parameters<typeof resolveFactoryAutomationStatus>[1];
 }) {
@@ -271,7 +271,7 @@ export function AutomationsPageList({
           <li key={app.id}>
             <AutomationCard
               app={app}
-              href={automationDetailPath(organizationId, factoryId, app.id)}
+              href={automationDetailPath(organizationId, factoryKey, app.id)}
               tick={status.tick}
               statusLabel={status.label}
             />

--- a/web_src/src/pages/factories/pages/automationsPageParts.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.tsx
@@ -106,7 +106,12 @@ export function AutomationDetail({
             <>
               {runs.map((run) => (
                 <li key={run.runId}>
-                  <AutomationRunCard organizationId={organizationId} factoryKey={factoryKey} appId={canvasId} run={run} />
+                  <AutomationRunCard
+                    organizationId={organizationId}
+                    factoryKey={factoryKey}
+                    appId={canvasId}
+                    run={run}
+                  />
                 </li>
               ))}
               {isFetchingNextPage ? (

--- a/web_src/src/pages/factories/pages/automationsPageRedirect.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageRedirect.tsx
@@ -10,7 +10,7 @@ import {
 
 type AutomationsLegacyRedirectProps = {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   factoryLoaded: boolean;
   legacyLineId?: string;
 };
@@ -18,7 +18,7 @@ type AutomationsLegacyRedirectProps = {
 /** Redirect stale /automations/:lineId bookmarks once factory lines resolve. */
 export function AutomationsLegacyRedirect({
   organizationId,
-  factoryId,
+  factoryKey,
   factoryLoaded,
   legacyLineId,
 }: AutomationsLegacyRedirectProps) {
@@ -39,7 +39,7 @@ export function AutomationsLegacyRedirect({
     );
   }
   if (legacyLineId) {
-    return <Navigate to={factoryLineDetailPath(organizationId, factoryId, legacyLineId)} replace />;
+    return <Navigate to={factoryLineDetailPath(organizationId, factoryKey, legacyLineId)} replace />;
   }
-  return <Navigate to={automationsPath(organizationId, factoryId)} replace />;
+  return <Navigate to={automationsPath(organizationId, factoryKey)} replace />;
 }

--- a/web_src/src/pages/factories/pages/factoryAppCanvasGuards.tsx
+++ b/web_src/src/pages/factories/pages/factoryAppCanvasGuards.tsx
@@ -1,6 +1,12 @@
 import { Navigate } from "react-router";
 import { factoryOverviewPath } from "../lib/factoryPagePaths";
 
-export function FactoryAppCanvasRedirect({ organizationId, factoryId }: { organizationId: string; factoryId: string }) {
-  return <Navigate to={factoryOverviewPath(organizationId, factoryId)} replace />;
+export function FactoryAppCanvasRedirect({
+  organizationId,
+  factoryKey,
+}: {
+  organizationId: string;
+  factoryKey: string;
+}) {
+  return <Navigate to={factoryOverviewPath(organizationId, factoryKey)} replace />;
 }

--- a/web_src/src/pages/factories/pages/index.ts
+++ b/web_src/src/pages/factories/pages/index.ts
@@ -8,7 +8,7 @@ export { MissionsPage } from "./MissionsPage";
 export { OverviewPage } from "./OverviewPage";
 export { VelocityPage } from "./VelocityPage";
 export { WikiPage } from "./WikiPage";
-export { WorkOrderDetailPage } from "./WorkOrderDetailPage";
+export { LegacyWorkOrderDetailRedirect, WorkOrderDetailPage } from "./WorkOrderDetailPage";
 export { WorkOrdersPage } from "./WorkOrdersPage";
 export { FactorySettingsLayout } from "./settings/FactorySettingsLayout";
 export { FactorySettingsGeneralPage } from "./settings/FactorySettingsGeneralPage";

--- a/web_src/src/pages/factories/pages/onboarding/GettingStartedWireframe.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/GettingStartedWireframe.tsx
@@ -13,12 +13,12 @@ import { useOnboardingStorybook } from "./useOnboardingStorybook";
  */
 export function GettingStartedWireframe() {
   const navigate = useNavigate();
-  const { organizationId, factoryId } = useFactoriesLayout();
+  const { organizationId, factoryKey } = useFactoriesLayout();
   const onboarding = useOnboardingStorybook();
 
   function handleCreateWorkOrder() {
     onboarding?.clearOverviewTips();
-    navigate(createWorkOrderPath(organizationId, factoryId));
+    navigate(createWorkOrderPath(organizationId, factoryKey));
   }
 
   return (
@@ -82,7 +82,7 @@ export function GettingStartedWireframe() {
               Each work order runs through a line: intake, build, verify, and related phases you can configure later.
             </p>
             <Link
-              to={linesPath(organizationId, factoryId)}
+              to={linesPath(organizationId, factoryKey)}
               className={cn(
                 "mt-3 inline-flex h-8 items-center rounded-md border border-border px-3 text-[13px]",
                 "text-foreground transition-colors hover:bg-accent",

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingGate.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingGate.tsx
@@ -1,5 +1,6 @@
-import { Navigate, Outlet, useLocation, useParams } from "react-router";
+import { Navigate, Outlet, useLocation } from "react-router";
 
+import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { factoryOnboardingPath } from "../../lib/factoryPagePaths";
 import { useOnboardingStorybook } from "./useOnboardingStorybook";
 
@@ -10,7 +11,7 @@ import { useOnboardingStorybook } from "./useOnboardingStorybook";
 export function OnboardingGate() {
   const onboarding = useOnboardingStorybook();
   const location = useLocation();
-  const { organizationId = "", factoryId = "" } = useParams<{ organizationId: string; factoryId: string }>();
+  const { organizationId, factoryId, factoryKey } = useFactoriesLayout();
 
   const pending = onboarding?.pending;
   if (!pending || pending.workspaceId !== factoryId) {
@@ -21,5 +22,5 @@ export function OnboardingGate() {
     return <Outlet />;
   }
 
-  return <Navigate to={factoryOnboardingPath(organizationId, pending.workspaceId)} replace />;
+  return <Navigate to={factoryOnboardingPath(organizationId, factoryKey)} replace />;
 }

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingWireframe.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingWireframe.tsx
@@ -2,8 +2,9 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Check, ChevronDown } from "lucide-react";
 import { useState, type ReactNode } from "react";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 
+import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { factoryOverviewPath } from "../../lib/factoryPagePaths";
 import type { OnboardingRepo } from "./onboardingMocks";
 import { AnalysisSidePanel } from "./AnalysisSidePanel";
@@ -232,7 +233,7 @@ function SetupSections({
  */
 export function OnboardingWireframe() {
   const navigate = useNavigate();
-  const { organizationId = "", factoryId = "" } = useParams<{ organizationId: string; factoryId: string }>();
+  const { organizationId, factoryId, factoryKey } = useFactoriesLayout();
   const onboarding = useOnboardingStorybook();
   const setup = useOnboardingSetupState(onboarding?.pending?.workspaceName ?? "");
   const { requestConnect, dialog } = useConnectDialog(setup);
@@ -242,8 +243,8 @@ export function OnboardingWireframe() {
     if (onboarding && factoryId) {
       onboarding.completeOnboarding(factoryId, onboardingReposFromSetup(setup.selectedRepo, setup.vcsHost));
     }
-    if (organizationId && factoryId) {
-      navigate(factoryOverviewPath(organizationId, factoryId), { replace: true });
+    if (organizationId && factoryKey) {
+      navigate(factoryOverviewPath(organizationId, factoryKey), { replace: true });
       return;
     }
     setup.setFinished(true);

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
@@ -13,7 +13,7 @@ import { Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { FactoryDeleteDialog } from "../../FactoryDeleteDialog";
-import { factoryListPath } from "../../lib/factoryPagePaths";
+import { factoryListPath, factorySettingsGeneralPathAfterKeyChange } from "../../lib/factoryPagePaths";
 import {
   factoryCardClassName,
   factoryContentBodyClassName,
@@ -74,12 +74,16 @@ export function FactorySettingsGeneralPage() {
       return;
     }
     try {
+      const nextSettingsPath = factorySettingsGeneralPathAfterKeyChange(organizationId, factory.key ?? "", key);
       await updateFactory.mutateAsync({
         name: trimmedName,
         description: description.trim(),
         key: key !== (factory.key ?? "") ? key : undefined,
       });
       showSuccessToast("Workspace updated.");
+      if (nextSettingsPath) {
+        navigate(nextSettingsPath, { replace: true });
+      }
     } catch (error) {
       const message = getApiErrorMessage(error, "Failed to update workspace");
       if (message.toLowerCase().includes("workspace key")) {

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Textarea } from "@/components/ui/textarea";
+import { useAccount } from "@/contexts/useAccount";
 import { usePermissions } from "@/contexts/usePermissions";
 import { useDeleteFactory, useUpdateFactory } from "@/hooks/useFactoryData";
 import { getApiErrorMessage } from "@/lib/errors";
@@ -14,6 +15,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { FactoryDeleteDialog } from "../../FactoryDeleteDialog";
 import { factoryListPath, factorySettingsGeneralPathAfterKeyChange } from "../../lib/factoryPagePaths";
+import { clearLastVisitedFactory } from "../../lib/lastVisitedFactory";
 import {
   factoryCardClassName,
   factoryContentBodyClassName,
@@ -35,6 +37,7 @@ const MAX_DESCRIPTION_LENGTH = 500;
 
 export function FactorySettingsGeneralPage() {
   const { organizationId, factoryId, factory } = useFactorySettingsLayout();
+  const { account } = useAccount();
   const navigate = useNavigate();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const updateFactory = useUpdateFactory(organizationId, factoryId);
@@ -97,6 +100,7 @@ export function FactorySettingsGeneralPage() {
   const handleDelete = async () => {
     try {
       await deleteFactory.mutateAsync(factoryId);
+      clearLastVisitedFactory(account?.id ?? "", organizationId, factoryId);
       showSuccessToast("Workspace deleted.");
       navigate(factoryListPath(organizationId));
     } catch {

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
@@ -1,10 +1,11 @@
 import { useAccount } from "@/contexts/useAccount";
-import { useFactory } from "@/hooks/useFactoryData";
+import { useFactories, useFactory } from "@/hooks/useFactoryData";
 import { useOrganization } from "@/hooks/useOrganizationData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { cn } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
-import { Navigate, NavLink, Outlet, useParams } from "react-router";
+import { Navigate, NavLink, Outlet, useLocation, useParams } from "react-router";
+import { factoryRouteNeedsCanonicalRedirect, replaceFactoryKeySegment, resolveFactoryByKey } from "../../lib/factoryKeyResolution";
 import { factoryDetailPath, factoryListPath, factorySettingsSectionPath } from "../../lib/factoryPagePaths";
 import { SidebarUserMenu } from "../../layout/SidebarUserMenu";
 import { useFactoriesThemeClass } from "../../lib/useFactoriesThemeClass";
@@ -12,16 +13,60 @@ import { FactorySettingsLayoutContext } from "./factorySettingsLayoutContext";
 import { FACTORY_SETTINGS_NAV_ITEMS } from "./settingsNavItems";
 
 export function FactorySettingsLayout() {
-  const { organizationId, factoryId } = useParams<{ organizationId: string; factoryId: string }>();
+  const { organizationId, factoryKey } = useParams<{ organizationId: string; factoryKey: string }>();
 
-  if (!organizationId || !factoryId) {
+  if (!organizationId || !factoryKey) {
     return null;
   }
 
-  return <FactorySettingsLayoutContent organizationId={organizationId} factoryId={factoryId} />;
+  return <FactorySettingsLayoutResolver organizationId={organizationId} factoryKey={factoryKey} />;
 }
 
-function FactorySettingsLayoutContent({ organizationId, factoryId }: { organizationId: string; factoryId: string }) {
+/** Mirrors `FactoriesLayoutResolver` — resolves `:factoryKey` before rendering the settings shell. */
+function FactorySettingsLayoutResolver({ organizationId, factoryKey }: { organizationId: string; factoryKey: string }) {
+  const location = useLocation();
+  const {
+    data: factories = [],
+    isLoading: factoriesLoading,
+    isFetching: factoriesFetching,
+  } = useFactories(organizationId);
+  const resolution = resolveFactoryByKey(factories, factoryKey, factoriesLoading || factoriesFetching);
+
+  if (factoryRouteNeedsCanonicalRedirect(resolution, factoryKey)) {
+    const target = replaceFactoryKeySegment(location.pathname, organizationId, factoryKey, resolution.factory!.key!);
+    return <Navigate to={`${target}${location.search}`} replace />;
+  }
+
+  if (resolution.status === "not-found") {
+    return <Navigate to={factoryListPath(organizationId)} replace />;
+  }
+
+  if (resolution.status === "loading" || !resolution.factory?.id) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
+        <p className="text-[13px] text-muted-foreground">Loading settings…</p>
+      </div>
+    );
+  }
+
+  return (
+    <FactorySettingsLayoutContent
+      organizationId={organizationId}
+      factoryId={resolution.factory.id}
+      factoryKey={resolution.factory.key ?? factoryKey}
+    />
+  );
+}
+
+function FactorySettingsLayoutContent({
+  organizationId,
+  factoryId,
+  factoryKey,
+}: {
+  organizationId: string;
+  factoryId: string;
+  factoryKey: string;
+}) {
   useFactoriesThemeClass();
   const { account } = useAccount();
   const { data: organization } = useOrganization(organizationId);
@@ -53,7 +98,7 @@ function FactorySettingsLayoutContent({ organizationId, factoryId }: { organizat
         >
           <div className="border-b border-sidebar-border px-3 py-3">
             <NavLink
-              to={factoryDetailPath(organizationId, factoryId)}
+              to={factoryDetailPath(organizationId, factoryKey)}
               className="inline-flex h-8 items-center gap-2 rounded-md px-2.5 text-[13px] tracking-[-0.01em] text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
               data-testid="factory-settings-back"
             >
@@ -69,8 +114,8 @@ function FactorySettingsLayoutContent({ organizationId, factoryId }: { organizat
             </p>
           </div>
           <nav className="flex flex-1 flex-col gap-4 px-2 py-4">
-            <SettingsNavGroup organizationId={organizationId} factoryId={factoryId} items={workspaceGroup} />
-            <SettingsNavGroup organizationId={organizationId} factoryId={factoryId} items={governanceGroup} />
+            <SettingsNavGroup organizationId={organizationId} factoryKey={factoryKey} items={workspaceGroup} />
+            <SettingsNavGroup organizationId={organizationId} factoryKey={factoryKey} items={governanceGroup} />
           </nav>
           <SidebarUserMenu
             organizationId={organizationId}
@@ -90,11 +135,11 @@ function FactorySettingsLayoutContent({ organizationId, factoryId }: { organizat
 
 function SettingsNavGroup({
   organizationId,
-  factoryId,
+  factoryKey,
   items,
 }: {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   items: typeof FACTORY_SETTINGS_NAV_ITEMS;
 }) {
   return (
@@ -104,7 +149,7 @@ function SettingsNavGroup({
         return (
           <li key={item.id}>
             <NavLink
-              to={factorySettingsSectionPath(organizationId, factoryId, item.id)}
+              to={factorySettingsSectionPath(organizationId, factoryKey, item.id)}
               className={({ isActive }) =>
                 cn(
                   "group flex items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] tracking-[-0.01em] text-foreground/80 hover:bg-sidebar-accent hover:text-foreground",

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
@@ -5,7 +5,11 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { cn } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
 import { Navigate, NavLink, Outlet, useLocation, useParams } from "react-router";
-import { factoryRouteNeedsCanonicalRedirect, replaceFactoryKeySegment, resolveFactoryByKey } from "../../lib/factoryKeyResolution";
+import {
+  factoryRouteNeedsCanonicalRedirect,
+  replaceFactoryKeySegment,
+  resolveFactoryByKey,
+} from "../../lib/factoryKeyResolution";
 import { factoryDetailPath, factoryListPath, factorySettingsSectionPath } from "../../lib/factoryPagePaths";
 import { SidebarUserMenu } from "../../layout/SidebarUserMenu";
 import { useFactoriesThemeClass } from "../../lib/useFactoriesThemeClass";

--- a/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
+++ b/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../../__fixtures__/FactoriesHarness";
-import { defaultFactoriesFixture, PRIMARY_FACTORY_ID } from "../../__fixtures__/factoryPageResponses";
+import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../../__fixtures__/factoryPageResponses";
 import { FactorySettingsLayout } from "./FactorySettingsLayout";
 
 /**
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 export const General: Story = {
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/settings/general`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/general`}
       factoriesFixture={defaultFactoriesFixture}
     />
   ),
@@ -30,7 +30,7 @@ export const RepositoriesSoon: Story = {
   name: "Repositories (Soon)",
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/settings/repositories`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/repositories`}
       factoriesFixture={defaultFactoriesFixture}
     />
   ),
@@ -40,7 +40,7 @@ export const MembersSoon: Story = {
   name: "Members (Soon)",
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_ID}/settings/members`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/members`}
       factoriesFixture={defaultFactoriesFixture}
     />
   ),

--- a/web_src/src/pages/factories/pages/useAutomationsPageModel.ts
+++ b/web_src/src/pages/factories/pages/useAutomationsPageModel.ts
@@ -10,7 +10,7 @@ import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
 import { factoryAppConfigurePath } from "../lib/factoryPagePaths";
 
 export function useAutomationsPageModel() {
-  const { organizationId, factoryId, factory } = useFactoriesLayout();
+  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
   const { appId: routeAppId } = useParams<{ appId: string }>();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const { data: apps = [], isLoading: appsLoading } = useFactoryApps(organizationId, factoryId);
@@ -51,7 +51,7 @@ export function useAutomationsPageModel() {
         return;
       }
       showSuccessToast("Automation created.");
-      navigate(factoryAppConfigurePath(organizationId, factoryId, canvasId, { from: "automations" }));
+      navigate(factoryAppConfigurePath(organizationId, factoryKey, canvasId, { from: "automations" }));
     } catch (error) {
       showErrorToast(getUsageLimitToastMessage(error, "Failed to create automation"));
       throw error;
@@ -63,6 +63,7 @@ export function useAutomationsPageModel() {
   return {
     organizationId,
     factoryId,
+    factoryKey,
     factory,
     apps,
     appsLoading,

--- a/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
@@ -32,7 +32,7 @@ export function useFactoryAppCanvasPageModel() {
 
   const from = searchParams.get("from");
   const lineId = searchParams.get("lineId");
-  const orderNumber = searchParams.get("orderNumber");
+  const orderNumber = searchParams.get("orderNumber") ?? searchParams.get("orderId");
   const isConfigure = isFactoryAppConfigureMode(searchParams);
   const lineName = useMemo(() => resolveFactoryLineName(factory?.lines, lineId), [factory?.lines, lineId]);
 

--- a/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
@@ -1,5 +1,5 @@
 import { useCanvas } from "@/hooks/useCanvasData";
-import { useWorkOrder } from "@/hooks/useFactoryData";
+import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import type { FactoryConfigureActions } from "@/pages/app";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
@@ -12,9 +12,10 @@ import {
   resolveFactoryLineName,
 } from "../lib/factoryAppCanvasCopy";
 import { shouldRedirectFactoryAppCanvas } from "../lib/factoryAppCanvasRedirect";
+import { resolveWorkOrderByNumber } from "../lib/workOrderNumberResolution";
 
 export function useFactoryAppCanvasPageModel() {
-  const { organizationId, factoryId, factory } = useFactoriesLayout();
+  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
   const { appId = "" } = useParams<{ appId: string }>();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -31,24 +32,31 @@ export function useFactoryAppCanvasPageModel() {
 
   const from = searchParams.get("from");
   const lineId = searchParams.get("lineId");
-  const orderId = searchParams.get("orderId");
+  const orderNumber = searchParams.get("orderNumber");
   const isConfigure = isFactoryAppConfigureMode(searchParams);
   const lineName = useMemo(() => resolveFactoryLineName(factory?.lines, lineId), [factory?.lines, lineId]);
 
-  const { data: order } = useWorkOrder(organizationId, factoryId, orderId ?? "");
+  // Reads the already-fetched work orders list (same query the sidebar's
+  // "recent orders" section uses) rather than fetching this one order by id,
+  // since all we need here is its title for the back-link label.
+  const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
+  const order = useMemo(
+    () => resolveWorkOrderByNumber(workOrders, orderNumber ?? undefined, false).order,
+    [workOrders, orderNumber],
+  );
 
   const back = useMemo(
     () =>
-      resolveFactoryAppBackNav(organizationId, factoryId, {
+      resolveFactoryAppBackNav(organizationId, factoryKey, {
         from,
         appId,
         appName: canvas?.metadata?.name,
         lineId,
-        orderId,
+        orderNumber,
         lineName,
         orderTitle: order?.title,
       }),
-    [appId, canvas?.metadata?.name, factoryId, from, lineId, lineName, order?.title, organizationId, orderId],
+    [appId, canvas?.metadata?.name, factoryKey, from, lineId, lineName, order?.title, organizationId, orderNumber],
   );
 
   const handleConfigureDone = useCallback(() => {
@@ -72,6 +80,7 @@ export function useFactoryAppCanvasPageModel() {
   return {
     organizationId,
     factoryId,
+    factoryKey,
     appId,
     canvas,
     canvasLoading,

--- a/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
@@ -14,6 +14,10 @@ import {
 import { shouldRedirectFactoryAppCanvas } from "../lib/factoryAppCanvasRedirect";
 import { resolveWorkOrderByNumber } from "../lib/workOrderNumberResolution";
 
+function readFactoryAppOrderRef(searchParams: URLSearchParams): string | null {
+  return searchParams.get("orderNumber") ?? searchParams.get("orderId");
+}
+
 export function useFactoryAppCanvasPageModel() {
   const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
   const { appId = "" } = useParams<{ appId: string }>();
@@ -32,7 +36,7 @@ export function useFactoryAppCanvasPageModel() {
 
   const from = searchParams.get("from");
   const lineId = searchParams.get("lineId");
-  const orderNumber = searchParams.get("orderNumber") ?? searchParams.get("orderId");
+  const orderNumber = readFactoryAppOrderRef(searchParams);
   const isConfigure = isFactoryAppConfigureMode(searchParams);
   const lineName = useMemo(() => resolveFactoryLineName(factory?.lines, lineId), [factory?.lines, lineId]);
 

--- a/web_src/src/pages/factories/sidebar/WorkOrderSidebarFactoryLines.tsx
+++ b/web_src/src/pages/factories/sidebar/WorkOrderSidebarFactoryLines.tsx
@@ -16,7 +16,7 @@ import { SidebarSectionHeading } from "./SidebarPrimitives";
 
 interface WorkOrderSidebarFactoryLinesProps {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   canEditFactoryLines: boolean;
   executions: FactoriesWorkOrderExecution[];
   factoryLines: FactoriesFactoryLine[];
@@ -29,7 +29,7 @@ interface WorkOrderSidebarFactoryLinesProps {
 
 export function WorkOrderSidebarFactoryLines({
   organizationId,
-  factoryId,
+  factoryKey,
   canEditFactoryLines,
   executions,
   factoryLines,
@@ -55,7 +55,7 @@ export function WorkOrderSidebarFactoryLines({
               key={row.lineId}
               row={row}
               organizationId={organizationId}
-              factoryId={factoryId}
+              factoryKey={factoryKey}
               canEdit={canEditFactoryLines}
             />
           ))
@@ -96,15 +96,15 @@ export function WorkOrderSidebarFactoryLines({
 function FactoryLineRow({
   row,
   organizationId,
-  factoryId,
+  factoryKey,
   canEdit,
 }: {
   row: FactoryLineRowModel;
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   canEdit: boolean;
 }) {
-  const href = factoryLineDestinationPath({ lineId: row.lineId, organizationId, factoryId, canEdit });
+  const href = factoryLineDestinationPath({ lineId: row.lineId, organizationId, factoryKey, canEdit });
   const inner = (
     <>
       <Sparkles className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />

--- a/web_src/src/pages/factories/timeline/DispatchTimelineItem.spec.tsx
+++ b/web_src/src/pages/factories/timeline/DispatchTimelineItem.spec.tsx
@@ -39,8 +39,8 @@ describe("DispatchTimelineItem", () => {
       <DispatchTimelineItem
         event={dispatchEvent([{ body: "Applying the fix now." }])}
         organizationId="org-1"
-        factoryId="factory-1"
-        orderId="order-1"
+        factoryKey="factory-1"
+        orderNumber="1"
         isLatestDispatch
       />,
     );

--- a/web_src/src/pages/factories/timeline/DispatchTimelineItem.tsx
+++ b/web_src/src/pages/factories/timeline/DispatchTimelineItem.tsx
@@ -20,16 +20,16 @@ import { timelineActorClassName, timelineParagraphClassName, timelineTimeClassNa
 interface DispatchTimelineItemProps {
   event: WorkOrderTimelineEvent;
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   isLatestDispatch: boolean;
 }
 
 export function DispatchTimelineItem({
   event,
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   isLatestDispatch,
 }: DispatchTimelineItemProps) {
   const [isExpanded, setIsExpanded] = useState(isLatestDispatch);
@@ -87,8 +87,8 @@ export function DispatchTimelineItem({
                 <DispatchStepRow
                   key={step.id}
                   organizationId={organizationId}
-                  factoryId={factoryId}
-                  orderId={orderId}
+                  factoryKey={factoryKey}
+                  orderNumber={orderNumber}
                   step={step}
                 />
               ))}
@@ -102,16 +102,16 @@ export function DispatchTimelineItem({
 
 function DispatchStepRow({
   organizationId,
-  factoryId,
-  orderId,
+  factoryKey,
+  orderNumber,
   step,
 }: {
   organizationId: string;
-  factoryId: string;
-  orderId?: string;
+  factoryKey: string;
+  orderNumber?: string;
   step: WorkOrderTimelineStep;
 }) {
-  const runHref = getWorkOrderExecutionRunHref(organizationId, factoryId, step.execution, { orderId });
+  const runHref = getWorkOrderExecutionRunHref(organizationId, factoryKey, step.execution, { orderNumber });
   const duration = formatStepExecutionDuration(step);
   const status = executionStatus(step.execution);
 

--- a/web_src/src/pages/factories/workOrders/WorkOrdersBoardView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersBoardView.tsx
@@ -15,7 +15,7 @@ import { AssigneeGroup, InlineDispatchButton } from "./WorkOrderRowActions";
 interface WorkOrdersBoardViewProps {
   entries: WorkOrderListEntry[];
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   factoryLines: FactoriesFactoryLine[];
   canDispatch: boolean;
   canAssign: boolean;
@@ -92,7 +92,7 @@ type BoardCardProps = Omit<WorkOrdersBoardViewProps, "entries"> & { entry: WorkO
 function BoardCard({
   entry,
   organizationId,
-  factoryId,
+  factoryKey,
   factoryLines,
   canDispatch,
   canAssign,
@@ -102,7 +102,8 @@ function BoardCard({
   onAssigneesSave,
 }: BoardCardProps) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
-  const href = workOrderDetailPath(organizationId, factoryId, entry.id);
+  const href =
+    entry.order.number !== undefined ? workOrderDetailPath(organizationId, factoryKey, entry.order.number) : "#";
   const timeLabel = entry.updatedAtMs > 0 ? formatTimeAgo(new Date(entry.updatedAtMs)) : "—";
   return (
     <article className="group relative rounded-md border border-border bg-card p-2.5 shadow-sm transition hover:border-foreground/20 hover:shadow">

--- a/web_src/src/pages/factories/workOrders/WorkOrdersCardClickHandler.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersCardClickHandler.spec.tsx
@@ -13,12 +13,13 @@ import { WorkOrdersListView } from "./WorkOrdersListView";
 import { WorkOrdersTableView } from "./WorkOrdersTableView";
 
 const organizationId = "org-1";
-const factoryId = "factory-1";
-const factory: FactoriesFactory = { id: factoryId, name: "Refunds", key: "RF" };
+const factoryKey = "RF";
+const factory: FactoriesFactory = { id: "factory-1", name: "Refunds", key: factoryKey };
 
 const entry = buildWorkOrderListEntry(
   {
     id: "wo-1",
+    number: "1",
     title: "Reconcile refund batch",
     state: "STATE_OPEN",
     createdAt: "2024-06-01T00:00:00Z",
@@ -29,7 +30,7 @@ const entry = buildWorkOrderListEntry(
   factory,
 );
 
-const detailHref = workOrderDetailPath(organizationId, factoryId, entry.id);
+const detailHref = workOrderDetailPath(organizationId, factoryKey, "1");
 
 /**
  * Board and list views group entries into lanes based on display status.
@@ -75,7 +76,7 @@ function renderView(Component: (typeof views)[number]["Component"]) {
         <Component
           entries={[entry]}
           organizationId={organizationId}
-          factoryId={factoryId}
+          factoryKey={factoryKey}
           factoryLines={[]}
           canDispatch={true}
           canAssign={true}

--- a/web_src/src/pages/factories/workOrders/WorkOrdersListView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersListView.tsx
@@ -11,7 +11,7 @@ import { AssigneeGroup, InlineDispatchButton } from "./WorkOrderRowActions";
 interface WorkOrdersListViewProps {
   entries: WorkOrderListEntry[];
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   factoryLines: FactoriesFactoryLine[];
   canDispatch: boolean;
   canAssign: boolean;
@@ -59,7 +59,7 @@ export function WorkOrdersListView(props: WorkOrdersListViewProps) {
 function ListRow({
   entry,
   organizationId,
-  factoryId,
+  factoryKey,
   factoryLines,
   canDispatch,
   canAssign,
@@ -69,7 +69,8 @@ function ListRow({
   onAssigneesSave,
 }: WorkOrdersListViewProps & { entry: WorkOrderListEntry }) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
-  const href = workOrderDetailPath(organizationId, factoryId, entry.id);
+  const href =
+    entry.order.number !== undefined ? workOrderDetailPath(organizationId, factoryKey, entry.order.number) : "#";
   const timeLabel = entry.updatedAtMs > 0 ? formatTimeAgo(new Date(entry.updatedAtMs)) : "—";
   return (
     <article

--- a/web_src/src/pages/factories/workOrders/WorkOrdersLoadedView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersLoadedView.tsx
@@ -23,7 +23,7 @@ import { WorkOrdersTableView } from "./WorkOrdersTableView";
 
 interface WorkOrdersLoadedViewProps {
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   factory: FactoriesFactory;
   factoryLines: FactoriesFactoryLine[];
   workOrders: FactoriesWorkOrder[];
@@ -57,7 +57,7 @@ export function WorkOrdersLoadedView(props: WorkOrdersLoadedViewProps) {
   const ordered = useMemo(() => applyWorkOrderOrdering(searched, state.ordering), [searched, state.ordering]);
 
   const totalCount = entries.length;
-  const createHref = createWorkOrderPath(props.organizationId, props.factoryId);
+  const createHref = createWorkOrderPath(props.organizationId, props.factoryKey);
 
   const body = () => {
     if (totalCount === 0) {
@@ -84,7 +84,7 @@ export function WorkOrdersLoadedView(props: WorkOrdersLoadedViewProps) {
     const sharedProps = {
       entries: ordered,
       organizationId: props.organizationId,
-      factoryId: props.factoryId,
+      factoryKey: props.factoryKey,
       factoryLines: props.factoryLines,
       canDispatch: props.canDispatch,
       canAssign: props.canAssign,

--- a/web_src/src/pages/factories/workOrders/WorkOrdersTableView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersTableView.tsx
@@ -11,7 +11,7 @@ import { AssigneeGroup, InlineDispatchButton } from "./WorkOrderRowActions";
 interface WorkOrdersTableViewProps {
   entries: WorkOrderListEntry[];
   organizationId: string;
-  factoryId: string;
+  factoryKey: string;
   factoryLines: FactoriesFactoryLine[];
   canDispatch: boolean;
   canAssign: boolean;
@@ -52,7 +52,7 @@ export function WorkOrdersTableView(props: WorkOrdersTableViewProps) {
 function TableRow({
   entry,
   organizationId,
-  factoryId,
+  factoryKey,
   factoryLines,
   canDispatch,
   canAssign,
@@ -62,7 +62,8 @@ function TableRow({
   onAssigneesSave,
 }: WorkOrdersTableViewProps & { entry: WorkOrderListEntry }) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
-  const href = workOrderDetailPath(organizationId, factoryId, entry.id);
+  const href =
+    entry.order.number !== undefined ? workOrderDetailPath(organizationId, factoryKey, entry.order.number) : "#";
   const timeLabel = entry.updatedAtMs > 0 ? formatTimeAgo(new Date(entry.updatedAtMs)) : "—";
   return (
     <article


### PR DESCRIPTION
## Summary

This change makes workspace and work order URLs human-readable. It replaces the
internal UUIDs in the URL path with the identifiers that the backend already
generates: the workspace `key` (for example `SP`) and the work order `number`
(for example `42`). URLs now look like
`/{organizationId}/workspaces/SP/work-order/42`.

This is a frontend-only change. The API already returns `Factory.key` and
`WorkOrder.number`, and the UI already shows them (for example the `SP-42`
badge). The UI resolves the key and number to the underlying UUIDs on the
client. Old UUID-based links keep working through redirects.

## UI

- Routing: renamed the workspace route parameter from `:factoryId` to
  `:workspaceKey`, and added a `work-order/:orderNumber` route for the work
  order detail page. All nested workspace routes (overview, missions, wiki,
  velocity, lines, automations, apps, settings, and work orders) now use the
  workspace key.
- Path helpers (`factoryPagePaths.ts`): the `factory*Path` builders now take a
  `workspaceKey`. Added `workOrderDetailPath` that builds
  `/workspaces/{key}/work-order/{number}`. The app-canvas back link now carries
  the work order number instead of the UUID.
- Workspace resolution (`FactoriesLayout.tsx`): reads `workspaceKey`, matches it
  to a `Factory` (case-insensitive), and keeps the true UUID in context so child
  pages need no change. Added `workspaceKey` to the layout context.
- Work order resolution (`WorkOrderDetailPage.tsx`): reads `orderNumber` and
  finds the matching work order from the already-cached work order list, then
  loads the order by its UUID as before.
- Call sites: updated the index page, workspace switcher, navigation, work order
  table/list/board views, the create flow redirect, overview, lines, settings,
  onboarding, and app-canvas navigation to build links from the workspace key
  and the work order number.

## Compatibility

- Old UUID URLs keep working. A UUID-shaped workspace segment redirects to the
  key form, and a UUID-shaped work order segment redirects to the number form.
  Unknown keys or numbers show a graceful error or redirect to the list.
- No localStorage migration is needed. The last-visited workspace still stores
  the UUID internally; only the outbound URL changes.

## API, workers, and database

- No changes. The workspace key and work order number are already part of the
  API responses, and the resolution to UUIDs happens on the client.

## Tests

- Updated the path-helper specs for the new function signatures.
- Added tests for the work order number lookup and the workspace key matching
  (valid key, unknown key, and legacy UUID redirect).
- Added route-level tests for key-based and number-based URLs and for the legacy
  UUID redirects.
- Updated Storybook stories that hardcoded UUID route parameters.

## Notes

- The work order number is resolved from the full work order list that the
  workspace already loads. If this list is paginated later, a backend
  lookup-by-number endpoint will be needed (follow-up, not required now).
