### PR TITLE
feat: Add verification PRDs and Storybook designs

### DIFF
--- a/docs/prd/code-quality-pack.md
+++ b/docs/prd/code-quality-pack.md
@@ -1,0 +1,165 @@
+# Code quality pack
+
+## Overview
+
+This PRD specifies a **prebuilt pack of quality templates**: installable
+canvases, one per quality domain, plus a **preset line** ("Verified delivery")
+that composes them with the verification layer from
+[line-verification.md](line-verification.md). The pack gives a new factory a
+working quality workflow in one install, instead of every team building the
+same checks by hand.
+
+This document is a specification. It does not add templates to
+`templates/manifest.json` or ship any canvas. The companion Storybook designs
+(`web_src/src/pages/factories/quality-pack/`) show the install experience.
+
+## Problem Statement
+
+The verification layer defines *how* checks run, but every organization would
+still start from an empty rule set and empty suites. The checks most teams
+want are the same six: type safety, test coverage, secrets, dead code, file
+size, dependencies. Building each one requires knowledge of agent components,
+runner components, prompt design, and result plumbing — exactly the setup cost
+templates exist to remove.
+
+SuperPlane already distributes installable apps through
+`templates/manifest.json` (Preview Envs, Auto Merge Bot, Semantic PRs, and
+others), each with optional `agentSuggestions` and a `console.yaml`. The
+quality pack follows this proven path.
+
+## Goals
+
+1. Ship six quality templates, one canvas per domain, each usable standalone
+   or as a check inside a verification suite.
+2. Ship a **preset line** definition, "Verified delivery": Build → Verify →
+   Approval → Close.
+3. Ship a default **rule set** the templates reference, so install produces a
+   working configuration without manual rule authoring.
+4. Package the review instructions as **skill files** (one `SKILL.md`-style
+   asset per domain), following
+   [ai-agent-component-skill-awareness.md](ai-agent-component-skill-awareness.md).
+5. Give each template a `console.yaml` with quality scorecards so results are
+   visible immediately after install.
+
+## Non-Goals
+
+- No new template distribution mechanism; the pack uses
+  `templates/manifest.json` as is.
+- No language-specific tooling beyond what runner components already execute;
+  command steps call the repository's own build, test, and lint commands.
+- No auto-installation into existing factories; installing the pack is always
+  a user action.
+- No marketplace or paid distribution concerns.
+
+## The six templates
+
+Each template is one canvas with the same shape: trigger → scan → parallel
+agent checks per concern → deterministic verify → findings and report emit.
+
+| Template | Domain | Agent checks (parallel) | Deterministic verify |
+| --- | --- | --- | --- |
+| Type Safety Review | type safety | untyped values; unsafe casts; missing narrowing | type check command (for example `tsc --noEmit`) |
+| Test Coverage Review | tests | coverage gaps; weak assertions; test hygiene | test run command |
+| Secret Scan | secrets | source scan; configuration files; history scan | secret scanner command |
+| Dead Code Review | dead code | unused exports; orphaned files; stale annotations | build command |
+| File Size Review | file size | oversized files; multi-responsibility modules | line count report command |
+| Dependency Audit | dependencies | unused packages; single-use packages | vulnerability audit command |
+
+Template shape in detail:
+
+1. **Trigger** — an `onRun` trigger so the canvas works as a factory app and
+   as a `verify`-step check; plus optional `schedule` and `webhook` triggers
+   for standalone use.
+2. **Scan** — a runner step that enumerates the changed files (from the work
+   order's branch or pull request artifact) and groups them per concern.
+3. **Agent checks** — parallel agent component steps (for example
+   `claude.runcodeagent`), each scoped to one concern, with the domain skill
+   file and the relevant rules injected. Output is a structured finding list.
+4. **Deterministic verify** — a runner step that executes the domain's
+   command. Its result is authoritative, per
+   [line-verification.md](line-verification.md).
+5. **Emit** — a step that records findings and a run summary (counts by
+   severity) as the canvas output, so a verification step or a console can
+   consume them.
+
+## Skill assets
+
+Each domain ships one skill file with the review instructions: what to look
+for, how to classify severity, the required finding format (rule, location,
+description, remediation), and explicit out-of-scope notes. Skill files use
+plain, neutral language and follow the repository's Simplified Technical
+English style. They live with the template assets and are injected into agent
+checks at run time, per
+[ai-agent-component-skill-awareness.md](ai-agent-component-skill-awareness.md).
+
+## Preset line: Verified delivery
+
+A factory preset installable together with the pack:
+
+```yaml
+name: verified-delivery
+steps:
+  - name: build
+    type: runApp
+    app: { app: "<build-canvas>", entrypoint: "on-run" }
+  - name: verify
+    type: verify
+    suite: quality-pack-default
+    ruleSet: quality-pack-default
+  - name: approval
+    type: runApp
+    app: { app: "<approval-canvas>", entrypoint: "on-run" }
+  - name: close
+    type: runApp
+    app: { app: "<close-canvas>", entrypoint: "on-run" }
+```
+
+The `verify` step references the pack's default suite, which contains the six
+templates as checks. The approval step reuses the existing `approval`
+component. The close step reuses `updateWorkOrderStatus`.
+
+## Distribution
+
+- One manifest entry per template in `templates/manifest.json`, following the
+  existing entry shape, each with:
+  - `agentSuggestions`: "Connect your repository." and "Adjust the rule set
+    for this project."
+  - `console.yaml`: a scorecard for findings by severity and a table of the
+    latest runs.
+- The pack's default rule set and suite install with the first template and
+  are shared by the rest.
+- Install order does not matter; each template is independently usable.
+
+## UX walkthrough
+
+The Storybook designs under `web_src/src/pages/factories/quality-pack/` define
+the visual contract:
+
+- **`QualityTemplateGallery`** — one card per template: name, domain, what it
+  checks, and the number of checks per run. Cards follow the existing canvas
+  card patterns. The primary action is "Install template".
+- **`PresetLinePreview`** — the install-time preview of the Verified delivery
+  line: its four steps in order, with the verification step expanded to show
+  the six checks it runs. Helper text: "This will not start a run yet."
+
+## Acceptance Criteria (for the eventual implementation)
+
+1. Installing any single template yields a canvas that runs standalone from
+   its triggers and emits findings in the standard format.
+2. Installing the pack yields the default rule set, the default suite, and
+   the Verified delivery line preset.
+3. A work order dispatched through Verified delivery is gated by the six
+   checks with the semantics of
+   [line-verification.md](line-verification.md).
+4. Each template's console shows findings by severity after the first run.
+5. Skill files contain the finding format contract, and agent checks return
+   findings in that format.
+
+## Open Questions
+
+- Do we pin repository commands (build, test, lint) per template
+  configuration, or read them from a repository manifest file?
+- Should the pack install one combined "quality" canvas as an alternative to
+  six separate templates for small teams?
+- Which additional domains follow the initial six (naming, observability,
+  accessibility) and in what order?

--- a/docs/prd/codebase-health.md
+++ b/docs/prd/codebase-health.md
@@ -1,0 +1,184 @@
+# Codebase health
+
+## Overview
+
+This PRD specifies **Codebase Health**: a factory-level surface that
+aggregates verification findings over time into a **health score**,
+**streaks**, **recurring patterns**, and **achievements**, plus a structured
+**run summary report** per verification run. The goal is sustained engagement
+with code quality: teams see progress, not only failures.
+
+This document is a specification. It does not ship backend or application
+code. The companion Storybook designs
+(`web_src/src/pages/factories/health/`) show the intended UI. It consumes the
+findings defined in [line-verification.md](line-verification.md) and the
+aggregation defined in
+[verification-suggestions.md](verification-suggestions.md).
+
+## Problem Statement
+
+Verification produces a stream of pass/fail results and findings. Streams are
+easy to ignore. Without an aggregate view, a team cannot answer basic
+questions: is quality improving, which problems repeat, which repositories
+need attention, and did last month's cleanup hold.
+
+Progress that is visible gets sustained. A score with a trend, a streak that
+a failing run would break, and named recurring problems with a clear path to
+zero give teams a reason to keep verification green — and give leads a
+truthful summary instead of anecdotes.
+
+SuperPlane already renders exactly the right primitives: console scorecard
+panels with value, change chip, sparkline, and target
+([console-and-widgets.md](console-and-widgets.md)). Codebase Health reuses
+this visual language at the factory level.
+
+## Goals
+
+1. Compute a **health score** per factory (and per repository where the
+   factory spans several) from severity-weighted findings over time, with
+   trend and target.
+2. Track **streaks**: consecutive work orders and consecutive days with zero
+   new blocking findings.
+3. Name **recurring patterns**: repeated finding groups presented as cards
+   with plain descriptions, top offender files, common cause, and standard
+   remediation.
+4. Award **achievements** for meaningful milestones, with descriptive names
+   that state the accomplishment directly.
+5. Emit a **run summary report** after each verification run: findings
+   detected, fixed, and remaining, by severity; postable to Slack through the
+   existing integration.
+
+## Non-Goals
+
+- No individual-person scoring in v1. Scores, streaks, and achievements
+  attach to factories, lines, and repositories, not to people. The optional
+  team leaderboard compares factories or lines only.
+- No paging or alerting; the run summary report is informational.
+- No external gamification integrations.
+- No changes to how findings are produced; this PRD is read-side only.
+
+## Concepts
+
+### Health score
+
+A number from 0 to 100 per factory, recomputed per verification run:
+
+- Start from 100; subtract weighted open findings (`high` > `medium` >
+  `low`), normalized by the volume of verified work so large factories are
+  comparable to small ones.
+- Blocking findings weigh more than advisory findings at equal severity.
+- The score carries a trend (versus the previous period) and an optional
+  target the team sets.
+
+The exact formula is an implementation decision; the contract is: fixing
+findings raises the score, new findings lower it, and severity orders the
+impact.
+
+### Streaks
+
+Two counters per factory:
+
+- **Work order streak** — consecutive work orders whose verification passed
+  with zero new blocking findings.
+- **Daily streak** — consecutive days with at least one verification run and
+  zero new blocking findings.
+
+A qualifying failure resets the counter. Days without runs pause, not reset,
+the daily streak.
+
+### Recurring patterns
+
+A recurring pattern is a named group of findings that repeat: same rule,
+similar locations, across runs and work orders (grouping from
+[verification-suggestions.md](verification-suggestions.md)). A pattern card
+shows:
+
+- A plain, descriptive name (for example "Untyped API response handling").
+- What it is and why it recurs, in one or two sentences.
+- Top offender files with occurrence counts.
+- The standard remediation.
+- An occurrence trend.
+
+Reducing a pattern's open count to zero completes it and awards an
+achievement.
+
+### Achievements
+
+Milestone records with descriptive names that state the fact:
+
+- "First verification passed"
+- "30 days without a type-safety finding"
+- "Zero secrets findings for 90 days"
+- "Recurring pattern resolved: <pattern name>"
+
+Achievements are permanent once earned; a later regression does not remove
+one, but the same achievement can be earned again after the streak rebuilds.
+An optional leaderboard compares factories or lines on score and streaks;
+it is off by default.
+
+### Run summary report
+
+A structured summary attached to the work order after each verification run:
+
+| Field | Meaning |
+| --- | --- |
+| `detected` | New findings this run, by severity. |
+| `fixed` | Previously open findings no longer reported, by severity. |
+| `remaining` | Open findings after this run, by severity. |
+| `gate` | Passed or failed, with the blocking finding count. |
+
+The report renders on the work order timeline and can post to a Slack channel
+through the existing Slack integration.
+
+## UX walkthrough
+
+The Storybook designs under `web_src/src/pages/factories/health/` define the
+visual contract:
+
+- **`FactoryHealthPage`** — the full Health tab: score, streaks, patterns,
+  and achievements composed in the style of the existing factory Overview
+  page.
+- **`HealthScoreCard`** — reuses the console scorecard visual language:
+  value, trend chip, sparkline, target.
+- **`StreakIndicator`** — the two streaks with their current counts and best
+  values.
+- **`AchievementsGrid`** — earned and not-yet-earned achievements;
+  not-yet-earned entries show what remains to earn them.
+- **`RecurringPatternCard`** — the pattern contract above, with a link to the
+  matching recurring suggestions.
+- **`RunSummaryReportCard`** — the report as it renders on a work order and
+  as a Slack message preview.
+
+## Future backend surface (specification only)
+
+Recorded for a later implementation phase; nothing here is built now.
+
+- **Aggregation**: a worker that folds verification runs into per-factory
+  daily health snapshots, streak counters, pattern groups, and achievement
+  records; append-only, recomputable from findings.
+- **Models**: `HealthSnapshot`, `Achievement`, and pattern aggregates in
+  `pkg/models`.
+- **APIs**: read-only endpoints for the Health tab; registered in
+  `pkg/authorization/interceptor.go` under factory read permissions.
+- **Slack**: run summary posting composes the existing Slack integration
+  components; no new integration surface.
+
+## Acceptance Criteria (for the eventual implementation)
+
+1. The health score updates after each verification run and moves in the
+   documented direction for fixed and new findings.
+2. Streaks increment, pause, and reset per the rules above.
+3. A pattern card appears when a finding group repeats across runs, and
+   completes when its open count reaches zero.
+4. Achievements are awarded exactly once per qualifying event and persist.
+5. The run summary report matches the run's findings and posts to Slack when
+   configured.
+
+## Open Questions
+
+- What period does the score trend compare against — previous week, previous
+  30 days, or configurable?
+- Are pattern names authored by an agent, by users, or generated from the
+  rule name plus location group?
+- Should the leaderboard be visible to all members or only to factory
+  admins?

--- a/docs/prd/line-verification.md
+++ b/docs/prd/line-verification.md
@@ -1,0 +1,199 @@
+# Line verification steps
+
+## Overview
+
+This PRD describes a **verification layer** for factory lines: a new line step
+type, `verify`, that inspects the output of a work order (branch, pull request,
+artifacts) before the line advances. A verification step runs a **verification
+suite** — a set of parallel **checks** driven by an org-scoped **rule set** —
+and records **findings**. Blocking findings stop the line; advisory findings
+pass but stay visible.
+
+This document is a specification. It does not ship backend or application code.
+The companion Storybook designs (`web_src/src/pages/factories/verification/`)
+show the intended UI. Related PRDs:
+
+- [verification-suggestions.md](verification-suggestions.md) — findings become
+  actionable suggestions with a dispatch-fix flow.
+- [code-quality-pack.md](code-quality-pack.md) — prebuilt quality templates
+  that use this layer.
+- [codebase-health.md](codebase-health.md) — aggregation of findings into a
+  health surface.
+
+## Problem Statement
+
+A factory line advances a work order when a step's canvas run passes
+(`docs/design/factory.md`). The run result is the only gate. Nothing inspects
+the produced work itself — the branch, the pull request, or the artifacts —
+against the organization's quality standards.
+
+Teams that run AI agents inside lines feel this gap most. An agent can produce
+a pull request that builds and still violates the rules the team cares about:
+untyped code, missing tests, committed secrets, dead code, oversized files,
+unjustified dependencies. Today the only options are a human review step or a
+custom canvas that each team must build and maintain by hand.
+
+We want verification to be a first-class line concept: declarative, reusable
+across lines, visible on the work order, and safe to trust because
+deterministic checks — not model output — make the final call.
+
+## Goals
+
+1. Add a `verify` step type to factory lines, next to `runApp`, that gates
+   line progression on verification results.
+2. Define **rule sets** as org-scoped resources: named rules grouped by
+   domain, each with a severity and a blocking or advisory enforcement level.
+3. Define **verification suites**: which checks run for a step, in parallel,
+   and which rule set governs them.
+4. Record **findings** as first-class data: rule, severity, location,
+   description, remediation, and a reviewable status.
+5. Keep deterministic checks authoritative: an AI review check alone never
+   fails or passes a work order.
+
+## Non-Goals
+
+- No changes to the `runApp` step type or to canvas run semantics.
+- No automatic fixing in this PRD; the fix loop is specified in
+  [verification-suggestions.md](verification-suggestions.md).
+- No cross-work-order aggregation; that is
+  [codebase-health.md](codebase-health.md).
+- No new agent runtime. Checks run on the existing component executions
+  (`claude.runcodeagent`, `cursor.launchAgent`, `pkg/components/runner/`).
+- No repository-hosting features. Verification reads the work order's
+  artifacts (branch, pull request) through existing integrations.
+
+## Concepts
+
+### Rule set
+
+An org-scoped resource. A rule set groups **rules** by **domain**. The initial
+domains match the quality pack: type safety, tests, secrets, dead code, file
+size, dependencies. A rule has:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable identifier, unique in the rule set (e.g. `type-safety/no-untyped-values`). |
+| `name` | Short human name shown in UI and findings. |
+| `domain` | Grouping key; one of the supported domains. |
+| `description` | What the rule requires, in one or two sentences. |
+| `severity` | `high`, `medium`, or `low`. Drives finding display and health weighting. |
+| `enforcement` | `blocking` or `advisory`. Blocking findings fail the verification step. |
+
+Rule sets are editable in the UI and as YAML. An organization can hold several
+rule sets (for example, one strict set for production repositories and one
+lighter set for prototypes).
+
+### Verification suite
+
+A named selection of **checks** bound to one rule set. A check is either:
+
+- **Agent check** — an AI review scoped to one domain. The check runs as an
+  agent component execution with the rule set's rules for that domain injected
+  as the prompt or skill. Output is a list of candidate findings.
+- **Command check** — a deterministic command (build, type check, linter,
+  test run, secret scanner) executed by a runner component. Output is
+  pass/fail plus parsed findings when the tool reports locations.
+
+Checks in a suite run **in parallel**. A suite declares, per check, whether
+its findings can block (the check-level flag combines with the rule-level
+`enforcement`; both must be blocking for a finding to block).
+
+### Verification run and findings
+
+One execution of a suite for one work order produces a **verification run**
+with per-check outcomes and a list of **findings**:
+
+| Field | Meaning |
+| --- | --- |
+| `rule` | Rule id the finding violates. |
+| `severity` | Copied from the rule at detection time. |
+| `location` | File path plus line range when available; empty for repo-level findings. |
+| `description` | What is wrong, specific to this occurrence. |
+| `remediation` | Concrete steps to fix this occurrence. |
+| `status` | `open`, `fixed`, `dismissed`, or `accepted`. |
+
+`fixed` is set when a later verification run no longer reports the finding.
+`dismissed` marks a false positive. `accepted` records a conscious exception;
+accepted findings never block again for the same location and rule.
+
+### Gate semantics
+
+- A verification step **fails** when the run finishes with one or more open
+  blocking findings, or when any command check marked as required fails.
+- A failed step stops the line; the work order stays `open`, matching the
+  current dispatch flow.
+- Advisory findings never fail the step. They are recorded and surfaced.
+- Agent checks alone cannot pass a step that a command check failed.
+  Deterministic results always win.
+
+## Line definition (conceptual)
+
+```yaml
+name: bug
+steps:
+  - name: implement
+    type: runApp
+    app: { app: "<canvas-uuid>", entrypoint: "start-work" }
+  - name: verify
+    type: verify
+    suite: default-quality
+    ruleSet: production
+  - name: review
+    type: runApp
+    app: { app: "<canvas-uuid>", entrypoint: "request-approval" }
+```
+
+## UX walkthrough
+
+The Storybook designs under `web_src/src/pages/factories/verification/` define
+the visual contract:
+
+- **`LineStepTypeEditor`** — the line editor step card gains a step type
+  choice (`Run app` / `Verify`). Selecting `Verify` shows a suite picker, the
+  governing rule set, and a per-check blocking/advisory toggle.
+- **`RuleSetEditor`** — rules grouped by domain with severity and enforcement
+  controls, plus a YAML preview pane. Empty state guides the first rule set.
+- **`WorkOrderVerificationPanel`** — on the work order detail: run status
+  (running, passed, failed), per-check outcomes, and findings grouped by
+  severity. Command check results are visually distinct from agent review
+  results.
+- **`VerificationStatusBadge`** and **`CheckOutcomeChip`** — status
+  primitives consistent with the existing run status badge.
+
+## Future backend surface (specification only)
+
+Recorded for a later implementation phase; nothing here is built now.
+
+- **Models**: `RuleSet`, `VerificationSuite`, `VerificationRun`, `Finding` in
+  `pkg/models`, following the explicit `*gorm.DB` parameter pattern.
+- **Protos**: rule set and suite CRUD plus verification run read APIs in a new
+  `protos/verifications.proto`; enums mapped to `pkg/models` constants.
+- **Step type**: extend the line step JSON (`factory_lines`) with
+  `type: verify`, `suite`, and `ruleSet` references; the dispatch worker
+  starts a verification run instead of a canvas run for these steps.
+- **Execution**: reuse component executions for checks; a finalizer collects
+  check outcomes, computes the gate result, and marks the execution
+  passed/failed so existing line advancement applies unchanged.
+- **Authorization**: new endpoints registered in
+  `pkg/authorization/interceptor.go`; rule sets under a `rule_sets` resource,
+  runs readable with `work_orders:read`.
+
+## Acceptance Criteria (for the eventual implementation)
+
+1. A line can declare a `verify` step; dispatching a work order through it
+   runs the suite and gates advancement on the result.
+2. Open blocking findings fail the step; advisory findings do not.
+3. A failed required command check fails the step even when agent checks
+   report no findings.
+4. Findings persist with rule, severity, location, description, remediation,
+   and status, and are visible on the work order.
+5. Accepted findings do not block subsequent runs for the same rule and
+   location.
+
+## Open Questions
+
+- Should a suite support per-repository overrides, or is one rule set per
+  step enough for v1?
+- Do we need a manual "re-run verification" action on the work order, or is
+  re-dispatching the line sufficient?
+- How long do verification runs and findings stay queryable before archival?

--- a/docs/prd/verification-suggestions.md
+++ b/docs/prd/verification-suggestions.md
@@ -1,0 +1,149 @@
+# Verification suggestions and dispatch fix
+
+## Overview
+
+This PRD turns verification **findings** into actionable **suggestions**. A
+suggestion pairs a finding with its exact location, concrete remediation
+steps, and a ready-to-run fix prompt. From a suggestion, one action —
+**Dispatch fix** — creates a fix work order on a designated line or starts an
+agent run directly.
+
+This document is a specification. It does not ship backend or application
+code. The companion Storybook designs
+(`web_src/src/pages/factories/verification/`) show the intended UI. It builds
+on [line-verification.md](line-verification.md), which defines findings, and
+feeds [codebase-health.md](codebase-health.md), which aggregates them.
+
+## Problem Statement
+
+A finding that only says "this is wrong" creates review work instead of
+removing it. The reader must locate the code, decide the fix, and route the
+work by hand — create an issue, write an agent prompt, or fix it themselves.
+
+Findings from the verification layer already carry location and remediation.
+The missing piece is the loop: show open findings where people already work
+(the work order, the factory), and let one click route the fix back through
+the factory's own machinery — a work order on a line, or a direct agent run.
+
+SuperPlane already has a narrower suggestions mechanism: template-defined
+agent prompts stored per canvas (`agentSuggestions` in
+`templates/manifest.json`, dismissals persisted on
+`Canvas.DismissedAgentSuggestionIDs`). This PRD extends the same idea to
+verification results, with server-side data instead of install-time strings.
+
+## Goals
+
+1. Present every open finding as a **suggestion**: summary, exact location,
+   remediation steps, and a prepared fix prompt.
+2. Provide **Dispatch fix** with two targets: create a fix work order on a
+   designated line, or start an agent run with the remediation prompt.
+3. Surface suggestions on the **work order detail** (findings from that
+   order's verification runs) and at the **factory level** (open suggestions
+   across work orders).
+4. Aggregate repeated suggestions into **recurring patterns** for
+   [codebase-health.md](codebase-health.md).
+5. Keep suggestion status in sync with finding status: fixing, dismissing, or
+   accepting a finding resolves its suggestion.
+
+## Non-Goals
+
+- No fully automatic fixing without a human action in v1. Dispatch fix is
+  always user-initiated.
+- No replacement of the template `agentSuggestions` mechanism; the two
+  coexist.
+- No suggestion authoring UI. Suggestions derive from findings only.
+- No notification channels in v1 (email, Slack pushes); the run summary
+  report in [codebase-health.md](codebase-health.md) covers reporting.
+
+## Concepts
+
+### Suggestion
+
+A read model over an open finding:
+
+| Field | Meaning |
+| --- | --- |
+| `finding` | The underlying finding (rule, severity, location, description, remediation, status). |
+| `fixPrompt` | Prepared agent instruction: the remediation steps plus location context, ready to dispatch. |
+| `sourceWorkOrder` | The work order whose verification run produced the finding. |
+| `occurrences` | Count of matching findings across runs (same rule and location group). |
+
+A suggestion is **open** while its finding is `open`. It resolves when the
+finding becomes `fixed`, `dismissed`, or `accepted`.
+
+### Dispatch fix
+
+One primary action with a target choice:
+
+- **Fix work order** — creates a `draft` work order titled from the
+  suggestion, with the fix prompt as description, and offers dispatch to a
+  designated fix line. This reuses the existing work order creation and
+  dispatch flow unchanged.
+- **Agent run** — starts an agent component run (for example
+  `claude.runcodeagent` or `cursor.launchAgent`) with the fix prompt, without
+  creating a work order. Suited to small, local fixes.
+
+Both targets record the dispatch on the suggestion, so repeated dispatches
+are visible and a suggestion under fix shows "Fix in progress".
+
+### Recurring suggestions
+
+The factory-level view groups suggestions by rule and location pattern and
+tracks count, trend, and last-seen time. This grouping is the input for the
+recurring patterns surface in [codebase-health.md](codebase-health.md).
+
+## UX walkthrough
+
+The Storybook designs under `web_src/src/pages/factories/verification/` define
+the visual contract:
+
+- **`SuggestionCard`** — finding summary, severity, exact location,
+  remediation steps, and the primary **Dispatch fix** action with a target
+  choice (fix work order or agent run). Secondary actions: **Dismiss** and
+  **Accept**. Helper text under the primary action states the outcome, for
+  example "This creates a draft work order. You choose when to dispatch it."
+- **`WorkOrderSuggestionsList`** — open suggestions on the work order detail
+  layout, with filters by severity and domain, and an empty state that
+  confirms a clean verification run.
+- **`RecurringSuggestionsTable`** — factory-level aggregation: pattern, rule,
+  count, trend, last seen; each row links to the pattern card defined in
+  [codebase-health.md](codebase-health.md).
+
+## Future backend surface (specification only)
+
+Recorded for a later implementation phase; nothing here is built now.
+
+- **Read APIs**: list suggestions per work order and per factory, derived
+  from findings; no separate suggestion table required in v1 beyond dispatch
+  records.
+- **Dispatch records**: a small model linking a finding to the fix work order
+  or agent run it spawned, so status can render "Fix in progress" and later
+  "Fixed by <work order>".
+- **Actions**: dismiss and accept mutate the finding status defined in
+  [line-verification.md](line-verification.md); dispatch-fix composes the
+  existing `createWorkOrder`, dispatch, and agent-run paths.
+- **Authorization**: suggestions readable with `work_orders:read`; dispatch
+  fix requires `work_orders:create` (work order target) or the existing
+  canvas-run permission (agent target).
+
+## Acceptance Criteria (for the eventual implementation)
+
+1. Every open finding appears as exactly one suggestion on its work order.
+2. Dispatch fix to a work order creates a `draft` order with the fix prompt
+   as description and links it back to the suggestion.
+3. Dispatch fix to an agent run starts the run with the fix prompt and links
+   it back to the suggestion.
+4. Dismiss and accept update the finding status and resolve the suggestion.
+5. A verification run that no longer reports a finding resolves its
+   suggestion as fixed.
+6. The factory-level view groups suggestions by rule and location pattern
+   with correct counts.
+
+## Open Questions
+
+- Should dispatch fix support batching (one work order for many suggestions
+  of the same rule), or is one-to-one enough for v1?
+- Who may accept a finding — any member with `work_orders:update`, or a
+  narrower reviewer role?
+- Should the agent-run target be limited to organizations with AI features
+  enabled, mirroring the AI Builder policy?

--- a/web_src/src/pages/factories/health/AchievementsGrid.stories.tsx
+++ b/web_src/src/pages/factories/health/AchievementsGrid.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+import { ACHIEVEMENTS } from "@/pages/factories/verification/__fixtures__/verificationFixtures";
+
+import { AchievementsGrid } from "./AchievementsGrid";
+
+/**
+ * Earned and not-yet-earned achievements with descriptive milestone names.
+ * Not-yet-earned entries show what remains to earn them.
+ */
+const meta = {
+  title: "Factories/Health/AchievementsGrid",
+  component: AchievementsGrid,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[360px] max-w-5xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof AchievementsGrid>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A mix of earned and not-yet-earned achievements. */
+export const Default: Story = {
+  args: { achievements: ACHIEVEMENTS },
+};

--- a/web_src/src/pages/factories/health/AchievementsGrid.tsx
+++ b/web_src/src/pages/factories/health/AchievementsGrid.tsx
@@ -1,0 +1,68 @@
+import { Award, Lock } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import { Timestamp } from "@/components/Timestamp";
+import type { Achievement } from "@/pages/factories/verification/types";
+
+interface AchievementsGridProps {
+  achievements: Achievement[];
+}
+
+/**
+ * Earned and not-yet-earned achievements. Not-yet-earned entries show what
+ * remains to earn them.
+ */
+export function AchievementsGrid({ achievements }: AchievementsGridProps) {
+  return (
+    <section className="flex flex-col gap-3" aria-label="Achievements">
+      <div className="flex flex-col gap-0.5">
+        <h3 className="workspace-section-title text-foreground">Achievements</h3>
+        <p className="text-[12px] text-muted-foreground">
+          Milestones this factory earned. A later regression does not remove an earned achievement.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {achievements.map((achievement) => (
+          <AchievementTile key={achievement.id} achievement={achievement} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AchievementTile({ achievement }: { achievement: Achievement }) {
+  const earned = achievement.earnedAt != null;
+  return (
+    <article
+      className={cn(factoryCardClassName, "flex flex-col gap-2 p-4", !earned && "opacity-80")}
+      aria-label={achievement.name}
+    >
+      <div className="flex items-start gap-2.5">
+        <span
+          className={cn(
+            "flex size-9 shrink-0 items-center justify-center rounded-full border",
+            earned
+              ? "border-amber-200 bg-amber-50 text-amber-600 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-400"
+              : "border-border bg-background text-muted-foreground",
+          )}
+        >
+          {earned ? <Award className="size-4.5" aria-hidden /> : <Lock className="size-4" aria-hidden />}
+        </span>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-[13px] font-medium text-foreground">{achievement.name}</span>
+          <p className="text-[12px] text-muted-foreground">{achievement.description}</p>
+        </div>
+      </div>
+      <p className="border-t border-border pt-2 text-[12px] text-muted-foreground">
+        {earned && achievement.earnedAt ? (
+          <>
+            Earned <Timestamp date={achievement.earnedAt} display="relative" />
+          </>
+        ) : (
+          (achievement.progressNote ?? "Not earned yet.")
+        )}
+      </p>
+    </article>
+  );
+}

--- a/web_src/src/pages/factories/health/FactoryHealthPage.stories.tsx
+++ b/web_src/src/pages/factories/health/FactoryHealthPage.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+import {
+  ACHIEVEMENTS,
+  HEALTH_SNAPSHOT,
+  RECURRING_PATTERNS,
+  RUN_SUMMARY_FAILED,
+  STREAKS,
+} from "@/pages/factories/verification/__fixtures__/verificationFixtures";
+
+import { FactoryHealthPage } from "./FactoryHealthPage";
+
+/**
+ * The full Health tab for a factory: score, streaks, recurring patterns,
+ * achievements, and the latest run summary.
+ */
+const meta = {
+  title: "Factories/Health/FactoryHealthPage",
+  component: FactoryHealthPage,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-screen w-full">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+  args: {
+    onViewSuggestions: (patternId) => console.log("view suggestions", patternId),
+  },
+} satisfies Meta<typeof FactoryHealthPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A factory with an improving score and active streaks. */
+export const Default: Story = {
+  args: {
+    factoryName: "Shipping",
+    snapshot: HEALTH_SNAPSHOT,
+    streaks: STREAKS,
+    patterns: RECURRING_PATTERNS,
+    achievements: ACHIEVEMENTS,
+    latestReport: RUN_SUMMARY_FAILED,
+  },
+};

--- a/web_src/src/pages/factories/health/FactoryHealthPage.tsx
+++ b/web_src/src/pages/factories/health/FactoryHealthPage.tsx
@@ -1,0 +1,90 @@
+import {
+  factoryContentBodyClassName,
+  factoryContentHeaderClassName,
+  factoryPageSubtitleClassName,
+  factoryPageTitleClassName,
+} from "@/pages/factories/pages/factoryPageLayoutStyles";
+import type {
+  Achievement,
+  HealthSnapshot,
+  RecurringPattern,
+  RunSummaryReport,
+  Streak,
+} from "@/pages/factories/verification/types";
+
+import { AchievementsGrid } from "./AchievementsGrid";
+import { HealthScoreCard } from "./HealthScoreCard";
+import { RecurringPatternCard } from "./RecurringPatternCard";
+import { RunSummaryReportCard } from "./RunSummaryReportCard";
+import { StreakIndicator } from "./StreakIndicator";
+
+interface FactoryHealthPageProps {
+  factoryName: string;
+  snapshot: HealthSnapshot;
+  streaks: Streak[];
+  patterns: RecurringPattern[];
+  achievements: Achievement[];
+  latestReport: RunSummaryReport;
+  onViewSuggestions: (patternId: string) => void;
+}
+
+/**
+ * The Health tab for a factory: score, streaks, recurring patterns,
+ * achievements, and the latest run summary, composed in the workspace page
+ * layout.
+ */
+export function FactoryHealthPage({
+  factoryName,
+  snapshot,
+  streaks,
+  patterns,
+  achievements,
+  latestReport,
+  onViewSuggestions,
+}: FactoryHealthPageProps) {
+  return (
+    <div className="min-h-screen bg-background">
+      <header className={factoryContentHeaderClassName}>
+        <h1 className={factoryPageTitleClassName}>Health</h1>
+        <p className={factoryPageSubtitleClassName}>
+          Verification results for {factoryName}, aggregated over time. Fixing findings raises the score.
+        </p>
+      </header>
+
+      <main className={factoryContentBodyClassName}>
+        <div className="flex flex-col gap-6">
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,2fr)]">
+            <HealthScoreCard label="Health score" snapshot={snapshot} />
+            <StreakIndicator streaks={streaks} />
+          </div>
+
+          <section className="flex flex-col gap-3" aria-label="Recurring patterns">
+            <div className="flex flex-col gap-0.5">
+              <h3 className="workspace-section-title text-foreground">Recurring patterns</h3>
+              <p className="text-[12px] text-muted-foreground">
+                Findings that repeat across work orders. Reduce a pattern to zero to complete it.
+              </p>
+            </div>
+            <div className="grid gap-3 lg:grid-cols-2">
+              {patterns.map((pattern) => (
+                <RecurringPatternCard key={pattern.id} pattern={pattern} onViewSuggestions={onViewSuggestions} />
+              ))}
+            </div>
+          </section>
+
+          <AchievementsGrid achievements={achievements} />
+
+          <section className="flex flex-col gap-3" aria-label="Latest verification summary">
+            <div className="flex flex-col gap-0.5">
+              <h3 className="workspace-section-title text-foreground">Latest verification summary</h3>
+              <p className="text-[12px] text-muted-foreground">
+                The same summary posts to Slack when a channel is configured.
+              </p>
+            </div>
+            <RunSummaryReportCard report={latestReport} />
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/health/HealthScoreCard.stories.tsx
+++ b/web_src/src/pages/factories/health/HealthScoreCard.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+import { HEALTH_SNAPSHOT } from "@/pages/factories/verification/__fixtures__/verificationFixtures";
+
+import { HealthScoreCard } from "./HealthScoreCard";
+
+/**
+ * Health score in the console scorecard visual language: status dot, large
+ * value, change chip, sparkline, and progress toward the target.
+ */
+const meta = {
+  title: "Factories/Health/HealthScoreCard",
+  component: HealthScoreCard,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[220px] max-w-sm bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof HealthScoreCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Score improving toward the target. */
+export const Improving: Story = {
+  args: { label: "Health score", snapshot: HEALTH_SNAPSHOT },
+};
+
+/** Score declining after new blocking findings. */
+export const Declining: Story = {
+  args: {
+    label: "Health score",
+    snapshot: { score: 64, change: -9, target: 90, series: [82, 80, 79, 76, 73, 70, 68, 64] },
+  },
+};
+
+/** No target set: the progress bar is hidden. */
+export const WithoutTarget: Story = {
+  args: {
+    label: "Health score",
+    snapshot: { score: 77, change: 0, series: [74, 75, 77, 76, 77, 77] },
+  },
+};

--- a/web_src/src/pages/factories/health/HealthScoreCard.tsx
+++ b/web_src/src/pages/factories/health/HealthScoreCard.tsx
@@ -1,0 +1,74 @@
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import { Sparkline } from "@/pages/app/console/widget/Sparkline";
+import type { HealthSnapshot } from "@/pages/factories/verification/types";
+
+interface HealthScoreCardProps {
+  label: string;
+  snapshot: HealthSnapshot;
+}
+
+/**
+ * Health score in the console scorecard visual language: status dot, large
+ * value, change chip, sparkline, and progress toward the target.
+ */
+export function HealthScoreCard({ label, snapshot }: HealthScoreCardProps) {
+  const improving = snapshot.change > 0;
+  const declining = snapshot.change < 0;
+  const statusDotClass = improving
+    ? "bg-emerald-500 dark:bg-emerald-400"
+    : declining
+      ? "bg-red-500 dark:bg-red-400"
+      : "bg-slate-400 dark:bg-gray-500";
+  const changeTextClass = improving
+    ? "text-emerald-600 dark:text-emerald-400"
+    : declining
+      ? "text-red-600 dark:text-red-400"
+      : "text-slate-500 dark:text-gray-400";
+  const sparklineClass = improving
+    ? "text-emerald-500 dark:text-emerald-400"
+    : declining
+      ? "text-red-500 dark:text-red-400"
+      : "text-slate-400 dark:text-gray-500";
+  const ChangeIcon = improving ? ArrowUpRight : ArrowDownRight;
+  const progressPercent =
+    snapshot.target && snapshot.target > 0 ? Math.min(100, (snapshot.score / snapshot.target) * 100) : null;
+
+  return (
+    <div className={cn(factoryCardClassName, "flex flex-col items-start justify-center gap-2 p-4")}>
+      <div className="flex items-center gap-2">
+        <span className={cn("inline-block h-2 w-2 rounded-full", statusDotClass)} aria-hidden />
+        <span className="text-[12px] font-medium uppercase tracking-wide text-muted-foreground">{label}</span>
+      </div>
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <div className="flex items-baseline gap-0.5">
+          <span className="text-4xl font-medium text-slate-900 dark:text-gray-100">{snapshot.score}</span>
+          <span className="text-xl font-semibold text-slate-900 dark:text-gray-100">/100</span>
+        </div>
+        {snapshot.change !== 0 ? (
+          <span className={cn("inline-flex items-center gap-1 text-sm font-medium tabular-nums", changeTextClass)}>
+            <ChangeIcon className="size-4" aria-hidden />
+            {improving ? "+" : ""}
+            {snapshot.change}
+          </span>
+        ) : null}
+      </div>
+      {snapshot.series.length > 1 ? <Sparkline values={snapshot.series} className={sparklineClass} /> : null}
+      {progressPercent != null ? (
+        <div className="flex w-full flex-col gap-1">
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-gray-700" aria-hidden>
+            <div
+              className={cn("h-full rounded-full", improving ? "bg-emerald-500 dark:bg-emerald-400" : "bg-sky-500")}
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+          <span className="text-xs text-slate-500 dark:text-gray-400">
+            {Math.round(progressPercent)}% of target {snapshot.target}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/health/RecurringPatternCard.stories.tsx
+++ b/web_src/src/pages/factories/health/RecurringPatternCard.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+import { RECURRING_PATTERNS } from "@/pages/factories/verification/__fixtures__/verificationFixtures";
+
+import { RecurringPatternCard } from "./RecurringPatternCard";
+
+/**
+ * One recurring finding pattern: plain description, top offender files,
+ * standard remediation, and the occurrence trend.
+ */
+const meta = {
+  title: "Factories/Health/RecurringPatternCard",
+  component: RecurringPatternCard,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[380px] max-w-xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+  args: {
+    onViewSuggestions: (patternId) => console.log("view suggestions", patternId),
+  },
+} satisfies Meta<typeof RecurringPatternCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A pattern whose occurrence count rises. */
+export const Rising: Story = {
+  args: { pattern: RECURRING_PATTERNS[0] },
+};
+
+/** A pattern whose occurrence count falls. */
+export const Falling: Story = {
+  args: { pattern: RECURRING_PATTERNS[1] },
+};

--- a/web_src/src/pages/factories/health/RecurringPatternCard.tsx
+++ b/web_src/src/pages/factories/health/RecurringPatternCard.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import { Sparkline } from "@/pages/app/console/widget/Sparkline";
+import type { RecurringPattern } from "@/pages/factories/verification/types";
+
+interface RecurringPatternCardProps {
+  pattern: RecurringPattern;
+  onViewSuggestions: (patternId: string) => void;
+}
+
+/**
+ * One recurring finding pattern: what it is, where it concentrates, the
+ * standard fix, and how its occurrence count trends.
+ */
+export function RecurringPatternCard({ pattern, onViewSuggestions }: RecurringPatternCardProps) {
+  const rising =
+    pattern.occurrenceSeries.length > 1 &&
+    pattern.occurrenceSeries[pattern.occurrenceSeries.length - 1] > pattern.occurrenceSeries[0];
+
+  return (
+    <article className={cn(factoryCardClassName, "flex flex-col gap-3 p-4")} aria-label={pattern.name}>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-[13px] font-medium text-foreground">{pattern.name}</span>
+          <p className="text-[13px] text-muted-foreground">{pattern.description}</p>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <span className="text-2xl font-medium tabular-nums text-slate-900 dark:text-gray-100">
+            {pattern.openCount}
+          </span>
+          <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Open</span>
+        </div>
+      </div>
+
+      {pattern.occurrenceSeries.length > 1 ? (
+        <Sparkline
+          values={pattern.occurrenceSeries}
+          className={rising ? "text-red-500 dark:text-red-400" : "text-emerald-500 dark:text-emerald-400"}
+        />
+      ) : null}
+
+      <div className="rounded-md border border-border bg-background px-3 py-2">
+        <p className="workspace-section-label text-muted-foreground">Top files</p>
+        <ul className="mt-1 flex flex-col gap-1">
+          {pattern.topFiles.map((file) => (
+            <li key={file.path} className="flex items-center justify-between gap-2 text-[12px]">
+              <code className="truncate font-mono text-slate-700 dark:text-gray-300">{file.path}</code>
+              <span className="shrink-0 tabular-nums text-muted-foreground">{file.count}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <p className="text-[13px] text-muted-foreground">
+        <span className="font-medium text-foreground">Standard fix: </span>
+        {pattern.remediation}
+      </p>
+
+      <div className="border-t border-border pt-3">
+        <Button variant="outline" size="sm" onClick={() => onViewSuggestions(pattern.id)}>
+          View matching suggestions
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/web_src/src/pages/factories/health/RunSummaryReportCard.stories.tsx
+++ b/web_src/src/pages/factories/health/RunSummaryReportCard.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+import {
+  RUN_SUMMARY_FAILED,
+  RUN_SUMMARY_PASSED,
+} from "@/pages/factories/verification/__fixtures__/verificationFixtures";
+
+import { RunSummaryReportCard } from "./RunSummaryReportCard";
+
+/**
+ * Structured summary of one verification run: findings detected, fixed, and
+ * remaining by severity, plus the gate result. Also shown as a Slack
+ * message preview.
+ */
+const meta = {
+  title: "Factories/Health/RunSummaryReportCard",
+  component: RunSummaryReportCard,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[260px] max-w-2xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof RunSummaryReportCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A failed gate on the work order timeline. */
+export const GateFailed: Story = {
+  args: { report: RUN_SUMMARY_FAILED },
+};
+
+/** A passed gate on the work order timeline. */
+export const GatePassed: Story = {
+  args: { report: RUN_SUMMARY_PASSED },
+};
+
+/** The same report as a Slack message preview. */
+export const SlackPreview: Story = {
+  args: { report: RUN_SUMMARY_FAILED, variant: "slack" },
+};

--- a/web_src/src/pages/factories/health/RunSummaryReportCard.tsx
+++ b/web_src/src/pages/factories/health/RunSummaryReportCard.tsx
@@ -1,0 +1,108 @@
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import type { RunSummaryReport, SeverityCounts } from "@/pages/factories/verification/types";
+
+interface RunSummaryReportCardProps {
+  report: RunSummaryReport;
+  /** `work-order` renders the timeline card; `slack` renders a message preview. */
+  variant?: "work-order" | "slack";
+}
+
+/**
+ * Structured summary of one verification run: findings detected, fixed, and
+ * remaining by severity, plus the gate result.
+ */
+export function RunSummaryReportCard({ report, variant = "work-order" }: RunSummaryReportCardProps) {
+  if (variant === "slack") return <SlackPreview report={report} />;
+
+  return (
+    <section className={cn(factoryCardClassName, "flex flex-col gap-3 p-4")} aria-label="Verification summary">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-[13px] font-medium text-foreground">{report.runLabel}</span>
+        <GateBadge report={report} />
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <CountsBlock label="Detected" counts={report.detected} />
+        <CountsBlock label="Fixed" counts={report.fixed} />
+        <CountsBlock label="Remaining" counts={report.remaining} />
+      </div>
+    </section>
+  );
+}
+
+function GateBadge({ report }: { report: RunSummaryReport }) {
+  if (report.gatePassed) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded bg-emerald-100 py-0.5 pl-1 pr-1.5 text-[12px] font-medium text-emerald-700 dark:bg-emerald-950/70 dark:text-emerald-300">
+        <CheckCircle2 className="size-3.5" aria-hidden />
+        Gate passed
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded bg-red-100 py-0.5 pl-1 pr-1.5 text-[12px] font-medium text-red-700 dark:bg-red-950/70 dark:text-red-300">
+      <AlertTriangle className="size-3.5" aria-hidden />
+      Gate failed · {report.blockingCount} blocking
+    </span>
+  );
+}
+
+function CountsBlock({ label, counts }: { label: string; counts: SeverityCounts }) {
+  const total = counts.high + counts.medium + counts.low;
+  return (
+    <div className="rounded-md border border-border bg-background px-3 py-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="workspace-section-label text-muted-foreground">{label}</span>
+        <span className="text-lg font-medium tabular-nums text-foreground">{total}</span>
+      </div>
+      <dl className="mt-1 flex flex-col gap-0.5 text-[12px] text-muted-foreground">
+        <SeverityRow label="High" value={counts.high} emphasizeClass="text-red-600 dark:text-red-400" />
+        <SeverityRow label="Medium" value={counts.medium} emphasizeClass="text-amber-700 dark:text-amber-400" />
+        <SeverityRow label="Low" value={counts.low} />
+      </dl>
+    </div>
+  );
+}
+
+function SeverityRow({ label, value, emphasizeClass }: { label: string; value: number; emphasizeClass?: string }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <dt>{label}</dt>
+      <dd className={cn("tabular-nums", value > 0 && emphasizeClass ? `font-medium ${emphasizeClass}` : undefined)}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function SlackPreview({ report }: { report: RunSummaryReport }) {
+  const line = (label: string, counts: SeverityCounts) =>
+    `${label}: ${counts.high} high, ${counts.medium} medium, ${counts.low} low`;
+  return (
+    <div className={cn(factoryCardClassName, "flex max-w-md flex-col gap-2 p-4")} aria-label="Slack message preview">
+      <p className="workspace-section-label text-muted-foreground">Slack preview</p>
+      <div className="flex gap-2.5 rounded-md border border-border bg-background p-3">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded bg-slate-200 text-[11px] font-semibold text-slate-700 dark:bg-gray-800 dark:text-gray-300">
+          SP
+        </span>
+        <div className="flex min-w-0 flex-col gap-1 text-[13px]">
+          <p>
+            <span className="font-semibold text-foreground">SuperPlane</span>{" "}
+            <span className="text-[11px] text-muted-foreground">APP</span>
+          </p>
+          <p className="font-medium text-foreground">
+            {report.gatePassed ? "Verification passed" : `Verification failed · ${report.blockingCount} blocking`}
+          </p>
+          <p className="text-muted-foreground">{report.runLabel}</p>
+          <ul className="text-muted-foreground">
+            <li>{line("Detected", report.detected)}</li>
+            <li>{line("Fixed", report.fixed)}</li>
+            <li>{line("Remaining", report.remaining)}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/health/StreakIndicator.stories.tsx
+++ b/web_src/src/pages/factories/health/StreakIndicator.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+import { STREAKS } from "@/pages/factories/verification/__fixtures__/verificationFixtures";
+
+import { StreakIndicator } from "./StreakIndicator";
+
+/** Current and best streaks without new blocking findings. */
+const meta = {
+  title: "Factories/Health/StreakIndicator",
+  component: StreakIndicator,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[200px] max-w-2xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof StreakIndicator>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Active streaks. */
+export const Active: Story = {
+  args: { streaks: STREAKS },
+};
+
+/** After a failing run reset the counters. */
+export const AfterReset: Story = {
+  args: {
+    streaks: [
+      { label: "Work orders without blocking findings", current: 0, best: 21, unit: "work orders" },
+      { label: "Days without blocking findings", current: 0, best: 15, unit: "days" },
+    ],
+  },
+};

--- a/web_src/src/pages/factories/health/StreakIndicator.tsx
+++ b/web_src/src/pages/factories/health/StreakIndicator.tsx
@@ -1,0 +1,40 @@
+import { Flame } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import type { Streak } from "@/pages/factories/verification/types";
+
+interface StreakIndicatorProps {
+  streaks: Streak[];
+}
+
+/** Current and best streaks without new blocking findings. */
+export function StreakIndicator({ streaks }: StreakIndicatorProps) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {streaks.map((streak) => (
+        <div key={streak.label} className={cn(factoryCardClassName, "flex flex-col gap-2 p-4")}>
+          <div className="flex items-center gap-2">
+            <Flame
+              className={cn(
+                "size-4 shrink-0",
+                streak.current > 0 ? "text-amber-500 dark:text-amber-400" : "text-muted-foreground",
+              )}
+              aria-hidden
+            />
+            <span className="text-[12px] font-medium uppercase tracking-wide text-muted-foreground">
+              {streak.label}
+            </span>
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-4xl font-medium text-slate-900 dark:text-gray-100">{streak.current}</span>
+            <span className="text-[13px] text-muted-foreground">{streak.unit}</span>
+          </div>
+          <p className="text-xs text-slate-500 dark:text-gray-400">
+            Best: {streak.best} {streak.unit}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/quality-pack/PresetLinePreview.stories.tsx
+++ b/web_src/src/pages/factories/quality-pack/PresetLinePreview.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+import { VERIFIED_DELIVERY_STEPS } from "@/pages/factories/verification/__fixtures__/verificationFixtures";
+
+import { PresetLinePreview } from "./PresetLinePreview";
+
+/**
+ * Install-time preview of the Verified delivery preset line. The verify step
+ * is expanded so the gate and its checks are visible before install.
+ */
+const meta = {
+  title: "Factories/Quality Pack/PresetLinePreview",
+  component: PresetLinePreview,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[560px] max-w-3xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof PresetLinePreview>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** The four steps of the Verified delivery line, with the verify step expanded. */
+export const VerifiedDelivery: Story = {
+  args: {
+    lineName: "verified-delivery",
+    steps: VERIFIED_DELIVERY_STEPS,
+    onInstall: () => console.log("install line"),
+  },
+};

--- a/web_src/src/pages/factories/quality-pack/PresetLinePreview.tsx
+++ b/web_src/src/pages/factories/quality-pack/PresetLinePreview.tsx
@@ -1,0 +1,83 @@
+import { AppWindow, ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import { LineStepArrow } from "@/pages/factories/FactoryLineStepFlow";
+import type { PresetLineStep } from "@/pages/factories/verification/types";
+
+interface PresetLinePreviewProps {
+  lineName: string;
+  steps: PresetLineStep[];
+  onInstall: () => void;
+}
+
+/**
+ * Install-time preview of a preset line. The verify step is expanded to show
+ * the checks it runs, so the gate is visible before install.
+ */
+export function PresetLinePreview({ lineName, steps, onInstall }: PresetLinePreviewProps) {
+  return (
+    <section className={cn(factoryCardClassName, "flex w-full max-w-xl flex-col")} aria-label="Line preview">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <div className="flex flex-col gap-0.5">
+          <h3 className="workspace-section-title text-foreground">Line preview: {lineName}</h3>
+          <p className="text-[12px] text-muted-foreground">
+            Work orders dispatched to this line pass through these steps in order.
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <Button size="sm" onClick={onInstall}>
+            Install line
+          </Button>
+          <p className="text-[11px] text-muted-foreground">This will not start a run yet.</p>
+        </div>
+      </header>
+
+      <div className="flex flex-col items-stretch px-4 py-4">
+        {steps.map((step, index) => (
+          <div key={step.name} className="flex flex-col items-stretch">
+            {index > 0 ? <LineStepArrow className="self-center" /> : null}
+            <PresetStepCard step={step} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PresetStepCard({ step }: { step: PresetLineStep }) {
+  const isVerify = step.type === "verify";
+  const StepIcon = isVerify ? ShieldCheck : AppWindow;
+  return (
+    <div
+      className={cn(
+        "rounded-xl border p-3",
+        isVerify
+          ? "border-blue-200 bg-blue-50/60 dark:border-blue-900 dark:bg-blue-950/30"
+          : "border-slate-200 bg-white dark:border-gray-700 dark:bg-gray-900",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <StepIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        <span className="text-[13px] font-medium text-foreground">{step.name}</span>
+        <span className="rounded border border-border px-1.5 py-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          {isVerify ? "Verify" : "Run app"}
+        </span>
+      </div>
+      <p className="mt-1 text-[13px] text-muted-foreground">{step.summary}</p>
+      {isVerify && step.checkNames && step.checkNames.length > 0 ? (
+        <ul className="mt-2 grid gap-1 sm:grid-cols-2">
+          {step.checkNames.map((checkName) => (
+            <li
+              key={checkName}
+              className="rounded border border-border bg-background px-2 py-1 text-[12px] text-foreground"
+            >
+              {checkName}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/quality-pack/QualityTemplateGallery.stories.tsx
+++ b/web_src/src/pages/factories/quality-pack/QualityTemplateGallery.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+import { QUALITY_TEMPLATES } from "@/pages/factories/verification/__fixtures__/verificationFixtures";
+
+import { QualityTemplateGallery } from "./QualityTemplateGallery";
+
+/**
+ * Gallery of the six installable quality templates from the code quality
+ * pack. Each template is one canvas that runs standalone or as a check
+ * inside a verification suite.
+ */
+const meta = {
+  title: "Factories/Quality Pack/QualityTemplateGallery",
+  component: QualityTemplateGallery,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[480px] max-w-5xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+  args: {
+    onInstall: (templateId) => console.log("install template", templateId),
+  },
+} satisfies Meta<typeof QualityTemplateGallery>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** The full pack; one template is already installed. */
+export const Default: Story = {
+  args: { templates: QUALITY_TEMPLATES },
+};

--- a/web_src/src/pages/factories/quality-pack/QualityTemplateGallery.tsx
+++ b/web_src/src/pages/factories/quality-pack/QualityTemplateGallery.tsx
@@ -1,0 +1,80 @@
+import { Check, FlaskConical, KeyRound, Package, Ruler, ShieldCheck, Trash2, type LucideIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import type { QualityDomain, QualityTemplate } from "@/pages/factories/verification/types";
+import { QUALITY_DOMAIN_LABELS } from "@/pages/factories/verification/types";
+
+const DOMAIN_ICONS: Record<QualityDomain, LucideIcon> = {
+  "type-safety": ShieldCheck,
+  tests: FlaskConical,
+  secrets: KeyRound,
+  "dead-code": Trash2,
+  "file-size": Ruler,
+  dependencies: Package,
+};
+
+interface QualityTemplateGalleryProps {
+  templates: QualityTemplate[];
+  onInstall: (templateId: string) => void;
+}
+
+/**
+ * Gallery of the installable quality templates. Each template is one canvas
+ * that runs standalone or as a check inside a verification suite.
+ */
+export function QualityTemplateGallery({ templates, onInstall }: QualityTemplateGalleryProps) {
+  return (
+    <section className="flex flex-col gap-3" aria-label="Quality templates">
+      <div className="flex flex-col gap-0.5">
+        <h3 className="workspace-section-title text-foreground">Quality templates</h3>
+        <p className="text-[12px] text-muted-foreground">
+          Install a template to add its checks to your factory. Each template also runs standalone.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {templates.map((template) => (
+          <QualityTemplateCard key={template.id} template={template} onInstall={onInstall} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function QualityTemplateCard({
+  template,
+  onInstall,
+}: {
+  template: QualityTemplate;
+  onInstall: (templateId: string) => void;
+}) {
+  const DomainIcon = DOMAIN_ICONS[template.domain];
+  return (
+    <article className={cn(factoryCardClassName, "flex flex-col gap-3 p-4")} aria-label={template.name}>
+      <div className="flex items-center gap-2.5">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground">
+          <DomainIcon className="size-4.5" aria-hidden />
+        </span>
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate text-[13px] font-medium text-foreground">{template.name}</span>
+          <span className="text-[12px] text-muted-foreground">{QUALITY_DOMAIN_LABELS[template.domain]}</span>
+        </div>
+      </div>
+      <p className="workspace-body-text flex-1 text-muted-foreground">{template.description}</p>
+      <div className="flex items-center justify-between gap-2 border-t border-border pt-3">
+        <span className="text-[12px] text-muted-foreground">{template.checksPerRun} checks per run</span>
+        {template.installed ? (
+          <span className="inline-flex items-center gap-1 text-[13px] font-medium text-emerald-700 dark:text-emerald-300">
+            <Check className="size-4" aria-hidden />
+            Installed
+          </span>
+        ) : (
+          <Button size="sm" variant="outline" onClick={() => onInstall(template.id)}>
+            Install template
+          </Button>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/web_src/src/pages/factories/verification/CheckOutcomeChip.tsx
+++ b/web_src/src/pages/factories/verification/CheckOutcomeChip.tsx
@@ -1,0 +1,64 @@
+import { AlertTriangle, Bot, CheckCircle2, Clock, MinusCircle, Terminal, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { CheckKind, CheckOutcome } from "./types";
+
+const OUTCOME_META: Record<CheckOutcome, { label: string; className: string; icon: LucideIcon }> = {
+  running: {
+    label: "Running",
+    className: "bg-blue-100 text-blue-700 dark:bg-blue-950/70 dark:text-blue-300",
+    icon: Clock,
+  },
+  passed: {
+    label: "Passed",
+    className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/70 dark:text-emerald-300",
+    icon: CheckCircle2,
+  },
+  failed: {
+    label: "Failed",
+    className: "bg-red-100 text-red-700 dark:bg-red-950/70 dark:text-red-300",
+    icon: AlertTriangle,
+  },
+  skipped: {
+    label: "Skipped",
+    className: "bg-slate-200 text-gray-700 dark:bg-slate-900 dark:text-gray-300",
+    icon: MinusCircle,
+  },
+};
+
+const KIND_META: Record<CheckKind, { label: string; icon: LucideIcon }> = {
+  agent: { label: "Agent review", icon: Bot },
+  command: { label: "Command", icon: Terminal },
+};
+
+/** Outcome chip for one check in a verification run. */
+export function CheckOutcomeChip({ outcome }: { outcome: CheckOutcome }) {
+  const meta = OUTCOME_META[outcome];
+  const OutcomeIcon = meta.icon;
+  return (
+    <span
+      aria-label={meta.label}
+      title={meta.label}
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 rounded py-0.5 pl-1 pr-1.5 text-[12px] font-medium leading-4",
+        meta.className,
+      )}
+    >
+      <OutcomeIcon className="size-3.5" aria-hidden />
+      <span>{meta.label}</span>
+    </span>
+  );
+}
+
+/** Label that tells an agent review apart from a deterministic command check. */
+export function CheckKindLabel({ kind }: { kind: CheckKind }) {
+  const meta = KIND_META[kind];
+  const KindIcon = meta.icon;
+  return (
+    <span className="inline-flex items-center gap-1 text-[12px] font-medium text-muted-foreground">
+      <KindIcon className="size-3.5" aria-hidden />
+      <span>{meta.label}</span>
+    </span>
+  );
+}

--- a/web_src/src/pages/factories/verification/FindingItem.tsx
+++ b/web_src/src/pages/factories/verification/FindingItem.tsx
@@ -1,0 +1,26 @@
+import type { Finding } from "./types";
+import { EnforcementBadge, SeverityBadge } from "./SeverityBadge";
+import { formatFindingLocation } from "./findingLocation";
+
+/** One finding: severity, rule, location, what is wrong, and how to fix it. */
+export function FindingItem({ finding }: { finding: Finding }) {
+  return (
+    <div className="flex flex-col gap-1.5 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <SeverityBadge severity={finding.severity} />
+        <span className="text-[13px] font-medium text-foreground">{finding.ruleName}</span>
+        <EnforcementBadge enforcement={finding.enforcement} />
+      </div>
+      {finding.location ? (
+        <code className="w-fit rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[12px] text-slate-700 dark:bg-gray-900 dark:text-gray-300">
+          {formatFindingLocation(finding.location)}
+        </code>
+      ) : null}
+      <p className="workspace-body-text text-foreground">{finding.description}</p>
+      <p className="text-[13px] text-muted-foreground">
+        <span className="font-medium text-foreground">Fix: </span>
+        {finding.remediation}
+      </p>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/verification/LineStepTypeEditor.stories.tsx
+++ b/web_src/src/pages/factories/verification/LineStepTypeEditor.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+
+import { LineStepTypeEditor } from "./LineStepTypeEditor";
+import { DEFAULT_SUITE_CHECKS, SUITE_OPTIONS } from "./__fixtures__/verificationFixtures";
+
+const APPS = [
+  { id: "app-build", name: "Build" },
+  { id: "app-review", name: "Request review" },
+];
+
+/**
+ * Design variant of the line step editor with a step type choice. `Verify`
+ * shows the suite picker, its rule set, and a blocking toggle per check.
+ */
+const meta = {
+  title: "Factories/Verification/LineStepTypeEditor",
+  component: LineStepTypeEditor,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[420px] max-w-3xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof LineStepTypeEditor>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A verify step with the default quality suite selected. */
+export const VerifyStep: Story = {
+  args: {
+    index: 1,
+    value: {
+      name: "verify",
+      type: "verify",
+      suiteId: "suite-default-quality",
+      ruleSetName: "Production",
+      checks: DEFAULT_SUITE_CHECKS,
+    },
+    suites: SUITE_OPTIONS,
+    apps: APPS,
+    onChange: (step) => console.log("step changed", step),
+  },
+};
+
+/** The existing run-app step shape, for comparison with the verify step. */
+export const RunAppStep: Story = {
+  args: {
+    index: 0,
+    value: {
+      name: "implement",
+      type: "runApp",
+      suiteId: "",
+      ruleSetName: "",
+      checks: [],
+    },
+    suites: SUITE_OPTIONS,
+    apps: APPS,
+    onChange: (step) => console.log("step changed", step),
+  },
+};
+
+/** A verify step before a suite is selected. */
+export const VerifyStepWithoutSuite: Story = {
+  args: {
+    index: 1,
+    value: {
+      name: "verify",
+      type: "verify",
+      suiteId: "",
+      ruleSetName: "",
+      checks: [],
+    },
+    suites: SUITE_OPTIONS,
+    apps: APPS,
+    onChange: (step) => console.log("step changed", step),
+  },
+};

--- a/web_src/src/pages/factories/verification/LineStepTypeEditor.tsx
+++ b/web_src/src/pages/factories/verification/LineStepTypeEditor.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/ui/switch";
+import { LineStepEditorShell } from "@/pages/factories/FactoryLineStepFlow";
+
+import type { LineStepType, VerificationCheck, VerificationSuiteOption, VerifyStepDraft } from "./types";
+import { CheckKindLabel } from "./CheckOutcomeChip";
+
+const STEP_TYPE_LABELS: Record<LineStepType, string> = {
+  runApp: "Run app",
+  verify: "Verify",
+};
+
+interface AppOption {
+  id: string;
+  name: string;
+}
+
+interface LineStepTypeEditorProps {
+  index: number;
+  value: VerifyStepDraft;
+  suites: VerificationSuiteOption[];
+  apps: AppOption[];
+  onChange: (step: VerifyStepDraft) => void;
+}
+
+/**
+ * Design variant of the line step editor with a step type choice. `Run app`
+ * keeps the existing app and trigger fields; `Verify` shows the verification
+ * suite, its rule set, and a blocking toggle per check.
+ */
+export function LineStepTypeEditor({ index, value, suites, apps, onChange }: LineStepTypeEditorProps) {
+  const [step, setStep] = useState(value);
+  const [appId, setAppId] = useState(apps[0]?.id ?? "");
+
+  const update = (next: VerifyStepDraft) => {
+    setStep(next);
+    onChange(next);
+  };
+
+  const selectedSuite = suites.find((suite) => suite.id === step.suiteId);
+
+  const selectSuite = (suiteId: string) => {
+    const suite = suites.find((option) => option.id === suiteId);
+    if (!suite) return;
+    update({ ...step, suiteId, ruleSetName: suite.ruleSetName, checks: suite.checks });
+  };
+
+  const toggleCheckBlocking = (checkId: string, blocking: boolean) => {
+    update({
+      ...step,
+      checks: step.checks.map((check) => (check.id === checkId ? { ...check, blocking } : check)),
+    });
+  };
+
+  return (
+    <LineStepEditorShell>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="w-full min-w-0 space-y-2">
+          <Label htmlFor={`verify-step-name-${index}`}>Step name</Label>
+          <Input
+            id={`verify-step-name-${index}`}
+            value={step.name}
+            onChange={(event) => update({ ...step, name: event.target.value })}
+            placeholder="verify"
+          />
+        </div>
+
+        <div className="w-full min-w-0 space-y-2">
+          <Label htmlFor={`verify-step-type-${index}`}>Step type</Label>
+          <Select value={step.type} onValueChange={(type) => update({ ...step, type: type as LineStepType })}>
+            <SelectTrigger id={`verify-step-type-${index}`} className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(STEP_TYPE_LABELS) as LineStepType[]).map((type) => (
+                <SelectItem key={type} value={type}>
+                  {STEP_TYPE_LABELS[type]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {step.type === "runApp" ? (
+          <div className="w-full min-w-0 space-y-2">
+            <Label htmlFor={`verify-step-app-${index}`}>App</Label>
+            <Select value={appId || undefined} onValueChange={setAppId}>
+              <SelectTrigger id={`verify-step-app-${index}`} className="w-full">
+                <SelectValue placeholder="Select app" />
+              </SelectTrigger>
+              <SelectContent>
+                {apps.map((app) => (
+                  <SelectItem key={app.id} value={app.id}>
+                    {app.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : (
+          <div className="w-full min-w-0 space-y-2">
+            <Label htmlFor={`verify-step-suite-${index}`}>Verification suite</Label>
+            <Select value={step.suiteId || undefined} onValueChange={selectSuite}>
+              <SelectTrigger id={`verify-step-suite-${index}`} className="w-full">
+                <SelectValue placeholder="Select suite" />
+              </SelectTrigger>
+              <SelectContent>
+                {suites.map((suite) => (
+                  <SelectItem key={suite.id} value={suite.id}>
+                    {suite.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {selectedSuite ? (
+              <p className="text-xs text-muted-foreground">Rule set: {selectedSuite.ruleSetName}</p>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      {step.type === "verify" && selectedSuite ? (
+        <div className="mt-4 rounded-md border border-border bg-background">
+          <div className="border-b border-border px-3 py-2">
+            <p className="workspace-section-label text-muted-foreground">Checks</p>
+            <p className="text-[12px] text-muted-foreground">
+              Blocking checks stop the line when they find a problem. Advisory checks only record findings.
+            </p>
+          </div>
+          <ul className="divide-y divide-border">
+            {step.checks.map((check) => (
+              <ChecksRow key={check.id} check={check} onBlockingChange={toggleCheckBlocking} />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </LineStepEditorShell>
+  );
+}
+
+function ChecksRow({
+  check,
+  onBlockingChange,
+}: {
+  check: VerificationCheck;
+  onBlockingChange: (checkId: string, blocking: boolean) => void;
+}) {
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-2 px-3 py-2">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-[13px] font-medium text-foreground">{check.name}</span>
+        <CheckKindLabel kind={check.kind} />
+      </div>
+      <label className="flex items-center gap-2 text-[12px] text-muted-foreground">
+        {check.blocking ? "Blocking" : "Advisory"}
+        <Switch
+          checked={check.blocking}
+          onCheckedChange={(blocking) => onBlockingChange(check.id, blocking)}
+          aria-label={`Blocking for ${check.name}`}
+        />
+      </label>
+    </li>
+  );
+}

--- a/web_src/src/pages/factories/verification/RecurringSuggestionsTable.stories.tsx
+++ b/web_src/src/pages/factories/verification/RecurringSuggestionsTable.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+
+import { RecurringSuggestionsTable } from "./RecurringSuggestionsTable";
+import { RECURRING_SUGGESTION_ROWS } from "./__fixtures__/verificationFixtures";
+
+/**
+ * Factory-level aggregation of repeated suggestions. Rows link to the
+ * matching pattern card on the Health tab.
+ */
+const meta = {
+  title: "Factories/Verification/RecurringSuggestionsTable",
+  component: RecurringSuggestionsTable,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[320px] max-w-4xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+  args: {
+    onOpenPattern: (rowId) => console.log("open pattern", rowId),
+  },
+} satisfies Meta<typeof RecurringSuggestionsTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Patterns ordered by open count, with trend and last-seen time. */
+export const Populated: Story = {
+  args: { rows: RECURRING_SUGGESTION_ROWS },
+};
+
+/** No repeated findings yet. */
+export const Empty: Story = {
+  args: { rows: [] },
+};

--- a/web_src/src/pages/factories/verification/RecurringSuggestionsTable.tsx
+++ b/web_src/src/pages/factories/verification/RecurringSuggestionsTable.tsx
@@ -1,0 +1,96 @@
+import { ArrowDownRight, ArrowUpRight, Minus, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import { Timestamp } from "@/components/Timestamp";
+
+import type { OccurrenceTrend, RecurringSuggestionRow } from "./types";
+import { QUALITY_DOMAIN_LABELS } from "./types";
+
+const TREND_META: Record<OccurrenceTrend, { label: string; className: string; icon: LucideIcon }> = {
+  up: { label: "Rising", className: "text-red-600 dark:text-red-400", icon: ArrowUpRight },
+  down: { label: "Falling", className: "text-emerald-600 dark:text-emerald-400", icon: ArrowDownRight },
+  flat: { label: "Flat", className: "text-slate-500 dark:text-gray-400", icon: Minus },
+};
+
+const GRID_COLUMNS = "grid-cols-[minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_88px_96px_minmax(0,1fr)]";
+
+interface RecurringSuggestionsTableProps {
+  rows: RecurringSuggestionRow[];
+  onOpenPattern: (rowId: string) => void;
+}
+
+/**
+ * Factory-level aggregation of repeated suggestions: same rule, similar
+ * locations, across runs and work orders. Rows link to the pattern card on
+ * the Health tab.
+ */
+export function RecurringSuggestionsTable({ rows, onOpenPattern }: RecurringSuggestionsTableProps) {
+  return (
+    <section className={cn(factoryCardClassName, "flex flex-col")} aria-label="Recurring suggestions">
+      <header className="border-b border-border px-4 py-3">
+        <h3 className="workspace-section-title text-foreground">Recurring suggestions</h3>
+        <p className="text-[12px] text-muted-foreground">
+          Findings that repeat across work orders. Open a pattern to see the standard fix.
+        </p>
+      </header>
+
+      {rows.length === 0 ? (
+        <div className="px-4 py-10 text-center">
+          <p className="workspace-body-text text-muted-foreground">No recurring suggestions yet.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <div
+            className={cn(
+              "grid min-w-[720px] gap-x-4 border-b border-border px-4 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground",
+              GRID_COLUMNS,
+            )}
+            role="row"
+          >
+            <span>Pattern</span>
+            <span>Rule</span>
+            <span>Domain</span>
+            <span className="text-right">Count</span>
+            <span>Trend</span>
+            <span>Last seen</span>
+          </div>
+          <ul className="divide-y divide-border">
+            {rows.map((row) => (
+              <li key={row.id}>
+                <button
+                  type="button"
+                  onClick={() => onOpenPattern(row.id)}
+                  className={cn(
+                    "grid w-full min-w-[720px] items-center gap-x-4 px-4 py-2.5 text-left text-[13px] hover:bg-slate-50 dark:hover:bg-gray-900",
+                    GRID_COLUMNS,
+                  )}
+                >
+                  <span className="truncate font-medium text-foreground">{row.patternName}</span>
+                  <span className="truncate text-muted-foreground">{row.ruleName}</span>
+                  <span className="truncate text-muted-foreground">{QUALITY_DOMAIN_LABELS[row.domain]}</span>
+                  <span className="text-right font-medium tabular-nums text-foreground">{row.count}</span>
+                  <TrendCell trend={row.trend} />
+                  <span className="text-muted-foreground">
+                    <Timestamp date={row.lastSeenAt} display="relative" />
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TrendCell({ trend }: { trend: OccurrenceTrend }) {
+  const meta = TREND_META[trend];
+  const TrendIcon = meta.icon;
+  return (
+    <span className={cn("inline-flex items-center gap-1 font-medium", meta.className)}>
+      <TrendIcon className="size-3.5" aria-hidden />
+      {meta.label}
+    </span>
+  );
+}

--- a/web_src/src/pages/factories/verification/RuleSetEditor.stories.tsx
+++ b/web_src/src/pages/factories/verification/RuleSetEditor.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+
+import { RuleSetEditor } from "./RuleSetEditor";
+import { EMPTY_RULE_SET, PRODUCTION_RULE_SET } from "./__fixtures__/verificationFixtures";
+
+/**
+ * Editor for an org-scoped rule set: rules grouped by domain with severity
+ * and enforcement controls, and a YAML preview of the same data.
+ */
+const meta = {
+  title: "Factories/Verification/RuleSetEditor",
+  component: RuleSetEditor,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-screen bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof RuleSetEditor>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** The default production rule set with rules in every domain. */
+export const Populated: Story = {
+  args: {
+    value: PRODUCTION_RULE_SET,
+    onChange: (ruleSet) => console.log("rule set changed", ruleSet),
+  },
+};
+
+/** Empty state for a new rule set. */
+export const Empty: Story = {
+  args: {
+    value: EMPTY_RULE_SET,
+    onChange: (ruleSet) => console.log("rule set changed", ruleSet),
+  },
+};

--- a/web_src/src/pages/factories/verification/RuleSetEditor.tsx
+++ b/web_src/src/pages/factories/verification/RuleSetEditor.tsx
@@ -1,0 +1,222 @@
+import { useState } from "react";
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+
+import type { FindingSeverity, QualityDomain, Rule, RuleEnforcement, RuleSet } from "./types";
+import { QUALITY_DOMAIN_LABELS } from "./types";
+
+const SEVERITY_OPTIONS: FindingSeverity[] = ["high", "medium", "low"];
+const ENFORCEMENT_OPTIONS: RuleEnforcement[] = ["blocking", "advisory"];
+const DOMAIN_ORDER = Object.keys(QUALITY_DOMAIN_LABELS) as QualityDomain[];
+
+interface RuleSetEditorProps {
+  value: RuleSet;
+  onChange: (ruleSet: RuleSet) => void;
+}
+
+/**
+ * Editor for an org-scoped rule set: rules grouped by domain with severity
+ * and enforcement controls, plus a YAML preview of the same data.
+ */
+export function RuleSetEditor({ value, onChange }: RuleSetEditorProps) {
+  const [ruleSet, setRuleSet] = useState(value);
+
+  const update = (next: RuleSet) => {
+    setRuleSet(next);
+    onChange(next);
+  };
+
+  const updateRule = (ruleId: string, changes: Partial<Rule>) => {
+    update({
+      ...ruleSet,
+      rules: ruleSet.rules.map((rule) => (rule.id === ruleId ? { ...rule, ...changes } : rule)),
+    });
+  };
+
+  const addRule = () => {
+    const nextIndex = ruleSet.rules.length + 1;
+    update({
+      ...ruleSet,
+      rules: [
+        ...ruleSet.rules,
+        {
+          id: `type-safety/new-rule-${nextIndex}`,
+          name: `New rule ${nextIndex}`,
+          domain: "type-safety",
+          description: "Describe what this rule requires.",
+          severity: "medium",
+          enforcement: "advisory",
+        },
+      ],
+    });
+  };
+
+  return (
+    <section className={cn(factoryCardClassName, "flex flex-col")} aria-label="Rule set editor">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <h3 className="workspace-section-title text-foreground">Rule set</h3>
+          <p className="text-[12px] text-muted-foreground">
+            Rules apply to every verification suite that uses this rule set.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={addRule}>
+          <Plus className="size-4" aria-hidden />
+          Add rule
+        </Button>
+      </header>
+
+      <div className="grid gap-4 px-4 py-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <div className="flex flex-col gap-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="rule-set-name">Name</Label>
+              <Input
+                id="rule-set-name"
+                value={ruleSet.name}
+                onChange={(event) => update({ ...ruleSet, name: event.target.value })}
+                placeholder="Production"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rule-set-description">Description</Label>
+              <Input
+                id="rule-set-description"
+                value={ruleSet.description}
+                onChange={(event) => update({ ...ruleSet, description: event.target.value })}
+                placeholder="Default rules for production repositories."
+              />
+            </div>
+          </div>
+
+          {ruleSet.rules.length === 0 ? (
+            <EmptyRulesState onAddRule={addRule} />
+          ) : (
+            <RulesByDomain rules={ruleSet.rules} onRuleChange={updateRule} />
+          )}
+        </div>
+
+        <YamlPreview ruleSet={ruleSet} />
+      </div>
+    </section>
+  );
+}
+
+function EmptyRulesState({ onAddRule }: { onAddRule: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border bg-background px-4 py-10 text-center">
+      <p className="workspace-body-text text-foreground">This rule set has no rules.</p>
+      <p className="text-[13px] text-muted-foreground">Add the first rule to make verification steps enforce it.</p>
+      <Button onClick={onAddRule}>
+        <Plus className="size-4" aria-hidden />
+        Add rule
+      </Button>
+    </div>
+  );
+}
+
+function RulesByDomain({
+  rules,
+  onRuleChange,
+}: {
+  rules: Rule[];
+  onRuleChange: (ruleId: string, changes: Partial<Rule>) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      {DOMAIN_ORDER.map((domain) => {
+        const group = rules.filter((rule) => rule.domain === domain);
+        if (group.length === 0) return null;
+        return (
+          <div key={domain} className="rounded-md border border-border bg-background">
+            <p className="workspace-section-label border-b border-border px-3 py-2 text-muted-foreground">
+              {QUALITY_DOMAIN_LABELS[domain]}
+            </p>
+            <ul className="divide-y divide-border">
+              {group.map((rule) => (
+                <RuleRow key={rule.id} rule={rule} onChange={onRuleChange} />
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RuleRow({ rule, onChange }: { rule: Rule; onChange: (ruleId: string, changes: Partial<Rule>) => void }) {
+  return (
+    <li className="flex flex-col gap-2 px-3 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-[13px] font-medium text-foreground">{rule.name}</span>
+          <code className="font-mono text-[11px] text-muted-foreground">{rule.id}</code>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            value={rule.severity}
+            onValueChange={(severity) => onChange(rule.id, { severity: severity as FindingSeverity })}
+          >
+            <SelectTrigger size="sm" aria-label={`Severity for ${rule.name}`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SEVERITY_OPTIONS.map((severity) => (
+                <SelectItem key={severity} value={severity}>
+                  {severity === "high" ? "High" : severity === "medium" ? "Medium" : "Low"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={rule.enforcement}
+            onValueChange={(enforcement) => onChange(rule.id, { enforcement: enforcement as RuleEnforcement })}
+          >
+            <SelectTrigger size="sm" aria-label={`Enforcement for ${rule.name}`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ENFORCEMENT_OPTIONS.map((enforcement) => (
+                <SelectItem key={enforcement} value={enforcement}>
+                  {enforcement === "blocking" ? "Blocking" : "Advisory"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <p className="text-[13px] text-muted-foreground">{rule.description}</p>
+    </li>
+  );
+}
+
+function YamlPreview({ ruleSet }: { ruleSet: RuleSet }) {
+  return (
+    <div className="flex min-w-0 flex-col rounded-md border border-border bg-slate-50 dark:bg-gray-900">
+      <p className="workspace-section-label border-b border-border px-3 py-2 text-muted-foreground">YAML preview</p>
+      <pre className="overflow-x-auto px-3 py-3 font-mono text-[12px] leading-5 text-slate-700 dark:text-gray-300">
+        {ruleSetToYaml(ruleSet)}
+      </pre>
+    </div>
+  );
+}
+
+function ruleSetToYaml(ruleSet: RuleSet): string {
+  const lines = [`name: ${ruleSet.name || "(unnamed)"}`];
+  if (ruleSet.description) lines.push(`description: ${ruleSet.description}`);
+  lines.push("rules:");
+  if (ruleSet.rules.length === 0) lines.push("  []");
+  for (const rule of ruleSet.rules) {
+    lines.push(`  - id: ${rule.id}`);
+    lines.push(`    domain: ${rule.domain}`);
+    lines.push(`    severity: ${rule.severity}`);
+    lines.push(`    enforcement: ${rule.enforcement}`);
+  }
+  return lines.join("\n");
+}

--- a/web_src/src/pages/factories/verification/SeverityBadge.tsx
+++ b/web_src/src/pages/factories/verification/SeverityBadge.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/lib/utils";
+
+import type { FindingSeverity, RuleEnforcement } from "./types";
+
+const SEVERITY_META: Record<FindingSeverity, { label: string; className: string }> = {
+  high: { label: "High", className: "bg-red-100 text-red-700 dark:bg-red-950/70 dark:text-red-300" },
+  medium: { label: "Medium", className: "bg-amber-100 text-amber-800 dark:bg-amber-950/70 dark:text-amber-300" },
+  low: { label: "Low", className: "bg-slate-200 text-gray-700 dark:bg-slate-900 dark:text-gray-300" },
+};
+
+/** Severity chip for a rule or a finding. */
+export function SeverityBadge({ severity }: { severity: FindingSeverity }) {
+  const meta = SEVERITY_META[severity];
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[12px] font-medium leading-4",
+        meta.className,
+      )}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+/** Enforcement chip: blocking findings fail the verification step. */
+export function EnforcementBadge({ enforcement }: { enforcement: RuleEnforcement }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded border px-1.5 py-0.5 text-[11px] font-medium uppercase leading-4 tracking-wide",
+        enforcement === "blocking"
+          ? "border-red-200 text-red-700 dark:border-red-900 dark:text-red-300"
+          : "border-border text-muted-foreground",
+      )}
+    >
+      {enforcement === "blocking" ? "Blocking" : "Advisory"}
+    </span>
+  );
+}

--- a/web_src/src/pages/factories/verification/SuggestionCard.stories.tsx
+++ b/web_src/src/pages/factories/verification/SuggestionCard.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+
+import { SuggestionCard } from "./SuggestionCard";
+import { SUGGESTIONS } from "./__fixtures__/verificationFixtures";
+
+/**
+ * One open finding as an actionable suggestion, with the dispatch-fix action
+ * that routes the fix as a draft work order or a direct agent run.
+ */
+const meta = {
+  title: "Factories/Verification/SuggestionCard",
+  component: SuggestionCard,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[280px] max-w-2xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+  args: {
+    onDispatchFix: (suggestionId, target) => console.log("dispatch fix", suggestionId, target),
+    onDismiss: (suggestionId) => console.log("dismiss", suggestionId),
+    onAccept: (suggestionId) => console.log("accept", suggestionId),
+  },
+} satisfies Meta<typeof SuggestionCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A blocking suggestion with several occurrences. */
+export const Blocking: Story = {
+  args: { suggestion: SUGGESTIONS[0] },
+};
+
+/** A suggestion whose fix was already dispatched. */
+export const FixInProgress: Story = {
+  args: { suggestion: SUGGESTIONS[1] },
+};
+
+/** An advisory suggestion; it never stops the line. */
+export const Advisory: Story = {
+  args: { suggestion: SUGGESTIONS[2] },
+};

--- a/web_src/src/pages/factories/verification/SuggestionCard.tsx
+++ b/web_src/src/pages/factories/verification/SuggestionCard.tsx
@@ -1,0 +1,93 @@
+import { Bot, ChevronDown, ClipboardList, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
+
+import type { FixDispatchTarget, Suggestion } from "./types";
+import { QUALITY_DOMAIN_LABELS } from "./types";
+import { EnforcementBadge, SeverityBadge } from "./SeverityBadge";
+import { formatFindingLocation } from "./findingLocation";
+
+interface SuggestionCardProps {
+  suggestion: Suggestion;
+  onDispatchFix: (suggestionId: string, target: FixDispatchTarget) => void;
+  onDismiss: (suggestionId: string) => void;
+  onAccept: (suggestionId: string) => void;
+}
+
+/**
+ * One open finding as an actionable suggestion: what is wrong, where, how to
+ * fix it, and one action that routes the fix as a draft work order or as a
+ * direct agent run.
+ */
+export function SuggestionCard({ suggestion, onDispatchFix, onDismiss, onAccept }: SuggestionCardProps) {
+  const { finding } = suggestion;
+  const fixInProgress = suggestion.fixStatus === "in-progress";
+
+  return (
+    <article className={cn(factoryCardClassName, "flex flex-col gap-3 p-4")} aria-label={finding.ruleName}>
+      <div className="flex flex-wrap items-center gap-2">
+        <SeverityBadge severity={finding.severity} />
+        <span className="text-[13px] font-medium text-foreground">{finding.ruleName}</span>
+        <EnforcementBadge enforcement={finding.enforcement} />
+        <span className="text-[12px] text-muted-foreground">{QUALITY_DOMAIN_LABELS[finding.domain]}</span>
+        {suggestion.occurrences > 1 ? (
+          <span className="text-[12px] text-muted-foreground">· {suggestion.occurrences} occurrences</span>
+        ) : null}
+      </div>
+
+      {finding.location ? (
+        <code className="w-fit rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[12px] text-slate-700 dark:bg-gray-900 dark:text-gray-300">
+          {formatFindingLocation(finding.location)}
+        </code>
+      ) : null}
+
+      <p className="workspace-body-text text-foreground">{finding.description}</p>
+      <p className="text-[13px] text-muted-foreground">
+        <span className="font-medium text-foreground">Fix: </span>
+        {finding.remediation}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2 border-t border-border pt-3">
+        {fixInProgress ? (
+          <span className="inline-flex items-center gap-1.5 text-[13px] font-medium text-blue-700 dark:text-blue-300">
+            <Loader2 className="size-3.5 animate-spin" aria-hidden />
+            Fix in progress
+          </span>
+        ) : (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button size="sm">
+                Dispatch fix
+                <ChevronDown className="size-4" aria-hidden />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem onClick={() => onDispatchFix(suggestion.id, "work-order")}>
+                <ClipboardList className="size-4" aria-hidden />
+                Create fix work order
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onDispatchFix(suggestion.id, "agent-run")}>
+                <Bot className="size-4" aria-hidden />
+                Start agent run
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        <Button variant="ghost" size="sm" onClick={() => onDismiss(suggestion.id)}>
+          Dismiss
+        </Button>
+        <Button variant="ghost" size="sm" onClick={() => onAccept(suggestion.id)}>
+          Accept
+        </Button>
+        {!fixInProgress ? (
+          <p className="text-[12px] text-muted-foreground">
+            A fix work order starts as a draft. You choose when to dispatch it.
+          </p>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/web_src/src/pages/factories/verification/VerificationStatusBadge.stories.tsx
+++ b/web_src/src/pages/factories/verification/VerificationStatusBadge.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CheckKindLabel, CheckOutcomeChip } from "./CheckOutcomeChip";
+import { EnforcementBadge, SeverityBadge } from "./SeverityBadge";
+import { VerificationStatusBadge } from "./VerificationStatusBadge";
+import type { CheckOutcome, FindingSeverity, VerificationRunStatus } from "./types";
+
+const RUN_STATUSES: VerificationRunStatus[] = ["running", "passed", "failed"];
+const CHECK_OUTCOMES: CheckOutcome[] = ["running", "passed", "failed", "skipped"];
+const SEVERITIES: FindingSeverity[] = ["high", "medium", "low"];
+
+/**
+ * Status primitives for the verification designs: run status badges, check
+ * outcome chips, check kind labels, severity badges, and enforcement badges.
+ */
+const meta = {
+  title: "Factories/Verification/StatusPrimitives",
+  component: VerificationStatusBadge,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof VerificationStatusBadge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** All verification run statuses. */
+export const RunStatuses: Story = {
+  args: { status: "running" },
+  render: () => (
+    <div className="flex items-center gap-2">
+      {RUN_STATUSES.map((status) => (
+        <VerificationStatusBadge key={status} status={status} />
+      ))}
+    </div>
+  ),
+};
+
+/** All check outcomes plus the agent/command kind labels. */
+export const CheckOutcomes: Story = {
+  args: { status: "running" },
+  render: () => (
+    <div className="flex flex-col items-start gap-3">
+      <div className="flex items-center gap-2">
+        {CHECK_OUTCOMES.map((outcome) => (
+          <CheckOutcomeChip key={outcome} outcome={outcome} />
+        ))}
+      </div>
+      <div className="flex items-center gap-4">
+        <CheckKindLabel kind="agent" />
+        <CheckKindLabel kind="command" />
+      </div>
+    </div>
+  ),
+};
+
+/** All finding severities plus the enforcement badges. */
+export const Severities: Story = {
+  args: { status: "running" },
+  render: () => (
+    <div className="flex flex-col items-start gap-3">
+      <div className="flex items-center gap-2">
+        {SEVERITIES.map((severity) => (
+          <SeverityBadge key={severity} severity={severity} />
+        ))}
+      </div>
+      <div className="flex items-center gap-2">
+        <EnforcementBadge enforcement="blocking" />
+        <EnforcementBadge enforcement="advisory" />
+      </div>
+    </div>
+  ),
+};

--- a/web_src/src/pages/factories/verification/VerificationStatusBadge.tsx
+++ b/web_src/src/pages/factories/verification/VerificationStatusBadge.tsx
@@ -1,0 +1,38 @@
+import { AlertTriangle, CheckCircle2, Clock, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { VerificationRunStatus } from "./types";
+
+const BASE_CLASSES =
+  "inline-flex shrink-0 items-center gap-1 rounded py-0.5 pl-1 pr-1.5 text-[12px] font-medium leading-4";
+
+const STATUS_META: Record<VerificationRunStatus, { label: string; className: string; icon: LucideIcon }> = {
+  running: {
+    label: "Running",
+    className: "bg-blue-100 text-blue-700 dark:bg-blue-950/70 dark:text-blue-300",
+    icon: Clock,
+  },
+  passed: {
+    label: "Passed",
+    className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/70 dark:text-emerald-300",
+    icon: CheckCircle2,
+  },
+  failed: {
+    label: "Failed",
+    className: "bg-red-100 text-red-700 dark:bg-red-950/70 dark:text-red-300",
+    icon: AlertTriangle,
+  },
+};
+
+/** Status badge for a verification run, matching the run status badge style. */
+export function VerificationStatusBadge({ status }: { status: VerificationRunStatus }) {
+  const meta = STATUS_META[status];
+  const StatusIcon = meta.icon;
+  return (
+    <span aria-label={meta.label} title={meta.label} className={cn(BASE_CLASSES, meta.className)}>
+      <StatusIcon className="size-3.5" aria-hidden />
+      <span>{meta.label}</span>
+    </span>
+  );
+}

--- a/web_src/src/pages/factories/verification/WorkOrderSuggestionsList.stories.tsx
+++ b/web_src/src/pages/factories/verification/WorkOrderSuggestionsList.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+
+import { WorkOrderSuggestionsList } from "./WorkOrderSuggestionsList";
+import { SUGGESTIONS } from "./__fixtures__/verificationFixtures";
+
+/**
+ * Open suggestions for one work order with severity and domain filters. The
+ * empty state confirms a clean verification run.
+ */
+const meta = {
+  title: "Factories/Verification/WorkOrderSuggestionsList",
+  component: WorkOrderSuggestionsList,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[480px] max-w-3xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+  args: {
+    onDispatchFix: (suggestionId, target) => console.log("dispatch fix", suggestionId, target),
+    onDismiss: (suggestionId) => console.log("dismiss", suggestionId),
+    onAccept: (suggestionId) => console.log("accept", suggestionId),
+  },
+} satisfies Meta<typeof WorkOrderSuggestionsList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Open suggestions across severities and domains. */
+export const Populated: Story = {
+  args: { suggestions: SUGGESTIONS },
+};
+
+/** No open suggestions: the last verification run was clean. */
+export const Empty: Story = {
+  args: { suggestions: [] },
+};

--- a/web_src/src/pages/factories/verification/WorkOrderSuggestionsList.tsx
+++ b/web_src/src/pages/factories/verification/WorkOrderSuggestionsList.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import type { FindingSeverity, FixDispatchTarget, QualityDomain, Suggestion } from "./types";
+import { QUALITY_DOMAIN_LABELS } from "./types";
+import { SuggestionCard } from "./SuggestionCard";
+
+const SEVERITY_FILTER_LABELS: Record<FindingSeverity, string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+interface WorkOrderSuggestionsListProps {
+  suggestions: Suggestion[];
+  onDispatchFix: (suggestionId: string, target: FixDispatchTarget) => void;
+  onDismiss: (suggestionId: string) => void;
+  onAccept: (suggestionId: string) => void;
+}
+
+/**
+ * Open suggestions for one work order, with severity and domain filters.
+ * The empty state confirms a clean verification run.
+ */
+export function WorkOrderSuggestionsList({
+  suggestions,
+  onDispatchFix,
+  onDismiss,
+  onAccept,
+}: WorkOrderSuggestionsListProps) {
+  const [severityFilter, setSeverityFilter] = useState<"all" | FindingSeverity>("all");
+  const [domainFilter, setDomainFilter] = useState<"all" | QualityDomain>("all");
+
+  const filtered = suggestions.filter((suggestion) => {
+    if (severityFilter !== "all" && suggestion.finding.severity !== severityFilter) return false;
+    if (domainFilter !== "all" && suggestion.finding.domain !== domainFilter) return false;
+    return true;
+  });
+
+  return (
+    <section className="flex flex-col gap-3" aria-label="Suggestions">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          <h3 className="workspace-section-title text-foreground">Suggestions</h3>
+          <p className="text-[12px] text-muted-foreground">
+            Open findings from the last verification run, with a prepared fix for each.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={severityFilter} onValueChange={(value) => setSeverityFilter(value as "all" | FindingSeverity)}>
+            <SelectTrigger size="sm" aria-label="Filter by severity">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All severities</SelectItem>
+              {(Object.keys(SEVERITY_FILTER_LABELS) as FindingSeverity[]).map((severity) => (
+                <SelectItem key={severity} value={severity}>
+                  {SEVERITY_FILTER_LABELS[severity]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={domainFilter} onValueChange={(value) => setDomainFilter(value as "all" | QualityDomain)}>
+            <SelectTrigger size="sm" aria-label="Filter by domain">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All domains</SelectItem>
+              {(Object.keys(QUALITY_DOMAIN_LABELS) as QualityDomain[]).map((domain) => (
+                <SelectItem key={domain} value={domain}>
+                  {QUALITY_DOMAIN_LABELS[domain]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <EmptySuggestionsState hasSuggestions={suggestions.length > 0} />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {filtered.map((suggestion) => (
+            <SuggestionCard
+              key={suggestion.id}
+              suggestion={suggestion}
+              onDispatchFix={onDispatchFix}
+              onDismiss={onDismiss}
+              onAccept={onAccept}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function EmptySuggestionsState({ hasSuggestions }: { hasSuggestions: boolean }) {
+  return (
+    <div className="flex flex-col items-center gap-1 rounded-lg border border-dashed border-border bg-card px-4 py-10 text-center">
+      <p className="workspace-body-text text-foreground">
+        {hasSuggestions ? "No suggestions match the filters." : "No open suggestions."}
+      </p>
+      <p className="text-[13px] text-muted-foreground">
+        {hasSuggestions
+          ? "Remove a filter to see the other suggestions."
+          : "The last verification run reported no open findings."}
+      </p>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/verification/WorkOrderVerificationPanel.stories.tsx
+++ b/web_src/src/pages/factories/verification/WorkOrderVerificationPanel.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "@/pages/factories/__fixtures__/ComponentStoryShell";
+
+import { WorkOrderVerificationPanel } from "./WorkOrderVerificationPanel";
+import {
+  FAILED_VERIFICATION_RUN,
+  PASSED_VERIFICATION_RUN,
+  RUNNING_VERIFICATION_RUN,
+} from "./__fixtures__/verificationFixtures";
+
+/**
+ * Verification results on the work order detail: run status, per-check
+ * outcomes with command checks apart from agent reviews, and findings
+ * grouped by severity.
+ */
+const meta = {
+  title: "Factories/Verification/WorkOrderVerificationPanel",
+  component: WorkOrderVerificationPanel,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <ComponentStoryShell className="min-h-[480px] max-w-4xl bg-gray-50 p-6 dark:bg-gray-950">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof WorkOrderVerificationPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A failed run: blocking findings stop the line. */
+export const Failed: Story = {
+  args: { run: FAILED_VERIFICATION_RUN },
+};
+
+/** A passed run: advisory findings are recorded but do not stop the line. */
+export const Passed: Story = {
+  args: { run: PASSED_VERIFICATION_RUN },
+};
+
+/** A run in progress: checks run in parallel and results appear as they finish. */
+export const Running: Story = {
+  args: { run: RUNNING_VERIFICATION_RUN },
+};

--- a/web_src/src/pages/factories/verification/WorkOrderVerificationPanel.tsx
+++ b/web_src/src/pages/factories/verification/WorkOrderVerificationPanel.tsx
@@ -1,0 +1,141 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { factoryCardClassName } from "@/pages/factories/pages/factoryPageLayoutStyles";
+
+import type { CheckResult, Finding, FindingSeverity, VerificationRun } from "./types";
+import { CheckKindLabel, CheckOutcomeChip } from "./CheckOutcomeChip";
+import { FindingItem } from "./FindingItem";
+import { VerificationStatusBadge } from "./VerificationStatusBadge";
+
+const SEVERITY_ORDER: FindingSeverity[] = ["high", "medium", "low"];
+
+const SEVERITY_GROUP_LABELS: Record<FindingSeverity, string> = {
+  high: "High severity",
+  medium: "Medium severity",
+  low: "Low severity",
+};
+
+interface WorkOrderVerificationPanelProps {
+  run: VerificationRun;
+}
+
+/**
+ * Verification results on the work order detail: run status, per-check
+ * outcomes, and findings grouped by severity. Command check results are
+ * shown apart from agent review results because commands are authoritative.
+ */
+export function WorkOrderVerificationPanel({ run }: WorkOrderVerificationPanelProps) {
+  const blockingOpen = run.findings.filter(
+    (finding) => finding.enforcement === "blocking" && finding.status === "open",
+  ).length;
+
+  return (
+    <section className={cn(factoryCardClassName, "flex flex-col")} aria-label="Verification">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <div className="flex items-center gap-2">
+          <h3 className="workspace-section-title text-foreground">Verification</h3>
+          <VerificationStatusBadge status={run.status} />
+        </div>
+        <p className="text-[12px] text-muted-foreground">
+          Suite {run.suiteName} · Rule set {run.ruleSetName}
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-4 px-4 py-4">
+        {run.status === "failed" ? (
+          <p className="workspace-body-text text-foreground">
+            {blockingOpen} blocking {blockingOpen === 1 ? "finding stops" : "findings stop"} this line. Fix or accept
+            the blocking findings, then dispatch the work order again.
+          </p>
+        ) : null}
+        {run.status === "running" ? (
+          <p className="flex items-center gap-2 workspace-body-text text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" aria-hidden />
+            Checks run in parallel. Results appear as each check finishes.
+          </p>
+        ) : null}
+        {run.status === "passed" ? (
+          <p className="workspace-body-text text-foreground">
+            All checks passed. Advisory findings do not stop the line.
+          </p>
+        ) : null}
+
+        <ChecksList results={run.checks} />
+        <FindingsBySeverity findings={run.findings} />
+      </div>
+    </section>
+  );
+}
+
+function ChecksList({ results }: { results: CheckResult[] }) {
+  const commandResults = results.filter((result) => result.check.kind === "command");
+  const agentResults = results.filter((result) => result.check.kind === "agent");
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <CheckGroup
+        title="Command checks"
+        helper="Deterministic results. These decide the gate."
+        results={commandResults}
+      />
+      <CheckGroup title="Agent reviews" helper="Findings from AI review of changed files." results={agentResults} />
+    </div>
+  );
+}
+
+function CheckGroup({ title, helper, results }: { title: string; helper: string; results: CheckResult[] }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-md border border-border bg-background p-3">
+      <p className="workspace-section-label text-muted-foreground">{title}</p>
+      <p className="text-[12px] text-muted-foreground">{helper}</p>
+      <ul className="mt-2 flex flex-col divide-y divide-border">
+        {results.map((result) => (
+          <li key={result.check.id} className="flex flex-col gap-1 py-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-[13px] font-medium text-foreground">{result.check.name}</span>
+              <CheckOutcomeChip outcome={result.outcome} />
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <CheckKindLabel kind={result.check.kind} />
+              {result.command ? (
+                <code className="font-mono text-[12px] text-muted-foreground">{result.command}</code>
+              ) : null}
+            </div>
+            {result.summary ? <p className="text-[12px] text-muted-foreground">{result.summary}</p> : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function FindingsBySeverity({ findings }: { findings: Finding[] }) {
+  if (findings.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-background px-4 py-6 text-center">
+        <p className="workspace-body-text text-muted-foreground">No findings for this run.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {SEVERITY_ORDER.map((severity) => {
+        const group = findings.filter((finding) => finding.severity === severity);
+        if (group.length === 0) return null;
+        return (
+          <div key={severity} className="rounded-md border border-border bg-background px-4 py-2">
+            <p className="workspace-section-label pt-2 text-muted-foreground">
+              {SEVERITY_GROUP_LABELS[severity]} ({group.length})
+            </p>
+            <div className="divide-y divide-border">
+              {group.map((finding) => (
+                <FindingItem key={finding.id} finding={finding} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/verification/__fixtures__/verificationFixtures.ts
+++ b/web_src/src/pages/factories/verification/__fixtures__/verificationFixtures.ts
@@ -1,0 +1,510 @@
+/**
+ * Shared mock data for the verification, suggestions, quality pack, and
+ * codebase health Storybook designs. Story-side only; never import from
+ * application components.
+ */
+
+import type {
+  Achievement,
+  CheckResult,
+  Finding,
+  HealthSnapshot,
+  PresetLineStep,
+  QualityTemplate,
+  RecurringPattern,
+  RecurringSuggestionRow,
+  Rule,
+  RuleSet,
+  RunSummaryReport,
+  Streak,
+  Suggestion,
+  VerificationCheck,
+  VerificationRun,
+  VerificationSuiteOption,
+} from "../types";
+
+const now = Date.now();
+const minutesAgo = (minutes: number) => new Date(now - minutes * 60_000);
+const daysAgo = (days: number) => new Date(now - days * 86_400_000);
+
+export const PRODUCTION_RULES: Rule[] = [
+  {
+    id: "type-safety/no-untyped-values",
+    name: "No untyped values",
+    domain: "type-safety",
+    description: "Every value has an explicit or inferred type. Escape hatches need a documented reason.",
+    severity: "high",
+    enforcement: "blocking",
+  },
+  {
+    id: "type-safety/no-unsafe-casts",
+    name: "No unsafe casts",
+    domain: "type-safety",
+    description: "Replace casts with runtime checks or parser functions at trust boundaries.",
+    severity: "medium",
+    enforcement: "blocking",
+  },
+  {
+    id: "tests/changed-code-is-tested",
+    name: "Changed code is tested",
+    domain: "tests",
+    description: "Changed functions have tests that assert behavior, not only execution.",
+    severity: "high",
+    enforcement: "blocking",
+  },
+  {
+    id: "tests/no-empty-assertions",
+    name: "No empty assertions",
+    domain: "tests",
+    description: "A test must fail when the behavior it covers breaks.",
+    severity: "medium",
+    enforcement: "advisory",
+  },
+  {
+    id: "secrets/no-committed-secrets",
+    name: "No committed secrets",
+    domain: "secrets",
+    description: "No credentials in code, configuration, or history. Rotate any value that was committed.",
+    severity: "high",
+    enforcement: "blocking",
+  },
+  {
+    id: "dead-code/no-unused-exports",
+    name: "No unused exports",
+    domain: "dead-code",
+    description: "Remove exports with no references. Version control preserves the history.",
+    severity: "low",
+    enforcement: "advisory",
+  },
+  {
+    id: "file-size/max-file-length",
+    name: "Files stay under 500 lines",
+    domain: "file-size",
+    description: "Split files that grow past 500 lines into focused modules.",
+    severity: "low",
+    enforcement: "advisory",
+  },
+  {
+    id: "dependencies/every-dependency-is-used",
+    name: "Every dependency is used",
+    domain: "dependencies",
+    description: "Remove packages with no imports. Replace single-use packages with local code when small.",
+    severity: "medium",
+    enforcement: "advisory",
+  },
+];
+
+export const PRODUCTION_RULE_SET: RuleSet = {
+  id: "rule-set-production",
+  name: "Production",
+  description: "Default rules for production repositories.",
+  rules: PRODUCTION_RULES,
+};
+
+export const EMPTY_RULE_SET: RuleSet = {
+  id: "rule-set-new",
+  name: "New rule set",
+  description: "",
+  rules: [],
+};
+
+export const DEFAULT_SUITE_CHECKS: VerificationCheck[] = [
+  { id: "check-type-safety", name: "Type safety review", domain: "type-safety", kind: "agent", blocking: true },
+  { id: "check-type-command", name: "Type check", domain: "type-safety", kind: "command", blocking: true },
+  { id: "check-tests", name: "Test coverage review", domain: "tests", kind: "agent", blocking: true },
+  { id: "check-test-command", name: "Test run", domain: "tests", kind: "command", blocking: true },
+  { id: "check-secrets", name: "Secret scan", domain: "secrets", kind: "command", blocking: true },
+  { id: "check-dead-code", name: "Dead code review", domain: "dead-code", kind: "agent", blocking: false },
+  { id: "check-file-size", name: "File size review", domain: "file-size", kind: "agent", blocking: false },
+  { id: "check-dependencies", name: "Dependency audit", domain: "dependencies", kind: "command", blocking: false },
+];
+
+export const SUITE_OPTIONS: VerificationSuiteOption[] = [
+  {
+    id: "suite-default-quality",
+    name: "Default quality",
+    ruleSetName: "Production",
+    checks: DEFAULT_SUITE_CHECKS,
+  },
+  {
+    id: "suite-secrets-only",
+    name: "Secrets only",
+    ruleSetName: "Production",
+    checks: DEFAULT_SUITE_CHECKS.filter((check) => check.domain === "secrets"),
+  },
+];
+
+export const OPEN_FINDINGS: Finding[] = [
+  {
+    id: "finding-1",
+    ruleId: "type-safety/no-untyped-values",
+    ruleName: "No untyped values",
+    domain: "type-safety",
+    severity: "high",
+    enforcement: "blocking",
+    location: { path: "web_src/src/pages/orders/orderMapper.ts", startLine: 42, endLine: 58 },
+    description: "The webhook payload is used without a type. Three fields are read from it unchecked.",
+    remediation: "Define a payload interface and parse the payload with a runtime check before use.",
+    status: "open",
+  },
+  {
+    id: "finding-2",
+    ruleId: "tests/changed-code-is-tested",
+    ruleName: "Changed code is tested",
+    domain: "tests",
+    severity: "high",
+    enforcement: "blocking",
+    location: { path: "pkg/billing/invoice.go", startLine: 118, endLine: 164 },
+    description: "The new proration branch has no test. A rounding regression would not be caught.",
+    remediation: "Add a test for the proration branch with one whole-period case and one partial-period case.",
+    status: "open",
+  },
+  {
+    id: "finding-3",
+    ruleId: "dead-code/no-unused-exports",
+    ruleName: "No unused exports",
+    domain: "dead-code",
+    severity: "low",
+    enforcement: "advisory",
+    location: { path: "web_src/src/lib/formatDuration.ts", startLine: 27 },
+    description: "formatDurationShort has no references after the timeline rewrite.",
+    remediation: "Remove the export and its tests. Restore from history if it is needed again.",
+    status: "open",
+  },
+  {
+    id: "finding-4",
+    ruleId: "file-size/max-file-length",
+    ruleName: "Files stay under 500 lines",
+    domain: "file-size",
+    severity: "low",
+    enforcement: "advisory",
+    location: { path: "pkg/workers/dispatcher.go" },
+    description: "The file is 742 lines and holds routing, retries, and metrics together.",
+    remediation: "Extract the retry policy and the metrics recorder into their own files.",
+    status: "open",
+  },
+];
+
+export const RESOLVED_FINDINGS: Finding[] = [
+  {
+    id: "finding-5",
+    ruleId: "secrets/no-committed-secrets",
+    ruleName: "No committed secrets",
+    domain: "secrets",
+    severity: "high",
+    enforcement: "blocking",
+    location: { path: "scripts/deploy.sh", startLine: 12 },
+    description: "A provider token was committed in a deploy script.",
+    remediation: "Move the token to a secret store and rotate it.",
+    status: "fixed",
+  },
+  {
+    id: "finding-6",
+    ruleId: "type-safety/no-unsafe-casts",
+    ruleName: "No unsafe casts",
+    domain: "type-safety",
+    severity: "medium",
+    enforcement: "blocking",
+    location: { path: "web_src/src/pages/reports/exportCsv.ts", startLine: 88 },
+    description: "A double cast bypasses the row type on export.",
+    remediation: "Map each row field through a constructor instead of casting the array.",
+    status: "accepted",
+  },
+];
+
+export const FAILED_VERIFICATION_CHECKS: CheckResult[] = [
+  {
+    check: DEFAULT_SUITE_CHECKS[0],
+    outcome: "failed",
+    findingCount: 1,
+    summary: "1 blocking finding in changed files.",
+  },
+  {
+    check: DEFAULT_SUITE_CHECKS[1],
+    outcome: "passed",
+    findingCount: 0,
+    command: "npx tsc --noEmit",
+  },
+  {
+    check: DEFAULT_SUITE_CHECKS[2],
+    outcome: "failed",
+    findingCount: 1,
+    summary: "1 changed function without tests.",
+  },
+  {
+    check: DEFAULT_SUITE_CHECKS[3],
+    outcome: "passed",
+    findingCount: 0,
+    command: "go test ./...",
+  },
+  {
+    check: DEFAULT_SUITE_CHECKS[4],
+    outcome: "passed",
+    findingCount: 0,
+    command: "gitleaks detect --source .",
+  },
+  {
+    check: DEFAULT_SUITE_CHECKS[5],
+    outcome: "passed",
+    findingCount: 1,
+    summary: "1 advisory finding.",
+  },
+  {
+    check: DEFAULT_SUITE_CHECKS[6],
+    outcome: "passed",
+    findingCount: 1,
+    summary: "1 advisory finding.",
+  },
+  {
+    check: DEFAULT_SUITE_CHECKS[7],
+    outcome: "skipped",
+    findingCount: 0,
+    command: "npm audit --omit dev",
+    summary: "No dependency changes in this work order.",
+  },
+];
+
+export const FAILED_VERIFICATION_RUN: VerificationRun = {
+  id: "verification-run-failed",
+  suiteName: "Default quality",
+  ruleSetName: "Production",
+  status: "failed",
+  startedAt: minutesAgo(18),
+  finishedAt: minutesAgo(11),
+  checks: FAILED_VERIFICATION_CHECKS,
+  findings: OPEN_FINDINGS,
+};
+
+export const PASSED_VERIFICATION_RUN: VerificationRun = {
+  id: "verification-run-passed",
+  suiteName: "Default quality",
+  ruleSetName: "Production",
+  status: "passed",
+  startedAt: minutesAgo(45),
+  finishedAt: minutesAgo(38),
+  checks: FAILED_VERIFICATION_CHECKS.map((result) => ({
+    ...result,
+    outcome: result.outcome === "skipped" ? "skipped" : "passed",
+    findingCount: result.check.blocking ? 0 : result.findingCount,
+    summary: result.check.blocking ? undefined : result.summary,
+  })),
+  findings: OPEN_FINDINGS.filter((finding) => finding.enforcement === "advisory"),
+};
+
+export const RUNNING_VERIFICATION_RUN: VerificationRun = {
+  id: "verification-run-running",
+  suiteName: "Default quality",
+  ruleSetName: "Production",
+  status: "running",
+  startedAt: minutesAgo(3),
+  checks: FAILED_VERIFICATION_CHECKS.map((result, index) => ({
+    ...result,
+    outcome: index < 3 ? result.outcome : "running",
+    findingCount: index < 3 ? result.findingCount : 0,
+    summary: index < 3 ? result.summary : undefined,
+  })),
+  findings: [],
+};
+
+export const SUGGESTIONS: Suggestion[] = OPEN_FINDINGS.map((finding, index) => ({
+  id: `suggestion-${finding.id}`,
+  finding,
+  fixPrompt:
+    `Fix the finding "${finding.ruleName}" at ${finding.location?.path ?? "the repository"}. ` + finding.remediation,
+  sourceWorkOrderTitle: "Add proration to invoice billing",
+  occurrences: index === 0 ? 3 : 1,
+  fixStatus: index === 1 ? "in-progress" : "none",
+}));
+
+export const RECURRING_SUGGESTION_ROWS: RecurringSuggestionRow[] = [
+  {
+    id: "recurring-1",
+    patternName: "Untyped API response handling",
+    ruleName: "No untyped values",
+    domain: "type-safety",
+    count: 14,
+    trend: "up",
+    lastSeenAt: minutesAgo(11),
+  },
+  {
+    id: "recurring-2",
+    patternName: "New branches without tests",
+    ruleName: "Changed code is tested",
+    domain: "tests",
+    count: 9,
+    trend: "flat",
+    lastSeenAt: daysAgo(1),
+  },
+  {
+    id: "recurring-3",
+    patternName: "Stale exports after rewrites",
+    ruleName: "No unused exports",
+    domain: "dead-code",
+    count: 6,
+    trend: "down",
+    lastSeenAt: daysAgo(3),
+  },
+  {
+    id: "recurring-4",
+    patternName: "Worker files that keep growing",
+    ruleName: "Files stay under 500 lines",
+    domain: "file-size",
+    count: 4,
+    trend: "down",
+    lastSeenAt: daysAgo(6),
+  },
+];
+
+export const QUALITY_TEMPLATES: QualityTemplate[] = [
+  {
+    id: "template-type-safety",
+    name: "Type Safety Review",
+    domain: "type-safety",
+    description: "Finds untyped values and unsafe casts in changed files, then runs the type check command.",
+    checksPerRun: 4,
+    installed: true,
+  },
+  {
+    id: "template-tests",
+    name: "Test Coverage Review",
+    domain: "tests",
+    description: "Finds changed code without tests and weak assertions, then runs the test command.",
+    checksPerRun: 4,
+    installed: false,
+  },
+  {
+    id: "template-secrets",
+    name: "Secret Scan",
+    domain: "secrets",
+    description: "Scans source, configuration, and history for committed credentials.",
+    checksPerRun: 4,
+    installed: false,
+  },
+  {
+    id: "template-dead-code",
+    name: "Dead Code Review",
+    domain: "dead-code",
+    description: "Finds unused exports, orphaned files, and stale annotations, then runs the build command.",
+    checksPerRun: 4,
+    installed: false,
+  },
+  {
+    id: "template-file-size",
+    name: "File Size Review",
+    domain: "file-size",
+    description: "Finds oversized files and modules with several responsibilities.",
+    checksPerRun: 3,
+    installed: false,
+  },
+  {
+    id: "template-dependencies",
+    name: "Dependency Audit",
+    domain: "dependencies",
+    description: "Finds unused and single-use packages, then runs the vulnerability audit command.",
+    checksPerRun: 3,
+    installed: false,
+  },
+];
+
+export const VERIFIED_DELIVERY_STEPS: PresetLineStep[] = [
+  { name: "build", type: "runApp", summary: "Run the build app for the work order branch." },
+  {
+    name: "verify",
+    type: "verify",
+    summary: "Run the quality suite. Blocking findings stop the line.",
+    checkNames: QUALITY_TEMPLATES.map((template) => template.name),
+  },
+  { name: "approval", type: "runApp", summary: "Request approval from the reviewers." },
+  { name: "close", type: "runApp", summary: "Close the work order as completed." },
+];
+
+export const HEALTH_SNAPSHOT: HealthSnapshot = {
+  score: 82,
+  change: 6,
+  target: 90,
+  series: [61, 64, 63, 68, 71, 74, 73, 78, 80, 82],
+};
+
+export const STREAKS: Streak[] = [
+  { label: "Work orders without blocking findings", current: 12, best: 21, unit: "work orders" },
+  { label: "Days without blocking findings", current: 8, best: 15, unit: "days" },
+];
+
+export const ACHIEVEMENTS: Achievement[] = [
+  {
+    id: "achievement-first-pass",
+    name: "First verification passed",
+    description: "A work order passed the full verification suite.",
+    earnedAt: daysAgo(41),
+  },
+  {
+    id: "achievement-type-safety-30",
+    name: "30 days without a type-safety finding",
+    description: "No new type-safety findings for 30 days in a row.",
+    earnedAt: daysAgo(4),
+  },
+  {
+    id: "achievement-pattern-resolved",
+    name: "Recurring pattern resolved: Stale exports after rewrites",
+    description: "The open count for this pattern reached zero.",
+    earnedAt: daysAgo(12),
+  },
+  {
+    id: "achievement-secrets-90",
+    name: "Zero secrets findings for 90 days",
+    description: "No secrets findings for 90 days in a row.",
+    progressNote: "34 days remain.",
+  },
+  {
+    id: "achievement-streak-25",
+    name: "25 work orders without blocking findings",
+    description: "25 work orders in a row passed verification.",
+    progressNote: "13 work orders remain.",
+  },
+];
+
+export const RECURRING_PATTERNS: RecurringPattern[] = [
+  {
+    id: "pattern-untyped-responses",
+    name: "Untyped API response handling",
+    description: "External payloads are read without a parse step, so type errors surface at run time.",
+    openCount: 14,
+    occurrenceSeries: [4, 6, 7, 9, 11, 12, 14],
+    topFiles: [
+      { path: "web_src/src/pages/orders/orderMapper.ts", count: 5 },
+      { path: "web_src/src/pages/reports/exportCsv.ts", count: 4 },
+      { path: "pkg/integrations/payments/webhook.go", count: 3 },
+    ],
+    remediation: "Parse every external payload with a typed parser function at the boundary.",
+  },
+  {
+    id: "pattern-untested-branches",
+    name: "New branches without tests",
+    description: "New conditional branches ship without a test that exercises them.",
+    openCount: 9,
+    occurrenceSeries: [11, 10, 10, 9, 9, 9, 9],
+    topFiles: [
+      { path: "pkg/billing/invoice.go", count: 4 },
+      { path: "pkg/workers/dispatcher.go", count: 3 },
+    ],
+    remediation: "Add one test per new branch before review. Cover the boundary values.",
+  },
+];
+
+export const RUN_SUMMARY_FAILED: RunSummaryReport = {
+  runLabel: "Verification for work order: Add proration to invoice billing",
+  detected: { high: 2, medium: 0, low: 2 },
+  fixed: { high: 1, medium: 1, low: 0 },
+  remaining: { high: 2, medium: 0, low: 2 },
+  gatePassed: false,
+  blockingCount: 2,
+};
+
+export const RUN_SUMMARY_PASSED: RunSummaryReport = {
+  runLabel: "Verification for work order: Update the export columns",
+  detected: { high: 0, medium: 0, low: 1 },
+  fixed: { high: 2, medium: 0, low: 1 },
+  remaining: { high: 0, medium: 0, low: 3 },
+  gatePassed: true,
+  blockingCount: 0,
+};

--- a/web_src/src/pages/factories/verification/findingLocation.ts
+++ b/web_src/src/pages/factories/verification/findingLocation.ts
@@ -1,0 +1,9 @@
+import type { FindingLocation } from "./types";
+
+export function formatFindingLocation(location: FindingLocation): string {
+  if (location.startLine == null) return location.path;
+  if (location.endLine == null || location.endLine === location.startLine) {
+    return `${location.path}:${location.startLine}`;
+  }
+  return `${location.path}:${location.startLine}-${location.endLine}`;
+}

--- a/web_src/src/pages/factories/verification/types.ts
+++ b/web_src/src/pages/factories/verification/types.ts
@@ -1,0 +1,205 @@
+/**
+ * Design-time types for the verification, suggestions, quality pack, and
+ * codebase health Storybook designs. These model the concepts specified in
+ * docs/prd/line-verification.md, docs/prd/verification-suggestions.md,
+ * docs/prd/code-quality-pack.md, and docs/prd/codebase-health.md.
+ *
+ * Presentational only: no API client types, no fetching. The eventual
+ * implementation replaces these with generated API types.
+ */
+
+export type QualityDomain = "type-safety" | "tests" | "secrets" | "dead-code" | "file-size" | "dependencies";
+
+export const QUALITY_DOMAIN_LABELS: Record<QualityDomain, string> = {
+  "type-safety": "Type safety",
+  tests: "Tests",
+  secrets: "Secrets",
+  "dead-code": "Dead code",
+  "file-size": "File size",
+  dependencies: "Dependencies",
+};
+
+export type FindingSeverity = "high" | "medium" | "low";
+
+export type RuleEnforcement = "blocking" | "advisory";
+
+export interface Rule {
+  id: string;
+  name: string;
+  domain: QualityDomain;
+  description: string;
+  severity: FindingSeverity;
+  enforcement: RuleEnforcement;
+}
+
+export interface RuleSet {
+  id: string;
+  name: string;
+  description: string;
+  rules: Rule[];
+}
+
+export type CheckKind = "agent" | "command";
+
+export type CheckOutcome = "running" | "passed" | "failed" | "skipped";
+
+export interface VerificationCheck {
+  id: string;
+  name: string;
+  domain: QualityDomain;
+  kind: CheckKind;
+  blocking: boolean;
+}
+
+export interface CheckResult {
+  check: VerificationCheck;
+  outcome: CheckOutcome;
+  findingCount: number;
+  /** Command line for command checks; shown so results are reproducible. */
+  command?: string;
+  summary?: string;
+}
+
+export type FindingStatus = "open" | "fixed" | "dismissed" | "accepted";
+
+export interface FindingLocation {
+  path: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+export interface Finding {
+  id: string;
+  ruleId: string;
+  ruleName: string;
+  domain: QualityDomain;
+  severity: FindingSeverity;
+  enforcement: RuleEnforcement;
+  location?: FindingLocation;
+  description: string;
+  remediation: string;
+  status: FindingStatus;
+}
+
+export type VerificationRunStatus = "running" | "passed" | "failed";
+
+export interface VerificationRun {
+  id: string;
+  suiteName: string;
+  ruleSetName: string;
+  status: VerificationRunStatus;
+  startedAt: Date;
+  finishedAt?: Date;
+  checks: CheckResult[];
+  findings: Finding[];
+}
+
+export type LineStepType = "runApp" | "verify";
+
+export interface VerifyStepDraft {
+  name: string;
+  type: LineStepType;
+  suiteId: string;
+  ruleSetName: string;
+  checks: VerificationCheck[];
+}
+
+export interface VerificationSuiteOption {
+  id: string;
+  name: string;
+  ruleSetName: string;
+  checks: VerificationCheck[];
+}
+
+export type FixDispatchTarget = "work-order" | "agent-run";
+
+export type SuggestionFixStatus = "none" | "in-progress" | "fixed";
+
+export interface Suggestion {
+  id: string;
+  finding: Finding;
+  fixPrompt: string;
+  sourceWorkOrderTitle: string;
+  occurrences: number;
+  fixStatus: SuggestionFixStatus;
+}
+
+export type OccurrenceTrend = "up" | "down" | "flat";
+
+export interface RecurringSuggestionRow {
+  id: string;
+  patternName: string;
+  ruleName: string;
+  domain: QualityDomain;
+  count: number;
+  trend: OccurrenceTrend;
+  lastSeenAt: Date;
+}
+
+export interface QualityTemplate {
+  id: string;
+  name: string;
+  domain: QualityDomain;
+  description: string;
+  checksPerRun: number;
+  installed: boolean;
+}
+
+export interface PresetLineStep {
+  name: string;
+  type: LineStepType;
+  summary: string;
+  /** Check names shown when the verify step is expanded. */
+  checkNames?: string[];
+}
+
+export interface HealthSnapshot {
+  score: number;
+  /** Score change versus the previous period; negative means decline. */
+  change: number;
+  target?: number;
+  /** Oldest-first score series for the sparkline. */
+  series: number[];
+}
+
+export interface Streak {
+  label: string;
+  current: number;
+  best: number;
+  unit: string;
+}
+
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  earnedAt?: Date;
+  /** What remains to earn it; set only when not yet earned. */
+  progressNote?: string;
+}
+
+export interface RecurringPattern {
+  id: string;
+  name: string;
+  description: string;
+  openCount: number;
+  /** Oldest-first occurrence counts for the trend sparkline. */
+  occurrenceSeries: number[];
+  topFiles: { path: string; count: number }[];
+  remediation: string;
+}
+
+export interface SeverityCounts {
+  high: number;
+  medium: number;
+  low: number;
+}
+
+export interface RunSummaryReport {
+  runLabel: string;
+  detected: SeverityCounts;
+  fixed: SeverityCounts;
+  remaining: SeverityCounts;
+  gatePassed: boolean;
+  blockingCount: number;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change specifies a verification layer for factory lines and designs its UI, without application code changes. Four PRDs in `docs/prd/` define the product areas: verification steps in lines with rule sets and findings, a findings-to-suggestions loop with a dispatch-fix action, a prebuilt code quality pack with a preset line, and a gamified codebase health surface.

The matching Storybook designs live under `web_src/src/pages/factories/verification/`, `quality-pack/`, and `health/`. All new components are presentational and are referenced only from stories. There are no changes to routes, application pages, protos, backend code, or the template manifest.

## Design walkthrough

[storybook_walkthrough_verification_quality_pack_health_designs.mp4](https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_walkthrough_verification_quality_pack_health_designs.mp4)

[Health page story](https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhealth_page_story.webp)
[Verification panel with a failed run](https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverification_panel_failed_story.webp)
[Line step editor with a verify step](https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fline_step_editor_verify_story.webp)
[Rule set editor with YAML preview](https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frule_set_editor_story.webp)
[Suggestion card with the dispatch-fix menu open](https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuggestion_card_dispatch_fix_story.webp)
[Quality template gallery](https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquality_template_gallery_story.webp)
[Preset line preview](https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreset_line_preview_story.webp)

## Test plan

- [ ] Read the four PRDs in `docs/prd/` and confirm the concepts stay consistent across them.
- [ ] Run `make check.build.ui` and confirm it passes.
- [ ] Run `make check.lint.ui` and confirm the budget check passes.
- [ ] Run `npm run build-storybook` in `web_src` and confirm it completes.
- [ ] Open Storybook and review the stories under `Factories/Verification`, `Factories/Quality Pack`, and `Factories/Health`.
- [ ] Confirm no application page imports the new components.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0048b-a16a-76a9-b845-bcd49d80a18e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0048b-a16a-76a9-b845-bcd49d80a18e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

