### PR TITLE
feat: Redesign the line-board work-order popup

### DIFF
--- a/web_src/src/pages/factories/__fixtures__/factoryPageEventFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageEventFixtures.ts
@@ -15,6 +15,7 @@ import {
   OPEN_WORK_ORDER,
   OPEN_WORK_ORDER_SECONDARY,
   OPERATOR_USER,
+  PR_CLOSURE_COMPLETED_WORK_ORDER,
   REVIEWER_USER,
   RUNNING_WORK_ORDER,
   STORYBOOK_ME_USER_ID,
@@ -257,7 +258,7 @@ export const INGEST_DRAFT_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
     automation: {
       appId: "app-refund-backlog",
       appName: "Ingest",
-      nodeName: "Create Work Order",
+      nodeName: "On Issue Label",
     },
     app: { id: "app-refund-backlog" },
   }),
@@ -423,6 +424,15 @@ export const CLOSED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   }),
 ];
 
+export const PR_CLOSURE_COMPLETED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
+  openedWorkOrderEvent(PR_CLOSURE_COMPLETED_WORK_ORDER, LAST_WEEK),
+  automationClosedEvent(PR_CLOSURE_COMPLETED_WORK_ORDER, YESTERDAY, "completed", {
+    appId: "app-refund-done",
+    appName: "PR Closure",
+    nodeName: "Complete Work Order",
+  }),
+];
+
 export const RICH_OPEN_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
   openedWorkOrderEvent(OPEN_WORK_ORDER, YESTERDAY),
   commentAddedEvent(
@@ -537,6 +547,7 @@ export const DEFAULT_EVENTS_BY_ORDER_ID: Record<string, FactoriesWorkOrderEvent[
   [DRAFT_WORK_ORDER.id!]: DRAFT_WORK_ORDER_EVENTS,
   [INGEST_DRAFT_WORK_ORDER.id!]: INGEST_DRAFT_WORK_ORDER_EVENTS,
   [CLOSED_WORK_ORDER.id!]: CLOSED_WORK_ORDER_EVENTS,
+  [PR_CLOSURE_COMPLETED_WORK_ORDER.id!]: PR_CLOSURE_COMPLETED_WORK_ORDER_EVENTS,
   [CLOSED_FAILED_WORK_ORDER.id!]: CLOSED_FAILED_WORK_ORDER_EVENTS,
 };
 

--- a/web_src/src/pages/factories/__fixtures__/factoryPageEventFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageEventFixtures.ts
@@ -6,6 +6,7 @@ import {
   DRAFT_WORK_ORDER,
   FAILED_WORK_ORDER,
   HOUR_AGO,
+  INGEST_DRAFT_WORK_ORDER,
   LAST_WEEK,
   LINE_RUN_IMPLEMENT_FAILED_ID,
   LINE_RUN_IMPLEMENT_ID,
@@ -247,6 +248,19 @@ export const DRAFT_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
     "Scoping notes: need product sign-off on metric names before moving to ready.",
     { kind: "user", userId: STORYBOOK_ME_USER_ID },
   ),
+];
+
+export const INGEST_DRAFT_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
+  statusUpdatedEvent(INGEST_DRAFT_WORK_ORDER, TWO_HOURS_AGO, {
+    fromState: "",
+    toState: "draft",
+    automation: {
+      appId: "app-refund-backlog",
+      appName: "Ingest",
+      nodeName: "Create Work Order",
+    },
+    app: { id: "app-refund-backlog" },
+  }),
 ];
 
 export const CLOSED_FAILED_WORK_ORDER_EVENTS: FactoriesWorkOrderEvent[] = [
@@ -521,6 +535,7 @@ export const DEFAULT_EVENTS_BY_ORDER_ID: Record<string, FactoriesWorkOrderEvent[
   [RUNNING_WORK_ORDER.id!]: RUNNING_WORK_ORDER_EVENTS,
   [FAILED_WORK_ORDER.id!]: FAILED_WORK_ORDER_EVENTS,
   [DRAFT_WORK_ORDER.id!]: DRAFT_WORK_ORDER_EVENTS,
+  [INGEST_DRAFT_WORK_ORDER.id!]: INGEST_DRAFT_WORK_ORDER_EVENTS,
   [CLOSED_WORK_ORDER.id!]: CLOSED_WORK_ORDER_EVENTS,
   [CLOSED_FAILED_WORK_ORDER.id!]: CLOSED_FAILED_WORK_ORDER_EVENTS,
 };

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -400,6 +400,31 @@ export const DRAFT_WORK_ORDER: FactoriesWorkOrder = {
   lineDispatches: [],
 };
 
+export const INGEST_DRAFT_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-ingest-pagination",
+  number: "106",
+  key: "RF-106",
+  title: "Paginated listings report a next page on the last full page",
+  description: [
+    "Every cursor-paginated listing reports `hasNextPage: true` on its last page whenever the number of rows is an exact multiple of the page size. Clients then request a page that comes back empty.",
+    "",
+    "Fetch `limit + 1` rows and let the extra row answer whether another page exists.",
+  ].join("\n"),
+  state: "STATE_DRAFT",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: TWO_HOURS_AGO,
+  updatedAt: TWO_HOURS_AGO,
+  createdBy: {
+    automation: {
+      appId: "app-refund-backlog",
+      appName: "Ingest",
+      nodeName: "Create Work Order",
+    },
+  },
+  assignees: [],
+  lineDispatches: [],
+};
+
 export const CLOSED_FAILED_WORK_ORDER: FactoriesWorkOrder = {
   id: "wo-closed-failed-refunds",
   number: "92",
@@ -475,6 +500,7 @@ export const DEFAULT_WORK_ORDERS: FactoriesWorkOrder[] = [
   RUNNING_WORK_ORDER,
   FAILED_WORK_ORDER,
   DRAFT_WORK_ORDER,
+  INGEST_DRAFT_WORK_ORDER,
   CLOSED_WORK_ORDER,
   CLOSED_FAILED_WORK_ORDER,
 ];

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -401,14 +401,33 @@ export const DRAFT_WORK_ORDER: FactoriesWorkOrder = {
 };
 
 export const INGEST_DRAFT_WORK_ORDER: FactoriesWorkOrder = {
-  id: "wo-ingest-pagination",
-  number: "106",
-  key: "RF-106",
-  title: "Paginated listings report a next page on the last full page",
+  id: "wo-ingest-api-key",
+  number: "72",
+  key: "RF-72",
+  title: "Duplicate API key name returns HTTP 500 instead of a validation/conflict error",
   description: [
-    "Every cursor-paginated listing reports `hasNextPage: true` on its last page whenever the number of rows is an exact multiple of the page size. Clients then request a page that comes back empty.",
+    "Creating an API key with a name that already exists in the organization returns `HTTP 500 Internal Server Error` with a generic message, instead of a client-actionable validation or conflict response.",
     "",
-    "Fetch `limit + 1` rows and let the extra row answer whether another page exists.",
+    "### What happens",
+    "",
+    "`POST /api/v1/api-keys` with a name that collides with an existing key (the name is trimmed before creation, so surrounding whitespace still collides) returns:",
+    "",
+    "```",
+    "HTTP/1.1 500 Internal Server Error",
+    '{"code": ...,"message":"failed to create API key","details":[]}',
+    "```",
+    "",
+    "The database correctly rejects the duplicate:",
+    "",
+    "```",
+    'ERROR: duplicate key value violates unique constraint "unique_api_key_in_organization" (SQLSTATE 23505)',
+    "```",
+    "",
+    "No second key is created, so the data stays consistent, but a foreseeable user input (reusing a name) surfaces as a server error with no indication of the real cause.",
+    "",
+    "### Expected",
+    "",
+    "A duplicate name should return a client-visible conflict or validation error explaining that the name is already in use, rather than a generic `500`.",
   ].join("\n"),
   state: "STATE_DRAFT",
   result: "RESULT_UNSPECIFIED",
@@ -418,7 +437,7 @@ export const INGEST_DRAFT_WORK_ORDER: FactoriesWorkOrder = {
     automation: {
       appId: "app-refund-backlog",
       appName: "Ingest",
-      nodeName: "Create Work Order",
+      nodeName: "On Issue Label",
     },
   },
   assignees: [],
@@ -494,6 +513,56 @@ export const CLOSED_WORK_ORDER: FactoriesWorkOrder = {
   totalCostCents: "538",
 };
 
+export const PR_CLOSURE_COMPLETED_WORK_ORDER: FactoriesWorkOrder = {
+  id: "wo-pr-closure-receipts",
+  number: "88",
+  key: "RF-88",
+  title: "Send refund receipts after provider confirm",
+  description: [
+    "Customers do not receive a receipt after a refund confirms at the provider.",
+    "",
+    "Send the receipt when the provider webhook reports success. PR Closure completes the work order after the pull request merges.",
+  ].join("\n"),
+  state: "STATE_CLOSED",
+  result: "RESULT_COMPLETED",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+  createdBy: { user: { id: OPERATOR_USER.id, name: OPERATOR_USER.name } },
+  assignees: [{ id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME }],
+  lineDispatches: [
+    planLineDispatch([
+      planLineExecution("plan", {
+        id: "pr-plan",
+        state: "STATE_FINISHED",
+        result: "RESULT_PASSED",
+        updatedAt: LAST_WEEK,
+        totalTokens: "900",
+        costCents: "22",
+      }),
+      planLineExecution("implement", {
+        id: "pr-impl",
+        state: "STATE_FINISHED",
+        result: "RESULT_PASSED",
+        run: { id: "run-pr-closure-implement", appId: "app-refund-implementer", appName: "Refund Implementer" },
+        updatedAt: LAST_WEEK,
+        totalTokens: "5400",
+        costCents: "180",
+      }),
+      planLineExecution("verify", {
+        id: "pr-verify",
+        state: "STATE_FINISHED",
+        result: "RESULT_PASSED",
+        run: { id: "run-pr-closure-verify", appId: "app-refund-verifier", appName: "Refund Verifier" },
+        updatedAt: YESTERDAY,
+        totalTokens: "700",
+        costCents: "16",
+      }),
+    ]),
+  ],
+  totalTokens: "7000",
+  totalCostCents: "218",
+};
+
 export const DEFAULT_WORK_ORDERS: FactoriesWorkOrder[] = [
   OPEN_WORK_ORDER,
   OPEN_WORK_ORDER_SECONDARY,
@@ -502,6 +571,7 @@ export const DEFAULT_WORK_ORDERS: FactoriesWorkOrder[] = [
   DRAFT_WORK_ORDER,
   INGEST_DRAFT_WORK_ORDER,
   CLOSED_WORK_ORDER,
+  PR_CLOSURE_COMPLETED_WORK_ORDER,
   CLOSED_FAILED_WORK_ORDER,
 ];
 

--- a/web_src/src/pages/factories/__fixtures__/lineMetricsFactoriesFixture.ts
+++ b/web_src/src/pages/factories/__fixtures__/lineMetricsFactoriesFixture.ts
@@ -11,6 +11,7 @@ import type {
 
 import {
   CLOSED_WORK_ORDER,
+  FAILED_WORK_ORDER,
   HOUR_AGO,
   OPEN_WORK_ORDER,
   OPEN_WORK_ORDER_SECONDARY,
@@ -172,6 +173,24 @@ function withVerifyPhase(order: FactoriesWorkOrder): FactoriesWorkOrder {
           run: { id: "run-verify-open", appId: "app-refund-verifier", appName: "Verify" },
         },
       ]),
+    ],
+  };
+}
+
+function withFailedWaitingNote(order: FactoriesWorkOrder): FactoriesWorkOrder {
+  if (order.id !== FAILED_WORK_ORDER.id) {
+    return order;
+  }
+  return {
+    ...order,
+    statusNotes: [
+      {
+        key: "implement-failed",
+        kind: "warning",
+        headline: "Review the failed implement step",
+        body: "Implement did not pass. Open the log, then dispatch the line again.",
+        updatedAt: HOUR_AGO,
+      },
     ],
   };
 }
@@ -401,6 +420,7 @@ export const lineMetricsFactoriesFixture: FactoriesFixture = {
       ...(defaultFactoriesFixture.workOrdersByFactoryId[PRIMARY_FACTORY_ID] ?? [])
         .map(withPlanPhase)
         .map(withVerifyPhase)
+        .map(withFailedWaitingNote)
         .map(withDonePhase),
       FEATURE_RUNNING_WORK_ORDER,
       FEATURE_PR_WORK_ORDER,

--- a/web_src/src/pages/factories/__fixtures__/lineMetricsFactoriesFixture.ts
+++ b/web_src/src/pages/factories/__fixtures__/lineMetricsFactoriesFixture.ts
@@ -19,6 +19,7 @@ import {
   LINE_RUN_IMPLEMENT_ID,
   LINE_RUN_VERIFY_PASSED_ID,
   OPERATOR_USER,
+  PR_CLOSURE_COMPLETED_WORK_ORDER,
   PRIMARY_FACTORY_ID,
   REFUND_FACTORY_APPS,
   REFUND_LINE_FEATURE_ID,
@@ -70,7 +71,7 @@ const PLAN_LINE_APPS: FactoryApp[] = [
   {
     id: PLAN_LINE_DONE_APP_ID,
     name: "Done",
-    description: "Closes the work order after verification.",
+    description: "Completes or rejects the work order when a pull request merges or closes.",
     createdAt: LAST_WEEK,
     updatedAt: YESTERDAY,
   },
@@ -196,7 +197,13 @@ function withFailedWaitingNote(order: FactoriesWorkOrder): FactoriesWorkOrder {
 }
 
 function withDonePhase(order: FactoriesWorkOrder): FactoriesWorkOrder {
-  if (order.id !== CLOSED_WORK_ORDER.id) {
+  const doneRun =
+    order.id === CLOSED_WORK_ORDER.id
+      ? { executionId: "exec-done-closed", runId: "run-done-closed", appName: "Done" }
+      : order.id === PR_CLOSURE_COMPLETED_WORK_ORDER.id
+        ? { executionId: "exec-done-pr-closure", runId: "run-done-pr-closure", appName: "PR Closure" }
+        : null;
+  if (!doneRun) {
     return order;
   }
   const dispatch = order.lineDispatches?.[0];
@@ -212,14 +219,14 @@ function withDonePhase(order: FactoriesWorkOrder): FactoriesWorkOrder {
         stepExecutions: [
           ...(dispatch.stepExecutions ?? []),
           {
-            id: "exec-done-closed",
+            id: doneRun.executionId,
             step: "Done",
             stepIndex: 3,
             state: "STATE_FINISHED",
             result: "RESULT_PASSED",
             createdAt: YESTERDAY,
             updatedAt: YESTERDAY,
-            run: { id: "run-done-closed", appId: PLAN_LINE_DONE_APP_ID, appName: "Done" },
+            run: { id: doneRun.runId, appId: PLAN_LINE_DONE_APP_ID, appName: doneRun.appName },
           },
         ],
       },

--- a/web_src/src/pages/factories/__fixtures__/lineMetricsFactoriesFixture.ts
+++ b/web_src/src/pages/factories/__fixtures__/lineMetricsFactoriesFixture.ts
@@ -5,16 +5,21 @@ import type {
   FactoriesWorkOrderLineDispatch,
   FactoriesWorkOrderLineDispatchResult,
   FactoriesWorkOrderLineDispatchState,
+  FactoryApp,
   FactoryLineStep,
 } from "@/api-client";
 
 import {
+  CLOSED_WORK_ORDER,
   HOUR_AGO,
+  OPEN_WORK_ORDER,
+  OPEN_WORK_ORDER_SECONDARY,
   LAST_WEEK,
   LINE_RUN_IMPLEMENT_ID,
   LINE_RUN_VERIFY_PASSED_ID,
   OPERATOR_USER,
   PRIMARY_FACTORY_ID,
+  REFUND_FACTORY_APPS,
   REFUND_LINE_FEATURE_ID,
   REFUND_LINE_ONBOARDING_ID,
   REFUND_LINE_PLAN_ID,
@@ -33,6 +38,173 @@ function runAppStep(appId: string, entrypoint: string): FactoryLineStep {
   return {
     type: RUN_APP_TYPE,
     app: { app: appId, entrypoint },
+  };
+}
+
+const PLAN_LINE_DONE_APP_ID = "app-refund-done";
+const PLAN_LINE_BACKLOG_APP_ID = "app-refund-backlog";
+
+const BACKLOG_APP: FactoryApp = {
+  id: PLAN_LINE_BACKLOG_APP_ID,
+  name: "Backlog",
+  description: "Scopes work orders before they enter a line.",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+};
+
+const PLAN_LINE_APPS: FactoryApp[] = [
+  BACKLOG_APP,
+  ...REFUND_FACTORY_APPS.map((app) => {
+    if (app.id === "app-refund-planner") {
+      return { ...app, name: "Plan" };
+    }
+    if (app.id === "app-refund-implementer") {
+      return { ...app, name: "Implement" };
+    }
+    if (app.id === "app-refund-verifier") {
+      return { ...app, name: "Verify" };
+    }
+    return app;
+  }),
+  {
+    id: PLAN_LINE_DONE_APP_ID,
+    name: "Done",
+    description: "Closes the work order after verification.",
+    createdAt: LAST_WEEK,
+    updatedAt: YESTERDAY,
+  },
+];
+
+function withPlanLinePhases(line: FactoriesFactoryLine): FactoriesFactoryLine {
+  if (line.id !== REFUND_LINE_PLAN_ID) {
+    return line;
+  }
+  return {
+    ...line,
+    steps: [
+      runAppStep("app-refund-planner", "start-plan"),
+      runAppStep("app-refund-implementer", "start-implementation"),
+      runAppStep("app-refund-verifier", "start-verification"),
+      runAppStep(PLAN_LINE_DONE_APP_ID, "start-done"),
+    ],
+  };
+}
+
+function planLineActiveDispatch(
+  orderId: string,
+  stepExecutions: FactoriesWorkOrderExecution[],
+): FactoriesWorkOrderLineDispatch {
+  return {
+    id: `dispatch-${REFUND_LINE_PLAN_ID}-${orderId}`,
+    line: { id: REFUND_LINE_PLAN_ID, name: "plan-and-implement" },
+    steps: [
+      { name: "Plan", stepIndex: 0 },
+      { name: "Implement", stepIndex: 1 },
+      { name: "Verify", stepIndex: 2 },
+      { name: "Done", stepIndex: 3 },
+    ],
+    state: "STATE_ACTIVE",
+    result: "RESULT_UNKNOWN",
+    createdAt: TWO_HOURS_AGO,
+    stepExecutions,
+  };
+}
+
+function withPlanPhase(order: FactoriesWorkOrder): FactoriesWorkOrder {
+  if (order.id !== OPEN_WORK_ORDER.id) {
+    return order;
+  }
+  return {
+    ...order,
+    lineDispatches: [
+      planLineActiveDispatch(order.id, [
+        {
+          id: "exec-plan-open",
+          step: "Plan",
+          stepIndex: 0,
+          state: "STATE_STARTED",
+          result: "RESULT_UNKNOWN",
+          createdAt: HOUR_AGO,
+          updatedAt: HOUR_AGO,
+          run: { id: "run-plan-open", appId: "app-refund-planner", appName: "Plan" },
+        },
+      ]),
+    ],
+  };
+}
+
+function withVerifyPhase(order: FactoriesWorkOrder): FactoriesWorkOrder {
+  if (order.id !== OPEN_WORK_ORDER_SECONDARY.id) {
+    return order;
+  }
+  return {
+    ...order,
+    lineDispatches: [
+      planLineActiveDispatch(order.id, [
+        {
+          id: "exec-verify-plan",
+          step: "Plan",
+          stepIndex: 0,
+          state: "STATE_FINISHED",
+          result: "RESULT_PASSED",
+          createdAt: TWO_HOURS_AGO,
+          updatedAt: TWO_HOURS_AGO,
+          run: { id: "run-verify-plan", appId: "app-refund-planner", appName: "Plan" },
+        },
+        {
+          id: "exec-verify-implement",
+          step: "Implement",
+          stepIndex: 1,
+          state: "STATE_FINISHED",
+          result: "RESULT_PASSED",
+          createdAt: TWO_HOURS_AGO,
+          updatedAt: HOUR_AGO,
+          run: { id: "run-verify-implement", appId: "app-refund-implementer", appName: "Implement" },
+        },
+        {
+          id: "exec-verify-open",
+          step: "Verify",
+          stepIndex: 2,
+          state: "STATE_STARTED",
+          result: "RESULT_UNKNOWN",
+          createdAt: HOUR_AGO,
+          updatedAt: HOUR_AGO,
+          run: { id: "run-verify-open", appId: "app-refund-verifier", appName: "Verify" },
+        },
+      ]),
+    ],
+  };
+}
+
+function withDonePhase(order: FactoriesWorkOrder): FactoriesWorkOrder {
+  if (order.id !== CLOSED_WORK_ORDER.id) {
+    return order;
+  }
+  const dispatch = order.lineDispatches?.[0];
+  if (!dispatch) {
+    return order;
+  }
+  return {
+    ...order,
+    lineDispatches: [
+      {
+        ...dispatch,
+        steps: [...(dispatch.steps ?? []), { name: "Done", stepIndex: 3 }],
+        stepExecutions: [
+          ...(dispatch.stepExecutions ?? []),
+          {
+            id: "exec-done-closed",
+            step: "Done",
+            stepIndex: 3,
+            state: "STATE_FINISHED",
+            result: "RESULT_PASSED",
+            createdAt: YESTERDAY,
+            updatedAt: YESTERDAY,
+            run: { id: "run-done-closed", appId: PLAN_LINE_DONE_APP_ID, appName: "Done" },
+          },
+        ],
+      },
+    ],
   };
 }
 
@@ -216,13 +388,20 @@ export const lineMetricsFactoriesFixture: FactoriesFixture = {
     }
     return {
       ...factory,
-      lines: [...(factory.lines ?? []), ONBOARDING_FACTORY_LINE, FEATURE_DELIVERY_LINE],
+      lines: [...(factory.lines ?? []).map(withPlanLinePhases), ONBOARDING_FACTORY_LINE, FEATURE_DELIVERY_LINE],
     };
   }),
+  appsByFactoryId: {
+    ...defaultFactoriesFixture.appsByFactoryId,
+    [PRIMARY_FACTORY_ID]: PLAN_LINE_APPS,
+  },
   workOrdersByFactoryId: {
     ...defaultFactoriesFixture.workOrdersByFactoryId,
     [PRIMARY_FACTORY_ID]: [
-      ...(defaultFactoriesFixture.workOrdersByFactoryId[PRIMARY_FACTORY_ID] ?? []),
+      ...(defaultFactoriesFixture.workOrdersByFactoryId[PRIMARY_FACTORY_ID] ?? [])
+        .map(withPlanPhase)
+        .map(withVerifyPhase)
+        .map(withDonePhase),
       FEATURE_RUNNING_WORK_ORDER,
       FEATURE_PR_WORK_ORDER,
       FEATURE_CI_WORK_ORDER,
@@ -254,4 +433,8 @@ export const fiveStepLineFactoriesFixture: FactoriesFixture = {
       }),
     };
   }),
+  appsByFactoryId: {
+    ...defaultFactoriesFixture.appsByFactoryId,
+    [PRIMARY_FACTORY_ID]: [BACKLOG_APP, ...(defaultFactoriesFixture.appsByFactoryId[PRIMARY_FACTORY_ID] ?? [])],
+  },
 };

--- a/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
@@ -7,7 +7,13 @@ import type {
   FactoriesWorkOrderLineDispatch,
 } from "@/api-client";
 import { factoryAppPath, factoryAppRunPath, linesPath } from "./factoryPagePaths";
-import { buildLinePhaseBoard, linePhaseRunHref, resolvePhaseRunStatus } from "./linePhaseRuns";
+import {
+  buildLinePhaseBoard,
+  collectLineBacklogOrders,
+  findBacklogAutomationApp,
+  linePhaseRunHref,
+  resolvePhaseRunStatus,
+} from "./linePhaseRuns";
 
 const APPS = [
   { id: "app-plan", name: "plan" },
@@ -340,6 +346,68 @@ describe("linePhaseRunHref", () => {
     });
 
     expect(href).toBe(linesPath("org-1", "RF"));
+  });
+});
+
+describe("collectLineBacklogOrders", () => {
+  it("returns only draft orders that are not on a line", () => {
+    const onLine = order("wo-on-line", "On line", [
+      {
+        id: "e-on",
+        line: { id: "line-1", name: "poc" },
+        step: "plan",
+        stepIndex: 0,
+        state: "STATE_STARTED",
+        createdAt: "2026-08-11T12:00:00.000Z",
+        updatedAt: "2026-08-11T12:00:00.000Z",
+      },
+    ]);
+    const otherLine = order("wo-other-line", "Other line", [
+      {
+        id: "e-other",
+        line: { id: "line-other", name: "other" },
+        step: "plan",
+        stepIndex: 0,
+        state: "STATE_STARTED",
+        createdAt: "2026-08-11T13:00:00.000Z",
+        updatedAt: "2026-08-11T13:00:00.000Z",
+      },
+    ]);
+    const draft: FactoriesWorkOrder = {
+      id: "wo-draft",
+      title: "Draft",
+      state: "STATE_DRAFT",
+      updatedAt: "2026-08-11T14:00:00.000Z",
+      lineDispatches: [],
+    };
+    const open: FactoriesWorkOrder = {
+      id: "wo-open",
+      title: "Open",
+      state: "STATE_OPEN",
+      updatedAt: "2026-08-11T11:00:00.000Z",
+      lineDispatches: [],
+    };
+    const closed: FactoriesWorkOrder = {
+      id: "wo-closed",
+      title: "Closed",
+      state: "STATE_CLOSED",
+      lineDispatches: [],
+    };
+
+    const backlog = collectLineBacklogOrders([onLine, otherLine, draft, open, closed]);
+
+    expect(backlog.map((entry) => entry.id)).toEqual(["wo-draft"]);
+  });
+});
+
+describe("findBacklogAutomationApp", () => {
+  it("returns the factory backlog automation", () => {
+    expect(
+      findBacklogAutomationApp([
+        { id: "app-plan", name: "Plan" },
+        { id: "app-refund-backlog", name: "Backlog" },
+      ]),
+    ).toEqual({ id: "app-refund-backlog", name: "Backlog" });
   });
 });
 

--- a/web_src/src/pages/factories/lib/linePhaseRuns.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.ts
@@ -91,6 +91,41 @@ export function buildLinePhaseBoard(
   });
 }
 
+/**
+ * Draft work orders that are not on a line yet. Newest updated drafts
+ * come first.
+ */
+export function collectLineBacklogOrders(workOrders: FactoriesWorkOrder[]): FactoriesWorkOrder[] {
+  return workOrders.filter(isLineBacklogOrder).sort(compareOrdersNewestFirst);
+}
+
+/** Factory-level intake automation. It is not a line step. */
+export function findBacklogAutomationApp(
+  apps: Array<{ id?: string; name?: string }>,
+): { id: string; name: string } | undefined {
+  const match = apps.find((app) => app.id && (app.name === "Backlog" || app.id === "app-refund-backlog"));
+  if (!match?.id) {
+    return undefined;
+  }
+  return { id: match.id, name: match.name ?? "Backlog" };
+}
+
+function isLineBacklogOrder(order: FactoriesWorkOrder): boolean {
+  if (!order.id || order.state !== "STATE_DRAFT") {
+    return false;
+  }
+  return (order.lineDispatches ?? []).length === 0;
+}
+
+function compareOrdersNewestFirst(left: FactoriesWorkOrder, right: FactoriesWorkOrder): number {
+  const leftTime = Date.parse(left.updatedAt ?? left.createdAt ?? "") || 0;
+  const rightTime = Date.parse(right.updatedAt ?? right.createdAt ?? "") || 0;
+  if (leftTime !== rightTime) {
+    return rightTime - leftTime;
+  }
+  return (right.id ?? "").localeCompare(left.id ?? "");
+}
+
 export function resolvePhaseRunStatus(execution: WorkOrderStepRow): {
   kind: "running" | "waiting" | "queued" | "failed" | "idle";
   label: string;

--- a/web_src/src/pages/factories/pages/Lines.stories.tsx
+++ b/web_src/src/pages/factories/pages/Lines.stories.tsx
@@ -6,8 +6,9 @@ import { fiveStepLineFactoriesFixture, lineMetricsFactoriesFixture } from "../__
 import { LinesPage } from "./LinesPage";
 
 /**
- * Line board is the workspace home: phase columns fill the pane, cards open
- * in a dialog. The list story remains for line management.
+ * Line board is the workspace home: phase columns fill the pane. Cards open
+ * the job-report popup (Storybook wireframe). The list story remains for
+ * line management.
  */
 const meta = {
   title: "Factories/Pages/Lines",

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -9,13 +9,15 @@ import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { ChevronDown, Clock, Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
+import { ChevronDown, Clock, Inbox, Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import {
   buildLinePhaseBoard,
+  collectLineBacklogOrders,
+  findBacklogAutomationApp,
   LINE_PHASE_RUNS_PAGE_SIZE,
   resolveColumnGlyph,
   resolvePhaseRunStatus,
@@ -33,7 +35,8 @@ import {
   type BoardLaneTone,
 } from "../workOrders/WorkOrderBoardChrome";
 import { WorkOrderCard, type WorkOrderCardContext } from "../workOrders/WorkOrderCard";
-import { WorkOrderPeekDialog } from "../WorkOrderPeekDialog";
+import { ConceptJobPopup } from "./work-order-popup-redesign/ConceptJobPopup";
+import { popupFixtureForWorkOrder } from "./work-order-popup-redesign/workOrderPopupMocks";
 import {
   createFactoryLinePath,
   editFactoryLinePath,
@@ -276,34 +279,34 @@ function LineDetail({
 }) {
   const steps = line.steps ?? [];
   const board = useMemo(() => buildLinePhaseBoard(line, workOrders ?? [], apps), [line, workOrders, apps]);
+  const backlogOrders = useMemo(() => collectLineBacklogOrders(workOrders ?? []), [workOrders]);
   const [peekOrderId, setPeekOrderId] = useState<string | null>(null);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="lines-detail">
-      {steps.length === 0 ? (
+      {steps.length === 0 && backlogOrders.length === 0 ? (
         <p className="text-[13px] text-muted-foreground">No phases yet. Edit this line to add app-driven phases.</p>
       ) : (
         <PhaseBoard
           organizationId={organizationId}
           factoryKey={factoryKey}
           lineId={line.id}
+          apps={apps}
+          backlogOrders={backlogOrders}
           columns={board}
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={setPeekOrderId}
         />
       )}
-      <WorkOrderPeekDialog
-        open={Boolean(peekOrderId)}
-        onOpenChange={(open) => {
-          if (!open) {
-            setPeekOrderId(null);
-          }
-        }}
-        organizationId={organizationId}
-        factoryId={factoryId}
-        factoryKey={factoryKey}
-        orderId={peekOrderId}
-      />
+      {peekOrderId ? (
+        <ConceptJobPopup
+          fixture={popupFixtureForWorkOrder(workOrders.find((order) => order.id === peekOrderId))}
+          organizationId={organizationId}
+          factoryKey={factoryKey}
+          onClose={() => setPeekOrderId(null)}
+          fixed
+        />
+      ) : null}
     </div>
   );
 }
@@ -312,6 +315,8 @@ function PhaseBoard({
   organizationId,
   factoryKey,
   lineId,
+  apps,
+  backlogOrders,
   columns,
   workOrderCardContext,
   onOpenWorkOrder,
@@ -319,12 +324,27 @@ function PhaseBoard({
   organizationId: string;
   factoryKey: string;
   lineId?: string;
+  apps: Array<{ id?: string; name?: string }>;
+  backlogOrders: FactoriesWorkOrder[];
   columns: LinePhaseColumn[];
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
 }) {
+  const backlogApp = findBacklogAutomationApp(apps);
+  const backlogConfigureHref = backlogApp
+    ? factoryAppConfigurePath(organizationId, factoryKey, backlogApp.id, { from: "lines", lineId })
+    : null;
+
   return (
     <WorkOrderKanbanBoard testId="lines-phase-board">
+      <div className={cn("relative flex min-h-0 self-stretch", workOrderKanbanLaneSizeClassName)}>
+        <BacklogColumn
+          orders={backlogOrders}
+          configureHref={backlogConfigureHref}
+          workOrderCardContext={workOrderCardContext}
+          onOpenWorkOrder={onOpenWorkOrder}
+        />
+      </div>
       {columns.map((column, index) => (
         <div
           key={`${column.stepIndex}-${column.stepName}`}
@@ -344,6 +364,71 @@ function PhaseBoard({
         </div>
       ))}
     </WorkOrderKanbanBoard>
+  );
+}
+
+function BacklogColumn({
+  orders,
+  configureHref,
+  workOrderCardContext,
+  onOpenWorkOrder,
+}: {
+  orders: FactoriesWorkOrder[];
+  configureHref: string | null;
+  workOrderCardContext: WorkOrderCardContext;
+  onOpenWorkOrder: (orderId: string) => void;
+}) {
+  return (
+    <WorkOrderBoardLane
+      title="Backlog"
+      label="Backlog"
+      count={orders.length}
+      tone="neutral"
+      emptyDescription="No work orders in the backlog."
+      className="bg-muted"
+      leading={<Inbox className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />}
+      actions={
+        configureHref ? <ColumnConfigureMenu title="Backlog" href={configureHref} testId="lines-backlog-menu" /> : null
+      }
+      testId="lines-backlog-column"
+    >
+      <ul className={workOrderKanbanLaneScrollClassName} data-testid="lines-backlog-column-scroll">
+        {orders.map((order) => (
+          <li key={order.id}>
+            <LineBoardOrderCard
+              order={order}
+              workOrderCardContext={workOrderCardContext}
+              onOpenWorkOrder={onOpenWorkOrder}
+            />
+          </li>
+        ))}
+      </ul>
+    </WorkOrderBoardLane>
+  );
+}
+
+function ColumnConfigureMenu({ title, href, testId }: { title: string; href: string; testId: string }) {
+  const navigate = useNavigate();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${title} menu`}
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          data-testid={testId}
+        >
+          <MoreHorizontal className="size-3.5" aria-hidden />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuItem onClick={() => navigate(href)} data-testid={`${testId}-edit`}>
+          <Pencil className="h-3.5 w-3.5" aria-hidden />
+          Edit
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -481,6 +566,31 @@ function PhaseRunCard({
         </p>
       ) : null}
     </div>
+  );
+}
+
+function LineBoardOrderCard({
+  order,
+  workOrderCardContext,
+  onOpenWorkOrder,
+}: {
+  order: FactoriesWorkOrder;
+  workOrderCardContext: WorkOrderCardContext;
+  onOpenWorkOrder: (orderId: string) => void;
+}) {
+  const { factory } = useFactoriesLayout();
+  const entry = useMemo(() => buildWorkOrderListEntry(order, factory), [order, factory]);
+
+  return (
+    <WorkOrderCard
+      {...workOrderCardContext}
+      entry={entry}
+      onOpen={() => {
+        if (order.id) {
+          onOpenWorkOrder(order.id);
+        }
+      }}
+    />
   );
 }
 

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/ConceptJobPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/ConceptJobPopup.tsx
@@ -1,0 +1,77 @@
+import { FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_KEY } from "../../__fixtures__/factoryPageResponses";
+import { WorkOrderCheckCard } from "../../WorkOrderChecksSection";
+import { DispatchTimelineItem } from "../../timeline/DispatchTimelineItem";
+import { OwnerTimeCostRow, PopupBody, PopupHeader, PopupShell, SectionTitle, WaitingNotes } from "./popupShared";
+import { buildPopupDispatchEvent, type PopupFixture } from "./workOrderPopupMocks";
+
+/**
+ * Job report. Pattern: Laravel Cloud / Railway deploy details.
+ *
+ * First screen: next step, scores, then the activity log.
+ * Artifacts hang on the step that produced them. Markdown opens a
+ * second popup. Pull requests and branches open in a new tab.
+ */
+export function ConceptJobPopup({
+  fixture,
+  organizationId = FACTORIES_ORGANIZATION_ID,
+  factoryKey = PRIMARY_FACTORY_KEY,
+  onClose,
+  fixed = false,
+}: {
+  fixture: PopupFixture;
+  organizationId?: string;
+  factoryKey?: string;
+  onClose?: () => void;
+  fixed?: boolean;
+}) {
+  const dispatch = buildPopupDispatchEvent(fixture);
+
+  return (
+    <PopupShell testId="work-order-popup-job" fixed={fixed} onDismiss={onClose}>
+      <PopupHeader title={fixture.title} onClose={onClose}>
+        <OwnerTimeCostRow fixture={fixture} />
+      </PopupHeader>
+      <PopupBody>
+        <div className="flex flex-col gap-8">
+          <WaitingNotes notes={fixture.waitingNotes} />
+
+          {fixture.checks.length > 0 ? (
+            <section>
+              <SectionTitle>Scores</SectionTitle>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                {fixture.checks.map((check) => (
+                  <WorkOrderCheckCard key={check.id} check={check} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          <section>
+            <div className="flex items-baseline justify-between gap-3">
+              <SectionTitle>Log</SectionTitle>
+              <span className="text-[12px] text-muted-foreground">{fixture.elapsed}</span>
+            </div>
+            <div className="mt-2">
+              {dispatch ? (
+                <ul className="relative space-y-4">
+                  <span
+                    className="pointer-events-none absolute top-3 bottom-3 left-[11px] w-px bg-border"
+                    aria-hidden
+                  />
+                  <DispatchTimelineItem
+                    event={dispatch}
+                    organizationId={organizationId}
+                    factoryKey={factoryKey}
+                    isLatestDispatch
+                  />
+                </ul>
+              ) : (
+                <p className="text-[13px] text-muted-foreground">No steps yet.</p>
+              )}
+            </div>
+          </section>
+        </div>
+      </PopupBody>
+    </PopupShell>
+  );
+}

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/ConceptSessionPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/ConceptSessionPopup.tsx
@@ -1,0 +1,55 @@
+import { RunCheckGrid } from "../work-order-run-overlay/runOverlayShared";
+import {
+  AgentLogList,
+  DescriptionFileCard,
+  OutputList,
+  OwnerTimeCostRow,
+  PopupBody,
+  PopupHeader,
+  PopupShell,
+  SectionTitle,
+  WaitingNotes,
+} from "./popupShared";
+import type { PopupFixture } from "./workOrderPopupMocks";
+
+/**
+ * Agent session. Pattern: Devin task feed.
+ *
+ * One column. The spec is a file. Outputs, scores, and the agent log follow.
+ */
+export function ConceptSessionPopup({ fixture }: { fixture: PopupFixture }) {
+  return (
+    <PopupShell testId="work-order-popup-session">
+      <PopupHeader title={fixture.title}>
+        <OwnerTimeCostRow fixture={fixture} />
+      </PopupHeader>
+      <PopupBody>
+        <DescriptionFileCard artifact={fixture.description} />
+
+        <section className="mt-8">
+          <SectionTitle>Outputs</SectionTitle>
+          <div className="mt-2">
+            <OutputList artifacts={fixture.outputs} />
+          </div>
+        </section>
+
+        <section className="mt-8">
+          <WaitingNotes notes={fixture.waitingNotes} />
+        </section>
+
+        <section className="mt-8">
+          <SectionTitle>Scores</SectionTitle>
+          <RunCheckGrid checks={fixture.checks} emptyLabel="No scores yet." className="mt-3" />
+        </section>
+
+        <section className="mt-8">
+          <SectionTitle>Worked for {fixture.elapsed}</SectionTitle>
+          <p className="workspace-body-text mt-1 text-muted-foreground">Agent and automation steps. No comments.</p>
+          <div className="mt-2">
+            <AgentLogList entries={fixture.log} />
+          </div>
+        </section>
+      </PopupBody>
+    </PopupShell>
+  );
+}

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/ConceptTracePopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/ConceptTracePopup.tsx
@@ -1,0 +1,120 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+import { toArtifactDataRecord } from "../../lib/workOrderArtifact";
+import { WorkOrderArtifactInline } from "../../WorkOrderArtifactInline";
+import { WorkOrderCheckCard } from "../../WorkOrderChecksSection";
+import { DescriptionMarkdown, OwnerTimeCostRow, PopupBody, PopupHeader, PopupShell, WaitingNotes } from "./popupShared";
+import type { PopupFixture, PopupLogEntry, PopupLogState } from "./workOrderPopupMocks";
+
+/**
+ * Trace inspector. Pattern: LangSmith / agent observability.
+ *
+ * The work is a tree of spans. description.md is the input span.
+ * Artifacts hang off the span that produced them. Checks are evals.
+ */
+export function ConceptTracePopup({ fixture }: { fixture: PopupFixture }) {
+  return (
+    <PopupShell testId="work-order-popup-trace">
+      <PopupHeader title={fixture.title}>
+        <OwnerTimeCostRow fixture={fixture} />
+      </PopupHeader>
+      <PopupBody>
+        <ol className="flex flex-col gap-1 border-l border-border pl-4">
+          <TraceSpan name="Input" actor="description.md" duration="—" state="passed" open>
+            <DescriptionMarkdown artifact={fixture.description} />
+          </TraceSpan>
+
+          {fixture.log.map((entry) => (
+            <TraceSpan
+              key={entry.id}
+              name={entry.title}
+              actor={entry.actor}
+              duration={entry.duration}
+              state={entry.state}
+              detail={entry.detail}
+              open={entry.state === "running" || entry.state === "waiting"}
+            >
+              <SpanArtifact fixture={fixture} entry={entry} />
+            </TraceSpan>
+          ))}
+
+          <TraceSpan name="Evals" actor="Automations" duration="—" state="passed" open>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {fixture.checks.slice(0, 4).map((check) => (
+                <WorkOrderCheckCard key={check.id} check={check} />
+              ))}
+            </div>
+          </TraceSpan>
+        </ol>
+
+        <div className="mt-8">
+          <WaitingNotes notes={fixture.waitingNotes} />
+        </div>
+      </PopupBody>
+    </PopupShell>
+  );
+}
+
+const STATE_DOT: Record<PopupLogState, string> = {
+  passed: "bg-[color:var(--status-completed-dot)]",
+  running: "bg-[color:var(--status-running-dot)]",
+  waiting: "bg-[color:var(--status-waiting-dot)]",
+};
+
+function TraceSpan({
+  name,
+  actor,
+  duration,
+  state,
+  detail,
+  open,
+  children,
+}: {
+  name: string;
+  actor: string;
+  duration: string;
+  state: PopupLogState;
+  detail?: string;
+  open?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <li className="relative py-2">
+      <span className={cn("absolute top-3.5 -left-[1.15rem] size-2 rounded-full", STATE_DOT[state])} aria-hidden />
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="min-w-0 text-[13px] text-foreground">
+          <span className="font-medium">{name}</span>
+          <span className="text-muted-foreground"> · {actor}</span>
+        </p>
+        <span className="shrink-0 text-[12px] tabular-nums text-muted-foreground">{duration}</span>
+      </div>
+      {detail ? <p className="mt-0.5 text-[12px] text-muted-foreground">{detail}</p> : null}
+      {open && children ? <div className="mt-2">{children}</div> : null}
+    </li>
+  );
+}
+
+function SpanArtifact({ fixture, entry }: { fixture: PopupFixture; entry: PopupLogEntry }) {
+  if (!entry.artifactId) {
+    return null;
+  }
+  const artifact =
+    entry.artifactId === fixture.description.id
+      ? fixture.description
+      : fixture.outputs.find((item) => item.id === entry.artifactId);
+  if (!artifact) {
+    return null;
+  }
+  return (
+    <div className="rounded-md border border-border bg-card px-2.5 py-1.5">
+      <WorkOrderArtifactInline
+        artifact={{
+          id: artifact.id,
+          type: artifact.type ?? "TYPE_UNSPECIFIED",
+          data: toArtifactDataRecord(artifact.data),
+        }}
+      />
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
@@ -121,7 +121,7 @@ describe("Line board job popup", () => {
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId("lines-backlog-column")).getByRole("button", {
-        name: "Open Paginated listings report a next page on the last full page",
+        name: "Open Duplicate API key name returns HTTP 500 instead of a validation/conflict error",
       }),
     ).toBeInTheDocument();
     expect(
@@ -141,6 +141,11 @@ describe("Line board job popup", () => {
     ).toBeInTheDocument();
     expect(
       within(screen.getByLabelText("Done phase")).getByRole("button", { name: "Open Backfill refund audit trail" }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("Done phase")).getByRole("button", {
+        name: "Open Send refund receipts after provider confirm",
+      }),
     ).toBeInTheDocument();
     await user.click(card);
 
@@ -199,10 +204,23 @@ describe("Line board job popup", () => {
     await user.click(within(dialog).getByRole("button", { name: "Close" }));
 
     await user.click(
-      screen.getByRole("button", { name: "Open Paginated listings report a next page on the last full page" }),
+      screen.getByRole("button", {
+        name: "Open Duplicate API key name returns HTTP 500 instead of a validation/conflict error",
+      }),
     );
     dialog = await screen.findByTestId("work-order-popup-job");
     expect(within(dialog).getByText("Create work order from GitHub issue")).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: "description.md" })).toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Close" }));
+
+    await user.click(screen.getByRole("button", { name: "Open Backfill refund audit trail" }));
+    dialog = await screen.findByTestId("work-order-popup-job");
+    expect(within(dialog).getByText("Complete work order")).toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Close" }));
+
+    await user.click(screen.getByRole("button", { name: "Open Send refund receipts after provider confirm" }));
+    dialog = await screen.findByTestId("work-order-popup-job");
+    expect(within(dialog).getByText("Complete work order from merged pull request")).toBeInTheDocument();
+    expect(within(dialog).getByRole("link", { name: /#510|Send refund receipts/ })).toHaveAttribute("target", "_blank");
   }, 15000);
 });

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
@@ -1,0 +1,157 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { client } from "@/api-client/client.gen";
+import { TooltipProvider } from "@/ui/tooltip";
+
+import { FactoriesHarness } from "../../__fixtures__/FactoriesHarness";
+import { PRIMARY_FACTORY_KEY, REFUND_FACTORY_LINES } from "../../__fixtures__/factoryPageResponses";
+import { lineMetricsFactoriesFixture } from "../../__fixtures__/lineMetricsFactoriesFixture";
+import { WorkOrderPopupRedesignPlayground } from "./WorkOrderPopupRedesignPlayground";
+import { AGENT_WORK_POPUP_RUNNING } from "./workOrderPopupMocks";
+
+function renderPlayground() {
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <WorkOrderPopupRedesignPlayground initialConcept="job" />
+      </TooltipProvider>
+    </MemoryRouter>,
+  );
+}
+
+function sectionOrder(dialog: HTMLElement) {
+  const text = dialog.textContent ?? "";
+  return {
+    waiting: text.indexOf("Review the pull request"),
+    scores: text.indexOf("Scores"),
+    log: text.indexOf("Log"),
+  };
+}
+
+describe("WorkOrderPopupRedesignPlayground", () => {
+  it("opens the job report without ticket chrome or an artifact preview", () => {
+    renderPlayground();
+
+    const dialog = screen.getByTestId("work-order-popup-job");
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Reconcile duplicate refunds in ledger" })).toBeInTheDocument();
+    expect(within(dialog).getByText("Review the pull request")).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Scores" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Log" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Outputs" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "description.md" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Artifacts" })).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(/Users see duplicate refund/)).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("link", { name: /#482|Fix duplicate refund/ })).toHaveAttribute("target", "_blank");
+    expect(within(dialog).getByRole("link", { name: /feature\/refund-retry/ })).toHaveAttribute("target", "_blank");
+    expect(within(dialog).getByText("plan-and-implement")).toBeInTheDocument();
+    expect(within(dialog).getByText("Plan")).toBeInTheDocument();
+    expect(within(dialog).getByText("Implement")).toBeInTheDocument();
+    expect(within(dialog).getByText("Verify")).toBeInTheDocument();
+    expect(within(dialog).getByText("Done")).toBeInTheDocument();
+    expect(within(dialog).getAllByText("Completed").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Factory Lines")).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+
+    const order = sectionOrder(dialog);
+    expect(order.waiting).toBeGreaterThan(-1);
+    expect(order.waiting).toBeLessThan(order.scores);
+    expect(order.scores).toBeLessThan(order.log);
+  });
+
+  it("keeps the log on a running job and hides scores", () => {
+    render(
+      <MemoryRouter>
+        <TooltipProvider>
+          <WorkOrderPopupRedesignPlayground initialConcept="job" fixture={AGENT_WORK_POPUP_RUNNING} />
+        </TooltipProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = screen.getByTestId("work-order-popup-job");
+    expect(within(dialog).getByRole("heading", { name: "Add refund reconciliation test" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Scores" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Log" })).toBeInTheDocument();
+    expect(within(dialog).getByText("Implement")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Review the pull request")).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Outputs" })).not.toBeInTheDocument();
+  });
+
+  it("opens a markdown output in a second popup", async () => {
+    const user = userEvent.setup();
+    renderPlayground();
+    const dialog = screen.getByTestId("work-order-popup-job");
+
+    await user.click(within(dialog).getByRole("button", { name: "description.md" }));
+
+    expect(screen.getByRole("heading", { name: "description.md" })).toBeInTheDocument();
+    expect(screen.getByText(/Users see duplicate refund/)).toBeInTheDocument();
+  });
+});
+
+describe("Line board job popup", () => {
+  beforeAll(() => {
+    client.setConfig({ baseUrl: "http://localhost" });
+  });
+
+  it("opens the job report from a line-board card", async () => {
+    const user = userEvent.setup();
+    const line = REFUND_FACTORY_LINES[0];
+
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}`}
+        factoriesFixture={lineMetricsFactoriesFixture}
+      />,
+    );
+
+    const card = await screen.findByRole("button", { name: "Open Add refund reconciliation test" }, { timeout: 8000 });
+    expect(screen.getByLabelText("Backlog")).toBeInTheDocument();
+    expect(screen.getByTestId("lines-backlog-column")).toBeInTheDocument();
+    expect(screen.getByLabelText("Backlog menu")).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("lines-backlog-column")).getByRole("button", {
+        name: "Open Draft: rework refund telemetry",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("lines-backlog-column")).queryByRole("button", {
+        name: "Open Reconcile duplicate refunds in ledger",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("Plan phase")).getByRole("button", {
+        name: "Open Reconcile duplicate refunds in ledger",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("Implement phase")).getByRole("button", {
+        name: "Open Add refund reconciliation test",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("Verify phase")).getByRole("button", {
+        name: "Open Add refund reason enum to schema",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("Done phase")).getByRole("button", { name: "Open Backfill refund audit trail" }),
+    ).toBeInTheDocument();
+    await user.click(card);
+
+    const dialog = await screen.findByTestId("work-order-popup-job");
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Add refund reconciliation test" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Outputs" })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: "description.md" })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Scores" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Log" })).toBeInTheDocument();
+    expect(within(dialog).getByText("Implement")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Review the pull request")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(/Users see duplicate refund/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("work-order-peek-dialog")).not.toBeInTheDocument();
+  }, 15000);
+});

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
@@ -48,6 +48,7 @@ describe("WorkOrderPopupRedesignPlayground", () => {
     expect(within(dialog).getByRole("link", { name: /#482|Fix duplicate refund/ })).toHaveAttribute("target", "_blank");
     expect(within(dialog).getByRole("link", { name: /feature\/refund-retry/ })).toHaveAttribute("target", "_blank");
     expect(within(dialog).getByText("plan-and-implement")).toBeInTheDocument();
+    expect(within(dialog).getByText("Backlog")).toBeInTheDocument();
     expect(within(dialog).getByText("Plan")).toBeInTheDocument();
     expect(within(dialog).getByText("Implement")).toBeInTheDocument();
     expect(within(dialog).getByText("Verify")).toBeInTheDocument();
@@ -75,6 +76,7 @@ describe("WorkOrderPopupRedesignPlayground", () => {
     expect(within(dialog).getByRole("heading", { name: "Add refund reconciliation test" })).toBeInTheDocument();
     expect(within(dialog).queryByRole("heading", { name: "Scores" })).not.toBeInTheDocument();
     expect(within(dialog).getByRole("heading", { name: "Log" })).toBeInTheDocument();
+    expect(within(dialog).getByText("Backlog")).toBeInTheDocument();
     expect(within(dialog).getByText("Implement")).toBeInTheDocument();
     expect(within(dialog).queryByText("Review the pull request")).not.toBeInTheDocument();
     expect(within(dialog).queryByRole("heading", { name: "Outputs" })).not.toBeInTheDocument();
@@ -118,10 +120,10 @@ describe("Line board job popup", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId("lines-backlog-column")).queryByRole("button", {
-        name: "Open Reconcile duplicate refunds in ledger",
+      within(screen.getByTestId("lines-backlog-column")).getByRole("button", {
+        name: "Open Paginated listings report a next page on the last full page",
       }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
     expect(
       within(screen.getByLabelText("Plan phase")).getByRole("button", {
         name: "Open Reconcile duplicate refunds in ledger",
@@ -146,12 +148,61 @@ describe("Line board job popup", () => {
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByRole("heading", { name: "Add refund reconciliation test" })).toBeInTheDocument();
     expect(within(dialog).queryByRole("heading", { name: "Outputs" })).not.toBeInTheDocument();
-    expect(within(dialog).queryByRole("button", { name: "description.md" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "description.md" })).toBeInTheDocument();
     expect(within(dialog).queryByRole("heading", { name: "Scores" })).not.toBeInTheDocument();
     expect(within(dialog).getByRole("heading", { name: "Log" })).toBeInTheDocument();
     expect(within(dialog).getByText("Implement")).toBeInTheDocument();
     expect(within(dialog).queryByText("Review the pull request")).not.toBeInTheDocument();
     expect(within(dialog).queryByText(/Users see duplicate refund/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("work-order-peek-dialog")).not.toBeInTheDocument();
+  }, 15000);
+
+  it("matches popup content to the card state", async () => {
+    const user = userEvent.setup();
+    const line = REFUND_FACTORY_LINES[0];
+
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}`}
+        factoriesFixture={lineMetricsFactoriesFixture}
+      />,
+    );
+
+    await screen.findByRole("button", { name: "Open Add refund reconciliation test" }, { timeout: 8000 });
+
+    await user.click(screen.getByRole("button", { name: "Open Reconcile duplicate refunds in ledger" }));
+    let dialog = await screen.findByTestId("work-order-popup-job");
+    expect(within(dialog).queryByText("Review the pull request")).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Scores" })).not.toBeInTheDocument();
+    expect(within(dialog).getByText("Plan")).toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Close" }));
+
+    await user.click(screen.getByRole("button", { name: "Open Ship idempotent refund retries" }));
+    dialog = await screen.findByTestId("work-order-popup-job");
+    expect(within(dialog).getByText("Review the failed implement step")).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Scores" })).not.toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Close" }));
+
+    await user.click(screen.getByRole("button", { name: "Open Add refund reason enum to schema" }));
+    dialog = await screen.findByTestId("work-order-popup-job");
+    expect(within(dialog).queryByText("Review the pull request")).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Scores" })).toBeInTheDocument();
+    expect(within(dialog).getByText("Verify")).toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Close" }));
+
+    await user.click(screen.getByRole("button", { name: "Open Draft: rework refund telemetry" }));
+    dialog = await screen.findByTestId("work-order-popup-job");
+    expect(within(dialog).getByText("Backlog")).toBeInTheDocument();
+    expect(within(dialog).getByText("Create work order")).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "description.md" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Scores" })).not.toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Close" }));
+
+    await user.click(
+      screen.getByRole("button", { name: "Open Paginated listings report a next page on the last full page" }),
+    );
+    dialog = await screen.findByTestId("work-order-popup-job");
+    expect(within(dialog).getByText("Create work order from GitHub issue")).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "description.md" })).toBeInTheDocument();
   }, 15000);
 });

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.stories.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "../../__fixtures__/ComponentStoryShell";
+import { withFactoriesTheme } from "../../__fixtures__/factoriesStoryTheme";
+import { WorkOrderPopupRedesignPlayground } from "./WorkOrderPopupRedesignPlayground";
+import { AGENT_WORK_POPUP_RUNNING } from "./workOrderPopupMocks";
+
+/**
+ * Work-order board popup as agent work, not a ticket.
+ *
+ * Storybook-only. The production peek dialog is unchanged.
+ *
+ * Shared rules: no right sidebar, no status, no author, no mission, no
+ * factory lines, no comments. Owner, time, and cost sit in one top row.
+ * The first screen is next step, scores, then the activity log.
+ * Artifacts hang on the step that produced them. Markdown opens a
+ * second popup.
+ */
+const meta = {
+  title: "Factories/Pages/Work Order Popup Redesign",
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    withFactoriesTheme,
+    (Story) => (
+      <ComponentStoryShell className="min-h-svh bg-background p-0">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Compare: Story = {
+  name: "Compare Session Trace Job",
+  render: () => <WorkOrderPopupRedesignPlayground />,
+};
+
+/** Devin-style feed: spec file, outputs, scores, then the agent log. */
+export const Session: Story = {
+  name: "Session — Agent feed",
+  render: () => <WorkOrderPopupRedesignPlayground initialConcept="session" />,
+};
+
+/** LangSmith-style tree: input span, tool spans, evals. */
+export const Trace: Story = {
+  name: "Trace — Span tree",
+  render: () => <WorkOrderPopupRedesignPlayground initialConcept="trace" />,
+};
+
+/** Deploy-details report: next step, scores, then the activity log. */
+export const Job: Story = {
+  name: "Job — Run report",
+  render: () => <WorkOrderPopupRedesignPlayground initialConcept="job" />,
+};
+
+/** In-flight job: no scores until automations finish. The log stays visible. */
+export const JobRunning: Story = {
+  name: "Job — Running",
+  render: () => <WorkOrderPopupRedesignPlayground initialConcept="job" fixture={AGENT_WORK_POPUP_RUNNING} />,
+};

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesignPlayground.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesignPlayground.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+
+import { ConceptJobPopup } from "./ConceptJobPopup";
+import { ConceptSessionPopup } from "./ConceptSessionPopup";
+import { ConceptTracePopup } from "./ConceptTracePopup";
+import { PrototypeSwitcher, RunOverlayBoardBackdrop } from "./popupShared";
+import { AGENT_WORK_POPUP, type PopupConcept, type PopupFixture } from "./workOrderPopupMocks";
+
+const CONCEPTS: { id: PopupConcept; label: string; pattern: string }[] = [
+  { id: "session", label: "Session", pattern: "Agent feed" },
+  { id: "trace", label: "Trace", pattern: "Span tree" },
+  { id: "job", label: "Job", pattern: "Run report" },
+];
+
+/**
+ * Storybook playground: line board under a popup that treats the work order
+ * as agent work. Production peek is unchanged.
+ */
+export function WorkOrderPopupRedesignPlayground({
+  initialConcept = "session",
+  fixture = AGENT_WORK_POPUP,
+}: {
+  initialConcept?: PopupConcept;
+  fixture?: PopupFixture;
+}) {
+  const [concept, setConcept] = useState<PopupConcept>(initialConcept);
+  const caption = CONCEPTS.find((entry) => entry.id === concept)?.pattern ?? "";
+
+  return (
+    <div className="relative min-h-svh">
+      <RunOverlayBoardBackdrop />
+      {concept === "session" ? <ConceptSessionPopup fixture={fixture} /> : null}
+      {concept === "trace" ? <ConceptTracePopup fixture={fixture} /> : null}
+      {concept === "job" ? <ConceptJobPopup fixture={fixture} /> : null}
+      <PrototypeSwitcher value={concept} onChange={(id) => setConcept(id as PopupConcept)} options={CONCEPTS} />
+      <p className="sr-only">{caption}</p>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
@@ -150,6 +150,7 @@ const LOG_DOT: Record<PopupLogState, string> = {
   passed: "bg-[color:var(--status-completed-dot)]",
   running: "bg-[color:var(--status-running-dot)]",
   waiting: "bg-[color:var(--status-waiting-dot)]",
+  failed: "bg-[color:var(--status-failed-dot)]",
 };
 
 export function AgentLogList({ entries }: { entries: PopupLogEntry[] }) {

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
@@ -1,0 +1,211 @@
+import type { FactoriesWorkOrderArtifact } from "@/api-client";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { MarkdownContent } from "@/pages/app/Markdown";
+import { CircleDollarSign, Clock, FileText, XIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { FACTORIES_ORGANIZATION_ID } from "../../__fixtures__/factoryPageResponses";
+import { extractArtifactMarkdownBody, toArtifactDataRecord } from "../../lib/workOrderArtifact";
+import { OrgUserReference } from "../../OrgUserReference";
+import { WorkOrderArtifactInline } from "../../WorkOrderArtifactInline";
+import { WorkOrderStatusNote } from "../../WorkOrderStatusNote";
+import { RunOverlayBoardBackdrop, RunOverlayFrame } from "../work-order-run-overlay/runOverlayShared";
+import type { PopupFixture, PopupLogEntry, PopupLogState } from "./workOrderPopupMocks";
+
+export { RunOverlayBoardBackdrop };
+
+export function PopupShell({
+  testId,
+  children,
+  fixed = false,
+  wide = false,
+  onDismiss,
+}: {
+  testId: string;
+  children: ReactNode;
+  fixed?: boolean;
+  wide?: boolean;
+  onDismiss?: () => void;
+}) {
+  return (
+    <RunOverlayFrame testId={testId} fixed={fixed} wide={wide} onDismiss={onDismiss}>
+      {children}
+    </RunOverlayFrame>
+  );
+}
+
+export function PopupHeader({
+  title,
+  children,
+  onClose,
+}: {
+  title: string;
+  children?: ReactNode;
+  onClose?: () => void;
+}) {
+  return (
+    <header className="relative shrink-0 border-b border-border px-5 py-3 pr-12">
+      <h2 className="truncate text-[16px] font-semibold tracking-[-0.02em] text-foreground">{title}</h2>
+      {children}
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-2 right-2 flex h-6 w-6 items-center justify-center rounded-full hover:bg-slate-950/5 dark:hover:bg-white/10"
+        aria-label="Close"
+      >
+        <XIcon className="h-4 w-4" />
+      </button>
+    </header>
+  );
+}
+
+/** Owner, elapsed time, and spend. No status, author, or ticket key. */
+export function OwnerTimeCostRow({ fixture, className }: { fixture: PopupFixture; className?: string }) {
+  return (
+    <div
+      className={cn("mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[13px] text-foreground", className)}
+      data-testid="popup-owner-time-cost"
+    >
+      <span className="inline-flex min-w-0 items-center gap-1.5">
+        <OrgUserReference display={fixture.owner} size="xs" nameClassName="truncate text-[13px]" />
+      </span>
+      <span className="inline-flex items-center gap-1.5 text-muted-foreground" title={fixture.startedLabel}>
+        <Clock className="size-3.5 shrink-0" aria-hidden />
+        <span className="text-foreground">{fixture.elapsed}</span>
+      </span>
+      <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+        <CircleDollarSign className="size-3.5 shrink-0" aria-hidden />
+        <span className="text-foreground">
+          {fixture.costUsd} <span className="text-muted-foreground">·</span> {fixture.tokensLabel}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export function DescriptionMarkdown({ artifact }: { artifact: FactoriesWorkOrderArtifact }) {
+  const body = extractArtifactMarkdownBody(toArtifactDataRecord(artifact.data)) ?? "";
+  return <MarkdownContent content={body} variant="workspace" />;
+}
+
+export function DescriptionFileCard({ artifact }: { artifact: FactoriesWorkOrderArtifact }) {
+  return (
+    <article className="overflow-hidden rounded-lg border border-border bg-card">
+      <div className="flex items-center gap-2 border-b border-border bg-muted/40 px-3 py-2">
+        <FileText className="size-3.5 text-muted-foreground" aria-hidden />
+        <span className="text-[13px] font-medium tracking-[-0.01em] text-foreground">description.md</span>
+      </div>
+      <div className="px-4 py-3">
+        <DescriptionMarkdown artifact={artifact} />
+      </div>
+    </article>
+  );
+}
+
+export function OutputList({ artifacts }: { artifacts: FactoriesWorkOrderArtifact[] }) {
+  return (
+    <ul className="flex flex-col">
+      {artifacts.map((artifact) => (
+        <li className="flex items-center py-1.5" key={artifact.id ?? `${artifact.type}-${artifact.createdAt}`}>
+          <WorkOrderArtifactInline
+            className="w-full justify-start"
+            artifact={{
+              id: artifact.id,
+              type: artifact.type ?? "TYPE_UNSPECIFIED",
+              data: toArtifactDataRecord(artifact.data),
+            }}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function WaitingNotes({ notes }: { notes: PopupFixture["waitingNotes"] }) {
+  if (notes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {notes.map((note) => (
+        <WorkOrderStatusNote
+          key={note.key}
+          note={note}
+          organizationId={FACTORIES_ORGANIZATION_ID}
+          canClose={false}
+          canManage={false}
+          isBusy={false}
+          statusActions={[]}
+          onClose={() => undefined}
+          onStatusChange={async () => undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+const LOG_DOT: Record<PopupLogState, string> = {
+  passed: "bg-[color:var(--status-completed-dot)]",
+  running: "bg-[color:var(--status-running-dot)]",
+  waiting: "bg-[color:var(--status-waiting-dot)]",
+};
+
+export function AgentLogList({ entries }: { entries: PopupLogEntry[] }) {
+  return (
+    <ol className="flex flex-col">
+      {entries.map((entry) => (
+        <li key={entry.id} className="flex items-start gap-3 py-2">
+          <span className={cn("mt-1.5 size-1.5 shrink-0 rounded-full", LOG_DOT[entry.state])} aria-hidden />
+          <div className="min-w-0 flex-1">
+            <p className="text-[13px] text-foreground">
+              <span className="font-medium">{entry.title}</span>
+              <span className="text-muted-foreground"> · {entry.actor}</span>
+            </p>
+            {entry.detail ? <p className="mt-0.5 text-[12px] text-muted-foreground">{entry.detail}</p> : null}
+          </div>
+          <span className="shrink-0 text-[12px] tabular-nums text-muted-foreground">{entry.duration}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function PopupBody({ children }: { children: ReactNode }) {
+  return <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{children}</div>;
+}
+
+export function SectionTitle({ children }: { children: ReactNode }) {
+  return <h3 className="workspace-section-title">{children}</h3>;
+}
+
+export function PrototypeSwitcher({
+  value,
+  onChange,
+  options,
+}: {
+  value: string;
+  onChange: (id: string) => void;
+  options: { id: string; label: string; pattern: string }[];
+}) {
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center p-3">
+      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-border bg-background/95 px-2 py-1.5 shadow-sm">
+        {options.map((entry) => (
+          <Button
+            key={entry.id}
+            type="button"
+            size="xs"
+            variant={value === entry.id ? "default" : "ghost"}
+            className={cn(value !== entry.id && "text-muted-foreground")}
+            onClick={() => onChange(entry.id)}
+            aria-pressed={value === entry.id}
+          >
+            {entry.label} · {entry.pattern}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import type { FactoriesWorkOrder, FactoriesWorkOrderExecution, FactoriesWorkOrderLineDispatch } from "@/api-client";
+
+import { OPEN_WORK_ORDER } from "../../__fixtures__/factoryPageResponses";
+import { popupFixtureForWorkOrder } from "./workOrderPopupMocks";
+
+const WAITING_NOTE = OPEN_WORK_ORDER.statusNotes;
+
+function dispatch(state: FactoriesWorkOrderLineDispatch["state"], stepExecutions: FactoriesWorkOrderExecution[]) {
+  return {
+    id: "dispatch-1",
+    line: { id: "line-1", name: "plan-and-implement" },
+    state,
+    stepExecutions,
+  };
+}
+
+function order(overrides: FactoriesWorkOrder): FactoriesWorkOrder {
+  return { id: "wo-1", ...overrides };
+}
+
+describe("popupFixtureForWorkOrder", () => {
+  it("hides notes and scores on a running plan job", () => {
+    const fixture = popupFixtureForWorkOrder(
+      order({
+        title: "Plan job",
+        state: "STATE_OPEN",
+        statusNotes: WAITING_NOTE,
+        lineDispatches: [
+          dispatch("STATE_ACTIVE", [
+            { id: "e-plan", step: "Plan", stepIndex: 0, state: "STATE_STARTED", result: "RESULT_UNKNOWN" },
+          ]),
+        ],
+      }),
+    );
+
+    expect(fixture.waitingNotes).toEqual([]);
+    expect(fixture.checks).toEqual([]);
+    expect(fixture.log.map((entry) => [entry.actor, entry.state])).toEqual([
+      ["Backlog", "passed"],
+      ["Plan", "running"],
+    ]);
+    expect(fixture.log[0]?.title).toBe("Create work order");
+    expect(fixture.log[0]?.artifactId).toBe("art-description");
+  });
+
+  it("shows scores only on the verify phase", () => {
+    const fixture = popupFixtureForWorkOrder(
+      order({
+        title: "Verify job",
+        state: "STATE_OPEN",
+        statusNotes: WAITING_NOTE,
+        lineDispatches: [
+          dispatch("STATE_ACTIVE", [
+            { id: "e-plan", step: "Plan", stepIndex: 0, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            { id: "e-impl", step: "Implement", stepIndex: 1, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            { id: "e-verify", step: "Verify", stepIndex: 2, state: "STATE_STARTED", result: "RESULT_UNKNOWN" },
+          ]),
+        ],
+      }),
+    );
+
+    expect(fixture.waitingNotes).toEqual([]);
+    expect(fixture.checks.length).toBeGreaterThan(0);
+    expect(fixture.log.map((entry) => entry.actor)).toEqual(["Backlog", "Plan", "Implement", "Verify"]);
+    expect(fixture.log.at(-1)?.state).toBe("running");
+  });
+
+  it("shows notes only when the work order is waiting", () => {
+    const fixture = popupFixtureForWorkOrder(
+      order({
+        title: "Waiting job",
+        state: "STATE_OPEN",
+        statusNotes: WAITING_NOTE,
+        lineDispatches: [
+          dispatch("STATE_FINISHED", [
+            { id: "e-plan", step: "Plan", stepIndex: 0, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            { id: "e-impl", step: "Implement", stepIndex: 1, state: "STATE_FINISHED", result: "RESULT_FAILED" },
+          ]),
+        ],
+      }),
+    );
+
+    expect(fixture.waitingNotes.map((note) => note.headline)).toEqual(["Review the pull request"]);
+    expect(fixture.checks).toEqual([]);
+    expect(fixture.log.at(-1)?.state).toBe("failed");
+  });
+
+  it("hides notes and scores on a completed done job", () => {
+    const fixture = popupFixtureForWorkOrder(
+      order({
+        title: "Done job",
+        state: "STATE_CLOSED",
+        result: "RESULT_COMPLETED",
+        statusNotes: WAITING_NOTE,
+        lineDispatches: [
+          dispatch("STATE_FINISHED", [
+            { id: "e-plan", step: "Plan", stepIndex: 0, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            { id: "e-impl", step: "Implement", stepIndex: 1, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            { id: "e-verify", step: "Verify", stepIndex: 2, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            { id: "e-done", step: "Done", stepIndex: 3, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+          ]),
+        ],
+      }),
+    );
+
+    expect(fixture.waitingNotes).toEqual([]);
+    expect(fixture.checks).toEqual([]);
+    expect(fixture.log.map((entry) => entry.actor)).toEqual(["Backlog", "Plan", "Implement", "Verify", "Done"]);
+  });
+
+  it("shows a backlog create step with description.md for a user draft", () => {
+    const fixture = popupFixtureForWorkOrder(
+      order({
+        title: "Draft job",
+        description: "User-written scope.",
+        state: "STATE_DRAFT",
+        createdBy: { user: { id: "user-1", name: "Ada" } },
+        statusNotes: WAITING_NOTE,
+        lineDispatches: [],
+      }),
+    );
+
+    expect(fixture.waitingNotes).toEqual([]);
+    expect(fixture.checks).toEqual([]);
+    expect(fixture.log.map((entry) => [entry.actor, entry.title, entry.state])).toEqual([
+      ["Backlog", "Create work order", "passed"],
+    ]);
+    expect(fixture.log[0]?.artifactId).toBe("art-description");
+    expect(fixture.description.data).toMatchObject({ name: "description.md", body: "User-written scope." });
+  });
+
+  it("shows a backlog ingest step for an automation draft", () => {
+    const fixture = popupFixtureForWorkOrder(
+      order({
+        title: "Ingested job",
+        description: "Issue body from GitHub.",
+        state: "STATE_DRAFT",
+        createdBy: { automation: { appId: "app-ingest", appName: "Ingest", nodeName: "Create Work Order" } },
+        lineDispatches: [],
+      }),
+    );
+
+    expect(fixture.log.map((entry) => [entry.actor, entry.title, entry.state])).toEqual([
+      ["Backlog", "Create work order from GitHub issue", "passed"],
+    ]);
+    expect(fixture.log[0]?.artifactId).toBe("art-description");
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.spec.ts
@@ -106,7 +106,87 @@ describe("popupFixtureForWorkOrder", () => {
 
     expect(fixture.waitingNotes).toEqual([]);
     expect(fixture.checks).toEqual([]);
-    expect(fixture.log.map((entry) => entry.actor)).toEqual(["Backlog", "Plan", "Implement", "Verify", "Done"]);
+    expect(fixture.log.map((entry) => [entry.actor, entry.title])).toEqual([
+      ["Backlog", "Create work order"],
+      ["Plan", "Plan"],
+      ["Implement", "Implement"],
+      ["Verify", "Verify"],
+      ["Done", "Complete work order"],
+    ]);
+  });
+
+  it("shows a PR Closure complete step with the pull request", () => {
+    const fixture = popupFixtureForWorkOrder(
+      order({
+        title: "Merged job",
+        state: "STATE_CLOSED",
+        result: "RESULT_COMPLETED",
+        lineDispatches: [
+          dispatch("STATE_FINISHED", [
+            { id: "e-plan", step: "Plan", stepIndex: 0, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            { id: "e-impl", step: "Implement", stepIndex: 1, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            { id: "e-verify", step: "Verify", stepIndex: 2, state: "STATE_FINISHED", result: "RESULT_PASSED" },
+            {
+              id: "e-done",
+              step: "Done",
+              stepIndex: 3,
+              state: "STATE_FINISHED",
+              result: "RESULT_PASSED",
+              run: { appId: "app-refund-done", appName: "PR Closure" },
+            },
+          ]),
+        ],
+      }),
+    );
+
+    expect(fixture.log.at(-1)).toMatchObject({
+      actor: "Done",
+      title: "Complete work order from merged pull request",
+      artifactId: "art-pr-closure",
+    });
+  });
+
+  it("shows reject titles for a user and for PR Closure", () => {
+    const userReject = popupFixtureForWorkOrder(
+      order({
+        title: "User reject",
+        state: "STATE_CLOSED",
+        result: "RESULT_REJECTED",
+        lineDispatches: [
+          dispatch("STATE_FINISHED", [
+            {
+              id: "e-done",
+              step: "Done",
+              stepIndex: 3,
+              state: "STATE_FINISHED",
+              result: "RESULT_PASSED",
+            },
+          ]),
+        ],
+      }),
+    );
+    const automationReject = popupFixtureForWorkOrder(
+      order({
+        title: "Automation reject",
+        state: "STATE_CLOSED",
+        result: "RESULT_REJECTED",
+        lineDispatches: [
+          dispatch("STATE_FINISHED", [
+            {
+              id: "e-done",
+              step: "Done",
+              stepIndex: 3,
+              state: "STATE_FINISHED",
+              result: "RESULT_PASSED",
+              run: { appId: "app-refund-done", appName: "PR Closure" },
+            },
+          ]),
+        ],
+      }),
+    );
+
+    expect(userReject.log.at(-1)?.title).toBe("Reject work order");
+    expect(automationReject.log.at(-1)?.title).toBe("Reject work order from closed pull request");
   });
 
   it("shows a backlog create step with description.md for a user draft", () => {

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.ts
@@ -211,6 +211,18 @@ export function buildPopupDispatchEvent(fixture: PopupFixture): WorkOrderTimelin
 }
 
 const PHASE_NAMES = ["Plan", "Implement", "Verify", "Done"] as const;
+const PR_CLOSURE_APP_NAME = "PR Closure";
+
+export const PR_CLOSURE_PR_ARTIFACT: FactoriesWorkOrderArtifact = {
+  id: "art-pr-closure",
+  type: "TYPE_PR",
+  data: {
+    url: "https://github.com/example/ledger/pull/510",
+    title: "Send refund receipts after provider confirm",
+    number: 510,
+    state: "merged",
+  },
+};
 
 function descriptionArtifactForOrder(order: FactoriesWorkOrder): FactoriesWorkOrderArtifact {
   return {
@@ -281,7 +293,8 @@ export function popupFixtureForWorkOrder(order?: FactoriesWorkOrder): PopupFixtu
       ? presentWorkOrderChecks(OPEN_WORK_ORDER_CHECKS).filter((check) => check.id !== "check-confidence")
       : [],
     description: descriptionArtifactForOrder(order),
-    log: [backlogLogEntry(order), ...executions.map(executionToLogEntry)],
+    outputs: executions.some(isPrClosureRun) ? [PR_CLOSURE_PR_ARTIFACT] : [],
+    log: [backlogLogEntry(order), ...executions.map((execution) => executionToLogEntry(order, execution))],
     elapsed: displayStatus === "draft" ? "Not started" : base.elapsed,
     owner: ownerForOrder(order, base.owner),
   };
@@ -316,16 +329,30 @@ function pickCurrentExecution(executions: FactoriesWorkOrderExecution[]): Factor
   }, undefined);
 }
 
-function executionToLogEntry(execution: FactoriesWorkOrderExecution): PopupLogEntry {
+function isPrClosureRun(execution: FactoriesWorkOrderExecution): boolean {
+  return execution.run?.appName === PR_CLOSURE_APP_NAME;
+}
+
+function doneLogTitle(order: FactoriesWorkOrder, execution: FactoriesWorkOrderExecution): string {
+  const fromPullRequest = isPrClosureRun(execution);
+  if (order.result === "RESULT_REJECTED") {
+    return fromPullRequest ? "Reject work order from closed pull request" : "Reject work order";
+  }
+  return fromPullRequest ? "Complete work order from merged pull request" : "Complete work order";
+}
+
+function executionToLogEntry(order: FactoriesWorkOrder, execution: FactoriesWorkOrderExecution): PopupLogEntry {
   const stepIndex = execution.stepIndex ?? 0;
   const actor = PHASE_NAMES[stepIndex] ?? execution.step ?? "Step";
   const state = logStateForExecution(execution);
+  const isDone = stepIndex === 3;
   return {
     id: execution.id ?? actor,
     actor,
-    title: execution.step ?? actor,
+    title: isDone ? doneLogTitle(order, execution) : (execution.step ?? actor),
     duration: state === "running" ? "4m so far" : "1m 12s",
     state,
+    artifactId: isDone && isPrClosureRun(execution) ? PR_CLOSURE_PR_ARTIFACT.id : undefined,
   };
 }
 

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.ts
@@ -1,0 +1,221 @@
+import type { FactoriesWorkOrder, FactoriesWorkOrderArtifact } from "@/api-client";
+import { getUserInitials, type OrgUserDisplay } from "@/lib/orgUserDisplay";
+
+import { OPEN_WORK_ORDER_ARTIFACTS } from "../../__fixtures__/factoryPageFixtureVariants";
+import {
+  HOUR_AGO,
+  OPEN_WORK_ORDER,
+  STORYBOOK_ME_USER_AVATAR_URL,
+  STORYBOOK_ME_USER_ID,
+  STORYBOOK_ME_USER_NAME,
+} from "../../__fixtures__/factoryPageResponses";
+import { OPEN_WORK_ORDER_CHECKS } from "../../__fixtures__/workOrderCheckFixtures";
+import { toArtifactDataRecord } from "../../lib/workOrderArtifact";
+import { presentWorkOrderChecks, type WorkOrderCheckPresentation } from "../../lib/workOrderChecks";
+import { presentWorkOrderStatusNotes, type WorkOrderStatusNotePresentation } from "../../lib/workOrderStatusNote";
+import type { WorkOrderTimelineEvent, WorkOrderTimelineStep } from "../../lib/workOrderTimelineEvents";
+
+export type PopupConcept = "session" | "trace" | "job";
+
+export type PopupLogState = "passed" | "running" | "waiting";
+
+export interface PopupLogEntry {
+  id: string;
+  actor: string;
+  title: string;
+  detail?: string;
+  duration: string;
+  state: PopupLogState;
+  artifactId?: string;
+}
+
+export interface PopupFixture {
+  title: string;
+  owner: OrgUserDisplay;
+  elapsed: string;
+  startedLabel: string;
+  costUsd: string;
+  tokensLabel: string;
+  description: FactoriesWorkOrderArtifact;
+  outputs: FactoriesWorkOrderArtifact[];
+  checks: WorkOrderCheckPresentation[];
+  waitingNotes: WorkOrderStatusNotePresentation[];
+  log: PopupLogEntry[];
+}
+
+const DESCRIPTION_BODY = OPEN_WORK_ORDER.description ?? "";
+
+export const DESCRIPTION_ARTIFACT: FactoriesWorkOrderArtifact = {
+  id: "art-description",
+  type: "TYPE_MARKDOWN",
+  data: {
+    name: "description.md",
+    title: "description.md",
+    body: DESCRIPTION_BODY,
+  },
+};
+
+export const AGENT_WORK_POPUP: PopupFixture = {
+  title: "Reconcile duplicate refunds in ledger",
+  owner: {
+    id: STORYBOOK_ME_USER_ID,
+    name: STORYBOOK_ME_USER_NAME,
+    initials: getUserInitials(STORYBOOK_ME_USER_NAME),
+    avatarUrl: STORYBOOK_ME_USER_AVATAR_URL,
+  },
+  elapsed: "12 min",
+  startedLabel: "Started 1h ago",
+  costUsd: "$4.18",
+  tokensLabel: "86k tokens",
+  description: DESCRIPTION_ARTIFACT,
+  outputs: OPEN_WORK_ORDER_ARTIFACTS,
+  checks: presentWorkOrderChecks(OPEN_WORK_ORDER_CHECKS).filter((check) => check.id !== "check-confidence"),
+  waitingNotes: presentWorkOrderStatusNotes(OPEN_WORK_ORDER.statusNotes),
+  log: [
+    {
+      id: "plan",
+      actor: "Plan",
+      title: "Write description.md",
+      duration: "1m 12s",
+      state: "passed",
+      artifactId: "art-description",
+    },
+    {
+      id: "implement",
+      actor: "Implement",
+      title: "Create feature/refund-retry",
+      duration: "7s",
+      state: "passed",
+      artifactId: "art-branch-1",
+    },
+    {
+      id: "verify",
+      actor: "Verify",
+      title: "Open PR #482",
+      duration: "5s",
+      state: "passed",
+      artifactId: "art-pr-1",
+    },
+    {
+      id: "done",
+      actor: "Done",
+      title: "Attach investigation notes",
+      duration: "2s",
+      state: "passed",
+      artifactId: "art-md-1",
+    },
+  ],
+};
+
+/** In-flight job: scores arrive after automations finish. The log stays visible. */
+export const AGENT_WORK_POPUP_RUNNING: PopupFixture = {
+  ...AGENT_WORK_POPUP,
+  title: "Add refund reconciliation test",
+  elapsed: "4 min so far",
+  startedLabel: "Started 1h ago",
+  costUsd: "$0.73",
+  tokensLabel: "2.7k tokens",
+  outputs: [],
+  checks: [],
+  waitingNotes: [],
+  log: [
+    {
+      id: "plan",
+      actor: "Plan",
+      title: "Write test plan",
+      duration: "1m 48s",
+      state: "passed",
+    },
+    {
+      id: "implement",
+      actor: "Implement",
+      title: "Add reconciliation test",
+      duration: "4m so far",
+      state: "running",
+    },
+  ],
+};
+
+export function buildPopupDispatchEvent(fixture: PopupFixture): WorkOrderTimelineEvent | null {
+  if (fixture.log.length === 0) {
+    return null;
+  }
+
+  const artifacts = [fixture.description, ...fixture.outputs];
+  let cursor = Date.parse(HOUR_AGO);
+  const steps: WorkOrderTimelineStep[] = fixture.log.map((entry) => {
+    const startedAt = new Date(cursor).toISOString();
+    const durationMs = logDurationMs(entry.duration);
+    const finishedAt = durationMs != null ? new Date(cursor + durationMs).toISOString() : undefined;
+    cursor += durationMs ?? 60_000;
+    const execution = logExecution(entry.state);
+    const artifact = entry.artifactId ? artifacts.find((item) => item.id === entry.artifactId) : undefined;
+
+    return {
+      id: entry.id,
+      stepName: entry.actor,
+      at: finishedAt ?? startedAt,
+      startedAt,
+      finishedAt,
+      artifacts: artifact
+        ? [
+            {
+              id: artifact.id,
+              type: artifact.type ?? "TYPE_UNSPECIFIED",
+              data: toArtifactDataRecord(artifact.data),
+            },
+          ]
+        : undefined,
+      execution: {
+        id: entry.id,
+        step: entry.actor,
+        state: execution.state,
+        result: execution.result,
+        createdAt: startedAt,
+        updatedAt: finishedAt ?? startedAt,
+        run: { appName: entry.actor },
+      },
+    };
+  });
+
+  return {
+    id: "popup-dispatch",
+    kind: "dispatched",
+    at: steps[0]?.startedAt ?? HOUR_AGO,
+    lineName: "plan-and-implement",
+    title: "Dispatched to plan-and-implement",
+    steps,
+  };
+}
+
+export function popupFixtureForWorkOrder(order?: FactoriesWorkOrder): PopupFixture {
+  const running = (order?.lineDispatches ?? []).some((dispatch) =>
+    (dispatch.stepExecutions ?? []).some((execution) => execution.state === "STATE_STARTED"),
+  );
+  const base = running ? AGENT_WORK_POPUP_RUNNING : AGENT_WORK_POPUP;
+  return {
+    ...base,
+    title: order?.title ?? base.title,
+  };
+}
+
+function logDurationMs(duration: string): number | null {
+  if (duration.includes("so far")) {
+    return null;
+  }
+
+  const minutes = duration.match(/(\d+)\s*m/);
+  const seconds = duration.match(/(\d+)\s*s/);
+  const ms = (minutes ? Number(minutes[1]) * 60_000 : 0) + (seconds ? Number(seconds[1]) * 1000 : 0);
+  return ms > 0 ? ms : null;
+}
+
+function logExecution(state: PopupLogState): { state: string; result: string } {
+  if (state === "passed") {
+    return { state: "STATE_FINISHED", result: "RESULT_PASSED" };
+  }
+  if (state === "waiting") {
+    return { state: "STATE_PENDING", result: "RESULT_UNKNOWN" };
+  }
+  return { state: "STATE_STARTED", result: "RESULT_UNKNOWN" };
+}

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/workOrderPopupMocks.ts
@@ -1,4 +1,9 @@
-import type { FactoriesWorkOrder, FactoriesWorkOrderArtifact } from "@/api-client";
+import type {
+  FactoriesWorkOrder,
+  FactoriesWorkOrderArtifact,
+  FactoriesWorkOrderExecution,
+  FactoriesWorkOrderLineDispatch,
+} from "@/api-client";
 import { getUserInitials, type OrgUserDisplay } from "@/lib/orgUserDisplay";
 
 import { OPEN_WORK_ORDER_ARTIFACTS } from "../../__fixtures__/factoryPageFixtureVariants";
@@ -12,12 +17,13 @@ import {
 import { OPEN_WORK_ORDER_CHECKS } from "../../__fixtures__/workOrderCheckFixtures";
 import { toArtifactDataRecord } from "../../lib/workOrderArtifact";
 import { presentWorkOrderChecks, type WorkOrderCheckPresentation } from "../../lib/workOrderChecks";
+import { getWorkOrderDisplayStatus } from "../../lib/workOrderProgress";
 import { presentWorkOrderStatusNotes, type WorkOrderStatusNotePresentation } from "../../lib/workOrderStatusNote";
 import type { WorkOrderTimelineEvent, WorkOrderTimelineStep } from "../../lib/workOrderTimelineEvents";
 
 export type PopupConcept = "session" | "trace" | "job";
 
-export type PopupLogState = "passed" | "running" | "waiting";
+export type PopupLogState = "passed" | "running" | "waiting" | "failed";
 
 export interface PopupLogEntry {
   id: string;
@@ -73,12 +79,19 @@ export const AGENT_WORK_POPUP: PopupFixture = {
   waitingNotes: presentWorkOrderStatusNotes(OPEN_WORK_ORDER.statusNotes),
   log: [
     {
-      id: "plan",
-      actor: "Plan",
-      title: "Write description.md",
-      duration: "1m 12s",
+      id: "backlog",
+      actor: "Backlog",
+      title: "Create work order",
+      duration: "2s",
       state: "passed",
       artifactId: "art-description",
+    },
+    {
+      id: "plan",
+      actor: "Plan",
+      title: "Write investigation notes",
+      duration: "1m 12s",
+      state: "passed",
     },
     {
       id: "implement",
@@ -119,6 +132,14 @@ export const AGENT_WORK_POPUP_RUNNING: PopupFixture = {
   checks: [],
   waitingNotes: [],
   log: [
+    {
+      id: "backlog",
+      actor: "Backlog",
+      title: "Create work order",
+      duration: "2s",
+      state: "passed",
+      artifactId: "art-description",
+    },
     {
       id: "plan",
       actor: "Plan",
@@ -166,6 +187,7 @@ export function buildPopupDispatchEvent(fixture: PopupFixture): WorkOrderTimelin
             },
           ]
         : undefined,
+      comments: entry.title !== entry.actor ? [{ body: entry.title }] : undefined,
       execution: {
         id: entry.id,
         step: entry.actor,
@@ -188,15 +210,139 @@ export function buildPopupDispatchEvent(fixture: PopupFixture): WorkOrderTimelin
   };
 }
 
+const PHASE_NAMES = ["Plan", "Implement", "Verify", "Done"] as const;
+
+function descriptionArtifactForOrder(order: FactoriesWorkOrder): FactoriesWorkOrderArtifact {
+  return {
+    ...DESCRIPTION_ARTIFACT,
+    data: {
+      name: "description.md",
+      title: "description.md",
+      body: order.description ?? "",
+    },
+  };
+}
+
+function backlogLogEntry(order: FactoriesWorkOrder): PopupLogEntry {
+  const ingested = Boolean(order.createdBy?.automation);
+  return {
+    id: "backlog",
+    actor: "Backlog",
+    title: ingested ? "Create work order from GitHub issue" : "Create work order",
+    duration: "2s",
+    state: "passed",
+    artifactId: "art-description",
+  };
+}
+
+function ownerForOrder(order: FactoriesWorkOrder, fallback: OrgUserDisplay): OrgUserDisplay {
+  const automation = order.createdBy?.automation;
+  if (automation) {
+    const name = automation.appName?.trim() || automation.nodeName?.trim();
+    if (name) {
+      return {
+        id: automation.appId || automation.nodeId || name,
+        name,
+        initials: getUserInitials(name) || "A",
+      };
+    }
+  }
+
+  const user = order.createdBy?.user;
+  if (user?.id || user?.name) {
+    const name = user.name?.trim() || fallback.name;
+    return {
+      id: user.id ?? fallback.id,
+      name,
+      initials: getUserInitials(name),
+      avatarUrl: user.id === STORYBOOK_ME_USER_ID ? STORYBOOK_ME_USER_AVATAR_URL : undefined,
+    };
+  }
+
+  return fallback;
+}
+
 export function popupFixtureForWorkOrder(order?: FactoriesWorkOrder): PopupFixture {
-  const running = (order?.lineDispatches ?? []).some((dispatch) =>
-    (dispatch.stepExecutions ?? []).some((execution) => execution.state === "STATE_STARTED"),
-  );
-  const base = running ? AGENT_WORK_POPUP_RUNNING : AGENT_WORK_POPUP;
+  if (!order) {
+    return AGENT_WORK_POPUP;
+  }
+
+  const displayStatus = getWorkOrderDisplayStatus(order);
+  const executions = latestDispatchExecutions(order);
+  const current = pickCurrentExecution(executions);
+  const inVerify = current?.stepIndex === 2;
+  const base = displayStatus === "running" ? AGENT_WORK_POPUP_RUNNING : AGENT_WORK_POPUP;
+
   return {
     ...base,
-    title: order?.title ?? base.title,
+    title: order.title ?? base.title,
+    waitingNotes: displayStatus === "waiting" ? presentWorkOrderStatusNotes(order.statusNotes, displayStatus) : [],
+    checks: inVerify
+      ? presentWorkOrderChecks(OPEN_WORK_ORDER_CHECKS).filter((check) => check.id !== "check-confidence")
+      : [],
+    description: descriptionArtifactForOrder(order),
+    log: [backlogLogEntry(order), ...executions.map(executionToLogEntry)],
+    elapsed: displayStatus === "draft" ? "Not started" : base.elapsed,
+    owner: ownerForOrder(order, base.owner),
   };
+}
+
+function latestDispatchExecutions(order: FactoriesWorkOrder): FactoriesWorkOrderExecution[] {
+  const dispatches = order.lineDispatches ?? [];
+  if (dispatches.length === 0) {
+    return [];
+  }
+  const latest = dispatches.reduce((best: FactoriesWorkOrderLineDispatch, candidate) => {
+    const bestAt = Date.parse(best.createdAt ?? "") || 0;
+    const candidateAt = Date.parse(candidate.createdAt ?? "") || 0;
+    return candidateAt >= bestAt ? candidate : best;
+  });
+  return latest.stepExecutions ?? [];
+}
+
+function pickCurrentExecution(executions: FactoriesWorkOrderExecution[]): FactoriesWorkOrderExecution | undefined {
+  const active = executions.filter(
+    (execution) =>
+      execution.state === "STATE_STARTED" ||
+      execution.state === "STATE_PENDING" ||
+      execution.state === "STATE_CANCELLING",
+  );
+  const pool = active.length > 0 ? active : executions;
+  return pool.reduce<FactoriesWorkOrderExecution | undefined>((best, candidate) => {
+    if (!best) {
+      return candidate;
+    }
+    return (candidate.stepIndex ?? -1) >= (best.stepIndex ?? -1) ? candidate : best;
+  }, undefined);
+}
+
+function executionToLogEntry(execution: FactoriesWorkOrderExecution): PopupLogEntry {
+  const stepIndex = execution.stepIndex ?? 0;
+  const actor = PHASE_NAMES[stepIndex] ?? execution.step ?? "Step";
+  const state = logStateForExecution(execution);
+  return {
+    id: execution.id ?? actor,
+    actor,
+    title: execution.step ?? actor,
+    duration: state === "running" ? "4m so far" : "1m 12s",
+    state,
+  };
+}
+
+function logStateForExecution(execution: FactoriesWorkOrderExecution): PopupLogState {
+  if (execution.state === "STATE_STARTED" || execution.state === "STATE_CANCELLING") {
+    return "running";
+  }
+  if (execution.state === "STATE_PENDING") {
+    return "waiting";
+  }
+  if (execution.result === "RESULT_FAILED") {
+    return "failed";
+  }
+  if (execution.result === "RESULT_PASSED") {
+    return "passed";
+  }
+  return "waiting";
 }
 
 function logDurationMs(duration: string): number | null {
@@ -216,6 +362,9 @@ function logExecution(state: PopupLogState): { state: string; result: string } {
   }
   if (state === "waiting") {
     return { state: "STATE_PENDING", result: "RESULT_UNKNOWN" };
+  }
+  if (state === "failed") {
+    return { state: "STATE_FINISHED", result: "RESULT_FAILED" };
   }
   return { state: "STATE_STARTED", result: "RESULT_UNKNOWN" };
 }

--- a/web_src/src/pages/factories/pages/work-order-run-overlay/runOverlayShared.tsx
+++ b/web_src/src/pages/factories/pages/work-order-run-overlay/runOverlayShared.tsx
@@ -46,14 +46,25 @@ export function RunOverlayFrame({
   testId,
   wide = false,
   canvas = false,
+  fixed = false,
+  onDismiss,
 }: {
   children: ReactNode;
   testId: string;
   wide?: boolean;
   canvas?: boolean;
+  /** Cover the viewport. Use on the live line board so overflow does not clip the dialog. */
+  fixed?: boolean;
+  onDismiss?: () => void;
 }) {
   return (
-    <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-3 sm:p-6">
+    <div
+      className={cn(
+        "inset-0 z-50 flex items-center justify-center bg-black/50 p-3 sm:p-6",
+        fixed ? "fixed" : "absolute",
+      )}
+      onClick={onDismiss}
+    >
       <div
         className={cn(
           "flex max-h-[min(52rem,calc(100vh-2.5rem))] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg dark:bg-gray-900",
@@ -66,6 +77,7 @@ export function RunOverlayFrame({
         data-testid={testId}
         role="dialog"
         aria-modal="true"
+        onClick={(event) => event.stopPropagation()}
       >
         {children}
       </div>

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
@@ -71,6 +71,7 @@ interface WorkOrderBoardLaneProps {
   actions?: ReactNode;
   /** Accessible name, when it must read differently from the title. */
   label?: string;
+  className?: string;
   testId?: string;
   children?: ReactNode;
 }
@@ -83,6 +84,7 @@ export function WorkOrderBoardLane({
   leading,
   actions,
   label,
+  className,
   testId,
   children,
 }: WorkOrderBoardLaneProps) {
@@ -93,6 +95,7 @@ export function WorkOrderBoardLane({
         "flex min-h-0 flex-col self-stretch rounded-lg border border-border/70 p-2",
         workOrderKanbanLaneSizeClassName,
         LANE_TONE_CLASSNAME[tone],
+        className,
       )}
       data-testid={testId}
     >


### PR DESCRIPTION
## Summary

The work-order peek read as a ticket. The line board now opens a job report with the next step, scores after the job ends, and a live log.

Each line also shows a factory Backlog column for draft work. Backlog uses a gray fill and an inbox icon so it is not a line phase.


Made with [Cursor](https://cursor.com)