### PR TITLE
fix: Disable pagers in runner tasks

### DIFF
--- a/pkg/components/runner/claude/component_test.go
+++ b/pkg/components/runner/claude/component_test.go
@@ -105,9 +105,7 @@ func TestRunClaudeCodeExecuteSendsPerStepCommandsToBroker(t *testing.T) {
 	assert.Contains(t, req.Commands[4].Command, `source "$SUPERPLANE_TASK_DIR/steps/04-status.sh"`)
 	assert.Contains(t, string(body), `"name":"Clone"`)
 	assert.Empty(t, req.DockerImage)
-	require.Len(t, req.Environment, 1)
-	assert.Equal(t, envAnthropicAPIKey, req.Environment[0].Name)
-	assert.Equal(t, "sk-test-key", req.Environment[0].Value)
+	assert.Equal(t, "sk-test-key", requireEnvironmentValue(t, req.Environment, envAnthropicAPIKey))
 	assert.NotContains(t, string(body), `"message_chain"`)
 
 	require.Len(t, req.Files, 7)
@@ -241,9 +239,7 @@ func TestRunClaudeCodeExecuteInjectsHostedAPIKey(t *testing.T) {
 	require.NoError(t, err)
 	var req createTaskRequest
 	require.NoError(t, json.Unmarshal(body, &req))
-	require.Len(t, req.Environment, 1)
-	assert.Equal(t, envAnthropicAPIKey, req.Environment[0].Name)
-	assert.Equal(t, "sk-hosted", req.Environment[0].Value)
+	assert.Equal(t, "sk-hosted", requireEnvironmentValue(t, req.Environment, envAnthropicAPIKey))
 }
 
 func TestRunClaudeCodeExecuteInjectsHostedBaseURL(t *testing.T) {
@@ -287,11 +283,8 @@ func TestRunClaudeCodeExecuteInjectsHostedBaseURL(t *testing.T) {
 	require.NoError(t, err)
 	var req createTaskRequest
 	require.NoError(t, json.Unmarshal(body, &req))
-	require.Len(t, req.Environment, 2)
-	assert.Equal(t, envAnthropicAPIKey, req.Environment[0].Name)
-	assert.Equal(t, "sk-hosted", req.Environment[0].Value)
-	assert.Equal(t, envAnthropicBaseURL, req.Environment[1].Name)
-	assert.Equal(t, "https://proxy.example/v1", req.Environment[1].Value)
+	assert.Equal(t, "sk-hosted", requireEnvironmentValue(t, req.Environment, envAnthropicAPIKey))
+	assert.Equal(t, "https://proxy.example/v1", requireEnvironmentValue(t, req.Environment, envAnthropicBaseURL))
 }
 
 func TestRunClaudeCodeExecuteRejectsPrivateHostedBaseURL(t *testing.T) {

--- a/pkg/components/runner/claude/spec_test.go
+++ b/pkg/components/runner/claude/spec_test.go
@@ -205,6 +205,17 @@ func TestShellSingleQuote(t *testing.T) {
 	assert.Equal(t, `'it'\''s fine'`, runner.ShellSingleQuote("it's fine"))
 }
 
+func requireEnvironmentValue(t *testing.T, environment []runner.BrokerEnvironmentVariable, name string) string {
+	t.Helper()
+	for _, variable := range environment {
+		if variable.Name == name {
+			return variable.Value
+		}
+	}
+	t.Fatalf("missing environment variable %q", name)
+	return ""
+}
+
 func requireTaskFile(t *testing.T, files []runner.BrokerTaskFile, path string) runner.BrokerTaskFile {
 	t.Helper()
 	for _, file := range files {

--- a/pkg/components/runner/environment.go
+++ b/pkg/components/runner/environment.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/superplanehq/superplane/pkg/configuration"
@@ -15,6 +16,14 @@ const (
 	EnvironmentValueSourceLiteral = "literal"
 	EnvironmentValueSourceSecret  = "secret"
 )
+
+// Runner tasks execute with a terminal attached, so commands like `git log`
+// send their output to a pager that then waits for a key press and blocks the
+// task until it times out. Task environments disable paging by default.
+var pagerDefaults = []BrokerEnvironmentVariable{
+	{Name: "GIT_PAGER", Value: "cat"},
+	{Name: "PAGER", Value: "cat"},
+}
 
 type EnvironmentFromEntry struct {
 	Source      string                       `json:"source" mapstructure:"source"`
@@ -193,7 +202,25 @@ func ResolveEnvironment(
 		resolved = append(resolved, variable)
 	}
 
-	return resolved, nil
+	return prependPagerDefaults(resolved), nil
+}
+
+// prependPagerDefaults keeps the configured environment authoritative: a
+// variable set by the node, an integration, or a secret is never replaced.
+func prependPagerDefaults(environment []BrokerEnvironmentVariable) []BrokerEnvironmentVariable {
+	defaults := make([]BrokerEnvironmentVariable, 0, len(pagerDefaults))
+	for _, variable := range pagerDefaults {
+		configured := slices.ContainsFunc(environment, func(existing BrokerEnvironmentVariable) bool {
+			return existing.Name == variable.Name
+		})
+		if configured {
+			continue
+		}
+
+		defaults = append(defaults, variable)
+	}
+
+	return append(defaults, environment...)
 }
 
 func appendImportedEnvironmentVariables(

--- a/pkg/components/runner/environment_test.go
+++ b/pkg/components/runner/environment_test.go
@@ -177,14 +177,51 @@ func Test__ResolveEnvironment(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	got := map[string]string{}
-	for _, variable := range resolved {
-		got[variable.Name] = variable.Value
-	}
+	got := environmentValues(resolved)
 
 	assert.Equal(t, "override", got["GITHUB_TOKEN"])
 	assert.Equal(t, "org/repo", got["REPO"])
 	assert.Equal(t, "secret-key-value", got["API_KEY"])
+}
+
+func Test__ResolveEnvironmentDisablesPagers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pagers are disabled by default", func(t *testing.T) {
+		t.Parallel()
+
+		resolved, err := ResolveEnvironment(nil, nil, nil)
+		require.NoError(t, err)
+
+		got := environmentValues(resolved)
+		assert.Equal(t, "cat", got["GIT_PAGER"])
+		assert.Equal(t, "cat", got["PAGER"])
+	})
+
+	t.Run("configured pager wins", func(t *testing.T) {
+		t.Parallel()
+
+		resolved, err := ResolveEnvironment(nil, nil, []EnvironmentVariable{
+			{Name: "GIT_PAGER", ValueSource: EnvironmentValueSourceLiteral, Value: strPtr("less")},
+		})
+		require.NoError(t, err)
+
+		var names []string
+		for _, variable := range resolved {
+			names = append(names, variable.Name)
+		}
+
+		assert.Equal(t, []string{"PAGER", "GIT_PAGER"}, names)
+		assert.Equal(t, "less", environmentValues(resolved)["GIT_PAGER"])
+	})
+}
+
+func environmentValues(environment []BrokerEnvironmentVariable) map[string]string {
+	values := map[string]string{}
+	for _, variable := range environment {
+		values[variable.Name] = variable.Value
+	}
+	return values
 }
 
 func Test__ValidateEnvironmentFromConfigurationField(t *testing.T) {

--- a/pkg/components/runner/run_commands_test.go
+++ b/pkg/components/runner/run_commands_test.go
@@ -493,7 +493,7 @@ func TestRunnerExecuteUsesConfiguredMachineType(t *testing.T) {
 	assert.Equal(t, MachineTypeE1LargeARM64, req.FleetID)
 }
 
-func TestRunnerExecuteOmitsEmptyEnvironment(t *testing.T) {
+func TestRunnerExecuteSendsOnlyPagerDefaultsWithoutConfiguredEnvironment(t *testing.T) {
 	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
 	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
 	t.Setenv("TASK_BROKER_FLEET_ID", "")
@@ -520,7 +520,10 @@ func TestRunnerExecuteOmitsEmptyEnvironment(t *testing.T) {
 
 	body, err := io.ReadAll(httpContext.Requests[0].Body)
 	require.NoError(t, err)
-	assert.NotContains(t, string(body), "environment")
+
+	var req brokerCreateTaskRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	assert.Equal(t, pagerDefaults, req.Environment)
 }
 
 func TestRunnerExecuteFailsWhenSecretCannotBeResolved(t *testing.T) {


### PR DESCRIPTION
## Summary

Runner tasks execute with a terminal attached. Git sends the output of commands such as `git log` to a pager. The pager cannot drive a dumb terminal, so it prints `WARNING: terminal is not fully functional`, waits for a key press, and blocks the step until the execution timeout.

The implementation step of the factory line stopped this way. The `git status` command printed its output, and the following `git log --oneline -5` command opened the pager and blocked.

This change sets `GIT_PAGER` and `PAGER` to `cat` for every runner task. The defaults apply in `ResolveEnvironment`, which all runner components use. Bash steps, git commands that the agent runs inside prompt steps, and canvases that are already installed get the fix without a template change or a reinstall. A value from the node, an integration, or a secret still wins.

## Test plan

- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/components/runner/...`.
- [ ] Dispatch a work order and confirm the implementation step finishes.
- [ ] Confirm the step log shows the `git log` output and no pager warning.
- [ ] Set `GIT_PAGER` on a runner node and confirm the node value is used.

Made with [Cursor](https://cursor.com)