### PR TITLE
feat: Consistent Workspace Header

### DIFF
--- a/web_src/src/pages/factories/WorkOrderDetailHeader.stories.tsx
+++ b/web_src/src/pages/factories/WorkOrderDetailHeader.stories.tsx
@@ -1,20 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { ComponentStoryShell } from "./__fixtures__/ComponentStoryShell";
+import { withFactoriesTheme } from "./__fixtures__/factoriesStoryTheme";
 import { WorkOrderDetailHeader } from "./WorkOrderDetailHeader";
 
 /**
- * Header for the work order detail page: title on the left, Copy link + a
- * kebab menu of lifecycle actions on the right. Status and dispatch live in
- * the sidebar, so the header stays minimal.
+ * Header for the work order detail page: back link + `SP-42` identifier +
+ * title on the left, Copy link + kebab menu of lifecycle actions on the
+ * right. Status and dispatch live in the sidebar, so the header stays
+ * minimal.
  */
 const meta = {
   title: "Factories/Components/WorkOrderDetailHeader",
   component: WorkOrderDetailHeader,
-  parameters: { layout: "padded" },
+  parameters: { layout: "fullscreen" },
   decorators: [
+    withFactoriesTheme,
     (Story) => (
-      <ComponentStoryShell className="min-h-[220px] max-w-5xl bg-white p-6 dark:bg-gray-900">
+      <ComponentStoryShell className="min-h-[220px] bg-background">
         <Story />
       </ComponentStoryShell>
     ),
@@ -39,6 +42,8 @@ const commonFlags = {
   isRejecting: false,
   isClosing: false,
   isUpdatingStatus: false,
+  backHref: "/org-1/workspaces/SP/work-orders",
+  orderIdentifier: "SP-42",
 };
 
 /** Open — Back to draft, Complete, Reject all available in the kebab. */

--- a/web_src/src/pages/factories/WorkOrderDetailHeader.tsx
+++ b/web_src/src/pages/factories/WorkOrderDetailHeader.tsx
@@ -11,10 +11,15 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
+import { WorkspacePageHeader } from "./layout/WorkspacePageHeader";
 import type { WorkOrderDisplayStatus } from "./lib/workOrderProgress";
 
 interface WorkOrderDetailHeaderProps {
   orderTitle: string;
+  /** Short identifier (e.g. `SP-42`). Rendered as a kicker above the title. */
+  orderIdentifier?: string;
+  /** Back link target (Work Orders list). */
+  backHref: string;
   displayStatus: WorkOrderDisplayStatus;
   isOpen: boolean;
   isDispatchable: boolean;
@@ -30,18 +35,21 @@ interface WorkOrderDetailHeaderProps {
 }
 
 export function WorkOrderDetailHeader(props: WorkOrderDetailHeaderProps) {
-  const { orderTitle } = props;
   return (
-    <header className="sticky top-0 z-10 col-span-full mx-[calc(var(--workspace-page-gutter)*-1)] mb-3 bg-background px-[var(--workspace-page-gutter)] py-3">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <h1 className="workspace-page-title min-w-0 flex-1">{orderTitle}</h1>
-
-        <div className="flex flex-wrap items-center gap-1">
+    <WorkspacePageHeader
+      variant="entity"
+      backHref={props.backHref}
+      backLabel="Work Orders"
+      backTestId="work-order-detail-back"
+      kicker={props.orderIdentifier}
+      title={props.orderTitle}
+      actions={
+        <>
           <CopyLinkButton />
           <HeaderOverflowMenu {...props} />
-        </div>
-      </div>
-    </header>
+        </>
+      }
+    />
   );
 }
 
@@ -63,13 +71,13 @@ function CopyLinkButton() {
     <Button
       type="button"
       variant="ghost"
-      size="icon"
+      size="icon-xs"
       onClick={() => void handleCopy()}
-      className="size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
+      className="text-muted-foreground hover:bg-accent hover:text-foreground"
       aria-label="Copy link to work order"
       data-testid="work-order-copy-link-button"
     >
-      {copied ? <Check className="h-4 w-4" aria-hidden /> : <Link2 className="h-4 w-4" aria-hidden />}
+      {copied ? <Check className="size-3.5" aria-hidden /> : <Link2 className="size-3.5" aria-hidden />}
     </Button>
   );
 }
@@ -92,8 +100,8 @@ function HeaderOverflowMenu(props: WorkOrderDetailHeaderProps) {
           <Button
             type="button"
             variant="ghost"
-            size="icon"
-            className="size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
+            size="icon-xs"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground"
             disabled={disabled}
             aria-label="More actions"
             data-testid="work-order-actions-button"

--- a/web_src/src/pages/factories/WorkOrderDetailLoadedView.tsx
+++ b/web_src/src/pages/factories/WorkOrderDetailLoadedView.tsx
@@ -6,6 +6,8 @@ import type {
   FactoriesWorkOrderResult,
   FactoriesWorkOrderState,
 } from "@/api-client";
+import { workOrdersPath } from "./lib/factoryPagePaths";
+import { getWorkOrderDisplayKey } from "./lib/workOrderProgress";
 import { factoryContentBodyClassName } from "./pages/factoryPageLayoutStyles";
 import { WorkOrderActivityTimeline } from "./WorkOrderActivityTimeline";
 import { WorkOrderCommentComposer } from "./WorkOrderCommentComposer";
@@ -97,82 +99,86 @@ export function WorkOrderDetailLoadedView({
   onStatusChange,
   onAddComment,
 }: WorkOrderDetailLoadedViewProps) {
+  const identifier = getWorkOrderDisplayKey(order, factoryKey);
   return (
-    <div className={factoryContentBodyClassName}>
-      <div className="grid gap-x-[var(--workspace-column-gap)] gap-y-0 lg:grid-cols-[minmax(0,1fr)_var(--workspace-detail-sidebar-width)]">
-        <WorkOrderDetailHeader
-          orderTitle={order.title ?? "Work Order"}
-          displayStatus={displayStatus}
-          isOpen={isOpen}
-          isDispatchable={isDispatchable}
-          isClosed={isClosed}
-          canClose={canClose}
-          canManage={canManage}
-          isCompleting={isCompleting}
-          isRejecting={isRejecting}
-          isClosing={isClosing}
-          isUpdatingStatus={isUpdatingStatus}
-          onClose={onClose}
-          onStatusChange={onStatusChange}
-        />
+    <>
+      <WorkOrderDetailHeader
+        orderTitle={order.title ?? "Work Order"}
+        orderIdentifier={identifier === "—" ? undefined : identifier}
+        backHref={workOrdersPath(organizationId, factoryKey)}
+        displayStatus={displayStatus}
+        isOpen={isOpen}
+        isDispatchable={isDispatchable}
+        isClosed={isClosed}
+        canClose={canClose}
+        canManage={canManage}
+        isCompleting={isCompleting}
+        isRejecting={isRejecting}
+        isClosing={isClosing}
+        isUpdatingStatus={isUpdatingStatus}
+        onClose={onClose}
+        onStatusChange={onStatusChange}
+      />
+      <div className={factoryContentBodyClassName}>
+        <div className="grid gap-x-[var(--workspace-column-gap)] gap-y-0 lg:grid-cols-[minmax(0,1fr)_var(--workspace-detail-sidebar-width)]">
+          <div className="min-w-0">
+            {order.description ? <WorkOrderDescription description={order.description} /> : null}
 
-        <div className="min-w-0">
-          {order.description ? <WorkOrderDescription description={order.description} /> : null}
+            <section className={order.description ? "mt-10" : undefined}>
+              <h2 className="workspace-section-title">Activity</h2>
+              <p className="workspace-body-text mt-1 text-muted-foreground">
+                Actions and comments on the work order, plus factory line runs.
+              </p>
+              <div className="mt-4">
+                <WorkOrderActivityTimeline
+                  organizationId={organizationId}
+                  factoryKey={factoryKey}
+                  order={order}
+                  events={events}
+                  eventsError={eventsError}
+                  isLoading={isEventsLoading}
+                  hasMoreEvents={hasMoreEvents}
+                  isLoadingMoreEvents={isLoadingMoreEvents}
+                  onLoadMoreEvents={onLoadMoreEvents}
+                  onRetryEvents={onRetryEvents}
+                  footer={
+                    <WorkOrderCommentComposer
+                      canComment={canManage}
+                      isSubmitting={isAddingComment}
+                      onSubmit={onAddComment}
+                    />
+                  }
+                />
+              </div>
+            </section>
+          </div>
 
-          <section className={order.description ? "mt-10" : undefined}>
-            <h2 className="workspace-section-title">Activity</h2>
-            <p className="workspace-body-text mt-1 text-muted-foreground">
-              Actions and comments on the work order, plus factory line runs.
-            </p>
-            <div className="mt-4">
-              <WorkOrderActivityTimeline
-                organizationId={organizationId}
-                factoryKey={factoryKey}
-                order={order}
-                events={events}
-                eventsError={eventsError}
-                isLoading={isEventsLoading}
-                hasMoreEvents={hasMoreEvents}
-                isLoadingMoreEvents={isLoadingMoreEvents}
-                onLoadMoreEvents={onLoadMoreEvents}
-                onRetryEvents={onRetryEvents}
-                footer={
-                  <WorkOrderCommentComposer
-                    canComment={canManage}
-                    isSubmitting={isAddingComment}
-                    onSubmit={onAddComment}
-                  />
-                }
-              />
-            </div>
-          </section>
+          <aside className="mt-1 lg:sticky lg:top-16 lg:self-start">
+            <WorkOrderDetailSidebar
+              organizationId={organizationId}
+              factoryKey={factoryKey}
+              order={order}
+              artifacts={artifacts}
+              isArtifactsLoading={isArtifactsLoading}
+              artifactsError={artifactsError}
+              displayStatus={displayStatus}
+              statusMeta={statusMeta}
+              assigneeIds={assigneeIds}
+              assigneeNames={assigneeNames}
+              factoryLines={factoryLines}
+              canEditFactoryLines={canEditFactoryLines}
+              canAssign={canAssign}
+              canDispatch={canDispatch}
+              permissionsLoading={permissionsLoading}
+              isAssigneesSaving={isAssigneesSaving}
+              isDispatchable={isDispatchable}
+              isDispatching={isDispatching}
+              onAssigneesSave={onAssigneesSave}
+              onDispatch={onDispatch}
+            />
+          </aside>
         </div>
-
-        <aside className="mt-1 lg:sticky lg:top-16 lg:self-start">
-          <WorkOrderDetailSidebar
-            organizationId={organizationId}
-            factoryKey={factoryKey}
-            order={order}
-            artifacts={artifacts}
-            isArtifactsLoading={isArtifactsLoading}
-            artifactsError={artifactsError}
-            displayStatus={displayStatus}
-            statusMeta={statusMeta}
-            assigneeIds={assigneeIds}
-            assigneeNames={assigneeNames}
-            factoryLines={factoryLines}
-            canEditFactoryLines={canEditFactoryLines}
-            canAssign={canAssign}
-            canDispatch={canDispatch}
-            permissionsLoading={permissionsLoading}
-            isAssigneesSaving={isAssigneesSaving}
-            isDispatchable={isDispatchable}
-            isDispatching={isDispatching}
-            onAssigneesSave={onAssigneesSave}
-            onDispatch={onDispatch}
-          />
-        </aside>
       </div>
-    </div>
+    </>
   );
 }

--- a/web_src/src/pages/factories/WorkOrderDetailLoadedView.tsx
+++ b/web_src/src/pages/factories/WorkOrderDetailLoadedView.tsx
@@ -7,14 +7,13 @@ import type {
   FactoriesWorkOrderState,
 } from "@/api-client";
 import { workOrdersPath } from "./lib/factoryPagePaths";
-import { getWorkOrderDisplayKey } from "./lib/workOrderProgress";
+import { getWorkOrderDisplayKey, type WorkOrderDisplayStatus } from "./lib/workOrderProgress";
 import { factoryContentBodyClassName } from "./pages/factoryPageLayoutStyles";
 import { WorkOrderActivityTimeline } from "./WorkOrderActivityTimeline";
 import { WorkOrderCommentComposer } from "./WorkOrderCommentComposer";
 import { WorkOrderDescription } from "./WorkOrderDescription";
 import { WorkOrderDetailHeader } from "./WorkOrderDetailHeader";
 import { WorkOrderDetailSidebar } from "./WorkOrderDetailSidebar";
-import type { WorkOrderDisplayStatus } from "./lib/workOrderProgress";
 
 interface WorkOrderDetailLoadedViewProps {
   organizationId: string;
@@ -58,7 +57,33 @@ interface WorkOrderDetailLoadedViewProps {
   onAddComment: (body: string) => Promise<void>;
 }
 
-export function WorkOrderDetailLoadedView({
+export function WorkOrderDetailLoadedView(props: WorkOrderDetailLoadedViewProps) {
+  const identifier = getWorkOrderDisplayKey(props.order, props.factoryKey);
+  return (
+    <>
+      <WorkOrderDetailHeader
+        orderTitle={props.order.title ?? "Work Order"}
+        orderIdentifier={identifier === "—" ? undefined : identifier}
+        backHref={workOrdersPath(props.organizationId, props.factoryKey)}
+        displayStatus={props.displayStatus}
+        isOpen={props.isOpen}
+        isDispatchable={props.isDispatchable}
+        isClosed={props.isClosed}
+        canClose={props.canClose}
+        canManage={props.canManage}
+        isCompleting={props.isCompleting}
+        isRejecting={props.isRejecting}
+        isClosing={props.isClosing}
+        isUpdatingStatus={props.isUpdatingStatus}
+        onClose={props.onClose}
+        onStatusChange={props.onStatusChange}
+      />
+      <WorkOrderDetailBody {...props} />
+    </>
+  );
+}
+
+function WorkOrderDetailBody({
   organizationId,
   factoryKey,
   order,
@@ -78,107 +103,78 @@ export function WorkOrderDetailLoadedView({
   assigneeNames,
   factoryLines,
   canEditFactoryLines,
-  isOpen,
   isDispatchable,
-  isClosed,
   canDispatch,
-  canClose,
   canAssign,
   canManage,
   permissionsLoading,
   isDispatching,
-  isCompleting,
-  isRejecting,
-  isClosing,
   isAssigneesSaving,
-  isUpdatingStatus,
   isAddingComment,
   onDispatch,
-  onClose,
   onAssigneesSave,
-  onStatusChange,
   onAddComment,
 }: WorkOrderDetailLoadedViewProps) {
-  const identifier = getWorkOrderDisplayKey(order, factoryKey);
   return (
-    <>
-      <WorkOrderDetailHeader
-        orderTitle={order.title ?? "Work Order"}
-        orderIdentifier={identifier === "—" ? undefined : identifier}
-        backHref={workOrdersPath(organizationId, factoryKey)}
-        displayStatus={displayStatus}
-        isOpen={isOpen}
-        isDispatchable={isDispatchable}
-        isClosed={isClosed}
-        canClose={canClose}
-        canManage={canManage}
-        isCompleting={isCompleting}
-        isRejecting={isRejecting}
-        isClosing={isClosing}
-        isUpdatingStatus={isUpdatingStatus}
-        onClose={onClose}
-        onStatusChange={onStatusChange}
-      />
-      <div className={factoryContentBodyClassName}>
-        <div className="grid gap-x-[var(--workspace-column-gap)] gap-y-0 lg:grid-cols-[minmax(0,1fr)_var(--workspace-detail-sidebar-width)]">
-          <div className="min-w-0">
-            {order.description ? <WorkOrderDescription description={order.description} /> : null}
+    <div className={factoryContentBodyClassName}>
+      <div className="grid gap-x-[var(--workspace-column-gap)] gap-y-0 lg:grid-cols-[minmax(0,1fr)_var(--workspace-detail-sidebar-width)]">
+        <div className="min-w-0">
+          {order.description ? <WorkOrderDescription description={order.description} /> : null}
 
-            <section className={order.description ? "mt-10" : undefined}>
-              <h2 className="workspace-section-title">Activity</h2>
-              <p className="workspace-body-text mt-1 text-muted-foreground">
-                Actions and comments on the work order, plus factory line runs.
-              </p>
-              <div className="mt-4">
-                <WorkOrderActivityTimeline
-                  organizationId={organizationId}
-                  factoryKey={factoryKey}
-                  order={order}
-                  events={events}
-                  eventsError={eventsError}
-                  isLoading={isEventsLoading}
-                  hasMoreEvents={hasMoreEvents}
-                  isLoadingMoreEvents={isLoadingMoreEvents}
-                  onLoadMoreEvents={onLoadMoreEvents}
-                  onRetryEvents={onRetryEvents}
-                  footer={
-                    <WorkOrderCommentComposer
-                      canComment={canManage}
-                      isSubmitting={isAddingComment}
-                      onSubmit={onAddComment}
-                    />
-                  }
-                />
-              </div>
-            </section>
-          </div>
-
-          <aside className="mt-1 lg:sticky lg:top-16 lg:self-start">
-            <WorkOrderDetailSidebar
-              organizationId={organizationId}
-              factoryKey={factoryKey}
-              order={order}
-              artifacts={artifacts}
-              isArtifactsLoading={isArtifactsLoading}
-              artifactsError={artifactsError}
-              displayStatus={displayStatus}
-              statusMeta={statusMeta}
-              assigneeIds={assigneeIds}
-              assigneeNames={assigneeNames}
-              factoryLines={factoryLines}
-              canEditFactoryLines={canEditFactoryLines}
-              canAssign={canAssign}
-              canDispatch={canDispatch}
-              permissionsLoading={permissionsLoading}
-              isAssigneesSaving={isAssigneesSaving}
-              isDispatchable={isDispatchable}
-              isDispatching={isDispatching}
-              onAssigneesSave={onAssigneesSave}
-              onDispatch={onDispatch}
-            />
-          </aside>
+          <section className={order.description ? "mt-10" : undefined}>
+            <h2 className="workspace-section-title">Activity</h2>
+            <p className="workspace-body-text mt-1 text-muted-foreground">
+              Actions and comments on the work order, plus factory line runs.
+            </p>
+            <div className="mt-4">
+              <WorkOrderActivityTimeline
+                organizationId={organizationId}
+                factoryKey={factoryKey}
+                order={order}
+                events={events}
+                eventsError={eventsError}
+                isLoading={isEventsLoading}
+                hasMoreEvents={hasMoreEvents}
+                isLoadingMoreEvents={isLoadingMoreEvents}
+                onLoadMoreEvents={onLoadMoreEvents}
+                onRetryEvents={onRetryEvents}
+                footer={
+                  <WorkOrderCommentComposer
+                    canComment={canManage}
+                    isSubmitting={isAddingComment}
+                    onSubmit={onAddComment}
+                  />
+                }
+              />
+            </div>
+          </section>
         </div>
+
+        <aside className="mt-1 lg:sticky lg:top-16 lg:self-start">
+          <WorkOrderDetailSidebar
+            organizationId={organizationId}
+            factoryKey={factoryKey}
+            order={order}
+            artifacts={artifacts}
+            isArtifactsLoading={isArtifactsLoading}
+            artifactsError={artifactsError}
+            displayStatus={displayStatus}
+            statusMeta={statusMeta}
+            assigneeIds={assigneeIds}
+            assigneeNames={assigneeNames}
+            factoryLines={factoryLines}
+            canEditFactoryLines={canEditFactoryLines}
+            canAssign={canAssign}
+            canDispatch={canDispatch}
+            permissionsLoading={permissionsLoading}
+            isAssigneesSaving={isAssigneesSaving}
+            isDispatchable={isDispatchable}
+            isDispatching={isDispatching}
+            onAssigneesSave={onAssigneesSave}
+            onDispatch={onDispatch}
+          />
+        </aside>
       </div>
-    </>
+    </div>
   );
 }

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.spec.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.spec.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { WorkspacePageHeader } from "./WorkspacePageHeader";
+
+function renderHeader(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("WorkspacePageHeader (section variant)", () => {
+  it("renders the title and optional subtitle", () => {
+    renderHeader(<WorkspacePageHeader title="Overview" subtitle="Your workspace at a glance." />);
+    expect(screen.getByTestId("workspace-page-header-title")).toHaveTextContent("Overview");
+    expect(screen.getByTestId("workspace-page-header-subtitle")).toHaveTextContent("Your workspace at a glance.");
+    expect(screen.queryByTestId("workspace-page-header-back")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-page-header-kicker")).not.toBeInTheDocument();
+  });
+
+  it("renders leading content next to the title", () => {
+    renderHeader(
+      <WorkspacePageHeader title="Work Orders" leading={<span data-testid="scope-pills">All | Active | My</span>} />,
+    );
+    expect(screen.getByTestId("scope-pills")).toBeInTheDocument();
+  });
+
+  it("renders trailing actions and belowRow content", () => {
+    renderHeader(
+      <WorkspacePageHeader
+        title="Work Orders"
+        actions={<button data-testid="new-button">New</button>}
+        belowRow={<div data-testid="filter-chips">chips</div>}
+      />,
+    );
+    expect(screen.getByTestId("workspace-page-header-actions")).toContainElement(screen.getByTestId("new-button"));
+    expect(screen.getByTestId("filter-chips")).toBeInTheDocument();
+  });
+});
+
+describe("WorkspacePageHeader (entity variant)", () => {
+  it("renders back link, kicker, title, and subtitle", () => {
+    renderHeader(
+      <WorkspacePageHeader
+        variant="entity"
+        title="Reconcile duplicate refunds"
+        kicker="SP-42"
+        subtitle="Ledger cleanup"
+        backHref="/org-1/workspaces/SP/work-orders"
+        backLabel="Work Orders"
+      />,
+    );
+    const back = screen.getByTestId("workspace-page-header-back");
+    expect(back).toHaveAttribute("href", "/org-1/workspaces/SP/work-orders");
+    expect(back).toHaveTextContent("Work Orders");
+    expect(screen.getByTestId("workspace-page-header-kicker")).toHaveTextContent("SP-42");
+    expect(screen.getByTestId("workspace-page-header-title")).toHaveTextContent("Reconcile duplicate refunds");
+    expect(screen.getByTestId("workspace-page-header-subtitle")).toHaveTextContent("Ledger cleanup");
+  });
+
+  it("omits the kicker when none is provided", () => {
+    renderHeader(<WorkspacePageHeader variant="entity" title="Refund line" backHref="/lines" backLabel="Lines" />);
+    expect(screen.queryByTestId("workspace-page-header-kicker")).not.toBeInTheDocument();
+  });
+
+  it("uses a custom back link test id when provided", () => {
+    renderHeader(
+      <WorkspacePageHeader
+        variant="entity"
+        title="Refund line"
+        backHref="/lines"
+        backLabel="Lines"
+        backTestId="lines-back"
+      />,
+    );
+    expect(screen.getByTestId("lines-back")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.spec.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.spec.tsx
@@ -34,6 +34,12 @@ describe("WorkspacePageHeader (section variant)", () => {
     );
     expect(screen.getByTestId("workspace-page-header-actions")).toContainElement(screen.getByTestId("new-button"));
     expect(screen.getByTestId("filter-chips")).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-page-header").children).toHaveLength(2);
+  });
+
+  it("does not add a below-row slot when belowRow is omitted", () => {
+    renderHeader(<WorkspacePageHeader title="Work Orders" />);
+    expect(screen.getByTestId("workspace-page-header").children).toHaveLength(1);
   });
 });
 

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Copy, Ellipsis, Funnel, Pencil, Plus, RefreshCw, Search, Settings2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
+import { withFactoriesTheme } from "../__fixtures__/factoriesStoryTheme";
+import { WorkspacePageHeader } from "./WorkspacePageHeader";
+
+const meta = {
+  title: "Factories/Layout/WorkspacePageHeader",
+  component: WorkspacePageHeader,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    withFactoriesTheme,
+    (Story) => (
+      <ComponentStoryShell className="min-h-screen bg-background">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof WorkspacePageHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SectionTitleOnly: Story = {
+  args: {
+    title: "Overview",
+  },
+};
+
+export const SectionWithSubtitle: Story = {
+  args: {
+    title: "Overview",
+    subtitle: "Your workspace at a glance.",
+  },
+};
+
+export const SectionWithPrimaryAction: Story = {
+  args: {
+    title: "Lines",
+    subtitle:
+      "Factory lines specialize how work moves through the workspace. Each phase is backed by a canvas that runs work orders.",
+    actions: (
+      <Button type="button" size="sm">
+        <Plus className="size-3.5" aria-hidden />
+        New line
+      </Button>
+    ),
+  },
+};
+
+export const SectionWithToolbarAndChips: Story = {
+  args: {
+    title: "Work Orders",
+    leading: (
+      <div className="flex items-center rounded-md border border-border p-0.5" role="group" aria-label="Scope">
+        <span className="inline-flex h-7 items-center rounded-[5px] bg-accent px-2.5 text-[12px] font-medium text-foreground">
+          All
+        </span>
+        <span className="inline-flex h-7 items-center rounded-[5px] px-2.5 text-[12px] font-medium text-muted-foreground">
+          Active
+        </span>
+        <span className="inline-flex h-7 items-center rounded-[5px] px-2.5 text-[12px] font-medium text-muted-foreground">
+          My
+        </span>
+      </div>
+    ),
+    actions: (
+      <>
+        <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
+          <Funnel className="size-3.5" aria-hidden />
+          Filter
+        </Button>
+        <Button type="button" variant="ghost" size="icon-xs" aria-label="Search work orders">
+          <Search className="size-3.5" aria-hidden />
+        </Button>
+        <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
+          <Settings2 className="size-3.5" aria-hidden />
+          Display
+        </Button>
+        <Button type="button" size="sm">
+          <Plus className="size-3.5" aria-hidden />
+          New work order
+        </Button>
+      </>
+    ),
+    belowRow: (
+      <div className="flex flex-wrap items-center gap-1.5 pt-1 text-[12px] text-muted-foreground">
+        <span className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2">
+          Status: Active
+        </span>
+        <span className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2">
+          Owner: You
+        </span>
+      </div>
+    ),
+  },
+};
+
+export const SectionWithSecondaryAction: Story = {
+  args: {
+    title: "Wiki",
+    subtitle: "Shared product context — intent, architecture, and delivery notes.",
+    actions: (
+      <Button type="button" variant="outline" size="sm">
+        <RefreshCw className="size-3.5" aria-hidden />
+        Refresh knowledge
+      </Button>
+    ),
+  },
+};
+
+export const EntityWithKicker: Story = {
+  args: {
+    variant: "entity",
+    backHref: "#",
+    backLabel: "Work Orders",
+    kicker: "SP-42",
+    title: "Reconcile duplicate refunds in ledger",
+    actions: (
+      <>
+        <Button type="button" variant="ghost" size="icon-xs" aria-label="Copy link">
+          <Copy className="size-3.5" aria-hidden />
+        </Button>
+        <Button type="button" variant="ghost" size="icon-xs" aria-label="More actions">
+          <Ellipsis className="size-3.5" aria-hidden />
+        </Button>
+      </>
+    ),
+  },
+};
+
+export const EntityWithSubtitleAndAction: Story = {
+  args: {
+    variant: "entity",
+    backHref: "#",
+    backLabel: "Lines",
+    title: "Refunds daily sweep",
+    subtitle: "3 phases",
+    actions: (
+      <Button type="button" variant="outline" size="sm">
+        <Pencil className="size-3.5" aria-hidden />
+        Edit
+      </Button>
+    ),
+  },
+};

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.tsx
@@ -95,7 +95,7 @@ export function WorkspacePageHeader(props: WorkspacePageHeaderProps) {
           </div>
         ) : null}
       </div>
-      {props.belowRow ? <div className="w-full">{props.belowRow}</div> : null}
+      {props.belowRow}
     </header>
   );
 }

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from "react";
+import { ArrowLeft } from "lucide-react";
+import { Link } from "@/components/Link/link";
+import { cn } from "@/lib/utils";
+import { factoryContentHeaderClassName } from "../pages/factoryPageLayoutStyles";
+
+interface WorkspacePageHeaderBaseProps {
+  /** Optional wrapper className appended to the shared shell. */
+  className?: string;
+  /** Optional test id on the outer header element. */
+  "data-testid"?: string;
+  /** Trailing actions, right-aligned. */
+  actions?: ReactNode;
+  /** Optional content stacked below the title/actions row (filter chips, tabs, etc.). */
+  belowRow?: ReactNode;
+}
+
+interface WorkspaceSectionHeaderProps extends WorkspacePageHeaderBaseProps {
+  variant?: "section";
+  /** Section title, e.g. "Work Orders", "Lines". */
+  title: string;
+  /** Optional description below the title. */
+  subtitle?: ReactNode;
+  /** Optional inline element rendered next to the title (e.g. Work Orders scope pills). */
+  leading?: ReactNode;
+}
+
+interface WorkspaceEntityHeaderProps extends WorkspacePageHeaderBaseProps {
+  variant: "entity";
+  /** Entity title, e.g. work order title, line name, automation name. */
+  title: string;
+  /** Optional short identifier shown above the title (e.g. "SP-42"). */
+  kicker?: ReactNode;
+  /** Optional description below the title. */
+  subtitle?: ReactNode;
+  /** Back link target. Renders "<Icon> <label>" affordance above the title. */
+  backHref: string;
+  /** Label for the back link, e.g. "Work Orders", "Lines", "Automations". */
+  backLabel: string;
+  /** Optional test id on the back link. */
+  backTestId?: string;
+}
+
+export type WorkspacePageHeaderProps = WorkspaceSectionHeaderProps | WorkspaceEntityHeaderProps;
+
+/**
+ * Shared page-chrome header for every top-level `/workspaces/:factoryKey`
+ * route. Two variants:
+ *
+ * - `section` (default): title + optional subtitle + trailing actions. Used
+ *   for Overview, Work Orders list, Lines list, Automations list, Wiki,
+ *   Velocity, and other section pages.
+ * - `entity`: back link + optional identifier kicker + entity title +
+ *   trailing actions. Used for work order, line, and automation detail.
+ *
+ * The header always uses the same gutter, max width, and vertical rhythm
+ * so pages match. Callers put body content in `factoryContentBodyClassName`
+ * after this header.
+ */
+export function WorkspacePageHeader(props: WorkspacePageHeaderProps) {
+  const isEntity = props.variant === "entity";
+  const hasSubtitle = Boolean(props.subtitle);
+  const alignItems = hasSubtitle || isEntity ? "items-start" : "items-center";
+  return (
+    <header
+      className={cn(factoryContentHeaderClassName, props.className)}
+      data-testid={props["data-testid"] ?? "workspace-page-header"}
+    >
+      <div className={cn("flex w-full flex-wrap justify-between gap-3", alignItems)}>
+        <div className="min-w-0 flex-1">
+          {isEntity ? <BackLink href={props.backHref} label={props.backLabel} testId={props.backTestId} /> : null}
+          {isEntity && props.kicker ? (
+            <p
+              className="mt-2 text-[12px] font-medium uppercase tracking-[0.06em] text-muted-foreground tabular-nums"
+              data-testid="workspace-page-header-kicker"
+            >
+              {props.kicker}
+            </p>
+          ) : null}
+          <div className={cn("flex min-w-0 flex-wrap items-center gap-3", isEntity && "mt-1")}>
+            <h1 className="workspace-page-title min-w-0" data-testid="workspace-page-header-title">
+              {props.title}
+            </h1>
+            {!isEntity && props.leading ? <div className="flex items-center gap-2">{props.leading}</div> : null}
+          </div>
+          {hasSubtitle ? (
+            <p className="workspace-body-text mt-1 text-muted-foreground" data-testid="workspace-page-header-subtitle">
+              {props.subtitle}
+            </p>
+          ) : null}
+        </div>
+        {props.actions ? (
+          <div className="flex shrink-0 items-center gap-2" data-testid="workspace-page-header-actions">
+            {props.actions}
+          </div>
+        ) : null}
+      </div>
+      {props.belowRow ? <div className="w-full">{props.belowRow}</div> : null}
+    </header>
+  );
+}
+
+function BackLink({ href, label, testId }: { href: string; label: string; testId?: string }) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center gap-1.5 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+      data-testid={testId ?? "workspace-page-header-back"}
+    >
+      <ArrowLeft className="size-3.5" strokeWidth={1.75} aria-hidden />
+      {label}
+    </Link>
+  );
+}

--- a/web_src/src/pages/factories/pages/AutomationDetail.tsx
+++ b/web_src/src/pages/factories/pages/AutomationDetail.tsx
@@ -1,0 +1,214 @@
+import type { FactoryApp } from "@/api-client";
+import { Link } from "@/components/Link/link";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
+import { useInfiniteCanvasRuns } from "@/hooks/useCanvasData";
+import { formatTimeAgo } from "@/lib/date";
+import { cn } from "@/lib/utils";
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
+import {
+  listFactoryAutomationRuns,
+  resolveFactoryAutomationStatusFromCanvasRuns,
+  type FactoryAutomationRunCard,
+} from "../lib/factoryAutomationStatus";
+import { automationsPath, factoryAppRunPath } from "../lib/factoryPagePaths";
+import { type AutomationCardActions } from "./automationCardActions";
+import { AutomationHeaderActions, DeleteAutomationDialog, StatusTick } from "./automationsPageParts";
+import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
+import { LineVelocityPanel } from "./LineVelocityPanel";
+
+export function AutomationDetail({
+  organizationId,
+  factoryKey,
+  app,
+  actions,
+}: {
+  organizationId: string;
+  factoryKey: string;
+  app: FactoryApp;
+  actions: AutomationCardActions;
+}) {
+  const canvasId = app.id ?? "";
+  const {
+    data: runsPages,
+    isLoading: runsLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteCanvasRuns(canvasId, {}, Boolean(canvasId));
+  const canvasRuns = useMemo(() => runsPages?.pages.flatMap((page) => page?.runs ?? []) ?? [], [runsPages]);
+  const status = resolveFactoryAutomationStatusFromCanvasRuns(canvasRuns);
+  const runs = useMemo(() => listFactoryAutomationRuns(canvasRuns), [canvasRuns]);
+
+  const runsScrollRef = useRef<HTMLUListElement>(null);
+  const loadMoreRuns = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) {
+      return;
+    }
+    void fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  const loadMoreRunsIfNeeded = useAutoLoadMoreOnScroll({
+    hasMore: Boolean(hasNextPage),
+    isLoading: isFetchingNextPage,
+    onLoadMore: loadMoreRuns,
+  });
+
+  useEffect(() => {
+    loadMoreRunsIfNeeded(runsScrollRef.current);
+  }, [runs.length, loadMoreRunsIfNeeded]);
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const automationName = app.name?.trim() || "Unnamed automation";
+  const description = app.description?.trim();
+  const subtitleParts = [status.label, description].filter(Boolean);
+  const subtitle = subtitleParts.length > 0 ? subtitleParts.join(" · ") : undefined;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="automations-detail">
+      <WorkspacePageHeader
+        variant="entity"
+        backHref={automationsPath(organizationId, factoryKey)}
+        backLabel="Automations"
+        backTestId="automations-detail-back"
+        title={automationName}
+        subtitle={subtitle}
+        actions={
+          <AutomationHeaderActions
+            name={automationName}
+            actions={actions}
+            onRequestDelete={() => setDeleteOpen(true)}
+          />
+        }
+      />
+
+      <DeleteAutomationDialog
+        open={deleteOpen}
+        name={automationName}
+        canDelete={actions.canDelete}
+        isDeleting={Boolean(actions.isDeleting)}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={actions.onDelete}
+      />
+
+      <div
+        className={cn(factoryContentBodyClassName, "flex min-h-0 flex-1 flex-col overflow-hidden")}
+        data-testid="automations-detail-body"
+      >
+        <AutomationDetailTabs
+          organizationId={organizationId}
+          factoryKey={factoryKey}
+          canvasId={canvasId}
+          runs={runs}
+          runsLoading={runsLoading}
+          isFetchingNextPage={isFetchingNextPage}
+          runsScrollRef={runsScrollRef}
+          loadMoreRunsIfNeeded={loadMoreRunsIfNeeded}
+        />
+      </div>
+    </div>
+  );
+}
+
+function AutomationDetailTabs({
+  organizationId,
+  factoryKey,
+  canvasId,
+  runs,
+  runsLoading,
+  isFetchingNextPage,
+  runsScrollRef,
+  loadMoreRunsIfNeeded,
+}: {
+  organizationId: string;
+  factoryKey: string;
+  canvasId: string;
+  runs: FactoryAutomationRunCard[];
+  runsLoading: boolean;
+  isFetchingNextPage: boolean;
+  runsScrollRef: RefObject<HTMLUListElement | null>;
+  loadMoreRunsIfNeeded: (element: HTMLElement | null) => void;
+}) {
+  return (
+    <Tabs defaultValue="runs" className="flex min-h-0 min-w-0 flex-1 flex-col gap-3">
+      <TabsList>
+        <TabsTrigger value="runs" data-testid="automations-tab-runs">
+          Runs
+        </TabsTrigger>
+        <TabsTrigger value="velocity" data-testid="automations-tab-velocity">
+          Velocity
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="runs" className="mt-0 flex min-h-0 min-w-0 flex-1 flex-col outline-none">
+        <ul
+          ref={runsScrollRef}
+          className="flex min-h-[12rem] min-w-0 max-h-[calc(100dvh-16rem)] flex-1 flex-col gap-2 overflow-y-auto overscroll-contain p-0.5 [scrollbar-width:thin]"
+          onScroll={(event) => loadMoreRunsIfNeeded(event.currentTarget)}
+          data-testid="automations-runs-scroll"
+        >
+          {runsLoading && runs.length === 0 ? (
+            <li className="px-2 py-4 text-[12px] text-muted-foreground">Loading runs…</li>
+          ) : runs.length === 0 ? (
+            <li className="px-2 py-4 text-[12px] text-muted-foreground">No runs</li>
+          ) : (
+            <>
+              {runs.map((run) => (
+                <li key={run.runId}>
+                  <AutomationRunRow
+                    organizationId={organizationId}
+                    factoryKey={factoryKey}
+                    appId={canvasId}
+                    run={run}
+                  />
+                </li>
+              ))}
+              {isFetchingNextPage ? (
+                <li className="py-2 text-center text-[12px] text-muted-foreground">Loading more…</li>
+              ) : null}
+            </>
+          )}
+        </ul>
+      </TabsContent>
+      <TabsContent
+        value="velocity"
+        className="mt-0 min-h-0 max-h-[calc(100dvh-16rem)] flex-1 overflow-y-auto outline-none [scrollbar-width:thin]"
+      >
+        <LineVelocityPanel intro="Run throughput for this automation." />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function AutomationRunRow({
+  organizationId,
+  factoryKey,
+  appId,
+  run,
+}: {
+  organizationId: string;
+  factoryKey: string;
+  appId: string;
+  run: FactoryAutomationRunCard;
+}) {
+  const href = factoryAppRunPath(organizationId, factoryKey, appId, run.runId, { from: "automations" });
+  const timestamp = run.updatedAt ?? run.finishedAt ?? run.createdAt;
+  const timeLabel =
+    run.tick === "queued" && !timestamp ? "next" : timestamp ? formatTimeAgo(new Date(timestamp), false) : null;
+
+  return (
+    <Link
+      href={href}
+      className="block w-full rounded-md border border-border bg-background px-3 py-2.5 text-left transition-colors hover:border-foreground/25 hover:bg-accent/40"
+      data-testid={`automations-run-${run.runId}`}
+    >
+      <div className="truncate text-[13px] font-medium tracking-[-0.01em] text-foreground">{run.title}</div>
+      <div className="mt-1.5 flex items-center gap-1.5 text-[12px] text-muted-foreground">
+        <StatusTick tick={run.tick} size="sm" />
+        <span>
+          {run.label}
+          {timeLabel ? ` · ${timeLabel}` : ""}
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/web_src/src/pages/factories/pages/AutomationsPage.tsx
+++ b/web_src/src/pages/factories/pages/AutomationsPage.tsx
@@ -1,15 +1,10 @@
 import { PermissionTooltip } from "@/components/PermissionGate";
-import { Heading } from "@/components/Heading/heading";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import { Plus } from "lucide-react";
 import { CreateFactoryAppDialog } from "../CreateFactoryAppDialog";
-import {
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageSubtitleClassName,
-  factoryPageTitleClassName,
-} from "./factoryPageLayoutStyles";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
+import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
+import { AutomationDetail } from "./automationsPageParts";
 import { AutomationsPageBody } from "./automationsPageBody";
 import { AutomationsLegacyRedirect } from "./automationsPageRedirect";
 import { useAutomationsPageModel } from "./useAutomationsPageModel";
@@ -30,51 +25,52 @@ export function AutomationsPage() {
 
   const selectedApp = model.selectedApp;
 
+  if (selectedApp && model.selectedAppActions) {
+    return (
+      <div className="flex h-full min-h-0 flex-col" data-testid="automations-detail-page">
+        <AutomationDetail
+          organizationId={model.organizationId}
+          factoryKey={model.factoryKey}
+          app={selectedApp}
+          actions={model.selectedAppActions}
+        />
+      </div>
+    );
+  }
+
   return (
-    <div
-      className={cn(selectedApp && "flex h-full min-h-0 flex-col")}
-      data-testid={selectedApp ? "automations-detail-page" : "automations-list-page"}
-    >
-      <header className={cn(factoryContentHeaderClassName, selectedApp && "shrink-0")}>
-        <div>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            Automations
-          </Heading>
-          <p className={cn("mt-1", factoryPageSubtitleClassName)}>
-            Automations are one-step lines. Each one listens for a trigger and runs a canvas when it fires.
-          </p>
-        </div>
-        {selectedApp == null ? (
+    <div data-testid="automations-list-page">
+      <WorkspacePageHeader
+        title="Automations"
+        subtitle="Automations are one-step lines. Each one listens for a trigger and runs a canvas when it fires."
+        actions={
           <PermissionTooltip
             allowed={model.canCreateApp || model.permissionsLoading}
             message="You don't have permission to create automations."
           >
             <Button
               type="button"
-              variant="outline"
-              asChild={false}
+              size="sm"
               disabled={!model.canCreateApp}
               onClick={() => model.setCreateOpen(true)}
               data-testid="automations-create-button"
             >
-              <Plus className="h-3.5 w-3.5" aria-hidden />
-              Add automation
+              <Plus className="size-3.5" aria-hidden />
+              New automation
             </Button>
           </PermissionTooltip>
-        ) : null}
-      </header>
+        }
+      />
 
-      <div
-        className={cn(factoryContentBodyClassName, selectedApp && "flex min-h-0 flex-1 flex-col overflow-hidden py-6")}
-      >
+      <div className={factoryContentBodyClassName}>
         <AutomationsPageBody
           organizationId={model.organizationId}
           factoryKey={model.factoryKey}
           apps={model.apps}
           workOrders={model.workOrders}
           appsLoading={model.appsLoading}
-          selectedApp={selectedApp}
-          selectedAppActions={model.selectedAppActions}
+          selectedApp={null}
+          selectedAppActions={null}
           actionsForApp={model.actionsForApp}
           canCreate={model.canCreateApp || model.permissionsLoading}
           onCreate={() => model.setCreateOpen(true)}

--- a/web_src/src/pages/factories/pages/AutomationsPage.tsx
+++ b/web_src/src/pages/factories/pages/AutomationsPage.tsx
@@ -4,7 +4,7 @@ import { Plus } from "lucide-react";
 import { CreateFactoryAppDialog } from "../CreateFactoryAppDialog";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
-import { AutomationDetail } from "./automationsPageParts";
+import { AutomationDetail } from "./AutomationDetail";
 import { AutomationsPageBody } from "./automationsPageBody";
 import { AutomationsLegacyRedirect } from "./automationsPageRedirect";
 import { useAutomationsPageModel } from "./useAutomationsPageModel";

--- a/web_src/src/pages/factories/pages/ComingSoonPage.tsx
+++ b/web_src/src/pages/factories/pages/ComingSoonPage.tsx
@@ -1,12 +1,6 @@
-import { Heading } from "@/components/Heading/heading";
-import { cn } from "@/lib/utils";
 import type { LucideIcon } from "lucide-react";
-import {
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageSubtitleClassName,
-  factoryPageTitleClassName,
-} from "./factoryPageLayoutStyles";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
+import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
 
 interface ComingSoonPageProps {
   title: string;
@@ -17,14 +11,7 @@ interface ComingSoonPageProps {
 export function ComingSoonPage({ title, description, Icon }: ComingSoonPageProps) {
   return (
     <>
-      <header className={factoryContentHeaderClassName}>
-        <div>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            {title}
-          </Heading>
-          <p className={cn("mt-1", factoryPageSubtitleClassName)}>{description}</p>
-        </div>
-      </header>
+      <WorkspacePageHeader title={title} subtitle={description} />
       <div className={factoryContentBodyClassName}>
         <div
           className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-8 py-16 text-center"

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -1,7 +1,6 @@
 import type { FactoriesFactoryLine, FactoriesWorkOrder, FactoryLineStep } from "@/api-client";
 import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
-import { Heading } from "@/components/Heading/heading";
 import { Button } from "@/components/ui/button";
 import { usePermissions } from "@/contexts/usePermissions";
 import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
@@ -9,10 +8,11 @@ import { formatTimeAgo } from "@/lib/date";
 import { cn } from "@/lib/utils";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { ArrowLeft, Layers, MoreHorizontal, Pencil, Plus, Workflow } from "lucide-react";
+import { Layers, MoreHorizontal, Pencil, Plus, Workflow } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import {
   buildLinePhaseBoard,
   LINE_PHASE_RUNS_PAGE_SIZE,
@@ -30,12 +30,7 @@ import {
   linesPath,
   workOrderDetailPath,
 } from "../lib/factoryPagePaths";
-import {
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageSubtitleClassName,
-  factoryPageTitleClassName,
-} from "./factoryPageLayoutStyles";
+import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
 
 export function LinesPage() {
   const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
@@ -56,30 +51,32 @@ export function LinesPage() {
 
   return (
     <>
-      <header className={factoryContentHeaderClassName}>
-        <div>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            Lines
-          </Heading>
-          <p className={cn("mt-1", factoryPageSubtitleClassName)}>
-            Factory lines specialize how work moves through the workspace. Each phase is backed by a canvas that runs
-            work orders.
-          </p>
-        </div>
-        {selectedLine == null ? (
-          <PermissionTooltip
-            allowed={canUpdate || permissionsLoading}
-            message="You don't have permission to create lines."
-          >
-            <Button type="button" variant="outline" asChild disabled={!canUpdate} data-testid="lines-create-button">
-              <Link href={canUpdate ? createFactoryLinePath(organizationId, factoryKey) : "#"}>
-                <Plus className="h-3.5 w-3.5" aria-hidden />
-                Add line
-              </Link>
-            </Button>
-          </PermissionTooltip>
-        ) : null}
-      </header>
+      {selectedLine == null ? (
+        <WorkspacePageHeader
+          title="Lines"
+          subtitle="Factory lines specialize how work moves through the workspace. Each phase is backed by a canvas that runs work orders."
+          actions={
+            <PermissionTooltip
+              allowed={canUpdate || permissionsLoading}
+              message="You don't have permission to create lines."
+            >
+              <Button type="button" size="sm" asChild disabled={!canUpdate} data-testid="lines-create-button">
+                <Link href={canUpdate ? createFactoryLinePath(organizationId, factoryKey) : "#"}>
+                  <Plus className="size-3.5" aria-hidden />
+                  New line
+                </Link>
+              </Button>
+            </PermissionTooltip>
+          }
+        />
+      ) : (
+        <LineDetailHeader
+          organizationId={organizationId}
+          factoryKey={factoryKey}
+          line={selectedLine}
+          canUpdate={canUpdate}
+        />
+      )}
 
       <div className={factoryContentBodyClassName}>
         {selectedLine ? (
@@ -88,7 +85,6 @@ export function LinesPage() {
             factoryKey={factoryKey}
             line={selectedLine}
             workOrders={workOrders}
-            canUpdate={canUpdate}
           />
         ) : lines.length === 0 ? (
           <EmptyLinesState
@@ -120,63 +116,59 @@ export function LinesPage() {
   );
 }
 
-function LineDetail({
+function LineDetailHeader({
   organizationId,
   factoryKey,
   line,
-  workOrders,
   canUpdate,
 }: {
   organizationId: string;
   factoryKey: string;
   line: FactoriesFactoryLine;
-  workOrders: FactoriesWorkOrder[];
   canUpdate: boolean;
 }) {
   const steps = line.steps ?? [];
   const editHref = line.id ? editFactoryLinePath(organizationId, factoryKey, line.id) : "#";
+  return (
+    <WorkspacePageHeader
+      variant="entity"
+      backHref={linesPath(organizationId, factoryKey)}
+      backLabel="Lines"
+      backTestId="lines-back-to-list"
+      title={line.name || "Unnamed line"}
+      subtitle={formatPhaseCount(steps.length)}
+      actions={
+        canUpdate ? (
+          <Button type="button" variant="outline" size="sm" asChild data-testid="lines-edit-button">
+            <Link href={editHref}>
+              <Pencil className="size-3.5" aria-hidden />
+              Edit
+            </Link>
+          </Button>
+        ) : undefined
+      }
+    />
+  );
+}
+
+function LineDetail({
+  organizationId,
+  factoryKey,
+  line,
+  workOrders,
+}: {
+  organizationId: string;
+  factoryKey: string;
+  line: FactoriesFactoryLine;
+  workOrders: FactoriesWorkOrder[];
+}) {
+  const steps = line.steps ?? [];
   const board = useMemo(() => buildLinePhaseBoard(line, workOrders ?? []), [line, workOrders]);
 
   return (
     <div data-testid="lines-detail">
-      <Link
-        href={linesPath(organizationId, factoryKey)}
-        className="mb-3 inline-flex items-center gap-1.5 text-[13px] text-muted-foreground hover:text-foreground"
-        data-testid="lines-back-to-list"
-      >
-        <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
-        All lines
-      </Link>
-
-      <section className={cn("w-full rounded-lg border border-foreground bg-background px-3.5 py-3")}>
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <Workflow className="size-3.5 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
-              <h2 className="text-[13px] font-medium tracking-[-0.01em] text-foreground">
-                {line.name || "Unnamed line"}
-              </h2>
-            </div>
-            <p className="mt-1 text-[12px] leading-snug text-muted-foreground">{formatPhaseCount(steps.length)}</p>
-          </div>
-          {canUpdate ? (
-            <Link
-              href={editHref}
-              className="inline-flex shrink-0 items-center gap-1.5 text-[13px] text-muted-foreground hover:text-foreground"
-              data-testid="lines-edit-button"
-            >
-              <Pencil className="h-3.5 w-3.5" aria-hidden />
-              Edit
-            </Link>
-          ) : null}
-        </div>
-        {steps.length > 0 ? <PhaseStrip steps={steps} ticks={board.map((column) => column.tick)} /> : null}
-      </section>
-
       {steps.length === 0 ? (
-        <p className="mt-6 text-[13px] text-muted-foreground">
-          No phases yet. Edit this line to add app-driven phases.
-        </p>
+        <p className="text-[13px] text-muted-foreground">No phases yet. Edit this line to add app-driven phases.</p>
       ) : (
         <PhaseBoard organizationId={organizationId} factoryKey={factoryKey} lineId={line.id} columns={board} />
       )}
@@ -455,10 +447,10 @@ function EmptyLinesState({
       <p className="mt-1 max-w-md text-[13px] text-muted-foreground">
         Lines define how work orders flow through your apps.
       </p>
-      <Button type="button" asChild className="mt-6" disabled={!canUpdate}>
+      <Button type="button" size="sm" asChild className="mt-6" disabled={!canUpdate}>
         <Link href={canUpdate ? createFactoryLinePath(organizationId, factoryKey) : "#"}>
-          <Plus className="h-3.5 w-3.5" aria-hidden />
-          Add line
+          <Plus className="size-3.5" aria-hidden />
+          New line
         </Link>
       </Button>
     </div>

--- a/web_src/src/pages/factories/pages/OverviewPage.tsx
+++ b/web_src/src/pages/factories/pages/OverviewPage.tsx
@@ -1,5 +1,4 @@
 import type { FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
-import { Heading } from "@/components/Heading/heading";
 import { Badge } from "@/components/ui/badge";
 import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import { cn } from "@/lib/utils";
@@ -7,15 +6,10 @@ import { formatTimeAgo } from "@/lib/date";
 import { ChevronRight, Loader2 } from "lucide-react";
 import { Link } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import { factoryLineDetailPath, linesPath, workOrderDetailPath, workOrdersPath } from "../lib/factoryPagePaths";
 import { getWorkOrderDisplayStatus, getWorkOrderDisplayStatusMeta } from "../lib/workOrderProgress";
-import {
-  factoryCardClassName,
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageSubtitleClassName,
-  factoryPageTitleClassName,
-} from "./factoryPageLayoutStyles";
+import { factoryCardClassName, factoryContentBodyClassName } from "./factoryPageLayoutStyles";
 
 const MAX_ROWS = 8;
 
@@ -39,16 +33,7 @@ export function OverviewPage() {
 
   return (
     <>
-      <header className={factoryContentHeaderClassName}>
-        <div>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            Overview
-          </Heading>
-          <p className={cn("mt-1", factoryPageSubtitleClassName)}>
-            Your workspace at a glance. Content for this page comes next.
-          </p>
-        </div>
-      </header>
+      <WorkspacePageHeader title="Overview" subtitle="Your workspace at a glance. Content for this page comes next." />
 
       <div className={factoryContentBodyClassName}>
         <div className="grid gap-6 lg:grid-cols-2">

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
-import { Heading } from "@/components/Heading/heading";
 import {
   ChartContainer,
   ChartLegend,
@@ -11,6 +10,7 @@ import {
 } from "@/components/ui/chart";
 import { cn } from "@/lib/utils";
 import { SegmentedNav } from "@/ui/SegmentedNav";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import {
   FACTORY_VELOCITY_BY_PERIOD,
   FACTORY_VELOCITY_YESTERDAY,
@@ -18,12 +18,7 @@ import {
   type FactoryVelocityPeriodDays,
   type FactoryVelocityYesterday,
 } from "./factoryVelocityMockData";
-import {
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageSubtitleClassName,
-  factoryPageTitleClassName,
-} from "./factoryPageLayoutStyles";
+import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
 
 const PERIOD_OPTIONS: { value: string; label: string }[] = [
   { value: "7", label: "7d" },
@@ -291,20 +286,10 @@ export function VelocityPage() {
 
   return (
     <>
-      <header className={factoryContentHeaderClassName}>
-        <div>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            Velocity
-          </Heading>
-          <p className={cn("mt-1", factoryPageSubtitleClassName)}>
-            Merged pull requests from SuperPlane, waste, and cost.
-          </p>
-        </div>
-      </header>
-
-      <div className={cn(factoryContentBodyClassName, "space-y-6")} data-testid="factory-velocity-page">
-        <YesterdayCard snapshot={FACTORY_VELOCITY_YESTERDAY} />
-        <div className="flex justify-end">
+      <WorkspacePageHeader
+        title="Velocity"
+        subtitle="Merged pull requests from SuperPlane, waste, and cost."
+        actions={
           <SegmentedNav
             ariaLabel="Velocity period in days"
             size="xs"
@@ -315,7 +300,11 @@ export function VelocityPage() {
             }}
             options={PERIOD_OPTIONS}
           />
-        </div>
+        }
+      />
+
+      <div className={cn(factoryContentBodyClassName, "space-y-6")} data-testid="factory-velocity-page">
+        <YesterdayCard snapshot={FACTORY_VELOCITY_YESTERDAY} />
         <TrendCard periodDays={periodDays} />
         <SourceSplitCard periodDays={periodDays} />
       </div>

--- a/web_src/src/pages/factories/pages/WorkOrdersPage.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrdersPage.tsx
@@ -4,15 +4,11 @@ import { useMe } from "@/hooks/useMe";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import { useWorkOrderListState } from "../lib/useWorkOrderListState";
 import { WorkOrdersLoadedView } from "../workOrders/WorkOrdersLoadedView";
 import { WorkOrdersErrorState, WorkOrdersLoadingState } from "../workOrders/WorkOrdersEmptyStates";
-import {
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageTitleClassName,
-} from "./factoryPageLayoutStyles";
-import { Heading } from "@/components/Heading/heading";
+import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
 
 /**
  * Data + action shell for the Work Orders list. Fetches work orders and
@@ -107,11 +103,5 @@ export function WorkOrdersPage() {
 
 /** Title-only header shown while work orders load or fail to load. */
 function WorkOrdersHeaderStub() {
-  return (
-    <header className={factoryContentHeaderClassName}>
-      <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-        Work Orders
-      </Heading>
-    </header>
-  );
+  return <WorkspacePageHeader title="Work Orders" />;
 }

--- a/web_src/src/pages/factories/pages/automationsPageBody.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageBody.tsx
@@ -1,6 +1,7 @@
 import type { FactoryApp } from "@/api-client";
 import type { AutomationCardActions } from "./automationCardActions";
-import { AutomationDetail, AutomationsPageList, EmptyAutomationsState } from "./automationsPageParts";
+import { AutomationDetail } from "./AutomationDetail";
+import { AutomationsPageList, EmptyAutomationsState } from "./automationsPageParts";
 
 type AutomationsPageBodyProps = {
   organizationId: string;

--- a/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
@@ -6,7 +6,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { FactoryApp } from "@/api-client";
 
-import { AutomationCard, AutomationDetail } from "./automationsPageParts";
+import { AutomationDetail } from "./AutomationDetail";
+import { AutomationCard } from "./automationsPageParts";
 import { duplicateAutomationName } from "./automationCardActions";
 
 vi.mock("@/hooks/useCanvasData", () => ({
@@ -152,6 +153,9 @@ describe("AutomationDetail tabs", () => {
     expect(run.className).toMatch(/\brounded-md\b/);
     expect(screen.getByTestId("automations-runs-scroll").className).toMatch(/\bgap-2\b/);
     expect(screen.getByTestId("automations-runs-scroll").closest("section")).toBeNull();
+    expect(screen.getByTestId("automations-detail-body").className).toMatch(
+      /max-w-\[var\(--workspace-content-max-width\)\]/,
+    );
   });
 
   it("opens the Velocity tab", async () => {

--- a/web_src/src/pages/factories/pages/automationsPageParts.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.tsx
@@ -1,13 +1,8 @@
 import type { FactoryApp } from "@/api-client";
-import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LoadingButton } from "@/components/ui/loading-button";
-import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
-import { useInfiniteCanvasRuns } from "@/hooks/useCanvasData";
-import { formatTimeAgo } from "@/lib/date";
 import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
@@ -17,179 +12,11 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
 import { Copy, MoreHorizontal, Pencil, Plus, Trash2, Workflow } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
+import { useState, type MouseEvent } from "react";
 import { useNavigate } from "react-router";
-import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
-import {
-  listFactoryAutomationRuns,
-  resolveFactoryAutomationStatus,
-  resolveFactoryAutomationStatusFromCanvasRuns,
-  type FactoryAutomationRunCard,
-  type FactoryAutomationTick,
-} from "../lib/factoryAutomationStatus";
-import { automationDetailPath, automationsPath, factoryAppRunPath } from "../lib/factoryPagePaths";
+import { resolveFactoryAutomationStatus, type FactoryAutomationTick } from "../lib/factoryAutomationStatus";
+import { automationDetailPath } from "../lib/factoryPagePaths";
 import { type AutomationCardActions } from "./automationCardActions";
-import { LineVelocityPanel } from "./LineVelocityPanel";
-
-export function AutomationDetail({
-  organizationId,
-  factoryKey,
-  app,
-  actions,
-}: {
-  organizationId: string;
-  factoryKey: string;
-  app: FactoryApp;
-  actions: AutomationCardActions;
-}) {
-  const canvasId = app.id ?? "";
-  const {
-    data: runsPages,
-    isLoading: runsLoading,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useInfiniteCanvasRuns(canvasId, {}, Boolean(canvasId));
-  const canvasRuns = useMemo(() => runsPages?.pages.flatMap((page) => page?.runs ?? []) ?? [], [runsPages]);
-  const status = resolveFactoryAutomationStatusFromCanvasRuns(canvasRuns);
-  const runs = useMemo(() => listFactoryAutomationRuns(canvasRuns), [canvasRuns]);
-
-  const runsScrollRef = useRef<HTMLUListElement>(null);
-  const loadMoreRuns = useCallback(() => {
-    if (!hasNextPage || isFetchingNextPage) {
-      return;
-    }
-    void fetchNextPage();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
-  const loadMoreRunsIfNeeded = useAutoLoadMoreOnScroll({
-    hasMore: Boolean(hasNextPage),
-    isLoading: isFetchingNextPage,
-    onLoadMore: loadMoreRuns,
-  });
-
-  useEffect(() => {
-    loadMoreRunsIfNeeded(runsScrollRef.current);
-  }, [runs.length, loadMoreRunsIfNeeded]);
-
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const automationName = app.name?.trim() || "Unnamed automation";
-  const description = app.description?.trim();
-  const subtitleParts = [status.label, description].filter(Boolean);
-  const subtitle = subtitleParts.length > 0 ? subtitleParts.join(" · ") : undefined;
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col" data-testid="automations-detail">
-      <WorkspacePageHeader
-        variant="entity"
-        backHref={automationsPath(organizationId, factoryKey)}
-        backLabel="Automations"
-        backTestId="automations-detail-back"
-        title={automationName}
-        subtitle={subtitle}
-        actions={
-          <AutomationHeaderActions
-            name={automationName}
-            actions={actions}
-            onRequestDelete={() => setDeleteOpen(true)}
-          />
-        }
-      />
-
-      <DeleteAutomationDialog
-        open={deleteOpen}
-        name={automationName}
-        canDelete={actions.canDelete}
-        isDeleting={Boolean(actions.isDeleting)}
-        onClose={() => setDeleteOpen(false)}
-        onConfirm={actions.onDelete}
-      />
-
-      <Tabs
-        defaultValue="runs"
-        className="mt-6 flex min-h-0 min-w-0 flex-1 flex-col gap-3 px-[var(--workspace-page-gutter)]"
-      >
-        <TabsList>
-          <TabsTrigger value="runs" data-testid="automations-tab-runs">
-            Runs
-          </TabsTrigger>
-          <TabsTrigger value="velocity" data-testid="automations-tab-velocity">
-            Velocity
-          </TabsTrigger>
-        </TabsList>
-        <TabsContent value="runs" className="mt-0 flex min-h-0 min-w-0 flex-1 flex-col outline-none">
-          <ul
-            ref={runsScrollRef}
-            className="flex min-h-[12rem] min-w-0 max-h-[calc(100dvh-16rem)] flex-1 flex-col gap-2 overflow-y-auto overscroll-contain p-0.5 [scrollbar-width:thin]"
-            onScroll={(event) => loadMoreRunsIfNeeded(event.currentTarget)}
-            data-testid="automations-runs-scroll"
-          >
-            {runsLoading && runs.length === 0 ? (
-              <li className="px-2 py-4 text-[12px] text-muted-foreground">Loading runs…</li>
-            ) : runs.length === 0 ? (
-              <li className="px-2 py-4 text-[12px] text-muted-foreground">No runs</li>
-            ) : (
-              <>
-                {runs.map((run) => (
-                  <li key={run.runId}>
-                    <AutomationRunRow
-                      organizationId={organizationId}
-                      factoryKey={factoryKey}
-                      appId={canvasId}
-                      run={run}
-                    />
-                  </li>
-                ))}
-                {isFetchingNextPage ? (
-                  <li className="py-2 text-center text-[12px] text-muted-foreground">Loading more…</li>
-                ) : null}
-              </>
-            )}
-          </ul>
-        </TabsContent>
-        <TabsContent
-          value="velocity"
-          className="mt-0 min-h-0 max-h-[calc(100dvh-16rem)] flex-1 overflow-y-auto outline-none [scrollbar-width:thin]"
-        >
-          <LineVelocityPanel intro="Run throughput for this automation." />
-        </TabsContent>
-      </Tabs>
-    </div>
-  );
-}
-
-function AutomationRunRow({
-  organizationId,
-  factoryKey,
-  appId,
-  run,
-}: {
-  organizationId: string;
-  factoryKey: string;
-  appId: string;
-  run: FactoryAutomationRunCard;
-}) {
-  const href = factoryAppRunPath(organizationId, factoryKey, appId, run.runId, { from: "automations" });
-  const timestamp = run.updatedAt ?? run.finishedAt ?? run.createdAt;
-  const timeLabel =
-    run.tick === "queued" && !timestamp ? "next" : timestamp ? formatTimeAgo(new Date(timestamp), false) : null;
-
-  return (
-    <Link
-      href={href}
-      className="block w-full rounded-md border border-border bg-background px-3 py-2.5 text-left transition-colors hover:border-foreground/25 hover:bg-accent/40"
-      data-testid={`automations-run-${run.runId}`}
-    >
-      <div className="truncate text-[13px] font-medium tracking-[-0.01em] text-foreground">{run.title}</div>
-      <div className="mt-1.5 flex items-center gap-1.5 text-[12px] text-muted-foreground">
-        <StatusTick tick={run.tick} size="sm" />
-        <span>
-          {run.label}
-          {timeLabel ? ` · ${timeLabel}` : ""}
-        </span>
-      </div>
-    </Link>
-  );
-}
 
 function resolveAutomationCardNavigation(href: string | undefined, navigate: ReturnType<typeof useNavigate>) {
   if (!href) {
@@ -407,7 +234,7 @@ function AutomationMenuItems({
   );
 }
 
-function DeleteAutomationDialog({
+export function DeleteAutomationDialog({
   open,
   name,
   canDelete,
@@ -467,7 +294,7 @@ function DeleteAutomationDialog({
   );
 }
 
-function StatusTick({ tick, size = "md" }: { tick: FactoryAutomationTick; size?: "sm" | "md" }) {
+export function StatusTick({ tick, size = "md" }: { tick: FactoryAutomationTick; size?: "sm" | "md" }) {
   return (
     <span
       className={cn(

--- a/web_src/src/pages/factories/pages/automationsPageParts.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.tsx
@@ -16,9 +16,10 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
-import { ArrowLeft, Copy, MoreHorizontal, Pencil, Plus, Trash2, Workflow } from "lucide-react";
+import { Copy, MoreHorizontal, Pencil, Plus, Trash2, Workflow } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { useNavigate } from "react-router";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import {
   listFactoryAutomationRuns,
   resolveFactoryAutomationStatus,
@@ -70,22 +71,43 @@ export function AutomationDetail({
     loadMoreRunsIfNeeded(runsScrollRef.current);
   }, [runs.length, loadMoreRunsIfNeeded]);
 
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const automationName = app.name?.trim() || "Unnamed automation";
+  const description = app.description?.trim();
+  const subtitleParts = [status.label, description].filter(Boolean);
+  const subtitle = subtitleParts.length > 0 ? subtitleParts.join(" · ") : undefined;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="automations-detail">
-      <Link
-        href={automationsPath(organizationId, factoryKey)}
-        className="mb-3 inline-flex shrink-0 items-center gap-1.5 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
-        data-testid="automations-detail-back"
+      <WorkspacePageHeader
+        variant="entity"
+        backHref={automationsPath(organizationId, factoryKey)}
+        backLabel="Automations"
+        backTestId="automations-detail-back"
+        title={automationName}
+        subtitle={subtitle}
+        actions={
+          <AutomationHeaderActions
+            name={automationName}
+            actions={actions}
+            onRequestDelete={() => setDeleteOpen(true)}
+          />
+        }
+      />
+
+      <DeleteAutomationDialog
+        open={deleteOpen}
+        name={automationName}
+        canDelete={actions.canDelete}
+        isDeleting={Boolean(actions.isDeleting)}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={actions.onDelete}
+      />
+
+      <Tabs
+        defaultValue="runs"
+        className="mt-6 flex min-h-0 min-w-0 flex-1 flex-col gap-3 px-[var(--workspace-page-gutter)]"
       >
-        <ArrowLeft className="size-3.5" strokeWidth={1.75} aria-hidden />
-        All automations
-      </Link>
-
-      <div className="shrink-0">
-        <AutomationCard app={app} tick={status.tick} statusLabel={status.label} emphasized actions={actions} />
-      </div>
-
-      <Tabs defaultValue="runs" className="mt-6 flex min-h-0 min-w-0 flex-1 flex-col gap-3">
         <TabsList>
           <TabsTrigger value="runs" data-testid="automations-tab-runs">
             Runs
@@ -263,6 +285,35 @@ const overflowMenuItemClassName = "cursor-pointer rounded-md px-2 py-1.5 text-[1
 const overflowMenuDestructiveItemClassName =
   "text-destructive focus:bg-destructive/10 focus:text-destructive dark:focus:bg-destructive/15";
 
+export function AutomationHeaderActions({
+  name,
+  actions,
+  onRequestDelete,
+}: {
+  name: string;
+  actions: AutomationCardActions;
+  onRequestDelete: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="text-muted-foreground hover:bg-accent hover:text-foreground"
+          disabled={actions.isDuplicating || actions.isDeleting}
+          aria-label={`${name} menu`}
+          data-testid="automations-detail-menu"
+        >
+          <MoreHorizontal className="size-3.5" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <AutomationMenuItems actions={actions} onRequestDelete={onRequestDelete} testIdPrefix="automations-detail" />
+    </DropdownMenu>
+  );
+}
+
 function AutomationCardMenu({
   name,
   actions,
@@ -296,49 +347,63 @@ function AutomationCardMenu({
             <MoreHorizontal className="size-3.5" aria-hidden />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" sideOffset={6} className={overflowMenuContentClassName}>
-          <PermissionTooltip allowed={actions.canEdit} message="You don't have permission to edit this automation.">
-            <DropdownMenuItem
-              className={overflowMenuItemClassName}
-              onClick={actions.onEdit}
-              disabled={!actions.canEdit}
-              data-testid="automations-card-edit"
-            >
-              <Pencil aria-hidden />
-              Edit
-            </DropdownMenuItem>
-          </PermissionTooltip>
-          <PermissionTooltip
-            allowed={actions.canDuplicate}
-            message="You don't have permission to duplicate this automation."
-          >
-            <DropdownMenuItem
-              className={overflowMenuItemClassName}
-              onClick={() => {
-                void actions.onDuplicate();
-              }}
-              disabled={!actions.canDuplicate || actions.isDuplicating}
-              data-testid="automations-card-duplicate"
-            >
-              <Copy aria-hidden />
-              Duplicate
-            </DropdownMenuItem>
-          </PermissionTooltip>
-          <DropdownMenuSeparator />
-          <PermissionTooltip allowed={actions.canDelete} message="You don't have permission to delete this automation.">
-            <DropdownMenuItem
-              className={cn(overflowMenuItemClassName, overflowMenuDestructiveItemClassName)}
-              onClick={onRequestDelete}
-              disabled={!actions.canDelete || actions.isDeleting}
-              data-testid="automations-card-delete"
-            >
-              <Trash2 aria-hidden />
-              Delete
-            </DropdownMenuItem>
-          </PermissionTooltip>
-        </DropdownMenuContent>
+        <AutomationMenuItems actions={actions} onRequestDelete={onRequestDelete} testIdPrefix="automations-card" />
       </DropdownMenu>
     </div>
+  );
+}
+
+function AutomationMenuItems({
+  actions,
+  onRequestDelete,
+  testIdPrefix,
+}: {
+  actions: AutomationCardActions;
+  onRequestDelete: () => void;
+  testIdPrefix: string;
+}) {
+  return (
+    <DropdownMenuContent align="end" sideOffset={6} className={overflowMenuContentClassName}>
+      <PermissionTooltip allowed={actions.canEdit} message="You don't have permission to edit this automation.">
+        <DropdownMenuItem
+          className={overflowMenuItemClassName}
+          onClick={actions.onEdit}
+          disabled={!actions.canEdit}
+          data-testid={`${testIdPrefix}-edit`}
+        >
+          <Pencil aria-hidden />
+          Edit
+        </DropdownMenuItem>
+      </PermissionTooltip>
+      <PermissionTooltip
+        allowed={actions.canDuplicate}
+        message="You don't have permission to duplicate this automation."
+      >
+        <DropdownMenuItem
+          className={overflowMenuItemClassName}
+          onClick={() => {
+            void actions.onDuplicate();
+          }}
+          disabled={!actions.canDuplicate || actions.isDuplicating}
+          data-testid={`${testIdPrefix}-duplicate`}
+        >
+          <Copy aria-hidden />
+          Duplicate
+        </DropdownMenuItem>
+      </PermissionTooltip>
+      <DropdownMenuSeparator />
+      <PermissionTooltip allowed={actions.canDelete} message="You don't have permission to delete this automation.">
+        <DropdownMenuItem
+          className={cn(overflowMenuItemClassName, overflowMenuDestructiveItemClassName)}
+          onClick={onRequestDelete}
+          disabled={!actions.canDelete || actions.isDeleting}
+          data-testid={`${testIdPrefix}-delete`}
+        >
+          <Trash2 aria-hidden />
+          Delete
+        </DropdownMenuItem>
+      </PermissionTooltip>
+    </DropdownMenuContent>
   );
 }
 
@@ -431,9 +496,9 @@ export function EmptyAutomationsState({ canCreate, onCreate }: { canCreate: bool
       <p className="mt-1 max-w-md text-[13px] text-muted-foreground">
         Automations listen for triggers and run canvases that power line phases.
       </p>
-      <Button type="button" className="mt-6" disabled={!canCreate} onClick={onCreate}>
-        <Plus className="h-3.5 w-3.5" aria-hidden />
-        Add automation
+      <Button type="button" size="sm" className="mt-6" disabled={!canCreate} onClick={onCreate}>
+        <Plus className="size-3.5" aria-hidden />
+        New automation
       </Button>
     </div>
   );

--- a/web_src/src/pages/factories/pages/automationsPageRedirect.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageRedirect.tsx
@@ -1,12 +1,7 @@
-import { Heading } from "@/components/Heading/heading";
-import { cn } from "@/lib/utils";
 import { Navigate } from "react-router";
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import { automationsPath, factoryLineDetailPath } from "../lib/factoryPagePaths";
-import {
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageTitleClassName,
-} from "./factoryPageLayoutStyles";
+import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
 
 type AutomationsLegacyRedirectProps = {
   organizationId: string;
@@ -25,13 +20,7 @@ export function AutomationsLegacyRedirect({
   if (!factoryLoaded) {
     return (
       <>
-        <header className={factoryContentHeaderClassName}>
-          <div>
-            <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-              Automations
-            </Heading>
-          </div>
-        </header>
+        <WorkspacePageHeader title="Automations" />
         <div className={factoryContentBodyClassName}>
           <p className="text-[13px] text-muted-foreground">Loading…</p>
         </div>

--- a/web_src/src/pages/factories/pages/factoryPageLayoutStyles.ts
+++ b/web_src/src/pages/factories/pages/factoryPageLayoutStyles.ts
@@ -2,10 +2,15 @@ import { cn } from "@/lib/utils";
 
 const contentColumn = "mx-auto w-full max-w-[var(--workspace-content-max-width)]";
 
+/**
+ * Shell for the workspace page header: gutter, max width, vertical rhythm.
+ * `WorkspacePageHeader` builds on this. Only reach for the class directly
+ * when you cannot use the component (very rare — most pages should not).
+ */
 export const factoryContentHeaderClassName = cn(
-  "bg-background px-[var(--workspace-page-gutter)] py-6",
+  "bg-background px-[var(--workspace-page-gutter)] pt-10 pb-6",
   contentColumn,
-  "flex flex-wrap items-center justify-between gap-3",
+  "flex flex-col gap-3",
 );
 
 /** The app shell owns vertical scrolling. */

--- a/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersLoadedView.tsx
+++ b/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersLoadedView.tsx
@@ -10,7 +10,7 @@ import {
   applyWorkOrderSearch,
   buildWorkOrderListEntries,
 } from "../../lib/workOrderListModel";
-import { factoryContentBodyClassName, factoryContentHeaderClassName } from "../factoryPageLayoutStyles";
+import { factoryContentBodyClassName } from "../factoryPageLayoutStyles";
 import {
   WorkOrdersFilteredEmptyState,
   WorkOrdersScopedEmptyState,
@@ -107,16 +107,14 @@ export function MissionsWorkOrdersLoadedView(props: MissionsWorkOrdersLoadedView
 
   return (
     <>
-      <header className={factoryContentHeaderClassName}>
-        <WorkOrdersHeader
-          state={state}
-          entries={entries}
-          factoryLines={props.factoryLines}
-          createHref={createHref}
-          canCreate={props.canCreate}
-          permissionsLoading={props.permissionsLoading}
-        />
-      </header>
+      <WorkOrdersHeader
+        state={state}
+        entries={entries}
+        factoryLines={props.factoryLines}
+        createHref={createHref}
+        canCreate={props.canCreate}
+        permissionsLoading={props.permissionsLoading}
+      />
 
       <div className={cn(factoryContentBodyClassName, "flex flex-col gap-4")}>
         {totalCount > 0 ? (

--- a/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersPage.tsx
+++ b/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersPage.tsx
@@ -1,16 +1,12 @@
-import { Heading } from "@/components/Heading/heading";
 import { usePermissions } from "@/contexts/usePermissions";
 import { useDispatchWorkOrder, useFactoryWorkOrders, useUpdateWorkOrderAssignees } from "@/hooks/useFactoryData";
 import { useMe } from "@/hooks/useMe";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
+import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
 import { WorkOrdersErrorState, WorkOrdersLoadingState } from "../../workOrders/WorkOrdersEmptyStates";
-import {
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageTitleClassName,
-} from "../factoryPageLayoutStyles";
+import { factoryContentBodyClassName } from "../factoryPageLayoutStyles";
 import { useWorkOrderListState } from "../../lib/useWorkOrderListState";
 import { MissionsWorkOrdersLoadedView } from "./MissionsWorkOrdersLoadedView";
 
@@ -58,11 +54,7 @@ export function MissionsWorkOrdersPage() {
   if (workOrdersError) {
     return (
       <>
-        <header className={factoryContentHeaderClassName}>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            Work Orders
-          </Heading>
-        </header>
+        <WorkspacePageHeader title="Work Orders" />
         <div className={cn(factoryContentBodyClassName, "flex flex-col gap-4")}>
           <WorkOrdersErrorState onRetry={() => void refetch()} />
         </div>
@@ -73,11 +65,7 @@ export function MissionsWorkOrdersPage() {
   if (isOrdersLoading || !factory) {
     return (
       <>
-        <header className={factoryContentHeaderClassName}>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            Work Orders
-          </Heading>
-        </header>
+        <WorkspacePageHeader title="Work Orders" />
         <div className={cn(factoryContentBodyClassName, "flex flex-col gap-4")}>
           <WorkOrdersLoadingState />
         </div>

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
@@ -1,5 +1,5 @@
-import { Heading } from "@/components/Heading/heading";
 import { PermissionTooltip } from "@/components/PermissionGate";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -14,17 +14,11 @@ import { Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { FactoryDeleteDialog } from "../../FactoryDeleteDialog";
+import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
 import { factoryListPath, factorySettingsGeneralPathAfterKeyChange } from "../../lib/factoryPagePaths";
 import { clearLastVisitedFactory } from "../../lib/lastVisitedFactory";
-import {
-  factoryCardClassName,
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageSubtitleClassName,
-  factoryPageTitleClassName,
-} from "../factoryPageLayoutStyles";
+import { factoryCardClassName, factoryContentBodyClassName } from "../factoryPageLayoutStyles";
 import { useFactorySettingsLayout } from "./factorySettingsLayoutContext";
-import { cn } from "@/lib/utils";
 import {
   WORKSPACE_KEY_MAX_LENGTH,
   WORKSPACE_KEY_MIN_LENGTH,
@@ -111,16 +105,10 @@ export function FactorySettingsGeneralPage() {
 
   return (
     <>
-      <header className={factoryContentHeaderClassName}>
-        <div>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            General
-          </Heading>
-          <p className={cn("mt-1", factoryPageSubtitleClassName)}>
-            General workspace preferences. Content for this page comes next.
-          </p>
-        </div>
-      </header>
+      <WorkspacePageHeader
+        title="General"
+        subtitle="General workspace preferences. Content for this page comes next."
+      />
 
       <div className={factoryContentBodyClassName}>
         <div className="max-w-2xl space-y-6">

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsSoonPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsSoonPage.tsx
@@ -1,12 +1,6 @@
-import { Heading } from "@/components/Heading/heading";
-import { cn } from "@/lib/utils";
 import type { LucideIcon } from "lucide-react";
-import {
-  factoryContentBodyClassName,
-  factoryContentHeaderClassName,
-  factoryPageSubtitleClassName,
-  factoryPageTitleClassName,
-} from "../factoryPageLayoutStyles";
+import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
+import { factoryContentBodyClassName } from "../factoryPageLayoutStyles";
 
 interface FactorySettingsSoonPageProps {
   title: string;
@@ -17,14 +11,7 @@ interface FactorySettingsSoonPageProps {
 export function FactorySettingsSoonPage({ title, description, Icon }: FactorySettingsSoonPageProps) {
   return (
     <>
-      <header className={factoryContentHeaderClassName}>
-        <div>
-          <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-            {title}
-          </Heading>
-          <p className={cn("mt-1", factoryPageSubtitleClassName)}>{description}</p>
-        </div>
-      </header>
+      <WorkspacePageHeader title={title} subtitle={description} />
       <div className={factoryContentBodyClassName}>
         <div
           className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-8 py-16 text-center"

--- a/web_src/src/pages/factories/pages/wiki/WikiWireframe.tsx
+++ b/web_src/src/pages/factories/pages/wiki/WikiWireframe.tsx
@@ -1,14 +1,13 @@
-import { Heading } from "@/components/Heading/heading";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { ChevronRight, FileText, Folder } from "lucide-react";
+import { ChevronRight, FileText, Folder, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import { factoryPageSubtitleClassName, factoryPageTitleClassName } from "../factoryPageLayoutStyles";
+import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
 import { buildWikiTree, wikiFolderPaths, type WikiDocument, type WikiTreeNode } from "./wikiMocks";
 
 export type WikiWireframeProps = {
@@ -211,19 +210,18 @@ function WikiDocumentPane({
 
 function WikiWireframeHeader({ refreshing, onRefresh }: { refreshing: boolean; onRefresh: () => void }) {
   return (
-    <header className="flex shrink-0 items-end justify-between gap-4 border-b border-border bg-background px-8 py-6">
-      <div className="min-w-0">
-        <Heading level={1} className={cn("!text-[22px]", factoryPageTitleClassName)}>
-          Wiki
-        </Heading>
-        <p className={cn("mt-1", factoryPageSubtitleClassName)}>
-          Shared product context — intent, architecture, and delivery notes for people and Planner.
-        </p>
-      </div>
-      <Button type="button" variant="outline" size="sm" className="shrink-0" disabled={refreshing} onClick={onRefresh}>
-        {refreshing ? "Refreshing…" : "Refresh knowledge"}
-      </Button>
-    </header>
+    <div className="shrink-0">
+      <WorkspacePageHeader
+        title="Wiki"
+        subtitle="Shared product context — intent, architecture, and delivery notes for people and Planner."
+        actions={
+          <Button type="button" variant="outline" size="sm" disabled={refreshing} onClick={onRefresh}>
+            <RefreshCw className="size-3.5" aria-hidden />
+            {refreshing ? "Refreshing…" : "Refresh knowledge"}
+          </Button>
+        }
+      />
+    </div>
   );
 }
 

--- a/web_src/src/pages/factories/workOrders/WorkOrdersEmptyStates.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersEmptyStates.tsx
@@ -51,7 +51,7 @@ export function WorkOrdersTrueEmptyState({ createHref, canCreate, permissionsLoa
         allowed={canCreate || permissionsLoading}
         message="You don't have permission to create work orders."
       >
-        <Button type="button" asChild disabled={!canCreate} data-testid="work-orders-empty-create">
+        <Button type="button" size="sm" asChild disabled={!canCreate} data-testid="work-orders-empty-create">
           <Link href={canCreate ? createHref : "#"}>
             <Icon name="plus" />
             New work order

--- a/web_src/src/pages/factories/workOrders/WorkOrdersLoadedView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersLoadedView.tsx
@@ -10,7 +10,7 @@ import {
   buildWorkOrderListEntries,
 } from "../lib/workOrderListModel";
 import type { WorkOrderListState } from "../lib/useWorkOrderListState";
-import { factoryContentBodyClassName, factoryContentHeaderClassName } from "../pages/factoryPageLayoutStyles";
+import { factoryContentBodyClassName } from "../pages/factoryPageLayoutStyles";
 import { WorkOrdersBoardView } from "./WorkOrdersBoardView";
 import {
   WorkOrdersFilteredEmptyState,
@@ -105,16 +105,14 @@ export function WorkOrdersLoadedView(props: WorkOrdersLoadedViewProps) {
 
   return (
     <>
-      <header className={factoryContentHeaderClassName}>
-        <WorkOrdersHeader
-          state={state}
-          entries={entries}
-          factoryLines={props.factoryLines}
-          createHref={createHref}
-          canCreate={props.canCreate}
-          permissionsLoading={props.permissionsLoading}
-        />
-      </header>
+      <WorkOrdersHeader
+        state={state}
+        entries={entries}
+        factoryLines={props.factoryLines}
+        createHref={createHref}
+        canCreate={props.canCreate}
+        permissionsLoading={props.permissionsLoading}
+      />
 
       <div className={cn(factoryContentBodyClassName, "flex flex-col gap-4")}>{body()}</div>
     </>

--- a/web_src/src/pages/factories/workOrders/header/FilterChips.tsx
+++ b/web_src/src/pages/factories/workOrders/header/FilterChips.tsx
@@ -17,7 +17,7 @@ export function FilterChips({ state, lineOptions, assigneeOptions }: FilterChips
   const chips = buildWorkOrderFilterChips(state.filters, { lines: lineOptions, assignees: assigneeOptions });
 
   return (
-    <div className="mt-3 flex flex-wrap items-center gap-1.5" data-testid="work-orders-filter-chips">
+    <div className="flex flex-wrap items-center gap-1.5" data-testid="work-orders-filter-chips">
       {chips.map((chip) => (
         <span
           key={`${chip.dimension}:${chip.value}`}

--- a/web_src/src/pages/factories/workOrders/header/WorkOrdersHeader.tsx
+++ b/web_src/src/pages/factories/workOrders/header/WorkOrdersHeader.tsx
@@ -76,7 +76,11 @@ export function WorkOrdersHeader({
           </PermissionTooltip>
         </>
       }
-      belowRow={<FilterChips state={state} lineOptions={lineOptions} assigneeOptions={assigneeOptions} />}
+      belowRow={
+        state.filterCount > 0 ? (
+          <FilterChips state={state} lineOptions={lineOptions} assigneeOptions={assigneeOptions} />
+        ) : undefined
+      }
     />
   );
 }

--- a/web_src/src/pages/factories/workOrders/header/WorkOrdersHeader.tsx
+++ b/web_src/src/pages/factories/workOrders/header/WorkOrdersHeader.tsx
@@ -3,6 +3,7 @@ import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
+import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
 import type { WorkOrderListState } from "../../lib/useWorkOrderListState";
 import { useWorkOrdersHeaderShortcuts } from "../../lib/useWorkOrdersHeaderShortcuts";
 import { buildAssigneeFilterOptions, buildLineFilterOptions } from "../../lib/workOrderFilterOptions";
@@ -24,10 +25,11 @@ interface WorkOrdersHeaderProps {
 }
 
 /**
- * Title bar for the Work Orders page. Everything lives on one row: the page
- * title and scope pills on the left, and the Filter menu, collapsible
- * search, Display menu, and New button on the right. Layout and ordering sit
- * inside Display rather than on the bar so the row stays quiet.
+ * Title bar for the Work Orders page. Uses the shared workspace page header,
+ * with scope pills next to the title and the Filter menu, collapsible
+ * search, Display menu, and New button in the trailing actions slot. Layout
+ * and ordering sit inside Display rather than on the bar so the row stays
+ * quiet.
  *
  * The Filter menu and the chip row read from one shared set of options, so
  * both always show the same labels.
@@ -45,14 +47,12 @@ export function WorkOrdersHeader({
   const assigneeOptions = buildAssigneeFilterOptions(entries);
 
   return (
-    <div className="flex w-full flex-col" data-testid="work-orders-header">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex min-w-0 flex-wrap items-center gap-3">
-          <h1 className="text-[22px] font-semibold tracking-[-0.02em] text-foreground">Work Orders</h1>
-          <ScopePills value={state.scope} onChange={state.setScope} />
-        </div>
-
-        <div className="flex items-center gap-1">
+    <WorkspacePageHeader
+      data-testid="work-orders-header"
+      title="Work Orders"
+      leading={<ScopePills value={state.scope} onChange={state.setScope} />}
+      actions={
+        <>
           <FilterMenu state={state} lineOptions={lineOptions} assigneeOptions={assigneeOptions} />
           <SearchField
             inputRef={searchRef}
@@ -67,24 +67,16 @@ export function WorkOrdersHeader({
             allowed={canCreate || permissionsLoading}
             message="You don't have permission to create work orders."
           >
-            <Button
-              type="button"
-              size="sm"
-              asChild
-              disabled={!canCreate}
-              className="h-8 shrink-0 gap-1.5 px-2.5"
-              data-testid="work-order-list-create-button"
-            >
+            <Button type="button" size="sm" asChild disabled={!canCreate} data-testid="work-order-list-create-button">
               <Link href={canCreate ? createHref : "#"}>
                 <Plus className="size-3.5" aria-hidden />
-                New
+                New work order
               </Link>
             </Button>
           </PermissionTooltip>
-        </div>
-      </div>
-
-      <FilterChips state={state} lineOptions={lineOptions} assigneeOptions={assigneeOptions} />
-    </div>
+        </>
+      }
+      belowRow={<FilterChips state={state} lineOptions={lineOptions} assigneeOptions={assigneeOptions} />}
+    />
   );
 }


### PR DESCRIPTION
## Summary

Each workspace page had its own header. Titles used different sizes, spacings, and typography. Detail pages put the back link in the body instead of the header. Work order detail did not show the `SP-42` identifier. This made the product feel inconsistent and hurt navigation.

This change adds one shared `WorkspacePageHeader` component with two variants and moves every workspace page onto it:

- **Section variant** — Overview, Work Orders list, Lines list, Automations list, Wiki, Velocity, Settings, Coming Soon. Title, optional subtitle, optional leading slot for scope pills, trailing actions, and an optional row below for filter chips.
- **Entity variant** — work order, line, and automation detail. Back link and optional identifier kicker above the entity title, with trailing actions in the header.

Other changes that come with the migration:
- Work order detail now shows the `SP-42` kicker above the title. The sticky header and negative-margin hack are gone.
- Line and automation detail move their back link out of the body and into the header. The duplicate emphasized automation card is removed; status and description move to the subtitle.
- Velocity moves its 7d / 30d toggle from the body into the header.
- Work Orders list drops the extra `h-8` on toolbar triggers and uses the standard `sm` size.
- Create, secondary, and icon buttons follow one style: filled `sm` with `Plus` for create (`New work order`, `New line`, `New automation`), outline `sm` for secondary (`Refresh knowledge`, line `Edit`), and ghost `icon-xs` for Copy and overflow.