### PR TITLE
fix: Show merged and draft states on work-order PR chips

### DIFF
--- a/web_src/src/pages/factories/lib/workOrderArtifact.spec.ts
+++ b/web_src/src/pages/factories/lib/workOrderArtifact.spec.ts
@@ -6,6 +6,7 @@ import {
   extractArtifactName,
   extractArtifactTitle,
   extractArtifactUrl,
+  extractBranchTreeUrl,
   extractPrArtifactState,
   formatPrArtifactLabel,
   overlayLiveArtifactData,
@@ -80,6 +81,47 @@ describe("extractArtifactUrl", () => {
     expect(extractArtifactUrl({ url: "" })).toBeUndefined();
     expect(extractArtifactUrl({ url: "   " })).toBeUndefined();
     expect(extractArtifactUrl({ url: null })).toBeUndefined();
+  });
+
+  it("synthesizes a GitHub tree URL from branch name + repository when url is missing", () => {
+    expect(extractArtifactUrl({ name: "feature/refund-retry", repository: "acme/app" })).toBe(
+      "https://github.com/acme/app/tree/feature/refund-retry",
+    );
+  });
+});
+
+describe("extractBranchTreeUrl", () => {
+  it("builds a github.com tree URL from owner/repo + name", () => {
+    expect(extractBranchTreeUrl({ name: "main", repository: "acme/app" })).toBe(
+      "https://github.com/acme/app/tree/main",
+    );
+  });
+
+  it("falls back to `repo` when `repository` is absent", () => {
+    expect(extractBranchTreeUrl({ name: "fix/thing", repo: "acme/app" })).toBe(
+      "https://github.com/acme/app/tree/fix/thing",
+    );
+  });
+
+  it("encodes path segments without double-encoding slashes", () => {
+    expect(extractBranchTreeUrl({ name: "feat/a b", repository: "acme/app" })).toBe(
+      "https://github.com/acme/app/tree/feat/a%20b",
+    );
+  });
+
+  it("joins a branch onto an http(s) repository URL", () => {
+    expect(
+      extractBranchTreeUrl({
+        name: "release",
+        repository: "https://github.example.com/acme/app",
+      }),
+    ).toBe("https://github.example.com/acme/app/tree/release");
+  });
+
+  it("returns undefined without a usable repository or name", () => {
+    expect(extractBranchTreeUrl({ name: "main" })).toBeUndefined();
+    expect(extractBranchTreeUrl({ repository: "acme/app" })).toBeUndefined();
+    expect(extractBranchTreeUrl({ name: "main", repository: "not-a-repo" })).toBeUndefined();
   });
 });
 
@@ -178,6 +220,19 @@ describe("extractPrArtifactState", () => {
 
   it("still treats state:closed as closed when merged is explicitly false", () => {
     expect(extractPrArtifactState({ state: "closed", merged: false })).toBe("closed");
+  });
+
+  it("treats a mergedAt/merged_at timestamp as merged when the boolean flag is missing", () => {
+    // PR-closure writes mergedAt for Velocity even if `merged` never
+    // lands in the data map. Without this the chip stays green.
+    expect(extractPrArtifactState({ state: "closed", mergedAt: "2026-08-17T12:34:56Z" })).toBe("merged");
+    expect(extractPrArtifactState({ merged_at: "2026-08-17T12:34:56Z" })).toBe("merged");
+  });
+
+  it("does not treat mergedAt as merged when merged is explicitly false", () => {
+    expect(extractPrArtifactState({ state: "closed", merged: false, mergedAt: "2026-08-17T12:34:56Z" })).toBe(
+      "closed",
+    );
   });
 });
 

--- a/web_src/src/pages/factories/lib/workOrderArtifact.ts
+++ b/web_src/src/pages/factories/lib/workOrderArtifact.ts
@@ -40,9 +40,38 @@ export function extractArtifactMarkdownBody(data: ArtifactData): string | undefi
  * canonical key; `html_url` is GitHub's own field name and is what
  * `github.createPullRequest` writes into free-form data, so it lands
  * here without the caller having to remap.
+ *
+ * Branch artifacts attached before the backend wrote a tree URL often
+ * only have `name` + `repository`/`repo`. Synthesize a GitHub tree URL
+ * in that case so the chip is clickable without re-running the flow.
  */
 export function extractArtifactUrl(data: ArtifactData): string | undefined {
-  return extractArtifactField(data, "url") ?? extractArtifactField(data, "html_url");
+  return (
+    extractArtifactField(data, "url") ??
+    extractArtifactField(data, "html_url") ??
+    extractBranchTreeUrl(data)
+  );
+}
+
+/**
+ * Builds `https://github.com/{owner}/{repo}/tree/{branch}` from a branch
+ * artifact's `name` and `repository` (or `repo`). Mirrors the backend
+ * `branchTreeURL` helper. Returns undefined when the repository is not
+ * an `owner/repo` slug or http(s) GitHub URL — we do not guess hosts.
+ */
+export function extractBranchTreeUrl(data: ArtifactData): string | undefined {
+  const name = extractArtifactName(data);
+  if (!name) {
+    return undefined;
+  }
+
+  const repository =
+    extractArtifactField(data, "repository") ?? extractArtifactField(data, "repo");
+  if (!repository) {
+    return undefined;
+  }
+
+  return branchTreeURL(repository, name);
 }
 
 export function extractArtifactTitle(data: ArtifactData): string | undefined {
@@ -62,9 +91,12 @@ export function extractArtifactName(data: ArtifactData): string | undefined {
  * Precedence, strongest signal first:
  * 1. `merged: true` — a merged GitHub PR is `{ state: "closed", merged: true }`;
  *    without this the chip would render red instead of purple.
- * 2. Explicit non-"open" SuperPlane `state` (draft/closed/merged).
- * 3. `draft: true` — GitHub draft PRs stay `state: "open"`.
- * 4. Explicit "open" `state`.
+ * 2. A non-empty `mergedAt` / `merged_at` timestamp — PR-closure stamps
+ *    this for Velocity even when the boolean `merged` flag never lands
+ *    in the free-form data map. The chip used to stay green.
+ * 3. Explicit non-"open" SuperPlane `state` (draft/closed/merged).
+ * 4. `draft: true` — GitHub draft PRs stay `state: "open"`.
+ * 5. Explicit "open" `state`.
  *
  * Returns undefined for missing / unrecognized values so the chip
  * falls back to the default "open" look instead of misrepresenting
@@ -83,6 +115,13 @@ export function extractPrArtifactState(data: ArtifactData): PrArtifactState | un
   }
   if (explicit === "draft" && extractArtifactBoolean(data, "draft") === false) {
     explicit = undefined;
+  }
+
+  // mergedAt is append-only and a GitHub PR cannot be un-merged, so a
+  // timestamp is as strong as merged:true unless the flag is explicitly
+  // false (a leftover timestamp after a bad write).
+  if (extractArtifactBoolean(data, "merged") !== false && hasArtifactTimestamp(data, MERGED_AT_KEYS)) {
+    return "merged";
   }
 
   if (explicit && explicit !== "open") {
@@ -166,4 +205,72 @@ function extractArtifactField(data: ArtifactData, key: string): string | undefin
     return String(value);
   }
   return undefined;
+}
+
+const MERGED_AT_KEYS = ["mergedAt", "merged_at"] as const;
+
+function hasArtifactTimestamp(data: ArtifactData, keys: readonly string[]): boolean {
+  return keys.some((key) => Boolean(extractArtifactField(data, key)));
+}
+
+function branchTreeURL(repository: string, name: string): string | undefined {
+  const repo = repository.replace(/\/+$/, "").trim();
+  const branch = name.trim();
+  if (!repo || !branch) {
+    return undefined;
+  }
+
+  const fromHttp = parseHttpRepositoryURL(repo);
+  if (fromHttp) {
+    return `${fromHttp}/tree/${encodeBranchPath(branch)}`;
+  }
+
+  if (repo.includes("://") || repo.startsWith("/")) {
+    return undefined;
+  }
+
+  const slash = repo.indexOf("/");
+  if (slash <= 0 || repo.indexOf("/", slash + 1) !== -1) {
+    return undefined;
+  }
+
+  const owner = repo.slice(0, slash);
+  const rest = repo.slice(slash + 1);
+  if (!owner || !rest) {
+    return undefined;
+  }
+
+  return `https://github.com/${owner}/${rest}/tree/${encodeBranchPath(branch)}`;
+}
+
+function parseHttpRepositoryURL(repository: string): string | undefined {
+  const lower = repository.toLowerCase();
+  if (!lower.startsWith("https://") && !lower.startsWith("http://")) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(repository);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    if (!parsed.host || !parsed.pathname || parsed.pathname === "/") {
+      return undefined;
+    }
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function encodeBranchPath(name: string): string {
+  return name
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
 }

--- a/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
@@ -169,8 +169,10 @@ spec:
       configuration:
         artifactKey: '{{ $["Create Draft Pull Request"].data.html_url }}'
         artifactType: pr
+        draft: true
         number: '{{ $["Create Draft Pull Request"].data.number }}'
         orderId: '{{ order().id }}'
+        state: draft
         title: '{{ $["Create Draft Pull Request"].data.title }}'
         url: '{{ $["Create Draft Pull Request"].data.html_url }}'
       position:

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -81,6 +81,11 @@ describe("setup factory line apps", () => {
 
     const pr = materializeOnboardingApp("line-pr");
     expect(pr).toMatch(/component: github\.createPullRequest[\s\S]*repository: acme\/app/);
+    // github.createPullRequest opens a draft; the chip defaults to open
+    // (green) unless the attach step records draft/state. Mirror the
+    // implementation line so merged/closed updates have a real starting state.
+    expect(pr).toMatch(/id: attach-pr-artifact[\s\S]*draft: true/);
+    expect(pr).toMatch(/id: attach-pr-artifact[\s\S]*state: draft/);
   });
 
   it("links the pull request back to the work order", () => {


### PR DESCRIPTION
## What changed

Work-order PR chips were stuck on the default **open** (green) look, including for merged PRs. Branch chips with `name` + `repository` but no `url` were not clickable.

- The Verify line (`pr.canvas.yaml`) now records `draft: true` / `state: draft` when it attaches the PR it just opened, matching the Implement line.
- `extractPrArtifactState` treats a `mergedAt` / `merged_at` timestamp as merged, so PR-closure Velocity stamps update the chip even when the boolean `merged` flag never lands in the data map.
- `extractArtifactUrl` synthesizes a GitHub tree URL from `name` + `repository`/`repo` so already-attached branch artifacts become links without re-running the flow.

## Why

[#6676](https://github.com/superplanehq/superplane/issues/6676) — icon and color stayed green for merged PRs. The chip only looked at `merged` / `state` / `draft`, defaulted to open, and the Verify attach step never wrote draft/state.

[#6675](https://github.com/superplanehq/superplane/issues/6675) — branch artifacts remain plain text when they were stored with name + repository only.

## How

- `merged: true` still wins. A non-empty `mergedAt`/`merged_at` is treated as merged unless `merged` is explicitly `false`.
- Branch tree URLs follow the backend `branchTreeURL` rules (`owner/repo` or http(s) repository URL). Existing `url` / `html_url` still take precedence.

## Tests

- `workOrderArtifact.spec.ts`: mergedAt → merged; merged:false keeps closed; branch tree URL from owner/repo, `repo` fallback, http(s) join, encoding.
- `lineApps.spec.ts`: Verify line attach step includes `draft: true` and `state: draft`.

Fixes #6676
Fixes #6675
