### PR TITLE
fix: Route factory false forks into left handles

### DIFF
--- a/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
@@ -10,6 +10,8 @@ import { FACTORY_HANDLE_STYLE, factoryCanvasBackground, factoryEdgePalette } fro
 import { FACTORY_SIDE_HANDLE_ID, FACTORY_SPINE_HANDLE_ID } from "@/lib/layout/factoryRunLeafLayout";
 import { cn } from "@/lib/utils";
 import { Link } from "@/components/Link/link";
+import { FACTORY_HANDLE_OUTSET_PX } from "@/ui/CanvasPage/Block/handleStyle";
+import { CustomEdge } from "@/ui/CanvasPage/CustomEdge";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { FactoryNodeCardShell } from "@/ui/factoryNodeChrome/FactoryNodeCardShell";
 
@@ -17,10 +19,40 @@ import { COMPACT_CANVAS_FIT_SETTLE_MS, compactCanvasFitKey, shouldFitCompactCanv
 import { compactLineCanvasGraph, type LineNodeData } from "./compactLineCanvasGraph";
 import type { SplitRunCanvasModel } from "./splitRunCanvases";
 
+function LineCanvasTargetHandle({ isSideTarget }: { isSideTarget: boolean }) {
+  if (isSideTarget) {
+    return (
+      <Handle
+        type="target"
+        position={Position.Left}
+        style={{
+          ...FACTORY_HANDLE_STYLE,
+          left: -FACTORY_HANDLE_OUTSET_PX,
+          top: "50%",
+          transform: "translateY(-50%)",
+        }}
+      />
+    );
+  }
+
+  return (
+    <Handle
+      type="target"
+      position={Position.Top}
+      style={{
+        ...FACTORY_HANDLE_STYLE,
+        left: "50%",
+        top: -FACTORY_HANDLE_OUTSET_PX,
+        transform: "translateX(-50%)",
+      }}
+    />
+  );
+}
+
 function LineCanvasNode({ data }: NodeProps<Node<LineNodeData>>) {
   return (
     <div
-      className={cn("relative rounded-2xl", data.isSelected && "z-10")}
+      className={cn("relative overflow-visible rounded-2xl", data.isSelected && "z-10")}
       data-testid={`split-run-canvas-node-${data.nodeId}`}
       data-selected={data.isSelected ? "true" : undefined}
       aria-selected={data.isSelected}
@@ -28,13 +60,12 @@ function LineCanvasNode({ data }: NodeProps<Node<LineNodeData>>) {
     >
       <div
         className={cn(
-          "rounded-2xl",
+          "relative overflow-visible rounded-2xl",
           data.isSelected &&
             "ring-2 ring-[color:var(--status-running-dot)] ring-offset-2 ring-offset-[color:var(--status-running-bg)]",
         )}
       >
-        <Handle type="target" position={Position.Top} style={FACTORY_HANDLE_STYLE} />
-        <Handle type="target" position={Position.Left} style={FACTORY_HANDLE_STYLE} />
+        <LineCanvasTargetHandle isSideTarget={data.isSideTarget} />
         <FactoryNodeCardShell
           title={data.title}
           subtitle={data.subtitle}
@@ -43,14 +74,35 @@ function LineCanvasNode({ data }: NodeProps<Node<LineNodeData>>) {
           metrics={data.metrics}
           selected={data.isSelected}
         />
-        <Handle id={FACTORY_SPINE_HANDLE_ID} type="source" position={Position.Bottom} style={FACTORY_HANDLE_STYLE} />
-        <Handle id={FACTORY_SIDE_HANDLE_ID} type="source" position={Position.Right} style={FACTORY_HANDLE_STYLE} />
+        <Handle
+          id={FACTORY_SPINE_HANDLE_ID}
+          type="source"
+          position={Position.Bottom}
+          style={{
+            ...FACTORY_HANDLE_STYLE,
+            left: "50%",
+            bottom: -FACTORY_HANDLE_OUTSET_PX,
+            transform: "translateX(-50%)",
+          }}
+        />
+        <Handle
+          id={FACTORY_SIDE_HANDLE_ID}
+          type="source"
+          position={Position.Right}
+          style={{
+            ...FACTORY_HANDLE_STYLE,
+            right: -FACTORY_HANDLE_OUTSET_PX,
+            top: "50%",
+            transform: "translateY(-50%)",
+          }}
+        />
       </div>
     </div>
   );
 }
 
 const nodeTypes = { lineCanvas: LineCanvasNode };
+const edgeTypes = { custom: CustomEdge };
 
 const COMPACT_FIT_VIEW_OPTIONS = { padding: 0.2 } as const;
 
@@ -151,6 +203,7 @@ export function CompactLineCanvas({
           nodes={nodes}
           edges={edges.map((edge) => ({ ...edge, style: { ...palette.default, ...edge.style } }))}
           nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
           fitView
           fitViewOptions={COMPACT_FIT_VIEW_OPTIONS}
           minZoom={0.1}
@@ -164,7 +217,7 @@ export function CompactLineCanvas({
           onPaneClick={() => onSelect(null)}
           proOptions={{ hideAttribution: true }}
           colorMode={isDark ? "dark" : "light"}
-          defaultEdgeOptions={{ type: "smoothstep", style: palette.default }}
+          defaultEdgeOptions={{ type: "custom", style: palette.default }}
         >
           <FitCompactCanvas contentKey={contentKey} />
           <Background

--- a/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.spec.ts
@@ -1,9 +1,15 @@
+import { Position, type Edge } from "@xyflow/react";
 import { describe, expect, it } from "vitest";
 
 import { FACTORY_SIDE_HANDLE_ID, FACTORY_SPINE_HANDLE_ID } from "@/lib/layout/factoryRunLeafLayout";
 
 import { compactLineCanvasGraph } from "./compactLineCanvasGraph";
 import type { SplitRunCanvasModel } from "./splitRunCanvases";
+
+type RoutedEdge = Edge & {
+  sourcePosition?: Position;
+  targetPosition?: Position;
+};
 
 function messyIfCanvas(): SplitRunCanvasModel {
   return {
@@ -48,7 +54,7 @@ function messyIfCanvas(): SplitRunCanvasModel {
 }
 
 describe("compactLineCanvasGraph", () => {
-  it("lays out the factory spine like the main run canvas, not saved YAML coords", () => {
+  it("lays out the factory spine like the main run canvas and badges channel names", () => {
     const { nodes, edges } = compactLineCanvasGraph(messyIfCanvas(), null, undefined, false);
     const byId = new Map(nodes.map((node) => [node.id, node]));
 
@@ -69,11 +75,20 @@ describe("compactLineCanvasGraph", () => {
     expect(trueAgent.position.y).toBeGreaterThan(label.position.y);
     expect(artifact.position.x).not.toBe(-40);
     expect(falseAgent.position.x).toBeGreaterThan(ifNode.position.x);
+    expect(falseAgent.position.y).toBe(ifNode.position.y);
+    expect(falseAgent.data.isSideTarget).toBe(true);
 
     const trueEdge = edges.find((edge) => edge.source === "if" && edge.target === "comment");
-    const falseEdge = edges.find((edge) => edge.source === "if" && edge.target === "false-agent");
+    const falseEdge = edges.find((edge) => edge.source === "if" && edge.target === "false-agent") as
+      | RoutedEdge
+      | undefined;
+    const mergeEdge = edges.find((edge) => edge.source === "false-agent" && edge.target === "true-agent");
     expect(trueEdge?.sourceHandle).toBe(FACTORY_SPINE_HANDLE_ID);
     expect(falseEdge?.sourceHandle).toBe(FACTORY_SIDE_HANDLE_ID);
-    expect(falseEdge?.label).toBe("false");
+    expect(falseEdge?.sourcePosition).toBe(Position.Right);
+    expect(falseEdge?.targetPosition).toBe(Position.Left);
+    expect(falseEdge?.data).toMatchObject({ channelLabel: "false" });
+    expect(mergeEdge?.data).toMatchObject({ channelLabel: "passed" });
+    expect(trueEdge?.type).toBe("custom");
   });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.ts
@@ -4,9 +4,9 @@ import type { ComponentsEdge, SuperplaneComponentsNode as ComponentsNode } from 
 import { FACTORY_NODE_CARD_HEIGHT, FACTORY_NODE_CARD_WIDTH } from "@/lib/factoryCanvasChrome";
 import { layoutFactoryRunLeafGraph } from "@/lib/layout/factoryRunLeafLayout";
 import { buildStyledCanvasEdges } from "@/ui/CanvasPage/factoryCanvasEdgeStyle";
+import type { FactoryNodeStatus } from "@/ui/factoryNodeChrome/types";
 
 import { componentPresentation, type SplitRunCanvasModel } from "./splitRunCanvases";
-import type { FactoryNodeStatus } from "@/ui/factoryNodeChrome/types";
 
 export type LineNodeData = {
   title: string;
@@ -35,8 +35,7 @@ function toFlowEdge(edge: ComponentsEdge, index: number): Edge {
     source: edge.sourceId ?? "",
     target: edge.targetId ?? "",
     sourceHandle: channel,
-    type: "smoothstep",
-    label: channel === "default" ? undefined : channel,
+    type: "custom",
   };
 }
 
@@ -106,7 +105,7 @@ export function compactLineCanvasGraph(
       nodes,
       isVerticalFlow: true,
       resolvedThemeIsDark,
-      edgeDefaults: { type: "smoothstep", style: { stroke: "#cbd5e1", strokeWidth: 1.5 } },
+      edgeDefaults: { type: "custom", style: { stroke: "#cbd5e1", strokeWidth: 1.5 } },
       hoveredEdgeId: null,
       isEditMode: false,
       isReadOnly: true,


### PR DESCRIPTION
## Summary

The factory split-run canvas drew the `false` branch from If up and over the next node.
That path looked wrong because the side node already sits on the same row.
This change attaches that branch to the left handle of the side node.

## Test plan

- [ ] Open a work order split-run popup with an If node that has a `false` branch.
- [ ] Confirm the `false` edge leaves the right of If and enters the left of the side node.
- [ ] Confirm the `true` spine still goes down from the bottom of If.
- [ ] Confirm channel labels still show on the paths.


Made with [Cursor](https://cursor.com)