### PR TITLE
fix: Stop per-item enforcer rebuilds in ListGroups and ListUsers

### DIFF
--- a/pkg/authorization/get_org_users_by_roles_test.go
+++ b/pkg/authorization/get_org_users_by_roles_test.go
@@ -1,0 +1,43 @@
+package authorization_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+// GetOrgUsersByRoles resolves every role from one read enforcer. This test
+// locks it to the per-role GetOrgUsersForRole method it replaces, so the
+// batched path can never silently diverge.
+func Test__AuthService_GetOrgUsersByRoles_MatchesGetOrgUsersForRole(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+	orgID := r.Organization.ID.String()
+	domainType := models.DomainTypeOrganization
+
+	require.NoError(t, r.AuthService.AssignRole("user-a", models.RoleOrgAdmin, orgID, domainType))
+	require.NoError(t, r.AuthService.AssignRole("user-b", models.RoleOrgAdmin, orgID, domainType))
+	require.NoError(t, r.AuthService.AssignRole("user-c", models.RoleOrgViewer, orgID, domainType))
+
+	// Includes a role with no members here (owner) to exercise the empty case.
+	roleNames := []string{models.RoleOrgAdmin, models.RoleOrgViewer, models.RoleOrgOwner}
+
+	usersByRole, err := r.AuthService.GetOrgUsersByRoles(ctx, orgID, roleNames)
+	require.NoError(t, err)
+
+	// Each role's users match the per-role method exactly.
+	for _, role := range roleNames {
+		want, err := r.AuthService.GetOrgUsersForRole(ctx, role, orgID)
+		require.NoError(t, err, "GetOrgUsersForRole(%s)", role)
+		assert.ElementsMatch(t, want, usersByRole[role], "users for role %s", role)
+	}
+
+	// Concrete expectations so a bug shared by both paths cannot hide. Subset/
+	// Contains keep this robust to any roles the org fixture pre-assigns.
+	assert.Subset(t, usersByRole[models.RoleOrgAdmin], []string{"user-a", "user-b"})
+	assert.Contains(t, usersByRole[models.RoleOrgViewer], "user-c")
+}

--- a/pkg/authorization/get_org_users_by_roles_test.go
+++ b/pkg/authorization/get_org_users_by_roles_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/superplanehq/superplane/test/support"
 )
 
-// GetOrgUsersByRoles resolves every role from one read enforcer. This test
-// locks it to the per-role GetOrgUsersForRole method it replaces, so the
-// batched path can never silently diverge.
+// Locks GetOrgUsersByRoles to GetOrgUsersForRole.
 func Test__AuthService_GetOrgUsersByRoles_MatchesGetOrgUsersForRole(t *testing.T) {
 	r := support.Setup(t)
 	ctx := context.Background()
@@ -23,21 +21,17 @@ func Test__AuthService_GetOrgUsersByRoles_MatchesGetOrgUsersForRole(t *testing.T
 	require.NoError(t, r.AuthService.AssignRole("user-b", models.RoleOrgAdmin, orgID, domainType))
 	require.NoError(t, r.AuthService.AssignRole("user-c", models.RoleOrgViewer, orgID, domainType))
 
-	// Includes a role with no members here (owner) to exercise the empty case.
 	roleNames := []string{models.RoleOrgAdmin, models.RoleOrgViewer, models.RoleOrgOwner}
 
 	usersByRole, err := r.AuthService.GetOrgUsersByRoles(ctx, orgID, roleNames)
 	require.NoError(t, err)
 
-	// Each role's users match the per-role method exactly.
 	for _, role := range roleNames {
 		want, err := r.AuthService.GetOrgUsersForRole(ctx, role, orgID)
 		require.NoError(t, err, "GetOrgUsersForRole(%s)", role)
 		assert.ElementsMatch(t, want, usersByRole[role], "users for role %s", role)
 	}
 
-	// Concrete expectations so a bug shared by both paths cannot hide. Subset/
-	// Contains keep this robust to any roles the org fixture pre-assigns.
 	assert.Subset(t, usersByRole[models.RoleOrgAdmin], []string{"user-a", "user-b"})
 	assert.Contains(t, usersByRole[models.RoleOrgViewer], "user-c")
 }

--- a/pkg/authorization/interface.go
+++ b/pkg/authorization/interface.go
@@ -22,8 +22,6 @@ type GroupManager interface {
 	GetUserGroups(ctx context.Context, domainID string, domainType string, userID string) ([]string, error)
 	GetGroups(ctx context.Context, domainID string, domainType string) ([]string, error)
 	GetGroupRole(ctx context.Context, domainID string, domainType string, group string) (string, error)
-	// GetGroupsWithDetails returns every group's role and members using a
-	// single read enforcer, instead of rebuilding one per group.
 	GetGroupsWithDetails(ctx context.Context, domainID string, domainType string) ([]GroupWithDetails, error)
 }
 

--- a/pkg/authorization/interface.go
+++ b/pkg/authorization/interface.go
@@ -30,6 +30,9 @@ type RoleManager interface {
 	AssignRole(userID, role, domainID string, domainType string) error
 	RemoveRole(userID, role, domainID string, domainType string) error
 	GetOrgUsersForRole(ctx context.Context, role string, orgID string) ([]string, error)
+	// GetOrgUsersByRoles resolves the users for several roles using a single
+	// read enforcer, instead of rebuilding one per role.
+	GetOrgUsersByRoles(ctx context.Context, orgID string, roleNames []string) (map[string][]string, error)
 }
 
 // Setup and initialization interface

--- a/pkg/authorization/interface.go
+++ b/pkg/authorization/interface.go
@@ -30,8 +30,6 @@ type RoleManager interface {
 	AssignRole(userID, role, domainID string, domainType string) error
 	RemoveRole(userID, role, domainID string, domainType string) error
 	GetOrgUsersForRole(ctx context.Context, role string, orgID string) ([]string, error)
-	// GetOrgUsersByRoles resolves the users for several roles using a single
-	// read enforcer, instead of rebuilding one per role.
 	GetOrgUsersByRoles(ctx context.Context, orgID string, roleNames []string) (map[string][]string, error)
 }
 

--- a/pkg/authorization/interface.go
+++ b/pkg/authorization/interface.go
@@ -22,6 +22,9 @@ type GroupManager interface {
 	GetUserGroups(ctx context.Context, domainID string, domainType string, userID string) ([]string, error)
 	GetGroups(ctx context.Context, domainID string, domainType string) ([]string, error)
 	GetGroupRole(ctx context.Context, domainID string, domainType string, group string) (string, error)
+	// GetGroupsWithDetails returns every group's role and members using a
+	// single read enforcer, instead of rebuilding one per group.
+	GetGroupsWithDetails(ctx context.Context, domainID string, domainType string) ([]GroupWithDetails, error)
 }
 
 // Role management interface

--- a/pkg/authorization/list_groups_details_test.go
+++ b/pkg/authorization/list_groups_details_test.go
@@ -1,0 +1,62 @@
+package authorization_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+// GetGroupsWithDetails builds a single read enforcer and derives every group
+// from it. This test locks it to the per-group GetGroupRole / GetGroupUsers
+// methods it replaces, so the batched path can never silently diverge.
+func Test__AuthService_GetGroupsWithDetails_MatchesPerGroupMethods(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+	orgID := r.Organization.ID.String()
+	domainType := models.DomainTypeOrganization
+
+	require.NoError(t, r.AuthService.CreateGroup(orgID, domainType, "admins", models.RoleOrgAdmin, "Admins", "Admin group"))
+	require.NoError(t, r.AuthService.CreateGroup(orgID, domainType, "viewers", models.RoleOrgViewer, "Viewers", "Viewer group"))
+	// A group with no members exercises the empty-members path.
+	require.NoError(t, r.AuthService.CreateGroup(orgID, domainType, "empty", models.RoleOrgViewer, "Empty", "No members"))
+
+	require.NoError(t, r.AuthService.AddUserToGroup(orgID, domainType, "user-a", "admins"))
+	require.NoError(t, r.AuthService.AddUserToGroup(orgID, domainType, "user-b", "admins"))
+	require.NoError(t, r.AuthService.AddUserToGroup(orgID, domainType, "user-c", "viewers"))
+
+	details, err := r.AuthService.GetGroupsWithDetails(ctx, orgID, domainType)
+	require.NoError(t, err)
+
+	// Same set of groups as GetGroups.
+	expectedNames, err := r.AuthService.GetGroups(ctx, orgID, domainType)
+	require.NoError(t, err)
+	actualNames := make([]string, len(details))
+	for i, d := range details {
+		actualNames[i] = d.Name
+	}
+	assert.ElementsMatch(t, expectedNames, actualNames)
+
+	// Each group's role and members match the per-group methods exactly.
+	for _, detail := range details {
+		wantRole, err := r.AuthService.GetGroupRole(ctx, orgID, domainType, detail.Name)
+		require.NoError(t, err, "GetGroupRole(%s)", detail.Name)
+		assert.Equal(t, wantRole, detail.Role, "role for group %s", detail.Name)
+
+		wantMembers, err := r.AuthService.GetGroupUsers(ctx, orgID, domainType, detail.Name)
+		require.NoError(t, err, "GetGroupUsers(%s)", detail.Name)
+		assert.ElementsMatch(t, wantMembers, detail.Members, "members for group %s", detail.Name)
+	}
+
+	// Spot-check the concrete expectations so a bug in both paths can't hide.
+	byName := make(map[string]int)
+	for _, detail := range details {
+		byName[detail.Name] = len(detail.Members)
+	}
+	assert.Equal(t, 2, byName["admins"])
+	assert.Equal(t, 1, byName["viewers"])
+	assert.Equal(t, 0, byName["empty"])
+}

--- a/pkg/authorization/list_groups_details_test.go
+++ b/pkg/authorization/list_groups_details_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/superplanehq/superplane/test/support"
 )
 
-// GetGroupsWithDetails builds a single read enforcer and derives every group
-// from it. This test locks it to the per-group GetGroupRole / GetGroupUsers
-// methods it replaces, so the batched path can never silently diverge.
+// Locks GetGroupsWithDetails to GetGroupRole and GetGroupUsers.
 func Test__AuthService_GetGroupsWithDetails_MatchesPerGroupMethods(t *testing.T) {
 	r := support.Setup(t)
 	ctx := context.Background()

--- a/pkg/authorization/list_groups_details_test.go
+++ b/pkg/authorization/list_groups_details_test.go
@@ -19,7 +19,6 @@ func Test__AuthService_GetGroupsWithDetails_MatchesPerGroupMethods(t *testing.T)
 
 	require.NoError(t, r.AuthService.CreateGroup(orgID, domainType, "admins", models.RoleOrgAdmin, "Admins", "Admin group"))
 	require.NoError(t, r.AuthService.CreateGroup(orgID, domainType, "viewers", models.RoleOrgViewer, "Viewers", "Viewer group"))
-	// A group with no members exercises the empty-members path.
 	require.NoError(t, r.AuthService.CreateGroup(orgID, domainType, "empty", models.RoleOrgViewer, "Empty", "No members"))
 
 	require.NoError(t, r.AuthService.AddUserToGroup(orgID, domainType, "user-a", "admins"))
@@ -29,7 +28,6 @@ func Test__AuthService_GetGroupsWithDetails_MatchesPerGroupMethods(t *testing.T)
 	details, err := r.AuthService.GetGroupsWithDetails(ctx, orgID, domainType)
 	require.NoError(t, err)
 
-	// Same set of groups as GetGroups.
 	expectedNames, err := r.AuthService.GetGroups(ctx, orgID, domainType)
 	require.NoError(t, err)
 	actualNames := make([]string, len(details))
@@ -38,7 +36,6 @@ func Test__AuthService_GetGroupsWithDetails_MatchesPerGroupMethods(t *testing.T)
 	}
 	assert.ElementsMatch(t, expectedNames, actualNames)
 
-	// Each group's role and members match the per-group methods exactly.
 	for _, detail := range details {
 		wantRole, err := r.AuthService.GetGroupRole(ctx, orgID, domainType, detail.Name)
 		require.NoError(t, err, "GetGroupRole(%s)", detail.Name)
@@ -49,7 +46,6 @@ func Test__AuthService_GetGroupsWithDetails_MatchesPerGroupMethods(t *testing.T)
 		assert.ElementsMatch(t, wantMembers, detail.Members, "members for group %s", detail.Name)
 	}
 
-	// Spot-check the concrete expectations so a bug in both paths can't hide.
 	byName := make(map[string]int)
 	for _, detail := range details {
 		byName[detail.Name] = len(detail.Members)

--- a/pkg/authorization/service.go
+++ b/pkg/authorization/service.go
@@ -354,20 +354,15 @@ func (a *AuthService) RemoveUserFromGroup(domainID string, domainType string, us
 	return nil
 }
 
-// GroupWithDetails carries a group's resolved role and members, computed from
-// a single read enforcer by GetGroupsWithDetails.
+// GroupWithDetails is a group's role and members.
 type GroupWithDetails struct {
 	Name    string
 	Role    string
 	Members []string
 }
 
-// GetGroupsWithDetails returns every group in the domain together with its
-// role and members. It builds one read enforcer and derives all groups from
-// it in memory, rather than rebuilding an enforcer per group as calling
-// GetGroups + GetGroupRole + GetGroupUsers in a loop would. The per-group
-// derivation uses the same casbin calls as those methods, so the results are
-// identical.
+// GetGroupsWithDetails returns each group's role and members.
+// It uses one read enforcer instead of one per group.
 func (a *AuthService) GetGroupsWithDetails(ctx context.Context, domainID string, domainType string) ([]GroupWithDetails, error) {
 	domain := prefixDomain(domainType, domainID)
 

--- a/pkg/authorization/service.go
+++ b/pkg/authorization/service.go
@@ -354,6 +354,85 @@ func (a *AuthService) RemoveUserFromGroup(domainID string, domainType string, us
 	return nil
 }
 
+// GroupWithDetails carries a group's resolved role and members, computed from
+// a single read enforcer by GetGroupsWithDetails.
+type GroupWithDetails struct {
+	Name    string
+	Role    string
+	Members []string
+}
+
+// GetGroupsWithDetails returns every group in the domain together with its
+// role and members. It builds one read enforcer and derives all groups from
+// it in memory, rather than rebuilding an enforcer per group as calling
+// GetGroups + GetGroupRole + GetGroupUsers in a loop would. The per-group
+// derivation uses the same casbin calls as those methods, so the results are
+// identical.
+func (a *AuthService) GetGroupsWithDetails(ctx context.Context, domainID string, domainType string) ([]GroupWithDetails, error) {
+	domain := prefixDomain(domainType, domainID)
+
+	var details []GroupWithDetails
+	err := a.withReadEnforcer(ctx, domainType, domainID, func(enforcer casbin.IEnforcer) error {
+		// Discover group names the same way GetGroups does: a group appears as
+		// the subject of a group->role grouping rule.
+		policies, err := enforcer.GetFilteredGroupingPolicy(2, domain)
+		if err != nil {
+			return fmt.Errorf("failed to get groups: %w", err)
+		}
+
+		groupNames := make([]string, 0)
+		seen := make(map[string]bool)
+		for _, policy := range policies {
+			if !strings.HasPrefix(policy[0], "/groups/") {
+				continue
+			}
+			groupName := policy[0][len("/groups/"):]
+			if seen[groupName] {
+				continue
+			}
+			seen[groupName] = true
+			groupNames = append(groupNames, groupName)
+		}
+
+		details = make([]GroupWithDetails, 0, len(groupNames))
+		for _, groupName := range groupNames {
+			prefixedGroupName := prefixGroupName(groupName)
+
+			// Role: first /roles/ role, matching GetGroupRole.
+			role := ""
+			for _, r := range enforcer.GetRolesForUserInDomain(prefixedGroupName, domain) {
+				if strings.HasPrefix(r, "/roles/") {
+					role = strings.TrimPrefix(r, "/roles/")
+					break
+				}
+			}
+
+			// Members: users assigned to the group, matching GetGroupUsers.
+			memberPolicies, err := enforcer.GetFilteredGroupingPolicy(1, prefixedGroupName, domain)
+			if err != nil {
+				return fmt.Errorf("failed to get group users: %w", err)
+			}
+			members := make([]string, 0, len(memberPolicies))
+			for _, policy := range memberPolicies {
+				members = append(members, strings.TrimPrefix(policy[0], "/users/"))
+			}
+
+			details = append(details, GroupWithDetails{
+				Name:    groupName,
+				Role:    role,
+				Members: members,
+			})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return details, nil
+}
+
 func (a *AuthService) GetGroupUsers(ctx context.Context, domainID string, domainType string, group string) ([]string, error) {
 	domain := prefixDomain(domainType, domainID)
 	prefixedGroupName := prefixGroupName(group)

--- a/pkg/authorization/service.go
+++ b/pkg/authorization/service.go
@@ -368,8 +368,6 @@ func (a *AuthService) GetGroupsWithDetails(ctx context.Context, domainID string,
 
 	var details []GroupWithDetails
 	err := a.withReadEnforcer(ctx, domainType, domainID, func(enforcer casbin.IEnforcer) error {
-		// Discover group names the same way GetGroups does: a group appears as
-		// the subject of a group->role grouping rule.
 		policies, err := enforcer.GetFilteredGroupingPolicy(2, domain)
 		if err != nil {
 			return fmt.Errorf("failed to get groups: %w", err)
@@ -393,7 +391,6 @@ func (a *AuthService) GetGroupsWithDetails(ctx context.Context, domainID string,
 		for _, groupName := range groupNames {
 			prefixedGroupName := prefixGroupName(groupName)
 
-			// Role: first /roles/ role, matching GetGroupRole.
 			role := ""
 			for _, r := range enforcer.GetRolesForUserInDomain(prefixedGroupName, domain) {
 				if strings.HasPrefix(r, "/roles/") {
@@ -402,7 +399,6 @@ func (a *AuthService) GetGroupsWithDetails(ctx context.Context, domainID string,
 				}
 			}
 
-			// Members: users assigned to the group, matching GetGroupUsers.
 			memberPolicies, err := enforcer.GetFilteredGroupingPolicy(1, prefixedGroupName, domain)
 			if err != nil {
 				return fmt.Errorf("failed to get group users: %w", err)
@@ -638,11 +634,9 @@ func (a *AuthService) RemoveRole(userID, role, domainID string, domainType strin
 	return nil
 }
 
-// GetOrgUsersByRoles resolves the users assigned to each of roleNames using a
-// single read enforcer, rather than rebuilding one per role as calling
-// GetOrgUsersForRole in a loop would. Each role's lookup uses the same casbin
-// call as GetOrgUsersForRole, so the results are identical. A role whose
-// lookup fails is skipped, matching the per-role method's tolerated errors.
+// GetOrgUsersByRoles returns the users for each role.
+// It uses one read enforcer instead of one per role.
+// A role whose lookup fails is skipped.
 func (a *AuthService) GetOrgUsersByRoles(ctx context.Context, orgID string, roleNames []string) (map[string][]string, error) {
 	orgDomain := prefixDomain(models.DomainTypeOrganization, orgID)
 

--- a/pkg/authorization/service.go
+++ b/pkg/authorization/service.go
@@ -638,6 +638,41 @@ func (a *AuthService) RemoveRole(userID, role, domainID string, domainType strin
 	return nil
 }
 
+// GetOrgUsersByRoles resolves the users assigned to each of roleNames using a
+// single read enforcer, rather than rebuilding one per role as calling
+// GetOrgUsersForRole in a loop would. Each role's lookup uses the same casbin
+// call as GetOrgUsersForRole, so the results are identical. A role whose
+// lookup fails is skipped, matching the per-role method's tolerated errors.
+func (a *AuthService) GetOrgUsersByRoles(ctx context.Context, orgID string, roleNames []string) (map[string][]string, error) {
+	orgDomain := prefixDomain(models.DomainTypeOrganization, orgID)
+
+	usersByRole := make(map[string][]string, len(roleNames))
+	err := a.withReadEnforcer(ctx, models.DomainTypeOrganization, orgID, func(enforcer casbin.IEnforcer) error {
+		for _, role := range roleNames {
+			prefixedRole := prefixRoleName(role)
+			users, err := enforcer.GetUsersForRole(prefixedRole, orgDomain)
+			if err != nil {
+				continue
+			}
+
+			unprefixedUsers := make([]string, 0, len(users))
+			for _, user := range users {
+				if strings.HasPrefix(user, "/users/") {
+					unprefixedUsers = append(unprefixedUsers, strings.TrimPrefix(user, "/users/"))
+				}
+			}
+			usersByRole[role] = unprefixedUsers
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return usersByRole, nil
+}
+
 func (a *AuthService) GetOrgUsersForRole(ctx context.Context, role string, orgID string) ([]string, error) {
 	prefixedRole := prefixRoleName(role)
 	orgDomain := prefixDomain(models.DomainTypeOrganization, orgID)

--- a/pkg/grpc/actions/auth/list_groups.go
+++ b/pkg/grpc/actions/auth/list_groups.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -12,51 +13,50 @@ import (
 )
 
 func ListGroups(ctx context.Context, domainType string, domainID string, authService authorization.Authorization) (*pb.ListGroupsResponse, error) {
-	groupNames, err := authService.GetGroups(ctx, domainID, domainType)
+	// One read enforcer resolves every group's role and members. Metadata for
+	// all groups loads in a single query. Both replace per-group work that
+	// rebuilt the casbin enforcer twice and queried metadata once per group.
+	groupDetails, err := authService.GetGroupsWithDetails(ctx, domainID, domainType)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to get groups")
 	}
 
-	groups := make([]*pb.Group, len(groupNames))
-	for i, groupName := range groupNames {
-		role, err := authService.GetGroupRole(ctx, domainID, domainType, groupName)
-		if err != nil {
-			return nil, grpcerrors.Internal(err, "failed to get group roles")
-		}
+	groupNames := make([]string, len(groupDetails))
+	for i, detail := range groupDetails {
+		groupNames[i] = detail.Name
+	}
 
-		groupUsers, err := authService.GetGroupUsers(ctx, domainID, domainType, groupName)
-		if err != nil {
-			return nil, grpcerrors.Internal(err, "failed to get group members count")
-		}
+	metadataByGroup, err := models.FindGroupMetadataByNames(database.DB(ctx), groupNames, domainType, domainID)
+	if err != nil {
+		return nil, grpcerrors.Internal(err, "failed to get group metadata")
+	}
 
-		groupMetadata, err := models.FindGroupMetadata(groupName, domainType, domainID)
+	groups := make([]*pb.Group, len(groupDetails))
+	for i, detail := range groupDetails {
 		var createdAt, updatedAt *timestamppb.Timestamp
-		var displayName, description string
-		if err == nil {
-			createdAt = timestamppb.New(groupMetadata.CreatedAt)
-			updatedAt = timestamppb.New(groupMetadata.UpdatedAt)
-			displayName = groupMetadata.DisplayName
-			description = groupMetadata.Description
-		} else {
-			displayName = groupName
-			description = ""
+		displayName, description := detail.Name, ""
+		if metadata := metadataByGroup[detail.Name]; metadata != nil {
+			createdAt = timestamppb.New(metadata.CreatedAt)
+			updatedAt = timestamppb.New(metadata.UpdatedAt)
+			displayName = metadata.DisplayName
+			description = metadata.Description
 		}
 
 		groups[i] = &pb.Group{
 			Metadata: &pb.Group_Metadata{
-				Name:       groupName,
+				Name:       detail.Name,
 				DomainType: actions.DomainTypeToProto(domainType),
 				DomainId:   domainID,
 				CreatedAt:  createdAt,
 				UpdatedAt:  updatedAt,
 			},
 			Spec: &pb.Group_Spec{
-				Role:        role,
+				Role:        detail.Role,
 				DisplayName: displayName,
 				Description: description,
 			},
 			Status: &pb.Group_Status{
-				MembersCount: int32(len(groupUsers)),
+				MembersCount: int32(len(detail.Members)),
 			},
 		}
 	}

--- a/pkg/grpc/actions/auth/list_groups.go
+++ b/pkg/grpc/actions/auth/list_groups.go
@@ -13,9 +13,6 @@ import (
 )
 
 func ListGroups(ctx context.Context, domainType string, domainID string, authService authorization.Authorization) (*pb.ListGroupsResponse, error) {
-	// One read enforcer resolves every group's role and members. Metadata for
-	// all groups loads in a single query. Both replace per-group work that
-	// rebuilt the casbin enforcer twice and queried metadata once per group.
 	groupDetails, err := authService.GetGroupsWithDetails(ctx, domainID, domainType)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to get groups")

--- a/pkg/grpc/actions/auth/list_users.go
+++ b/pkg/grpc/actions/auth/list_users.go
@@ -58,10 +58,6 @@ func ListUsers(
 		return nil, grpcerrors.NotFound(err, "role not found")
 	}
 
-	//
-	// Resolve the users for every role with a single read enforcer, instead
-	// of rebuilding one per role.
-	//
 	usersByRole, err := authService.GetOrgUsersByRoles(ctx, domainID, roleNames)
 	if err != nil {
 		return nil, grpcerrors.Internal(err, "failed to get users for roles")

--- a/pkg/grpc/actions/auth/list_users.go
+++ b/pkg/grpc/actions/auth/list_users.go
@@ -59,13 +59,16 @@ func ListUsers(
 	}
 
 	//
-	// For each role, get all users for it
+	// Resolve the users for every role with a single read enforcer, instead
+	// of rebuilding one per role.
 	//
+	usersByRole, err := authService.GetOrgUsersByRoles(ctx, domainID, roleNames)
+	if err != nil {
+		return nil, grpcerrors.Internal(err, "failed to get users for roles")
+	}
+
 	for _, roleDef := range roleDefinitions {
-		userIDs, err := authService.GetOrgUsersForRole(ctx, roleDef.Name, domainID)
-		if err != nil {
-			continue
-		}
+		userIDs := usersByRole[roleDef.Name]
 
 		roleMetadata := roleMetadataMap[roleDef.Name]
 		roleAssignment := &pb.RoleAssignment{

--- a/pkg/models/role_metadata.go
+++ b/pkg/models/role_metadata.go
@@ -96,9 +96,7 @@ func FindGroupMetadata(groupName, domainType, domainID string) (*GroupMetadata, 
 }
 
 // FindGroupMetadataByNames loads metadata for several groups in one query.
-// Groups without a metadata row are simply absent from the returned map, so
-// callers fall back to defaults the same way FindGroupMetadata's not-found
-// path does. Mirrors FindRoleMetadataByNames.
+// Groups without a row are omitted so callers can use defaults.
 func FindGroupMetadataByNames(tx *gorm.DB, groupNames []string, domainType, domainID string) (map[string]*GroupMetadata, error) {
 	result := make(map[string]*GroupMetadata)
 	if len(groupNames) == 0 {

--- a/pkg/models/role_metadata.go
+++ b/pkg/models/role_metadata.go
@@ -95,6 +95,28 @@ func FindGroupMetadata(groupName, domainType, domainID string) (*GroupMetadata, 
 	return &metadata, nil
 }
 
+// FindGroupMetadataByNames loads metadata for several groups in one query.
+// Groups without a metadata row are simply absent from the returned map, so
+// callers fall back to defaults the same way FindGroupMetadata's not-found
+// path does. Mirrors FindRoleMetadataByNames.
+func FindGroupMetadataByNames(tx *gorm.DB, groupNames []string, domainType, domainID string) (map[string]*GroupMetadata, error) {
+	result := make(map[string]*GroupMetadata)
+	if len(groupNames) == 0 {
+		return result, nil
+	}
+
+	var metadata []GroupMetadata
+	err := tx.Where("group_name IN ? AND domain_type = ? AND domain_id = ?", groupNames, domainType, domainID).Find(&metadata).Error
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range metadata {
+		result[metadata[i].GroupName] = &metadata[i]
+	}
+	return result, nil
+}
+
 func UpsertRoleMetadata(roleName, domainType, domainID, displayName, description string) error {
 	return UpsertRoleMetadataInTransaction(database.Conn(), roleName, domainType, domainID, displayName, description)
 }


### PR DESCRIPTION
## Summary
ListGroups and ListUsers rebuilt a casbin enforcer for every group or role.
Both pages then got slower as the organization grew.
This change loads all groups and users with one enforcer each.
Group metadata loads in one query.
Output stays the same.
## Test plan
- [x] Run `make test PKG_TEST_PACKAGES="./pkg/authorization ./pkg/grpc/actions/auth"`.
- [x] Confirm the two parity tests pass.