### PR TITLE
fix(sns): cache SNS signing certificate instead of re-fetching every webhook call

### DIFF
--- a/pkg/integrations/aws/sns/on_topic_message.go
+++ b/pkg/integrations/aws/sns/on_topic_message.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -297,9 +298,6 @@ func (t *OnTopicMessage) verifyMessageSignature(ctx core.WebhookRequestContext, 
 		return fmt.Errorf("failed to build string to sign: %w", err)
 	}
 
-	//
-	// TODO: it would be good to not fetch the certificate every time.
-	//
 	cert, err := t.fetchSigningCertificate(ctx, message.SigningCertURL)
 	if err != nil {
 		return fmt.Errorf("failed to fetch signing certificate: %w", err)
@@ -380,6 +378,41 @@ func (t *OnTopicMessage) getSignableFields(message SubscriptionMessage) ([]Signa
 	}
 }
 
+var signingCertCache sync.Map
+
+const signingCertificateCacheTTL = 24 * time.Hour
+
+type signingCertCacheEntry struct {
+	cert      *x509.Certificate
+	expiresAt time.Time
+}
+
+func getCachedSigningCertificate(cacheKey string) (*x509.Certificate, bool) {
+	value, ok := signingCertCache.Load(cacheKey)
+	if !ok {
+		return nil, false
+	}
+
+	entry := value.(signingCertCacheEntry)
+
+	now := time.Now()
+	if now.After(entry.expiresAt) || now.Before(entry.cert.NotBefore) || now.After(entry.cert.NotAfter) {
+		signingCertCache.Delete(cacheKey)
+		return nil, false
+	}
+
+	return entry.cert, true
+}
+
+func cacheSigningCertificate(cacheKey string, cert *x509.Certificate) {
+	expiresAt := time.Now().Add(signingCertificateCacheTTL)
+	if cert.NotAfter.Before(expiresAt) {
+		expiresAt = cert.NotAfter
+	}
+
+	signingCertCache.Store(cacheKey, signingCertCacheEntry{cert: cert, expiresAt: expiresAt})
+}
+
 func (t *OnTopicMessage) fetchSigningCertificate(ctx core.WebhookRequestContext, signingCertURL string) (*x509.Certificate, error) {
 	parsedURL, err := url.Parse(signingCertURL)
 	if err != nil {
@@ -403,7 +436,12 @@ func (t *OnTopicMessage) fetchSigningCertificate(ctx core.WebhookRequestContext,
 		return nil, fmt.Errorf("SigningCertURL host must be an AWS SNS domain")
 	}
 
-	req, err := http.NewRequest(http.MethodGet, parsedURL.String(), nil)
+	cacheKey := parsedURL.String()
+	if cert, ok := getCachedSigningCertificate(cacheKey); ok {
+		return cert, nil
+	}
+
+	req, err := http.NewRequest(http.MethodGet, cacheKey, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create certificate request: %w", err)
 	}
@@ -453,6 +491,8 @@ func (t *OnTopicMessage) fetchSigningCertificate(ctx core.WebhookRequestContext,
 	if now.Before(cert.NotBefore) || now.After(cert.NotAfter) {
 		return nil, fmt.Errorf("signing certificate is not currently valid")
 	}
+
+	cacheSigningCertificate(cacheKey, cert)
 
 	return cert, nil
 }

--- a/pkg/integrations/aws/sns/on_topic_message_test.go
+++ b/pkg/integrations/aws/sns/on_topic_message_test.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -119,6 +120,7 @@ func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
 	trigger := &OnTopicMessage{}
 
 	t.Run("notification for configured topic -> emits event", func(t *testing.T) {
+		resetSigningCertCache(t)
 		privateKey, certPEM := createTestSigningCert(t)
 		message := signTestMessage(t, trigger, SubscriptionMessage{
 			Type:             "Notification",
@@ -167,6 +169,7 @@ func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
 	})
 
 	t.Run("subscription confirmation for different topic -> ignored", func(t *testing.T) {
+		resetSigningCertCache(t)
 		privateKey, certPEM := createTestSigningCert(t)
 		message := signTestMessage(t, trigger, SubscriptionMessage{
 			Type:             "SubscriptionConfirmation",
@@ -206,6 +209,7 @@ func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
 	})
 
 	t.Run("confirmation for configured topic -> confirms subscription", func(t *testing.T) {
+		resetSigningCertCache(t)
 		privateKey, certPEM := createTestSigningCert(t)
 		message := signTestMessage(t, trigger, SubscriptionMessage{
 			Type:             "SubscriptionConfirmation",
@@ -270,6 +274,86 @@ func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
 }
 
 const testSigningCertURL = "https://sns.us-east-1.amazonaws.com/test.pem"
+
+func resetSigningCertCache(t *testing.T) {
+	t.Helper()
+	signingCertCache = sync.Map{}
+}
+
+func Test__OnTopicMessage__fetchSigningCertificate__Caching(t *testing.T) {
+	trigger := &OnTopicMessage{}
+
+	t.Run("second fetch for the same URL is served from cache", func(t *testing.T) {
+		resetSigningCertCache(t)
+		_, certPEM := createTestSigningCert(t)
+
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(certPEM))},
+			},
+		}
+		ctx := core.WebhookRequestContext{HTTP: httpContext, Logger: log.NewEntry(log.New())}
+
+		cert1, err := trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 1)
+
+		cert2, err := trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+		require.NoError(t, err)
+		assert.Same(t, cert1, cert2)
+		assert.Len(t, httpContext.Requests, 1, "second fetch should not issue a new HTTP request")
+	})
+
+	t.Run("expired cache entry triggers a re-fetch", func(t *testing.T) {
+		resetSigningCertCache(t)
+		_, certPEM1 := createTestSigningCert(t)
+		_, certPEM2 := createTestSigningCert(t)
+
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(certPEM1))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(certPEM2))},
+			},
+		}
+		ctx := core.WebhookRequestContext{HTTP: httpContext, Logger: log.NewEntry(log.New())}
+
+		cert1, err := trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+		require.NoError(t, err)
+
+		// Force the cached entry to look expired.
+		signingCertCache.Store(testSigningCertURL, signingCertCacheEntry{
+			cert:      cert1,
+			expiresAt: time.Now().Add(-time.Second),
+		})
+
+		cert2, err := trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+		require.NoError(t, err)
+		assert.NotSame(t, cert1, cert2)
+		assert.Len(t, httpContext.Requests, 2, "expired cache entry should trigger a new HTTP request")
+	})
+
+	t.Run("different URLs are cached independently", func(t *testing.T) {
+		resetSigningCertCache(t)
+		_, certPEM1 := createTestSigningCert(t)
+		_, certPEM2 := createTestSigningCert(t)
+
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(certPEM1))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(certPEM2))},
+			},
+		}
+		ctx := core.WebhookRequestContext{HTTP: httpContext, Logger: log.NewEntry(log.New())}
+
+		_, err := trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+		require.NoError(t, err)
+
+		_, err = trigger.fetchSigningCertificate(ctx, "https://sns.us-west-2.amazonaws.com/test.pem")
+		require.NoError(t, err)
+
+		assert.Len(t, httpContext.Requests, 2)
+	})
+}
 
 func createTestSigningCert(t *testing.T) (*rsa.PrivateKey, []byte) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- Every incoming SNS webhook message re-fetched and re-parsed the signing certificate from `SigningCertURL`, even though AWS reuses the same certificate for a long time (there was already a `TODO` noting this).
- Add an in-memory cache in `pkg/integrations/aws/sns/on_topic_message.go`, keyed by the certificate URL (which is already validated as a genuine AWS SNS domain before use), bounded by a 24h TTL and the certificate's own `NotAfter`. Cache hits are re-checked against `NotBefore`/`NotAfter` so an expired certificate is never served stale.
- The cache is a package-level `sync.Map` rather than a field on `OnTopicMessage`, since a fresh `OnTopicMessage{}` is constructed on every trigger lookup (`Registry.GetIntegrationTrigger`) — a struct field would never actually persist across requests. `sync.Map` is safe for the concurrent webhook requests that share it within a process.
- Scope note: caching is per-process, so with multiple server replicas each one builds its own cache independently, and a restart clears it. That matches the intent of the original TODO (avoid re-fetching on every call) rather than a cluster-wide shared cache.

## Test plan
- [x] `go test ./pkg/integrations/aws/sns/...` — existing tests pass, plus 3 new tests covering: cache hit avoids a second HTTP fetch, an expired cache entry triggers a re-fetch, and different certificate URLs are cached independently.
- [x] `go vet ./pkg/integrations/aws/sns/...` and `gofmt -l` clean.
- [x] `go build ./...` for the full repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)