### PR TITLE
fix: emit poll-detected successful GitLab pipelines on the passed channel

### DIFF
--- a/pkg/integrations/gitlab/run_pipeline.go
+++ b/pkg/integrations/gitlab/run_pipeline.go
@@ -448,7 +448,7 @@ func (r *RunPipeline) poll(ctx core.ActionHookContext) error {
 	}
 
 	channel := PipelineFailedOutputChannel
-	if metadata.Pipeline != nil && metadata.Pipeline.Status == PipelineStatusSuccess {
+	if pipeline.Status == PipelineStatusSuccess {
 		channel = PipelinePassedOutputChannel
 	}
 

--- a/pkg/integrations/gitlab/run_pipeline_test.go
+++ b/pkg/integrations/gitlab/run_pipeline_test.go
@@ -225,3 +225,86 @@ func Test__RunPipeline__Poll__SchedulesNextWhenRunning(t *testing.T) {
 	assert.Equal(t, RunPipelinePollInterval, requestsCtx.Duration)
 	assert.Empty(t, executionState.Channel)
 }
+
+func Test__RunPipeline__Poll__FinishedPipeline(t *testing.T) {
+	tests := []struct {
+		name          string
+		status        string
+		expectChannel string
+	}{
+		{
+			name:          "successful pipeline emits on passed channel",
+			status:        "success",
+			expectChannel: PipelinePassedOutputChannel,
+		},
+		{
+			name:          "failed pipeline emits on failed channel",
+			status:        "failed",
+			expectChannel: PipelineFailedOutputChannel,
+		},
+		{
+			name:          "canceled pipeline emits on failed channel",
+			status:        "canceled",
+			expectChannel: PipelineFailedOutputChannel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			component := &RunPipeline{}
+			metadataCtx := &contexts.MetadataContext{
+				Metadata: RunPipelineExecutionMetadata{
+					Pipeline: &PipelineMetadata{
+						ID:     1001,
+						Status: "running",
+					},
+				},
+			}
+			requestsCtx := &contexts.RequestContext{}
+			executionState := &contexts.ExecutionStateContext{
+				KVs: map[string]string{},
+			}
+
+			err := component.HandleHook(core.ActionHookContext{
+				Name: RunPipelinePollAction,
+				Configuration: map[string]any{
+					"project": "123",
+					"ref":     "main",
+				},
+				Metadata: metadataCtx,
+				Integration: &contexts.IntegrationContext{
+					Configuration: map[string]any{
+						"authType":    AuthTypePersonalAccessToken,
+						"groupId":     "123",
+						"accessToken": "pat",
+						"baseUrl":     "https://gitlab.com",
+					},
+				},
+				HTTP: &contexts.HTTPContext{
+					Responses: []*http.Response{
+						GitlabMockResponse(http.StatusOK, `{
+							"id": 1001,
+							"iid": 73,
+							"project_id": 123,
+							"status": "`+tt.status+`",
+							"ref": "main"
+						}`),
+					},
+				},
+				Requests:       requestsCtx,
+				ExecutionState: executionState,
+				Logger:         log.NewEntry(log.New()),
+			})
+
+			require.NoError(t, err)
+			assert.Empty(t, requestsCtx.Action)
+			assert.Equal(t, tt.expectChannel, executionState.Channel)
+			assert.Equal(t, PipelinePayloadType, executionState.Type)
+
+			metadata, ok := metadataCtx.Metadata.(RunPipelineExecutionMetadata)
+			require.True(t, ok)
+			require.NotNil(t, metadata.Pipeline)
+			assert.Equal(t, tt.status, metadata.Pipeline.Status)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #6878

## What

The `gitlab.runPipeline` poll handler routed its completion result using the *stale* pipeline status from execution metadata instead of the status it had just fetched. Because the handler returns early when the stored status is already terminal, the stored status is always non-terminal at the routing point — so the success comparison could never be true, and **every poll-detected completion (including successful pipelines) was emitted on the `failed` channel**. The webhook path in the same file already routes on the freshly fetched status.

## How

- Route on the fetched `pipeline.Status`, matching the webhook path (one-line change in `pkg/integrations/gitlab/run_pipeline.go`).
- Add `Test__RunPipeline__Poll__FinishedPipeline` covering poll-detected completion: success → `passed` channel, failed → `failed` channel, canceled → `failed` channel, plus metadata update assertions. The success case fails against the previous implementation (emitted on `failed`); the existing tests only covered webhook completion and the poll still-running path.

## Verification

- `go test ./pkg/integrations/gitlab/` — pass (new success case fails on the old code)
- `gofmt` / `go vet` clean
