### PR TITLE
feat: Load factory line metrics on the Lines list

### DIFF
--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -223,6 +223,12 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			DomainType:                   models.DomainTypeOrganization,
 			RequiredExperimentalFeatures: []string{features.FeatureFactories},
 		},
+		{Method: "GET", Pattern: "/api/v1/factories/{factory_id}/line-metrics"}: {
+			Resource:                     "factories",
+			Action:                       "read",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureFactories},
+		},
 		{Method: "GET", Pattern: "/api/v1/factories/{factory_id}/orders/{order_id}"}: {
 			Resource:                     "work_orders",
 			Action:                       "read",

--- a/pkg/authorization/http_route_match_test.go
+++ b/pkg/authorization/http_route_match_test.go
@@ -37,6 +37,12 @@ func TestMatchHTTPRoute(t *testing.T) {
 		},
 		{
 			method: http.MethodGet,
+			path:   "/api/v1/factories/factory-123/line-metrics",
+			want:   HTTPRoute{Method: http.MethodGet, Pattern: "/api/v1/factories/{factory_id}/line-metrics"},
+			wantOK: true,
+		},
+		{
+			method: http.MethodGet,
 			path:   "/api/v1/me",
 			wantOK: false,
 		},

--- a/pkg/grpc/actions/factories/list_factory_line_metrics.go
+++ b/pkg/grpc/actions/factories/list_factory_line_metrics.go
@@ -1,0 +1,73 @@
+package factories
+
+import (
+	"context"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+)
+
+func ListFactoryLineMetrics(
+	ctx context.Context,
+	organizationID string,
+	req *pb.ListFactoryLineMetricsRequest,
+) (*pb.ListFactoryLineMetricsResponse, error) {
+	orgID, err := parseOrganizationID(organizationID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to list factory line metrics")
+	}
+
+	factoryID, err := parseFactoryID(req.GetFactoryId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to list factory line metrics")
+	}
+
+	db := database.DB(ctx)
+	factoryModel, err := models.FindFactory(db, orgID, factoryID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to list factory line metrics")
+	}
+
+	rows, err := models.ListFactoryLineMetrics(db, factoryModel.OrganizationID, factoryModel.ID, time.Now())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to list factory line metrics")
+	}
+
+	return &pb.ListFactoryLineMetricsResponse{
+		Lines: serializeFactoryLineMetrics(rows),
+	}, nil
+}
+
+func serializeFactoryLineMetrics(rows []models.FactoryLineMetrics) []*pb.FactoryLineMetricsEntry {
+	result := make([]*pb.FactoryLineMetricsEntry, len(rows))
+	for i, row := range rows {
+		entry := &pb.FactoryLineMetricsEntry{LineId: row.LineID.String()}
+		if row.Present {
+			entry.Metrics = serializeFactoryLineMetricsValue(row)
+		}
+		result[i] = entry
+	}
+	return result
+}
+
+func serializeFactoryLineMetricsValue(row models.FactoryLineMetrics) *pb.FactoryLineMetrics {
+	trend := make([]int32, len(row.ThroughputTrend))
+	for i, value := range row.ThroughputTrend {
+		trend[i] = int32(value)
+	}
+	return &pb.FactoryLineMetrics{
+		SuccessRatePct:     row.SuccessRatePct,
+		MergedCount:        int32(row.MergedCount),
+		TotalClosedCount:   int32(row.TotalClosedCount),
+		ReworkPerWorkOrder: row.ReworkPerWorkOrder,
+		CostPerSuccessUsd:  row.CostPerSuccessUsd,
+		SuccessTrendPct:    row.SuccessTrendPct,
+		SuccessDeltaPts:    row.SuccessDeltaPts,
+		ReworkDelta:        row.ReworkDelta,
+		CostDeltaUsd:       row.CostDeltaUsd,
+		ThroughputPerDay:   row.ThroughputPerDay,
+		ThroughputTrend:    trend,
+	}
+}

--- a/pkg/grpc/actions/factories/list_factory_line_metrics_test.go
+++ b/pkg/grpc/actions/factories/list_factory_line_metrics_test.go
@@ -1,0 +1,95 @@
+package factories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+)
+
+func Test__ListFactoryLineMetrics(t *testing.T) {
+	r := support.Setup(t)
+	ctx := t.Context()
+	db := database.DB(ctx)
+
+	t.Run("invalid factory id -> error", func(t *testing.T) {
+		_, err := ListFactoryLineMetrics(context.Background(), r.Organization.ID.String(), &pb.ListFactoryLineMetricsRequest{
+			FactoryId: "not-a-uuid",
+		})
+		code, _, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, code)
+	})
+
+	t.Run("unknown factory -> not found", func(t *testing.T) {
+		_, err := ListFactoryLineMetrics(context.Background(), r.Organization.ID.String(), &pb.ListFactoryLineMetricsRequest{
+			FactoryId: "00000000-0000-0000-0000-000000000001",
+		})
+		code, _, ok := grpcerrors.HandlerStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.NotFound, code)
+	})
+
+	t.Run("returns a row per line", func(t *testing.T) {
+		factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+		require.NoError(t, err)
+		_, err = factoryModel.CreateLine(db, "ship", nil)
+		require.NoError(t, err)
+		_, err = factoryModel.CreateLine(db, "hotfix", nil)
+		require.NoError(t, err)
+
+		response, err := ListFactoryLineMetrics(ctx, r.Organization.ID.String(), &pb.ListFactoryLineMetricsRequest{
+			FactoryId: factoryModel.ID.String(),
+		})
+		require.NoError(t, err)
+		require.Len(t, response.Lines, 2)
+		assert.Empty(t, response.Lines[0].Metrics)
+		assert.Empty(t, response.Lines[1].Metrics)
+	})
+}
+
+func TestSerializeFactoryLineMetricsOmitsAbsentRows(t *testing.T) {
+	absentID := "11111111-1111-4111-8111-111111111111"
+	presentID := "22222222-2222-4222-8222-222222222222"
+	got := serializeFactoryLineMetrics([]models.FactoryLineMetrics{
+		{LineID: mustUUID(t, absentID), Present: false},
+		{
+			LineID:             mustUUID(t, presentID),
+			Present:            true,
+			SuccessRatePct:     50,
+			MergedCount:        1,
+			TotalClosedCount:   2,
+			ReworkPerWorkOrder: 1,
+			CostPerSuccessUsd:  4,
+			SuccessTrendPct:    []float64{0, 50},
+			SuccessDeltaPts:    50,
+			ThroughputPerDay:   1.0 / 30.0,
+			ThroughputTrend:    []int{0, 1},
+		},
+	})
+
+	require.Len(t, got, 2)
+	assert.Equal(t, absentID, got[0].LineId)
+	assert.Nil(t, got[0].Metrics)
+	assert.Equal(t, presentID, got[1].LineId)
+	require.NotNil(t, got[1].Metrics)
+	assert.Equal(t, 50.0, got[1].Metrics.SuccessRatePct)
+	assert.Equal(t, int32(1), got[1].Metrics.MergedCount)
+	assert.Equal(t, []int32{0, 1}, got[1].Metrics.ThroughputTrend)
+}
+
+func mustUUID(t *testing.T, value string) uuid.UUID {
+	t.Helper()
+	id, err := uuid.Parse(value)
+	require.NoError(t, err)
+	return id
+}

--- a/pkg/grpc/factory_service.go
+++ b/pkg/grpc/factory_service.go
@@ -56,6 +56,11 @@ func (s *FactoryService) ListFactoryApps(ctx context.Context, req *pb.ListFactor
 	return actions.ListFactoryApps(ctx, organizationID, req)
 }
 
+func (s *FactoryService) ListFactoryLineMetrics(ctx context.Context, req *pb.ListFactoryLineMetricsRequest) (*pb.ListFactoryLineMetricsResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return actions.ListFactoryLineMetrics(ctx, organizationID, req)
+}
+
 func (s *FactoryService) ListWorkOrders(ctx context.Context, req *pb.ListWorkOrdersRequest) (*pb.ListWorkOrdersResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 	return actions.ListWorkOrders(ctx, organizationID, req)

--- a/pkg/models/factory_line_metrics.go
+++ b/pkg/models/factory_line_metrics.go
@@ -1,0 +1,358 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/models/factory"
+	"gorm.io/gorm"
+)
+
+const (
+	FactoryLineMetricsWindowDays = 30
+	FactoryLineMetricsTrendDays  = 14
+)
+
+// FactoryLineMetrics is the last-30-day performance rollup for one line.
+// Present is false when the line has no closed work orders in the window.
+type FactoryLineMetrics struct {
+	LineID             uuid.UUID
+	Present            bool
+	SuccessRatePct     float64
+	MergedCount        int
+	TotalClosedCount   int
+	ReworkPerWorkOrder float64
+	CostPerSuccessUsd  float64
+	SuccessTrendPct    []float64
+	SuccessDeltaPts    float64
+	ReworkDelta        float64
+	CostDeltaUsd       float64
+	ThroughputPerDay   float64
+	ThroughputTrend    []int
+}
+
+type closedWorkOrderRow struct {
+	ID       uuid.UUID
+	LineID   uuid.UUID
+	ClosedAt time.Time
+}
+
+type workOrderIntRow struct {
+	WorkOrderID uuid.UUID
+	Value       int64
+}
+
+type workOrderCostRow struct {
+	WorkOrderID uuid.UUID
+	CostCents   int64
+	ExtraRuns   int64
+}
+
+type windowStats struct {
+	closed      int
+	merged      int
+	successRate float64
+	rework      float64
+	costPerUSD  float64
+}
+
+// ListFactoryLineMetrics returns one row per factory line. now is the
+// exclusive end of the current 30-day window.
+func ListFactoryLineMetrics(tx *gorm.DB, orgID, factoryID uuid.UUID, now time.Time) ([]FactoryLineMetrics, error) {
+	lines, err := listFactoryLineIDs(tx, orgID, factoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	currentStart := now.AddDate(0, 0, -FactoryLineMetricsWindowDays)
+	priorStart := currentStart.AddDate(0, 0, -FactoryLineMetricsWindowDays)
+
+	closed, err := listClosedWorkOrdersOnLines(tx, orgID, factoryID, priorStart, now)
+	if err != nil {
+		return nil, err
+	}
+
+	orderIDs := make([]uuid.UUID, 0, len(closed))
+	for _, row := range closed {
+		orderIDs = append(orderIDs, row.ID)
+	}
+
+	merged, err := listMergedWorkOrderIDs(tx, orgID, factoryID, orderIDs)
+	if err != nil {
+		return nil, err
+	}
+	comments, err := countUserCommentsByWorkOrder(tx, orderIDs)
+	if err != nil {
+		return nil, err
+	}
+	costs, err := listWorkOrderReworkAndCost(tx, orderIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	byLine := map[uuid.UUID][]closedWorkOrderRow{}
+	for _, row := range closed {
+		byLine[row.LineID] = append(byLine[row.LineID], row)
+	}
+
+	result := make([]FactoryLineMetrics, 0, len(lines))
+	for _, lineID := range lines {
+		result = append(result, buildLineMetrics(
+			lineID,
+			byLine[lineID],
+			merged,
+			comments,
+			costs,
+			currentStart,
+			now,
+		))
+	}
+	return result, nil
+}
+
+func listFactoryLineIDs(tx *gorm.DB, orgID, factoryID uuid.UUID) ([]uuid.UUID, error) {
+	var ids []uuid.UUID
+	err := tx.
+		Model(&FactoryLine{}).
+		Where("organization_id = ? AND factory_id = ?", orgID, factoryID).
+		Order("name ASC").
+		Order("id ASC").
+		Pluck("id", &ids).
+		Error
+	return ids, err
+}
+
+func listClosedWorkOrdersOnLines(
+	tx *gorm.DB,
+	orgID, factoryID uuid.UUID,
+	from, until time.Time,
+) ([]closedWorkOrderRow, error) {
+	var rows []closedWorkOrderRow
+	err := tx.Raw(`
+		WITH latest_exec AS (
+			SELECT DISTINCT ON (e.work_order_id)
+				e.work_order_id,
+				e.line_id
+			FROM factory_work_order_executions e
+			WHERE e.organization_id = ? AND e.factory_id = ?
+			ORDER BY e.work_order_id, e.created_at DESC, e.id DESC
+		),
+		latest_close AS (
+			SELECT DISTINCT ON (ev.work_order_id)
+				ev.work_order_id,
+				ev.created_at AS closed_at
+			FROM factory_work_order_events ev
+			INNER JOIN factory_work_orders o ON o.id = ev.work_order_id
+			WHERE o.organization_id = ?
+				AND o.factory_id = ?
+				AND ev.type = ?
+				AND ev.data->>'toState' = ?
+			ORDER BY ev.work_order_id, ev.created_at DESC, ev.id DESC
+		)
+		SELECT o.id, le.line_id, lc.closed_at
+		FROM factory_work_orders o
+		INNER JOIN latest_exec le ON le.work_order_id = o.id
+		INNER JOIN latest_close lc ON lc.work_order_id = o.id
+		WHERE o.organization_id = ?
+			AND o.factory_id = ?
+			AND o.state = ?
+			AND lc.closed_at >= ?
+			AND lc.closed_at < ?
+	`, orgID, factoryID, orgID, factoryID, factory.EventTypeOrderStatusUpdated, FactoryWorkOrderStateClosed,
+		orgID, factoryID, FactoryWorkOrderStateClosed, from, until).
+		Scan(&rows).Error
+	return rows, err
+}
+
+func listMergedWorkOrderIDs(tx *gorm.DB, orgID, factoryID uuid.UUID, orderIDs []uuid.UUID) (map[uuid.UUID]struct{}, error) {
+	result := map[uuid.UUID]struct{}{}
+	if len(orderIDs) == 0 {
+		return result, nil
+	}
+
+	var ids []uuid.UUID
+	err := tx.
+		Model(&FactoryWorkOrderArtifact{}).
+		Where("organization_id = ? AND factory_id = ? AND type = ? AND data->>'state' = ? AND work_order_id IN ?",
+			orgID, factoryID, FactoryWorkOrderArtifactTypePR, PrArtifactStateMerged, orderIDs).
+		Distinct("work_order_id").
+		Pluck("work_order_id", &ids).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range ids {
+		result[id] = struct{}{}
+	}
+	return result, nil
+}
+
+func countUserCommentsByWorkOrder(tx *gorm.DB, orderIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
+	result := map[uuid.UUID]int64{}
+	if len(orderIDs) == 0 {
+		return result, nil
+	}
+
+	var rows []workOrderIntRow
+	err := tx.Raw(`
+		SELECT ev.work_order_id, COUNT(*) AS value
+		FROM factory_work_order_events ev
+		WHERE ev.type = ?
+			AND ev.data->'author'->>'kind' = ?
+			AND ev.work_order_id IN ?
+		GROUP BY ev.work_order_id
+	`, factory.EventTypeOrderCommentAdded, factory.CommentAuthorKindUser, orderIDs).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[row.WorkOrderID] = row.Value
+	}
+	return result, nil
+}
+
+func listWorkOrderReworkAndCost(tx *gorm.DB, orderIDs []uuid.UUID) (map[uuid.UUID]workOrderCostRow, error) {
+	result := map[uuid.UUID]workOrderCostRow{}
+	if len(orderIDs) == 0 {
+		return result, nil
+	}
+
+	var rows []workOrderCostRow
+	err := tx.Raw(`
+		SELECT
+			work_order_id,
+			SUM(cost_cents) AS cost_cents,
+			SUM(GREATEST(cnt - 1, 0)) AS extra_runs
+		FROM (
+			SELECT work_order_id, step_index, COUNT(*) AS cnt, SUM(cost_cents) AS cost_cents
+			FROM factory_work_order_executions
+			WHERE work_order_id IN ?
+			GROUP BY work_order_id, step_index
+		) grouped
+		GROUP BY work_order_id
+	`, orderIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[row.WorkOrderID] = row
+	}
+	return result, nil
+}
+
+func buildLineMetrics(
+	lineID uuid.UUID,
+	closed []closedWorkOrderRow,
+	merged map[uuid.UUID]struct{},
+	comments map[uuid.UUID]int64,
+	costs map[uuid.UUID]workOrderCostRow,
+	currentStart, now time.Time,
+) FactoryLineMetrics {
+	metrics := FactoryLineMetrics{
+		LineID:          lineID,
+		SuccessTrendPct: make([]float64, FactoryLineMetricsTrendDays),
+		ThroughputTrend: make([]int, FactoryLineMetricsTrendDays),
+	}
+
+	var current, prior []closedWorkOrderRow
+	for _, row := range closed {
+		if !row.ClosedAt.Before(currentStart) && row.ClosedAt.Before(now) {
+			current = append(current, row)
+			continue
+		}
+		if row.ClosedAt.Before(currentStart) {
+			prior = append(prior, row)
+		}
+	}
+
+	if len(current) == 0 {
+		return metrics
+	}
+
+	currentStats := statsForWindow(current, merged, comments, costs)
+	priorStats := statsForWindow(prior, merged, comments, costs)
+	fillTrend(metrics.SuccessTrendPct, metrics.ThroughputTrend, current, merged, now)
+
+	metrics.Present = true
+	metrics.SuccessRatePct = currentStats.successRate
+	metrics.MergedCount = currentStats.merged
+	metrics.TotalClosedCount = currentStats.closed
+	metrics.ReworkPerWorkOrder = currentStats.rework
+	metrics.CostPerSuccessUsd = currentStats.costPerUSD
+	metrics.SuccessDeltaPts = currentStats.successRate - priorStats.successRate
+	metrics.ReworkDelta = currentStats.rework - priorStats.rework
+	metrics.CostDeltaUsd = currentStats.costPerUSD - priorStats.costPerUSD
+	metrics.ThroughputPerDay = float64(currentStats.merged) / float64(FactoryLineMetricsWindowDays)
+	return metrics
+}
+
+func statsForWindow(
+	closed []closedWorkOrderRow,
+	merged map[uuid.UUID]struct{},
+	comments map[uuid.UUID]int64,
+	costs map[uuid.UUID]workOrderCostRow,
+) windowStats {
+	stats := windowStats{closed: len(closed)}
+	if stats.closed == 0 {
+		return stats
+	}
+
+	var interventions int64
+	var costCents int64
+	for _, row := range closed {
+		if _, ok := merged[row.ID]; ok {
+			stats.merged++
+		}
+		interventions += comments[row.ID]
+		cost := costs[row.ID]
+		interventions += cost.ExtraRuns
+		costCents += cost.CostCents
+	}
+
+	stats.successRate = (float64(stats.merged) / float64(stats.closed)) * 100
+	stats.rework = float64(interventions) / float64(stats.closed)
+	if stats.merged > 0 {
+		stats.costPerUSD = float64(costCents) / float64(stats.merged) / 100
+	}
+	return stats
+}
+
+func fillTrend(
+	success []float64,
+	throughput []int,
+	closed []closedWorkOrderRow,
+	merged map[uuid.UUID]struct{},
+	now time.Time,
+) {
+	type dayCounts struct {
+		closed int
+		merged int
+	}
+	byDay := map[time.Time]dayCounts{}
+	for _, row := range closed {
+		day := utcDay(row.ClosedAt)
+		counts := byDay[day]
+		counts.closed++
+		if _, ok := merged[row.ID]; ok {
+			counts.merged++
+		}
+		byDay[day] = counts
+	}
+
+	end := utcDay(now.Add(-time.Nanosecond))
+	start := end.AddDate(0, 0, -(FactoryLineMetricsTrendDays - 1))
+	for i := 0; i < FactoryLineMetricsTrendDays; i++ {
+		day := start.AddDate(0, 0, i)
+		counts := byDay[day]
+		throughput[i] = counts.merged
+		if counts.closed > 0 {
+			success[i] = (float64(counts.merged) / float64(counts.closed)) * 100
+		}
+	}
+}
+
+func utcDay(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/pkg/models/factory_line_metrics_test.go
+++ b/pkg/models/factory_line_metrics_test.go
@@ -1,0 +1,304 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models/factory"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+func TestListFactoryLineMetrics(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	_, userID, factoryModel := setupFactoryWithUser(t, "line-metrics")
+	db := database.Conn()
+	now := time.Date(2026, 8, 17, 15, 0, 0, 0, time.UTC)
+
+	ship, err := factoryModel.CreateLine(db, "ship", nil)
+	require.NoError(t, err)
+	hotfix, err := factoryModel.CreateLine(db, "hotfix", nil)
+	require.NoError(t, err)
+
+	t.Run("returns empty metrics when no work orders closed", func(t *testing.T) {
+		got, err := ListFactoryLineMetrics(db, factoryModel.OrganizationID, factoryModel.ID, now)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, hotfix.ID, got[0].LineID)
+		assert.False(t, got[0].Present)
+		assert.Equal(t, ship.ID, got[1].LineID)
+		assert.False(t, got[1].Present)
+	})
+
+	runID := insertMetricsCanvasRun(t, factoryModel.OrganizationID, userID)
+
+	_ = insertClosedWorkOrder(t, metricsOrderSetup{
+		factory:   factoryModel,
+		userID:    userID,
+		lineID:    ship.ID,
+		runID:     runID,
+		closedAt:  now.Add(-2 * 24 * time.Hour),
+		merged:    true,
+		costCents: 320,
+		extraRuns: 1,
+		userNotes: 1,
+		autoNotes: 4,
+		stepIndex: 0,
+	})
+	_ = insertClosedWorkOrder(t, metricsOrderSetup{
+		factory:   factoryModel,
+		userID:    userID,
+		lineID:    ship.ID,
+		runID:     insertMetricsCanvasRun(t, factoryModel.OrganizationID, userID),
+		closedAt:  now.Add(-3 * 24 * time.Hour),
+		merged:    false,
+		costCents: 80,
+	})
+	_ = insertClosedWorkOrder(t, metricsOrderSetup{
+		factory:   factoryModel,
+		userID:    userID,
+		lineID:    hotfix.ID,
+		runID:     insertMetricsCanvasRun(t, factoryModel.OrganizationID, userID),
+		closedAt:  now.Add(-40 * 24 * time.Hour),
+		merged:    true,
+		costCents: 1100,
+	})
+
+	got, err := ListFactoryLineMetrics(db, factoryModel.OrganizationID, factoryModel.ID, now)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	hotfixMetrics := got[0]
+	assert.Equal(t, hotfix.ID, hotfixMetrics.LineID)
+	assert.False(t, hotfixMetrics.Present, "prior-window closes must not fill the current window")
+
+	shipMetrics := got[1]
+	assert.Equal(t, ship.ID, shipMetrics.LineID)
+	require.True(t, shipMetrics.Present)
+	assert.Equal(t, 50.0, shipMetrics.SuccessRatePct)
+	assert.Equal(t, 1, shipMetrics.MergedCount)
+	assert.Equal(t, 2, shipMetrics.TotalClosedCount)
+	assert.InDelta(t, 1.0, shipMetrics.ReworkPerWorkOrder, 0.001)
+	assert.InDelta(t, 4.00, shipMetrics.CostPerSuccessUsd, 0.001)
+	assert.InDelta(t, 1.0/30.0, shipMetrics.ThroughputPerDay, 0.0001)
+	assert.Equal(t, 50.0, shipMetrics.SuccessDeltaPts)
+	assert.Len(t, shipMetrics.SuccessTrendPct, FactoryLineMetricsTrendDays)
+	assert.Len(t, shipMetrics.ThroughputTrend, FactoryLineMetricsTrendDays)
+	assert.Equal(t, 1, shipMetrics.ThroughputTrend[FactoryLineMetricsTrendDays-3])
+}
+
+func TestListFactoryLineMetrics_UsesLatestExecutionLine(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	_, userID, factoryModel := setupFactoryWithUser(t, "line-metrics-latest")
+	db := database.Conn()
+	now := time.Date(2026, 8, 17, 15, 0, 0, 0, time.UTC)
+
+	ship, err := factoryModel.CreateLine(db, "ship", nil)
+	require.NoError(t, err)
+	hotfix, err := factoryModel.CreateLine(db, "hotfix", nil)
+	require.NoError(t, err)
+
+	order := insertClosedWorkOrder(t, metricsOrderSetup{
+		factory:  factoryModel,
+		userID:   userID,
+		lineID:   ship.ID,
+		runID:    insertMetricsCanvasRun(t, factoryModel.OrganizationID, userID),
+		closedAt: now.Add(-time.Hour),
+		merged:   true,
+	})
+
+	later := now.Add(-30 * time.Minute)
+	require.NoError(t, db.Create(&FactoryWorkOrderExecution{
+		ID:             uuid.New(),
+		OrganizationID: factoryModel.OrganizationID,
+		FactoryID:      factoryModel.ID,
+		WorkOrderID:    order.ID,
+		LineID:         hotfix.ID,
+		StepIndex:      0,
+		StepName:       "verify",
+		RunID:          insertMetricsCanvasRun(t, factoryModel.OrganizationID, userID),
+		Status:         FactoryWorkOrderExecutionStatusFinished,
+		CreatedAt:      later,
+		UpdatedAt:      later,
+	}).Error)
+
+	got, err := ListFactoryLineMetrics(db, factoryModel.OrganizationID, factoryModel.ID, now)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.False(t, got[1].Present)
+	require.True(t, got[0].Present)
+	assert.Equal(t, hotfix.ID, got[0].LineID)
+	assert.Equal(t, 1, got[0].MergedCount)
+}
+
+type metricsOrderSetup struct {
+	factory   *Factory
+	userID    uuid.UUID
+	lineID    uuid.UUID
+	runID     uuid.UUID
+	closedAt  time.Time
+	merged    bool
+	costCents int64
+	extraRuns int
+	userNotes int
+	autoNotes int
+	stepIndex int
+}
+
+func insertClosedWorkOrder(t *testing.T, setup metricsOrderSetup) *FactoryWorkOrder {
+	t.Helper()
+	db := database.Conn()
+
+	order, err := setup.factory.CreateWorkOrder(db, "Metrics order", "", &setup.userID, nil, nil)
+	require.NoError(t, err)
+
+	_, err = order.UpdateStatus(db, FactoryWorkOrderStatusUpdate{
+		ToState: FactoryWorkOrderStateOpen,
+		Actor:   &setup.userID,
+	})
+	require.NoError(t, err)
+	_, err = order.UpdateStatus(db, FactoryWorkOrderStatusUpdate{
+		ToState: FactoryWorkOrderStateClosed,
+		Result:  FactoryWorkOrderResultCompleted,
+		Actor:   &setup.userID,
+	})
+	require.NoError(t, err)
+
+	created := setup.closedAt.Add(-time.Hour)
+	require.NoError(t, db.Create(&FactoryWorkOrderExecution{
+		ID:             uuid.New(),
+		OrganizationID: setup.factory.OrganizationID,
+		FactoryID:      setup.factory.ID,
+		WorkOrderID:    order.ID,
+		LineID:         setup.lineID,
+		StepIndex:      setup.stepIndex,
+		StepName:       "implement",
+		RunID:          setup.runID,
+		Status:         FactoryWorkOrderExecutionStatusFinished,
+		CostCents:      setup.costCents,
+		CreatedAt:      created,
+		UpdatedAt:      created,
+	}).Error)
+
+	for i := 0; i < setup.extraRuns; i++ {
+		require.NoError(t, db.Create(&FactoryWorkOrderExecution{
+			ID:             uuid.New(),
+			OrganizationID: setup.factory.OrganizationID,
+			FactoryID:      setup.factory.ID,
+			WorkOrderID:    order.ID,
+			LineID:         setup.lineID,
+			StepIndex:      setup.stepIndex,
+			StepName:       "implement",
+			RunID:          insertMetricsCanvasRun(t, setup.factory.OrganizationID, setup.userID),
+			Status:         FactoryWorkOrderExecutionStatusFinished,
+			CreatedAt:      created.Add(time.Duration(i+1) * time.Minute),
+			UpdatedAt:      created.Add(time.Duration(i+1) * time.Minute),
+		}).Error)
+	}
+
+	if setup.merged {
+		_, err = order.CreateArtifact(db, FactoryWorkOrderArtifactParams{
+			Type: FactoryWorkOrderArtifactTypePR,
+			Data: map[string]any{
+				"url":   fmt.Sprintf("https://github.com/example/repo/pull/%s", order.ID),
+				"state": PrArtifactStateMerged,
+			},
+			CreatedBy: &setup.userID,
+		})
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < setup.userNotes; i++ {
+		require.NoError(t, order.RecordCommentAdded(db, "steer this", factory.WorkOrderCommentAuthor{
+			Kind:   factory.CommentAuthorKindUser,
+			UserID: ptrTo(setup.userID.String()),
+		}, nil))
+	}
+	for i := 0; i < setup.autoNotes; i++ {
+		require.NoError(t, order.RecordCommentAdded(db, "bot note", factory.WorkOrderCommentAuthor{
+			Kind: factory.CommentAuthorKindAutomation,
+		}, nil))
+	}
+
+	require.NoError(t, db.Model(&FactoryWorkOrderEvent{}).
+		Where("work_order_id = ? AND type = ? AND data->>'toState' = ?", order.ID, factory.EventTypeOrderStatusUpdated, FactoryWorkOrderStateClosed).
+		Update("created_at", setup.closedAt).Error)
+
+	return order
+}
+
+func insertMetricsCanvasRun(t *testing.T, orgID, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now()
+	versionID := uuid.New()
+	canvas := Canvas{
+		ID:             uuid.New(),
+		OrganizationID: orgID,
+		LiveVersionID:  &versionID,
+		Name:           fmt.Sprintf("metrics-canvas-%s", uuid.New()),
+		CreatedBy:      &userID,
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}
+	version := CanvasVersion{
+		ID:         versionID,
+		WorkflowID: canvas.ID,
+		OwnerID:    &userID,
+		Nodes:      datatypes.NewJSONSlice([]Node{}),
+		Edges:      datatypes.NewJSONSlice([]Edge{}),
+		CreatedAt:  &now,
+		UpdatedAt:  &now,
+	}
+	node := CanvasNode{
+		WorkflowID:    canvas.ID,
+		NodeID:        "trigger",
+		Name:          "Trigger",
+		State:         CanvasNodeStateReady,
+		Type:          NodeTypeTrigger,
+		Ref:           datatypes.NewJSONType(NodeRef{}),
+		Configuration: datatypes.NewJSONType(map[string]any{}),
+		Position:      datatypes.NewJSONType(Position{}),
+		Metadata:      datatypes.NewJSONType(map[string]any{}),
+		CreatedAt:     &now,
+		UpdatedAt:     &now,
+	}
+	run := CanvasRun{
+		ID:         uuid.New(),
+		WorkflowID: canvas.ID,
+		NodeID:     node.NodeID,
+		VersionID:  versionID,
+		Input:      NewJSONValue(map[string]any{}),
+		State:      CanvasRunStateFinished,
+		CreatedAt:  &now,
+		UpdatedAt:  &now,
+	}
+	require.NoError(t, database.Conn().Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&canvas).Error; err != nil {
+			return err
+		}
+		if err := tx.Create(&version).Error; err != nil {
+			return err
+		}
+		if err := tx.Create(&node).Error; err != nil {
+			return err
+		}
+		return tx.Create(&run).Error
+	}))
+	return run.ID
+}
+
+func ptrTo[T any](value T) *T {
+	return &value
+}
+
+func TestUtcDay(t *testing.T) {
+	got := utcDay(time.Date(2026, 8, 17, 23, 59, 0, 0, time.FixedZone("x", -2*3600)))
+	assert.Equal(t, time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC), got)
+}

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -122,6 +122,17 @@ service Factories {
     };
   }
 
+  rpc ListFactoryLineMetrics(ListFactoryLineMetricsRequest) returns (ListFactoryLineMetricsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/factories/{factory_id}/line-metrics"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List factory line metrics";
+      description: "Returns last-30-day performance metrics for each factory line";
+      tags: "Factory";
+    };
+  }
+
   // Work orders APIs
 
   rpc ListWorkOrders(ListWorkOrdersRequest) returns (ListWorkOrdersResponse) {
@@ -364,6 +375,38 @@ message ListFactoryAppsRequest {
 
 message ListFactoryAppsResponse {
   repeated Factory.App apps = 1;
+}
+
+message ListFactoryLineMetricsRequest {
+  string factory_id = 1;
+}
+
+message ListFactoryLineMetricsResponse {
+  repeated FactoryLineMetricsEntry lines = 1;
+}
+
+message FactoryLineMetricsEntry {
+  string line_id = 1;
+  // Unset when the line has no closed work orders in the last 30 days.
+  FactoryLineMetrics metrics = 2;
+}
+
+// Last 30 days. Daily trend series cover the last 14 days, oldest first.
+message FactoryLineMetrics {
+  // Share of closed work orders whose pull request merged to main.
+  double success_rate_pct = 1;
+  int32 merged_count = 2;
+  int32 total_closed_count = 3;
+  // Average user comments plus extra step runs per closed work order.
+  double rework_per_work_order = 4;
+  // Execution cost in USD divided by merged work orders.
+  double cost_per_success_usd = 5;
+  repeated double success_trend_pct = 6;
+  double success_delta_pts = 7;
+  double rework_delta = 8;
+  double cost_delta_usd = 9;
+  double throughput_per_day = 10;
+  repeated int32 throughput_trend = 11;
 }
 
 // Work orders

--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -10,6 +10,7 @@ import {
   factoriesDispatchWorkOrder,
   factoriesListFactories,
   factoriesListFactoryApps,
+  factoriesListFactoryLineMetrics,
   factoriesListWorkOrderArtifacts,
   factoriesListWorkOrderEvents,
   factoriesListWorkOrders,
@@ -33,6 +34,7 @@ import {
   getWorkOrderEventsNextPageParam,
   WORK_ORDER_EVENTS_PAGE_LIMIT,
 } from "@/pages/factories/lib/workOrderEventsPagination";
+import { lineListMetricsFromApi, type LineListMetrics } from "@/pages/factories/pages/lineListMetrics";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const factoryQueryKeys = {
@@ -47,6 +49,8 @@ export const factoryQueryKeys = {
   workOrderArtifacts: (organizationId: string, factoryId: string, orderId: string) =>
     ["factories", organizationId, factoryId, "work-orders", orderId, "artifacts"] as const,
   apps: (organizationId: string, factoryId: string) => ["factories", organizationId, factoryId, "apps"] as const,
+  lineMetrics: (organizationId: string, factoryId: string) =>
+    ["factories", organizationId, factoryId, "line-metrics"] as const,
 };
 
 function factoryListKey(organizationId: string) {
@@ -75,6 +79,10 @@ function workOrderArtifactsKey(organizationId: string, factoryId: string, orderI
 
 export function factoryAppsKey(organizationId: string, factoryId: string) {
   return factoryQueryKeys.apps(organizationId, factoryId);
+}
+
+function factoryLineMetricsKey(organizationId: string, factoryId: string) {
+  return factoryQueryKeys.lineMetrics(organizationId, factoryId);
 }
 
 export function useFactories(organizationId: string, enabled = true) {
@@ -336,6 +344,7 @@ export function useDispatchWorkOrder(organizationId: string, factoryId: string) 
       void queryClient.invalidateQueries({
         queryKey: workOrderEventsKey(organizationId, factoryId, variables.orderId),
       });
+      void queryClient.invalidateQueries({ queryKey: factoryLineMetricsKey(organizationId, factoryId) });
     },
   });
 }
@@ -372,6 +381,7 @@ export function useUpdateWorkOrderStatus(organizationId: string, factoryId: stri
       void queryClient.invalidateQueries({
         queryKey: workOrderEventsKey(organizationId, factoryId, variables.orderId),
       });
+      void queryClient.invalidateQueries({ queryKey: factoryLineMetricsKey(organizationId, factoryId) });
     },
   });
 }
@@ -399,6 +409,7 @@ export function useAddWorkOrderComment(organizationId: string, factoryId: string
       void queryClient.invalidateQueries({
         queryKey: workOrderEventsKey(organizationId, factoryId, variables.orderId),
       });
+      void queryClient.invalidateQueries({ queryKey: factoryLineMetricsKey(organizationId, factoryId) });
     },
   });
 }
@@ -446,6 +457,7 @@ export function useCloseWorkOrder(organizationId: string, factoryId: string) {
       void queryClient.invalidateQueries({
         queryKey: workOrderEventsKey(organizationId, factoryId, variables.orderId),
       });
+      void queryClient.invalidateQueries({ queryKey: factoryLineMetricsKey(organizationId, factoryId) });
     },
   });
 }
@@ -461,6 +473,29 @@ export function useFactoryApps(organizationId: string, factoryId: string) {
         }),
       );
       return response.data?.apps ?? [];
+    },
+    enabled: Boolean(organizationId && factoryId),
+  });
+}
+
+export function useFactoryLineMetrics(organizationId: string, factoryId: string) {
+  return useQuery({
+    queryKey: factoryLineMetricsKey(organizationId, factoryId),
+    queryFn: async (): Promise<Record<string, LineListMetrics | null>> => {
+      const response = await factoriesListFactoryLineMetrics(
+        withOrganizationHeader({
+          organizationId,
+          path: { factoryId },
+        }),
+      );
+      const byLineId: Record<string, LineListMetrics | null> = {};
+      for (const entry of response.data?.lines ?? []) {
+        if (!entry.lineId) {
+          continue;
+        }
+        byLineId[entry.lineId] = lineListMetricsFromApi(entry.metrics);
+      }
+      return byLineId;
     },
     enabled: Boolean(organizationId && factoryId),
   });
@@ -488,6 +523,7 @@ export function useCreateFactoryLine(organizationId: string, factoryId: string) 
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
+      void queryClient.invalidateQueries({ queryKey: factoryLineMetricsKey(organizationId, factoryId) });
     },
   });
 }
@@ -514,6 +550,7 @@ export function useUpdateFactoryLine(organizationId: string, factoryId: string) 
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
+      void queryClient.invalidateQueries({ queryKey: factoryLineMetricsKey(organizationId, factoryId) });
     },
   });
 }

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -102,8 +102,10 @@ export const REFUND_FACTORY_APPS: FactoryApp[] = [
   },
 ];
 
-const REFUND_LINE_PLAN_ID = "line-plan-and-implement";
-const REFUND_LINE_HOTFIX_ID = "line-hotfix";
+export const REFUND_LINE_PLAN_ID = "line-plan-and-implement";
+export const REFUND_LINE_HOTFIX_ID = "line-hotfix";
+export const REFUND_LINE_ONBOARDING_ID = "line-onboarding";
+export const REFUND_LINE_FEATURE_ID = "line-feature-delivery";
 
 export const REFUND_FACTORY_LINES: FactoriesFactoryLine[] = [
   {
@@ -393,6 +395,153 @@ export const emptyWorkOrdersFactoriesFixture: FactoriesFixture = {
   workOrdersByFactoryId: {
     [PRIMARY_FACTORY_ID]: [CLOSED_WORK_ORDER],
     [EMPTY_FACTORY_ID]: [],
+  },
+};
+
+const ONBOARDING_FACTORY_LINE: FactoriesFactoryLine = {
+  id: REFUND_LINE_ONBOARDING_ID,
+  name: "onboarding",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+  steps: [
+    runAppStep("plan", "app-refund-planner", "start-plan"),
+    runAppStep("implement", "app-refund-implementer", "start-implementation"),
+  ],
+};
+
+const FEATURE_PLAN_STEP = "Create Implementation Plan";
+const FEATURE_IMPLEMENT_STEP = "Implement";
+const FEATURE_PR_STEP = "Open Pull Request";
+const FEATURE_CI_STEP = "Ci Loop";
+
+const FEATURE_DELIVERY_LINE: FactoriesFactoryLine = {
+  id: REFUND_LINE_FEATURE_ID,
+  name: "feature-delivery",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+  steps: [
+    runAppStep(FEATURE_PLAN_STEP, "app-refund-planner", "start-plan"),
+    runAppStep(FEATURE_IMPLEMENT_STEP, "app-refund-implementer", "start-implementation"),
+    runAppStep(FEATURE_PR_STEP, "app-refund-implementer", "start-pull-request"),
+    runAppStep(FEATURE_CI_STEP, "app-refund-verifier", "start-ci-loop"),
+  ],
+};
+
+function featureLineExecution(
+  step: string,
+  overrides: Partial<FactoriesWorkOrderExecution> = {},
+): FactoriesWorkOrderExecution {
+  return {
+    id: `exec-feature-${overrides.id ?? step}`,
+    line: { id: REFUND_LINE_FEATURE_ID, name: "feature-delivery" },
+    step,
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    createdAt: TWO_HOURS_AGO,
+    updatedAt: HOUR_AGO,
+    run: {
+      id: `run-feature-${step}`,
+      appId: "app-refund-implementer",
+      appName: "Refund Implementer",
+    },
+    ...overrides,
+  };
+}
+
+const FEATURE_RUNNING_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-implement",
+  number: "201",
+  key: "RF-201",
+  title: "Ship ledger retry window",
+  description: "Implement the retry window from the plan and open a pull request.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-1" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, {
+      id: "impl-1",
+      state: "STATE_STARTED",
+      result: "RESULT_UNKNOWN",
+      run: { id: LINE_RUN_IMPLEMENT_ID, appId: "app-refund-implementer", appName: "Refund Implementer" },
+    }),
+  ],
+};
+
+const FEATURE_PR_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-pr",
+  number: "202",
+  key: "RF-202",
+  title: "Open refund schema pull request",
+  description: "Plan and implementation passed. Pull request is waiting for review.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: REVIEWER_USER.id, name: REVIEWER_USER.name } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-2" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, { id: "impl-2" }),
+    featureLineExecution(FEATURE_PR_STEP, {
+      id: "pr-2",
+      state: "STATE_PENDING",
+      result: "RESULT_UNKNOWN",
+    }),
+  ],
+};
+
+const FEATURE_CI_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-feature-ci",
+  number: "203",
+  key: "RF-203",
+  title: "Run CI on refund enum pull request",
+  description: "Pull request is open. CI loop is running.",
+  state: "STATE_OPEN",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: YESTERDAY,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: OPERATOR_USER.id, name: OPERATOR_USER.name } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  executions: [
+    featureLineExecution(FEATURE_PLAN_STEP, { id: "plan-3" }),
+    featureLineExecution(FEATURE_IMPLEMENT_STEP, { id: "impl-3" }),
+    featureLineExecution(FEATURE_PR_STEP, { id: "pr-3" }),
+    featureLineExecution(FEATURE_CI_STEP, {
+      id: "ci-3",
+      state: "STATE_STARTED",
+      result: "RESULT_UNKNOWN",
+      run: { id: LINE_RUN_VERIFY_PASSED_ID, appId: "app-refund-verifier", appName: "Refund Verifier" },
+    }),
+  ],
+};
+
+/**
+ * Extra lines for the populated Lines list: unused onboarding plus a
+ * four-phase feature line.
+ */
+export const lineMetricsFactoriesFixture: FactoriesFixture = {
+  ...defaultFactoriesFixture,
+  factories: defaultFactoriesFixture.factories.map((factory) => {
+    if (factory.id !== PRIMARY_FACTORY_ID) {
+      return factory;
+    }
+    return {
+      ...factory,
+      lines: [...(factory.lines ?? []), ONBOARDING_FACTORY_LINE, FEATURE_DELIVERY_LINE],
+    };
+  }),
+  workOrdersByFactoryId: {
+    ...defaultFactoriesFixture.workOrdersByFactoryId,
+    [PRIMARY_FACTORY_ID]: [
+      ...(defaultFactoriesFixture.workOrdersByFactoryId[PRIMARY_FACTORY_ID] ?? []),
+      FEATURE_RUNNING_WORK_ORDER,
+      FEATURE_PR_WORK_ORDER,
+      FEATURE_CI_WORK_ORDER,
+    ],
   },
 };
 

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -1,6 +1,7 @@
 import { defaultFactoriesFixture, ORGANIZATION_USERS, type FactoriesFixture } from "./factoryPageResponses";
 import type { FactoriesWorkOrder } from "@/api-client";
 import { fixtureResponse, type FixtureResult } from "@/pages/home/__fixtures__/handlers";
+import { LINE_LIST_METRICS_BY_ID } from "../pages/lineListMetricsMockData";
 
 export type { FactoriesFixture };
 
@@ -77,6 +78,25 @@ function factoriesCollectionRoute(fixture: FactoriesFixture): FactoriesRoute {
 
 function factoryDetailRoutes(fixture: FactoriesFixture): FactoriesRoute[] {
   return [
+    {
+      pattern: re("/api/v1/factories/([^/]+)/line-metrics"),
+      resolve: (match) => {
+        const factory = fixture.factories.find((entry) => entry.id === match[1]);
+        const lines = (factory?.lines ?? []).flatMap((line) => {
+          if (!line.id) {
+            return [];
+          }
+          const metrics = LINE_LIST_METRICS_BY_ID[line.id];
+          return [
+            {
+              lineId: line.id,
+              ...(metrics ? { metrics } : {}),
+            },
+          ];
+        });
+        return { json: { lines } };
+      },
+    },
     {
       pattern: re("/api/v1/factories/([^/]+)"),
       resolve: (match, method, body) => {

--- a/web_src/src/pages/factories/pages/LineListCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineListCard.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { REFUND_FACTORY_LINES, REFUND_LINE_PLAN_ID } from "../__fixtures__/factoryPageResponses";
+import { LINE_LIST_DESCRIPTION_BY_ID, LINE_LIST_METRICS_BY_ID } from "./lineListMetricsMockData";
+import { LineListCard, LineListHeroSplit } from "./LineListCard";
+
+const planLine = REFUND_FACTORY_LINES[0];
+const planMetrics = LINE_LIST_METRICS_BY_ID[REFUND_LINE_PLAN_ID] ?? null;
+const planDescription = LINE_LIST_DESCRIPTION_BY_ID[REFUND_LINE_PLAN_ID];
+
+describe("LineListCard", () => {
+  it("shows a purpose description and no phase names", () => {
+    render(
+      <MemoryRouter>
+        <LineListCard line={planLine} href="/lines/x" metrics={planMetrics} description={planDescription} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(planDescription)).toBeInTheDocument();
+    expect(screen.queryByText("Plan → Implement → Verify")).not.toBeInTheDocument();
+  });
+
+  it("splits success sparkline and completion bars", () => {
+    render(<LineListHeroSplit metrics={planMetrics} />);
+
+    const split = screen.getByTestId("lines-card-metrics");
+    expect(split).toHaveTextContent("82%");
+    expect(split).toHaveTextContent("+6 pts");
+    expect(split).toHaveTextContent("1.4 per day");
+    expect(split).toHaveTextContent("Success rate");
+    expect(split).toHaveTextContent("Completions");
+    expect(split).toHaveTextContent("1.4x");
+    expect(split).toHaveTextContent("$3.20");
+  });
+
+  it("shows dashes when the line has no merged work orders", () => {
+    render(<LineListHeroSplit metrics={null} />);
+
+    expect(screen.getByTestId("lines-card-metrics")).toHaveTextContent("—");
+  });
+});

--- a/web_src/src/pages/factories/pages/LineListCard.tsx
+++ b/web_src/src/pages/factories/pages/LineListCard.tsx
@@ -14,7 +14,7 @@ import {
   formatSuccessRate,
   formatThroughput,
 } from "./lineListMetricsFormat";
-import type { LineListMetrics } from "./lineListMetricsMockData";
+import type { LineListMetrics } from "./lineListMetrics";
 
 export function LineListCard({
   line,

--- a/web_src/src/pages/factories/pages/LineListCard.tsx
+++ b/web_src/src/pages/factories/pages/LineListCard.tsx
@@ -1,0 +1,179 @@
+import type { FactoriesFactoryLine } from "@/api-client";
+import { cn } from "@/lib/utils";
+import { Workflow } from "lucide-react";
+import type { KeyboardEvent, ReactNode } from "react";
+import { useNavigate } from "react-router";
+import { humanizeLineName } from "../lib/humanizeLineName";
+import { factoryCardClassName } from "./factoryPageLayoutStyles";
+import {
+  formatCostDelta,
+  formatCostPerSuccess,
+  formatReworkDelta,
+  formatReworkRate,
+  formatSuccessDelta,
+  formatSuccessRate,
+  formatThroughput,
+} from "./lineListMetricsFormat";
+import type { LineListMetrics } from "./lineListMetricsMockData";
+
+export function LineListCard({
+  line,
+  href,
+  metrics,
+  description,
+}: {
+  line: FactoriesFactoryLine;
+  href: string;
+  metrics: LineListMetrics | null;
+  description?: string;
+}) {
+  return (
+    <CardShell href={href} testId={`lines-card-${line.id}`} className="px-4 py-4">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <Workflow className="size-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+          <span className="text-[15px] font-medium tracking-[-0.01em] text-foreground">
+            {humanizeLineName(line.name)}
+          </span>
+        </div>
+        {description ? <p className="mt-1 text-[12px] leading-snug text-muted-foreground">{description}</p> : null}
+      </div>
+      <LineListHeroSplit metrics={metrics} />
+    </CardShell>
+  );
+}
+
+/** Success sparkline on the left. Completion bars on the right. */
+export function LineListHeroSplit({ metrics }: { metrics: LineListMetrics | null }) {
+  return (
+    <div className="mt-4 flex items-end justify-between gap-6" data-testid="lines-card-metrics">
+      <div className="grid min-w-0 flex-1 grid-cols-2 gap-6">
+        <div className="min-w-0">
+          <p className="text-[11px] text-muted-foreground">Success rate</p>
+          <div className="mt-1 flex items-end gap-3">
+            <p className="text-[28px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+              {formatSuccessRate(metrics)}
+            </p>
+            <p className="pb-0.5 text-[12px] tabular-nums text-muted-foreground">{formatSuccessDelta(metrics)}</p>
+          </div>
+          <Sparkline values={metrics?.successTrendPct} className="mt-3 h-10 w-full text-foreground" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[11px] text-muted-foreground">Completions</p>
+          <p className="mt-1 text-[28px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+            {formatThroughput(metrics)}
+          </p>
+          <ThroughputBars values={metrics?.throughputTrend} className="mt-3 h-10 w-full text-muted-foreground" />
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-col gap-3 border-l border-border pl-5">
+        <MiniStat label="Rework" value={formatReworkRate(metrics)} hint={formatReworkDelta(metrics)} />
+        <MiniStat label="Cost" value={formatCostPerSuccess(metrics)} hint={formatCostDelta(metrics)} />
+      </div>
+    </div>
+  );
+}
+
+function MiniStat({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+      <p className="mt-0.5 text-[15px] font-medium tracking-[-0.02em] tabular-nums text-foreground">{value}</p>
+      <p className="text-[11px] tabular-nums text-muted-foreground">{hint}</p>
+    </div>
+  );
+}
+
+function Sparkline({ values, className }: { values: number[] | undefined; className?: string }) {
+  if (!values || values.length < 2) {
+    return <span className={cn("block", className)} aria-hidden />;
+  }
+
+  const width = 120;
+  const height = 32;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const points = values
+    .map((value, index) => {
+      const x = (index / (values.length - 1)) * width;
+      const y = height - ((value - min) / range) * (height - 2) - 1;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className={className} aria-hidden preserveAspectRatio="none">
+      <polyline fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" points={points} />
+    </svg>
+  );
+}
+
+function ThroughputBars({ values, className }: { values: number[] | undefined; className?: string }) {
+  if (!values || values.length === 0) {
+    return <span className={cn("block", className)} aria-hidden />;
+  }
+
+  const width = 120;
+  const height = 32;
+  const max = Math.max(...values, 1);
+  const gap = 1.2;
+  const barWidth = Math.max(2, width / values.length - gap);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className={className} aria-hidden preserveAspectRatio="none">
+      {values.map((value, index) => {
+        const barHeight = (value / max) * (height - 2);
+        const x = (index / values.length) * width;
+        return (
+          <rect
+            key={index}
+            x={x}
+            y={height - barHeight}
+            width={barWidth}
+            height={barHeight}
+            className="fill-current"
+            opacity={0.45}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function CardShell({
+  href,
+  testId,
+  className,
+  children,
+}: {
+  href: string;
+  testId: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={cn(
+        factoryCardClassName,
+        "group/line w-full cursor-pointer text-left transition-colors",
+        "hover:border-foreground/25 hover:bg-accent/30",
+        className,
+      )}
+      onClick={() => navigate(href)}
+      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          navigate(href);
+        }
+      }}
+      data-testid={testId}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/Lines.stories.tsx
+++ b/web_src/src/pages/factories/pages/Lines.stories.tsx
@@ -2,16 +2,16 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
-  defaultFactoriesFixture,
   emptyFactoriesFixture,
   fiveStepLineFactoriesFixture,
+  lineMetricsFactoriesFixture,
   PRIMARY_FACTORY_KEY,
   REFUND_FACTORY_LINES,
 } from "../__fixtures__/factoryPageResponses";
 import { LinesPage } from "./LinesPage";
 
 /**
- * Lines page: card list → line detail with phase board.
+ * Lines page: metric cards on the list, phase board on line detail.
  * FactoriesHarness supplies a factory-owned canvas so a run-card click opens
  * the automation run instead of Overview.
  */
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof meta>;
 const linesListPath = `workspaces/${PRIMARY_FACTORY_KEY}/lines`;
 
 export const Populated: Story = {
-  render: () => <FactoriesHarness pathSuffix={linesListPath} factoriesFixture={defaultFactoriesFixture} />,
+  render: () => <FactoriesHarness pathSuffix={linesListPath} factoriesFixture={lineMetricsFactoriesFixture} />,
 };
 
 export const EmptyFactory: Story = {
@@ -43,7 +43,7 @@ export const LineDetail: Story = {
     return (
       <FactoriesHarness
         pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}`}
-        factoriesFixture={defaultFactoriesFixture}
+        factoriesFixture={lineMetricsFactoriesFixture}
       />
     );
   },

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -3,7 +3,7 @@ import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { usePermissions } from "@/contexts/usePermissions";
-import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
+import { useFactoryLineMetrics, useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
@@ -46,7 +46,7 @@ import {
   factoryWorkOrdersBodyClassName,
 } from "./factoryPageLayoutStyles";
 import { LineListCard } from "./LineListCard";
-import { descriptionForLine, metricsForLine } from "./lineListMetricsMockData";
+import { descriptionForLine } from "./lineListMetricsMockData";
 import { PhaseGlyph } from "./linePhaseGlyph";
 
 const LIST_SUBTITLE = "Last 30 days. Success rate, completions per day, rework, and cost per merged work order.";
@@ -56,6 +56,7 @@ export function LinesPage() {
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const { lineId: routeLineId } = useParams<{ lineId: string }>();
   const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
+  const { data: metricsByLineId = {} } = useFactoryLineMetrics(organizationId, factoryId);
   const cardActions = useWorkOrderCardActions(organizationId, factoryId);
 
   const canUpdate = canAct("factories", "update");
@@ -143,7 +144,7 @@ export function LinesPage() {
                   <LineListCard
                     line={line}
                     href={factoryLineDetailPath(organizationId, factoryKey, line.id)}
-                    metrics={metricsForLine(line.id)}
+                    metrics={metricsByLineId[line.id] ?? null}
                     description={descriptionForLine(line.id)}
                   />
                 </li>

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -1,4 +1,4 @@
-import type { FactoriesFactoryLine, FactoriesWorkOrder, FactoryLineStep } from "@/api-client";
+import type { FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
@@ -8,7 +8,7 @@ import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { Layers, MoreHorizontal, Pencil, Plus, Workflow } from "lucide-react";
+import { Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
@@ -20,7 +20,6 @@ import {
   resolveColumnGlyph,
   type LinePhaseColumn,
   type LinePhaseRunCard,
-  type LinePhaseTick,
   type PhaseGlyphKind,
 } from "../lib/linePhaseRuns";
 import { buildWorkOrderListEntry } from "../lib/workOrderListModel";
@@ -46,7 +45,11 @@ import {
   factorySectionHeaderClassName,
   factoryWorkOrdersBodyClassName,
 } from "./factoryPageLayoutStyles";
+import { LineListCard } from "./LineListCard";
+import { descriptionForLine, metricsForLine } from "./lineListMetricsMockData";
 import { PhaseGlyph } from "./linePhaseGlyph";
+
+const LIST_SUBTITLE = "Last 30 days. Success rate, completions per day, rework, and cost per merged work order.";
 
 export function LinesPage() {
   const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
@@ -106,7 +109,7 @@ export function LinesPage() {
       <WorkspacePageHeader
         className={factorySectionHeaderClassName}
         title="Lines"
-        subtitle="Factory lines specialize how work moves through the workspace. Each phase is backed by a canvas that runs work orders."
+        subtitle={LIST_SUBTITLE}
         actions={
           <PermissionTooltip
             allowed={canUpdate || permissionsLoading}
@@ -130,18 +133,18 @@ export function LinesPage() {
             canUpdate={canUpdate || permissionsLoading}
           />
         ) : (
-          <ul className="flex flex-col gap-2" data-testid="lines-list">
+          <ul className="flex flex-col gap-4" data-testid="lines-list">
             {lines.map((line) => {
               if (!line.id) {
                 return null;
               }
-              const board = buildLinePhaseBoard(line, workOrders);
               return (
                 <li key={line.id}>
-                  <LineCard
+                  <LineListCard
                     line={line}
                     href={factoryLineDetailPath(organizationId, factoryKey, line.id)}
-                    ticks={board.map((column) => column.tick)}
+                    metrics={metricsForLine(line.id)}
+                    description={descriptionForLine(line.id)}
                   />
                 </li>
               );
@@ -218,67 +221,6 @@ function LineDetail({
         />
       )}
     </div>
-  );
-}
-
-function LineCard({ line, href, ticks }: { line: FactoriesFactoryLine; href: string; ticks: LinePhaseTick[] }) {
-  const navigate = useNavigate();
-  const steps = line.steps ?? [];
-  const description = formatLinePhaseDescription(steps);
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      className={cn(
-        "group/line w-full cursor-pointer rounded-lg border border-border bg-background px-3.5 py-3 text-left transition-colors",
-        "hover:border-foreground/25 hover:bg-accent/40",
-      )}
-      onClick={() => navigate(href)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          navigate(href);
-        }
-      }}
-      data-testid={`lines-card-${line.id}`}
-    >
-      <div className="flex items-start gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <Workflow className="size-3.5 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
-            <span className="text-[13px] font-medium tracking-[-0.01em] text-foreground">
-              {humanizeLineName(line.name)}
-            </span>
-          </div>
-          {description ? <p className="mt-1 text-[12px] leading-snug text-muted-foreground">{description}</p> : null}
-        </div>
-      </div>
-      {steps.length > 0 ? <PhaseStrip steps={steps} ticks={ticks} /> : null}
-    </div>
-  );
-}
-
-function PhaseStrip({ steps, ticks }: { steps: FactoryLineStep[]; ticks: LinePhaseTick[] }) {
-  return (
-    <ol className="mt-3.5 flex w-full items-start" aria-label="Phases">
-      {steps.map((step, index) => (
-        <li key={`${step.name}-${index}`} className="relative flex min-w-0 flex-1 flex-col items-center text-center">
-          {index < steps.length - 1 ? (
-            <span
-              className="absolute top-[7px] left-[calc(50%+8px)] right-[calc(-50%+8px)] h-px bg-border"
-              aria-hidden
-            />
-          ) : null}
-          <span className="relative z-[1] flex h-3.5 items-center justify-center">
-            <PhaseTickDot tick={ticks[index] ?? null} />
-          </span>
-          <span className="mt-1.5 max-w-full truncate px-1 text-[12px] leading-tight text-muted-foreground">
-            {step.name || `Phase ${index + 1}`}
-          </span>
-        </li>
-      ))}
-    </ol>
   );
 }
 
@@ -445,21 +387,6 @@ function PhaseRunCard({
     stepAppId,
   );
   return <WorkOrderCard {...workOrderCardContext} entry={entry} href={href} />;
-}
-
-function PhaseTickDot({ tick }: { tick: LinePhaseTick }) {
-  return (
-    <span
-      className={cn(
-        "size-2 shrink-0 rounded-full bg-[#c4c4c4]",
-        tick === "running" && "bg-[#3b82f6] animate-pulse",
-        tick === "waiting" && "bg-[#f59e0b]",
-        tick === "failed" && "bg-[#ef4444]",
-        tick === "queued" && "bg-[#a3a3a3]",
-      )}
-      aria-hidden
-    />
-  );
 }
 
 function EmptyLinesState({

--- a/web_src/src/pages/factories/pages/lineListMetrics.spec.ts
+++ b/web_src/src/pages/factories/pages/lineListMetrics.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { lineListMetricsFromApi } from "./lineListMetrics";
+
+describe("lineListMetricsFromApi", () => {
+  it("returns null when the API omitted metrics", () => {
+    expect(lineListMetricsFromApi(undefined)).toBeNull();
+  });
+
+  it("fills missing numeric fields with zero", () => {
+    expect(lineListMetricsFromApi({ successRatePct: 82, mergedCount: 41 })).toEqual({
+      successRatePct: 82,
+      mergedCount: 41,
+      totalClosedCount: 0,
+      reworkPerWorkOrder: 0,
+      costPerSuccessUsd: 0,
+      successTrendPct: [],
+      successDeltaPts: 0,
+      reworkDelta: 0,
+      costDeltaUsd: 0,
+      throughputPerDay: 0,
+      throughputTrend: [],
+    });
+  });
+});

--- a/web_src/src/pages/factories/pages/lineListMetrics.ts
+++ b/web_src/src/pages/factories/pages/lineListMetrics.ts
@@ -1,0 +1,38 @@
+import type { FactoriesFactoryLineMetrics } from "@/api-client";
+
+/**
+ * Line-list performance metrics for the last 30 days.
+ * Daily trend series cover the last 14 days, oldest first.
+ */
+export type LineListMetrics = {
+  successRatePct: number;
+  mergedCount: number;
+  totalClosedCount: number;
+  reworkPerWorkOrder: number;
+  costPerSuccessUsd: number;
+  successTrendPct: number[];
+  successDeltaPts: number;
+  reworkDelta: number;
+  costDeltaUsd: number;
+  throughputPerDay: number;
+  throughputTrend: number[];
+};
+
+export function lineListMetricsFromApi(metrics: FactoriesFactoryLineMetrics | undefined): LineListMetrics | null {
+  if (!metrics) {
+    return null;
+  }
+  return {
+    successRatePct: metrics.successRatePct ?? 0,
+    mergedCount: metrics.mergedCount ?? 0,
+    totalClosedCount: metrics.totalClosedCount ?? 0,
+    reworkPerWorkOrder: metrics.reworkPerWorkOrder ?? 0,
+    costPerSuccessUsd: metrics.costPerSuccessUsd ?? 0,
+    successTrendPct: metrics.successTrendPct ?? [],
+    successDeltaPts: metrics.successDeltaPts ?? 0,
+    reworkDelta: metrics.reworkDelta ?? 0,
+    costDeltaUsd: metrics.costDeltaUsd ?? 0,
+    throughputPerDay: metrics.throughputPerDay ?? 0,
+    throughputTrend: metrics.throughputTrend ?? [],
+  };
+}

--- a/web_src/src/pages/factories/pages/lineListMetricsFormat.spec.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsFormat.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatCostDelta,
+  formatCostPerSuccess,
+  formatReworkDelta,
+  formatReworkRate,
+  formatSuccessDelta,
+  formatSuccessRate,
+  formatThroughput,
+  LINE_LIST_METRICS_EMPTY,
+} from "./lineListMetricsFormat";
+import type { LineListMetrics } from "./lineListMetricsMockData";
+
+const sample: LineListMetrics = {
+  successRatePct: 82,
+  mergedCount: 41,
+  totalClosedCount: 50,
+  reworkPerWorkOrder: 1.4,
+  costPerSuccessUsd: 3.2,
+  successTrendPct: [70, 82],
+  successDeltaPts: 6,
+  reworkDelta: -0.2,
+  costDeltaUsd: -0.4,
+  throughputPerDay: 1.4,
+  throughputTrend: [2, 3, 4],
+};
+
+describe("lineListMetricsFormat", () => {
+  it("formats success rate, rework, cost, and completions", () => {
+    expect(formatSuccessRate(sample)).toBe("82%");
+    expect(formatReworkRate(sample)).toBe("1.4x");
+    expect(formatCostPerSuccess(sample)).toBe("$3.20");
+    expect(formatThroughput(sample)).toBe("1.4 per day");
+  });
+
+  it("formats change vs the prior window", () => {
+    expect(formatSuccessDelta(sample)).toBe("+6 pts");
+    expect(formatReworkDelta(sample)).toBe("−0.2x");
+    expect(formatCostDelta(sample)).toBe("−$0.40");
+  });
+
+  it("uses an em dash when the line has no closed work orders", () => {
+    expect(formatSuccessRate(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatReworkRate(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatCostPerSuccess(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatThroughput(null)).toBe(LINE_LIST_METRICS_EMPTY);
+    expect(formatSuccessDelta(null)).toBe(LINE_LIST_METRICS_EMPTY);
+  });
+
+  it("drops the decimal on whole rework counts", () => {
+    expect(formatReworkRate({ ...sample, reworkPerWorkOrder: 2 })).toBe("2x");
+  });
+});

--- a/web_src/src/pages/factories/pages/lineListMetricsFormat.spec.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsFormat.spec.ts
@@ -10,7 +10,7 @@ import {
   formatThroughput,
   LINE_LIST_METRICS_EMPTY,
 } from "./lineListMetricsFormat";
-import type { LineListMetrics } from "./lineListMetricsMockData";
+import type { LineListMetrics } from "./lineListMetrics";
 
 const sample: LineListMetrics = {
   successRatePct: 82,

--- a/web_src/src/pages/factories/pages/lineListMetricsFormat.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsFormat.ts
@@ -1,4 +1,4 @@
-import type { LineListMetrics } from "./lineListMetricsMockData";
+import type { LineListMetrics } from "./lineListMetrics";
 
 export const LINE_LIST_METRICS_EMPTY = "—";
 

--- a/web_src/src/pages/factories/pages/lineListMetricsFormat.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsFormat.ts
@@ -1,0 +1,78 @@
+import type { LineListMetrics } from "./lineListMetricsMockData";
+
+export const LINE_LIST_METRICS_EMPTY = "—";
+
+export function formatSuccessRate(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  return `${Math.round(metrics.successRatePct)}%`;
+}
+
+export function formatReworkRate(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  const value = metrics.reworkPerWorkOrder;
+  const rounded = value % 1 === 0 ? value.toFixed(0) : value.toFixed(1);
+  return `${rounded}x`;
+}
+
+export function formatCostPerSuccess(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  return `$${metrics.costPerSuccessUsd.toFixed(2)}`;
+}
+
+function signedNumber(value: number, digits: number): string {
+  const abs = Math.abs(value).toFixed(digits);
+  if (value > 0) {
+    return `+${abs}`;
+  }
+  if (value < 0) {
+    return `−${abs}`;
+  }
+  return digits === 0 ? "0" : (0).toFixed(digits);
+}
+
+/** Success-rate change vs the prior window. Example: `+6 pts`. */
+export function formatSuccessDelta(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  return `${signedNumber(metrics.successDeltaPts, 0)} pts`;
+}
+
+/** Rework change vs the prior window. Example: `−0.2x`. */
+export function formatReworkDelta(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  return `${signedNumber(metrics.reworkDelta, 1)}x`;
+}
+
+/** Cost change vs the prior window. Example: `−$0.40`. */
+export function formatCostDelta(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  const abs = `$${Math.abs(metrics.costDeltaUsd).toFixed(2)}`;
+  if (metrics.costDeltaUsd > 0) {
+    return `+${abs}`;
+  }
+  if (metrics.costDeltaUsd < 0) {
+    return `−${abs}`;
+  }
+  return abs;
+}
+
+/** Completions per day. Example: `1.4 per day`. */
+export function formatThroughput(metrics: LineListMetrics | null): string {
+  if (!metrics) {
+    return LINE_LIST_METRICS_EMPTY;
+  }
+  const value = metrics.throughputPerDay;
+  const rounded = value % 1 === 0 ? value.toFixed(0) : value.toFixed(1);
+  return `${rounded} per day`;
+}

--- a/web_src/src/pages/factories/pages/lineListMetricsMockData.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsMockData.ts
@@ -1,0 +1,121 @@
+import {
+  REFUND_LINE_FEATURE_ID,
+  REFUND_LINE_HOTFIX_ID,
+  REFUND_LINE_ONBOARDING_ID,
+  REFUND_LINE_PLAN_ID,
+} from "../__fixtures__/factoryPageResponses";
+
+/**
+ * Stand-in line-list metrics until an aggregation API exists.
+ *
+ * None of these fields exist on the factory-line API yet. This type is the
+ * contract a later endpoint should fill.
+ *
+ * Window: last 30 days.
+ */
+export type LineListMetrics = {
+  /**
+   * Share of closed work orders on this line whose pull request merged to main.
+   * Numerator is merged work orders. Denominator is closed work orders
+   * (merged + not merged). Omit when the line has no closed work orders.
+   */
+  successRatePct: number;
+  /** Merged-to-main work orders in the window (success-rate numerator). */
+  mergedCount: number;
+  /** Closed work orders in the window (success-rate denominator). */
+  totalClosedCount: number;
+  /**
+   * Average human interventions per work order: steering comments, tweaks,
+   * and re-dispatches. 1.0 means one intervention per work order.
+   */
+  reworkPerWorkOrder: number;
+  /**
+   * Tracked cost (model tokens + execution compute) divided by merged work
+   * orders. Failed and reworked runs raise this number.
+   */
+  costPerSuccessUsd: number;
+  /** Daily success-rate samples in the window, oldest first. 0–100. */
+  successTrendPct: number[];
+  /** Success-rate points vs the prior 30 days. Positive is better. */
+  successDeltaPts: number;
+  /** Rework change vs the prior 30 days. Negative is better. */
+  reworkDelta: number;
+  /** Cost change vs the prior 30 days, in USD. Negative is better. */
+  costDeltaUsd: number;
+  /**
+   * Merged work orders per day in the window. Completions, not closed
+   * work orders.
+   */
+  throughputPerDay: number;
+  /** Daily merged-work-order counts in the window, oldest first. */
+  throughputTrend: number[];
+};
+
+/** Per-line mock values keyed to the Refunds Factory fixture lines. */
+export const LINE_LIST_METRICS_BY_ID: Record<string, LineListMetrics | null> = {
+  [REFUND_LINE_PLAN_ID]: {
+    successRatePct: 82,
+    mergedCount: 41,
+    totalClosedCount: 50,
+    reworkPerWorkOrder: 1.4,
+    costPerSuccessUsd: 3.2,
+    successTrendPct: [68, 70, 69, 72, 74, 73, 76, 77, 78, 79, 80, 81, 80, 82],
+    successDeltaPts: 6,
+    reworkDelta: -0.2,
+    costDeltaUsd: -0.4,
+    throughputPerDay: 1.4,
+    throughputTrend: [2, 3, 2, 4, 3, 2, 5, 3, 4, 3, 4, 2, 3, 4],
+  },
+  [REFUND_LINE_HOTFIX_ID]: {
+    successRatePct: 54,
+    mergedCount: 13,
+    totalClosedCount: 24,
+    reworkPerWorkOrder: 3.8,
+    costPerSuccessUsd: 11.45,
+    successTrendPct: [62, 65, 60, 58, 61, 55, 59, 57, 56, 54, 58, 52, 55, 54],
+    successDeltaPts: -8,
+    reworkDelta: 0.9,
+    costDeltaUsd: 2.1,
+    throughputPerDay: 0.4,
+    throughputTrend: [1, 0, 2, 1, 0, 1, 0, 2, 1, 0, 1, 1, 0, 2],
+  },
+  [REFUND_LINE_ONBOARDING_ID]: null,
+  [REFUND_LINE_FEATURE_ID]: {
+    successRatePct: 71,
+    mergedCount: 22,
+    totalClosedCount: 31,
+    reworkPerWorkOrder: 2.1,
+    costPerSuccessUsd: 5.4,
+    successTrendPct: [64, 65, 66, 68, 67, 69, 70, 68, 70, 71, 69, 72, 70, 71],
+    successDeltaPts: 3,
+    reworkDelta: 0.1,
+    costDeltaUsd: 0.2,
+    throughputPerDay: 0.7,
+    throughputTrend: [1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2],
+  },
+};
+
+/**
+ * Purpose copy for each line. The API has no description field. This copy
+ * says when to use the line.
+ */
+export const LINE_LIST_DESCRIPTION_BY_ID: Record<string, string> = {
+  [REFUND_LINE_PLAN_ID]: "Default path for planned product work that needs review before merge.",
+  [REFUND_LINE_HOTFIX_ID]: "Production-incident path for urgent fixes.",
+  [REFUND_LINE_ONBOARDING_ID]: "First-run path for a new workspace.",
+  [REFUND_LINE_FEATURE_ID]: "Feature path that includes a pull request and a CI loop.",
+};
+
+export function metricsForLine(lineId: string | undefined): LineListMetrics | null {
+  if (!lineId) {
+    return null;
+  }
+  return LINE_LIST_METRICS_BY_ID[lineId] ?? null;
+}
+
+export function descriptionForLine(lineId: string | undefined): string | undefined {
+  if (!lineId) {
+    return undefined;
+  }
+  return LINE_LIST_DESCRIPTION_BY_ID[lineId];
+}

--- a/web_src/src/pages/factories/pages/lineListMetricsMockData.ts
+++ b/web_src/src/pages/factories/pages/lineListMetricsMockData.ts
@@ -4,54 +4,11 @@ import {
   REFUND_LINE_ONBOARDING_ID,
   REFUND_LINE_PLAN_ID,
 } from "../__fixtures__/factoryPageResponses";
+import type { LineListMetrics } from "./lineListMetrics";
 
 /**
- * Stand-in line-list metrics until an aggregation API exists.
- *
- * None of these fields exist on the factory-line API yet. This type is the
- * contract a later endpoint should fill.
- *
- * Window: last 30 days.
+ * Per-line mock values keyed to the Refunds Factory fixture lines.
  */
-export type LineListMetrics = {
-  /**
-   * Share of closed work orders on this line whose pull request merged to main.
-   * Numerator is merged work orders. Denominator is closed work orders
-   * (merged + not merged). Omit when the line has no closed work orders.
-   */
-  successRatePct: number;
-  /** Merged-to-main work orders in the window (success-rate numerator). */
-  mergedCount: number;
-  /** Closed work orders in the window (success-rate denominator). */
-  totalClosedCount: number;
-  /**
-   * Average human interventions per work order: steering comments, tweaks,
-   * and re-dispatches. 1.0 means one intervention per work order.
-   */
-  reworkPerWorkOrder: number;
-  /**
-   * Tracked cost (model tokens + execution compute) divided by merged work
-   * orders. Failed and reworked runs raise this number.
-   */
-  costPerSuccessUsd: number;
-  /** Daily success-rate samples in the window, oldest first. 0–100. */
-  successTrendPct: number[];
-  /** Success-rate points vs the prior 30 days. Positive is better. */
-  successDeltaPts: number;
-  /** Rework change vs the prior 30 days. Negative is better. */
-  reworkDelta: number;
-  /** Cost change vs the prior 30 days, in USD. Negative is better. */
-  costDeltaUsd: number;
-  /**
-   * Merged work orders per day in the window. Completions, not closed
-   * work orders.
-   */
-  throughputPerDay: number;
-  /** Daily merged-work-order counts in the window, oldest first. */
-  throughputTrend: number[];
-};
-
-/** Per-line mock values keyed to the Refunds Factory fixture lines. */
 export const LINE_LIST_METRICS_BY_ID: Record<string, LineListMetrics | null> = {
   [REFUND_LINE_PLAN_ID]: {
     successRatePct: 82,
@@ -105,13 +62,6 @@ export const LINE_LIST_DESCRIPTION_BY_ID: Record<string, string> = {
   [REFUND_LINE_ONBOARDING_ID]: "First-run path for a new workspace.",
   [REFUND_LINE_FEATURE_ID]: "Feature path that includes a pull request and a CI loop.",
 };
-
-export function metricsForLine(lineId: string | undefined): LineListMetrics | null {
-  if (!lineId) {
-    return null;
-  }
-  return LINE_LIST_METRICS_BY_ID[lineId] ?? null;
-}
 
 export function descriptionForLine(lineId: string | undefined): string | undefined {
   if (!lineId) {


### PR DESCRIPTION
## Summary

The Lines list used stand-in numbers. Operators need real success, completions, rework, and cost for each line.

This change adds a factory read endpoint for the last 30 days. The list loads those numbers for each line.

Lines with no closed work orders in the window show dashes. Close time comes from the status event, not updated_at.

Cost per success reads execution `cost_cents`. Those columns stay empty until a later change writes them.

Related: #6765 has the list layout with fixture numbers. #6769 is a separate aggregation with different metric rules.

## Test plan

- [ ] Open the Lines list in a factory with closed work orders.
- [ ] Confirm each line card shows success rate, completions, rework, and cost.
- [ ] Confirm a line with no closed work orders in 30 days shows dashes.
- [ ] Dispatch, comment on, or close a work order and confirm the metrics refresh.
- [ ] Open Storybook Lines stories and confirm fixture metrics still render.


Made with [Cursor](https://cursor.com)