### PR TITLE
fix: Match blocked hosts in fully qualified form

### DIFF
--- a/pkg/registry/http.go
+++ b/pkg/registry/http.go
@@ -328,9 +328,9 @@ func (c *HTTPContext) validateURLWithPolicy(policy compiledHTTPPolicy, URL *url.
 	//
 	// Check blocked hostnames
 	//
-	hostLower := strings.ToLower(host)
+	normalizedHost := normalizeHost(host)
 	for _, blocked := range policy.blockedHosts {
-		if hostLower == blocked || strings.HasSuffix(hostLower, "."+blocked) {
+		if normalizedHost == blocked || strings.HasSuffix(normalizedHost, "."+blocked) {
 			return fmt.Errorf("access to %s is not allowed", host)
 		}
 	}
@@ -339,13 +339,22 @@ func (c *HTTPContext) validateURLWithPolicy(policy compiledHTTPPolicy, URL *url.
 	// If host is an IP address, validate it immediately
 	// For hostnames, IP validation happens at connection time via the dialer.
 	//
-	if ip := net.ParseIP(host); ip != nil {
+	if ip := net.ParseIP(normalizedHost); ip != nil {
 		if err := c.validateIPWithPolicy(policy, ip); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// normalizeHost prepares a hostname for policy matching. Hostnames are
+// case-insensitive, and the fully qualified form ("example.com.") names the
+// same host as "example.com", so both forms must match the same policy entry.
+// A policy entry can also arrive padded from configuration, so surrounding
+// space is removed here and not at each call site.
+func normalizeHost(host string) string {
+	return strings.TrimRight(strings.ToLower(strings.TrimSpace(host)), ".")
 }
 
 func (c *HTTPContext) validateIP(ip net.IP) error {
@@ -437,7 +446,12 @@ func compileHTTPPolicy(policy HTTPPolicy) (compiledHTTPPolicy, error) {
 	}
 
 	for _, host := range policy.BlockedHosts {
-		compiledPolicy.blockedHosts = append(compiledPolicy.blockedHosts, strings.ToLower(host))
+		normalizedHost := normalizeHost(host)
+		if normalizedHost == "" {
+			continue
+		}
+
+		compiledPolicy.blockedHosts = append(compiledPolicy.blockedHosts, normalizedHost)
 	}
 
 	for _, cidr := range policy.PrivateIPRanges {

--- a/pkg/registry/http_test.go
+++ b/pkg/registry/http_test.go
@@ -113,25 +113,103 @@ func Test__HTTPContext__ValidateURL_AllowsNonBlockedHost(t *testing.T) {
 	require.NoError(t, ctx.validateURL(parsed))
 }
 
-func Test__HTTPContext__ValidateURL__BlockedHostSubdomains(t *testing.T) {
+// Every form below names the same host as the blocked entry it derives from:
+// hostnames are case-insensitive, subdomains inherit the block, and a trailing
+// dot only spells out the fully qualified form.
+func Test__HTTPContext__ValidateURL__BlockedHostEquivalentForms(t *testing.T) {
 	ctx, err := NewHTTPContext(defaultHTTPOptions())
 	require.NoError(t, err)
 
+	forms := []struct {
+		name  string
+		build func(host string) string
+	}{
+		{name: "subdomain", build: func(host string) string { return "sub." + host }},
+		{name: "fully qualified", build: func(host string) string { return host + "." }},
+		{name: "fully qualified subdomain", build: func(host string) string { return "sub." + host + "." }},
+		{name: "fully qualified uppercase", build: func(host string) string { return strings.ToUpper(host) + "." }},
+	}
+
+	for _, host := range blockedHostNames() {
+		for _, form := range forms {
+			t.Run(form.name+"/"+host, func(t *testing.T) {
+				blocked := form.build(host)
+				parsed, err := url.Parse("http://" + blocked)
+				require.NoError(t, err)
+
+				err = ctx.validateURL(parsed)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "access to "+blocked+" is not allowed")
+			})
+		}
+	}
+}
+
+// An IP literal also has a fully qualified form, and the private range check
+// only sees it once the hostname is normalized.
+func Test__HTTPContext__ValidateURL__IPLiteralFullyQualified(t *testing.T) {
+	ctx, err := NewHTTPContext(HTTPOptions{
+		PrivateIPRanges: []string{"127.0.0.0/8"},
+	})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse("http://127.0.0.1./path")
+	require.NoError(t, err)
+
+	err = ctx.validateURL(parsed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access to private IP address 127.0.0.1 is not allowed")
+}
+
+// A blank entry must not act as a wildcard: the suffix comparison would append
+// it to a dot and block every host that a caller writes in fully qualified form.
+func Test__HTTPContext__ValidateURL__BlankBlockedHostsAreIgnored(t *testing.T) {
+	ctx, err := NewHTTPContext(HTTPOptions{
+		BlockedHosts: []string{"", "   ", ".", " example.com "},
+	})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse("https://other.org.")
+	require.NoError(t, err)
+	require.NoError(t, ctx.validateURL(parsed))
+
+	parsed, err = url.Parse("https://example.com")
+	require.NoError(t, err)
+	require.Error(t, ctx.validateURL(parsed))
+}
+
+func Test__HTTPContext__ValidateURL__BlockedHostConfiguredAsFullyQualified(t *testing.T) {
+	ctx, err := NewHTTPContext(HTTPOptions{
+		BlockedHosts: []string{"Internal.Example.Com."},
+	})
+	require.NoError(t, err)
+
+	for _, rawURL := range []string{"https://internal.example.com", "https://internal.example.com.", "https://api.internal.example.com."} {
+		t.Run(rawURL, func(t *testing.T) {
+			parsed, err := url.Parse(rawURL)
+			require.NoError(t, err)
+			require.Error(t, ctx.validateURL(parsed))
+		})
+	}
+
+	parsed, err := url.Parse("https://internal.example.com.other.org")
+	require.NoError(t, err)
+	require.NoError(t, ctx.validateURL(parsed))
+}
+
+// blockedHostNames returns the default blocked hosts that are names, dropping
+// the entries that are IP literals and take no subdomain or trailing dot.
+func blockedHostNames() []string {
+	names := make([]string, 0, len(defaultHTTPOptions().BlockedHosts))
 	for _, host := range defaultHTTPOptions().BlockedHosts {
 		if strings.Contains(host, ":") || net.ParseIP(host) != nil {
 			continue
 		}
 
-		subdomain := "sub." + host
-		t.Run(subdomain, func(t *testing.T) {
-			parsed, err := url.Parse("http://" + subdomain)
-			require.NoError(t, err)
-
-			err = ctx.validateURL(parsed)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "access to "+subdomain+" is not allowed")
-		})
+		names = append(names, host)
 	}
+
+	return names
 }
 
 func Test__HTTPContext__ValidateIP_IPv4MappedIPv6(t *testing.T) {
@@ -164,6 +242,15 @@ func Test__HTTPContext__Do(t *testing.T) {
 		_, err = ctx.Do(req)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "access to example.com is not allowed")
+	})
+
+	t.Run("blocked host in fully qualified form", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com./path", nil)
+		require.NoError(t, err)
+
+		_, err = ctx.Do(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access to example.com. is not allowed")
 	})
 
 	t.Run("private IP", func(t *testing.T) {


### PR DESCRIPTION
## Summary

The outbound HTTP policy compares a URL hostname with the blocked host list
after a lowercase conversion only. DNS gives the same meaning to
`metadata.google.internal` and to `metadata.google.internal.` with the trailing
dot, but the comparison does not. A URL that uses the fully qualified form
passes the hostname gate.

The default policy also blocks the metadata IP ranges, and the dialer validates
the resolved IP for each connection, so a default installation stays protected.
An operator who adds an internal host to `BLOCKED_HTTP_HOSTS` gets no
protection when that host resolves to a public address.

## Approach

`normalizeHost` prepares a hostname for the comparison. The request path and
the policy compile path use the same function, so a URL and a policy entry that
name the same host always match.

The function also removes the surrounding space. A padded entry from
configuration now matches. The policy drops a blank entry, because the suffix
comparison adds a blank entry to a dot and blocks every host that a caller
writes in the fully qualified form.

Behavior that does not change:

- A host that only shares a suffix stays allowed
  (`internal.example.com.other.org` does not match `internal.example.com`).
- The dialer keeps the IP check for each connection.

## Test plan

- [x] `make test PKG_TEST_PACKAGES=./pkg/registry` passes.
- [x] The new cases fail against the previous `validateURLWithPolicy`, and the
      cases for the subdomain form still pass.
- [x] `make format.go`, `make lint`, and `go vet ./pkg/registry/` report no
      findings.
- [x] `ctx.Do` refuses `http://example.com./path` when the policy blocks
      `example.com`.

## Note for reviewers

PR #6471 also changes `pkg/registry/http.go` and `pkg/registry/http_test.go`.
It adds typed policy errors and removes sensitive headers on a cross-origin
redirect. It changes `checkRedirect`, `dialer`, `doWithTransaction`, `do`, and
`LimitedReadCloser`. This PR changes the hostname comparison in
`validateURLWithPolicy` and the host list in `compileHTTPPolicy`. The two sets
of changes do not overlap.
