### PR TITLE
fix: add Perplexity integration attribution

### DIFF
--- a/pkg/integrations/perplexity/client.go
+++ b/pkg/integrations/perplexity/client.go
@@ -145,6 +145,7 @@ func (c *Client) execRequest(method, URL string, body io.Reader) ([]byte, error)
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("X-Pplx-Integration", "superplane")
 
 	res, err := c.http.Do(req)
 	if err != nil {

--- a/pkg/integrations/perplexity/perplexity_test.go
+++ b/pkg/integrations/perplexity/perplexity_test.go
@@ -39,6 +39,7 @@ func TestSync_Success(t *testing.T) {
 	require.Len(t, httpCtx.Requests, 1)
 	assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
 	assert.Contains(t, httpCtx.Requests[0].URL.String(), "/v1/models")
+	assert.Equal(t, "superplane", httpCtx.Requests[0].Header.Get("X-Pplx-Integration"))
 }
 
 func TestSync_InvalidKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Perplexity would like to identify requests sent through Superplane's native integration.

- Send `X-Pplx-Integration: superplane` from the shared Perplexity request executor.
- Cover every current Perplexity operation without changing authentication, payloads, or responses.

## Test plan

- [x] Extend the existing sync request test to verify the transmitted header.
