### PR TITLE
feat: Show Claude Code steps on factory nodes

### DIFF
--- a/web_src/src/lib/agentRunnerSteps.spec.ts
+++ b/web_src/src/lib/agentRunnerSteps.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { agentRunnerStepTitles } from "./agentRunnerSteps";
+
+describe("agentRunnerStepTitles", () => {
+  it("returns each configured step title in order", () => {
+    expect(
+      agentRunnerStepTitles({
+        steps: [
+          { name: "Clone repo", type: "bash" },
+          { name: "Write implementation plan", type: "prompt" },
+          { name: "Use plan as output", type: "bash" },
+        ],
+      }),
+    ).toEqual(["Clone repo", "Write implementation plan", "Use plan as output"]);
+  });
+
+  it("ignores malformed and blank steps", () => {
+    expect(
+      agentRunnerStepTitles({
+        steps: [{ name: "Clone repo" }, null, { name: " " }, { title: "Wrong field" }],
+      }),
+    ).toEqual(["Clone repo"]);
+    expect(agentRunnerStepTitles(undefined)).toEqual([]);
+  });
+});

--- a/web_src/src/lib/agentRunnerSteps.ts
+++ b/web_src/src/lib/agentRunnerSteps.ts
@@ -1,0 +1,18 @@
+/** Titles of configured bash and prompt steps, in execution order. */
+export function agentRunnerStepTitles(configuration: unknown): string[] {
+  if (!configuration || typeof configuration !== "object") {
+    return [];
+  }
+  const steps = (configuration as Record<string, unknown>).steps;
+  if (!Array.isArray(steps)) {
+    return [];
+  }
+
+  return steps.flatMap((step) => {
+    if (!step || typeof step !== "object") {
+      return [];
+    }
+    const name = (step as Record<string, unknown>).name;
+    return typeof name === "string" && name.trim() ? [name.trim()] : [];
+  });
+}

--- a/web_src/src/lib/factoryCanvasChrome.ts
+++ b/web_src/src/lib/factoryCanvasChrome.ts
@@ -91,6 +91,19 @@ export const FACTORY_HANDLE_STYLE = {
 /** Keep FactoryNodeCard, append ghost, placement gap, and ELK estimates aligned. */
 export const FACTORY_NODE_CARD_WIDTH = 280;
 export const FACTORY_NODE_CARD_HEIGHT = 104;
+export const FACTORY_NODE_STEP_CARD_WIDTH = 320;
+const FACTORY_NODE_STEP_ROW_HEIGHT = 28;
+const FACTORY_NODE_STEP_LIST_PADDING = 20;
+
+export function factoryNodeCardSize(stepCount = 0): { width: number; height: number } {
+  if (stepCount <= 0) {
+    return { width: FACTORY_NODE_CARD_WIDTH, height: FACTORY_NODE_CARD_HEIGHT };
+  }
+  return {
+    width: FACTORY_NODE_STEP_CARD_WIDTH,
+    height: FACTORY_NODE_CARD_HEIGHT + FACTORY_NODE_STEP_LIST_PADDING + stepCount * FACTORY_NODE_STEP_ROW_HEIGHT,
+  };
+}
 /** Vertical gap below a factory card in persisted ELK layout, live, and run. */
 export const FACTORY_NODE_VERTICAL_GAP = 64;
 /**

--- a/web_src/src/lib/layout/elk.spec.ts
+++ b/web_src/src/lib/layout/elk.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ActionsAction, CanvasesCanvas, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
-import { FACTORY_NODE_CARD_WIDTH } from "@/lib/factoryCanvasChrome";
+import { FACTORY_NODE_CARD_WIDTH, factoryNodeCardSize } from "@/lib/factoryCanvasChrome";
 import { ElkLayoutEngine } from "@/lib/layout";
 import { resolveForwardLayoutEdges } from "./layoutGraph";
 
@@ -22,6 +22,22 @@ type ElkLayoutEngineInternals = {
 };
 
 describe("ElkLayoutEngine", () => {
+  it("reserves room for Claude Code steps in vertical layouts", () => {
+    const autoLayout = new ElkLayoutEngine();
+    const node: ComponentsNode = {
+      id: "agent",
+      component: "runnerClaudeCode",
+      configuration: {
+        steps: [{ name: "Clone Repo" }, { name: "Write Implementation Plan" }, { name: "Use plan as output" }],
+      },
+    };
+
+    expect(autoLayout.estimateNodeSize(node, "vertical")).toEqual(factoryNodeCardSize(3));
+    expect(autoLayout.estimateNodeSize({ id: "bash", component: "runnerBash" }, "vertical")).toEqual(
+      factoryNodeCardSize(),
+    );
+  });
+
   it("does not crash when an edge channel is missing from outputChannelsByNodeId", async () => {
     const workflow: CanvasesCanvas = {
       metadata: {

--- a/web_src/src/lib/layout/elk.ts
+++ b/web_src/src/lib/layout/elk.ts
@@ -1,10 +1,7 @@
 import type { CanvasesCanvas, ActionsAction, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
 import type { CanvasFlowDirection } from "@/lib/canvasFlowDirection";
-import {
-  FACTORY_NODE_CARD_HEIGHT,
-  FACTORY_NODE_CARD_WIDTH,
-  FACTORY_NODE_VERTICAL_GAP,
-} from "@/lib/factoryCanvasChrome";
+import { agentRunnerStepTitles } from "@/lib/agentRunnerSteps";
+import { FACTORY_NODE_VERTICAL_GAP, factoryNodeCardSize } from "@/lib/factoryCanvasChrome";
 import ELK from "elkjs/lib/elk.bundled.js";
 import type { LayoutEngine, LayoutEngineApplyOptions } from "./types";
 import { appendUniqueChannels, resolveForwardLayoutEdges } from "./layoutGraph";
@@ -46,10 +43,8 @@ export class ElkLayoutEngine implements LayoutEngine {
     }
 
     if (direction === "vertical") {
-      return {
-        width: FACTORY_NODE_CARD_WIDTH,
-        height: FACTORY_NODE_CARD_HEIGHT,
-      };
+      const stepCount = node.component === "runnerClaudeCode" ? agentRunnerStepTitles(node.configuration).length : 0;
+      return factoryNodeCardSize(stepCount);
     }
 
     return {

--- a/web_src/src/pages/app/mappers/index.spec.ts
+++ b/web_src/src/pages/app/mappers/index.spec.ts
@@ -137,7 +137,11 @@ describe("getExecutionDetails", () => {
         isCollapsed: false,
         configuration: {
           machineType: "e1-large-amd64",
-          prompt: "Fix the failing tests",
+          steps: [
+            { name: "Clone repo", type: "bash" },
+            { name: "Write implementation plan", type: "prompt" },
+            { name: "Use plan as output", type: "bash" },
+          ],
         },
         metadata: {},
       },
@@ -156,6 +160,7 @@ describe("getExecutionDetails", () => {
     });
 
     expect(props.customField).toBeDefined();
+    expect(props.factoryBody).toBeDefined();
     expect(getStateMap("runnerClaudeCode")).toBe(RUNNER_STATE_REGISTRY.stateMap);
   });
 

--- a/web_src/src/pages/app/mappers/index.ts
+++ b/web_src/src/pages/app/mappers/index.ts
@@ -270,7 +270,7 @@ import {
 import { filterMapper, FILTER_STATE_REGISTRY } from "./filter";
 import { forEachMapper, FOR_EACH_STATE_REGISTRY } from "./forEach";
 import { sshMapper, SSH_STATE_REGISTRY } from "./ssh";
-import { runnerMapper, RUNNER_STATE_REGISTRY } from "./runner";
+import { claudeCodeMapper, runnerMapper, RUNNER_STATE_REGISTRY } from "./runner";
 import { waitCustomFieldRenderer, waitMapper, WAIT_STATE_REGISTRY } from "./wait";
 import { approvalMapper, APPROVAL_STATE_REGISTRY } from "./approval";
 import { loopMapper, LOOP_STATE_REGISTRY } from "./loop";
@@ -313,7 +313,7 @@ const componentBaseMappers: Record<string, ComponentBaseMapper> = {
   runnerJS: runnerMapper,
   runnerBash: runnerMapper,
   runnerPython: runnerMapper,
-  runnerClaudeCode: runnerMapper,
+  runnerClaudeCode: claudeCodeMapper,
   runnerCodex: runnerMapper,
   runnerOpenRouter: runnerMapper,
   timeGate: timeGateMapper,

--- a/web_src/src/pages/app/mappers/runner.tsx
+++ b/web_src/src/pages/app/mappers/runner.tsx
@@ -1,8 +1,10 @@
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { agentRunnerStepTitles } from "@/lib/agentRunnerSteps";
 import { getColorClass } from "@/lib/colors";
 import { RunnerLiveLogDialog } from "@/ui/CanvasPage/RunnerLiveLogDialog";
 import type { ComponentBaseProps, EventSection, EventState, EventStateMap } from "@/ui/componentBase";
 import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import { FactoryNodeStepList } from "@/ui/factoryNodeChrome";
 import React from "react";
 import { getTriggerRenderer } from ".";
 
@@ -212,6 +214,18 @@ export const runnerMapper: ComponentBaseMapper = {
     details["Status"] = stringOrDash(payload.status);
     details["Exit code"] = stringOrDash(payload.exit_code);
     return details;
+  },
+};
+
+export const claudeCodeMapper: ComponentBaseMapper = {
+  ...runnerMapper,
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const props = runnerMapper.props(context);
+    const steps = agentRunnerStepTitles(context.node.configuration);
+    return {
+      ...props,
+      factoryBody: steps.length > 0 ? <FactoryNodeStepList steps={steps} /> : undefined,
+    };
   },
 };
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
@@ -14,6 +14,7 @@ import { FACTORY_HANDLE_OUTSET_PX } from "@/ui/CanvasPage/Block/handleStyle";
 import { CustomEdge } from "@/ui/CanvasPage/CustomEdge";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { FactoryNodeCardShell } from "@/ui/factoryNodeChrome/FactoryNodeCardShell";
+import { FactoryNodeStepList } from "@/ui/factoryNodeChrome/FactoryNodeStepList";
 
 import { COMPACT_CANVAS_FIT_SETTLE_MS, compactCanvasFitKey, shouldFitCompactCanvas } from "./compactCanvasFit";
 import { compactLineCanvasGraph, type LineNodeData } from "./compactLineCanvasGraph";
@@ -74,6 +75,7 @@ function LineCanvasNode({ data }: NodeProps<Node<LineNodeData>>) {
           status={data.status}
           metrics={data.metrics}
           selected={data.isSelected}
+          body={data.steps.length > 0 ? <FactoryNodeStepList steps={data.steps} /> : undefined}
         />
         <Handle
           id={FACTORY_SPINE_HANDLE_ID}

--- a/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.spec.ts
@@ -1,6 +1,7 @@
 import { Position, type Edge } from "@xyflow/react";
 import { describe, expect, it } from "vitest";
 
+import { factoryNodeCardSize } from "@/lib/factoryCanvasChrome";
 import { FACTORY_SIDE_HANDLE_ID, FACTORY_SPINE_HANDLE_ID } from "@/lib/layout/factoryRunLeafLayout";
 
 import { compactLineCanvasGraph } from "./compactLineCanvasGraph";
@@ -36,6 +37,13 @@ function messyIfCanvas(): SplitRunCanvasModel {
         id: "false-agent",
         name: "Agent - No GH Issue Plan",
         component: "runnerClaudeCode",
+        configuration: {
+          steps: [
+            { name: "Clone Repo", type: "bash" },
+            { name: "Write Implementation Plan", type: "prompt" },
+            { name: "Use plan as output", type: "bash" },
+          ],
+        },
         position: { x: 480, y: 400 },
       },
     ],
@@ -77,6 +85,9 @@ describe("compactLineCanvasGraph", () => {
     expect(falseAgent.position.x).toBeGreaterThan(ifNode.position.x);
     expect(falseAgent.position.y).toBe(ifNode.position.y);
     expect(falseAgent.data.isSideTarget).toBe(true);
+    expect(falseAgent.data.steps).toEqual(["Clone Repo", "Write Implementation Plan", "Use plan as output"]);
+    expect({ width: falseAgent.width, height: falseAgent.height }).toEqual(factoryNodeCardSize(3));
+    expect({ width: trueAgent.width, height: trueAgent.height }).toEqual(factoryNodeCardSize());
 
     const trueEdge = edges.find((edge) => edge.source === "if" && edge.target === "comment");
     const falseEdge = edges.find((edge) => edge.source === "if" && edge.target === "false-agent") as

--- a/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.ts
@@ -1,7 +1,8 @@
 import type { Edge, Node } from "@xyflow/react";
 
 import type { ComponentsEdge, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
-import { FACTORY_NODE_CARD_HEIGHT, FACTORY_NODE_CARD_WIDTH } from "@/lib/factoryCanvasChrome";
+import { agentRunnerStepTitles } from "@/lib/agentRunnerSteps";
+import { factoryNodeCardSize } from "@/lib/factoryCanvasChrome";
 import { layoutFactoryRunLeafGraph } from "@/lib/layout/factoryRunLeafLayout";
 import { buildStyledCanvasEdges } from "@/ui/CanvasPage/factoryCanvasEdgeStyle";
 import type { FactoryNodeStatus } from "@/ui/factoryNodeChrome/types";
@@ -21,6 +22,7 @@ export type LineNodeData = {
   isSideSource: boolean;
   isSpineSource: boolean;
   isSideTarget: boolean;
+  steps: string[];
 } & Record<string, unknown>;
 
 function origin(nodes: ComponentsNode[]): { x: number; y: number } {
@@ -51,6 +53,8 @@ export function compactLineCanvasGraph(
     .filter((node): node is ComponentsNode & { id: string } => Boolean(node.id))
     .map((node) => {
       const presentation = componentPresentation(node.component);
+      const steps = node.component === "runnerClaudeCode" ? agentRunnerStepTitles(node.configuration) : [];
+      const size = factoryNodeCardSize(steps.length);
       return {
         id: node.id,
         type: "lineCanvas",
@@ -71,17 +75,18 @@ export function compactLineCanvasGraph(
           isSideSource: false,
           isSpineSource: false,
           isSideTarget: false,
+          steps,
         },
         selected: node.id === selectedId,
         draggable: false,
-        width: FACTORY_NODE_CARD_WIDTH,
-        height: FACTORY_NODE_CARD_HEIGHT,
+        width: size.width,
+        height: size.height,
       };
     });
 
   const rawEdges = canvas.edges.map((edge, index) => toFlowEdge(edge, index));
   const layout = layoutFactoryRunLeafGraph(
-    rawNodes.map((node) => ({ id: node.id, position: node.position })),
+    rawNodes.map((node) => ({ id: node.id, position: node.position, width: node.width, height: node.height })),
     rawEdges.map((edge) => ({
       id: edge.id,
       source: edge.source,

--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -65,6 +65,8 @@ export interface ComponentBaseProps extends ComponentActionsProps {
   metadata?: MetadataItem[];
   /** Custom content rendered on the node */
   customField?: React.ReactNode | (() => React.ReactNode);
+  /** Extra body content for the larger factory node card. */
+  factoryBody?: React.ReactNode;
   /** Where to render customField: "before" (before events) or "after" (after events, default) */
   customFieldPosition?: "before" | "after";
   /** Whether the custom field should only be shown in live mode */
@@ -128,6 +130,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = (props) => {
         showRuntimeStatus={props.showRuntimeStatus}
         runIsActive={props.runIsActive}
         eventStateMap={props.eventStateMap}
+        body={props.factoryBody}
       />
     );
   }

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.render.spec.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.render.spec.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FactoryNodeCard } from "./FactoryNodeCard";
+import { FactoryNodeStepList } from "./FactoryNodeStepList";
+
+describe("FactoryNodeCard", () => {
+  it("shows configured steps in a wider node body", () => {
+    render(
+      <FactoryNodeCard
+        title="Run Claude Code"
+        componentLabel="Run Claude Code"
+        nodeName="Agent - No GH Issue Plan"
+        iconSlug="code"
+        canvasMode="edit"
+        body={<FactoryNodeStepList steps={["Clone repo", "Write implementation plan", "Use plan as output"]} />}
+      />,
+    );
+
+    const card = screen.getByTestId("factory-node-run-claude-code");
+    expect(card).toHaveStyle({ width: "320px" });
+    expect(screen.getByText("Clone repo")).toBeInTheDocument();
+    expect(screen.getByText("Write implementation plan")).toBeInTheDocument();
+    expect(screen.getByText("Use plan as output")).toBeInTheDocument();
+  });
+
+  it("keeps ordinary factory nodes at the default width", () => {
+    render(<FactoryNodeCard title="Run Bash" componentLabel="Run Bash" nodeName="Check files" />);
+
+    expect(screen.getByTestId("factory-node-run-bash")).toHaveStyle({ width: "280px" });
+  });
+});

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
@@ -53,6 +53,8 @@ export type FactoryNodeCardProps = {
   runIsActive?: boolean;
   /** Mapper eventStateMap — same source the run sidebar uses for badge color. */
   eventStateMap?: EventStateMap;
+  /** Optional content between the node header and status footer. */
+  body?: React.ReactNode;
 };
 
 function useFactoryNodeMetrics(
@@ -140,6 +142,7 @@ export function FactoryNodeCard({
   showRuntimeStatus = true,
   runIsActive = true,
   eventStateMap,
+  body,
 }: FactoryNodeCardProps) {
   const primarySection = eventSections?.[0];
   const runtimeStatus = resolveFactoryRuntimeStatus({
@@ -186,6 +189,7 @@ export function FactoryNodeCard({
         dimBodyBelowHeader={dimBodyBelowHeader}
         isCompactView={isCompactView}
         showStatusFooter={footer.showStatusFooter}
+        body={body}
       />
     </div>
   );

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCardShell.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCardShell.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { getDraftDiffOutlineClassName, type DraftDiffStatus } from "@/lib/draftDiff";
 import { resolveNodeIconColorClass } from "@/lib/colors";
+import { FACTORY_NODE_CARD_WIDTH, FACTORY_NODE_STEP_CARD_WIDTH } from "@/lib/factoryCanvasChrome";
 import { cn, resolveIcon } from "@/lib/utils";
 import { toTestId } from "@/lib/testID";
 import { NodeStatusFooter } from "./NodeStatusFooter";
@@ -20,6 +21,7 @@ type FactoryNodeCardShellProps = {
   isCompactView?: boolean;
   showStatusFooter?: boolean;
   statusLabel?: string;
+  body?: React.ReactNode;
 };
 
 /** Monochrome logos (github / SuperPlane) need invert on dark card chrome. */
@@ -27,6 +29,14 @@ function shouldInvertMonoFactoryIcon(iconSrc: string | undefined): boolean {
   if (!iconSrc) return false;
   const lower = iconSrc.toLowerCase();
   return lower.includes("github") || lower.includes("superplane");
+}
+
+function factoryNodeWidth(body: React.ReactNode, isCompactView: boolean | undefined): number {
+  return body && !isCompactView ? FACTORY_NODE_STEP_CARD_WIDTH : FACTORY_NODE_CARD_WIDTH;
+}
+
+function FactoryNodeBody({ body, isCompactView }: { body: React.ReactNode; isCompactView?: boolean }) {
+  return body && !isCompactView ? body : null;
 }
 
 export function FactoryNodeCardShell({
@@ -43,6 +53,7 @@ export function FactoryNodeCardShell({
   isCompactView,
   showStatusFooter = true,
   statusLabel,
+  body,
 }: FactoryNodeCardShellProps) {
   const Icon = React.useMemo(() => resolveIcon(iconSlug), [iconSlug]);
   const invertMonoIcon = shouldInvertMonoFactoryIcon(iconSrc);
@@ -50,9 +61,10 @@ export function FactoryNodeCardShell({
   return (
     <div
       data-testid={toTestId(`factory-node-${title}`)}
+      style={{ width: factoryNodeWidth(body, isCompactView) }}
       className={cn(
         // No border box — transparent border left a 1px canvas gap that read as white rim.
-        "canvas-node-drag-handle cursor-pointer overflow-hidden rounded-2xl border-0 bg-card text-left shadow-[0_1px_3px_rgba(15,23,42,0.06),0_2px_6px_rgba(15,23,42,0.04)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.28)] w-[280px]",
+        "canvas-node-drag-handle cursor-pointer overflow-hidden rounded-2xl border-0 bg-card text-left shadow-[0_1px_3px_rgba(15,23,42,0.06),0_2px_6px_rgba(15,23,42,0.04)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.28)]",
         draftDiffStatus
           ? getDraftDiffOutlineClassName(draftDiffStatus)
           : "outline-1 outline-black/[0.04] dark:outline-white/[0.06]",
@@ -84,6 +96,7 @@ export function FactoryNodeCardShell({
           </div>
         </div>
       </div>
+      <FactoryNodeBody body={body} isCompactView={isCompactView} />
       {showStatusFooter ? <NodeStatusFooter status={status} metrics={metrics} label={statusLabel} /> : null}
     </div>
   );

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeStepList.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeStepList.tsx
@@ -1,0 +1,28 @@
+export function FactoryNodeStepList({ steps }: { steps: string[] }) {
+  if (steps.length === 0) {
+    return null;
+  }
+
+  return (
+    <ol
+      className="border-t border-border/70 bg-muted/30 px-3.5 py-2.5"
+      data-testid="factory-node-step-list"
+      aria-label="Steps"
+    >
+      {steps.map((step, index) => (
+        <li
+          key={`${index}-${step}`}
+          className="flex min-h-7 items-center gap-2 border-b border-border/50 py-1.5 last:border-b-0"
+        >
+          <span
+            className="flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-semibold tabular-nums text-muted-foreground"
+            aria-hidden
+          >
+            {index + 1}
+          </span>
+          <span className="min-w-0 text-[12px] leading-4 font-medium text-card-foreground">{step}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/web_src/src/ui/factoryNodeChrome/index.ts
+++ b/web_src/src/ui/factoryNodeChrome/index.ts
@@ -1,4 +1,5 @@
 export { FactoryNodeCard, type FactoryNodeCardProps } from "./FactoryNodeCard";
+export { FactoryNodeStepList } from "./FactoryNodeStepList";
 export {
   factorySidebarCloseButtonClassName,
   factorySidebarFontClassName,


### PR DESCRIPTION
## Summary

A Run Claude Code node only showed the agent title. Operators could not see the configured steps on the canvas or on the compact run graph.

This change lists the step titles on the factory node card. The card grows so the canvas layout still fits.

Codex and OpenRouter runner nodes stay on the compact card. They do not use this step list yet.

## Test plan

- [ ] Open a factory canvas that includes Run Claude Code (for example planner-agent-no-issue).
- [ ] Confirm the node lists the configured step titles and is wider than a default node.
- [ ] Confirm other runner nodes stay at the default size.
- [ ] Open a work-order run with a Claude Code agent and confirm the compact canvas shows the same steps.
- [ ] Confirm ELK layout does not overlap the taller Claude Code node.


Made with [Cursor](https://cursor.com)