### PR TITLE
feat(aws): add cloudwatch createAlarmMuteRule and getAlarmMuteRule components

### DIFF
--- a/docs/components/AWS.mdx
+++ b/docs/components/AWS.mdx
@@ -23,6 +23,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="CloudWatch • Create Alarm" href="#cloud-watch-•-create-alarm" description="Create a CloudWatch metric alarm for any metric" />
+  <LinkCard title="CloudWatch • Create Alarm Mute Rule" href="#cloud-watch-•-create-alarm-mute-rule" description="Mute one or more CloudWatch alarms during a scheduled window, like a Grafana silence" />
+  <LinkCard title="CloudWatch • Get Alarm Mute Rule" href="#cloud-watch-•-get-alarm-mute-rule" description="Fetch the current configuration and status of a CloudWatch alarm mute rule" />
   <LinkCard title="CloudWatch • Update Alarm" href="#cloud-watch-•-update-alarm" description="Update an existing CloudWatch metric alarm" />
   <LinkCard title="CodeArtifact • Copy Package Versions" href="#code-artifact-•-copy-package-versions" description="Copy package versions from one repository to another in the same domain" />
   <LinkCard title="CodeArtifact • Create Repository" href="#code-artifact-•-create-repository" description="Create an AWS CodeArtifact repository in a domain" />
@@ -665,6 +667,115 @@ Emits the created alarm on the default output channel, including `alarmName`, `a
   },
   "timestamp": "2026-06-03T16:36:13.985915034Z",
   "type": "aws.cloudwatch.alarm"
+}
+```
+
+<a id="cloud-watch-•-create-alarm-mute-rule"></a>
+
+## CloudWatch • Create Alarm Mute Rule
+
+**Component key:** `aws.cloudwatch.createAlarmMuteRule`
+
+The Create Alarm Mute Rule component creates or updates a CloudWatch alarm mute rule. While a rule is active, its targeted alarms keep evaluating and changing state, but their configured actions (SNS notifications, EC2 automations, etc.) are muted.
+
+### Use Cases
+
+- **Planned maintenance**: Silence noisy alarms during a deploy or maintenance window
+- **Recurring quiet hours**: Mute non-critical alarms every night or every weekend
+- **Incident response**: Silence a known-flapping alarm once, for a fixed duration
+
+### Configuration
+
+- **Region**: AWS region the alarms and the rule live in
+- **Name**: Unique mute rule name within the region; creating a rule with an existing name updates it
+- **Description** *(toggleable)*: Free-text description
+- **Alarms**: Alarms to mute while the rule is active (up to 100)
+- **Schedule Expression**: A recurring `cron(Minutes Hours Day-of-month Month Day-of-week)` expression (e.g. `cron(0 2 * * *)`) or a one-time `at(yyyy-MM-ddThh:mm)` expression (e.g. `at(2026-01-20T14:00)`)
+- **Duration**: How long alarms stay muted once the schedule activates, in ISO 8601 duration format (e.g. `PT2H` for 2 hours), between `PT1M` and `P15D`
+- **Timezone**: Timezone the schedule expression runs in, and that offset-less start/expire dates are interpreted in (default UTC)
+- **Starts At** *(toggleable)*: Rule takes effect immediately if left unset
+- **Expires At** *(toggleable)*: Rule never expires if left unset
+
+### Output
+
+Emits the mute rule on the default output channel, including `name`, `alarmMuteRuleArn`,
+`scheduleExpression`, `scheduleDuration`, `alarmNames`, `status` and `muteType`.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "alarmMuteRuleArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm-mute-rule:DailyMaintenanceWindow",
+    "alarmNames": [
+      "WebServerCPUAlarm",
+      "DatabaseConnectionAlarm"
+    ],
+    "description": "Mute alarms during daily maintenance",
+    "expireDate": "",
+    "lastUpdatedTimestamp": "2026-06-03T16:36:13Z",
+    "muteType": "RECURRING",
+    "name": "DailyMaintenanceWindow",
+    "scheduleDuration": "PT2H",
+    "scheduleExpression": "cron(0 2 * * *)",
+    "scheduleTimezone": "UTC",
+    "startDate": "",
+    "status": "SCHEDULED"
+  },
+  "timestamp": "2026-06-03T16:36:13.985915034Z",
+  "type": "aws.cloudwatch.alarmMuteRule"
+}
+```
+
+<a id="cloud-watch-•-get-alarm-mute-rule"></a>
+
+## CloudWatch • Get Alarm Mute Rule
+
+**Component key:** `aws.cloudwatch.getAlarmMuteRule`
+
+The Get Alarm Mute Rule component describes a CloudWatch alarm mute rule and emits its current details.
+
+### Use Cases
+
+- **Status inspection**: Check whether a mute rule is SCHEDULED, ACTIVE or EXPIRED before taking action
+- **Audit**: Record a mute rule's targeted alarms and schedule at a point in time
+
+### Configuration
+
+- **Region**: AWS region the mute rule lives in
+- **Name**: Name of the mute rule to describe
+
+### Output
+
+Emits the mute rule details on the default output channel:
+- `name`, `alarmMuteRuleArn`, `description`
+- `scheduleExpression`, `scheduleDuration`, `scheduleTimezone`
+- `alarmNames`, `startDate`, `expireDate`
+- `status`, `muteType`, `lastUpdatedTimestamp`
+
+### Example Output
+
+```json
+{
+  "data": {
+    "alarmMuteRuleArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm-mute-rule:DailyMaintenanceWindow",
+    "alarmNames": [
+      "WebServerCPUAlarm",
+      "DatabaseConnectionAlarm"
+    ],
+    "description": "Mute alarms during daily maintenance",
+    "expireDate": "",
+    "lastUpdatedTimestamp": "2026-06-03T16:36:13Z",
+    "muteType": "RECURRING",
+    "name": "DailyMaintenanceWindow",
+    "scheduleDuration": "PT2H",
+    "scheduleExpression": "cron(0 2 * * *)",
+    "scheduleTimezone": "UTC",
+    "startDate": "",
+    "status": "ACTIVE"
+  },
+  "timestamp": "2026-06-03T16:36:13.985915034Z",
+  "type": "aws.cloudwatch.alarmMuteRule"
 }
 ```
 

--- a/pkg/integrations/aws/aws.go
+++ b/pkg/integrations/aws/aws.go
@@ -139,6 +139,8 @@ func (a *AWS) Actions() []core.Action {
 	return []core.Action{
 		&cloudwatch.CreateAlarm{},
 		&cloudwatch.UpdateAlarm{},
+		&cloudwatch.CreateAlarmMuteRule{},
+		&cloudwatch.GetAlarmMuteRule{},
 		&codeartifact.CopyPackageVersions{},
 		&codeartifact.CreateRepository{},
 		&codeartifact.DeletePackageVersions{},

--- a/pkg/integrations/aws/cloudwatch/client.go
+++ b/pkg/integrations/aws/cloudwatch/client.go
@@ -286,6 +286,76 @@ func (c *Client) ListMetrics(namespace, metricName string) ([]Metric, error) {
 	return metrics, nil
 }
 
+// AlarmMuteRuleSchedule mirrors CloudWatch's Schedule shape: a recurring
+// cron(...) or one-time at(...) expression, how long each activation mutes
+// alarms for, and the timezone the expression is evaluated in.
+type AlarmMuteRuleSchedule struct {
+	Expression string
+	Duration   string
+	Timezone   string
+}
+
+type PutAlarmMuteRuleInput struct {
+	Name        string
+	Description string
+	Schedule    AlarmMuteRuleSchedule
+	AlarmNames  []string
+	StartDate   *time.Time
+	ExpireDate  *time.Time
+}
+
+type AlarmMuteRule struct {
+	Name                 string
+	AlarmMuteRuleArn     string
+	Description          string
+	Schedule             AlarmMuteRuleSchedule
+	AlarmNames           []string
+	StartDate            string
+	ExpireDate           string
+	Status               string
+	MuteType             string
+	LastUpdatedTimestamp string
+}
+
+func (c *Client) PutAlarmMuteRule(input PutAlarmMuteRuleInput) error {
+	params := url.Values{}
+	params.Set("Name", strings.TrimSpace(input.Name))
+	params.Set("Rule.Schedule.Expression", strings.TrimSpace(input.Schedule.Expression))
+	params.Set("Rule.Schedule.Duration", strings.TrimSpace(input.Schedule.Duration))
+
+	if description := strings.TrimSpace(input.Description); description != "" {
+		params.Set("Description", description)
+	}
+
+	if timezone := strings.TrimSpace(input.Schedule.Timezone); timezone != "" {
+		params.Set("Rule.Schedule.Timezone", timezone)
+	}
+
+	setActionMembers(params, "MuteTargets.AlarmNames", input.AlarmNames)
+
+	if input.StartDate != nil {
+		params.Set("StartDate", input.StartDate.UTC().Format(time.RFC3339))
+	}
+
+	if input.ExpireDate != nil {
+		params.Set("ExpireDate", input.ExpireDate.UTC().Format(time.RFC3339))
+	}
+
+	return c.postSignedForm("PutAlarmMuteRule", params, nil)
+}
+
+func (c *Client) GetAlarmMuteRule(name string) (*AlarmMuteRule, error) {
+	params := url.Values{}
+	params.Set("AlarmMuteRuleName", strings.TrimSpace(name))
+
+	response := getAlarmMuteRuleResponse{}
+	if err := c.postSignedForm("GetAlarmMuteRule", params, &response); err != nil {
+		return nil, err
+	}
+
+	return alarmMuteRuleFromXML(response.Result), nil
+}
+
 func setActionMembers(params url.Values, key string, arns []string) {
 	index := 0
 	for _, arn := range arns {
@@ -406,6 +476,78 @@ func alarmFromXML(x xmlMetricAlarm, region string) *MetricAlarm {
 		Region:                             region,
 		ConsoleURL:                         AlarmConsoleURL(region, x.AlarmName),
 		HasMetricQueries:                   len(x.Metrics) > 0,
+	}
+}
+
+type getAlarmMuteRuleResponse struct {
+	XMLName xml.Name               `xml:"GetAlarmMuteRuleResponse"`
+	Result  getAlarmMuteRuleResult `xml:"GetAlarmMuteRuleResult"`
+}
+
+type getAlarmMuteRuleResult struct {
+	Name                 string         `xml:"Name"`
+	AlarmMuteRuleArn     string         `xml:"AlarmMuteRuleArn"`
+	Description          string         `xml:"Description"`
+	Rule                 xmlMuteRule    `xml:"Rule"`
+	MuteTargets          xmlMuteTargets `xml:"MuteTargets"`
+	StartDate            string         `xml:"StartDate"`
+	ExpireDate           string         `xml:"ExpireDate"`
+	Status               string         `xml:"Status"`
+	LastUpdatedTimestamp string         `xml:"LastUpdatedTimestamp"`
+	MuteType             string         `xml:"MuteType"`
+}
+
+type xmlMuteRule struct {
+	Schedule xmlMuteSchedule `xml:"Schedule"`
+}
+
+type xmlMuteSchedule struct {
+	Expression string `xml:"Expression"`
+	Duration   string `xml:"Duration"`
+	Timezone   string `xml:"Timezone"`
+}
+
+type xmlMuteTargets struct {
+	AlarmNames []string `xml:"AlarmNames>member"`
+}
+
+func alarmMuteRuleFromXML(x getAlarmMuteRuleResult) *AlarmMuteRule {
+	return &AlarmMuteRule{
+		Name:             x.Name,
+		AlarmMuteRuleArn: x.AlarmMuteRuleArn,
+		Description:      x.Description,
+		Schedule: AlarmMuteRuleSchedule{
+			Expression: x.Rule.Schedule.Expression,
+			Duration:   x.Rule.Schedule.Duration,
+			Timezone:   x.Rule.Schedule.Timezone,
+		},
+		AlarmNames:           x.MuteTargets.AlarmNames,
+		StartDate:            x.StartDate,
+		ExpireDate:           x.ExpireDate,
+		Status:               x.Status,
+		MuteType:             x.MuteType,
+		LastUpdatedTimestamp: x.LastUpdatedTimestamp,
+	}
+}
+
+func alarmMuteRuleToMap(rule *AlarmMuteRule) map[string]any {
+	if rule == nil {
+		return map[string]any{}
+	}
+
+	return map[string]any{
+		"name":                 rule.Name,
+		"alarmMuteRuleArn":     rule.AlarmMuteRuleArn,
+		"description":          rule.Description,
+		"scheduleExpression":   rule.Schedule.Expression,
+		"scheduleDuration":     rule.Schedule.Duration,
+		"scheduleTimezone":     rule.Schedule.Timezone,
+		"alarmNames":           rule.AlarmNames,
+		"startDate":            rule.StartDate,
+		"expireDate":           rule.ExpireDate,
+		"status":               rule.Status,
+		"muteType":             rule.MuteType,
+		"lastUpdatedTimestamp": rule.LastUpdatedTimestamp,
 	}
 }
 

--- a/pkg/integrations/aws/cloudwatch/common.go
+++ b/pkg/integrations/aws/cloudwatch/common.go
@@ -14,10 +14,18 @@ const (
 )
 
 const (
+	CreateAlarmMuteRulePayloadType = "aws.cloudwatch.alarmMuteRule"
+	GetAlarmMuteRulePayloadType    = "aws.cloudwatch.alarmMuteRule"
+)
+
+const (
 	StatisticAverage = "Average"
 
 	defaultAlarmPeriod            = 300
 	defaultAlarmEvaluationPeriods = 1
+
+	// maxMuteRuleAlarms mirrors PutAlarmMuteRule's own limit on MuteTargets.AlarmNames.
+	maxMuteRuleAlarms = 100
 )
 
 var AllAlarmStates = []configuration.FieldOption{

--- a/pkg/integrations/aws/cloudwatch/component_validation.go
+++ b/pkg/integrations/aws/cloudwatch/component_validation.go
@@ -3,6 +3,7 @@ package cloudwatch
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 func requireRegion(value string) (string, error) {
@@ -97,6 +98,113 @@ func effectiveEvaluationPeriods(evaluationPeriods int) int {
 	}
 
 	return evaluationPeriods
+}
+
+func requireAlarmMuteRuleName(value string) (string, error) {
+	name := strings.TrimSpace(value)
+	if name == "" {
+		return "", fmt.Errorf("name is required")
+	}
+
+	return name, nil
+}
+
+// requireAlarmNames drops blank entries and enforces PutAlarmMuteRule's own
+// bounds on how many alarms a single mute rule can target.
+func requireAlarmNames(values []string) ([]string, error) {
+	names := make([]string, 0, len(values))
+	for _, value := range values {
+		if name := strings.TrimSpace(value); name != "" {
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		return nil, fmt.Errorf("at least one alarm is required")
+	}
+
+	if len(names) > maxMuteRuleAlarms {
+		return nil, fmt.Errorf("a mute rule can target at most %d alarms", maxMuteRuleAlarms)
+	}
+
+	return names, nil
+}
+
+func requireScheduleExpression(value string) (string, error) {
+	expression := strings.TrimSpace(value)
+	if expression == "" {
+		return "", fmt.Errorf("schedule expression is required")
+	}
+
+	if !strings.HasPrefix(expression, "cron(") && !strings.HasPrefix(expression, "at(") {
+		return "", fmt.Errorf(`schedule expression must be a recurring "cron(...)" or one-time "at(...)" expression`)
+	}
+
+	return expression, nil
+}
+
+func requireScheduleDuration(value string) (string, error) {
+	duration := strings.TrimSpace(value)
+	if duration == "" {
+		return "", fmt.Errorf("duration is required")
+	}
+
+	return duration, nil
+}
+
+// muteRuleDatetimeLayouts covers the value shape produced by the "datetime"
+// field's HTML datetime-local input, which carries no timezone of its own.
+var muteRuleDatetimeLayouts = []string{
+	"2006-01-02T15:04:05",
+	"2006-01-02T15:04",
+}
+
+// parseMuteRuleTimestamp accepts either a full RFC3339 timestamp, whose own
+// offset always wins, or a bare datetime-local value, interpreted in the
+// given timezone since it carries no offset of its own.
+func parseMuteRuleTimestamp(raw, timezone string) (time.Time, error) {
+	if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+		return parsed.UTC(), nil
+	}
+
+	location, err := time.LoadLocation(timezone)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid timezone %q: %w", timezone, err)
+	}
+
+	for _, layout := range muteRuleDatetimeLayouts {
+		if parsed, err := time.ParseInLocation(layout, raw, location); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("invalid timestamp %q: expected RFC3339 or YYYY-MM-DDTHH:MM", raw)
+}
+
+// parseOptionalMuteRuleTimestamp is parseMuteRuleTimestamp for a togglable
+// field: a blank value is left unset rather than treated as an error.
+func parseOptionalMuteRuleTimestamp(raw, timezone string) (*time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	parsed, err := parseMuteRuleTimestamp(raw, timezone)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parsed, nil
+}
+
+// effectiveTimezone mirrors the "timezone" field's own UI default, so
+// validation resolves the same value the client will send.
+func effectiveTimezone(value string) string {
+	if timezone := strings.TrimSpace(value); timezone != "" {
+		return timezone
+	}
+
+	return "UTC"
 }
 
 func hasConfigKey(configuration any, key string) bool {

--- a/pkg/integrations/aws/cloudwatch/create_alarm_mute_rule.go
+++ b/pkg/integrations/aws/cloudwatch/create_alarm_mute_rule.go
@@ -1,0 +1,291 @@
+package cloudwatch
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+type CreateAlarmMuteRule struct{}
+
+type CreateAlarmMuteRuleConfiguration struct {
+	Region             string   `json:"region" mapstructure:"region"`
+	Name               string   `json:"name" mapstructure:"name"`
+	Description        string   `json:"description" mapstructure:"description"`
+	AlarmNames         []string `json:"alarmNames" mapstructure:"alarmNames"`
+	ScheduleExpression string   `json:"scheduleExpression" mapstructure:"scheduleExpression"`
+	Duration           string   `json:"duration" mapstructure:"duration"`
+	Timezone           string   `json:"timezone" mapstructure:"timezone"`
+	StartDate          string   `json:"startDate" mapstructure:"startDate"`
+	ExpireDate         string   `json:"expireDate" mapstructure:"expireDate"`
+}
+
+type CreateAlarmMuteRuleNodeMetadata struct {
+	Region string `json:"region" mapstructure:"region"`
+	Name   string `json:"name" mapstructure:"name"`
+}
+
+func (c *CreateAlarmMuteRule) Name() string {
+	return "aws.cloudwatch.createAlarmMuteRule"
+}
+
+func (c *CreateAlarmMuteRule) Label() string {
+	return "CloudWatch • Create Alarm Mute Rule"
+}
+
+func (c *CreateAlarmMuteRule) Description() string {
+	return "Mute one or more CloudWatch alarms during a scheduled window, like a Grafana silence"
+}
+
+func (c *CreateAlarmMuteRule) Documentation() string {
+	return `The Create Alarm Mute Rule component creates or updates a CloudWatch alarm mute rule. While a rule is active, its targeted alarms keep evaluating and changing state, but their configured actions (SNS notifications, EC2 automations, etc.) are muted.
+
+## Use Cases
+
+- **Planned maintenance**: Silence noisy alarms during a deploy or maintenance window
+- **Recurring quiet hours**: Mute non-critical alarms every night or every weekend
+- **Incident response**: Silence a known-flapping alarm once, for a fixed duration
+
+## Configuration
+
+- **Region**: AWS region the alarms and the rule live in
+- **Name**: Unique mute rule name within the region; creating a rule with an existing name updates it
+- **Description** *(toggleable)*: Free-text description
+- **Alarms**: Alarms to mute while the rule is active (up to 100)
+- **Schedule Expression**: A recurring ` + "`cron(Minutes Hours Day-of-month Month Day-of-week)`" + ` expression (e.g. ` + "`cron(0 2 * * *)`" + `) or a one-time ` + "`at(yyyy-MM-ddThh:mm)`" + ` expression (e.g. ` + "`at(2026-01-20T14:00)`" + `)
+- **Duration**: How long alarms stay muted once the schedule activates, in ISO 8601 duration format (e.g. ` + "`PT2H`" + ` for 2 hours), between ` + "`PT1M`" + ` and ` + "`P15D`" + `
+- **Timezone**: Timezone the schedule expression runs in, and that offset-less start/expire dates are interpreted in (default UTC)
+- **Starts At** *(toggleable)*: Rule takes effect immediately if left unset
+- **Expires At** *(toggleable)*: Rule never expires if left unset
+
+## Output
+
+Emits the mute rule on the default output channel, including ` + "`name`" + `, ` + "`alarmMuteRuleArn`" + `,
+` + "`scheduleExpression`" + `, ` + "`scheduleDuration`" + `, ` + "`alarmNames`" + `, ` + "`status`" + ` and ` + "`muteType`" + `.
+`
+}
+
+func (c *CreateAlarmMuteRule) Icon() string {
+	return "aws"
+}
+
+func (c *CreateAlarmMuteRule) Color() string {
+	return "gray"
+}
+
+func (c *CreateAlarmMuteRule) OutputChannels(_ any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateAlarmMuteRule) Configuration() []configuration.Field {
+	return []configuration.Field{
+		regionField(),
+		{
+			Name:        "name",
+			Label:       "Name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Unique mute rule name within the region; creating a rule with an existing name updates it",
+		},
+		{
+			Name:      "description",
+			Label:     "Description",
+			Type:      configuration.FieldTypeText,
+			Required:  false,
+			Togglable: true,
+		},
+		{
+			Name:        "alarmNames",
+			Label:       "Alarms",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Alarms to mute while the rule is active (up to 100)",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "region", Values: []string{"*"}},
+			},
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:       "cloudwatch.alarm",
+					Multi:      true,
+					Parameters: []configuration.ParameterRef{regionParameter()},
+				},
+			},
+		},
+		{
+			Name:        "scheduleExpression",
+			Label:       "Schedule Expression",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: `A recurring "cron(Minutes Hours Day-of-month Month Day-of-week)" expression (e.g. cron(0 2 * * *)) or a one-time "at(yyyy-MM-ddThh:mm)" expression (e.g. at(2026-01-20T14:00))`,
+		},
+		{
+			Name:        "duration",
+			Label:       "Duration",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Default:     "PT1H",
+			Description: "How long alarms stay muted once the schedule activates, in ISO 8601 duration format (e.g. PT2H). Between PT1M and P15D",
+		},
+		scheduleTimezoneField(),
+		{
+			Name:        "startDate",
+			Label:       "Starts At",
+			Type:        configuration.FieldTypeDateTime,
+			Required:    false,
+			Togglable:   true,
+			Description: "Rule takes effect immediately if left unset",
+		},
+		{
+			Name:        "expireDate",
+			Label:       "Expires At",
+			Type:        configuration.FieldTypeDateTime,
+			Required:    false,
+			Togglable:   true,
+			Description: "Rule never expires if left unset",
+		},
+	}
+}
+
+func (c *CreateAlarmMuteRule) Setup(ctx core.SetupContext) error {
+	config := CreateAlarmMuteRuleConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+
+	name, err := requireAlarmMuteRuleName(config.Name)
+	if err != nil {
+		return err
+	}
+
+	if _, err := requireAlarmNames(config.AlarmNames); err != nil {
+		return err
+	}
+
+	if _, err := requireScheduleExpression(config.ScheduleExpression); err != nil {
+		return err
+	}
+
+	if _, err := requireScheduleDuration(config.Duration); err != nil {
+		return err
+	}
+
+	timezone := effectiveTimezone(config.Timezone)
+	if _, err := parseOptionalMuteRuleTimestamp(config.StartDate, timezone); err != nil {
+		return fmt.Errorf("invalid start date: %w", err)
+	}
+
+	if _, err := parseOptionalMuteRuleTimestamp(config.ExpireDate, timezone); err != nil {
+		return fmt.Errorf("invalid expire date: %w", err)
+	}
+
+	return ctx.Metadata.Set(CreateAlarmMuteRuleNodeMetadata{
+		Region: region,
+		Name:   name,
+	})
+}
+
+func (c *CreateAlarmMuteRule) Execute(ctx core.ExecutionContext) error {
+	config := CreateAlarmMuteRuleConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+
+	name, err := requireAlarmMuteRuleName(config.Name)
+	if err != nil {
+		return err
+	}
+
+	alarmNames, err := requireAlarmNames(config.AlarmNames)
+	if err != nil {
+		return err
+	}
+
+	expression, err := requireScheduleExpression(config.ScheduleExpression)
+	if err != nil {
+		return err
+	}
+
+	duration, err := requireScheduleDuration(config.Duration)
+	if err != nil {
+		return err
+	}
+
+	timezone := effectiveTimezone(config.Timezone)
+	startDate, err := parseOptionalMuteRuleTimestamp(config.StartDate, timezone)
+	if err != nil {
+		return fmt.Errorf("invalid start date: %w", err)
+	}
+
+	expireDate, err := parseOptionalMuteRuleTimestamp(config.ExpireDate, timezone)
+	if err != nil {
+		return fmt.Errorf("invalid expire date: %w", err)
+	}
+
+	creds, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	client := NewClient(ctx.HTTP, creds, region)
+	err = client.PutAlarmMuteRule(PutAlarmMuteRuleInput{
+		Name:        name,
+		Description: config.Description,
+		Schedule: AlarmMuteRuleSchedule{
+			Expression: expression,
+			Duration:   duration,
+			Timezone:   timezone,
+		},
+		AlarmNames: alarmNames,
+		StartDate:  startDate,
+		ExpireDate: expireDate,
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to create alarm mute rule: %w", err)
+	}
+
+	rule, err := client.GetAlarmMuteRule(name)
+	if err != nil {
+		return fmt.Errorf("failed to fetch alarm mute rule after creation: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		CreateAlarmMuteRulePayloadType,
+		[]any{alarmMuteRuleToMap(rule)},
+	)
+}
+
+func (c *CreateAlarmMuteRule) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateAlarmMuteRule) HandleHook(_ core.ActionHookContext) error {
+	return nil
+}
+
+func (c *CreateAlarmMuteRule) Cancel(_ core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateAlarmMuteRule) Cleanup(_ core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateAlarmMuteRule) HandleWebhook(_ core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}

--- a/pkg/integrations/aws/cloudwatch/create_alarm_mute_rule_test.go
+++ b/pkg/integrations/aws/cloudwatch/create_alarm_mute_rule_test.go
@@ -1,0 +1,241 @@
+package cloudwatch
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+const getAlarmMuteRuleXML = `
+<GetAlarmMuteRuleResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
+  <GetAlarmMuteRuleResult>
+    <Name>DailyMaintenanceWindow</Name>
+    <AlarmMuteRuleArn>arn:aws:cloudwatch:us-east-1:123456789012:alarm-mute-rule:DailyMaintenanceWindow</AlarmMuteRuleArn>
+    <Description>Mute alarms during daily maintenance</Description>
+    <Rule>
+      <Schedule>
+        <Expression>cron(0 2 * * *)</Expression>
+        <Duration>PT2H</Duration>
+        <Timezone>UTC</Timezone>
+      </Schedule>
+    </Rule>
+    <MuteTargets>
+      <AlarmNames>
+        <member>WebServerCPUAlarm</member>
+        <member>DatabaseConnectionAlarm</member>
+      </AlarmNames>
+    </MuteTargets>
+    <Status>SCHEDULED</Status>
+    <LastUpdatedTimestamp>2026-01-15T10:30:00Z</LastUpdatedTimestamp>
+    <MuteType>RECURRING</MuteType>
+  </GetAlarmMuteRuleResult>
+</GetAlarmMuteRuleResponse>`
+
+func validCreateAlarmMuteRuleConfig() map[string]any {
+	return map[string]any{
+		"region":             "us-east-1",
+		"name":               "DailyMaintenanceWindow",
+		"alarmNames":         []string{"WebServerCPUAlarm", "DatabaseConnectionAlarm"},
+		"scheduleExpression": "cron(0 2 * * *)",
+		"duration":           "PT2H",
+	}
+}
+
+func Test__CreateAlarmMuteRule__Setup(t *testing.T) {
+	component := &CreateAlarmMuteRule{}
+
+	t.Run("missing region -> error", func(t *testing.T) {
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["region"] = " "
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "region is required")
+	})
+
+	t.Run("missing name -> error", func(t *testing.T) {
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["name"] = " "
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "name is required")
+	})
+
+	t.Run("missing alarm names -> error", func(t *testing.T) {
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["alarmNames"] = []string{}
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "at least one alarm is required")
+	})
+
+	t.Run("missing schedule expression -> error", func(t *testing.T) {
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["scheduleExpression"] = " "
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "schedule expression is required")
+	})
+
+	t.Run("schedule expression missing cron/at prefix -> error", func(t *testing.T) {
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["scheduleExpression"] = "0 2 * * *"
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, `must be a recurring "cron(...)" or one-time "at(...)" expression`)
+	})
+
+	t.Run("missing duration -> error", func(t *testing.T) {
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["duration"] = " "
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "duration is required")
+	})
+
+	t.Run("invalid start date -> error", func(t *testing.T) {
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["startDate"] = "not-a-date"
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "invalid start date")
+	})
+
+	t.Run("invalid expire date -> error", func(t *testing.T) {
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["expireDate"] = "not-a-date"
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "invalid expire date")
+	})
+
+	t.Run("valid configuration -> no error", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: validCreateAlarmMuteRuleConfig(),
+			Metadata:      metadata,
+		})
+		require.NoError(t, err)
+
+		nodeMetadata, ok := metadata.Metadata.(CreateAlarmMuteRuleNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "us-east-1", nodeMetadata.Region)
+		assert.Equal(t, "DailyMaintenanceWindow", nodeMetadata.Name)
+	})
+}
+
+func Test__CreateAlarmMuteRule__Execute(t *testing.T) {
+	component := &CreateAlarmMuteRule{}
+
+	t.Run("creates the rule and emits its fetched details", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				// PutAlarmMuteRule returns an empty body on success.
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(``))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(getAlarmMuteRuleXML))},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{}
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  validCreateAlarmMuteRuleConfig(),
+			HTTP:           httpContext,
+			ExecutionState: executionState,
+			Integration:    awsIntegrationContext(),
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, CreateAlarmMuteRulePayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		wrapped := executionState.Payloads[0].(map[string]any)
+		data := wrapped["data"].(map[string]any)
+		assert.Equal(t, "DailyMaintenanceWindow", data["name"])
+		assert.Equal(t, "cron(0 2 * * *)", data["scheduleExpression"])
+		assert.Equal(t, "PT2H", data["scheduleDuration"])
+		assert.Equal(t, "SCHEDULED", data["status"])
+		assert.Equal(t, []string{"WebServerCPUAlarm", "DatabaseConnectionAlarm"}, data["alarmNames"])
+	})
+
+	t.Run("sends the schedule and targets to CloudWatch", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(``))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(getAlarmMuteRuleXML))},
+			},
+		}
+
+		configuration := validCreateAlarmMuteRuleConfig()
+		configuration["description"] = "Mute alarms during daily maintenance"
+		configuration["timezone"] = "America/New_York"
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  configuration,
+			HTTP:           httpContext,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Integration:    awsIntegrationContext(),
+		})
+		require.NoError(t, err)
+
+		body := requestBody(t, httpContext, 0)
+		assert.Contains(t, body, "Action=PutAlarmMuteRule")
+		assert.Contains(t, body, "Name=DailyMaintenanceWindow")
+		assert.Contains(t, body, "Description=Mute+alarms+during+daily+maintenance")
+		assert.Contains(t, body, "Rule.Schedule.Expression=cron%280+2+%2A+%2A+%2A%29")
+		assert.Contains(t, body, "Rule.Schedule.Duration=PT2H")
+		assert.Contains(t, body, "Rule.Schedule.Timezone=America%2FNew_York")
+		assert.Contains(t, body, "MuteTargets.AlarmNames.member.1=WebServerCPUAlarm")
+		assert.Contains(t, body, "MuteTargets.AlarmNames.member.2=DatabaseConnectionAlarm")
+	})
+
+	t.Run("rule creation failure -> error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusBadRequest,
+					Body: io.NopCloser(strings.NewReader(`
+<ErrorResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
+  <Error>
+    <Code>ValidationError</Code>
+    <Message>Invalid schedule expression</Message>
+  </Error>
+</ErrorResponse>`)),
+				},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  validCreateAlarmMuteRuleConfig(),
+			HTTP:           httpContext,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Integration:    awsIntegrationContext(),
+		})
+
+		require.ErrorContains(t, err, "failed to create alarm mute rule")
+		require.ErrorContains(t, err, "Invalid schedule expression")
+	})
+
+	t.Run("fetch after creation fails -> error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(``))},
+				{
+					StatusCode: http.StatusNotFound,
+					Body: io.NopCloser(strings.NewReader(`
+<ErrorResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
+  <Error>
+    <Code>ResourceNotFoundException</Code>
+    <Message>rule not found</Message>
+  </Error>
+</ErrorResponse>`)),
+				},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  validCreateAlarmMuteRuleConfig(),
+			HTTP:           httpContext,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Integration:    awsIntegrationContext(),
+		})
+
+		require.ErrorContains(t, err, "failed to fetch alarm mute rule after creation")
+	})
+}

--- a/pkg/integrations/aws/cloudwatch/example.go
+++ b/pkg/integrations/aws/cloudwatch/example.go
@@ -36,3 +36,23 @@ var exampleOutputUpdateAlarm map[string]any
 func (c *UpdateAlarm) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateAlarmOnce, exampleOutputUpdateAlarmBytes, &exampleOutputUpdateAlarm)
 }
+
+//go:embed example_output_create_alarm_mute_rule.json
+var exampleOutputCreateAlarmMuteRuleBytes []byte
+
+var exampleOutputCreateAlarmMuteRuleOnce sync.Once
+var exampleOutputCreateAlarmMuteRule map[string]any
+
+func (c *CreateAlarmMuteRule) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateAlarmMuteRuleOnce, exampleOutputCreateAlarmMuteRuleBytes, &exampleOutputCreateAlarmMuteRule)
+}
+
+//go:embed example_output_get_alarm_mute_rule.json
+var exampleOutputGetAlarmMuteRuleBytes []byte
+
+var exampleOutputGetAlarmMuteRuleOnce sync.Once
+var exampleOutputGetAlarmMuteRule map[string]any
+
+func (c *GetAlarmMuteRule) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetAlarmMuteRuleOnce, exampleOutputGetAlarmMuteRuleBytes, &exampleOutputGetAlarmMuteRule)
+}

--- a/pkg/integrations/aws/cloudwatch/example_output_create_alarm_mute_rule.json
+++ b/pkg/integrations/aws/cloudwatch/example_output_create_alarm_mute_rule.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "alarmMuteRuleArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm-mute-rule:DailyMaintenanceWindow",
+    "alarmNames": ["WebServerCPUAlarm", "DatabaseConnectionAlarm"],
+    "description": "Mute alarms during daily maintenance",
+    "expireDate": "",
+    "lastUpdatedTimestamp": "2026-06-03T16:36:13Z",
+    "muteType": "RECURRING",
+    "name": "DailyMaintenanceWindow",
+    "scheduleDuration": "PT2H",
+    "scheduleExpression": "cron(0 2 * * *)",
+    "scheduleTimezone": "UTC",
+    "startDate": "",
+    "status": "SCHEDULED"
+  },
+  "timestamp": "2026-06-03T16:36:13.985915034Z",
+  "type": "aws.cloudwatch.alarmMuteRule"
+}

--- a/pkg/integrations/aws/cloudwatch/example_output_get_alarm_mute_rule.json
+++ b/pkg/integrations/aws/cloudwatch/example_output_get_alarm_mute_rule.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "alarmMuteRuleArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm-mute-rule:DailyMaintenanceWindow",
+    "alarmNames": ["WebServerCPUAlarm", "DatabaseConnectionAlarm"],
+    "description": "Mute alarms during daily maintenance",
+    "expireDate": "",
+    "lastUpdatedTimestamp": "2026-06-03T16:36:13Z",
+    "muteType": "RECURRING",
+    "name": "DailyMaintenanceWindow",
+    "scheduleDuration": "PT2H",
+    "scheduleExpression": "cron(0 2 * * *)",
+    "scheduleTimezone": "UTC",
+    "startDate": "",
+    "status": "ACTIVE"
+  },
+  "timestamp": "2026-06-03T16:36:13.985915034Z",
+  "type": "aws.cloudwatch.alarmMuteRule"
+}

--- a/pkg/integrations/aws/cloudwatch/fields.go
+++ b/pkg/integrations/aws/cloudwatch/fields.go
@@ -99,6 +99,39 @@ func ec2ActionField(visibilityConditions []configuration.VisibilityCondition) co
 	}
 }
 
+// timestampTimezoneOptions is a curated set of IANA zones, matching the
+// select statuspage.CreateIncident already offers for the same "disambiguate
+// an offset-less timestamp" problem.
+var timestampTimezoneOptions = []configuration.FieldOption{
+	{Label: "UTC", Value: "UTC"},
+	{Label: "America/New_York", Value: "America/New_York"},
+	{Label: "America/Los_Angeles", Value: "America/Los_Angeles"},
+	{Label: "America/Chicago", Value: "America/Chicago"},
+	{Label: "Europe/London", Value: "Europe/London"},
+	{Label: "Europe/Paris", Value: "Europe/Paris"},
+	{Label: "Asia/Tokyo", Value: "Asia/Tokyo"},
+	{Label: "Asia/Singapore", Value: "Asia/Singapore"},
+}
+
+// scheduleTimezoneField lets a mute rule's schedule expression, and any
+// offset-less start/expire date, be evaluated in a specific timezone instead
+// of UTC.
+func scheduleTimezoneField() configuration.Field {
+	return configuration.Field{
+		Name:        "timezone",
+		Label:       "Timezone",
+		Type:        configuration.FieldTypeSelect,
+		Required:    false,
+		Default:     "UTC",
+		Description: "Timezone the schedule expression runs in, and that offset-less start/expire dates are interpreted in",
+		TypeOptions: &configuration.TypeOptions{
+			Select: &configuration.SelectTypeOptions{
+				Options: timestampTimezoneOptions,
+			},
+		},
+	}
+}
+
 func regionParameter() configuration.ParameterRef {
 	return configuration.ParameterRef{
 		Name:      "region",

--- a/pkg/integrations/aws/cloudwatch/get_alarm_mute_rule.go
+++ b/pkg/integrations/aws/cloudwatch/get_alarm_mute_rule.go
@@ -1,0 +1,159 @@
+package cloudwatch
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+type GetAlarmMuteRule struct{}
+
+type GetAlarmMuteRuleConfiguration struct {
+	Region string `json:"region" mapstructure:"region"`
+	Name   string `json:"name" mapstructure:"name"`
+}
+
+type GetAlarmMuteRuleNodeMetadata struct {
+	Region string `json:"region" mapstructure:"region"`
+	Name   string `json:"name" mapstructure:"name"`
+}
+
+func (c *GetAlarmMuteRule) Name() string {
+	return "aws.cloudwatch.getAlarmMuteRule"
+}
+
+func (c *GetAlarmMuteRule) Label() string {
+	return "CloudWatch • Get Alarm Mute Rule"
+}
+
+func (c *GetAlarmMuteRule) Description() string {
+	return "Fetch the current configuration and status of a CloudWatch alarm mute rule"
+}
+
+func (c *GetAlarmMuteRule) Documentation() string {
+	return `The Get Alarm Mute Rule component describes a CloudWatch alarm mute rule and emits its current details.
+
+## Use Cases
+
+- **Status inspection**: Check whether a mute rule is SCHEDULED, ACTIVE or EXPIRED before taking action
+- **Audit**: Record a mute rule's targeted alarms and schedule at a point in time
+
+## Configuration
+
+- **Region**: AWS region the mute rule lives in
+- **Name**: Name of the mute rule to describe
+
+## Output
+
+Emits the mute rule details on the default output channel:
+- ` + "`name`" + `, ` + "`alarmMuteRuleArn`" + `, ` + "`description`" + `
+- ` + "`scheduleExpression`" + `, ` + "`scheduleDuration`" + `, ` + "`scheduleTimezone`" + `
+- ` + "`alarmNames`" + `, ` + "`startDate`" + `, ` + "`expireDate`" + `
+- ` + "`status`" + `, ` + "`muteType`" + `, ` + "`lastUpdatedTimestamp`" + `
+`
+}
+
+func (c *GetAlarmMuteRule) Icon() string {
+	return "aws"
+}
+
+func (c *GetAlarmMuteRule) Color() string {
+	return "gray"
+}
+
+func (c *GetAlarmMuteRule) OutputChannels(_ any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetAlarmMuteRule) Configuration() []configuration.Field {
+	return []configuration.Field{
+		regionField(),
+		{
+			Name:        "name",
+			Label:       "Name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Name of the mute rule to describe",
+		},
+	}
+}
+
+func (c *GetAlarmMuteRule) Setup(ctx core.SetupContext) error {
+	config := GetAlarmMuteRuleConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+
+	name, err := requireAlarmMuteRuleName(config.Name)
+	if err != nil {
+		return err
+	}
+
+	return ctx.Metadata.Set(GetAlarmMuteRuleNodeMetadata{
+		Region: region,
+		Name:   name,
+	})
+}
+
+func (c *GetAlarmMuteRule) Execute(ctx core.ExecutionContext) error {
+	config := GetAlarmMuteRuleConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+
+	name, err := requireAlarmMuteRuleName(config.Name)
+	if err != nil {
+		return err
+	}
+
+	creds, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	client := NewClient(ctx.HTTP, creds, region)
+	rule, err := client.GetAlarmMuteRule(name)
+	if err != nil {
+		return fmt.Errorf("failed to get alarm mute rule: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetAlarmMuteRulePayloadType,
+		[]any{alarmMuteRuleToMap(rule)},
+	)
+}
+
+func (c *GetAlarmMuteRule) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetAlarmMuteRule) HandleHook(_ core.ActionHookContext) error {
+	return nil
+}
+
+func (c *GetAlarmMuteRule) Cancel(_ core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetAlarmMuteRule) Cleanup(_ core.SetupContext) error {
+	return nil
+}
+
+func (c *GetAlarmMuteRule) HandleWebhook(_ core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}

--- a/pkg/integrations/aws/cloudwatch/get_alarm_mute_rule_test.go
+++ b/pkg/integrations/aws/cloudwatch/get_alarm_mute_rule_test.go
@@ -1,0 +1,135 @@
+package cloudwatch
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func validGetAlarmMuteRuleConfig() map[string]any {
+	return map[string]any{
+		"region": "us-east-1",
+		"name":   "DailyMaintenanceWindow",
+	}
+}
+
+func Test__GetAlarmMuteRule__Setup(t *testing.T) {
+	component := &GetAlarmMuteRule{}
+
+	t.Run("missing region -> error", func(t *testing.T) {
+		configuration := validGetAlarmMuteRuleConfig()
+		configuration["region"] = " "
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "region is required")
+	})
+
+	t.Run("missing name -> error", func(t *testing.T) {
+		configuration := validGetAlarmMuteRuleConfig()
+		configuration["name"] = " "
+		err := component.Setup(core.SetupContext{Configuration: configuration})
+		require.ErrorContains(t, err, "name is required")
+	})
+
+	t.Run("valid configuration -> no error", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: validGetAlarmMuteRuleConfig(),
+			Metadata:      metadata,
+		})
+		require.NoError(t, err)
+
+		nodeMetadata, ok := metadata.Metadata.(GetAlarmMuteRuleNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "us-east-1", nodeMetadata.Region)
+		assert.Equal(t, "DailyMaintenanceWindow", nodeMetadata.Name)
+	})
+}
+
+func Test__GetAlarmMuteRule__Execute(t *testing.T) {
+	component := &GetAlarmMuteRule{}
+
+	t.Run("fetches and emits the rule details", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(getAlarmMuteRuleXML))},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{}
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  validGetAlarmMuteRuleConfig(),
+			HTTP:           httpContext,
+			ExecutionState: executionState,
+			Integration:    awsIntegrationContext(),
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, GetAlarmMuteRulePayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		wrapped := executionState.Payloads[0].(map[string]any)
+		data := wrapped["data"].(map[string]any)
+		assert.Equal(t, "DailyMaintenanceWindow", data["name"])
+		assert.Equal(t, "arn:aws:cloudwatch:us-east-1:123456789012:alarm-mute-rule:DailyMaintenanceWindow", data["alarmMuteRuleArn"])
+		assert.Equal(t, "cron(0 2 * * *)", data["scheduleExpression"])
+		assert.Equal(t, "PT2H", data["scheduleDuration"])
+		assert.Equal(t, "UTC", data["scheduleTimezone"])
+		assert.Equal(t, []string{"WebServerCPUAlarm", "DatabaseConnectionAlarm"}, data["alarmNames"])
+		assert.Equal(t, "SCHEDULED", data["status"])
+		assert.Equal(t, "RECURRING", data["muteType"])
+	})
+
+	t.Run("requests the rule by name", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(getAlarmMuteRuleXML))},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  validGetAlarmMuteRuleConfig(),
+			HTTP:           httpContext,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Integration:    awsIntegrationContext(),
+		})
+		require.NoError(t, err)
+
+		body := requestBody(t, httpContext, 0)
+		assert.Contains(t, body, "Action=GetAlarmMuteRule")
+		assert.Contains(t, body, "AlarmMuteRuleName=DailyMaintenanceWindow")
+	})
+
+	t.Run("rule not found -> error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body: io.NopCloser(strings.NewReader(`
+<ErrorResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
+  <Error>
+    <Code>ResourceNotFoundException</Code>
+    <Message>rule not found</Message>
+  </Error>
+</ErrorResponse>`)),
+				},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  validGetAlarmMuteRuleConfig(),
+			HTTP:           httpContext,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Integration:    awsIntegrationContext(),
+		})
+
+		require.ErrorContains(t, err, "failed to get alarm mute rule")
+		require.ErrorContains(t, err, "rule not found")
+	})
+}


### PR DESCRIPTION
Adds `aws.cloudwatch.createAlarmMuteRule` and `aws.cloudwatch.getAlarmMuteRule`, wrapping CloudWatch's `PutAlarmMuteRule`/`GetAlarmMuteRule` — schedule-based alarm silencing, similar to a Grafana silence.
