### PR TITLE
fix: Stop the request worker from undoing cancellations

### DIFF
--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -393,21 +393,14 @@ func (w *NodeRequestWorker) invokeExecutionComponentHook(
 	}
 
 	logger.Infof("Component execution hook completed")
-	finished, err := execution.IsFinished(tx)
-	if err != nil {
-		return err
-	}
 
-	if finished {
-		logger.Infof("Execution %s already finished after hook - completing request", execution.ID)
-		return request.Complete(tx)
-	}
-
-	err = tx.Save(&execution).Error
-	if err != nil {
-		return fmt.Errorf("error saving execution after action handler: %v", err)
-	}
-
+	//
+	// Hook contexts persist their own execution columns in this transaction:
+	// Metadata.Set updates metadata, Pass and Fail write state and result.
+	// A full-row save here would undo a cancellation committed while the hook
+	// ran, because this worker locks the request row, not the execution row.
+	// The executor saves under its execution row lock (FOR NO KEY UPDATE SKIP LOCKED).
+	//
 	logger.Infof("Request completed")
 	return request.Complete(tx)
 }

--- a/pkg/workers/node_request_worker_test.go
+++ b/pkg/workers/node_request_worker_test.go
@@ -886,6 +886,93 @@ func Test__NodeRequestWorker_DoesNotSaveStaleExecutionAfterHookFindsPersistedExe
 	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
 }
 
+func Test__NodeRequestWorker_DoesNotSaveStaleExecutionAfterHookFindsPersistedExecutionCancelling(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, r.GitProvider, "", r.AuthService)
+
+	componentName := "cancelling_execution_after_hook_" + uuid.New().String()
+	var executionID uuid.UUID
+	var cancelledAt time.Time
+	r.Registry.Actions[componentName] = impl.NewDummyAction(impl.DummyActionOptions{
+		Name:  componentName,
+		Hooks: []core.Hook{{Name: "poll", Type: core.HookTypeInternal}},
+		HandleHookFunc: func(ctx core.ActionHookContext) error {
+			//
+			// The hook does not write the execution row. While it runs, a user
+			// cancels the execution in another transaction, which commits.
+			//
+			var cancelled models.CanvasNodeExecution
+			require.NoError(t, database.Conn().Where("id = ?", executionID).First(&cancelled).Error)
+			require.NoError(t, cancelled.RequestCancellation(database.Conn(), &r.User))
+			require.NotNil(t, cancelled.CancelledAt)
+			cancelledAt = *cancelled.CancelledAt
+
+			return nil
+		},
+	})
+
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: componentName}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, componentNode, "default", nil)
+	execution := support.CreateNodeExecutionWithConfiguration(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID, map[string]any{})
+	require.NoError(t, database.Conn().Model(execution).Update("state", models.CanvasNodeExecutionStateStarted).Error)
+	executionID = execution.ID
+
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		ExecutionID: &execution.ID,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "poll",
+				Parameters: map[string]any{},
+			},
+		}),
+		State: models.NodeExecutionRequestStatePending,
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	err := worker.LockAndProcessRequest(request)
+	require.NoError(t, err)
+
+	var updatedExecution models.CanvasNodeExecution
+	require.NoError(t, database.Conn().Where("id = ?", execution.ID).First(&updatedExecution).Error)
+	assert.Equal(t, models.CanvasNodeExecutionStateCancelling, updatedExecution.State)
+	require.NotNil(t, updatedExecution.CancelledAt)
+	assert.WithinDuration(t, cancelledAt, *updatedExecution.CancelledAt, time.Second)
+	require.NotNil(t, updatedExecution.CancelledBy)
+	assert.Equal(t, r.User, *updatedExecution.CancelledBy)
+
+	var updatedRequest models.CanvasNodeRequest
+	require.NoError(t, database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error)
+	assert.Equal(t, models.NodeExecutionRequestStateCompleted, updatedRequest.State)
+
+	//
+	// The committed cancellation must remain visible to the execution
+	// terminator, which finds its work through ListCancellingNodeExecutions.
+	//
+	cancelling, err := models.ListCancellingNodeExecutions(database.Conn())
+	require.NoError(t, err)
+	require.Len(t, cancelling, 1)
+	assert.Equal(t, execution.ID, cancelling[0].ID)
+}
+
 func Test__NodeRequestWorker_CancelsExecutionForDeletedNodeWhenComponentCancelFails(t *testing.T) {
 	cancelCalled := false
 	componentName := "cancel_failing_" + uuid.New().String()


### PR DESCRIPTION
## Summary

- A user cancels a running execution. The request worker is inside a component
  hook at that moment, for example the runner poll hook in a broker call.
- When the hook returns, the worker writes the whole execution row back from
  the snapshot it read before the hook. The guard before that write only
  checks `finished`. It came from #6138. #6199 later added `cancelling` to the
  two other state guards in this file, but not to this one. The row goes back
  to `started` and `cancelled_at` becomes null.
- `ExecutionTerminator` finds work only in state `cancelling`, so it never
  stops the task. `RunFinalizer` repairs a cancelled run after five minutes. A
  cancelled execution stays lost.
- This change removes the write and its guard. The hook contexts already
  persist their own columns, and `InvokeNodeExecutionHook` runs component
  hooks with the same contexts and writes no row. The node executor keeps its
  write, because it holds the row locked with `FOR NO KEY UPDATE SKIP LOCKED`.

Not in this change: the worker still reads the execution row without a lock.

## Test plan

- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/workers`.
- [ ] Confirm that the new test fails on `main`.
- [ ] Cancel a runner execution while its poll hook runs.
- [ ] Confirm that the execution ends as cancelled.
