### PR TITLE
fix: Bind local secret encryption to the secret ID

### DIFF
--- a/pkg/grpc/actions/secrets/create_secret.go
+++ b/pkg/grpc/actions/secrets/create_secret.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -39,12 +38,13 @@ func CreateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType st
 		return nil, grpcerrors.InvalidArgument(nil, "invalid provider")
 	}
 
-	data, err := prepareSecretData(ctx, encryptor, spec)
+	secretID := uuid.New()
+	data, err := prepareSecretData(ctx, encryptor, secretID, spec)
 	if err != nil {
 		return nil, grpcerrors.InvalidArgument(err, "invalid secret configuration")
 	}
 
-	secret, err := models.CreateSecret(spec.Metadata.Name, provider, userID, domainType, uuid.MustParse(domainID), data)
+	secret, err := models.CreateSecret(secretID, spec.Metadata.Name, provider, userID, domainType, uuid.MustParse(domainID), data)
 	if err != nil {
 		if errors.Is(err, models.ErrNameAlreadyUsed) {
 			return nil, grpcerrors.InvalidArgument(err, "name already used")
@@ -80,7 +80,7 @@ func secretProviderToProto(provider string) pb.Secret_Provider {
 	}
 }
 
-func prepareSecretData(ctx context.Context, encryptor crypto.Encryptor, secret *pb.Secret) ([]byte, error) {
+func prepareSecretData(ctx context.Context, encryptor crypto.Encryptor, secretID uuid.UUID, secret *pb.Secret) ([]byte, error) {
 	if secret.Spec == nil {
 		return nil, fmt.Errorf("missing secret spec")
 	}
@@ -90,45 +90,9 @@ func prepareSecretData(ctx context.Context, encryptor crypto.Encryptor, secret *
 			return nil, fmt.Errorf("missing data")
 		}
 
-		data, err := json.Marshal(secret.Spec.Local.Data)
-		if err != nil {
-			return nil, err
-		}
-
-		encrypted, err := encryptor.Encrypt(ctx, data, []byte(secret.Metadata.Name))
-		if err != nil {
-			return nil, err
-		}
-
-		return encrypted, nil
+		return secrets.EncryptLocalData(ctx, encryptor, secretID, secret.Spec.Local.Data)
 
 	default:
 		return nil, fmt.Errorf("provider not supported")
 	}
-}
-
-// decryptSecretData decrypts a secret's stored data and returns the key-value map.
-func decryptSecretData(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) (map[string]string, error) {
-	data, err := encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
-	if err != nil {
-		return nil, err
-	}
-	var values map[string]string
-	if len(data) == 0 {
-		return make(map[string]string), nil
-	}
-	err = json.Unmarshal(data, &values)
-	if err != nil {
-		return nil, err
-	}
-	return values, nil
-}
-
-// encryptSecretData marshals the key-value map and encrypts it for storage.
-func encryptSecretData(ctx context.Context, encryptor crypto.Encryptor, secretName string, data map[string]string) ([]byte, error) {
-	raw, err := json.Marshal(data)
-	if err != nil {
-		return nil, err
-	}
-	return encryptor.Encrypt(ctx, raw, []byte(secretName))
 }

--- a/pkg/grpc/actions/secrets/delete_secret_key.go
+++ b/pkg/grpc/actions/secrets/delete_secret_key.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	"github.com/superplanehq/superplane/pkg/secrets"
 )
 
 func DeleteSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType, domainID, idOrName, keyName string) (*pb.DeleteSecretKeyResponse, error) {
@@ -27,7 +28,7 @@ func DeleteSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType
 		return nil, grpcerrors.InvalidArgument(nil, "secret not found")
 	}
 
-	data, err := decryptSecretData(ctx, encryptor, *secret)
+	data, err := secrets.DecryptLocalData(ctx, encryptor, secret)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func DeleteSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType
 		return nil, grpcerrors.InvalidArgument(nil, "secret must have at least one key")
 	}
 
-	encrypted, err := encryptSecretData(ctx, encryptor, secret.Name, data)
+	encrypted, err := secrets.EncryptLocalData(ctx, encryptor, secret.ID, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/secrets/delete_secret_test.go
+++ b/pkg/grpc/actions/secrets/delete_secret_test.go
@@ -22,7 +22,7 @@ func Test__DeleteSecret(t *testing.T) {
 	local := map[string]string{"test": "test"}
 	data, _ := json.Marshal(local)
 
-	_, err := models.CreateSecret("test", secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, data)
+	_, err := models.CreateSecret(uuid.New(), "test", secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, data)
 	require.NoError(t, err)
 
 	t.Run("secret does not exist -> error", func(t *testing.T) {

--- a/pkg/grpc/actions/secrets/describe_secret.go
+++ b/pkg/grpc/actions/secrets/describe_secret.go
@@ -2,13 +2,13 @@ package secrets
 
 import (
 	"context"
-	"encoding/json"
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	"github.com/superplanehq/superplane/pkg/secrets"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -65,13 +65,7 @@ func serializeSecret(ctx context.Context, encryptor crypto.Encryptor, secret mod
 }
 
 func serializeLocalSecretData(ctx context.Context, encryptor crypto.Encryptor, secret models.Secret) (*pb.Secret_Local, error) {
-	data, err := encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
-	if err != nil {
-		return nil, err
-	}
-
-	var values map[string]string
-	err = json.Unmarshal(data, &values)
+	values, err := secrets.DecryptLocalData(ctx, encryptor, &secret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/secrets/describe_secret_test.go
+++ b/pkg/grpc/actions/secrets/describe_secret_test.go
@@ -33,7 +33,7 @@ func Test__DescribeSecret(t *testing.T) {
 		local := map[string]string{"test": "test"}
 		data, _ := json.Marshal(local)
 
-		_, err := models.CreateSecret("test", secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, data)
+		_, err := models.CreateSecret(uuid.New(), "test", secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, data)
 		require.NoError(t, err)
 
 		response, err := DescribeSecret(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), "test")

--- a/pkg/grpc/actions/secrets/list_secrets_test.go
+++ b/pkg/grpc/actions/secrets/list_secrets_test.go
@@ -30,7 +30,7 @@ func Test__ListSecrets(t *testing.T) {
 		local := map[string]string{"test": "test"}
 		data, _ := json.Marshal(local)
 
-		_, err := models.CreateSecret("test", secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, data)
+		_, err := models.CreateSecret(uuid.New(), "test", secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, data)
 		require.NoError(t, err)
 
 		response, err := ListSecrets(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String())

--- a/pkg/grpc/actions/secrets/set_secret_key.go
+++ b/pkg/grpc/actions/secrets/set_secret_key.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	"github.com/superplanehq/superplane/pkg/secrets"
 )
 
 func SetSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType, domainID, idOrName, keyName, value string) (*pb.SetSecretKeyResponse, error) {
@@ -27,7 +28,7 @@ func SetSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType, d
 		return nil, grpcerrors.InvalidArgument(nil, "secret not found")
 	}
 
-	data, err := decryptSecretData(ctx, encryptor, *secret)
+	data, err := secrets.DecryptLocalData(ctx, encryptor, secret)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +38,7 @@ func SetSecretKey(ctx context.Context, encryptor crypto.Encryptor, domainType, d
 	}
 	data[keyName] = value
 
-	encrypted, err := encryptSecretData(ctx, encryptor, secret.Name, data)
+	encrypted, err := secrets.EncryptLocalData(ctx, encryptor, secret.ID, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/secrets/update_secret.go
+++ b/pkg/grpc/actions/secrets/update_secret.go
@@ -40,7 +40,7 @@ func UpdateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType, d
 		return nil, grpcerrors.InvalidArgument(nil, "cannot update provider")
 	}
 
-	data, err := prepareSecretData(ctx, encryptor, spec)
+	data, err := prepareSecretData(ctx, encryptor, secret.ID, spec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/actions/secrets/update_secret_name.go
+++ b/pkg/grpc/actions/secrets/update_secret_name.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/errors"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/secrets"
+	"github.com/superplanehq/superplane/pkg/secrets"
 	"gorm.io/gorm"
 )
 
@@ -38,23 +39,15 @@ func UpdateSecretName(ctx context.Context, encryptor crypto.Encryptor, domainTyp
 		return &pb.UpdateSecretNameResponse{Secret: s}, nil
 	}
 
-	oldName := secret.Name
-	var reEncrypted []byte
-	if len(secret.Data) > 0 {
-		plainData, err := decryptSecretData(ctx, encryptor, models.Secret{Name: oldName, Data: secret.Data})
-		if err != nil {
-			return nil, grpcerrors.Internal(err, "failed to decrypt secret data for re-encryption")
-		}
-		reEncrypted, err = encryptSecretData(ctx, encryptor, name, plainData)
-		if err != nil {
-			return nil, grpcerrors.Internal(err, "failed to re-encrypt secret data with new name")
-		}
+	rebound, err := secrets.RebindLocalData(ctx, encryptor, secret)
+	if err != nil {
+		return nil, grpcerrors.Internal(err, "failed to bind secret data to the secret ID")
 	}
 
 	var updated *models.Secret
 	err = database.DB(ctx).Transaction(func(tx *gorm.DB) error {
 		var txErr error
-		updated, txErr = secret.UpdateNameAndData(tx, name, reEncrypted)
+		updated, txErr = secret.UpdateNameAndData(tx, name, rebound)
 		return txErr
 	})
 	if err != nil {

--- a/pkg/grpc/actions/secrets/update_secret_name_test.go
+++ b/pkg/grpc/actions/secrets/update_secret_name_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/crypto"
@@ -19,21 +20,50 @@ func Test__UpdateSecretName(t *testing.T) {
 	r := support.SetupWithOptions(t, support.SetupOptions{})
 	encryptor := crypto.NewAESGCMEncryptor([]byte("1234567890abcdefghijklmnopqrstuv"))
 
-	createEncryptedSecret := func(t *testing.T, name string, data map[string]string) {
+	createNameBoundSecret := func(t *testing.T, name string, data map[string]string) *models.Secret {
 		t.Helper()
 		raw, err := json.Marshal(data)
 		require.NoError(t, err)
 		encrypted, err := encryptor.Encrypt(context.Background(), raw, []byte(name))
 		require.NoError(t, err)
-		_, err = models.CreateSecret(name, secrets.ProviderLocal, r.User.String(), models.DomainTypeOrganization, r.Organization.ID, encrypted)
+		secret, err := models.CreateSecret(uuid.New(), name, secrets.ProviderLocal, r.User.String(), models.DomainTypeOrganization, r.Organization.ID, encrypted)
 		require.NoError(t, err)
+		return secret
 	}
 
-	t.Run("renamed secret data decrypts with new name", func(t *testing.T) {
+	createIDBoundSecret := func(t *testing.T, name string, data map[string]string) *models.Secret {
+		t.Helper()
+		secretID := uuid.New()
+		encrypted, err := secrets.EncryptLocalData(context.Background(), encryptor, secretID, data)
+		require.NoError(t, err)
+		secret, err := models.CreateSecret(secretID, name, secrets.ProviderLocal, r.User.String(), models.DomainTypeOrganization, r.Organization.ID, encrypted)
+		require.NoError(t, err)
+		return secret
+	}
+
+	t.Run("renaming an ID-bound secret leaves the stored payload untouched", func(t *testing.T) {
 		oldName := support.RandomName("secret")
 		newName := support.RandomName("secret-renamed")
 		plainData := map[string]string{"key": "value"}
-		createEncryptedSecret(t, oldName, plainData)
+		before := createIDBoundSecret(t, oldName, plainData)
+
+		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), oldName, newName)
+		require.NoError(t, err)
+
+		after, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, newName)
+		require.NoError(t, err)
+		assert.Equal(t, before.Data, after.Data)
+
+		decrypted, err := secrets.DecryptLocalData(context.Background(), encryptor, after)
+		require.NoError(t, err)
+		assert.Equal(t, plainData, decrypted)
+	})
+
+	t.Run("renaming a name-bound secret rebinds the payload to the ID", func(t *testing.T) {
+		oldName := support.RandomName("secret")
+		newName := support.RandomName("secret-renamed")
+		plainData := map[string]string{"key": "value"}
+		before := createNameBoundSecret(t, oldName, plainData)
 
 		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), oldName, newName)
 		require.NoError(t, err)
@@ -41,8 +71,9 @@ func Test__UpdateSecretName(t *testing.T) {
 		secret, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, newName)
 		require.NoError(t, err)
 		assert.Equal(t, newName, secret.Name)
+		assert.NotEqual(t, before.Data, secret.Data)
 
-		decrypted, err := decryptSecretData(context.Background(), encryptor, *secret)
+		decrypted, err := secrets.DecryptLocalData(context.Background(), encryptor, secret)
 		require.NoError(t, err)
 		assert.Equal(t, plainData, decrypted)
 	})
@@ -51,7 +82,7 @@ func Test__UpdateSecretName(t *testing.T) {
 		oldName := support.RandomName("secret")
 		newName := support.RandomName("secret-renamed")
 		plainData := map[string]string{"key": "value", "key2": "value2"}
-		createEncryptedSecret(t, oldName, plainData)
+		createNameBoundSecret(t, oldName, plainData)
 
 		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), oldName, newName)
 		require.NoError(t, err)
@@ -62,7 +93,7 @@ func Test__UpdateSecretName(t *testing.T) {
 		secret, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, newName)
 		require.NoError(t, err)
 
-		decrypted, err := decryptSecretData(context.Background(), encryptor, *secret)
+		decrypted, err := secrets.DecryptLocalData(context.Background(), encryptor, secret)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"key": "value"}, decrypted)
 	})
@@ -70,7 +101,7 @@ func Test__UpdateSecretName(t *testing.T) {
 	t.Run("same name is a no-op", func(t *testing.T) {
 		name := support.RandomName("secret")
 		plainData := map[string]string{"key": "value"}
-		createEncryptedSecret(t, name, plainData)
+		createNameBoundSecret(t, name, plainData)
 
 		_, err := UpdateSecretName(context.Background(), encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), name, name)
 		require.NoError(t, err)
@@ -78,7 +109,7 @@ func Test__UpdateSecretName(t *testing.T) {
 		secret, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, name)
 		require.NoError(t, err)
 
-		decrypted, err := decryptSecretData(context.Background(), encryptor, *secret)
+		decrypted, err := secrets.DecryptLocalData(context.Background(), encryptor, secret)
 		require.NoError(t, err)
 		assert.Equal(t, plainData, decrypted)
 	})
@@ -88,8 +119,8 @@ func Test__UpdateSecretName(t *testing.T) {
 		otherName := support.RandomName("secret")
 		existingData := map[string]string{"key": "existing"}
 		otherData := map[string]string{"key": "other"}
-		createEncryptedSecret(t, existingName, existingData)
-		createEncryptedSecret(t, otherName, otherData)
+		createNameBoundSecret(t, existingName, existingData)
+		createNameBoundSecret(t, otherName, otherData)
 
 		secretBefore, err := models.FindSecretByName(models.DomainTypeOrganization, r.Organization.ID, otherName)
 		require.NoError(t, err)
@@ -105,7 +136,7 @@ func Test__UpdateSecretName(t *testing.T) {
 		assert.Equal(t, secretBefore.Name, secretAfter.Name)
 		assert.Equal(t, secretBefore.Data, secretAfter.Data)
 
-		decrypted, err := decryptSecretData(context.Background(), encryptor, *secretAfter)
+		decrypted, err := secrets.DecryptLocalData(context.Background(), encryptor, secretAfter)
 		require.NoError(t, err)
 		assert.Equal(t, otherData, decrypted)
 	})

--- a/pkg/grpc/actions/secrets/update_secret_test.go
+++ b/pkg/grpc/actions/secrets/update_secret_test.go
@@ -24,7 +24,7 @@ func Test__UpdateSecret(t *testing.T) {
 	local := map[string]string{"test": "test"}
 	data, _ := json.Marshal(local)
 
-	_, err := models.CreateSecret("test", secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, data)
+	_, err := models.CreateSecret(uuid.New(), "test", secrets.ProviderLocal, uuid.NewString(), models.DomainTypeOrganization, r.Organization.ID, data)
 	require.NoError(t, err)
 
 	t.Run("secret does not exist -> error", func(t *testing.T) {

--- a/pkg/models/constants.go
+++ b/pkg/models/constants.go
@@ -34,6 +34,7 @@ const (
 var (
 	ErrNameAlreadyUsed         = fmt.Errorf("name already used")
 	ErrInvitationAlreadyExists = fmt.Errorf("invitation already exists")
+	ErrSecretIDRequired        = fmt.Errorf("secret ID is required")
 )
 
 func ValidateDomainType(domainType string) error {

--- a/pkg/models/secret.go
+++ b/pkg/models/secret.go
@@ -122,10 +122,17 @@ func FindSecretByIDInTransaction(tx *gorm.DB, domainType string, domainID uuid.U
 	return &secret, nil
 }
 
-func CreateSecret(name, provider, requesterID, domainType string, domainID uuid.UUID, data []byte) (*Secret, error) {
+// CreateSecret takes the ID because local secret payloads are encrypted under it,
+// so the caller has to know the ID before it can build the data to store.
+func CreateSecret(id uuid.UUID, name, provider, requesterID, domainType string, domainID uuid.UUID, data []byte) (*Secret, error) {
+	if id == uuid.Nil {
+		return nil, ErrSecretIDRequired
+	}
+
 	now := time.Now()
 
 	secret := Secret{
+		ID:         id,
 		Name:       name,
 		DomainType: domainType,
 		DomainID:   domainID,

--- a/pkg/secrets/local_crypto.go
+++ b/pkg/secrets/local_crypto.go
@@ -1,0 +1,82 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+//
+// Local secret payloads are bound to the secret ID, which never changes, so a
+// rename is a metadata-only update. Older rows are bound to the name the secret
+// had when the row was written. Those rows are rebound to the ID the next time
+// the payload is written.
+//
+
+func associatedData(secretID uuid.UUID) []byte {
+	return []byte(secretID.String())
+}
+
+func EncryptLocalData(ctx context.Context, encryptor crypto.Encryptor, secretID uuid.UUID, values map[string]string) ([]byte, error) {
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+
+	return encryptor.Encrypt(ctx, raw, associatedData(secretID))
+}
+
+func DecryptLocalPayload(ctx context.Context, encryptor crypto.Encryptor, secret *models.Secret) ([]byte, error) {
+	payload, err := encryptor.Decrypt(ctx, secret.Data, associatedData(secret.ID))
+	if err == nil {
+		return payload, nil
+	}
+
+	payload, legacyErr := encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
+	if legacyErr != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}
+
+func DecryptLocalData(ctx context.Context, encryptor crypto.Encryptor, secret *models.Secret) (map[string]string, error) {
+	payload, err := DecryptLocalPayload(ctx, encryptor, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(payload) == 0 {
+		return map[string]string{}, nil
+	}
+
+	var values map[string]string
+	if err := json.Unmarshal(payload, &values); err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
+// RebindLocalData returns the payload re-encrypted under the secret ID, or nil when
+// the payload is already bound to it. Callers that rename a secret need this because
+// the name a legacy payload is bound to is gone once the rename lands.
+func RebindLocalData(ctx context.Context, encryptor crypto.Encryptor, secret *models.Secret) ([]byte, error) {
+	if len(secret.Data) == 0 {
+		return nil, nil
+	}
+
+	if _, err := encryptor.Decrypt(ctx, secret.Data, associatedData(secret.ID)); err == nil {
+		return nil, nil
+	}
+
+	payload, err := encryptor.Decrypt(ctx, secret.Data, []byte(secret.Name))
+	if err != nil {
+		return nil, err
+	}
+
+	return encryptor.Encrypt(ctx, payload, associatedData(secret.ID))
+}

--- a/pkg/secrets/local_crypto_test.go
+++ b/pkg/secrets/local_crypto_test.go
@@ -1,0 +1,130 @@
+package secrets
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func testEncryptor(t *testing.T) crypto.Encryptor {
+	t.Helper()
+
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+
+	return crypto.NewAESGCMEncryptor(key)
+}
+
+func nameBoundSecret(t *testing.T, encryptor crypto.Encryptor, name string, values map[string]string) *models.Secret {
+	t.Helper()
+
+	raw, err := json.Marshal(values)
+	require.NoError(t, err)
+
+	data, err := encryptor.Encrypt(context.Background(), raw, []byte(name))
+	require.NoError(t, err)
+
+	return &models.Secret{ID: uuid.New(), Name: name, Data: data}
+}
+
+func Test__LocalCrypto(t *testing.T) {
+	ctx := context.Background()
+	values := map[string]string{"username": "admin", "password": "s3cret"}
+
+	t.Run("payload written under the ID reads back", func(t *testing.T) {
+		encryptor := testEncryptor(t)
+		secret := &models.Secret{ID: uuid.New(), Name: "creds"}
+
+		data, err := EncryptLocalData(ctx, encryptor, secret.ID, values)
+		require.NoError(t, err)
+		secret.Data = data
+
+		got, err := DecryptLocalData(ctx, encryptor, secret)
+		require.NoError(t, err)
+		require.Equal(t, values, got)
+	})
+
+	t.Run("renaming does not require re-encryption", func(t *testing.T) {
+		encryptor := testEncryptor(t)
+		secret := &models.Secret{ID: uuid.New(), Name: "creds"}
+
+		data, err := EncryptLocalData(ctx, encryptor, secret.ID, values)
+		require.NoError(t, err)
+		secret.Data = data
+
+		secret.Name = "renamed-creds"
+
+		got, err := DecryptLocalData(ctx, encryptor, secret)
+		require.NoError(t, err)
+		require.Equal(t, values, got)
+	})
+
+	t.Run("payload written under the name still reads back", func(t *testing.T) {
+		encryptor := testEncryptor(t)
+		secret := nameBoundSecret(t, encryptor, "legacy-creds", values)
+
+		got, err := DecryptLocalData(ctx, encryptor, secret)
+		require.NoError(t, err)
+		require.Equal(t, values, got)
+	})
+
+	t.Run("payload bound to neither the ID nor the name fails", func(t *testing.T) {
+		encryptor := testEncryptor(t)
+		secret := nameBoundSecret(t, encryptor, "legacy-creds", values)
+		secret.Name = "some-other-name"
+
+		_, err := DecryptLocalData(ctx, encryptor, secret)
+		require.Error(t, err)
+	})
+
+	t.Run("empty payload reads back as an empty map", func(t *testing.T) {
+		got, err := DecryptLocalData(ctx, crypto.NewNoOpEncryptor(), &models.Secret{ID: uuid.New(), Name: "empty"})
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("rebinding leaves an ID-bound payload alone", func(t *testing.T) {
+		encryptor := testEncryptor(t)
+		secret := &models.Secret{ID: uuid.New(), Name: "creds"}
+
+		data, err := EncryptLocalData(ctx, encryptor, secret.ID, values)
+		require.NoError(t, err)
+		secret.Data = data
+
+		rebound, err := RebindLocalData(ctx, encryptor, secret)
+		require.NoError(t, err)
+		require.Nil(t, rebound)
+	})
+
+	t.Run("rebinding a name-bound payload survives the rename", func(t *testing.T) {
+		encryptor := testEncryptor(t)
+		secret := nameBoundSecret(t, encryptor, "legacy-creds", values)
+
+		rebound, err := RebindLocalData(ctx, encryptor, secret)
+		require.NoError(t, err)
+		require.NotNil(t, rebound)
+
+		secret.Data = rebound
+		secret.Name = "renamed-creds"
+
+		got, err := DecryptLocalData(ctx, encryptor, secret)
+		require.NoError(t, err)
+		require.Equal(t, values, got)
+	})
+
+	t.Run("rebinding a payload bound to neither fails", func(t *testing.T) {
+		encryptor := testEncryptor(t)
+		secret := nameBoundSecret(t, encryptor, "legacy-creds", values)
+		secret.Name = "some-other-name"
+
+		_, err := RebindLocalData(ctx, encryptor, secret)
+		require.Error(t, err)
+	})
+}

--- a/pkg/secrets/local_provider.go
+++ b/pkg/secrets/local_provider.go
@@ -26,7 +26,7 @@ func NewLocalProvider(tx *gorm.DB, encryptor crypto.Encryptor, record *models.Se
 
 func (p *LocalProvider) Load(ctx context.Context) (map[string]string, error) {
 	name := p.record.Name
-	decrypted, err := p.encryptor.Decrypt(ctx, p.record.Data, []byte(name))
+	decrypted, err := DecryptLocalPayload(ctx, p.encryptor, p.record)
 	if err != nil {
 		return nil, fmt.Errorf("error decrypting secret %s: %v", name, err)
 	}

--- a/pkg/workers/contexts/secrets_context.go
+++ b/pkg/workers/contexts/secrets_context.go
@@ -2,7 +2,6 @@ package contexts
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
+	"github.com/superplanehq/superplane/pkg/secrets"
 	"gorm.io/gorm"
 )
 
@@ -125,17 +125,5 @@ func (c *SecretsContext) GetIntegrationKeys(integrationName string) (map[string]
 }
 
 func (c *SecretsContext) decryptSecretData(secret *models.Secret) (map[string]string, error) {
-	plain, err := c.encryptor.Decrypt(context.Background(), secret.Data, []byte(secret.Name))
-	if err != nil {
-		return nil, err
-	}
-
-	var data map[string]string
-	if len(plain) == 0 {
-		return make(map[string]string), nil
-	}
-	if err := json.Unmarshal(plain, &data); err != nil {
-		return nil, err
-	}
-	return data, nil
+	return secrets.DecryptLocalData(context.Background(), c.encryptor, secret)
 }

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -2,10 +2,10 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	pw "github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/crypto"
@@ -297,11 +297,7 @@ func (s *SecretsSteps) assertSecretSavedInDB(name string, expectedData map[strin
 	require.Equal(s.t, s.session.OrgID.String(), secret.DomainID.String())
 
 	// Secrets created via UI are encrypted; decrypt before comparing
-	encryptor := encryptorFromEnv()
-	decrypted, err := encryptor.Decrypt(context.Background(), secret.Data, []byte(secret.Name))
-	require.NoError(s.t, err)
-	var secretData map[string]string
-	err = json.Unmarshal(decrypted, &secretData)
+	secretData, err := secrets.DecryptLocalData(context.Background(), encryptorFromEnv(), secret)
 	require.NoError(s.t, err)
 	require.Equal(s.t, expectedData, secretData)
 }
@@ -343,12 +339,10 @@ func encryptorFromEnv() crypto.Encryptor {
 // givenASecretExists creates a secret directly in the DB (same format as app), then opens the secret detail page.
 // Call after visitSecretsPage(); leaves the user on the secret detail page.
 func (s *SecretsSteps) givenASecretExists(name string, data map[string]string) {
-	encryptor := encryptorFromEnv()
-	raw, err := json.Marshal(data)
+	secretID := uuid.New()
+	encrypted, err := secrets.EncryptLocalData(context.Background(), encryptorFromEnv(), secretID, data)
 	require.NoError(s.t, err)
-	encrypted, err := encryptor.Encrypt(context.Background(), raw, []byte(name))
-	require.NoError(s.t, err)
-	_, err = models.CreateSecret(name, secrets.ProviderLocal, s.session.Account.ID.String(), models.DomainTypeOrganization, s.session.OrgID, encrypted)
+	_, err = models.CreateSecret(secretID, name, secrets.ProviderLocal, s.session.Account.ID.String(), models.DomainTypeOrganization, s.session.OrgID, encrypted)
 	require.NoError(s.t, err)
 	s.clickEditSecret(name)
 }

--- a/test/e2e/ssh_line_endings_test.go
+++ b/test/e2e/ssh_line_endings_test.go
@@ -15,6 +15,7 @@ import (
 	pwssh "golang.org/x/crypto/ssh"
 	"gorm.io/datatypes"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
 	gitstorage "github.com/superplanehq/superplane/pkg/git"
@@ -129,6 +130,7 @@ func (s *sshLineEndingsSteps) createPasswordSecret() {
 	require.NoError(s.t, err)
 
 	_, err = models.CreateSecret(
+		uuid.New(),
 		sshLineEndingSecretName,
 		secrets.ProviderLocal,
 		s.session.Account.ID.String(),

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -151,7 +151,7 @@ func SetupWithOptions(t require.TestingT, options SetupOptions) *ResourceRegistr
 func CreateSecret(t *testing.T, r *ResourceRegistry, secretData map[string]string) (*models.Secret, error) {
 	data, err := json.Marshal(secretData)
 	require.NoError(t, err)
-	secret, err := models.CreateSecret(RandomName("secret"), secrets.ProviderLocal, r.User.String(), models.DomainTypeOrganization, r.Organization.ID, data)
+	secret, err := models.CreateSecret(uuid.New(), RandomName("secret"), secrets.ProviderLocal, r.User.String(), models.DomainTypeOrganization, r.Organization.ID, data)
 	require.NoError(t, err)
 	return secret, nil
 }


### PR DESCRIPTION
Fixes #5884

## Summary

Local secrets used the secret name as AES-GCM associated data. The name is
user-changeable, so a rename had to re-encrypt the stored payload to keep the
associated data in sync with the row. That coupling caused #5877, an HTTP 500
after a rename and a key delete. Integration secrets and webhooks already bind
their ciphertext to a stable identifier.

Local secret payloads are now bound to the secret ID, which never changes.

- `pkg/secrets/local_crypto.go` holds the associated-data choice and the
  encrypt and decrypt helpers. All eight read and write paths use it, so the
  choice is in one place.
- Reads accept rows written under the old scheme. The helper tries the ID
  first, then the name.
- Writes that touch the payload store it under the ID, so rows move over as
  they are used.
- `models.CreateSecret` takes the secret ID. The payload is encrypted under
  the ID, so the caller must know the ID before it builds the data. The
  function rejects a nil ID, because an ID in the associated data that does
  not match the ID in the row makes the payload permanently unreadable.

The change also removes four copies of the decrypt-and-unmarshal step, in
`pkg/grpc/actions/secrets`, `pkg/workers/contexts`, and `pkg/secrets`.

## Two points where this differs from the issue

The issue proposes to centralize the choice in `encryptSecretData` and
`decryptSecretData` in `pkg/grpc/actions/secrets`. Those functions are not
reachable from `pkg/workers/contexts` and `pkg/secrets`, which also decrypt
local payloads. The helpers are in `pkg/secrets` for that reason.

The issue also proposes to remove the re-encryption in `UpdateSecretName`.
A plain removal loses data. The read fallback uses the current name, so a
name-bound row that is renamed becomes unreadable. `UpdateSecretName` now
rebinds a name-bound payload to the ID once, and leaves an ID-bound payload
untouched. After a backfill of the remaining name-bound rows, a rename
becomes a metadata-only update for every row and the rebind can go. The
backfill is not in this change.

## Test plan

- [x] `make test PKG_TEST_PACKAGES=./pkg/secrets`. New cases cover the
      round trip under the ID, a rename with no re-encryption, a legacy
      name-bound row, a payload bound to neither the ID nor the name, and
      both rebind outcomes.
- [x] `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/secrets`. New cases in
      `update_secret_name_test.go` assert that a rename leaves an ID-bound
      payload byte-identical, and that a rename rewrites a name-bound payload
      and the result still decrypts.
- [x] `make format.go`
- [x] `make lint`
- [x] `make check.build.app`
