### PR TITLE
fix: reject non-finite durations in the duration formatters

### DIFF
--- a/web_src/src/lib/duration.spec.ts
+++ b/web_src/src/lib/duration.spec.ts
@@ -22,6 +22,28 @@ describe("duration", () => {
     expect(format).toHaveBeenCalledWith({ seconds: 1, milliseconds: 500 });
   });
 
+  it("never hands a non-finite duration to Intl.DurationFormat", () => {
+    const format = vi.fn((duration: Record<string, number>) => {
+      // Matches the runtime: Intl.DurationFormat rejects non-finite values.
+      for (const value of Object.values(duration)) {
+        if (!Number.isFinite(value)) throw new RangeError("Expected finite integer");
+      }
+      return "formatted-by-intl";
+    });
+    const DurationFormat = vi.fn().mockImplementation(function () {
+      return { format };
+    });
+
+    vi.stubGlobal("Intl", {
+      ...Intl,
+      DurationFormat,
+    });
+
+    expect(formatDuration(Number.NaN)).toBe("");
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe("");
+    expect(format).not.toHaveBeenCalled();
+  });
+
   it("formats milliseconds-only durations", () => {
     expect(formatDuration(250)).toBe("250ms");
   });
@@ -54,6 +76,12 @@ describe("duration", () => {
     expect(formatDuration(125_000)).toBe("2m 5s");
     expect(formatDuration(5_400_000)).toBe("1h 30m");
     expect(formatDuration(0)).toBe("");
+  });
+
+  it("returns an empty string for non-finite minute and second durations", () => {
+    expect(formatMinutesSecondsDuration(Number.NaN)).toBe("");
+    expect(formatMinutesSecondsDuration(Number.POSITIVE_INFINITY)).toBe("");
+    expect(formatMinutesSecondsDuration(Number.NEGATIVE_INFINITY)).toBe("");
   });
 
   it("formats minutes and seconds without milliseconds", () => {

--- a/web_src/src/lib/duration.ts
+++ b/web_src/src/lib/duration.ts
@@ -69,8 +69,10 @@ export type FormatDurationOptions = {
 };
 
 export function formatDuration(durationMs: number, options?: FormatDurationOptions): string {
+  if (!Number.isFinite(durationMs)) return "";
+
   if (options?.precision === "second") {
-    if (!Number.isFinite(durationMs) || durationMs <= 0) return "";
+    if (durationMs <= 0) return "";
     if (durationMs < 1000) return "< 1s";
 
     durationMs = Math.round(durationMs / 1000) * 1000;
@@ -87,7 +89,7 @@ export function formatDuration(durationMs: number, options?: FormatDurationOptio
 }
 
 export function formatMinutesSecondsDuration(durationMs: number): string {
-  if (durationMs <= 0) return "";
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return "";
   if (durationMs < 1000) return "<1s";
 
   const totalSeconds = Math.floor(durationMs / 1000);


### PR DESCRIPTION
`web_src/src/lib/duration.ts` guards non-finite input in
`formatDuration(ms, { precision: "second" })` — which has returned `""` for `NaN`
and `Infinity` since the file was added — but not in `formatDuration(ms)` or
`formatMinutesSecondsDuration(ms)`:

| call | before (fallback path) |
|---|---|
| `formatDuration(Infinity)` | `"Infinityd"` |
| `formatMinutesSecondsDuration(NaN)` | `"NaNs"` |
| `formatMinutesSecondsDuration(Infinity)` | `"Infinitym"` |

Where `Intl.DurationFormat` is current it rejects these rather than formatting
them — on Chrome 151, `formatDuration(NaN)` and `formatDuration(Infinity)` throw
`RangeError: Temporal error: Expected finite integer.` CI never sees that: Node 22
keeps `Intl.DurationFormat` behind `--harmony-intl-duration-format`, so the suite
always takes the `formatDurationFallback` path. `duration.spec.ts:9` covers that
branch through a stub, but never the real implementation.

`NaN` does reach `formatDuration` today. `DispatchTimelineItem.tsx:229` passes
`Date.parse(a) - Date.parse(b)` straight in, and a step's `startedAt` can be the
empty string (`workOrderTimelineFromEvents.ts:136` →
`workOrderTimelineStepBuilder.ts:98`; the fixture at
`workOrderTimelineEvents.spec.ts:19` uses exactly that). It is harmless only
because that call passes `{ precision: "second" }`, the precision that already
guards. `workOrderTimelineEvents.ts:157` does the same computation and guards at
the caller instead.

This hoists the guard to the top of `formatDuration` so both precisions agree,
and adds it to `formatMinutesSecondsDuration`. Scope is non-finite only: a current
`Intl.DurationFormat` still throws above roughly `Number.MAX_SAFE_INTEGER * 1000`
ms, but that bound is a Temporal constant no `Date.parse` difference can
approach, so I have not encoded it.

Both added tests were verified to fail when their own guard is reverted.
