### PR TITLE
fix: Evaluate all workflows when polling a pipeline

### DIFF
--- a/pkg/integrations/circleci/run_pipeline.go
+++ b/pkg/integrations/circleci/run_pipeline.go
@@ -483,15 +483,15 @@ func (t *RunPipeline) poll(ctx core.ActionHookContext) error {
 		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, PollInterval)
 	}
 
-	firstWorkflow := workflows[0]
+	outcome := t.evaluateWorkflows(workflows)
 
-	if t.isRunning(firstWorkflow.Status) {
+	if outcome == pipelineRunning {
 		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, PollInterval)
 	}
 
 	payload := map[string]any{"pipeline": metadata.Pipeline}
 	channel := SuccessOutputChannel
-	if t.isFailed(firstWorkflow.Status) {
+	if outcome == pipelineFailed {
 		channel = FailedOutputChannel
 	}
 
@@ -529,6 +529,40 @@ func IsValidLocation(location string) bool {
 
 func (t *RunPipeline) Cleanup(ctx core.SetupContext) error {
 	return nil
+}
+
+// pipelineOutcome is the aggregate result of all workflows in a pipeline.
+type pipelineOutcome int
+
+const (
+	pipelineRunning pipelineOutcome = iota
+	pipelineSucceeded
+	pipelineFailed
+)
+
+// evaluateWorkflows reduces all workflows in a pipeline to one result.
+//
+// A CircleCI pipeline can contain more than one workflow. The pipeline is
+// complete only when all of its workflows are complete. The pipeline fails
+// if any one of its workflows fails.
+func (t *RunPipeline) evaluateWorkflows(workflows []WorkflowResponse) pipelineOutcome {
+	failed := false
+
+	for _, workflow := range workflows {
+		if t.isRunning(workflow.Status) {
+			return pipelineRunning
+		}
+
+		if t.isFailed(workflow.Status) {
+			failed = true
+		}
+	}
+
+	if failed {
+		return pipelineFailed
+	}
+
+	return pipelineSucceeded
 }
 
 func (t *RunPipeline) isFailed(workflowStatus string) bool {

--- a/pkg/integrations/circleci/run_pipeline_test.go
+++ b/pkg/integrations/circleci/run_pipeline_test.go
@@ -21,3 +21,63 @@ func Test__RunPipeline__buildParameters(t *testing.T) {
 		assert.Len(t, result, 2)
 	})
 }
+
+func Test__RunPipeline__evaluateWorkflows(t *testing.T) {
+	tp := &RunPipeline{}
+
+	workflows := func(statuses ...string) []WorkflowResponse {
+		result := make([]WorkflowResponse, 0, len(statuses))
+		for _, status := range statuses {
+			result = append(result, WorkflowResponse{Status: status})
+		}
+
+		return result
+	}
+
+	t.Run("single successful workflow succeeds", func(t *testing.T) {
+		assert.Equal(t, pipelineSucceeded, tp.evaluateWorkflows(workflows("success")))
+	})
+
+	t.Run("single failed workflow fails", func(t *testing.T) {
+		assert.Equal(t, pipelineFailed, tp.evaluateWorkflows(workflows("failed")))
+	})
+
+	t.Run("all workflows successful succeeds", func(t *testing.T) {
+		assert.Equal(t, pipelineSucceeded, tp.evaluateWorkflows(workflows("success", "success", "success")))
+	})
+
+	// The defect in #6925: workflows[0] succeeded, so the pipeline was reported
+	// on the success channel even though a later workflow failed.
+	t.Run("later workflow failing fails the pipeline", func(t *testing.T) {
+		assert.Equal(t, pipelineFailed, tp.evaluateWorkflows(workflows("success", "failed")))
+	})
+
+	t.Run("failure anywhere fails the pipeline", func(t *testing.T) {
+		assert.Equal(t, pipelineFailed, tp.evaluateWorkflows(workflows("success", "success", "canceled")))
+		assert.Equal(t, pipelineFailed, tp.evaluateWorkflows(workflows("failed", "success")))
+	})
+
+	// The second half of #6925: workflows[0] reached a final status, so a result
+	// was emitted while another workflow was still running.
+	t.Run("later workflow still running keeps polling", func(t *testing.T) {
+		assert.Equal(t, pipelineRunning, tp.evaluateWorkflows(workflows("success", "running")))
+	})
+
+	t.Run("running takes precedence over an earlier failure", func(t *testing.T) {
+		assert.Equal(t, pipelineRunning, tp.evaluateWorkflows(workflows("failed", "running")))
+	})
+
+	t.Run("on_hold is not final", func(t *testing.T) {
+		assert.Equal(t, pipelineRunning, tp.evaluateWorkflows(workflows("success", "on_hold")))
+	})
+
+	t.Run("every failure status is treated as a failure", func(t *testing.T) {
+		for _, status := range []string{"failed", "canceled", "error", "failing", "unauthorized"} {
+			assert.Equal(t, pipelineFailed, tp.evaluateWorkflows(workflows("success", status)), status)
+		}
+	})
+
+	t.Run("no workflows is not a failure", func(t *testing.T) {
+		assert.Equal(t, pipelineSucceeded, tp.evaluateWorkflows(workflows()))
+	})
+}


### PR DESCRIPTION
## Summary

A CircleCI pipeline can contain more than one workflow. The `circleci.runPipeline` poll handler used only `workflows[0]` to decide the result of the pipeline.

This caused two failures. A pipeline whose first workflow passed and whose second workflow failed was emitted on the **success** channel. A result was also emitted before the pipeline was complete, because a final status on the first workflow ended the poll while other workflows still ran.

A pipeline is now complete only when all of its workflows are complete. A pipeline fails if any one of its workflows fails.

The decision is now a pure function, `evaluateWorkflows`, so it is tested without HTTP mocks.

## Test plan

- [x] Run `go test ./pkg/integrations/circleci/...`. All tests pass.
- [x] Confirm a pipeline with `[success, failed]` gives the failed outcome.
- [x] Confirm a pipeline with `[success, running]` continues to poll.
- [x] Confirm a pipeline with `[failed, running]` continues to poll.
- [x] Confirm each failure status (`failed`, `canceled`, `error`, `failing`, `unauthorized`) fails the pipeline.
- [x] Confirm single-workflow pipelines keep their current behaviour.
- [ ] Run a real multi-workflow pipeline where a later workflow fails, and confirm the failed channel receives it.

## Out of scope

`isRunning` treats CircleCI's `not_run` status as still running. `not_run` is a terminal status, given to a workflow that was filtered out and never ran. With the previous `workflows[0]` logic this was rarely reached. With an aggregate over all workflows, a pipeline that contains a filtered-out workflow can now poll until it times out.

I did not change this, because it changes behaviour beyond the reported defect. Tell me if you want it in this PR or in a separate one.

Resolves #6925
