### PR TITLE
feat: Set SuperPlane Agent as Setup Default

### DIFF
--- a/docs/design/superplane-agent-onboarding.md
+++ b/docs/design/superplane-agent-onboarding.md
@@ -1,0 +1,147 @@
+# SuperPlane agent as the default onboarding runner
+
+Status: Draft
+
+Date: 2026-08-27
+
+## Problem
+
+New-workspace automations are authored as **Run Claude Code**. Setup can
+rewrite those nodes when the user has a key or hosted credit. The default
+story still asks the user to connect Anthropic, OpenAI, or OpenRouter.
+
+The product default is SuperPlane agent. SuperPlane agent is hosted
+OpenRouter. The UI must not name OpenRouter on that default path. A user
+can still bring a key, but that choice must stay optional and collapsed.
+
+## Goal
+
+After the agent step, a new workspace:
+
+- Uses **Run OpenRouter Agent** with SuperPlane-hosted credentials by
+  default.
+- Explains that SuperPlane runs the agent. It does not name OpenRouter.
+- Lets the user expand **Use your own key** and connect Claude, OpenAI,
+  or OpenRouter.
+- Rewrites the same automation nodes when the user selects a key.
+
+Existing workspaces do not change.
+
+## Agent step
+
+The default choice is selected: SuperPlane agent.
+
+Copy:
+
+- Headline: name the SuperPlane agent. Do not say "Connect agent" as the
+  only story.
+- Body: SuperPlane will run the agent on this workspace. Work still
+  starts only after approval on a ticket.
+- Do not write "OpenRouter", "hosted OpenRouter", or provider product
+  names on the default card.
+
+A muted control, **Use your own key**, expands three connect rows:
+
+- Claude (Anthropic)
+- OpenAI
+- OpenRouter
+
+Those rows keep the current connect flow. Selecting one row makes that
+provider the agent plan. Clearing the key, or choosing SuperPlane agent
+again, returns to the default.
+
+If hosted credit is empty and the user does not connect a key, they
+cannot finish. Empty-credit copy lives in the expanded BYOK path, not as
+the main story.
+
+A Claude, OpenAI, or OpenRouter key that already exists on the
+organization does not steal the default. The user must expand BYOK and
+select that provider.
+
+## Agent plan
+
+Keep the existing finish-setup rewrite. Change how the plan is chosen.
+
+Default plan:
+
+- Component: `runnerOpenRouter`
+- Credentials: `{ source: "hosted" }`
+- Model: first allowlisted OpenRouter model that matches the current
+  hosted-model picker. Prefer a Sonnet id when the allowlist has one.
+  Fall back to the first allowlisted OpenRouter model.
+
+BYOK plan:
+
+- Claude → `runnerClaudeCode` and the Claude installation
+- OpenAI → `runnerCodex` and the OpenAI installation
+- OpenRouter → `runnerOpenRouter` and the OpenRouter installation
+
+`resolveOnboardingAgent` must stop preferring a connected provider over
+hosted SuperPlane agent. Connected providers apply only after an explicit
+BYOK selection.
+
+Intake analysis uses the same plan. Backend `intakeAgentSpecs` keeps
+Claude, Codex, and OpenRouter as valid runners. Hosted fallback prefers
+OpenRouter first.
+
+## Templates
+
+Author the bundled canvases as SuperPlane agent:
+
+- `web_src/src/pages/home/factories/line-apps/planning.canvas.yaml`
+- `web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml`
+- `web_src/src/pages/home/factories/line-apps/pr.canvas.yaml`
+- `web_src/src/pages/home/factories/software-factory/canvas.yaml`
+
+Each agent node:
+
+- `component: runnerOpenRouter`
+- `credentials.source: hosted`
+- `model:` an OpenRouter model id, default `anthropic/claude-sonnet-4-6`
+
+Keep the existing bash and prompt steps. Only the runner, credentials,
+and model change.
+
+Storybook and first-run intake fixtures that hardcode `runnerClaudeCode`
+as the generated analysis node follow the same default.
+
+## Rewrite
+
+`rewriteOnboardingAgentNodes` today matches only `runnerClaudeCode`.
+After the templates change, it must match the authored agent nodes
+(`runnerOpenRouter`) and any leftover Claude Code or Codex nodes.
+
+Finish setup still calls `agentRewriteFromPlan`. The default path writes
+hosted OpenRouter onto nodes that already use that component. A BYOK
+path swaps the component and the installation.
+
+Do not change canvases on workspaces that already finished setup.
+
+## Copy rules
+
+- Product name: SuperPlane.
+- Default path: SuperPlane agent.
+- BYOK path may name Claude, OpenAI, and OpenRouter.
+- ASD-STE100 for user-facing strings. No contractions. No slang.
+
+## Tests
+
+- Agent step: SuperPlane agent is selected. BYOK rows stay hidden until
+  expand. Finish is enabled when hosted credit remains.
+- Agent plan: no BYOK selection yields hosted OpenRouter. A connected
+  Claude key does not change that plan.
+- Agent plan: an expanded Claude, OpenAI, or OpenRouter selection yields
+  that runner and installation.
+- Materialize: default rewrite keeps `runnerOpenRouter` and hosted
+  credentials. BYOK rewrite swaps to Claude Code, Codex, or OpenRouter
+  with the installation name.
+- Intake: hosted fallback prefers OpenRouter. A setup-recorded BYOK
+  agent still scores with that runner.
+- Copy: default strings do not contain "OpenRouter".
+
+## Non-goals
+
+- Do not migrate existing factory canvases.
+- Do not add a new runner component.
+- Do not expose OpenRouter as the default product name.
+- Do not change GitHub, repository, or ticket steps.

--- a/pkg/grpc/actions/factories/intake_agent.go
+++ b/pkg/grpc/actions/factories/intake_agent.go
@@ -157,7 +157,7 @@ func intakeAgentFromHostedProvider(tx *gorm.DB, factory *models.Factory) *intake
 		return nil
 	}
 
-	for _, spec := range intakeAgentSpecs {
+	for _, spec := range hostedIntakeAgentSpecs() {
 		index := slices.IndexFunc(providers, func(provider models.HostedLLMProvider) bool {
 			return provider.Provider == spec.hostedProvider && provider.OffersHostedModels()
 		})
@@ -178,6 +178,22 @@ func intakeAgentFromHostedProvider(tx *gorm.DB, factory *models.Factory) *intake
 	}
 
 	return nil
+}
+
+// hostedIntakeAgentSpecs prefers SuperPlane-hosted OpenRouter, then the other
+// hosted providers. Installation lookup keeps intakeAgentSpecs order so a
+// workspace that already connected Claude does not flip to OpenRouter.
+func hostedIntakeAgentSpecs() []intakeAgentSpec {
+	preferred := make([]intakeAgentSpec, 0, 1)
+	rest := make([]intakeAgentSpec, 0, len(intakeAgentSpecs))
+	for _, spec := range intakeAgentSpecs {
+		if spec.hostedProvider == models.UsageProviderOpenRouter {
+			preferred = append(preferred, spec)
+			continue
+		}
+		rest = append(rest, spec)
+	}
+	return append(preferred, rest...)
 }
 
 func intakeAgentFromIntegration(integration *models.Integration) *intakeAgent {

--- a/pkg/grpc/actions/factories/intake_agent_test.go
+++ b/pkg/grpc/actions/factories/intake_agent_test.go
@@ -98,6 +98,32 @@ func Test__ResolveIntakeAgent(t *testing.T) {
 		assert.Equal(t, "claude-sonnet-4-6", agent.Model)
 	})
 
+	t.Run("hosted fallback prefers OpenRouter when several providers are enabled", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		clearHostedLLMProviders(t, db)
+		_, err := models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+			Provider:      models.UsageProviderAnthropic,
+			Enabled:       true,
+			APIKey:        []byte("test-hosted-key"),
+			AllowedModels: datatypes.JSONSlice[string]{"claude-sonnet-4-6"},
+		})
+		require.NoError(t, err)
+		_, err = models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+			Provider:      models.UsageProviderOpenRouter,
+			Enabled:       true,
+			APIKey:        []byte("test-openrouter-key"),
+			AllowedModels: datatypes.JSONSlice[string]{"openai/gpt-4.1", "anthropic/claude-sonnet-4-6"},
+		})
+		require.NoError(t, err)
+
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
+		assert.Equal(t, "runnerOpenRouter", agent.Component)
+		assert.Equal(t, map[string]any{"source": runner.CredentialsSourceHosted}, agent.Credentials)
+		assert.Equal(t, "anthropic/claude-sonnet-4-6", agent.Model)
+	})
+
 	t.Run("a workspace with no agent at all leaves the node incomplete", func(t *testing.T) {
 		organization := support.CreateOrganization(t, r, r.User)
 		factory := newFactoryIn(t, organization.ID)

--- a/web_src/src/pages/factories/pages/Onboarding.stories.tsx
+++ b/web_src/src/pages/factories/pages/Onboarding.stories.tsx
@@ -93,13 +93,13 @@ export const Issues: Story = {
   ),
 };
 
-/** The organization has hosted credit, so the user can continue without keys. */
+/** SuperPlane agent is the default. Remaining credit lets setup finish. */
 export const AgentWithGrant: Story = {
-  name: "4a Agent (hosted credit)",
+  name: "4a Agent (SuperPlane agent)",
   render: () => <SetupStep step="agent" answers={SETUP_ANSWERS.issues} orgIntegrations={GITHUB_SETUP_INTEGRATIONS} />,
 };
 
-/** No grant: the user must connect Anthropic, OpenAI, or OpenRouter. */
+/** Empty credit: the user expands Use your own key and connects a provider. */
 export const AgentWithoutGrant: Story = {
   name: "4b Agent (connect a provider)",
   render: () => (

--- a/web_src/src/pages/factories/pages/lineIntakeCanvas.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeCanvas.ts
@@ -58,7 +58,7 @@ export function intakeCanvasForSource(source: LineIntakeSource): SplitRunCanvasM
       id: runnerId,
       name: "Classify intake",
       type: "TYPE_ACTION",
-      component: "runnerClaudeCode",
+      component: "runnerOpenRouter",
       configuration: {
         prompt: spec.classifyPrompt,
       },

--- a/web_src/src/pages/factories/pages/lineIntakeModel.spec.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeModel.spec.ts
@@ -89,7 +89,7 @@ describe("lineIntakeModel", () => {
     ]);
     expect(fixture.phases[0]?.canvas?.nodes.map((node) => node.component)).toEqual([
       "github.onIssue",
-      "runnerClaudeCode",
+      "runnerOpenRouter",
       "addWorkOrderArtifact",
       "reportWorkOrderCheck",
     ]);
@@ -280,7 +280,7 @@ describe("lineIntakeModel", () => {
     const canvas = fixture.phases[0]?.canvas;
     expect(canvas?.nodes.map((node) => node.component)).toEqual([
       "github.onIssue",
-      "runnerClaudeCode",
+      "runnerOpenRouter",
       "createWorkOrder",
     ]);
   });
@@ -289,14 +289,14 @@ describe("lineIntakeModel", () => {
     const sentry = intakeAutomationFixture(lineIntakeSourceById("sentry-exceptions")!);
     expect(sentry.phases[0]?.canvas?.nodes.map((node) => node.component)).toEqual([
       "sentry.onIssue",
-      "runnerClaudeCode",
+      "runnerOpenRouter",
       "createWorkOrder",
     ]);
 
     const pagerduty = intakeAutomationFixture(lineIntakeSourceById("pagerduty-incidents")!);
     expect(pagerduty.phases[0]?.canvas?.nodes.map((node) => node.component)).toEqual([
       "pagerduty.onIncident",
-      "runnerClaudeCode",
+      "runnerOpenRouter",
       "createWorkOrder",
     ]);
   });

--- a/web_src/src/pages/factories/pages/lineIntakeModel.ts
+++ b/web_src/src/pages/factories/pages/lineIntakeModel.ts
@@ -513,7 +513,7 @@ function ticketAnalysisCanvas(complete: boolean): SplitRunCanvasModel {
       id: analyzeId,
       name: "Analyze ticket",
       type: "TYPE_ACTION",
-      component: "runnerClaudeCode",
+      component: "runnerOpenRouter",
       configuration: {
         prompt: "Read this ticket and the repository. Find the files and risks that matter.",
       },

--- a/web_src/src/pages/factories/pages/onboarding/AgentStep.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/AgentStep.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FACTORIES_ORGANIZATION_ID } from "@/pages/factories/__fixtures__/factoryPageResponses";
 
@@ -28,7 +28,7 @@ function renderAgentStep(args?: {
   function Harness() {
     const setup = useOnboardingSetupState("Payments", {
       connected: new Set(args?.connected ?? []),
-      remainingCreditCents: 0,
+      remainingCreditCents: Number(spendState.remainingCreditCents),
       simulateDiscovery: false,
     });
     return <AgentStep organizationId={FACTORIES_ORGANIZATION_ID} setup={setup} onRequestConnect={onRequestConnect} />;
@@ -41,52 +41,58 @@ function renderAgentStep(args?: {
 }
 
 describe("AgentStep", () => {
-  it("shows hosted credit when the organization has a grant", () => {
-    renderAgentStep();
-
-    expect(screen.getByTestId("hosted-credit-grant")).toBeInTheDocument();
-    expect(screen.getByText("SuperPlane-hosted credit")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "This organization has $41.24 of hosted credit. You can continue without connecting your own keys.",
-      ),
-    ).toBeInTheDocument();
+  beforeEach(() => {
+    sessionStorage.removeItem("superplane.onboarding.keyProvider");
   });
 
-  it("hides the grant block when the organization has no grant", () => {
-    renderAgentStep({
-      spend: { remainingCreditCents: "0", grantTotalCents: "0" },
-    });
+  it("selects SuperPlane agent by default and hides BYOK rows", () => {
+    renderAgentStep();
 
-    expect(screen.getByRole("button", { name: "Connect Anthropic" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /SuperPlane agent/ })).toBeInTheDocument();
+    expect(
+      screen.getByText("SuperPlane will run the agent on this workspace. Work starts only after you approve a ticket."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Use your own key" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect Anthropic" })).not.toBeInTheDocument();
+    expect(screen.queryByText("OpenRouter")).not.toBeInTheDocument();
     expect(screen.queryByTestId("hosted-credit-grant")).not.toBeInTheDocument();
   });
 
-  it("shows Anthropic, OpenAI, and OpenRouter as connectable, and Cursor as coming soon", () => {
+  it("expands Claude, OpenAI, and OpenRouter after Use your own key, without Cursor", async () => {
+    const user = userEvent.setup();
     renderAgentStep({ spend: { remainingCreditCents: "0", grantTotalCents: "0" } });
+
+    await user.click(screen.getByRole("button", { name: "Use your own key" }));
 
     expect(screen.getByRole("button", { name: "Connect Anthropic" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Connect OpenAI" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Connect OpenRouter" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Connect Cursor/ })).not.toBeInTheDocument();
-    expect(screen.getByText("Coming soon")).toBeInTheDocument();
+    expect(screen.queryByText("Coming soon")).not.toBeInTheDocument();
   });
 
-  it("asks to connect a provider when a grant exists but remaining credit is empty", () => {
+  it("shows empty SuperPlane agent credit copy on the BYOK path", async () => {
+    const user = userEvent.setup();
     renderAgentStep({
       spend: { remainingCreditCents: "0", grantTotalCents: "5000" },
     });
 
-    expect(screen.getByTestId("hosted-credit-grant")).toBeInTheDocument();
-    expect(screen.getByText("Hosted credit is empty. Connect a provider to continue.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("SuperPlane agent credit is empty. Connect a provider to continue."),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Use your own key" }));
+
+    expect(screen.getByText("SuperPlane agent credit is empty. Connect a provider to continue.")).toBeInTheDocument();
   });
 
-  it("connects OpenAI without selecting a single harness", async () => {
+  it("connects OpenAI from the expanded BYOK list", async () => {
     const user = userEvent.setup();
     const { onRequestConnect } = renderAgentStep({
       spend: { remainingCreditCents: "0", grantTotalCents: "0" },
     });
 
+    await user.click(screen.getByRole("button", { name: "Use your own key" }));
     await user.click(screen.getByRole("button", { name: "Connect OpenAI" }));
 
     expect(onRequestConnect).toHaveBeenCalledWith("openai");

--- a/web_src/src/pages/factories/pages/onboarding/AgentStep.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/AgentStep.tsx
@@ -1,11 +1,18 @@
+import superplaneLogo from "@/assets/superplane.svg";
 import { useOrganizationLLMSpend } from "@/hooks/useOrganizationLLMSpend";
 import { cn } from "@/lib/utils";
 import { parseWorkOrderMetric } from "@/pages/factories/lib/workOrderUsage";
+import { useState } from "react";
 
-import { hostedCreditGrantCopy, shouldShowHostedCreditGrant } from "./onboardingAgentReadiness";
+import { AGENT_PROVIDER_IDS, hostedCreditGrantCopy, type AgentProviderId } from "./onboardingAgentReadiness";
 import { AGENT_OPTIONS, type IntegrationId } from "./onboardingFixtures";
 import { ConnectOptionRow, IntegrationChoiceIcon } from "./onboardingSteps";
 import type { OnboardingSetupApi } from "./useOnboardingSetupState";
+
+const BYOK_OPTIONS = AGENT_OPTIONS.filter(
+  (option): option is (typeof AGENT_OPTIONS)[number] & { id: AgentProviderId } =>
+    AGENT_PROVIDER_IDS.includes(option.id as AgentProviderId),
+);
 
 export function AgentStep({
   organizationId,
@@ -17,40 +24,46 @@ export function AgentStep({
   onRequestConnect: (id: IntegrationId) => void;
 }) {
   const spend = useOrganizationLLMSpend(organizationId);
-  const grantTotalCents = parseWorkOrderMetric(spend.data?.grantTotalCents);
   const remainingCreditCents = parseWorkOrderMetric(spend.data?.remainingCreditCents);
-  const showGrant = shouldShowHostedCreditGrant(grantTotalCents);
+  const [ownKeyOpen, setOwnKeyOpen] = useState(() => setup.keyProvider !== null);
+  const superPlaneSelected = setup.keyProvider === null;
 
   return (
     <div className="grid gap-3">
-      {showGrant ? (
-        <div className="rounded-lg border border-border bg-muted/30 px-4 py-3" data-testid="hosted-credit-grant">
-          <p className="text-[13px] font-medium tracking-[-0.01em]">SuperPlane-hosted credit</p>
-          <p
-            className={cn(
-              "mt-1 text-[12px]",
-              remainingCreditCents > 0 ? "text-muted-foreground" : "text-amber-700 dark:text-amber-400",
-            )}
-          >
-            {hostedCreditGrantCopy(remainingCreditCents)}
-          </p>
+      <ConnectOptionRow
+        icon={<img src={superplaneLogo} alt="" className="size-5 dark:brightness-0 dark:invert" />}
+        title="SuperPlane agent"
+        detail="SuperPlane will run the agent on this workspace. Work starts only after you approve a ticket."
+        selected={superPlaneSelected}
+        onSelect={() => setup.setKeyProvider(null)}
+      />
+      <button
+        type="button"
+        className="justify-self-start text-[12px] text-muted-foreground underline-offset-4 hover:underline"
+        onClick={() => setOwnKeyOpen((open) => !open)}
+      >
+        Use your own key
+      </button>
+      {ownKeyOpen ? (
+        <div className="grid gap-2">
+          {remainingCreditCents <= 0 ? (
+            <p className={cn("text-[12px] text-amber-700 dark:text-amber-400")}>{hostedCreditGrantCopy(0)}</p>
+          ) : null}
+          {BYOK_OPTIONS.map((option) => (
+            <ConnectOptionRow
+              key={option.id}
+              icon={<IntegrationChoiceIcon name={option.id} />}
+              title={option.label}
+              detail={option.detail}
+              connectLabel={option.label}
+              connected={setup.connected.has(option.id)}
+              selected={setup.keyProvider === option.id}
+              onSelect={() => setup.setKeyProvider(option.id)}
+              onConnect={() => onRequestConnect(option.id)}
+            />
+          ))}
         </div>
       ) : null}
-      <div className="grid gap-2">
-        {AGENT_OPTIONS.map((option) => (
-          <ConnectOptionRow
-            key={option.id}
-            icon={<IntegrationChoiceIcon name={option.id} />}
-            title={option.label}
-            detail={option.detail}
-            connectLabel={option.label}
-            connected={setup.connected.has(option.id)}
-            soon={option.soon}
-            onSelect={() => undefined}
-            onConnect={() => onRequestConnect(option.id)}
-          />
-        ))}
-      </div>
     </div>
   );
 }

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
@@ -41,10 +41,10 @@ export const FIRST_RUN_COPY = {
     jiraHelper: "Find tickets in your Jira backlog.",
     linearHelper: "Find tickets in your Linear backlog.",
     analyze: "Analyze my tickets",
-    continue: "Connect agent",
+    continue: "Continue",
   },
   agent: {
-    headline: "Connect agent",
+    headline: "SuperPlane agent",
   },
   analysis: {
     headline: "Analyzing your backlog",

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
@@ -21,29 +21,62 @@ const noHostedModels = {
 };
 
 describe("isAgentStepReady", () => {
-  it("is ready when remaining hosted credit is greater than zero", () => {
-    expect(isAgentStepReady(connected(), 4124)).toBe(true);
+  it("is ready when SuperPlane agent has remaining hosted credit", () => {
+    expect(isAgentStepReady(connected(), 4124, null)).toBe(true);
+    expect(isAgentStepReady(connected("claude"), 4124, null)).toBe(true);
   });
 
-  it("is ready when Anthropic, OpenAI, or OpenRouter is connected", () => {
-    expect(isAgentStepReady(connected("claude"), 0)).toBe(true);
-    expect(isAgentStepReady(connected("openai"), 0)).toBe(true);
-    expect(isAgentStepReady(connected("openrouter"), 0)).toBe(true);
+  it("is not ready when SuperPlane agent has empty credit", () => {
+    expect(isAgentStepReady(connected(), 0, null)).toBe(false);
+    expect(isAgentStepReady(connected("claude"), 0, null)).toBe(false);
   });
 
-  it("is not ready when credit is empty and no provider is connected", () => {
-    expect(isAgentStepReady(connected(), 0)).toBe(false);
-    expect(isAgentStepReady(connected("github"), 0)).toBe(false);
+  it("is ready for BYOK only when the selected provider is connected", () => {
+    expect(isAgentStepReady(connected("claude"), 0, "claude")).toBe(true);
+    expect(isAgentStepReady(connected("openai"), 0, "openai")).toBe(true);
+    expect(isAgentStepReady(connected("openrouter"), 0, "openrouter")).toBe(true);
+    expect(isAgentStepReady(connected("openai"), 0, "claude")).toBe(false);
+    expect(isAgentStepReady(connected(), 5000, "claude")).toBe(false);
   });
 });
 
 describe("resolveOnboardingAgent", () => {
-  it("uses a connected OpenRouter integration and an allowlisted model", () => {
+  it("uses hosted OpenRouter when SuperPlane agent is selected", () => {
+    expect(
+      resolveOnboardingAgent({
+        connected: connected("claude"),
+        remainingCreditCents: 5000,
+        hostedModels: { ...noHostedModels, openrouter: ["openai/gpt-4.1", "anthropic/claude-sonnet-4-6"] },
+        keyProvider: null,
+      }),
+    ).toEqual({
+      providerId: "openrouter",
+      component: "runnerOpenRouter",
+      credentialsSource: "hosted",
+      integrationName: "openrouter",
+      harness: "AGENT_HARNESS_CLAUDE_CODE",
+      model: "anthropic/claude-sonnet-4-6",
+    });
+  });
+
+  it("does not let a connected Claude key steal the SuperPlane agent default", () => {
+    expect(
+      resolveOnboardingAgent({
+        connected: connected("claude", "openai"),
+        remainingCreditCents: 5000,
+        hostedModels: { ...noHostedModels, openrouter: ["anthropic/claude-sonnet-4-6"] },
+        keyProvider: null,
+      })?.providerId,
+    ).toBe("openrouter");
+  });
+
+  it("uses a connected OpenRouter integration only after BYOK selection", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected("openrouter"),
         remainingCreditCents: 5000,
         hostedModels: { ...noHostedModels, openrouter: ["openai/gpt-4.1", "anthropic/claude-sonnet-4-6"] },
+        keyProvider: "openrouter",
       }),
     ).toEqual({
       providerId: "openrouter",
@@ -55,48 +88,44 @@ describe("resolveOnboardingAgent", () => {
     });
   });
 
-  it("uses hosted OpenRouter and the selected allowlist when only credit remains", () => {
+  it("uses the selected BYOK Claude runner and installation", () => {
     expect(
       resolveOnboardingAgent({
-        connected: connected(),
+        connected: connected("claude"),
         remainingCreditCents: 5000,
-        hostedModels: { ...noHostedModels, openrouter: ["openai/gpt-4.1"] },
+        hostedModels: { ...noHostedModels, openrouter: ["anthropic/claude-sonnet-4-6"] },
+        keyProvider: "claude",
       }),
     ).toEqual({
-      providerId: "openrouter",
-      component: "runnerOpenRouter",
-      credentialsSource: "hosted",
-      integrationName: "openrouter",
+      providerId: "claude",
+      component: "runnerClaudeCode",
+      credentialsSource: "integration",
+      integrationName: "claude",
       harness: "AGENT_HARNESS_CLAUDE_CODE",
-      model: "openai/gpt-4.1",
+      model: "sonnet",
     });
   });
 
-  it("uses hosted OpenAI when that provider is the enabled hosted allowlist", () => {
-    expect(
-      resolveOnboardingAgent({
-        connected: connected(),
-        remainingCreditCents: 5000,
-        hostedModels: { ...noHostedModels, openai: ["gpt-5", "gpt-4.1"] },
-      }),
-    ).toEqual({
-      providerId: "openai",
-      component: "runnerCodex",
-      credentialsSource: "hosted",
-      integrationName: "openai",
-      harness: "AGENT_HARNESS_CODEX",
-      model: "gpt-5",
-    });
-  });
-
-  it("prefers a connected provider over hosted credit", () => {
+  it("uses the selected BYOK OpenAI runner", () => {
     expect(
       resolveOnboardingAgent({
         connected: connected("openai"),
+        remainingCreditCents: 0,
+        hostedModels: noHostedModels,
+        keyProvider: "openai",
+      })?.component,
+    ).toBe("runnerCodex");
+  });
+
+  it("returns undefined when SuperPlane agent has credit but OpenRouter is not allowlisted", () => {
+    expect(
+      resolveOnboardingAgent({
+        connected: connected(),
         remainingCreditCents: 5000,
-        hostedModels: { ...noHostedModels, openrouter: ["anthropic/claude-sonnet-4-6"] },
-      })?.providerId,
-    ).toBe("openai");
+        hostedModels: { ...noHostedModels, openai: ["gpt-5"] },
+        keyProvider: null,
+      }),
+    ).toBeUndefined();
   });
 
   it("returns undefined when credit remains but no hosted models are enabled", () => {
@@ -105,6 +134,7 @@ describe("resolveOnboardingAgent", () => {
         connected: connected(),
         remainingCreditCents: 5000,
         hostedModels: noHostedModels,
+        keyProvider: null,
       }),
     ).toBeUndefined();
   });
@@ -122,14 +152,14 @@ describe("hostedModelsQueriesLoading", () => {
 });
 
 describe("firstWorkOrderAgentError", () => {
-  it("asks the user to connect a provider when credit is empty", () => {
+  it("asks the user to use SuperPlane agent credit or a key when credit is empty", () => {
     expect(
       firstWorkOrderAgentError({
         remainingCreditCents: 0,
         hostedModelsLoading: false,
         plan: undefined,
       }),
-    ).toBe("Connect Anthropic, OpenAI, or OpenRouter, or use hosted credit.");
+    ).toBe("Use SuperPlane agent credit, or connect Anthropic, OpenAI, or OpenRouter.");
   });
 
   it("asks the user to wait when hosted models are still loading", () => {
@@ -179,13 +209,13 @@ describe("hosted credit grant copy", () => {
     expect(shouldShowHostedCreditGrant(5000)).toBe(true);
   });
 
-  it("explains that remaining credit lets the user continue without keys", () => {
+  it("explains that remaining credit lets SuperPlane run the agent", () => {
     expect(hostedCreditGrantCopy(5000)).toBe(
-      "This organization has $50.00 of hosted credit. You can continue without connecting your own keys.",
+      "This organization has $50.00 of SuperPlane agent credit. SuperPlane can run the agent without your own key.",
     );
   });
 
   it("asks the user to connect a provider when remaining credit is empty", () => {
-    expect(hostedCreditGrantCopy(0)).toBe("Hosted credit is empty. Connect a provider to continue.");
+    expect(hostedCreditGrantCopy(0)).toBe("SuperPlane agent credit is empty. Connect a provider to continue.");
   });
 });

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
@@ -50,41 +50,31 @@ const AGENT_PROVIDER_SPECS: Record<AgentProviderId, AgentProviderSpec> = {
   },
 };
 
-export function isAgentProviderConnected(connected: Set<IntegrationId>): boolean {
-  return AGENT_PROVIDER_IDS.some((id) => connected.has(id));
-}
-
-export function isAgentStepReady(connected: Set<IntegrationId>, remainingCreditCents: number): boolean {
-  return remainingCreditCents > 0 || isAgentProviderConnected(connected);
+export function isAgentStepReady(
+  connected: Set<IntegrationId>,
+  remainingCreditCents: number,
+  keyProvider: AgentProviderId | null,
+): boolean {
+  if (keyProvider) {
+    return connected.has(keyProvider);
+  }
+  return remainingCreditCents > 0;
 }
 
 export function resolveOnboardingAgent(args: {
   connected: Set<IntegrationId>;
   remainingCreditCents: number;
   hostedModels: HostedModelsByProvider;
+  keyProvider: AgentProviderId | null;
 }): OnboardingAgentPlan | undefined {
-  for (const providerId of AGENT_PROVIDER_IDS) {
-    if (!args.connected.has(providerId)) continue;
-    return planForConnectedProvider(providerId, args.hostedModels);
+  if (args.keyProvider) {
+    if (!args.connected.has(args.keyProvider)) return undefined;
+    return planForConnectedProvider(args.keyProvider, args.hostedModels);
   }
 
   if (args.remainingCreditCents <= 0) return undefined;
 
-  for (const providerId of AGENT_PROVIDER_IDS) {
-    const spec = AGENT_PROVIDER_SPECS[providerId];
-    const model = pickHostedModel(spec.hostedProvider, args.hostedModels[spec.hostedProvider]);
-    if (!model) continue;
-    return {
-      providerId,
-      component: spec.component,
-      credentialsSource: "hosted",
-      integrationName: providerId,
-      harness: spec.harness,
-      model,
-    };
-  }
-
-  return undefined;
+  return hostedSuperPlaneAgent(args.hostedModels);
 }
 
 export function hostedModelsQueriesLoading(needHosted: boolean, queries: Array<{ isFetched: boolean }>): boolean {
@@ -101,7 +91,7 @@ export function firstWorkOrderAgentError(args: {
   }
   if (args.plan) return null;
   if (args.remainingCreditCents <= 0) {
-    return "Connect Anthropic, OpenAI, or OpenRouter, or use hosted credit.";
+    return "Use SuperPlane agent credit, or connect Anthropic, OpenAI, or OpenRouter.";
   }
   return "Ask an installation admin to enable SuperPlane-hosted models.";
 }
@@ -112,9 +102,23 @@ export function shouldShowHostedCreditGrant(grantTotalCents: number): boolean {
 
 export function hostedCreditGrantCopy(remainingCreditCents: number): string {
   if (remainingCreditCents > 0) {
-    return `This organization has ${formatUsdCents(remainingCreditCents)} of hosted credit. You can continue without connecting your own keys.`;
+    return `This organization has ${formatUsdCents(remainingCreditCents)} of SuperPlane agent credit. SuperPlane can run the agent without your own key.`;
   }
-  return "Hosted credit is empty. Connect a provider to continue.";
+  return "SuperPlane agent credit is empty. Connect a provider to continue.";
+}
+
+function hostedSuperPlaneAgent(hostedModels: HostedModelsByProvider): OnboardingAgentPlan | undefined {
+  const spec = AGENT_PROVIDER_SPECS.openrouter;
+  const model = pickHostedModel(spec.hostedProvider, hostedModels[spec.hostedProvider]);
+  if (!model) return undefined;
+  return {
+    providerId: "openrouter",
+    component: spec.component,
+    credentialsSource: "hosted",
+    integrationName: "openrouter",
+    harness: spec.harness,
+    model,
+  };
 }
 
 function planForConnectedProvider(

--- a/web_src/src/pages/factories/pages/onboarding/onboardingFixtures.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingFixtures.ts
@@ -126,7 +126,7 @@ export const WIZARD_STEPS = [
   {
     id: "agent" as const,
     label: "Agent",
-    purpose: "Connect Anthropic, OpenAI, or OpenRouter. Hosted credit lets you continue without your own keys.",
+    purpose: "SuperPlane will run the agent on this workspace. Work starts only after you approve a ticket.",
   },
   {
     id: "name" as const,

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.ts
@@ -6,6 +6,7 @@ import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSect
 import {
   hostedModelsQueriesLoading,
   resolveOnboardingAgent,
+  type AgentProviderId,
   type OnboardingAgentPlan,
 } from "./onboardingAgentReadiness";
 import type { IntegrationId } from "./onboardingFixtures";
@@ -14,22 +15,22 @@ export function useOnboardingAgentPlan(
   organizationId: string,
   connected: Set<IntegrationId>,
   remainingCreditCents: number,
+  keyProvider: AgentProviderId | null,
 ) {
-  const needHosted = remainingCreditCents > 0;
-  const anthropic = useHostedLLMModels(organizationId, "anthropic", needHosted);
-  const openai = useHostedLLMModels(organizationId, "openai", needHosted);
+  const needHosted = remainingCreditCents > 0 && keyProvider === null;
   const openrouter = useHostedLLMModels(organizationId, "openrouter", needHosted);
   return {
     remainingCreditCents,
-    hostedModelsLoading: hostedModelsQueriesLoading(needHosted, [anthropic, openai, openrouter]),
+    hostedModelsLoading: hostedModelsQueriesLoading(needHosted, [openrouter]),
     plan: resolveOnboardingAgent({
       connected,
       remainingCreditCents,
       hostedModels: {
-        anthropic: hostedModelIds(anthropic.data?.models),
-        openai: hostedModelIds(openai.data?.models),
+        anthropic: [],
+        openai: [],
         openrouter: hostedModelIds(openrouter.data?.models),
       },
+      keyProvider,
     }),
   };
 }

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -70,10 +70,6 @@ function useRestoreSetup(
     const source = localIssuesSource(onboarding?.issuesSource);
     if (source && setup.issuesChoice !== source) setup.setIssuesChoice(source);
   }, [onboarding?.issuesSource, setup]);
-  useEffect(() => {
-    if (!selections.claude?.ready) return;
-    setup.setAgent("claude-code");
-  }, [onboarding?.agentHarness, selections.claude?.ready, setup]);
 }
 
 async function runSave(setSaving: (saving: boolean) => void, action: () => Promise<unknown>): Promise<boolean> {
@@ -150,10 +146,9 @@ function canConfigureWorkspace(canAct: (resource: string, action: string) => boo
   );
 }
 
-function useOnboardingAgentContext(organizationId: string, connected: Set<IntegrationId>) {
+function useRemainingCreditCents(organizationId: string) {
   const spend = useOrganizationLLMSpend(organizationId);
-  const remainingCreditCents = parseWorkOrderMetric(spend.data?.remainingCreditCents);
-  return useOnboardingAgentPlan(organizationId, connected, remainingCreditCents);
+  return parseWorkOrderMetric(spend.data?.remainingCreditCents);
 }
 
 function useOnboardingGithubRepos(organizationId: string, githubIntegrationId: string) {
@@ -184,12 +179,19 @@ export function useOnboardingPageModel(args: {
   const { canAct } = usePermissions();
   const onboarding = args.factory?.onboarding;
   const integrations = useIntegrationSelections(onboarding);
-  const agent = useOnboardingAgentContext(args.organizationId, integrations.connected);
+  const remainingCreditCents = useRemainingCreditCents(args.organizationId);
   const setup = useOnboardingSetupState(args.factory?.name ?? "", {
     connected: integrations.connected,
-    remainingCreditCents: agent.remainingCreditCents,
+    remainingCreditCents,
     simulateDiscovery: false,
+    factoryId: args.factoryId,
   });
+  const agent = useOnboardingAgentPlan(
+    args.organizationId,
+    integrations.connected,
+    remainingCreditCents,
+    setup.keyProvider,
+  );
   useRestoreSetup(setup, onboarding, integrations.selections);
   const [searchParams] = useSearchParams();
   const [openSection, setOpenSection] = useState<WizardStepId>(() => {

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingSetupState.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingSetupState.spec.ts
@@ -1,10 +1,14 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import type { IntegrationId } from "./onboardingFixtures";
 import { useOnboardingSetupState } from "./useOnboardingSetupState";
 
 describe("useOnboardingSetupState", () => {
+  beforeEach(() => {
+    sessionStorage.removeItem("superplane.onboarding.keyProvider");
+  });
+
   it("uses real connected state and completes discovery without fixture counts", () => {
     const connected = new Set<IntegrationId>(["github", "claude"]);
     const { result } = renderHook(() =>
@@ -27,7 +31,7 @@ describe("useOnboardingSetupState", () => {
     expect(result.current.issueCount).toBeUndefined();
   });
 
-  it("marks the agent step ready when remaining credit is greater than zero", () => {
+  it("marks the agent step ready when SuperPlane agent has remaining credit", () => {
     const { result } = renderHook(() =>
       useOnboardingSetupState("Payments", {
         connected: new Set<IntegrationId>(),
@@ -36,10 +40,11 @@ describe("useOnboardingSetupState", () => {
       }),
     );
 
+    expect(result.current.keyProvider).toBeNull();
     expect(result.current.agentReady).toBe(true);
   });
 
-  it("marks the agent step ready when OpenAI is connected and credit is empty", () => {
+  it("does not mark the agent step ready from a connected key without BYOK selection", () => {
     const { result } = renderHook(() =>
       useOnboardingSetupState("Payments", {
         connected: new Set<IntegrationId>(["openai"]),
@@ -48,10 +53,10 @@ describe("useOnboardingSetupState", () => {
       }),
     );
 
-    expect(result.current.agentReady).toBe(true);
+    expect(result.current.agentReady).toBe(false);
   });
 
-  it("lets setup finish when OpenRouter is connected", () => {
+  it("marks the agent step ready after the user selects a connected BYOK provider", () => {
     const connected = new Set<IntegrationId>(["github", "openrouter"]);
     const { result } = renderHook(() =>
       useOnboardingSetupState("Payments", {
@@ -64,18 +69,19 @@ describe("useOnboardingSetupState", () => {
     act(() => {
       result.current.selectVcsHost("github");
       result.current.selectRepo("acme/payments");
+      result.current.setKeyProvider("openrouter");
     });
 
     expect(result.current.agentReady).toBe(true);
     expect(result.current.canFinish).toBe(true);
   });
 
-  it("lets setup finish when Anthropic is connected or remaining credit is greater than zero", () => {
-    const connected = new Set<IntegrationId>(["github", "claude"]);
+  it("lets setup finish on SuperPlane agent credit without a connected key", () => {
+    const connected = new Set<IntegrationId>(["github"]);
     const { result } = renderHook(() =>
       useOnboardingSetupState("Payments", {
         connected,
-        remainingCreditCents: 0,
+        remainingCreditCents: 5000,
         simulateDiscovery: false,
       }),
     );

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingSetupState.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingSetupState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { isAgentStepReady } from "./onboardingAgentReadiness";
+import { isAgentStepReady, type AgentProviderId, AGENT_PROVIDER_IDS } from "./onboardingAgentReadiness";
 import {
   fixtureIssueCount,
   type AgentHarnessId,
@@ -9,6 +9,31 @@ import {
   type VcsHostId,
 } from "./onboardingFixtures";
 import { isPlaceholderWorkspaceName, workspaceNameFromRepository } from "./workspaceNames";
+
+const KEY_PROVIDER_STORAGE = "superplane.onboarding.keyProvider";
+
+function keyProviderStorageKey(factoryId?: string): string {
+  return factoryId ? `${KEY_PROVIDER_STORAGE}.${factoryId}` : KEY_PROVIDER_STORAGE;
+}
+
+function readStoredKeyProvider(factoryId?: string): AgentProviderId | null {
+  if (typeof sessionStorage === "undefined") return null;
+  const stored = sessionStorage.getItem(keyProviderStorageKey(factoryId));
+  if (stored && AGENT_PROVIDER_IDS.includes(stored as AgentProviderId)) {
+    return stored as AgentProviderId;
+  }
+  return null;
+}
+
+function writeStoredKeyProvider(factoryId: string | undefined, keyProvider: AgentProviderId | null): void {
+  if (typeof sessionStorage === "undefined") return;
+  const key = keyProviderStorageKey(factoryId);
+  if (keyProvider) {
+    sessionStorage.setItem(key, keyProvider);
+    return;
+  }
+  sessionStorage.removeItem(key);
+}
 
 export type OnboardingSetupState = {
   workspaceName: string;
@@ -20,6 +45,7 @@ export type OnboardingSetupState = {
   issuesDiscovered: boolean;
   issuesChoice: IssuesChoiceId | null;
   agent: AgentHarnessId | null;
+  keyProvider: AgentProviderId | null;
   finished: boolean;
 };
 
@@ -43,12 +69,13 @@ function setupReadiness(input: {
   connected: Set<IntegrationId>;
   issuesChoice: IssuesChoiceId | null;
   remainingCreditCents: number;
+  keyProvider: AgentProviderId | null;
 }) {
   const nameReady = input.workspaceName.trim().length > 0;
   const vcsReady = input.vcsHost !== null && input.connected.has(input.vcsHost);
   const repoReady = vcsReady && input.selectedRepo !== null;
   const issuesReady = isIssuesReady(input.issuesChoice, input.connected);
-  const agentReady = isAgentStepReady(input.connected, input.remainingCreditCents);
+  const agentReady = isAgentStepReady(input.connected, input.remainingCreditCents, input.keyProvider);
   return {
     nameReady,
     vcsReady,
@@ -65,6 +92,7 @@ export function useOnboardingSetupState(
     connected?: Set<IntegrationId>;
     remainingCreditCents?: number;
     simulateDiscovery?: boolean;
+    factoryId?: string;
   },
 ) {
   const [workspaceName, setWorkspaceName] = useState(() => initialName.trim());
@@ -86,6 +114,16 @@ export function useOnboardingSetupState(
   /** True after Continue to coding agent — starts backlog analysis. */
   const [issuesCommitted, setIssuesCommitted] = useState(false);
   const [agent, setAgent] = useState<AgentHarnessId | null>(null);
+  const [keyProvider, setKeyProviderState] = useState<AgentProviderId | null>(() =>
+    readStoredKeyProvider(options?.factoryId),
+  );
+  const setKeyProvider = useCallback(
+    (next: AgentProviderId | null) => {
+      writeStoredKeyProvider(options?.factoryId, next);
+      setKeyProviderState(next);
+    },
+    [options?.factoryId],
+  );
   const [finished, setFinished] = useState(false);
   const discoveryTimerRef = useRef<number | null>(null);
   const connected = options?.connected ?? localConnected;
@@ -205,6 +243,7 @@ export function useOnboardingSetupState(
     connected,
     issuesChoice,
     remainingCreditCents: options?.remainingCreditCents ?? 0,
+    keyProvider,
   });
 
   const summary = useMemo(
@@ -243,6 +282,8 @@ export function useOnboardingSetupState(
     commitIssuesStep,
     agent,
     setAgent,
+    keyProvider,
+    setKeyProvider,
     finished,
     setFinished,
     issueCount,

--- a/web_src/src/pages/home/factories/index.ts
+++ b/web_src/src/pages/home/factories/index.ts
@@ -89,7 +89,7 @@ function buildLineApp(args: {
 }): FactoryDefinition {
   return buildOnboardingApp({
     ...args,
-    integrations: ["github", "claude"],
+    integrations: ["github"],
     componentIntegrations: LINE_APP_COMPONENT_INTEGRATIONS,
     consoleYaml: lineAppConsoleYaml,
   });

--- a/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
@@ -131,14 +131,12 @@ spec:
     - id: implementation-agent
       name: Agent - Implement from GH issue
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       concurrency:
         max: 5
       configuration:
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
         environmentFrom:
           - source: integration
             integration:
@@ -158,7 +156,7 @@ spec:
             valueSource: literal
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
-        model: sonnet
+        model: anthropic/claude-sonnet-4-6
         steps:
           - name: Set Up Git User
             type: bash
@@ -234,14 +232,12 @@ spec:
     - id: implementation-agent-no-issue
       name: Agent - Implement from order description
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       concurrency:
         max: 5
       configuration:
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
         environmentFrom:
           - source: integration
             integration:
@@ -261,7 +257,7 @@ spec:
             valueSource: literal
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
-        model: sonnet
+        model: anthropic/claude-sonnet-4-6
         steps:
           - name: Set Up Git User
             type: bash

--- a/web_src/src/pages/home/factories/line-apps/planning.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/planning.canvas.yaml
@@ -74,14 +74,12 @@ spec:
     - id: planner-agent
       name: Agent - Plan for GH Issue
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       concurrency:
         max: 5
       configuration:
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
         environmentFrom:
           - source: integration
             integration:
@@ -92,7 +90,7 @@ spec:
             valueSource: literal
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
-        model: sonnet
+        model: anthropic/claude-sonnet-4-6
         steps:
           - name: Clone Repo
             type: bash
@@ -134,14 +132,12 @@ spec:
     - id: planner-agent-no-issue
       name: Agent - No GH Issue Plan
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       concurrency:
         max: 5
       configuration:
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
         environmentFrom:
           - source: integration
             integration:
@@ -155,7 +151,7 @@ spec:
             valueSource: literal
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
-        model: sonnet
+        model: anthropic/claude-sonnet-4-6
         steps:
           - name: Clone Repo
             type: bash

--- a/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
@@ -46,14 +46,12 @@ spec:
     - id: generate-pr-text
       name: Generate PR title and description
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       concurrency:
         max: 5
       configuration:
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
         environmentFrom:
           - source: integration
             integration:
@@ -73,6 +71,7 @@ spec:
             valueSource: literal
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
+        model: anthropic/claude-sonnet-4-6
         steps:
           - name: Inject Plan
             type: bash

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -54,8 +54,10 @@ describe("setup factory line apps", () => {
   it("materializes repositories and integration wiring, leaving no template placeholders", () => {
     for (const app of ONBOARDING_LINE_APPS) {
       const canvasYaml = materializeOnboardingApp(app.factoryId);
-      expect(canvasYaml).toContain("name: acme-claude");
+      expect(canvasYaml).toContain("runnerOpenRouter");
+      expect(canvasYaml).toContain("source: hosted");
       expect(canvasYaml).toContain("name: acme-github");
+      expect(canvasYaml).not.toContain("name: acme-claude");
       expect(canvasYaml).not.toContain("{{ install_params.");
       expect(canvasYaml).not.toContain(FACTORY_CANVAS_ID_PLACEHOLDER);
       // No org-specific bindings copied from the production canvases.

--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
@@ -120,7 +120,7 @@ spec:
     expect(canvasYaml).toContain("app: canvas-123");
     expect(canvasYaml).not.toContain(FACTORY_CANVAS_ID_PLACEHOLDER);
     expect(canvasYaml).not.toContain("{{ install_params.");
-    expect(definition.integrations).toEqual(["github", "claude"]);
+    expect(definition.integrations).toEqual(["github"]);
   });
 
   it("routes issue work to backlog and branch/PR/CI work to app repositories", () => {
@@ -178,17 +178,19 @@ spec:
     expect(steps["Commit and push"]?.workingDirectory).toBe("repo");
   });
 
-  it("materializes runners with integration-sourced credentials", () => {
+  it("materializes runners with SuperPlane-hosted OpenRouter credentials", () => {
     const canvasYaml = materializeSoftwareFactory();
 
-    expect(canvasYaml).toContain("runnerClaudeCode");
+    expect(canvasYaml).toContain("runnerOpenRouter");
     expect(canvasYaml).toContain("@superplaneagent");
     expect(canvasYaml).toContain('name == "factory"');
     expect(canvasYaml).toContain("REPLACE ME WITH");
-    expect(canvasYaml).toContain("source: integration");
+    expect(canvasYaml).toContain("source: hosted");
     expect(canvasYaml).toContain("environmentFrom:");
-    expect(canvasYaml).toContain("name: acme-claude");
     expect(canvasYaml).toContain("name: acme-github");
+    expect(canvasYaml).toContain("model: anthropic/claude-sonnet-4-6");
+    expect(canvasYaml).not.toContain("runnerClaudeCode");
+    expect(canvasYaml).not.toContain("name: acme-claude");
     expect(canvasYaml).not.toContain("anthropicApiKey");
     expect(canvasYaml).not.toContain("install_params.anthropic_api_key");
     expect(canvasYaml).not.toContain("install_params.github_token");
@@ -218,7 +220,7 @@ spec:
     expect(definition.installParams.map((param) => param.name)).toEqual(["appRepository", "backlogRepository"]);
   });
 
-  it("rewrites Claude Code credentials to hosted when Claude is not connected", () => {
+  it("keeps hosted OpenRouter on the default SuperPlane agent rewrite", () => {
     const canvasYaml = materializeFactoryCanvas({
       definition: getFactoryDefinition("line-implementation"),
       canvasName: "Implementation",
@@ -228,19 +230,19 @@ spec:
         github: { id: "int-1", name: "acme-github", ready: true },
       },
       agentRewrite: {
-        component: "runnerClaudeCode",
-        model: "claude-sonnet-4-6",
+        component: "runnerOpenRouter",
+        model: "anthropic/claude-sonnet-4-6",
         credentials: { source: "hosted" },
       },
     });
 
-    expect(canvasYaml).toMatch(/component: runnerClaudeCode[\s\S]*credentials:[\s\S]*source: hosted/);
-    expect(canvasYaml).toContain("model: claude-sonnet-4-6");
+    expect(canvasYaml).toMatch(/component: runnerOpenRouter[\s\S]*credentials:[\s\S]*source: hosted/);
+    expect(canvasYaml).toContain("model: anthropic/claude-sonnet-4-6");
+    expect(canvasYaml).not.toContain("runnerClaudeCode");
     expect(canvasYaml).not.toMatch(/credentials:[\s\S]*source: integration[\s\S]*name: claude/);
-    expect(canvasYaml).not.toContain("model: sonnet");
   });
 
-  it("rewrites Claude Code nodes to hosted OpenRouter with an allowlisted model", () => {
+  it("rewrites SuperPlane agent nodes to hosted OpenRouter with an allowlisted model", () => {
     const canvasYaml = materializeFactoryCanvas({
       definition: getFactoryDefinition("line-planning"),
       canvasName: "Planning",
@@ -261,7 +263,28 @@ spec:
     expect(canvasYaml).not.toContain("runnerClaudeCode");
   });
 
-  it("rewrites Claude Code nodes to an OpenRouter integration", () => {
+  it("rewrites SuperPlane agent nodes to a Claude Code installation", () => {
+    const canvasYaml = materializeFactoryCanvas({
+      definition: getFactoryDefinition("line-planning"),
+      canvasName: "Planning",
+      canvasId: "canvas-claude-byok",
+      installParams: { appRepository: "acme/app", backlogRepository: "acme/backlog" },
+      integrations: {
+        github: { id: "int-1", name: "acme-github", ready: true },
+        claude: { id: "int-2", name: "acme-claude", ready: true },
+      },
+      agentRewrite: {
+        component: "runnerClaudeCode",
+        model: "sonnet",
+        credentials: { source: "integration", name: "acme-claude" },
+      },
+    });
+
+    expect(canvasYaml).toMatch(/component: runnerClaudeCode[\s\S]*credentials:[\s\S]*name: acme-claude/);
+    expect(canvasYaml).not.toContain("runnerOpenRouter");
+  });
+
+  it("rewrites SuperPlane agent nodes to an OpenRouter integration", () => {
     const canvasYaml = materializeFactoryCanvas({
       definition: getFactoryDefinition("line-pr"),
       canvasName: "Verify",

--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.ts
@@ -106,7 +106,7 @@ export function wireFactoryIntegrations(
   return yaml.dump(doc, { lineWidth: -1, noRefs: true });
 }
 
-const CLAUDE_CODE_COMPONENT = "runnerClaudeCode";
+const ONBOARDING_AGENT_COMPONENTS = new Set(["runnerClaudeCode", "runnerCodex", "runnerOpenRouter"]);
 
 export type FactoryAgentRewrite = {
   component: string;
@@ -116,7 +116,7 @@ export type FactoryAgentRewrite = {
 
 function rewriteOnboardingAgentNodes(doc: YamlCanvas, rewrite: FactoryAgentRewrite): void {
   for (const node of doc.spec?.nodes ?? []) {
-    if (node.component !== CLAUDE_CODE_COMPONENT) continue;
+    if (typeof node.component !== "string" || !ONBOARDING_AGENT_COMPONENTS.has(node.component)) continue;
     node.component = rewrite.component;
     const configuration = node.configuration;
     if (!configuration || typeof configuration !== "object") continue;

--- a/web_src/src/pages/home/factories/software-factory/canvas.yaml
+++ b/web_src/src/pages/home/factories/software-factory/canvas.yaml
@@ -145,7 +145,7 @@ spec:
     - id: apply-user-request-claude
       name: Apply user request
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       configuration:
         environmentFrom:
           - source: integration
@@ -222,9 +222,8 @@ spec:
             type: bash
             workingDirectory: repo
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
+        model: anthropic/claude-sonnet-4-6
       position:
         x: 672
         'y': 816
@@ -361,7 +360,7 @@ spec:
     - id: implementation-implementation-2-ilbopr
       name: Write Plan
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       configuration:
         environmentFrom:
           - source: integration
@@ -429,9 +428,8 @@ spec:
             name: Update PR description
             type: bash
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
+        model: anthropic/claude-sonnet-4-6
       position:
         x: 2304
         'y': 0
@@ -491,7 +489,7 @@ spec:
     - id: run-claude-code-implementation
       name: Implementation
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       configuration:
         environmentFrom:
           - source: integration
@@ -572,9 +570,8 @@ spec:
             type: bash
             workingDirectory: repo
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
+        model: anthropic/claude-sonnet-4-6
       position:
         x: 3000
         'y': 0
@@ -642,7 +639,7 @@ spec:
     - id: fix-ci-claude
       name: Review & Fix PR Checks
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       configuration:
         environmentFrom:
           - source: integration
@@ -723,9 +720,8 @@ spec:
             type: bash
             workingDirectory: repo
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
+        model: anthropic/claude-sonnet-4-6
       position:
         x: 1920
         'y': 2688
@@ -1227,7 +1223,7 @@ spec:
     - id: analyze-create-issue
       name: Draft Issue
       type: TYPE_ACTION
-      component: runnerClaudeCode
+      component: runnerOpenRouter
       configuration:
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
@@ -1296,9 +1292,8 @@ spec:
             value: '{{ install_params.appRepository }}'
             valueSource: literal
         credentials:
-          source: integration
-          integration:
-            name: claude
+          source: hosted
+        model: anthropic/claude-sonnet-4-6
       position:
         x: 672
         'y': 4200

--- a/web_src/src/pages/home/factories/software-factory/factory.json
+++ b/web_src/src/pages/home/factories/software-factory/factory.json
@@ -2,7 +2,7 @@
   "id": "software-factory",
   "title": "Software Factory",
   "description": "Automate coding work with agents, from issue to pull request.",
-  "integrations": ["github", "claude"],
+  "integrations": ["github"],
   "componentIntegrations": {
     "github.addIssueLabel": "github",
     "github.createIssue": "github",


### PR DESCRIPTION
## Summary

New workspace setup asked users to connect a provider key. The product default is SuperPlane agent. The setup UI must not name OpenRouter on that path.

This change authors new canvases with SuperPlane-hosted credentials. A user can still expand Use your own key and connect Claude, OpenAI, or OpenRouter. A connected key does not take the default. Existing workspaces do not change.


Made with [Cursor](https://cursor.com)