### PR TITLE
fix: Keep intake drawer open after workspace setup

### DIFF
--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
@@ -95,8 +95,8 @@ const GITHUB_INTAKE_CANVAS = {
   },
 };
 
-function renderDrawer(props: Partial<LineIntakeDrawerProps> = {}) {
-  return render(
+function drawerElement(props: Partial<LineIntakeDrawerProps>) {
+  return (
     <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
       <MemoryRouter>
         <ThemeProvider>
@@ -109,8 +109,17 @@ function renderDrawer(props: Partial<LineIntakeDrawerProps> = {}) {
           </TooltipProvider>
         </ThemeProvider>
       </MemoryRouter>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+}
+
+function renderDrawer(props: Partial<LineIntakeDrawerProps> = {}) {
+  const view = render(drawerElement(props));
+  return {
+    ...view,
+    showSources: (configuredSources: ConfiguredLineIntakeSource[]) =>
+      view.rerender(drawerElement({ ...props, configuredSources })),
+  };
 }
 
 function intakeRuns(runs: unknown[]) {
@@ -257,6 +266,34 @@ describe("LineIntakeDrawer", () => {
     await user.click(screen.getByRole("button", { name: "Collapse GitHub issues" }));
 
     expect(screen.queryByTestId("line-intake-analyzing")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand GitHub issues" })).toHaveAttribute("aria-expanded", "false");
+  });
+
+  // Setup can open the drawer without an intake in the URL. A workspace with
+  // one intake must still show what that intake found.
+  it("expands the only intake when the URL names none", () => {
+    renderDrawer({ configuredSources: [GITHUB_INTAKE] });
+
+    expect(screen.getByRole("button", { name: "Collapse GitHub issues" })).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("expands the only intake when it loads after the drawer opens", async () => {
+    const { showSources } = renderDrawer({ configuredSources: [] });
+    showSources([GITHUB_INTAKE]);
+
+    expect(await screen.findByRole("button", { name: "Collapse GitHub issues" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("keeps the only intake collapsed after the reader collapses it", async () => {
+    const user = userEvent.setup();
+    const { showSources } = renderDrawer({ configuredSources: [GITHUB_INTAKE] });
+
+    await user.click(screen.getByRole("button", { name: "Collapse GitHub issues" }));
+    showSources([GITHUB_INTAKE]);
+
     expect(screen.getByRole("button", { name: "Expand GitHub issues" })).toHaveAttribute("aria-expanded", "false");
   });
 

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
@@ -2,7 +2,7 @@ import { useUpdateFactoryIntake } from "@/hooks/useFactoryIntakeData";
 import { getApiErrorMessage } from "@/lib/errors";
 import { cn } from "@/lib/utils";
 import { ChevronRight, Plus, Settings, XIcon } from "lucide-react";
-import { useCallback, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
 import { AddIntakePicker } from "./AddIntakePicker";
 import { AnalyzingIntakeTicketList } from "./AnalyzingIntakeTicketList";
@@ -28,6 +28,28 @@ import { useIntakeAutomationRuns } from "./useIntakeAutomationRuns";
 import { useLiveIntakeTickets } from "./useLiveIntakeTickets";
 import { WorkOrderSplitRunPopup } from "./work-order-split-run/WorkOrderSplitRunPopup";
 
+/**
+ * Opens the sole intake of a workspace, one time, when the URL names no
+ * intake. Setup opens the drawer this way, and a single collapsed row hides
+ * the work the intake is doing. The intakes load after the drawer, so this
+ * waits for them. It runs one time only, so a collapse holds.
+ */
+function useExpandLoneIntake(
+  configuredSources: ConfiguredLineIntakeSource[],
+  initialIntakeId: string | undefined,
+  setExpandedIntakeIds: (expanded: ReadonlySet<string>) => void,
+) {
+  const expanded = useRef(false);
+
+  useEffect(() => {
+    if (expanded.current || initialIntakeId || configuredSources.length !== 1) {
+      return;
+    }
+    expanded.current = true;
+    setExpandedIntakeIds(new Set([configuredSources[0].intakeId]));
+  }, [configuredSources, initialIntakeId, setExpandedIntakeIds]);
+}
+
 function useLineIntakeDrawerState({
   initialIntakeId,
   initialSettingsOpen,
@@ -44,6 +66,7 @@ function useLineIntakeDrawerState({
   const [expandedIntakeIds, setExpandedIntakeIds] = useState<ReadonlySet<string>>(
     () => new Set(initialIntakeId ? [initialIntakeId] : []),
   );
+  useExpandLoneIntake(configuredSources, initialIntakeId, setExpandedIntakeIds);
   const [openTicket, setOpenTicket] = useState<LineIntakeAnalyzingTicket | null>(null);
   const [previewIntakeId, setPreviewIntakeId] = useState<string | null>(null);
   const [settingsIntakeId, setSettingsIntakeId] = useState<string | null>(

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingGate.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingGate.spec.tsx
@@ -18,7 +18,8 @@ vi.mock("../../layout/factoriesLayoutContext", () => ({
 }));
 
 function CurrentPath() {
-  return <span>{useLocation().pathname}</span>;
+  const { pathname, search } = useLocation();
+  return <span>{`${pathname}${search}`}</span>;
 }
 
 function Layout() {
@@ -58,5 +59,18 @@ describe("OnboardingGate", () => {
     renderRoute("/org-1/workspaces/PAY/setup");
 
     expect(await screen.findByText("/org-1/workspaces/PAY/lines")).toBeInTheDocument();
+  });
+
+  // Setup finishes with its own redirect to the intake drawer. This redirect
+  // can land after it, so both must open the same board with the drawer.
+  it("opens the intake drawer when a completed workspace leaves setup", async () => {
+    factory = {
+      id: "factory-1",
+      lines: [{ id: "line-plan" }],
+      onboarding: { completedAt: "2026-08-17T12:00:00Z" },
+    };
+    renderRoute("/org-1/workspaces/PAY/setup");
+
+    expect(await screen.findByText("/org-1/workspaces/PAY/lines/line-plan?intake=1")).toBeInTheDocument();
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingGate.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingGate.tsx
@@ -1,12 +1,27 @@
+import type { FactoriesFactory } from "@/api-client";
 import { Navigate, Outlet, useLocation } from "react-router";
 
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
-import { factoryHomePath, factorySetupPath, firstFactoryLineId } from "../../lib/factoryPagePaths";
+import { factoryHomePath, factoryIntakePath, factorySetupPath, firstFactoryLineId } from "../../lib/factoryPagePaths";
 import { isFactoryOnboardingComplete } from "./onboardingStatus";
 import { useOnboardingStorybook } from "./useOnboardingStorybook";
 
 function isWorkspaceSetupRoute(pathname: string) {
   return pathname.endsWith("/setup") || pathname.endsWith("/onboarding");
+}
+
+/**
+ * Where a finished workspace goes when it leaves setup: the line board with
+ * the Intake drawer open, the same place the Finish action opens. Finish and
+ * this redirect run in the same tick, so a different target here would drop
+ * the drawer whenever this redirect lands last.
+ */
+function pathAfterSetup(organizationId: string, factoryKey: string, factory: FactoriesFactory | null) {
+  const lineId = firstFactoryLineId(factory);
+  if (!lineId) {
+    return factoryHomePath(organizationId, factoryKey);
+  }
+  return factoryIntakePath(organizationId, factoryKey, lineId);
 }
 
 /**
@@ -24,7 +39,7 @@ export function OnboardingGate() {
 
   if (!isIncomplete) {
     if (isSetupRoute) {
-      return <Navigate to={factoryHomePath(organizationId, factoryKey, firstFactoryLineId(factory))} replace />;
+      return <Navigate to={pathAfterSetup(organizationId, factoryKey, factory)} replace />;
     }
     return <Outlet />;
   }


### PR DESCRIPTION
## Summary

Workspace setup completed, but the line board opened with the Intake drawer closed. When the drawer did open, the GitHub intake stayed collapsed, so the issues it analyzes stayed hidden.

The Finish action opens the line board with the intake query. The onboarding gate also redirects, because the workspace becomes complete while the browser is still on the setup route. The gate opened the bare line board. The two redirects run in the same tick, so the gate could land last and replace the URL without the intake query. The result looks intermittent.

The gate now uses the same destination as Finish, so the drawer opens for both redirects. The gate knows the line but not the intake, so the URL can name no intake. For that case the drawer now expands the intake when the workspace has exactly one. A workspace with more than one intake keeps every row collapsed.

## Test plan

- [ ] Complete workspace setup. Confirm that the line board opens with the Intake drawer.
- [ ] Confirm that the GitHub intake row is expanded and shows the issues it analyzes.
- [ ] Confirm that the Intake icon in the rail is current, and the Board icon is not.
- [ ] Open the setup URL of a completed workspace. Confirm that it opens the line board with the drawer.
- [ ] Open the setup URL of a completed workspace that has no line. Confirm that it opens the lines list.
- [ ] Add a second intake. Confirm that the drawer keeps every row collapsed until you click one.
