### PR TITLE
fix: Unblock the lines phase run-fit e2e

### DIFF
--- a/test/e2e/lines_run_fit_view_test.go
+++ b/test/e2e/lines_run_fit_view_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/superplanehq/superplane/test/e2e/session"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 // The fixed browser context viewport configured in test_context.go. A node
@@ -27,7 +28,6 @@ const (
 
 const (
 	linesRunFitTriggerNodeID = "kickoff"
-	linesRunFitStepName      = "Build"
 	// Factory run inspection re-lays a linear run out in a single vertical
 	// spine from a fixed, small origin (see layoutFactoryRunLeafGraph),
 	// independent of any saved editor position. A dozen chained steps stack
@@ -78,9 +78,34 @@ func (s *linesRunFitSteps) start() {
 }
 
 func (s *linesRunFitSteps) givenAFactory() {
-	factory, err := models.CreateFactory(database.Conn(), s.session.OrgID, support.RandomName("factory"), "", "")
+	tx := database.DB(s.t.Context())
+	factory, err := models.CreateFactory(tx, s.session.OrgID, support.RandomName("factory"), "", "")
 	require.NoError(s.t, err)
 	s.factory = factory
+	s.completeFactoryOnboarding()
+}
+
+// OnboardingGate sends incomplete workspaces to /setup, so the line
+// detail page never mounts unless this factory is marked complete.
+func (s *linesRunFitSteps) completeFactoryOnboarding() {
+	vcsID := uuid.New().String()
+	agentID := uuid.New().String()
+	appRepository := "acme/app"
+	backlogRepository := "acme/backlog"
+	issuesSource := models.FactoryOnboardingIssuesSourceVCS
+	agentHarness := models.FactoryOnboardingAgentHarnessClaudeCode
+	appID := uuid.New().String()
+	lineID := uuid.New().String()
+	require.NoError(s.t, s.factory.CompleteOnboarding(database.DB(s.t.Context()), models.FactoryOnboardingPatch{
+		VCSIntegrationID:   &vcsID,
+		AgentIntegrationID: &agentID,
+		AppRepository:      &appRepository,
+		BacklogRepository:  &backlogRepository,
+		IssuesSource:       &issuesSource,
+		AgentHarness:       &agentHarness,
+		ProvisionedAppID:   &appID,
+		ProvisionedLineID:  &lineID,
+	}))
 }
 
 // Builds an app with a trigger followed by a long, linear chain of
@@ -148,7 +173,6 @@ func (s *linesRunFitSteps) givenAFactoryAppWithAWideParticipantChain() {
 func (s *linesRunFitSteps) givenALineDispatchedForThatApp() {
 	line, err := s.factory.CreateLine(database.Conn(), support.RandomName("line"), []models.FactoryLineStep{
 		{
-			Name:       linesRunFitStepName,
 			Type:       models.FactoryLineStepTypeRunApp,
 			AppID:      s.canvas.ID,
 			Entrypoint: linesRunFitTriggerNodeID,
@@ -161,8 +185,15 @@ func (s *linesRunFitSteps) givenALineDispatchedForThatApp() {
 	require.NoError(s.t, err)
 	require.NoError(s.t, order.TransitionOnDispatch(database.Conn(), nil))
 
-	result, err := line.StartStep(database.Conn(), order, 0)
-	require.NoError(s.t, err)
+	var result *models.FactoryLineStepResult
+	require.NoError(s.t, database.Conn().Transaction(func(tx *gorm.DB) error {
+		var dispatchErr error
+		_, result, dispatchErr = line.Dispatch(tx, order)
+		return dispatchErr
+	}))
+	require.NotNil(s.t, result)
+	require.NotNil(s.t, result.Execution)
+	require.NotNil(s.t, result.Run)
 	s.execution = result.Execution
 	s.runID = result.Run.ID
 
@@ -205,6 +236,7 @@ func (s *linesRunFitSteps) whenIVisitTheLineDetail() {
 func (s *linesRunFitSteps) whenIOpenThePhaseRunCard() {
 	s.session.Click(q.TestID("lines-phase-run-" + s.execution.ID.String()))
 	s.session.AssertURLContains("run=" + s.runID.String())
+	s.session.AssertVisible(q.TestID("factory-app-canvas-page"))
 }
 
 func (s *linesRunFitSteps) thenTheFirstAndLastParticipantsFitIntoView() {

--- a/web_src/src/pages/app/useInitialRunFitOnEntry.spec.ts
+++ b/web_src/src/pages/app/useInitialRunFitOnEntry.spec.ts
@@ -108,4 +108,28 @@ describe("useInitialRunFitOnEntry", () => {
 
     expect(requestRunFit).not.toHaveBeenCalled();
   });
+
+  it("requests a fit once conditions become ready after mount", () => {
+    const requestRunFit = vi.fn();
+
+    const { rerender } = renderWithRef(
+      {
+        isRunInspectionMode: false,
+        selectedRunId: null,
+        searchParams: new URLSearchParams(),
+      },
+      requestRunFit,
+    );
+
+    expect(requestRunFit).not.toHaveBeenCalled();
+
+    rerender({
+      isRunInspectionMode: true,
+      selectedRunId: runId,
+      searchParams: new URLSearchParams({ run: runId }),
+    });
+
+    expect(requestRunFit).toHaveBeenCalledTimes(1);
+    expect(requestRunFit).toHaveBeenCalledWith(runId);
+  });
 });

--- a/web_src/src/pages/app/useInitialRunFitOnEntry.ts
+++ b/web_src/src/pages/app/useInitialRunFitOnEntry.ts
@@ -27,9 +27,8 @@ export function useInitialRunFitOnEntry({
 
   useEffect(() => {
     if (handledRef.current) return;
-    handledRef.current = true;
-
     if (!shouldRequestInitialRunFit({ isRunInspectionMode, selectedRunId, searchParams })) return;
+    handledRef.current = true;
     requestRunFitRef.current(selectedRunId!);
   }, [isRunInspectionMode, requestRunFitRef, searchParams, selectedRunId]);
 }

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -405,7 +405,7 @@ function PhaseRunCard({
   const queuedLabel = isQueuedStepRow(run.execution) ? resolvePhaseRunStatus(run.execution).label : null;
 
   return (
-    <div>
+    <div data-testid={`lines-phase-run-${run.executionId}`}>
       <WorkOrderCard {...workOrderCardContext} entry={entry} href={href} />
       {queuedLabel ? (
         <p className="mt-1 flex items-center gap-1 px-0.5 text-[11px] text-muted-foreground">

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2865,6 +2865,7 @@ function CanvasContent({
     getNodes,
     getViewport,
     hasFitToViewRef,
+    hasReactFlowInitialized,
     isAutoFocusEnabled,
     isRunInspectionMode,
     reportZoom,


### PR DESCRIPTION
## Summary

Opening a phase run card sent an incomplete factory to `/setup`.
The phase card had no stable test id, so the e2e could not open the run.
The canvas could skip the participant fit when ReactFlow was not ready.
The e2e still used `FactoryLineStep.Name` and `StartStep` after those APIs were removed.

## Test plan

- [ ] Run `make test.e2e.single FILE=test/e2e/lines_run_fit_view_test.go LINE=48`.
- [ ] Open a line that has a long app chain.
- [ ] Click a phase run card.
- [ ] Confirm the first and last participant nodes stay in view.


Made with [Cursor](https://cursor.com)