### PR TITLE
fix: Open the Unique Line on Workspace Visit

### DIFF
--- a/pkg/grpc/actions/factories/list_factories.go
+++ b/pkg/grpc/actions/factories/list_factories.go
@@ -3,6 +3,7 @@ package factories
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
@@ -14,12 +15,32 @@ func ListFactories(ctx context.Context, organizationID string) (*pb.ListFactorie
 		return nil, factoryErrorToStatus(err, "failed to list factories")
 	}
 
-	factories, err := models.ListFactories(database.DB(ctx), orgID)
+	db := database.DB(ctx)
+	factories, err := models.ListFactories(db, orgID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to list factories")
+	}
+
+	factoryIDs := make([]uuid.UUID, len(factories))
+	for i := range factories {
+		factoryIDs[i] = factories[i].ID
+	}
+
+	lines, err := models.ListFactoryLinesByFactoryIDs(db, orgID, factoryIDs)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to list factories")
 	}
 
 	return &pb.ListFactoriesResponse{
-		Factories: serializeFactories(factories),
+		Factories: serializeFactories(factories, groupFactoryLinesByFactoryID(lines)),
 	}, nil
+}
+
+func groupFactoryLinesByFactoryID(lines []models.FactoryLine) map[uuid.UUID][]models.FactoryLine {
+	grouped := make(map[uuid.UUID][]models.FactoryLine)
+	for i := range lines {
+		factoryID := lines[i].FactoryID
+		grouped[factoryID] = append(grouped[factoryID], lines[i])
+	}
+	return grouped
 }

--- a/pkg/grpc/actions/factories/list_factories_test.go
+++ b/pkg/grpc/actions/factories/list_factories_test.go
@@ -1,0 +1,49 @@
+package factories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func Test__ListFactories_IncludesLines(t *testing.T) {
+	r := support.Setup(t)
+	ctx := t.Context()
+	db := database.DB(ctx)
+
+	withLine, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	line, err := withLine.CreateLine(db, "plan-and-implement", nil)
+	require.NoError(t, err)
+
+	empty, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	resp, err := ListFactories(ctx, r.Organization.ID.String())
+	require.NoError(t, err)
+
+	listedWithLine := listedFactoryByID(resp.Factories, withLine.ID.String())
+	require.NotNil(t, listedWithLine)
+	require.Len(t, listedWithLine.Lines, 1)
+	assert.Equal(t, line.ID.String(), listedWithLine.Lines[0].Id)
+	assert.Equal(t, "plan-and-implement", listedWithLine.Lines[0].Name)
+	assert.Nil(t, listedWithLine.Lines[0].Metrics)
+
+	listedEmpty := listedFactoryByID(resp.Factories, empty.ID.String())
+	require.NotNil(t, listedEmpty)
+	assert.Empty(t, listedEmpty.Lines)
+}
+
+func listedFactoryByID(factories []*pb.Factory, id string) *pb.Factory {
+	for _, factory := range factories {
+		if factory.GetId() == id {
+			return factory
+		}
+	}
+	return nil
+}

--- a/pkg/grpc/actions/factories/serialization.go
+++ b/pkg/grpc/actions/factories/serialization.go
@@ -207,10 +207,10 @@ func serializeFactoryLine(line *models.FactoryLine) *pb.FactoryLine {
 	}
 }
 
-func serializeFactories(factories []models.Factory) []*pb.Factory {
+func serializeFactories(factories []models.Factory, linesByFactory map[uuid.UUID][]models.FactoryLine) []*pb.Factory {
 	result := make([]*pb.Factory, len(factories))
 	for i := range factories {
-		result[i] = serializeFactory(&factories[i])
+		result[i] = serializeFactoryWithLines(&factories[i], linesByFactory[factories[i].ID], nil)
 	}
 	return result
 }

--- a/pkg/models/factory_line.go
+++ b/pkg/models/factory_line.go
@@ -152,6 +152,25 @@ func (f *Factory) ListLines(tx *gorm.DB) ([]FactoryLine, error) {
 	return lines, nil
 }
 
+func ListFactoryLinesByFactoryIDs(tx *gorm.DB, organizationID uuid.UUID, factoryIDs []uuid.UUID) ([]FactoryLine, error) {
+	if len(factoryIDs) == 0 {
+		return nil, nil
+	}
+
+	var lines []FactoryLine
+	err := tx.
+		Where("organization_id = ? AND factory_id IN ?", organizationID, factoryIDs).
+		Order("name ASC").
+		Order("id ASC").
+		Find(&lines).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return lines, nil
+}
+
 func (l *FactoryLine) Update(tx *gorm.DB, name *string, steps []FactoryLineStep) error {
 	updates := map[string]any{
 		"updated_at": time.Now(),

--- a/web_src/src/pages/factories/FactoriesIndexPage.spec.tsx
+++ b/web_src/src/pages/factories/FactoriesIndexPage.spec.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ACME_ONBOARDING_FACTORY,
+  ACME_ONBOARDING_LINE_ID,
+  EMPTY_FACTORY,
+  FACTORIES_ORGANIZATION_ID,
+} from "./__fixtures__/factoryPageResponses";
+import { FactoriesIndexPage } from "./FactoriesIndexPage";
+import { factoryHomePath } from "./lib/factoryPagePaths";
+
+const listedFactories: Array<typeof ACME_ONBOARDING_FACTORY> = [];
+
+vi.mock("@/hooks/useFactoryData", () => ({
+  useFactories: () => ({ data: listedFactories, isLoading: false, error: null }),
+}));
+
+vi.mock("@/contexts/useAccount", () => ({
+  useAccount: () => ({ account: null }),
+}));
+
+vi.mock("@/contexts/usePermissions", () => ({
+  usePermissions: () => ({ canAct: () => true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: () => undefined,
+}));
+
+function CurrentPath() {
+  return <span data-testid="location-path">{useLocation().pathname}</span>;
+}
+
+function renderIndex() {
+  return render(
+    <MemoryRouter initialEntries={[`/${FACTORIES_ORGANIZATION_ID}/workspaces`]}>
+      <Routes>
+        <Route path="/:organizationId/workspaces" element={<FactoriesIndexPage />} />
+        <Route path="/:organizationId/workspaces/:factoryKey/*" element={<CurrentPath />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("FactoriesIndexPage", () => {
+  beforeEach(() => {
+    listedFactories.length = 0;
+  });
+
+  it("opens the unique line when the workspace has one line", () => {
+    listedFactories.splice(0, listedFactories.length, ACME_ONBOARDING_FACTORY);
+    renderIndex();
+
+    expect(screen.getByTestId("location-path")).toHaveTextContent(
+      factoryHomePath(FACTORIES_ORGANIZATION_ID, ACME_ONBOARDING_FACTORY.key!, ACME_ONBOARDING_LINE_ID),
+    );
+  });
+
+  it("opens the workspace index when the workspace has no line", () => {
+    listedFactories.splice(0, listedFactories.length, EMPTY_FACTORY);
+    renderIndex();
+
+    expect(screen.getByTestId("location-path")).toHaveTextContent(
+      factoryHomePath(FACTORIES_ORGANIZATION_ID, EMPTY_FACTORY.key!),
+    );
+  });
+});

--- a/web_src/src/pages/factories/FactoriesIndexPage.tsx
+++ b/web_src/src/pages/factories/FactoriesIndexPage.tsx
@@ -10,7 +10,7 @@ import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { cn } from "@/lib/utils";
 import { Factory as FactoryIcon, Plus } from "lucide-react";
 import { Navigate, useNavigate, useParams } from "react-router";
-import { factoryDetailPath, newFactoryPath } from "./lib/factoryPagePaths";
+import { factoryHomePath, firstFactoryLineId, newFactoryPath } from "./lib/factoryPagePaths";
 import { pickInitialFactory, readLastVisitedFactory } from "./lib/lastVisitedFactory";
 import { useFactoriesThemeClass } from "./lib/useFactoriesThemeClass";
 
@@ -59,7 +59,9 @@ function FactoriesIndexPageContent({ organizationId }: { organizationId: string 
   const targetFactory = pickInitialFactory(factories, lastVisited);
 
   if (targetFactory?.key) {
-    return <Navigate to={factoryDetailPath(organizationId, targetFactory.key)} replace />;
+    return (
+      <Navigate to={factoryHomePath(organizationId, targetFactory.key, firstFactoryLineId(targetFactory))} replace />
+    );
   }
 
   const canCreate = canAct("factories", "create");


### PR DESCRIPTION
## Summary

ListFactories omitted line ids. The workspace switcher and the organization workspace index then opened the workspace index.

A workspace with one line must open that line board in one step.

ListFactories now returns lines. The client builds `/workspaces/{key}/lines/{id}` without a stop on the Lines list.

## Test plan

- [ ] Open an organization whose last workspace has one line.
- [ ] Confirm the browser opens `/workspaces/{key}/lines/{lineId}`.
- [ ] Switch to that workspace from another workspace.
- [ ] Confirm the browser does not show the Lines list.
- [ ] Open `/workspaces/{key}/lines` and confirm the redirect to the line board.
- [ ] Open a workspace with no line and confirm overview still opens.


Made with [Cursor](https://cursor.com)