### PR TITLE
fix: keep monthly schedules from skipping or overshooting months

### DIFF
--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -762,9 +762,22 @@ func nextMonthsTrigger(interval int, dayOfMonth int, hour int, minute int, now t
 	}
 
 	nowInTZ := now
-	nextTriggerMonths := interval
-	nextTrigger := nowInTZ.AddDate(0, nextTriggerMonths, 0)
-	nextTrigger = time.Date(nextTrigger.Year(), nextTrigger.Month(), dayOfMonth, hour, minute, 0, 0, nextTrigger.Location())
+
+	// Advance the month arithmetically: AddDate normalizes day overflow
+	// (Jan 31 + 1 month = Feb 31 -> Mar 3), which would land the trigger a
+	// month late whenever "now" falls on day 29-31.
+	totalMonths := int(nowInTZ.Month()) - 1 + interval
+	year := nowInTZ.Year() + totalMonths/12
+	month := time.Month(totalMonths%12 + 1)
+
+	// Clamp dayOfMonth to the target month's length, so 31 means the last
+	// day of shorter months instead of rolling into the next one.
+	day := dayOfMonth
+	if lastDay := time.Date(year, month+1, 0, 0, 0, 0, 0, nowInTZ.Location()).Day(); day > lastDay {
+		day = lastDay
+	}
+
+	nextTrigger := time.Date(year, month, day, hour, minute, 0, 0, nowInTZ.Location())
 
 	utcResult := nextTrigger.UTC()
 	return &utcResult, nil

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -74,6 +74,102 @@ func TestNextMinutesTrigger(t *testing.T) {
 	}
 }
 
+func TestNextMonthsTrigger(t *testing.T) {
+	tests := []struct {
+		name       string
+		interval   int
+		dayOfMonth int
+		now        string
+		expectNext string
+	}{
+		{
+			name:       "mid-month tick advances one month",
+			interval:   1,
+			dayOfMonth: 15,
+			now:        "2025-01-10T10:00:00Z",
+			expectNext: "2025-02-15T09:00:00Z",
+		},
+		{
+			name:       "tick on Jan 31 must not skip February",
+			interval:   1,
+			dayOfMonth: 15,
+			now:        "2025-01-31T10:00:00Z",
+			expectNext: "2025-02-15T09:00:00Z",
+		},
+		{
+			name:       "tick on Mar 30 must not skip April",
+			interval:   1,
+			dayOfMonth: 15,
+			now:        "2025-03-30T10:00:00Z",
+			expectNext: "2025-04-15T09:00:00Z",
+		},
+		{
+			name:       "dayOfMonth 31 clamps to Apr 30",
+			interval:   1,
+			dayOfMonth: 31,
+			now:        "2025-03-10T10:00:00Z",
+			expectNext: "2025-04-30T09:00:00Z",
+		},
+		{
+			name:       "dayOfMonth 31 clamps to Feb 28",
+			interval:   1,
+			dayOfMonth: 31,
+			now:        "2025-01-10T10:00:00Z",
+			expectNext: "2025-02-28T09:00:00Z",
+		},
+		{
+			name:       "dayOfMonth 30 clamps to Feb 28",
+			interval:   1,
+			dayOfMonth: 30,
+			now:        "2025-01-10T10:00:00Z",
+			expectNext: "2025-02-28T09:00:00Z",
+		},
+		{
+			name:       "dayOfMonth 31 clamps to Feb 29 on leap years",
+			interval:   1,
+			dayOfMonth: 31,
+			now:        "2024-01-10T10:00:00Z",
+			expectNext: "2024-02-29T09:00:00Z",
+		},
+		{
+			name:       "December wraps into the next year",
+			interval:   1,
+			dayOfMonth: 15,
+			now:        "2025-12-10T10:00:00Z",
+			expectNext: "2026-01-15T09:00:00Z",
+		},
+		{
+			name:       "multi-month interval crosses the year boundary",
+			interval:   6,
+			dayOfMonth: 31,
+			now:        "2025-11-10T10:00:00Z",
+			expectNext: "2026-05-31T09:00:00Z",
+		},
+		{
+			name:       "24 month interval",
+			interval:   24,
+			dayOfMonth: 15,
+			now:        "2025-01-31T10:00:00Z",
+			expectNext: "2027-01-15T09:00:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := nextMonthsTrigger(tt.interval, tt.dayOfMonth, 9, 0, mustParseTime(tt.now))
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if !result.Equal(mustParseTime(tt.expectNext)) {
+				t.Errorf("expected next trigger at %v, got %v", tt.expectNext, *result)
+			}
+		})
+	}
+}
+
 func TestGetNextTrigger(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -158,6 +254,30 @@ func TestGetNextTrigger(t *testing.T) {
 			},
 			now:        mustParseTime("2025-01-01T10:00:00Z"),
 			expectNext: mustParseTime("2025-02-15T14:30:00Z"),
+		},
+		{
+			name: "months configuration when now is on a day the next month does not have",
+			config: Configuration{
+				Type:           TypeMonths,
+				MonthsInterval: intPtr(1),
+				DayOfMonth:     intPtr(15),
+				Hour:           intPtr(14),
+				Minute:         intPtr(30),
+			},
+			now:        mustParseTime("2025-01-31T10:00:00Z"),
+			expectNext: mustParseTime("2025-02-15T14:30:00Z"),
+		},
+		{
+			name: "months configuration with dayOfMonth beyond the target month's length",
+			config: Configuration{
+				Type:           TypeMonths,
+				MonthsInterval: intPtr(1),
+				DayOfMonth:     intPtr(31),
+				Hour:           intPtr(14),
+				Minute:         intPtr(30),
+			},
+			now:        mustParseTime("2025-03-10T10:00:00Z"),
+			expectNext: mustParseTime("2025-04-30T14:30:00Z"),
 		},
 		{
 			name: "cron configuration",

--- a/web_src/src/pages/app/mappers/schedule.spec.ts
+++ b/web_src/src/pages/app/mappers/schedule.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { calculateNextTrigger } from "./schedule";
+
+// System time is set with a local-time Date and results are asserted on
+// local-time fields, so the tests are independent of the runner's timezone.
+function setNow(year: number, monthIndex: number, day: number, hour = 10) {
+  vi.setSystemTime(new Date(year, monthIndex, day, hour, 0, 0));
+}
+
+function localFields(date: Date | null) {
+  expect(date).not.toBeNull();
+  return {
+    year: date!.getFullYear(),
+    month: date!.getMonth(),
+    day: date!.getDate(),
+    hour: date!.getHours(),
+    minute: date!.getMinutes(),
+  };
+}
+
+describe("calculateNextTrigger months schedule", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const monthsConfig = (dayOfMonth: number, monthsInterval = 1) => ({
+    type: "months" as const,
+    monthsInterval,
+    dayOfMonth,
+    hour: 9,
+    minute: 0,
+  });
+
+  it("advances one month from a mid-month tick", () => {
+    setNow(2025, 0, 10); // Jan 10
+    const result = calculateNextTrigger(monthsConfig(15));
+    expect(localFields(result)).toEqual({ year: 2025, month: 1, day: 15, hour: 9, minute: 0 });
+  });
+
+  it("does not skip February when now is Jan 31", () => {
+    setNow(2025, 0, 31); // Jan 31: +1 month must be Feb 15, not Mar 15
+    const result = calculateNextTrigger(monthsConfig(15));
+    expect(localFields(result)).toEqual({ year: 2025, month: 1, day: 15, hour: 9, minute: 0 });
+  });
+
+  it("does not skip April when now is Mar 30", () => {
+    setNow(2025, 2, 30);
+    const result = calculateNextTrigger(monthsConfig(15));
+    expect(localFields(result)).toEqual({ year: 2025, month: 3, day: 15, hour: 9, minute: 0 });
+  });
+
+  it("clamps dayOfMonth 31 to Apr 30", () => {
+    setNow(2025, 2, 10); // Mar 10
+    const result = calculateNextTrigger(monthsConfig(31));
+    expect(localFields(result)).toEqual({ year: 2025, month: 3, day: 30, hour: 9, minute: 0 });
+  });
+
+  it("clamps dayOfMonth 31 to Feb 28", () => {
+    setNow(2025, 0, 10); // Jan 10
+    const result = calculateNextTrigger(monthsConfig(31));
+    expect(localFields(result)).toEqual({ year: 2025, month: 1, day: 28, hour: 9, minute: 0 });
+  });
+
+  it("clamps dayOfMonth 31 to Feb 29 on leap years", () => {
+    setNow(2024, 0, 10);
+    const result = calculateNextTrigger(monthsConfig(31));
+    expect(localFields(result)).toEqual({ year: 2024, month: 1, day: 29, hour: 9, minute: 0 });
+  });
+
+  it("wraps December into the next year", () => {
+    setNow(2025, 11, 10); // Dec 10
+    const result = calculateNextTrigger(monthsConfig(15));
+    expect(localFields(result)).toEqual({ year: 2026, month: 0, day: 15, hour: 9, minute: 0 });
+  });
+
+  it("crosses the year boundary on multi-month intervals", () => {
+    setNow(2025, 10, 10); // Nov 10, every 6 months
+    const result = calculateNextTrigger(monthsConfig(31, 6));
+    expect(localFields(result)).toEqual({ year: 2026, month: 4, day: 31, hour: 9, minute: 0 });
+  });
+});

--- a/web_src/src/pages/app/mappers/schedule.ts
+++ b/web_src/src/pages/app/mappers/schedule.ts
@@ -81,7 +81,7 @@ function formatScheduleDescription(configuration: ScheduleConfiguration): string
   }
 }
 
-function calculateNextTrigger(configuration: ScheduleConfiguration, referenceNextTrigger?: string): Date | null {
+export function calculateNextTrigger(configuration: ScheduleConfiguration, referenceNextTrigger?: string): Date | null {
   // Always use backend-calculated nextTrigger first if available
   if (referenceNextTrigger) {
     try {
@@ -244,10 +244,15 @@ function calculateNextTrigger(configuration: ScheduleConfiguration, referenceNex
 
       if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
 
-      // Match Go backend: add interval months in timezone, set day/hour/minute
+      // Match Go backend: advance the month arithmetically and clamp
+      // dayOfMonth to the target month's length. setMonth/setDate would roll
+      // day overflow into the following month.
       const nextTriggerInTZ = new Date(nowInTZ);
-      nextTriggerInTZ.setMonth(nextTriggerInTZ.getMonth() + interval);
-      nextTriggerInTZ.setDate(dayOfMonth);
+      const totalMonths = nextTriggerInTZ.getMonth() + interval;
+      const targetYear = nextTriggerInTZ.getFullYear() + Math.floor(totalMonths / 12);
+      const targetMonth = totalMonths % 12;
+      const lastDayOfTargetMonth = new Date(targetYear, targetMonth + 1, 0).getDate();
+      nextTriggerInTZ.setFullYear(targetYear, targetMonth, Math.min(dayOfMonth, lastDayOfTargetMonth));
       nextTriggerInTZ.setHours(hour);
       nextTriggerInTZ.setMinutes(minute);
       nextTriggerInTZ.setSeconds(0);


### PR DESCRIPTION
Fixes #6877

## What

Monthly schedules computed their next fire time with `now.AddDate(0, interval, 0)` followed by `time.Date(..., dayOfMonth, ...)`. Both steps normalize date overflow forward, producing two bugs:

1. **A tick on day 29–31 skips an entire month.** `AddDate` keeps the current day while adding months: Jan 31 + 1 month = Feb 31 → Mar 3, so a monthly schedule for the 15th fired **Mar 15 instead of Feb 15**. Since each tick recomputes from the previous fire time, one late-day fire shifts the schedule permanently.
2. **`dayOfMonth` beyond the target month's length rolls into the next month.** `dayOfMonth=31` (the natural "last day of the month") fired **May 1 instead of Apr 30**, and **Mar 3 instead of Feb 28**.

The frontend `calculateNextTrigger` (months case in `web_src/src/pages/app/mappers/schedule.ts`) mirrored both bugs through `setMonth`/`setDate` normalization, so the sidebar "Next:" preview showed the same wrong dates.

## How

- `nextMonthsTrigger` now advances the target month arithmetically (no day-based normalization) and clamps `dayOfMonth` to the target month's length, in the schedule's timezone.
- The frontend months case applies the identical arithmetic + clamp.
- New exact-date tests on both sides: `TestNextMonthsTrigger` (10 cases: skip-month, clamp to 30/28/29-day months, leap year, December→January wrap, multi-month intervals crossing year boundaries) plus two exact-date cases in the `TestGetNextTrigger` table, and an 8-case vitest spec for `calculateNextTrigger`. All of them fail against the previous implementation.

Existing months tests only asserted a mid-month happy path (or that *some* future time was returned), which is why both bugs survived.

## Verification

- `go test ./pkg/triggers/schedule/` — pass (and the new cases fail on the old code: Mar 15 vs Feb 15, May 1 vs Apr 30, Mar 3 vs Feb 28)
- `npx vitest run src/pages/app/mappers/schedule.spec.ts` — 8/8 pass (4 fail on the old code)
- `gofmt` / `go vet` clean; `prettier --check` clean; no new eslint findings (the file's pre-existing complexity warnings are unchanged)
