### PR TITLE
fix: only check for CLI updates once per day

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	if cli.ShouldStartUpdateCheck(os.Args[1:]) {
+	if cli.ShouldStartUpdateCheck(os.Args[1:]) && cli.ShouldCheckForUpdateNow() {
 		cli.StartUpdateCheck()
 	}
 	err := cli.RootCmd.Execute()

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -28,10 +28,11 @@ import (
 )
 
 const (
-	DefaultAPIURL           = "http://localhost:8000"
-	ConfigKeyOutput         = "output"
-	ConfigKeyContexts       = "contexts"
-	ConfigKeyCurrentContext = "currentContext"
+	DefaultAPIURL            = "http://localhost:8000"
+	ConfigKeyOutput          = "output"
+	ConfigKeyContexts        = "contexts"
+	ConfigKeyCurrentContext  = "currentContext"
+	ConfigKeyLastUpdateCheck = "lastUpdateCheck"
 )
 
 var cfgFile string

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -8,11 +8,17 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // Version is set at build time via -ldflags.
 // Defaults to "dev" for development builds.
 var Version = "dev"
+
+// updateCheckInterval controls how often StartUpdateCheck is allowed to hit
+// the GitHub releases API. We only need to know about new releases once a
+// day, so there's no reason to pay that network cost on every command.
+const updateCheckInterval = 24 * time.Hour
 
 var updateCheckResult <-chan *updateInfo
 
@@ -52,12 +58,40 @@ func StartUpdateCheck() {
 		return
 	}
 
+	recordUpdateCheck()
+
 	ch := make(chan *updateInfo, 1)
 	updateCheckResult = ch
 	go func() {
 		release, err := fetchLatestRelease()
 		ch <- &updateInfo{release: release, err: err}
 	}()
+}
+
+// ShouldCheckForUpdateNow reports whether enough time has passed since the
+// last update check for it to be worth hitting the GitHub releases API
+// again. The timestamp of the last check is persisted in the CLI
+// configuration file, so this holds across separate command invocations.
+func ShouldCheckForUpdateNow() bool {
+	last := viper.GetString(ConfigKeyLastUpdateCheck)
+	if last == "" {
+		return true
+	}
+
+	lastChecked, err := time.Parse(time.RFC3339, last)
+	if err != nil {
+		return true
+	}
+
+	return time.Since(lastChecked) >= updateCheckInterval
+}
+
+// recordUpdateCheck persists the current time as the last update check
+// timestamp. Failures to persist it are non-fatal: at worst, we check for
+// updates again earlier than strictly necessary next time.
+func recordUpdateCheck() {
+	viper.Set(ConfigKeyLastUpdateCheck, time.Now().UTC().Format(time.RFC3339))
+	_ = WriteConfig()
 }
 
 func ShouldStartUpdateCheck(args []string) bool {

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"testing"
+	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,4 +121,28 @@ func TestBuildUpdateNoticeEmptyWhenAlreadyCurrent(t *testing.T) {
 	release := &releaseInfo{TagName: "v0.17.0"}
 
 	require.Empty(t, buildUpdateNotice("v0.17.0", release, "linux", "amd64"))
+}
+
+func TestShouldCheckForUpdateNow(t *testing.T) {
+	setupViper(t)
+
+	require.True(t, ShouldCheckForUpdateNow(), "expected a check when no timestamp has been recorded yet")
+
+	viper.Set(ConfigKeyLastUpdateCheck, time.Now().UTC().Format(time.RFC3339))
+	require.False(t, ShouldCheckForUpdateNow(), "expected no check right after one was just recorded")
+
+	viper.Set(ConfigKeyLastUpdateCheck, time.Now().UTC().Add(-25*time.Hour).Format(time.RFC3339))
+	require.True(t, ShouldCheckForUpdateNow(), "expected a check once the interval has elapsed")
+
+	viper.Set(ConfigKeyLastUpdateCheck, "not-a-timestamp")
+	require.True(t, ShouldCheckForUpdateNow(), "expected a check when the stored timestamp can't be parsed")
+}
+
+func TestRecordUpdateCheckPersistsTimestamp(t *testing.T) {
+	setupViper(t)
+
+	require.True(t, ShouldCheckForUpdateNow())
+	recordUpdateCheck()
+	require.False(t, ShouldCheckForUpdateNow(), "expected the recorded timestamp to be picked up immediately")
+	require.NotEmpty(t, viper.GetString(ConfigKeyLastUpdateCheck))
 }


### PR DESCRIPTION
## What changed
The CLI currently calls the GitHub releases API on every single command to check for a newer version. This adds an extra network round-trip (plus up to a 1s wait in `PrintUpdateNotice`) to every command, even ones that have nothing to do with upgrading.

## Why
Closes #5000. The CLI feels sluggish because of this extra HTTP call on every invocation, and checking that often is unnecessary — a new release isn't going to show up more than once a day in practice.

## How
- Added `ConfigKeyLastUpdateCheck` and persist the last-checked timestamp (RFC3339, UTC) in the existing viper-backed `.superplane.yaml` config, reusing the same `WriteConfig()` path already used for CLI contexts.
- Added `ShouldCheckForUpdateNow()`, which returns `true` if there's no stored timestamp, the stored value can't be parsed, or more than 24h have passed since the last check.
- `StartUpdateCheck()` now calls `recordUpdateCheck()` right before kicking off the async release check, so the timestamp is written as soon as we decide to check (not only on success), avoiding retry storms if the network call fails.
- `cmd/cli/main.go` now gates `StartUpdateCheck()` on `ShouldStartUpdateCheck(...) && ShouldCheckForUpdateNow()`.
- Added unit tests for the new gating logic (`TestShouldCheckForUpdateNow`, `TestRecordUpdateCheckPersistsTimestamp`), reusing the existing `setupViper` test helper.

I wasn't able to run the full `make dev.setup` / Docker-based codegen pipeline in my environment (no Docker), so I verified `pkg/cli`'s existing and new tests in isolation against real `cobra`/`viper`/`testify` — all passing, `gofmt`-clean. Happy to fix up anything CI catches that I couldn't reproduce locally.

## Related issues
Closes #5000