### PR TITLE
feat: Keep Low-Confidence Tickets in Intake

### DIFF
--- a/web_src/src/pages/factories/lib/confidenceScore.spec.ts
+++ b/web_src/src/pages/factories/lib/confidenceScore.spec.ts
@@ -6,6 +6,7 @@ import {
   confidenceBandForScore,
   confidenceCheckLevel,
   confidenceScoreFromChecks,
+  confidenceScoreFromPercent,
   confidenceSuitabilityAnalysis,
   confidenceSuitabilitySummary,
 } from "./confidenceScore";
@@ -35,6 +36,14 @@ describe("confidenceScore", () => {
     expect(clampConfidenceScore(-1)).toBe(0);
     expect(clampConfidenceScore(5.4)).toBe(5);
     expect(clampConfidenceScore(3.6)).toBe(4);
+  });
+
+  it("turns an intake percentage into a 0 to 5 score", () => {
+    expect(confidenceScoreFromPercent(94)).toBe(5);
+    expect(confidenceScoreFromPercent(58)).toBe(3);
+    expect(confidenceScoreFromPercent(44)).toBe(2);
+    expect(confidenceScoreFromPercent(12)).toBe(1);
+    expect(confidenceScoreFromPercent(0)).toBe(0);
   });
 
   it("bands and levels a 0 to 5 score", () => {

--- a/web_src/src/pages/factories/lib/confidenceScore.ts
+++ b/web_src/src/pages/factories/lib/confidenceScore.ts
@@ -20,6 +20,11 @@ export function confidenceScoreFromChecks(
   return clampConfidenceScore(check.score);
 }
 
+/** Intake scores arrive as a percentage. The meter shows five steps. */
+export function confidenceScoreFromPercent(percent: number): number {
+  return clampConfidenceScore((percent / 100) * CONFIDENCE_SCORE_MAX);
+}
+
 export type ConfidenceBand = "High" | "Medium" | "Low";
 
 export function clampConfidenceScore(score: number): number {

--- a/web_src/src/pages/factories/pages/AnalyzingIntakeTicketList.tsx
+++ b/web_src/src/pages/factories/pages/AnalyzingIntakeTicketList.tsx
@@ -1,8 +1,15 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Loader2 } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 
-import { LINE_INTAKE_COPY, type LineIntakeAnalyzingTicket } from "./lineIntakeModel";
+import { ConfidenceMeter } from "../workOrders/ConfidenceMeter";
+import {
+  intakeTicketConfidenceScore,
+  isBelowThresholdTicket,
+  LINE_INTAKE_COPY,
+  sortIntakeTicketsByOutcome,
+  type LineIntakeAnalyzingTicket,
+} from "./lineIntakeModel";
 
 interface AnalyzingIntakeTicketListProps {
   tickets: LineIntakeAnalyzingTicket[];
@@ -54,32 +61,60 @@ export function AnalyzingIntakeTicketList({
       data-testid="line-intake-analyzing"
       aria-label={LINE_INTAKE_COPY.analyzingTitle}
     >
-      {tickets.map((ticket) => {
-        const selected = openTicketId === ticket.id;
-        return (
-          <li key={ticket.id} data-testid={`line-intake-analyzing-ticket-${ticket.id}`}>
-            <button
-              type="button"
-              onClick={() => onOpenTicket?.(ticket)}
-              aria-label={`Open ${ticket.title}`}
-              aria-pressed={selected}
-              className={cn(
-                "flex w-full items-start gap-2.5 px-3 py-3.5 text-left transition-colors hover:bg-accent/70",
-                selected && "bg-accent",
-              )}
-            >
-              <Loader2
-                className="mt-0.5 size-3.5 shrink-0 animate-spin text-muted-foreground"
-                aria-hidden
-                data-testid="line-intake-analyzing-spinner"
-              />
-              <span className="min-w-0 flex-1 text-left text-[13px] font-medium leading-snug tracking-[-0.01em] text-foreground">
-                {ticket.title}
-              </span>
-            </button>
-          </li>
-        );
-      })}
+      {sortIntakeTicketsByOutcome(tickets).map((ticket) => (
+        <li key={ticket.id} data-testid={`line-intake-analyzing-ticket-${ticket.id}`}>
+          <IntakeTicketRow ticket={ticket} selected={openTicketId === ticket.id} onOpenTicket={onOpenTicket} />
+        </li>
+      ))}
     </ul>
+  );
+}
+
+function IntakeTicketRow({
+  ticket,
+  selected,
+  onOpenTicket,
+}: {
+  ticket: LineIntakeAnalyzingTicket;
+  selected: boolean;
+  onOpenTicket?: (ticket: LineIntakeAnalyzingTicket) => void;
+}) {
+  const belowThreshold = isBelowThresholdTicket(ticket);
+  const score = intakeTicketConfidenceScore(ticket);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenTicket?.(ticket)}
+      aria-label={`Open ${ticket.title}`}
+      aria-pressed={selected}
+      className={cn(
+        "flex w-full items-start gap-2.5 px-3 py-3.5 text-left transition-colors hover:bg-accent/70",
+        selected && "bg-accent",
+      )}
+    >
+      {belowThreshold ? (
+        <span className="mt-0.5 shrink-0" title={LINE_INTAKE_COPY.belowThresholdHelper}>
+          <X className="size-3.5 text-muted-foreground" aria-hidden data-testid="line-intake-below-threshold-icon" />
+        </span>
+      ) : (
+        <Loader2
+          className="mt-0.5 size-3.5 shrink-0 animate-spin text-muted-foreground"
+          aria-hidden
+          data-testid="line-intake-analyzing-spinner"
+        />
+      )}
+      <span
+        className={cn(
+          "min-w-0 flex-1 text-left text-[13px] font-medium leading-snug tracking-[-0.01em]",
+          belowThreshold ? "text-muted-foreground" : "text-foreground",
+        )}
+      >
+        {ticket.title}
+      </span>
+      {belowThreshold && score != null ? (
+        <ConfidenceMeter score={score} className="mt-0.5 shrink-0" testId={`line-intake-ticket-score-${ticket.id}`} />
+      ) : null}
+    </button>
   );
 }

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
@@ -324,6 +324,34 @@ describe("LineIntakeDrawer", () => {
     expect(within(analyzing).queryByText("Already in Backlog")).not.toBeInTheDocument();
   });
 
+  it("keeps live tickets below the minimum confidence in the Intake list", () => {
+    intakeRuns([
+      { id: "run-1", title: "Handle duplicate refunds on retry", placement: "PLACEMENT_ANALYZING" },
+      { id: "run-2", title: "Already in Backlog", placement: "PLACEMENT_BACKLOG" },
+      {
+        id: "run-3",
+        title: "Document the refund webhook contract",
+        placement: "PLACEMENT_BELOW_THRESHOLD",
+        confidencePct: 52,
+      },
+    ]);
+    renderDrawer({
+      configuredSources: [GITHUB_INTAKE],
+      initialIntakeId: "intake-github",
+      organizationId: "org-1",
+      factoryId: "factory-1",
+    });
+
+    const analyzing = screen.getByTestId("line-intake-analyzing");
+    expect(within(analyzing).getByText("Handle duplicate refunds on retry")).toBeInTheDocument();
+    expect(within(analyzing).queryByText("Already in Backlog")).not.toBeInTheDocument();
+    expect(within(analyzing).getByTestId("line-intake-below-threshold-icon")).toBeInTheDocument();
+    expect(within(analyzing).getByTestId("line-intake-ticket-score-run-3")).toHaveAttribute("aria-valuenow", "3");
+    expect(
+      within(screen.getByTestId("line-intake-source-intake-github")).getByText("1 Not accepted"),
+    ).toBeInTheDocument();
+  });
+
   // A ticket that scores under the minimum confidence never reaches Backlog.
   // It stays under the analyzing tickets so a reader can see what was left out.
   it("keeps tickets below the minimum confidence at the bottom with their score", () => {

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
@@ -252,7 +252,7 @@ describe("LineIntakeDrawer", () => {
     const analyzing = within(github).getByTestId("line-intake-analyzing");
     expect(within(analyzing).getAllByTestId("line-intake-analyzing-spinner")).toHaveLength(5);
     expect(within(analyzing).getByText("Handle duplicate refunds on retry")).toBeInTheDocument();
-    expect(within(github).getByText("Analyzing")).toBeInTheDocument();
+    expect(within(github).getByText("5 Analyzing")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Collapse GitHub issues" })).toHaveAttribute("aria-expanded", "true");
     expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
   });
@@ -322,6 +322,43 @@ describe("LineIntakeDrawer", () => {
     const analyzing = screen.getByTestId("line-intake-analyzing");
     expect(within(analyzing).getByText("Handle duplicate refunds on retry")).toBeInTheDocument();
     expect(within(analyzing).queryByText("Already in Backlog")).not.toBeInTheDocument();
+  });
+
+  // A ticket that scores under the minimum confidence never reaches Backlog.
+  // It stays under the analyzing tickets so a reader can see what was left out.
+  it("keeps tickets below the minimum confidence at the bottom with their score", () => {
+    renderDrawer({ initialIntakeId: "intake-github", analyzingTickets: GITHUB_ISSUES_ANALYZING_TICKETS });
+
+    const analyzing = screen.getByTestId("line-intake-analyzing");
+    expect(within(analyzing).getAllByTestId("line-intake-below-threshold-icon")).toHaveLength(6);
+    expect(
+      within(analyzing)
+        .getAllByRole("button")
+        .map((ticket) => ticket.getAttribute("aria-label"))
+        .slice(-6),
+    ).toEqual([
+      "Open Document the refund webhook contract",
+      "Open Make the billing dashboard faster",
+      "Open Redesign the invoice settings page",
+      "Open Investigate flaky payouts in staging",
+      "Open Move the ledger to a new database",
+      "Open Payments break for some customers",
+    ]);
+    expect(within(analyzing).getByTestId("line-intake-ticket-score-gh-issue-6")).toHaveAttribute("aria-valuenow", "3");
+    expect(within(analyzing).getByTestId("line-intake-ticket-score-gh-issue-11")).toHaveAttribute("aria-valuenow", "1");
+    expect(
+      within(screen.getByTestId("line-intake-source-intake-github")).getByText("6 Not accepted"),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the analysis of a ticket below the minimum confidence", async () => {
+    const user = userEvent.setup();
+    renderDrawer({ initialIntakeId: "intake-github", analyzingTickets: GITHUB_ISSUES_ANALYZING_TICKETS });
+
+    await user.click(screen.getByRole("button", { name: "Open Payments break for some customers" }));
+
+    const dialog = screen.getByTestId("work-order-split-run");
+    expect(within(dialog).getByRole("heading", { name: "Payments break for some customers" })).toBeInTheDocument();
   });
 
   it("opens the analysis popup from an analyzing ticket", async () => {

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
@@ -16,6 +16,7 @@ import {
 import {
   intakeAutomationFixture,
   intakeTicketAnalysisFixture,
+  isBelowThresholdTicket,
   LINE_INTAKE_COPY,
   type AddIntakeTemplate,
   type ConfiguredLineIntakeSource,
@@ -295,13 +296,15 @@ function IntakeListItem({
   const live = useLiveIntakeTickets(organizationId, factoryId, intake, expanded);
   const connected = Boolean(organizationId && factoryId);
   const tickets = connected ? live.tickets : fallbackTickets;
+  const belowThresholdCount = tickets.filter(isBelowThresholdTicket).length;
 
   return (
     <li>
       <IntakeCard
         intake={intake}
         expanded={expanded}
-        childCount={tickets.length}
+        analyzingCount={tickets.length - belowThresholdCount}
+        belowThresholdCount={belowThresholdCount}
         onToggle={() => onToggleIntake(intake.intakeId)}
         onOpenGear={() => onOpenGear(intake)}
       >
@@ -426,14 +429,16 @@ function LineIntakeDrawerPopups({
 function IntakeCard({
   intake,
   expanded,
-  childCount,
+  analyzingCount,
+  belowThresholdCount,
   onToggle,
   onOpenGear,
   children,
 }: {
   intake: ConfiguredLineIntakeSource;
   expanded: boolean;
-  childCount: number;
+  analyzingCount: number;
+  belowThresholdCount: number;
   onToggle: () => void;
   onOpenGear: () => void;
   children?: ReactNode;
@@ -466,11 +471,15 @@ function IntakeCard({
         <div className="relative z-10 min-w-0 flex-1 pointer-events-none">
           <h3 className="flex flex-wrap items-center gap-1.5 text-[13px] font-medium tracking-[-0.01em] leading-[19.5px] text-foreground">
             {displayName}
-            {expanded && childCount > 0 ? (
-              <span className="text-[11px] font-medium tabular-nums text-muted-foreground">{childCount}</span>
+            {expanded && analyzingCount > 0 ? (
+              <span className="text-[11px] font-medium tabular-nums text-muted-foreground">
+                {analyzingCount} {LINE_INTAKE_COPY.analyzingStatus}
+              </span>
             ) : null}
-            {expanded && childCount > 0 ? (
-              <span className="text-[11px] font-medium text-muted-foreground">{LINE_INTAKE_COPY.analyzingStatus}</span>
+            {expanded && belowThresholdCount > 0 ? (
+              <span className="text-[11px] font-medium tabular-nums text-muted-foreground">
+                {belowThresholdCount} {LINE_INTAKE_COPY.belowThresholdStatus}
+              </span>
             ) : null}
             {intake.healthy ? null : (
               <span

--- a/web_src/src/pages/factories/pages/intakeSourceSettingsModel.spec.ts
+++ b/web_src/src/pages/factories/pages/intakeSourceSettingsModel.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  analyzingTicketsFromApi,
   DEFAULT_GITHUB_INTAKE_SETTINGS,
   GITHUB_INTAKE_RUNS,
   isIntakeSettingsTab,
@@ -48,5 +49,39 @@ describe("intakeSourceSettingsModel", () => {
     expect(isIntakeSettingsTab("runs")).toBe(true);
     expect(isIntakeSettingsTab("general")).toBe(true);
     expect(isIntakeSettingsTab("listen")).toBe(false);
+  });
+
+  it("keeps analyzing runs and tickets below the minimum in the Intake list", () => {
+    expect(
+      analyzingTicketsFromApi(
+        [
+          { id: "run-analyzing", title: "Handle duplicate refunds on retry", placement: "PLACEMENT_ANALYZING" },
+          { id: "run-backlog", title: "Already in Backlog", placement: "PLACEMENT_BACKLOG", confidencePct: 81 },
+          {
+            id: "run-held",
+            title: "Document the refund webhook contract",
+            placement: "PLACEMENT_BELOW_THRESHOLD",
+            confidencePct: 52,
+          },
+          { id: "run-rejected", title: "A person rejected this", placement: "PLACEMENT_REJECTED" },
+        ],
+        "app-github-issues-intake",
+      ),
+    ).toEqual([
+      {
+        id: "run-analyzing",
+        title: "Handle duplicate refunds on retry",
+        runId: "run-analyzing",
+        appId: "app-github-issues-intake",
+      },
+      {
+        id: "run-held",
+        title: "Document the refund webhook contract",
+        runId: "run-held",
+        appId: "app-github-issues-intake",
+        outcome: "below-threshold",
+        confidencePct: 52,
+      },
+    ]);
   });
 });

--- a/web_src/src/pages/factories/pages/intakeSourceSettingsModel.ts
+++ b/web_src/src/pages/factories/pages/intakeSourceSettingsModel.ts
@@ -289,19 +289,49 @@ export function intakeRunsFromApi(
   });
 }
 
-/** Runs the intake is still analyzing, shown as tickets under the source. */
+interface IntakeListTicket {
+  id: string;
+  title: string;
+  appId?: string;
+  runId?: string;
+  outcome?: "analyzing" | "below-threshold";
+  confidencePct?: number;
+}
+
+/** Tickets that stay in the Intake list: still analyzing, or below the minimum. */
 export function analyzingTicketsFromApi(
   runs: FactoriesFactoryIntakeRun[],
   appId: string | undefined,
-): Array<{ id: string; title: string; appId?: string; runId?: string }> {
+): IntakeListTicket[] {
   return runs.flatMap((run) => {
-    const id = run.id?.trim();
-    const title = run.title?.trim();
-    if (!id || !title || run.placement !== "PLACEMENT_ANALYZING") {
-      return [];
-    }
-    return [{ id, title, runId: id, ...(appId ? { appId } : {}) }];
+    const ticket = intakeListTicketFromRun(run, appId);
+    return ticket ? [ticket] : [];
   });
+}
+
+function intakeListTicketFromRun(
+  run: FactoriesFactoryIntakeRun,
+  appId: string | undefined,
+): IntakeListTicket | undefined {
+  const id = run.id?.trim();
+  const title = run.title?.trim();
+  if (!id || !title) {
+    return undefined;
+  }
+
+  const ticket: IntakeListTicket = { id, title, runId: id, ...(appId ? { appId } : {}) };
+  if (run.placement === "PLACEMENT_ANALYZING") {
+    return ticket;
+  }
+  if (run.placement !== "PLACEMENT_BELOW_THRESHOLD") {
+    return undefined;
+  }
+
+  return {
+    ...ticket,
+    outcome: "below-threshold",
+    ...(run.confidencePct != null ? { confidencePct: run.confidencePct } : {}),
+  };
 }
 
 function minutesAgo(timestamp: string | undefined, now: Date): number {

--- a/web_src/src/pages/factories/pages/lineIntakeModel.spec.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeModel.spec.ts
@@ -3,11 +3,14 @@ import { describe, expect, it } from "vitest";
 import {
   ADD_INTAKE_TEMPLATES,
   filterAddIntakeTemplates,
+  GITHUB_ISSUES_ANALYZING_TICKETS,
   intakeAutomationFixture,
   intakeSourcesFromFactoryIntakes,
   intakeTicketAnalysisFixture,
+  intakeTicketConfidenceScore,
   LINE_INTAKE_SOURCES,
   lineIntakeSourceById,
+  sortIntakeTicketsByOutcome,
 } from "./lineIntakeModel";
 
 describe("lineIntakeModel", () => {
@@ -167,6 +170,50 @@ describe("lineIntakeModel", () => {
     };
     expect(fixture.checks).toEqual([check]);
     expect(fixture.phases.find((phase) => phase.id === "score")?.checks).toEqual([check]);
+  });
+
+  it("reads the ticket score from the intake percentage", () => {
+    expect(intakeTicketConfidenceScore({ id: "gh-1", title: "Ticket", confidencePct: 58 })).toBe(3);
+    expect(intakeTicketConfidenceScore({ id: "gh-1", title: "Ticket", confidencePct: 12 })).toBe(1);
+    expect(intakeTicketConfidenceScore({ id: "gh-1", title: "Ticket", confidenceScore: 5, confidencePct: 12 })).toBe(5);
+    expect(intakeTicketConfidenceScore({ id: "gh-1", title: "Ticket" })).toBeUndefined();
+  });
+
+  it("keeps analyzing tickets over the tickets below the minimum confidence", () => {
+    expect(
+      sortIntakeTicketsByOutcome([
+        { id: "gh-1", title: "Below", outcome: "below-threshold", confidencePct: 20 },
+        { id: "gh-2", title: "Analyzing" },
+      ]).map((ticket) => ticket.id),
+    ).toEqual(["gh-2", "gh-1"]);
+
+    expect(GITHUB_ISSUES_ANALYZING_TICKETS.filter((ticket) => ticket.outcome === "below-threshold")).toHaveLength(6);
+    expect(
+      GITHUB_ISSUES_ANALYZING_TICKETS.filter((ticket) => ticket.outcome === "below-threshold").every(
+        (ticket) => (ticket.confidencePct ?? 100) < 60,
+      ),
+    ).toBe(true);
+  });
+
+  // The analysis of a ticket under the minimum confidence is over. The popup
+  // must show the finished run and the score, not a run that is still going.
+  it("marks the analysis of a ticket below the minimum confidence as finished", () => {
+    const fixture = intakeTicketAnalysisFixture({
+      id: "gh-issue-11",
+      title: "Payments break for some customers",
+      outcome: "below-threshold",
+      confidencePct: 12,
+    });
+
+    expect(fixture.phases.map((phase) => phase.status)).toEqual(["passed", "passed", "passed", "passed"]);
+    expect(fixture.checks).toEqual([
+      expect.objectContaining({
+        name: "Confidence score",
+        score: 1,
+        level: "caution",
+        summary: "This issue is a poor fit for an agent on this factory line.",
+      }),
+    ]);
   });
 
   it("keeps later analysis steps pending while analyze runs", () => {

--- a/web_src/src/pages/factories/pages/lineIntakeModel.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeModel.ts
@@ -16,7 +16,14 @@ import {
   STORYBOOK_ME_USER_ID,
   STORYBOOK_ME_USER_NAME,
 } from "../__fixtures__/factoryPageResponses";
-import { CONFIDENCE_CHECK_NAME, CONFIDENCE_SCORE_MAX, confidenceCheckLevel } from "../lib/confidenceScore";
+import {
+  CONFIDENCE_CHECK_NAME,
+  CONFIDENCE_SCORE_MAX,
+  confidenceBandForScore,
+  confidenceCheckLevel,
+  confidenceScoreFromPercent,
+  confidenceSuitabilitySummary,
+} from "../lib/confidenceScore";
 import type { WorkOrderCheckPresentation } from "../lib/workOrderChecks";
 import type { WorkOrderStatusNotePresentation } from "../lib/workOrderStatusNote";
 import { intakeSettingsFromApi, type IntakeSourceSettings } from "./intakeSourceSettingsModel";
@@ -182,18 +189,49 @@ export function intakeSourcesFromFactoryIntakes(intakes: FactoriesFactoryIntake[
   });
 }
 
+/**
+ * A ticket the intake still analyzes, or one that finished with a score under
+ * the minimum confidence. Tickets over the minimum leave the list for Backlog.
+ */
+export type LineIntakeTicketOutcome = "analyzing" | "below-threshold";
+
 export interface LineIntakeAnalyzingTicket {
   id: string;
   title: string;
   appId?: string;
   runId?: string;
+  outcome?: LineIntakeTicketOutcome;
   detailsMarkdown?: string;
   issueKey?: string;
   issueUrl?: string;
   planMarkdown?: string;
+  /** Score the intake reports, on the same scale as the minimum confidence. */
+  confidencePct?: number;
   confidenceScore?: number;
   confidenceSummary?: string;
   confidenceAnalysis?: string;
+}
+
+export function isBelowThresholdTicket(ticket: LineIntakeAnalyzingTicket): boolean {
+  return ticket.outcome === "below-threshold";
+}
+
+/** Analyzing tickets stay on top. Tickets that did not make it stay below. */
+export function sortIntakeTicketsByOutcome(tickets: LineIntakeAnalyzingTicket[]): LineIntakeAnalyzingTicket[] {
+  return [
+    ...tickets.filter((ticket) => !isBelowThresholdTicket(ticket)),
+    ...tickets.filter((ticket) => isBelowThresholdTicket(ticket)),
+  ];
+}
+
+export function intakeTicketConfidenceScore(ticket: LineIntakeAnalyzingTicket): number | undefined {
+  if (ticket.confidenceScore != null) {
+    return ticket.confidenceScore;
+  }
+  if (ticket.confidencePct != null) {
+    return confidenceScoreFromPercent(ticket.confidencePct);
+  }
+  return undefined;
 }
 
 export const LINE_INTAKE_COPY = {
@@ -201,6 +239,8 @@ export const LINE_INTAKE_COPY = {
   analyzingHelper: "Tickets from this intake.",
   analyzingStatus: "Analyzing",
   analyzingEmpty: "No tickets in analysis.",
+  belowThresholdStatus: "Not accepted",
+  belowThresholdHelper: "Not accepted. The score is below the minimum confidence.",
   needsRepair: "Needs repair",
   needsRepairHelper: "The automation can no longer create work orders. Open it to repair the steps.",
   analysisHeadline: "SuperPlane is analyzing this ticket",
@@ -216,6 +256,12 @@ export const GITHUB_ISSUES_ANALYZING_TICKETS: LineIntakeAnalyzingTicket[] = [
   { id: "gh-issue-3", title: "Show a clearer empty state on the billing page" },
   { id: "gh-issue-4", title: "Upgrade the Node 20 base image" },
   { id: "gh-issue-5", title: "Add a flake retry to the checkout e2e suite" },
+  { id: "gh-issue-6", title: "Document the refund webhook contract", outcome: "below-threshold", confidencePct: 58 },
+  { id: "gh-issue-7", title: "Make the billing dashboard faster", outcome: "below-threshold", confidencePct: 52 },
+  { id: "gh-issue-8", title: "Redesign the invoice settings page", outcome: "below-threshold", confidencePct: 44 },
+  { id: "gh-issue-9", title: "Investigate flaky payouts in staging", outcome: "below-threshold", confidencePct: 38 },
+  { id: "gh-issue-10", title: "Move the ledger to a new database", outcome: "below-threshold", confidencePct: 27 },
+  { id: "gh-issue-11", title: "Payments break for some customers", outcome: "below-threshold", confidencePct: 12 },
 ];
 
 const OWNER = {
@@ -258,7 +304,7 @@ export function intakeTicketAnalysisFixture(
   ticket: LineIntakeAnalyzingTicket,
   options?: { complete?: boolean },
 ): SplitRunFixture {
-  const complete = Boolean(options?.complete);
+  const complete = options?.complete ?? isBelowThresholdTicket(ticket);
   const canvas = ticketAnalysisCanvas(complete);
   const checks = complete ? confidenceChecks(ticket) : [];
   const view = ticketAnalysisPresentation(complete);
@@ -375,18 +421,19 @@ function planArtifact(ticket: LineIntakeAnalyzingTicket): FactoriesWorkOrderArti
 }
 
 function confidenceChecks(ticket: LineIntakeAnalyzingTicket): WorkOrderCheckPresentation[] {
-  if (ticket.confidenceScore == null) {
+  const score = intakeTicketConfidenceScore(ticket);
+  if (score == null) {
     return [];
   }
   return [
     {
       id: `${ticket.id}-confidence`,
       name: CONFIDENCE_CHECK_NAME,
-      score: ticket.confidenceScore,
+      score,
       maxScore: CONFIDENCE_SCORE_MAX,
       format: "fraction",
-      level: confidenceCheckLevel(ticket.confidenceScore),
-      summary: ticket.confidenceSummary,
+      level: confidenceCheckLevel(score),
+      summary: ticket.confidenceSummary ?? confidenceSuitabilitySummary(confidenceBandForScore(score)),
       analysis: ticket.confidenceAnalysis,
       sourceName: "Score",
     },


### PR DESCRIPTION
## Summary

Tickets that finish analysis below the minimum confidence stay in the Intake list. SuperPlane does not move them to Backlog.

The list shows a small X in place of the spinner, and the five-step confidence meter on the right. Analyzing tickets stay at the top. The source header shows both counts.

Connected factories now receive the same list from live intake runs. The mapper keeps analyzing runs and below-threshold runs, and it drops tickets that already moved to Backlog.

## Test plan

- [ ] Open the Intake drawer for GitHub issues in Storybook: Factories/Pages/Intake tree / GitHub issues expanded.
- [ ] Confirm five tickets show a spinner at the top.
- [ ] Confirm six tickets stay at the bottom with an X and a red or orange confidence meter.
- [ ] Confirm the header shows 5 Analyzing and 6 Not accepted.
- [ ] Click a ticket below the minimum confidence. Confirm the analysis popup opens.
- [ ] Open a connected factory Intake drawer after a low-score analysis.
- [ ] Confirm the ticket stays in the list with Not accepted and the score meter.
- [ ] Confirm tickets that meet the minimum confidence still leave the list for Backlog.