### PR TITLE
fix: Theme payload JSON in the component sidebar

### DIFF
--- a/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.spec.tsx
+++ b/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.spec.tsx
@@ -1,0 +1,71 @@
+import type { CSSProperties } from "react";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { darkJsonViewStyle, lightJsonViewStyle } from "@/lib/jsonViewTheme";
+import type { SidebarEvent } from "../types";
+import { SidebarEventItem } from "./SidebarEventItem";
+
+const { jsonViewStyles, themeState } = vi.hoisted(() => ({
+  jsonViewStyles: [] as CSSProperties[],
+  themeState: { resolvedTheme: "light" as "light" | "dark" },
+}));
+
+vi.mock("@uiw/react-json-view", () => ({
+  default: ({ style }: { style?: CSSProperties }) => {
+    jsonViewStyles.push(style ?? {});
+    return <div data-testid="json-view" />;
+  },
+}));
+
+vi.mock("@/contexts/useTheme", () => ({
+  useTheme: () => ({
+    preference: themeState.resolvedTheme,
+    resolvedTheme: themeState.resolvedTheme,
+    setPreference: () => undefined,
+  }),
+}));
+
+vi.mock("@tippyjs/react/headless", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const event: SidebarEvent = {
+  id: "event-1",
+  title: "HTTP Request",
+  subtitle: "GET",
+  state: "success",
+};
+
+const payload = { status: 200, body: { ok: true } };
+
+function renderPayloadItem() {
+  return render(<SidebarEventItem event={event} index={0} isOpen onToggleOpen={vi.fn()} tabData={{ payload }} />);
+}
+
+describe("SidebarEventItem payload JSON theme", () => {
+  beforeEach(() => {
+    jsonViewStyles.length = 0;
+    themeState.resolvedTheme = "light";
+  });
+
+  it("applies the dark jsonViewTheme to the payload viewer", () => {
+    themeState.resolvedTheme = "dark";
+    renderPayloadItem();
+
+    expect(screen.getByTestId("json-view")).toBeInTheDocument();
+    expect(jsonViewStyles[0]).toMatchObject({
+      backgroundColor: darkJsonViewStyle.backgroundColor,
+      color: darkJsonViewStyle.color,
+    });
+  });
+
+  it("applies the light jsonViewTheme to the payload viewer", () => {
+    renderPayloadItem();
+
+    expect(jsonViewStyles[0]).toMatchObject({
+      backgroundColor: lightJsonViewStyle.backgroundColor,
+      color: lightJsonViewStyle.color,
+    });
+  });
+});

--- a/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.tsx
+++ b/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.tsx
@@ -1,14 +1,24 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Button } from "@/components/ui/button";
+import { useTheme } from "@/contexts/useTheme";
+import { getJsonViewStyle, jsonViewClassName } from "@/lib/jsonViewTheme";
 import { resolveIcon, isUrl } from "@/lib/utils";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { SidebarEvent } from "../types";
 import { SidebarEventActionsMenu } from "./SidebarEventActionsMenu";
 import JsonView from "@uiw/react-json-view";
 import { SimpleTooltip } from "../SimpleTooltip";
-import type { EventState, EventStateMap, EventStateStyle } from "@/ui/componentBase";
-import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import type { EventState, EventStateMap, EventStateStyle } from "@/ui/componentBase/eventState";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase/defaultEventStateMap";
 import type { CanvasesCanvasNodeExecution } from "@/api-client";
+
+function payloadJsonValue(payload: unknown): object {
+  if (typeof payload === "string") {
+    return JSON.parse(payload) as object;
+  }
+
+  return payload as object;
+}
 
 export interface TabData {
   current?: Record<string, any>;
@@ -62,6 +72,8 @@ export const SidebarEventItem: React.FC<SidebarEventItemProps> = ({
   const [payloadCopied, setPayloadCopied] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
+  const { resolvedTheme } = useTheme();
+  const jsonViewStyle = getJsonViewStyle(resolvedTheme);
 
   const eventStateStyle: EventStateStyle = useMemo(() => {
     if (!getExecutionState) return DEFAULT_EVENT_STATE_MAP["neutral"];
@@ -338,16 +350,9 @@ export const SidebarEventItem: React.FC<SidebarEventItemProps> = ({
               </div>
               <div className="h-50 overflow-auto rounded -mt-2">
                 <JsonView
-                  value={typeof tabData.payload === "string" ? JSON.parse(tabData.payload) : tabData.payload}
-                  style={{
-                    fontSize: "12px",
-                    fontFamily:
-                      'Monaco, Menlo, "Cascadia Code", "Segoe UI Mono", "Roboto Mono", Consolas, "Courier New", monospace',
-                    backgroundColor: "#ffffff",
-                    color: "#24292e",
-                    padding: "8px",
-                  }}
-                  className="json-viewer-hide-types"
+                  value={payloadJsonValue(tabData.payload)}
+                  style={{ ...jsonViewStyle, padding: "8px" }}
+                  className={jsonViewClassName}
                   displayObjectSize={false}
                   enableClipboard={false}
                 />
@@ -427,15 +432,9 @@ export const SidebarEventItem: React.FC<SidebarEventItemProps> = ({
             <div className="flex-1 overflow-auto bg-white rounded-b-lg dark:bg-gray-900">
               <div className="p-4">
                 <JsonView
-                  value={typeof modalPayload === "string" ? JSON.parse(modalPayload) : modalPayload}
-                  style={{
-                    fontSize: "14px",
-                    fontFamily:
-                      'Monaco, Menlo, "Cascadia Code", "Segoe UI Mono", "Roboto Mono", Consolas, "Courier New", monospace',
-                    backgroundColor: "#ffffff",
-                    color: "#24292e",
-                  }}
-                  className="json-viewer-hide-types"
+                  value={payloadJsonValue(modalPayload)}
+                  style={{ ...jsonViewStyle, fontSize: "14px" }}
+                  className={jsonViewClassName}
                   displayObjectSize={false}
                   enableClipboard={false}
                 />


### PR DESCRIPTION
## Summary

The component sidebar payload JSON stays light in dark mode.
The run inspector already uses `jsonViewTheme`.
This change applies the same theme to the component sidebar payload view and modal.

## Test plan

- [ ] Open a component in the canvas sidebar.
- [ ] Open an event and select the Payload tab.
- [ ] Switch SuperPlane to dark mode.
- [ ] Confirm the payload JSON uses dark background and text colors.
- [ ] Open the payload modal and confirm the same dark theme.
- [ ] Switch to light mode and confirm the payload JSON stays readable.
