### PR TITLE
feat: Add --follow to executions logs

### DIFF
--- a/pkg/cli/commands/executions/logs.go
+++ b/pkg/cli/commands/executions/logs.go
@@ -21,6 +21,7 @@ type LogsCommand struct {
 	RunID       *string
 	NodeID      *string
 	Limit       *int64
+	Follow      *bool
 }
 
 type runnerLogTarget struct {
@@ -47,6 +48,16 @@ func (c *LogsCommand) Execute(ctx core.CommandContext) error {
 	targets, err := c.resolveTargets(ctx, canvasID)
 	if err != nil {
 		return err
+	}
+
+	if c.Follow != nil && *c.Follow {
+		if !ctx.Renderer.IsText() {
+			return fmt.Errorf("--follow is only supported with text output")
+		}
+		if len(targets) != 1 {
+			return fmt.Errorf("--follow is only supported when exactly one execution is selected, got %d; narrow the target with --execution-id", len(targets))
+		}
+		return c.followExecutionLogs(ctx, canvasID, targets[0])
 	}
 
 	outputs := make([]runnerLogOutput, 0, len(targets))
@@ -249,6 +260,37 @@ func (c *LogsCommand) fetchLiveLogSession(ctx core.CommandContext, canvasID, exe
 		return nil, err
 	}
 	return &session, nil
+}
+
+// followExecutionLogs tails a single execution's runner logs, printing each
+// record as it arrives, and returns once the runner finishes and the broker
+// closes the log stream (or --limit records have been streamed).
+func (c *LogsCommand) followExecutionLogs(ctx core.CommandContext, canvasID string, target runnerLogTarget) error {
+	header := runnerLogOutput{CanvasID: canvasID, ExecutionID: target.ExecutionID, NodeID: target.NodeID}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		if err := renderRunnerLogHeader(stdout, header); err != nil {
+			return err
+		}
+
+		session, err := c.fetchLiveLogSession(ctx, canvasID, target.ExecutionID)
+		if err != nil {
+			return err
+		}
+
+		records, err := runneraction.FetchLiveLogSessionRecords(ctx.Context, *session, runneraction.LiveLogFetchOptions{
+			Limit:      normalizedLogLimit(c.Limit),
+			HTTPClient: logHTTPClient(ctx.API.GetConfig()),
+			OnRecord:   func(record runneraction.LiveLogRecord) { _ = renderRunnerLogRecord(stdout, record) },
+		})
+		if err != nil {
+			return fmt.Errorf("fetch runner logs for execution %s: %w", target.ExecutionID, err)
+		}
+		if records.Truncated {
+			_, _ = fmt.Fprintln(stdout, "... truncated")
+		}
+		return nil
+	})
 }
 
 func responseErrorMessage(status string, body []byte) string {

--- a/pkg/cli/commands/executions/logs_test.go
+++ b/pkg/cli/commands/executions/logs_test.go
@@ -45,6 +45,193 @@ func TestLogsCommandReturnsExecutionLogsJSON(t *testing.T) {
 	require.Equal(t, "hello", output[0].Records[0].Text)
 }
 
+// newFollowExecutionLogBroker serves one live-log stream whose body is
+// written incrementally over time, so that --follow prints each record as
+// it arrives, then closes the stream to end the fetch.
+func newFollowExecutionLogBroker(t *testing.T, records []string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/tasks/task-001/live-logs", r.URL.Path)
+		require.Equal(t, "Bearer token-001", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		flusher := w.(http.Flusher)
+		for _, record := range records {
+			_, _ = w.Write([]byte(record + "\n"))
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestLogsCommandFollowPrintsRecordsAsTheyArrive(t *testing.T) {
+	broker := newFollowExecutionLogBroker(t, []string{
+		`{"type":"line","text":"first"}`,
+		`{"type":"line","text":"second"}`,
+		`{"type":"line","text":"third"}`,
+	})
+	server := newExecutionLogsServer(t, broker.URL)
+	ctx, stdout := newExecutionsCommandContext(t, server, "text")
+	canvasID := "canvas-001"
+	executionID := "exec-001"
+	empty := ""
+	limit := int64(5)
+	follow := true
+
+	cmd := &LogsCommand{
+		CanvasID:    &canvasID,
+		ExecutionID: &executionID,
+		RunID:       &empty,
+		NodeID:      &empty,
+		Limit:       &limit,
+		Follow:      &follow,
+	}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	raw := stdout.String()
+	require.Contains(t, raw, "Execution")
+	require.Contains(t, raw, "exec-001")
+	require.Contains(t, raw, "first")
+	require.Contains(t, raw, "second")
+	require.Contains(t, raw, "third")
+	require.NotContains(t, raw, "truncated")
+}
+
+func TestLogsCommandFollowReportsTruncatedLimit(t *testing.T) {
+	broker := newFollowExecutionLogBroker(t, []string{
+		`{"type":"line","text":"first"}`,
+		`{"type":"line","text":"second"}`,
+		`{"type":"line","text":"third"}`,
+		`{"type":"line","text":"fourth"}`,
+	})
+	server := newExecutionLogsServer(t, broker.URL)
+	ctx, stdout := newExecutionsCommandContext(t, server, "text")
+	canvasID := "canvas-001"
+	executionID := "exec-001"
+	empty := ""
+	limit := int64(2)
+	follow := true
+
+	cmd := &LogsCommand{
+		CanvasID:    &canvasID,
+		ExecutionID: &executionID,
+		RunID:       &empty,
+		NodeID:      &empty,
+		Limit:       &limit,
+		Follow:      &follow,
+	}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	raw := stdout.String()
+	require.Contains(t, raw, "first")
+	require.Contains(t, raw, "second")
+	require.Contains(t, raw, "truncated")
+	require.NotContains(t, raw, "fourth")
+}
+
+func TestLogsCommandFollowRequiresTextOutput(t *testing.T) {
+	broker := newExecutionLogBroker(t)
+	server := newExecutionLogsServer(t, broker.URL)
+	ctx, _ := newExecutionsCommandContext(t, server, "json")
+	canvasID := "canvas-001"
+	executionID := "exec-001"
+	empty := ""
+	limit := int64(5)
+	follow := true
+
+	cmd := &LogsCommand{
+		CanvasID:    &canvasID,
+		ExecutionID: &executionID,
+		RunID:       &empty,
+		NodeID:      &empty,
+		Limit:       &limit,
+		Follow:      &follow,
+	}
+
+	err := cmd.Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "text output")
+}
+
+func TestLogsCommandFollowRefusesMultiTargetRun(t *testing.T) {
+	ctx := newTwoRunnerExecutionContext(t, "canvas-001", "run-001")
+	canvasID := "canvas-001"
+	empty := ""
+	runID := "run-001"
+	limit := int64(5)
+	follow := true
+
+	cmd := &LogsCommand{
+		CanvasID:    &canvasID,
+		ExecutionID: &empty,
+		RunID:       &runID,
+		NodeID:      &empty,
+		Limit:       &limit,
+		Follow:      &follow,
+	}
+
+	err := cmd.Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exactly one execution")
+}
+
+// newTwoRunnerExecutionContext builds a command context against a fake
+// server where run "run-001" has two runner-node executions, for the
+// multi-target --follow rejection test.
+func newTwoRunnerExecutionContext(t *testing.T, canvasID, runID string) core.CommandContext {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/canvases/"+canvasID+"/runs/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"run":{
+					"id":"` + runID + `",
+					"canvasId":"` + canvasID + `",
+					"executions":[
+						{"id":"exec-001","nodeId":"node-001","state":"STATE_FINISHED"},
+						{"id":"exec-002","nodeId":"node-002","state":"STATE_FINISHED"}
+					]
+				}
+			}`))
+		case r.URL.Path == "/api/v1/canvases/"+canvasID:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"canvas":{
+					"spec":{
+						"nodes":[
+							{"id":"node-001","component":"runner"},
+							{"id":"node-002","component":"runner"}
+						]
+					}
+				}
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	stdout := bytes.NewBuffer(nil)
+	renderer, err := core.NewRenderer("text", stdout)
+	require.NoError(t, err)
+
+	config := openapi_client.NewConfiguration()
+	config.Servers = openapi_client.ServerConfigurations{{URL: server.URL}}
+
+	cobraCmd := &cobra.Command{}
+	cobraCmd.SetOut(stdout)
+
+	return core.CommandContext{
+		Context:  context.Background(),
+		Cmd:      cobraCmd,
+		API:      openapi_client.NewAPIClient(config),
+		Renderer: renderer,
+	}
+}
+
 func TestLogsCommandResolvesLatestNodeExecution(t *testing.T) {
 	broker := newExecutionLogBroker(t)
 	server := newExecutionLogsServer(t, broker.URL)

--- a/pkg/cli/commands/executions/root.go
+++ b/pkg/cli/commands/executions/root.go
@@ -12,6 +12,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	var runID string
 	var limit int64
 	var before string
+	var follow bool
 
 	root := &cobra.Command{
 		Use:     "executions",
@@ -59,12 +60,14 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	logsCmd.Flags().StringVar(&runID, "run-id", "", "run ID")
 	logsCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
 	logsCmd.Flags().Int64Var(&limit, "limit", 200, "maximum number of log records to return per execution")
+	logsCmd.Flags().BoolVar(&follow, "follow", false, "keep the command running and print new log records as they arrive, until the runner finishes")
 	core.Bind(logsCmd, &LogsCommand{
 		CanvasID:    &appID,
 		ExecutionID: &executionID,
 		RunID:       &runID,
 		NodeID:      &nodeID,
 		Limit:       &limit,
+		Follow:      &follow,
 	}, options)
 
 	root.AddCommand(listCmd)

--- a/pkg/components/runner/live_log_fetch.go
+++ b/pkg/components/runner/live_log_fetch.go
@@ -31,6 +31,12 @@ type LiveLogFetchOptions struct {
 	HTTPClient  *http.Client
 	Now         time.Time
 	IdleTimeout time.Duration
+	// OnRecord, when set, is invoked synchronously for each record as it is
+	// read, in addition to the record being included in the returned result.
+	// It lets a caller (e.g. a CLI --follow flag) print records live while
+	// the fetch is still reading the stream, instead of waiting for the
+	// whole fetch to finish.
+	OnRecord func(LiveLogRecord)
 }
 
 type LiveLogFetchResult struct {
@@ -78,9 +84,9 @@ func FetchLiveLogSessionRecords(ctx context.Context, session LiveLogSession, opt
 	}
 
 	if opts.IdleTimeout > 0 {
-		return readLiveLogRecordsUntilIdle(ctx, response.Body, limit, opts.IdleTimeout)
+		return readLiveLogRecordsUntilIdle(ctx, response.Body, limit, opts.IdleTimeout, opts.OnRecord)
 	}
-	return readLiveLogRecords(response.Body, limit)
+	return readLiveLogRecords(response.Body, limit, opts.OnRecord)
 }
 
 func normalizeLiveLogRecordLimit(limit int) int {
@@ -100,7 +106,7 @@ func liveLogHTTPClient(client *http.Client) *http.Client {
 	return &http.Client{Timeout: 30 * time.Second}
 }
 
-func readLiveLogRecords(reader io.Reader, limit int) (*LiveLogFetchResult, error) {
+func readLiveLogRecords(reader io.Reader, limit int, onRecord func(LiveLogRecord)) (*LiveLogFetchResult, error) {
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
@@ -121,6 +127,9 @@ func readLiveLogRecords(reader io.Reader, limit int) (*LiveLogFetchResult, error
 		}
 
 		records = append(records, record)
+		if onRecord != nil {
+			onRecord(record)
+		}
 		if len(records) >= limit {
 			return &LiveLogFetchResult{Records: records, Truncated: true}, nil
 		}
@@ -142,6 +151,7 @@ func readLiveLogRecordsUntilIdle(
 	reader io.Reader,
 	limit int,
 	idleTimeout time.Duration,
+	onRecord func(LiveLogRecord),
 ) (*LiveLogFetchResult, error) {
 	done := make(chan struct{})
 	events := make(chan liveLogReadEvent)
@@ -164,7 +174,7 @@ func readLiveLogRecordsUntilIdle(
 	for {
 		select {
 		case event := <-events:
-			result, complete, err := applyLiveLogReadEvent(records, event, limit)
+			result, complete, err := applyLiveLogReadEvent(records, event, limit, onRecord)
 			if err != nil {
 				return nil, err
 			}
@@ -174,7 +184,7 @@ func readLiveLogRecordsUntilIdle(
 			}
 			resetLiveLogIdleTimer(idle, idleTimeout)
 		case <-idle.C:
-			result, complete, err := drainReadyLiveLogReadEvents(records, events, limit)
+			result, complete, err := drainReadyLiveLogReadEvents(records, events, limit, onRecord)
 			if err != nil {
 				return nil, err
 			}
@@ -197,13 +207,14 @@ func drainReadyLiveLogReadEvents(
 	records []LiveLogRecord,
 	events <-chan liveLogReadEvent,
 	limit int,
+	onRecord func(LiveLogRecord),
 ) (*LiveLogFetchResult, bool, error) {
 	result := &LiveLogFetchResult{Records: records}
 
 	for {
 		select {
 		case event := <-events:
-			next, complete, err := applyLiveLogReadEvent(result.Records, event, limit)
+			next, complete, err := applyLiveLogReadEvent(result.Records, event, limit, onRecord)
 			if err != nil {
 				return nil, false, err
 			}
@@ -221,6 +232,7 @@ func applyLiveLogReadEvent(
 	records []LiveLogRecord,
 	event liveLogReadEvent,
 	limit int,
+	onRecord func(LiveLogRecord),
 ) (*LiveLogFetchResult, bool, error) {
 	if event.err != nil {
 		return nil, false, fmt.Errorf("read live logs: %w", event.err)
@@ -230,6 +242,9 @@ func applyLiveLogReadEvent(
 	}
 
 	records = append(records, event.record)
+	if onRecord != nil {
+		onRecord(event.record)
+	}
 	if len(records) >= limit {
 		return &LiveLogFetchResult{Records: records, Truncated: true}, true, nil
 	}

--- a/pkg/components/runner/live_log_fetch_test.go
+++ b/pkg/components/runner/live_log_fetch_test.go
@@ -22,7 +22,7 @@ func TestReadLiveLogRecordsReturnsAfterLimitOnOpenStream(t *testing.T) {
 
 	done := make(chan liveLogReadResult, 1)
 	go func() {
-		result, err := readLiveLogRecords(reader, 1)
+		result, err := readLiveLogRecords(reader, 1, nil)
 		done <- liveLogReadResult{result: result, err: err}
 	}()
 
@@ -41,7 +41,7 @@ func TestReadLiveLogRecordsReturnsAfterLimitOnOpenStream(t *testing.T) {
 }
 
 func TestReadLiveLogRecordsStopsAfterLimitEvenWhenNextLineIsInvalid(t *testing.T) {
-	result, err := readLiveLogRecords(strings.NewReader(`{"type":"line","text":"first"}`+"\nnot-json\n"), 1)
+	result, err := readLiveLogRecords(strings.NewReader(`{"type":"line","text":"first"}`+"\nnot-json\n"), 1, nil)
 
 	require.NoError(t, err)
 	require.Len(t, result.Records, 1)
@@ -56,7 +56,7 @@ func TestReadLiveLogRecordsUntilIdleReturnsPartialOpenStream(t *testing.T) {
 
 	done := make(chan liveLogReadResult, 1)
 	go func() {
-		result, err := readLiveLogRecordsUntilIdle(context.Background(), reader, 10, 20*time.Millisecond)
+		result, err := readLiveLogRecordsUntilIdle(context.Background(), reader, 10, 20*time.Millisecond, nil)
 		done <- liveLogReadResult{result: result, err: err}
 	}()
 
@@ -82,7 +82,7 @@ func TestReadLiveLogRecordsUntilIdleReturnsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan liveLogReadResult, 1)
 	go func() {
-		result, err := readLiveLogRecordsUntilIdle(ctx, reader, 10, time.Minute)
+		result, err := readLiveLogRecordsUntilIdle(ctx, reader, 10, time.Minute, nil)
 		done <- liveLogReadResult{result: result, err: err}
 	}()
 
@@ -105,6 +105,7 @@ func TestDrainReadyLiveLogReadEventsKeepsQueuedRecord(t *testing.T) {
 		[]LiveLogRecord{{Type: "line", Text: "first"}},
 		events,
 		10,
+		nil,
 	)
 
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed

Adds `--follow` to `superplane executions logs`. With the flag set, the command prints each runner log record as it arrives and keeps running until the runner finishes and the broker closes the log stream (or `--limit` records have been streamed, at which point a `... truncated` marker is printed). Without the flag, behavior is unchanged.

## Why

`executions logs` today returns one static snapshot of the runner's log buffer. For an in-progress run you have to re-run the command to see new output; there is no `kubectl logs -f` equivalent. This makes it possible to watch a long-running task's runner output live from the terminal.

## How

- `runneraction.LiveLogFetchOptions` gains an `OnRecord` callback that is invoked synchronously as each record is read from the stream (in addition to being collected into the returned result). Existing callers are unaffected; `read_runtime.go`'s bounded-snapshot fetch is unchanged.
- `LogsCommand.Execute` routes `--follow` to a new `followExecutionLogs` path: mint a session, do one non-idle fetch so the fetch blocks until the stream closes, and render each record live via the callback.
- `--follow` is text-output-only and requires exactly one execution target; a run resolving to multiple runner executions is rejected with a hint to narrow with `--execution-id`.
- Tests: new follow-mode tests (records printed as they arrive, limit truncation marker, multi-target rejection, non-text rejection) plus updated call sites for the `OnRecord` parameter in the fetch-layer tests.

## Verification

- `go build ./cmd/... ./pkg/...`
- `go vet ./pkg/cli/commands/executions/... ./pkg/components/runner/...`
- `go test ./pkg/cli/commands/executions/... ./pkg/components/runner/...` — all pass
- Smoke-tested the built CLI: `superplane executions logs --help` shows the new flag
