### PR TITLE
fix: Load admin org flags via admin API

### DIFF
--- a/pkg/public/admin.go
+++ b/pkg/public/admin.go
@@ -765,6 +765,31 @@ func (s *Server) unblockAccount(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"status": "unblocked"})
 }
 
+// adminListOrgExperimentalFeatures returns the installation feature registry
+// plus the features enabled for the given organization. Installation admins
+// are not always members of the org, so this must not go through the member
+// DescribeOrganization API.
+func (s *Server) adminListOrgExperimentalFeatures(w http.ResponseWriter, r *http.Request) {
+	orgID := mux.Vars(r)["orgId"]
+
+	org, err := models.FindOrganizationByID(orgID)
+	if err != nil {
+		http.Error(w, "Organization not found", http.StatusNotFound)
+		return
+	}
+
+	enabled := []string(org.EnabledExperimentalFeatures)
+	if enabled == nil {
+		enabled = []string{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"features": experimentalFeatureItems(),
+		"enabled":  enabled,
+	})
+}
+
 // adminEnableOrgExperimentalFeature toggles an experimental feature on for
 // the given organization.
 func (s *Server) adminEnableOrgExperimentalFeature(w http.ResponseWriter, r *http.Request) {

--- a/pkg/public/admin_test.go
+++ b/pkg/public/admin_test.go
@@ -858,6 +858,70 @@ func TestImpersonationSecurityGuardrails(t *testing.T) {
 	})
 }
 
+func TestAdminListOrgExperimentalFeatures(t *testing.T) {
+	server, _, token := setupAdminTestServer(t)
+
+	foreignOrg, err := models.CreateOrganization("admin-flags-foreign", "")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = models.DisableExperimentalFeature(foreignOrg.ID, features.FeatureFactories)
+	})
+
+	t.Run("returns registry and enabled features without org membership", func(t *testing.T) {
+		require.NoError(t, models.EnableExperimentalFeature(foreignOrg.ID, features.FeatureFactories))
+
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/organizations/" + foreignOrg.ID.String() + "/experimental-features",
+			authCookie: token,
+		})
+		require.Equal(t, http.StatusOK, response.Code)
+
+		var body struct {
+			Features []map[string]any `json:"features"`
+			Enabled  []string         `json:"enabled"`
+		}
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+		require.NotEmpty(t, body.Features)
+		assert.Contains(t, body.Enabled, features.FeatureFactories)
+
+		ids := make([]string, 0, len(body.Features))
+		for _, f := range body.Features {
+			id, _ := f["id"].(string)
+			ids = append(ids, id)
+		}
+		assert.Contains(t, ids, features.FeatureFactories)
+	})
+
+	t.Run("returns an empty enabled list when none are on", func(t *testing.T) {
+		require.NoError(t, models.DisableExperimentalFeature(foreignOrg.ID, features.FeatureFactories))
+
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/organizations/" + foreignOrg.ID.String() + "/experimental-features",
+			authCookie: token,
+		})
+		require.Equal(t, http.StatusOK, response.Code)
+
+		var body struct {
+			Enabled []string `json:"enabled"`
+		}
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+		assert.Empty(t, body.Enabled)
+		assert.NotNil(t, body.Enabled)
+	})
+
+	t.Run("returns 404 for non-existent org", func(t *testing.T) {
+		response := execRequest(server, requestParams{
+			method:     "GET",
+			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features",
+			authCookie: token,
+		})
+		assert.Equal(t, http.StatusNotFound, response.Code)
+	})
+}
+
 func TestAdminEnableOrgExperimentalFeature(t *testing.T) {
 	server, r, token := setupAdminTestServer(t)
 

--- a/pkg/public/experimental_features.go
+++ b/pkg/public/experimental_features.go
@@ -7,32 +7,36 @@ import (
 	"github.com/superplanehq/superplane/pkg/features"
 )
 
-// listExperimentalFeatures returns the static registry of experimental
-// features available in this installation. It is account-authenticated and
-// does not require installation admin: any signed-in user can fetch it so
-// the UI can decide whether to render gated experiences. Per-organization
-// enablement is exposed separately on the organization resource.
-func (s *Server) listExperimentalFeatures(w http.ResponseWriter, r *http.Request) {
-	type featureItem struct {
-		ID          string `json:"id"`
-		Label       string `json:"label"`
-		Description string `json:"description"`
-		Released    bool   `json:"released"`
-	}
+type experimentalFeatureItem struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Released    bool   `json:"released"`
+}
 
+func experimentalFeatureItems() []experimentalFeatureItem {
 	registry := features.All()
-	items := make([]featureItem, 0, len(registry))
+	items := make([]experimentalFeatureItem, 0, len(registry))
 	for _, f := range registry {
-		items = append(items, featureItem{
+		items = append(items, experimentalFeatureItem{
 			ID:          f.ID,
 			Label:       f.Label,
 			Description: f.Description,
 			Released:    f.Released != nil && *f.Released,
 		})
 	}
+	return items
+}
 
+// listExperimentalFeatures returns the static registry of experimental
+// features available in this installation. It is account-authenticated and
+// does not require installation admin: any signed-in user can fetch it so
+// the UI can decide whether to render gated experiences. Per-organization
+// enablement is exposed separately on the organization resource for members,
+// and on the admin experimental-features route for installation admins.
+func (s *Server) listExperimentalFeatures(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"features": items,
+		"features": experimentalFeatureItems(),
 	})
 }

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -685,6 +685,7 @@ func (s *Server) InitRouter(additionalMiddlewares ...mux.MiddlewareFunc) {
 	adminRoute.HandleFunc("/organizations", s.adminListOrganizations).Methods("GET")
 	adminRoute.HandleFunc("/organizations/{orgId}/canvases", s.adminListCanvases).Methods("GET")
 	adminRoute.HandleFunc("/organizations/{orgId}/users", s.adminListOrgUsers).Methods("GET")
+	adminRoute.HandleFunc("/organizations/{orgId}/experimental-features", s.adminListOrgExperimentalFeatures).Methods("GET")
 	adminRoute.HandleFunc("/organizations/{orgId}/experimental-features/{featureId}", s.adminEnableOrgExperimentalFeature).Methods("POST")
 	adminRoute.HandleFunc("/organizations/{orgId}/experimental-features/{featureId}", s.adminDisableOrgExperimentalFeature).Methods("DELETE")
 	adminRoute.HandleFunc("/installation/network-settings", s.adminGetInstallationNetworkSettings).Methods("GET")

--- a/web_src/src/hooks/useAdminExperimentalFeatures.ts
+++ b/web_src/src/hooks/useAdminExperimentalFeatures.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { organizationKeys } from "./useOrganizationData";
 
@@ -17,6 +17,30 @@ export interface ExperimentalFeaturesRegistry {
 export const adminExperimentalFeaturesKeys = {
   all: ["adminExperimentalFeatures"] as const,
   registry: (orgId: string) => [...adminExperimentalFeaturesKeys.all, "registry", orgId] as const,
+};
+
+async function fetchAdminExperimentalFeatures(orgId: string): Promise<ExperimentalFeaturesRegistry> {
+  const res = await fetch(`/admin/api/organizations/${orgId}/experimental-features`, {
+    credentials: "include",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to load experimental features (${res.status})`);
+  }
+  const data = (await res.json()) as Partial<ExperimentalFeaturesRegistry>;
+  return {
+    features: data.features ?? [],
+    enabled: data.enabled ?? [],
+  };
+}
+
+export const useAdminExperimentalFeaturesRegistry = (orgId: string, enabled = true) => {
+  return useQuery({
+    queryKey: adminExperimentalFeaturesKeys.registry(orgId),
+    queryFn: () => fetchAdminExperimentalFeatures(orgId),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    enabled: !!orgId && enabled,
+  });
 };
 
 async function toggleAdminExperimentalFeature(orgId: string, featureId: string, enabled: boolean): Promise<void> {

--- a/web_src/src/pages/admin/OrgExperimentalFeaturesTable.spec.tsx
+++ b/web_src/src/pages/admin/OrgExperimentalFeaturesTable.spec.tsx
@@ -1,0 +1,92 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OrgExperimentalFeaturesTable } from "./OrgExperimentalFeaturesTable";
+
+const ORG_ID = "org-1";
+
+const registryResponse = {
+  features: [
+    { id: "factories", label: "Factories", description: "Software factories", released: false },
+    { id: "claude_managed_agents", label: "Claude Managed Agents", description: "Chat", released: true },
+  ],
+  enabled: ["factories"],
+};
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderTable() {
+  const queryClient = createQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(<OrgExperimentalFeaturesTable orgId={ORG_ID} />, { wrapper });
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("OrgExperimentalFeaturesTable", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === `/admin/api/organizations/${ORG_ID}/experimental-features`) {
+          return jsonResponse(registryResponse);
+        }
+        if (url.startsWith(`/admin/api/organizations/${ORG_ID}/experimental-features/`)) {
+          return jsonResponse({ status: init?.method === "DELETE" ? "disabled" : "enabled" });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads flags from the admin route, not the member organization API", async () => {
+    renderTable();
+
+    expect(await screen.findByText("Factories")).toBeInTheDocument();
+    expect(screen.queryByText("Claude Managed Agents")).not.toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Toggle Factories" })).toHaveAttribute("data-state", "checked");
+
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock).toHaveBeenCalledWith(`/admin/api/organizations/${ORG_ID}/experimental-features`, {
+      credentials: "include",
+    });
+    expect(fetchMock.mock.calls.every(([url]) => !String(url).includes("/api/v1/organizations"))).toBe(true);
+    expect(fetchMock.mock.calls.every(([url]) => !String(url).includes("/account/experimental-features"))).toBe(true);
+  });
+
+  it("toggles a flag through the admin route", async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.click(await screen.findByRole("switch", { name: "Toggle Factories" }));
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      `/admin/api/organizations/${ORG_ID}/experimental-features/factories`,
+      {
+        method: "DELETE",
+        credentials: "include",
+      },
+    );
+  });
+});

--- a/web_src/src/pages/admin/OrgExperimentalFeaturesTable.tsx
+++ b/web_src/src/pages/admin/OrgExperimentalFeaturesTable.tsx
@@ -1,25 +1,21 @@
 import { Heading } from "@/components/Heading/heading";
 import { Text } from "@/components/Text/text";
-import { useToggleAdminExperimentalFeature } from "@/hooks/useAdminExperimentalFeatures";
-import { useExperimentalFeaturesRegistry } from "@/hooks/useExperimentalFeatures";
-import { useOrganization } from "@/hooks/useOrganizationData";
+import {
+  useAdminExperimentalFeaturesRegistry,
+  useToggleAdminExperimentalFeature,
+} from "@/hooks/useAdminExperimentalFeatures";
 import { Switch } from "@/ui/switch";
 import { FlaskConical } from "lucide-react";
 import { useMemo, useState } from "react";
 
 export function OrgExperimentalFeaturesTable({ orgId }: { orgId: string }) {
-  const { data: registry, isLoading: registryLoading } = useExperimentalFeaturesRegistry();
-  const { data: organization, isLoading: orgLoading } = useOrganization(orgId);
+  const { data: registry, isLoading } = useAdminExperimentalFeaturesRegistry(orgId);
   const toggleFeature = useToggleAdminExperimentalFeature(orgId);
   const [error, setError] = useState<string | null>(null);
 
   const features = registry?.features ?? [];
-  const enabled = useMemo(
-    () => new Set(organization?.spec?.enabledExperimentalFeatures ?? []),
-    [organization?.spec?.enabledExperimentalFeatures],
-  );
+  const enabled = useMemo(() => new Set(registry?.enabled ?? []), [registry?.enabled]);
   const pendingId = toggleFeature.isPending ? (toggleFeature.variables?.featureId ?? null) : null;
-  const isLoading = registryLoading || orgLoading;
 
   const handleToggle = (featureId: string, next: boolean) => {
     setError(null);


### PR DESCRIPTION
## Summary

Fixes the installation admin organization page so it can show experimental features.
The page used the member organization API. Installation admins are not always members, so that request returned 404.
The page now loads flags from the admin experimental-features route.

## Test plan

- [ ] Open `/admin/organizations/{id}` as an installation admin who is not a member of that organization.
- [ ] Confirm the Experimental Features table loads.
- [ ] Enable a feature and confirm the switch stays on after reload.
- [ ] Disable the feature and confirm the switch stays off.


Made with [Cursor](https://cursor.com)