### PR TITLE
feat: Link Opened PRs Back to Work Orders

### DIFF
--- a/docs/design/factory.md
+++ b/docs/design/factory.md
@@ -50,6 +50,11 @@ Expressions on a dispatched run should prefer `order()` over
 `root().data.work_order`. `order()` resolves the live work order for the
 current run (`id`, `title`, `description`, `factory_id`, `state`, `result`,
 `source`) and returns `nil` when the run is not attached to a work order.
+`order().url` is the work order permalink
+(`{BASE_URL}/{orgId}/workspaces/{factoryKey}/work-order/{number}`), resolved
+lazily only when the expression references it, because the factory that owns
+the order has to be loaded for its key. Use it to link back from anything an
+automation creates, e.g. a pull request description.
 `order().artifacts` is a list field loaded lazily only when the expression
 references it (e.g. `none(order().artifacts, {#.type == "pr"})`).
 `order().comments` is likewise a list field loaded lazily only when the

--- a/pkg/configuration/expressionvalidation/order_references.go
+++ b/pkg/configuration/expressionvalidation/order_references.go
@@ -19,6 +19,13 @@ func ExpressionUsesOrderComments(expression string) (bool, error) {
 	return expressionReferencesOrderProperty(expression, "comments")
 }
 
+// ExpressionUsesOrderURL reports whether the expression accesses order().url
+// (dot or bracket). Used to resolve the work order permalink only when needed,
+// since it costs an extra lookup of the factory that owns the order.
+func ExpressionUsesOrderURL(expression string) (bool, error) {
+	return expressionReferencesOrderProperty(expression, "url")
+}
+
 // expressionReferencesOrderProperty reports whether the expression accesses
 // order().<property> (dot or bracket), including nested uses such as
 // len(order().<property>) or none(order().<property>, …).

--- a/pkg/configuration/expressionvalidation/order_references_test.go
+++ b/pkg/configuration/expressionvalidation/order_references_test.go
@@ -35,6 +35,34 @@ func TestExpressionUsesOrderArtifacts(t *testing.T) {
 	}
 }
 
+func TestExpressionUsesOrderURL(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "order only", raw: `order()`, want: false},
+		{name: "order id", raw: `order().id`, want: false},
+		{name: "artifact url", raw: `order().artifacts[0].data.url`, want: false},
+		{name: "dot url", raw: `order().url`, want: true},
+		{name: "bracket url", raw: `order()["url"]`, want: true},
+		{name: "concatenated", raw: `"[Work Order](" + order().url + ")"`, want: true},
+		{name: "unrelated", raw: `app().url`, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExpressionUsesOrderURL(tc.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestExpressionUsesOrderComments(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/models/factory_work_order.go
+++ b/pkg/models/factory_work_order.go
@@ -80,6 +80,13 @@ func (FactoryWorkOrder) TableName() string {
 	return "factory_work_orders"
 }
 
+// URLPath is the canonical UI permalink of the work order, relative to the
+// server base URL. The factory key is part of the path, so callers that only
+// hold the order must load the factory that owns it.
+func (o *FactoryWorkOrder) URLPath(factoryKey string) string {
+	return fmt.Sprintf("/%s/workspaces/%s/work-order/%d", o.OrganizationID, factoryKey, o.Number)
+}
+
 func (o *FactoryWorkOrder) IsOpen() bool {
 	return o.State == FactoryWorkOrderStateOpen
 }

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -1013,8 +1013,8 @@ func (b *NodeConfigurationBuilder) resolveRunPayload() (any, error) {
 
 // resolveOrderPayload exposes the work order driving this run via order().
 // Returns nil when the run is not attached to a factory work-order execution.
-// Artifacts and comments are loaded only when the expression AST references
-// order().artifacts / order().comments.
+// The url, artifacts, and comments are loaded only when the expression AST
+// references order().url / order().artifacts / order().comments.
 func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, error) {
 	if b.rootEventID == nil {
 		return nil, nil
@@ -1052,6 +1052,18 @@ func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, 
 
 	if err := attachOrderSource(b.tx, order, payload); err != nil {
 		return nil, err
+	}
+
+	usesURL, err := expressionvalidation.ExpressionUsesOrderURL(expression)
+	if err != nil {
+		return nil, fmt.Errorf("order() could not inspect expression: %w", err)
+	}
+	if usesURL {
+		url, err := b.buildWorkOrderURL(order)
+		if err != nil {
+			return nil, err
+		}
+		payload["url"] = url
 	}
 
 	usesArtifacts, err := expressionvalidation.ExpressionUsesOrderArtifacts(expression)
@@ -1200,6 +1212,17 @@ func commentAuthorExpressionPayload(author *factory.WorkOrderCommentAuthor) map[
 	}
 
 	return authorPayload
+}
+
+// buildWorkOrderURL resolves the work order permalink in the SuperPlane UI.
+// The factory key is part of that path, so the owning factory has to be loaded.
+func (b *NodeConfigurationBuilder) buildWorkOrderURL(order *models.FactoryWorkOrder) (string, error) {
+	owner, err := models.FindFactory(b.tx, order.OrganizationID, order.FactoryID)
+	if err != nil {
+		return "", fmt.Errorf("order() could not resolve the factory that owns the work order: %w", err)
+	}
+
+	return uiBaseURL() + order.URLPath(owner.Key), nil
 }
 
 func (b *NodeConfigurationBuilder) buildRunURL(run *models.CanvasRun) (string, error) {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -301,6 +301,7 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		assert.Equal(t, factoryModel.ID.String(), payload["factory_id"])
 		assert.Equal(t, models.FactoryWorkOrderStateDraft, payload["state"])
 		assert.Equal(t, "", payload["result"])
+		assert.NotContains(t, payload, "url")
 		assert.NotContains(t, payload, "artifacts")
 		assert.NotContains(t, payload, "comments")
 
@@ -332,6 +333,27 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, order.ID.String(), built["orderID"])
 		assert.Equal(t, "Ship feature", built["title"])
+	})
+
+	t.Run("permalink back to the work order", func(t *testing.T) {
+		expectedSuffix := fmt.Sprintf(
+			"/%s/workspaces/%s/work-order/%d",
+			r.Organization.ID.String(), factoryModel.Key, order.Number,
+		)
+
+		url, err := builder.ResolveExpression(`order().url`)
+		require.NoError(t, err)
+		assert.Contains(t, url, expectedSuffix)
+
+		bracket, err := builder.ResolveExpression(`order()["url"]`)
+		require.NoError(t, err)
+		assert.Equal(t, url, bracket)
+
+		built, err := builder.Build(map[string]any{
+			"body": "[Work Order]({{ order().url }})",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("[Work Order](%s)", url), built["body"])
 	})
 
 	t.Run("artifacts equivalents", func(t *testing.T) {

--- a/pkg/workers/factory_notification_consumer.go
+++ b/pkg/workers/factory_notification_consumer.go
@@ -155,10 +155,7 @@ func (c *FactoryNotificationConsumer) process(db *gorm.DB, message messages.Fact
 
 	content := buildWorkOrderNotificationContent(factoryModel, order, message, c.actorDisplayName(db, orgID, message))
 	applyWorkOrderEmailCard(&content.Data, order, loadWorkOrderExecutionsForEmail(db, order.ID), time.Now())
-	content.Data.WorkOrderLink = fmt.Sprintf(
-		"%s/%s/workspaces/%s/work-order/%d",
-		c.BaseURL, orgID, factoryModel.Key, order.Number,
-	)
+	content.Data.WorkOrderLink = c.BaseURL + order.URLPath(factoryModel.Key)
 
 	sent := false
 	for _, recipient := range recipients {

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -114,7 +114,7 @@ export const EXPR_FUNCTIONS: readonly ExprFunction[] = [
     name: "order",
     snippet: "order().",
     description:
-      "Returns the work order for this run when dispatched from a factory, exposing id, title, description, factory_id, state, result, source, artifacts, and comments (both loaded when accessed).",
+      "Returns the work order for this run when dispatched from a factory, exposing id, title, description, factory_id, state, result, source, url, artifacts, and comments (the last three loaded when accessed).",
     example: 'none(order().artifacts, {#.type == "pr"})',
   },
   // String

--- a/web_src/src/pages/app/buildAutocompleteExampleObj.ts
+++ b/web_src/src/pages/app/buildAutocompleteExampleObj.ts
@@ -82,6 +82,20 @@ function buildRunExample(): Record<string, unknown> {
 // Real values come from the factory execution at runtime; this is only a stub.
 const EXAMPLE_ORDER_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
 const EXAMPLE_FACTORY_ID = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+const EXAMPLE_ORDER_NUMBER = 12;
+
+// Work order permalinks are workspace-scoped
+// (`/{org}/workspaces/{workspaceKey}/work-order/{number}`), so the example is
+// only meaningful on a workspace app page, where order() also resolves.
+function exampleOrderUrl(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const { origin, pathname } = window.location;
+  const workspacePath = pathname.match(/^\/[^/]+\/workspaces\/[^/]+/)?.[0];
+  return workspacePath ? `${origin}${workspacePath}/work-order/${EXAMPLE_ORDER_NUMBER}` : "";
+}
 
 function buildOrderExample(): Record<string, unknown> {
   return {
@@ -91,6 +105,7 @@ function buildOrderExample(): Record<string, unknown> {
     factory_id: EXAMPLE_FACTORY_ID,
     state: "open",
     result: "",
+    url: exampleOrderUrl(),
     source: {
       issue: { number: 42, title: "Fix login" },
     },

--- a/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
@@ -127,7 +127,14 @@ spec:
       component: github.createPullRequest
       configuration:
         base: main
-        body: '{{ fromBase64(previous().data.result.description) }}'
+        body: |-
+          [Work Order]({{ order().url }}).
+
+          {{ fromBase64(previous().data.result.description) }}
+
+          <hr>
+
+          Created via [SuperPlane](https://superplane.com).
         draft: true
         head: '{{ find(order().artifacts, {.type == "branch"}).data.name }}'
         repository: '{{ install_params.appRepository }}'

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -61,6 +61,13 @@ describe("setup factory line apps", () => {
     const pr = materializeOnboardingApp("line-pr");
     expect(pr).toMatch(/component: github\.createPullRequest[\s\S]*repository: acme\/app/);
   });
+
+  it("links the pull request back to the work order", () => {
+    const pr = materializeOnboardingApp("line-pr");
+
+    expect(pr).toMatch(/component: github\.createPullRequest[\s\S]*\[Work Order\]\(\{\{ order\(\)\.url \}\}\)/);
+    expect(pr).toContain("Created via [SuperPlane](https://superplane.com)");
+  });
 });
 
 describe("setup factory event apps", () => {


### PR DESCRIPTION
## Summary

Factory-opened pull requests need a clear link back to the source work order. This change adds `order().url` and uses it at the top of the PR Creation line app description, with a SuperPlane footer.

## Test plan

- [ ] Open a work order through the PR Creation line app and confirm the GitHub PR body starts with `[Work Order](<permalink>).`
- [ ] Confirm the footer shows `Created via [SuperPlane](https://superplane.com).`
- [ ] Confirm the work order link opens the correct work order page.
- [ ] Confirm `order().url` resolves in expression autocomplete and docs.


Made with [Cursor](https://cursor.com)