### PR TITLE
fix: Forward the gated event from the Time Gate

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -1691,6 +1691,7 @@ The Time Gate component delays event processing until the next valid day and tim
 ### Behavior
 
 - Events wait until the next valid time window is reached
+- The gate forwards the event that it held, so downstream nodes receive the original payload
 - Exclude dates override the day/time rules
 - Can be manually pushed through using the "Push Through" action
 - Automatically schedules execution when the time window is reached

--- a/pkg/components/timegate/time_gate.go
+++ b/pkg/components/timegate/time_gate.go
@@ -21,7 +21,12 @@ func init() {
 type TimeGate struct{}
 
 type Metadata struct {
-	NextValidTime   *string    `json:"nextValidTime"`
+	NextValidTime *string `json:"nextValidTime"`
+
+	// Data holds the event the gate is waiting on. Hooks that finish the
+	// execution run without an ExecutionContext, so the payload has to survive
+	// in metadata to be forwarded once the window opens.
+	Data            any        `json:"data,omitempty"`
 	PushedThroughBy *core.User `json:"pushedThroughBy,omitempty"`
 	PushedThroughAt *string    `json:"pushedThroughAt,omitempty"`
 }
@@ -65,6 +70,7 @@ func (tg *TimeGate) Documentation() string {
 ## Behavior
 
 - Events wait until the next valid time window is reached
+- The gate forwards the event that it held, so downstream nodes receive the original payload
 - Exclude dates override the day/time rules
 - Can be manually pushed through using the "Push Through" action
 - Automatically schedules execution when the time window is reached`
@@ -190,6 +196,7 @@ func (tg *TimeGate) Execute(ctx core.ExecutionContext) error {
 	formatted := nextValidTime.Format(time.RFC3339)
 	return ctx.Metadata.Set(Metadata{
 		NextValidTime: &formatted,
+		Data:          ctx.Data,
 	})
 }
 
@@ -263,10 +270,15 @@ func (tg *TimeGate) HandleTimeReached(ctx core.ActionHookContext) error {
 		return nil
 	}
 
+	var metadata Metadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to parse metadata: %w", err)
+	}
+
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"timegate.finished",
-		[]any{map[string]any{}},
+		[]any{gatedData(metadata)},
 	)
 }
 
@@ -293,8 +305,18 @@ func (tg *TimeGate) HandlePushThrough(ctx core.ActionHookContext) error {
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"timegate.finished",
-		[]any{map[string]any{}},
+		[]any{gatedData(metadata)},
 	)
+}
+
+// gatedData returns the event the gate held. Executions that finish without
+// ever storing a payload fall back to an empty object.
+func gatedData(metadata Metadata) any {
+	if metadata.Data == nil {
+		return map[string]any{}
+	}
+
+	return metadata.Data
 }
 
 func (tg *TimeGate) findNextValidTime(now time.Time, spec Spec, startMinutes int, endMinutes int) time.Time {

--- a/pkg/components/timegate/time_gate_test.go
+++ b/pkg/components/timegate/time_gate_test.go
@@ -1,6 +1,7 @@
 package timegate
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -187,4 +188,144 @@ func TestGetDayString(t *testing.T) {
 func timeOnDate(base time.Time, dayOffset int, hour int, minute int) time.Time {
 	date := base.AddDate(0, 0, dayOffset)
 	return time.Date(date.Year(), date.Month(), date.Day(), hour, minute, 0, 0, base.Location())
+}
+
+// deferringSpec builds a configuration whose only active day is tomorrow, so
+// the gate always defers regardless of the wall-clock time the test runs at.
+func deferringSpec(base time.Time) map[string]any {
+	return map[string]any{
+		"days":      []string{getDayString(base.AddDate(0, 0, 1).Weekday())},
+		"timeRange": "09:00-17:00",
+		"timezone":  "0",
+	}
+}
+
+func TestTimeGate_TimeReached_ForwardsGatedEvent(t *testing.T) {
+	tg := &TimeGate{}
+	data := map[string]any{"deployment": map[string]any{"sha": "abc123"}}
+
+	metadata := &contexts.MetadataContext{}
+	state := &contexts.ExecutionStateContext{}
+
+	err := tg.Execute(core.ExecutionContext{
+		Data:           data,
+		Configuration:  deferringSpec(time.Now().UTC()),
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	})
+	assert.NoError(t, err)
+	assert.False(t, state.Finished, "gate must defer, not emit immediately")
+
+	err = tg.HandleHook(core.ActionHookContext{
+		Name:           "timeReached",
+		ExecutionState: state,
+		Metadata:       metadata,
+	})
+	assert.NoError(t, err)
+	assert.True(t, state.Finished)
+	assert.Len(t, state.Payloads, 1)
+
+	payload := state.Payloads[0].(map[string]any)
+	assert.Equal(t, data, payload["data"])
+}
+
+func TestTimeGate_PushThrough_ForwardsGatedEvent(t *testing.T) {
+	tg := &TimeGate{}
+	data := map[string]any{"deployment": map[string]any{"sha": "abc123"}}
+
+	metadata := &contexts.MetadataContext{}
+	state := &contexts.ExecutionStateContext{}
+
+	err := tg.Execute(core.ExecutionContext{
+		Data:           data,
+		Configuration:  deferringSpec(time.Now().UTC()),
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	})
+	assert.NoError(t, err)
+	assert.False(t, state.Finished, "gate must defer, not emit immediately")
+
+	err = tg.HandleHook(core.ActionHookContext{
+		Name:           "pushThrough",
+		ExecutionState: state,
+		Metadata:       metadata,
+		Auth: &contexts.AuthContext{
+			User: &core.User{ID: "123", Name: "Test User", Email: "test@example.com"},
+		},
+	})
+	assert.NoError(t, err)
+	assert.True(t, state.Finished)
+	assert.Len(t, state.Payloads, 1)
+
+	payload := state.Payloads[0].(map[string]any)
+	assert.Equal(t, data, payload["data"])
+}
+
+// jsonMetadataContext mimics the production metadata context, which round-trips
+// metadata through JSON before handing it back to the component.
+type jsonMetadataContext struct {
+	stored map[string]any
+}
+
+func (m *jsonMetadataContext) Get() any {
+	return m.stored
+}
+
+func (m *jsonMetadataContext) Set(metadata any) error {
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(encoded, &m.stored)
+}
+
+func TestTimeGate_ForwardsGatedEventStoredAsJSON(t *testing.T) {
+	tg := &TimeGate{}
+	data := map[string]any{
+		"repository": "superplanehq/superplane",
+		"commits":    []any{map[string]any{"sha": "abc123"}},
+	}
+
+	metadata := &jsonMetadataContext{}
+	state := &contexts.ExecutionStateContext{}
+
+	err := tg.Execute(core.ExecutionContext{
+		Data:           data,
+		Configuration:  deferringSpec(time.Now().UTC()),
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: state,
+	})
+	assert.NoError(t, err)
+	assert.False(t, state.Finished, "gate must defer, not emit immediately")
+
+	err = tg.HandleHook(core.ActionHookContext{
+		Name:           "timeReached",
+		ExecutionState: state,
+		Metadata:       metadata,
+	})
+	assert.NoError(t, err)
+	assert.Len(t, state.Payloads, 1)
+
+	payload := state.Payloads[0].(map[string]any)
+	assert.Equal(t, data, payload["data"])
+}
+
+func TestTimeGate_EmitsEmptyObjectWhenNoEventStored(t *testing.T) {
+	tg := &TimeGate{}
+	state := &contexts.ExecutionStateContext{}
+
+	err := tg.HandleHook(core.ActionHookContext{
+		Name:           "timeReached",
+		ExecutionState: state,
+		Metadata:       &contexts.MetadataContext{},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, state.Payloads, 1)
+
+	payload := state.Payloads[0].(map[string]any)
+	assert.Equal(t, map[string]any{}, payload["data"])
 }


### PR DESCRIPTION
## Summary

The Time Gate drops the event payload whenever it actually gates.

The component emits from two paths:

- `Execute()` emits the incoming event when the current time is already inside the active window ([`time_gate.go#L176`](https://github.com/superplanehq/superplane/blob/main/pkg/components/timegate/time_gate.go#L176)).
- `HandleTimeReached` and `HandlePushThrough` emit when the gate waited. Hooks run with an `ActionHookContext`, which does not carry the event data, so both sent a literal `map[string]any{}`.

`ExecutionStateContext.Emit` writes that payload directly to the `data` field of the event that downstream nodes consume, and `PassInTransaction` adds no fallback. Downstream nodes therefore receive `{}`, and every expression that reads the gate output resolves to nothing.

The failure is silent and depends on timing. The same canvas keeps the payload when the run starts inside the window and drops it when the gate defers. Deferring is the normal case, so a "release at 09:00" gate loses the payload every day, while a manual test run during business hours looks correct.

This also contradicts the component documentation, which describes the gate as delaying event processing rather than replacing the event.

## Fix

Store the event in the execution metadata when the gate defers, then emit that event from both hooks. Executions that stored no event keep the previous empty object, so executions already in flight during a deploy stay valid.

The change stays inside the component. Adding `Data` to `core.ActionHookContext` would work too, but it touches the framework and the other hook-based components synthesize their own payloads on purpose.

## Test plan

- [x] `TestTimeGate_TimeReached_ForwardsGatedEvent` — the gate defers, then `timeReached` emits the original event. Fails on `main` with `data = {}`.
- [x] `TestTimeGate_PushThrough_ForwardsGatedEvent` — same for the manual push-through action.
- [x] `TestTimeGate_ForwardsGatedEventStoredAsJSON` — the payload survives the JSON round trip that `ExecutionMetadataContext` performs.
- [x] `TestTimeGate_EmitsEmptyObjectWhenNoEventStored` — executions with no stored event still emit `{}`.
- [x] The existing Time Gate tests pass unchanged.
- [x] `gofmt` and `go vet` are clean for the package.
- [x] `docs/components/Core.mdx` is updated for the new documentation line.

The new tests select tomorrow as the only active day, so the gate always defers and the tests do not depend on the wall-clock time at which CI runs them.
