### PR TITLE
fix: Read the intake analysis from a result file

### DIFF
--- a/pkg/grpc/actions/factories/intake_template.go
+++ b/pkg/grpc/actions/factories/intake_template.go
@@ -41,6 +41,8 @@ const (
 	intakeConfidenceCautionAt  = 3
 	intakeConfidenceCriticalAt = 2
 
+	intakeAnalysisOutputFile = "/tmp/intake-analysis.json"
+
 	// intakeConcurrencyMax is how many items an intake node works on at once.
 	// A node runs one execution at a time by default, which makes a batch of
 	// items wait for each other: a seeded batch, or a source that reports many
@@ -266,6 +268,11 @@ func intakeAnalysisConfiguration(spec intakeSpec, agent *intakeAgent) map[string
 				"type":   "prompt",
 				"prompt": intakeAnalysisPrompt(spec.analysisSubject),
 			},
+			map[string]any{
+				"name":    "Use analysis as output",
+				"type":    runner.AgentStepBash,
+				"command": intakeAnalysisOutputCommand(),
+			},
 		},
 	}
 
@@ -283,7 +290,8 @@ func intakeAnalysisPrompt(subject string) string {
 	return strings.Join([]string{
 		fmt.Sprintf("Analyze this %s and decide whether it is suitable for an engineering work order.", subject),
 		"Consider impact, clarity, feasibility, and whether an agent on this factory line can take a concrete action.",
-		"Return only one JSON object. Do not wrap it in markdown.",
+		fmt.Sprintf("Write one JSON object to %s. Do not write the result to another file.", intakeAnalysisOutputFile),
+		fmt.Sprintf("The file must parse with jq. Run `jq empty %s` and keep editing until it succeeds.", intakeAnalysisOutputFile),
 		"Keys:",
 		`- "score": integer from 0 through 100. A higher value means greater confidence.`,
 		`- "summary": one sentence on how suitable the work is for an agent on this factory line.`,
@@ -295,23 +303,25 @@ func intakeAnalysisPrompt(subject string) string {
 	}, "\n")
 }
 
-// intakeAnalysisResultRaw is the runner's text output. A node reference
-// resolves to one event, whose data holds that text, so the path walks
-// straight into it rather than indexing a list.
-func intakeAnalysisResultRaw() string {
-	return fmt.Sprintf(`$[%q].data.result.result`, intakeAnalysisNodeName)
-}
-
-// intakeAnalysisJSONExpr parses the JSON object the analysis runner returns.
-// Agents often wrap JSON in prose, so the slice is from the first "{" to the
-// last "}".
-func intakeAnalysisJSONExpr() string {
-	raw := intakeAnalysisResultRaw()
-	return fmt.Sprintf(`fromJSON(%s[indexOf(%s, "{"):lastIndexOf(%s, "}") + 1])`, raw, raw, raw)
+// intakeAnalysisOutputCommand promotes the file the agent wrote to the node's
+// result, so the rest of the graph reads fields instead of parsing text. The
+// prompt asks for an exact shape, but this step accepts what an agent really
+// produces: a quoted number, a missing summary, or a different number of
+// reasons. Only the score is required, because the threshold cannot run without
+// it.
+func intakeAnalysisOutputCommand() string {
+	return fmt.Sprintf(`if ! jq -ce '{
+  score: (.score | tonumber | floor),
+  summary: ((.summary // "") | tostring),
+  reasons: [(if (.reasons | type) == "array" then .reasons[] else empty end) | tostring]
+}' %s > "$SUPERPLANE_RESULT_FILE"; then
+  echo "The analysis at %s has no readable score" >&2
+  exit 1
+fi`, intakeAnalysisOutputFile, intakeAnalysisOutputFile)
 }
 
 func intakeAnalysisScorePath() string {
-	return intakeAnalysisJSONExpr() + ".score"
+	return fmt.Sprintf(`$[%q].data.result.score`, intakeAnalysisNodeName)
 }
 
 func intakeThresholdExpression(confidencePct int) string {
@@ -323,7 +333,7 @@ func intakeWorkOrderIDExpression() string {
 }
 
 func intakeConfidenceSummaryExpression() string {
-	return fmt.Sprintf(`{{ %s.summary }}`, intakeAnalysisJSONExpr())
+	return fmt.Sprintf(`{{ $[%q].data.result.summary }}`, intakeAnalysisNodeName)
 }
 
 func intakeConfidenceWriteupExpression(subject string) string {
@@ -332,9 +342,9 @@ func intakeConfidenceWriteupExpression(subject string) string {
 		subject,
 	)
 	return fmt.Sprintf(
-		`{{ %q + "\n\n### Why this score\n- " + join(%s.reasons, "\n- ") }}`,
+		`{{ %q + "\n\n### Why this score\n- " + join($[%q].data.result.reasons, "\n- ") }}`,
 		intro,
-		intakeAnalysisJSONExpr(),
+		intakeAnalysisNodeName,
 	)
 }
 

--- a/pkg/grpc/actions/factories/intake_template_test.go
+++ b/pkg/grpc/actions/factories/intake_template_test.go
@@ -1,6 +1,7 @@
 package factories
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -83,17 +84,22 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 		assert.Contains(t, prompt, `"reasons"`)
 		assert.Contains(t, prompt, `"summary"`)
 		assert.Contains(t, prompt, "exactly three short sentences")
+		assert.Contains(t, prompt, "/tmp/intake-analysis.json")
+		assert.Contains(t, prompt, "jq empty /tmp/intake-analysis.json")
+
+		output := steps[1].(map[string]any)
+		assert.Equal(t, "Use analysis as output", output["name"])
+		assert.Equal(t, runner.AgentStepBash, output["type"])
+		assert.Contains(t, output["command"], "/tmp/intake-analysis.json")
+		assert.Contains(t, output["command"], `"$SUPERPLANE_RESULT_FILE"`)
+		// A quoted or fractional score still resolves, and a summary or a
+		// reason list the agent left out does not fail the item.
+		assert.Contains(t, output["command"], "tonumber")
+		assert.Contains(t, output["command"], `(.summary // "")`)
+		assert.Contains(t, output["command"], `(.reasons | type) == "array"`)
 
 		report := findSpecNode(t, canvas, intakeReportConfidenceNodeID)
-		result := `{
-			"score": 72,
-			"summary": "This issue is a mixed fit for an agent on this factory line.",
-			"reasons": [
-				"The GitHub issue names the empty-state title and the create-invoice action.",
-				"The billing page already has an empty branch and a shared empty-state component.",
-				"The change is copy and layout. An agent can do the work, but the copy is a judgment call."
-			]
-		}`
+		result := intakeAnalysisResult(72)
 
 		assert.Equal(
 			t,
@@ -341,21 +347,21 @@ func evaluateIntakeTemplate(t *testing.T, template string, result string) any {
 func evaluateIntakeExpression(t *testing.T, expression string, pct int) any {
 	t.Helper()
 
-	return evaluateIntakeExpressionResult(t, expression, fmt.Sprintf(`{"score":%d,"reasons":["a","b","c"]}`, pct))
+	return evaluateIntakeExpressionResult(t, expression, intakeAnalysisResult(pct))
 }
 
 func evaluateIntakeExpressionResult(t *testing.T, expression string, result string) any {
 	t.Helper()
+
+	var structuredResult map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &structuredResult))
 
 	analysis := map[string]any{
 		"type": intakeAgentSpecs[0].component + ".finished",
 		"data": map[string]any{
 			"status":    "succeeded",
 			"exit_code": 0,
-			"result": map[string]any{
-				"type":   "result",
-				"result": "Here is the score:\n" + result,
-			},
+			"result":    structuredResult,
 		},
 	}
 
@@ -365,6 +371,18 @@ func evaluateIntakeExpressionResult(t *testing.T, expression string, result stri
 	require.NoError(t, err)
 
 	return output
+}
+
+func intakeAnalysisResult(score int) string {
+	return fmt.Sprintf(`{
+		"score": %d,
+		"summary": "This issue is a mixed fit for an agent on this factory line.",
+		"reasons": [
+			"The GitHub issue names the empty-state title and the create-invoice action.",
+			"The billing page already has an empty branch and a shared empty-state component.",
+			"The change is copy and layout. An agent can do the work, but the copy is a judgment call."
+		]
+	}`, score)
 }
 
 func findSpecNode(t *testing.T, canvas *yaml.Canvas, nodeID string) yaml.Node {


### PR DESCRIPTION
## Summary

An intake scored a new GitHub issue at 86, well above the 65 threshold, and
the run still failed. The analysis agent printed one JSON object to stdout,
and three node expressions parsed that text with `fromJSON` after a slice
from the first `{` to the last `}`. The agent closed the `reasons` array
with a brace, so the parse failed. The run stopped at "Meets confidence
threshold?" with an expression error, and no work order was created.

The analysis node now publishes structured output instead of text:

- The prompt asks the agent to write the object to
  `/tmp/intake-analysis.json` and to check the file with `jq empty`.
- A second step, "Use analysis as output", normalizes that file and writes
  it to `$SUPERPLANE_RESULT_FILE`, the same pattern the Plan app uses.
- The threshold, the confidence score, and the write-up read `score`,
  `summary`, and `reasons` as fields. The string slicing and the `fromJSON`
  calls are gone.

The normalization accepts what an agent really produces. A quoted or
fractional score, a missing summary, or a different number of reasons no
longer stops the item. Only the score is required, because the threshold
cannot run without it. An unparsable file or a missing score fails inside
the analysis node, where the message names the analysis.

Existing intake canvases keep their current expressions. Only intakes
created after this change get the new graph.

## Test plan

- [ ] `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories`
- [ ] Create a GitHub issues intake in a workspace with a ready agent.
- [ ] Confirm the analysis node has two steps and that the run creates a
      work order with the confidence check filled in.
- [ ] Confirm an intake whose agent writes an unparsable file fails on the
      analysis node with the message about the analysis file.

Made with [Cursor](https://cursor.com)