### PR TITLE
docs: Align pull request guidance

### DIFF
--- a/docs/contributing/commit_sign-off.md
+++ b/docs/contributing/commit_sign-off.md
@@ -12,7 +12,7 @@ Any contributions to SuperPlane must only contain code that can legally be
 contributed to SuperPlane, and which the SuperPlane project can distribute
 under its license.
 
-Prior to contributing to SuperPlane please read the [Developer's Certificate of Origin](/docs/legal/developer_certificate_of_origin.txt)
+Prior to contributing to SuperPlane please read the [Developer's Certificate of Origin](../legal/developer_certificate_of_origin.txt)
 and sign-off all commits with the `--signoff` option provided by `git commit`.
 
 For example:
@@ -44,12 +44,12 @@ To automatically append the sign-off line to every commit made via the VS Code
 interface, you can enable a setting:
 
 1. Open VS Code Settings (Code > Settings on macOS, or File > Preferences > Settings on Linux/Windows)
-2. Search for git.enableCommitSigning or git signoff.
-3. Check the box for "Git: Enable Commit Signing".
+2. Search for `git.alwaysSignOff`.
+3. Check the box for "Git: Always Sign Off".
 
-This setting automatically appends the -s or --signoff flag to the git commit
-command when you commit via the VS Code UI, achieving the same result as running
-git commit -s in the terminal.
+This setting appends a `Signed-off-by` trailer when you commit from the VS Code
+UI. It is the DCO sign-off. Do not confuse it with "Git: Enable Commit Signing",
+which enables GPG or SSH commit signatures.
 
 ### Automatic verification of DCO
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -85,7 +85,7 @@ git push origin feat/add-new-feature
 2. You should see a banner suggesting to create a pull request from your recently pushed branch
 3. Click "Compare & pull request"
 4. Fill in the PR title following the [title format rules](#title-format-rules)
-5. Add a detailed description (see [Pull Request Description](#pull-request-description))
+5. Add a description with a Summary and a Test plan (see [Pull Request Description](#pull-request-description))
 6. Submit the pull request
 
 ## Title Format Rules
@@ -129,15 +129,28 @@ You can optionally add more detail about the breaking behavior in the PR descrip
 
 ## Pull Request Description
 
-A good PR description helps reviewers understand your changes quickly. Include:
+Use this shape so reviewers can scan the change. The in-repo agent guide
+([AGENTS.md](../../AGENTS.md) and
+[.agents/skills/commit-and-pr-messages/SKILL.md](../../.agents/skills/commit-and-pr-messages/SKILL.md))
+uses the same sections.
 
-### Required Information
+```markdown
+## Summary
 
-- **What changed**: A clear summary of what the PR does
-- **Why**: The motivation or problem being solved
-- **How**: Brief explanation of the approach taken (if not obvious from the code)
-- **Related issues**: Link to any related GitHub issues using `Closes #123` or `Fixes #456`
-- **Breaking changes**: If applicable, clearly document any breaking changes
+<2-4 short sentences or bullets: the problem and why this change exists.
+Focus on motivation and user or system impact.>
+
+## Test plan
+
+- [ ] <Imperative check a reviewer can run>
+- [ ] <Edge cases or regressions worth checking>
+```
+
+Also include when they apply:
+
+- Related issues: `Closes #123` or `Fixes #456`
+- A brief note on approach when it is not obvious from the diff
+- Breaking changes, with migration steps for users
 
 ## Review Process
 


### PR DESCRIPTION
## Summary

The public contributor guide does not match the repository rules for titles, descriptions, test plans, and commit sign-off. The DCO link also fails from GitHub.

This change aligns the guide so external contributors can prepare review-ready pull requests.

## Test plan

- [x] Check the changed Markdown files with `git diff --check`.
- [x] Confirm each relative link resolves to a repository file.
- [x] Confirm the title and description examples match repository rules.


Made with [Cursor](https://cursor.com)