### PR TITLE
fix: Quote host paths in Docker volume mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OPENAPI_GENERATOR_IMAGE := openapitools/openapi-generator-cli:v7.13.0
 # - exports junit report
 # - sets parallelism to 1
 #
-GOTESTSUM=$(COMPOSE) run --rm -e DB_NAME=superplane_test -v "$(PWD)/tmp/screenshots:/app/test/screenshots" app gotestsum --format short --junitfile junit-report.xml
+GOTESTSUM=$(COMPOSE) run --rm -e DB_NAME=superplane_test -v "$(CURDIR)/tmp/screenshots:/app/test/screenshots" app gotestsum --format short --junitfile junit-report.xml
 
 #
 # Targets for test environment
@@ -77,7 +77,7 @@ test.watch:
 	$(GOTESTSUM) --packages="$(PKG_TEST_PACKAGES)" --watch -- -p 1
 
 test.shell:
-	$(COMPOSE) run --rm -e DB_NAME=superplane_test -v "$(PWD)/tmp/screenshots:/app/test/screenshots" app /bin/bash
+	$(COMPOSE) run --rm -e DB_NAME=superplane_test -v "$(CURDIR)/tmp/screenshots:/app/test/screenshots" app /bin/bash
 
 #
 # Code formatting
@@ -345,7 +345,7 @@ openapi.client.gen: dev.test.is.running
 	@./scripts/docker-pull-retry $(OPENAPI_GENERATOR_IMAGE)
 	@log=$$(mktemp); trap 'rm -f "$$log"' EXIT; \
 	if ! docker run --rm --user $(shell id -u):$(shell id -g) \
-		-v "$(PWD):/local" $(OPENAPI_GENERATOR_IMAGE) generate \
+		-v "$(CURDIR):/local" $(OPENAPI_GENERATOR_IMAGE) generate \
 		-i /local/api/swagger/superplane.swagger.json \
 		-g go \
 		-o /local/pkg/openapi_client \

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OPENAPI_GENERATOR_IMAGE := openapitools/openapi-generator-cli:v7.13.0
 # - exports junit report
 # - sets parallelism to 1
 #
-GOTESTSUM=$(COMPOSE) run --rm -e DB_NAME=superplane_test -v $(PWD)/tmp/screenshots:/app/test/screenshots app gotestsum --format short --junitfile junit-report.xml 
+GOTESTSUM=$(COMPOSE) run --rm -e DB_NAME=superplane_test -v "$(PWD)/tmp/screenshots:/app/test/screenshots" app gotestsum --format short --junitfile junit-report.xml
 
 #
 # Targets for test environment
@@ -77,7 +77,7 @@ test.watch:
 	$(GOTESTSUM) --packages="$(PKG_TEST_PACKAGES)" --watch -- -p 1
 
 test.shell:
-	$(COMPOSE) run --rm -e DB_NAME=superplane_test -v $(PWD)/tmp/screenshots:/app/test/screenshots app /bin/bash	
+	$(COMPOSE) run --rm -e DB_NAME=superplane_test -v "$(PWD)/tmp/screenshots:/app/test/screenshots" app /bin/bash
 
 #
 # Code formatting
@@ -345,7 +345,7 @@ openapi.client.gen: dev.test.is.running
 	@./scripts/docker-pull-retry $(OPENAPI_GENERATOR_IMAGE)
 	@log=$$(mktemp); trap 'rm -f "$$log"' EXIT; \
 	if ! docker run --rm --user $(shell id -u):$(shell id -g) \
-		-v ${PWD}:/local $(OPENAPI_GENERATOR_IMAGE) generate \
+		-v "$(PWD):/local" $(OPENAPI_GENERATOR_IMAGE) generate \
 		-i /local/api/swagger/superplane.swagger.json \
 		-g go \
 		-o /local/pkg/openapi_client \


### PR DESCRIPTION
## Summary

The Makefile passes $(PWD) to Docker volume flags without quotes. When the repository path contains a space, Docker rejects the argument with "invalid reference format".

This breaks the documented onboarding flow. `make dev.setup` removes `pkg/openapi_client` and `web_src/src/api-client` before the generator runs, then fails. The development stack stays broken: the Go CLI packages do not build, and Vite fails on the missing `@/api-client/sdk.gen` import.

This change quotes the three volume arguments, so all Make targets work from any checkout location.

## Test plan

- [x] Clone the repository into a path with a space, for example `~/Web Projects/superplane`.
- [x] Run `make dev.up` and `make dev.setup`. Before this change, `openapi.client.gen` fails with "invalid reference format".
- [x] Run `make openapi.client.gen`. The target completes and `pkg/openapi_client` is generated.
- [x] Run `make test PKG_TEST_PACKAGES=./pkg/retry`. The quoted screenshots mount works.
- [x] Run `make dev.setup` from a path without a space. Confirm no regression.