### PR TITLE
feat: Add Storybook work-order time metrics

### DIFF
--- a/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
+++ b/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
@@ -80,6 +80,8 @@ export interface OrgWorkspacePageOverrides {
   onboarding?: ComponentType;
   /** Storybook-only Work Orders page. Live app ignores this. */
   workOrders?: ComponentType;
+  /** Storybook-only Velocity page (e.g. work-order flow prototype). */
+  velocity?: ComponentType;
 }
 
 export interface OrgWorkspaceHarnessProps {
@@ -196,6 +198,7 @@ function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePag
   const WikiRoutePage = pageOverrides?.wiki ?? WikiPage;
   const OverviewRoutePage = pageOverrides?.overview ?? OverviewPage;
   const WorkOrdersRoutePage = pageOverrides?.workOrders ?? WorkOrdersPage;
+  const VelocityRoutePage = pageOverrides?.velocity ?? VelocityPage;
   const OnboardingRoutePage = pageOverrides?.onboarding;
   const onboardingEnabled = Boolean(OnboardingRoutePage);
 
@@ -222,7 +225,7 @@ function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePag
               <Route path="missions" element={<MissionsPage />} />
               <Route path="missions/:missionId" element={<MissionDetailPage />} />
               <Route path="wiki" element={<WikiRoutePage />} />
-              <Route path="velocity" element={<VelocityPage />} />
+              <Route path="velocity" element={<VelocityRoutePage />} />
               <Route path="work-orders">
                 <Route index element={<WorkOrdersRoutePage />} />
                 <Route path="new" element={<CreateWorkOrderComposeRedirect />} />

--- a/web_src/src/pages/factories/pages/Velocity.stories.tsx
+++ b/web_src/src/pages/factories/pages/Velocity.stories.tsx
@@ -2,10 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
-import { VelocityPage } from "./VelocityPage";
+import { VelocityPage, VelocityPrototypePage } from "./VelocityPage";
 
 /**
- * Velocity page: yesterday snapshot, SuperPlane output trend, and source split.
+ * Velocity page: PR output plus Storybook work-order time (cycle and Waiting).
  */
 const meta = {
   title: "Factories/Pages/Velocity",
@@ -22,6 +22,7 @@ export const Default: Story = {
     <FactoriesHarness
       pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/velocity`}
       factoriesFixture={defaultFactoriesFixture}
+      pageOverrides={{ velocity: VelocityPrototypePage }}
     />
   ),
 };

--- a/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import { FACTORY_VELOCITY_BY_PERIOD, FACTORY_VELOCITY_YESTERDAY } from "./factoryVelocityMockData";
+import { FACTORY_VELOCITY_FLOW_BY_PERIOD } from "./factoryVelocityFlowMockData";
 import { VelocityPage } from "./VelocityPage";
 
 describe("VelocityPage", () => {
@@ -30,6 +31,8 @@ describe("VelocityPage", () => {
     expect(split).toHaveTextContent("Merged PRs by source");
     expect(split).toHaveTextContent("SuperPlane");
     expect(split).toHaveTextContent(`${FACTORY_VELOCITY_BY_PERIOD[7].totals.superplaneSharePct}%`);
+
+    expect(screen.queryByTestId("velocity-work-order-flow")).not.toBeInTheDocument();
   });
 
   it("updates trend totals when the period changes and keeps yesterday fixed", async () => {
@@ -47,5 +50,42 @@ describe("VelocityPage", () => {
       String(FACTORY_VELOCITY_BY_PERIOD[30].totals.merged),
     );
     expect(screen.getByTestId("velocity-yesterday")).toHaveTextContent(String(yesterdayMerged));
+  });
+
+  it("shows work-order time metrics when includeWorkOrderFlow is set", () => {
+    render(<VelocityPage includeWorkOrderFlow />);
+
+    const flow = screen.getByTestId("velocity-work-order-flow");
+    const period = FACTORY_VELOCITY_FLOW_BY_PERIOD[7];
+
+    expect(flow).toHaveTextContent("Work order time");
+    expect(flow).not.toHaveTextContent("Closed work orders");
+    expect(flow).toHaveTextContent("Last 7 days");
+    expect(flow).toHaveTextContent("Cycle time");
+    expect(flow).toHaveTextContent("Time running");
+    expect(flow).toHaveTextContent("Time in Waiting");
+    expect(flow).toHaveTextContent(`${period.runningShareOfCyclePct}% of cycle time`);
+    expect(flow).toHaveTextContent(`${period.waitingShareOfCyclePct}% of cycle time`);
+    expect(flow).toHaveTextContent("Time running and Time in Waiting by day");
+    expect(flow).not.toHaveTextContent("Work orders in Waiting");
+    expect(flow).not.toHaveTextContent("Open in Waiting");
+    expect(flow).not.toHaveTextContent("Waiting now");
+    expect(flow).not.toHaveTextContent("Median age");
+    expect(flow).not.toHaveTextContent("Lead time");
+  });
+
+  it("updates closed-period metrics when the period changes", async () => {
+    const user = userEvent.setup();
+    render(<VelocityPage includeWorkOrderFlow />);
+
+    expect(screen.getByTestId("velocity-work-order-flow")).toHaveTextContent(
+      `${FACTORY_VELOCITY_FLOW_BY_PERIOD[7].waitingShareOfCyclePct}% of cycle time`,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "30d" }));
+
+    const flow = screen.getByTestId("velocity-work-order-flow");
+    expect(flow).toHaveTextContent("Last 30 days");
+    expect(flow).toHaveTextContent(`${FACTORY_VELOCITY_FLOW_BY_PERIOD[30].waitingShareOfCyclePct}% of cycle time`);
   });
 });

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 import { SegmentedNav } from "@/ui/SegmentedNav";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
+import { FACTORY_VELOCITY_FLOW_BY_PERIOD, type FactoryVelocityFlowPeriod } from "./factoryVelocityFlowMockData";
 import {
   FACTORY_VELOCITY_BY_PERIOD,
   FACTORY_VELOCITY_YESTERDAY,
@@ -39,8 +40,22 @@ const sourceChartConfig = {
   superplaneMerged: { label: "SuperPlane", color: "#10b981" },
 } satisfies ChartConfig;
 
+const timeTrendChartConfig = {
+  runningHours: { label: "Time running", color: "#60a5fa" },
+  waitingHours: { label: "Time in Waiting", color: "#f59e0b" },
+} satisfies ChartConfig;
+
 function formatUsd(value: number) {
   return `$${value.toFixed(2)}`;
+}
+
+/** Formats elapsed hours as `14h` or `1.5d` for compact metric cells. */
+function formatDurationHours(hours: number) {
+  if (hours < 48) {
+    return `${Math.round(hours)}h`;
+  }
+  const days = hours / 24;
+  return `${days % 1 === 0 ? days.toFixed(0) : days.toFixed(1)}d`;
 }
 
 function formatTokens(value: number) {
@@ -53,6 +68,24 @@ function formatTokens(value: number) {
 
 function formatPct(value: number) {
   return `${value}%`;
+}
+
+function formatTimeTrendTooltip(value: unknown, name: unknown) {
+  const hours = Array.isArray(value) ? Number(value[0]) : Number(value);
+  const seriesKey = String(name);
+  const label =
+    seriesKey in timeTrendChartConfig
+      ? timeTrendChartConfig[seriesKey as keyof typeof timeTrendChartConfig].label
+      : seriesKey;
+
+  return (
+    <div className="flex w-full items-center justify-between gap-8">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono font-medium text-foreground tabular-nums">
+        {Number.isFinite(hours) ? formatDurationHours(hours) : String(value)}
+      </span>
+    </div>
+  );
 }
 
 function MetricCell({ value, label, hint }: { value: string; label: string; hint?: string }) {
@@ -281,14 +314,127 @@ function SourceSplitCard({ periodDays }: { periodDays: FactoryVelocityPeriodDays
   );
 }
 
-export function VelocityPage() {
+function TimeTrendChart({ period }: { period: FactoryVelocityFlowPeriod }) {
+  const height = period.days === 7 ? 240 : 220;
+
+  return (
+    <ChartContainer
+      config={timeTrendChartConfig}
+      className="aspect-auto w-full"
+      style={{ height }}
+      initialDimension={{ width: 720, height }}
+    >
+      <AreaChart data={period.timeTrend} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={36}
+          tickMargin={4}
+          className="text-[11px]"
+          tickFormatter={(value: number) => `${Number(value).toFixed(0)}h`}
+        />
+        <ChartTooltip content={<ChartTooltipContent formatter={formatTimeTrendTooltip} />} />
+        <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+        <Area
+          type="monotone"
+          dataKey="runningHours"
+          stackId="day"
+          stroke="var(--color-runninghours)"
+          fill="var(--color-runninghours)"
+          fillOpacity={0.35}
+          strokeWidth={1.5}
+        />
+        <Area
+          type="monotone"
+          dataKey="waitingHours"
+          stackId="day"
+          stroke="var(--color-waitinghours)"
+          fill="var(--color-waitinghours)"
+          fillOpacity={0.35}
+          strokeWidth={1.5}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+function WorkOrderFlowCard({ periodDays }: { periodDays: FactoryVelocityPeriodDays }) {
+  const period = FACTORY_VELOCITY_FLOW_BY_PERIOD[periodDays];
+
+  return (
+    <section
+      className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5"
+      data-testid="velocity-work-order-flow"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">Work order time</h2>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">
+            Median times for work orders that closed in this period. Cycle time is time running plus time in Waiting
+            after the work order leaves Draft.
+          </p>
+        </div>
+        <p className="text-[12px] text-muted-foreground">{period.label}</p>
+      </div>
+
+      <div className="mt-5">
+        <div className="grid grid-cols-2 gap-x-8 gap-y-5 sm:grid-cols-3">
+          <MetricCell
+            value={formatDurationHours(period.medianCycleHours)}
+            label="Cycle time"
+            hint="From start to close"
+          />
+          <MetricCell
+            value={formatDurationHours(period.medianRunningHours)}
+            label="Time running"
+            hint={`${period.runningShareOfCyclePct}% of cycle time`}
+          />
+          <MetricCell
+            value={formatDurationHours(period.medianWaitingHours)}
+            label="Time in Waiting"
+            hint={`${period.waitingShareOfCyclePct}% of cycle time`}
+          />
+        </div>
+        <p className="mt-3 text-[12px] text-muted-foreground">
+          Time running is time on a line. Time in Waiting is review or a pause before the next dispatch.
+        </p>
+      </div>
+
+      <div className="mt-6 border-t border-border pt-5">
+        <h3 className="text-[13px] font-medium text-foreground">Time running and Time in Waiting by day</h3>
+        <p className="mb-3 mt-0.5 text-[12px] text-muted-foreground">
+          Median for work orders that closed on that day. The stacked area is the two parts of cycle time.
+        </p>
+        <TimeTrendChart period={period} />
+      </div>
+    </section>
+  );
+}
+
+export type VelocityPageProps = {
+  /** Storybook prototype: show work-order lifecycle and Waiting bottleneck. */
+  includeWorkOrderFlow?: boolean;
+};
+
+/** Storybook entry that enables the work-order flow prototype section. */
+export function VelocityPrototypePage() {
+  return <VelocityPage includeWorkOrderFlow />;
+}
+
+export function VelocityPage({ includeWorkOrderFlow = false }: VelocityPageProps = {}) {
   const [periodDays, setPeriodDays] = useState<FactoryVelocityPeriodDays>(7);
 
   return (
     <>
       <WorkspacePageHeader
         title="Velocity"
-        subtitle="Merged pull requests from SuperPlane, waste, and cost."
+        subtitle={
+          includeWorkOrderFlow
+            ? "Merged pull requests, waste, cost, and work order time."
+            : "Merged pull requests from SuperPlane, waste, and cost."
+        }
         actions={
           <SegmentedNav
             ariaLabel="Velocity period in days"
@@ -307,6 +453,7 @@ export function VelocityPage() {
         <YesterdayCard snapshot={FACTORY_VELOCITY_YESTERDAY} />
         <TrendCard periodDays={periodDays} />
         <SourceSplitCard periodDays={periodDays} />
+        {includeWorkOrderFlow ? <WorkOrderFlowCard periodDays={periodDays} /> : null}
       </div>
     </>
   );

--- a/web_src/src/pages/factories/pages/factoryVelocityFlowMockData.ts
+++ b/web_src/src/pages/factories/pages/factoryVelocityFlowMockData.ts
@@ -1,0 +1,66 @@
+import type { FactoryVelocityPeriodDays } from "./factoryVelocityMockData";
+
+export type FactoryVelocityFlowTrendPoint = {
+  day: string;
+  /** Median hours in Running for work orders that closed that day. */
+  runningHours: number;
+  /** Median hours in Waiting for work orders that closed that day. */
+  waitingHours: number;
+};
+
+export type FactoryVelocityFlowPeriod = {
+  days: FactoryVelocityPeriodDays;
+  label: string;
+  /** Median hours from leaving Draft to closed. */
+  medianCycleHours: number;
+  /** Median hours spent in Running before close. */
+  medianRunningHours: number;
+  /** Median hours spent in Waiting before close. */
+  medianWaitingHours: number;
+  runningShareOfCyclePct: number;
+  waitingShareOfCyclePct: number;
+  timeTrend: FactoryVelocityFlowTrendPoint[];
+};
+
+const WEEK_TREND: FactoryVelocityFlowTrendPoint[] = [
+  { day: "Fri", runningHours: 16, waitingHours: 12 },
+  { day: "Sat", runningHours: 14, waitingHours: 16 },
+  { day: "Sun", runningHours: 12, waitingHours: 20 },
+  { day: "Mon", runningHours: 12, waitingHours: 22 },
+  { day: "Tue", runningHours: 12, waitingHours: 26 },
+  { day: "Wed", runningHours: 12, waitingHours: 28 },
+  { day: "Thu", runningHours: 14, waitingHours: 22 },
+];
+
+function buildMonthTimeTrend(): FactoryVelocityFlowTrendPoint[] {
+  return Array.from({ length: 30 }, (_, index) => {
+    const dayNumber = index + 1;
+    const day = dayNumber % 5 === 1 || dayNumber === 30 ? String(dayNumber) : "";
+    const runningHours = Math.max(10, Math.round(14 + 2 * Math.sin(index * 0.5)));
+    const waitingHours = Math.max(10, Math.round(16 + index * 0.25 + 4 * Math.sin(index * 0.35)));
+    return { day, runningHours, waitingHours };
+  });
+}
+
+export const FACTORY_VELOCITY_FLOW_BY_PERIOD: Record<FactoryVelocityPeriodDays, FactoryVelocityFlowPeriod> = {
+  7: {
+    days: 7,
+    label: "Last 7 days",
+    medianCycleHours: 36,
+    medianRunningHours: 14,
+    medianWaitingHours: 22,
+    runningShareOfCyclePct: 39,
+    waitingShareOfCyclePct: 61,
+    timeTrend: WEEK_TREND,
+  },
+  30: {
+    days: 30,
+    label: "Last 30 days",
+    medianCycleHours: 42,
+    medianRunningHours: 16,
+    medianWaitingHours: 26,
+    runningShareOfCyclePct: 38,
+    waitingShareOfCyclePct: 62,
+    timeTrend: buildMonthTimeTrend(),
+  },
+};


### PR DESCRIPTION
## Summary

Factory owners need to see if Waiting is the bottleneck, or if lines get slower.

The Velocity Storybook page only showed pull request output. This change adds a prototype Work order time section with median cycle, running, and Waiting times, plus a stacked area chart of the same split by day.

Production Velocity stays unchanged. Storybook mounts the section through a page override.


Made with [Cursor](https://cursor.com)