### PR TITLE
fix: Decide CircleCI result from every workflow

### DIFF
--- a/pkg/integrations/circleci/run_pipeline.go
+++ b/pkg/integrations/circleci/run_pipeline.go
@@ -459,39 +459,21 @@ func (t *RunPipeline) poll(ctx core.ActionHookContext) error {
 		return err
 	}
 
-	pipeline, err := client.GetPipeline(metadata.Pipeline.ID)
-	if err != nil {
-		return err
-	}
-
-	if pipeline.State == "errored" {
-		payload := map[string]any{"pipeline": pipeline}
-		err = ctx.ExecutionState.Emit(FailedOutputChannel, PayloadType, []any{payload})
-		if err != nil {
-			return fmt.Errorf("failed to emit output: %w", err)
-		}
-
-		return nil
-	}
-
-	workflows, err := client.GetPipelineWorkflows(metadata.Pipeline.ID)
+	// A pipeline can run more than one workflow. The result of the pipeline is
+	// only known when every workflow reached a final status, and the pipeline
+	// failed if any one of them failed.
+	status, err := client.CheckPipelineStatus(metadata.Pipeline.ID)
 	if err != nil {
 		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, PollInterval)
 	}
 
-	if len(workflows) == 0 {
-		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, PollInterval)
-	}
-
-	firstWorkflow := workflows[0]
-
-	if t.isRunning(firstWorkflow.Status) {
+	if !status.AllDone {
 		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, PollInterval)
 	}
 
 	payload := map[string]any{"pipeline": metadata.Pipeline}
 	channel := SuccessOutputChannel
-	if t.isFailed(firstWorkflow.Status) {
+	if status.AnyFailed {
 		channel = FailedOutputChannel
 	}
 
@@ -533,8 +515,4 @@ func (t *RunPipeline) Cleanup(ctx core.SetupContext) error {
 
 func (t *RunPipeline) isFailed(workflowStatus string) bool {
 	return workflowStatus == WorkflowStatusFailed || workflowStatus == WorkflowStatusCanceled || workflowStatus == "error" || workflowStatus == "failing" || workflowStatus == "unauthorized"
-}
-
-func (t *RunPipeline) isRunning(workflowStatus string) bool {
-	return workflowStatus == "running" || workflowStatus == "on_hold" || workflowStatus == "not_run"
 }

--- a/pkg/integrations/circleci/run_pipeline_test.go
+++ b/pkg/integrations/circleci/run_pipeline_test.go
@@ -1,9 +1,15 @@
 package circleci
 
 import (
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
 func Test__RunPipeline__buildParameters(t *testing.T) {
@@ -19,5 +25,100 @@ func Test__RunPipeline__buildParameters(t *testing.T) {
 		assert.Equal(t, "production", result["env"])
 		assert.Equal(t, "1.0.0", result["version"])
 		assert.Len(t, result, 2)
+	})
+}
+
+func pollContext(t *testing.T, workflows string) (core.ActionHookContext, *contexts.ExecutionStateContext, *contexts.RequestContext) {
+	t.Helper()
+
+	// The pipeline lookup and the workflow listing are both served the same
+	// body, so the fake does not depend on the order the two are called in.
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(workflows)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(workflows)),
+			},
+		},
+	}
+
+	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	requests := &contexts.RequestContext{}
+
+	return core.ActionHookContext{
+		Name: "poll",
+		HTTP: httpContext,
+		Metadata: &contexts.MetadataContext{
+			Metadata: map[string]any{
+				"pipeline": map[string]any{"id": "pipe-123", "number": 7},
+			},
+		},
+		ExecutionState: executionState,
+		Requests:       requests,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "test-token"},
+		},
+	}, executionState, requests
+}
+
+func Test__RunPipeline__poll(t *testing.T) {
+	component := &RunPipeline{}
+
+	t.Run("all workflows successful -> success channel", func(t *testing.T) {
+		ctx, executionState, _ := pollContext(t, `{"items":[
+			{"id":"wf-1","name":"build","status":"success"},
+			{"id":"wf-2","name":"deploy","status":"success"}
+		]}`)
+
+		require.NoError(t, component.poll(ctx))
+
+		assert.True(t, executionState.Finished)
+		assert.Equal(t, SuccessOutputChannel, executionState.Channel)
+	})
+
+	t.Run("a later workflow is still running -> keeps polling", func(t *testing.T) {
+		ctx, executionState, requests := pollContext(t, `{"items":[
+			{"id":"wf-1","name":"build","status":"success"},
+			{"id":"wf-2","name":"deploy","status":"running"}
+		]}`)
+
+		require.NoError(t, component.poll(ctx))
+
+		assert.False(t, executionState.Finished, "must not emit while a workflow is still running")
+		assert.Equal(t, "poll", requests.Action)
+	})
+
+	t.Run("a later workflow failed -> failed channel", func(t *testing.T) {
+		ctx, executionState, _ := pollContext(t, `{"items":[
+			{"id":"wf-1","name":"build","status":"success"},
+			{"id":"wf-2","name":"deploy","status":"failed"}
+		]}`)
+
+		require.NoError(t, component.poll(ctx))
+
+		assert.True(t, executionState.Finished)
+		assert.Equal(t, FailedOutputChannel, executionState.Channel)
+	})
+
+	t.Run("no workflows and the pipeline errored -> failed channel", func(t *testing.T) {
+		ctx, executionState, _ := pollContext(t, `{"items":[],"state":"errored"}`)
+
+		require.NoError(t, component.poll(ctx))
+
+		assert.True(t, executionState.Finished)
+		assert.Equal(t, FailedOutputChannel, executionState.Channel)
+	})
+
+	t.Run("no workflows started yet -> keeps polling", func(t *testing.T) {
+		ctx, executionState, requests := pollContext(t, `{"items":[],"state":"created"}`)
+
+		require.NoError(t, component.poll(ctx))
+
+		assert.False(t, executionState.Finished)
+		assert.Equal(t, "poll", requests.Action)
 	})
 }


### PR DESCRIPTION
## Summary

A CircleCI pipeline can run more than one workflow. The `circleci.runPipeline`
poll handler decided the result of the whole pipeline from the first workflow
only. When the first workflow passed and a later workflow failed, the component
emitted the result on the `success` channel. Steps that wait for success then ran
after a failed pipeline, and the `failed` channel never fired. The handler also
emitted a final result while other workflows were still running.

The package already contains `Client.CheckPipelineStatus`. It aggregates the
status of all workflows and covers the empty-workflow and errored-pipeline cases,
but no code called it. The poll handler now uses it, so the component waits until
all workflows reach a final status and reports a failure if any workflow failed.

The change also removes a pipeline request that each poll no longer needs, and the
`isRunning` helper, which has no caller after the change.

## Behavior change to note

For an errored pipeline, the failed payload now carries `metadata.Pipeline`
instead of the freshly fetched pipeline object. This matches the webhook path and
the normal completion path, so all completion paths now emit the same payload
shape.

The webhook path at `run_pipeline.go:405` emits `failed` as soon as one workflow
fails, without waiting for the other workflows. That behavior is out of scope
here and stays unchanged.

## Test plan

- [x] Two new poll tests fail on `main` and pass with this change: a later
      workflow that failed selects the `failed` channel, and a later workflow that
      is still running schedules another poll.
- [x] Three further poll tests pass both before and after the change: all
      workflows successful, an errored pipeline with no workflows, and no
      workflows started yet. These confirm the change does not alter the other
      paths.
- [x] `go test ./pkg/integrations/circleci/` passes.
- [x] `gofmt -l pkg/integrations/circleci/` reports no files.
- [x] `go vet ./pkg/integrations/circleci/` is clean.

Closes #6925
