### PR TITLE
feat: Duplicate Factory Automation Canvas

### DIFF
--- a/web_src/src/pages/app/factoryConfigureActions.spec.ts
+++ b/web_src/src/pages/app/factoryConfigureActions.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { runFactoryConfigureSave, withCanvasMetadataName } from "./factoryConfigureActions";
+import { runFactoryConfigureSave, stagingSummaryHasChanges, withCanvasMetadataName } from "./factoryConfigureActions";
 
 describe("withCanvasMetadataName", () => {
   it("overlays metadata.name when a new name is provided", () => {
@@ -24,22 +24,20 @@ describe("withCanvasMetadataName", () => {
   });
 });
 
-describe("runFactoryConfigureSave", () => {
-  it("materializes canvas.yaml with the overlaid rename", async () => {
-    const updateCanvasVersionMutation = {
-      mutateAsync: vi.fn().mockResolvedValue({}),
-    };
-    const handleCommitStaging = vi.fn().mockResolvedValue(true);
-    const onDone = vi.fn();
-    const setSavePending = vi.fn();
-    const setDraftCanvasSpec = vi.fn();
-    const setLastSavedWorkflowSnapshot = vi.fn();
-    const draftCanvasSpecsRef = { current: new Map() };
-    const activeCanvasVersionIdRef = { current: "ver-1" };
+describe("stagingSummaryHasChanges", () => {
+  it("detects staged paths and hasStaging", () => {
+    expect(stagingSummaryHasChanges(undefined)).toBe(false);
+    expect(stagingSummaryHasChanges({ hasStaging: false, stagedPaths: [] })).toBe(false);
+    expect(stagingSummaryHasChanges({ hasStaging: true, stagedPaths: [] })).toBe(true);
+    expect(stagingSummaryHasChanges({ hasStaging: false, stagedPaths: ["canvas.yaml"] })).toBe(true);
+  });
+});
 
-    await runFactoryConfigureSave({
+describe("runFactoryConfigureSave", () => {
+  function baseDeps(overrides: Partial<Parameters<typeof runFactoryConfigureSave>[0]> = {}) {
+    return {
       canStageCanvasVersion: true,
-      activeCanvasVersionIdRef,
+      activeCanvasVersionIdRef: { current: "ver-1" },
       activeCanvasVersionId: "ver-1",
       editSessionActive: true,
       setEditSessionActive: vi.fn(),
@@ -47,24 +45,53 @@ describe("runFactoryConfigureSave", () => {
         metadata: { id: "c1", name: "Old" },
         spec: { nodes: [{ id: "n1", name: "Node", component: "noop", type: "TYPE_ACTION" }], edges: [] },
       }),
-      setSavePending,
-      updateCanvasVersionMutation,
-      draftCanvasSpecsRef,
-      setDraftCanvasSpec,
-      setLastSavedWorkflowSnapshot,
-      handleCommitStaging,
-      canvasName: "Renamed",
-      onDone,
-    });
+      setSavePending: vi.fn(),
+      updateCanvasVersionMutation: {
+        mutateAsync: vi.fn().mockResolvedValue({
+          data: { stagingSummary: { hasStaging: true, stagedPaths: ["canvas.yaml"] } },
+        }),
+      },
+      draftCanvasSpecsRef: { current: new Map() },
+      setDraftCanvasSpec: vi.fn(),
+      setLastSavedWorkflowSnapshot: vi.fn(),
+      handleCommitStaging: vi.fn().mockResolvedValue(true),
+      onDone: vi.fn(),
+      ...overrides,
+    } satisfies Parameters<typeof runFactoryConfigureSave>[0];
+  }
+
+  it("materializes canvas.yaml with the overlaid rename", async () => {
+    const updateCanvasVersionMutation = {
+      mutateAsync: vi.fn().mockResolvedValue({
+        data: { stagingSummary: { hasStaging: true, stagedPaths: ["canvas.yaml"] } },
+      }),
+    };
+    const deps = baseDeps({ updateCanvasVersionMutation, canvasName: "Renamed" });
+
+    await runFactoryConfigureSave(deps);
 
     expect(updateCanvasVersionMutation.mutateAsync).toHaveBeenCalledTimes(1);
     const stagedYaml = updateCanvasVersionMutation.mutateAsync.mock.calls[0]?.[0]?.canvasYaml as string;
     expect(stagedYaml).toContain("name: Renamed");
     expect(stagedYaml).not.toContain("name: Old");
-    expect(handleCommitStaging).toHaveBeenCalled();
-    expect(onDone).toHaveBeenCalled();
-    expect(setLastSavedWorkflowSnapshot).toHaveBeenCalledWith(
+    expect(deps.handleCommitStaging).toHaveBeenCalled();
+    expect(deps.onDone).toHaveBeenCalled();
+    expect(deps.setLastSavedWorkflowSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({ metadata: expect.objectContaining({ name: "Renamed" }) }),
     );
+  });
+
+  it("skips commit and finishes when staging is empty", async () => {
+    const updateCanvasVersionMutation = {
+      mutateAsync: vi.fn().mockResolvedValue({
+        data: { stagingSummary: { hasStaging: false, stagedPaths: [] } },
+      }),
+    };
+    const deps = baseDeps({ updateCanvasVersionMutation });
+
+    await runFactoryConfigureSave(deps);
+
+    expect(deps.handleCommitStaging).not.toHaveBeenCalled();
+    expect(deps.onDone).toHaveBeenCalled();
   });
 });

--- a/web_src/src/pages/app/factoryConfigureActions.spec.ts
+++ b/web_src/src/pages/app/factoryConfigureActions.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runFactoryConfigureSave, withCanvasMetadataName } from "./factoryConfigureActions";
+
+describe("withCanvasMetadataName", () => {
+  it("overlays metadata.name when a new name is provided", () => {
+    const next = withCanvasMetadataName(
+      {
+        metadata: { id: "c1", name: "Old" },
+        spec: { nodes: [], edges: [] },
+      },
+      "Renamed",
+    );
+    expect(next.metadata?.name).toBe("Renamed");
+    expect(next.spec).toEqual({ nodes: [], edges: [] });
+  });
+
+  it("returns the same workflow when the name is unchanged", () => {
+    const workflow = {
+      metadata: { id: "c1", name: "Same" },
+      spec: { nodes: [], edges: [] },
+    };
+    expect(withCanvasMetadataName(workflow, "Same")).toBe(workflow);
+  });
+});
+
+describe("runFactoryConfigureSave", () => {
+  it("materializes canvas.yaml with the overlaid rename", async () => {
+    const updateCanvasVersionMutation = {
+      mutateAsync: vi.fn().mockResolvedValue({}),
+    };
+    const handleCommitStaging = vi.fn().mockResolvedValue(true);
+    const onDone = vi.fn();
+    const setSavePending = vi.fn();
+    const setDraftCanvasSpec = vi.fn();
+    const setLastSavedWorkflowSnapshot = vi.fn();
+    const draftCanvasSpecsRef = { current: new Map() };
+    const activeCanvasVersionIdRef = { current: "ver-1" };
+
+    await runFactoryConfigureSave({
+      canStageCanvasVersion: true,
+      activeCanvasVersionIdRef,
+      activeCanvasVersionId: "ver-1",
+      editSessionActive: true,
+      setEditSessionActive: vi.fn(),
+      getCurrentWorkflowSnapshot: () => ({
+        metadata: { id: "c1", name: "Old" },
+        spec: { nodes: [{ id: "n1", name: "Node", component: "noop", type: "TYPE_ACTION" }], edges: [] },
+      }),
+      setSavePending,
+      updateCanvasVersionMutation,
+      draftCanvasSpecsRef,
+      setDraftCanvasSpec,
+      setLastSavedWorkflowSnapshot,
+      handleCommitStaging,
+      canvasName: "Renamed",
+      onDone,
+    });
+
+    expect(updateCanvasVersionMutation.mutateAsync).toHaveBeenCalledTimes(1);
+    const stagedYaml = updateCanvasVersionMutation.mutateAsync.mock.calls[0]?.[0]?.canvasYaml as string;
+    expect(stagedYaml).toContain("name: Renamed");
+    expect(stagedYaml).not.toContain("name: Old");
+    expect(handleCommitStaging).toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalled();
+    expect(setLastSavedWorkflowSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ name: "Renamed" }) }),
+    );
+  });
+});

--- a/web_src/src/pages/app/factoryConfigureActions.ts
+++ b/web_src/src/pages/app/factoryConfigureActions.ts
@@ -9,6 +9,11 @@ type UpdateCanvasVersionMutation = {
   mutateAsync: (input: { versionId: string; canvasYaml: string }) => Promise<unknown>;
 };
 
+export type FactoryConfigureSaveOptions = {
+  /** Overlay metadata.name before staging canvas.yaml (keeps YAML in sync after rename). */
+  canvasName?: string;
+};
+
 export type FactoryConfigureSaveDeps = {
   canStageCanvasVersion: boolean;
   activeCanvasVersionIdRef: MutableRefObject<string>;
@@ -24,6 +29,7 @@ export type FactoryConfigureSaveDeps = {
   setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
   handleCommitStaging: (commitMessage: string, options?: { versionId?: string }) => Promise<boolean | void>;
   onDone?: () => void;
+  canvasName?: string;
 };
 
 export type FactoryConfigureDiscardDeps = {
@@ -34,6 +40,21 @@ export type FactoryConfigureDiscardDeps = {
   handleExitEditSession: () => void;
   onDone?: () => void;
 };
+
+/** Merge a renamed canvas name into the workflow snapshot used for canvas.yaml. */
+export function withCanvasMetadataName(workflow: CanvasesCanvas, canvasName?: string): CanvasesCanvas {
+  const name = canvasName?.trim();
+  if (!name || name === workflow.metadata?.name) {
+    return workflow;
+  }
+  return {
+    ...workflow,
+    metadata: {
+      ...workflow.metadata,
+      name,
+    },
+  };
+}
 
 export async function runFactoryConfigureSave(deps: FactoryConfigureSaveDeps): Promise<void> {
   if (!deps.canStageCanvasVersion) {
@@ -55,11 +76,12 @@ export async function runFactoryConfigureSave(deps: FactoryConfigureSaveDeps): P
     deps.setEditSessionActive(true);
   }
 
-  const workflow = deps.getCurrentWorkflowSnapshot();
-  if (!workflow?.spec) {
+  const snapshot = deps.getCurrentWorkflowSnapshot();
+  if (!snapshot?.spec) {
     showErrorToast("Nothing to save");
     return;
   }
+  const workflow = withCanvasMetadataName(snapshot, deps.canvasName);
 
   deps.setSavePending(true);
   try {
@@ -83,7 +105,7 @@ export async function runFactoryConfigureSave(deps: FactoryConfigureSaveDeps): P
 function applyStagedWorkflowSnapshot(
   deps: FactoryConfigureSaveDeps,
   savingVersionId: string,
-  workflow: NonNullable<ReturnType<FactoryConfigureSaveDeps["getCurrentWorkflowSnapshot"]>>,
+  workflow: CanvasesCanvas,
 ) {
   if (!workflow.spec) {
     return;

--- a/web_src/src/pages/app/factoryConfigureActions.ts
+++ b/web_src/src/pages/app/factoryConfigureActions.ts
@@ -5,8 +5,19 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
 import { materializeCanvasSpec } from "./lib/workflow-spec-files";
 
+type StagingSummary = {
+  hasStaging?: boolean;
+  stagedPaths?: string[];
+};
+
+type UpdateCanvasVersionResult = {
+  data?: {
+    stagingSummary?: StagingSummary;
+  };
+};
+
 type UpdateCanvasVersionMutation = {
-  mutateAsync: (input: { versionId: string; canvasYaml: string }) => Promise<unknown>;
+  mutateAsync: (input: { versionId: string; canvasYaml: string }) => Promise<UpdateCanvasVersionResult | unknown>;
 };
 
 export type FactoryConfigureSaveOptions = {
@@ -56,6 +67,44 @@ export function withCanvasMetadataName(workflow: CanvasesCanvas, canvasName?: st
   };
 }
 
+export function stagingSummaryHasChanges(summary: StagingSummary | undefined): boolean {
+  if (!summary) {
+    return false;
+  }
+  if (summary.hasStaging) {
+    return true;
+  }
+  return (summary.stagedPaths?.length ?? 0) > 0;
+}
+
+function readStagingSummary(result: UpdateCanvasVersionResult | unknown): StagingSummary | undefined {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  const data = (result as UpdateCanvasVersionResult).data;
+  return data?.stagingSummary;
+}
+
+async function stageAndCommitFactoryConfigure(deps: FactoryConfigureSaveDeps, savingVersionId: string, workflow: CanvasesCanvas) {
+  const stageResult = await deps.updateCanvasVersionMutation.mutateAsync({
+    versionId: savingVersionId,
+    canvasYaml: materializeCanvasSpec(workflow),
+  });
+  applyStagedWorkflowSnapshot(deps, savingVersionId, workflow);
+
+  // Matching YAML discards the staged path. Skip commit so title-only / no-op
+  // Saves do not fail with "no staged changes".
+  if (!stagingSummaryHasChanges(readStagingSummary(stageResult))) {
+    deps.onDone?.();
+    return;
+  }
+
+  const committed = await deps.handleCommitStaging("Update automation", { versionId: savingVersionId });
+  if (committed) {
+    deps.onDone?.();
+  }
+}
+
 export async function runFactoryConfigureSave(deps: FactoryConfigureSaveDeps): Promise<void> {
   if (!deps.canStageCanvasVersion) {
     showErrorToast("You don't have permission to edit this canvas.");
@@ -85,16 +134,7 @@ export async function runFactoryConfigureSave(deps: FactoryConfigureSaveDeps): P
 
   deps.setSavePending(true);
   try {
-    // Stage canvas.yaml directly — skip enqueueCanvasSave stale/session checks.
-    await deps.updateCanvasVersionMutation.mutateAsync({
-      versionId: savingVersionId,
-      canvasYaml: materializeCanvasSpec(workflow),
-    });
-    applyStagedWorkflowSnapshot(deps, savingVersionId, workflow);
-    const committed = await deps.handleCommitStaging("Update automation", { versionId: savingVersionId });
-    if (committed) {
-      deps.onDone?.();
-    }
+    await stageAndCommitFactoryConfigure(deps, savingVersionId, workflow);
   } catch (error) {
     showErrorToast(getApiErrorMessage(error, "Failed to stage canvas changes"));
   } finally {

--- a/web_src/src/pages/app/factoryConfigureActions.ts
+++ b/web_src/src/pages/app/factoryConfigureActions.ts
@@ -85,7 +85,11 @@ function readStagingSummary(result: UpdateCanvasVersionResult | unknown): Stagin
   return data?.stagingSummary;
 }
 
-async function stageAndCommitFactoryConfigure(deps: FactoryConfigureSaveDeps, savingVersionId: string, workflow: CanvasesCanvas) {
+async function stageAndCommitFactoryConfigure(
+  deps: FactoryConfigureSaveDeps,
+  savingVersionId: string,
+  workflow: CanvasesCanvas,
+) {
   const stageResult = await deps.updateCanvasVersionMutation.mutateAsync({
     versionId: savingVersionId,
     canvasYaml: materializeCanvasSpec(workflow),

--- a/web_src/src/pages/app/lib/staging-content-match.spec.ts
+++ b/web_src/src/pages/app/lib/staging-content-match.spec.ts
@@ -54,6 +54,11 @@ describe("staging-content-match", () => {
     await expect(matchesCommittedCanvasYaml("canvas-1", "version-1", reorderedCanvasYaml)).resolves.toBe(true);
   });
 
+  it("treats a metadata name change as uncommitted", async () => {
+    const renamedYaml = sampleCanvasYaml.replace("name: demo", "name: renamed");
+    await expect(matchesCommittedCanvasYaml("canvas-1", "version-1", renamedYaml)).resolves.toBe(false);
+  });
+
   it("treats semantically identical console yaml as committed", async () => {
     await expect(matchesCommittedConsoleYaml("canvas-1", "version-1", emptyConsoleYaml)).resolves.toBe(true);
   });

--- a/web_src/src/pages/app/lib/staging-content-match.ts
+++ b/web_src/src/pages/app/lib/staging-content-match.ts
@@ -3,8 +3,23 @@ import type { CanvasesCanvasVersion } from "@/api-client";
 import { hasDraftVersusLiveConsoleDiff } from "../draftConsoleDiff";
 import { hasDraftVersusLiveGraphDiff } from "../draftNodeDiff";
 import { consoleSpecFromYaml, fetchRepositorySpecFileContent } from "./repository-spec-files";
-import { dematerializeCanvasSpec } from "./workflow-spec-files";
+import { dematerializeCanvasMetadata, dematerializeCanvasSpec } from "./workflow-spec-files";
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "./workflow-spec-paths";
+
+function canvasYamlMetadataMatches(committedYaml: string, nextYaml: string): boolean {
+  const committedMeta = dematerializeCanvasMetadata(committedYaml);
+  const nextMeta = dematerializeCanvasMetadata(nextYaml);
+  if (!committedMeta && !nextMeta) {
+    return true;
+  }
+  if (!committedMeta || !nextMeta) {
+    return false;
+  }
+  return (
+    (committedMeta.name ?? "").trim() === (nextMeta.name ?? "").trim() &&
+    (committedMeta.description ?? "").trim() === (nextMeta.description ?? "").trim()
+  );
+}
 
 export async function matchesCommittedCanvasYaml(
   canvasId: string,
@@ -13,6 +28,10 @@ export async function matchesCommittedCanvasYaml(
 ): Promise<boolean> {
   try {
     const committedYaml = await fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH, versionId, false);
+    if (!canvasYamlMetadataMatches(committedYaml, nextCanvasYaml)) {
+      return false;
+    }
+
     const committedSpec = dematerializeCanvasSpec(committedYaml);
     const nextSpec = dematerializeCanvasSpec(nextCanvasYaml);
     if (!committedSpec || !nextSpec) {

--- a/web_src/src/pages/app/useFactoryConfigureSession.ts
+++ b/web_src/src/pages/app/useFactoryConfigureSession.ts
@@ -9,7 +9,7 @@ import {
 import { useFactoryConfigureEnter } from "./useFactoryConfigureEnter";
 
 export type FactoryConfigureActions = {
-  save: (options?: FactoryConfigureSaveOptions) => void;
+  save: (options?: FactoryConfigureSaveOptions) => Promise<void>;
   discard: () => void;
   busy: boolean;
   /** True when Configure has graph/console/files changes to stage+commit. */
@@ -110,11 +110,11 @@ export function useFactoryConfigureSession(options: UseFactoryConfigureSessionOp
       : {
           busy: factoryConfigureBusy,
           hasUncommittedChanges,
-          save: (saveOptions) => {
+          save: async (saveOptions) => {
             if (factoryConfigureBusy) {
               return;
             }
-            void runFactoryConfigureSave({
+            await runFactoryConfigureSave({
               canStageCanvasVersion,
               activeCanvasVersionIdRef,
               activeCanvasVersionId,

--- a/web_src/src/pages/app/useFactoryConfigureSession.ts
+++ b/web_src/src/pages/app/useFactoryConfigureSession.ts
@@ -1,13 +1,19 @@
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { useEffect, useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 
-import { runFactoryConfigureDiscard, runFactoryConfigureSave } from "./factoryConfigureActions";
+import {
+  runFactoryConfigureDiscard,
+  runFactoryConfigureSave,
+  type FactoryConfigureSaveOptions,
+} from "./factoryConfigureActions";
 import { useFactoryConfigureEnter } from "./useFactoryConfigureEnter";
 
 export type FactoryConfigureActions = {
-  save: () => void;
+  save: (options?: FactoryConfigureSaveOptions) => void;
   discard: () => void;
   busy: boolean;
+  /** True when Configure has graph/console/files changes to stage+commit. */
+  hasUncommittedChanges: boolean;
 };
 
 type UpdateCanvasVersionMutation = {
@@ -90,6 +96,7 @@ export function useFactoryConfigureSession(options: UseFactoryConfigureSessionOp
   useFactoryConfigureEnter(options);
 
   const factoryConfigureBusy = commitStagingPending || resetStagingPending || factoryConfigureSavePending;
+  const hasUncommittedChanges = hasStagingChanges || hasUncommittedCanvasDraftChanges;
   useEffect(() => {
     if (!factoryConfigure || !onFactoryConfigureBusyChange) {
       return;
@@ -102,7 +109,8 @@ export function useFactoryConfigureSession(options: UseFactoryConfigureSessionOp
       ? null
       : {
           busy: factoryConfigureBusy,
-          save: () => {
+          hasUncommittedChanges,
+          save: (saveOptions) => {
             if (factoryConfigureBusy) {
               return;
             }
@@ -120,6 +128,7 @@ export function useFactoryConfigureSession(options: UseFactoryConfigureSessionOp
               setDraftCanvasSpec,
               setLastSavedWorkflowSnapshot,
               handleCommitStaging,
+              canvasName: saveOptions?.canvasName,
               onDone: () => onFactoryConfigureDoneRef.current?.(),
             });
           },

--- a/web_src/src/pages/factories/pages/FactoryAppCanvasHeader.spec.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvasHeader.spec.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+
+import { FactoryAppCanvasHeader } from "./FactoryAppCanvasHeader";
+
+describe("FactoryAppCanvasHeader", () => {
+  it("commits a draft title locally without waiting for Save", async () => {
+    const user = userEvent.setup();
+    const onDraftTitleChange = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <FactoryAppCanvasHeader
+          backHref="/back"
+          backLabel="Automations"
+          title="DFFDGD"
+          subtitle="Drag steps"
+          isConfigure
+          configureBusy={false}
+          canRename
+          onDraftTitleChange={onDraftTitleChange}
+          onDiscard={vi.fn()}
+          onSave={onSave}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("factory-app-canvas-title"));
+    const input = await screen.findByTestId("factory-app-rename-input");
+    expect(input).toHaveValue("DFFDGD");
+    await user.clear(input);
+    await user.type(input, "Renamed automation");
+    await user.keyboard("{Enter}");
+
+    expect(onDraftTitleChange).toHaveBeenCalledWith("Renamed automation");
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("does not open rename when canRename is false", async () => {
+    const user = userEvent.setup();
+    const onDraftTitleChange = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <FactoryAppCanvasHeader
+          backHref="/back"
+          backLabel="Automations"
+          title="DFFDGD"
+          subtitle="Drag steps"
+          isConfigure
+          configureBusy={false}
+          canRename={false}
+          onDraftTitleChange={onDraftTitleChange}
+          onDiscard={vi.fn()}
+          onSave={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("factory-app-canvas-title"));
+    expect(screen.queryByTestId("factory-app-rename-input")).not.toBeInTheDocument();
+    expect(onDraftTitleChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps the title static outside configure mode", async () => {
+    const user = userEvent.setup();
+    const onDraftTitleChange = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <FactoryAppCanvasHeader
+          backHref="/back"
+          backLabel="Automations"
+          title="DFFDGD"
+          subtitle="Canvas"
+          isConfigure={false}
+          configureBusy={false}
+          canRename
+          onDraftTitleChange={onDraftTitleChange}
+          onDiscard={vi.fn()}
+          onSave={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("factory-app-canvas-title"));
+    expect(screen.queryByTestId("factory-app-rename-input")).not.toBeInTheDocument();
+    expect(onDraftTitleChange).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/factories/pages/FactoryAppCanvasHeader.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvasHeader.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@/components/Link/link";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
+import { FactoryAppCanvasTitleEditor } from "./FactoryAppCanvasTitleEditor";
 
 type FactoryAppCanvasHeaderProps = {
   backHref: string;
@@ -9,8 +10,11 @@ type FactoryAppCanvasHeaderProps = {
   subtitle: string;
   isConfigure: boolean;
   configureBusy: boolean;
+  canRename?: boolean;
   onDiscard: () => void;
   onSave: () => void;
+  /** Local draft only — persisted when the user clicks Save. */
+  onDraftTitleChange?: (name: string) => void;
 };
 
 export function FactoryAppCanvasHeader({
@@ -20,9 +24,13 @@ export function FactoryAppCanvasHeader({
   subtitle,
   isConfigure,
   configureBusy,
+  canRename = false,
   onDiscard,
   onSave,
+  onDraftTitleChange,
 }: FactoryAppCanvasHeaderProps) {
+  const renameEnabled = Boolean(isConfigure && canRename && onDraftTitleChange);
+
   return (
     <div
       className={
@@ -41,15 +49,21 @@ export function FactoryAppCanvasHeader({
           {backLabel}
         </Link>
         <div className="flex flex-wrap items-center gap-2">
-          <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-foreground">{title}</h2>
-          {isConfigure ? (
-            <span
-              className="rounded-md bg-foreground px-1.5 py-0.5 text-[11px] font-medium text-primary-foreground"
-              data-testid="factory-app-edit-mode-badge"
+          {isConfigure && onDraftTitleChange ? (
+            <FactoryAppCanvasTitleEditor
+              title={title}
+              renameEnabled={renameEnabled}
+              configureBusy={configureBusy}
+              onDraftTitleChange={onDraftTitleChange}
+            />
+          ) : (
+            <h2
+              className="text-[15px] font-semibold tracking-[-0.01em] text-foreground"
+              data-testid="factory-app-canvas-title"
             >
-              Edit mode
-            </span>
-          ) : null}
+              {title}
+            </h2>
+          )}
         </div>
         <p
           className={

--- a/web_src/src/pages/factories/pages/FactoryAppCanvasPage.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvasPage.tsx
@@ -28,8 +28,10 @@ export function FactoryAppCanvasPage() {
         subtitle={model.subtitle}
         isConfigure={model.isConfigure}
         configureBusy={model.configureBusy}
-        onDiscard={() => model.configureActionsRef.current?.discard()}
-        onSave={() => model.configureActionsRef.current?.save()}
+        canRename={model.canRename}
+        onDraftTitleChange={model.isConfigure ? model.handleDraftTitleChange : undefined}
+        onDiscard={model.handleConfigureDiscard}
+        onSave={model.handleConfigureSave}
       />
       <div className="relative min-h-0 flex-1 overflow-hidden">
         {model.canvasLoading && !model.canvas ? (

--- a/web_src/src/pages/factories/pages/FactoryAppCanvasTitleEditor.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvasTitleEditor.tsx
@@ -1,0 +1,131 @@
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
+
+type FactoryAppCanvasTitleEditorProps = {
+  title: string;
+  renameEnabled: boolean;
+  configureBusy: boolean;
+  onDraftTitleChange: (name: string) => void;
+};
+
+export function FactoryAppCanvasTitleEditor({
+  title,
+  renameEnabled,
+  configureBusy,
+  onDraftTitleChange,
+}: FactoryAppCanvasTitleEditorProps) {
+  const [editing, setEditing] = useState(false);
+  const [draftName, setDraftName] = useState(title);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const skipBlurCommitRef = useRef(false);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraftName(title);
+    }
+  }, [editing, title]);
+
+  useEffect(() => {
+    if (!editing) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [editing]);
+
+  const startEditing = (event?: MouseEvent) => {
+    if (!renameEnabled || configureBusy) {
+      return;
+    }
+    event?.preventDefault();
+    skipBlurCommitRef.current = false;
+    setDraftName(title);
+    setEditing(true);
+  };
+
+  const cancelEditing = () => {
+    skipBlurCommitRef.current = true;
+    setDraftName(title);
+    setEditing(false);
+  };
+
+  const commitDraft = () => {
+    const nextName = draftName.trim();
+    if (!nextName) {
+      inputRef.current?.focus();
+      return;
+    }
+    if (nextName !== title.trim()) {
+      onDraftTitleChange(nextName);
+    }
+    skipBlurCommitRef.current = true;
+    setEditing(false);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitDraft();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelEditing();
+    }
+  };
+
+  if (editing) {
+    return (
+      <Input
+        ref={inputRef}
+        value={draftName}
+        onChange={(event) => setDraftName(event.target.value)}
+        onBlur={() => {
+          if (skipBlurCommitRef.current) {
+            skipBlurCommitRef.current = false;
+            return;
+          }
+          commitDraft();
+        }}
+        onKeyDown={handleKeyDown}
+        disabled={configureBusy}
+        size={Math.max(draftName.length + 1, 8)}
+        aria-label="Automation name"
+        data-testid="factory-app-rename-input"
+        className="h-6 w-auto max-w-[16rem] px-1.5 py-0 text-[15px] font-semibold tracking-[-0.01em] leading-none"
+      />
+    );
+  }
+
+  return (
+    <h2
+      className={cn(
+        "text-[15px] font-semibold tracking-[-0.01em] text-foreground",
+        renameEnabled
+          ? "cursor-text rounded-sm border border-transparent px-1 -mx-1 hover:border-border hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          : undefined,
+      )}
+      title={renameEnabled ? "Click to rename" : undefined}
+      data-testid="factory-app-canvas-title"
+      tabIndex={renameEnabled ? 0 : undefined}
+      onMouseDown={(event) => {
+        if (renameEnabled) {
+          event.preventDefault();
+        }
+      }}
+      onClick={(event) => startEditing(event)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          startEditing();
+        }
+      }}
+    >
+      {title}
+    </h2>
+  );
+}

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { duplicateAutomationCanvas } from "./duplicateAutomationCanvas";
+
+describe("duplicateAutomationCanvas", () => {
+  it("creates a canvas and stages the source live graph", async () => {
+    const createCanvas = vi.fn().mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-new" } } },
+    });
+    const describeCanvas = vi.fn().mockResolvedValue({
+      data: {
+        canvas: {
+          metadata: { description: "from source" },
+          spec: {
+            nodes: [{ id: "n1", name: "Node 1", component: "noop", type: "TYPE_ACTION" }],
+            edges: [{ sourceId: "n1", targetId: "n2", channel: "default" }],
+          },
+        },
+      },
+    });
+    const putCanvasStaging = vi.fn().mockResolvedValue({});
+    const commitCanvasStaging = vi.fn().mockResolvedValue({});
+
+    const canvasId = await duplicateAutomationCanvas({
+      factoryId: "factory-1",
+      app: { id: "canvas-source", name: "Refund Planner", description: "Plans refunds" },
+      createCanvas,
+      describeCanvas,
+      putCanvasStaging,
+      commitCanvasStaging,
+    });
+
+    expect(canvasId).toBe("canvas-new");
+    expect(describeCanvas).toHaveBeenCalledWith("canvas-source");
+    expect(createCanvas).toHaveBeenCalledWith({
+      name: "Refund Planner copy",
+      description: "Plans refunds",
+      factoryId: "factory-1",
+      method: "ui",
+    });
+    expect(putCanvasStaging).toHaveBeenCalledTimes(1);
+    expect(putCanvasStaging.mock.calls[0]?.[0]).toBe("canvas-new");
+    expect(String(putCanvasStaging.mock.calls[0]?.[1])).toContain("id: canvas-new");
+    expect(String(putCanvasStaging.mock.calls[0]?.[1])).toContain("name: Refund Planner copy");
+    expect(String(putCanvasStaging.mock.calls[0]?.[1])).toContain("n1");
+    expect(commitCanvasStaging).toHaveBeenCalledWith("canvas-new");
+  });
+
+  it("skips staging when the source graph is empty", async () => {
+    const createCanvas = vi.fn().mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-empty-copy" } } },
+    });
+    const putCanvasStaging = vi.fn();
+    const commitCanvasStaging = vi.fn();
+
+    const canvasId = await duplicateAutomationCanvas({
+      factoryId: "factory-1",
+      app: { id: "canvas-empty", name: "Empty" },
+      createCanvas,
+      describeCanvas: vi.fn().mockResolvedValue({
+        data: { canvas: { spec: { nodes: [], edges: [] } } },
+      }),
+      putCanvasStaging,
+      commitCanvasStaging,
+    });
+
+    expect(canvasId).toBe("canvas-empty-copy");
+    expect(putCanvasStaging).not.toHaveBeenCalled();
+    expect(commitCanvasStaging).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the source automation id is missing", async () => {
+    await expect(
+      duplicateAutomationCanvas({
+        factoryId: "factory-1",
+        app: { name: "No Id" },
+        createCanvas: vi.fn(),
+      }),
+    ).rejects.toThrow("source automation id is required");
+  });
+});

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
@@ -148,9 +148,11 @@ describe("duplicateAutomationCanvas", () => {
           },
         },
       }),
-      fetchConsoleYaml: vi.fn().mockResolvedValue(
-        "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\n  canvasId: canvas-source\nspec:\n  panels:\n    - id: p1\n      type: markdown\n      content:\n        body: hi\n  layout:\n    - i: p1\n      x: 0\n      'y': 0\n      w: 6\n      h: 4\n",
-      ),
+      fetchConsoleYaml: vi
+        .fn()
+        .mockResolvedValue(
+          "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\n  canvasId: canvas-source\nspec:\n  panels:\n    - id: p1\n      type: markdown\n      content:\n        body: hi\n  layout:\n    - i: p1\n      x: 0\n      'y': 0\n      w: 6\n      h: 4\n",
+        ),
     });
 
     await duplicateAutomationCanvas(deps);
@@ -240,6 +242,61 @@ describe("duplicateAutomationCanvas", () => {
     });
 
     await expect(duplicateAutomationCanvas(deps)).rejects.toThrow("stage failed");
-    expect(onCanvasCreated).toHaveBeenCalledWith("canvas-orphan");
+    expect(onCanvasCreated).toHaveBeenCalledWith("canvas-orphan", "Refund Planner copy");
+  });
+
+  it("picks a unique name when the copy name is already taken", async () => {
+    const createCanvas = vi.fn().mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-new-2" } } },
+    });
+    const deps = baseDeps({
+      createCanvas,
+      existingCanvasNames: ["Refund Planner copy"],
+      describeCanvas: vi.fn().mockResolvedValue({
+        data: { canvas: { spec: { nodes: [], edges: [] } } },
+      }),
+    });
+
+    const canvasId = await duplicateAutomationCanvas(deps);
+
+    expect(canvasId).toBe("canvas-new-2");
+    expect(createCanvas).toHaveBeenCalledTimes(1);
+    expect(createCanvas).toHaveBeenCalledWith({
+      name: "Refund Planner copy (2)",
+      description: "Plans refunds",
+      factoryId: "factory-1",
+      method: "ui",
+    });
+  });
+
+  it("retries CreateCanvas when the server reports a name collision", async () => {
+    const createCanvas = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Canvas with the same name already exists"))
+      .mockResolvedValueOnce({
+        data: { canvas: { metadata: { id: "canvas-new-3" } } },
+      });
+    const deps = baseDeps({
+      createCanvas,
+      describeCanvas: vi.fn().mockResolvedValue({
+        data: { canvas: { spec: { nodes: [], edges: [] } } },
+      }),
+    });
+
+    const canvasId = await duplicateAutomationCanvas(deps);
+
+    expect(canvasId).toBe("canvas-new-3");
+    expect(createCanvas).toHaveBeenNthCalledWith(1, {
+      name: "Refund Planner copy",
+      description: "Plans refunds",
+      factoryId: "factory-1",
+      method: "ui",
+    });
+    expect(createCanvas).toHaveBeenNthCalledWith(2, {
+      name: "Refund Planner copy (2)",
+      description: "Plans refunds",
+      factoryId: "factory-1",
+      method: "ui",
+    });
   });
 });

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
@@ -1,13 +1,22 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 
 import {
   consoleYamlHasContent,
   duplicateAutomationCanvas,
   rematerializeDuplicateConsoleYaml,
   rewriteSelfCanvasRefs,
+  type DuplicateAutomationCanvasDeps,
 } from "./duplicateAutomationCanvas";
 
-function baseDeps(overrides: Partial<Parameters<typeof duplicateAutomationCanvas>[0]> = {}) {
+type TestDuplicateDeps = DuplicateAutomationCanvasDeps & {
+  createCanvas: Mock;
+  describeCanvas?: Mock;
+  fetchConsoleYaml: Mock;
+  putCanvasStaging: Mock;
+  commitCanvasStaging: Mock;
+};
+
+function baseDeps(overrides: Partial<TestDuplicateDeps> = {}): TestDuplicateDeps {
   return {
     factoryId: "factory-1",
     app: { id: "canvas-source", name: "Refund Planner", description: "Plans refunds" },

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
@@ -1,94 +1,173 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { duplicateAutomationCanvas } from "./duplicateAutomationCanvas";
+import {
+  duplicateAutomationCanvas,
+  rematerializeDuplicateConsoleYaml,
+  rewriteSelfCanvasRefs,
+} from "./duplicateAutomationCanvas";
+
+function baseDeps(overrides: Partial<Parameters<typeof duplicateAutomationCanvas>[0]> = {}) {
+  return {
+    factoryId: "factory-1",
+    app: { id: "canvas-source", name: "Refund Planner", description: "Plans refunds" },
+    createCanvas: vi.fn().mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-new" } } },
+    }),
+    fetchConsoleYaml: vi.fn().mockResolvedValue(undefined),
+    putCanvasStaging: vi.fn().mockResolvedValue({}),
+    commitCanvasStaging: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+describe("rewriteSelfCanvasRefs", () => {
+  it("rewrites runApp configuration.app and metadata.app to the clone id", () => {
+    const rewritten = rewriteSelfCanvasRefs(
+      [
+        {
+          id: "run-self",
+          name: "Run Self",
+          component: "runApp",
+          configuration: { app: "canvas-source", node: "onrun-1" },
+          metadata: { app: { id: "canvas-source", name: "Refund Planner" } },
+        },
+        {
+          id: "run-other",
+          name: "Run Other",
+          component: "runApp",
+          configuration: { app: "other-canvas", node: "onrun-2" },
+          metadata: { app: { id: "other-canvas", name: "Other" } },
+        },
+      ],
+      "canvas-source",
+      "canvas-new",
+      "Refund Planner copy",
+    );
+
+    expect(rewritten[0]?.configuration).toEqual({ app: "canvas-new", node: "onrun-1" });
+    expect(rewritten[0]?.metadata).toEqual({
+      app: { id: "canvas-new", name: "Refund Planner copy" },
+    });
+    expect(rewritten[1]?.configuration).toEqual({ app: "other-canvas", node: "onrun-2" });
+  });
+});
+
+describe("rematerializeDuplicateConsoleYaml", () => {
+  it("rewrites console metadata name and canvasId", () => {
+    const next = rematerializeDuplicateConsoleYaml(
+      "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\n  canvasId: canvas-source\nspec:\n  panels: []\n",
+      "canvas-new",
+      "Refund Planner copy",
+    );
+    expect(next).toContain("name: Refund Planner copy");
+    expect(next).toContain("canvasId: canvas-new");
+    expect(next).not.toContain("canvas-source");
+  });
+});
 
 describe("duplicateAutomationCanvas", () => {
   it("creates a canvas and stages the source live graph", async () => {
-    const createCanvas = vi.fn().mockResolvedValue({
-      data: { canvas: { metadata: { id: "canvas-new" } } },
-    });
-    const describeCanvas = vi.fn().mockResolvedValue({
-      data: {
-        canvas: {
-          metadata: { description: "from source" },
-          spec: {
-            nodes: [{ id: "n1", name: "Node 1", component: "noop", type: "TYPE_ACTION" }],
-            edges: [{ sourceId: "n1", targetId: "n2", channel: "default" }],
+    const deps = baseDeps({
+      describeCanvas: vi.fn().mockResolvedValue({
+        data: {
+          canvas: {
+            metadata: { description: "from source" },
+            spec: {
+              nodes: [{ id: "n1", name: "Node 1", component: "noop", type: "TYPE_ACTION" }],
+              edges: [{ sourceId: "n1", targetId: "n2", channel: "default" }],
+            },
           },
         },
-      },
+      }),
     });
-    const putCanvasStaging = vi.fn().mockResolvedValue({});
-    const commitCanvasStaging = vi.fn().mockResolvedValue({});
 
-    const canvasId = await duplicateAutomationCanvas({
-      factoryId: "factory-1",
-      app: { id: "canvas-source", name: "Refund Planner", description: "Plans refunds" },
-      createCanvas,
-      describeCanvas,
-      putCanvasStaging,
-      commitCanvasStaging,
-    });
+    const canvasId = await duplicateAutomationCanvas(deps);
 
     expect(canvasId).toBe("canvas-new");
-    expect(describeCanvas).toHaveBeenCalledWith("canvas-source");
-    expect(createCanvas).toHaveBeenCalledWith({
+    expect(deps.describeCanvas).toHaveBeenCalledWith("canvas-source");
+    expect(deps.createCanvas).toHaveBeenCalledWith({
       name: "Refund Planner copy",
       description: "Plans refunds",
       factoryId: "factory-1",
       method: "ui",
     });
-    expect(putCanvasStaging).toHaveBeenCalledTimes(1);
-    expect(putCanvasStaging.mock.calls[0]?.[0]).toBe("canvas-new");
-    expect(String(putCanvasStaging.mock.calls[0]?.[1])).toContain("id: canvas-new");
-    expect(String(putCanvasStaging.mock.calls[0]?.[1])).toContain("name: Refund Planner copy");
-    expect(String(putCanvasStaging.mock.calls[0]?.[1])).toContain("n1");
-    expect(commitCanvasStaging).toHaveBeenCalledWith("canvas-new");
+    expect(deps.putCanvasStaging).toHaveBeenCalledTimes(1);
+    expect(deps.putCanvasStaging.mock.calls[0]?.[0]).toBe("canvas-new");
+    expect(String(deps.putCanvasStaging.mock.calls[0]?.[1])).toContain("id: canvas-new");
+    expect(String(deps.putCanvasStaging.mock.calls[0]?.[1])).toContain("name: Refund Planner copy");
+    expect(String(deps.putCanvasStaging.mock.calls[0]?.[1])).toContain("n1");
+    expect(deps.putCanvasStaging.mock.calls[0]?.[2]).toBeUndefined();
+    expect(deps.commitCanvasStaging).toHaveBeenCalledWith("canvas-new");
   });
 
-  it("skips staging when the source graph is empty", async () => {
-    const createCanvas = vi.fn().mockResolvedValue({
-      data: { canvas: { metadata: { id: "canvas-empty-copy" } } },
+  it("rewrites self canvas refs and stages console.yaml when present", async () => {
+    const deps = baseDeps({
+      describeCanvas: vi.fn().mockResolvedValue({
+        data: {
+          canvas: {
+            spec: {
+              nodes: [
+                {
+                  id: "run-self",
+                  name: "Run Self",
+                  component: "runApp",
+                  configuration: { app: "canvas-source", node: "onrun-1" },
+                  metadata: { app: { id: "canvas-source", name: "Refund Planner" } },
+                },
+              ],
+              edges: [],
+            },
+          },
+        },
+      }),
+      fetchConsoleYaml: vi.fn().mockResolvedValue(
+        "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\n  canvasId: canvas-source\nspec:\n  panels: []\n",
+      ),
     });
-    const putCanvasStaging = vi.fn();
-    const commitCanvasStaging = vi.fn();
 
-    const canvasId = await duplicateAutomationCanvas({
-      factoryId: "factory-1",
-      app: { id: "canvas-empty", name: "Empty" },
-      createCanvas,
+    await duplicateAutomationCanvas(deps);
+
+    const stagedCanvasYaml = String(deps.putCanvasStaging.mock.calls[0]?.[1]);
+    const stagedConsoleYaml = String(deps.putCanvasStaging.mock.calls[0]?.[2]);
+    expect(stagedCanvasYaml).toContain("app: canvas-new");
+    expect(stagedCanvasYaml).not.toContain("app: canvas-source");
+    expect(stagedConsoleYaml).toContain("canvasId: canvas-new");
+    expect(stagedConsoleYaml).toContain("name: Refund Planner copy");
+  });
+
+  it("skips staging when the source graph and console are empty", async () => {
+    const deps = baseDeps({
+      createCanvas: vi.fn().mockResolvedValue({
+        data: { canvas: { metadata: { id: "canvas-empty-copy" } } },
+      }),
       describeCanvas: vi.fn().mockResolvedValue({
         data: { canvas: { spec: { nodes: [], edges: [] } } },
       }),
-      putCanvasStaging,
-      commitCanvasStaging,
+      app: { id: "canvas-empty", name: "Empty" },
     });
 
+    const canvasId = await duplicateAutomationCanvas(deps);
+
     expect(canvasId).toBe("canvas-empty-copy");
-    expect(putCanvasStaging).not.toHaveBeenCalled();
-    expect(commitCanvasStaging).not.toHaveBeenCalled();
+    expect(deps.putCanvasStaging).not.toHaveBeenCalled();
+    expect(deps.commitCanvasStaging).not.toHaveBeenCalled();
   });
 
   it("rejects when the source automation id is missing", async () => {
     await expect(
-      duplicateAutomationCanvas({
-        factoryId: "factory-1",
-        app: { name: "No Id" },
-        createCanvas: vi.fn(),
-      }),
+      duplicateAutomationCanvas(
+        baseDeps({
+          app: { name: "No Id" },
+          createCanvas: vi.fn(),
+        }),
+      ),
     ).rejects.toThrow("source automation id is required");
   });
 
   it("reuses pendingCanvasId on retry and skips CreateCanvas", async () => {
-    const createCanvas = vi.fn();
     const onCanvasCreated = vi.fn();
-    const putCanvasStaging = vi.fn().mockResolvedValue({});
-    const commitCanvasStaging = vi.fn().mockResolvedValue({});
-
-    const canvasId = await duplicateAutomationCanvas({
-      factoryId: "factory-1",
-      app: { id: "canvas-source", name: "Refund Planner", description: "Plans refunds" },
-      createCanvas,
+    const deps = baseDeps({
+      createCanvas: vi.fn(),
       pendingCanvasId: "canvas-pending",
       onCanvasCreated,
       describeCanvas: vi.fn().mockResolvedValue({
@@ -101,44 +180,38 @@ describe("duplicateAutomationCanvas", () => {
           },
         },
       }),
-      putCanvasStaging,
-      commitCanvasStaging,
     });
 
+    const canvasId = await duplicateAutomationCanvas(deps);
+
     expect(canvasId).toBe("canvas-pending");
-    expect(createCanvas).not.toHaveBeenCalled();
+    expect(deps.createCanvas).not.toHaveBeenCalled();
     expect(onCanvasCreated).not.toHaveBeenCalled();
-    expect(putCanvasStaging.mock.calls[0]?.[0]).toBe("canvas-pending");
-    expect(commitCanvasStaging).toHaveBeenCalledWith("canvas-pending");
+    expect(deps.putCanvasStaging.mock.calls[0]?.[0]).toBe("canvas-pending");
+    expect(deps.commitCanvasStaging).toHaveBeenCalledWith("canvas-pending");
   });
 
   it("notifies onCanvasCreated before a stage/commit failure", async () => {
     const onCanvasCreated = vi.fn();
-    const createCanvas = vi.fn().mockResolvedValue({
-      data: { canvas: { metadata: { id: "canvas-orphan" } } },
-    });
-
-    await expect(
-      duplicateAutomationCanvas({
-        factoryId: "factory-1",
-        app: { id: "canvas-source", name: "Refund Planner" },
-        createCanvas,
-        onCanvasCreated,
-        describeCanvas: vi.fn().mockResolvedValue({
-          data: {
-            canvas: {
-              spec: {
-                nodes: [{ id: "n1", name: "Node 1", component: "noop", type: "TYPE_ACTION" }],
-                edges: [],
-              },
+    const deps = baseDeps({
+      createCanvas: vi.fn().mockResolvedValue({
+        data: { canvas: { metadata: { id: "canvas-orphan" } } },
+      }),
+      onCanvasCreated,
+      describeCanvas: vi.fn().mockResolvedValue({
+        data: {
+          canvas: {
+            spec: {
+              nodes: [{ id: "n1", name: "Node 1", component: "noop", type: "TYPE_ACTION" }],
+              edges: [],
             },
           },
-        }),
-        putCanvasStaging: vi.fn().mockRejectedValue(new Error("stage failed")),
-        commitCanvasStaging: vi.fn(),
+        },
       }),
-    ).rejects.toThrow("stage failed");
+      putCanvasStaging: vi.fn().mockRejectedValue(new Error("stage failed")),
+    });
 
+    await expect(duplicateAutomationCanvas(deps)).rejects.toThrow("stage failed");
     expect(onCanvasCreated).toHaveBeenCalledWith("canvas-orphan");
   });
 });

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  consoleYamlHasContent,
   duplicateAutomationCanvas,
   rematerializeDuplicateConsoleYaml,
   rewriteSelfCanvasRefs,
@@ -65,6 +66,24 @@ describe("rematerializeDuplicateConsoleYaml", () => {
   });
 });
 
+describe("consoleYamlHasContent", () => {
+  it("treats empty panels/layout console shells as absent", () => {
+    expect(
+      consoleYamlHasContent(
+        "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\n  canvasId: canvas-source\nspec:\n  panels: []\n  layout: []\n",
+      ),
+    ).toBe(false);
+  });
+
+  it("treats consoles with panels as present", () => {
+    expect(
+      consoleYamlHasContent(
+        "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\nspec:\n  panels:\n    - id: p1\n      type: markdown\n      content:\n        body: hi\n  layout:\n    - i: p1\n      x: 0\n      'y': 0\n      w: 6\n      h: 4\n",
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("duplicateAutomationCanvas", () => {
   it("creates a canvas and stages the source live graph", async () => {
     const deps = baseDeps({
@@ -121,7 +140,7 @@ describe("duplicateAutomationCanvas", () => {
         },
       }),
       fetchConsoleYaml: vi.fn().mockResolvedValue(
-        "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\n  canvasId: canvas-source\nspec:\n  panels: []\n",
+        "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\n  canvasId: canvas-source\nspec:\n  panels:\n    - id: p1\n      type: markdown\n      content:\n        body: hi\n  layout:\n    - i: p1\n      x: 0\n      'y': 0\n      w: 6\n      h: 4\n",
       ),
     });
 

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
@@ -124,6 +124,7 @@ async function stageAndCommitDuplicateGraph(
 /**
  * Creates a factory automation clone: empty CreateCanvas, then stage+commit
  * the source live graph as canvas.yaml (same pattern as factory template install).
+ * Secrets and run history are not copied.
  */
 export async function duplicateAutomationCanvas(deps: DuplicateAutomationCanvasDeps): Promise<string> {
   const sourceCanvasId = deps.app.id?.trim();

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
@@ -8,7 +8,7 @@ import {
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import { encodeRepositoryFileContent } from "@/pages/app/files/lib/repository-files";
 import { fetchRepositorySpecFileContent } from "@/pages/app/lib/repository-spec-files";
-import { materializeCanvasSpec } from "@/pages/app/lib/workflow-spec-files";
+import { dematerializeConsoleSpec, materializeCanvasSpec } from "@/pages/app/lib/workflow-spec-files";
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
 import { isNotFoundError } from "@/pages/app/workflowPageHelpers";
 import * as yaml from "js-yaml";
@@ -59,13 +59,25 @@ async function defaultDescribeCanvas(sourceCanvasId: string) {
 async function defaultFetchConsoleYaml(sourceCanvasId: string): Promise<string | undefined> {
   try {
     const consoleYaml = await fetchRepositorySpecFileContent(sourceCanvasId, CONSOLE_YAML_PATH);
-    return consoleYaml.trim() ? consoleYaml : undefined;
+    return consoleYamlHasContent(consoleYaml) ? consoleYaml : undefined;
   } catch (error) {
     if (isNotFoundError(error) || (error instanceof Error && /404|not found/i.test(error.message))) {
       return undefined;
     }
     throw error;
   }
+}
+
+/** True when console.yaml has at least one panel or layout item (not the empty default shell). */
+export function consoleYamlHasContent(consoleYaml: string): boolean {
+  if (!consoleYaml.trim()) {
+    return false;
+  }
+  const parsed = dematerializeConsoleSpec(consoleYaml);
+  if (!parsed) {
+    return false;
+  }
+  return parsed.panels.length > 0 || parsed.layout.length > 0;
 }
 
 async function defaultPutCanvasStaging(canvasId: string, canvasYaml: string, consoleYaml?: string) {

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
@@ -1,0 +1,125 @@
+import {
+  canvasesCommitCanvasStaging,
+  canvasesDescribeCanvas,
+  canvasesPutCanvasStaging,
+  type CanvasesCanvas,
+  type FactoryApp,
+} from "@/api-client";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+import { encodeRepositoryFileContent } from "@/pages/app/files/lib/repository-files";
+import { materializeCanvasSpec } from "@/pages/app/lib/workflow-spec-files";
+import { CANVAS_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
+
+import { duplicateAutomationName } from "./automationCardActions";
+
+type CreateCanvasResult = {
+  data?: {
+    canvas?: {
+      metadata?: {
+        id?: string;
+      };
+    };
+  };
+};
+
+type CreateCanvasInput = {
+  name: string;
+  description?: string;
+  factoryId?: string;
+  method?: "ui" | "cli" | "yaml_import" | "template";
+};
+
+export type DuplicateAutomationCanvasDeps = {
+  factoryId: string;
+  app: FactoryApp;
+  createCanvas: (input: CreateCanvasInput) => Promise<CreateCanvasResult>;
+  describeCanvas?: (sourceCanvasId: string) => Promise<{ data?: { canvas?: CanvasesCanvas } }>;
+  putCanvasStaging?: (canvasId: string, canvasYaml: string) => Promise<unknown>;
+  commitCanvasStaging?: (canvasId: string) => Promise<unknown>;
+};
+
+async function defaultDescribeCanvas(sourceCanvasId: string) {
+  return canvasesDescribeCanvas(
+    withOrganizationHeader({
+      path: { id: sourceCanvasId },
+    }),
+  );
+}
+
+async function defaultPutCanvasStaging(canvasId: string, canvasYaml: string) {
+  return canvasesPutCanvasStaging(
+    withOrganizationHeader({
+      path: { canvasId },
+      body: {
+        operations: [
+          {
+            path: CANVAS_YAML_PATH,
+            content: encodeRepositoryFileContent(canvasYaml),
+          },
+        ],
+      },
+    }),
+  );
+}
+
+async function defaultCommitCanvasStaging(canvasId: string) {
+  return canvasesCommitCanvasStaging(
+    withOrganizationHeader({
+      path: { canvasId },
+      body: { commitMessage: "Duplicate automation" },
+    }),
+  );
+}
+
+/**
+ * Creates a factory automation clone: empty CreateCanvas, then stage+commit
+ * the source live graph as canvas.yaml (same pattern as factory template install).
+ */
+export async function duplicateAutomationCanvas(deps: DuplicateAutomationCanvasDeps): Promise<string> {
+  const sourceCanvasId = deps.app.id?.trim();
+  if (!sourceCanvasId) {
+    throw new Error("source automation id is required");
+  }
+
+  const describeCanvas = deps.describeCanvas ?? defaultDescribeCanvas;
+  const putCanvasStaging = deps.putCanvasStaging ?? defaultPutCanvasStaging;
+  const commitCanvasStaging = deps.commitCanvasStaging ?? defaultCommitCanvasStaging;
+
+  const sourceResponse = await describeCanvas(sourceCanvasId);
+  const sourceCanvas = sourceResponse.data?.canvas;
+  const duplicateName = duplicateAutomationName(deps.app.name);
+  const description = deps.app.description ?? sourceCanvas?.metadata?.description ?? "";
+
+  const created = await deps.createCanvas({
+    name: duplicateName,
+    description,
+    factoryId: deps.factoryId,
+    method: "ui",
+  });
+  const canvasId = created.data?.canvas?.metadata?.id;
+  if (!canvasId) {
+    throw new Error("Failed to create automation canvas");
+  }
+
+  const nodes = sourceCanvas?.spec?.nodes ?? [];
+  const edges = sourceCanvas?.spec?.edges ?? [];
+  if (nodes.length === 0 && edges.length === 0) {
+    return canvasId;
+  }
+
+  const canvasYaml = materializeCanvasSpec({
+    metadata: {
+      id: canvasId,
+      name: duplicateName,
+      description,
+    },
+    spec: {
+      nodes,
+      edges,
+    },
+  });
+
+  await putCanvasStaging(canvasId, canvasYaml);
+  await commitCanvasStaging(canvasId);
+  return canvasId;
+}

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
@@ -71,6 +71,56 @@ async function defaultCommitCanvasStaging(canvasId: string) {
   );
 }
 
+function sourceGraphIsEmpty(canvas: CanvasesCanvas | undefined): boolean {
+  const nodes = canvas?.spec?.nodes ?? [];
+  const edges = canvas?.spec?.edges ?? [];
+  return nodes.length === 0 && edges.length === 0;
+}
+
+function buildDuplicateCanvasYaml(args: {
+  canvasId: string;
+  name: string;
+  description: string;
+  sourceCanvas: CanvasesCanvas | undefined;
+}): string {
+  return materializeCanvasSpec({
+    metadata: {
+      id: args.canvasId,
+      name: args.name,
+      description: args.description,
+    },
+    spec: {
+      nodes: args.sourceCanvas?.spec?.nodes ?? [],
+      edges: args.sourceCanvas?.spec?.edges ?? [],
+    },
+  });
+}
+
+async function createDuplicateCanvasShell(deps: DuplicateAutomationCanvasDeps, name: string, description: string) {
+  const created = await deps.createCanvas({
+    name,
+    description,
+    factoryId: deps.factoryId,
+    method: "ui",
+  });
+  const canvasId = created.data?.canvas?.metadata?.id;
+  if (!canvasId) {
+    throw new Error("Failed to create automation canvas");
+  }
+  return canvasId;
+}
+
+async function stageAndCommitDuplicateGraph(
+  deps: DuplicateAutomationCanvasDeps,
+  canvasId: string,
+  canvasYaml: string,
+) {
+  const putCanvasStaging = deps.putCanvasStaging ?? defaultPutCanvasStaging;
+  const commitCanvasStaging = deps.commitCanvasStaging ?? defaultCommitCanvasStaging;
+  await putCanvasStaging(canvasId, canvasYaml);
+  await commitCanvasStaging(canvasId);
+}
+
 /**
  * Creates a factory automation clone: empty CreateCanvas, then stage+commit
  * the source live graph as canvas.yaml (same pattern as factory template install).
@@ -82,44 +132,24 @@ export async function duplicateAutomationCanvas(deps: DuplicateAutomationCanvasD
   }
 
   const describeCanvas = deps.describeCanvas ?? defaultDescribeCanvas;
-  const putCanvasStaging = deps.putCanvasStaging ?? defaultPutCanvasStaging;
-  const commitCanvasStaging = deps.commitCanvasStaging ?? defaultCommitCanvasStaging;
-
-  const sourceResponse = await describeCanvas(sourceCanvasId);
-  const sourceCanvas = sourceResponse.data?.canvas;
+  const sourceCanvas = (await describeCanvas(sourceCanvasId)).data?.canvas;
   const duplicateName = duplicateAutomationName(deps.app.name);
   const description = deps.app.description ?? sourceCanvas?.metadata?.description ?? "";
+  const canvasId = await createDuplicateCanvasShell(deps, duplicateName, description);
 
-  const created = await deps.createCanvas({
-    name: duplicateName,
-    description,
-    factoryId: deps.factoryId,
-    method: "ui",
-  });
-  const canvasId = created.data?.canvas?.metadata?.id;
-  if (!canvasId) {
-    throw new Error("Failed to create automation canvas");
-  }
-
-  const nodes = sourceCanvas?.spec?.nodes ?? [];
-  const edges = sourceCanvas?.spec?.edges ?? [];
-  if (nodes.length === 0 && edges.length === 0) {
+  if (sourceGraphIsEmpty(sourceCanvas)) {
     return canvasId;
   }
 
-  const canvasYaml = materializeCanvasSpec({
-    metadata: {
-      id: canvasId,
+  await stageAndCommitDuplicateGraph(
+    deps,
+    canvasId,
+    buildDuplicateCanvasYaml({
+      canvasId,
       name: duplicateName,
       description,
-    },
-    spec: {
-      nodes,
-      edges,
-    },
-  });
-
-  await putCanvasStaging(canvasId, canvasYaml);
-  await commitCanvasStaging(canvasId);
+      sourceCanvas,
+    }),
+  );
   return canvasId;
 }

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
@@ -7,8 +7,11 @@ import {
 } from "@/api-client";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import { encodeRepositoryFileContent } from "@/pages/app/files/lib/repository-files";
+import { fetchRepositorySpecFileContent } from "@/pages/app/lib/repository-spec-files";
 import { materializeCanvasSpec } from "@/pages/app/lib/workflow-spec-files";
-import { CANVAS_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
+import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
+import { isNotFoundError } from "@/pages/app/workflowPageHelpers";
+import * as yaml from "js-yaml";
 
 import { duplicateAutomationName } from "./automationCardActions";
 
@@ -29,6 +32,8 @@ type CreateCanvasInput = {
   method?: "ui" | "cli" | "yaml_import" | "template";
 };
 
+type CanvasNodes = NonNullable<NonNullable<CanvasesCanvas["spec"]>["nodes"]>;
+
 export type DuplicateAutomationCanvasDeps = {
   factoryId: string;
   app: FactoryApp;
@@ -38,7 +43,8 @@ export type DuplicateAutomationCanvasDeps = {
   /** Called once a new empty canvas is created, before stage/commit. */
   onCanvasCreated?: (canvasId: string) => void;
   describeCanvas?: (sourceCanvasId: string) => Promise<{ data?: { canvas?: CanvasesCanvas } }>;
-  putCanvasStaging?: (canvasId: string, canvasYaml: string) => Promise<unknown>;
+  fetchConsoleYaml?: (sourceCanvasId: string) => Promise<string | undefined>;
+  putCanvasStaging?: (canvasId: string, canvasYaml: string, consoleYaml?: string) => Promise<unknown>;
   commitCanvasStaging?: (canvasId: string) => Promise<unknown>;
 };
 
@@ -50,18 +56,36 @@ async function defaultDescribeCanvas(sourceCanvasId: string) {
   );
 }
 
-async function defaultPutCanvasStaging(canvasId: string, canvasYaml: string) {
+async function defaultFetchConsoleYaml(sourceCanvasId: string): Promise<string | undefined> {
+  try {
+    const consoleYaml = await fetchRepositorySpecFileContent(sourceCanvasId, CONSOLE_YAML_PATH);
+    return consoleYaml.trim() ? consoleYaml : undefined;
+  } catch (error) {
+    if (isNotFoundError(error) || (error instanceof Error && /404|not found/i.test(error.message))) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function defaultPutCanvasStaging(canvasId: string, canvasYaml: string, consoleYaml?: string) {
+  const operations = [
+    {
+      path: CANVAS_YAML_PATH,
+      content: encodeRepositoryFileContent(canvasYaml),
+    },
+  ];
+  if (consoleYaml) {
+    operations.push({
+      path: CONSOLE_YAML_PATH,
+      content: encodeRepositoryFileContent(consoleYaml),
+    });
+  }
+
   return canvasesPutCanvasStaging(
     withOrganizationHeader({
       path: { canvasId },
-      body: {
-        operations: [
-          {
-            path: CANVAS_YAML_PATH,
-            content: encodeRepositoryFileContent(canvasYaml),
-          },
-        ],
-      },
+      body: { operations },
     }),
   );
 }
@@ -81,10 +105,74 @@ function sourceGraphIsEmpty(canvas: CanvasesCanvas | undefined): boolean {
   return nodes.length === 0 && edges.length === 0;
 }
 
+/** Point self-runApp refs at the clone instead of the source canvas. */
+export function rewriteSelfCanvasRefs(
+  nodes: CanvasNodes | undefined,
+  sourceCanvasId: string,
+  newCanvasId: string,
+  newCanvasName: string,
+): CanvasNodes {
+  return (nodes ?? []).map((node) => {
+    const configuration = node.configuration;
+    if (!configuration || typeof configuration !== "object" || Array.isArray(configuration)) {
+      return node;
+    }
+
+    const configRecord = configuration as Record<string, unknown>;
+    if (configRecord.app !== sourceCanvasId) {
+      return node;
+    }
+
+    const metadata =
+      node.metadata && typeof node.metadata === "object" && !Array.isArray(node.metadata)
+        ? { ...(node.metadata as Record<string, unknown>) }
+        : {};
+    const existingAppMeta =
+      metadata.app && typeof metadata.app === "object" && !Array.isArray(metadata.app)
+        ? { ...(metadata.app as Record<string, unknown>) }
+        : {};
+
+    return {
+      ...node,
+      configuration: {
+        ...configRecord,
+        app: newCanvasId,
+      },
+      metadata: {
+        ...metadata,
+        app: {
+          ...existingAppMeta,
+          id: newCanvasId,
+          name: newCanvasName,
+        },
+      },
+    };
+  });
+}
+
+export function rematerializeDuplicateConsoleYaml(
+  consoleYaml: string,
+  canvasId: string,
+  canvasName: string,
+): string {
+  const doc = yaml.load(consoleYaml) as { metadata?: Record<string, unknown>; [key: string]: unknown } | null;
+  if (!doc || typeof doc !== "object" || Array.isArray(doc)) {
+    return consoleYaml;
+  }
+
+  doc.metadata = {
+    ...(doc.metadata ?? {}),
+    name: canvasName,
+    canvasId,
+  };
+  return yaml.dump(doc, { lineWidth: -1, noRefs: true });
+}
+
 function buildDuplicateCanvasYaml(args: {
   canvasId: string;
   name: string;
   description: string;
+  sourceCanvasId: string;
   sourceCanvas: CanvasesCanvas | undefined;
 }): string {
   return materializeCanvasSpec({
@@ -94,7 +182,12 @@ function buildDuplicateCanvasYaml(args: {
       description: args.description,
     },
     spec: {
-      nodes: args.sourceCanvas?.spec?.nodes ?? [],
+      nodes: rewriteSelfCanvasRefs(
+        args.sourceCanvas?.spec?.nodes,
+        args.sourceCanvasId,
+        args.canvasId,
+        args.name,
+      ),
       edges: args.sourceCanvas?.spec?.edges ?? [],
     },
   });
@@ -128,20 +221,21 @@ async function ensureDuplicateCanvasId(
   return canvasId;
 }
 
-async function stageAndCommitDuplicateGraph(
+async function stageAndCommitDuplicateSpecs(
   deps: DuplicateAutomationCanvasDeps,
   canvasId: string,
   canvasYaml: string,
+  consoleYaml?: string,
 ) {
   const putCanvasStaging = deps.putCanvasStaging ?? defaultPutCanvasStaging;
   const commitCanvasStaging = deps.commitCanvasStaging ?? defaultCommitCanvasStaging;
-  await putCanvasStaging(canvasId, canvasYaml);
+  await putCanvasStaging(canvasId, canvasYaml, consoleYaml);
   await commitCanvasStaging(canvasId);
 }
 
 /**
  * Creates a factory automation clone: empty CreateCanvas, then stage+commit
- * the source live graph as canvas.yaml (same pattern as factory template install).
+ * the source live graph as canvas.yaml (and console.yaml when present).
  * Secrets and run history are not copied.
  */
 export async function duplicateAutomationCanvas(deps: DuplicateAutomationCanvasDeps): Promise<string> {
@@ -151,24 +245,32 @@ export async function duplicateAutomationCanvas(deps: DuplicateAutomationCanvasD
   }
 
   const describeCanvas = deps.describeCanvas ?? defaultDescribeCanvas;
+  const fetchConsoleYaml = deps.fetchConsoleYaml ?? defaultFetchConsoleYaml;
   const sourceCanvas = (await describeCanvas(sourceCanvasId)).data?.canvas;
   const duplicateName = duplicateAutomationName(deps.app.name);
   const description = deps.app.description ?? sourceCanvas?.metadata?.description ?? "";
   const canvasId = await ensureDuplicateCanvasId(deps, duplicateName, description);
 
-  if (sourceGraphIsEmpty(sourceCanvas)) {
+  const sourceConsoleYaml = await fetchConsoleYaml(sourceCanvasId);
+  const consoleYaml = sourceConsoleYaml
+    ? rematerializeDuplicateConsoleYaml(sourceConsoleYaml, canvasId, duplicateName)
+    : undefined;
+
+  if (sourceGraphIsEmpty(sourceCanvas) && !consoleYaml) {
     return canvasId;
   }
 
-  await stageAndCommitDuplicateGraph(
+  await stageAndCommitDuplicateSpecs(
     deps,
     canvasId,
     buildDuplicateCanvasYaml({
       canvasId,
       name: duplicateName,
       description,
+      sourceCanvasId,
       sourceCanvas,
     }),
+    consoleYaml,
   );
   return canvasId;
 }

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
@@ -11,9 +11,12 @@ import { fetchRepositorySpecFileContent } from "@/pages/app/lib/repository-spec-
 import { dematerializeConsoleSpec, materializeCanvasSpec } from "@/pages/app/lib/workflow-spec-files";
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
 import { isNotFoundError } from "@/pages/app/workflowPageHelpers";
+import { isCanvasNameAlreadyExistsError, uniqueCanvasName } from "@/pages/home/uniqueCanvasName";
 import * as yaml from "js-yaml";
 
 import { duplicateAutomationName } from "./automationCardActions";
+
+const MAX_NAME_RETRY_ATTEMPTS = 20;
 
 type CreateCanvasResult = {
   data?: {
@@ -38,10 +41,14 @@ export type DuplicateAutomationCanvasDeps = {
   factoryId: string;
   app: FactoryApp;
   createCanvas: (input: CreateCanvasInput) => Promise<CreateCanvasResult>;
+  /** Names already taken in the org (used to pick "X copy", "X copy (2)", …). */
+  existingCanvasNames?: Iterable<string>;
   /** When set, skip CreateCanvas and reuse this id (retry after failed stage/commit). */
   pendingCanvasId?: string;
+  /** Name already assigned to the pending canvas (keeps yaml metadata in sync on retry). */
+  pendingCanvasName?: string;
   /** Called once a new empty canvas is created, before stage/commit. */
-  onCanvasCreated?: (canvasId: string) => void;
+  onCanvasCreated?: (canvasId: string, canvasName: string) => void;
   describeCanvas?: (sourceCanvasId: string) => Promise<{ data?: { canvas?: CanvasesCanvas } }>;
   fetchConsoleYaml?: (sourceCanvasId: string) => Promise<string | undefined>;
   putCanvasStaging?: (canvasId: string, canvasYaml: string, consoleYaml?: string) => Promise<unknown>;
@@ -162,11 +169,7 @@ export function rewriteSelfCanvasRefs(
   });
 }
 
-export function rematerializeDuplicateConsoleYaml(
-  consoleYaml: string,
-  canvasId: string,
-  canvasName: string,
-): string {
+export function rematerializeDuplicateConsoleYaml(consoleYaml: string, canvasId: string, canvasName: string): string {
   const doc = yaml.load(consoleYaml) as { metadata?: Record<string, unknown>; [key: string]: unknown } | null;
   if (!doc || typeof doc !== "object" || Array.isArray(doc)) {
     return consoleYaml;
@@ -194,43 +197,62 @@ function buildDuplicateCanvasYaml(args: {
       description: args.description,
     },
     spec: {
-      nodes: rewriteSelfCanvasRefs(
-        args.sourceCanvas?.spec?.nodes,
-        args.sourceCanvasId,
-        args.canvasId,
-        args.name,
-      ),
+      nodes: rewriteSelfCanvasRefs(args.sourceCanvas?.spec?.nodes, args.sourceCanvasId, args.canvasId, args.name),
       edges: args.sourceCanvas?.spec?.edges ?? [],
     },
   });
 }
 
-async function createDuplicateCanvasShell(deps: DuplicateAutomationCanvasDeps, name: string, description: string) {
-  const created = await deps.createCanvas({
-    name,
-    description,
-    factoryId: deps.factoryId,
-    method: "ui",
-  });
-  const canvasId = created.data?.canvas?.metadata?.id;
-  if (!canvasId) {
-    throw new Error("Failed to create automation canvas");
+async function createDuplicateCanvasShell(
+  deps: DuplicateAutomationCanvasDeps,
+  preferredName: string,
+  description: string,
+): Promise<{ canvasId: string; name: string }> {
+  const taken = new Set(
+    [...(deps.existingCanvasNames ?? [])].map((name) => name.trim()).filter((name): name is string => Boolean(name)),
+  );
+  let canvasName = uniqueCanvasName(preferredName, taken);
+
+  for (let attempt = 0; attempt < MAX_NAME_RETRY_ATTEMPTS; attempt++) {
+    try {
+      const created = await deps.createCanvas({
+        name: canvasName,
+        description,
+        factoryId: deps.factoryId,
+        method: "ui",
+      });
+      const canvasId = created.data?.canvas?.metadata?.id;
+      if (!canvasId) {
+        throw new Error("Failed to create automation canvas");
+      }
+      return { canvasId, name: canvasName };
+    } catch (error) {
+      if (!isCanvasNameAlreadyExistsError(error)) {
+        throw error;
+      }
+      taken.add(canvasName);
+      canvasName = uniqueCanvasName(preferredName, taken);
+    }
   }
-  return canvasId;
+
+  throw new Error("Failed to create automation canvas");
 }
 
 async function ensureDuplicateCanvasId(
   deps: DuplicateAutomationCanvasDeps,
-  name: string,
+  preferredName: string,
   description: string,
-): Promise<string> {
+): Promise<{ canvasId: string; name: string }> {
   if (deps.pendingCanvasId) {
-    return deps.pendingCanvasId;
+    return {
+      canvasId: deps.pendingCanvasId,
+      name: deps.pendingCanvasName?.trim() || preferredName,
+    };
   }
 
-  const canvasId = await createDuplicateCanvasShell(deps, name, description);
-  deps.onCanvasCreated?.(canvasId);
-  return canvasId;
+  const created = await createDuplicateCanvasShell(deps, preferredName, description);
+  deps.onCanvasCreated?.(created.canvasId, created.name);
+  return created;
 }
 
 async function stageAndCommitDuplicateSpecs(
@@ -259,9 +281,9 @@ export async function duplicateAutomationCanvas(deps: DuplicateAutomationCanvasD
   const describeCanvas = deps.describeCanvas ?? defaultDescribeCanvas;
   const fetchConsoleYaml = deps.fetchConsoleYaml ?? defaultFetchConsoleYaml;
   const sourceCanvas = (await describeCanvas(sourceCanvasId)).data?.canvas;
-  const duplicateName = duplicateAutomationName(deps.app.name);
+  const preferredName = duplicateAutomationName(deps.app.name);
   const description = deps.app.description ?? sourceCanvas?.metadata?.description ?? "";
-  const canvasId = await ensureDuplicateCanvasId(deps, duplicateName, description);
+  const { canvasId, name: duplicateName } = await ensureDuplicateCanvasId(deps, preferredName, description);
 
   const sourceConsoleYaml = await fetchConsoleYaml(sourceCanvasId);
   const consoleYaml = sourceConsoleYaml

--- a/web_src/src/pages/factories/pages/useAutomationCardMutations.ts
+++ b/web_src/src/pages/factories/pages/useAutomationCardMutations.ts
@@ -1,4 +1,4 @@
-import type { FactoryApp } from "@/api-client";
+import type { CanvasesCanvasSummary, FactoryApp } from "@/api-client";
 import { canvasKeys, useCreateCanvas, useDeleteCanvas } from "@/hooks/useCanvasData";
 import { factoryAppsKey } from "@/hooks/useFactoryData";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
@@ -9,6 +9,77 @@ import { useNavigate } from "react-router";
 import { automationsPath, factoryAppConfigurePath } from "../lib/factoryPagePaths";
 import type { AutomationCardActions } from "./automationCardActions";
 import { duplicateAutomationCanvas } from "./duplicateAutomationCanvas";
+
+type PendingDuplicateCanvas = {
+  canvasId: string;
+  name: string;
+};
+
+function collectExistingCanvasNames(
+  queryClient: ReturnType<typeof useQueryClient>,
+  organizationId: string,
+  factoryId: string,
+  sessionNames: Iterable<string>,
+): string[] {
+  const names = new Set<string>([...sessionNames]);
+  const canvases = queryClient.getQueryData<CanvasesCanvasSummary[]>(canvasKeys.list(organizationId));
+  for (const canvas of canvases ?? []) {
+    if (canvas.name?.trim()) {
+      names.add(canvas.name.trim());
+    }
+  }
+  const apps = queryClient.getQueryData<FactoryApp[]>(factoryAppsKey(organizationId, factoryId));
+  for (const app of apps ?? []) {
+    if (app.name?.trim()) {
+      names.add(app.name.trim());
+    }
+  }
+  return [...names];
+}
+
+async function runDuplicateAutomation(args: {
+  app: FactoryApp;
+  factoryId: string;
+  factoryKey: string;
+  organizationId: string;
+  createCanvas: ReturnType<typeof useCreateCanvas>["mutateAsync"];
+  queryClient: ReturnType<typeof useQueryClient>;
+  pendingDuplicateCanvases: Map<string, PendingDuplicateCanvas>;
+  sessionDuplicateNames: Set<string>;
+  invalidateFactoryApps: () => void;
+  navigate: ReturnType<typeof useNavigate>;
+}) {
+  const { app } = args;
+  if (!app.id) {
+    return;
+  }
+  const pending = args.pendingDuplicateCanvases.get(app.id);
+  const canvasId = await duplicateAutomationCanvas({
+    factoryId: args.factoryId,
+    app,
+    createCanvas: args.createCanvas,
+    existingCanvasNames: collectExistingCanvasNames(
+      args.queryClient,
+      args.organizationId,
+      args.factoryId,
+      args.sessionDuplicateNames,
+    ),
+    pendingCanvasId: pending?.canvasId,
+    pendingCanvasName: pending?.name,
+    onCanvasCreated: (createdCanvasId, createdName) => {
+      args.pendingDuplicateCanvases.set(app.id!, {
+        canvasId: createdCanvasId,
+        name: createdName,
+      });
+      args.sessionDuplicateNames.add(createdName);
+    },
+  });
+  args.pendingDuplicateCanvases.delete(app.id);
+  args.invalidateFactoryApps();
+  args.queryClient.removeQueries({ queryKey: canvasKeys.detail(args.organizationId, canvasId) });
+  showSuccessToast("Automation duplicated.");
+  args.navigate(factoryAppConfigurePath(args.organizationId, args.factoryKey, canvasId, { from: "automations" }));
+}
 
 export function useAutomationCardMutations(args: {
   organizationId: string;
@@ -25,8 +96,8 @@ export function useAutomationCardMutations(args: {
   const createCanvas = useCreateCanvas(organizationId);
   const deleteCanvas = useDeleteCanvas(organizationId);
   const [isDuplicating, setIsDuplicating] = useState(false);
-  // Reuse a canvas created on a failed stage/commit so retry does not spawn empties.
-  const pendingDuplicateCanvasIds = useRef(new Map<string, string>());
+  const pendingDuplicateCanvases = useRef(new Map<string, PendingDuplicateCanvas>());
+  const sessionDuplicateNames = useRef(new Set<string>());
 
   const invalidateFactoryApps = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: factoryAppsKey(organizationId, factoryId) });
@@ -49,20 +120,18 @@ export function useAutomationCardMutations(args: {
       }
       setIsDuplicating(true);
       try {
-        const canvasId = await duplicateAutomationCanvas({
-          factoryId,
+        await runDuplicateAutomation({
           app,
+          factoryId,
+          factoryKey,
+          organizationId,
           createCanvas: createCanvas.mutateAsync,
-          pendingCanvasId: pendingDuplicateCanvasIds.current.get(app.id),
-          onCanvasCreated: (createdCanvasId) => {
-            pendingDuplicateCanvasIds.current.set(app.id!, createdCanvasId);
-          },
+          queryClient,
+          pendingDuplicateCanvases: pendingDuplicateCanvases.current,
+          sessionDuplicateNames: sessionDuplicateNames.current,
+          invalidateFactoryApps,
+          navigate,
         });
-        pendingDuplicateCanvasIds.current.delete(app.id);
-        invalidateFactoryApps();
-        queryClient.removeQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
-        showSuccessToast("Automation duplicated.");
-        navigate(factoryAppConfigurePath(organizationId, factoryKey, canvasId, { from: "automations" }));
       } catch (error) {
         showErrorToast(getUsageLimitToastMessage(error, "Failed to duplicate automation"));
       } finally {

--- a/web_src/src/pages/factories/pages/useAutomationCardMutations.ts
+++ b/web_src/src/pages/factories/pages/useAutomationCardMutations.ts
@@ -1,13 +1,14 @@
 import type { FactoryApp } from "@/api-client";
-import { useCreateCanvas, useDeleteCanvas } from "@/hooks/useCanvasData";
+import { canvasKeys, useCreateCanvas, useDeleteCanvas } from "@/hooks/useCanvasData";
 import { factoryAppsKey } from "@/hooks/useFactoryData";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate } from "react-router";
 import { automationsPath, factoryAppConfigurePath } from "../lib/factoryPagePaths";
-import { duplicateAutomationName, type AutomationCardActions } from "./automationCardActions";
+import type { AutomationCardActions } from "./automationCardActions";
+import { duplicateAutomationCanvas } from "./duplicateAutomationCanvas";
 
 export function useAutomationCardMutations(args: {
   organizationId: string;
@@ -22,6 +23,7 @@ export function useAutomationCardMutations(args: {
   const queryClient = useQueryClient();
   const createCanvas = useCreateCanvas(organizationId);
   const deleteCanvas = useDeleteCanvas(organizationId);
+  const [isDuplicating, setIsDuplicating] = useState(false);
 
   const invalidateFactoryApps = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: factoryAppsKey(organizationId, factoryId) });
@@ -39,25 +41,27 @@ export function useAutomationCardMutations(args: {
 
   const handleDuplicateAutomation = useCallback(
     async (app: FactoryApp) => {
+      if (isDuplicating) {
+        return;
+      }
+      setIsDuplicating(true);
       try {
-        const result = await createCanvas.mutateAsync({
-          name: duplicateAutomationName(app.name),
-          description: app.description ?? "",
+        const canvasId = await duplicateAutomationCanvas({
           factoryId,
-          method: "ui",
+          app,
+          createCanvas: createCanvas.mutateAsync,
         });
-        const canvasId = result?.data?.canvas?.metadata?.id;
         invalidateFactoryApps();
-        if (!canvasId) {
-          return;
-        }
+        queryClient.removeQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
         showSuccessToast("Automation duplicated.");
         navigate(factoryAppConfigurePath(organizationId, factoryId, canvasId, { from: "automations" }));
       } catch (error) {
         showErrorToast(getUsageLimitToastMessage(error, "Failed to duplicate automation"));
+      } finally {
+        setIsDuplicating(false);
       }
     },
-    [createCanvas, factoryId, invalidateFactoryApps, navigate, organizationId],
+    [createCanvas.mutateAsync, factoryId, invalidateFactoryApps, isDuplicating, navigate, organizationId, queryClient],
   );
 
   const handleDeleteAutomation = useCallback(
@@ -88,19 +92,19 @@ export function useAutomationCardMutations(args: {
       canEdit: canUpdateApp,
       canDuplicate: canCreateApp,
       canDelete: canDeleteApp,
-      isDuplicating: createCanvas.isPending,
+      isDuplicating,
       isDeleting: deleteCanvas.isPending && deleteCanvas.variables === app.id,
     }),
     [
       canCreateApp,
       canDeleteApp,
       canUpdateApp,
-      createCanvas.isPending,
       deleteCanvas.isPending,
       deleteCanvas.variables,
       handleDeleteAutomation,
       handleDuplicateAutomation,
       handleEditAutomation,
+      isDuplicating,
     ],
   );
 

--- a/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
@@ -1,3 +1,4 @@
+import { usePermissions } from "@/contexts/usePermissions";
 import { useCanvas } from "@/hooks/useCanvasData";
 import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import type { FactoryConfigureActions } from "@/pages/app";
@@ -8,14 +9,21 @@ import { resolveFactoryAppBackNav } from "../lib/factoryAppNav";
 import {
   isFactoryAppConfigureMode,
   resolveFactoryAppCanvasSubtitle,
-  resolveFactoryAppCanvasTitle,
   resolveFactoryLineName,
 } from "../lib/factoryAppCanvasCopy";
 import { shouldRedirectFactoryAppCanvas } from "../lib/factoryAppCanvasRedirect";
 import { resolveWorkOrderByNumber } from "../lib/workOrderNumberResolution";
+import { useFactoryAppConfigureTitle } from "./useFactoryAppConfigureTitle";
 
 function readFactoryAppOrderRef(searchParams: URLSearchParams): string | null {
   return searchParams.get("orderNumber") ?? searchParams.get("orderId");
+}
+
+function resolveCanRenameAutomation(
+  permissionsLoading: boolean,
+  canAct: (resource: string, action: string) => boolean,
+) {
+  return permissionsLoading || canAct("canvases", "update");
 }
 
 export function useFactoryAppCanvasPageModel() {
@@ -23,6 +31,7 @@ export function useFactoryAppCanvasPageModel() {
   const { appId = "" } = useParams<{ appId: string }>();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
   const configureActionsRef = useRef<FactoryConfigureActions | null>(null);
   const [configureBusy, setConfigureBusy] = useState(false);
 
@@ -33,12 +42,30 @@ export function useFactoryAppCanvasPageModel() {
   } = useCanvas(organizationId, appId, {
     enabled: Boolean(appId),
   });
-
+  const canRename = resolveCanRenameAutomation(permissionsLoading, canAct);
   const from = searchParams.get("from");
   const lineId = searchParams.get("lineId");
   const orderNumber = readFactoryAppOrderRef(searchParams);
   const isConfigure = isFactoryAppConfigureMode(searchParams);
   const lineName = useMemo(() => resolveFactoryLineName(factory?.lines, lineId), [factory?.lines, lineId]);
+
+  const {
+    title,
+    configureBusy: titleConfigureBusy,
+    handleDraftTitleChange,
+    handleConfigureSave,
+    handleConfigureDiscard,
+    clearDraftTitle,
+  } = useFactoryAppConfigureTitle({
+    organizationId,
+    factoryId,
+    appId,
+    isConfigure,
+    canRename,
+    savedName: canvas?.metadata?.name,
+    configureBusy,
+    configureActionsRef,
+  });
 
   // Reads the already-fetched work orders list (same query the sidebar's
   // "recent orders" section uses) rather than fetching this one order by id,
@@ -64,21 +91,27 @@ export function useFactoryAppCanvasPageModel() {
   );
 
   const handleConfigureDone = useCallback(() => {
+    clearDraftTitle();
     navigate(back.href);
-  }, [back.href, navigate]);
+  }, [back.href, clearDraftTitle, navigate]);
 
   const handleConfigureBusyChange = useCallback((busy: boolean) => {
     setConfigureBusy(busy);
   }, []);
 
-  const canvasFactoryId = canvas?.metadata?.factoryId;
-  const belongsToFactory = canvasFactoryId === factoryId;
+  const belongsToFactory = canvas?.metadata?.factoryId === factoryId;
   const shouldRedirect = shouldRedirectFactoryAppCanvas({
     appId,
     canvasLoading,
     canvasError,
     belongsToFactory,
     hasCanvas: Boolean(canvas),
+  });
+
+  const subtitle = resolveFactoryAppCanvasSubtitle({
+    isConfigure,
+    description: canvas?.metadata?.description?.trim(),
+    factoryName: factory?.name,
   });
 
   return {
@@ -89,16 +122,16 @@ export function useFactoryAppCanvasPageModel() {
     canvas,
     canvasLoading,
     isConfigure,
-    configureBusy,
+    configureBusy: titleConfigureBusy,
     configureActionsRef,
     back,
-    title: resolveFactoryAppCanvasTitle(canvas?.metadata?.name),
-    subtitle: resolveFactoryAppCanvasSubtitle({
-      isConfigure,
-      description: canvas?.metadata?.description?.trim(),
-      factoryName: factory?.name,
-    }),
+    title,
+    subtitle,
     shouldRedirect,
+    canRename,
+    handleDraftTitleChange,
+    handleConfigureSave,
+    handleConfigureDiscard,
     handleConfigureDone,
     handleConfigureBusyChange,
   };

--- a/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
@@ -23,7 +23,7 @@ function resolveCanRenameAutomation(
   permissionsLoading: boolean,
   canAct: (resource: string, action: string) => boolean,
 ) {
-  return permissionsLoading || canAct("canvases", "update");
+  return !permissionsLoading && canAct("canvases", "update");
 }
 
 export function useFactoryAppCanvasPageModel() {

--- a/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppCanvasPageModel.ts
@@ -49,24 +49,6 @@ export function useFactoryAppCanvasPageModel() {
   const isConfigure = isFactoryAppConfigureMode(searchParams);
   const lineName = useMemo(() => resolveFactoryLineName(factory?.lines, lineId), [factory?.lines, lineId]);
 
-  const {
-    title,
-    configureBusy: titleConfigureBusy,
-    handleDraftTitleChange,
-    handleConfigureSave,
-    handleConfigureDiscard,
-    clearDraftTitle,
-  } = useFactoryAppConfigureTitle({
-    organizationId,
-    factoryId,
-    appId,
-    isConfigure,
-    canRename,
-    savedName: canvas?.metadata?.name,
-    configureBusy,
-    configureActionsRef,
-  });
-
   // Reads the already-fetched work orders list (same query the sidebar's
   // "recent orders" section uses) rather than fetching this one order by id,
   // since all we need here is its title for the back-link label.
@@ -90,10 +72,33 @@ export function useFactoryAppCanvasPageModel() {
     [appId, canvas?.metadata?.name, factoryKey, from, lineId, lineName, order?.title, organizationId, orderNumber],
   );
 
+  const navigateDone = useCallback(() => {
+    navigate(back.href);
+  }, [back.href, navigate]);
+
+  const {
+    title,
+    configureBusy: titleConfigureBusy,
+    handleDraftTitleChange,
+    handleConfigureSave,
+    handleConfigureDiscard,
+    clearDraftTitle,
+  } = useFactoryAppConfigureTitle({
+    organizationId,
+    factoryId,
+    appId,
+    isConfigure,
+    canRename,
+    savedName: canvas?.metadata?.name,
+    configureBusy,
+    configureActionsRef,
+    onDone: navigateDone,
+  });
+
   const handleConfigureDone = useCallback(() => {
     clearDraftTitle();
-    navigate(back.href);
-  }, [back.href, clearDraftTitle, navigate]);
+    navigateDone();
+  }, [clearDraftTitle, navigateDone]);
 
   const handleConfigureBusyChange = useCallback((busy: boolean) => {
     setConfigureBusy(busy);

--- a/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.spec.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDraftTitleToPersist } from "./useFactoryAppConfigureTitle";
+
+describe("resolveDraftTitleToPersist", () => {
+  it("returns null when the draft matches the saved title", () => {
+    expect(resolveDraftTitleToPersist("Same", "Same")).toBeNull();
+    expect(resolveDraftTitleToPersist(null, "Same")).toBeNull();
+  });
+
+  it("returns the trimmed draft when it differs", () => {
+    expect(resolveDraftTitleToPersist("  New name  ", "Old")).toBe("New name");
+  });
+});

--- a/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.ts
@@ -110,7 +110,8 @@ export function useFactoryAppConfigureTitle(args: UseFactoryAppConfigureTitleArg
         // Always stage through Configure Save. Trusting hasUncommittedChanges alone
         // can skip real graph edits while staging baselines are still loading.
         // Empty staging (no YAML diff) finishes cleanly inside runFactoryConfigureSave.
-        actions.save({ canvasName: persistedName ?? undefined });
+        // Await so savingRef stays locked until stage/commit finishes.
+        await actions.save({ canvasName: persistedName ?? undefined });
       } finally {
         savingRef.current = false;
       }

--- a/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.ts
@@ -16,68 +16,103 @@ type UseFactoryAppConfigureTitleArgs = {
   savedName?: string;
   configureBusy: boolean;
   configureActionsRef: MutableRefObject<FactoryConfigureActions | null>;
+  onDone: () => void;
 };
 
+export function resolveDraftTitleToPersist(draftTitle: string | null, savedTitle: string): string | null {
+  const nextName = (draftTitle ?? savedTitle).trim();
+  if (!nextName || nextName === savedTitle.trim()) {
+    return null;
+  }
+  return nextName;
+}
+
 export function useFactoryAppConfigureTitle(args: UseFactoryAppConfigureTitleArgs) {
-  const { organizationId, factoryId, appId, isConfigure, canRename, savedName, configureBusy, configureActionsRef } =
-    args;
+  const {
+    organizationId,
+    factoryId,
+    appId,
+    isConfigure,
+    canRename,
+    savedName,
+    configureBusy,
+    configureActionsRef,
+    onDone,
+  } = args;
   const queryClient = useQueryClient();
   const updateCanvas = useUpdateCanvas(organizationId, appId);
   const [draftTitle, setDraftTitle] = useState<string | null>(null);
-  const renamingRef = useRef(false);
+  const draftTitleRef = useRef<string | null>(null);
+  const savingRef = useRef(false);
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
 
   const savedTitle = resolveFactoryAppCanvasTitle(savedName);
   const title = isConfigure && draftTitle != null ? draftTitle : savedTitle;
-  const busy = configureBusy || updateCanvas.isPending || renamingRef.current;
 
   useEffect(() => {
     if (!isConfigure) {
+      draftTitleRef.current = null;
       setDraftTitle(null);
     }
   }, [isConfigure]);
 
   const clearDraftTitle = useCallback(() => {
+    draftTitleRef.current = null;
     setDraftTitle(null);
   }, []);
 
   const handleDraftTitleChange = useCallback((name: string) => {
+    draftTitleRef.current = name;
     setDraftTitle(name);
   }, []);
 
-  const persistDraftTitleIfNeeded = useCallback(async () => {
-    const nextName = (draftTitle ?? savedTitle).trim();
-    if (!nextName || nextName === savedTitle.trim()) {
-      return true;
+  const persistDraftTitleIfNeeded = useCallback(async (): Promise<string | null> => {
+    const nextName = resolveDraftTitleToPersist(draftTitleRef.current, savedTitle);
+    if (!nextName) {
+      return null;
     }
     if (!canRename) {
       showErrorToast("You don't have permission to rename this automation.");
-      return false;
+      throw new Error("rename not allowed");
     }
-    try {
-      await updateCanvas.mutateAsync({ name: nextName });
-      void queryClient.invalidateQueries({ queryKey: factoryAppsKey(organizationId, factoryId) });
-      setDraftTitle(null);
-      return true;
-    } catch (error) {
-      showErrorToast(getApiErrorMessage(error, "Failed to rename automation"));
-      return false;
-    }
-  }, [canRename, draftTitle, factoryId, organizationId, queryClient, savedTitle, updateCanvas]);
+    await updateCanvas.mutateAsync({ name: nextName });
+    void queryClient.invalidateQueries({ queryKey: factoryAppsKey(organizationId, factoryId) });
+    draftTitleRef.current = null;
+    setDraftTitle(null);
+    return nextName;
+  }, [canRename, factoryId, organizationId, queryClient, savedTitle, updateCanvas]);
 
   const handleConfigureSave = useCallback(() => {
-    if (configureBusy || updateCanvas.isPending) {
+    if (configureBusy || updateCanvas.isPending || savingRef.current) {
       return;
     }
-    renamingRef.current = true;
+    savingRef.current = true;
     void (async () => {
       try {
-        const renamed = await persistDraftTitleIfNeeded();
-        if (!renamed) {
+        let persistedName: string | null = null;
+        try {
+          persistedName = await persistDraftTitleIfNeeded();
+        } catch (error) {
+          if (error instanceof Error && error.message === "rename not allowed") {
+            return;
+          }
+          showErrorToast(getApiErrorMessage(error, "Failed to rename automation"));
           return;
         }
-        configureActionsRef.current?.save();
+
+        const actions = configureActionsRef.current;
+        const hasGraphChanges = Boolean(actions?.hasUncommittedChanges);
+        if (hasGraphChanges) {
+          // Pass the new name so canvas.yaml metadata matches the renamed record.
+          actions?.save({ canvasName: persistedName ?? undefined });
+          return;
+        }
+
+        // Title-only (or no-op) Save: skip stage/commit — empty staging fails commit.
+        onDoneRef.current();
       } finally {
-        renamingRef.current = false;
+        savingRef.current = false;
       }
     })();
   }, [configureActionsRef, configureBusy, persistDraftTitleIfNeeded, updateCanvas.isPending]);
@@ -92,7 +127,7 @@ export function useFactoryAppConfigureTitle(args: UseFactoryAppConfigureTitleArg
 
   return {
     title,
-    configureBusy: busy || updateCanvas.isPending,
+    configureBusy: configureBusy || updateCanvas.isPending,
     handleDraftTitleChange,
     handleConfigureSave,
     handleConfigureDiscard,

--- a/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.ts
@@ -102,15 +102,15 @@ export function useFactoryAppConfigureTitle(args: UseFactoryAppConfigureTitleArg
         }
 
         const actions = configureActionsRef.current;
-        const hasGraphChanges = Boolean(actions?.hasUncommittedChanges);
-        if (hasGraphChanges) {
-          // Pass the new name so canvas.yaml metadata matches the renamed record.
-          actions?.save({ canvasName: persistedName ?? undefined });
+        if (!actions) {
+          onDoneRef.current();
           return;
         }
 
-        // Title-only (or no-op) Save: skip stage/commit — empty staging fails commit.
-        onDoneRef.current();
+        // Always stage through Configure Save. Trusting hasUncommittedChanges alone
+        // can skip real graph edits while staging baselines are still loading.
+        // Empty staging (no YAML diff) finishes cleanly inside runFactoryConfigureSave.
+        actions.save({ canvasName: persistedName ?? undefined });
       } finally {
         savingRef.current = false;
       }
@@ -121,9 +121,9 @@ export function useFactoryAppConfigureTitle(args: UseFactoryAppConfigureTitleArg
     if (configureBusy || updateCanvas.isPending) {
       return;
     }
-    setDraftTitle(null);
+    clearDraftTitle();
     configureActionsRef.current?.discard();
-  }, [configureActionsRef, configureBusy, updateCanvas.isPending]);
+  }, [clearDraftTitle, configureActionsRef, configureBusy, updateCanvas.isPending]);
 
   return {
     title,

--- a/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.ts
+++ b/web_src/src/pages/factories/pages/useFactoryAppConfigureTitle.ts
@@ -1,0 +1,101 @@
+import { useUpdateCanvas } from "@/hooks/useCanvasData";
+import { factoryAppsKey } from "@/hooks/useFactoryData";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast } from "@/lib/toast";
+import type { FactoryConfigureActions } from "@/pages/app";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
+import { resolveFactoryAppCanvasTitle } from "../lib/factoryAppCanvasCopy";
+
+type UseFactoryAppConfigureTitleArgs = {
+  organizationId: string;
+  factoryId: string;
+  appId: string;
+  isConfigure: boolean;
+  canRename: boolean;
+  savedName?: string;
+  configureBusy: boolean;
+  configureActionsRef: MutableRefObject<FactoryConfigureActions | null>;
+};
+
+export function useFactoryAppConfigureTitle(args: UseFactoryAppConfigureTitleArgs) {
+  const { organizationId, factoryId, appId, isConfigure, canRename, savedName, configureBusy, configureActionsRef } =
+    args;
+  const queryClient = useQueryClient();
+  const updateCanvas = useUpdateCanvas(organizationId, appId);
+  const [draftTitle, setDraftTitle] = useState<string | null>(null);
+  const renamingRef = useRef(false);
+
+  const savedTitle = resolveFactoryAppCanvasTitle(savedName);
+  const title = isConfigure && draftTitle != null ? draftTitle : savedTitle;
+  const busy = configureBusy || updateCanvas.isPending || renamingRef.current;
+
+  useEffect(() => {
+    if (!isConfigure) {
+      setDraftTitle(null);
+    }
+  }, [isConfigure]);
+
+  const clearDraftTitle = useCallback(() => {
+    setDraftTitle(null);
+  }, []);
+
+  const handleDraftTitleChange = useCallback((name: string) => {
+    setDraftTitle(name);
+  }, []);
+
+  const persistDraftTitleIfNeeded = useCallback(async () => {
+    const nextName = (draftTitle ?? savedTitle).trim();
+    if (!nextName || nextName === savedTitle.trim()) {
+      return true;
+    }
+    if (!canRename) {
+      showErrorToast("You don't have permission to rename this automation.");
+      return false;
+    }
+    try {
+      await updateCanvas.mutateAsync({ name: nextName });
+      void queryClient.invalidateQueries({ queryKey: factoryAppsKey(organizationId, factoryId) });
+      setDraftTitle(null);
+      return true;
+    } catch (error) {
+      showErrorToast(getApiErrorMessage(error, "Failed to rename automation"));
+      return false;
+    }
+  }, [canRename, draftTitle, factoryId, organizationId, queryClient, savedTitle, updateCanvas]);
+
+  const handleConfigureSave = useCallback(() => {
+    if (configureBusy || updateCanvas.isPending) {
+      return;
+    }
+    renamingRef.current = true;
+    void (async () => {
+      try {
+        const renamed = await persistDraftTitleIfNeeded();
+        if (!renamed) {
+          return;
+        }
+        configureActionsRef.current?.save();
+      } finally {
+        renamingRef.current = false;
+      }
+    })();
+  }, [configureActionsRef, configureBusy, persistDraftTitleIfNeeded, updateCanvas.isPending]);
+
+  const handleConfigureDiscard = useCallback(() => {
+    if (configureBusy || updateCanvas.isPending) {
+      return;
+    }
+    setDraftTitle(null);
+    configureActionsRef.current?.discard();
+  }, [configureActionsRef, configureBusy, updateCanvas.isPending]);
+
+  return {
+    title,
+    configureBusy: busy || updateCanvas.isPending,
+    handleDraftTitleChange,
+    handleConfigureSave,
+    handleConfigureDiscard,
+    clearDraftTitle,
+  };
+}


### PR DESCRIPTION
## Summary

Automations Duplicate created an empty canvas. That left users with no cloned nodes or edges.

This change clones the source live graph on the client. It creates the canvas, then stages and commits `canvas.yaml`, using the same pattern as factory template install.

Secrets, integration credentials, git remotes, and run history are not copied.

## Test plan

- [ ] Open Automations, duplicate an automation that has nodes and edges
- [ ] Confirm the new canvas opens in Configure with the same graph and factory
- [ ] Duplicate an empty automation and confirm create still succeeds
- [ ] `npx vitest run src/pages/factories/pages/duplicateAutomationCanvas.spec.ts`


Made with [Cursor](https://cursor.com)