### PR TITLE
fix: Route polled GitLab pipelines by fresh status

### DIFF
--- a/pkg/integrations/gitlab/run_pipeline.go
+++ b/pkg/integrations/gitlab/run_pipeline.go
@@ -448,7 +448,7 @@ func (r *RunPipeline) poll(ctx core.ActionHookContext) error {
 	}
 
 	channel := PipelineFailedOutputChannel
-	if metadata.Pipeline != nil && metadata.Pipeline.Status == PipelineStatusSuccess {
+	if pipeline.Status == PipelineStatusSuccess {
 		channel = PipelinePassedOutputChannel
 	}
 

--- a/pkg/integrations/gitlab/run_pipeline_test.go
+++ b/pkg/integrations/gitlab/run_pipeline_test.go
@@ -225,3 +225,85 @@ func Test__RunPipeline__Poll__SchedulesNextWhenRunning(t *testing.T) {
 	assert.Equal(t, RunPipelinePollInterval, requestsCtx.Duration)
 	assert.Empty(t, executionState.Channel)
 }
+
+func Test__RunPipeline__Poll__EmitsTerminalStatus(t *testing.T) {
+	testCases := []struct {
+		name            string
+		pipelineStatus  string
+		expectedChannel string
+	}{
+		{
+			name:            "successful pipeline",
+			pipelineStatus:  PipelineStatusSuccess,
+			expectedChannel: PipelinePassedOutputChannel,
+		},
+		{
+			name:            "failed pipeline",
+			pipelineStatus:  PipelineStatusFailed,
+			expectedChannel: PipelineFailedOutputChannel,
+		},
+		{
+			name:            "canceled pipeline",
+			pipelineStatus:  PipelineStatusCanceled,
+			expectedChannel: PipelineFailedOutputChannel,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			component := &RunPipeline{}
+			metadataCtx := &contexts.MetadataContext{
+				Metadata: RunPipelineExecutionMetadata{
+					Pipeline: &PipelineMetadata{
+						ID:     1001,
+						Status: "running",
+					},
+				},
+			}
+			executionState := &contexts.ExecutionStateContext{
+				KVs: map[string]string{},
+			}
+
+			err := component.HandleHook(core.ActionHookContext{
+				Name: RunPipelinePollAction,
+				Configuration: map[string]any{
+					"project": "123",
+					"ref":     "main",
+				},
+				Metadata: metadataCtx,
+				Integration: &contexts.IntegrationContext{
+					Configuration: map[string]any{
+						"authType":    AuthTypePersonalAccessToken,
+						"groupId":     "123",
+						"accessToken": "pat",
+						"baseUrl":     "https://gitlab.com",
+					},
+				},
+				HTTP: &contexts.HTTPContext{
+					Responses: []*http.Response{
+						GitlabMockResponse(http.StatusOK, `{
+							"id": 1001,
+							"iid": 73,
+							"project_id": 123,
+							"status": "`+testCase.pipelineStatus+`",
+							"ref": "main",
+							"web_url": "https://gitlab.com/group/project/-/pipelines/1001"
+						}`),
+					},
+				},
+				Requests:       &contexts.RequestContext{},
+				ExecutionState: executionState,
+				Logger:         log.NewEntry(log.New()),
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedChannel, executionState.Channel)
+			assert.Equal(t, PipelinePayloadType, executionState.Type)
+
+			metadata, ok := metadataCtx.Metadata.(RunPipelineExecutionMetadata)
+			require.True(t, ok)
+			require.NotNil(t, metadata.Pipeline)
+			assert.Equal(t, testCase.pipelineStatus, metadata.Pipeline.Status)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The polling path used stale execution metadata to choose the output
channel. As a result, a successful GitLab pipeline could emit on the
failed channel.

This change uses the freshly fetched pipeline status. It also adds
coverage for successful, failed, and canceled terminal states.

Fixes #6878

## Test plan

- [x] Add a table-driven test for terminal polling results.
- [x] Run `gofmt -s` on the changed Go files.
- [x] Run `git diff --check`.
- [x] Run `go test ./pkg/integrations/gitlab`.
