### PR TITLE
feat: Add factory configure auto-layout

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -2505,73 +2505,67 @@ export function AppPage({
     async (newNodeData: NewNodeData): Promise<string> => {
       if (!canvas || !organizationId || !canvasId) return "";
 
-      const latestWorkflow = getCurrentWorkflowSnapshot();
-      if (!latestWorkflow) return "";
-
-      // Save snapshot before making changes
-
       const { buildingBlock, configuration, position, sourceConnection, integrationRef } = newNodeData;
 
       // Filter configuration to only include visible fields
       const filteredConfiguration = filterVisibleConfiguration(configuration, buildingBlock.configuration || []);
-
-      // Get existing node names for unique name generation
-      const existingNodeNames = (latestWorkflow.spec?.nodes || []).map((n) => n.name || "").filter(Boolean);
-
-      // Generate unique node name based on component name + ordinal
       const nameBase = newNodeData.nodeName || buildingBlock.name || "node";
-      const uniqueNodeName = generateUniqueNodeName(nameBase, existingNodeNames);
+      let newNodeId = "";
 
-      // Generate a unique node ID
-      const newNodeId = generateNodeId(buildingBlock.name || "node", uniqueNodeName);
+      await commitTopologyMutation((workflow) => {
+        const existingNodeNames = (workflow.spec?.nodes || []).map((node) => node.name || "").filter(Boolean);
+        const uniqueNodeName = generateUniqueNodeName(nameBase, existingNodeNames);
+        newNodeId = generateNodeId(buildingBlock.name || "node", uniqueNodeName);
 
-      // Create the new node
-      const newNode: ComponentsNode = {
-        id: newNodeId,
-        name: uniqueNodeName,
-        type:
-          buildingBlock.type === "trigger"
-            ? "TYPE_TRIGGER"
-            : buildingBlock.name === "annotation"
-              ? "TYPE_WIDGET"
-              : "TYPE_ACTION",
-        configuration: filteredConfiguration,
-        integration: integrationRef,
-        position: position
-          ? {
-              x: Math.round(position.x),
-              y: Math.round(position.y),
-            }
-          : {
-              x: (latestWorkflow?.spec?.nodes?.length || 0) * 250,
-              y: 100,
-            },
-      };
+        const newNode: ComponentsNode = {
+          id: newNodeId,
+          name: uniqueNodeName,
+          type:
+            buildingBlock.type === "trigger"
+              ? "TYPE_TRIGGER"
+              : buildingBlock.name === "annotation"
+                ? "TYPE_WIDGET"
+                : "TYPE_ACTION",
+          configuration: filteredConfiguration,
+          integration: integrationRef,
+          position: position
+            ? {
+                x: Math.round(position.x),
+                y: Math.round(position.y),
+              }
+            : {
+                x: (workflow.spec?.nodes?.length || 0) * 250,
+                y: 100,
+              },
+        };
 
-      // Add type-specific component reference
-      if (buildingBlock.name === "annotation") {
-        // Annotation nodes are now widgets
-        newNode.component = "annotation";
-        newNode.configuration = { text: "", color: "yellow" };
-      } else if (buildingBlock.type === "component") {
-        newNode.component = buildingBlock.name;
-      } else if (buildingBlock.type === "trigger") {
-        newNode.component = buildingBlock.name;
-      }
+        if (buildingBlock.name === "annotation") {
+          newNode.component = "annotation";
+          newNode.configuration = { text: "", color: "yellow" };
+        } else if (buildingBlock.type === "component" || buildingBlock.type === "trigger") {
+          newNode.component = buildingBlock.name;
+        }
 
-      // Track node addition
-      const { nodeType, integration, nodeRef } = getNodeAnalyticsProps(newNode, availableIntegrations);
-      analytics.nodeAdd(nodeType, integration, nodeRef, organizationId);
+        const { nodeType, integration, nodeRef } = getNodeAnalyticsProps(newNode, availableIntegrations);
+        analytics.nodeAdd(nodeType, integration, nodeRef, organizationId);
 
-      const newEdges: ComponentsEdge[] = sourceConnection
-        ? [{ sourceId: sourceConnection.nodeId, targetId: newNodeId, channel: sourceConnection.handleId || "default" }]
-        : [];
-      await commitTopologyMutation((workflow) => appendWorkflowFragment(workflow, [newNode], newEdges), {
-        addedNodeId: newNodeId,
+        const newEdges: ComponentsEdge[] = sourceConnection
+          ? [
+              {
+                sourceId: sourceConnection.nodeId,
+                targetId: newNodeId,
+                channel: sourceConnection.handleId || "default",
+              },
+            ]
+          : [];
+        return {
+          workflow: appendWorkflowFragment(workflow, [newNode], newEdges),
+          options: { addedNodeId: newNodeId },
+        };
       });
       return newNodeId;
     },
-    [canvas, organizationId, canvasId, getCurrentWorkflowSnapshot, availableIntegrations, commitTopologyMutation],
+    [canvas, organizationId, canvasId, availableIntegrations, commitTopologyMutation],
   );
 
   const handlePlaceholderAdd = useCallback(
@@ -2758,14 +2752,14 @@ export function AppPage({
     async (nodeIds: string[]) => {
       if (!canvas || !organizationId || !canvasId) return;
 
-      const specNodes = canvas.spec?.nodes || [];
-      const { newNodes, nodeIdMap } = buildDuplicatedNodes(specNodes, nodeIds);
-      if (newNodes.length === 0) return;
+      await commitTopologyMutation((workflow) => {
+        const { newNodes, nodeIdMap } = buildDuplicatedNodes(workflow.spec?.nodes || [], nodeIds);
+        if (newNodes.length === 0) return workflow;
 
-      const duplicatedNodeIds = new Set(nodeIds);
-      const newEdges = buildDuplicatedEdges(canvas.spec?.edges || [], duplicatedNodeIds, nodeIdMap);
-
-      await commitTopologyMutation((workflow) => appendWorkflowFragment(workflow, newNodes, newEdges));
+        const duplicatedNodeIds = new Set(nodeIds);
+        const newEdges = buildDuplicatedEdges(workflow.spec?.edges || [], duplicatedNodeIds, nodeIdMap);
+        return appendWorkflowFragment(workflow, newNodes, newEdges);
+      });
     },
     [canvas, organizationId, canvasId, commitTopologyMutation],
   );
@@ -2904,44 +2898,37 @@ export function AppPage({
     async (nodeId: string) => {
       if (!canvas || !organizationId || !canvasId) return;
 
-      const nodeToDuplicate = canvas.spec?.nodes?.find((node) => node.id === nodeId);
-      if (!nodeToDuplicate) return;
+      await commitTopologyMutation((workflow) => {
+        const nodeToDuplicate = workflow.spec?.nodes?.find((node) => node.id === nodeId);
+        if (!nodeToDuplicate) return workflow;
 
-      const existingNodeNames = (canvas.spec?.nodes || []).map((n) => n.name || "").filter(Boolean);
-
-      let baseName = nodeToDuplicate.name?.trim() || "";
-      if (!baseName) {
-        if (nodeToDuplicate.type === "TYPE_TRIGGER" && nodeToDuplicate.component) {
-          baseName = nodeToDuplicate.component;
-        } else if (nodeToDuplicate.type === "TYPE_ACTION" && nodeToDuplicate.component) {
-          baseName = nodeToDuplicate.component;
-        } else {
-          baseName = "node";
+        const existingNodeNames = (workflow.spec?.nodes || []).map((node) => node.name || "").filter(Boolean);
+        let baseName = nodeToDuplicate.name?.trim() || "";
+        if (!baseName) {
+          baseName =
+            (nodeToDuplicate.type === "TYPE_TRIGGER" || nodeToDuplicate.type === "TYPE_ACTION") &&
+            nodeToDuplicate.component
+              ? nodeToDuplicate.component
+              : "node";
         }
-      }
 
-      // Generate unique node name based on the existing node name + ordinal
-      const uniqueNodeName = generateUniqueNodeName(baseName, existingNodeNames);
+        const uniqueNodeName = generateUniqueNodeName(baseName, existingNodeNames);
+        const newNodeId = generateNodeId(baseName, uniqueNodeName);
+        const duplicateNode: ComponentsNode = {
+          ...nodeToDuplicate,
+          id: newNodeId,
+          name: uniqueNodeName,
+          position: {
+            x: (nodeToDuplicate.position?.x || 0) + 50,
+            y: (nodeToDuplicate.position?.y || 0) + 50,
+          },
+          isCollapsed: false,
+        };
 
-      const newNodeId = generateNodeId(baseName, uniqueNodeName);
-
-      const offsetX = 50;
-      const offsetY = 50;
-
-      const duplicateNode: ComponentsNode = {
-        ...nodeToDuplicate,
-        id: newNodeId,
-        name: uniqueNodeName,
-        position: {
-          x: (nodeToDuplicate.position?.x || 0) + offsetX,
-          y: (nodeToDuplicate.position?.y || 0) + offsetY,
-        },
-        // Reset collapsed state for the duplicate
-        isCollapsed: false,
-      };
-
-      await commitTopologyMutation((workflow) => appendWorkflowFragment(workflow, [duplicateNode]), {
-        addedNodeId: newNodeId,
+        return {
+          workflow: appendWorkflowFragment(workflow, [duplicateNode]),
+          options: { addedNodeId: newNodeId },
+        };
       });
     },
     [canvas, organizationId, canvasId, commitTopologyMutation],

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -2754,7 +2754,7 @@ export function AppPage({
 
       await commitTopologyMutation((workflow) => {
         const { newNodes, nodeIdMap } = buildDuplicatedNodes(workflow.spec?.nodes || [], nodeIds);
-        if (newNodes.length === 0) return workflow;
+        if (newNodes.length === 0) return { workflow, changed: false };
 
         const duplicatedNodeIds = new Set(nodeIds);
         const newEdges = buildDuplicatedEdges(workflow.spec?.edges || [], duplicatedNodeIds, nodeIdMap);
@@ -2900,7 +2900,7 @@ export function AppPage({
 
       await commitTopologyMutation((workflow) => {
         const nodeToDuplicate = workflow.spec?.nodes?.find((node) => node.id === nodeId);
-        if (!nodeToDuplicate) return workflow;
+        if (!nodeToDuplicate) return { workflow, changed: false };
 
         const existingNodeNames = (workflow.spec?.nodes || []).map((node) => node.name || "").filter(Boolean);
         let baseName = nodeToDuplicate.name?.trim() || "";

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -66,12 +66,19 @@ import { DefaultLayoutEngine } from "@/lib/layout";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import { getActiveNoteId, restoreActiveNoteFocus } from "@/ui/annotationComponent/noteFocus";
 import { buildBuildingBlockCategories } from "@/ui/buildingBlocks";
-import type { CanvasNode, NewNodeData, NodeEditData } from "@/ui/CanvasPage";
+import type { BuildingBlock } from "@/ui/BuildingBlocksSidebar";
+import type { CanvasNode, CanvasPageProps, NewNodeData, NodeEditData } from "@/ui/CanvasPage";
 import { CANVAS_SIDEBAR_STORAGE_KEY, CanvasPage, type MissingIntegration } from "@/ui/CanvasPage";
 import { CanvasPageLoadingOverlay } from "@/ui/CanvasPage/CanvasPageLoadingOverlay";
 import { resolveFitViewVersionId } from "@/ui/CanvasPage/fitView";
 import { useAppPageAgentSuggestions } from "./useAppPageAgentSuggestions";
 import { useAutoLayoutOnUpdatePreference } from "./useAutoLayoutOnUpdatePreference";
+import {
+  appendWorkflowFragment,
+  removeWorkflowEdges,
+  removeWorkflowNodes,
+  useTopologyMutationCommit,
+} from "./useTopologyMutationCommit";
 import type { EventState, EventStateMap } from "@/ui/componentBase";
 import type { TabData } from "@/ui/componentSidebar/SidebarEventItem/SidebarEventItem";
 import type { SidebarEvent } from "@/ui/componentSidebar/types";
@@ -119,6 +126,7 @@ import { useCanvasEchoReleaseGuards } from "./useCanvasEchoReleaseGuards";
 import { useCanvasLifecycleEventHandlers } from "./useCanvasLifecycleEventHandlers";
 import { useDraftStagingActions } from "./useDraftStagingActions";
 import { useFactoryConfigureSession, type FactoryConfigureActions } from "./useFactoryConfigureSession";
+import { useFactoryConfigureInitialLayout } from "./useFactoryConfigureInitialLayout";
 import { resolveFactoryEmbedCanvasChrome, resolveFactoryEmbedSidebars } from "./factoryEmbedCanvasChrome";
 import { executeCommitStaging } from "./lib/commit-staging-flow";
 import { buildDuplicatedEdges, buildDuplicatedNodes } from "./lib/duplicate-nodes";
@@ -228,6 +236,35 @@ function resolveFactoryAwareToggleView(
   }
   return handler;
 }
+
+function resolveFactoryAutoCanvasProps(
+  enabled: boolean,
+  readOnly: boolean,
+  callbacks: { [Key in keyof FactoryLayoutCanvasCallbacks]-?: NonNullable<CanvasPageProps[Key]> },
+): Pick<
+  CanvasPageProps,
+  | "layoutMode"
+  | "onAutoLayoutNodes"
+  | "onNodePositionChange"
+  | "onNodesPositionChange"
+  | "onPlaceholderAdd"
+  | "onPlaceholderConfigure"
+> {
+  if (readOnly) return { layoutMode: enabled ? "factory-auto" : "manual" };
+  if (enabled) {
+    return {
+      layoutMode: "factory-auto",
+      onPlaceholderAdd: callbacks.onPlaceholderAdd,
+      onPlaceholderConfigure: callbacks.onPlaceholderConfigure,
+    };
+  }
+  return { layoutMode: "manual", ...callbacks };
+}
+
+type FactoryLayoutCanvasCallbacks = Pick<
+  CanvasPageProps,
+  "onAutoLayoutNodes" | "onNodePositionChange" | "onNodesPositionChange" | "onPlaceholderAdd" | "onPlaceholderConfigure"
+>;
 
 export type { FactoryConfigureActions } from "./useFactoryConfigureSession";
 
@@ -348,6 +385,7 @@ export function AppPage({
     refetchOnMount: false,
   });
   const factoryOwnedApp = isFactoryApp(liveCanvas?.metadata?.factoryId);
+  const factoryAutoLayout = factoryConfigure && factoryOwnedApp;
   const urlViewFlags = useMemo(
     () => (factoryOwnedApp ? clampWorkflowViewFlagsForFactoryApp(rawUrlViewFlags) : rawUrlViewFlags),
     [factoryOwnedApp, rawUrlViewFlags],
@@ -1193,27 +1231,6 @@ export function AppPage({
     });
   }, []);
 
-  const applyAutoLayoutOnAddedNode = useCallback(
-    async (workflow: CanvasesCanvas, nodeID?: string): Promise<CanvasesCanvas> => {
-      if (!isAutoLayoutOnUpdateEnabled || !nodeID) {
-        return workflow;
-      }
-
-      const node = workflow.spec?.nodes?.find((candidate) => candidate.id === nodeID);
-      if (!node || node.type === "TYPE_WIDGET") {
-        return workflow;
-      }
-
-      return DefaultLayoutEngine.apply(workflow, {
-        scope: "connected-component",
-        nodeIds: [nodeID],
-        components,
-        direction: resolveCanvasFlowDirection(workflow.metadata?.factoryId),
-      });
-    },
-    [isAutoLayoutOnUpdateEnabled, components],
-  );
-
   /**
    * Ref to track pending position updates that need to be auto-saved.
    * Maps node ID to its updated position.
@@ -1484,6 +1501,7 @@ export function AppPage({
     allComponents,
     canvasId,
     queryClient,
+    includeRemovedNodeGhosts: !factoryOwnedApp,
   });
 
   const nodesWithIntegrationStatus = useMemo(
@@ -1927,6 +1945,28 @@ export function AppPage({
       setLastSavedWorkflowSnapshot,
     ],
   );
+
+  const commitTopologyMutation = useTopologyMutationCommit({
+    factoryAutoLayout,
+    autoLayoutOnUpdate: isAutoLayoutOnUpdateEnabled,
+    components,
+    getCurrentWorkflow: getCurrentWorkflowSnapshot,
+    applyLocalWorkflow: applyLocalWorkflowUpdate,
+    saveWorkflow: handleSaveWorkflow,
+    saveSessionRef: canvasSaveSessionRef,
+    readOnly: isReadOnly,
+  });
+  const applyInitialFactoryLayout = useCallback(
+    () => commitTopologyMutation((workflow) => workflow),
+    [commitTopologyMutation],
+  );
+  useFactoryConfigureInitialLayout({
+    factoryAutoLayout,
+    isEditing,
+    editBootstrapReady: isEditBootstrapReady,
+    activeCanvasVersionId,
+    applyLayout: applyInitialFactoryLayout,
+  });
 
   const getNodeEditData = useCallback(
     (nodeId: string): NodeEditData | null => {
@@ -2523,52 +2563,15 @@ export function AppPage({
       const { nodeType, integration, nodeRef } = getNodeAnalyticsProps(newNode, availableIntegrations);
       analytics.nodeAdd(nodeType, integration, nodeRef, organizationId);
 
-      // Add the new node to the workflow
-      const updatedNodes = [...(latestWorkflow.spec?.nodes || []), newNode];
-
-      // If there's a source connection, create the edge
-      let updatedEdges = latestWorkflow.spec?.edges || [];
-      if (sourceConnection) {
-        const newEdge: ComponentsEdge = {
-          sourceId: sourceConnection.nodeId,
-          targetId: newNodeId,
-          channel: sourceConnection.handleId || "default",
-        };
-        updatedEdges = [...updatedEdges, newEdge];
-      }
-
-      const updatedWorkflow = {
-        ...latestWorkflow,
-        spec: {
-          ...latestWorkflow.spec,
-          nodes: updatedNodes,
-          edges: updatedEdges,
-        },
-      };
-
-      const finalWorkflow = await applyAutoLayoutOnAddedNode(updatedWorkflow, newNodeId);
-
-      // Update local cache
-      applyLocalWorkflowUpdate(finalWorkflow);
-
-      if (!isReadOnly) {
-        await handleSaveWorkflow(finalWorkflow, { showToast: false });
-      }
-
-      // Return the new node ID
+      const newEdges: ComponentsEdge[] = sourceConnection
+        ? [{ sourceId: sourceConnection.nodeId, targetId: newNodeId, channel: sourceConnection.handleId || "default" }]
+        : [];
+      await commitTopologyMutation((workflow) => appendWorkflowFragment(workflow, [newNode], newEdges), {
+        addedNodeId: newNodeId,
+      });
       return newNodeId;
     },
-    [
-      canvas,
-      organizationId,
-      canvasId,
-      getCurrentWorkflowSnapshot,
-      handleSaveWorkflow,
-      applyAutoLayoutOnAddedNode,
-      isReadOnly,
-      applyLocalWorkflowUpdate,
-      availableIntegrations,
-    ],
+    [canvas, organizationId, canvasId, getCurrentWorkflowSnapshot, availableIntegrations, commitTopologyMutation],
   );
 
   const handlePlaceholderAdd = useCallback(
@@ -2608,51 +2611,27 @@ export function AppPage({
             } as ComponentsEdge)
           : null;
 
-      const updatedWorkflow = {
-        ...latestWorkflow,
-        spec: {
-          ...latestWorkflow.spec,
-          nodes: [...(latestWorkflow.spec?.nodes || []), newNode],
-          edges: newEdge ? [...(latestWorkflow.spec?.edges || []), newEdge] : [...(latestWorkflow.spec?.edges || [])],
+      await commitTopologyMutation(
+        (workflow) => appendWorkflowFragment(workflow, [newNode], newEdge ? [newEdge] : []),
+        {
+          addedNodeId: newNodeId,
         },
-      };
-
-      const finalWorkflow = await applyAutoLayoutOnAddedNode(updatedWorkflow, newNodeId);
-
-      applyLocalWorkflowUpdate(finalWorkflow);
-
-      if (!isReadOnly) {
-        await handleSaveWorkflow(finalWorkflow, { showToast: false });
-      }
+      );
 
       return newNodeId;
     },
-    [
-      canvas,
-      organizationId,
-      canvasId,
-      getCurrentWorkflowSnapshot,
-      handleSaveWorkflow,
-      applyAutoLayoutOnAddedNode,
-      isReadOnly,
-      applyLocalWorkflowUpdate,
-    ],
+    [canvas, organizationId, canvasId, getCurrentWorkflowSnapshot, commitTopologyMutation],
   );
 
   const handlePlaceholderConfigure = useCallback(
     async (data: {
       placeholderId: string;
-      buildingBlock: any;
+      buildingBlock: BuildingBlock;
       nodeName: string;
-      configuration: Record<string, any>;
-      appName?: string;
+      configuration: Record<string, unknown>;
+      integrationName?: string;
     }): Promise<void> => {
       if (!canvas || !organizationId || !canvasId) {
-        return;
-      }
-
-      const nodeIndex = canvas.spec?.nodes?.findIndex((n) => n.id === data.placeholderId);
-      if (nodeIndex === undefined || nodeIndex === -1) {
         return;
       }
 
@@ -2660,76 +2639,46 @@ export function AppPage({
         data.configuration,
         data.buildingBlock.configuration || [],
       );
+      await commitTopologyMutation((workflow) => {
+        const nodes = workflow.spec?.nodes || [];
+        const nodeIndex = nodes.findIndex((node) => node.id === data.placeholderId);
+        if (nodeIndex === -1) {
+          return workflow;
+        }
 
-      // Get existing node names for unique name generation (exclude the placeholder being configured)
-      const existingNodeNames = (canvas.spec?.nodes || [])
-        .filter((n) => n.id !== data.placeholderId)
-        .map((n) => n.name || "")
-        .filter(Boolean);
+        const existingNodeNames = nodes
+          .filter((node) => node.id !== data.placeholderId)
+          .map((node) => node.name || "")
+          .filter(Boolean);
+        const uniqueNodeName = generateUniqueNodeName(data.buildingBlock.name || "node", existingNodeNames);
+        const updatedNode: ComponentsNode = {
+          ...nodes[nodeIndex],
+          name: uniqueNodeName,
+          type: data.buildingBlock.type === "trigger" ? "TYPE_TRIGGER" : "TYPE_ACTION",
+          component: data.buildingBlock.name,
+          configuration: filteredConfiguration,
+        };
+        const updatedNodes = [...nodes];
+        updatedNodes[nodeIndex] = updatedNode;
 
-      // Generate unique node name based on component name + ordinal
-      const uniqueNodeName = generateUniqueNodeName(data.buildingBlock.name || "node", existingNodeNames);
-
-      // Update placeholder with real component data
-      const updatedNode: ComponentsNode = {
-        ...canvas.spec!.nodes![nodeIndex],
-        name: uniqueNodeName,
-        type: data.buildingBlock.type === "trigger" ? "TYPE_TRIGGER" : "TYPE_ACTION",
-        configuration: filteredConfiguration,
-      };
-
-      // Add the component reference that was missing
-      if (data.buildingBlock.type === "component") {
-        updatedNode.component = data.buildingBlock.name;
-      } else if (data.buildingBlock.type === "trigger") {
-        updatedNode.component = data.buildingBlock.name;
-      }
-
-      const updatedNodes = [...(canvas.spec?.nodes || [])];
-      updatedNodes[nodeIndex] = updatedNode;
-
-      // Update outgoing edges from this node to use valid channels
-      // Find edges where this node is the source
-      const outgoingEdges = canvas.spec?.edges?.filter((edge) => edge.sourceId === data.placeholderId) || [];
-
-      let updatedEdges = [...(canvas.spec?.edges || [])];
-
-      if (outgoingEdges.length > 0) {
-        // Get the valid output channels for the new component
-        const validChannels = data.buildingBlock.outputChannels?.map((ch: any) => ch.name).filter(Boolean) || [
-          "default",
-        ];
-
-        // Update each outgoing edge to use a valid channel
-        updatedEdges = updatedEdges.map((edge) => {
-          if (edge.sourceId === data.placeholderId) {
-            // If the current channel is not valid for the new component, use the first valid channel
-            const newChannel = validChannels.includes(edge.channel) ? edge.channel : validChannels[0];
-            return {
-              ...edge,
-              channel: newChannel,
-            };
+        const declaredChannels = (data.buildingBlock.outputChannels || [])
+          .map((channel) => channel.name)
+          .filter((channel): channel is string => Boolean(channel));
+        const validChannels = declaredChannels.length > 0 ? declaredChannels : ["default"];
+        const updatedEdges = (workflow.spec?.edges || []).map((edge) => {
+          if (edge.sourceId !== data.placeholderId || validChannels.includes(edge.channel || "default")) {
+            return edge;
           }
-          return edge;
+          return { ...edge, channel: validChannels[0] };
         });
-      }
 
-      const updatedWorkflow = {
-        ...canvas,
-        spec: {
-          ...canvas.spec,
-          nodes: updatedNodes,
-          edges: updatedEdges,
-        },
-      };
-
-      applyLocalWorkflowUpdate(updatedWorkflow);
-
-      if (!isReadOnly) {
-        await handleSaveWorkflow(updatedWorkflow, { showToast: false });
-      }
+        return {
+          ...workflow,
+          spec: { ...workflow.spec, nodes: updatedNodes, edges: updatedEdges },
+        };
+      });
     },
-    [canvas, organizationId, canvasId, handleSaveWorkflow, isReadOnly, applyLocalWorkflowUpdate],
+    [canvas, organizationId, canvasId, commitTopologyMutation],
   );
 
   const handleEdgeCreate = useCallback(
@@ -2746,26 +2695,9 @@ export function AppPage({
       };
 
       analytics.edgeCreate(organizationId);
-
-      // Add the new edge to the workflow
-      const updatedEdges = [...(canvas.spec?.edges || []), newEdge];
-
-      const updatedWorkflow = {
-        ...canvas,
-        spec: {
-          ...canvas.spec,
-          edges: updatedEdges,
-        },
-      };
-
-      // Update local cache
-      applyLocalWorkflowUpdate(updatedWorkflow);
-
-      if (!isReadOnly) {
-        await handleSaveWorkflow(updatedWorkflow, { showToast: false });
-      }
+      await commitTopologyMutation((workflow) => appendWorkflowFragment(workflow, [], [newEdge]));
     },
-    [canvas, organizationId, canvasId, handleSaveWorkflow, isReadOnly, applyLocalWorkflowUpdate],
+    [canvas, organizationId, canvasId, commitTopologyMutation],
   );
   const handleNodeDelete = useCallback(
     async (nodeId: string) => {
@@ -2779,32 +2711,10 @@ export function AppPage({
         const { nodeType, integration, nodeRef } = getNodeAnalyticsProps(nodeBeingDeleted, availableIntegrations);
         analytics.nodeRemove(nodeType, integration, nodeRef, organizationId);
       }
-      const updatedNodes = specNodes.filter((node) => node.id !== nodeId);
-      const survivingNodeIds = new Set(updatedNodes.map((node) => node.id).filter(Boolean));
 
-      const updatedEdges = canvas.spec?.edges?.filter(
-        (edge) =>
-          (!edge.sourceId || survivingNodeIds.has(edge.sourceId)) &&
-          (!edge.targetId || survivingNodeIds.has(edge.targetId)),
-      );
-
-      const updatedWorkflow = {
-        ...canvas,
-        spec: {
-          ...canvas.spec,
-          nodes: updatedNodes,
-          edges: updatedEdges,
-        },
-      };
-
-      // Update local cache
-      applyLocalWorkflowUpdate(updatedWorkflow);
-
-      if (!isReadOnly) {
-        await handleSaveWorkflow(updatedWorkflow, { showToast: false });
-      }
+      await commitTopologyMutation((workflow) => removeWorkflowNodes(workflow, new Set([nodeId])));
     },
-    [canvas, organizationId, canvasId, handleSaveWorkflow, isReadOnly, applyLocalWorkflowUpdate, availableIntegrations],
+    [canvas, organizationId, canvasId, availableIntegrations, commitTopologyMutation],
   );
   const handleNodesDelete = useCallback(
     async (nodeIds: string[]) => {
@@ -2818,30 +2728,9 @@ export function AppPage({
           const { nodeType, integration, nodeRef } = getNodeAnalyticsProps(node, availableIntegrations);
           analytics.nodeRemove(nodeType, integration, nodeRef, organizationId);
         });
-      const updatedNodes = specNodes.filter((node) => !node.id || !nodeIdSet.has(node.id));
-      const survivingNodeIds = new Set(updatedNodes.map((node) => node.id).filter(Boolean));
-      const updatedEdges = canvas.spec?.edges?.filter(
-        (edge) =>
-          (!edge.sourceId || survivingNodeIds.has(edge.sourceId)) &&
-          (!edge.targetId || survivingNodeIds.has(edge.targetId)),
-      );
-
-      const updatedWorkflow = {
-        ...canvas,
-        spec: {
-          ...canvas.spec,
-          nodes: updatedNodes,
-          edges: updatedEdges,
-        },
-      };
-
-      applyLocalWorkflowUpdate(updatedWorkflow);
-
-      if (!isReadOnly) {
-        await handleSaveWorkflow(updatedWorkflow, { showToast: false });
-      }
+      await commitTopologyMutation((workflow) => removeWorkflowNodes(workflow, nodeIdSet));
     },
-    [canvas, organizationId, canvasId, handleSaveWorkflow, isReadOnly, applyLocalWorkflowUpdate, availableIntegrations],
+    [canvas, organizationId, canvasId, availableIntegrations, commitTopologyMutation],
   );
   const handleAutoLayoutNodes = useCallback(
     async (nodeIds: string[]) => {
@@ -2876,22 +2765,9 @@ export function AppPage({
       const duplicatedNodeIds = new Set(nodeIds);
       const newEdges = buildDuplicatedEdges(canvas.spec?.edges || [], duplicatedNodeIds, nodeIdMap);
 
-      const updatedWorkflow = {
-        ...canvas,
-        spec: {
-          ...canvas.spec,
-          nodes: [...(canvas.spec?.nodes || []), ...newNodes],
-          edges: [...(canvas.spec?.edges || []), ...newEdges],
-        },
-      };
-
-      applyLocalWorkflowUpdate(updatedWorkflow);
-
-      if (!isReadOnly) {
-        await handleSaveWorkflow(updatedWorkflow, { showToast: false });
-      }
+      await commitTopologyMutation((workflow) => appendWorkflowFragment(workflow, newNodes, newEdges));
     },
-    [canvas, organizationId, canvasId, handleSaveWorkflow, isReadOnly, applyLocalWorkflowUpdate],
+    [canvas, organizationId, canvasId, commitTopologyMutation],
   );
 
   const handleEdgeDelete = useCallback(
@@ -2913,33 +2789,9 @@ export function AppPage({
       });
 
       analytics.edgeRemove(organizationId);
-
-      // Remove the edges from the workflow
-      const updatedEdges = canvas.spec?.edges?.filter((edge) => {
-        return !edgesToRemove.some(
-          (toRemove) =>
-            edge.sourceId === toRemove.sourceId &&
-            edge.targetId === toRemove.targetId &&
-            edge.channel === toRemove.channel,
-        );
-      });
-
-      const updatedWorkflow = {
-        ...canvas,
-        spec: {
-          ...canvas.spec,
-          edges: updatedEdges,
-        },
-      };
-
-      // Update local cache
-      applyLocalWorkflowUpdate(updatedWorkflow);
-
-      if (!isReadOnly) {
-        await handleSaveWorkflow(updatedWorkflow, { showToast: false });
-      }
+      await commitTopologyMutation((workflow) => removeWorkflowEdges(workflow, edgesToRemove));
     },
-    [canvas, organizationId, canvasId, handleSaveWorkflow, isReadOnly, applyLocalWorkflowUpdate],
+    [canvas, organizationId, canvasId, commitTopologyMutation],
   );
 
   /**
@@ -3088,34 +2940,11 @@ export function AppPage({
         isCollapsed: false,
       };
 
-      // Add the duplicate node to the workflow
-      const updatedNodes = [...(canvas.spec?.nodes || []), duplicateNode];
-
-      const updatedWorkflow = {
-        ...canvas,
-        spec: {
-          ...canvas.spec,
-          nodes: updatedNodes,
-        },
-      };
-
-      const finalWorkflow = await applyAutoLayoutOnAddedNode(updatedWorkflow, newNodeId);
-
-      // Update local cache
-      applyLocalWorkflowUpdate(finalWorkflow);
-      if (!isReadOnly) {
-        await handleSaveWorkflow(finalWorkflow, { showToast: false });
-      }
+      await commitTopologyMutation((workflow) => appendWorkflowFragment(workflow, [duplicateNode]), {
+        addedNodeId: newNodeId,
+      });
     },
-    [
-      canvas,
-      organizationId,
-      canvasId,
-      handleSaveWorkflow,
-      applyAutoLayoutOnAddedNode,
-      isReadOnly,
-      applyLocalWorkflowUpdate,
-    ],
+    [canvas, organizationId, canvasId, commitTopologyMutation],
   );
 
   const cancelPendingCanvasSaves = useCallback(() => {
@@ -3953,6 +3782,13 @@ export function AppPage({
     loadMoreLiveVersionsDisabled: !hasMoreLiveVersions || isLoadingMoreLiveVersions,
     loadMoreLiveVersionsPending: isLoadingMoreLiveVersions,
   });
+  const factoryLayoutCanvasProps = resolveFactoryAutoCanvasProps(factoryAutoLayout, isReadOnly, {
+    onAutoLayoutNodes: handleAutoLayoutNodes,
+    onNodePositionChange: handleNodePositionChange,
+    onNodesPositionChange: handleNodesPositionChange,
+    onPlaceholderAdd: handlePlaceholderAdd,
+    onPlaceholderConfigure: handlePlaceholderConfigure,
+  });
 
   return (
     <>
@@ -4035,6 +3871,7 @@ export function AppPage({
           onSeeCurrentVersion={handleSeeCurrentVersion}
           nodes={nodes}
           edges={renderedEdges}
+          {...factoryLayoutCanvasProps}
           organizationId={organizationId}
           canvasId={canvasId}
           getSidebarData={getSidebarData}
@@ -4050,12 +3887,9 @@ export function AppPage({
           onNodeDelete={!isReadOnly ? handleNodeDelete : undefined}
           onNodesDelete={!isReadOnly ? handleNodesDelete : undefined}
           onDuplicateNodes={!isReadOnly ? handleNodesDuplicate : undefined}
-          onAutoLayoutNodes={!isReadOnly ? handleAutoLayoutNodes : undefined}
           onEdgeDelete={!isReadOnly ? handleEdgeDelete : undefined}
           isAutoLayoutOnUpdateEnabled={isAutoLayoutOnUpdateEnabled && !isReadOnly}
           onToggleAutoLayoutOnUpdate={!isReadOnly ? handleToggleAutoLayoutOnUpdate : undefined}
-          onNodePositionChange={!isReadOnly ? handleNodePositionChange : undefined}
-          onNodesPositionChange={!isReadOnly ? handleNodesPositionChange : undefined}
           onToggleView={resolveFactoryAwareToggleView(isReadOnly, factoryOwnedApp, handleNodeCollapseChange)}
           onDuplicate={!isReadOnly ? handleNodeDuplicate : undefined}
           buildingBlocks={buildingBlocks}
@@ -4065,8 +3899,6 @@ export function AppPage({
           onAgentStagingReady={handleAgentStagingReady}
           onAgentStagingCommit={whenAllowed(canUpdateCanvas, handleAgentSidebarStagingCommit)}
           onNodeAdd={!isReadOnly ? handleNodeAdd : undefined}
-          onPlaceholderAdd={!isReadOnly ? handlePlaceholderAdd : undefined}
-          onPlaceholderConfigure={!isReadOnly ? handlePlaceholderConfigure : undefined}
           integrations={canReadIntegrations ? integrations : []}
           canReadIntegrations={canReadIntegrations}
           canCreateIntegrations={canAct("integrations", "create")}

--- a/web_src/src/pages/app/useDraftVisualDiff.spec.tsx
+++ b/web_src/src/pages/app/useDraftVisualDiff.spec.tsx
@@ -1,0 +1,46 @@
+import { QueryClient } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useDraftVisualDiff } from "./useDraftVisualDiff";
+
+describe("useDraftVisualDiff", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("does not add removed-node ghosts when the context disables them", () => {
+    const { result } = renderHook(() =>
+      useDraftVisualDiff({
+        isViewingDraftVersion: true,
+        canvas: { metadata: { id: "canvas-1" }, spec: { nodes: [], edges: [] } },
+        liveCanvasVersion: {
+          metadata: { id: "version-live" },
+          spec: {
+            nodes: [
+              {
+                id: "removed-node",
+                name: "Removed node",
+                type: "TYPE_ACTION",
+                component: "noop",
+                position: { x: 100, y: 100 },
+              },
+            ],
+            edges: [],
+          },
+        },
+        preparedNodes: [],
+        preparedEdges: [],
+        allTriggers: [],
+        allComponents: [],
+        canvasId: "canvas-1",
+        queryClient: new QueryClient(),
+        includeRemovedNodeGhosts: false,
+      }),
+    );
+
+    expect(result.current.nodes).toEqual([]);
+    expect(result.current.diffCounts.removed).toBe(1);
+    expect(result.current.diffToggles.showDeletedNodesControl).toBe(false);
+  });
+});

--- a/web_src/src/pages/app/useDraftVisualDiff.ts
+++ b/web_src/src/pages/app/useDraftVisualDiff.ts
@@ -24,6 +24,7 @@ type UseDraftVisualDiffArgs = {
   allComponents: ActionsAction[];
   canvasId?: string;
   queryClient: QueryClient;
+  includeRemovedNodeGhosts?: boolean;
 };
 
 const edgeKey = (source: string, target: string, channel: string) => `${source}->${target}::${channel}`;
@@ -125,6 +126,7 @@ export function useDraftVisualDiff({
   allComponents,
   canvasId,
   queryClient,
+  includeRemovedNodeGhosts = true,
 }: UseDraftVisualDiffArgs) {
   const { visualDiffEnabled: enabled, toggleVisualDiff } = useVisualDiffToggle();
   const { showDeletedNodes, toggleShowDeletedNodes, showEdgeDiff, toggleShowEdgeDiff } = useDiffSubToggles();
@@ -146,6 +148,7 @@ export function useDraftVisualDiff({
     if (
       !enabled ||
       !showDeletedNodes ||
+      !includeRemovedNodeGhosts ||
       !draftDiffResult?.removedNodes.length ||
       !liveCanvasVersion?.spec?.nodes ||
       !canvasId
@@ -190,6 +193,7 @@ export function useDraftVisualDiff({
     draftDiffResult?.removedNodes,
     draftDiffResult?.statusMap,
     enabled,
+    includeRemovedNodeGhosts,
     liveCanvasVersion?.spec,
     preparedNodes,
     queryClient,
@@ -229,7 +233,13 @@ export function useDraftVisualDiff({
     diffCounts,
     visualDiffEnabled: enabled,
     toggleVisualDiff,
-    diffToggles: { showDeletedNodes, toggleShowDeletedNodes, showEdgeDiff, toggleShowEdgeDiff },
+    diffToggles: {
+      showDeletedNodes,
+      showDeletedNodesControl: includeRemovedNodeGhosts,
+      toggleShowDeletedNodes,
+      showEdgeDiff,
+      toggleShowEdgeDiff,
+    },
   };
 }
 

--- a/web_src/src/pages/app/useFactoryConfigureInitialLayout.spec.tsx
+++ b/web_src/src/pages/app/useFactoryConfigureInitialLayout.spec.tsx
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useFactoryConfigureInitialLayout } from "./useFactoryConfigureInitialLayout";
+
+describe("useFactoryConfigureInitialLayout", () => {
+  it("applies layout once when Factory Configure becomes ready", async () => {
+    const applyLayout = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderHook(
+      (props: { factoryAutoLayout: boolean; isEditing: boolean; editBootstrapReady: boolean }) =>
+        useFactoryConfigureInitialLayout({
+          ...props,
+          activeCanvasVersionId: "version-live",
+          applyLayout,
+        }),
+      {
+        initialProps: { factoryAutoLayout: true, isEditing: false, editBootstrapReady: false },
+      },
+    );
+
+    expect(applyLayout).not.toHaveBeenCalled();
+
+    await act(async () => {
+      rerender({ factoryAutoLayout: true, isEditing: true, editBootstrapReady: true });
+    });
+    expect(applyLayout).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender({ factoryAutoLayout: true, isEditing: true, editBootstrapReady: true });
+    });
+    expect(applyLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies layout again on a new Configure visit", async () => {
+    const applyLayout = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderHook(
+      ({ factoryAutoLayout }: { factoryAutoLayout: boolean }) =>
+        useFactoryConfigureInitialLayout({
+          factoryAutoLayout,
+          isEditing: true,
+          editBootstrapReady: true,
+          activeCanvasVersionId: "version-live",
+          applyLayout,
+        }),
+      { initialProps: { factoryAutoLayout: true } },
+    );
+
+    expect(applyLayout).toHaveBeenCalledTimes(1);
+
+    await act(async () => rerender({ factoryAutoLayout: false }));
+    await act(async () => rerender({ factoryAutoLayout: true }));
+
+    expect(applyLayout).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web_src/src/pages/app/useFactoryConfigureInitialLayout.ts
+++ b/web_src/src/pages/app/useFactoryConfigureInitialLayout.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+
+type UseFactoryConfigureInitialLayoutOptions = {
+  factoryAutoLayout: boolean;
+  isEditing: boolean;
+  editBootstrapReady: boolean;
+  activeCanvasVersionId: string;
+  applyLayout: () => Promise<unknown>;
+};
+
+/** Apply the mandatory layout once after each Factory Configure session becomes ready. */
+export function useFactoryConfigureInitialLayout({
+  factoryAutoLayout,
+  isEditing,
+  editBootstrapReady,
+  activeCanvasVersionId,
+  applyLayout,
+}: UseFactoryConfigureInitialLayoutOptions) {
+  const layoutAppliedRef = useRef(false);
+  const applyLayoutRef = useRef(applyLayout);
+  applyLayoutRef.current = applyLayout;
+
+  useEffect(() => {
+    if (factoryAutoLayout) {
+      return;
+    }
+    layoutAppliedRef.current = false;
+  }, [factoryAutoLayout]);
+
+  useEffect(() => {
+    if (!factoryAutoLayout || !isEditing || !editBootstrapReady || !activeCanvasVersionId) {
+      return;
+    }
+    if (layoutAppliedRef.current) {
+      return;
+    }
+
+    layoutAppliedRef.current = true;
+    void applyLayoutRef.current();
+  }, [activeCanvasVersionId, editBootstrapReady, factoryAutoLayout, isEditing]);
+}

--- a/web_src/src/pages/app/useTopologyMutationCommit.spec.tsx
+++ b/web_src/src/pages/app/useTopologyMutationCommit.spec.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { CanvasesCanvas, SuperplaneComponentsNode } from "@/api-client";
 import { DefaultLayoutEngine } from "@/lib/layout";
+import { generateUniqueNodeName } from "./utils";
 import { appendWorkflowFragment, useTopologyMutationCommit } from "./useTopologyMutationCommit";
 
 function workflowWith(nodes: SuperplaneComponentsNode[] = []): CanvasesCanvas {
@@ -35,14 +36,31 @@ describe("useTopologyMutationCommit", () => {
         readOnly: false,
       }),
     );
-    const firstNode: SuperplaneComponentsNode = { id: "first", type: "TYPE_ACTION", component: "filter" };
-    const secondNode: SuperplaneComponentsNode = { id: "second", type: "TYPE_ACTION", component: "filter" };
+    const addNamedNode = (id: string) => (workflow: CanvasesCanvas) => {
+      const names = (workflow.spec?.nodes || []).map((node) => node.name || "").filter(Boolean);
+      const node: SuperplaneComponentsNode = {
+        id,
+        name: generateUniqueNodeName("filter", names),
+        type: "TYPE_ACTION",
+        component: "filter",
+      };
+      return {
+        workflow: appendWorkflowFragment(workflow, [node]),
+        options: { addedNodeId: id },
+      };
+    };
+    const firstNode: SuperplaneComponentsNode = {
+      id: "first",
+      name: "filter",
+      type: "TYPE_ACTION",
+      component: "filter",
+    };
 
     let firstCommit: Promise<CanvasesCanvas | null>;
     let secondCommit: Promise<CanvasesCanvas | null>;
     act(() => {
-      firstCommit = result.current((workflow) => appendWorkflowFragment(workflow, [firstNode]));
-      secondCommit = result.current((workflow) => appendWorkflowFragment(workflow, [secondNode]));
+      firstCommit = result.current(addNamedNode("first"));
+      secondCommit = result.current(addNamedNode("second"));
     });
 
     await act(async () => Promise.resolve());
@@ -53,6 +71,7 @@ describe("useTopologyMutationCommit", () => {
     });
 
     expect(currentWorkflow.spec?.nodes?.map((node) => node.id)).toEqual(["first", "second"]);
+    expect(currentWorkflow.spec?.nodes?.map((node) => node.name)).toEqual(["filter", "filter 2"]);
     expect(saveWorkflow).toHaveBeenCalledTimes(2);
     layoutSpy.mockRestore();
   });

--- a/web_src/src/pages/app/useTopologyMutationCommit.spec.tsx
+++ b/web_src/src/pages/app/useTopologyMutationCommit.spec.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CanvasesCanvas, SuperplaneComponentsNode } from "@/api-client";
+import { DefaultLayoutEngine } from "@/lib/layout";
+import { appendWorkflowFragment, useTopologyMutationCommit } from "./useTopologyMutationCommit";
+
+function workflowWith(nodes: SuperplaneComponentsNode[] = []): CanvasesCanvas {
+  return { metadata: { factoryId: "factory" }, spec: { nodes, edges: [] } };
+}
+
+describe("useTopologyMutationCommit", () => {
+  it("serializes factory mutations against the latest laid-out workflow", async () => {
+    let releaseFirstLayout: ((workflow: CanvasesCanvas) => void) | undefined;
+    const firstLayout = new Promise<CanvasesCanvas>((resolve) => {
+      releaseFirstLayout = resolve;
+    });
+    const layoutSpy = vi
+      .spyOn(DefaultLayoutEngine, "apply")
+      .mockImplementationOnce(() => firstLayout)
+      .mockImplementation(async (workflow) => workflow);
+    let currentWorkflow = workflowWith();
+    const saveWorkflow = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useTopologyMutationCommit({
+        factoryAutoLayout: true,
+        autoLayoutOnUpdate: false,
+        components: [],
+        getCurrentWorkflow: () => currentWorkflow,
+        applyLocalWorkflow: (workflow) => {
+          currentWorkflow = workflow;
+        },
+        saveWorkflow,
+        saveSessionRef: { current: 0 },
+        readOnly: false,
+      }),
+    );
+    const firstNode: SuperplaneComponentsNode = { id: "first", type: "TYPE_ACTION", component: "filter" };
+    const secondNode: SuperplaneComponentsNode = { id: "second", type: "TYPE_ACTION", component: "filter" };
+
+    let firstCommit: Promise<CanvasesCanvas | null>;
+    let secondCommit: Promise<CanvasesCanvas | null>;
+    act(() => {
+      firstCommit = result.current((workflow) => appendWorkflowFragment(workflow, [firstNode]));
+      secondCommit = result.current((workflow) => appendWorkflowFragment(workflow, [secondNode]));
+    });
+
+    await act(async () => Promise.resolve());
+    expect(layoutSpy).toHaveBeenCalledTimes(1);
+    releaseFirstLayout?.(workflowWith([firstNode]));
+    await act(async () => {
+      await Promise.all([firstCommit, secondCommit]);
+    });
+
+    expect(currentWorkflow.spec?.nodes?.map((node) => node.id)).toEqual(["first", "second"]);
+    expect(saveWorkflow).toHaveBeenCalledTimes(2);
+    layoutSpy.mockRestore();
+  });
+
+  it("drops queued layout results after the edit session changes", async () => {
+    let releaseLayout: ((workflow: CanvasesCanvas) => void) | undefined;
+    const layoutResult = new Promise<CanvasesCanvas>((resolve) => {
+      releaseLayout = resolve;
+    });
+    const layoutSpy = vi.spyOn(DefaultLayoutEngine, "apply").mockImplementationOnce(() => layoutResult);
+    const applyLocalWorkflow = vi.fn();
+    const saveWorkflow = vi.fn(async () => undefined);
+    const saveSessionRef = { current: 0 };
+    const { result } = renderHook(() =>
+      useTopologyMutationCommit({
+        factoryAutoLayout: true,
+        autoLayoutOnUpdate: false,
+        components: [],
+        getCurrentWorkflow: () => workflowWith(),
+        applyLocalWorkflow,
+        saveWorkflow,
+        saveSessionRef,
+        readOnly: false,
+      }),
+    );
+
+    const commit = result.current((workflow) => appendWorkflowFragment(workflow, []));
+    await act(async () => Promise.resolve());
+    saveSessionRef.current += 1;
+    releaseLayout?.(workflowWith());
+    await act(async () => {
+      await commit;
+    });
+
+    expect(applyLocalWorkflow).not.toHaveBeenCalled();
+    expect(saveWorkflow).not.toHaveBeenCalled();
+    layoutSpy.mockRestore();
+  });
+});

--- a/web_src/src/pages/app/useTopologyMutationCommit.spec.tsx
+++ b/web_src/src/pages/app/useTopologyMutationCommit.spec.tsx
@@ -110,4 +110,34 @@ describe("useTopologyMutationCommit", () => {
     expect(saveWorkflow).not.toHaveBeenCalled();
     layoutSpy.mockRestore();
   });
+
+  it("does not layout or save a mutation with no changes", async () => {
+    const layoutSpy = vi.spyOn(DefaultLayoutEngine, "apply");
+    const currentWorkflow = workflowWith();
+    const applyLocalWorkflow = vi.fn();
+    const saveWorkflow = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useTopologyMutationCommit({
+        factoryAutoLayout: true,
+        autoLayoutOnUpdate: false,
+        components: [],
+        getCurrentWorkflow: () => currentWorkflow,
+        applyLocalWorkflow,
+        saveWorkflow,
+        saveSessionRef: { current: 0 },
+        readOnly: false,
+      }),
+    );
+
+    let committedWorkflow: CanvasesCanvas | null = null;
+    await act(async () => {
+      committedWorkflow = await result.current((workflow) => ({ workflow, changed: false }));
+    });
+
+    expect(committedWorkflow).toBe(currentWorkflow);
+    expect(layoutSpy).not.toHaveBeenCalled();
+    expect(applyLocalWorkflow).not.toHaveBeenCalled();
+    expect(saveWorkflow).not.toHaveBeenCalled();
+    layoutSpy.mockRestore();
+  });
 });

--- a/web_src/src/pages/app/useTopologyMutationCommit.ts
+++ b/web_src/src/pages/app/useTopologyMutationCommit.ts
@@ -4,7 +4,16 @@ import { DefaultLayoutEngine } from "@/lib/layout";
 import { useCallback, useRef, type MutableRefObject } from "react";
 
 type CommitOptions = { addedNodeId?: string };
+type TopologyMutationResult = {
+  workflow: CanvasesCanvas;
+  options?: CommitOptions;
+};
 type EdgeIdentity = Pick<ComponentsEdge, "sourceId" | "targetId" | "channel">;
+
+function resolveMutationResult(result: CanvasesCanvas | TopologyMutationResult): TopologyMutationResult {
+  if ("workflow" in result) return result;
+  return { workflow: result };
+}
 
 export function appendWorkflowFragment(
   workflow: CanvasesCanvas,
@@ -103,13 +112,14 @@ export function useTopologyMutationCommit({
   );
 
   return useCallback(
-    (mutate: (workflow: CanvasesCanvas) => CanvasesCanvas, options?: CommitOptions) => {
+    (mutate: (workflow: CanvasesCanvas) => CanvasesCanvas | TopologyMutationResult, options?: CommitOptions) => {
       const requestedSaveSession = saveSessionRef.current;
       const run = async () => {
         if (saveSessionRef.current !== requestedSaveSession) return null;
         const workflow = getCurrentWorkflow();
         if (!workflow) return null;
-        const finalWorkflow = await applyRequiredLayout(mutate(workflow), options);
+        const mutation = resolveMutationResult(mutate(workflow));
+        const finalWorkflow = await applyRequiredLayout(mutation.workflow, mutation.options ?? options);
         if (saveSessionRef.current !== requestedSaveSession) return null;
 
         applyLocalWorkflow(finalWorkflow);

--- a/web_src/src/pages/app/useTopologyMutationCommit.ts
+++ b/web_src/src/pages/app/useTopologyMutationCommit.ts
@@ -1,0 +1,138 @@
+import type { ActionsAction, CanvasesCanvas, ComponentsEdge, SuperplaneComponentsNode } from "@/api-client";
+import { resolveCanvasFlowDirection } from "@/lib/canvasFlowDirection";
+import { DefaultLayoutEngine } from "@/lib/layout";
+import { useCallback, useRef, type MutableRefObject } from "react";
+
+type CommitOptions = { addedNodeId?: string };
+type EdgeIdentity = Pick<ComponentsEdge, "sourceId" | "targetId" | "channel">;
+
+export function appendWorkflowFragment(
+  workflow: CanvasesCanvas,
+  nodes: SuperplaneComponentsNode[],
+  edges: ComponentsEdge[] = [],
+): CanvasesCanvas {
+  return {
+    ...workflow,
+    spec: {
+      ...workflow.spec,
+      nodes: [...(workflow.spec?.nodes || []), ...nodes],
+      edges: [...(workflow.spec?.edges || []), ...edges],
+    },
+  };
+}
+
+export function removeWorkflowNodes(workflow: CanvasesCanvas, removedNodeIds: Set<string>): CanvasesCanvas {
+  const nodes = (workflow.spec?.nodes || []).filter((node) => !node.id || !removedNodeIds.has(node.id));
+  const survivingIds = new Set(nodes.map((node) => node.id).filter(Boolean));
+  return {
+    ...workflow,
+    spec: {
+      ...workflow.spec,
+      nodes,
+      edges: (workflow.spec?.edges || []).filter(
+        (edge) =>
+          (!edge.sourceId || survivingIds.has(edge.sourceId)) && (!edge.targetId || survivingIds.has(edge.targetId)),
+      ),
+    },
+  };
+}
+
+export function removeWorkflowEdges(workflow: CanvasesCanvas, removedEdges: EdgeIdentity[]): CanvasesCanvas {
+  return {
+    ...workflow,
+    spec: {
+      ...workflow.spec,
+      edges: (workflow.spec?.edges || []).filter(
+        (edge) =>
+          !removedEdges.some(
+            (removed) =>
+              edge.sourceId === removed.sourceId &&
+              edge.targetId === removed.targetId &&
+              edge.channel === removed.channel,
+          ),
+      ),
+    },
+  };
+}
+
+export function useTopologyMutationCommit({
+  factoryAutoLayout,
+  autoLayoutOnUpdate,
+  components,
+  getCurrentWorkflow,
+  applyLocalWorkflow,
+  saveWorkflow,
+  saveSessionRef,
+  readOnly,
+}: {
+  factoryAutoLayout: boolean;
+  autoLayoutOnUpdate: boolean;
+  components: ActionsAction[];
+  getCurrentWorkflow: () => CanvasesCanvas | null | undefined;
+  applyLocalWorkflow: (workflow: CanvasesCanvas) => void;
+  saveWorkflow: (workflow: CanvasesCanvas, options: { showToast: false }) => Promise<unknown>;
+  saveSessionRef: MutableRefObject<number>;
+  readOnly: boolean;
+}) {
+  const queueRef = useRef<Promise<void>>(Promise.resolve());
+
+  const applyRequiredLayout = useCallback(
+    async (workflow: CanvasesCanvas, options?: CommitOptions) => {
+      if (factoryAutoLayout) {
+        return DefaultLayoutEngine.apply(workflow, {
+          scope: "full-canvas",
+          components,
+          direction: "vertical",
+        });
+      }
+      if (!autoLayoutOnUpdate || !options?.addedNodeId) {
+        return workflow;
+      }
+      const node = workflow.spec?.nodes?.find((candidate) => candidate.id === options.addedNodeId);
+      if (!node || node.type === "TYPE_WIDGET") {
+        return workflow;
+      }
+      return DefaultLayoutEngine.apply(workflow, {
+        scope: "connected-component",
+        nodeIds: [options.addedNodeId],
+        components,
+        direction: resolveCanvasFlowDirection(workflow.metadata?.factoryId),
+      });
+    },
+    [autoLayoutOnUpdate, components, factoryAutoLayout],
+  );
+
+  return useCallback(
+    (mutate: (workflow: CanvasesCanvas) => CanvasesCanvas, options?: CommitOptions) => {
+      const requestedSaveSession = saveSessionRef.current;
+      const run = async () => {
+        if (saveSessionRef.current !== requestedSaveSession) return null;
+        const workflow = getCurrentWorkflow();
+        if (!workflow) return null;
+        const finalWorkflow = await applyRequiredLayout(mutate(workflow), options);
+        if (saveSessionRef.current !== requestedSaveSession) return null;
+
+        applyLocalWorkflow(finalWorkflow);
+        if (!readOnly) await saveWorkflow(finalWorkflow, { showToast: false });
+        return finalWorkflow;
+      };
+
+      if (!factoryAutoLayout) return run();
+      const operation = queueRef.current.then(run, run);
+      queueRef.current = operation.then(
+        () => undefined,
+        () => undefined,
+      );
+      return operation;
+    },
+    [
+      applyLocalWorkflow,
+      applyRequiredLayout,
+      factoryAutoLayout,
+      getCurrentWorkflow,
+      readOnly,
+      saveSessionRef,
+      saveWorkflow,
+    ],
+  );
+}

--- a/web_src/src/pages/app/useTopologyMutationCommit.ts
+++ b/web_src/src/pages/app/useTopologyMutationCommit.ts
@@ -7,6 +7,7 @@ type CommitOptions = { addedNodeId?: string };
 type TopologyMutationResult = {
   workflow: CanvasesCanvas;
   options?: CommitOptions;
+  changed?: boolean;
 };
 type EdgeIdentity = Pick<ComponentsEdge, "sourceId" | "targetId" | "channel">;
 
@@ -119,6 +120,7 @@ export function useTopologyMutationCommit({
         const workflow = getCurrentWorkflow();
         if (!workflow) return null;
         const mutation = resolveMutationResult(mutate(workflow));
+        if (mutation.changed === false) return mutation.workflow;
         const finalWorkflow = await applyRequiredLayout(mutation.workflow, mutation.options ?? options);
         if (saveSessionRef.current !== requestedSaveSession) return null;
 

--- a/web_src/src/ui/CanvasPage/Block/appendHandle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block/appendHandle.spec.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AppendHandlePreview } from "./appendHandle";
+
+describe("AppendHandlePreview", () => {
+  it("matches factory node dimensions for vertical canvases", () => {
+    const { container } = render(<AppendHandlePreview orientation="vertical" style={{}} />);
+
+    const previewCard = container.querySelector<HTMLElement>(".sp-append-source-preview > div:last-child");
+
+    expect(previewCard?.style.width).toBe("280px");
+    expect(previewCard?.style.height).toBe("104px");
+    expect(previewCard?.style.borderRadius).toBe("16px");
+  });
+
+  it("keeps legacy dimensions for horizontal canvases", () => {
+    const { container } = render(<AppendHandlePreview style={{}} />);
+
+    const previewCard = container.querySelector<HTMLElement>(".sp-append-source-preview > div:last-child");
+
+    expect(previewCard?.style.width).toBe("23rem");
+    expect(previewCard?.style.height).toBe("96px");
+    expect(previewCard?.style.borderRadius).toBe("8px");
+  });
+});

--- a/web_src/src/ui/CanvasPage/Block/appendHandle.tsx
+++ b/web_src/src/ui/CanvasPage/Block/appendHandle.tsx
@@ -3,6 +3,7 @@ import { Plus } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
 import { CANVAS_CONNECTOR_COLOR } from "@/lib/canvasEdgeColors";
+import { FACTORY_NODE_CARD_HEIGHT, FACTORY_NODE_CARD_WIDTH } from "@/lib/factoryCanvasChrome";
 import { resolveHandleStyle } from "./handleStyle";
 import type { BlockProps } from "./types";
 
@@ -226,11 +227,12 @@ export function AppendHandlePreview({
             left: "50%",
             top: previewContainerTop + containerOffsetY,
             transform: "translateX(-50%)",
-            width: "23rem",
-            height: 96,
-            borderRadius: 8,
-            background: "white",
-            outline: "1px solid rgb(15 23 42 / 0.15)",
+            width: FACTORY_NODE_CARD_WIDTH,
+            height: FACTORY_NODE_CARD_HEIGHT,
+            borderRadius: 16,
+            background: "var(--card, #ffffff)",
+            outline: "1px solid rgb(15 23 42 / 0.08)",
+            boxShadow: "0 1px 3px rgb(15 23 42 / 0.06), 0 2px 6px rgb(15 23 42 / 0.04)",
             opacity: 0.6,
           }}
         />

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -32,6 +32,7 @@ export interface HeaderProps {
     diffCounts: { added: number; updated: number; removed: number };
     diffToggles: {
       showDeletedNodes: boolean;
+      showDeletedNodesControl?: boolean;
       toggleShowDeletedNodes: () => void;
       showEdgeDiff: boolean;
       toggleShowEdgeDiff: () => void;

--- a/web_src/src/ui/CanvasPage/components/DiffSummaryHoverCard.tsx
+++ b/web_src/src/ui/CanvasPage/components/DiffSummaryHoverCard.tsx
@@ -9,6 +9,7 @@ interface DiffSummaryHoverCardProps {
   onToggleVisualDiff?: () => void;
   diffToggles?: {
     showDeletedNodes: boolean;
+    showDeletedNodesControl?: boolean;
     toggleShowDeletedNodes: () => void;
     showEdgeDiff: boolean;
     toggleShowEdgeDiff: () => void;
@@ -66,16 +67,18 @@ export function DiffSummaryHoverCard({
           )}
           {diffToggles && visualDiffEnabled && (
             <>
-              <div className="flex items-center gap-1.5">
-                <Checkbox
-                  id="show-deleted-nodes"
-                  checked={diffToggles.showDeletedNodes}
-                  onCheckedChange={diffToggles.toggleShowDeletedNodes}
-                />
-                <label htmlFor="show-deleted-nodes" className={diffMenuLabelClassName}>
-                  Show deleted nodes
-                </label>
-              </div>
+              {diffToggles.showDeletedNodesControl !== false ? (
+                <div className="flex items-center gap-1.5">
+                  <Checkbox
+                    id="show-deleted-nodes"
+                    checked={diffToggles.showDeletedNodes}
+                    onCheckedChange={diffToggles.toggleShowDeletedNodes}
+                  />
+                  <label htmlFor="show-deleted-nodes" className={diffMenuLabelClassName}>
+                    Show deleted nodes
+                  </label>
+                </div>
+              ) : null}
               <div className="flex items-center gap-1.5">
                 <Checkbox
                   id="show-edge-diff"

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -20,6 +20,7 @@ const { captureException, fitViewMock, getNodesMock, reactFlowPropsRef } = vi.ho
       onEdgeMouseLeave?: (...args: unknown[]) => unknown;
       onInit?: (instance: { setViewport: (viewport: unknown) => void }) => void;
       onlyRenderVisibleElements?: boolean;
+      nodesDraggable?: boolean;
     },
   },
 }));
@@ -223,6 +224,68 @@ describe("CanvasPage connection drop", () => {
     expect(reactFlowPropsRef.current?.onlyRenderVisibleElements).not.toBe(true);
   });
 
+  it("locks nodes only in Factory auto-layout mode", () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Factory automation"
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing
+          activeCanvasVersionId="version-live"
+          layoutMode="factory-auto"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(reactFlowPropsRef.current?.nodesDraggable).toBe(false);
+
+    rerender(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing
+          activeCanvasVersionId="version-live"
+          layoutMode="manual"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(reactFlowPropsRef.current?.nodesDraggable).toBe(true);
+  });
+
+  it("hides the auto-layout preference in Factory auto-layout mode", () => {
+    const commonProps = {
+      title: "Factory automation",
+      nodes: [],
+      edges: [],
+      buildingBlocks: [],
+      isEditing: true,
+      activeCanvasVersionId: "version-live",
+      isAutoLayoutOnUpdateEnabled: true,
+      onToggleAutoLayoutOnUpdate: vi.fn(),
+    };
+    const { rerender } = render(
+      <MemoryRouter>
+        <CanvasPage {...commonProps} layoutMode="factory-auto" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { pressed: true })).not.toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <CanvasPage {...commonProps} layoutMode="manual" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("button", { pressed: true })).toBeInTheDocument();
+  });
+
   it("does not open the versions sidebar as the initial edit-session view", () => {
     render(
       <MemoryRouter>
@@ -284,7 +347,7 @@ describe("CanvasPage connection drop", () => {
     expect(screen.getByTestId("building-blocks-sidebar")).toBeInTheDocument();
   });
 
-  it("creates a placeholder when appending from an end-node connector", () => {
+  it("creates a placeholder when appending from an end-node connector", async () => {
     const onPlaceholderAdd = vi.fn(async () => "placeholder-node");
 
     render(
@@ -323,14 +386,14 @@ describe("CanvasPage connection drop", () => {
       data: {
         _callbacksRef?: {
           current?: {
-            onAppendFromNode?: (nodeId: string, sourceHandleId?: string | null) => void;
+            onAppendFromNode?: (nodeId: string, sourceHandleId?: string | null) => void | Promise<void>;
           };
         };
       };
     }>;
 
-    act(() => {
-      nodes[0].data._callbacksRef?.current?.onAppendFromNode?.("source-node", "default");
+    await act(async () => {
+      await nodes[0].data._callbacksRef?.current?.onAppendFromNode?.("source-node", "default");
     });
 
     expect(onPlaceholderAdd).toHaveBeenCalledWith({

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -112,6 +112,7 @@ import type { CanvasPageState } from "./useCanvasState";
 import { useCanvasState } from "./useCanvasState";
 import { applyCanvasViewportCulling, useCanvasViewportCulling } from "./useCanvasViewportCulling";
 import type { TriggerActionModal } from "@/pages/app/mappers/types";
+import { isFactoryAutoLayout, type CanvasLayoutMode } from "./layoutMode";
 
 export interface SidebarData {
   latestEvents: SidebarEvent[];
@@ -175,6 +176,7 @@ export interface NewNodeData {
 export interface CanvasPageProps {
   nodes: CanvasNode[];
   edges: CanvasEdge[];
+  layoutMode?: CanvasLayoutMode;
 
   startCollapsed?: boolean;
   /** Display name for the canvas header (center title). */
@@ -194,6 +196,7 @@ export interface CanvasPageProps {
     diffCounts: { added: number; updated: number; removed: number };
     diffToggles: {
       showDeletedNodes: boolean;
+      showDeletedNodesControl?: boolean;
       toggleShowDeletedNodes: () => void;
       showEdgeDiff: boolean;
       toggleShowEdgeDiff: () => void;
@@ -1524,6 +1527,7 @@ function CanvasPage(props: CanvasPageProps) {
                   state={state}
                   factoryId={props.factoryId}
                   factoryEmbed={props.factoryEmbed}
+                  layoutMode={props.layoutMode}
                   onNodeDelete={handleNodeDelete}
                   onNodesDelete={handleNodesDelete}
                   onDuplicateNodes={props.onDuplicateNodes}
@@ -1972,6 +1976,7 @@ function CanvasContentHeader({
     diffCounts: { added: number; updated: number; removed: number };
     diffToggles: {
       showDeletedNodes: boolean;
+      showDeletedNodesControl?: boolean;
       toggleShowDeletedNodes: () => void;
       showEdgeDiff: boolean;
       toggleShowEdgeDiff: () => void;
@@ -2156,6 +2161,7 @@ function CanvasContent({
   state,
   factoryId,
   factoryEmbed = false,
+  layoutMode,
   onNodeDelete,
   onNodesDelete,
   onDuplicateNodes,
@@ -2209,6 +2215,7 @@ function CanvasContent({
   state: CanvasPageState;
   factoryId?: string;
   factoryEmbed?: boolean;
+  layoutMode?: CanvasLayoutMode;
   onNodeDelete?: (nodeId: string) => void;
   onNodesDelete?: (nodeIds: string[]) => void;
   onDuplicateNodes?: (nodeIds: string[]) => void;
@@ -2266,6 +2273,7 @@ function CanvasContent({
   canCreateIntegrations?: boolean;
 }) {
   const { fitView, screenToFlowPosition, getViewport, getInternalNode, getNodes, setViewport } = useReactFlow();
+  const factoryAutoLayout = isFactoryAutoLayout(layoutMode);
   const { zoom } = useViewport();
   const { resolvedTheme } = useTheme();
   const flowColorMode = resolvedTheme === "dark" ? "dark" : "light";
@@ -3272,7 +3280,7 @@ function CanvasContent({
             snapToGrid={isSnapToGridEnabled}
             snapGrid={[SNAP_GRID_STEP_PX, SNAP_GRID_STEP_PX]}
             panOnScrollSpeed={0.8}
-            nodesDraggable={!isReadOnly}
+            nodesDraggable={!isReadOnly && !factoryAutoLayout}
             nodesConnectable={isConnectionEditingEnabled}
             elementsSelectable={true}
             onNodesChange={handleNodesChange}
@@ -3317,8 +3325,10 @@ function CanvasContent({
                   className="!static !m-0"
                   isSnapToGridEnabled={isEditMode ? isSnapToGridEnabled : undefined}
                   onSnapToGridToggle={isEditMode ? handleSnapToGridToggle : undefined}
-                  isAutoLayoutOnUpdateEnabled={isEditMode ? isAutoLayoutOnUpdateEnabled : undefined}
-                  onAutoLayoutOnUpdateToggle={isEditMode ? onToggleAutoLayoutOnUpdate : undefined}
+                  isAutoLayoutOnUpdateEnabled={
+                    isEditMode && !factoryAutoLayout ? isAutoLayoutOnUpdateEnabled : undefined
+                  }
+                  onAutoLayoutOnUpdateToggle={isEditMode && !factoryAutoLayout ? onToggleAutoLayoutOnUpdate : undefined}
                   autoLayoutOnUpdateDisabled={isReadOnly || autoLayoutOnUpdateDisabled}
                   autoLayoutOnUpdateDisabledTooltip={
                     isReadOnly ? "You don't have permission to edit this canvas." : autoLayoutOnUpdateDisabledTooltip

--- a/web_src/src/ui/CanvasPage/layoutMode.ts
+++ b/web_src/src/ui/CanvasPage/layoutMode.ts
@@ -1,0 +1,5 @@
+export type CanvasLayoutMode = "manual" | "factory-auto";
+
+export function isFactoryAutoLayout(mode: CanvasLayoutMode | undefined): boolean {
+  return mode === "factory-auto";
+}

--- a/web_src/src/ui/CanvasPage/nodePositionAnimation.spec.ts
+++ b/web_src/src/ui/CanvasPage/nodePositionAnimation.spec.ts
@@ -1,0 +1,39 @@
+import type { Edge, Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+import { interpolateLayoutNodes } from "./nodePositionAnimation";
+
+describe("interpolateLayoutNodes", () => {
+  it("moves existing nodes and fades a connected node from its source", () => {
+    const current: Node[] = [{ id: "source", position: { x: 0, y: 0 }, data: {} }];
+    const target: Node[] = [
+      { id: "source", position: { x: 100, y: 100 }, data: {} },
+      { id: "added", position: { x: 100, y: 300 }, data: {} },
+    ];
+    const edges: Edge[] = [{ id: "edge", source: "source", target: "added" }];
+
+    const halfway = interpolateLayoutNodes(current, target, edges, 0.5);
+
+    expect(halfway.find((node) => node.id === "source")?.position).toEqual({ x: 50, y: 50 });
+    expect(halfway.find((node) => node.id === "added")).toMatchObject({
+      position: { x: 50, y: 150 },
+      style: { opacity: 0.5 },
+    });
+  });
+
+  it("fades a disconnected node at its final position", () => {
+    const target: Node[] = [{ id: "added", position: { x: 400, y: 200 }, data: {} }];
+
+    expect(interpolateLayoutNodes([], target, [], 0.25)[0]).toMatchObject({
+      position: { x: 400, y: 200 },
+      style: { opacity: 0.25 },
+    });
+  });
+
+  it("preserves stationary node references during animation", () => {
+    const stationary: Node = { id: "stationary", position: { x: 20, y: 40 }, data: {} };
+
+    const animated = interpolateLayoutNodes([stationary], [stationary], [], 0.5);
+
+    expect(animated[0]).toBe(stationary);
+  });
+});

--- a/web_src/src/ui/CanvasPage/nodePositionAnimation.ts
+++ b/web_src/src/ui/CanvasPage/nodePositionAnimation.ts
@@ -1,0 +1,48 @@
+import type { Edge, Node } from "@xyflow/react";
+
+export const FACTORY_LAYOUT_ANIMATION_DURATION_MS = 140;
+
+function interpolate(start: number, end: number, progress: number): number {
+  return start + (end - start) * progress;
+}
+
+export function easeOutQuadratic(progress: number): number {
+  return 1 - (1 - progress) * (1 - progress);
+}
+
+export function createLayoutNodeInterpolator(currentNodes: Node[], edges: Edge[]) {
+  const currentById = new Map(currentNodes.map((node) => [node.id, node]));
+  const incomingByTarget = new Map(edges.map((edge) => [edge.target, edge.source]));
+
+  return (targetNodes: Node[], progress: number): Node[] =>
+    targetNodes.map((targetNode) => {
+      const currentNode = currentById.get(targetNode.id);
+      const sourceNode = currentById.get(incomingByTarget.get(targetNode.id) || "");
+      const startPosition = currentNode?.position ?? sourceNode?.position ?? targetNode.position;
+      const isNew = !currentNode;
+      const isStationary =
+        !isNew && startPosition.x === targetNode.position.x && startPosition.y === targetNode.position.y;
+
+      if (isStationary) {
+        return targetNode;
+      }
+
+      return {
+        ...targetNode,
+        position: {
+          x: interpolate(startPosition.x, targetNode.position.x, progress),
+          y: interpolate(startPosition.y, targetNode.position.y, progress),
+        },
+        style: isNew ? { ...targetNode.style, opacity: progress } : targetNode.style,
+      };
+    });
+}
+
+export function interpolateLayoutNodes(
+  currentNodes: Node[],
+  targetNodes: Node[],
+  edges: Edge[],
+  progress: number,
+): Node[] {
+  return createLayoutNodeInterpolator(currentNodes, edges)(targetNodes, progress);
+}

--- a/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Edge, Node } from "@xyflow/react";
 import type { CanvasPageProps } from ".";
 import { useCanvasState } from "./useCanvasState";
@@ -26,6 +26,10 @@ function makeProps(nodes: Node[], edges: Edge[] = []): CanvasPageProps {
 }
 
 describe("useCanvasState", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("preserves position of actively dragged nodes when props update", () => {
     const initial = [makeNode("a", 0, 0), makeNode("b", 100, 100)];
     const { result, rerender } = renderHook(({ props }) => useCanvasState(props), {
@@ -91,6 +95,44 @@ describe("useCanvasState", () => {
     });
 
     expect(result.current.edges).toBe(edgesBeforeDrag);
+  });
+
+  it("does not restart an active factory layout animation when the same layout refreshes", () => {
+    const animationFrames = new Map<number, FrameRequestCallback>();
+    let nextFrameId = 1;
+    const requestAnimationFrame = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      const frameId = nextFrameId++;
+      animationFrames.set(frameId, callback);
+      return frameId;
+    });
+    const cancelAnimationFrame = vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frameId) => {
+      animationFrames.delete(frameId);
+    });
+    const initialProps = {
+      ...makeProps([makeNode("a", 0, 0)]),
+      layoutMode: "factory-auto" as const,
+    };
+    const { rerender } = renderHook(({ props }) => useCanvasState(props), {
+      initialProps: { props: initialProps },
+    });
+
+    rerender({
+      props: {
+        ...makeProps([makeNode("a", 100, 100)]),
+        layoutMode: "factory-auto" as const,
+      },
+    });
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+    rerender({
+      props: {
+        ...makeProps([{ ...makeNode("a", 100, 100), data: { status: "saved" } }]),
+        layoutMode: "factory-auto" as const,
+      },
+    });
+
+    expect(cancelAnimationFrame).not.toHaveBeenCalled();
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
   });
 
   it("does not re-push sidebar params when onSidebarChange identity changes", () => {

--- a/web_src/src/ui/CanvasPage/useCanvasState.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.ts
@@ -139,12 +139,23 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
   useEffect(() => {
     if (!initialNodes) return;
 
+    const factoryAutoLayout = isFactoryAutoLayout(props.layoutMode);
+    if (!factoryAutoLayout) {
+      if (animationFrameRef.current !== null) {
+        window.cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+      animationTargetKeyRef.current = null;
+      setNodes((currentNodes) => buildSyncedNodes(currentNodes, initialNodes, pendingNodePositionsRef.current));
+      return;
+    }
+
     const currentNodes = displayedNodesRef.current;
     const targetNodes = buildSyncedNodes(currentNodes, initialNodes, pendingNodePositionsRef.current);
     const targetKey = getLayoutTargetKey(targetNodes);
-    const animationEnabled =
-      isFactoryAutoLayout(props.layoutMode) &&
-      !(typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+    const animationEnabled = !(
+      typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
     animationTargetNodesRef.current = targetNodes;
     animationEdgesRef.current = initialEdges || [];
 

--- a/web_src/src/ui/CanvasPage/useCanvasState.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.ts
@@ -2,6 +2,12 @@ import type { Edge, EdgeChange, Node, NodeChange, NodePositionChange } from "@xy
 import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CanvasPageProps } from ".";
+import { isFactoryAutoLayout } from "./layoutMode";
+import {
+  createLayoutNodeInterpolator,
+  easeOutQuadratic,
+  FACTORY_LAYOUT_ANIMATION_DURATION_MS,
+} from "./nodePositionAnimation";
 
 function areEdgeListsReferentiallyEqual(currentEdges: Edge[], nextEdges: Edge[]): boolean {
   if (currentEdges.length !== nextEdges.length) {
@@ -25,10 +31,66 @@ function getRoundedPosition(position: { x: number; y: number }): { x: number; y:
   };
 }
 
+function getLayoutTargetKey(nodes: Node[]): string {
+  return nodes
+    .map((node) => `${node.id}:${node.position.x}:${node.position.y}`)
+    .sort()
+    .join("\0");
+}
+
 type PendingNodePosition = {
   localPosition: { x: number; y: number };
   savedPosition: { x: number; y: number };
 };
+
+function buildSyncedNodes(
+  currentNodes: Node[],
+  initialNodes: Node[],
+  pendingNodePositions: Map<string, PendingNodePosition>,
+): Node[] {
+  const localOnlyNodes = currentNodes.filter((node) => node.data.isTemplate || node.data.isPendingConnection);
+  const currentById = new Map(currentNodes.map((node) => [node.id, node]));
+  const syncedNodeIds = new Set<string>();
+
+  const syncedNodes = initialNodes.map((newNode) => {
+    syncedNodeIds.add(newNode.id);
+    const existingNode = currentById.get(newNode.id);
+    const nodeData = { ...newNode.data };
+    const nodeType = nodeData.type as string;
+
+    if (existingNode && nodeType && nodeData[nodeType]) {
+      const existingType = existingNode.data.type as string;
+      const existingCollapsed = existingType && (existingNode.data[existingType] as { collapsed: boolean })?.collapsed;
+      nodeData[nodeType] = { ...nodeData[nodeType], collapsed: existingCollapsed };
+    }
+
+    const pendingPosition = pendingNodePositions.get(newNode.id);
+    let position = (existingNode?.dragging && existingNode.position) || newNode.position;
+    if (pendingPosition) {
+      if (arePositionsEqual(newNode.position, pendingPosition.savedPosition)) {
+        pendingNodePositions.delete(newNode.id);
+      } else {
+        position = pendingPosition.localPosition;
+      }
+    }
+
+    return {
+      ...newNode,
+      data: nodeData,
+      selected: existingNode?.selected ?? newNode.selected,
+      position,
+      dragging: existingNode?.dragging,
+    };
+  });
+
+  for (const nodeId of pendingNodePositions.keys()) {
+    if (!syncedNodeIds.has(nodeId)) {
+      pendingNodePositions.delete(nodeId);
+    }
+  }
+
+  return [...syncedNodes, ...localOnlyNodes];
+}
 
 export interface CanvasPageState {
   nodes: Node[];
@@ -57,6 +119,12 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
   const [nodes, setNodes] = useState<Node[]>(() => initialNodes ?? []);
   const [edges, setEdges] = useState<Edge[]>(() => initialEdges ?? []);
   const pendingNodePositionsRef = useRef<Map<string, PendingNodePosition>>(new Map());
+  const displayedNodesRef = useRef(nodes);
+  const animationFrameRef = useRef<number | null>(null);
+  const animationTargetKeyRef = useRef<string | null>(null);
+  const animationTargetNodesRef = useRef<Node[]>([]);
+  const animationEdgesRef = useRef<Edge[]>([]);
+  displayedNodesRef.current = nodes;
   const localOnlyNodeIdsKey = useMemo(
     () =>
       nodes
@@ -71,58 +139,69 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
   useEffect(() => {
     if (!initialNodes) return;
 
-    setNodes((currentNodes) => {
-      // Preserve locally-added template and pending connection nodes
-      const localOnlyNodes = currentNodes.filter((node) => node.data.isTemplate || node.data.isPendingConnection);
-      const syncedNodeIds = new Set<string>();
+    const currentNodes = displayedNodesRef.current;
+    const targetNodes = buildSyncedNodes(currentNodes, initialNodes, pendingNodePositionsRef.current);
+    const targetKey = getLayoutTargetKey(targetNodes);
+    const animationEnabled =
+      isFactoryAutoLayout(props.layoutMode) &&
+      !(typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+    animationTargetNodesRef.current = targetNodes;
+    animationEdgesRef.current = initialEdges || [];
 
-      const syncedNodes = initialNodes.map((newNode) => {
-        syncedNodeIds.add(newNode.id);
-        const existingNode = currentNodes.find((n) => n.id === newNode.id);
-        const nodeData = { ...newNode.data };
-        const nodeType = nodeData.type as string;
+    if (animationEnabled && animationFrameRef.current !== null && animationTargetKeyRef.current === targetKey) {
+      return;
+    }
 
-        // Preserve collapsed state from existing node
-        if (existingNode && nodeType && nodeData[nodeType]) {
-          const existingType = existingNode.data.type as string;
-          const existingCollapsed =
-            existingType && (existingNode.data[existingType] as { collapsed: boolean })?.collapsed;
-          nodeData[nodeType] = {
-            ...nodeData[nodeType],
-            collapsed: existingCollapsed,
-          };
-        }
+    if (animationFrameRef.current !== null) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
 
-        const pendingPosition = pendingNodePositionsRef.current.get(newNode.id);
-        let position = (existingNode?.dragging && existingNode.position) || newNode.position;
-        if (pendingPosition) {
-          if (arePositionsEqual(newNode.position, pendingPosition.savedPosition)) {
-            pendingNodePositionsRef.current.delete(newNode.id);
-          } else {
-            position = pendingPosition.localPosition;
-          }
-        }
-
-        // Preserve selected state and position of actively dragged nodes
-        return {
-          ...newNode,
-          data: nodeData,
-          selected: existingNode?.selected ?? newNode.selected,
-          position,
-          dragging: existingNode?.dragging,
-        };
+    const shouldAnimate =
+      animationEnabled &&
+      targetNodes.some((targetNode) => {
+        const currentNode = currentNodes.find((node) => node.id === targetNode.id);
+        return !currentNode || !arePositionsEqual(currentNode.position, targetNode.position);
       });
 
-      for (const nodeId of pendingNodePositionsRef.current.keys()) {
-        if (!syncedNodeIds.has(nodeId)) {
-          pendingNodePositionsRef.current.delete(nodeId);
-        }
+    if (!shouldAnimate) {
+      animationTargetKeyRef.current = null;
+      displayedNodesRef.current = targetNodes;
+      setNodes(targetNodes);
+      return;
+    }
+
+    animationTargetKeyRef.current = targetKey;
+    const startedAt = performance.now();
+    const interpolateNodes = createLayoutNodeInterpolator(currentNodes, animationEdgesRef.current);
+    const animate = (now: number) => {
+      const linearProgress = Math.min((now - startedAt) / FACTORY_LAYOUT_ANIMATION_DURATION_MS, 1);
+      const latestTargetNodes = animationTargetNodesRef.current;
+      if (linearProgress >= 1) {
+        displayedNodesRef.current = latestTargetNodes;
+        setNodes(latestTargetNodes);
+        animationFrameRef.current = null;
+        animationTargetKeyRef.current = null;
+        return;
       }
 
-      // Append local-only nodes at the end
-      return [...syncedNodes, ...localOnlyNodes];
-    });
-  }, [initialNodes]);
+      const animatedNodes = interpolateNodes(latestTargetNodes, easeOutQuadratic(linearProgress));
+      displayedNodesRef.current = animatedNodes;
+      setNodes(animatedNodes);
+      animationFrameRef.current = window.requestAnimationFrame(animate);
+    };
+
+    animationFrameRef.current = window.requestAnimationFrame(animate);
+  }, [initialEdges, initialNodes, props.layoutMode]);
+
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current !== null) {
+        window.cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!initialEdges) return;


### PR DESCRIPTION
## Summary

- Applies mandatory vertical auto-layout when Factory Configure opens or topology changes.
- Locks factory nodes and animates layout updates while preserving existing edit controls.
- Hides deleted-node ghosts and irrelevant layout controls to keep the draft canvas clear.

## Test plan

- [x] Run 75 focused UI tests for layout, diff, node, and canvas behavior.
- [x] Run `make check.lint.ui`.
- [x] Run `make check.build.ui`.