### PR TITLE
feat: Polish the work-order automations popup

### DIFF
--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -236,7 +236,8 @@ describe("LinesPage board", () => {
     expect(within(dialog).queryByTestId("split-run-review")).not.toBeInTheDocument();
 
     await user.click(within(dialog).getByRole("tab", { name: "Automations" }));
-    expect(within(dialog).getByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Automations" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("switch", { name: "Follow" })).toBeInTheDocument();
     expect(within(dialog).getByTestId("split-run-phase-backlog")).toBeInTheDocument();
     expect(within(dialog).queryByTestId("split-run-phase-ingest")).not.toBeInTheDocument();
     expect(within(dialog).queryByTestId("split-run-phase-analyze")).not.toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/linePhaseGlyph.spec.tsx
+++ b/web_src/src/pages/factories/pages/linePhaseGlyph.spec.tsx
@@ -14,12 +14,15 @@ describe("PhaseGlyph", () => {
     expect(container.querySelector(".lucide-x")).not.toBeNull();
   });
 
-  it("fills running and waiting disks", () => {
-    const { rerender, container } = render(<PhaseGlyph kind="running" />);
-    expect(container.firstElementChild?.className).toMatch(/status-running-dot/);
+  it("uses a spinner without a fill disk", () => {
+    const { container } = render(<PhaseGlyph kind="running" />);
     expect(container.querySelector(".lucide-loader-circle")).not.toBeNull();
+    expect(container.firstElementChild?.getAttribute("class")).toMatch(/status-running-dot/);
+    expect(container.firstElementChild?.getAttribute("class")).not.toMatch(/rounded-full/);
+  });
 
-    rerender(<PhaseGlyph kind="waiting" />);
+  it("fills the waiting disk", () => {
+    const { container } = render(<PhaseGlyph kind="waiting" />);
     expect(container.firstElementChild?.className).toMatch(/status-waiting-dot/);
     expect(container.querySelector(".lucide-clock")).not.toBeNull();
   });

--- a/web_src/src/pages/factories/pages/linePhaseGlyph.spec.tsx
+++ b/web_src/src/pages/factories/pages/linePhaseGlyph.spec.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PhaseGlyph } from "./linePhaseGlyph";
+
+describe("PhaseGlyph", () => {
+  it("fills passed and failed so status reads at a glance", () => {
+    const { rerender, container } = render(<PhaseGlyph kind="passed" />);
+    expect(container.firstElementChild?.className).toMatch(/status-completed-dot/);
+    expect(container.querySelector(".lucide-check")).not.toBeNull();
+
+    rerender(<PhaseGlyph kind="failed" />);
+    expect(container.firstElementChild?.className).toMatch(/status-failed-dot/);
+    expect(container.querySelector(".lucide-x")).not.toBeNull();
+  });
+
+  it("fills running and waiting disks", () => {
+    const { rerender, container } = render(<PhaseGlyph kind="running" />);
+    expect(container.firstElementChild?.className).toMatch(/status-running-dot/);
+    expect(container.querySelector(".lucide-loader-circle")).not.toBeNull();
+
+    rerender(<PhaseGlyph kind="waiting" />);
+    expect(container.firstElementChild?.className).toMatch(/status-waiting-dot/);
+    expect(container.querySelector(".lucide-clock")).not.toBeNull();
+  });
+});

--- a/web_src/src/pages/factories/pages/linePhaseGlyph.tsx
+++ b/web_src/src/pages/factories/pages/linePhaseGlyph.tsx
@@ -1,24 +1,53 @@
 import { cn } from "@/lib/utils";
-import { Circle, CircleAlert, CircleCheck, CircleDashed, Clock, LoaderCircle } from "lucide-react";
+import { Check, Circle, CircleDashed, Clock, LoaderCircle, X } from "lucide-react";
+import type { ReactNode } from "react";
+
 import type { PhaseGlyphKind } from "../lib/linePhaseRuns";
+
+const DISK = "inline-flex items-center justify-center rounded-full text-white dark:text-zinc-950";
+const MARK = "size-[0.68em] stroke-[3]";
 
 export function PhaseGlyph({ kind, className }: { kind: PhaseGlyphKind; className?: string }) {
   const shared = cn("size-3.5 shrink-0", className);
 
   if (kind === "running") {
-    return <LoaderCircle className={cn(shared, "animate-spin text-[#3b82f6]")} aria-hidden />;
+    return (
+      <StatusDisk className={shared} tone="bg-[color:var(--status-running-dot)]">
+        <LoaderCircle className={cn(MARK, "animate-spin")} />
+      </StatusDisk>
+    );
   }
   if (kind === "waiting") {
-    return <Clock className={cn(shared, "text-[#f59e0b]")} aria-hidden />;
+    return (
+      <StatusDisk className={shared} tone="bg-[color:var(--status-waiting-dot)]">
+        <Clock className={cn(MARK, "[&_circle]:hidden")} />
+      </StatusDisk>
+    );
   }
   if (kind === "failed") {
-    return <CircleAlert className={cn(shared, "text-[#ef4444]")} aria-hidden />;
+    return (
+      <StatusDisk className={shared} tone="bg-[color:var(--status-failed-dot)]">
+        <X className={MARK} />
+      </StatusDisk>
+    );
   }
   if (kind === "passed") {
-    return <CircleCheck className={cn(shared, "text-[#10b981]")} aria-hidden />;
+    return (
+      <StatusDisk className={shared} tone="bg-[color:var(--status-completed-dot)]">
+        <Check className={MARK} />
+      </StatusDisk>
+    );
   }
   if (kind === "queued") {
-    return <CircleDashed className={cn(shared, "text-[#a3a3a3]")} aria-hidden />;
+    return <CircleDashed className={cn(shared, "text-muted-foreground")} aria-hidden />;
   }
   return <Circle className={cn(shared, "text-muted-foreground/40")} aria-hidden />;
+}
+
+function StatusDisk({ className, tone, children }: { className?: string; tone: string; children: ReactNode }) {
+  return (
+    <span className={cn(DISK, tone, className)} aria-hidden>
+      {children}
+    </span>
+  );
 }

--- a/web_src/src/pages/factories/pages/linePhaseGlyph.tsx
+++ b/web_src/src/pages/factories/pages/linePhaseGlyph.tsx
@@ -11,11 +11,7 @@ export function PhaseGlyph({ kind, className }: { kind: PhaseGlyphKind; classNam
   const shared = cn("size-3.5 shrink-0", className);
 
   if (kind === "running") {
-    return (
-      <StatusDisk className={shared} tone="bg-[color:var(--status-running-dot)]">
-        <LoaderCircle className={cn(MARK, "animate-spin")} />
-      </StatusDisk>
-    );
+    return <LoaderCircle className={cn(shared, "animate-spin text-[color:var(--status-running-dot)]")} aria-hidden />;
   }
   if (kind === "waiting") {
     return (

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
@@ -212,7 +212,7 @@ describe("Line board job popup", () => {
     expect(within(dialog).queryByRole("button", { name: "plan.md" })).not.toBeInTheDocument();
     expect(within(dialog).queryByRole("link", { name: /feature\/rf-103/ })).not.toBeInTheDocument();
     expect(within(dialog).queryByTestId("split-run-checks")).not.toBeInTheDocument();
-    expect(within(dialog).getByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Automations" })).not.toBeInTheDocument();
     expect(within(dialog).getByTestId("split-run-phase-implement-0")).toBeInTheDocument();
     expect(within(dialog).queryByText("Listening for user review")).not.toBeInTheDocument();
     expect(within(dialog).queryByText(/Users see duplicate refund/)).not.toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/WorkOrderPopupRedesign.spec.tsx
@@ -272,8 +272,9 @@ describe("Line board job popup", () => {
     dialog = await screen.findByTestId("work-order-split-run");
     expect(within(dialog).getByRole("heading", { name: "Listening for user review" })).toBeInTheDocument();
     expect(within(dialog).getByRole("link", { name: "Review PR #6812" })).toBeInTheDocument();
-    expect(within(dialog).getByRole("button", { name: "Reject" })).toBeInTheDocument();
-    expect(within(dialog).getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "Open full screen" })).toBeInTheDocument();
     expect(within(dialog).queryByRole("button", { name: "Stop and Close" })).not.toBeInTheDocument();
     expect(within(dialog).queryByRole("button", { name: /Update manually/ })).not.toBeInTheDocument();
     expect(within(dialog).queryByTestId("split-run-checks")).not.toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
@@ -120,12 +120,7 @@ export function PopupHeader({
         <div className="flex shrink-0 items-center gap-2">
           {actions}
           {onToggleExpanded ? <PopupFullScreenButton expanded={expanded} onToggle={onToggleExpanded} /> : null}
-          <button
-            type="button"
-            onClick={onClose}
-            className={POPUP_HEADER_ICON_BUTTON}
-            aria-label="Close"
-          >
+          <button type="button" onClick={onClose} className={POPUP_HEADER_ICON_BUTTON} aria-label="Close">
             <XIcon className="h-4 w-4" />
           </button>
         </div>

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
@@ -2,7 +2,7 @@ import type { FactoriesWorkOrderArtifact } from "@/api-client";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { MarkdownContent } from "@/pages/app/Markdown";
-import { CircleDollarSign, Clock, FileText, UserPlus, XIcon } from "lucide-react";
+import { CircleDollarSign, Clock, FileText, Maximize2, Minimize2, UserPlus, XIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { FACTORIES_ORGANIZATION_ID } from "../../__fixtures__/factoryPageResponses";
@@ -23,6 +23,7 @@ export function PopupShell({
   fixed = false,
   wide = false,
   canvas = false,
+  fullPage = false,
   onDismiss,
 }: {
   testId: string;
@@ -30,12 +31,40 @@ export function PopupShell({
   fixed?: boolean;
   wide?: boolean;
   canvas?: boolean;
+  fullPage?: boolean;
   onDismiss?: () => void;
 }) {
   return (
-    <RunOverlayFrame testId={testId} fixed={fixed} wide={wide} canvas={canvas} onDismiss={onDismiss}>
+    <RunOverlayFrame
+      testId={testId}
+      fixed={fixed}
+      wide={wide}
+      canvas={canvas}
+      fullPage={fullPage}
+      onDismiss={onDismiss}
+    >
       {children}
     </RunOverlayFrame>
+  );
+}
+
+const OPEN_FULL_SCREEN_LABEL = "Open full screen";
+const EXIT_FULL_SCREEN_LABEL = "Exit full screen";
+const POPUP_HEADER_ICON_BUTTON =
+  "flex h-6 w-6 items-center justify-center rounded-full hover:bg-slate-950/5 dark:hover:bg-white/10";
+
+function PopupFullScreenButton({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) {
+  const label = expanded ? EXIT_FULL_SCREEN_LABEL : OPEN_FULL_SCREEN_LABEL;
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={POPUP_HEADER_ICON_BUTTON}
+      aria-label={label}
+      data-testid="popup-fullscreen-button"
+    >
+      {expanded ? <Minimize2 className="h-4 w-4" aria-hidden /> : <Maximize2 className="h-4 w-4" aria-hidden />}
+    </button>
   );
 }
 
@@ -44,6 +73,8 @@ export function PopupHeader({
   children,
   onClose,
   actions,
+  expanded = false,
+  onToggleExpanded,
   canEditTitle = false,
   titleBusy = false,
   onTitleSave,
@@ -54,6 +85,8 @@ export function PopupHeader({
   children?: ReactNode;
   onClose?: () => void;
   actions?: ReactNode;
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
   canEditTitle?: boolean;
   titleBusy?: boolean;
   onTitleSave?: (next: string) => void;
@@ -86,10 +119,11 @@ export function PopupHeader({
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {actions}
+          {onToggleExpanded ? <PopupFullScreenButton expanded={expanded} onToggle={onToggleExpanded} /> : null}
           <button
             type="button"
             onClick={onClose}
-            className="flex h-6 w-6 items-center justify-center rounded-full hover:bg-slate-950/5 dark:hover:bg-white/10"
+            className={POPUP_HEADER_ICON_BUTTON}
             aria-label="Close"
           >
             <XIcon className="h-4 w-4" />

--- a/web_src/src/pages/factories/pages/work-order-run-overlay/runOverlayShared.tsx
+++ b/web_src/src/pages/factories/pages/work-order-run-overlay/runOverlayShared.tsx
@@ -41,12 +41,39 @@ export function RunOverlayBoardBackdrop() {
   );
 }
 
+function overlayLayerClassName(fixed: boolean, fullPage: boolean) {
+  if (fullPage) {
+    // Pin to the viewport beside the sidebar. Absolute fill is clipped by the
+    // kanban overflow ancestors, so it cannot cover the main pane.
+    if (fixed) {
+      return "fixed inset-y-0 right-0 left-[var(--workspace-navigation-width)] z-50 flex bg-background p-0";
+    }
+    return "absolute inset-0 z-50 flex bg-background p-0";
+  }
+  return cn("inset-0 z-50 flex items-center justify-center bg-black/50 p-5 sm:p-10", fixed ? "fixed" : "absolute");
+}
+
+function overlayDialogClassName(wide: boolean, canvas: boolean, fullPage: boolean) {
+  if (fullPage) {
+    return "flex h-full w-full flex-col overflow-hidden bg-background dark:bg-gray-900";
+  }
+  return cn(
+    "flex max-h-[min(56rem,calc(100vh-5rem))] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg dark:bg-gray-900",
+    canvas
+      ? "h-[min(52rem,calc(100vh-5rem))] w-[min(84rem,calc(100vw-5rem))]"
+      : wide
+        ? "h-[min(48rem,calc(100vh-5rem))] w-[min(72rem,calc(100vw-5rem))]"
+        : "h-[min(50rem,calc(100vh-5rem))] w-[min(70rem,calc(100vw-5rem))]",
+  );
+}
+
 export function RunOverlayFrame({
   children,
   testId,
   wide = false,
   canvas = false,
   fixed = false,
+  fullPage = false,
   onDismiss,
 }: {
   children: ReactNode;
@@ -55,25 +82,14 @@ export function RunOverlayFrame({
   canvas?: boolean;
   /** Cover the viewport. Use on the live line board so overflow does not clip the dialog. */
   fixed?: boolean;
+  /** Fill the main pane. The factory sidebar stays visible. */
+  fullPage?: boolean;
   onDismiss?: () => void;
 }) {
   return (
-    <div
-      className={cn(
-        "inset-0 z-50 flex items-center justify-center bg-black/50 p-5 sm:p-10",
-        fixed ? "fixed" : "absolute",
-      )}
-      onClick={onDismiss}
-    >
+    <div className={overlayLayerClassName(fixed, fullPage)} onClick={onDismiss}>
       <div
-        className={cn(
-          "flex max-h-[min(52rem,calc(100vh-5rem))] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg dark:bg-gray-900",
-          canvas
-            ? "h-[min(52rem,calc(100vh-5rem))] w-[min(84rem,calc(100vw-5rem))]"
-            : wide
-              ? "h-[min(48rem,calc(100vh-5rem))] w-[min(72rem,calc(100vw-5rem))]"
-              : "h-[min(46rem,calc(100vh-5rem))] w-[min(56rem,calc(100vw-5rem))]",
-        )}
+        className={overlayDialogClassName(wide, canvas, fullPage)}
         data-testid={testId}
         role="dialog"
         aria-modal="true"

--- a/web_src/src/pages/factories/pages/work-order-split-run/AutomationLookPreview.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/AutomationLookPreview.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@/components/ui/button";
 import { formatClockDurationLabel } from "@/lib/duration";
 import { cn } from "@/lib/utils";
+import { CircleX, RotateCw } from "lucide-react";
 import { useState } from "react";
 
 import { PhaseGlyph } from "../linePhaseGlyph";
@@ -96,7 +96,7 @@ export function AutomationLookPreview({ look }: { look: AutomationLook }) {
 
   return (
     <div className="flex h-[32rem] min-h-0 w-full max-w-xl flex-col border border-border bg-background">
-      <div className="flex items-center gap-3 px-3 pt-3">
+      <div className="flex items-center justify-between gap-3 px-3 pt-3">
         <SectionTitle>Automations</SectionTitle>
         <span className="text-xs font-medium text-muted-foreground">Follow</span>
       </div>
@@ -121,16 +121,26 @@ export function AutomationLookPreview({ look }: { look: AutomationLook }) {
 function previewHeaderAction(status: SplitRunPhaseStatus, onStop: () => void, onRerun: () => void) {
   if (status === "running") {
     return (
-      <Button type="button" size="xs" variant="outline" className="text-destructive" onClick={onStop}>
-        Stop
-      </Button>
+      <button
+        type="button"
+        aria-label="Stop"
+        className="inline-flex size-6 shrink-0 items-center justify-center text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+        onClick={onStop}
+      >
+        <CircleX className="size-3.5" aria-hidden />
+      </button>
     );
   }
   if (status === "failed") {
     return (
-      <Button type="button" size="xs" variant="ghost" onClick={onRerun}>
-        Rerun
-      </Button>
+      <button
+        type="button"
+        aria-label="Rerun"
+        className="inline-flex size-6 shrink-0 items-center justify-center text-muted-foreground hover:text-foreground"
+        onClick={onRerun}
+      >
+        <RotateCw className="size-3.5" aria-hidden />
+      </button>
     );
   }
   return null;

--- a/web_src/src/pages/factories/pages/work-order-split-run/AutomationLookPreview.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/AutomationLookPreview.tsx
@@ -100,9 +100,9 @@ export function AutomationLookPreview({ look }: { look: AutomationLook }) {
         <SectionTitle>Automations</SectionTitle>
         <span className="text-xs font-medium text-muted-foreground">Follow</span>
       </div>
-      <ol className="min-h-0 flex-1 list-none space-y-1 overflow-y-auto px-3 py-3">
+      <ol className="min-h-0 flex-1 list-none space-y-1 overflow-y-auto px-3 pb-3">
         {phases.map((phase) => (
-          <li key={phase.id}>
+          <li key={phase.id} className="first:mt-3">
             <AutomationRow
               look={look}
               phase={phase}

--- a/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.spec.tsx
@@ -36,6 +36,8 @@ describe("FactoryAppSplitRunPage", () => {
     expect(screen.getByTestId("factory-app-canvas-title")).toHaveTextContent("Refund Implementer");
     expect(within(page).queryByTestId("split-run-phase-refund-planner-0")).not.toBeInTheDocument();
     expect(within(page).getByTestId("split-run-stream-implement-0")).toBeInTheDocument();
+    expect(within(page).getByTestId("split-run-log-scroll").className).not.toMatch(/\bpy-\d/);
+    expect(within(page).getByTestId("split-run-log-scroll").className).not.toMatch(/\bpt-\d/);
     expect(within(page).getByTestId("run-overlay-compact-canvas")).toBeInTheDocument();
     expect(within(page).getByTestId("split-run-resize-handle")).toBeInTheDocument();
     expect(within(page).getByRole("switch", { name: "Follow" })).toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.tsx
@@ -89,12 +89,13 @@ function SplitRunLoadedPage({ model }: { model: ReturnType<typeof useFactoryAppS
           <SplitRunLogHeader
             following={follow.following}
             onFollowingChange={follow.setFollowing}
-            className="px-4 pt-3"
+            className="px-4 pt-3 pb-2"
           />
           <ol
             ref={follow.scrollRef}
             onScroll={follow.onScroll}
-            className="min-h-0 min-w-0 flex-1 list-none overflow-x-hidden overflow-y-auto px-4 py-3"
+            className="min-h-0 min-w-0 flex-1 list-none overflow-x-hidden overflow-y-auto px-4 pb-3"
+            data-testid="split-run-log-scroll"
           >
             <li className="min-w-0">
               <PhaseLogCard

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
@@ -406,8 +406,8 @@ describe("PhaseLogCard collapsed stream", () => {
     expect(phase.className).toMatch(/sticky/);
     expect(phase.className).toMatch(/top-0/);
     expect(phase.className).toMatch(/\bh-8\b/);
-    expect(phase.className).not.toMatch(/\bbg-muted\b/);
-    expect(phase.className).toMatch(/\bbg-background\b/);
+    expect(phase.className).toMatch(/\bbg-muted\b/);
+    expect(phase.className).not.toMatch(/\bbg-background\b/);
 
     const node = screen.getByTestId("split-run-stream-line-planner-agent");
     expect(node.className).toMatch(/sticky/);

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
@@ -141,7 +141,8 @@ describe("PhaseLogCard collapsed stream", () => {
 
     const node = screen.getByTestId("split-run-stream-line-planner-agent");
     expect(node.querySelector(".lucide-chevron-right")).toBeNull();
-    expect(node.className).not.toMatch(/\bbg-muted\b/);
+    expect(node.className).toMatch(/\bbg-muted\b/);
+    expect(node.className).not.toMatch(/\bbg-background\b/);
     expect(node.className).not.toMatch(/border-b/);
     expect(screen.getByText("Clone Repo")).toBeInTheDocument();
     expect(screen.getByText("Write Implementation Plan")).toBeInTheDocument();
@@ -149,7 +150,8 @@ describe("PhaseLogCard collapsed stream", () => {
     expect(within(screen.getByTestId("split-run-stream-line-step-clone")).getByText("✓")).toBeInTheDocument();
     expect(within(screen.getByTestId("split-run-stream-line-step-fail")).getByText("✗")).toBeInTheDocument();
     expect(screen.getByTestId("split-run-stream-line-step-clone").querySelector(".lucide-chevron-right")).toBeNull();
-    expect(screen.getByTestId("split-run-stream-line-step-clone").className).not.toMatch(/\bbg-muted\b/);
+    expect(screen.getByTestId("split-run-stream-line-step-clone").className).toMatch(/\bbg-muted\b/);
+    expect(screen.getByTestId("split-run-stream-line-step-clone").className).not.toMatch(/\bbg-background\b/);
     expect(screen.getByText("Cloning into 'superplane'...")).toBeInTheDocument();
     expect(screen.getByText(LONG_NOTE)).toBeInTheDocument();
     expect(screen.queryByText("cat /tmp/ORDER.md")).not.toBeInTheDocument();
@@ -412,14 +414,14 @@ describe("PhaseLogCard collapsed stream", () => {
     const node = screen.getByTestId("split-run-stream-line-planner-agent");
     expect(node.className).toMatch(/sticky/);
     expect(node.className).toMatch(/top-8/);
-    expect(node.className).not.toMatch(/\bbg-muted\b/);
-    expect(node.className).toMatch(/\bbg-background\b/);
+    expect(node.className).toMatch(/\bbg-muted\b/);
+    expect(node.className).not.toMatch(/\bbg-background\b/);
 
     const step = screen.getByTestId("split-run-stream-line-step-clone");
     expect(step.className).toMatch(/sticky/);
     expect(step.className).toMatch(/top-\[3\.375rem\]/);
-    expect(step.className).not.toMatch(/\bbg-muted\b/);
-    expect(step.className).toMatch(/\bbg-background\b/);
+    expect(step.className).toMatch(/\bbg-muted\b/);
+    expect(step.className).not.toMatch(/\bbg-background\b/);
   });
 
   it("shows agent text and a collapsed tool summary", async () => {
@@ -430,8 +432,13 @@ describe("PhaseLogCard collapsed stream", () => {
     expect(note).toBeInTheDocument();
     expect(note).not.toHaveClass("truncate");
     expect(note).toHaveClass("whitespace-normal");
-    expect(screen.getByRole("button", { name: "Ran 1 command" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Ran 1 command" }).querySelector('[style*="ch"]')).toBeNull();
+    expect(note.parentElement?.className).toMatch(/\bbg-muted\b/);
+    expect(note.parentElement?.className).not.toMatch(/\bbg-background\b/);
+    const toolSummary = screen.getByRole("button", { name: "Ran 1 command" });
+    expect(toolSummary).toBeInTheDocument();
+    expect(toolSummary.className).toMatch(/\bbg-muted\b/);
+    expect(toolSummary.className).not.toMatch(/\bbg-background\b/);
+    expect(toolSummary.querySelector('[style*="ch"]')).toBeNull();
     expect(screen.getByRole("button", { name: "Read 1 file" })).toBeInTheDocument();
     expect(screen.queryByText("cat /tmp/ORDER.md")).not.toBeInTheDocument();
     expect(screen.queryByText("LineListCard.tsx")).not.toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.spec.tsx
@@ -141,15 +141,15 @@ describe("PhaseLogCard collapsed stream", () => {
 
     const node = screen.getByTestId("split-run-stream-line-planner-agent");
     expect(node.querySelector(".lucide-chevron-right")).toBeNull();
-    expect(node.className).toMatch(/\bbg-muted\b/);
-    expect(node.className).toMatch(/border-b/);
+    expect(node.className).not.toMatch(/\bbg-muted\b/);
+    expect(node.className).not.toMatch(/border-b/);
     expect(screen.getByText("Clone Repo")).toBeInTheDocument();
     expect(screen.getByText("Write Implementation Plan")).toBeInTheDocument();
     expect(screen.getByText("Use plan as output")).toBeInTheDocument();
     expect(within(screen.getByTestId("split-run-stream-line-step-clone")).getByText("✓")).toBeInTheDocument();
     expect(within(screen.getByTestId("split-run-stream-line-step-fail")).getByText("✗")).toBeInTheDocument();
     expect(screen.getByTestId("split-run-stream-line-step-clone").querySelector(".lucide-chevron-right")).toBeNull();
-    expect(screen.getByTestId("split-run-stream-line-step-clone").className).toMatch(/\bbg-muted\b/);
+    expect(screen.getByTestId("split-run-stream-line-step-clone").className).not.toMatch(/\bbg-muted\b/);
     expect(screen.getByText("Cloning into 'superplane'...")).toBeInTheDocument();
     expect(screen.getByText(LONG_NOTE)).toBeInTheDocument();
     expect(screen.queryByText("cat /tmp/ORDER.md")).not.toBeInTheDocument();
@@ -374,24 +374,27 @@ describe("PhaseLogCard collapsed stream", () => {
     expect(screen.queryAllByTestId("split-run-log-line-no")).toHaveLength(0);
   });
 
-  it("gives each log line a hover background", () => {
-    render(<PhaseLogCard phase={PHASE} expanded stream={PLANNING_STREAM} />);
+  it("tints collapsed phases on hover and leaves log lines clear", () => {
+    const { rerender } = render(<PhaseLogCard phase={PHASE} expanded={false} />);
 
-    const phaseRow = screen.getByTestId("split-run-automation-header-plan");
-    expect(phaseRow.className).toMatch(/sticky|flex/);
+    expect(screen.getByTestId("split-run-phase-plan").firstElementChild?.className).toMatch(/hover:bg-/);
+
+    rerender(<PhaseLogCard phase={PHASE} expanded stream={PLANNING_STREAM} />);
+
+    expect(screen.getByTestId("split-run-phase-plan").firstElementChild?.className).not.toMatch(/hover:bg-/);
 
     const node = screen.getByTestId("split-run-stream-line-planner-agent");
-    expect(node.className).toMatch(/hover:bg-/);
+    expect(node.className).not.toMatch(/hover:bg-/);
     const step = screen.getByTestId("split-run-stream-line-step-clone");
-    expect(step.className).toMatch(/hover:bg-/);
+    expect(step.className).not.toMatch(/hover:bg-/);
 
     const outputLine = screen.getAllByTestId("split-run-stream-output")[0]?.firstElementChild;
-    expect(outputLine?.className).toMatch(/hover:bg-/);
+    expect(outputLine?.className).not.toMatch(/hover:bg-/);
 
-    expect(screen.getByText(LONG_NOTE).closest("[data-testid^='split-run-stream-line-']")?.className).toMatch(
+    expect(screen.getByText(LONG_NOTE).closest("[data-testid^='split-run-stream-line-']")?.className).not.toMatch(
       /hover:bg-/,
     );
-    expect(screen.getByRole("button", { name: "Ran 1 command" }).className).toMatch(/hover:bg-/);
+    expect(screen.getByRole("button", { name: "Ran 1 command" }).className).not.toMatch(/hover:bg-/);
   });
 
   it("pins the open phase, node, and step while their output scrolls", () => {
@@ -403,17 +406,20 @@ describe("PhaseLogCard collapsed stream", () => {
     expect(phase.className).toMatch(/sticky/);
     expect(phase.className).toMatch(/top-0/);
     expect(phase.className).toMatch(/\bh-8\b/);
-    expect(phase.className).toMatch(/\bbg-muted\b/);
+    expect(phase.className).not.toMatch(/\bbg-muted\b/);
+    expect(phase.className).toMatch(/\bbg-background\b/);
 
     const node = screen.getByTestId("split-run-stream-line-planner-agent");
     expect(node.className).toMatch(/sticky/);
     expect(node.className).toMatch(/top-8/);
-    expect(node.className).toMatch(/\bbg-muted\b/);
+    expect(node.className).not.toMatch(/\bbg-muted\b/);
+    expect(node.className).toMatch(/\bbg-background\b/);
 
     const step = screen.getByTestId("split-run-stream-line-step-clone");
     expect(step.className).toMatch(/sticky/);
     expect(step.className).toMatch(/top-\[3\.375rem\]/);
-    expect(step.className).toMatch(/\bbg-muted\b/);
+    expect(step.className).not.toMatch(/\bbg-muted\b/);
+    expect(step.className).toMatch(/\bbg-background\b/);
   });
 
   it("shows agent text and a collapsed tool summary", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
@@ -88,7 +88,7 @@ describe("PhaseLogCard title line", () => {
     expect(screen.getByTestId("split-run-phase-duration-plan")).toHaveTextContent("04:00");
     const badge = screen.getByTestId("split-run-stream-duration-planner-agent");
     expect(badge).toHaveAccessibleName("Running");
-    expect(badge).toHaveTextContent("✓");
+    expect(badge).not.toHaveTextContent("✓");
     expect(badge).toHaveTextContent("04:00");
     expect(badge).not.toHaveTextContent("Running");
     expect(badge.querySelector(".lucide-loader-circle")).toBeNull();
@@ -520,7 +520,8 @@ describe("PhaseLogCard node line", () => {
 
     const row = screen.getByTestId("split-run-stream-line-planner-agent");
     expect(row.querySelector(".lucide-chevron-right")).toBeNull();
-    expect(row.className).not.toMatch(/\bbg-muted\b/);
+    expect(row.className).toMatch(/\bbg-muted\b/);
+    expect(row.className).not.toMatch(/\bbg-background\b/);
     expect(row.className).not.toMatch(/hover:bg-/);
     expect(row.className).not.toMatch(/border-b/);
     expect(row.className).not.toMatch(/-mx-2/);

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
@@ -38,15 +38,35 @@ describe("PhaseLogCard title line", () => {
     expect(within(row).getByRole("button", { name: "Plan" })).toBeInTheDocument();
     expect(within(row).queryByText("Planning")).not.toBeInTheDocument();
     expect(within(row).queryByText("Completed")).not.toBeInTheDocument();
-    expect(within(row).queryByTestId("split-run-phase-duration-plan")).not.toBeInTheDocument();
     expect(within(row).queryByText("Passed 01:00")).not.toBeInTheDocument();
+    expect(within(row).getByTestId("split-run-phase-duration-plan")).toHaveTextContent("01:00");
     expect(row.firstElementChild?.className).toMatch(/rounded-md/);
-    expect(row.firstElementChild?.className).toMatch(/border/);
+    expect(row.firstElementChild?.className).not.toMatch(/\bbg-muted\b/);
+    expect(row.firstElementChild?.className).toMatch(/hover:bg-/);
+    expect(row.firstElementChild?.className).not.toMatch(/\bborder\b/);
     expect(within(row).getByRole("button", { name: "Plan" }).querySelector(".lucide-chevron-right")).toBeNull();
-    expect(within(row).getByRole("button", { name: "Plan" }).className).not.toMatch(/font-mono/);
   });
 
-  it("ticks the running clock on a node, not the automation", async () => {
+  it("uses one mono face and size on the name and artifact", () => {
+    render(
+      <PhaseLogCard
+        phase={{ ...PHASE, status: "running", artifacts: [PLAN_MD_ARTIFACT] }}
+        expanded={false}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const header = screen.getByTestId("split-run-automation-header-plan");
+    const name = within(header).getByRole("button", { name: "Plan" });
+    const artifact = within(header).getByRole("button", { name: "PLAN.md" });
+
+    for (const el of [name, artifact]) {
+      expect(el.className).toMatch(/font-mono/);
+      expect(el.className).toMatch(/text-\[14px\]/);
+    }
+  });
+
+  it("ticks the running clock on the automation and the node", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
 
@@ -65,7 +85,7 @@ describe("PhaseLogCard title line", () => {
       />,
     );
 
-    expect(screen.queryByTestId("split-run-phase-duration-plan")).not.toBeInTheDocument();
+    expect(screen.getByTestId("split-run-phase-duration-plan")).toHaveTextContent("04:00");
     const badge = screen.getByTestId("split-run-stream-duration-planner-agent");
     expect(badge).toHaveAccessibleName("Running");
     expect(badge).toHaveTextContent("|");
@@ -80,6 +100,7 @@ describe("PhaseLogCard title line", () => {
       vi.advanceTimersByTime(750);
     });
     expect(badge).toHaveTextContent("Running 04:01");
+    expect(screen.getByTestId("split-run-phase-duration-plan")).toHaveTextContent("04:01");
 
     vi.useRealTimers();
   });
@@ -97,9 +118,13 @@ describe("PhaseLogCard title line", () => {
 
     expect(name.compareDocumentPosition(artifact) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(artifact.className).toMatch(/font-bold/);
-    expect(name.className).toMatch(/flex-1/);
-    expect(within(row).getByTestId("split-run-phase-artifacts-plan").className).toMatch(/justify-end/);
-    expect(within(row).queryByTestId("split-run-phase-duration-plan")).not.toBeInTheDocument();
+    expect(name.className).not.toMatch(/flex-1/);
+    const artifacts = within(row).getByTestId("split-run-phase-artifacts-plan");
+    const duration = within(row).getByTestId("split-run-phase-duration-plan");
+    expect(artifacts.className).toMatch(/justify-end/);
+    expect(artifacts.parentElement).toBe(duration.parentElement);
+    expect(artifacts.parentElement?.className).toMatch(/ml-auto/);
+    expect(duration).toHaveTextContent("01:00");
 
     rerender(<PhaseLogCard phase={phase} expanded stream={[]} />);
     expect(within(row).getByTestId("split-run-phase-artifacts-plan")).toBeInTheDocument();
@@ -108,7 +133,7 @@ describe("PhaseLogCard title line", () => {
     ).toBeInTheDocument();
   });
 
-  it("puts Stop to the right of artifacts on a running automation", () => {
+  it("puts artifacts immediately before the duration on the right", () => {
     render(
       <PhaseLogCard
         phase={{
@@ -122,9 +147,11 @@ describe("PhaseLogCard title line", () => {
     );
 
     const header = screen.getByTestId("split-run-automation-header-plan");
-    const artifact = within(header).getByRole("button", { name: "PLAN.md" });
-    const stop = within(header).getByRole("button", { name: "Stop" });
-    expect(artifact.compareDocumentPosition(stop) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const artifacts = within(header).getByTestId("split-run-phase-artifacts-plan");
+    const duration = within(header).getByTestId("split-run-phase-duration-plan");
+    expect(artifacts.compareDocumentPosition(duration) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(artifacts.parentElement).toBe(duration.parentElement);
+    expect(artifacts.nextElementSibling).toBe(duration);
   });
 
   it("offers Stop on a running automation and Rerun on a failed one", () => {
@@ -135,15 +162,18 @@ describe("PhaseLogCard title line", () => {
     );
 
     expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Stop" }).className).toMatch(/text-destructive/);
-    expect(screen.getByRole("button", { name: "Stop" }).className).not.toMatch(/bg-destructive/);
-    expect(screen.getByRole("button", { name: "Stop" }).className).not.toMatch(/text-muted-foreground/);
+    expect(screen.getByRole("button", { name: "Stop" }).className).toMatch(/size-6/);
+    expect(screen.getByRole("button", { name: "Stop" }).className).toMatch(/hover:text-destructive/);
+    expect(screen.queryByText("Stop")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Rerun" })).not.toBeInTheDocument();
 
     rerender(
       <PhaseLogCard phase={{ ...PHASE, status: "failed" }} expanded={false} onStop={onStop} onRerun={onRerun} />,
     );
-    expect(screen.getByRole("button", { name: "Rerun" })).toBeInTheDocument();
+    const rerun = screen.getByRole("button", { name: "Rerun" });
+    expect(rerun).toBeInTheDocument();
+    expect(rerun.className).toMatch(/size-6/);
+    expect(screen.queryByText("Rerun")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
 
     rerender(<PhaseLogCard phase={PHASE} expanded={false} onStop={onStop} onRerun={onRerun} />);
@@ -185,27 +215,80 @@ describe("PhaseLogCard title line", () => {
     expect(onRerun).not.toHaveBeenCalled();
   });
 
-  it("puts a muted fill on the expanded header, not the nested log", () => {
-    render(<PhaseLogCard phase={PHASE} expanded stream={[]} />);
+  it("toggles from the gray header except nested controls", async () => {
+    const onToggle = vi.fn();
+    const onStop = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <PhaseLogCard
+        phase={{ ...PHASE, status: "running", artifacts: [PLAN_MD_ARTIFACT] }}
+        expanded={false}
+        onToggle={onToggle}
+        onStop={onStop}
+      />,
+    );
 
     const card = screen.getByTestId("split-run-phase-plan").firstElementChild;
-    expect(card?.className).toMatch(/\bbg-card\b/);
-    expect(card?.className).not.toMatch(/\bbg-muted\b/);
+    expect(card?.className).toMatch(/cursor-pointer/);
+    expect(screen.getByTestId("split-run-phase-expand-plan")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("split-run-phase-duration-plan"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onStop).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "PLAN.md" }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    await user.keyboard("{Escape}");
+
+    rerender(
+      <PhaseLogCard
+        phase={{ ...PHASE, status: "running", artifacts: [PLAN_MD_ARTIFACT] }}
+        expanded
+        stream={[line({ id: "planner-agent", componentName: "Agent - Plan for GH Issue" })]}
+        onToggle={onToggle}
+        onStop={onStop}
+      />,
+    );
+    expect(screen.getByTestId("split-run-phase-expand-plan")).toBeInTheDocument();
+    expect(screen.getByTestId("split-run-phase-plan").firstElementChild?.className).not.toMatch(/cursor-pointer/);
+    expect(screen.getByTestId("split-run-automation-header-plan").className).toMatch(/cursor-pointer/);
+
+    await user.click(screen.getByTestId("split-run-phase-duration-plan"));
+    expect(onToggle).toHaveBeenCalledTimes(2);
+
+    await user.click(screen.getByText("Agent - Plan for GH Issue"));
+    expect(onToggle).toHaveBeenCalledTimes(2);
+  });
+
+  it("sits on a rounded block that tints on hover", () => {
+    const { rerender } = render(<PhaseLogCard phase={PHASE} expanded={false} />);
+
+    const card = () => screen.getByTestId("split-run-phase-plan").firstElementChild;
+    expect(card()?.className).toMatch(/rounded-md/);
+    expect(card()?.className).not.toMatch(/\bbg-muted\b/);
+    expect(card()?.className).toMatch(/hover:bg-/);
+    expect(card()?.className).not.toMatch(/\bbg-card\b/);
+    expect(card()?.className).not.toMatch(/\bborder\b/);
+    expect(card()?.className).not.toMatch(/border-l/);
+
+    expect(card()?.className).toMatch(/\bpy-2\b/);
+
+    rerender(<PhaseLogCard phase={PHASE} expanded stream={[]} />);
+    expect(card()?.className).not.toMatch(/\bbg-muted\b/);
+    expect(card()?.className).not.toMatch(/hover:bg-/);
+    expect(card()?.className).toMatch(/\bpb-2\b/);
+    expect(card()?.className).not.toMatch(/\bborder\b/);
 
     const header = screen.getByTestId("split-run-automation-header-plan");
     expect(header.className).toMatch(/\bh-8\b/);
-    expect(header.className).toMatch(/\bbg-muted\b/);
-    expect(card?.className).not.toMatch(/\bpx-2\b/);
+    expect(header.className).not.toMatch(/\bbg-muted\b/);
+    expect(header.className).toMatch(/\bbg-background\b/);
+    expect(card()?.className).not.toMatch(/\bpx-2\b/);
     expect(header.className).toMatch(/\bpx-2\b/);
     expect(header.className).not.toMatch(/-mx-2/);
-  });
-
-  it("keeps a collapsed automation on the card background", () => {
-    render(<PhaseLogCard phase={PHASE} expanded={false} />);
-
-    const card = screen.getByTestId("split-run-phase-plan").firstElementChild;
-    expect(card?.className).toMatch(/\bbg-card\b/);
-    expect(card?.className).not.toMatch(/\bbg-muted\b/);
   });
 
   it("keeps produced artifacts on the title line when the phase is expanded", () => {
@@ -228,7 +311,7 @@ describe("PhaseLogCard title line", () => {
     const row = screen.getByTestId("split-run-phase-plan");
     expect(within(row).getByRole("button", { name: "PLAN.md" })).toBeInTheDocument();
     expect(within(row).getByTestId("split-run-phase-artifacts-plan")).toBeInTheDocument();
-    expect(within(row).queryByTestId("split-run-phase-duration-plan")).not.toBeInTheDocument();
+    expect(within(row).getByTestId("split-run-phase-duration-plan")).toHaveTextContent("01:00");
   });
 });
 
@@ -243,19 +326,113 @@ describe("PhaseLogCard phase actions", () => {
   it("stays off collapsed phases", () => {
     renderCard(<PhaseLogCard phase={PHASE} expanded={false} runHref={RUN_HREF} editHref={EDIT_HREF} />);
 
-    expect(screen.queryByRole("link", { name: "View Automation Run" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Edit Automation" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "View automation run" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Edit automation" })).not.toBeInTheDocument();
   });
 
-  it("puts View Automation Run and Edit Automation next to an expanded name", () => {
-    renderCard(<PhaseLogCard phase={PHASE} expanded runHref={RUN_HREF} editHref={EDIT_HREF} />);
+  it("puts icon actions next to the expanded name without pill chrome", async () => {
+    const user = userEvent.setup();
+    renderCard(
+      <PhaseLogCard
+        phase={{ ...PHASE, artifacts: [PLAN_MD_ARTIFACT] }}
+        expanded
+        runHref={RUN_HREF}
+        editHref={EDIT_HREF}
+      />,
+    );
 
-    const view = screen.getByRole("link", { name: "View Automation Run" });
-    const edit = screen.getByRole("link", { name: "Edit Automation" });
+    const header = screen.getByTestId("split-run-automation-header-plan");
+    const name = within(header).getByRole("button", { name: "Plan" });
+    const view = screen.getByRole("link", { name: "View automation run" });
+    const edit = screen.getByRole("link", { name: "Edit automation" });
+    const artifact = within(header).getByRole("button", { name: "PLAN.md" });
+    const duration = within(header).getByTestId("split-run-phase-duration-plan");
     expect(view).toHaveAttribute("href", RUN_HREF);
     expect(edit).toHaveAttribute("href", EDIT_HREF);
-    expect(view.previousElementSibling).toBe(screen.getByRole("button", { name: "Plan" }));
-    expect(edit.previousElementSibling).toBe(view);
+    expect(screen.queryByText("View automation run")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit automation")).not.toBeInTheDocument();
+    expect(view.className).toMatch(/font-mono/);
+    expect(view.className).not.toMatch(/rounded-full/);
+    expect(view.className).not.toMatch(/border-border/);
+    expect(name.compareDocumentPosition(view) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(view.compareDocumentPosition(edit) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(edit.compareDocumentPosition(artifact) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(artifact.compareDocumentPosition(duration) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(artifact.closest("[data-testid='split-run-phase-artifacts-plan']")?.parentElement).toBe(
+      duration.parentElement,
+    );
+    expect(duration.parentElement?.className).toMatch(/ml-auto/);
+    expect(duration).toHaveTextContent("01:00");
+    expect(duration.className).toMatch(/font-mono/);
+    expect(duration.className).toMatch(/tabular-nums/);
+
+    await user.hover(view);
+    expect(await screen.findByRole("tooltip", { name: "View automation run" })).toBeInTheDocument();
+    await user.unhover(view);
+    await user.hover(edit);
+    expect(await screen.findByRole("tooltip", { name: "Edit automation" })).toBeInTheDocument();
+  });
+
+  it("puts Stop after Edit on the left of a running automation", async () => {
+    const user = userEvent.setup();
+    const onStop = vi.fn();
+    renderCard(
+      <PhaseLogCard
+        phase={{ ...PHASE, status: "running", artifacts: [PLAN_MD_ARTIFACT] }}
+        expanded
+        runHref={RUN_HREF}
+        editHref={EDIT_HREF}
+        onStop={onStop}
+      />,
+    );
+
+    const header = screen.getByTestId("split-run-automation-header-plan");
+    const edit = screen.getByRole("link", { name: "Edit automation" });
+    const stop = screen.getByRole("button", { name: "Stop" });
+    const artifact = within(header).getByRole("button", { name: "PLAN.md" });
+    expect(edit.compareDocumentPosition(stop) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(stop.compareDocumentPosition(artifact) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(artifact.closest("[data-testid='split-run-phase-artifacts-plan']")?.parentElement).not.toBe(
+      stop.parentElement,
+    );
+    expect(stop.querySelector(".lucide-circle-x")).toBeTruthy();
+
+    await user.hover(stop);
+    expect(await screen.findByRole("tooltip", { name: "Stop" })).toBeInTheDocument();
+    await user.click(stop);
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("puts Rerun after Edit on the left of a failed automation", async () => {
+    const user = userEvent.setup();
+    const onRerun = vi.fn();
+    renderCard(
+      <PhaseLogCard
+        phase={{ ...PHASE, status: "failed", artifacts: [PLAN_MD_ARTIFACT] }}
+        expanded
+        runHref={RUN_HREF}
+        editHref={EDIT_HREF}
+        onRerun={onRerun}
+      />,
+    );
+
+    const header = screen.getByTestId("split-run-automation-header-plan");
+    const name = within(header).getByRole("button", { name: "Plan" });
+    const edit = screen.getByRole("link", { name: "Edit automation" });
+    const rerun = screen.getByRole("button", { name: "Rerun" });
+    const artifact = within(header).getByRole("button", { name: "PLAN.md" });
+    expect(name.compareDocumentPosition(edit) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(edit.compareDocumentPosition(rerun) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(rerun.compareDocumentPosition(artifact) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(artifact.closest("[data-testid='split-run-phase-artifacts-plan']")?.parentElement).not.toBe(
+      rerun.parentElement,
+    );
+    expect(screen.queryByText("Rerun")).not.toBeInTheDocument();
+
+    await user.hover(rerun);
+    expect(await screen.findByRole("tooltip", { name: "Rerun" })).toBeInTheDocument();
+    await user.click(rerun);
+    expect(onRerun).toHaveBeenCalledTimes(1);
   });
 
   it("opens the run or canvas without collapsing the phase", async () => {
@@ -263,8 +440,8 @@ describe("PhaseLogCard phase actions", () => {
     const user = userEvent.setup();
     renderCard(<PhaseLogCard phase={PHASE} expanded runHref={RUN_HREF} editHref={EDIT_HREF} onToggle={onToggle} />);
 
-    await user.click(screen.getByRole("link", { name: "View Automation Run" }));
-    await user.click(screen.getByRole("link", { name: "Edit Automation" }));
+    await user.click(screen.getByRole("link", { name: "View automation run" }));
+    await user.click(screen.getByRole("link", { name: "Edit automation" }));
 
     expect(onToggle).not.toHaveBeenCalled();
   });
@@ -272,8 +449,8 @@ describe("PhaseLogCard phase actions", () => {
   it("is absent when the log has no run or canvas path", () => {
     renderCard(<PhaseLogCard phase={PHASE} expanded />);
 
-    expect(screen.queryByRole("link", { name: "View Automation Run" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Edit Automation" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "View automation run" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Edit automation" })).not.toBeInTheDocument();
   });
 });
 
@@ -302,6 +479,8 @@ describe("PhaseLogCard node line", () => {
     expect(statusTime).toHaveTextContent("Passed 01:20");
     expect(statusTime.parentElement?.className).toMatch(/ml-auto/);
     expect(statusTime.className).toMatch(/text-right/);
+    expect(statusTime.className).toMatch(/font-mono/);
+    expect(statusTime.className).toMatch(/text-\[14px\]/);
     expect(screen.getByTestId("split-run-stream-plan").className).toMatch(/font-mono/);
   });
 
@@ -339,8 +518,9 @@ describe("PhaseLogCard node line", () => {
 
     const row = screen.getByTestId("split-run-stream-line-planner-agent");
     expect(row.querySelector(".lucide-chevron-right")).toBeNull();
-    expect(row.className).toMatch(/\bbg-muted\b/);
-    expect(row.className).toMatch(/border-b/);
+    expect(row.className).not.toMatch(/\bbg-muted\b/);
+    expect(row.className).not.toMatch(/hover:bg-/);
+    expect(row.className).not.toMatch(/border-b/);
     expect(row.className).not.toMatch(/-mx-2/);
     const toggle = screen.getByTestId("split-run-node-toggle-planner-agent");
     expect(toggle.className).toMatch(/gap-1\.5/);

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
@@ -88,18 +88,16 @@ describe("PhaseLogCard title line", () => {
     expect(screen.getByTestId("split-run-phase-duration-plan")).toHaveTextContent("04:00");
     const badge = screen.getByTestId("split-run-stream-duration-planner-agent");
     expect(badge).toHaveAccessibleName("Running");
-    expect(badge).toHaveTextContent("|");
-    expect(badge).toHaveTextContent("Running 04:00");
+    expect(badge).toHaveTextContent("✓");
+    expect(badge).toHaveTextContent("04:00");
+    expect(badge).not.toHaveTextContent("Running");
+    expect(badge.querySelector(".lucide-loader-circle")).toBeNull();
+    expect(badge.className).not.toMatch(/bg-/);
 
     await act(async () => {
-      vi.advanceTimersByTime(250);
+      vi.advanceTimersByTime(1000);
     });
-    expect(badge).toHaveTextContent("/");
-
-    await act(async () => {
-      vi.advanceTimersByTime(750);
-    });
-    expect(badge).toHaveTextContent("Running 04:01");
+    expect(badge).toHaveTextContent("04:01");
     expect(screen.getByTestId("split-run-phase-duration-plan")).toHaveTextContent("04:01");
 
     vi.useRealTimers();
@@ -476,7 +474,11 @@ describe("PhaseLogCard node line", () => {
     expect(within(row).queryByText("Run Claude Code")).not.toBeInTheDocument();
 
     const statusTime = within(row).getByTestId("split-run-stream-duration-planner-agent");
-    expect(statusTime).toHaveTextContent("Passed 01:20");
+    expect(statusTime).toHaveAccessibleName("Passed");
+    expect(statusTime).toHaveTextContent("✓");
+    expect(statusTime).toHaveTextContent("01:20");
+    expect(statusTime).not.toHaveTextContent("Passed");
+    expect(statusTime.className).not.toMatch(/bg-/);
     expect(statusTime.parentElement?.className).toMatch(/ml-auto/);
     expect(statusTime.className).toMatch(/text-right/);
     expect(statusTime.className).toMatch(/font-mono/);

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
@@ -41,7 +41,7 @@ describe("PhaseLogCard title line", () => {
     expect(within(row).queryByText("Passed 01:00")).not.toBeInTheDocument();
     expect(within(row).getByTestId("split-run-phase-duration-plan")).toHaveTextContent("01:00");
     expect(row.firstElementChild?.className).toMatch(/rounded-md/);
-    expect(row.firstElementChild?.className).not.toMatch(/\bbg-muted\b/);
+    expect(row.firstElementChild?.className).toMatch(/\bbg-muted\b/);
     expect(row.firstElementChild?.className).toMatch(/hover:bg-/);
     expect(row.firstElementChild?.className).not.toMatch(/\bborder\b/);
     expect(within(row).getByRole("button", { name: "Plan" }).querySelector(".lucide-chevron-right")).toBeNull();
@@ -268,7 +268,7 @@ describe("PhaseLogCard title line", () => {
 
     const card = () => screen.getByTestId("split-run-phase-plan").firstElementChild;
     expect(card()?.className).toMatch(/rounded-md/);
-    expect(card()?.className).not.toMatch(/\bbg-muted\b/);
+    expect(card()?.className).toMatch(/\bbg-muted\b/);
     expect(card()?.className).toMatch(/hover:bg-/);
     expect(card()?.className).not.toMatch(/\bbg-card\b/);
     expect(card()?.className).not.toMatch(/\bborder\b/);
@@ -277,15 +277,15 @@ describe("PhaseLogCard title line", () => {
     expect(card()?.className).toMatch(/\bpy-2\b/);
 
     rerender(<PhaseLogCard phase={PHASE} expanded stream={[]} />);
-    expect(card()?.className).not.toMatch(/\bbg-muted\b/);
+    expect(card()?.className).toMatch(/\bbg-muted\b/);
     expect(card()?.className).not.toMatch(/hover:bg-/);
     expect(card()?.className).toMatch(/\bpb-2\b/);
     expect(card()?.className).not.toMatch(/\bborder\b/);
 
     const header = screen.getByTestId("split-run-automation-header-plan");
     expect(header.className).toMatch(/\bh-8\b/);
-    expect(header.className).not.toMatch(/\bbg-muted\b/);
-    expect(header.className).toMatch(/\bbg-background\b/);
+    expect(header.className).toMatch(/\bbg-muted\b/);
+    expect(header.className).not.toMatch(/\bbg-background\b/);
     expect(card()?.className).not.toMatch(/\bpx-2\b/);
     expect(header.className).toMatch(/\bpx-2\b/);
     expect(header.className).not.toMatch(/-mx-2/);

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -47,21 +47,23 @@ function statusTimeTone(status: SplitRunPhaseStatus): string {
 
 const LOG_ROW_HOVER = "hover:bg-[color:var(--status-running-bg)]";
 const LOG_ROW_H = "h-[1.375rem]";
-const STREAM_SECTION = "px-2";
+const STREAM_SECTION = "bg-muted px-2";
 const STICKY_PHASE = "sticky top-0 z-30 h-8 bg-muted";
-const STICKY_NODE = cn("sticky top-8 z-20 bg-background", STREAM_SECTION);
-const STICKY_STEP = cn("sticky top-[3.375rem] z-10 bg-background", STREAM_SECTION);
+const STICKY_NODE = cn("sticky top-8 z-20", STREAM_SECTION);
+const STICKY_STEP = cn("sticky top-[3.375rem] z-10", STREAM_SECTION);
 
 const LAST_RUNNING_LINE_PULSE = "data-[last-running-line]:animate-pulse";
 
 const STREAM_LINE_ROW = cn(
-  "flex w-full min-w-0 max-w-full items-center justify-start overflow-hidden whitespace-nowrap px-2 text-left",
+  "flex w-full min-w-0 max-w-full items-center justify-start overflow-hidden whitespace-nowrap text-left",
+  STREAM_SECTION,
   LOG_ROW_H,
   LAST_RUNNING_LINE_PULSE,
 );
 
 const STREAM_LINE_WRAP_ROW = cn(
-  "flex w-full min-w-0 max-w-full items-start justify-start px-2 text-left",
+  "flex w-full min-w-0 max-w-full items-start justify-start text-left",
+  STREAM_SECTION,
   LAST_RUNNING_LINE_PULSE,
 );
 
@@ -627,7 +629,7 @@ function statusTimeName(status: SplitRunPhaseStatus): string | undefined {
 }
 
 function statusTimeMark(status: SplitRunPhaseStatus): ReactNode {
-  if (status === "passed" || status === "running") {
+  if (status === "passed") {
     return <span aria-hidden>✓</span>;
   }
   if (status === "failed") {
@@ -785,7 +787,7 @@ function StreamStep({ step }: { step: ClaudeStepGroup }) {
       <div
         data-testid={`split-run-stream-line-${step.line.id}`}
         {...streamLineAttrs(step.line.status)}
-        className={cn(STREAM_LINE_WRAP_ROW, STREAM_SECTION, hasBody && STICKY_STEP)}
+        className={cn(STREAM_LINE_WRAP_ROW, hasBody && STICKY_STEP)}
       >
         {step.line.componentType ? (
           <span className={cn("mr-2 shrink-0", stepTypeTone(step.line.componentType))}>{step.line.componentType}</span>
@@ -802,7 +804,7 @@ function StreamStep({ step }: { step: ClaudeStepGroup }) {
                 key={event.line.id}
                 data-testid={`split-run-stream-line-${event.line.id}`}
                 {...streamLineAttrs(event.line.status)}
-                className={cn("flex w-full items-start px-2", LAST_RUNNING_LINE_PULSE)}
+                className={cn("flex w-full items-start", STREAM_SECTION, LAST_RUNNING_LINE_PULSE)}
               >
                 <span className="inline-flex w-4 shrink-0" aria-hidden />
                 <span className="min-w-0 flex-1 whitespace-normal break-words py-0.5 leading-5 text-foreground">
@@ -903,7 +905,7 @@ function StreamOutput({ text }: { text: string }) {
         <div
           key={index}
           data-stream-line=""
-          className={cn("flex min-w-0 w-full items-start px-2", LOG_FACE, LAST_RUNNING_LINE_PULSE)}
+          className={cn("flex min-w-0 w-full items-start", STREAM_SECTION, LOG_FACE, LAST_RUNNING_LINE_PULSE)}
         >
           <span className="inline-flex w-4 shrink-0" aria-hidden />
           <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 leading-5 text-muted-foreground">

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -1,9 +1,10 @@
+import { formatClockDurationLabel } from "@/lib/duration";
 import { cn, resolveIcon } from "@/lib/utils";
-import { ChevronRight, Loader2, Maximize2, Pencil } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { ChevronRight, CircleX, Loader2, Maximize2, Pencil, RotateCw } from "lucide-react";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
 import type { FactoriesWorkOrderArtifact } from "@/api-client";
-import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Link } from "@/components/Link/link";
 import { useLiveLogStream } from "@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream";
 
@@ -18,6 +19,7 @@ import { isRunnerComponent, notesForLiveStream } from "./streamNotesFromLiveLog"
 
 /** One face and size for every log row, matched to the run log viewer. */
 const LOG_FACE = "font-mono text-[14px]";
+const PHASE_NAME_FACE = cn("flex min-w-0 items-center gap-1.5", LOG_FACE, "font-medium");
 
 function statusGlyph(status: SplitRunPhaseStatus): PhaseGlyphKind {
   if (status === "running") return "running";
@@ -45,23 +47,21 @@ function statusTimeTone(status: SplitRunPhaseStatus): string {
 
 const LOG_ROW_HOVER = "hover:bg-[color:var(--status-running-bg)]";
 const LOG_ROW_H = "h-[1.375rem]";
-const STREAM_SECTION = "bg-muted border-b border-border px-2";
-const STICKY_PHASE = "sticky top-0 z-30 h-8 bg-muted";
-const STICKY_NODE = cn("sticky top-8 z-20", STREAM_SECTION);
-const STICKY_STEP = cn("sticky top-[3.375rem] z-10", STREAM_SECTION);
+const STREAM_SECTION = "px-2";
+const STICKY_PHASE = "sticky top-0 z-30 h-8 bg-background";
+const STICKY_NODE = cn("sticky top-8 z-20 bg-background", STREAM_SECTION);
+const STICKY_STEP = cn("sticky top-[3.375rem] z-10 bg-background", STREAM_SECTION);
 
 const LAST_RUNNING_LINE_PULSE = "data-[last-running-line]:animate-pulse";
 
 const STREAM_LINE_ROW = cn(
   "flex w-full min-w-0 max-w-full items-center justify-start overflow-hidden whitespace-nowrap px-2 text-left",
   LOG_ROW_H,
-  LOG_ROW_HOVER,
   LAST_RUNNING_LINE_PULSE,
 );
 
 const STREAM_LINE_WRAP_ROW = cn(
   "flex w-full min-w-0 max-w-full items-start justify-start px-2 text-left",
-  LOG_ROW_HOVER,
   LAST_RUNNING_LINE_PULSE,
 );
 
@@ -273,6 +273,10 @@ function streamLineAttrs(status?: SplitRunPhaseStatus) {
   return { "data-stream-line": "", "data-stream-status": status };
 }
 
+function isNestedHeaderControl(target: EventTarget | null): boolean {
+  return target instanceof Element && Boolean(target.closest("a, button, [role='button']"));
+}
+
 export function PhaseLogCard({
   phase,
   expanded,
@@ -321,6 +325,8 @@ export function PhaseLogCard({
     }
   }, [selectedNodeId]);
 
+  const canToggleFromHeader = collapsible && Boolean(onToggle);
+
   return (
     <div
       ref={rootRef}
@@ -330,10 +336,22 @@ export function PhaseLogCard({
     >
       <div
         className={cn(
-          "rounded-md border border-border border-l-2 bg-card",
-          expanded ? "pb-1.5" : "py-1.5",
-          automationAccent(phase.status),
+          "rounded-md",
+          !expanded && LOG_ROW_HOVER,
+          expanded ? "pb-2" : "py-2",
+          canToggleFromHeader && !expanded && "cursor-pointer",
         )}
+        data-testid={canToggleFromHeader ? `split-run-phase-expand-${phase.id}` : undefined}
+        onClick={
+          canToggleFromHeader
+            ? (event) => {
+                if (isNestedHeaderControl(event.target)) {
+                  return;
+                }
+                onToggle?.();
+              }
+            : undefined
+        }
       >
         <AutomationHeader
           phase={phase}
@@ -352,6 +370,7 @@ export function PhaseLogCard({
           <ol
             className={cn("mt-1 min-w-0 list-none leading-tight", LOG_FACE)}
             data-testid={`split-run-stream-${phase.id}`}
+            onClick={(event) => event.stopPropagation()}
           >
             {groups.map((group) => (
               <StreamNode
@@ -401,73 +420,58 @@ function AutomationHeader({
         "flex w-full min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap px-2 leading-tight",
         LAST_RUNNING_LINE_PULSE,
         expanded && STICKY_PHASE,
+        collapsible && onToggle && "cursor-pointer",
       )}
     >
       {collapsible ? (
-        <button
-          type="button"
-          onClick={onToggle}
-          aria-expanded={expanded}
-          className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-[13px] font-medium tracking-[-0.01em]"
-        >
+        <button type="button" onClick={onToggle} aria-expanded={expanded} className={cn(PHASE_NAME_FACE, "text-left")}>
           <PhaseGlyph kind={statusGlyph(phase.status)} className="size-3.5" />
           <span className="min-w-0 truncate text-foreground">{phase.name}</span>
         </button>
       ) : (
-        <div className="flex min-w-0 flex-1 items-center gap-1.5 text-[13px] font-medium tracking-[-0.01em]">
+        <div className={PHASE_NAME_FACE}>
           <PhaseGlyph kind={statusGlyph(phase.status)} className="size-3.5" />
           <span className="min-w-0 truncate text-foreground">{phase.name}</span>
         </div>
       )}
       {expanded ? <PhaseActionPills phase={phase} runHref={runHref} editHref={editHref} /> : null}
-      {producedArtifacts.length > 0 ? (
-        <span
-          data-testid={`split-run-phase-artifacts-${phase.id}`}
-          className="flex min-w-0 items-center justify-end gap-2 overflow-hidden whitespace-nowrap"
-        >
-          {producedArtifacts.map((artifact) => (
-            <StreamArtifact key={artifact.id ?? `${artifact.type}`} artifact={artifact} />
-          ))}
-        </span>
-      ) : null}
-      {phase.checks && phase.checks.length > 0 ? (
-        <span className="shrink-0">
-          <SplitRunCheckPills checks={phase.checks} testId={`split-run-phase-checks-${phase.id}`} />
-        </span>
-      ) : null}
       {phase.status === "running" && onStop ? (
-        <Button
-          type="button"
-          size="xs"
-          variant="outline"
-          className="text-destructive"
-          disabled={actionBusy}
-          onClick={onStop}
-        >
-          {actionBusy ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : null}
-          Stop
-        </Button>
+        <PhaseStopButton phaseId={phase.id} busy={actionBusy} onStop={onStop} />
       ) : null}
       {phase.status === "failed" && onRerun ? (
-        <Button type="button" size="xs" variant="ghost" disabled={actionBusy} onClick={onRerun}>
-          {actionBusy ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : null}
-          Rerun
-        </Button>
+        <PhaseRerunButton phaseId={phase.id} busy={actionBusy} onRerun={onRerun} />
       ) : null}
+      <span className="ml-auto flex min-w-0 items-center justify-end gap-2 overflow-hidden">
+        {phase.checks && phase.checks.length > 0 ? (
+          <span className="shrink-0">
+            <SplitRunCheckPills checks={phase.checks} testId={`split-run-phase-checks-${phase.id}`} />
+          </span>
+        ) : null}
+        {producedArtifacts.length > 0 ? (
+          <span
+            data-testid={`split-run-phase-artifacts-${phase.id}`}
+            className="flex min-w-0 items-center justify-end gap-2 overflow-hidden whitespace-nowrap"
+          >
+            {producedArtifacts.map((artifact) => (
+              <StreamArtifact key={artifact.id ?? `${artifact.type}`} artifact={artifact} />
+            ))}
+          </span>
+        ) : null}
+        <PhaseDuration phase={phase} />
+      </span>
     </div>
   );
 }
 
-function automationAccent(status: SplitRunPhaseStatus): string {
-  if (status === "passed") return "border-l-[#10b981]";
-  if (status === "running") return "border-l-[#3b82f6]";
-  if (status === "failed") return "border-l-[#ef4444]";
-  if (status === "waiting") return "border-l-[#f59e0b]";
-  return "border-l-border";
-}
-
-const PHASE_ACTION_PILL =
-  "inline-flex shrink-0 items-center gap-1 rounded-full border border-border bg-card px-1.5 py-0.5 font-sans text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
+const PHASE_ACTION_LINK = cn(
+  LOG_FACE,
+  "inline-flex size-6 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground",
+);
+const VIEW_RUN_LABEL = "View automation run";
+const EDIT_AUTOMATION_LABEL = "Edit automation";
+const RERUN_LABEL = "Rerun";
+const STOP_LABEL = "Stop";
+const PHASE_STOP_ACTION = cn(PHASE_ACTION_LINK, "hover:bg-destructive/10 hover:text-destructive");
 
 function PhaseActionPills({ phase, runHref, editHref }: { phase: SplitRunPhase; runHref?: string; editHref?: string }) {
   if (!runHref && !editHref) {
@@ -476,18 +480,95 @@ function PhaseActionPills({ phase, runHref, editHref }: { phase: SplitRunPhase; 
   return (
     <>
       {runHref ? (
-        <Link href={runHref} data-testid={`split-run-phase-run-${phase.id}`} className={PHASE_ACTION_PILL}>
-          <Maximize2 className="size-2.5" aria-hidden />
-          View Automation Run
-        </Link>
+        <PhaseActionLink href={runHref} testId={`split-run-phase-run-${phase.id}`} label={VIEW_RUN_LABEL}>
+          <Maximize2 className="size-3.5" aria-hidden />
+        </PhaseActionLink>
       ) : null}
       {editHref ? (
-        <Link href={editHref} data-testid={`split-run-phase-edit-${phase.id}`} className={PHASE_ACTION_PILL}>
-          <Pencil className="size-2.5" aria-hidden />
-          Edit Automation
-        </Link>
+        <PhaseActionLink href={editHref} testId={`split-run-phase-edit-${phase.id}`} label={EDIT_AUTOMATION_LABEL}>
+          <Pencil className="size-3.5" aria-hidden />
+        </PhaseActionLink>
       ) : null}
     </>
+  );
+}
+
+function PhaseActionLink({
+  href,
+  testId,
+  label,
+  children,
+}: {
+  href: string;
+  testId: string;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link href={href} data-testid={testId} aria-label={label} className={PHASE_ACTION_LINK}>
+          {children}
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function PhaseIconButton({
+  testId,
+  label,
+  className = PHASE_ACTION_LINK,
+  disabled,
+  onClick,
+  children,
+}: {
+  testId: string;
+  label: string;
+  className?: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          data-testid={testId}
+          aria-label={label}
+          className={className}
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function PhaseRerunButton({ phaseId, busy, onRerun }: { phaseId: string; busy: boolean; onRerun: () => void }) {
+  return (
+    <PhaseIconButton testId={`split-run-phase-rerun-${phaseId}`} label={RERUN_LABEL} disabled={busy} onClick={onRerun}>
+      {busy ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : <RotateCw className="size-3.5" aria-hidden />}
+    </PhaseIconButton>
+  );
+}
+
+function PhaseStopButton({ phaseId, busy, onStop }: { phaseId: string; busy: boolean; onStop: () => void }) {
+  return (
+    <PhaseIconButton
+      testId={`split-run-phase-stop-${phaseId}`}
+      label={STOP_LABEL}
+      className={PHASE_STOP_ACTION}
+      disabled={busy}
+      onClick={onStop}
+    >
+      {busy ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : <CircleX className="size-3.5" aria-hidden />}
+    </PhaseIconButton>
   );
 }
 
@@ -519,7 +600,8 @@ function LogStatusTime({
       data-testid={testId}
       aria-label={running ? "Running" : undefined}
       className={cn(
-        "shrink-0 rounded-sm px-1.5 text-right text-[12px] leading-[1.125rem] tabular-nums [font-feature-settings:'zero']",
+        "shrink-0 rounded-sm px-1.5 text-right tabular-nums [font-feature-settings:'zero']",
+        LOG_FACE,
         statusTimeTone(status),
       )}
     >
@@ -529,6 +611,25 @@ function LogStatusTime({
         </span>
       ) : null}
       {label}
+    </span>
+  );
+}
+
+function PhaseDuration({ phase }: { phase: SplitRunPhase }) {
+  const running = phase.status === "running";
+  const { now, sampledAt } = useRunningLogClock(running, phase.duration);
+  const clock = running
+    ? tickingRunningClock(phase.duration, sampledAt, now)
+    : formatClockDurationLabel(phase.duration);
+  if (!clock || clock === "—") {
+    return null;
+  }
+  return (
+    <span
+      data-testid={`split-run-phase-duration-${phase.id}`}
+      className={cn(LOG_FACE, "min-w-[5ch] text-right tabular-nums text-muted-foreground")}
+    >
+      {clock}
     </span>
   );
 }
@@ -623,7 +724,6 @@ function StreamNodeHeader({
       className={cn(
         "flex w-full min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap",
         LOG_ROW_H,
-        LOG_ROW_HOVER,
         STREAM_SECTION,
         LAST_RUNNING_LINE_PULSE,
         hasChildren && STICKY_NODE,
@@ -681,7 +781,7 @@ function StreamStep({ step }: { step: ClaudeStepGroup }) {
                 key={event.line.id}
                 data-testid={`split-run-stream-line-${event.line.id}`}
                 {...streamLineAttrs(event.line.status)}
-                className={cn("flex w-full items-start px-2", LOG_ROW_HOVER, LAST_RUNNING_LINE_PULSE)}
+                className={cn("flex w-full items-start px-2", LAST_RUNNING_LINE_PULSE)}
               >
                 <span className="inline-flex w-4 shrink-0" aria-hidden />
                 <span className="min-w-0 flex-1 whitespace-normal break-words py-0.5 leading-5 text-foreground">
@@ -782,7 +882,7 @@ function StreamOutput({ text }: { text: string }) {
         <div
           key={index}
           data-stream-line=""
-          className={cn("flex min-w-0 w-full items-start px-2", LOG_FACE, LOG_ROW_HOVER, LAST_RUNNING_LINE_PULSE)}
+          className={cn("flex min-w-0 w-full items-start px-2", LOG_FACE, LAST_RUNNING_LINE_PULSE)}
         >
           <span className="inline-flex w-4 shrink-0" aria-hidden />
           <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 leading-5 text-muted-foreground">

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -12,7 +12,7 @@ import type { PhaseGlyphKind } from "../../lib/linePhaseRuns";
 import { toArtifactDataRecord } from "../../lib/workOrderArtifact";
 import { WorkOrderArtifactInline } from "../../WorkOrderArtifactInline";
 import { PhaseGlyph } from "../linePhaseGlyph";
-import { logStatusTimeLabel, runningSpinnerFrame, tickingRunningClock } from "./logStatusTime";
+import { logStatusTimeLabel, tickingRunningClock } from "./logStatusTime";
 import { SplitRunCheckPills } from "./SplitRunReview";
 import { type SplitRunPhase, type SplitRunPhaseStatus, type SplitRunStreamLine } from "./splitRunMocks";
 import { isRunnerComponent, notesForLiveStream } from "./streamNotesFromLiveLog";
@@ -31,16 +31,16 @@ function statusGlyph(status: SplitRunPhaseStatus): PhaseGlyphKind {
 
 function statusTimeTone(status: SplitRunPhaseStatus): string {
   if (status === "passed") {
-    return "bg-[color:var(--status-completed-bg)] text-[color:var(--status-completed-fg)]";
+    return "text-[color:var(--status-completed-fg)]";
   }
   if (status === "running") {
-    return "bg-[color:var(--status-running-bg)] text-[color:var(--status-running-fg)]";
+    return "text-[color:var(--status-running-fg)]";
   }
   if (status === "waiting") {
-    return "bg-[color:var(--status-waiting-bg)] text-[color:var(--status-waiting-fg)]";
+    return "text-[color:var(--status-waiting-fg)]";
   }
   if (status === "failed") {
-    return "bg-[color:var(--status-failed-bg)] text-[color:var(--status-failed-fg)]";
+    return "text-[color:var(--status-failed-fg)]";
   }
   return "text-muted-foreground";
 }
@@ -589,30 +589,51 @@ function LogStatusTime({
 }) {
   const running = status === "running";
   const { now, sampledAt } = useRunningLogClock(running, duration);
-  const label = running
-    ? `Running ${tickingRunningClock(duration, sampledAt, now)}`
-    : logStatusTimeLabel(status, duration);
-  if (!label) {
+  const clock = running ? tickingRunningClock(duration, sampledAt, now) : logStatusTimeLabel(duration);
+  const mark = statusTimeMark(status);
+  if (!mark && !clock) {
     return null;
   }
   return (
     <span
       data-testid={testId}
-      aria-label={running ? "Running" : undefined}
+      aria-label={statusTimeName(status)}
       className={cn(
-        "shrink-0 rounded-sm px-1.5 text-right tabular-nums [font-feature-settings:'zero']",
+        "inline-flex shrink-0 items-center gap-1 text-right tabular-nums [font-feature-settings:'zero']",
         LOG_FACE,
         statusTimeTone(status),
       )}
     >
-      {running ? (
-        <span data-testid="split-run-running-spinner" className="mr-1 inline-block w-[1ch]" aria-hidden>
-          {runningSpinnerFrame(now - sampledAt)}
-        </span>
-      ) : null}
-      {label}
+      {mark}
+      {clock ? <span>{clock}</span> : null}
     </span>
   );
+}
+
+function statusTimeName(status: SplitRunPhaseStatus): string | undefined {
+  if (status === "passed") {
+    return "Passed";
+  }
+  if (status === "running") {
+    return "Running";
+  }
+  if (status === "failed") {
+    return "Failed";
+  }
+  if (status === "waiting") {
+    return "Waiting";
+  }
+  return undefined;
+}
+
+function statusTimeMark(status: SplitRunPhaseStatus): ReactNode {
+  if (status === "passed" || status === "running") {
+    return <span aria-hidden>✓</span>;
+  }
+  if (status === "failed") {
+    return <span aria-hidden>✗</span>;
+  }
+  return null;
 }
 
 function PhaseDuration({ phase }: { phase: SplitRunPhase }) {

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -48,7 +48,7 @@ function statusTimeTone(status: SplitRunPhaseStatus): string {
 const LOG_ROW_HOVER = "hover:bg-[color:var(--status-running-bg)]";
 const LOG_ROW_H = "h-[1.375rem]";
 const STREAM_SECTION = "px-2";
-const STICKY_PHASE = "sticky top-0 z-30 h-8 bg-background";
+const STICKY_PHASE = "sticky top-0 z-30 h-8 bg-muted";
 const STICKY_NODE = cn("sticky top-8 z-20 bg-background", STREAM_SECTION);
 const STICKY_STEP = cn("sticky top-[3.375rem] z-10 bg-background", STREAM_SECTION);
 
@@ -336,7 +336,7 @@ export function PhaseLogCard({
     >
       <div
         className={cn(
-          "rounded-md",
+          "rounded-md bg-muted",
           !expanded && LOG_ROW_HOVER,
           expanded ? "pb-2" : "py-2",
           canToggleFromHeader && !expanded && "cursor-pointer",
@@ -417,7 +417,7 @@ function AutomationHeader({
       data-testid={`split-run-automation-header-${phase.id}`}
       {...streamLineAttrs(phase.status)}
       className={cn(
-        "flex w-full min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap px-2 leading-tight",
+        "flex w-full min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap px-2 leading-tight bg-muted",
         LAST_RUNNING_LINE_PULSE,
         expanded && STICKY_PHASE,
         collapsible && onToggle && "cursor-pointer",

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunHeaderActions.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunHeaderActions.tsx
@@ -1,39 +1,18 @@
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/ui/alertDialog";
-
-import {
-  splitRunCloseNeedsConfirm,
-  type SplitRunFooter,
-  type SplitRunFooterAction,
-  type SplitRunFooterActionKind,
-  type SplitRunStopChoice,
-} from "./splitRunFooter";
-
-type CloseKind = Extract<SplitRunFooterActionKind, "reject" | "approve">;
+import { type SplitRunFooter, type SplitRunFooterAction, type SplitRunStopChoice } from "./splitRunFooter";
 
 function visibleHeaderActions(
   actions: SplitRunFooter["actions"],
   onStop?: (choice: SplitRunStopChoice) => void | Promise<void>,
-  onReject?: () => void | Promise<void>,
 ) {
   return actions.filter((action) => {
-    if (action.kind === "reopen" || action.kind === "approve") {
-      return Boolean(onStop);
+    if (action.kind === "reject" || action.kind === "approve") {
+      return false;
     }
-    if (action.kind === "reject") {
-      return Boolean(onReject) || Boolean(onStop);
+    if (action.kind === "reopen") {
+      return Boolean(onStop);
     }
     return true;
   });
@@ -41,12 +20,12 @@ function visibleHeaderActions(
 
 /**
  * Work-order actions in the popup header, left of Close.
+ * Start stays on drafts. Reopen stays on closed orders.
  */
 export function SplitRunHeaderActions({
   footer,
   onStart,
   onStop,
-  onReject,
   startBusy = false,
   stopBusy = false,
   startDisabled = false,
@@ -54,28 +33,14 @@ export function SplitRunHeaderActions({
   footer: SplitRunFooter;
   onStart?: () => void | Promise<void>;
   onStop?: (choice: SplitRunStopChoice) => void | Promise<void>;
-  onReject?: () => void | Promise<void>;
   startBusy?: boolean;
   stopBusy?: boolean;
   startDisabled?: boolean;
 }) {
-  const [pendingKind, setPendingKind] = useState<CloseKind | null>(null);
-  const actions = visibleHeaderActions(footer.actions, onStop, onReject);
+  const actions = visibleHeaderActions(footer.actions, onStop);
   if (actions.length === 0) {
     return null;
   }
-
-  const runClose = (kind: CloseKind) => {
-    if (kind === "approve") {
-      void onStop?.("completed");
-      return;
-    }
-    if (footer.kind === "draft") {
-      void onReject?.();
-      return;
-    }
-    void onStop?.("canceled");
-  };
 
   const onActionClick = (action: SplitRunFooterAction) => {
     if (action.kind === "start") {
@@ -84,14 +49,6 @@ export function SplitRunHeaderActions({
     }
     if (action.kind === "reopen") {
       void onStop?.("reopen");
-      return;
-    }
-    if (action.kind === "reject" || action.kind === "approve") {
-      if (splitRunCloseNeedsConfirm(footer.kind)) {
-        setPendingKind(action.kind);
-        return;
-      }
-      runClose(action.kind);
     }
   };
 
@@ -107,28 +64,6 @@ export function SplitRunHeaderActions({
           onClick={() => onActionClick(action)}
         />
       ))}
-      <AlertDialog open={pendingKind !== null} onOpenChange={(open) => !open && setPendingKind(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Stop running automations?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action stops all running automations on this work order. Then it closes the work order.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (pendingKind) {
-                  runClose(pendingKind);
-                }
-              }}
-            >
-              {pendingKind === "approve" ? "Approve" : "Reject"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunLogHeader.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunLogHeader.tsx
@@ -22,25 +22,23 @@ export function SplitRunLogHeader({
 
   return (
     <div className={cn("flex items-center justify-between gap-2", className)}>
-      <div className="flex min-w-0 items-center gap-3">
-        <SectionTitle>Automations</SectionTitle>
-        <div className="flex items-center gap-1.5">
-          <Label htmlFor={followId} className="text-xs font-medium text-muted-foreground">
-            Follow
-          </Label>
-          <Switch id={followId} checked={following} onCheckedChange={onFollowingChange} />
-        </div>
+      <SectionTitle>Automations</SectionTitle>
+      <div className="ml-auto flex items-center gap-1.5" data-testid="split-run-follow">
+        {expandHref ? (
+          <Link
+            href={expandHref}
+            aria-label="Open automation run"
+            className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            data-testid="split-run-log-expand"
+          >
+            <Maximize2 className="size-3.5" aria-hidden />
+          </Link>
+        ) : null}
+        <Label htmlFor={followId} className="text-xs font-medium text-muted-foreground">
+          Follow
+        </Label>
+        <Switch id={followId} checked={following} onCheckedChange={onFollowingChange} />
       </div>
-      {expandHref ? (
-        <Link
-          href={expandHref}
-          aria-label="Open automation run"
-          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          data-testid="split-run-log-expand"
-        >
-          <Maximize2 className="size-3.5" aria-hidden />
-        </Link>
-      ) : null}
     </div>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/SplitRunLogHeader.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/SplitRunLogHeader.tsx
@@ -7,6 +7,27 @@ import { useId } from "react";
 
 import { SectionTitle } from "../work-order-popup-redesign/popupShared";
 
+export function SplitRunFollowSwitch({
+  following,
+  onFollowingChange,
+  className,
+}: {
+  following: boolean;
+  onFollowingChange: (next: boolean) => void;
+  className?: string;
+}) {
+  const followId = useId();
+
+  return (
+    <div className={cn("ml-auto flex items-center gap-1.5", className)} data-testid="split-run-follow">
+      <Label htmlFor={followId} className="text-xs font-medium text-muted-foreground">
+        Follow
+      </Label>
+      <Switch id={followId} checked={following} onCheckedChange={onFollowingChange} />
+    </div>
+  );
+}
+
 export function SplitRunLogHeader({
   following,
   onFollowingChange,
@@ -18,27 +39,20 @@ export function SplitRunLogHeader({
   expandHref?: string | null;
   className?: string;
 }) {
-  const followId = useId();
-
   return (
     <div className={cn("flex items-center justify-between gap-2", className)}>
       <SectionTitle>Automations</SectionTitle>
-      <div className="ml-auto flex items-center gap-1.5" data-testid="split-run-follow">
-        {expandHref ? (
-          <Link
-            href={expandHref}
-            aria-label="Open automation run"
-            className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            data-testid="split-run-log-expand"
-          >
-            <Maximize2 className="size-3.5" aria-hidden />
-          </Link>
-        ) : null}
-        <Label htmlFor={followId} className="text-xs font-medium text-muted-foreground">
-          Follow
-        </Label>
-        <Switch id={followId} checked={following} onCheckedChange={onFollowingChange} />
-      </div>
+      {expandHref ? (
+        <Link
+          href={expandHref}
+          aria-label="Open automation run"
+          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          data-testid="split-run-log-expand"
+        >
+          <Maximize2 className="size-3.5" aria-hidden />
+        </Link>
+      ) : null}
+      <SplitRunFollowSwitch following={following} onFollowingChange={onFollowingChange} />
     </div>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.busy.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.busy.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -48,7 +48,7 @@ describe("WorkOrderSplitRunPopup action busy state", () => {
     cancelRunMock.mockReset().mockReturnValue(new Promise(() => {}));
   });
 
-  it("shares the busy state between automation Stop and header Reject", async () => {
+  it("keeps automation Stop busy while a cancel is in flight", async () => {
     const user = userEvent.setup();
     renderRunningPopup();
 
@@ -58,12 +58,8 @@ describe("WorkOrderSplitRunPopup action busy state", () => {
     });
 
     expect(screen.getByRole("button", { name: "Stop" })).toBeDisabled();
-    expect(
-      within(screen.getByTestId("split-run-header-actions")).getByRole("button", { name: "Reject" }),
-    ).toBeDisabled();
-    expect(
-      within(screen.getByTestId("split-run-header-actions")).getByRole("button", { name: "Approve" }),
-    ).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Stop" }));
     expect(cancelRunMock).toHaveBeenCalledTimes(1);

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.follow.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.follow.spec.tsx
@@ -34,9 +34,19 @@ describe("WorkOrderSplitRunPopup Follow", () => {
     const follow = screen.getByTestId("split-run-follow");
     expect(follow.className).toMatch(/ml-auto/);
     expect(
-      screen.getByRole("heading", { name: "Automations" }).compareDocumentPosition(follow) &
+      screen.getByRole("tab", { name: "Automations" }).compareDocumentPosition(follow) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Automations" })).not.toBeInTheDocument();
+  });
+
+  it("hides Follow on the Description tab", async () => {
+    const user = userEvent.setup();
+    renderPopup({ fixture: SPLIT_RUN_RUNNING });
+
+    await user.click(screen.getByRole("tab", { name: "Description" }));
+
+    expect(screen.queryByRole("switch", { name: "Follow" })).not.toBeInTheDocument();
   });
 
   it("starts Follow off when the run is finished", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.follow.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.follow.spec.tsx
@@ -31,6 +31,12 @@ describe("WorkOrderSplitRunPopup Follow", () => {
     renderPopup({ fixture: SPLIT_RUN_RUNNING });
 
     expect(screen.getByRole("switch", { name: "Follow" })).toBeChecked();
+    const follow = screen.getByTestId("split-run-follow");
+    expect(follow.className).toMatch(/ml-auto/);
+    expect(
+      screen.getByRole("heading", { name: "Automations" }).compareDocumentPosition(follow) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("starts Follow off when the run is finished", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -123,7 +123,8 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(runningDot.querySelector(".animate-ping")).toBeTruthy();
     expect(within(dialog).queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
     expect(within(dialog).queryByTestId("split-run-checks")).not.toBeInTheDocument();
-    expect(within(dialog).getByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("heading", { name: "Automations" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("switch", { name: "Follow" })).toBeInTheDocument();
     expect(within(dialog).queryByRole("region", { name: "Run" })).not.toBeInTheDocument();
     expect(within(dialog).queryByTestId("run-overlay-compact-canvas")).not.toBeInTheDocument();
 
@@ -383,7 +384,8 @@ describe("WorkOrderSplitRunPopup", () => {
     renderPopup({ fixture: { ...SPLIT_RUN_RUNNING, waitingNotes: [], checks: [] } });
 
     expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Automations" })).not.toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Follow" })).toBeInTheDocument();
   });
 
   it("pins a review note and keeps Update manually off the note", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -76,17 +76,52 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
   });
 
+  it("expands next to Close into a full page that leaves the sidebar uncovered", async () => {
+    const user = userEvent.setup();
+    renderPopup({
+      fixture: splitRunFixtureForWorkOrder(OPEN_WORK_ORDER),
+      fixed: true,
+    });
+
+    const expand = screen.getByRole("button", { name: "Open full screen" });
+    const close = screen.getByRole("button", { name: "Close" });
+    expect(expand.compareDocumentPosition(close) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(expand).toHaveClass("h-6", "w-6", "rounded-full");
+    expect(close).toHaveClass("h-6", "w-6", "rounded-full");
+
+    const dialog = screen.getByTestId("work-order-split-run");
+    expect(dialog.className).toContain("w-[min(70rem,calc(100vw-5rem))]");
+    expect(dialog.parentElement).toHaveClass("fixed");
+    expect(dialog.parentElement?.className).not.toContain("left-[var(--workspace-navigation-width)]");
+
+    await user.click(expand);
+
+    const fullPage = screen.getByTestId("work-order-split-run");
+    expect(fullPage.className).toContain("h-full");
+    expect(fullPage.className).toContain("w-full");
+    expect(fullPage.className).not.toContain("w-[min(70rem,calc(100vw-5rem))]");
+    expect(fullPage.parentElement).toHaveClass("fixed");
+    expect(fullPage.parentElement?.className).toContain("left-[var(--workspace-navigation-width)]");
+    expect(fullPage.parentElement).not.toHaveClass("bg-black/50");
+    expect(screen.getByRole("button", { name: "Exit full screen" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Exit full screen" }));
+
+    expect(screen.getByTestId("work-order-split-run").className).toContain("w-[min(70rem,calc(100vw-5rem))]");
+    expect(screen.getByRole("button", { name: "Open full screen" })).toBeInTheDocument();
+  });
+
   it("collapses finished steps and expands the running component stream", () => {
     renderSplitRun();
 
     const dialog = screen.getByTestId("work-order-split-run");
-    expect(dialog.className).toContain("w-[min(56rem,calc(100vw-5rem))]");
+    expect(dialog.className).toContain("w-[min(70rem,calc(100vw-5rem))]");
     expect(within(dialog).getByRole("heading", { name: "Add refund reconciliation test" })).toBeInTheDocument();
     expect(within(dialog).getByRole("tab", { name: "Description" })).toBeInTheDocument();
     const runningDot = within(dialog).getByTestId("split-run-log-tab-dot");
     expect(runningDot).toHaveAttribute("title", "Running");
     expect(runningDot.querySelector(".animate-ping")).toBeTruthy();
-    expect(within(dialog).getByTestId("split-run-header-actions")).toBeInTheDocument();
+    expect(within(dialog).queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
     expect(within(dialog).queryByTestId("split-run-checks")).not.toBeInTheDocument();
     expect(within(dialog).getByRole("heading", { name: "Automations" })).toBeInTheDocument();
     expect(within(dialog).queryByRole("region", { name: "Run" })).not.toBeInTheDocument();
@@ -94,19 +129,19 @@ describe("WorkOrderSplitRunPopup", () => {
 
     const backlog = screen.getByTestId("split-run-phase-backlog");
     expect(within(backlog).getByText("Backlog")).toBeInTheDocument();
-    expect(within(backlog).queryByTestId("split-run-phase-duration-backlog")).not.toBeInTheDocument();
+    expect(within(backlog).getByTestId("split-run-phase-duration-backlog")).toHaveTextContent("00:02");
     expect(within(backlog).getByRole("button", { name: "description.md" })).toBeInTheDocument();
     expect(screen.queryByTestId("split-run-stream-backlog")).not.toBeInTheDocument();
 
     const plan = screen.getByTestId("split-run-phase-plan");
     expect(within(plan).getAllByText(/Create plan/).length).toBeGreaterThan(0);
-    expect(within(plan).queryByTestId("split-run-phase-duration-plan")).not.toBeInTheDocument();
+    expect(within(plan).getByTestId("split-run-phase-duration-plan")).toHaveTextContent("01:12");
     expect(within(plan).getByRole("button", { name: "plan.md" })).toBeInTheDocument();
     expect(screen.queryByTestId("split-run-stream-plan")).not.toBeInTheDocument();
 
     const implement = screen.getByTestId("split-run-phase-implement");
     expect(within(implement).getAllByText(/Implementation/).length).toBeGreaterThan(0);
-    expect(within(implement).queryByTestId(/^split-run-phase-duration-/)).not.toBeInTheDocument();
+    expect(within(implement).getByTestId("split-run-phase-duration-implement")).toHaveTextContent("04:00");
     expect(within(implement).getAllByRole("link", { name: /feature\/refund-retry/ }).length).toBeGreaterThan(0);
     expect(screen.getByTestId("split-run-stream-implement")).toBeInTheDocument();
     expect(within(implement).queryByText("Started")).not.toBeInTheDocument();
@@ -152,7 +187,8 @@ describe("WorkOrderSplitRunPopup", () => {
     const plan = screen.getByTestId("split-run-phase-plan");
     const planToggle = within(plan).getByRole("button", { name: /^Create plan/ });
     const planArtifacts = within(plan).getByTestId("split-run-phase-artifacts-plan");
-    expect(planToggle.parentElement).toBe(planArtifacts.parentElement);
+    expect(planToggle.parentElement).toBe(planArtifacts.parentElement?.parentElement);
+    expect(planArtifacts.parentElement?.className).toMatch(/ml-auto/);
     expect(within(planArtifacts).getByRole("button", { name: "plan.md" })).toBeInTheDocument();
     expect(screen.queryByTestId("split-run-stream-plan")).not.toBeInTheDocument();
 
@@ -169,7 +205,8 @@ describe("WorkOrderSplitRunPopup", () => {
     const implement = screen.getByTestId("split-run-phase-implement");
     const implementToggle = within(implement).getByRole("button", { name: /^Implement/ });
     const implementArtifacts = within(implement).getByTestId("split-run-phase-artifacts-implement");
-    expect(implementToggle.parentElement).toBe(implementArtifacts.parentElement);
+    expect(implementToggle.parentElement).toBe(implementArtifacts.parentElement?.parentElement);
+    expect(implementArtifacts.parentElement?.className).toMatch(/ml-auto/);
     expect(within(implementArtifacts).getByRole("link", { name: /feature\/refund-retry/ })).toBeInTheDocument();
     expect(screen.queryByTestId("split-run-stream-implement")).not.toBeInTheDocument();
 
@@ -248,7 +285,7 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(within(verifyChecks).queryByText("Test coverage")).not.toBeInTheDocument();
     expect(within(verifyChecks).queryByText("Confidence score")).not.toBeInTheDocument();
     expect(within(verifyChecks).queryByText("CI")).not.toBeInTheDocument();
-    expect(screen.getByTestId("split-run-header-actions")).toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
   });
 
   it("pins the pull request review to the waiting implement log", () => {
@@ -338,14 +375,14 @@ describe("WorkOrderSplitRunPopup", () => {
       }),
     });
 
-    expect(screen.getByTestId("split-run-header-actions")).toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
     expect(screen.queryByText("This work order needs attention from test test.")).not.toBeInTheDocument();
   });
 
   it("keeps the running log visible when the work order has no note or checks", () => {
     renderPopup({ fixture: { ...SPLIT_RUN_RUNNING, waitingNotes: [], checks: [] } });
 
-    expect(screen.getByTestId("split-run-header-actions")).toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
   });
 
@@ -353,7 +390,6 @@ describe("WorkOrderSplitRunPopup", () => {
     renderPopup({ fixture: splitRunFixtureForWorkOrder(OPEN_WORK_ORDER) });
 
     const note = screen.getByTestId("split-run-attention-note");
-    const header = screen.getByTestId("split-run-header-actions");
     expect(within(note).getByRole("heading", { name: "Listening for user review" })).toBeInTheDocument();
     expect(note).toHaveTextContent("This automation finished and opened PR #6812.");
     expect(note).toHaveTextContent("Task will automatically close when the pull request is closed or merged.");
@@ -364,13 +400,13 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(within(note).queryByText("PR Closure")).not.toBeInTheDocument();
     expect(within(note).queryByText(/ago/)).not.toBeInTheDocument();
     expect(within(note).queryByRole("button", { name: /Update manually/ })).not.toBeInTheDocument();
-    expect(within(note).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
-    expect(within(header).getByRole("button", { name: "Reject" })).toBeInTheDocument();
-    expect(within(header).getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Stop and Close" })).not.toBeInTheDocument();
   });
 
-  it("hides Reject and Approve when the user cannot update the work order", () => {
+  it("hides work-order close actions when the user cannot update the work order", () => {
     renderPopup({
       fixture: splitRunFixtureForWorkOrder(OPEN_WORK_ORDER),
       canUpdate: false,
@@ -457,7 +493,7 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.queryByRole("button", { name: "Stop and Close" })).not.toBeInTheDocument();
   });
 
-  it("offers Reject and Approve on a failed open implement", () => {
+  it("offers no Reject or Approve on a failed open implement", () => {
     renderPopup({
       fixture: splitRunFixtureForWorkOrder({
         id: "wo-2",
@@ -483,19 +519,19 @@ describe("WorkOrderSplitRunPopup", () => {
       }),
     });
 
-    const header = screen.getByTestId("split-run-header-actions");
-    expect(within(header).getByRole("button", { name: "Reject" })).toBeInTheDocument();
-    expect(within(header).getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Rerun step" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Choose how to stop" })).not.toBeInTheDocument();
   });
 
-  it("puts Reject and Approve in the header on a running order", () => {
+  it("keeps Reject and Approve off the header on a running order", () => {
     renderSplitRun();
 
-    const header = screen.getByTestId("split-run-header-actions");
-    expect(within(header).getByRole("button", { name: "Reject" })).toBeInTheDocument();
-    expect(within(header).getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Stop and Close" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("split-run-stop")).not.toBeInTheDocument();
   });
@@ -514,9 +550,8 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(within(source).getByRole("img", { name: "Leonardo DiCaprio" })).toBeInTheDocument();
     expect(within(source).getByText("Created manually")).toBeInTheDocument();
     const header = screen.getByTestId("split-run-header-actions");
-    const headerStart = within(header).getByRole("button", { name: "Start" });
-    const headerReject = within(header).getByRole("button", { name: "Reject" });
-    expect(headerReject.compareDocumentPosition(headerStart) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(within(header).getByRole("button", { name: "Start" })).toBeInTheDocument();
+    expect(within(header).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
     expect(
       within(screen.getByTestId("split-run-work-order-tab")).queryByRole("button", { name: "Start" }),
     ).not.toBeInTheDocument();
@@ -528,7 +563,7 @@ describe("WorkOrderSplitRunPopup", () => {
     await openLogTab(user);
     expect(screen.getByTestId("split-run-log-pane").className).not.toContain("minmax(0,3fr)_minmax(0,2fr)");
     expect(within(header).getByRole("button", { name: "Start" })).toBeInTheDocument();
-    expect(within(header).getByRole("button", { name: "Reject" })).toBeInTheDocument();
+    expect(within(header).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
     const backlog = screen.getByTestId("split-run-phase-backlog");
     expect(within(backlog).getByRole("button", { name: "Backlog" })).toHaveAttribute("aria-expanded", "false");
     expect(within(backlog).queryByText(/Created manually/)).not.toBeInTheDocument();
@@ -691,10 +726,12 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.queryByRole("link", { name: /#510/ })).not.toBeInTheDocument();
   });
 
-  it("shows a failed implement stream with Reject and Approve in the header", () => {
+  it("shows a failed implement stream without Reject or Approve in the header", () => {
     renderPopup({ fixture: splitRunFixtureForWorkOrder(FAILED_WORK_ORDER) });
 
-    expect(screen.getByTestId("split-run-header-actions")).toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
     expect(screen.getByTestId("split-run-stream-implement-0")).toBeInTheDocument();
   });
 
@@ -784,8 +821,8 @@ describe("WorkOrderSplitRunPopup", () => {
     });
 
     const prCreation = screen.getByTestId("split-run-phase-pr-creation-2");
-    const view = within(prCreation).getByRole("link", { name: "View Automation Run" });
-    const edit = within(prCreation).getByRole("link", { name: "Edit Automation" });
+    const view = within(prCreation).getByRole("link", { name: "View automation run" });
+    const edit = within(prCreation).getByRole("link", { name: "Edit automation" });
     expect(view).toHaveAttribute(
       "href",
       factoryAppSplitRunPath(FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_KEY, "app-pr-closure", {
@@ -802,10 +839,10 @@ describe("WorkOrderSplitRunPopup", () => {
     );
 
     const backlog = screen.getByTestId("split-run-phase-backlog");
-    expect(within(backlog).queryByRole("link", { name: "View Automation Run" })).not.toBeInTheDocument();
+    expect(within(backlog).queryByRole("link", { name: "View automation run" })).not.toBeInTheDocument();
     await user.click(within(backlog).getByRole("button", { name: /^Backlog/ }));
-    expect(within(backlog).queryByRole("link", { name: "View Automation Run" })).not.toBeInTheDocument();
-    expect(within(backlog).queryByRole("link", { name: "Edit Automation" })).not.toBeInTheDocument();
+    expect(within(backlog).queryByRole("link", { name: "View automation run" })).not.toBeInTheDocument();
+    expect(within(backlog).queryByRole("link", { name: "Edit automation" })).not.toBeInTheDocument();
   });
 
   it("opens a mapped implement-running work order on the implement log", () => {
@@ -834,7 +871,7 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.getByTestId("split-run-stream-implement-0")).toBeInTheDocument();
     expect(screen.getAllByText("Implementation").length).toBeGreaterThan(0);
     expect(screen.queryByTestId("run-overlay-compact-canvas")).not.toBeInTheDocument();
-    expect(screen.getByTestId("split-run-header-actions")).toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
   });
 
   it("highlights the PR Closure log for the selected canvas component", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -65,6 +65,14 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(screen.queryByRole("link", { name: "Open automation run" })).not.toBeInTheDocument();
   });
 
+  it("keeps the log scroller flush so sticky phase headers cover scrolled lines", () => {
+    renderSplitRun();
+    const scroll = screen.getByTestId("split-run-log-scroll");
+    expect(scroll.className).not.toMatch(/\bpy-\d/);
+    expect(scroll.className).not.toMatch(/\bpt-\d/);
+    expect(scroll.className).toMatch(/\bpb-3\b/);
+  });
+
   it("does not put an Open work order link next to close", () => {
     renderPopup({
       fixture: splitRunFixtureForWorkOrder(OPEN_WORK_ORDER),

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -148,10 +148,11 @@ export function WorkOrderSplitRunBody({
       <ol
         ref={follow.scrollRef}
         onScroll={follow.onScroll}
-        className="min-h-0 min-w-0 flex-1 list-none space-y-2 overflow-x-hidden overflow-y-auto px-3 py-3"
+        className="min-h-0 min-w-0 flex-1 list-none space-y-2 overflow-x-hidden overflow-y-auto px-3 pb-3"
+        data-testid="split-run-log-scroll"
       >
         {fixture.phases.map((entry) => (
-          <li key={entry.id} className="min-w-0">
+          <li key={entry.id} className="min-w-0 first:mt-3">
             <PhaseLogCard
               phase={entry}
               expanded={entry.id === openPhaseId}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -8,7 +8,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { OwnerTimeCostRow, PopupHeader, PopupShell } from "../work-order-popup-redesign/popupShared";
 import { PhaseLogCard } from "./PhaseLogCard";
 import { SplitRunHeaderActions } from "./SplitRunHeaderActions";
-import { SplitRunLogHeader } from "./SplitRunLogHeader";
+import { SplitRunFollowSwitch } from "./SplitRunLogHeader";
 import { SplitRunReview } from "./SplitRunReview";
 import { attachArtifactsToStream } from "./attachStreamArtifacts";
 import { emptySplitRunCanvas } from "./splitRunCanvases";
@@ -65,6 +65,8 @@ type WorkOrderSplitRunBodyProps = {
   footerActions: SplitRunFooterActions;
 };
 
+type SplitRunFollow = ReturnType<typeof useFollowLogScroll>;
+
 /** Phase log for a work-order popup. The popup wraps this. */
 export function WorkOrderSplitRunBody({
   organizationId,
@@ -76,7 +78,12 @@ export function WorkOrderSplitRunBody({
   fixture,
   canUpdate = true,
   footerActions,
-}: WorkOrderSplitRunBodyProps) {
+  follow,
+  onStreamTick,
+}: WorkOrderSplitRunBodyProps & {
+  follow: SplitRunFollow;
+  onStreamTick: (tick: string) => void;
+}) {
   const [phaseId, setPhaseId] = useState<SplitRunPhaseId>(fixture.currentPhaseId);
   const [openPhaseId, setOpenPhaseId] = useState<SplitRunPhaseId | null>(() => autoExpandedPhaseId(fixture));
   const [nodeId, setNodeId] = useState<string | null>(null);
@@ -112,7 +119,9 @@ export function WorkOrderSplitRunBody({
     );
   }, [artifactIndex, demoArtifacts, fixture.phases, selectedPhase?.id, visual.stream]);
   const streamTick = useMemo(() => [...streams.values()].map((stream) => stream?.length ?? 0).join(":"), [streams]);
-  const follow = useFollowLogScroll(runningSplitRunPhaseId(fixture.phases), streamTick);
+  useEffect(() => {
+    onStreamTick(streamTick);
+  }, [onStreamTick, streamTick]);
   const liveOrder = Boolean(organizationId && factoryId && orderId);
   const automationStop = (entry: SplitRunPhase) => {
     const appId = entry.appId;
@@ -136,16 +145,10 @@ export function WorkOrderSplitRunBody({
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col" data-testid="split-run-log-pane">
-      <SplitRunLogHeader
-        following={follow.following}
-        onFollowingChange={follow.setFollowing}
-        className="mb-2 px-3 pt-3"
-      />
-
       <ol
         ref={follow.scrollRef}
         onScroll={follow.onScroll}
-        className="min-h-0 min-w-0 flex-1 list-none space-y-2 overflow-x-hidden overflow-y-auto px-3 pb-3"
+        className="min-h-0 min-w-0 flex-1 list-none space-y-2 overflow-x-hidden overflow-y-auto px-3 py-3"
       >
         {fixture.phases.map((entry) => (
           <li key={entry.id} className="min-w-0">
@@ -335,9 +338,13 @@ function SplitRunPopupTabs({
   canUpdate: boolean;
   footerActions: SplitRunFooterActions;
 }) {
+  const [tab, setTab] = useState(initialTab);
+  const [streamTick, setStreamTick] = useState("");
+  const follow = useFollowLogScroll(runningSplitRunPhaseId(fixture.phases), streamTick);
+
   return (
-    <Tabs defaultValue={initialTab} className="flex min-h-0 min-w-0 flex-1 flex-col">
-      <div className="shrink-0 border-b border-border px-5 py-2">
+    <Tabs value={tab} onValueChange={setTab} className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-5 py-2">
         <TabsList aria-label="Work order views">
           <TabsTrigger value="description">Description</TabsTrigger>
           <TabsTrigger value="log">
@@ -352,6 +359,9 @@ function SplitRunPopupTabs({
             Automations
           </TabsTrigger>
         </TabsList>
+        {tab === "log" ? (
+          <SplitRunFollowSwitch following={follow.following} onFollowingChange={follow.setFollowing} />
+        ) : null}
       </div>
       <TabsContent value="description" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
         <WorkOrderSplitRunOverview
@@ -381,6 +391,8 @@ function SplitRunPopupTabs({
           fixture={fixture}
           canUpdate={canUpdate}
           footerActions={footerActions}
+          follow={follow}
+          onStreamTick={setStreamTick}
         />
       </TabsContent>
     </Tabs>

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -39,14 +39,9 @@ import { useSplitRunStreamArtifacts } from "./useSplitRunStreamArtifacts";
 import { WorkOrderStatusDot } from "../../workOrders/WorkOrderStatusDot";
 import { WorkOrderSplitRunOverview } from "./WorkOrderSplitRunOverview";
 
-function footerMutationHandlers(
-  canUpdate: boolean,
-  footerActions: SplitRunFooterActions,
-  fixture: SplitRunFixture,
-  onClose?: () => void,
-) {
+function footerMutationHandlers(canUpdate: boolean, footerActions: SplitRunFooterActions, fixture: SplitRunFixture) {
   if (!canUpdate) {
-    return { onStop: undefined, onReject: undefined };
+    return { onStop: undefined };
   }
   return {
     onStop: (choice: Parameters<typeof footerActions.handleStop>[0]) =>
@@ -55,11 +50,6 @@ function footerMutationHandlers(
         lineName: fixture.lineName,
         stepIndex: fixture.currentStepIndex,
       }),
-    onReject: async () => {
-      if (await footerActions.handleReject()) {
-        onClose?.();
-      }
-    },
   };
 }
 
@@ -155,7 +145,7 @@ export function WorkOrderSplitRunBody({
       <ol
         ref={follow.scrollRef}
         onScroll={follow.onScroll}
-        className="min-h-0 min-w-0 flex-1 list-none space-y-1.5 overflow-x-hidden overflow-y-auto px-3 pb-3"
+        className="min-h-0 min-w-0 flex-1 list-none space-y-2 overflow-x-hidden overflow-y-auto px-3 pb-3"
       >
         {fixture.phases.map((entry) => (
           <li key={entry.id} className="min-w-0">
@@ -218,7 +208,7 @@ export function WorkOrderSplitRunPopup({
   canUpdate?: boolean;
 }) {
   const footerActions = useSplitRunFooterActions(organizationId, factoryId, orderId);
-  const mutations = footerMutationHandlers(canUpdate, footerActions, fixture, onClose);
+  const mutations = footerMutationHandlers(canUpdate, footerActions, fixture);
   const draftStart = draftStartAction(fixture.footer.kind, onDispatch);
   const fixtureArtifacts = collectSplitRunArtifacts(fixture);
   const useLiveArtifacts = hasLiveWorkOrder(organizationId, factoryId, orderId);
@@ -247,21 +237,23 @@ export function WorkOrderSplitRunPopup({
   });
   const initialTab = defaultSplitRunPopupTab(fixture);
   const ownerOrganizationId = popupOwnerOrganizationId(organizationId, edits.canEdit);
+  const [fullPage, setFullPage] = useState(false);
 
   return (
-    <PopupShell testId="work-order-split-run" fixed={fixed} onDismiss={onClose}>
+    <PopupShell testId="work-order-split-run" fixed={fixed} fullPage={fullPage} onDismiss={onClose}>
       <PopupHeader
         title={edits.title}
         onClose={onClose}
         canEditTitle={edits.canEdit}
         titleBusy={edits.titleBusy}
         onTitleSave={(next) => void edits.saveTitle(next)}
+        expanded={fullPage}
+        onToggleExpanded={() => setFullPage((current) => !current)}
         actions={
           <SplitRunHeaderActions
             footer={fixture.footer}
             onStart={draftStart}
             onStop={mutations.onStop}
-            onReject={mutations.onReject}
             startBusy={isDispatching}
             stopBusy={footerActions.busy}
             startDisabled={!canDispatch}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunStop.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { MemoryRouter } from "react-router";
@@ -41,92 +41,42 @@ function renderPopup(fixture: ComponentProps<typeof WorkOrderSplitRunPopup>["fix
   );
 }
 
-function headerActions() {
-  return screen.getByTestId("split-run-header-actions");
-}
-
 describe("WorkOrderSplitRunPopup header actions", () => {
   beforeEach(() => {
     handleStopMock.mockReset();
     handleRejectMock.mockReset();
   });
 
-  it("asks before Reject closes a running work order", async () => {
-    const user = userEvent.setup();
+  it("keeps Reject and Approve off a running work order", () => {
     renderPopup(SPLIT_RUN_RUNNING);
 
-    expect(screen.queryByRole("button", { name: "Stop and Close" })).not.toBeInTheDocument();
-    await user.click(within(headerActions()).getByRole("button", { name: "Reject" }));
-    expect(handleStopMock).not.toHaveBeenCalled();
-
-    const dialog = await screen.findByRole("alertdialog");
-    expect(within(dialog).getByRole("heading", { name: "Stop running automations?" })).toBeInTheDocument();
-    expect(
-      within(dialog).getByText(/This action stops all running automations on this work order/),
-    ).toBeInTheDocument();
-    await user.click(within(dialog).getByRole("button", { name: "Reject" }));
-    expect(handleStopMock).toHaveBeenCalledWith("canceled", expect.objectContaining({ kind: "running" }));
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("split-run-header-actions")).not.toBeInTheDocument();
   });
 
-  it("asks before Approve closes a running work order", async () => {
-    const user = userEvent.setup();
-    renderPopup(SPLIT_RUN_RUNNING);
-
-    await user.click(within(headerActions()).getByRole("button", { name: "Approve" }));
-    expect(handleStopMock).not.toHaveBeenCalled();
-
-    const dialog = await screen.findByRole("alertdialog");
-    await user.click(within(dialog).getByRole("button", { name: "Approve" }));
-    expect(handleStopMock).toHaveBeenCalledWith("completed", expect.objectContaining({ kind: "running" }));
-  });
-
-  it("does not close when Cancel is used on the running confirm", async () => {
-    const user = userEvent.setup();
-    renderPopup(SPLIT_RUN_RUNNING);
-
-    await user.click(within(headerActions()).getByRole("button", { name: "Reject" }));
-    await user.click(within(await screen.findByRole("alertdialog")).getByRole("button", { name: "Cancel" }));
-    expect(handleStopMock).not.toHaveBeenCalled();
-    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
-  });
-
-  it("rejects a waiting work order without a confirm", async () => {
-    const user = userEvent.setup();
+  it("keeps Reject and Approve off a waiting work order", () => {
     renderPopup(splitRunFixtureForWorkOrder(OPEN_WORK_ORDER));
 
-    await user.click(within(headerActions()).getByRole("button", { name: "Reject" }));
-    expect(handleStopMock).toHaveBeenCalledWith("canceled", expect.objectContaining({ kind: "waiting" }));
-    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
   });
 
-  it("approves a waiting work order without a confirm", async () => {
-    const user = userEvent.setup();
-    renderPopup(splitRunFixtureForWorkOrder(OPEN_WORK_ORDER));
+  it("keeps Start on a draft and omits Reject", () => {
+    renderPopup(splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER));
 
-    await user.click(within(headerActions()).getByRole("button", { name: "Approve" }));
-    expect(handleStopMock).toHaveBeenCalledWith("completed", expect.objectContaining({ kind: "waiting" }));
-    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
-  });
-
-  it("closes the popup after Reject deletes a draft", async () => {
-    handleRejectMock.mockResolvedValue(true);
-    const user = userEvent.setup();
-    const onClose = vi.fn();
-    renderPopup(splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER), onClose);
-
-    await user.click(within(headerActions()).getByRole("button", { name: "Reject" }));
-    expect(handleRejectMock).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(onClose).toHaveBeenCalledTimes(1);
-    });
+    const header = screen.getByTestId("split-run-header-actions");
+    expect(within(header).getByRole("button", { name: "Start" })).toBeInTheDocument();
+    expect(within(header).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
   });
 
   it("reopens a closed work order from Reopen", async () => {
     const user = userEvent.setup();
     renderPopup(splitRunFixtureForWorkOrder(BOARD_IMPLEMENT_FAILED_ORDER));
 
-    expect(within(headerActions()).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
-    await user.click(within(headerActions()).getByRole("button", { name: "Reopen" }));
+    const header = screen.getByTestId("split-run-header-actions");
+    expect(within(header).queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    await user.click(within(header).getByRole("button", { name: "Reopen" }));
     expect(handleStopMock).toHaveBeenCalledWith(
       "reopen",
       expect.objectContaining({ kind: "failed", status: "failed" }),

--- a/web_src/src/pages/factories/pages/work-order-split-run/logStatusTime.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/logStatusTime.spec.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { logStatusTimeLabel, runningSpinnerFrame, tickingRunningClock } from "./logStatusTime";
+import { logStatusTimeLabel, tickingRunningClock } from "./logStatusTime";
 
 describe("logStatusTimeLabel", () => {
-  it("puts the status word and the clock on one right-hand label", () => {
-    expect(logStatusTimeLabel("passed", "1m 20s")).toBe("Passed 01:20");
-    expect(logStatusTimeLabel("running", "4m so far")).toBe("Running 04:00");
-    expect(logStatusTimeLabel("failed", "12s")).toBe("Failed 00:12");
+  it("returns only the clock", () => {
+    expect(logStatusTimeLabel("1m 20s")).toBe("01:20");
+    expect(logStatusTimeLabel("4m so far")).toBe("04:00");
+    expect(logStatusTimeLabel("12s")).toBe("00:12");
   });
 
-  it("keeps the status word when there is no clock", () => {
-    expect(logStatusTimeLabel("waiting")).toBe("Waiting");
-    expect(logStatusTimeLabel("pending")).toBe("");
+  it("is empty when there is no clock", () => {
+    expect(logStatusTimeLabel()).toBe("");
+    expect(logStatusTimeLabel("")).toBe("");
   });
 });
 
@@ -20,15 +20,5 @@ describe("tickingRunningClock", () => {
     expect(tickingRunningClock("4m so far", 1_000, 1_000)).toBe("04:00");
     expect(tickingRunningClock("4m so far", 1_000, 2_000)).toBe("04:01");
     expect(tickingRunningClock(undefined, 1_000, 3_500)).toBe("00:02");
-  });
-});
-
-describe("runningSpinnerFrame", () => {
-  it("rotates the line through four frames", () => {
-    expect(runningSpinnerFrame(0)).toBe("|");
-    expect(runningSpinnerFrame(250)).toBe("/");
-    expect(runningSpinnerFrame(500)).toBe("-");
-    expect(runningSpinnerFrame(750)).toBe("\\");
-    expect(runningSpinnerFrame(1_000)).toBe("|");
   });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/logStatusTime.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/logStatusTime.ts
@@ -1,45 +1,15 @@
 import { durationLabelMs, formatClockDuration, formatClockDurationLabel } from "@/lib/duration";
 
-import type { SplitRunPhaseStatus } from "./splitRunMocks";
-
-export const RUNNING_SPINNER_FRAMES = ["|", "/", "-", "\\"] as const;
-
-export function runningSpinnerFrame(nowMs: number): string {
-  const index = Math.floor(Math.max(0, nowMs) / 250) % RUNNING_SPINNER_FRAMES.length;
-  return RUNNING_SPINNER_FRAMES[index];
-}
-
 export function tickingRunningClock(duration: string | undefined, sampledAtMs: number, nowMs: number): string {
   const base = duration ? durationLabelMs(duration) : 0;
   const elapsedMs = Math.max(0, nowMs - sampledAtMs);
   return formatClockDuration(base + Math.floor(elapsedMs / 1000) * 1000);
 }
 
-export function logStatusTimeLabel(status: SplitRunPhaseStatus, duration?: string): string {
-  const word = statusWord(status);
+export function logStatusTimeLabel(duration?: string): string {
   const clock = duration ? formatClockDurationLabel(duration) : "";
-  const hasClock = Boolean(clock && clock !== "—");
-  if (!word) {
-    return hasClock ? clock : "";
+  if (!clock || clock === "—") {
+    return "";
   }
-  if (!hasClock) {
-    return word;
-  }
-  return `${word} ${clock}`;
-}
-
-function statusWord(status: SplitRunPhaseStatus): string {
-  if (status === "passed") {
-    return "Passed";
-  }
-  if (status === "running") {
-    return "Running";
-  }
-  if (status === "failed") {
-    return "Failed";
-  }
-  if (status === "waiting") {
-    return "Waiting";
-  }
-  return "";
+  return clock;
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
@@ -11,11 +11,6 @@ import {
   SPLIT_RUN_STOP_CHOICES,
 } from "./splitRunFooter";
 
-const REJECT_APPROVE = [
-  { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" },
-  { id: "approve", kind: "approve", label: "Approve", emphasis: "primary" },
-] as const;
-
 const PR_NOTE = {
   key: "pr",
   headline: "Review the pull request",
@@ -39,19 +34,18 @@ const DRAFT_NOTE = {
 };
 
 describe("buildSplitRunFooter", () => {
-  it("keeps a draft note above the state bar with Start and Reject", () => {
+  it("keeps a draft note above the state bar with Start", () => {
     expect(buildSplitRunFooter({ kind: "draft", note: DRAFT_NOTE })).toEqual({
       kind: "draft",
       sentence: "This work order is a draft.",
       note: { headline: "Review the plan, then start", text: "From GitHub issue PAY-842. Confidence 5/5." },
       actions: [
-        { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" },
         { id: "start", kind: "start", label: "Start", emphasis: "primary" },
       ],
     });
   });
 
-  it("keeps Reject and Approve on a running order", () => {
+  it("keeps no close actions on a running order", () => {
     const footer = buildSplitRunFooter({
       kind: "running",
       note: { key: "running-step", headline: "Implement is running", text: "The log shows live progress." },
@@ -60,7 +54,7 @@ describe("buildSplitRunFooter", () => {
     expect(footer.sentence).toBe("This work order is running.");
     expect(footer.note?.headline).toBe("Implement is running");
     expect(footer.run).toBeUndefined();
-    expect(footer.actions).toEqual([...REJECT_APPROVE]);
+    expect(footer.actions).toEqual([]);
     expect(splitRunCloseNeedsConfirm("running")).toBe(true);
     expect(DEFAULT_SPLIT_RUN_STOP_CHOICE).toBe("canceled");
     expect(SPLIT_RUN_STOP_CHOICES.map((choice) => choice.label)).toEqual([
@@ -83,7 +77,7 @@ describe("buildSplitRunFooter", () => {
     ]);
   });
 
-  it("keeps a waiting note off the bar and shows Reject and Approve", () => {
+  it("keeps a waiting note off the bar without header close actions", () => {
     const footer = buildSplitRunFooter({ kind: "waiting", note: PR_NOTE });
 
     expect(footer.attentionCard).toBeUndefined();
@@ -94,7 +88,7 @@ describe("buildSplitRunFooter", () => {
       cta: PR_NOTE.cta,
     });
     expect(footer.sentence).toBe("This work order needs attention.");
-    expect(footer.actions).toEqual([...REJECT_APPROVE]);
+    expect(footer.actions).toEqual([]);
     expect(splitRunCloseNeedsConfirm("waiting")).toBe(false);
   });
 
@@ -103,25 +97,25 @@ describe("buildSplitRunFooter", () => {
 
     expect(footer.attentionCard).toBe(true);
     expect(footer.note?.cta).toEqual(PR_NOTE.cta);
-    expect(footer.actions).toEqual([...REJECT_APPROVE]);
+    expect(footer.actions).toEqual([]);
   });
 
-  it("still shows Reject and Approve when a waiting order has no run note", () => {
+  it("still has no header close actions when a waiting order has no run note", () => {
     expect(buildSplitRunFooter({ kind: "waiting" })).toEqual({
       kind: "waiting",
       sentence: "This work order needs attention.",
-      actions: [...REJECT_APPROVE],
+      actions: [],
     });
   });
 
-  it("treats a failed open implement as a run note plus Reject and Approve", () => {
+  it("treats a failed open implement as a run note without header close actions", () => {
     const footer = buildSplitRunFooter({ kind: "failed", note: FAILED_NOTE, attentionCard: true });
 
     expect(footer.attentionCard).toBe(true);
     expect(footer.note?.headline).toBe("Implement did not pass");
     expect(footer.note?.cta?.label).toBe("Review the run");
     expect(footer.sentence).toBe("This work order needs attention.");
-    expect(footer.actions).toEqual([...REJECT_APPROVE]);
+    expect(footer.actions).toEqual([]);
     expect(splitRunCloseNeedsConfirm("failed")).toBe(false);
   });
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.spec.ts
@@ -39,9 +39,7 @@ describe("buildSplitRunFooter", () => {
       kind: "draft",
       sentence: "This work order is a draft.",
       note: { headline: "Review the plan, then start", text: "From GitHub issue PAY-842. Confidence 5/5." },
-      actions: [
-        { id: "start", kind: "start", label: "Start", emphasis: "primary" },
-      ],
+      actions: [{ id: "start", kind: "start", label: "Start", emphasis: "primary" }],
     });
   });
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooter.ts
@@ -141,10 +141,7 @@ export interface SplitRunFooter {
 }
 
 const START: SplitRunFooterAction = { id: "start", kind: "start", label: "Start", emphasis: "primary" };
-const REJECT: SplitRunFooterAction = { id: "reject", kind: "reject", label: "Reject", emphasis: "quiet" };
-const APPROVE: SplitRunFooterAction = { id: "approve", kind: "approve", label: "Approve", emphasis: "primary" };
 const REOPEN: SplitRunFooterAction = { id: "reopen", kind: "reopen", label: "Reopen", emphasis: "primary" };
-const REJECT_APPROVE: SplitRunFooterAction[] = [REJECT, APPROVE];
 
 export function toFooterNote(note: WorkOrderStatusNotePresentation): SplitRunFooterNote {
   return {
@@ -158,8 +155,8 @@ export function toFooterNote(note: WorkOrderStatusNotePresentation): SplitRunFoo
 }
 
 /**
- * Header actions for the work-order popup. Draft keeps Reject and Start.
- * Open orders keep Reject and Approve. Closed orders keep Reopen.
+ * Header actions for the work-order popup. Draft keeps Start.
+ * Open orders have no close actions in the header. Closed orders keep Reopen.
  * A visible waiting note sits under the log as an attention card.
  */
 export function buildSplitRunFooter(input: {
@@ -175,7 +172,7 @@ export function buildSplitRunFooter(input: {
   const withStatus = (footer: SplitRunFooter): SplitRunFooter =>
     input.status ? { ...footer, status: input.status } : footer;
   if (input.kind === "draft") {
-    return withStatus({ kind: "draft", sentence: "This work order is a draft.", note, actions: [REJECT, START] });
+    return withStatus({ kind: "draft", sentence: "This work order is a draft.", note, actions: [START] });
   }
   if (isClosedWorkOrderDisplayStatus(input.status) || input.kind === "done") {
     if (input.kind === "failed") {
@@ -201,7 +198,7 @@ export function buildSplitRunFooter(input: {
       sentence: "This work order is running.",
       note,
       run: input.run,
-      actions: REJECT_APPROVE,
+      actions: [],
     });
   }
   if (input.kind === "waiting" || input.kind === "failed") {
@@ -211,7 +208,7 @@ export function buildSplitRunFooter(input: {
       note,
       attentionCard,
       run: input.run,
-      actions: REJECT_APPROVE,
+      actions: [],
     });
   }
   return withStatus({

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
@@ -107,7 +107,7 @@ describe("splitRunFixtureForWorkOrder", () => {
       appId: "app-refund-implementer",
       runId: RUNNING_WORK_ORDER.lineDispatches?.[0]?.stepExecutions?.[0]?.run?.id,
     });
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Reject", "Approve"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual([]);
     expect(fixture.checks).toMatchObject([{ id: "wo-running-refunds-confidence", name: "Confidence score", score: 4 }]);
     expect(artifactNames(fixture.phases.find((phase) => phase.id === "plan")?.artifacts)).toEqual(["plan.md"]);
     expect(fixture.phases.find((phase) => phase.id === "score")?.checks?.[0]).toMatchObject({
@@ -149,7 +149,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(note?.text).toContain("**plan.md**");
     expect(note?.text).toContain("Confidence 5/5 (High):");
     expect(note?.text).toContain("- The GitHub issue names retryable status codes and a hard attempt limit.");
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Reject", "Start"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Start"]);
   });
 
   it("pins a pull request review on a waiting implement card", () => {
@@ -170,7 +170,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(fixture.waitingNotes[0]?.cta?.label).toBe("Review PR #6812");
     expect(fixture.footer.note?.headline).toBe("Listening for user review");
     expect(fixture.footer.attentionCard).toBe(true);
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Reject", "Approve"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual([]);
     expect(fixture.checks).toEqual([]);
   });
 
@@ -191,7 +191,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(fixture.waitingNotes).toEqual([]);
     expect(fixture.footer.note?.headline).toBe("A person must act");
     expect(fixture.footer.attentionCard).toBeUndefined();
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Reject", "Approve"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual([]);
   });
 
   it("does not treat a missing execution step index as the first step", () => {
@@ -569,7 +569,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(fixture.waitingNotes.map((note) => note.headline)).toEqual(["Implement did not pass"]);
     expect(fixture.waitingNotes[0]?.cta?.label).toBe("Review the run");
     expect(fixture.footer.attentionCard).toBe(true);
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Reject", "Approve"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual([]);
     expect(fixture.checks).toEqual([]);
   });
 
@@ -657,7 +657,7 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(fixture.waitingNotes).toEqual([]);
     expect(fixture.footer.note?.headline).toBe("Start this work order");
     expect(fixture.footer.note?.text).toContain("A person created this work order manually.");
-    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Reject", "Start"]);
+    expect(fixture.footer.actions.map((action) => action.label)).toEqual(["Start"]);
   });
 
   it("omits invented files and ledger pull requests for a live order", () => {


### PR DESCRIPTION
## Summary

Operators need a denser run view from the line board.
The popup opens full page beside the sidebar and uses icon actions on each phase.
The Automations tab already names the view, so Follow sits on that tab row.
Grey phase bars stay visible, and status chips use a small check instead of a pill.

## Test plan

- [ ] Open a running work order from the line board.
- [ ] Confirm Open full screen sits left of Close.
- [ ] Confirm Follow sits on the Automations tab row.
- [ ] Open the Description tab and confirm Follow is hidden.
- [ ] Confirm each phase shows a grey bar when collapsed and expanded.
- [ ] Confirm Passed and Running use a small check, not a pill.
- [ ] Confirm a running automation shows the spinner on the left.
- [ ] Confirm View, Edit, Stop, and Rerun icons still work.
- [ ] Confirm the popup header has no Reject or Approve action.