### PR TITLE
feat: show dialog to let the user set app name upon creating (#5805)

### DIFF
--- a/web_src/src/pages/home/CreateAppModal.tsx
+++ b/web_src/src/pages/home/CreateAppModal.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { generateCanvasName } from "@/lib/canvasNameGenerator";
+import { getApiErrorMessage } from "@/lib/errors";
+
+const MAX_APP_NAME_LENGTH = 50;
+
+interface CreateAppModalProps {
+  open: boolean;
+  isSaving: boolean;
+  onClose: () => void;
+  onCreate: (name: string) => Promise<void>;
+}
+
+export function CreateAppModal({ open, isSaving, onClose, onCreate }: CreateAppModalProps) {
+  const [name, setName] = useState("");
+  const [nameError, setNameError] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+
+    setName("");
+    setNameError("");
+  }, [open]);
+
+  const handleClose = () => {
+    if (isSaving) return;
+
+    onClose();
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSaving) return;
+
+    const appName = name.trim() || generateCanvasName();
+
+    try {
+      await onCreate(appName);
+    } catch (error) {
+      const errorMessage = getApiErrorMessage(error, "Failed to create app");
+      if (errorMessage.toLowerCase().includes("already") || errorMessage.toLowerCase().includes("exists")) {
+        setNameError("An app with this name already exists");
+      }
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) handleClose();
+      }}
+    >
+      <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create app</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={(event) => void handleSubmit(event)}>
+          <div className="space-y-2">
+            <Label htmlFor="create-app-name-input">App name (optional)</Label>
+            <Input
+              id="create-app-name-input"
+              value={name}
+              onChange={(event) => {
+                setName(event.target.value);
+                setNameError("");
+              }}
+              maxLength={MAX_APP_NAME_LENGTH}
+              aria-invalid={Boolean(nameError)}
+              aria-describedby={`create-app-name-description ${nameError ? "create-app-name-error" : ""}`}
+              autoFocus
+            />
+            <p id="create-app-name-description" className="text-xs text-gray-500 dark:text-gray-400">
+              Leave this blank to use a generated name.
+            </p>
+            {nameError ? (
+              <p id="create-app-name-error" className="text-xs text-red-600">
+                {nameError}
+              </p>
+            ) : null}
+          </div>
+
+          <DialogFooter className="mt-6 flex-row justify-start gap-3 sm:justify-start">
+            <LoadingButton type="submit" loading={isSaving} loadingText="Creating...">
+              Create app
+            </LoadingButton>
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+              Cancel
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/home/FreshOrgLanding.tsx
+++ b/web_src/src/pages/home/FreshOrgLanding.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/components/ui/button";
 import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
-import { generateCanvasName } from "@/lib/canvasNameGenerator";
 import { FEATURE_FACTORIES } from "@/lib/experimentalFeatures";
 import { cn } from "@/lib/utils";
 import { ArrowRight } from "lucide-react";
@@ -8,6 +7,7 @@ import { useEffect, useRef, useState, type RefObject } from "react";
 
 import { LeadIcon, type AppEntry } from "./AppDetailModal";
 import { APP_CATALOG } from "./appCatalog";
+import { CreateAppModal } from "./CreateAppModal";
 import { FactorySetupPanel } from "./FactorySetupPanel";
 import { getFactoryDefinition } from "./factories";
 import { homeListCardClassName, homePageSubtitleClassName, homePageTitleClassName } from "./homePageStyles";
@@ -36,7 +36,11 @@ export function FreshOrgLanding({
   const { has: hasExperimentalFeature } = useExperimentalFeature(organizationId);
   const showLegacyFactoryOnboarding = !hasExperimentalFeature(FEATURE_FACTORIES);
   const factory = getFactoryDefinition();
-  const { createApp, isSaving } = useCreateApp({ folder });
+  const [isCreateAppModalOpen, setIsCreateAppModalOpen] = useState(false);
+  const { createApp, isSaving } = useCreateApp({
+    folder,
+    onCreated: () => setIsCreateAppModalOpen(false),
+  });
   const { installFactory, isInstalling } = useInstallFactory({ folder });
   const [showFactorySetup, setShowFactorySetup] = useState(false);
   const [showCatalog, setShowCatalog] = useState(false);
@@ -117,7 +121,7 @@ export function FreshOrgLanding({
             showCatalog={showCatalog}
             onCreateBlank={() => {
               if (busy) return;
-              void createApp(generateCanvasName());
+              setIsCreateAppModalOpen(true);
             }}
             onToggleCatalog={() => setShowCatalog((open) => !open)}
           />
@@ -137,6 +141,13 @@ export function FreshOrgLanding({
           }}
         />
       )}
+
+      <CreateAppModal
+        open={isCreateAppModalOpen}
+        isSaving={isSaving}
+        onClose={() => setIsCreateAppModalOpen(false)}
+        onCreate={createApp}
+      />
     </div>
   );
 }

--- a/web_src/src/pages/home/index.spec.tsx
+++ b/web_src/src/pages/home/index.spec.tsx
@@ -254,7 +254,7 @@ describe("HomePage canvas folders", () => {
     });
   });
 
-  it("uses the factory-first landing as the canvas creation entrypoint", async () => {
+  it("uses a generated name when the optional app name is blank", async () => {
     const user = userEvent.setup();
     mutationMocks.createCanvasAsync.mockResolvedValue({
       data: { canvas: { metadata: { id: "canvas-new" } } },
@@ -266,6 +266,14 @@ describe("HomePage canvas folders", () => {
 
     await user.click(await screen.findByRole("button", { name: /create a blank app/i }));
 
+    expect(screen.getByRole("dialog", { name: "Create app" })).toBeInTheDocument();
+    expect(screen.getByLabelText("App name (optional)")).toHaveValue("");
+    expect(screen.getByText("Leave this blank to use a generated name.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create app" })).toBeEnabled();
+    expect(mutationMocks.createCanvasAsync).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Create app" }));
+
     await waitFor(() => {
       expect(mutationMocks.createCanvasAsync).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -273,6 +281,28 @@ describe("HomePage canvas folders", () => {
           method: "ui",
         }),
       );
+    });
+  });
+
+  it("uses the app name entered by the user", async () => {
+    const user = userEvent.setup();
+    mutationMocks.createCanvasAsync.mockResolvedValue({
+      data: { canvas: { metadata: { id: "canvas-new" } } },
+    });
+    useCanvases.mockReturnValue({ data: [], isLoading: false, error: null });
+    useCanvasFolders.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderHome();
+
+    await user.click(await screen.findByRole("button", { name: /create a blank app/i }));
+    await user.type(screen.getByLabelText("App name (optional)"), "Sentry Analysis");
+    await user.click(screen.getByRole("button", { name: "Create app" }));
+
+    await waitFor(() => {
+      expect(mutationMocks.createCanvasAsync).toHaveBeenCalledWith({
+        name: "Sentry Analysis",
+        method: "ui",
+      });
     });
   });
 
@@ -496,10 +526,12 @@ describe("HomePage canvas folders", () => {
     expect(await screen.findByRole("heading", { name: "Create New App in Deployments Folder" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /create a blank app/i }));
+    await user.type(screen.getByLabelText("App name (optional)"), "Deployment Analysis");
+    await user.click(screen.getByRole("button", { name: "Create app" }));
 
     await waitFor(() => {
       expect(mutationMocks.createCanvasAsync).toHaveBeenCalledWith({
-        name: expect.stringMatching(/^[a-z]+-[a-z]+$/),
+        name: "Deployment Analysis",
         method: "ui",
       });
       expect(mutationMocks.updateCanvasFolderMembership).toHaveBeenCalledWith({
@@ -528,6 +560,8 @@ describe("HomePage canvas folders", () => {
     const deploymentsSection = screen.getByText("Deployments").closest("section")!;
     await user.click(within(deploymentsSection).getByLabelText("Create app in folder Deployments"));
     await user.click(await screen.findByRole("button", { name: /create a blank app/i }));
+    await user.type(screen.getByLabelText("App name (optional)"), "Deployment Analysis");
+    await user.click(screen.getByRole("button", { name: "Create app" }));
 
     expect(await screen.findByText("Canvas editor")).toBeInTheDocument();
     expect(showErrorToast).toHaveBeenCalledWith("App created, but failed to add it to folder");
@@ -586,6 +620,8 @@ describe("HomePage canvas folders", () => {
 
     renderHome(["/org-123/apps/new?folderId=folder-1"]);
     await user.click(await screen.findByRole("button", { name: /create a blank app/i }));
+    await user.type(screen.getByLabelText("App name (optional)"), "Deployment Analysis");
+    await user.click(screen.getByRole("button", { name: "Create app" }));
 
     expect(mutationMocks.createCanvasAsync).not.toHaveBeenCalled();
     expect(showErrorToast).toHaveBeenCalledWith("You don't have permission to update canvases.");


### PR DESCRIPTION
**What changed**
Blank app creation now opens a naming dialog. Users can enter a custom name or leave the field blank to use a generated name.

**Why**
Generated names make apps difficult to find later. The dialog lets users assign a memorable name during creation.

**How**
The dialog uses the existing app creation flow. Empty input calls the current name generator, while custom input uses the trimmed value.

**Related issues**
Closes #5805

**Breaking changes**
None. Existing generated-name behavior remains available when the name field is blank.