### PR TITLE
fix: Show Start busy state only on the clicked card

### DIFF
--- a/web_src/src/hooks/useWorkOrderCardActions.spec.tsx
+++ b/web_src/src/hooks/useWorkOrderCardActions.spec.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useDispatchWorkOrder, useUpdateWorkOrderAssignees } from "./useFactoryData";
+import { useWorkOrderCardActions } from "./useWorkOrderCardActions";
+
+vi.mock("./useFactoryData", () => ({
+  useDispatchWorkOrder: vi.fn(),
+  useUpdateWorkOrderAssignees: vi.fn(),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}));
+
+type DispatchMutation = ReturnType<typeof useDispatchWorkOrder>;
+
+function mockMutations() {
+  let resolveDispatch: (() => void) | undefined;
+  const mutateAsync = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      }),
+  );
+  vi.mocked(useDispatchWorkOrder).mockReturnValue({ mutateAsync } as unknown as DispatchMutation);
+  vi.mocked(useUpdateWorkOrderAssignees).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdateWorkOrderAssignees>);
+  return { finishDispatch: () => resolveDispatch?.() };
+}
+
+describe("useWorkOrderCardActions", () => {
+  it("reports only the work order that dispatches as in flight", async () => {
+    const { finishDispatch } = mockMutations();
+    const { result } = renderHook(() => useWorkOrderCardActions("org-1", "factory-1"));
+
+    let dispatched: Promise<void> | undefined;
+    act(() => {
+      dispatched = result.current.onDispatch("wo-1", { lineName: "hotfix" });
+    });
+
+    await waitFor(() => expect(result.current.dispatchingOrderIds.has("wo-1")).toBe(true));
+    expect(result.current.dispatchingOrderIds.has("wo-2")).toBe(false);
+
+    await act(async () => {
+      finishDispatch();
+      await dispatched;
+    });
+
+    expect(result.current.dispatchingOrderIds.has("wo-1")).toBe(false);
+  });
+
+  it("clears the in-flight work order when the dispatch fails", async () => {
+    mockMutations();
+    vi.mocked(useDispatchWorkOrder).mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(new Error("nope")),
+    } as unknown as DispatchMutation);
+    const { result } = renderHook(() => useWorkOrderCardActions("org-1", "factory-1"));
+
+    await act(async () => {
+      await result.current.onDispatch("wo-1", { lineName: "hotfix" });
+    });
+
+    expect(result.current.dispatchingOrderIds.has("wo-1")).toBe(false);
+  });
+});

--- a/web_src/src/hooks/useWorkOrderCardActions.ts
+++ b/web_src/src/hooks/useWorkOrderCardActions.ts
@@ -1,19 +1,28 @@
 import { useDispatchWorkOrder, useUpdateWorkOrderAssignees } from "@/hooks/useFactoryData";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
+
+const NO_ORDERS: ReadonlySet<string> = new Set();
 
 /** Shared mutation state and callbacks for every surface that renders work order cards. */
 export function useWorkOrderCardActions(organizationId: string, factoryId: string) {
   const dispatchWorkOrder = useDispatchWorkOrder(organizationId, factoryId);
   const updateAssignees = useUpdateWorkOrderAssignees(organizationId, factoryId);
+  // The mutation is shared by every card on the page, so its pending flag
+  // cannot say which card the user clicked. Track the work orders in flight
+  // instead, so only their controls show a busy state.
+  const [dispatchingOrderIds, setDispatchingOrderIds] = useState<ReadonlySet<string>>(NO_ORDERS);
 
   const onDispatch = useCallback(
     async (orderId: string, input: { lineName: string }) => {
+      setDispatchingOrderIds((current) => withOrderId(current, orderId));
       try {
         await dispatchWorkOrder.mutateAsync({ orderId, lineName: input.lineName });
         showSuccessToast(`Dispatched to ${input.lineName}.`);
       } catch {
         showErrorToast("Failed to dispatch work order.");
+      } finally {
+        setDispatchingOrderIds((current) => withoutOrderId(current, orderId));
       }
     },
     [dispatchWorkOrder],
@@ -32,9 +41,24 @@ export function useWorkOrderCardActions(organizationId: string, factoryId: strin
   );
 
   return {
-    isDispatching: dispatchWorkOrder.isPending,
+    dispatchingOrderIds,
     isAssigneesSaving: updateAssignees.isPending,
     onDispatch,
     onAssigneesSave,
   };
+}
+
+function withOrderId(orderIds: ReadonlySet<string>, orderId: string): ReadonlySet<string> {
+  const next = new Set(orderIds);
+  next.add(orderId);
+  return next;
+}
+
+function withoutOrderId(orderIds: ReadonlySet<string>, orderId: string): ReadonlySet<string> {
+  if (!orderIds.has(orderId)) {
+    return orderIds;
+  }
+  const next = new Set(orderIds);
+  next.delete(orderId);
+  return next;
 }

--- a/web_src/src/pages/factories/pages/LinesPage.doneColumn.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.doneColumn.spec.tsx
@@ -42,7 +42,7 @@ vi.mock("@/hooks/useFactoryIntakeData", () => ({
 
 vi.mock("@/hooks/useWorkOrderCardActions", () => ({
   useWorkOrderCardActions: () => ({
-    isDispatching: false,
+    dispatchingOrderIds: new Set<string>(),
     isAssigneesSaving: false,
     onDispatch: vi.fn(),
     onAssigneesSave: vi.fn(),

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -77,7 +77,7 @@ vi.mock("@/hooks/useFactoryIntakeData", () => ({
 
 vi.mock("@/hooks/useWorkOrderCardActions", () => ({
   useWorkOrderCardActions: () => ({
-    isDispatching: false,
+    dispatchingOrderIds: new Set<string>(),
     isAssigneesSaving: false,
     onDispatch: vi.fn(),
     onAssigneesSave: vi.fn(),

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -477,7 +477,7 @@ function LineDetail({
           peekOrder={peekOrder}
           canDispatch={workOrderCardContext.canDispatch}
           canUpdate={workOrderCardContext.canAssign}
-          isDispatching={workOrderCardContext.isDispatching}
+          isDispatching={workOrderCardContext.dispatchingOrderIds.has(peekOrderId)}
           onDispatch={workOrderCardContext.onDispatch}
           onClose={() => setPeekOrderId(null)}
         />

--- a/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
+++ b/web_src/src/pages/factories/pages/automationsPageParts.spec.tsx
@@ -147,7 +147,7 @@ describe("AutomationDetail tabs", () => {
     factoryLines: [],
     canDispatch: false,
     canAssign: false,
-    isDispatching: false,
+    dispatchingOrderIds: new Set<string>(),
     isAssigneesSaving: false,
     onDispatch: vi.fn().mockResolvedValue(undefined),
     onAssigneesSave: vi.fn().mockResolvedValue(undefined),

--- a/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersLoadedView.tsx
+++ b/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersLoadedView.tsx
@@ -33,7 +33,8 @@ export interface MissionsWorkOrdersLoadedViewProps {
   canDispatch: boolean;
   canAssign: boolean;
   permissionsLoading: boolean;
-  isDispatching: boolean;
+  /** Work orders with a dispatch in flight. Only their controls show a busy state. */
+  dispatchingOrderIds: ReadonlySet<string>;
   isAssigneesSaving: boolean;
   onDispatch: (orderId: string, input: { lineName: string }) => Promise<void>;
   onAssigneesSave: (orderId: string, assigneeIds: string[]) => Promise<void>;
@@ -82,7 +83,7 @@ export function MissionsWorkOrdersLoadedView(props: MissionsWorkOrdersLoadedView
       factoryLines: props.factoryLines,
       canDispatch: props.canDispatch,
       canAssign: props.canAssign,
-      isDispatching: props.isDispatching,
+      dispatchingOrderIds: props.dispatchingOrderIds,
       isAssigneesSaving: props.isAssigneesSaving,
       onDispatch: props.onDispatch,
       onAssigneesSave: props.onAssigneesSave,

--- a/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersPage.tsx
+++ b/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersPage.tsx
@@ -1,7 +1,7 @@
 import { usePermissions } from "@/contexts/usePermissions";
-import { useDispatchWorkOrder, useFactoryWorkOrders, useUpdateWorkOrderAssignees } from "@/hooks/useFactoryData";
+import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import { useMe } from "@/hooks/useMe";
-import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
@@ -25,31 +25,12 @@ export function MissionsWorkOrdersPage() {
     refetch,
   } = useFactoryWorkOrders(organizationId, factoryId);
 
-  const dispatchWorkOrder = useDispatchWorkOrder(organizationId, factoryId);
-  const updateAssignees = useUpdateWorkOrderAssignees(organizationId, factoryId);
+  const cardActions = useWorkOrderCardActions(organizationId, factoryId);
 
   const canCreate = canAct("work_orders", "create");
   const canDispatch = canAct("work_orders", "update");
   const canAssign = canAct("work_orders", "update");
   const isOrdersLoading = workOrdersLoading || (workOrdersFetching && workOrders.length === 0);
-
-  const handleDispatch = async (orderId: string, input: { lineName: string }) => {
-    try {
-      await dispatchWorkOrder.mutateAsync({ orderId, lineName: input.lineName });
-      showSuccessToast(`Dispatched to ${input.lineName}.`);
-    } catch {
-      showErrorToast("Failed to dispatch work order.");
-    }
-  };
-
-  const handleAssigneesSave = async (orderId: string, assigneeIds: string[]) => {
-    try {
-      await updateAssignees.mutateAsync({ orderId, assigneeIds });
-      showSuccessToast("Owner updated.");
-    } catch {
-      showErrorToast("Failed to update the owner.");
-    }
-  };
 
   if (workOrdersError) {
     return (
@@ -87,10 +68,7 @@ export function MissionsWorkOrdersPage() {
       canDispatch={canDispatch}
       canAssign={canAssign}
       permissionsLoading={permissionsLoading}
-      isDispatching={dispatchWorkOrder.isPending}
-      isAssigneesSaving={updateAssignees.isPending}
-      onDispatch={handleDispatch}
-      onAssigneesSave={handleAssigneesSave}
+      {...cardActions}
     />
   );
 }

--- a/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
@@ -24,7 +24,8 @@ export interface WorkOrderCardContext extends WorkOrderRowCallbacks {
   preferredLineName?: string;
   canDispatch: boolean;
   canAssign: boolean;
-  isDispatching: boolean;
+  /** Work orders with a dispatch in flight. Only their controls show a busy state. */
+  dispatchingOrderIds: ReadonlySet<string>;
   isAssigneesSaving: boolean;
 }
 
@@ -57,7 +58,7 @@ export function WorkOrderCard({
   factoryLines,
   preferredLineName,
   canDispatch,
-  isDispatching,
+  dispatchingOrderIds,
   onDispatch,
   href,
   onOpen,
@@ -125,7 +126,7 @@ export function WorkOrderCard({
                   lines={factoryLines}
                   preferredLineName={preferredLineName}
                   canDispatch={canDispatch}
-                  isDispatching={isDispatching}
+                  isDispatching={dispatchingOrderIds.has(entry.id)}
                   onDispatch={onDispatch}
                 />
               ) : null}

--- a/web_src/src/pages/factories/workOrders/WorkOrderCardStartButton.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderCardStartButton.spec.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import type { FactoriesFactory, FactoriesWorkOrder } from "@/api-client";
+
+import { buildWorkOrderListEntry } from "../lib/workOrderListModel";
+import { WorkOrdersBoardView } from "./WorkOrdersBoardView";
+
+const factory: FactoriesFactory = { id: "factory-1", name: "Refunds", key: "RF" };
+
+function draft(id: string, title: string) {
+  return buildWorkOrderListEntry(
+    {
+      id,
+      number: id,
+      title,
+      state: "STATE_DRAFT",
+      createdAt: "2024-06-01T00:00:00Z",
+      updatedAt: "2024-06-02T00:00:00Z",
+      lineDispatches: [],
+      assignees: [],
+    } satisfies FactoriesWorkOrder,
+    factory,
+  );
+}
+
+function renderBoard(dispatchingOrderIds: ReadonlySet<string>) {
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <WorkOrdersBoardView
+          entries={[draft("wo-1", "Reconcile refund batch"), draft("wo-2", "Handle duplicate charges")]}
+          organizationId="org-1"
+          factoryKey="RF"
+          factoryLines={[{ id: "line-a", name: "hotfix" }]}
+          canDispatch
+          canAssign
+          dispatchingOrderIds={dispatchingOrderIds}
+          isAssigneesSaving={false}
+          onDispatch={vi.fn().mockResolvedValue(undefined)}
+          onAssigneesSave={vi.fn().mockResolvedValue(undefined)}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Start button on draft cards", () => {
+  it("shows the busy state only on the work order that dispatches", () => {
+    renderBoard(new Set(["wo-1"]));
+
+    const starting = screen.getByTestId("work-order-card-start-wo-1");
+    expect(starting).toHaveTextContent("Starting...");
+    expect(starting).toBeDisabled();
+
+    const idle = screen.getByTestId("work-order-card-start-wo-2");
+    expect(idle).toHaveTextContent("Start");
+    expect(idle).toBeEnabled();
+  });
+
+  it("leaves every card ready when no dispatch runs", () => {
+    renderBoard(new Set());
+
+    for (const id of ["wo-1", "wo-2"]) {
+      const start = screen.getByTestId(`work-order-card-start-${id}`);
+      expect(start).toHaveTextContent("Start");
+      expect(start).toBeEnabled();
+    }
+  });
+});

--- a/web_src/src/pages/factories/workOrders/WorkOrdersCardClickHandler.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersCardClickHandler.spec.tsx
@@ -100,7 +100,7 @@ function renderView(
           preferredLineName={extras.preferredLineName}
           canDispatch={true}
           canAssign={true}
-          isDispatching={false}
+          dispatchingOrderIds={new Set()}
           isAssigneesSaving={false}
           onDispatch={onDispatch}
           onAssigneesSave={onAssigneesSave}
@@ -322,7 +322,7 @@ describe("WorkOrderCard scores", () => {
             factoryLines={[{ id: "line-a", name: "hotfix" }]}
             canDispatch
             canAssign
-            isDispatching={false}
+            dispatchingOrderIds={new Set()}
             isAssigneesSaving={false}
             onDispatch={vi.fn()}
             onAssigneesSave={vi.fn()}
@@ -369,7 +369,7 @@ describe("WorkOrderCard scores", () => {
             factoryLines={[{ id: "line-a", name: "hotfix" }]}
             canDispatch
             canAssign
-            isDispatching={false}
+            dispatchingOrderIds={new Set()}
             isAssigneesSaving={false}
             onDispatch={vi.fn()}
             onAssigneesSave={vi.fn()}

--- a/web_src/src/pages/factories/workOrders/WorkOrdersListView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersListView.tsx
@@ -15,7 +15,8 @@ interface WorkOrdersListViewProps {
   factoryLines: FactoriesFactoryLine[];
   canDispatch: boolean;
   canAssign: boolean;
-  isDispatching: boolean;
+  /** Work orders with a dispatch in flight. Only their controls show a busy state. */
+  dispatchingOrderIds: ReadonlySet<string>;
   isAssigneesSaving: boolean;
   onDispatch: (orderId: string, input: { lineName: string }) => Promise<void>;
   onAssigneesSave: (orderId: string, assigneeIds: string[]) => Promise<void>;
@@ -63,7 +64,7 @@ function ListRow({
   factoryLines,
   canDispatch,
   canAssign,
-  isDispatching,
+  dispatchingOrderIds,
   isAssigneesSaving,
   onDispatch,
   onAssigneesSave,
@@ -115,7 +116,7 @@ function ListRow({
           entry={entry}
           lines={factoryLines}
           canDispatch={canDispatch}
-          isDispatching={isDispatching}
+          isDispatching={dispatchingOrderIds.has(entry.id)}
           onDispatch={onDispatch}
           visible={entry.isDispatchable}
         />

--- a/web_src/src/pages/factories/workOrders/WorkOrdersLoadedView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersLoadedView.tsx
@@ -33,7 +33,8 @@ interface WorkOrdersLoadedViewProps {
   canDispatch: boolean;
   canAssign: boolean;
   permissionsLoading: boolean;
-  isDispatching: boolean;
+  /** Work orders with a dispatch in flight. Only their controls show a busy state. */
+  dispatchingOrderIds: ReadonlySet<string>;
   isAssigneesSaving: boolean;
   onDispatch: (orderId: string, input: { lineName: string }) => Promise<void>;
   onAssigneesSave: (orderId: string, assigneeIds: string[]) => Promise<void>;
@@ -88,7 +89,7 @@ export function WorkOrdersLoadedView(props: WorkOrdersLoadedViewProps) {
       factoryLines: props.factoryLines,
       canDispatch: props.canDispatch,
       canAssign: props.canAssign,
-      isDispatching: props.isDispatching,
+      dispatchingOrderIds: props.dispatchingOrderIds,
       isAssigneesSaving: props.isAssigneesSaving,
       onDispatch: props.onDispatch,
       onAssigneesSave: props.onAssigneesSave,

--- a/web_src/src/pages/factories/workOrders/WorkOrdersTableView.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersTableView.spec.tsx
@@ -72,7 +72,7 @@ function renderTable() {
           factoryLines={[]}
           canDispatch={true}
           canAssign={true}
-          isDispatching={false}
+          dispatchingOrderIds={new Set()}
           isAssigneesSaving={false}
           onDispatch={vi.fn().mockResolvedValue(undefined)}
           onAssigneesSave={vi.fn().mockResolvedValue(undefined)}

--- a/web_src/src/pages/factories/workOrders/WorkOrdersTableView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersTableView.tsx
@@ -16,7 +16,8 @@ interface WorkOrdersTableViewProps {
   factoryLines: FactoriesFactoryLine[];
   canDispatch: boolean;
   canAssign: boolean;
-  isDispatching: boolean;
+  /** Work orders with a dispatch in flight. Only their controls show a busy state. */
+  dispatchingOrderIds: ReadonlySet<string>;
   isAssigneesSaving: boolean;
   onDispatch: (orderId: string, input: { lineName: string }) => Promise<void>;
   onAssigneesSave: (orderId: string, assigneeIds: string[]) => Promise<void>;
@@ -75,7 +76,7 @@ function TableRow({
   factoryLines,
   canDispatch,
   canAssign,
-  isDispatching,
+  dispatchingOrderIds,
   isAssigneesSaving,
   onDispatch,
   onAssigneesSave,
@@ -128,7 +129,7 @@ function TableRow({
           entry={entry}
           lines={factoryLines}
           canDispatch={canDispatch}
-          isDispatching={isDispatching}
+          isDispatching={dispatchingOrderIds.has(entry.id)}
           onDispatch={onDispatch}
           visible={entry.isDispatchable}
         />


### PR DESCRIPTION
## Summary

On a work order board, a click on Start put every Start button into the
busy state. Only the card that the user clicked must react.

Each Start button read one page-level flag: the pending state of the
dispatch mutation, which all cards on the page share. A mutation cannot
tell which card the user clicked.

`useWorkOrderCardActions` now keeps the set of work orders that have a
dispatch in flight. Each card compares its own id against that set. A
set, and not a single id, is necessary because sibling cards stay
clickable, so two dispatches can overlap. The id is removed in a
`finally` block, so a failed dispatch also releases the button.

The Missions work orders page had a copy of the dispatch and assignee
handlers with the same defect. It now uses the shared hook.

## Test plan

- [ ] Open a factory Lines board that has more than one draft work order.
- [ ] Click Start on one card. Only that card shows "Starting..." and is
      disabled. The other cards stay ready.
- [ ] Do the same on the Work Orders list layout and table layout.
- [ ] Make the dispatch fail. The card shows the error toast and the
      Start button becomes ready again.
- [ ] Run `make check.lint.ui`.
- [ ] Run the UI tests for `src/pages/factories` and
      `src/hooks/useWorkOrderCardActions.spec.tsx`.

Made with [Cursor](https://cursor.com)