### PR TITLE
fix: Cancel runs before a work-order rerun

### DIFF
--- a/pkg/models/factory_work_order_line_dispatch.go
+++ b/pkg/models/factory_work_order_line_dispatch.go
@@ -525,6 +525,18 @@ func (l *FactoryWorkOrderLineDispatch) settleOpenWorkFrom(tx *gorm.DB, stepIndex
 	}
 
 	for i := range executions {
+		if executions[i].RunID != nil {
+			run, err := LockCanvasRunInTransaction(tx, *executions[i].RunID)
+			if err != nil {
+				return err
+			}
+			if run.State != CanvasRunStateFinished && run.State != CanvasRunStateCancelling {
+				if err := run.MarkAsCancelling(tx, nil); err != nil {
+					return err
+				}
+			}
+		}
+
 		if err := executions[i].MarkFinished(tx, CanvasRunResultCancelled); err != nil {
 			return err
 		}

--- a/pkg/models/factory_work_order_line_dispatch_test.go
+++ b/pkg/models/factory_work_order_line_dispatch_test.go
@@ -501,6 +501,10 @@ func Test__FactoryWorkOrder__RetryLineStep__SettlesInFlightStepBeforeRerun(t *te
 	require.NoError(t, err)
 	assert.Equal(t, models.FactoryWorkOrderExecutionStatusFinished, settled.Status)
 	assert.Equal(t, models.CanvasRunResultCancelled, settled.Result)
+
+	cancelledRun, err := models.FindCanvasRunInTransaction(db, secondApp.ID, *inFlight.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasRunStateCancelling, cancelledRun.State)
 }
 
 func Test__FactoryWorkOrder__RetryLineStep__AdmitsQueuedWorkForFreedSlot(t *testing.T) {

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunStopButton.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunStopButton.spec.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SplitRunStopButton } from "./SplitRunStopButton";
+
+describe("SplitRunStopButton", () => {
+  it("updates the default action when the footer kind changes", () => {
+    const { rerender } = render(<SplitRunStopButton kind="running" />);
+
+    expect(screen.getByRole("button", { name: "Stop and Close" })).toBeInTheDocument();
+
+    rerender(<SplitRunStopButton kind="failed" />);
+
+    expect(screen.getByRole("button", { name: "Rerun step" })).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunStopButton.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunStopButton.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdownMenu";
 import { Check, ChevronDown } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { WorkOrderDisplayStatus } from "../../lib/workOrderProgress";
 import {
@@ -40,6 +40,10 @@ export function SplitRunStopButton({
   const [choice, setChoice] = useState<SplitRunStopChoice>(
     () => defaultSplitRunStopChoice(status, kind) ?? DEFAULT_SPLIT_RUN_STOP_CHOICE,
   );
+  useEffect(() => {
+    setChoice(defaultSplitRunStopChoice(status, kind) ?? DEFAULT_SPLIT_RUN_STOP_CHOICE);
+  }, [kind, status]);
+
   const selectedId = choices.some((item) => item.id === choice) ? choice : choices[0]?.id;
   const selected = choices.find((item) => item.id === selectedId);
 


### PR DESCRIPTION
## Summary

A replaced traversal released its parallelism slot while its canvas run stayed active. This change requests cancellation before the replacement starts.

A mounted failed-run footer also retained its earlier Stop and Close selection. This change selects Rerun this step when the footer state changes.

Follow-up to #6899.

Made with [Cursor](https://cursor.com)