### PR TITLE
feat: Add Storybook Workspace Settings Pages

### DIFF
--- a/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
+++ b/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
@@ -38,9 +38,15 @@ import type { FactoriesFixture } from "@/pages/factories/__fixtures__/handlers";
 import { createFactoryLinePath, editFactoryLinePath } from "@/pages/factories/lib/factoryPagePaths";
 import { ConfigureAutomationPage } from "@/pages/factories/pages/ConfigureAutomationPage";
 import { OnboardingGate } from "@/pages/factories/pages/onboarding/OnboardingGate";
+import {
+  resolveFactorySettingsPage,
+  type FactorySettingsPageOverrides,
+} from "@/pages/factories/pages/settings/settingsStorybookPages";
 import { HomePage } from "@/pages/home";
 import { homePageIds, type HomePageFixture } from "@/pages/home/__fixtures__/handlers";
 import { NewAppPage } from "@/pages/home/NewAppPage";
+import { IntegrationDetailsRoute } from "@/pages/organization/settings/components/IntegrationDetailsRoute";
+import { SecretDetail } from "@/pages/organization/settings/SecretDetail";
 import type { AgentSuggestion } from "@/ui/CanvasPage";
 import { TooltipProvider } from "@/ui/tooltip";
 
@@ -77,6 +83,8 @@ export interface OrgWorkspacePageOverrides {
   overview?: ComponentType;
   /** When set, mounts `/onboarding` and gates other factory pages while pending. */
   onboarding?: ComponentType;
+  /** Workspace settings sections. Live App routes stay Coming Soon. */
+  settings?: FactorySettingsPageOverrides;
 }
 
 export interface OrgWorkspaceHarnessProps {
@@ -189,6 +197,22 @@ function OptionalOnboardingGate({ enabled }: { enabled: boolean }) {
   return <OnboardingGate />;
 }
 
+function HarnessSecretDetailPage() {
+  const { organizationId } = useParams<{ organizationId: string }>();
+  if (!organizationId) {
+    return null;
+  }
+  return <SecretDetail organizationId={organizationId} />;
+}
+
+function HarnessIntegrationDetailsPage() {
+  const { organizationId } = useParams<{ organizationId: string }>();
+  if (!organizationId) {
+    return null;
+  }
+  return <IntegrationDetailsRoute organizationId={organizationId} />;
+}
+
 function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePageOverrides }) {
   const WikiRoutePage = pageOverrides?.wiki ?? WikiPage;
   const OverviewRoutePage = pageOverrides?.overview ?? OverviewPage;
@@ -244,25 +268,34 @@ function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePag
           <Route path=":factoryKey/settings" element={factoryRoute(<FactorySettingsLayout />)}>
             <Route index element={<Navigate to={FACTORY_SETTINGS_NAV_ITEMS[0].id} replace />} />
             <Route path="general" element={<FactorySettingsGeneralPage />} />
-            {FACTORY_SETTINGS_NAV_ITEMS.filter((item) => item.id !== "general").map((item) => (
-              <Route
-                key={item.id}
-                path={item.id}
-                element={
-                  <FactorySettingsSoonPage
-                    title={item.label}
-                    description={`${item.label} settings for this workspace.`}
-                    Icon={item.Icon}
-                  />
-                }
-              />
-            ))}
+            {FACTORY_SETTINGS_NAV_ITEMS.filter((item) => item.id !== "general").map((item) => {
+              const OverridePage = resolveFactorySettingsPage(item.id, pageOverrides?.settings);
+              return (
+                <Route
+                  key={item.id}
+                  path={item.id}
+                  element={
+                    OverridePage ? (
+                      <OverridePage />
+                    ) : (
+                      <FactorySettingsSoonPage
+                        title={item.label}
+                        description={`${item.label} settings for this workspace.`}
+                        Icon={item.Icon}
+                      />
+                    )
+                  }
+                />
+              );
+            })}
           </Route>
         </Route>
         <Route
           path="settings/integrations/:integrationName/setup"
           element={<div data-testid="integration-setup-placeholder">Integration setup</div>}
         />
+        <Route path="settings/integrations/:integrationId" element={<HarnessIntegrationDetailsPage />} />
+        <Route path="settings/secrets/:secretId" element={<HarnessSecretDetailPage />} />
       </Route>
     </Routes>
   );

--- a/web_src/src/pages/__fixtures__/createOrgWorkspaceFixtureFetch.ts
+++ b/web_src/src/pages/__fixtures__/createOrgWorkspaceFixtureFetch.ts
@@ -7,6 +7,8 @@ import { matchCanvasAppFixture, type CanvasAppFixture } from "@/pages/app/__fixt
 import {
   factoriesOrganizationUsersResponse,
   matchFactoryPageFixture,
+  matchFactorySettingsFixture,
+  STORYBOOK_CONNECTED_ORG_INTEGRATIONS,
   type FactoriesFixture,
 } from "@/pages/factories/__fixtures__/handlers";
 import {
@@ -57,7 +59,9 @@ export function createOrgWorkspaceFixtureFetch(
   // would permanently alter the module-level `defaultFactoriesFixture` (and every
   // fixture that shares nested arrays with it).
   const factoriesFixture = options?.factoriesFixture ? structuredClone(options.factoriesFixture) : undefined;
-  const orgIntegrations: StorybookOrgIntegration[] = [];
+  const orgIntegrations: StorybookOrgIntegration[] = factoriesFixture
+    ? structuredClone(STORYBOOK_CONNECTED_ORG_INTEGRATIONS)
+    : [];
   const agentMessages = createStorybookAgentMessageStore(appFixture?.agentMessages?.messages);
 
   const impl = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -115,7 +119,7 @@ function resolveFactoryFixtures(
   factoriesFixture: FactoriesFixture | undefined,
 ) {
   if (!factoriesFixture) {
-    return { factoryPagesResolved: null, factoryUsersResolved: null };
+    return { factoryPagesResolved: null, factoryUsersResolved: null, factorySettingsResolved: null };
   }
   const factoryPagesResolved = matchFactoryPageFixture(
     url,
@@ -125,7 +129,8 @@ function resolveFactoryFixtures(
   );
   const factoryUsersResolved =
     url.pathname === "/api/v1/users" && method === "GET" ? factoriesOrganizationUsersResponse() : null;
-  return { factoryPagesResolved, factoryUsersResolved };
+  const factorySettingsResolved = matchFactorySettingsFixture(url, method);
+  return { factoryPagesResolved, factoryUsersResolved, factorySettingsResolved };
 }
 
 async function resolveOrgWorkspaceFixture(args: {
@@ -144,7 +149,12 @@ async function resolveOrgWorkspaceFixture(args: {
   const homeResolved = matchHomePageFixture(url, method, homeFixture);
   const canvasResolved = matchCanvasAppFixture(url, appFixture, method, body);
   const factorySetupResolved = await matchFactorySetupFixture(url, method, input, init, orgIntegrations);
-  const { factoryPagesResolved, factoryUsersResolved } = resolveFactoryFixtures(url, method, body, factoriesFixture);
+  const { factoryPagesResolved, factoryUsersResolved, factorySettingsResolved } = resolveFactoryFixtures(
+    url,
+    method,
+    body,
+    factoriesFixture,
+  );
   // AppPageHarness always supplies `appFixture`, so canvas integrations win there.
   // HomePageHarness omits it, so factory GitHub/Claude stubs stay available for setup.
   if (url.pathname === "/api/v1/integrations" && method === "GET" && appFixture !== undefined) {
@@ -153,6 +163,7 @@ async function resolveOrgWorkspaceFixture(args: {
   return (
     factoryPagesResolved ??
     factoryUsersResolved ??
+    factorySettingsResolved ??
     factorySetupResolved ??
     homeResolved ??
     canvasResolved ??

--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.tsx
@@ -7,9 +7,16 @@ import { OnboardingStorybookProvider } from "../pages/onboarding/OnboardingStory
 import { OnboardingWireframe } from "../pages/onboarding/OnboardingWireframe";
 import type { OnboardingStorybookSeed } from "../pages/onboarding/onboardingMocks";
 import { StorybookOverviewPage } from "../pages/onboarding/StorybookOverviewPage";
+import { STORYBOOK_FACTORY_SETTINGS_PAGES } from "../pages/settings/settingsStorybookPages";
 import { WikiWireframe } from "../pages/wiki/WikiWireframe";
 import { WIKI_DOCUMENTS_DEFAULT, WIKI_DOCUMENTS_REFRESHED } from "../pages/wiki/wikiMocks";
-import { defaultFactoriesFixture, FACTORIES_ORGANIZATION_ID, type FactoriesFixture } from "./factoryPageResponses";
+import { STORYBOOK_WORKSPACE_CONNECTIONS } from "../pages/settings/settingsPrototype/workspaceConnections";
+import {
+  defaultFactoriesFixture,
+  FACTORIES_ORGANIZATION_ID,
+  PRIMARY_FACTORY_ID,
+  type FactoriesFixture,
+} from "./factoryPageResponses";
 
 interface FactoriesHarnessProps {
   /** Path under the org. Defaults to `workspaces` (list page). */
@@ -23,6 +30,8 @@ interface FactoriesHarnessProps {
    * Wiki defaults to the wireframe so sidebar navigation shows it; pass
    * `pageOverrides={{ wiki: WikiPage }}` to keep Coming Soon.
    * Onboarding + Get started overview are enabled by default.
+   * Members, Integrations, and Secrets default to the org settings pages.
+   * Repositories and Models show the onboarding selections.
    */
   pageOverrides?: OrgWorkspacePageOverrides;
   /** Seed pending providers/repos/tips for onboarding stories. */
@@ -73,8 +82,13 @@ export function FactoriesHarness({
               overview: StorybookOverviewPage,
               onboarding: OnboardingWireframe,
               ...pageOverrides,
+              settings: { ...STORYBOOK_FACTORY_SETTINGS_PAGES, ...pageOverrides?.settings },
             }
-          : { wiki: DefaultWikiWireframe, ...pageOverrides }
+          : {
+              wiki: DefaultWikiWireframe,
+              ...pageOverrides,
+              settings: { ...STORYBOOK_FACTORY_SETTINGS_PAGES, ...pageOverrides?.settings },
+            }
       }
     />
   );
@@ -83,5 +97,23 @@ export function FactoriesHarness({
     return harness;
   }
 
-  return <OnboardingStorybookProvider initial={onboardingSeed}>{harness}</OnboardingStorybookProvider>;
+  return (
+    <OnboardingStorybookProvider initial={withDefaultWorkspaceConnections(onboardingSeed)}>
+      {harness}
+    </OnboardingStorybookProvider>
+  );
+}
+
+function withDefaultWorkspaceConnections(seed?: OnboardingStorybookSeed): OnboardingStorybookSeed {
+  return {
+    ...seed,
+    enabledReposByWorkspace: {
+      [PRIMARY_FACTORY_ID]: STORYBOOK_WORKSPACE_CONNECTIONS.repos,
+      ...seed?.enabledReposByWorkspace,
+    },
+    connectionsByWorkspace: {
+      [PRIMARY_FACTORY_ID]: STORYBOOK_WORKSPACE_CONNECTIONS,
+      ...seed?.connectionsByWorkspace,
+    },
+  };
 }

--- a/web_src/src/pages/factories/__fixtures__/handlers.spec.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.spec.ts
@@ -29,4 +29,61 @@ describe("matchFactoryPageFixture", () => {
       apps: expect.arrayContaining([expect.objectContaining({ name: "Refund Planner" })]),
     });
   });
+
+  it("serves workspace settings members, roles, secrets, and invite link", async () => {
+    const users = await fetchFactoryPageFixture("/api/v1/users");
+    await expect(users.json()).resolves.toMatchObject({
+      users: expect.arrayContaining([
+        expect.objectContaining({
+          spec: { displayName: "Storybook User" },
+          status: { roles: [expect.objectContaining({ roleName: "org_owner", roleDisplayName: "Owner" })] },
+        }),
+      ]),
+    });
+
+    const roles = await fetchFactoryPageFixture("/api/v1/roles");
+    await expect(roles.json()).resolves.toMatchObject({
+      roles: expect.arrayContaining([expect.objectContaining({ metadata: { name: "org_admin" } })]),
+    });
+
+    const secrets = await fetchFactoryPageFixture("/api/v1/secrets");
+    await expect(secrets.json()).resolves.toMatchObject({
+      secrets: expect.arrayContaining([
+        expect.objectContaining({ metadata: expect.objectContaining({ name: "openai" }) }),
+      ]),
+    });
+
+    const secret = await fetchFactoryPageFixture("/api/v1/secrets/secret-openai");
+    await expect(secret.json()).resolves.toMatchObject({
+      secret: expect.objectContaining({ metadata: { id: "secret-openai", name: "openai" } }),
+    });
+
+    const invite = await fetchFactoryPageFixture("/api/v1/organizations/org-1/invite-link");
+    await expect(invite.json()).resolves.toMatchObject({
+      inviteLink: expect.objectContaining({ token: "storybook-invite-token", enabled: true }),
+    });
+  });
+
+  it("serves the organization integrations catalog and connected instances", async () => {
+    const catalog = await fetchFactoryPageFixture("/api/v1/integrations");
+    const catalogBody = (await catalog.json()) as { integrations: Array<{ name?: string; description?: string }> };
+    const names = catalogBody.integrations.map((entry) => entry.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["github", "gitlab", "slack", "linear", "jira", "claude", "datadog", "aws"]),
+    );
+    expect(catalogBody.integrations.length).toBeGreaterThan(20);
+    expect(catalogBody.integrations.find((entry) => entry.name === "github")?.description).toBe(
+      "Manage and react to changes in your GitHub repositories",
+    );
+
+    const connected = await fetchFactoryPageFixture("/api/v1/organizations/org-1/integrations");
+    await expect(connected.json()).resolves.toMatchObject({
+      integrations: expect.arrayContaining([
+        expect.objectContaining({
+          metadata: expect.objectContaining({ integrationName: "github" }),
+          status: expect.objectContaining({ state: "ready" }),
+        }),
+      ]),
+    });
+  });
 });

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -1,6 +1,14 @@
-import { defaultFactoriesFixture, ORGANIZATION_USERS, type FactoriesFixture } from "./factoryPageResponses";
+import {
+  defaultFactoriesFixture,
+  FACTORIES_ORGANIZATION_ID,
+  OPERATOR_USER,
+  ORGANIZATION_USERS,
+  REVIEWER_USER,
+  STORYBOOK_ME_USER_ID,
+  type FactoriesFixture,
+} from "./factoryPageResponses";
 import type { FactoriesWorkOrder } from "@/api-client";
-import { fixtureResponse, type FixtureResult } from "@/pages/home/__fixtures__/handlers";
+import { fixtureResponse, type FixtureResult, type StorybookOrgIntegration } from "@/pages/home/__fixtures__/handlers";
 
 export type { FactoriesFixture };
 
@@ -276,16 +284,174 @@ export function matchFactoryPageFixture(
   return null;
 }
 
+const STORYBOOK_USER_ROLES: Record<string, { roleName: string; roleDisplayName: string }> = {
+  [STORYBOOK_ME_USER_ID]: { roleName: "org_owner", roleDisplayName: "Owner" },
+  [REVIEWER_USER.id]: { roleName: "org_admin", roleDisplayName: "Admin" },
+  [OPERATOR_USER.id]: { roleName: "org_member", roleDisplayName: "Member" },
+};
+
+const STORYBOOK_WORKSPACE_ROLES = [
+  { metadata: { name: "org_owner" }, spec: { displayName: "Owner" } },
+  { metadata: { name: "org_admin" }, spec: { displayName: "Admin" } },
+  { metadata: { name: "org_member" }, spec: { displayName: "Member" } },
+];
+
+const STORYBOOK_WORKSPACE_SECRETS = [
+  {
+    metadata: { id: "secret-openai", name: "openai" },
+    spec: { provider: "PROVIDER_LOCAL", local: { data: { OPENAI_API_KEY: "sk-storybook" } } },
+  },
+  {
+    metadata: { id: "secret-github", name: "github-app" },
+    spec: {
+      provider: "PROVIDER_LOCAL",
+      local: { data: { GITHUB_TOKEN: "ghs-storybook", APP_ID: "12345" } },
+    },
+  },
+];
+
+const STORYBOOK_INVITE_LINK = {
+  id: "storybook-invite",
+  organizationId: FACTORIES_ORGANIZATION_ID,
+  token: "storybook-invite-token",
+  enabled: true,
+};
+
+function catalogIntegration(name: string, label: string, description: string, options?: { legacySetupOnly?: boolean }) {
+  return {
+    name,
+    label,
+    icon: name,
+    description,
+    configuration: [],
+    instructions: "",
+    legacySetupOnly: options?.legacySetupOnly ?? true,
+  };
+}
+
+/** Same catalog the organization Integrations page lists in the live app. */
+export const STORYBOOK_WORKSPACE_INTEGRATION_CATALOG = [
+  catalogIntegration("github", "GitHub", "Manage and react to changes in your GitHub repositories", {
+    legacySetupOnly: false,
+  }),
+  catalogIntegration("gitlab", "GitLab", "Manage and react to changes in your GitLab repositories"),
+  catalogIntegration("bitbucket", "Bitbucket", "Manage and react to changes in your Bitbucket repositories"),
+  catalogIntegration("slack", "Slack", "Send and react to Slack messages and interactions"),
+  catalogIntegration("linear", "Linear", "Manage and react to issues in Linear"),
+  catalogIntegration("jira", "Jira", "Manage issues in Jira"),
+  catalogIntegration("claude", "Claude", "Use Claude models in workflows"),
+  catalogIntegration("openai", "OpenAI", "Generate text responses with OpenAI models"),
+  catalogIntegration("cursor", "Cursor", "Build workflows with Cursor AI Agents and track usage"),
+  catalogIntegration("semaphore", "Semaphore", "Run and react to your Semaphore workflows"),
+  catalogIntegration("circleci", "CircleCI", "Run and react to CircleCI pipelines"),
+  catalogIntegration("datadog", "Datadog", "Create events in Datadog"),
+  catalogIntegration("sentry", "Sentry", "React to issue events and manage issues and metric alerts in Sentry"),
+  catalogIntegration("pagerduty", "PagerDuty", "Manage and react to incidents in PagerDuty"),
+  catalogIntegration("grafana", "Grafana", "React to Grafana alerts and annotations"),
+  catalogIntegration("aws", "AWS", "Manage resources and execute AWS commands in workflows"),
+  catalogIntegration("gcp", "Google Cloud", "Manage and use Google Cloud resources in your workflows"),
+  catalogIntegration("azure", "Azure", "Manage Azure resources in workflows"),
+  catalogIntegration("digitalocean", "DigitalOcean", "Manage DigitalOcean resources in workflows"),
+  catalogIntegration("dockerhub", "DockerHub", "React to image pushes and manage Docker Hub repositories"),
+  catalogIntegration("cloudflare", "Cloudflare", "Manage Cloudflare resources and react to events"),
+  catalogIntegration("discord", "Discord", "Send and react to Discord messages"),
+  catalogIntegration("teams", "Microsoft Teams", "Send and react to Microsoft Teams messages"),
+  catalogIntegration("incident", "Incident.io", "Manage and react to incidents"),
+  catalogIntegration("rootly", "Rootly", "Manage and react to incidents in Rootly"),
+  catalogIntegration("firehydrant", "FireHydrant", "Manage and react to incidents in FireHydrant"),
+  catalogIntegration("launchdarkly", "LaunchDarkly", "Manage feature flags in LaunchDarkly"),
+  catalogIntegration("honeycomb", "Honeycomb", "React to Honeycomb triggers and burn alerts"),
+  catalogIntegration("newrelic", "New Relic", "React to New Relic alerts"),
+  catalogIntegration("elastic", "Elastic", "Search and react to Elastic events"),
+  catalogIntegration("statuspage", "Statuspage", "Update Statuspage incidents and components"),
+  catalogIntegration("sendgrid", "SendGrid", "Send email with SendGrid"),
+  catalogIntegration("smtp", "SMTP", "Send email through an SMTP server"),
+  catalogIntegration("perplexity", "Perplexity", "Use Perplexity models in workflows"),
+  catalogIntegration("daytona", "Daytona", "Create and manage Daytona sandboxes"),
+  catalogIntegration("dash0", "Dash0", "Query Dash0 and react to alerts"),
+  catalogIntegration("coolify", "Coolify", "Manage Coolify applications and deployments"),
+  catalogIntegration("cloudsmith", "Cloudsmith", "Manage Cloudsmith packages"),
+  catalogIntegration("harness", "Harness", "Run and react to Harness pipelines"),
+  catalogIntegration("hetzner", "Hetzner", "Manage Hetzner Cloud resources"),
+  catalogIntegration("oci", "OCI", "Manage Oracle Cloud resources"),
+  catalogIntegration("octopus", "Octopus Deploy", "Run and react to Octopus Deploy releases"),
+  catalogIntegration("prometheus", "Prometheus", "Query Prometheus and react to alerts"),
+  catalogIntegration("render", "Render", "Manage Render services and deploys"),
+  catalogIntegration("servicenow", "ServiceNow", "Create and update ServiceNow records"),
+  catalogIntegration("telegram", "Telegram", "Send and react to Telegram messages"),
+  catalogIntegration("logfire", "Logfire", "React to Logfire alerts"),
+  catalogIntegration("jfrogArtifactory", "JFrog Artifactory", "Manage JFrog Artifactory packages"),
+];
+
+export const STORYBOOK_CONNECTED_ORG_INTEGRATIONS: StorybookOrgIntegration[] = [
+  {
+    metadata: { id: "int-github-acme", name: "github", integrationName: "github" },
+    status: { state: "ready" },
+  },
+  {
+    metadata: { id: "int-claude-workspace", name: "claude", integrationName: "claude" },
+    status: { state: "ready" },
+  },
+];
+
 /** Response body for `GET /api/v1/users` (`useOrganizationUsers`). */
 export function factoriesOrganizationUsersResponse(): FixtureResult {
   return {
     json: {
-      users: ORGANIZATION_USERS.map((user) => ({
-        metadata: { id: user.id, email: user.email },
-        spec: { displayName: user.name },
-      })),
+      users: ORGANIZATION_USERS.map((user) => {
+        const role = STORYBOOK_USER_ROLES[user.id];
+        return {
+          metadata: { id: user.id, email: user.email },
+          spec: { displayName: user.name },
+          status: role
+            ? {
+                roles: [
+                  {
+                    roleName: role.roleName,
+                    roleDisplayName: role.roleDisplayName,
+                  },
+                ],
+              }
+            : {},
+        };
+      }),
     },
   };
+}
+
+/**
+ * Roles, secrets, and invite-link fixtures for Storybook workspace settings.
+ * Factory page routes stay factory-scoped; these org APIs back the reused
+ * Members / Integrations / Secrets pages.
+ */
+export function matchFactorySettingsFixture(url: URL, method: string): FixtureResult {
+  if (url.pathname === "/api/v1/integrations" && method === "GET") {
+    return { json: { integrations: STORYBOOK_WORKSPACE_INTEGRATION_CATALOG } };
+  }
+
+  if (/^\/api\/v1\/organizations\/[^/]+\/integrations$/.test(url.pathname) && method === "GET") {
+    return { json: { integrations: STORYBOOK_CONNECTED_ORG_INTEGRATIONS } };
+  }
+
+  if (url.pathname === "/api/v1/roles" && method === "GET") {
+    return { json: { roles: STORYBOOK_WORKSPACE_ROLES } };
+  }
+
+  if (url.pathname === "/api/v1/secrets" && method === "GET") {
+    return { json: { secrets: STORYBOOK_WORKSPACE_SECRETS } };
+  }
+
+  const secretMatch = /^\/api\/v1\/secrets\/([^/]+)$/.exec(url.pathname);
+  if (secretMatch && method === "GET") {
+    const secret = STORYBOOK_WORKSPACE_SECRETS.find((entry) => entry.metadata.id === secretMatch[1]);
+    return secret ? { json: { secret } } : { json: {} };
+  }
+
+  if (/^\/api\/v1\/organizations\/[^/]+\/invite-link$/.test(url.pathname)) {
+    return { json: { inviteLink: STORYBOOK_INVITE_LINK } };
+  }
+
+  return null;
 }
 
 /**
@@ -303,7 +469,10 @@ export async function fetchFactoryPageFixture(
     typeof options?.body === "string" && options.body.trim()
       ? (JSON.parse(options.body) as Record<string, unknown>)
       : null;
-  const result = matchFactoryPageFixture(url, method, body, fixture);
+  const result =
+    matchFactoryPageFixture(url, method, body, fixture) ??
+    (url.pathname === "/api/v1/users" && method === "GET" ? factoriesOrganizationUsersResponse() : null) ??
+    matchFactorySettingsFixture(url, method);
   if (!result) {
     return new Response(null, { status: 404 });
   }

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingStorybookContext.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingStorybookContext.tsx
@@ -1,7 +1,23 @@
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 
-import type { OnboardingRepo, OnboardingStorybookSeed, PendingOnboarding } from "./onboardingMocks";
+import type {
+  OnboardingRepo,
+  OnboardingStorybookSeed,
+  PendingOnboarding,
+  WorkspaceConnections,
+} from "./onboardingMocks";
 import { OnboardingStorybookContext } from "./onboardingStorybookContextValue";
+
+function connectionsFromSeed(initial?: OnboardingStorybookSeed): Record<string, WorkspaceConnections> {
+  const connections = { ...(initial?.connectionsByWorkspace ?? {}) };
+  for (const [workspaceId, repos] of Object.entries(initial?.enabledReposByWorkspace ?? {})) {
+    if (connections[workspaceId]) {
+      continue;
+    }
+    connections[workspaceId] = { repos, issuesChoice: null, issuesRepo: null, agent: null };
+  }
+  return connections;
+}
 
 export function OnboardingStorybookProvider({
   children,
@@ -14,6 +30,9 @@ export function OnboardingStorybookProvider({
   const [enabledReposByWorkspace, setEnabledReposByWorkspace] = useState<Record<string, OnboardingRepo[]>>(
     initial?.enabledReposByWorkspace ?? {},
   );
+  const [connectionsByWorkspace, setConnectionsByWorkspace] = useState<Record<string, WorkspaceConnections>>(() =>
+    connectionsFromSeed(initial),
+  );
   const [overviewTipsWorkspaceId, setOverviewTipsWorkspaceId] = useState<string | null>(
     initial?.overviewTipsWorkspaceId ?? null,
   );
@@ -22,11 +41,23 @@ export function OnboardingStorybookProvider({
     setPending(next);
   }, []);
 
-  const completeOnboarding = useCallback((workspaceId: string, repos: OnboardingRepo[]) => {
-    setEnabledReposByWorkspace((current) => ({ ...current, [workspaceId]: repos }));
-    setOverviewTipsWorkspaceId(workspaceId);
-    setPending(null);
-  }, []);
+  const completeOnboarding = useCallback(
+    (workspaceId: string, repos: OnboardingRepo[], details?: Omit<WorkspaceConnections, "repos">) => {
+      setEnabledReposByWorkspace((current) => ({ ...current, [workspaceId]: repos }));
+      setConnectionsByWorkspace((current) => ({
+        ...current,
+        [workspaceId]: {
+          repos,
+          issuesChoice: details?.issuesChoice ?? null,
+          issuesRepo: details?.issuesRepo ?? null,
+          agent: details?.agent ?? null,
+        },
+      }));
+      setOverviewTipsWorkspaceId(workspaceId);
+      setPending(null);
+    },
+    [],
+  );
 
   const clearOverviewTips = useCallback(() => {
     setOverviewTipsWorkspaceId(null);
@@ -36,6 +67,16 @@ export function OnboardingStorybookProvider({
     (workspaceId: string) => enabledReposByWorkspace[workspaceId] ?? [],
     [enabledReposByWorkspace],
   );
+
+  const connections = useCallback(
+    (workspaceId: string) => connectionsByWorkspace[workspaceId],
+    [connectionsByWorkspace],
+  );
+
+  const updateConnections = useCallback((workspaceId: string, next: WorkspaceConnections) => {
+    setConnectionsByWorkspace((current) => ({ ...current, [workspaceId]: next }));
+    setEnabledReposByWorkspace((current) => ({ ...current, [workspaceId]: next.repos }));
+  }, []);
 
   const shouldShowOverviewTips = useCallback(
     (workspaceId: string) =>
@@ -51,8 +92,19 @@ export function OnboardingStorybookProvider({
       shouldShowOverviewTips,
       clearOverviewTips,
       enabledRepos,
+      connections,
+      updateConnections,
     }),
-    [pending, beginOnboarding, completeOnboarding, shouldShowOverviewTips, clearOverviewTips, enabledRepos],
+    [
+      pending,
+      beginOnboarding,
+      completeOnboarding,
+      shouldShowOverviewTips,
+      clearOverviewTips,
+      enabledRepos,
+      connections,
+      updateConnections,
+    ],
   );
 
   return <OnboardingStorybookContext.Provider value={value}>{children}</OnboardingStorybookContext.Provider>;

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingWireframe.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingWireframe.tsx
@@ -241,7 +241,11 @@ export function OnboardingWireframe() {
 
   const finishSetup = () => {
     if (onboarding && factoryId) {
-      onboarding.completeOnboarding(factoryId, onboardingReposFromSetup(setup.selectedRepo, setup.vcsHost));
+      onboarding.completeOnboarding(factoryId, onboardingReposFromSetup(setup.selectedRepo, setup.vcsHost), {
+        issuesChoice: setup.issuesChoice,
+        issuesRepo: setup.issuesRepo ?? setup.selectedRepo,
+        agent: setup.agent,
+      });
     }
     if (organizationId && factoryKey) {
       navigate(factoryOverviewPath(organizationId, factoryKey), { replace: true });

--- a/web_src/src/pages/factories/pages/onboarding/onboardingMocks.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingMocks.ts
@@ -1,3 +1,5 @@
+import type { AgentHarnessId, IssuesChoiceId } from "./onboardingFixtures";
+
 export type GitProvider = "github" | "gitlab";
 
 export type OnboardingRepo = {
@@ -29,8 +31,16 @@ export function providerLabel(provider: GitProvider) {
   return provider === "github" ? "GitHub" : "GitLab";
 }
 
+export type WorkspaceConnections = {
+  repos: OnboardingRepo[];
+  issuesChoice: IssuesChoiceId | null;
+  issuesRepo: string | null;
+  agent: AgentHarnessId | null;
+};
+
 export type OnboardingStorybookSeed = {
   pending?: PendingOnboarding | null;
   enabledReposByWorkspace?: Record<string, OnboardingRepo[]>;
+  connectionsByWorkspace?: Record<string, WorkspaceConnections>;
   overviewTipsWorkspaceId?: string | null;
 };

--- a/web_src/src/pages/factories/pages/onboarding/onboardingSteps.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingSteps.tsx
@@ -201,7 +201,7 @@ export function NameInviteStep({ setup }: { setup: OnboardingSetupApi }) {
   );
 }
 
-function RepositoryPicker({
+export function RepositoryPicker({
   host,
   repos,
   selectedRepo,

--- a/web_src/src/pages/factories/pages/onboarding/onboardingStorybookContextValue.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingStorybookContextValue.ts
@@ -1,14 +1,20 @@
 import { createContext } from "react";
 
-import type { OnboardingRepo, PendingOnboarding } from "./onboardingMocks";
+import type { OnboardingRepo, PendingOnboarding, WorkspaceConnections } from "./onboardingMocks";
 
 export type OnboardingStorybookContextValue = {
   pending: PendingOnboarding | null;
   beginOnboarding: (pending: PendingOnboarding) => void;
-  completeOnboarding: (workspaceId: string, repos: OnboardingRepo[]) => void;
+  completeOnboarding: (
+    workspaceId: string,
+    repos: OnboardingRepo[],
+    details?: Omit<WorkspaceConnections, "repos">,
+  ) => void;
   shouldShowOverviewTips: (workspaceId: string) => boolean;
   clearOverviewTips: () => void;
   enabledRepos: (workspaceId: string) => OnboardingRepo[];
+  connections: (workspaceId: string) => WorkspaceConnections | undefined;
+  updateConnections: (workspaceId: string, next: WorkspaceConnections) => void;
 };
 
 export const OnboardingStorybookContext = createContext<OnboardingStorybookContextValue | null>(null);

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
@@ -117,7 +117,7 @@ export function FactorySettingsGeneralPage() {
             General
           </Heading>
           <p className={cn("mt-1", factoryPageSubtitleClassName)}>
-            General workspace preferences. Content for this page comes next.
+            Set the workspace name, key, and description. The key is part of every work order ID.
           </p>
         </div>
       </header>

--- a/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
+++ b/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
@@ -26,8 +26,7 @@ export const General: Story = {
   ),
 };
 
-export const RepositoriesSoon: Story = {
-  name: "Repositories (Soon)",
+export const Repositories: Story = {
   render: () => (
     <FactoriesHarness
       pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/repositories`}
@@ -36,11 +35,37 @@ export const RepositoriesSoon: Story = {
   ),
 };
 
-export const MembersSoon: Story = {
-  name: "Members (Soon)",
+export const Models: Story = {
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/models`}
+      factoriesFixture={defaultFactoriesFixture}
+    />
+  ),
+};
+
+export const Members: Story = {
   render: () => (
     <FactoriesHarness
       pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/members`}
+      factoriesFixture={defaultFactoriesFixture}
+    />
+  ),
+};
+
+export const Integrations: Story = {
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/integrations`}
+      factoriesFixture={defaultFactoriesFixture}
+    />
+  ),
+};
+
+export const Secrets: Story = {
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/secrets`}
       factoriesFixture={defaultFactoriesFixture}
     />
   ),

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceIntegrationsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceIntegrationsPage.tsx
@@ -1,0 +1,19 @@
+import { Integrations } from "@/pages/organization/settings/Integrations";
+
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
+
+export function WorkspaceIntegrationsPage() {
+  const { organizationId } = useFactorySettingsLayout();
+
+  return (
+    <WorkspaceSettingsSection
+      title="Integrations"
+      description="Connect the tools this workspace can use. SuperPlane uses these connections for repositories, models, and notifications."
+    >
+      <div className="max-w-3xl">
+        <Integrations organizationId={organizationId} />
+      </div>
+    </WorkspaceSettingsSection>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceMembersPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceMembersPage.tsx
@@ -1,0 +1,17 @@
+import { Members } from "@/pages/organization/settings/Members";
+
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
+
+export function WorkspaceMembersPage() {
+  const { organizationId } = useFactorySettingsLayout();
+
+  return (
+    <WorkspaceSettingsSection
+      title="Members"
+      description="Invite people to this workspace and assign roles. Members can create work orders and review agent results."
+    >
+      <Members organizationId={organizationId} />
+    </WorkspaceSettingsSection>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceModelsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceModelsPage.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/lib/utils";
+import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
+
+import { factoryCardClassName } from "../../factoryPageLayoutStyles";
+import { AGENT_OPTIONS, type AgentHarnessId, integrationLabel } from "../../onboarding/onboardingFixtures";
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { useWorkspaceConnections } from "./useWorkspaceConnections";
+import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
+import { agentSummary } from "./workspaceConnections";
+
+export function WorkspaceModelsPage() {
+  const { factoryId } = useFactorySettingsLayout();
+  const { connections, updateConnections } = useWorkspaceConnections(factoryId);
+
+  return (
+    <WorkspaceSettingsSection
+      title="Models"
+      description="Select the coding agent for this workspace. The agent changes the app repository and opens pull requests."
+    >
+      <div className="max-w-2xl space-y-6">
+        <section className={cn("p-6", factoryCardClassName)} data-testid="workspace-settings-models">
+          <h2 className="text-[13px] font-medium tracking-[-0.01em] text-foreground">Coding agent</h2>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            SuperPlane sends work orders to this agent. The agent writes code in the app repository and opens a pull
+            request.
+          </p>
+          <p className="mt-3 text-[13px] font-medium">{agentSummary(connections)}</p>
+
+          <div className="mt-4 grid gap-2">
+            {AGENT_OPTIONS.map((option) => {
+              const selected = connections.agent === option.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  disabled={option.soon}
+                  onClick={() => updateConnections({ ...connections, agent: option.id as AgentHarnessId })}
+                  className={cn(
+                    "relative flex items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors",
+                    option.soon && "cursor-not-allowed border-border/70 bg-muted/20 opacity-70",
+                    !option.soon && selected && "border-foreground bg-accent/40",
+                    !option.soon && !selected && "border-border bg-background hover:bg-accent/30",
+                  )}
+                >
+                  <IntegrationIcon integrationName={option.integrationId} className="mt-0.5 size-5" size={20} />
+                  <span className="min-w-0">
+                    <span className="block text-[13px] font-medium">{option.label}</span>
+                    <span className="mt-0.5 block text-[12px] text-muted-foreground">{option.detail}</span>
+                    <span className="mt-1 block text-[11px] text-muted-foreground">
+                      {option.soon ? "Coming soon" : `Uses ${integrationLabel(option.integrationId)}`}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </WorkspaceSettingsSection>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceRepositoriesPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceRepositoriesPage.tsx
@@ -1,0 +1,179 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
+import { ListTodo } from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import { factoryCardClassName } from "../../factoryPageLayoutStyles";
+import { FIXTURE_REPOS, type IssuesChoiceId, type VcsHostId, vcsLabel } from "../../onboarding/onboardingFixtures";
+import { RepositoryPicker } from "../../onboarding/onboardingSteps";
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { useWorkspaceConnections } from "./useWorkspaceConnections";
+import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
+import { appRepositoryFullName, appRepositorySummary, backlogSummary, repoFromFullName } from "./workspaceConnections";
+
+export function WorkspaceRepositoriesPage() {
+  const { factoryId } = useFactorySettingsLayout();
+  const { connections, updateConnections } = useWorkspaceConnections(factoryId);
+  const appRepo = connections.repos[0];
+  const host = (appRepo?.provider ?? "github") as VcsHostId;
+  const backlogRepo = connections.issuesRepo ?? appRepositoryFullName(appRepo);
+  const [changingAppRepo, setChangingAppRepo] = useState(false);
+  const [changingBacklogRepo, setChangingBacklogRepo] = useState(false);
+
+  return (
+    <WorkspaceSettingsSection
+      title="Repositories"
+      description="Choose the app repository that agents analyze and change. Optionally connect a backlog so SuperPlane can find work."
+    >
+      <div className="max-w-2xl space-y-6">
+        <section className={cn("p-6", factoryCardClassName)} data-testid="workspace-settings-app-repo">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="text-[13px] font-medium tracking-[-0.01em] text-foreground">App repository</h2>
+              <p className="mt-1 text-[12px] text-muted-foreground">
+                SuperPlane analyzes this repository. Coding agents change the code here and open pull requests.
+              </p>
+              <p className="mt-3 flex items-center gap-2 text-[13px] font-medium">
+                {appRepo ? <IntegrationIcon integrationName={appRepo.provider} className="size-4" size={16} /> : null}
+                {appRepositorySummary(connections)}
+              </p>
+            </div>
+            <Button type="button" size="sm" variant="outline" onClick={() => setChangingAppRepo((open) => !open)}>
+              {changingAppRepo ? "Close" : "Change"}
+            </Button>
+          </div>
+          {changingAppRepo ? (
+            <div className="mt-4">
+              <RepositoryPicker
+                host={host}
+                repos={FIXTURE_REPOS[host]}
+                selectedRepo={appRepositoryFullName(appRepo)}
+                onSelect={(fullName) => {
+                  const nextRepo = repoFromFullName(fullName, host);
+                  const nextBacklog =
+                    connections.issuesRepo === appRepositoryFullName(appRepo) || !connections.issuesRepo
+                      ? fullName
+                      : connections.issuesRepo;
+                  updateConnections({
+                    ...connections,
+                    repos: [nextRepo],
+                    issuesRepo: connections.issuesChoice === "vcs" ? nextBacklog : connections.issuesRepo,
+                  });
+                  setChangingAppRepo(false);
+                }}
+              />
+            </div>
+          ) : null}
+        </section>
+
+        <section className={cn("p-6", factoryCardClassName)} data-testid="workspace-settings-backlog">
+          <h2 className="text-[13px] font-medium tracking-[-0.01em] text-foreground">Backlog</h2>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            SuperPlane looks here for small work that a coding agent can complete. You can also skip this and create
+            work orders yourself.
+          </p>
+          <p className="mt-3 text-[13px] font-medium">{backlogSummary(connections)}</p>
+
+          <div className="mt-4 grid gap-2">
+            <BacklogChoice
+              selected={connections.issuesChoice === "vcs"}
+              icon={<IntegrationIcon integrationName={host} className="size-5" size={20} />}
+              title={`Use ${vcsLabel(host)} Issues`}
+              detail={`Use open issues on ${backlogRepo || "the selected repository"} as the source of work.`}
+              onSelect={() =>
+                updateConnections({
+                  ...connections,
+                  issuesChoice: "vcs",
+                  issuesRepo: backlogRepo || appRepositoryFullName(appRepo),
+                })
+              }
+            />
+            <BacklogChoice
+              selected={connections.issuesChoice === "linear"}
+              soon
+              icon={<IntegrationIcon integrationName="linear" className="size-5" size={20} />}
+              title="Linear"
+              detail="Use Linear issues as the source of work."
+              onSelect={() => updateConnections({ ...connections, issuesChoice: "linear" as IssuesChoiceId })}
+            />
+            <BacklogChoice
+              selected={connections.issuesChoice === "jira"}
+              soon
+              icon={<IntegrationIcon integrationName="jira" className="size-5" size={20} />}
+              title="Jira"
+              detail="Use Jira issues as the source of work."
+              onSelect={() => updateConnections({ ...connections, issuesChoice: "jira" as IssuesChoiceId })}
+            />
+            <BacklogChoice
+              selected={connections.issuesChoice === "skip"}
+              icon={<ListTodo className="size-5 text-muted-foreground" aria-hidden />}
+              title="No backlog"
+              detail="Do not import issues. Create each work order yourself."
+              onSelect={() => updateConnections({ ...connections, issuesChoice: "skip", issuesRepo: null })}
+            />
+          </div>
+
+          {connections.issuesChoice === "vcs" ? (
+            <div className="mt-4">
+              <Button type="button" size="sm" variant="outline" onClick={() => setChangingBacklogRepo((open) => !open)}>
+                {changingBacklogRepo ? "Close" : "Change backlog repository"}
+              </Button>
+              {changingBacklogRepo ? (
+                <div className="mt-3">
+                  <RepositoryPicker
+                    host={host}
+                    repos={FIXTURE_REPOS[host]}
+                    selectedRepo={backlogRepo}
+                    title="Select backlog repository"
+                    description="Choose the repository that holds the issue backlog. This does not change the app repository."
+                    onSelect={(fullName) => {
+                      updateConnections({ ...connections, issuesChoice: "vcs", issuesRepo: fullName });
+                      setChangingBacklogRepo(false);
+                    }}
+                  />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </section>
+      </div>
+    </WorkspaceSettingsSection>
+  );
+}
+
+function BacklogChoice({
+  icon,
+  title,
+  detail,
+  selected,
+  soon,
+  onSelect,
+}: {
+  icon: ReactNode;
+  title: string;
+  detail: string;
+  selected: boolean;
+  soon?: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={soon}
+      onClick={onSelect}
+      className={cn(
+        "relative flex items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors",
+        soon && "cursor-not-allowed border-border/70 bg-muted/20 opacity-70",
+        !soon && selected && "border-foreground bg-accent/40",
+        !soon && !selected && "border-border bg-background hover:bg-accent/30",
+      )}
+    >
+      <span className="mt-0.5 shrink-0">{icon}</span>
+      <span className="min-w-0">
+        <span className="block text-[13px] font-medium">{title}</span>
+        <span className="mt-0.5 block text-[12px] text-muted-foreground">{detail}</span>
+      </span>
+    </button>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceSecretsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceSecretsPage.tsx
@@ -1,0 +1,17 @@
+import { Secrets } from "@/pages/organization/settings/Secrets";
+
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
+
+export function WorkspaceSecretsPage() {
+  const { organizationId } = useFactorySettingsLayout();
+
+  return (
+    <WorkspaceSettingsSection
+      title="Secrets"
+      description="Store API keys and other secret values for this workspace. Components and agents can read them during runs."
+    >
+      <Secrets organizationId={organizationId} />
+    </WorkspaceSettingsSection>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceSettingsSection.tsx
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/WorkspaceSettingsSection.tsx
@@ -1,0 +1,32 @@
+import { Heading } from "@/components/Heading/heading";
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+import {
+  factoryContentBodyClassName,
+  factoryContentHeaderClassName,
+  factoryPageSubtitleClassName,
+  factoryPageTitleClassName,
+} from "../../factoryPageLayoutStyles";
+
+interface WorkspaceSettingsSectionProps {
+  title: string;
+  description: string;
+  children: ReactNode;
+}
+
+export function WorkspaceSettingsSection({ title, description, children }: WorkspaceSettingsSectionProps) {
+  return (
+    <>
+      <header className={factoryContentHeaderClassName}>
+        <div>
+          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
+            {title}
+          </Heading>
+          <p className={cn("mt-1 max-w-2xl", factoryPageSubtitleClassName)}>{description}</p>
+        </div>
+      </header>
+      <div className={factoryContentBodyClassName}>{children}</div>
+    </>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/useWorkspaceConnections.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/useWorkspaceConnections.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from "react";
+
+import { useOnboardingStorybook } from "../../onboarding/useOnboardingStorybook";
+import { STORYBOOK_WORKSPACE_CONNECTIONS, type WorkspaceConnections } from "./workspaceConnections";
+
+export function useWorkspaceConnections(workspaceId: string) {
+  const onboarding = useOnboardingStorybook();
+  const fromContext = onboarding?.connections(workspaceId);
+  const [localConnections, setLocalConnections] = useState<WorkspaceConnections>(STORYBOOK_WORKSPACE_CONNECTIONS);
+  const connections = fromContext ?? localConnections;
+
+  const updateConnections = useCallback(
+    (next: WorkspaceConnections) => {
+      if (onboarding) {
+        onboarding.updateConnections(workspaceId, next);
+        return;
+      }
+      setLocalConnections(next);
+    },
+    [onboarding, workspaceId],
+  );
+
+  return { connections, updateConnections };
+}

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/workspaceConnections.spec.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/workspaceConnections.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  STORYBOOK_WORKSPACE_CONNECTIONS,
+  agentSummary,
+  appRepositorySummary,
+  backlogSummary,
+} from "./workspaceConnections";
+
+describe("workspaceConnections summaries", () => {
+  it("describes the seeded post-onboarding app repository", () => {
+    expect(appRepositorySummary(STORYBOOK_WORKSPACE_CONNECTIONS)).toBe("GitHub · acme/api");
+  });
+
+  it("describes GitHub Issues on the backlog repository", () => {
+    expect(backlogSummary(STORYBOOK_WORKSPACE_CONNECTIONS)).toBe("GitHub Issues · acme/api");
+  });
+
+  it("describes a skipped backlog", () => {
+    expect(backlogSummary({ ...STORYBOOK_WORKSPACE_CONNECTIONS, issuesChoice: "skip", issuesRepo: null })).toBe(
+      "No backlog. Create each work order yourself.",
+    );
+  });
+
+  it("describes the selected coding agent", () => {
+    expect(agentSummary(STORYBOOK_WORKSPACE_CONNECTIONS)).toBe("Claude Code");
+  });
+});

--- a/web_src/src/pages/factories/pages/settings/settingsPrototype/workspaceConnections.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsPrototype/workspaceConnections.ts
@@ -1,0 +1,67 @@
+import { AGENT_OPTIONS, vcsLabel } from "../../onboarding/onboardingFixtures";
+import type { GitProvider, OnboardingRepo, WorkspaceConnections } from "../../onboarding/onboardingMocks";
+import { providerLabel } from "../../onboarding/onboardingMocks";
+
+export type { WorkspaceConnections };
+
+export const STORYBOOK_APP_REPO: OnboardingRepo = {
+  id: "gh-acme-api",
+  name: "api",
+  org: "acme",
+  provider: "github",
+};
+
+export const STORYBOOK_WORKSPACE_CONNECTIONS: WorkspaceConnections = {
+  repos: [STORYBOOK_APP_REPO],
+  issuesChoice: "vcs",
+  issuesRepo: "acme/api",
+  agent: "claude-code",
+};
+
+export function appRepositoryFullName(repo: OnboardingRepo | undefined): string {
+  if (!repo) {
+    return "";
+  }
+  return `${repo.org}/${repo.name}`;
+}
+
+export function appRepositorySummary(connections: WorkspaceConnections): string {
+  const repo = connections.repos[0];
+  if (!repo) {
+    return "No app repository.";
+  }
+  return `${providerLabel(repo.provider)} · ${appRepositoryFullName(repo)}`;
+}
+
+export function backlogSummary(connections: WorkspaceConnections): string {
+  if (connections.issuesChoice === "skip") {
+    return "No backlog. Create each work order yourself.";
+  }
+  if (connections.issuesChoice === "linear") {
+    return "Linear";
+  }
+  if (connections.issuesChoice === "jira") {
+    return "Jira";
+  }
+  if (connections.issuesChoice === "vcs") {
+    const repo = connections.issuesRepo ?? appRepositoryFullName(connections.repos[0]);
+    const provider = connections.repos[0]?.provider;
+    const host = provider ? `${vcsLabel(provider)} Issues` : "Issues";
+    return repo ? `${host} · ${repo}` : host;
+  }
+  return "No backlog selected.";
+}
+
+export function agentSummary(connections: WorkspaceConnections): string {
+  return AGENT_OPTIONS.find((option) => option.id === connections.agent)?.label ?? "No coding agent.";
+}
+
+export function repoFromFullName(fullName: string, provider: GitProvider): OnboardingRepo {
+  const [org, name] = fullName.split("/");
+  return {
+    id: `${provider === "github" ? "gh" : "gl"}-${org}-${name}`,
+    org: org ?? "",
+    name: name ?? fullName,
+    provider,
+  };
+}

--- a/web_src/src/pages/factories/pages/settings/settingsStorybookPages.spec.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsStorybookPages.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  STORYBOOK_FACTORY_SETTINGS_PAGES,
+  STORYBOOK_FACTORY_SETTINGS_SECTIONS,
+  resolveFactorySettingsPage,
+} from "./settingsStorybookPages";
+import { FACTORY_SETTINGS_NAV_ITEMS } from "./settingsNavItems";
+
+describe("resolveFactorySettingsPage", () => {
+  it("overrides Repositories, Models, Members, Integrations, and Secrets", () => {
+    expect([...STORYBOOK_FACTORY_SETTINGS_SECTIONS]).toEqual([
+      "repositories",
+      "models",
+      "members",
+      "integrations",
+      "secrets",
+    ]);
+    expect(Object.keys(STORYBOOK_FACTORY_SETTINGS_PAGES).sort()).toEqual(
+      [...STORYBOOK_FACTORY_SETTINGS_SECTIONS].sort(),
+    );
+  });
+
+  it("uses the Storybook page when the section is overridden", () => {
+    expect(resolveFactorySettingsPage("repositories", STORYBOOK_FACTORY_SETTINGS_PAGES)).toBe(
+      STORYBOOK_FACTORY_SETTINGS_PAGES.repositories,
+    );
+    expect(resolveFactorySettingsPage("models", STORYBOOK_FACTORY_SETTINGS_PAGES)).toBe(
+      STORYBOOK_FACTORY_SETTINGS_PAGES.models,
+    );
+    expect(resolveFactorySettingsPage("members", STORYBOOK_FACTORY_SETTINGS_PAGES)).toBe(
+      STORYBOOK_FACTORY_SETTINGS_PAGES.members,
+    );
+    expect(resolveFactorySettingsPage("integrations", STORYBOOK_FACTORY_SETTINGS_PAGES)).toBe(
+      STORYBOOK_FACTORY_SETTINGS_PAGES.integrations,
+    );
+    expect(resolveFactorySettingsPage("secrets", STORYBOOK_FACTORY_SETTINGS_PAGES)).toBe(
+      STORYBOOK_FACTORY_SETTINGS_PAGES.secrets,
+    );
+  });
+
+  it("keeps General and other sections on Coming Soon when no override is set", () => {
+    expect(resolveFactorySettingsPage("general", STORYBOOK_FACTORY_SETTINGS_PAGES)).toBeUndefined();
+    expect(resolveFactorySettingsPage("environments", STORYBOOK_FACTORY_SETTINGS_PAGES)).toBeUndefined();
+    expect(resolveFactorySettingsPage("usage", STORYBOOK_FACTORY_SETTINGS_PAGES)).toBeUndefined();
+    expect(resolveFactorySettingsPage("members")).toBeUndefined();
+  });
+
+  it("does not take General away from the live page even if an override is passed", () => {
+    const GeneralOverride = () => null;
+    expect(resolveFactorySettingsPage("general", { general: GeneralOverride })).toBeUndefined();
+  });
+
+  it("covers every settings nav item as General, override, or Coming Soon", () => {
+    const kinds = FACTORY_SETTINGS_NAV_ITEMS.map((item) => {
+      if (item.id === "general") return "general";
+      return resolveFactorySettingsPage(item.id, STORYBOOK_FACTORY_SETTINGS_PAGES) ? "override" : "soon";
+    });
+
+    expect(kinds).toEqual(["general", "override", "soon", "override", "override", "override", "override", "soon"]);
+  });
+});

--- a/web_src/src/pages/factories/pages/settings/settingsStorybookPages.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsStorybookPages.ts
@@ -1,0 +1,38 @@
+import type { ComponentType } from "react";
+
+import type { FactorySettingsSection } from "./settingsNavItems";
+import { WorkspaceIntegrationsPage } from "./settingsPrototype/WorkspaceIntegrationsPage";
+import { WorkspaceMembersPage } from "./settingsPrototype/WorkspaceMembersPage";
+import { WorkspaceModelsPage } from "./settingsPrototype/WorkspaceModelsPage";
+import { WorkspaceRepositoriesPage } from "./settingsPrototype/WorkspaceRepositoriesPage";
+import { WorkspaceSecretsPage } from "./settingsPrototype/WorkspaceSecretsPage";
+
+export const STORYBOOK_FACTORY_SETTINGS_SECTIONS = [
+  "repositories",
+  "models",
+  "members",
+  "integrations",
+  "secrets",
+] as const;
+
+export type StorybookFactorySettingsSection = (typeof STORYBOOK_FACTORY_SETTINGS_SECTIONS)[number];
+
+export type FactorySettingsPageOverrides = Partial<Record<FactorySettingsSection, ComponentType>>;
+
+export const STORYBOOK_FACTORY_SETTINGS_PAGES: Pick<FactorySettingsPageOverrides, StorybookFactorySettingsSection> = {
+  repositories: WorkspaceRepositoriesPage,
+  models: WorkspaceModelsPage,
+  members: WorkspaceMembersPage,
+  integrations: WorkspaceIntegrationsPage,
+  secrets: WorkspaceSecretsPage,
+};
+
+export function resolveFactorySettingsPage(
+  section: FactorySettingsSection,
+  overrides?: FactorySettingsPageOverrides,
+): ComponentType | undefined {
+  if (section === "general") {
+    return undefined;
+  }
+  return overrides?.[section];
+}

--- a/web_src/src/pages/home/__fixtures__/handlers.ts
+++ b/web_src/src/pages/home/__fixtures__/handlers.ts
@@ -21,6 +21,7 @@ function buildMeUser(orgId: string) {
       "secrets",
       "groups",
       "users",
+      "members",
       "roles",
       "organization",
       "agents",


### PR DESCRIPTION
## Summary

Workspace settings other than General were Coming Soon, so onboarding choices had no lasting home. This change adds Storybook pages for Members, Integrations, Secrets, Repositories, and Models in the workspace settings shell. Live app routes stay Coming Soon.


Made with [Cursor](https://cursor.com)