### PR TITLE
fix: Widen factory edit node Y spacing

### DIFF
--- a/web_src/src/lib/factoryCanvasChrome.ts
+++ b/web_src/src/lib/factoryCanvasChrome.ts
@@ -90,5 +90,10 @@ export const FACTORY_HANDLE_STYLE = {
 /** Keep FactoryNodeCard, append ghost, placement gap, and ELK estimates aligned. */
 export const FACTORY_NODE_CARD_WIDTH = 280;
 export const FACTORY_NODE_CARD_HEIGHT = 104;
-/** Vertical gap below a factory card when appending / layering. */
+/** Vertical gap below a factory card in persisted ELK layout, live, and run. */
 export const FACTORY_NODE_VERTICAL_GAP = 64;
+/**
+ * Edit/configure only. Compact 64px leaves node duplicate/delete on top of
+ * the edge-delete control. Live and run keep FACTORY_NODE_VERTICAL_GAP.
+ */
+export const FACTORY_NODE_EDIT_VERTICAL_GAP = 200;

--- a/web_src/src/lib/factoryEditVerticalSpacing.spec.ts
+++ b/web_src/src/lib/factoryEditVerticalSpacing.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  FACTORY_NODE_CARD_HEIGHT,
+  FACTORY_NODE_EDIT_VERTICAL_GAP,
+  FACTORY_NODE_VERTICAL_GAP,
+} from "./factoryCanvasChrome";
+import {
+  expandFactoryEditVerticalPositions,
+  FACTORY_COMPACT_LAYER_STRIDE,
+  FACTORY_EDIT_VERTICAL_EXTRA_PER_LAYER,
+} from "./factoryEditVerticalSpacing";
+
+function node(id: string, x: number, y: number) {
+  return { id, position: { x, y } };
+}
+
+describe("expandFactoryEditVerticalPositions", () => {
+  it("leaves a single node unchanged", () => {
+    const nodes = [node("only", 10, 20)];
+    expect(expandFactoryEditVerticalPositions(nodes)).toBe(nodes);
+  });
+
+  it("leaves same-layer nodes on the same Y", () => {
+    const nodes = [node("left", 0, 0), node("right", 400, 0)];
+    expect(expandFactoryEditVerticalPositions(nodes)).toEqual(nodes);
+  });
+
+  it("adds extra Y per stacked rank so edit gap fits node actions and edge delete", () => {
+    const stride = FACTORY_COMPACT_LAYER_STRIDE;
+    const nodes = [node("top", 0, 0), node("mid", 0, stride), node("bottom", 0, stride * 2)];
+
+    const expanded = expandFactoryEditVerticalPositions(nodes);
+    const extra = FACTORY_EDIT_VERTICAL_EXTRA_PER_LAYER;
+
+    expect(expanded[0].position).toEqual({ x: 0, y: 0 });
+    expect(expanded[1].position).toEqual({ x: 0, y: stride + extra });
+    expect(expanded[2].position).toEqual({ x: 0, y: stride * 2 + extra * 2 });
+
+    const gapBetweenCards = expanded[1].position.y - FACTORY_NODE_CARD_HEIGHT;
+    expect(gapBetweenCards).toBe(FACTORY_NODE_EDIT_VERTICAL_GAP);
+    expect(FACTORY_NODE_EDIT_VERTICAL_GAP).toBeGreaterThan(FACTORY_NODE_VERTICAL_GAP);
+  });
+
+  it("keeps side-by-side ranks aligned after stretching", () => {
+    const stride = FACTORY_COMPACT_LAYER_STRIDE;
+    const nodes = [node("a1", 0, 0), node("a2", 0, stride), node("b1", 400, 0), node("b2", 400, stride)];
+
+    const expanded = expandFactoryEditVerticalPositions(nodes);
+    expect(expanded.find((item) => item.id === "a1")?.position.y).toBe(0);
+    expect(expanded.find((item) => item.id === "b1")?.position.y).toBe(0);
+    expect(expanded.find((item) => item.id === "a2")?.position.y).toBe(
+      expanded.find((item) => item.id === "b2")?.position.y,
+    );
+  });
+
+  it("does not change X", () => {
+    const stride = FACTORY_COMPACT_LAYER_STRIDE;
+    const nodes = [node("top", 42, 0), node("bottom", 42, stride)];
+    const expanded = expandFactoryEditVerticalPositions(nodes);
+    expect(expanded.map((item) => item.position.x)).toEqual([42, 42]);
+  });
+});

--- a/web_src/src/lib/factoryEditVerticalSpacing.ts
+++ b/web_src/src/lib/factoryEditVerticalSpacing.ts
@@ -1,0 +1,71 @@
+import {
+  FACTORY_NODE_CARD_HEIGHT,
+  FACTORY_NODE_EDIT_VERTICAL_GAP,
+  FACTORY_NODE_VERTICAL_GAP,
+} from "./factoryCanvasChrome";
+
+/** Same-layer nodes can differ by a few pixels after packing. */
+const LAYER_Y_TOLERANCE_PX = 8;
+
+export const FACTORY_EDIT_VERTICAL_EXTRA_PER_LAYER = FACTORY_NODE_EDIT_VERTICAL_GAP - FACTORY_NODE_VERTICAL_GAP;
+
+type PositionedNode = {
+  position: { x: number; y: number };
+};
+
+function clusteredLayerYs(ys: number[]): number[] {
+  const sorted = [...ys].sort((left, right) => left - right);
+  const layers: number[] = [];
+  for (const y of sorted) {
+    const last = layers[layers.length - 1];
+    if (last === undefined || y - last > LAYER_Y_TOLERANCE_PX) {
+      layers.push(y);
+    }
+  }
+  return layers;
+}
+
+function nearestLayerIndex(y: number, layers: number[]): number {
+  let bestIndex = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < layers.length; index += 1) {
+    const distance = Math.abs(y - layers[index]);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  }
+  return bestIndex;
+}
+
+/**
+ * Stretch stacked factory ranks in edit/configure only.
+ * Spec / live / run keep compact ELK positions (FACTORY_NODE_VERTICAL_GAP).
+ */
+export function expandFactoryEditVerticalPositions<T extends PositionedNode>(nodes: T[]): T[] {
+  if (nodes.length <= 1 || FACTORY_EDIT_VERTICAL_EXTRA_PER_LAYER === 0) {
+    return nodes;
+  }
+
+  const layers = clusteredLayerYs(nodes.map((node) => node.position.y));
+  if (layers.length <= 1) {
+    return nodes;
+  }
+
+  return nodes.map((node) => {
+    const rank = nearestLayerIndex(node.position.y, layers);
+    if (rank === 0) {
+      return node;
+    }
+    return {
+      ...node,
+      position: {
+        x: node.position.x,
+        y: node.position.y + rank * FACTORY_EDIT_VERTICAL_EXTRA_PER_LAYER,
+      },
+    };
+  });
+}
+
+/** Compact layer stride used by factory ELK (card + view gap). */
+export const FACTORY_COMPACT_LAYER_STRIDE = FACTORY_NODE_CARD_HEIGHT + FACTORY_NODE_VERTICAL_GAP;

--- a/web_src/src/ui/CanvasPage/appendFromNodePlacement.spec.ts
+++ b/web_src/src/ui/CanvasPage/appendFromNodePlacement.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { FACTORY_NODE_CARD_HEIGHT, FACTORY_NODE_EDIT_VERTICAL_GAP } from "@/lib/factoryCanvasChrome";
+import { computeAppendFromNodePlacement } from "./appendFromNodePlacement";
+
+describe("computeAppendFromNodePlacement", () => {
+  const viewport = { x: 0, y: 0, zoom: 1 };
+
+  it("places the factory edit placeholder using the edit vertical gap", () => {
+    const { placeholderPosition } = computeAppendFromNodePlacement({
+      sourcePosition: { x: 10, y: 20 },
+      sourceWidth: 280,
+      sourceHeight: FACTORY_NODE_CARD_HEIGHT,
+      isVerticalFlow: true,
+      viewport,
+      canvasWidth: 2000,
+      canvasHeight: 2000,
+    });
+
+    expect(placeholderPosition).toEqual({
+      x: 10,
+      y: 20 + FACTORY_NODE_CARD_HEIGHT + FACTORY_NODE_EDIT_VERTICAL_GAP,
+    });
+  });
+});

--- a/web_src/src/ui/CanvasPage/appendFromNodePlacement.ts
+++ b/web_src/src/ui/CanvasPage/appendFromNodePlacement.ts
@@ -1,7 +1,7 @@
 import {
   FACTORY_NODE_CARD_HEIGHT,
   FACTORY_NODE_CARD_WIDTH,
-  FACTORY_NODE_VERTICAL_GAP,
+  FACTORY_NODE_EDIT_VERTICAL_GAP,
 } from "@/lib/factoryCanvasChrome";
 
 type FlowPoint = { x: number; y: number };
@@ -41,7 +41,7 @@ export function computeAppendFromNodePlacement({
   canvasWidth,
   canvasHeight,
 }: AppendPlacementInput): AppendPlacementResult {
-  const gapY = isVerticalFlow ? FACTORY_NODE_VERTICAL_GAP : APPEND_GAP_Y;
+  const gapY = isVerticalFlow ? FACTORY_NODE_EDIT_VERTICAL_GAP : APPEND_GAP_Y;
   const estimatedWidth = isVerticalFlow ? FACTORY_NODE_CARD_WIDTH : PLACEHOLDER_ESTIMATED_WIDTH;
   const estimatedHeight = isVerticalFlow ? FACTORY_NODE_CARD_HEIGHT : PLACEHOLDER_ESTIMATED_HEIGHT;
 

--- a/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
@@ -102,8 +102,8 @@ describe("useCanvasState", () => {
     const compactStride = FACTORY_COMPACT_LAYER_STRIDE;
     const stacked = [makeNode("top", 0, 0), makeNode("bottom", 0, compactStride)];
 
-    const { result, rerender } = renderHook(({ props }) => useCanvasState(props), {
-      initialProps: { props: { ...makeProps(stacked), layoutMode: "factory-auto" as const } },
+    const { result, rerender } = renderHook(({ props }: { props: CanvasPageProps }) => useCanvasState(props), {
+      initialProps: { props: { ...makeProps(stacked), layoutMode: "factory-auto" } },
     });
 
     expect(result.current.nodes.find((node) => node.id === "top")?.position.y).toBe(0);
@@ -111,7 +111,7 @@ describe("useCanvasState", () => {
       compactStride + FACTORY_EDIT_VERTICAL_EXTRA_PER_LAYER,
     );
 
-    rerender({ props: makeProps(stacked) });
+    rerender({ props: { ...makeProps(stacked), layoutMode: "manual" } });
     expect(result.current.nodes.find((node) => node.id === "bottom")?.position.y).toBe(compactStride);
   });
 

--- a/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Edge, Node } from "@xyflow/react";
+import { FACTORY_COMPACT_LAYER_STRIDE, FACTORY_EDIT_VERTICAL_EXTRA_PER_LAYER } from "@/lib/factoryEditVerticalSpacing";
 import type { CanvasPageProps } from ".";
 import { useCanvasState } from "./useCanvasState";
 
@@ -95,6 +96,23 @@ describe("useCanvasState", () => {
     });
 
     expect(result.current.edges).toBe(edgesBeforeDrag);
+  });
+
+  it("stretches stacked factory ranks in factory-auto edit layout only", () => {
+    const compactStride = FACTORY_COMPACT_LAYER_STRIDE;
+    const stacked = [makeNode("top", 0, 0), makeNode("bottom", 0, compactStride)];
+
+    const { result, rerender } = renderHook(({ props }) => useCanvasState(props), {
+      initialProps: { props: { ...makeProps(stacked), layoutMode: "factory-auto" as const } },
+    });
+
+    expect(result.current.nodes.find((node) => node.id === "top")?.position.y).toBe(0);
+    expect(result.current.nodes.find((node) => node.id === "bottom")?.position.y).toBe(
+      compactStride + FACTORY_EDIT_VERTICAL_EXTRA_PER_LAYER,
+    );
+
+    rerender({ props: makeProps(stacked) });
+    expect(result.current.nodes.find((node) => node.id === "bottom")?.position.y).toBe(compactStride);
   });
 
   it("does not restart an active factory layout animation when the same layout refreshes", () => {

--- a/web_src/src/ui/CanvasPage/useCanvasState.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.ts
@@ -1,6 +1,7 @@
 import type { Edge, EdgeChange, Node, NodeChange, NodePositionChange } from "@xyflow/react";
 import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { expandFactoryEditVerticalPositions } from "@/lib/factoryEditVerticalSpacing";
 import type { CanvasPageProps } from ".";
 import { isFactoryAutoLayout } from "./layoutMode";
 import {
@@ -92,6 +93,12 @@ function buildSyncedNodes(
   return [...syncedNodes, ...localOnlyNodes];
 }
 
+function withFactoryEditVerticalSpacing(nodes: Node[], specNodeIds: Set<string>): Node[] {
+  const specNodes = nodes.filter((node) => specNodeIds.has(node.id));
+  const localOnlyNodes = nodes.filter((node) => !specNodeIds.has(node.id));
+  return [...expandFactoryEditVerticalPositions(specNodes), ...localOnlyNodes];
+}
+
 export interface CanvasPageState {
   nodes: Node[];
   edges: Edge[];
@@ -116,7 +123,13 @@ export interface CanvasPageState {
 export function useCanvasState(props: CanvasPageProps): CanvasPageState {
   const { nodes: initialNodes, edges: initialEdges, startCollapsed } = props;
 
-  const [nodes, setNodes] = useState<Node[]>(() => initialNodes ?? []);
+  const [nodes, setNodes] = useState<Node[]>(() => {
+    const list = initialNodes ?? [];
+    if (!isFactoryAutoLayout(props.layoutMode)) {
+      return list;
+    }
+    return expandFactoryEditVerticalPositions(list);
+  });
   const [edges, setEdges] = useState<Edge[]>(() => initialEdges ?? []);
   const pendingNodePositionsRef = useRef<Map<string, PendingNodePosition>>(new Map());
   const displayedNodesRef = useRef(nodes);
@@ -151,7 +164,10 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
     }
 
     const currentNodes = displayedNodesRef.current;
-    const targetNodes = buildSyncedNodes(currentNodes, initialNodes, pendingNodePositionsRef.current);
+    const targetNodes = withFactoryEditVerticalSpacing(
+      buildSyncedNodes(currentNodes, initialNodes, pendingNodePositionsRef.current),
+      new Set(initialNodes.map((node) => node.id)),
+    );
     const targetKey = getLayoutTargetKey(targetNodes);
     const animationEnabled = !(
       typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches


### PR DESCRIPTION
## Summary

Factory configure puts node duplicate and delete controls on the edge-delete control.
The compact 64px gap is too short for those controls.
This PR increases the displayed vertical gap in edit mode only.
Live and run keep the compact layout.

## Test plan

- [ ] Open a factory canvas in configure mode.
- [ ] Confirm stacked nodes have more vertical space.
- [ ] Hover an edge and delete it without hitting node duplicate or delete.
- [ ] Leave edit mode and confirm the live layout stays compact.
- [ ] Open run inspection and confirm the run layout is unchanged.


Made with [Cursor](https://cursor.com)