### PR TITLE
feat: Live-update Factory Line and Automations

### DIFF
--- a/pkg/grpc/actions/canvases/create_canvas.go
+++ b/pkg/grpc/actions/canvases/create_canvas.go
@@ -218,6 +218,11 @@ func CreateCanvasWithSeedFiles(
 	if publishErr := messages.NewCanvasCreatedMessage(canvas.ID.String(), canvas.OrganizationID.String()).PublishCreated(); publishErr != nil {
 		log.Errorf("failed to publish canvas created RabbitMQ message: %v", publishErr)
 	}
+	if canvas.FactoryID != nil {
+		if publishErr := messages.PublishFactoryAppUpdated(canvas.FactoryID.String(), canvas.ID.String(), "app.created"); publishErr != nil {
+			log.Errorf("failed to publish factory app updated RabbitMQ message: %v", publishErr)
+		}
+	}
 
 	var user *models.User
 	if canvas.CreatedBy != nil {

--- a/pkg/grpc/actions/canvases/delete_canvas.go
+++ b/pkg/grpc/actions/canvases/delete_canvas.go
@@ -23,6 +23,11 @@ func DeleteCanvas(ctx context.Context, db *gorm.DB, canvas *models.Canvas) (*pb.
 	if err := messages.NewCanvasDeletedMessage(canvas.ID.String(), canvas.OrganizationID.String()).PublishDeleted(); err != nil {
 		log.Errorf("failed to publish canvas deleted RabbitMQ message: %v", err)
 	}
+	if canvas.FactoryID != nil {
+		if publishErr := messages.PublishFactoryAppUpdated(canvas.FactoryID.String(), canvas.ID.String(), "app.deleted"); publishErr != nil {
+			log.Errorf("failed to publish factory app updated RabbitMQ message: %v", publishErr)
+		}
+	}
 
 	return &pb.DeleteCanvasResponse{}, nil
 }

--- a/pkg/grpc/actions/canvases/update_canvas.go
+++ b/pkg/grpc/actions/canvases/update_canvas.go
@@ -38,6 +38,11 @@ func UpdateCanvas(
 	if publishErr := messages.NewCanvasUpdatedMessage(canvas.ID.String(), canvas.OrganizationID.String()).PublishUpdated(); publishErr != nil {
 		log.Errorf("failed to publish canvas updated RabbitMQ message: %v", publishErr)
 	}
+	if canvas.FactoryID != nil {
+		if publishErr := messages.PublishFactoryAppUpdated(canvas.FactoryID.String(), canvas.ID.String(), "app.updated"); publishErr != nil {
+			log.Errorf("failed to publish factory app updated RabbitMQ message: %v", publishErr)
+		}
+	}
 
 	refreshedCanvas, err := models.FindCanvasInTransaction(db, canvas.OrganizationID, canvas.ID)
 	if err != nil {

--- a/pkg/grpc/actions/factories/create_factory_line.go
+++ b/pkg/grpc/actions/factories/create_factory_line.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
@@ -39,6 +41,10 @@ func CreateFactoryLine(ctx context.Context, organizationID string, req *pb.Creat
 	line, err := factory.CreateLine(db, name, steps)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory line")
+	}
+
+	if publishErr := messages.PublishFactoryUpdated(factory.ID.String(), "line.created"); publishErr != nil {
+		log.Errorf("failed to publish factory updated RabbitMQ message: %v", publishErr)
 	}
 
 	return &pb.CreateFactoryLineResponse{

--- a/pkg/grpc/actions/factories/update_factory.go
+++ b/pkg/grpc/actions/factories/update_factory.go
@@ -3,7 +3,9 @@ package factories
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
@@ -27,6 +29,10 @@ func UpdateFactory(ctx context.Context, organizationID string, req *pb.UpdateFac
 
 	if err := factory.Update(db, req.Name, req.Description, req.Key); err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory")
+	}
+
+	if publishErr := messages.PublishFactoryUpdated(factory.ID.String(), "factory.updated"); publishErr != nil {
+		log.Errorf("failed to publish factory updated RabbitMQ message: %v", publishErr)
 	}
 
 	lines, err := factory.ListLines(db)

--- a/pkg/grpc/actions/factories/update_factory_line.go
+++ b/pkg/grpc/actions/factories/update_factory_line.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 )
@@ -59,6 +61,10 @@ func UpdateFactoryLine(ctx context.Context, organizationID string, req *pb.Updat
 
 	if err := line.Update(db, name, steps); err != nil {
 		return nil, factoryErrorToStatus(err, "failed to update factory line")
+	}
+
+	if publishErr := messages.PublishFactoryUpdated(factory.ID.String(), "line.updated"); publishErr != nil {
+		log.Errorf("failed to publish factory updated RabbitMQ message: %v", publishErr)
 	}
 
 	return &pb.UpdateFactoryLineResponse{

--- a/pkg/grpc/actions/messages/factory_lifecycle.go
+++ b/pkg/grpc/actions/messages/factory_lifecycle.go
@@ -1,0 +1,58 @@
+package messages
+
+import (
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	// FactoryAppUpdatedRoutingKey: factory-scoped canvas mutations -> EventDistributer -> websocket clients.
+	FactoryAppUpdatedRoutingKey = "factory-app-updated"
+	// FactoryUpdatedRoutingKey: factory / line mutations -> EventDistributer -> websocket clients.
+	FactoryUpdatedRoutingKey = "factory-updated"
+)
+
+type FactoryAppUpdatedMessage struct {
+	message *pb.FactoryAppUpdatedMessage
+}
+
+func NewFactoryAppUpdatedMessage(factoryID, appID, reason string) FactoryAppUpdatedMessage {
+	return FactoryAppUpdatedMessage{
+		message: &pb.FactoryAppUpdatedMessage{
+			FactoryId: factoryID,
+			AppId:     appID,
+			Reason:    reason,
+			Timestamp: timestamppb.Now(),
+		},
+	}
+}
+
+func (m FactoryAppUpdatedMessage) Publish() error {
+	return Publish(CanvasExchange, FactoryAppUpdatedRoutingKey, toBytes(m.message))
+}
+
+func PublishFactoryAppUpdated(factoryID, appID, reason string) error {
+	return NewFactoryAppUpdatedMessage(factoryID, appID, reason).Publish()
+}
+
+type FactoryUpdatedMessage struct {
+	message *pb.FactoryUpdatedMessage
+}
+
+func NewFactoryUpdatedMessage(factoryID, reason string) FactoryUpdatedMessage {
+	return FactoryUpdatedMessage{
+		message: &pb.FactoryUpdatedMessage{
+			FactoryId: factoryID,
+			Reason:    reason,
+			Timestamp: timestamppb.Now(),
+		},
+	}
+}
+
+func (m FactoryUpdatedMessage) Publish() error {
+	return Publish(CanvasExchange, FactoryUpdatedRoutingKey, toBytes(m.message))
+}
+
+func PublishFactoryUpdated(factoryID, reason string) error {
+	return NewFactoryUpdatedMessage(factoryID, reason).Publish()
+}

--- a/pkg/workers/event_distributer.go
+++ b/pkg/workers/event_distributer.go
@@ -63,6 +63,8 @@ func (e *EventDistributer) Start() error {
 		{messages.CanvasExchange, messages.CanvasMemoryUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasMemoryUpdated)},
 		{messages.CanvasExchange, messages.AgentSessionEventRoutingKey, e.createHandler(eventdistributer.HandleAgentSessionEvent)},
 		{messages.CanvasExchange, messages.FactoryWorkOrderUpdatedRoutingKey, e.createHandler(eventdistributer.HandleFactoryWorkOrderUpdated)},
+		{messages.CanvasExchange, messages.FactoryAppUpdatedRoutingKey, e.createHandler(eventdistributer.HandleFactoryAppUpdated)},
+		{messages.CanvasExchange, messages.FactoryUpdatedRoutingKey, e.createHandler(eventdistributer.HandleFactoryUpdated)},
 	}
 
 	for _, routingKey := range messages.ExecutionRoutingKeys {

--- a/pkg/workers/eventdistributer/factory_lifecycle.go
+++ b/pkg/workers/eventdistributer/factory_lifecycle.go
@@ -1,0 +1,100 @@
+package eventdistributer
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/pkg/public/ws"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	FactoryAppUpdatedEvent = "factory_app_updated"
+	FactoryUpdatedEvent    = "factory_updated"
+)
+
+type factoryAppUpdatedPayload struct {
+	FactoryID string `json:"factoryId"`
+	AppID     string `json:"appId,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type factoryAppWebsocketEvent struct {
+	Event   string                   `json:"event"`
+	Payload factoryAppUpdatedPayload `json:"payload"`
+}
+
+type factoryUpdatedPayload struct {
+	FactoryID string `json:"factoryId"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type factoryUpdatedWebsocketEvent struct {
+	Event   string                `json:"event"`
+	Payload factoryUpdatedPayload `json:"payload"`
+}
+
+func HandleFactoryAppUpdated(messageBody []byte, wsHub *ws.Hub) error {
+	pbMsg := &pb.FactoryAppUpdatedMessage{}
+	if err := proto.Unmarshal(messageBody, pbMsg); err != nil {
+		return fmt.Errorf("failed to unmarshal factory app updated: %w", err)
+	}
+
+	return BroadcastFactoryAppUpdated(wsHub, pbMsg)
+}
+
+func BroadcastFactoryAppUpdated(wsHub *ws.Hub, msg *pb.FactoryAppUpdatedMessage) error {
+	if msg == nil || msg.FactoryId == "" {
+		return fmt.Errorf("missing factoryId in factory app updated")
+	}
+
+	payload, err := json.Marshal(factoryAppWebsocketEvent{
+		Event: FactoryAppUpdatedEvent,
+		Payload: factoryAppUpdatedPayload{
+			FactoryID: msg.FactoryId,
+			AppID:     msg.AppId,
+			Reason:    msg.Reason,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal factory app websocket event: %w", err)
+	}
+
+	topic := FactoryWebsocketTopic(msg.FactoryId)
+	wsHub.BroadcastToWorkflow(topic, payload)
+	log.Debugf("Broadcasted factory_app_updated to factory %s (app %s, reason %s)", msg.FactoryId, msg.AppId, msg.Reason)
+	return nil
+}
+
+func HandleFactoryUpdated(messageBody []byte, wsHub *ws.Hub) error {
+	pbMsg := &pb.FactoryUpdatedMessage{}
+	if err := proto.Unmarshal(messageBody, pbMsg); err != nil {
+		return fmt.Errorf("failed to unmarshal factory updated: %w", err)
+	}
+
+	return BroadcastFactoryUpdated(wsHub, pbMsg)
+}
+
+func BroadcastFactoryUpdated(wsHub *ws.Hub, msg *pb.FactoryUpdatedMessage) error {
+	if msg == nil || msg.FactoryId == "" {
+		return fmt.Errorf("missing factoryId in factory updated")
+	}
+
+	payload, err := json.Marshal(factoryUpdatedWebsocketEvent{
+		Event: FactoryUpdatedEvent,
+		Payload: factoryUpdatedPayload{
+			FactoryID: msg.FactoryId,
+			Reason:    msg.Reason,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal factory updated websocket event: %w", err)
+	}
+
+	topic := FactoryWebsocketTopic(msg.FactoryId)
+	wsHub.BroadcastToWorkflow(topic, payload)
+	log.Debugf("Broadcasted factory_updated to factory %s (reason %s)", msg.FactoryId, msg.Reason)
+	return nil
+}

--- a/pkg/workers/eventdistributer/factory_lifecycle_test.go
+++ b/pkg/workers/eventdistributer/factory_lifecycle_test.go
@@ -1,0 +1,127 @@
+package eventdistributer_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/pkg/public/ws"
+	"github.com/superplanehq/superplane/pkg/workers/eventdistributer"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHandleFactoryAppUpdated_BroadcastsToTopicSubscribers(t *testing.T) {
+	hub := ws.NewHub()
+	hub.Run()
+
+	factoryID := "11111111-1111-1111-1111-111111111111"
+	appID := "33333333-3333-3333-3333-333333333333"
+	topic := eventdistributer.FactoryWebsocketTopic(factoryID)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+		hub.NewClient(conn, topic)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	wsURL := "ws://" + u.Host
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.Eventually(t, func() bool {
+		return hub.WorkflowSubscriberCount(topic) == 1
+	}, 2*time.Second, 5*time.Millisecond, "subscriber never registered on hub")
+
+	payload, err := proto.Marshal(&pb.FactoryAppUpdatedMessage{
+		FactoryId: factoryID,
+		AppId:     appID,
+		Reason:    "app.created",
+	})
+	require.NoError(t, err)
+	require.NoError(t, eventdistributer.HandleFactoryAppUpdated(payload, hub))
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	var got struct {
+		Event   string `json:"event"`
+		Payload struct {
+			FactoryID string `json:"factoryId"`
+			AppID     string `json:"appId"`
+			Reason    string `json:"reason"`
+		} `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, eventdistributer.FactoryAppUpdatedEvent, got.Event)
+	require.Equal(t, factoryID, got.Payload.FactoryID)
+	require.Equal(t, appID, got.Payload.AppID)
+	require.Equal(t, "app.created", got.Payload.Reason)
+}
+
+func TestHandleFactoryUpdated_BroadcastsToTopicSubscribers(t *testing.T) {
+	hub := ws.NewHub()
+	hub.Run()
+
+	factoryID := "11111111-1111-1111-1111-111111111111"
+	topic := eventdistributer.FactoryWebsocketTopic(factoryID)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+		hub.NewClient(conn, topic)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	wsURL := "ws://" + u.Host
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.Eventually(t, func() bool {
+		return hub.WorkflowSubscriberCount(topic) == 1
+	}, 2*time.Second, 5*time.Millisecond, "subscriber never registered on hub")
+
+	payload, err := proto.Marshal(&pb.FactoryUpdatedMessage{
+		FactoryId: factoryID,
+		Reason:    "line.updated",
+	})
+	require.NoError(t, err)
+	require.NoError(t, eventdistributer.HandleFactoryUpdated(payload, hub))
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	var got struct {
+		Event   string `json:"event"`
+		Payload struct {
+			FactoryID string `json:"factoryId"`
+			Reason    string `json:"reason"`
+		} `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, eventdistributer.FactoryUpdatedEvent, got.Event)
+	require.Equal(t, factoryID, got.Payload.FactoryID)
+	require.Equal(t, "line.updated", got.Payload.Reason)
+}

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -647,3 +647,18 @@ message FactoryWorkOrderUpdatedMessage {
   string reason = 3;
   google.protobuf.Timestamp timestamp = 4;
 }
+
+// Internal AMQP message for factory app (canvas) websocket fan-out.
+message FactoryAppUpdatedMessage {
+  string factory_id = 1;
+  string app_id = 2;
+  string reason = 3;
+  google.protobuf.Timestamp timestamp = 4;
+}
+
+// Internal AMQP message for factory / line websocket fan-out.
+message FactoryUpdatedMessage {
+  string factory_id = 1;
+  string reason = 2;
+  google.protobuf.Timestamp timestamp = 3;
+}

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -102,6 +102,8 @@ export function useFactory(organizationId: string, factoryId: string) {
       return response.data.factory;
     },
     enabled: Boolean(organizationId && factoryId),
+    // Live via websocket; remount must refetch instead of serving 5m global stale cache.
+    staleTime: 0,
   });
 }
 
@@ -461,6 +463,8 @@ export function useFactoryApps(organizationId: string, factoryId: string) {
       return response.data?.apps ?? [];
     },
     enabled: Boolean(organizationId && factoryId),
+    // Live via websocket; remount must refetch instead of serving 5m global stale cache.
+    staleTime: 0,
   });
 }
 

--- a/web_src/src/hooks/useFactoryWebsocket.spec.ts
+++ b/web_src/src/hooks/useFactoryWebsocket.spec.ts
@@ -94,6 +94,32 @@ describe("useFactoryWebsocket", () => {
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
+  it("invalidates apps on factory_app_updated", () => {
+    const { invalidateSpy } = renderFactoryWebsocket();
+    invalidateSpy.mockClear();
+    emit({
+      event: "factory_app_updated",
+      payload: { factoryId: "factory-1", appId: "app-1", reason: "app.created" },
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: factoryQueryKeys.apps("org-1", "factory-1"),
+    });
+  });
+
+  it("invalidates factory detail on factory_updated", () => {
+    const { invalidateSpy } = renderFactoryWebsocket();
+    invalidateSpy.mockClear();
+    emit({
+      event: "factory_updated",
+      payload: { factoryId: "factory-1", reason: "line.updated" },
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: factoryQueryKeys.detail("org-1", "factory-1"),
+    });
+  });
+
   it("skips invalidation on the first open and invalidates on reconnect", () => {
     const { invalidateSpy } = renderFactoryWebsocket();
     invalidateSpy.mockClear();
@@ -110,6 +136,12 @@ describe("useFactoryWebsocket", () => {
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: factoryQueryKeys.workOrders("org-1", "factory-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: factoryQueryKeys.apps("org-1", "factory-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: factoryQueryKeys.detail("org-1", "factory-1"),
     });
   });
 });

--- a/web_src/src/hooks/useFactoryWebsocket.ts
+++ b/web_src/src/hooks/useFactoryWebsocket.ts
@@ -5,15 +5,16 @@ import { factoryQueryKeys } from "./useFactoryData";
 
 const SOCKET_SERVER_URL = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws/factories/`;
 
-type FactoryWorkOrderUpdatedPayload = {
+type FactoryWebsocketPayload = {
   factoryId?: string;
   orderId?: string;
+  appId?: string;
   reason?: string;
 };
 
 type FactoryWebsocketMessage = {
   event?: string;
-  payload?: FactoryWorkOrderUpdatedPayload;
+  payload?: FactoryWebsocketPayload;
 };
 
 function parseFactoryEvent(event: MessageEvent<unknown>): FactoryWebsocketMessage | null {
@@ -47,11 +48,31 @@ export function invalidateFactoryWorkOrderQueries(
   });
 }
 
+export function invalidateFactoryAppQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  organizationId: string,
+  factoryId: string,
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: factoryQueryKeys.apps(organizationId, factoryId),
+  });
+}
+
+export function invalidateFactoryDetailQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  organizationId: string,
+  factoryId: string,
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: factoryQueryKeys.detail(organizationId, factoryId),
+  });
+}
+
 export function useFactoryWebsocket(organizationId: string, factoryId: string, enabled = true): void {
   const queryClient = useQueryClient();
   const hasConnectedOnce = useRef(false);
 
-  const invalidate = useCallback(
+  const invalidateWorkOrders = useCallback(
     (orderId?: string) => {
       if (!organizationId || !factoryId) {
         return;
@@ -61,18 +82,45 @@ export function useFactoryWebsocket(organizationId: string, factoryId: string, e
     [queryClient, organizationId, factoryId],
   );
 
+  const invalidateApps = useCallback(() => {
+    if (!organizationId || !factoryId) {
+      return;
+    }
+    invalidateFactoryAppQueries(queryClient, organizationId, factoryId);
+  }, [queryClient, organizationId, factoryId]);
+
+  const invalidateDetail = useCallback(() => {
+    if (!organizationId || !factoryId) {
+      return;
+    }
+    invalidateFactoryDetailQueries(queryClient, organizationId, factoryId);
+  }, [queryClient, organizationId, factoryId]);
+
   const onMessage = useCallback(
     (event: MessageEvent<unknown>) => {
       const data = parseFactoryEvent(event);
-      if (!data || data.event !== "work_order_updated") {
+      if (!data?.event) {
         return;
       }
       if (data.payload?.factoryId && data.payload.factoryId !== factoryId) {
         return;
       }
-      invalidate(data.payload?.orderId);
+
+      switch (data.event) {
+        case "work_order_updated":
+          invalidateWorkOrders(data.payload?.orderId);
+          return;
+        case "factory_app_updated":
+          invalidateApps();
+          return;
+        case "factory_updated":
+          invalidateDetail();
+          return;
+        default:
+          return;
+      }
     },
-    [factoryId, invalidate],
+    [factoryId, invalidateApps, invalidateDetail, invalidateWorkOrders],
   );
 
   const onOpen = useCallback(() => {
@@ -82,8 +130,10 @@ export function useFactoryWebsocket(organizationId: string, factoryId: string, e
     }
 
     // Catch updates missed while disconnected; WS is the only push channel.
-    invalidate();
-  }, [invalidate]);
+    invalidateWorkOrders();
+    invalidateApps();
+    invalidateDetail();
+  }, [invalidateApps, invalidateDetail, invalidateWorkOrders]);
 
   const url = organizationId && factoryId ? `${SOCKET_SERVER_URL}${factoryId}?organization_id=${organizationId}` : null;
 

--- a/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
@@ -38,6 +38,10 @@ vi.mock("@/hooks/useCanvasData", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useCanvasWebsocket", () => ({
+  useCanvasWebsocket: vi.fn(),
+}));
+
 vi.mock("./LineVelocityPanel", () => ({
   LineVelocityPanel: () => <div data-testid="line-velocity-panel">Velocity</div>,
 }));

--- a/web_src/src/pages/factories/pages/automationsPageParts.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { useInfiniteCanvasRuns } from "@/hooks/useCanvasData";
+import { useCanvasWebsocket } from "@/hooks/useCanvasWebsocket";
 import { formatTimeAgo } from "@/lib/date";
 import { cn } from "@/lib/utils";
 import {
@@ -42,6 +43,7 @@ export function AutomationDetail({
   actions: AutomationCardActions;
 }) {
   const canvasId = app.id ?? "";
+  useCanvasWebsocket(canvasId, organizationId);
   const {
     data: runsPages,
     isLoading: runsLoading,


### PR DESCRIPTION
## Summary

Factory websocket updates covered work orders only. Apps list, factory/line detail, and Automations detail runs stayed stale across clients.

This change publishes `factory_app_updated` and `factory_updated` on the factory topic, invalidates those queries on the client, and mounts canvas websocket on Automations detail for live runs.

## Test plan

- [ ] Open Automations in two browsers; create/delete/rename an automation in one; confirm the other list refreshes
- [ ] Edit a line in one browser; confirm the other factory/line detail refreshes
- [ ] Open Automations detail; start a run elsewhere; confirm the runs list updates without reload
- [ ] `npx vitest run src/hooks/useFactoryWebsocket.spec.ts`
- [ ] `make test PKG_TEST_PACKAGES=./pkg/workers/eventdistributer`


Made with [Cursor](https://cursor.com)