### PR TITLE
fix: guard approval details when records metadata is missing

### DIFF
--- a/web_src/src/pages/app/mappers/approval.spec.ts
+++ b/web_src/src/pages/app/mappers/approval.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { approvalMapper } from "./approval";
-import type { ExecutionInfo, SubtitleContext } from "./types";
+import type { ExecutionDetailsContext, ExecutionInfo, SubtitleContext } from "./types";
 
 const DEFAULT_NODE = { id: "n1", name: "Approval Node", componentName: "approval", isCollapsed: false };
 
@@ -23,6 +23,10 @@ function makeExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
 
 function makeSubtitleContext(execution: ExecutionInfo): SubtitleContext {
   return { node: DEFAULT_NODE, execution };
+}
+
+function makeExecutionDetailsContext(execution: ExecutionInfo): ExecutionDetailsContext {
+  return { execution };
 }
 
 describe("approvalMapper.subtitle", () => {
@@ -50,5 +54,24 @@ describe("approvalMapper.subtitle", () => {
     );
 
     expect(approvalMapper.subtitle(ctx)).toBe("1/1 approved");
+  });
+});
+
+describe("approvalMapper.getExecutionDetails", () => {
+  it("does not throw when metadata exists but records is missing", () => {
+    const ctx = makeExecutionDetailsContext(
+      makeExecution({
+        createdAt: "2026-08-24T10:00:00.000Z",
+        updatedAt: "2026-08-24T10:05:00.000Z",
+        metadata: { result: "approved" },
+      }),
+    );
+
+    expect(() => approvalMapper.getExecutionDetails(ctx)).not.toThrow();
+    expect(approvalMapper.getExecutionDetails(ctx)).toMatchObject({
+      "Started at": expect.any(String),
+      "Finished at": expect.any(String),
+    });
+    expect(approvalMapper.getExecutionDetails(ctx)["State"]).toBeUndefined();
   });
 });

--- a/web_src/src/pages/app/mappers/approval.ts
+++ b/web_src/src/pages/app/mappers/approval.ts
@@ -184,11 +184,11 @@ export const approvalMapper: ComponentBaseMapper = {
       details["Finished at"] = new Date(context.execution.updatedAt).toLocaleString();
     }
 
-    if (!metadata) {
+    if (!metadata?.records) {
       return details;
     }
 
-    return withApprovals(details, metadata!);
+    return withApprovals(details, metadata);
   },
 };
 


### PR DESCRIPTION
**What changed**
This PR guards the approval mapper when execution metadata exists but _`records`_ is missing.

**Why**
Approval execution metadata can be partially incomplete, and the UI should still show basic execution details instead of crashing.

**How**
- return base execution details when _`metadata.records`_ is missing
- add a focused regression _test for that edge case_