### PR TITLE
fix: Fit canvas when opening a run from Lines

### DIFF
--- a/web_src/src/ui/CanvasPage/fitView.spec.ts
+++ b/web_src/src/ui/CanvasPage/fitView.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveFitViewVersionId, shouldRefitOnInit, stampFittedContentKey } from "./fitView";
+import { resolveFitViewVersionId, shouldRefitOnInit, shouldRunFitAllRequest, stampFittedContentKey } from "./fitView";
 
 describe("resolveFitViewVersionId", () => {
   const liveParams = {
@@ -76,5 +76,46 @@ describe("stampFittedContentKey", () => {
 
   it("is a no-op without a ref", () => {
     expect(() => stampFittedContentKey(undefined, "c1:v1")).not.toThrow();
+  });
+});
+
+describe("shouldRunFitAllRequest", () => {
+  const ready = {
+    hasFitted: true,
+    reactFlowReady: true,
+    isAutoFocusEnabled: true,
+    isFirstFitAllOnMount: false,
+  };
+
+  it("waits until React Flow has fitted once", () => {
+    expect(shouldRunFitAllRequest({ ...ready, hasFitted: false })).toBe("wait");
+  });
+
+  it("waits until React Flow reports initialized", () => {
+    expect(shouldRunFitAllRequest({ ...ready, reactFlowReady: false })).toBe("wait");
+  });
+
+  it("runs when auto-focus is on", () => {
+    expect(shouldRunFitAllRequest(ready)).toBe("run");
+  });
+
+  it("still runs the first fitAll on a mount when auto-focus is off", () => {
+    expect(
+      shouldRunFitAllRequest({
+        ...ready,
+        isAutoFocusEnabled: false,
+        isFirstFitAllOnMount: true,
+      }),
+    ).toBe("run");
+  });
+
+  it("skips later fitAll requests when auto-focus is off", () => {
+    expect(
+      shouldRunFitAllRequest({
+        ...ready,
+        isAutoFocusEnabled: false,
+        isFirstFitAllOnMount: false,
+      }),
+    ).toBe("skip");
   });
 });

--- a/web_src/src/ui/CanvasPage/fitView.ts
+++ b/web_src/src/ui/CanvasPage/fitView.ts
@@ -52,3 +52,30 @@ export function stampFittedContentKey(
   }
   ref.current = fitViewContentKey;
 }
+
+/** Outcome of a bumped `fitAllRequest` before `fitView` is called. */
+export type FitAllRequestDecision = "wait" | "skip" | "run";
+
+/**
+ * Decide whether a bumped `fitAllRequest` should call fitView.
+ *
+ * Wait until React Flow has finished its first fit; the caller must retry
+ * without consuming the nonce. Skip when auto-focus is off, except the first
+ * fitAll on this mount — Lines / Automations deep links land in run inspection
+ * without `handleSelectRun`, so that first request has to fit the same way the
+ * "Fit all components in view" control does.
+ */
+export function shouldRunFitAllRequest(params: {
+  hasFitted: boolean;
+  reactFlowReady: boolean;
+  isAutoFocusEnabled: boolean;
+  isFirstFitAllOnMount: boolean;
+}): FitAllRequestDecision {
+  if (!params.hasFitted || !params.reactFlowReady) {
+    return "wait";
+  }
+  if (!params.isAutoFocusEnabled && !params.isFirstFitAllOnMount) {
+    return "skip";
+  }
+  return "run";
+}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -106,7 +106,7 @@ import type { AgentSuggestion } from "./components/AgentSuggestionsHoverCard";
 import { isComponentSidebarVisibleMode } from "./canvasTabHeaderMode";
 import { enrichCanvasNodes, type EnrichedCanvasNodeCacheEntry } from "./enrichCanvasNodes";
 import { buildStyledCanvasEdges } from "./factoryCanvasEdgeStyle";
-import { shouldRefitOnInit, stampFittedContentKey } from "./fitView";
+import { shouldRefitOnInit, shouldRunFitAllRequest, stampFittedContentKey } from "./fitView";
 import { useFactoryConfigureFitView } from "./useFactoryConfigureFitView";
 import { publishBuildingBlocksSidebarChanged, useBuildingBlocksSidebarRequest } from "./buildingBlocksSidebarRequest";
 import { RightSideControls } from "./RightSideControls";
@@ -2894,13 +2894,26 @@ function CanvasContent({
     }
     const last = lastFitAllRequestRef.current;
     if (last?.nonce === fitAllRequest && last.runMode === isRunInspectionMode) return;
-    if (!hasFitToViewRef.current) return;
-    // Consume the nonce so re-enabling auto-focus later does not retroactively
-    // replay this run's participant fit. The viewport stays where the user is.
-    lastFitAllRequestRef.current = { nonce: fitAllRequest, runMode: isRunInspectionMode };
-    if (!isAutoFocusEnabled) return;
     let timeoutId: number | null = null;
     const runFit = (attempt: number) => {
+      const decision = shouldRunFitAllRequest({
+        hasFitted: hasFitToViewRef.current,
+        reactFlowReady: hasReactFlowInitialized,
+        isAutoFocusEnabled,
+        isFirstFitAllOnMount: lastFitAllRequestRef.current == null,
+      });
+      if (decision === "wait") {
+        if (attempt < 20) {
+          timeoutId = window.setTimeout(() => runFit(attempt + 1), 50);
+        }
+        return;
+      }
+      // Consume the nonce so re-enabling auto-focus later does not retroactively
+      // replay this run's participant fit. The viewport stays where the user is.
+      lastFitAllRequestRef.current = { nonce: fitAllRequest, runMode: isRunInspectionMode };
+      if (decision === "skip") {
+        return;
+      }
       const focusIds = fitAllFocusNodeIds?.length ? new Set(fitAllFocusNodeIds) : null;
       const nodesById = new Map(stateRef.current.nodes.map((node) => [node.id, node]));
       getNodes().forEach((node) => nodesById.set(node.id, node));

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2895,24 +2895,28 @@ function CanvasContent({
     const last = lastFitAllRequestRef.current;
     if (last?.nonce === fitAllRequest && last.runMode === isRunInspectionMode) return;
     let timeoutId: number | null = null;
+    let accepted = false;
     const runFit = (attempt: number) => {
-      const decision = shouldRunFitAllRequest({
-        hasFitted: hasFitToViewRef.current,
-        reactFlowReady: hasReactFlowInitialized,
-        isAutoFocusEnabled,
-        isFirstFitAllOnMount: lastFitAllRequestRef.current == null,
-      });
-      if (decision === "wait") {
-        if (attempt < 20) {
-          timeoutId = window.setTimeout(() => runFit(attempt + 1), 50);
+      if (!accepted) {
+        const decision = shouldRunFitAllRequest({
+          hasFitted: hasFitToViewRef.current,
+          reactFlowReady: hasReactFlowInitialized,
+          isAutoFocusEnabled,
+          isFirstFitAllOnMount: lastFitAllRequestRef.current == null,
+        });
+        if (decision === "wait") {
+          if (attempt < 20) {
+            timeoutId = window.setTimeout(() => runFit(attempt + 1), 50);
+          }
+          return;
         }
-        return;
-      }
-      // Consume the nonce so re-enabling auto-focus later does not retroactively
-      // replay this run's participant fit. The viewport stays where the user is.
-      lastFitAllRequestRef.current = { nonce: fitAllRequest, runMode: isRunInspectionMode };
-      if (decision === "skip") {
-        return;
+        // Consume the nonce so re-enabling auto-focus later does not retroactively
+        // replay this run's participant fit. The viewport stays where the user is.
+        lastFitAllRequestRef.current = { nonce: fitAllRequest, runMode: isRunInspectionMode };
+        if (decision === "skip") {
+          return;
+        }
+        accepted = true;
       }
       const focusIds = fitAllFocusNodeIds?.length ? new Set(fitAllFocusNodeIds) : null;
       const nodesById = new Map(stateRef.current.nodes.map((node) => [node.id, node]));


### PR DESCRIPTION
Fixes #6714

## What changed
Opening a step run from Factory Lines (`?run=` + `from=lines`) now fits the graph into view the same way the zoom control “Fit all components in view” does.

`fitAllRequest` used to:
- return immediately if React Flow had not finished its first fit (the ref never retriggered the effect)
- skip entirely when auto-focus was off, after consuming the nonce

Deep links from Lines never go through `handleSelectRun`, so that left the canvas on a stale / empty viewport.

## Why
The canvas could land off-graph and look empty until someone clicked the zoom control.

## How
- Added `shouldRunFitAllRequest` (`wait` / `skip` / `run`) with unit tests
- Retry until React Flow is ready instead of dropping the request
- Always run the first `fitAll` on a mount, even when auto-focus is off (later requests still respect the preference)

## Test plan
- [ ] From Lines, open a phase step run → canvas frames the participating nodes without clicking “Fit all components in view”
- [ ] Repeat with auto-focus off — first land still fits
- [ ] Selecting another run with auto-focus off does not yank the viewport
- [ ] In-canvas run selection with auto-focus on still fits participants


Made with [Cursor](https://cursor.com)