### PR TITLE
feat: Provision Issue Intake During Workspace Setup

### DIFF
--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { FactoriesFactory } from "@/api-client";
 
-import { DEFAULT_LINE_NAME, provisionLine } from "./onboardingProvision";
+import { DEFAULT_LINE_NAME, provisionEventApps, provisionLine } from "./onboardingProvision";
 
 describe("provisionLine", () => {
   it("reuses a line that already has the planning entrypoint", async () => {
@@ -62,5 +62,41 @@ describe("provisionLine", () => {
       provisionedAppId: result.primaryAppId,
       provisionedLineId: "line-new",
     });
+  });
+});
+
+describe("provisionEventApps", () => {
+  it("installs issue intake and PR closure for the workspace", async () => {
+    const installFactory = vi.fn().mockImplementation(async ({ factoryId }: { factoryId: string }) => ({
+      canvasId: `canvas-${factoryId}`,
+      canvasName: factoryId,
+    }));
+
+    await provisionEventApps({
+      factoryId: "factory-1",
+      selections: {},
+      appRepository: "acme/app",
+      backlogRepository: "acme/backlog",
+      installFactory,
+    });
+
+    expect(installFactory).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        factoryId: "issue-intake",
+        workspaceFactoryId: "factory-1",
+        installParams: {
+          appRepository: "acme/app",
+          backlogRepository: "acme/backlog",
+        },
+      }),
+    );
+    expect(installFactory).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        factoryId: "pr-closure",
+        workspaceFactoryId: "factory-1",
+      }),
+    );
   });
 });

--- a/web_src/src/pages/home/factories/index.ts
+++ b/web_src/src/pages/home/factories/index.ts
@@ -11,6 +11,8 @@ import planningCanvasYaml from "./line-apps/planning.canvas.yaml?raw";
 import implementationCanvasYaml from "./line-apps/implementation.canvas.yaml?raw";
 import prCanvasYaml from "./line-apps/pr.canvas.yaml?raw";
 import prClosureCanvasYaml from "./line-apps/pr-closure.canvas.yaml?raw";
+import issueIntakeCanvasYaml from "./line-apps/issue-intake.canvas.yaml?raw";
+import issueIntakeConsoleYaml from "./line-apps/issue-intake.console.yaml?raw";
 
 export type { FactoryDefinition, FactoryStartingTask, FactoryRunDefinition } from "./types";
 export {
@@ -95,6 +97,7 @@ function buildLineApp(args: {
 }
 
 const EVENT_APP_COMPONENT_INTEGRATIONS: Record<string, string> = {
+  "github.onIssue": "github",
   "github.onPullRequest": "github",
 };
 
@@ -103,6 +106,7 @@ function buildEventApp(args: {
   title: string;
   description: string;
   canvasYaml: string;
+  consoleYaml?: string;
   triggerNodeId: string;
 }): FactoryDefinition {
   return buildOnboardingApp({
@@ -110,7 +114,7 @@ function buildEventApp(args: {
     title: args.title,
     description: args.description,
     canvasYaml: args.canvasYaml,
-    consoleYaml: eventAppConsoleYaml,
+    consoleYaml: args.consoleYaml ?? eventAppConsoleYaml,
     integrations: ["github"],
     componentIntegrations: EVENT_APP_COMPONENT_INTEGRATIONS,
     entrypointNodeId: args.triggerNodeId,
@@ -134,7 +138,7 @@ export const ONBOARDING_LINE_APPS: OnboardingLineApp[] = [
 
 // Event-driven factory apps provisioned during onboarding. These listen for
 // GitHub events; they are not factory line steps.
-export const ONBOARDING_EVENT_APPS = ["pr-closure"] as const;
+export const ONBOARDING_EVENT_APPS = ["issue-intake", "pr-closure"] as const;
 
 const FACTORY_BY_ID: Record<string, FactoryDefinition> = {
   "software-factory": buildSoftwareFactory(),
@@ -158,6 +162,14 @@ const FACTORY_BY_ID: Record<string, FactoryDefinition> = {
     description: "Generate a pull request title and body, then open a draft PR.",
     canvasYaml: prCanvasYaml,
     entrypointNodeId: "onrun-open-pr",
+  }),
+  "issue-intake": buildEventApp({
+    id: "issue-intake",
+    title: "Issue Intake",
+    description: "Create a work order when an issue gets the factory label or is assigned to the SuperPlane agent.",
+    canvasYaml: issueIntakeCanvasYaml,
+    consoleYaml: issueIntakeConsoleYaml,
+    triggerNodeId: "on-issue-labeled",
   }),
   "pr-closure": buildEventApp({
     id: "pr-closure",

--- a/web_src/src/pages/home/factories/line-apps/issue-intake.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/issue-intake.canvas.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Canvas
+metadata:
+  name: Issue Intake
+  description: Create a work order when an issue gets the factory label or is assigned to the SuperPlane agent.
+spec:
+  edges:
+    - channel: default
+      sourceId: on-issue-labeled
+      targetId: has-factory-label
+    - channel: default
+      sourceId: has-factory-label
+      targetId: create-work-order
+    - channel: default
+      sourceId: on-issue-assigned
+      targetId: assigned-to-agent
+    - channel: default
+      sourceId: assigned-to-agent
+      targetId: create-work-order
+  nodes:
+    - id: on-issue-labeled
+      name: On Issue Label
+      type: TYPE_TRIGGER
+      component: github.onIssue
+      configuration:
+        actions:
+          - labeled
+        repository: '{{ install_params.backlogRepository }}'
+      position:
+        x: 576
+        'y': 258
+      isCollapsed: false
+    - id: has-factory-label
+      name: Factory Label?
+      type: TYPE_ACTION
+      component: filter
+      configuration:
+        expression: root().data.label.name == "factory"
+      position:
+        x: 576
+        'y': 618
+      isCollapsed: false
+    - id: on-issue-assigned
+      name: On Issue Assignment
+      type: TYPE_TRIGGER
+      component: github.onIssue
+      configuration:
+        actions:
+          - assigned
+        repository: '{{ install_params.backlogRepository }}'
+      position:
+        x: 1044
+        'y': 258
+      isCollapsed: false
+    - id: assigned-to-agent
+      name: Assigned to agent?
+      type: TYPE_ACTION
+      component: filter
+      configuration:
+        expression: root().data.assignee.login == "superplaneagent"
+      position:
+        x: 1044
+        'y': 618
+      isCollapsed: false
+    - id: create-work-order
+      name: Create Work Order
+      type: TYPE_ACTION
+      component: createWorkOrder
+      configuration:
+        title: '{{ root().data.issue.title }}'
+        description: '{{ root().data.issue.body }}'
+      position:
+        x: 810
+        'y': 978
+      isCollapsed: false

--- a/web_src/src/pages/home/factories/line-apps/issue-intake.console.yaml
+++ b/web_src/src/pages/home/factories/line-apps/issue-intake.console.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Console
+metadata:
+  name: Issue Intake
+  canvasId: __FACTORY_CANVAS_ID__
+spec:
+  panels:
+    - id: about
+      type: markdown
+      content:
+        title: About this app
+        body: |
+          > [!SECTION:setup] GitHub issue intake
+          >
+          > This app listens for issues in the backlog repository.
+          >
+          > It creates a work order when:
+          > - An issue gets the `factory` label.
+          > - An issue is assigned to `superplaneagent`.
+  layout:
+    - i: about
+      x: 0
+      'y': 0
+      w: 12
+      h: 5
+      minW: 3
+      minH: 5

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -66,9 +66,28 @@ describe("setup factory line apps", () => {
 });
 
 describe("setup factory event apps", () => {
-  it("provisions PR Closure outside the factory line", () => {
-    expect(ONBOARDING_EVENT_APPS).toEqual(["pr-closure"]);
+  it("provisions issue intake and PR closure outside the factory line", () => {
+    expect(ONBOARDING_EVENT_APPS).toEqual(["issue-intake", "pr-closure"]);
+    expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).not.toContain("issue-intake");
     expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).not.toContain("pr-closure");
+  });
+
+  it("creates work orders for factory-labeled or agent-assigned issues", () => {
+    const canvasYaml = materializeOnboardingApp("issue-intake");
+
+    expect(canvasYaml).toMatch(/component: github\.onIssue[\s\S]*actions:[\s\S]*- labeled/);
+    expect(canvasYaml).toMatch(/component: github\.onIssue[\s\S]*actions:[\s\S]*- assigned/);
+    expect(canvasYaml).toMatch(/component: github\.onIssue[\s\S]*repository: acme\/backlog/);
+    expect(canvasYaml).toContain('root().data.label.name == "factory"');
+    expect(canvasYaml).toContain('root().data.assignee.login == "superplaneagent"');
+    expect(canvasYaml).toMatch(/component: createWorkOrder[\s\S]*title: '{{ root\(\)\.data\.issue\.title }}'/);
+    expect(canvasYaml).toContain("description: '{{ root().data.issue.body }}'");
+    expect(canvasYaml).toContain("id: int-1");
+    expect(canvasYaml).toContain("name: acme-github");
+    expect(canvasYaml).not.toContain("{{ install_params.");
+    expect(canvasYaml).not.toContain(FACTORY_CANVAS_ID_PLACEHOLDER);
+    expect(canvasYaml).not.toContain("superplanehq");
+    expect(canvasYaml).not.toMatch(/component: onRun/);
   });
 
   it("closes the work order when a factory pull request is closed", () => {


### PR DESCRIPTION
## Summary

Workspace setup did not install the production Ingest automation. Factory-labeled or agent-assigned GitHub issues therefore did not create work orders.

This change installs Issue Intake as an event app for every new workspace. The app uses the backlog repository and the connected GitHub integration.

Existing workspaces do not receive this app automatically.

## Test plan

- [ ] Finish workspace setup with GitHub connected and a backlog repository selected.
- [ ] Open Automations and confirm Issue Intake is present next to PR Closure.
- [ ] Confirm Issue Intake watches the selected backlog repository.
- [ ] Add the `factory` label to an issue and confirm SuperPlane creates a work order.
- [ ] Assign an issue to `superplaneagent` and confirm SuperPlane creates a work order.

Made with [Cursor](https://cursor.com)