### PR TITLE
chore: Stabilize approval metadata wait

### DIFF
--- a/test/e2e/approvals_test.go
+++ b/test/e2e/approvals_test.go
@@ -466,26 +466,27 @@ func (s *ApprovalSteps) approveAnyoneRequirement() {
 }
 
 func (s *ApprovalSteps) waitForApprovalMetadata(nodeName string, approvedCount int, pendingCount int, approvedType string) {
-	found := false
-	start := time.Now()
-
-	for time.Since(start) < 5*time.Second {
+	require.Eventually(s.t, func() bool {
 		executions := s.canvas.GetExecutionsForNode(nodeName)
 		if len(executions) == 0 {
-			s.session.Sleep(500)
-			continue
+			return false
 		}
 
 		metadata := executions[0].Metadata.Data()
 		rawRecords, ok := metadata["records"].([]any)
-		require.True(s.t, ok, "expected approval records metadata")
+		if !ok {
+			return false
+		}
 
 		approved := 0
 		pending := 0
 		approvedTypeMatch := false
 		for _, rawRecord := range rawRecords {
 			record, ok := rawRecord.(map[string]any)
-			require.True(s.t, ok, "expected approval record metadata")
+			if !ok {
+				return false
+			}
+
 			state, _ := record["state"].(string)
 			recordType, _ := record["type"].(string)
 			switch state {
@@ -499,15 +500,8 @@ func (s *ApprovalSteps) waitForApprovalMetadata(nodeName string, approvedCount i
 			}
 		}
 
-		if approved == approvedCount && pending == pendingCount && approvedTypeMatch {
-			found = true
-			break
-		}
-
-		s.session.Sleep(500)
-	}
-
-	require.True(s.t, found, "timed out waiting for approval metadata to update")
+		return approved == approvedCount && pending == pendingCount && approvedTypeMatch
+	}, 30*time.Second, 500*time.Millisecond, "timed out waiting for approval metadata to update")
 }
 
 func (s *ApprovalSteps) assertNoApproveButtons() {


### PR DESCRIPTION
## Summary

Approval metadata can be incomplete when the test first observes an execution.

This change waits for complete metadata and uses the standard E2E timeout. It prevents premature failures under load.

Closes #5383

## Test plan

- [x] Run the affected approval E2E subtest.
- [x] Run the affected subtest three consecutive times.
- [x] Run `make check.format.go`.
- [x] Run `make lint`.