### PR TITLE
fix: Require org read permission on widget endpoints

### DIFF
--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -336,6 +336,16 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			Action:     "read",
 			DomainType: models.DomainTypeOrganization,
 		},
+		{Method: "GET", Pattern: "/api/v1/widgets"}: {
+			Resource:   "org",
+			Action:     "read",
+			DomainType: models.DomainTypeOrganization,
+		},
+		{Method: "GET", Pattern: "/api/v1/widgets/{name}"}: {
+			Resource:   "org",
+			Action:     "read",
+			DomainType: models.DomainTypeOrganization,
+		},
 		{Method: "PATCH", Pattern: "/api/v1/canvas-folders/{id}/position"}: {
 			Resource:   "canvases",
 			Action:     "update",

--- a/pkg/authorization/interceptor_test.go
+++ b/pkg/authorization/interceptor_test.go
@@ -295,6 +295,58 @@ func TestDefaultAuthorizationRulesAreKeyedByHTTPRoute(t *testing.T) {
 	assert.Equal(t, []string{IDPathParam}, rule.ResourcePathParams)
 }
 
+func TestWidgetRoutesRequireOrgRead(t *testing.T) {
+	rules := DefaultAuthorizationRules()
+	routes := []HTTPRoute{
+		{Method: http.MethodGet, Pattern: "/api/v1/widgets"},
+		{Method: http.MethodGet, Pattern: "/api/v1/widgets/{name}"},
+	}
+
+	for _, route := range routes {
+		rule, ok := rules[route]
+		require.True(t, ok, route.String())
+		assert.Equal(t, "org", rule.Resource, route.String())
+		assert.Equal(t, "read", rule.Action, route.String())
+		assert.Equal(t, models.DomainTypeOrganization, rule.DomainType, route.String())
+	}
+}
+
+func TestGatewayAuthorizerEnforcesAuthOnWidgetRoutes(t *testing.T) {
+	route := HTTPRoute{Method: http.MethodGet, Pattern: "/api/v1/widgets"}
+
+	t.Run("rejects request without identity headers", func(t *testing.T) {
+		authorizer := NewGatewayAuthorizer(allowingPermissionChecker{})
+		r := httptestRequest(t, nil)
+
+		_, err := authorizer.AuthorizeHTTP(context.Background(), r, route, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects user without org read permission", func(t *testing.T) {
+		authorizer := NewGatewayAuthorizer(actionPermissionChecker{"org:read": false})
+		r := httptestRequest(t, map[string]string{
+			"x-user-id":         "22222222-2222-4222-8222-222222222222",
+			"x-organization-id": "11111111-1111-4111-8111-111111111111",
+		})
+
+		_, err := authorizer.AuthorizeHTTP(context.Background(), r, route, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("sets organization context for permitted user", func(t *testing.T) {
+		organizationID := "11111111-1111-4111-8111-111111111111"
+		authorizer := NewGatewayAuthorizer(actionPermissionChecker{"org:read": true})
+		r := httptestRequest(t, map[string]string{
+			"x-user-id":         "22222222-2222-4222-8222-222222222222",
+			"x-organization-id": organizationID,
+		})
+
+		ctx, err := authorizer.AuthorizeHTTP(context.Background(), r, route, nil)
+		require.NoError(t, err)
+		assert.Equal(t, organizationID, ctx.Value(OrganizationContextKey))
+	})
+}
+
 func httptestRequest(t *testing.T, headers map[string]string) *http.Request {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

The HTTP gateway authorizer only checks routes that exist in `DefaultAuthorizationRules`. The two widget routes had no entry. The authorizer skipped the identity, organization, RBAC, and token scope checks for them. This change registers `GET /api/v1/widgets` and `GET /api/v1/widgets/{name}` with the same `org` / `read` rule as the trigger registry routes. New tests lock the rules in place and check the authorizer behavior.

Fixes #6707

## Test plan

- [x] Run `make test PKG_TEST_PACKAGES=./pkg/authorization` and confirm all 98 tests pass
- [x] Send an authenticated request without organization context and confirm a 404 response
- [x] Open the app Console tab, click "Add panel", and confirm the widget list loads