### PR TITLE
feat: Add canvas duplication to the home page

### DIFF
--- a/web_src/src/pages/home/CanvasActionsMenu.tsx
+++ b/web_src/src/pages/home/CanvasActionsMenu.tsx
@@ -3,21 +3,49 @@ import { Dialog, DialogActions, DialogDescription, DialogTitle } from "@/compone
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { useDeleteCanvas } from "@/hooks/useCanvasData";
+import { useCreateCanvas, useDeleteCanvas, useUpdateCanvasFolderMembership, canvasKeys } from "@/hooks/useCanvasData";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
-import { MoreVertical, Pencil, Trash2 } from "lucide-react";
-import { useState, type MouseEvent } from "react";
+import { getUsageLimitToastMessage } from "@/lib/usageLimits";
+import { Copy, MoreVertical, Pencil, Trash2 } from "lucide-react";
+import { useRef, useState, type MouseEvent } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { CanvasFolderSubmenu } from "./CanvasFolderSubmenu";
+import { duplicateCanvas } from "./duplicateCanvas";
 import type { CanvasCardData, CanvasFolderData } from "./types";
+
+type PendingDuplicateCanvas = { canvasId: string; name: string };
+type FolderMembershipMutation = ReturnType<typeof useUpdateCanvasFolderMembership>;
+
+async function addDuplicateToFolder(
+  canvasId: string,
+  folderId: string,
+  canvasFolders: CanvasFolderData[],
+  mutation: FolderMembershipMutation,
+) {
+  const folder = canvasFolders.find((f) => f.id === folderId);
+  if (!folder) return;
+  try {
+    await mutation.mutateAsync({
+      folderId: folder.id,
+      title: folder.title,
+      backgroundColor: folder.backgroundColor,
+      canvasIds: [...folder.canvasIds, canvasId],
+    });
+  } catch {
+    showErrorToast("Canvas duplicated, but could not add it to the folder");
+  }
+}
 
 interface CanvasActionsMenuProps {
   canvas: CanvasCardData;
   canvasFolders: CanvasFolderData[];
   organizationId: string;
   onEdit: (canvas: CanvasCardData) => void;
+  canCreateCanvases: boolean;
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
   permissionsLoading: boolean;
+  allCanvasNames: string[];
 }
 
 export function CanvasActionsMenu({
@@ -25,13 +53,51 @@ export function CanvasActionsMenu({
   canvasFolders,
   organizationId,
   onEdit,
+  canCreateCanvases,
   canUpdateCanvases,
   canDeleteCanvases,
   permissionsLoading,
+  allCanvasNames,
 }: CanvasActionsMenuProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const deleteCanvasMutation = useDeleteCanvas(organizationId);
-  const canManage = canUpdateCanvases || canDeleteCanvases;
+  const createCanvasMutation = useCreateCanvas(organizationId);
+  const updateFolderMembership = useUpdateCanvasFolderMembership(organizationId);
+  const queryClient = useQueryClient();
+  const pendingDuplicate = useRef(new Map<string, PendingDuplicateCanvas>());
+  const sessionDuplicateNames = useRef(new Set<string>());
+  const canManage = canUpdateCanvases || canDeleteCanvases || canCreateCanvases;
+
+  const duplicateMutation = useMutation({
+    mutationFn: () => {
+      const pending = pendingDuplicate.current.get(canvas.id);
+      return duplicateCanvas({
+        sourceCanvasId: canvas.id,
+        sourceName: canvas.name,
+        sourceDescription: canvas.description,
+        createCanvas: createCanvasMutation.mutateAsync,
+        existingCanvasNames: [...allCanvasNames, ...sessionDuplicateNames.current],
+        pendingCanvasId: pending?.canvasId,
+        pendingCanvasName: pending?.name,
+        onCanvasCreated: (canvasId, name) => {
+          pendingDuplicate.current.set(canvas.id, { canvasId, name });
+          sessionDuplicateNames.current.add(name);
+        },
+      });
+    },
+    onSuccess: (newCanvasId) => {
+      pendingDuplicate.current.delete(canvas.id);
+      queryClient.invalidateQueries({ queryKey: canvasKeys.lists() });
+      queryClient.removeQueries({ queryKey: canvasKeys.detail(organizationId, newCanvasId) });
+      showSuccessToast("Canvas duplicated");
+      if (canvas.canvasFolderId) {
+        void addDuplicateToFolder(newCanvasId, canvas.canvasFolderId, canvasFolders, updateFolderMembership);
+      }
+    },
+    onError: (error) => {
+      showErrorToast(getUsageLimitToastMessage(error, "Failed to duplicate canvas"));
+    },
+  });
 
   const closeDialog = () => {
     setIsDialogOpen(false);
@@ -48,6 +114,13 @@ export function CanvasActionsMenu({
     event.stopPropagation();
     if (!canUpdateCanvases) return;
     onEdit(canvas);
+  };
+
+  const handleDuplicate = (event: MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!canCreateCanvases) return;
+    duplicateMutation.mutate();
   };
 
   const handleDelete = async () => {
@@ -93,7 +166,7 @@ export function CanvasActionsMenu({
               <button
                 className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-500 dark:text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed"
                 aria-label="Canvas actions"
-                disabled={deleteCanvasMutation.isPending}
+                disabled={deleteCanvasMutation.isPending || duplicateMutation.isPending}
               >
                 <MoreVertical size={16} />
               </button>
@@ -103,6 +176,16 @@ export function CanvasActionsMenu({
                 <DropdownMenuItem onClick={handleChangeName} disabled={!canUpdateCanvases}>
                   <Pencil size={16} />
                   Rename
+                </DropdownMenuItem>
+              </PermissionTooltip>
+
+              <PermissionTooltip allowed={canCreateCanvases} message="You don't have permission to create canvases.">
+                <DropdownMenuItem
+                  onClick={handleDuplicate}
+                  disabled={!canCreateCanvases || duplicateMutation.isPending}
+                >
+                  <Copy size={16} />
+                  Duplicate
                 </DropdownMenuItem>
               </PermissionTooltip>
 

--- a/web_src/src/pages/home/CanvasCardsGrid.tsx
+++ b/web_src/src/pages/home/CanvasCardsGrid.tsx
@@ -28,9 +28,11 @@ interface CanvasCardsGridProps {
   organizationId: string;
   onEditCanvas: (canvas: CanvasCardData) => void;
   onToggleStar: (canvasId: string, starred: boolean) => void;
+  canCreateCanvases: boolean;
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
   permissionsLoading: boolean;
+  allCanvasNames: string[];
 }
 
 export function CanvasCardsGrid({
@@ -39,9 +41,11 @@ export function CanvasCardsGrid({
   organizationId,
   onEditCanvas,
   onToggleStar,
+  canCreateCanvases,
   canUpdateCanvases,
   canDeleteCanvases,
   permissionsLoading,
+  allCanvasNames,
 }: CanvasCardsGridProps) {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -53,9 +57,11 @@ export function CanvasCardsGrid({
           organizationId={organizationId}
           onEdit={onEditCanvas}
           onToggleStar={onToggleStar}
+          canCreateCanvases={canCreateCanvases}
           canUpdateCanvases={canUpdateCanvases}
           canDeleteCanvases={canDeleteCanvases}
           permissionsLoading={permissionsLoading}
+          allCanvasNames={allCanvasNames}
         />
       ))}
     </div>
@@ -68,9 +74,11 @@ interface CanvasCardProps {
   organizationId: string;
   onEdit: (canvas: CanvasCardData) => void;
   onToggleStar: (canvasId: string, starred: boolean) => void;
+  canCreateCanvases: boolean;
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
   permissionsLoading: boolean;
+  allCanvasNames: string[];
 }
 
 function CanvasCard({
@@ -79,9 +87,11 @@ function CanvasCard({
   organizationId,
   onEdit,
   onToggleStar,
+  canCreateCanvases,
   canUpdateCanvases,
   canDeleteCanvases,
   permissionsLoading,
+  allCanvasNames,
 }: CanvasCardProps) {
   const canvasHref = appPath(organizationId, canvas.id);
   const previewNodes = canvas.nodes || [];
@@ -122,9 +132,11 @@ function CanvasCard({
                 canvasFolders={canvasFolders}
                 organizationId={organizationId}
                 onEdit={onEdit}
+                canCreateCanvases={canCreateCanvases}
                 canUpdateCanvases={canUpdateCanvases}
                 canDeleteCanvases={canDeleteCanvases}
                 permissionsLoading={permissionsLoading}
+                allCanvasNames={allCanvasNames}
               />
             </div>
           </div>

--- a/web_src/src/pages/home/CanvasFolderSection.tsx
+++ b/web_src/src/pages/home/CanvasFolderSection.tsx
@@ -35,6 +35,7 @@ interface CanvasFolderSectionProps {
   permissionsLoading: boolean;
   canMoveUp: boolean;
   canMoveDown: boolean;
+  allCanvasNames: string[];
 }
 
 interface CanvasFolderTitleProps {
@@ -189,6 +190,7 @@ export function CanvasFolderSection({
   permissionsLoading,
   canMoveUp,
   canMoveDown,
+  allCanvasNames,
 }: CanvasFolderSectionProps) {
   const [draftTitle, setDraftTitle] = useState(folder.title);
   const [isRenaming, setIsRenaming] = useState(false);
@@ -282,9 +284,11 @@ export function CanvasFolderSection({
           organizationId={organizationId}
           onEditCanvas={onEditCanvas}
           onToggleStar={onToggleStar}
+          canCreateCanvases={canCreateCanvases}
           canUpdateCanvases={canUpdateCanvases}
           canDeleteCanvases={canDeleteCanvases}
           permissionsLoading={permissionsLoading}
+          allCanvasNames={allCanvasNames}
         />
       ) : folder.canvasIds.length === 0 ? (
         <EmptyCanvasFolder backgroundColor={folder.backgroundColor} />

--- a/web_src/src/pages/home/duplicateCanvas.spec.ts
+++ b/web_src/src/pages/home/duplicateCanvas.spec.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi, type Mock } from "vitest";
+
+import { duplicateCanvas, type DuplicateCanvasDeps } from "./duplicateCanvas";
+
+type TestDeps = DuplicateCanvasDeps & {
+  createCanvas: Mock;
+  describeCanvas: Mock;
+  fetchSourceSpec: Mock;
+  fetchConsoleYaml: Mock;
+  putCanvasStaging: Mock;
+  commitCanvasStaging: Mock;
+};
+
+function baseDeps(overrides: Partial<TestDeps> = {}): TestDeps {
+  return {
+    sourceCanvasId: "canvas-source",
+    sourceName: "Refund Planner",
+    sourceDescription: "Plans refunds",
+    createCanvas: vi.fn().mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-new" } } },
+    }),
+    describeCanvas: vi.fn().mockResolvedValue({
+      data: {
+        canvas: {
+          metadata: { description: "from source" },
+          spec: { nodes: [], edges: [] },
+        },
+      },
+    }),
+    fetchSourceSpec: vi.fn().mockResolvedValue({
+      nodes: [{ id: "n1", name: "Node 1", component: "noop" }],
+      edges: [{ sourceId: "n1", targetId: "n2", channel: "default" }],
+    }),
+    fetchConsoleYaml: vi.fn().mockResolvedValue(undefined),
+    putCanvasStaging: vi.fn().mockResolvedValue({}),
+    commitCanvasStaging: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+describe("duplicateCanvas", () => {
+  it("creates a canvas and stages+commits the source graph", async () => {
+    const deps = baseDeps();
+
+    const canvasId = await duplicateCanvas(deps);
+
+    expect(canvasId).toBe("canvas-new");
+    expect(deps.describeCanvas).toHaveBeenCalledWith("canvas-source");
+    expect(deps.fetchSourceSpec).toHaveBeenCalledWith("canvas-source");
+    expect(deps.createCanvas).toHaveBeenCalledWith({
+      name: "Refund Planner copy",
+      description: "Plans refunds",
+    });
+    expect(deps.putCanvasStaging).toHaveBeenCalledTimes(1);
+    expect(String(deps.putCanvasStaging.mock.calls[0]?.[0])).toBe("canvas-new");
+    expect(String(deps.putCanvasStaging.mock.calls[0]?.[1])).toContain("id: canvas-new");
+    expect(String(deps.putCanvasStaging.mock.calls[0]?.[1])).toContain("name: Refund Planner copy");
+    expect(String(deps.putCanvasStaging.mock.calls[0]?.[1])).toContain("n1");
+    expect(deps.putCanvasStaging.mock.calls[0]?.[2]).toBeUndefined();
+    expect(deps.commitCanvasStaging).toHaveBeenCalledWith("canvas-new");
+  });
+
+  it("uses sourceDescription over source canvas metadata description", async () => {
+    const deps = baseDeps({
+      sourceDescription: "custom description",
+    });
+
+    await duplicateCanvas(deps);
+
+    expect(deps.createCanvas).toHaveBeenCalledWith({
+      name: "Refund Planner copy",
+      description: "custom description",
+    });
+  });
+
+  it("falls back to source canvas description when sourceDescription is not provided", async () => {
+    const deps = baseDeps({
+      sourceDescription: undefined,
+    });
+
+    await duplicateCanvas(deps);
+
+    expect(deps.createCanvas).toHaveBeenCalledWith({
+      name: "Refund Planner copy",
+      description: "from source",
+    });
+  });
+
+  it("rewrites self canvas refs and stages console.yaml when present", async () => {
+    const deps = baseDeps({
+      fetchSourceSpec: vi.fn().mockResolvedValue({
+        nodes: [
+          {
+            id: "run-self",
+            name: "Run Self",
+            component: "runApp",
+            configuration: { app: "canvas-source", node: "onrun-1" },
+            metadata: { app: { id: "canvas-source", name: "Refund Planner" } },
+          },
+        ],
+        edges: [],
+      }),
+      fetchConsoleYaml: vi
+        .fn()
+        .mockResolvedValue(
+          "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\n  canvasId: canvas-source\nspec:\n  panels:\n    - id: p1\n      type: markdown\n      content:\n        body: hi\n  layout:\n    - i: p1\n      x: 0\n      'y': 0\n      w: 6\n      h: 4\n",
+        ),
+    });
+
+    await duplicateCanvas(deps);
+
+    const stagedCanvasYaml = String(deps.putCanvasStaging.mock.calls[0]?.[1]);
+    const stagedConsoleYaml = String(deps.putCanvasStaging.mock.calls[0]?.[2]);
+    expect(stagedCanvasYaml).toContain("app: canvas-new");
+    expect(stagedCanvasYaml).not.toContain("app: canvas-source");
+    expect(stagedConsoleYaml).toContain("canvasId: canvas-new");
+    expect(stagedConsoleYaml).toContain("name: Refund Planner copy");
+  });
+
+  it("skips staging when the source graph and console are empty", async () => {
+    const deps = baseDeps({
+      createCanvas: vi.fn().mockResolvedValue({
+        data: { canvas: { metadata: { id: "canvas-empty-copy" } } },
+      }),
+      fetchSourceSpec: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    });
+
+    const canvasId = await duplicateCanvas(deps);
+
+    expect(canvasId).toBe("canvas-empty-copy");
+    expect(deps.putCanvasStaging).not.toHaveBeenCalled();
+    expect(deps.commitCanvasStaging).not.toHaveBeenCalled();
+  });
+
+  it("stages when console.yaml has content even if graph is empty", async () => {
+    const deps = baseDeps({
+      fetchSourceSpec: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+      fetchConsoleYaml: vi
+        .fn()
+        .mockResolvedValue(
+          "apiVersion: v1\nkind: Console\nmetadata:\n  name: Source\nspec:\n  panels:\n    - id: p1\n      type: markdown\n      content:\n        body: hi\n  layout:\n    - i: p1\n      x: 0\n      'y': 0\n      w: 6\n      h: 4\n",
+        ),
+    });
+
+    await duplicateCanvas(deps);
+
+    expect(deps.putCanvasStaging).toHaveBeenCalledTimes(1);
+    expect(deps.commitCanvasStaging).toHaveBeenCalledTimes(1);
+  });
+
+  it("picks a unique name when the copy name is already taken", async () => {
+    const createCanvas = vi.fn().mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-new-2" } } },
+    });
+    const deps = baseDeps({
+      createCanvas,
+      existingCanvasNames: ["Refund Planner copy"],
+      fetchSourceSpec: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    });
+
+    const canvasId = await duplicateCanvas(deps);
+
+    expect(canvasId).toBe("canvas-new-2");
+    expect(createCanvas).toHaveBeenCalledTimes(1);
+    expect(createCanvas).toHaveBeenCalledWith({
+      name: "Refund Planner copy (2)",
+      description: "Plans refunds",
+    });
+  });
+
+  it("retries CreateCanvas when the server reports a name collision", async () => {
+    const createCanvas = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Canvas with the same name already exists"))
+      .mockResolvedValueOnce({
+        data: { canvas: { metadata: { id: "canvas-new-3" } } },
+      });
+    const deps = baseDeps({
+      createCanvas,
+      fetchSourceSpec: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    });
+
+    const canvasId = await duplicateCanvas(deps);
+
+    expect(canvasId).toBe("canvas-new-3");
+    expect(createCanvas).toHaveBeenNthCalledWith(1, {
+      name: "Refund Planner copy",
+      description: "Plans refunds",
+    });
+    expect(createCanvas).toHaveBeenNthCalledWith(2, {
+      name: "Refund Planner copy (2)",
+      description: "Plans refunds",
+    });
+  });
+
+  it("propagates non-name-collision errors from createCanvas", async () => {
+    const deps = baseDeps({
+      createCanvas: vi.fn().mockRejectedValue(new Error("server down")),
+    });
+
+    await expect(duplicateCanvas(deps)).rejects.toThrow("server down");
+  });
+
+  it("propagates stage/commit errors", async () => {
+    const deps = baseDeps({
+      putCanvasStaging: vi.fn().mockRejectedValue(new Error("stage failed")),
+    });
+
+    await expect(duplicateCanvas(deps)).rejects.toThrow("stage failed");
+    expect(deps.commitCanvasStaging).not.toHaveBeenCalled();
+  });
+
+  it("throws when createCanvas returns no ID", async () => {
+    const deps = baseDeps({
+      createCanvas: vi.fn().mockResolvedValue({ data: { canvas: { metadata: {} } } }),
+    });
+
+    await expect(duplicateCanvas(deps)).rejects.toThrow("Failed to create canvas");
+  });
+
+  it("reuses pending canvas id on retry (skips createCanvas)", async () => {
+    const deps = baseDeps({
+      pendingCanvasId: "canvas-pending",
+      pendingCanvasName: "Refund Planner copy",
+      fetchSourceSpec: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    });
+
+    const canvasId = await duplicateCanvas(deps);
+
+    expect(canvasId).toBe("canvas-pending");
+    expect(deps.createCanvas).not.toHaveBeenCalled();
+  });
+
+  it("calls onCanvasCreated after creating a new canvas", async () => {
+    const onCanvasCreated = vi.fn();
+    const deps = baseDeps({
+      onCanvasCreated,
+      fetchSourceSpec: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    });
+
+    await duplicateCanvas(deps);
+
+    expect(onCanvasCreated).toHaveBeenCalledWith("canvas-new", "Refund Planner copy");
+  });
+
+  it("handles missing console.yaml gracefully (404)", async () => {
+    const deps = baseDeps({
+      fetchConsoleYaml: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await duplicateCanvas(deps);
+
+    expect(deps.putCanvasStaging.mock.calls[0]?.[2]).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/home/duplicateCanvas.ts
+++ b/web_src/src/pages/home/duplicateCanvas.ts
@@ -1,0 +1,204 @@
+import { canvasesCommitCanvasStaging, canvasesDescribeCanvas, canvasesPutCanvasStaging } from "@/api-client";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+import { encodeRepositoryFileContent } from "@/pages/app/files/lib/repository-files";
+import { fetchRepositorySpecFileContent } from "@/pages/app/lib/repository-spec-files";
+import { dematerializeCanvasSpec, materializeCanvasSpec } from "@/pages/app/lib/workflow-spec-files";
+import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
+import { isNotFoundError } from "@/pages/app/workflowPageHelpers";
+import {
+  rewriteSelfCanvasRefs,
+  rematerializeDuplicateConsoleYaml,
+  consoleYamlHasContent,
+} from "@/pages/factories/pages/duplicateAutomationCanvas";
+import { isCanvasNameAlreadyExistsError, uniqueCanvasName } from "./uniqueCanvasName";
+
+const MAX_NAME_RETRY_ATTEMPTS = 20;
+
+type CreateCanvasResult = {
+  data?: {
+    canvas?: {
+      metadata?: {
+        id?: string;
+      };
+    };
+  };
+};
+
+type CanvasSpec = {
+  nodes?: {
+    id?: string;
+    name?: string;
+    component?: string;
+    configuration?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+  }[];
+  edges?: { sourceId?: string; targetId?: string; channel?: string }[];
+};
+
+export type DuplicateCanvasDeps = {
+  sourceCanvasId: string;
+  sourceName: string;
+  sourceDescription?: string;
+  createCanvas: (input: { name: string; description?: string }) => Promise<CreateCanvasResult>;
+  existingCanvasNames?: Iterable<string>;
+  /** When set, skip CreateCanvas and reuse this id (retry after failed stage/commit). */
+  pendingCanvasId?: string;
+  /** Name already assigned to the pending canvas (keeps yaml metadata in sync on retry). */
+  pendingCanvasName?: string;
+  /** Called once a new empty canvas is created, before stage/commit. */
+  onCanvasCreated?: (canvasId: string, name: string) => void;
+  /** Injectable I/O — defaults to real API calls. */
+  describeCanvas?: (
+    sourceCanvasId: string,
+  ) => Promise<{ data?: { canvas?: { metadata?: { description?: string }; spec?: CanvasSpec } } }>;
+  fetchSourceSpec?: (sourceCanvasId: string) => Promise<CanvasSpec | null | undefined>;
+  fetchConsoleYaml?: (sourceCanvasId: string) => Promise<string | undefined>;
+  putCanvasStaging?: (canvasId: string, canvasYaml: string, consoleYaml?: string) => Promise<unknown>;
+  commitCanvasStaging?: (canvasId: string) => Promise<unknown>;
+};
+
+export async function duplicateCanvas(deps: DuplicateCanvasDeps): Promise<string> {
+  const io = resolveIO(deps);
+  const { sourceCanvasId, sourceName, sourceDescription } = deps;
+
+  const sourceCanvas = (await io.describeCanvas(sourceCanvasId)).data?.canvas;
+  const sourceSpec = await io.fetchSourceSpec(sourceCanvasId);
+
+  const preferredName = `${sourceName} copy`;
+  const description = sourceDescription ?? sourceCanvas?.metadata?.description ?? "";
+  const { canvasId, name: duplicateName } = await ensureCanvasId(deps, preferredName, description);
+
+  const sourceConsoleYaml = await io.fetchConsoleYaml(sourceCanvasId);
+
+  if (specIsEmpty(sourceSpec) && !sourceConsoleYaml) {
+    return canvasId;
+  }
+
+  const nodes = sourceSpec?.nodes ?? [];
+  const edges = sourceSpec?.edges ?? [];
+
+  const canvasYaml = materializeCanvasSpec({
+    metadata: { id: canvasId, name: duplicateName, description },
+    spec: {
+      nodes: rewriteSelfCanvasRefs(nodes, sourceCanvasId, canvasId, duplicateName),
+      edges,
+    },
+  });
+  const consoleYaml = sourceConsoleYaml
+    ? rematerializeDuplicateConsoleYaml(sourceConsoleYaml, canvasId, duplicateName)
+    : undefined;
+
+  await io.putCanvasStaging(canvasId, canvasYaml, consoleYaml);
+  await io.commitCanvasStaging(canvasId);
+  return canvasId;
+}
+
+function resolveIO(deps: DuplicateCanvasDeps) {
+  return {
+    describeCanvas: deps.describeCanvas ?? defaultDescribeCanvas,
+    fetchSourceSpec: deps.fetchSourceSpec ?? defaultFetchSourceSpec,
+    fetchConsoleYaml: deps.fetchConsoleYaml ?? defaultFetchConsoleYaml,
+    putCanvasStaging: deps.putCanvasStaging ?? defaultPutCanvasStaging,
+    commitCanvasStaging: deps.commitCanvasStaging ?? defaultCommitCanvasStaging,
+  };
+}
+
+function specIsEmpty(spec: CanvasSpec | null | undefined): boolean {
+  return (spec?.nodes ?? []).length === 0 && (spec?.edges ?? []).length === 0;
+}
+
+async function ensureCanvasId(
+  deps: DuplicateCanvasDeps,
+  preferredName: string,
+  description: string,
+): Promise<{ canvasId: string; name: string }> {
+  if (deps.pendingCanvasId) {
+    return {
+      canvasId: deps.pendingCanvasId,
+      name: deps.pendingCanvasName?.trim() || preferredName,
+    };
+  }
+  const created = await createCanvasShell({
+    preferredName,
+    description,
+    createCanvas: deps.createCanvas,
+    existingCanvasNames: deps.existingCanvasNames,
+  });
+  deps.onCanvasCreated?.(created.canvasId, created.name);
+  return created;
+}
+
+async function defaultDescribeCanvas(sourceCanvasId: string) {
+  return canvasesDescribeCanvas(withOrganizationHeader({ path: { id: sourceCanvasId } }));
+}
+
+/** Reads the effective canvas spec (staged content, or committed if nothing staged). */
+async function defaultFetchSourceSpec(canvasId: string): Promise<CanvasSpec | null | undefined> {
+  try {
+    const yaml = await fetchRepositorySpecFileContent(canvasId, CANVAS_YAML_PATH, undefined, true);
+    return yaml?.trim() ? dematerializeCanvasSpec(yaml) : undefined;
+  } catch (error) {
+    if (isNotFoundError(error) || (error instanceof Error && /404|not found/i.test(error.message))) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function defaultFetchConsoleYaml(canvasId: string): Promise<string | undefined> {
+  try {
+    const raw = await fetchRepositorySpecFileContent(canvasId, CONSOLE_YAML_PATH, undefined, true);
+    return consoleYamlHasContent(raw) ? raw : undefined;
+  } catch (error) {
+    if (isNotFoundError(error) || (error instanceof Error && /404|not found/i.test(error.message))) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function defaultPutCanvasStaging(canvasId: string, canvasYaml: string, consoleYaml?: string) {
+  const operations = [{ path: CANVAS_YAML_PATH, content: encodeRepositoryFileContent(canvasYaml) }];
+  if (consoleYaml) {
+    operations.push({ path: CONSOLE_YAML_PATH, content: encodeRepositoryFileContent(consoleYaml) });
+  }
+  return canvasesPutCanvasStaging(withOrganizationHeader({ path: { canvasId }, body: { operations } }));
+}
+
+async function defaultCommitCanvasStaging(canvasId: string) {
+  return canvasesCommitCanvasStaging(
+    withOrganizationHeader({ path: { canvasId }, body: { commitMessage: "Duplicate canvas" } }),
+  );
+}
+
+async function createCanvasShell(params: {
+  preferredName: string;
+  description: string;
+  createCanvas: (input: { name: string; description?: string }) => Promise<CreateCanvasResult>;
+  existingCanvasNames?: Iterable<string>;
+}): Promise<{ canvasId: string; name: string }> {
+  const taken = new Set([...(params.existingCanvasNames ?? [])].map((n) => n.trim()).filter(Boolean));
+  let canvasName = uniqueCanvasName(params.preferredName, taken);
+
+  for (let attempt = 0; attempt < MAX_NAME_RETRY_ATTEMPTS; attempt++) {
+    try {
+      const created = await params.createCanvas({
+        name: canvasName,
+        description: params.description,
+      });
+      const canvasId = created.data?.canvas?.metadata?.id;
+      if (!canvasId) {
+        throw new Error("Failed to create canvas");
+      }
+      return { canvasId, name: canvasName };
+    } catch (error) {
+      if (!isCanvasNameAlreadyExistsError(error)) {
+        throw error;
+      }
+      taken.add(canvasName);
+      canvasName = uniqueCanvasName(params.preferredName, taken);
+    }
+  }
+
+  throw new Error("Failed to create canvas");
+}

--- a/web_src/src/pages/home/index.tsx
+++ b/web_src/src/pages/home/index.tsx
@@ -5,7 +5,7 @@ import { FEATURE_FACTORIES } from "@/lib/experimentalFeatures";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { Palette } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Navigate, useParams } from "react-router";
 import { Heading } from "../../components/Heading/heading";
 import { Text } from "../../components/Text/text";
@@ -52,6 +52,7 @@ export function HomePage() {
   const canCreateCanvases = canAct("canvases", "create");
   const canUpdateCanvases = canAct("canvases", "update");
   const canDeleteCanvases = canAct("canvases", "delete");
+  const allCanvasNames = useMemo(() => canvases.map((c) => c.name), [canvases]);
 
   const isHomePageLoading = isLoading || (isFetching && canvases.length === 0 && canvasFolders.length === 0);
   useReportPageReady(!isHomePageLoading && !!account && !!organizationId, {
@@ -100,6 +101,7 @@ export function HomePage() {
             canUpdateCanvases={canUpdateCanvases}
             canDeleteCanvases={canDeleteCanvases}
             permissionsLoading={permissionsLoading}
+            allCanvasNames={allCanvasNames}
           />
         )}
       </div>
@@ -128,6 +130,7 @@ function Content({
   canUpdateCanvases,
   canDeleteCanvases,
   permissionsLoading,
+  allCanvasNames,
 }: {
   filteredCanvases: CanvasCardData[];
   preferredFilteredCanvases: CanvasCardData[];
@@ -140,6 +143,7 @@ function Content({
   canUpdateCanvases: boolean;
   canDeleteCanvases: boolean;
   permissionsLoading: boolean;
+  allCanvasNames: string[];
 }) {
   const folderedLayout = buildFolderedLayout(
     preferredFilteredCanvases,
@@ -175,6 +179,7 @@ function Content({
           canMoveDown={
             canvasFolders.findIndex((canvasFolder) => canvasFolder.id === folder.id) < canvasFolders.length - 1
           }
+          allCanvasNames={allCanvasNames}
         />
       ))}
 
@@ -186,9 +191,11 @@ function Content({
             organizationId={organizationId}
             onEditCanvas={onEditCanvas}
             onToggleStar={onToggleStar}
+            canCreateCanvases={canCreateCanvases}
             canUpdateCanvases={canUpdateCanvases}
             canDeleteCanvases={canDeleteCanvases}
             permissionsLoading={permissionsLoading}
+            allCanvasNames={allCanvasNames}
           />
         </section>
       ) : null}


### PR DESCRIPTION
## Summary

The three-dot menu on home page canvas cards has Rename, Move to Folder, and Delete. Factory automations already support duplication, but regular canvases do not.

This PR adds a Duplicate action that copies the source graph (nodes,edges) and console dashboard into a new canvas. The copy reads from the staging layer to match what the user sees in the editor. Self-referencing runApp nodes are rewritten to point at the duplicate. Secrets, run history, and webhook URLs are not copied.

## Test plan

  - [ ] Duplicate a canvas from the three-dot menu — the copy appears as "{original} copy"
  - [ ] Duplicate the same canvas again — the second copy appears as "{original} copy (2)"
  - [ ] Open the duplicate and verify it has the same nodes and edges
  - [ ] Duplicate a canvas with a console dashboard and verify it copies
  - [ ] Duplicate an empty canvas — the copy is created successfully
  - [ ] Run `npx vitest run web_src/src/pages/home/duplicateCanvas.spec.ts` — 14 tests pass
