### PR TITLE
feat: Show which lines use an automation

### DIFF
--- a/web_src/src/pages/factories/lib/automationLineUsage.spec.ts
+++ b/web_src/src/pages/factories/lib/automationLineUsage.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import type { FactoriesFactoryLine } from "@/api-client";
+
+import { linesUsingAutomation } from "./automationLineUsage";
+
+const planner = "app-refund-planner";
+const verifier = "app-refund-verifier";
+
+function line(id: string, name: string, appIds: string[]): FactoriesFactoryLine {
+  return {
+    id,
+    name,
+    steps: appIds.map((appId, index) => ({
+      name: `step-${index}`,
+      app: { app: appId, entrypoint: "on-run" },
+    })),
+  };
+}
+
+describe("linesUsingAutomation", () => {
+  const plan = line("line-plan", "plan-and-implement", [planner, "app-refund-implementer", verifier]);
+  const hotfix = line("line-hotfix", "hotfix", [verifier]);
+  const empty = line("line-empty", "empty", []);
+
+  it("returns lines that reference the automation, in factory order", () => {
+    expect(linesUsingAutomation([plan, hotfix, empty], verifier)).toEqual([
+      { id: "line-plan", name: "plan-and-implement" },
+      { id: "line-hotfix", name: "hotfix" },
+    ]);
+  });
+
+  it("returns one entry when a line uses the automation in several steps", () => {
+    const twice = line("line-twice", "twice", [planner, planner]);
+    expect(linesUsingAutomation([twice], planner)).toEqual([{ id: "line-twice", name: "twice" }]);
+  });
+
+  it("returns an empty list when no line uses the automation", () => {
+    expect(linesUsingAutomation([plan, hotfix], "app-unused")).toEqual([]);
+  });
+
+  it("skips lines without an id", () => {
+    const unnamed: FactoriesFactoryLine = {
+      name: "ghost",
+      steps: [{ name: "plan", app: { app: planner, entrypoint: "on-run" } }],
+    };
+    expect(linesUsingAutomation([unnamed, plan], planner)).toEqual([{ id: "line-plan", name: "plan-and-implement" }]);
+  });
+
+  it("ignores blank app ids", () => {
+    expect(linesUsingAutomation([plan], "  ")).toEqual([]);
+    expect(linesUsingAutomation([plan], undefined)).toEqual([]);
+  });
+});

--- a/web_src/src/pages/factories/lib/automationLineUsage.ts
+++ b/web_src/src/pages/factories/lib/automationLineUsage.ts
@@ -1,0 +1,32 @@
+import type { FactoriesFactoryLine } from "@/api-client";
+
+export type AutomationLineRef = {
+  id: string;
+  name: string;
+};
+
+function lineUsesAutomation(line: FactoriesFactoryLine, appId: string): boolean {
+  return (line.steps ?? []).some((step) => step.app?.app?.trim() === appId);
+}
+
+/**
+ * Lines that run `appId` as a step, in factory order. A line appears once
+ * even when several of its steps use the same automation.
+ */
+export function linesUsingAutomation(
+  lines: FactoriesFactoryLine[] | undefined | null,
+  appId: string | undefined | null,
+): AutomationLineRef[] {
+  const trimmedAppId = appId?.trim();
+  if (!trimmedAppId) {
+    return [];
+  }
+
+  return (lines ?? []).flatMap((line) => {
+    const id = line.id?.trim();
+    if (!id || !lineUsesAutomation(line, trimmedAppId)) {
+      return [];
+    }
+    return [{ id, name: line.name ?? "" }];
+  });
+}

--- a/web_src/src/pages/factories/pages/AutomationDetail.tsx
+++ b/web_src/src/pages/factories/pages/AutomationDetail.tsx
@@ -7,17 +7,23 @@ import { formatTimeAgo } from "@/lib/date";
 import { cn } from "@/lib/utils";
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
+import { linesUsingAutomation } from "../lib/automationLineUsage";
 import {
   findWorkOrderForAutomationRun,
   listFactoryAutomationRuns,
   resolveFactoryAutomationStatusFromCanvasRuns,
   type FactoryAutomationRunCard,
 } from "../lib/factoryAutomationStatus";
-import { automationsPath, factoryAppRunPath } from "../lib/factoryPagePaths";
+import { automationsPath, factoryAppRunPath, factoryLineDetailPath } from "../lib/factoryPagePaths";
 import { buildWorkOrderListEntry } from "../lib/workOrderListModel";
 import { WorkOrderCard, type WorkOrderCardContext } from "../workOrders/WorkOrderCard";
 import { type AutomationCardActions } from "./automationCardActions";
-import { AutomationHeaderActions, DeleteAutomationDialog, StatusTick } from "./automationsPageParts";
+import {
+  AutomationHeaderActions,
+  AutomationUsedByLines,
+  DeleteAutomationDialog,
+  StatusTick,
+} from "./automationsPageParts";
 import { factorySectionBodyClassName, factorySectionHeaderClassName } from "./factoryPageLayoutStyles";
 import { LineVelocityPanel } from "./LineVelocityPanel";
 
@@ -72,6 +78,7 @@ export function AutomationDetail({
   const description = app.description?.trim();
   const subtitleParts = [status.label, description].filter(Boolean);
   const subtitle = subtitleParts.length > 0 ? subtitleParts.join(" · ") : undefined;
+  const usedByLines = linesUsingAutomation(factory?.lines, app.id);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="automations-detail">
@@ -83,6 +90,12 @@ export function AutomationDetail({
         backTestId="automations-detail-back"
         title={automationName}
         subtitle={subtitle}
+        belowRow={
+          <AutomationUsedByLines
+            lines={usedByLines}
+            lineHref={(lineId) => factoryLineDetailPath(organizationId, factoryKey, lineId)}
+          />
+        }
         actions={
           <AutomationHeaderActions
             name={automationName}

--- a/web_src/src/pages/factories/pages/AutomationsPage.tsx
+++ b/web_src/src/pages/factories/pages/AutomationsPage.tsx
@@ -93,6 +93,7 @@ export function AutomationsPage() {
           actionsForApp={model.actionsForApp}
           canCreate={model.canCreateApp || model.permissionsLoading}
           onCreate={() => model.setCreateOpen(true)}
+          lines={model.factory?.lines}
         />
       </div>
 

--- a/web_src/src/pages/factories/pages/automationsPageBody.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageBody.tsx
@@ -1,4 +1,4 @@
-import type { FactoryApp } from "@/api-client";
+import type { FactoriesFactoryLine, FactoryApp } from "@/api-client";
 import type { AutomationCardActions } from "./automationCardActions";
 import { AutomationsPageList, EmptyAutomationsState } from "./automationsPageParts";
 
@@ -11,6 +11,7 @@ type AutomationsPageBodyProps = {
   actionsForApp: (app: FactoryApp) => AutomationCardActions;
   canCreate: boolean;
   onCreate: () => void;
+  lines?: FactoriesFactoryLine[];
 };
 
 export function AutomationsPageBody({
@@ -22,6 +23,7 @@ export function AutomationsPageBody({
   actionsForApp,
   canCreate,
   onCreate,
+  lines,
 }: AutomationsPageBodyProps) {
   if (appsLoading) {
     return <p className="text-[13px] text-muted-foreground">Loading automations…</p>;
@@ -36,6 +38,7 @@ export function AutomationsPageBody({
       apps={apps}
       workOrders={workOrders}
       actionsForApp={actionsForApp}
+      lines={lines}
     />
   );
 }

--- a/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
@@ -4,12 +4,24 @@ import type { ComponentProps } from "react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
-import type { FactoriesWorkOrder, FactoryApp } from "@/api-client";
+import type { FactoriesFactoryLine, FactoriesWorkOrder, FactoryApp } from "@/api-client";
 
 import { AutomationDetail } from "./AutomationDetail";
 import { AutomationCard } from "./automationsPageParts";
 import { duplicateAutomationName } from "./automationCardActions";
 import type { WorkOrderCardContext } from "../workOrders/WorkOrderCard";
+
+const planLine: FactoriesFactoryLine = {
+  id: "line-plan",
+  name: "plan-and-implement",
+  steps: [{ name: "plan", app: { app: "app-refund-planner", entrypoint: "start-plan" } }],
+};
+
+const hotfixLine: FactoriesFactoryLine = {
+  id: "line-hotfix",
+  name: "hotfix",
+  steps: [{ name: "verify", app: { app: "app-refund-planner", entrypoint: "start-verification" } }],
+};
 
 vi.mock("@/hooks/useCanvasData", () => ({
   useInfiniteCanvasRuns: () => ({
@@ -61,7 +73,7 @@ const app: FactoryApp = {
 function renderCard(props: Partial<ComponentProps<typeof AutomationCard>> = {}) {
   return render(
     <MemoryRouter>
-      <AutomationCard app={app} tick="passed" statusLabel="Passed" emphasized {...props} />
+      <AutomationCard app={app} tick="passed" statusLabel="Passed" emphasized lines={[planLine]} {...props} />
     </MemoryRouter>,
   );
 }
@@ -131,6 +143,25 @@ describe("AutomationCard menu", () => {
   });
 });
 
+describe("AutomationCard line usage", () => {
+  it("lists the lines that use the automation", () => {
+    renderCard({ lines: [planLine, hotfixLine] });
+
+    const usedBy = screen.getByTestId("automations-used-by");
+    expect(usedBy).toHaveTextContent("Used by Plan and Implement, Hotfix");
+    expect(usedBy.querySelector("a")).toBeNull();
+  });
+
+  it("says when no line uses the automation", () => {
+    renderCard({
+      app: { ...app, id: "app-unused" },
+      lines: [planLine],
+    });
+
+    expect(screen.getByTestId("automations-used-by")).toHaveTextContent("Not used by a line");
+  });
+});
+
 describe("AutomationDetail tabs", () => {
   const actions = {
     onEdit: vi.fn(),
@@ -185,7 +216,7 @@ describe("AutomationDetail tabs", () => {
           factoryKey="SP"
           app={app}
           actions={actions}
-          factory={{ id: "factory-1", name: "Refunds", key: "SP" }}
+          factory={{ id: "factory-1", name: "Refunds", key: "SP", lines: [planLine, hotfixLine] }}
           workOrders={workOrders}
           workOrderCardContext={workOrderCardContext}
         />
@@ -220,6 +251,21 @@ describe("AutomationDetail tabs", () => {
     expect(screen.getByRole("link", { name: "Open Add refund reconciliation test" })).toHaveAttribute(
       "href",
       expect.stringContaining("run=run-c1111111"),
+    );
+  });
+
+  it("links each line that uses the automation", () => {
+    renderDetail();
+
+    const usedBy = screen.getByTestId("automations-used-by");
+    expect(usedBy).toHaveTextContent("Used by Plan and Implement, Hotfix");
+    expect(screen.getByRole("link", { name: "Plan and Implement" })).toHaveAttribute(
+      "href",
+      "/org-1/workspaces/SP/lines/line-plan",
+    );
+    expect(screen.getByRole("link", { name: "Hotfix" })).toHaveAttribute(
+      "href",
+      "/org-1/workspaces/SP/lines/line-hotfix",
     );
   });
 

--- a/web_src/src/pages/factories/pages/automationsPageParts.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.tsx
@@ -1,4 +1,5 @@
-import type { FactoryApp } from "@/api-client";
+import type { FactoriesFactoryLine, FactoryApp } from "@/api-client";
+import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -12,10 +13,12 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
 import { Copy, MoreHorizontal, Pencil, Plus, Trash2, Workflow } from "lucide-react";
-import { useState, type MouseEvent } from "react";
+import { Fragment, useState, type MouseEvent } from "react";
 import { useNavigate } from "react-router";
+import { linesUsingAutomation, type AutomationLineRef } from "../lib/automationLineUsage";
 import { resolveFactoryAutomationStatus, type FactoryAutomationTick } from "../lib/factoryAutomationStatus";
 import { automationDetailPath } from "../lib/factoryPagePaths";
+import { humanizeLineName } from "../lib/humanizeLineName";
 import { type AutomationCardActions } from "./automationCardActions";
 
 function resolveAutomationCardNavigation(href: string | undefined, navigate: ReturnType<typeof useNavigate>) {
@@ -45,6 +48,7 @@ export function AutomationCard({
   statusLabel,
   emphasized,
   actions,
+  lines,
 }: {
   app: FactoryApp;
   href?: string;
@@ -52,12 +56,14 @@ export function AutomationCard({
   statusLabel: string;
   emphasized?: boolean;
   actions?: AutomationCardActions;
+  lines?: FactoriesFactoryLine[];
 }) {
   const navigate = useNavigate();
   const [deleteOpen, setDeleteOpen] = useState(false);
   const description = app.description?.trim() || "Factory automation canvas.";
   const automationName = app.name?.trim() || "Unnamed automation";
   const { interactive, onClick, onKeyDown } = resolveAutomationCardNavigation(href, navigate);
+  const usedByLines = linesUsingAutomation(lines, app.id);
 
   return (
     <div
@@ -93,6 +99,7 @@ export function AutomationCard({
         <StatusTick tick={tick} />
         <span className="text-[12px] leading-tight text-muted-foreground">{statusLabel}</span>
       </div>
+      <AutomationUsedByLines lines={usedByLines} className="mt-1.5" />
       {actions ? (
         <DeleteAutomationDialog
           open={deleteOpen}
@@ -312,6 +319,46 @@ export function StatusTick({ tick, size = "md" }: { tick: FactoryAutomationTick;
   );
 }
 
+export function AutomationUsedByLines({
+  lines,
+  className,
+  lineHref,
+}: {
+  lines: AutomationLineRef[];
+  className?: string;
+  lineHref?: (lineId: string) => string;
+}) {
+  return (
+    <p className={cn("text-[12px] leading-snug text-muted-foreground", className)} data-testid="automations-used-by">
+      {lines.length === 0 ? (
+        "Not used by a line"
+      ) : (
+        <>
+          Used by{" "}
+          {lines.map((line, index) => (
+            <Fragment key={line.id}>
+              {index > 0 ? ", " : null}
+              <AutomationUsedByLineName line={line} href={lineHref?.(line.id)} />
+            </Fragment>
+          ))}
+        </>
+      )}
+    </p>
+  );
+}
+
+function AutomationUsedByLineName({ line, href }: { line: AutomationLineRef; href?: string }) {
+  const name = humanizeLineName(line.name);
+  if (!href) {
+    return name;
+  }
+  return (
+    <Link href={href} className="text-foreground hover:underline" onClick={(event) => event.stopPropagation()}>
+      {name}
+    </Link>
+  );
+}
+
 export function EmptyAutomationsState({ canCreate, onCreate }: { canCreate: boolean; onCreate: () => void }) {
   return (
     <div
@@ -337,12 +384,14 @@ export function AutomationsPageList({
   apps,
   workOrders,
   actionsForApp,
+  lines,
 }: {
   organizationId: string;
   factoryKey: string;
   apps: FactoryApp[];
   workOrders: Parameters<typeof resolveFactoryAutomationStatus>[1];
   actionsForApp: (app: FactoryApp) => AutomationCardActions;
+  lines?: FactoriesFactoryLine[];
 }) {
   return (
     <ul className="flex flex-col gap-2" data-testid="automations-list">
@@ -359,6 +408,7 @@ export function AutomationsPageList({
               tick={status.tick}
               statusLabel={status.label}
               actions={actionsForApp(app)}
+              lines={lines}
             />
           </li>
         );


### PR DESCRIPTION
## Summary

Operators cannot see which factory lines run an automation.

This change names those lines on the Automations list and on the automation detail page. The detail page links each line name so you can open the line. If no line uses the automation, the UI says "Not used by a line".

## Test plan

- [ ] Open Factories / Pages / Automations / Populated in Storybook.
- [ ] Confirm Refund Planner shows "Used by Plan and Implement".
- [ ] Confirm Refund Verifier shows "Used by Plan and Implement, Hotfix".
- [ ] Open an automation detail page and click a line name.
- [ ] Confirm the line page opens.
- [ ] Confirm an unused automation shows "Not used by a line".


Made with [Cursor](https://cursor.com)