### PR TITLE
docs: note WSL2 as a supported option for Windows users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ your machine. Everything runs in containers managed by Make and Docker.
 
 Before you begin, make sure you have the following:
 
-- You are running MacOS or Linux
+- You are running MacOS or Linux (Windows users can use [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) with a Linux distribution such as Ubuntu)
 - [Make](https://www.gnu.org/software/make/)
-- [Docker](https://www.docker.com/)
+- [Docker](https://www.docker.com/) — if using WSL2, enable [Docker Desktop's WSL2 integration](https://docs.docker.com/desktop/wsl/) for your distro
 
 ### Forking and Cloning the Repository
 


### PR DESCRIPTION
## What changedAdded a note in the Prerequisites section of CONTRIBUTING.md that Windows users can satisfy the "MacOS or Linux" requirement by using WSL2, along with a link to Docker Desktop's WSL2 integration setting.
## WhyThe prerequisites currently list only "MacOS or Linux," which could lead Windows contributors to think they need a separate machine, VM, or dual-boot setup to contribute. WSL2 (with Docker Desktop's WSL2 integration enabled) works fine for the full make dev.up / make dev.setup / make dev.server flow — I went through this setup myself while getting the dev environment running and thought it was worth calling out explicitly for other Windows-based contributors.
## HowSmall documentation-only change — one bullet point updated in the Pre-requisites list, no code or behavior changes.
## Related issues
None — noticed this gap while setting up the dev environment for the first time.
