### PR TITLE
feat: Drop factory line step name

### DIFF
--- a/pkg/grpc/actions/factories/dispatch_work_order_test.go
+++ b/pkg/grpc/actions/factories/dispatch_work_order_test.go
@@ -33,7 +33,7 @@ func Test__DispatchWorkOrder__CreatesLineDispatchWithSnapshot(t *testing.T) {
 
 	app, entrypoint := support.CreateFactoryAppWithOnRunTrigger(t, r, factoryModel.ID, "step-one", "start-one")
 	line, err := factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: entrypoint},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: entrypoint},
 	})
 	require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func Test__DispatchWorkOrder__CreatesLineDispatchWithSnapshot(t *testing.T) {
 	assert.Equal(t, pb.WorkOrderLineDispatch_STATE_ACTIVE, dispatch.State)
 	assert.Equal(t, line.Name, dispatch.Line.Name)
 	require.Len(t, dispatch.Steps, 1)
-	assert.Equal(t, "step-one", dispatch.Steps[0].Name)
+	assert.Equal(t, app.Name, dispatch.Steps[0].Name)
 	require.Len(t, dispatch.StepExecutions, 1)
 	assert.Equal(t, pb.WorkOrderExecution_STATE_PENDING, dispatch.StepExecutions[0].State)
 
@@ -78,7 +78,7 @@ func Test__DispatchWorkOrder__RejectsWhenAlreadyActive(t *testing.T) {
 
 	app, entrypoint := support.CreateFactoryAppWithOnRunTrigger(t, r, factoryModel.ID, "step-one", "start-one")
 	line, err := factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: entrypoint},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: entrypoint},
 	})
 	require.NoError(t, err)
 
@@ -117,7 +117,7 @@ func Test__DispatchWorkOrder__SecondDispatchAfterFirstFinishesCreatesSeparateTra
 
 	app, entrypoint := support.CreateFactoryAppWithOnRunTrigger(t, r, factoryModel.ID, "step-one", "start-one")
 	line, err := factoryModel.CreateLine(db, "ship", []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: entrypoint},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: app.ID, Entrypoint: entrypoint},
 	})
 	require.NoError(t, err)
 

--- a/pkg/grpc/actions/factories/line_steps.go
+++ b/pkg/grpc/actions/factories/line_steps.go
@@ -29,11 +29,9 @@ func parseLineSteps(
 		return nil, invalidArgument("at least one step is required")
 	}
 
-	seenNames := make(map[string]struct{}, len(steps))
 	result := make([]models.FactoryLineStep, 0, len(steps))
-
 	for i, step := range steps {
-		parsed, err := parseLineStep(tx, organizationID, factoryID, step, i+1, seenNames)
+		parsed, err := parseLineStep(tx, organizationID, factoryID, step, i+1)
 		if err != nil {
 			return nil, err
 		}
@@ -48,37 +46,26 @@ func parseLineStep(
 	organizationID, factoryID uuid.UUID,
 	step *pb.FactoryLine_Step,
 	stepNumber int,
-	seenNames map[string]struct{},
 ) (models.FactoryLineStep, error) {
-	name := strings.TrimSpace(step.GetName())
-	if name == "" {
-		return models.FactoryLineStep{}, invalidArgument(fmt.Sprintf("step %d: name is required", stepNumber))
-	}
-
-	if _, exists := seenNames[name]; exists {
-		return models.FactoryLineStep{}, invalidArgument(fmt.Sprintf("duplicate step name %q", name))
-	}
-	seenNames[name] = struct{}{}
-
 	stepType := strings.TrimSpace(step.GetType())
 	if stepType != models.FactoryLineStepTypeRunApp {
 		return models.FactoryLineStep{}, invalidArgument(
-			fmt.Sprintf("step %q: unsupported type %q", name, stepType),
+			fmt.Sprintf("step %d: unsupported type %q", stepNumber, stepType),
 		)
 	}
 
 	appStep := step.GetApp()
 	if appStep == nil {
-		return models.FactoryLineStep{}, invalidArgument(fmt.Sprintf("step %q: app is required", name))
+		return models.FactoryLineStep{}, invalidArgument(fmt.Sprintf("step %d: app is required", stepNumber))
 	}
 
 	appRef := strings.TrimSpace(appStep.GetApp())
 	entrypoint := strings.TrimSpace(appStep.GetEntrypoint())
 	if appRef == "" {
-		return models.FactoryLineStep{}, invalidArgument(fmt.Sprintf("step %q: app is required", name))
+		return models.FactoryLineStep{}, invalidArgument(fmt.Sprintf("step %d: app is required", stepNumber))
 	}
 	if entrypoint == "" {
-		return models.FactoryLineStep{}, invalidArgument(fmt.Sprintf("step %q: entrypoint is required", name))
+		return models.FactoryLineStep{}, invalidArgument(fmt.Sprintf("step %d: entrypoint is required", stepNumber))
 	}
 
 	canvas, err := resolveFactoryOwnedApp(tx, organizationID, factoryID, appRef)
@@ -90,7 +77,7 @@ func parseLineStep(
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return models.FactoryLineStep{}, invalidArgument(
-				fmt.Sprintf("step %q: entrypoint %q not found", name, entrypoint),
+				fmt.Sprintf("step %d: entrypoint %q not found", stepNumber, entrypoint),
 			)
 		}
 		return models.FactoryLineStep{}, err
@@ -98,12 +85,11 @@ func parseLineStep(
 
 	if node.Type != models.NodeTypeTrigger {
 		return models.FactoryLineStep{}, invalidArgument(
-			fmt.Sprintf("step %q: entrypoint %q is not a trigger", name, entrypoint),
+			fmt.Sprintf("step %d: entrypoint %q is not a trigger", stepNumber, entrypoint),
 		)
 	}
 
 	return models.FactoryLineStep{
-		Name:       name,
 		Type:       models.FactoryLineStepTypeRunApp,
 		AppID:      canvas.ID,
 		Entrypoint: entrypoint,

--- a/pkg/grpc/actions/factories/serialization.go
+++ b/pkg/grpc/actions/factories/serialization.go
@@ -108,7 +108,6 @@ func serializeFactoryLine(line *models.FactoryLine) *pb.FactoryLine {
 	steps := make([]*pb.FactoryLine_Step, len(line.Steps))
 	for i, step := range line.Steps {
 		steps[i] = &pb.FactoryLine_Step{
-			Name: step.Name,
 			Type: step.Type,
 			App: &pb.FactoryLine_AppStep{
 				App:        step.AppID.String(),
@@ -232,7 +231,7 @@ func serializeWorkOrderLineDispatch(dispatch models.FactoryWorkOrderLineDispatch
 			Id:   dispatch.LineID.String(),
 			Name: dispatch.LineName,
 		},
-		Steps:          serializeExecutionSteps(dispatch.Steps),
+		Steps:          serializeExecutionSteps(dispatch.Steps, dispatch.Executions),
 		State:          serializeLineDispatchState(dispatch.State),
 		Result:         serializeLineDispatchResult(dispatch.Result),
 		CreatedAt:      timestamppb.New(dispatch.CreatedAt),
@@ -299,14 +298,25 @@ func serializeWorkOrderExecution(execution models.FactoryWorkOrderExecutionRecor
 	return item
 }
 
-func serializeExecutionSteps(steps []models.FactoryLineStep) []*pb.WorkOrderExecutionStep {
+func serializeExecutionSteps(
+	steps []models.FactoryLineStep,
+	executions []models.FactoryWorkOrderExecutionRecord,
+) []*pb.WorkOrderExecutionStep {
 	if len(steps) == 0 {
 		return nil
 	}
+
+	nameByIndex := make(map[int]string, len(executions))
+	for _, execution := range executions {
+		if execution.CanvasName != "" {
+			nameByIndex[execution.StepIndex] = execution.CanvasName
+		}
+	}
+
 	result := make([]*pb.WorkOrderExecutionStep, len(steps))
-	for i, step := range steps {
+	for i := range steps {
 		result[i] = &pb.WorkOrderExecutionStep{
-			Name:      step.Name,
+			Name:      nameByIndex[i],
 			StepIndex: int32(i),
 		}
 	}

--- a/pkg/grpc/actions/factories/serialization_test.go
+++ b/pkg/grpc/actions/factories/serialization_test.go
@@ -58,26 +58,31 @@ func TestSerializeWorkOrderCreator_NoneReturnsNil(t *testing.T) {
 	assert.Nil(t, serializeWorkOrder(nil, order, nil, nil).GetCreatedBy())
 }
 
-func TestSerializeExecutionSteps_SnapshotsLineSteps(t *testing.T) {
+func TestSerializeExecutionSteps_UsesCanvasNames(t *testing.T) {
 	steps := []models.FactoryLineStep{
-		{Name: "plan"},
-		{Name: "implement"},
-		{Name: "verify"},
+		{Type: models.FactoryLineStepTypeRunApp},
+		{Type: models.FactoryLineStepTypeRunApp},
+		{Type: models.FactoryLineStepTypeRunApp},
+	}
+	executions := []models.FactoryWorkOrderExecutionRecord{
+		{FactoryWorkOrderExecution: models.FactoryWorkOrderExecution{StepIndex: 0}, CanvasName: "plan-app"},
+		{FactoryWorkOrderExecution: models.FactoryWorkOrderExecution{StepIndex: 1}, CanvasName: "implement-app"},
+		{FactoryWorkOrderExecution: models.FactoryWorkOrderExecution{StepIndex: 2}, CanvasName: "verify-app"},
 	}
 
-	out := serializeExecutionSteps(steps)
+	out := serializeExecutionSteps(steps, executions)
 	require.Len(t, out, 3)
-	assert.Equal(t, "plan", out[0].GetName())
+	assert.Equal(t, "plan-app", out[0].GetName())
 	assert.EqualValues(t, 0, out[0].GetStepIndex())
-	assert.Equal(t, "implement", out[1].GetName())
+	assert.Equal(t, "implement-app", out[1].GetName())
 	assert.EqualValues(t, 1, out[1].GetStepIndex())
-	assert.Equal(t, "verify", out[2].GetName())
+	assert.Equal(t, "verify-app", out[2].GetName())
 	assert.EqualValues(t, 2, out[2].GetStepIndex())
 }
 
 func TestSerializeExecutionSteps_EmptyReturnsNil(t *testing.T) {
-	assert.Nil(t, serializeExecutionSteps(nil))
-	assert.Nil(t, serializeExecutionSteps([]models.FactoryLineStep{}))
+	assert.Nil(t, serializeExecutionSteps(nil, nil))
+	assert.Nil(t, serializeExecutionSteps([]models.FactoryLineStep{}, nil))
 }
 
 func TestSerializeWorkOrder_LineDispatchesReplaceFlatExecutions(t *testing.T) {
@@ -93,8 +98,8 @@ func TestSerializeWorkOrder_LineDispatchesReplaceFlatExecutions(t *testing.T) {
 				LineID:   lineID,
 				LineName: "ship",
 				Steps: datatypes.NewJSONSlice([]models.FactoryLineStep{
-					{Name: "step-one"},
-					{Name: "step-two"},
+					{Type: models.FactoryLineStepTypeRunApp},
+					{Type: models.FactoryLineStepTypeRunApp},
 				}),
 				State: models.FactoryWorkOrderLineDispatchStateActive,
 			},
@@ -127,8 +132,8 @@ func TestSerializeWorkOrder_LineDispatchesReplaceFlatExecutions(t *testing.T) {
 	assert.Equal(t, "ship", dispatch.Line.Name)
 	assert.Equal(t, pb.WorkOrderLineDispatch_STATE_ACTIVE, dispatch.State)
 	require.Len(t, dispatch.Steps, 2)
-	assert.Equal(t, "step-one", dispatch.Steps[0].Name)
-	assert.Equal(t, "step-two", dispatch.Steps[1].Name)
+	assert.Equal(t, "step-one-app", dispatch.Steps[0].Name)
+	assert.Equal(t, "", dispatch.Steps[1].Name)
 
 	require.Len(t, dispatch.StepExecutions, 1)
 	execution := dispatch.StepExecutions[0]

--- a/pkg/grpc/actions/factories/update_factory_onboarding_test.go
+++ b/pkg/grpc/actions/factories/update_factory_onboarding_test.go
@@ -194,7 +194,6 @@ func createOnboardingResources(
 	require.NoError(t, database.DB(t.Context()).Model(app).Update("factory_id", factory.ID).Error)
 	line, err := factory.CreateLine(database.DB(t.Context()), support.RandomName("line"), []models.FactoryLineStep{
 		{
-			Name:       "Build",
 			Type:       models.FactoryLineStepTypeRunApp,
 			AppID:      app.ID,
 			Entrypoint: "work-order-dispatch",

--- a/pkg/models/factory/events.go
+++ b/pkg/models/factory/events.go
@@ -168,7 +168,8 @@ type LineRef struct {
 }
 
 type AppRef struct {
-	ID uuid.UUID `json:"id"`
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name,omitempty"`
 }
 
 type RunRef struct {

--- a/pkg/models/factory_line.go
+++ b/pkg/models/factory_line.go
@@ -25,7 +25,6 @@ var (
 )
 
 type FactoryLineStep struct {
-	Name       string    `json:"name"`
 	Type       string    `json:"type"`
 	AppID      uuid.UUID `json:"app_id"`
 	Entrypoint string    `json:"entrypoint"`

--- a/pkg/models/factory_work_order_execution.go
+++ b/pkg/models/factory_work_order_execution.go
@@ -29,8 +29,9 @@ type FactoryWorkOrderExecution struct {
 	WorkOrderID    uuid.UUID
 	LineID         uuid.UUID
 	// LineDispatchID is the parent traversal this step run belongs to. Its
-	// steps snapshot is authoritative for what StepIndex/StepName refer to
-	// — see FactoryWorkOrderLineDispatch.
+	// steps snapshot is authoritative for what StepIndex refers to —
+	// see FactoryWorkOrderLineDispatch. StepName is the automation
+	// (canvas) name captured when the step started.
 	LineDispatchID uuid.UUID
 	StepIndex      int
 	StepName       string
@@ -125,7 +126,7 @@ func (e *FactoryWorkOrderExecution) RecordFinished(tx *gorm.DB, result string) e
 		StepName: e.StepName,
 		Order:    order.Ref(),
 		Line:     dispatch.Ref(),
-		App:      &factory.AppRef{ID: run.WorkflowID},
+		App:      &factory.AppRef{ID: run.WorkflowID, Name: e.StepName},
 		Run:      &factory.RunRef{ID: run.ID, State: run.State, Result: &run.Result},
 	}
 

--- a/pkg/models/factory_work_order_line_dispatch.go
+++ b/pkg/models/factory_work_order_line_dispatch.go
@@ -125,6 +125,11 @@ func (l *FactoryWorkOrderLineDispatch) StartStep(tx *gorm.DB, order *FactoryWork
 		return nil, err
 	}
 
+	canvas, err := FindCanvasInTransaction(tx, l.OrganizationID, step.AppID)
+	if err != nil {
+		return nil, err
+	}
+
 	runInput, err := factoryWorkOrderRunInput(tx, order)
 	if err != nil {
 		return nil, err
@@ -161,7 +166,7 @@ func (l *FactoryWorkOrderLineDispatch) StartStep(tx *gorm.DB, order *FactoryWork
 		LineID:         l.LineID,
 		LineDispatchID: l.ID,
 		StepIndex:      stepIndex,
-		StepName:       step.Name,
+		StepName:       canvas.Name,
 		RunID:          run.ID,
 		Status:         FactoryWorkOrderExecutionStatusPending,
 		Result:         "",
@@ -173,7 +178,7 @@ func (l *FactoryWorkOrderLineDispatch) StartStep(tx *gorm.DB, order *FactoryWork
 		return nil, err
 	}
 
-	if err := l.RecordStepExecutionCreated(tx, order, execution, &step, run); err != nil {
+	if err := l.RecordStepExecutionCreated(tx, order, execution, run); err != nil {
 		return nil, err
 	}
 
@@ -187,14 +192,13 @@ func (l *FactoryWorkOrderLineDispatch) RecordStepExecutionCreated(
 	tx *gorm.DB,
 	order *FactoryWorkOrder,
 	execution *FactoryWorkOrderExecution,
-	step *FactoryLineStep,
 	run *CanvasRun,
 ) error {
 	data := factory.LineStepExecutionCreated{
-		StepName: step.Name,
+		StepName: execution.StepName,
 		Order:    order.Ref(),
 		Line:     l.Ref(),
-		App:      &factory.AppRef{ID: run.WorkflowID},
+		App:      &factory.AppRef{ID: run.WorkflowID, Name: execution.StepName},
 		Run:      &factory.RunRef{ID: run.ID, State: run.State},
 	}
 

--- a/pkg/models/factory_work_order_line_dispatch_test.go
+++ b/pkg/models/factory_work_order_line_dispatch_test.go
@@ -29,8 +29,8 @@ func Test__FactoryLine__Dispatch__SnapshotsLineAndStartsStepZero(t *testing.T) {
 	firstApp, firstEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-one", "start-one")
 	secondApp, secondEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-two", "start-two")
 	steps := []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
-		{Name: "step-two", Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
 	}
 	require.NoError(t, line.Update(db, nil, steps))
 
@@ -49,14 +49,14 @@ func Test__FactoryLine__Dispatch__SnapshotsLineAndStartsStepZero(t *testing.T) {
 	assert.Empty(t, dispatch.Result)
 	assert.Nil(t, dispatch.FinishedAt)
 	require.Len(t, []models.FactoryLineStep(dispatch.Steps), 2)
-	assert.Equal(t, "step-one", dispatch.Steps[0].Name)
-	assert.Equal(t, "step-two", dispatch.Steps[1].Name)
+	assert.Equal(t, firstApp.ID, dispatch.Steps[0].AppID)
+	assert.Equal(t, secondApp.ID, dispatch.Steps[1].AppID)
 
 	require.NotNil(t, result)
 	execution := result.Execution
 	assert.Equal(t, dispatch.ID, execution.LineDispatchID)
 	assert.Equal(t, 0, execution.StepIndex)
-	assert.Equal(t, "step-one", execution.StepName)
+	assert.Equal(t, firstApp.Name, execution.StepName)
 	assert.Equal(t, models.FactoryWorkOrderExecutionStatusPending, execution.Status)
 }
 
@@ -102,8 +102,8 @@ func Test__FactoryWorkOrderLineDispatch__StartStep__UsesSnapshotNotLiveLine(t *t
 	firstApp, firstEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-one", "start-one")
 	secondApp, secondEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-two", "start-two")
 	require.NoError(t, line.Update(db, nil, []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
-		{Name: "step-two", Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
 	}))
 
 	var dispatch *models.FactoryWorkOrderLineDispatch
@@ -116,8 +116,8 @@ func Test__FactoryWorkOrderLineDispatch__StartStep__UsesSnapshotNotLiveLine(t *t
 	// Replace the live line's steps entirely with a different app at index 1.
 	thirdApp, thirdEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-two-replaced", "start-replaced")
 	require.NoError(t, line.Update(db, nil, []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
-		{Name: "step-two-replaced", Type: models.FactoryLineStepTypeRunApp, AppID: thirdApp.ID, Entrypoint: thirdEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: thirdApp.ID, Entrypoint: thirdEntry},
 	}))
 
 	var result *models.FactoryLineStepResult
@@ -129,7 +129,7 @@ func Test__FactoryWorkOrderLineDispatch__StartStep__UsesSnapshotNotLiveLine(t *t
 
 	assert.Equal(t, secondApp.ID, result.Run.WorkflowID,
 		"the dispatch's own snapshot still points at the originally dispatched app")
-	assert.Equal(t, "step-two", result.Execution.StepName)
+	assert.Equal(t, secondApp.Name, result.Execution.StepName)
 }
 
 func Test__FactoryWorkOrderLineDispatch__Finish(t *testing.T) {

--- a/pkg/workers/contexts/factory_context.go
+++ b/pkg/workers/contexts/factory_context.go
@@ -358,7 +358,7 @@ func (c *FactoryContext) appRef() *factory.AppRef {
 		return nil
 	}
 
-	return &factory.AppRef{ID: c.canvas.ID}
+	return &factory.AppRef{ID: c.canvas.ID, Name: c.canvas.Name}
 }
 
 // automationRef captures node/app/line/step identity for timeline

--- a/pkg/workers/run_finalizer_test.go
+++ b/pkg/workers/run_finalizer_test.go
@@ -562,13 +562,11 @@ func Test__RunFinalizer__ExecuteNextFactoryLineStep(t *testing.T) {
 
 	steps := []models.FactoryLineStep{
 		{
-			Name:       "step-one",
 			Type:       models.FactoryLineStepTypeRunApp,
 			AppID:      firstApp.ID,
 			Entrypoint: firstEntry,
 		},
 		{
-			Name:       "step-two",
 			Type:       models.FactoryLineStepTypeRunApp,
 			AppID:      secondApp.ID,
 			Entrypoint: secondEntry,
@@ -611,7 +609,7 @@ func Test__RunFinalizer__ExecuteNextFactoryLineStep(t *testing.T) {
 	secondExecution, err := models.FindWorkOrderExecutionByRunID(database.Conn(), pending.runID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, secondExecution.StepIndex)
-	assert.Equal(t, "step-two", secondExecution.StepName)
+	assert.Equal(t, secondApp.Name, secondExecution.StepName)
 	assert.Equal(t, models.FactoryWorkOrderExecutionStatusPending, secondExecution.Status)
 	assert.Equal(t, firstExecution.LineDispatchID, secondExecution.LineDispatchID,
 		"both steps of the same traversal share one line dispatch")
@@ -641,7 +639,7 @@ func Test__RunFinalizer__ExecuteNextFactoryLineStep__FinishesDispatchOnLastStepP
 
 	onlyApp, onlyEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-one", "start-one")
 	require.NoError(t, line.Update(database.Conn(), nil, []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: onlyApp.ID, Entrypoint: onlyEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: onlyApp.ID, Entrypoint: onlyEntry},
 	}))
 
 	var dispatch *models.FactoryWorkOrderLineDispatch
@@ -705,8 +703,8 @@ func testExecuteNextFactoryLineStepFinishesDispatchWithResult(t *testing.T, term
 	firstApp, firstEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-one", "start-one")
 	secondApp, secondEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-two", "start-two")
 	require.NoError(t, line.Update(database.Conn(), nil, []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
-		{Name: "step-two", Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
 	}))
 
 	var dispatch *models.FactoryWorkOrderLineDispatch
@@ -761,8 +759,8 @@ func Test__RunFinalizer__ExecuteNextFactoryLineStep__CancelsDispatchWhenOrderClo
 	firstApp, firstEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-one", "start-one")
 	secondApp, secondEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-two", "start-two")
 	require.NoError(t, line.Update(database.Conn(), nil, []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
-		{Name: "step-two", Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
 	}))
 
 	var dispatch *models.FactoryWorkOrderLineDispatch
@@ -822,8 +820,8 @@ func Test__RunFinalizer__ExecuteNextFactoryLineStep__LineEditMidTraversalDoesNot
 	firstApp, firstEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-one", "start-one")
 	secondApp, secondEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "step-two", "start-two")
 	require.NoError(t, line.Update(database.Conn(), nil, []models.FactoryLineStep{
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
-		{Name: "step-two", Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
 	}))
 
 	var result *models.FactoryLineStepResult
@@ -838,9 +836,9 @@ func Test__RunFinalizer__ExecuteNextFactoryLineStep__LineEditMidTraversalDoesNot
 	// with the dispatch's snapshot about what "step two" is.
 	insertedApp, insertedEntry := support.CreateFactoryAppWithOnRunTrigger(t, r, factory.ID, "inserted", "start-inserted")
 	require.NoError(t, line.Update(database.Conn(), nil, []models.FactoryLineStep{
-		{Name: "inserted", Type: models.FactoryLineStepTypeRunApp, AppID: insertedApp.ID, Entrypoint: insertedEntry},
-		{Name: "step-one", Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
-		{Name: "step-two-renamed", Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: insertedApp.ID, Entrypoint: insertedEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: firstApp.ID, Entrypoint: firstEntry},
+		{Type: models.FactoryLineStepTypeRunApp, AppID: secondApp.ID, Entrypoint: secondEntry},
 	}))
 
 	now := time.Now()
@@ -867,8 +865,8 @@ func Test__RunFinalizer__ExecuteNextFactoryLineStep__LineEditMidTraversalDoesNot
 	secondExecution, err := models.FindWorkOrderExecutionByRunID(database.Conn(), pending.runID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, secondExecution.StepIndex)
-	assert.Equal(t, "step-two", secondExecution.StepName,
-		"the snapshot's original step name, unaffected by the later rename")
+	assert.Equal(t, secondApp.Name, secondExecution.StepName,
+		"the snapshot's original automation name, unaffected by the later line edit")
 }
 
 // dispatchWorkOrderForTest promotes a draft order to open, mirroring
@@ -900,13 +898,11 @@ func Test__RunFinalizer__FinalizeRunAdvancesFactoryLineInSameTransaction(t *test
 
 	steps := []models.FactoryLineStep{
 		{
-			Name:       "step-one",
 			Type:       models.FactoryLineStepTypeRunApp,
 			AppID:      firstApp.ID,
 			Entrypoint: firstEntry,
 		},
 		{
-			Name:       "step-two",
 			Type:       models.FactoryLineStepTypeRunApp,
 			AppID:      secondApp.ID,
 			Entrypoint: secondEntry,
@@ -946,7 +942,7 @@ func Test__RunFinalizer__FinalizeRunAdvancesFactoryLineInSameTransaction(t *test
 	secondExecution, err := models.FindWorkOrderExecutionByRunID(database.Conn(), secondRun.ID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, secondExecution.StepIndex)
-	assert.Equal(t, "step-two", secondExecution.StepName)
+	assert.Equal(t, secondApp.Name, secondExecution.StepName)
 }
 
 func Test__RunFinalizer__FinalizeRunRollsBackWhenFactoryLineAdvanceFails(t *testing.T) {
@@ -968,13 +964,11 @@ func Test__RunFinalizer__FinalizeRunRollsBackWhenFactoryLineAdvanceFails(t *test
 
 	steps := []models.FactoryLineStep{
 		{
-			Name:       "step-one",
 			Type:       models.FactoryLineStepTypeRunApp,
 			AppID:      firstApp.ID,
 			Entrypoint: firstEntry,
 		},
 		{
-			Name:       "step-two",
 			Type:       models.FactoryLineStepTypeRunApp,
 			AppID:      secondApp.ID,
 			Entrypoint: "missing-entrypoint",

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -407,9 +407,8 @@ message Factory {
 
 message FactoryLine {
   message Step {
-    string name = 1;
-    string type = 2;
-    optional AppStep app = 3;
+    string type = 1;
+    optional AppStep app = 2;
   }
 
   message AppStep {

--- a/web_src/src/pages/factories/FactoryLineStepEditor.tsx
+++ b/web_src/src/pages/factories/FactoryLineStepEditor.tsx
@@ -1,5 +1,4 @@
 import type { FactoryApp } from "@/api-client";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useCanvas } from "@/hooks/useCanvasData";
@@ -35,18 +34,7 @@ export function FactoryLineStepEditor({
 
   return (
     <LineStepEditorShell>
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <div className={cn("space-y-2", stepFieldClassName)}>
-          <Label htmlFor={`factory-line-step-name-${index}`}>Step name</Label>
-          <Input
-            id={`factory-line-step-name-${index}`}
-            className={stepFieldClassName}
-            value={step.name}
-            onChange={(event) => onChange({ ...step, name: event.target.value })}
-            placeholder="start-implementation"
-          />
-        </div>
-
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <div className={cn("space-y-2", stepFieldClassName)}>
           <Label htmlFor={`factory-line-step-app-${index}`}>Automation</Label>
           <Select

--- a/web_src/src/pages/factories/FactoryLineStepFlow.stories.tsx
+++ b/web_src/src/pages/factories/FactoryLineStepFlow.stories.tsx
@@ -22,7 +22,7 @@ export const StepNode: Story = {
   name: "LineStepDisplayNode",
   render: () => (
     <div className="w-64">
-      <LineStepDisplayNode stepName="implement" appName="Refund Implementer" entrypoint="start-implementation" />
+      <LineStepDisplayNode appName="Refund Implementer" entrypoint="start-implementation" />
     </div>
   ),
 };
@@ -58,11 +58,11 @@ export const CompactFlow: Story = {
   name: "LineStepFlow (compact)",
   render: () => (
     <LineStepFlow className="w-64">
-      <LineStepDisplayNode stepName="plan" appName="Refund Planner" entrypoint="start-plan" />
+      <LineStepDisplayNode appName="Refund Planner" entrypoint="start-plan" />
       <LineStepArrow />
-      <LineStepDisplayNode stepName="implement" appName="Refund Implementer" entrypoint="start-implementation" />
+      <LineStepDisplayNode appName="Refund Implementer" entrypoint="start-implementation" />
       <LineStepArrow />
-      <LineStepDisplayNode stepName="verify" appName="Refund Verifier" entrypoint="start-verification" />
+      <LineStepDisplayNode appName="Refund Verifier" entrypoint="start-verification" />
       <LineStepAddButton onClick={() => console.log("add step")} />
     </LineStepFlow>
   ),

--- a/web_src/src/pages/factories/FactoryLineStepFlow.tsx
+++ b/web_src/src/pages/factories/FactoryLineStepFlow.tsx
@@ -13,13 +13,12 @@ export function LineStepArrow({ className }: { className?: string }) {
 }
 
 interface LineStepDisplayNodeProps {
-  stepName: string;
   appName: string;
   entrypoint?: string;
   className?: string;
 }
 
-export function LineStepDisplayNode({ stepName, appName, entrypoint, className }: LineStepDisplayNodeProps) {
+export function LineStepDisplayNode({ appName, entrypoint, className }: LineStepDisplayNodeProps) {
   return (
     <div
       className={cn(
@@ -27,9 +26,8 @@ export function LineStepDisplayNode({ stepName, appName, entrypoint, className }
         className,
       )}
     >
-      <p className="text-sm font-medium text-slate-900 dark:text-gray-100">{stepName || "Unnamed step"}</p>
-      <p className="mt-1 truncate text-xs text-gray-500 dark:text-gray-400">{appName}</p>
-      {entrypoint ? <p className="mt-0.5 truncate text-[11px] text-gray-400 dark:text-gray-500">{entrypoint}</p> : null}
+      <p className="text-sm font-medium text-slate-900 dark:text-gray-100">{appName || "Unnamed automation"}</p>
+      {entrypoint ? <p className="mt-1 truncate text-xs text-gray-500 dark:text-gray-400">{entrypoint}</p> : null}
     </div>
   );
 }

--- a/web_src/src/pages/factories/__fixtures__/factoryPageEventFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageEventFixtures.ts
@@ -87,7 +87,7 @@ function stepExecutionCreatedEvent(input: StepExecutionEventFixture): FactoriesW
       stepName,
       order: { id: order.id, title: order.title },
       line: REFUND_LINE,
-      app: { id: appId },
+      app: { id: appId, name: stepName },
       run: { id: runId, state: "pending" },
     },
   };
@@ -104,7 +104,7 @@ function stepExecutionFinishedEvent(
       stepName,
       order: { id: order.id, title: order.title },
       line: REFUND_LINE,
-      app: { id: appId },
+      app: { id: appId, name: stepName },
       run: { id: runId, state: "finished", result },
     },
   };
@@ -268,7 +268,7 @@ export const CLOSED_FAILED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
     nodeName: "node-close",
     appName: "Refund Diagnostics",
     lineName: "Plan",
-    stepName: "step-01",
+    stepName: "Refund Diagnostics",
   }),
 ];
 
@@ -276,14 +276,14 @@ export const RUNNING_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   openedWorkOrderEvent(RUNNING_WORK_ORDER, YESTERDAY),
   stepExecutionCreatedEvent({
     order: RUNNING_WORK_ORDER,
-    stepName: "plan",
+    stepName: "Refund Planner",
     at: TWO_HOURS_AGO,
     runId: "run-plan",
     appId: "app-refund-planner",
   }),
   stepExecutionFinishedEvent({
     order: RUNNING_WORK_ORDER,
-    stepName: "plan",
+    stepName: "Refund Planner",
     at: TWO_HOURS_AGO,
     runId: "run-plan",
     appId: "app-refund-planner",
@@ -291,7 +291,7 @@ export const RUNNING_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   }),
   stepExecutionCreatedEvent({
     order: RUNNING_WORK_ORDER,
-    stepName: "implement",
+    stepName: "Refund Implementer",
     at: HOUR_AGO,
     runId: LINE_RUN_IMPLEMENT_ID,
     appId: "app-refund-implementer",
@@ -313,7 +313,7 @@ export const RUNNING_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
         appName: "Refund Implementer",
         lineId: REFUND_LINE.id,
         lineName: REFUND_LINE.name,
-        stepName: "implement",
+        stepName: "Refund Implementer",
       },
     },
     { id: LINE_RUN_IMPLEMENT_ID },
@@ -324,14 +324,14 @@ export const FAILED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   openedWorkOrderEvent(FAILED_WORK_ORDER, YESTERDAY),
   stepExecutionCreatedEvent({
     order: FAILED_WORK_ORDER,
-    stepName: "plan",
+    stepName: "Refund Planner",
     at: TWO_HOURS_AGO,
     runId: "run-plan-2",
     appId: "app-refund-planner",
   }),
   stepExecutionFinishedEvent({
     order: FAILED_WORK_ORDER,
-    stepName: "plan",
+    stepName: "Refund Planner",
     at: TWO_HOURS_AGO,
     runId: "run-plan-2",
     appId: "app-refund-planner",
@@ -339,14 +339,14 @@ export const FAILED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   }),
   stepExecutionCreatedEvent({
     order: FAILED_WORK_ORDER,
-    stepName: "implement",
+    stepName: "Refund Implementer",
     at: HOUR_AGO,
     runId: LINE_RUN_IMPLEMENT_FAILED_ID,
     appId: "app-refund-implementer",
   }),
   stepExecutionFinishedEvent({
     order: FAILED_WORK_ORDER,
-    stepName: "implement",
+    stepName: "Refund Implementer",
     at: HOUR_AGO,
     runId: LINE_RUN_IMPLEMENT_FAILED_ID,
     appId: "app-refund-implementer",
@@ -358,14 +358,14 @@ export const CLOSED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   openedWorkOrderEvent(CLOSED_WORK_ORDER, LAST_WEEK),
   stepExecutionCreatedEvent({
     order: CLOSED_WORK_ORDER,
-    stepName: "plan",
+    stepName: "Refund Planner",
     at: LAST_WEEK,
     runId: "run-plan-3",
     appId: "app-refund-planner",
   }),
   stepExecutionFinishedEvent({
     order: CLOSED_WORK_ORDER,
-    stepName: "plan",
+    stepName: "Refund Planner",
     at: LAST_WEEK,
     runId: "run-plan-3",
     appId: "app-refund-planner",
@@ -373,14 +373,14 @@ export const CLOSED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   }),
   stepExecutionCreatedEvent({
     order: CLOSED_WORK_ORDER,
-    stepName: "implement",
+    stepName: "Refund Implementer",
     at: LAST_WEEK,
     runId: LINE_RUN_IMPLEMENT_PASSED_ID,
     appId: "app-refund-implementer",
   }),
   stepExecutionFinishedEvent({
     order: CLOSED_WORK_ORDER,
-    stepName: "implement",
+    stepName: "Refund Implementer",
     at: LAST_WEEK,
     runId: LINE_RUN_IMPLEMENT_PASSED_ID,
     appId: "app-refund-implementer",
@@ -388,14 +388,14 @@ export const CLOSED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   }),
   stepExecutionCreatedEvent({
     order: CLOSED_WORK_ORDER,
-    stepName: "verify",
+    stepName: "Refund Verifier",
     at: YESTERDAY,
     runId: LINE_RUN_VERIFY_PASSED_ID,
     appId: "app-refund-verifier",
   }),
   stepExecutionFinishedEvent({
     order: CLOSED_WORK_ORDER,
-    stepName: "verify",
+    stepName: "Refund Verifier",
     at: YESTERDAY,
     runId: LINE_RUN_VERIFY_PASSED_ID,
     appId: "app-refund-verifier",
@@ -472,7 +472,7 @@ export const RICH_OPEN_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
       },
     },
     null,
-    { nodeName: "attach-artifact", appName: "Refund Diagnostics", lineName: "Plan", stepName: "step-01" },
+    { nodeName: "attach-artifact", appName: "Refund Diagnostics", lineName: "Plan", stepName: "Refund Diagnostics" },
   ),
   // Check history: the first risk score landed before the PR, follow-up
   // commits addressed the concerns, and the re-score dropped 82 → 65 — the

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -77,9 +77,8 @@ export const ORGANIZATION_USERS = [
 
 const RUN_APP_TYPE = "runApp";
 
-function runAppStep(name: string, appId: string, entrypoint: string): FactoryLineStep {
+function runAppStep(appId: string, entrypoint: string): FactoryLineStep {
   return {
-    name,
     type: RUN_APP_TYPE,
     app: { app: appId, entrypoint },
   };
@@ -119,9 +118,9 @@ export const REFUND_FACTORY_LINES: FactoriesFactoryLine[] = [
     createdAt: LAST_WEEK,
     updatedAt: YESTERDAY,
     steps: [
-      runAppStep("plan", "app-refund-planner", "start-plan"),
-      runAppStep("implement", "app-refund-implementer", "start-implementation"),
-      runAppStep("verify", "app-refund-verifier", "start-verification"),
+      runAppStep("app-refund-planner", "start-plan"),
+      runAppStep("app-refund-implementer", "start-implementation"),
+      runAppStep("app-refund-verifier", "start-verification"),
     ],
   },
   {
@@ -129,7 +128,7 @@ export const REFUND_FACTORY_LINES: FactoriesFactoryLine[] = [
     name: "hotfix",
     createdAt: LAST_WEEK,
     updatedAt: YESTERDAY,
-    steps: [runAppStep("verify", "app-refund-verifier", "start-verification")],
+    steps: [runAppStep("app-refund-verifier", "start-verification")],
   },
 ];
 
@@ -150,13 +149,21 @@ export const EMPTY_FACTORY: FactoriesFactory = {
   lines: [],
 };
 
+const PLAN_STEP_INDEX: Record<string, number> = { plan: 0, implement: 1, verify: 2 };
+const PLAN_STEP_LABEL: Record<string, string> = {
+  plan: "Refund Planner",
+  implement: "Refund Implementer",
+  verify: "Refund Verifier",
+};
+
 function planLineExecution(
   step: string,
   overrides: Partial<FactoriesWorkOrderExecution> = {},
 ): FactoriesWorkOrderExecution {
   return {
     id: `exec-${step}-${overrides.id ?? Math.random().toString(36).slice(2, 8)}`,
-    step,
+    step: PLAN_STEP_LABEL[step] ?? step,
+    stepIndex: PLAN_STEP_INDEX[step] ?? 0,
     state: "STATE_FINISHED",
     result: "RESULT_PASSED",
     createdAt: TWO_HOURS_AGO,
@@ -194,9 +201,9 @@ function planLineDispatch(
     id: `dispatch-${REFUND_LINE_PLAN_ID}-${stepExecutions[0]?.id ?? "empty"}`,
     line: { id: REFUND_LINE_PLAN_ID, name: "plan-and-implement" },
     steps: [
-      { name: "plan", stepIndex: 0 },
-      { name: "implement", stepIndex: 1 },
-      { name: "verify", stepIndex: 2 },
+      { name: "Refund Planner", stepIndex: 0 },
+      { name: "Refund Implementer", stepIndex: 1 },
+      { name: "Refund Verifier", stepIndex: 2 },
     ],
     state,
     result,
@@ -527,8 +534,8 @@ export const fiveStepLineFactoriesFixture: FactoriesFixture = {
           ...line,
           steps: [
             ...(line.steps ?? []),
-            runAppStep("release", "app-refund-verifier", "start-verification"),
-            runAppStep("observe", "app-refund-planner", "start-plan"),
+            runAppStep("app-refund-verifier", "start-verification"),
+            runAppStep("app-refund-planner", "start-plan"),
           ],
         };
       }),

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -16,6 +16,7 @@ import type {
 } from "@/api-client";
 import { defaultNotificationSettings } from "@/lib/notificationSettings";
 import { fixtureResponse, type FixtureResult } from "@/pages/home/__fixtures__/handlers";
+import { automationNameForLineStep } from "../lib/factoryLineFormShared";
 
 export type { FactoriesFixture };
 
@@ -192,23 +193,31 @@ function buildDispatchedLineDispatch(
   line: FactoriesFactoryLine | undefined,
   lineName: string,
   now: string,
+  apps: Array<{ id?: string; name?: string }> = [],
 ): FactoriesWorkOrderLineDispatch {
+  const firstStep = line?.steps?.[0];
+  const firstAppId = firstStep?.app?.app;
+  const firstName = automationNameForLineStep(firstStep, apps, 0);
   return {
     id: `dispatch-${Date.now()}`,
     line: line ? { id: line.id, name: line.name } : { id: "line-unknown", name: lineName },
-    steps: (line?.steps ?? []).map((step, index) => ({ name: step.name, stepIndex: index })),
+    steps: (line?.steps ?? []).map((step, index) => ({
+      name: automationNameForLineStep(step, apps, index),
+      stepIndex: index,
+    })),
     state: "STATE_ACTIVE",
     result: "RESULT_UNKNOWN",
     createdAt: now,
     stepExecutions: [
       {
         id: `exec-${Date.now()}`,
-        step: line?.steps?.[0]?.name ?? "start",
+        step: firstName,
         stepIndex: 0,
         state: "STATE_STARTED",
         result: "RESULT_UNKNOWN",
         createdAt: now,
         updatedAt: now,
+        run: firstAppId ? { appId: firstAppId, appName: firstName } : undefined,
       },
     ],
   };
@@ -227,7 +236,8 @@ function dispatchOrder(fixture: FactoriesFixture, factoryId: string, orderId: st
   const now = new Date().toISOString();
   order.updatedAt = now;
 
-  const newDispatch = buildDispatchedLineDispatch(line, lineName, now);
+  const apps = fixture.appsByFactoryId[factoryId] ?? [];
+  const newDispatch = buildDispatchedLineDispatch(line, lineName, now, apps);
   order.lineDispatches = [...(order.lineDispatches ?? []), newDispatch];
   return { json: { order } };
 }

--- a/web_src/src/pages/factories/lib/factoryLineFormShared.ts
+++ b/web_src/src/pages/factories/lib/factoryLineFormShared.ts
@@ -3,13 +3,12 @@ import type { FactoryLineStep } from "@/api-client";
 export const RUN_APP_TYPE = "runApp";
 
 export type DraftStep = {
-  name: string;
   appId: string;
   entrypoint: string;
 };
 
 export function emptyStep(): DraftStep {
-  return { name: "", appId: "", entrypoint: "" };
+  return { appId: "", entrypoint: "" };
 }
 
 export function draftStepsFromLine(steps: FactoryLineStep[] | undefined): DraftStep[] {
@@ -18,7 +17,6 @@ export function draftStepsFromLine(steps: FactoryLineStep[] | undefined): DraftS
   }
 
   return steps.map((step) => ({
-    name: step.name ?? "",
     appId: step.app?.app ?? "",
     entrypoint: step.app?.entrypoint ?? "",
   }));
@@ -26,11 +24,24 @@ export function draftStepsFromLine(steps: FactoryLineStep[] | undefined): DraftS
 
 export function draftStepsToProto(steps: DraftStep[]): FactoryLineStep[] {
   return steps.map((step) => ({
-    name: step.name.trim(),
     type: RUN_APP_TYPE,
     app: {
       app: step.appId,
       entrypoint: step.entrypoint.trim(),
     },
   }));
+}
+
+/** Display label for a line step: the automation (canvas) name. */
+export function automationNameForLineStep(
+  step: { app?: { app?: string } } | undefined,
+  apps: Array<{ id?: string; name?: string }> | undefined,
+  fallbackIndex: number,
+): string {
+  const appId = step?.app?.app?.trim();
+  const name = apps?.find((app) => app.id === appId)?.name?.trim();
+  if (name) {
+    return name;
+  }
+  return `Phase ${fallbackIndex + 1}`;
 }

--- a/web_src/src/pages/factories/lib/humanizeLineName.spec.ts
+++ b/web_src/src/pages/factories/lib/humanizeLineName.spec.ts
@@ -18,14 +18,22 @@ describe("humanizeLineName", () => {
 });
 
 describe("formatLinePhaseDescription", () => {
-  it("joins humanized phase names as a flow", () => {
-    expect(formatLinePhaseDescription([{ name: "plan" }, { name: "implement" }, { name: "verify" }])).toBe(
-      "Plan → Implement → Verify",
-    );
+  it("joins automation names as a flow", () => {
+    expect(
+      formatLinePhaseDescription(
+        [{ app: { app: "app-plan" } }, { app: { app: "app-implement" } }, { app: { app: "app-verify" } }],
+        [
+          { id: "app-plan", name: "Refund Planner" },
+          { id: "app-implement", name: "Refund Implementer" },
+          { id: "app-verify", name: "Refund Verifier" },
+        ],
+      ),
+    ).toBe("Refund Planner → Refund Implementer → Refund Verifier");
   });
 
   it("returns undefined when there are no named phases", () => {
-    expect(formatLinePhaseDescription([])).toBeUndefined();
-    expect(formatLinePhaseDescription(undefined)).toBeUndefined();
+    expect(formatLinePhaseDescription([], [])).toBeUndefined();
+    expect(formatLinePhaseDescription(undefined, undefined)).toBeUndefined();
+    expect(formatLinePhaseDescription([{ app: { app: "missing" } }], [])).toBeUndefined();
   });
 });

--- a/web_src/src/pages/factories/lib/humanizeLineName.ts
+++ b/web_src/src/pages/factories/lib/humanizeLineName.ts
@@ -23,13 +23,16 @@ export function humanizeLineName(name: string | undefined | null): string {
 
 /**
  * Short line description when the API has no description field:
- * humanized phase names joined as a flow, e.g. `Plan → Implement → Verify`.
+ * automation names joined as a flow, e.g. `Refund Planner → Refund Implementer`.
  */
-export function formatLinePhaseDescription(steps: Array<{ name?: string }> | undefined | null): string | undefined {
+export function formatLinePhaseDescription(
+  steps: Array<{ app?: { app?: string } }> | undefined | null,
+  apps: Array<{ id?: string; name?: string }> | undefined | null,
+): string | undefined {
   const names = (steps ?? [])
     .map((step) => {
-      const trimmed = step.name?.trim();
-      return trimmed ? humanizeLineName(trimmed) : null;
+      const appId = step.app?.app?.trim();
+      return apps?.find((app) => app.id === appId)?.name?.trim();
     })
     .filter((name): name is string => Boolean(name));
 

--- a/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
@@ -9,10 +9,16 @@ import type {
 import { factoryAppPath, factoryAppRunPath, linesPath } from "./factoryPagePaths";
 import { buildLinePhaseBoard, linePhaseRunHref, resolvePhaseRunStatus } from "./linePhaseRuns";
 
+const APPS = [
+  { id: "app-plan", name: "plan" },
+  { id: "app-build", name: "build" },
+  { id: "app-demo", name: "demo" },
+];
+
 const LINE: FactoriesFactoryLine = {
   id: "line-1",
   name: "poc",
-  steps: [{ name: "plan" }, { name: "build" }, { name: "demo" }],
+  steps: [{ app: { app: "app-plan" } }, { app: { app: "app-build" } }, { app: { app: "app-demo" } }],
 };
 
 /** Fixture-only shape: a step execution plus which line it ran on, before
@@ -53,6 +59,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e1",
           line: { id: "line-1", name: "poc" },
           step: "plan",
+          stepIndex: 0,
           state: "STATE_FINISHED",
           result: "RESULT_PASSED",
           createdAt: "2026-08-11T10:00:00.000Z",
@@ -64,6 +71,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e2",
           line: { id: "line-1", name: "poc" },
           step: "plan",
+          stepIndex: 0,
           state: "STATE_STARTED",
           createdAt: "2026-08-11T11:00:00.000Z",
           updatedAt: "2026-08-11T12:00:00.000Z",
@@ -74,6 +82,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e3",
           line: { id: "line-1", name: "poc" },
           step: "plan",
+          stepIndex: 0,
           state: "STATE_PENDING",
           createdAt: "2026-08-11T11:30:00.000Z",
           updatedAt: "2026-08-11T11:30:00.000Z",
@@ -84,6 +93,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e4",
           line: { id: "line-1", name: "poc" },
           step: "plan",
+          stepIndex: 0,
           state: "STATE_PENDING",
           createdAt: "2026-08-11T09:00:00.000Z",
           updatedAt: "2026-08-11T09:00:00.000Z",
@@ -94,6 +104,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e5",
           line: { id: "line-other", name: "other" },
           step: "plan",
+          stepIndex: 0,
           state: "STATE_STARTED",
           createdAt: "2026-08-11T13:00:00.000Z",
           updatedAt: "2026-08-11T13:00:00.000Z",
@@ -101,11 +112,11 @@ describe("buildLinePhaseBoard", () => {
       ]),
     ];
 
-    const board = buildLinePhaseBoard(LINE, orders);
+    const board = buildLinePhaseBoard(LINE, orders, APPS);
 
     expect(board).toHaveLength(3);
     expect(board[0].stepName).toBe("plan");
-    expect(board[0].appId).toBeUndefined();
+    expect(board[0].appId).toBe("app-plan");
     expect(board[0].runs.map((run) => run.order.title)).toEqual(["Beta", "Gamma", "Alpha", "Delta"]);
     expect(board[0].tick).toBe("running");
     expect(board[1].stepName).toBe("build");
@@ -122,6 +133,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e-plan",
           line: { id: "line-1", name: "poc" },
           step: "plan",
+          stepIndex: 0,
           state: "STATE_FINISHED",
           result: "RESULT_PASSED",
           createdAt: "2026-08-11T10:00:00.000Z",
@@ -131,6 +143,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e-build",
           line: { id: "line-1", name: "poc" },
           step: "build",
+          stepIndex: 1,
           state: "STATE_FINISHED",
           result: "RESULT_PASSED",
           createdAt: "2026-08-11T11:00:00.000Z",
@@ -140,6 +153,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e-demo",
           line: { id: "line-1", name: "poc" },
           step: "demo",
+          stepIndex: 2,
           state: "STATE_STARTED",
           createdAt: "2026-08-11T12:00:00.000Z",
           updatedAt: "2026-08-11T12:30:00.000Z",
@@ -147,7 +161,7 @@ describe("buildLinePhaseBoard", () => {
       ]),
     ];
 
-    const board = buildLinePhaseBoard(LINE, orders);
+    const board = buildLinePhaseBoard(LINE, orders, APPS);
 
     expect(board[0].runs).toEqual([]);
     expect(board[1].runs).toEqual([]);
@@ -164,6 +178,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e-plan",
           line: { id: "line-1", name: "poc" },
           step: "plan",
+          stepIndex: 0,
           state: "STATE_FINISHED",
           result: "RESULT_PASSED",
           createdAt: "2026-08-11T09:00:00.000Z",
@@ -173,6 +188,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e-fail",
           line: { id: "line-1", name: "poc" },
           step: "build",
+          stepIndex: 1,
           state: "STATE_FINISHED",
           result: "RESULT_FAILED",
           createdAt: "2026-08-11T10:00:00.000Z",
@@ -181,7 +197,7 @@ describe("buildLinePhaseBoard", () => {
       ]),
     ];
 
-    const board = buildLinePhaseBoard(LINE, orders);
+    const board = buildLinePhaseBoard(LINE, orders, APPS);
 
     expect(board[0].runs).toEqual([]);
     expect(board[1].runs).toHaveLength(1);
@@ -196,11 +212,40 @@ describe("buildLinePhaseBoard", () => {
     const line: FactoriesFactoryLine = {
       id: "line-1",
       name: "poc",
-      steps: [{ name: "plan", app: { app: "app-planner", entrypoint: "start" } }],
+      steps: [{ app: { app: "app-planner", entrypoint: "start" } }],
     };
 
-    const board = buildLinePhaseBoard(line, []);
+    const board = buildLinePhaseBoard(line, [], [{ id: "app-planner", name: "plan" }]);
     expect(board[0]).toMatchObject({ stepName: "plan", appId: "app-planner" });
+  });
+
+  it("keeps two columns when the same automation appears twice", () => {
+    const line: FactoriesFactoryLine = {
+      id: "line-1",
+      name: "poc",
+      steps: [{ app: { app: "app-plan" } }, { app: { app: "app-plan" } }],
+    };
+    const orders = [
+      order("wo-a", "Alpha", [
+        {
+          id: "e-second",
+          line: { id: "line-1", name: "poc" },
+          step: "plan",
+          stepIndex: 1,
+          state: "STATE_STARTED",
+          createdAt: "2026-08-11T12:00:00.000Z",
+          updatedAt: "2026-08-11T12:00:00.000Z",
+        },
+      ]),
+    ];
+
+    const board = buildLinePhaseBoard(line, orders, APPS);
+    expect(board).toHaveLength(2);
+    expect(board[0]).toMatchObject({ stepName: "plan", stepIndex: 0, appId: "app-plan" });
+    expect(board[1]).toMatchObject({ stepName: "plan", stepIndex: 1, appId: "app-plan" });
+    expect(board[0].runs).toEqual([]);
+    expect(board[1].runs).toHaveLength(1);
+    expect(board[1].runs[0].workOrderId).toBe("wo-a");
   });
 
   it("keeps phase idle when only finished failed runs exist", () => {
@@ -210,6 +255,7 @@ describe("buildLinePhaseBoard", () => {
           id: "e-fail",
           line: { id: "line-1", name: "poc" },
           step: "build",
+          stepIndex: 1,
           state: "STATE_FINISHED",
           result: "RESULT_FAILED",
           createdAt: "2026-08-11T10:00:00.000Z",
@@ -218,7 +264,7 @@ describe("buildLinePhaseBoard", () => {
       ]),
     ];
 
-    const board = buildLinePhaseBoard(LINE, orders);
+    const board = buildLinePhaseBoard(LINE, orders, APPS);
     expect(board[1].tick).toBeNull();
   });
 });

--- a/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
@@ -248,6 +248,34 @@ describe("buildLinePhaseBoard", () => {
     expect(board[1].runs[0].workOrderId).toBe("wo-a");
   });
 
+  it("places a card on the live automation after a step is inserted ahead of it", () => {
+    const line: FactoriesFactoryLine = {
+      id: "line-1",
+      name: "poc",
+      steps: [{ app: { app: "app-new" } }, { app: { app: "app-plan" } }, { app: { app: "app-build" } }],
+    };
+    const orders = [
+      order("wo-a", "Alpha", [
+        {
+          id: "e1",
+          line: { id: "line-1", name: "poc" },
+          step: "plan",
+          stepIndex: 0,
+          state: "STATE_STARTED",
+          run: { appId: "app-plan" },
+          createdAt: "2026-08-11T12:00:00.000Z",
+          updatedAt: "2026-08-11T12:00:00.000Z",
+        },
+      ]),
+    ];
+
+    const board = buildLinePhaseBoard(line, orders, [...APPS, { id: "app-new", name: "new" }]);
+    expect(board[0].runs).toEqual([]);
+    expect(board[1].runs).toHaveLength(1);
+    expect(board[1].runs[0].workOrderId).toBe("wo-a");
+    expect(board[2].runs).toEqual([]);
+  });
+
   it("keeps phase idle when only finished failed runs exist", () => {
     const orders = [
       order("wo-f", "Failing", [

--- a/web_src/src/pages/factories/lib/linePhaseRuns.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.ts
@@ -71,7 +71,7 @@ export function buildLinePhaseBoard(
     return [];
   }
 
-  const runsByStep = collectCurrentRunsByStep(lineId, steps.length, workOrders);
+  const runsByStep = collectCurrentRunsByStep(lineId, steps, workOrders);
 
   return steps.map((step, stepIndex) => {
     const runs = runsByStep.get(stepIndex) ?? [];
@@ -133,12 +133,12 @@ export function resolveRunGlyph(run: LinePhaseRunCard): PhaseGlyphKind {
 
 function collectCurrentRunsByStep(
   lineId: string,
-  stepCount: number,
+  steps: NonNullable<FactoriesFactoryLine["steps"]>,
   workOrders: FactoriesWorkOrder[],
 ): Map<number, LinePhaseRunCard[]> {
   const runsByStep = new Map<number, LinePhaseRunCard[]>();
   for (const order of workOrders) {
-    appendCurrentRunForOrder(order, lineId, stepCount, runsByStep);
+    appendCurrentRunForOrder(order, lineId, steps, runsByStep);
   }
   for (const runs of runsByStep.values()) {
     runs.sort(compareRunsNewestFirst);
@@ -153,10 +153,48 @@ function executionStepIndex(execution: FactoriesWorkOrderExecution): number | un
   return execution.stepIndex;
 }
 
+function liveColumnIndexForExecution(
+  steps: NonNullable<FactoriesFactoryLine["steps"]>,
+  execution: FactoriesWorkOrderExecution,
+): number | undefined {
+  const stepIndex = executionStepIndex(execution);
+  if (stepIndex == null) {
+    return undefined;
+  }
+
+  // Dispatch stepIndex is a snapshot. A later line edit can move that
+  // index onto a different automation. Keep the snapshot index when the
+  // app still matches; otherwise place the card on the live column with
+  // the same app.
+  const executionAppId = execution.run?.appId?.trim();
+  const liveAppId = steps[stepIndex]?.app?.app?.trim();
+  if (stepIndex < steps.length && (!executionAppId || liveAppId === executionAppId)) {
+    return stepIndex;
+  }
+
+  if (!executionAppId) {
+    return undefined;
+  }
+
+  const matches: number[] = [];
+  for (let index = 0; index < steps.length; index++) {
+    if (steps[index]?.app?.app?.trim() === executionAppId) {
+      matches.push(index);
+    }
+  }
+  if (matches.length === 0) {
+    return undefined;
+  }
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  return matches.reduce((best, index) => (Math.abs(index - stepIndex) < Math.abs(best - stepIndex) ? index : best));
+}
+
 function appendCurrentRunForOrder(
   order: FactoriesWorkOrder,
   lineId: string,
-  stepCount: number,
+  steps: NonNullable<FactoriesFactoryLine["steps"]>,
   runsByStep: Map<number, LinePhaseRunCard[]>,
 ): void {
   if (!order.id) {
@@ -172,16 +210,15 @@ function appendCurrentRunForOrder(
   }
   const currentDispatch = pickMostRecentDispatch(dispatchesForLine);
 
-  const lineExecutions = (currentDispatch.stepExecutions ?? []).filter((execution) => {
-    const stepIndex = executionStepIndex(execution);
-    return stepIndex != null && stepIndex < stepCount;
-  });
+  const lineExecutions = (currentDispatch.stepExecutions ?? []).filter(
+    (execution) => liveColumnIndexForExecution(steps, execution) != null,
+  );
   if (lineExecutions.length === 0) {
     return;
   }
 
   const currentExecution = pickCurrentLineExecution(lineExecutions);
-  const stepIndex = currentExecution ? executionStepIndex(currentExecution) : undefined;
+  const stepIndex = currentExecution ? liveColumnIndexForExecution(steps, currentExecution) : undefined;
   if (!currentExecution || stepIndex == null) {
     return;
   }

--- a/web_src/src/pages/factories/lib/linePhaseRuns.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.ts
@@ -4,6 +4,7 @@ import type {
   FactoriesWorkOrderExecution,
   FactoriesWorkOrderLineDispatch,
 } from "@/api-client";
+import { automationNameForLineStep } from "./factoryLineFormShared";
 import { factoryAppPath, factoryAppRunPath, linesPath } from "./factoryPagePaths";
 import { isActiveWorkOrderExecution } from "./workOrderExecutions";
 
@@ -59,21 +60,24 @@ export function linePhaseRunHref(
  * appears once, in the column for its current (furthest active, else furthest
  * finished) step on this line — newest cards first within a column.
  */
-export function buildLinePhaseBoard(line: FactoriesFactoryLine, workOrders: FactoriesWorkOrder[]): LinePhaseColumn[] {
+export function buildLinePhaseBoard(
+  line: FactoriesFactoryLine,
+  workOrders: FactoriesWorkOrder[],
+  apps: Array<{ id?: string; name?: string }> = [],
+): LinePhaseColumn[] {
   const lineId = line.id;
   const steps = line.steps ?? [];
   if (!lineId || steps.length === 0) {
     return [];
   }
 
-  const runsByStep = collectCurrentRunsByStep(lineId, steps, workOrders);
+  const runsByStep = collectCurrentRunsByStep(lineId, steps.length, workOrders);
 
   return steps.map((step, stepIndex) => {
-    const stepName = step.name?.trim() || `Phase ${stepIndex + 1}`;
-    const runs = runsByStep.get(step.name ?? "") ?? [];
+    const runs = runsByStep.get(stepIndex) ?? [];
     const appId = step.app?.app?.trim() || undefined;
     return {
-      stepName,
+      stepName: automationNameForLineStep(step, apps, stepIndex),
       stepIndex,
       appId,
       runs,
@@ -129,19 +133,12 @@ export function resolveRunGlyph(run: LinePhaseRunCard): PhaseGlyphKind {
 
 function collectCurrentRunsByStep(
   lineId: string,
-  steps: NonNullable<FactoriesFactoryLine["steps"]>,
+  stepCount: number,
   workOrders: FactoriesWorkOrder[],
-): Map<string, LinePhaseRunCard[]> {
-  const stepIndexByName = new Map<string, number>();
-  for (const [index, step] of steps.entries()) {
-    if (step.name) {
-      stepIndexByName.set(step.name, index);
-    }
-  }
-
-  const runsByStep = new Map<string, LinePhaseRunCard[]>();
+): Map<number, LinePhaseRunCard[]> {
+  const runsByStep = new Map<number, LinePhaseRunCard[]>();
   for (const order of workOrders) {
-    appendCurrentRunForOrder(order, lineId, stepIndexByName, runsByStep);
+    appendCurrentRunForOrder(order, lineId, stepCount, runsByStep);
   }
   for (const runs of runsByStep.values()) {
     runs.sort(compareRunsNewestFirst);
@@ -149,11 +146,18 @@ function collectCurrentRunsByStep(
   return runsByStep;
 }
 
+function executionStepIndex(execution: FactoriesWorkOrderExecution): number | undefined {
+  if (execution.stepIndex == null || execution.stepIndex < 0) {
+    return undefined;
+  }
+  return execution.stepIndex;
+}
+
 function appendCurrentRunForOrder(
   order: FactoriesWorkOrder,
   lineId: string,
-  stepIndexByName: Map<string, number>,
-  runsByStep: Map<string, LinePhaseRunCard[]>,
+  stepCount: number,
+  runsByStep: Map<number, LinePhaseRunCard[]>,
 ): void {
   if (!order.id) {
     return;
@@ -168,30 +172,32 @@ function appendCurrentRunForOrder(
   }
   const currentDispatch = pickMostRecentDispatch(dispatchesForLine);
 
-  const lineExecutions = (currentDispatch.stepExecutions ?? []).filter(
-    (execution) => execution.step != null && stepIndexByName.has(execution.step),
-  );
+  const lineExecutions = (currentDispatch.stepExecutions ?? []).filter((execution) => {
+    const stepIndex = executionStepIndex(execution);
+    return stepIndex != null && stepIndex < stepCount;
+  });
   if (lineExecutions.length === 0) {
     return;
   }
 
-  const currentExecution = pickCurrentLineExecution(lineExecutions, stepIndexByName);
-  if (!currentExecution?.step) {
+  const currentExecution = pickCurrentLineExecution(lineExecutions);
+  const stepIndex = currentExecution ? executionStepIndex(currentExecution) : undefined;
+  if (!currentExecution || stepIndex == null) {
     return;
   }
 
   const card: LinePhaseRunCard = {
-    executionId: currentExecution.id ?? `${order.id}-${currentExecution.step}-${currentExecution.createdAt ?? ""}`,
+    executionId: currentExecution.id ?? `${order.id}-${stepIndex}-${currentExecution.createdAt ?? ""}`,
     workOrderId: order.id,
     order,
     execution: currentExecution,
   };
-  const existing = runsByStep.get(currentExecution.step);
+  const existing = runsByStep.get(stepIndex);
   if (existing) {
     existing.push(card);
     return;
   }
-  runsByStep.set(currentExecution.step, [card]);
+  runsByStep.set(stepIndex, [card]);
 }
 
 function pickMostRecentDispatch(dispatches: FactoriesWorkOrderLineDispatch[]): FactoriesWorkOrderLineDispatch {
@@ -209,10 +215,9 @@ function executionTimestamp(execution: FactoriesWorkOrderExecution): number {
 function isPreferableCurrentExecution(
   candidate: FactoriesWorkOrderExecution,
   incumbent: FactoriesWorkOrderExecution,
-  stepIndexByName: Map<string, number>,
 ): boolean {
-  const candidateStep = stepIndexByName.get(candidate.step ?? "") ?? -1;
-  const incumbentStep = stepIndexByName.get(incumbent.step ?? "") ?? -1;
+  const candidateStep = executionStepIndex(candidate) ?? -1;
+  const incumbentStep = executionStepIndex(incumbent) ?? -1;
   if (candidateStep !== incumbentStep) {
     return candidateStep > incumbentStep;
   }
@@ -224,20 +229,16 @@ function isPreferableCurrentExecution(
   return (candidate.id ?? "") > (incumbent.id ?? "");
 }
 
-function pickCurrentLineExecution(
-  executions: FactoriesWorkOrderExecution[],
-  stepIndexByName: Map<string, number>,
-): FactoriesWorkOrderExecution | null {
+function pickCurrentLineExecution(executions: FactoriesWorkOrderExecution[]): FactoriesWorkOrderExecution | null {
   const active = executions.filter(isActiveWorkOrderExecution);
   const candidates = active.length > 0 ? active : executions;
   let best: FactoriesWorkOrderExecution | null = null;
 
   for (const execution of candidates) {
-    const stepIndex = stepIndexByName.get(execution.step ?? "") ?? -1;
-    if (stepIndex < 0) {
+    if (executionStepIndex(execution) == null) {
       continue;
     }
-    if (!best || isPreferableCurrentExecution(execution, best, stepIndexByName)) {
+    if (!best || isPreferableCurrentExecution(execution, best)) {
       best = execution;
     }
   }

--- a/web_src/src/pages/factories/lib/workOrderTimelineStepBuilder.ts
+++ b/web_src/src/pages/factories/lib/workOrderTimelineStepBuilder.ts
@@ -10,7 +10,7 @@ export type StepExecutionEventType = "step.execution.created" | "step.execution.
 export interface LineStepExecutionPayload {
   stepName?: string;
   line?: { id?: string; name?: string };
-  app?: { id?: string };
+  app?: { id?: string; name?: string };
   run?: { id?: string; state?: string; result?: string };
 }
 
@@ -48,7 +48,7 @@ export function appendStepExecutionEvent(
     return;
   }
 
-  const stepName = payload.stepName?.trim() || "Unnamed step";
+  const stepName = payload.app?.name?.trim() || payload.stepName?.trim() || "Unnamed step";
   const batch = findOrCreateDispatchBatch(ctx, {
     lineId: line.id,
     lineName: line.name?.trim() || "Unnamed line",
@@ -157,7 +157,7 @@ function executionFromStepPayload(
 
   return {
     id: run?.id,
-    step: payload.stepName,
+    step: payload.app?.name?.trim() || payload.stepName,
     state: mapExecutionState(run?.state, eventType),
     result: isFinished ? mapExecutionResult(run?.result) : "RESULT_UNKNOWN",
     createdAt: startedAt,
@@ -167,6 +167,7 @@ function executionFromStepPayload(
         ? {
             id: run.id,
             appId: payload.app.id,
+            appName: payload.app.name,
           }
         : undefined,
   };

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -3,7 +3,7 @@ import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { usePermissions } from "@/contexts/usePermissions";
-import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
+import { useFactoryApps, useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
@@ -40,6 +40,7 @@ import {
   factoryLineDetailPath,
   linesPath,
 } from "../lib/factoryPagePaths";
+import { automationNameForLineStep } from "../lib/factoryLineFormShared";
 import { formatLinePhaseDescription, humanizeLineName } from "../lib/humanizeLineName";
 import {
   factoryKanbanPageClassName,
@@ -54,6 +55,7 @@ export function LinesPage() {
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const { lineId: routeLineId } = useParams<{ lineId: string }>();
   const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
+  const { data: factoryApps = [] } = useFactoryApps(organizationId, factoryId);
   const cardActions = useWorkOrderCardActions(organizationId, factoryId);
 
   const canUpdate = canAct("factories", "update");
@@ -84,6 +86,7 @@ export function LinesPage() {
             organizationId={organizationId}
             factoryKey={factoryKey}
             line={selectedLine}
+            apps={factoryApps}
             canUpdate={canUpdate}
           />
         </div>
@@ -93,6 +96,7 @@ export function LinesPage() {
             organizationId={organizationId}
             factoryKey={factoryKey}
             line={selectedLine}
+            apps={factoryApps}
             workOrders={workOrders}
             workOrderCardContext={{
               organizationId,
@@ -142,11 +146,12 @@ export function LinesPage() {
               if (!line.id) {
                 return null;
               }
-              const board = buildLinePhaseBoard(line, workOrders);
+              const board = buildLinePhaseBoard(line, workOrders, factoryApps);
               return (
                 <li key={line.id}>
                   <LineCard
                     line={line}
+                    apps={factoryApps}
                     href={factoryLineDetailPath(organizationId, factoryKey, line.id)}
                     ticks={board.map((column) => column.tick)}
                   />
@@ -164,11 +169,13 @@ function LineDetailHeader({
   organizationId,
   factoryKey,
   line,
+  apps,
   canUpdate,
 }: {
   organizationId: string;
   factoryKey: string;
   line: FactoriesFactoryLine;
+  apps: Array<{ id?: string; name?: string }>;
   canUpdate: boolean;
 }) {
   const editHref = line.id ? editFactoryLinePath(organizationId, factoryKey, line.id) : "#";
@@ -180,7 +187,7 @@ function LineDetailHeader({
       backLabel="Lines"
       backTestId="lines-back-to-list"
       title={humanizeLineName(line.name)}
-      subtitle={formatLinePhaseDescription(line.steps)}
+      subtitle={formatLinePhaseDescription(line.steps, apps)}
       actions={
         canUpdate ? (
           <Button type="button" variant="outline" size="sm" asChild data-testid="lines-edit-button">
@@ -199,17 +206,19 @@ function LineDetail({
   organizationId,
   factoryKey,
   line,
+  apps,
   workOrders,
   workOrderCardContext,
 }: {
   organizationId: string;
   factoryKey: string;
   line: FactoriesFactoryLine;
+  apps: Array<{ id?: string; name?: string }>;
   workOrders: FactoriesWorkOrder[];
   workOrderCardContext: WorkOrderCardContext;
 }) {
   const steps = line.steps ?? [];
-  const board = useMemo(() => buildLinePhaseBoard(line, workOrders ?? []), [line, workOrders]);
+  const board = useMemo(() => buildLinePhaseBoard(line, workOrders ?? [], apps), [line, workOrders, apps]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="lines-detail">
@@ -228,10 +237,20 @@ function LineDetail({
   );
 }
 
-function LineCard({ line, href, ticks }: { line: FactoriesFactoryLine; href: string; ticks: LinePhaseTick[] }) {
+function LineCard({
+  line,
+  apps,
+  href,
+  ticks,
+}: {
+  line: FactoriesFactoryLine;
+  apps: Array<{ id?: string; name?: string }>;
+  href: string;
+  ticks: LinePhaseTick[];
+}) {
   const navigate = useNavigate();
   const steps = line.steps ?? [];
-  const description = formatLinePhaseDescription(steps);
+  const description = formatLinePhaseDescription(steps, apps);
 
   return (
     <div
@@ -261,16 +280,27 @@ function LineCard({ line, href, ticks }: { line: FactoriesFactoryLine; href: str
           {description ? <p className="mt-1 text-[12px] leading-snug text-muted-foreground">{description}</p> : null}
         </div>
       </div>
-      {steps.length > 0 ? <PhaseStrip steps={steps} ticks={ticks} /> : null}
+      {steps.length > 0 ? <PhaseStrip steps={steps} apps={apps} ticks={ticks} /> : null}
     </div>
   );
 }
 
-function PhaseStrip({ steps, ticks }: { steps: FactoryLineStep[]; ticks: LinePhaseTick[] }) {
+function PhaseStrip({
+  steps,
+  apps,
+  ticks,
+}: {
+  steps: FactoryLineStep[];
+  apps: Array<{ id?: string; name?: string }>;
+  ticks: LinePhaseTick[];
+}) {
   return (
     <ol className="mt-3.5 flex w-full items-start" aria-label="Phases">
       {steps.map((step, index) => (
-        <li key={`${step.name}-${index}`} className="relative flex min-w-0 flex-1 flex-col items-center text-center">
+        <li
+          key={`${step.app?.app ?? "step"}-${index}`}
+          className="relative flex min-w-0 flex-1 flex-col items-center text-center"
+        >
           {index < steps.length - 1 ? (
             <span
               className="absolute top-[7px] left-[calc(50%+8px)] right-[calc(-50%+8px)] h-px bg-border"
@@ -281,7 +311,7 @@ function PhaseStrip({ steps, ticks }: { steps: FactoryLineStep[]; ticks: LinePha
             <PhaseTickDot tick={ticks[index] ?? null} />
           </span>
           <span className="mt-1.5 max-w-full truncate px-1 text-[12px] leading-tight text-muted-foreground">
-            {step.name || `Phase ${index + 1}`}
+            {automationNameForLineStep(step, apps, index)}
           </span>
         </li>
       ))}
@@ -377,7 +407,7 @@ function PhaseColumn({
 
   return (
     <WorkOrderBoardLane
-      title={humanizeLineName(column.stepName)}
+      title={column.stepName}
       label={`${column.stepName} phase`}
       count={totalRuns}
       tone={PHASE_LANE_TONE[glyph]}

--- a/web_src/src/pages/factories/pages/WorkOrderCanvas.stories.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderCanvas.stories.tsx
@@ -26,7 +26,7 @@ export const ConfigurePhase: Story = {
   name: "Configure phase",
   render: () => {
     const line = REFUND_FACTORY_LINES[0];
-    const phase = line.steps?.[0]?.name ?? "plan";
+    const phase = line.steps?.[0]?.app?.app ?? "plan";
     return (
       <FactoriesHarness
         enableOnboarding={false}

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -188,7 +188,6 @@ async function provisionLineApps(args: {
       installFactory: args.installFactory,
     });
     steps.push({
-      name: app.lineStepName,
       type: "runApp",
       app: { app: installed.canvasId, entrypoint: app.entrypointNodeId },
     });

--- a/web_src/src/pages/factories/timeline/DispatchTimelineItem.tsx
+++ b/web_src/src/pages/factories/timeline/DispatchTimelineItem.tsx
@@ -115,11 +115,12 @@ function DispatchStepRow({
   const runHref = getWorkOrderExecutionRunHref(organizationId, factoryKey, step.execution, { orderNumber });
   const duration = formatStepExecutionDuration(step);
   const status = executionStatus(step.execution);
+  const name = step.execution.run?.appName?.trim() || step.stepName;
 
   return (
     <li className="min-w-0 py-1.5">
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-        <StepName name={step.stepName} runHref={runHref} />
+        <StepName name={name} runHref={runHref} />
         {status ? (
           <span className={cn("inline-flex items-center gap-1.5 text-[12px]", status.textClassName)}>
             <span className={cn("size-1.5 shrink-0 rounded-full", status.dotClassName)} aria-hidden />

--- a/web_src/src/pages/factories/timeline/TimelineAutomationActor.tsx
+++ b/web_src/src/pages/factories/timeline/TimelineAutomationActor.tsx
@@ -10,10 +10,9 @@ interface TimelineAutomationActorProps {
 
 export function TimelineAutomationActor({ actor, fallbackLabel = "Automation" }: TimelineAutomationActorProps) {
   const lineName = actor.lineName?.trim();
-  const stepName = actor.stepName?.trim();
   const nodeName = actor.nodeName?.trim();
-  const appName = actor.appName?.trim();
-  const tooltip = formatStepNodeTooltip(stepName, nodeName);
+  const appName = actor.appName?.trim() || actor.stepName?.trim();
+  const tooltip = formatStepNodeTooltip(appName, nodeName);
 
   if (lineName && tooltip) {
     return (

--- a/web_src/src/pages/home/factories/index.ts
+++ b/web_src/src/pages/home/factories/index.ts
@@ -124,13 +124,12 @@ function buildEventApp(args: {
 export interface OnboardingLineApp {
   factoryId: string;
   entrypointNodeId: string;
-  lineStepName: string;
 }
 
 export const ONBOARDING_LINE_APPS: OnboardingLineApp[] = [
-  { factoryId: "line-planning", entrypointNodeId: "onrun-create-plan", lineStepName: "Create Implementation Plan" },
-  { factoryId: "line-implementation", entrypointNodeId: "onrun-implement", lineStepName: "Implement" },
-  { factoryId: "line-pr", entrypointNodeId: "onrun-open-pr", lineStepName: "Open Pull Request" },
+  { factoryId: "line-planning", entrypointNodeId: "onrun-create-plan" },
+  { factoryId: "line-implementation", entrypointNodeId: "onrun-implement" },
+  { factoryId: "line-pr", entrypointNodeId: "onrun-open-pr" },
 ];
 
 // Event-driven factory apps provisioned during onboarding. These listen for

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -23,11 +23,6 @@ describe("setup factory line apps", () => {
       "line-implementation",
       "line-pr",
     ]);
-    expect(ONBOARDING_LINE_APPS.map((app) => app.lineStepName)).toEqual([
-      "Create Implementation Plan",
-      "Implement",
-      "Open Pull Request",
-    ]);
   });
 
   it("exposes a single onRun entrypoint per app that the line calls", () => {


### PR DESCRIPTION
## Summary

A factory line step is an automation plus a trigger. The extra step name was unused identity.

SuperPlane now stores and shows the automation name. Execution history still stores that name as `step_name`.

## Test plan

- [ ] Open the line editor and confirm the form has no Step name field.
- [ ] Confirm each step title is the automation name.
- [ ] Dispatch a work order and confirm the run label is the automation name.
- [ ] Confirm two steps with the same automation show as two columns on Lines.


Made with [Cursor](https://cursor.com)