### PR TITLE
feat: Add Groq integration

### DIFF
--- a/pkg/integrations/groq/chat_completion.go
+++ b/pkg/integrations/groq/chat_completion.go
@@ -1,0 +1,289 @@
+package groq
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+const ChatCompletionPayloadType = "groq.chatCompletion.result"
+
+type ChatCompletion struct{}
+
+type ChatCompletionSpec struct {
+	Model        string  `json:"model" mapstructure:"model"`
+	Input        string  `json:"input" mapstructure:"input"`
+	SystemPrompt *string `json:"systemPrompt,omitempty" mapstructure:"systemPrompt"`
+}
+
+type ChatCompletionPayload struct {
+	ID       string                  `json:"id"`
+	Model    string                  `json:"model"`
+	Text     string                  `json:"text"`
+	Usage    *ChatCompletionUsage    `json:"usage,omitempty"`
+	Response *ChatCompletionResponse `json:"response"`
+}
+
+type ChatCompletionNodeMetadata struct {
+	Model string `json:"model" mapstructure:"model"`
+}
+
+func (c *ChatCompletion) Name() string {
+	return "groq.chatCompletion"
+}
+
+func (c *ChatCompletion) Label() string {
+	return "Chat Completion"
+}
+
+func (c *ChatCompletion) Description() string {
+	return "Generate a response with a Groq-hosted chat model"
+}
+
+func (c *ChatCompletion) Documentation() string {
+	return `The Chat Completion component sends a prompt to a selected Groq model and returns its text response.
+
+## Use Cases
+
+- **Content generation**: Generate text for a workflow step
+- **Summarization**: Summarize input from an earlier workflow step
+- **Classification**: Ask a model to classify text or select an outcome
+- **Data transformation**: Convert input into a different text format
+
+## Configuration
+
+- **Model**: Select an active Groq-hosted chat model. SuperPlane filters known non-chat models.
+- **Input**: Enter the user message to send to the model. This field supports expressions.
+- **System Prompt**: Add optional instructions. SuperPlane sends these instructions before the user message.
+
+## Output
+
+The component returns:
+
+- **text**: The generated text response
+- **model**: The model used for the response
+- **usage**: Prompt, completion, and total token counts
+- **id**: The Groq response ID
+- **response**: The chat completion response
+
+## Notes
+
+- Requires a valid Groq API key in the Groq integration.
+- Available models depend on your Groq account and Groq's current model catalog.
+- Token usage is recorded for the run when Groq returns usage data.`
+}
+
+func (c *ChatCompletion) Icon() string {
+	return "message-square"
+}
+
+func (c *ChatCompletion) Color() string {
+	return "orange"
+}
+
+func (c *ChatCompletion) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *ChatCompletion) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "model",
+			Label:       "Model",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Placeholder: "openai/gpt-oss-120b",
+			Description: "Select a Groq model",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{Type: "model"},
+			},
+		},
+		{
+			Name:        "input",
+			Label:       "Input",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Placeholder: "Enter the prompt",
+			Description: "The user message (supports expressions)",
+		},
+		{
+			Name:        "systemPrompt",
+			Label:       "System Prompt",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Togglable:   true,
+			Placeholder: "Optional system-level prompt",
+			Description: "System-level instructions sent before the user prompt",
+		},
+	}
+}
+
+func (c *ChatCompletion) Setup(ctx core.SetupContext) error {
+	spec, err := decodeChatCompletionSpec(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+	if err := validateChatCompletionSpec(spec); err != nil {
+		return err
+	}
+
+	if ctx.Metadata != nil {
+		_ = ctx.Metadata.Set(ChatCompletionNodeMetadata{Model: spec.Model})
+	}
+
+	return nil
+}
+
+func (c *ChatCompletion) Execute(ctx core.ExecutionContext) error {
+	spec, err := decodeChatCompletionSpec(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+	if err := validateChatCompletionSpec(spec); err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	response, err := client.CreateChatCompletion(ChatCompletionRequest{
+		Model:    spec.Model,
+		Messages: buildMessages(spec.SystemPrompt, spec.Input),
+	})
+	if err != nil {
+		return err
+	}
+
+	payload, err := buildChatCompletionPayload(response)
+	if err != nil {
+		return err
+	}
+
+	recordGroqUsage(ctx, response)
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		ChatCompletionPayloadType,
+		[]any{*payload},
+	)
+}
+
+func decodeChatCompletionSpec(configuration any) (ChatCompletionSpec, error) {
+	spec := ChatCompletionSpec{}
+	if err := mapstructure.Decode(configuration, &spec); err != nil {
+		return ChatCompletionSpec{}, fmt.Errorf("failed to decode Groq chat completion configuration: %w", err)
+	}
+	return spec, nil
+}
+
+func validateChatCompletionSpec(spec ChatCompletionSpec) error {
+	if spec.Model == "" {
+		return fmt.Errorf("model is required")
+	}
+	if spec.Input == "" {
+		return fmt.Errorf("input is required")
+	}
+	return nil
+}
+
+func buildMessages(systemPrompt *string, input string) []ChatMessage {
+	messages := make([]ChatMessage, 0, 2)
+	if systemPrompt != nil && *systemPrompt != "" {
+		messages = append(messages, ChatMessage{Role: "system", Content: *systemPrompt})
+	}
+	return append(messages, ChatMessage{Role: "user", Content: input})
+}
+
+func buildChatCompletionPayload(response *ChatCompletionResponse) (*ChatCompletionPayload, error) {
+	if response == nil || len(response.Choices) == 0 {
+		return nil, fmt.Errorf("Groq chat completion returned no choices")
+	}
+	choice := response.Choices[0]
+	return &ChatCompletionPayload{
+		ID:       response.ID,
+		Model:    response.Model,
+		Text:     choice.Message.Content,
+		Usage:    response.Usage,
+		Response: response,
+	}, nil
+}
+
+func recordGroqUsage(ctx core.ExecutionContext, response *ChatCompletionResponse) {
+	if response == nil || response.Usage == nil {
+		return
+	}
+	inputTokens := int64(response.Usage.PromptTokens)
+	outputTokens := int64(response.Usage.CompletionTokens)
+	totalTokens := int64(response.Usage.TotalTokens)
+	if totalTokens == 0 {
+		totalTokens = inputTokens + outputTokens
+	}
+	ctx.RecordUsageBestEffort(core.UsageRecord{
+		Provider:     models.UsageProviderGroq,
+		Model:        response.Model,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  totalTokens,
+	})
+}
+
+func (c *ChatCompletion) ExampleOutput() map[string]any {
+	return map[string]any{
+		"type":      ChatCompletionPayloadType,
+		"timestamp": "2026-08-25T12:00:00Z",
+		"data": map[string]any{
+			"id":    "chatcmpl-example",
+			"model": "llama-3.3-70b-versatile",
+			"text":  "Response from the model",
+			"usage": map[string]any{
+				"prompt_tokens":     10,
+				"completion_tokens": 10,
+				"total_tokens":      20,
+			},
+			"response": map[string]any{
+				"id":      "chatcmpl-example",
+				"object":  "chat.completion",
+				"created": 1756123200,
+				"model":   "llama-3.3-70b-versatile",
+				"choices": []map[string]any{{
+					"index": 0,
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": "Response from the model",
+					},
+					"finish_reason": "stop",
+				}},
+				"usage": map[string]any{
+					"prompt_tokens":     10,
+					"completion_tokens": 10,
+					"total_tokens":      20,
+				},
+			},
+		},
+	}
+}
+
+func (c *ChatCompletion) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *ChatCompletion) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *ChatCompletion) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *ChatCompletion) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *ChatCompletion) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/groq/chat_completion_test.go
+++ b/pkg/integrations/groq/chat_completion_test.go
@@ -1,0 +1,189 @@
+package groq
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+type groqUsageRecorder struct {
+	records []core.UsageRecord
+}
+
+func (r *groqUsageRecorder) Record(record core.UsageRecord) error {
+	r.records = append(r.records, record)
+	return nil
+}
+
+func TestChatCompletionConfiguration(t *testing.T) {
+	fields := (&ChatCompletion{}).Configuration()
+	fieldTypes := make(map[string]string, len(fields))
+	for _, field := range fields {
+		fieldTypes[field.Name] = field.Type
+	}
+
+	assert.Equal(t, configuration.FieldTypeIntegrationResource, fieldTypes["model"])
+	assert.Equal(t, configuration.FieldTypeText, fieldTypes["input"])
+	assert.Equal(t, configuration.FieldTypeText, fieldTypes["systemPrompt"])
+}
+
+func TestChatCompletionSetupValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		configuration map[string]any
+		wantError     string
+	}{
+		{
+			name:          "missing model",
+			configuration: map[string]any{"input": "Hello"},
+			wantError:     "model is required",
+		},
+		{
+			name:          "missing input",
+			configuration: map[string]any{"model": "llama-3.3-70b-versatile"},
+			wantError:     "input is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := (&ChatCompletion{}).Setup(core.SetupContext{Configuration: tt.configuration})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+
+	t.Run("accepts a valid configuration and records model metadata", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := (&ChatCompletion{}).Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"model":        "llama-3.3-70b-versatile",
+				"input":        "Hello",
+				"systemPrompt": "Be concise.",
+			},
+			Metadata: metadata,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, ChatCompletionNodeMetadata{Model: "llama-3.3-70b-versatile"}, metadata.Metadata)
+	})
+}
+
+func TestChatCompletionExecute(t *testing.T) {
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"id":"chatcmpl-123",
+				"model":"llama-3.3-70b-versatile",
+				"choices":[{
+					"index":0,
+					"message":{"role":"assistant","content":"Hello from Groq"},
+					"finish_reason":"stop"
+				}],
+				"usage":{"prompt_tokens":4,"completion_tokens":3,"total_tokens":7}
+			}`)),
+		}},
+	}
+	usage := &groqUsageRecorder{}
+	executionState := &contexts.ExecutionStateContext{}
+	executionContext := core.ExecutionContext{
+		Configuration: map[string]any{
+			"model":        "llama-3.3-70b-versatile",
+			"input":        "Say hello.",
+			"systemPrompt": "Be concise.",
+		},
+		ExecutionState: executionState,
+		HTTP:           httpContext,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "gsk-test"},
+		},
+		Usage: usage,
+	}
+
+	err := (&ChatCompletion{}).Execute(executionContext)
+
+	require.NoError(t, err)
+	assert.True(t, executionState.Finished)
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, ChatCompletionPayloadType, executionState.Type)
+	require.Len(t, executionState.Payloads, 1)
+	wrapper, ok := executionState.Payloads[0].(map[string]any)
+	require.True(t, ok)
+	payload, ok := wrapper["data"].(ChatCompletionPayload)
+	require.True(t, ok)
+	assert.Equal(t, "chatcmpl-123", payload.ID)
+	assert.Equal(t, "llama-3.3-70b-versatile", payload.Model)
+	assert.Equal(t, "Hello from Groq", payload.Text)
+	require.NotNil(t, payload.Usage)
+	assert.Equal(t, 7, payload.Usage.TotalTokens)
+	require.NotNil(t, payload.Response)
+	assert.Equal(t, "chatcmpl-123", payload.Response.ID)
+
+	require.Len(t, usage.records, 1)
+	assert.Equal(t, usage.records[0], core.UsageRecord{
+		Provider:     "groq",
+		Model:        "llama-3.3-70b-versatile",
+		InputTokens:  4,
+		OutputTokens: 3,
+		TotalTokens:  7,
+	})
+
+	require.Len(t, httpContext.Requests, 1)
+	request := httpContext.Requests[0]
+	assert.Equal(t, http.MethodPost, request.Method)
+	assert.Equal(t, defaultBaseURL+"/chat/completions", request.URL.String())
+	assert.Equal(t, "Bearer gsk-test", request.Header.Get("Authorization"))
+	var body ChatCompletionRequest
+	require.NoError(t, json.NewDecoder(request.Body).Decode(&body))
+	require.Len(t, body.Messages, 2)
+	assert.Equal(t, ChatMessage{Role: "system", Content: "Be concise."}, body.Messages[0])
+	assert.Equal(t, ChatMessage{Role: "user", Content: "Say hello."}, body.Messages[1])
+}
+
+func TestChatCompletionExecuteAPIError(t *testing.T) {
+	executionState := &contexts.ExecutionStateContext{}
+	err := (&ChatCompletion{}).Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"model": "llama-3.3-70b-versatile",
+			"input": "Hello",
+		},
+		ExecutionState: executionState,
+		HTTP: &contexts.HTTPContext{Responses: []*http.Response{{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"rate limited"}}`)),
+		}}},
+		Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "gsk-test"}},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "Groq API rate limit reached (429); wait and try again", err.Error())
+	assert.Empty(t, executionState.Payloads)
+}
+
+func TestChatCompletionExecuteRequiresChoices(t *testing.T) {
+	err := (&ChatCompletion{}).Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"model": "llama-3.3-70b-versatile",
+			"input": "Hello",
+		},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		HTTP: &contexts.HTTPContext{Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"chatcmpl-123","model":"llama-3.3-70b-versatile","choices":[]}`)),
+		}}},
+		Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "gsk-test"}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no choices")
+}

--- a/pkg/integrations/groq/client.go
+++ b/pkg/integrations/groq/client.go
@@ -1,0 +1,204 @@
+package groq
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const (
+	defaultBaseURL    = "https://api.groq.com/openai/v1"
+	generationTimeout = 5 * time.Minute
+)
+
+// Client wraps the subset of Groq's OpenAI-compatible API used by the
+// integration. The base URL is fixed so model verification and generation
+// always target GroqCloud.
+type Client struct {
+	APIKey  string
+	BaseURL string
+	http    core.HTTPContext
+}
+
+func NewClient(httpClient core.HTTPContext, ctx core.IntegrationContext) (*Client, error) {
+	key, err := integrationAPIKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		APIKey:  key,
+		BaseURL: defaultBaseURL,
+		http:    httpClient,
+	}, nil
+}
+
+type ModelsResponse struct {
+	Data []Model `json:"data"`
+}
+
+// Model is the model metadata returned by GET /models. Groq currently marks
+// inactive models with active=false; a missing active field remains usable for
+// compatibility with older responses and test doubles.
+type Model struct {
+	ID                  string `json:"id"`
+	Object              string `json:"object"`
+	Created             int64  `json:"created"`
+	OwnedBy             string `json:"owned_by"`
+	Active              *bool  `json:"active"`
+	ContextWindow       int    `json:"context_window"`
+	MaxCompletionTokens int    `json:"max_completion_tokens"`
+}
+
+const (
+	speechToTextModelMarker  = "whisper"
+	textToSpeechModelMarker  = "tts"
+	orpheusSpeechModelPrefix = "canopylabs/orpheus-"
+)
+
+func (m Model) IsSelectable() bool {
+	if strings.TrimSpace(m.ID) == "" || (m.Active != nil && !*m.Active) {
+		return false
+	}
+
+	// Groq's model metadata does not expose a chat capability flag. Exclude
+	// known speech models and keep other active IDs discoverable for chat.
+	return !isKnownNonChatModel(m.ID)
+}
+
+func isKnownNonChatModel(modelID string) bool {
+	normalizedID := strings.ToLower(strings.TrimSpace(modelID))
+	return strings.Contains(normalizedID, speechToTextModelMarker) ||
+		strings.Contains(normalizedID, textToSpeechModelMarker) ||
+		strings.HasPrefix(normalizedID, orpheusSpeechModelPrefix)
+}
+
+type ChatCompletionRequest struct {
+	Model    string        `json:"model"`
+	Messages []ChatMessage `json:"messages"`
+}
+
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatCompletionResponse struct {
+	ID                string               `json:"id"`
+	Object            string               `json:"object"`
+	Created           int64                `json:"created"`
+	Model             string               `json:"model"`
+	SystemFingerprint string               `json:"system_fingerprint,omitempty"`
+	Choices           []ChatChoice         `json:"choices"`
+	Usage             *ChatCompletionUsage `json:"usage,omitempty"`
+}
+
+type ChatChoice struct {
+	Index        int         `json:"index"`
+	Message      ChatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type ChatCompletionUsage struct {
+	QueueTime        float64 `json:"queue_time,omitempty"`
+	PromptTime       float64 `json:"prompt_time,omitempty"`
+	CompletionTime   float64 `json:"completion_time,omitempty"`
+	TotalTime        float64 `json:"total_time,omitempty"`
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+}
+
+func (c *Client) Verify() error {
+	_, err := c.ListModels()
+	return err
+}
+
+func (c *Client) ListModels() ([]Model, error) {
+	responseBody, err := c.execRequest(context.Background(), http.MethodGet, c.BaseURL+"/models", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ModelsResponse
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("Groq API returned an invalid models response")
+	}
+
+	return response.Data, nil
+}
+
+func (c *Client) CreateChatCompletion(request ChatCompletionRequest) (*ChatCompletionResponse, error) {
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Groq chat completion request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), generationTimeout)
+	defer cancel()
+
+	responseBody, err := c.execRequest(ctx, http.MethodPost, c.BaseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChatCompletionResponse
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("Groq API returned an invalid chat completion response")
+	}
+
+	return &response, nil
+}
+
+func (c *Client) execRequest(ctx context.Context, method, requestURL string, body io.Reader) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, method, requestURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("could not create Groq API request")
+	}
+
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+c.APIKey)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	response, err := c.http.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("could not reach Groq API; check your connection and try again")
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, response.Body)
+		return nil, groqAPIStatusError(response.StatusCode)
+	}
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read the Groq API response; try again")
+	}
+
+	return responseBody, nil
+}
+
+func groqAPIStatusError(statusCode int) error {
+	switch {
+	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
+		return fmt.Errorf("Groq API rejected the request (%d); verify your API key", statusCode)
+	case statusCode == http.StatusRequestTimeout:
+		return fmt.Errorf("Groq API request timed out (%d); try again", statusCode)
+	case statusCode == http.StatusTooManyRequests:
+		return fmt.Errorf("Groq API rate limit reached (%d); wait and try again", statusCode)
+	case statusCode >= http.StatusInternalServerError:
+		return fmt.Errorf("Groq API is unavailable (%d); try again later", statusCode)
+	default:
+		return fmt.Errorf("Groq API rejected the request (%d); review the request and try again", statusCode)
+	}
+}

--- a/pkg/integrations/groq/client_test.go
+++ b/pkg/integrations/groq/client_test.go
@@ -1,0 +1,144 @@
+package groq
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Run("reads the API key and uses the Groq API base URL", func(t *testing.T) {
+		client, err := NewClient(&contexts.HTTPContext{}, &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "gsk-test"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "gsk-test", client.APIKey)
+		assert.Equal(t, defaultBaseURL, client.BaseURL)
+	})
+
+	t.Run("requires an integration context", func(t *testing.T) {
+		_, err := NewClient(&contexts.HTTPContext{}, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no integration context")
+	})
+
+	t.Run("requires an API key", func(t *testing.T) {
+		_, err := NewClient(&contexts.HTTPContext{}, &contexts.IntegrationContext{
+			Configuration: map[string]any{},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "apiKey")
+	})
+}
+
+func TestClientVerify(t *testing.T) {
+	t.Run("authenticates the models request", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+			}},
+		}
+		client := &Client{APIKey: "gsk-test", BaseURL: defaultBaseURL, http: httpContext}
+
+		require.NoError(t, client.Verify())
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+		assert.Equal(t, defaultBaseURL+"/models", httpContext.Requests[0].URL.String())
+		assert.Equal(t, "Bearer gsk-test", httpContext.Requests[0].Header.Get("Authorization"))
+	})
+
+	t.Run("returns API errors with status context", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"invalid key"}}`)),
+			}},
+		}
+		client := &Client{APIKey: "bad-key", BaseURL: defaultBaseURL, http: httpContext}
+
+		err := client.Verify()
+
+		require.Error(t, err)
+		assert.Equal(t, "Groq API rejected the request (401); verify your API key", err.Error())
+	})
+}
+
+func TestClientListModels(t *testing.T) {
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"object": "list",
+				"data": [{
+					"id": "llama-3.3-70b-versatile",
+					"active": true,
+					"context_window": 131072,
+					"max_completion_tokens": 32768
+				}]
+			}`)),
+		}},
+	}
+	client := &Client{APIKey: "gsk-test", BaseURL: defaultBaseURL, http: httpContext}
+
+	models, err := client.ListModels()
+
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	assert.Equal(t, "llama-3.3-70b-versatile", models[0].ID)
+	assert.NotNil(t, models[0].Active)
+	assert.Equal(t, 131072, models[0].ContextWindow)
+}
+
+func TestClientCreateChatCompletion(t *testing.T) {
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"id": "chatcmpl-123",
+				"model": "llama-3.3-70b-versatile",
+				"choices": [{
+					"index": 0,
+					"message": {"role": "assistant", "content": "Hello from Groq"},
+					"finish_reason": "stop"
+				}],
+				"usage": {"prompt_tokens": 4, "completion_tokens": 3, "total_tokens": 7}
+			}`)),
+		}},
+	}
+	client := &Client{APIKey: "gsk-test", BaseURL: defaultBaseURL, http: httpContext}
+	req := ChatCompletionRequest{
+		Model: "llama-3.3-70b-versatile",
+		Messages: []ChatMessage{
+			{Role: "system", Content: "Be concise."},
+			{Role: "user", Content: "Say hello."},
+		},
+	}
+
+	response, err := client.CreateChatCompletion(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "chatcmpl-123", response.ID)
+	assert.Equal(t, "Hello from Groq", response.Choices[0].Message.Content)
+	require.Len(t, httpContext.Requests, 1)
+	assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+	assert.Equal(t, defaultBaseURL+"/chat/completions", httpContext.Requests[0].URL.String())
+	assert.Equal(t, "Bearer gsk-test", httpContext.Requests[0].Header.Get("Authorization"))
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(httpContext.Requests[0].Body).Decode(&body))
+	assert.Equal(t, "llama-3.3-70b-versatile", body["model"])
+	assert.Equal(t, []any{
+		map[string]any{"role": "system", "content": "Be concise."},
+		map[string]any{"role": "user", "content": "Say hello."},
+	}, body["messages"])
+}

--- a/pkg/integrations/groq/groq.go
+++ b/pkg/integrations/groq/groq.go
@@ -1,0 +1,123 @@
+package groq
+
+import (
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+func init() {
+	registry.RegisterIntegration("groq", &Groq{})
+}
+
+type Groq struct{}
+
+type Configuration struct {
+	APIKey string `json:"apiKey" mapstructure:"apiKey"`
+}
+
+func (g *Groq) Name() string {
+	return "groq"
+}
+
+func (g *Groq) Label() string {
+	return "Groq"
+}
+
+func (g *Groq) Icon() string {
+	return "groq"
+}
+
+func (g *Groq) Description() string {
+	return "Generate text responses with models hosted by Groq"
+}
+
+func (g *Groq) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "apiKey",
+			Label:       "API Key",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Groq API key",
+		},
+	}
+}
+
+func (g *Groq) Actions() []core.Action {
+	return []core.Action{&ChatCompletion{}}
+}
+
+func (g *Groq) Triggers() []core.Trigger {
+	return []core.Trigger{}
+}
+
+func (g *Groq) Instructions() string {
+	return `## Groq API Key
+
+Create a [Groq API key](https://console.groq.com/keys) and copy it.`
+}
+
+func (g *Groq) Cleanup(ctx core.IntegrationCleanupContext) error {
+	return nil
+}
+
+func (g *Groq) Sync(ctx core.SyncContext) error {
+	if _, err := configurationAPIKey(ctx.Configuration); err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+	if err := client.Verify(); err != nil {
+		return err
+	}
+
+	ctx.Integration.Ready()
+	return nil
+}
+
+func (g *Groq) HandleRequest(ctx core.HTTPRequestContext) {
+	// no-op
+}
+
+func (g *Groq) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	if resourceType != "model" {
+		return []core.IntegrationResource{}, nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := client.ListModels()
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(models))
+	for _, model := range models {
+		if !model.IsSelectable() {
+			continue
+		}
+		resources = append(resources, core.IntegrationResource{
+			Type: resourceType,
+			Name: model.ID,
+			ID:   model.ID,
+		})
+	}
+
+	return resources, nil
+}
+
+func (g *Groq) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (g *Groq) HandleHook(ctx core.IntegrationHookContext) error {
+	return nil
+}

--- a/pkg/integrations/groq/groq_test.go
+++ b/pkg/integrations/groq/groq_test.go
@@ -1,0 +1,112 @@
+package groq
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func TestGroqSync(t *testing.T) {
+	t.Run("marks the integration ready after key verification", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+			}},
+		}
+		integrationContext := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "gsk-test"},
+		}
+
+		err := (&Groq{}).Sync(core.SyncContext{
+			Configuration: integrationContext.Configuration,
+			HTTP:          httpContext,
+			Integration:   integrationContext,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "ready", integrationContext.State)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.groq.com/openai/v1/models", httpContext.Requests[0].URL.String())
+	})
+
+	t.Run("rejects an invalid key", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"invalid api key"}`)),
+			}},
+		}
+		integrationContext := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "bad-key"},
+		}
+
+		err := (&Groq{}).Sync(core.SyncContext{
+			Logger:        logrus.NewEntry(logrus.New()),
+			Configuration: integrationContext.Configuration,
+			HTTP:          httpContext,
+			Integration:   integrationContext,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "401")
+		assert.NotEqual(t, "ready", integrationContext.State)
+	})
+
+	t.Run("requires an API key", func(t *testing.T) {
+		err := (&Groq{}).Sync(core.SyncContext{
+			Configuration: map[string]any{},
+			HTTP:          &contexts.HTTPContext{},
+			Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "apiKey is required")
+	})
+}
+
+func TestGroqListResources(t *testing.T) {
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"data": [
+					{"id":"llama-3.3-70b-versatile","active":true},
+					{"id":"whisper-large-v3","active":true},
+					{"id":"canopylabs/orpheus-v1-english","active":true},
+					{"id":"llama-3.1-8b-instant","active":false},
+					{"id":"","active":true}
+				]
+			}`)),
+		}},
+	}
+	integrationContext := &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "gsk-test"}}
+
+	resources, err := (&Groq{}).ListResources("model", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: integrationContext,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "model", resources[0].Type)
+	assert.Equal(t, "llama-3.3-70b-versatile", resources[0].ID)
+	assert.Equal(t, "llama-3.3-70b-versatile", resources[0].Name)
+}
+
+func TestGroqListResourcesUnknownType(t *testing.T) {
+	resources, err := (&Groq{}).ListResources("unknown", core.ListResourcesContext{
+		HTTP:        &contexts.HTTPContext{},
+		Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "gsk-test"}},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, resources)
+}

--- a/pkg/integrations/groq/integration_secrets.go
+++ b/pkg/integrations/groq/integration_secrets.go
@@ -1,0 +1,51 @@
+package groq
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const integrationSecretGroqAPIKey = "GROQ_API_KEY"
+
+func (g *Groq) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][]byte, error) {
+	key, err := integrationAPIKey(ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string][]byte{integrationSecretGroqAPIKey: []byte(key)}, nil
+}
+
+func integrationAPIKey(integration core.IntegrationContext) (string, error) {
+	if integration == nil {
+		return "", fmt.Errorf("no integration context")
+	}
+
+	apiKey, err := integration.GetConfig("apiKey")
+	if err != nil {
+		return "", fmt.Errorf("failed to get Groq API key: %w", err)
+	}
+
+	return normalizeAPIKey(string(apiKey))
+}
+
+func configurationAPIKey(configuration any) (string, error) {
+	config := Configuration{}
+	if err := mapstructure.Decode(configuration, &config); err != nil {
+		return "", fmt.Errorf("failed to decode Groq configuration: %w", err)
+	}
+
+	return normalizeAPIKey(config.APIKey)
+}
+
+func normalizeAPIKey(apiKey string) (string, error) {
+	key := strings.TrimSpace(apiKey)
+	if key == "" {
+		return "", fmt.Errorf("apiKey is required")
+	}
+
+	return key, nil
+}

--- a/pkg/integrations/groq/integration_secrets_test.go
+++ b/pkg/integrations/groq/integration_secrets_test.go
@@ -1,0 +1,30 @@
+package groq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func TestGroqResolveSecrets(t *testing.T) {
+	secrets, err := (&Groq{}).ResolveSecrets(core.IntegrationSecretContext{
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiKey": "  gsk-test  "},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte("gsk-test"), secrets[integrationSecretGroqAPIKey])
+}
+
+func TestGroqResolveSecretsRequiresAPIKey(t *testing.T) {
+	_, err := (&Groq{}).ResolveSecrets(core.IntegrationSecretContext{
+		Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "  "}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apiKey is required")
+}

--- a/pkg/models/llm_usage_event.go
+++ b/pkg/models/llm_usage_event.go
@@ -19,6 +19,7 @@ const (
 	UsageFundingSourceHosted = "hosted"
 
 	UsageProviderAnthropic  = "anthropic"
+	UsageProviderGroq       = "groq"
 	UsageProviderOpenAI     = "openai"
 	UsageProviderOpenRouter = "openrouter"
 	UsageProviderPerplexity = "perplexity"

--- a/pkg/registryimports/registryimports.go
+++ b/pkg/registryimports/registryimports.go
@@ -50,6 +50,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/integrations/github"
 	_ "github.com/superplanehq/superplane/pkg/integrations/gitlab"
 	_ "github.com/superplanehq/superplane/pkg/integrations/grafana"
+	_ "github.com/superplanehq/superplane/pkg/integrations/groq"
 	_ "github.com/superplanehq/superplane/pkg/integrations/harness"
 	_ "github.com/superplanehq/superplane/pkg/integrations/hetzner"
 	_ "github.com/superplanehq/superplane/pkg/integrations/honeycomb"

--- a/web_src/src/assets/icons/integrations/groq.svg
+++ b/web_src/src/assets/icons/integrations/groq.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="33" height="33" viewBox="0 0 33 33"><title>Groq</title><g clip-path="url(#a)"><path fill="#F43E01" d="M.54.39h32v32h-32z"/><path fill="#fff" d="m18.445 4.406-9.468 13.74 7.341.665-1.69 9.578 9.469-13.74-7.342-.664 1.69-9.579Z"/></g><defs><clipPath id="a"><path fill="#fff" d="M.54.39h32v32h-32z"/></clipPath></defs></svg>

--- a/web_src/src/pages/app/mappers/groq/base.spec.ts
+++ b/web_src/src/pages/app/mappers/groq/base.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { baseMapper } from "./base";
+import type { ComponentBaseContext, ComponentDefinition, NodeInfo } from "../types";
+
+const definition: ComponentDefinition = {
+  name: "groq.chatCompletion",
+  label: "Text prompt",
+  description: "",
+  icon: "message-square",
+  color: "orange",
+};
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "groq.chatCompletion",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildContext(node: NodeInfo): ComponentBaseContext {
+  return {
+    nodes: [],
+    node,
+    componentDefinition: definition,
+    lastExecutions: [],
+    currentUser: { id: "user-1", name: "Test User", email: "test@example.com", roles: [], groups: [] },
+    actions: { invokeNodeExecutionHook: async () => {} },
+  };
+}
+
+describe("groq baseMapper", () => {
+  it("shows the selected model on the node", () => {
+    const props = baseMapper.props(buildContext(buildNode({ configuration: { model: "llama-3.3-70b-versatile" } })));
+
+    expect(props.metadata).toEqual([{ icon: "sparkles", label: "llama-3.3-70b-versatile" }]);
+    expect(props.iconSrc).toBeTruthy();
+  });
+
+  it("shows model and token details for a completion", () => {
+    const details = baseMapper.getExecutionDetails!({
+      nodes: [buildNode()],
+      node: buildNode(),
+      execution: {
+        id: "execution-1",
+        createdAt: "2026-08-25T10:00:00.000Z",
+        updatedAt: "2026-08-25T10:00:00.000Z",
+        state: "STATE_FINISHED",
+        result: "RESULT_PASSED",
+        resultReason: "RESULT_REASON_OK",
+        resultMessage: "",
+        metadata: {},
+        configuration: {},
+        rootEvent: undefined,
+        outputs: {
+          default: [
+            {
+              type: "groq.chatCompletion.result",
+              timestamp: "2026-08-25T10:00:00.000Z",
+              data: {
+                model: "llama-3.3-70b-versatile",
+                usage: { prompt_tokens: 4, completion_tokens: 3, total_tokens: 7 },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(details.Model).toBe("llama-3.3-70b-versatile");
+    expect(details["Tokens"]).toBe("7 (4 in / 3 out)");
+  });
+});

--- a/web_src/src/pages/app/mappers/groq/base.ts
+++ b/web_src/src/pages/app/mappers/groq/base.ts
@@ -1,0 +1,139 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import groqIcon from "@/assets/icons/integrations/groq.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+type ChatCompletionConfiguration = {
+  model?: string;
+};
+
+type ChatCompletionPayload = {
+  model?: string;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as ChatCompletionConfiguration | undefined;
+  if (!configuration?.model) return [];
+
+  return [{ icon: "sparkles", label: configuration.model }];
+}
+
+function formatTokens(usage?: ChatCompletionPayload["usage"]): string | undefined {
+  if (!usage?.total_tokens) return undefined;
+  const input = usage.prompt_tokens ?? 0;
+  const output = usage.completion_tokens ?? 0;
+  return `${usage.total_tokens.toLocaleString()} (${input.toLocaleString()} in / ${output.toLocaleString()} out)`;
+}
+
+function formatTimestamp(timestamp?: string): string | undefined {
+  if (!timestamp) return undefined;
+
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? undefined : date.toLocaleString();
+}
+
+export const baseMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "groq";
+
+    return {
+      iconSrc: groqIcon,
+      iconSlug: context.componentDefinition?.icon ?? "message-square",
+      collapsedBackground: "bg-white",
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition?.label || context.componentDefinition?.name || "Groq",
+      metadata: metadataList(context.node),
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const payload = outputs?.default?.[0];
+    const data = payload?.data as ChatCompletionPayload | undefined;
+    const details: Record<string, string> = {};
+
+    const startedAt = formatTimestamp(context.execution.createdAt);
+    if (startedAt) {
+      details["Started At"] = startedAt;
+    }
+
+    const completedAt = formatTimestamp(payload?.timestamp);
+    if (completedAt) {
+      details["Completed At"] = completedAt;
+    }
+    if (data?.model) {
+      details["Model"] = data.model;
+    }
+    const tokens = formatTokens(data?.usage);
+    if (tokens) {
+      details["Tokens"] = tokens;
+    }
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? renderTimeAgo(new Date(timestamp)) : "";
+  },
+};
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootEvent = execution.rootEvent;
+  const createdAt = formatDate(execution.createdAt);
+  const receivedAt = createdAt ?? new Date();
+  const eventSubtitle = createdAt ? renderTimeAgo(createdAt) : "";
+  const eventState = getState(componentName)(execution);
+
+  if (!rootEvent?.id) {
+    return [
+      {
+        receivedAt,
+        eventTitle: "Execution",
+        eventSubtitle,
+        eventState,
+        eventId: execution.id ?? "",
+      },
+    ];
+  }
+
+  const rootTriggerNode = nodes.find((node) => node.id === rootEvent.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+
+  return [
+    {
+      receivedAt,
+      eventTitle: title,
+      eventSubtitle,
+      eventState,
+      eventId: rootEvent.id,
+    },
+  ];
+}
+
+function formatDate(timestamp?: string): Date | undefined {
+  if (!timestamp) return undefined;
+
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}

--- a/web_src/src/pages/app/mappers/groq/index.ts
+++ b/web_src/src/pages/app/mappers/groq/index.ts
@@ -1,0 +1,13 @@
+import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
+import { buildActionStateRegistry } from "../utils";
+import { baseMapper } from "./base";
+
+export const componentMappers: Record<string, ComponentBaseMapper> = {
+  chatCompletion: baseMapper,
+};
+
+export const triggerRenderers: Record<string, TriggerRenderer> = {};
+
+export const eventStateRegistry: Record<string, EventStateRegistry> = {
+  chatCompletion: buildActionStateRegistry("completed"),
+};

--- a/web_src/src/pages/app/mappers/index.ts
+++ b/web_src/src/pages/app/mappers/index.ts
@@ -217,6 +217,11 @@ import {
   eventStateRegistry as openrouterEventStateRegistry,
 } from "./openrouter/index";
 import {
+  componentMappers as groqComponentMappers,
+  triggerRenderers as groqTriggerRenderers,
+  eventStateRegistry as groqEventStateRegistry,
+} from "./groq/index";
+import {
   componentMappers as prometheusComponentMappers,
   customFieldRenderers as prometheusCustomFieldRenderers,
   triggerRenderers as prometheusTriggerRenderers,
@@ -362,6 +367,7 @@ const appMappers: Record<string, Record<string, ComponentBaseMapper>> = {
   logfire: logfireComponentMappers,
   perplexity: perplexityComponentMappers,
   openrouter: openrouterComponentMappers,
+  groq: groqComponentMappers,
   gcp: gcpComponentMappers,
   prometheus: prometheusComponentMappers,
   cursor: cursorComponentMappers,
@@ -412,6 +418,7 @@ const appTriggerRenderers: Record<string, Record<string, TriggerRenderer>> = {
   logfire: logfireTriggerRenderers,
   perplexity: perplexityTriggerRenderers,
   openrouter: openrouterTriggerRenderers,
+  groq: groqTriggerRenderers,
   gcp: gcpTriggerRenderers,
   grafana: grafanaTriggerRenderers,
   bitbucket: bitbucketTriggerRenderers,
@@ -457,6 +464,7 @@ const appEventStateRegistries: Record<string, Record<string, EventStateRegistry>
   logfire: logfireEventStateRegistry,
   perplexity: perplexityEventStateRegistry,
   openrouter: openrouterEventStateRegistry,
+  groq: groqEventStateRegistry,
   gcp: gcpEventStateRegistry,
   statuspage: statuspageEventStateRegistry,
   aws: awsEventStateRegistry,

--- a/web_src/src/ui/componentSidebar/integrationIconMaps.ts
+++ b/web_src/src/ui/componentSidebar/integrationIconMaps.ts
@@ -32,6 +32,7 @@ import linearIcon from "@/assets/icons/integrations/linear.svg";
 import octopusIcon from "@/assets/icons/integrations/octopus.svg";
 import openAiIcon from "@/assets/icons/integrations/openai.svg";
 import openRouterIcon from "@/assets/icons/integrations/openrouter.svg";
+import groqIcon from "@/assets/icons/integrations/groq.svg";
 import claudeIcon from "@/assets/icons/integrations/claude.svg";
 import logfireIcon from "@/assets/icons/integrations/logfire.svg";
 import gcpIcon from "@/assets/icons/integrations/gcp.svg";
@@ -96,6 +97,7 @@ export const INTEGRATION_APP_LOGO_MAP: Record<string, string> = {
   openai: openAiIcon,
   "open-ai": openAiIcon,
   openrouter: openRouterIcon,
+  groq: groqIcon,
   claude: claudeIcon,
   logfire: logfireIcon,
   cursor: cursorIcon,
@@ -149,6 +151,7 @@ export const APP_LOGO_MAP: Record<string, string | Record<string, string>> = {
   openai: openAiIcon,
   "open-ai": openAiIcon,
   openrouter: openRouterIcon,
+  groq: groqIcon,
   claude: claudeIcon,
   logfire: logfireIcon,
   cursor: cursorIcon,


### PR DESCRIPTION
## Summary
This PR adds a new Groq integration with the following components:

    groq.chatCompletion

Groq is a provider that hosts open weights model on their own ASIC chips, with speeds up to [500 tokens per second](https://console.groq.com/docs/models) making it a great choice for users who want to process larger amounts of data in a short time.

Users can connect an API key, select supported Groq models, and use generated text in canvases.


## Demo video

https://github.com/user-attachments/assets/f32af77e-93e5-4f13-b226-204fc8aac2f3


