### PR TITLE
fix: Handle stale run cancellation errors

### DIFF
--- a/web_src/src/lib/errors.spec.ts
+++ b/web_src/src/lib/errors.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getApiErrorMessage, getResponseErrorMessage } from "@/lib/errors";
+import { getApiErrorMessage, getResponseErrorMessage, isNotFoundError } from "@/lib/errors";
 
 describe("errors", () => {
   it("extracts nested api error messages", () => {
@@ -82,5 +82,21 @@ describe("errors", () => {
     const response = new Response("", { status: 500 });
 
     await expect(getResponseErrorMessage(response, "fallback")).resolves.toBe("fallback");
+  });
+});
+
+describe("isNotFoundError", () => {
+  it.each([
+    ["numeric gRPC codes", { code: 5, message: "Not found" }],
+    ["named gRPC codes", { code: "NOT_FOUND" }],
+    ["HTTP statuses", { status: 404 }],
+    ["nested HTTP responses", { response: { status: 404 } }],
+    ["nested messages", { error: { message: "Resource not found" } }],
+  ])("detects not-found API errors from %s", (_source, error) => {
+    expect(isNotFoundError(error)).toBe(true);
+  });
+
+  it("rejects other API errors", () => {
+    expect(isNotFoundError({ code: 13, message: "Service unavailable" })).toBe(false);
   });
 });

--- a/web_src/src/lib/errors.ts
+++ b/web_src/src/lib/errors.ts
@@ -1,3 +1,6 @@
+const HTTP_NOT_FOUND_STATUS = 404;
+const GRPC_NOT_FOUND_CODE = 5;
+
 /**
  * Extract error message from API error response
  * Handles the structure returned by the generated OpenAPI client
@@ -11,6 +14,21 @@ export function getApiErrorMessage(error: unknown, fallback = "An error occurred
     getNonEmptyString(error instanceof Error ? error.message : null) ??
     fallback
   );
+}
+
+/** Detect API errors that indicate the requested resource does not exist. */
+export function isNotFoundError(error: unknown): boolean {
+  const response = getErrorField(error, "response");
+  const nestedError = getErrorField(error, "error");
+  const responseData = getErrorField(response, "data");
+  const errorCandidates = [error, response, nestedError, responseData];
+
+  if (errorCandidates.some(hasNotFoundStatus)) {
+    return true;
+  }
+
+  const message = getApiErrorMessage(error, "").toLowerCase();
+  return message.includes("not found") || message.includes("404");
 }
 
 export async function getResponseErrorMessage(response: Response, fallback = "An error occurred"): Promise<string> {
@@ -35,6 +53,20 @@ function getNestedError(error: unknown): unknown {
   }
 
   return error.error;
+}
+
+function hasNotFoundStatus(error: unknown): boolean {
+  const status = getErrorField(error, "status");
+  const code = getErrorField(error, "code");
+  return status === HTTP_NOT_FOUND_STATUS || code === GRPC_NOT_FOUND_CODE || code === "NOT_FOUND";
+}
+
+function getErrorField(error: unknown, key: string): unknown {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  return (error as Record<string, unknown>)[key];
 }
 
 function getResponseDataError(error: unknown): unknown {

--- a/web_src/src/pages/app/lib/repository-spec-files.ts
+++ b/web_src/src/pages/app/lib/repository-spec-files.ts
@@ -6,11 +6,11 @@ import {
   type CanvasesStagingSummary,
 } from "@/api-client";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+import { isNotFoundError } from "@/lib/errors";
 
 import { dematerializeCanvasSpec, dematerializeConsoleSpec } from "./workflow-spec-files";
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "./workflow-spec-paths";
 import { toCanvasVersionShell } from "./canvas-versions";
-import { isNotFoundError } from "../workflowPageHelpers";
 
 // Confirms whether a canvas version still exists via DescribeCanvasVersion.
 export async function canvasVersionExists(canvasId: string, versionId: string): Promise<boolean> {

--- a/web_src/src/pages/app/workflowPageHelpers.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.ts
@@ -14,6 +14,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import type { CanvasEdge, CanvasNode, SidebarData } from "@/ui/CanvasPage";
 import type { LogEntry } from "@/ui/CanvasLogSidebar";
 import { getColorClass } from "@/lib/colors";
+import { isNotFoundError } from "@/lib/errors";
 import { prepareAnnotationNode } from "./lib/canvas-annotation-node";
 import { prepareComponentNode, prepareTriggerNode } from "./lib/canvas-node-preparation";
 import { getNodeIntegrationName } from "./lib/node-integrations";
@@ -351,33 +352,6 @@ function readErrorField(error: unknown, key: string): unknown {
     return undefined;
   }
   return (error as Record<string, unknown>)[key];
-}
-
-/**
- * True when an API call failed because the targeted resource does not exist
- * (HTTP 404 / gRPC NOT_FOUND / "not found" message). Used to turn a stale
- * draft-version id into a graceful recovery instead of an opaque error.
- */
-export function isNotFoundError(error: unknown): boolean {
-  if (readErrorField(error, "status") === 404) {
-    return true;
-  }
-
-  const response = readErrorField(error, "response");
-  if (typeof response === "object" && response !== null && readErrorField(response, "status") === 404) {
-    return true;
-  }
-
-  if (readErrorField(error, "code") === "NOT_FOUND") {
-    return true;
-  }
-
-  const message = readErrorField(error, "message");
-  if (typeof message !== "string") {
-    return false;
-  }
-
-  return message.includes("not found") || message.includes("404");
 }
 
 /**

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
@@ -6,11 +6,11 @@ import {
   type FactoryApp,
 } from "@/api-client";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+import { isNotFoundError } from "@/lib/errors";
 import { encodeRepositoryFileContent } from "@/pages/app/files/lib/repository-files";
 import { fetchRepositorySpecFileContent } from "@/pages/app/lib/repository-spec-files";
 import { dematerializeConsoleSpec, materializeCanvasSpec } from "@/pages/app/lib/workflow-spec-files";
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
-import { isNotFoundError } from "@/pages/app/workflowPageHelpers";
 import { isCanvasNameAlreadyExistsError, uniqueCanvasName } from "@/pages/home/uniqueCanvasName";
 import * as yaml from "js-yaml";
 
@@ -68,7 +68,7 @@ async function defaultFetchConsoleYaml(sourceCanvasId: string): Promise<string |
     const consoleYaml = await fetchRepositorySpecFileContent(sourceCanvasId, CONSOLE_YAML_PATH);
     return consoleYamlHasContent(consoleYaml) ? consoleYaml : undefined;
   } catch (error) {
-    if (isNotFoundError(error) || (error instanceof Error && /404|not found/i.test(error.message))) {
+    if (isNotFoundError(error)) {
       return undefined;
     }
     throw error;

--- a/web_src/src/ui/Runs/useRunInspectorActions.spec.tsx
+++ b/web_src/src/ui/Runs/useRunInspectorActions.spec.tsx
@@ -1,10 +1,30 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CanvasesCanvasRun } from "@/api-client";
 import type { RunInspectorNodeSection } from "./types";
 import { useRunInspectorActions } from "./useRunInspectorActions";
+
+const { cancelRun, showErrorToast, showInfoToast } = vi.hoisted(() => ({
+  cancelRun: vi.fn(),
+  showErrorToast: vi.fn(),
+  showInfoToast: vi.fn(),
+}));
+
+vi.mock("@/api-client", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    canvasesCancelRun: cancelRun,
+  };
+});
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast,
+  showInfoToast,
+  showSuccessToast: vi.fn(),
+}));
 
 const run: CanvasesCanvasRun = {
   rootEvent: {
@@ -65,6 +85,15 @@ function actionSection(overrides: Partial<RunInspectorNodeSection> = {}): RunIns
 }
 
 describe("useRunInspectorActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cancelRun.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("allows Stop when action sections only have lightweight running execution refs", () => {
     const { result } = renderActions([
       actionSection({
@@ -104,5 +133,30 @@ describe("useRunInspectorActions", () => {
     });
 
     expect(result.current.stopDisabled).toBe(false);
+  });
+
+  it("treats a missing run as no longer active", async () => {
+    cancelRun.mockRejectedValue({ code: 5, message: "Not found" });
+    const { result } = renderActions([], {
+      runOverride: { ...run, id: "run-1" },
+    });
+
+    act(() => result.current.stop());
+
+    await waitFor(() => expect(showInfoToast).toHaveBeenCalledWith("Run is no longer active"));
+    expect(showErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("shows the API message when stopping a run fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    cancelRun.mockRejectedValue({ code: 13, message: "Service unavailable" });
+    const { result } = renderActions([], {
+      runOverride: { ...run, id: "run-1" },
+    });
+
+    act(() => result.current.stop());
+
+    await waitFor(() => expect(showErrorToast).toHaveBeenCalledWith("Failed to stop run: Service unavailable"));
+    expect(consoleError).toHaveBeenCalledWith("Failed to stop run: Service unavailable");
   });
 });

--- a/web_src/src/ui/Runs/useRunInspectorActions.ts
+++ b/web_src/src/ui/Runs/useRunInspectorActions.ts
@@ -8,7 +8,8 @@ import {
   canvasesReemitTriggerEvent,
   type CanvasesCanvasRun,
 } from "@/api-client";
-import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { getApiErrorMessage, isNotFoundError } from "@/lib/errors";
+import { showErrorToast, showInfoToast, showSuccessToast } from "@/lib/toast";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import type { RunInspectorNodeSection } from "./types";
 
@@ -172,9 +173,17 @@ function useStopMutation({
     onSuccess: async () => {
       await refreshRunQueries();
     },
-    onError: (error) => {
-      console.error("Failed to stop run", error);
-      showErrorToast("Failed to stop run");
+    onError: async (error) => {
+      if (isNotFoundError(error)) {
+        showInfoToast("Run is no longer active");
+        await refreshRunQueries();
+        return;
+      }
+
+      const apiMessage = getApiErrorMessage(error, "");
+      const errorMessage = apiMessage ? `Failed to stop run: ${apiMessage}` : "Failed to stop run";
+      console.error(errorMessage);
+      showErrorToast(errorMessage);
     },
   });
 }


### PR DESCRIPTION
## Summary

Runs can finish between inspection and cancellation. The API then returns `NOT_FOUND` for a run that is no longer active.

Treat this response as an informational outcome. Keep unexpected cancellation errors readable for users and error reporting.

Centralize not-found detection so frontend consumers handle HTTP and gRPC errors consistently.

Closes #6788

## Test plan

- [x] Run the affected frontend unit tests.
- [x] Run `make check.build.ui`.
- [x] Run `make check.lint.ui`.