### PR TITLE
fix: Fail agent session when turn deadline expires

### DIFF
--- a/pkg/models/agent_session.go
+++ b/pkg/models/agent_session.go
@@ -282,9 +282,12 @@ func MarkAgentSessionTokenUsageTracked(sessionID uuid.UUID, usage AgentSessionTo
 			return err
 		}
 
+		// UpdateColumns keeps updated_at untouched: bumping it here would
+		// break the optimistic status guard in UpdateAgentSessionStatusIfUnchanged
+		// for any turn that tracked token usage.
 		return tx.Model(&AgentSession{}).
 			Where("id = ?", sessionID).
-			Updates(map[string]any{
+			UpdateColumns(map[string]any{
 				"tracked_usage_input_tokens":       maxInt64(session.TrackedUsageInputTokens, usage.InputTokens),
 				"tracked_usage_output_tokens":      maxInt64(session.TrackedUsageOutputTokens, usage.OutputTokens),
 				"tracked_usage_cache_read_tokens":  maxInt64(session.TrackedUsageCacheReadTokens, usage.CacheReadTokens),
@@ -302,7 +305,11 @@ func MarkAgentSessionTokenUsageTracked(sessionID uuid.UUID, usage AgentSessionTo
 func FailStuckStreamingSessions(heartbeatCutoff, legacyCutoff time.Time) ([]AgentSession, error) {
 	var stuck []AgentSession
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		// Lock the rows so a concurrent InterruptSession cannot flip a
+		// session to idle between this read and the update below; without
+		// the lock a user Stop could be overwritten with failed.
 		if err := tx.
+			Clauses(clause.Locking{Strength: "UPDATE"}).
 			Where("status = ?", AgentSessionStatusStreaming).
 			Where("(heartbeat_at IS NOT NULL AND heartbeat_at < ?) OR (heartbeat_at IS NULL AND updated_at < ?)", heartbeatCutoff, legacyCutoff).
 			Find(&stuck).Error; err != nil {
@@ -317,7 +324,7 @@ func FailStuckStreamingSessions(heartbeatCutoff, legacyCutoff time.Time) ([]Agen
 		}
 		now := time.Now()
 		return tx.Model(&AgentSession{}).
-			Where("id IN ?", ids).
+			Where("id IN ? AND status = ?", ids, AgentSessionStatusStreaming).
 			Updates(map[string]any{
 				"status":       AgentSessionStatusFailed,
 				"updated_at":   &now,

--- a/pkg/workers/agent_stream_classify_test.go
+++ b/pkg/workers/agent_stream_classify_test.go
@@ -1,0 +1,84 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyTurnError(t *testing.T) {
+	background := context.Background()
+
+	expiredTurn, cancelExpired := context.WithTimeout(background, time.Nanosecond)
+	defer cancelExpired()
+	<-expiredTurn.Done()
+
+	canceledParent, cancelParent := context.WithCancel(background)
+	cancelParent()
+
+	liveTurn, cancelLive := context.WithTimeout(background, time.Hour)
+	defer cancelLive()
+
+	providerErr := errors.New("provider exploded")
+
+	tests := []struct {
+		name      string
+		parentCtx context.Context
+		turnCtx   context.Context
+		err       error
+		want      error
+	}{
+		{
+			name:      "clean end is not an error even during shutdown",
+			parentCtx: canceledParent,
+			turnCtx:   liveTurn,
+			err:       nil,
+			want:      nil,
+		},
+		{
+			name:      "expired turn deadline fails the turn",
+			parentCtx: background,
+			turnCtx:   expiredTurn,
+			err:       context.DeadlineExceeded,
+			want:      errTurnDeadlineExpired,
+		},
+		{
+			name:      "expired turn deadline wins over a racing shutdown",
+			parentCtx: canceledParent,
+			turnCtx:   expiredTurn,
+			err:       context.DeadlineExceeded,
+			want:      errTurnDeadlineExpired,
+		},
+		{
+			name:      "shutdown with a truncated stream has no outcome",
+			parentCtx: canceledParent,
+			turnCtx:   liveTurn,
+			err:       context.Canceled,
+			want:      errWorkerShutdown,
+		},
+		{
+			name:      "provider-internal deadline is a plain provider error, not the turn deadline",
+			parentCtx: background,
+			turnCtx:   liveTurn,
+			err:       context.DeadlineExceeded,
+			want:      context.DeadlineExceeded,
+		},
+		{
+			name:      "provider error passes through",
+			parentCtx: background,
+			turnCtx:   liveTurn,
+			err:       providerErr,
+			want:      providerErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyTurnError(tt.parentCtx, tt.turnCtx, tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -45,6 +45,27 @@ var errWorkerShutdown = errors.New("agent stream worker interrupted")
 
 var errTurnDeadlineExpired = fmt.Errorf("provider turn did not complete within %v", agentStreamTimeout)
 
+// classifyTurnError maps the error a provider turn ended with to the turn's
+// outcome. turnCtx is the worker's own per-turn deadline context; only its
+// expiry counts as the turn deadline, so a provider-internal timeout is not
+// misreported as agentStreamTimeout. A canceled parent means worker shutdown:
+// the turn has no outcome and the session must stay streaming for cleanup —
+// unless the turn deadline had already expired, which is a real outcome.
+func classifyTurnError(parentCtx, turnCtx context.Context, err error) error {
+	switch {
+	case err == nil:
+		// The stream ended cleanly; a shutdown racing in after that does
+		// not un-complete the turn.
+		return nil
+	case turnCtx.Err() == context.DeadlineExceeded:
+		return errTurnDeadlineExpired
+	case parentCtx.Err() != nil:
+		return errWorkerShutdown
+	default:
+		return err
+	}
+}
+
 var publishAgentRunFinished = func(session *models.AgentSession, evt agents.ProviderEvent, idempotencyKey string) error {
 	return messages.NewAgentRunFinishedMessage(
 		session.OrganizationID.String(),
@@ -368,6 +389,9 @@ func (w *AgentStreamWorker) handleLocked(parentCtx context.Context, req messages
 		}).Warn("agent stream: provider mismatch, dropping")
 		return nil
 	}
+	// A streaming row is either a live turn or one a shut-down worker
+	// abandoned for cleanup; a later request may legitimately resume the
+	// latter here before FailStuckStreamingSessions reclaims it.
 	if session.Status != models.AgentSessionStatusStreaming {
 		log.WithFields(log.Fields{
 			"session_id": sessionID,
@@ -388,15 +412,16 @@ func (w *AgentStreamWorker) handleLocked(parentCtx context.Context, req messages
 		publish(messages.AgentSessionEventMessage{Event: "stream_started", Status: models.AgentSessionStatusStreaming})
 
 		streamErr := w.streamProviderTurn(parentCtx, session, publish)
-		closeOpenTools(sessionID, publish)
 
 		if errors.Is(streamErr, errWorkerShutdown) {
 			// Leave the row streaming: FailStuckStreamingSessions (or
 			// another replica) reclaims it once the heartbeat goes stale.
 			// Marking it failed here would burst failures on every deploy.
+			// Open tools are left open too — the turn has no outcome.
 			log.WithField("session_id", sessionID).Info("agent stream: worker interrupted mid-turn, leaving session streaming for cleanup")
 			return nil
 		}
+		closeOpenTools(sessionID, publish)
 
 		if streamErr != nil {
 			// Conditional on turnStartedAt so a stream that errors out
@@ -470,37 +495,22 @@ func (w *AgentStreamWorker) streamProviderTurn(
 		if errors.Is(err, errSessionAlreadyReset) {
 			return nil
 		}
-		if err != nil && parentCtx.Err() != nil {
-			// Worker shutdown: the turn has no outcome. Report it so the
-			// caller leaves the row streaming for stuck-session cleanup.
-			return errWorkerShutdown
-		}
-		if streamErr == nil && err != nil {
-			switch {
-			case errors.Is(err, context.DeadlineExceeded):
-				// The turn hit agentStreamTimeout. Partial output is not a
-				// completed turn; fail the session so the UI unblocks.
-				streamErr = errTurnDeadlineExpired
-			case errors.Is(err, context.Canceled):
-				// A cancellation that is not the worker's own shutdown has
-				// no known producer; keep the previous behavior and end
-				// the turn without an error.
-			default:
-				streamErr = err
-			}
+		if streamErr == nil {
+			// A failure the provider already reported (streamErr) is a real
+			// turn outcome and wins over the shutdown classification below.
+			streamErr = classifyTurnError(parentCtx, ctx, err)
 		}
 		if streamErr != nil || !customTools.resultsRequired {
 			return streamErr
 		}
 
+		if parentCtx.Err() != nil {
+			// Do not execute side-effecting custom tools with a dead
+			// context: the resumed session would run them again.
+			return errWorkerShutdown
+		}
 		if err := w.executeAndSendCustomToolResults(ctx, session, customTools, publish); err != nil {
-			if parentCtx.Err() != nil {
-				return errWorkerShutdown
-			}
-			if errors.Is(err, context.DeadlineExceeded) {
-				return errTurnDeadlineExpired
-			}
-			return err
+			return classifyTurnError(parentCtx, ctx, err)
 		}
 	}
 }

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -41,6 +41,9 @@ const (
 var errCustomToolResultsRequired = errors.New("custom tool results required")
 var errAgentStreamAlreadyLocked = errors.New("agent stream already in progress")
 var errSessionAlreadyReset = errors.New("agent session no longer streaming")
+var errWorkerShutdown = errors.New("agent stream worker interrupted")
+
+var errTurnDeadlineExpired = fmt.Errorf("provider turn did not complete within %v", agentStreamTimeout)
 
 var publishAgentRunFinished = func(session *models.AgentSession, evt agents.ProviderEvent, idempotencyKey string) error {
 	return messages.NewAgentRunFinishedMessage(
@@ -387,6 +390,14 @@ func (w *AgentStreamWorker) handleLocked(parentCtx context.Context, req messages
 		streamErr := w.streamProviderTurn(parentCtx, session, publish)
 		closeOpenTools(sessionID, publish)
 
+		if errors.Is(streamErr, errWorkerShutdown) {
+			// Leave the row streaming: FailStuckStreamingSessions (or
+			// another replica) reclaims it once the heartbeat goes stale.
+			// Marking it failed here would burst failures on every deploy.
+			log.WithField("session_id", sessionID).Info("agent stream: worker interrupted mid-turn, leaving session streaming for cleanup")
+			return nil
+		}
+
 		if streamErr != nil {
 			// Conditional on turnStartedAt so a stream that errors out
 			// after the user already hit Stop (InterruptSession bumps
@@ -459,14 +470,36 @@ func (w *AgentStreamWorker) streamProviderTurn(
 		if errors.Is(err, errSessionAlreadyReset) {
 			return nil
 		}
-		if streamErr == nil && err != nil && !isContextCancel(err) {
-			streamErr = err
+		if err != nil && parentCtx.Err() != nil {
+			// Worker shutdown: the turn has no outcome. Report it so the
+			// caller leaves the row streaming for stuck-session cleanup.
+			return errWorkerShutdown
+		}
+		if streamErr == nil && err != nil {
+			switch {
+			case errors.Is(err, context.DeadlineExceeded):
+				// The turn hit agentStreamTimeout. Partial output is not a
+				// completed turn; fail the session so the UI unblocks.
+				streamErr = errTurnDeadlineExpired
+			case errors.Is(err, context.Canceled):
+				// A cancellation that is not the worker's own shutdown has
+				// no known producer; keep the previous behavior and end
+				// the turn without an error.
+			default:
+				streamErr = err
+			}
 		}
 		if streamErr != nil || !customTools.resultsRequired {
 			return streamErr
 		}
 
 		if err := w.executeAndSendCustomToolResults(ctx, session, customTools, publish); err != nil {
+			if parentCtx.Err() != nil {
+				return errWorkerShutdown
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				return errTurnDeadlineExpired
+			}
 			return err
 		}
 	}
@@ -1124,11 +1157,4 @@ func runStreamHeartbeat(ctx context.Context, sessionID uuid.UUID) {
 			}
 		}
 	}
-}
-
-func isContextCancel(err error) bool {
-	if err == nil {
-		return false
-	}
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/pkg/workers/agent_stream_worker_test.go
+++ b/pkg/workers/agent_stream_worker_test.go
@@ -629,6 +629,65 @@ func TestAgentStreamWorker_MarksFailedOnSessionError(t *testing.T) {
 	assert.Equal(t, models.AgentSessionStatusFailed, refreshed.Status)
 }
 
+func TestAgentStreamWorker_MarksFailedWhenTurnDeadlineExpires(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	session := mustCreateSession(t, r, canvas.ID)
+
+	provider := &scriptedProvider{
+		name: testProvider,
+		err:  context.DeadlineExceeded,
+	}
+
+	w := workers.NewAgentStreamWorker(provider, "amqp://ignored")
+	body, _ := json.Marshal(messages.AgentStreamRequest{
+		SessionID: session.ID.String(),
+	})
+	require.NoError(t, w.Handle(context.Background(), body))
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusFailed, refreshed.Status,
+		"a turn cut short by its deadline must fail the session, not read as a completed turn")
+}
+
+func TestAgentStreamWorker_LeavesSessionStreamingOnWorkerShutdown(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	session := mustCreateSession(t, r, canvas.ID)
+
+	provider := &scriptedProvider{
+		name:        testProvider,
+		streamReady: make(chan struct{}),
+		// release is never closed, so StreamEvents blocks until the
+		// worker's context ends and then returns ctx.Err().
+		release: make(chan struct{}),
+	}
+
+	w := workers.NewAgentStreamWorker(provider, "amqp://ignored")
+	body, _ := json.Marshal(messages.AgentStreamRequest{
+		SessionID: session.ID.String(),
+	})
+
+	parentCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Handle(parentCtx, body)
+	}()
+	<-provider.streamReady
+
+	cancel()
+	require.NoError(t, <-done)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status,
+		"a turn interrupted by worker shutdown has no outcome; the row must stay streaming so cleanup can reclaim it")
+}
+
 func TestAgentStreamWorker_SkipsUnknownProvider(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()

--- a/pkg/workers/agent_stream_worker_test.go
+++ b/pkg/workers/agent_stream_worker_test.go
@@ -649,7 +649,7 @@ func TestAgentStreamWorker_MarksFailedWhenTurnDeadlineExpires(t *testing.T) {
 	refreshed, err := models.FindAgentSession(session.ID)
 	require.NoError(t, err)
 	assert.Equal(t, models.AgentSessionStatusFailed, refreshed.Status,
-		"a turn cut short by its deadline must fail the session, not read as a completed turn")
+		"a deadline error from the provider must fail the session, not read as a completed turn")
 }
 
 func TestAgentStreamWorker_LeavesSessionStreamingOnWorkerShutdown(t *testing.T) {
@@ -671,21 +671,41 @@ func TestAgentStreamWorker_LeavesSessionStreamingOnWorkerShutdown(t *testing.T) 
 		SessionID: session.ID.String(),
 	})
 
+	// Production rows always carry a heartbeat (dispatch starts one before
+	// handling); seed it so the reclaim assertion below exercises the
+	// heartbeat branch of FailStuckStreamingSessions, not the legacy one.
+	require.NoError(t, models.TouchAgentSessionHeartbeat(session.ID))
+
 	parentCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan error, 1)
 	go func() {
 		done <- w.Handle(parentCtx, body)
 	}()
-	<-provider.streamReady
+	select {
+	case <-provider.streamReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("worker never reached StreamEvents")
+	}
 
 	cancel()
-	require.NoError(t, <-done)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Handle did not return after parent context cancel")
+	}
 
 	refreshed, err := models.FindAgentSession(session.ID)
 	require.NoError(t, err)
 	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status,
 		"a turn interrupted by worker shutdown has no outcome; the row must stay streaming so cleanup can reclaim it")
+
+	// The abandoned row must be reclaimable through the heartbeat branch.
+	reclaimed, err := models.FailStuckStreamingSessions(time.Now().Add(time.Minute), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, reclaimed, 1)
+	assert.Equal(t, session.ID, reclaimed[0].ID)
 }
 
 func TestAgentStreamWorker_SkipsUnknownProvider(t *testing.T) {


### PR DESCRIPTION
## Summary

A provider turn that runs longer than `agentStreamTimeout` is recorded as a successful turn. The session is marked `idle`, no terminal event is published, and the chat stays on "thinking" until the user reloads the page. `FailStuckStreamingSessions` cannot reclaim the row because it only scans `streaming` sessions.

This change makes the expired deadline a stream error. The worker marks the session `failed` and publishes `session_failed`, so the UI unblocks.

A turn interrupted by worker shutdown is a different case: it has no outcome. The worker now leaves the row `streaming`, so stuck-session cleanup or another replica reclaims it after the heartbeat goes stale. Without this second part, every deploy would convert in-flight turns into a burst of failed sessions.

The change removes `isContextCancel`. The user Stop path does not cancel the worker context; it is already handled through `errSessionAlreadyReset`.

Resolves #6462

## Test plan

- [x] Add a test: a provider stream that returns `context.DeadlineExceeded` marks the session `failed`, not `idle`.
- [x] Add a test: a parent context cancel mid-turn leaves the session `streaming` for cleanup.
- [x] Run `make test PKG_TEST_PACKAGES=./pkg/workers`. All 178 tests pass.
- [x] Run `make format.go`, `make lint`, and `make check.build.app`. All pass.
- [x] Manual check: start an agent turn, stop the provider mid-stream with a deadline error, and confirm the chat shows the failure instead of a stuck "thinking" state.