### PR TITLE
feat: Add GitHub commit comparison

### DIFF
--- a/pkg/integrations/github/capability_mapper.go
+++ b/pkg/integrations/github/capability_mapper.go
@@ -86,6 +86,7 @@ func NewCapabilityMapper() *CapabilityMapper {
 			PermissionContents: {
 				PermissionScope: PermissionScopeRepository,
 				Capabilities: []CapabilityDef{
+					{ReadOnly: true, Action: &contents.CompareCommits{}},
 					{ReadOnly: true, Action: &contents.GetRelease{}},
 					{ReadOnly: true, Trigger: &contents.OnBranchCreated{}},
 					{ReadOnly: true, Trigger: &contents.OnPush{}},

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -56,6 +56,23 @@ func (c *Client) FindRepository(repository string) (*github.Repository, error) {
 	return repo, nil
 }
 
+func (c *Client) CompareCommits(ctx context.Context, repository, base, head string) (*github.CommitsComparison, error) {
+	owner, name := c.ownerAndName(repository)
+	comparison, _, err := c.underlying.Repositories.CompareCommits(ctx, owner, name, base, head, nil)
+	return comparison, err
+}
+
+func (c *Client) GetCommit(ctx context.Context, repository, ref string) (*github.RepositoryCommit, error) {
+	owner, name := c.ownerAndName(repository)
+	commit, _, err := c.underlying.Repositories.GetCommit(ctx, owner, name, ref, nil)
+	return commit, err
+}
+
+func (c *Client) CanonicalRepository(repository string) string {
+	owner, name := c.ownerAndName(repository)
+	return owner + "/" + name
+}
+
 // ownerAndName accepts either "repo" (scoped to the integration owner) or
 // "owner/repo". Claude components need the latter; GitHub components historically
 // stored the short name.

--- a/pkg/integrations/github/components/contents/compare_commits.go
+++ b/pkg/integrations/github/components/contents/compare_commits.go
@@ -1,0 +1,335 @@
+package contents
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/google/go-github/v84/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+	"github.com/superplanehq/superplane/pkg/pathfilter"
+)
+
+const (
+	commitComparisonPayloadType = "github.commitComparison"
+
+	fileStatusAdded    = "added"
+	fileStatusModified = "modified"
+	fileStatusRemoved  = "removed"
+	fileStatusRenamed  = "renamed"
+)
+
+var supportedFileStatuses = []string{
+	fileStatusAdded,
+	fileStatusModified,
+	fileStatusRemoved,
+	fileStatusRenamed,
+}
+
+type CompareCommits struct{}
+
+type CompareCommitsConfiguration struct {
+	Repository string    `json:"repository" mapstructure:"repository"`
+	Base       string    `json:"base" mapstructure:"base"`
+	Head       string    `json:"head" mapstructure:"head"`
+	Statuses   *[]string `json:"statuses,omitempty" mapstructure:"statuses,omitempty"`
+	Paths      *[]string `json:"paths,omitempty" mapstructure:"paths,omitempty"`
+}
+
+type CommitComparisonPayload struct {
+	Comparison     ComparisonMetadata `json:"comparison"`
+	AppliedFilters *AppliedFilters    `json:"appliedFilters,omitempty"`
+	Files          []ComparedFile     `json:"files"`
+}
+
+type ComparisonMetadata struct {
+	Repository       string `json:"repository"`
+	BaseSHA          string `json:"baseSha"`
+	HeadSHA          string `json:"headSha"`
+	MergeBaseSHA     string `json:"mergeBaseSha"`
+	URL              string `json:"url"`
+	ChangedFileCount int    `json:"changedFileCount"`
+}
+
+type AppliedFilters struct {
+	Statuses *[]string `json:"statuses,omitempty"`
+	Paths    *[]string `json:"paths,omitempty"`
+}
+
+type ComparedFile struct {
+	Path         string `json:"path"`
+	Status       string `json:"status"`
+	Additions    int    `json:"additions"`
+	Deletions    int    `json:"deletions"`
+	Changes      int    `json:"changes"`
+	PreviousPath string `json:"previousPath,omitempty"`
+}
+
+func (c *CompareCommits) Name() string  { return "github.compareCommits" }
+func (c *CompareCommits) Label() string { return "Compare Commits" }
+func (c *CompareCommits) Description() string {
+	return "Find files changed between two GitHub branches, tags, or commits"
+}
+func (c *CompareCommits) Icon() string  { return "github" }
+func (c *CompareCommits) Color() string { return "gray" }
+
+func (c *CompareCommits) Documentation() string {
+	return `Compare Commits returns files that changed from the base ref to the head ref. Refs can be branch names, tag names, or commit SHAs. GitHub does not require the base ref to be an ancestor of the head ref.
+
+GitHub statuses are normalized to added, modified, removed, and renamed. Copied files become added files, changed files become modified files, and unchanged files are omitted.
+
+Status and path filters are optional. Status values use OR logic. Path patterns support ** and ! exclusions. Exclusions take precedence, and exclusion-only lists include ** implicitly. For renamed files, the component evaluates the current and previous paths separately. The file matches when either path passes all include and exclude patterns. Status and path filters use AND logic together.
+
+The component always emits matched or unmatched. Without filters, all changed files match. The payload contains resolved comparison SHAs, the GitHub URL, the unfiltered file count, applied filters, and sorted file metadata.
+
+GitHub returns the changed-file list on the first comparison page and limits the list to 300 files. GitHub paginates only the commit list. The component resolves the configured head separately and does not load the paginated commit list. The component fails when GitHub returns 300 files because it cannot determine whether the file list is complete.
+
+Example filtered payload:
+
+    {"comparison":{"repository":"owner/repo","baseSha":"abc","headSha":"def","mergeBaseSha":"aaa","url":"https://github.com/owner/repo/compare/main...feature","changedFileCount":1},"appliedFilters":{"statuses":["renamed"],"paths":["src/**"]},"files":[{"path":"src/new.ts","status":"renamed","additions":1,"deletions":1,"changes":2,"previousPath":"lib/old.ts"}]}`
+}
+
+func (c *CompareCommits) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{Name: "repository", Label: "Repository", Type: configuration.FieldTypeIntegrationResource, Required: true, TypeOptions: &configuration.TypeOptions{Resource: &configuration.ResourceTypeOptions{Type: "repository", UseNameAsValue: true}}},
+		{Name: "base", Label: "Base", Type: configuration.FieldTypeString, Required: true, Description: "Branch name, tag name, or commit SHA to compare from"},
+		{Name: "head", Label: "Head", Type: configuration.FieldTypeString, Required: true, Description: "Branch name, tag name, or commit SHA to compare to"},
+		{Name: "statuses", Label: "Statuses", Type: configuration.FieldTypeMultiSelect, Togglable: true, Default: []string{fileStatusAdded}, TypeOptions: &configuration.TypeOptions{MultiSelect: &configuration.MultiSelectTypeOptions{Options: []configuration.FieldOption{{Label: "Added", Value: fileStatusAdded}, {Label: "Modified", Value: fileStatusModified}, {Label: "Removed", Value: fileStatusRemoved}, {Label: "Renamed", Value: fileStatusRenamed}}}}},
+		{Name: "paths", Label: "Paths", Type: configuration.FieldTypeList, Togglable: true, Default: []string{"**"}, Description: "Path patterns. Use ** for directories and prefix exclusions with !.", TypeOptions: &configuration.TypeOptions{List: &configuration.ListTypeOptions{ItemLabel: "Pattern", ItemDefinition: &configuration.ListItemDefinition{Type: configuration.FieldTypeExpression}}}},
+	}
+}
+
+func (c *CompareCommits) OutputChannels(any) []core.OutputChannel {
+	return []core.OutputChannel{{Name: "matched", Description: "One or more files matched"}, {Name: "unmatched", Description: "No files matched"}}
+}
+
+func (c *CompareCommits) Setup(ctx core.SetupContext) error {
+	config, err := decodeCompareCommitsConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+	config = normalizeRequiredCompareCommitsConfiguration(config)
+	if err := validateRequiredCompareCommitsConfiguration(config); err != nil {
+		return err
+	}
+	if config.Paths != nil {
+		literalPaths := slices.DeleteFunc(normalizedPaths(config.Paths), common.IsExpression)
+		if err := validatePathPatterns(literalPaths); err != nil {
+			return err
+		}
+	}
+	if err := validateStatusFilters(uniqueStrings(config.Statuses)); err != nil {
+		return err
+	}
+	return common.EnsureRepoInMetadata(ctx.Metadata, ctx.Integration, ctx.HTTP, ctx.Configuration)
+}
+
+func (c *CompareCommits) Execute(ctx core.ExecutionContext) error {
+	config, err := decodeCompareCommitsConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+	config = normalizeRequiredCompareCommitsConfiguration(config)
+	if err := validateRequiredCompareCommitsConfiguration(config); err != nil {
+		return err
+	}
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+	comparison, err := client.CompareCommits(context.Background(), config.Repository, config.Base, config.Head)
+	if err != nil {
+		return fmt.Errorf("failed to compare %q with %q: %w", config.Base, config.Head, err)
+	}
+	if len(comparison.Files) >= 300 {
+		return fmt.Errorf("GitHub returned 300 files; narrow the comparison because the result can be incomplete")
+	}
+
+	files, err := normalizeComparedFiles(comparison.Files)
+	if err != nil {
+		return err
+	}
+	headCommit, err := client.GetCommit(context.Background(), config.Repository, config.Head)
+	if err != nil {
+		return fmt.Errorf("failed to resolve head %q: %w", config.Head, err)
+	}
+	payload := CommitComparisonPayload{Comparison: ComparisonMetadata{Repository: client.CanonicalRepository(config.Repository), BaseSHA: comparison.GetBaseCommit().GetSHA(), HeadSHA: headCommit.GetSHA(), MergeBaseSHA: comparison.GetMergeBaseCommit().GetSHA(), URL: comparison.GetHTMLURL(), ChangedFileCount: len(files)}, Files: files}
+
+	filterMode := config.Statuses != nil || config.Paths != nil
+	if filterMode {
+		statuses := uniqueStrings(config.Statuses)
+		paths := normalizedPaths(config.Paths)
+		if err := validateStatusFilters(statuses); err != nil {
+			return err
+		}
+		if err := validatePathPatterns(paths); err != nil {
+			return err
+		}
+		files = filterComparedFiles(files, statuses, paths)
+		payload.Files = files
+		payload.AppliedFilters = &AppliedFilters{}
+		if config.Statuses != nil {
+			payload.AppliedFilters.Statuses = &statuses
+		}
+		if config.Paths != nil {
+			payload.AppliedFilters.Paths = &paths
+		}
+	}
+
+	return ctx.ExecutionState.Emit(compareCommitsOutputChannel(len(files)), commitComparisonPayloadType, []any{payload})
+}
+
+func normalizeComparedFiles(githubFiles []*github.CommitFile) ([]ComparedFile, error) {
+	files := make([]ComparedFile, 0, len(githubFiles))
+	for _, file := range githubFiles {
+		status, include, err := normalizeFileStatus(file.GetStatus())
+		if err != nil {
+			return nil, err
+		}
+		if !include {
+			continue
+		}
+		comparedFile := ComparedFile{Path: file.GetFilename(), Status: status, Additions: file.GetAdditions(), Deletions: file.GetDeletions(), Changes: file.GetChanges()}
+		if status == fileStatusRenamed {
+			comparedFile.PreviousPath = file.GetPreviousFilename()
+		}
+		files = append(files, comparedFile)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, nil
+}
+
+func compareCommitsOutputChannel(fileCount int) string {
+	if fileCount > 0 {
+		return "matched"
+	}
+	return "unmatched"
+}
+
+func decodeCompareCommitsConfiguration(raw any) (CompareCommitsConfiguration, error) {
+	var config CompareCommitsConfiguration
+	if err := mapstructure.Decode(raw, &config); err != nil {
+		return config, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	return config, nil
+}
+
+func validateRequiredCompareCommitsConfiguration(config CompareCommitsConfiguration) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "repository", value: config.Repository},
+		{name: "base", value: config.Base},
+		{name: "head", value: config.Head},
+	} {
+		if field.value == "" {
+			return fmt.Errorf("%s is required", field.name)
+		}
+	}
+	return nil
+}
+
+func normalizeRequiredCompareCommitsConfiguration(config CompareCommitsConfiguration) CompareCommitsConfiguration {
+	config.Repository = strings.TrimSpace(config.Repository)
+	config.Base = strings.TrimSpace(config.Base)
+	config.Head = strings.TrimSpace(config.Head)
+	return config
+}
+
+func normalizeFileStatus(status string) (string, bool, error) {
+	switch status {
+	case fileStatusAdded, fileStatusModified, fileStatusRemoved, fileStatusRenamed:
+		return status, true, nil
+	case "copied":
+		return fileStatusAdded, true, nil
+	case "changed":
+		return fileStatusModified, true, nil
+	case "unchanged":
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("unsupported GitHub file status %q", status)
+	}
+}
+
+func uniqueStrings(values *[]string) []string {
+	if values == nil {
+		return nil
+	}
+	unique := make([]string, 0, len(*values))
+	for _, value := range *values {
+		if !slices.Contains(unique, value) {
+			unique = append(unique, value)
+		}
+	}
+	return unique
+}
+
+func normalizedPaths(values *[]string) []string {
+	if values == nil {
+		return nil
+	}
+	return pathfilter.TrimNonEmptyStrings(*values)
+}
+
+func validatePathPatterns(patterns []string) error {
+	for _, pattern := range patterns {
+		glob := strings.TrimSpace(strings.TrimPrefix(pattern, "!"))
+		if glob == "" || !doublestar.ValidatePattern(glob) {
+			return fmt.Errorf("invalid path pattern %q", pattern)
+		}
+	}
+	return nil
+}
+
+func validateStatusFilters(statuses []string) error {
+	for _, status := range statuses {
+		if !slices.Contains(supportedFileStatuses, status) {
+			return fmt.Errorf("unsupported status filter %q", status)
+		}
+	}
+	return nil
+}
+
+func filterComparedFiles(files []ComparedFile, statuses, patterns []string) []ComparedFile {
+	matched := make([]ComparedFile, 0, len(files))
+	for _, file := range files {
+		if len(statuses) > 0 && !slices.Contains(statuses, file.Status) {
+			continue
+		}
+		if len(patterns) > 0 && !comparedFileMatchesPaths(file, patterns) {
+			continue
+		}
+		matched = append(matched, file)
+	}
+	return matched
+}
+
+func comparedFileMatchesPaths(file ComparedFile, patterns []string) bool {
+	paths := []string{file.Path}
+	if file.PreviousPath != "" {
+		paths = append(paths, file.PreviousPath)
+	}
+
+	return slices.ContainsFunc(paths, func(path string) bool {
+		return pathfilter.EvaluatePushPathGlobFilter(patterns, []string{path}, nil, nil, nil)
+	})
+}
+
+func (c *CompareCommits) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+func (c *CompareCommits) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+func (c *CompareCommits) Cancel(ctx core.ExecutionContext) error      { return nil }
+func (c *CompareCommits) Cleanup(ctx core.SetupContext) error         { return nil }
+func (c *CompareCommits) Hooks() []core.Hook                          { return nil }
+func (c *CompareCommits) HandleHook(ctx core.ActionHookContext) error { return nil }

--- a/pkg/integrations/github/components/contents/compare_commits_test.go
+++ b/pkg/integrations/github/components/contents/compare_commits_test.go
@@ -1,0 +1,390 @@
+package contents
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+	"github.com/superplanehq/superplane/test/support/contexts"
+	githubmocks "github.com/superplanehq/superplane/test/support/mocks/github"
+)
+
+func Test__CompareCommits__Setup(t *testing.T) {
+	component := CompareCommits{}
+
+	for _, field := range []string{"repository", "base", "head"} {
+		t.Run("requires "+field, func(t *testing.T) {
+			configuration := map[string]any{"repository": "testhq/hello", "base": "main", "head": "feature"}
+			delete(configuration, field)
+
+			err := component.Setup(core.SetupContext{
+				Configuration: configuration,
+				Metadata:      &contexts.MetadataContext{},
+				Integration:   githubmocks.IntegrationContextForNewSetupFlow(),
+				HTTP:          &contexts.HTTPContext{},
+			})
+
+			require.ErrorContains(t, err, field+" is required")
+		})
+	}
+
+	t.Run("stores repository metadata", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+			githubmocks.GitHubResponse(http.StatusOK, `{
+				"id": 42,
+				"full_name": "testhq/hello",
+				"html_url": "https://github.com/testhq/hello"
+			}`),
+		}}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"repository": "testhq/hello", "base": "main", "head": "feature"},
+			Metadata:      metadata,
+			Integration:   githubmocks.IntegrationContextForNewSetupFlow(),
+			HTTP:          httpContext,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, common.NodeMetadata{Repository: &common.Repository{
+			ID: 42, Name: "testhq/hello", URL: "https://github.com/testhq/hello",
+		}}, metadata.Get())
+	})
+
+	t.Run("rejects an invalid literal path pattern", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{
+			"repository": "testhq/hello", "base": "main", "head": "feature", "paths": []string{"[invalid"},
+		}})
+		require.ErrorContains(t, err, `invalid path pattern "[invalid"`)
+	})
+
+	t.Run("allows a path expression until execution", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{Metadata: common.NodeMetadata{Repository: &common.Repository{Name: "testhq/hello"}}}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"repository": "testhq/hello", "base": "main", "head": "feature", "paths": []string{`{{$.paths}}`}},
+			Metadata:      metadata,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects an unsupported status filter", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{
+			"repository": "testhq/hello", "base": "main", "head": "feature", "statuses": []string{"deleted"},
+		}})
+		require.ErrorContains(t, err, `unsupported status filter "deleted"`)
+	})
+
+	t.Run("reports missing fields in configuration order", func(t *testing.T) {
+		for _, testCase := range []struct {
+			configuration map[string]any
+			expectedError string
+		}{
+			{configuration: map[string]any{"repository": " ", "base": " ", "head": " "}, expectedError: "repository is required"},
+			{configuration: map[string]any{"repository": "testhq/hello", "base": " ", "head": " "}, expectedError: "base is required"},
+		} {
+			err := component.Setup(core.SetupContext{Configuration: testCase.configuration})
+			require.EqualError(t, err, testCase.expectedError)
+		}
+	})
+}
+
+func Test__CompareCommits__Execute__routesEmptyComparison(t *testing.T) {
+	state := executeComparison(t, map[string]any{"repository": "testhq/hello", "base": "main", "head": "main"}, comparisonResponse(`[]`))
+	assert.Equal(t, "unmatched", state.Channel)
+	payload := comparisonPayload(t, state)
+	assert.Empty(t, payload.Files)
+	assert.Equal(t, "head-sha", payload.Comparison.HeadSHA)
+}
+
+func Test__CompareCommits__Execute__normalizesStatuses(t *testing.T) {
+	state := executeComparison(t, baseConfiguration(), comparisonResponse(`[
+		{"filename":"added","status":"added"},
+		{"filename":"changed","status":"changed"},
+		{"filename":"copied","previous_filename":"source","status":"copied"},
+		{"filename":"modified","status":"modified"},
+		{"filename":"removed","status":"removed"},
+		{"filename":"renamed","previous_filename":"old","status":"renamed"},
+		{"filename":"unchanged","status":"unchanged"}
+	]`))
+
+	assert.Equal(t, []ComparedFile{
+		{Path: "added", Status: "added"},
+		{Path: "changed", Status: "modified"},
+		{Path: "copied", Status: "added"},
+		{Path: "modified", Status: "modified"},
+		{Path: "removed", Status: "removed"},
+		{Path: "renamed", Status: "renamed", PreviousPath: "old"},
+	}, comparisonPayload(t, state).Files)
+	assert.Equal(t, 6, comparisonPayload(t, state).Comparison.ChangedFileCount)
+}
+
+func Test__CompareCommits__Execute__omitsUnchangedFilesFromChangedCount(t *testing.T) {
+	state := executeComparison(t, baseConfiguration(), comparisonResponse(`[
+		{"filename":"unchanged","status":"unchanged"}
+	]`))
+
+	assert.Equal(t, "unmatched", state.Channel)
+	payload := comparisonPayload(t, state)
+	assert.Zero(t, payload.Comparison.ChangedFileCount)
+	assert.Empty(t, payload.Files)
+}
+
+func Test__CompareCommits__Execute__failsForUnsupportedStatus(t *testing.T) {
+	state, err := runComparison(baseConfiguration(), comparisonResponse(`[{"filename":"file","status":"mystery"}]`))
+	require.ErrorContains(t, err, `unsupported GitHub file status "mystery"`)
+	assert.False(t, state.Finished)
+}
+
+func Test__CompareCommits__Execute__filtersFiles(t *testing.T) {
+	files := comparisonResponse(`[
+		{"filename":"docs/readme.md","status":"modified"},
+		{"filename":"src/new.go","previous_filename":"legacy/new.go","status":"renamed"},
+		{"filename":"src/copied.go","status":"copied"},
+		{"filename":"src/skip.md","status":"added"}
+	]`)
+
+	t.Run("status after normalization", func(t *testing.T) {
+		config := baseConfiguration()
+		config["statuses"] = []string{"added", "added"}
+		state := executeComparison(t, config, files)
+		assert.Equal(t, "matched", state.Channel)
+		assert.Equal(t, []ComparedFile{{Path: "src/copied.go", Status: "added"}, {Path: "src/skip.md", Status: "added"}}, comparisonPayload(t, state).Files)
+		assert.Equal(t, &AppliedFilters{Statuses: stringSlicePointer([]string{"added"})}, comparisonPayload(t, state).AppliedFilters)
+	})
+
+	t.Run("path includes and exclusions", func(t *testing.T) {
+		config := baseConfiguration()
+		config["paths"] = []string{" src/** ", "!src/**/*.md"}
+		state := executeComparison(t, config, files)
+		assert.Equal(t, []ComparedFile{{Path: "src/copied.go", Status: "added"}, {Path: "src/new.go", Status: "renamed", PreviousPath: "legacy/new.go"}}, comparisonPayload(t, state).Files)
+		assert.Equal(t, stringSlicePointer([]string{"src/**", "!src/**/*.md"}), comparisonPayload(t, state).AppliedFilters.Paths)
+	})
+
+	t.Run("rename matches previous path", func(t *testing.T) {
+		config := baseConfiguration()
+		config["paths"] = []string{"legacy/**"}
+		state := executeComparison(t, config, files)
+		assert.Equal(t, []ComparedFile{{Path: "src/new.go", Status: "renamed", PreviousPath: "legacy/new.go"}}, comparisonPayload(t, state).Files)
+	})
+
+	t.Run("rename into included path matches when previous path is excluded", func(t *testing.T) {
+		config := baseConfiguration()
+		config["paths"] = []string{"src/**", "!legacy/**"}
+		state := executeComparison(t, config, files)
+		assert.Equal(t, []ComparedFile{
+			{Path: "src/copied.go", Status: "added"},
+			{Path: "src/new.go", Status: "renamed", PreviousPath: "legacy/new.go"},
+			{Path: "src/skip.md", Status: "added"},
+		}, comparisonPayload(t, state).Files)
+	})
+
+	t.Run("exclusion-only patterns use an implicit include", func(t *testing.T) {
+		config := baseConfiguration()
+		config["paths"] = []string{"!docs/**"}
+		state := executeComparison(t, config, files)
+		assert.Len(t, comparisonPayload(t, state).Files, 3)
+		assert.NotContains(t, comparisonPayload(t, state).Files, ComparedFile{Path: "docs/readme.md", Status: "modified"})
+	})
+
+	t.Run("status and path use AND logic", func(t *testing.T) {
+		config := baseConfiguration()
+		config["statuses"] = []string{"renamed"}
+		config["paths"] = []string{"docs/**"}
+		state := executeComparison(t, config, files)
+		assert.Equal(t, "unmatched", state.Channel)
+		assert.Empty(t, comparisonPayload(t, state).Files)
+	})
+
+	t.Run("empty enabled filters match every changed file", func(t *testing.T) {
+		config := baseConfiguration()
+		config["statuses"] = []string{}
+		config["paths"] = []string{" ", ""}
+		state := executeComparison(t, config, files)
+		assert.Equal(t, "matched", state.Channel)
+		assert.Len(t, comparisonPayload(t, state).Files, 4)
+		assert.Empty(t, *comparisonPayload(t, state).AppliedFilters.Statuses)
+		assert.Empty(t, *comparisonPayload(t, state).AppliedFilters.Paths)
+	})
+}
+
+func Test__CompareCommits__Execute__failsForInvalidGlob(t *testing.T) {
+	config := baseConfiguration()
+	config["paths"] = []string{"src/**", "[invalid"}
+	state, err := runComparison(config, comparisonResponse(`[]`))
+	require.ErrorContains(t, err, `invalid path pattern "[invalid"`)
+	assert.False(t, state.Finished)
+}
+
+func Test__CompareCommits__Execute__preservesGitHubError(t *testing.T) {
+	state, err := runComparison(baseConfiguration(), `{"message":"No common ancestor"}`, http.StatusNotFound)
+	require.ErrorContains(t, err, "No common ancestor")
+	assert.False(t, state.Finished)
+}
+
+func Test__CompareCommits__Execute__rejectsThreeHundredFiles(t *testing.T) {
+	files := make([]string, 300)
+	for index := range files {
+		files[index] = fmt.Sprintf(`{"filename":"file-%03d","status":"modified"}`, index)
+	}
+	state, err := runComparison(baseConfiguration(), comparisonResponse("["+strings.Join(files, ",")+"]"))
+	require.ErrorContains(t, err, "GitHub returned 300 files")
+	assert.False(t, state.Finished)
+}
+
+func Test__CompareCommits__OutputChannels(t *testing.T) {
+	component := CompareCommits{}
+	assert.Equal(t, []string{"matched", "unmatched"}, channelNames(component.OutputChannels(baseConfiguration())))
+	config := baseConfiguration()
+	config["statuses"] = []string{}
+	assert.Equal(t, []string{"matched", "unmatched"}, channelNames(component.OutputChannels(config)))
+	assert.Equal(t, []string{"matched", "unmatched"}, channelNames(component.OutputChannels("invalid")))
+}
+
+func Test__CompareCommits__Execute__emitsMatchedComparison(t *testing.T) {
+	component := CompareCommits{}
+	executionState := &contexts.ExecutionStateContext{}
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+		githubmocks.GitHubResponse(http.StatusOK, comparisonResponse(`[
+			{"filename":"z.go","status":"modified","additions":2,"deletions":1,"changes":3},
+			{"filename":"a.go","status":"added","additions":4,"deletions":0,"changes":4}
+		]`)),
+		githubmocks.GitHubResponse(http.StatusOK, `{"sha":"head-sha"}`),
+	}}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"repository": "testhq/hello", "base": "main", "head": "feature"},
+		Integration:    githubmocks.IntegrationContextForNewSetupFlow(),
+		HTTP:           httpContext,
+		ExecutionState: executionState,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "matched", executionState.Channel)
+	assert.Equal(t, "github.commitComparison", executionState.Type)
+	require.Len(t, executionState.Payloads, 1)
+	payload := executionState.Payloads[0].(map[string]any)["data"].(CommitComparisonPayload)
+	assert.Equal(t, ComparisonMetadata{
+		Repository:       "testhq/hello",
+		BaseSHA:          "base-sha",
+		HeadSHA:          "head-sha",
+		MergeBaseSHA:     "merge-base-sha",
+		URL:              "https://github.com/testhq/hello/compare/main...feature",
+		ChangedFileCount: 2,
+	}, payload.Comparison)
+	assert.Equal(t, []ComparedFile{
+		{Path: "a.go", Status: "added", Additions: 4, Changes: 4},
+		{Path: "z.go", Status: "modified", Additions: 2, Deletions: 1, Changes: 3},
+	}, payload.Files)
+	assert.Equal(t, "/repos/testhq/hello/compare/main...feature", httpContext.Requests[0].URL.Path)
+}
+
+func Test__CompareCommits__Execute__normalizesRequiredConfiguration(t *testing.T) {
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+		githubmocks.GitHubResponse(http.StatusOK, comparisonResponse(`[]`)),
+		githubmocks.GitHubResponse(http.StatusOK, `{"sha":"head-sha"}`),
+	}}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := (&CompareCommits{}).Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"repository": " hello ", "base": " main ", "head": " feature "},
+		Integration:    githubmocks.IntegrationContextForNewSetupFlow(),
+		HTTP:           httpContext,
+		ExecutionState: executionState,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "testhq/hello", comparisonPayload(t, executionState).Comparison.Repository)
+	require.Len(t, httpContext.Requests, 2)
+	assert.Equal(t, "/repos/testhq/hello/compare/main...feature", httpContext.Requests[0].URL.Path)
+	assert.Equal(t, "/repos/testhq/hello/commits/feature", httpContext.Requests[1].URL.Path)
+}
+
+func Test__CompareCommits__Execute__resolvesConfiguredHead(t *testing.T) {
+	firstPage := githubmocks.GitHubResponse(http.StatusOK, `{
+		"html_url":"https://github.com/testhq/hello/compare/main...feature",
+		"base_commit":{"sha":"base-sha"},
+		"merge_base_commit":{"sha":"merge-base-sha"},
+		"commits":[{"sha":"comparison-head"}],
+		"files":[{"filename":"file.go","status":"modified"}]
+	}`)
+	firstPage.Header.Set("Link", `<https://api.github.com/repos/testhq/hello/compare/main...feature?page=2>; rel="next"`)
+	httpContext := &contexts.HTTPContext{Responses: []*http.Response{
+		firstPage,
+		githubmocks.GitHubResponse(http.StatusOK, `{"sha":"resolved-head"}`),
+	}}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := (&CompareCommits{}).Execute(core.ExecutionContext{
+		Configuration:  baseConfiguration(),
+		Integration:    githubmocks.IntegrationContextForNewSetupFlow(),
+		HTTP:           httpContext,
+		ExecutionState: executionState,
+	})
+
+	require.NoError(t, err)
+	payload := comparisonPayload(t, executionState)
+	assert.Equal(t, "resolved-head", payload.Comparison.HeadSHA)
+	assert.Equal(t, []ComparedFile{{Path: "file.go", Status: "modified"}}, payload.Files)
+	require.Len(t, httpContext.Requests, 2)
+	assert.Equal(t, "/repos/testhq/hello/commits/feature", httpContext.Requests[1].URL.Path)
+}
+
+func comparisonResponse(files string) string {
+	return `{
+		"html_url":"https://github.com/testhq/hello/compare/main...feature",
+		"base_commit":{"sha":"base-sha"},
+		"merge_base_commit":{"sha":"merge-base-sha"},
+		"commits":[{"sha":"head-sha"}],
+		"files":` + files + `
+	}`
+}
+
+func baseConfiguration() map[string]any {
+	return map[string]any{"repository": "testhq/hello", "base": "main", "head": "feature"}
+}
+
+func executeComparison(t *testing.T, configuration map[string]any, body string) *contexts.ExecutionStateContext {
+	t.Helper()
+	state, err := runComparison(configuration, body)
+	require.NoError(t, err)
+	return state
+}
+
+func runComparison(configuration map[string]any, body string, statusCodes ...int) (*contexts.ExecutionStateContext, error) {
+	statusCode := http.StatusOK
+	if len(statusCodes) > 0 {
+		statusCode = statusCodes[0]
+	}
+	state := &contexts.ExecutionStateContext{}
+	err := (&CompareCommits{}).Execute(core.ExecutionContext{
+		Configuration: configuration,
+		Integration:   githubmocks.IntegrationContextForNewSetupFlow(),
+		HTTP: &contexts.HTTPContext{Responses: []*http.Response{
+			githubmocks.GitHubResponse(statusCode, body),
+			githubmocks.GitHubResponse(http.StatusOK, `{"sha":"head-sha"}`),
+		}},
+		ExecutionState: state,
+	})
+	return state, err
+}
+
+func comparisonPayload(t *testing.T, state *contexts.ExecutionStateContext) CommitComparisonPayload {
+	t.Helper()
+	require.Len(t, state.Payloads, 1)
+	return state.Payloads[0].(map[string]any)["data"].(CommitComparisonPayload)
+}
+
+func stringSlicePointer(values []string) *[]string { return &values }
+
+func channelNames(channels []core.OutputChannel) []string {
+	names := make([]string, len(channels))
+	for index, channel := range channels {
+		names[index] = channel.Name
+	}
+	return names
+}

--- a/pkg/integrations/github/components/contents/example.go
+++ b/pkg/integrations/github/components/contents/example.go
@@ -7,6 +7,9 @@ import (
 	"github.com/superplanehq/superplane/pkg/utils"
 )
 
+//go:embed payloads/compare_commits.json
+var exampleOutputCompareCommitsBytes []byte
+
 //go:embed payloads/create_release.json
 var exampleOutputCreateReleaseBytes []byte
 
@@ -31,6 +34,9 @@ var exampleDataOnTagCreatedBytes []byte
 //go:embed payloads/on_branch_created.json
 var exampleDataOnBranchCreatedBytes []byte
 
+var exampleOutputCompareCommitsOnce sync.Once
+var exampleOutputCompareCommits map[string]any
+
 var exampleOutputCreateReleaseOnce sync.Once
 var exampleOutputCreateRelease map[string]any
 
@@ -54,6 +60,14 @@ var exampleDataOnTagCreated map[string]any
 
 var exampleDataOnBranchCreatedOnce sync.Once
 var exampleDataOnBranchCreated map[string]any
+
+func (c *CompareCommits) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputCompareCommitsOnce,
+		exampleOutputCompareCommitsBytes,
+		&exampleOutputCompareCommits,
+	)
+}
 
 func (c *CreateRelease) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateReleaseOnce, exampleOutputCreateReleaseBytes, &exampleOutputCreateRelease)

--- a/pkg/integrations/github/components/contents/payloads/compare_commits.json
+++ b/pkg/integrations/github/components/contents/payloads/compare_commits.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "comparison": {
+      "repository": "owner/repo",
+      "baseSha": "d34db33fd34db33fd34db33fd34db33fd34db33f",
+      "headSha": "c0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ff",
+      "mergeBaseSha": "abc1234abc1234abc1234abc1234abc1234abc12",
+      "url": "https://github.com/owner/repo/compare/main...feature",
+      "changedFileCount": 1
+    },
+    "appliedFilters": {
+      "statuses": ["renamed"],
+      "paths": ["src/**"]
+    },
+    "files": [
+      {
+        "path": "src/new-name.ts",
+        "status": "renamed",
+        "additions": 3,
+        "deletions": 1,
+        "changes": 4,
+        "previousPath": "lib/old-name.ts"
+      }
+    ]
+  },
+  "timestamp": "2026-08-15T12:00:00Z",
+  "type": "github.commitComparison"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -114,6 +114,7 @@ func (g *GitHub) Actions() []core.Action {
 		&checks.ListCheckRunsForRef{},
 		&actions.RunWorkflow{},
 		&contents.CreateRelease{},
+		&contents.CompareCommits{},
 		&contents.GetRelease{},
 		&contents.UpdateRelease{},
 		&contents.DeleteRelease{},

--- a/pkg/integrations/github/github_test.go
+++ b/pkg/integrations/github/github_test.go
@@ -73,6 +73,15 @@ func Test__GitHub__Sync(t *testing.T) {
 	})
 }
 
+func Test__GitHub__Actions__includesCompareCommits(t *testing.T) {
+	actionNames := make([]string, 0)
+	for _, action := range (&GitHub{}).Actions() {
+		actionNames = append(actionNames, action.Name())
+	}
+
+	require.Contains(t, actionNames, "github.compareCommits")
+}
+
 func Test__listInstallationRepositories__paginates_all_pages(t *testing.T) {
 	t.Parallel()
 

--- a/web_src/src/pages/app/mappers/github/compare_commits.spec.ts
+++ b/web_src/src/pages/app/mappers/github/compare_commits.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ComponentBaseContext, ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { compareCommitsMapper } from "./compare_commits";
+
+describe("compareCommitsMapper", () => {
+  it("shows repository and comparison refs", () => {
+    const props = compareCommitsMapper.props(buildBaseContext(buildNode()));
+
+    expect(props.metadata).toEqual([
+      { icon: "book", label: "testhq/hello" },
+      { icon: "git-compare", label: "main → feature/3317" },
+    ]);
+  });
+
+  it.each([
+    [{ statuses: ["added", "modified"] }, "added, modified"],
+    [{ paths: ["src/**"] }, "src/**"],
+    [{ statuses: [] }, "All statuses"],
+    [{ paths: [] }, "All paths"],
+    [{ statuses: ["renamed"], paths: ["src/a-very-long-pattern-that-needs-truncation/**"] }, "2 filters"],
+  ])("summarizes active filters", (filters, summary) => {
+    const props = compareCommitsMapper.props(buildBaseContext(buildNode(filters)));
+
+    expect(props.metadata).toContainEqual({ icon: "funnel", label: summary });
+  });
+
+  it("shows unfiltered execution details", () => {
+    const details = compareCommitsMapper.getExecutionDetails(buildDetailsContext("matched", comparisonPayload(3, 3)));
+
+    expect(details).toEqual({
+      "Changed files": "3",
+      "Base SHA": "base-sha",
+      "Head SHA": "head-sha",
+      "Comparison URL": "https://github.com/testhq/hello/compare/main...feature",
+    });
+  });
+
+  it("shows filtered and empty execution details", () => {
+    const details = compareCommitsMapper.getExecutionDetails(
+      buildDetailsContext("unmatched", comparisonPayload(3, 0, { statuses: ["added"] })),
+    );
+
+    expect(details["Changed files"]).toBe("3");
+    expect(details["Matched files"]).toBe("0");
+    expect(details["Comparison URL"]).toBe("https://github.com/testhq/hello/compare/main...feature");
+  });
+
+  it("shows missing count data", () => {
+    const details = compareCommitsMapper.getExecutionDetails(
+      buildDetailsContext("matched", { comparison: {}, appliedFilters: { paths: ["src/**"] } }),
+    );
+
+    expect(details["Changed files"]).toBe("-");
+    expect(details["Matched files"]).toBe("-");
+  });
+
+  it("ignores undeclared output channels", () => {
+    const details = compareCommitsMapper.getExecutionDetails(buildDetailsContext("changed", comparisonPayload(1, 1)));
+
+    expect(details).toEqual({});
+  });
+});
+
+function buildNode(filters: Record<string, unknown> = {}): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Compare commits",
+    componentName: "github.compareCommits",
+    isCollapsed: false,
+    metadata: { repository: { name: "testhq/hello" } },
+    configuration: { repository: "testhq/hello", base: "main", head: "feature/3317", ...filters },
+  };
+}
+
+function buildBaseContext(node: NodeInfo): ComponentBaseContext {
+  return {
+    nodes: [node],
+    node,
+    componentDefinition: {
+      name: "github.compareCommits",
+      label: "Compare Commits",
+      description: "",
+      icon: "github",
+      color: "gray",
+    },
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: vi.fn() },
+  };
+}
+
+function buildDetailsContext(channel: string, payload: unknown): ExecutionDetailsContext {
+  const node = buildNode();
+  const execution = {
+    id: "execution-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    outputs: { [channel]: [{ data: payload }] },
+  } as ExecutionInfo;
+  return { nodes: [node], node, execution };
+}
+
+function comparisonPayload(
+  changedFileCount: number,
+  returnedFileCount: number,
+  appliedFilters?: Record<string, unknown>,
+) {
+  return {
+    comparison: {
+      changedFileCount,
+      baseSha: "base-sha",
+      headSha: "head-sha",
+      url: "https://github.com/testhq/hello/compare/main...feature",
+    },
+    appliedFilters,
+    files: Array.from({ length: returnedFileCount }, (_, index) => ({ path: `file-${index}` })),
+  };
+}

--- a/web_src/src/pages/app/mappers/github/compare_commits.ts
+++ b/web_src/src/pages/app/mappers/github/compare_commits.ts
@@ -1,0 +1,129 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import { buildGithubExecutionSubtitle } from "./utils";
+
+interface CompareCommitsConfiguration {
+  base?: string;
+  head?: string;
+  statuses?: string[];
+  paths?: string[];
+}
+
+interface ComparisonPayload {
+  comparison?: {
+    changedFileCount?: number;
+    baseSha?: string;
+    headSha?: string;
+    url?: string;
+  };
+  appliedFilters?: {
+    statuses?: string[];
+    paths?: string[];
+  };
+  files?: unknown[];
+}
+
+const SUMMARY_LIMIT = 36;
+
+export const compareCommitsMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return {
+      ...baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions),
+      metadata: compareCommitsMetadata(context.node),
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGithubExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const { payload, filtered } = comparisonOutput(context.execution.outputs);
+    if (!payload) {
+      return {};
+    }
+
+    return {
+      "Changed files": displayCount(payload.comparison?.changedFileCount),
+      ...(filtered ? { "Matched files": displayCount(payload.files?.length) } : {}),
+      "Base SHA": payload.comparison?.baseSha || "-",
+      "Head SHA": payload.comparison?.headSha || "-",
+      "Comparison URL": payload.comparison?.url || "-",
+    };
+  },
+};
+
+function displayCount(count: number | undefined): string {
+  return count === undefined ? "-" : String(count);
+}
+
+function compareCommitsMetadata(node: NodeInfo): MetadataItem[] {
+  const metadata = node.metadata as { repository?: { name?: string } } | undefined;
+  const configuration = node.configuration as CompareCommitsConfiguration | undefined;
+
+  return [repositoryMetadata(metadata), refsMetadata(configuration), filterMetadata(configuration)]
+    .filter((item): item is MetadataItem => Boolean(item))
+    .slice(0, 3);
+}
+
+function repositoryMetadata(metadata: { repository?: { name?: string } } | undefined): MetadataItem | undefined {
+  return metadata?.repository?.name ? { icon: "book", label: metadata.repository.name } : undefined;
+}
+
+function refsMetadata(configuration: CompareCommitsConfiguration | undefined): MetadataItem | undefined {
+  if (!configuration?.base && !configuration?.head) {
+    return undefined;
+  }
+
+  return { icon: "git-compare", label: `${configuration.base || "-"} → ${configuration.head || "-"}` };
+}
+
+function filterMetadata(configuration: CompareCommitsConfiguration | undefined): MetadataItem | undefined {
+  if (!configuration) {
+    return undefined;
+  }
+
+  const hasStatuses = Object.prototype.hasOwnProperty.call(configuration, "statuses");
+  const hasPaths = Object.prototype.hasOwnProperty.call(configuration, "paths");
+  if (hasStatuses && hasPaths) {
+    return { icon: "funnel", label: "2 filters" };
+  }
+  if (hasStatuses) {
+    return { icon: "funnel", label: compactSummary(configuration.statuses || [], "All statuses") };
+  }
+  if (hasPaths) {
+    return { icon: "funnel", label: compactSummary(configuration.paths || [], "All paths") };
+  }
+
+  return undefined;
+}
+
+function compactSummary(values: string[], emptySummary: string): string {
+  const summary =
+    values
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .join(", ") || emptySummary;
+  return summary.length <= SUMMARY_LIMIT ? summary : `${summary.slice(0, SUMMARY_LIMIT - 1)}…`;
+}
+
+function comparisonOutput(outputs: unknown): { payload?: ComparisonPayload; filtered: boolean } {
+  const outputPayloads = outputs as Record<string, OutputPayload[]> | undefined;
+  for (const channel of ["matched", "unmatched"]) {
+    const payload = outputPayloads?.[channel]?.[0]?.data as ComparisonPayload | undefined;
+    if (payload) {
+      return { payload, filtered: Boolean(payload.appliedFilters) };
+    }
+  }
+  return { filtered: false };
+}

--- a/web_src/src/pages/app/mappers/github/index.ts
+++ b/web_src/src/pages/app/mappers/github/index.ts
@@ -34,6 +34,7 @@ import { labelsMapper } from "./labels";
 import { addReactionMapper } from "./add_reaction";
 import { getCombinedCommitStatusMapper } from "./get_combined_commit_status";
 import { listCheckRunsForRefMapper } from "./list_check_runs_for_ref";
+import { compareCommitsMapper } from "./compare_commits";
 import { buildActionStateRegistry } from "../utils";
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
@@ -60,6 +61,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   getWorkflowUsage: buildActionStateRegistry("retrieved"),
   getCombinedCommitStatus: buildActionStateRegistry("retrieved"),
   listCheckRunsForRef: buildActionStateRegistry("retrieved"),
+  compareCommits: buildActionStateRegistry("compared"),
   addIssueLabel: buildActionStateRegistry("added"),
   removeIssueLabel: buildActionStateRegistry("removed"),
   addIssueAssignee: buildActionStateRegistry("added"),
@@ -91,6 +93,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   getWorkflowUsage: getWorkflowUsageMapper,
   getCombinedCommitStatus: getCombinedCommitStatusMapper,
   listCheckRunsForRef: listCheckRunsForRefMapper,
+  compareCommits: compareCommitsMapper,
   addIssueLabel: labelsMapper,
   removeIssueLabel: labelsMapper,
   addIssueAssignee: baseIssueMapper,


### PR DESCRIPTION
## Summary

Adds a native GitHub component that returns normalized changed-file metadata between two refs.

Optional status and path filters let workflows route comparison results without custom scripts.

Rejects GitHub results at the 300-file boundary because the file list can be incomplete.

Closes #3317

## Test plan

- [x] Run the 141 GitHub contents component tests.
- [x] Run the 10 GitHub comparison mapper tests.
- [x] Build the production UI.