### PR TITLE
fix: keep factory step selects controlled

### DIFF
--- a/web_src/src/pages/factories/FactoryLineStepEditor.tsx
+++ b/web_src/src/pages/factories/FactoryLineStepEditor.tsx
@@ -39,7 +39,7 @@ export function FactoryLineStepEditor({
         <div className={cn("space-y-2", stepFieldClassName)}>
           <Label htmlFor={`factory-line-step-app-${index}`}>Automation</Label>
           <Select
-            value={step.appId || undefined}
+            value={step.appId}
             onValueChange={(appId) => onChange({ ...step, appId, entrypoint: "" })}
           >
             <SelectTrigger id={`factory-line-step-app-${index}`} className={stepFieldClassName}>
@@ -58,7 +58,7 @@ export function FactoryLineStepEditor({
         <div className={cn("space-y-2", stepFieldClassName)}>
           <Label htmlFor={`factory-line-step-entrypoint-${index}`}>Trigger</Label>
           <Select
-            value={step.entrypoint || undefined}
+            value={step.entrypoint}
             onValueChange={(entrypoint) => onChange({ ...step, entrypoint })}
             disabled={!step.appId || canvasLoading}
           >


### PR DESCRIPTION
## What

Keeps the factory line step selects controlled when their selected values
are derived from the current step configuration.

## Why

Prevents the select inputs from receiving inconsistent controlled/uncontrolled
state while editing factory line steps.

## Testing

- Verified the affected component change locally.
- Existing test suite was not run because dependencies were not installed
  in the local web_src workspace.