### PR TITLE
chore: Mount Go caches for Semaphore restore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,8 +13,10 @@ global_job_config:
     commands:
       - checkout
       - mkdir -p tmp/go tmp/go-build
-      - "cache restore go-mod-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum),go-mod-$SEMAPHORE_GIT_BRANCH,go-mod"
-      - "cache restore go-build-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum),go-build-$SEMAPHORE_GIT_BRANCH,go-build"
+      # Only main stores these caches, so the keys carry no branch name.
+      # See scripts/ci_cache_store_go.sh.
+      - "cache restore go-mod-$(checksum go.sum),go-mod"
+      - "cache restore go-build-$(checksum go.sum),go-build"
       - make dev.up
       - make dev.setup
 
@@ -62,8 +64,7 @@ blocks:
           commands:
             - "[ -f junit-report.xml ] && test-results publish junit-report.xml"
             - "if [ -d tmp/screenshots ] && ls tmp/screenshots/**/*.png >/dev/null 2>&1; then artifact push job tmp/screenshots; fi"
-            - "cache store go-mod-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum) tmp/go"
-            - "cache store go-build-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum) tmp/go-build"
+            - bash scripts/ci_cache_store_go.sh
 
   - name: "Frontend Tests"
     dependencies: []

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,16 @@ endif
 PKG_TEST_PACKAGES := ./pkg/...
 E2E_TEST_PACKAGES := ./test/e2e/...
 
-COMPOSE=docker compose -f docker-compose.dev.yml
+# On CI, overlay docker-compose.ci.yml so the Go module and build caches live in
+# host directories that the CI cache can restore and store between jobs.
+COMPOSE_FILES := -f docker-compose.dev.yml
+GO_CACHE_DIRS :=
+ifneq ($(strip $(CI)),)
+COMPOSE_FILES += -f docker-compose.ci.yml
+GO_CACHE_DIRS := tmp/go tmp/go-build
+endif
+
+COMPOSE=docker compose $(COMPOSE_FILES)
 GENERATED_ARTIFACT_PATHS := pkg/protos pkg/openapi_client web_src/src/api-client api/swagger/superplane.swagger.json
 OPENAPI_GENERATOR_IMAGE := openapitools/openapi-generator-cli:v7.13.0
 
@@ -102,7 +111,7 @@ dev.test.is.running:
 	@test -n "$$($(COMPOSE) ps --status running -q app 2>/dev/null)" || { echo "Run \`make dev.up\` first (app container is not running)." >&2; exit 1; }
 
 dev.up:
-	@mkdir -p tmp/screenshots
+	@mkdir -p tmp/screenshots $(GO_CACHE_DIRS)
 	$(COMPOSE) up -d --wait --build --pull always --quiet-pull
 
 dev.setup:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,18 @@
+#
+# CI-only overlay for docker-compose.dev.yml. The Makefile adds this file when
+# the CI environment variable is set.
+#
+# In development, GOMODCACHE and GOCACHE live on the `go-pkg-cache` named volume.
+# On CI that volume starts empty on every machine, so `go mod download` and every
+# compile step run cold in each job. Bind both caches to host directories that the
+# CI cache restores before the job and stores after it (tmp/go, tmp/go-build).
+#
+# Do not use this overlay in development: with the module cache on the bind mount,
+# two concurrent `go build` processes (for example two Air instances) corrupt the
+# same module download temp files.
+#
+services:
+  app:
+    volumes:
+      - ./tmp/go:/go/pkg/mod
+      - ./tmp/go-build:/go/go-build-cache

--- a/scripts/ci_cache_store_go.sh
+++ b/scripts/ci_cache_store_go.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Store the Go module cache (tmp/go) and build cache (tmp/go-build) on CI.
+#
+# Only the default branch uploads. The keys hold a go.sum checksum and no branch
+# name, so a feature branch would replace the entry that every other branch
+# reads, and each upload adds gigabytes to the project cache quota. Feature
+# branches restore the entry from the default branch and download only the
+# modules that their own go.sum adds.
+#
+# The keys also stay stable while go.sum stays the same, so the entry keeps the
+# compiled standard library and dependencies. Packages of this repository change
+# with every commit and miss the build cache in any case.
+
+set -euo pipefail
+
+DEFAULT_BRANCH="main"
+
+if [[ "${SEMAPHORE_GIT_BRANCH:-}" != "$DEFAULT_BRANCH" ]]; then
+  echo "Branch is not ${DEFAULT_BRANCH}; keep the Go caches as they are."
+  exit 0
+fi
+
+go_sum_checksum="$(checksum go.sum)"
+
+cache store "go-mod-${go_sum_checksum}" tmp/go
+cache store "go-build-${go_sum_checksum}" tmp/go-build


### PR DESCRIPTION
## Summary

Semaphore restored `tmp/go` and `tmp/go-build`, but the app container used a named Docker volume for `GOMODCACHE` and `GOCACHE`. Each job downloaded Go modules again and compiled from a cold cache.

This change bind-mounts those host directories on CI only. Feature branches restore the cache. Only `main` stores it, with keys that use the `go.sum` checksum.

## Test plan

- [ ] Confirm a local `make dev.up` does not load `docker-compose.ci.yml`.
- [ ] Confirm `CI=true make -n dev.up` loads `docker-compose.ci.yml` and creates `tmp/go` and `tmp/go-build`.
- [ ] After merge, wait for one green `main` pipeline, then confirm a later job restores `go-mod-$(checksum go.sum)` and `go-build-$(checksum go.sum)`.
- [ ] Confirm `make dev.setup.go` on a later CI job is much faster than a cold ~87s download and build.


Made with [Cursor](https://cursor.com)