### PR TITLE
feat: Analyze open issues when an intake starts

### DIFF
--- a/pkg/grpc/actions/factories/create_factory_intake.go
+++ b/pkg/grpc/actions/factories/create_factory_intake.go
@@ -71,13 +71,14 @@ func CreateFactoryIntake(
 		confidencePct = int(req.GetConfidencePct())
 	}
 
+	binding := resolveIntakeBinding(db, factory, source)
 	canvasID, err := createIntakeCanvas(ctx, deps, intakeCanvasRequest{
 		OrganizationID: orgID,
 		FactoryID:      factoryID,
 		Source:         source,
 		Name:           name,
 		ConfidencePct:  confidencePct,
-		Binding:        resolveIntakeBinding(db, factory, source),
+		Binding:        binding,
 	})
 	if err != nil {
 		return nil, err
@@ -89,6 +90,12 @@ func CreateFactoryIntake(
 		// linger as an unexplained factory app. Retire it.
 		discardIntakeCanvas(db, orgID, canvasID)
 		return nil, factoryErrorToStatus(err, "failed to create factory intake")
+	}
+
+	// An intake works without a first batch, so a source that cannot be read
+	// now costs the head start and nothing more.
+	if err := seedIntake(ctx, deps, db, canvasID, source, binding); err != nil {
+		log.Warnf("factory %s: intake %s starts without a first batch: %v", factory.ID, intake.ID, err)
 	}
 
 	intake, err = factory.FindIntake(db, intake.ID)

--- a/pkg/grpc/actions/factories/intake_binding.go
+++ b/pkg/grpc/actions/factories/intake_binding.go
@@ -18,6 +18,9 @@ type intakeBinding struct {
 	// Configuration carries the trigger fields that name the resource to
 	// listen on, such as the repository of a GitHub intake.
 	Configuration map[string]any
+	// Installation is the row the reference points at. Seeding the intake
+	// reads the source through the same installation the trigger listens with.
+	Installation *models.Integration
 }
 
 func (b *intakeBinding) integrationRef() *yaml.IntegrationRef {
@@ -32,6 +35,13 @@ func (b *intakeBinding) configuration() map[string]any {
 		return nil
 	}
 	return b.Configuration
+}
+
+func (b *intakeBinding) installation() *models.Integration {
+	if b == nil {
+		return nil
+	}
+	return b.Installation
 }
 
 // resolveIntakeBinding takes what the trigger needs from the workspace setup:
@@ -59,6 +69,7 @@ func resolveIntakeBinding(tx *gorm.DB, factory *models.Factory, source string) *
 			Name: integration.InstallationName,
 		},
 		Configuration: map[string]any{"repository": config.BacklogRepository},
+		Installation:  integration,
 	}
 }
 

--- a/pkg/grpc/actions/factories/intake_seed.go
+++ b/pkg/grpc/actions/factories/intake_seed.go
@@ -1,0 +1,194 @@
+package factories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/workers/contexts"
+	"gorm.io/gorm"
+)
+
+const (
+	// intakeSeedSize is how many items a new intake analyzes at once.
+	intakeSeedSize = 5
+
+	// intakeSeedPageSize reads more than the seed size because GitHub answers
+	// the issue endpoint with pull requests too, and those are dropped.
+	intakeSeedPageSize = 30
+
+	// intakeGitHubIssuePayloadType is the payload type the GitHub trigger emits.
+	// A seeded item uses the same one, so the graph reads it the same way.
+	intakeGitHubIssuePayloadType = "github.issue"
+)
+
+// seedIntake gives a new intake work at once: the newest open items of the
+// source enter the graph as if they had just arrived. Without a seed the intake
+// stays empty until the source sends its next event, which can take days.
+func seedIntake(
+	ctx context.Context,
+	deps IntakeDependencies,
+	tx *gorm.DB,
+	canvasID uuid.UUID,
+	source string,
+	binding *intakeBinding,
+) error {
+	// Only a bound GitHub intake can be read now. The other sources reach their
+	// items through the webhook alone.
+	installation := binding.installation()
+	if source != models.FactoryIntakeSourceGitHubIssues || installation == nil {
+		return nil
+	}
+
+	client, err := newIntakeGitHubClient(deps, tx, installation)
+	if err != nil {
+		return err
+	}
+
+	repository, _ := binding.Configuration["repository"].(string)
+	payloads, err := newestGitHubIssueEvents(ctx, client, repository, intakeSeedSize)
+	if err != nil {
+		return err
+	}
+
+	return emitIntakeEvents(tx, canvasID, intakeGitHubIssuePayloadType, payloads)
+}
+
+func newIntakeGitHubClient(deps IntakeDependencies, tx *gorm.DB, integration *models.Integration) (*common.Client, error) {
+	if deps.Registry == nil {
+		return nil, fmt.Errorf("integration registry is unavailable")
+	}
+
+	if integration.State != models.IntegrationStateReady {
+		return nil, fmt.Errorf("integration %s is not ready", integration.ID)
+	}
+
+	integrationContext := contexts.NewIntegrationContext(tx, nil, integration, deps.Encryptor, deps.Registry, nil)
+	client, err := common.NewClient(integrationContext, deps.Registry.HTTPContext())
+	if err != nil {
+		return nil, fmt.Errorf("failed to build GitHub client: %w", err)
+	}
+
+	return client, nil
+}
+
+// newestGitHubIssueEvents reads the newest open issues of the repository.
+func newestGitHubIssueEvents(
+	ctx context.Context,
+	client *common.Client,
+	repository string,
+	limit int,
+) ([]map[string]any, error) {
+	issues, _, err := client.ListIssues(ctx, repository, &github.IssueListByRepoOptions{
+		State:       "open",
+		Sort:        "created",
+		Direction:   "desc",
+		ListOptions: github.ListOptions{PerPage: intakeSeedPageSize},
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list the issues of %s: %w", repository, err)
+	}
+
+	return gitHubIssueEvents(issues, repository, limit)
+}
+
+// gitHubIssueEvents keeps the first issues of a newest-first page and shapes
+// each one like the webhook body the trigger would have delivered, so the rest
+// of the graph cannot tell a seeded item from a received one.
+func gitHubIssueEvents(issues []*github.Issue, repository string, limit int) ([]map[string]any, error) {
+	events := make([]map[string]any, 0, limit)
+	for _, issue := range issues {
+		if len(events) == limit {
+			break
+		}
+
+		if issue == nil || issue.IsPullRequest() {
+			continue
+		}
+
+		event, err := gitHubIssueEvent(issue, repository)
+		if err != nil {
+			return nil, err
+		}
+
+		events = append(events, event)
+	}
+
+	// The intake lists its runs newest first. Emitting the oldest issue first
+	// keeps the newest issue at the top, where the reader expects it.
+	slices.Reverse(events)
+
+	return events, nil
+}
+
+// gitHubIssueEvent converts an issue from the API into the body of an "issues"
+// webhook. The generated graph reads titles, bodies, labels, and assignees out
+// of that shape.
+func gitHubIssueEvent(issue *github.Issue, repository string) (map[string]any, error) {
+	encoded, err := json.Marshal(issue)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode issue: %w", err)
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		return nil, fmt.Errorf("failed to read issue: %w", err)
+	}
+
+	// A webhook always sends both lists. The API leaves them out when they are
+	// empty, and the intake filters read them without a guard.
+	for _, field := range []string{"labels", "assignees"} {
+		if _, ok := payload[field]; !ok {
+			payload[field] = []any{}
+		}
+	}
+
+	return map[string]any{
+		"action":     "opened",
+		"issue":      payload,
+		"repository": map[string]any{"full_name": repository},
+	}, nil
+}
+
+// emitIntakeEvents feeds the payloads into the intake's trigger on the path a
+// webhook takes: one pending root event for each item, and one run for each
+// event.
+func emitIntakeEvents(tx *gorm.DB, canvasID uuid.UUID, payloadType string, payloads []map[string]any) error {
+	if len(payloads) == 0 {
+		return nil
+	}
+
+	node, err := models.FindCanvasNode(tx, canvasID, intakeTriggerNodeID)
+	if err != nil {
+		return fmt.Errorf("failed to load the intake trigger: %w", err)
+	}
+
+	emitted := []models.CanvasEvent{}
+	events := contexts.NewEventContext(tx, node, nil, func(created []models.CanvasEvent) {
+		emitted = append(emitted, created...)
+	})
+
+	for _, payload := range payloads {
+		if err := events.Emit(payloadType, payload); err != nil {
+			return fmt.Errorf("failed to emit an intake event: %w", err)
+		}
+	}
+
+	for i := range emitted {
+		// The event router also polls for pending events, so a lost message
+		// only delays the analysis.
+		if err := messages.PublishCanvasEventCreatedMessage(&emitted[i]); err != nil {
+			log.Warnf("failed to publish intake event %s: %v", emitted[i].ID, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/grpc/actions/factories/intake_seed_test.go
+++ b/pkg/grpc/actions/factories/intake_seed_test.go
@@ -1,0 +1,175 @@
+package factories
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/test/support"
+
+	_ "github.com/superplanehq/superplane/pkg/registryimports"
+)
+
+func Test__IntakeSeed(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	orgID := r.Organization.ID.String()
+	deps := IntakeDependencies{
+		Registry:       r.Registry,
+		Encryptor:      r.Encryptor,
+		AuthService:    r.AuthService,
+		GitProvider:    r.GitProvider,
+		WebhookBaseURL: "http://localhost:8000",
+	}
+
+	t.Run("seeded issues analyze at once", func(t *testing.T) {
+		factory, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "", "")
+		require.NoError(t, err)
+
+		response, err := CreateFactoryIntake(ctx, deps, orgID, &pb.CreateFactoryIntakeRequest{
+			FactoryId: factory.ID.String(),
+			Source:    pb.FactoryIntake_SOURCE_GITHUB_ISSUES,
+		})
+		require.NoError(t, err)
+		intake := response.GetIntake()
+
+		titles := []string{
+			"Handle duplicate refunds on retry",
+			"Return 409 when the invoice is already paid",
+			"Show a clearer empty state on the billing page",
+			"Upgrade the Node 20 base image",
+			"Add a flake retry to the checkout e2e suite",
+		}
+
+		events, err := gitHubIssueEvents(gitHubIssuePage(titles), "acme/backlog", intakeSeedSize)
+		require.NoError(t, err)
+		require.NoError(t, emitIntakeEvents(
+			database.DB(t.Context()),
+			uuid.MustParse(intake.GetCanvasId()),
+			intakeGitHubIssuePayloadType,
+			events,
+		))
+
+		runs, err := ListFactoryIntakeRuns(ctx, orgID, &pb.ListFactoryIntakeRunsRequest{
+			FactoryId: factory.ID.String(),
+			IntakeId:  intake.GetId(),
+		})
+		require.NoError(t, err)
+		require.Len(t, runs.GetRuns(), len(titles))
+
+		// The newest issue leads the list, and nothing is scored yet.
+		reported := []string{}
+		for _, run := range runs.GetRuns() {
+			assert.Equal(t, pb.FactoryIntakeRun_PLACEMENT_ANALYZING, run.GetPlacement())
+			reported = append(reported, run.GetTitle())
+		}
+		assert.Equal(t, titles, reported)
+	})
+
+	t.Run("an intake without a connection starts empty", func(t *testing.T) {
+		factory, err := models.CreateFactory(database.DB(t.Context()), r.Organization.ID, support.RandomName("factory"), "", "")
+		require.NoError(t, err)
+
+		response, err := CreateFactoryIntake(ctx, deps, orgID, &pb.CreateFactoryIntakeRequest{
+			FactoryId: factory.ID.String(),
+			Source:    pb.FactoryIntake_SOURCE_GITHUB_ISSUES,
+		})
+		require.NoError(t, err)
+
+		runs, err := ListFactoryIntakeRuns(ctx, orgID, &pb.ListFactoryIntakeRunsRequest{
+			FactoryId: factory.ID.String(),
+			IntakeId:  response.GetIntake().GetId(),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, runs.GetRuns())
+	})
+}
+
+func Test__GitHubIssueEvents(t *testing.T) {
+	t.Run("pull requests do not enter the intake", func(t *testing.T) {
+		issues := gitHubIssuePage([]string{"Newest issue", "Older issue"})
+		issues = append([]*github.Issue{{
+			Title:            github.Ptr("A pull request"),
+			PullRequestLinks: &github.PullRequestLinks{URL: github.Ptr("https://github.com/acme/backlog/pull/1")},
+		}}, issues...)
+
+		events, err := gitHubIssueEvents(issues, "acme/backlog", intakeSeedSize)
+		require.NoError(t, err)
+		require.Len(t, events, 2)
+
+		// Events are emitted oldest first, so the newest issue ends up on top
+		// of the intake list.
+		assert.Equal(t, "Older issue", issueEventTitle(t, events[0]))
+		assert.Equal(t, "Newest issue", issueEventTitle(t, events[1]))
+	})
+
+	t.Run("a page longer than the seed is cut to the newest items", func(t *testing.T) {
+		titles := []string{"1", "2", "3", "4", "5", "6", "7"}
+		events, err := gitHubIssueEvents(gitHubIssuePage(titles), "acme/backlog", intakeSeedSize)
+		require.NoError(t, err)
+
+		require.Len(t, events, intakeSeedSize)
+		assert.Equal(t, "5", issueEventTitle(t, events[0]))
+		assert.Equal(t, "1", issueEventTitle(t, events[len(events)-1]))
+	})
+
+	t.Run("an event carries what the graph reads", func(t *testing.T) {
+		issue := &github.Issue{
+			Number: github.Ptr(42),
+			Title:  github.Ptr("Handle duplicate refunds on retry"),
+			Body:   github.Ptr("A retried refund charges the customer twice."),
+		}
+
+		events, err := gitHubIssueEvents([]*github.Issue{issue}, "acme/backlog", intakeSeedSize)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+
+		event := events[0]
+		assert.Equal(t, "opened", event["action"])
+		assert.Equal(t, map[string]any{"full_name": "acme/backlog"}, event["repository"])
+
+		payload, ok := event["issue"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Handle duplicate refunds on retry", payload["title"])
+		assert.Equal(t, "A retried refund charges the customer twice.", payload["body"])
+
+		// The filters read both lists without a guard, and GitHub leaves them
+		// out of the response when the issue has none.
+		assert.Equal(t, []any{}, payload["labels"])
+		assert.Equal(t, []any{}, payload["assignees"])
+	})
+}
+
+// gitHubIssuePage builds a page as the API returns it, so the titles are given
+// newest first.
+func gitHubIssuePage(titles []string) []*github.Issue {
+	issues := make([]*github.Issue, 0, len(titles))
+	for i, title := range titles {
+		issues = append(issues, &github.Issue{
+			Number: github.Ptr(len(titles) - i),
+			Title:  github.Ptr(title),
+			Body:   github.Ptr(fmt.Sprintf("Body of %s", title)),
+		})
+	}
+
+	return issues
+}
+
+func issueEventTitle(t *testing.T, event map[string]any) string {
+	t.Helper()
+
+	payload, ok := event["issue"].(map[string]any)
+	require.True(t, ok)
+	title, ok := payload["title"].(string)
+	require.True(t, ok)
+
+	return title
+}

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -307,6 +307,14 @@ func (c *Client) GetIssue(ctx context.Context, repository string, issueNumber in
 	return c.underlying.Issues.Get(ctx, owner, name, issueNumber)
 }
 
+// ListIssues wraps the repository issue list. GitHub answers this endpoint with
+// pull requests too, so a caller that wants issues only must skip the entries
+// that report IsPullRequest.
+func (c *Client) ListIssues(ctx context.Context, repository string, opts *github.IssueListByRepoOptions) ([]*github.Issue, *github.Response, error) {
+	owner, name := c.ownerAndName(repository)
+	return c.underlying.Issues.ListByRepo(ctx, owner, name, opts)
+}
+
 func (c *Client) EditIssue(ctx context.Context, repository string, issueNumber int, issue *github.IssueRequest) (*github.Issue, *github.Response, error) {
 	owner, name := c.ownerAndName(repository)
 	return c.underlying.Issues.Edit(ctx, owner, name, issueNumber, issue)

--- a/web_src/src/hooks/useFactoryIntakeData.ts
+++ b/web_src/src/hooks/useFactoryIntakeData.ts
@@ -64,6 +64,9 @@ export function useFactoryIntakeRuns(
       return response.data?.runs ?? [];
     },
     enabled: Boolean(organizationId && factoryId && intakeId) && enabled,
+    // Items leave the analysis on their own. The open list has to follow them,
+    // because a new intake starts with a batch that drains within minutes.
+    refetchInterval: 10_000,
   });
 }
 


### PR DESCRIPTION
## Summary

A new GitHub intake only listened for the next webhook. After the workspace
setup the user saw an empty intake, and a quiet repository kept it empty for
days.

The intake now reads the five newest open issues of the backlog repository
and emits each one on its trigger node, in the shape a webhook delivers. The
graph cannot tell a seeded item from a received one, so the confidence
threshold, the label and assignment filters, and the work order templates all
apply without a change.

The seed is best-effort. An intake that setup left unbound, or a source that
the API cannot read, only loses the head start. Sentry and PagerDuty intakes
do not change.

The run list also polls now, because the first batch drains within minutes and
the list never refreshed on its own.

## Test plan

- [ ] Complete the workspace setup with a GitHub connection and a backlog repository.
- [ ] Confirm that the intake drawer shows five issues with the status Analyzing.
- [ ] Confirm that the newest issue is at the top of the list.
- [ ] Confirm that pull requests do not enter the intake.
- [ ] Create an intake without a GitHub connection and confirm that it starts empty.
- [ ] Confirm that an item leaves the list after the analysis ends.

Made with [Cursor](https://cursor.com)