### PR TITLE
fix: Open repository step after GitHub setup returns

### DIFF
--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
@@ -76,6 +76,19 @@ describe("FactoriesHarness workspace setup", () => {
     expect(await screen.findByRole("option", { name: /acme\/api/ }, { timeout: 8000 })).toBeInTheDocument();
   }, 15000);
 
+  it("opens the repository list when GitHub sends the browser back to the VCS step", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/setup?step=vcs&pick=newest`}
+        factoriesFixture={defaultFactoriesFixture}
+        onboardingSeed={{ pending: { workspaceId: PRIMARY_FACTORY_ID, workspaceName: "Refunds Factory" } }}
+        orgIntegrations={CONNECTED_SETUP_INTEGRATIONS}
+      />,
+    );
+
+    expect(await screen.findByRole("option", { name: /acme\/api/ }, { timeout: 8000 })).toBeInTheDocument();
+  }, 15000);
+
   it("opens the step from the URL with the saved answers restored", async () => {
     render(
       <FactoriesHarness

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -355,6 +355,14 @@ export function useOnboardingPageModel(args: {
     selectNewest: searchParams.get("pick") === "newest",
     selections: integrations.selections,
     selectInstance: connect.selectInstance,
+    // The user left the wizard to connect GitHub, so the answer for the VCS
+    // step is in. Open the repository step, the same as a connection the user
+    // selects by hand. The host must be set here too, or the repository step
+    // shows "Connect version control first" until the restore effect runs.
+    onConnectionSelected: () => {
+      setup.selectVcsHost("github");
+      setOpenSection("repo");
+    },
   });
   const githubIntegration = useIntegration(args.organizationId, githubIntegrationId);
   const resources = useIntegrationResources(args.organizationId, githubIntegrationId, "repository");

--- a/web_src/src/pages/factories/pages/onboarding/useSelectNewGithubConnection.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useSelectNewGithubConnection.ts
@@ -22,6 +22,7 @@ export function useOnboardingGithubConnections(args: {
   selectNewest: boolean;
   selections: IntegrationSelections;
   selectInstance: (integrationName: string, integrationId: string) => void;
+  onConnectionSelected: () => void;
 }): IntegrationInstanceSummary {
   const githubConnections =
     args.integrationData.find((integration) => integration.name === "github") ?? EMPTY_GITHUB_CONNECTIONS;
@@ -32,6 +33,7 @@ export function useOnboardingGithubConnections(args: {
     readyInstances: githubConnections.readyInstances,
     selections: args.selections,
     selectInstance: args.selectInstance,
+    onConnectionSelected: args.onConnectionSelected,
   });
 
   return githubConnections;
@@ -46,7 +48,9 @@ function newestReadyInstance(instances: OrganizationsIntegration[]): Organizatio
 }
 
 /**
- * Selects the newest ready GitHub connection after the return from GitHub.
+ * Selects the newest ready GitHub connection after the return from GitHub, then
+ * reports the selection so the wizard can continue.
+ *
  * The round trip reloads the page, so the in-memory "just connected" hint is
  * gone. Only runs when the return URL asks for it (`pick=newest`), and at most
  * once, so the user can still choose a different connection afterwards.
@@ -57,9 +61,10 @@ function useSelectNewGithubConnection(args: {
   readyInstances: IntegrationInstanceSummary["readyInstances"];
   selections: IntegrationSelections;
   selectInstance: (integrationName: string, integrationId: string) => void;
+  onConnectionSelected: () => void;
 }) {
   const selectedNewConnection = useRef(false);
-  const { openSection, selectNewest, readyInstances, selections, selectInstance } = args;
+  const { openSection, selectNewest, readyInstances, selections, selectInstance, onConnectionSelected } = args;
 
   useEffect(() => {
     if (selectedNewConnection.current || !selectNewest || openSection !== "vcs") return;
@@ -71,5 +76,6 @@ function useSelectNewGithubConnection(args: {
 
     selectedNewConnection.current = true;
     if (selections.github?.id !== id) selectInstance("github", id);
-  }, [openSection, selectNewest, readyInstances, selections, selectInstance]);
+    onConnectionSelected();
+  }, [openSection, selectNewest, readyInstances, selections, selectInstance, onConnectionSelected]);
 }


### PR DESCRIPTION
## Summary

The workspace setup wizard sends the browser to GitHub to connect a new
integration. GitHub redirects back into the app, and the wizard opens
again at the VCS step. The wizard selected the new connection, but it did
not continue. The user had to select the same connection a second time to
get the repository list.

The wizard advanced with an in-memory hint that held the connection from
before the connect flow started. The round trip to GitHub reloads the
page, so that hint was gone on return.

The automatic selection now reports back to the page model. The model
sets the version control host and opens the repository step, the same as
for a connection that the user selects by hand. The model sets the host
in the same update, because the repository step shows "Connect version
control first" for one frame if the host arrives later.

## Test plan

- [x] Add a setup smoke test that mounts the wizard at `?step=vcs&pick=newest` with a connected GitHub organization and waits for the repository list, with no click.
- [x] Confirm the new test fails without the fix.
- [x] Run the onboarding and factories fixture suites: 52 tests pass.
- [x] Run `npm run lint:budget` and `npm run build`.
- [x] Manual check: start workspace setup, connect a new GitHub integration, and confirm that the return from GitHub opens the repository step with the new connection selected.

Made with [Cursor](https://cursor.com)