### PR TITLE
fix: add external link icon to work order creator

### DIFF
--- a/web_src/src/pages/factories/sidebar/WorkOrderSidebarOverview.tsx
+++ b/web_src/src/pages/factories/sidebar/WorkOrderSidebarOverview.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useOrgUserLookup } from "@/hooks/useOrgUserLookup";
 import { appPath } from "@/lib/appPaths";
 import { cn } from "@/lib/utils";
-import { Calendar, ChevronDown, CircleDollarSign, CircleDot, Loader2, User, UserPlus } from "lucide-react";
+import { Calendar, ChevronDown, CircleDollarSign, CircleDot, ExternalLink, Loader2, User, UserPlus } from "lucide-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router";
 
@@ -145,9 +145,10 @@ function AutomationLink({
     return (
       <Link
         to={appPath(organizationId, automation.appId)}
-        className="truncate text-foreground underline underline-offset-2 hover:no-underline"
+        className="inline-flex min-w-0 items-center gap-1 text-foreground underline underline-offset-2 hover:no-underline"
       >
-        {label}
+        <span className="truncate">{label}</span>
+        <ExternalLink className="size-3 shrink-0 text-muted-foreground" aria-hidden />
       </Link>
     );
   }


### PR DESCRIPTION
## Summary

- add the `ExternalLink` icon to automation creators in the work order overview
- match the existing activity timeline affordance
- preserve the existing navigation destination

Closes #6682