### PR TITLE
feat: Show Intake Confidence on Backlog Cards

### DIFF
--- a/pkg/grpc/actions/factories/factory_intake_test.go
+++ b/pkg/grpc/actions/factories/factory_intake_test.go
@@ -65,8 +65,8 @@ func Test__FactoryIntakeActions(t *testing.T) {
 
 		liveVersion, err := models.FindLiveCanvasVersionByCanvasInTransaction(database.DB(t.Context()), canvas)
 		require.NoError(t, err)
-		assert.Len(t, liveVersion.Nodes, 4)
-		assert.Len(t, liveVersion.Edges, 3)
+		assert.Len(t, liveVersion.Nodes, 5)
+		assert.Len(t, liveVersion.Edges, 4)
 	})
 
 	t.Run("a GitHub intake listens with the workspace connection", func(t *testing.T) {

--- a/pkg/grpc/actions/factories/intake_template.go
+++ b/pkg/grpc/actions/factories/intake_template.go
@@ -14,17 +14,32 @@ import (
 const (
 	// Node identifiers of a generated intake graph. An intake owns its whole
 	// canvas, so the identifiers are fixed rather than derived from the source.
-	intakeTriggerNodeID   = "trigger"
-	intakeAnalysisNodeID  = "analyze"
-	intakeThresholdNodeID = "threshold"
-	intakeCreateNodeID    = "create-work-order"
+	intakeTriggerNodeID          = "trigger"
+	intakeAnalysisNodeID         = "analyze"
+	intakeThresholdNodeID        = "threshold"
+	intakeCreateNodeID           = "create-work-order"
+	intakeReportConfidenceNodeID = "report-confidence"
 
 	// The threshold expression reads the analysis result by node name, so the
 	// name is part of the generated graph's contract.
 	intakeAnalysisNodeName = "Analyze intake"
+	intakeCreateNodeName   = "Create Work Order"
 
-	intakeThresholdComponent = "if"
-	intakeCreateComponent    = "createWorkOrder"
+	intakeThresholdComponent        = "if"
+	intakeCreateComponent           = "createWorkOrder"
+	intakeReportConfidenceComponent = "reportWorkOrderCheck"
+
+	intakeConfidenceCheckKey  = "confidence"
+	intakeConfidenceCheckName = "Confidence score"
+	intakeConfidenceScoreMax  = 5
+	intakeConfidenceFormat    = "fraction"
+	intakeConfidenceDirection = "higherIsBetter"
+
+	// Band edges of the confidence meter, which reads High from 4, Medium at
+	// 3, and Low below 3. The check has no neutral threshold, so Medium maps
+	// to caution and Low maps to critical.
+	intakeConfidenceCautionAt  = 3
+	intakeConfidenceCriticalAt = 2
 
 	DefaultIntakeConfidencePct = 65
 )
@@ -133,6 +148,7 @@ func buildIntakeCanvas(source, name string, confidencePct int, binding *intakeBi
 				{Channel: "default", SourceID: intakeTriggerNodeID, TargetID: intakeAnalysisNodeID},
 				{Channel: "passed", SourceID: intakeAnalysisNodeID, TargetID: intakeThresholdNodeID},
 				{Channel: "true", SourceID: intakeThresholdNodeID, TargetID: intakeCreateNodeID},
+				{Channel: "default", SourceID: intakeCreateNodeID, TargetID: intakeReportConfidenceNodeID},
 			},
 			Nodes: []yaml.Node{
 				{
@@ -173,7 +189,7 @@ func buildIntakeCanvas(source, name string, confidencePct int, binding *intakeBi
 				},
 				{
 					ID:        intakeCreateNodeID,
-					Name:      "Create Work Order",
+					Name:      intakeCreateNodeName,
 					Type:      yaml.NodeTypeAction,
 					Component: intakeCreateComponent,
 					Configuration: map[string]any{
@@ -181,6 +197,24 @@ func buildIntakeCanvas(source, name string, confidencePct int, binding *intakeBi
 						"description": spec.createDescription,
 					},
 					Position: yaml.Position{X: 160, Y: 620},
+				},
+				{
+					ID:        intakeReportConfidenceNodeID,
+					Name:      "Report Confidence",
+					Type:      yaml.NodeTypeAction,
+					Component: intakeReportConfidenceComponent,
+					Configuration: map[string]any{
+						"orderId":    intakeWorkOrderIDExpression(),
+						"checkKey":   intakeConfidenceCheckKey,
+						"name":       intakeConfidenceCheckName,
+						"score":      intakeConfidenceScoreExpression(),
+						"maxScore":   strconv.Itoa(intakeConfidenceScoreMax),
+						"format":     intakeConfidenceFormat,
+						"direction":  intakeConfidenceDirection,
+						"cautionAt":  float64(intakeConfidenceCautionAt),
+						"criticalAt": float64(intakeConfidenceCriticalAt),
+					},
+					Position: yaml.Position{X: 160, Y: 800},
 				},
 			},
 		},
@@ -215,6 +249,21 @@ func intakeAnalysisPrompt(subject string) string {
 
 func intakeThresholdExpression(confidencePct int) string {
 	return fmt.Sprintf(`int($[%q].data[0].result.result) >= %d`, intakeAnalysisNodeName, clampIntakeConfidence(confidencePct))
+}
+
+func intakeWorkOrderIDExpression() string {
+	return fmt.Sprintf(`{{ $[%q].data.workOrder.id }}`, intakeCreateNodeName)
+}
+
+// intakeConfidenceScoreExpression maps the analysis percentage to the 0–5
+// scale of the work-order confidence meter. The meter rounds the score it
+// receives, so the expression rounds too and both agree on the bar count.
+func intakeConfidenceScoreExpression() string {
+	pctPerPoint := 100 / intakeConfidenceScoreMax
+	return fmt.Sprintf(
+		`{{ int(round(int($[%q].data[0].result.result) / %d.0)) }}`,
+		intakeAnalysisNodeName, pctPerPoint,
+	)
 }
 
 var intakeThresholdPattern = regexp.MustCompile(`>=\s*(\d+)`)

--- a/pkg/grpc/actions/factories/intake_template_test.go
+++ b/pkg/grpc/actions/factories/intake_template_test.go
@@ -1,8 +1,11 @@
 package factories
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/expr-lang/expr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/components/runner"
@@ -34,7 +37,50 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 			{Channel: "default", SourceID: intakeTriggerNodeID, TargetID: intakeAnalysisNodeID},
 			{Channel: "passed", SourceID: intakeAnalysisNodeID, TargetID: intakeThresholdNodeID},
 			{Channel: "true", SourceID: intakeThresholdNodeID, TargetID: intakeCreateNodeID},
+			{Channel: "default", SourceID: intakeCreateNodeID, TargetID: intakeReportConfidenceNodeID},
 		}, canvas.Spec.Edges)
+	})
+
+	t.Run("the created work order receives the intake confidence score", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		require.NoError(t, err)
+
+		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
+		assert.Equal(t, intakeReportConfidenceComponent, report.Component)
+		assert.Equal(t, "{{ $[\"Create Work Order\"].data.workOrder.id }}", report.Configuration["orderId"])
+		assert.Equal(t, "confidence", report.Configuration["checkKey"])
+		assert.Equal(t, "Confidence score", report.Configuration["name"])
+		assert.Equal(t, "5", report.Configuration["maxScore"])
+		assert.Equal(t, "fraction", report.Configuration["format"])
+	})
+
+	t.Run("the score rounds onto the meter scale like the UI does", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		require.NoError(t, err)
+
+		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
+		assert.Equal(
+			t,
+			`{{ int(round(int($["Analyze intake"].data[0].result.result) / 20.0)) }}`,
+			report.Configuration["score"],
+		)
+
+		expression := report.Configuration["score"].(string)
+		for pct, expected := range map[int]int{0: 0, 49: 2, 50: 3, 69: 3, 70: 4, 89: 4, 90: 5, 100: 5} {
+			assert.Equal(t, expected, evaluateIntakeConfidenceScore(t, expression, pct), "confidence %d%%", pct)
+		}
+	})
+
+	t.Run("the check level follows the meter bands", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		require.NoError(t, err)
+
+		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
+		assert.Equal(t, "higherIsBetter", report.Configuration["direction"])
+		// High starts at 4, so 3 is caution (Medium) and 2 and below is
+		// critical (Low).
+		assert.Equal(t, float64(3), report.Configuration["cautionAt"])
+		assert.Equal(t, float64(2), report.Configuration["criticalAt"])
 	})
 
 	t.Run("the analysis runner asks for a machine", func(t *testing.T) {
@@ -121,6 +167,30 @@ func Test__IntakeConfidenceFromExpression(t *testing.T) {
 		_, ok := intakeConfidenceFromExpression("$.result == 'ship it'")
 		assert.False(t, ok)
 	})
+}
+
+// evaluateIntakeConfidenceScore runs the generated score expression against an
+// analysis result of pct, so the band edges are checked with the same engine
+// that resolves node configuration at run time.
+func evaluateIntakeConfidenceScore(t *testing.T, expression string, pct int) int {
+	t.Helper()
+
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(expression, "{{"), "}}"))
+	analysis := map[string]any{
+		"data": []any{
+			map[string]any{"result": map[string]any{"result": strconv.Itoa(pct)}},
+		},
+	}
+
+	output, err := expr.Eval(inner, map[string]any{
+		"$": map[string]any{intakeAnalysisNodeName: analysis},
+	})
+	require.NoError(t, err)
+
+	score, ok := output.(int)
+	require.Truef(t, ok, "expression returned %T, want int", output)
+
+	return score
 }
 
 func findSpecNode(t *testing.T, canvas *yaml.Canvas, nodeID string) yaml.Node {


### PR DESCRIPTION
## Summary

Intake analysis scored tickets, but the work order did not keep that score. Backlog cards therefore hid the five-bar confidence meter.

This change reports a Confidence score check after intake creates the work order. The score rounds onto the 0-5 meter scale. The check level follows the High, Medium, and Low bands.

## Test plan

- [ ] Open a factory with GitHub intake and wait until analysis creates a work order.
- [ ] Confirm the Backlog card shows the five-bar confidence meter next to Start.
- [ ] Confirm the work order checks include Confidence score with the same bar count.
- [ ] Confirm a score at or above 70% shows High (4 or 5 bars) and 50-69% shows Medium (3 bars).
- [ ] Confirm a work order created by hand still has no confidence bars.


Made with [Cursor](https://cursor.com)