### PR TITLE
fix: Check for CLI updates once per day

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,8 +8,9 @@ import (
 )
 
 func main() {
-	if cli.ShouldStartUpdateCheck(os.Args[1:]) {
-		cli.StartUpdateCheck()
+	args := os.Args[1:]
+	if cli.ShouldStartUpdateCheck(args) {
+		cli.StartUpdateCheck(args)
 	}
 	err := cli.RootCmd.Execute()
 	cli.PrintUpdateNotice()

--- a/pkg/cli/update_check.go
+++ b/pkg/cli/update_check.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// ConfigKeyLastUpdateCheck holds the time of the last update check in the
+	// CLI configuration file. Viper writes configuration keys in lower case, so
+	// the key is stored in lower case and read without case sensitivity.
+	ConfigKeyLastUpdateCheck = "lastupdatecheck"
+
+	// updateCheckInterval is the minimum time between two update checks.
+	updateCheckInterval = 24 * time.Hour
+
+	// configFileName is the name of the CLI configuration file in the home
+	// directory.
+	configFileName = ".superplane.yaml"
+
+	// newConfigFileMode applies only when the configuration file does not exist
+	// yet. The file can hold an API token, so it stays private to the user.
+	newConfigFileMode = os.FileMode(0600)
+)
+
+// timeNow gives the current time. Tests replace it to control the clock.
+var timeNow = time.Now
+
+// configFilePath gives the configuration file that the CLI reads for the given
+// command line arguments. It repeats the resolution in initConfig, because the
+// update check runs before Cobra parses the flags.
+func configFilePath(args []string) string {
+	if path := configFlagValue(args); path != "" {
+		return path
+	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(home, configFileName)
+}
+
+func configFlagValue(args []string) string {
+	for i, arg := range args {
+		if value, found := strings.CutPrefix(arg, "--config="); found {
+			return value
+		}
+
+		if arg == "--config" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+
+	return ""
+}
+
+// updateCheckDue reports whether the CLI must look for a new release. A
+// configuration file that does not exist, or that has no readable timestamp,
+// counts as "never checked".
+func updateCheckDue(path string) bool {
+	last, found := lastUpdateCheck(path)
+	if !found {
+		return true
+	}
+
+	return timeNow().Sub(last) >= updateCheckInterval
+}
+
+func lastUpdateCheck(path string) (time.Time, bool) {
+	document, err := readConfigDocument(path)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	_, value, found := findEntry(mappingOf(document), ConfigKeyLastUpdateCheck)
+	if !found {
+		return time.Time{}, false
+	}
+
+	last, err := time.Parse(time.RFC3339, value.Value)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return last, true
+}
+
+// recordUpdateCheck writes the current time to the configuration file. It edits
+// the YAML document in place, so that the comments, the key order and the
+// indentation of the file stay as the user has them. The file also holds the
+// contexts and the API token, and this write runs without the user asking for
+// it.
+func recordUpdateCheck(path string) error {
+	document, err := readConfigDocument(path)
+	if err != nil {
+		return err
+	}
+
+	setEntry(mappingOf(document), ConfigKeyLastUpdateCheck, timeNow().UTC().Format(time.RFC3339))
+
+	contents, err := yaml.Marshal(document)
+	if err != nil {
+		return fmt.Errorf("failed to encode configuration: %w", err)
+	}
+
+	if err := os.WriteFile(path, contents, configFileMode(path)); err != nil {
+		return fmt.Errorf("failed to write configuration: %w", err)
+	}
+
+	return nil
+}
+
+// readConfigDocument decodes the configuration file. A file that is absent or
+// empty gives an empty document, so that the first run of the CLI can record a
+// timestamp.
+func readConfigDocument(path string) (*yaml.Node, error) {
+	if path == "" {
+		return nil, fmt.Errorf("no configuration file path")
+	}
+
+	contents, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to read configuration: %w", err)
+	}
+
+	var document yaml.Node
+	if err := yaml.Unmarshal(contents, &document); err != nil {
+		return nil, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if len(document.Content) == 0 {
+		return emptyDocument(), nil
+	}
+
+	if document.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("configuration is not a YAML mapping")
+	}
+
+	return &document, nil
+}
+
+func emptyDocument() *yaml.Node {
+	return &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}},
+	}
+}
+
+func mappingOf(document *yaml.Node) *yaml.Node {
+	return document.Content[0]
+}
+
+// findEntry looks up a key without case sensitivity, because Viper writes
+// configuration keys in lower case and a user can edit the file by hand.
+func findEntry(mapping *yaml.Node, key string) (*yaml.Node, *yaml.Node, bool) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if strings.EqualFold(mapping.Content[i].Value, key) {
+			return mapping.Content[i], mapping.Content[i+1], true
+		}
+	}
+
+	return nil, nil, false
+}
+
+// setEntry updates the value of a key that exists, and keeps the name that the
+// file uses. It appends the key when the file does not have it.
+func setEntry(mapping *yaml.Node, key, value string) {
+	if _, current, found := findEntry(mapping, key); found {
+		current.SetString(value)
+		return
+	}
+
+	mapping.Content = append(
+		mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+	)
+}
+
+// configFileMode keeps the mode of a configuration file that exists, and uses a
+// private mode for a file that the CLI creates.
+func configFileMode(path string) os.FileMode {
+	info, err := os.Stat(path)
+	if err != nil {
+		return newConfigFileMode
+	}
+
+	return info.Mode().Perm()
+}

--- a/pkg/cli/update_check_test.go
+++ b/pkg/cli/update_check_test.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func writeConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), ".superplane.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0600))
+	return path
+}
+
+func freezeClock(t *testing.T, at time.Time) {
+	t.Helper()
+
+	original := timeNow
+	timeNow = func() time.Time { return at }
+	t.Cleanup(func() { timeNow = original })
+}
+
+func TestUpdateCheckDue(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		contents string
+		expected bool
+	}{
+		{
+			name:     "no record of a previous check",
+			contents: "currentContext: http://localhost:8000/acme\n",
+			expected: true,
+		},
+		{
+			name:     "empty config file",
+			contents: "",
+			expected: true,
+		},
+		{
+			name:     "last check is older than the interval",
+			contents: "lastupdatecheck: " + now.Add(-25*time.Hour).Format(time.RFC3339) + "\n",
+			expected: true,
+		},
+		{
+			name:     "last check is exactly one interval ago",
+			contents: "lastupdatecheck: " + now.Add(-updateCheckInterval).Format(time.RFC3339) + "\n",
+			expected: true,
+		},
+		{
+			name:     "last check is inside the interval",
+			contents: "lastupdatecheck: " + now.Add(-time.Hour).Format(time.RFC3339) + "\n",
+			expected: false,
+		},
+		{
+			name:     "timestamp without quotes, which YAML reads as a time",
+			contents: "lastupdatecheck: " + now.Add(-time.Hour).Format(time.RFC3339) + "\n",
+			expected: false,
+		},
+		{
+			name:     "timestamp in quotes",
+			contents: "lastupdatecheck: \"" + now.Add(-time.Hour).Format(time.RFC3339) + "\"\n",
+			expected: false,
+		},
+		{
+			name:     "timestamp is not readable",
+			contents: "lastupdatecheck: not-a-timestamp\n",
+			expected: true,
+		},
+		{
+			name:     "config file is not valid YAML",
+			contents: "\tthis is not yaml\n",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			freezeClock(t, now)
+
+			require.Equal(t, tt.expected, updateCheckDue(writeConfigFile(t, tt.contents)))
+		})
+	}
+}
+
+func TestUpdateCheckDueWhenConfigFileIsMissing(t *testing.T) {
+	freezeClock(t, time.Now())
+
+	require.True(t, updateCheckDue(filepath.Join(t.TempDir(), "absent.yaml")))
+	require.True(t, updateCheckDue(""))
+}
+
+// A check that just ran must not run again until the interval passes.
+func TestRecordUpdateCheckStopsTheNextCheck(t *testing.T) {
+	now := time.Now()
+	freezeClock(t, now)
+
+	path := writeConfigFile(t, "")
+	require.NoError(t, recordUpdateCheck(path))
+	require.False(t, updateCheckDue(path))
+
+	freezeClock(t, now.Add(updateCheckInterval))
+	require.True(t, updateCheckDue(path))
+}
+
+func TestRecordUpdateCheckKeepsOtherSettings(t *testing.T) {
+	freezeClock(t, time.Now())
+
+	path := writeConfigFile(t, "currentContext: http://localhost:8000/acme\noutput: json\n")
+	require.NoError(t, recordUpdateCheck(path))
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var config map[string]any
+	require.NoError(t, yaml.Unmarshal(contents, &config))
+	require.Equal(t, "http://localhost:8000/acme", config["currentContext"])
+	require.Equal(t, "json", config["output"])
+	require.Contains(t, config, ConfigKeyLastUpdateCheck)
+}
+
+// A user can write the key by hand in camel case. The CLI must not rename it.
+func TestRecordUpdateCheckKeepsTheKeyNameInTheFile(t *testing.T) {
+	freezeClock(t, time.Now())
+
+	path := writeConfigFile(t, "lastUpdateCheck: \"2020-01-01T00:00:00Z\"\n")
+	require.NoError(t, recordUpdateCheck(path))
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var config map[string]any
+	require.NoError(t, yaml.Unmarshal(contents, &config))
+	require.Contains(t, config, "lastUpdateCheck")
+	require.NotContains(t, config, ConfigKeyLastUpdateCheck)
+}
+
+func TestRecordUpdateCheckCreatesMissingConfigFile(t *testing.T) {
+	freezeClock(t, time.Now())
+
+	path := filepath.Join(t.TempDir(), ".superplane.yaml")
+	require.NoError(t, recordUpdateCheck(path))
+	require.False(t, updateCheckDue(path))
+}
+
+func TestRecordUpdateCheckWithoutAPath(t *testing.T) {
+	freezeClock(t, time.Now())
+
+	require.Error(t, recordUpdateCheck(""))
+}
+
+// Viper writes configuration keys in lower case. The timestamp must survive a
+// command that saves the configuration after an update check.
+func TestUpdateCheckDueIsNotCaseSensitive(t *testing.T) {
+	now := time.Now()
+	freezeClock(t, now)
+
+	path := writeConfigFile(t, "lastUpdateCheck: "+now.Add(-time.Hour).Format(time.RFC3339)+"\n")
+	require.False(t, updateCheckDue(path))
+}
+
+func TestConfigFilePath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	defaultPath := filepath.Join(home, ".superplane.yaml")
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{name: "no arguments", args: nil, expected: defaultPath},
+		{name: "unrelated flags", args: []string{"apps", "list", "-o", "json"}, expected: defaultPath},
+		{name: "config flag", args: []string{"--config", "/tmp/custom.yaml", "whoami"}, expected: "/tmp/custom.yaml"},
+		{name: "config flag with equals", args: []string{"--config=/tmp/custom.yaml"}, expected: "/tmp/custom.yaml"},
+		{name: "config flag without a value", args: []string{"whoami", "--config"}, expected: defaultPath},
+		{name: "empty config flag", args: []string{"--config="}, expected: defaultPath},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, configFilePath(tt.args))
+		})
+	}
+}
+
+// The CLI writes this file without the user asking for it, once a day. It must
+// not remove the comments or change the order of the keys.
+func TestRecordUpdateCheckKeepsTheShapeOfTheFile(t *testing.T) {
+	freezeClock(t, time.Now())
+
+	original := `# SuperPlane CLI configuration
+currentContext: http://localhost:8000/acme
+contexts:
+    - url: http://localhost:8000
+      organization: acme
+      apiToken: secret-token # do not share
+output: json
+`
+	path := writeConfigFile(t, original)
+	require.NoError(t, recordUpdateCheck(path))
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	updated := string(contents)
+	require.Contains(t, updated, "# SuperPlane CLI configuration")
+	require.Contains(t, updated, "apiToken: secret-token # do not share")
+	require.Contains(t, updated, "output: json")
+
+	// The new key is appended, so every original line keeps its position.
+	require.Equal(t, strings.Split(original, "\n")[:6], strings.Split(updated, "\n")[:6])
+	require.Contains(t, updated, ConfigKeyLastUpdateCheck)
+}
+
+// A second run must replace the timestamp, not add a second one.
+func TestRecordUpdateCheckReplacesTheTimestamp(t *testing.T) {
+	now := time.Now()
+	freezeClock(t, now)
+
+	path := writeConfigFile(t, "output: json\n")
+	require.NoError(t, recordUpdateCheck(path))
+
+	freezeClock(t, now.Add(48*time.Hour))
+	require.NoError(t, recordUpdateCheck(path))
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(contents), ConfigKeyLastUpdateCheck))
+	require.False(t, updateCheckDue(path))
+}
+
+func TestReadConfigDocumentRejectsAFileThatIsNotAMapping(t *testing.T) {
+	_, err := readConfigDocument(writeConfigFile(t, "- one\n- two\n"))
+	require.Error(t, err)
+}

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -46,11 +46,25 @@ func init() {
 }
 
 // StartUpdateCheck begins an async check for a newer CLI version.
-// It is a no-op for dev builds.
-func StartUpdateCheck() {
+// It is a no-op for dev builds, and for a check that already ran in the last
+// updateCheckInterval. The arguments give the configuration file that holds the
+// time of the last check.
+func StartUpdateCheck(args []string) {
 	if isDevBuild() {
 		return
 	}
+
+	path := configFilePath(args)
+	if !updateCheckDue(path) {
+		return
+	}
+
+	// Record the check before the request, not after. A check that fails or
+	// times out must also count, or a network problem gives one HTTP call for
+	// every command, which is the cost this interval removes. A write that
+	// fails is not fatal, because the update notice matters more than the
+	// interval.
+	_ = recordUpdateCheck(path)
 
 	ch := make(chan *updateInfo, 1)
 	updateCheckResult = ch


### PR DESCRIPTION
## Summary

The CLI sent a request to the GitHub releases API after every command. The
extra request made the CLI feel slow, as reported in #5000.

The CLI now records the time of the check in the CLI configuration file
(`.superplane.yaml`) and starts a new check only after 24 hours.

Notes on the implementation:

- The record occurs before the request, not after it. A check that fails or
  that times out also counts. If it did not count, a network problem would
  give one request for every command again.
- The write edits the YAML document in place with `yaml.Node`. The comments,
  the key order and the indentation of the configuration file stay unchanged.
  This write occurs once a day without a user request, so it must not change
  a file that also holds the contexts and the API token.
- The lookup of the key is not case sensitive, because Viper writes
  configuration keys in lower case. A key that the user writes by hand in
  camel case keeps its name.
- The update check runs before Cobra parses the flags, so `configFilePath`
  reads `--config` from the arguments. It repeats the resolution in
  `initConfig`.

Closes #5000

## Test plan

- [x] `make test PKG_TEST_PACKAGES=./pkg/cli` passes (81 tests).
- [x] `make format.go` makes no change.
- [x] `make lint` reports no problem.
- [x] `make check.build.app` passes.
- [x] New unit tests cover: a first run with no record, a check inside the
      interval, a check at the interval, a timestamp that is not readable, a
      configuration file that is absent or not valid YAML, a timestamp with
      and without quotes, a key in camel case, and a file with comments.