### PR TITLE
feat: Open intake drawer after setup

### DIFF
--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -316,6 +316,7 @@ describe("LinesPage board", () => {
     );
 
     expect(screen.getByTestId(`line-intake-source-${GITHUB_ISSUES_INTAKE_ID}`)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse GitHub issues" })).toHaveAttribute("aria-expanded", "true");
     expect(screen.queryByTestId(`line-intake-source-${SENTRY_INTAKE_ID}`)).not.toBeInTheDocument();
     expect(screen.queryByTestId(`line-intake-source-${PAGERDUTY_INTAKE_ID}`)).not.toBeInTheDocument();
   });

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
@@ -105,26 +105,29 @@ describe("provisionGithubIntake", () => {
     const listIntakes = vi.fn().mockResolvedValue([]);
     const createIntake = vi.fn().mockResolvedValue({ id: "intake-1" } as FactoriesFactoryIntake);
 
-    await provisionGithubIntake({ listIntakes, createIntake });
+    const intake = await provisionGithubIntake({ listIntakes, createIntake });
 
     expect(createIntake).toHaveBeenCalledWith({ source: GITHUB_INTAKE_SOURCE });
+    expect(intake.id).toBe("intake-1");
   });
 
   it("leaves an existing GitHub intake alone so a retry adds no second copy", async () => {
     const listIntakes = vi.fn().mockResolvedValue([{ id: "intake-1", source: GITHUB_INTAKE_SOURCE }]);
     const createIntake = vi.fn();
 
-    await provisionGithubIntake({ listIntakes, createIntake });
+    const intake = await provisionGithubIntake({ listIntakes, createIntake });
 
     expect(createIntake).not.toHaveBeenCalled();
+    expect(intake.id).toBe("intake-1");
   });
 
   it("creates the GitHub intake next to an intake of another source", async () => {
     const listIntakes = vi.fn().mockResolvedValue([{ id: "intake-1", source: "SOURCE_SENTRY_EXCEPTIONS" }]);
     const createIntake = vi.fn().mockResolvedValue({ id: "intake-2" } as FactoriesFactoryIntake);
 
-    await provisionGithubIntake({ listIntakes, createIntake });
+    const intake = await provisionGithubIntake({ listIntakes, createIntake });
 
     expect(createIntake).toHaveBeenCalledWith({ source: GITHUB_INTAKE_SOURCE });
+    expect(intake.id).toBe("intake-2");
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
@@ -127,13 +127,14 @@ export type CreateFactoryIntake = (input: { source: FactoriesFactoryIntakeSource
 export async function provisionGithubIntake(args: {
   listIntakes: ListFactoryIntakes;
   createIntake: CreateFactoryIntake;
-}): Promise<void> {
+}): Promise<FactoriesFactoryIntake> {
   const intakes = await args.listIntakes();
-  if (intakes.some((intake) => intake.source === GITHUB_INTAKE_SOURCE)) {
-    return;
+  const existing = intakes.find((intake) => intake.source === GITHUB_INTAKE_SOURCE);
+  if (existing) {
+    return existing;
   }
 
-  await args.createIntake({ source: GITHUB_INTAKE_SOURCE });
+  return args.createIntake({ source: GITHUB_INTAKE_SOURCE });
 }
 
 export async function provisionLine(args: {

--- a/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { afterOnboardingPath } from "./useFinishOnboarding";
+
+describe("afterOnboardingPath", () => {
+  it("opens the intake drawer on the provisioned line", () => {
+    expect(
+      afterOnboardingPath({
+        organizationId: "org-1",
+        factoryKey: "SP",
+        lineId: "line-1",
+      }),
+    ).toBe("/org-1/workspaces/SP/lines/line-1?intake=1");
+  });
+
+  it("expands the GitHub intake chevron", () => {
+    expect(
+      afterOnboardingPath({
+        organizationId: "org-1",
+        factoryKey: "SP",
+        lineId: "line-1",
+        githubIntakeId: "intake-github",
+      }),
+    ).toBe("/org-1/workspaces/SP/lines/line-1?intake=1&intakeId=intake-github");
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.ts
@@ -5,7 +5,7 @@ import type { FactoryAgentRewrite } from "@/pages/home/factories";
 import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
 import { useNavigate } from "react-router";
 
-import { factoryOverviewPath, workOrderDetailPath } from "../../lib/factoryPagePaths";
+import { factoryIntakePath } from "../../lib/factoryPagePaths";
 import { markWorkspaceGettingStarted } from "./gettingStartedState";
 import { firstWorkOrderAgentError, type OnboardingAgentPlan } from "./onboardingAgentReadiness";
 import {
@@ -53,17 +53,23 @@ export function finishOnboardingError(args: {
   return null;
 }
 
+export function afterOnboardingPath(args: {
+  organizationId: string;
+  factoryKey: string;
+  lineId: string;
+  githubIntakeId?: string;
+}) {
+  return factoryIntakePath(args.organizationId, args.factoryKey, args.lineId, args.githubIntakeId);
+}
+
 function navigateAfterFinish(
   navigate: ReturnType<typeof useNavigate>,
   organizationId: string,
   factoryKey: string,
-  orderNumber: number | string | null | undefined,
+  lineId: string,
+  githubIntakeId?: string,
 ) {
-  if (orderNumber != null && orderNumber !== "") {
-    navigate(workOrderDetailPath(organizationId, factoryKey, orderNumber), { replace: true });
-    return;
-  }
-  navigate(factoryOverviewPath(organizationId, factoryKey), { replace: true });
+  navigate(afterOnboardingPath({ organizationId, factoryKey, lineId, githubIntakeId }), { replace: true });
 }
 
 async function provisionWorkspace(args: {
@@ -93,7 +99,7 @@ async function provisionWorkspace(args: {
   agentPlan: OnboardingAgentPlan;
   agentRewrite: FactoryAgentRewrite;
   agentIntegrationId?: string;
-}): Promise<{ number?: number | string | null }> {
+}): Promise<{ lineId: string; githubIntakeId?: string }> {
   if (args.workspaceName !== args.factory?.name) {
     await saveWithFreeWorkspaceName({
       name: args.workspaceName,
@@ -130,7 +136,7 @@ async function provisionWorkspace(args: {
     installFactory: args.installFactory,
   });
   // The intake needs the line: it opens work orders that the line runs.
-  await provisionGithubIntake({
+  const githubIntake = await provisionGithubIntake({
     listIntakes: args.listIntakes,
     createIntake: args.createIntake,
   });
@@ -139,13 +145,14 @@ async function provisionWorkspace(args: {
     provisionedLineId: lineId,
     complete: true,
   });
-  return createAndDispatchInitialWorkOrder({
+  await createAndDispatchInitialWorkOrder({
     title: args.workOrderTitle,
     description: args.workOrderDescription,
     lineName: DEFAULT_LINE_NAME,
     createWorkOrder: args.createWorkOrder,
     dispatchWorkOrder: args.dispatchWorkOrder,
   });
+  return { lineId, githubIntakeId: githubIntake.id ?? undefined };
 }
 
 export function useFinishOnboarding(args: {
@@ -201,7 +208,7 @@ export function useFinishOnboarding(args: {
 
     args.setSaving(true);
     try {
-      const order = await provisionWorkspace({
+      const provisioned = await provisionWorkspace({
         ...args,
         workspaceName,
         appRepository,
@@ -215,7 +222,13 @@ export function useFinishOnboarding(args: {
           args.plan.credentialsSource === "integration" ? args.selections[args.plan.integrationName]?.id : undefined,
       });
       markWorkspaceGettingStarted(args.organizationId, args.factoryId);
-      navigateAfterFinish(navigate, args.organizationId, args.factoryKey, order.number);
+      navigateAfterFinish(
+        navigate,
+        args.organizationId,
+        args.factoryKey,
+        provisioned.lineId,
+        provisioned.githubIntakeId,
+      );
     } catch (error) {
       showErrorToast(getApiErrorMessage(error, "Failed to finish workspace setup"));
     } finally {

--- a/web_src/src/pages/factories/pages/onboarding/useFinishSetupAction.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useFinishSetupAction.ts
@@ -1,7 +1,10 @@
 import { useNavigate } from "react-router";
 
-import { factoryHomePath } from "../../lib/factoryPagePaths";
+import type { FactoriesFactory } from "@/api-client";
+
+import { firstFactoryLineId } from "../../lib/factoryPagePaths";
 import type { OnboardingRepo } from "./onboardingMocks";
+import { afterOnboardingPath } from "./useFinishOnboarding";
 import type { OnboardingSetupApi } from "./useOnboardingSetupState";
 import { useOnboardingStorybook } from "./useOnboardingStorybook";
 
@@ -26,6 +29,7 @@ export function useFinishSetupAction(args: {
   organizationId: string;
   factoryId: string;
   factoryKey: string;
+  factory: FactoriesFactory | null;
   setup: OnboardingSetupApi;
   finish: () => void | Promise<void>;
 }): () => void | Promise<void> {
@@ -38,6 +42,12 @@ export function useFinishSetupAction(args: {
 
   return () => {
     onboarding.completeOnboarding(args.factoryId, storybookRepos(args.setup));
-    navigate(factoryHomePath(args.organizationId, args.factoryKey), { replace: true });
+    const lineId = firstFactoryLineId(args.factory) ?? args.factory?.onboarding?.provisionedLineId;
+    if (!lineId) {
+      return;
+    }
+    navigate(afterOnboardingPath({ organizationId: args.organizationId, factoryKey: args.factoryKey, lineId }), {
+      replace: true,
+    });
   };
 }

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -270,6 +270,7 @@ export function useOnboardingPageModel(args: {
     organizationId: args.organizationId,
     factoryId: args.factoryId,
     factoryKey: args.factoryKey,
+    factory: args.factory,
     setup,
     finish,
   });


### PR DESCRIPTION
## Summary

A finished workspace must show the GitHub intake that setup just created.
This change opens the line board with the intake drawer expanded and the GitHub chevron open.
The first work order is still created. SuperPlane no longer opens that work order after setup.

## Test plan

- [x] Run the onboarding path tests.
- [x] Run the intake drawer and line board tests.
- [ ] Finish workspace setup with a GitHub backlog.
- [ ] Confirm the intake drawer is open and GitHub issues is expanded.

Made with [Cursor](https://cursor.com)