### PR TITLE
fix: Monthly schedules skipping a month on day 29-31 ticks

### DIFF
--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -762,9 +762,21 @@ func nextMonthsTrigger(interval int, dayOfMonth int, hour int, minute int, now t
 	}
 
 	nowInTZ := now
-	nextTriggerMonths := interval
-	nextTrigger := nowInTZ.AddDate(0, nextTriggerMonths, 0)
-	nextTrigger = time.Date(nextTrigger.Year(), nextTrigger.Month(), dayOfMonth, hour, minute, 0, 0, nextTrigger.Location())
+	// Advance the month arithmetically instead of via AddDate, which keeps the
+	// current day while adding months and normalizes overflow forward (Jan 31
+	// + 1 month = Feb 31 = Mar 3), landing the trigger one month late whenever
+	// a tick happens on day 29-31.
+	monthIndex := int(nowInTZ.Month()) - 1 + interval
+	targetYear := nowInTZ.Year() + monthIndex/12
+	targetMonth := time.Month(monthIndex%12 + 1)
+	// Clamp dayOfMonth to the target month's length so 29-31 means "last day"
+	// in shorter months instead of rolling into the following month.
+	lastDay := time.Date(targetYear, targetMonth+1, 0, 0, 0, 0, 0, nowInTZ.Location()).Day()
+	day := dayOfMonth
+	if day > lastDay {
+		day = lastDay
+	}
+	nextTrigger := time.Date(targetYear, targetMonth, day, hour, minute, 0, 0, nowInTZ.Location())
 
 	utcResult := nextTrigger.UTC()
 	return &utcResult, nil

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -160,6 +160,54 @@ func TestGetNextTrigger(t *testing.T) {
 			expectNext: mustParseTime("2025-02-15T14:30:00Z"),
 		},
 		{
+			name: "months configuration on day 31 does not skip a month",
+			config: Configuration{
+				Type:           TypeMonths,
+				MonthsInterval: intPtr(1),
+				DayOfMonth:     intPtr(15),
+				Hour:           intPtr(14),
+				Minute:         intPtr(30),
+			},
+			now:        mustParseTime("2025-01-31T10:00:00Z"),
+			expectNext: mustParseTime("2025-02-15T14:30:00Z"),
+		},
+		{
+			name: "months configuration clamps dayOfMonth to the target month's length",
+			config: Configuration{
+				Type:           TypeMonths,
+				MonthsInterval: intPtr(1),
+				DayOfMonth:     intPtr(31),
+				Hour:           intPtr(14),
+				Minute:         intPtr(30),
+			},
+			now:        mustParseTime("2025-01-10T10:00:00Z"),
+			expectNext: mustParseTime("2025-02-28T14:30:00Z"),
+		},
+		{
+			name: "months configuration keeps dayOfMonth 31 in months that have it",
+			config: Configuration{
+				Type:           TypeMonths,
+				MonthsInterval: intPtr(1),
+				DayOfMonth:     intPtr(31),
+				Hour:           intPtr(14),
+				Minute:         intPtr(30),
+			},
+			now:        mustParseTime("2025-02-10T10:00:00Z"),
+			expectNext: mustParseTime("2025-03-31T14:30:00Z"),
+		},
+		{
+			name: "months configuration crosses a year boundary",
+			config: Configuration{
+				Type:           TypeMonths,
+				MonthsInterval: intPtr(2),
+				DayOfMonth:     intPtr(15),
+				Hour:           intPtr(14),
+				Minute:         intPtr(30),
+			},
+			now:        mustParseTime("2025-11-30T10:00:00Z"),
+			expectNext: mustParseTime("2026-01-15T14:30:00Z"),
+		},
+		{
 			name: "cron configuration",
 			config: Configuration{
 				Type:           TypeCron,

--- a/web_src/src/pages/app/mappers/schedule.ts
+++ b/web_src/src/pages/app/mappers/schedule.ts
@@ -244,10 +244,16 @@ function calculateNextTrigger(configuration: ScheduleConfiguration, referenceNex
 
       if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
 
-      // Match Go backend: add interval months in timezone, set day/hour/minute
+      // Match Go backend: advance the month arithmetically (setMonth on a day
+      // 29-31 normalizes overflow into the following month, skipping a month),
+      // then clamp the day to the target month's length so dayOfMonth 29-31
+      // means "last day" in shorter months.
       const nextTriggerInTZ = new Date(nowInTZ);
-      nextTriggerInTZ.setMonth(nextTriggerInTZ.getMonth() + interval);
-      nextTriggerInTZ.setDate(dayOfMonth);
+      const monthIndex = nextTriggerInTZ.getMonth() + interval;
+      const targetYear = nextTriggerInTZ.getFullYear() + Math.floor(monthIndex / 12);
+      const targetMonth = monthIndex % 12;
+      const lastDay = new Date(targetYear, targetMonth + 1, 0).getDate();
+      nextTriggerInTZ.setFullYear(targetYear, targetMonth, Math.min(dayOfMonth, lastDay));
       nextTriggerInTZ.setHours(hour);
       nextTriggerInTZ.setMinutes(minute);
       nextTriggerInTZ.setSeconds(0);


### PR DESCRIPTION
Fixes #6877.

`nextMonthsTrigger` advanced the month with `AddDate`, which keeps the current day-of-month and normalizes overflow forward (Jan 31 + 1 month = Feb 31 = Mar 3). The target month was read off after that normalization, so any tick landing on day 29-31 scheduled the next trigger one month late, and the drift self-perpetuated because `emitEvent` recomputes from `time.Now()` on every tick. `time.Date` normalized `dayOfMonth` the same way, so `dayOfMonth=31` fired on the 1st-3rd of the following month in every month shorter than 31 days.

This change advances the month arithmetically and clamps `dayOfMonth` to the target month's length, so 29-31 means last day in shorter months. The frontend mirror in `calculateNextTrigger` (months case) reproduced both bugs in the Next: preview via `setMonth`/`setDate` normalization and gets the same fix.

Tests: added exact-date cases for a day-31 tick, dayOfMonth=31 clamping to Feb 28, dayOfMonth=31 kept in a 31-day month, and a year-boundary interval. `go test ./pkg/triggers/schedule/` passes.
