### PR TITLE
fix: Improve onboarding work order intake flow

### DIFF
--- a/pkg/components/factory/create_work_order.go
+++ b/pkg/components/factory/create_work_order.go
@@ -17,9 +17,19 @@ func init() {
 
 type CreateWorkOrder struct{}
 
+type CreateWorkOrderArtifactDataEntry struct {
+	Name  string `json:"name" mapstructure:"name"`
+	Value string `json:"value" mapstructure:"value"`
+}
+
 type CreateWorkOrderConfiguration struct {
-	Title       string `json:"title" mapstructure:"title"`
-	Description string `json:"description" mapstructure:"description"`
+	Title           string                           `json:"title" mapstructure:"title"`
+	Description     string                           `json:"description" mapstructure:"description"`
+	ArtifactType    string                           `json:"artifactType" mapstructure:"artifactType"`
+	ArtifactURL     string                           `json:"artifactUrl" mapstructure:"artifactUrl"`
+	ArtifactTitle   string                           `json:"artifactTitle" mapstructure:"artifactTitle"`
+	ArtifactKey     string                           `json:"artifactKey" mapstructure:"artifactKey"`
+	ArtifactData    []CreateWorkOrderArtifactDataEntry `json:"artifactData" mapstructure:"artifactData"`
 }
 
 func (c *CreateWorkOrder) Name() string {
@@ -35,7 +45,11 @@ func (c *CreateWorkOrder) Description() string {
 }
 
 func (c *CreateWorkOrder) Documentation() string {
-	return `The Create Work Order component creates a new work order in the factory. This component can only be used in factory-owned apps.`
+	return `The Create Work Order component creates a new work order in the factory.
+
+When you set the optional artifact fields, it also attaches the artifact in the same transaction. This is useful for event-driven intake flows that need an idempotency key such as a source issue URL.
+
+This component can only be used in factory-owned apps.`
 }
 
 func (c *CreateWorkOrder) Icon() string {
@@ -80,6 +94,66 @@ func (c *CreateWorkOrder) Configuration() []configuration.Field {
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 		},
+		{
+			Name:        "artifactType",
+			Label:       "Initial Artifact Type",
+			Description: "Optional artifact to attach as part of work order creation",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Togglable:   true,
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Link", Value: "link"},
+					},
+				},
+			},
+		},
+		{
+			Name:                 "artifactUrl",
+			Label:                "Initial Artifact URL",
+			Description:          "HTTP or HTTPS URL to attach when the initial artifact type is link",
+			Type:                 configuration.FieldTypeString,
+			Required:             false,
+			RequiredConditions:   []configuration.RequiredCondition{{Field: "artifactType", Values: []string{"link"}}},
+			VisibilityConditions: []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"link"}}},
+		},
+		{
+			Name:                 "artifactTitle",
+			Label:                "Initial Artifact Title",
+			Description:          "Optional chip label for the attached link artifact",
+			Type:                 configuration.FieldTypeString,
+			Required:             false,
+			VisibilityConditions: []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"link"}}},
+		},
+		{
+			Name:        "artifactKey",
+			Label:       "Initial Artifact Key",
+			Description: "Optional stable key used to find an existing work order before creation",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Togglable:   true,
+		},
+		{
+			Name:                 "artifactData",
+			Label:                "Initial Artifact Metadata",
+			Description:          "Extra name/value pairs merged into the attached artifact data",
+			Type:                 configuration.FieldTypeList,
+			Required:             false,
+			VisibilityConditions: []configuration.VisibilityCondition{{Field: "artifactType", Values: []string{"link"}}},
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Entry",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+						Schema: []configuration.Field{
+							{Name: "name", Label: "Name", Type: configuration.FieldTypeString, Required: true},
+							{Name: "value", Label: "Value", Type: configuration.FieldTypeString, Required: true},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -89,13 +163,37 @@ func (c *CreateWorkOrder) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	workOrder, err := ctx.Factory.CreateWorkOrder(core.WorkOrderParams{
+	params := core.WorkOrderParams{
 		Title:       config.Title,
 		Description: config.Description,
-	})
+	}
+	if config.ArtifactType != "" {
+		artifactData := map[string]any{}
+		for _, entry := range config.ArtifactData {
+			if entry.Name == "" {
+				continue
+			}
+			artifactData[entry.Name] = entry.Value
+		}
+		if config.ArtifactURL != "" {
+			artifactData["url"] = config.ArtifactURL
+		}
+		if config.ArtifactTitle != "" {
+			artifactData["title"] = config.ArtifactTitle
+		}
+		params.Artifact = &core.WorkOrderArtifactSeed{
+			Type: config.ArtifactType,
+			Data: artifactData,
+			Key:  config.ArtifactKey,
+		}
+	}
 
+	workOrder, created, err := ctx.Factory.CreateWorkOrder(params)
 	if err != nil {
 		return err
+	}
+	if !created {
+		return ctx.ExecutionState.Pass()
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/components/factory/factory_components_spec_test.go
+++ b/pkg/components/factory/factory_components_spec_test.go
@@ -13,9 +13,15 @@ import (
 )
 
 // fakeFactoryContext lets Execute-level tests drive `core.FactoryContext`
-// without spinning up a database. Only UpdateWorkOrderStatus and
-// FindWorkOrder are wired up; the rest of the interface returns zero values.
+// without spinning up a database. Only the methods exercised by these
+// component tests capture inputs; the rest return zero values.
 type fakeFactoryContext struct {
+	createWorkOrderCalls  int
+	createWorkOrderParams core.WorkOrderParams
+	createWorkOrderResult *core.WorkOrder
+	createWorkOrderMade   bool
+	createWorkOrderErr    error
+
 	statusCalls int
 	nextChanged bool
 	nextErr     error
@@ -44,8 +50,10 @@ type fakeFactoryContext struct {
 	setStatusNoteErr    error
 }
 
-func (f *fakeFactoryContext) CreateWorkOrder(_ core.WorkOrderParams) (*core.WorkOrder, error) {
-	return nil, nil
+func (f *fakeFactoryContext) CreateWorkOrder(params core.WorkOrderParams) (*core.WorkOrder, bool, error) {
+	f.createWorkOrderCalls++
+	f.createWorkOrderParams = params
+	return f.createWorkOrderResult, f.createWorkOrderMade, f.createWorkOrderErr
 }
 
 func (f *fakeFactoryContext) FindWorkOrder(params core.FindWorkOrderParams) (*core.WorkOrder, error) {
@@ -125,6 +133,87 @@ func TestUpdateWorkOrderStatus_Execute(t *testing.T) {
 		assert.Empty(t, stateCtx.Channel, "no-op must not emit on any channel")
 		assert.Empty(t, stateCtx.Type)
 		assert.Nil(t, stateCtx.Payloads)
+	})
+}
+
+func TestCreateWorkOrder_Execute(t *testing.T) {
+	component := &CreateWorkOrder{}
+	workOrder := &core.WorkOrder{ID: "wo-1", Title: "From issue", Description: "Automated intake", State: "draft"}
+	factoryCtx := &fakeFactoryContext{createWorkOrderResult: workOrder, createWorkOrderMade: true}
+	stateCtx := &contexts.ExecutionStateContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"title":         "From issue",
+			"description":   "Automated intake",
+			"artifactType":  "link",
+			"artifactKey":   "https://github.com/example/repo/issues/42",
+			"artifactUrl":   "https://github.com/example/repo/issues/42",
+			"artifactTitle": "Issue #42",
+			"artifactData": []map[string]any{
+				{"name": "repository", "value": "example/repo"},
+			},
+		},
+		ExecutionState: stateCtx,
+		Factory:        factoryCtx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, factoryCtx.createWorkOrderCalls)
+	require.NotNil(t, factoryCtx.createWorkOrderParams.Artifact)
+	assert.Equal(t, "link", factoryCtx.createWorkOrderParams.Artifact.Type)
+	assert.Equal(t, "https://github.com/example/repo/issues/42", factoryCtx.createWorkOrderParams.Artifact.Key)
+	assert.Equal(t, "https://github.com/example/repo/issues/42", factoryCtx.createWorkOrderParams.Artifact.Data["url"])
+	assert.Equal(t, "Issue #42", factoryCtx.createWorkOrderParams.Artifact.Data["title"])
+	assert.Equal(t, "example/repo", factoryCtx.createWorkOrderParams.Artifact.Data["repository"])
+	assert.Equal(t, core.DefaultOutputChannel.Name, stateCtx.Channel)
+	assert.Equal(t, "workOrder.created", stateCtx.Type)
+}
+
+func TestCreateWorkOrder_Execute_PassesWhenWorkOrderAlreadyExists(t *testing.T) {
+	component := &CreateWorkOrder{}
+	workOrder := &core.WorkOrder{ID: "wo-1", Title: "From issue", Description: "Automated intake", State: "draft"}
+	factoryCtx := &fakeFactoryContext{createWorkOrderResult: workOrder, createWorkOrderMade: false}
+	stateCtx := &contexts.ExecutionStateContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"title":       "From issue",
+			"description": "Automated intake",
+		},
+		ExecutionState: stateCtx,
+		Factory:        factoryCtx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, factoryCtx.createWorkOrderCalls)
+	assert.True(t, stateCtx.Passed)
+	assert.True(t, stateCtx.Finished)
+	assert.Empty(t, stateCtx.Channel)
+	assert.Empty(t, stateCtx.Type)
+	assert.Nil(t, stateCtx.Payloads)
+}
+
+func TestCreateWorkOrder_ValidatesConfiguration(t *testing.T) {
+	fields := (&CreateWorkOrder{}).Configuration()
+
+	t.Run("requires artifactUrl for link artifacts", func(t *testing.T) {
+		err := configuration.ValidateConfiguration(fields, map[string]any{
+			"title":        "From issue",
+			"artifactType": "link",
+		})
+		if err == nil {
+			t.Fatal("expected error for link artifact without artifactUrl")
+		}
+	})
+
+	t.Run("accepts link artifacts with artifactUrl", func(t *testing.T) {
+		err := configuration.ValidateConfiguration(fields, map[string]any{
+			"title":        "From issue",
+			"artifactType": "link",
+			"artifactUrl":  "https://github.com/example/repo/issues/42",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	})
 }
 

--- a/pkg/core/factory.go
+++ b/pkg/core/factory.go
@@ -8,7 +8,9 @@ import "errors"
 var ErrWorkOrderNotFound = errors.New("work order not found")
 
 type FactoryContext interface {
-	CreateWorkOrder(params WorkOrderParams) (*WorkOrder, error)
+	// CreateWorkOrder reports whether it created a new row or reused an
+	// existing work order resolved by the initial artifact key.
+	CreateWorkOrder(params WorkOrderParams) (order *WorkOrder, created bool, err error)
 	// FindWorkOrder resolves a work order by id or by one of its
 	// artifacts' keys, without requiring the current run to be attached
 	// to a `factory_work_order_executions` row. Returns ErrWorkOrderNotFound
@@ -43,6 +45,13 @@ type FactoryContext interface {
 type WorkOrderParams struct {
 	Title       string
 	Description string
+	Artifact    *WorkOrderArtifactSeed
+}
+
+type WorkOrderArtifactSeed struct {
+	Type string
+	Data map[string]any
+	Key  string
 }
 
 // FindWorkOrderParams configures FactoryContext.FindWorkOrder. By selects

--- a/pkg/workers/contexts/factory_context.go
+++ b/pkg/workers/contexts/factory_context.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -62,33 +63,116 @@ func (c *FactoryContext) WithWorkOrderNotification(
 	return c
 }
 
-func (c *FactoryContext) CreateWorkOrder(params core.WorkOrderParams) (*core.WorkOrder, error) {
+func (c *FactoryContext) CreateWorkOrder(params core.WorkOrderParams) (*core.WorkOrder, bool, error) {
 	// A run already tied to another work order must not spawn a new one.
 	_, err := models.FindWorkOrderExecutionByRunID(c.tx, c.execution.RunID)
 	if err == nil {
-		return nil, errors.New("cannot create work order while executing another work order")
+		return nil, false, errors.New("cannot create work order while executing another work order")
 	}
 	if !errors.Is(err, models.ErrFactoryWorkOrderExecutionNotFound) {
-		return nil, err
+		return nil, false, err
 	}
 
 	if c.canvas.FactoryID == nil {
-		return nil, errors.New("app is not owned by a factory")
-	}
-
-	f, err := models.FindFactory(c.tx, c.canvas.OrganizationID, *c.canvas.FactoryID)
-	if err != nil {
-		return nil, err
+		return nil, false, errors.New("app is not owned by a factory")
 	}
 
 	sourceRunID := c.execution.RunID
-	order, err := f.CreateWorkOrder(c.tx, params.Title, params.Description, nil, []uuid.UUID{}, &sourceRunID)
+	var (
+		order   *models.FactoryWorkOrder
+		created bool
+	)
+
+	err = c.tx.Transaction(func(tx *gorm.DB) error {
+		f, findErr := models.FindFactory(tx, c.canvas.OrganizationID, *c.canvas.FactoryID)
+		if findErr != nil {
+			return findErr
+		}
+
+		if params.Artifact != nil {
+			if lockErr := lockFactoryArtifactKey(tx, f.ID, params.Artifact.Key); lockErr != nil {
+				return lockErr
+			}
+			existing, existingErr := findFactoryWorkOrderByArtifactKey(tx, f, params.Artifact.Key)
+			if existingErr != nil {
+				return existingErr
+			}
+			if existing != nil {
+				order = existing
+				return nil
+			}
+		}
+
+		createdOrder, createErr := f.CreateWorkOrder(tx, params.Title, params.Description, nil, []uuid.UUID{}, &sourceRunID)
+		if createErr != nil {
+			return createErr
+		}
+		order = createdOrder
+		created = true
+
+		if params.Artifact == nil {
+			return nil
+		}
+
+		_, artifactErr := order.CreateArtifact(tx, models.FactoryWorkOrderArtifactParams{
+			Type:       params.Artifact.Type,
+			Data:       params.Artifact.Data,
+			Key:        params.Artifact.Key,
+			Automation: c.automationRef(),
+			Run:        c.runRef(),
+		})
+		return artifactErr
+	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	c.notifyWorkOrderUpdated(f.ID, order.ID, factory.EventTypeOrderStatusUpdated)
-	return workOrderToCore(order), nil
+	if created {
+		c.notifyWorkOrderUpdated(order.FactoryID, order.ID, factory.EventTypeOrderStatusUpdated)
+		if params.Artifact != nil {
+			c.notifyWorkOrderUpdated(order.FactoryID, order.ID, factory.EventTypeOrderArtifactAdded)
+		}
+	}
+	return workOrderToCore(order), created, nil
+}
+
+func lockFactoryArtifactKey(tx *gorm.DB, factoryID uuid.UUID, key string) error {
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedKey == "" {
+		return nil
+	}
+
+	lockID := hashFactoryArtifactKeyLock(factoryID, trimmedKey)
+	return tx.Exec("SELECT pg_advisory_xact_lock(?)", lockID).Error
+}
+
+func findFactoryWorkOrderByArtifactKey(
+	tx *gorm.DB,
+	f *models.Factory,
+	key string,
+) (*models.FactoryWorkOrder, error) {
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedKey == "" {
+		return nil, nil
+	}
+
+	order, err := f.FindWorkOrderByArtifactKey(tx, trimmedKey)
+	if err == nil {
+		return order, nil
+	}
+	if errors.Is(err, models.ErrFactoryWorkOrderNotFound) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+func hashFactoryArtifactKeyLock(factoryID uuid.UUID, key string) int64 {
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte("factory-work-order-artifact-key:"))
+	_, _ = hasher.Write([]byte(factoryID.String()))
+	_, _ = hasher.Write([]byte(":"))
+	_, _ = hasher.Write([]byte(key))
+	return int64(hasher.Sum64())
 }
 
 func (c *FactoryContext) UpdateWorkOrderStatus(params core.UpdateWorkOrderStatusParams) (*core.WorkOrder, bool, error) {

--- a/pkg/workers/contexts/factory_context_test.go
+++ b/pkg/workers/contexts/factory_context_test.go
@@ -29,11 +29,12 @@ func TestFactoryContext_CreateWorkOrder(t *testing.T) {
 	t.Run("creates work order on factory-owned app", func(t *testing.T) {
 		ctx := NewFactoryContext(database.Conn(), canvas, nodeExecution)
 
-		workOrder, err := ctx.CreateWorkOrder(core.WorkOrderParams{
+		workOrder, created, err := ctx.CreateWorkOrder(core.WorkOrderParams{
 			Title:       "From GitHub issue",
 			Description: "Automated intake",
 		})
 		require.NoError(t, err)
+		assert.True(t, created)
 		assert.Equal(t, "From GitHub issue", workOrder.Title)
 		assert.Equal(t, "Automated intake", workOrder.Description)
 		assert.NotEmpty(t, workOrder.ID)
@@ -84,10 +85,89 @@ func TestFactoryContext_CreateWorkOrder(t *testing.T) {
 		assert.Nil(t, opened.User)
 	})
 
+	t.Run("atomically attaches the source artifact during creation", func(t *testing.T) {
+		ctx := NewFactoryContext(database.Conn(), canvas, nodeExecution)
+
+		workOrder, created, err := ctx.CreateWorkOrder(core.WorkOrderParams{
+			Title:       "From labeled issue",
+			Description: "Automated intake",
+			Artifact: &core.WorkOrderArtifactSeed{
+				Type: "link",
+				Key:  "https://github.com/acme/backlog/issues/42",
+				Data: map[string]any{
+					"url":   "https://github.com/acme/backlog/issues/42",
+					"title": "Issue #42",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, created)
+
+		found, err := factory.FindWorkOrderByArtifactKey(database.Conn(), "https://github.com/acme/backlog/issues/42")
+		require.NoError(t, err)
+		assert.Equal(t, workOrder.ID, found.ID.String())
+	})
+
+	t.Run("reuses an existing work order when the artifact key already exists", func(t *testing.T) {
+		ctx := NewFactoryContext(database.Conn(), canvas, nodeExecution)
+		var beforeCount int64
+		err = database.Conn().
+			Model(&models.FactoryWorkOrder{}).
+			Where("organization_id = ? AND factory_id = ?", r.Organization.ID, factory.ID).
+			Count(&beforeCount).
+			Error
+		require.NoError(t, err)
+
+		var notifications int
+		ctx = ctx.WithWorkOrderUpdated(func(_, _, _ string) { notifications++ })
+
+		first, created, err := ctx.CreateWorkOrder(core.WorkOrderParams{
+			Title:       "From labeled issue",
+			Description: "Automated intake",
+			Artifact: &core.WorkOrderArtifactSeed{
+				Type: "link",
+				Key:  "https://github.com/acme/backlog/issues/99",
+				Data: map[string]any{
+					"url":   "https://github.com/acme/backlog/issues/99",
+					"title": "Issue #99",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, created)
+		assert.Equal(t, 2, notifications, "create with artifact should fan out status and artifact updates")
+
+		second, created, err := ctx.CreateWorkOrder(core.WorkOrderParams{
+			Title:       "Duplicate labeled issue",
+			Description: "Should reuse the first work order",
+			Artifact: &core.WorkOrderArtifactSeed{
+				Type: "link",
+				Key:  "https://github.com/acme/backlog/issues/99",
+				Data: map[string]any{
+					"url":   "https://github.com/acme/backlog/issues/99",
+					"title": "Issue #99",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.False(t, created)
+		assert.Equal(t, first.ID, second.ID)
+		assert.Equal(t, 2, notifications, "reused work orders must not fan out duplicate creation updates")
+
+		var afterCount int64
+		err = database.Conn().
+			Model(&models.FactoryWorkOrder{}).
+			Where("organization_id = ? AND factory_id = ?", r.Organization.ID, factory.ID).
+			Count(&afterCount).
+			Error
+		require.NoError(t, err)
+		assert.EqualValues(t, beforeCount+1, afterCount)
+	})
+
 	t.Run("rejects blank title", func(t *testing.T) {
 		ctx := NewFactoryContext(database.Conn(), canvas, nodeExecution)
 
-		_, err := ctx.CreateWorkOrder(core.WorkOrderParams{Title: "   "})
+		_, _, err := ctx.CreateWorkOrder(core.WorkOrderParams{Title: "   "})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, models.ErrFactoryWorkOrderTitleRequired)
 	})
@@ -96,7 +176,7 @@ func TestFactoryContext_CreateWorkOrder(t *testing.T) {
 		regularCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
 		ctx := NewFactoryContext(database.Conn(), regularCanvas, nodeExecution)
 
-		_, err := ctx.CreateWorkOrder(core.WorkOrderParams{Title: "Should fail"})
+		_, _, err := ctx.CreateWorkOrder(core.WorkOrderParams{Title: "Should fail"})
 		require.Error(t, err)
 		assert.EqualError(t, err, "app is not owned by a factory")
 	})
@@ -128,7 +208,7 @@ func TestFactoryContext_CreateWorkOrder(t *testing.T) {
 		require.NoError(t, database.Conn().Create(&workOrderExecution).Error)
 
 		ctx := NewFactoryContext(database.Conn(), canvas, nodeExecution)
-		_, err = ctx.CreateWorkOrder(core.WorkOrderParams{Title: "Nested"})
+		_, _, err = ctx.CreateWorkOrder(core.WorkOrderParams{Title: "Nested"})
 		require.Error(t, err)
 		assert.EqualError(t, err, "cannot create work order while executing another work order")
 	})

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { FactoriesFactory } from "@/api-client";
-import { getFactoryDefinition } from "@/pages/home/factories";
+import type { CanvasesCanvas, FactoriesFactory } from "@/api-client";
 
-import { DEFAULT_LINE_NAME, provisionEventApps, provisionLine } from "./onboardingProvision";
+import { DEFAULT_LINE_NAME, identifyProvisionedEventApp, provisionEventApps, provisionLine } from "./onboardingProvision";
 
 describe("provisionLine", () => {
   it("reuses a line that already has the planning entrypoint", async () => {
@@ -113,13 +112,7 @@ describe("provisionEventApps", () => {
       appRepository: "acme/app",
       backlogRepository: "acme/backlog",
       installFactory,
-      existingApps: [
-        {
-          id: "canvas-existing",
-          name: "Issue Intake",
-          description: getFactoryDefinition("issue-intake").description,
-        },
-      ],
+      existingAppFactoryIds: ["issue-intake"],
     });
 
     expect(installFactory).toHaveBeenCalledTimes(1);
@@ -143,13 +136,7 @@ describe("provisionEventApps", () => {
       appRepository: "acme/app",
       backlogRepository: "acme/backlog",
       installFactory,
-      existingApps: [
-        {
-          id: "canvas-existing",
-          name: "PR Closure",
-          description: getFactoryDefinition("pr-closure").description,
-        },
-      ],
+      existingAppFactoryIds: ["pr-closure"],
     });
 
     expect(installFactory).toHaveBeenCalledTimes(1);
@@ -161,7 +148,7 @@ describe("provisionEventApps", () => {
     );
   });
 
-  it("reuses a uniquely renamed event app from an earlier attempt", async () => {
+  it("reuses event apps loaded from stable factory ids", async () => {
     const installFactory = vi.fn();
 
     await provisionEventApps({
@@ -170,20 +157,53 @@ describe("provisionEventApps", () => {
       appRepository: "acme/app",
       backlogRepository: "acme/backlog",
       installFactory,
-      existingApps: [
-        {
-          id: "canvas-existing",
-          name: "Issue Intake (2)",
-          description: getFactoryDefinition("issue-intake").description,
-        },
-        {
-          id: "canvas-existing-2",
-          name: "PR Closure",
-          description: getFactoryDefinition("pr-closure").description,
-        },
-      ],
+      loadExistingAppFactoryIds: async () => new Set(["issue-intake", "pr-closure"]),
     });
 
     expect(installFactory).not.toHaveBeenCalled();
+  });
+});
+
+describe("identifyProvisionedEventApp", () => {
+  it("identifies Issue Intake from its graph", () => {
+    const canvas = {
+      spec: {
+        nodes: [
+          { id: "on-issue-labeled", component: "github.onIssue", configuration: { actions: ["labeled"] } },
+          { id: "on-issue-assigned", component: "github.onIssue", configuration: { actions: ["assigned"] } },
+          { id: "find-existing-work-order", component: "findWorkOrder" },
+          { id: "create-work-order", component: "createWorkOrder" },
+        ],
+      },
+    } as CanvasesCanvas;
+
+    expect(identifyProvisionedEventApp(canvas)).toBe("issue-intake");
+  });
+
+  it("identifies PR Closure from its graph", () => {
+    const canvas = {
+      spec: {
+        nodes: [
+          { id: "on-pr-closed", component: "github.onPullRequest", configuration: { actions: ["closed"] } },
+          { id: "find-work-order", component: "findWorkOrder" },
+          { id: "stamp-pr-merged", component: "updateWorkOrderArtifact" },
+          { id: "stamp-pr-closed", component: "updateWorkOrderArtifact" },
+          { id: "complete-work-order", component: "updateWorkOrderStatus" },
+          { id: "reject-work-order", component: "updateWorkOrderStatus" },
+        ],
+      },
+    } as CanvasesCanvas;
+
+    expect(identifyProvisionedEventApp(canvas)).toBe("pr-closure");
+  });
+
+  it("returns undefined for unrelated apps", () => {
+    const canvas = {
+      spec: {
+        nodes: [{ id: "onrun-create-plan", component: "onRun" }],
+      },
+    } as CanvasesCanvas;
+
+    expect(identifyProvisionedEventApp(canvas)).toBeUndefined();
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { FactoriesFactory } from "@/api-client";
+import { getFactoryDefinition } from "@/pages/home/factories";
 
 import { DEFAULT_LINE_NAME, provisionEventApps, provisionLine } from "./onboardingProvision";
 
@@ -98,5 +99,91 @@ describe("provisionEventApps", () => {
         workspaceFactoryId: "factory-1",
       }),
     );
+  });
+
+  it("skips issue intake when a prior setup attempt already installed it", async () => {
+    const installFactory = vi.fn().mockImplementation(async ({ factoryId }: { factoryId: string }) => ({
+      canvasId: `canvas-${factoryId}`,
+      canvasName: factoryId,
+    }));
+
+    await provisionEventApps({
+      factoryId: "factory-1",
+      selections: {},
+      appRepository: "acme/app",
+      backlogRepository: "acme/backlog",
+      installFactory,
+      existingApps: [
+        {
+          id: "canvas-existing",
+          name: "Issue Intake",
+          description: getFactoryDefinition("issue-intake").description,
+        },
+      ],
+    });
+
+    expect(installFactory).toHaveBeenCalledTimes(1);
+    expect(installFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        factoryId: "pr-closure",
+        workspaceFactoryId: "factory-1",
+      }),
+    );
+  });
+
+  it("skips PR closure when a prior setup attempt already installed it", async () => {
+    const installFactory = vi.fn().mockImplementation(async ({ factoryId }: { factoryId: string }) => ({
+      canvasId: `canvas-${factoryId}`,
+      canvasName: factoryId,
+    }));
+
+    await provisionEventApps({
+      factoryId: "factory-1",
+      selections: {},
+      appRepository: "acme/app",
+      backlogRepository: "acme/backlog",
+      installFactory,
+      existingApps: [
+        {
+          id: "canvas-existing",
+          name: "PR Closure",
+          description: getFactoryDefinition("pr-closure").description,
+        },
+      ],
+    });
+
+    expect(installFactory).toHaveBeenCalledTimes(1);
+    expect(installFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        factoryId: "issue-intake",
+        workspaceFactoryId: "factory-1",
+      }),
+    );
+  });
+
+  it("reuses a uniquely renamed event app from an earlier attempt", async () => {
+    const installFactory = vi.fn();
+
+    await provisionEventApps({
+      factoryId: "factory-1",
+      selections: {},
+      appRepository: "acme/app",
+      backlogRepository: "acme/backlog",
+      installFactory,
+      existingApps: [
+        {
+          id: "canvas-existing",
+          name: "Issue Intake (2)",
+          description: getFactoryDefinition("issue-intake").description,
+        },
+        {
+          id: "canvas-existing-2",
+          name: "PR Closure",
+          description: getFactoryDefinition("pr-closure").description,
+        },
+      ],
+    });
+
+    expect(installFactory).not.toHaveBeenCalled();
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
@@ -1,12 +1,12 @@
 import type {
-  FactoryApp,
+  CanvasesCanvas,
   FactoriesFactory,
   FactoriesFactoryLine,
   FactoriesUpdateFactoryOnboardingBody,
   FactoryLineStep,
 } from "@/api-client";
 import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
-import { getFactoryDefinition, ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "@/pages/home/factories";
+import { ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "@/pages/home/factories";
 import type { InstallFactoryInput } from "@/pages/home/useInstallFactory";
 
 export const DEFAULT_LINE_NAME = "Software delivery";
@@ -25,6 +25,7 @@ export interface ProvisionedLine {
 }
 
 type OnboardingEventAppId = (typeof ONBOARDING_EVENT_APPS)[number];
+type CanvasNode = NonNullable<NonNullable<CanvasesCanvas["spec"]>["nodes"]>[number];
 
 // A finished line has one step per bundled app, each calling the app onRun
 // entrypoint. Match on the first entrypoint to recover a line provisioned by an
@@ -59,23 +60,58 @@ async function installOnboardingApp(args: {
   return installed;
 }
 
-function isMatchingEventAppName(name: string | undefined, expectedName: string): boolean {
-  if (!name) return false;
-  if (name === expectedName) return true;
-  const escapedName = expectedName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^${escapedName} \\(\\d+\\)$`).test(name);
+function readNodeConfiguration(node: CanvasNode): Record<string, unknown> {
+  const configuration = node.configuration;
+  return configuration && typeof configuration === "object" ? configuration : {};
 }
 
-function findProvisionedEventApp(
-  apps: FactoryApp[],
-  appFactoryId: OnboardingEventAppId,
-): FactoryApp | undefined {
-  const definition = getFactoryDefinition(appFactoryId);
-  return apps.find(
-    (app) =>
-      app.description === definition.description &&
-      isMatchingEventAppName(app.name ?? undefined, definition.title),
+function hasAction(nodes: CanvasNode[], component: string, nodeId: string): boolean {
+  return nodes.some((node) => node.component === component && node.id === nodeId);
+}
+
+function hasTriggerAction(nodes: CanvasNode[], nodeId: string, expectedAction: string): boolean {
+  return nodes.some((node) => {
+    if (node.component !== "github.onIssue" && node.component !== "github.onPullRequest") {
+      return false;
+    }
+    if (node.id !== nodeId) {
+      return false;
+    }
+    const actions = readNodeConfiguration(node).actions;
+    return Array.isArray(actions) && actions.includes(expectedAction);
+  });
+}
+
+function isIssueIntakeCanvas(canvas: CanvasesCanvas): boolean {
+  const nodes = canvas.spec?.nodes ?? [];
+  return (
+    hasTriggerAction(nodes, "on-issue-labeled", "labeled") &&
+    hasTriggerAction(nodes, "on-issue-assigned", "assigned") &&
+    hasAction(nodes, "findWorkOrder", "find-existing-work-order") &&
+    hasAction(nodes, "createWorkOrder", "create-work-order")
   );
+}
+
+function isPrClosureCanvas(canvas: CanvasesCanvas): boolean {
+  const nodes = canvas.spec?.nodes ?? [];
+  return (
+    hasTriggerAction(nodes, "on-pr-closed", "closed") &&
+    hasAction(nodes, "findWorkOrder", "find-work-order") &&
+    hasAction(nodes, "updateWorkOrderArtifact", "stamp-pr-merged") &&
+    hasAction(nodes, "updateWorkOrderArtifact", "stamp-pr-closed") &&
+    hasAction(nodes, "updateWorkOrderStatus", "complete-work-order") &&
+    hasAction(nodes, "updateWorkOrderStatus", "reject-work-order")
+  );
+}
+
+export function identifyProvisionedEventApp(canvas: CanvasesCanvas): OnboardingEventAppId | undefined {
+  if (isIssueIntakeCanvas(canvas)) {
+    return "issue-intake";
+  }
+  if (isPrClosureCanvas(canvas)) {
+    return "pr-closure";
+  }
+  return undefined;
 }
 
 // Install each bundled app in order and return the line steps that call them.
@@ -115,17 +151,22 @@ export async function provisionEventApps(args: {
   appRepository: string;
   backlogRepository: string;
   installFactory: InstallOnboardingApp;
-  existingApps?: FactoryApp[];
-  loadExistingApps?: () => Promise<FactoryApp[]>;
+  existingAppFactoryIds?: Iterable<OnboardingEventAppId>;
+  loadExistingAppFactoryIds?: () => Promise<Set<OnboardingEventAppId>>;
 }): Promise<void> {
-  const provisionedApps = [...(args.existingApps ?? (args.loadExistingApps ? await args.loadExistingApps() : []))];
+  const provisionedAppFactoryIds = new Set<OnboardingEventAppId>(args.existingAppFactoryIds ?? []);
+  if (args.loadExistingAppFactoryIds) {
+    for (const appFactoryId of await args.loadExistingAppFactoryIds()) {
+      provisionedAppFactoryIds.add(appFactoryId);
+    }
+  }
 
   for (const appFactoryId of ONBOARDING_EVENT_APPS) {
-    if (findProvisionedEventApp(provisionedApps, appFactoryId)) {
+    if (provisionedAppFactoryIds.has(appFactoryId)) {
       continue;
     }
 
-    const installed = await installOnboardingApp({
+    await installOnboardingApp({
       factoryId: args.factoryId,
       appFactoryId,
       selections: args.selections,
@@ -133,12 +174,7 @@ export async function provisionEventApps(args: {
       backlogRepository: args.backlogRepository,
       installFactory: args.installFactory,
     });
-
-    provisionedApps.push({
-      id: installed.canvasId,
-      name: installed.canvasName,
-      description: getFactoryDefinition(appFactoryId).description,
-    });
+    provisionedAppFactoryIds.add(appFactoryId);
   }
 }
 

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
@@ -1,11 +1,12 @@
 import type {
+  FactoryApp,
   FactoriesFactory,
   FactoriesFactoryLine,
   FactoriesUpdateFactoryOnboardingBody,
   FactoryLineStep,
 } from "@/api-client";
 import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
-import { ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "@/pages/home/factories";
+import { getFactoryDefinition, ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "@/pages/home/factories";
 import type { InstallFactoryInput } from "@/pages/home/useInstallFactory";
 
 export const DEFAULT_LINE_NAME = "Software delivery";
@@ -22,6 +23,8 @@ export interface ProvisionedLine {
   lineId: string;
   primaryAppId: string;
 }
+
+type OnboardingEventAppId = (typeof ONBOARDING_EVENT_APPS)[number];
 
 // A finished line has one step per bundled app, each calling the app onRun
 // entrypoint. Match on the first entrypoint to recover a line provisioned by an
@@ -54,6 +57,25 @@ async function installOnboardingApp(args: {
   });
   if (!installed?.canvasId) throw new Error(`Failed to create the ${args.appFactoryId} app`);
   return installed;
+}
+
+function isMatchingEventAppName(name: string | undefined, expectedName: string): boolean {
+  if (!name) return false;
+  if (name === expectedName) return true;
+  const escapedName = expectedName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escapedName} \\(\\d+\\)$`).test(name);
+}
+
+function findProvisionedEventApp(
+  apps: FactoryApp[],
+  appFactoryId: OnboardingEventAppId,
+): FactoryApp | undefined {
+  const definition = getFactoryDefinition(appFactoryId);
+  return apps.find(
+    (app) =>
+      app.description === definition.description &&
+      isMatchingEventAppName(app.name ?? undefined, definition.title),
+  );
 }
 
 // Install each bundled app in order and return the line steps that call them.
@@ -93,15 +115,29 @@ export async function provisionEventApps(args: {
   appRepository: string;
   backlogRepository: string;
   installFactory: InstallOnboardingApp;
+  existingApps?: FactoryApp[];
+  loadExistingApps?: () => Promise<FactoryApp[]>;
 }): Promise<void> {
+  const provisionedApps = [...(args.existingApps ?? (args.loadExistingApps ? await args.loadExistingApps() : []))];
+
   for (const appFactoryId of ONBOARDING_EVENT_APPS) {
-    await installOnboardingApp({
+    if (findProvisionedEventApp(provisionedApps, appFactoryId)) {
+      continue;
+    }
+
+    const installed = await installOnboardingApp({
       factoryId: args.factoryId,
       appFactoryId,
       selections: args.selections,
       appRepository: args.appRepository,
       backlogRepository: args.backlogRepository,
       installFactory: args.installFactory,
+    });
+
+    provisionedApps.push({
+      id: installed.canvasId,
+      name: installed.canvasName,
+      description: getFactoryDefinition(appFactoryId).description,
     });
   }
 }

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -1,8 +1,14 @@
-import type { FactoriesFactory, FactoriesFactoryLine, FactoryLineStep } from "@/api-client";
+import type { FactoriesFactory, FactoriesFactoryLine, FactoryApp, FactoryLineStep } from "@/api-client";
 import { useAccount } from "@/contexts/useAccount";
 import { usePermissions } from "@/contexts/usePermissions";
-import { useCreateFactoryLine, useCreateWorkOrder, useDeleteFactory, useUpdateFactory } from "@/hooks/useFactoryData";
-import { useDispatchWorkOrder } from "@/hooks/useFactoryData";
+import {
+  useCreateFactoryLine,
+  useCreateWorkOrder,
+  useDeleteFactory,
+  useDispatchWorkOrder,
+  useFactoryApps,
+  useUpdateFactory,
+} from "@/hooks/useFactoryData";
 import { useIntegration, useIntegrationResources } from "@/hooks/useIntegrations";
 import { getApiErrorMessage } from "@/lib/errors";
 import { githubInstallationUrl } from "@/lib/githubInstallation";
@@ -158,6 +164,7 @@ async function provisionWorkspace(args: {
   workOrderDescription: string;
   github: { id: string };
   claude: { id: string };
+  loadFactoryApps: () => Promise<FactoryApp[]>;
 }): Promise<{ number?: number | string | null }> {
   if (args.workspaceName !== args.factory?.name) {
     await args.updateFactory({ name: args.workspaceName });
@@ -187,6 +194,7 @@ async function provisionWorkspace(args: {
     appRepository: args.appRepository,
     backlogRepository: args.backlogRepository,
     installFactory: args.installFactory,
+    loadExistingApps: args.loadFactoryApps,
   });
   await args.updateOnboarding({
     provisionedAppId: primaryAppId,
@@ -232,6 +240,7 @@ function useFinishOnboarding(args: {
     description: string;
   }) => Promise<{ id?: string | null; number?: number | string | null }>;
   dispatchWorkOrder: (input: { orderId: string; lineName: string }) => Promise<unknown>;
+  loadFactoryApps: () => Promise<FactoryApp[]>;
 }) {
   const navigate = useNavigate();
   return async () => {
@@ -347,6 +356,7 @@ export function useOnboardingPageModel(args: {
   const createLine = useCreateFactoryLine(args.organizationId, args.factoryId);
   const createWorkOrder = useCreateWorkOrder(args.organizationId, args.factoryId);
   const dispatchWorkOrder = useDispatchWorkOrder(args.organizationId, args.factoryId);
+  const factoryApps = useFactoryApps(args.organizationId, args.factoryId);
   const installer = useInstallFactory();
   const githubIntegrationId = integrations.selections.github?.ready ? integrations.selections.github.id : "";
   const githubConnections = useOnboardingGithubConnections({
@@ -385,6 +395,7 @@ export function useOnboardingPageModel(args: {
     createLine: createLine.mutateAsync,
     createWorkOrder: createWorkOrder.mutateAsync,
     dispatchWorkOrder: dispatchWorkOrder.mutateAsync,
+    loadFactoryApps: async () => factoryApps.data ?? (await factoryApps.refetch()).data ?? [],
   });
   const cancel = useCancelOnboarding({
     organizationId: args.organizationId,

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -1,4 +1,4 @@
-import type { FactoriesFactory, FactoriesFactoryLine, FactoryApp, FactoryLineStep } from "@/api-client";
+import { canvasesDescribeCanvas, type FactoriesFactory, type FactoriesFactoryLine, type FactoryLineStep } from "@/api-client";
 import { useAccount } from "@/contexts/useAccount";
 import { usePermissions } from "@/contexts/usePermissions";
 import {
@@ -13,6 +13,7 @@ import { useIntegration, useIntegrationResources } from "@/hooks/useIntegrations
 import { getApiErrorMessage } from "@/lib/errors";
 import { githubInstallationUrl } from "@/lib/githubInstallation";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
 import { useIntegrationConnectDialog } from "@/pages/home/useIntegrationConnectDialog";
 import { useInstallFactory } from "@/pages/home/useInstallFactory";
@@ -37,6 +38,7 @@ import {
 } from "./onboardingStatus";
 import {
   DEFAULT_LINE_NAME,
+  identifyProvisionedEventApp,
   provisionEventApps,
   provisionLine,
   type InstallOnboardingApp,
@@ -164,7 +166,7 @@ async function provisionWorkspace(args: {
   workOrderDescription: string;
   github: { id: string };
   claude: { id: string };
-  loadFactoryApps: () => Promise<FactoryApp[]>;
+  loadExistingAppFactoryIds: () => Promise<Set<"issue-intake" | "pr-closure">>;
 }): Promise<{ number?: number | string | null }> {
   if (args.workspaceName !== args.factory?.name) {
     await args.updateFactory({ name: args.workspaceName });
@@ -194,7 +196,7 @@ async function provisionWorkspace(args: {
     appRepository: args.appRepository,
     backlogRepository: args.backlogRepository,
     installFactory: args.installFactory,
-    loadExistingApps: args.loadFactoryApps,
+    loadExistingAppFactoryIds: args.loadExistingAppFactoryIds,
   });
   await args.updateOnboarding({
     provisionedAppId: primaryAppId,
@@ -240,7 +242,7 @@ function useFinishOnboarding(args: {
     description: string;
   }) => Promise<{ id?: string | null; number?: number | string | null }>;
   dispatchWorkOrder: (input: { orderId: string; lineName: string }) => Promise<unknown>;
-  loadFactoryApps: () => Promise<FactoryApp[]>;
+  loadExistingAppFactoryIds: () => Promise<Set<"issue-intake" | "pr-closure">>;
 }) {
   const navigate = useNavigate();
   return async () => {
@@ -395,7 +397,28 @@ export function useOnboardingPageModel(args: {
     createLine: createLine.mutateAsync,
     createWorkOrder: createWorkOrder.mutateAsync,
     dispatchWorkOrder: dispatchWorkOrder.mutateAsync,
-    loadFactoryApps: async () => factoryApps.data ?? (await factoryApps.refetch()).data ?? [],
+    loadExistingAppFactoryIds: async () => {
+      const apps = (await factoryApps.refetch()).data ?? [];
+      const appTypes = await Promise.all(
+        apps
+          .map((app) => app.id)
+          .filter((appId): appId is string => Boolean(appId))
+          .map(async (appId) => {
+            try {
+              const response = await canvasesDescribeCanvas(
+                withOrganizationHeader({
+                  path: { id: appId },
+                }),
+              );
+              const canvas = response.data?.canvas;
+              return canvas ? identifyProvisionedEventApp(canvas) : undefined;
+            } catch {
+              return undefined;
+            }
+          }),
+      );
+      return new Set(appTypes.filter((appType): appType is "issue-intake" | "pr-closure" => Boolean(appType)));
+    },
   });
   const cancel = useCancelOnboarding({
     organizationId: args.organizationId,

--- a/web_src/src/pages/home/factories/line-apps/issue-intake.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/issue-intake.canvas.yaml
@@ -20,9 +20,6 @@ spec:
     - channel: notFound
       sourceId: find-existing-work-order
       targetId: create-work-order
-    - channel: default
-      sourceId: create-work-order
-      targetId: attach-source-issue
   nodes:
     - id: on-issue-labeled
       name: On Issue Label
@@ -86,26 +83,16 @@ spec:
       configuration:
         title: '{{ root().data.issue.title }}'
         description: '{{ root().data.issue.body }}'
-      position:
-        x: 810
-        'y': 978
-      isCollapsed: false
-    - id: attach-source-issue
-      name: Attach Source Issue
-      type: TYPE_ACTION
-      component: addWorkOrderArtifact
-      configuration:
         artifactType: link
         artifactKey: '{{ root().data.issue.html_url }}'
-        orderId: '{{ $["Create Work Order"].data.workOrder.id }}'
-        title: 'Issue #{{ root().data.issue.number }}'
-        url: '{{ root().data.issue.html_url }}'
-        data:
+        artifactTitle: 'Issue #{{ root().data.issue.number }}'
+        artifactUrl: '{{ root().data.issue.html_url }}'
+        artifactData:
           - name: repository
             value: '{{ root().data.repository.full_name }}'
           - name: issueNumber
             value: '{{ root().data.issue.number }}'
       position:
         x: 810
-        'y': 1158
+        'y': 978
       isCollapsed: false

--- a/web_src/src/pages/home/factories/line-apps/issue-intake.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/issue-intake.canvas.yaml
@@ -10,13 +10,19 @@ spec:
       targetId: has-factory-label
     - channel: default
       sourceId: has-factory-label
-      targetId: create-work-order
+      targetId: find-existing-work-order
     - channel: default
       sourceId: on-issue-assigned
       targetId: assigned-to-agent
     - channel: default
       sourceId: assigned-to-agent
+      targetId: find-existing-work-order
+    - channel: notFound
+      sourceId: find-existing-work-order
       targetId: create-work-order
+    - channel: default
+      sourceId: create-work-order
+      targetId: attach-source-issue
   nodes:
     - id: on-issue-labeled
       name: On Issue Label
@@ -62,6 +68,17 @@ spec:
         x: 1044
         'y': 618
       isCollapsed: false
+    - id: find-existing-work-order
+      name: Find Existing Work Order
+      type: TYPE_ACTION
+      component: findWorkOrder
+      configuration:
+        artifactKey: '{{ root().data.issue.html_url }}'
+        by: artifactKey
+      position:
+        x: 810
+        'y': 798
+      isCollapsed: false
     - id: create-work-order
       name: Create Work Order
       type: TYPE_ACTION
@@ -72,4 +89,23 @@ spec:
       position:
         x: 810
         'y': 978
+      isCollapsed: false
+    - id: attach-source-issue
+      name: Attach Source Issue
+      type: TYPE_ACTION
+      component: addWorkOrderArtifact
+      configuration:
+        artifactType: link
+        artifactKey: '{{ root().data.issue.html_url }}'
+        orderId: '{{ $["Create Work Order"].data.workOrder.id }}'
+        title: 'Issue #{{ root().data.issue.number }}'
+        url: '{{ root().data.issue.html_url }}'
+        data:
+          - name: repository
+            value: '{{ root().data.repository.full_name }}'
+          - name: issueNumber
+            value: '{{ root().data.issue.number }}'
+      position:
+        x: 810
+        'y': 1158
       isCollapsed: false

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -97,10 +97,10 @@ describe("setup factory event apps", () => {
     expect(canvasYaml).toMatch(/channel: notFound[\s\S]*sourceId: find-existing-work-order[\s\S]*targetId: create-work-order/);
     expect(canvasYaml).toMatch(/component: createWorkOrder[\s\S]*title: '{{ root\(\)\.data\.issue\.title }}'/);
     expect(canvasYaml).toContain("description: '{{ root().data.issue.body }}'");
-    expect(canvasYaml).toContain("component: addWorkOrderArtifact");
     expect(canvasYaml).toContain("artifactType: link");
-    expect(canvasYaml).toContain("orderId: '{{ $[\"Create Work Order\"].data.workOrder.id }}'");
-    expect(canvasYaml).toContain("url: '{{ root().data.issue.html_url }}'");
+    expect(canvasYaml).toContain("artifactKey: '{{ root().data.issue.html_url }}'");
+    expect(canvasYaml).toContain("artifactUrl: '{{ root().data.issue.html_url }}'");
+    expect(canvasYaml).toContain("artifactTitle: 'Issue #{{ root().data.issue.number }}'");
     expect(canvasYaml).toContain("id: int-1");
     expect(canvasYaml).toContain("name: acme-github");
     expect(canvasYaml).not.toContain("{{ install_params.");

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -83,7 +83,7 @@ describe("setup factory event apps", () => {
     expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).not.toContain("pr-closure");
   });
 
-  it("creates work orders for factory-labeled or agent-assigned issues", () => {
+  it("deduplicates source issues before creating a work order", () => {
     const canvasYaml = materializeOnboardingApp("issue-intake");
 
     expect(canvasYaml).toMatch(/component: github\.onIssue[\s\S]*actions:[\s\S]*- labeled/);
@@ -91,8 +91,16 @@ describe("setup factory event apps", () => {
     expect(canvasYaml).toMatch(/component: github\.onIssue[\s\S]*repository: acme\/backlog/);
     expect(canvasYaml).toContain('root().data.label.name == "factory"');
     expect(canvasYaml).toContain('root().data.assignee.login == "superplaneagent"');
+    expect(canvasYaml).toContain("component: findWorkOrder");
+    expect(canvasYaml).toContain("by: artifactKey");
+    expect(canvasYaml).toContain("artifactKey: '{{ root().data.issue.html_url }}'");
+    expect(canvasYaml).toMatch(/channel: notFound[\s\S]*sourceId: find-existing-work-order[\s\S]*targetId: create-work-order/);
     expect(canvasYaml).toMatch(/component: createWorkOrder[\s\S]*title: '{{ root\(\)\.data\.issue\.title }}'/);
     expect(canvasYaml).toContain("description: '{{ root().data.issue.body }}'");
+    expect(canvasYaml).toContain("component: addWorkOrderArtifact");
+    expect(canvasYaml).toContain("artifactType: link");
+    expect(canvasYaml).toContain("orderId: '{{ $[\"Create Work Order\"].data.workOrder.id }}'");
+    expect(canvasYaml).toContain("url: '{{ root().data.issue.html_url }}'");
     expect(canvasYaml).toContain("id: int-1");
     expect(canvasYaml).toContain("name: acme-github");
     expect(canvasYaml).not.toContain("{{ install_params.");

--- a/web_src/src/pages/home/useInstallFactory.ts
+++ b/web_src/src/pages/home/useInstallFactory.ts
@@ -163,7 +163,7 @@ export function useInstallFactory({ folder }: UseInstallFactoryOptions = {}) {
           navigate,
         });
         if (input.workspaceFactoryId) {
-          void queryClient.invalidateQueries({
+          await queryClient.invalidateQueries({
             queryKey: factoryAppsKey(organizationId, input.workspaceFactoryId),
           });
         }

--- a/web_src/src/pages/home/useInstallFactory.ts
+++ b/web_src/src/pages/home/useInstallFactory.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { writeCanvasAgentSidebarOpen } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { writeCanvasRunsSidebarOpen } from "@/components/CanvasRunsSidebar/useCanvasRunsSidebarState";
 import { usePermissions } from "@/contexts/usePermissions";
+import { factoryAppsKey } from "@/hooks/useFactoryData";
 import { canvasKeys, useCreateCanvas, useUpdateCanvasFolderMembership } from "@/hooks/useCanvasData";
 import { setAgentSuggestions } from "@/lib/agentSuggestionsContext";
 import { appPath } from "@/lib/appPaths";
@@ -161,6 +162,11 @@ export function useInstallFactory({ folder }: UseInstallFactoryOptions = {}) {
           queryClient,
           navigate,
         });
+        if (input.workspaceFactoryId) {
+          void queryClient.invalidateQueries({
+            queryKey: factoryAppsKey(organizationId, input.workspaceFactoryId),
+          });
+        }
         pendingCanvasRef.current = null;
         return { canvasId, canvasName };
       } catch (error) {


### PR DESCRIPTION
## Summary

- Fix onboarding app detection after a retry or partial setup.
- Prevent duplicate issue intake runs from creating extra work orders or duplicate downstream events.
- Validate initial link artifacts earlier and ignore stale app canvases during onboarding recovery.

## Test plan

- [ ] Run `make check.build.ui`.
- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/components/factory`.
- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/workers/contexts`.
- [ ] Repeat issue intake for one issue and confirm one work order stays open.
- [ ] Retry onboarding after one event app is missing or unreadable.