### PR TITLE
fix: Keep work order assignee edits during refetch

### DIFF
--- a/web_src/src/pages/factories/WorkOrderAssigneePicker.spec.tsx
+++ b/web_src/src/pages/factories/WorkOrderAssigneePicker.spec.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorkOrderAssigneePicker } from "./WorkOrderAssigneePicker";
+
+vi.mock("@/hooks/useOrganizationData", () => ({
+  useOrganizationUsers: () => ({
+    data: [
+      {
+        metadata: { id: "user-alex", email: "alex@superplane.dev" },
+        spec: { displayName: "Alex Reviewer" },
+      },
+      {
+        metadata: { id: "user-blake", email: "blake@superplane.dev" },
+        spec: { displayName: "Blake Builder" },
+      },
+      {
+        metadata: { id: "user-casey", email: "casey@superplane.dev" },
+        spec: { displayName: "Casey Coder" },
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+function memberOrder() {
+  return screen.getAllByRole("listitem").map((row) => {
+    const spans = row.querySelectorAll("span");
+    return spans[spans.length - 1]?.textContent ?? "";
+  });
+}
+
+describe("WorkOrderAssigneePicker", () => {
+  it("lists members alphabetically when nobody is assigned", () => {
+    render(<WorkOrderAssigneePicker organizationId="org-1" selectedIds={[]} onChange={vi.fn()} />);
+
+    expect(memberOrder()).toEqual(["Alex Reviewer", "Blake Builder", "Casey Coder"]);
+  });
+
+  it("lists the assigned members first", () => {
+    render(<WorkOrderAssigneePicker organizationId="org-1" selectedIds={["user-casey"]} onChange={vi.fn()} />);
+
+    expect(memberOrder()).toEqual(["Casey Coder", "Alex Reviewer", "Blake Builder"]);
+  });
+
+  it("keeps the order stable while the selection changes", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<WorkOrderAssigneePicker organizationId="org-1" selectedIds={["user-casey"]} onChange={onChange} />);
+
+    await user.click(screen.getAllByRole("checkbox")[1]);
+
+    expect(onChange).toHaveBeenCalledWith(["user-casey", "user-alex"]);
+    expect(memberOrder()).toEqual(["Casey Coder", "Alex Reviewer", "Blake Builder"]);
+  });
+});

--- a/web_src/src/pages/factories/WorkOrderAssigneePicker.tsx
+++ b/web_src/src/pages/factories/WorkOrderAssigneePicker.tsx
@@ -3,7 +3,7 @@ import { Avatar } from "@/components/Avatar/avatar";
 import { useOrganizationUsers } from "@/hooks/useOrganizationData";
 import { buildOrgUserDisplayMap, getUserInitials, resolveOrgUserDisplay } from "@/lib/orgUserDisplay";
 import { cn } from "@/lib/utils";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 interface WorkOrderAssigneePickerProps {
   organizationId: string;
@@ -21,6 +21,8 @@ export function WorkOrderAssigneePicker({
   variant = "default",
 }: WorkOrderAssigneePickerProps) {
   const { data: users = [], isLoading } = useOrganizationUsers(organizationId);
+
+  const [assignedOnOpen] = useState(() => new Set(selectedIds));
 
   const userOptions = useMemo(() => {
     const usersById = buildOrgUserDisplayMap(users);
@@ -41,8 +43,16 @@ export function WorkOrderAssigneePicker({
           display,
         };
       })
-      .sort((left, right) => left.label.localeCompare(right.label));
-  }, [users]);
+      .sort((left, right) => {
+        const leftAssigned = assignedOnOpen.has(left.id);
+        const rightAssigned = assignedOnOpen.has(right.id);
+        if (leftAssigned !== rightAssigned) {
+          return leftAssigned ? -1 : 1;
+        }
+
+        return left.label.localeCompare(right.label);
+      });
+  }, [assignedOnOpen, users]);
 
   const toggleUser = (userId: string, checked: boolean) => {
     if (disabled) {

--- a/web_src/src/pages/factories/WorkOrderAssigneesPopover.spec.tsx
+++ b/web_src/src/pages/factories/WorkOrderAssigneesPopover.spec.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorkOrderAssigneesPopover } from "./WorkOrderAssigneesPopover";
+
+vi.mock("@/hooks/useOrganizationData", () => ({
+  useOrganizationUsers: () => ({
+    data: [
+      {
+        metadata: { id: "user-alex", email: "alex@superplane.dev" },
+        spec: { displayName: "Alex Reviewer" },
+      },
+      {
+        metadata: { id: "user-blake", email: "blake@superplane.dev" },
+        spec: { displayName: "Blake Builder" },
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+function popover(selectedIds: string[], onSave: (ids: string[]) => Promise<void>) {
+  return (
+    <WorkOrderAssigneesPopover organizationId="org-1" selectedIds={selectedIds} onSave={onSave}>
+      <button type="button">Owner</button>
+    </WorkOrderAssigneesPopover>
+  );
+}
+
+function memberOrder() {
+  return screen.getAllByRole("listitem").map((row) => {
+    const spans = row.querySelectorAll("span");
+    return spans[spans.length - 1]?.textContent ?? "";
+  });
+}
+
+describe("WorkOrderAssigneesPopover", () => {
+  it("saves the deselection after the order refetches while the popover is open", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(popover(["user-alex"], onSave));
+
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+    await user.click(screen.getByRole("checkbox", { name: /Alex Reviewer/ }));
+
+    rerender(popover(["user-alex"], onSave));
+
+    await user.click(screen.getByTestId("work-order-save-assignees"));
+
+    expect(onSave).toHaveBeenCalledWith([]);
+  });
+
+  it("seeds the draft from the current assignees each time it opens", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(popover([], onSave));
+
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+    await user.click(screen.getByRole("checkbox", { name: /Blake Builder/ }));
+    await user.click(screen.getByTestId("work-order-save-assignees"));
+
+    expect(onSave).toHaveBeenCalledWith(["user-blake"]);
+
+    rerender(popover(["user-blake"], onSave));
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+
+    expect(screen.getByRole("checkbox", { name: /Blake Builder/ })).toBeChecked();
+  });
+
+  it("regroups the assigned member to the top when reopened", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(popover(["user-blake"], onSave));
+
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+    expect(memberOrder()).toEqual(["Blake Builder", "Alex Reviewer"]);
+    await user.keyboard("{Escape}");
+
+    rerender(popover(["user-alex"], onSave));
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+
+    expect(memberOrder()).toEqual(["Alex Reviewer", "Blake Builder"]);
+  });
+
+  it("discards an unsaved draft when the popover closes", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    render(popover(["user-alex"], onSave));
+
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+    await user.click(screen.getByRole("checkbox", { name: /Alex Reviewer/ }));
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+
+    expect(screen.getByRole("checkbox", { name: /Alex Reviewer/ })).toBeChecked();
+  });
+});

--- a/web_src/src/pages/factories/WorkOrderAssigneesPopover.tsx
+++ b/web_src/src/pages/factories/WorkOrderAssigneesPopover.tsx
@@ -1,6 +1,6 @@
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
-import { useEffect, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { WorkOrderAssigneePicker } from "./WorkOrderAssigneePicker";
 
 interface WorkOrderAssigneesPopoverProps {
@@ -30,22 +30,17 @@ export function WorkOrderAssigneesPopover({
   const [draftIds, setDraftIds] = useState<string[]>(selectedIds);
   const isSaveMode = Boolean(onSave);
 
-  useEffect(() => {
-    if (open) {
-      setDraftIds(selectedIds);
-    }
-  }, [open, selectedIds]);
-
   const handleOpenChange = (nextOpen: boolean) => {
     if (isSaving) {
       return;
     }
 
+    // Seed the draft when the popover opens and reset it when it closes. The
+    // draft must not follow `selectedIds` while the popover stays open: the
+    // work order refetches on websocket events, which rebuilds the assignee
+    // array and would discard the edit in progress.
+    setDraftIds(selectedIds);
     setOpen(nextOpen);
-
-    if (!nextOpen && isSaveMode) {
-      setDraftIds(selectedIds);
-    }
   };
 
   const handleChange = (nextIds: string[]) => {


### PR DESCRIPTION
The assignees popover synced its draft state from the `selectedIds` prop on every change of that prop, not only when the popover opened. The work order detail page rebuilds the assignee array on each render, and the factory websocket invalidates the work order query on each order event. A refetch while the popover stayed open therefore replaced the draft with the server state.

A user who removed all assignees and then clicked Save sent the original assignee list. The request succeeded and the UI showed the "Assignees updated" toast, but the users stayed assigned.

Seed the draft when the popover opens and reset it when the popover closes. The draft no longer follows the prop while the popover is open.

Also group the members that are already assigned at the top of the picker. The order is anchored to the assignees present when the picker mounts, so rows do not move while the user toggles checkboxes.

Closes #6681