### PR TITLE
fix: Give the intake analysis node credentials

### DIFF
--- a/pkg/grpc/actions/factories/create_factory_intake.go
+++ b/pkg/grpc/actions/factories/create_factory_intake.go
@@ -79,6 +79,7 @@ func CreateFactoryIntake(
 		Name:           name,
 		ConfidencePct:  confidencePct,
 		Binding:        binding,
+		Agent:          resolveIntakeAgent(db, factory),
 	})
 	if err != nil {
 		return nil, err
@@ -121,6 +122,7 @@ type intakeCanvasRequest struct {
 	Name           string
 	ConfidencePct  int
 	Binding        *intakeBinding
+	Agent          *intakeAgent
 }
 
 // createIntakeCanvas builds the intake graph and commits it as the canvas's
@@ -132,7 +134,7 @@ func createIntakeCanvas(
 	request intakeCanvasRequest,
 ) (uuid.UUID, error) {
 	orgID := request.OrganizationID
-	canvasDoc, err := buildIntakeCanvas(request.Source, request.Name, request.ConfidencePct, request.Binding)
+	canvasDoc, err := buildIntakeCanvas(request)
 	if err != nil {
 		return uuid.Nil, factoryErrorToStatus(err, "failed to create factory intake")
 	}

--- a/pkg/grpc/actions/factories/factory_intake_test.go
+++ b/pkg/grpc/actions/factories/factory_intake_test.go
@@ -95,6 +95,33 @@ func Test__FactoryIntakeActions(t *testing.T) {
 		assert.NotContains(t, trigger.Configuration, "repository")
 	})
 
+	t.Run("an intake of a set up workspace has no incomplete node", func(t *testing.T) {
+		factory := newFactory(t)
+		agentID := createReadyOnboardingIntegration(t, r.Organization.ID, "claude")
+		require.NoError(t, factory.UpdateOnboarding(database.DB(t.Context()), models.FactoryOnboardingPatch{
+			AgentIntegrationID: &agentID,
+		}))
+
+		intake := create(t, factory, &pb.CreateFactoryIntakeRequest{Source: pb.FactoryIntake_SOURCE_GITHUB_ISSUES})
+
+		// A node the canvas reports an error on cannot run, so the intake
+		// would look ready and never produce a work order. The trigger stays
+		// out: it validates against the GitHub API, which the installation of
+		// the test cannot answer. Its binding has a test of its own.
+		for _, node := range liveIntakeNodes(t, r.Organization.ID, intake) {
+			if node.ID == intakeTriggerNodeID {
+				continue
+			}
+			assert.Nilf(t, node.ErrorMessage, "node %s is incomplete: %s", node.ID, nodeErrorMessage(node))
+		}
+
+		analysis := liveIntakeNode(t, r.Organization.ID, intake, intakeAnalysisNodeID)
+		assert.Equal(t, "runnerClaudeCode", analysis.ComponentName())
+		credentials, ok := analysis.Configuration["credentials"].(map[string]any)
+		require.True(t, ok, "analysis node has no credentials")
+		assert.Equal(t, "integration", credentials["source"])
+	})
+
 	t.Run("a source can have several intakes", func(t *testing.T) {
 		factory := newFactory(t)
 		first := create(t, factory, &pb.CreateFactoryIntakeRequest{Source: pb.FactoryIntake_SOURCE_GITHUB_ISSUES})
@@ -304,18 +331,37 @@ func Test__FactoryIntakeActions(t *testing.T) {
 func liveIntakeTrigger(t *testing.T, organizationID uuid.UUID, intake *pb.FactoryIntake) models.Node {
 	t.Helper()
 
+	return liveIntakeNode(t, organizationID, intake, intakeTriggerNodeID)
+}
+
+func liveIntakeNode(t *testing.T, organizationID uuid.UUID, intake *pb.FactoryIntake, nodeID string) models.Node {
+	t.Helper()
+
+	for _, node := range liveIntakeNodes(t, organizationID, intake) {
+		if node.ID == nodeID {
+			return node
+		}
+	}
+
+	require.Failf(t, "node not found", "intake canvas %s has no node %q", intake.GetCanvasId(), nodeID)
+	return models.Node{}
+}
+
+func nodeErrorMessage(node models.Node) string {
+	if node.ErrorMessage == nil {
+		return ""
+	}
+	return *node.ErrorMessage
+}
+
+func liveIntakeNodes(t *testing.T, organizationID uuid.UUID, intake *pb.FactoryIntake) []models.Node {
+	t.Helper()
+
 	canvas, err := models.FindCanvasInTransaction(database.DB(t.Context()), organizationID, uuid.MustParse(intake.GetCanvasId()))
 	require.NoError(t, err)
 
 	liveVersion, err := models.FindLiveCanvasVersionByCanvasInTransaction(database.DB(t.Context()), canvas)
 	require.NoError(t, err)
 
-	for _, node := range liveVersion.Nodes {
-		if node.ID == intakeTriggerNodeID {
-			return node
-		}
-	}
-
-	require.Failf(t, "trigger not found", "intake canvas %s has no node %q", intake.GetCanvasId(), intakeTriggerNodeID)
-	return models.Node{}
+	return liveVersion.Nodes
 }

--- a/pkg/grpc/actions/factories/intake_agent.go
+++ b/pkg/grpc/actions/factories/intake_agent.go
@@ -1,0 +1,228 @@
+package factories
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/components/runner"
+	"github.com/superplanehq/superplane/pkg/models"
+	"gorm.io/gorm"
+)
+
+// intakeAgentSpec pairs one runner component with the installation and the
+// SuperPlane-hosted provider that can authenticate it. The order of the list is
+// the order an intake prefers, and it follows the order the workspace setup
+// offers the providers in.
+type intakeAgentSpec struct {
+	component      string
+	integrationApp string
+	hostedProvider string
+	// hostedModelHint is the part of a model id an intake looks for first on a
+	// hosted allowlist. An allowlist without it falls back to its first model.
+	hostedModelHint string
+	// model is the model the runner asks for when it authenticates with an
+	// installation. Only OpenRouter needs one; the other runners have a
+	// default of their own.
+	model string
+}
+
+var intakeAgentSpecs = []intakeAgentSpec{
+	{
+		component:       "runnerClaudeCode",
+		integrationApp:  "claude",
+		hostedProvider:  models.UsageProviderAnthropic,
+		hostedModelHint: "sonnet",
+	},
+	{
+		component:       "runnerCodex",
+		integrationApp:  "openai",
+		hostedProvider:  models.UsageProviderOpenAI,
+		hostedModelHint: "gpt-5",
+	},
+	{
+		component:       "runnerOpenRouter",
+		integrationApp:  "openrouter",
+		hostedProvider:  models.UsageProviderOpenRouter,
+		hostedModelHint: "sonnet",
+		model:           "anthropic/claude-sonnet-4-6",
+	},
+}
+
+// intakeAgent is the runner the generated analysis node scores with, together
+// with the credentials it authenticates by. A runner node without credentials
+// cannot run, so an intake takes the agent the workspace already uses.
+type intakeAgent struct {
+	Component   string
+	Credentials map[string]any
+	Model       string
+}
+
+func (a *intakeAgent) component() string {
+	if a == nil || a.Component == "" {
+		return intakeAgentSpecs[0].component
+	}
+	return a.Component
+}
+
+func (a *intakeAgent) credentials() map[string]any {
+	if a == nil {
+		return nil
+	}
+	return a.Credentials
+}
+
+func (a *intakeAgent) model() string {
+	if a == nil {
+		return ""
+	}
+	return a.Model
+}
+
+// resolveIntakeAgent picks the runner and the credentials of the analysis node.
+// The workspace setup records the coding agent of the workspace, so an intake
+// scores with the same one. A workspace that named no agent still has its
+// installations and the hosted providers to fall back on. An intake that finds
+// nothing keeps an incomplete analysis node, and the user completes it in the
+// canvas.
+func resolveIntakeAgent(tx *gorm.DB, factory *models.Factory) *intakeAgent {
+	config := factory.OnboardingConfigValue()
+	if agent := intakeAgentFromSetup(tx, factory, config.AgentIntegrationID); agent != nil {
+		return agent
+	}
+
+	if agent := intakeAgentFromInstallations(tx, factory); agent != nil {
+		return agent
+	}
+
+	return intakeAgentFromHostedProvider(tx, factory)
+}
+
+// intakeAgentFromSetup reads the agent the workspace setup recorded. A setup
+// that used hosted credentials records no installation, and a setup that used
+// an agent without a runner component (such as Cursor) records one an intake
+// cannot score with, so both fall through to the other sources.
+func intakeAgentFromSetup(tx *gorm.DB, factory *models.Factory, integrationID string) *intakeAgent {
+	if strings.TrimSpace(integrationID) == "" {
+		return nil
+	}
+
+	id, err := uuid.Parse(integrationID)
+	if err != nil {
+		log.Warnf("factory %s: intake ignores the setup agent, invalid integration id %q", factory.ID, integrationID)
+		return nil
+	}
+
+	integration, err := models.FindIntegrationInTransaction(tx, factory.OrganizationID, id)
+	if err != nil {
+		log.Warnf("factory %s: intake ignores the setup agent, integration %s not found: %v", factory.ID, id, err)
+		return nil
+	}
+
+	return intakeAgentFromIntegration(integration)
+}
+
+// intakeAgentFromInstallations takes the first agent installation the
+// organization has, in the order an intake prefers. A workspace set up before
+// setup recorded its agent reaches its agent this way.
+func intakeAgentFromInstallations(tx *gorm.DB, factory *models.Factory) *intakeAgent {
+	integrations, err := models.ListIntegrations(tx, factory.OrganizationID)
+	if err != nil {
+		log.Warnf("factory %s: intake cannot read the installations of the organization: %v", factory.ID, err)
+		return nil
+	}
+
+	for _, spec := range intakeAgentSpecs {
+		for i := range integrations {
+			if integrations[i].AppName != spec.integrationApp {
+				continue
+			}
+			if agent := intakeAgentFromIntegration(&integrations[i]); agent != nil {
+				return agent
+			}
+		}
+	}
+
+	return nil
+}
+
+// intakeAgentFromHostedProvider falls back to SuperPlane-hosted credentials.
+// A hosted run needs a model from the allowlist of the provider, so a provider
+// without one cannot serve the intake.
+func intakeAgentFromHostedProvider(tx *gorm.DB, factory *models.Factory) *intakeAgent {
+	providers, err := models.ListHostedLLMProviders(tx)
+	if err != nil {
+		log.Warnf("factory %s: intake cannot read the hosted providers: %v", factory.ID, err)
+		return nil
+	}
+
+	for _, spec := range intakeAgentSpecs {
+		index := slices.IndexFunc(providers, func(provider models.HostedLLMProvider) bool {
+			return provider.Provider == spec.hostedProvider && provider.OffersHostedModels()
+		})
+		if index < 0 {
+			continue
+		}
+
+		model := hostedIntakeModel(providers[index], spec.hostedModelHint)
+		if model == "" {
+			continue
+		}
+
+		return &intakeAgent{
+			Component:   spec.component,
+			Credentials: map[string]any{"source": runner.CredentialsSourceHosted},
+			Model:       model,
+		}
+	}
+
+	return nil
+}
+
+func intakeAgentFromIntegration(integration *models.Integration) *intakeAgent {
+	if integration.State != models.IntegrationStateReady {
+		return nil
+	}
+
+	index := slices.IndexFunc(intakeAgentSpecs, func(spec intakeAgentSpec) bool {
+		return spec.integrationApp == integration.AppName
+	})
+	if index < 0 {
+		return nil
+	}
+
+	return &intakeAgent{
+		Component: intakeAgentSpecs[index].component,
+		Credentials: map[string]any{
+			"source":      runner.CredentialsSourceIntegration,
+			"integration": map[string]any{"name": integration.InstallationName},
+		},
+		Model: intakeAgentSpecs[index].model,
+	}
+}
+
+// hostedIntakeModel picks the model an intake scores with from an allowlist.
+// The list is free-form, so the hint only expresses a preference: any
+// allowlisted model can run the analysis. The choice is stable, because an
+// intake that is created twice has to produce the same graph.
+func hostedIntakeModel(provider models.HostedLLMProvider, hint string) string {
+	allowed := []string{}
+	for _, model := range provider.AllowedModels {
+		if trimmed := strings.TrimSpace(model); trimmed != "" {
+			allowed = append(allowed, trimmed)
+		}
+	}
+	if len(allowed) == 0 {
+		return ""
+	}
+
+	slices.Sort(allowed)
+	for _, model := range allowed {
+		if strings.Contains(strings.ToLower(model), hint) {
+			return model
+		}
+	}
+
+	return allowed[0]
+}

--- a/pkg/grpc/actions/factories/intake_agent_test.go
+++ b/pkg/grpc/actions/factories/intake_agent_test.go
@@ -1,0 +1,172 @@
+package factories
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/components/runner"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+)
+
+func Test__ResolveIntakeAgent(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+
+	newFactoryIn := func(t *testing.T, organizationID uuid.UUID) *models.Factory {
+		t.Helper()
+		factory, err := models.CreateFactory(db, organizationID, support.RandomName("factory"), "", "")
+		require.NoError(t, err)
+		return factory
+	}
+
+	t.Run("the intake scores with the agent the setup recorded", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		agentID := createReadyOnboardingIntegration(t, organization.ID, "openai")
+		require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
+			AgentIntegrationID: &agentID,
+		}))
+
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
+		assert.Equal(t, "runnerCodex", agent.Component)
+		assert.Equal(t, runner.CredentialsSourceIntegration, agent.Credentials["source"])
+		assert.Equal(t, integrationName(t, organization.ID, agentID), integrationRefName(t, agent))
+	})
+
+	t.Run("OpenRouter needs the model the runner asks for", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		agentID := createReadyOnboardingIntegration(t, organization.ID, "openrouter")
+		require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
+			AgentIntegrationID: &agentID,
+		}))
+
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
+		assert.Equal(t, "runnerOpenRouter", agent.Component)
+		assert.NotEmpty(t, agent.Model)
+	})
+
+	t.Run("an agent without a runner falls back to the installations", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		cursorID := createReadyOnboardingIntegration(t, organization.ID, "cursor")
+		claudeID := createReadyOnboardingIntegration(t, organization.ID, "claude")
+		require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
+			AgentIntegrationID: &cursorID,
+		}))
+
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
+		assert.Equal(t, "runnerClaudeCode", agent.Component)
+		assert.Equal(t, integrationName(t, organization.ID, claudeID), integrationRefName(t, agent))
+	})
+
+	t.Run("a setup without an agent uses the installations of the organization", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		claudeID := createReadyOnboardingIntegration(t, organization.ID, "claude")
+
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
+		assert.Equal(t, "runnerClaudeCode", agent.Component)
+		assert.Equal(t, integrationName(t, organization.ID, claudeID), integrationRefName(t, agent))
+	})
+
+	t.Run("an organization without an installation runs on hosted credentials", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		clearHostedLLMProviders(t, db)
+		_, err := models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+			Provider:      models.UsageProviderAnthropic,
+			Enabled:       true,
+			APIKey:        []byte("test-hosted-key"),
+			AllowedModels: datatypes.JSONSlice[string]{"claude-haiku-4-6", "claude-sonnet-4-6"},
+		})
+		require.NoError(t, err)
+
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
+		assert.Equal(t, "runnerClaudeCode", agent.Component)
+		assert.Equal(t, map[string]any{"source": runner.CredentialsSourceHosted}, agent.Credentials)
+		assert.Equal(t, "claude-sonnet-4-6", agent.Model)
+	})
+
+	t.Run("a workspace with no agent at all leaves the node incomplete", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		clearHostedLLMProviders(t, db)
+
+		assert.Nil(t, resolveIntakeAgent(db, factory))
+	})
+
+	t.Run("an installation that is not ready cannot authenticate the runner", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		clearHostedLLMProviders(t, db)
+		integration, err := models.CreateIntegration(
+			uuid.New(),
+			organization.ID,
+			"claude",
+			support.RandomName("claude"),
+			map[string]any{},
+		)
+		require.NoError(t, err)
+		agentID := integration.ID.String()
+		require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
+			AgentIntegrationID: &agentID,
+		}))
+
+		assert.Nil(t, resolveIntakeAgent(db, factory))
+	})
+}
+
+func Test__HostedIntakeModel(t *testing.T) {
+	t.Run("prefers the model the hint names", func(t *testing.T) {
+		provider := models.HostedLLMProvider{
+			AllowedModels: datatypes.JSONSlice[string]{"gpt-5-mini", "gpt-4.1"},
+		}
+		assert.Equal(t, "gpt-5-mini", hostedIntakeModel(provider, "gpt-5"))
+	})
+
+	t.Run("takes the first model when the hint misses", func(t *testing.T) {
+		provider := models.HostedLLMProvider{
+			AllowedModels: datatypes.JSONSlice[string]{"  ", "z-model", "a-model"},
+		}
+		assert.Equal(t, "a-model", hostedIntakeModel(provider, "sonnet"))
+	})
+
+	t.Run("reports no model for an empty allowlist", func(t *testing.T) {
+		assert.Empty(t, hostedIntakeModel(models.HostedLLMProvider{}, "sonnet"))
+	})
+}
+
+func integrationName(t *testing.T, organizationID uuid.UUID, integrationID string) string {
+	t.Helper()
+
+	integration, err := models.FindIntegrationInTransaction(
+		database.DB(t.Context()),
+		organizationID,
+		uuid.MustParse(integrationID),
+	)
+	require.NoError(t, err)
+
+	return integration.InstallationName
+}
+
+func integrationRefName(t *testing.T, agent *intakeAgent) string {
+	t.Helper()
+
+	ref, ok := agent.Credentials["integration"].(map[string]any)
+	require.True(t, ok, "credentials have no integration reference")
+	name, ok := ref["name"].(string)
+	require.True(t, ok, "integration reference has no name")
+
+	return name
+}

--- a/pkg/grpc/actions/factories/intake_graph_test.go
+++ b/pkg/grpc/actions/factories/intake_graph_test.go
@@ -95,7 +95,7 @@ func Test__ResolveIntakeGraph(t *testing.T) {
 func intakeSpecFromTemplate(t *testing.T, source string, confidencePct int) models.LiveCanvasSpec {
 	t.Helper()
 
-	canvas, err := buildIntakeCanvas(source, "", confidencePct, nil)
+	canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: source, ConfidencePct: confidencePct})
 	require.NoError(t, err)
 
 	return models.LiveCanvasSpec{Nodes: canvas.Nodes(), Edges: canvas.Edges()}

--- a/pkg/grpc/actions/factories/intake_template.go
+++ b/pkg/grpc/actions/factories/intake_template.go
@@ -50,12 +50,17 @@ const (
 const intakeAnalysisMachineType = runner.MachineTypeE1LargeAMD64
 
 // intakeAnalysisComponents are the runners an intake can score with. Creation
-// always picks Claude Code, but a graph the user re-pointed at another runner
-// still has to resolve.
-var intakeAnalysisComponents = []string{
-	"runnerClaudeCode",
-	"runnerCodex",
-	"runnerOpenRouter",
+// picks the runner of the workspace agent, but a graph the user re-pointed at
+// another runner still has to resolve.
+var intakeAnalysisComponents = intakeAgentComponents()
+
+func intakeAgentComponents() []string {
+	components := make([]string, 0, len(intakeAgentSpecs))
+	for _, spec := range intakeAgentSpecs {
+		components = append(components, spec.component)
+	}
+
+	return components
 }
 
 type intakeSpec struct {
@@ -125,14 +130,16 @@ func intakeDefaultDescription(source string) string {
 // buildIntakeCanvas returns the canvas document for a new intake: listen on the
 // source, score the item with an agent, and create a work order when the score
 // clears the threshold. The binding tells the trigger which installation and
-// resource to listen on; without one the user completes the trigger by hand.
-func buildIntakeCanvas(source, name string, confidencePct int, binding *intakeBinding) (*yaml.Canvas, error) {
-	spec, ok := intakeSpecsBySource[source]
+// resource to listen on, and the agent tells the analysis node which runner to
+// score with; without them the user completes those nodes by hand.
+func buildIntakeCanvas(request intakeCanvasRequest) (*yaml.Canvas, error) {
+	spec, ok := intakeSpecsBySource[request.Source]
 	if !ok {
 		return nil, models.ErrFactoryIntakeSourceInvalid
 	}
 
-	if strings.TrimSpace(name) == "" {
+	name := strings.TrimSpace(request.Name)
+	if name == "" {
 		name = spec.name
 	}
 
@@ -156,26 +163,17 @@ func buildIntakeCanvas(source, name string, confidencePct int, binding *intakeBi
 					Name:          spec.triggerName,
 					Type:          yaml.NodeTypeTrigger,
 					Component:     spec.triggerComponent,
-					Configuration: intakeTriggerConfiguration(spec, binding),
-					Integration:   binding.integrationRef(),
+					Configuration: intakeTriggerConfiguration(spec, request.Binding),
+					Integration:   request.Binding.integrationRef(),
 					Position:      yaml.Position{X: 160, Y: 80},
 				},
 				{
-					ID:        intakeAnalysisNodeID,
-					Name:      intakeAnalysisNodeName,
-					Type:      yaml.NodeTypeAction,
-					Component: intakeAnalysisComponents[0],
-					Configuration: map[string]any{
-						"machineType": intakeAnalysisMachineType,
-						"steps": []any{
-							map[string]any{
-								"name":   "Analyze and score",
-								"type":   "prompt",
-								"prompt": intakeAnalysisPrompt(spec.analysisSubject),
-							},
-						},
-					},
-					Position: yaml.Position{X: 160, Y: 260},
+					ID:            intakeAnalysisNodeID,
+					Name:          intakeAnalysisNodeName,
+					Type:          yaml.NodeTypeAction,
+					Component:     request.Agent.component(),
+					Configuration: intakeAnalysisConfiguration(spec, request.Agent),
+					Position:      yaml.Position{X: 160, Y: 260},
 				},
 				{
 					ID:        intakeThresholdNodeID,
@@ -183,7 +181,7 @@ func buildIntakeCanvas(source, name string, confidencePct int, binding *intakeBi
 					Type:      yaml.NodeTypeAction,
 					Component: intakeThresholdComponent,
 					Configuration: map[string]any{
-						"expression": intakeThresholdExpression(confidencePct),
+						"expression": intakeThresholdExpression(request.ConfidencePct),
 					},
 					Position: yaml.Position{X: 160, Y: 440},
 				},
@@ -231,6 +229,31 @@ func intakeTriggerConfiguration(spec intakeSpec, binding *intakeBinding) map[str
 	}
 	for name, value := range binding.configuration() {
 		configuration[name] = value
+	}
+
+	return configuration
+}
+
+// intakeAnalysisConfiguration configures the runner that scores an item. The
+// runner components reject a node without a machine type or credentials, so the
+// generated node names the machine and the credentials of the workspace agent.
+func intakeAnalysisConfiguration(spec intakeSpec, agent *intakeAgent) map[string]any {
+	configuration := map[string]any{
+		"machineType": intakeAnalysisMachineType,
+		"steps": []any{
+			map[string]any{
+				"name":   "Analyze and score",
+				"type":   "prompt",
+				"prompt": intakeAnalysisPrompt(spec.analysisSubject),
+			},
+		},
+	}
+
+	if credentials := agent.credentials(); credentials != nil {
+		configuration["credentials"] = credentials
+	}
+	if model := agent.model(); model != "" {
+		configuration["model"] = model
 	}
 
 	return configuration

--- a/pkg/grpc/actions/factories/intake_template_test.go
+++ b/pkg/grpc/actions/factories/intake_template_test.go
@@ -20,7 +20,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 			models.FactoryIntakeSourceSentryExceptions:   "sentry.onIssue",
 			models.FactoryIntakeSourcePagerDutyIncidents: "pagerduty.onIncident",
 		} {
-			canvas, err := buildIntakeCanvas(source, "", DefaultIntakeConfidencePct, nil)
+			canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: source, ConfidencePct: DefaultIntakeConfidencePct})
 			require.NoError(t, err)
 
 			trigger := findSpecNode(t, canvas, intakeTriggerNodeID)
@@ -30,7 +30,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 	})
 
 	t.Run("the item flows from the trigger to the work order", func(t *testing.T) {
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
 		require.NoError(t, err)
 
 		assert.Equal(t, []yaml.Edge{
@@ -42,7 +42,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 	})
 
 	t.Run("the created work order receives the intake confidence score", func(t *testing.T) {
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
 		require.NoError(t, err)
 
 		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
@@ -55,7 +55,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 	})
 
 	t.Run("the score rounds onto the meter scale like the UI does", func(t *testing.T) {
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
 		require.NoError(t, err)
 
 		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
@@ -72,7 +72,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 	})
 
 	t.Run("the check level follows the meter bands", func(t *testing.T) {
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
 		require.NoError(t, err)
 
 		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
@@ -84,15 +84,64 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 	})
 
 	t.Run("the analysis runner asks for a machine", func(t *testing.T) {
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
 		require.NoError(t, err)
 
 		analysis := findSpecNode(t, canvas, intakeAnalysisNodeID)
 		assert.Equal(t, runner.MachineTypeE1LargeAMD64, analysis.Configuration["machineType"])
 	})
 
+	t.Run("the analysis runner authenticates with the workspace agent", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{
+			Source:        models.FactoryIntakeSourceGitHubIssues,
+			ConfidencePct: DefaultIntakeConfidencePct,
+			Agent: &intakeAgent{
+				Component: "runnerCodex",
+				Credentials: map[string]any{
+					"source":      runner.CredentialsSourceIntegration,
+					"integration": map[string]any{"name": "acme-openai"},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		analysis := findSpecNode(t, canvas, intakeAnalysisNodeID)
+		assert.Equal(t, "runnerCodex", analysis.Component)
+		assert.Equal(t, map[string]any{
+			"source":      runner.CredentialsSourceIntegration,
+			"integration": map[string]any{"name": "acme-openai"},
+		}, analysis.Configuration["credentials"])
+		// Codex reads its own default model, so the node leaves the model out.
+		assert.NotContains(t, analysis.Configuration, "model")
+	})
+
+	t.Run("a hosted agent names the model it runs", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{
+			Source:        models.FactoryIntakeSourceGitHubIssues,
+			ConfidencePct: DefaultIntakeConfidencePct,
+			Agent: &intakeAgent{
+				Component:   "runnerClaudeCode",
+				Credentials: map[string]any{"source": runner.CredentialsSourceHosted},
+				Model:       "claude-sonnet-4-6",
+			},
+		})
+		require.NoError(t, err)
+
+		analysis := findSpecNode(t, canvas, intakeAnalysisNodeID)
+		assert.Equal(t, "claude-sonnet-4-6", analysis.Configuration["model"])
+	})
+
+	t.Run("an intake without an agent leaves the credentials to the user", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
+		require.NoError(t, err)
+
+		analysis := findSpecNode(t, canvas, intakeAnalysisNodeID)
+		assert.Equal(t, intakeAgentSpecs[0].component, analysis.Component)
+		assert.NotContains(t, analysis.Configuration, "credentials")
+	})
+
 	t.Run("the threshold gates on the analysis score", func(t *testing.T) {
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", 80, nil)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: 80})
 		require.NoError(t, err)
 
 		threshold := findSpecNode(t, canvas, intakeThresholdNodeID)
@@ -101,7 +150,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 
 	t.Run("confidence outside the scale is clamped", func(t *testing.T) {
 		for confidence, expected := range map[int]int{-20: 0, 0: 0, 65: 65, 100: 100, 140: 100} {
-			canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", confidence, nil)
+			canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: confidence})
 			require.NoError(t, err)
 
 			threshold := findSpecNode(t, canvas, intakeThresholdNodeID)
@@ -112,17 +161,17 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 	})
 
 	t.Run("a given name wins over the source default", func(t *testing.T) {
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "Backlog triage", DefaultIntakeConfidencePct, nil)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, Name: "Backlog triage", ConfidencePct: DefaultIntakeConfidencePct})
 		require.NoError(t, err)
 		assert.Equal(t, "Backlog triage", canvas.Metadata.Name)
 
-		canvas, err = buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "   ", DefaultIntakeConfidencePct, nil)
+		canvas, err = buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, Name: "   ", ConfidencePct: DefaultIntakeConfidencePct})
 		require.NoError(t, err)
 		assert.Equal(t, "GitHub issues", canvas.Metadata.Name)
 	})
 
 	t.Run("an unknown source has no graph", func(t *testing.T) {
-		_, err := buildIntakeCanvas("linear-issues", "", DefaultIntakeConfidencePct, nil)
+		_, err := buildIntakeCanvas(intakeCanvasRequest{Source: "linear-issues", ConfidencePct: DefaultIntakeConfidencePct})
 		assert.ErrorIs(t, err, models.ErrFactoryIntakeSourceInvalid)
 	})
 
@@ -131,7 +180,11 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 			Integration:   &yaml.IntegrationRef{ID: "integration-1", Name: "acme-github"},
 			Configuration: map[string]any{"repository": "acme/backlog"},
 		}
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, binding)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{
+			Source:        models.FactoryIntakeSourceGitHubIssues,
+			ConfidencePct: DefaultIntakeConfidencePct,
+			Binding:       binding,
+		})
 		require.NoError(t, err)
 
 		trigger := findSpecNode(t, canvas, intakeTriggerNodeID)
@@ -142,12 +195,16 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 	})
 
 	t.Run("a binding does not leak into the next intake", func(t *testing.T) {
-		_, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, &intakeBinding{
-			Configuration: map[string]any{"repository": "acme/backlog"},
+		_, err := buildIntakeCanvas(intakeCanvasRequest{
+			Source:        models.FactoryIntakeSourceGitHubIssues,
+			ConfidencePct: DefaultIntakeConfidencePct,
+			Binding: &intakeBinding{
+				Configuration: map[string]any{"repository": "acme/backlog"},
+			},
 		})
 		require.NoError(t, err)
 
-		canvas, err := buildIntakeCanvas(models.FactoryIntakeSourceGitHubIssues, "", DefaultIntakeConfidencePct, nil)
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
 		require.NoError(t, err)
 
 		trigger := findSpecNode(t, canvas, intakeTriggerNodeID)


### PR DESCRIPTION
## Summary

A generated intake created its analysis node without credentials. The runner components require them, so the canvas showed `field 'credentials' is required` on the node.

The intake looked ready, but the analysis could not run. No work order was created from a new GitHub issue.

The intake now scores with the coding agent of the workspace. It uses the agent that the workspace setup recorded, then any ready agent installation of the organization, then SuperPlane-hosted credentials. A hosted node also receives a model from the allowlist of the provider, because a hosted run without a model is rejected.

A workspace with no agent keeps an incomplete analysis node, and the user completes it in the canvas. A message at creation time would be more helpful here. This is a follow-up.

## Test plan

- [ ] Complete the workspace setup with a connected Anthropic, OpenAI, or OpenRouter integration.
- [ ] Open the generated GitHub intake canvas. Confirm that the analysis node shows no error.
- [ ] Confirm that the analysis node uses the runner of the connected agent.
- [ ] Complete the workspace setup with hosted credit and no connected agent. Confirm that the analysis node uses hosted credentials and names a model.
- [ ] Create an intake from the Lines page. Confirm that the analysis node has credentials.
- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories`.

Made with [Cursor](https://cursor.com)