### PR TITLE
feat: Add an executive summary to the intake confidence score

### DIFF
--- a/pkg/grpc/actions/factories/intake_template.go
+++ b/pkg/grpc/actions/factories/intake_template.go
@@ -220,6 +220,8 @@ func buildIntakeCanvas(request intakeCanvasRequest) (*yaml.Canvas, error) {
 						"direction":  intakeConfidenceDirection,
 						"cautionAt":  float64(intakeConfidenceCautionAt),
 						"criticalAt": float64(intakeConfidenceCriticalAt),
+						"summary":    intakeConfidenceSummaryExpression(),
+						"analysis":   intakeConfidenceWriteupExpression(spec.analysisSubject),
 					},
 					Concurrency: intakeConcurrency(),
 					Position:    yaml.Position{X: 160, Y: 800},
@@ -280,19 +282,36 @@ func intakeAnalysisConfiguration(spec intakeSpec, agent *intakeAgent) map[string
 func intakeAnalysisPrompt(subject string) string {
 	return strings.Join([]string{
 		fmt.Sprintf("Analyze this %s and decide whether it is suitable for an engineering work order.", subject),
-		"Consider impact, clarity, feasibility, and whether an engineer can take a concrete action.",
-		"Return only one integer from 0 through 100. A higher value means greater confidence.",
+		"Consider impact, clarity, feasibility, and whether an agent on this factory line can take a concrete action.",
+		"Return only one JSON object. Do not wrap it in markdown.",
+		"Keys:",
+		`- "score": integer from 0 through 100. A higher value means greater confidence.`,
+		`- "summary": one sentence on how suitable the work is for an agent on this factory line.`,
+		`- "reasons": exactly three short sentences that explain the score.`,
+		"Write three reasons: what the item names, what already exists, and whether an agent can do the work.",
 		"",
 		"Event:",
 		"{{ root().data }}",
 	}, "\n")
 }
 
-// intakeAnalysisScorePath reads the score out of the analysis node's output. A
-// node reference resolves to one event, whose data holds the runner's result,
-// so the path walks straight into it rather than indexing a list.
-func intakeAnalysisScorePath() string {
+// intakeAnalysisResultRaw is the runner's text output. A node reference
+// resolves to one event, whose data holds that text, so the path walks
+// straight into it rather than indexing a list.
+func intakeAnalysisResultRaw() string {
 	return fmt.Sprintf(`$[%q].data.result.result`, intakeAnalysisNodeName)
+}
+
+// intakeAnalysisJSONExpr parses the JSON object the analysis runner returns.
+// Agents often wrap JSON in prose, so the slice is from the first "{" to the
+// last "}".
+func intakeAnalysisJSONExpr() string {
+	raw := intakeAnalysisResultRaw()
+	return fmt.Sprintf(`fromJSON(%s[indexOf(%s, "{"):lastIndexOf(%s, "}") + 1])`, raw, raw, raw)
+}
+
+func intakeAnalysisScorePath() string {
+	return intakeAnalysisJSONExpr() + ".score"
 }
 
 func intakeThresholdExpression(confidencePct int) string {
@@ -301,6 +320,22 @@ func intakeThresholdExpression(confidencePct int) string {
 
 func intakeWorkOrderIDExpression() string {
 	return fmt.Sprintf(`{{ $[%q].data.workOrder.id }}`, intakeCreateNodeName)
+}
+
+func intakeConfidenceSummaryExpression() string {
+	return fmt.Sprintf(`{{ %s.summary }}`, intakeAnalysisJSONExpr())
+}
+
+func intakeConfidenceWriteupExpression(subject string) string {
+	intro := fmt.Sprintf(
+		"The automation read this %s. It scored how suitable the work is for an agent on this factory line.",
+		subject,
+	)
+	return fmt.Sprintf(
+		`{{ %q + "\n\n### Why this score\n- " + join(%s.reasons, "\n- ") }}`,
+		intro,
+		intakeAnalysisJSONExpr(),
+	)
 }
 
 // intakeConfidenceScoreExpression maps the analysis percentage to the 0–5

--- a/pkg/grpc/actions/factories/intake_template_test.go
+++ b/pkg/grpc/actions/factories/intake_template_test.go
@@ -1,7 +1,7 @@
 package factories
 
 import (
-	"strconv"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -52,6 +52,8 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 		assert.Equal(t, "Confidence score", report.Configuration["name"])
 		assert.Equal(t, "5", report.Configuration["maxScore"])
 		assert.Equal(t, "fraction", report.Configuration["format"])
+		assert.Equal(t, intakeConfidenceSummaryExpression(), report.Configuration["summary"])
+		assert.Equal(t, intakeConfidenceWriteupExpression("GitHub issue"), report.Configuration["analysis"])
 	})
 
 	t.Run("the score rounds onto the meter scale like the UI does", func(t *testing.T) {
@@ -61,7 +63,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
 		assert.Equal(
 			t,
-			`{{ int(round(int($["Analyze intake"].data.result.result) / 20.0)) }}`,
+			`{{ int(round(int(`+intakeAnalysisScorePath()+`) / 20.0)) }}`,
 			report.Configuration["score"],
 		)
 
@@ -69,6 +71,47 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 		for pct, expected := range map[int]int{0: 0, 49: 2, 50: 3, 69: 3, 70: 4, 89: 4, 90: 5, 100: 5} {
 			assert.Equal(t, expected, evaluateIntakeConfidenceScore(t, expression, pct), "confidence %d%%", pct)
 		}
+	})
+
+	t.Run("the confidence check stores a short executive summary", func(t *testing.T) {
+		canvas, err := buildIntakeCanvas(intakeCanvasRequest{Source: models.FactoryIntakeSourceGitHubIssues, ConfidencePct: DefaultIntakeConfidencePct})
+		require.NoError(t, err)
+
+		analysis := findSpecNode(t, canvas, intakeAnalysisNodeID)
+		steps := analysis.Configuration["steps"].([]any)
+		prompt := steps[0].(map[string]any)["prompt"].(string)
+		assert.Contains(t, prompt, `"reasons"`)
+		assert.Contains(t, prompt, `"summary"`)
+		assert.Contains(t, prompt, "exactly three short sentences")
+
+		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
+		result := `{
+			"score": 72,
+			"summary": "This issue is a mixed fit for an agent on this factory line.",
+			"reasons": [
+				"The GitHub issue names the empty-state title and the create-invoice action.",
+				"The billing page already has an empty branch and a shared empty-state component.",
+				"The change is copy and layout. An agent can do the work, but the copy is a judgment call."
+			]
+		}`
+
+		assert.Equal(
+			t,
+			"This issue is a mixed fit for an agent on this factory line.",
+			evaluateIntakeTemplate(t, report.Configuration["summary"].(string), result),
+		)
+		assert.Equal(
+			t,
+			strings.Join([]string{
+				"The automation read this GitHub issue. It scored how suitable the work is for an agent on this factory line.",
+				"",
+				"### Why this score",
+				"- The GitHub issue names the empty-state title and the create-invoice action.",
+				"- The billing page already has an empty branch and a shared empty-state component.",
+				"- The change is copy and layout. An agent can do the work, but the copy is a judgment call.",
+			}, "\n"),
+			evaluateIntakeTemplate(t, report.Configuration["analysis"].(string), result),
+		)
 	})
 
 	t.Run("the check level follows the meter bands", func(t *testing.T) {
@@ -145,7 +188,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 		require.NoError(t, err)
 
 		threshold := findSpecNode(t, canvas, intakeThresholdNodeID)
-		assert.Equal(t, `int($["Analyze intake"].data.result.result) >= 80`, threshold.Configuration["expression"])
+		assert.Equal(t, `int(`+intakeAnalysisScorePath()+`) >= 80`, threshold.Configuration["expression"])
 	})
 
 	t.Run("the threshold reads the score the analysis runner reports", func(t *testing.T) {
@@ -283,10 +326,25 @@ func evaluateIntakeThreshold(t *testing.T, expression string, pct int) bool {
 	return matches
 }
 
+// evaluateIntakeTemplate resolves a {{ }} configuration string against the
+// analysis runner result, the same way report-check fields are filled.
+func evaluateIntakeTemplate(t *testing.T, template string, result string) any {
+	t.Helper()
+
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(template, "{{"), "}}"))
+	return evaluateIntakeExpressionResult(t, inner, result)
+}
+
 // evaluateIntakeExpression resolves an expression against the event the
 // analysis runner emits when it finishes, so the generated result path is
 // checked against the shape the graph actually receives.
 func evaluateIntakeExpression(t *testing.T, expression string, pct int) any {
+	t.Helper()
+
+	return evaluateIntakeExpressionResult(t, expression, fmt.Sprintf(`{"score":%d,"reasons":["a","b","c"]}`, pct))
+}
+
+func evaluateIntakeExpressionResult(t *testing.T, expression string, result string) any {
 	t.Helper()
 
 	analysis := map[string]any{
@@ -296,7 +354,7 @@ func evaluateIntakeExpression(t *testing.T, expression string, pct int) any {
 			"exit_code": 0,
 			"result": map[string]any{
 				"type":   "result",
-				"result": strconv.Itoa(pct),
+				"result": "Here is the score:\n" + result,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

The intake confidence check showed only a number. A user who opened the check
saw a score with no explanation, so the user could not tell why the automation
gave that score.

The analysis step now returns a JSON object with three parts: the score, a
one-sentence verdict on agent fit, and three short reasons. The report step
stores the verdict as the check summary and builds a "Why this score" write-up
for the check analysis. The check now reads like this:

> The automation read this GitHub issue. It scored how suitable the work is for
> an agent on this factory line.
>
> ### Why this score
> - The GitHub issue names the empty-state title and the create-invoice action.
> - The billing page already has an empty branch and a shared empty-state component.
> - The change is copy and layout. An agent can do the work, but the copy is a judgment call.

The score path and the threshold now read the `score` key of that JSON object.
The expression cuts the text from the first `{` to the last `}`, because an
agent can put prose around the JSON.

This changes new intakes only. An intake that exists keeps its current prompt
until a user creates the intake again.

## Test plan

- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories`.
- [ ] Create a GitHub issues intake. Confirm the analysis node prompt asks for `score`, `summary`, and `reasons`.
- [ ] Open an issue that clears the confidence threshold. Wait for the work order.
- [ ] Open the Confidence score check on the work order. Confirm the summary sentence and the "Why this score" list show three reasons.

Made with [Cursor](https://cursor.com)