### PR TITLE
fix: Remove GitHub App default events

### DIFF
--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -59,20 +59,6 @@ If no account has the App, GitHub will ask you to install it.
 `
 )
 
-var defaultGitHubAppEvents = []string{
-	"create",
-	"issue_comment",
-	"issues",
-	"pull_request",
-	"pull_request_review",
-	"pull_request_review_comment",
-	"push",
-	"release",
-	"status",
-	"check_run",
-	"workflow_run",
-}
-
 func init() {
 	registry.RegisterIntegrationWithOptions("github", &GitHub{}, registry.IntegrationRegistrationOptions{
 		WebhookHandler: &GitHubWebhookHandler{},
@@ -963,10 +949,9 @@ func (g *GitHub) browserActionURL(organization string) string {
 
 func (g *GitHub) appManifest(ctx core.SyncContext) string {
 	manifest := map[string]any{
-		"name":           `SuperPlane GH integration`,
-		"public":         false,
-		"url":            "https://superplane.com",
-		"default_events": defaultGitHubAppEvents,
+		"name":   `SuperPlane GH integration`,
+		"public": false,
+		"url":    "https://superplane.com",
 		"default_permissions": map[string]string{
 			"issues":                      "write",
 			"actions":                     "write",

--- a/pkg/integrations/github/github_test.go
+++ b/pkg/integrations/github/github_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 type githubManifest struct {
-	DefaultEvents      []string          `json:"default_events"`
 	DefaultPermissions map[string]string `json:"default_permissions"`
 }
 
@@ -36,7 +35,7 @@ func Test__GitHub__Sync(t *testing.T) {
 		assert.Equal(t, integrationCtx.BrowserAction.Method, "POST")
 		assert.NotEmpty(t, integrationCtx.BrowserAction.Description)
 		assert.Equal(t, integrationCtx.BrowserAction.URL, "https://github.com/settings/apps/new")
-		assertManifestContainsDefaultEvents(t, integrationCtx.BrowserAction.FormFields["manifest"])
+		assertManifestContainsChecksPermission(t, integrationCtx.BrowserAction.FormFields["manifest"])
 
 		//
 		// Metadata is set
@@ -61,7 +60,7 @@ func Test__GitHub__Sync(t *testing.T) {
 		assert.Equal(t, integrationCtx.BrowserAction.Method, "POST")
 		assert.NotEmpty(t, integrationCtx.BrowserAction.Description)
 		assert.Equal(t, integrationCtx.BrowserAction.URL, "https://github.com/organizations/testhq/settings/apps/new")
-		assertManifestContainsDefaultEvents(t, integrationCtx.BrowserAction.FormFields["manifest"])
+		assertManifestContainsChecksPermission(t, integrationCtx.BrowserAction.FormFields["manifest"])
 
 		//
 		// Metadata is set
@@ -273,13 +272,12 @@ func Test__listInstallationRepositories__paginates_all_pages(t *testing.T) {
 	require.Equal(t, "https://github.com/test/repo2", repos[1].URL)
 }
 
-func assertManifestContainsDefaultEvents(t *testing.T, manifestJSON string) {
+func assertManifestContainsChecksPermission(t *testing.T, manifestJSON string) {
 	t.Helper()
 
 	require.NotEmpty(t, manifestJSON)
 
 	var manifest githubManifest
 	require.NoError(t, json.Unmarshal([]byte(manifestJSON), &manifest))
-	require.Equal(t, defaultGitHubAppEvents, manifest.DefaultEvents)
 	require.Equal(t, "read", manifest.DefaultPermissions["checks"])
 }


### PR DESCRIPTION
## Summary

Reverts https://github.com/superplanehq/superplane/pull/4302.

The GitHub App manifest no longer includes `default_events`.
#4302 pre-selected webhook events at app creation.
That list grew as new triggers landed.
Setup must not pin webhook subscriptions in the manifest.

Permissions in the manifest stay unchanged.

## Test plan

- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/integrations/github`.
- [ ] Start GitHub App setup from organization settings.
- [ ] Confirm the GitHub create-app page does not pre-select webhook events.
- [ ] Confirm the checks permission is still `read`.


Made with [Cursor](https://cursor.com)