### PR TITLE
fix: Read intake issues with GraphQL

### DIFF
--- a/pkg/grpc/actions/factories/intake_items.go
+++ b/pkg/grpc/actions/factories/intake_items.go
@@ -102,7 +102,7 @@ func (unsupportedIntakeItemSource) Get(context.Context, string) (*IntakeItem, er
 
 func (s *gitHubIntakeItemSource) Search(ctx context.Context, query string, limit int) ([]IntakeItem, error) {
 	result, _, err := s.github.SearchIssues(ctx, gitHubIssueSearchQuery(s.repository, query), &github.SearchOptions{
-		ListOptions: github.ListOptions{PerPage: gitHubIntakePageSize(limit)},
+		ListOptions: github.ListOptions{PerPage: limit},
 	})
 	if err != nil {
 		return nil, err
@@ -198,13 +198,6 @@ func gitHubIssueSearchQuery(repository, query string) string {
 		return base
 	}
 	return fmt.Sprintf("%s %q", base, trimmed)
-}
-
-func gitHubIntakePageSize(limit int) int {
-	if limit > intakeSeedPageSize {
-		return limit
-	}
-	return intakeSeedPageSize
 }
 
 func intakeItemLimit(query string, requested int) int {

--- a/pkg/grpc/actions/factories/intake_seed.go
+++ b/pkg/grpc/actions/factories/intake_seed.go
@@ -20,10 +20,6 @@ const (
 	// intakeSeedSize is how many items a new intake analyzes at once.
 	intakeSeedSize = 5
 
-	// intakeSeedPageSize reads more than the seed size because GitHub answers
-	// the issue endpoint with pull requests too, and those are dropped.
-	intakeSeedPageSize = 30
-
 	// intakeGitHubIssuePayloadType is the payload type the GitHub trigger emits.
 	// A seeded item uses the same one, so the graph reads it the same way.
 	intakeGitHubIssuePayloadType = "github.issue"
@@ -86,34 +82,20 @@ func newestGitHubIssueEvents(
 	repository string,
 	limit int,
 ) ([]map[string]any, error) {
-	issues, _, err := client.ListIssues(ctx, repository, &github.IssueListByRepoOptions{
-		State:       "open",
-		Sort:        "created",
-		Direction:   "desc",
-		ListOptions: github.ListOptions{PerPage: intakeSeedPageSize},
-	})
-
+	issues, err := client.ListNewestOpenIssues(ctx, repository, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list the issues of %s: %w", repository, err)
 	}
 
-	return gitHubIssueEvents(issues, repository, limit)
+	return gitHubIssueEvents(issues, repository)
 }
 
-// gitHubIssueEvents keeps the first issues of a newest-first page and shapes
-// each one like the webhook body the trigger would have delivered, so the rest
-// of the graph cannot tell a seeded item from a received one.
-func gitHubIssueEvents(issues []*github.Issue, repository string, limit int) ([]map[string]any, error) {
-	events := make([]map[string]any, 0, limit)
+// gitHubIssueEvents shapes each issue of a newest-first page like the webhook
+// body the trigger would have delivered, so the rest of the graph cannot tell a
+// seeded item from a received one.
+func gitHubIssueEvents(issues []*github.Issue, repository string) ([]map[string]any, error) {
+	events := make([]map[string]any, 0, len(issues))
 	for _, issue := range issues {
-		if len(events) == limit {
-			break
-		}
-
-		if issue == nil || issue.IsPullRequest() {
-			continue
-		}
-
 		event, err := gitHubIssueEvent(issue, repository)
 		if err != nil {
 			return nil, err

--- a/pkg/grpc/actions/factories/intake_seed_test.go
+++ b/pkg/grpc/actions/factories/intake_seed_test.go
@@ -49,7 +49,7 @@ func Test__IntakeSeed(t *testing.T) {
 			"Add a flake retry to the checkout e2e suite",
 		}
 
-		events, err := gitHubIssueEvents(gitHubIssuePage(titles), "acme/backlog", intakeSeedSize)
+		events, err := gitHubIssueEvents(gitHubIssuePage(titles), "acme/backlog")
 		require.NoError(t, err)
 		require.NoError(t, emitIntakeEvents(
 			database.DB(t.Context()),
@@ -94,14 +94,8 @@ func Test__IntakeSeed(t *testing.T) {
 }
 
 func Test__GitHubIssueEvents(t *testing.T) {
-	t.Run("pull requests do not enter the intake", func(t *testing.T) {
-		issues := gitHubIssuePage([]string{"Newest issue", "Older issue"})
-		issues = append([]*github.Issue{{
-			Title:            github.Ptr("A pull request"),
-			PullRequestLinks: &github.PullRequestLinks{URL: github.Ptr("https://github.com/acme/backlog/pull/1")},
-		}}, issues...)
-
-		events, err := gitHubIssueEvents(issues, "acme/backlog", intakeSeedSize)
+	t.Run("the newest issue ends up on top of the intake", func(t *testing.T) {
+		events, err := gitHubIssueEvents(gitHubIssuePage([]string{"Newest issue", "Older issue"}), "acme/backlog")
 		require.NoError(t, err)
 		require.Len(t, events, 2)
 
@@ -111,16 +105,6 @@ func Test__GitHubIssueEvents(t *testing.T) {
 		assert.Equal(t, "Newest issue", issueEventTitle(t, events[1]))
 	})
 
-	t.Run("a page longer than the seed is cut to the newest items", func(t *testing.T) {
-		titles := []string{"1", "2", "3", "4", "5", "6", "7"}
-		events, err := gitHubIssueEvents(gitHubIssuePage(titles), "acme/backlog", intakeSeedSize)
-		require.NoError(t, err)
-
-		require.Len(t, events, intakeSeedSize)
-		assert.Equal(t, "5", issueEventTitle(t, events[0]))
-		assert.Equal(t, "1", issueEventTitle(t, events[len(events)-1]))
-	})
-
 	t.Run("an event carries what the graph reads", func(t *testing.T) {
 		issue := &github.Issue{
 			Number: github.Ptr(42),
@@ -128,7 +112,7 @@ func Test__GitHubIssueEvents(t *testing.T) {
 			Body:   github.Ptr("A retried refund charges the customer twice."),
 		}
 
-		events, err := gitHubIssueEvents([]*github.Issue{issue}, "acme/backlog", intakeSeedSize)
+		events, err := gitHubIssueEvents([]*github.Issue{issue}, "acme/backlog")
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -219,7 +220,7 @@ func (c *Client) MarkPullRequestReadyForReview(ctx context.Context, pullRequestI
 	  }
 	}`
 
-	return c.doGraphQL(ctx, mutation, map[string]any{"pullRequestId": pullRequestID})
+	return c.doGraphQL(ctx, mutation, map[string]any{"pullRequestId": pullRequestID}, nil)
 }
 
 func (c *Client) MergePullRequest(ctx context.Context, repository string, pullNumber int, commitMessage string, options *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error) {
@@ -305,14 +306,6 @@ func (c *Client) CreateIssue(ctx context.Context, repository string, issue *gith
 func (c *Client) GetIssue(ctx context.Context, repository string, issueNumber int) (*github.Issue, *github.Response, error) {
 	owner, name := c.ownerAndName(repository)
 	return c.underlying.Issues.Get(ctx, owner, name, issueNumber)
-}
-
-// ListIssues wraps the repository issue list. GitHub answers this endpoint with
-// pull requests too, so a caller that wants issues only must skip the entries
-// that report IsPullRequest.
-func (c *Client) ListIssues(ctx context.Context, repository string, opts *github.IssueListByRepoOptions) ([]*github.Issue, *github.Response, error) {
-	owner, name := c.ownerAndName(repository)
-	return c.underlying.Issues.ListByRepo(ctx, owner, name, opts)
 }
 
 func (c *Client) EditIssue(ctx context.Context, repository string, issueNumber int, issue *github.IssueRequest) (*github.Issue, *github.Response, error) {
@@ -412,7 +405,10 @@ type graphQLRequest struct {
 	Variables map[string]any `json:"variables,omitempty"`
 }
 
+// graphQLResponse reports a failure in its `errors` array on an HTTP 200, so
+// err() turns that array into a regular error.
 type graphQLResponse struct {
+	Data   json.RawMessage `json:"data"`
 	Errors []struct {
 		Message string `json:"message"`
 	} `json:"errors"`
@@ -420,9 +416,9 @@ type graphQLResponse struct {
 
 // doGraphQL sends a mutation or query to GitHub's GraphQL endpoint, reusing the
 // REST client so that authentication and the HTTP context transport apply.
-// GraphQL reports failures as an `errors` array on an HTTP 200, so those are
-// turned into a regular error here.
-func (c *Client) doGraphQL(ctx context.Context, query string, variables map[string]any) error {
+// A query that reads data passes a target for the `data` object; a mutation
+// passes nil.
+func (c *Client) doGraphQL(ctx context.Context, query string, variables map[string]any, data any) error {
 	request, err := c.underlying.NewRequest(http.MethodPost, "graphql", graphQLRequest{
 		Query:     query,
 		Variables: variables,
@@ -436,12 +432,28 @@ func (c *Client) doGraphQL(ctx context.Context, query string, variables map[stri
 		return err
 	}
 
-	if len(response.Errors) == 0 {
+	if err := response.err(); err != nil {
+		return err
+	}
+
+	if data == nil || len(response.Data) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(response.Data, data); err != nil {
+		return fmt.Errorf("failed to read GraphQL response: %w", err)
+	}
+
+	return nil
+}
+
+func (r graphQLResponse) err() error {
+	if len(r.Errors) == 0 {
 		return nil
 	}
 
 	messages := []string{}
-	for _, e := range response.Errors {
+	for _, e := range r.Errors {
 		if e.Message != "" {
 			messages = append(messages, e.Message)
 		}

--- a/pkg/integrations/github/common/issues.go
+++ b/pkg/integrations/github/common/issues.go
@@ -1,0 +1,149 @@
+package common
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v84/github"
+)
+
+// maxIssuePageSize is the largest page GitHub GraphQL returns at once.
+const maxIssuePageSize = 100
+
+const newestOpenIssuesQuery = `query($owner: String!, $name: String!, $limit: Int!) {
+  repository(owner: $owner, name: $name) {
+    issues(first: $limit, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        id
+        databaseId
+        number
+        title
+        body
+        url
+        state
+        createdAt
+        updatedAt
+        author { login }
+        labels(first: 50) { nodes { name description color } }
+        assignees(first: 50) { nodes { login databaseId } }
+        comments { totalCount }
+      }
+    }
+  }
+}`
+
+// ListNewestOpenIssues reads the newest open issues of a repository, newest
+// first.
+//
+// It asks GraphQL instead of the REST issue list because REST answers that list
+// with pull requests in the same page. A caller that wants N issues then has to
+// read a larger page and drop the pull requests, and a repository with many
+// open pull requests returns few issues, or none.
+func (c *Client) ListNewestOpenIssues(ctx context.Context, repository string, limit int) ([]*github.Issue, error) {
+	owner, name := c.ownerAndName(repository)
+
+	var result issueQueryResult
+	err := c.doGraphQL(ctx, newestOpenIssuesQuery, map[string]any{
+		"owner": owner,
+		"name":  name,
+		"limit": min(max(limit, 1), maxIssuePageSize),
+	}, &result)
+
+	if err != nil {
+		return nil, err
+	}
+
+	issues := make([]*github.Issue, 0, len(result.Repository.Issues.Nodes))
+	for _, node := range result.Repository.Issues.Nodes {
+		if node == nil {
+			continue
+		}
+
+		issues = append(issues, node.issue())
+	}
+
+	return issues, nil
+}
+
+type issueQueryResult struct {
+	Repository struct {
+		Issues struct {
+			Nodes []*issueNode `json:"nodes"`
+		} `json:"issues"`
+	} `json:"repository"`
+}
+
+type issueNode struct {
+	NodeID     string    `json:"id"`
+	DatabaseID int64     `json:"databaseId"`
+	Number     int       `json:"number"`
+	Title      string    `json:"title"`
+	Body       string    `json:"body"`
+	URL        string    `json:"url"`
+	State      string    `json:"state"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+
+	// GraphQL leaves the author out when the account is gone.
+	Author *struct {
+		Login string `json:"login"`
+	} `json:"author"`
+
+	Labels struct {
+		Nodes []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Color       string `json:"color"`
+		} `json:"nodes"`
+	} `json:"labels"`
+
+	Assignees struct {
+		Nodes []struct {
+			Login      string `json:"login"`
+			DatabaseID int64  `json:"databaseId"`
+		} `json:"nodes"`
+	} `json:"assignees"`
+
+	Comments struct {
+		TotalCount int `json:"totalCount"`
+	} `json:"comments"`
+}
+
+// issue shapes a GraphQL node like the REST body of the same issue. Callers
+// and webhook handlers then read one issue format, whatever API delivered it.
+func (n *issueNode) issue() *github.Issue {
+	issue := &github.Issue{
+		ID:        github.Ptr(n.DatabaseID),
+		NodeID:    github.Ptr(n.NodeID),
+		Number:    github.Ptr(n.Number),
+		Title:     github.Ptr(n.Title),
+		Body:      github.Ptr(n.Body),
+		HTMLURL:   github.Ptr(n.URL),
+		State:     github.Ptr(strings.ToLower(n.State)),
+		Comments:  github.Ptr(n.Comments.TotalCount),
+		CreatedAt: &github.Timestamp{Time: n.CreatedAt},
+		UpdatedAt: &github.Timestamp{Time: n.UpdatedAt},
+	}
+
+	if n.Author != nil {
+		issue.User = &github.User{Login: github.Ptr(n.Author.Login)}
+	}
+
+	for _, label := range n.Labels.Nodes {
+		issue.Labels = append(issue.Labels, &github.Label{
+			Name:        github.Ptr(label.Name),
+			Description: github.Ptr(label.Description),
+			Color:       github.Ptr(label.Color),
+		})
+	}
+
+	for _, assignee := range n.Assignees.Nodes {
+		issue.Assignees = append(issue.Assignees, &github.User{
+			ID:    github.Ptr(assignee.DatabaseID),
+			Login: github.Ptr(assignee.Login),
+		})
+	}
+
+	return issue
+}

--- a/pkg/integrations/github/common/issues_test.go
+++ b/pkg/integrations/github/common/issues_test.go
@@ -1,0 +1,85 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__issueQueryResult(t *testing.T) {
+	const response = `{
+	  "repository": {
+	    "issues": {
+	      "nodes": [
+	        {
+	          "id": "I_kwDOABCD",
+	          "databaseId": 918273,
+	          "number": 42,
+	          "title": "Handle duplicate refunds on retry",
+	          "body": "A retried refund charges the customer twice.",
+	          "url": "https://github.com/acme/backlog/issues/42",
+	          "state": "OPEN",
+	          "createdAt": "2026-08-01T10:00:00Z",
+	          "updatedAt": "2026-08-02T11:30:00Z",
+	          "author": { "login": "ana" },
+	          "labels": { "nodes": [{ "name": "bug", "description": "Broken behavior", "color": "d73a4a" }] },
+	          "assignees": { "nodes": [{ "login": "bruno", "databaseId": 77 }] },
+	          "comments": { "totalCount": 3 }
+	        },
+	        {
+	          "id": "I_kwDOEFGH",
+	          "databaseId": 918274,
+	          "number": 41,
+	          "title": "Upgrade the Node 20 base image",
+	          "body": "",
+	          "url": "https://github.com/acme/backlog/issues/41",
+	          "state": "OPEN",
+	          "createdAt": "2026-07-30T09:00:00Z",
+	          "updatedAt": "2026-07-30T09:00:00Z",
+	          "author": null,
+	          "labels": { "nodes": [] },
+	          "assignees": { "nodes": [] },
+	          "comments": { "totalCount": 0 }
+	        }
+	      ]
+	    }
+	  }
+	}`
+
+	var result issueQueryResult
+	require.NoError(t, json.Unmarshal([]byte(response), &result))
+	require.Len(t, result.Repository.Issues.Nodes, 2)
+
+	t.Run("an issue reads like its REST body", func(t *testing.T) {
+		issue := result.Repository.Issues.Nodes[0].issue()
+
+		assert.Equal(t, int64(918273), issue.GetID())
+		assert.Equal(t, "I_kwDOABCD", issue.GetNodeID())
+		assert.Equal(t, 42, issue.GetNumber())
+		assert.Equal(t, "Handle duplicate refunds on retry", issue.GetTitle())
+		assert.Equal(t, "A retried refund charges the customer twice.", issue.GetBody())
+		assert.Equal(t, "https://github.com/acme/backlog/issues/42", issue.GetHTMLURL())
+		assert.Equal(t, "open", issue.GetState())
+		assert.Equal(t, 3, issue.GetComments())
+		assert.Equal(t, "2026-08-01T10:00:00Z", issue.GetCreatedAt().Format("2006-01-02T15:04:05Z"))
+		assert.Equal(t, "ana", issue.GetUser().GetLogin())
+
+		require.Len(t, issue.Labels, 1)
+		assert.Equal(t, "bug", issue.Labels[0].GetName())
+
+		require.Len(t, issue.Assignees, 1)
+		assert.Equal(t, "bruno", issue.Assignees[0].GetLogin())
+		assert.Equal(t, int64(77), issue.Assignees[0].GetID())
+	})
+
+	t.Run("an issue without an author or lists stays readable", func(t *testing.T) {
+		issue := result.Repository.Issues.Nodes[1].issue()
+
+		assert.Equal(t, 41, issue.GetNumber())
+		assert.Nil(t, issue.User)
+		assert.Empty(t, issue.Labels)
+		assert.Empty(t, issue.Assignees)
+	})
+}


### PR DESCRIPTION
## Summary

A new GitHub issues intake seeds itself with the newest open issues of
the repository, so the board has work at once. The seed read the REST
issue list. GitHub answers that endpoint with pull requests in the same
page, so the seed asked for a page of 30 and dropped every row that was
a pull request. A repository with many open pull requests gave the
intake fewer issues than the seed size of five. Some repositories
started with three items, and a repository whose newest 30 rows are all
pull requests started empty.

The seed now uses the GraphQL `repository.issues` connection. That
connection contains issues only, so a request for five issues returns
five issues and no page padding is necessary.

Each GraphQL node maps back into the REST issue shape (`number`,
`title`, `body`, `html_url`, `state`, timestamps, author, labels,
assignees, comment count). The generated graph reads one issue format,
whatever API delivered the item: the CEL filters on
`root().data.issue.labels` and `root().data.issue.assignees` and the
work order origin URL keep the same source of data.

The change also removes code that only existed for the mixed page: the
REST `ListIssues` wrapper, the `intakeSeedPageSize` over-fetch
constant, and the pull request filter in the seed. The intake item
search path constrains its query with `is:issue is:open` already, so it
now requests exactly the number of items it wants.

GraphQL needs the same issue read permission as the REST list, and the
client already calls the `graphql` endpoint for
`MarkPullRequestReadyForReview`, so no new authentication path is
introduced.

## Test plan

- [ ] `make test PKG_TEST_PACKAGES=./pkg/integrations/github/common` passes: a GraphQL page decodes and maps to the REST issue shape, including an issue with a deleted author and empty label and assignee lists.
- [ ] `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/factories` passes: the seed emits the newest issue on top of the intake.
- [ ] `make lint` and `make check.build.app` pass.
- [ ] Manual: create a GitHub issues intake for a repository that has more open pull requests than issues in its newest rows. Confirm the intake starts with five issues and no pull requests.
- [ ] Manual: confirm a seeded item shows its title, body, and origin link, and that a label filter on the intake still matches.


Made with [Cursor](https://cursor.com)