### PR TITLE
feat: Align onboarding automations with Plan line

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/builder.go
+++ b/pkg/grpc/actions/canvases/changesets/builder.go
@@ -204,6 +204,7 @@ func changeNodeRefForAdd(proposedNode models.Node) (*ChangeNode, error) {
 		Name:        proposedNode.Name,
 		Block:       blockNameFromNode(proposedNode),
 		IsCollapsed: proto.Bool(proposedNode.IsCollapsed),
+		Concurrency: proposedNode.Concurrency,
 		Position: &componentpb.Position{
 			X: int32(proposedNode.Position.X),
 			Y: int32(proposedNode.Position.Y),

--- a/pkg/grpc/actions/canvases/changesets/canvas_patcher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_patcher.go
@@ -158,8 +158,9 @@ func (p *CanvasPatcher) addNode(change *Change) error {
 	}
 
 	newNode := models.Node{
-		ID:   nodeID,
-		Name: node.Name,
+		ID:          nodeID,
+		Name:        node.Name,
+		Concurrency: node.Concurrency,
 	}
 	if node.IsCollapsed != nil {
 		newNode.IsCollapsed = *node.IsCollapsed

--- a/pkg/grpc/actions/canvases/changesets/canvas_patcher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_patcher_test.go
@@ -562,6 +562,29 @@ func Test__CanvasPatcher(t *testing.T) {
 		steps.assertNodeCollapsed("node-a", false)
 	})
 
+	t.Run("add node -> keeps the concurrency spec of the change", func(t *testing.T) {
+		steps := &CanvasPatcherSteps{t: t, registry: r.Registry}
+		steps.givenCanvasVersion(nil, nil)
+
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
+				{
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:            "node-a",
+						Name:          "Node A",
+						Block:         "if",
+						Configuration: structFromMap(t, map[string]any{"expression": "true"}),
+						Concurrency:   concurrencyMax(100),
+					},
+				},
+			},
+		})
+
+		steps.assertNoError()
+		steps.assertNodeConcurrencyMax("node-a", 100)
+	})
+
 	t.Run("update node -> invalid configuration sets node error without returning error", func(t *testing.T) {
 		steps := &CanvasPatcherSteps{t: t, registry: r.Registry}
 		steps.givenCanvasVersion(
@@ -1070,6 +1093,15 @@ func (s *CanvasPatcherSteps) assertNodeCollapsed(nodeID string, expected bool) {
 	require.Equal(s.t, expected, s.finalVersion.Nodes[i].IsCollapsed)
 }
 
+func (s *CanvasPatcherSteps) assertNodeConcurrencyMax(nodeID string, expected int) {
+	i := slices.IndexFunc(s.finalVersion.Nodes, func(node models.Node) bool {
+		return node.ID == nodeID
+	})
+
+	require.True(s.t, i != -1, "expected node %s", nodeID)
+	require.Equal(s.t, expected, s.finalVersion.Nodes[i].Concurrency.EffectiveMax())
+}
+
 func (s *CanvasPatcherSteps) assertNodeErrorContains(nodeID string, text string) {
 	i := slices.IndexFunc(s.finalVersion.Nodes, func(node models.Node) bool {
 		return node.ID == nodeID
@@ -1145,6 +1177,10 @@ func (s *CanvasPatcherSteps) assertEdgeOrder(edges []models.Edge) {
 
 func (s *CanvasPatcherSteps) assertGraphIsValid() {
 	require.NoError(s.t, CheckForCycles(s.finalVersion.Nodes, s.finalVersion.Edges))
+}
+
+func concurrencyMax(max int) *models.ConcurrencySpec {
+	return &models.ConcurrencySpec{Max: &max}
 }
 
 func structFromMap(t *testing.T, value map[string]any) *structpb.Struct {

--- a/pkg/grpc/actions/canvases/changesets/changeset.go
+++ b/pkg/grpc/actions/canvases/changesets/changeset.go
@@ -1,6 +1,7 @@
 package changesets
 
 import (
+	"github.com/superplanehq/superplane/pkg/models"
 	componentpb "github.com/superplanehq/superplane/pkg/protos/components"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -51,6 +52,10 @@ type ChangeNode struct {
 	IntegrationID string
 	Position      *componentpb.Position
 	IsCollapsed   *bool
+
+	// Concurrency is the node's inline concurrency spec. Nil leaves the node
+	// with the default of one execution at a time.
+	Concurrency *models.ConcurrencySpec
 }
 
 type ChangeEdge struct {

--- a/pkg/grpc/actions/factories/factory_intake_test.go
+++ b/pkg/grpc/actions/factories/factory_intake_test.go
@@ -122,6 +122,28 @@ func Test__FactoryIntakeActions(t *testing.T) {
 		assert.Equal(t, "integration", credentials["source"])
 	})
 
+	t.Run("an intake analyzes a batch of items in parallel", func(t *testing.T) {
+		factory := newFactory(t)
+		intake := create(t, factory, &pb.CreateFactoryIntakeRequest{Source: pb.FactoryIntake_SOURCE_GITHUB_ISSUES})
+
+		// A node without a concurrency spec runs one execution at a time, so a
+		// seeded batch would take as long as the sum of its analyses. Both the
+		// canvas version and the node record have to carry the spec: the
+		// scheduler reads the record.
+		canvasID := uuid.MustParse(intake.GetCanvasId())
+		for _, node := range liveIntakeNodes(t, r.Organization.ID, intake) {
+			if node.ID == intakeTriggerNodeID {
+				continue
+			}
+
+			assert.Equalf(t, intakeConcurrencyMax, node.Concurrency.EffectiveMax(), "version node %s", node.ID)
+
+			stored, err := models.FindCanvasNode(database.DB(t.Context()), canvasID, node.ID)
+			require.NoError(t, err)
+			assert.Equalf(t, intakeConcurrencyMax, stored.ConcurrencySpec().EffectiveMax(), "node record %s", node.ID)
+		}
+	})
+
 	t.Run("a source can have several intakes", func(t *testing.T) {
 		factory := newFactory(t)
 		first := create(t, factory, &pb.CreateFactoryIntakeRequest{Source: pb.FactoryIntake_SOURCE_GITHUB_ISSUES})

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
@@ -40,7 +40,7 @@ describe("provisionLine", () => {
     expect(installFactory).not.toHaveBeenCalled();
   });
 
-  it("creates the plan-and-implement line when none exists", async () => {
+  it("installs all workspace apps and creates a line with plan and implement", async () => {
     const createLine = vi.fn().mockResolvedValue({ id: "line-new" });
     const updateOnboarding = vi.fn().mockResolvedValue({});
     const installFactory = vi.fn().mockImplementation(async ({ factoryId }: { factoryId: string }) => ({
@@ -58,11 +58,24 @@ describe("provisionLine", () => {
       updateOnboarding,
     });
 
-    expect(createLine).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: DEFAULT_LINE_NAME,
-      }),
-    );
+    expect(installFactory.mock.calls.map(([input]) => input.factoryId)).toEqual([
+      "line-planning",
+      "line-implementation",
+      "line-pr",
+    ]);
+    expect(createLine).toHaveBeenCalledWith({
+      name: DEFAULT_LINE_NAME,
+      steps: [
+        {
+          type: "runApp",
+          app: { app: "canvas-line-planning", entrypoint: "onrun-create-plan" },
+        },
+        {
+          type: "runApp",
+          app: { app: "canvas-line-implementation", entrypoint: "onrun-implement" },
+        },
+      ],
+    });
     expect(result.lineId).toBe("line-new");
     expect(updateOnboarding).toHaveBeenCalledWith({
       provisionedAppId: result.primaryAppId,

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.spec.ts
@@ -40,7 +40,7 @@ describe("provisionLine", () => {
     expect(installFactory).not.toHaveBeenCalled();
   });
 
-  it("installs all workspace apps and creates a line with plan and implement", async () => {
+  it("installs plan and implement, and creates a line that runs both", async () => {
     const createLine = vi.fn().mockResolvedValue({ id: "line-new" });
     const updateOnboarding = vi.fn().mockResolvedValue({});
     const installFactory = vi.fn().mockImplementation(async ({ factoryId }: { factoryId: string }) => ({
@@ -61,7 +61,6 @@ describe("provisionLine", () => {
     expect(installFactory.mock.calls.map(([input]) => input.factoryId)).toEqual([
       "line-planning",
       "line-implementation",
-      "line-pr",
     ]);
     expect(createLine).toHaveBeenCalledWith({
       name: DEFAULT_LINE_NAME,

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
@@ -7,14 +7,14 @@ import type {
   FactoryLineStep,
 } from "@/api-client";
 import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
-import { ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS, type FactoryAgentRewrite } from "@/pages/home/factories";
+import { ONBOARDING_APPS, ONBOARDING_EVENT_APPS, type FactoryAgentRewrite } from "@/pages/home/factories";
 import type { InstallFactoryInput } from "@/pages/home/useInstallFactory";
 
 export const DEFAULT_LINE_NAME = "plan-and-implement";
 
 export const GITHUB_INTAKE_SOURCE: FactoriesFactoryIntakeSource = "SOURCE_GITHUB_ISSUES";
 
-const PRIMARY_LINE_APP_ENTRYPOINT = ONBOARDING_LINE_APPS[0].entrypointNodeId;
+const PRIMARY_LINE_APP_ENTRYPOINT = ONBOARDING_APPS[0].entrypointNodeId;
 
 export type InstallOnboardingApp = (
   input: InstallFactoryInput,
@@ -62,7 +62,8 @@ async function installOnboardingApp(args: {
   return installed;
 }
 
-// Install each bundled app in order and return the line steps that call them.
+// Install each bundled workspace app in order. Only apps marked for the line
+// become steps; the other apps remain available as standalone automations.
 // installFactory clears its pending-canvas ref after each success, so the
 // sequential calls create distinct canvases.
 async function provisionLineApps(args: {
@@ -74,7 +75,7 @@ async function provisionLineApps(args: {
   installFactory: InstallOnboardingApp;
 }): Promise<FactoryLineStep[]> {
   const steps: FactoryLineStep[] = [];
-  for (const app of ONBOARDING_LINE_APPS) {
+  for (const app of ONBOARDING_APPS) {
     const installed = await installOnboardingApp({
       factoryId: args.factoryId,
       appFactoryId: app.factoryId,
@@ -84,6 +85,9 @@ async function provisionLineApps(args: {
       agentRewrite: args.agentRewrite,
       installFactory: args.installFactory,
     });
+    if (!app.runsOnLine) {
+      continue;
+    }
     steps.push({
       type: "runApp",
       app: { app: installed.canvasId, entrypoint: app.entrypointNodeId },

--- a/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingProvision.ts
@@ -7,14 +7,14 @@ import type {
   FactoryLineStep,
 } from "@/api-client";
 import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
-import { ONBOARDING_APPS, ONBOARDING_EVENT_APPS, type FactoryAgentRewrite } from "@/pages/home/factories";
+import { ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS, type FactoryAgentRewrite } from "@/pages/home/factories";
 import type { InstallFactoryInput } from "@/pages/home/useInstallFactory";
 
 export const DEFAULT_LINE_NAME = "plan-and-implement";
 
 export const GITHUB_INTAKE_SOURCE: FactoriesFactoryIntakeSource = "SOURCE_GITHUB_ISSUES";
 
-const PRIMARY_LINE_APP_ENTRYPOINT = ONBOARDING_APPS[0].entrypointNodeId;
+const PRIMARY_LINE_APP_ENTRYPOINT = ONBOARDING_LINE_APPS[0].entrypointNodeId;
 
 export type InstallOnboardingApp = (
   input: InstallFactoryInput,
@@ -62,8 +62,7 @@ async function installOnboardingApp(args: {
   return installed;
 }
 
-// Install each bundled workspace app in order. Only apps marked for the line
-// become steps; the other apps remain available as standalone automations.
+// Install each bundled app in order and return the line steps that call them.
 // installFactory clears its pending-canvas ref after each success, so the
 // sequential calls create distinct canvases.
 async function provisionLineApps(args: {
@@ -75,7 +74,7 @@ async function provisionLineApps(args: {
   installFactory: InstallOnboardingApp;
 }): Promise<FactoryLineStep[]> {
   const steps: FactoryLineStep[] = [];
-  for (const app of ONBOARDING_APPS) {
+  for (const app of ONBOARDING_LINE_APPS) {
     const installed = await installOnboardingApp({
       factoryId: args.factoryId,
       appFactoryId: app.factoryId,
@@ -85,9 +84,6 @@ async function provisionLineApps(args: {
       agentRewrite: args.agentRewrite,
       installFactory: args.installFactory,
     });
-    if (!app.runsOnLine) {
-      continue;
-    }
     steps.push({
       type: "runApp",
       app: { app: installed.canvasId, entrypoint: app.entrypointNodeId },

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -749,7 +749,7 @@ describe("WorkOrderSplitRunPopup", () => {
     );
     expect(within(screen.getByTestId("split-run-stream-plan")).queryByText("Clone Repo")).not.toBeInTheDocument();
 
-    await user.click(within(screen.getByTestId("split-run-stream-plan")).getByText("Agent - Plan for GH Issue"));
+    await user.click(within(screen.getByTestId("split-run-stream-plan")).getByText("Agent - No GH Issue Plan"));
     const planStream = screen.getByTestId("split-run-stream-plan");
     expect(within(planStream).getByText("Clone Repo")).toBeInTheDocument();
     expect(within(planStream).getAllByText("✓").length).toBeGreaterThan(0);

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunCanvases.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunCanvases.spec.ts
@@ -80,15 +80,13 @@ describe("splitRunCanvasForPhase", () => {
     const canvas = splitRunCanvasForPhase(implement!);
     expect(canvas.title).toBe("Implement");
     expect(canvas.nodes.map((node) => node.name)).toContain("Create Branch");
-    expect(canvas.nodes.map((node) => node.name)).toContain("From GH issue?");
+    expect(canvas.nodes.map((node) => node.name)).toContain("Agent - Implement from order description");
     expect(canvas.nodes.map((node) => node.name)).toContain("Create Draft Pull Request");
     expect(canvas.nodes.map((node) => node.name)).toContain("Attach PR to Work Order");
     expect(canvas.statuses["create-branch"]).toBe("passed");
-    expect(canvas.statuses["implementation-agent"]).toBe("running");
-    expect(canvas.statuses["implementation-agent-no-issue"]).toBe("did_not_run");
+    expect(canvas.statuses["implementation-agent-no-issue"]).toBe("running");
     expect(canvas.statuses["create-draft-pr"]).toBe("did_not_run");
     expect(canvas.statuses["attach-pr-artifact"]).toBe("did_not_run");
-    expect(canvas.statuses["add-run-error"]).toBe("did_not_run");
   });
 
   it("opens a draft pull request after a finished implement run", () => {
@@ -103,10 +101,9 @@ describe("splitRunCanvasForPhase", () => {
       canvasSteps: [],
     });
 
-    expect(canvas.statuses["implementation-agent"]).toBe("passed");
+    expect(canvas.statuses["implementation-agent-no-issue"]).toBe("passed");
     expect(canvas.statuses["create-draft-pr"]).toBe("passed");
     expect(canvas.statuses["attach-pr-artifact"]).toBe("passed");
-    expect(canvas.statuses["add-run-error"]).toBe("did_not_run");
 
     const stream = richStreamForCanvas(canvas);
     expect(stream.find((line) => line.id === "create-draft-pr")).toMatchObject({
@@ -124,8 +121,8 @@ describe("splitRunCanvasForPhase", () => {
     const canvas = splitRunCanvasForPhase(plan!);
     expect(canvas.title).toBe("Plan");
     expect(canvas.statuses["onrun-create-plan"]).toBe("triggered");
-    expect(canvas.statuses["planner-agent"]).toBe("passed");
-    expect(canvas.statuses["planner-agent-no-issue"]).toBe("did_not_run");
+    expect(canvas.statuses["planner-agent-no-issue"]).toBe("passed");
+    expect(canvas.statuses["add-plan-artifact"]).toBe("passed");
   });
 
   it("writes one log line per canvas node and extra Claude Code notes", () => {
@@ -260,15 +257,15 @@ describe("splitRunCanvasForPhase", () => {
       canvasSteps: [],
     });
     const stream = richStreamForCanvas(canvas);
-    expect(stream.find((line) => line.id === "add-factory-label")).toMatchObject({
-      componentType: "github.addIssueLabel",
-      componentName: "Add Factory Label",
+    expect(stream.find((line) => line.id === "add-plan-artifact")).toMatchObject({
+      componentType: "Add Work Order Artifact",
+      componentName: "Add Plan Artifact",
     });
-    expect(stream.find((line) => line.id === "planner-agent")).toMatchObject({
+    expect(stream.find((line) => line.id === "planner-agent-no-issue")).toMatchObject({
       componentType: "Run Claude Code",
-      componentName: "Agent - Plan for GH Issue",
+      componentName: "Agent - No GH Issue Plan",
     });
-    const plannerNotes = stream.filter((line) => line.nodeId === "planner-agent" && line.note);
+    const plannerNotes = stream.filter((line) => line.nodeId === "planner-agent-no-issue" && line.note);
     expect(
       plannerNotes
         .filter((line) => !line.noteParentId)
@@ -299,11 +296,6 @@ describe("splitRunCanvasForPhase", () => {
       plannerNotes.some((line) => line.componentName.includes("LineListCard.tsx") && line.componentType === "read"),
     ).toBe(true);
     expect(plannerNotes.some((line) => line.componentName.includes("import type"))).toBe(false);
-    expect(claudeCodeSteps(canvas.nodes.find((node) => node.id === "planner-agent") ?? {})).toEqual([
-      { name: "Clone Repo", type: "bash" },
-      { name: "Write Implementation Plan", type: "prompt" },
-      { name: "Use plan as output", type: "bash" },
-    ]);
     expect(claudeCodeSteps(canvas.nodes.find((node) => node.id === "planner-agent-no-issue") ?? {})).toEqual([
       { name: "Clone Repo", type: "bash" },
       { name: "Write Implementation Plan", type: "prompt" },
@@ -323,7 +315,7 @@ describe("splitRunCanvasForPhase", () => {
       canvasSteps: [],
     });
     const stream = richStreamForCanvas(canvas);
-    const agentNotes = stream.filter((line) => line.nodeId === "implementation-agent" && line.note);
+    const agentNotes = stream.filter((line) => line.nodeId === "implementation-agent-no-issue" && line.note);
     expect(
       agentNotes
         .filter((line) => !line.noteParentId)

--- a/web_src/src/pages/home/factories/index.ts
+++ b/web_src/src/pages/home/factories/index.ts
@@ -120,19 +120,19 @@ function buildEventApp(args: {
 }
 
 /**
- * Ordered workspace apps provisioned during onboarding. runsOnLine controls
- * whether the provisioned line calls the app's onRun entrypoint.
+ * Ordered factory-line apps provisioned during onboarding. Each entry maps to a
+ * bundled app template and the line step that calls its onRun entrypoint. The
+ * bundled Verify app stays available for manual install, because the line hands
+ * the pull request to review from Implement.
  */
-export interface OnboardingApp {
+export interface OnboardingLineApp {
   factoryId: string;
   entrypointNodeId: string;
-  runsOnLine: boolean;
 }
 
-export const ONBOARDING_APPS: OnboardingApp[] = [
-  { factoryId: "line-planning", entrypointNodeId: "onrun-create-plan", runsOnLine: true },
-  { factoryId: "line-implementation", entrypointNodeId: "onrun-implement", runsOnLine: true },
-  { factoryId: "line-pr", entrypointNodeId: "onrun-open-pr", runsOnLine: false },
+export const ONBOARDING_LINE_APPS: OnboardingLineApp[] = [
+  { factoryId: "line-planning", entrypointNodeId: "onrun-create-plan" },
+  { factoryId: "line-implementation", entrypointNodeId: "onrun-implement" },
 ];
 
 // Event-driven factory apps provisioned during onboarding. These listen for

--- a/web_src/src/pages/home/factories/index.ts
+++ b/web_src/src/pages/home/factories/index.ts
@@ -120,18 +120,19 @@ function buildEventApp(args: {
 }
 
 /**
- * Ordered factory-line apps provisioned during onboarding. Each entry maps to a
- * bundled app template and the line step that calls its onRun entrypoint.
+ * Ordered workspace apps provisioned during onboarding. runsOnLine controls
+ * whether the provisioned line calls the app's onRun entrypoint.
  */
-export interface OnboardingLineApp {
+export interface OnboardingApp {
   factoryId: string;
   entrypointNodeId: string;
+  runsOnLine: boolean;
 }
 
-export const ONBOARDING_LINE_APPS: OnboardingLineApp[] = [
-  { factoryId: "line-planning", entrypointNodeId: "onrun-create-plan" },
-  { factoryId: "line-implementation", entrypointNodeId: "onrun-implement" },
-  { factoryId: "line-pr", entrypointNodeId: "onrun-open-pr" },
+export const ONBOARDING_APPS: OnboardingApp[] = [
+  { factoryId: "line-planning", entrypointNodeId: "onrun-create-plan", runsOnLine: true },
+  { factoryId: "line-implementation", entrypointNodeId: "onrun-implement", runsOnLine: true },
+  { factoryId: "line-pr", entrypointNodeId: "onrun-open-pr", runsOnLine: false },
 ];
 
 // Event-driven factory apps provisioned during onboarding. These listen for

--- a/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
@@ -13,28 +13,13 @@ spec:
       targetId: add-branch-artifact
     - channel: default
       sourceId: add-branch-artifact
-      targetId: from-gh-issue-check
-    - channel: "true"
-      sourceId: from-gh-issue-check
-      targetId: implementation-agent
-    - channel: "false"
-      sourceId: from-gh-issue-check
       targetId: implementation-agent-no-issue
-    - channel: passed
-      sourceId: implementation-agent
-      targetId: create-draft-pr
     - channel: passed
       sourceId: implementation-agent-no-issue
       targetId: create-draft-pr
     - channel: default
       sourceId: create-draft-pr
       targetId: attach-pr-artifact
-    - channel: failed
-      sourceId: implementation-agent
-      targetId: add-run-error
-    - channel: failed
-      sourceId: implementation-agent-no-issue
-      targetId: add-run-error
   nodes:
     - id: onrun-implement
       name: Start
@@ -42,13 +27,15 @@ spec:
       component: onRun
       configuration: {}
       position:
-        x: 1536
+        x: 1542
         'y': 144
       isCollapsed: true
     - id: create-branch
       name: Create Branch
       type: TYPE_ACTION
       component: runnerBash
+      concurrency:
+        max: 5
       configuration:
         enable_setup_commands: false
         environmentFrom:
@@ -102,135 +89,24 @@ spec:
           # Respond with branch and session id
           printf '{"branch":"%s", "session":"%s"}\n' "$BRANCH" "$SESSION_ID" > "$SUPERPLANE_RESULT_FILE"
       position:
-        x: 1536
+        x: 1542
         'y': 312
       isCollapsed: false
     - id: add-branch-artifact
       name: Add Branch Artifact
       type: TYPE_ACTION
       component: addWorkOrderArtifact
+      concurrency:
+        max: 100
       configuration:
         artifactType: branch
         name: '{{ $["Create Branch"].data.result.branch }}'
         orderId: '{{ order().id }}'
         repository: '{{ install_params.appRepository }}'
       position:
-        x: 1489
+        x: 1495
         'y': 480
       isCollapsed: true
-    - id: from-gh-issue-check
-      name: From GH issue?
-      type: TYPE_ACTION
-      component: if
-      configuration:
-        expression: '"source" in order()'
-      position:
-        x: 1489
-        'y': 648
-      isCollapsed: true
-    - id: implementation-agent
-      name: Agent - Implement from GH issue
-      type: TYPE_ACTION
-      component: runnerClaudeCode
-      concurrency:
-        max: 5
-      configuration:
-        credentials:
-          source: integration
-          integration:
-            name: claude
-        environmentFrom:
-          - source: integration
-            integration:
-              name: github
-        environment:
-          - name: REPO
-            value: '{{ order().source.repository.full_name }}'
-            valueSource: literal
-          - name: BRANCH
-            value: '{{ $["Create Branch"].data.result.branch }}'
-            valueSource: literal
-          - name: ISSUE_NUMBER
-            value: '{{ order().source.issue.number }}'
-            valueSource: literal
-          - name: PLAN
-            value: '{{ toBase64(find(order().artifacts, {#.type == "markdown" && #.data.title == "PLAN.md"}).data.body) }}'
-            valueSource: literal
-        executionTimeoutSeconds: 3600
-        machineType: e1-large-amd64
-        model: sonnet
-        steps:
-          - name: Set Up Git User
-            type: bash
-            command: |-
-              echo "Using superplaneagent@superplane.com"
-              git config --global user.email "superplaneagent@superplane.com"
-              git config --global user.name "SuperPlane Agent"
-          - name: Provide Plan
-            type: bash
-            command: |-
-              echo $PLAN | base64 -d > /tmp/PLAN.md
-              cat /tmp/PLAN.md
-          - name: Checkout Branch
-            type: bash
-            command: |-
-              set -euo pipefail
-              rm -rf repo
-              git clone --depth 1 --branch "$BRANCH" "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git" repo
-              cd repo
-          - name: Set Up DCO Signing
-            type: bash
-            workingDirectory: repo
-            command: |-
-              cat > .git/hooks/prepare-commit-msg <<'HOOK'
-              printf '\n%s\n' "Signed-off-by: SuperPlane Agent <superplaneagent@superplane.com>" >> "$1"
-              HOOK
-
-              chmod +x .git/hooks/prepare-commit-msg
-          - name: Implementation
-            type: prompt
-            workingDirectory: repo
-            prompt: |-
-              You are implementing a fix for a SuperPlane work order. The repository is already checked out in your current working directory, on the branch to work on.
-
-              Repository: {{ order().source.repository.full_name }}
-              Issue number: {{ order().source.issue.number }}
-              Issue title: {{ order().source.issue.title }}
-
-              1/ The preliminary plan is at /tmp/PLAN.md. Read it before writing any implementation.
-              2/ Gather context. Using the GitHub token in the GITHUB_TOKEN environment variable, read the FULL issue and ALL of its comments before writing any code.
-              3/ Implement. Make the code changes required to resolve the issue and address the discussion in the comments.
-              4/ Keep the change focused and commit your work to the current branch with clear commit messages.
-
-              Guidelines:
-
-              1/ Focus on clean code.
-              2/ Make long term fixes, not fast patches.
-              3/ Add tests where it makes sense.
-          - name: Commit and Push
-            type: bash
-            workingDirectory: repo
-            command: |-
-              set -euo pipefail
-              echo "cwd=$(pwd -P)"
-              git status
-              git log --oneline -5
-              git add -A
-              if ! git diff --cached --quiet; then
-                git commit -s -m "fix: implement issue #${ISSUE_NUMBER} via SuperPlane"
-              fi
-              if git rev-parse --verify "origin/${BRANCH}" >/dev/null 2>&1; then
-                if [ "$(git rev-list --count "origin/${BRANCH}..HEAD")" -eq 0 ]; then
-                  echo "No file changes and no unpushed commits on ${BRANCH}" >&2
-                  exit 1
-                fi
-              fi
-              git push origin "$BRANCH"
-              echo "Pushed implementation to $BRANCH"
-      position:
-        x: 1442
-        'y': 816
-      isCollapsed: false
     - id: implementation-agent-no-issue
       name: Agent - Implement from order description
       type: TYPE_ACTION
@@ -335,13 +211,15 @@ spec:
               git push origin "$BRANCH"
               echo "Pushed implementation to $BRANCH"
       position:
-        x: 1770
-        'y': 816
+        x: 1475
+        'y': 648
       isCollapsed: false
     - id: create-draft-pr
       name: Create Draft Pull Request
       type: TYPE_ACTION
       component: github.createPullRequest
+      concurrency:
+        max: 100
       configuration:
         base: main
         body: |-
@@ -358,31 +236,20 @@ spec:
         title: '{{ order().title }}'
       position:
         x: 1442
-        'y': 984
+        'y': 1032
       isCollapsed: true
     - id: attach-pr-artifact
       name: Attach PR to Work Order
       type: TYPE_ACTION
       component: addWorkOrderArtifact
+      concurrency:
+        max: 100
       configuration:
-        artifactKey: '{{ $["Create Draft Pull Request"].data.html_url }}'
         artifactType: pr
-        draft: true
-        number: '{{ $["Create Draft Pull Request"].data.number }}'
         orderId: '{{ order().id }}'
-        state: draft
-        title: '{{ $["Create Draft Pull Request"].data.title }}'
-        url: '{{ $["Create Draft Pull Request"].data.html_url }}'
+        state: open
+        url: '{{ $["Create Draft Pull Request"].data._links.html.href }}'
       position:
         x: 1442
-        'y': 1152
-      isCollapsed: true
-    - id: add-run-error
-      name: addRunError
-      type: TYPE_ACTION
-      component: addRunError
-      configuration: {}
-      position:
-        x: 1770
-        'y': 984
-      isCollapsed: true
+        'y': 1200
+      isCollapsed: false

--- a/web_src/src/pages/home/factories/line-apps/planning.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/planning.canvas.yaml
@@ -7,21 +7,6 @@ spec:
   edges:
     - channel: default
       sourceId: onrun-create-plan
-      targetId: from-gh-issue-check
-    - channel: "true"
-      sourceId: from-gh-issue-check
-      targetId: comment-progress-started
-    - channel: default
-      sourceId: comment-progress-started
-      targetId: add-factory-label
-    - channel: default
-      sourceId: add-factory-label
-      targetId: planner-agent
-    - channel: passed
-      sourceId: planner-agent
-      targetId: add-plan-artifact
-    - channel: "false"
-      sourceId: from-gh-issue-check
       targetId: planner-agent-no-issue
     - channel: passed
       sourceId: planner-agent-no-issue
@@ -33,104 +18,9 @@ spec:
       component: onRun
       configuration: {}
       position:
-        x: 454
+        x: 413
         'y': 888
       isCollapsed: true
-    - id: from-gh-issue-check
-      name: From GH issue?
-      type: TYPE_ACTION
-      component: if
-      configuration:
-        expression: '"source" in root().data.work_order'
-      position:
-        x: 454
-        'y': 1056
-      isCollapsed: true
-    - id: comment-progress-started
-      name: Progress Started Comment
-      type: TYPE_ACTION
-      component: github.createIssueComment
-      configuration:
-        body: Taking a look!
-        issueNumber: '{{ root().data.work_order.source.issue.number }}'
-        repository: '{{ install_params.backlogRepository }}'
-      position:
-        x: 407
-        'y': 1224
-      isCollapsed: true
-    - id: add-factory-label
-      name: Add Factory Label
-      type: TYPE_ACTION
-      component: github.addIssueLabel
-      configuration:
-        issueNumber: '{{ root().data.work_order.source.issue.number }}'
-        labels:
-          - factory
-        repository: '{{ install_params.backlogRepository }}'
-      position:
-        x: 407
-        'y': 1392
-      isCollapsed: true
-    - id: planner-agent
-      name: Agent - Plan for GH Issue
-      type: TYPE_ACTION
-      component: runnerClaudeCode
-      concurrency:
-        max: 5
-      configuration:
-        credentials:
-          source: integration
-          integration:
-            name: claude
-        environmentFrom:
-          - source: integration
-            integration:
-              name: github
-        environment:
-          - name: REPO
-            value: '{{ root().data.work_order.source.repository.full_name }}'
-            valueSource: literal
-        executionTimeoutSeconds: 3600
-        machineType: e1-large-amd64
-        model: sonnet
-        steps:
-          - name: Clone Repo
-            type: bash
-            command: |-
-              rm -rf repo
-              git clone --depth 1 "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git" repo
-              cd repo
-          - name: Write Implementation Plan
-            type: prompt
-            workingDirectory: repo
-            prompt: |-
-              You are writing an implementation plan for a SuperPlane Work Order. The repository is cloned out in your current working directory.
-
-              Repository: {{ root().data.work_order.source.repository.full_name }}
-              Issue number: {{ root().data.work_order.source.issue.number }}
-              Issue title: {{ root().data.work_order.source.issue.title }}
-
-              1/ Gather context: using the GitHub token in the GITHUB_TOKEN environment variable, read the FULL issue and all of its comments, and inspect the codebase as needed.
-              2/ Write the plan to the file /tmp/plan.md. Do NOT create any files inside the repository, and do NOT commit anything.
-
-              Start with a very short, high-level summary: 1-3 concise sentences or a few bullets. Clear and to the point. No heading above it.
-
-              Write clearly, for humans. Keep the top summary genuinely short.
-          - name: Use plan as output
-            type: bash
-            command: |-
-              if [ -s /tmp/plan.md ]; then
-                echo "Plan found. Using as output"
-                jq -n --rawfile plan /tmp/plan.md '{plan: ($plan | @base64)}' > "$SUPERPLANE_RESULT_FILE"
-              else
-                jq -n '{error: "No plan produced at /tmp/plan.md"}' > "$SUPERPLANE_RESULT_FILE"
-                echo "No plan produced at /tmp/plan.md" >&2
-                exit 1
-              fi
-      position:
-        x: 407
-        'y': 1560
-      isCollapsed: false
     - id: planner-agent-no-issue
       name: Agent - No GH Issue Plan
       type: TYPE_ACTION
@@ -155,7 +45,7 @@ spec:
             valueSource: literal
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
-        model: sonnet
+        model: opus
         steps:
           - name: Clone Repo
             type: bash
@@ -192,8 +82,8 @@ spec:
                 exit 1
               fi
       position:
-        x: 735
-        'y': 1392
+        x: 393
+        'y': 1056
       isCollapsed: false
     - id: add-plan-artifact
       name: Add Plan Artifact
@@ -206,5 +96,5 @@ spec:
         title: PLAN.md
       position:
         x: 360
-        'y': 1728
+        'y': 1328
       isCollapsed: true

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import yaml from "js-yaml";
 
-import { getFactoryDefinition, ONBOARDING_APPS, ONBOARDING_EVENT_APPS } from "./index";
+import { getFactoryDefinition, ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "./index";
 import { FACTORY_CANVAS_ID_PLACEHOLDER, materializeFactoryCanvas } from "./materializeFactoryTemplate";
 
 type AgentStep = { name?: string; command?: string; workingDirectory?: string };
@@ -38,23 +38,20 @@ function materializeOnboardingApp(factoryId: string) {
 }
 
 describe("setup factory line apps", () => {
-  it("installs plan, implement, and verify, but runs only plan and implement on the line", () => {
-    expect(ONBOARDING_APPS.map((app) => app.factoryId)).toEqual(["line-planning", "line-implementation", "line-pr"]);
-    expect(ONBOARDING_APPS.filter((app) => app.runsOnLine).map((app) => app.factoryId)).toEqual([
-      "line-planning",
-      "line-implementation",
-    ]);
+  it("installs plan and implement only, and leaves verify out of the workspace", () => {
+    expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).toEqual(["line-planning", "line-implementation"]);
+    expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).not.toContain("line-pr");
   });
 
   it("exposes a single onRun entrypoint per installed app", () => {
-    for (const app of ONBOARDING_APPS) {
+    for (const app of ONBOARDING_LINE_APPS) {
       const canvasYaml = materializeOnboardingApp(app.factoryId);
       expect(canvasYaml).toMatch(new RegExp(`id: ${app.entrypointNodeId}[\\s\\S]*component: onRun`));
     }
   });
 
   it("materializes repositories and integration wiring, leaving no template placeholders", () => {
-    for (const app of ONBOARDING_APPS) {
+    for (const app of ONBOARDING_LINE_APPS) {
       const canvasYaml = materializeOnboardingApp(app.factoryId);
       expect(canvasYaml).toContain("name: acme-claude");
       expect(canvasYaml).toContain("name: acme-github");
@@ -219,7 +216,7 @@ describe("setup factory event apps", () => {
   // intake API rather than as a bundled app.
   it("provisions PR closure outside the factory line", () => {
     expect(ONBOARDING_EVENT_APPS).toEqual(["pr-closure"]);
-    expect(ONBOARDING_APPS.map((app) => app.factoryId)).not.toContain("pr-closure");
+    expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).not.toContain("pr-closure");
   });
 
   it("closes the work order when a factory pull request is closed", () => {

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "vitest";
 import yaml from "js-yaml";
 
-import { getFactoryDefinition, ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "./index";
+import { getFactoryDefinition, ONBOARDING_APPS, ONBOARDING_EVENT_APPS } from "./index";
 import { FACTORY_CANVAS_ID_PLACEHOLDER, materializeFactoryCanvas } from "./materializeFactoryTemplate";
 
 type AgentStep = { name?: string; command?: string; workingDirectory?: string };
 
 type CanvasNode = {
   id?: string;
-  configuration?: { steps?: AgentStep[] };
+  component?: string;
+  concurrency?: { max?: number };
+  configuration?: { model?: string; steps?: AgentStep[] };
 };
 
 function canvasNodes(canvasYaml: string): CanvasNode[] {
@@ -36,23 +38,23 @@ function materializeOnboardingApp(factoryId: string) {
 }
 
 describe("setup factory line apps", () => {
-  it("orders the apps as plan, implement, open PR", () => {
-    expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).toEqual([
+  it("installs plan, implement, and verify, but runs only plan and implement on the line", () => {
+    expect(ONBOARDING_APPS.map((app) => app.factoryId)).toEqual(["line-planning", "line-implementation", "line-pr"]);
+    expect(ONBOARDING_APPS.filter((app) => app.runsOnLine).map((app) => app.factoryId)).toEqual([
       "line-planning",
       "line-implementation",
-      "line-pr",
     ]);
   });
 
-  it("exposes a single onRun entrypoint per app that the line calls", () => {
-    for (const app of ONBOARDING_LINE_APPS) {
+  it("exposes a single onRun entrypoint per installed app", () => {
+    for (const app of ONBOARDING_APPS) {
       const canvasYaml = materializeOnboardingApp(app.factoryId);
       expect(canvasYaml).toMatch(new RegExp(`id: ${app.entrypointNodeId}[\\s\\S]*component: onRun`));
     }
   });
 
   it("materializes repositories and integration wiring, leaving no template placeholders", () => {
-    for (const app of ONBOARDING_LINE_APPS) {
+    for (const app of ONBOARDING_APPS) {
       const canvasYaml = materializeOnboardingApp(app.factoryId);
       expect(canvasYaml).toContain("name: acme-claude");
       expect(canvasYaml).toContain("name: acme-github");
@@ -64,20 +66,92 @@ describe("setup factory line apps", () => {
     }
   });
 
+  it("keeps the planning agent on Opus when the coding agent stays Claude Code", () => {
+    const planning = materializeOnboardingApp("line-planning");
+    const implementation = materializeOnboardingApp("line-implementation");
+    const planningAgent = canvasNodes(planning).find((node) => node.id === "planner-agent-no-issue");
+    const implementationAgent = canvasNodes(implementation).find((node) => node.id === "implementation-agent-no-issue");
+
+    expect(planningAgent?.configuration?.model).toBe("opus");
+    expect(implementationAgent?.configuration?.model).toBe("sonnet");
+
+    const rewrittenPlanning = materializeFactoryCanvas({
+      definition: getFactoryDefinition("line-planning"),
+      canvasName: "Plan",
+      canvasId: "canvas-abc",
+      installParams: { appRepository: "acme/app", backlogRepository: "acme/backlog" },
+      integrations: {
+        github: { id: "int-1", name: "acme-github", ready: true },
+      },
+      agentRewrite: {
+        component: "runnerClaudeCode",
+        model: "sonnet",
+        credentials: { source: "hosted" },
+      },
+    });
+    const rewrittenAgent = canvasNodes(rewrittenPlanning).find((node) => node.id === "planner-agent-no-issue");
+    expect(rewrittenAgent?.configuration?.model).toBe("opus");
+  });
+
+  it("uses the agent provider and model selected during onboarding", () => {
+    for (const factoryId of ["line-planning", "line-implementation"]) {
+      const canvasYaml = materializeFactoryCanvas({
+        definition: getFactoryDefinition(factoryId),
+        canvasName: factoryId,
+        canvasId: "canvas-abc",
+        installParams: { appRepository: "acme/app", backlogRepository: "acme/backlog" },
+        integrations: {
+          github: { id: "int-1", name: "acme-github", ready: true },
+        },
+        agentRewrite: {
+          component: "runnerOpenRouter",
+          model: "openai/gpt-4.1",
+          credentials: { source: "hosted" },
+        },
+      });
+      const agentNodes = canvasNodes(canvasYaml).filter((node) => node.component === "runnerOpenRouter");
+
+      expect(agentNodes).toHaveLength(1);
+      expect(agentNodes[0]?.configuration?.model).toBe("openai/gpt-4.1");
+    }
+  });
+
   it("routes code work to the app repository", () => {
     const planning = materializeOnboardingApp("line-planning");
+    const planningNodeIds = canvasNodes(planning).map((node) => node.id);
     expect(planning).toContain("acme/app");
-    expect(planning).toContain("acme/backlog");
+    expect(planningNodeIds).toEqual(["onrun-create-plan", "planner-agent-no-issue", "add-plan-artifact"]);
+    expect(planning).toMatch(/sourceId: onrun-create-plan\n\s+targetId: planner-agent-no-issue/);
 
     const implementation = materializeOnboardingApp("line-implementation");
+    const implementationNodeIds = canvasNodes(implementation).map((node) => node.id);
     expect(implementation).toContain("acme/app");
     expect(implementation).toMatch(
       /id: add-branch-artifact[\s\S]*component: addWorkOrderArtifact[\s\S]*repository: acme\/app/,
     );
-    expect(implementation).toMatch(/sourceId: implementation-agent\n\s+targetId: create-draft-pr/);
+    expect(implementationNodeIds).toEqual([
+      "onrun-implement",
+      "create-branch",
+      "add-branch-artifact",
+      "implementation-agent-no-issue",
+      "create-draft-pr",
+      "attach-pr-artifact",
+    ]);
+    expect(implementation).toMatch(/sourceId: add-branch-artifact\n\s+targetId: implementation-agent-no-issue/);
+    expect(implementation).toMatch(/sourceId: implementation-agent-no-issue\n\s+targetId: create-draft-pr/);
     expect(implementation).toMatch(/component: github\.createPullRequest[\s\S]*repository: acme\/app/);
     expect(implementation).toMatch(/sourceId: create-draft-pr\n\s+targetId: attach-pr-artifact/);
-    expect(implementation).toMatch(/id: attach-pr-artifact[\s\S]*artifactType: pr/);
+    expect(implementation).toMatch(
+      /id: attach-pr-artifact[\s\S]*artifactType: pr[\s\S]*state: open[\s\S]*url: '\{\{ \$\["Create Draft Pull Request"\]\.data\._links\.html\.href \}\}'/,
+    );
+    expect(Object.fromEntries(canvasNodes(implementation).map((node) => [node.id, node.concurrency?.max]))).toEqual({
+      "onrun-implement": undefined,
+      "create-branch": 5,
+      "add-branch-artifact": 100,
+      "implementation-agent-no-issue": 5,
+      "create-draft-pr": 100,
+      "attach-pr-artifact": 100,
+    });
 
     const pr = materializeOnboardingApp("line-pr");
     expect(pr).toMatch(/component: github\.createPullRequest[\s\S]*repository: acme\/app/);
@@ -117,30 +191,26 @@ describe("setup factory line apps", () => {
     const implementation = materializeOnboardingApp("line-implementation");
     const nodes = canvasNodes(implementation);
 
-    for (const nodeId of ["implementation-agent", "implementation-agent-no-issue"]) {
-      const steps = nodeStepsByName(nodes, nodeId);
-      const checkout = steps["Checkout Branch"]?.command ?? "";
-      const commit = steps["Commit and Push"]?.command ?? "";
+    const steps = nodeStepsByName(nodes, "implementation-agent-no-issue");
+    const checkout = steps["Checkout Branch"]?.command ?? "";
+    const commit = steps["Commit and Push"]?.command ?? "";
 
-      expect(checkout).toContain("set -euo pipefail");
-      expect(commit).toContain("No file changes and no unpushed commits");
-      expect(commit).toContain("exit 1");
-      expect(commit).not.toContain("already up to date on origin");
-      expect(commit).toContain("git status");
-      expect(commit).toContain("git log --oneline -5");
-    }
+    expect(checkout).toContain("set -euo pipefail");
+    expect(commit).toContain("No file changes and no unpushed commits");
+    expect(commit).toContain("exit 1");
+    expect(commit).not.toContain("already up to date on origin");
+    expect(commit).toContain("git status");
+    expect(commit).toContain("git log --oneline -5");
   });
 
   it("runs implementation prompt and commit steps in the cloned repo", () => {
     const implementation = materializeOnboardingApp("line-implementation");
     const nodes = canvasNodes(implementation);
 
-    for (const nodeId of ["implementation-agent", "implementation-agent-no-issue"]) {
-      const steps = nodeStepsByName(nodes, nodeId);
-      expect(steps["Set Up DCO Signing"]?.workingDirectory).toBe("repo");
-      expect(steps["Implementation"]?.workingDirectory).toBe("repo");
-      expect(steps["Commit and Push"]?.workingDirectory).toBe("repo");
-    }
+    const steps = nodeStepsByName(nodes, "implementation-agent-no-issue");
+    expect(steps["Set Up DCO Signing"]?.workingDirectory).toBe("repo");
+    expect(steps["Implementation"]?.workingDirectory).toBe("repo");
+    expect(steps["Commit and Push"]?.workingDirectory).toBe("repo");
   });
 });
 
@@ -149,7 +219,7 @@ describe("setup factory event apps", () => {
   // intake API rather than as a bundled app.
   it("provisions PR closure outside the factory line", () => {
     expect(ONBOARDING_EVENT_APPS).toEqual(["pr-closure"]);
-    expect(ONBOARDING_LINE_APPS.map((app) => app.factoryId)).not.toContain("pr-closure");
+    expect(ONBOARDING_APPS.map((app) => app.factoryId)).not.toContain("pr-closure");
   });
 
   it("closes the work order when a factory pull request is closed", () => {

--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
@@ -218,6 +218,26 @@ spec:
     expect(definition.installParams.map((param) => param.name)).toEqual(["appRepository", "backlogRepository"]);
   });
 
+  it("keeps the planning agent on Opus when Claude Code credentials become hosted", () => {
+    const canvasYaml = materializeFactoryCanvas({
+      definition: getFactoryDefinition("line-planning"),
+      canvasName: "Plan",
+      canvasId: "canvas-hosted-plan",
+      installParams: { appRepository: "acme/app", backlogRepository: "acme/backlog" },
+      integrations: {
+        github: { id: "int-1", name: "acme-github", ready: true },
+      },
+      agentRewrite: {
+        component: "runnerClaudeCode",
+        model: "claude-sonnet-4-6",
+        credentials: { source: "hosted" },
+      },
+    });
+
+    expect(canvasYaml).toMatch(/id: planner-agent-no-issue[\s\S]*model: opus/);
+    expect(canvasYaml).not.toContain("model: claude-sonnet-4-6");
+  });
+
   it("rewrites Claude Code credentials to hosted when Claude is not connected", () => {
     const canvasYaml = materializeFactoryCanvas({
       definition: getFactoryDefinition("line-implementation"),

--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.ts
@@ -107,6 +107,8 @@ export function wireFactoryIntegrations(
 }
 
 const CLAUDE_CODE_COMPONENT = "runnerClaudeCode";
+const PLANNING_AGENT_NODE_ID = "planner-agent-no-issue";
+const PLANNING_AGENT_MODEL = "opus";
 
 export type FactoryAgentRewrite = {
   component: string;
@@ -128,8 +130,15 @@ function rewriteOnboardingAgentNodes(doc: YamlCanvas, rewrite: FactoryAgentRewri
         integration: { name: rewrite.credentials.name },
       };
     }
-    configuration.model = rewrite.model;
+    configuration.model = planningAgentModel(node.id, rewrite);
   }
+}
+
+function planningAgentModel(nodeId: string | undefined, rewrite: FactoryAgentRewrite): string {
+  if (nodeId === PLANNING_AGENT_NODE_ID && rewrite.component === CLAUDE_CODE_COMPONENT) {
+    return PLANNING_AGENT_MODEL;
+  }
+  return rewrite.model;
 }
 
 export function materializeFactoryCanvas(args: {

--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.ts
@@ -35,6 +35,7 @@ export function substituteInstallParams(content: string, params: Record<string, 
 }
 
 type YamlNode = {
+  id?: string;
   component?: string;
   integration?: { id?: string; name?: string };
   configuration?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

New workspaces installed a three-step factory line that still used GitHub-issue branch paths. Production workspaces run Plan then Implement only.

This change makes onboarding install the same Plan and Implement line. Finish still installs Verify as a standalone app. Plan keeps Opus when the coding agent stays Claude Code. Implement allows more concurrent branch and pull-request work. Canvas patches now keep node concurrency so those limits survive later edits.

## Test plan

- [ ] Finish onboarding and confirm the line has Plan then Implement only.
- [ ] Confirm Verify exists as a standalone app after Finish.
- [ ] Confirm Plan uses Opus when the coding agent is Claude Code.
- [ ] Confirm Implement can run more than one branch or pull-request node at a time.
- [ ] Edit a canvas node that has concurrency and confirm the limit stays after save.


Made with [Cursor](https://cursor.com)