### PR TITLE
fix: Clarify GitHub owner fields

### DIFF
--- a/pkg/integrations/github/setup_provider.go
+++ b/pkg/integrations/github/setup_provider.go
@@ -234,7 +234,7 @@ func (g *SetupProvider) FirstStep(ctx core.SetupStepContext) core.SetupStep {
 	return core.SetupStep{
 		Type:  core.SetupStepTypeInputs,
 		Name:  SetupStepSelectOwner,
-		Label: "Select the user account / organization",
+		Label: "Select the GitHub user or organization",
 		Inputs: []configuration.Field{
 			{
 				Name:     common.PropertyOwnerType,
@@ -253,7 +253,7 @@ func (g *SetupProvider) FirstStep(ctx core.SetupStepContext) core.SetupStep {
 			},
 			{
 				Name:        common.PropertyOwner,
-				Label:       "User account / organization name",
+				Label:       "GitHub user or organization name",
 				Type:        configuration.FieldTypeString,
 				Required:    true,
 				Placeholder: "e.g. superplanehq",

--- a/pkg/integrations/github/setup_provider_test.go
+++ b/pkg/integrations/github/setup_provider_test.go
@@ -191,6 +191,14 @@ func Test__GitHub__SetupProvider__OnSecretUpdate(t *testing.T) {
 	})
 }
 
+func Test__GitHub__SetupProvider__FirstStep(t *testing.T) {
+	step := (&SetupProvider{}).FirstStep(core.SetupStepContext{})
+
+	assert.Equal(t, "Select the GitHub user or organization", step.Label)
+	require.Len(t, step.Inputs, 2)
+	assert.Equal(t, "GitHub user or organization name", step.Inputs[1].Label)
+}
+
 func Test__GitHub__SetupProvider__OnStepSubmit(t *testing.T) {
 	g := &SetupProvider{}
 	log := logger.DiscardLogger()


### PR DESCRIPTION
Fixes #5031

## Summary
- clarify that the owner field accepts a GitHub user or organization
- add a focused regression test for the first setup step labels

## Testing
- `gofmt` on the changed files
- `git diff --check`
- full Go test suite not run because Docker and dependency network access were unavailable in the current environment