### PR TITLE
feat: Add automation actions and Velocity panel

### DIFF
--- a/web_src/src/pages/factories/pages/Automations.stories.tsx
+++ b/web_src/src/pages/factories/pages/Automations.stories.tsx
@@ -16,7 +16,7 @@ import {
 import { AutomationsPage } from "./AutomationsPage";
 
 /**
- * Automations page: v3-style card list + detail (automation card + Runs board).
+ * Automations page: v3-style card list + detail (automation card + Runs / Velocity tabs).
  */
 const meta = {
   title: "Factories/Pages/Automations",

--- a/web_src/src/pages/factories/pages/AutomationsPage.tsx
+++ b/web_src/src/pages/factories/pages/AutomationsPage.tsx
@@ -74,6 +74,8 @@ export function AutomationsPage() {
           workOrders={model.workOrders}
           appsLoading={model.appsLoading}
           selectedApp={selectedApp}
+          selectedAppActions={model.selectedAppActions}
+          actionsForApp={model.actionsForApp}
           canCreate={model.canCreateApp || model.permissionsLoading}
           onCreate={() => model.setCreateOpen(true)}
         />

--- a/web_src/src/pages/factories/pages/LineVelocityPanel.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineVelocityPanel.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { LineVelocityPanel, VELOCITY_BY_PERIOD } from "./LineVelocityPanel";
+
+describe("LineVelocityPanel", () => {
+  it("shows Cursor-style period pills, hero run stats, cost rows, and daily velocity", () => {
+    render(<LineVelocityPanel />);
+
+    expect(screen.getByTestId("line-velocity-panel")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Velocity" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "7d" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "30d" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "90d" })).toBeInTheDocument();
+
+    const stats = screen.getByTestId("velocity-run-stats");
+    expect(stats).toHaveTextContent(String(VELOCITY_BY_PERIOD[7].runs));
+    expect(stats).toHaveTextContent("Succeeded");
+    expect(stats).toHaveTextContent("Failed");
+    expect(stats).toHaveTextContent("Daily velocity");
+
+    const cost = screen.getByTestId("velocity-cost-per-run");
+    expect(cost).toHaveTextContent("Tokens");
+    expect(cost).toHaveTextContent("VM spend");
+
+    expect(screen.queryByRole("heading", { name: "Stage success" })).not.toBeInTheDocument();
+  });
+
+  it("updates run stats when the period changes", async () => {
+    const user = userEvent.setup();
+    render(<LineVelocityPanel />);
+
+    await user.click(screen.getByRole("tab", { name: "30d" }));
+
+    expect(screen.getByRole("tab", { name: "30d" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("velocity-run-stats")).toHaveTextContent(String(VELOCITY_BY_PERIOD[30].runs));
+    expect(screen.getByTestId("velocity-run-stats")).toHaveTextContent("Last 30 days");
+  });
+});

--- a/web_src/src/pages/factories/pages/LineVelocityPanel.tsx
+++ b/web_src/src/pages/factories/pages/LineVelocityPanel.tsx
@@ -1,17 +1,5 @@
-import { useMemo } from "react";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Layer,
-  Rectangle,
-  Sankey,
-  Tooltip,
-  XAxis,
-  YAxis,
-  type NodeProps,
-  type LinkProps,
-} from "recharts";
+import { useMemo, useState } from "react";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
   ChartContainer,
   ChartLegend,
@@ -20,401 +8,63 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import { cn } from "@/lib/utils";
+import { SegmentedNav } from "@/ui/SegmentedNav";
 
-/** Storybook mock for the current 7-day window. */
-export const WEEK_VELOCITY = {
-  periodLabel: "Last 7 days",
-  entered: 42,
-  succeeded: 28,
-  failed: 5,
-} as const;
+export type VelocityPeriodDays = 7 | 30 | 90;
 
-type WeekVelocity = typeof WEEK_VELOCITY;
-
-const DEFAULT_STAGES = ["Plan", "Implement", "Review", "Ship"] as const;
-
-const OUTCOME_SUCCEEDED = "Succeeded";
-const OUTCOME_FAILED = "Failed";
-const OUTCOME_OPEN = "Still in queue or running";
-
-const OUTCOME_FILL: Record<string, string> = {
-  [OUTCOME_SUCCEEDED]: "#10b981",
-  [OUTCOME_FAILED]: "#ef4444",
-  [OUTCOME_OPEN]: "#60a5fa",
+type VelocityPeriodStats = {
+  days: VelocityPeriodDays;
+  label: string;
+  runs: number;
+  succeeded: number;
+  failed: number;
+  /** Average tokens per completed run in the period. */
+  tokensPerRun: number;
+  /** Estimated token spend per completed run (USD). */
+  tokenSpendPerRun: number;
+  /** Estimated VM spend per completed run (USD). */
+  vmSpendPerRun: number;
 };
 
-const STAGE_FILL = "#64748b";
-const PROGRESS_STROKE = "#64748b";
+const PERIOD_OPTIONS: { value: string; label: string; days: VelocityPeriodDays }[] = [
+  { value: "7", label: "7d", days: 7 },
+  { value: "30", label: "30d", days: 30 },
+  { value: "90", label: "90d", days: 90 },
+];
 
-const sankeyChartConfig = {
-  succeeded: { label: OUTCOME_SUCCEEDED, color: OUTCOME_FILL[OUTCOME_SUCCEEDED] },
-  failed: { label: OUTCOME_FAILED, color: OUTCOME_FILL[OUTCOME_FAILED] },
-  open: { label: OUTCOME_OPEN, color: OUTCOME_FILL[OUTCOME_OPEN] },
-  stage: { label: "Stage", color: STAGE_FILL },
-} satisfies ChartConfig;
-
-function isOutcomeName(name: string) {
-  return name === OUTCOME_SUCCEEDED || name === OUTCOME_FAILED || name === OUTCOME_OPEN;
-}
-
-function nodeFill(name: string) {
-  if (isOutcomeName(name)) return OUTCOME_FILL[name];
-  return STAGE_FILL;
-}
-
-function linkStroke(_sourceName: string, targetName: string) {
-  if (isOutcomeName(targetName)) return nodeFill(targetName) ?? PROGRESS_STROKE;
-  return PROGRESS_STROKE;
-}
-
-function resolveStages(stageNames: string[]) {
-  return stageNames.length > 0 ? stageNames : [...DEFAULT_STAGES];
-}
-
-type SankeyGraph = {
-  nodes: { name: string }[];
-  links: { source: number; target: number; value: number }[];
+/** Storybook / UI mock stats by selected window. */
+export const VELOCITY_BY_PERIOD: Record<VelocityPeriodDays, VelocityPeriodStats> = {
+  7: {
+    days: 7,
+    label: "Last 7 days",
+    runs: 42,
+    succeeded: 28,
+    failed: 5,
+    tokensPerRun: 18400,
+    tokenSpendPerRun: 0.42,
+    vmSpendPerRun: 1.18,
+  },
+  30: {
+    days: 30,
+    label: "Last 30 days",
+    runs: 168,
+    succeeded: 121,
+    failed: 22,
+    tokensPerRun: 17200,
+    tokenSpendPerRun: 0.39,
+    vmSpendPerRun: 1.05,
+  },
+  90: {
+    days: 90,
+    label: "Last 90 days",
+    runs: 512,
+    succeeded: 381,
+    failed: 64,
+    tokensPerRun: 16900,
+    tokenSpendPerRun: 0.37,
+    vmSpendPerRun: 0.98,
+  },
 };
-
-type StageExitSplit = {
-  entered: number[];
-  midFailed: number[];
-  midOpen: number[];
-  terminalFailed: number;
-  terminalOpen: number;
-};
-
-/** Mock split: some Failed / Still-open exit early; the rest resolve at the last stage. */
-function splitStageExits(data: WeekVelocity, stageCount: number): StageExitSplit {
-  const open = Math.max(0, data.entered - data.succeeded - data.failed);
-  const gaps = Math.max(0, stageCount - 1);
-
-  if (stageCount <= 1 || gaps === 0) {
-    return {
-      entered: [data.entered],
-      midFailed: [],
-      midOpen: [],
-      terminalFailed: data.failed,
-      terminalOpen: open,
-    };
-  }
-
-  let midFailedBudget = Math.floor(data.failed * 0.4);
-  let midOpenBudget = Math.floor(open * 0.55);
-  const maxMid = Math.max(0, data.entered - data.succeeded - 1);
-  if (midFailedBudget + midOpenBudget > maxMid) {
-    const scale = maxMid / (midFailedBudget + midOpenBudget || 1);
-    midFailedBudget = Math.floor(midFailedBudget * scale);
-    midOpenBudget = Math.max(0, maxMid - midFailedBudget);
-  }
-
-  const terminalFailed = data.failed - midFailedBudget;
-  const terminalOpen = open - midOpenBudget;
-  const lastEntered = data.succeeded + terminalFailed + terminalOpen;
-
-  const midFailed: number[] = [];
-  const midOpen: number[] = [];
-  let failedLeft = midFailedBudget;
-  let openLeft = midOpenBudget;
-  for (let i = 0; i < gaps; i += 1) {
-    const isLastGap = i === gaps - 1;
-    const failedHere = isLastGap ? failedLeft : Math.round(midFailedBudget / gaps);
-    const openHere = isLastGap ? openLeft : Math.round(midOpenBudget / gaps);
-    midFailed.push(Math.min(failedLeft, failedHere));
-    midOpen.push(Math.min(openLeft, openHere));
-    failedLeft -= midFailed[i]!;
-    openLeft -= midOpen[i]!;
-  }
-
-  const entered: number[] = [data.entered];
-  for (let i = 0; i < gaps; i += 1) {
-    entered.push((entered[i] ?? 0) - (midFailed[i] ?? 0) - (midOpen[i] ?? 0));
-  }
-  entered[stageCount - 1] = lastEntered;
-  if (stageCount >= 2) {
-    const prev = entered[stageCount - 2] ?? lastEntered;
-    const drop = Math.max(0, prev - lastEntered);
-    const failedHere = Math.min(midFailed[gaps - 1] ?? 0, drop);
-    midFailed[gaps - 1] = failedHere;
-    midOpen[gaps - 1] = Math.max(0, drop - failedHere);
-  }
-
-  return { entered, midFailed, midOpen, terminalFailed, terminalOpen };
-}
-
-/**
- * Stage columns left → right. Failed / Still-in-queue from every stage merge into the
- * same three far-right outcomes. Succeeded only from the last stage.
- */
-function buildMergedOutcomePipeline(data: WeekVelocity, stageNames: string[]): SankeyGraph {
-  const stages = resolveStages(stageNames);
-  const stageCount = stages.length;
-  const open = Math.max(0, data.entered - data.succeeded - data.failed);
-
-  if (stageCount === 1) {
-    const nodes = [
-      { name: `Entered ${stages[0]}` },
-      { name: OUTCOME_SUCCEEDED },
-      { name: OUTCOME_FAILED },
-      { name: OUTCOME_OPEN },
-    ];
-    const links: SankeyGraph["links"] = [];
-    if (data.succeeded > 0) links.push({ source: 0, target: 1, value: data.succeeded });
-    if (data.failed > 0) links.push({ source: 0, target: 2, value: data.failed });
-    if (open > 0) links.push({ source: 0, target: 3, value: open });
-    return { nodes, links };
-  }
-
-  const { entered, midFailed, midOpen, terminalFailed, terminalOpen } = splitStageExits(data, stageCount);
-  const gaps = stageCount - 1;
-
-  const nodes: { name: string }[] = stages.map((name, index) => ({
-    name: index === 0 ? `Entered ${name}` : name,
-  }));
-  const succIdx = nodes.length;
-  nodes.push({ name: OUTCOME_SUCCEEDED });
-  const failIdx = nodes.length;
-  nodes.push({ name: OUTCOME_FAILED });
-  const openIdx = nodes.length;
-  nodes.push({ name: OUTCOME_OPEN });
-
-  const links: SankeyGraph["links"] = [];
-  for (let i = 0; i < gaps; i += 1) {
-    const progress = entered[i + 1] ?? 0;
-    if (progress > 0) links.push({ source: i, target: i + 1, value: progress });
-    const failedHere = midFailed[i] ?? 0;
-    const openHere = midOpen[i] ?? 0;
-    if (failedHere > 0) links.push({ source: i, target: failIdx, value: failedHere });
-    if (openHere > 0) links.push({ source: i, target: openIdx, value: openHere });
-  }
-
-  const last = stageCount - 1;
-  if (data.succeeded > 0) links.push({ source: last, target: succIdx, value: data.succeeded });
-  if (terminalFailed > 0) links.push({ source: last, target: failIdx, value: terminalFailed });
-  if (terminalOpen > 0) links.push({ source: last, target: openIdx, value: terminalOpen });
-
-  return { nodes, links };
-}
-
-type StageSuccessMetrics = {
-  name: string;
-  /** % of work that successfully entered the next stage. */
-  successRate: number;
-  avgDurationLabel: string;
-  avgDurationCostUsd: number;
-  avgTokens: number;
-  avgTokenCostUsd: number;
-};
-
-type OutcomeSpendMetrics = {
-  wellSpentPct: number;
-  poorlySpentPct: number;
-  wellSpentUsd: number;
-  poorlySpentUsd: number;
-  totalUsd: number;
-};
-
-function formatUsd(value: number) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: value >= 100 ? 0 : 2,
-  }).format(value);
-}
-
-function formatTokens(value: number) {
-  if (value >= 1000) return `${(value / 1000).toFixed(value >= 10000 ? 0 : 1)}k`;
-  return String(value);
-}
-
-/** Deterministic mock metrics aligned to the line’s stages + a terminal outcomes column. */
-function buildStageSuccessMetrics(stageNames: string[]): {
-  stages: StageSuccessMetrics[];
-  outcomes: OutcomeSpendMetrics;
-} {
-  const stages = resolveStages(stageNames);
-  const stageMetrics: StageSuccessMetrics[] = stages.map((name, index) => {
-    const successRate = Math.max(55, 92 - index * 8 - (index === stages.length - 1 ? 4 : 0));
-    const durationMinutes = 18 + index * 27 + (index % 2) * 6;
-    const hours = durationMinutes / 60;
-    const avgDurationCostUsd = Math.round(hours * 42 * 100) / 100;
-    const avgTokens = 4200 + index * 2800 + (index === 0 ? 800 : 0);
-    const avgTokenCostUsd = Math.round((avgTokens / 1000) * 0.85 * 100) / 100;
-    const hoursPart = Math.floor(durationMinutes / 60);
-    const minsPart = durationMinutes % 60;
-    const avgDurationLabel = hoursPart > 0 ? `${hoursPart}h ${minsPart}m` : `${minsPart}m`;
-
-    return {
-      name,
-      successRate,
-      avgDurationLabel,
-      avgDurationCostUsd,
-      avgTokens,
-      avgTokenCostUsd,
-    };
-  });
-
-  const totalUsd =
-    stageMetrics.reduce((sum, stage) => sum + stage.avgDurationCostUsd + stage.avgTokenCostUsd, 0) * 12;
-  const wellSpentPct = 74;
-  const poorlySpentPct = 26;
-
-  return {
-    stages: stageMetrics,
-    outcomes: {
-      wellSpentPct,
-      poorlySpentPct,
-      wellSpentUsd: Math.round(totalUsd * (wellSpentPct / 100)),
-      poorlySpentUsd: Math.round(totalUsd * (poorlySpentPct / 100)),
-      totalUsd: Math.round(totalUsd),
-    },
-  };
-}
-
-function StageMetricBlock({ stage }: { stage: StageSuccessMetrics }) {
-  return (
-    <>
-      <div>
-        <div className="text-[11px] text-muted-foreground">Success to next</div>
-        <div className="mt-1 text-[22px] font-semibold tracking-[-0.03em] tabular-nums text-foreground">
-          {stage.successRate}%
-        </div>
-      </div>
-      <div>
-        <div className="text-[11px] text-muted-foreground">Avg duration</div>
-        <div className="mt-1 text-[15px] font-semibold tracking-[-0.02em] tabular-nums text-foreground">
-          {stage.avgDurationLabel}
-        </div>
-        <div className="mt-0.5 text-[12px] tabular-nums text-muted-foreground">{formatUsd(stage.avgDurationCostUsd)}</div>
-      </div>
-      <div>
-        <div className="text-[11px] text-muted-foreground">Avg tokens</div>
-        <div className="mt-1 text-[15px] font-semibold tracking-[-0.02em] tabular-nums text-foreground">
-          {formatTokens(stage.avgTokens)}
-        </div>
-        <div className="mt-0.5 text-[12px] tabular-nums text-muted-foreground">{formatUsd(stage.avgTokenCostUsd)}</div>
-      </div>
-    </>
-  );
-}
-
-function OutcomesMetricBlock({ outcomes }: { outcomes: OutcomeSpendMetrics }) {
-  return (
-    <>
-      <div>
-        <div className="text-[11px] text-muted-foreground">Money well spent</div>
-        <div className="mt-1 flex items-baseline gap-2">
-          <span className="text-[22px] font-semibold tracking-[-0.03em] tabular-nums text-emerald-700 dark:text-emerald-300">
-            {outcomes.wellSpentPct}%
-          </span>
-          <span className="text-[12px] tabular-nums text-muted-foreground">{formatUsd(outcomes.wellSpentUsd)}</span>
-        </div>
-      </div>
-      <div>
-        <div className="text-[11px] text-muted-foreground">Not well spent</div>
-        <div className="mt-1 flex items-baseline gap-2">
-          <span className="text-[22px] font-semibold tracking-[-0.03em] tabular-nums text-red-700 dark:text-red-300">
-            {outcomes.poorlySpentPct}%
-          </span>
-          <span className="text-[12px] tabular-nums text-muted-foreground">{formatUsd(outcomes.poorlySpentUsd)}</span>
-        </div>
-      </div>
-      <div>
-        <div className="mb-1.5 flex items-center justify-between text-[11px] text-muted-foreground">
-          <span>Spend mix</span>
-          <span className="tabular-nums">{formatUsd(outcomes.totalUsd)}</span>
-        </div>
-        <div className="flex h-2 overflow-hidden rounded-full bg-muted">
-          <span className="bg-emerald-500/80" style={{ width: `${outcomes.wellSpentPct}%` }} />
-          <span className="bg-red-500/70" style={{ width: `${outcomes.poorlySpentPct}%` }} />
-        </div>
-      </div>
-    </>
-  );
-}
-
-/** Stage columns aligned to the pipeline (+ always an Outcomes column). */
-function StageSuccessColumns({
-  stages,
-  outcomes,
-}: {
-  stages: StageSuccessMetrics[];
-  outcomes: OutcomeSpendMetrics;
-}) {
-  const columns = stages.length + 1;
-
-  return (
-    <div
-      className="overflow-hidden rounded-lg border border-border bg-card"
-      style={{ display: "grid", gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
-    >
-      {stages.map((stage, index) => (
-        <div
-          key={stage.name}
-          className={cn("flex flex-col gap-4 px-3.5 py-3.5", index > 0 && "border-l border-border")}
-        >
-          <div className="text-[12px] font-medium tracking-[-0.01em] text-foreground">{stage.name}</div>
-          <StageMetricBlock stage={stage} />
-        </div>
-      ))}
-      <div className="flex flex-col gap-4 border-l border-border bg-muted/30 px-3.5 py-3.5">
-        <div className="text-[12px] font-medium tracking-[-0.01em] text-foreground">Outcomes</div>
-        <OutcomesMetricBlock outcomes={outcomes} />
-      </div>
-    </div>
-  );
-}
-
-function VelocitySankeyNode({ x, y, width, height, payload }: NodeProps) {
-  const depth = payload.depth;
-  const fill = nodeFill(payload.name) ?? STAGE_FILL;
-  const labelOnLeft = depth === 0;
-  const labelX = labelOnLeft ? x - 8 : x + width + 8;
-  const textAnchor = labelOnLeft ? "end" : "start";
-
-  return (
-    <Layer>
-      <Rectangle x={x} y={y} width={width} height={height} fill={fill} radius={2} />
-      <text
-        x={labelX}
-        y={y + height / 2}
-        textAnchor={textAnchor}
-        dominantBaseline="middle"
-        className="fill-foreground text-[11px] font-medium"
-      >
-        {payload.name}
-      </text>
-      <text
-        x={labelX}
-        y={y + height / 2 + 14}
-        textAnchor={textAnchor}
-        dominantBaseline="middle"
-        className="fill-muted-foreground text-[11px] tabular-nums"
-      >
-        {payload.value}
-      </text>
-    </Layer>
-  );
-}
-
-function VelocitySankeyLink(props: LinkProps) {
-  const { sourceX, targetX, sourceY, targetY, sourceControlX, targetControlX, linkWidth, payload } = props;
-  const stroke = linkStroke(payload.source.name, payload.target.name);
-
-  return (
-    <path
-      d={`
-        M${sourceX},${sourceY}
-        C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}
-      `}
-      fill="none"
-      stroke={stroke}
-      strokeWidth={linkWidth}
-      strokeOpacity={0.38}
-    />
-  );
-}
 
 const dailyVelocityChartConfig = {
   succeeded: { label: "Succeeded", color: "#10b981" },
@@ -424,41 +74,75 @@ const dailyVelocityChartConfig = {
 
 type DailyVelocityPoint = {
   day: string;
-  entered: number;
   succeeded: number;
   failed: number;
   inProgress: number;
 };
 
-/**
- * Seven daily points. Still-in-progress only on Sat/Sun; weekdays are
- * succeeded + failed only.
- */
-function buildDailyVelocity(data: WeekVelocity): DailyVelocityPoint[] {
-  const open = Math.max(0, data.entered - data.succeeded - data.failed);
-  const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-  const intakeWeights = [0.12, 0.16, 0.18, 0.17, 0.15, 0.12, 0.1];
-  // No in-progress mid-week; park open volume on the weekend.
-  const inProgressShare = [0, 0, 0, 0, 0, 0.45, 0.55];
+function formatTokens(value: number) {
+  if (value >= 1000) {
+    const thousands = value / 1000;
+    return `${thousands % 1 === 0 ? thousands.toFixed(0) : thousands.toFixed(1)}k`;
+  }
+  return String(value);
+}
 
-  const distribute = (total: number, weights: number[]) => {
-    const values = weights.map((weight) => Math.round(total * weight));
+function formatUsd(value: number) {
+  return `$${value.toFixed(2)}`;
+}
+
+function formatPct(part: number, whole: number) {
+  if (whole <= 0) return "0%";
+  return `${Math.round((part / whole) * 100)}%`;
+}
+
+function buildDayLabels(days: VelocityPeriodDays): string[] {
+  if (days === 7) return ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+  const labels: string[] = [];
+  for (let index = 0; index < days; index += 1) {
+    const dayNumber = index + 1;
+    if (days === 30) {
+      labels.push(dayNumber % 5 === 1 || dayNumber === days ? String(dayNumber) : "");
+      continue;
+    }
+    labels.push(dayNumber % 15 === 1 || dayNumber === days ? String(dayNumber) : "");
+  }
+  return labels;
+}
+
+/**
+ * Build stacked daily outcomes for the selected window.
+ * Still-in-progress only on the last two days when the period has open work.
+ */
+function buildDailyVelocity(stats: VelocityPeriodStats): DailyVelocityPoint[] {
+  const open = Math.max(0, stats.runs - stats.succeeded - stats.failed);
+  const dayCount = stats.days;
+  const labels = buildDayLabels(stats.days);
+
+  const intakeWeights = Array.from({ length: dayCount }, (_, index) => {
+    const wave = 0.85 + 0.3 * Math.sin((index / dayCount) * Math.PI * 2);
+    return wave;
+  });
+  const weightSum = intakeWeights.reduce((sum, weight) => sum + weight, 0);
+  const normalized = intakeWeights.map((weight) => weight / weightSum);
+
+  const distribute = (total: number) => {
+    const values = normalized.map((weight) => Math.round(total * weight));
     const drift = total - values.reduce((sum, value) => sum + value, 0);
     values[values.length - 1] = (values[values.length - 1] ?? 0) + drift;
     return values.map((value) => Math.max(0, value));
   };
 
-  const entered = distribute(data.entered, intakeWeights);
-  const closedTotal = data.succeeded + data.failed;
-  const successShareOfClosed = closedTotal > 0 ? data.succeeded / closedTotal : 1;
+  const entered = distribute(stats.runs);
+  const closedTotal = stats.succeeded + stats.failed;
+  const successShareOfClosed = closedTotal > 0 ? stats.succeeded / closedTotal : 1;
+  const openDayIndexes = [dayCount - 2, dayCount - 1];
 
-  // First pass: weekday closes only; weekend keeps a share open.
-  const points: DailyVelocityPoint[] = dayLabels.map((day, index) => {
+  const points: DailyVelocityPoint[] = labels.map((day, index) => {
     const dayEntered = entered[index] ?? 0;
-    const isWeekend = index >= 5;
-    let dayInProgress = isWeekend
-      ? Math.min(dayEntered, Math.round(dayEntered * (inProgressShare[index] ?? 0)))
-      : 0;
+    const isOpenDay = open > 0 && openDayIndexes.includes(index);
+    let dayInProgress = isOpenDay ? Math.min(dayEntered, Math.round(dayEntered * (index === dayCount - 1 ? 0.55 : 0.35))) : 0;
     let closed = dayEntered - dayInProgress;
     let daySucceeded = Math.round(closed * successShareOfClosed);
     let dayFailed = closed - daySucceeded;
@@ -468,23 +152,18 @@ function buildDailyVelocity(data: WeekVelocity): DailyVelocityPoint[] {
     }
     const used = daySucceeded + dayFailed + dayInProgress;
     if (used !== dayEntered) {
-      if (isWeekend) {
-        dayInProgress = Math.max(0, dayInProgress + (dayEntered - used));
-      } else {
-        daySucceeded = Math.max(0, daySucceeded + (dayEntered - used));
-      }
+      if (isOpenDay) dayInProgress = Math.max(0, dayInProgress + (dayEntered - used));
+      else daySucceeded = Math.max(0, daySucceeded + (dayEntered - used));
     }
     return {
-      day,
-      entered: dayEntered,
+      day: day || "·",
       succeeded: daySucceeded,
       failed: dayFailed,
       inProgress: dayInProgress,
     };
   });
 
-  const sum = (key: keyof Omit<DailyVelocityPoint, "day">) =>
-    points.reduce((total, point) => total + point[key], 0);
+  const sum = (key: keyof Omit<DailyVelocityPoint, "day">) => points.reduce((total, point) => total + point[key], 0);
 
   const shift = (
     from: "succeeded" | "failed" | "inProgress",
@@ -505,34 +184,32 @@ function buildDailyVelocity(data: WeekVelocity): DailyVelocityPoint[] {
     }
   };
 
-  const weekend = [5, 6];
-  const weekdays = [0, 1, 2, 3, 4];
+  const closedDays = Array.from({ length: dayCount }, (_, index) => index).filter(
+    (index) => !openDayIndexes.includes(index),
+  );
 
-  // Move open volume onto Sat/Sun only.
   let openDelta = open - sum("inProgress");
   if (openDelta > 0) {
-    shift("succeeded", "inProgress", openDelta, weekend);
+    shift("succeeded", "inProgress", openDelta, openDayIndexes);
     openDelta = open - sum("inProgress");
-    if (openDelta > 0) shift("failed", "inProgress", openDelta, weekend);
+    if (openDelta > 0) shift("failed", "inProgress", openDelta, openDayIndexes);
   } else if (openDelta < 0) {
-    shift("inProgress", "succeeded", -openDelta, weekend);
+    shift("inProgress", "succeeded", -openDelta, openDayIndexes);
   }
 
-  // Clear any residual weekday in-progress from rebalancing.
-  for (const index of weekdays) {
+  for (const index of closedDays) {
     const point = points[index];
     if (!point || point.inProgress === 0) continue;
     point.succeeded += point.inProgress;
     point.inProgress = 0;
   }
 
-  let successDelta = data.succeeded - sum("succeeded");
-  if (successDelta > 0) shift("failed", "succeeded", successDelta, weekdays);
-  else if (successDelta < 0) shift("succeeded", "failed", -successDelta, weekdays);
+  let successDelta = stats.succeeded - sum("succeeded");
+  if (successDelta > 0) shift("failed", "succeeded", successDelta, closedDays);
+  else if (successDelta < 0) shift("succeeded", "failed", -successDelta, closedDays);
 
-  // Both weekend days should show still-in-progress when the week has open work.
   if (open > 0) {
-    for (const index of weekend) {
+    for (const index of openDayIndexes) {
       const point = points[index];
       if (!point || point.inProgress > 0) continue;
       if (point.succeeded > 0) {
@@ -545,216 +222,204 @@ function buildDailyVelocity(data: WeekVelocity): DailyVelocityPoint[] {
     }
   }
 
-  return points;
+  // Restore blank tick labels for sparse axes (chart still needs a stable key).
+  return points.map((point, index) => ({
+    ...point,
+    day: labels[index] || "",
+  }));
 }
 
-function DailyVelocityChart({ data }: { data: WeekVelocity }) {
-  const points = useMemo(() => buildDailyVelocity(data), [data]);
+function DailyVelocityChart({ stats }: { stats: VelocityPeriodStats }) {
+  const points = useMemo(() => buildDailyVelocity(stats), [stats]);
+  const chartHeight = stats.days === 7 ? 260 : 240;
 
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-card px-3 py-3">
-      <ChartContainer
-        config={dailyVelocityChartConfig}
-        className="aspect-auto h-[280px] w-full"
-        initialDimension={{ width: 720, height: 280 }}
-      >
-        <BarChart data={points} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
-          <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
-          <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} className="text-[11px]" />
-          <YAxis
-            allowDecimals={false}
-            tickLine={false}
-            axisLine={false}
-            width={28}
-            tickMargin={4}
-            className="text-[11px]"
-          />
-          <ChartTooltip content={<ChartTooltipContent />} />
-          <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
-          <Bar dataKey="succeeded" stackId="day" fill="var(--color-succeeded)" maxBarSize={36} />
-          <Bar dataKey="failed" stackId="day" fill="var(--color-failed)" maxBarSize={36} />
-          <Bar
-            dataKey="inProgress"
-            stackId="day"
-            fill="var(--color-inprogress)"
-            radius={[3, 3, 0, 0]}
-            maxBarSize={36}
-          />
-        </BarChart>
-      </ChartContainer>
+    <ChartContainer
+      config={dailyVelocityChartConfig}
+      className="aspect-auto w-full"
+      style={{ height: chartHeight }}
+      initialDimension={{ width: 720, height: chartHeight }}
+    >
+      <BarChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis
+          allowDecimals={false}
+          tickLine={false}
+          axisLine={false}
+          width={28}
+          tickMargin={4}
+          className="text-[11px]"
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+        <Bar dataKey="succeeded" stackId="day" fill="var(--color-succeeded)" maxBarSize={stats.days === 7 ? 36 : 12} />
+        <Bar dataKey="failed" stackId="day" fill="var(--color-failed)" maxBarSize={stats.days === 7 ? 36 : 12} />
+        <Bar
+          dataKey="inProgress"
+          stackId="day"
+          fill="var(--color-inprogress)"
+          radius={[3, 3, 0, 0]}
+          maxBarSize={stats.days === 7 ? 36 : 12}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+function OutcomeSplitBar({ stats }: { stats: VelocityPeriodStats }) {
+  const open = Math.max(0, stats.runs - stats.succeeded - stats.failed);
+  if (stats.runs <= 0) return null;
+
+  const succeededPct = (stats.succeeded / stats.runs) * 100;
+  const failedPct = (stats.failed / stats.runs) * 100;
+  const openPct = (open / stats.runs) * 100;
+
+  return (
+    <div
+      className="flex h-1.5 w-full overflow-hidden rounded-full bg-muted"
+      role="img"
+      aria-label={`Succeeded ${formatPct(stats.succeeded, stats.runs)}, failed ${formatPct(stats.failed, stats.runs)}${open > 0 ? `, still in progress ${formatPct(open, stats.runs)}` : ""}`}
+    >
+      {succeededPct > 0 ? (
+        <span className="h-full bg-[#10b981]" style={{ width: `${succeededPct}%` }} />
+      ) : null}
+      {failedPct > 0 ? <span className="h-full bg-[#ef4444]" style={{ width: `${failedPct}%` }} /> : null}
+      {openPct > 0 ? <span className="h-full bg-[#60a5fa]" style={{ width: `${openPct}%` }} /> : null}
     </div>
   );
 }
 
-type ThroughputStep = {
-  key: string;
+function MetricCell({
+  value,
+  label,
+  hint,
+  emphasize,
+}: {
+  value: string;
   label: string;
-  value: number;
-  color: string;
-  pct: number;
-};
-
-function buildThroughputSteps(data: WeekVelocity): ThroughputStep[] {
-  const open = Math.max(0, data.entered - data.succeeded - data.failed);
-  const pctOfEntered = (value: number) =>
-    data.entered > 0 ? Math.round((value / data.entered) * 1000) / 10 : 0;
-
-  return [
-    { key: "entered", label: "Entered", value: data.entered, color: "#64748b", pct: 100 },
-    {
-      key: "succeeded",
-      label: "Succeeded",
-      value: data.succeeded,
-      color: "#10b981",
-      pct: pctOfEntered(data.succeeded),
-    },
-    {
-      key: "failed",
-      label: "Failed",
-      value: data.failed,
-      color: "#ef4444",
-      pct: pctOfEntered(data.failed),
-    },
-    {
-      key: "open",
-      label: "Still in progress",
-      value: open,
-      color: "#60a5fa",
-      pct: pctOfEntered(open),
-    },
-  ];
+  hint?: string;
+  emphasize?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <p
+        className={
+          emphasize
+            ? "text-[28px] leading-none font-semibold tracking-[-0.03em] tabular-nums text-foreground"
+            : "text-[22px] leading-none font-semibold tracking-[-0.02em] tabular-nums text-foreground"
+        }
+      >
+        {value}
+      </p>
+      <p className="mt-1.5 text-[12px] text-muted-foreground">{label}</p>
+      {hint ? <p className="mt-0.5 text-[12px] tabular-nums text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
 }
 
-/** Dub-like metric columns with proportional panels. */
-function ThroughputFunnelColumns({ data }: { data: WeekVelocity }) {
-  const steps = buildThroughputSteps(data);
+/** Cursor Usage–style hero metrics + daily chart in one card. */
+function VelocityOverviewCard({ stats }: { stats: VelocityPeriodStats }) {
+  const open = Math.max(0, stats.runs - stats.succeeded - stats.failed);
 
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-card">
-      <div className="grid grid-cols-4 divide-x divide-border">
-        {steps.map((step) => {
-          const panelHeight = Math.max(48, Math.round(140 * (step.pct / 100)));
-          return (
-            <div key={step.key} className="flex min-w-0 flex-col pt-3.5">
-              <div className="flex items-center gap-1.5 px-3.5">
-                <span className="size-2 shrink-0 rounded-[2px]" style={{ backgroundColor: step.color }} aria-hidden />
-                <span className="truncate text-[12px] font-medium tracking-[-0.01em] text-foreground">{step.label}</span>
-              </div>
-              <div className="mt-1.5 px-3.5 text-[28px] leading-none font-semibold tracking-[-0.03em] tabular-nums text-foreground">
-                {step.value}
-              </div>
-
-              <div className="mt-4 flex flex-1 items-end">
-                <div
-                  className="relative flex w-full items-center justify-center overflow-hidden"
-                  style={{
-                    height: panelHeight,
-                    backgroundColor: step.color,
-                    boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${step.color} 40%, transparent), 0 8px 24px color-mix(in srgb, ${step.color} 22%, transparent)`,
-                  }}
-                >
-                  <span className="rounded-full bg-white/90 px-2 py-0.5 text-[11px] font-semibold tabular-nums tracking-[-0.01em] text-neutral-900 shadow-sm dark:bg-black/50 dark:text-white">
-                    {step.pct}%
-                  </span>
-                </div>
-              </div>
-            </div>
-          );
-        })}
+    <section className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5" data-testid="velocity-run-stats">
+      <div className="flex flex-wrap items-end gap-x-8 gap-y-4">
+        <MetricCell value={String(stats.runs)} label="Runs" hint={stats.label} emphasize />
+        <MetricCell
+          value={String(stats.succeeded)}
+          label="Succeeded"
+          hint={formatPct(stats.succeeded, stats.runs)}
+        />
+        <MetricCell value={String(stats.failed)} label="Failed" hint={formatPct(stats.failed, stats.runs)} />
+        {open > 0 ? (
+          <MetricCell value={String(open)} label="Still in progress" hint={formatPct(open, stats.runs)} />
+        ) : null}
       </div>
-    </div>
+
+      <div className="mt-4">
+        <OutcomeSplitBar stats={stats} />
+      </div>
+
+      <div className="mt-6 border-t border-border pt-4">
+        <div className="mb-3">
+          <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">Daily velocity</h2>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">Succeeded, failed, and still in progress by day.</p>
+        </div>
+        <DailyVelocityChart stats={stats} />
+      </div>
+    </section>
+  );
+}
+
+/** Cursor Spending–style cost rows. */
+function CostPerRun({ stats }: { stats: VelocityPeriodStats }) {
+  return (
+    <section className="space-y-3" data-testid="velocity-cost-per-run">
+      <div>
+        <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">Cost per run</h2>
+        <p className="mt-0.5 text-[12px] text-muted-foreground">Average for completed runs in this period.</p>
+      </div>
+      <div className="overflow-hidden rounded-xl border border-border bg-card">
+        <div className="flex items-start justify-between gap-4 px-4 py-3.5 sm:px-5">
+          <div className="min-w-0">
+            <p className="text-[13px] font-medium tracking-[-0.01em] text-foreground">Tokens</p>
+            <p className="mt-0.5 text-[12px] text-muted-foreground">Model usage for the run</p>
+          </div>
+          <div className="shrink-0 text-right">
+            <p className="text-[15px] font-semibold tracking-[-0.02em] tabular-nums text-foreground">
+              {formatTokens(stats.tokensPerRun)}
+            </p>
+            <p className="mt-0.5 text-[12px] tabular-nums text-muted-foreground">{formatUsd(stats.tokenSpendPerRun)}</p>
+          </div>
+        </div>
+        <div className="flex items-start justify-between gap-4 border-t border-border px-4 py-3.5 sm:px-5">
+          <div className="min-w-0">
+            <p className="text-[13px] font-medium tracking-[-0.01em] text-foreground">VM spend</p>
+            <p className="mt-0.5 text-[12px] text-muted-foreground">Compute for the run</p>
+          </div>
+          <div className="shrink-0 text-right">
+            <p className="text-[15px] font-semibold tracking-[-0.02em] tabular-nums text-foreground">
+              {formatUsd(stats.vmSpendPerRun)}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }
 
 export function LineVelocityPanel({
-  data = WEEK_VELOCITY,
-  stageNames = [...DEFAULT_STAGES],
+  intro = "Run throughput for this automation.",
+  defaultPeriodDays = 7,
 }: {
-  data?: WeekVelocity;
-  stageNames?: string[];
+  intro?: string;
+  defaultPeriodDays?: VelocityPeriodDays;
 }) {
-  const sankeyData = useMemo(() => buildMergedOutcomePipeline(data, stageNames), [data, stageNames]);
-  const successMetrics = useMemo(() => buildStageSuccessMetrics(stageNames), [stageNames]);
-  const stageCount = resolveStages(stageNames).length;
-  const height = Math.max(300, 210 + stageCount * 32);
+  const [periodDays, setPeriodDays] = useState<VelocityPeriodDays>(defaultPeriodDays);
+  const stats = VELOCITY_BY_PERIOD[periodDays];
 
   return (
-    <div className="space-y-8" data-testid="line-velocity-panel">
-      <div className="flex items-baseline justify-between gap-3">
-        <p className="text-[13px] text-muted-foreground">Work-order throughput for this line.</p>
-        <span className="shrink-0 rounded-md border border-border bg-accent px-2 py-0.5 text-[11px] font-medium tracking-[-0.01em] text-muted-foreground">
-          {data.periodLabel}
-        </span>
-      </div>
-
-      <div className="space-y-4">
-        <div>
-          <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-foreground">Daily velocity</h2>
-          <p className="mt-1 text-[13px] text-muted-foreground">
-            Stacked bars for succeeded, failed, and still in progress (weekend only).
-          </p>
+    <div className="space-y-6" data-testid="line-velocity-panel">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="text-[15px] font-semibold tracking-[-0.01em] text-foreground">Velocity</h1>
+          <p className="mt-0.5 text-[13px] text-muted-foreground">{intro}</p>
         </div>
-        <DailyVelocityChart data={data} />
+        <SegmentedNav
+          ariaLabel="Velocity period in days"
+          size="xs"
+          value={String(periodDays)}
+          onValueChange={(value) => {
+            const next = Number(value);
+            if (next === 7 || next === 30 || next === 90) setPeriodDays(next);
+          }}
+          options={PERIOD_OPTIONS.map(({ value, label }) => ({ value, label }))}
+        />
       </div>
 
-      <div className="space-y-4">
-        <ThroughputFunnelColumns data={data} />
-
-        <div className="overflow-hidden rounded-lg border border-border bg-card px-2 py-3">
-          <div className="mb-1 flex items-center justify-between px-2 text-[11px] text-muted-foreground">
-            <span>Entered first stage</span>
-            <span>Succeeded · Failed · Still in queue or running</span>
-          </div>
-          <ChartContainer
-            config={sankeyChartConfig}
-            className="aspect-auto w-full [&_.recharts-surface]:overflow-visible"
-            style={{ height }}
-            initialDimension={{ width: 720, height }}
-          >
-            <Sankey
-              data={sankeyData}
-              nodeWidth={12}
-              nodePadding={24}
-              linkCurvature={0.5}
-              margin={{ top: 12, bottom: 12, left: 118, right: 150 }}
-              node={VelocitySankeyNode}
-              link={VelocitySankeyLink}
-              sort={false}
-              verticalAlign="top"
-            >
-              <Tooltip
-                content={({ payload }) => {
-                  const item = payload?.[0]?.payload as
-                    | { source?: { name?: string }; target?: { name?: string }; value?: number }
-                    | undefined;
-                  if (!item?.value) return null;
-                  const from = item.source?.name;
-                  const to = item.target?.name;
-                  if (!from || !to) return null;
-                  return (
-                    <div className="rounded-md border border-border bg-background px-2.5 py-1.5 text-[12px] shadow-sm">
-                      <span className="text-foreground">
-                        {from} → {to}
-                      </span>
-                      <span className="ml-2 font-medium tabular-nums text-foreground">{item.value}</span>
-                    </div>
-                  );
-                }}
-              />
-            </Sankey>
-          </ChartContainer>
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        <div>
-          <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-foreground">Stage success</h2>
-          <p className="mt-1 text-[13px] text-muted-foreground">
-            Per-stage handoff rate, time, and token cost — plus Outcomes for money well spent vs not.
-          </p>
-        </div>
-        <StageSuccessColumns stages={successMetrics.stages} outcomes={successMetrics.outcomes} />
-      </div>
+      <VelocityOverviewCard stats={stats} />
+      <CostPerRun stats={stats} />
     </div>
   );
 }

--- a/web_src/src/pages/factories/pages/LineVelocityPanel.tsx
+++ b/web_src/src/pages/factories/pages/LineVelocityPanel.tsx
@@ -1,0 +1,760 @@
+import { useMemo } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Layer,
+  Rectangle,
+  Sankey,
+  Tooltip,
+  XAxis,
+  YAxis,
+  type NodeProps,
+  type LinkProps,
+} from "recharts";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+/** Storybook mock for the current 7-day window. */
+export const WEEK_VELOCITY = {
+  periodLabel: "Last 7 days",
+  entered: 42,
+  succeeded: 28,
+  failed: 5,
+} as const;
+
+type WeekVelocity = typeof WEEK_VELOCITY;
+
+const DEFAULT_STAGES = ["Plan", "Implement", "Review", "Ship"] as const;
+
+const OUTCOME_SUCCEEDED = "Succeeded";
+const OUTCOME_FAILED = "Failed";
+const OUTCOME_OPEN = "Still in queue or running";
+
+const OUTCOME_FILL: Record<string, string> = {
+  [OUTCOME_SUCCEEDED]: "#10b981",
+  [OUTCOME_FAILED]: "#ef4444",
+  [OUTCOME_OPEN]: "#60a5fa",
+};
+
+const STAGE_FILL = "#64748b";
+const PROGRESS_STROKE = "#64748b";
+
+const sankeyChartConfig = {
+  succeeded: { label: OUTCOME_SUCCEEDED, color: OUTCOME_FILL[OUTCOME_SUCCEEDED] },
+  failed: { label: OUTCOME_FAILED, color: OUTCOME_FILL[OUTCOME_FAILED] },
+  open: { label: OUTCOME_OPEN, color: OUTCOME_FILL[OUTCOME_OPEN] },
+  stage: { label: "Stage", color: STAGE_FILL },
+} satisfies ChartConfig;
+
+function isOutcomeName(name: string) {
+  return name === OUTCOME_SUCCEEDED || name === OUTCOME_FAILED || name === OUTCOME_OPEN;
+}
+
+function nodeFill(name: string) {
+  if (isOutcomeName(name)) return OUTCOME_FILL[name];
+  return STAGE_FILL;
+}
+
+function linkStroke(_sourceName: string, targetName: string) {
+  if (isOutcomeName(targetName)) return nodeFill(targetName) ?? PROGRESS_STROKE;
+  return PROGRESS_STROKE;
+}
+
+function resolveStages(stageNames: string[]) {
+  return stageNames.length > 0 ? stageNames : [...DEFAULT_STAGES];
+}
+
+type SankeyGraph = {
+  nodes: { name: string }[];
+  links: { source: number; target: number; value: number }[];
+};
+
+type StageExitSplit = {
+  entered: number[];
+  midFailed: number[];
+  midOpen: number[];
+  terminalFailed: number;
+  terminalOpen: number;
+};
+
+/** Mock split: some Failed / Still-open exit early; the rest resolve at the last stage. */
+function splitStageExits(data: WeekVelocity, stageCount: number): StageExitSplit {
+  const open = Math.max(0, data.entered - data.succeeded - data.failed);
+  const gaps = Math.max(0, stageCount - 1);
+
+  if (stageCount <= 1 || gaps === 0) {
+    return {
+      entered: [data.entered],
+      midFailed: [],
+      midOpen: [],
+      terminalFailed: data.failed,
+      terminalOpen: open,
+    };
+  }
+
+  let midFailedBudget = Math.floor(data.failed * 0.4);
+  let midOpenBudget = Math.floor(open * 0.55);
+  const maxMid = Math.max(0, data.entered - data.succeeded - 1);
+  if (midFailedBudget + midOpenBudget > maxMid) {
+    const scale = maxMid / (midFailedBudget + midOpenBudget || 1);
+    midFailedBudget = Math.floor(midFailedBudget * scale);
+    midOpenBudget = Math.max(0, maxMid - midFailedBudget);
+  }
+
+  const terminalFailed = data.failed - midFailedBudget;
+  const terminalOpen = open - midOpenBudget;
+  const lastEntered = data.succeeded + terminalFailed + terminalOpen;
+
+  const midFailed: number[] = [];
+  const midOpen: number[] = [];
+  let failedLeft = midFailedBudget;
+  let openLeft = midOpenBudget;
+  for (let i = 0; i < gaps; i += 1) {
+    const isLastGap = i === gaps - 1;
+    const failedHere = isLastGap ? failedLeft : Math.round(midFailedBudget / gaps);
+    const openHere = isLastGap ? openLeft : Math.round(midOpenBudget / gaps);
+    midFailed.push(Math.min(failedLeft, failedHere));
+    midOpen.push(Math.min(openLeft, openHere));
+    failedLeft -= midFailed[i]!;
+    openLeft -= midOpen[i]!;
+  }
+
+  const entered: number[] = [data.entered];
+  for (let i = 0; i < gaps; i += 1) {
+    entered.push((entered[i] ?? 0) - (midFailed[i] ?? 0) - (midOpen[i] ?? 0));
+  }
+  entered[stageCount - 1] = lastEntered;
+  if (stageCount >= 2) {
+    const prev = entered[stageCount - 2] ?? lastEntered;
+    const drop = Math.max(0, prev - lastEntered);
+    const failedHere = Math.min(midFailed[gaps - 1] ?? 0, drop);
+    midFailed[gaps - 1] = failedHere;
+    midOpen[gaps - 1] = Math.max(0, drop - failedHere);
+  }
+
+  return { entered, midFailed, midOpen, terminalFailed, terminalOpen };
+}
+
+/**
+ * Stage columns left → right. Failed / Still-in-queue from every stage merge into the
+ * same three far-right outcomes. Succeeded only from the last stage.
+ */
+function buildMergedOutcomePipeline(data: WeekVelocity, stageNames: string[]): SankeyGraph {
+  const stages = resolveStages(stageNames);
+  const stageCount = stages.length;
+  const open = Math.max(0, data.entered - data.succeeded - data.failed);
+
+  if (stageCount === 1) {
+    const nodes = [
+      { name: `Entered ${stages[0]}` },
+      { name: OUTCOME_SUCCEEDED },
+      { name: OUTCOME_FAILED },
+      { name: OUTCOME_OPEN },
+    ];
+    const links: SankeyGraph["links"] = [];
+    if (data.succeeded > 0) links.push({ source: 0, target: 1, value: data.succeeded });
+    if (data.failed > 0) links.push({ source: 0, target: 2, value: data.failed });
+    if (open > 0) links.push({ source: 0, target: 3, value: open });
+    return { nodes, links };
+  }
+
+  const { entered, midFailed, midOpen, terminalFailed, terminalOpen } = splitStageExits(data, stageCount);
+  const gaps = stageCount - 1;
+
+  const nodes: { name: string }[] = stages.map((name, index) => ({
+    name: index === 0 ? `Entered ${name}` : name,
+  }));
+  const succIdx = nodes.length;
+  nodes.push({ name: OUTCOME_SUCCEEDED });
+  const failIdx = nodes.length;
+  nodes.push({ name: OUTCOME_FAILED });
+  const openIdx = nodes.length;
+  nodes.push({ name: OUTCOME_OPEN });
+
+  const links: SankeyGraph["links"] = [];
+  for (let i = 0; i < gaps; i += 1) {
+    const progress = entered[i + 1] ?? 0;
+    if (progress > 0) links.push({ source: i, target: i + 1, value: progress });
+    const failedHere = midFailed[i] ?? 0;
+    const openHere = midOpen[i] ?? 0;
+    if (failedHere > 0) links.push({ source: i, target: failIdx, value: failedHere });
+    if (openHere > 0) links.push({ source: i, target: openIdx, value: openHere });
+  }
+
+  const last = stageCount - 1;
+  if (data.succeeded > 0) links.push({ source: last, target: succIdx, value: data.succeeded });
+  if (terminalFailed > 0) links.push({ source: last, target: failIdx, value: terminalFailed });
+  if (terminalOpen > 0) links.push({ source: last, target: openIdx, value: terminalOpen });
+
+  return { nodes, links };
+}
+
+type StageSuccessMetrics = {
+  name: string;
+  /** % of work that successfully entered the next stage. */
+  successRate: number;
+  avgDurationLabel: string;
+  avgDurationCostUsd: number;
+  avgTokens: number;
+  avgTokenCostUsd: number;
+};
+
+type OutcomeSpendMetrics = {
+  wellSpentPct: number;
+  poorlySpentPct: number;
+  wellSpentUsd: number;
+  poorlySpentUsd: number;
+  totalUsd: number;
+};
+
+function formatUsd(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value >= 100 ? 0 : 2,
+  }).format(value);
+}
+
+function formatTokens(value: number) {
+  if (value >= 1000) return `${(value / 1000).toFixed(value >= 10000 ? 0 : 1)}k`;
+  return String(value);
+}
+
+/** Deterministic mock metrics aligned to the line’s stages + a terminal outcomes column. */
+function buildStageSuccessMetrics(stageNames: string[]): {
+  stages: StageSuccessMetrics[];
+  outcomes: OutcomeSpendMetrics;
+} {
+  const stages = resolveStages(stageNames);
+  const stageMetrics: StageSuccessMetrics[] = stages.map((name, index) => {
+    const successRate = Math.max(55, 92 - index * 8 - (index === stages.length - 1 ? 4 : 0));
+    const durationMinutes = 18 + index * 27 + (index % 2) * 6;
+    const hours = durationMinutes / 60;
+    const avgDurationCostUsd = Math.round(hours * 42 * 100) / 100;
+    const avgTokens = 4200 + index * 2800 + (index === 0 ? 800 : 0);
+    const avgTokenCostUsd = Math.round((avgTokens / 1000) * 0.85 * 100) / 100;
+    const hoursPart = Math.floor(durationMinutes / 60);
+    const minsPart = durationMinutes % 60;
+    const avgDurationLabel = hoursPart > 0 ? `${hoursPart}h ${minsPart}m` : `${minsPart}m`;
+
+    return {
+      name,
+      successRate,
+      avgDurationLabel,
+      avgDurationCostUsd,
+      avgTokens,
+      avgTokenCostUsd,
+    };
+  });
+
+  const totalUsd =
+    stageMetrics.reduce((sum, stage) => sum + stage.avgDurationCostUsd + stage.avgTokenCostUsd, 0) * 12;
+  const wellSpentPct = 74;
+  const poorlySpentPct = 26;
+
+  return {
+    stages: stageMetrics,
+    outcomes: {
+      wellSpentPct,
+      poorlySpentPct,
+      wellSpentUsd: Math.round(totalUsd * (wellSpentPct / 100)),
+      poorlySpentUsd: Math.round(totalUsd * (poorlySpentPct / 100)),
+      totalUsd: Math.round(totalUsd),
+    },
+  };
+}
+
+function StageMetricBlock({ stage }: { stage: StageSuccessMetrics }) {
+  return (
+    <>
+      <div>
+        <div className="text-[11px] text-muted-foreground">Success to next</div>
+        <div className="mt-1 text-[22px] font-semibold tracking-[-0.03em] tabular-nums text-foreground">
+          {stage.successRate}%
+        </div>
+      </div>
+      <div>
+        <div className="text-[11px] text-muted-foreground">Avg duration</div>
+        <div className="mt-1 text-[15px] font-semibold tracking-[-0.02em] tabular-nums text-foreground">
+          {stage.avgDurationLabel}
+        </div>
+        <div className="mt-0.5 text-[12px] tabular-nums text-muted-foreground">{formatUsd(stage.avgDurationCostUsd)}</div>
+      </div>
+      <div>
+        <div className="text-[11px] text-muted-foreground">Avg tokens</div>
+        <div className="mt-1 text-[15px] font-semibold tracking-[-0.02em] tabular-nums text-foreground">
+          {formatTokens(stage.avgTokens)}
+        </div>
+        <div className="mt-0.5 text-[12px] tabular-nums text-muted-foreground">{formatUsd(stage.avgTokenCostUsd)}</div>
+      </div>
+    </>
+  );
+}
+
+function OutcomesMetricBlock({ outcomes }: { outcomes: OutcomeSpendMetrics }) {
+  return (
+    <>
+      <div>
+        <div className="text-[11px] text-muted-foreground">Money well spent</div>
+        <div className="mt-1 flex items-baseline gap-2">
+          <span className="text-[22px] font-semibold tracking-[-0.03em] tabular-nums text-emerald-700 dark:text-emerald-300">
+            {outcomes.wellSpentPct}%
+          </span>
+          <span className="text-[12px] tabular-nums text-muted-foreground">{formatUsd(outcomes.wellSpentUsd)}</span>
+        </div>
+      </div>
+      <div>
+        <div className="text-[11px] text-muted-foreground">Not well spent</div>
+        <div className="mt-1 flex items-baseline gap-2">
+          <span className="text-[22px] font-semibold tracking-[-0.03em] tabular-nums text-red-700 dark:text-red-300">
+            {outcomes.poorlySpentPct}%
+          </span>
+          <span className="text-[12px] tabular-nums text-muted-foreground">{formatUsd(outcomes.poorlySpentUsd)}</span>
+        </div>
+      </div>
+      <div>
+        <div className="mb-1.5 flex items-center justify-between text-[11px] text-muted-foreground">
+          <span>Spend mix</span>
+          <span className="tabular-nums">{formatUsd(outcomes.totalUsd)}</span>
+        </div>
+        <div className="flex h-2 overflow-hidden rounded-full bg-muted">
+          <span className="bg-emerald-500/80" style={{ width: `${outcomes.wellSpentPct}%` }} />
+          <span className="bg-red-500/70" style={{ width: `${outcomes.poorlySpentPct}%` }} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+/** Stage columns aligned to the pipeline (+ always an Outcomes column). */
+function StageSuccessColumns({
+  stages,
+  outcomes,
+}: {
+  stages: StageSuccessMetrics[];
+  outcomes: OutcomeSpendMetrics;
+}) {
+  const columns = stages.length + 1;
+
+  return (
+    <div
+      className="overflow-hidden rounded-lg border border-border bg-card"
+      style={{ display: "grid", gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
+      {stages.map((stage, index) => (
+        <div
+          key={stage.name}
+          className={cn("flex flex-col gap-4 px-3.5 py-3.5", index > 0 && "border-l border-border")}
+        >
+          <div className="text-[12px] font-medium tracking-[-0.01em] text-foreground">{stage.name}</div>
+          <StageMetricBlock stage={stage} />
+        </div>
+      ))}
+      <div className="flex flex-col gap-4 border-l border-border bg-muted/30 px-3.5 py-3.5">
+        <div className="text-[12px] font-medium tracking-[-0.01em] text-foreground">Outcomes</div>
+        <OutcomesMetricBlock outcomes={outcomes} />
+      </div>
+    </div>
+  );
+}
+
+function VelocitySankeyNode({ x, y, width, height, payload }: NodeProps) {
+  const depth = payload.depth;
+  const fill = nodeFill(payload.name) ?? STAGE_FILL;
+  const labelOnLeft = depth === 0;
+  const labelX = labelOnLeft ? x - 8 : x + width + 8;
+  const textAnchor = labelOnLeft ? "end" : "start";
+
+  return (
+    <Layer>
+      <Rectangle x={x} y={y} width={width} height={height} fill={fill} radius={2} />
+      <text
+        x={labelX}
+        y={y + height / 2}
+        textAnchor={textAnchor}
+        dominantBaseline="middle"
+        className="fill-foreground text-[11px] font-medium"
+      >
+        {payload.name}
+      </text>
+      <text
+        x={labelX}
+        y={y + height / 2 + 14}
+        textAnchor={textAnchor}
+        dominantBaseline="middle"
+        className="fill-muted-foreground text-[11px] tabular-nums"
+      >
+        {payload.value}
+      </text>
+    </Layer>
+  );
+}
+
+function VelocitySankeyLink(props: LinkProps) {
+  const { sourceX, targetX, sourceY, targetY, sourceControlX, targetControlX, linkWidth, payload } = props;
+  const stroke = linkStroke(payload.source.name, payload.target.name);
+
+  return (
+    <path
+      d={`
+        M${sourceX},${sourceY}
+        C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}
+      `}
+      fill="none"
+      stroke={stroke}
+      strokeWidth={linkWidth}
+      strokeOpacity={0.38}
+    />
+  );
+}
+
+const dailyVelocityChartConfig = {
+  succeeded: { label: "Succeeded", color: "#10b981" },
+  failed: { label: "Failed", color: "#ef4444" },
+  inProgress: { label: "Still in progress", color: "#60a5fa" },
+} satisfies ChartConfig;
+
+type DailyVelocityPoint = {
+  day: string;
+  entered: number;
+  succeeded: number;
+  failed: number;
+  inProgress: number;
+};
+
+/**
+ * Seven daily points. Still-in-progress only on Sat/Sun; weekdays are
+ * succeeded + failed only.
+ */
+function buildDailyVelocity(data: WeekVelocity): DailyVelocityPoint[] {
+  const open = Math.max(0, data.entered - data.succeeded - data.failed);
+  const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+  const intakeWeights = [0.12, 0.16, 0.18, 0.17, 0.15, 0.12, 0.1];
+  // No in-progress mid-week; park open volume on the weekend.
+  const inProgressShare = [0, 0, 0, 0, 0, 0.45, 0.55];
+
+  const distribute = (total: number, weights: number[]) => {
+    const values = weights.map((weight) => Math.round(total * weight));
+    const drift = total - values.reduce((sum, value) => sum + value, 0);
+    values[values.length - 1] = (values[values.length - 1] ?? 0) + drift;
+    return values.map((value) => Math.max(0, value));
+  };
+
+  const entered = distribute(data.entered, intakeWeights);
+  const closedTotal = data.succeeded + data.failed;
+  const successShareOfClosed = closedTotal > 0 ? data.succeeded / closedTotal : 1;
+
+  // First pass: weekday closes only; weekend keeps a share open.
+  const points: DailyVelocityPoint[] = dayLabels.map((day, index) => {
+    const dayEntered = entered[index] ?? 0;
+    const isWeekend = index >= 5;
+    let dayInProgress = isWeekend
+      ? Math.min(dayEntered, Math.round(dayEntered * (inProgressShare[index] ?? 0)))
+      : 0;
+    let closed = dayEntered - dayInProgress;
+    let daySucceeded = Math.round(closed * successShareOfClosed);
+    let dayFailed = closed - daySucceeded;
+    if (dayFailed < 0) {
+      daySucceeded = closed;
+      dayFailed = 0;
+    }
+    const used = daySucceeded + dayFailed + dayInProgress;
+    if (used !== dayEntered) {
+      if (isWeekend) {
+        dayInProgress = Math.max(0, dayInProgress + (dayEntered - used));
+      } else {
+        daySucceeded = Math.max(0, daySucceeded + (dayEntered - used));
+      }
+    }
+    return {
+      day,
+      entered: dayEntered,
+      succeeded: daySucceeded,
+      failed: dayFailed,
+      inProgress: dayInProgress,
+    };
+  });
+
+  const sum = (key: keyof Omit<DailyVelocityPoint, "day">) =>
+    points.reduce((total, point) => total + point[key], 0);
+
+  const shift = (
+    from: "succeeded" | "failed" | "inProgress",
+    to: "succeeded" | "failed" | "inProgress",
+    amount: number,
+    dayIndexes: number[],
+  ) => {
+    let remaining = amount;
+    for (const index of dayIndexes) {
+      if (remaining <= 0) break;
+      const point = points[index];
+      if (!point) continue;
+      const move = Math.min(remaining, point[from]);
+      if (move <= 0) continue;
+      point[from] -= move;
+      point[to] += move;
+      remaining -= move;
+    }
+  };
+
+  const weekend = [5, 6];
+  const weekdays = [0, 1, 2, 3, 4];
+
+  // Move open volume onto Sat/Sun only.
+  let openDelta = open - sum("inProgress");
+  if (openDelta > 0) {
+    shift("succeeded", "inProgress", openDelta, weekend);
+    openDelta = open - sum("inProgress");
+    if (openDelta > 0) shift("failed", "inProgress", openDelta, weekend);
+  } else if (openDelta < 0) {
+    shift("inProgress", "succeeded", -openDelta, weekend);
+  }
+
+  // Clear any residual weekday in-progress from rebalancing.
+  for (const index of weekdays) {
+    const point = points[index];
+    if (!point || point.inProgress === 0) continue;
+    point.succeeded += point.inProgress;
+    point.inProgress = 0;
+  }
+
+  let successDelta = data.succeeded - sum("succeeded");
+  if (successDelta > 0) shift("failed", "succeeded", successDelta, weekdays);
+  else if (successDelta < 0) shift("succeeded", "failed", -successDelta, weekdays);
+
+  // Both weekend days should show still-in-progress when the week has open work.
+  if (open > 0) {
+    for (const index of weekend) {
+      const point = points[index];
+      if (!point || point.inProgress > 0) continue;
+      if (point.succeeded > 0) {
+        point.succeeded -= 1;
+        point.inProgress += 1;
+      } else if (point.failed > 0) {
+        point.failed -= 1;
+        point.inProgress += 1;
+      }
+    }
+  }
+
+  return points;
+}
+
+function DailyVelocityChart({ data }: { data: WeekVelocity }) {
+  const points = useMemo(() => buildDailyVelocity(data), [data]);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card px-3 py-3">
+      <ChartContainer
+        config={dailyVelocityChartConfig}
+        className="aspect-auto h-[280px] w-full"
+        initialDimension={{ width: 720, height: 280 }}
+      >
+        <BarChart data={points} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+          <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+          <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} className="text-[11px]" />
+          <YAxis
+            allowDecimals={false}
+            tickLine={false}
+            axisLine={false}
+            width={28}
+            tickMargin={4}
+            className="text-[11px]"
+          />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+          <Bar dataKey="succeeded" stackId="day" fill="var(--color-succeeded)" maxBarSize={36} />
+          <Bar dataKey="failed" stackId="day" fill="var(--color-failed)" maxBarSize={36} />
+          <Bar
+            dataKey="inProgress"
+            stackId="day"
+            fill="var(--color-inprogress)"
+            radius={[3, 3, 0, 0]}
+            maxBarSize={36}
+          />
+        </BarChart>
+      </ChartContainer>
+    </div>
+  );
+}
+
+type ThroughputStep = {
+  key: string;
+  label: string;
+  value: number;
+  color: string;
+  pct: number;
+};
+
+function buildThroughputSteps(data: WeekVelocity): ThroughputStep[] {
+  const open = Math.max(0, data.entered - data.succeeded - data.failed);
+  const pctOfEntered = (value: number) =>
+    data.entered > 0 ? Math.round((value / data.entered) * 1000) / 10 : 0;
+
+  return [
+    { key: "entered", label: "Entered", value: data.entered, color: "#64748b", pct: 100 },
+    {
+      key: "succeeded",
+      label: "Succeeded",
+      value: data.succeeded,
+      color: "#10b981",
+      pct: pctOfEntered(data.succeeded),
+    },
+    {
+      key: "failed",
+      label: "Failed",
+      value: data.failed,
+      color: "#ef4444",
+      pct: pctOfEntered(data.failed),
+    },
+    {
+      key: "open",
+      label: "Still in progress",
+      value: open,
+      color: "#60a5fa",
+      pct: pctOfEntered(open),
+    },
+  ];
+}
+
+/** Dub-like metric columns with proportional panels. */
+function ThroughputFunnelColumns({ data }: { data: WeekVelocity }) {
+  const steps = buildThroughputSteps(data);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <div className="grid grid-cols-4 divide-x divide-border">
+        {steps.map((step) => {
+          const panelHeight = Math.max(48, Math.round(140 * (step.pct / 100)));
+          return (
+            <div key={step.key} className="flex min-w-0 flex-col pt-3.5">
+              <div className="flex items-center gap-1.5 px-3.5">
+                <span className="size-2 shrink-0 rounded-[2px]" style={{ backgroundColor: step.color }} aria-hidden />
+                <span className="truncate text-[12px] font-medium tracking-[-0.01em] text-foreground">{step.label}</span>
+              </div>
+              <div className="mt-1.5 px-3.5 text-[28px] leading-none font-semibold tracking-[-0.03em] tabular-nums text-foreground">
+                {step.value}
+              </div>
+
+              <div className="mt-4 flex flex-1 items-end">
+                <div
+                  className="relative flex w-full items-center justify-center overflow-hidden"
+                  style={{
+                    height: panelHeight,
+                    backgroundColor: step.color,
+                    boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${step.color} 40%, transparent), 0 8px 24px color-mix(in srgb, ${step.color} 22%, transparent)`,
+                  }}
+                >
+                  <span className="rounded-full bg-white/90 px-2 py-0.5 text-[11px] font-semibold tabular-nums tracking-[-0.01em] text-neutral-900 shadow-sm dark:bg-black/50 dark:text-white">
+                    {step.pct}%
+                  </span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function LineVelocityPanel({
+  data = WEEK_VELOCITY,
+  stageNames = [...DEFAULT_STAGES],
+}: {
+  data?: WeekVelocity;
+  stageNames?: string[];
+}) {
+  const sankeyData = useMemo(() => buildMergedOutcomePipeline(data, stageNames), [data, stageNames]);
+  const successMetrics = useMemo(() => buildStageSuccessMetrics(stageNames), [stageNames]);
+  const stageCount = resolveStages(stageNames).length;
+  const height = Math.max(300, 210 + stageCount * 32);
+
+  return (
+    <div className="space-y-8" data-testid="line-velocity-panel">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-[13px] text-muted-foreground">Work-order throughput for this line.</p>
+        <span className="shrink-0 rounded-md border border-border bg-accent px-2 py-0.5 text-[11px] font-medium tracking-[-0.01em] text-muted-foreground">
+          {data.periodLabel}
+        </span>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-foreground">Daily velocity</h2>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            Stacked bars for succeeded, failed, and still in progress (weekend only).
+          </p>
+        </div>
+        <DailyVelocityChart data={data} />
+      </div>
+
+      <div className="space-y-4">
+        <ThroughputFunnelColumns data={data} />
+
+        <div className="overflow-hidden rounded-lg border border-border bg-card px-2 py-3">
+          <div className="mb-1 flex items-center justify-between px-2 text-[11px] text-muted-foreground">
+            <span>Entered first stage</span>
+            <span>Succeeded · Failed · Still in queue or running</span>
+          </div>
+          <ChartContainer
+            config={sankeyChartConfig}
+            className="aspect-auto w-full [&_.recharts-surface]:overflow-visible"
+            style={{ height }}
+            initialDimension={{ width: 720, height }}
+          >
+            <Sankey
+              data={sankeyData}
+              nodeWidth={12}
+              nodePadding={24}
+              linkCurvature={0.5}
+              margin={{ top: 12, bottom: 12, left: 118, right: 150 }}
+              node={VelocitySankeyNode}
+              link={VelocitySankeyLink}
+              sort={false}
+              verticalAlign="top"
+            >
+              <Tooltip
+                content={({ payload }) => {
+                  const item = payload?.[0]?.payload as
+                    | { source?: { name?: string }; target?: { name?: string }; value?: number }
+                    | undefined;
+                  if (!item?.value) return null;
+                  const from = item.source?.name;
+                  const to = item.target?.name;
+                  if (!from || !to) return null;
+                  return (
+                    <div className="rounded-md border border-border bg-background px-2.5 py-1.5 text-[12px] shadow-sm">
+                      <span className="text-foreground">
+                        {from} → {to}
+                      </span>
+                      <span className="ml-2 font-medium tabular-nums text-foreground">{item.value}</span>
+                    </div>
+                  );
+                }}
+              />
+            </Sankey>
+          </ChartContainer>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-foreground">Stage success</h2>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            Per-stage handoff rate, time, and token cost — plus Outcomes for money well spent vs not.
+          </p>
+        </div>
+        <StageSuccessColumns stages={successMetrics.stages} outcomes={successMetrics.outcomes} />
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/automationCardActions.ts
+++ b/web_src/src/pages/factories/pages/automationCardActions.ts
@@ -1,0 +1,15 @@
+export function duplicateAutomationName(name: string | undefined) {
+  const trimmed = name?.trim() || "Unnamed automation";
+  return `${trimmed} copy`;
+}
+
+export type AutomationCardActions = {
+  onEdit: () => void;
+  onDuplicate: () => void | Promise<void>;
+  onDelete: () => void | Promise<void>;
+  canEdit: boolean;
+  canDuplicate: boolean;
+  canDelete: boolean;
+  isDuplicating?: boolean;
+  isDeleting?: boolean;
+};

--- a/web_src/src/pages/factories/pages/automationsPageBody.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageBody.tsx
@@ -1,4 +1,5 @@
 import type { FactoryApp } from "@/api-client";
+import type { AutomationCardActions } from "./automationCardActions";
 import { AutomationDetail, AutomationsPageList, EmptyAutomationsState } from "./automationsPageParts";
 
 type AutomationsPageBodyProps = {
@@ -8,6 +9,8 @@ type AutomationsPageBodyProps = {
   workOrders: Parameters<typeof AutomationsPageList>[0]["workOrders"];
   appsLoading: boolean;
   selectedApp: FactoryApp | null;
+  selectedAppActions: AutomationCardActions | null;
+  actionsForApp: (app: FactoryApp) => AutomationCardActions;
   canCreate: boolean;
   onCreate: () => void;
 };
@@ -19,19 +22,34 @@ export function AutomationsPageBody({
   workOrders,
   appsLoading,
   selectedApp,
+  selectedAppActions,
+  actionsForApp,
   canCreate,
   onCreate,
 }: AutomationsPageBodyProps) {
   if (appsLoading && !selectedApp) {
     return <p className="text-[13px] text-muted-foreground">Loading automations…</p>;
   }
-  if (selectedApp) {
-    return <AutomationDetail organizationId={organizationId} factoryId={factoryId} app={selectedApp} />;
+  if (selectedApp && selectedAppActions) {
+    return (
+      <AutomationDetail
+        organizationId={organizationId}
+        factoryId={factoryId}
+        app={selectedApp}
+        actions={selectedAppActions}
+      />
+    );
   }
   if (apps.length === 0) {
     return <EmptyAutomationsState canCreate={canCreate} onCreate={onCreate} />;
   }
   return (
-    <AutomationsPageList organizationId={organizationId} factoryId={factoryId} apps={apps} workOrders={workOrders} />
+    <AutomationsPageList
+      organizationId={organizationId}
+      factoryId={factoryId}
+      apps={apps}
+      workOrders={workOrders}
+      actionsForApp={actionsForApp}
+    />
   );
 }

--- a/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
@@ -6,8 +6,41 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { FactoryApp } from "@/api-client";
 
-import { AutomationCard } from "./automationsPageParts";
+import { AutomationCard, AutomationDetail } from "./automationsPageParts";
 import { duplicateAutomationName } from "./automationCardActions";
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useInfiniteCanvasRuns: () => ({
+    data: {
+      pages: [
+        {
+          runs: [
+            {
+              id: "run-c1111111",
+              state: "STATE_STARTED",
+              updatedAt: "2026-08-13T10:00:00.000Z",
+              rootEvent: { customName: "Run c1111111" },
+            },
+            {
+              id: "run-c2222222",
+              state: "STATE_STARTED",
+              updatedAt: "2026-08-12T10:00:00.000Z",
+              rootEvent: { customName: "Run c2222222" },
+            },
+          ],
+        },
+      ],
+    },
+    isLoading: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+}));
+
+vi.mock("./LineVelocityPanel", () => ({
+  LineVelocityPanel: () => <div data-testid="line-velocity-panel">Velocity</div>,
+}));
 
 const app: FactoryApp = {
   id: "app-refund-planner",
@@ -85,5 +118,47 @@ describe("AutomationCard menu", () => {
 
     await user.click(screen.getByTestId("automations-card-edit"));
     expect(actions.onEdit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AutomationDetail tabs", () => {
+  const actions = {
+    onEdit: vi.fn(),
+    onDuplicate: vi.fn(),
+    onDelete: vi.fn(),
+    canEdit: true,
+    canDuplicate: true,
+    canDelete: true,
+  };
+
+  function renderDetail() {
+    return render(
+      <MemoryRouter>
+        <AutomationDetail organizationId="org-1" factoryId="factory-1" app={app} actions={actions} />
+      </MemoryRouter>,
+    );
+  }
+
+  it("shows Runs and Velocity tabs, with run rows as soft cards", () => {
+    renderDetail();
+
+    expect(screen.getByRole("tab", { name: "Runs" })).toHaveAttribute("data-state", "active");
+    expect(screen.getByRole("tab", { name: "Velocity" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Runs" })).not.toBeInTheDocument();
+
+    const run = screen.getByTestId("automations-run-run-c1111111");
+    expect(run).toHaveTextContent("Run c1111111");
+    expect(run.className).toMatch(/\bborder\b/);
+    expect(run.className).toMatch(/\brounded-md\b/);
+    expect(screen.getByTestId("automations-runs-scroll").className).toMatch(/\bgap-2\b/);
+    expect(screen.getByTestId("automations-runs-scroll").closest("section")).toBeNull();
+  });
+
+  it("opens the Velocity tab", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    await user.click(screen.getByRole("tab", { name: "Velocity" }));
+    expect(screen.getByTestId("line-velocity-panel")).toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import type { FactoryApp } from "@/api-client";
+
+import { AutomationCard } from "./automationsPageParts";
+import { duplicateAutomationName } from "./automationCardActions";
+
+const app: FactoryApp = {
+  id: "app-refund-planner",
+  name: "Refund Planner",
+  description: "Plans reconciliation work across ledger + payment services.",
+};
+
+function renderCard(props: Partial<ComponentProps<typeof AutomationCard>> = {}) {
+  return render(
+    <MemoryRouter>
+      <AutomationCard app={app} tick="passed" statusLabel="Passed" emphasized {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("duplicateAutomationName", () => {
+  it("appends copy to the trimmed name", () => {
+    expect(duplicateAutomationName("Refund Planner")).toBe("Refund Planner copy");
+  });
+
+  it("falls back when the name is empty", () => {
+    expect(duplicateAutomationName("  ")).toBe("Unnamed automation copy");
+  });
+});
+
+describe("AutomationCard menu", () => {
+  const actions = {
+    onEdit: vi.fn(),
+    onDuplicate: vi.fn(),
+    onDelete: vi.fn(),
+    canEdit: true,
+    canDuplicate: true,
+    canDelete: true,
+  };
+
+  it("hides the list-card menu until hover, then opens Edit, Duplicate, and Delete", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <AutomationCard
+          app={app}
+          tick="passed"
+          statusLabel="Passed"
+          href="/automations/app-refund-planner"
+          actions={actions}
+        />
+      </MemoryRouter>,
+    );
+
+    const trigger = screen.getByTestId("automations-card-menu");
+    expect(trigger).toHaveClass("opacity-0");
+
+    await user.click(trigger);
+    expect(screen.getByTestId("automations-card-edit")).toHaveTextContent("Edit");
+    expect(screen.getByTestId("automations-card-duplicate")).toHaveTextContent("Duplicate");
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+    expect(screen.getByTestId("automations-card-delete")).toHaveTextContent("Delete");
+  });
+
+  it("keeps the detail-card menu visible and opens Edit, Duplicate, and Delete", async () => {
+    const user = userEvent.setup();
+
+    renderCard({ actions });
+
+    const trigger = screen.getByTestId("automations-card-menu");
+    expect(trigger).not.toHaveClass("opacity-0");
+
+    await user.click(trigger);
+    expect(screen.getByTestId("automations-card-edit")).toHaveTextContent("Edit");
+    expect(screen.getByTestId("automations-card-duplicate")).toHaveTextContent("Duplicate");
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+    expect(screen.getByTestId("automations-card-delete")).toHaveTextContent("Delete");
+    expect(screen.getByTestId("automations-card-delete")).toHaveClass("text-destructive");
+
+    await user.click(screen.getByTestId("automations-card-edit"));
+    expect(actions.onEdit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web_src/src/pages/factories/pages/automationsPageParts.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.tsx
@@ -3,6 +3,7 @@ import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { useInfiniteCanvasRuns } from "@/hooks/useCanvasData";
@@ -27,6 +28,7 @@ import {
 } from "../lib/factoryAutomationStatus";
 import { automationDetailPath, automationsPath, factoryAppRunPath } from "../lib/factoryPagePaths";
 import { type AutomationCardActions } from "./automationCardActions";
+import { LineVelocityPanel } from "./LineVelocityPanel";
 
 export function AutomationDetail({
   organizationId,
@@ -83,42 +85,57 @@ export function AutomationDetail({
         <AutomationCard app={app} tick={status.tick} statusLabel={status.label} emphasized actions={actions} />
       </div>
 
-      <section
-        className="mt-6 flex min-h-[12rem] min-w-0 max-h-[calc(100dvh-16rem)] flex-1 flex-col overflow-hidden rounded-lg border border-border bg-background"
-        aria-label="Runs"
-      >
-        <div className="flex h-9 shrink-0 items-center border-b border-border px-3">
-          <h2 className="truncate text-[12px] font-medium tracking-[-0.01em] text-foreground">Runs</h2>
-        </div>
-        <ul
-          ref={runsScrollRef}
-          className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain p-2 [scrollbar-width:thin]"
-          onScroll={(event) => loadMoreRunsIfNeeded(event.currentTarget)}
-          data-testid="automations-runs-scroll"
+      <Tabs defaultValue="runs" className="mt-6 flex min-h-0 min-w-0 flex-1 flex-col gap-3">
+        <TabsList>
+          <TabsTrigger value="runs" data-testid="automations-tab-runs">
+            Runs
+          </TabsTrigger>
+          <TabsTrigger value="velocity" data-testid="automations-tab-velocity">
+            Velocity
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="runs" className="mt-0 flex min-h-0 min-w-0 flex-1 flex-col outline-none">
+          <ul
+            ref={runsScrollRef}
+            className="flex min-h-[12rem] min-w-0 max-h-[calc(100dvh-16rem)] flex-1 flex-col gap-2 overflow-y-auto overscroll-contain p-0.5 [scrollbar-width:thin]"
+            onScroll={(event) => loadMoreRunsIfNeeded(event.currentTarget)}
+            data-testid="automations-runs-scroll"
+          >
+            {runsLoading && runs.length === 0 ? (
+              <li className="px-2 py-4 text-[12px] text-muted-foreground">Loading runs…</li>
+            ) : runs.length === 0 ? (
+              <li className="px-2 py-4 text-[12px] text-muted-foreground">No runs</li>
+            ) : (
+              <>
+                {runs.map((run) => (
+                  <li key={run.runId}>
+                    <AutomationRunRow
+                      organizationId={organizationId}
+                      factoryId={factoryId}
+                      appId={canvasId}
+                      run={run}
+                    />
+                  </li>
+                ))}
+                {isFetchingNextPage ? (
+                  <li className="py-2 text-center text-[12px] text-muted-foreground">Loading more…</li>
+                ) : null}
+              </>
+            )}
+          </ul>
+        </TabsContent>
+        <TabsContent
+          value="velocity"
+          className="mt-0 min-h-0 max-h-[calc(100dvh-16rem)] flex-1 overflow-y-auto outline-none [scrollbar-width:thin]"
         >
-          {runsLoading && runs.length === 0 ? (
-            <li className="px-2 py-4 text-[12px] text-muted-foreground">Loading runs…</li>
-          ) : runs.length === 0 ? (
-            <li className="px-2 py-4 text-[12px] text-muted-foreground">No runs</li>
-          ) : (
-            <>
-              {runs.map((run) => (
-                <li key={run.runId}>
-                  <AutomationRunCard organizationId={organizationId} factoryId={factoryId} appId={canvasId} run={run} />
-                </li>
-              ))}
-              {isFetchingNextPage ? (
-                <li className="px-2 py-2 text-center text-[12px] text-muted-foreground">Loading more…</li>
-              ) : null}
-            </>
-          )}
-        </ul>
-      </section>
+          <LineVelocityPanel intro="Run throughput for this automation." />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }
 
-function AutomationRunCard({
+function AutomationRunRow({
   organizationId,
   factoryId,
   appId,
@@ -140,7 +157,7 @@ function AutomationRunCard({
       className="block w-full rounded-md border border-border bg-background px-3 py-2.5 text-left transition-colors hover:border-foreground/25 hover:bg-accent/40"
       data-testid={`automations-run-${run.runId}`}
     >
-      <div className="text-[13px] font-medium tracking-[-0.01em] text-foreground">{run.title}</div>
+      <div className="truncate text-[13px] font-medium tracking-[-0.01em] text-foreground">{run.title}</div>
       <div className="mt-1.5 flex items-center gap-1.5 text-[12px] text-muted-foreground">
         <StatusTick tick={run.tick} size="sm" />
         <span>

--- a/web_src/src/pages/factories/pages/automationsPageParts.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.tsx
@@ -1,12 +1,22 @@
 import type { FactoryApp } from "@/api-client";
 import { Link } from "@/components/Link/link";
+import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { useInfiniteCanvasRuns } from "@/hooks/useCanvasData";
 import { formatTimeAgo } from "@/lib/date";
 import { cn } from "@/lib/utils";
-import { ArrowLeft, Plus, Workflow } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdownMenu";
+import { ArrowLeft, Copy, MoreHorizontal, Pencil, Plus, Trash2, Workflow } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { useNavigate } from "react-router";
 import {
   listFactoryAutomationRuns,
@@ -15,21 +25,19 @@ import {
   type FactoryAutomationRunCard,
   type FactoryAutomationTick,
 } from "../lib/factoryAutomationStatus";
-import {
-  automationDetailPath,
-  automationsPath,
-  factoryAppConfigurePath,
-  factoryAppRunPath,
-} from "../lib/factoryPagePaths";
+import { automationDetailPath, automationsPath, factoryAppRunPath } from "../lib/factoryPagePaths";
+import { type AutomationCardActions } from "./automationCardActions";
 
 export function AutomationDetail({
   organizationId,
   factoryId,
   app,
+  actions,
 }: {
   organizationId: string;
   factoryId: string;
   app: FactoryApp;
+  actions: AutomationCardActions;
 }) {
   const canvasId = app.id ?? "";
   const {
@@ -42,9 +50,6 @@ export function AutomationDetail({
   const canvasRuns = useMemo(() => runsPages?.pages.flatMap((page) => page?.runs ?? []) ?? [], [runsPages]);
   const status = resolveFactoryAutomationStatusFromCanvasRuns(canvasRuns);
   const runs = useMemo(() => listFactoryAutomationRuns(canvasRuns), [canvasRuns]);
-  const configureHref = canvasId
-    ? factoryAppConfigurePath(organizationId, factoryId, canvasId, { from: "automations" })
-    : "#";
 
   const runsScrollRef = useRef<HTMLUListElement>(null);
   const loadMoreRuns = useCallback(() => {
@@ -75,22 +80,15 @@ export function AutomationDetail({
       </Link>
 
       <div className="shrink-0">
-        <AutomationCard app={app} tick={status.tick} statusLabel={status.label} emphasized />
+        <AutomationCard app={app} tick={status.tick} statusLabel={status.label} emphasized actions={actions} />
       </div>
 
       <section
         className="mt-6 flex min-h-[12rem] min-w-0 max-h-[calc(100dvh-16rem)] flex-1 flex-col overflow-hidden rounded-lg border border-border bg-background"
         aria-label="Runs"
       >
-        <div className="flex h-9 shrink-0 items-center justify-between gap-2 border-b border-border px-3">
+        <div className="flex h-9 shrink-0 items-center border-b border-border px-3">
           <h2 className="truncate text-[12px] font-medium tracking-[-0.01em] text-foreground">Runs</h2>
-          <Link
-            href={configureHref}
-            className="cursor-pointer text-[13px] text-muted-foreground transition-colors hover:text-foreground"
-            data-testid="automations-configure"
-          >
-            Configure
-          </Link>
         </div>
         <ul
           ref={runsScrollRef}
@@ -160,16 +158,20 @@ export function AutomationCard({
   tick,
   statusLabel,
   emphasized,
+  actions,
 }: {
   app: FactoryApp;
   href?: string;
   tick: FactoryAutomationTick;
   statusLabel: string;
   emphasized?: boolean;
+  actions?: AutomationCardActions;
 }) {
   const navigate = useNavigate();
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const description = app.description?.trim() || "Factory automation canvas.";
   const interactive = Boolean(href);
+  const automationName = app.name?.trim() || "Unnamed automation";
 
   return (
     <div
@@ -197,18 +199,178 @@ export function AutomationCard({
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
             <Workflow className="size-3.5 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
-            <span className="text-[13px] font-medium tracking-[-0.01em] text-foreground">
-              {app.name?.trim() || "Unnamed automation"}
-            </span>
+            <span className="text-[13px] font-medium tracking-[-0.01em] text-foreground">{automationName}</span>
           </div>
           <p className="mt-1 text-[12px] leading-snug text-muted-foreground">{description}</p>
         </div>
+        {actions ? (
+          <AutomationCardMenu
+            name={automationName}
+            actions={actions}
+            hoverReveal={!emphasized}
+            onRequestDelete={() => setDeleteOpen(true)}
+          />
+        ) : null}
       </div>
       <div className="mt-3.5 flex items-center gap-1.5">
         <StatusTick tick={tick} />
         <span className="text-[12px] leading-tight text-muted-foreground">{statusLabel}</span>
       </div>
+      {actions ? (
+        <DeleteAutomationDialog
+          open={deleteOpen}
+          name={automationName}
+          canDelete={actions.canDelete}
+          isDeleting={Boolean(actions.isDeleting)}
+          onClose={() => setDeleteOpen(false)}
+          onConfirm={actions.onDelete}
+        />
+      ) : null}
     </div>
+  );
+}
+
+const overflowMenuContentClassName = "min-w-[12rem] rounded-xl border-border p-1 shadow-lg";
+const overflowMenuItemClassName = "cursor-pointer rounded-md px-2 py-1.5 text-[13px] [&_svg]:size-3.5";
+const overflowMenuDestructiveItemClassName =
+  "text-destructive focus:bg-destructive/10 focus:text-destructive dark:focus:bg-destructive/15";
+
+function AutomationCardMenu({
+  name,
+  actions,
+  hoverReveal,
+  onRequestDelete,
+}: {
+  name: string;
+  actions: AutomationCardActions;
+  hoverReveal: boolean;
+  onRequestDelete: () => void;
+}) {
+  const stopCardClick = (event: MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <div className="shrink-0" onClick={stopCardClick}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={`${name} menu`}
+            className={cn(
+              "flex size-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground",
+              hoverReveal &&
+                "opacity-0 group-hover/automation:opacity-100 group-focus-within/automation:opacity-100 data-[state=open]:opacity-100",
+            )}
+            disabled={actions.isDuplicating || actions.isDeleting}
+            data-testid="automations-card-menu"
+          >
+            <MoreHorizontal className="size-3.5" aria-hidden />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" sideOffset={6} className={overflowMenuContentClassName}>
+          <PermissionTooltip allowed={actions.canEdit} message="You don't have permission to edit this automation.">
+            <DropdownMenuItem
+              className={overflowMenuItemClassName}
+              onClick={actions.onEdit}
+              disabled={!actions.canEdit}
+              data-testid="automations-card-edit"
+            >
+              <Pencil aria-hidden />
+              Edit
+            </DropdownMenuItem>
+          </PermissionTooltip>
+          <PermissionTooltip
+            allowed={actions.canDuplicate}
+            message="You don't have permission to duplicate this automation."
+          >
+            <DropdownMenuItem
+              className={overflowMenuItemClassName}
+              onClick={() => {
+                void actions.onDuplicate();
+              }}
+              disabled={!actions.canDuplicate || actions.isDuplicating}
+              data-testid="automations-card-duplicate"
+            >
+              <Copy aria-hidden />
+              Duplicate
+            </DropdownMenuItem>
+          </PermissionTooltip>
+          <DropdownMenuSeparator />
+          <PermissionTooltip allowed={actions.canDelete} message="You don't have permission to delete this automation.">
+            <DropdownMenuItem
+              className={cn(overflowMenuItemClassName, overflowMenuDestructiveItemClassName)}
+              onClick={onRequestDelete}
+              disabled={!actions.canDelete || actions.isDeleting}
+              data-testid="automations-card-delete"
+            >
+              <Trash2 aria-hidden />
+              Delete
+            </DropdownMenuItem>
+          </PermissionTooltip>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+function DeleteAutomationDialog({
+  open,
+  name,
+  canDelete,
+  isDeleting,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  name: string;
+  canDelete: boolean;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && !isDeleting) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete "{name}"?</DialogTitle>
+        </DialogHeader>
+        <p className="text-[13px] text-muted-foreground">This cannot be undone.</p>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
+            Cancel
+          </Button>
+          <LoadingButton
+            type="button"
+            variant="destructive"
+            onClick={() => {
+              void (async () => {
+                try {
+                  await onConfirm();
+                  onClose();
+                } catch {
+                  // Toast is handled by the caller; keep the dialog open for retry.
+                }
+              })();
+            }}
+            disabled={!canDelete}
+            loading={isDeleting}
+            loadingText="Deleting..."
+            data-testid="automations-delete-confirm"
+          >
+            <Trash2 className="h-3.5 w-3.5" aria-hidden />
+            Delete
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -254,11 +416,13 @@ export function AutomationsPageList({
   factoryId,
   apps,
   workOrders,
+  actionsForApp,
 }: {
   organizationId: string;
   factoryId: string;
   apps: FactoryApp[];
   workOrders: Parameters<typeof resolveFactoryAutomationStatus>[1];
+  actionsForApp: (app: FactoryApp) => AutomationCardActions;
 }) {
   return (
     <ul className="flex flex-col gap-2" data-testid="automations-list">
@@ -274,6 +438,7 @@ export function AutomationsPageList({
               href={automationDetailPath(organizationId, factoryId, app.id)}
               tick={status.tick}
               statusLabel={status.label}
+              actions={actionsForApp(app)}
             />
           </li>
         );

--- a/web_src/src/pages/factories/pages/useAutomationsPageModel.ts
+++ b/web_src/src/pages/factories/pages/useAutomationsPageModel.ts
@@ -1,13 +1,15 @@
 import { usePermissions } from "@/contexts/usePermissions";
-import { useCreateCanvas } from "@/hooks/useCanvasData";
+import { useCreateCanvas, useDeleteCanvas } from "@/hooks/useCanvasData";
 import { factoryAppsKey, useFactoryApps, useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
+import type { FactoryApp } from "@/api-client";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
-import { factoryAppConfigurePath } from "../lib/factoryPagePaths";
+import { automationsPath, factoryAppConfigurePath } from "../lib/factoryPagePaths";
+import { duplicateAutomationName, type AutomationCardActions } from "./automationCardActions";
 
 export function useAutomationsPageModel() {
   const { organizationId, factoryId, factory } = useFactoriesLayout();
@@ -16,11 +18,14 @@ export function useAutomationsPageModel() {
   const { data: apps = [], isLoading: appsLoading } = useFactoryApps(organizationId, factoryId);
   const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
   const canCreateApp = canAct("canvases", "create");
+  const canUpdateApp = canAct("canvases", "update");
+  const canDeleteApp = canAct("canvases", "delete");
 
   const [createOpen, setCreateOpen] = useState(false);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const createCanvas = useCreateCanvas(organizationId);
+  const deleteCanvas = useDeleteCanvas(organizationId);
 
   const selectedApp = useMemo(() => {
     if (!routeAppId) {
@@ -58,6 +63,89 @@ export function useAutomationsPageModel() {
     }
   };
 
+  const invalidateFactoryApps = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: factoryAppsKey(organizationId, factoryId) });
+  }, [factoryId, organizationId, queryClient]);
+
+  const handleEditAutomation = useCallback(
+    (app: FactoryApp) => {
+      if (!app.id) {
+        return;
+      }
+      navigate(factoryAppConfigurePath(organizationId, factoryId, app.id, { from: "automations" }));
+    },
+    [factoryId, navigate, organizationId],
+  );
+
+  const handleDuplicateAutomation = useCallback(
+    async (app: FactoryApp) => {
+      try {
+        const result = await createCanvas.mutateAsync({
+          name: duplicateAutomationName(app.name),
+          description: app.description ?? "",
+          factoryId,
+          method: "ui",
+        });
+        const canvasId = result?.data?.canvas?.metadata?.id;
+        invalidateFactoryApps();
+        if (!canvasId) {
+          return;
+        }
+        showSuccessToast("Automation duplicated.");
+        navigate(factoryAppConfigurePath(organizationId, factoryId, canvasId, { from: "automations" }));
+      } catch (error) {
+        showErrorToast(getUsageLimitToastMessage(error, "Failed to duplicate automation"));
+      }
+    },
+    [createCanvas, factoryId, invalidateFactoryApps, navigate, organizationId],
+  );
+
+  const handleDeleteAutomation = useCallback(
+    async (app: FactoryApp) => {
+      if (!app.id) {
+        return;
+      }
+      try {
+        await deleteCanvas.mutateAsync(app.id);
+        invalidateFactoryApps();
+        showSuccessToast("Automation deleted.");
+        if (selectedApp?.id === app.id) {
+          navigate(automationsPath(organizationId, factoryId));
+        }
+      } catch (error) {
+        showErrorToast("Failed to delete automation");
+        throw error;
+      }
+    },
+    [deleteCanvas, factoryId, invalidateFactoryApps, navigate, organizationId, selectedApp?.id],
+  );
+
+  const actionsForApp = useCallback(
+    (app: FactoryApp): AutomationCardActions => ({
+      onEdit: () => handleEditAutomation(app),
+      onDuplicate: () => handleDuplicateAutomation(app),
+      onDelete: () => handleDeleteAutomation(app),
+      canEdit: canUpdateApp,
+      canDuplicate: canCreateApp,
+      canDelete: canDeleteApp,
+      isDuplicating: createCanvas.isPending,
+      isDeleting: deleteCanvas.isPending && deleteCanvas.variables === app.id,
+    }),
+    [
+      canCreateApp,
+      canDeleteApp,
+      canUpdateApp,
+      createCanvas.isPending,
+      deleteCanvas.isPending,
+      deleteCanvas.variables,
+      handleDeleteAutomation,
+      handleDuplicateAutomation,
+      handleEditAutomation,
+    ],
+  );
+
+  const selectedAppActions = selectedApp ? actionsForApp(selectedApp) : null;
+
   const showLegacyRedirect = Boolean(routeAppId && !appsLoading && !selectedApp);
 
   return {
@@ -72,6 +160,8 @@ export function useAutomationsPageModel() {
     createOpen,
     setCreateOpen,
     selectedApp,
+    selectedAppActions,
+    actionsForApp,
     legacyLineId,
     createCanvas,
     handleCreateAutomation,


### PR DESCRIPTION
## Summary

- Adds edit, duplicate, and delete actions on automation cards so operators can manage automations from the list and detail views.
- Adds a Storybook Velocity panel for run throughput, outcome breakdown, and cost-per-run concepts.
- Keeps Velocity UI as a shared panel so Automations (and later Lines) can reuse the same layout.

## Test plan

- [ ] Open Factories Automations list and use the card overflow menu for Edit, Duplicate, and Delete
- [ ] Open an automation detail view and confirm the same actions still work
- [ ] Review Storybook / Automations stories that show the Velocity panel
- [ ] Confirm light and dark themes still look correct on Automations


Made with [Cursor](https://cursor.com)