### PR TITLE
feat: Add intake drawer and quieter line board

### DIFF
--- a/docs/prd/onboarding-first-run.md
+++ b/docs/prd/onboarding-first-run.md
@@ -1,0 +1,293 @@
+# Onboarding First Run — Copy and UX
+
+> Status: Draft
+>
+> This document specifies the first steps of a new post-login onboarding
+> flow: greeting, connections, and analysis. After analysis, SuperPlane
+> opens the workspace board. It is a copy and UX specification only. It
+> does not change the existing workspace setup wizard, and it does not
+> specify backend behavior beyond what the screens require.
+
+## Overview
+
+A new user signs in and must reach the workspace board. Everything in
+this flow exists to connect a repository and a ticket system, run the
+first analysis, and open the board. The scored ticket list is a board
+surface, not an onboarding screen.
+
+The flow makes two promises and must keep both visible:
+
+1. SuperPlane does not start work and does not change tickets.
+2. SuperPlane does not change code without approval on a specific ticket.
+
+Vocabulary: this flow says **ticket** for one item of backlog work
+(a GitHub issue, a Jira issue, or a Linear issue) and **backlog** for the
+collection. It says **confidence score** for the 65–95% rating. Use these
+terms consistently on every screen.
+
+## Flow
+
+Five onboarding screens. Analysis then opens the board.
+
+```mermaid
+flowchart LR
+    login[Sign in with GitHub or Google] --> welcome[1 Welcome]
+    welcome --> github[2 Connect GitHub]
+    github --> pick[3 Choose repository]
+    pick --> tickets[4 Connect ticket system]
+    tickets --> analysis[5 Analysis]
+    analysis --> board[Workspace board]
+```
+
+### Entry conditions
+
+- The flow starts after the first sign-in, when the organization has no
+  connected repository.
+- A returning user who abandoned the flow resumes at the first incomplete
+  screen. Completed connections stay completed.
+
+### Login provider does not change the flow
+
+The greeting and all five screens are identical for GitHub and Google
+sign-in. One nuance the UI must respect: signing in with GitHub does not
+grant repository access. OAuth sign-in and GitHub App installation are
+separate grants. Every user sees the same `Connect GitHub` step, and the
+copy must never imply that a GitHub-login user is already connected.
+
+### Layout
+
+Every onboarding screen uses the same chrome, from Linear web
+onboarding (Mobbin):
+
+- The content block is centered in the viewport, horizontally and
+  vertically.
+- Top left: `Log out`.
+- Top right: `Logged in as` and the user email.
+- Bottom center: five step dots.
+- SuperPlane type, buttons, and tokens. Do not copy Linear colors.
+
+### Screen 1 — Welcome
+
+One job: show the payoff and invite the user in. No permission ask on
+this screen (see Decision below).
+
+Layout, top to bottom:
+
+1. Greeting (`Hi {firstName}.`) when the name is known.
+2. Headline and one intro sentence.
+3. Result preview: a static scored ticket list (65–95%).
+4. One button: `Get started`.
+
+### Screen 2 — Connect GitHub
+
+One job: ask for repository access.
+
+Layout, top to bottom:
+
+1. Headline and body: SuperPlane reads repositories and does not start
+   work yet.
+2. `Connect GitHub`.
+3. One helper line under the button: SuperPlane does not change code
+   without approval.
+
+Connecting GitHub opens the GitHub App installation. On return, the
+screen shows `Connected` and `Choose a repository`.
+
+### Screen 3 — Choose repository
+
+A searchable GitHub repository list. The user picks the repository
+SuperPlane will analyze. Tickets are not on this screen.
+
+The primary button names the current task: `Choose a repository to continue`.
+
+### Screen 4 — Connect ticket system
+
+One job: choose where tickets live for the selected repository.
+
+Layout, top to bottom:
+
+1. Headline, the repository name, and one body sentence.
+2. Ticket options: GitHub Issues, Jira, Linear.
+3. Helper: the analysis starts when the user chooses a source.
+
+GitHub Issues requires no second connection; it reuses the GitHub
+connection and the selected repository. Jira and Linear open their own
+connect dialogs. Choosing GitHub Issues starts the analysis.
+
+### Screen 5 — Analysis
+
+A waiting screen with an honest time expectation and staged progress
+lines. The stages tell the user what SuperPlane reads, and the copy
+repeats that nothing is changed. If the analysis runs longer than the
+stated time, the screen must say so rather than spin silently.
+
+The user can leave. When the analysis finishes, SuperPlane opens the
+workspace board. The scored ticket list is not an onboarding screen.
+
+## Decision: one screen or two for welcome and connect
+
+The question: one combined screen (intro plus connect actions), or a
+separate welcome page before the connect page?
+
+### Option A — Combined screen
+
+| Pros | Cons |
+| --- | --- |
+| Value and action are visible together | Trust copy competes with the buttons |
+| One less click | The screen looks like a settings form |
+| Trust statements sit next to the permission ask | No room for a greeting or preview to breathe |
+
+### Option B — Separate welcome, then connect (recommended)
+
+| Pros | Cons |
+| --- | --- |
+| One idea per screen: payoff first, then the ask | Adds one click |
+| Trust statements stay next to the permission ask | Users who skip welcome meet the ask with less context |
+| Welcome can use larger type and more space | Two screens to maintain |
+
+### Recommendation
+
+Option B. Review of comparable onboarding on Mobbin (Linear, Height,
+Profound, Gemini) shows the same split: a centered welcome with one
+button, then a dedicated connect step for the permission ask.
+
+Keep a hard copy budget on each screen. Welcome: greeting, headline,
+one intro, caption, `Get started`. Connect: headline, body,
+`Connect GitHub`, one helper line. Permission details stay in the
+connect dialog.
+
+The extra click is cheaper than a first screen that asks for GitHub
+before the user has a reason to care.
+
+## Copy
+
+All strings follow the ui-copy and Simplified Technical English skills:
+active voice, imperative buttons, no contractions, one term per concept,
+instructions within 20 words, descriptions within 25 words.
+
+### Chrome (every onboarding screen)
+
+| Element | Copy |
+| --- | --- |
+| Top left | `Log out` |
+| Top right label | `Logged in as` |
+| Top right value | User email. Use the first name if the email is missing. |
+
+### Screen 1 — Welcome
+
+| Element | Copy |
+| --- | --- |
+| Greeting | `Hi {firstName}.` |
+| Headline | `See what SuperPlane can ship from your backlog` |
+| Intro | `Each ticket is scored by how confident SuperPlane is that an agent can complete it.` |
+| Preview caption | `Example: tickets scored from a real backlog.` |
+| Button, primary | `Get started` |
+
+Personalization: when the sign-in provider supplies a first name, show
+`Hi {firstName}.` as a separate short line above the headline. Do not
+merge the greeting into the headline, and do not block on a missing
+name.
+
+### Screen 2 — Connect GitHub
+
+| Element | Copy |
+| --- | --- |
+| Headline | `Connect GitHub` |
+| Body | `SuperPlane reads your repositories. It does not start work yet.` |
+| Button, primary | `Connect GitHub` |
+| Button state after connect | `Connected` |
+| Button after connect | `Choose a repository` |
+| Helper under button | `SuperPlane does not change code without your approval on a specific ticket.` |
+| Connect error | `SuperPlane could not connect to GitHub. Check your access and try again.` |
+
+### Screen 3 — Choose repository
+
+| Element | Copy |
+| --- | --- |
+| Headline | `Choose a repository` |
+| Repository label | `Repository` |
+| Repository helper | `Select the repository you want SuperPlane to analyze.` |
+| Repository search placeholder | `Search repositories` |
+| Missing repository link | `Do not see your repository? Edit the GitHub connection.` |
+| Button, primary | `Choose a repository to continue` |
+| Helper under button | `You can add more repositories later.` |
+
+### Screen 4 — Connect ticket system
+
+| Element | Copy |
+| --- | --- |
+| Headline | `Connect your ticket system` |
+| Repository caption | `Tickets for {repository}` |
+| Body | `SuperPlane reads tickets for this repository. It does not start work yet.` |
+| Ticket options | `GitHub Issues` / `Jira` / `Linear` |
+| GitHub Issues helper | `Uses GitHub Issues on this repository. No extra setup.` |
+| Jira helper | `Find tickets in your Jira backlog.` |
+| Linear helper | `Find tickets in your Linear backlog.` |
+| Helper under options | `SuperPlane does not start work and does not change your tickets.` |
+| Helper under options | `The analysis starts when you choose a ticket system.` |
+
+### Screen 5 — Analysis
+
+| Element | Copy |
+| --- | --- |
+| Headline | `Analyzing your backlog` |
+| Body | `SuperPlane reads your code and your tickets. This takes a few minutes.` |
+| Reassurance line | `Nothing is changed. No work starts.` |
+| Stage 1 | `Reading the repository structure` |
+| Stage 2 | `Reading open tickets` |
+| Stage 3 | `Scoring each ticket against the codebase` |
+| Leave hint | `You can leave this page. SuperPlane opens the board when the analysis finishes.` |
+| Overrun notice | `The analysis needs more time than usual. It is still running.` |
+| Failure | `The analysis did not finish. Try again.` |
+| Failure button | `Run analysis again` |
+
+## After onboarding — Workspace board
+
+The scored ticket list is a board surface. It is not part of this flow.
+Copy for that surface stays on the board work, not here.
+
+## Best practices and rationale
+
+Each copy decision maps to an established onboarding practice.
+
+**Show the payoff before the permission ask.** The scored-list preview
+sits on the welcome screen. Users grant access more willingly when they
+can see exactly what they get. This is why the headline names the
+outcome (`See what SuperPlane can ship`) instead of the product.
+
+**One primary action per screen.** Welcome has `Get started`. Then
+`Connect GitHub`, then a repository, then a ticket system. Each button
+names the specific action.
+
+**Just-in-time permission detail.** Scope lists and installation
+mechanics live in the connect dialog, at the moment of the grant. The
+connect screen carries only the two behavioral promises. Note: the trust
+statements are behavioral ("does not change code without your approval"),
+not scope claims ("read-only access"). Behavioral promises stay honest
+even when the GitHub App requests write scopes for later pull requests.
+
+**Honest time expectations, never a silent spinner.** The analysis
+screen shows staged progress, an overrun notice when it runs long, and
+a leave hint so the wait never holds the user hostage.
+
+**Trust statements adjacent to the moment of doubt.** The two promises
+appear directly above the connect buttons. The second promise must
+reappear on the board when the user first sees a mutating action.
+
+**Do not block on optional integrations.** GitHub Issues works with zero
+extra setup, so a GitHub-only user reaches the board without touching
+Jira or Linear. Jira and Linear are offered, not required, and can ship
+as "coming soon" without breaking the flow.
+
+**The board closes the loop.** The welcome preview names the outcome.
+The board is where that list lives after analysis.
+
+## Out of scope
+
+- Backend analysis behavior, scoring model, and score thresholds.
+- Changes to the existing workspace setup wizard
+  (`web_src/src/pages/factories/pages/onboarding/`).
+- How scored tickets appear on the workspace board.
+- What happens after ticket approval (work order creation, line
+  dispatch).
+- Email notification when a long analysis finishes.

--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
@@ -8,6 +8,9 @@ import { factorySettingsPath } from "../lib/factoryPagePaths";
 import { FactoriesHarness } from "./FactoriesHarness";
 import { REFUND_IMPLEMENTER_APP, refundLineCanvasFixture } from "./factoryOwnedCanvasFixture";
 import {
+  ACME_ONBOARDING_FACTORY_ID,
+  ACME_ONBOARDING_FACTORY_KEY,
+  ACME_ONBOARDING_LINE_ID,
   FACTORIES_ORGANIZATION_ID,
   LINE_RUN_IMPLEMENT_FAILED_ID,
   PRIMARY_FACTORY_ID,
@@ -15,6 +18,7 @@ import {
   REFUND_FACTORY_LINES,
   defaultFactoriesFixture,
 } from "./factoryPageResponses";
+import { lineMetricsFactoriesFixture } from "./lineMetricsFactoriesFixture";
 import { CONNECTED_SETUP_INTEGRATIONS, SETUP_ANSWERS, factoriesFixtureWithSetupAnswers } from "./setupStoryFixtures";
 
 describe("FactoriesHarness work orders", () => {
@@ -236,6 +240,23 @@ describe("FactoriesHarness workspace setup", () => {
     expect(await screen.findByRole("option", { name: /acme\/api/ }, { timeout: 8000 })).toBeInTheDocument();
   }, 15000);
 
+  it("opens setup after Create new workspace", async () => {
+    const user = userEvent.setup();
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/overview`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    await user.click(await screen.findByTestId("factories-workspace-switch", {}, { timeout: 8000 }));
+    await user.click(screen.getByTestId("factories-workspace-create"));
+
+    expect(await screen.findByTestId("workspace-setup", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(screen.queryByText("The workspace was created without a key")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("factories-sidebar")).not.toBeInTheDocument();
+  }, 15000);
+
   it("opens the step from the URL with the saved answers restored", async () => {
     render(
       <FactoriesHarness
@@ -249,5 +270,66 @@ describe("FactoriesHarness workspace setup", () => {
     expect(
       await screen.findByRole("button", { name: /Change backlog repository/ }, { timeout: 8000 }),
     ).toBeInTheDocument();
+  }, 15000);
+});
+
+describe("FactoriesHarness Acme onboarding", () => {
+  beforeAll(() => {
+    client.setConfig({ baseUrl: "http://localhost" });
+  });
+
+  it("opens Acme onboarding from the switcher with an empty line board", async () => {
+    const user = userEvent.setup();
+    const planLineId = REFUND_FACTORY_LINES[0]?.id;
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${planLineId}`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    await user.click(await screen.findByTestId("factories-workspace-switch", {}, { timeout: 8000 }));
+    await user.click(screen.getByTestId(`factories-workspace-option-${ACME_ONBOARDING_FACTORY_ID}`));
+
+    expect(
+      await screen.findByRole("button", { name: /Switch workspace, Acme onboarding/ }, { timeout: 8000 }),
+    ).toBeInTheDocument();
+    expect(await screen.findByTestId("lines-detail-page", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(screen.getByTestId("lines-column-title-backlog")).toHaveTextContent("Backlog");
+    await waitFor(() => {
+      expect(screen.getByTestId("lines-column-title-phase-0")).toHaveTextContent("Plan");
+    });
+    expect(screen.getByTestId("lines-column-title-phase-1")).toHaveTextContent("Implement");
+    expect(screen.getByTestId("lines-column-title-phase-2")).toHaveTextContent("Verify");
+    expect(screen.getByTestId("lines-column-title-phase-3")).toHaveTextContent("Done");
+    expect(screen.getByTestId("backlog-onboarding-card")).toBeInTheDocument();
+    expect(screen.getByTestId("lines-backlog-column")).not.toHaveTextContent("No work orders in the backlog.");
+    expect(screen.getByTestId("lines-phase-column-0")).toHaveTextContent("Nothing here.");
+    expect(screen.getByTestId("lines-phase-column-1")).toHaveTextContent("Nothing here.");
+    expect(screen.getByTestId("lines-phase-column-2")).toHaveTextContent("Nothing here.");
+    expect(screen.getByTestId("lines-phase-column-3")).toHaveTextContent("Nothing here.");
+    expect(screen.queryAllByTestId(/^work-order-card-/)).toHaveLength(0);
+  }, 15000);
+
+  it("opens the populated Semaphore line board from the first-run Acme board", async () => {
+    const user = userEvent.setup();
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${ACME_ONBOARDING_FACTORY_KEY}/lines/${ACME_ONBOARDING_LINE_ID}?intake=1&source=github-issues`}
+        factoriesFixture={lineMetricsFactoriesFixture}
+        enableOnboarding={false}
+      />,
+    );
+
+    await user.click(await screen.findByTestId("factories-workspace-switch", {}, { timeout: 8000 }));
+    await user.click(screen.getByTestId(`factories-workspace-option-${PRIMARY_FACTORY_ID}`));
+
+    expect(
+      await screen.findByRole("button", { name: /Switch workspace, Semaphore/ }, { timeout: 8000 }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("factories-sidebar")).toBeInTheDocument();
+    expect(await screen.findByTestId("lines-detail-page", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-setup")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId(/^work-order-card-/).length).toBeGreaterThan(0);
   }, 15000);
 });

--- a/web_src/src/pages/factories/__fixtures__/factoryOwnedCanvasFixture.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryOwnedCanvasFixture.ts
@@ -43,6 +43,7 @@ export const REFUND_VERIFIER_APP = REFUND_FACTORY_APPS[2];
 export function factoryOwnedCanvasFixture(
   app: Pick<FactoryApp, "id" | "name" | "description"> = REFUND_PLANNER_APP,
   extras: Partial<CanvasAppFixture> = {},
+  factoryId = PRIMARY_FACTORY_ID,
 ): CanvasAppFixture {
   const baseCanvas = defaultCanvasAppFixture.canvas?.canvas as
     | { metadata?: Record<string, unknown>; spec?: unknown }
@@ -66,7 +67,7 @@ export function factoryOwnedCanvasFixture(
           id: canvasId,
           name: app.name,
           description: app.description,
-          factoryId: PRIMARY_FACTORY_ID,
+          factoryId,
         },
       },
     } as CanvasAppFixture["canvas"],
@@ -129,19 +130,24 @@ export function refundFactoryLineRuns(): NonNullable<CanvasAppFixture["runs"]> {
 /** Factory-owned compact CI canvas plus the runs that Line cards open. */
 export function refundLineCanvasFixture(
   app: Pick<FactoryApp, "id" | "name" | "description"> = REFUND_IMPLEMENTER_APP,
+  factoryId = PRIMARY_FACTORY_ID,
 ): CanvasAppFixture {
-  return factoryOwnedCanvasFixture(app, {
-    runs: refundFactoryLineRuns(),
-    triggers: { triggers: [simpleFactoryRunOnRunTrigger()] },
-    actions: mergeSimpleFactoryRunActions(defaultCanvasAppFixture.actions),
-    executionsByEventId: {
-      [LINE_RUN_IMPLEMENT_FAILED_ROOT_EVENT_ID]: { executions: simpleFactoryRunExecutions() },
-    },
-    agentMessages: factoryAgentChatMessages(),
-    canvas: {
+  return factoryOwnedCanvasFixture(
+    app,
+    {
+      runs: refundFactoryLineRuns(),
+      triggers: { triggers: [simpleFactoryRunOnRunTrigger()] },
+      actions: mergeSimpleFactoryRunActions(defaultCanvasAppFixture.actions),
+      executionsByEventId: {
+        [LINE_RUN_IMPLEMENT_FAILED_ROOT_EVENT_ID]: { executions: simpleFactoryRunExecutions() },
+      },
+      agentMessages: factoryAgentChatMessages(),
       canvas: {
-        spec: simpleFactoryRunCanvasSpec(),
+        canvas: {
+          spec: simpleFactoryRunCanvasSpec(),
+        },
       },
     },
-  });
+    factoryId,
+  );
 }

--- a/web_src/src/pages/factories/__fixtures__/factoryPageFixtureVariants.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageFixtureVariants.ts
@@ -2,7 +2,6 @@ import type { FactoriesWorkOrderArtifact } from "@/api-client";
 
 import {
   CLOSED_WORK_ORDER,
-  EMPTY_FACTORY_ID,
   FACTORIES_ORGANIZATION_ID,
   HOUR_AGO,
   PRIMARY_FACTORY_ID,
@@ -57,8 +56,8 @@ export const emptyFactoriesFixture: FactoriesFixture = {
 export const emptyWorkOrdersFactoriesFixture: FactoriesFixture = {
   ...defaultFactoriesFixture,
   workOrdersByFactoryId: {
+    ...defaultFactoriesFixture.workOrdersByFactoryId,
     [PRIMARY_FACTORY_ID]: [CLOSED_WORK_ORDER],
-    [EMPTY_FACTORY_ID]: [],
   },
 };
 

--- a/web_src/src/pages/factories/__fixtures__/factoryPageIds.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageIds.ts
@@ -5,11 +5,14 @@ export const FACTORIES_ORGANIZATION_ID = "3ee1aa47-3a60-4c1f-b645-0b9859ab91f8";
 
 export const PRIMARY_FACTORY_ID = "factory-refunds";
 export const EMPTY_FACTORY_ID = "factory-payments";
+export const ACME_ONBOARDING_FACTORY_ID = "factory-acme-onboarding";
 
 /** Workspace key for `PRIMARY_FACTORY_ID` — routes use this, not the raw id. */
 export const PRIMARY_FACTORY_KEY = "RF";
 /** Workspace key for `EMPTY_FACTORY_ID` — routes use this, not the raw id. */
 export const EMPTY_FACTORY_KEY = "PF";
+/** Workspace key for `ACME_ONBOARDING_FACTORY_ID` — routes use this, not the raw id. */
+export const ACME_ONBOARDING_FACTORY_KEY = "AO";
 
 export const STORYBOOK_ME_USER_ID = "storybook-user";
 export const STORYBOOK_ME_USER_NAME = "Leonardo DiCaprio";
@@ -81,3 +84,5 @@ export const REFUND_LINE_PLAN_ID = "line-plan-and-implement";
 export const REFUND_LINE_HOTFIX_ID = "line-hotfix";
 export const REFUND_LINE_ONBOARDING_ID = "line-onboarding";
 export const REFUND_LINE_FEATURE_ID = "line-feature-delivery";
+export const ACME_ONBOARDING_LINE_ID = "line-acme-onboarding";
+export const GITHUB_ISSUES_INTAKE_APP_ID = "app-github-issues-intake";

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -13,6 +13,9 @@ import type {
 import type { FactoriesWorkOrderCheck } from "@/api-client";
 import { DEFAULT_FACTORY_USAGE, EMPTY_USAGE_REPORT, type StorybookUsageReport } from "./usageReportFixtures";
 import {
+  ACME_ONBOARDING_FACTORY_ID,
+  ACME_ONBOARDING_LINE_ID,
+  GITHUB_ISSUES_INTAKE_APP_ID,
   EMPTY_FACTORY_ID,
   FACTORIES_ORGANIZATION_ID,
   LAST_WEEK,
@@ -47,6 +50,14 @@ export function toStorybookOrganizationUser(user: (typeof ORGANIZATION_USERS)[nu
     ...(avatarUrl ? { status: { accountProviders: [{ avatarUrl }] } } : {}),
   };
 }
+
+export const GITHUB_ISSUES_INTAKE_APP: FactoryApp = {
+  id: GITHUB_ISSUES_INTAKE_APP_ID,
+  name: "GitHub issue intake",
+  description: "Listens for GitHub issues and creates backlog work orders.",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+};
 
 const RUN_APP_TYPE = "runApp";
 
@@ -86,6 +97,7 @@ export const REFUND_FACTORY_APPS: FactoryApp[] = [
     createdAt: LAST_WEEK,
     updatedAt: YESTERDAY,
   },
+  GITHUB_ISSUES_INTAKE_APP,
 ];
 
 export const REFUND_FACTORY_LINES: FactoriesFactoryLine[] = [
@@ -116,6 +128,7 @@ export const REFUND_FACTORY: FactoriesFactory = {
   description:
     "Handles reconciliation work: plan a change, implement across affected services, and verify with regression suites.",
   lines: REFUND_FACTORY_LINES,
+  onboarding: { completedAt: LAST_WEEK },
 };
 
 export const EMPTY_FACTORY: FactoriesFactory = {
@@ -124,6 +137,70 @@ export const EMPTY_FACTORY: FactoriesFactory = {
   key: "PF",
   description: "New factory. No lines or work orders configured yet.",
   lines: [],
+};
+
+const ACME_ONBOARDING_DONE_APP_ID = "app-acme-done";
+const ACME_ONBOARDING_BACKLOG_APP_ID = "app-acme-backlog";
+
+export const ACME_ONBOARDING_APPS: FactoryApp[] = [
+  {
+    id: ACME_ONBOARDING_BACKLOG_APP_ID,
+    name: "Backlog",
+    description: "Scopes work orders before they enter a line.",
+    createdAt: LAST_WEEK,
+    updatedAt: YESTERDAY,
+  },
+  {
+    id: "app-acme-planner",
+    name: "Plan",
+    description: "Plans work from the backlog.",
+    createdAt: LAST_WEEK,
+    updatedAt: YESTERDAY,
+  },
+  {
+    id: "app-acme-implementer",
+    name: "Implement",
+    description: "Implements the plan.",
+    createdAt: LAST_WEEK,
+    updatedAt: YESTERDAY,
+  },
+  {
+    id: "app-acme-verifier",
+    name: "Verify",
+    description: "Verifies the change.",
+    createdAt: LAST_WEEK,
+    updatedAt: YESTERDAY,
+  },
+  {
+    id: ACME_ONBOARDING_DONE_APP_ID,
+    name: "Done",
+    description: "Completes the work order.",
+    createdAt: LAST_WEEK,
+    updatedAt: YESTERDAY,
+  },
+  GITHUB_ISSUES_INTAKE_APP,
+];
+
+export const ACME_ONBOARDING_LINE: FactoriesFactoryLine = {
+  id: ACME_ONBOARDING_LINE_ID,
+  name: "Plan and Implement",
+  createdAt: LAST_WEEK,
+  updatedAt: YESTERDAY,
+  steps: [
+    runAppStep("app-acme-planner", "start-plan"),
+    runAppStep("app-acme-implementer", "start-implementation"),
+    runAppStep("app-acme-verifier", "start-verification"),
+    runAppStep(ACME_ONBOARDING_DONE_APP_ID, "start-done"),
+  ],
+};
+
+export const ACME_ONBOARDING_FACTORY: FactoriesFactory = {
+  id: ACME_ONBOARDING_FACTORY_ID,
+  name: "Acme onboarding",
+  key: "AO",
+  description: "Empty first-run workspace. The board has no tickets yet.",
+  lines: [ACME_ONBOARDING_LINE],
+  onboarding: { completedAt: LAST_WEEK },
 };
 
 export const DEFAULT_WORK_ORDERS: FactoriesWorkOrder[] = [
@@ -162,18 +239,21 @@ export interface FactoriesFixture {
 
 export const defaultFactoriesFixture: FactoriesFixture = {
   organizationId: FACTORIES_ORGANIZATION_ID,
-  factories: [REFUND_FACTORY, EMPTY_FACTORY],
+  factories: [REFUND_FACTORY, EMPTY_FACTORY, ACME_ONBOARDING_FACTORY],
   workOrdersByFactoryId: {
     [PRIMARY_FACTORY_ID]: DEFAULT_WORK_ORDERS,
     [EMPTY_FACTORY_ID]: [],
+    [ACME_ONBOARDING_FACTORY_ID]: [],
   },
   appsByFactoryId: {
     [PRIMARY_FACTORY_ID]: REFUND_FACTORY_APPS,
     [EMPTY_FACTORY_ID]: [],
+    [ACME_ONBOARDING_FACTORY_ID]: ACME_ONBOARDING_APPS,
   },
   usageByFactoryId: {
     [PRIMARY_FACTORY_ID]: DEFAULT_FACTORY_USAGE,
     [EMPTY_FACTORY_ID]: EMPTY_USAGE_REPORT,
+    [ACME_ONBOARDING_FACTORY_ID]: EMPTY_USAGE_REPORT,
   },
   organizationLlmSpend: DEFAULT_FACTORY_USAGE,
 };

--- a/web_src/src/pages/factories/__fixtures__/handlers.spec.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.spec.ts
@@ -4,6 +4,7 @@ import { fetchFactoryPageFixture } from "./handlers";
 import { lineMetricsFactoriesFixture } from "./lineMetricsFactoriesFixture";
 import {
   CLOSED_WORK_ORDER,
+  defaultFactoriesFixture,
   FACTORIES_ORGANIZATION_ID,
   OPEN_WORK_ORDER,
   PRIMARY_FACTORY_ID,
@@ -89,6 +90,35 @@ describe("matchFactoryPageFixture", () => {
     const onboarding = body.factory.lines?.find((line) => line.id === REFUND_LINE_ONBOARDING_ID);
     expect(onboarding).toBeDefined();
     expect(onboarding?.metrics).toBeUndefined();
+  });
+
+  it("creates a workspace with a unique key derived from the name", async () => {
+    const response = await fetchFactoryPageFixture("/api/v1/factories", {
+      method: "POST",
+      body: JSON.stringify({ name: "New workspace", description: "", key: "" }),
+    });
+    const body = (await response.json()) as { factory?: { id?: string; name?: string; key?: string } };
+
+    expect(body.factory?.name).toBe("New workspace");
+    expect(body.factory?.id).toMatch(/^storybook-factory-/);
+    expect(body.factory?.key).toBe("NEWWO");
+  });
+
+  it("walks to a free key when the name-derived key is already taken", async () => {
+    const fixture = structuredClone(defaultFactoriesFixture);
+    fixture.factories.push({ id: "taken-newwo", name: "Taken", key: "NEWWO", lines: [] });
+
+    const response = await fetchFactoryPageFixture(
+      "/api/v1/factories",
+      {
+        method: "POST",
+        body: JSON.stringify({ name: "New workspace", description: "", key: "" }),
+      },
+      fixture,
+    );
+    const body = (await response.json()) as { factory?: { key?: string } };
+
+    expect(body.factory?.key).toBe("NEWWA");
   });
 
   it("does not serve a separate line-metrics route", async () => {

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -22,6 +22,7 @@ import type {
 import { defaultNotificationSettings } from "@/lib/notificationSettings";
 import { buildStorybookMeUser, fixtureResponse, type FixtureResult } from "@/pages/home/__fixtures__/handlers";
 import { automationNameForLineStep } from "../lib/factoryLineFormShared";
+import { isValidWorkspaceKey, suggestWorkspaceKeyFromName, WORKSPACE_KEY_MAX_LENGTH } from "../lib/workspaceKey";
 import { metricsForLine } from "../pages/lineListMetricsMockData";
 
 export type { FactoriesFixture };
@@ -41,6 +42,7 @@ interface RequestBody {
   name?: unknown;
   title?: unknown;
   description?: unknown;
+  key?: unknown;
   assigneeIds?: unknown;
   assignee_ids?: unknown;
   lineName?: unknown;
@@ -76,6 +78,28 @@ function ensureFactoryWorkOrders(fixture: FactoriesFixture, factoryId: string): 
   return created;
 }
 
+function takenFactoryKeys(factories: FactoriesFactory[]): Set<string> {
+  return new Set(factories.map((factory) => factory.key).filter((key): key is string => Boolean(key)));
+}
+
+/** Same letter-only keys the live API derives when the client omits `key`. */
+function unusedFactoryKey(factories: FactoriesFactory[], name: string, requestedKey: string): string {
+  const taken = takenFactoryKeys(factories);
+  const seed = isValidWorkspaceKey(requestedKey) ? requestedKey : suggestWorkspaceKeyFromName(name) || "WS";
+  if (!taken.has(seed)) {
+    return seed;
+  }
+
+  const prefix = seed.slice(0, WORKSPACE_KEY_MAX_LENGTH - 1);
+  for (let code = 65; code <= 90; code += 1) {
+    const candidate = `${prefix}${String.fromCharCode(code)}`;
+    if (!taken.has(candidate)) {
+      return candidate;
+    }
+  }
+  return `${prefix}Z`;
+}
+
 function factoriesCollectionRoute(fixture: FactoriesFixture): FactoriesRoute {
   return {
     pattern: re("/api/v1/factories"),
@@ -84,11 +108,14 @@ function factoriesCollectionRoute(fixture: FactoriesFixture): FactoriesRoute {
         return { json: { factories: fixture.factories } };
       }
       const request = (body ?? {}) as RequestBody;
+      const name = stringOrEmpty(request.name) || "New workspace";
       const created = {
         id: `storybook-factory-${fixture.factories.length + 1}`,
-        name: stringOrEmpty(request.name) || "New workspace",
+        name,
+        key: unusedFactoryKey(fixture.factories, name, stringOrEmpty(request.key)),
         description: stringOrEmpty(request.description),
         lines: [],
+        onboarding: {},
       };
       fixture.factories.push(created);
       fixture.workOrdersByFactoryId[created.id] = [];

--- a/web_src/src/pages/factories/__fixtures__/lineMetricsFactoriesFixture.ts
+++ b/web_src/src/pages/factories/__fixtures__/lineMetricsFactoriesFixture.ts
@@ -1,5 +1,6 @@
 import type { FactoriesWorkOrder } from "@/api-client";
 
+import { REVIEW_CANDIDATE_WORK_ORDERS } from "../pages/onboarding/first-run/reviewCandidates";
 import {
   CLOSED_WORK_ORDER,
   FAILED_WORK_ORDER,
@@ -198,6 +199,7 @@ export const lineMetricsFactoriesFixture: FactoriesFixture = {
   workOrdersByFactoryId: {
     ...defaultFactoriesFixture.workOrdersByFactoryId,
     [PRIMARY_FACTORY_ID]: [
+      ...REVIEW_CANDIDATE_WORK_ORDERS,
       ...(defaultFactoriesFixture.workOrdersByFactoryId[PRIMARY_FACTORY_ID] ?? [])
         .map(withPlanPhase)
         .map(withVerifyPhase)

--- a/web_src/src/pages/factories/layout/ClickToRename.spec.tsx
+++ b/web_src/src/pages/factories/layout/ClickToRename.spec.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ClickToRename } from "./ClickToRename";
+
+function renderRename(onSave = vi.fn(), canEdit = true) {
+  return {
+    onSave,
+    user: userEvent.setup(),
+    ...render(
+      <ClickToRename
+        value="Plan and Implement"
+        onSave={onSave}
+        canEdit={canEdit}
+        testId="rename-target"
+        ariaLabel="Line name"
+      />,
+    ),
+  };
+}
+
+describe("ClickToRename", () => {
+  it("opens an input on click and saves on Enter", async () => {
+    const { user, onSave } = renderRename();
+
+    await user.click(screen.getByTestId("rename-target"));
+    const input = await screen.findByTestId("rename-target-input");
+    await waitFor(() => expect(input).toHaveFocus());
+    await user.clear(input);
+    await user.type(input, "Refund line");
+    await user.keyboard("{Enter}");
+
+    expect(onSave).toHaveBeenCalledWith("Refund line");
+    expect(screen.queryByTestId("rename-target-input")).not.toBeInTheDocument();
+  });
+
+  it("saves on blur", async () => {
+    const { user, onSave } = renderRename();
+
+    await user.click(screen.getByTestId("rename-target"));
+    const input = await screen.findByTestId("rename-target-input");
+    await waitFor(() => expect(input).toHaveFocus());
+    await user.clear(input);
+    await user.type(input, "Inbox");
+    await user.tab();
+
+    expect(onSave).toHaveBeenCalledWith("Inbox");
+  });
+
+  it("restores the previous name on Escape", async () => {
+    const { user, onSave } = renderRename();
+
+    await user.click(screen.getByTestId("rename-target"));
+    const input = screen.getByTestId("rename-target-input");
+    await user.clear(input);
+    await user.type(input, "Scratch");
+    await user.keyboard("{Escape}");
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByTestId("rename-target")).toHaveTextContent("Plan and Implement");
+  });
+
+  it("keeps the label in the document so the layout size does not change", async () => {
+    const { user } = renderRename();
+
+    const label = screen.getByTestId("rename-target");
+    await user.click(label);
+    await waitFor(() => expect(screen.getByTestId("rename-target-input")).toBeInTheDocument());
+
+    expect(screen.getByTestId("rename-target")).toBeInTheDocument();
+    expect(screen.getByTestId("rename-target")).toHaveClass("invisible");
+  });
+
+  it("does not open when canEdit is false", async () => {
+    const { user } = renderRename(vi.fn(), false);
+
+    await user.click(screen.getByTestId("rename-target"));
+    expect(screen.queryByTestId("rename-target-input")).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/layout/ClickToRename.tsx
+++ b/web_src/src/pages/factories/layout/ClickToRename.tsx
@@ -1,0 +1,148 @@
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
+
+type ClickToRenameProps = {
+  value: string;
+  onSave: (next: string) => void;
+  canEdit: boolean;
+  busy?: boolean;
+  testId: string;
+  ariaLabel: string;
+  className?: string;
+  inputClassName?: string;
+};
+
+/**
+ * Click (or Enter/Space) opens an input. Enter or blur saves a non-empty
+ * name. Escape restores the previous value.
+ *
+ * The label keeps the layout size. The field paints around that label so
+ * opening edit does not shift the header or the columns.
+ */
+export function ClickToRename({
+  value,
+  onSave,
+  canEdit,
+  busy = false,
+  testId,
+  ariaLabel,
+  className,
+  inputClassName,
+}: ClickToRenameProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const skipBlurCommitRef = useRef(false);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraft(value);
+    }
+  }, [editing, value]);
+
+  useEffect(() => {
+    if (!editing) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [editing]);
+
+  const startEditing = (event?: MouseEvent) => {
+    if (!canEdit || busy) {
+      return;
+    }
+    event?.preventDefault();
+    skipBlurCommitRef.current = false;
+    setDraft(value);
+    setEditing(true);
+  };
+
+  const cancelEditing = () => {
+    skipBlurCommitRef.current = true;
+    setDraft(value);
+    setEditing(false);
+  };
+
+  const commitDraft = () => {
+    const next = draft.trim();
+    if (!next) {
+      inputRef.current?.focus();
+      return;
+    }
+    if (next !== value.trim()) {
+      onSave(next);
+    }
+    skipBlurCommitRef.current = true;
+    setEditing(false);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitDraft();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelEditing();
+    }
+  };
+
+  return (
+    <span className={cn("relative inline-flex max-w-full min-w-0 items-center overflow-visible", className)}>
+      <span
+        className={cn(
+          "min-w-0 whitespace-nowrap",
+          editing ? "invisible" : "truncate",
+          canEdit && !editing
+            ? "cursor-text rounded-sm hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            : undefined,
+        )}
+        title={canEdit && !editing ? "Click to rename" : undefined}
+        data-testid={testId}
+        tabIndex={canEdit && !editing ? 0 : undefined}
+        onMouseDown={(event) => {
+          if (canEdit && !editing) {
+            event.preventDefault();
+          }
+        }}
+        onClick={(event) => startEditing(event)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            startEditing();
+          }
+        }}
+      >
+        {editing ? draft || "\u00a0" : value}
+      </span>
+      {editing ? (
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={() => {
+            if (skipBlurCommitRef.current) {
+              skipBlurCommitRef.current = false;
+              return;
+            }
+            commitDraft();
+          }}
+          onKeyDown={handleKeyDown}
+          disabled={busy}
+          aria-label={ariaLabel}
+          data-testid={`${testId}-input`}
+          className={cn(
+            "absolute top-1/2 left-1/2 z-10 h-[calc(100%+10px)] w-[calc(100%+18px)] -translate-x-1/2 -translate-y-1/2 rounded-md border border-border bg-background px-1.5 py-0 text-foreground shadow-none focus:border-foreground/40 focus:ring-1 focus:ring-ring",
+            inputClassName,
+          )}
+        />
+      ) : null}
+    </span>
+  );
+}

--- a/web_src/src/pages/factories/layout/FactoriesLayout.stories.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesLayout.stories.tsx
@@ -5,8 +5,8 @@ import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/fa
 import { FactoriesLayout } from "./FactoriesLayout";
 
 /**
- * The Factories layout shell: a thin icon rail (workspace, settings, new
- * work order, user) and the line board as the main pane.
+ * The Factories layout shell: a thin icon rail (workspace, intake, board,
+ * velocity, settings, new work order, user) and the line board as the main pane.
  * Stories mount the layout with a live route so the rail controls behave.
  */
 const meta = {

--- a/web_src/src/pages/factories/layout/FactoriesLayout.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesLayout.tsx
@@ -1,13 +1,12 @@
 import type { FactoriesFactory } from "@/api-client";
 import { Link } from "@/components/Link/link";
-import { PermissionTooltip } from "@/components/PermissionGate";
 import { useAccount } from "@/contexts/useAccount";
 import { usePermissions } from "@/contexts/usePermissions";
 import { useFactories, useFactory } from "@/hooks/useFactoryData";
 import { useFactoryWebsocket } from "@/hooks/useFactoryWebsocket";
 import { useOrganization } from "@/hooks/useOrganizationData";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { AlertTriangle, Plus } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { Navigate, Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { CreateWorkOrderDialog } from "../CreateWorkOrderDialog";
@@ -16,13 +15,13 @@ import {
   replaceFactoryKeySegment,
   resolveFactoryByKey,
 } from "../lib/factoryKeyResolution";
-import { factoryListPath, newFactoryPath } from "../lib/factoryPagePaths";
+import { factoryListPath, firstFactoryLineId, newFactoryPath } from "../lib/factoryPagePaths";
 import { clearLastVisitedFactory, recordLastVisitedFactory } from "../lib/lastVisitedFactory";
 import { useFactoriesThemeClass } from "../lib/useFactoriesThemeClass";
 import { useOnboardingStorybook } from "../pages/onboarding/useOnboardingStorybook";
 import { isFactoryOnboardingComplete } from "../pages/onboarding/onboardingStatus";
 import { FactoriesLayoutContext } from "./factoriesLayoutContext";
-import { factoriesRailControlClassName } from "./factoriesRail";
+import { FactoriesSidebarNav } from "./FactoriesSidebarNav";
 import { SidebarUserMenu } from "./SidebarUserMenu";
 import { useCreateWorkOrderDialogState } from "./useCreateWorkOrderDialogState";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
@@ -257,31 +256,19 @@ function FactoriesSidebar({
         organizationId={organizationId}
         factory={factory}
         factories={factories}
-        canOpenSettings={canOpenSettings}
         canCreateFactory={canCreateFactory}
         permissionsLoading={permissionsLoading}
         onCreateFactory={onOpenCreateFactory}
       />
-      <PermissionTooltip
-        allowed={canCreateWorkOrder || permissionsLoading}
-        message="You don't have permission to create work orders."
-      >
-        <button
-          type="button"
-          onClick={() => {
-            if (canCreateWorkOrder) {
-              onCreateWorkOrder();
-            }
-          }}
-          disabled={!canCreateWorkOrder}
-          aria-label="Create work order"
-          title="Create work order"
-          data-testid="factories-sidebar-create-work-order"
-          className={factoriesRailControlClassName}
-        >
-          <Plus className="size-3.5" aria-hidden />
-        </button>
-      </PermissionTooltip>
+      <FactoriesSidebarNav
+        organizationId={organizationId}
+        factoryKey={factoryKey}
+        lineId={firstFactoryLineId(factory)}
+        canOpenSettings={canOpenSettings}
+        canCreateWorkOrder={canCreateWorkOrder}
+        permissionsLoading={permissionsLoading}
+        onCreateWorkOrder={onCreateWorkOrder}
+      />
       <div className="flex-1" />
       <SidebarUserMenu
         organizationId={organizationId}

--- a/web_src/src/pages/factories/layout/FactoriesLayout.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesLayout.tsx
@@ -194,10 +194,8 @@ function FactoriesLayoutContent({
             accountAvatarUrl={account?.avatar_url}
             canOpenSettings={canAct("factories", "update")}
             canCreateFactory={canAct("factories", "create")}
-            canCreateWorkOrder={canCreateWorkOrder}
             permissionsLoading={permissionsLoading}
             onOpenCreateFactory={() => navigate(newFactoryPath(organizationId))}
-            onCreateWorkOrder={openCreateWorkOrder}
           />
         )}
         <main className="relative min-h-0 min-w-0 flex-1 overflow-y-auto bg-background">
@@ -226,10 +224,8 @@ interface FactoriesSidebarProps {
   accountAvatarUrl?: string | null;
   canOpenSettings: boolean;
   canCreateFactory: boolean;
-  canCreateWorkOrder: boolean;
   permissionsLoading: boolean;
   onOpenCreateFactory: () => void;
-  onCreateWorkOrder: () => void;
 }
 
 function FactoriesSidebar({
@@ -242,10 +238,8 @@ function FactoriesSidebar({
   accountAvatarUrl,
   canOpenSettings,
   canCreateFactory,
-  canCreateWorkOrder,
   permissionsLoading,
   onOpenCreateFactory,
-  onCreateWorkOrder,
 }: FactoriesSidebarProps) {
   return (
     <aside
@@ -265,9 +259,7 @@ function FactoriesSidebar({
         factoryKey={factoryKey}
         lineId={firstFactoryLineId(factory)}
         canOpenSettings={canOpenSettings}
-        canCreateWorkOrder={canCreateWorkOrder}
         permissionsLoading={permissionsLoading}
-        onCreateWorkOrder={onCreateWorkOrder}
       />
       <div className="flex-1" />
       <SidebarUserMenu

--- a/web_src/src/pages/factories/layout/FactoriesSidebarNav.spec.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesSidebarNav.spec.tsx
@@ -1,14 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { TooltipProvider } from "@/ui/tooltip";
 import { FACTORIES_ORGANIZATION_ID, REFUND_FACTORY, REFUND_LINE_PLAN_ID } from "../__fixtures__/factoryPageResponses";
-import { factoryHomePath, factorySettingsPath, factoryVelocityPath, workOrdersPath } from "../lib/factoryPagePaths";
+import { factoryHomePath, factoryIntakePath, factorySettingsPath, factoryVelocityPath } from "../lib/factoryPagePaths";
 import { FactoriesSidebarNav } from "./FactoriesSidebarNav";
 
-function renderNav(path: string, onCreateWorkOrder = vi.fn()) {
+function renderNav(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <TooltipProvider>
@@ -17,9 +16,7 @@ function renderNav(path: string, onCreateWorkOrder = vi.fn()) {
           factoryKey={REFUND_FACTORY.key!}
           lineId={REFUND_LINE_PLAN_ID}
           canOpenSettings
-          canCreateWorkOrder
           permissionsLoading={false}
-          onCreateWorkOrder={onCreateWorkOrder}
         />
       </TooltipProvider>
     </MemoryRouter>,
@@ -30,7 +27,7 @@ const org = FACTORIES_ORGANIZATION_ID;
 const key = REFUND_FACTORY.key!;
 
 describe("FactoriesSidebarNav", () => {
-  it("places Intake, Board, Velocity, Settings, and Create under the switcher", () => {
+  it("places Intake, Board, Velocity, and Settings under the switcher", () => {
     renderNav(`/${org}/workspaces/${key}/lines/${REFUND_LINE_PLAN_ID}`);
 
     const nav = screen.getByTestId("factories-sidebar-nav");
@@ -39,11 +36,14 @@ describe("FactoriesSidebarNav", () => {
       screen.getByTestId("factories-nav-board"),
       screen.getByTestId("factories-nav-velocity"),
       screen.getByTestId("factories-workspace-settings-link"),
-      screen.getByTestId("factories-sidebar-create-work-order"),
     ];
 
-    expect(controls.map((node) => nav.contains(node))).toEqual([true, true, true, true, true]);
-    expect(screen.getByTestId("factories-nav-intake")).toHaveAttribute("href", workOrdersPath(org, key));
+    expect(controls.map((node) => nav.contains(node))).toEqual([true, true, true, true]);
+    expect(screen.queryByTestId("factories-sidebar-create-work-order")).not.toBeInTheDocument();
+    expect(screen.getByTestId("factories-nav-intake")).toHaveAttribute(
+      "href",
+      factoryIntakePath(org, key, REFUND_LINE_PLAN_ID),
+    );
     expect(screen.getByTestId("factories-nav-board")).toHaveAttribute(
       "href",
       factoryHomePath(org, key, REFUND_LINE_PLAN_ID),
@@ -62,19 +62,14 @@ describe("FactoriesSidebarNav", () => {
     expect(screen.getByTestId("factories-nav-intake")).not.toHaveAttribute("aria-current");
   });
 
-  it("marks the Intake icon current on work orders", () => {
-    renderNav(`/${org}/workspaces/${key}/work-orders`);
+  it("marks the Intake icon current when the line board shows the drawer", () => {
+    renderNav(`/${org}/workspaces/${key}/lines/${REFUND_LINE_PLAN_ID}?intake=1`);
 
     expect(screen.getByTestId("factories-nav-intake")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("factories-nav-intake")).toHaveAttribute(
+      "href",
+      factoryHomePath(org, key, REFUND_LINE_PLAN_ID),
+    );
     expect(screen.getByTestId("factories-nav-board")).not.toHaveAttribute("aria-current");
-  });
-
-  it("opens create work order from the plus control", async () => {
-    const onCreateWorkOrder = vi.fn();
-    const user = userEvent.setup();
-    renderNav(`/${org}/workspaces/${key}/lines/${REFUND_LINE_PLAN_ID}`, onCreateWorkOrder);
-
-    await user.click(screen.getByTestId("factories-sidebar-create-work-order"));
-    expect(onCreateWorkOrder).toHaveBeenCalledTimes(1);
   });
 });

--- a/web_src/src/pages/factories/layout/FactoriesSidebarNav.spec.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesSidebarNav.spec.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "@/ui/tooltip";
+import { FACTORIES_ORGANIZATION_ID, REFUND_FACTORY, REFUND_LINE_PLAN_ID } from "../__fixtures__/factoryPageResponses";
+import { factoryHomePath, factorySettingsPath, factoryVelocityPath, workOrdersPath } from "../lib/factoryPagePaths";
+import { FactoriesSidebarNav } from "./FactoriesSidebarNav";
+
+function renderNav(path: string, onCreateWorkOrder = vi.fn()) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <TooltipProvider>
+        <FactoriesSidebarNav
+          organizationId={FACTORIES_ORGANIZATION_ID}
+          factoryKey={REFUND_FACTORY.key!}
+          lineId={REFUND_LINE_PLAN_ID}
+          canOpenSettings
+          canCreateWorkOrder
+          permissionsLoading={false}
+          onCreateWorkOrder={onCreateWorkOrder}
+        />
+      </TooltipProvider>
+    </MemoryRouter>,
+  );
+}
+
+const org = FACTORIES_ORGANIZATION_ID;
+const key = REFUND_FACTORY.key!;
+
+describe("FactoriesSidebarNav", () => {
+  it("places Intake, Board, Velocity, Settings, and Create under the switcher", () => {
+    renderNav(`/${org}/workspaces/${key}/lines/${REFUND_LINE_PLAN_ID}`);
+
+    const nav = screen.getByTestId("factories-sidebar-nav");
+    const controls = [
+      screen.getByTestId("factories-nav-intake"),
+      screen.getByTestId("factories-nav-board"),
+      screen.getByTestId("factories-nav-velocity"),
+      screen.getByTestId("factories-workspace-settings-link"),
+      screen.getByTestId("factories-sidebar-create-work-order"),
+    ];
+
+    expect(controls.map((node) => nav.contains(node))).toEqual([true, true, true, true, true]);
+    expect(screen.getByTestId("factories-nav-intake")).toHaveAttribute("href", workOrdersPath(org, key));
+    expect(screen.getByTestId("factories-nav-board")).toHaveAttribute(
+      "href",
+      factoryHomePath(org, key, REFUND_LINE_PLAN_ID),
+    );
+    expect(screen.getByTestId("factories-nav-velocity")).toHaveAttribute("href", factoryVelocityPath(org, key));
+    expect(screen.getByTestId("factories-workspace-settings-link")).toHaveAttribute(
+      "href",
+      factorySettingsPath(org, key),
+    );
+  });
+
+  it("marks the Board icon current on the line board", () => {
+    renderNav(`/${org}/workspaces/${key}/lines/${REFUND_LINE_PLAN_ID}`);
+
+    expect(screen.getByTestId("factories-nav-board")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("factories-nav-intake")).not.toHaveAttribute("aria-current");
+  });
+
+  it("marks the Intake icon current on work orders", () => {
+    renderNav(`/${org}/workspaces/${key}/work-orders`);
+
+    expect(screen.getByTestId("factories-nav-intake")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("factories-nav-board")).not.toHaveAttribute("aria-current");
+  });
+
+  it("opens create work order from the plus control", async () => {
+    const onCreateWorkOrder = vi.fn();
+    const user = userEvent.setup();
+    renderNav(`/${org}/workspaces/${key}/lines/${REFUND_LINE_PLAN_ID}`, onCreateWorkOrder);
+
+    await user.click(screen.getByTestId("factories-sidebar-create-work-order"));
+    expect(onCreateWorkOrder).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web_src/src/pages/factories/layout/FactoriesSidebarNav.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesSidebarNav.tsx
@@ -1,0 +1,148 @@
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { cn } from "@/lib/utils";
+import { ArrowRightFromLine, Gauge, Kanban, Plus, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Link, useLocation } from "react-router";
+import { factoryHomePath, factorySettingsPath, factoryVelocityPath, workOrdersPath } from "../lib/factoryPagePaths";
+import { factoriesRailControlClassName } from "./factoriesRail";
+
+interface FactoriesSidebarNavProps {
+  organizationId: string;
+  factoryKey: string;
+  lineId?: string;
+  canOpenSettings: boolean;
+  canCreateWorkOrder: boolean;
+  permissionsLoading: boolean;
+  onCreateWorkOrder: () => void;
+}
+
+function railLinkClassName(isCurrent: boolean) {
+  return cn(factoriesRailControlClassName, isCurrent && "bg-sidebar-accent text-foreground");
+}
+
+function RailNavLink({
+  to,
+  label,
+  Icon,
+  testId,
+  isCurrent,
+}: {
+  to: string;
+  label: string;
+  Icon: LucideIcon;
+  testId: string;
+  isCurrent: boolean;
+}) {
+  return (
+    <Link
+      to={to}
+      aria-label={label}
+      title={label}
+      aria-current={isCurrent ? "page" : undefined}
+      data-testid={testId}
+      className={railLinkClassName(isCurrent)}
+    >
+      <Icon className="size-3.5" aria-hidden />
+    </Link>
+  );
+}
+
+/**
+ * Icon rail under the workspace switcher: incoming work, the line board,
+ * velocity, settings, then create.
+ */
+export function FactoriesSidebarNav({
+  organizationId,
+  factoryKey,
+  lineId,
+  canOpenSettings,
+  canCreateWorkOrder,
+  permissionsLoading,
+  onCreateWorkOrder,
+}: FactoriesSidebarNavProps) {
+  const { pathname } = useLocation();
+  const intakeHref = workOrdersPath(organizationId, factoryKey);
+  const boardHref = factoryHomePath(organizationId, factoryKey, lineId);
+  const velocityHref = factoryVelocityPath(organizationId, factoryKey);
+  const settingsHref = factorySettingsPath(organizationId, factoryKey);
+  const intakeCurrent = isIntakePath(pathname);
+  const boardCurrent = isBoardPath(pathname);
+  const velocityCurrent = isVelocityPath(pathname);
+  const settingsCurrent = isSettingsPath(pathname);
+
+  return (
+    <nav className="flex flex-col items-center gap-1 px-1.5" aria-label="Workspace" data-testid="factories-sidebar-nav">
+      <RailNavLink
+        to={intakeHref}
+        label="Intake"
+        Icon={ArrowRightFromLine}
+        testId="factories-nav-intake"
+        isCurrent={intakeCurrent}
+      />
+      <RailNavLink to={boardHref} label="Board" Icon={Kanban} testId="factories-nav-board" isCurrent={boardCurrent} />
+      <RailNavLink
+        to={velocityHref}
+        label="Velocity"
+        Icon={Gauge}
+        testId="factories-nav-velocity"
+        isCurrent={velocityCurrent}
+      />
+      <PermissionTooltip
+        allowed={canOpenSettings || permissionsLoading}
+        message="You don't have permission to open workspace settings."
+      >
+        <Link
+          to={canOpenSettings ? settingsHref : "#"}
+          onClick={(event) => {
+            if (!canOpenSettings) {
+              event.preventDefault();
+            }
+          }}
+          aria-label="Workspace settings"
+          title="Workspace settings"
+          aria-current={settingsCurrent ? "page" : undefined}
+          data-testid="factories-workspace-settings-link"
+          className={cn(railLinkClassName(settingsCurrent), !canOpenSettings && "pointer-events-none opacity-60")}
+        >
+          <Settings className="size-3.5" aria-hidden />
+        </Link>
+      </PermissionTooltip>
+      <PermissionTooltip
+        allowed={canCreateWorkOrder || permissionsLoading}
+        message="You don't have permission to create work orders."
+      >
+        <button
+          type="button"
+          onClick={() => {
+            if (canCreateWorkOrder) {
+              onCreateWorkOrder();
+            }
+          }}
+          disabled={!canCreateWorkOrder}
+          aria-label="Create work order"
+          title="Create work order"
+          data-testid="factories-sidebar-create-work-order"
+          className={factoriesRailControlClassName}
+        >
+          <Plus className="size-3.5" aria-hidden />
+        </button>
+      </PermissionTooltip>
+    </nav>
+  );
+}
+
+export function isIntakePath(pathname: string): boolean {
+  return pathname.includes("/work-orders") || /\/work-order\//.test(pathname);
+}
+
+export function isBoardPath(pathname: string): boolean {
+  return pathname.includes("/lines");
+}
+
+export function isVelocityPath(pathname: string): boolean {
+  return pathname.includes("/velocity");
+}
+
+export function isSettingsPath(pathname: string): boolean {
+  return pathname.includes("/settings");
+}

--- a/web_src/src/pages/factories/layout/FactoriesSidebarNav.tsx
+++ b/web_src/src/pages/factories/layout/FactoriesSidebarNav.tsx
@@ -1,9 +1,15 @@
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { cn } from "@/lib/utils";
-import { ArrowRightFromLine, Gauge, Kanban, Plus, Settings } from "lucide-react";
+import { ArrowRightFromLine, Gauge, Kanban, Settings } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Link, useLocation } from "react-router";
-import { factoryHomePath, factorySettingsPath, factoryVelocityPath, workOrdersPath } from "../lib/factoryPagePaths";
+import {
+  factoryHomePath,
+  factoryIntakePath,
+  factorySettingsPath,
+  factoryVelocityPath,
+  isIntakeSearchOpen,
+} from "../lib/factoryPagePaths";
 import { factoriesRailControlClassName } from "./factoriesRail";
 
 interface FactoriesSidebarNavProps {
@@ -11,9 +17,7 @@ interface FactoriesSidebarNavProps {
   factoryKey: string;
   lineId?: string;
   canOpenSettings: boolean;
-  canCreateWorkOrder: boolean;
   permissionsLoading: boolean;
-  onCreateWorkOrder: () => void;
 }
 
 function railLinkClassName(isCurrent: boolean) {
@@ -48,25 +52,24 @@ function RailNavLink({
 }
 
 /**
- * Icon rail under the workspace switcher: incoming work, the line board,
- * velocity, settings, then create.
+ * Icon rail under the workspace switcher: intake drawer on the line board,
+ * the line board, velocity, then settings.
  */
 export function FactoriesSidebarNav({
   organizationId,
   factoryKey,
   lineId,
   canOpenSettings,
-  canCreateWorkOrder,
   permissionsLoading,
-  onCreateWorkOrder,
 }: FactoriesSidebarNavProps) {
-  const { pathname } = useLocation();
-  const intakeHref = workOrdersPath(organizationId, factoryKey);
+  const { pathname, search } = useLocation();
   const boardHref = factoryHomePath(organizationId, factoryKey, lineId);
+  const intakeOpen = isIntakeSearchOpen(search);
+  const intakeHref = intakeOpen ? boardHref : factoryIntakePath(organizationId, factoryKey, lineId);
   const velocityHref = factoryVelocityPath(organizationId, factoryKey);
   const settingsHref = factorySettingsPath(organizationId, factoryKey);
-  const intakeCurrent = isIntakePath(pathname);
-  const boardCurrent = isBoardPath(pathname);
+  const intakeCurrent = intakeOpen;
+  const boardCurrent = isBoardPath(pathname) && !intakeOpen;
   const velocityCurrent = isVelocityPath(pathname);
   const settingsCurrent = isSettingsPath(pathname);
 
@@ -107,32 +110,8 @@ export function FactoriesSidebarNav({
           <Settings className="size-3.5" aria-hidden />
         </Link>
       </PermissionTooltip>
-      <PermissionTooltip
-        allowed={canCreateWorkOrder || permissionsLoading}
-        message="You don't have permission to create work orders."
-      >
-        <button
-          type="button"
-          onClick={() => {
-            if (canCreateWorkOrder) {
-              onCreateWorkOrder();
-            }
-          }}
-          disabled={!canCreateWorkOrder}
-          aria-label="Create work order"
-          title="Create work order"
-          data-testid="factories-sidebar-create-work-order"
-          className={factoriesRailControlClassName}
-        >
-          <Plus className="size-3.5" aria-hidden />
-        </button>
-      </PermissionTooltip>
     </nav>
   );
-}
-
-export function isIntakePath(pathname: string): boolean {
-  return pathname.includes("/work-orders") || /\/work-order\//.test(pathname);
 }
 
 export function isBoardPath(pathname: string): boolean {

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
@@ -6,6 +6,7 @@ import { SegmentedNav } from "@/ui/SegmentedNav";
 import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
 import { withFactoriesTheme } from "../__fixtures__/factoriesStoryTheme";
 import {
+  ACME_ONBOARDING_FACTORY,
   EMPTY_FACTORY,
   FACTORIES_ORGANIZATION_ID,
   REFUND_FACTORY,
@@ -209,7 +210,7 @@ export const AlignedWithSidebar: Story = {
         <WorkspaceSwitcher
           organizationId={FACTORIES_ORGANIZATION_ID}
           factory={REFUND_FACTORY}
-          factories={[REFUND_FACTORY, EMPTY_FACTORY]}
+          factories={[REFUND_FACTORY, EMPTY_FACTORY, ACME_ONBOARDING_FACTORY]}
           canCreateFactory
           permissionsLoading={false}
           onCreateFactory={() => console.log("create workspace")}

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
@@ -219,9 +219,7 @@ export const AlignedWithSidebar: Story = {
           factoryKey={REFUND_FACTORY.key!}
           lineId={REFUND_LINE_PLAN_ID}
           canOpenSettings
-          canCreateWorkOrder
           permissionsLoading={false}
-          onCreateWorkOrder={() => console.log("create work order")}
         />
       </aside>
       <div className="min-w-0 flex-1">

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
@@ -5,8 +5,14 @@ import { Button } from "@/components/ui/button";
 import { SegmentedNav } from "@/ui/SegmentedNav";
 import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
 import { withFactoriesTheme } from "../__fixtures__/factoriesStoryTheme";
-import { EMPTY_FACTORY, FACTORIES_ORGANIZATION_ID, REFUND_FACTORY } from "../__fixtures__/factoryPageResponses";
+import {
+  EMPTY_FACTORY,
+  FACTORIES_ORGANIZATION_ID,
+  REFUND_FACTORY,
+  REFUND_LINE_PLAN_ID,
+} from "../__fixtures__/factoryPageResponses";
 import { factorySectionHeaderClassName } from "../pages/factoryPageLayoutStyles";
+import { FactoriesSidebarNav } from "./FactoriesSidebarNav";
 import { WorkspacePageHeader } from "./WorkspacePageHeader";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 
@@ -204,10 +210,18 @@ export const AlignedWithSidebar: Story = {
           organizationId={FACTORIES_ORGANIZATION_ID}
           factory={REFUND_FACTORY}
           factories={[REFUND_FACTORY, EMPTY_FACTORY]}
-          canOpenSettings
           canCreateFactory
           permissionsLoading={false}
           onCreateFactory={() => console.log("create workspace")}
+        />
+        <FactoriesSidebarNav
+          organizationId={FACTORIES_ORGANIZATION_ID}
+          factoryKey={REFUND_FACTORY.key!}
+          lineId={REFUND_LINE_PLAN_ID}
+          canOpenSettings
+          canCreateWorkOrder
+          permissionsLoading={false}
+          onCreateWorkOrder={() => console.log("create work order")}
         />
       </aside>
       <div className="min-w-0 flex-1">

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.tsx
@@ -89,7 +89,7 @@ export function WorkspacePageHeader(props: WorkspacePageHeaderProps) {
             </p>
           ) : null}
           <div className={cn("flex min-w-0 flex-wrap items-center gap-3", isEntity && "mt-1")}>
-            <h1 className="workspace-page-title min-w-0" data-testid="workspace-page-header-title">
+            <h1 className="workspace-page-title min-w-0 overflow-visible" data-testid="workspace-page-header-title">
               {props.title}
             </h1>
             {!isEntity && props.leading ? <div className="flex items-center gap-2">{props.leading}</div> : null}

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.spec.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.spec.tsx
@@ -4,7 +4,11 @@ import { MemoryRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 
 import { TooltipProvider } from "@/ui/tooltip";
-import { FACTORIES_ORGANIZATION_ID, REFUND_FACTORY } from "../__fixtures__/factoryPageResponses";
+import {
+  ACME_ONBOARDING_FACTORY,
+  FACTORIES_ORGANIZATION_ID,
+  REFUND_FACTORY,
+} from "../__fixtures__/factoryPageResponses";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 
 function renderSwitcher() {
@@ -14,7 +18,7 @@ function renderSwitcher() {
         <WorkspaceSwitcher
           organizationId={FACTORIES_ORGANIZATION_ID}
           factory={REFUND_FACTORY}
-          factories={[REFUND_FACTORY]}
+          factories={[REFUND_FACTORY, ACME_ONBOARDING_FACTORY]}
           canCreateFactory
           permissionsLoading={false}
           onCreateFactory={() => undefined}
@@ -33,5 +37,8 @@ describe("WorkspaceSwitcher", () => {
     expect(trigger).toHaveAccessibleName(/Switch workspace, Semaphore/);
     await user.click(trigger);
     expect(screen.getByTestId(`factories-workspace-option-${REFUND_FACTORY.id}`)).toHaveTextContent("Semaphore");
+    expect(screen.getByTestId(`factories-workspace-option-${ACME_ONBOARDING_FACTORY.id}`)).toHaveTextContent(
+      "Acme onboarding",
+    );
   });
 });

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.spec.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.spec.tsx
@@ -5,7 +5,6 @@ import { describe, expect, it } from "vitest";
 
 import { TooltipProvider } from "@/ui/tooltip";
 import { FACTORIES_ORGANIZATION_ID, REFUND_FACTORY } from "../__fixtures__/factoryPageResponses";
-import { factorySettingsPath } from "../lib/factoryPagePaths";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 
 function renderSwitcher() {
@@ -16,7 +15,6 @@ function renderSwitcher() {
           organizationId={FACTORIES_ORGANIZATION_ID}
           factory={REFUND_FACTORY}
           factories={[REFUND_FACTORY]}
-          canOpenSettings
           canCreateFactory
           permissionsLoading={false}
           onCreateFactory={() => undefined}
@@ -35,12 +33,5 @@ describe("WorkspaceSwitcher", () => {
     expect(trigger).toHaveAccessibleName(/Switch workspace, Semaphore/);
     await user.click(trigger);
     expect(screen.getByTestId(`factories-workspace-option-${REFUND_FACTORY.id}`)).toHaveTextContent("Semaphore");
-  });
-
-  it("links workspace settings from the rail", () => {
-    renderSwitcher();
-
-    const settingsLink = screen.getByTestId("factories-workspace-settings-link");
-    expect(settingsLink).toHaveAttribute("href", factorySettingsPath(FACTORIES_ORGANIZATION_ID, REFUND_FACTORY.key!));
   });
 });

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.stories.tsx
@@ -2,7 +2,12 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
 import { withFactoriesTheme } from "../__fixtures__/factoriesStoryTheme";
-import { EMPTY_FACTORY, FACTORIES_ORGANIZATION_ID, REFUND_FACTORY } from "../__fixtures__/factoryPageResponses";
+import {
+  ACME_ONBOARDING_FACTORY,
+  EMPTY_FACTORY,
+  FACTORIES_ORGANIZATION_ID,
+  REFUND_FACTORY,
+} from "../__fixtures__/factoryPageResponses";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 
 const meta = {
@@ -34,7 +39,7 @@ export const Default: Story = {
   args: {
     organizationId: FACTORIES_ORGANIZATION_ID,
     factory: REFUND_FACTORY,
-    factories: [REFUND_FACTORY, EMPTY_FACTORY],
+    factories: [REFUND_FACTORY, EMPTY_FACTORY, ACME_ONBOARDING_FACTORY],
     canCreateFactory: true,
     permissionsLoading: false,
     onCreateFactory: () => console.log("create workspace"),

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
     layout: "padded",
     docs: {
       description: {
-        component: "The workspace initials open the switcher. The gear opens settings.",
+        component: "The workspace initials open the switcher.",
       },
     },
   },
@@ -35,7 +35,6 @@ export const Default: Story = {
     organizationId: FACTORIES_ORGANIZATION_ID,
     factory: REFUND_FACTORY,
     factories: [REFUND_FACTORY, EMPTY_FACTORY],
-    canOpenSettings: true,
     canCreateFactory: true,
     permissionsLoading: false,
     onCreateFactory: () => console.log("create workspace"),
@@ -45,7 +44,6 @@ export const Default: Story = {
 export const ReadOnly: Story = {
   args: {
     ...Default.args!,
-    canOpenSettings: false,
     canCreateFactory: false,
   },
 };

--- a/web_src/src/pages/factories/layout/WorkspaceSwitcher.tsx
+++ b/web_src/src/pages/factories/layout/WorkspaceSwitcher.tsx
@@ -9,16 +9,15 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
 import { cn } from "@/lib/utils";
-import { Check, Plus, Settings, Triangle } from "lucide-react";
-import { Link, useNavigate } from "react-router";
-import { factoryDetailPath, factorySettingsPath } from "../lib/factoryPagePaths";
+import { Check, Plus, Triangle } from "lucide-react";
+import { useNavigate } from "react-router";
+import { factoryDetailPath } from "../lib/factoryPagePaths";
 import { factoriesRailControlClassName, initialsForName } from "./factoriesRail";
 
 interface WorkspaceSwitcherProps {
   organizationId: string;
   factory: FactoriesFactory;
   factories: FactoriesFactory[];
-  canOpenSettings: boolean;
   canCreateFactory: boolean;
   permissionsLoading: boolean;
   onCreateFactory: () => void;
@@ -28,13 +27,11 @@ export function WorkspaceSwitcher({
   organizationId,
   factory,
   factories,
-  canOpenSettings,
   canCreateFactory,
   permissionsLoading,
   onCreateFactory,
 }: WorkspaceSwitcherProps) {
   const navigate = useNavigate();
-  const settingsHref = factory.key ? factorySettingsPath(organizationId, factory.key) : "#";
   const workspaceName = factory.name?.trim() || "Workspace";
 
   return (
@@ -95,25 +92,6 @@ export function WorkspaceSwitcher({
           </PermissionTooltip>
         </DropdownMenuContent>
       </DropdownMenu>
-      <PermissionTooltip
-        allowed={canOpenSettings || permissionsLoading}
-        message="You don't have permission to open workspace settings."
-      >
-        <Link
-          to={canOpenSettings ? settingsHref : "#"}
-          onClick={(event) => {
-            if (!canOpenSettings) {
-              event.preventDefault();
-            }
-          }}
-          aria-label="Workspace settings"
-          title="Workspace settings"
-          data-testid="factories-workspace-settings-link"
-          className={cn(factoriesRailControlClassName, !canOpenSettings && "pointer-events-none opacity-60")}
-        >
-          <Settings className="size-3.5" aria-hidden />
-        </Link>
-      </PermissionTooltip>
     </div>
   );
 }

--- a/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
@@ -25,14 +25,14 @@ describe("resolveFactoryAppBackNav", () => {
 
   it("returns line detail when lineId present", () => {
     expect(resolveFactoryAppBackNav("org", "fac", { from: "lines", lineId: "line-1", lineName: "poc" })).toEqual({
-      label: "poc",
+      label: "Back",
       href: "/org/workspaces/fac/lines/line-1",
     });
   });
 
   it("falls back to the line board when from is missing", () => {
     expect(resolveFactoryAppBackNav("org", "fac", {})).toEqual({
-      label: "Line",
+      label: "Back",
       href: "/org/workspaces/fac/lines",
     });
   });

--- a/web_src/src/pages/factories/lib/factoryAppNav.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.ts
@@ -47,11 +47,11 @@ export function resolveFactoryAppBackNav(
   if (from === "lines") {
     if (options.lineId) {
       return {
-        label: options.lineName?.trim() || "All lines",
+        label: "Back",
         href: factoryLineDetailPath(organizationId, factoryKey, options.lineId),
       };
     }
-    return { label: "All lines", href: linesPath(organizationId, factoryKey) };
+    return { label: "Back", href: linesPath(organizationId, factoryKey) };
   }
 
   if (from === "work-order") {
@@ -65,5 +65,5 @@ export function resolveFactoryAppBackNav(
     return { label: "Work Orders", href: workOrdersPath(organizationId, factoryKey) };
   }
 
-  return { label: "Line", href: factoryHomePath(organizationId, factoryKey) };
+  return { label: "Back", href: factoryHomePath(organizationId, factoryKey) };
 }

--- a/web_src/src/pages/factories/lib/factoryLineFormShared.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryLineFormShared.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  setParallelismLabel,
+  clampLineStepParallelism,
+  DEFAULT_LINE_STEP_PARALLELISM,
+  lineStepParallelism,
+  replaceLineStepParallelism,
+} from "./factoryLineFormShared";
+
+describe("lineStepParallelism", () => {
+  it("uses 10 when the step has no value", () => {
+    expect(lineStepParallelism(undefined)).toBe(DEFAULT_LINE_STEP_PARALLELISM);
+    expect(lineStepParallelism({})).toBe(10);
+    expect(lineStepParallelism({ maxParallelism: 25 })).toBe(25);
+  });
+
+  it("clamps values to 1–100", () => {
+    expect(clampLineStepParallelism(0)).toBe(1);
+    expect(clampLineStepParallelism(140)).toBe(100);
+    expect(clampLineStepParallelism(12.6)).toBe(13);
+  });
+
+  it("names the menu item with the current value", () => {
+    expect(setParallelismLabel(10)).toBe("Set parallelism (10)");
+  });
+
+  it("writes parallelism onto one step and keeps the others", () => {
+    const steps = replaceLineStepParallelism(
+      [
+        { type: "runApp", app: { app: "app-plan", entrypoint: "start-plan" } },
+        { type: "runApp", app: { app: "app-impl", entrypoint: "start-impl" }, maxParallelism: 4 },
+      ],
+      0,
+      20,
+    );
+
+    expect(steps[0]?.maxParallelism).toBe(20);
+    expect(steps[1]?.maxParallelism).toBe(4);
+  });
+});

--- a/web_src/src/pages/factories/lib/factoryLineFormShared.ts
+++ b/web_src/src/pages/factories/lib/factoryLineFormShared.ts
@@ -2,6 +2,10 @@ import type { FactoryLineStep } from "@/api-client";
 
 export const RUN_APP_TYPE = "runApp";
 
+export const DEFAULT_LINE_STEP_PARALLELISM = 10;
+export const LINE_STEP_PARALLELISM_MIN = 1;
+export const LINE_STEP_PARALLELISM_MAX = 100;
+
 export type DraftStep = {
   appId: string;
   entrypoint: string;
@@ -42,6 +46,39 @@ export function draftStepsToProto(steps: DraftStep[]): FactoryLineStep[] {
 
     return proto;
   });
+}
+
+export function lineStepParallelism(step: { maxParallelism?: number | null } | undefined): number {
+  const value = step?.maxParallelism;
+  if (value == null || value < LINE_STEP_PARALLELISM_MIN || value > LINE_STEP_PARALLELISM_MAX) {
+    return DEFAULT_LINE_STEP_PARALLELISM;
+  }
+  return value;
+}
+
+export function clampLineStepParallelism(value: number): number {
+  return Math.min(LINE_STEP_PARALLELISM_MAX, Math.max(LINE_STEP_PARALLELISM_MIN, Math.round(value)));
+}
+
+export function setParallelismLabel(parallelism: number): string {
+  return `Set parallelism (${parallelism})`;
+}
+
+export function replaceLineStepParallelism(
+  steps: FactoryLineStep[] | undefined,
+  stepIndex: number,
+  parallelism: number,
+): FactoryLineStep[] {
+  const drafts = draftStepsFromLine(steps);
+  const current = drafts[stepIndex];
+  if (!current) {
+    return draftStepsToProto(drafts);
+  }
+  drafts[stepIndex] = {
+    ...current,
+    maxParallelism: String(clampLineStepParallelism(parallelism)),
+  };
+  return draftStepsToProto(drafts);
 }
 
 // Null keeps the server default (10).

--- a/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
@@ -7,6 +7,8 @@ import {
   factoryDetailPath,
   factoryHomePath,
   factoryIntakePath,
+  intakeSettingsTabFromSearch,
+  intakeSourceFromSearch,
   isIntakeSearchOpen,
   factorySettingsGeneralPathAfterKeyChange,
   firstFactoryLineId,
@@ -43,6 +45,25 @@ describe("factoryIntakePath", () => {
     expect(isIntakeSearchOpen("?intake=1")).toBe(true);
     expect(isIntakeSearchOpen("intake=1")).toBe(true);
     expect(isIntakeSearchOpen("")).toBe(false);
+  });
+
+  it("opens the line board with a selected intake source", () => {
+    expect(factoryIntakePath("org-1", "SP", "line-plan", "github-issues")).toBe(
+      "/org-1/workspaces/SP/lines/line-plan?intake=1&source=github-issues",
+    );
+    expect(factoryIntakePath("org-1", "SP", "line-plan", "github-issues", "automation")).toBe(
+      "/org-1/workspaces/SP/lines/line-plan?intake=1&source=github-issues&settings=automation",
+    );
+  });
+
+  it("reads the intake source from the search string", () => {
+    expect(intakeSourceFromSearch("?intake=1&source=github-issues")).toBe("github-issues");
+    expect(intakeSourceFromSearch("intake=1")).toBeNull();
+  });
+
+  it("reads the settings tab from the search string", () => {
+    expect(intakeSettingsTabFromSearch("?intake=1&settings=automation")).toBe("automation");
+    expect(intakeSettingsTabFromSearch("intake=1")).toBeNull();
   });
 });
 

--- a/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
@@ -6,6 +6,8 @@ import {
   factoryAppViewPath,
   factoryDetailPath,
   factoryHomePath,
+  factoryIntakePath,
+  isIntakeSearchOpen,
   factorySettingsGeneralPathAfterKeyChange,
   firstFactoryLineId,
   legacyWorkOrderDetailPath,
@@ -29,6 +31,18 @@ describe("factoryHomePath", () => {
 
   it("opens the lines list when no line id is present", () => {
     expect(factoryHomePath("org-1", "SP")).toBe("/org-1/workspaces/SP/lines");
+  });
+});
+
+describe("factoryIntakePath", () => {
+  it("opens the line board with the intake query", () => {
+    expect(factoryIntakePath("org-1", "SP", "line-plan")).toBe("/org-1/workspaces/SP/lines/line-plan?intake=1");
+  });
+
+  it("reads the intake query from the search string", () => {
+    expect(isIntakeSearchOpen("?intake=1")).toBe(true);
+    expect(isIntakeSearchOpen("intake=1")).toBe(true);
+    expect(isIntakeSearchOpen("")).toBe(false);
   });
 });
 

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -35,14 +35,37 @@ export function factoryHomePath(organizationId: string, factoryKey: string, line
 
 /** Opens the line board with the Intake drawer beside the columns. */
 export const INTAKE_SEARCH_PARAM = "intake";
+/** Selects an intake source when the drawer opens. */
+export const INTAKE_SOURCE_SEARCH_PARAM = "source";
+/** Opens GitHub issues settings on a tab: general, runs, or automation. */
+export const INTAKE_SETTINGS_SEARCH_PARAM = "settings";
 
-export function factoryIntakePath(organizationId: string, factoryKey: string, lineId?: string | null) {
-  return `${factoryHomePath(organizationId, factoryKey, lineId)}?${INTAKE_SEARCH_PARAM}=1`;
+export function factoryIntakePath(
+  organizationId: string,
+  factoryKey: string,
+  lineId?: string | null,
+  sourceId?: string,
+  settingsTab?: string,
+) {
+  const path = `${factoryHomePath(organizationId, factoryKey, lineId)}?${INTAKE_SEARCH_PARAM}=1`;
+  const sourceQuery = sourceId ? `&${INTAKE_SOURCE_SEARCH_PARAM}=${encodeURIComponent(sourceId)}` : "";
+  const settingsQuery = settingsTab ? `&${INTAKE_SETTINGS_SEARCH_PARAM}=${encodeURIComponent(settingsTab)}` : "";
+  return `${path}${sourceQuery}${settingsQuery}`;
 }
 
 export function isIntakeSearchOpen(search: string): boolean {
   const query = search.startsWith("?") ? search.slice(1) : search;
   return new URLSearchParams(query).get(INTAKE_SEARCH_PARAM) === "1";
+}
+
+export function intakeSourceFromSearch(search: string): string | null {
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  return new URLSearchParams(query).get(INTAKE_SOURCE_SEARCH_PARAM);
+}
+
+export function intakeSettingsTabFromSearch(search: string): string | null {
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  return new URLSearchParams(query).get(INTAKE_SETTINGS_SEARCH_PARAM);
 }
 
 export function factorySetupPath(organizationId: string, factoryKey: string) {

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -33,6 +33,18 @@ export function factoryHomePath(organizationId: string, factoryKey: string, line
   return linesPath(organizationId, factoryKey);
 }
 
+/** Opens the line board with the Intake drawer beside the columns. */
+export const INTAKE_SEARCH_PARAM = "intake";
+
+export function factoryIntakePath(organizationId: string, factoryKey: string, lineId?: string | null) {
+  return `${factoryHomePath(organizationId, factoryKey, lineId)}?${INTAKE_SEARCH_PARAM}=1`;
+}
+
+export function isIntakeSearchOpen(search: string): boolean {
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  return new URLSearchParams(query).get(INTAKE_SEARCH_PARAM) === "1";
+}
+
 export function factorySetupPath(organizationId: string, factoryKey: string) {
   return `${factoryDetailPath(organizationId, factoryKey)}/setup`;
 }

--- a/web_src/src/pages/factories/lib/humanizeLineName.spec.ts
+++ b/web_src/src/pages/factories/lib/humanizeLineName.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatLinePhaseDescription, humanizeLineName } from "./humanizeLineName";
+import { humanizeLineName } from "./humanizeLineName";
 
 describe("humanizeLineName", () => {
   it("turns kebab-case into title case and keeps connectors lowercase", () => {
@@ -14,26 +14,5 @@ describe("humanizeLineName", () => {
   it("falls back when the name is empty", () => {
     expect(humanizeLineName("")).toBe("Unnamed line");
     expect(humanizeLineName(undefined)).toBe("Unnamed line");
-  });
-});
-
-describe("formatLinePhaseDescription", () => {
-  it("joins automation names as a flow", () => {
-    expect(
-      formatLinePhaseDescription(
-        [{ app: { app: "app-plan" } }, { app: { app: "app-implement" } }, { app: { app: "app-verify" } }],
-        [
-          { id: "app-plan", name: "Refund Planner" },
-          { id: "app-implement", name: "Refund Implementer" },
-          { id: "app-verify", name: "Refund Verifier" },
-        ],
-      ),
-    ).toBe("Refund Planner → Refund Implementer → Refund Verifier");
-  });
-
-  it("returns undefined when there are no named phases", () => {
-    expect(formatLinePhaseDescription([], [])).toBeUndefined();
-    expect(formatLinePhaseDescription(undefined, undefined)).toBeUndefined();
-    expect(formatLinePhaseDescription([{ app: { app: "missing" } }], [])).toBeUndefined();
   });
 });

--- a/web_src/src/pages/factories/lib/humanizeLineName.ts
+++ b/web_src/src/pages/factories/lib/humanizeLineName.ts
@@ -20,24 +20,3 @@ export function humanizeLineName(name: string | undefined | null): string {
     })
     .join(" ");
 }
-
-/**
- * Short line description when the API has no description field:
- * automation names joined as a flow, e.g. `Refund Planner → Refund Implementer`.
- */
-export function formatLinePhaseDescription(
-  steps: Array<{ app?: { app?: string } }> | undefined | null,
-  apps: Array<{ id?: string; name?: string }> | undefined | null,
-): string | undefined {
-  const names = (steps ?? [])
-    .map((step) => {
-      const appId = step.app?.app?.trim();
-      return apps?.find((app) => app.id === appId)?.name?.trim();
-    })
-    .filter((name): name is string => Boolean(name));
-
-  if (names.length === 0) {
-    return undefined;
-  }
-  return names.join(" → ");
-}

--- a/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.spec.ts
@@ -12,6 +12,7 @@ import {
   collectLineBacklogOrders,
   findBacklogAutomationApp,
   findClosureAutomationApp,
+  isDoneLineColumn,
   linePhaseRunHref,
   resolvePhaseRunStatus,
 } from "./linePhaseRuns";
@@ -428,6 +429,14 @@ describe("findClosureAutomationApp", () => {
       id: "app-refund-done",
       name: "PR Closure",
     });
+  });
+});
+
+describe("isDoneLineColumn", () => {
+  it("treats the Done name and the closure app id as special columns", () => {
+    expect(isDoneLineColumn({ stepName: "Done", appId: "app-plan" })).toBe(true);
+    expect(isDoneLineColumn({ stepName: "Phase 4", appId: "app-refund-done" })).toBe(true);
+    expect(isDoneLineColumn({ stepName: "Plan", appId: "app-plan" })).toBe(false);
   });
 });
 

--- a/web_src/src/pages/factories/lib/linePhaseRuns.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.ts
@@ -129,6 +129,17 @@ export function findClosureAutomationApp(
   return { id: match.id, name: match.name ?? "PR Closure" };
 }
 
+/** Backlog and Done are not canvas-backed columns. */
+export function isDoneLineColumn(column: Pick<LinePhaseColumn, "stepName" | "appId">): boolean {
+  if (column.stepName.trim().toLowerCase() === "done") {
+    return true;
+  }
+  if (!column.appId) {
+    return false;
+  }
+  return column.appId === "app-refund-done" || column.appId.includes("pr-closure");
+}
+
 function isLineBacklogOrder(order: FactoriesWorkOrder): boolean {
   if (!order.id || order.state !== "STATE_DRAFT") {
     return false;

--- a/web_src/src/pages/factories/lib/linePhaseRuns.ts
+++ b/web_src/src/pages/factories/lib/linePhaseRuns.ts
@@ -4,7 +4,7 @@ import type {
   FactoriesWorkOrderExecution,
   FactoriesWorkOrderLineDispatch,
 } from "@/api-client";
-import { automationNameForLineStep } from "./factoryLineFormShared";
+import { automationNameForLineStep, lineStepParallelism } from "./factoryLineFormShared";
 import { factoryAppPath, factoryAppRunPath, linesPath } from "./factoryPagePaths";
 import {
   dispatchStepRows,
@@ -31,6 +31,8 @@ export type LinePhaseColumn = {
   stepIndex: number;
   /** Factory app id for this runApp step, when present. */
   appId?: string;
+  /** In-flight cap for this step. Defaults to 10 when the line omits it. */
+  maxParallelism: number;
   runs: LinePhaseRunCard[];
   tick: LinePhaseTick;
 };
@@ -89,6 +91,7 @@ export function buildLinePhaseBoard(
       stepName: automationNameForLineStep(step, apps, stepIndex),
       stepIndex,
       appId,
+      maxParallelism: lineStepParallelism(step),
       runs,
       tick: resolvePhaseTick(runs),
     };

--- a/web_src/src/pages/factories/pages/AddIntakePicker.tsx
+++ b/web_src/src/pages/factories/pages/AddIntakePicker.tsx
@@ -1,0 +1,103 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Search } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { filterAddIntakeTemplates, type AddIntakeTemplate } from "./lineIntakeModel";
+
+interface AddIntakePickerProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (template: AddIntakeTemplate) => void;
+}
+
+/**
+ * Lightweight picker: search, then choose one intake template box.
+ */
+export function AddIntakePicker({ open, onClose, onSelect }: AddIntakePickerProps) {
+  const [query, setQuery] = useState("");
+  const templates = useMemo(() => filterAddIntakeTemplates(query), [query]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+    }
+  }, [open]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent className="gap-0 p-0 sm:max-w-lg" showCloseButton data-testid="add-intake-picker">
+        <DialogHeader className="border-b border-border px-4 py-3 text-left">
+          <DialogTitle className="text-[15px] font-semibold tracking-[-0.01em]">Add intake</DialogTitle>
+          <DialogDescription className="workspace-body-text text-muted-foreground">
+            Choose a template for a new intake automation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="border-b border-border px-4 py-3">
+          <label className="relative block">
+            <Search
+              className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+              aria-hidden
+            />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search intakes"
+              aria-label="Search intakes"
+              className="h-9 pl-8 text-[13px] shadow-none"
+              data-testid="add-intake-search"
+              autoFocus
+            />
+          </label>
+        </div>
+
+        <ul
+          className="grid max-h-[min(24rem,50vh)] grid-cols-2 gap-2 overflow-y-auto p-3 [scrollbar-width:thin]"
+          data-testid="add-intake-templates"
+        >
+          {templates.length === 0 ? (
+            <li className="col-span-2 px-2 py-8 text-center">
+              <p className="workspace-body-text text-muted-foreground">No intakes match this search.</p>
+            </li>
+          ) : (
+            templates.map((template) => (
+              <li key={template.id}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(template)}
+                  data-testid={`add-intake-template-${template.id}`}
+                  className="flex h-full min-h-24 w-full flex-col items-start gap-1 rounded-lg border border-border bg-card px-3 py-2.5 text-left shadow-sm transition-colors hover:border-foreground/20 hover:bg-accent/40"
+                >
+                  <TemplateGlyph template={template} />
+                  <span className="text-[13px] font-medium tracking-[-0.01em] leading-5 text-foreground">
+                    {template.name}
+                  </span>
+                  <span className="workspace-body-text text-muted-foreground">{template.description}</span>
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TemplateGlyph({ template }: { template: AddIntakeTemplate }) {
+  if (template.iconSrc) {
+    return <img src={template.iconSrc} alt="" className="size-5 shrink-0" />;
+  }
+  return (
+    <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted text-[11px] font-medium text-muted-foreground">
+      {template.name.charAt(0)}
+    </span>
+  );
+}

--- a/web_src/src/pages/factories/pages/BacklogSettingsDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/BacklogSettingsDialog.spec.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { BacklogSettingsDialog } from "./BacklogSettingsDialog";
+
+describe("BacklogSettingsDialog", () => {
+  it("saves the name and a positive size", async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+
+    render(<BacklogSettingsDialog open name="Backlog" size={null} onSave={onSave} onClose={vi.fn()} />);
+
+    const name = screen.getByLabelText("Name");
+    const size = screen.getByLabelText("Size");
+    await user.clear(name);
+    await user.type(name, "Inbox");
+    await user.type(size, "8");
+    await user.click(screen.getByTestId("lines-backlog-settings-save"));
+
+    expect(onSave).toHaveBeenCalledWith({ name: "Inbox", size: 8 });
+  });
+
+  it("keeps size empty when the field is blank", async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+
+    render(<BacklogSettingsDialog open name="Backlog" size={12} onSave={onSave} onClose={vi.fn()} />);
+
+    await user.clear(screen.getByLabelText("Size"));
+    await user.click(screen.getByTestId("lines-backlog-settings-save"));
+
+    expect(onSave).toHaveBeenCalledWith({ name: "Backlog", size: null });
+  });
+
+  it("rejects a size that is not a positive whole number", async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+
+    render(<BacklogSettingsDialog open name="Backlog" size={null} onSave={onSave} onClose={vi.fn()} />);
+
+    await user.type(screen.getByLabelText("Size"), "0");
+    await user.click(screen.getByTestId("lines-backlog-settings-save"));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText("Enter a whole number of 1 or more.")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/BacklogSettingsDialog.tsx
+++ b/web_src/src/pages/factories/pages/BacklogSettingsDialog.tsx
@@ -1,0 +1,135 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useEffect, useState } from "react";
+
+export type BacklogSettings = {
+  name: string;
+  size: number | null;
+};
+
+interface BacklogSettingsDialogProps {
+  open: boolean;
+  name: string;
+  size: number | null;
+  onSave: (settings: BacklogSettings) => void;
+  onClose: () => void;
+}
+
+const SIZE_ERROR = "Enter a whole number of 1 or more.";
+
+function parseBacklogSize(value: string): { size: number | null; error?: string } {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { size: null };
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    return { size: null, error: SIZE_ERROR };
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (parsed < 1) {
+    return { size: null, error: SIZE_ERROR };
+  }
+  return { size: parsed };
+}
+
+export function BacklogSettingsDialog({ open, name, size, onSave, onClose }: BacklogSettingsDialogProps) {
+  const [draftName, setDraftName] = useState(name);
+  const [draftSize, setDraftSize] = useState(size == null ? "" : String(size));
+  const [nameError, setNameError] = useState("");
+  const [sizeError, setSizeError] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setDraftName(name);
+    setDraftSize(size == null ? "" : String(size));
+    setNameError("");
+    setSizeError("");
+  }, [open, name, size]);
+
+  const handleSave = () => {
+    const trimmedName = draftName.trim();
+    if (!trimmedName) {
+      setNameError("Enter a name.");
+      return;
+    }
+    const parsed = parseBacklogSize(draftSize);
+    if (parsed.error) {
+      setSizeError(parsed.error);
+      return;
+    }
+    onSave({ name: trimmedName, size: parsed.size });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-md" data-testid="lines-backlog-settings">
+        <DialogHeader>
+          <DialogTitle>Edit backlog</DialogTitle>
+          <DialogDescription>Set the column name and the maximum number of work orders.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="lines-backlog-settings-name">Name</Label>
+            <Input
+              id="lines-backlog-settings-name"
+              value={draftName}
+              onChange={(event) => {
+                setDraftName(event.target.value);
+                if (nameError) {
+                  setNameError("");
+                }
+              }}
+              autoFocus
+            />
+            {nameError ? <p className="text-xs text-red-600">{nameError}</p> : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="lines-backlog-settings-size">Size</Label>
+            <Input
+              id="lines-backlog-settings-size"
+              inputMode="numeric"
+              value={draftSize}
+              onChange={(event) => {
+                setDraftSize(event.target.value);
+                if (sizeError) {
+                  setSizeError("");
+                }
+              }}
+            />
+            <p className="text-xs text-muted-foreground">Maximum number of work orders. Leave empty for no limit.</p>
+            {sizeError ? <p className="text-xs text-red-600">{sizeError}</p> : null}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} data-testid="lines-backlog-settings-save">
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { ColumnLaneMenu } from "./ColumnLaneMenu";
+
+describe("ColumnLaneMenu", () => {
+  it("offers circular colour swatches and applies a selection", async () => {
+    const onColorChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ColumnLaneMenu
+          title="Backlog"
+          testId="lines-backlog-menu"
+          editHref="/edit"
+          colorId={null}
+          onColorChange={onColorChange}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("lines-backlog-menu"));
+    expect(screen.getByText("Set color")).toBeInTheDocument();
+    expect(screen.getByTestId("lines-backlog-menu-color-lime")).toHaveAttribute("aria-label", "Lime");
+
+    await user.click(screen.getByTestId("lines-backlog-menu-color-lime"));
+    expect(onColorChange).toHaveBeenCalledWith("lime");
+  });
+
+  it("removes the colour when requested", async () => {
+    const onColorChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ColumnLaneMenu title="Plan" testId="lines-phase-menu-0" colorId="sky" onColorChange={onColorChange} />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("lines-phase-menu-0"));
+    expect(screen.getByTestId("lines-phase-menu-0-color-sky")).toHaveAttribute("aria-selected", "true");
+    await user.click(screen.getByTestId("lines-phase-menu-0-color-remove"));
+    expect(onColorChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
@@ -15,7 +15,7 @@ describe("ColumnLaneMenu", () => {
         <ColumnLaneMenu
           title="Backlog"
           testId="lines-backlog-menu"
-          editHref="/edit"
+          onEdit={vi.fn()}
           colorId={null}
           onColorChange={onColorChange}
         />
@@ -44,5 +44,40 @@ describe("ColumnLaneMenu", () => {
     expect(screen.getByTestId("lines-phase-menu-0-color-sky")).toHaveAttribute("aria-selected", "true");
     await user.click(screen.getByTestId("lines-phase-menu-0-color-remove"));
     expect(onColorChange).toHaveBeenCalledWith(null);
+  });
+
+  it("calls onEdit instead of following a canvas href", async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ColumnLaneMenu
+          title="Backlog"
+          testId="lines-backlog-menu"
+          editHref="/canvas-edit"
+          onEdit={onEdit}
+          colorId={null}
+          onColorChange={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("lines-backlog-menu"));
+    await user.click(screen.getByTestId("lines-backlog-menu-edit"));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Edit when the column has no editor", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ColumnLaneMenu title="Done" testId="lines-phase-menu-3" colorId={null} onColorChange={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("lines-phase-menu-3"));
+    expect(screen.queryByTestId("lines-phase-menu-3-edit")).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ColumnLaneMenu } from "./ColumnLaneMenu";
 
 describe("ColumnLaneMenu", () => {
-  it("offers circular colour swatches and applies a selection", async () => {
+  it("offers colour swatches and applies a selection", async () => {
     const onColorChange = vi.fn();
     const user = userEvent.setup();
 

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.spec.tsx
@@ -68,6 +68,51 @@ describe("ColumnLaneMenu", () => {
     expect(onEdit).toHaveBeenCalledTimes(1);
   });
 
+  it("uses the supplied Edit label for canvas columns", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ColumnLaneMenu
+          title="Plan"
+          testId="lines-phase-menu-0"
+          editHref="/canvas-edit"
+          editLabel="Edit Automation"
+          colorId={null}
+          onColorChange={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("lines-phase-menu-0"));
+    expect(screen.getByTestId("lines-phase-menu-0-edit")).toHaveTextContent("Edit Automation");
+  });
+
+  it("offers Set parallelism with the current value", async () => {
+    const onSetParallelism = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ColumnLaneMenu
+          title="Implement"
+          testId="lines-phase-menu-1"
+          editHref="/canvas-edit"
+          editLabel="Edit Automation"
+          onSetParallelism={onSetParallelism}
+          parallelism={10}
+          colorId={null}
+          onColorChange={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("lines-phase-menu-1"));
+    expect(screen.getByTestId("lines-phase-menu-1-parallelism")).toHaveTextContent("Set parallelism (10)");
+    await user.click(screen.getByTestId("lines-phase-menu-1-parallelism"));
+    expect(onSetParallelism).toHaveBeenCalledTimes(1);
+  });
+
   it("hides Edit when the column has no editor", async () => {
     const user = userEvent.setup();
 

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
@@ -1,0 +1,100 @@
+import { Check, MoreHorizontal, Pencil, XIcon } from "lucide-react";
+import { useNavigate } from "react-router";
+
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdownMenu";
+
+import { LINE_BOARD_COLUMN_COLORS, type LineBoardColumnColorId } from "./lineBoardColumnColors";
+
+interface ColumnLaneMenuProps {
+  title: string;
+  testId: string;
+  /** Opens the automation editor when present. */
+  editHref?: string | null;
+  colorId: LineBoardColumnColorId | null;
+  onColorChange: (colorId: LineBoardColumnColorId | null) => void;
+}
+
+/**
+ * Column header menu: Edit (optional) and circular color swatches
+ * inspired by Apple Notes / HoneyBook tag pickers.
+ */
+export function ColumnLaneMenu({ title, testId, editHref, colorId, onColorChange }: ColumnLaneMenuProps) {
+  const navigate = useNavigate();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${title} menu`}
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          data-testid={testId}
+        >
+          <MoreHorizontal className="size-3.5" aria-hidden />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[13.5rem] p-0" data-testid={`${testId}-content`}>
+        {editHref ? (
+          <>
+            <div className="p-1">
+              <DropdownMenuItem onClick={() => navigate(editHref)} data-testid={`${testId}-edit`}>
+                <Pencil className="h-3.5 w-3.5" aria-hidden />
+                Edit
+              </DropdownMenuItem>
+            </div>
+            <DropdownMenuSeparator className="my-0" />
+          </>
+        ) : null}
+
+        <div className="px-3 pb-2 pt-2.5" data-testid={`${testId}-color-picker`}>
+          <DropdownMenuLabel className="px-0 pb-2 pt-0 text-[12px] font-medium text-muted-foreground">
+            Set color
+          </DropdownMenuLabel>
+          <div className="grid grid-cols-5 gap-2" role="listbox" aria-label={`Color for ${title}`}>
+            {LINE_BOARD_COLUMN_COLORS.map((color) => {
+              const selected = colorId === color.id;
+              return (
+                <button
+                  key={color.id}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  aria-label={color.label}
+                  title={color.label}
+                  data-testid={`${testId}-color-${color.id}`}
+                  onClick={() => onColorChange(color.id)}
+                  className={cn(
+                    "relative flex size-6 items-center justify-center rounded-full transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                    color.swatchClassName,
+                    selected && "ring-2 ring-foreground/80 ring-offset-2 ring-offset-background",
+                  )}
+                >
+                  {selected ? <Check className="size-3 text-white drop-shadow-sm" aria-hidden strokeWidth={3} /> : null}
+                </button>
+              );
+            })}
+          </div>
+          {colorId ? (
+            <button
+              type="button"
+              data-testid={`${testId}-color-remove`}
+              onClick={() => onColorChange(null)}
+              className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-md border border-border px-2 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <XIcon className="size-3" aria-hidden />
+              Remove color
+            </button>
+          ) : null}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
@@ -16,8 +16,10 @@ import { LINE_BOARD_COLUMN_COLORS, type LineBoardColumnColorId } from "./lineBoa
 interface ColumnLaneMenuProps {
   title: string;
   testId: string;
-  /** Opens the automation editor when present. */
+  /** Opens the automation canvas. Ignored when onEdit is set. */
   editHref?: string | null;
+  /** Opens column settings. Use this for Backlog instead of a canvas href. */
+  onEdit?: () => void;
   colorId: LineBoardColumnColorId | null;
   onColorChange: (colorId: LineBoardColumnColorId | null) => void;
 }
@@ -25,8 +27,19 @@ interface ColumnLaneMenuProps {
 /**
  * Column header menu: Edit (optional) and a compact colour grid.
  */
-export function ColumnLaneMenu({ title, testId, editHref, colorId, onColorChange }: ColumnLaneMenuProps) {
+export function ColumnLaneMenu({ title, testId, editHref, onEdit, colorId, onColorChange }: ColumnLaneMenuProps) {
   const navigate = useNavigate();
+  const canEdit = Boolean(onEdit || editHref);
+
+  const handleEdit = () => {
+    if (onEdit) {
+      onEdit();
+      return;
+    }
+    if (editHref) {
+      navigate(editHref);
+    }
+  };
 
   return (
     <DropdownMenu>
@@ -41,10 +54,10 @@ export function ColumnLaneMenu({ title, testId, editHref, colorId, onColorChange
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-0 w-32 p-0" data-testid={`${testId}-content`}>
-        {editHref ? (
+        {canEdit ? (
           <>
             <div className="p-1">
-              <DropdownMenuItem onClick={() => navigate(editHref)} data-testid={`${testId}-edit`}>
+              <DropdownMenuItem onClick={handleEdit} data-testid={`${testId}-edit`}>
                 <Pencil className="h-3.5 w-3.5" aria-hidden />
                 Edit
               </DropdownMenuItem>

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
@@ -23,8 +23,7 @@ interface ColumnLaneMenuProps {
 }
 
 /**
- * Column header menu: Edit (optional) and circular color swatches
- * inspired by Apple Notes / HoneyBook tag pickers.
+ * Column header menu: Edit (optional) and a compact colour grid.
  */
 export function ColumnLaneMenu({ title, testId, editHref, colorId, onColorChange }: ColumnLaneMenuProps) {
   const navigate = useNavigate();
@@ -41,7 +40,7 @@ export function ColumnLaneMenu({ title, testId, editHref, colorId, onColorChange
           <MoreHorizontal className="size-3.5" aria-hidden />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-[13.5rem] p-0" data-testid={`${testId}-content`}>
+      <DropdownMenuContent align="end" className="min-w-0 w-32 p-0" data-testid={`${testId}-content`}>
         {editHref ? (
           <>
             <div className="p-1">
@@ -54,11 +53,11 @@ export function ColumnLaneMenu({ title, testId, editHref, colorId, onColorChange
           </>
         ) : null}
 
-        <div className="px-3 pb-2 pt-2.5" data-testid={`${testId}-color-picker`}>
-          <DropdownMenuLabel className="px-0 pb-2 pt-0 text-[12px] font-medium text-muted-foreground">
+        <div className="px-2 pb-2 pt-2" data-testid={`${testId}-color-picker`}>
+          <DropdownMenuLabel className="px-0 pb-1.5 pt-0 text-[12px] font-medium text-muted-foreground">
             Set color
           </DropdownMenuLabel>
-          <div className="grid grid-cols-5 gap-2" role="listbox" aria-label={`Color for ${title}`}>
+          <div className="grid grid-cols-3 gap-1.5" role="listbox" aria-label={`Color for ${title}`}>
             {LINE_BOARD_COLUMN_COLORS.map((color) => {
               const selected = colorId === color.id;
               return (
@@ -72,12 +71,12 @@ export function ColumnLaneMenu({ title, testId, editHref, colorId, onColorChange
                   data-testid={`${testId}-color-${color.id}`}
                   onClick={() => onColorChange(color.id)}
                   className={cn(
-                    "relative flex size-6 items-center justify-center rounded-full transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                    color.swatchClassName,
-                    selected && "ring-2 ring-foreground/80 ring-offset-2 ring-offset-background",
+                    "relative flex aspect-square w-full items-center justify-center rounded-md ring-1 ring-inset ring-black/10 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:ring-white/15",
+                    color.className,
+                    selected && "ring-2 ring-foreground",
                   )}
                 >
-                  {selected ? <Check className="size-3 text-white drop-shadow-sm" aria-hidden strokeWidth={3} /> : null}
+                  {selected ? <Check className="size-3 text-foreground" aria-hidden strokeWidth={3} /> : null}
                 </button>
               );
             })}
@@ -87,7 +86,7 @@ export function ColumnLaneMenu({ title, testId, editHref, colorId, onColorChange
               type="button"
               data-testid={`${testId}-color-remove`}
               onClick={() => onColorChange(null)}
-              className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-md border border-border px-2 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="mt-2 flex w-full items-center justify-center gap-1 rounded-md border border-border px-1.5 py-1 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
               <XIcon className="size-3" aria-hidden />
               Remove color

--- a/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
+++ b/web_src/src/pages/factories/pages/ColumnLaneMenu.tsx
@@ -1,4 +1,4 @@
-import { Check, MoreHorizontal, Pencil, XIcon } from "lucide-react";
+import { Check, MoreHorizontal, Pencil, SlidersHorizontal, XIcon } from "lucide-react";
 import { useNavigate } from "react-router";
 
 import { cn } from "@/lib/utils";
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
 
+import { DEFAULT_LINE_STEP_PARALLELISM, setParallelismLabel } from "../lib/factoryLineFormShared";
 import { LINE_BOARD_COLUMN_COLORS, type LineBoardColumnColorId } from "./lineBoardColumnColors";
 
 interface ColumnLaneMenuProps {
@@ -20,16 +21,32 @@ interface ColumnLaneMenuProps {
   editHref?: string | null;
   /** Opens column settings. Use this for Backlog instead of a canvas href. */
   onEdit?: () => void;
+  /** Menu item copy. Defaults to Edit. */
+  editLabel?: string;
+  /** Opens the parallelism modal for canvas-backed phases. */
+  onSetParallelism?: () => void;
+  parallelism?: number;
   colorId: LineBoardColumnColorId | null;
   onColorChange: (colorId: LineBoardColumnColorId | null) => void;
 }
 
 /**
- * Column header menu: Edit (optional) and a compact colour grid.
+ * Column header menu: Edit (optional) and a single row of colour circles.
  */
-export function ColumnLaneMenu({ title, testId, editHref, onEdit, colorId, onColorChange }: ColumnLaneMenuProps) {
+export function ColumnLaneMenu({
+  title,
+  testId,
+  editHref,
+  onEdit,
+  editLabel = "Edit",
+  onSetParallelism,
+  parallelism = DEFAULT_LINE_STEP_PARALLELISM,
+  colorId,
+  onColorChange,
+}: ColumnLaneMenuProps) {
   const navigate = useNavigate();
   const canEdit = Boolean(onEdit || editHref);
+  const hasActions = canEdit || Boolean(onSetParallelism);
 
   const handleEdit = () => {
     if (onEdit) {
@@ -53,14 +70,22 @@ export function ColumnLaneMenu({ title, testId, editHref, onEdit, colorId, onCol
           <MoreHorizontal className="size-3.5" aria-hidden />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-0 w-32 p-0" data-testid={`${testId}-content`}>
-        {canEdit ? (
+      <DropdownMenuContent align="end" className="min-w-32 w-max p-0" data-testid={`${testId}-content`}>
+        {hasActions ? (
           <>
             <div className="p-1">
-              <DropdownMenuItem onClick={handleEdit} data-testid={`${testId}-edit`}>
-                <Pencil className="h-3.5 w-3.5" aria-hidden />
-                Edit
-              </DropdownMenuItem>
+              {canEdit ? (
+                <DropdownMenuItem onClick={handleEdit} data-testid={`${testId}-edit`}>
+                  <Pencil className="h-3.5 w-3.5" aria-hidden />
+                  {editLabel}
+                </DropdownMenuItem>
+              ) : null}
+              {onSetParallelism ? (
+                <DropdownMenuItem onClick={onSetParallelism} data-testid={`${testId}-parallelism`}>
+                  <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden />
+                  {setParallelismLabel(parallelism)}
+                </DropdownMenuItem>
+              ) : null}
             </div>
             <DropdownMenuSeparator className="my-0" />
           </>
@@ -70,7 +95,7 @@ export function ColumnLaneMenu({ title, testId, editHref, onEdit, colorId, onCol
           <DropdownMenuLabel className="px-0 pb-1.5 pt-0 text-[12px] font-medium text-muted-foreground">
             Set color
           </DropdownMenuLabel>
-          <div className="grid grid-cols-3 gap-1.5" role="listbox" aria-label={`Color for ${title}`}>
+          <div className="flex items-center gap-1" role="listbox" aria-label={`Color for ${title}`}>
             {LINE_BOARD_COLUMN_COLORS.map((color) => {
               const selected = colorId === color.id;
               return (
@@ -84,12 +109,12 @@ export function ColumnLaneMenu({ title, testId, editHref, onEdit, colorId, onCol
                   data-testid={`${testId}-color-${color.id}`}
                   onClick={() => onColorChange(color.id)}
                   className={cn(
-                    "relative flex aspect-square w-full items-center justify-center rounded-md ring-1 ring-inset ring-black/10 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:ring-white/15",
+                    "relative flex size-5 shrink-0 items-center justify-center rounded-full ring-1 ring-inset ring-black/10 transition-transform hover:z-10 hover:scale-125 hover:ring-2 hover:ring-foreground/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:ring-white/15",
                     color.className,
                     selected && "ring-2 ring-foreground",
                   )}
                 >
-                  {selected ? <Check className="size-3 text-foreground" aria-hidden strokeWidth={3} /> : null}
+                  {selected ? <Check className="size-2.5 text-foreground" aria-hidden strokeWidth={3} /> : null}
                 </button>
               );
             })}

--- a/web_src/src/pages/factories/pages/FactoryAppCanvasHeader.spec.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvasHeader.spec.tsx
@@ -113,6 +113,8 @@ describe("FactoryAppCanvasHeader", () => {
     );
 
     expect(screen.queryByTestId("factory-app-view-yaml")).not.toBeInTheDocument();
+    expect(screen.getByTestId("factory-app-edit")).toHaveTextContent("Edit Automation");
+    expect(screen.getByTestId("factory-app-edit").className).toContain("rounded-md");
     await user.click(screen.getByTestId("factory-app-edit"));
     expect(onOpenVisualEditor).toHaveBeenCalledTimes(1);
   });

--- a/web_src/src/pages/factories/pages/FactoryAppCanvasViewActions.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvasViewActions.tsx
@@ -8,20 +8,32 @@ type FactoryAppCanvasViewActionsProps = {
   onOpenVisualEditor?: () => void;
 };
 
+const editAutomationClassName = "rounded-md";
+
 export function FactoryAppCanvasViewActions({ href, onOpenVisualEditor }: FactoryAppCanvasViewActionsProps) {
   if (href) {
     return (
       <div className="flex items-start justify-end">
-        <Link href={href} className={cn(buttonVariants({ size: "sm" }))} data-testid="factory-app-edit">
-          Edit
+        <Link
+          href={href}
+          className={cn(buttonVariants({ size: "sm" }), editAutomationClassName)}
+          data-testid="factory-app-edit"
+        >
+          Edit Automation
         </Link>
       </div>
     );
   }
   return (
     <div className="flex items-start justify-end">
-      <Button type="button" size="sm" onClick={onOpenVisualEditor} data-testid="factory-app-edit">
-        Edit
+      <Button
+        type="button"
+        size="sm"
+        className={editAutomationClassName}
+        onClick={onOpenVisualEditor}
+        data-testid="factory-app-edit"
+      >
+        Edit Automation
       </Button>
     </div>
   );

--- a/web_src/src/pages/factories/pages/FirstRun.stories.tsx
+++ b/web_src/src/pages/factories/pages/FirstRun.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FIRST_RUN_COPY } from "./onboarding/first-run/firstRunCopy";
+import { firstRunStoryChrome } from "./onboarding/first-run/firstRunMocks";
+import { FirstRunAnalysisScreen } from "./onboarding/first-run/FirstRunAnalysisScreen";
+import { FirstRunBoardExit } from "./onboarding/first-run/FirstRunBoardExit";
+import { FirstRunConnectScreen } from "./onboarding/first-run/FirstRunConnectScreen";
+import { FirstRunFlow } from "./onboarding/first-run/FirstRunFlow";
+
+/**
+ * Separate first-run journey from docs/prd/onboarding-first-run.md.
+ * Does not replace the existing workspace setup wizard.
+ *
+ * Step stories mount the clickable flow so primary buttons advance.
+ */
+const meta = {
+  title: "Factories/Pages/First run",
+  parameters: { layout: "fullscreen" },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Journey: Story = {
+  name: "0 Clickable journey",
+  render: () => <FirstRunFlow firstName="Ada" />,
+};
+
+export const Welcome: Story = {
+  name: "1 Welcome",
+  render: () => <FirstRunFlow firstName="Ada" />,
+};
+
+export const Connect: Story = {
+  name: "2a Connect GitHub",
+  render: () => <FirstRunFlow firstName="Ada" initialScreen="connect" />,
+};
+
+export const ConnectGitHubConnected: Story = {
+  name: "2b Connect GitHub (connected)",
+  render: () => (
+    <FirstRunConnectScreen
+      githubConnected
+      chrome={firstRunStoryChrome(1)}
+      onConnectGitHub={() => undefined}
+      onContinue={() => undefined}
+    />
+  ),
+};
+
+export const ConnectError: Story = {
+  name: "2c Connect GitHub (error)",
+  render: () => (
+    <FirstRunConnectScreen
+      githubConnected={false}
+      connectError={FIRST_RUN_COPY.connect.connectError}
+      chrome={firstRunStoryChrome(1)}
+      onConnectGitHub={() => undefined}
+      onContinue={() => undefined}
+    />
+  ),
+};
+
+export const Choose: Story = {
+  name: "3 Choose repository",
+  render: () => <FirstRunFlow firstName="Ada" initialScreen="choose" />,
+};
+
+export const Tickets: Story = {
+  name: "4 Connect ticket system",
+  render: () => <FirstRunFlow firstName="Ada" initialScreen="tickets" />,
+};
+
+export const Analysis: Story = {
+  name: "5a Analysis",
+  render: () => <FirstRunFlow firstName="Ada" initialScreen="analysis" />,
+};
+
+export const AnalysisOverrun: Story = {
+  name: "5b Analysis (overrun)",
+  render: () => (
+    <FirstRunAnalysisScreen
+      status="overrun"
+      currentStageIndex={2}
+      chrome={firstRunStoryChrome(4)}
+      onRetry={() => undefined}
+    />
+  ),
+};
+
+export const AnalysisFailed: Story = {
+  name: "5c Analysis (failed)",
+  render: () => (
+    <FirstRunAnalysisScreen
+      status="failed"
+      currentStageIndex={0}
+      chrome={firstRunStoryChrome(4)}
+      onRetry={() => undefined}
+    />
+  ),
+};
+
+export const Board: Story = {
+  name: "6 Board",
+  render: () => <FirstRunBoardExit />,
+};

--- a/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.spec.tsx
@@ -1,0 +1,156 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { TooltipProvider } from "@/ui/tooltip";
+
+import { IntakeSourceSettingsPopup } from "./IntakeSourceSettingsPopup";
+import { DEFAULT_GITHUB_INTAKE_SETTINGS, type IntakeAutomationRun } from "./intakeSourceSettingsModel";
+import { intakeAutomationCanvas, lineIntakeSourceById } from "./lineIntakeModel";
+
+const githubAutomationCanvas = intakeAutomationCanvas(lineIntakeSourceById("github-issues")!);
+
+function renderPopup(
+  props: {
+    onSave?: (next: typeof DEFAULT_GITHUB_INTAKE_SETTINGS) => void;
+    onClose?: () => void;
+    onOpenRun?: (run: IntakeAutomationRun) => void;
+    editAutomationHref?: string;
+    initialTab?: "general" | "runs" | "automation";
+  } = {},
+) {
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <TooltipProvider>
+            <IntakeSourceSettingsPopup
+              settings={DEFAULT_GITHUB_INTAKE_SETTINGS}
+              automationCanvas={githubAutomationCanvas}
+              onSave={props.onSave ?? vi.fn()}
+              onOpenRun={props.onOpenRun}
+              editAutomationHref={props.editAutomationHref}
+              onClose={props.onClose ?? vi.fn()}
+              initialTab={props.initialTab}
+              fixed={false}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("IntakeSourceSettingsPopup", () => {
+  it("shows the GitHub issues configuration fields", () => {
+    renderPopup();
+
+    const dialog = screen.getByTestId("intake-source-settings");
+    expect(dialog).toHaveAttribute("role", "dialog");
+    expect(screen.getByRole("heading", { name: "Intake GitHub issues" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("GitHub issues");
+    expect(screen.getByRole("radio", { name: /Listen for new issues/ })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /Run on a schedule/ })).not.toBeChecked();
+    expect(screen.getByTestId("intake-confidence-value")).toHaveTextContent("65%");
+    expect(screen.getByRole("radio", { name: "Include these labels" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Exclude these labels" })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "bug" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Any assignment" })).toBeChecked();
+    expect(screen.getByRole("tab", { name: "General" })).toHaveAttribute("data-state", "active");
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual(["General", "Runs", "Automation"]);
+    expect(screen.queryByTestId("intake-source-automation")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("intake-source-runs")).not.toBeInTheDocument();
+  });
+
+  it("shows the intake automation on the Automation tab", async () => {
+    const user = userEvent.setup();
+    renderPopup({ editAutomationHref: "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1" });
+
+    await user.click(screen.getByRole("tab", { name: "Automation" }));
+
+    const automation = screen.getByTestId("intake-source-automation");
+    expect(automation).toHaveAccessibleName("Automation");
+    expect(within(automation).getByText("GitHub issue intake")).toBeInTheDocument();
+    expect(within(automation).getByTestId("run-overlay-compact-canvas")).toBeInTheDocument();
+    expect(within(automation).getByTestId("split-run-canvas-node-github-issues-trigger")).toBeInTheDocument();
+    expect(within(automation).getByTestId("split-run-canvas-node-github-issues-classify")).toBeInTheDocument();
+    expect(within(automation).getByTestId("split-run-canvas-node-github-issues-create")).toBeInTheDocument();
+    expect(within(automation).getByRole("link", { name: "Edit automation" })).toHaveAttribute(
+      "href",
+      "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1",
+    );
+    expect(within(automation).queryByTestId("split-run-canvas-menu")).not.toBeInTheDocument();
+    expect(within(automation).queryByTestId("split-run-phase-listen")).not.toBeInTheDocument();
+    expect(within(automation).queryByRole("heading", { name: "Log" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Accepted events go to Backlog" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("intake-source-settings-save")).not.toBeInTheDocument();
+  });
+
+  it("lists scored intake runs on the Runs tab", async () => {
+    const onOpenRun = vi.fn();
+    const user = userEvent.setup();
+    renderPopup({ onOpenRun });
+
+    await user.click(screen.getByRole("tab", { name: "Runs" }));
+
+    const runs = screen.getByTestId("intake-source-runs");
+    expect(runs).toHaveAccessibleName("Runs");
+    expect(within(runs).getByText("Handle duplicate refunds on retry")).toBeInTheDocument();
+    expect(within(runs).queryByText("acme/payments-service")).not.toBeInTheDocument();
+    expect(within(runs).queryByText("acme/docs")).not.toBeInTheDocument();
+
+    const implement = within(runs).getByTestId("intake-source-run-gh-issue-1");
+    expect(implement).toHaveTextContent("94%");
+    expect(implement).toHaveTextContent("3h ago");
+    expect(implement).toHaveTextContent("2h ago");
+    expect(implement).toHaveTextContent("Implement");
+    expect(implement).toHaveTextContent("Writing the retry handler.");
+    expect(implement).not.toHaveTextContent("Moved to Backlog");
+
+    expect(within(runs).getByTestId("intake-source-run-gh-issue-2")).toHaveTextContent("Plan");
+    expect(within(runs).getByTestId("intake-source-run-gh-issue-3")).toHaveTextContent("In Backlog");
+    expect(within(runs).getByTestId("intake-source-run-gh-issue-4")).toHaveTextContent("Rejected");
+    expect(within(runs).getByTestId("intake-source-run-gh-issue-5")).toHaveTextContent("Waiting for review.");
+
+    const held = within(runs).getByTestId("intake-source-run-gh-issue-6");
+    expect(held).toHaveTextContent("52%");
+    expect(held).toHaveTextContent("Not moved to Backlog");
+    expect(held).not.toHaveTextContent("Below the confidence score");
+
+    expect(within(runs).getAllByTestId(/^intake-source-run-/)).toHaveLength(6);
+    expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("intake-source-settings-save")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View run for Handle duplicate refunds on retry" }));
+    expect(onOpenRun).toHaveBeenCalledWith(expect.objectContaining({ id: "gh-issue-1", placement: "progressed" }));
+  });
+
+  it("saves the edited configuration", async () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderPopup({ onSave, onClose });
+
+    await user.clear(screen.getByLabelText("Name"));
+    await user.type(screen.getByLabelText("Name"), "Acme GitHub issues");
+    await user.click(screen.getByRole("radio", { name: /Run on a schedule/ }));
+    await user.click(screen.getByRole("radio", { name: "Exclude these labels" }));
+    await user.click(screen.getByRole("checkbox", { name: "bug" }));
+    await user.click(screen.getByRole("radio", { name: "Unassigned" }));
+    await user.click(screen.getByTestId("intake-source-settings-save"));
+
+    expect(onSave).toHaveBeenCalledWith({
+      name: "Acme GitHub issues",
+      listenMode: "schedule",
+      confidencePct: 65,
+      labelFilterMode: "exclude",
+      labels: ["bug"],
+      assignment: "unassigned",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.tsx
@@ -1,0 +1,437 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import { History, Settings, Workflow } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import {
+  GITHUB_INTAKE_LABEL_OPTIONS,
+  GITHUB_INTAKE_RUNS,
+  INTAKE_SETTINGS_COPY,
+  intakePlacementActivity,
+  intakePlacementLabel,
+  intakeRelativeTime,
+  normalizeIntakeSourceSettings,
+  toggleIntakeLabel,
+  type IntakeAssignmentFilter,
+  type IntakeAutomationRun,
+  type IntakeLabelFilterMode,
+  type IntakeListenMode,
+  type IntakeSettingsTab,
+  type IntakeSourceSettings,
+  type IntakeTicketPlacement,
+} from "./intakeSourceSettingsModel";
+import { PopupHeader, PopupShell } from "./work-order-popup-redesign/popupShared";
+import { CompactLineCanvas } from "./work-order-split-run/CompactLineCanvas";
+import type { SplitRunCanvasModel } from "./work-order-split-run/splitRunCanvases";
+
+interface IntakeSourceSettingsPopupProps {
+  settings: IntakeSourceSettings;
+  automationCanvas: SplitRunCanvasModel;
+  runs?: IntakeAutomationRun[];
+  onSave: (next: IntakeSourceSettings) => void;
+  onOpenRun?: (run: IntakeAutomationRun) => void;
+  editAutomationHref?: string;
+  onClose: () => void;
+  fixed?: boolean;
+  initialTab?: IntakeSettingsTab;
+}
+
+export function IntakeSourceSettingsPopup({
+  settings,
+  automationCanvas,
+  runs = GITHUB_INTAKE_RUNS,
+  onSave,
+  onOpenRun,
+  editAutomationHref,
+  onClose,
+  fixed = true,
+  initialTab = "general",
+}: IntakeSourceSettingsPopupProps) {
+  const [draft, setDraft] = useState(settings);
+  const [tab, setTab] = useState<IntakeSettingsTab>(initialTab);
+
+  useEffect(() => {
+    setDraft(settings);
+  }, [settings]);
+
+  function update<K extends keyof IntakeSourceSettings>(key: K, value: IntakeSourceSettings[K]) {
+    setDraft((current) => ({ ...current, [key]: value }));
+  }
+
+  return (
+    <PopupShell testId="intake-source-settings" canvas fixed={fixed} onDismiss={onClose}>
+      <PopupHeader title={INTAKE_SETTINGS_COPY.title} onClose={onClose}>
+        <Tabs value={tab} onValueChange={(value) => setTab(value as IntakeSettingsTab)} className="mt-3">
+          <TabsList aria-label={INTAKE_SETTINGS_COPY.tabsLabel}>
+            <TabsTrigger value="general" data-testid="intake-settings-tab-general">
+              <Settings />
+              {INTAKE_SETTINGS_COPY.generalTab}
+            </TabsTrigger>
+            <TabsTrigger value="runs" data-testid="intake-settings-tab-runs">
+              <History />
+              {INTAKE_SETTINGS_COPY.runsTab}
+            </TabsTrigger>
+            <TabsTrigger value="automation" data-testid="intake-settings-tab-automation">
+              <Workflow />
+              {INTAKE_SETTINGS_COPY.automationTab}
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </PopupHeader>
+      {tab === "automation" ? (
+        <IntakeAutomationCanvas canvas={automationCanvas} editHref={editAutomationHref} />
+      ) : tab === "runs" ? (
+        <IntakeRunsList runs={runs} onOpenRun={onOpenRun} />
+      ) : (
+        <>
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+            <div className="mx-auto flex w-full max-w-xl flex-col gap-6">
+              <section>
+                <Label htmlFor="intake-source-name">{INTAKE_SETTINGS_COPY.nameLabel}</Label>
+                <p className="workspace-body-text mt-1 text-muted-foreground">{INTAKE_SETTINGS_COPY.nameHelper}</p>
+                <Input
+                  id="intake-source-name"
+                  className="mt-2"
+                  value={draft.name}
+                  onChange={(event) => update("name", event.target.value)}
+                  data-testid="intake-source-name"
+                />
+              </section>
+
+              <fieldset className="min-w-0">
+                <legend className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                  {INTAKE_SETTINGS_COPY.listenLabel}
+                </legend>
+                <div className="mt-2 flex flex-col gap-2">
+                  <RadioOption
+                    name="intake-listen-mode"
+                    value="listen"
+                    checked={draft.listenMode === "listen"}
+                    title={INTAKE_SETTINGS_COPY.listenOption}
+                    helper={INTAKE_SETTINGS_COPY.listenHelper}
+                    onChange={() => update("listenMode", "listen" satisfies IntakeListenMode)}
+                  />
+                  <RadioOption
+                    name="intake-listen-mode"
+                    value="schedule"
+                    checked={draft.listenMode === "schedule"}
+                    title={INTAKE_SETTINGS_COPY.scheduleOption}
+                    helper={INTAKE_SETTINGS_COPY.scheduleHelper}
+                    onChange={() => update("listenMode", "schedule" satisfies IntakeListenMode)}
+                  />
+                </div>
+              </fieldset>
+
+              <section>
+                <div className="flex items-baseline justify-between gap-3">
+                  <Label htmlFor="intake-confidence-slider">{INTAKE_SETTINGS_COPY.confidenceLabel}</Label>
+                  <span
+                    className="text-[13px] font-medium tabular-nums text-foreground"
+                    data-testid="intake-confidence-value"
+                  >
+                    {draft.confidencePct}%
+                  </span>
+                </div>
+                <p className="workspace-body-text mt-1 text-muted-foreground">
+                  {INTAKE_SETTINGS_COPY.confidenceHelper}
+                </p>
+                <Slider
+                  id="intake-confidence-slider"
+                  className="mt-4 max-w-xs"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={[draft.confidencePct]}
+                  onValueChange={(values) => update("confidencePct", values[0] ?? draft.confidencePct)}
+                  aria-label={INTAKE_SETTINGS_COPY.confidenceLabel}
+                  data-testid="intake-confidence-slider"
+                />
+              </section>
+
+              <section className="flex flex-col gap-6">
+                <h3 className="workspace-section-title">{INTAKE_SETTINGS_COPY.filtersLabel}</h3>
+
+                <fieldset className="min-w-0">
+                  <legend className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                    {INTAKE_SETTINGS_COPY.labelsLabel}
+                  </legend>
+                  <p className="workspace-body-text mt-1 text-muted-foreground">{INTAKE_SETTINGS_COPY.labelsHelper}</p>
+                  <div className="mt-2 flex flex-col gap-2">
+                    <RadioOption
+                      name="intake-label-filter"
+                      value="include"
+                      checked={draft.labelFilterMode === "include"}
+                      title={INTAKE_SETTINGS_COPY.includeLabels}
+                      onChange={() => update("labelFilterMode", "include" satisfies IntakeLabelFilterMode)}
+                    />
+                    <RadioOption
+                      name="intake-label-filter"
+                      value="exclude"
+                      checked={draft.labelFilterMode === "exclude"}
+                      title={INTAKE_SETTINGS_COPY.excludeLabels}
+                      onChange={() => update("labelFilterMode", "exclude" satisfies IntakeLabelFilterMode)}
+                    />
+                  </div>
+                  <ul className="mt-3 flex flex-wrap gap-2" data-testid="intake-label-options">
+                    {GITHUB_INTAKE_LABEL_OPTIONS.map((label) => {
+                      const checked = draft.labels.includes(label);
+                      return (
+                        <li key={label}>
+                          <label
+                            className={cn(
+                              "inline-flex cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1.5 text-[13px]",
+                              checked
+                                ? "border-foreground/20 bg-accent/50 text-foreground"
+                                : "border-border bg-card text-muted-foreground hover:border-foreground/15",
+                            )}
+                          >
+                            <Checkbox
+                              checked={checked}
+                              onChange={() => update("labels", toggleIntakeLabel(draft.labels, label))}
+                              aria-label={label}
+                            />
+                            {label}
+                          </label>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </fieldset>
+
+                <fieldset className="min-w-0">
+                  <legend className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                    {INTAKE_SETTINGS_COPY.assignmentLabel}
+                  </legend>
+                  <div className="mt-2 flex flex-col gap-2">
+                    <RadioOption
+                      name="intake-assignment"
+                      value="any"
+                      checked={draft.assignment === "any"}
+                      title={INTAKE_SETTINGS_COPY.assignmentAny}
+                      onChange={() => update("assignment", "any" satisfies IntakeAssignmentFilter)}
+                    />
+                    <RadioOption
+                      name="intake-assignment"
+                      value="assigned"
+                      checked={draft.assignment === "assigned"}
+                      title={INTAKE_SETTINGS_COPY.assignmentAssigned}
+                      onChange={() => update("assignment", "assigned" satisfies IntakeAssignmentFilter)}
+                    />
+                    <RadioOption
+                      name="intake-assignment"
+                      value="unassigned"
+                      checked={draft.assignment === "unassigned"}
+                      title={INTAKE_SETTINGS_COPY.assignmentUnassigned}
+                      onChange={() => update("assignment", "unassigned" satisfies IntakeAssignmentFilter)}
+                    />
+                  </div>
+                </fieldset>
+              </section>
+            </div>
+          </div>
+          <footer className="flex shrink-0 items-center justify-end gap-3 border-t border-border px-5 py-3">
+            <Button
+              type="button"
+              onClick={() => {
+                onSave(normalizeIntakeSourceSettings(draft));
+                onClose();
+              }}
+              data-testid="intake-source-settings-save"
+            >
+              {INTAKE_SETTINGS_COPY.save}
+            </Button>
+          </footer>
+        </>
+      )}
+    </PopupShell>
+  );
+}
+
+function RadioOption({
+  name,
+  value,
+  checked,
+  title,
+  helper,
+  onChange,
+}: {
+  name: string;
+  value: string;
+  checked: boolean;
+  title: string;
+  helper?: string;
+  onChange: () => void;
+}) {
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2.5 transition-colors",
+        checked ? "border-foreground/20 bg-accent/50" : "border-border bg-card hover:border-foreground/15",
+      )}
+    >
+      <input
+        type="radio"
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={onChange}
+        className="mt-0.5 size-4 accent-gray-900"
+      />
+      <span className="min-w-0">
+        <span className="block text-[13px] font-medium tracking-[-0.01em] text-foreground">{title}</span>
+        {helper ? <span className="mt-0.5 block text-[12px] leading-5 text-muted-foreground">{helper}</span> : null}
+      </span>
+    </label>
+  );
+}
+
+function IntakeAutomationCanvas({ canvas, editHref }: { canvas: SplitRunCanvasModel; editHref?: string }) {
+  const [nodeId, setNodeId] = useState<string | null>(null);
+
+  return (
+    <section
+      className="flex min-h-0 min-w-0 flex-1 flex-col"
+      aria-label="Automation"
+      data-testid="intake-source-automation"
+    >
+      <CompactLineCanvas
+        canvas={canvas}
+        selectedId={nodeId}
+        onSelect={setNodeId}
+        headerEdit="button"
+        editHref={editHref}
+        editLabel={INTAKE_SETTINGS_COPY.editAutomation}
+      />
+    </section>
+  );
+}
+
+const PLACEMENT_CHIP_CLASS: Record<IntakeTicketPlacement, string> = {
+  progressed:
+    "border-[color:var(--status-running-border)] bg-[color:var(--status-running-bg)] text-[color:var(--status-running-fg)]",
+  backlog:
+    "border-[color:var(--status-draft-border)] bg-[color:var(--status-draft-bg)] text-[color:var(--status-draft-fg)]",
+  rejected:
+    "border-[color:var(--status-failed-border)] bg-[color:var(--status-failed-bg)] text-[color:var(--status-failed-fg)]",
+  "below-threshold":
+    "border-[color:var(--status-cancelled-border)] bg-[color:var(--status-cancelled-bg)] text-[color:var(--status-cancelled-fg)]",
+};
+
+const PLACEMENT_DOT_CLASS: Record<IntakeTicketPlacement, string> = {
+  progressed: "bg-[color:var(--status-running-dot)]",
+  backlog: "bg-[color:var(--status-draft-dot)]",
+  rejected: "bg-[color:var(--status-failed-dot)]",
+  "below-threshold": "bg-[color:var(--status-cancelled-dot)]",
+};
+
+function IntakeRunsList({
+  runs,
+  onOpenRun,
+}: {
+  runs: IntakeAutomationRun[];
+  onOpenRun?: (run: IntakeAutomationRun) => void;
+}) {
+  if (runs.length === 0) {
+    return (
+      <p className="workspace-body-text px-6 py-6 text-muted-foreground" data-testid="intake-source-runs">
+        {INTAKE_SETTINGS_COPY.runsEmpty}
+      </p>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+      <ul
+        className="mx-auto flex w-full max-w-2xl flex-col gap-2"
+        data-testid="intake-source-runs"
+        aria-label={INTAKE_SETTINGS_COPY.runsTab}
+      >
+        {runs.map((run) => (
+          <li key={run.id}>
+            <IntakeRunCard run={run} onOpenRun={onOpenRun} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function IntakeRunCard({
+  run,
+  onOpenRun,
+}: {
+  run: IntakeAutomationRun;
+  onOpenRun?: (run: IntakeAutomationRun) => void;
+}) {
+  const placementLabel = intakePlacementLabel(run);
+  const activity = intakePlacementActivity(run);
+
+  return (
+    <article
+      className="group relative w-full rounded-lg border border-border bg-card p-3.5 shadow-sm transition hover:border-foreground/20 hover:shadow"
+      data-testid={`intake-source-run-${run.id}`}
+    >
+      {onOpenRun ? (
+        <button
+          type="button"
+          className="absolute inset-0 z-0 rounded-lg"
+          aria-label={INTAKE_SETTINGS_COPY.viewRunFor(run.title)}
+          onClick={() => onOpenRun(run)}
+        />
+      ) : null}
+      <div className="relative z-10 pointer-events-none">
+        <div className="flex items-start gap-3">
+          <span className="relative mt-1.5 size-2 shrink-0" title={placementLabel} aria-label={placementLabel}>
+            {run.placement === "progressed" ? (
+              <span
+                className={cn(
+                  "absolute inset-0 animate-ping rounded-full opacity-60",
+                  PLACEMENT_DOT_CLASS[run.placement],
+                )}
+                aria-hidden
+              />
+            ) : null}
+            <span className={cn("relative block size-2 rounded-full", PLACEMENT_DOT_CLASS[run.placement])} />
+          </span>
+          <h3 className="min-w-0 flex-1 text-[13px] font-medium leading-snug tracking-[-0.01em] text-foreground">
+            {run.title}
+          </h3>
+        </div>
+
+        <dl className="mt-3 grid grid-cols-3 gap-3">
+          <div>
+            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.runWhen}</dt>
+            <dd className="mt-0.5 text-[13px] tabular-nums text-foreground">{intakeRelativeTime(run.ranMinutesAgo)}</dd>
+          </div>
+          <div>
+            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.analysisWhen}</dt>
+            <dd className="mt-0.5 text-[13px] tabular-nums text-foreground">
+              {intakeRelativeTime(run.analyzedMinutesAgo)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[11px] font-medium text-muted-foreground">{INTAKE_SETTINGS_COPY.scoreWhen}</dt>
+            <dd className="mt-0.5 text-[13px] font-medium tabular-nums text-foreground">{run.confidencePct}%</dd>
+          </div>
+        </dl>
+
+        <div className="mt-3 flex items-start gap-2">
+          <Badge variant="outline" className={cn("mt-0.5", PLACEMENT_CHIP_CLASS[run.placement])}>
+            {placementLabel}
+          </Badge>
+          {activity ? <p className="min-w-0 text-[12px] leading-5 text-muted-foreground">{activity}</p> : null}
+        </div>
+
+        {onOpenRun ? (
+          <p className="mt-3 text-[12px] font-medium text-foreground">{INTAKE_SETTINGS_COPY.viewRun}</p>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
@@ -1,0 +1,79 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { LineIntakeDrawer } from "./LineIntakeDrawer";
+
+function renderDrawer(props: { onClose?: () => void } = {}) {
+  return render(
+    <MemoryRouter>
+      <LineIntakeDrawer onClose={props.onClose ?? vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
+describe("LineIntakeDrawer", () => {
+  it("lists GitHub, Sentry, and PagerDuty as intake sources", () => {
+    renderDrawer();
+
+    const drawer = screen.getByTestId("line-intake-drawer");
+    expect(drawer).toHaveAccessibleName("Intake");
+    expect(screen.getByRole("heading", { name: "Intake" })).toBeInTheDocument();
+    expect(screen.getByTestId("line-intake-source-github-issues")).toHaveTextContent("GitHub issues");
+    expect(screen.getByTestId("line-intake-source-sentry-exceptions")).toHaveTextContent("Sentry exceptions");
+    expect(screen.getByTestId("line-intake-source-pagerduty-incidents")).toHaveTextContent("PagerDuty incidents");
+  });
+
+  it("closes the drawer from the header control", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderDrawer({ onClose });
+
+    await user.click(screen.getByTestId("line-intake-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a searchable picker with six intake templates", async () => {
+    const user = userEvent.setup();
+    renderDrawer();
+
+    await user.click(screen.getByTestId("line-intake-add"));
+
+    const picker = screen.getByTestId("add-intake-picker");
+    expect(within(picker).getByRole("heading", { name: "Add intake" })).toBeInTheDocument();
+    expect(within(picker).getByTestId("add-intake-search")).toBeInTheDocument();
+    expect(within(picker).getByTestId("add-intake-template-improve-ci-runtime")).toHaveTextContent(
+      "Improve CI runtime",
+    );
+    expect(within(picker).getByTestId("add-intake-template-improve-page-performance")).toHaveTextContent(
+      "Improve page performance",
+    );
+    expect(within(picker).getAllByTestId(/^add-intake-template-/)).toHaveLength(6);
+  });
+
+  it("filters templates from the picker search", async () => {
+    const user = userEvent.setup();
+    renderDrawer();
+
+    await user.click(screen.getByTestId("line-intake-add"));
+    await user.type(screen.getByTestId("add-intake-search"), "runtime");
+
+    expect(screen.getByTestId("add-intake-template-improve-ci-runtime")).toBeInTheDocument();
+    expect(screen.queryByTestId("add-intake-template-flaky-tests")).not.toBeInTheDocument();
+  });
+
+  it("opens the intake automation popup from a source card", async () => {
+    const user = userEvent.setup();
+    renderDrawer();
+
+    await user.click(screen.getByRole("button", { name: "Open GitHub issues intake" }));
+
+    const dialog = screen.getByTestId("work-order-split-run");
+    expect(within(dialog).getByRole("heading", { name: "GitHub issues" })).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-phase-listen")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-phase-evaluate")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-phase-backlog")).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Accepted events go to Backlog" })).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
@@ -1,15 +1,44 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
-import { LineIntakeDrawer } from "./LineIntakeDrawer";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { TooltipProvider } from "@/ui/tooltip";
 
-function renderDrawer(props: { onClose?: () => void } = {}) {
+import { LineIntakeDrawer } from "./LineIntakeDrawer";
+import { LINE_INTAKE_SOURCES, type LineIntakeAnalyzingTicket, type LineIntakeSource } from "./lineIntakeModel";
+
+function renderDrawer(
+  props: {
+    onClose?: () => void;
+    initialSourceId?: "github-issues" | "sentry-exceptions" | "pagerduty-incidents";
+    initialSettingsOpen?: boolean;
+    initialSettingsTab?: "general" | "runs" | "automation";
+    sources?: LineIntakeSource[];
+    onOpenTicket?: (ticket: LineIntakeAnalyzingTicket) => void;
+    editAutomationHref?: string;
+  } = {},
+) {
   return render(
-    <MemoryRouter>
-      <LineIntakeDrawer onClose={props.onClose ?? vi.fn()} />
-    </MemoryRouter>,
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <TooltipProvider>
+            <LineIntakeDrawer
+              onClose={props.onClose ?? vi.fn()}
+              initialSourceId={props.initialSourceId}
+              initialSettingsOpen={props.initialSettingsOpen}
+              initialSettingsTab={props.initialSettingsTab}
+              sources={props.sources}
+              onOpenTicket={props.onOpenTicket}
+              editAutomationHref={props.editAutomationHref}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -23,6 +52,16 @@ describe("LineIntakeDrawer", () => {
     expect(screen.getByTestId("line-intake-source-github-issues")).toHaveTextContent("GitHub issues");
     expect(screen.getByTestId("line-intake-source-sentry-exceptions")).toHaveTextContent("Sentry exceptions");
     expect(screen.getByTestId("line-intake-source-pagerduty-incidents")).toHaveTextContent("PagerDuty incidents");
+  });
+
+  it("can show GitHub issues without Sentry or PagerDuty", () => {
+    renderDrawer({
+      sources: LINE_INTAKE_SOURCES.filter((source) => source.id === "github-issues"),
+    });
+
+    expect(screen.getByTestId("line-intake-source-github-issues")).toBeInTheDocument();
+    expect(screen.queryByTestId("line-intake-source-sentry-exceptions")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("line-intake-source-pagerduty-incidents")).not.toBeInTheDocument();
   });
 
   it("closes the drawer from the header control", async () => {
@@ -63,17 +102,188 @@ describe("LineIntakeDrawer", () => {
     expect(screen.queryByTestId("add-intake-template-flaky-tests")).not.toBeInTheDocument();
   });
 
-  it("opens the intake automation popup from a source card", async () => {
+  it("lets each source expand and collapse on its own", async () => {
     const user = userEvent.setup();
     renderDrawer();
 
-    await user.click(screen.getByRole("button", { name: "Open GitHub issues intake" }));
+    expect(screen.getByRole("button", { name: "Expand GitHub issues" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: "Expand Sentry exceptions" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: "Expand PagerDuty incidents" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
 
+    await user.click(screen.getByRole("button", { name: "Expand GitHub issues" }));
+
+    const github = screen.getByTestId("line-intake-source-github-issues");
+    const analyzing = within(github).getByTestId("line-intake-analyzing");
+    expect(within(analyzing).getAllByTestId("line-intake-analyzing-spinner")).toHaveLength(5);
+    expect(within(analyzing).getByText("Handle duplicate refunds on retry")).toBeInTheDocument();
+    expect(within(analyzing).queryByText("acme/api")).not.toBeInTheDocument();
+    expect(within(analyzing).queryByText("Analyzing")).not.toBeInTheDocument();
+    expect(within(github).getByText("Analyzing")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse GitHub issues" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Expand Sentry exceptions" }));
+
+    const sentry = screen.getByTestId("line-intake-source-sentry-exceptions");
+    expect(within(sentry).getByText("No tickets in analysis.")).toBeInTheDocument();
+    expect(within(sentry).queryByText("Handle duplicate refunds on retry")).not.toBeInTheDocument();
+    expect(within(github).getByTestId("line-intake-analyzing")).toBeInTheDocument();
+  });
+
+  it("collapses GitHub issues on a second header click", async () => {
+    const user = userEvent.setup();
+    renderDrawer({ initialSourceId: "github-issues" });
+
+    expect(screen.getByTestId("line-intake-analyzing")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Collapse GitHub issues" }));
+
+    expect(screen.queryByTestId("line-intake-analyzing")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand GitHub issues" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+  });
+
+  it("expands GitHub issues when that source is chosen from Add intake", async () => {
+    const user = userEvent.setup();
+    renderDrawer();
+
+    await user.click(screen.getByTestId("line-intake-add"));
+    await user.click(screen.getByTestId("add-intake-template-github-issues"));
+
+    expect(
+      within(screen.getByTestId("line-intake-source-github-issues")).getByTestId("line-intake-analyzing"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("add-intake-picker")).not.toBeInTheDocument();
+  });
+
+  it("expands GitHub issues when it is the initial source", () => {
+    renderDrawer({ initialSourceId: "github-issues" });
+
+    const source = screen.getByTestId("line-intake-source-github-issues");
+    expect(within(source).getByTestId("line-intake-analyzing")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse GitHub issues" })).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("opens the analysis popup from a nested GitHub issues ticket", async () => {
+    const onOpenTicket = vi.fn();
+    const user = userEvent.setup();
+    renderDrawer({ initialSourceId: "github-issues", onOpenTicket });
+
+    await user.click(screen.getByRole("button", { name: "Open Handle duplicate refunds on retry" }));
+
+    expect(onOpenTicket).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "gh-issue-1", title: "Handle duplicate refunds on retry" }),
+    );
     const dialog = screen.getByTestId("work-order-split-run");
-    expect(within(dialog).getByRole("heading", { name: "GitHub issues" })).toBeInTheDocument();
-    expect(within(dialog).getByTestId("split-run-phase-listen")).toBeInTheDocument();
-    expect(within(dialog).getByTestId("split-run-phase-evaluate")).toBeInTheDocument();
-    expect(within(dialog).getByTestId("split-run-phase-backlog")).toBeInTheDocument();
-    expect(within(dialog).getByRole("heading", { name: "Accepted events go to Backlog" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Handle duplicate refunds on retry" })).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-phase-ingest")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-phase-analyze")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-phase-plan")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-phase-score")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-canvas-node-ticket-ingest")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-canvas-node-ticket-analyze")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-canvas-node-ticket-plan")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-canvas-node-ticket-score")).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "SuperPlane is analyzing this ticket" })).toBeInTheDocument();
+  });
+
+  it("opens GitHub issues settings from the source gear", async () => {
+    const user = userEvent.setup();
+    renderDrawer();
+
+    await user.click(screen.getByRole("button", { name: "Open GitHub issues settings" }));
+
+    const dialog = screen.getByTestId("intake-source-settings");
+    expect(within(dialog).getByRole("heading", { name: "Intake GitHub issues" })).toBeInTheDocument();
+    expect(within(dialog).getByLabelText("Name")).toHaveValue("GitHub issues");
+    expect(within(dialog).getByRole("radio", { name: /Listen for new issues/ })).toBeChecked();
+    expect(within(dialog).getByTestId("intake-confidence-value")).toHaveTextContent("65%");
+    expect(within(dialog).getByRole("tab", { name: "General" })).toHaveAttribute("data-state", "active");
+    expect(
+      within(dialog)
+        .getAllByRole("tab")
+        .map((tab) => tab.textContent),
+    ).toEqual(["General", "Runs", "Automation"]);
+    expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("intake-source-automation")).not.toBeInTheDocument();
+  });
+
+  it("shows the GitHub issues automation from the settings Automation tab", async () => {
+    const user = userEvent.setup();
+    renderDrawer({
+      editAutomationHref: "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1&from=lines",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Open GitHub issues settings" }));
+    await user.click(screen.getByRole("tab", { name: "Automation" }));
+
+    const automation = within(screen.getByTestId("intake-source-settings")).getByTestId("intake-source-automation");
+    expect(within(automation).getByTestId("run-overlay-compact-canvas")).toBeInTheDocument();
+    expect(within(automation).getByTestId("split-run-canvas-node-github-issues-trigger")).toBeInTheDocument();
+    expect(within(automation).getByRole("link", { name: "Edit automation" })).toHaveAttribute(
+      "href",
+      "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1&from=lines",
+    );
+    expect(within(automation).queryByTestId("split-run-phase-listen")).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Accepted events go to Backlog" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+  });
+
+  it("keeps the analysis popup when a ticket is opened after settings", async () => {
+    const user = userEvent.setup();
+    renderDrawer({ initialSourceId: "github-issues" });
+
+    await user.click(screen.getByRole("button", { name: "Open GitHub issues settings" }));
+    expect(screen.getByTestId("intake-source-settings")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open Handle duplicate refunds on retry" }));
+
+    expect(screen.queryByTestId("intake-source-settings")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("work-order-split-run")).getByRole("heading", {
+        name: "Handle duplicate refunds on retry",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens an intake run from the Runs tab and keeps settings open", async () => {
+    const onOpenTicket = vi.fn();
+    const user = userEvent.setup();
+    renderDrawer({
+      initialSourceId: "github-issues",
+      initialSettingsOpen: true,
+      initialSettingsTab: "runs",
+      onOpenTicket,
+    });
+
+    const settings = screen.getByTestId("intake-source-settings");
+    expect(within(settings).getByTestId("intake-source-run-gh-issue-1")).toHaveTextContent("Implement");
+    expect(within(settings).queryByText("acme/payments-service")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View run for Handle duplicate refunds on retry" }));
+
+    expect(onOpenTicket).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "gh-issue-1", title: "Handle duplicate refunds on retry" }),
+    );
+    expect(screen.getByTestId("intake-source-settings")).toBeInTheDocument();
+    const dialog = screen.getByTestId("work-order-split-run");
+    expect(within(dialog).getByRole("heading", { name: "Handle duplicate refunds on retry" })).toBeInTheDocument();
+    expect(within(dialog).getByTestId("split-run-phase-analyze")).toBeInTheDocument();
+  });
+
+  it("updates the GitHub issues name after save", async () => {
+    const user = userEvent.setup();
+    renderDrawer();
+
+    await user.click(screen.getByRole("button", { name: "Open GitHub issues settings" }));
+    await user.clear(screen.getByLabelText("Name"));
+    await user.type(screen.getByLabelText("Name"), "Acme issues");
+    await user.click(screen.getByTestId("intake-source-settings-save"));
+
+    expect(screen.queryByTestId("intake-source-settings")).not.toBeInTheDocument();
+    expect(screen.getByTestId("line-intake-source-github-issues")).toHaveTextContent("Acme issues");
   });
 });

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.stories.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "../__fixtures__/ComponentStoryShell";
+import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
+import {
+  GITHUB_ISSUES_INTAKE_APP,
+  PRIMARY_FACTORY_KEY,
+  REFUND_FACTORY_LINES,
+} from "../__fixtures__/factoryPageResponses";
+import { refundLineCanvasFixture } from "../__fixtures__/factoryOwnedCanvasFixture";
+import { LineIntakeDrawer } from "./LineIntakeDrawer";
+
+const meta = {
+  title: "Factories/Pages/Intake tree",
+  parameters: { layout: "fullscreen" },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const GitHubIssuesExpanded: Story = {
+  name: "GitHub issues expanded",
+  render: () => (
+    <ComponentStoryShell className="flex h-svh bg-slate-300 p-0 dark:bg-slate-900">
+      <LineIntakeDrawer initialSourceId="github-issues" onClose={() => undefined} />
+    </ComponentStoryShell>
+  ),
+};
+
+export const GitHubIssuesSettings: Story = {
+  name: "GitHub issues settings",
+  render: () => (
+    <ComponentStoryShell className="flex h-svh bg-slate-300 p-0 dark:bg-slate-900">
+      <LineIntakeDrawer initialSourceId="github-issues" initialSettingsOpen onClose={() => undefined} />
+    </ComponentStoryShell>
+  ),
+};
+
+export const GitHubIssuesAutomation: Story = {
+  name: "GitHub issues automation",
+  render: () => {
+    const line = REFUND_FACTORY_LINES[0];
+    return (
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}?intake=1&source=github-issues&settings=automation`}
+        appFixture={refundLineCanvasFixture(GITHUB_ISSUES_INTAKE_APP)}
+      />
+    );
+  },
+};
+
+export const GitHubIssuesRuns: Story = {
+  name: "GitHub issues runs",
+  render: () => (
+    <ComponentStoryShell className="flex h-svh bg-slate-300 p-0 dark:bg-slate-900">
+      <LineIntakeDrawer
+        initialSourceId="github-issues"
+        initialSettingsOpen
+        initialSettingsTab="runs"
+        onClose={() => undefined}
+      />
+    </ComponentStoryShell>
+  ),
+};

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
@@ -1,32 +1,90 @@
-import { Plus, XIcon } from "lucide-react";
-import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { ChevronRight, Loader2, Plus, Settings, XIcon } from "lucide-react";
+import { useState, type ReactNode } from "react";
 
 import { AddIntakePicker } from "./AddIntakePicker";
+import { IntakeSourceSettingsPopup } from "./IntakeSourceSettingsPopup";
 import {
+  DEFAULT_GITHUB_INTAKE_SETTINGS,
+  type IntakeAutomationRun,
+  type IntakeSettingsTab,
+} from "./intakeSourceSettingsModel";
+import {
+  GITHUB_ISSUES_ANALYZING_TICKETS,
+  intakeAutomationCanvas,
   intakeAutomationFixture,
+  intakeTicketAnalysisFixture,
+  isLineIntakeSourceId,
+  LINE_INTAKE_COPY,
   LINE_INTAKE_SOURCES,
   lineIntakeSourceById,
+  type LineIntakeAnalyzingTicket,
   type LineIntakeSource,
+  type LineIntakeSourceId,
 } from "./lineIntakeModel";
 import { WorkOrderSplitRunPopup } from "./work-order-split-run/WorkOrderSplitRunPopup";
 
 interface LineIntakeDrawerProps {
   onClose: () => void;
+  initialSourceId?: LineIntakeSourceId;
+  initialSettingsOpen?: boolean;
+  initialSettingsTab?: IntakeSettingsTab;
+  sources?: LineIntakeSource[];
+  analyzingTickets?: LineIntakeAnalyzingTicket[];
+  onOpenTicket?: (ticket: LineIntakeAnalyzingTicket) => void;
+  editAutomationHref?: string;
 }
 
 /**
- * Column beside the line board. Lists the automations that listen to
- * external sources, evaluate events, and create backlog work orders.
+ * Pane beside the line board. Each intake source is a white card that
+ * expands and collapses on its own.
  */
-export function LineIntakeDrawer({ onClose }: LineIntakeDrawerProps) {
+export function LineIntakeDrawer({
+  onClose,
+  initialSourceId,
+  initialSettingsOpen = false,
+  initialSettingsTab = "general",
+  sources = LINE_INTAKE_SOURCES,
+  analyzingTickets = GITHUB_ISSUES_ANALYZING_TICKETS,
+  onOpenTicket,
+  editAutomationHref,
+}: LineIntakeDrawerProps) {
+  const [expandedSourceIds, setExpandedSourceIds] = useState<ReadonlySet<LineIntakeSourceId>>(
+    () => new Set(initialSourceId ? [initialSourceId] : []),
+  );
+  const [openTicket, setOpenTicket] = useState<LineIntakeAnalyzingTicket | null>(null);
   const [openSourceId, setOpenSourceId] = useState<string | null>(null);
+  const [githubSettings, setGithubSettings] = useState(DEFAULT_GITHUB_INTAKE_SETTINGS);
+  const [settingsOpen, setSettingsOpen] = useState(initialSettingsOpen);
   const [pickerOpen, setPickerOpen] = useState(false);
   const openSource = openSourceId ? lineIntakeSourceById(openSourceId) : undefined;
+
+  function toggleSource(sourceId: LineIntakeSourceId) {
+    setExpandedSourceIds((current) => {
+      const next = new Set(current);
+      if (next.has(sourceId)) {
+        next.delete(sourceId);
+      } else {
+        next.add(sourceId);
+      }
+      return next;
+    });
+  }
+
+  function expandSource(sourceId: LineIntakeSourceId) {
+    setExpandedSourceIds((current) => new Set(current).add(sourceId));
+  }
+
+  function openIntakeRun(run: IntakeAutomationRun) {
+    const ticket = { id: run.id, title: run.title };
+    setOpenTicket(ticket);
+    onOpenTicket?.(ticket);
+  }
 
   return (
     <>
       <aside
-        className="flex h-full min-h-0 w-72 shrink-0 flex-col border-r border-border bg-slate-200 dark:bg-slate-800"
+        className="flex h-full min-h-0 w-[26rem] shrink-0 flex-col border-r border-border bg-slate-200 dark:bg-slate-800"
         data-testid="line-intake-drawer"
         aria-label="Intake"
       >
@@ -46,18 +104,51 @@ export function LineIntakeDrawer({ onClose }: LineIntakeDrawerProps) {
         <p className="workspace-body-text shrink-0 px-3 pb-3 text-muted-foreground">
           Automations that listen, evaluate, and create backlog work orders.
         </p>
-        <ul className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto px-2 pb-3 [scrollbar-width:thin]">
-          {LINE_INTAKE_SOURCES.map((source) => (
-            <li key={source.id}>
-              <IntakeSourceCard source={source} onOpen={() => setOpenSourceId(source.id)} />
-            </li>
-          ))}
+        <ul className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2 [scrollbar-width:thin]">
+          {sources.map((source) => {
+            const expanded = expandedSourceIds.has(source.id);
+            const tickets = source.id === "github-issues" ? analyzingTickets : [];
+            return (
+              <li key={source.id}>
+                <IntakeSourceCard
+                  source={source}
+                  displayName={source.id === "github-issues" ? githubSettings.name : source.name}
+                  expanded={expanded}
+                  childCount={tickets.length}
+                  onToggle={() => toggleSource(source.id)}
+                  onOpenGear={() => {
+                    setOpenTicket(null);
+                    if (source.id === "github-issues") {
+                      setOpenSourceId(null);
+                      setSettingsOpen(true);
+                      return;
+                    }
+                    setSettingsOpen(false);
+                    setOpenSourceId(source.id);
+                  }}
+                >
+                  {expanded ? (
+                    <AnalyzingTicketList
+                      tickets={tickets}
+                      openTicketId={openTicket?.id ?? null}
+                      onOpenTicket={(ticket) => {
+                        setOpenSourceId(null);
+                        setSettingsOpen(false);
+                        setOpenTicket(ticket);
+                        onOpenTicket?.(ticket);
+                      }}
+                    />
+                  ) : null}
+                </IntakeSourceCard>
+              </li>
+            );
+          })}
           <li>
             <button
               type="button"
               onClick={() => setPickerOpen(true)}
               data-testid="line-intake-add"
-              className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-muted/60 px-3 py-2.5 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors hover:border-foreground/20 hover:bg-muted hover:text-foreground"
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-muted/60 px-3 py-3 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors hover:border-foreground/20 hover:bg-muted hover:text-foreground"
             >
               <Plus className="size-3.5 shrink-0" aria-hidden />
               Add intake
@@ -71,11 +162,24 @@ export function LineIntakeDrawer({ onClose }: LineIntakeDrawerProps) {
         onClose={() => setPickerOpen(false)}
         onSelect={(template) => {
           setPickerOpen(false);
-          if (lineIntakeSourceById(template.id)) {
-            setOpenSourceId(template.id);
+          if (isLineIntakeSourceId(template.id)) {
+            expandSource(template.id);
           }
         }}
       />
+
+      {settingsOpen ? (
+        <IntakeSourceSettingsPopup
+          settings={githubSettings}
+          automationCanvas={intakeAutomationCanvas(lineIntakeSourceById("github-issues")!)}
+          onSave={setGithubSettings}
+          onOpenRun={openIntakeRun}
+          editAutomationHref={editAutomationHref}
+          onClose={() => setSettingsOpen(false)}
+          initialTab={initialSettingsTab}
+          fixed
+        />
+      ) : null}
 
       {openSource ? (
         <WorkOrderSplitRunPopup
@@ -85,29 +189,136 @@ export function LineIntakeDrawer({ onClose }: LineIntakeDrawerProps) {
           fixed
         />
       ) : null}
+
+      {openTicket ? (
+        <WorkOrderSplitRunPopup
+          key={openTicket.id}
+          fixture={intakeTicketAnalysisFixture(openTicket)}
+          onClose={() => setOpenTicket(null)}
+          fixed
+        />
+      ) : null}
     </>
   );
 }
 
-function IntakeSourceCard({ source, onOpen }: { source: LineIntakeSource; onOpen: () => void }) {
+function IntakeSourceCard({
+  source,
+  displayName,
+  expanded,
+  childCount,
+  onToggle,
+  onOpenGear,
+  children,
+}: {
+  source: LineIntakeSource;
+  displayName: string;
+  expanded: boolean;
+  childCount: number;
+  onToggle: () => void;
+  onOpenGear: () => void;
+  children?: ReactNode;
+}) {
+  const gearKind = source.id === "github-issues" ? "settings" : "automation";
   return (
-    <article
-      className="relative w-full rounded-lg bg-card px-3 py-2.5 shadow-sm"
-      data-testid={`line-intake-source-${source.id}`}
-    >
-      <button
-        type="button"
-        className="absolute inset-0 z-0 rounded-lg"
-        aria-label={`Open ${source.name} intake`}
-        onClick={onOpen}
-      />
-      <div className="relative z-10 pointer-events-none flex items-start gap-2.5">
-        <img src={source.iconSrc} alt={source.iconAlt} className="mt-0.5 size-5 shrink-0" />
-        <div className="min-w-0 flex-1">
-          <h3 className="text-[13px] font-medium tracking-[-0.01em] leading-[19.5px] text-foreground">{source.name}</h3>
+    <article className="relative w-full rounded-lg bg-card shadow-sm" data-testid={`line-intake-source-${source.id}`}>
+      <div className="relative flex items-start gap-2 px-3 py-3">
+        <ChevronRight
+          className={cn("mt-1 size-3.5 shrink-0 text-muted-foreground transition-transform", expanded && "rotate-90")}
+          aria-hidden
+        />
+        <button
+          type="button"
+          className="absolute inset-0 z-0 rounded-lg"
+          aria-label={expanded ? `Collapse ${displayName}` : `Expand ${displayName}`}
+          aria-expanded={expanded}
+          onClick={onToggle}
+        />
+        <img
+          src={source.iconSrc}
+          alt={source.iconAlt}
+          className="relative z-10 mt-0.5 size-5 shrink-0 pointer-events-none"
+        />
+        <div className="relative z-10 min-w-0 flex-1 pointer-events-none">
+          <h3 className="flex flex-wrap items-center gap-1.5 text-[13px] font-medium tracking-[-0.01em] leading-[19.5px] text-foreground">
+            {displayName}
+            {expanded && childCount > 0 ? (
+              <span className="text-[11px] font-medium tabular-nums text-muted-foreground">{childCount}</span>
+            ) : null}
+            {expanded && childCount > 0 ? (
+              <span className="text-[11px] font-medium text-muted-foreground">{LINE_INTAKE_COPY.analyzingStatus}</span>
+            ) : null}
+          </h3>
           <p className="workspace-body-text mt-0.5 text-muted-foreground">{source.description}</p>
         </div>
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenGear();
+          }}
+          aria-label={`Open ${displayName} ${gearKind}`}
+          title={`Open ${displayName} ${gearKind}`}
+          data-testid={`line-intake-source-${source.id}-${gearKind}`}
+          className="relative z-20 -mr-1 -mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <Settings className="size-3.5" aria-hidden />
+        </button>
       </div>
+      {children}
     </article>
+  );
+}
+
+function AnalyzingTicketList({
+  tickets,
+  openTicketId,
+  onOpenTicket,
+}: {
+  tickets: LineIntakeAnalyzingTicket[];
+  openTicketId: string | null;
+  onOpenTicket?: (ticket: LineIntakeAnalyzingTicket) => void;
+}) {
+  if (tickets.length === 0) {
+    return (
+      <p className="workspace-body-text px-3 pb-3 pl-9 text-muted-foreground" data-testid="line-intake-empty">
+        {LINE_INTAKE_COPY.analyzingEmpty}
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      className="divide-y divide-border/70 border-t border-border/70"
+      data-testid="line-intake-analyzing"
+      aria-label={LINE_INTAKE_COPY.analyzingTitle}
+    >
+      {tickets.map((ticket) => {
+        const selected = openTicketId === ticket.id;
+        return (
+          <li key={ticket.id} data-testid={`line-intake-analyzing-ticket-${ticket.id}`}>
+            <button
+              type="button"
+              onClick={() => onOpenTicket?.(ticket)}
+              aria-label={`Open ${ticket.title}`}
+              aria-pressed={selected}
+              className={cn(
+                "flex w-full items-start gap-2.5 px-3 py-3.5 text-left transition-colors hover:bg-accent/70",
+                selected && "bg-accent",
+              )}
+            >
+              <Loader2
+                className="mt-0.5 size-3.5 shrink-0 animate-spin text-muted-foreground"
+                aria-hidden
+                data-testid="line-intake-analyzing-spinner"
+              />
+              <span className="min-w-0 flex-1 text-left text-[13px] font-medium leading-snug tracking-[-0.01em] text-foreground">
+                {ticket.title}
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
@@ -1,0 +1,113 @@
+import { Plus, XIcon } from "lucide-react";
+import { useState } from "react";
+
+import { AddIntakePicker } from "./AddIntakePicker";
+import {
+  intakeAutomationFixture,
+  LINE_INTAKE_SOURCES,
+  lineIntakeSourceById,
+  type LineIntakeSource,
+} from "./lineIntakeModel";
+import { WorkOrderSplitRunPopup } from "./work-order-split-run/WorkOrderSplitRunPopup";
+
+interface LineIntakeDrawerProps {
+  onClose: () => void;
+}
+
+/**
+ * Column beside the line board. Lists the automations that listen to
+ * external sources, evaluate events, and create backlog work orders.
+ */
+export function LineIntakeDrawer({ onClose }: LineIntakeDrawerProps) {
+  const [openSourceId, setOpenSourceId] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const openSource = openSourceId ? lineIntakeSourceById(openSourceId) : undefined;
+
+  return (
+    <>
+      <aside
+        className="flex h-full min-h-0 w-72 shrink-0 flex-col border-r border-border bg-slate-200 dark:bg-slate-800"
+        data-testid="line-intake-drawer"
+        aria-label="Intake"
+      >
+        <header className="flex shrink-0 items-center justify-between gap-2 px-3 pb-2 pt-3">
+          <h2 className="workspace-section-title">Intake</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close Intake"
+            title="Close Intake"
+            data-testid="line-intake-close"
+            className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <XIcon className="size-3.5" aria-hidden />
+          </button>
+        </header>
+        <p className="workspace-body-text shrink-0 px-3 pb-3 text-muted-foreground">
+          Automations that listen, evaluate, and create backlog work orders.
+        </p>
+        <ul className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto px-2 pb-3 [scrollbar-width:thin]">
+          {LINE_INTAKE_SOURCES.map((source) => (
+            <li key={source.id}>
+              <IntakeSourceCard source={source} onOpen={() => setOpenSourceId(source.id)} />
+            </li>
+          ))}
+          <li>
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              data-testid="line-intake-add"
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-muted/60 px-3 py-2.5 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors hover:border-foreground/20 hover:bg-muted hover:text-foreground"
+            >
+              <Plus className="size-3.5 shrink-0" aria-hidden />
+              Add intake
+            </button>
+          </li>
+        </ul>
+      </aside>
+
+      <AddIntakePicker
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={(template) => {
+          setPickerOpen(false);
+          if (lineIntakeSourceById(template.id)) {
+            setOpenSourceId(template.id);
+          }
+        }}
+      />
+
+      {openSource ? (
+        <WorkOrderSplitRunPopup
+          key={openSource.id}
+          fixture={intakeAutomationFixture(openSource)}
+          onClose={() => setOpenSourceId(null)}
+          fixed
+        />
+      ) : null}
+    </>
+  );
+}
+
+function IntakeSourceCard({ source, onOpen }: { source: LineIntakeSource; onOpen: () => void }) {
+  return (
+    <article
+      className="relative w-full rounded-lg bg-card px-3 py-2.5 shadow-sm"
+      data-testid={`line-intake-source-${source.id}`}
+    >
+      <button
+        type="button"
+        className="absolute inset-0 z-0 rounded-lg"
+        aria-label={`Open ${source.name} intake`}
+        onClick={onOpen}
+      />
+      <div className="relative z-10 pointer-events-none flex items-start gap-2.5">
+        <img src={source.iconSrc} alt={source.iconAlt} className="mt-0.5 size-5 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[13px] font-medium tracking-[-0.01em] leading-[19.5px] text-foreground">{source.name}</h3>
+          <p className="workspace-body-text mt-0.5 text-muted-foreground">{source.description}</p>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/web_src/src/pages/factories/pages/Lines.stories.tsx
+++ b/web_src/src/pages/factories/pages/Lines.stories.tsx
@@ -1,7 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
-import { PRIMARY_FACTORY_KEY, REFUND_FACTORY_LINES } from "../__fixtures__/factoryPageResponses";
+import { refundLineCanvasFixture } from "../__fixtures__/factoryOwnedCanvasFixture";
+import {
+  ACME_ONBOARDING_FACTORY_ID,
+  ACME_ONBOARDING_FACTORY_KEY,
+  ACME_ONBOARDING_LINE_ID,
+  GITHUB_ISSUES_INTAKE_APP,
+  PRIMARY_FACTORY_KEY,
+  REFUND_FACTORY_LINES,
+} from "../__fixtures__/factoryPageResponses";
 import { emptyFactoriesFixture } from "../__fixtures__/factoryPageFixtureVariants";
 import { fiveStepLineFactoriesFixture, lineMetricsFactoriesFixture } from "../__fixtures__/lineMetricsFactoriesFixture";
 import { LinesPage } from "./LinesPage";
@@ -45,6 +53,28 @@ export const EmptyFactory: Story = {
   render: () => <FactoriesHarness pathSuffix={linesListPath} factoriesFixture={emptyFactoriesFixture} />,
 };
 
+export const AcmeOnboardingEmpty: Story = {
+  name: "Acme onboarding — empty board",
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={`workspaces/${ACME_ONBOARDING_FACTORY_KEY}/lines/${ACME_ONBOARDING_LINE_ID}`}
+      factoriesFixture={lineMetricsFactoriesFixture}
+      appFixture={refundLineCanvasFixture(GITHUB_ISSUES_INTAKE_APP, ACME_ONBOARDING_FACTORY_ID)}
+    />
+  ),
+};
+
+export const AcmeOnboardingIntake: Story = {
+  name: "Acme onboarding — intake",
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={`workspaces/${ACME_ONBOARDING_FACTORY_KEY}/lines/${ACME_ONBOARDING_LINE_ID}?intake=1&source=github-issues`}
+      factoriesFixture={lineMetricsFactoriesFixture}
+      appFixture={refundLineCanvasFixture(GITHUB_ISSUES_INTAKE_APP, ACME_ONBOARDING_FACTORY_ID)}
+    />
+  ),
+};
+
 export const LineBoardIntake: Story = {
   name: "Line board — intake",
   render: () => {
@@ -52,6 +82,19 @@ export const LineBoardIntake: Story = {
     return (
       <FactoriesHarness
         pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}?intake=1`}
+        factoriesFixture={lineMetricsFactoriesFixture}
+      />
+    );
+  },
+};
+
+export const LineBoardIntakeAnalyzing: Story = {
+  name: "Line board — intake tree",
+  render: () => {
+    const line = REFUND_FACTORY_LINES[0];
+    return (
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}?intake=1&source=github-issues`}
         factoriesFixture={lineMetricsFactoriesFixture}
       />
     );

--- a/web_src/src/pages/factories/pages/Lines.stories.tsx
+++ b/web_src/src/pages/factories/pages/Lines.stories.tsx
@@ -45,6 +45,19 @@ export const EmptyFactory: Story = {
   render: () => <FactoriesHarness pathSuffix={linesListPath} factoriesFixture={emptyFactoriesFixture} />,
 };
 
+export const LineBoardIntake: Story = {
+  name: "Line board — intake",
+  render: () => {
+    const line = REFUND_FACTORY_LINES[0];
+    return (
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/lines/${line.id}?intake=1`}
+        factoriesFixture={lineMetricsFactoriesFixture}
+      />
+    );
+  },
+};
+
 export const LineDetailFivePhases: Story = {
   name: "Line detail — five phases",
   render: () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FactoriesFactory } from "@/api-client";
 import { editFactoryLinePath, factoryLineDetailPath } from "../lib/factoryPagePaths";
@@ -17,11 +17,13 @@ import { LINE_LIST_METRICS_BY_ID } from "./lineListMetricsMockData";
 import { LinesPage } from "./LinesPage";
 
 const createFactoryLineMutateAsync = vi.fn();
+const updateFactoryLineMutateAsync = vi.fn();
 
 vi.mock("@/hooks/useFactoryData", () => ({
   useFactoryWorkOrders: () => ({ data: [] }),
   useFactoryApps: () => ({ data: [] }),
   useCreateFactoryLine: () => ({ mutateAsync: createFactoryLineMutateAsync, isPending: false }),
+  useUpdateFactoryLine: () => ({ mutateAsync: updateFactoryLineMutateAsync, isPending: false }),
 }));
 
 vi.mock("@/hooks/useWorkOrderCardActions", () => ({
@@ -119,6 +121,10 @@ describe("LinesPage card menu", () => {
 });
 
 describe("LinesPage board", () => {
+  beforeEach(() => {
+    updateFactoryLineMutateAsync.mockReset();
+  });
+
   function renderBoard(
     path = `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`,
     openCreateWorkOrder = vi.fn(),
@@ -174,7 +180,7 @@ describe("LinesPage board", () => {
     await user.click(screen.getByTestId("lines-backlog-menu"));
     await user.click(screen.getByTestId("lines-backlog-menu-color-lime"));
 
-    expect(screen.getByTestId("lines-backlog-column").className).toContain("bg-lime-100");
+    expect(screen.getByTestId("lines-backlog-column").className).toContain("bg-lime-300");
   });
 
   it("opens the Intake drawer beside the board when the intake query is set", () => {
@@ -185,6 +191,40 @@ describe("LinesPage board", () => {
     expect(screen.getByRole("heading", { name: "Plan and Implement" })).toBeInTheDocument();
     expect(screen.getByTestId("line-intake-close")).toBeInTheDocument();
     expect(screen.getByTestId("line-intake-add")).toHaveTextContent("Add intake");
+  });
+
+  it("renames the board title on Enter", async () => {
+    updateFactoryLineMutateAsync.mockResolvedValueOnce({});
+    const user = userEvent.setup();
+    renderBoard();
+
+    await user.click(screen.getByTestId("lines-board-title"));
+    const input = await screen.findByTestId("lines-board-title-input");
+    await waitFor(() => expect(input).toHaveFocus());
+    await user.clear(input);
+    await user.type(input, "Refund line");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(updateFactoryLineMutateAsync).toHaveBeenCalledWith({
+        lineId: REFUND_LINE_PLAN_ID,
+        name: "Refund line",
+      });
+    });
+  });
+
+  it("renames a column title on Enter", async () => {
+    const user = userEvent.setup();
+    renderBoard();
+
+    await user.click(screen.getByTestId("lines-column-title-backlog"));
+    const input = await screen.findByTestId("lines-column-title-backlog-input");
+    await waitFor(() => expect(input).toHaveFocus());
+    await user.clear(input);
+    await user.type(input, "Inbox");
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByTestId("lines-column-title-backlog")).toHaveTextContent("Inbox");
   });
 
   it("opens Edit from the line overflow menu", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -119,10 +119,13 @@ describe("LinesPage card menu", () => {
 });
 
 describe("LinesPage board", () => {
-  function renderBoard() {
+  function renderBoard(
+    path = `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`,
+    openCreateWorkOrder = vi.fn(),
+  ) {
     return render(
       <QueryClientProvider client={new QueryClient()}>
-        <MemoryRouter initialEntries={[`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`]}>
+        <MemoryRouter initialEntries={[path]}>
           <FactoriesLayoutContext.Provider
             value={{
               organizationId: "org-1",
@@ -130,7 +133,7 @@ describe("LinesPage board", () => {
               factoryKey: PRIMARY_FACTORY_KEY,
               factory: REFUND_FACTORY,
               factories: [REFUND_FACTORY],
-              openCreateWorkOrder: vi.fn(),
+              openCreateWorkOrder,
             }}
           >
             <Routes>
@@ -149,6 +152,31 @@ describe("LinesPage board", () => {
 
     expect(screen.getByTestId("lines-detail-page")).toBeInTheDocument();
     expect(screen.queryByTestId("lines-back-to-list")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("line-intake-drawer")).not.toBeInTheDocument();
+  });
+
+  it("creates work orders from the backlog header plus and add control", async () => {
+    const openCreateWorkOrder = vi.fn();
+    const user = userEvent.setup();
+    renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`, openCreateWorkOrder);
+
+    const backlog = screen.getByTestId("lines-backlog-column");
+    expect(within(backlog).getByTestId("lines-backlog-create")).toBeInTheDocument();
+    expect(within(backlog).getByTestId("lines-backlog-add")).toHaveTextContent("Add work order");
+
+    await user.click(within(backlog).getByTestId("lines-backlog-create"));
+    await user.click(within(backlog).getByTestId("lines-backlog-add"));
+    expect(openCreateWorkOrder).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens the Intake drawer beside the board when the intake query is set", () => {
+    renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?intake=1`);
+
+    expect(screen.getByTestId("line-intake-drawer")).toBeInTheDocument();
+    expect(screen.getByTestId("lines-detail-page")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Plan and Implement" })).toBeInTheDocument();
+    expect(screen.getByTestId("line-intake-close")).toBeInTheDocument();
+    expect(screen.getByTestId("line-intake-add")).toHaveTextContent("Add intake");
   });
 
   it("opens Edit from the line overflow menu", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -259,6 +259,43 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId("lines-column-title-backlog")).toHaveTextContent("Inbox");
   });
 
+  it("labels phase Edit as Edit Automation", async () => {
+    const user = userEvent.setup();
+    renderBoard();
+
+    await user.click(screen.getByTestId("lines-phase-menu-0"));
+    expect(screen.getByTestId("lines-phase-menu-0-edit")).toHaveTextContent("Edit Automation");
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByTestId("lines-backlog-menu"));
+    expect(screen.getByTestId("lines-backlog-menu-edit")).toHaveTextContent("Edit");
+    expect(screen.queryByTestId("lines-backlog-menu-parallelism")).not.toBeInTheDocument();
+  });
+
+  it("opens Set parallelism and saves a new cap", async () => {
+    updateFactoryLineMutateAsync.mockResolvedValueOnce({});
+    const user = userEvent.setup();
+    renderBoard();
+
+    await user.click(screen.getByTestId("lines-phase-menu-0"));
+    expect(screen.getByTestId("lines-phase-menu-0-parallelism")).toHaveTextContent("Set parallelism (10)");
+    await user.click(screen.getByTestId("lines-phase-menu-0-parallelism"));
+
+    const input = screen.getByTestId("lines-parallelism-input");
+    await user.clear(input);
+    await user.type(input, "20");
+    await user.click(screen.getByTestId("lines-parallelism-save"));
+
+    await waitFor(() => {
+      expect(updateFactoryLineMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lineId: REFUND_LINE_PLAN_ID,
+          steps: expect.arrayContaining([expect.objectContaining({ maxParallelism: 20 })]),
+        }),
+      );
+    });
+  });
+
   it("hides Edit on the Done column", async () => {
     const user = userEvent.setup();
     const factory: FactoriesFactory = {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -169,6 +169,16 @@ describe("LinesPage board", () => {
     expect(openCreateWorkOrder).toHaveBeenCalledTimes(2);
   });
 
+  it("sets a pastel colour on the backlog from circular swatches", async () => {
+    const user = userEvent.setup();
+    renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`);
+
+    await user.click(screen.getByTestId("lines-backlog-menu"));
+    await user.click(screen.getByTestId("lines-backlog-menu-color-lime"));
+
+    expect(screen.getByTestId("lines-backlog-column").className).toContain("bg-lime-100");
+  });
+
   it("opens the Intake drawer beside the board when the intake query is set", () => {
     renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?intake=1`);
 

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -4,9 +4,14 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { FactoriesFactory } from "@/api-client";
+import type { FactoriesFactory, FactoriesWorkOrder } from "@/api-client";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
 import { editFactoryLinePath, factoryAppConfigurePath, factoryLineDetailPath } from "../lib/factoryPagePaths";
 import {
+  ACME_ONBOARDING_FACTORY,
+  ACME_ONBOARDING_FACTORY_KEY,
+  ACME_ONBOARDING_LINE_ID,
+  GITHUB_ISSUES_INTAKE_APP,
   PRIMARY_FACTORY_ID,
   PRIMARY_FACTORY_KEY,
   REFUND_FACTORY,
@@ -15,14 +20,17 @@ import {
 import { withPlanLinePhases } from "../__fixtures__/lineMetricsPlanLine";
 import { FactoriesLayoutContext } from "../layout/factoriesLayoutContext";
 import { LINE_LIST_METRICS_BY_ID } from "./lineListMetricsMockData";
+import { REVIEW_CANDIDATE_WORK_ORDERS } from "./onboarding/first-run/reviewCandidates";
 import { LinesPage } from "./LinesPage";
 
 const createFactoryLineMutateAsync = vi.fn();
 const updateFactoryLineMutateAsync = vi.fn();
+const useFactoryWorkOrders = vi.fn(() => ({ data: [] as FactoriesWorkOrder[] }));
+const useFactoryApps = vi.fn(() => ({ data: [] as Array<{ id?: string; name?: string }> }));
 
 vi.mock("@/hooks/useFactoryData", () => ({
-  useFactoryWorkOrders: () => ({ data: [] }),
-  useFactoryApps: () => ({ data: [] }),
+  useFactoryWorkOrders: () => useFactoryWorkOrders(),
+  useFactoryApps: () => useFactoryApps(),
   useCreateFactoryLine: () => ({ mutateAsync: createFactoryLineMutateAsync, isPending: false }),
   useUpdateFactoryLine: () => ({ mutateAsync: updateFactoryLineMutateAsync, isPending: false }),
 }));
@@ -124,6 +132,8 @@ describe("LinesPage card menu", () => {
 describe("LinesPage board", () => {
   beforeEach(() => {
     updateFactoryLineMutateAsync.mockReset();
+    useFactoryWorkOrders.mockReturnValue({ data: [] });
+    useFactoryApps.mockReturnValue({ data: [] });
   });
 
   function renderBoard(
@@ -133,24 +143,26 @@ describe("LinesPage board", () => {
   ) {
     return render(
       <QueryClientProvider client={new QueryClient()}>
-        <MemoryRouter initialEntries={[path]}>
-          <FactoriesLayoutContext.Provider
-            value={{
-              organizationId: "org-1",
-              factoryId: PRIMARY_FACTORY_ID,
-              factoryKey: PRIMARY_FACTORY_KEY,
-              factory,
-              factories: [factory],
-              openCreateWorkOrder,
-            }}
-          >
-            <Routes>
-              <Route path="/org-1/workspaces/:factoryKey/lines/:lineId" element={<LinesPage />} />
-              <Route path="/org-1/workspaces/:factoryKey/lines/:lineId/edit" element={<div>Edit line</div>} />
-            </Routes>
-            <LocationProbe />
-          </FactoriesLayoutContext.Provider>
-        </MemoryRouter>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={[path]}>
+            <FactoriesLayoutContext.Provider
+              value={{
+                organizationId: "org-1",
+                factoryId: factory.id ?? PRIMARY_FACTORY_ID,
+                factoryKey: factory.key ?? PRIMARY_FACTORY_KEY,
+                factory,
+                factories: [factory],
+                openCreateWorkOrder,
+              }}
+            >
+              <Routes>
+                <Route path="/org-1/workspaces/:factoryKey/lines/:lineId" element={<LinesPage />} />
+                <Route path="/org-1/workspaces/:factoryKey/lines/:lineId/edit" element={<div>Edit line</div>} />
+              </Routes>
+              <LocationProbe />
+            </FactoriesLayoutContext.Provider>
+          </MemoryRouter>
+        </ThemeProvider>
       </QueryClientProvider>,
     );
   }
@@ -185,6 +197,26 @@ describe("LinesPage board", () => {
     expect(screen.getByTestId("lines-backlog-column").className).toContain("bg-lime-300");
   });
 
+  it("shows a score on a review-candidate backlog card and opens the plan review", async () => {
+    useFactoryWorkOrders.mockReturnValue({ data: REVIEW_CANDIDATE_WORK_ORDERS });
+    const user = userEvent.setup();
+    renderBoard();
+
+    const card = screen.getByTestId("work-order-card-wo-review-pay-842");
+    expect(within(card).getByTestId("work-order-card-score-wo-review-pay-842")).toHaveTextContent("95%");
+    expect(within(card).queryByRole("button", { name: "Start" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open Add retry handling to webhook delivery" }));
+
+    const dialog = screen.getByTestId("review-candidate-modal");
+    expect(within(dialog).getByRole("heading", { name: "Add retry handling to webhook delivery" })).toBeInTheDocument();
+    expect(within(dialog).getByTestId("review-candidate-score")).toHaveTextContent("95%");
+    expect(within(dialog).getByTestId("review-candidate-plan")).toHaveTextContent(
+      "Add a webhook-specific retry policy using the shared backoff utility.",
+    );
+    expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+  });
+
   it("opens the Intake drawer beside the board when the intake query is set", () => {
     renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?intake=1`);
 
@@ -193,6 +225,56 @@ describe("LinesPage board", () => {
     expect(screen.getByRole("heading", { name: "Plan and Implement" })).toBeInTheDocument();
     expect(screen.getByTestId("line-intake-close")).toBeInTheDocument();
     expect(screen.getByTestId("line-intake-add")).toHaveTextContent("Add intake");
+    expect(screen.getByTestId("line-intake-source-sentry-exceptions")).toBeInTheDocument();
+    expect(screen.getByTestId("line-intake-source-pagerduty-incidents")).toBeInTheDocument();
+    expect(screen.queryByTestId("line-intake-analyzing")).not.toBeInTheDocument();
+  });
+
+  it("shows a backlog onboarding card on Acme when the backlog is empty", () => {
+    renderBoard(
+      `/org-1/workspaces/${ACME_ONBOARDING_FACTORY_KEY}/lines/${ACME_ONBOARDING_LINE_ID}`,
+      vi.fn(),
+      ACME_ONBOARDING_FACTORY,
+    );
+
+    expect(screen.getByTestId("backlog-onboarding-card")).toBeInTheDocument();
+    expect(screen.queryByText("No work orders in the backlog.")).not.toBeInTheDocument();
+  });
+
+  it("shows GitHub issues only on Acme onboarding intake", () => {
+    renderBoard(
+      `/org-1/workspaces/${ACME_ONBOARDING_FACTORY_KEY}/lines/${ACME_ONBOARDING_LINE_ID}?intake=1&source=github-issues`,
+      vi.fn(),
+      ACME_ONBOARDING_FACTORY,
+    );
+
+    expect(screen.getByTestId("line-intake-source-github-issues")).toBeInTheDocument();
+    expect(screen.queryByTestId("line-intake-source-sentry-exceptions")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("line-intake-source-pagerduty-incidents")).not.toBeInTheDocument();
+  });
+
+  it("opens the factory canvas editor from Edit automation", async () => {
+    useFactoryApps.mockReturnValue({ data: [GITHUB_ISSUES_INTAKE_APP] });
+    const user = userEvent.setup();
+    renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?intake=1&source=github-issues`);
+
+    await user.click(screen.getByRole("button", { name: "Open GitHub issues settings" }));
+    await user.click(screen.getByRole("tab", { name: "Automation" }));
+
+    expect(screen.getByRole("link", { name: "Edit automation" })).toHaveAttribute(
+      "href",
+      factoryAppConfigurePath("org-1", PRIMARY_FACTORY_KEY, GITHUB_ISSUES_INTAKE_APP.id!, {
+        from: "lines",
+        lineId: REFUND_LINE_PLAN_ID,
+      }),
+    );
+  });
+
+  it("nests analyzing tickets under GitHub issues when that source is open", () => {
+    renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?intake=1&source=github-issues`);
+
+    expect(screen.getByTestId("line-intake-analyzing")).toBeInTheDocument();
+    expect(screen.getByText("Handle duplicate refunds on retry")).toBeInTheDocument();
   });
 
   it("renames the board title on Enter", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -5,13 +5,14 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FactoriesFactory } from "@/api-client";
-import { editFactoryLinePath, factoryLineDetailPath } from "../lib/factoryPagePaths";
+import { editFactoryLinePath, factoryAppConfigurePath, factoryLineDetailPath } from "../lib/factoryPagePaths";
 import {
   PRIMARY_FACTORY_ID,
   PRIMARY_FACTORY_KEY,
   REFUND_FACTORY,
   REFUND_LINE_PLAN_ID,
 } from "../__fixtures__/factoryPageResponses";
+import { withPlanLinePhases } from "../__fixtures__/lineMetricsPlanLine";
 import { FactoriesLayoutContext } from "../layout/factoriesLayoutContext";
 import { LINE_LIST_METRICS_BY_ID } from "./lineListMetricsMockData";
 import { LinesPage } from "./LinesPage";
@@ -128,6 +129,7 @@ describe("LinesPage board", () => {
   function renderBoard(
     path = `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`,
     openCreateWorkOrder = vi.fn(),
+    factory: FactoriesFactory = REFUND_FACTORY,
   ) {
     return render(
       <QueryClientProvider client={new QueryClient()}>
@@ -137,8 +139,8 @@ describe("LinesPage board", () => {
               organizationId: "org-1",
               factoryId: PRIMARY_FACTORY_ID,
               factoryKey: PRIMARY_FACTORY_KEY,
-              factory: REFUND_FACTORY,
-              factories: [REFUND_FACTORY],
+              factory,
+              factories: [factory],
               openCreateWorkOrder,
             }}
           >
@@ -225,6 +227,54 @@ describe("LinesPage board", () => {
     await user.keyboard("{Enter}");
 
     expect(screen.getByTestId("lines-column-title-backlog")).toHaveTextContent("Inbox");
+  });
+
+  it("opens backlog settings in a modal and does not open a canvas", async () => {
+    const user = userEvent.setup();
+    const linePath = `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`;
+    renderBoard();
+
+    await user.click(screen.getByTestId("lines-backlog-menu"));
+    await user.click(screen.getByTestId("lines-backlog-menu-edit"));
+
+    expect(screen.getByTestId("lines-backlog-settings")).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("Backlog");
+    expect(screen.getByLabelText("Size")).toBeInTheDocument();
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(linePath);
+    expect(screen.getByTestId("lines-test-location")).not.toHaveTextContent("configure=1");
+  });
+
+  it("saves the backlog name from the settings modal", async () => {
+    const user = userEvent.setup();
+    renderBoard();
+
+    await user.click(screen.getByTestId("lines-backlog-menu"));
+    await user.click(screen.getByTestId("lines-backlog-menu-edit"));
+    const name = screen.getByLabelText("Name");
+    await user.clear(name);
+    await user.type(name, "Inbox");
+    await user.click(screen.getByTestId("lines-backlog-settings-save"));
+
+    expect(screen.queryByTestId("lines-backlog-settings")).not.toBeInTheDocument();
+    expect(screen.getByTestId("lines-column-title-backlog")).toHaveTextContent("Inbox");
+  });
+
+  it("hides Edit on the Done column", async () => {
+    const user = userEvent.setup();
+    const factory: FactoriesFactory = {
+      ...REFUND_FACTORY,
+      lines: (REFUND_FACTORY.lines ?? []).map(withPlanLinePhases),
+    };
+    renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`, vi.fn(), factory);
+
+    await user.click(screen.getByTestId("lines-phase-menu-3"));
+    expect(screen.queryByTestId("lines-phase-menu-3-edit")).not.toBeInTheDocument();
+    expect(screen.getByTestId("lines-test-location")).not.toHaveTextContent(
+      factoryAppConfigurePath("org-1", PRIMARY_FACTORY_KEY, "app-refund-done", {
+        from: "lines",
+        lineId: REFUND_LINE_PLAN_ID,
+      }),
+    );
   });
 
   it("opens Edit from the line overflow menu", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -155,18 +155,16 @@ describe("LinesPage board", () => {
     expect(screen.queryByTestId("line-intake-drawer")).not.toBeInTheDocument();
   });
 
-  it("creates work orders from the backlog header plus and add control", async () => {
+  it("creates work orders from the backlog header plus", async () => {
     const openCreateWorkOrder = vi.fn();
     const user = userEvent.setup();
     renderBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`, openCreateWorkOrder);
 
     const backlog = screen.getByTestId("lines-backlog-column");
-    expect(within(backlog).getByTestId("lines-backlog-create")).toBeInTheDocument();
-    expect(within(backlog).getByTestId("lines-backlog-add")).toHaveTextContent("Add work order");
+    expect(within(backlog).queryByRole("button", { name: "Add work order" })).not.toBeInTheDocument();
 
     await user.click(within(backlog).getByTestId("lines-backlog-create"));
-    await user.click(within(backlog).getByTestId("lines-backlog-add"));
-    expect(openCreateWorkOrder).toHaveBeenCalledTimes(2);
+    expect(openCreateWorkOrder).toHaveBeenCalledTimes(1);
   });
 
   it("sets a pastel colour on the backlog from circular swatches", async () => {

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -10,7 +10,7 @@ import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { Clock, Inbox, Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
+import { Clock, Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
@@ -50,7 +50,7 @@ import {
   linesPath,
   workOrderDetailPath,
 } from "../lib/factoryPagePaths";
-import { formatLinePhaseDescription, humanizeLineName } from "../lib/humanizeLineName";
+import { humanizeLineName } from "../lib/humanizeLineName";
 import {
   factoryKanbanPageClassName,
   factorySectionBodyClassName,
@@ -106,7 +106,6 @@ export function LinesPage() {
             organizationId={organizationId}
             factoryKey={factoryKey}
             line={selectedLine}
-            apps={factoryApps}
             canUpdate={canUpdate}
           />
         </div>
@@ -191,13 +190,11 @@ function LineDetailHeader({
   organizationId,
   factoryKey,
   line,
-  apps,
   canUpdate,
 }: {
   organizationId: string;
   factoryKey: string;
   line: FactoriesFactoryLine;
-  apps: Array<{ id?: string; name?: string }>;
   canUpdate: boolean;
 }) {
   const editHref = line.id ? editFactoryLinePath(organizationId, factoryKey, line.id) : "#";
@@ -205,9 +202,8 @@ function LineDetailHeader({
     <WorkspacePageHeader
       className={factorySectionHeaderClassName}
       title={humanizeLineName(line.name)}
-      subtitle={formatLinePhaseDescription(line.steps, apps)}
       actions={
-        canUpdate ? (
+        canUpdate && line.id ? (
           <ColumnConfigureMenu title={humanizeLineName(line.name)} href={editHref} testId="lines-edit-menu" />
         ) : undefined
       }
@@ -494,7 +490,6 @@ function BacklogColumn({
       tone="neutral"
       emptyDescription="No work orders in the backlog."
       className="bg-muted"
-      leading={<Inbox className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />}
       actions={
         configureHref ? <ColumnConfigureMenu title="Backlog" href={configureHref} testId="lines-backlog-menu" /> : null
       }

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -12,7 +12,7 @@ import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoL
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { Clock, Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Navigate, useNavigate, useParams } from "react-router";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import {
@@ -46,7 +46,9 @@ import {
   editFactoryLinePath,
   factoryAppConfigurePath,
   factoryAppSplitRunPath,
+  factoryHomePath,
   factoryLineDetailPath,
+  isIntakeSearchOpen,
   linesPath,
   workOrderDetailPath,
 } from "../lib/factoryPagePaths";
@@ -57,6 +59,7 @@ import {
   factorySectionHeaderClassName,
   factoryWorkOrdersBodyClassName,
 } from "./factoryPageLayoutStyles";
+import { LineIntakeDrawer } from "./LineIntakeDrawer";
 import { LineListCard } from "./LineListCard";
 import { descriptionForLine, toLineListMetrics } from "./lineListMetricsMockData";
 import { useLineCardMutations } from "./useLineCardMutations";
@@ -64,15 +67,19 @@ import { useLineCardMutations } from "./useLineCardMutations";
 const LIST_SUBTITLE = "Last 30 days. Success rate, completions per day, duration, and cost per merged work order.";
 
 export function LinesPage() {
-  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
+  const { organizationId, factoryId, factoryKey, factory, openCreateWorkOrder } = useFactoriesLayout();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const { lineId: routeLineId } = useParams<{ lineId: string }>();
+  const { search } = useLocation();
+  const navigate = useNavigate();
+  const intakeOpen = isIntakeSearchOpen(search);
   const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
   const { data: factoryApps = [] } = useFactoryApps(organizationId, factoryId);
   const cardActions = useWorkOrderCardActions(organizationId, factoryId);
 
   const canUpdate = canAct("factories", "update");
   const canUpdateWorkOrders = canAct("work_orders", "update");
+  const canCreateWorkOrder = canAct("work_orders", "create");
   const lines = useMemo(() => factory?.lines ?? [], [factory?.lines]);
   const { actionsForLine } = useLineCardMutations({
     organizationId,
@@ -100,34 +107,41 @@ export function LinesPage() {
   // the lanes read as columns rather than as boxes around their cards.
   if (selectedLine) {
     return (
-      <div className={factoryKanbanPageClassName} data-testid="lines-detail-page">
-        <div className="shrink-0">
-          <LineDetailHeader
-            organizationId={organizationId}
-            factoryKey={factoryKey}
-            line={selectedLine}
-            canUpdate={canUpdate}
-          />
-        </div>
+      <div className="flex h-full min-h-0 min-w-0 w-full" data-testid="lines-detail-page">
+        {intakeOpen ? (
+          <LineIntakeDrawer onClose={() => navigate(factoryHomePath(organizationId, factoryKey, selectedLine.id))} />
+        ) : null}
+        <div className={factoryKanbanPageClassName}>
+          <div className="shrink-0">
+            <LineDetailHeader
+              organizationId={organizationId}
+              factoryKey={factoryKey}
+              line={selectedLine}
+              canUpdate={canUpdate}
+            />
+          </div>
 
-        <div className={factoryWorkOrdersBodyClassName}>
-          <LineDetail
-            organizationId={organizationId}
-            factoryId={factoryId}
-            factoryKey={factoryKey}
-            line={selectedLine}
-            apps={factoryApps}
-            workOrders={workOrders}
-            workOrderCardContext={{
-              organizationId,
-              factoryKey,
-              factoryLines: lines,
-              canDispatch: canUpdateWorkOrders,
-              preferredLineName: selectedLine.name,
-              canAssign: canUpdateWorkOrders,
-              ...cardActions,
-            }}
-          />
+          <div className={factoryWorkOrdersBodyClassName}>
+            <LineDetail
+              organizationId={organizationId}
+              factoryId={factoryId}
+              factoryKey={factoryKey}
+              line={selectedLine}
+              apps={factoryApps}
+              workOrders={workOrders}
+              canCreateWorkOrder={canCreateWorkOrder || permissionsLoading}
+              onCreateWorkOrder={openCreateWorkOrder}
+              workOrderCardContext={{
+                organizationId,
+                factoryKey,
+                factoryLines: lines,
+                canDispatch: canUpdateWorkOrders,
+                preferredLineName: selectedLine.name,
+                canAssign: canUpdateWorkOrders,
+                ...cardActions,
+              }}
+            />
+          </div>
         </div>
       </div>
     );
@@ -218,6 +232,8 @@ function LineDetail({
   line,
   apps,
   workOrders,
+  canCreateWorkOrder,
+  onCreateWorkOrder,
   workOrderCardContext,
 }: {
   organizationId: string;
@@ -226,6 +242,8 @@ function LineDetail({
   line: FactoriesFactoryLine;
   apps: Array<{ id?: string; name?: string }>;
   workOrders: FactoriesWorkOrder[];
+  canCreateWorkOrder: boolean;
+  onCreateWorkOrder: () => void;
   workOrderCardContext: WorkOrderCardContext;
 }) {
   const steps = line.steps ?? [];
@@ -254,6 +272,8 @@ function LineDetail({
           apps={apps}
           backlogOrders={backlogOrders}
           columns={board}
+          canCreateWorkOrder={canCreateWorkOrder}
+          onCreateWorkOrder={onCreateWorkOrder}
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={setPeekOrderId}
         />
@@ -422,6 +442,8 @@ function PhaseBoard({
   apps,
   backlogOrders,
   columns,
+  canCreateWorkOrder,
+  onCreateWorkOrder,
   workOrderCardContext,
   onOpenWorkOrder,
 }: {
@@ -431,6 +453,8 @@ function PhaseBoard({
   apps: Array<{ id?: string; name?: string }>;
   backlogOrders: FactoriesWorkOrder[];
   columns: LinePhaseColumn[];
+  canCreateWorkOrder: boolean;
+  onCreateWorkOrder: () => void;
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
 }) {
@@ -445,6 +469,8 @@ function PhaseBoard({
         <BacklogColumn
           orders={backlogOrders}
           configureHref={backlogConfigureHref}
+          canCreateWorkOrder={canCreateWorkOrder}
+          onCreateWorkOrder={onCreateWorkOrder}
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={onOpenWorkOrder}
         />
@@ -474,11 +500,15 @@ function PhaseBoard({
 function BacklogColumn({
   orders,
   configureHref,
+  canCreateWorkOrder,
+  onCreateWorkOrder,
   workOrderCardContext,
   onOpenWorkOrder,
 }: {
   orders: FactoriesWorkOrder[];
   configureHref: string | null;
+  canCreateWorkOrder: boolean;
+  onCreateWorkOrder: () => void;
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
 }) {
@@ -490,12 +520,44 @@ function BacklogColumn({
       tone="neutral"
       emptyDescription="No work orders in the backlog."
       className="bg-muted"
+      keepChildrenWhenEmpty
       actions={
-        configureHref ? <ColumnConfigureMenu title="Backlog" href={configureHref} testId="lines-backlog-menu" /> : null
+        <div className="flex shrink-0 items-center gap-0.5">
+          <PermissionTooltip
+            allowed={canCreateWorkOrder}
+            message="You don't have permission to create work orders."
+          >
+            <button
+              type="button"
+              onClick={() => {
+                if (canCreateWorkOrder) {
+                  onCreateWorkOrder();
+                }
+              }}
+              disabled={!canCreateWorkOrder}
+              aria-label="Create work order"
+              title="Create work order"
+              data-testid="lines-backlog-create"
+              className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
+            >
+              <Plus className="size-3.5" aria-hidden />
+            </button>
+          </PermissionTooltip>
+          {configureHref ? (
+            <ColumnConfigureMenu title="Backlog" href={configureHref} testId="lines-backlog-menu" />
+          ) : null}
+        </div>
       }
       testId="lines-backlog-column"
     >
       <ul className={workOrderKanbanLaneScrollClassName} data-testid="lines-backlog-column-scroll">
+        {orders.length === 0 ? (
+          <li>
+            <p className="rounded-md border border-dashed border-border/60 px-3 py-6 text-center text-[12px] text-muted-foreground">
+              No work orders in the backlog.
+            </p>
+          </li>
+        ) : null}
         {orders.map((order) => (
           <li key={order.id}>
             <LineBoardOrderCard
@@ -505,6 +567,24 @@ function BacklogColumn({
             />
           </li>
         ))}
+        <li>
+          <PermissionTooltip allowed={canCreateWorkOrder} message="You don't have permission to create work orders.">
+            <button
+              type="button"
+              onClick={() => {
+                if (canCreateWorkOrder) {
+                  onCreateWorkOrder();
+                }
+              }}
+              disabled={!canCreateWorkOrder}
+              data-testid="lines-backlog-add"
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-muted/60 px-3 py-2.5 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors hover:border-foreground/20 hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
+            >
+              <Plus className="size-3.5 shrink-0" aria-hidden />
+              Add work order
+            </button>
+          </PermissionTooltip>
+        </li>
       </ul>
     </WorkOrderBoardLane>
   );

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -3,16 +3,19 @@ import { Link } from "@/components/Link/link";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { usePermissions } from "@/contexts/usePermissions";
-import { useFactoryApps, useFactoryWorkOrders } from "@/hooks/useFactoryData";
+import { useFactoryApps, useFactoryWorkOrders, useUpdateFactoryLine } from "@/hooks/useFactoryData";
 import { useWorkOrderChecks } from "@/hooks/useWorkOrderChecks";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { Clock, Layers, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate, useParams } from "react-router";
+import { ClickToRename } from "../layout/ClickToRename";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import {
@@ -117,6 +120,7 @@ export function LinesPage() {
           <div className="shrink-0">
             <LineDetailHeader
               organizationId={organizationId}
+              factoryId={factoryId}
               factoryKey={factoryKey}
               line={selectedLine}
               canUpdate={canUpdate}
@@ -132,6 +136,7 @@ export function LinesPage() {
               apps={factoryApps}
               workOrders={workOrders}
               canCreateWorkOrder={canCreateWorkOrder || permissionsLoading}
+              canUpdate={canUpdate}
               onCreateWorkOrder={openCreateWorkOrder}
               workOrderCardContext={{
                 organizationId,
@@ -204,23 +209,49 @@ export function LinesPage() {
 
 function LineDetailHeader({
   organizationId,
+  factoryId,
   factoryKey,
   line,
   canUpdate,
 }: {
   organizationId: string;
+  factoryId: string;
   factoryKey: string;
   line: FactoriesFactoryLine;
   canUpdate: boolean;
 }) {
+  const updateLine = useUpdateFactoryLine(organizationId, factoryId);
+  const title = humanizeLineName(line.name);
   const editHref = line.id ? editFactoryLinePath(organizationId, factoryKey, line.id) : "#";
+
+  const handleRename = async (name: string) => {
+    if (!line.id) {
+      return;
+    }
+    try {
+      await updateLine.mutateAsync({ lineId: line.id, name });
+    } catch (error) {
+      showErrorToast(getApiErrorMessage(error, "Failed to rename line"));
+    }
+  };
+
   return (
     <WorkspacePageHeader
       className={factorySectionHeaderClassName}
-      title={humanizeLineName(line.name)}
+      title={
+        <ClickToRename
+          value={title}
+          onSave={(name) => void handleRename(name)}
+          canEdit={canUpdate && Boolean(line.id)}
+          busy={updateLine.isPending}
+          testId="lines-board-title"
+          ariaLabel="Line name"
+          inputClassName="font-medium text-[length:var(--workspace-page-title-size)] leading-[var(--workspace-page-title-line-height)] tracking-[var(--workspace-page-title-tracking)]"
+        />
+      }
       actions={
         canUpdate && line.id ? (
-          <ColumnConfigureMenu title={humanizeLineName(line.name)} href={editHref} testId="lines-edit-menu" />
+          <ColumnConfigureMenu title={title} href={editHref} testId="lines-edit-menu" />
         ) : undefined
       }
     />
@@ -235,6 +266,7 @@ function LineDetail({
   apps,
   workOrders,
   canCreateWorkOrder,
+  canUpdate,
   onCreateWorkOrder,
   workOrderCardContext,
 }: {
@@ -245,6 +277,7 @@ function LineDetail({
   apps: Array<{ id?: string; name?: string }>;
   workOrders: FactoriesWorkOrder[];
   canCreateWorkOrder: boolean;
+  canUpdate: boolean;
   onCreateWorkOrder: () => void;
   workOrderCardContext: WorkOrderCardContext;
 }) {
@@ -275,6 +308,7 @@ function LineDetail({
           backlogOrders={backlogOrders}
           columns={board}
           canCreateWorkOrder={canCreateWorkOrder}
+          canRename={canUpdate}
           onCreateWorkOrder={onCreateWorkOrder}
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={setPeekOrderId}
@@ -445,6 +479,7 @@ function PhaseBoard({
   backlogOrders,
   columns,
   canCreateWorkOrder,
+  canRename,
   onCreateWorkOrder,
   workOrderCardContext,
   onOpenWorkOrder,
@@ -456,6 +491,7 @@ function PhaseBoard({
   backlogOrders: FactoriesWorkOrder[];
   columns: LinePhaseColumn[];
   canCreateWorkOrder: boolean;
+  canRename: boolean;
   onCreateWorkOrder: () => void;
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
@@ -465,9 +501,14 @@ function PhaseBoard({
     ? factoryAppConfigurePath(organizationId, factoryKey, backlogApp.id, { from: "lines", lineId })
     : null;
   const [columnColors, setColumnColors] = useState<Record<string, LineBoardColumnColorId | null>>({});
+  const [columnTitles, setColumnTitles] = useState<Record<string, string>>({});
 
   const setColumnColor = useCallback((columnKey: string, colorId: LineBoardColumnColorId | null) => {
     setColumnColors((current) => ({ ...current, [columnKey]: colorId }));
+  }, []);
+
+  const setColumnTitle = useCallback((columnKey: string, title: string) => {
+    setColumnTitles((current) => ({ ...current, [columnKey]: title }));
   }, []);
 
   return (
@@ -475,10 +516,13 @@ function PhaseBoard({
       <div className={cn("relative flex min-h-0 self-stretch", workOrderKanbanLaneSizeClassName)}>
         <BacklogColumn
           orders={backlogOrders}
+          title={columnTitles.backlog ?? "Backlog"}
           configureHref={backlogConfigureHref}
           colorId={columnColors.backlog ?? null}
           onColorChange={(colorId) => setColumnColor("backlog", colorId)}
           canCreateWorkOrder={canCreateWorkOrder}
+          canRename={canRename}
+          onRename={(title) => setColumnTitle("backlog", title)}
           onCreateWorkOrder={onCreateWorkOrder}
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={onOpenWorkOrder}
@@ -499,8 +543,11 @@ function PhaseBoard({
               factoryKey={factoryKey}
               lineId={lineId}
               column={column}
+              title={columnTitles[columnKey] ?? column.stepName}
               colorId={columnColors[columnKey] ?? null}
               onColorChange={(colorId) => setColumnColor(columnKey, colorId)}
+              canRename={canRename}
+              onRename={(title) => setColumnTitle(columnKey, title)}
               workOrderCardContext={workOrderCardContext}
               onOpenWorkOrder={onOpenWorkOrder}
             />
@@ -513,19 +560,25 @@ function PhaseBoard({
 
 function BacklogColumn({
   orders,
+  title,
   configureHref,
   colorId,
   onColorChange,
   canCreateWorkOrder,
+  canRename,
+  onRename,
   onCreateWorkOrder,
   workOrderCardContext,
   onOpenWorkOrder,
 }: {
   orders: FactoriesWorkOrder[];
+  title: string;
   configureHref: string | null;
   colorId: LineBoardColumnColorId | null;
   onColorChange: (colorId: LineBoardColumnColorId | null) => void;
   canCreateWorkOrder: boolean;
+  canRename: boolean;
+  onRename: (title: string) => void;
   onCreateWorkOrder: () => void;
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
@@ -534,8 +587,11 @@ function BacklogColumn({
 
   return (
     <WorkOrderBoardLane
-      title="Backlog"
-      label="Backlog"
+      title={title}
+      label={title}
+      canRename={canRename}
+      onRename={onRename}
+      titleTestId="lines-column-title-backlog"
       count={orders.length}
       tone="neutral"
       surfaceClassName={surfaceClassName}
@@ -561,7 +617,7 @@ function BacklogColumn({
             </button>
           </PermissionTooltip>
           <ColumnLaneMenu
-            title="Backlog"
+            title={title}
             testId="lines-backlog-menu"
             editHref={configureHref}
             colorId={colorId}
@@ -626,8 +682,11 @@ function PhaseColumn({
   factoryKey,
   lineId,
   column,
+  title,
   colorId,
   onColorChange,
+  canRename,
+  onRename,
   workOrderCardContext,
   onOpenWorkOrder,
 }: {
@@ -635,8 +694,11 @@ function PhaseColumn({
   factoryKey: string;
   lineId?: string;
   column: LinePhaseColumn;
+  title: string;
   colorId: LineBoardColumnColorId | null;
   onColorChange: (colorId: LineBoardColumnColorId | null) => void;
+  canRename: boolean;
+  onRename: (title: string) => void;
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
 }) {
@@ -669,16 +731,19 @@ function PhaseColumn({
 
   return (
     <WorkOrderBoardLane
-      title={column.stepName}
-      label={`${column.stepName} phase`}
+      title={title}
+      label={`${title} phase`}
       count={totalRuns}
       tone={PHASE_LANE_TONE[glyph]}
       surfaceClassName={surfaceClassName}
       emptyDescription="No work orders in this phase."
+      canRename={canRename}
+      onRename={onRename}
+      titleTestId={`lines-column-title-phase-${column.stepIndex}`}
       testId={`lines-phase-column-${column.stepIndex}`}
       actions={
         <ColumnLaneMenu
-          title={column.stepName}
+          title={title}
           testId={`lines-phase-menu-${column.stepIndex}`}
           editHref={configureHref}
           colorId={colorId}

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -59,8 +59,10 @@ import {
   factorySectionHeaderClassName,
   factoryWorkOrdersBodyClassName,
 } from "./factoryPageLayoutStyles";
+import { ColumnLaneMenu } from "./ColumnLaneMenu";
 import { LineIntakeDrawer } from "./LineIntakeDrawer";
 import { LineListCard } from "./LineListCard";
+import { lineBoardColumnLaneClassName, type LineBoardColumnColorId } from "./lineBoardColumnColors";
 import { descriptionForLine, toLineListMetrics } from "./lineListMetricsMockData";
 import { useLineCardMutations } from "./useLineCardMutations";
 
@@ -462,6 +464,11 @@ function PhaseBoard({
   const backlogConfigureHref = backlogApp
     ? factoryAppConfigurePath(organizationId, factoryKey, backlogApp.id, { from: "lines", lineId })
     : null;
+  const [columnColors, setColumnColors] = useState<Record<string, LineBoardColumnColorId | null>>({});
+
+  const setColumnColor = useCallback((columnKey: string, colorId: LineBoardColumnColorId | null) => {
+    setColumnColors((current) => ({ ...current, [columnKey]: colorId }));
+  }, []);
 
   return (
     <WorkOrderKanbanBoard testId="lines-phase-board">
@@ -469,30 +476,37 @@ function PhaseBoard({
         <BacklogColumn
           orders={backlogOrders}
           configureHref={backlogConfigureHref}
+          colorId={columnColors.backlog ?? null}
+          onColorChange={(colorId) => setColumnColor("backlog", colorId)}
           canCreateWorkOrder={canCreateWorkOrder}
           onCreateWorkOrder={onCreateWorkOrder}
           workOrderCardContext={workOrderCardContext}
           onOpenWorkOrder={onOpenWorkOrder}
         />
       </div>
-      {columns.map((column, index) => (
-        <div
-          key={`${column.stepIndex}-${column.stepName}`}
-          className={cn("relative flex min-h-0 self-stretch", workOrderKanbanLaneSizeClassName)}
-        >
-          {index < columns.length - 1 ? (
-            <span className="absolute top-[21px] left-full z-[1] h-px w-3 bg-border" aria-hidden />
-          ) : null}
-          <PhaseColumn
-            organizationId={organizationId}
-            factoryKey={factoryKey}
-            lineId={lineId}
-            column={column}
-            workOrderCardContext={workOrderCardContext}
-            onOpenWorkOrder={onOpenWorkOrder}
-          />
-        </div>
-      ))}
+      {columns.map((column, index) => {
+        const columnKey = `phase-${column.stepIndex}`;
+        return (
+          <div
+            key={`${column.stepIndex}-${column.stepName}`}
+            className={cn("relative flex min-h-0 self-stretch", workOrderKanbanLaneSizeClassName)}
+          >
+            {index < columns.length - 1 ? (
+              <span className="absolute top-[21px] left-full z-[1] h-px w-3 bg-border" aria-hidden />
+            ) : null}
+            <PhaseColumn
+              organizationId={organizationId}
+              factoryKey={factoryKey}
+              lineId={lineId}
+              column={column}
+              colorId={columnColors[columnKey] ?? null}
+              onColorChange={(colorId) => setColumnColor(columnKey, colorId)}
+              workOrderCardContext={workOrderCardContext}
+              onOpenWorkOrder={onOpenWorkOrder}
+            />
+          </div>
+        );
+      })}
     </WorkOrderKanbanBoard>
   );
 }
@@ -500,6 +514,8 @@ function PhaseBoard({
 function BacklogColumn({
   orders,
   configureHref,
+  colorId,
+  onColorChange,
   canCreateWorkOrder,
   onCreateWorkOrder,
   workOrderCardContext,
@@ -507,26 +523,28 @@ function BacklogColumn({
 }: {
   orders: FactoriesWorkOrder[];
   configureHref: string | null;
+  colorId: LineBoardColumnColorId | null;
+  onColorChange: (colorId: LineBoardColumnColorId | null) => void;
   canCreateWorkOrder: boolean;
   onCreateWorkOrder: () => void;
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
 }) {
+  const surfaceClassName = lineBoardColumnLaneClassName(colorId);
+
   return (
     <WorkOrderBoardLane
       title="Backlog"
       label="Backlog"
       count={orders.length}
       tone="neutral"
+      surfaceClassName={surfaceClassName}
       emptyDescription="No work orders in the backlog."
-      className="bg-muted"
+      className={surfaceClassName ? undefined : "bg-muted"}
       keepChildrenWhenEmpty
       actions={
         <div className="flex shrink-0 items-center gap-0.5">
-          <PermissionTooltip
-            allowed={canCreateWorkOrder}
-            message="You don't have permission to create work orders."
-          >
+          <PermissionTooltip allowed={canCreateWorkOrder} message="You don't have permission to create work orders.">
             <button
               type="button"
               onClick={() => {
@@ -543,9 +561,13 @@ function BacklogColumn({
               <Plus className="size-3.5" aria-hidden />
             </button>
           </PermissionTooltip>
-          {configureHref ? (
-            <ColumnConfigureMenu title="Backlog" href={configureHref} testId="lines-backlog-menu" />
-          ) : null}
+          <ColumnLaneMenu
+            title="Backlog"
+            testId="lines-backlog-menu"
+            editHref={configureHref}
+            colorId={colorId}
+            onColorChange={onColorChange}
+          />
         </div>
       }
       testId="lines-backlog-column"
@@ -630,6 +652,8 @@ function PhaseColumn({
   factoryKey,
   lineId,
   column,
+  colorId,
+  onColorChange,
   workOrderCardContext,
   onOpenWorkOrder,
 }: {
@@ -637,6 +661,8 @@ function PhaseColumn({
   factoryKey: string;
   lineId?: string;
   column: LinePhaseColumn;
+  colorId: LineBoardColumnColorId | null;
+  onColorChange: (colorId: LineBoardColumnColorId | null) => void;
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
 }) {
@@ -660,12 +686,12 @@ function PhaseColumn({
     loadMoreIfNeeded(scrollRef.current);
   }, [visibleCount, loadMoreIfNeeded]);
 
-  const navigate = useNavigate();
   const visibleRuns = column.runs.slice(0, Math.min(visibleCount, totalRuns));
   const configureHref = column.appId
     ? factoryAppConfigurePath(organizationId, factoryKey, column.appId, { from: "lines", lineId })
     : null;
   const glyph = resolveColumnGlyph(column);
+  const surfaceClassName = lineBoardColumnLaneClassName(colorId);
 
   return (
     <WorkOrderBoardLane
@@ -673,32 +699,17 @@ function PhaseColumn({
       label={`${column.stepName} phase`}
       count={totalRuns}
       tone={PHASE_LANE_TONE[glyph]}
+      surfaceClassName={surfaceClassName}
       emptyDescription="No work orders in this phase."
       testId={`lines-phase-column-${column.stepIndex}`}
       actions={
-        configureHref ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                aria-label={`${column.stepName} menu`}
-                className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                data-testid={`lines-phase-menu-${column.stepIndex}`}
-              >
-                <MoreHorizontal className="size-3.5" aria-hidden />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-40">
-              <DropdownMenuItem
-                onClick={() => navigate(configureHref)}
-                data-testid={`lines-phase-edit-${column.stepIndex}`}
-              >
-                <Pencil className="h-3.5 w-3.5" aria-hidden />
-                Edit
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : null
+        <ColumnLaneMenu
+          title={column.stepName}
+          testId={`lines-phase-menu-${column.stepIndex}`}
+          editHref={configureHref}
+          colorId={colorId}
+          onColorChange={onColorChange}
+        />
       }
     >
       <ul

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -63,8 +63,10 @@ import {
   factorySectionHeaderClassName,
   factoryWorkOrdersBodyClassName,
 } from "./factoryPageLayoutStyles";
+import { replaceLineStepParallelism } from "../lib/factoryLineFormShared";
 import { BacklogSettingsDialog } from "./BacklogSettingsDialog";
 import { ColumnLaneMenu } from "./ColumnLaneMenu";
+import { ParallelismSettingsDialog } from "./ParallelismSettingsDialog";
 import { LineIntakeDrawer } from "./LineIntakeDrawer";
 import { LineListCard } from "./LineListCard";
 import { lineBoardColumnLaneClassName, type LineBoardColumnColorId } from "./lineBoardColumnColors";
@@ -304,8 +306,9 @@ function LineDetail({
       ) : (
         <PhaseBoard
           organizationId={organizationId}
+          factoryId={factoryId}
           factoryKey={factoryKey}
-          lineId={line.id}
+          line={line}
           backlogOrders={backlogOrders}
           columns={board}
           canCreateWorkOrder={canCreateWorkOrder}
@@ -474,8 +477,9 @@ function executionRunIdForCanvas(
 
 function PhaseBoard({
   organizationId,
+  factoryId,
   factoryKey,
-  lineId,
+  line,
   backlogOrders,
   columns,
   canCreateWorkOrder,
@@ -485,8 +489,9 @@ function PhaseBoard({
   onOpenWorkOrder,
 }: {
   organizationId: string;
+  factoryId: string;
   factoryKey: string;
-  lineId?: string;
+  line: FactoriesFactoryLine;
   backlogOrders: FactoriesWorkOrder[];
   columns: LinePhaseColumn[];
   canCreateWorkOrder: boolean;
@@ -499,6 +504,9 @@ function PhaseBoard({
   const [columnTitles, setColumnTitles] = useState<Record<string, string>>({});
   const [backlogSize, setBacklogSize] = useState<number | null>(null);
   const [backlogSettingsOpen, setBacklogSettingsOpen] = useState(false);
+  const [parallelismByStep, setParallelismByStep] = useState<Record<number, number>>({});
+  const updateLine = useUpdateFactoryLine(organizationId, factoryId);
+  const lineId = line.id;
 
   const setColumnColor = useCallback((columnKey: string, colorId: LineBoardColumnColorId | null) => {
     setColumnColors((current) => ({ ...current, [columnKey]: colorId }));
@@ -507,6 +515,29 @@ function PhaseBoard({
   const setColumnTitle = useCallback((columnKey: string, title: string) => {
     setColumnTitles((current) => ({ ...current, [columnKey]: title }));
   }, []);
+
+  const saveParallelism = useCallback(
+    async (stepIndex: number, value: number) => {
+      setParallelismByStep((current) => ({ ...current, [stepIndex]: value }));
+      if (!line.id) {
+        return;
+      }
+      try {
+        await updateLine.mutateAsync({
+          lineId: line.id,
+          steps: replaceLineStepParallelism(line.steps, stepIndex, value),
+        });
+      } catch (error) {
+        setParallelismByStep((current) => {
+          const next = { ...current };
+          delete next[stepIndex];
+          return next;
+        });
+        showErrorToast(getApiErrorMessage(error, "Failed to update parallelism"));
+      }
+    },
+    [line.id, line.steps, updateLine],
+  );
 
   return (
     <WorkOrderKanbanBoard testId="lines-phase-board">
@@ -549,6 +580,8 @@ function PhaseBoard({
               lineId={lineId}
               column={column}
               title={columnTitles[columnKey] ?? column.stepName}
+              parallelism={parallelismByStep[column.stepIndex] ?? column.maxParallelism}
+              onSaveParallelism={(value) => void saveParallelism(column.stepIndex, value)}
               colorId={columnColors[columnKey] ?? null}
               onColorChange={(colorId) => setColumnColor(columnKey, colorId)}
               canRename={canRename}
@@ -707,6 +740,8 @@ function PhaseColumn({
   lineId,
   column,
   title,
+  parallelism,
+  onSaveParallelism,
   colorId,
   onColorChange,
   canRename,
@@ -719,6 +754,8 @@ function PhaseColumn({
   lineId?: string;
   column: LinePhaseColumn;
   title: string;
+  parallelism: number;
+  onSaveParallelism: (value: number) => void;
   colorId: LineBoardColumnColorId | null;
   onColorChange: (colorId: LineBoardColumnColorId | null) => void;
   canRename: boolean;
@@ -728,6 +765,7 @@ function PhaseColumn({
 }) {
   const scrollRef = useRef<HTMLUListElement>(null);
   const [visibleCount, setVisibleCount] = useState(LINE_PHASE_RUNS_PAGE_SIZE);
+  const [parallelismOpen, setParallelismOpen] = useState(false);
   const totalRuns = column.runs.length;
   const hasMore = visibleCount < totalRuns;
 
@@ -755,40 +793,54 @@ function PhaseColumn({
   const surfaceClassName = lineBoardColumnLaneClassName(colorId);
 
   return (
-    <WorkOrderBoardLane
-      title={title}
-      label={`${title} phase`}
-      count={totalRuns}
-      tone={PHASE_LANE_TONE[glyph]}
-      surfaceClassName={surfaceClassName}
-      emptyDescription="No work orders in this phase."
-      canRename={canRename}
-      onRename={onRename}
-      titleTestId={`lines-column-title-phase-${column.stepIndex}`}
-      testId={`lines-phase-column-${column.stepIndex}`}
-      actions={
-        <ColumnLaneMenu
-          title={title}
-          testId={`lines-phase-menu-${column.stepIndex}`}
-          editHref={configureHref}
-          colorId={colorId}
-          onColorChange={onColorChange}
-        />
-      }
-    >
-      <ul
-        ref={scrollRef}
-        className={workOrderKanbanLaneScrollClassName}
-        onScroll={(event) => loadMoreIfNeeded(event.currentTarget)}
-        data-testid={`lines-phase-column-scroll-${column.stepIndex}`}
+    <>
+      <WorkOrderBoardLane
+        title={title}
+        label={`${title} phase`}
+        count={totalRuns}
+        tone={PHASE_LANE_TONE[glyph]}
+        surfaceClassName={surfaceClassName}
+        emptyDescription="No work orders in this phase."
+        canRename={canRename}
+        onRename={onRename}
+        titleTestId={`lines-column-title-phase-${column.stepIndex}`}
+        testId={`lines-phase-column-${column.stepIndex}`}
+        actions={
+          <ColumnLaneMenu
+            title={title}
+            testId={`lines-phase-menu-${column.stepIndex}`}
+            editHref={configureHref}
+            editLabel={configureHref ? "Edit Automation" : undefined}
+            onSetParallelism={configureHref ? () => setParallelismOpen(true) : undefined}
+            parallelism={parallelism}
+            colorId={colorId}
+            onColorChange={onColorChange}
+          />
+        }
       >
-        {visibleRuns.map((run) => (
-          <li key={run.executionId}>
-            <PhaseRunCard run={run} workOrderCardContext={workOrderCardContext} onOpenWorkOrder={onOpenWorkOrder} />
-          </li>
-        ))}
-      </ul>
-    </WorkOrderBoardLane>
+        <ul
+          ref={scrollRef}
+          className={workOrderKanbanLaneScrollClassName}
+          onScroll={(event) => loadMoreIfNeeded(event.currentTarget)}
+          data-testid={`lines-phase-column-scroll-${column.stepIndex}`}
+        >
+          {visibleRuns.map((run) => (
+            <li key={run.executionId}>
+              <PhaseRunCard run={run} workOrderCardContext={workOrderCardContext} onOpenWorkOrder={onOpenWorkOrder} />
+            </li>
+          ))}
+        </ul>
+      </WorkOrderBoardLane>
+      <ParallelismSettingsDialog
+        open={parallelismOpen}
+        value={parallelism}
+        onSave={(value) => {
+          onSaveParallelism(value);
+          setParallelismOpen(false);
+        }}
+        onClose={() => setParallelismOpen(false)}
+      />
+    </>
   );
 }
 

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -541,7 +541,6 @@ function BacklogColumn({
       surfaceClassName={surfaceClassName}
       emptyDescription="No work orders in the backlog."
       className={surfaceClassName ? undefined : "bg-muted"}
-      keepChildrenWhenEmpty
       actions={
         <div className="flex shrink-0 items-center gap-0.5">
           <PermissionTooltip allowed={canCreateWorkOrder} message="You don't have permission to create work orders.">
@@ -573,13 +572,6 @@ function BacklogColumn({
       testId="lines-backlog-column"
     >
       <ul className={workOrderKanbanLaneScrollClassName} data-testid="lines-backlog-column-scroll">
-        {orders.length === 0 ? (
-          <li>
-            <p className="rounded-md border border-dashed border-border/60 px-3 py-6 text-center text-[12px] text-muted-foreground">
-              No work orders in the backlog.
-            </p>
-          </li>
-        ) : null}
         {orders.map((order) => (
           <li key={order.id}>
             <LineBoardOrderCard
@@ -589,24 +581,6 @@ function BacklogColumn({
             />
           </li>
         ))}
-        <li>
-          <PermissionTooltip allowed={canCreateWorkOrder} message="You don't have permission to create work orders.">
-            <button
-              type="button"
-              onClick={() => {
-                if (canCreateWorkOrder) {
-                  onCreateWorkOrder();
-                }
-              }}
-              disabled={!canCreateWorkOrder}
-              data-testid="lines-backlog-add"
-              className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-muted/60 px-3 py-2.5 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors hover:border-foreground/20 hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
-            >
-              <Plus className="size-3.5 shrink-0" aria-hidden />
-              Add work order
-            </button>
-          </PermissionTooltip>
-        </li>
       </ul>
     </WorkOrderBoardLane>
   );

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -42,6 +42,9 @@ import {
   type BoardLaneTone,
 } from "../workOrders/WorkOrderBoardChrome";
 import { WorkOrderCard, type WorkOrderCardContext } from "../workOrders/WorkOrderCard";
+import { BacklogOnboardingCard } from "./onboarding/first-run/BacklogOnboardingCard";
+import { ReviewCandidateModal } from "./onboarding/first-run/ReviewCandidateModal";
+import { reviewCandidateForWorkOrderId } from "./onboarding/first-run/reviewCandidates";
 import { WorkOrderSplitRunPopup } from "./work-order-split-run/WorkOrderSplitRunPopup";
 import type { SplitRunCanvasKey } from "./work-order-split-run/splitRunCanvases";
 import { splitRunFixtureForWorkOrder } from "./work-order-split-run/splitRunMocks";
@@ -52,6 +55,8 @@ import {
   factoryAppSplitRunPath,
   factoryHomePath,
   factoryLineDetailPath,
+  intakeSettingsTabFromSearch,
+  intakeSourceFromSearch,
   isIntakeSearchOpen,
   linesPath,
   workOrderDetailPath,
@@ -67,6 +72,13 @@ import { replaceLineStepParallelism } from "../lib/factoryLineFormShared";
 import { BacklogSettingsDialog } from "./BacklogSettingsDialog";
 import { ColumnLaneMenu } from "./ColumnLaneMenu";
 import { ParallelismSettingsDialog } from "./ParallelismSettingsDialog";
+import {
+  intakeAutomationAppId,
+  isFirstRunOnboardingFactory,
+  isLineIntakeSourceId,
+  lineIntakeSourcesForFactory,
+} from "./lineIntakeModel";
+import { isIntakeSettingsTab } from "./intakeSourceSettingsModel";
 import { LineIntakeDrawer } from "./LineIntakeDrawer";
 import { LineListCard } from "./LineListCard";
 import { lineBoardColumnLaneClassName, type LineBoardColumnColorId } from "./lineBoardColumnColors";
@@ -82,6 +94,8 @@ export function LinesPage() {
   const { search } = useLocation();
   const navigate = useNavigate();
   const intakeOpen = isIntakeSearchOpen(search);
+  const intakeSourceId = intakeSourceFromSearch(search);
+  const intakeSettingsTab = intakeSettingsTabFromSearch(search);
   const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
   const { data: factoryApps = [] } = useFactoryApps(organizationId, factoryId);
   const cardActions = useWorkOrderCardActions(organizationId, factoryId);
@@ -115,10 +129,24 @@ export function LinesPage() {
   // The phase board is a Kanban surface: it claims the full viewport height so
   // the lanes read as columns rather than as boxes around their cards.
   if (selectedLine) {
+    const intakeEditAppId = intakeAutomationAppId(factoryApps);
+    const editAutomationHref = intakeEditAppId
+      ? factoryAppConfigurePath(organizationId, factoryKey, intakeEditAppId, {
+          from: "lines",
+          lineId: selectedLine.id,
+        })
+      : undefined;
     return (
       <div className="flex h-full min-h-0 min-w-0 w-full" data-testid="lines-detail-page">
         {intakeOpen ? (
-          <LineIntakeDrawer onClose={() => navigate(factoryHomePath(organizationId, factoryKey, selectedLine.id))} />
+          <LineIntakeDrawer
+            sources={lineIntakeSourcesForFactory(factoryKey)}
+            initialSourceId={isLineIntakeSourceId(intakeSourceId) ? intakeSourceId : undefined}
+            initialSettingsOpen={isIntakeSettingsTab(intakeSettingsTab)}
+            initialSettingsTab={isIntakeSettingsTab(intakeSettingsTab) ? intakeSettingsTab : "general"}
+            editAutomationHref={editAutomationHref}
+            onClose={() => navigate(factoryHomePath(organizationId, factoryKey, selectedLine.id))}
+          />
         ) : null}
         <div className={factoryKanbanPageClassName}>
           <div className="shrink-0">
@@ -290,6 +318,7 @@ function LineDetail({
   const backlogOrders = useMemo(() => collectLineBacklogOrders(workOrders ?? []), [workOrders]);
   const [peekOrderId, setPeekOrderId] = useState<string | null>(null);
   const peekOrder = workOrders.find((order) => order.id === peekOrderId);
+  const reviewCandidate = reviewCandidateForWorkOrderId(peekOrderId ?? undefined);
   const canvasEditHref = useMemo(
     () => canvasEditHrefForLine(organizationId, factoryKey, line, apps),
     [organizationId, factoryKey, line, apps],
@@ -318,7 +347,9 @@ function LineDetail({
           onOpenWorkOrder={setPeekOrderId}
         />
       )}
-      {peekOrderId ? (
+      {reviewCandidate ? (
+        <ReviewCandidateModal candidate={reviewCandidate} onClose={() => setPeekOrderId(null)} />
+      ) : peekOrderId ? (
         <LineBoardSplitRunPopup
           organizationId={organizationId}
           factoryId={factoryId}
@@ -543,6 +574,7 @@ function PhaseBoard({
     <WorkOrderKanbanBoard testId="lines-phase-board">
       <div className={cn("relative flex min-h-0 self-stretch", workOrderKanbanLaneSizeClassName)}>
         <BacklogColumn
+          factoryKey={factoryKey}
           orders={backlogOrders}
           title={columnTitles.backlog ?? "Backlog"}
           size={backlogSize}
@@ -597,6 +629,7 @@ function PhaseBoard({
 }
 
 function BacklogColumn({
+  factoryKey,
   orders,
   title,
   size,
@@ -613,6 +646,7 @@ function BacklogColumn({
   workOrderCardContext,
   onOpenWorkOrder,
 }: {
+  factoryKey: string;
   orders: FactoriesWorkOrder[];
   title: string;
   size: number | null;
@@ -645,6 +679,7 @@ function BacklogColumn({
         tone="neutral"
         surfaceClassName={surfaceClassName}
         emptyDescription="No work orders in the backlog."
+        emptyContent={isFirstRunOnboardingFactory(factoryKey) ? <BacklogOnboardingCard /> : undefined}
         className={surfaceClassName ? undefined : "bg-muted"}
         actions={
           <div className="flex shrink-0 items-center gap-0.5">
@@ -800,7 +835,7 @@ function PhaseColumn({
         count={totalRuns}
         tone={PHASE_LANE_TONE[glyph]}
         surfaceClassName={surfaceClassName}
-        emptyDescription="No work orders in this phase."
+        emptyDescription="Nothing here."
         canRename={canRename}
         onRename={onRename}
         titleTestId={`lines-column-title-phase-${column.stepIndex}`}
@@ -889,11 +924,13 @@ function LineBoardOrderCard({
 }) {
   const { factory } = useFactoriesLayout();
   const entry = useMemo(() => buildWorkOrderListEntry(order, factory), [order, factory]);
+  const reviewCandidate = reviewCandidateForWorkOrderId(order.id);
 
   return (
     <WorkOrderCard
       {...workOrderCardContext}
       entry={entry}
+      confidencePct={reviewCandidate?.confidencePct}
       onOpen={() => {
         if (order.id) {
           onOpenWorkOrder(order.id);

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -23,6 +23,7 @@ import {
   collectLineBacklogOrders,
   findBacklogAutomationApp,
   findClosureAutomationApp,
+  isDoneLineColumn,
   LINE_PHASE_RUNS_PAGE_SIZE,
   resolveColumnGlyph,
   resolvePhaseRunStatus,
@@ -62,6 +63,7 @@ import {
   factorySectionHeaderClassName,
   factoryWorkOrdersBodyClassName,
 } from "./factoryPageLayoutStyles";
+import { BacklogSettingsDialog } from "./BacklogSettingsDialog";
 import { ColumnLaneMenu } from "./ColumnLaneMenu";
 import { LineIntakeDrawer } from "./LineIntakeDrawer";
 import { LineListCard } from "./LineListCard";
@@ -304,7 +306,6 @@ function LineDetail({
           organizationId={organizationId}
           factoryKey={factoryKey}
           lineId={line.id}
-          apps={apps}
           backlogOrders={backlogOrders}
           columns={board}
           canCreateWorkOrder={canCreateWorkOrder}
@@ -475,7 +476,6 @@ function PhaseBoard({
   organizationId,
   factoryKey,
   lineId,
-  apps,
   backlogOrders,
   columns,
   canCreateWorkOrder,
@@ -487,7 +487,6 @@ function PhaseBoard({
   organizationId: string;
   factoryKey: string;
   lineId?: string;
-  apps: Array<{ id?: string; name?: string }>;
   backlogOrders: FactoriesWorkOrder[];
   columns: LinePhaseColumn[];
   canCreateWorkOrder: boolean;
@@ -496,12 +495,10 @@ function PhaseBoard({
   workOrderCardContext: WorkOrderCardContext;
   onOpenWorkOrder: (orderId: string) => void;
 }) {
-  const backlogApp = findBacklogAutomationApp(apps);
-  const backlogConfigureHref = backlogApp
-    ? factoryAppConfigurePath(organizationId, factoryKey, backlogApp.id, { from: "lines", lineId })
-    : null;
   const [columnColors, setColumnColors] = useState<Record<string, LineBoardColumnColorId | null>>({});
   const [columnTitles, setColumnTitles] = useState<Record<string, string>>({});
+  const [backlogSize, setBacklogSize] = useState<number | null>(null);
+  const [backlogSettingsOpen, setBacklogSettingsOpen] = useState(false);
 
   const setColumnColor = useCallback((columnKey: string, colorId: LineBoardColumnColorId | null) => {
     setColumnColors((current) => ({ ...current, [columnKey]: colorId }));
@@ -517,7 +514,15 @@ function PhaseBoard({
         <BacklogColumn
           orders={backlogOrders}
           title={columnTitles.backlog ?? "Backlog"}
-          configureHref={backlogConfigureHref}
+          size={backlogSize}
+          settingsOpen={backlogSettingsOpen}
+          onOpenSettings={() => setBacklogSettingsOpen(true)}
+          onCloseSettings={() => setBacklogSettingsOpen(false)}
+          onSaveSettings={({ name, size }) => {
+            setColumnTitle("backlog", name);
+            setBacklogSize(size);
+            setBacklogSettingsOpen(false);
+          }}
           colorId={columnColors.backlog ?? null}
           onColorChange={(colorId) => setColumnColor("backlog", colorId)}
           canCreateWorkOrder={canCreateWorkOrder}
@@ -561,7 +566,11 @@ function PhaseBoard({
 function BacklogColumn({
   orders,
   title,
-  configureHref,
+  size,
+  settingsOpen,
+  onOpenSettings,
+  onCloseSettings,
+  onSaveSettings,
   colorId,
   onColorChange,
   canCreateWorkOrder,
@@ -573,7 +582,11 @@ function BacklogColumn({
 }: {
   orders: FactoriesWorkOrder[];
   title: string;
-  configureHref: string | null;
+  size: number | null;
+  settingsOpen: boolean;
+  onOpenSettings: () => void;
+  onCloseSettings: () => void;
+  onSaveSettings: (settings: { name: string; size: number | null }) => void;
   colorId: LineBoardColumnColorId | null;
   onColorChange: (colorId: LineBoardColumnColorId | null) => void;
   canCreateWorkOrder: boolean;
@@ -584,61 +597,72 @@ function BacklogColumn({
   onOpenWorkOrder: (orderId: string) => void;
 }) {
   const surfaceClassName = lineBoardColumnLaneClassName(colorId);
+  const atCapacity = size != null && orders.length >= size;
+  const canAdd = canCreateWorkOrder && !atCapacity;
 
   return (
-    <WorkOrderBoardLane
-      title={title}
-      label={title}
-      canRename={canRename}
-      onRename={onRename}
-      titleTestId="lines-column-title-backlog"
-      count={orders.length}
-      tone="neutral"
-      surfaceClassName={surfaceClassName}
-      emptyDescription="No work orders in the backlog."
-      className={surfaceClassName ? undefined : "bg-muted"}
-      actions={
-        <div className="flex shrink-0 items-center gap-0.5">
-          <PermissionTooltip allowed={canCreateWorkOrder} message="You don't have permission to create work orders.">
-            <button
-              type="button"
-              onClick={() => {
-                if (canCreateWorkOrder) {
-                  onCreateWorkOrder();
-                }
-              }}
-              disabled={!canCreateWorkOrder}
-              aria-label="Create work order"
-              title="Create work order"
-              data-testid="lines-backlog-create"
-              className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
-            >
-              <Plus className="size-3.5" aria-hidden />
-            </button>
-          </PermissionTooltip>
-          <ColumnLaneMenu
-            title={title}
-            testId="lines-backlog-menu"
-            editHref={configureHref}
-            colorId={colorId}
-            onColorChange={onColorChange}
-          />
-        </div>
-      }
-      testId="lines-backlog-column"
-    >
-      <ul className={workOrderKanbanLaneScrollClassName} data-testid="lines-backlog-column-scroll">
-        {orders.map((order) => (
-          <li key={order.id}>
-            <LineBoardOrderCard
-              order={order}
-              workOrderCardContext={workOrderCardContext}
-              onOpenWorkOrder={onOpenWorkOrder}
+    <>
+      <WorkOrderBoardLane
+        title={title}
+        label={title}
+        canRename={canRename}
+        onRename={onRename}
+        titleTestId="lines-column-title-backlog"
+        count={orders.length}
+        tone="neutral"
+        surfaceClassName={surfaceClassName}
+        emptyDescription="No work orders in the backlog."
+        className={surfaceClassName ? undefined : "bg-muted"}
+        actions={
+          <div className="flex shrink-0 items-center gap-0.5">
+            <PermissionTooltip allowed={canCreateWorkOrder} message="You don't have permission to create work orders.">
+              <button
+                type="button"
+                onClick={() => {
+                  if (canAdd) {
+                    onCreateWorkOrder();
+                  }
+                }}
+                disabled={!canAdd}
+                aria-label="Create work order"
+                title={atCapacity ? "The backlog is full." : "Create work order"}
+                data-testid="lines-backlog-create"
+                className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
+              >
+                <Plus className="size-3.5" aria-hidden />
+              </button>
+            </PermissionTooltip>
+            <ColumnLaneMenu
+              title={title}
+              testId="lines-backlog-menu"
+              onEdit={onOpenSettings}
+              colorId={colorId}
+              onColorChange={onColorChange}
             />
-          </li>
-        ))}
-      </ul>
-    </WorkOrderBoardLane>
+          </div>
+        }
+        testId="lines-backlog-column"
+      >
+        <ul className={workOrderKanbanLaneScrollClassName} data-testid="lines-backlog-column-scroll">
+          {orders.map((order) => (
+            <li key={order.id}>
+              <LineBoardOrderCard
+                order={order}
+                workOrderCardContext={workOrderCardContext}
+                onOpenWorkOrder={onOpenWorkOrder}
+              />
+            </li>
+          ))}
+        </ul>
+      </WorkOrderBoardLane>
+      <BacklogSettingsDialog
+        open={settingsOpen}
+        name={title}
+        size={size}
+        onSave={onSaveSettings}
+        onClose={onCloseSettings}
+      />
+    </>
   );
 }
 
@@ -723,9 +747,10 @@ function PhaseColumn({
   }, [visibleCount, loadMoreIfNeeded]);
 
   const visibleRuns = column.runs.slice(0, Math.min(visibleCount, totalRuns));
-  const configureHref = column.appId
-    ? factoryAppConfigurePath(organizationId, factoryKey, column.appId, { from: "lines", lineId })
-    : null;
+  const configureHref =
+    !isDoneLineColumn(column) && column.appId
+      ? factoryAppConfigurePath(organizationId, factoryKey, column.appId, { from: "lines", lineId })
+      : null;
   const glyph = resolveColumnGlyph(column);
   const surfaceClassName = lineBoardColumnLaneClassName(colorId);
 

--- a/web_src/src/pages/factories/pages/ParallelismSettingsDialog.spec.tsx
+++ b/web_src/src/pages/factories/pages/ParallelismSettingsDialog.spec.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ParallelismSettingsDialog } from "./ParallelismSettingsDialog";
+
+describe("ParallelismSettingsDialog", () => {
+  it("saves a value from the input", async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ParallelismSettingsDialog open value={10} onSave={onSave} onClose={vi.fn()} />);
+
+    const input = screen.getByTestId("lines-parallelism-input");
+    expect(input).toHaveValue(10);
+    expect(screen.getByRole("slider")).toHaveAttribute("aria-valuenow", "10");
+
+    await user.clear(input);
+    await user.type(input, "25");
+    await user.click(screen.getByTestId("lines-parallelism-save"));
+
+    expect(onSave).toHaveBeenCalledWith(25);
+  });
+
+  it("rejects a value outside 1 to 100", async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ParallelismSettingsDialog open value={10} onSave={onSave} onClose={vi.fn()} />);
+
+    const input = screen.getByTestId("lines-parallelism-input");
+    await user.clear(input);
+    await user.type(input, "0");
+    await user.click(screen.getByTestId("lines-parallelism-save"));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText("Enter a whole number from 1 to 100.")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/ParallelismSettingsDialog.tsx
+++ b/web_src/src/pages/factories/pages/ParallelismSettingsDialog.tsx
@@ -1,0 +1,132 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { useEffect, useState } from "react";
+
+import {
+  clampLineStepParallelism,
+  LINE_STEP_PARALLELISM_MAX,
+  LINE_STEP_PARALLELISM_MIN,
+} from "../lib/factoryLineFormShared";
+
+interface ParallelismSettingsDialogProps {
+  open: boolean;
+  value: number;
+  onSave: (value: number) => void;
+  onClose: () => void;
+}
+
+const VALUE_ERROR = "Enter a whole number from 1 to 100.";
+
+function parseParallelism(raw: string): { value: number; error?: string } {
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return { value: LINE_STEP_PARALLELISM_MIN, error: VALUE_ERROR };
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (parsed < LINE_STEP_PARALLELISM_MIN || parsed > LINE_STEP_PARALLELISM_MAX) {
+    return { value: parsed, error: VALUE_ERROR };
+  }
+  return { value: parsed };
+}
+
+export function ParallelismSettingsDialog({ open, value, onSave, onClose }: ParallelismSettingsDialogProps) {
+  const [draft, setDraft] = useState(value);
+  const [input, setInput] = useState(String(value));
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setDraft(value);
+    setInput(String(value));
+    setError("");
+  }, [open, value]);
+
+  const applyValue = (next: number) => {
+    const clamped = clampLineStepParallelism(next);
+    setDraft(clamped);
+    setInput(String(clamped));
+    setError("");
+  };
+
+  const handleSave = () => {
+    const parsed = parseParallelism(input);
+    if (parsed.error) {
+      setError(parsed.error);
+      return;
+    }
+    onSave(parsed.value);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-md" data-testid="lines-parallelism-settings">
+        <DialogHeader>
+          <DialogTitle>Set parallelism</DialogTitle>
+          <DialogDescription>Maximum number of work orders to be processed in parallel at this step.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="lines-parallelism-input">Parallelism</Label>
+            <Input
+              id="lines-parallelism-input"
+              data-testid="lines-parallelism-input"
+              type="number"
+              min={LINE_STEP_PARALLELISM_MIN}
+              max={LINE_STEP_PARALLELISM_MAX}
+              inputMode="numeric"
+              value={input}
+              onChange={(event) => {
+                const raw = event.target.value;
+                setInput(raw);
+                setError("");
+                const parsed = parseParallelism(raw);
+                if (!parsed.error) {
+                  setDraft(parsed.value);
+                }
+              }}
+            />
+          </div>
+          <Slider
+            min={LINE_STEP_PARALLELISM_MIN}
+            max={LINE_STEP_PARALLELISM_MAX}
+            step={1}
+            value={[draft]}
+            onValueChange={(values) => applyValue(values[0] ?? draft)}
+            aria-label="Parallelism slider"
+            data-testid="lines-parallelism-slider"
+          />
+          {error ? <p className="text-xs text-red-600">{error}</p> : null}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} data-testid="lines-parallelism-save">
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/factories/pages/intakeSourceSettingsModel.spec.ts
+++ b/web_src/src/pages/factories/pages/intakeSourceSettingsModel.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_GITHUB_INTAKE_SETTINGS,
+  GITHUB_INTAKE_RUNS,
+  isIntakeSettingsTab,
+  intakePlacementActivity,
+  intakePlacementLabel,
+  intakeRelativeTime,
+  normalizeIntakeSourceSettings,
+  toggleIntakeLabel,
+} from "./intakeSourceSettingsModel";
+
+describe("intakeSourceSettingsModel", () => {
+  it("adds and removes a label", () => {
+    expect(toggleIntakeLabel([], "bug")).toEqual(["bug"]);
+    expect(toggleIntakeLabel(["bug", "enhancement"], "bug")).toEqual(["enhancement"]);
+  });
+
+  it("keeps a default name when the draft name is empty", () => {
+    const next = normalizeIntakeSourceSettings({
+      ...DEFAULT_GITHUB_INTAKE_SETTINGS,
+      name: "   ",
+      confidencePct: 140.6,
+    });
+
+    expect(next.name).toBe("GitHub issues");
+    expect(next.confidencePct).toBe(100);
+  });
+
+  it("labels ticket placement for backlog, rejected, and in-progress work", () => {
+    const implement = GITHUB_INTAKE_RUNS.find((run) => run.id === "gh-issue-1")!;
+    const backlog = GITHUB_INTAKE_RUNS.find((run) => run.id === "gh-issue-3")!;
+    const rejected = GITHUB_INTAKE_RUNS.find((run) => run.id === "gh-issue-4")!;
+    const held = GITHUB_INTAKE_RUNS.find((run) => run.id === "gh-issue-6")!;
+
+    expect(intakePlacementLabel(implement)).toBe("Implement");
+    expect(intakePlacementActivity(implement)).toBe("Writing the retry handler.");
+    expect(intakePlacementLabel(backlog)).toBe("In Backlog");
+    expect(intakePlacementActivity(backlog)).toBe("Waiting for review.");
+    expect(intakePlacementLabel(rejected)).toBe("Rejected");
+    expect(intakePlacementLabel(held)).toBe("Not moved to Backlog");
+    expect(intakeRelativeTime(180)).toBe("3h ago");
+  });
+
+  it("accepts only the three settings tabs", () => {
+    expect(isIntakeSettingsTab("automation")).toBe(true);
+    expect(isIntakeSettingsTab("runs")).toBe(true);
+    expect(isIntakeSettingsTab("general")).toBe(true);
+    expect(isIntakeSettingsTab("listen")).toBe(false);
+  });
+});

--- a/web_src/src/pages/factories/pages/intakeSourceSettingsModel.ts
+++ b/web_src/src/pages/factories/pages/intakeSourceSettingsModel.ts
@@ -1,0 +1,193 @@
+import { formatTimeAgo } from "@/lib/date";
+
+export type IntakeListenMode = "listen" | "schedule";
+export type IntakeLabelFilterMode = "include" | "exclude";
+export type IntakeAssignmentFilter = "any" | "assigned" | "unassigned";
+export type IntakeSettingsTab = "general" | "runs" | "automation";
+
+export function isIntakeSettingsTab(value: string | null | undefined): value is IntakeSettingsTab {
+  return value === "general" || value === "runs" || value === "automation";
+}
+export type IntakeTicketPlacement = "backlog" | "rejected" | "progressed" | "below-threshold";
+export type IntakeLineStage = "plan" | "implement" | "verify" | "done";
+
+export interface IntakeAutomationRun {
+  id: string;
+  title: string;
+  confidencePct: number;
+  ranMinutesAgo: number;
+  analyzedMinutesAgo: number;
+  placement: IntakeTicketPlacement;
+  stage?: IntakeLineStage;
+  activity?: string;
+}
+
+export interface IntakeSourceSettings {
+  name: string;
+  listenMode: IntakeListenMode;
+  confidencePct: number;
+  labelFilterMode: IntakeLabelFilterMode;
+  labels: string[];
+  assignment: IntakeAssignmentFilter;
+}
+
+export const GITHUB_INTAKE_LABEL_OPTIONS = ["bug", "enhancement", "documentation", "good first issue"] as const;
+
+export const DEFAULT_GITHUB_INTAKE_SETTINGS: IntakeSourceSettings = {
+  name: "GitHub issues",
+  listenMode: "listen",
+  confidencePct: 65,
+  labelFilterMode: "include",
+  labels: [],
+  assignment: "any",
+};
+
+export const INTAKE_SETTINGS_COPY = {
+  title: "Intake GitHub issues",
+  tabsLabel: "Intake settings",
+  generalTab: "General",
+  automationTab: "Automation",
+  editAutomation: "Edit automation",
+  runsTab: "Runs",
+  runsEmpty: "No runs yet.",
+  runWhen: "Run",
+  analysisWhen: "Analysis",
+  scoreWhen: "Score",
+  viewRun: "View run",
+  viewRunFor: (title: string) => `View run for ${title}`,
+  inBacklog: "In Backlog",
+  backlogActivity: "Waiting for review.",
+  rejected: "Rejected",
+  rejectedActivity: "A person rejected this ticket.",
+  belowThreshold: "Not moved to Backlog",
+  belowThresholdActivity: "Score is below the minimum confidence.",
+  stagePlan: "Plan",
+  stageImplement: "Implement",
+  stageVerify: "Verify",
+  stageDone: "Done",
+  nameLabel: "Name",
+  nameHelper: "Shown in the Intake list.",
+  listenLabel: "When to analyze",
+  listenOption: "Listen for new issues",
+  listenHelper: "Analyze a GitHub issue when it is created.",
+  scheduleOption: "Run on a schedule",
+  scheduleHelper: "Analyze open issues every few hours.",
+  confidenceLabel: "Minimum confidence",
+  confidenceHelper: "Move a ticket to Backlog when the score is this value or higher.",
+  filtersLabel: "Filters",
+  labelsLabel: "Labels",
+  includeLabels: "Include these labels",
+  excludeLabels: "Exclude these labels",
+  labelsHelper: "Leave all labels off to match every issue.",
+  assignmentLabel: "Assignment",
+  assignmentAny: "Any assignment",
+  assignmentAssigned: "Assigned",
+  assignmentUnassigned: "Unassigned",
+  save: "Save",
+} as const;
+
+const STAGE_LABEL: Record<IntakeLineStage, string> = {
+  plan: INTAKE_SETTINGS_COPY.stagePlan,
+  implement: INTAKE_SETTINGS_COPY.stageImplement,
+  verify: INTAKE_SETTINGS_COPY.stageVerify,
+  done: INTAKE_SETTINGS_COPY.stageDone,
+};
+
+export function toggleIntakeLabel(labels: string[], label: string): string[] {
+  return labels.includes(label) ? labels.filter((entry) => entry !== label) : [...labels, label];
+}
+
+export const GITHUB_INTAKE_RUNS: IntakeAutomationRun[] = [
+  {
+    id: "gh-issue-1",
+    title: "Handle duplicate refunds on retry",
+    confidencePct: 94,
+    ranMinutesAgo: 180,
+    analyzedMinutesAgo: 170,
+    placement: "progressed",
+    stage: "implement",
+    activity: "Writing the retry handler.",
+  },
+  {
+    id: "gh-issue-2",
+    title: "Return 409 when the invoice is already paid",
+    confidencePct: 88,
+    ranMinutesAgo: 120,
+    analyzedMinutesAgo: 110,
+    placement: "progressed",
+    stage: "plan",
+    activity: "Drafting the 409 response plan.",
+  },
+  {
+    id: "gh-issue-3",
+    title: "Show a clearer empty state on the billing page",
+    confidencePct: 81,
+    ranMinutesAgo: 90,
+    analyzedMinutesAgo: 80,
+    placement: "backlog",
+  },
+  {
+    id: "gh-issue-4",
+    title: "Upgrade the Node 20 base image",
+    confidencePct: 76,
+    ranMinutesAgo: 45,
+    analyzedMinutesAgo: 40,
+    placement: "rejected",
+  },
+  {
+    id: "gh-issue-5",
+    title: "Add a flake retry to the checkout e2e suite",
+    confidencePct: 68,
+    ranMinutesAgo: 20,
+    analyzedMinutesAgo: 15,
+    placement: "backlog",
+  },
+  {
+    id: "gh-issue-6",
+    title: "Document the refund webhook contract",
+    confidencePct: 52,
+    ranMinutesAgo: 8,
+    analyzedMinutesAgo: 5,
+    placement: "below-threshold",
+  },
+];
+
+export function intakeRelativeTime(minutesAgo: number): string {
+  return formatTimeAgo(new Date(Date.now() - minutesAgo * 60_000));
+}
+
+export function intakeStageLabel(stage: IntakeLineStage): string {
+  return STAGE_LABEL[stage];
+}
+
+export function intakePlacementLabel(run: IntakeAutomationRun): string {
+  if (run.placement === "progressed" && run.stage) {
+    return intakeStageLabel(run.stage);
+  }
+  if (run.placement === "rejected") {
+    return INTAKE_SETTINGS_COPY.rejected;
+  }
+  if (run.placement === "below-threshold") {
+    return INTAKE_SETTINGS_COPY.belowThreshold;
+  }
+  return INTAKE_SETTINGS_COPY.inBacklog;
+}
+
+export function intakePlacementActivity(run: IntakeAutomationRun): string {
+  if (run.placement === "progressed") {
+    return run.activity ?? "";
+  }
+  if (run.placement === "rejected") {
+    return INTAKE_SETTINGS_COPY.rejectedActivity;
+  }
+  if (run.placement === "below-threshold") {
+    return INTAKE_SETTINGS_COPY.belowThresholdActivity;
+  }
+  return INTAKE_SETTINGS_COPY.backlogActivity;
+}
+
+export function normalizeIntakeSourceSettings(draft: IntakeSourceSettings): IntakeSourceSettings {
+  const name = draft.name.trim() || DEFAULT_GITHUB_INTAKE_SETTINGS.name;
+  const confidencePct = Math.min(100, Math.max(0, Math.round(draft.confidencePct)));
+  return { ...draft, name, confidencePct };
+}

--- a/web_src/src/pages/factories/pages/lineBoardColumnColors.spec.ts
+++ b/web_src/src/pages/factories/pages/lineBoardColumnColors.spec.ts
@@ -7,14 +7,14 @@ import {
 } from "./lineBoardColumnColors";
 
 describe("lineBoardColumnColors", () => {
-  it("lists ten pastel lane colours for the picker", () => {
-    expect(LINE_BOARD_COLUMN_COLORS).toHaveLength(10);
-    expect(LINE_BOARD_COLUMN_COLORS.every((color) => color.swatchClassName.includes("bg-"))).toBe(true);
-    expect(LINE_BOARD_COLUMN_COLORS.every((color) => color.laneClassName.includes("bg-"))).toBe(true);
+  it("lists six colours and uses the same fill for the swatch and the lane", () => {
+    expect(LINE_BOARD_COLUMN_COLORS).toHaveLength(6);
+    expect(LINE_BOARD_COLUMN_COLORS.every((color) => color.className.includes("bg-"))).toBe(true);
   });
 
   it("resolves a lane class from a colour id", () => {
     expect(lineBoardColumnColorById("lime")?.label).toBe("Lime");
+    expect(lineBoardColumnLaneClassName("lime")).toBe(lineBoardColumnColorById("lime")?.className);
     expect(lineBoardColumnLaneClassName("lime")).toContain("lime");
     expect(lineBoardColumnLaneClassName(null)).toBeUndefined();
   });

--- a/web_src/src/pages/factories/pages/lineBoardColumnColors.spec.ts
+++ b/web_src/src/pages/factories/pages/lineBoardColumnColors.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LINE_BOARD_COLUMN_COLORS,
+  lineBoardColumnColorById,
+  lineBoardColumnLaneClassName,
+} from "./lineBoardColumnColors";
+
+describe("lineBoardColumnColors", () => {
+  it("lists ten pastel lane colours for the picker", () => {
+    expect(LINE_BOARD_COLUMN_COLORS).toHaveLength(10);
+    expect(LINE_BOARD_COLUMN_COLORS.every((color) => color.swatchClassName.includes("bg-"))).toBe(true);
+    expect(LINE_BOARD_COLUMN_COLORS.every((color) => color.laneClassName.includes("bg-"))).toBe(true);
+  });
+
+  it("resolves a lane class from a colour id", () => {
+    expect(lineBoardColumnColorById("lime")?.label).toBe("Lime");
+    expect(lineBoardColumnLaneClassName("lime")).toContain("lime");
+    expect(lineBoardColumnLaneClassName(null)).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/factories/pages/lineBoardColumnColors.spec.ts
+++ b/web_src/src/pages/factories/pages/lineBoardColumnColors.spec.ts
@@ -10,6 +10,7 @@ describe("lineBoardColumnColors", () => {
   it("lists six colours and uses the same fill for the swatch and the lane", () => {
     expect(LINE_BOARD_COLUMN_COLORS).toHaveLength(6);
     expect(LINE_BOARD_COLUMN_COLORS.every((color) => color.className.includes("bg-"))).toBe(true);
+    expect(LINE_BOARD_COLUMN_COLORS.map((color) => color.id)).not.toContain("red");
   });
 
   it("resolves a lane class from a colour id", () => {

--- a/web_src/src/pages/factories/pages/lineBoardColumnColors.ts
+++ b/web_src/src/pages/factories/pages/lineBoardColumnColors.ts
@@ -1,92 +1,25 @@
 /**
- * Soft lane colours for the line board. Swatches are small circles in the
- * column menu (Apple Notes / HoneyBook style). Lane fills stay pastel so
- * white cards stay readable.
+ * Lane colours for the line board. The picker circle and the lane use the
+ * same fill so the colour you tap is the colour you see on the board.
  */
 
-export type LineBoardColumnColorId =
-  | "green"
-  | "yellow"
-  | "orange"
-  | "red"
-  | "purple"
-  | "blue"
-  | "sky"
-  | "lime"
-  | "pink"
-  | "slate";
+export type LineBoardColumnColorId = "lime" | "yellow" | "red" | "sky" | "purple" | "slate";
 
 export interface LineBoardColumnColor {
   id: LineBoardColumnColorId;
   /** Accessible name for the swatch button. */
   label: string;
-  /** Saturated circle in the picker. */
-  swatchClassName: string;
-  /** Soft fill for the whole lane. */
-  laneClassName: string;
+  /** Shared fill for the picker circle and the lane. */
+  className: string;
 }
 
 export const LINE_BOARD_COLUMN_COLORS: LineBoardColumnColor[] = [
-  {
-    id: "green",
-    label: "Green",
-    swatchClassName: "bg-emerald-500",
-    laneClassName: "bg-emerald-100 dark:bg-emerald-950/50",
-  },
-  {
-    id: "yellow",
-    label: "Yellow",
-    swatchClassName: "bg-amber-400",
-    laneClassName: "bg-amber-100 dark:bg-amber-950/45",
-  },
-  {
-    id: "orange",
-    label: "Orange",
-    swatchClassName: "bg-orange-500",
-    laneClassName: "bg-orange-100 dark:bg-orange-950/45",
-  },
-  {
-    id: "red",
-    label: "Red",
-    swatchClassName: "bg-rose-500",
-    laneClassName: "bg-rose-100 dark:bg-rose-950/45",
-  },
-  {
-    id: "purple",
-    label: "Purple",
-    swatchClassName: "bg-violet-500",
-    laneClassName: "bg-violet-100 dark:bg-violet-950/45",
-  },
-  {
-    id: "blue",
-    label: "Blue",
-    swatchClassName: "bg-blue-500",
-    laneClassName: "bg-blue-100 dark:bg-blue-950/45",
-  },
-  {
-    id: "sky",
-    label: "Sky",
-    swatchClassName: "bg-sky-500",
-    laneClassName: "bg-sky-100 dark:bg-sky-950/45",
-  },
-  {
-    id: "lime",
-    label: "Lime",
-    swatchClassName: "bg-lime-500",
-    laneClassName: "bg-lime-100 dark:bg-lime-950/45",
-  },
-  {
-    id: "pink",
-    label: "Pink",
-    swatchClassName: "bg-fuchsia-500",
-    laneClassName: "bg-fuchsia-100 dark:bg-fuchsia-950/45",
-  },
-  {
-    id: "slate",
-    label: "Slate",
-    swatchClassName: "bg-slate-500",
-    laneClassName: "bg-slate-200 dark:bg-slate-800",
-  },
+  { id: "lime", label: "Lime", className: "bg-lime-300 dark:bg-lime-800" },
+  { id: "yellow", label: "Yellow", className: "bg-amber-300 dark:bg-amber-800" },
+  { id: "red", label: "Red", className: "bg-rose-300 dark:bg-rose-800" },
+  { id: "sky", label: "Sky", className: "bg-sky-300 dark:bg-sky-800" },
+  { id: "purple", label: "Purple", className: "bg-violet-300 dark:bg-violet-800" },
+  { id: "slate", label: "Slate", className: "bg-slate-300 dark:bg-slate-600" },
 ];
 
 export function lineBoardColumnColorById(id: string | null | undefined): LineBoardColumnColor | undefined {
@@ -97,5 +30,5 @@ export function lineBoardColumnColorById(id: string | null | undefined): LineBoa
 }
 
 export function lineBoardColumnLaneClassName(id: string | null | undefined): string | undefined {
-  return lineBoardColumnColorById(id)?.laneClassName;
+  return lineBoardColumnColorById(id)?.className;
 }

--- a/web_src/src/pages/factories/pages/lineBoardColumnColors.ts
+++ b/web_src/src/pages/factories/pages/lineBoardColumnColors.ts
@@ -3,7 +3,7 @@
  * same fill so the colour you tap is the colour you see on the board.
  */
 
-export type LineBoardColumnColorId = "lime" | "yellow" | "red" | "sky" | "purple" | "slate";
+export type LineBoardColumnColorId = "lime" | "yellow" | "teal" | "sky" | "purple" | "slate";
 
 export interface LineBoardColumnColor {
   id: LineBoardColumnColorId;
@@ -16,7 +16,7 @@ export interface LineBoardColumnColor {
 export const LINE_BOARD_COLUMN_COLORS: LineBoardColumnColor[] = [
   { id: "lime", label: "Lime", className: "bg-lime-300 dark:bg-lime-800" },
   { id: "yellow", label: "Yellow", className: "bg-amber-300 dark:bg-amber-800" },
-  { id: "red", label: "Red", className: "bg-rose-300 dark:bg-rose-800" },
+  { id: "teal", label: "Teal", className: "bg-teal-300 dark:bg-teal-800" },
   { id: "sky", label: "Sky", className: "bg-sky-300 dark:bg-sky-800" },
   { id: "purple", label: "Purple", className: "bg-violet-300 dark:bg-violet-800" },
   { id: "slate", label: "Slate", className: "bg-slate-300 dark:bg-slate-600" },

--- a/web_src/src/pages/factories/pages/lineBoardColumnColors.ts
+++ b/web_src/src/pages/factories/pages/lineBoardColumnColors.ts
@@ -1,0 +1,101 @@
+/**
+ * Soft lane colours for the line board. Swatches are small circles in the
+ * column menu (Apple Notes / HoneyBook style). Lane fills stay pastel so
+ * white cards stay readable.
+ */
+
+export type LineBoardColumnColorId =
+  | "green"
+  | "yellow"
+  | "orange"
+  | "red"
+  | "purple"
+  | "blue"
+  | "sky"
+  | "lime"
+  | "pink"
+  | "slate";
+
+export interface LineBoardColumnColor {
+  id: LineBoardColumnColorId;
+  /** Accessible name for the swatch button. */
+  label: string;
+  /** Saturated circle in the picker. */
+  swatchClassName: string;
+  /** Soft fill for the whole lane. */
+  laneClassName: string;
+}
+
+export const LINE_BOARD_COLUMN_COLORS: LineBoardColumnColor[] = [
+  {
+    id: "green",
+    label: "Green",
+    swatchClassName: "bg-emerald-500",
+    laneClassName: "bg-emerald-100 dark:bg-emerald-950/50",
+  },
+  {
+    id: "yellow",
+    label: "Yellow",
+    swatchClassName: "bg-amber-400",
+    laneClassName: "bg-amber-100 dark:bg-amber-950/45",
+  },
+  {
+    id: "orange",
+    label: "Orange",
+    swatchClassName: "bg-orange-500",
+    laneClassName: "bg-orange-100 dark:bg-orange-950/45",
+  },
+  {
+    id: "red",
+    label: "Red",
+    swatchClassName: "bg-rose-500",
+    laneClassName: "bg-rose-100 dark:bg-rose-950/45",
+  },
+  {
+    id: "purple",
+    label: "Purple",
+    swatchClassName: "bg-violet-500",
+    laneClassName: "bg-violet-100 dark:bg-violet-950/45",
+  },
+  {
+    id: "blue",
+    label: "Blue",
+    swatchClassName: "bg-blue-500",
+    laneClassName: "bg-blue-100 dark:bg-blue-950/45",
+  },
+  {
+    id: "sky",
+    label: "Sky",
+    swatchClassName: "bg-sky-500",
+    laneClassName: "bg-sky-100 dark:bg-sky-950/45",
+  },
+  {
+    id: "lime",
+    label: "Lime",
+    swatchClassName: "bg-lime-500",
+    laneClassName: "bg-lime-100 dark:bg-lime-950/45",
+  },
+  {
+    id: "pink",
+    label: "Pink",
+    swatchClassName: "bg-fuchsia-500",
+    laneClassName: "bg-fuchsia-100 dark:bg-fuchsia-950/45",
+  },
+  {
+    id: "slate",
+    label: "Slate",
+    swatchClassName: "bg-slate-500",
+    laneClassName: "bg-slate-200 dark:bg-slate-800",
+  },
+];
+
+export function lineBoardColumnColorById(id: string | null | undefined): LineBoardColumnColor | undefined {
+  if (!id) {
+    return undefined;
+  }
+  return LINE_BOARD_COLUMN_COLORS.find((color) => color.id === id);
+}
+
+export function lineBoardColumnLaneClassName(id: string | null | undefined): string | undefined {
+  return lineBoardColumnColorById(id)?.laneClassName;
+}

--- a/web_src/src/pages/factories/pages/lineIntakeModel.spec.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeModel.spec.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+import { ACME_ONBOARDING_FACTORY_KEY, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
 import {
   ADD_INTAKE_TEMPLATES,
   filterAddIntakeTemplates,
+  intakeAutomationAppId,
   intakeAutomationFixture,
+  intakeTicketAnalysisFixture,
   LINE_INTAKE_SOURCES,
   lineIntakeSourceById,
+  lineIntakeSourcesForFactory,
 } from "./lineIntakeModel";
 
 describe("lineIntakeModel", () => {
@@ -19,6 +23,52 @@ describe("lineIntakeModel", () => {
     const github = lineIntakeSourceById("github-issues");
     expect(github?.listen.kind).toBe("webhook");
     expect(github?.accept.destination).toBe("backlog");
+  });
+
+  it("keeps Sentry and PagerDuty on Semaphore and GitHub issues only on Acme", () => {
+    expect(lineIntakeSourcesForFactory(PRIMARY_FACTORY_KEY).map((source) => source.id)).toEqual([
+      "github-issues",
+      "sentry-exceptions",
+      "pagerduty-incidents",
+    ]);
+    expect(lineIntakeSourcesForFactory(ACME_ONBOARDING_FACTORY_KEY).map((source) => source.id)).toEqual([
+      "github-issues",
+    ]);
+  });
+
+  it("prefers the GitHub issues intake app for the editor", () => {
+    expect(intakeAutomationAppId([{ id: "app-acme-planner" }, { id: "app-github-issues-intake" }])).toBe(
+      "app-github-issues-intake",
+    );
+    expect(intakeAutomationAppId([{ id: "app-acme-planner" }])).toBe("app-acme-planner");
+    expect(intakeAutomationAppId([])).toBeUndefined();
+  });
+
+  it("builds a ticket analysis fixture with ingest, analyze, plan, and score", () => {
+    const fixture = intakeTicketAnalysisFixture({
+      id: "gh-issue-1",
+      title: "Handle duplicate refunds on retry",
+    });
+
+    expect(fixture.title).toBe("Handle duplicate refunds on retry");
+    expect(fixture.phases.map((phase) => phase.id)).toEqual(["ingest", "analyze", "plan", "score"]);
+    expect(fixture.currentPhaseId).toBe("analyze");
+    expect(
+      intakeTicketAnalysisFixture({ id: "gh-issue-1", title: "Handle duplicate refunds on retry" }, { complete: true })
+        .currentPhaseId,
+    ).toBe("score");
+    expect(fixture.phases[0]?.canvas?.nodes.map((node) => node.name)).toEqual([
+      "Ingest",
+      "Analyze ticket",
+      "Create plan",
+      "Score",
+    ]);
+    expect(fixture.phases[0]?.canvas?.nodes.map((node) => node.component)).toEqual([
+      "github.onIssue",
+      "runnerClaudeCode",
+      "addWorkOrderArtifact",
+      "reportWorkOrderCheck",
+    ]);
   });
 
   it("builds a split-run fixture with listen, evaluate, and backlog steps", () => {

--- a/web_src/src/pages/factories/pages/lineIntakeModel.spec.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeModel.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ADD_INTAKE_TEMPLATES,
+  filterAddIntakeTemplates,
+  intakeAutomationFixture,
+  LINE_INTAKE_SOURCES,
+  lineIntakeSourceById,
+} from "./lineIntakeModel";
+
+describe("lineIntakeModel", () => {
+  it("defines GitHub, Sentry, and PagerDuty as automations that feed Backlog", () => {
+    expect(LINE_INTAKE_SOURCES.map((source) => source.id)).toEqual([
+      "github-issues",
+      "sentry-exceptions",
+      "pagerduty-incidents",
+    ]);
+
+    const github = lineIntakeSourceById("github-issues");
+    expect(github?.listen.kind).toBe("webhook");
+    expect(github?.accept.destination).toBe("backlog");
+  });
+
+  it("builds a split-run fixture with listen, evaluate, and backlog steps", () => {
+    const github = lineIntakeSourceById("github-issues");
+    expect(github).toBeDefined();
+    const fixture = intakeAutomationFixture(github!);
+
+    expect(fixture.title).toBe("GitHub issues");
+    expect(fixture.phases.map((phase) => phase.id)).toEqual(["listen", "evaluate", "backlog"]);
+    expect(fixture.currentPhaseId).toBe("evaluate");
+    expect(fixture.waitingNotes[0]?.text).toContain("Backlog");
+
+    const canvas = fixture.phases[0]?.canvas;
+    expect(canvas?.nodes.map((node) => node.component)).toEqual([
+      "github.onIssue",
+      "runnerClaudeCode",
+      "createWorkOrder",
+    ]);
+  });
+
+  it("builds Sentry and PagerDuty canvases from catalogue triggers", () => {
+    const sentry = intakeAutomationFixture(lineIntakeSourceById("sentry-exceptions")!);
+    expect(sentry.phases[0]?.canvas?.nodes.map((node) => node.component)).toEqual([
+      "sentry.onIssue",
+      "runnerClaudeCode",
+      "createWorkOrder",
+    ]);
+
+    const pagerduty = intakeAutomationFixture(lineIntakeSourceById("pagerduty-incidents")!);
+    expect(pagerduty.phases[0]?.canvas?.nodes.map((node) => node.component)).toEqual([
+      "pagerduty.onIncident",
+      "runnerClaudeCode",
+      "createWorkOrder",
+    ]);
+  });
+
+  it("lists six add-intake templates including CI and page performance", () => {
+    expect(ADD_INTAKE_TEMPLATES).toHaveLength(6);
+    expect(ADD_INTAKE_TEMPLATES.map((template) => template.id)).toContain("improve-ci-runtime");
+    expect(ADD_INTAKE_TEMPLATES.map((template) => template.id)).toContain("improve-page-performance");
+  });
+
+  it("filters add-intake templates by name or description", () => {
+    expect(filterAddIntakeTemplates("runtime").map((template) => template.id)).toEqual(["improve-ci-runtime"]);
+    expect(filterAddIntakeTemplates("page performance").map((template) => template.id)).toEqual([
+      "improve-page-performance",
+    ]);
+    expect(filterAddIntakeTemplates("")).toHaveLength(6);
+  });
+});

--- a/web_src/src/pages/factories/pages/lineIntakeModel.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeModel.ts
@@ -1,0 +1,362 @@
+import type { ComponentsEdge, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import githubIcon from "@/assets/icons/integrations/github.svg";
+import pagerdutyIcon from "@/assets/icons/integrations/pagerduty.svg";
+import sentryIcon from "@/assets/icons/integrations/sentry.svg";
+import { getUserInitials } from "@/lib/orgUserDisplay";
+import type { FactoryNodeStatus } from "@/ui/factoryNodeChrome/types";
+
+import {
+  STORYBOOK_ME_USER_AVATAR_URL,
+  STORYBOOK_ME_USER_ID,
+  STORYBOOK_ME_USER_NAME,
+} from "../__fixtures__/factoryPageResponses";
+import type { WorkOrderStatusNotePresentation } from "../lib/workOrderStatusNote";
+import type { SplitRunCanvasModel } from "./work-order-split-run/splitRunCanvases";
+import type { SplitRunFixture, SplitRunPhase, SplitRunStreamLine } from "./work-order-split-run/splitRunMocks";
+
+export type LineIntakeSourceId = "github-issues" | "sentry-exceptions" | "pagerduty-incidents";
+
+export type LineIntakeListenKind = "webhook" | "poll";
+
+export interface LineIntakeSource {
+  id: LineIntakeSourceId;
+  name: string;
+  description: string;
+  iconSrc: string;
+  iconAlt: string;
+  /** How SuperPlane receives events from this source. */
+  listen: {
+    kind: LineIntakeListenKind;
+    label: string;
+  };
+  /** Runner that classifies whether the event becomes a work order. */
+  evaluate: {
+    label: string;
+    rule: string;
+  };
+  /** Accepted events land in the line backlog. */
+  accept: {
+    destination: "backlog";
+    label: string;
+  };
+}
+
+/**
+ * Intake is an automation that listens to an external source, decides which
+ * events to take in, and creates backlog work orders with that context.
+ */
+export const LINE_INTAKE_SOURCES: LineIntakeSource[] = [
+  {
+    id: "github-issues",
+    name: "GitHub issues",
+    description: "Open issues from connected repositories.",
+    iconSrc: githubIcon,
+    iconAlt: "GitHub",
+    listen: {
+      kind: "webhook",
+      label: "On GitHub issue",
+    },
+    evaluate: {
+      label: "Classify with a runner",
+      rule: "A runner classifies the issue and decides whether to create a work order.",
+    },
+    accept: {
+      destination: "backlog",
+      label: "Create a work order in Backlog",
+    },
+  },
+  {
+    id: "sentry-exceptions",
+    name: "Sentry exceptions",
+    description: "Unresolved errors from production.",
+    iconSrc: sentryIcon,
+    iconAlt: "Sentry",
+    listen: {
+      kind: "webhook",
+      label: "On Sentry exception",
+    },
+    evaluate: {
+      label: "Classify with a runner",
+      rule: "A runner classifies the exception and decides whether to create a work order.",
+    },
+    accept: {
+      destination: "backlog",
+      label: "Create a work order in Backlog",
+    },
+  },
+  {
+    id: "pagerduty-incidents",
+    name: "PagerDuty incidents",
+    description: "Firing incidents that need a work order.",
+    iconSrc: pagerdutyIcon,
+    iconAlt: "PagerDuty",
+    listen: {
+      kind: "webhook",
+      label: "On PagerDuty incident",
+    },
+    evaluate: {
+      label: "Classify with a runner",
+      rule: "A runner classifies the incident and decides whether to create a work order.",
+    },
+    accept: {
+      destination: "backlog",
+      label: "Create a work order in Backlog",
+    },
+  },
+];
+
+export function lineIntakeSourceById(id: string): LineIntakeSource | undefined {
+  return LINE_INTAKE_SOURCES.find((source) => source.id === id);
+}
+
+export interface AddIntakeTemplate {
+  id: string;
+  name: string;
+  description: string;
+  /** Optional integration icon. Letter glyph when omitted. */
+  iconSrc?: string;
+}
+
+/**
+ * Templates in the Add intake picker. Source-based intakes and a few
+ * common improvement automations.
+ */
+export const ADD_INTAKE_TEMPLATES: AddIntakeTemplate[] = [
+  {
+    id: "github-issues",
+    name: "GitHub issues",
+    description: "Open issues from connected repositories.",
+    iconSrc: githubIcon,
+  },
+  {
+    id: "sentry-exceptions",
+    name: "Sentry exceptions",
+    description: "Unresolved errors from production.",
+    iconSrc: sentryIcon,
+  },
+  {
+    id: "pagerduty-incidents",
+    name: "PagerDuty incidents",
+    description: "Firing incidents that need a work order.",
+    iconSrc: pagerdutyIcon,
+  },
+  {
+    id: "improve-ci-runtime",
+    name: "Improve CI runtime",
+    description: "Find slow jobs and cut pipeline wait time.",
+  },
+  {
+    id: "improve-page-performance",
+    name: "Improve page performance",
+    description: "Track slow pages and open work to speed them up.",
+  },
+  {
+    id: "flaky-tests",
+    name: "Flaky tests",
+    description: "Catch unstable tests and create fix work orders.",
+  },
+];
+
+export function filterAddIntakeTemplates(query: string): AddIntakeTemplate[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) {
+    return ADD_INTAKE_TEMPLATES;
+  }
+  return ADD_INTAKE_TEMPLATES.filter((template) => {
+    const haystack = `${template.name} ${template.description}`.toLowerCase();
+    return haystack.includes(needle);
+  });
+}
+
+const OWNER = {
+  id: STORYBOOK_ME_USER_ID,
+  name: STORYBOOK_ME_USER_NAME,
+  initials: getUserInitials(STORYBOOK_ME_USER_NAME),
+  avatarUrl: STORYBOOK_ME_USER_AVATAR_URL,
+};
+
+/**
+ * Builds the same popup shape as a line-board work order: log on the left,
+ * automation canvas on the right. Phases are listen → evaluate → backlog.
+ */
+export function intakeAutomationFixture(source: LineIntakeSource): SplitRunFixture {
+  const canvas = intakeCanvasForSource(source);
+  const waitingNotes: WorkOrderStatusNotePresentation[] = [
+    {
+      key: `${source.id}-backlog`,
+      headline: "Accepted events go to Backlog",
+      text: `${source.evaluate.rule} Accepted items become work orders in Backlog with the source context.`,
+    },
+  ];
+
+  return {
+    title: source.name,
+    owner: OWNER,
+    elapsed: "Running",
+    startedLabel: source.listen.label,
+    costUsd: "—",
+    tokensLabel: "Automation",
+    lineName: "Intake",
+    lineStatus: "running",
+    currentPhaseId: "evaluate",
+    waitingNotes,
+    checks: [],
+    footerTone: "waiting",
+    phases: [listenPhase(source, canvas), evaluatePhase(source, canvas), backlogPhase(source, canvas)],
+  };
+}
+
+function listenPhase(source: LineIntakeSource, canvas: SplitRunCanvasModel): SplitRunPhase {
+  return {
+    id: "listen",
+    name: "Listen",
+    status: "passed",
+    duration: "—",
+    componentName: source.listen.label,
+    artifacts: [],
+    canvas,
+    stream: [
+      {
+        id: `${source.id}-listen`,
+        at: "12:00:01",
+        componentName: source.listen.label,
+        status: "passed",
+        detail: source.listen.kind === "webhook" ? "Webhook received" : "Poll completed",
+      },
+    ],
+  };
+}
+
+function evaluatePhase(source: LineIntakeSource, canvas: SplitRunCanvasModel): SplitRunPhase {
+  return {
+    id: "evaluate",
+    name: "Evaluate",
+    status: "running",
+    duration: "—",
+    componentName: source.evaluate.label,
+    artifacts: [],
+    canvas,
+    stream: [
+      {
+        id: `${source.id}-evaluate`,
+        at: "12:00:04",
+        componentName: source.evaluate.label,
+        status: "running",
+        detail: source.evaluate.rule,
+      },
+    ],
+  };
+}
+
+function backlogPhase(source: LineIntakeSource, canvas: SplitRunCanvasModel): SplitRunPhase {
+  const stream: SplitRunStreamLine[] = [
+    {
+      id: `${source.id}-backlog`,
+      at: "12:00:08",
+      componentName: source.accept.label,
+      status: "pending",
+      detail: "Waiting for accept",
+    },
+  ];
+  return {
+    id: "backlog",
+    name: "Backlog",
+    status: "pending",
+    duration: "—",
+    componentName: source.accept.label,
+    artifacts: [],
+    canvas,
+    stream,
+  };
+}
+
+interface IntakeCanvasSpec {
+  triggerComponent: string;
+  triggerName: string;
+  classifyPrompt: string;
+  createTitle: string;
+  createDescription: string;
+  title: string;
+}
+
+const INTAKE_CANVAS_BY_SOURCE: Record<LineIntakeSourceId, IntakeCanvasSpec> = {
+  "github-issues": {
+    triggerComponent: "github.onIssue",
+    triggerName: "On Issue",
+    classifyPrompt: "Classify this GitHub issue. Accept it only when it should become a work order.",
+    createTitle: "{{ root().data.issue.title }}",
+    createDescription: "{{ root().data.issue.body }}",
+    title: "GitHub issue intake",
+  },
+  "sentry-exceptions": {
+    triggerComponent: "sentry.onIssue",
+    triggerName: "On Issue",
+    classifyPrompt: "Classify this Sentry exception. Accept it only when it should become a work order.",
+    createTitle: "{{ root().data.data.issue.title }}",
+    createDescription: "{{ root().data.data.issue.permalink }}",
+    title: "Sentry exception intake",
+  },
+  "pagerduty-incidents": {
+    triggerComponent: "pagerduty.onIncident",
+    triggerName: "On Incident",
+    classifyPrompt: "Classify this PagerDuty incident. Accept it only when it should become a work order.",
+    createTitle: "{{ root().data.incident.title }}",
+    createDescription: "{{ root().data.incident.html_url }}",
+    title: "PagerDuty incident intake",
+  },
+};
+
+function intakeCanvasForSource(source: LineIntakeSource): SplitRunCanvasModel {
+  const spec = INTAKE_CANVAS_BY_SOURCE[source.id];
+  const triggerId = `${source.id}-trigger`;
+  const runnerId = `${source.id}-classify`;
+  const createId = `${source.id}-create`;
+
+  const nodes: ComponentsNode[] = [
+    {
+      id: triggerId,
+      name: spec.triggerName,
+      type: "TYPE_TRIGGER",
+      component: spec.triggerComponent,
+      position: { x: 160, y: 80 },
+    },
+    {
+      id: runnerId,
+      name: "Classify intake",
+      type: "TYPE_ACTION",
+      component: "runnerClaudeCode",
+      configuration: {
+        prompt: spec.classifyPrompt,
+      },
+      position: { x: 160, y: 260 },
+    },
+    {
+      id: createId,
+      name: "Create Work Order",
+      type: "TYPE_ACTION",
+      component: "createWorkOrder",
+      configuration: {
+        title: spec.createTitle,
+        description: spec.createDescription,
+      },
+      position: { x: 160, y: 440 },
+    },
+  ];
+  const edges: ComponentsEdge[] = [
+    { channel: "default", sourceId: triggerId, targetId: runnerId },
+    { channel: "default", sourceId: runnerId, targetId: createId },
+  ];
+
+  return {
+    key: "intake",
+    title: spec.title,
+    nodes,
+    edges,
+    statuses: {
+      [triggerId]: "succeeded",
+      [runnerId]: "running",
+      [createId]: "pending",
+    } satisfies Record<string, FactoryNodeStatus>,
+    metrics: {},
+  };
+}

--- a/web_src/src/pages/factories/pages/lineIntakeModel.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeModel.ts
@@ -5,6 +5,7 @@ import sentryIcon from "@/assets/icons/integrations/sentry.svg";
 import { getUserInitials } from "@/lib/orgUserDisplay";
 import type { FactoryNodeStatus } from "@/ui/factoryNodeChrome/types";
 
+import { ACME_ONBOARDING_FACTORY_KEY, GITHUB_ISSUES_INTAKE_APP_ID } from "../__fixtures__/factoryPageIds";
 import {
   STORYBOOK_ME_USER_AVATAR_URL,
   STORYBOOK_ME_USER_ID,
@@ -109,6 +110,51 @@ export function lineIntakeSourceById(id: string): LineIntakeSource | undefined {
   return LINE_INTAKE_SOURCES.find((source) => source.id === id);
 }
 
+export function isFirstRunOnboardingFactory(factoryKey: string | undefined): boolean {
+  return factoryKey === ACME_ONBOARDING_FACTORY_KEY;
+}
+
+/** Acme onboarding starts with GitHub issues only. Semaphore keeps the full set. */
+export function lineIntakeSourcesForFactory(factoryKey: string | undefined): LineIntakeSource[] {
+  if (isFirstRunOnboardingFactory(factoryKey)) {
+    return LINE_INTAKE_SOURCES.filter((source) => source.id === "github-issues");
+  }
+  return LINE_INTAKE_SOURCES;
+}
+
+export function isLineIntakeSourceId(id: string | null | undefined): id is LineIntakeSourceId {
+  return Boolean(id && lineIntakeSourceById(id));
+}
+
+export function intakeAutomationAppId(apps: Array<{ id?: string }>): string | undefined {
+  return apps.find((app) => app.id === GITHUB_ISSUES_INTAKE_APP_ID)?.id ?? apps.find((app) => app.id)?.id;
+}
+
+export interface LineIntakeAnalyzingTicket {
+  id: string;
+  title: string;
+}
+
+export const LINE_INTAKE_COPY = {
+  analyzingTitle: "Analyzing",
+  analyzingHelper: "Tickets from this intake.",
+  analyzingStatus: "Analyzing",
+  analyzingEmpty: "No tickets in analysis.",
+  analysisHeadline: "SuperPlane is analyzing this ticket",
+  analysisHelper: "SuperPlane reads the ticket and the repository. It does not start work yet.",
+  analysisCompleteHeadline: "Ticket analysis finished",
+  analysisCompleteHelper: "SuperPlane did not change the ticket. Review the plan before work starts.",
+} as const;
+
+/** GitHub issues pulled in for first-run analysis. Scores land on the board later. */
+export const GITHUB_ISSUES_ANALYZING_TICKETS: LineIntakeAnalyzingTicket[] = [
+  { id: "gh-issue-1", title: "Handle duplicate refunds on retry" },
+  { id: "gh-issue-2", title: "Return 409 when the invoice is already paid" },
+  { id: "gh-issue-3", title: "Show a clearer empty state on the billing page" },
+  { id: "gh-issue-4", title: "Upgrade the Node 20 base image" },
+  { id: "gh-issue-5", title: "Add a flake retry to the checkout e2e suite" },
+];
+
 export interface AddIntakeTemplate {
   id: string;
   name: string;
@@ -176,11 +222,181 @@ const OWNER = {
 };
 
 /**
+ * Ticket click from GitHub issues: same split-run popup, with a canvas
+ * for ingest, analyze, create plan, and score.
+ */
+export function intakeTicketAnalysisFixture(
+  ticket: LineIntakeAnalyzingTicket,
+  options?: { complete?: boolean },
+): SplitRunFixture {
+  const canvas = ticketAnalysisCanvas();
+  const complete = Boolean(options?.complete);
+  return {
+    title: ticket.title,
+    owner: OWNER,
+    elapsed: complete ? "4m 12s" : "Running",
+    startedLabel: "Analyze ticket",
+    costUsd: complete ? "0.18" : "—",
+    tokensLabel: "Analysis",
+    lineName: "Intake",
+    lineStatus: complete ? "passed" : "running",
+    currentPhaseId: complete ? "score" : "analyze",
+    waitingNotes: [
+      {
+        key: `${ticket.id}-${complete ? "complete" : "analyzing"}`,
+        headline: complete ? LINE_INTAKE_COPY.analysisCompleteHeadline : LINE_INTAKE_COPY.analysisHeadline,
+        text: complete ? LINE_INTAKE_COPY.analysisCompleteHelper : LINE_INTAKE_COPY.analysisHelper,
+      },
+    ],
+    checks: [],
+    footerTone: complete ? undefined : "waiting",
+    phases: [
+      ticketAnalysisPhase({
+        id: "ingest",
+        name: "Ingest",
+        status: "passed",
+        componentName: "Ingest",
+        detail: "Ticket received from GitHub issues.",
+        canvas,
+      }),
+      ticketAnalysisPhase({
+        id: "analyze",
+        name: "Analyze",
+        status: complete ? "passed" : "running",
+        componentName: "Analyze ticket",
+        detail: complete ? "Read the ticket and the repository." : "Reading the ticket and the repository.",
+        canvas,
+      }),
+      ticketAnalysisPhase({
+        id: "plan",
+        name: "Create plan",
+        status: complete ? "passed" : "pending",
+        componentName: "Create plan",
+        detail: complete ? "Wrote the implementation plan." : "Waiting for analysis to finish.",
+        canvas,
+      }),
+      ticketAnalysisPhase({
+        id: "score",
+        name: "Score",
+        status: complete ? "passed" : "pending",
+        componentName: "Score",
+        detail: complete ? "Scored the ticket against the codebase." : "Waiting for a plan.",
+        canvas,
+      }),
+    ],
+  };
+}
+
+function ticketAnalysisPhase({
+  id,
+  name,
+  status,
+  componentName,
+  detail,
+  canvas,
+}: {
+  id: SplitRunPhase["id"];
+  name: string;
+  status: SplitRunPhase["status"];
+  componentName: string;
+  detail: string;
+  canvas: SplitRunCanvasModel;
+}): SplitRunPhase {
+  return {
+    id,
+    name,
+    status,
+    duration: "—",
+    componentName,
+    artifacts: [],
+    canvas,
+    stream: [
+      {
+        id: `ticket-${id}`,
+        at: "12:00:04",
+        componentName,
+        status,
+        detail,
+      },
+    ],
+  };
+}
+
+function ticketAnalysisCanvas(): SplitRunCanvasModel {
+  const ingestId = "ticket-ingest";
+  const analyzeId = "ticket-analyze";
+  const planId = "ticket-plan";
+  const scoreId = "ticket-score";
+
+  const nodes: ComponentsNode[] = [
+    {
+      id: ingestId,
+      name: "Ingest",
+      type: "TYPE_TRIGGER",
+      component: "github.onIssue",
+      position: { x: 160, y: 40 },
+    },
+    {
+      id: analyzeId,
+      name: "Analyze ticket",
+      type: "TYPE_ACTION",
+      component: "runnerClaudeCode",
+      configuration: {
+        prompt: "Read this ticket and the repository. Find the files and risks that matter.",
+      },
+      position: { x: 160, y: 200 },
+    },
+    {
+      id: planId,
+      name: "Create plan",
+      type: "TYPE_ACTION",
+      component: "addWorkOrderArtifact",
+      configuration: {
+        name: "plan.md",
+      },
+      position: { x: 160, y: 360 },
+    },
+    {
+      id: scoreId,
+      name: "Score",
+      type: "TYPE_ACTION",
+      component: "reportWorkOrderCheck",
+      configuration: {
+        name: "confidence",
+      },
+      position: { x: 160, y: 520 },
+    },
+  ];
+
+  return {
+    key: "intake",
+    title: "Ticket analysis",
+    nodes,
+    edges: [
+      { channel: "default", sourceId: ingestId, targetId: analyzeId },
+      { channel: "default", sourceId: analyzeId, targetId: planId },
+      { channel: "default", sourceId: planId, targetId: scoreId },
+    ],
+    statuses: {
+      [ingestId]: "triggered",
+      [analyzeId]: "running",
+      [planId]: "pending",
+      [scoreId]: "pending",
+    } satisfies Record<string, FactoryNodeStatus>,
+    metrics: {},
+  };
+}
+
+/**
  * Builds the same popup shape as a line-board work order: log on the left,
  * automation canvas on the right. Phases are listen → evaluate → backlog.
  */
+export function intakeAutomationCanvas(source: LineIntakeSource): SplitRunCanvasModel {
+  return intakeCanvasForSource(source);
+}
+
 export function intakeAutomationFixture(source: LineIntakeSource): SplitRunFixture {
-  const canvas = intakeCanvasForSource(source);
+  const canvas = intakeAutomationCanvas(source);
   const waitingNotes: WorkOrderStatusNotePresentation[] = [
     {
       key: `${source.id}-backlog`,

--- a/web_src/src/pages/factories/pages/onboarding/NewWorkspacePage.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/NewWorkspacePage.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from "react-router";
 
 import { factoryListPath, factorySetupPath } from "../../lib/factoryPagePaths";
 import { useFactoriesThemeClass } from "../../lib/useFactoriesThemeClass";
+import { useOnboardingStorybook } from "./useOnboardingStorybook";
 import { placeholderWorkspaceName } from "./workspaceNames";
 
 /**
@@ -31,6 +32,7 @@ function NewWorkspacePageContent({ organizationId }: { organizationId: string })
   const navigate = useNavigate();
   const factories = useFactories(organizationId);
   const createFactory = useCreateFactory(organizationId);
+  const storybookOnboarding = useOnboardingStorybook();
   const [error, setError] = useState<string | null>(null);
   const [attempt, setAttempt] = useState(0);
   // Workspace creation must run once per attempt, not on every render.
@@ -48,9 +50,15 @@ function NewWorkspacePageContent({ organizationId }: { organizationId: string })
           description: "",
           key: "",
         });
-        if (!factory.key) {
+        if (!factory.id || !factory.key) {
           throw new Error("The workspace was created without a key");
         }
+        // Storybook gates setup on this pending pointer. Production uses the
+        // server-backed onboarding record and ignores the storybook context.
+        storybookOnboarding?.beginOnboarding({
+          workspaceId: factory.id,
+          workspaceName: factory.name ?? "",
+        });
         navigate(factorySetupPath(organizationId, factory.key), { replace: true });
       } catch (creationError) {
         setError(getApiErrorMessage(creationError, "Failed to create workspace"));
@@ -58,7 +66,7 @@ function NewWorkspacePageContent({ organizationId }: { organizationId: string })
     };
 
     void create();
-  }, [attempt, createFactory, factories.data, factories.isLoading, navigate, organizationId]);
+  }, [attempt, createFactory, factories.data, factories.isLoading, navigate, organizationId, storybookOnboarding]);
 
   const retry = () => {
     setError(null);

--- a/web_src/src/pages/factories/pages/onboarding/first-run/BacklogOnboardingCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/BacklogOnboardingCard.spec.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BacklogOnboardingCard } from "./BacklogOnboardingCard";
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+
+describe("BacklogOnboardingCard", () => {
+  it("explains that analyzed intake tickets appear in the backlog for review", () => {
+    render(<BacklogOnboardingCard />);
+
+    const card = screen.getByTestId("backlog-onboarding-card");
+    expect(card).toHaveTextContent(FIRST_RUN_COPY.board.backlogHintTitle);
+    expect(card).toHaveTextContent(FIRST_RUN_COPY.board.backlogHintBody);
+    expect(card).not.toHaveTextContent(/candidates from intake/i);
+    expect(card).not.toHaveTextContent(/work order/i);
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/first-run/BacklogOnboardingCard.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/BacklogOnboardingCard.tsx
@@ -1,0 +1,18 @@
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+
+/** First-run backlog zero state. Centered copy, not a ticket card. */
+export function BacklogOnboardingCard() {
+  const copy = FIRST_RUN_COPY.board;
+
+  return (
+    <article
+      className="flex min-h-40 flex-1 flex-col items-center justify-center px-3 py-10 text-center"
+      data-testid="backlog-onboarding-card"
+    >
+      <h3 className="max-w-[14rem] text-[15px] font-semibold leading-snug tracking-[-0.03em] text-balance text-foreground">
+        {copy.backlogHintTitle}
+      </h3>
+      <p className="workspace-body-text mt-2 max-w-[15rem] text-pretty text-muted-foreground">{copy.backlogHintBody}</p>
+    </article>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunAnalysisScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunAnalysisScreen.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FirstRunAnalysisScreen } from "./FirstRunAnalysisScreen";
+
+describe("FirstRunAnalysisScreen", () => {
+  it("shows the overrun notice while stages keep running", () => {
+    render(<FirstRunAnalysisScreen status="overrun" currentStageIndex={2} onRetry={vi.fn()} />);
+
+    expect(screen.getByText(FIRST_RUN_COPY.analysis.overrun)).toBeInTheDocument();
+    expect(screen.getByText(FIRST_RUN_COPY.analysis.leaveHint)).toBeInTheDocument();
+  });
+
+  it("offers a retry when analysis fails", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(<FirstRunAnalysisScreen status="failed" currentStageIndex={0} onRetry={onRetry} />);
+
+    expect(screen.getByText(FIRST_RUN_COPY.analysis.failure)).toBeInTheDocument();
+    await user.click(screen.getByTestId("first-run-run-again"));
+    expect(onRetry).toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunAnalysisScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunAnalysisScreen.tsx
@@ -1,0 +1,68 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Check, Loader2 } from "lucide-react";
+
+import { FIRST_RUN_COPY, FIRST_RUN_STAGES } from "./firstRunCopy";
+import { FirstRunHeading, FirstRunPanel, FirstRunShell } from "./FirstRunShell";
+import type { FirstRunAnalysisStatus, FirstRunChrome } from "./firstRunTypes";
+
+export function FirstRunAnalysisScreen({
+  status,
+  currentStageIndex,
+  chrome,
+  onRetry,
+}: {
+  status: FirstRunAnalysisStatus;
+  /** 0–2 while running. Stages at or below this index are active or done. */
+  currentStageIndex: number;
+  chrome?: FirstRunChrome;
+  onRetry: () => void;
+}) {
+  const copy = FIRST_RUN_COPY.analysis;
+
+  return (
+    <FirstRunShell testId="first-run-analysis" chrome={chrome}>
+      <FirstRunHeading headline={copy.headline}>
+        <p className="text-[13px] text-muted-foreground">{copy.body}</p>
+        <p className="text-[13px] text-muted-foreground">{copy.reassurance}</p>
+      </FirstRunHeading>
+
+      {status === "failed" ? (
+        <div className="mt-8 space-y-4">
+          <p className="text-[13px] text-destructive">{copy.failure}</p>
+          <Button type="button" onClick={onRetry} data-testid="first-run-run-again">
+            {copy.retry}
+          </Button>
+        </div>
+      ) : (
+        <FirstRunPanel>
+          <ol className="space-y-3">
+            {FIRST_RUN_STAGES.map((stage, index) => {
+              const done = index < currentStageIndex;
+              const current = index === currentStageIndex && status !== "failed";
+              return (
+                <li key={stage} className="flex items-center gap-3 text-[13px]">
+                  {done ? (
+                    <Check className="size-3.5 shrink-0 text-emerald-600" strokeWidth={2.5} aria-hidden />
+                  ) : (
+                    <Loader2
+                      className={cn(
+                        "size-3.5 shrink-0",
+                        current ? "animate-spin text-foreground" : "text-muted-foreground",
+                      )}
+                      aria-hidden
+                    />
+                  )}
+                  <span className={current || done ? "text-foreground" : "text-muted-foreground"}>{stage}</span>
+                </li>
+              );
+            })}
+          </ol>
+        </FirstRunPanel>
+      )}
+
+      {status === "overrun" ? <p className="mt-6 text-[13px] text-muted-foreground">{copy.overrun}</p> : null}
+      {status !== "failed" ? <p className="mt-6 text-[12px] text-muted-foreground">{copy.leaveHint}</p> : null}
+    </FirstRunShell>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunBoardExit.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunBoardExit.tsx
@@ -1,0 +1,27 @@
+import { FactoriesHarness } from "../../../__fixtures__/FactoriesHarness";
+import { refundLineCanvasFixture } from "../../../__fixtures__/factoryOwnedCanvasFixture";
+import {
+  ACME_ONBOARDING_FACTORY_ID,
+  ACME_ONBOARDING_FACTORY_KEY,
+  ACME_ONBOARDING_LINE_ID,
+  GITHUB_ISSUES_INTAKE_APP,
+} from "../../../__fixtures__/factoryPageResponses";
+import { lineMetricsFactoriesFixture } from "../../../__fixtures__/lineMetricsFactoriesFixture";
+
+/**
+ * Storybook stand-in for the real app after first-run analysis.
+ * Opens Acme onboarding Intake with GitHub issues selected.
+ * Production will open the workspace line board instead of this fixture.
+ */
+export function FirstRunBoardExit() {
+  return (
+    <div data-testid="first-run-board">
+      <FactoriesHarness
+        pathSuffix={`workspaces/${ACME_ONBOARDING_FACTORY_KEY}/lines/${ACME_ONBOARDING_LINE_ID}?intake=1&source=github-issues`}
+        factoriesFixture={lineMetricsFactoriesFixture}
+        appFixture={refundLineCanvasFixture(GITHUB_ISSUES_INTAKE_APP, ACME_ONBOARDING_FACTORY_ID)}
+        enableOnboarding={false}
+      />
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunChooseScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunChooseScreen.tsx
@@ -1,0 +1,66 @@
+import { Button } from "@/components/ui/button";
+
+import { RepositoryPicker } from "../onboardingSteps";
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FirstRunHeading, FirstRunPanel, FirstRunShell } from "./FirstRunShell";
+import type { FirstRunChrome } from "./firstRunTypes";
+
+export function FirstRunChooseScreen({
+  repositories,
+  selectedRepository,
+  chrome,
+  onSelectRepository,
+  onEditConnection,
+  onContinue,
+}: {
+  repositories: string[];
+  selectedRepository: string | null;
+  chrome?: FirstRunChrome;
+  onSelectRepository: (repository: string) => void;
+  onEditConnection: () => void;
+  onContinue: () => void;
+}) {
+  const copy = FIRST_RUN_COPY.choose;
+
+  return (
+    <FirstRunShell testId="first-run-choose" chrome={chrome}>
+      <FirstRunHeading headline={copy.headline}>
+        <p className="text-[13px] text-muted-foreground">{copy.repositoryHelper}</p>
+      </FirstRunHeading>
+
+      <div className="mt-8 space-y-4">
+        <FirstRunPanel>
+          <RepositoryPicker
+            host="github"
+            repos={repositories}
+            selectedRepo={selectedRepository}
+            onSelect={onSelectRepository}
+          />
+          <p className="mt-3 text-[13px] text-muted-foreground">
+            {copy.missingRepository}{" "}
+            <button
+              type="button"
+              onClick={onEditConnection}
+              className="font-medium text-foreground underline underline-offset-2 hover:no-underline"
+            >
+              {copy.editConnection}
+            </button>
+          </p>
+        </FirstRunPanel>
+
+        <div className="space-y-2">
+          <Button
+            type="button"
+            className="w-full"
+            disabled={!selectedRepository}
+            onClick={onContinue}
+            data-testid="first-run-continue-to-tickets"
+          >
+            {copy.continue}
+          </Button>
+          <p className="text-[12px] text-muted-foreground">{copy.moreLater}</p>
+        </div>
+      </div>
+    </FirstRunShell>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.spec.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FirstRunConnectScreen } from "./FirstRunConnectScreen";
+
+describe("FirstRunConnectScreen", () => {
+  it("asks only for GitHub and keeps tickets off this screen", async () => {
+    const user = userEvent.setup();
+    const onConnectGitHub = vi.fn();
+
+    render(<FirstRunConnectScreen githubConnected={false} onConnectGitHub={onConnectGitHub} onContinue={vi.fn()} />);
+
+    expect(screen.getByTestId("first-run-connect-github")).toHaveTextContent(FIRST_RUN_COPY.connect.connectGitHub);
+    expect(screen.getByText(FIRST_RUN_COPY.connect.trust)).toBeInTheDocument();
+    expect(screen.queryByText(FIRST_RUN_COPY.tickets.trust)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /GitHub Issues/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("first-run-connect-github"));
+    expect(onConnectGitHub).toHaveBeenCalled();
+  });
+
+  it("continues to the repository step after GitHub is connected", async () => {
+    const user = userEvent.setup();
+    const onContinue = vi.fn();
+
+    render(<FirstRunConnectScreen githubConnected onConnectGitHub={vi.fn()} onContinue={onContinue} />);
+
+    expect(screen.getByTestId("first-run-github-connected")).toHaveTextContent(FIRST_RUN_COPY.connect.connected);
+    await user.click(screen.getByTestId("first-run-github-continue"));
+    expect(onContinue).toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunConnectScreen.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@/components/ui/button";
+import { Check } from "lucide-react";
+
+import { IntegrationChoiceIcon } from "../onboardingSteps";
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FirstRunHeading, FirstRunShell } from "./FirstRunShell";
+import type { FirstRunChrome } from "./firstRunTypes";
+
+export function FirstRunConnectScreen({
+  githubConnected,
+  connectError,
+  chrome,
+  onConnectGitHub,
+  onContinue,
+}: {
+  githubConnected: boolean;
+  connectError?: string;
+  chrome?: FirstRunChrome;
+  onConnectGitHub: () => void;
+  onContinue: () => void;
+}) {
+  const copy = FIRST_RUN_COPY.connect;
+
+  return (
+    <FirstRunShell testId="first-run-connect" chrome={chrome}>
+      <FirstRunHeading headline={copy.headline}>
+        <p className="text-[15px] leading-6 text-muted-foreground">{copy.body}</p>
+      </FirstRunHeading>
+
+      <div className="mt-8 space-y-3">
+        {githubConnected ? (
+          <>
+            <div
+              className="flex items-center gap-3 rounded-md bg-accent/40 px-3 py-2.5 text-left"
+              data-testid="first-run-github-connected"
+            >
+              <IntegrationChoiceIcon name="github" />
+              <span className="text-[13px] font-medium">{copy.connected}</span>
+              <Check className="ml-auto size-3.5" strokeWidth={2.5} aria-hidden />
+            </div>
+            <Button type="button" className="min-w-40" onClick={onContinue} data-testid="first-run-github-continue">
+              {copy.continue}
+            </Button>
+          </>
+        ) : (
+          <Button type="button" className="min-w-40" onClick={onConnectGitHub} data-testid="first-run-connect-github">
+            {copy.connectGitHub}
+          </Button>
+        )}
+        <p className="text-[13px] text-muted-foreground">{copy.trust}</p>
+        {connectError ? <p className="text-[13px] text-destructive">{connectError}</p> : null}
+      </div>
+    </FirstRunShell>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunFlow.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunFlow.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FirstRunFlow } from "./FirstRunFlow";
+
+describe("FirstRunFlow", () => {
+  it("walks welcome, GitHub, repository, tickets, then analysis", async () => {
+    const user = userEvent.setup();
+    render(<FirstRunFlow />);
+
+    await user.click(screen.getByTestId("first-run-get-started"));
+    expect(screen.getByTestId("first-run-connect")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("first-run-connect-github"));
+    expect(screen.getByTestId("first-run-choose")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("option", { name: /acme\/payments-service/ }));
+    await user.click(screen.getByTestId("first-run-continue-to-tickets"));
+
+    expect(screen.getByTestId("first-run-tickets")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: FIRST_RUN_COPY.tickets.headline })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /GitHub Issues/ }));
+    expect(screen.getByTestId("first-run-tickets")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-analysis")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("first-run-analyze-tickets"));
+
+    expect(screen.getByTestId("first-run-analysis")).toBeInTheDocument();
+    expect(screen.getByText(FIRST_RUN_COPY.analysis.reassurance)).toBeInTheDocument();
+  });
+
+  it("opens the board when analysis finishes", async () => {
+    render(
+      <FirstRunFlow initialScreen="analysis" completeAfterMs={20} board={<div data-testid="first-run-board" />} />,
+    );
+
+    expect(await screen.findByTestId("first-run-board")).toBeInTheDocument();
+    expect(screen.queryByText(FIRST_RUN_COPY.results.headline)).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunFlow.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunFlow.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+import { FirstRunAnalysisScreen } from "./FirstRunAnalysisScreen";
+import { FirstRunBoardExit } from "./FirstRunBoardExit";
+import { FirstRunChooseScreen } from "./FirstRunChooseScreen";
+import { FirstRunConnectScreen } from "./FirstRunConnectScreen";
+import { FIRST_RUN_REPOSITORIES, FIRST_RUN_STORY_EMAIL } from "./firstRunMocks";
+import { FirstRunTicketsScreen } from "./FirstRunTicketsScreen";
+import type { FirstRunAnalysisStatus, FirstRunChrome, FirstRunScreenId, FirstRunTicketSource } from "./firstRunTypes";
+import { FirstRunWelcomeScreen } from "./FirstRunWelcomeScreen";
+
+const STAGE_MS = 900;
+const COMPLETE_AFTER_MS = STAGE_MS * 3;
+
+/**
+ * Clickable Storybook journey for the first-run PRD. Local state only.
+ * Production wiring stays out of this file.
+ */
+export function FirstRunFlow({
+  firstName,
+  email = FIRST_RUN_STORY_EMAIL,
+  initialScreen = "welcome",
+  githubStartsConnected = false,
+  analysisStatus = "running",
+  completeAfterMs = COMPLETE_AFTER_MS,
+  board,
+  onLogOut,
+}: {
+  firstName?: string;
+  email?: string;
+  initialScreen?: FirstRunScreenId;
+  githubStartsConnected?: boolean;
+  analysisStatus?: FirstRunAnalysisStatus;
+  completeAfterMs?: number;
+  board?: ReactNode;
+  onLogOut?: () => void;
+}) {
+  const [screen, setScreen] = useState<FirstRunScreenId>(initialScreen);
+  const [githubConnected, setGithubConnected] = useState(githubStartsConnected);
+  const [ticketSource, setTicketSource] = useState<FirstRunTicketSource | null>(null);
+  const [selectedRepository, setSelectedRepository] = useState<string | null>(null);
+  const [stageIndex, setStageIndex] = useState(0);
+
+  const chromeFor = (stepIndex: number): FirstRunChrome => ({
+    displayName: firstName,
+    email,
+    onLogOut,
+    stepIndex,
+  });
+
+  useEffect(() => {
+    if (screen !== "analysis" || analysisStatus === "failed") return;
+
+    const stageTimer = window.setInterval(() => {
+      setStageIndex((current) => Math.min(current + 1, 2));
+    }, STAGE_MS);
+    const doneTimer =
+      analysisStatus === "running" ? window.setTimeout(() => setScreen("board"), completeAfterMs) : undefined;
+
+    return () => {
+      window.clearInterval(stageTimer);
+      if (doneTimer) window.clearTimeout(doneTimer);
+    };
+  }, [analysisStatus, completeAfterMs, screen]);
+
+  if (screen === "welcome") {
+    return (
+      <FirstRunWelcomeScreen firstName={firstName} chrome={chromeFor(0)} onGetStarted={() => setScreen("connect")} />
+    );
+  }
+
+  if (screen === "connect") {
+    return (
+      <FirstRunConnectScreen
+        githubConnected={githubConnected}
+        chrome={chromeFor(1)}
+        onConnectGitHub={() => {
+          setGithubConnected(true);
+          setScreen("choose");
+        }}
+        onContinue={() => setScreen("choose")}
+      />
+    );
+  }
+
+  if (screen === "choose") {
+    return (
+      <FirstRunChooseScreen
+        repositories={FIRST_RUN_REPOSITORIES}
+        selectedRepository={selectedRepository}
+        chrome={chromeFor(2)}
+        onSelectRepository={setSelectedRepository}
+        onEditConnection={() => setScreen("connect")}
+        onContinue={() => {
+          if (selectedRepository) setScreen("tickets");
+        }}
+      />
+    );
+  }
+
+  if (screen === "tickets") {
+    return (
+      <FirstRunTicketsScreen
+        ticketSource={ticketSource}
+        chrome={chromeFor(3)}
+        onSelectTicketSource={setTicketSource}
+        onAnalyzeTickets={() => {
+          if (!ticketSource) return;
+          setStageIndex(0);
+          setScreen("analysis");
+        }}
+      />
+    );
+  }
+
+  if (screen === "analysis") {
+    return (
+      <FirstRunAnalysisScreen
+        status={analysisStatus}
+        currentStageIndex={stageIndex}
+        chrome={chromeFor(4)}
+        onRetry={() => {
+          setStageIndex(0);
+          setScreen("analysis");
+        }}
+      />
+    );
+  }
+
+  return board ?? <FirstRunBoardExit />;
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
@@ -1,0 +1,101 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+import { useFactoriesThemeClass } from "../../../lib/useFactoriesThemeClass";
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import type { FirstRunChrome } from "./firstRunTypes";
+
+export const FIRST_RUN_STEP_COUNT = 5;
+
+export function FirstRunShell({
+  children,
+  testId,
+  chrome,
+  width = "narrow",
+}: {
+  children: ReactNode;
+  testId: string;
+  chrome?: FirstRunChrome;
+  width?: "narrow" | "wide";
+}) {
+  useFactoriesThemeClass();
+  const copy = FIRST_RUN_COPY.chrome;
+  const identity = chrome?.email ?? chrome?.displayName;
+
+  return (
+    <div className="fixed inset-0 bg-background text-foreground" data-testid={testId}>
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between px-6 py-5">
+        <button
+          type="button"
+          className="pointer-events-auto text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+          onClick={chrome?.onLogOut}
+          data-testid="first-run-log-out"
+        >
+          {copy.logOut}
+        </button>
+        {identity ? (
+          <p className="text-right text-[13px] leading-5 text-muted-foreground" data-testid="first-run-signed-in">
+            <span className="block">{copy.loggedInAs}</span>
+            <span className="block text-foreground">{identity}</span>
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex h-full items-center justify-center overflow-y-auto px-6 py-24">
+        <div className={cn("w-full text-center", width === "wide" ? "max-w-xl" : "max-w-md")}>{children}</div>
+      </div>
+
+      {chrome ? (
+        <nav
+          className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center pb-6"
+          aria-label={copy.stepLabel(chrome.stepIndex + 1, FIRST_RUN_STEP_COUNT)}
+        >
+          <ol className="flex items-center gap-1.5">
+            {Array.from({ length: FIRST_RUN_STEP_COUNT }, (_, index) => (
+              <li
+                key={index}
+                className={cn(
+                  "size-1.5 rounded-full",
+                  index === chrome.stepIndex ? "bg-foreground" : "bg-muted-foreground/30",
+                )}
+                aria-current={index === chrome.stepIndex ? "step" : undefined}
+              />
+            ))}
+          </ol>
+        </nav>
+      ) : null}
+    </div>
+  );
+}
+
+export function FirstRunHeading({
+  greeting,
+  headline,
+  size = "page",
+  children,
+}: {
+  greeting?: string;
+  headline: string;
+  size?: "page" | "display";
+  children?: ReactNode;
+}) {
+  return (
+    <header className="mx-auto max-w-lg space-y-3">
+      {greeting ? <p className="text-[15px] font-medium tracking-[-0.01em]">{greeting}</p> : null}
+      <h1
+        className={cn(
+          size === "display"
+            ? "text-[26px] font-semibold leading-8 tracking-[-0.03em]"
+            : "workspace-page-title font-semibold",
+        )}
+      >
+        {headline}
+      </h1>
+      {children}
+    </header>
+  );
+}
+
+export function FirstRunPanel({ children }: { children: ReactNode }) {
+  return <div className="rounded-lg border border-border bg-card p-4 text-left">{children}</div>;
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.spec.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FirstRunTicketsScreen } from "./FirstRunTicketsScreen";
+
+describe("FirstRunTicketsScreen", () => {
+  it("keeps analysis stopped until a ticket system is selected", async () => {
+    const user = userEvent.setup();
+    const onSelectTicketSource = vi.fn();
+    const onAnalyzeTickets = vi.fn();
+
+    render(
+      <FirstRunTicketsScreen
+        ticketSource={null}
+        onSelectTicketSource={onSelectTicketSource}
+        onAnalyzeTickets={onAnalyzeTickets}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: FIRST_RUN_COPY.tickets.headline })).toBeInTheDocument();
+    expect(screen.getByText(FIRST_RUN_COPY.tickets.trust)).toBeInTheDocument();
+    expect(screen.getByText(FIRST_RUN_COPY.tickets.scoreHint)).toBeInTheDocument();
+    expect(screen.queryByText(/The analysis starts when you choose/)).not.toBeInTheDocument();
+    expect(screen.getByTestId("first-run-analyze-tickets")).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /GitHub Issues/ }));
+    expect(onSelectTicketSource).toHaveBeenCalledWith("github-issues");
+    expect(onAnalyzeTickets).not.toHaveBeenCalled();
+  });
+
+  it("starts analysis from the button after a ticket system is selected", async () => {
+    const user = userEvent.setup();
+    const onAnalyzeTickets = vi.fn();
+
+    render(
+      <FirstRunTicketsScreen
+        ticketSource="github-issues"
+        onSelectTicketSource={vi.fn()}
+        onAnalyzeTickets={onAnalyzeTickets}
+      />,
+    );
+
+    const analyze = screen.getByRole("button", { name: FIRST_RUN_COPY.tickets.analyze });
+    expect(analyze).toBeEnabled();
+    await user.click(analyze);
+    expect(onAnalyzeTickets).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@/components/ui/button";
+
+import { ConnectOptionRow, IntegrationChoiceIcon } from "../onboardingSteps";
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FirstRunHeading, FirstRunPanel, FirstRunShell } from "./FirstRunShell";
+import type { FirstRunChrome, FirstRunTicketSource } from "./firstRunTypes";
+
+export function FirstRunTicketsScreen({
+  ticketSource,
+  chrome,
+  onSelectTicketSource,
+  onAnalyzeTickets,
+}: {
+  ticketSource: FirstRunTicketSource | null;
+  chrome?: FirstRunChrome;
+  onSelectTicketSource: (source: FirstRunTicketSource) => void;
+  onAnalyzeTickets: () => void;
+}) {
+  const copy = FIRST_RUN_COPY.tickets;
+
+  return (
+    <FirstRunShell testId="first-run-tickets" chrome={chrome}>
+      <FirstRunHeading headline={copy.headline} />
+
+      <div className="mt-8 space-y-4">
+        <FirstRunPanel>
+          <div className="space-y-3">
+            <ConnectOptionRow
+              icon={<IntegrationChoiceIcon name="github" />}
+              title={copy.githubIssues}
+              detail={copy.githubIssuesHelper}
+              selected={ticketSource === "github-issues"}
+              onSelect={() => onSelectTicketSource("github-issues")}
+            />
+            <ConnectOptionRow
+              icon={<IntegrationChoiceIcon name="jira" />}
+              title={copy.jira}
+              detail={copy.jiraHelper}
+              soon
+              onSelect={() => undefined}
+            />
+            <ConnectOptionRow
+              icon={<IntegrationChoiceIcon name="linear" />}
+              title={copy.linear}
+              detail={copy.linearHelper}
+              soon
+              onSelect={() => undefined}
+            />
+          </div>
+        </FirstRunPanel>
+
+        <div className="space-y-3">
+          <div className="space-y-1 text-[13px] leading-5 text-muted-foreground">
+            <p>{copy.trust}</p>
+            <p>{copy.scoreHint}</p>
+          </div>
+          <Button
+            type="button"
+            className="w-full"
+            disabled={!ticketSource}
+            onClick={onAnalyzeTickets}
+            data-testid="first-run-analyze-tickets"
+          >
+            {copy.analyze}
+          </Button>
+        </div>
+      </div>
+    </FirstRunShell>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWelcomeScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWelcomeScreen.spec.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FIRST_RUN_STORY_EMAIL, firstRunStoryChrome } from "./firstRunMocks";
+import { FirstRunWelcomeScreen } from "./FirstRunWelcomeScreen";
+
+describe("FirstRunWelcomeScreen", () => {
+  it("shows the greeting, chrome, and Get started", async () => {
+    const user = userEvent.setup();
+    const onGetStarted = vi.fn();
+    const onLogOut = vi.fn();
+
+    render(
+      <FirstRunWelcomeScreen
+        firstName="Ada"
+        chrome={{ ...firstRunStoryChrome(0), onLogOut }}
+        onGetStarted={onGetStarted}
+      />,
+    );
+
+    expect(screen.getByText("Hi Ada.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: FIRST_RUN_COPY.welcome.headline })).toBeInTheDocument();
+    expect(screen.getByText(FIRST_RUN_COPY.welcome.intro)).toBeInTheDocument();
+    expect(screen.queryByText(FIRST_RUN_COPY.connect.connectGitHub)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-ticket-list")).not.toBeInTheDocument();
+    expect(screen.queryByText("Example: tickets scored from a real backlog.")).not.toBeInTheDocument();
+    expect(screen.getByTestId("first-run-log-out")).toHaveTextContent(FIRST_RUN_COPY.chrome.logOut);
+    expect(screen.getByTestId("first-run-signed-in")).toHaveTextContent(FIRST_RUN_STORY_EMAIL);
+
+    await user.click(screen.getByTestId("first-run-get-started"));
+    expect(onGetStarted).toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("first-run-log-out"));
+    expect(onLogOut).toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWelcomeScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunWelcomeScreen.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@/components/ui/button";
+
+import { FIRST_RUN_COPY } from "./firstRunCopy";
+import { FirstRunHeading, FirstRunShell } from "./FirstRunShell";
+import type { FirstRunChrome } from "./firstRunTypes";
+
+export function FirstRunWelcomeScreen({
+  firstName,
+  chrome,
+  onGetStarted,
+}: {
+  firstName?: string;
+  chrome?: FirstRunChrome;
+  onGetStarted: () => void;
+}) {
+  const copy = FIRST_RUN_COPY.welcome;
+
+  return (
+    <FirstRunShell testId="first-run-welcome" chrome={chrome}>
+      <FirstRunHeading
+        greeting={firstName ? copy.greeting(firstName) : undefined}
+        headline={copy.headline}
+        size="display"
+      >
+        <p className="text-[15px] leading-6 text-muted-foreground">{copy.intro}</p>
+      </FirstRunHeading>
+
+      <div className="mt-10">
+        <Button type="button" className="min-w-40" onClick={onGetStarted} data-testid="first-run-get-started">
+          {copy.getStarted}
+        </Button>
+      </div>
+    </FirstRunShell>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/ReviewCandidateModal.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/ReviewCandidateModal.spec.tsx
@@ -1,0 +1,144 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { TooltipProvider } from "@/ui/tooltip";
+
+import { formatRelative } from "@/lib/datetime";
+
+import { LINE_INTAKE_COPY } from "../../lineIntakeModel";
+import { ReviewCandidateModal } from "./ReviewCandidateModal";
+import { REVIEW_CANDIDATE_COPY, REVIEW_CANDIDATES } from "./reviewCandidates";
+
+const candidate = REVIEW_CANDIDATES[0]!;
+
+function renderModal(onClose = vi.fn()) {
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <TooltipProvider>
+            <ReviewCandidateModal candidate={candidate} onClose={onClose} />
+          </TooltipProvider>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ReviewCandidateModal", () => {
+  it("shows the ticket title, score, reasons, then the plan", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    const dialog = screen.getByTestId("review-candidate-modal");
+    expect(within(dialog).queryByRole("heading", { name: "Review candidate" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: candidate.title })).toBeInTheDocument();
+    expect(within(dialog).getByRole("tab", { name: REVIEW_CANDIDATE_COPY.planTab })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    const score = within(dialog).getByTestId("review-candidate-score");
+    expect(score).toHaveTextContent("95%");
+    expect(score).toHaveTextContent("High");
+    expect(within(score).getByText("High").className).toMatch(/emerald/);
+    expect(within(dialog).queryByText(candidate.summary)).not.toBeInTheDocument();
+
+    const reasons = within(dialog).getByTestId("review-candidate-reasons");
+    expect(within(reasons).getAllByRole("listitem")).toHaveLength(3);
+    expect(reasons).toHaveTextContent(candidate.reasons[0]!);
+    expect(within(dialog).getByRole("heading", { name: REVIEW_CANDIDATE_COPY.planHeading })).toBeInTheDocument();
+    expect(within(dialog).getByTestId("review-candidate-plan-divider")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("review-candidate-plan-file")).toHaveTextContent(REVIEW_CANDIDATE_COPY.planFile);
+    const plan = within(dialog).getByTestId("review-candidate-plan");
+    expect(plan).toHaveTextContent("Goal");
+    expect(plan).toHaveTextContent("Add a webhook-specific retry policy using the shared backoff utility.");
+    expect(within(dialog).getByRole("button", { name: REVIEW_CANDIDATE_COPY.editPlan })).toBeInTheDocument();
+    expect(within(dialog).queryByText(candidate.ticketBody)).not.toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("tab", { name: REVIEW_CANDIDATE_COPY.ticketTab }));
+    const ticket = within(dialog).getByTestId("review-candidate-ticket");
+    expect(within(ticket).getByRole("heading", { name: candidate.title })).toBeInTheDocument();
+    expect(within(ticket).getByText(candidate.ticketBody)).toBeInTheDocument();
+    expect(within(ticket).getByText(/GitHub Issues/)).toBeInTheDocument();
+    expect(within(ticket).getByText(/acme\/payments-service/)).toBeInTheDocument();
+    expect(within(dialog).queryByTestId("review-candidate-plan")).not.toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("tab", { name: REVIEW_CANDIDATE_COPY.analysisTab }));
+    expect(within(dialog).getByText(LINE_INTAKE_COPY.analysisCompleteHeadline)).toBeInTheDocument();
+    expect(within(dialog).getByLabelText("Run")).toBeInTheDocument();
+    expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+  });
+
+  it("shows GitHub issue fields and opens the issue in a new tab", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    const dialog = screen.getByTestId("review-candidate-modal");
+    await user.click(within(dialog).getByRole("tab", { name: REVIEW_CANDIDATE_COPY.ticketTab }));
+
+    const ticket = within(dialog).getByTestId("review-candidate-ticket");
+    const openIssue = within(ticket).getByRole("link", { name: REVIEW_CANDIDATE_COPY.openIssue });
+    expect(openIssue).toHaveAttribute("href", candidate.issue.url);
+    expect(openIssue).toHaveAttribute("target", "_blank");
+    expect(openIssue).toHaveAttribute("rel", "noopener noreferrer");
+
+    expect(
+      within(ticket).getByText(new RegExp(`Opened ${formatRelative(candidate.issue.createdAt)}`)),
+    ).toBeInTheDocument();
+    expect(
+      within(ticket).getByText(new RegExp(`Updated ${formatRelative(candidate.issue.updatedAt)}`)),
+    ).toBeInTheDocument();
+    expect(within(ticket).getByTestId("review-candidate-issue-labels")).toHaveTextContent(
+      candidate.issue.labels[0]!.name,
+    );
+    expect(within(ticket).getByTestId("review-candidate-issue-author")).toHaveTextContent(candidate.issue.author.name);
+    expect(within(ticket).getByTestId("review-candidate-issue-author")).toHaveTextContent(
+      `@${candidate.issue.author.login}`,
+    );
+    expect(within(ticket).getByTestId("review-candidate-issue-assignees")).toHaveTextContent(
+      candidate.issue.assignees[0]!.name,
+    );
+    expect(
+      within(ticket).getByText("Record the last response code and attempt count on final failure."),
+    ).toBeInTheDocument();
+  });
+
+  it("closes from Back to results", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderModal(onClose);
+
+    await user.click(screen.getByRole("button", { name: REVIEW_CANDIDATE_COPY.back }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("edits the implementation plan from the side button", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    const dialog = screen.getByTestId("review-candidate-modal");
+    await user.click(within(dialog).getByRole("button", { name: REVIEW_CANDIDATE_COPY.editPlan }));
+
+    const editor = within(dialog).getByLabelText(REVIEW_CANDIDATE_COPY.planEditorLabel);
+    expect(editor).toHaveValue(candidate.planMarkdown);
+    await user.clear(editor);
+    await user.type(editor, "Retry webhooks only.");
+    await user.click(within(dialog).getByRole("button", { name: REVIEW_CANDIDATE_COPY.donePlan }));
+
+    expect(within(dialog).getByTestId("review-candidate-plan")).toHaveTextContent("Retry webhooks only.");
+    expect(within(dialog).queryByLabelText(REVIEW_CANDIDATE_COPY.planEditorLabel)).not.toBeInTheDocument();
+  });
+
+  it("approves the plan without starting implementation twice", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("button", { name: REVIEW_CANDIDATE_COPY.approve }));
+    expect(screen.getByRole("button", { name: REVIEW_CANDIDATE_COPY.approved })).toBeDisabled();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/first-run/ReviewCandidateModal.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/ReviewCandidateModal.tsx
@@ -1,0 +1,255 @@
+import { Avatar } from "@/components/Avatar/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/buttonVariants";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { formatRelative } from "@/lib/datetime";
+import { getUserInitials } from "@/lib/orgUserDisplay";
+import { cn } from "@/lib/utils";
+import { MarkdownContent } from "@/pages/app/Markdown";
+import { ExternalLink, FileText, Pencil, Ticket, Workflow } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { intakeTicketAnalysisFixture } from "../../lineIntakeModel";
+import { PopupHeader, PopupShell } from "../../work-order-popup-redesign/popupShared";
+import { WorkOrderSplitRunBody } from "../../work-order-split-run/WorkOrderSplitRunPopup";
+import {
+  REVIEW_CANDIDATE_COPY,
+  confidenceBandClassName,
+  isReviewCandidateTab,
+  type ReviewCandidate,
+  type ReviewCandidateTab,
+  type ReviewIssuePerson,
+} from "./reviewCandidates";
+
+interface ReviewCandidateModalProps {
+  candidate: ReviewCandidate;
+  onClose: () => void;
+}
+
+/**
+ * Plan review after first-run analysis. The backlog card opens this
+ * instead of the split-run popup. SuperPlane does not start work until
+ * the user approves the plan.
+ */
+export function ReviewCandidateModal({ candidate, onClose }: ReviewCandidateModalProps) {
+  const [approved, setApproved] = useState(false);
+  const [tab, setTab] = useState<ReviewCandidateTab>("plan");
+  const [planMarkdown, setPlanMarkdown] = useState(candidate.planMarkdown);
+  const analysisFixture = useMemo(
+    () => intakeTicketAnalysisFixture({ id: candidate.workOrderId, title: candidate.title }, { complete: true }),
+    [candidate.title, candidate.workOrderId],
+  );
+
+  return (
+    <PopupShell testId="review-candidate-modal" canvas fixed onDismiss={onClose}>
+      <PopupHeader title={candidate.title} onClose={onClose}>
+        <Tabs
+          value={tab}
+          onValueChange={(value) => {
+            if (isReviewCandidateTab(value)) setTab(value);
+          }}
+          className="mt-3"
+        >
+          <TabsList aria-label={REVIEW_CANDIDATE_COPY.tabsLabel}>
+            <TabsTrigger value="plan" data-testid="review-candidate-tab-plan">
+              <FileText />
+              {REVIEW_CANDIDATE_COPY.planTab}
+            </TabsTrigger>
+            <TabsTrigger value="ticket" data-testid="review-candidate-tab-ticket">
+              <Ticket />
+              {REVIEW_CANDIDATE_COPY.ticketTab}
+            </TabsTrigger>
+            <TabsTrigger value="analysis" data-testid="review-candidate-tab-analysis">
+              <Workflow />
+              {REVIEW_CANDIDATE_COPY.analysisTab}
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </PopupHeader>
+
+      {tab === "analysis" ? (
+        <WorkOrderSplitRunBody fixture={analysisFixture} />
+      ) : (
+        <>
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            {tab === "ticket" ? (
+              <TicketPanel candidate={candidate} />
+            ) : (
+              <PlanPanel candidate={candidate} planMarkdown={planMarkdown} onPlanMarkdownChange={setPlanMarkdown} />
+            )}
+          </div>
+          <footer className="flex shrink-0 items-center justify-between gap-3 border-t border-border px-5 py-3">
+            <Button type="button" variant="outline" onClick={onClose}>
+              {REVIEW_CANDIDATE_COPY.back}
+            </Button>
+            <Button type="button" disabled={approved} onClick={() => setApproved(true)}>
+              {approved ? REVIEW_CANDIDATE_COPY.approved : REVIEW_CANDIDATE_COPY.approve}
+            </Button>
+          </footer>
+        </>
+      )}
+    </PopupShell>
+  );
+}
+
+function PlanPanel({
+  candidate,
+  planMarkdown,
+  onPlanMarkdownChange,
+}: {
+  candidate: ReviewCandidate;
+  planMarkdown: string;
+  onPlanMarkdownChange: (next: string) => void;
+}) {
+  const [editingPlan, setEditingPlan] = useState(false);
+
+  return (
+    <>
+      <p className="text-[22px] font-semibold tracking-[-0.03em] text-foreground" data-testid="review-candidate-score">
+        <span className="tabular-nums">{candidate.confidencePct}%</span>
+        <span className={cn("ml-2 text-[15px] font-medium", confidenceBandClassName(candidate.confidenceBand))}>
+          {candidate.confidenceBand}
+        </span>
+      </p>
+      <h3 className="mt-5 text-[13px] font-semibold tracking-[-0.01em] text-foreground">
+        {REVIEW_CANDIDATE_COPY.reasonsHeading}
+      </h3>
+      <ul
+        className="mt-2 list-disc space-y-1.5 pl-5 text-[13px] leading-6 text-foreground"
+        data-testid="review-candidate-reasons"
+      >
+        {candidate.reasons.map((reason) => (
+          <li key={reason}>{reason}</li>
+        ))}
+      </ul>
+      <div className="mt-8 border-t border-border pt-6" data-testid="review-candidate-plan-divider">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <h3 className="text-[13px] font-semibold tracking-[-0.01em] text-foreground">
+              {REVIEW_CANDIDATE_COPY.planHeading}
+            </h3>
+            <Badge
+              variant="outline"
+              className="rounded-full font-mono text-[11px] font-normal text-muted-foreground"
+              data-testid="review-candidate-plan-file"
+            >
+              {REVIEW_CANDIDATE_COPY.planFile}
+            </Badge>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={() => setEditingPlan((open) => !open)}
+            data-testid="review-candidate-edit-plan"
+          >
+            {editingPlan ? null : <Pencil className="size-3.5" aria-hidden />}
+            {editingPlan ? REVIEW_CANDIDATE_COPY.donePlan : REVIEW_CANDIDATE_COPY.editPlan}
+          </Button>
+        </div>
+        {editingPlan ? (
+          <Textarea
+            value={planMarkdown}
+            onChange={(event) => onPlanMarkdownChange(event.target.value)}
+            aria-label={REVIEW_CANDIDATE_COPY.planEditorLabel}
+            spellCheck={false}
+            className="mt-3 min-h-[280px] resize-y font-mono text-[13px] leading-relaxed"
+          />
+        ) : (
+          <MarkdownContent
+            className="mt-3"
+            content={planMarkdown}
+            variant="workspace"
+            data-testid="review-candidate-plan"
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+function TicketPanel({ candidate }: { candidate: ReviewCandidate }) {
+  const { issue } = candidate;
+
+  return (
+    <div data-testid="review-candidate-ticket">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[12px] font-medium tracking-[-0.01em] text-muted-foreground">{candidate.ticketKey}</p>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            {REVIEW_CANDIDATE_COPY.ticketSource}
+            <span className="mx-1.5 text-border">·</span>
+            {REVIEW_CANDIDATE_COPY.ticketRepository}
+          </p>
+        </div>
+        <a
+          href={issue.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(buttonVariants({ variant: "outline", size: "sm" }), "shrink-0")}
+          data-testid="review-candidate-open-issue"
+        >
+          {REVIEW_CANDIDATE_COPY.openIssue}
+          <ExternalLink className="size-3.5" aria-hidden />
+        </a>
+      </div>
+      <h3 className="mt-5 text-[18px] font-semibold tracking-[-0.02em] text-foreground">{candidate.title}</h3>
+      <p className="mt-2 text-[13px] text-muted-foreground">
+        {REVIEW_CANDIDATE_COPY.opened} {formatRelative(issue.createdAt)}
+        <span className="mx-1.5 text-border">·</span>
+        {REVIEW_CANDIDATE_COPY.updated} {formatRelative(issue.updatedAt)}
+      </p>
+      <ul className="mt-3 flex flex-wrap gap-1.5" data-testid="review-candidate-issue-labels">
+        {issue.labels.map((label) => (
+          <li key={label.name}>
+            <Badge variant="outline" className="rounded-full font-normal">
+              {label.name}
+            </Badge>
+          </li>
+        ))}
+      </ul>
+      <MarkdownContent className="mt-5" content={issue.bodyMarkdown} variant="workspace" />
+      <dl className="mt-8 grid gap-5 sm:grid-cols-2">
+        <div>
+          <dt className="text-[12px] font-medium tracking-[-0.01em] text-muted-foreground">
+            {REVIEW_CANDIDATE_COPY.author}
+          </dt>
+          <dd className="mt-2" data-testid="review-candidate-issue-author">
+            <IssuePerson person={issue.author} />
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[12px] font-medium tracking-[-0.01em] text-muted-foreground">
+            {REVIEW_CANDIDATE_COPY.assignees}
+          </dt>
+          <dd className="mt-2" data-testid="review-candidate-issue-assignees">
+            {issue.assignees.length === 0 ? (
+              <p className="text-[13px] text-muted-foreground">{REVIEW_CANDIDATE_COPY.noAssignees}</p>
+            ) : (
+              <ul className="space-y-2">
+                {issue.assignees.map((person) => (
+                  <li key={person.login}>
+                    <IssuePerson person={person} />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function IssuePerson({ person }: { person: ReviewIssuePerson }) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5">
+      <Avatar src={person.avatarUrl} initials={getUserInitials(person.name)} alt={person.name} className="size-5" />
+      <span className="truncate text-[13px] text-foreground">{person.name}</span>
+      <span className="truncate text-[13px] text-muted-foreground">@{person.login}</span>
+    </span>
+  );
+}

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
@@ -1,0 +1,78 @@
+/** Copy for the first-run flow. Source: docs/prd/onboarding-first-run.md */
+
+export const FIRST_RUN_COPY = {
+  chrome: {
+    logOut: "Log out",
+    loggedInAs: "Logged in as",
+    stepLabel: (step: number, total: number) => `Step ${step} of ${total}`,
+  },
+  welcome: {
+    greeting: (firstName: string) => `Hi ${firstName}.`,
+    headline: "See what SuperPlane can ship from your backlog",
+    intro: "Each ticket is scored by how confident SuperPlane is that an agent can complete it.",
+    getStarted: "Get started",
+  },
+  connect: {
+    headline: "Connect GitHub",
+    body: "SuperPlane reads your repositories. It does not start work yet.",
+    trust: "SuperPlane does not change code without your approval on a specific ticket.",
+    connectGitHub: "Connect GitHub",
+    connected: "Connected",
+    continue: "Choose a repository",
+    connectError: "SuperPlane could not connect to GitHub. Check your access and try again.",
+  },
+  choose: {
+    headline: "Choose a repository",
+    repositoryLabel: "Repository",
+    repositoryHelper: "Select the repository you want SuperPlane to analyze.",
+    searchPlaceholder: "Search repositories",
+    missingRepository: "Do not see your repository?",
+    editConnection: "Edit the GitHub connection.",
+    continue: "Choose a repository to continue",
+    moreLater: "You can add more repositories later.",
+  },
+  tickets: {
+    headline: "Connect your ticket system",
+    trust: "SuperPlane does not change any tickets.",
+    scoreHint:
+      "It only analyzes them and shows a confidence score for how likely SuperPlane is to address each ticket.",
+    githubIssues: "GitHub Issues",
+    jira: "Jira",
+    linear: "Linear",
+    githubIssuesHelper: "Uses GitHub Issues on this repository. No extra setup.",
+    jiraHelper: "Find tickets in your Jira backlog.",
+    linearHelper: "Find tickets in your Linear backlog.",
+    analyze: "Analyze my tickets",
+  },
+  analysis: {
+    headline: "Analyzing your backlog",
+    body: "SuperPlane reads your code and your tickets. This takes a few minutes.",
+    reassurance: "Nothing is changed. No work starts.",
+    stage1: "Reading the repository structure",
+    stage2: "Reading open tickets",
+    stage3: "Scoring each ticket against the codebase",
+    leaveHint: "You can leave this page. SuperPlane opens the board when the analysis finishes.",
+    overrun: "The analysis needs more time than usual. It is still running.",
+    failure: "The analysis did not finish. Try again.",
+    retry: "Run analysis again",
+  },
+  results: {
+    headline: "Tickets SuperPlane can implement",
+    subhead: "Each score shows how confident SuperPlane is that an agent can complete the ticket correctly.",
+    approve: "Approve",
+    approved: "Approved",
+    helper: "Work starts only on tickets you approve.",
+    empty: "No tickets scored above 65%. Connect more of your backlog or create a work order yourself.",
+    rescan: "Rescan backlog",
+  },
+  board: {
+    backlogHintTitle: "Tickets land here first.",
+    backlogHintBody: "Intake is scoring issues now. Review the ones SuperPlane can implement, then start the work.",
+  },
+} as const;
+
+export const FIRST_RUN_STAGES = [
+  FIRST_RUN_COPY.analysis.stage1,
+  FIRST_RUN_COPY.analysis.stage2,
+  FIRST_RUN_COPY.analysis.stage3,
+] as const;

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunMocks.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunMocks.ts
@@ -1,0 +1,53 @@
+import type { FirstRunChrome, FirstRunScoredTicket } from "./firstRunTypes";
+
+export const FIRST_RUN_STORY_EMAIL = "ada@superplane.dev";
+
+export function firstRunStoryChrome(stepIndex: number): FirstRunChrome {
+  return {
+    displayName: "Ada",
+    email: FIRST_RUN_STORY_EMAIL,
+    stepIndex,
+  };
+}
+
+export const FIRST_RUN_SCORED_TICKETS: FirstRunScoredTicket[] = [
+  {
+    id: "ticket-1",
+    title: "Handle duplicate refunds on retry",
+    source: "acme/payments-service",
+    confidencePct: 94,
+  },
+  {
+    id: "ticket-2",
+    title: "Return 409 when the invoice is already paid",
+    source: "acme/api",
+    confidencePct: 88,
+  },
+  {
+    id: "ticket-3",
+    title: "Show a clearer empty state on the billing page",
+    source: "acme/web",
+    confidencePct: 81,
+  },
+  {
+    id: "ticket-4",
+    title: "Upgrade the Node 20 base image",
+    source: "acme/infra",
+    confidencePct: 76,
+  },
+  {
+    id: "ticket-5",
+    title: "Add a flake retry to the checkout e2e suite",
+    source: "acme/web",
+    confidencePct: 68,
+  },
+];
+
+export const FIRST_RUN_REPOSITORIES = [
+  "acme/api",
+  "acme/web",
+  "acme/payments-service",
+  "acme/billing",
+  "acme/docs",
+  "acme/infra",
+];

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
@@ -1,0 +1,19 @@
+export type FirstRunScreenId = "welcome" | "connect" | "choose" | "tickets" | "analysis" | "board";
+
+export type FirstRunChrome = {
+  email?: string;
+  displayName?: string;
+  onLogOut?: () => void;
+  stepIndex: number;
+};
+
+export type FirstRunTicketSource = "github-issues" | "jira" | "linear";
+
+export type FirstRunAnalysisStatus = "running" | "overrun" | "failed";
+
+export type FirstRunScoredTicket = {
+  id: string;
+  title: string;
+  source: string;
+  confidencePct: number;
+};

--- a/web_src/src/pages/factories/pages/onboarding/first-run/index.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/index.ts
@@ -1,0 +1,8 @@
+export { FirstRunAnalysisScreen } from "./FirstRunAnalysisScreen";
+export { FirstRunBoardExit } from "./FirstRunBoardExit";
+export { FirstRunChooseScreen } from "./FirstRunChooseScreen";
+export { FirstRunConnectScreen } from "./FirstRunConnectScreen";
+export { FIRST_RUN_COPY } from "./firstRunCopy";
+export { FirstRunFlow } from "./FirstRunFlow";
+export { FirstRunTicketsScreen } from "./FirstRunTicketsScreen";
+export { FirstRunWelcomeScreen } from "./FirstRunWelcomeScreen";

--- a/web_src/src/pages/factories/pages/onboarding/first-run/reviewCandidates.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/reviewCandidates.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  confidenceBandClassName,
+  confidenceBandForScore,
+  implementationPlanMarkdown,
+  isReviewCandidateTab,
+  githubIssueUrl,
+  reviewCandidateForWorkOrderId,
+  REVIEW_CANDIDATE_COPY,
+  REVIEW_CANDIDATE_WORK_ORDERS,
+  REVIEW_CANDIDATES,
+} from "./reviewCandidates";
+
+describe("reviewCandidates", () => {
+  it("maps a work order id to a review candidate", () => {
+    const candidate = reviewCandidateForWorkOrderId("wo-review-pay-842");
+    expect(candidate?.ticketKey).toBe("PAY-842");
+    expect(candidate?.ticketBody).toContain("Webhook delivery");
+    expect(candidate?.reasons).toHaveLength(3);
+    expect(candidate?.confidencePct).toBe(95);
+    expect(candidate?.sections.map((section) => section.title)).toEqual([
+      "Requirements understood",
+      "Acceptance criteria",
+      "Relevant code and tests",
+      "Implementation plan",
+    ]);
+    expect(candidate?.planMarkdown).toContain("## Goal");
+    expect(candidate?.planMarkdown).toContain("Add a webhook-specific retry policy using the shared backoff utility.");
+    expect(candidate?.issue.url).toBe(githubIssueUrl(REVIEW_CANDIDATE_COPY.ticketRepository, "PAY-842"));
+    expect(candidate?.issue.author.login).toBe("ldicaprio");
+    expect(candidate?.issue.labels.map((label) => label.name)).toEqual(["reliability", "webhooks", "ready"]);
+    expect(candidate?.issue.assignees.map((person) => person.login)).toEqual(["alex"]);
+    expect(candidate?.issue.bodyMarkdown).toContain(candidate?.ticketBody);
+  });
+
+  it("builds a GitHub issue URL from the repository and ticket key", () => {
+    expect(githubIssueUrl("acme/payments-service", "PAY-846")).toBe(
+      "https://github.com/acme/payments-service/issues/846",
+    );
+  });
+
+  it("builds a markdown implementation plan from analysis parts", () => {
+    expect(
+      implementationPlanMarkdown({
+        goal: "Move both images to Node 20.",
+        files: ["docker/app.Dockerfile — Application base image"],
+        steps: ["Update both Dockerfiles to the Node 20 base image."],
+        verify: ["CI builds both images and runs the existing image smoke tests."],
+      }),
+    ).toBe(`## Goal
+
+Move both images to Node 20.
+
+## Files to change
+
+- docker/app.Dockerfile — Application base image
+
+## Steps
+
+1. Update both Dockerfiles to the Node 20 base image.
+
+## Verify
+
+- CI builds both images and runs the existing image smoke tests.`);
+  });
+
+  it("builds draft backlog work orders for each candidate", () => {
+    expect(REVIEW_CANDIDATE_WORK_ORDERS).toHaveLength(REVIEW_CANDIDATES.length);
+    expect(REVIEW_CANDIDATE_WORK_ORDERS[0]?.state).toBe("STATE_DRAFT");
+    expect(REVIEW_CANDIDATE_WORK_ORDERS[0]?.key).toBe("PAY-842");
+    expect(REVIEW_CANDIDATE_WORK_ORDERS[0]?.lineDispatches).toEqual([]);
+  });
+
+  it("bands confidence scores", () => {
+    expect(confidenceBandForScore(95)).toBe("High");
+    expect(confidenceBandForScore(81)).toBe("Medium");
+    expect(confidenceBandForScore(68)).toBe("Low");
+    expect(confidenceBandClassName("High")).toMatch(/emerald/);
+    expect(confidenceBandClassName("Medium")).toMatch(/orange/);
+    expect(confidenceBandClassName("Low")).toMatch(/red/);
+  });
+
+  it("accepts only the three review tabs", () => {
+    expect(isReviewCandidateTab("plan")).toBe(true);
+    expect(isReviewCandidateTab("ticket")).toBe(true);
+    expect(isReviewCandidateTab("analysis")).toBe(true);
+    expect(isReviewCandidateTab("runs")).toBe(false);
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/first-run/reviewCandidates.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/reviewCandidates.ts
@@ -1,0 +1,616 @@
+import type { FactoriesWorkOrder } from "@/api-client";
+
+import {
+  HOUR_AGO,
+  LAST_WEEK,
+  OPERATOR_USER,
+  REVIEWER_USER,
+  STORYBOOK_ME_USER_AVATAR_URL,
+  STORYBOOK_ME_USER_ID,
+  STORYBOOK_ME_USER_NAME,
+  TWO_HOURS_AGO,
+  YESTERDAY,
+} from "../../../__fixtures__/factoryPageResponses";
+
+export type ReviewConfidenceBand = "High" | "Medium" | "Low";
+
+export interface ReviewCandidateSection {
+  number: string;
+  title: string;
+  intro: string;
+  items: string[];
+}
+
+export interface ReviewIssuePerson {
+  name: string;
+  login: string;
+  avatarUrl?: string;
+}
+
+export interface ReviewIssueLabel {
+  name: string;
+}
+
+export interface ReviewIssue {
+  url: string;
+  bodyMarkdown: string;
+  createdAt: string;
+  updatedAt: string;
+  author: ReviewIssuePerson;
+  assignees: ReviewIssuePerson[];
+  labels: ReviewIssueLabel[];
+}
+
+export interface ReviewCandidate {
+  workOrderId: string;
+  ticketKey: string;
+  title: string;
+  ticketBody: string;
+  issue: ReviewIssue;
+  confidencePct: number;
+  confidenceBand: ReviewConfidenceBand;
+  /** Three reasons SuperPlane can implement this ticket. */
+  reasons: [string, string, string];
+  /** Markdown implementation plan shown on the Plan tab. */
+  planMarkdown: string;
+  summary: string;
+  readyNote: string;
+  sections: ReviewCandidateSection[];
+  noBlockingQuestions: string;
+}
+
+export type ReviewCandidateTab = "plan" | "ticket" | "analysis";
+
+export const REVIEW_CANDIDATE_COPY = {
+  tabsLabel: "Ticket review",
+  planTab: "Plan",
+  ticketTab: "Ticket",
+  analysisTab: "Analysis Run",
+  ticketSource: "GitHub Issues",
+  ticketRepository: "acme/payments-service",
+  openIssue: "Open issue on GitHub",
+  opened: "Opened",
+  updated: "Updated",
+  author: "Author",
+  assignees: "Assignees",
+  noAssignees: "No assignees",
+  reasonsHeading: "Why SuperPlane can implement this",
+  planHeading: "Implementation plan",
+  planFile: "plan.md",
+  editPlan: "Edit",
+  donePlan: "Done",
+  planEditorLabel: "Plan markdown",
+  back: "Back to results",
+  approve: "Approve plan and start",
+  approved: "Plan approved",
+} as const;
+
+export function githubIssueUrl(repository: string, ticketKey: string): string {
+  return `https://github.com/${repository}/issues/${ticketKey.replace(/\D/g, "")}`;
+}
+
+export function isReviewCandidateTab(value: string): value is ReviewCandidateTab {
+  return value === "plan" || value === "ticket" || value === "analysis";
+}
+
+export function confidenceBandForScore(confidencePct: number): ReviewConfidenceBand {
+  if (confidencePct >= 85) {
+    return "High";
+  }
+  if (confidencePct >= 75) {
+    return "Medium";
+  }
+  return "Low";
+}
+
+export function implementationPlanMarkdown(parts: {
+  goal: string;
+  files: readonly string[];
+  steps: readonly string[];
+  verify: readonly string[];
+}): string {
+  return [
+    "## Goal",
+    "",
+    parts.goal,
+    "",
+    "## Files to change",
+    "",
+    ...parts.files.map((file) => `- ${file}`),
+    "",
+    "## Steps",
+    "",
+    ...parts.steps.map((step, index) => `${index + 1}. ${step}`),
+    "",
+    "## Verify",
+    "",
+    ...parts.verify.map((item) => `- ${item}`),
+  ].join("\n");
+}
+
+function planMarkdownFromSections(sections: ReviewCandidateSection[]): string {
+  const requirements = sectionByNumber(sections, "01");
+  const criteria = sectionByNumber(sections, "02");
+  const files = sectionByNumber(sections, "03");
+  const plan = sectionByNumber(sections, "04");
+
+  return implementationPlanMarkdown({
+    goal: requirements?.intro ?? "",
+    files: files?.items ?? [],
+    steps: plan?.items ?? [],
+    verify: criteria?.items ?? [],
+  });
+}
+
+function sectionByNumber(sections: ReviewCandidateSection[], number: string) {
+  return sections.find((section) => section.number === number);
+}
+
+function withPlanMarkdown(candidate: Omit<ReviewCandidate, "planMarkdown">): ReviewCandidate {
+  return { ...candidate, planMarkdown: planMarkdownFromSections(candidate.sections) };
+}
+
+export function confidenceBandClassName(band: ReviewConfidenceBand): string {
+  if (band === "High") {
+    return "text-emerald-700 dark:text-emerald-300";
+  }
+  if (band === "Medium") {
+    return "text-orange-600 dark:text-orange-400";
+  }
+  return "text-red-600 dark:text-red-400";
+}
+
+const ISSUE_AUTHOR: ReviewIssuePerson = {
+  name: STORYBOOK_ME_USER_NAME,
+  login: "ldicaprio",
+  avatarUrl: STORYBOOK_ME_USER_AVATAR_URL,
+};
+
+const ISSUE_ASSIGNEE_ALEX: ReviewIssuePerson = {
+  name: REVIEWER_USER.name,
+  login: "alex",
+};
+
+const ISSUE_ASSIGNEE_JAMIE: ReviewIssuePerson = {
+  name: OPERATOR_USER.name,
+  login: "jamie",
+};
+
+function reviewIssue(ticketKey: string, issue: Omit<ReviewIssue, "url">): ReviewIssue {
+  return { ...issue, url: githubIssueUrl(REVIEW_CANDIDATE_COPY.ticketRepository, ticketKey) };
+}
+
+function issueMarkdown(summary: string, extra: string): string {
+  return `${summary}\n\n${extra}`;
+}
+
+export const REVIEW_CANDIDATES: ReviewCandidate[] = [
+  withPlanMarkdown({
+    workOrderId: "wo-review-pay-842",
+    ticketKey: "PAY-842",
+    title: "Add retry handling to webhook delivery",
+    ticketBody:
+      "Webhook delivery stops after a transient provider error. Add bounded retries that stay idempotent and keep the delivery audit trail.",
+    issue: reviewIssue("PAY-842", {
+      createdAt: LAST_WEEK,
+      updatedAt: TWO_HOURS_AGO,
+      author: ISSUE_AUTHOR,
+      assignees: [ISSUE_ASSIGNEE_ALEX],
+      labels: [{ name: "reliability" }, { name: "webhooks" }, { name: "ready" }],
+      bodyMarkdown: issueMarkdown(
+        "Webhook delivery stops after a transient provider error. Add bounded retries that stay idempotent and keep the delivery audit trail.",
+        `## Acceptance criteria
+
+- Retry 5xx, 408, and 429 responses up to four attempts.
+- Reuse the delivery ID so retries never create a duplicate event.
+- Record the last response code and attempt count on final failure.
+
+## Notes
+
+Do not retry permanent 4xx responses, except rate limits and timeouts.`,
+      ),
+    }),
+    confidencePct: 95,
+    confidenceBand: "High",
+    reasons: [
+      "Acceptance criteria name the retryable status codes and the attempt limit.",
+      "The dispatcher and the shared retry utility are mapped, with neighboring tests.",
+      "No product decision is open. The change stays in one delivery path.",
+    ],
+    summary:
+      "Analysis complete. Requirements, acceptance criteria, relevant code, tests, and the implementation plan have been reviewed.",
+    readyNote:
+      "No implementation has started. Review the completed analysis and approve the plan when you are ready for SuperPlane to begin.",
+    sections: [
+      {
+        number: "01",
+        title: "Requirements understood",
+        intro:
+          "The retry behavior is already established in two adjacent services. SuperPlane found the relevant module, matching test patterns, and no unresolved product decisions.",
+        items: [
+          "Retry transient webhook failures with bounded exponential backoff.",
+          "Keep every retry idempotent and preserve the existing delivery audit trail.",
+          "Do not retry permanent 4xx responses, except rate limits and timeouts.",
+        ],
+      },
+      {
+        number: "02",
+        title: "Acceptance criteria",
+        intro: "Mapped from the ticket and repository conventions.",
+        items: [
+          "5xx, 408, and 429 responses are retried up to four attempts.",
+          "Retries use the existing delivery ID and never produce duplicate events.",
+          "The final failure records the last response code and attempt count.",
+          "Existing successful-delivery behavior and latency remain unchanged.",
+        ],
+      },
+      {
+        number: "03",
+        title: "Relevant code and tests",
+        intro: "Evidence used to assess feasibility and confidence.",
+        items: [
+          "src/webhooks/dispatcher.ts — Delivery loop and provider error handling",
+          "src/shared/retry-policy.ts — Existing backoff pattern used by two services",
+          "tests/webhooks/dispatcher.test.ts — 14 neighboring tests cover delivery outcomes",
+        ],
+      },
+      {
+        number: "04",
+        title: "Implementation plan",
+        intro: "The planned path to a review-ready pull request.",
+        items: [
+          "Add a webhook-specific retry policy using the shared backoff utility.",
+          "Classify provider responses as retryable or terminal in the dispatcher.",
+          "Reuse the delivery ID across attempts and record attempt metadata.",
+          "Add tests for success-after-retry, exhaustion, 429, and permanent 4xx responses.",
+        ],
+      },
+    ],
+    noBlockingQuestions: "The analysis found enough context to begin implementation with the plan above.",
+  }),
+  withPlanMarkdown({
+    workOrderId: "wo-review-pay-843",
+    ticketKey: "PAY-843",
+    title: "Handle duplicate refunds on retry",
+    ticketBody:
+      "A retry of a successful refund can post a second ledger entry. Treat the same provider key as the original refund.",
+    issue: reviewIssue("PAY-843", {
+      createdAt: LAST_WEEK,
+      updatedAt: YESTERDAY,
+      author: ISSUE_AUTHOR,
+      assignees: [ISSUE_ASSIGNEE_JAMIE],
+      labels: [{ name: "refunds" }, { name: "idempotency" }, { name: "ready" }],
+      bodyMarkdown: issueMarkdown(
+        "A retry of a successful refund can post a second ledger entry. Treat the same provider key as the original refund.",
+        `## Acceptance criteria
+
+- A retry with the same provider key returns the original refund result.
+- The ledger gains at most one posted refund for that key.
+- A failed first attempt can retry after success without a duplicate post.
+
+## Notes
+
+Reuse the charge idempotency store. Keep the existing refund audit trail.`,
+      ),
+    }),
+    confidencePct: 94,
+    confidenceBand: "High",
+    reasons: [
+      "Acceptance criteria require one ledger post per provider key.",
+      "The refund post path and the charge idempotency store are mapped.",
+      "Neighboring tests already cover success and conflict.",
+    ],
+    summary:
+      "Analysis complete. Requirements, acceptance criteria, relevant code, tests, and the implementation plan have been reviewed.",
+    readyNote:
+      "No implementation has started. Review the completed analysis and approve the plan when you are ready for SuperPlane to begin.",
+    sections: [
+      {
+        number: "01",
+        title: "Requirements understood",
+        intro:
+          "The ledger already records refund attempts. SuperPlane found the retry path and the duplicate-guard tests.",
+        items: [
+          "Treat a repeated refund request with the same provider key as the original refund.",
+          "Do not create a second ledger entry when the first attempt succeeded.",
+          "Keep the existing refund audit trail.",
+        ],
+      },
+      {
+        number: "02",
+        title: "Acceptance criteria",
+        intro: "Mapped from the ticket and repository conventions.",
+        items: [
+          "A retry with the same idempotency key returns the original refund result.",
+          "The ledger gains at most one posted refund for that key.",
+          "Failed first attempts can retry without a duplicate post after success.",
+        ],
+      },
+      {
+        number: "03",
+        title: "Relevant code and tests",
+        intro: "Evidence used to assess feasibility and confidence.",
+        items: [
+          "src/refunds/posting.ts — Refund post and provider key lookup",
+          "src/refunds/idempotency.ts — Existing key store used by charges",
+          "tests/refunds/posting.test.ts — Neighboring tests cover success and conflict",
+        ],
+      },
+      {
+        number: "04",
+        title: "Implementation plan",
+        intro: "The planned path to a review-ready pull request.",
+        items: [
+          "Reuse the charge idempotency store for refund retries.",
+          "Return the stored result when the key already posted.",
+          "Add tests for success-after-retry and duplicate-after-success.",
+        ],
+      },
+    ],
+    noBlockingQuestions: "The analysis found enough context to begin implementation with the plan above.",
+  }),
+  withPlanMarkdown({
+    workOrderId: "wo-review-pay-844",
+    ticketKey: "PAY-844",
+    title: "Return 409 when the invoice is already paid",
+    ticketBody:
+      "A second pay on a paid invoice returns HTTP 500. Map the already-paid state to HTTP 409 and leave the invoice unchanged.",
+    issue: reviewIssue("PAY-844", {
+      createdAt: YESTERDAY,
+      updatedAt: TWO_HOURS_AGO,
+      author: ISSUE_AUTHOR,
+      assignees: [ISSUE_ASSIGNEE_ALEX],
+      labels: [{ name: "bug" }, { name: "invoices" }, { name: "api" }],
+      bodyMarkdown: issueMarkdown(
+        "A second pay on a paid invoice returns HTTP 500. Map the already-paid state to HTTP 409 and leave the invoice unchanged.",
+        `## Acceptance criteria
+
+- A second pay on a paid invoice returns HTTP 409.
+- The response names the invoice as already paid.
+- A first successful pay still returns HTTP 200.
+
+## Notes
+
+The domain already rejects a second capture. Only the HTTP mapping is wrong.`,
+      ),
+    }),
+    confidencePct: 88,
+    confidenceBand: "High",
+    reasons: [
+      "Acceptance criteria name HTTP 409 for a second pay on a paid invoice.",
+      "The pay handler and the existing conflict error mapping are known.",
+      "The domain already rejects a second capture. Only the HTTP layer is wrong.",
+    ],
+    summary:
+      "Analysis complete. Requirements, acceptance criteria, relevant code, tests, and the implementation plan have been reviewed.",
+    readyNote:
+      "No implementation has started. Review the completed analysis and approve the plan when you are ready for SuperPlane to begin.",
+    sections: [
+      {
+        number: "01",
+        title: "Requirements understood",
+        intro: "Invoice pay already rejects a second capture in the model. The HTTP layer still returns 500.",
+        items: [
+          "Map an already-paid invoice to HTTP 409.",
+          "Keep the invoice state unchanged on the second pay request.",
+          "Do not change the successful first-pay response.",
+        ],
+      },
+      {
+        number: "02",
+        title: "Acceptance criteria",
+        intro: "Mapped from the ticket and repository conventions.",
+        items: [
+          "A second pay on a paid invoice returns 409.",
+          "The response names the invoice as already paid.",
+          "A first successful pay still returns 200.",
+        ],
+      },
+      {
+        number: "03",
+        title: "Relevant code and tests",
+        intro: "Evidence used to assess feasibility and confidence.",
+        items: [
+          "src/invoices/pay.ts — Pay handler and state transition",
+          "src/http/errors.ts — Conflict mapping used by subscriptions",
+          "tests/invoices/pay.test.ts — Existing paid-state coverage",
+        ],
+      },
+      {
+        number: "04",
+        title: "Implementation plan",
+        intro: "The planned path to a review-ready pull request.",
+        items: [
+          "Translate the already-paid domain error to 409 in the pay handler.",
+          "Reuse the conflict error body used by subscriptions.",
+          "Add a test for a second pay on a paid invoice.",
+        ],
+      },
+    ],
+    noBlockingQuestions: "The analysis found enough context to begin implementation with the plan above.",
+  }),
+  withPlanMarkdown({
+    workOrderId: "wo-review-pay-845",
+    ticketKey: "PAY-845",
+    title: "Show a clearer empty state on the billing page",
+    ticketBody:
+      "The billing page empty branch does not tell the user what to do next. Show a short title and one create-invoice action.",
+    issue: reviewIssue("PAY-845", {
+      createdAt: YESTERDAY,
+      updatedAt: HOUR_AGO,
+      author: ISSUE_AUTHOR,
+      assignees: [],
+      labels: [{ name: "ui" }, { name: "billing" }],
+      bodyMarkdown: issueMarkdown(
+        "The billing page empty branch does not tell the user what to do next. Show a short title and one create-invoice action.",
+        `## Acceptance criteria
+
+- A user with no invoices sees the empty state and a create-invoice action.
+- A user with invoices still sees the invoice list.
+- The empty state uses the existing page header.
+
+## Notes
+
+This change is copy and layout only. Do not add a new billing API.`,
+      ),
+    }),
+    confidencePct: 81,
+    confidenceBand: "Medium",
+    reasons: [
+      "Acceptance criteria name the empty-state title and the create-invoice action.",
+      "The billing page already has an empty branch and a shared empty-state component.",
+      "The change is copy and layout only. No new billing API.",
+    ],
+    summary:
+      "Analysis complete. Requirements, acceptance criteria, relevant code, tests, and the implementation plan have been reviewed.",
+    readyNote:
+      "No implementation has started. Review the completed analysis and approve the plan when you are ready for SuperPlane to begin.",
+    sections: [
+      {
+        number: "01",
+        title: "Requirements understood",
+        intro: "The billing page already has an empty branch. The copy does not tell the user what to do next.",
+        items: [
+          "Show a short empty-state title and one next action.",
+          "Keep the page layout when invoices exist.",
+          "Do not add a new billing API.",
+        ],
+      },
+      {
+        number: "02",
+        title: "Acceptance criteria",
+        intro: "Mapped from the ticket and repository conventions.",
+        items: [
+          "A user with no invoices sees the empty state and a create-invoice action.",
+          "A user with invoices still sees the invoice list.",
+          "The empty state uses the existing page header.",
+        ],
+      },
+      {
+        number: "03",
+        title: "Relevant code and tests",
+        intro: "Evidence used to assess feasibility and confidence.",
+        items: [
+          "web/src/pages/Billing.tsx — Invoice list and empty branch",
+          "web/src/ui/EmptyState.tsx — Shared empty-state pattern",
+          "web/src/pages/Billing.spec.tsx — List and empty coverage",
+        ],
+      },
+      {
+        number: "04",
+        title: "Implementation plan",
+        intro: "The planned path to a review-ready pull request.",
+        items: [
+          "Replace the empty paragraph with the shared empty-state component.",
+          "Add a create-invoice action that opens the existing dialog.",
+          "Add a test for the empty-state title and action.",
+        ],
+      },
+    ],
+    noBlockingQuestions: "The analysis found enough context to begin implementation with the plan above.",
+  }),
+  withPlanMarkdown({
+    workOrderId: "wo-review-pay-846",
+    ticketKey: "PAY-846",
+    title: "Upgrade the Node 20 base image",
+    ticketBody:
+      "The app and worker images still pin Node 18. Move both images to Node 20 and keep the same entrypoint.",
+    issue: reviewIssue("PAY-846", {
+      createdAt: YESTERDAY,
+      updatedAt: HOUR_AGO,
+      author: ISSUE_AUTHOR,
+      assignees: [ISSUE_ASSIGNEE_ALEX, ISSUE_ASSIGNEE_JAMIE],
+      labels: [{ name: "infrastructure" }, { name: "node" }, { name: "ci" }],
+      bodyMarkdown: issueMarkdown(
+        "The app and worker images still pin Node 18. Move both images to Node 20 and keep the same entrypoint.",
+        `## Acceptance criteria
+
+- The app and worker images build on Node 20.
+- CI builds both images and runs the existing image smoke tests.
+- Runtime environment variables stay the same.
+
+## Notes
+
+Keep the same entrypoint and process user. Do not change application dependencies in this ticket.`,
+      ),
+    }),
+    confidencePct: 76,
+    confidenceBand: "Medium",
+    reasons: [
+      "Acceptance criteria name the Node 20 images and the existing smoke tests.",
+      "The change is limited to two Dockerfiles and the image CI job.",
+      "CI already runs a Node 20 job, so the target image is known.",
+    ],
+    summary:
+      "Analysis complete. Requirements, acceptance criteria, relevant code, tests, and the implementation plan have been reviewed.",
+    readyNote:
+      "No implementation has started. Review the completed analysis and approve the plan when you are ready for SuperPlane to begin.",
+    sections: [
+      {
+        number: "01",
+        title: "Requirements understood",
+        intro: "Two Dockerfiles pin Node 18. CI already has a Node 20 job for the web package.",
+        items: [
+          "Move the application and worker images to Node 20.",
+          "Keep the same entrypoint and process user.",
+          "Do not change application dependencies in this ticket.",
+        ],
+      },
+      {
+        number: "02",
+        title: "Acceptance criteria",
+        intro: "Mapped from the ticket and repository conventions.",
+        items: [
+          "The app and worker images build on Node 20.",
+          "CI builds both images and runs the existing image smoke tests.",
+          "Runtime environment variables stay the same.",
+        ],
+      },
+      {
+        number: "03",
+        title: "Relevant code and tests",
+        intro: "Evidence used to assess feasibility and confidence.",
+        items: [
+          "docker/app.Dockerfile — Application base image",
+          "docker/worker.Dockerfile — Worker base image",
+          ".github/workflows/images.yml — Image build and smoke tests",
+        ],
+      },
+      {
+        number: "04",
+        title: "Implementation plan",
+        intro: "The planned path to a review-ready pull request.",
+        items: [
+          "Update both Dockerfiles to the Node 20 base image.",
+          "Align the CI image job with the new tag.",
+          "Run the existing image smoke tests.",
+        ],
+      },
+    ],
+    noBlockingQuestions: "The analysis found enough context to begin implementation with the plan above.",
+  }),
+];
+
+const REVIEW_CANDIDATES_BY_ID = new Map(REVIEW_CANDIDATES.map((candidate) => [candidate.workOrderId, candidate]));
+
+export function reviewCandidateForWorkOrderId(id: string | undefined): ReviewCandidate | undefined {
+  if (!id) {
+    return undefined;
+  }
+  return REVIEW_CANDIDATES_BY_ID.get(id);
+}
+
+export const REVIEW_CANDIDATE_WORK_ORDERS: FactoriesWorkOrder[] = REVIEW_CANDIDATES.map((candidate, index) => ({
+  id: candidate.workOrderId,
+  number: String(842 + index),
+  key: candidate.ticketKey,
+  title: candidate.title,
+  description: candidate.summary,
+  state: "STATE_DRAFT",
+  result: "RESULT_UNSPECIFIED",
+  createdAt: HOUR_AGO,
+  updatedAt: HOUR_AGO,
+  createdBy: { user: { id: STORYBOOK_ME_USER_ID, name: STORYBOOK_ME_USER_NAME } },
+  assignees: [],
+  lineDispatches: [],
+}));

--- a/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
@@ -4,6 +4,8 @@ import { Maximize2, MoreHorizontal, Pencil } from "lucide-react";
 import { useCallback, useMemo, type MouseEvent } from "react";
 
 import type { ComponentsEdge, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/buttonVariants";
 import { useTheme } from "@/contexts/useTheme";
 import { factoryCanvasBackground, factoryEdgePalette } from "@/lib/factoryCanvasChrome";
 import { cn } from "@/lib/utils";
@@ -133,6 +135,9 @@ export function CompactLineCanvas({
   editHref,
   expandHref,
   showHeader = true,
+  headerEdit = "menu",
+  editLabel = "Edit Automation",
+  onEdit,
 }: {
   canvas: SplitRunCanvasModel;
   selectedId: string | null;
@@ -140,6 +145,9 @@ export function CompactLineCanvas({
   editHref?: string;
   expandHref?: string;
   showHeader?: boolean;
+  headerEdit?: "menu" | "button";
+  editLabel?: string;
+  onEdit?: () => void;
 }) {
   const { nodes, edges } = useMemo(() => graphFromCanvas(canvas, selectedId, onSelect), [canvas, selectedId, onSelect]);
   const { resolvedTheme } = useTheme();
@@ -161,7 +169,7 @@ export function CompactLineCanvas({
           <p className="min-w-0 truncate text-[15px] font-semibold tracking-[-0.02em] text-foreground">
             {canvas.title}
           </p>
-          <div className="flex shrink-0 items-center gap-0.5">
+          <div className="flex shrink-0 items-center gap-2">
             {expandHref ? (
               <Link
                 href={expandHref}
@@ -172,7 +180,19 @@ export function CompactLineCanvas({
                 <Maximize2 className="size-3.5" aria-hidden />
               </Link>
             ) : null}
-            <CanvasOverflowMenu title={canvas.title} editHref={editHref} />
+            {headerEdit === "button" ? (
+              editHref ? (
+                <Link href={editHref} className={buttonVariants({ size: "sm" })} data-testid="split-run-canvas-edit">
+                  {editLabel}
+                </Link>
+              ) : (
+                <Button type="button" size="sm" onClick={onEdit} data-testid="split-run-canvas-edit">
+                  {editLabel}
+                </Button>
+              )
+            ) : (
+              <CanvasOverflowMenu title={canvas.title} editHref={editHref} />
+            )}
           </div>
         </div>
       ) : null}

--- a/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
@@ -220,18 +220,18 @@ function CanvasOverflowMenu({ title, editHref }: { title: string; editHref?: str
           <MoreHorizontal className="size-3.5" aria-hidden />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-40">
+      <DropdownMenuContent align="end" className="w-max min-w-40">
         {editHref ? (
           <DropdownMenuItem asChild data-testid="split-run-canvas-edit">
             <Link href={editHref}>
               <Pencil className="h-3.5 w-3.5" aria-hidden />
-              Edit
+              Edit Automation
             </Link>
           </DropdownMenuItem>
         ) : (
           <DropdownMenuItem disabled data-testid="split-run-canvas-edit">
             <Pencil className="h-3.5 w-3.5" aria-hidden />
-            Edit
+            Edit Automation
           </DropdownMenuItem>
         )}
       </DropdownMenuContent>

--- a/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.spec.tsx
@@ -40,7 +40,7 @@ describe("FactoryAppSplitRunPage", () => {
     expect(within(page).getByTestId("split-run-resize-handle")).toBeInTheDocument();
     expect(within(page).queryByTestId("split-run-canvas-expand")).not.toBeInTheDocument();
     expect(within(page).queryByTestId("split-run-canvas-menu")).not.toBeInTheDocument();
-    expect(within(page).getByTestId("factory-app-edit")).toHaveTextContent("Edit");
+    expect(within(page).getByTestId("factory-app-edit")).toHaveTextContent("Edit Automation");
   }, 10000);
 
   it("opens the planner canvas when the URL omits canvas", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -93,21 +93,21 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.getByTestId("split-run-canvas-node-onrun-implement")).not.toHaveAttribute("data-selected");
   });
 
-  it("keeps Edit in the canvas overflow menu when no edit href is set", async () => {
+  it("keeps Edit Automation in the canvas overflow menu when no edit href is set", async () => {
     const user = userEvent.setup();
     renderSplitRun();
 
     await user.click(screen.getByTestId("split-run-canvas-menu"));
-    expect(await screen.findByTestId("split-run-canvas-edit")).toHaveTextContent("Edit");
+    expect(await screen.findByTestId("split-run-canvas-edit")).toHaveTextContent("Edit Automation");
   });
 
-  it("opens Edit from the canvas overflow menu", async () => {
+  it("opens Edit Automation from the canvas overflow menu", async () => {
     const user = userEvent.setup();
     renderPopup({ fixture: SPLIT_RUN_RUNNING, canvasEditHref: () => "/edit-implementation" });
 
     await user.click(screen.getByTestId("split-run-canvas-menu"));
     const edit = await screen.findByTestId("split-run-canvas-edit");
-    expect(edit).toHaveTextContent("Edit");
+    expect(edit).toHaveTextContent("Edit Automation");
     expect(edit).toHaveAttribute("href", "/edit-implementation");
   });
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -9,6 +9,87 @@ import { resolveSplitRunVisual } from "./splitRunLiveCanvas";
 import { type SplitRunFixture, type SplitRunPhaseId } from "./splitRunMocks";
 import { useSplitRunLiveCanvas } from "./useSplitRunLiveCanvas";
 
+type WorkOrderSplitRunBodyProps = {
+  organizationId?: string;
+  fixture: SplitRunFixture;
+  canvasEditHref?: (key: SplitRunCanvasKey) => string | undefined;
+  canvasExpandHref?: (key: SplitRunCanvasKey) => string | undefined;
+  onDispatch?: () => Promise<void>;
+  isDispatching?: boolean;
+  canDispatch?: boolean;
+};
+
+/** Log and canvas for a split run. The popup wraps this. */
+export function WorkOrderSplitRunBody({
+  organizationId,
+  fixture,
+  canvasEditHref,
+  canvasExpandHref,
+  onDispatch,
+  isDispatching = false,
+  canDispatch = false,
+}: WorkOrderSplitRunBodyProps) {
+  const [phaseId, setPhaseId] = useState<SplitRunPhaseId>(fixture.currentPhaseId);
+  const [openPhaseId, setOpenPhaseId] = useState<SplitRunPhaseId | null>(fixture.currentPhaseId);
+  const [nodeId, setNodeId] = useState<string | null>(null);
+  const selectedPhase = fixture.phases.find((entry) => entry.id === phaseId) ?? fixture.phases[0];
+  const live = useSplitRunLiveCanvas(organizationId, selectedPhase);
+  const visual = useMemo(
+    () =>
+      selectedPhase ? resolveSplitRunVisual(selectedPhase, live) : { canvas: emptySplitRunCanvas(), stream: undefined },
+    [live, selectedPhase],
+  );
+
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+      <aside className="flex min-h-0 flex-col border-b border-border bg-muted/25 md:border-r md:border-b-0">
+        <div className="mb-2 px-3 pt-3">
+          <SectionTitle>Log</SectionTitle>
+        </div>
+
+        <ol className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+          {fixture.phases.map((entry) => (
+            <li key={entry.id} className="border-b border-border/70 py-1 last:border-b-0">
+              <PhaseLogCard
+                phase={entry}
+                expanded={entry.id === openPhaseId}
+                stream={
+                  entry.id === openPhaseId ? (entry.id === selectedPhase?.id ? visual.stream : entry.stream) : undefined
+                }
+                selectedNodeId={nodeId}
+                onSelectNode={setNodeId}
+                onToggle={() => {
+                  setPhaseId(entry.id);
+                  setNodeId(null);
+                  setOpenPhaseId((current) => (current === entry.id ? null : entry.id));
+                }}
+              />
+            </li>
+          ))}
+        </ol>
+        <SplitRunReview
+          notes={fixture.waitingNotes}
+          tone={fixture.footerTone}
+          onAction={fixture.footerTone === "draft" ? onDispatch : undefined}
+          actionBusy={isDispatching}
+          actionDisabled={!canDispatch}
+        />
+      </aside>
+
+      <section className="flex min-h-0 min-w-0 flex-col" aria-label="Run">
+        <CompactLineCanvas
+          key={selectedPhase?.id ?? "empty"}
+          canvas={visual.canvas}
+          selectedId={nodeId}
+          onSelect={setNodeId}
+          editHref={canvasEditHref?.(visual.canvas.key)}
+          expandHref={canvasExpandHref?.(visual.canvas.key)}
+        />
+      </section>
+    </div>
+  );
+}
+
 /**
  * Split run popup. Left 60% is a terminal log. Right 40% is the canvas
  * for the selected log step. Storybook and the line board.
@@ -24,29 +105,11 @@ export function WorkOrderSplitRunPopup({
   onDispatch,
   isDispatching = false,
   canDispatch = false,
-}: {
-  organizationId?: string;
-  fixture: SplitRunFixture;
+}: WorkOrderSplitRunBodyProps & {
   onClose?: () => void;
   fixed?: boolean;
-  canvasEditHref?: (key: SplitRunCanvasKey) => string | undefined;
-  canvasExpandHref?: (key: SplitRunCanvasKey) => string | undefined;
   detailHref?: string;
-  onDispatch?: () => Promise<void>;
-  isDispatching?: boolean;
-  canDispatch?: boolean;
 }) {
-  const [phaseId, setPhaseId] = useState<SplitRunPhaseId>(fixture.currentPhaseId);
-  const [openPhaseId, setOpenPhaseId] = useState<SplitRunPhaseId | null>(fixture.currentPhaseId);
-  const [nodeId, setNodeId] = useState<string | null>(null);
-  const selectedPhase = fixture.phases.find((entry) => entry.id === phaseId) ?? fixture.phases[0];
-  const live = useSplitRunLiveCanvas(organizationId, selectedPhase);
-  const visual = useMemo(
-    () =>
-      selectedPhase ? resolveSplitRunVisual(selectedPhase, live) : { canvas: emptySplitRunCanvas(), stream: undefined },
-    [live, selectedPhase],
-  );
-
   return (
     <PopupShell testId="work-order-split-run" canvas fixed={fixed} onDismiss={onClose}>
       <PopupHeader title={fixture.title} onClose={onClose} detailHref={detailHref}>
@@ -54,57 +117,15 @@ export function WorkOrderSplitRunPopup({
           <SplitRunCheckPills checks={fixture.checks} />
         </OwnerTimeCostRow>
       </PopupHeader>
-
-      <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
-        <aside className="flex min-h-0 flex-col border-b border-border bg-muted/25 md:border-r md:border-b-0">
-          <div className="mb-2 px-3 pt-3">
-            <SectionTitle>Log</SectionTitle>
-          </div>
-
-          <ol className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
-            {fixture.phases.map((entry) => (
-              <li key={entry.id} className="border-b border-border/70 py-1 last:border-b-0">
-                <PhaseLogCard
-                  phase={entry}
-                  expanded={entry.id === openPhaseId}
-                  stream={
-                    entry.id === openPhaseId
-                      ? entry.id === selectedPhase?.id
-                        ? visual.stream
-                        : entry.stream
-                      : undefined
-                  }
-                  selectedNodeId={nodeId}
-                  onSelectNode={setNodeId}
-                  onToggle={() => {
-                    setPhaseId(entry.id);
-                    setNodeId(null);
-                    setOpenPhaseId((current) => (current === entry.id ? null : entry.id));
-                  }}
-                />
-              </li>
-            ))}
-          </ol>
-          <SplitRunReview
-            notes={fixture.waitingNotes}
-            tone={fixture.footerTone}
-            onAction={fixture.footerTone === "draft" ? onDispatch : undefined}
-            actionBusy={isDispatching}
-            actionDisabled={!canDispatch}
-          />
-        </aside>
-
-        <section className="flex min-h-0 min-w-0 flex-col" aria-label="Run">
-          <CompactLineCanvas
-            key={selectedPhase?.id ?? "empty"}
-            canvas={visual.canvas}
-            selectedId={nodeId}
-            onSelect={setNodeId}
-            editHref={canvasEditHref?.(visual.canvas.key)}
-            expandHref={canvasExpandHref?.(visual.canvas.key)}
-          />
-        </section>
-      </div>
+      <WorkOrderSplitRunBody
+        organizationId={organizationId}
+        fixture={fixture}
+        canvasEditHref={canvasEditHref}
+        canvasExpandHref={canvasExpandHref}
+        onDispatch={onDispatch}
+        isDispatching={isDispatching}
+        canDispatch={canDispatch}
+      />
     </PopupShell>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunCanvases.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunCanvases.ts
@@ -82,6 +82,9 @@ export function emptySplitRunCanvas(phase?: SplitRunPhase, title?: string): Spli
 }
 
 export function splitRunCanvasForPhase(phase: SplitRunPhase): SplitRunCanvasModel {
+  if (phase.canvas) {
+    return phase.canvas;
+  }
   const key = canvasKeyForPhase(phase);
   const yaml = CANVAS_YAML[key];
   const spec = parseCanvasYamlToSpec(yaml);
@@ -235,6 +238,8 @@ const COMPONENT_PRESENTATION: Record<string, { title: string; iconSlug: string }
   "github.createIssueComment": { title: "Create Issue Comment", iconSlug: "message-square" },
   "github.addIssueLabel": { title: "Add Issue Label", iconSlug: "tag" },
   "github.onIssue": { title: "On Issue", iconSlug: "github" },
+  "sentry.onIssue": { title: "On Issue", iconSlug: "sentry" },
+  "pagerduty.onIncident": { title: "On Incident", iconSlug: "pagerduty" },
   "github.onPullRequest": { title: "On Pull Request", iconSlug: "git-pull-request" },
   findWorkOrder: { title: "Find Work Order", iconSlug: "search" },
   updateWorkOrderArtifact: { title: "Update Work Order Artifact", iconSlug: "file-pen" },

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
@@ -27,6 +27,7 @@ import type {
   RunOverlayStep,
   RunOverlayStepStatus,
 } from "../work-order-run-overlay/workOrderRunOverlayMocks";
+import type { SplitRunCanvasModel } from "./splitRunCanvases";
 
 export type SplitRunPhaseId = string;
 
@@ -60,6 +61,8 @@ export interface SplitRunPhase {
   canvasSteps: RunOverlayStep[];
   appId?: string;
   runId?: string;
+  /** When set, the popup shows this canvas instead of the phase-name map. */
+  canvas?: SplitRunCanvasModel;
 }
 
 export type SplitRunFooterTone = "waiting" | "draft" | "failed";

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
@@ -11,7 +11,7 @@ describe("WorkOrderKanbanBoard", () => {
         <WorkOrderBoardLane
           title="Plan"
           count={0}
-          emptyDescription="No work orders in this phase."
+          emptyDescription="Nothing here."
           testId="lane-plan"
         />
       </WorkOrderKanbanBoard>,
@@ -29,15 +29,30 @@ describe("WorkOrderKanbanBoard", () => {
       <WorkOrderBoardLane
         title="Verify"
         count={0}
-        emptyDescription="No work orders in this phase."
+        emptyDescription="Nothing here."
         testId="lane-empty"
       />,
     );
 
-    const emptyCopy = screen.getByText("No work orders in this phase.");
+    const emptyCopy = screen.getByText("Nothing here.");
     expect(emptyCopy).toBeInTheDocument();
     expect(emptyCopy.className).toContain("flex-1");
     expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("renders custom empty content instead of the dashed copy", () => {
+    render(
+      <WorkOrderBoardLane
+        title="Backlog"
+        count={0}
+        emptyDescription="No work orders in the backlog."
+        emptyContent={<p data-testid="custom-empty">Tickets land here first.</p>}
+        testId="lane-hint"
+      />,
+    );
+
+    expect(screen.getByTestId("custom-empty")).toHaveTextContent("Tickets land here first.");
+    expect(screen.queryByText("No work orders in the backlog.")).not.toBeInTheDocument();
   });
 
   it("renames the lane title on Enter when canRename is set", async () => {

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
@@ -19,6 +19,8 @@ describe("WorkOrderKanbanBoard", () => {
     expect(screen.getByTestId("kanban-board").className).toContain("overflow-x-auto");
     expect(screen.getByTestId("lane-plan").className).toContain("min-w-72");
     expect(screen.getByTestId("lane-plan").className).toContain("shrink-0");
+    expect(screen.getByRole("heading", { name: "Plan" })).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 
   it("keeps empty-lane copy and stretches the empty body", () => {
@@ -34,5 +36,6 @@ describe("WorkOrderKanbanBoard", () => {
     const emptyCopy = screen.getByText("No work orders in this phase.");
     expect(emptyCopy).toBeInTheDocument();
     expect(emptyCopy.className).toContain("flex-1");
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
 import { WorkOrderBoardLane, WorkOrderKanbanBoard } from "./WorkOrderBoardChrome";
 
@@ -37,5 +38,30 @@ describe("WorkOrderKanbanBoard", () => {
     expect(emptyCopy).toBeInTheDocument();
     expect(emptyCopy.className).toContain("flex-1");
     expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("renames the lane title on Enter when canRename is set", async () => {
+    const onRename = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <WorkOrderBoardLane
+        title="Backlog"
+        count={0}
+        emptyDescription="No work orders in the backlog."
+        canRename
+        onRename={onRename}
+        titleTestId="lane-title"
+        testId="lane-backlog"
+      />,
+    );
+
+    await user.click(screen.getByTestId("lane-title"));
+    const input = await screen.findByTestId("lane-title-input");
+    await waitFor(() => expect(input).toHaveFocus());
+    await user.clear(input);
+    await user.type(input, "Inbox");
+    await user.keyboard("{Enter}");
+
+    expect(onRename).toHaveBeenCalledWith("Inbox");
   });
 });

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
@@ -38,4 +38,21 @@ describe("WorkOrderKanbanBoard", () => {
     expect(emptyCopy.className).toContain("flex-1");
     expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
+
+  it("keeps children under an empty lane when asked", () => {
+    render(
+      <WorkOrderBoardLane
+        title="Backlog"
+        count={0}
+        emptyDescription="No work orders in the backlog."
+        keepChildrenWhenEmpty
+        testId="lane-backlog"
+      >
+        <button type="button">Add work order</button>
+      </WorkOrderBoardLane>,
+    );
+
+    expect(screen.queryByText("No work orders in the backlog.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add work order" })).toBeInTheDocument();
+  });
 });

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.spec.tsx
@@ -38,21 +38,4 @@ describe("WorkOrderKanbanBoard", () => {
     expect(emptyCopy.className).toContain("flex-1");
     expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
-
-  it("keeps children under an empty lane when asked", () => {
-    render(
-      <WorkOrderBoardLane
-        title="Backlog"
-        count={0}
-        emptyDescription="No work orders in the backlog."
-        keepChildrenWhenEmpty
-        testId="lane-backlog"
-      >
-        <button type="button">Add work order</button>
-      </WorkOrderBoardLane>,
-    );
-
-    expect(screen.queryByText("No work orders in the backlog.")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Add work order" })).toBeInTheDocument();
-  });
 });

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
@@ -65,8 +65,6 @@ interface WorkOrderBoardLaneProps {
   /** Replaces the body while the lane holds nothing. */
   emptyDescription: string;
   tone?: BoardLaneTone;
-  /** Sits before the title, for example a phase status glyph. */
-  leading?: ReactNode;
   /** Sits at the end of the header, for example a menu button. */
   actions?: ReactNode;
   /** Accessible name, when it must read differently from the title. */
@@ -81,7 +79,6 @@ export function WorkOrderBoardLane({
   count,
   emptyDescription,
   tone = "neutral",
-  leading,
   actions,
   label,
   className,
@@ -100,13 +97,7 @@ export function WorkOrderBoardLane({
       data-testid={testId}
     >
       <header className="flex shrink-0 items-center justify-between gap-2 px-2 pb-2">
-        <div className="inline-flex min-w-0 items-center gap-2">
-          {leading}
-          <h2 className="truncate text-[12px] font-semibold uppercase tracking-[0.06em] text-foreground/80">{title}</h2>
-          <span className="shrink-0 rounded-full bg-background/70 px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
-            {count}
-          </span>
-        </div>
+        <h2 className="workspace-section-title truncate">{title}</h2>
         {actions}
       </header>
 

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { useEffect, useRef, type ReactNode } from "react";
+import { ClickToRename } from "../layout/ClickToRename";
 import { shouldRedirectWheelToHorizontalScroll } from "./kanbanBoardWheel";
 
 /**
@@ -72,6 +73,10 @@ interface WorkOrderBoardLaneProps {
   surfaceClassName?: string;
   /** Sits at the end of the header, for example a menu button. */
   actions?: ReactNode;
+  /** When set, a click on the title opens an inline rename field. */
+  onRename?: (name: string) => void;
+  canRename?: boolean;
+  titleTestId?: string;
   /** Accessible name, when it must read differently from the title. */
   label?: string;
   className?: string;
@@ -86,6 +91,9 @@ export function WorkOrderBoardLane({
   tone = "neutral",
   surfaceClassName,
   actions,
+  onRename,
+  canRename = false,
+  titleTestId,
   label,
   className,
   testId,
@@ -103,7 +111,20 @@ export function WorkOrderBoardLane({
       data-testid={testId}
     >
       <header className="flex shrink-0 items-center justify-between gap-2 px-2 pb-2">
-        <h2 className="workspace-section-title truncate">{title}</h2>
+        <h2 className="workspace-section-title min-w-0 flex-1 overflow-visible">
+          {onRename ? (
+            <ClickToRename
+              value={title}
+              onSave={onRename}
+              canEdit={canRename}
+              testId={titleTestId ?? `${testId ?? "lane"}-title`}
+              ariaLabel={`${title} column name`}
+              inputClassName="text-[15px] font-semibold leading-[22.5px] tracking-[-0.01em]"
+            />
+          ) : (
+            <span className="truncate">{title}</span>
+          )}
+        </h2>
         {actions}
       </header>
 

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
@@ -67,6 +67,11 @@ interface WorkOrderBoardLaneProps {
   tone?: BoardLaneTone;
   /** Sits at the end of the header, for example a menu button. */
   actions?: ReactNode;
+  /**
+   * Keep rendering children when count is 0 (for a trailing add control
+   * under an empty or short list).
+   */
+  keepChildrenWhenEmpty?: boolean;
   /** Accessible name, when it must read differently from the title. */
   label?: string;
   className?: string;
@@ -80,6 +85,7 @@ export function WorkOrderBoardLane({
   emptyDescription,
   tone = "neutral",
   actions,
+  keepChildrenWhenEmpty = false,
   label,
   className,
   testId,
@@ -101,7 +107,7 @@ export function WorkOrderBoardLane({
         {actions}
       </header>
 
-      {count === 0 ? (
+      {count === 0 && !keepChildrenWhenEmpty ? (
         <p className="mt-2 flex-1 rounded-md border border-dashed border-border/60 px-3 py-6 text-center text-[12px] text-muted-foreground">
           {emptyDescription}
         </p>

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
@@ -65,6 +65,11 @@ interface WorkOrderBoardLaneProps {
   /** Replaces the body while the lane holds nothing. */
   emptyDescription: string;
   tone?: BoardLaneTone;
+  /**
+   * Optional pastel fill from the column color picker. When set, it replaces
+   * the status tone background so the chosen color is visible.
+   */
+  surfaceClassName?: string;
   /** Sits at the end of the header, for example a menu button. */
   actions?: ReactNode;
   /**
@@ -84,6 +89,7 @@ export function WorkOrderBoardLane({
   count,
   emptyDescription,
   tone = "neutral",
+  surfaceClassName,
   actions,
   keepChildrenWhenEmpty = false,
   label,
@@ -97,7 +103,7 @@ export function WorkOrderBoardLane({
       className={cn(
         "flex min-h-0 flex-col self-stretch rounded-lg border border-border/70 p-2",
         workOrderKanbanLaneSizeClassName,
-        LANE_TONE_CLASSNAME[tone],
+        surfaceClassName ?? LANE_TONE_CLASSNAME[tone],
         className,
       )}
       data-testid={testId}

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
@@ -72,11 +72,6 @@ interface WorkOrderBoardLaneProps {
   surfaceClassName?: string;
   /** Sits at the end of the header, for example a menu button. */
   actions?: ReactNode;
-  /**
-   * Keep rendering children when count is 0 (for a trailing add control
-   * under an empty or short list).
-   */
-  keepChildrenWhenEmpty?: boolean;
   /** Accessible name, when it must read differently from the title. */
   label?: string;
   className?: string;
@@ -91,7 +86,6 @@ export function WorkOrderBoardLane({
   tone = "neutral",
   surfaceClassName,
   actions,
-  keepChildrenWhenEmpty = false,
   label,
   className,
   testId,
@@ -113,7 +107,7 @@ export function WorkOrderBoardLane({
         {actions}
       </header>
 
-      {count === 0 && !keepChildrenWhenEmpty ? (
+      {count === 0 ? (
         <p className="mt-2 flex-1 rounded-md border border-dashed border-border/60 px-3 py-6 text-center text-[12px] text-muted-foreground">
           {emptyDescription}
         </p>

--- a/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderBoardChrome.tsx
@@ -65,6 +65,8 @@ interface WorkOrderBoardLaneProps {
   count: number;
   /** Replaces the body while the lane holds nothing. */
   emptyDescription: string;
+  /** When set, replaces the dashed empty copy while the lane holds nothing. */
+  emptyContent?: ReactNode;
   tone?: BoardLaneTone;
   /**
    * Optional pastel fill from the column color picker. When set, it replaces
@@ -88,6 +90,7 @@ export function WorkOrderBoardLane({
   title,
   count,
   emptyDescription,
+  emptyContent,
   tone = "neutral",
   surfaceClassName,
   actions,
@@ -129,9 +132,13 @@ export function WorkOrderBoardLane({
       </header>
 
       {count === 0 ? (
-        <p className="mt-2 flex-1 rounded-md border border-dashed border-border/60 px-3 py-6 text-center text-[12px] text-muted-foreground">
-          {emptyDescription}
-        </p>
+        emptyContent ? (
+          <div className={cn(workOrderKanbanLaneScrollClassName, "justify-center")}>{emptyContent}</div>
+        ) : (
+          <p className="mt-2 flex-1 rounded-md border border-dashed border-border/60 px-3 py-6 text-center text-[12px] text-muted-foreground">
+            {emptyDescription}
+          </p>
+        )
       ) : (
         children
       )}

--- a/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
@@ -34,6 +34,8 @@ export interface WorkOrderCardProps extends WorkOrderCardContext {
   href?: string;
   /** When set, the card overlay opens this handler instead of navigating. */
   onOpen?: () => void;
+  /** First-run analysis score. Hides Start on draft cards. */
+  confidencePct?: number;
 }
 
 /**
@@ -41,8 +43,9 @@ export interface WorkOrderCardProps extends WorkOrderCardContext {
  *
  * Every board uses this complete component. Status is a colored dot next
  * to the title. The footer shows the owner (except on drafts), the age of
- * the work order, and a Start button on drafts or an attention label
- * on waiting cards. The owner is display-only on the card.
+ * the work order, and a Start button on drafts or a score on reviewed
+ * drafts. Waiting cards show an attention label. The owner is
+ * display-only on the card.
  */
 export function WorkOrderCard({
   entry,
@@ -55,6 +58,7 @@ export function WorkOrderCard({
   onDispatch,
   href,
   onOpen,
+  confidencePct,
 }: WorkOrderCardProps) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
   const destination =
@@ -62,7 +66,7 @@ export function WorkOrderCard({
     (entry.order.number !== undefined ? workOrderDetailPath(organizationId, factoryKey, entry.order.number) : "#");
   const startedAt = entry.createdAtMs > 0 ? new Date(entry.createdAtMs) : null;
   const startedLabel = startedAt ? formatTimeAgo(startedAt) : "—";
-  const showStart = entry.displayStatus === "draft";
+  const showStart = entry.displayStatus === "draft" && confidencePct == null;
   const attentionReason = getWorkOrderAttentionReason(entry.order);
   const AttentionIcon = attentionReason ? WORK_ORDER_ATTENTION_ICON[attentionReason] : null;
 
@@ -108,6 +112,14 @@ export function WorkOrderCard({
               {startedLabel}
             </span>
           </div>
+          {confidencePct != null ? (
+            <span
+              className="shrink-0 text-[12px] font-medium tabular-nums text-foreground"
+              data-testid={`work-order-card-score-${entry.id}`}
+            >
+              {confidencePct}%
+            </span>
+          ) : null}
           {showStart ? (
             <StartDraftButton
               entry={entry}

--- a/web_src/src/pages/factories/workOrders/WorkOrdersCardClickHandler.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersCardClickHandler.spec.tsx
@@ -1,13 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createMemoryRouter, RouterProvider } from "react-router";
+import { createMemoryRouter, MemoryRouter, RouterProvider } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
 import type { FactoriesFactory, FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 
 import { workOrderDetailPath } from "../lib/factoryPagePaths";
 import { buildWorkOrderListEntry } from "../lib/workOrderListModel";
+import { WorkOrderCard } from "./WorkOrderCard";
 import { WorkOrdersBoardView } from "./WorkOrdersBoardView";
 import { WorkOrdersListView } from "./WorkOrdersListView";
 import { WorkOrdersTableView } from "./WorkOrdersTableView";
@@ -292,5 +293,47 @@ describe.each(viewsWithDispatch)("$name dispatch control", ({ Component }) => {
 
     expect(router.state.location.pathname).toBe("/");
     expect(onDispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkOrderCard scores", () => {
+  it("shows a score and hides Start on a scored draft card", () => {
+    const draft = buildWorkOrderListEntry(
+      {
+        id: "wo-draft-scored",
+        number: "842",
+        title: "Add retry handling to webhook delivery",
+        state: "STATE_DRAFT",
+        createdAt: "2024-06-01T00:00:00Z",
+        updatedAt: "2024-06-02T00:00:00Z",
+        lineDispatches: [],
+        assignees: [],
+      },
+      factory,
+    );
+
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <WorkOrderCard
+            entry={draft}
+            organizationId={organizationId}
+            factoryKey={factoryKey}
+            factoryLines={[{ id: "line-a", name: "hotfix" }]}
+            canDispatch
+            canAssign
+            isDispatching={false}
+            isAssigneesSaving={false}
+            onDispatch={vi.fn()}
+            onAssigneesSave={vi.fn()}
+            confidencePct={95}
+            onOpen={vi.fn()}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("work-order-card-score-wo-draft-scored")).toHaveTextContent("95%");
+    expect(screen.queryByRole("button", { name: "Start" })).not.toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/factories/workOrders/WorkOrdersListView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersListView.tsx
@@ -37,7 +37,7 @@ export function WorkOrdersListView(props: WorkOrdersListViewProps) {
         return (
           <section key={lane.id} aria-label={lane.title} data-testid={`work-orders-list-lane-${lane.id}`}>
             <header className="mb-1.5 flex items-center gap-2 px-1">
-              <h2 className="text-[12px] font-semibold uppercase tracking-[0.06em] text-foreground/80">{lane.title}</h2>
+              <h2 className="workspace-section-title">{lane.title}</h2>
               <span className="rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
                 {laneEntries.length}
               </span>


### PR DESCRIPTION
## Summary

The line board chrome was loud, and intake lived away from the board. Operators need a short path to incoming work and clearer column controls.

This change adds an intake drawer and rail icons. It quiets the header, lets operators tint and rename lanes, and opens backlog settings without a canvas. Phase menus now say Edit Automation and Set parallelism.

## Test plan

- [ ] Open Storybook Factories / Pages / Lines and confirm the header shows only the line name.
- [ ] Open Intake from the rail and add a template from the picker.
- [ ] Confirm Backlog create lives on the header plus only.
- [ ] Open a phase menu and confirm Edit Automation and Set parallelism.
- [ ] Open Backlog settings and change the name without opening a canvas.
- [ ] Tint a lane from the column menu and confirm the pale fill.
- [ ] Rename the board title in place.
- [ ] Run `npx vitest run src/pages/factories/pages/LineIntakeDrawer.spec.tsx src/pages/factories/pages/LinesPage.spec.tsx src/pages/factories/layout/FactoriesSidebarNav.spec.tsx`.