### PR TITLE
fix: Ask to create account after SSO

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -43,6 +43,7 @@ const (
 	authSignupResultParam      = "auth_signup_result"
 	authErrorParam             = "auth_error"
 	authErrorSignupRequired    = "signup_required"
+	authProviderParam          = "provider"
 	jsonContentType            = "application/json"
 )
 
@@ -144,7 +145,7 @@ func (a *Handler) RegisterRoutes(router *mux.Router) {
 func (a *Handler) handleAuth(w http.ResponseWriter, r *http.Request) {
 	gothUser, err := gothic.CompleteUserAuth(w, r)
 	if err == nil {
-		a.handleSuccessfulAuth(w, r, gothUser, false)
+		a.completeProviderAuth(w, r, gothUser)
 		return
 	}
 
@@ -181,36 +182,7 @@ func (a *Handler) handleDevAuth(w http.ResponseWriter, r *http.Request) {
 		AccessToken: "dev-token-" + provider,
 	}
 
-	account, wasCreated, err := a.findOrCreateAccountForProvider(mockUser, a.allowSignupFromRequest(r))
-
-	if err != nil {
-		if errors.Is(err, models.ErrAccountBlocked) {
-			redirectAccountBlocked(w, r)
-			return
-		}
-
-		if errors.Is(err, errSignupRequired) {
-			http.Redirect(w, r, getSignupRequiredRedirectURL(r), http.StatusSeeOther)
-			return
-		}
-
-		if errorStatusForAccountError(err) == http.StatusForbidden {
-			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
-
-		log.Errorf("Error finding/creating dev account for %s: %v", mockUser.Email, err)
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	err = updateAccountProviders(a.encryptor, account, mockUser)
-	if err != nil {
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	a.handleSuccessfulAuth(w, r, mockUser, wasCreated)
+	a.completeProviderAuth(w, r, mockUser)
 }
 
 func (a *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
@@ -220,24 +192,13 @@ func (a *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	a.completeProviderAuth(w, r, gothUser)
+}
+
+func (a *Handler) completeProviderAuth(w http.ResponseWriter, r *http.Request, gothUser goth.User) {
 	account, wasCreated, err := a.findOrCreateAccountForProvider(gothUser, a.allowSignupFromRequest(r))
 	if err != nil {
-		if errors.Is(err, models.ErrAccountBlocked) {
-			redirectAccountBlocked(w, r)
-			return
-		}
-
-		if errors.Is(err, errSignupRequired) {
-			http.Redirect(w, r, getSignupRequiredRedirectURL(r), http.StatusSeeOther)
-			return
-		}
-
-		if errorStatusForAccountError(err) == http.StatusForbidden {
-			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
-		log.Errorf("Error finding/creating account for %s: %v", gothUser.Email, err)
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		a.handleProviderAuthError(w, r, gothUser, err)
 		return
 	}
 
@@ -249,6 +210,26 @@ func (a *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	a.handleSuccessfulAuth(w, r, gothUser, wasCreated)
+}
+
+func (a *Handler) handleProviderAuthError(w http.ResponseWriter, r *http.Request, gothUser goth.User, err error) {
+	if errors.Is(err, models.ErrAccountBlocked) {
+		redirectAccountBlocked(w, r)
+		return
+	}
+
+	if errors.Is(err, errSignupRequired) {
+		http.Redirect(w, r, getSignupRequiredRedirectURL(r), http.StatusSeeOther)
+		return
+	}
+
+	if errorStatusForAccountError(err) == http.StatusForbidden {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	log.Errorf("Error finding/creating account for %s: %v", gothUser.Email, err)
+	http.Error(w, "Internal server error", http.StatusInternalServerError)
 }
 
 func (a *Handler) handleSuccessfulAuth(w http.ResponseWriter, r *http.Request, gothUser goth.User, wasCreated bool) {
@@ -811,12 +792,17 @@ func getSignupRequiredRedirectURL(r *http.Request) string {
 	params := url.Values{}
 	params.Set(authErrorParam, authErrorSignupRequired)
 
+	provider := mux.Vars(r)["provider"]
+	if provider != "" {
+		params.Set(authProviderParam, provider)
+	}
+
 	redirectURL := getRedirectURL(r)
 	if redirectURL != "/" {
 		params.Set("redirect", redirectURL)
 	}
 
-	return fmt.Sprintf("/signup?%s", params.Encode())
+	return fmt.Sprintf("/login?%s", params.Encode())
 }
 
 func generateMagicCode() (string, error) {

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -258,7 +258,16 @@ func (a *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 
 	ClearAccountCookie(w, r)
 
-	http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
+	http.Redirect(w, r, getPostLogoutRedirectURL(r), http.StatusTemporaryRedirect)
+}
+
+func getPostLogoutRedirectURL(r *http.Request) string {
+	redirectURL := getRedirectURL(r)
+	if redirectURL == "/" {
+		return "/login"
+	}
+
+	return "/login?redirect=" + url.QueryEscape(redirectURL)
 }
 
 func (a *Handler) handleAuthConfig(w http.ResponseWriter, r *http.Request) {

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/markbates/goth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -337,20 +338,82 @@ func TestGetRedirectURL(t *testing.T) {
 }
 
 func TestGetSignupRequiredRedirectURL(t *testing.T) {
-	t.Run("should redirect to signup with an auth error", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/auth/github/callback", nil)
+	t.Run("should redirect to login with an auth error and provider", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/google/callback", nil)
+		req = mux.SetURLVars(req, map[string]string{"provider": "google"})
 
 		redirectURL := getSignupRequiredRedirectURL(req)
 
-		assert.Equal(t, "/signup?auth_error=signup_required", redirectURL)
+		assert.Equal(t, "/login?auth_error=signup_required&provider=google", redirectURL)
 	})
 
 	t.Run("should preserve the original OAuth redirect", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/github/callback?state=%2Finvite%2Fabc", nil)
+		req = mux.SetURLVars(req, map[string]string{"provider": "github"})
 
 		redirectURL := getSignupRequiredRedirectURL(req)
 
-		assert.Equal(t, "/signup?auth_error=signup_required&redirect=%2Finvite%2Fabc", redirectURL)
+		assert.Equal(t, "/login?auth_error=signup_required&provider=github&redirect=%2Finvite%2Fabc", redirectURL)
+	})
+
+	t.Run("should omit provider when it is missing from the request", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/google/callback", nil)
+
+		redirectURL := getSignupRequiredRedirectURL(req)
+
+		assert.Equal(t, "/login?auth_error=signup_required", redirectURL)
+	})
+}
+
+func TestHandler_completeProviderAuth(t *testing.T) {
+	t.Run("should redirect to login when signup intent is missing", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		googleUser := goth.User{
+			UserID:      "google-login-no-account",
+			Email:       "google-login-no-account@example.com",
+			Name:        "Google Login User",
+			NickName:    "googlelogin",
+			Provider:    "google",
+			AccessToken: "google-access-token",
+		}
+		req := mux.SetURLVars(
+			httptest.NewRequest(http.MethodGet, "/auth/google", nil),
+			map[string]string{"provider": "google"},
+		)
+		recorder := httptest.NewRecorder()
+
+		handler.completeProviderAuth(recorder, req, googleUser)
+
+		assert.Equal(t, http.StatusSeeOther, recorder.Code)
+		assert.Equal(t, "/login?auth_error=signup_required&provider=google", recorder.Header().Get("Location"))
+
+		_, err := models.FindAccountByEmail(googleUser.Email)
+		assert.Error(t, err)
+	})
+
+	t.Run("should create the account when signup intent is present", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		googleUser := goth.User{
+			UserID:      "google-signup-create",
+			Email:       "google-signup-create@example.com",
+			Name:        "Google Signup User",
+			NickName:    "googlesignup",
+			Provider:    "google",
+			AccessToken: "google-access-token",
+		}
+		req := mux.SetURLVars(
+			httptest.NewRequest(http.MethodGet, "/auth/google?signup=true", nil),
+			map[string]string{"provider": "google"},
+		)
+		recorder := httptest.NewRecorder()
+
+		handler.completeProviderAuth(recorder, req, googleUser)
+
+		assert.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+
+		account, err := models.FindAccountByEmail(googleUser.Email)
+		require.NoError(t, err)
+		assert.Equal(t, googleUser.Name, account.Name)
 	})
 }
 

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -365,6 +365,26 @@ func TestGetSignupRequiredRedirectURL(t *testing.T) {
 	})
 }
 
+func TestGetPostLogoutRedirectURL(t *testing.T) {
+	t.Run("should return login when no redirect is present", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/logout", nil)
+
+		assert.Equal(t, "/login", getPostLogoutRedirectURL(req))
+	})
+
+	t.Run("should preserve a safe redirect on login", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/logout?redirect=%2Finvite%2Fabc", nil)
+
+		assert.Equal(t, "/login?redirect=%2Finvite%2Fabc", getPostLogoutRedirectURL(req))
+	})
+
+	t.Run("should reject an absolute redirect", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/logout?redirect=http%3A%2F%2Fevil.com", nil)
+
+		assert.Equal(t, "/login", getPostLogoutRedirectURL(req))
+	})
+}
+
 func TestHandler_completeProviderAuth(t *testing.T) {
 	t.Run("should redirect to login when signup intent is missing", func(t *testing.T) {
 		handler, _ := setupAuthHandler(t, false)

--- a/test/e2e/login_page_test.go
+++ b/test/e2e/login_page_test.go
@@ -1,13 +1,17 @@
 package e2e
 
 import (
+	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	pw "github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
 )
@@ -141,4 +145,125 @@ func (steps *TestLoginPageSteps) SetInvalidAuthCookie() {
 		HttpOnly: pw.Bool(true),
 	}})
 	assert.NoError(steps.t, err)
+}
+
+const googleDevAccountEmail = "dev@superplane.local"
+
+func TestGoogleSSONoAccountSignup(t *testing.T) {
+	t.Run("google sign-in without an account asks to create one", func(t *testing.T) {
+		steps := &googleSSONoAccountSteps{t: t}
+		steps.start()
+		steps.visitLoginPage()
+		steps.capture("01-login")
+		steps.clickContinueWithGoogle()
+		steps.assertNoAccountPromptVisible()
+		steps.capture("02-prompt")
+		steps.clickCreateAccount()
+		steps.assertAccountCreatedAndSignedIn()
+		steps.capture("03-after-create")
+	})
+
+	t.Run("use a different account returns to sign in", func(t *testing.T) {
+		steps := &googleSSONoAccountSteps{t: t}
+		steps.start()
+		steps.visitLoginPage()
+		steps.clickContinueWithGoogle()
+		steps.assertNoAccountPromptVisible()
+		steps.clickUseADifferentAccount()
+		steps.assertLoginPageVisible()
+	})
+
+	t.Run("existing google user signs in from the login page", func(t *testing.T) {
+		steps := &googleSSONoAccountSteps{t: t}
+		steps.start()
+		steps.givenTheGoogleDevAccountExists()
+		steps.visitLoginPage()
+		steps.clickContinueWithGoogle()
+		steps.assertLeftLoginPage()
+	})
+}
+
+type googleSSONoAccountSteps struct {
+	t       *testing.T
+	session *session.TestSession
+}
+
+func (s *googleSSONoAccountSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+}
+
+func (s *googleSSONoAccountSteps) visitLoginPage() {
+	s.session.Visit("/login")
+	s.session.AssertVisible(q.Text("Continue with Google"))
+}
+
+func (s *googleSSONoAccountSteps) clickContinueWithGoogle() {
+	s.session.Click(q.Text("Continue with Google"))
+}
+
+func (s *googleSSONoAccountSteps) assertNoAccountPromptVisible() {
+	s.session.AssertVisible(q.Text("No account found"))
+	s.session.AssertVisible(q.Text("This Google account does not have a SuperPlane account."))
+	s.session.AssertVisible(q.Text("Create an account to continue."))
+	s.session.AssertVisible(q.Text("Create account"))
+	s.session.AssertVisible(q.Text("Use a different account"))
+	s.session.AssertURLContains("auth_error=signup_required")
+	s.session.AssertURLContains("provider=google")
+}
+
+func (s *googleSSONoAccountSteps) clickCreateAccount() {
+	s.session.Click(q.Text("Create account"))
+}
+
+func (s *googleSSONoAccountSteps) clickUseADifferentAccount() {
+	s.session.Click(q.Text("Use a different account"))
+}
+
+func (s *googleSSONoAccountSteps) assertAccountCreatedAndSignedIn() {
+	waitErr := s.session.Page().WaitForURL("**/welcome**", pw.PageWaitForURLOptions{
+		Timeout: pw.Float(s.sessionTimeout()),
+	})
+	require.NoError(s.t, waitErr)
+
+	account, err := models.FindAccountByEmail(googleDevAccountEmail)
+	require.NoError(s.t, err)
+	assert.Equal(s.t, googleDevAccountEmail, account.Email)
+}
+
+func (s *googleSSONoAccountSteps) assertLoginPageVisible() {
+	s.session.AssertVisible(q.Text("Welcome to SuperPlane"))
+	s.session.AssertVisible(q.Text("Continue with Google"))
+	assert.NotContains(s.t, s.session.Page().URL(), "auth_error=signup_required")
+}
+
+func (s *googleSSONoAccountSteps) givenTheGoogleDevAccountExists() {
+	_, err := models.CreateAccount("Dev User", googleDevAccountEmail)
+	require.NoError(s.t, err)
+}
+
+func (s *googleSSONoAccountSteps) assertLeftLoginPage() {
+	s.session.WaitUntilURLDoesNotContain("/login")
+	currentURL := s.session.Page().URL()
+	assert.NotContains(s.t, currentURL, "auth_error=signup_required")
+}
+
+func (s *googleSSONoAccountSteps) capture(name string) {
+	s.session.Sleep(300)
+	path := fmt.Sprintf("/app/tmp/screenshots/sso-no-account-%s.png", name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		s.t.Fatalf("screenshot dir %s: %v", path, err)
+	}
+
+	if _, err := s.session.Page().Screenshot(pw.PageScreenshotOptions{
+		Path:     pw.String(path),
+		FullPage: pw.Bool(true),
+		Type:     pw.ScreenshotTypePng,
+	}); err != nil {
+		s.t.Fatalf("screenshot %s: %v", name, err)
+	}
+}
+
+func (s *googleSSONoAccountSteps) sessionTimeout() float64 {
+	return 15000
 }

--- a/test/e2e/test_context.go
+++ b/test/e2e/test_context.go
@@ -65,6 +65,11 @@ func (s *TestContext) Start() {
 	os.Setenv("OWNER_SETUP_ENABLED", "yes")
 	os.Setenv("ENABLE_PASSWORD_LOGIN", "yes")
 	os.Setenv("ENABLE_MAGIC_CODE_LOGIN", "yes")
+	os.Setenv("BLOCK_SIGNUP", "no")
+	if os.Getenv("GOOGLE_CLIENT_ID") == "" {
+		os.Setenv("GOOGLE_CLIENT_ID", "e2e-google-client-id")
+		os.Setenv("GOOGLE_CLIENT_SECRET", "e2e-google-client-secret")
+	}
 
 	s.AgentProvider = support.NewAgentProvider()
 	s.ResetAgentProvider()

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -25,6 +25,7 @@ import { getAuthRedirectURL, getWelcomeRedirectPath } from "./authRedirect";
 import { SignupWaitlist } from "./SignupWaitlist";
 import {
   SIGNUP_REQUIRED_AUTH_ERROR,
+  getLogoutHref,
   getSignupRequiredAccountBody,
   getSignupRequiredCreateHref,
   isKnownAuthProvider,
@@ -464,10 +465,9 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
     isSignupMode && canSignup && magicCodeStep === "email" && !canSignupWithPassword && !useMagicCodePrimary;
   const visibleFormError = formError ?? authErrorMessage;
   const showSignupRequiredPrompt = !configLoading && shouldShowSignupRequiredPrompt(authError, canSignup);
-  const showSignupRequiredProductUpdates =
-    showSignupRequiredPrompt && !canSignupWithPassword && !authConfig.magicCodeEnabled;
   const showAuthMethods = !configLoading && !isSignupRequiredReturn;
   const signupRequiredCreateHref = getSignupRequiredCreateHref(authProvider, redirectQuery);
+  const logoutHref = getLogoutHref(redirectQuery);
 
   const handleMagicCodeRequest = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -713,7 +713,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
           {!configLoading && showSignupClosedNotice && <SignupClosedNotice />}
           {!configLoading && isSignupRequiredReturn && !canSignup && (
             <Button variant="outline" className="mt-4 w-full" asChild>
-              <a href="/logout">Back to sign in</a>
+              <a href={logoutHref}>Back to sign in</a>
             </Button>
           )}
 
@@ -722,12 +722,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
               <p className="text-left text-sm leading-6 text-gray-600 dark:text-gray-400">
                 {getSignupRequiredAccountBody(authProvider)}
               </p>
-              {showSignupRequiredProductUpdates && (
-                <ProductUpdatesOptIn
-                  checked={signupProductUpdatesOptIn}
-                  onCheckedChange={setSignupProductUpdatesOptIn}
-                />
-              )}
+              <ProductUpdatesOptIn checked={signupProductUpdatesOptIn} onCheckedChange={setSignupProductUpdatesOptIn} />
               <Button className="w-full" asChild>
                 <a
                   href={signupRequiredCreateHref}
@@ -742,7 +737,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
                 </a>
               </Button>
               <Button variant="outline" className="w-full" asChild>
-                <a href="/logout">Use a different account</a>
+                <a href={logoutHref}>Use a different account</a>
               </Button>
             </div>
           )}

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -23,7 +23,14 @@ import { hasSignupWaitlistConfig } from "@/lib/signupWaitlistConfig";
 import { buildMagicLinkVerifyRequest } from "./magicLinkVerifyRequest";
 import { getAuthRedirectURL, getWelcomeRedirectPath } from "./authRedirect";
 import { SignupWaitlist } from "./SignupWaitlist";
-import { getSignupUnavailableReason, type SignupUnavailableReason } from "./signupUnavailableReason";
+import {
+  SIGNUP_REQUIRED_AUTH_ERROR,
+  getSignupRequiredAccountBody,
+  getSignupRequiredCreateHref,
+  isKnownAuthProvider,
+  shouldShowSignupRequiredPrompt,
+} from "./signupRequiredPrompt";
+import { getSignupUnavailableReason } from "./signupUnavailableReason";
 
 type AuthConfig = {
   providers: string[];
@@ -86,21 +93,9 @@ interface LoginProps {
   mode?: AuthMode;
 }
 
-const getAuthErrorMessage = (authError: string | null, signupUnavailableReason: SignupUnavailableReason) => {
+const getAuthErrorMessage = (authError: string | null) => {
   if (authError === "account_blocked") {
     return ACCOUNT_BLOCKED_MESSAGE;
-  }
-
-  if (authError === "signup_required") {
-    if (signupUnavailableReason === "waitlist") {
-      return "No account exists for that provider yet. Join the waitlist to request access.";
-    }
-
-    if (signupUnavailableReason === "closed") {
-      return "No account exists for that provider yet. Signups are not available right now.";
-    }
-
-    return "No account exists for that provider yet. Create an account to continue.";
   }
 
   return null;
@@ -299,6 +294,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const magicLinkToken = searchParams.get("magic_link_token");
   const redirectTarget = safeRedirect || "";
   const authError = searchParams.get("auth_error");
+  const authProvider = searchParams.get("provider");
 
   const handleRedirectAfterAuth = useCallback(
     async (response: Response, authRedirectURL?: string) => {
@@ -451,7 +447,8 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const showProviderButtons = hasProviders && (!isSignupMode || canSignup);
   const canUseMagicCode = authConfig.magicCodeEnabled && (!isSignupMode || canSignup);
   const useMagicCodePrimary = canUseMagicCode && !showPasswordLogin;
-  const showSignupUnavailable = !configLoading && isSignupMode && !canSignup;
+  const isSignupRequiredReturn = authError === SIGNUP_REQUIRED_AUTH_ERROR;
+  const showSignupUnavailable = !configLoading && !canSignup && (isSignupMode || isSignupRequiredReturn);
   const hasConfiguredSignupWaitlist = hasSignupWaitlistConfig();
   const signupUnavailableReason = getSignupUnavailableReason(
     showSignupUnavailable,
@@ -462,10 +459,15 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const showSignupClosedNotice = signupUnavailableReason === "closed";
   const showSignupEntryPoint = canSignup || !authConfig.signupsBlockedByEnvironment;
   const showLastUsedMethodHints = !isSignupMode;
-  const authErrorMessage = getAuthErrorMessage(authError, signupUnavailableReason);
+  const authErrorMessage = getAuthErrorMessage(authError);
   const showStandaloneProductUpdatesOptIn =
     isSignupMode && canSignup && magicCodeStep === "email" && !canSignupWithPassword && !useMagicCodePrimary;
   const visibleFormError = formError ?? authErrorMessage;
+  const showSignupRequiredPrompt = !configLoading && shouldShowSignupRequiredPrompt(authError, canSignup);
+  const showSignupRequiredProductUpdates =
+    showSignupRequiredPrompt && !canSignupWithPassword && !authConfig.magicCodeEnabled;
+  const showAuthMethods = !configLoading && !isSignupRequiredReturn;
+  const signupRequiredCreateHref = getSignupRequiredCreateHref(authProvider, redirectQuery);
 
   const handleMagicCodeRequest = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -672,6 +674,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const providerButtonsNeedTopSpacing = useMagicCodePrimary && magicCodeStep === "email";
 
   const getHeading = () => {
+    if (showSignupRequiredPrompt) return "No account found";
     if (useMagicCodePrimary && magicCodeStep === "code") return "Check your email";
     if (showSignupClosedNotice) return "Signups are closed";
     if (showSignupWaitlist) return "SuperPlane Cloud";
@@ -680,6 +683,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   };
 
   const getSubheading = () => {
+    if (showSignupRequiredPrompt) return "Create an account to continue.";
     if (showSignupClosedNotice) return "New accounts are not available.";
     if (showSignupWaitlist) return "Join the waitlist for access.";
     if (isSignupMode) return "Set up your account.";
@@ -707,18 +711,53 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
 
           {!configLoading && showSignupWaitlist && <SignupWaitlist />}
           {!configLoading && showSignupClosedNotice && <SignupClosedNotice />}
+          {!configLoading && isSignupRequiredReturn && !canSignup && (
+            <Button variant="outline" className="mt-4 w-full" asChild>
+              <a href="/logout">Back to sign in</a>
+            </Button>
+          )}
 
-          {!configLoading && !isSignupMode && !hasAnyFormMethod && (
+          {!configLoading && showSignupRequiredPrompt && (
+            <div className="space-y-4">
+              <p className="text-left text-sm leading-6 text-gray-600 dark:text-gray-400">
+                {getSignupRequiredAccountBody(authProvider)}
+              </p>
+              {showSignupRequiredProductUpdates && (
+                <ProductUpdatesOptIn
+                  checked={signupProductUpdatesOptIn}
+                  onCheckedChange={setSignupProductUpdatesOptIn}
+                />
+              )}
+              <Button className="w-full" asChild>
+                <a
+                  href={signupRequiredCreateHref}
+                  onClick={() => {
+                    saveSignupPreference(true, signupProductUpdatesOptIn);
+                    if (isKnownAuthProvider(authProvider)) {
+                      recordLastUsedLoginMethod(authProvider);
+                    }
+                  }}
+                >
+                  Create account
+                </a>
+              </Button>
+              <Button variant="outline" className="w-full" asChild>
+                <a href="/logout">Use a different account</a>
+              </Button>
+            </div>
+          )}
+
+          {showAuthMethods && !isSignupMode && !hasAnyFormMethod && (
             <p className="text-sm text-gray-500 dark:text-gray-400">No login methods are configured.</p>
           )}
 
-          {!configLoading && visibleFormError && (
+          {showAuthMethods && visibleFormError && (
             <div className="mb-4 rounded-md border border-red-300 bg-white px-3 py-1 text-sm text-red-500 dark:border-red-500/40 dark:bg-red-950/40 dark:text-red-300">
               {visibleFormError}
             </div>
           )}
 
-          {!configLoading && useMagicCodePrimary && magicCodeStep === "email" && (
+          {showAuthMethods && useMagicCodePrimary && magicCodeStep === "email" && (
             <form onSubmit={handleMagicCodeRequest} className="space-y-4">
               <div className="space-y-2">
                 <Label>Email</Label>
@@ -746,7 +785,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </form>
           )}
 
-          {!configLoading && useMagicCodePrimary && magicCodeStep === "code" && (
+          {showAuthMethods && useMagicCodePrimary && magicCodeStep === "code" && (
             <form onSubmit={handleMagicCodeVerify} className="space-y-4">
               <div className="space-y-2">
                 <Label>Code</Label>
@@ -779,7 +818,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </form>
           )}
 
-          {!configLoading && !isSignupMode && !useMagicCodePrimary && canLoginWithPassword && (
+          {showAuthMethods && !isSignupMode && !useMagicCodePrimary && canLoginWithPassword && (
             <form onSubmit={handleLoginSubmit} className="space-y-4">
               <div className="space-y-2">
                 <Label>Email</Label>
@@ -817,7 +856,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </form>
           )}
 
-          {!configLoading && isSignupMode && canSignupWithPassword && (
+          {showAuthMethods && isSignupMode && canSignupWithPassword && (
             <form onSubmit={handleSignupSubmit} className="space-y-4">
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
@@ -901,7 +940,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </form>
           )}
 
-          {!configLoading &&
+          {showAuthMethods &&
             useMagicCodePrimary &&
             !isSignupMode &&
             magicCodeStep === "email" &&
@@ -920,7 +959,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
               </div>
             )}
 
-          {!configLoading &&
+          {showAuthMethods &&
             !isSignupMode &&
             showPasswordLogin &&
             !useMagicCodePrimary &&
@@ -939,7 +978,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
               </div>
             )}
 
-          {!configLoading &&
+          {showAuthMethods &&
             showProviderButtons &&
             (isSignupMode
               ? canSignupWithPassword
@@ -953,13 +992,13 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
               </div>
             )}
 
-          {!configLoading && showStandaloneProductUpdatesOptIn && (
+          {showAuthMethods && showStandaloneProductUpdatesOptIn && (
             <div className="mb-4">
               <ProductUpdatesOptIn checked={signupProductUpdatesOptIn} onCheckedChange={setSignupProductUpdatesOptIn} />
             </div>
           )}
 
-          {!configLoading && showProviderButtons && (!useMagicCodePrimary || magicCodeStep === "email") && (
+          {showAuthMethods && showProviderButtons && (!useMagicCodePrimary || magicCodeStep === "email") && (
             <div className={providerButtonsNeedTopSpacing ? "mt-4 space-y-3" : "space-y-3"}>
               {activeProviders.map((provider) => (
                 <div key={provider}>
@@ -1004,7 +1043,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </div>
           )}
 
-          {!configLoading && !isSignupMode && showSignupEntryPoint && !useMagicCodePrimary && (
+          {showAuthMethods && !isSignupMode && showSignupEntryPoint && !useMagicCodePrimary && (
             <div className="mt-6 text-sm text-gray-500 dark:text-gray-400">
               {"Don't have an account? "}
               <Link
@@ -1016,7 +1055,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </div>
           )}
 
-          {!configLoading && isSignupMode && (
+          {showAuthMethods && isSignupMode && (
             <div className="mt-6 text-sm text-gray-500 dark:text-gray-400">
               Already have an account?{" "}
               <Link
@@ -1028,7 +1067,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </div>
           )}
 
-          {!configLoading &&
+          {showAuthMethods &&
             useMagicCodePrimary &&
             magicCodeStep === "email" &&
             !isSignupMode &&

--- a/web_src/src/pages/auth/signupRequiredPrompt.spec.ts
+++ b/web_src/src/pages/auth/signupRequiredPrompt.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getLogoutHref,
   getSignupRequiredAccountBody,
   getSignupRequiredCreateHref,
   isKnownAuthProvider,
@@ -48,6 +49,16 @@ describe("shouldShowSignupRequiredPrompt", () => {
 
   it("ignores other auth errors", () => {
     expect(shouldShowSignupRequiredPrompt("account_blocked", true)).toBe(false);
+  });
+});
+
+describe("getLogoutHref", () => {
+  it("keeps logout on login when no redirect is present", () => {
+    expect(getLogoutHref("")).toBe("/logout");
+  });
+
+  it("preserves the redirect query on logout", () => {
+    expect(getLogoutHref("?redirect=%2Finvite%2Fabc")).toBe("/logout?redirect=%2Finvite%2Fabc");
   });
 });
 

--- a/web_src/src/pages/auth/signupRequiredPrompt.spec.ts
+++ b/web_src/src/pages/auth/signupRequiredPrompt.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getSignupRequiredAccountBody,
+  getSignupRequiredCreateHref,
+  isKnownAuthProvider,
+  shouldShowSignupRequiredPrompt,
+} from "./signupRequiredPrompt";
+
+describe("getSignupRequiredAccountBody", () => {
+  it("names the Google account", () => {
+    expect(getSignupRequiredAccountBody("google")).toBe("This Google account does not have a SuperPlane account.");
+  });
+
+  it("names the GitHub account", () => {
+    expect(getSignupRequiredAccountBody("github")).toBe("This GitHub account does not have a SuperPlane account.");
+  });
+
+  it("uses generic copy when the provider is missing", () => {
+    expect(getSignupRequiredAccountBody(null)).toBe("This account does not have a SuperPlane account.");
+  });
+});
+
+describe("getSignupRequiredCreateHref", () => {
+  it("continues Google OAuth with signup intent", () => {
+    expect(getSignupRequiredCreateHref("google", "")).toBe("/auth/google?signup=true");
+  });
+
+  it("preserves the redirect query on the Google create path", () => {
+    expect(getSignupRequiredCreateHref("google", "?redirect=%2Finvite%2Fabc")).toBe(
+      "/auth/google?redirect=%2Finvite%2Fabc&signup=true",
+    );
+  });
+
+  it("sends unknown providers to signup", () => {
+    expect(getSignupRequiredCreateHref(null, "?redirect=%2Finvite%2Fabc")).toBe("/signup?redirect=%2Finvite%2Fabc");
+  });
+});
+
+describe("shouldShowSignupRequiredPrompt", () => {
+  it("shows the create prompt when signups are open", () => {
+    expect(shouldShowSignupRequiredPrompt("signup_required", true)).toBe(true);
+  });
+
+  it("hides the create prompt when signups are closed or waitlisted", () => {
+    expect(shouldShowSignupRequiredPrompt("signup_required", false)).toBe(false);
+  });
+
+  it("ignores other auth errors", () => {
+    expect(shouldShowSignupRequiredPrompt("account_blocked", true)).toBe(false);
+  });
+});
+
+describe("isKnownAuthProvider", () => {
+  it("accepts google and github only", () => {
+    expect(isKnownAuthProvider("google")).toBe(true);
+    expect(isKnownAuthProvider("github")).toBe(true);
+    expect(isKnownAuthProvider(null)).toBe(false);
+    expect(isKnownAuthProvider("okta")).toBe(false);
+  });
+});

--- a/web_src/src/pages/auth/signupRequiredPrompt.ts
+++ b/web_src/src/pages/auth/signupRequiredPrompt.ts
@@ -29,3 +29,7 @@ export function getSignupRequiredCreateHref(provider: string | null, redirectQue
   params.set("signup", "true");
   return `/auth/${provider}?${params.toString()}`;
 }
+
+export function getLogoutHref(redirectQuery: string): string {
+  return redirectQuery ? `/logout${redirectQuery}` : "/logout";
+}

--- a/web_src/src/pages/auth/signupRequiredPrompt.ts
+++ b/web_src/src/pages/auth/signupRequiredPrompt.ts
@@ -1,0 +1,31 @@
+export const SIGNUP_REQUIRED_AUTH_ERROR = "signup_required";
+
+export function isKnownAuthProvider(provider: string | null): provider is "google" | "github" {
+  return provider === "google" || provider === "github";
+}
+
+export function shouldShowSignupRequiredPrompt(authError: string | null, canSignup: boolean): boolean {
+  return authError === SIGNUP_REQUIRED_AUTH_ERROR && canSignup;
+}
+
+export function getSignupRequiredAccountBody(provider: string | null): string {
+  if (provider === "google") {
+    return "This Google account does not have a SuperPlane account.";
+  }
+
+  if (provider === "github") {
+    return "This GitHub account does not have a SuperPlane account.";
+  }
+
+  return "This account does not have a SuperPlane account.";
+}
+
+export function getSignupRequiredCreateHref(provider: string | null, redirectQuery: string): string {
+  if (!isKnownAuthProvider(provider)) {
+    return `/signup${redirectQuery}`;
+  }
+
+  const params = new URLSearchParams(redirectQuery.startsWith("?") ? redirectQuery.slice(1) : redirectQuery);
+  params.set("signup", "true");
+  return `/auth/${provider}?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary

SSO sign-in with no SuperPlane account looked broken. Users landed on signup and the next Google click returned Account not found.

This change keeps the user on sign-in and asks them to create an account. Create account reuses the Google session.

## Test plan

- [ ] Open `/login` and click Continue with Google with a new Google account.
- [ ] Confirm the page shows No account found.
- [ ] Click Create account and confirm you sign in.
- [ ] Click Use a different account and confirm you return to sign-in.
- [ ] Sign in with Google for an existing account and confirm you enter the app.


Made with [Cursor](https://cursor.com)