### PR TITLE
fix: Set Machine Type on Intake Analysis

### DIFF
--- a/pkg/grpc/actions/factories/intake_template.go
+++ b/pkg/grpc/actions/factories/intake_template.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/yaml"
 )
@@ -27,6 +28,11 @@ const (
 
 	DefaultIntakeConfidencePct = 65
 )
+
+// intakeAnalysisMachineType is the machine the analysis runner asks for. The
+// runner components reject a node without one, so the generated graph has to
+// name it.
+const intakeAnalysisMachineType = runner.MachineTypeE1LargeAMD64
 
 // intakeAnalysisComponents are the runners an intake can score with. Creation
 // always picks Claude Code, but a graph the user re-pointed at another runner
@@ -144,6 +150,7 @@ func buildIntakeCanvas(source, name string, confidencePct int, binding *intakeBi
 					Type:      yaml.NodeTypeAction,
 					Component: intakeAnalysisComponents[0],
 					Configuration: map[string]any{
+						"machineType": intakeAnalysisMachineType,
 						"steps": []any{
 							map[string]any{
 								"name":   "Analyze and score",

--- a/pkg/grpc/actions/factories/intake_template_test.go
+++ b/pkg/grpc/actions/factories/intake_template_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/yaml"
 )
@@ -34,6 +35,14 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 			{Channel: "passed", SourceID: intakeAnalysisNodeID, TargetID: intakeThresholdNodeID},
 			{Channel: "true", SourceID: intakeThresholdNodeID, TargetID: intakeCreateNodeID},
 		}, canvas.Spec.Edges)
+	})
+
+	t.Run("the analysis runner asks for a machine", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		require.NoError(t, err)
+
+		analysis := findSpecNode(t, canvas, intakeAnalysisNodeID)
+		assert.Equal(t, runner.MachineTypeE1LargeAMD64, analysis.Configuration["machineType"])
 	})
 
 	t.Run("the threshold gates on the analysis score", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes intake automations that onboarding creates without a runner machine type.

The analysis node uses Claude Code. That component requires a machine type, so the generated graph now sets `e1-large-amd64`.

This also applies to Sentry and PagerDuty intakes that share the same template.

## Test plan

- [ ] Finish onboarding and create a GitHub intake.
- [ ] Open the intake canvas and confirm the analysis node uses `e1-large-amd64`.
- [ ] Confirm a new GitHub issue starts an intake analysis run.


Made with [Cursor](https://cursor.com)