### PR TITLE
fix: Return First-Run GitHub Connect to Setup

### DIFF
--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -6,6 +6,7 @@ import { appPath, appSettingsPath } from "./lib/appPaths";
 import { FEATURE_FACTORIES } from "./lib/experimentalFeatures";
 import { recordLastVisitedOrganization } from "./lib/lastVisitedOrganization";
 import { isReservedAppPathSegment } from "./lib/reservedAppPaths";
+import { useConsumeIntegrationSetupReturnOnArrival } from "./hooks/useConsumeIntegrationSetupReturnOnArrival";
 import { Toaster } from "sonner";
 import "./App.css";
 
@@ -249,6 +250,7 @@ function PageObservabilityScope() {
 function OrganizationScope() {
   const { organizationId } = useParams<{ organizationId: string }>();
   const { account } = useAccount();
+  useConsumeIntegrationSetupReturnOnArrival(organizationId);
 
   useEffect(() => {
     if (account?.id && organizationId && !isReservedAppPathSegment(organizationId)) {

--- a/web_src/src/hooks/useConsumeIntegrationSetupReturnOnArrival.ts
+++ b/web_src/src/hooks/useConsumeIntegrationSetupReturnOnArrival.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+import { consumeIntegrationSetupReturnIfArrived } from "@/lib/integrationSetupReturn";
+
+/** Clears the GitHub setup return marker once this page is the stored destination. */
+export function useConsumeIntegrationSetupReturnOnArrival(organizationId: string | undefined): void {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!organizationId) return;
+    consumeIntegrationSetupReturnIfArrived(organizationId, location.pathname);
+  }, [location.pathname, organizationId]);
+}

--- a/web_src/src/lib/integrationSetupReturn.spec.ts
+++ b/web_src/src/lib/integrationSetupReturn.spec.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   consumeIntegrationSetupReturn,
+  consumeIntegrationSetupReturnIfArrived,
+  hasIntegrationSetupStay,
   peekIntegrationSetupReturn,
   rememberIntegrationSetupReturn,
 } from "./integrationSetupReturn";
@@ -19,6 +21,22 @@ describe("integration setup return", () => {
 
     consumeIntegrationSetupReturn("org-1");
     expect(peekIntegrationSetupReturn("org-1")).toBeNull();
+  });
+
+  it("consumes the marker only after the browser arrives on the stored page", () => {
+    rememberIntegrationSetupReturn("org-1", "/org-1/workspaces/APP/setup?step=vcs&pick=newest");
+
+    consumeIntegrationSetupReturnIfArrived("org-1", "/org-1/settings/integrations/abc");
+    expect(peekIntegrationSetupReturn("org-1")).toBe("/org-1/workspaces/APP/setup?step=vcs&pick=newest");
+
+    consumeIntegrationSetupReturnIfArrived("org-1", "/org-1/workspaces/APP/setup");
+    expect(peekIntegrationSetupReturn("org-1")).toBeNull();
+  });
+
+  it("detects the setupStay query", () => {
+    expect(hasIntegrationSetupStay("setupStay=1")).toBe(true);
+    expect(hasIntegrationSetupStay("?setupStay=1")).toBe(true);
+    expect(hasIntegrationSetupStay("")).toBe(false);
   });
 
   it("returns the path regardless of the integration the provider redirects to", () => {

--- a/web_src/src/lib/integrationSetupReturn.ts
+++ b/web_src/src/lib/integrationSetupReturn.ts
@@ -1,6 +1,9 @@
 const STORAGE_PREFIX = "integration-setup-return";
 const MAX_AGE_MS = 15 * 60 * 1000;
 
+/** Keeps the hosted GitHub account picker on Integrations instead of bouncing back. */
+export const INTEGRATION_SETUP_STAY_PARAM = "setupStay";
+
 interface StoredReturn {
   path: string;
   createdAt: number;
@@ -51,4 +54,21 @@ export function peekIntegrationSetupReturn(organizationId: string): string | nul
 
 export function consumeIntegrationSetupReturn(organizationId: string): void {
   window.localStorage.removeItem(storageKey(organizationId));
+}
+
+function pathnameOf(path: string): string {
+  return path.split("?")[0] ?? path;
+}
+
+/** Deletes the marker after the browser lands on the stored return page. */
+export function consumeIntegrationSetupReturnIfArrived(organizationId: string, currentPathname: string): void {
+  const stored = peekIntegrationSetupReturn(organizationId);
+  if (!stored) return;
+  if (pathnameOf(stored) !== pathnameOf(currentPathname)) return;
+  consumeIntegrationSetupReturn(organizationId);
+}
+
+export function hasIntegrationSetupStay(search: string): boolean {
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  return new URLSearchParams(query).get(INTEGRATION_SETUP_STAY_PARAM) === "1";
 }

--- a/web_src/src/lib/startDirectGitHubConnect.spec.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.spec.ts
@@ -11,6 +11,7 @@ const follow = vi.hoisted(() => vi.fn(() => true));
 
 vi.mock("@/lib/integrationSetupReturn", () => ({
   rememberIntegrationSetupReturn: remember,
+  INTEGRATION_SETUP_STAY_PARAM: "setupStay",
 }));
 
 vi.mock("@/lib/browserAction", () => ({
@@ -162,7 +163,7 @@ describe("startDirectGitHubConnect", () => {
     expect(create).not.toHaveBeenCalled();
     expect(follow).not.toHaveBeenCalled();
     expect(remember).toHaveBeenCalledWith("org-1", "/org-1/settings/integrations");
-    expect(goTo).toHaveBeenCalledWith("/org-1/settings/integrations/int-1");
+    expect(goTo).toHaveBeenCalledWith("/org-1/settings/integrations/int-1?setupStay=1");
   });
 
   it("reuses a pending browser action", async () => {

--- a/web_src/src/lib/startDirectGitHubConnect.ts
+++ b/web_src/src/lib/startDirectGitHubConnect.ts
@@ -6,7 +6,7 @@ import type {
 
 import { followBrowserAction } from "@/lib/browserAction";
 import { pendingGitHubInstallations } from "@/lib/hostedGitHubInstall";
-import { rememberIntegrationSetupReturn } from "@/lib/integrationSetupReturn";
+import { INTEGRATION_SETUP_STAY_PARAM, rememberIntegrationSetupReturn } from "@/lib/integrationSetupReturn";
 import { createWithGeneratedName } from "@/ui/IntegrationCreateDialog/generatedName";
 
 function startedByUserID(item: OrganizationsIntegration): string {
@@ -68,7 +68,7 @@ export async function startDirectGitHubConnect(args: {
     const picker = pendingGitHubInstallPicker(args.connected, args.currentUserId);
     if (picker) {
       rememberIntegrationSetupReturn(args.organizationId, args.returnTo);
-      const path = `/${args.organizationId}/settings/integrations/${picker.id}`;
+      const path = `/${args.organizationId}/settings/integrations/${picker.id}?${INTEGRATION_SETUP_STAY_PARAM}=1`;
       if (args.goTo) {
         args.goTo(path);
         return true;

--- a/web_src/src/pages/factories/pages/onboarding/OnboardingPage.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/OnboardingPage.tsx
@@ -1,9 +1,12 @@
+import { useConsumeIntegrationSetupReturnOnArrival } from "@/hooks/useConsumeIntegrationSetupReturnOnArrival";
+
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { FirstRunSetup } from "./FirstRunSetup";
 import { useOnboardingPageModel } from "./useOnboardingPageModel";
 
 export function OnboardingPage() {
   const layout = useFactoriesLayout();
+  useConsumeIntegrationSetupReturnOnArrival(layout.organizationId);
   const model = useOnboardingPageModel(layout);
 
   if (!model.canConfigureWorkspace) {

--- a/web_src/src/pages/organization/settings/components/IntegrationSetupReturn.spec.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetupReturn.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router";
 
@@ -36,13 +36,27 @@ describe("IntegrationSetupReturn", () => {
     expect(screen.queryByText("integration details")).not.toBeInTheDocument();
   });
 
-  it("consumes the marker so a later visit stays on the integration page", async () => {
+  it("keeps the marker so a remount can still return to setup", async () => {
     rememberIntegrationSetupReturn(ORGANIZATION_ID, SETUP_PATH);
 
-    renderAt("/org-1/settings/integrations/abc", <div>integration details</div>);
+    const first = renderAt("/org-1/settings/integrations/an-id-created-during-setup", <div>integration details</div>);
+    expect(await screen.findByText("workspace setup")).toBeInTheDocument();
+    expect(peekIntegrationSetupReturn(ORGANIZATION_ID)).toBe(SETUP_PATH);
+    first.unmount();
 
-    await screen.findByText("workspace setup");
-    await waitFor(() => expect(peekIntegrationSetupReturn(ORGANIZATION_ID)).toBeNull());
+    renderAt("/org-1/settings/integrations/an-id-created-during-setup", <div>integration details</div>);
+    expect(await screen.findByText("workspace setup")).toBeInTheDocument();
+    expect(peekIntegrationSetupReturn(ORGANIZATION_ID)).toBe(SETUP_PATH);
+  });
+
+  it("stays on the integration page when setupStay is set", async () => {
+    rememberIntegrationSetupReturn(ORGANIZATION_ID, SETUP_PATH);
+
+    renderAt("/org-1/settings/integrations/abc?setupStay=1", <div>integration details</div>);
+
+    expect(await screen.findByText("integration details")).toBeInTheDocument();
+    expect(screen.queryByText("workspace setup")).not.toBeInTheDocument();
+    expect(peekIntegrationSetupReturn(ORGANIZATION_ID)).toBe(SETUP_PATH);
   });
 
   it("renders the page when no setup is in progress", () => {

--- a/web_src/src/pages/organization/settings/components/IntegrationSetupReturn.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetupReturn.tsx
@@ -1,9 +1,9 @@
 import { Loader2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 
-import { consumeIntegrationSetupReturn, peekIntegrationSetupReturn } from "@/lib/integrationSetupReturn";
+import { hasIntegrationSetupStay, peekIntegrationSetupReturn } from "@/lib/integrationSetupReturn";
 
 interface IntegrationSetupReturnProps {
   organizationId: string;
@@ -22,17 +22,18 @@ interface IntegrationSetupReturnProps {
  */
 export function IntegrationSetupReturn({ organizationId, children }: IntegrationSetupReturnProps) {
   const navigate = useNavigate();
-  // Read once on mount. After the marker is consumed the value must stay set,
-  // so the children never flash before the navigation happens.
+  const [searchParams] = useSearchParams();
+  const stayOnPage = hasIntegrationSetupStay(searchParams.toString());
+  // Peek only. The destination page deletes the marker, so a Strict Mode remount
+  // still finds the path and can navigate again.
   const [returnTo] = useState(() => peekIntegrationSetupReturn(organizationId));
 
   useEffect(() => {
-    if (!returnTo) return;
-    consumeIntegrationSetupReturn(organizationId);
+    if (!returnTo || stayOnPage) return;
     navigate(returnTo, { replace: true });
-  }, [navigate, organizationId, returnTo]);
+  }, [navigate, returnTo, stayOnPage]);
 
-  if (returnTo) {
+  if (returnTo && !stayOnPage) {
     return (
       <div className="flex min-h-screen items-center justify-center" data-testid="integration-setup-return">
         <Loader2 className="size-8 animate-spin text-gray-500 dark:text-gray-400" />


### PR DESCRIPTION
## Summary

Connect GitHub in first-run workspace setup sent the browser to org Integrations after GitHub bind. SuperPlane deleted the return marker on first mount, so React Strict Mode dropped the bounce back to setup.

This change keeps the marker until workspace setup loads. The hosted GitHub account picker stays on Integrations until the user selects an account. After bind, SuperPlane returns the user to first-run with GitHub connected.

## Test plan

- [ ] Open first-run workspace setup. Click Connect GitHub with one GitHub account. Confirm you return to setup with GitHub connected.
- [ ] Click Continue. Confirm the repository list opens.
- [ ] Repeat with two GitHub accounts. Confirm the picker stays on Integrations. Select an account. Confirm you return to setup with GitHub connected.
- [ ] Open org Integrations after a later visit. Confirm SuperPlane does not bounce you back to setup.
- [ ] Run `make check.lint.ui` and confirm the eslint budget stays within limits.

Made with [Cursor](https://cursor.com)