### PR TITLE
fix: prompt for a name when creating a blank app

### DIFF
--- a/web_src/src/pages/home/CreateAppModal.spec.tsx
+++ b/web_src/src/pages/home/CreateAppModal.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { CreateAppModal } from "./CreateAppModal";
+
+describe("CreateAppModal", () => {
+  it("does not create until the user enters a name", () => {
+    const onCreate = vi.fn();
+
+    render(<CreateAppModal open isSaving={false} onClose={vi.fn()} onCreate={onCreate} />);
+
+    expect(screen.getByRole("dialog", { name: /create app/i })).toBeInTheDocument();
+    expect(screen.getByTestId("create-app-submit-button")).toBeDisabled();
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates with the trimmed name", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+
+    render(<CreateAppModal open isSaving={false} onClose={vi.fn()} onCreate={onCreate} />);
+
+    await user.type(screen.getByLabelText(/app name/i), "Sentry Analysis ");
+    await user.click(screen.getByTestId("create-app-submit-button"));
+
+    expect(onCreate).toHaveBeenCalledWith("Sentry Analysis");
+  });
+
+  it("shows an error when the name is already taken", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockRejectedValue(new Error("Canvas with the same name already exists"));
+
+    render(<CreateAppModal open isSaving={false} onClose={vi.fn()} onCreate={onCreate} />);
+
+    await user.type(screen.getByLabelText(/app name/i), "Sentry Analysis");
+    await user.click(screen.getByTestId("create-app-submit-button"));
+
+    expect(await screen.findByText("An app with this name already exists")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/home/CreateAppModal.tsx
+++ b/web_src/src/pages/home/CreateAppModal.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingButton } from "@/components/ui/loading-button";
+
+import { isCanvasNameAlreadyExistsError } from "./uniqueCanvasName";
+
+const MAX_APP_NAME_LENGTH = 50;
+
+interface CreateAppModalProps {
+  open: boolean;
+  isSaving: boolean;
+  onClose: () => void;
+  onCreate: (name: string) => Promise<void>;
+}
+
+export function CreateAppModal({ open, isSaving, onClose, onCreate }: CreateAppModalProps) {
+  const [name, setName] = useState("");
+  const [nameError, setNameError] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setNameError("");
+    }
+  }, [open]);
+
+  const handleClose = () => {
+    if (isSaving) {
+      return;
+    }
+
+    onClose();
+  };
+
+  const handleCreate = async () => {
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      setNameError("Name is required");
+      return;
+    }
+
+    if (trimmedName.length > MAX_APP_NAME_LENGTH) {
+      setNameError(`Name must be ${MAX_APP_NAME_LENGTH} characters or less`);
+      return;
+    }
+
+    try {
+      await onCreate(trimmedName);
+    } catch (error) {
+      if (isCanvasNameAlreadyExistsError(error)) {
+        setNameError("An app with this name already exists");
+      }
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          handleClose();
+        }
+      }}
+    >
+      <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleCreate();
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Create app</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="create-app-name-input">App name</Label>
+              <Input
+                id="create-app-name-input"
+                data-testid="create-app-name-input"
+                value={name}
+                onChange={(event) => {
+                  if (event.target.value.length <= MAX_APP_NAME_LENGTH) {
+                    setName(event.target.value);
+                  }
+
+                  if (nameError) {
+                    setNameError("");
+                  }
+                }}
+                maxLength={MAX_APP_NAME_LENGTH}
+                placeholder="Sentry Analysis"
+                autoFocus
+              />
+              {nameError ? <p className="text-xs text-red-600">{nameError}</p> : null}
+            </div>
+          </div>
+
+          <DialogFooter className="flex-row justify-start gap-3 sm:justify-start">
+            <LoadingButton
+              type="submit"
+              disabled={!name.trim()}
+              loading={isSaving}
+              loadingText="Creating..."
+              data-testid="create-app-submit-button"
+            >
+              Create
+            </LoadingButton>
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+              Cancel
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/home/FreshOrgLanding.smoke.spec.tsx
+++ b/web_src/src/pages/home/FreshOrgLanding.smoke.spec.tsx
@@ -108,4 +108,15 @@ describe("FreshOrgLanding", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(panel).toBeInTheDocument();
   });
+
+  it("asks for an app name when creating a blank app", async () => {
+    const user = userEvent.setup();
+    render(<HomePageHarness fixture={emptyHomePageFixture} pathSuffix="apps/new" />);
+
+    await screen.findByRole("heading", { name: "Create a new app" }, { timeout: 5000 });
+    await user.click(screen.getByRole("button", { name: /create a blank app/i }));
+
+    expect(await screen.findByRole("dialog", { name: /create app/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/app name/i)).toBeInTheDocument();
+  });
 });

--- a/web_src/src/pages/home/FreshOrgLanding.tsx
+++ b/web_src/src/pages/home/FreshOrgLanding.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@/components/ui/button";
 import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
-import { generateCanvasName } from "@/lib/canvasNameGenerator";
 import { FEATURE_FACTORIES } from "@/lib/experimentalFeatures";
 import { cn } from "@/lib/utils";
 import { ArrowRight } from "lucide-react";
 import { useEffect, useRef, useState, type RefObject } from "react";
 
 import { LeadIcon, type AppEntry } from "./AppDetailModal";
+import { CreateAppModal } from "./CreateAppModal";
 import { APP_CATALOG } from "./appCatalog";
 import { FactorySetupPanel } from "./FactorySetupPanel";
 import { getFactoryDefinition } from "./factories";
@@ -42,6 +42,7 @@ export function FreshOrgLanding({
   const [showCatalog, setShowCatalog] = useState(false);
   const [visibleCount, setVisibleCount] = useState(7);
   const [installingApp, setInstallingApp] = useState<AppEntry | null>(null);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const busy = folderContextPending || isSaving || isInstalling;
   const inFocusedSetup = showFactorySetup || installingApp !== null;
@@ -117,7 +118,7 @@ export function FreshOrgLanding({
             showCatalog={showCatalog}
             onCreateBlank={() => {
               if (busy) return;
-              void createApp(generateCanvasName());
+              setCreateModalOpen(true);
             }}
             onToggleCatalog={() => setShowCatalog((open) => !open)}
           />
@@ -137,6 +138,16 @@ export function FreshOrgLanding({
           }}
         />
       )}
+
+      <CreateAppModal
+        open={createModalOpen}
+        isSaving={isSaving}
+        onClose={() => setCreateModalOpen(false)}
+        onCreate={async (name) => {
+          await createApp(name);
+          setCreateModalOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/web_src/src/pages/home/index.spec.tsx
+++ b/web_src/src/pages/home/index.spec.tsx
@@ -217,6 +217,13 @@ function renderInstallProgressPanel(app: AppEntry) {
   );
 }
 
+async function createBlankAppNamed(user: ReturnType<typeof userEvent.setup>, name = "Sentry Analysis") {
+  await user.click(await screen.findByRole("button", { name: /create a blank app/i }));
+  const dialog = await screen.findByRole("dialog", { name: /create app/i });
+  await user.type(within(dialog).getByLabelText(/app name/i), name);
+  await user.click(within(dialog).getByTestId("create-app-submit-button"));
+}
+
 describe("HomePage canvas folders", () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
@@ -266,10 +273,17 @@ describe("HomePage canvas folders", () => {
 
     await user.click(await screen.findByRole("button", { name: /create a blank app/i }));
 
+    expect(await screen.findByRole("dialog", { name: /create app/i })).toBeInTheDocument();
+    expect(mutationMocks.createCanvasAsync).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog", { name: /create app/i });
+    await user.type(within(dialog).getByLabelText(/app name/i), "Sentry Analysis");
+    await user.click(within(dialog).getByTestId("create-app-submit-button"));
+
     await waitFor(() => {
       expect(mutationMocks.createCanvasAsync).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: expect.stringMatching(/^[a-z]+-[a-z]+$/),
+          name: "Sentry Analysis",
           method: "ui",
         }),
       );
@@ -495,11 +509,11 @@ describe("HomePage canvas folders", () => {
     await user.click(within(deploymentsSection).getByLabelText("Create app in folder Deployments"));
     expect(await screen.findByRole("heading", { name: "Create New App in Deployments Folder" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /create a blank app/i }));
+    await createBlankAppNamed(user);
 
     await waitFor(() => {
       expect(mutationMocks.createCanvasAsync).toHaveBeenCalledWith({
-        name: expect.stringMatching(/^[a-z]+-[a-z]+$/),
+        name: "Sentry Analysis",
         method: "ui",
       });
       expect(mutationMocks.updateCanvasFolderMembership).toHaveBeenCalledWith({
@@ -527,7 +541,7 @@ describe("HomePage canvas folders", () => {
     renderHome();
     const deploymentsSection = screen.getByText("Deployments").closest("section")!;
     await user.click(within(deploymentsSection).getByLabelText("Create app in folder Deployments"));
-    await user.click(await screen.findByRole("button", { name: /create a blank app/i }));
+    await createBlankAppNamed(user);
 
     expect(await screen.findByText("Canvas editor")).toBeInTheDocument();
     expect(showErrorToast).toHaveBeenCalledWith("App created, but failed to add it to folder");
@@ -585,7 +599,7 @@ describe("HomePage canvas folders", () => {
     });
 
     renderHome(["/org-123/apps/new?folderId=folder-1"]);
-    await user.click(await screen.findByRole("button", { name: /create a blank app/i }));
+    await createBlankAppNamed(user);
 
     expect(mutationMocks.createCanvasAsync).not.toHaveBeenCalled();
     expect(showErrorToast).toHaveBeenCalledWith("You don't have permission to update canvases.");


### PR DESCRIPTION
## Summary

Creating a blank app immediately assigned a random kebab-case name (for example `paper-tiger`). That made the app hard to find later, especially after closing SuperPlane overnight.

This restores a name dialog on **Create a blank app**, matching the existing Edit app modal. The canvas is only created after the user submits a name.

## UI

- Clicking **Create a blank app** on the new-app landing opens a **Create app** dialog with a required name field (max 50 characters).
- Submit creates the canvas with that name through the existing `useCreateApp` path (including folder membership).
- Duplicate names show the same inline error used elsewhere (`An app with this name already exists`).
- Starter-app install is unchanged.

## Tests

- Added `CreateAppModal.spec.tsx` for required name, trimmed submit, and duplicate-name error.
- Extended `FreshOrgLanding.smoke.spec.tsx` to assert the dialog opens instead of creating immediately.
- Updated `index.spec.tsx` create-from-landing cases to fill in a name before expecting `createCanvas`.

## API / Workers / Database

No changes. This is a frontend-only fix.

Fixes #5805