### PR TITLE
feat: Add factory Velocity dashboard

### DIFF
--- a/web_src/src/pages/factories/pages/ComingSoon.stories.tsx
+++ b/web_src/src/pages/factories/pages/ComingSoon.stories.tsx
@@ -3,11 +3,10 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
 import { MissionsPage } from "./MissionsPage";
-import { VelocityPage } from "./VelocityPage";
 import { WikiPage } from "./WikiPage";
 
 /**
- * Missions/Wiki/Velocity landing pages — all render the ComingSoon placeholder.
+ * Missions/Wiki landing pages — ComingSoon placeholders.
  */
 const meta = {
   title: "Factories/Pages/Coming Soon",
@@ -37,16 +36,6 @@ export const Wiki: Story = {
   ),
 };
 
-export const Velocity: Story = {
-  render: () => (
-    <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/velocity`}
-      factoriesFixture={defaultFactoriesFixture}
-    />
-  ),
-};
-
 // Direct component references so Storybook's DevTools recognise them.
 void MissionsPage;
-void VelocityPage;
 void WikiPage;

--- a/web_src/src/pages/factories/pages/Velocity.stories.tsx
+++ b/web_src/src/pages/factories/pages/Velocity.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
+import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
+import { VelocityPage } from "./VelocityPage";
+
+/**
+ * Velocity page: yesterday snapshot, SuperPlane output trend, and source split.
+ */
+const meta = {
+  title: "Factories/Pages/Velocity",
+  component: VelocityPage,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof VelocityPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/velocity`}
+      factoriesFixture={defaultFactoriesFixture}
+    />
+  ),
+};

--- a/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { FACTORY_VELOCITY_BY_PERIOD, FACTORY_VELOCITY_YESTERDAY } from "./factoryVelocityMockData";
+import { VelocityPage } from "./VelocityPage";
+
+describe("VelocityPage", () => {
+  it("shows yesterday metrics, period pills, trend, and source split", () => {
+    render(<VelocityPage />);
+
+    expect(screen.getByRole("heading", { name: "Velocity" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "7d" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "30d" })).toBeInTheDocument();
+
+    const yesterday = screen.getByTestId("velocity-yesterday");
+    expect(yesterday).toHaveTextContent("Yesterday");
+    expect(yesterday).toHaveTextContent(String(FACTORY_VELOCITY_YESTERDAY.merged));
+    expect(yesterday).toHaveTextContent("Merged PRs");
+    expect(yesterday).toHaveTextContent("Waste");
+    expect(yesterday).toHaveTextContent("Cost");
+    expect(yesterday).toHaveTextContent("Cost per merged PR");
+
+    const trend = screen.getByTestId("velocity-trend");
+    expect(trend).toHaveTextContent("Last 7 days");
+    expect(trend).toHaveTextContent(String(FACTORY_VELOCITY_BY_PERIOD[7].totals.merged));
+    expect(trend).toHaveTextContent("SuperPlane output");
+
+    const split = screen.getByTestId("velocity-source-split");
+    expect(split).toHaveTextContent("Merged PRs by source");
+    expect(split).toHaveTextContent("SuperPlane");
+    expect(split).toHaveTextContent(`${FACTORY_VELOCITY_BY_PERIOD[7].totals.superplaneSharePct}%`);
+  });
+
+  it("updates trend totals when the period changes and keeps yesterday fixed", async () => {
+    const user = userEvent.setup();
+    render(<VelocityPage />);
+
+    const yesterdayMerged = FACTORY_VELOCITY_YESTERDAY.merged;
+    expect(screen.getByTestId("velocity-yesterday")).toHaveTextContent(String(yesterdayMerged));
+
+    await user.click(screen.getByRole("tab", { name: "30d" }));
+
+    expect(screen.getByRole("tab", { name: "30d" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("velocity-trend")).toHaveTextContent("Last 30 days");
+    expect(screen.getByTestId("velocity-trend")).toHaveTextContent(
+      String(FACTORY_VELOCITY_BY_PERIOD[30].totals.merged),
+    );
+    expect(screen.getByTestId("velocity-yesterday")).toHaveTextContent(String(yesterdayMerged));
+  });
+});

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -1,8 +1,324 @@
-import { Gauge } from "lucide-react";
-import { ComingSoonPage } from "./ComingSoonPage";
+import { useState } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
+import { Heading } from "@/components/Heading/heading";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+import { SegmentedNav } from "@/ui/SegmentedNav";
+import {
+  FACTORY_VELOCITY_BY_PERIOD,
+  FACTORY_VELOCITY_YESTERDAY,
+  type FactoryVelocityDay,
+  type FactoryVelocityPeriodDays,
+  type FactoryVelocityYesterday,
+} from "./factoryVelocityMockData";
+import {
+  factoryContentBodyClassName,
+  factoryContentHeaderClassName,
+  factoryPageSubtitleClassName,
+  factoryPageTitleClassName,
+} from "./factoryPageLayoutStyles";
+
+const PERIOD_OPTIONS: { value: string; label: string }[] = [
+  { value: "7", label: "7d" },
+  { value: "30", label: "30d" },
+];
+
+const outputChartConfig = {
+  merged: { label: "Merged", color: "#10b981" },
+  waste: { label: "Waste", color: "#ef4444" },
+} satisfies ChartConfig;
+
+const costChartConfig = {
+  costUsd: { label: "Cost", color: "#64748b" },
+} satisfies ChartConfig;
+
+const sourceChartConfig = {
+  peopleMerged: { label: "People", color: "#64748b" },
+  superplaneMerged: { label: "SuperPlane", color: "#10b981" },
+} satisfies ChartConfig;
+
+function formatUsd(value: number) {
+  return `$${value.toFixed(2)}`;
+}
+
+function formatTokens(value: number) {
+  if (value >= 1000) {
+    const thousands = value / 1000;
+    return `${thousands % 1 === 0 ? thousands.toFixed(0) : thousands.toFixed(1)}k`;
+  }
+  return String(value);
+}
+
+function formatPct(value: number) {
+  return `${value}%`;
+}
+
+function MetricCell({ value, label, hint }: { value: string; label: string; hint?: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-[12px] text-muted-foreground">{label}</p>
+      <p className="mt-2 text-[32px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+        {value}
+      </p>
+      {hint ? <p className="mt-2 min-h-[1rem] text-[12px] text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+type YesterdayMetric = {
+  value: string;
+  label: string;
+  hint: string;
+};
+
+function yesterdayMetrics(snapshot: FactoryVelocityYesterday): YesterdayMetric[] {
+  return [
+    { value: String(snapshot.merged), label: "Merged PRs", hint: "Productive SuperPlane work" },
+    { value: String(snapshot.waste), label: "Waste", hint: `${formatPct(snapshot.wastePct)} of SuperPlane output` },
+    { value: formatUsd(snapshot.costUsd), label: "Cost", hint: `${formatTokens(snapshot.tokens)} tokens` },
+    { value: formatUsd(snapshot.costPerMergedPr), label: "Cost per merged PR", hint: "Average spend" },
+  ];
+}
+
+function YesterdayCard({ snapshot }: { snapshot: FactoryVelocityYesterday }) {
+  const metrics = yesterdayMetrics(snapshot);
+
+  return (
+    <section
+      className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5"
+      data-testid="velocity-yesterday"
+    >
+      <p className="text-[12px] font-medium text-foreground">{snapshot.dateLabel}</p>
+      <div className="mt-5 grid grid-cols-2 gap-x-8 gap-y-5 sm:grid-cols-4">
+        {metrics.map((metric) => (
+          <div key={metric.label} className="min-w-0">
+            <p className="text-[12px] text-muted-foreground">{metric.label}</p>
+            <p className="mt-2 text-[32px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+              {metric.value}
+            </p>
+            <p className="mt-2 min-h-[1rem] text-[12px] text-muted-foreground">{metric.hint}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DailyOutputChart({ points, days }: { points: FactoryVelocityDay[]; days: FactoryVelocityPeriodDays }) {
+  const height = days === 7 ? 240 : 220;
+
+  return (
+    <ChartContainer
+      config={outputChartConfig}
+      className="aspect-auto w-full"
+      style={{ height }}
+      initialDimension={{ width: 720, height }}
+    >
+      <BarChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis
+          allowDecimals={false}
+          tickLine={false}
+          axisLine={false}
+          width={28}
+          tickMargin={4}
+          className="text-[11px]"
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+        <Bar dataKey="merged" stackId="day" fill="var(--color-merged)" maxBarSize={days === 7 ? 36 : 12} />
+        <Bar
+          dataKey="waste"
+          stackId="day"
+          fill="var(--color-waste)"
+          radius={[3, 3, 0, 0]}
+          maxBarSize={days === 7 ? 36 : 12}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+function CostSparkline({ points, days }: { points: FactoryVelocityDay[]; days: FactoryVelocityPeriodDays }) {
+  const height = days === 7 ? 180 : 160;
+
+  return (
+    <ChartContainer
+      config={costChartConfig}
+      className="aspect-auto w-full"
+      style={{ height }}
+      initialDimension={{ width: 720, height }}
+    >
+      <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={44}
+          tickMargin={4}
+          className="text-[11px]"
+          tickFormatter={(value: number) => `$${Number(value).toFixed(0)}`}
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <Area
+          type="monotone"
+          dataKey="costUsd"
+          stroke="var(--color-costusd)"
+          fill="var(--color-costusd)"
+          fillOpacity={0.12}
+          strokeWidth={1.5}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+function TrendCard({ periodDays }: { periodDays: FactoryVelocityPeriodDays }) {
+  const period = FACTORY_VELOCITY_BY_PERIOD[periodDays];
+
+  return (
+    <section className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5" data-testid="velocity-trend">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">SuperPlane output</h2>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">Merged, waste, and cost by day.</p>
+        </div>
+        <p className="text-[12px] text-muted-foreground">{period.label}</p>
+      </div>
+
+      <div className="mt-5 grid grid-cols-2 gap-x-8 gap-y-5 sm:grid-cols-3">
+        <MetricCell value={String(period.totals.merged)} label="Merged PRs" />
+        <MetricCell
+          value={String(period.totals.waste)}
+          label="Waste"
+          hint={`${formatPct(period.totals.wastePct)} of SuperPlane output`}
+        />
+        <MetricCell value={formatUsd(period.totals.costUsd)} label="Cost" />
+      </div>
+
+      <div className="mt-6">
+        <DailyOutputChart points={period.points} days={period.days} />
+      </div>
+
+      <div className="mt-4 border-t border-border pt-3">
+        <p className="mb-1 text-[12px] text-muted-foreground">Cost</p>
+        <CostSparkline points={period.points} days={period.days} />
+      </div>
+    </section>
+  );
+}
+
+function SourceSplitCard({ periodDays }: { periodDays: FactoryVelocityPeriodDays }) {
+  const period = FACTORY_VELOCITY_BY_PERIOD[periodDays];
+  const height = period.days === 7 ? 200 : 180;
+
+  return (
+    <section
+      className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5"
+      data-testid="velocity-source-split"
+    >
+      <div>
+        <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">Merged PRs by source</h2>
+        <p className="mt-0.5 text-[12px] text-muted-foreground">
+          SuperPlane authored {formatPct(period.totals.superplaneSharePct)} of merged PRs in this period.
+        </p>
+      </div>
+
+      <div className="mt-5 grid grid-cols-2 gap-x-8 gap-y-5">
+        <MetricCell value={String(period.totals.peopleMerged)} label="People" />
+        <MetricCell value={String(period.totals.superplaneMerged)} label="SuperPlane" />
+      </div>
+
+      <div className="mt-6">
+        <ChartContainer
+          config={sourceChartConfig}
+          className="aspect-auto w-full"
+          style={{ height }}
+          initialDimension={{ width: 720, height }}
+        >
+          <LineChart data={period.points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+            <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="day"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              interval={0}
+              className="text-[11px]"
+            />
+            <YAxis
+              allowDecimals={false}
+              tickLine={false}
+              axisLine={false}
+              width={28}
+              tickMargin={4}
+              className="text-[11px]"
+            />
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+            <Line
+              type="monotone"
+              dataKey="peopleMerged"
+              stroke="var(--color-peoplemerged)"
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="superplaneMerged"
+              stroke="var(--color-superplanemerged)"
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        </ChartContainer>
+      </div>
+    </section>
+  );
+}
 
 export function VelocityPage() {
+  const [periodDays, setPeriodDays] = useState<FactoryVelocityPeriodDays>(7);
+
   return (
-    <ComingSoonPage title="Velocity" description="Track how quickly work moves through the workspace." Icon={Gauge} />
+    <>
+      <header className={factoryContentHeaderClassName}>
+        <div>
+          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
+            Velocity
+          </Heading>
+          <p className={cn("mt-1", factoryPageSubtitleClassName)}>
+            Merged pull requests from SuperPlane, waste, and cost.
+          </p>
+        </div>
+      </header>
+
+      <div className={cn(factoryContentBodyClassName, "space-y-6")} data-testid="factory-velocity-page">
+        <YesterdayCard snapshot={FACTORY_VELOCITY_YESTERDAY} />
+        <div className="flex justify-end">
+          <SegmentedNav
+            ariaLabel="Velocity period in days"
+            size="xs"
+            value={String(periodDays)}
+            onValueChange={(value) => {
+              const next = Number(value);
+              if (next === 7 || next === 30) setPeriodDays(next);
+            }}
+            options={PERIOD_OPTIONS}
+          />
+        </div>
+        <TrendCard periodDays={periodDays} />
+        <SourceSplitCard periodDays={periodDays} />
+      </div>
+    </>
   );
 }

--- a/web_src/src/pages/factories/pages/factoryVelocityMockData.ts
+++ b/web_src/src/pages/factories/pages/factoryVelocityMockData.ts
@@ -1,0 +1,153 @@
+export type FactoryVelocityPeriodDays = 7 | 30;
+
+export type FactoryVelocityDay = {
+  day: string;
+  merged: number;
+  waste: number;
+  costUsd: number;
+  tokens: number;
+  superplaneMerged: number;
+  peopleMerged: number;
+};
+
+export type FactoryVelocityYesterday = {
+  dateLabel: string;
+  merged: number;
+  waste: number;
+  wastePct: number;
+  costUsd: number;
+  tokens: number;
+  costPerMergedPr: number;
+};
+
+export type FactoryVelocityTotals = {
+  merged: number;
+  waste: number;
+  wastePct: number;
+  costUsd: number;
+  superplaneMerged: number;
+  peopleMerged: number;
+  superplaneSharePct: number;
+};
+
+export type FactoryVelocityPeriod = {
+  days: FactoryVelocityPeriodDays;
+  label: string;
+  points: FactoryVelocityDay[];
+  totals: FactoryVelocityTotals;
+};
+
+function pct(part: number, whole: number) {
+  if (whole <= 0) return 0;
+  return Math.round((part / whole) * 100);
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function totalsFrom(points: FactoryVelocityDay[]): FactoryVelocityTotals {
+  const merged = points.reduce((sum, point) => sum + point.merged, 0);
+  const waste = points.reduce((sum, point) => sum + point.waste, 0);
+  const costUsd = Math.round(points.reduce((sum, point) => sum + point.costUsd, 0) * 100) / 100;
+  const superplaneMerged = points.reduce((sum, point) => sum + point.superplaneMerged, 0);
+  const peopleMerged = points.reduce((sum, point) => sum + point.peopleMerged, 0);
+  return {
+    merged,
+    waste,
+    wastePct: pct(waste, merged + waste),
+    costUsd,
+    superplaneMerged,
+    peopleMerged,
+    superplaneSharePct: pct(superplaneMerged, superplaneMerged + peopleMerged),
+  };
+}
+
+function peopleMergedForDay(index: number, isWeekend: boolean) {
+  const base = isWeekend ? 20 : 25;
+  return Math.max(16, Math.round(base + 3 * Math.sin(index * 0.7)));
+}
+
+/** SuperPlane starts at 0, then ramps to about 20–30% of people volume (3–10 PRs). */
+function superplaneMergedForDay(index: number, peopleMerged: number) {
+  if (index < 2) return 0;
+  if (index === 2) return 2;
+  if (index === 3) return 3;
+  if (index === 4) return 4;
+
+  const share = 0.24 + 0.05 * Math.sin(index * 0.45);
+  return clamp(Math.round(peopleMerged * share), 3, 10);
+}
+
+function buildDay(index: number, day: string, weekday: string): FactoryVelocityDay {
+  const isWeekend = weekday === "Sat" || weekday === "Sun";
+  const peopleMerged = peopleMergedForDay(index, isWeekend);
+  const superplaneMerged = superplaneMergedForDay(index, peopleMerged);
+  const waste = superplaneMerged === 0 ? 0 : Math.max(0, Math.round(superplaneMerged * (isWeekend ? 0.3 : 0.18)));
+  const costUsd = superplaneMerged === 0 ? 0 : Math.round(superplaneMerged * 1.85 * 100) / 100;
+
+  return {
+    day,
+    merged: superplaneMerged,
+    waste,
+    costUsd,
+    tokens: superplaneMerged * 18500,
+    superplaneMerged,
+    peopleMerged,
+  };
+}
+
+const WEEKDAYS = ["Fri", "Sat", "Sun", "Mon", "Tue", "Wed", "Thu"] as const;
+
+const WEEK_POINTS: FactoryVelocityDay[] = WEEKDAYS.map((weekday, index) => buildDay(index, weekday, weekday));
+
+function buildMonthPoints(): FactoryVelocityDay[] {
+  return Array.from({ length: 30 }, (_, index) => {
+    const weekday = WEEKDAYS[index % 7] ?? "Mon";
+    const dayNumber = index + 1;
+    const day = dayNumber % 5 === 1 || dayNumber === 30 ? String(dayNumber) : "";
+    return buildDay(index, day, weekday);
+  });
+}
+
+const MONTH_POINTS = buildMonthPoints();
+
+/** Last complete day. Fixed, not affected by the period pills. */
+export const FACTORY_VELOCITY_YESTERDAY: FactoryVelocityYesterday = (() => {
+  const yesterday = WEEK_POINTS[WEEK_POINTS.length - 1];
+  if (!yesterday) {
+    return {
+      dateLabel: "Yesterday",
+      merged: 0,
+      waste: 0,
+      wastePct: 0,
+      costUsd: 0,
+      tokens: 0,
+      costPerMergedPr: 0,
+    };
+  }
+  return {
+    dateLabel: "Yesterday",
+    merged: yesterday.merged,
+    waste: yesterday.waste,
+    wastePct: pct(yesterday.waste, yesterday.merged + yesterday.waste),
+    costUsd: yesterday.costUsd,
+    tokens: yesterday.tokens,
+    costPerMergedPr: yesterday.merged > 0 ? Math.round((yesterday.costUsd / yesterday.merged) * 100) / 100 : 0,
+  };
+})();
+
+export const FACTORY_VELOCITY_BY_PERIOD: Record<FactoryVelocityPeriodDays, FactoryVelocityPeriod> = {
+  7: {
+    days: 7,
+    label: "Last 7 days",
+    points: WEEK_POINTS,
+    totals: totalsFrom(WEEK_POINTS),
+  },
+  30: {
+    days: 30,
+    label: "Last 30 days",
+    points: MONTH_POINTS,
+    totals: totalsFrom(MONTH_POINTS),
+  },
+};


### PR DESCRIPTION
## Summary

- Replaces the factory Velocity Coming soon page with a dashboard for SuperPlane pull-request output.
- Shows yesterday merged PRs, waste, and cost, then a 7-day or 30-day trend for SuperPlane output and spend.
- Adds a people vs SuperPlane source chart so operators can see how much merged work SuperPlane authors.

## Test plan

- [ ] Open Storybook → Factories / Pages / Velocity
- [ ] Confirm Yesterday metrics use label-first type and stay fixed when the period changes
- [ ] Switch 7d and 30d and confirm SuperPlane output bars and Cost axes update
- [ ] Confirm Merged PRs by source shows People and SuperPlane lines
- [ ] Open the factory Velocity nav item in the app and confirm the same page
- [ ] Spot-check light and dark


Made with [Cursor](https://cursor.com)