### PR TITLE
chore: Add repository provisioner metrics

### DIFF
--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -36,6 +36,11 @@ var (
 	nodeRequestWorkerTickHistogram          metric.Float64Histogram
 	nodeRequestWorkerRequestsCountHistogram metric.Int64Histogram
 
+	repositoryProvisionerWorkerTickHistogram               metric.Float64Histogram
+	repositoryProvisionerWorkerRepositoriesCountGauge      metric.Int64Gauge
+	repositoryProvisionerWorkerRepositoriesCounter         metric.Int64Counter
+	repositoryProvisionerWorkerRepositoryDurationHistogram metric.Float64Histogram
+
 	webhookProvisionerWorkerTickHistogram            metric.Float64Histogram
 	webhookProvisionerWorkerWebhooksCountGauge       metric.Int64Gauge
 	webhookProvisionerWorkerWebhooksCounter          metric.Int64Counter
@@ -246,6 +251,42 @@ func InitMetrics(ctx context.Context) error {
 		"node_request_worker.tick.requests.pending",
 		metric.WithDescription("Number of pending workflow node requests each tick"),
 		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	repositoryProvisionerWorkerTickHistogram, err = meter.Float64Histogram(
+		"repository_provisioner_worker.tick.duration.seconds",
+		metric.WithDescription("Duration of each RepositoryProvisionerWorker backfill tick"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return err
+	}
+
+	repositoryProvisionerWorkerRepositoriesCountGauge, err = meter.Int64Gauge(
+		"repository_provisioner_worker.tick.repositories.pending",
+		metric.WithDescription("Number of pending repositories on the last repository provisioner tick"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	repositoryProvisionerWorkerRepositoriesCounter, err = meter.Int64Counter(
+		"repository_provisioner_worker.repositories.total",
+		metric.WithDescription("RepositoryProvisionerWorker repository processing outcomes"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	repositoryProvisionerWorkerRepositoryDurationHistogram, err = meter.Float64Histogram(
+		"repository_provisioner_worker.repository.duration.seconds",
+		metric.WithDescription("Duration of RepositoryProvisionerWorker repository processing"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
 		return err
@@ -658,6 +699,48 @@ func RecordNodeRequestWorkerRequestsCount(ctx context.Context, count int) {
 	}
 
 	nodeRequestWorkerRequestsCountHistogram.Record(ctx, int64(count))
+}
+
+func RecordRepositoryProvisionerWorkerTickDuration(ctx context.Context, d time.Duration) {
+	if !metricsReady.Load() {
+		return
+	}
+
+	repositoryProvisionerWorkerTickHistogram.Record(ctx, d.Seconds())
+}
+
+func RecordRepositoryProvisionerWorkerRepositoriesCount(ctx context.Context, count int) {
+	if !metricsReady.Load() {
+		return
+	}
+
+	repositoryProvisionerWorkerRepositoriesCountGauge.Record(ctx, int64(count))
+}
+
+func RecordRepositoryProvisionerWorkerRepositoryProcessing(
+	ctx context.Context,
+	d time.Duration,
+	trigger, outcome, reason string,
+) {
+	if !metricsReady.Load() {
+		return
+	}
+
+	attrs := metric.WithAttributes(
+		attribute.String("trigger", trigger),
+		attribute.String("outcome", outcome),
+		attribute.String("reason", reason),
+	)
+
+	repositoryProvisionerWorkerRepositoriesCounter.Add(ctx, 1, attrs)
+	repositoryProvisionerWorkerRepositoryDurationHistogram.Record(
+		ctx,
+		d.Seconds(),
+		metric.WithAttributes(
+			attribute.String("trigger", trigger),
+			attribute.String("outcome", outcome),
+		),
+	)
 }
 
 func RecordWebhookProvisionerWorkerTickDuration(ctx context.Context, d time.Duration) {

--- a/pkg/workers/repository_provisioner.go
+++ b/pkg/workers/repository_provisioner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"github.com/superplanehq/superplane/pkg/telemetry"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/proto"
 	"gorm.io/gorm"
@@ -28,6 +29,14 @@ const (
 	canvasRepositoryProvisionerConnection    = "superplane"
 	canvasRepositoryProvisionerBatch         = 100
 	canvasRepositoryProvisionerBackfillEvery = time.Minute
+
+	repositoryProvisionerTriggerBackfill = "backfill"
+	repositoryProvisionerTriggerEvent    = "event"
+
+	repositoryProvisionerReasonCreateRepository = "create_repository"
+	repositoryProvisionerReasonCommitSeedFiles  = "commit_seed_files"
+	repositoryProvisionerReasonMarkError        = "mark_error"
+	repositoryProvisionerReasonMarkReady        = "mark_ready"
 )
 
 type RepositoryProvisionerWorker struct {
@@ -35,6 +44,43 @@ type RepositoryProvisionerWorker struct {
 	RabbitMQURL string
 	Storage     git.Provider
 	semaphore   *semaphore.Weighted
+	metrics     repositoryProvisionerMetrics
+}
+
+type repositoryProvisionerMetrics interface {
+	recordTickDuration(context.Context, time.Duration)
+	recordRepositoriesCount(context.Context, int)
+	recordRepository(context.Context, repositoryProvisioningMetric)
+}
+
+type repositoryProvisioningMetric struct {
+	duration time.Duration
+	trigger  string
+	outcome  string
+	reason   string
+}
+
+type telemetryRepositoryProvisionerMetrics struct{}
+
+func (telemetryRepositoryProvisionerMetrics) recordTickDuration(ctx context.Context, duration time.Duration) {
+	telemetry.RecordRepositoryProvisionerWorkerTickDuration(ctx, duration)
+}
+
+func (telemetryRepositoryProvisionerMetrics) recordRepositoriesCount(ctx context.Context, count int) {
+	telemetry.RecordRepositoryProvisionerWorkerRepositoriesCount(ctx, count)
+}
+
+func (telemetryRepositoryProvisionerMetrics) recordRepository(
+	ctx context.Context,
+	record repositoryProvisioningMetric,
+) {
+	telemetry.RecordRepositoryProvisionerWorkerRepositoryProcessing(
+		ctx,
+		record.duration,
+		record.trigger,
+		record.outcome,
+		record.reason,
+	)
 }
 
 func NewRepositoryProvisionerWorker(rabbitMQURL string, storage git.Provider) *RepositoryProvisionerWorker {
@@ -50,6 +96,7 @@ func NewRepositoryProvisionerWorker(rabbitMQURL string, storage git.Provider) *R
 		RabbitMQURL: rabbitMQURL,
 		Storage:     storage,
 		semaphore:   semaphore.NewWeighted(25),
+		metrics:     telemetryRepositoryProvisionerMetrics{},
 	}
 }
 
@@ -122,11 +169,17 @@ func (w *RepositoryProvisionerWorker) startBackfillLoop(ctx context.Context) {
 }
 
 func (w *RepositoryProvisionerWorker) backfill(ctx context.Context) {
+	startedAt := time.Now()
+	defer func() {
+		w.metrics.recordTickDuration(ctx, time.Since(startedAt))
+	}()
+
 	repositories, err := models.ListPendingRepositories(canvasRepositoryProvisionerBatch)
 	if err != nil {
 		w.log("Error listing pending canvas repositories: %v", err)
 		return
 	}
+	w.metrics.recordRepositoriesCount(ctx, len(repositories))
 
 	for _, repository := range repositories {
 		if err := w.semaphore.Acquire(ctx, 1); err != nil {
@@ -136,7 +189,7 @@ func (w *RepositoryProvisionerWorker) backfill(ctx context.Context) {
 		go func(repository models.Repository) {
 			defer w.semaphore.Release(1)
 
-			if err := w.provisionRepository(ctx, repository); err != nil {
+			if err := w.provisionRepository(ctx, repository, repositoryProvisionerTriggerBackfill); err != nil {
 				w.log("Error provisioning repository for canvas %s: %v", repository.CanvasID, err)
 			}
 		}(repository)
@@ -165,7 +218,11 @@ func (w *RepositoryProvisionerWorker) ConsumeCanvasCreated(delivery tackle.Deliv
 		return err
 	}
 
-	err = w.provisionRepository(context.Background(), *repository)
+	err = w.provisionRepository(
+		context.Background(),
+		*repository,
+		repositoryProvisionerTriggerEvent,
+	)
 	if err != nil {
 		w.log("Error provisioning canvas repository for canvas %s: %v", canvasID, err)
 		return err
@@ -174,31 +231,75 @@ func (w *RepositoryProvisionerWorker) ConsumeCanvasCreated(delivery tackle.Deliv
 	return nil
 }
 
-func (w *RepositoryProvisionerWorker) provisionRepository(ctx context.Context, repository models.Repository) error {
-	return database.Conn().Transaction(func(tx *gorm.DB) error {
+func (w *RepositoryProvisionerWorker) provisionRepository(
+	ctx context.Context,
+	repository models.Repository,
+	trigger string,
+) error {
+	startedAt := time.Now()
+	outcome := executorOutcomeSuccess
+	reason := executorReasonNone
+	defer func() {
+		w.metrics.recordRepository(ctx, repositoryProvisioningMetric{
+			duration: time.Since(startedAt),
+			trigger:  trigger,
+			outcome:  outcome,
+			reason:   reason,
+		})
+	}()
+
+	err := database.DB(ctx).Transaction(func(tx *gorm.DB) error {
 		repository, err := models.LockPendingRepository(tx, repository.ID)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
+				outcome = executorOutcomeSkipped
+				reason = executorReasonNotFound
 				return nil
 			}
 
+			outcome = executorOutcomeFailed
+			reason = classifyProcessError(err)
 			return err
 		}
 
 		_, err = w.Storage.CreateRepository(ctx, repository.RepoID)
 		if err != nil {
 			w.log("Error creating repository for canvas %s: %v", repository.CanvasID, err)
-			return repository.MarkError(tx)
+			outcome = executorOutcomeFailed
+			reason = repositoryProvisionerReasonCreateRepository
+			if err := repository.MarkError(tx); err != nil {
+				reason = repositoryProvisionerReasonMarkError
+				return err
+			}
+			return nil
 		}
 
 		if err := w.commitSeedFiles(ctx, tx, repository); err != nil {
 			w.log("Error committing seed files for canvas %s: %v", repository.CanvasID, err)
-			return repository.MarkError(tx)
+			outcome = executorOutcomeFailed
+			reason = repositoryProvisionerReasonCommitSeedFiles
+			if err := repository.MarkError(tx); err != nil {
+				reason = repositoryProvisionerReasonMarkError
+				return err
+			}
+			return nil
 		}
 
 		w.log("Repository created for canvas %s", repository.CanvasID)
-		return repository.MarkReady(tx)
+		if err := repository.MarkReady(tx); err != nil {
+			outcome = executorOutcomeFailed
+			reason = repositoryProvisionerReasonMarkReady
+			return err
+		}
+
+		return nil
 	})
+	if err != nil && outcome == executorOutcomeSuccess {
+		outcome = executorOutcomeFailed
+		reason = classifyProcessError(err)
+	}
+
+	return err
 }
 
 // commitSeedFiles applies any persisted seed files as the canvas repository's

--- a/pkg/workers/repository_provisioner_test.go
+++ b/pkg/workers/repository_provisioner_test.go
@@ -2,8 +2,10 @@ package workers
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +34,20 @@ func Test__RepositoryProvisionerWorker_CommitsSeedFiles(t *testing.T) {
 	}))
 
 	worker := NewRepositoryProvisionerWorker("", r.GitProvider)
-	require.NoError(t, worker.provisionRepository(context.Background(), *repository))
+	metrics := &recordingRepositoryProvisionerMetrics{}
+	worker.metrics = metrics
+	require.NoError(t, worker.provisionRepository(
+		context.Background(),
+		*repository,
+		repositoryProvisionerTriggerBackfill,
+	))
+	assertRepositoryProvisioningMetric(
+		t,
+		metrics,
+		repositoryProvisionerTriggerBackfill,
+		executorOutcomeSuccess,
+		executorReasonNone,
+	)
 
 	//
 	// The repository is marked ready and the seed-file rows are cleaned up.
@@ -74,11 +89,128 @@ func Test__RepositoryProvisionerWorker_NoSeedFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	worker := NewRepositoryProvisionerWorker("", r.GitProvider)
-	require.NoError(t, worker.provisionRepository(context.Background(), *repository))
+	require.NoError(t, worker.provisionRepository(
+		context.Background(),
+		*repository,
+		repositoryProvisionerTriggerBackfill,
+	))
 
 	updated, err := models.FindRepository(canvas.OrganizationID, canvas.ID)
 	require.NoError(t, err)
 	assert.Equal(t, models.RepositoryStatusReady, updated.Status)
+}
+
+func Test__RepositoryProvisionerWorker_RecordsBackfillMetrics(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	metrics := &recordingRepositoryProvisionerMetrics{}
+	worker := NewRepositoryProvisionerWorker("", r.GitProvider)
+	worker.metrics = metrics
+
+	worker.backfill(context.Background())
+
+	require.Len(t, metrics.tickDurations, 1)
+	assert.Positive(t, metrics.tickDurations[0])
+	assert.Equal(t, []int{0}, metrics.repositoryCounts)
+}
+
+func Test__RepositoryProvisionerWorker_RecordsRepositoryCreationFailure(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	repository := createPendingRepository(t, canvas, r.GitProvider)
+	provider := &failingGitProvider{
+		Provider:  r.GitProvider,
+		createErr: errors.New("repository service unavailable"),
+	}
+	metrics := &recordingRepositoryProvisionerMetrics{}
+	worker := NewRepositoryProvisionerWorker("", provider)
+	worker.metrics = metrics
+
+	require.NoError(t, worker.provisionRepository(
+		context.Background(),
+		*repository,
+		repositoryProvisionerTriggerEvent,
+	))
+
+	updated, err := models.FindRepository(canvas.OrganizationID, canvas.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.RepositoryStatusError, updated.Status)
+	assertRepositoryProvisioningMetric(
+		t,
+		metrics,
+		repositoryProvisionerTriggerEvent,
+		executorOutcomeFailed,
+		repositoryProvisionerReasonCreateRepository,
+	)
+}
+
+func Test__RepositoryProvisionerWorker_RecordsSeedCommitFailure(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	repository := createPendingRepository(t, canvas, r.GitProvider)
+	require.NoError(t, models.CreateRepositorySeedFiles(repository.ID, []models.RepositorySeedFile{
+		{Path: "README.md", Content: []byte("# seeded")},
+	}))
+
+	provider := &failingGitProvider{
+		Provider:  r.GitProvider,
+		commitErr: errors.New("commit rejected"),
+	}
+	metrics := &recordingRepositoryProvisionerMetrics{}
+	worker := NewRepositoryProvisionerWorker("", provider)
+	worker.metrics = metrics
+
+	require.NoError(t, worker.provisionRepository(
+		context.Background(),
+		*repository,
+		repositoryProvisionerTriggerBackfill,
+	))
+
+	updated, err := models.FindRepository(canvas.OrganizationID, canvas.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.RepositoryStatusError, updated.Status)
+	assertRepositoryProvisioningMetric(
+		t,
+		metrics,
+		repositoryProvisionerTriggerBackfill,
+		executorOutcomeFailed,
+		repositoryProvisionerReasonCommitSeedFiles,
+	)
+}
+
+func Test__RepositoryProvisionerWorker_RecordsAlreadyProcessedRepository(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	repository := createPendingRepository(t, canvas, r.GitProvider)
+	worker := NewRepositoryProvisionerWorker("", r.GitProvider)
+	require.NoError(t, worker.provisionRepository(
+		context.Background(),
+		*repository,
+		repositoryProvisionerTriggerEvent,
+	))
+
+	metrics := &recordingRepositoryProvisionerMetrics{}
+	worker.metrics = metrics
+	require.NoError(t, worker.provisionRepository(
+		context.Background(),
+		*repository,
+		repositoryProvisionerTriggerBackfill,
+	))
+
+	assertRepositoryProvisioningMetric(
+		t,
+		metrics,
+		repositoryProvisionerTriggerBackfill,
+		executorOutcomeSkipped,
+		executorReasonNotFound,
+	)
 }
 
 func Test__RepositoryProvisionerWorker_SeedFilesPersistedDuringInstallSurvive(t *testing.T) {
@@ -113,4 +245,76 @@ func readGitFile(t *testing.T, provider git.Provider, repoID, path, ref string) 
 	body, err := io.ReadAll(reader)
 	require.NoError(t, err)
 	return string(body)
+}
+
+type recordingRepositoryProvisionerMetrics struct {
+	repositoryMetrics []repositoryProvisioningMetric
+	tickDurations     []time.Duration
+	repositoryCounts  []int
+}
+
+func (m *recordingRepositoryProvisionerMetrics) recordTickDuration(_ context.Context, duration time.Duration) {
+	m.tickDurations = append(m.tickDurations, duration)
+}
+
+func (m *recordingRepositoryProvisionerMetrics) recordRepositoriesCount(_ context.Context, count int) {
+	m.repositoryCounts = append(m.repositoryCounts, count)
+}
+
+func (m *recordingRepositoryProvisionerMetrics) recordRepository(
+	_ context.Context,
+	record repositoryProvisioningMetric,
+) {
+	m.repositoryMetrics = append(m.repositoryMetrics, record)
+}
+
+func assertRepositoryProvisioningMetric(
+	t *testing.T,
+	metrics *recordingRepositoryProvisionerMetrics,
+	trigger, outcome, reason string,
+) {
+	t.Helper()
+	require.Len(t, metrics.repositoryMetrics, 1)
+	record := metrics.repositoryMetrics[0]
+	assert.Positive(t, record.duration)
+	assert.Equal(t, trigger, record.trigger)
+	assert.Equal(t, outcome, record.outcome)
+	assert.Equal(t, reason, record.reason)
+}
+
+func createPendingRepository(
+	t *testing.T,
+	canvas *models.Canvas,
+	provider git.Provider,
+) *models.Repository {
+	t.Helper()
+	repoID := provider.GetRepositoryID(git.RepositoryOptions{
+		OrganizationID: canvas.OrganizationID,
+		CanvasID:       canvas.ID,
+	})
+	repository, err := canvas.CreatePendingRepository(provider.Name(), repoID)
+	require.NoError(t, err)
+	return repository
+}
+
+type failingGitProvider struct {
+	git.Provider
+	createErr error
+	commitErr error
+}
+
+func (p *failingGitProvider) CreateRepository(ctx context.Context, repoID string) (*git.Repository, error) {
+	if p.createErr != nil {
+		return nil, p.createErr
+	}
+
+	return p.Provider.CreateRepository(ctx, repoID)
+}
+
+func (p *failingGitProvider) Commit(ctx context.Context, repoID string, options git.CommitOptions) (string, error) {
+	if p.commitErr != nil {
+		return "", p.commitErr
+	}
+
+	return p.Provider.Commit(ctx, repoID, options)
 }


### PR DESCRIPTION
## Summary

Repository provisioning can fail during event handling or backfill without clear operational signals.

This change reports workload, latency, trigger, outcome, and stable failure reasons.

Operators can distinguish successful, failed, and skipped attempts without depending only on logs.

Related to #5575.

## Test plan

- [x] Run `make format.go`.
- [x] Run `make lint`.
- [x] Run `make check.build.app`.
- [x] Run `make test`.
- [x] Confirm provider failures record a failed outcome.
- [x] Confirm completed repositories record a skipped outcome.