### PR TITLE
chore: Add tests for telemetry metrics guards

### DIFF
--- a/pkg/telemetry/metrics_test.go
+++ b/pkg/telemetry/metrics_test.go
@@ -1,0 +1,132 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Every Record* function in metrics.go guards on metricsReady before touching
+// its instrument. The instruments are package-level vars that stay nil until
+// InitMetrics runs, so a dropped guard is a nil dereference on a hot path in
+// any process that never initialized telemetry (CLI commands, tests, workers
+// started before InitMetrics). This pins the guard on all of them at once.
+func TestRecordMetrics_NoPanicWhenNotReady(t *testing.T) {
+	previous := metricsReady.Load()
+	metricsReady.Store(false)
+	t.Cleanup(func() {
+		metricsReady.Store(previous)
+	})
+
+	tests := []struct {
+		name   string
+		record func(context.Context)
+	}{
+		{"RecordQueueWorkerTickDuration", func(ctx context.Context) {
+			RecordQueueWorkerTickDuration(ctx, time.Second)
+		}},
+		{"RecordQueueWorkerNodesCount", func(ctx context.Context) {
+			RecordQueueWorkerNodesCount(ctx, 1)
+		}},
+		{"RecordQueueWorkerNodeProcessing", func(ctx context.Context) {
+			RecordQueueWorkerNodeProcessing(ctx, time.Second, "outcome", "reason")
+		}},
+		{"RecordExecutorWorkerTickDuration", func(ctx context.Context) {
+			RecordExecutorWorkerTickDuration(ctx, time.Second)
+		}},
+		{"RecordExecutorWorkerNodesCount", func(ctx context.Context) {
+			RecordExecutorWorkerNodesCount(ctx, 1)
+		}},
+		{"RecordExecutorWorkerExecution", func(ctx context.Context) {
+			RecordExecutorWorkerExecution(ctx, time.Second, "outcome", "reason", "component")
+		}},
+		{"RecordEventWorkerTickDuration", func(ctx context.Context) {
+			RecordEventWorkerTickDuration(ctx, time.Second)
+		}},
+		{"RecordEventWorkerEventsCount", func(ctx context.Context) {
+			RecordEventWorkerEventsCount(ctx, 1)
+		}},
+		{"RecordEventWorkerEventProcessing", func(ctx context.Context) {
+			RecordEventWorkerEventProcessing(ctx, time.Second, "outcome", "reason")
+		}},
+		{"RecordNodeRequestWorkerTickDuration", func(ctx context.Context) {
+			RecordNodeRequestWorkerTickDuration(ctx, time.Second)
+		}},
+		{"RecordNodeRequestWorkerRequestsCount", func(ctx context.Context) {
+			RecordNodeRequestWorkerRequestsCount(ctx, 1)
+		}},
+		{"RecordWebhookProvisionerWorkerTickDuration", func(ctx context.Context) {
+			RecordWebhookProvisionerWorkerTickDuration(ctx, time.Second)
+		}},
+		{"RecordWebhookProvisionerWorkerWebhooksCount", func(ctx context.Context) {
+			RecordWebhookProvisionerWorkerWebhooksCount(ctx, 1)
+		}},
+		{"RecordWebhookProvisionerWorkerWebhookProcessing", func(ctx context.Context) {
+			RecordWebhookProvisionerWorkerWebhookProcessing(ctx, time.Second, "outcome", "reason", "app")
+		}},
+		{"RecordWebhookCleanupWorkerTickDuration", func(ctx context.Context) {
+			RecordWebhookCleanupWorkerTickDuration(ctx, time.Second)
+		}},
+		{"RecordWebhookCleanupWorkerWebhooksCount", func(ctx context.Context) {
+			RecordWebhookCleanupWorkerWebhooksCount(ctx, 1)
+		}},
+		{"RecordWebhookCleanupWorkerWebhookProcessing", func(ctx context.Context) {
+			RecordWebhookCleanupWorkerWebhookProcessing(ctx, time.Second, "outcome", "reason")
+		}},
+		{"RecordWorkflowCleanupWorkerTickDuration", func(ctx context.Context) {
+			RecordWorkflowCleanupWorkerTickDuration(ctx, time.Second)
+		}},
+		{"RecordWorkflowCleanupWorkerCanvasesCount", func(ctx context.Context) {
+			RecordWorkflowCleanupWorkerCanvasesCount(ctx, 1)
+		}},
+		{"RecordRunFinalizerTickDuration", func(ctx context.Context) {
+			RecordRunFinalizerTickDuration(ctx, time.Second)
+		}},
+		{"RecordRunFinalizerRunsCount", func(ctx context.Context) {
+			RecordRunFinalizerRunsCount(ctx, 1)
+		}},
+		{"RecordRunFinalizerRunProcessing", func(ctx context.Context) {
+			RecordRunFinalizerRunProcessing(ctx, time.Second, "trigger", "outcome", "reason")
+		}},
+		{"RecordEmailWorkerEmailProcessing", func(ctx context.Context) {
+			RecordEmailWorkerEmailProcessing(ctx, time.Second, "type", "outcome", "reason")
+		}},
+		{"RecordDBLocksCount", func(ctx context.Context) {
+			RecordDBLocksCount(ctx, 1)
+		}},
+		{"RecordStuckQueueItemsCount", func(ctx context.Context) {
+			RecordStuckQueueItemsCount(ctx, 1)
+		}},
+		{"RecordDBLongQueriesCount", func(ctx context.Context) {
+			RecordDBLongQueriesCount(ctx, 1)
+		}},
+		{"RecordDBPoolStats", func(ctx context.Context) {
+			RecordDBPoolStats(ctx, 1, 2, 3, 4)
+		}},
+		{"RecordDBPoolWaitCount", func(ctx context.Context) {
+			RecordDBPoolWaitCount(ctx, 1)
+		}},
+		{"RecordDBPoolWaitDuration", func(ctx context.Context) {
+			RecordDBPoolWaitDuration(ctx, time.Second)
+		}},
+		{"RecordDBRowsAffected", func(ctx context.Context) {
+			RecordDBRowsAffected(ctx, 1, "table", "operation")
+		}},
+		{"RecordIntegrationSecretWrite", func(ctx context.Context) {
+			RecordIntegrationSecretWrite(ctx, "app", IntegrationSecretOperationCreate)
+		}},
+		{"RecordPendingEventsCount", func(ctx context.Context) {
+			RecordPendingEventsCount(ctx, 1)
+		}},
+		{"RecordPendingExecutionsCount", func(ctx context.Context) {
+			RecordPendingExecutionsCount(ctx, 1)
+		}},
+	}
+
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.record(ctx)
+		})
+	}
+}


### PR DESCRIPTION
## What changed

Adds `pkg/telemetry/metrics_test.go`, a table-driven test covering all 33 `Record*` functions in `metrics.go`.

Test-only change. No production code is modified.

## Why

`metrics.go` is the largest file in `pkg/telemetry` at 908 lines and had no test file, while every smaller file in the package is covered:

| File | Lines | Tests |
| --- | --- | --- |
| `metrics.go` | 908 | none (until this PR) |
| `periodic.go` | 186 | `periodic_test.go` |
| `websocket_metrics.go` | 144 | `websocket_metrics_test.go` |
| `traces.go` | 110 | `traces_test.go` |
| `critical_traces.go` | 102 | `critical_traces_test.go` |

## How

Every `Record*` function follows the same shape:

```go
func RecordQueueWorkerTickDuration(ctx context.Context, d time.Duration) {
	if !metricsReady.Load() {
		return
	}
	queueWorkerTickHistogram.Record(ctx, d.Seconds())
}
```

The instruments are package-level vars that stay nil until `InitMetrics` runs. Any process that records before initialization, or never initializes telemetry at all, depends entirely on that guard. Dropping one is a nil dereference rather than a missing metric, so the failure is a crash on a hot path.

The test sets `metricsReady` false, calls all 33 functions as subtests, and restores the previous value in `t.Cleanup` so it does not affect other tests in the package.

This mirrors `TestRecordWebSocketMetrics_NoPanicWhenNotReady` in `websocket_metrics_test.go`, which already pins the same contract for the four WebSocket recorders. This PR extends that coverage to the rest of the package.

## Verification

Confirmed the test fails for the right reason. Removing the guard from `RecordExecutorWorkerExecution`:

```
--- FAIL: TestRecordMetrics_NoPanicWhenNotReady/RecordExecutorWorkerExecution
panic: runtime error: invalid memory address or nil pointer dereference
```

With the guard restored:

- `go test ./pkg/telemetry/` passes (33/33 subtests)
- `gofmt -l pkg/telemetry/` clean
- `go vet ./pkg/telemetry/` clean
- `revive -config lint.toml ./pkg/telemetry/...` clean

## Related

Part of #6854.
