### PR TITLE
fix: Preselect GitHub Issues in workspace setup

### DIFF
--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.smoke.spec.tsx
@@ -271,6 +271,7 @@ describe("FactoriesHarness workspace setup", () => {
 
     expect(await screen.findByTestId("first-run-tickets", {}, { timeout: 8000 })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: /GitHub Issues/ }, { timeout: 8000 })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("first-run-analyze-tickets")).toBeEnabled(), { timeout: 8000 });
   }, 15000);
 });
 

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
@@ -15,7 +15,7 @@ import { FirstRunTicketsScreen } from "./first-run/FirstRunTicketsScreen";
 import type { FirstRunChrome, FirstRunTicketSource } from "./first-run/firstRunTypes";
 import { FIRST_RUN_COPY } from "./first-run/firstRunCopy";
 import { FirstRunWelcomeScreen } from "./first-run/FirstRunWelcomeScreen";
-import { WIZARD_STEPS, type IntegrationId, type WizardStepId } from "./onboardingFixtures";
+import { WIZARD_STEPS, type IntegrationId, type IssuesChoiceId, type WizardStepId } from "./onboardingFixtures";
 import type { OnboardingSetupApi } from "./useOnboardingSetupState";
 import type { useOnboardingPageModel } from "./useOnboardingPageModel";
 
@@ -53,6 +53,13 @@ const STEP_INDEX_FOR_SCREEN: Record<FirstRunScreen, number> = {
  * wizard step copy, because provisioning needs a connected agent.
  */
 const AGENT_STEP: { id: "agent"; label: string; purpose: string } = WIZARD_STEPS[3];
+
+/**
+ * GitHub Issues is the only source setup can connect, so the tickets screen
+ * opens with it selected. Jira and Linear stay marked as coming soon.
+ */
+const DEFAULT_TICKET_SOURCE: FirstRunTicketSource = "github-issues";
+const DEFAULT_ISSUES_CHOICE: IssuesChoiceId = "vcs";
 
 function firstNameOf(name: string | undefined): string | undefined {
   const first = name?.trim().split(/\s+/)[0];
@@ -180,16 +187,17 @@ function useFirstRunSetupFlow(model: OnboardingPageModel) {
   };
 
   const continueFromTickets = async () => {
+    setup.setIssuesChoice(DEFAULT_ISSUES_CHOICE);
     setup.commitIssuesStep();
-    if (!(await model.saveIssues())) return;
+    if (!(await model.saveIssues(DEFAULT_ISSUES_CHOICE))) return;
     goToScreen("agent");
   };
 
   const selectTicketSource = (source: FirstRunTicketSource) => {
     // Jira and Linear are not connectable yet, so the screen shows them as
     // coming soon and reports GitHub Issues only.
-    if (source !== "github-issues") return;
-    setup.setIssuesChoice("vcs");
+    if (source !== DEFAULT_TICKET_SOURCE) return;
+    setup.setIssuesChoice(DEFAULT_ISSUES_CHOICE);
   };
 
   return {
@@ -255,7 +263,7 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
   if (flow.screen === "tickets") {
     return (
       <FirstRunTicketsScreen
-        ticketSource={setup.issuesChoice === "vcs" ? "github-issues" : null}
+        ticketSource={DEFAULT_TICKET_SOURCE}
         chrome={chromeFor("tickets")}
         continueLabel={FIRST_RUN_COPY.tickets.continue}
         onSelectTicketSource={flow.selectTicketSource}

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -16,7 +16,7 @@ import { useSearchParams } from "react-router";
 
 import { factorySetupPath } from "../../lib/factoryPagePaths";
 import { AGENT_PROVIDER_IDS } from "./onboardingAgentReadiness";
-import type { IntegrationId, WizardStepId } from "./onboardingFixtures";
+import type { IntegrationId, IssuesChoiceId, WizardStepId } from "./onboardingFixtures";
 import type { UpdateOnboarding } from "./onboardingProvision";
 import {
   apiIssuesSource,
@@ -120,13 +120,15 @@ function useSectionSaves(args: {
       }),
     );
   };
-  const saveIssues = () => {
+  // The caller passes the source, because a selection made in the same render
+  // is not readable from the setup state yet.
+  const saveIssues = (source: IssuesChoiceId) => {
     const backlogRepository = args.setup.issuesRepo ?? args.setup.selectedRepo;
-    if (!backlogRepository || !args.setup.issuesChoice) return Promise.resolve(false);
+    if (!backlogRepository) return Promise.resolve(false);
     return runSave(args.setSaving, () =>
       args.updateOnboarding({
         backlogRepository,
-        issuesSource: apiIssuesSource(args.setup.issuesChoice),
+        issuesSource: apiIssuesSource(source),
       }),
     );
   };


### PR DESCRIPTION
## Summary

The issue source step of workspace setup opened with no source selected.
The user had to click GitHub Issues before the step let them continue.
GitHub Issues is the only source that setup can connect, because Jira and
Linear are marked as coming soon. The extra click gave the user no real
choice.

The step now opens with GitHub Issues selected.

The save of the issue source now takes the source as an argument. The
restore effects of the setup model run in the parent component, so they
clear the issue selection after the child effects run. A default that is
set in an effect does not stay. An explicit argument does not depend on a
state update.

## Test plan

- [ ] Open workspace setup and go to the issue source step. GitHub Issues
      is selected and the continue button is enabled.
- [ ] Click continue. Setup saves the issue source and opens the coding
      agent step.
- [ ] Resume setup at the issue source step with a URL that has
      `?step=issues`. GitHub Issues is selected.
- [ ] Frontend tests pass: `make test.ui`.


Made with [Cursor](https://cursor.com)