### PR TITLE
fix: Stop Agent loader after setup errors

### DIFF
--- a/web_src/src/hooks/useAgentChats.spec.tsx
+++ b/web_src/src/hooks/useAgentChats.spec.tsx
@@ -3,14 +3,22 @@ import { QueryClient, QueryClientProvider, type InfiniteData } from "@tanstack/r
 import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
+  agentsGetCanvasAgentChat,
   agentsListAgentChatMessages,
   agentsResetCanvasAgentChat,
   agentsSendAgentChatMessage,
 } from "@/api-client/sdk.gen";
 import type { AgentMessagesPage } from "./useAgentChats";
-import { agentChatKeys, useAgentChatMessages, useResetCanvasAgentChat, useSendAgentChatMessage } from "./useAgentChats";
+import {
+  agentChatKeys,
+  useAgentChatMessages,
+  useCanvasAgentChat,
+  useResetCanvasAgentChat,
+  useSendAgentChatMessage,
+} from "./useAgentChats";
 
 vi.mock("@/api-client/sdk.gen", () => ({
+  agentsGetCanvasAgentChat: vi.fn(),
   agentsListAgentChatMessages: vi.fn(),
   agentsResetCanvasAgentChat: vi.fn(),
   agentsSendAgentChatMessage: vi.fn(),
@@ -21,6 +29,26 @@ function wrapper(queryClient: QueryClient) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
 }
+
+describe("useCanvasAgentChat", () => {
+  it("reports a structured API error when chat setup fails", async () => {
+    type GetCanvasAgentChatResult = Awaited<ReturnType<typeof agentsGetCanvasAgentChat>>;
+    const apiError = { code: 14, message: "agents are not enabled on this installation" };
+    vi.mocked(agentsGetCanvasAgentChat).mockResolvedValue({
+      error: apiError,
+      request: new Request("https://superplane.test"),
+      response: new Response(null, { status: 503 }),
+    } as GetCanvasAgentChatResult);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useCanvasAgentChat("canvas-1", "org-1", true), {
+      wrapper: wrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBe(apiError);
+  });
+});
 
 describe("useSendAgentChatMessage", () => {
   it("adds a local user message before the send request resolves", async () => {

--- a/web_src/src/hooks/useAgentChats.ts
+++ b/web_src/src/hooks/useAgentChats.ts
@@ -49,6 +49,7 @@ export function useCanvasAgentChat(
       const response = await agentsGetCanvasAgentChat(
         withOrganizationHeader({ organizationId, path: { canvasId: canvasId ?? "" } }),
       );
+      if (response.error) throw response.error;
       return fromApiChat(response.data?.chat);
     },
   });


### PR DESCRIPTION
## Summary

The Agent panel continued to load when chat setup returned a structured 503 error.

This change propagates the API error so the panel shows the correct unavailable or retryable state.

## Test plan

- [x] Add regression coverage for a structured 503 response.
- [ ] Open a canvas on a default installation.
- [ ] Click Agent and confirm that the loader stops.
- [ ] Confirm that the panel shows the unavailable message.
- [ ] Run the frontend tests after installing the required dependencies.