### PR TITLE
feat: Open Factory User Menu From Profile Row

### DIFF
--- a/web_src/src/pages/factories/layout/SidebarUserMenu.spec.tsx
+++ b/web_src/src/pages/factories/layout/SidebarUserMenu.spec.tsx
@@ -30,9 +30,9 @@ describe("SidebarUserMenu", () => {
     const user = userEvent.setup();
     renderMenu();
 
-    const trigger = screen.getByTestId("factories-sidebar-user-menu-trigger");
-    expect(trigger).toHaveTextContent("Ada Lovelace");
-    expect(trigger).toHaveTextContent("SuperPlane");
+    const trigger = screen.getByRole("button", { name: /Ada Lovelace/ });
+    expect(trigger).toHaveAccessibleName(/Ada Lovelace.*SuperPlane/s);
+    expect(trigger).toHaveAttribute("data-testid", "factories-sidebar-user-menu-trigger");
     expect(within(trigger).queryByRole("button")).not.toBeInTheDocument();
 
     await user.click(trigger);

--- a/web_src/src/pages/factories/layout/SidebarUserMenu.spec.tsx
+++ b/web_src/src/pages/factories/layout/SidebarUserMenu.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { SidebarUserMenu } from "./SidebarUserMenu";
+
+vi.mock("@/posthog", () => ({
+  posthog: { reset: vi.fn() },
+}));
+
+function renderMenu() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <SidebarUserMenu
+          organizationId="org-1"
+          userName="Ada Lovelace"
+          userEmail="ada@example.com"
+          organizationName="SuperPlane"
+        />
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("SidebarUserMenu", () => {
+  it("opens the user menu from the whole profile row", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    const trigger = screen.getByTestId("factories-sidebar-user-menu-trigger");
+    expect(trigger).toHaveTextContent("Ada Lovelace");
+    expect(trigger).toHaveTextContent("SuperPlane");
+    expect(within(trigger).queryByRole("button")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(screen.getByText("ada@example.com")).toBeInTheDocument();
+    expect(screen.getByTestId("factories-sidebar-back-to-apps")).toHaveTextContent("Back to Apps");
+    expect(screen.getByRole("menuitem", { name: "Profile" })).toBeInTheDocument();
+    expect(screen.getByTestId("factories-sidebar-appearance")).toHaveTextContent("Appearance");
+    expect(screen.getByRole("menuitem", { name: "Sign out" })).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/layout/SidebarUserMenu.stories.tsx
+++ b/web_src/src/pages/factories/layout/SidebarUserMenu.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: { layout: "padded" },
   decorators: [
     (Story) => (
-      <ComponentStoryShell className="w-[240px] border-r border-sidebar-border bg-sidebar">
+      <ComponentStoryShell className="flex min-h-[380px] w-[240px] flex-col justify-end border-r border-sidebar-border bg-sidebar">
         <Story />
       </ComponentStoryShell>
     ),
@@ -23,12 +23,21 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const defaultArgs = {
+  organizationId: FACTORIES_ORGANIZATION_ID,
+  userName: "Storybook User",
+  userEmail: "storybook@superplane.dev",
+  userAvatarUrl: null,
+  organizationName: "SuperPlane",
+};
+
 export const Default: Story = {
+  args: defaultArgs,
+};
+
+export const Open: Story = {
   args: {
-    organizationId: FACTORIES_ORGANIZATION_ID,
-    userName: "Storybook User",
-    userEmail: "storybook@superplane.dev",
-    userAvatarUrl: null,
-    organizationName: "SuperPlane",
+    ...defaultArgs,
+    defaultOpen: true,
   },
 };

--- a/web_src/src/pages/factories/layout/SidebarUserMenu.tsx
+++ b/web_src/src/pages/factories/layout/SidebarUserMenu.tsx
@@ -1,18 +1,22 @@
 import { Avatar } from "@/components/Avatar/avatar";
 import { useTheme } from "@/contexts/useTheme";
-import { cn } from "@/lib/utils";
-import { posthog } from "@/posthog";
+import { isThemePreference } from "@/lib/themePreference";
 import type { ThemePreference } from "@/lib/themePreference";
+import { posthog } from "@/posthog";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
-import { LogOut, Monitor, Moon, MoreHorizontal, Sun, User as UserIcon } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { LayoutGrid, LogOut, SunMoon, User as UserIcon } from "lucide-react";
 import { useNavigate } from "react-router";
 
 interface SidebarUserMenuProps {
@@ -21,13 +25,16 @@ interface SidebarUserMenuProps {
   userEmail?: string;
   userAvatarUrl?: string | null;
   organizationName: string;
+  defaultOpen?: boolean;
 }
 
-const THEME_OPTIONS: Array<{ value: ThemePreference; label: string; Icon: LucideIcon }> = [
-  { value: "light", label: "Light", Icon: Sun },
-  { value: "dark", label: "Dark", Icon: Moon },
-  { value: "system", label: "System", Icon: Monitor },
+const THEME_OPTIONS: Array<{ value: ThemePreference; label: string }> = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
 ];
+
+const MENU_ITEM_CLASS = "py-1 text-[13px] [&>svg]:size-3.5";
 
 function initialsFor(name: string): string {
   const parts = name
@@ -43,12 +50,17 @@ function initialsFor(name: string): string {
   return `${parts[0]}${parts[parts.length - 1]}`;
 }
 
+function labelForTheme(preference: ThemePreference): string {
+  return THEME_OPTIONS.find((option) => option.value === preference)?.label ?? "System";
+}
+
 export function SidebarUserMenu({
   organizationId,
   userName,
   userEmail,
   userAvatarUrl,
   organizationName,
+  defaultOpen = false,
 }: SidebarUserMenuProps) {
   const navigate = useNavigate();
   const homeHref = `/${organizationId}`;
@@ -60,53 +72,54 @@ export function SidebarUserMenu({
   };
 
   return (
-    <div
-      className="flex items-center gap-2 border-t border-sidebar-border px-2 py-3"
-      data-testid="factories-sidebar-user-menu"
-    >
-      <Avatar
-        src={userAvatarUrl ?? undefined}
-        initials={initialsFor(userName || "?")}
-        alt={userName}
-        className="size-7 text-[10px]"
-      />
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-[13px] tracking-[-0.01em] text-foreground">{userName}</p>
-        <p className="truncate text-[12px] text-muted-foreground">{organizationName}</p>
-      </div>
-      <DropdownMenu>
+    <div className="border-t border-sidebar-border p-2" data-testid="factories-sidebar-user-menu">
+      <DropdownMenu defaultOpen={defaultOpen}>
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            aria-label="Open user menu"
+            aria-label={`Open user menu for ${userName}`}
             data-testid="factories-sidebar-user-menu-trigger"
-            className="flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+            className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none data-[state=open]:bg-sidebar-accent"
           >
-            <MoreHorizontal className="size-3.5" aria-hidden />
+            <Avatar
+              src={userAvatarUrl ?? undefined}
+              initials={initialsFor(userName || "?")}
+              alt=""
+              className="size-7 text-[10px]"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-[13px] tracking-[-0.01em] text-foreground">{userName}</p>
+              <p className="truncate text-[12px] text-muted-foreground">{organizationName}</p>
+            </div>
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuItem onClick={() => navigate(homeHref)} data-testid="factories-sidebar-back-to-apps">
-            <UserIcon className="h-3.5 w-3.5" aria-hidden />
+        <DropdownMenuContent
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="w-(--radix-popper-anchor-width) min-w-56"
+        >
+          <div className="px-2 py-1.5">
+            <p className="truncate text-[13px] font-medium text-foreground">{userName}</p>
+            {userEmail ? <p className="truncate text-[11px] text-muted-foreground">{userEmail}</p> : null}
+          </div>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className={MENU_ITEM_CLASS}
+            onClick={() => navigate(homeHref)}
+            data-testid="factories-sidebar-back-to-apps"
+          >
+            <LayoutGrid aria-hidden />
             Back to Apps
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => navigate(profileHref)}>
-            <UserIcon className="h-3.5 w-3.5" aria-hidden />
+          <DropdownMenuItem className={MENU_ITEM_CLASS} onClick={() => navigate(profileHref)}>
+            <UserIcon aria-hidden />
             Profile
           </DropdownMenuItem>
-          {userEmail ? (
-            <>
-              <DropdownMenuSeparator />
-              <div className="px-2 py-1.5 text-[11px] text-muted-foreground" aria-hidden>
-                {userEmail}
-              </div>
-            </>
-          ) : null}
+          <AppearanceMenuItem />
           <DropdownMenuSeparator />
-          <ThemeMenuSection />
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={handleSignOut}>
-            <LogOut className="h-3.5 w-3.5" aria-hidden />
+          <DropdownMenuItem className={MENU_ITEM_CLASS} onClick={handleSignOut}>
+            <LogOut aria-hidden />
             Sign out
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -115,52 +128,39 @@ export function SidebarUserMenu({
   );
 }
 
-/**
- * Segmented theme picker (Light / Dark / System) rendered inline in the user
- * menu. Rendered outside the DropdownMenuItem primitive so clicking a theme
- * option doesn't dismiss the menu — that lets the user preview each mode
- * without reopening the menu each time.
- */
-function ThemeMenuSection() {
+function AppearanceMenuItem() {
   const { preference, setPreference } = useTheme();
 
   return (
-    <div
-      className="px-2 pt-1 pb-2"
-      onPointerDown={(event) => {
-        // Radix dismisses the menu on any pointerdown inside DropdownMenuContent
-        // that isn't handled by a menu primitive; blocking the event here keeps
-        // the menu open while the user cycles through themes.
-        event.stopPropagation();
-      }}
-      data-testid="factories-sidebar-theme-picker"
-    >
-      <DropdownMenuLabel className="px-0 pt-0 pb-1.5 text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
-        Theme
-      </DropdownMenuLabel>
-      <div role="radiogroup" aria-label="Theme" className="flex gap-1 rounded-md bg-muted p-1">
-        {THEME_OPTIONS.map(({ value, label, Icon }) => {
-          const isActive = preference === value;
-          return (
-            <button
-              key={value}
-              type="button"
-              role="radio"
-              aria-checked={isActive}
-              aria-label={label}
-              title={label}
-              onClick={() => setPreference(value)}
-              className={cn(
-                "flex flex-1 items-center justify-center rounded-sm px-2 py-1 transition-colors",
-                isActive ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
-              )}
-              data-testid={`factories-sidebar-theme-${value}`}
-            >
-              <Icon className="size-3.5" aria-hidden />
-            </button>
-          );
-        })}
-      </div>
-    </div>
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger className="py-1 text-[13px] [&_svg]:size-3.5" data-testid="factories-sidebar-appearance">
+        <SunMoon aria-hidden />
+        Appearance
+        <span className="ml-auto text-[11px] text-muted-foreground">{labelForTheme(preference)}</span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuPortal>
+        <DropdownMenuSubContent>
+          <DropdownMenuRadioGroup
+            value={preference}
+            onValueChange={(value) => {
+              if (isThemePreference(value)) {
+                setPreference(value);
+              }
+            }}
+          >
+            {THEME_OPTIONS.map(({ value, label }) => (
+              <DropdownMenuRadioItem
+                key={value}
+                value={value}
+                className="py-1 text-[13px]"
+                data-testid={`factories-sidebar-theme-${value}`}
+              >
+                {label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuSubContent>
+      </DropdownMenuPortal>
+    </DropdownMenuSub>
   );
 }

--- a/web_src/src/pages/factories/layout/SidebarUserMenu.tsx
+++ b/web_src/src/pages/factories/layout/SidebarUserMenu.tsx
@@ -77,7 +77,6 @@ export function SidebarUserMenu({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            aria-label={`Open user menu for ${userName}`}
             data-testid="factories-sidebar-user-menu-trigger"
             className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none data-[state=open]:bg-sidebar-accent"
           >
@@ -133,7 +132,10 @@ function AppearanceMenuItem() {
 
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger className="py-1 text-[13px] [&_svg]:size-3.5" data-testid="factories-sidebar-appearance">
+      <DropdownMenuSubTrigger
+        className="py-1 text-[13px] [&_svg]:size-3.5 [&>svg:last-child]:ml-0"
+        data-testid="factories-sidebar-appearance"
+      >
         <SunMoon aria-hidden />
         Appearance
         <span className="ml-auto text-[11px] text-muted-foreground">{labelForTheme(preference)}</span>


### PR DESCRIPTION
## Summary

The factory sidebar profile used a three-dot button to open the account menu.
That control was easy to miss.
This change makes the whole profile row the menu trigger.
The menu shows the name and email first, then the actions.
Appearance uses a submenu instead of a segmented control.

## Test plan

- [ ] Open a factory workspace.
- [ ] Click the profile row at the bottom of the left sidebar.
- [ ] Confirm the menu opens and the three-dot icon is absent.
- [ ] Open Appearance and select Light, Dark, and System.
- [ ] Open Storybook story Factories/Layout/SidebarUserMenu Open.


Made with [Cursor](https://cursor.com)