### PR TITLE
fix: Map factory node success states correctly

### DIFF
--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -127,6 +127,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = (props) => {
         canvasMode={props.canvasMode}
         showRuntimeStatus={props.showRuntimeStatus}
         runIsActive={props.runIsActive}
+        eventStateMap={props.eventStateMap}
       />
     );
   }

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { DraftDiffStatus } from "@/lib/draftDiff";
+import type { EventStateMap } from "../componentBase/eventState";
 import type { MetadataItem } from "../metadataList";
 import { FactoryNodeCardShell } from "./FactoryNodeCardShell";
 import { NodeHoverActions } from "./NodeHoverActions";
@@ -50,6 +51,8 @@ export type FactoryNodeCardProps = {
    * Defaults true when unknown.
    */
   runIsActive?: boolean;
+  /** Mapper eventStateMap — same source the run sidebar uses for badge color. */
+  eventStateMap?: EventStateMap;
 };
 
 function useFactoryNodeMetrics(
@@ -136,11 +139,13 @@ export function FactoryNodeCard({
   canvasMode = "live",
   showRuntimeStatus = true,
   runIsActive = true,
+  eventStateMap,
 }: FactoryNodeCardProps) {
   const primarySection = eventSections?.[0];
   const runtimeStatus = resolveFactoryRuntimeStatus({
     eventState: primarySection?.eventState,
     runIsActive,
+    stateMap: eventStateMap,
   });
   const runtimeMetrics = useFactoryNodeMetrics(runtimeStatus, primarySection);
   const { title: cardTitle, subtitle } = resolveFactoryNodeCardTitles({

--- a/web_src/src/ui/factoryNodeChrome/status.spec.ts
+++ b/web_src/src/ui/factoryNodeChrome/status.spec.ts
@@ -78,6 +78,20 @@ describe("normalizeFactoryNodeStatus", () => {
     expect(normalizeFactoryNodeStatus("stopped", stateMap)).toBe("cancelled");
   });
 
+  it("does not classify success icons by badge color alone", () => {
+    const stateMap = {
+      ...DEFAULT_EVENT_STATE_MAP,
+      completed: {
+        icon: "circle-check",
+        textColor: "text-gray-800",
+        backgroundColor: "bg-gray-100",
+        badgeColor: "bg-gray-500",
+      },
+    };
+
+    expect(normalizeFactoryNodeStatus("completed", stateMap)).toBe("passed");
+  });
+
   it("treats unlisted mapper success aliases as Passed when no map is given", () => {
     expect(normalizeFactoryNodeStatus("marked ready")).toBe("passed");
   });

--- a/web_src/src/ui/factoryNodeChrome/status.spec.ts
+++ b/web_src/src/ui/factoryNodeChrome/status.spec.ts
@@ -92,8 +92,8 @@ describe("normalizeFactoryNodeStatus", () => {
     expect(normalizeFactoryNodeStatus("completed", stateMap)).toBe("passed");
   });
 
-  it("treats unlisted mapper success aliases as Passed when no map is given", () => {
-    expect(normalizeFactoryNodeStatus("marked ready")).toBe("passed");
+  it("keeps unlisted states Pending when the map does not classify them", () => {
+    expect(normalizeFactoryNodeStatus("marked ready")).toBe("pending");
   });
 });
 

--- a/web_src/src/ui/factoryNodeChrome/status.spec.ts
+++ b/web_src/src/ui/factoryNodeChrome/status.spec.ts
@@ -50,6 +50,34 @@ describe("normalizeFactoryNodeStatus", () => {
     expect(normalizeFactoryNodeStatus("is running", stateMap)).toBe("running");
   });
 
+  it("maps custom cancelled styles such as GitHub workflow stopped", () => {
+    const stateMap = {
+      ...DEFAULT_EVENT_STATE_MAP,
+      stopped: {
+        icon: "circle-stop",
+        textColor: "text-gray-800",
+        backgroundColor: "bg-gray-100",
+        badgeColor: "bg-gray-500",
+      },
+    };
+
+    expect(normalizeFactoryNodeStatus("stopped", stateMap)).toBe("cancelled");
+  });
+
+  it("maps circle-stop icons even when the badge color is not a default", () => {
+    const stateMap = {
+      ...DEFAULT_EVENT_STATE_MAP,
+      stopped: {
+        icon: "circle-stop",
+        textColor: "text-gray-800",
+        backgroundColor: "bg-slate-100",
+        badgeColor: "bg-slate-500",
+      },
+    };
+
+    expect(normalizeFactoryNodeStatus("stopped", stateMap)).toBe("cancelled");
+  });
+
   it("treats unlisted mapper success aliases as Passed when no map is given", () => {
     expect(normalizeFactoryNodeStatus("marked ready")).toBe("passed");
   });

--- a/web_src/src/ui/factoryNodeChrome/status.spec.ts
+++ b/web_src/src/ui/factoryNodeChrome/status.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DEFAULT_EVENT_STATE_MAP } from "../componentBase/defaultEventStateMap";
 import {
   factoryNodeStatusLabel,
   formatFactoryNodeDuration,
@@ -28,6 +29,30 @@ describe("normalizeFactoryNodeStatus", () => {
     expect(normalizeFactoryNodeStatus("waiting")).toBe("running");
     expect(normalizeFactoryNodeStatus("rejected")).toBe("cancelled");
   });
+
+  it("maps mapper success aliases from the eventStateMap success style", () => {
+    const stateMap = {
+      ...DEFAULT_EVENT_STATE_MAP,
+      "marked ready": DEFAULT_EVENT_STATE_MAP.success,
+      merged: DEFAULT_EVENT_STATE_MAP.success,
+    };
+
+    expect(normalizeFactoryNodeStatus("marked ready", stateMap)).toBe("passed");
+    expect(normalizeFactoryNodeStatus("merged", stateMap)).toBe("passed");
+  });
+
+  it("maps custom running styles instead of treating every alias as Passed", () => {
+    const stateMap = {
+      ...DEFAULT_EVENT_STATE_MAP,
+      "is running": DEFAULT_EVENT_STATE_MAP.running,
+    };
+
+    expect(normalizeFactoryNodeStatus("is running", stateMap)).toBe("running");
+  });
+
+  it("treats unlisted mapper success aliases as Passed when no map is given", () => {
+    expect(normalizeFactoryNodeStatus("marked ready")).toBe("passed");
+  });
 });
 
 describe("resolveFactoryRuntimeStatus", () => {
@@ -46,6 +71,15 @@ describe("resolveFactoryRuntimeStatus", () => {
     expect(resolveFactoryRuntimeStatus({ eventState: "true", runIsActive: false })).toBe("passed");
     expect(resolveFactoryRuntimeStatus({ eventState: "success", runIsActive: false })).toBe("passed");
     expect(resolveFactoryRuntimeStatus({ eventState: "failed", runIsActive: false })).toBe("failed");
+  });
+
+  it("maps mapper success aliases when the run has finished", () => {
+    const stateMap = {
+      ...DEFAULT_EVENT_STATE_MAP,
+      "marked ready": DEFAULT_EVENT_STATE_MAP.success,
+    };
+
+    expect(resolveFactoryRuntimeStatus({ eventState: "marked ready", runIsActive: false, stateMap })).toBe("passed");
   });
 
   it("defaults runIsActive to true when omitted", () => {

--- a/web_src/src/ui/factoryNodeChrome/status.ts
+++ b/web_src/src/ui/factoryNodeChrome/status.ts
@@ -109,12 +109,6 @@ function factoryStatusFromEventStyle(style: EventStateStyle | undefined): Factor
     }
   }
 
-  for (const [eventState, defaultStyle] of Object.entries(DEFAULT_EVENT_STATE_MAP)) {
-    if (style.badgeColor === defaultStyle.badgeColor) {
-      return normalizeFactoryNodeStatus(eventState);
-    }
-  }
-
   return ICON_TO_FACTORY_STATUS[style.icon];
 }
 

--- a/web_src/src/ui/factoryNodeChrome/status.ts
+++ b/web_src/src/ui/factoryNodeChrome/status.ts
@@ -24,6 +24,18 @@ const CANCELLED_EVENT_STATES = new Set(["cancelled", "rejected"]);
 
 const UNSET_EVENT_STATES = new Set(["pending", "neutral"]);
 
+const ICON_TO_FACTORY_STATUS: Record<string, FactoryNodeStatus> = {
+  "circle-check": "passed",
+  "circle-x": "failed",
+  "triangle-alert": "error",
+  "refresh-cw": "running",
+  "loader-circle": "running",
+  "circle-slash-2": "cancelled",
+  "circle-slash": "cancelled",
+  "circle-stop": "cancelled",
+  "circle-dashed": "queued",
+};
+
 function isUnsetEventState(status: string | undefined): boolean {
   return status === undefined || UNSET_EVENT_STATES.has(status);
 }
@@ -63,7 +75,7 @@ export function normalizeFactoryNodeStatus(status: string | undefined, stateMap?
     return mappedStatus;
   }
 
-  // Mapper success aliases (buildActionStateRegistry) are not in the whitelist.
+  // No map entry: mapper success aliases (buildActionStateRegistry) are not in the whitelist.
   return "passed";
 }
 
@@ -97,7 +109,13 @@ function factoryStatusFromEventStyle(style: EventStateStyle | undefined): Factor
     }
   }
 
-  return undefined;
+  for (const [eventState, defaultStyle] of Object.entries(DEFAULT_EVENT_STATE_MAP)) {
+    if (style.badgeColor === defaultStyle.badgeColor) {
+      return normalizeFactoryNodeStatus(eventState);
+    }
+  }
+
+  return ICON_TO_FACTORY_STATUS[style.icon];
 }
 
 export function factoryNodeStatusLabel(status: FactoryNodeStatus): string {

--- a/web_src/src/ui/factoryNodeChrome/status.ts
+++ b/web_src/src/ui/factoryNodeChrome/status.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_EVENT_STATE_MAP } from "../componentBase/defaultEventStateMap";
+import type { EventStateMap, EventStateStyle } from "../componentBase/eventState";
 import type { FactoryNodeStatus } from "./types";
 
 const PASSED_EVENT_STATES = new Set([
@@ -27,7 +29,7 @@ function isUnsetEventState(status: string | undefined): boolean {
 }
 
 /** Map classic ComponentBase / mapper eventState → factory footer status. */
-export function normalizeFactoryNodeStatus(status: string | undefined): FactoryNodeStatus {
+export function normalizeFactoryNodeStatus(status: string | undefined, stateMap?: EventStateMap): FactoryNodeStatus {
   if (status === undefined || UNSET_EVENT_STATES.has(status)) {
     return "pending";
   }
@@ -55,7 +57,14 @@ export function normalizeFactoryNodeStatus(status: string | undefined): FactoryN
   if (status === "triggered") {
     return "triggered";
   }
-  return "pending";
+
+  const mappedStatus = factoryStatusFromEventStyle(stateMap?.[status]);
+  if (mappedStatus !== undefined) {
+    return mappedStatus;
+  }
+
+  // Mapper success aliases (buildActionStateRegistry) are not in the whitelist.
+  return "passed";
 }
 
 /**
@@ -65,14 +74,30 @@ export function normalizeFactoryNodeStatus(status: string | undefined): FactoryN
 export function resolveFactoryRuntimeStatus({
   eventState,
   runIsActive = true,
+  stateMap,
 }: {
   eventState: string | undefined;
   runIsActive?: boolean;
+  stateMap?: EventStateMap;
 }): FactoryNodeStatus {
   if (isUnsetEventState(eventState)) {
     return runIsActive ? "pending" : "did_not_run";
   }
-  return normalizeFactoryNodeStatus(eventState);
+  return normalizeFactoryNodeStatus(eventState, stateMap);
+}
+
+function factoryStatusFromEventStyle(style: EventStateStyle | undefined): FactoryNodeStatus | undefined {
+  if (style === undefined) {
+    return undefined;
+  }
+
+  for (const [eventState, defaultStyle] of Object.entries(DEFAULT_EVENT_STATE_MAP)) {
+    if (style.icon === defaultStyle.icon && style.badgeColor === defaultStyle.badgeColor) {
+      return normalizeFactoryNodeStatus(eventState);
+    }
+  }
+
+  return undefined;
 }
 
 export function factoryNodeStatusLabel(status: FactoryNodeStatus): string {

--- a/web_src/src/ui/factoryNodeChrome/status.ts
+++ b/web_src/src/ui/factoryNodeChrome/status.ts
@@ -75,8 +75,7 @@ export function normalizeFactoryNodeStatus(status: string | undefined, stateMap?
     return mappedStatus;
   }
 
-  // No map entry: mapper success aliases (buildActionStateRegistry) are not in the whitelist.
-  return "passed";
+  return "pending";
 }
 
 /**


### PR DESCRIPTION
## Summary

Factory automation run view showed Pending for finished actions such as Mark Pull Request Ready for Review. The node card used a closed status list. The sidebar used the mapper state map. This change classifies the card from the same map so success verbs show as Passed.

## Test plan

- [ ] Open a factory automation run that includes Mark Pull Request Ready for Review.
- [ ] Confirm the node card footer shows Passed, not Pending.
- [ ] Confirm the sidebar still shows MARKED READY.
- [ ] Confirm a failed or running node still shows Failed or Running.
- [ ] Run `make format.js` and `make check.build.ui`.


Made with [Cursor](https://cursor.com)