### PR TITLE
feat: Provision PR Closure during workspace setup

### DIFF
--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -12,7 +12,7 @@ import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast } from "@/lib/toast";
 import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
 import { useIntegrationConnectDialog } from "@/pages/home/useIntegrationConnectDialog";
-import { ONBOARDING_LINE_APPS } from "@/pages/home/factories";
+import { ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "@/pages/home/factories";
 import { useInstallFactory, type InstallFactoryInput } from "@/pages/home/useInstallFactory";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
@@ -139,6 +139,34 @@ function findProvisionedLine(factory: FactoriesFactory | null): FactoriesFactory
   );
 }
 
+type InstallOnboardingApp = (
+  input: InstallFactoryInput,
+) => Promise<{ canvasId: string; canvasName: string } | undefined>;
+
+async function installOnboardingApp(args: {
+  factoryId: string;
+  appFactoryId: string;
+  selections: IntegrationSelections;
+  appRepository: string;
+  backlogRepository: string;
+  installFactory: InstallOnboardingApp;
+}): Promise<{ canvasId: string; canvasName: string }> {
+  const installed = await args.installFactory({
+    factoryId: args.appFactoryId,
+    workspaceFactoryId: args.factoryId,
+    integrations: args.selections,
+    installParams: {
+      appRepository: args.appRepository,
+      backlogRepository: args.backlogRepository,
+    },
+    startingTaskPrompt: "",
+    navigateOnComplete: false,
+    startInitialRun: false,
+  });
+  if (!installed?.canvasId) throw new Error(`Failed to create the ${args.appFactoryId} app`);
+  return installed;
+}
+
 // Install each bundled app in order and return the line steps that call them.
 // installFactory clears its pending-canvas ref after each success, so the
 // sequential calls create distinct canvases.
@@ -147,23 +175,18 @@ async function provisionLineApps(args: {
   selections: IntegrationSelections;
   appRepository: string;
   backlogRepository: string;
-  installFactory: (input: InstallFactoryInput) => Promise<{ canvasId: string; canvasName: string } | undefined>;
+  installFactory: InstallOnboardingApp;
 }): Promise<FactoryLineStep[]> {
   const steps: FactoryLineStep[] = [];
   for (const app of ONBOARDING_LINE_APPS) {
-    const installed = await args.installFactory({
-      factoryId: app.factoryId,
-      workspaceFactoryId: args.factoryId,
-      integrations: args.selections,
-      installParams: {
-        appRepository: args.appRepository,
-        backlogRepository: args.backlogRepository,
-      },
-      startingTaskPrompt: "",
-      navigateOnComplete: false,
-      startInitialRun: false,
+    const installed = await installOnboardingApp({
+      factoryId: args.factoryId,
+      appFactoryId: app.factoryId,
+      selections: args.selections,
+      appRepository: args.appRepository,
+      backlogRepository: args.backlogRepository,
+      installFactory: args.installFactory,
     });
-    if (!installed?.canvasId) throw new Error(`Failed to create the ${app.factoryId} app`);
     steps.push({
       name: app.lineStepName,
       type: "runApp",
@@ -171,6 +194,28 @@ async function provisionLineApps(args: {
     });
   }
   return steps;
+}
+
+// Event apps listen for GitHub events and are not factory line steps. Install
+// them even when the line already exists, so a retry after a failed finish
+// still creates PR Closure.
+async function provisionEventApps(args: {
+  factoryId: string;
+  selections: IntegrationSelections;
+  appRepository: string;
+  backlogRepository: string;
+  installFactory: InstallOnboardingApp;
+}): Promise<void> {
+  for (const appFactoryId of ONBOARDING_EVENT_APPS) {
+    await installOnboardingApp({
+      factoryId: args.factoryId,
+      appFactoryId,
+      selections: args.selections,
+      appRepository: args.appRepository,
+      backlogRepository: args.backlogRepository,
+      installFactory: args.installFactory,
+    });
+  }
 }
 
 interface ProvisionedLine {
@@ -185,7 +230,7 @@ async function provisionLine(args: {
   selections: IntegrationSelections;
   appRepository: string;
   backlogRepository: string;
-  installFactory: (input: InstallFactoryInput) => Promise<{ canvasId: string; canvasName: string } | undefined>;
+  installFactory: InstallOnboardingApp;
   createLine: (input: { name: string; steps: FactoryLineStep[] }) => Promise<FactoriesFactoryLine>;
   updateOnboarding: UpdateOnboarding;
 }): Promise<ProvisionedLine> {
@@ -252,7 +297,7 @@ function useFinishOnboarding(args: {
   selections: IntegrationSelections;
   setSaving: (saving: boolean) => void;
   updateOnboarding: UpdateOnboarding;
-  installFactory: (input: InstallFactoryInput) => Promise<{ canvasId: string; canvasName: string } | undefined>;
+  installFactory: InstallOnboardingApp;
   createLine: (input: { name: string; steps: FactoryLineStep[] }) => Promise<FactoriesFactoryLine>;
 }) {
   const navigate = useNavigate();
@@ -286,6 +331,13 @@ function useFinishOnboarding(args: {
         installFactory: args.installFactory,
         createLine: args.createLine,
         updateOnboarding: args.updateOnboarding,
+      });
+      await provisionEventApps({
+        factoryId: args.factoryId,
+        selections: args.selections,
+        appRepository,
+        backlogRepository,
+        installFactory: args.installFactory,
       });
       await args.updateOnboarding({
         provisionedAppId: primaryAppId,

--- a/web_src/src/pages/home/factories/index.ts
+++ b/web_src/src/pages/home/factories/index.ts
@@ -6,9 +6,11 @@ import factoryParams from "./software-factory/params.json";
 import softwareFactoryCanvasYaml from "./software-factory/canvas.yaml?raw";
 import softwareFactoryConsoleYaml from "./software-factory/console.yaml?raw";
 import lineAppConsoleYaml from "./line-apps/console.yaml?raw";
+import eventAppConsoleYaml from "./line-apps/event-app.console.yaml?raw";
 import planningCanvasYaml from "./line-apps/planning.canvas.yaml?raw";
 import implementationCanvasYaml from "./line-apps/implementation.canvas.yaml?raw";
 import prCanvasYaml from "./line-apps/pr.canvas.yaml?raw";
+import prClosureCanvasYaml from "./line-apps/pr-closure.canvas.yaml?raw";
 
 export type { FactoryDefinition, FactoryStartingTask, FactoryRunDefinition } from "./types";
 export {
@@ -46,21 +48,24 @@ const LINE_APP_COMPONENT_INTEGRATIONS: Record<string, string> = {
   "github.createPullRequest": "github",
 };
 
-function buildLineApp(args: {
+function buildOnboardingApp(args: {
   id: string;
   title: string;
   description: string;
   canvasYaml: string;
+  consoleYaml: string;
+  integrations: string[];
+  componentIntegrations: Record<string, string>;
   entrypointNodeId: string;
 }): FactoryDefinition {
   return {
     id: args.id,
     title: args.title,
     description: args.description,
-    integrations: ["github", "claude"],
-    componentIntegrations: LINE_APP_COMPONENT_INTEGRATIONS,
+    integrations: args.integrations,
+    componentIntegrations: args.componentIntegrations,
     startingTasks: [],
-    // Onboarding never triggers the entrypoint directly; the factory line does.
+    // Onboarding never triggers the entrypoint directly.
     run: {
       nodeId: args.entrypointNodeId,
       hookName: "run",
@@ -70,8 +75,46 @@ function buildLineApp(args: {
     source: { type: "bundled" },
     installParams: factoryParams.install_params as InstallParam[],
     canvasYaml: args.canvasYaml,
-    consoleYaml: lineAppConsoleYaml,
+    consoleYaml: args.consoleYaml,
   };
+}
+
+function buildLineApp(args: {
+  id: string;
+  title: string;
+  description: string;
+  canvasYaml: string;
+  entrypointNodeId: string;
+}): FactoryDefinition {
+  return buildOnboardingApp({
+    ...args,
+    integrations: ["github", "claude"],
+    componentIntegrations: LINE_APP_COMPONENT_INTEGRATIONS,
+    consoleYaml: lineAppConsoleYaml,
+  });
+}
+
+const EVENT_APP_COMPONENT_INTEGRATIONS: Record<string, string> = {
+  "github.onPullRequest": "github",
+};
+
+function buildEventApp(args: {
+  id: string;
+  title: string;
+  description: string;
+  canvasYaml: string;
+  triggerNodeId: string;
+}): FactoryDefinition {
+  return buildOnboardingApp({
+    id: args.id,
+    title: args.title,
+    description: args.description,
+    canvasYaml: args.canvasYaml,
+    consoleYaml: eventAppConsoleYaml,
+    integrations: ["github"],
+    componentIntegrations: EVENT_APP_COMPONENT_INTEGRATIONS,
+    entrypointNodeId: args.triggerNodeId,
+  });
 }
 
 /**
@@ -89,6 +132,10 @@ export const ONBOARDING_LINE_APPS: OnboardingLineApp[] = [
   { factoryId: "line-implementation", entrypointNodeId: "onrun-implement", lineStepName: "Implement" },
   { factoryId: "line-pr", entrypointNodeId: "onrun-open-pr", lineStepName: "Open Pull Request" },
 ];
+
+// Event-driven factory apps provisioned during onboarding. These listen for
+// GitHub events; they are not factory line steps.
+export const ONBOARDING_EVENT_APPS = ["pr-closure"] as const;
 
 const FACTORY_BY_ID: Record<string, FactoryDefinition> = {
   "software-factory": buildSoftwareFactory(),
@@ -112,6 +159,13 @@ const FACTORY_BY_ID: Record<string, FactoryDefinition> = {
     description: "Generate a pull request title and body, then open a draft PR.",
     canvasYaml: prCanvasYaml,
     entrypointNodeId: "onrun-open-pr",
+  }),
+  "pr-closure": buildEventApp({
+    id: "pr-closure",
+    title: "PR Closure",
+    description: "Close the work order when the attached pull request merges or is closed without a merge.",
+    canvasYaml: prClosureCanvasYaml,
+    triggerNodeId: "on-pr-closed",
   }),
 };
 

--- a/web_src/src/pages/home/factories/line-apps/event-app.console.yaml
+++ b/web_src/src/pages/home/factories/line-apps/event-app.console.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Console
+metadata:
+  name: Factory Event App
+  canvasId: __FACTORY_CANVAS_ID__
+spec:
+  panels:
+    - id: about
+      type: markdown
+      content:
+        title: About this app
+        body: |
+          > [!SECTION:setup] Pull request events
+          >
+          > This app is not a factory line step. It listens for closed pull
+          > requests on the app repository.
+          >
+          > When a pull request is attached to a work order:
+          > - A merge closes the work order as completed.
+          > - A close without a merge closes the work order as rejected.
+  layout:
+    - i: about
+      x: 0
+      'y': 0
+      w: 12
+      h: 6
+      minW: 3
+      minH: 5

--- a/web_src/src/pages/home/factories/line-apps/pr-closure.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/pr-closure.canvas.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Canvas
+metadata:
+  name: PR Closure
+  description: Close the work order when the attached pull request merges or is closed without a merge.
+spec:
+  edges:
+    - channel: default
+      sourceId: on-pr-closed
+      targetId: find-work-order
+    - channel: found
+      sourceId: find-work-order
+      targetId: is-pr-merged
+    - channel: "true"
+      sourceId: is-pr-merged
+      targetId: complete-work-order
+    - channel: "false"
+      sourceId: is-pr-merged
+      targetId: reject-work-order
+  nodes:
+    - id: on-pr-closed
+      name: On Pull Request Closed
+      type: TYPE_TRIGGER
+      component: github.onPullRequest
+      configuration:
+        actions:
+          - closed
+        repository: '{{ install_params.appRepository }}'
+      position:
+        x: 1272
+        'y': 72
+      isCollapsed: true
+    - id: find-work-order
+      name: Find Work Order
+      type: TYPE_ACTION
+      component: findWorkOrder
+      configuration:
+        artifactKey: '{{ root().data.pull_request.html_url }}'
+        by: artifactKey
+      position:
+        x: 1272
+        'y': 432
+      isCollapsed: true
+    - id: is-pr-merged
+      name: PR Merged?
+      type: TYPE_ACTION
+      component: if
+      configuration:
+        expression: root().data.pull_request.merged == true
+      position:
+        x: 1202
+        'y': 792
+      isCollapsed: true
+    - id: complete-work-order
+      name: Complete Work Order
+      type: TYPE_ACTION
+      component: updateWorkOrderStatus
+      configuration:
+        orderId: '{{ $["Find Work Order"].data.workOrder.id }}'
+        result: completed
+        status: closed
+      position:
+        x: 1132
+        'y': 1152
+      isCollapsed: true
+    - id: reject-work-order
+      name: Reject Work Order
+      type: TYPE_ACTION
+      component: updateWorkOrderStatus
+      configuration:
+        orderId: '{{ $["Find Work Order"].data.workOrder.id }}'
+        result: rejected
+        status: closed
+      position:
+        x: 1600
+        'y': 1152
+      isCollapsed: true

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getFactoryDefinition, ONBOARDING_LINE_APPS } from "./index";
+import { getFactoryDefinition, ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "./index";
 import { FACTORY_CANVAS_ID_PLACEHOLDER, materializeFactoryCanvas } from "./materializeFactoryTemplate";
 
-function materializeLineApp(factoryId: string) {
+function materializeOnboardingApp(factoryId: string) {
   return materializeFactoryCanvas({
     definition: getFactoryDefinition(factoryId),
     canvasName: "My Planning",
@@ -32,14 +32,14 @@ describe("setup factory line apps", () => {
 
   it("exposes a single onRun entrypoint per app that the line calls", () => {
     for (const app of ONBOARDING_LINE_APPS) {
-      const canvasYaml = materializeLineApp(app.factoryId);
+      const canvasYaml = materializeOnboardingApp(app.factoryId);
       expect(canvasYaml).toMatch(new RegExp(`id: ${app.entrypointNodeId}[\\s\\S]*component: onRun`));
     }
   });
 
   it("materializes repositories and integration wiring, leaving no template placeholders", () => {
     for (const app of ONBOARDING_LINE_APPS) {
-      const canvasYaml = materializeLineApp(app.factoryId);
+      const canvasYaml = materializeOnboardingApp(app.factoryId);
       expect(canvasYaml).toContain("name: acme-claude");
       expect(canvasYaml).toContain("name: acme-github");
       expect(canvasYaml).not.toContain("{{ install_params.");
@@ -51,14 +51,38 @@ describe("setup factory line apps", () => {
   });
 
   it("routes code work to the app repository", () => {
-    const planning = materializeLineApp("line-planning");
+    const planning = materializeOnboardingApp("line-planning");
     expect(planning).toContain("acme/app");
     expect(planning).toContain("acme/backlog");
 
-    const implementation = materializeLineApp("line-implementation");
+    const implementation = materializeOnboardingApp("line-implementation");
     expect(implementation).toContain("acme/app");
 
-    const pr = materializeLineApp("line-pr");
+    const pr = materializeOnboardingApp("line-pr");
     expect(pr).toMatch(/component: github\.createPullRequest[\s\S]*repository: acme\/app/);
+  });
+});
+
+describe("setup factory event apps", () => {
+  it("provisions PR Closure outside the factory line", () => {
+    expect(ONBOARDING_EVENT_APPS).toEqual(["pr-closure"]);
+    expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).not.toContain("pr-closure");
+  });
+
+  it("closes the work order when a factory pull request is closed", () => {
+    const canvasYaml = materializeOnboardingApp("pr-closure");
+
+    expect(canvasYaml).toMatch(/component: github\.onPullRequest[\s\S]*actions:[\s\S]*- closed/);
+    expect(canvasYaml).toMatch(/component: github\.onPullRequest[\s\S]*repository: acme\/app/);
+    expect(canvasYaml).toContain("component: findWorkOrder");
+    expect(canvasYaml).toContain("by: artifactKey");
+    expect(canvasYaml).toContain("result: completed");
+    expect(canvasYaml).toContain("result: rejected");
+    expect(canvasYaml).toContain("id: int-1");
+    expect(canvasYaml).toContain("name: acme-github");
+    expect(canvasYaml).not.toContain("{{ install_params.");
+    expect(canvasYaml).not.toContain(FACTORY_CANVAS_ID_PLACEHOLDER);
+    expect(canvasYaml).not.toContain("superplanehq");
+    expect(canvasYaml).not.toMatch(/component: onRun/);
   });
 });


### PR DESCRIPTION
## Summary

Workspace setup created Planning, Implementation, and PR Creation, but not the app that closes the work order when the pull request closes. A merged or abandoned pull request then left the work order open.

This change provisions a factory-owned PR Closure app during Finish setup. The app listens for closed pull requests on the app repository. If the pull request merged, SuperPlane closes the work order as completed. If it closed without a merge, SuperPlane closes the work order as rejected.

The app is not a factory line step. It starts from a GitHub pull request event, not from onRun.

Workspaces that already finished setup do not get this app automatically.

## Test plan

- [ ] Create a new factory workspace and finish setup with GitHub and Claude connected.
- [ ] Confirm SuperPlane creates Planning, Implementation, PR Creation, and PR Closure apps.
- [ ] Confirm the Software delivery line still has three steps only.
- [ ] Merge a factory pull request and confirm the work order closes as completed.
- [ ] Close a factory pull request without a merge and confirm the work order closes as rejected.
- [ ] Confirm a pull request with no work order does not fail the PR Closure run.


Made with [Cursor](https://cursor.com)