### PR TITLE
feat: Enable factories flag for new orgs

### DIFF
--- a/pkg/models/organization.go
+++ b/pkg/models/organization.go
@@ -180,7 +180,7 @@ func CreateOrganizationInTransaction(tx *gorm.DB, name, description string) (*Or
 		Name:                        name,
 		Description:                 description,
 		AllowedProviders:            datatypes.JSONSlice[string]{ProviderGitHub},
-		EnabledExperimentalFeatures: datatypes.JSONSlice[string]{},
+		EnabledExperimentalFeatures: datatypes.JSONSlice[string]{features.FeatureFactories},
 		CreatedAt:                   &now,
 		UpdatedAt:                   &now,
 	}

--- a/pkg/models/organization_experimental_features_test.go
+++ b/pkg/models/organization_experimental_features_test.go
@@ -14,13 +14,14 @@ import (
 func Test__ExperimentalFeatures(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 
-	t.Run("new org has empty enabled list", func(t *testing.T) {
+	t.Run("new org has factories enabled", func(t *testing.T) {
 		org, err := CreateOrganization("expfeat-new", "")
 		require.NoError(t, err)
 
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.Empty(t, []string(reloaded.EnabledExperimentalFeatures))
+		assert.Equal(t, []string{features.FeatureFactories}, []string(reloaded.EnabledExperimentalFeatures))
+		assert.True(t, reloaded.HasExperimentalFeature(features.FeatureFactories))
 	})
 
 	t.Run("Enable adds the feature and is idempotent", func(t *testing.T) {
@@ -31,13 +32,13 @@ func Test__ExperimentalFeatures(t *testing.T) {
 
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.Equal(t, []string{"exp-feature"}, []string(reloaded.EnabledExperimentalFeatures))
+		assert.Equal(t, []string{features.FeatureFactories, "exp-feature"}, []string(reloaded.EnabledExperimentalFeatures))
 
 		require.NoError(t, EnableExperimentalFeature(org.ID, "exp-feature"))
 
 		reloaded, err = FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.Equal(t, []string{"exp-feature"}, []string(reloaded.EnabledExperimentalFeatures))
+		assert.Equal(t, []string{features.FeatureFactories, "exp-feature"}, []string(reloaded.EnabledExperimentalFeatures))
 	})
 
 	t.Run("Disable removes the feature and is idempotent", func(t *testing.T) {
@@ -49,7 +50,7 @@ func Test__ExperimentalFeatures(t *testing.T) {
 
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.Empty(t, []string(reloaded.EnabledExperimentalFeatures))
+		assert.Equal(t, []string{features.FeatureFactories}, []string(reloaded.EnabledExperimentalFeatures))
 
 		// Disabling again is a no-op.
 		require.NoError(t, DisableExperimentalFeature(org.ID, "exp-feature"))
@@ -126,7 +127,8 @@ func Test__ExperimentalFeatures(t *testing.T) {
 
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.ElementsMatch(t, ids, []string(reloaded.EnabledExperimentalFeatures))
+		expected := append([]string{features.FeatureFactories}, ids...)
+		assert.ElementsMatch(t, expected, []string(reloaded.EnabledExperimentalFeatures))
 	})
 }
 

--- a/pkg/public/factory_ws_test.go
+++ b/pkg/public/factory_ws_test.go
@@ -19,6 +19,7 @@ func TestFactoryWebSocketRequiresFactoriesFeature(t *testing.T) {
 
 	factory, err := models.CreateFactory(database.Conn(), r.Organization.ID, "ws-factory", "desc", "")
 	require.NoError(t, err)
+	require.NoError(t, models.DisableExperimentalFeature(r.Organization.ID, features.FeatureFactories))
 
 	response := execRequest(server, requestParams{
 		method:     http.MethodGet,

--- a/test/e2e/home_page_test.go
+++ b/test/e2e/home_page_test.go
@@ -159,11 +159,8 @@ func (steps *TestHomePageSteps) AssertUpdatePermissionToast() {
 }
 
 func (steps *TestHomePageSteps) ClickNewApp() {
-	newAppButton := q.Locator(`button[aria-label="Create new app"]`).Run(steps.session)
-	if visible, _ := newAppButton.IsVisible(); visible {
-		steps.session.Click(q.Locator(`button[aria-label="Create new app"]`))
-	}
-
-	steps.session.Click(q.Text("Create a blank app"))
-	steps.session.Sleep(3000)
+	steps.session.Click(q.Locator(`button[aria-label="Create new app"]`))
+	steps.session.WaitForBrowserPath("/" + steps.session.OrgID.String() + "/apps/new")
+	steps.ClickStartFromScratch()
+	steps.session.Sleep(2500)
 }


### PR DESCRIPTION
## Summary

New organizations started with no experimental features enabled. Factories is the default product path for new organizations, so organization create now turns the factories flag on. Existing organizations keep the flags that they already store.

## Test plan

- [ ] Create a new organization.
- [ ] Confirm the Factories UI is available for that organization.
- [ ] Confirm an existing organization without the flag still hides Factories.
- [ ] Confirm an admin can disable the factories flag after create.


Made with [Cursor](https://cursor.com)