### PR TITLE
feat: Show line metrics on the Lines list

### DIFF
--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -109,8 +109,10 @@ export const REFUND_FACTORY_APPS: FactoryApp[] = [
   },
 ];
 
-const REFUND_LINE_PLAN_ID = "line-plan-and-implement";
-const REFUND_LINE_HOTFIX_ID = "line-hotfix";
+export const REFUND_LINE_PLAN_ID = "line-plan-and-implement";
+export const REFUND_LINE_HOTFIX_ID = "line-hotfix";
+export const REFUND_LINE_ONBOARDING_ID = "line-onboarding";
+export const REFUND_LINE_FEATURE_ID = "line-feature-delivery";
 
 export const REFUND_FACTORY_LINES: FactoriesFactoryLine[] = [
   {
@@ -507,6 +509,153 @@ export const emptyWorkOrdersFactoriesFixture: FactoriesFixture = {
   workOrdersByFactoryId: {
     [PRIMARY_FACTORY_ID]: [CLOSED_WORK_ORDER],
     [EMPTY_FACTORY_ID]: [],
+  },
+};
+
+const ONBOARDING_FACTORY_LINE: FactoriesFactoryLine = {
+  id: REFUND_LINE_ONBOARDING_ID,
+  name: "onboarding",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+  steps: [
+    runAppStep("plan", "app-refund-planner", "start-plan"),
+    runAppStep("implement", "app-refund-implementer", "start-implementation"),
+  ],
+};
+
+const FEATURE_PLAN_STEP = "Create Implementation Plan";
+const FEATURE_IMPLEMENT_STEP = "Implement";
+const FEATURE_PR_STEP = "Open Pull Request";
+const FEATURE_CI_STEP = "Ci Loop";
+
+const FEATURE_DELIVERY_LINE: FactoriesFactoryLine = {
+  id: REFUND_LINE_FEATURE_ID,
+  name: "feature-delivery",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+  steps: [
+    runAppStep(FEATURE_PLAN_STEP, "app-refund-planner", "start-plan"),
+    runAppStep(FEATURE_IMPLEMENT_STEP, "app-refund-implementer", "start-implementation"),
+    runAppStep(FEATURE_PR_STEP, "app-refund-implementer", "start-pull-request"),
+    runAppStep(FEATURE_CI_STEP, "app-refund-verifier", "start-ci-loop"),
+  ],
+};
+
+function featureLineExecution(
+  step: string,
+  overrides: Partial<FactoriesWorkOrderExecution> = {},
+): FactoriesWorkOrderExecution {
+  return {
+    id: `exec-feature-${overrides.id ?? step}`,
+    line: { id: REFUND_LINE_FEATURE_ID, name: "feature-delivery" },
+    step,
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    createdAt: TWO_HOURS_AGO,
+    updatedAt: HOUR_AGO,
+    run: {
+      id: `run-feature-${step}`,
+      appId: "app-refund-implementer",
+      appName: "Refund Implementer",
+    },
+    ...overrides,
+  };
+}
+
+const FEATURE_RUNNING_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-implement",
+  number: "201",
+  key: "RF-201",
+  title: "Ship ledger retry window",
+  description: "Implement the retry window from the plan and open a pull request.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-1" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, {
+      id: "impl-1",
+      state: "STATE_STARTED",
+      result: "RESULT_UNKNOWN",
+      run: { id: LINE_RUN_IMPLEMENT_ID, appId: "app-refund-implementer", appName: "Refund Implementer" },
+    }),
+  ],
+};
+
+const FEATURE_PR_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-pr",
+  number: "202",
+  key: "RF-202",
+  title: "Open refund schema pull request",
+  description: "Plan and implementation passed. Pull request is waiting for review.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: REVIEWER_USER.id, name: REVIEWER_USER.name } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-2" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, { id: "impl-2" }),
+    featureLineExecution(FEATURE_PR_STEP, {
+      id: "pr-2",
+      state: "STATE_PENDING",
+      result: "RESULT_UNKNOWN",
+    }),
+  ],
+};
+
+const FEATURE_CI_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-ci",
+  number: "203",
+  key: "RF-203",
+  title: "Run CI on refund enum pull request",
+  description: "Pull request is open. CI loop is running.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: OPERATOR_USER.id, name: OPERATOR_USER.name } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-3" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, { id: "impl-3" }),
+    featureLineExecution(FEATURE_PR_STEP, { id: "pr-3" }),
+    featureLineExecution(FEATURE_CI_STEP, {
+      id: "ci-3",
+      state: "STATE_STARTED",
+      result: "RESULT_UNKNOWN",
+      run: { id: LINE_RUN_VERIFY_PASSED_ID, appId: "app-refund-verifier", appName: "Refund Verifier" },
+    }),
+  ],
+};
+
+/**
+ * Extra lines for the populated Lines list: unused onboarding plus a
+ * four-phase feature line.
+ */
+export const lineMetricsFactoriesFixture: FactoriesFixture = {
+  ...defaultFactoriesFixture,
+  factories: defaultFactoriesFixture.factories.map((factory) => {
+    if (factory.id !== PRIMARY_FACTORY_ID) {
+      return factory;
+    }
+    return {
+      ...factory,
+      lines: [...(factory.lines ?? []), ONBOARDING_FACTORY_LINE, FEATURE_DELIVERY_LINE],
+    };
+  }),
+  workOrdersByFactoryId: {
+    ...defaultFactoriesFixture.workOrdersByFactoryId,
+    [PRIMARY_FACTORY_ID]: [
+      ...(defaultFactoriesFixture.workOrdersByFactoryId[PRIMARY_FACTORY_ID] ?? []),
+      FEATURE_RUNNING_WORK_ORDER,
+      FEATURE_PR_WORK_ORDER,
+      FEATURE_CI_WORK_ORDER,
+    ],
   },
 };
 

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -102,8 +102,10 @@ export const REFUND_FACTORY_APPS: FactoryApp[] = [
   },
 ];
 
-const REFUND_LINE_PLAN_ID = "line-plan-and-implement";
-const REFUND_LINE_HOTFIX_ID = "line-hotfix";
+export const REFUND_LINE_PLAN_ID = "line-plan-and-implement";
+export const REFUND_LINE_HOTFIX_ID = "line-hotfix";
+export const REFUND_LINE_ONBOARDING_ID = "line-onboarding";
+export const REFUND_LINE_FEATURE_ID = "line-feature-delivery";
 
 export const REFUND_FACTORY_LINES: FactoriesFactoryLine[] = [
   {
@@ -393,6 +395,153 @@ export const emptyWorkOrdersFactoriesFixture: FactoriesFixture = {
   workOrdersByFactoryId: {
     [PRIMARY_FACTORY_ID]: [CLOSED_WORK_ORDER],
     [EMPTY_FACTORY_ID]: [],
+  },
+};
+
+const ONBOARDING_FACTORY_LINE: FactoriesFactoryLine = {
+  id: REFUND_LINE_ONBOARDING_ID,
+  name: "onboarding",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+  steps: [
+    runAppStep("plan", "app-refund-planner", "start-plan"),
+    runAppStep("implement", "app-refund-implementer", "start-implementation"),
+  ],
+};
+
+const FEATURE_PLAN_STEP = "Create Implementation Plan";
+const FEATURE_IMPLEMENT_STEP = "Implement";
+const FEATURE_PR_STEP = "Open Pull Request";
+const FEATURE_CI_STEP = "Ci Loop";
+
+const FEATURE_DELIVERY_LINE: FactoriesFactoryLine = {
+  id: REFUND_LINE_FEATURE_ID,
+  name: "feature-delivery",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+  steps: [
+    runAppStep(FEATURE_PLAN_STEP, "app-refund-planner", "start-plan"),
+    runAppStep(FEATURE_IMPLEMENT_STEP, "app-refund-implementer", "start-implementation"),
+    runAppStep(FEATURE_PR_STEP, "app-refund-implementer", "start-pull-request"),
+    runAppStep(FEATURE_CI_STEP, "app-refund-verifier", "start-ci-loop"),
+  ],
+};
+
+function featureLineExecution(
+  step: string,
+  overrides: Partial<FactoriesWorkOrderExecution> = {},
+): FactoriesWorkOrderExecution {
+  return {
+    id: `exec-feature-${overrides.id ?? step}`,
+    line: { id: REFUND_LINE_FEATURE_ID, name: "feature-delivery" },
+    step,
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    createdAt: TWO_HOURS_AGO,
+    updatedAt: HOUR_AGO,
+    run: {
+      id: `run-feature-${step}`,
+      appId: "app-refund-implementer",
+      appName: "Refund Implementer",
+    },
+    ...overrides,
+  };
+}
+
+const FEATURE_RUNNING_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-implement",
+  number: "201",
+  key: "RF-201",
+  title: "Ship ledger retry window",
+  description: "Implement the retry window from the plan and open a pull request.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-1" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, {
+      id: "impl-1",
+      state: "STATE_STARTED",
+      result: "RESULT_UNKNOWN",
+      run: { id: LINE_RUN_IMPLEMENT_ID, appId: "app-refund-implementer", appName: "Refund Implementer" },
+    }),
+  ],
+};
+
+const FEATURE_PR_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-pr",
+  number: "202",
+  key: "RF-202",
+  title: "Open refund schema pull request",
+  description: "Plan and implementation passed. Pull request is waiting for review.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: REVIEWER_USER.id, name: REVIEWER_USER.name } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-2" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, { id: "impl-2" }),
+    featureLineExecution(FEATURE_PR_STEP, {
+      id: "pr-2",
+      state: "STATE_PENDING",
+      result: "RESULT_UNKNOWN",
+    }),
+  ],
+};
+
+const FEATURE_CI_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-ci",
+  number: "203",
+  key: "RF-203",
+  title: "Run CI on refund enum pull request",
+  description: "Pull request is open. CI loop is running.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: OPERATOR_USER.id, name: OPERATOR_USER.name } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-3" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, { id: "impl-3" }),
+    featureLineExecution(FEATURE_PR_STEP, { id: "pr-3" }),
+    featureLineExecution(FEATURE_CI_STEP, {
+      id: "ci-3",
+      state: "STATE_STARTED",
+      result: "RESULT_UNKNOWN",
+      run: { id: LINE_RUN_VERIFY_PASSED_ID, appId: "app-refund-verifier", appName: "Refund Verifier" },
+    }),
+  ],
+};
+
+/**
+ * Extra lines for the populated Lines list: unused onboarding plus a
+ * four-phase feature line.
+ */
+export const lineMetricsFactoriesFixture: FactoriesFixture = {
+  ...defaultFactoriesFixture,
+  factories: defaultFactoriesFixture.factories.map((factory) => {
+    if (factory.id !== PRIMARY_FACTORY_ID) {
+      return factory;
+    }
+    return {
+      ...factory,
+      lines: [...(factory.lines ?? []), ONBOARDING_FACTORY_LINE, FEATURE_DELIVERY_LINE],
+    };
+  }),
+  workOrdersByFactoryId: {
+    ...defaultFactoriesFixture.workOrdersByFactoryId,
+    [PRIMARY_FACTORY_ID]: [
+      ...(defaultFactoriesFixture.workOrdersByFactoryId[PRIMARY_FACTORY_ID] ?? []),
+      FEATURE_RUNNING_WORK_ORDER,
+      FEATURE_PR_WORK_ORDER,
+      FEATURE_CI_WORK_ORDER,
+    ],
   },
 };
 

--- a/web_src/src/pages/factories/pages/LineListCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineListCard.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { REFUND_FACTORY_LINES, REFUND_LINE_PLAN_ID } from "../__fixtures__/factoryPageResponses";
+import { LINE_LIST_DESCRIPTION_BY_ID, LINE_LIST_METRICS_BY_ID } from "./lineListMetricsMockData";
+import { LineListCard, LineListHeroSplit } from "./LineListCard";
+
+const planLine = REFUND_FACTORY_LINES[0];
+const planMetrics = LINE_LIST_METRICS_BY_ID[REFUND_LINE_PLAN_ID] ?? null;
+const planDescription = LINE_LIST_DESCRIPTION_BY_ID[REFUND_LINE_PLAN_ID];
+
+describe("LineListCard", () => {
+  it("shows a purpose description and no phase names", () => {
+    render(
+      <MemoryRouter>
+        <LineListCard line={planLine} href="/lines/x" metrics={planMetrics} description={planDescription} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(planDescription)).toBeInTheDocument();
+    expect(screen.queryByText("Plan → Implement → Verify")).not.toBeInTheDocument();
+  });
+
+  it("splits success sparkline and completion bars", () => {
+    render(<LineListHeroSplit metrics={planMetrics} />);
+
+    const split = screen.getByTestId("lines-card-metrics");
+    expect(split).toHaveTextContent("82%");
+    expect(split).toHaveTextContent("+6 pts");
+    expect(split).toHaveTextContent("1.4 per day");
+    expect(split).toHaveTextContent("Success rate");
+    expect(split).toHaveTextContent("Completions");
+    expect(split).toHaveTextContent("1.4x");
+    expect(split).toHaveTextContent("$3.20");
+  });
+
+  it("shows dashes when the line has no merged work orders", () => {
+    render(<LineListHeroSplit metrics={null} />);
+
+    expect(screen.getByTestId("lines-card-metrics")).toHaveTextContent("—");
+  });
+});

--- a/web_src/src/pages/factories/pages/LineListCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineListCard.spec.tsx
@@ -31,7 +31,9 @@ describe("LineListCard", () => {
     expect(split).toHaveTextContent("1.4 per day");
     expect(split).toHaveTextContent("Success rate");
     expect(split).toHaveTextContent("Completions");
-    expect(split).toHaveTextContent("1.4x");
+    expect(split).toHaveTextContent("Duration");
+    expect(split).toHaveTextContent("15m");
+    expect(split).toHaveTextContent("−2m");
     expect(split).toHaveTextContent("$3.20");
   });
 

--- a/web_src/src/pages/factories/pages/LineListCard.tsx
+++ b/web_src/src/pages/factories/pages/LineListCard.tsx
@@ -8,8 +8,8 @@ import { factoryCardClassName } from "./factoryPageLayoutStyles";
 import {
   formatCostDelta,
   formatCostPerSuccess,
-  formatReworkDelta,
-  formatReworkRate,
+  formatDuration,
+  formatDurationDelta,
   formatSuccessDelta,
   formatSuccessRate,
   formatThroughput,
@@ -67,7 +67,7 @@ export function LineListHeroSplit({ metrics }: { metrics: LineListMetrics | null
         </div>
       </div>
       <div className="flex shrink-0 flex-col gap-3 border-l border-border pl-5">
-        <MiniStat label="Rework" value={formatReworkRate(metrics)} hint={formatReworkDelta(metrics)} />
+        <MiniStat label="Duration" value={formatDuration(metrics)} hint={formatDurationDelta(metrics)} />
         <MiniStat label="Cost" value={formatCostPerSuccess(metrics)} hint={formatCostDelta(metrics)} />
       </div>
     </div>

--- a/web_src/src/pages/factories/pages/LineListCard.tsx
+++ b/web_src/src/pages/factories/pages/LineListCard.tsx
@@ -1,0 +1,179 @@
+import type { FactoriesFactoryLine } from "@/api-client";
+import { cn } from "@/lib/utils";
+import { Workflow } from "lucide-react";
+import type { KeyboardEvent, ReactNode } from "react";
+import { useNavigate } from "react-router";
+import { humanizeLineName } from "../lib/humanizeLineName";
+import { factoryCardClassName } from "./factoryPageLayoutStyles";
+import {
+  formatCostDelta,
+  formatCostPerSuccess,
+  formatReworkDelta,
+  formatReworkRate,
+  formatSuccessDelta,
+  formatSuccessRate,
+  formatThroughput,
+} from "./lineListMetricsFormat";
+import type { LineListMetrics } from "./lineListMetricsMockData";
+
+export function LineListCard({
+  line,
+  href,
+  metrics,
+  description,
+}: {
+  line: FactoriesFactoryLine;
+  href: string;
+  metrics: LineListMetrics | null;
+  description?: string;
+}) {
+  return (
+    <CardShell href={href} testId={`lines-card-${line.id}`} className="px-4 py-4">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <Workflow className="size-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+          <span className="text-[15px] font-medium tracking-[-0.01em] text-foreground">
+            {humanizeLineName(line.name)}
+          </span>
+        </div>
+        {description ? <p className="mt-1 text-[12px] leading-snug text-muted-foreground">{description}</p> : null}
+      </div>
+      <LineListHeroSplit metrics={metrics} />
+    </CardShell>
+  );
+}
+
+/** Success sparkline on the left. Completion bars on the right. */
+export function LineListHeroSplit({ metrics }: { metrics: LineListMetrics | null }) {
+  return (
+    <div className="mt-4 flex items-end justify-between gap-6" data-testid="lines-card-metrics">
+      <div className="grid min-w-0 flex-1 grid-cols-2 gap-6">
+        <div className="min-w-0">
+          <p className="text-[11px] text-muted-foreground">Success rate</p>
+          <div className="mt-1 flex items-end gap-3">
+            <p className="text-[28px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+              {formatSuccessRate(metrics)}
+            </p>
+            <p className="pb-0.5 text-[12px] tabular-nums text-muted-foreground">{formatSuccessDelta(metrics)}</p>
+          </div>
+          <Sparkline values={metrics?.successTrendPct} className="mt-3 h-10 w-full text-foreground" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[11px] text-muted-foreground">Completions</p>
+          <p className="mt-1 text-[28px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+            {formatThroughput(metrics)}
+          </p>
+          <ThroughputBars values={metrics?.throughputTrend} className="mt-3 h-10 w-full text-muted-foreground" />
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-col gap-3 border-l border-border pl-5">
+        <MiniStat label="Rework" value={formatReworkRate(metrics)} hint={formatReworkDelta(metrics)} />
+        <MiniStat label="Cost" value={formatCostPerSuccess(metrics)} hint={formatCostDelta(metrics)} />
+      </div>
+    </div>
+  );
+}
+
+function MiniStat({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+      <p className="mt-0.5 text-[15px] font-medium tracking-[-0.02em] tabular-nums text-foreground">{value}</p>
+      <p className="text-[11px] tabular-nums text-muted-foreground">{hint}</p>
+    </div>
+  );
+}
+
+function Sparkline({ values, className }: { values: number[] | undefined; className?: string }) {
+  if (!values || values.length < 2) {
+    return <span className={cn("block", className)} aria-hidden />;
+  }
+
+  const width = 120;
+  const height = 32;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const points = values
+    .map((value, index) => {
+      const x = (index / (values.length - 1)) * width;
+      const y = height - ((value - min) / range) * (height - 2) - 1;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className={className} aria-hidden preserveAspectRatio="none">
+      <polyline fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" points={points} />
+    </svg>
+  );
+}
+
+function ThroughputBars({ values, className }: { values: number[] | undefined; className?: string }) {
+  if (!values || values.length === 0) {
+    return <span className={cn("block", className)} aria-hidden />;
+  }
+
+  const width = 120;
+  const height = 32;
+  const max = Math.max(...values, 1);
+  const gap = 1.2;
+  const barWidth = Math.max(2, width / values.length - gap);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className={className} aria-hidden preserveAspectRatio="none">
+      {values.map((value, index) => {
+        const barHeight = (value / max) * (height - 2);
+        const x = (index / values.length) * width;
+        return (
+          <rect
+            key={index}
+            x={x}
+            y={height - barHeight}
+            width={barWidth}
+            height={barHeight}
+            className="fill-current"
+            opacity={0.45}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function CardShell({
+  href,
+  testId,
+  className,
+  children,
+}: {
+  href: string;
+  testId: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={cn(
+        factoryCardClassName,
+        "group/line w-full cursor-pointer text-left transition-colors",
+        "hover:border-foreground/25 hover:bg-accent/30",
+        className,
+      )}
+      onClick={() => navigate(href)}
+      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          navigate(href);
+        }
+      }}
+      data-testid={testId}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/Lines.stories.tsx
+++ b/web_src/src/pages/factories/pages/Lines.stories.tsx
@@ -2,16 +2,16 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
-  defaultFactoriesFixture,
   emptyFactoriesFixture,
   fiveStepLineFactoriesFixture,
+  lineMetricsFactoriesFixture,
   PRIMARY_FACTORY_KEY,
   REFUND_FACTORY_LINES,
 } from "../__fixtures__/factoryPageResponses";
 import { LinesPage } from "./LinesPage";
 
 /**
- * Lines page: card list → line detail with phase board.
+ * Lines page: metric cards on the list, phase board on line detail.
  * FactoriesHarness supplies a factory-owned canvas so a run-card click opens
  * the automation run instead of Overview.
  */
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof meta>;
 const linesListPath = `workspaces/${PRIMARY_FACTORY_KEY}/lines`;
 
 export const Populated: Story = {
-  render: () => <FactoriesHarness pathSuffix={linesListPath} factoriesFixture={defaultFactoriesFixture} />,
+  render: () => <FactoriesHarness pathSuffix={linesListPath} factoriesFixture={lineMetricsFactoriesFixture} />,
 };
 
 export const EmptyFactory: Story = {
@@ -43,7 +43,7 @@ export const LineDetail: Story = {
     return (
       <FactoriesHarness
         pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}`}
-        factoriesFixture={defaultFactoriesFixture}
+        factoriesFixture={lineMetricsFactoriesFixture}
       />
     );
   },

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -50,7 +50,7 @@ import { LineListCard } from "./LineListCard";
 import { descriptionForLine, metricsForLine } from "./lineListMetricsMockData";
 import { PhaseGlyph } from "./linePhaseGlyph";
 
-const LIST_SUBTITLE = "Last 30 days. Success rate, completions per day, rework, and cost per merged work order.";
+const LIST_SUBTITLE = "Last 30 days. Success rate, completions per day, duration, and cost per merged work order.";
 
 export function LinesPage() {
   const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -1,4 +1,4 @@
-import type { FactoriesFactoryLine, FactoriesWorkOrder, FactoryLineStep } from "@/api-client";
+import type { FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
@@ -8,7 +8,7 @@ import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { Layers, MoreHorizontal, Pencil, Plus, Workflow } from "lucide-react";
+import { Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
@@ -20,7 +20,6 @@ import {
   resolveColumnGlyph,
   type LinePhaseColumn,
   type LinePhaseRunCard,
-  type LinePhaseTick,
   type PhaseGlyphKind,
 } from "../lib/linePhaseRuns";
 import { buildWorkOrderListEntry } from "../lib/workOrderListModel";
@@ -46,7 +45,11 @@ import {
   factorySectionHeaderClassName,
   factoryWorkOrdersBodyClassName,
 } from "./factoryPageLayoutStyles";
+import { LineListCard } from "./LineListCard";
+import { descriptionForLine, metricsForLine } from "./lineListMetricsMockData";
 import { PhaseGlyph } from "./linePhaseGlyph";
+
+const LIST_SUBTITLE = "Last 30 days. Success rate, completions per day, rework, and cost per merged work order.";
 
 export function LinesPage() {
   const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
@@ -106,7 +109,7 @@ export function LinesPage() {
       <WorkspacePageHeader
         className={factorySectionHeaderClassName}
         title="Lines"
-        subtitle="Factory lines specialize how work moves through the workspace. Each phase is backed by a canvas that runs work orders."
+        subtitle={LIST_SUBTITLE}
         actions={
           <PermissionTooltip
             allowed={canUpdate || permissionsLoading}
@@ -130,18 +133,18 @@ export function LinesPage() {
             canUpdate={canUpdate || permissionsLoading}
           />
         ) : (
-          <ul className="flex flex-col gap-2" data-testid="lines-list">
+          <ul className="flex flex-col gap-4" data-testid="lines-list">
             {lines.map((line) => {
               if (!line.id) {
                 return null;
               }
-              const board = buildLinePhaseBoard(line, workOrders);
               return (
                 <li key={line.id}>
-                  <LineCard
+                  <LineListCard
                     line={line}
                     href={factoryLineDetailPath(organizationId, factoryKey, line.id)}
-                    ticks={board.map((column) => column.tick)}
+                    metrics={metricsForLine(line.id)}
+                    description={descriptionForLine(line.id)}
                   />
                 </li>
               );
@@ -218,67 +221,6 @@ function LineDetail({
         />
       )}
     </div>
-  );
-}
-
-function LineCard({ line, href, ticks }: { line: FactoriesFactoryLine; href: string; ticks: LinePhaseTick[] }) {
-  const navigate = useNavigate();
-  const steps = line.steps ?? [];
-  const description = formatLinePhaseDescription(steps);
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      className={cn(
-        "group/line w-full cursor-pointer rounded-lg border border-border bg-background px-3.5 py-3 text-left transition-colors",
-        "hover:border-foreground/25 hover:bg-accent/40",
-      )}
-      onClick={() => navigate(href)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          navigate(href);
-        }
-      }}
-      data-testid={`lines-card-${line.id}`}
-    >
-      <div className="flex items-start gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <Workflow className="size-3.5 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
-            <span className="text-[13px] font-medium tracking-[-0.01em] text-foreground">
-              {humanizeLineName(line.name)}
-            </span>
-          </div>
-          {description ? <p className="mt-1 text-[12px] leading-snug text-muted-foreground">{description}</p> : null}
-        </div>
-      </div>
-      {steps.length > 0 ? <PhaseStrip steps={steps} ticks={ticks} /> : null}
-    </div>
-  );
-}
-
-function PhaseStrip({ steps, ticks }: { steps: FactoryLineStep[]; ticks: LinePhaseTick[] }) {
-  return (
-    <ol className="mt-3.5 flex w-full items-start" aria-label="Phases">
-      {steps.map((step, index) => (
-        <li key={`${step.name}-${index}`} className="relative flex min-w-0 flex-1 flex-col items-center text-center">
-          {index < steps.length - 1 ? (
-            <span
-              className="absolute top-[7px] left-[calc(50%+8px)] right-[calc(-50%+8px)] h-px bg-border"
-              aria-hidden
-            />
-          ) : null}
-          <span className="relative z-[1] flex h-3.5 items-center justify-center">
-            <PhaseTickDot tick={ticks[index] ?? null} />
-          </span>
-          <span className="mt-1.5 max-w-full truncate px-1 text-[12px] leading-tight text-muted-foreground">
-            {step.name || `Phase ${index + 1}`}
-          </span>
-        </li>
-      ))}
-    </ol>
   );
 }
 
@@ -445,21 +387,6 @@ function PhaseRunCard({
     stepAppId,
   );
   return <WorkOrderCard {...workOrderCardContext} entry={entry} href={href} />;
-}
-
-function PhaseTickDot({ tick }: { tick: LinePhaseTick }) {
-  return (
-    <span
-      className={cn(
-        "size-2 shrink-0 rounded-full bg-[#c4c4c4]",
-        tick === "running" && "bg-[#3b82f6] animate-pulse",
-        tick === "waiting" && "bg-[#f59e0b]",
-        tick === "failed" && "bg-[#ef4444]",
-        tick === "queued" && "bg-[#a3a3a3]",
-      )}
-      aria-hidden
-    />
-  );
 }
 
 function EmptyLinesState({

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -1,4 +1,4 @@
-import type { FactoriesFactoryLine, FactoriesWorkOrder, FactoryLineStep } from "@/api-client";
+import type { FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
@@ -9,7 +9,7 @@ import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { Layers, MoreHorizontal, Pencil, Plus, Workflow } from "lucide-react";
+import { Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
@@ -21,7 +21,6 @@ import {
   resolveColumnGlyph,
   type LinePhaseColumn,
   type LinePhaseRunCard,
-  type LinePhaseTick,
   type PhaseGlyphKind,
 } from "../lib/linePhaseRuns";
 import { buildWorkOrderListEntry } from "../lib/workOrderListModel";
@@ -47,7 +46,11 @@ import {
   factorySectionHeaderClassName,
   factoryWorkOrdersBodyClassName,
 } from "./factoryPageLayoutStyles";
+import { LineListCard } from "./LineListCard";
+import { descriptionForLine, metricsForLine } from "./lineListMetricsMockData";
 import { PhaseGlyph } from "./linePhaseGlyph";
+
+const LIST_SUBTITLE = "Last 30 days. Success rate, completions per day, rework, and cost per merged work order.";
 
 export function LinesPage() {
   const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
@@ -113,7 +116,7 @@ export function LinesPage() {
       <WorkspacePageHeader
         className={factorySectionHeaderClassName}
         title="Lines"
-        subtitle="Factory lines specialize how work moves through the workspace. Each phase is backed by a canvas that runs work orders."
+        subtitle={LIST_SUBTITLE}
         actions={
           <PermissionTooltip
             allowed={canUpdate || permissionsLoading}
@@ -137,18 +140,18 @@ export function LinesPage() {
             canUpdate={canUpdate || permissionsLoading}
           />
         ) : (
-          <ul className="flex flex-col gap-2" data-testid="lines-list">
+          <ul className="flex flex-col gap-4" data-testid="lines-list">
             {lines.map((line) => {
               if (!line.id) {
                 return null;
               }
-              const board = buildLinePhaseBoard(line, workOrders);
               return (
                 <li key={line.id}>
-                  <LineCard
+                  <LineListCard
                     line={line}
                     href={factoryLineDetailPath(organizationId, factoryKey, line.id)}
-                    ticks={board.map((column) => column.tick)}
+                    metrics={metricsForLine(line.id)}
+                    description={descriptionForLine(line.id)}
                   />
                 </li>
               );
@@ -225,67 +228,6 @@ function LineDetail({
         />
       )}
     </div>
-  );
-}
-
-function LineCard({ line, href, ticks }: { line: FactoriesFactoryLine; href: string; ticks: LinePhaseTick[] }) {
-  const navigate = useNavigate();
-  const steps = line.steps ?? [];
-  const description = formatLinePhaseDescription(steps);
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      className={cn(
-        "group/line w-full cursor-pointer rounded-lg border border-border bg-background px-3.5 py-3 text-left transition-colors",
-        "hover:border-foreground/25 hover:bg-accent/40",
-      )}
-      onClick={() => navigate(href)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          navigate(href);
-        }
-      }}
-      data-testid={`lines-card-${line.id}`}
-    >
-      <div className="flex items-start gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <Workflow className="size-3.5 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
-            <span className="text-[13px] font-medium tracking-[-0.01em] text-foreground">
-              {humanizeLineName(line.name)}
-            </span>
-          </div>
-          {description ? <p className="mt-1 text-[12px] leading-snug text-muted-foreground">{description}</p> : null}
-        </div>
-      </div>
-      {steps.length > 0 ? <PhaseStrip steps={steps} ticks={ticks} /> : null}
-    </div>
-  );
-}
-
-function PhaseStrip({ steps, ticks }: { steps: FactoryLineStep[]; ticks: LinePhaseTick[] }) {
-  return (
-    <ol className="mt-3.5 flex w-full items-start" aria-label="Phases">
-      {steps.map((step, index) => (
-        <li key={`${step.name}-${index}`} className="relative flex min-w-0 flex-1 flex-col items-center text-center">
-          {index < steps.length - 1 ? (
-            <span
-              className="absolute top-[7px] left-[calc(50%+8px)] right-[calc(-50%+8px)] h-px bg-border"
-              aria-hidden
-            />
-          ) : null}
-          <span className="relative z-[1] flex h-3.5 items-center justify-center">
-            <PhaseTickDot tick={ticks[index] ?? null} />
-          </span>
-          <span className="mt-1.5 max-w-full truncate px-1 text-[12px] leading-tight text-muted-foreground">
-            {step.name || `Phase ${index + 1}`}
-          </span>
-        </li>
-      ))}
-    </ol>
   );
 }
 
@@ -452,21 +394,6 @@ function PhaseRunCard({
     stepAppId,
   );
   return <WorkOrderCard {...workOrderCardContext} entry={entry} href={href} />;
-}
-
-function PhaseTickDot({ tick }: { tick: LinePhaseTick }) {
-  return (
-    <span
-      className={cn(
-        "size-2 shrink-0 rounded-full bg-[#c4c4c4]",
-        tick === "running" && "bg-[#3b82f6] animate-pulse",
-        tick === "waiting" && "bg-[#f59e0b]",
-        tick === "failed" && "bg-[#ef4444]",
-        tick === "queued" && "bg-[#a3a3a3]",
-      )}
-      aria-hidden
-    />
-  );
 }
 
 function EmptyLinesState({

--- a/web_src/src/pages/factories/pages/lineListMetricsFormat.spec.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsFormat.spec.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   formatCostDelta,
   formatCostPerSuccess,
-  formatReworkDelta,
-  formatReworkRate,
+  formatDuration,
+  formatDurationDelta,
   formatSuccessDelta,
   formatSuccessRate,
   formatThroughput,
@@ -16,39 +16,39 @@ const sample: LineListMetrics = {
   successRatePct: 82,
   mergedCount: 41,
   totalClosedCount: 50,
-  reworkPerWorkOrder: 1.4,
+  durationMinutes: 15,
   costPerSuccessUsd: 3.2,
   successTrendPct: [70, 82],
   successDeltaPts: 6,
-  reworkDelta: -0.2,
+  durationDeltaMinutes: -2,
   costDeltaUsd: -0.4,
   throughputPerDay: 1.4,
   throughputTrend: [2, 3, 4],
 };
 
 describe("lineListMetricsFormat", () => {
-  it("formats success rate, rework, cost, and completions", () => {
+  it("formats success rate, duration, cost, and completions", () => {
     expect(formatSuccessRate(sample)).toBe("82%");
-    expect(formatReworkRate(sample)).toBe("1.4x");
+    expect(formatDuration(sample)).toBe("15m");
     expect(formatCostPerSuccess(sample)).toBe("$3.20");
     expect(formatThroughput(sample)).toBe("1.4 per day");
   });
 
   it("formats change vs the prior window", () => {
     expect(formatSuccessDelta(sample)).toBe("+6 pts");
-    expect(formatReworkDelta(sample)).toBe("−0.2x");
+    expect(formatDurationDelta(sample)).toBe("−2m");
     expect(formatCostDelta(sample)).toBe("−$0.40");
   });
 
   it("uses an em dash when the line has no closed work orders", () => {
     expect(formatSuccessRate(null)).toBe(LINE_LIST_METRICS_EMPTY);
-    expect(formatReworkRate(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatDuration(null)).toBe(LINE_LIST_METRICS_EMPTY);
     expect(formatCostPerSuccess(null)).toBe(LINE_LIST_METRICS_EMPTY);
     expect(formatThroughput(null)).toBe(LINE_LIST_METRICS_EMPTY);
     expect(formatSuccessDelta(null)).toBe(LINE_LIST_METRICS_EMPTY);
   });
 
-  it("drops the decimal on whole rework counts", () => {
-    expect(formatReworkRate({ ...sample, reworkPerWorkOrder: 2 })).toBe("2x");
+  it("formats 60 minutes or more as hours", () => {
+    expect(formatDuration({ ...sample, durationMinutes: 90 })).toBe("1.5h");
   });
 });

--- a/web_src/src/pages/factories/pages/lineListMetricsFormat.spec.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsFormat.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatCostDelta,
+  formatCostPerSuccess,
+  formatReworkDelta,
+  formatReworkRate,
+  formatSuccessDelta,
+  formatSuccessRate,
+  formatThroughput,
+  LINE_LIST_METRICS_EMPTY,
+} from "./lineListMetricsFormat";
+import type { LineListMetrics } from "./lineListMetricsMockData";
+
+const sample: LineListMetrics = {
+  successRatePct: 82,
+  mergedCount: 41,
+  totalClosedCount: 50,
+  reworkPerWorkOrder: 1.4,
+  costPerSuccessUsd: 3.2,
+  successTrendPct: [70, 82],
+  successDeltaPts: 6,
+  reworkDelta: -0.2,
+  costDeltaUsd: -0.4,
+  throughputPerDay: 1.4,
+  throughputTrend: [2, 3, 4],
+};
+
+describe("lineListMetricsFormat", () => {
+  it("formats success rate, rework, cost, and completions", () => {
+    expect(formatSuccessRate(sample)).toBe("82%");
+    expect(formatReworkRate(sample)).toBe("1.4x");
+    expect(formatCostPerSuccess(sample)).toBe("$3.20");
+    expect(formatThroughput(sample)).toBe("1.4 per day");
+  });
+
+  it("formats change vs the prior window", () => {
+    expect(formatSuccessDelta(sample)).toBe("+6 pts");
+    expect(formatReworkDelta(sample)).toBe("−0.2x");
+    expect(formatCostDelta(sample)).toBe("−$0.40");
+  });
+
+  it("uses an em dash when the line has no closed work orders", () => {
+    expect(formatSuccessRate(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatReworkRate(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatCostPerSuccess(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatThroughput(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatSuccessDelta(null)).toBe(LINE_LIST_METRICS_EMPTY);
+  });
+
+  it("drops the decimal on whole rework counts", () => {
+    expect(formatReworkRate({ ...sample, reworkPerWorkOrder: 2 })).toBe("2x");
+  });
+});

--- a/web_src/src/pages/factories/pages/lineListMetricsFormat.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsFormat.ts
@@ -9,13 +9,12 @@ export function formatSuccessRate(metrics: LineListMetrics | null): string {
   return `${Math.round(metrics.successRatePct)}%`;
 }
 
-export function formatReworkRate(metrics: LineListMetrics | null): string {
+/** Median cycle time. Example: `15m`. */
+export function formatDuration(metrics: LineListMetrics | null): string {
   if (!metrics) {
     return LINE_LIST_METRICS_EMPTY;
   }
-  const value = metrics.reworkPerWorkOrder;
-  const rounded = value % 1 === 0 ? value.toFixed(0) : value.toFixed(1);
-  return `${rounded}x`;
+  return compactDurationMinutes(metrics.durationMinutes);
 }
 
 export function formatCostPerSuccess(metrics: LineListMetrics | null): string {
@@ -44,12 +43,20 @@ export function formatSuccessDelta(metrics: LineListMetrics | null): string {
   return `${signedNumber(metrics.successDeltaPts, 0)} pts`;
 }
 
-/** Rework change vs the prior window. Example: `−0.2x`. */
-export function formatReworkDelta(metrics: LineListMetrics | null): string {
+/** Duration change vs the prior window. Example: `−2m`. */
+export function formatDurationDelta(metrics: LineListMetrics | null): string {
   if (!metrics) {
     return LINE_LIST_METRICS_EMPTY;
   }
-  return `${signedNumber(metrics.reworkDelta, 1)}x`;
+  const minutes = metrics.durationDeltaMinutes;
+  const formatted = compactDurationMinutes(Math.abs(minutes));
+  if (minutes > 0) {
+    return `+${formatted}`;
+  }
+  if (minutes < 0) {
+    return `−${formatted}`;
+  }
+  return formatted;
 }
 
 /** Cost change vs the prior window. Example: `−$0.40`. */
@@ -75,4 +82,17 @@ export function formatThroughput(metrics: LineListMetrics | null): string {
   const value = metrics.throughputPerDay;
   const rounded = value % 1 === 0 ? value.toFixed(0) : value.toFixed(1);
   return `${rounded} per day`;
+}
+
+/** Compact minutes as `15m`, hours when 60 or more, days when 48 hours or more. */
+function compactDurationMinutes(minutes: number): string {
+  if (minutes < 60) {
+    return `${Math.round(minutes)}m`;
+  }
+  const hours = minutes / 60;
+  if (hours < 48) {
+    return `${hours % 1 === 0 ? hours.toFixed(0) : hours.toFixed(1)}h`;
+  }
+  const days = hours / 24;
+  return `${days % 1 === 0 ? days.toFixed(0) : days.toFixed(1)}d`;
 }

--- a/web_src/src/pages/factories/pages/lineListMetricsFormat.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsFormat.ts
@@ -1,0 +1,78 @@
+import type { LineListMetrics } from "./lineListMetricsMockData";
+
+export const LINE_LIST_METRICS_EMPTY = "—";
+
+export function formatSuccessRate(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  return `${Math.round(metrics.successRatePct)}%`;
+}
+
+export function formatReworkRate(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  const value = metrics.reworkPerWorkOrder;
+  const rounded = value % 1 === 0 ? value.toFixed(0) : value.toFixed(1);
+  return `${rounded}x`;
+}
+
+export function formatCostPerSuccess(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  return `$${metrics.costPerSuccessUsd.toFixed(2)}`;
+}
+
+function signedNumber(value: number, digits: number): string {
+  const abs = Math.abs(value).toFixed(digits);
+  if (value > 0) {
+    return `+${abs}`;
+  }
+  if (value < 0) {
+    return `−${abs}`;
+  }
+  return digits === 0 ? "0" : (0).toFixed(digits);
+}
+
+/** Success-rate change vs the prior window. Example: `+6 pts`. */
+export function formatSuccessDelta(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  return `${signedNumber(metrics.successDeltaPts, 0)} pts`;
+}
+
+/** Rework change vs the prior window. Example: `−0.2x`. */
+export function formatReworkDelta(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  return `${signedNumber(metrics.reworkDelta, 1)}x`;
+}
+
+/** Cost change vs the prior window. Example: `−$0.40`. */
+export function formatCostDelta(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  const abs = `$${Math.abs(metrics.costDeltaUsd).toFixed(2)}`;
+  if (metrics.costDeltaUsd > 0) {
+    return `+${abs}`;
+  }
+  if (metrics.costDeltaUsd < 0) {
+    return `−${abs}`;
+  }
+  return abs;
+}
+
+/** Completions per day. Example: `1.4 per day`. */
+export function formatThroughput(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  const value = metrics.throughputPerDay;
+  const rounded = value % 1 === 0 ? value.toFixed(0) : value.toFixed(1);
+  return `${rounded} per day`;
+}

--- a/web_src/src/pages/factories/pages/lineListMetricsMockData.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsMockData.ts
@@ -1,0 +1,121 @@
+import {
+  REFUND_LINE_FEATURE_ID,
+  REFUND_LINE_HOTFIX_ID,
+  REFUND_LINE_ONBOARDING_ID,
+  REFUND_LINE_PLAN_ID,
+} from "../__fixtures__/factoryPageResponses";
+
+/**
+ * Stand-in line-list metrics until an aggregation API exists.
+ *
+ * None of these fields exist on the factory-line API yet. This type is the
+ * contract a later endpoint should fill.
+ *
+ * Window: last 30 days.
+ */
+export type LineListMetrics = {
+  /**
+   * Share of closed work orders on this line whose pull request merged to main.
+   * Numerator is merged work orders. Denominator is closed work orders
+   * (merged + not merged). Omit when the line has no closed work orders.
+   */
+  successRatePct: number;
+  /** Merged-to-main work orders in the window (success-rate numerator). */
+  mergedCount: number;
+  /** Closed work orders in the window (success-rate denominator). */
+  totalClosedCount: number;
+  /**
+   * Average human interventions per work order: steering comments, tweaks,
+   * and re-dispatches. 1.0 means one intervention per work order.
+   */
+  reworkPerWorkOrder: number;
+  /**
+   * Tracked cost (model tokens + execution compute) divided by merged work
+   * orders. Failed and reworked runs raise this number.
+   */
+  costPerSuccessUsd: number;
+  /** Daily success-rate samples in the window, oldest first. 0–100. */
+  successTrendPct: number[];
+  /** Success-rate points vs the prior 30 days. Positive is better. */
+  successDeltaPts: number;
+  /** Rework change vs the prior 30 days. Negative is better. */
+  reworkDelta: number;
+  /** Cost change vs the prior 30 days, in USD. Negative is better. */
+  costDeltaUsd: number;
+  /**
+   * Merged work orders per day in the window. Completions, not closed
+   * work orders.
+   */
+  throughputPerDay: number;
+  /** Daily merged-work-order counts in the window, oldest first. */
+  throughputTrend: number[];
+};
+
+/** Per-line mock values keyed to the Refunds Factory fixture lines. */
+export const LINE_LIST_METRICS_BY_ID: Record<string, LineListMetrics | null> = {
+  [REFUND_LINE_PLAN_ID]: {
+    successRatePct: 82,
+    mergedCount: 41,
+    totalClosedCount: 50,
+    reworkPerWorkOrder: 1.4,
+    costPerSuccessUsd: 3.2,
+    successTrendPct: [68, 70, 69, 72, 74, 73, 76, 77, 78, 79, 80, 81, 80, 82],
+    successDeltaPts: 6,
+    reworkDelta: -0.2,
+    costDeltaUsd: -0.4,
+    throughputPerDay: 1.4,
+    throughputTrend: [2, 3, 2, 4, 3, 2, 5, 3, 4, 3, 4, 2, 3, 4],
+  },
+  [REFUND_LINE_HOTFIX_ID]: {
+    successRatePct: 54,
+    mergedCount: 13,
+    totalClosedCount: 24,
+    reworkPerWorkOrder: 3.8,
+    costPerSuccessUsd: 11.45,
+    successTrendPct: [62, 65, 60, 58, 61, 55, 59, 57, 56, 54, 58, 52, 55, 54],
+    successDeltaPts: -8,
+    reworkDelta: 0.9,
+    costDeltaUsd: 2.1,
+    throughputPerDay: 0.4,
+    throughputTrend: [1, 0, 2, 1, 0, 1, 0, 2, 1, 0, 1, 1, 0, 2],
+  },
+  [REFUND_LINE_ONBOARDING_ID]: null,
+  [REFUND_LINE_FEATURE_ID]: {
+    successRatePct: 71,
+    mergedCount: 22,
+    totalClosedCount: 31,
+    reworkPerWorkOrder: 2.1,
+    costPerSuccessUsd: 5.4,
+    successTrendPct: [64, 65, 66, 68, 67, 69, 70, 68, 70, 71, 69, 72, 70, 71],
+    successDeltaPts: 3,
+    reworkDelta: 0.1,
+    costDeltaUsd: 0.2,
+    throughputPerDay: 0.7,
+    throughputTrend: [1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2],
+  },
+};
+
+/**
+ * Purpose copy for each line. The API has no description field. This copy
+ * says when to use the line.
+ */
+export const LINE_LIST_DESCRIPTION_BY_ID: Record<string, string> = {
+  [REFUND_LINE_PLAN_ID]: "Default path for planned product work that needs review before merge.",
+  [REFUND_LINE_HOTFIX_ID]: "Production-incident path for urgent fixes.",
+  [REFUND_LINE_ONBOARDING_ID]: "First-run path for a new workspace.",
+  [REFUND_LINE_FEATURE_ID]: "Feature path that includes a pull request and a CI loop.",
+};
+
+export function metricsForLine(lineId: string | undefined): LineListMetrics | null {
+  if (!lineId) {
+    return null;
+  }
+  return LINE_LIST_METRICS_BY_ID[lineId] ?? null;
+}
+
+export function descriptionForLine(lineId: string | undefined): string | undefined {
+  if (!lineId) {
+    return undefined;
+  }
+  return LINE_LIST_DESCRIPTION_BY_ID[lineId];
+}

--- a/web_src/src/pages/factories/pages/lineListMetricsMockData.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsMockData.ts
@@ -25,10 +25,10 @@ export type LineListMetrics = {
   /** Closed work orders in the window (success-rate denominator). */
   totalClosedCount: number;
   /**
-   * Average human interventions per work order: steering comments, tweaks,
-   * and re-dispatches. 1.0 means one intervention per work order.
+   * Median time from first execution to merge, in minutes, for merged work
+   * orders.
    */
-  reworkPerWorkOrder: number;
+  durationMinutes: number;
   /**
    * Tracked cost (model tokens + execution compute) divided by merged work
    * orders. Failed and reworked runs raise this number.
@@ -38,8 +38,8 @@ export type LineListMetrics = {
   successTrendPct: number[];
   /** Success-rate points vs the prior 30 days. Positive is better. */
   successDeltaPts: number;
-  /** Rework change vs the prior 30 days. Negative is better. */
-  reworkDelta: number;
+  /** Duration change vs the prior 30 days, in minutes. Negative is better. */
+  durationDeltaMinutes: number;
   /** Cost change vs the prior 30 days, in USD. Negative is better. */
   costDeltaUsd: number;
   /**
@@ -57,11 +57,11 @@ export const LINE_LIST_METRICS_BY_ID: Record<string, LineListMetrics | null> = {
     successRatePct: 82,
     mergedCount: 41,
     totalClosedCount: 50,
-    reworkPerWorkOrder: 1.4,
+    durationMinutes: 15,
     costPerSuccessUsd: 3.2,
     successTrendPct: [68, 70, 69, 72, 74, 73, 76, 77, 78, 79, 80, 81, 80, 82],
     successDeltaPts: 6,
-    reworkDelta: -0.2,
+    durationDeltaMinutes: -2,
     costDeltaUsd: -0.4,
     throughputPerDay: 1.4,
     throughputTrend: [2, 3, 2, 4, 3, 2, 5, 3, 4, 3, 4, 2, 3, 4],
@@ -70,11 +70,11 @@ export const LINE_LIST_METRICS_BY_ID: Record<string, LineListMetrics | null> = {
     successRatePct: 54,
     mergedCount: 13,
     totalClosedCount: 24,
-    reworkPerWorkOrder: 3.8,
+    durationMinutes: 17,
     costPerSuccessUsd: 11.45,
     successTrendPct: [62, 65, 60, 58, 61, 55, 59, 57, 56, 54, 58, 52, 55, 54],
     successDeltaPts: -8,
-    reworkDelta: 0.9,
+    durationDeltaMinutes: 2,
     costDeltaUsd: 2.1,
     throughputPerDay: 0.4,
     throughputTrend: [1, 0, 2, 1, 0, 1, 0, 2, 1, 0, 1, 1, 0, 2],
@@ -84,11 +84,11 @@ export const LINE_LIST_METRICS_BY_ID: Record<string, LineListMetrics | null> = {
     successRatePct: 71,
     mergedCount: 22,
     totalClosedCount: 31,
-    reworkPerWorkOrder: 2.1,
+    durationMinutes: 14,
     costPerSuccessUsd: 5.4,
     successTrendPct: [64, 65, 66, 68, 67, 69, 70, 68, 70, 71, 69, 72, 70, 71],
     successDeltaPts: 3,
-    reworkDelta: 0.1,
+    durationDeltaMinutes: -1,
     costDeltaUsd: 0.2,
     throughputPerDay: 0.7,
     throughputTrend: [1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2],


### PR DESCRIPTION
## Summary

The Lines list showed phase names. Operators cannot compare line health from that view. This change shows success rate, completions, rework, and cost on each card. Phase names stay on line detail. Metric values are stand-in data until an aggregation API exists.

## Test plan

- [ ] Open Factories / Pages / Lines / Populated in Storybook
- [ ] Confirm each card shows success, completions, rework, and cost
- [ ] Confirm the Onboarding card shows dashes
- [ ] Open a line and confirm the phase board is unchanged
- [ ] Open Empty factory and confirm the empty state


Made with [Cursor](https://cursor.com)