### PR TITLE
chore: Show Add intake in Storybook previews

### DIFF
--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.tsx
@@ -4,6 +4,7 @@ import type { HomePageFixture, StorybookOrgIntegration } from "@/pages/home/__fi
 import { defaultHomePageFixture } from "@/pages/home/__fixtures__/homePageResponses";
 import { FEATURE_CLAUDE_MANAGED_AGENTS, FEATURE_FACTORIES } from "@/lib/experimentalFeatures";
 
+import { FactoryPreviewFlagsContext, type FactoryPreviewFlags } from "../pages/factoryPreviewFlagsContext";
 import { OnboardingStorybookProvider } from "../pages/onboarding/OnboardingStorybookContext";
 import { OnboardingPage } from "../pages/onboarding/OnboardingPage";
 import type { OnboardingStorybookSeed } from "../pages/onboarding/onboardingMocks";
@@ -47,6 +48,9 @@ function DefaultWikiWireframe() {
 }
 
 const defaultFactoryAppFixture = refundLineCanvasFixture();
+
+/** Stories keep hidden-in-app surfaces visible for design review. */
+const PREVIEW_FLAGS: FactoryPreviewFlags = { addIntakeControl: true };
 
 /**
  * Mounts the org home routes with the factories feature enabled and a fixture
@@ -102,11 +106,13 @@ export function FactoriesHarness({
   );
 
   const withMissions = (
-    <MissionAssignmentProvider>
-      <WorkOrderOverviewMissionSlotContext.Provider value={WorkOrderMissionOverviewRow}>
-        {harness}
-      </WorkOrderOverviewMissionSlotContext.Provider>
-    </MissionAssignmentProvider>
+    <FactoryPreviewFlagsContext.Provider value={PREVIEW_FLAGS}>
+      <MissionAssignmentProvider>
+        <WorkOrderOverviewMissionSlotContext.Provider value={WorkOrderMissionOverviewRow}>
+          {harness}
+        </WorkOrderOverviewMissionSlotContext.Provider>
+      </MissionAssignmentProvider>
+    </FactoryPreviewFlagsContext.Provider>
   );
 
   if (!enableOnboarding) {

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
@@ -201,10 +201,48 @@ describe("LineIntakeDrawer", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("does not show an Add intake control", () => {
+  it("hides the Add intake control by default", () => {
     renderDrawer();
 
     expect(screen.queryByTestId("line-intake-add")).not.toBeInTheDocument();
+  });
+
+  it("opens a searchable picker with six intake templates", async () => {
+    const user = userEvent.setup();
+    renderDrawer({ showAddIntakeControl: true });
+
+    await user.click(screen.getByTestId("line-intake-add"));
+
+    const picker = screen.getByTestId("add-intake-picker");
+    expect(within(picker).getByRole("heading", { name: "Add intake" })).toBeInTheDocument();
+    expect(within(picker).getByTestId("add-intake-search")).toBeInTheDocument();
+    expect(within(picker).getByTestId("add-intake-template-improve-ci-runtime")).toHaveTextContent(
+      "Improve CI runtime",
+    );
+    expect(within(picker).getAllByTestId(/^add-intake-template-/)).toHaveLength(6);
+  });
+
+  it("filters templates from the picker search", async () => {
+    const user = userEvent.setup();
+    renderDrawer({ showAddIntakeControl: true });
+
+    await user.click(screen.getByTestId("line-intake-add"));
+    await user.type(screen.getByTestId("add-intake-search"), "runtime");
+
+    expect(screen.getByTestId("add-intake-template-improve-ci-runtime")).toBeInTheDocument();
+    expect(screen.queryByTestId("add-intake-template-flaky-tests")).not.toBeInTheDocument();
+  });
+
+  it("reports the chosen template to the caller and closes the picker", async () => {
+    const onSelectIntakeTemplate = vi.fn();
+    const user = userEvent.setup();
+    renderDrawer({ showAddIntakeControl: true, onSelectIntakeTemplate });
+
+    await user.click(screen.getByTestId("line-intake-add"));
+    await user.click(screen.getByTestId("add-intake-template-github-issues"));
+
+    expect(onSelectIntakeTemplate).toHaveBeenCalledWith(expect.objectContaining({ id: "github-issues" }));
+    expect(screen.queryByTestId("add-intake-picker")).not.toBeInTheDocument();
   });
 
   it("lets each intake expand and collapse on its own", async () => {

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.stories.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.stories.tsx
@@ -33,15 +33,17 @@ const CONFIGURED_INTAKES = intakeSourcesFromFactoryIntakes([
   },
 ]);
 
+const storyDrawerProps = { showAddIntakeControl: true, onClose: () => undefined } as const;
+
 export const GitHubIssuesExpanded: Story = {
   name: "GitHub issues expanded",
   render: () => (
     <ComponentStoryShell className="flex h-svh bg-slate-300 p-0 dark:bg-slate-900">
       <LineIntakeDrawer
+        {...storyDrawerProps}
         configuredSources={CONFIGURED_INTAKES}
         analyzingTickets={GITHUB_ISSUES_ANALYZING_TICKETS}
         initialIntakeId={GITHUB_ISSUES_INTAKE_ID}
-        onClose={() => undefined}
       />
     </ComponentStoryShell>
   ),
@@ -52,6 +54,7 @@ export const TwoGitHubIntakes: Story = {
   render: () => (
     <ComponentStoryShell className="flex h-svh bg-slate-300 p-0 dark:bg-slate-900">
       <LineIntakeDrawer
+        {...storyDrawerProps}
         configuredSources={intakeSourcesFromFactoryIntakes([
           GITHUB_ISSUES_INTAKE,
           {
@@ -70,7 +73,6 @@ export const TwoGitHubIntakes: Story = {
         ])}
         analyzingTickets={GITHUB_ISSUES_ANALYZING_TICKETS}
         initialIntakeId={GITHUB_ISSUES_INTAKE_ID}
-        onClose={() => undefined}
       />
     </ComponentStoryShell>
   ),
@@ -81,10 +83,10 @@ export const GitHubIssuesSettings: Story = {
   render: () => (
     <ComponentStoryShell className="flex h-svh bg-slate-300 p-0 dark:bg-slate-900">
       <LineIntakeDrawer
+        {...storyDrawerProps}
         configuredSources={CONFIGURED_INTAKES}
         initialIntakeId={GITHUB_ISSUES_INTAKE_ID}
         initialSettingsOpen
-        onClose={() => undefined}
       />
     </ComponentStoryShell>
   ),

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.tsx
@@ -29,9 +29,6 @@ import { useIntakeAutomationRuns } from "./useIntakeAutomationRuns";
 import { useLiveIntakeTickets } from "./useLiveIntakeTickets";
 import { WorkOrderSplitRunPopup } from "./work-order-split-run/WorkOrderSplitRunPopup";
 
-/** Hidden until operators can add intakes from the board. */
-const SHOW_ADD_INTAKE_CONTROL = false;
-
 /**
  * Opens the sole intake of a workspace, one time, when the URL names no
  * intake. Setup opens the drawer this way, and a single collapsed row hides
@@ -152,6 +149,7 @@ export function LineIntakeDrawer({
   editAutomationHrefFor,
   previewSource,
   onSettingsSaved,
+  showAddIntakeControl = false,
 }: LineIntakeDrawerProps) {
   const drawer = useLineIntakeDrawerState({
     initialIntakeId,
@@ -195,6 +193,7 @@ export function LineIntakeDrawer({
           onOpenGear={drawer.openIntakeGear}
           onOpenAnalyzingTicket={drawer.openAnalyzingTicket}
           onOpenPicker={drawer.openPicker}
+          showAddIntakeControl={showAddIntakeControl}
         />
       </aside>
 
@@ -232,6 +231,7 @@ function LineIntakeList({
   onOpenGear,
   onOpenAnalyzingTicket,
   onOpenPicker,
+  showAddIntakeControl,
 }: {
   organizationId?: string;
   factoryId?: string;
@@ -243,6 +243,7 @@ function LineIntakeList({
   onOpenGear: (intake: ConfiguredLineIntakeSource) => void;
   onOpenAnalyzingTicket: (ticket: LineIntakeAnalyzingTicket) => void;
   onOpenPicker: () => void;
+  showAddIntakeControl: boolean;
 }) {
   return (
     <ul className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2 [scrollbar-width:thin]">
@@ -260,7 +261,7 @@ function LineIntakeList({
           onOpenAnalyzingTicket={onOpenAnalyzingTicket}
         />
       ))}
-      {SHOW_ADD_INTAKE_CONTROL ? (
+      {showAddIntakeControl ? (
         <li>
           <button
             type="button"

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -22,6 +22,7 @@ import {
 } from "../__fixtures__/factoryPageResponses";
 import { BOARD_DONE_REJECTED_ORDER, BOARD_IMPLEMENT_FAILED_ORDER } from "../__fixtures__/lineMetricsBoardOrders";
 import { FactoriesLayoutContext } from "../layout/factoriesLayoutContext";
+import { FactoryPreviewFlagsContext, type FactoryPreviewFlags } from "./factoryPreviewFlagsContext";
 import { LINE_LIST_METRICS_BY_ID } from "./lineListMetricsMockData";
 import { REVIEW_CANDIDATE_WORK_ORDERS } from "./onboarding/first-run/reviewCandidates";
 import { LinesPage } from "./LinesPage";
@@ -204,28 +205,31 @@ describe("LinesPage board", () => {
     path = `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`,
     openCreateWorkOrder = vi.fn(),
     factory: FactoriesFactory = REFUND_FACTORY,
+    previewFlags: FactoryPreviewFlags | null = null,
   ) {
     return render(
       <QueryClientProvider client={new QueryClient()}>
         <ThemeProvider>
           <TooltipProvider>
             <MemoryRouter initialEntries={[path]}>
-              <FactoriesLayoutContext.Provider
-                value={{
-                  organizationId: "org-1",
-                  factoryId: factory.id ?? PRIMARY_FACTORY_ID,
-                  factoryKey: factory.key ?? PRIMARY_FACTORY_KEY,
-                  factory,
-                  factories: [factory],
-                  openCreateWorkOrder,
-                }}
-              >
-                <Routes>
-                  <Route path="/org-1/workspaces/:factoryKey/lines/:lineId" element={<LinesPage />} />
-                  <Route path="/org-1/workspaces/:factoryKey/lines/:lineId/edit" element={<div>Edit line</div>} />
-                </Routes>
-                <LocationProbe />
-              </FactoriesLayoutContext.Provider>
+              <FactoryPreviewFlagsContext.Provider value={previewFlags}>
+                <FactoriesLayoutContext.Provider
+                  value={{
+                    organizationId: "org-1",
+                    factoryId: factory.id ?? PRIMARY_FACTORY_ID,
+                    factoryKey: factory.key ?? PRIMARY_FACTORY_KEY,
+                    factory,
+                    factories: [factory],
+                    openCreateWorkOrder,
+                  }}
+                >
+                  <Routes>
+                    <Route path="/org-1/workspaces/:factoryKey/lines/:lineId" element={<LinesPage />} />
+                    <Route path="/org-1/workspaces/:factoryKey/lines/:lineId/edit" element={<div>Edit line</div>} />
+                  </Routes>
+                  <LocationProbe />
+                </FactoriesLayoutContext.Provider>
+              </FactoryPreviewFlagsContext.Provider>
             </MemoryRouter>
           </TooltipProvider>
         </ThemeProvider>
@@ -337,6 +341,29 @@ describe("LinesPage board", () => {
 
     expect(screen.getByTestId(`line-intake-source-${GITHUB_ISSUES_INTAKE_ID}`)).toHaveTextContent("GitHub issues");
     expect(screen.getByTestId("line-intake-source-intake-triage")).toHaveTextContent("Triage issues");
+  });
+
+  it("creates an intake from the picker and opens its canvas", async () => {
+    createFactoryIntakeMutateAsync.mockResolvedValueOnce({ id: "intake-new", canvasId: "canvas-new" });
+    const user = userEvent.setup();
+    renderBoard(
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}?intake=1`,
+      vi.fn(),
+      REFUND_FACTORY,
+      { addIntakeControl: true },
+    );
+
+    await user.click(screen.getByTestId("line-intake-add"));
+    await user.click(screen.getByTestId("add-intake-template-github-issues"));
+
+    await waitFor(() => {
+      expect(createFactoryIntakeMutateAsync).toHaveBeenCalledWith({ source: "SOURCE_GITHUB_ISSUES" });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+        `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/apps/canvas-new`,
+      );
+    });
   });
 
   it("shows a backlog onboarding card on Acme when the backlog is empty", () => {

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -97,6 +97,7 @@ import {
   type ConfiguredLineIntakeSource,
 } from "./lineIntakeModel";
 import { isIntakeSettingsTab } from "./intakeSourceSettingsModel";
+import { useFactoryPreviewFlag } from "./factoryPreviewFlagsContext";
 import { LineIntakeDrawer } from "./LineIntakeDrawer";
 import { LineListCard } from "./LineListCard";
 import { lineBoardColumnLaneClassName, type LineBoardColumnColorId } from "./lineBoardColumnColors";
@@ -146,6 +147,7 @@ export function LinesPage() {
   const { data: factoryIntakes = [] } = useFactoryIntakes(organizationId, factoryId);
   const createIntake = useCreateFactoryIntake(organizationId, factoryId);
   const configuredIntakes = useMemo(() => intakeSourcesFromFactoryIntakes(factoryIntakes), [factoryIntakes]);
+  const showAddIntakeControl = useFactoryPreviewFlag("addIntakeControl");
   const cardActions = useWorkOrderCardActions(organizationId, factoryId);
 
   const canUpdate = canAct("factories", "update");
@@ -212,6 +214,7 @@ export function LinesPage() {
             organizationId={organizationId}
             factoryId={factoryId}
             editAutomationHrefFor={editAutomationHrefFor}
+            showAddIntakeControl={showAddIntakeControl}
             onSelectIntakeTemplate={(template) => {
               if (!isLineIntakeSourceId(template.id)) {
                 showErrorToast("This intake template is not available yet.");

--- a/web_src/src/pages/factories/pages/factoryPreviewFlagsContext.ts
+++ b/web_src/src/pages/factories/pages/factoryPreviewFlagsContext.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Surfaces that are built, but hidden from the app until the flow is ready.
+ * The Storybook harness turns them on so design review keeps the UI.
+ */
+export interface FactoryPreviewFlags {
+  /** Show Add intake in the Intake drawer. */
+  addIntakeControl: boolean;
+}
+
+export const FactoryPreviewFlagsContext = createContext<FactoryPreviewFlags | null>(null);
+
+/** Returns false in the app, where no preview provider is present. */
+export function useFactoryPreviewFlag(flag: keyof FactoryPreviewFlags): boolean {
+  return useContext(FactoryPreviewFlagsContext)?.[flag] ?? false;
+}

--- a/web_src/src/pages/factories/pages/lineIntakeDrawerTypes.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeDrawerTypes.ts
@@ -23,4 +23,6 @@ export interface LineIntakeDrawerProps {
   /** Preview an unconfigured source, used by the picker in Storybook. */
   previewSource?: LineIntakeSource;
   onSettingsSaved?: () => void;
+  /** Show Add intake in Storybook. Hidden on the board until the flow is ready. */
+  showAddIntakeControl?: boolean;
 }


### PR DESCRIPTION
## Summary

The app hides the Add intake control in the Intake drawer (#6919). The picker code stays in the repository, so design review must still see the flow.

This change adds a preview flag context. The Storybook harness turns the flag on for every factory page story. The app mounts no provider, so the control stays hidden there.

The picker tests return and now run through the flag, together with the create-intake test on the line board.

## Test plan

- [ ] Open the story `Factories/Pages/Lines` → "Line board — intake". Confirm Add intake is visible.
- [ ] Click Add intake. Confirm the template picker opens.
- [ ] Open a line board in the app with the Intake drawer. Confirm Add intake is not visible.
- [ ] Run `make check.test.ui` and `make check.build.ui`.


Made with [Cursor](https://cursor.com)