### PR TITLE
fix: treat non-positive DB_POOL_SIZE as invalid

### DIFF
--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -49,7 +49,7 @@ func dbPoolSize() int {
 	poolSize := os.Getenv("DB_POOL_SIZE")
 
 	size, err := strconv.Atoi(poolSize)
-	if err != nil {
+	if err != nil || size <= 0 {
 		return 5
 	}
 

--- a/pkg/database/connection_test.go
+++ b/pkg/database/connection_test.go
@@ -74,6 +74,27 @@ func TestOpenDedicatedSQLDB_ConfiguresDedicatedPool(t *testing.T) {
 	require.NoError(t, db.Ping())
 }
 
+func TestDbPoolSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  int
+	}{
+		{"unset", "", 5},
+		{"valid", "10", 10},
+		{"zero", "0", 5},
+		{"negative", "-1", 5},
+		{"not_a_number", "abc", 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DB_POOL_SIZE", tt.value)
+			require.Equal(t, tt.want, dbPoolSize())
+		})
+	}
+}
+
 func TestIsTestDatabaseName(t *testing.T) {
 	require.True(t, isTestDatabaseName("superplane_test"))
 	require.False(t, isTestDatabaseName("superplane_dev"))


### PR DESCRIPTION
## Summary
- `dbPoolSize()` in `pkg/database/connection.go` only fell back to the default pool size (5) when `DB_POOL_SIZE` failed to parse as an integer, not when it parsed to `0` or a negative number.
- That value is passed directly to `sqlDB.SetMaxOpenConns`/`SetMaxIdleConns`, where `<= 0` means "no limit" per the `database/sql` docs — the opposite of what an operator setting a low/zero pool size would expect.
- `OpenDedicatedSQLDB` in the same file already guards against this (`if maxOpenConns <= 0 { maxOpenConns = 1 }`); `dbPoolSize()` was the inconsistent one.

## Test plan
- [x] Added `TestDbPoolSize` covering unset, valid, zero, negative, and non-numeric `DB_POOL_SIZE` values.
- [ ] CI: `make test PKG_TEST_PACKAGES=./pkg/database` (no local Go/Docker toolchain available in this environment to run it directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)