### PR TITLE
fix: Improve factory run graph routing

### DIFF
--- a/web_src/src/lib/layout/factoryRunEdgeClassification.ts
+++ b/web_src/src/lib/layout/factoryRunEdgeClassification.ts
@@ -1,0 +1,126 @@
+import type { FactoryRunLayoutEdge, FactoryRunLayoutPosition } from "./factoryRunLeafLayout";
+import {
+  DEFAULT_NODE_HEIGHT,
+  DEFAULT_NODE_WIDTH,
+  GUTTER_PAD,
+  SIDE_X_THRESHOLD,
+  VERTICAL_GAP,
+  factoryRunLeafEdgeKey,
+} from "./factoryRunLeafLayoutHelpers";
+
+type ResolveEdgeGutterOptions = {
+  key: string;
+  isSide: boolean;
+  sourcePos: FactoryRunLayoutPosition;
+  targetPos: FactoryRunLayoutPosition;
+  sourceLayer: number;
+  targetLayer: number;
+  sourceCol: number;
+  targetCol: number;
+  graphRight: number;
+  edgeRouteGutters: Map<string, number>;
+};
+
+function resolveEdgeGutter(options: ResolveEdgeGutterOptions): void {
+  const {
+    key,
+    isSide,
+    sourcePos,
+    targetPos,
+    sourceLayer,
+    targetLayer,
+    sourceCol,
+    targetCol,
+    graphRight,
+    edgeRouteGutters,
+  } = options;
+  const layerSkip = targetLayer - sourceLayer > 1;
+  const crossColumn = Math.abs(sourceCol - targetCol) > 0;
+  if (isSide || (!layerSkip && !crossColumn)) return;
+
+  const leftwardMerge = sourcePos.x > targetPos.x + SIDE_X_THRESHOLD;
+  if (!leftwardMerge) {
+    edgeRouteGutters.set(key, graphRight);
+    return;
+  }
+
+  const nearby = targetPos.y - sourcePos.y < (DEFAULT_NODE_HEIGHT + VERTICAL_GAP) * 3;
+  if (!nearby) {
+    edgeRouteGutters.set(key, sourcePos.x + DEFAULT_NODE_WIDTH + GUTTER_PAD);
+  }
+}
+
+type ClassifyComponentEdgesOptions = {
+  componentEdges: FactoryRunLayoutEdge[];
+  positions: Map<string, FactoryRunLayoutPosition>;
+  layer: Map<string, number>;
+  column: Map<string, number>;
+  graphRight: number;
+  leafEdgeKeys: Set<string>;
+  spineEdgeKeys: Set<string>;
+  sideHandleNodeIds: Set<string>;
+  sideTargetNodeIds: Set<string>;
+  edgeRouteGutters: Map<string, number>;
+};
+
+export function classifyComponentEdges(options: ClassifyComponentEdgesOptions): void {
+  const {
+    componentEdges,
+    positions,
+    layer,
+    column,
+    graphRight,
+    leafEdgeKeys,
+    spineEdgeKeys,
+    sideHandleNodeIds,
+    sideTargetNodeIds,
+    edgeRouteGutters,
+  } = options;
+  for (const edge of componentEdges) {
+    const sourcePos = positions.get(edge.source);
+    const targetPos = positions.get(edge.target);
+    if (!sourcePos || !targetPos) continue;
+
+    const key = factoryRunLeafEdgeKey(edge.source, edge.target, edge.sourceHandle);
+    const isSide = targetPos.x >= sourcePos.x + SIDE_X_THRESHOLD;
+    if (isSide) {
+      leafEdgeKeys.add(key);
+      sideHandleNodeIds.add(edge.source);
+      sideTargetNodeIds.add(edge.target);
+    } else {
+      spineEdgeKeys.add(key);
+    }
+    resolveEdgeGutter({
+      key,
+      isSide,
+      sourcePos,
+      targetPos,
+      graphRight,
+      edgeRouteGutters,
+      sourceLayer: layer.get(edge.source) ?? 0,
+      targetLayer: layer.get(edge.target) ?? 0,
+      sourceCol: column.get(edge.source) ?? 0,
+      targetCol: column.get(edge.target) ?? 0,
+    });
+  }
+}
+
+type MarkDisplaySourceNodesOptions = {
+  componentEdges: FactoryRunLayoutEdge[];
+  leafEdgeKeys: Set<string>;
+  spineEdgeKeys: Set<string>;
+  displaySourceNodeIds: Set<string>;
+  spineSourceNodeIds: Set<string>;
+};
+
+export function markDisplaySourceNodes(options: MarkDisplaySourceNodesOptions): void {
+  const { componentEdges, leafEdgeKeys, spineEdgeKeys, displaySourceNodeIds, spineSourceNodeIds } = options;
+  for (const edge of componentEdges) {
+    const key = factoryRunLeafEdgeKey(edge.source, edge.target, edge.sourceHandle);
+    if (!leafEdgeKeys.has(key) && !spineEdgeKeys.has(key)) continue;
+    displaySourceNodeIds.add(edge.source);
+    if (spineEdgeKeys.has(key)) {
+      spineSourceNodeIds.add(edge.source);
+    }
+  }
+}

--- a/web_src/src/lib/layout/factoryRunFeedbackRouting.ts
+++ b/web_src/src/lib/layout/factoryRunFeedbackRouting.ts
@@ -1,0 +1,77 @@
+import type { FactoryRunLayoutEdge, FactoryRunLayoutNode, FactoryRunLayoutPosition } from "./factoryRunLeafLayout";
+import { GUTTER_PAD, factoryRunChannelPriority, factoryRunLeafEdgeKey, nodeSize } from "./factoryRunLeafLayoutHelpers";
+
+const FEEDBACK_LANE_SPACING = 48;
+const FEEDBACK_INTERVAL_GAP = 32;
+const FEEDBACK_ROUTE_Y_SPACING = 16;
+
+type FeedbackInterval = { start: number; end: number };
+
+function feedbackInterval(
+  edge: FactoryRunLayoutEdge,
+  positions: Map<string, FactoryRunLayoutPosition>,
+  nodeById: Map<string, FactoryRunLayoutNode>,
+): FeedbackInterval | null {
+  const sourcePosition = positions.get(edge.source);
+  const targetPosition = positions.get(edge.target);
+  if (!sourcePosition || !targetPosition) return null;
+
+  const sourceY = sourcePosition.y + nodeSize(nodeById.get(edge.source)!).height;
+  const targetY = targetPosition.y;
+  return { start: Math.min(sourceY, targetY), end: Math.max(sourceY, targetY) };
+}
+
+function feedbackIntervalsOverlap(a: FeedbackInterval, b: FeedbackInterval): boolean {
+  return a.start < b.end + FEEDBACK_INTERVAL_GAP && b.start < a.end + FEEDBACK_INTERVAL_GAP;
+}
+
+function compareFeedbackEdges(
+  a: FactoryRunLayoutEdge,
+  b: FactoryRunLayoutEdge,
+  positions: Map<string, FactoryRunLayoutPosition>,
+): number {
+  const sourceA = positions.get(a.source);
+  const sourceB = positions.get(b.source);
+  const bySourceX = (sourceA?.x ?? 0) - (sourceB?.x ?? 0);
+  if (bySourceX !== 0) return bySourceX;
+  const bySourceY = (sourceA?.y ?? 0) - (sourceB?.y ?? 0);
+  if (bySourceY !== 0) return bySourceY;
+  const byChannel = factoryRunChannelPriority(a.sourceHandle) - factoryRunChannelPriority(b.sourceHandle);
+  if (byChannel !== 0) return byChannel;
+  return (a.id ?? factoryRunLeafEdgeKey(a.source, a.target, a.sourceHandle)).localeCompare(
+    b.id ?? factoryRunLeafEdgeKey(b.source, b.target, b.sourceHandle),
+  );
+}
+
+type RouteFeedbackEdgesOptions = {
+  feedbackEdges: FactoryRunLayoutEdge[];
+  positions: Map<string, FactoryRunLayoutPosition>;
+  nodeById: Map<string, FactoryRunLayoutNode>;
+  graphLeft: number;
+  feedbackEdgeKeys: Set<string>;
+  spineEdgeKeys: Set<string>;
+  edgeRouteGutters: Map<string, number>;
+  edgeRouteOffsetsY: Map<string, number>;
+};
+
+export function routeFeedbackEdges(options: RouteFeedbackEdgesOptions): void {
+  const lanes: FeedbackInterval[][] = [];
+  const sortedEdges = [...options.feedbackEdges].sort((a, b) => compareFeedbackEdges(a, b, options.positions));
+
+  for (const edge of sortedEdges) {
+    const interval = feedbackInterval(edge, options.positions, options.nodeById);
+    if (!interval) continue;
+    let laneIndex = lanes.findIndex((lane) => lane.every((placed) => !feedbackIntervalsOverlap(interval, placed)));
+    if (laneIndex < 0) {
+      laneIndex = lanes.length;
+      lanes.push([]);
+    }
+    lanes[laneIndex].push(interval);
+
+    const key = factoryRunLeafEdgeKey(edge.source, edge.target, edge.sourceHandle);
+    options.feedbackEdgeKeys.add(key);
+    options.spineEdgeKeys.add(key);
+    options.edgeRouteGutters.set(key, options.graphLeft - GUTTER_PAD - laneIndex * FEEDBACK_LANE_SPACING);
+    options.edgeRouteOffsetsY.set(key, laneIndex * FEEDBACK_ROUTE_Y_SPACING);
+  }
+}

--- a/web_src/src/lib/layout/factoryRunLeafLayout.spec.ts
+++ b/web_src/src/lib/layout/factoryRunLeafLayout.spec.ts
@@ -15,6 +15,97 @@ function expectNoOverlaps(positions: Map<string, { x: number; y: number }>, widt
 }
 
 describe("layoutFactoryRunLeafGraph", () => {
+  it("keeps multiple roots and their branches in separate saved-position lanes", () => {
+    const result = layoutFactoryRunLeafGraph(
+      [
+        { id: "merge", position: { x: 576, y: 978 } },
+        { id: "right-root", position: { x: 1044, y: 258 } },
+        { id: "left-root", position: { x: 576, y: 258 } },
+        { id: "right-filter", position: { x: 1044, y: 618 } },
+        { id: "left-filter", position: { x: 576, y: 618 } },
+      ],
+      [
+        { source: "right-root", target: "right-filter", sourceHandle: "default" },
+        { source: "left-root", target: "left-filter", sourceHandle: "default" },
+        { source: "right-filter", target: "merge", sourceHandle: "default" },
+        { source: "left-filter", target: "merge", sourceHandle: "default" },
+      ],
+    );
+
+    const leftRoot = result.positions.get("left-root")!;
+    const rightRoot = result.positions.get("right-root")!;
+    const leftFilter = result.positions.get("left-filter")!;
+    const rightFilter = result.positions.get("right-filter")!;
+    const merge = result.positions.get("merge")!;
+
+    expect(leftRoot.y).toBe(rightRoot.y);
+    expect(leftRoot.x).toBeLessThan(rightRoot.x);
+    expect(leftFilter.x).toBe(leftRoot.x);
+    expect(rightFilter.x).toBe(rightRoot.x);
+    expect(leftFilter.y).toBe(rightFilter.y);
+    expect(merge.x).toBe(leftFilter.x);
+    expect(merge.y).toBeGreaterThan(leftFilter.y);
+    expectNoOverlaps(result.positions);
+  });
+
+  it("assigns overlapping feedback edges to separate left gutters", () => {
+    const result = layoutFactoryRunLeafGraph(
+      [
+        { id: "trigger", position: { x: 768, y: 1848 } },
+        { id: "loop", position: { x: 769, y: 2064 } },
+        { id: "workflow", position: { x: 1104, y: 2304 } },
+        { id: "runner", position: { x: 1200, y: 2592 } },
+        { id: "done", position: { x: 699, y: 2424 } },
+      ],
+      [
+        { id: "trigger-loop", source: "trigger", target: "loop", sourceHandle: "default" },
+        { id: "loop-workflow", source: "loop", target: "workflow", sourceHandle: "next" },
+        { id: "workflow-loop", source: "workflow", target: "loop", sourceHandle: "passed" },
+        { id: "workflow-runner", source: "workflow", target: "runner", sourceHandle: "failed" },
+        { id: "runner-loop-passed", source: "runner", target: "loop", sourceHandle: "passed" },
+        { id: "runner-loop-failed", source: "runner", target: "loop", sourceHandle: "failed" },
+        { id: "loop-done", source: "loop", target: "done", sourceHandle: "done" },
+      ],
+    );
+
+    const feedbackKeys = [
+      factoryRunLeafEdgeKey("workflow", "loop", "passed"),
+      factoryRunLeafEdgeKey("runner", "loop", "passed"),
+      factoryRunLeafEdgeKey("runner", "loop", "failed"),
+    ];
+    const gutters = feedbackKeys.map((key) => result.edgeRouteGutters.get(key));
+    const yOffsets = feedbackKeys.map((key) => result.edgeRouteOffsetsY.get(key));
+    const graphLeft = Math.min(...[...result.positions.values()].map((position) => position.x));
+
+    expect(feedbackKeys.every((key) => result.feedbackEdgeKeys.has(key))).toBe(true);
+    expect(new Set(gutters).size).toBe(3);
+    expect(yOffsets).toEqual([0, 16, 32]);
+    expect(gutters.every((gutter) => gutter != null && gutter < graphLeft)).toBe(true);
+    expect(result.displaySourceNodeIds.has("runner")).toBe(true);
+    expect(result.spineSourceNodeIds.has("runner")).toBe(true);
+    expectNoOverlaps(result.positions);
+  });
+
+  it("reuses a feedback gutter when vertical intervals do not overlap", () => {
+    const result = layoutFactoryRunLeafGraph(
+      [{ id: "root" }, { id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }],
+      [
+        { source: "root", target: "a", sourceHandle: "default" },
+        { source: "a", target: "b", sourceHandle: "default" },
+        { source: "b", target: "a", sourceHandle: "repeat" },
+        { source: "b", target: "c", sourceHandle: "default" },
+        { source: "c", target: "d", sourceHandle: "default" },
+        { source: "d", target: "c", sourceHandle: "repeat" },
+      ],
+    );
+
+    const firstGutter = result.edgeRouteGutters.get(factoryRunLeafEdgeKey("b", "a", "repeat"));
+    const secondGutter = result.edgeRouteGutters.get(factoryRunLeafEdgeKey("d", "c", "repeat"));
+
+    expect(firstGutter).toBeDefined();
+    expect(secondGutter).toBe(firstGutter);
+  });
+
   it("keeps the longest non-leaf path on the spine and parks leaves to the right", () => {
     const result = layoutFactoryRunLeafGraph(
       [{ id: "a" }, { id: "b" }, { id: "leaf1" }, { id: "leaf2" }, { id: "d" }, { id: "e" }],
@@ -94,7 +185,7 @@ describe("layoutFactoryRunLeafGraph", () => {
     expect(s2.x).toBeGreaterThan(s1.x);
     expect(result.leafEdgeKeys.has(factoryRunLeafEdgeKey("router", "failed", "false"))).toBe(true);
     expect(result.leafEdgeKeys.has(factoryRunLeafEdgeKey("router", "success", "true"))).toBe(false);
-    expect(result.compactForkNodeIds.has("router")).toBe(true);
+    expect(result.displaySourceNodeIds.has("router")).toBe(true);
     expect(result.spineSourceNodeIds.has("router")).toBe(true);
     expect(result.spineEdgeKeys.has(factoryRunLeafEdgeKey("router", "success", "true"))).toBe(true);
     expectNoOverlaps(result.positions);

--- a/web_src/src/lib/layout/factoryRunLeafLayout.ts
+++ b/web_src/src/lib/layout/factoryRunLeafLayout.ts
@@ -16,16 +16,16 @@ import {
   MAIN_X,
   assignComponentColumns,
   buildAdjacency,
-  classifyComponentEdges,
   computeComponentLayers,
-  computeComponentSpine,
+  computeComponentSpineColumns,
   createSpinePickers,
   findWeakComponents,
-  markCompactForkNodes,
+  partitionLayoutEdges,
   placeComponentNodes,
-  resolveForwardEdges,
   type SpinePickers,
 } from "./factoryRunLeafLayoutHelpers";
+import { classifyComponentEdges, markDisplaySourceNodes } from "./factoryRunEdgeClassification";
+import { routeFeedbackEdges } from "./factoryRunFeedbackRouting";
 
 export { factoryRunLeafEdgeKey } from "./factoryRunLeafLayoutHelpers";
 
@@ -37,6 +37,7 @@ export type FactoryRunLayoutNode = {
   id: string;
   width?: number;
   height?: number;
+  position?: FactoryRunLayoutPosition;
 };
 
 export type FactoryRunLayoutEdge = {
@@ -52,9 +53,9 @@ export type FactoryRunLeafLayoutResult = {
   positions: Map<string, FactoryRunLayoutPosition>;
   /** Parents that need a Right side handle for off-spine fan-out. */
   sideHandleNodeIds: Set<string>;
-  /** Parents that use compact center+side chrome (no MultiBottom true/false stems). */
-  compactForkNodeIds: Set<string>;
-  /** Compact-fork parents that still have a spine child (centered bottom handle). */
+  /** Sources that use route-based display ports instead of channel stems. */
+  displaySourceNodeIds: Set<string>;
+  /** Display sources that need a centered bottom handle. */
   spineSourceNodeIds: Set<string>;
   /** Edge keys that route side→left. */
   leafEdgeKeys: Set<string>;
@@ -62,39 +63,71 @@ export type FactoryRunLeafLayoutResult = {
   spineEdgeKeys: Set<string>;
   /** Targets of side edges — use Left target handle. */
   sideTargetNodeIds: Set<string>;
-  /** Optional right-gutter X for long / cross-column edges (edge key → x). */
+  /** Optional vertical-gutter X for long, cross-column, and feedback edges. */
   edgeRouteGutters: Map<string, number>;
+  /** Small endpoint-turn Y stagger for feedback edges that use adjacent gutters. */
+  edgeRouteOffsetsY: Map<string, number>;
+  /** Edges removed from the DAG for ranking but preserved for display routing. */
+  feedbackEdgeKeys: Set<string>;
 };
 
 type ComponentLayoutContext = {
   outgoing: Map<string, FactoryRunLayoutEdge[]>;
   incoming: Map<string, FactoryRunLayoutEdge[]>;
   forwardEdges: FactoryRunLayoutEdge[];
+  feedbackEdges: FactoryRunLayoutEdge[];
   nodeById: Map<string, FactoryRunLayoutNode>;
   pickers: SpinePickers;
   positions: Map<string, FactoryRunLayoutPosition>;
   sideHandleNodeIds: Set<string>;
-  compactForkNodeIds: Set<string>;
+  displaySourceNodeIds: Set<string>;
   spineSourceNodeIds: Set<string>;
   leafEdgeKeys: Set<string>;
   spineEdgeKeys: Set<string>;
   sideTargetNodeIds: Set<string>;
   edgeRouteGutters: Map<string, number>;
+  edgeRouteOffsetsY: Map<string, number>;
+  feedbackEdgeKeys: Set<string>;
 };
+
+function savedCoordinate(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+}
+
+function sortRootsBySavedPosition(roots: string[], nodeById: Map<string, FactoryRunLayoutNode>): string[] {
+  return [...roots].sort((a, b) => {
+    const positionA = nodeById.get(a)?.position;
+    const positionB = nodeById.get(b)?.position;
+    const byX = savedCoordinate(positionA?.x) - savedCoordinate(positionB?.x);
+    if (byX !== 0) return byX;
+    const byY = savedCoordinate(positionA?.y) - savedCoordinate(positionB?.y);
+    if (byY !== 0) return byY;
+    return a.localeCompare(b);
+  });
+}
 
 function layoutOneComponent(component: string[], componentOriginX: number, ctx: ComponentLayoutContext): number {
   const componentSet = new Set(component);
   const componentRoots = component.filter((id) =>
     (ctx.incoming.get(id) ?? []).every((e) => !componentSet.has(e.source)),
   );
-  const rootsForComponent = componentRoots.length > 0 ? componentRoots : [component[0]];
+  const rootsForComponent = sortRootsBySavedPosition(
+    componentRoots.length > 0 ? componentRoots : [component[0]],
+    ctx.nodeById,
+  );
 
   const layer = computeComponentLayers(component, componentSet, rootsForComponent, ctx.incoming);
-  const spine = computeComponentSpine(rootsForComponent, componentSet, ctx.outgoing, ctx.pickers.pickMainChildEdge);
+  const spineColumns = computeComponentSpineColumns(
+    rootsForComponent,
+    componentSet,
+    ctx.outgoing,
+    ctx.pickers.pickMainChildEdge,
+  );
   const column = assignComponentColumns({
     component,
     componentSet,
-    spine,
+    spineColumns,
+    firstSideColumn: rootsForComponent.length,
     layer,
     incoming: ctx.incoming,
     isMainSuccessor: ctx.pickers.isMainSuccessor,
@@ -109,11 +142,14 @@ function layoutOneComponent(component: string[], componentOriginX: number, ctx: 
     nodeById: ctx.nodeById,
     incoming: ctx.incoming,
     positions: ctx.positions,
+    spineColumns,
   });
 
-  const componentEdges = ctx.forwardEdges.filter((e) => componentSet.has(e.source) && componentSet.has(e.target));
+  const componentForwardEdges = ctx.forwardEdges.filter(
+    (edge) => componentSet.has(edge.source) && componentSet.has(edge.target),
+  );
   classifyComponentEdges({
-    componentEdges,
+    componentEdges: componentForwardEdges,
     positions: ctx.positions,
     layer,
     column,
@@ -125,12 +161,26 @@ function layoutOneComponent(component: string[], componentOriginX: number, ctx: 
     edgeRouteGutters: ctx.edgeRouteGutters,
   });
 
-  markCompactForkNodes({
-    component,
-    outgoing: ctx.outgoing,
+  const componentFeedbackEdges = ctx.feedbackEdges.filter(
+    (edge) => componentSet.has(edge.source) && componentSet.has(edge.target),
+  );
+  const graphLeft = Math.min(...component.map((id) => ctx.positions.get(id)?.x ?? componentOriginX));
+  routeFeedbackEdges({
+    feedbackEdges: componentFeedbackEdges,
+    positions: ctx.positions,
+    nodeById: ctx.nodeById,
+    graphLeft,
+    feedbackEdgeKeys: ctx.feedbackEdgeKeys,
+    spineEdgeKeys: ctx.spineEdgeKeys,
+    edgeRouteGutters: ctx.edgeRouteGutters,
+    edgeRouteOffsetsY: ctx.edgeRouteOffsetsY,
+  });
+
+  markDisplaySourceNodes({
+    componentEdges: [...componentForwardEdges, ...componentFeedbackEdges],
     leafEdgeKeys: ctx.leafEdgeKeys,
     spineEdgeKeys: ctx.spineEdgeKeys,
-    compactForkNodeIds: ctx.compactForkNodeIds,
+    displaySourceNodeIds: ctx.displaySourceNodeIds,
     spineSourceNodeIds: ctx.spineSourceNodeIds,
   });
 
@@ -141,12 +191,14 @@ function emptyFactoryRunLeafLayoutResult(): FactoryRunLeafLayoutResult {
   return {
     positions: new Map(),
     sideHandleNodeIds: new Set(),
-    compactForkNodeIds: new Set(),
+    displaySourceNodeIds: new Set(),
     spineSourceNodeIds: new Set(),
     leafEdgeKeys: new Set(),
     spineEdgeKeys: new Set(),
     sideTargetNodeIds: new Set(),
     edgeRouteGutters: new Map(),
+    edgeRouteOffsetsY: new Map(),
+    feedbackEdgeKeys: new Set(),
   };
 }
 
@@ -160,16 +212,18 @@ export function layoutFactoryRunLeafGraph(
 
   const positions = new Map<string, FactoryRunLayoutPosition>();
   const sideHandleNodeIds = new Set<string>();
-  const compactForkNodeIds = new Set<string>();
+  const displaySourceNodeIds = new Set<string>();
   const spineSourceNodeIds = new Set<string>();
   const leafEdgeKeys = new Set<string>();
   const spineEdgeKeys = new Set<string>();
   const sideTargetNodeIds = new Set<string>();
   const edgeRouteGutters = new Map<string, number>();
+  const edgeRouteOffsetsY = new Map<string, number>();
+  const feedbackEdgeKeys = new Set<string>();
 
   const nodeById = new Map(nodes.map((node) => [node.id, node]));
   const nodeIds = new Set(nodes.map((node) => node.id));
-  const forwardEdges = resolveForwardEdges(edges, nodeIds);
+  const { forwardEdges, feedbackEdges } = partitionLayoutEdges(edges, nodeIds);
   const { outgoing, incoming } = buildAdjacency(nodes, forwardEdges);
   const pickers = createSpinePickers(outgoing);
   const components = findWeakComponents(nodes, forwardEdges, incoming);
@@ -178,16 +232,19 @@ export function layoutFactoryRunLeafGraph(
     outgoing,
     incoming,
     forwardEdges,
+    feedbackEdges,
     nodeById,
     pickers,
     positions,
     sideHandleNodeIds,
-    compactForkNodeIds,
+    displaySourceNodeIds,
     spineSourceNodeIds,
     leafEdgeKeys,
     spineEdgeKeys,
     sideTargetNodeIds,
     edgeRouteGutters,
+    edgeRouteOffsetsY,
+    feedbackEdgeKeys,
   };
 
   let componentOriginX = MAIN_X;
@@ -198,11 +255,13 @@ export function layoutFactoryRunLeafGraph(
   return {
     positions,
     sideHandleNodeIds,
-    compactForkNodeIds,
+    displaySourceNodeIds,
     spineSourceNodeIds,
     leafEdgeKeys,
     spineEdgeKeys,
     sideTargetNodeIds,
     edgeRouteGutters,
+    edgeRouteOffsetsY,
+    feedbackEdgeKeys,
   };
 }

--- a/web_src/src/lib/layout/factoryRunLeafLayoutHelpers.ts
+++ b/web_src/src/lib/layout/factoryRunLeafLayoutHelpers.ts
@@ -9,11 +9,11 @@ export const DEFAULT_NODE_WIDTH = FACTORY_NODE_CARD_WIDTH;
 export const DEFAULT_NODE_HEIGHT = FACTORY_NODE_CARD_HEIGHT;
 export const MAIN_X = 120;
 const SIDE_GAP = 96;
-const VERTICAL_GAP = 104;
+export const VERTICAL_GAP = 104;
 const SIDE_COLUMN_EXTRA_GAP = 88;
 export const COMPONENT_GAP_X = 120;
 export const GUTTER_PAD = 48;
-const SIDE_X_THRESHOLD = SIDE_GAP / 2;
+export const SIDE_X_THRESHOLD = SIDE_GAP / 2;
 
 const SPINE_CHANNEL_PRIORITY: Record<string, number> = {
   default: 0,
@@ -34,13 +34,13 @@ export function nodeSize(node: FactoryRunLayoutNode): { width: number; height: n
   };
 }
 
-function channelPriority(channel: string | null | undefined): number {
+export function factoryRunChannelPriority(channel: string | null | undefined): number {
   const key = (channel ?? "default").toLowerCase();
   return SPINE_CHANNEL_PRIORITY[key] ?? 50;
 }
 
 function compareChildEdges(a: FactoryRunLayoutEdge, b: FactoryRunLayoutEdge): number {
-  const byChannel = channelPriority(a.sourceHandle) - channelPriority(b.sourceHandle);
+  const byChannel = factoryRunChannelPriority(a.sourceHandle) - factoryRunChannelPriority(b.sourceHandle);
   if (byChannel !== 0) return byChannel;
   const handleA = a.sourceHandle ?? "default";
   const handleB = b.sourceHandle ?? "default";
@@ -67,8 +67,14 @@ function hasPath(
   return false;
 }
 
-export function resolveForwardEdges(edges: FactoryRunLayoutEdge[], nodeIds: Set<string>): FactoryRunLayoutEdge[] {
+export type FactoryRunEdgePartition = {
+  forwardEdges: FactoryRunLayoutEdge[];
+  feedbackEdges: FactoryRunLayoutEdge[];
+};
+
+export function partitionLayoutEdges(edges: FactoryRunLayoutEdge[], nodeIds: Set<string>): FactoryRunEdgePartition {
   const forward: FactoryRunLayoutEdge[] = [];
+  const feedback: FactoryRunLayoutEdge[] = [];
   const adjacency = new Map<string, string[]>();
 
   for (const edge of edges) {
@@ -76,13 +82,14 @@ export function resolveForwardEdges(edges: FactoryRunLayoutEdge[], nodeIds: Set<
       continue;
     }
     if (hasPath(adjacency, edge.target, edge.source)) {
+      feedback.push(edge);
       continue;
     }
     forward.push(edge);
     adjacency.set(edge.source, [...(adjacency.get(edge.source) ?? []), edge.target]);
   }
 
-  return forward;
+  return { forwardEdges: forward, feedbackEdges: feedback };
 }
 
 export function buildAdjacency(
@@ -261,42 +268,45 @@ export function computeComponentLayers(
   return layer;
 }
 
-export function computeComponentSpine(
+export function computeComponentSpineColumns(
   rootsForComponent: string[],
   componentSet: Set<string>,
   outgoing: Map<string, FactoryRunLayoutEdge[]>,
   pickMainChildEdge: SpinePickers["pickMainChildEdge"],
-): Set<string> {
-  const spine = new Set<string>();
-  for (const rootId of rootsForComponent) {
+): Map<string, number> {
+  const spineColumns = new Map<string, number>();
+  rootsForComponent.forEach((rootId, rootColumn) => {
     let current: string | null = rootId;
+    const visited = new Set<string>();
     while (current) {
-      spine.add(current);
+      const currentColumn = spineColumns.get(current);
+      if (currentColumn == null || rootColumn < currentColumn) {
+        spineColumns.set(current, rootColumn);
+      }
+      visited.add(current);
       const main = pickMainChildEdge((outgoing.get(current) ?? []).filter((e) => componentSet.has(e.target)));
       current = main?.target ?? null;
-      if (current && spine.has(current)) {
+      if (current && visited.has(current)) {
         break;
       }
     }
-  }
-  return spine;
+  });
+  return spineColumns;
 }
 
 type AssignComponentColumnsOptions = {
   component: string[];
   componentSet: Set<string>;
-  spine: Set<string>;
+  spineColumns: Map<string, number>;
+  firstSideColumn: number;
   layer: Map<string, number>;
   incoming: Map<string, FactoryRunLayoutEdge[]>;
   isMainSuccessor: SpinePickers["isMainSuccessor"];
 };
 
 export function assignComponentColumns(options: AssignComponentColumnsOptions): Map<string, number> {
-  const { component, componentSet, spine, layer, incoming, isMainSuccessor } = options;
-  const column = new Map<string, number>();
-  for (const id of spine) {
-    column.set(id, 0);
-  }
+  const { component, componentSet, spineColumns, firstSideColumn, layer, incoming, isMainSuccessor } = options;
+  const column = new Map(spineColumns);
 
   const byLayer = [...component].sort((a, b) => (layer.get(a) ?? 0) - (layer.get(b) ?? 0) || a.localeCompare(b));
   for (const id of byLayer) {
@@ -313,7 +323,7 @@ export function assignComponentColumns(options: AssignComponentColumnsOptions): 
     }
     const parentCol = parentCols[0];
     const parentId = parents[0].source;
-    column.set(id, isMainSuccessor(parentId, id) ? parentCol : parentCol + 1);
+    column.set(id, isMainSuccessor(parentId, id) ? parentCol : Math.max(parentCol + 1, firstSideColumn));
   }
   return column;
 }
@@ -351,12 +361,13 @@ type PlaceColumnNodeOptions = {
   componentSet: Set<string>;
   incoming: Map<string, FactoryRunLayoutEdge[]>;
   positions: Map<string, FactoryRunLayoutPosition>;
+  isSpineNode: boolean;
 };
 
 function placeOneColumnNode(options: PlaceColumnNodeOptions): { y: number; right: number } {
-  const { id, x, col, nextY, size, componentSet, incoming, positions } = options;
+  const { id, x, col, nextY, size, componentSet, incoming, positions, isSpineNode } = options;
   let preferredY = options.preferredY;
-  if (col > 0) {
+  if (col > 0 && !isSpineNode) {
     const parentYs = parentYsBeside(id, componentSet, incoming, positions);
     if (parentYs.length > 0) {
       preferredY = Math.min(...parentYs);
@@ -376,10 +387,12 @@ type PlaceComponentNodesOptions = {
   nodeById: Map<string, FactoryRunLayoutNode>;
   incoming: Map<string, FactoryRunLayoutEdge[]>;
   positions: Map<string, FactoryRunLayoutPosition>;
+  spineColumns: Map<string, number>;
 };
 
 export function placeComponentNodes(options: PlaceComponentNodesOptions): number {
-  const { component, componentSet, column, layer, componentOriginX, nodeById, incoming, positions } = options;
+  const { component, componentSet, column, layer, componentOriginX, nodeById, incoming, positions, spineColumns } =
+    options;
   let maxRight = componentOriginX;
   const strideY = DEFAULT_NODE_HEIGHT + VERTICAL_GAP;
   const strideX = DEFAULT_NODE_WIDTH + SIDE_GAP;
@@ -390,7 +403,8 @@ export function placeComponentNodes(options: PlaceComponentNodesOptions): number
     const ids = byColumn.get(col)!;
     ids.sort((a, b) => (layer.get(a) ?? 0) - (layer.get(b) ?? 0) || a.localeCompare(b));
     const x = componentOriginX + col * strideX;
-    const gapY = col > 0 ? VERTICAL_GAP + SIDE_COLUMN_EXTRA_GAP : VERTICAL_GAP;
+    const hasSpineNodes = ids.some((id) => spineColumns.has(id));
+    const gapY = hasSpineNodes ? VERTICAL_GAP : VERTICAL_GAP + SIDE_COLUMN_EXTRA_GAP;
     let nextY = 0;
     for (const id of ids) {
       const size = nodeSize(nodeById.get(id)!);
@@ -404,134 +418,11 @@ export function placeComponentNodes(options: PlaceComponentNodesOptions): number
         componentSet,
         incoming,
         positions,
+        isSpineNode: spineColumns.has(id),
       });
       maxRight = Math.max(maxRight, placed.right);
       nextY = placed.y + size.height + gapY;
     }
   }
   return maxRight;
-}
-
-type ResolveEdgeGutterOptions = {
-  key: string;
-  isSide: boolean;
-  sourcePos: FactoryRunLayoutPosition;
-  targetPos: FactoryRunLayoutPosition;
-  sourceLayer: number;
-  targetLayer: number;
-  sourceCol: number;
-  targetCol: number;
-  graphRight: number;
-  edgeRouteGutters: Map<string, number>;
-};
-
-export function resolveEdgeGutter(options: ResolveEdgeGutterOptions): void {
-  const {
-    key,
-    isSide,
-    sourcePos,
-    targetPos,
-    sourceLayer,
-    targetLayer,
-    sourceCol,
-    targetCol,
-    graphRight,
-    edgeRouteGutters,
-  } = options;
-  const layerSkip = targetLayer - sourceLayer > 1;
-  const crossColumn = Math.abs(sourceCol - targetCol) > 0;
-  if (isSide || (!layerSkip && !crossColumn)) return;
-
-  const leftwardMerge = sourcePos.x > targetPos.x + SIDE_X_THRESHOLD;
-  if (!leftwardMerge) {
-    edgeRouteGutters.set(key, graphRight);
-    return;
-  }
-
-  const nearby = targetPos.y - sourcePos.y < (DEFAULT_NODE_HEIGHT + VERTICAL_GAP) * 3;
-  if (!nearby) {
-    edgeRouteGutters.set(key, sourcePos.x + DEFAULT_NODE_WIDTH + GUTTER_PAD);
-  }
-}
-
-type ClassifyComponentEdgesOptions = {
-  componentEdges: FactoryRunLayoutEdge[];
-  positions: Map<string, FactoryRunLayoutPosition>;
-  layer: Map<string, number>;
-  column: Map<string, number>;
-  graphRight: number;
-  leafEdgeKeys: Set<string>;
-  spineEdgeKeys: Set<string>;
-  sideHandleNodeIds: Set<string>;
-  sideTargetNodeIds: Set<string>;
-  edgeRouteGutters: Map<string, number>;
-};
-
-export function classifyComponentEdges(options: ClassifyComponentEdgesOptions): void {
-  const {
-    componentEdges,
-    positions,
-    layer,
-    column,
-    graphRight,
-    leafEdgeKeys,
-    spineEdgeKeys,
-    sideHandleNodeIds,
-    sideTargetNodeIds,
-    edgeRouteGutters,
-  } = options;
-  for (const edge of componentEdges) {
-    const sourcePos = positions.get(edge.source);
-    const targetPos = positions.get(edge.target);
-    if (!sourcePos || !targetPos) continue;
-
-    const key = factoryRunLeafEdgeKey(edge.source, edge.target, edge.sourceHandle);
-    const isSide = targetPos.x >= sourcePos.x + SIDE_X_THRESHOLD;
-    if (isSide) {
-      leafEdgeKeys.add(key);
-      sideHandleNodeIds.add(edge.source);
-      sideTargetNodeIds.add(edge.target);
-    } else {
-      spineEdgeKeys.add(key);
-    }
-    resolveEdgeGutter({
-      key,
-      isSide,
-      sourcePos,
-      targetPos,
-      graphRight,
-      edgeRouteGutters,
-      sourceLayer: layer.get(edge.source) ?? 0,
-      targetLayer: layer.get(edge.target) ?? 0,
-      sourceCol: column.get(edge.source) ?? 0,
-      targetCol: column.get(edge.target) ?? 0,
-    });
-  }
-}
-
-type MarkCompactForkNodesOptions = {
-  component: string[];
-  outgoing: Map<string, FactoryRunLayoutEdge[]>;
-  leafEdgeKeys: Set<string>;
-  spineEdgeKeys: Set<string>;
-  compactForkNodeIds: Set<string>;
-  spineSourceNodeIds: Set<string>;
-};
-
-export function markCompactForkNodes(options: MarkCompactForkNodesOptions): void {
-  const { component, outgoing, leafEdgeKeys, spineEdgeKeys, compactForkNodeIds, spineSourceNodeIds } = options;
-  for (const id of component) {
-    const outs = outgoing.get(id) ?? [];
-    const hasSide = outs.some((edge) =>
-      leafEdgeKeys.has(factoryRunLeafEdgeKey(edge.source, edge.target, edge.sourceHandle)),
-    );
-    if (!hasSide) continue;
-    compactForkNodeIds.add(id);
-    const hasSpine = outs.some((edge) =>
-      spineEdgeKeys.has(factoryRunLeafEdgeKey(edge.source, edge.target, edge.sourceHandle)),
-    );
-    if (hasSpine) {
-      spineSourceNodeIds.add(id);
-    }
-  }
 }

--- a/web_src/src/ui/CanvasPage/Block.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block.spec.tsx
@@ -233,6 +233,39 @@ describe("Block fallback rendering", () => {
     expect(screen.getByTestId("handle-source-default")).toHaveAttribute("data-position", "bottom");
   });
 
+  it("hides channel stems when factory run display ports are active", () => {
+    render(
+      <Block
+        canvasMode="live"
+        nodeId="runner"
+        data={{
+          label: "Run Claude Code",
+          state: "pending",
+          type: "component",
+          outputChannels: ["passed", "failed"],
+          _flowDirection: "vertical",
+          _factoryRunDisplaySource: true,
+          _factorySpineSource: true,
+          component: {
+            title: "Run Claude Code",
+            iconSlug: "box",
+            collapsed: false,
+          },
+          _allEdges: [
+            { source: "runner", sourceHandle: "passed", target: "loop" },
+            { source: "runner", sourceHandle: "failed", target: "loop" },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("passed")).not.toBeInTheDocument();
+    expect(screen.queryByText("failed")).not.toBeInTheDocument();
+    expect(screen.getByTestId("handle-source-__factorySpine")).toHaveAttribute("data-position", "bottom");
+    expect(screen.queryByTestId("handle-source-passed")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("handle-source-failed")).not.toBeInTheDocument();
+  });
+
   it("shows an append connector button for end nodes in edit mode", () => {
     const onAppendFromNode = vi.fn();
 

--- a/web_src/src/ui/CanvasPage/Block/handles.tsx
+++ b/web_src/src/ui/CanvasPage/Block/handles.tsx
@@ -374,12 +374,14 @@ export function RightHandle({
     <FactorySideSourceHandle isConnectionInteractive={isConnectionInteractive} />
   ) : null;
 
-  // Run-inspection compact fork: centered spine + side — no MultiBottom S-stems.
-  // Always mount spine so cycle/loop-back edges (not leaf/spine classified) still attach.
-  if (data._factoryCompactFork) {
+  // Run inspection uses only the ports required by route geometry. Channel
+  // names stay on edge badges instead of rendering edit-style stems.
+  if (data._factoryRunDisplaySource) {
     return (
       <>
-        <FactorySpineSourceHandle isConnectionInteractive={isConnectionInteractive} />
+        {data._factorySpineSource ? (
+          <FactorySpineSourceHandle isConnectionInteractive={isConnectionInteractive} />
+        ) : null}
         {sideSource}
       </>
     );

--- a/web_src/src/ui/CanvasPage/Block/types.ts
+++ b/web_src/src/ui/CanvasPage/Block/types.ts
@@ -54,9 +54,9 @@ export interface BlockInternalData {
   _factorySideSource?: boolean;
   /** Factory run-inspection leaf layout: use Left target handle. */
   _factorySideTarget?: boolean;
-  /** Suppress MultiBottom true/false stems; use center spine + side handles. */
-  _factoryCompactFork?: boolean;
-  /** Compact fork has a spine child — show centered `__factorySpine` bottom handle. */
+  /** Factory run display uses route-based ports instead of channel stems. */
+  _factoryRunDisplaySource?: boolean;
+  /** Factory run display source needs a centered `__factorySpine` bottom handle. */
   _factorySpineSource?: boolean;
   isTemplate?: boolean;
   isPendingConnection?: boolean;

--- a/web_src/src/ui/CanvasPage/CustomEdge.tsx
+++ b/web_src/src/ui/CanvasPage/CustomEdge.tsx
@@ -19,10 +19,12 @@ interface CustomEdgeData {
   isHovered?: boolean;
   canDelete?: boolean;
   onDelete?: (edgeId: string) => void;
-  /** Factory run compact forks: original channel name (true/false/…). */
+  /** Factory run display: original channel name shown as an edge badge. */
   channelLabel?: string;
-  /** Factory run long/cross-column edges: route clear of node cards. */
+  /** Factory run long, cross-column, or feedback edge: route clear of node cards. */
   routeGutterX?: number;
+  /** Feedback-only Y stagger for adjacent return routes. */
+  routeOffsetY?: number;
   /** Factory run: this edge geometrically touches/crosses another. */
   touchesOtherEdge?: boolean;
   /** Factory run: longer edge in a touch pair — darker stroke + label border. */
@@ -133,6 +135,10 @@ function readCustomEdgeData(data: EdgeProps["data"]) {
     typeof edgeData?.routeGutterX === "number" && Number.isFinite(edgeData.routeGutterX)
       ? edgeData.routeGutterX
       : undefined;
+  const routeOffsetY =
+    typeof edgeData?.routeOffsetY === "number" && Number.isFinite(edgeData.routeOffsetY)
+      ? edgeData.routeOffsetY
+      : undefined;
   return {
     isHovered: edgeData?.isHovered === true,
     canDelete: edgeData?.canDelete === true,
@@ -141,6 +147,7 @@ function readCustomEdgeData(data: EdgeProps["data"]) {
     touchesOtherEdge: edgeData?.touchesOtherEdge === true,
     contrastStroke: edgeData?.contrastStroke === true,
     routeGutterX,
+    routeOffsetY,
   };
 }
 
@@ -182,8 +189,16 @@ export const CustomEdge = React.memo(function CustomEdge({
   const { setEdges } = useReactFlow();
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
-  const { isHovered, canDelete, onDeleteEdge, channelLabel, touchesOtherEdge, contrastStroke, routeGutterX } =
-    readCustomEdgeData(data);
+  const {
+    isHovered,
+    canDelete,
+    onDeleteEdge,
+    channelLabel,
+    touchesOtherEdge,
+    contrastStroke,
+    routeGutterX,
+    routeOffsetY,
+  } = readCustomEdgeData(data);
 
   const [edgePath, labelX, labelY] = getCanvasEdgePath({
     sourceX,
@@ -193,6 +208,7 @@ export const CustomEdge = React.memo(function CustomEdge({
     targetY,
     targetPosition,
     routeGutterX,
+    routeOffsetY,
   });
 
   const pathLength = estimatePathLength(edgePath);

--- a/web_src/src/ui/CanvasPage/edgePath.spec.ts
+++ b/web_src/src/ui/CanvasPage/edgePath.spec.ts
@@ -9,7 +9,7 @@ import {
   getCanvasEdgePath,
   getFlowArrowPoints,
   getPointAlongPath,
-  getRightGutterEdgePath,
+  getVerticalGutterEdgePath,
   getUpwardBackwardGutterY,
   isBackwardEdge,
   isVerticalFlowEdge,
@@ -203,7 +203,7 @@ describe("getCanvasEdgePath", () => {
   });
 
   it("keeps gutter paths clear of a blocking node between columns", () => {
-    const [path] = getRightGutterEdgePath({
+    const [path] = getVerticalGutterEdgePath({
       sourceX: 520,
       sourceY: 120,
       sourcePosition: Position.Bottom,
@@ -215,6 +215,39 @@ describe("getCanvasEdgePath", () => {
 
     const blockingNode = { x: 200, y: 250, width: 280, height: 104 };
     expect(doesEdgePathIntersectRect(path, blockingNode)).toBe(false);
+  });
+
+  it("uses a left gutter to keep feedback edges clear of intervening nodes", () => {
+    const [path] = getVerticalGutterEdgePath({
+      sourceX: 636,
+      sourceY: 520,
+      sourcePosition: Position.Bottom,
+      targetX: 260,
+      targetY: 208,
+      targetPosition: Position.Top,
+      routeGutterX: 72,
+    });
+
+    expect(path).toContain("72");
+    expect(doesEdgePathIntersectRect(path, { x: 120, y: 340, width: 280, height: 104 })).toBe(false);
+  });
+
+  it("staggers feedback turns vertically without moving their endpoints", () => {
+    const [path] = getVerticalGutterEdgePath({
+      sourceX: 636,
+      sourceY: 520,
+      sourcePosition: Position.Bottom,
+      targetX: 260,
+      targetY: 208,
+      targetPosition: Position.Top,
+      routeGutterX: 72,
+      routeOffsetY: 16,
+    });
+
+    expect(path).toContain("M 636 520");
+    expect(path).toContain("636,560");
+    expect(path).toContain("260,168");
+    expect(path).toContain("L 260 208");
   });
 
   it("keeps short vertical edges as bezier when no gutter is set", () => {
@@ -231,7 +264,7 @@ describe("getCanvasEdgePath", () => {
   });
 
   it("adds sparse flow chevrons on long edges and skips short ones", () => {
-    const [longPath] = getRightGutterEdgePath({
+    const [longPath] = getVerticalGutterEdgePath({
       sourceX: 520,
       sourceY: 120,
       sourcePosition: Position.Bottom,
@@ -284,7 +317,7 @@ describe("getCanvasEdgePath", () => {
   });
 
   it("marks both ids when a gutter path crosses a vertical fork", () => {
-    const [gutterPath] = getRightGutterEdgePath({
+    const [gutterPath] = getVerticalGutterEdgePath({
       sourceX: 520,
       sourceY: 100,
       sourcePosition: Position.Bottom,
@@ -308,7 +341,7 @@ describe("getCanvasEdgePath", () => {
   });
 
   it("darkens only the longer edge in a touch pair", () => {
-    const [gutterPath] = getRightGutterEdgePath({
+    const [gutterPath] = getVerticalGutterEdgePath({
       sourceX: 520,
       sourceY: 100,
       sourcePosition: Position.Bottom,

--- a/web_src/src/ui/CanvasPage/edgePath.ts
+++ b/web_src/src/ui/CanvasPage/edgePath.ts
@@ -36,8 +36,10 @@ export type CanvasEdgePathParams = {
   targetX: number;
   targetY: number;
   targetPosition: Position;
-  /** When set, route via this X gutter (factory run long / cross-column edges). */
+  /** When set, route via this X gutter (factory run long, cross-column, or feedback edges). */
   routeGutterX?: number;
+  /** Feedback-only Y stagger for the horizontal turns beside shared endpoints. */
+  routeOffsetY?: number;
 };
 
 export function isVerticalFlowEdge({
@@ -273,14 +275,17 @@ function getHorizontalBackwardEdgePath(params: CanvasEdgePathParams): [path: str
 }
 
 /**
- * Exit down/right → travel vertical gutter → enter target.
- * Keeps long factory edges clear of node cards between columns.
+ * Exit from the source, travel through a vertical gutter, then enter the target.
+ * Keeps long and feedback factory edges clear of node cards.
  */
-export function getRightGutterEdgePath(params: CanvasEdgePathParams): [path: string, labelX: number, labelY: number] {
+export function getVerticalGutterEdgePath(
+  params: CanvasEdgePathParams,
+): [path: string, labelX: number, labelY: number] {
   const { sourceX, sourceY, targetX, targetY, routeGutterX } = params;
   const gutterX = routeGutterX ?? Math.max(sourceX, targetX) + BACKWARD_ROUTE_OFFSET;
-  const exitY = sourceY + HANDLE_OFFSET;
-  const entryY = targetY - HANDLE_OFFSET;
+  const routeOffsetY = params.routeOffsetY ?? 0;
+  const exitY = sourceY + HANDLE_OFFSET + routeOffsetY;
+  const entryY = targetY - HANDLE_OFFSET - routeOffsetY;
 
   const points: Point[] = [
     { x: sourceX, y: sourceY },
@@ -297,7 +302,7 @@ export function getRightGutterEdgePath(params: CanvasEdgePathParams): [path: str
 
 export function getCanvasEdgePath(params: CanvasEdgePathParams): [path: string, labelX: number, labelY: number] {
   if (typeof params.routeGutterX === "number" && Number.isFinite(params.routeGutterX)) {
-    return getRightGutterEdgePath(params);
+    return getVerticalGutterEdgePath(params);
   }
 
   // Factory (vertical) canvases use curvy bezier edges like WorkOrderCanvas Storybook.

--- a/web_src/src/ui/CanvasPage/enrichCanvasNodes.ts
+++ b/web_src/src/ui/CanvasPage/enrichCanvasNodes.ts
@@ -23,7 +23,7 @@ type CanvasBlockNodeData = Record<string, unknown> & {
   _flowDirection?: ReturnType<typeof resolveCanvasFlowDirection>;
   _factorySideSource?: boolean;
   _factorySideTarget?: boolean;
-  _factoryCompactFork?: boolean;
+  _factoryRunDisplaySource?: boolean;
   _factorySpineSource?: boolean;
 };
 
@@ -86,14 +86,14 @@ function resolveFactoryLayoutFlags(
 ): {
   sideSource: boolean;
   sideTarget: boolean;
-  compactFork: boolean;
+  runDisplaySource: boolean;
   spineSource: boolean;
   overlayPosition: { x: number; y: number } | undefined;
 } {
   return {
     sideSource: layout?.sideHandleNodeIds.has(nodeId) ?? false,
     sideTarget: layout?.sideTargetNodeIds.has(nodeId) ?? false,
-    compactFork: layout?.compactForkNodeIds.has(nodeId) ?? false,
+    runDisplaySource: layout?.displaySourceNodeIds.has(nodeId) ?? false,
     spineSource: layout?.spineSourceNodeIds.has(nodeId) ?? false,
     overlayPosition: layout?.positions.get(nodeId),
   };
@@ -102,16 +102,16 @@ function resolveFactoryLayoutFlags(
 function buildFactoryLayoutDataFlags(flags: {
   sideSource: boolean;
   sideTarget: boolean;
-  compactFork: boolean;
+  runDisplaySource: boolean;
   spineSource: boolean;
 }): Pick<
   CanvasBlockNodeData,
-  "_factorySideSource" | "_factorySideTarget" | "_factoryCompactFork" | "_factorySpineSource"
+  "_factorySideSource" | "_factorySideTarget" | "_factoryRunDisplaySource" | "_factorySpineSource"
 > {
   return {
     _factorySideSource: flags.sideSource,
     _factorySideTarget: flags.sideTarget,
-    _factoryCompactFork: flags.compactFork,
+    _factoryRunDisplaySource: flags.runDisplaySource,
     _factorySpineSource: flags.spineSource,
   };
 }

--- a/web_src/src/ui/CanvasPage/factoryCanvasEdgeStyle.spec.ts
+++ b/web_src/src/ui/CanvasPage/factoryCanvasEdgeStyle.spec.ts
@@ -1,0 +1,72 @@
+import { Position, type Edge, type Node } from "@xyflow/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  FACTORY_SPINE_HANDLE_ID,
+  factoryRunLeafEdgeKey,
+  layoutFactoryRunLeafGraph,
+} from "@/lib/layout/factoryRunLeafLayout";
+import { buildStyledCanvasEdges } from "./factoryCanvasEdgeStyle";
+
+type RoutedEdge = Edge & {
+  sourcePosition?: Position;
+  targetPosition?: Position;
+};
+
+describe("buildStyledCanvasEdges factory run routing", () => {
+  it("uses compact ports, edge badges, and distinct gutters for feedback channels", () => {
+    const nodes: Node[] = [
+      { id: "loop", position: { x: 0, y: 0 }, data: {} },
+      { id: "workflow", position: { x: 0, y: 300 }, data: {} },
+      { id: "runner", position: { x: 400, y: 500 }, data: {} },
+    ];
+    const edges: Edge[] = [
+      { id: "loop-workflow", source: "loop", target: "workflow", sourceHandle: "next" },
+      { id: "workflow-loop", source: "workflow", target: "loop", sourceHandle: "passed" },
+      { id: "workflow-runner", source: "workflow", target: "runner", sourceHandle: "failed" },
+      { id: "runner-loop-passed", source: "runner", target: "loop", sourceHandle: "passed" },
+      { id: "runner-loop-failed", source: "runner", target: "loop", sourceHandle: "failed" },
+    ];
+    const layout = layoutFactoryRunLeafGraph(
+      nodes.map((node) => ({ id: node.id, position: node.position })),
+      edges,
+    );
+
+    const styledEdges = buildStyledCanvasEdges({
+      edges,
+      nodes,
+      isVerticalFlow: true,
+      resolvedThemeIsDark: false,
+      edgeDefaults: { type: "custom", style: { stroke: "#cbd5e1", strokeWidth: 1.5 } },
+      hoveredEdgeId: null,
+      isEditMode: false,
+      isReadOnly: false,
+      stableEdgeDelete: vi.fn(),
+      factoryRunLeafLayout: layout,
+    })!;
+
+    const passed = styledEdges.find((edge) => edge.id === "runner-loop-passed")! as RoutedEdge;
+    const failed = styledEdges.find((edge) => edge.id === "runner-loop-failed")! as RoutedEdge;
+    const passedGutter = layout.edgeRouteGutters.get(factoryRunLeafEdgeKey("runner", "loop", "passed"));
+    const failedGutter = layout.edgeRouteGutters.get(factoryRunLeafEdgeKey("runner", "loop", "failed"));
+    const passedOffsetY = layout.edgeRouteOffsetsY.get(factoryRunLeafEdgeKey("runner", "loop", "passed"));
+    const failedOffsetY = layout.edgeRouteOffsetsY.get(factoryRunLeafEdgeKey("runner", "loop", "failed"));
+
+    expect(passed.sourceHandle).toBe(FACTORY_SPINE_HANDLE_ID);
+    expect(failed.sourceHandle).toBe(FACTORY_SPINE_HANDLE_ID);
+    expect(passed.sourcePosition).toBe(Position.Bottom);
+    expect(passed.targetPosition).toBe(Position.Top);
+    expect(passed.data).toMatchObject({
+      channelLabel: "passed",
+      routeGutterX: passedGutter,
+      routeOffsetY: passedOffsetY,
+    });
+    expect(failed.data).toMatchObject({
+      channelLabel: "failed",
+      routeGutterX: failedGutter,
+      routeOffsetY: failedOffsetY,
+    });
+    expect(passedGutter).not.toBe(failedGutter);
+    expect(passedOffsetY).not.toBe(failedOffsetY);
+  });
+});

--- a/web_src/src/ui/CanvasPage/factoryCanvasEdgeStyle.ts
+++ b/web_src/src/ui/CanvasPage/factoryCanvasEdgeStyle.ts
@@ -86,6 +86,7 @@ function buildOneFactoryEdgePathEntry(
   const sourceAnchor = factoryRunHandleAnchor(endpoints.sourcePos, sourceBox.width, sourceBox.height, sourceSide);
   const targetAnchor = factoryRunHandleAnchor(endpoints.targetPos, targetBox.width, targetBox.height, targetSide);
   const routeGutterX = layout.edgeRouteGutters.get(edgeKey);
+  const routeOffsetY = layout.edgeRouteOffsetsY.get(edgeKey);
   const [path] = getCanvasEdgePath({
     sourceX: sourceAnchor.x,
     sourceY: sourceAnchor.y,
@@ -94,6 +95,7 @@ function buildOneFactoryEdgePathEntry(
     sourcePosition: sourceSide,
     targetPosition: targetSide,
     ...(typeof routeGutterX === "number" ? { routeGutterX } : {}),
+    ...(typeof routeOffsetY === "number" ? { routeOffsetY } : {}),
   });
   return { id: edge.id, path, source: edge.source, target: edge.target };
 }
@@ -159,6 +161,7 @@ type FactoryEdgeRouting = {
   spineEdge: boolean;
   originalChannel: string | undefined;
   routeGutterX: number | undefined;
+  routeOffsetY: number | undefined;
 };
 
 function resolveFactoryEdgeRouting(
@@ -167,13 +170,14 @@ function resolveFactoryEdgeRouting(
 ): FactoryEdgeRouting {
   const edgeKey = factoryRunLeafEdgeKey(edge.source, edge.target, edge.sourceHandle);
   const leafEdge = layout != null && layout.leafEdgeKeys.has(edgeKey);
-  const spineEdge = layout != null && layout.spineEdgeKeys.has(edgeKey) && layout.compactForkNodeIds.has(edge.source);
+  const spineEdge = layout != null && layout.spineEdgeKeys.has(edgeKey);
   const originalChannel =
     typeof edge.sourceHandle === "string" && edge.sourceHandle.length > 0 && edge.sourceHandle !== "default"
       ? edge.sourceHandle
       : undefined;
   const routeGutterX = layout?.edgeRouteGutters.get(edgeKey);
-  return { leafEdge, spineEdge, originalChannel, routeGutterX };
+  const routeOffsetY = layout?.edgeRouteOffsetsY.get(edgeKey);
+  return { leafEdge, spineEdge, originalChannel, routeGutterX, routeOffsetY };
 }
 
 function resolveFactoryEdgeContrastFlags(
@@ -195,11 +199,7 @@ type FactoryEdgeHandlePatch = {
   targetPosition?: Position;
 };
 
-function factoryLeafSpineHandlePatch(
-  routing: FactoryEdgeRouting,
-  edge: CanvasEdge,
-  layout: FactoryRunLeafLayoutResult | null | undefined,
-): FactoryEdgeHandlePatch {
+function factoryRunHandlePatch(routing: FactoryEdgeRouting): FactoryEdgeHandlePatch {
   if (routing.leafEdge) {
     return {
       sourceHandle: FACTORY_SIDE_HANDLE_ID,
@@ -208,15 +208,6 @@ function factoryLeafSpineHandlePatch(
     };
   }
   if (routing.spineEdge) {
-    return {
-      sourceHandle: FACTORY_SPINE_HANDLE_ID,
-      sourcePosition: Position.Bottom,
-      targetPosition: Position.Top,
-    };
-  }
-  // Cycle edges are omitted from leaf/spine keys but compact forks only mount
-  // side/spine ports — remap loop-backs onto the spine handle so paths attach.
-  if (layout?.compactForkNodeIds.has(edge.source)) {
     return {
       sourceHandle: FACTORY_SPINE_HANDLE_ID,
       sourcePosition: Position.Bottom,
@@ -236,6 +227,7 @@ function buildStyledEdgeData(args: {
   layout: FactoryRunLeafLayoutResult | null | undefined;
   originalChannel: string | undefined;
   routeGutterX: number | undefined;
+  routeOffsetY: number | undefined;
   touchesOtherEdge: boolean;
   contrastStroke: boolean;
 }): CanvasEdge["data"] {
@@ -247,6 +239,7 @@ function buildStyledEdgeData(args: {
     onDelete: canMutate ? args.stableEdgeDelete : undefined,
     ...(args.layout && args.originalChannel ? { channelLabel: args.originalChannel } : {}),
     ...(typeof args.routeGutterX === "number" ? { routeGutterX: args.routeGutterX } : {}),
+    ...(typeof args.routeOffsetY === "number" ? { routeOffsetY: args.routeOffsetY } : {}),
     ...(args.touchesOtherEdge ? { touchesOtherEdge: true } : {}),
     ...(args.contrastStroke ? { contrastStroke: true } : {}),
   };
@@ -286,7 +279,7 @@ function styleOneCanvasEdge(args: {
   return {
     ...edge,
     ...args.edgeDefaults,
-    ...factoryLeafSpineHandlePatch(routing, edge, args.layout),
+    ...factoryRunHandlePatch(routing),
     animated: toneVisual.animated,
     className,
     style: { ...args.edgeDefaults.style, ...toneVisual.factoryToneStyle, ...diffStyle },
@@ -300,6 +293,7 @@ function styleOneCanvasEdge(args: {
       layout: args.layout,
       originalChannel: routing.originalChannel,
       routeGutterX: routing.routeGutterX,
+      routeOffsetY: routing.routeOffsetY,
       touchesOtherEdge: contrast.touchesOtherEdge,
       contrastStroke: contrast.contrastStroke,
     }),

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2908,7 +2908,7 @@ function CanvasContent({
       return null;
     }
     return layoutFactoryRunLeafGraph(
-      state.nodes.map((node) => ({ id: node.id })),
+      state.nodes.map((node) => ({ id: node.id, position: node.position })),
       (state.edges ?? []).map((edge) => ({
         id: edge.id,
         source: edge.source,


### PR DESCRIPTION
## Summary

Factory run inspection can place independent roots in one column and overlap feedback edges.

Preserve root lanes and route feedback edges through deterministic X and Y gutters.

Show channel names on edge badges without changing saved canvas positions or edit-mode handles.

## Test plan

- [x] Run `make format.js`.
- [x] Run 60 focused layout, edge, and block tests.
- [x] Run `make check.lint.ui`.
- [x] Run `make check.build.ui`.
- [x] Run the complete UI test suite with 4,344 tests.
