### PR TITLE
chore: Split Backend Unit Tests into 4 CI Jobs

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,12 +37,12 @@ blocks:
         - name: Unit Tests
           parallelism: 4
           commands:
-            - make test.coverage.autoparallel INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
+            - make test.coverage.autoparallel SHARD_INDEX=$SEMAPHORE_JOB_INDEX SHARD_COUNT=$SEMAPHORE_JOB_COUNT
 
         - name: E2E Tests
           parallelism: 10
           commands:
-            - make test.e2e.autoparallel INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
+            - make test.e2e.autoparallel SHARD_INDEX=$SEMAPHORE_JOB_INDEX SHARD_COUNT=$SEMAPHORE_JOB_COUNT
 
         - name: Checks
           commands:
@@ -82,7 +82,7 @@ blocks:
         - name: Unit Tests
           parallelism: 4
           commands:
-            - make check.test.ui.shard INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
+            - make check.test.ui.shard SHARD_INDEX=$SEMAPHORE_JOB_INDEX SHARD_COUNT=$SEMAPHORE_JOB_COUNT
 
         - name: Format Check
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -35,8 +35,9 @@ blocks:
             - make lint
 
         - name: Unit Tests
+          parallelism: 4
           commands:
-            - make test.coverage.check
+            - make test.coverage.autoparallel INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
 
         - name: E2E Tests
           parallelism: 10

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ endif
 
 PKG_TEST_PACKAGES := ./pkg/...
 E2E_TEST_PACKAGES := ./test/e2e/...
-INDEX ?= 1
-TOTAL ?= 1
 
 COMPOSE=docker compose -f docker-compose.dev.yml
 GENERATED_ARTIFACT_PATHS := pkg/protos pkg/openapi_client web_src/src/api-client api/swagger/superplane.swagger.json
@@ -52,7 +50,7 @@ test.e2e:
 	$(COMPOSE) exec -e DB_NAME=superplane_test app gotestsum --format short --junitfile junit-report.xml --rerun-fails=3 --rerun-fails-max-failures=1 --packages="$(E2E_TEST_PACKAGES)" -- -p 1 -timeout 30m
 
 test.e2e.autoparallel:
-	$(COMPOSE) exec -e DB_NAME=superplane_test -e INDEX -e TOTAL app bash -lc "cd /app && bash scripts/test_e2e_autoparallel.sh"
+	$(COMPOSE) exec -e DB_NAME=superplane_test -e SHARD_INDEX -e SHARD_COUNT app bash -lc "cd /app && bash scripts/test_e2e_autoparallel.sh"
 
 test.e2e.single:
 	bash ./scripts/vscode_run_tests.sh line $(FILE) $(LINE)
@@ -69,7 +67,7 @@ test.coverage.check:
 	$(MAKE) check.coverage.go
 
 test.coverage.autoparallel:
-	$(COMPOSE) run --rm -e DB_NAME=superplane_test -e INDEX=$(INDEX) -e TOTAL=$(TOTAL) -v $(PWD)/tmp/screenshots:/app/test/screenshots app bash -lc "cd /app && bash scripts/test_unit_autoparallel.sh"
+	$(COMPOSE) run --rm -e DB_NAME=superplane_test -e SHARD_INDEX -e SHARD_COUNT -v $(PWD)/tmp/screenshots:/app/test/screenshots app bash -lc "cd /app && bash scripts/test_unit_autoparallel.sh"
 
 test.coverage.baseline.update:
 	$(MAKE) test.coverage
@@ -212,7 +210,7 @@ check.test.ui:
 	$(COMPOSE) exec app bash -c "cd web_src && npm run test:run"
 
 check.test.ui.shard:
-	$(COMPOSE) exec -e INDEX -e TOTAL app bash -lc "cd /app && bash scripts/test_ui_autoparallel.sh"
+	$(COMPOSE) exec -e SHARD_INDEX -e SHARD_COUNT app bash -lc "cd /app && bash scripts/test_ui_autoparallel.sh"
 
 check.format.js:
 	$(COMPOSE) exec app bash -c "cd web_src && npm run format:check"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test test.coverage test.license.check check.generated.artifacts dev.up dev.setup dev.setup.app dev.setup.go dev.clean.go.cache dev.server dev.server.fg profile.cpu profile.heap profile.goroutines check.grpc.actions.status
+.PHONY: lint test test.coverage test.coverage.autoparallel test.license.check check.generated.artifacts dev.up dev.setup dev.setup.app dev.setup.go dev.clean.go.cache dev.server dev.server.fg profile.cpu profile.heap profile.goroutines check.grpc.actions.status
 
 MAKE=make
 MAKEFLAGS+=--no-print-directory
@@ -21,6 +21,8 @@ endif
 
 PKG_TEST_PACKAGES := ./pkg/...
 E2E_TEST_PACKAGES := ./test/e2e/...
+INDEX ?= 1
+TOTAL ?= 1
 
 COMPOSE=docker compose -f docker-compose.dev.yml
 GENERATED_ARTIFACT_PATHS := pkg/protos pkg/openapi_client web_src/src/api-client api/swagger/superplane.swagger.json
@@ -65,6 +67,9 @@ test.coverage:
 test.coverage.check:
 	$(MAKE) test.coverage
 	$(MAKE) check.coverage.go
+
+test.coverage.autoparallel:
+	$(COMPOSE) run --rm -e DB_NAME=superplane_test -e INDEX=$(INDEX) -e TOTAL=$(TOTAL) -v $(PWD)/tmp/screenshots:/app/test/screenshots app bash -lc "cd /app && bash scripts/test_unit_autoparallel.sh"
 
 test.coverage.baseline.update:
 	$(MAKE) test.coverage

--- a/scripts/check_go_coverage_budget.go
+++ b/scripts/check_go_coverage_budget.go
@@ -60,6 +60,7 @@ func main() {
 	updateBaseline := flag.Bool("update-baseline", false, "write the current coverage as the new baseline")
 	profilePath := flag.String("profile", defaultProfilePath, "coverage profile path")
 	baselinePath := flag.String("baseline", defaultBaselinePath, "coverage baseline file path")
+	ignoreMissingPackages := flag.Bool("ignore-missing-packages", false, "skip total coverage and packages absent from this profile (sharded CI runs)")
 	flag.Parse()
 
 	existingBaseline, err := readBaseline(*baselinePath)
@@ -93,7 +94,7 @@ func main() {
 		}
 
 		fmt.Printf("Updated Go coverage baseline to total coverage %.1f%% across %d package(s).\n", stats.TotalCoverage, len(stats.CoverageByPackage))
-		printCoverageVsBudget(stats, newBaseline)
+		printCoverageVsBudget(stats, newBaseline, false)
 		fmt.Printf("WITHIN BUDGET %.1f/%.1f\n", stats.TotalCoverage, stats.TotalCoverage)
 		return
 	}
@@ -105,11 +106,19 @@ func main() {
 
 	totalRegression := roundCoverage(existingBaseline.MinTotalCoverage - stats.TotalCoverage)
 	packageRegressions := findPackageRegressions(stats.CoverageByPackage, existingBaseline.MinCoverageByPackage)
-	missingPackages := findMissingPackages(stats.CoverageByPackage, existingBaseline.MinCoverageByPackage)
+	missingPackages := []string{}
+	if !*ignoreMissingPackages {
+		missingPackages = findMissingPackages(stats.CoverageByPackage, existingBaseline.MinCoverageByPackage)
+	}
 
-	if totalRegression > tolerancePercentage || len(packageRegressions) > 0 || len(missingPackages) > 0 {
+	failedTotal := !*ignoreMissingPackages && totalRegression > tolerancePercentage
+	if failedTotal || len(packageRegressions) > 0 || len(missingPackages) > 0 {
 		fmt.Fprintln(os.Stderr, "Go coverage budget exceeded.")
-		fmt.Fprintf(os.Stderr, "- Total coverage: %.1f%% (allowed %.1f%%)\n", stats.TotalCoverage, existingBaseline.MinTotalCoverage)
+		if *ignoreMissingPackages {
+			fmt.Fprintf(os.Stderr, "- Shard coverage: %.1f%% (total budget is skipped for sharded runs)\n", stats.TotalCoverage)
+		} else {
+			fmt.Fprintf(os.Stderr, "- Total coverage: %.1f%% (allowed %.1f%%)\n", stats.TotalCoverage, existingBaseline.MinTotalCoverage)
+		}
 
 		if len(packageRegressions) > 0 {
 			fmt.Fprintln(os.Stderr, "- Package regressions:")
@@ -125,12 +134,12 @@ func main() {
 			}
 		}
 
-		printCoverageVsBudget(stats, *existingBaseline)
+		printCoverageVsBudget(stats, *existingBaseline, *ignoreMissingPackages)
 		fmt.Fprintf(os.Stderr, "FAILED %.1f/%.1f\n", stats.TotalCoverage, existingBaseline.MinTotalCoverage)
 		os.Exit(1)
 	}
 
-	printCoverageVsBudget(stats, *existingBaseline)
+	printCoverageVsBudget(stats, *existingBaseline, *ignoreMissingPackages)
 	fmt.Printf("WITHIN BUDGET %.1f/%.1f\n", stats.TotalCoverage, existingBaseline.MinTotalCoverage)
 }
 
@@ -312,7 +321,7 @@ func findMissingPackages(currentByPackage map[string]float64, minByPackage map[s
 	return missing
 }
 
-func printCoverageVsBudget(stats coverageStats, budget baseline) {
+func printCoverageVsBudget(stats coverageStats, budget baseline, onlyPresentPackages bool) {
 	fmt.Println("Coverage vs budget:")
 	fmt.Printf("- total: %.1f/%.1f\n", stats.TotalCoverage, budget.MinTotalCoverage)
 
@@ -323,10 +332,13 @@ func printCoverageVsBudget(stats coverageStats, budget baseline) {
 
 	sortedPackages := mapsKeys(budget.MinCoverageByPackage)
 	for _, pkg := range sortedPackages {
-		currentCoverage := stats.CoverageByPackage[pkg]
+		currentCoverage, present := stats.CoverageByPackage[pkg]
+		if onlyPresentPackages && !present {
+			continue
+		}
 		minCoverage := budget.MinCoverageByPackage[pkg]
 		status := ""
-		if roundCoverage(minCoverage-currentCoverage) > tolerancePercentage {
+		if present && roundCoverage(minCoverage-currentCoverage) > tolerancePercentage {
 			status = " !!! OVER BUDGET"
 		}
 		fmt.Printf("- %s: %.1f/%.1f%s\n", pkg, currentCoverage, minCoverage, status)

--- a/scripts/lib/shard_args.sh
+++ b/scripts/lib/shard_args.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shared shard argument handling for the test sharding scripts.
+#
+# Source this file, then use $SHARD_INDEX and $SHARD_COUNT.
+#
+#   SHARD_INDEX - 1-based index of this shard (defaults to 1)
+#   SHARD_COUNT - total number of shards (defaults to 1)
+
+SHARD_INDEX="${SHARD_INDEX:-1}"
+SHARD_COUNT="${SHARD_COUNT:-1}"
+
+if ! [[ "$SHARD_INDEX" =~ ^[0-9]+$ ]] || ! [[ "$SHARD_COUNT" =~ ^[0-9]+$ ]]; then
+  echo "SHARD_INDEX and SHARD_COUNT must be positive integers (got SHARD_INDEX=${SHARD_INDEX}, SHARD_COUNT=${SHARD_COUNT})" >&2
+  exit 1
+fi
+
+if [[ "$SHARD_COUNT" -lt 1 ]]; then
+  echo "SHARD_COUNT must be >= 1 (got ${SHARD_COUNT})" >&2
+  exit 1
+fi
+
+if [[ "$SHARD_INDEX" -lt 1 || "$SHARD_INDEX" -gt "$SHARD_COUNT" ]]; then
+  echo "SHARD_INDEX must be between 1 and SHARD_COUNT (${SHARD_COUNT}), got ${SHARD_INDEX}" >&2
+  exit 1
+fi

--- a/scripts/test_e2e_autoparallel.sh
+++ b/scripts/test_e2e_autoparallel.sh
@@ -3,31 +3,11 @@ set -euo pipefail
 
 # Shard e2e Go tests across CI workers.
 # Usage (Semaphore example):
-#   make test.e2e.autoparallel INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
-#
-# Environment:
-#   INDEX - 1-based index of this shard (defaults to 1)
-#   TOTAL - total number of shards (defaults to 1)
+#   make test.e2e.autoparallel SHARD_INDEX=$SEMAPHORE_JOB_INDEX SHARD_COUNT=$SEMAPHORE_JOB_COUNT
 
-INDEX="${INDEX:-${SEMAPHORE_JOB_INDEX:-1}}"
-TOTAL="${TOTAL:-${SEMAPHORE_JOB_COUNT:-1}}"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/shard_args.sh"
 
-if ! [[ "$INDEX" =~ ^[0-9]+$ ]] || ! [[ "$TOTAL" =~ ^[0-9]+$ ]]; then
-  echo "INDEX and TOTAL must be positive integers (got INDEX=${INDEX}, TOTAL=${TOTAL})" >&2
-  exit 1
-fi
-
-if [[ "$TOTAL" -lt 1 ]]; then
-  echo "TOTAL must be >= 1 (got ${TOTAL})" >&2
-  exit 1
-fi
-
-if [[ "$INDEX" -lt 1 || "$INDEX" -gt "$TOTAL" ]]; then
-  echo "INDEX must be between 1 and TOTAL (${TOTAL}), got ${INDEX}" >&2
-  exit 1
-fi
-
-echo "Running e2e tests shard ${INDEX}/${TOTAL}"
+echo "Running e2e tests shard ${SHARD_INDEX}/${SHARD_COUNT}"
 
 if [[ ! -d "./test/e2e" ]]; then
   echo "No ./test/e2e directory found, nothing to run."
@@ -61,19 +41,19 @@ mapfile -t all_tests < <(printf '%s\n' "${all_tests[@]}" | sort -u)
 selected_tests=()
 idx=0
 for test_name in "${all_tests[@]}"; do
-  shard=$(( (idx % TOTAL) + 1 ))
-  if [[ "$shard" -eq "$INDEX" ]]; then
+  shard=$(( (idx % SHARD_COUNT) + 1 ))
+  if [[ "$shard" -eq "$SHARD_INDEX" ]]; then
     selected_tests+=("$test_name")
   fi
   idx=$((idx + 1))
 done
 
 if [[ "${#selected_tests[@]}" -eq 0 ]]; then
-  echo "No tests assigned to shard ${INDEX}/${TOTAL}; exiting successfully."
+  echo "No tests assigned to shard ${SHARD_INDEX}/${SHARD_COUNT}; exiting successfully."
   exit 0
 fi
 
-echo "Selected tests for shard ${INDEX}/${TOTAL}:"
+echo "Selected tests for shard ${SHARD_INDEX}/${SHARD_COUNT}:"
 for t in "${selected_tests[@]}"; do
   echo "  - ${t}"
 done

--- a/scripts/test_ui_autoparallel.sh
+++ b/scripts/test_ui_autoparallel.sh
@@ -3,31 +3,11 @@ set -euo pipefail
 
 # Shard Vitest UI unit tests across CI workers.
 # Usage (Semaphore example):
-#   make check.test.ui.shard INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
-#
-# Environment:
-#   INDEX - 1-based index of this shard (defaults to 1)
-#   TOTAL - total number of shards (defaults to 1)
+#   make check.test.ui.shard SHARD_INDEX=$SEMAPHORE_JOB_INDEX SHARD_COUNT=$SEMAPHORE_JOB_COUNT
 
-INDEX="${INDEX:-${SEMAPHORE_JOB_INDEX:-1}}"
-TOTAL="${TOTAL:-${SEMAPHORE_JOB_COUNT:-1}}"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/shard_args.sh"
 
-if ! [[ "$INDEX" =~ ^[0-9]+$ ]] || ! [[ "$TOTAL" =~ ^[0-9]+$ ]]; then
-  echo "INDEX and TOTAL must be positive integers (got INDEX=${INDEX}, TOTAL=${TOTAL})" >&2
-  exit 1
-fi
-
-if [[ "$TOTAL" -lt 1 ]]; then
-  echo "TOTAL must be >= 1 (got ${TOTAL})" >&2
-  exit 1
-fi
-
-if [[ "$INDEX" -lt 1 || "$INDEX" -gt "$TOTAL" ]]; then
-  echo "INDEX must be between 1 and TOTAL (${TOTAL}), got ${INDEX}" >&2
-  exit 1
-fi
-
-echo "Running UI unit tests shard ${INDEX}/${TOTAL}"
+echo "Running UI unit tests shard ${SHARD_INDEX}/${SHARD_COUNT}"
 
 cd web_src
-npm run test:run -- --shard="${INDEX}/${TOTAL}"
+npm run test:run -- --shard="${SHARD_INDEX}/${SHARD_COUNT}"

--- a/scripts/test_unit_autoparallel.sh
+++ b/scripts/test_unit_autoparallel.sh
@@ -66,17 +66,15 @@ for package_dir in "${shard_packages[@]}"; do
 done
 echo ""
 
-packages_csv="$(IFS=','; echo "${shard_packages[*]}")"
-
+# gotestsum expects the package patterns separated by spaces.
 gotestsum \
   --format short \
   --junitfile junit-report.xml \
-  --packages="${packages_csv}" \
+  --packages="${shard_packages[*]}" \
   -- \
   -p 1 \
   -coverprofile=coverage-go.out \
-  -covermode=atomic \
-  -coverpkg="${packages_csv}"
+  -covermode=atomic
 
 go tool cover -func=coverage-go.out | grep '^total:'
 

--- a/scripts/test_unit_autoparallel.sh
+++ b/scripts/test_unit_autoparallel.sh
@@ -3,90 +3,70 @@ set -euo pipefail
 
 # Shard Go unit tests across CI workers.
 # Usage (Semaphore example):
-#   make test.coverage.autoparallel INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
-#
-# Environment:
-#   INDEX - 1-based index of this shard (defaults to 1)
-#   TOTAL - total number of shards (defaults to 1)
+#   make test.coverage.autoparallel SHARD_INDEX=$SEMAPHORE_JOB_INDEX SHARD_COUNT=$SEMAPHORE_JOB_COUNT
 
-INDEX="${INDEX:-${SEMAPHORE_JOB_INDEX:-1}}"
-TOTAL="${TOTAL:-${SEMAPHORE_JOB_COUNT:-1}}"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/shard_args.sh"
 
-if ! [[ "$INDEX" =~ ^[0-9]+$ ]] || ! [[ "$TOTAL" =~ ^[0-9]+$ ]]; then
-  echo "INDEX and TOTAL must be positive integers (got INDEX=${INDEX}, TOTAL=${TOTAL})" >&2
-  exit 1
-fi
-
-if [[ "$TOTAL" -lt 1 ]]; then
-  echo "TOTAL must be >= 1 (got ${TOTAL})" >&2
-  exit 1
-fi
-
-if [[ "$INDEX" -lt 1 || "$INDEX" -gt "$TOTAL" ]]; then
-  echo "INDEX must be between 1 and TOTAL (${TOTAL}), got ${INDEX}" >&2
-  exit 1
-fi
-
-echo "Running unit tests shard ${INDEX}/${TOTAL}"
+echo "Running unit tests shard ${SHARD_INDEX}/${SHARD_COUNT}"
 
 module_prefix="$(go list -m)"
-mapfile -t all_packages < <(go list ./pkg/...)
 
-if [[ "${#all_packages[@]}" -eq 0 ]]; then
+# Weigh each package by its test file count, so that heavy packages do not
+# cluster on one shard.
+weighted_packages=()
+while IFS= read -r import_path; do
+  package_dir="./${import_path#"$module_prefix"/}"
+  test_file_count="$(find "$package_dir" -maxdepth 1 -type f -name '*_test.go' | wc -l | tr -d ' ')"
+  weighted_packages+=("${test_file_count}:${package_dir}")
+done < <(go list ./pkg/...)
+
+if [[ "${#weighted_packages[@]}" -eq 0 ]]; then
   echo "No packages found under ./pkg, nothing to run."
   exit 0
 fi
 
-# Balance shards by *_test.go count so large packages do not cluster on one job.
-package_weights=()
-for import_path in "${all_packages[@]}"; do
-  rel="./${import_path#"${module_prefix}/"}"
-  weight="$(find "$rel" -maxdepth 1 -type f -name '*_test.go' 2>/dev/null | wc -l | tr -d ' ')"
-  package_weights+=("${weight}:${import_path}")
+# Heaviest package first, so the greedy assignment below stays balanced.
+sorted_packages=()
+while IFS= read -r entry; do
+  sorted_packages+=("$entry")
+done < <(printf '%s\n' "${weighted_packages[@]}" | sort -t: -k1,1nr -k2,2)
+
+shard_loads=()
+for ((shard = 0; shard < SHARD_COUNT; shard++)); do
+  shard_loads+=("0")
 done
 
-mapfile -t package_weights < <(printf '%s\n' "${package_weights[@]}" | sort -t: -k1,1nr -k2,2)
+# Assign every package to the least loaded shard, and keep the ones for us.
+shard_packages=()
+for entry in "${sorted_packages[@]}"; do
+  test_file_count="${entry%%:*}"
+  package_dir="${entry#*:}"
 
-shard_weights=()
-for ((i = 0; i < TOTAL; i++)); do
-  shard_weights+=("0")
-done
-
-selected_packages=()
-for entry in "${package_weights[@]}"; do
-  weight="${entry%%:*}"
-  import_path="${entry#*:}"
   lightest_shard=0
-  lightest_weight="${shard_weights[0]}"
-  for ((i = 1; i < TOTAL; i++)); do
-    if [[ "${shard_weights[$i]}" -lt "$lightest_weight" ]]; then
-      lightest_shard="$i"
-      lightest_weight="${shard_weights[$i]}"
+  for ((shard = 1; shard < SHARD_COUNT; shard++)); do
+    if [[ "${shard_loads[$shard]}" -lt "${shard_loads[$lightest_shard]}" ]]; then
+      lightest_shard="$shard"
     fi
   done
 
-  shard_index=$((lightest_shard + 1))
-  shard_weights[$lightest_shard]=$((lightest_weight + weight))
-  if [[ "$shard_index" -eq "$INDEX" ]]; then
-    selected_packages+=("${import_path}")
+  shard_loads[$lightest_shard]=$((shard_loads[lightest_shard] + test_file_count))
+  if [[ $((lightest_shard + 1)) -eq "$SHARD_INDEX" ]]; then
+    shard_packages+=("$package_dir")
   fi
 done
 
-if [[ "${#selected_packages[@]}" -eq 0 ]]; then
-  echo "No packages assigned to shard ${INDEX}/${TOTAL}; exiting successfully."
+if [[ "${#shard_packages[@]}" -eq 0 ]]; then
+  echo "No packages assigned to shard ${SHARD_INDEX}/${SHARD_COUNT}; exiting successfully."
   exit 0
 fi
 
-selected_rel=()
-echo "Selected packages for shard ${INDEX}/${TOTAL}:"
-for import_path in "${selected_packages[@]}"; do
-  rel="./${import_path#"${module_prefix}/"}"
-  selected_rel+=("$rel")
-  echo "  - ${rel}"
+echo "Selected packages for shard ${SHARD_INDEX}/${SHARD_COUNT}:"
+for package_dir in "${shard_packages[@]}"; do
+  echo "  - ${package_dir}"
 done
 echo ""
 
-packages_csv="$(IFS=','; echo "${selected_rel[*]}")"
+packages_csv="$(IFS=','; echo "${shard_packages[*]}")"
 
 gotestsum \
   --format short \
@@ -101,7 +81,7 @@ gotestsum \
 go tool cover -func=coverage-go.out | grep '^total:'
 
 coverage_args=(--profile coverage-go.out)
-if [[ "$TOTAL" -gt 1 ]]; then
+if [[ "$SHARD_COUNT" -gt 1 ]]; then
   coverage_args+=(--ignore-missing-packages)
 fi
 

--- a/scripts/test_unit_autoparallel.sh
+++ b/scripts/test_unit_autoparallel.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shard Go unit tests across CI workers.
+# Usage (Semaphore example):
+#   make test.coverage.autoparallel INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
+#
+# Environment:
+#   INDEX - 1-based index of this shard (defaults to 1)
+#   TOTAL - total number of shards (defaults to 1)
+
+INDEX="${INDEX:-${SEMAPHORE_JOB_INDEX:-1}}"
+TOTAL="${TOTAL:-${SEMAPHORE_JOB_COUNT:-1}}"
+
+if ! [[ "$INDEX" =~ ^[0-9]+$ ]] || ! [[ "$TOTAL" =~ ^[0-9]+$ ]]; then
+  echo "INDEX and TOTAL must be positive integers (got INDEX=${INDEX}, TOTAL=${TOTAL})" >&2
+  exit 1
+fi
+
+if [[ "$TOTAL" -lt 1 ]]; then
+  echo "TOTAL must be >= 1 (got ${TOTAL})" >&2
+  exit 1
+fi
+
+if [[ "$INDEX" -lt 1 || "$INDEX" -gt "$TOTAL" ]]; then
+  echo "INDEX must be between 1 and TOTAL (${TOTAL}), got ${INDEX}" >&2
+  exit 1
+fi
+
+echo "Running unit tests shard ${INDEX}/${TOTAL}"
+
+module_prefix="$(go list -m)"
+mapfile -t all_packages < <(go list ./pkg/...)
+
+if [[ "${#all_packages[@]}" -eq 0 ]]; then
+  echo "No packages found under ./pkg, nothing to run."
+  exit 0
+fi
+
+# Balance shards by *_test.go count so large packages do not cluster on one job.
+package_weights=()
+for import_path in "${all_packages[@]}"; do
+  rel="./${import_path#"${module_prefix}/"}"
+  weight="$(find "$rel" -maxdepth 1 -type f -name '*_test.go' 2>/dev/null | wc -l | tr -d ' ')"
+  package_weights+=("${weight}:${import_path}")
+done
+
+mapfile -t package_weights < <(printf '%s\n' "${package_weights[@]}" | sort -t: -k1,1nr -k2,2)
+
+shard_weights=()
+for ((i = 0; i < TOTAL; i++)); do
+  shard_weights+=("0")
+done
+
+selected_packages=()
+for entry in "${package_weights[@]}"; do
+  weight="${entry%%:*}"
+  import_path="${entry#*:}"
+  lightest_shard=0
+  lightest_weight="${shard_weights[0]}"
+  for ((i = 1; i < TOTAL; i++)); do
+    if [[ "${shard_weights[$i]}" -lt "$lightest_weight" ]]; then
+      lightest_shard="$i"
+      lightest_weight="${shard_weights[$i]}"
+    fi
+  done
+
+  shard_index=$((lightest_shard + 1))
+  shard_weights[$lightest_shard]=$((lightest_weight + weight))
+  if [[ "$shard_index" -eq "$INDEX" ]]; then
+    selected_packages+=("${import_path}")
+  fi
+done
+
+if [[ "${#selected_packages[@]}" -eq 0 ]]; then
+  echo "No packages assigned to shard ${INDEX}/${TOTAL}; exiting successfully."
+  exit 0
+fi
+
+selected_rel=()
+echo "Selected packages for shard ${INDEX}/${TOTAL}:"
+for import_path in "${selected_packages[@]}"; do
+  rel="./${import_path#"${module_prefix}/"}"
+  selected_rel+=("$rel")
+  echo "  - ${rel}"
+done
+echo ""
+
+packages_csv="$(IFS=','; echo "${selected_rel[*]}")"
+
+gotestsum \
+  --format short \
+  --junitfile junit-report.xml \
+  --packages="${packages_csv}" \
+  -- \
+  -p 1 \
+  -coverprofile=coverage-go.out \
+  -covermode=atomic \
+  -coverpkg="${packages_csv}"
+
+go tool cover -func=coverage-go.out | grep '^total:'
+
+coverage_args=(--profile coverage-go.out)
+if [[ "$TOTAL" -gt 1 ]]; then
+  coverage_args+=(--ignore-missing-packages)
+fi
+
+go run ./scripts/check_go_coverage_budget.go "${coverage_args[@]}"


### PR DESCRIPTION
## Summary

Backend unit tests run as one Semaphore job today. That job waits for every package and delays the pipeline.

This change splits `./pkg/...` across four parallel jobs. Each job still checks coverage for the packages that it runs.

The shard arguments are now `SHARD_INDEX` and `SHARD_COUNT` for all three sharded suites (backend unit, E2E, UI). The shared checks live in `scripts/lib/shard_args.sh`, which replaces the generic `INDEX` and `TOTAL` variables in the Makefile.

## Test plan

- [ ] Confirm CI starts four Unit Tests jobs on this pull request.
- [ ] Confirm each job runs a different package set and all jobs pass.
- [ ] Confirm the E2E and UI shard jobs still pass with the renamed variables.
- [ ] Confirm a package coverage drop still fails the job that owns that package.
- [ ] Run `make test.coverage.check` locally and confirm the full coverage budget still applies.

Made with [Cursor](https://cursor.com)
