### PR TITLE
feat: Announce the review wait from the Implement app

### DIFF
--- a/web_src/src/pages/factories/__fixtures__/factoryPageWorkOrders.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageWorkOrders.ts
@@ -80,7 +80,7 @@ export const OPEN_WORK_ORDER: FactoriesWorkOrder = {
       key: "pr-closure",
       kind: "info",
       headline: "Listening for user review",
-      body: "This automation finished and opened [PR #6812](https://github.com/superplanehq/superplane/pull/6812). Tag `@superplaneagent` in comment to request changes. Task will automatically close when the pull request is closed or merged.",
+      body: "This automation finished and opened [PR #6812](https://github.com/superplanehq/superplane/pull/6812). Task will automatically close when the pull request is closed or merged.",
       ctaLabel: "Review PR #6812",
       ctaUrl: "https://github.com/superplanehq/superplane/pull/6812",
       automation: { appId: "app-refund-verifier", appName: "PR Closure" },

--- a/web_src/src/pages/factories/lib/workOrderAttention.spec.ts
+++ b/web_src/src/pages/factories/lib/workOrderAttention.spec.ts
@@ -72,7 +72,7 @@ describe("getWorkOrderAttentionReason", () => {
             {
               key: "pr-closure",
               headline: "Waiting for user review",
-              body: "Tag `@superplaneagent` to request changes.",
+              body: "The pull request is open.",
             },
           ],
         }),

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -375,7 +375,6 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(note.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(within(note).getByRole("heading", { name: "Listening for user review" })).toBeInTheDocument();
     expect(note).toHaveTextContent("This automation finished and opened PR #6812.");
-    expect(note).toHaveTextContent("Tag @superplaneagent in comment to request changes.");
     expect(note).toHaveTextContent("Task will automatically close when the pull request is closed or merged.");
     expect(within(note).getByRole("link", { name: "Review PR #6812" })).toHaveAttribute(
       "href",

--- a/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
@@ -20,6 +20,9 @@ spec:
     - channel: default
       sourceId: create-draft-pr
       targetId: attach-pr-artifact
+    - channel: default
+      sourceId: attach-pr-artifact
+      targetId: set-pr-closure-note
   nodes:
     - id: onrun-implement
       name: Start
@@ -253,3 +256,19 @@ spec:
         x: 1442
         'y': 1200
       isCollapsed: false
+    - id: set-pr-closure-note
+      name: Set PR closure note
+      type: TYPE_ACTION
+      component: setWorkOrderStatusNote
+      configuration:
+        orderId: '{{ order().id }}'
+        noteKey: pr-closure
+        headline: Listening for user review
+        body: This automation finished and opened this pull request. Task will automatically close when the pull request is closed or merged.
+        ctaLabel: 'Review PR #{{ $["Create Draft Pull Request"].data.number }}'
+        ctaUrl: '{{ $["Create Draft Pull Request"].data._links.html.href }}'
+        showOnlyWhenWaiting: true
+      position:
+        x: 1442
+        'y': 1368
+      isCollapsed: true

--- a/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/pr.canvas.yaml
@@ -185,7 +185,7 @@ spec:
         orderId: '{{ order().id }}'
         noteKey: pr-closure
         headline: Listening for user review
-        body: This automation finished and opened this pull request. Tag `@superplaneagent` in comment to request changes. Task will automatically close when the pull request is closed or merged.
+        body: This automation finished and opened this pull request. Task will automatically close when the pull request is closed or merged.
         ctaLabel: 'Review PR #{{ $["Create Draft Pull Request"].data.number }}'
         ctaUrl: '{{ $["Create Draft Pull Request"].data.html_url }}'
         showOnlyWhenWaiting: true

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -133,11 +133,13 @@ describe("setup factory line apps", () => {
       "implementation-agent-no-issue",
       "create-draft-pr",
       "attach-pr-artifact",
+      "set-pr-closure-note",
     ]);
     expect(implementation).toMatch(/sourceId: add-branch-artifact\n\s+targetId: implementation-agent-no-issue/);
     expect(implementation).toMatch(/sourceId: implementation-agent-no-issue\n\s+targetId: create-draft-pr/);
     expect(implementation).toMatch(/component: github\.createPullRequest[\s\S]*repository: acme\/app/);
     expect(implementation).toMatch(/sourceId: create-draft-pr\n\s+targetId: attach-pr-artifact/);
+    expect(implementation).toMatch(/sourceId: attach-pr-artifact\n\s+targetId: set-pr-closure-note/);
     expect(implementation).toMatch(
       /id: attach-pr-artifact[\s\S]*artifactType: pr[\s\S]*state: open[\s\S]*url: '\{\{ \$\["Create Draft Pull Request"\]\.data\._links\.html\.href \}\}'/,
     );
@@ -148,6 +150,7 @@ describe("setup factory line apps", () => {
       "implementation-agent-no-issue": 5,
       "create-draft-pr": 100,
       "attach-pr-artifact": 100,
+      "set-pr-closure-note": undefined,
     });
 
     const pr = materializeOnboardingApp("line-pr");
@@ -170,6 +173,17 @@ describe("setup factory line apps", () => {
     expect(pr).toContain("headline: Listening for user review");
     expect(pr).toContain("ctaUrl: '{{ $[\"Create Draft Pull Request\"].data.html_url }}'");
     expect(pr).toContain("showOnlyWhenWaiting: true");
+  });
+
+  it("announces the PR-merge wait after the implement app attaches the pull request", () => {
+    const implementation = materializeOnboardingApp("line-implementation");
+
+    expect(implementation).toMatch(/sourceId: attach-pr-artifact[\s\S]*targetId: set-pr-closure-note/);
+    expect(implementation).toContain("component: setWorkOrderStatusNote");
+    expect(implementation).toContain("noteKey: pr-closure");
+    expect(implementation).toContain("headline: Listening for user review");
+    expect(implementation).toContain("ctaUrl: '{{ $[\"Create Draft Pull Request\"].data._links.html.href }}'");
+    expect(implementation).toContain("showOnlyWhenWaiting: true");
   });
 
   it("fails planning when the agent does not write the plan file", () => {


### PR DESCRIPTION
## Summary

A new workspace installs the Plan and Implement apps only. The Verify app stays out of the workspace, but it held the only `setWorkOrderStatusNote` step that tells the user the work order waits for a pull request review.

The Implement app opens the draft pull request, attaches it to the work order, and stops. The work order page then shows no next step. The user does not know that a review is necessary, or that the order closes automatically when the pull request closes or merges.

This change sets the pull request closure note from the Implement app, after the pull request artifact attaches. The note uses the same key (`pr-closure`) and copy as the Verify app, so the `pr-closure` event app still updates or clears the same note.

The note body no longer asks the user to tag the agent for changes. A status note must show only what resolves the wait.

## Test plan

- [ ] Run `make check.test.ui`. The factory line app tests pass.
- [ ] Create a new workspace and dispatch a work order through the line.
- [ ] Confirm the work order page shows the "Listening for user review" note after the Implement app opens the draft pull request.
- [ ] Confirm the note action button opens the correct pull request.
- [ ] Merge the pull request and confirm the work order closes and the note clears.


Made with [Cursor](https://cursor.com)