### PR TITLE
fix: Authenticate incoming Telegram webhook updates

### DIFF
--- a/pkg/integrations/telegram/client.go
+++ b/pkg/integrations/telegram/client.go
@@ -58,9 +58,10 @@ func (c *Client) GetMe() (*User, error) {
 }
 
 // SetWebhook sets the webhook URL for receiving updates
-func (c *Client) SetWebhook(url string) error {
+func (c *Client) SetWebhook(url, secretToken string) error {
 	payload := map[string]string{
-		"url": url,
+		"url":          url,
+		"secret_token": secretToken,
 	}
 
 	body, err := json.Marshal(payload)

--- a/pkg/integrations/telegram/telegram.go
+++ b/pkg/integrations/telegram/telegram.go
@@ -1,6 +1,9 @@
 package telegram
 
 import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +19,11 @@ import (
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+const (
+	WebhookSecretName = "webhookSecret"
+	secretTokenHeader = "X-Telegram-Bot-Api-Secret-Token"
 )
 
 func init() {
@@ -120,9 +128,20 @@ func (t *Telegram) Sync(ctx core.SyncContext) error {
 	}
 	webhookURL = fmt.Sprintf("%s/api/v1/integrations/%s/events", webhookURL, ctx.Integration.ID().String())
 
-	err = client.SetWebhook(webhookURL)
+	secret, isNew, err := webhookSecret(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get webhook secret: %v", err)
+	}
+
+	err = client.SetWebhook(webhookURL, secret)
 	if err != nil {
 		return fmt.Errorf("failed to set webhook: %v", err)
+	}
+
+	if isNew {
+		if err := ctx.Integration.SetSecret(WebhookSecretName, []byte(secret)); err != nil {
+			return fmt.Errorf("failed to store webhook secret: %v", err)
+		}
 	}
 
 	ctx.Integration.SetMetadata(Metadata{
@@ -135,7 +154,47 @@ func (t *Telegram) Sync(ctx core.SyncContext) error {
 	return nil
 }
 
+func webhookSecret(integration core.IntegrationContext) (string, bool, error) {
+	secrets, err := integration.GetSecrets()
+	if err != nil {
+		return "", false, err
+	}
+
+	for _, secret := range secrets {
+		if secret.Name == WebhookSecretName {
+			return string(secret.Value), false, nil
+		}
+	}
+
+	value := make([]byte, 32)
+	if _, err := rand.Read(value); err != nil {
+		return "", false, err
+	}
+
+	// Telegram's secret-token alphabet does not allow base64 padding.
+	return base64.RawURLEncoding.EncodeToString(value), true, nil
+}
+
 func (t *Telegram) HandleRequest(ctx core.HTTPRequestContext) {
+	secrets, err := ctx.Integration.GetSecrets()
+	if err != nil {
+		ctx.Logger.Errorf("error getting integration secrets: %v", err)
+		ctx.Response.WriteHeader(500)
+		return
+	}
+
+	for _, secret := range secrets {
+		if secret.Name != WebhookSecretName {
+			continue
+		}
+
+		if subtle.ConstantTimeCompare([]byte(ctx.Request.Header.Get(secretTokenHeader)), secret.Value) != 1 {
+			ctx.Response.WriteHeader(403)
+			return
+		}
+		break
+	}
+
 	body, err := io.ReadAll(ctx.Request.Body)
 	if err != nil {
 		ctx.Logger.Errorf("error reading request body: %v", err)

--- a/pkg/integrations/telegram/telegram_test.go
+++ b/pkg/integrations/telegram/telegram_test.go
@@ -1,0 +1,209 @@
+package telegram
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Telegram__Sync(t *testing.T) {
+	t.Run("new webhook secret -> registers and stores secret", func(t *testing.T) {
+		var webhookPayload map[string]string
+		withDefaultTransport(t, func(req *http.Request) (*http.Response, error) {
+			switch {
+			case strings.HasSuffix(req.URL.Path, "/getMe"):
+				return jsonResponse(http.StatusOK, `{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"Test","username":"testbot"}}`), nil
+			case strings.HasSuffix(req.URL.Path, "/setWebhook"):
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				require.NoError(t, json.Unmarshal(body, &webhookPayload))
+				return jsonResponse(http.StatusOK, `{"ok":true,"result":true}`), nil
+			default:
+				t.Fatalf("unexpected Telegram API request: %s", req.URL.Path)
+				return nil, nil
+			}
+		})
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"botToken": "test-token"},
+		}
+
+		err := (&Telegram{}).Sync(core.SyncContext{
+			Integration:     integrationCtx,
+			WebhooksBaseURL: "https://hooks.example.com",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "ready", integrationCtx.State)
+		secret := webhookPayload["secret_token"]
+		require.NotEmpty(t, secret)
+		assert.Regexp(t, `^[A-Za-z0-9_-]+$`, secret)
+		require.Contains(t, integrationCtx.CurrentSecrets, "webhookSecret")
+		assert.Equal(t, secret, string(integrationCtx.CurrentSecrets["webhookSecret"].Value))
+	})
+
+	t.Run("existing webhook secret -> reuses secret", func(t *testing.T) {
+		var webhookPayload map[string]string
+		withDefaultTransport(t, func(req *http.Request) (*http.Response, error) {
+			switch {
+			case strings.HasSuffix(req.URL.Path, "/getMe"):
+				return jsonResponse(http.StatusOK, `{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"Test","username":"testbot"}}`), nil
+			case strings.HasSuffix(req.URL.Path, "/setWebhook"):
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				require.NoError(t, json.Unmarshal(body, &webhookPayload))
+				return jsonResponse(http.StatusOK, `{"ok":true,"result":true}`), nil
+			default:
+				t.Fatalf("unexpected Telegram API request: %s", req.URL.Path)
+				return nil, nil
+			}
+		})
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"botToken": "test-token"},
+		}
+		require.NoError(t, integrationCtx.SetSecret("webhookSecret", []byte("existing-secret")))
+
+		err := (&Telegram{}).Sync(core.SyncContext{
+			Integration:     integrationCtx,
+			WebhooksBaseURL: "https://hooks.example.com",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "existing-secret", webhookPayload["secret_token"])
+		assert.Equal(t, "existing-secret", string(integrationCtx.CurrentSecrets["webhookSecret"].Value))
+	})
+
+	t.Run("webhook registration failure -> does not store secret", func(t *testing.T) {
+		withDefaultTransport(t, func(req *http.Request) (*http.Response, error) {
+			switch {
+			case strings.HasSuffix(req.URL.Path, "/getMe"):
+				return jsonResponse(http.StatusOK, `{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"Test","username":"testbot"}}`), nil
+			case strings.HasSuffix(req.URL.Path, "/setWebhook"):
+				return jsonResponse(http.StatusOK, `{"ok":false,"description":"Bad Request"}`), nil
+			default:
+				t.Fatalf("unexpected Telegram API request: %s", req.URL.Path)
+				return nil, nil
+			}
+		})
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"botToken": "test-token"},
+		}
+
+		err := (&Telegram{}).Sync(core.SyncContext{
+			Integration:     integrationCtx,
+			WebhooksBaseURL: "https://hooks.example.com",
+		})
+
+		require.ErrorContains(t, err, "failed to set webhook")
+		assert.NotContains(t, integrationCtx.CurrentSecrets, "webhookSecret")
+		assert.NotEqual(t, "ready", integrationCtx.State)
+	})
+}
+
+type trackedReader struct {
+	io.Reader
+	read bool
+}
+
+func (r *trackedReader) Read(p []byte) (int, error) {
+	r.read = true
+	return r.Reader.Read(p)
+}
+
+func Test__Telegram__HandleRequest(t *testing.T) {
+	const (
+		secret        = "expected-secret"
+		mentionUpdate = `{"update_id":1,"message":{"message_id":42,"chat":{"id":123,"type":"group"},"text":"@testbot hello","entities":[{"type":"mention","offset":0,"length":8}],"date":1737028800}}`
+		forgedUpdate  = `{"update_id":1,"callback_query":{"id":"query-1","from":{"id":7,"is_bot":false,"first_name":"Attacker"},"message":{"message_id":42,"chat":{"id":123,"type":"group"},"date":1737028800},"data":"approve"}}`
+	)
+
+	tests := []struct {
+		name         string
+		storedSecret string
+		header       string
+		body         string
+		wantStatus   int
+		wantBodyRead bool
+	}{
+		{
+			name:         "no stored secret -> processes legacy request",
+			body:         mentionUpdate,
+			wantStatus:   http.StatusOK,
+			wantBodyRead: true,
+		},
+		{
+			name:         "matching secret -> processes request",
+			storedSecret: secret,
+			header:       secret,
+			body:         mentionUpdate,
+			wantStatus:   http.StatusOK,
+			wantBodyRead: true,
+		},
+		{
+			name:         "missing secret header -> rejects before reading body",
+			storedSecret: secret,
+			body:         forgedUpdate,
+			wantStatus:   http.StatusForbidden,
+			wantBodyRead: false,
+		},
+		{
+			name:         "wrong secret header -> rejects before reading body",
+			storedSecret: secret,
+			header:       "wrong-secret",
+			body:         forgedUpdate,
+			wantStatus:   http.StatusForbidden,
+			wantBodyRead: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := &trackedReader{Reader: strings.NewReader(test.body)}
+			request := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/test/events", body)
+			if test.header != "" {
+				request.Header.Set("X-Telegram-Bot-Api-Secret-Token", test.header)
+			}
+			response := httptest.NewRecorder()
+			integrationCtx := &contexts.IntegrationContext{
+				Configuration: map[string]any{"botToken": "test-token"},
+				Metadata: map[string]any{
+					"username": "testbot",
+					"botId":    float64(1),
+				},
+				Subscriptions: []contexts.Subscription{
+					{Configuration: SubscriptionConfiguration{EventTypes: []string{"message_mention"}}},
+					{Configuration: map[string]any{
+						"type":         "button_click",
+						"message_id":   float64(42),
+						"chat_id":      "123",
+						"execution_id": "b4fef823-3921-4270-8b1d-8c324bc624b2",
+					}},
+				},
+			}
+			if test.storedSecret != "" {
+				require.NoError(t, integrationCtx.SetSecret("webhookSecret", []byte(test.storedSecret)))
+			}
+
+			(&Telegram{}).HandleRequest(core.HTTPRequestContext{
+				Logger:      logrus.NewEntry(logrus.New()),
+				Request:     request,
+				Response:    response,
+				Integration: integrationCtx,
+			})
+
+			assert.Equal(t, test.wantStatus, response.Code)
+			assert.Equal(t, test.wantBodyRead, body.read)
+		})
+	}
+}


### PR DESCRIPTION
No related issue exists for this fix.

## Summary

Telegram integration webhooks currently accept unauthenticated requests. A forged callback can invoke an action against a waiting execution.

This change registers a secret with Telegram and validates it before processing protected webhook updates.

## Problem

The Telegram event route is public and does not use application authentication middleware. The handler reads each request body without validating its origin.

A forged `callback_query` can reach `createButtonClickAction` and invoke a button-click action for a waiting execution.

## Fix

- Send `secret_token` with every Telegram `setWebhook` request.
- Generate a 32-byte secret with Telegram-compatible raw URL-safe Base64.
- Store a new secret only after Telegram accepts the webhook registration.
- Compare the webhook header in constant time before reading the request body.

## Rollout and backward compatibility

Secret presence enables authentication. Existing installations without a stored secret continue legacy processing until their next synchronization.

Synchronization always registers the webhook again. This behavior updates legacy installations and repairs out-of-band webhook changes.

If secret storage fails after registration, legacy processing continues until the next synchronization stores a fresh secret.

## Test plan

- [x] Run `go test ./pkg/integrations/telegram/`.
- [x] Run `go vet ./pkg/integrations/telegram/`.
- [x] Run `make lint`.
- [x] Run `make check.build.app`.
- [x] Verify new, reused, and failed webhook-secret synchronization cases.
- [x] Verify legacy, valid, missing, and incorrect webhook-secret request cases.
- [x] Verify rejected requests do not read the request body.

## Intentionally left out

- No metadata versioning.
- No shared cryptography helper changes.
- No changes to other integrations.
