### PR TITLE
feat: Add PR wait note to factory setup

### DIFF
--- a/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
@@ -20,6 +20,9 @@ spec:
     - channel: default
       sourceId: add-pr-label
       targetId: attach-pr-artifact
+    - channel: default
+      sourceId: attach-pr-artifact
+      targetId: set-pr-closure-note
   nodes:
     - id: onrun-open-pr
       name: Open Pull Request
@@ -170,4 +173,19 @@ spec:
       position:
         x: 1706
         'y': 624
+      isCollapsed: true
+    - id: set-pr-closure-note
+      name: Set PR closure note
+      type: TYPE_ACTION
+      component: setWorkOrderStatusNote
+      configuration:
+        orderId: '{{ order().id }}'
+        noteKey: pr-closure
+        headline: Review the pull request
+        body: When the pull request merges, this work order completes. If it closes without a merge, SuperPlane rejects the work order.
+        ctaLabel: 'Review PR #{{ $["Create Draft Pull Request"].data.number }}'
+        ctaUrl: '{{ $["Create Draft Pull Request"].data.html_url }}'
+      position:
+        x: 1706
+        'y': 792
       isCollapsed: true

--- a/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
@@ -185,6 +185,7 @@ spec:
         body: When the pull request merges, this work order completes. If it closes without a merge, SuperPlane rejects the work order.
         ctaLabel: 'Review PR #{{ $["Create Draft Pull Request"].data.number }}'
         ctaUrl: '{{ $["Create Draft Pull Request"].data.html_url }}'
+        showOnlyWhenWaiting: true
       position:
         x: 1706
         'y': 792

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -72,6 +72,7 @@ describe("setup factory line apps", () => {
     expect(pr).toContain("noteKey: pr-closure");
     expect(pr).toContain("headline: Review the pull request");
     expect(pr).toContain("ctaUrl: '{{ $[\"Create Draft Pull Request\"].data.html_url }}'");
+    expect(pr).toContain("showOnlyWhenWaiting: true");
   });
 });
 

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -63,6 +63,16 @@ describe("setup factory line apps", () => {
     expect(pr).toMatch(/component: github\.createPullRequest[\s\S]*\[Work Order\]\(\{\{ order\(\)\.url \}\}\)/);
     expect(pr).toContain("Created via [SuperPlane](https://superplane.com)");
   });
+
+  it("announces the PR-merge wait after the work order attaches the pull request", () => {
+    const pr = materializeOnboardingApp("line-pr");
+
+    expect(pr).toMatch(/sourceId: attach-pr-artifact[\s\S]*targetId: set-pr-closure-note/);
+    expect(pr).toContain("component: setWorkOrderStatusNote");
+    expect(pr).toContain("noteKey: pr-closure");
+    expect(pr).toContain("headline: Review the pull request");
+    expect(pr).toContain("ctaUrl: '{{ $[\"Create Draft Pull Request\"].data.html_url }}'");
+  });
 });
 
 describe("setup factory event apps", () => {


### PR DESCRIPTION
## Summary

Factory setup now includes the PR-merge wait note on PR Creation.
New workspaces show the same next-step panel as production after a draft PR is attached.
PR Closure stays an event app. It does not set the note.


Made with [Cursor](https://cursor.com)