### PR TITLE
fix: Run Intake Nodes in Parallel

### DIFF
--- a/pkg/grpc/actions/factories/intake_template.go
+++ b/pkg/grpc/actions/factories/intake_template.go
@@ -41,6 +41,12 @@ const (
 	intakeConfidenceCautionAt  = 3
 	intakeConfidenceCriticalAt = 2
 
+	// intakeConcurrencyMax is how many items an intake node works on at once.
+	// A node runs one execution at a time by default, which makes a batch of
+	// items wait for each other: a seeded batch, or a source that reports many
+	// items in a burst, would take as long as the sum of its analyses.
+	intakeConcurrencyMax = 100
+
 	DefaultIntakeConfidencePct = 65
 )
 
@@ -173,6 +179,7 @@ func buildIntakeCanvas(request intakeCanvasRequest) (*yaml.Canvas, error) {
 					Type:          yaml.NodeTypeAction,
 					Component:     request.Agent.component(),
 					Configuration: intakeAnalysisConfiguration(spec, request.Agent),
+					Concurrency:   intakeConcurrency(),
 					Position:      yaml.Position{X: 160, Y: 260},
 				},
 				{
@@ -183,7 +190,8 @@ func buildIntakeCanvas(request intakeCanvasRequest) (*yaml.Canvas, error) {
 					Configuration: map[string]any{
 						"expression": intakeThresholdExpression(request.ConfidencePct),
 					},
-					Position: yaml.Position{X: 160, Y: 440},
+					Concurrency: intakeConcurrency(),
+					Position:    yaml.Position{X: 160, Y: 440},
 				},
 				{
 					ID:        intakeCreateNodeID,
@@ -194,7 +202,8 @@ func buildIntakeCanvas(request intakeCanvasRequest) (*yaml.Canvas, error) {
 						"title":       spec.createTitle,
 						"description": spec.createDescription,
 					},
-					Position: yaml.Position{X: 160, Y: 620},
+					Concurrency: intakeConcurrency(),
+					Position:    yaml.Position{X: 160, Y: 620},
 				},
 				{
 					ID:        intakeReportConfidenceNodeID,
@@ -212,11 +221,20 @@ func buildIntakeCanvas(request intakeCanvasRequest) (*yaml.Canvas, error) {
 						"cautionAt":  float64(intakeConfidenceCautionAt),
 						"criticalAt": float64(intakeConfidenceCriticalAt),
 					},
-					Position: yaml.Position{X: 160, Y: 800},
+					Concurrency: intakeConcurrency(),
+					Position:    yaml.Position{X: 160, Y: 800},
 				},
 			},
 		},
 	}, nil
+}
+
+// intakeConcurrency returns the concurrency of one intake node. Each node owns
+// its spec, so a later edit to one node cannot reach the others. Only action
+// nodes take a spec; a trigger has no queue to widen.
+func intakeConcurrency() *yaml.ConcurrencySpec {
+	max := intakeConcurrencyMax
+	return &yaml.ConcurrencySpec{Max: &max}
 }
 
 // intakeTriggerConfiguration lays the binding over the template so the trigger
@@ -270,8 +288,15 @@ func intakeAnalysisPrompt(subject string) string {
 	}, "\n")
 }
 
+// intakeAnalysisScorePath reads the score out of the analysis node's output. A
+// node reference resolves to one event, whose data holds the runner's result,
+// so the path walks straight into it rather than indexing a list.
+func intakeAnalysisScorePath() string {
+	return fmt.Sprintf(`$[%q].data.result.result`, intakeAnalysisNodeName)
+}
+
 func intakeThresholdExpression(confidencePct int) string {
-	return fmt.Sprintf(`int($[%q].data[0].result.result) >= %d`, intakeAnalysisNodeName, clampIntakeConfidence(confidencePct))
+	return fmt.Sprintf(`int(%s) >= %d`, intakeAnalysisScorePath(), clampIntakeConfidence(confidencePct))
 }
 
 func intakeWorkOrderIDExpression() string {
@@ -284,8 +309,8 @@ func intakeWorkOrderIDExpression() string {
 func intakeConfidenceScoreExpression() string {
 	pctPerPoint := 100 / intakeConfidenceScoreMax
 	return fmt.Sprintf(
-		`{{ int(round(int($[%q].data[0].result.result) / %d.0)) }}`,
-		intakeAnalysisNodeName, pctPerPoint,
+		`{{ int(round(int(%s) / %d.0)) }}`,
+		intakeAnalysisScorePath(), pctPerPoint,
 	)
 }
 

--- a/pkg/grpc/actions/factories/intake_template_test.go
+++ b/pkg/grpc/actions/factories/intake_template_test.go
@@ -61,7 +61,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
 		assert.Equal(
 			t,
-			`{{ int(round(int($["Analyze intake"].data[0].result.result) / 20.0)) }}`,
+			`{{ int(round(int($["Analyze intake"].data.result.result) / 20.0)) }}`,
 			report.Configuration["score"],
 		)
 
@@ -145,7 +145,35 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 		require.NoError(t, err)
 
 		threshold := findSpecNode(t, canvas, intakeThresholdNodeID)
-		assert.Equal(t, `int($["Analyze intake"].data[0].result.result) >= 80`, threshold.Configuration["expression"])
+		assert.Equal(t, `int($["Analyze intake"].data.result.result) >= 80`, threshold.Configuration["expression"])
+	})
+
+	t.Run("the threshold reads the score the analysis runner reports", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: 70})
+		require.NoError(t, err)
+
+		threshold := findSpecNode(t, canvas, intakeThresholdNodeID)
+		expression := threshold.Configuration["expression"].(string)
+		assert.False(t, evaluateIntakeThreshold(t, expression, 69))
+		assert.True(t, evaluateIntakeThreshold(t, expression, 70))
+	})
+
+	t.Run("every action node works on a whole batch at once", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
+		require.NoError(t, err)
+
+		for _, node := range canvas.Spec.Nodes {
+			// A trigger has no queue of its own, and the parser rejects a
+			// concurrency spec on it.
+			if node.Type == yaml.NodeTypeTrigger {
+				assert.Nilf(t, node.Concurrency, "trigger %s caps its concurrency", node.ID)
+				continue
+			}
+
+			require.NotNilf(t, node.Concurrency, "node %s has no concurrency", node.ID)
+			require.NotNilf(t, node.Concurrency.Max, "node %s has no concurrency max", node.ID)
+			assert.Equalf(t, intakeConcurrencyMax, *node.Concurrency.Max, "node %s", node.ID)
+		}
 	})
 
 	t.Run("confidence outside the scale is clamped", func(t *testing.T) {
@@ -233,21 +261,52 @@ func evaluateIntakeConfidenceScore(t *testing.T, expression string, pct int) int
 	t.Helper()
 
 	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(expression, "{{"), "}}"))
-	analysis := map[string]any{
-		"data": []any{
-			map[string]any{"result": map[string]any{"result": strconv.Itoa(pct)}},
-		},
-	}
-
-	output, err := expr.Eval(inner, map[string]any{
-		"$": map[string]any{intakeAnalysisNodeName: analysis},
-	})
-	require.NoError(t, err)
+	output := evaluateIntakeExpression(t, inner, pct)
 
 	score, ok := output.(int)
 	require.Truef(t, ok, "expression returned %T, want int", output)
 
 	return score
+}
+
+// evaluateIntakeThreshold runs the generated threshold expression. The if
+// component requires a boolean, so a wrong result path fails here instead of at
+// run time.
+func evaluateIntakeThreshold(t *testing.T, expression string, pct int) bool {
+	t.Helper()
+
+	output := evaluateIntakeExpression(t, expression, pct)
+
+	matches, ok := output.(bool)
+	require.Truef(t, ok, "expression returned %T, want bool", output)
+
+	return matches
+}
+
+// evaluateIntakeExpression resolves an expression against the event the
+// analysis runner emits when it finishes, so the generated result path is
+// checked against the shape the graph actually receives.
+func evaluateIntakeExpression(t *testing.T, expression string, pct int) any {
+	t.Helper()
+
+	analysis := map[string]any{
+		"type": intakeAgentSpecs[0].component + ".finished",
+		"data": map[string]any{
+			"status":    "succeeded",
+			"exit_code": 0,
+			"result": map[string]any{
+				"type":   "result",
+				"result": strconv.Itoa(pct),
+			},
+		},
+	}
+
+	output, err := expr.Eval(expression, map[string]any{
+		"$": map[string]any{intakeAnalysisNodeName: analysis},
+	})
+	require.NoError(t, err)
+
+	return output
 }
 
 func findSpecNode(t *testing.T, canvas *yaml.Canvas, nodeID string) yaml.Node {


### PR DESCRIPTION
## Summary

A new intake seeds several items at once, but each node runs one execution at a time by default. The seeded batch then waits in a line, and analysis time adds up.

The confidence `if` node also read the analysis score as a list. The runner emits one event object, so the node failed instead of routing to true or false.

This change sets concurrency to 100 on each intake action node. It also reads the score from the event data the runner emits.

Existing intakes keep the old graph. A settings update rewrites the threshold expression. Nodes keep concurrency 1 until you recreate the intake.

## Test plan

- [ ] Create a new GitHub issues intake with a bound repository.
- [ ] Confirm the analysis, threshold, create, and report nodes show concurrency 100.
- [ ] Confirm the trigger node has no concurrency setting.
- [ ] Open the threshold node and confirm the expression uses `.data.result.result`.
- [ ] Seed or wait for several issues, and confirm analyses start together.
- [ ] Confirm items above the threshold create a work order.


Made with [Cursor](https://cursor.com)