### PR TITLE
fix: Report the real error behind 5xx responses to Sentry

### DIFF
--- a/pkg/grpc/gateway_http_error.go
+++ b/pkg/grpc/gateway_http_error.go
@@ -7,9 +7,13 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/superplanehq/superplane/pkg/telemetry"
 )
 
 func writeGatewayHTTPError(ctx context.Context, w http.ResponseWriter, err error) {
+	telemetry.RecordServerError(ctx, err)
+
 	sanitized := SanitizeError(ctx, err)
 	s := status.Convert(sanitized)
 

--- a/pkg/grpc/gateway_middleware.go
+++ b/pkg/grpc/gateway_middleware.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/superplanehq/superplane/pkg/telemetry"
 )
 
 func GatewayRecoveryMiddleware() runtime.Middleware {
@@ -32,5 +34,11 @@ func SanitizedGatewayErrorHandler(
 	r *http.Request,
 	err error,
 ) {
+	//
+	// Hand the original error to the HTTP layer before it is replaced by a
+	// message the client is allowed to see, so Sentry reports the real failure.
+	//
+	telemetry.RecordServerError(r.Context(), err)
+
 	runtime.DefaultHTTPErrorHandler(ctx, mux, marshaler, w, r, SanitizeError(r.Context(), err))
 }

--- a/pkg/grpc/gateway_middleware_test.go
+++ b/pkg/grpc/gateway_middleware_test.go
@@ -1,0 +1,46 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/superplanehq/superplane/pkg/telemetry"
+)
+
+func TestSanitizedGatewayErrorHandler(t *testing.T) {
+	t.Run("records the original error and still sanitizes the response", func(t *testing.T) {
+		ctx, recorder := telemetry.WithServerErrorRecorder(context.Background())
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/factories", nil).WithContext(ctx)
+		response := httptest.NewRecorder()
+
+		original := errors.New("ERROR: column factories.key does not exist (SQLSTATE 42703)")
+		SanitizedGatewayErrorHandler(ctx, runtime.NewServeMux(), &runtime.JSONPb{}, response, request, original)
+
+		assert.Equal(t, original, recorder.Err())
+
+		assert.Equal(t, http.StatusInternalServerError, response.Code)
+		assert.NotContains(t, response.Body.String(), "factories.key")
+		assert.Contains(t, response.Body.String(), sanitizedInternalMessage)
+	})
+}
+
+func TestWriteGatewayHTTPError(t *testing.T) {
+	t.Run("records the original error and still sanitizes the response", func(t *testing.T) {
+		ctx, recorder := telemetry.WithServerErrorRecorder(context.Background())
+		response := httptest.NewRecorder()
+
+		original := errors.New("failed to load permissions: dial tcp 10.0.0.7:5432: connect: connection refused")
+		writeGatewayHTTPError(ctx, response, original)
+
+		assert.Equal(t, original, recorder.Err())
+
+		assert.Equal(t, http.StatusInternalServerError, response.Code)
+		assert.NotContains(t, response.Body.String(), "10.0.0.7")
+		assert.Contains(t, response.Body.String(), sanitizedInternalMessage)
+	})
+}

--- a/pkg/public/middleware/logging.go
+++ b/pkg/public/middleware/logging.go
@@ -13,6 +13,8 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/superplanehq/superplane/pkg/telemetry"
 )
 
 func LoggingMiddleware(logger *log.Logger) mux.MiddlewareFunc {
@@ -21,6 +23,14 @@ func LoggingMiddleware(logger *log.Logger) mux.MiddlewareFunc {
 			start := time.Now()
 			// Use a response writer wrapper to capture status code
 			lrw := &loggingResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+			//
+			// Error responses are sanitized before they are written, so the
+			// status code is all we would otherwise know about a failure.
+			// The recorder lets the handlers hand us the original error.
+			//
+			ctx, serverError := telemetry.WithServerErrorRecorder(r.Context())
+			r = r.WithContext(ctx)
 
 			defer func() {
 				recovered := recover()
@@ -50,6 +60,11 @@ func LoggingMiddleware(logger *log.Logger) mux.MiddlewareFunc {
 					fields["user_agent"] = r.UserAgent()
 				}
 
+				handlerErr := serverError.Err()
+				if handlerErr != nil && shouldCaptureHTTPError(status) {
+					fields["error"] = handlerErr
+				}
+
 				logger.WithFields(fields).Info("handled request")
 
 				if recovered != nil {
@@ -58,7 +73,7 @@ func LoggingMiddleware(logger *log.Logger) mux.MiddlewareFunc {
 				}
 
 				if shouldCaptureHTTPError(status) {
-					captureHTTPError(r, status)
+					captureHTTPError(r, status, handlerErr)
 				}
 			}()
 
@@ -107,7 +122,12 @@ func shouldCaptureHTTPError(status int) bool {
 	return true
 }
 
-func captureHTTPError(r *http.Request, status int) {
+// captureHTTPError forwards a server error to Sentry. When the handler recorded
+// the error behind the response, we send that error so the issue carries a
+// message and a stacktrace pointing at the failing code. Without it there is
+// nothing to report but the status code and the path, which is not enough to
+// tell a schema mismatch from a nil dereference.
+func captureHTTPError(r *http.Request, status int, handlerErr error) {
 	hub := sentry.CurrentHub()
 	if hub == nil || hub.Client() == nil {
 		return
@@ -116,7 +136,17 @@ func captureHTTPError(r *http.Request, status int) {
 	hub.WithScope(func(scope *sentry.Scope) {
 		scope.SetRequest(r)
 		scope.SetTag("status", strconv.Itoa(status))
-		hub.CaptureMessage(fmt.Sprintf("HTTP %d %s", status, r.URL.Path))
+
+		if handlerErr == nil {
+			//
+			// Responses written outside the gRPC error paths (static assets,
+			// websocket upgrades, http.Error calls) have no recorded error.
+			//
+			hub.CaptureMessage(fmt.Sprintf("HTTP %d %s", status, r.URL.Path))
+			return
+		}
+
+		hub.CaptureException(handlerErr)
 	})
 }
 

--- a/pkg/public/middleware/logging_test.go
+++ b/pkg/public/middleware/logging_test.go
@@ -1,10 +1,19 @@
 package middleware
 
 import (
+	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/getsentry/sentry-go"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/superplanehq/superplane/pkg/telemetry"
 )
 
 func TestShouldCaptureHTTPError(t *testing.T) {
@@ -34,3 +43,89 @@ func TestShouldCaptureHTTPError(t *testing.T) {
 		assert.False(t, shouldCaptureHTTPError(http.StatusHTTPVersionNotSupported))
 	})
 }
+
+func TestLoggingMiddlewareErrorReporting(t *testing.T) {
+	t.Run("reports the error recorded behind the response", func(t *testing.T) {
+		transport := captureSentryEvents(t)
+
+		serveWithLoggingMiddleware(t, "/api/v1/factories", func(w http.ResponseWriter, r *http.Request) {
+			telemetry.RecordServerError(r.Context(), errors.New(`ERROR: column factories.key does not exist (SQLSTATE 42703)`))
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		require.Len(t, transport.events, 1)
+		event := transport.events[0]
+
+		require.Len(t, event.Exception, 1)
+		assert.Equal(t, `ERROR: column factories.key does not exist (SQLSTATE 42703)`, event.Exception[0].Value)
+		assert.Equal(t, "500", event.Tags["status"])
+		assert.Empty(t, event.Message)
+	})
+
+	t.Run("falls back to the request summary when no error was recorded", func(t *testing.T) {
+		transport := captureSentryEvents(t)
+
+		serveWithLoggingMiddleware(t, "/api/v1/factories", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		require.Len(t, transport.events, 1)
+		event := transport.events[0]
+
+		assert.Equal(t, "HTTP 500 /api/v1/factories", event.Message)
+		assert.Empty(t, event.Exception)
+	})
+
+	t.Run("reports nothing for successful responses", func(t *testing.T) {
+		transport := captureSentryEvents(t)
+
+		serveWithLoggingMiddleware(t, "/api/v1/factories", func(w http.ResponseWriter, r *http.Request) {
+			telemetry.RecordServerError(r.Context(), errors.New("recorded but recovered from"))
+			w.WriteHeader(http.StatusOK)
+		})
+
+		assert.Empty(t, transport.events)
+	})
+}
+
+func serveWithLoggingMiddleware(t *testing.T, path string, handler http.HandlerFunc) {
+	t.Helper()
+
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	LoggingMiddleware(logger)(handler).ServeHTTP(httptest.NewRecorder(), request)
+}
+
+// captureSentryEvents binds a client with an in-memory transport to the current
+// hub for the duration of the test.
+func captureSentryEvents(t *testing.T) *sentryTransportStub {
+	t.Helper()
+
+	transport := &sentryTransportStub{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://public@example.com/1",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+
+	hub := sentry.CurrentHub()
+	previous := hub.Client()
+	hub.BindClient(client)
+	t.Cleanup(func() { hub.BindClient(previous) })
+
+	return transport
+}
+
+type sentryTransportStub struct {
+	events []*sentry.Event
+}
+
+func (t *sentryTransportStub) Configure(sentry.ClientOptions) {}
+
+func (t *sentryTransportStub) SendEvent(event *sentry.Event) {
+	t.events = append(t.events, event)
+}
+
+func (t *sentryTransportStub) Flush(time.Duration) bool { return true }

--- a/pkg/telemetry/server_error.go
+++ b/pkg/telemetry/server_error.go
@@ -1,0 +1,74 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+)
+
+/*
+ * Errors are sanitized before they reach the client, so a 5xx response carries
+ * nothing about what actually failed. The HTTP layer that reports the failure
+ * only sees a status code, which is not enough to act on.
+ *
+ * A ServerErrorRecorder travels with the request context so the layer that
+ * still holds the original error can hand it to the layer that reports it.
+ */
+type ServerErrorRecorder struct {
+	mu  sync.Mutex
+	err error
+}
+
+type serverErrorRecorderKey struct{}
+
+// WithServerErrorRecorder attaches an empty recorder to ctx and returns it
+// together with the derived context.
+func WithServerErrorRecorder(ctx context.Context) (context.Context, *ServerErrorRecorder) {
+	recorder := &ServerErrorRecorder{}
+	return context.WithValue(ctx, serverErrorRecorderKey{}, recorder), recorder
+}
+
+// RecordServerError stores err on the recorder attached to ctx. It is a no-op
+// when err is nil or when no recorder is attached, so call sites do not have to
+// care whether they run inside an instrumented HTTP request.
+func RecordServerError(ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
+
+	recorder := serverErrorRecorderFrom(ctx)
+	if recorder == nil {
+		return
+	}
+
+	recorder.record(err)
+}
+
+// Err returns the recorded error, or nil when nothing was recorded.
+func (r *ServerErrorRecorder) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.err
+}
+
+// record keeps the first error it is given. That is the one closest to the root
+// cause: anything recorded later in the same request is a reaction to it.
+func (r *ServerErrorRecorder) record(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.err != nil {
+		return
+	}
+
+	r.err = err
+}
+
+func serverErrorRecorderFrom(ctx context.Context) *ServerErrorRecorder {
+	if ctx == nil {
+		return nil
+	}
+
+	recorder, _ := ctx.Value(serverErrorRecorderKey{}).(*ServerErrorRecorder)
+	return recorder
+}

--- a/pkg/telemetry/server_error_test.go
+++ b/pkg/telemetry/server_error_test.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerErrorRecorder(t *testing.T) {
+	t.Run("records the error for the request", func(t *testing.T) {
+		ctx, recorder := WithServerErrorRecorder(context.Background())
+		require.Nil(t, recorder.Err())
+
+		boom := errors.New("boom")
+		RecordServerError(ctx, boom)
+
+		assert.Equal(t, boom, recorder.Err())
+	})
+
+	t.Run("keeps the first error", func(t *testing.T) {
+		ctx, recorder := WithServerErrorRecorder(context.Background())
+
+		rootCause := errors.New("column factories.key does not exist")
+		RecordServerError(ctx, rootCause)
+		RecordServerError(ctx, errors.New("internal server error"))
+
+		assert.Equal(t, rootCause, recorder.Err())
+	})
+
+	t.Run("ignores nil errors", func(t *testing.T) {
+		ctx, recorder := WithServerErrorRecorder(context.Background())
+
+		RecordServerError(ctx, nil)
+
+		assert.Nil(t, recorder.Err())
+	})
+
+	t.Run("is a no-op without a recorder in the context", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			RecordServerError(context.Background(), errors.New("boom"))
+		})
+	})
+
+	t.Run("is safe for concurrent use", func(t *testing.T) {
+		ctx, recorder := WithServerErrorRecorder(context.Background())
+
+		var wg sync.WaitGroup
+		for i := 0; i < 16; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				RecordServerError(ctx, errors.New("boom"))
+				_ = recorder.Err()
+			}()
+		}
+		wg.Wait()
+
+		assert.Error(t, recorder.Err())
+	})
+}


### PR DESCRIPTION
## Summary

- The HTTP layer sanitizes errors before it writes a 5xx response, so Sentry received only the status code and the path.
- Five open issues show the effect: #6693, #6694, #6695, #6696 and #6697. No event carries an exception or a stacktrace, so the cause stays unknown.
- This change keeps the original error for the report. The two gateway error paths record it, and the logging middleware sends it with `CaptureException`.
- The client response does not change. The sanitized message and the status code stay the same. The original error goes only to Sentry and to the request log.
- The request log line for a 5xx now carries an `error` field. Self-hosted installations without a Sentry DSN can then see the cause.

The recorder lives in `pkg/telemetry` because both `pkg/grpc` and `pkg/public/middleware` need it, and `pkg/grpc` cannot import `pkg/public`.

Responses that other code writes, for example static assets, websocket upgrades and direct `http.Error` calls, have no recorded error. They keep the current message capture, so every 5xx is still reported.

This change does not address the deploy sequence that produced those five 500 responses. It makes the next occurrence diagnosable.

## Test plan

- [x] `go test ./pkg/telemetry/ -run TestServerErrorRecorder`: the recorder keeps the first error, ignores nil, and stays a no-op without a recorder in the context.
- [x] `go test ./pkg/grpc/ -run 'TestSanitizedGatewayErrorHandler|TestWriteGatewayHTTPError'`: both gateway paths record the original error, and the response body stays sanitized.
- [x] `go test ./pkg/public/middleware/ -run TestLoggingMiddlewareErrorReporting`: the middleware sends an exception when an error is recorded, sends the message when none is recorded, and sends nothing for a 2xx.
- [ ] Start the app with a Sentry DSN, force a 500 on `/api/v1/factories`, and confirm that the issue holds the exception and the stacktrace. I did not run this step, because my local setup has no DSN.
