### PR TITLE
fix: Clarify GitHub owner name field

### DIFF
--- a/pkg/integrations/github/setup_provider.go
+++ b/pkg/integrations/github/setup_provider.go
@@ -253,7 +253,7 @@ func (g *SetupProvider) FirstStep(ctx core.SetupStepContext) core.SetupStep {
 			},
 			{
 				Name:        common.PropertyOwner,
-				Label:       "User account / organization name",
+				Label:       "GitHub user account or organization name",
 				Type:        configuration.FieldTypeString,
 				Required:    true,
 				Placeholder: "e.g. superplanehq",

--- a/pkg/integrations/github/setup_provider_test.go
+++ b/pkg/integrations/github/setup_provider_test.go
@@ -161,6 +161,13 @@ func Test__GitHub__SetupProvider__OnPropertyUpdate(t *testing.T) {
 	assert.Contains(t, err.Error(), "no property updates are supported")
 }
 
+func Test__GitHub__SetupProvider__FirstStep(t *testing.T) {
+	step := (&SetupProvider{}).FirstStep(core.SetupStepContext{})
+
+	require.Len(t, step.Inputs, 2)
+	assert.Equal(t, "GitHub user account or organization name", step.Inputs[1].Label)
+}
+
 func Test__GitHub__SetupProvider__OnSecretUpdate(t *testing.T) {
 	g := &SetupProvider{}
 	log := logger.DiscardLogger()


### PR DESCRIPTION
## Summary

- Adds GitHub to the owner-name field label in the integration setup step.
- This change prevents users from entering a SuperPlane organization name.

Fixes #5031

## Test plan

- [x] Run `go test ./pkg/integrations/github -count=1`.
- [x] Confirm the owner-name label identifies the GitHub account or organization.
