### PR TITLE
fix: Stabilize invite password signup e2e

### DIFF
--- a/test/e2e/invitations_test.go
+++ b/test/e2e/invitations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/gorm"
@@ -116,7 +117,7 @@ func (s *invitationSteps) acceptInvite(token string) {
 
 func (s *invitationSteps) waitForOrganizationRedirect() {
 	waitErr := s.session.Page().WaitForURL("**/"+s.session.OrgID.String()+"*", pw.PageWaitForURLOptions{
-		Timeout: pw.Float(10000),
+		Timeout: pw.Float(30000),
 	})
 	require.NoError(s.t, waitErr)
 }
@@ -132,37 +133,27 @@ func (s *invitationSteps) visitMembersSettings() {
 func (s *invitationSteps) followInviteLinkToLogin(token string) {
 	s.session.Visit("/invite/" + token)
 	waitErr := s.session.Page().WaitForURL("**/login?redirect=**", pw.PageWaitForURLOptions{
-		Timeout: pw.Float(10000),
+		Timeout: pw.Float(30000),
 	})
 	require.NoError(s.t, waitErr)
 }
 
 func (s *invitationSteps) openSignupForm() {
-	// With magic code enabled, toggle to password login first
-	// so the "Create an account" link becomes visible.
-	toggle := s.session.Page().Locator("text=Sign in with password instead").First()
-	if err := toggle.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(3000)}); err == nil {
-		require.NoError(s.t, toggle.Click())
-	}
-
-	button := s.session.Page().Locator("text=Create an account").First()
-	require.NoError(s.t, button.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible}))
-	require.NoError(s.t, button.Click())
+	s.session.AssertVisible(q.Text("Continue with email"))
+	s.session.Click(q.Text("Sign in with password instead"))
+	s.session.Click(q.Text("Create an account"))
 }
 
 func (s *invitationSteps) fillSignupForm(firstName, lastName, email, password string) {
-	page := s.session.Page()
-
-	require.NoError(s.t, page.Locator(`input[placeholder="First name"]`).Fill(firstName))
-	require.NoError(s.t, page.Locator(`input[placeholder="Last name"]`).Fill(lastName))
-	require.NoError(s.t, page.Locator(`input[placeholder="Email"]`).Fill(email))
-	require.NoError(s.t, page.Locator(`input[placeholder="Password"]`).Fill(password))
-	require.NoError(s.t, page.Locator(`input[placeholder="Repeat password"]`).Fill(password))
+	s.session.FillIn(q.Locator(`input[placeholder="First name"]`), firstName)
+	s.session.FillIn(q.Locator(`input[placeholder="Last name"]`), lastName)
+	s.session.FillIn(q.Locator(`input[placeholder="Email"]`), email)
+	s.session.FillIn(q.Locator(`input[placeholder="Password"]`), password)
+	s.session.FillIn(q.Locator(`input[placeholder="Repeat password"]`), password)
 }
 
 func (s *invitationSteps) submitSignup() {
-	button := s.session.Page().Locator("text=Create account").First()
-	require.NoError(s.t, button.Click())
+	s.session.Click(q.Text("Create account"))
 }
 
 func (s *invitationSteps) disableInviteLink(token string) {

--- a/web_src/src/lib/api-interceptor.spec.ts
+++ b/web_src/src/lib/api-interceptor.spec.ts
@@ -103,6 +103,17 @@ describe("api-interceptor", () => {
     expect(locationHref).toBe("http://localhost/dashboard?tab=overview");
   });
 
+  it("does not hard-redirect the account session probe on 401", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("", { status: 401 }));
+    const { setupApiInterceptor } = await import("@/lib/api-interceptor");
+
+    setupApiInterceptor();
+
+    const response = await globalThis.fetch("/account");
+    expect(response.status).toBe(401);
+    expect(locationHref).toBe("http://localhost/dashboard?tab=overview");
+  });
+
   it("does not redirect auth routes", async () => {
     pathname = "/login";
     search = "";

--- a/web_src/src/lib/api-interceptor.ts
+++ b/web_src/src/lib/api-interceptor.ts
@@ -22,6 +22,10 @@ export const setupApiInterceptor = (): void => {
     }
 
     if (response.status === 401) {
+      if (isAccountSessionProbe(input)) {
+        return response;
+      }
+
       redirectUnauthorized();
       throw new Error("Unauthorized");
     }
@@ -32,11 +36,18 @@ export const setupApiInterceptor = (): void => {
   interceptorSetup = true;
 };
 
-function isAuthenticatedRequest(input: RequestInfo | URL): boolean {
+function requestPath(input: RequestInfo | URL): string {
   const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-  const path = new URL(url, "http://localhost").pathname;
+  return new URL(url, "http://localhost").pathname;
+}
 
+function isAuthenticatedRequest(input: RequestInfo | URL): boolean {
+  const path = requestPath(input);
   return path.includes("/api/") || path.startsWith("/account/") || ACCOUNT_SESSION_PATHS.has(path);
+}
+
+function isAccountSessionProbe(input: RequestInfo | URL): boolean {
+  return requestPath(input) === "/account";
 }
 
 function isAuthRoute(pathname: string): boolean {


### PR DESCRIPTION
## Summary

The invite password signup e2e failed when login options loaded after 3 seconds.
The test skipped the password toggle, so Create an account never appeared.

GET /account 401 also started a full-page login redirect beside AuthGuard.
That race canceled the login request and left a 502 page.

This change waits for the login form, then follows the password signup path.
The account session probe no longer forces a document redirect.

## Test plan

- [ ] Run TestInvitations locally.
- [ ] Confirm following_invite_link_and_creating_password_account passes.
- [ ] Confirm an unauthenticated invite link still opens the login page.

Made with [Cursor](https://cursor.com)