### PR TITLE
feat: Keep the selected run node in Configure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,9 @@ after a disk-full or interrupted download), run `make dev.clean.go.cache` then
 - Targeted E2E tests: `E2E_TEST_PACKAGES=./test/e2e/workflows make test.e2e`
   (or `make test.e2e FILE=test/e2e/foo_test.go LINE=19` for a single test).
 - After editing Go code: `make format.go`, then `make lint && make check.build.app`.
-- After editing JS/TS code: `make format.js`, then `make check.build.ui`.
+- After editing JS/TS code: `make format.js`, then `make check.lint.ui` and
+  `make check.build.ui`. Run `make check.lint.ui` locally before you open a
+  pull request. CI fails when the ESLint budget grows.
 - After updating `protos/`: regenerate protos, the OpenAPI spec, and the CLI/UI
   SDKs with `make pb.gen` (requires a running `app` container from `make dev.up`).
   After removing proto fields, renumber remaining fields so message field numbers
@@ -280,7 +282,8 @@ contractions, slang, or idioms).
   (`Signed-off-by: Name <email>`). Use `git commit -s` (or `git commit --amend -s`).
 - Before submitting, run the checks relevant to your change:
   - Backend: `make format.go`, `make lint`, `make check.build.app`, `make test`.
-  - Frontend: `make format.js`, `make check.build.ui`.
+  - Frontend: `make format.js`, `make check.lint.ui`, `make check.build.ui`.
+    Run ESLint locally (`make check.lint.ui`) before you open a pull request.
   - Protos: `make pb.gen` and `make check.proto.field.numbers`.
 
 For user-facing UI strings while designing or implementing frontend work, follow

--- a/web_src/src/lib/factoryCanvasChrome.spec.ts
+++ b/web_src/src/lib/factoryCanvasChrome.spec.ts
@@ -24,11 +24,22 @@ describe("factoryCanvasChrome", () => {
       color: "#33312b",
       bgColor: "#14120b",
     });
-    expect(factoryCanvasBackground(false, true)).toMatchObject({ gap: 22, size: 3, color: "#e5e7eb" });
+    expect(factoryCanvasBackground(false, true)).toMatchObject({ gap: 22, size: 3, color: "#b8c4d0" });
   });
 
-  it("uses thin slate edges in light mode", () => {
-    expect(factoryEdgePalette(false).default).toEqual({ stroke: "#cbd5e1", strokeWidth: 1.5 });
+  it("uses a darker light-mode pane so white nodes contrast", () => {
+    expect(factoryCanvasBackground(false)).toEqual({
+      gap: 22,
+      size: 1,
+      color: "#b8c4d0",
+      bgColor: "#e2e8f0",
+    });
+  });
+
+  it("uses darker, thicker slate edges in light mode", () => {
+    expect(factoryEdgePalette(false).default).toEqual({ stroke: "#94a3b8", strokeWidth: 2 });
+    expect(factoryEdgePalette(false).running.strokeWidth).toBe(2);
+    expect(factoryEdgePalette(true).default.strokeWidth).toBe(2);
   });
 
   it("maps event state to edge tone and class", () => {

--- a/web_src/src/lib/factoryCanvasChrome.ts
+++ b/web_src/src/lib/factoryCanvasChrome.ts
@@ -20,21 +20,26 @@ export function factoryCanvasBackground(isDark: boolean, isEditing = false): Fac
   if (isDark) {
     return { gap: 22, size, color: "#33312b", bgColor: "#14120b" };
   }
-  return { gap: 22, size, color: "#e5e7eb", bgColor: "#f9fafb" };
+  return { gap: 22, size, color: "#b8c4d0", bgColor: "#e2e8f0" };
 }
 
+/** Light-mode factory wires. Darker than the canvas dots; used in edit and view. */
+export const FACTORY_EDGE_STROKE = "#94a3b8";
+export const FACTORY_EDGE_STROKE_WIDTH = 2;
+
 export function factoryEdgePalette(isDark: boolean): FactoryEdgePalette {
+  const strokeWidth = FACTORY_EDGE_STROKE_WIDTH;
   if (isDark) {
     return {
-      default: { stroke: "#4a4740", strokeWidth: 1.5 },
-      running: { stroke: "#818cf8", strokeWidth: 1.5 },
-      failed: { stroke: "#f87171", strokeWidth: 1.5 },
+      default: { stroke: "#4a4740", strokeWidth },
+      running: { stroke: "#818cf8", strokeWidth },
+      failed: { stroke: "#f87171", strokeWidth },
     };
   }
   return {
-    default: { stroke: "#cbd5e1", strokeWidth: 1.5 },
-    running: { stroke: "#818cf8", strokeWidth: 1.5 },
-    failed: { stroke: "#fca5a5", strokeWidth: 1.5 },
+    default: { stroke: FACTORY_EDGE_STROKE, strokeWidth },
+    running: { stroke: "#818cf8", strokeWidth },
+    failed: { stroke: "#fca5a5", strokeWidth },
   };
 }
 

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -163,6 +163,7 @@ import {
   isNonCanvasAppViewParam,
   useWorkflowUrlViewFlags,
   clearRunInspectionSearchParams,
+  resolveCanvasPageInitialSidebar,
 } from "./viewState";
 import {
   buildExecutionInfo,
@@ -3870,15 +3871,13 @@ export function AppPage({
         <CanvasPage
           key={canvasRenderKey}
           // In run inspection, sidebar/node params restore the run detail pane,
-          // not the live node inspector.
-          initialSidebar={
-            runInspectionChromeActive
-              ? { isOpen: false, nodeId: null }
-              : {
-                  isOpen: searchParams.get("sidebar") === "1",
-                  nodeId: searchParams.get("node") || null,
-                }
-          }
+          // not the live node inspector. Configure reuses those params for the
+          // component editor, including the brief window where `run` is still set.
+          initialSidebar={resolveCanvasPageInitialSidebar({
+            factoryConfigure,
+            runInspectionChromeActive,
+            searchParams,
+          })}
           onSidebarChange={handleSidebarChange}
           onTriggerModalHostReady={registerTriggerModalHost}
           title={canvas?.metadata?.name || liveCanvas?.metadata?.name || "Canvas"}

--- a/web_src/src/pages/app/lib/canvas-version-activation.spec.ts
+++ b/web_src/src/pages/app/lib/canvas-version-activation.spec.ts
@@ -44,6 +44,48 @@ describe("activateCanvasVersionForEditing", () => {
     expect(next.get("version")).toBeNull();
   });
 
+  it("keeps the Configure component selection when activating the live version for edit", () => {
+    const setSearchParams = vi.fn();
+
+    activateCanvasVersionForEditing({
+      organizationId: "org-1",
+      canvasId: "canvas-1",
+      versionID: "version-live",
+      version: { metadata: { id: "version-live" }, spec: {} },
+      options: { preserveStagedLayer: true },
+      liveCanvasVersionId: "version-live",
+      queryClient: {
+        cancelQueries: vi.fn(),
+      } as never,
+      draftCanvasSpec: null,
+      draftCanvasSpecsRef: { current: new Map() },
+      activeCanvasVersionIdRef: { current: "" },
+      lastAppliedVersionSnapshotRef: { current: "" },
+      clearPendingAutoSaveWork: vi.fn(),
+      setDraftCanvasSpec: vi.fn(),
+      setActiveCanvasVersion: vi.fn(),
+      setLastSavedWorkflowSnapshot: vi.fn(),
+      setSearchParams,
+      initializeFromWorkflow: vi.fn(),
+    });
+
+    const updater = setSearchParams.mock.calls[0]?.[0] as (current: URLSearchParams) => URLSearchParams;
+    const next = updater(
+      new URLSearchParams({
+        run: "run-42",
+        configure: "1",
+        agent: "1",
+        sidebar: "1",
+        node: "create-pr",
+      }),
+    );
+
+    expect(next.get("run")).toBeNull();
+    expect(next.get("configure")).toBe("1");
+    expect(next.get("sidebar")).toBe("1");
+    expect(next.get("node")).toBe("create-pr");
+  });
+
   it("returns the same searchParams instance when activation is a no-op rewrite", () => {
     const setSearchParams = vi.fn();
     const current = new URLSearchParams("configure=1&from=automations");

--- a/web_src/src/pages/app/viewState.spec.ts
+++ b/web_src/src/pages/app/viewState.spec.ts
@@ -5,6 +5,7 @@ import {
   clampWorkflowViewFlagsForFactoryApp,
   clearRunInspectionSearchParams,
   getExitEditModeDisabledTooltip,
+  resolveCanvasPageInitialSidebar,
   getWorkflowViewPresentation,
   isNonCanvasAppViewParam,
 } from "./viewState";
@@ -65,6 +66,44 @@ describe("clearRunInspectionSearchParams", () => {
     expect(next.get("sidebar")).toBeNull();
     expect(next.get("node")).toBeNull();
     expect(next.get("version")).toBe("draft-1");
+  });
+
+  it("keeps the component editor selection when Configure is entering", () => {
+    const next = clearRunInspectionSearchParams(
+      new URLSearchParams({
+        run: "run-42",
+        configure: "1",
+        sidebar: "1",
+        node: "create-pr",
+      }),
+    );
+
+    expect(next.get("run")).toBeNull();
+    expect(next.get("configure")).toBe("1");
+    expect(next.get("sidebar")).toBe("1");
+    expect(next.get("node")).toBe("create-pr");
+  });
+});
+
+describe("resolveCanvasPageInitialSidebar", () => {
+  it("opens the component editor from the URL during Configure even if a run is still present", () => {
+    expect(
+      resolveCanvasPageInitialSidebar({
+        factoryConfigure: true,
+        runInspectionChromeActive: true,
+        searchParams: new URLSearchParams("run=run-42&configure=1&sidebar=1&node=create-pr"),
+      }),
+    ).toEqual({ isOpen: true, nodeId: "create-pr" });
+  });
+
+  it("does not restore the live node inspector from run inspection params", () => {
+    expect(
+      resolveCanvasPageInitialSidebar({
+        factoryConfigure: false,
+        runInspectionChromeActive: true,
+        searchParams: new URLSearchParams("run=run-42&sidebar=1&node=create-pr"),
+      }),
+    ).toEqual({ isOpen: false, nodeId: null });
   });
 });
 

--- a/web_src/src/pages/app/viewState.ts
+++ b/web_src/src/pages/app/viewState.ts
@@ -118,11 +118,40 @@ export function clearComponentSidebarSearchParams(params: URLSearchParams): URLS
   return params;
 }
 
+export function componentSidebarFromSearchParams(params: URLSearchParams): {
+  isOpen: boolean;
+  nodeId: string | null;
+} {
+  return {
+    isOpen: params.get("sidebar") === "1",
+    nodeId: params.get("node") || null,
+  };
+}
+
+/**
+ * Run inspection uses `sidebar`/`node` for the run detail pane. Configure uses
+ * the same params for the component editor. Prefer the editor when Configure
+ * is active, including the brief window where `run` is still on the URL.
+ */
+export function resolveCanvasPageInitialSidebar(args: {
+  factoryConfigure: boolean;
+  runInspectionChromeActive: boolean;
+  searchParams: URLSearchParams;
+}): { isOpen: boolean; nodeId: string | null } {
+  if (args.runInspectionChromeActive && !args.factoryConfigure) {
+    return { isOpen: false, nodeId: null };
+  }
+  return componentSidebarFromSearchParams(args.searchParams);
+}
+
 export function clearRunInspectionSearchParams(params: URLSearchParams): URLSearchParams {
   const next = new URLSearchParams(params);
+  const keepComponentEditorSelection = next.get("configure") === "1" && Boolean(next.get("node"));
   next.delete("run");
-  next.delete("sidebar");
-  next.delete("node");
+  if (!keepComponentEditorSelection) {
+    next.delete("sidebar");
+    next.delete("node");
+  }
   return next;
 }
 

--- a/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
@@ -64,9 +64,9 @@ describe("factoryAppPath", () => {
     );
   });
 
-  it("builds configure path with configure=1 and components closed", () => {
+  it("builds configure path with the agent panel open and components closed", () => {
     expect(factoryAppConfigurePath("org", "fac", "app-1", { from: "automations" })).toBe(
-      "/org/workspaces/fac/apps/app-1?configure=1&from=automations",
+      "/org/workspaces/fac/apps/app-1?configure=1&agent=1&from=automations",
     );
   });
 });

--- a/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
@@ -130,20 +130,37 @@ describe("factorySettingsGeneralPathAfterKeyChange", () => {
 });
 
 describe("factoryAppConfigurePath", () => {
-  it("adds configure=1 and keeps the components panel closed", () => {
-    expect(factoryAppConfigurePath("org-1", "SP", "app-1")).toBe("/org-1/workspaces/SP/apps/app-1?configure=1");
+  it("adds configure=1, opens the agent panel, and keeps the components panel closed", () => {
+    expect(factoryAppConfigurePath("org-1", "SP", "app-1")).toBe("/org-1/workspaces/SP/apps/app-1?configure=1&agent=1");
   });
 
   it("keeps the run when entering edit from a run page", () => {
     expect(factoryAppConfigurePath("org-1", "SP", "app-1", { from: "lines", lineId: "line-1", runId: "run-9" })).toBe(
-      "/org-1/workspaces/SP/apps/app-1?run=run-9&configure=1&from=lines&lineId=line-1",
+      "/org-1/workspaces/SP/apps/app-1?run=run-9&configure=1&agent=1&from=lines&lineId=line-1",
     );
   });
 
   it("opens components only when blocks is requested", () => {
     expect(factoryAppConfigurePath("org-1", "SP", "app-1", { blocks: true })).toBe(
-      "/org-1/workspaces/SP/apps/app-1?configure=1&blocks=1",
+      "/org-1/workspaces/SP/apps/app-1?configure=1&agent=1&blocks=1",
     );
+  });
+
+  it("opens the component sidebar on the selected node", () => {
+    expect(factoryAppConfigurePath("org-1", "SP", "app-1", { nodeId: "create-pr" })).toBe(
+      "/org-1/workspaces/SP/apps/app-1?configure=1&agent=1&sidebar=1&node=create-pr",
+    );
+  });
+
+  it("does not keep run inspection when opening a component for edit", () => {
+    expect(
+      factoryAppConfigurePath("org-1", "SP", "app-1", {
+        from: "lines",
+        lineId: "line-1",
+        runId: "run-9",
+        nodeId: "create-pr",
+      }),
+    ).toBe("/org-1/workspaces/SP/apps/app-1?configure=1&agent=1&sidebar=1&node=create-pr&from=lines&lineId=line-1");
   });
 });
 

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -153,8 +153,12 @@ export type FactoryAppNavOptions = {
    * AppPage auto-edit cleanup does not tear down the Configure UI mid-bootstrap.
    */
   configure?: boolean;
+  /** Open the agent sidebar in factory edit mode (`agent=1`). */
+  agent?: boolean;
   /** Open the components panel in factory edit mode (`blocks=1`). */
   blocks?: boolean;
+  /** Open the component sidebar on this node (`sidebar=1&node=`). */
+  nodeId?: string;
 };
 
 function buildFactoryAppSearchParams(options?: FactoryAppNavOptions): string {
@@ -168,8 +172,15 @@ function buildFactoryAppSearchParams(options?: FactoryAppNavOptions): string {
   if (options.configure) {
     params.set("configure", "1");
   }
+  if (options.agent) {
+    params.set("agent", "1");
+  }
   if (options.blocks) {
     params.set("blocks", "1");
+  }
+  if (options.nodeId) {
+    params.set("sidebar", "1");
+    params.set("node", options.nodeId);
   }
   if (options.from) {
     params.set("from", options.from);
@@ -193,6 +204,10 @@ export function factoryAppConfigurePath(
   return factoryAppPath(organizationId, factoryKey, appId, {
     ...options,
     configure: true,
+    agent: options?.agent ?? true,
+    // Component edit is not run inspection. A leftover `run` param would hide
+    // the editor sidebar and strip `node` while Configure starts.
+    runId: options?.nodeId ? undefined : options?.runId,
   });
 }
 

--- a/web_src/src/pages/factories/pages/FactoryAppCanvas.stories.tsx
+++ b/web_src/src/pages/factories/pages/FactoryAppCanvas.stories.tsx
@@ -63,7 +63,7 @@ export const ConfigureEditMode: Story = {
   name: "Configure edit mode",
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/apps/${plannerAppId}?configure=1&from=automations`}
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/apps/${plannerAppId}?configure=1&agent=1&from=automations`}
       factoriesFixture={defaultFactoriesFixture}
       appFixture={plannerCanvasFixture}
     />

--- a/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/IntakeSourceSettingsPopup.spec.tsx
@@ -108,7 +108,7 @@ describe("IntakeSourceSettingsPopup", () => {
 
   it("shows the intake automation on the Automation tab", async () => {
     const user = userEvent.setup();
-    renderPopup({ editAutomationHref: "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1" });
+    renderPopup({ editAutomationHref: "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1&agent=1" });
 
     await user.click(screen.getByRole("tab", { name: "Automation" }));
 
@@ -120,7 +120,7 @@ describe("IntakeSourceSettingsPopup", () => {
     expect(within(automation).getAllByText("Create Work Order").length).toBeGreaterThan(0);
     expect(within(automation).getByRole("link", { name: "Edit automation" })).toHaveAttribute(
       "href",
-      "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1",
+      "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1&agent=1",
     );
     expect(screen.queryByRole("heading", { name: "Accepted events go to Backlog" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
+++ b/web_src/src/pages/factories/pages/LineIntakeDrawer.spec.tsx
@@ -461,7 +461,7 @@ describe("LineIntakeDrawer", () => {
       configuredSources: [GITHUB_INTAKE],
       organizationId: "org-1",
       factoryId: "factory-1",
-      editAutomationHref: "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1&from=lines",
+      editAutomationHref: "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1&agent=1&from=lines",
     });
 
     await user.click(screen.getByRole("button", { name: "Open GitHub issues settings" }));
@@ -473,7 +473,7 @@ describe("LineIntakeDrawer", () => {
     expect(within(automation).getByText("Analyze intake")).toBeInTheDocument();
     expect(within(automation).getByRole("link", { name: "Edit automation" })).toHaveAttribute(
       "href",
-      "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1&from=lines",
+      "/org-1/workspaces/RF/apps/app-github-issues-intake?configure=1&agent=1&from=lines",
     );
   });
 

--- a/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
+++ b/web_src/src/pages/factories/pages/work-order-popup-redesign/popupShared.tsx
@@ -2,7 +2,7 @@ import type { FactoriesWorkOrderArtifact } from "@/api-client";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { MarkdownContent } from "@/pages/app/Markdown";
-import { CircleDollarSign, Clock, FileText, Maximize2, Minimize2, UserPlus, XIcon } from "lucide-react";
+import { FileText, Maximize2, Minimize2, UserPlus, XIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { FACTORIES_ORGANIZATION_ID } from "../../__fixtures__/factoryPageResponses";
@@ -129,9 +129,9 @@ export function PopupHeader({
   );
 }
 
-type OwnerTimeCostFields = Pick<PopupFixture, "owner" | "startedLabel" | "elapsed" | "costUsd" | "tokensLabel">;
+type OwnerTimeCostFields = Pick<PopupFixture, "owner" | "costUsd" | "tokensLabel">;
 
-/** Owner, elapsed time, and spend. No status, author, or ticket key. */
+/** Owner and spend. No elapsed time, status, author, or ticket key. */
 export function OwnerTimeCostRow({
   fixture,
   className,
@@ -191,15 +191,8 @@ export function OwnerTimeCostRow({
       ) : (
         ownerMark
       )}
-      <span className="inline-flex items-center gap-1.5 text-muted-foreground" title={fixture.startedLabel}>
-        <Clock className="size-3.5 shrink-0" aria-hidden />
-        <span className="text-foreground">{fixture.elapsed}</span>
-      </span>
-      <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-        <CircleDollarSign className="size-3.5 shrink-0" aria-hidden />
-        <span className="text-foreground">
-          {fixture.costUsd} <span className="text-muted-foreground">·</span> {fixture.tokensLabel}
-        </span>
+      <span className="text-foreground">
+        {fixture.costUsd} <span className="text-muted-foreground">·</span> {fixture.tokensLabel}
       </span>
       {children}
     </div>

--- a/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.spec.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+
+import { CompactLineCanvas } from "./CompactLineCanvas";
+import type { SplitRunCanvasModel } from "./splitRunCanvases";
+
+const CREATE_PR_CANVAS: SplitRunCanvasModel = {
+  key: "implementation",
+  title: "PR Creation",
+  nodes: [
+    {
+      id: "create-pr",
+      name: "Create Draft Pull Request",
+      component: "github.createPullRequest",
+      position: { x: 0, y: 0 },
+    },
+  ],
+  edges: [],
+  statuses: { "create-pr": "failed" },
+  metrics: { "create-pr": "00:00" },
+};
+
+function renderCanvas(selectedId: string | null, nodeEditHref?: (nodeId: string) => string) {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <ReactFlowProvider>
+          <CompactLineCanvas
+            canvas={CREATE_PR_CANVAS}
+            selectedId={selectedId}
+            onSelect={() => undefined}
+            showHeader={false}
+            nodeEditHref={nodeEditHref}
+          />
+        </ReactFlowProvider>
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("CompactLineCanvas", () => {
+  it("draws a thicker ring on the selected node", () => {
+    renderCanvas("create-pr");
+
+    const node = screen.getByTestId("split-run-canvas-node-create-pr");
+    expect(node).toHaveAttribute("data-selected", "true");
+    expect(node.querySelector("[class*='ring-4']")).not.toBeNull();
+  });
+
+  it("shows an Edit component control on the selected node", () => {
+    renderCanvas("create-pr", (nodeId) => `/edit?node=${nodeId}`);
+
+    const edit = screen.getByRole("link", { name: "Edit component" });
+    expect(edit).toHaveAttribute("href", "/edit?node=create-pr");
+    expect(edit).toHaveAttribute("data-testid", "split-run-canvas-node-edit");
+    expect(edit.className).toContain("top-2");
+    expect(edit.className).toContain("right-2");
+    expect(edit.className).toContain("bg-foreground");
+    expect(edit.className).toContain("text-background");
+  });
+
+  it("hides the Edit component control when no node is selected", () => {
+    renderCanvas(null, (nodeId) => `/edit?node=${nodeId}`);
+
+    expect(screen.queryByRole("link", { name: "Edit component" })).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/CompactLineCanvas.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, type MouseEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 import { buttonVariants } from "@/components/ui/buttonVariants";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTheme } from "@/contexts/useTheme";
 import { FACTORY_HANDLE_STYLE, factoryCanvasBackground, factoryEdgePalette } from "@/lib/factoryCanvasChrome";
 import { FACTORY_SIDE_HANDLE_ID, FACTORY_SPINE_HANDLE_ID } from "@/lib/layout/factoryRunLeafLayout";
@@ -14,9 +15,16 @@ import { FACTORY_HANDLE_OUTSET_PX } from "@/ui/CanvasPage/Block/handleStyle";
 import { CustomEdge } from "@/ui/CanvasPage/CustomEdge";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { FactoryNodeCardShell } from "@/ui/factoryNodeChrome/FactoryNodeCardShell";
+import { FACTORY_NODE_SELECTED_RING_CLASSNAME } from "@/ui/factoryNodeChrome/factoryNodeSelectedRing";
 import { FactoryNodeStepList } from "@/ui/factoryNodeChrome/FactoryNodeStepList";
 
-import { COMPACT_CANVAS_FIT_SETTLE_MS, compactCanvasFitKey, shouldFitCompactCanvas } from "./compactCanvasFit";
+import {
+  COMPACT_CANVAS_FIT_SETTLE_MS,
+  COMPACT_FIT_VIEW_OPTIONS,
+  compactCanvasFitKey,
+  compactCanvasNodeFocusRequest,
+  shouldFitCompactCanvas,
+} from "./compactCanvasFit";
 import { compactLineCanvasGraph, type LineNodeData } from "./compactLineCanvasGraph";
 import type { SplitRunCanvasModel } from "./splitRunCanvases";
 
@@ -60,11 +68,7 @@ function LineCanvasNode({ data }: NodeProps<Node<LineNodeData>>) {
       onClick={() => data.onSelect?.(data.nodeId)}
     >
       <div
-        className={cn(
-          "relative overflow-visible rounded-2xl",
-          data.isSelected &&
-            "ring-2 ring-[color:var(--status-running-dot)] ring-offset-2 ring-offset-[color:var(--status-running-bg)]",
-        )}
+        className={cn("relative overflow-visible rounded-2xl", data.isSelected && FACTORY_NODE_SELECTED_RING_CLASSNAME)}
       >
         <LineCanvasTargetHandle isSideTarget={data.isSideTarget} />
         <FactoryNodeCardShell
@@ -77,6 +81,7 @@ function LineCanvasNode({ data }: NodeProps<Node<LineNodeData>>) {
           selected={data.isSelected}
           body={data.steps.length > 0 ? <FactoryNodeStepList steps={data.steps} /> : undefined}
         />
+        {data.isSelected && data.editHref ? <SelectedNodeEditButton href={data.editHref} /> : null}
         <Handle
           id={FACTORY_SPINE_HANDLE_ID}
           type="source"
@@ -107,20 +112,53 @@ function LineCanvasNode({ data }: NodeProps<Node<LineNodeData>>) {
 const nodeTypes = { lineCanvas: LineCanvasNode };
 const edgeTypes = { custom: CustomEdge };
 
-const COMPACT_FIT_VIEW_OPTIONS = { padding: 0.2 } as const;
+const EDIT_COMPONENT_LABEL = "Edit component";
 
-function FitCompactCanvas({ contentKey }: { contentKey: string }) {
-  const { fitView } = useReactFlow();
+function SelectedNodeEditButton({ href }: { href: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          href={href}
+          aria-label={EDIT_COMPONENT_LABEL}
+          data-testid="split-run-canvas-node-edit"
+          className="nodrag nopan absolute top-2 right-2 z-20 flex size-7 items-center justify-center rounded-md bg-foreground text-background shadow-sm transition-colors hover:bg-foreground/90"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Pencil className="size-3.5" aria-hidden />
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent side="top">{EDIT_COMPONENT_LABEL}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CompactCanvasViewport({ contentKey, selectedId }: { contentKey: string; selectedId: string | null }) {
+  const { fitView, getNode } = useReactFlow();
 
   useEffect(() => {
-    if (!shouldFitCompactCanvas(contentKey)) {
+    if (!shouldFitCompactCanvas(contentKey) || selectedId) {
       return;
     }
     const timer = window.setTimeout(() => {
       void fitView(COMPACT_FIT_VIEW_OPTIONS);
     }, COMPACT_CANVAS_FIT_SETTLE_MS);
     return () => window.clearTimeout(timer);
-  }, [contentKey, fitView]);
+  }, [contentKey, fitView, selectedId]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const request = compactCanvasNodeFocusRequest(getNode(selectedId));
+      if (!request) {
+        return;
+      }
+      void fitView(request);
+    }, COMPACT_CANVAS_FIT_SETTLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [contentKey, fitView, getNode, selectedId]);
 
   return null;
 }
@@ -138,6 +176,7 @@ export function CompactLineCanvas({
   headerEdit = "menu",
   editLabel = "Edit Automation",
   onEdit,
+  nodeEditHref,
 }: {
   canvas: SplitRunCanvasModel;
   selectedId: string | null;
@@ -148,12 +187,13 @@ export function CompactLineCanvas({
   headerEdit?: "menu" | "button";
   editLabel?: string;
   onEdit?: () => void;
+  nodeEditHref?: (nodeId: string) => string;
 }) {
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
   const { nodes, edges } = useMemo(
-    () => compactLineCanvasGraph(canvas, selectedId, onSelect, isDark),
-    [canvas, isDark, onSelect, selectedId],
+    () => compactLineCanvasGraph(canvas, selectedId, onSelect, isDark, nodeEditHref),
+    [canvas, isDark, nodeEditHref, onSelect, selectedId],
   );
   const background = factoryCanvasBackground(isDark);
   const palette = factoryEdgePalette(isDark);
@@ -222,7 +262,7 @@ export function CompactLineCanvas({
           colorMode={isDark ? "dark" : "light"}
           defaultEdgeOptions={{ type: "custom", style: palette.default }}
         >
-          <FitCompactCanvas contentKey={contentKey} />
+          <CompactCanvasViewport contentKey={contentKey} selectedId={selectedId} />
           <Background
             gap={background.gap}
             size={background.size}

--- a/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.spec.tsx
@@ -44,6 +44,7 @@ describe("FactoryAppSplitRunPage", () => {
     expect(within(page).queryByTestId("split-run-canvas-expand")).not.toBeInTheDocument();
     expect(within(page).queryByTestId("split-run-canvas-menu")).not.toBeInTheDocument();
     expect(within(page).getByTestId("factory-app-edit")).toHaveTextContent("Edit Automation");
+    expect(within(page).getByRole("complementary", { name: "Automations" })).toHaveStyle({ width: "65%" });
   }, 10000);
 
   it("does not invent a planning ingest phase for a live order", async () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/FactoryAppSplitRunPage.tsx
@@ -134,6 +134,7 @@ function SplitRunLoadedPage({ model }: { model: ReturnType<typeof useFactoryAppS
             selectedId={model.nodeId}
             onSelect={model.setNodeId}
             showHeader={false}
+            nodeEditHref={model.nodeEditHref}
           />
         </section>
       </div>

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -73,6 +73,16 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(scroll.className).toMatch(/\bpb-3\b/);
   });
 
+  it("does not show elapsed time or a spend icon on the owner row", () => {
+    renderSplitRun();
+    const row = screen.getByTestId("popup-owner-time-cost");
+    expect(within(row).queryByText(/so far/)).not.toBeInTheDocument();
+    expect(row.querySelector(".lucide-clock")).toBeNull();
+    expect(row.querySelector(".lucide-circle-dollar-sign")).toBeNull();
+    expect(row).toHaveTextContent("$0.73");
+    expect(row).toHaveTextContent("2.7k tokens");
+  });
+
   it("does not put an Open work order link next to close", () => {
     renderPopup({
       fixture: splitRunFixtureForWorkOrder(OPEN_WORK_ORDER),

--- a/web_src/src/pages/factories/pages/work-order-split-run/compactCanvasFit.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/compactCanvasFit.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { compactCanvasFitKey, shouldFitCompactCanvas } from "./compactCanvasFit";
+import {
+  compactCanvasFitKey,
+  compactCanvasNodeFocusRequest,
+  COMPACT_CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS,
+  shouldFitCompactCanvas,
+} from "./compactCanvasFit";
 
 describe("compactCanvasFitKey", () => {
   it("uses empty when there are no nodes", () => {
@@ -15,5 +20,21 @@ describe("compactCanvasFitKey", () => {
   it("fits only after live nodes arrive", () => {
     expect(shouldFitCompactCanvas("empty")).toBe(false);
     expect(shouldFitCompactCanvas("kickoff|step-1")).toBe(true);
+  });
+});
+
+describe("compactCanvasNodeFocusRequest", () => {
+  it("frames the selected node so the compact canvas zooms to it", () => {
+    const node = { id: "create-pr" };
+    expect(compactCanvasNodeFocusRequest(node)).toEqual({
+      nodes: [node],
+      ...COMPACT_CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS,
+    });
+    expect(COMPACT_CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS.maxZoom).toBe(1.2);
+    expect(COMPACT_CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS.duration).toBe(400);
+  });
+
+  it("returns null when the selected node is not on the canvas", () => {
+    expect(compactCanvasNodeFocusRequest(undefined)).toBeNull();
   });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/compactCanvasFit.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/compactCanvasFit.ts
@@ -1,5 +1,17 @@
+import { CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS } from "@/ui/CanvasPage/canvasFitOptions";
+
 /** Wait for the popup pane to get a real size, then fit the graph. */
 export const COMPACT_CANVAS_FIT_SETTLE_MS = 200;
+
+/** Fit the whole compact graph when no node is selected. */
+export const COMPACT_FIT_VIEW_OPTIONS = { padding: 0.2 } as const;
+
+/** Zoom the compact canvas onto one selected node. */
+export const COMPACT_CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS = {
+  ...CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS,
+  padding: 0.35,
+  duration: 400,
+} as const;
 
 /** Stable key so the compact canvas remounts and fits when live nodes arrive. */
 export function compactCanvasFitKey(nodeIds: string[]): string {
@@ -11,4 +23,11 @@ export function compactCanvasFitKey(nodeIds: string[]): string {
 
 export function shouldFitCompactCanvas(contentKey: string): boolean {
   return contentKey !== "empty";
+}
+
+export function compactCanvasNodeFocusRequest<T extends { id: string }>(node: T | undefined) {
+  if (!node) {
+    return null;
+  }
+  return { nodes: [node], ...COMPACT_CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS };
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.spec.ts
@@ -102,4 +102,22 @@ describe("compactLineCanvasGraph", () => {
     expect(mergeEdge?.data).toMatchObject({ channelLabel: "passed" });
     expect(trueEdge?.type).toBe("custom");
   });
+
+  it("marks the selected node so the compact canvas can highlight it", () => {
+    const { nodes } = compactLineCanvasGraph(messyIfCanvas(), "comment", undefined, false);
+    expect(nodes.find((node) => node.id === "comment")?.data.isSelected).toBe(true);
+    expect(nodes.find((node) => node.id === "on-run")?.data.isSelected).toBe(false);
+  });
+
+  it("attaches an edit href only to the selected node", () => {
+    const { nodes } = compactLineCanvasGraph(
+      messyIfCanvas(),
+      "comment",
+      undefined,
+      false,
+      (nodeId) => `/edit?node=${nodeId}`,
+    );
+    expect(nodes.find((node) => node.id === "comment")?.data.editHref).toBe("/edit?node=comment");
+    expect(nodes.find((node) => node.id === "on-run")?.data.editHref).toBeUndefined();
+  });
 });

--- a/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/compactLineCanvasGraph.ts
@@ -2,7 +2,7 @@ import type { Edge, Node } from "@xyflow/react";
 
 import type { ComponentsEdge, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
 import { agentRunnerStepTitles } from "@/lib/agentRunnerSteps";
-import { factoryNodeCardSize } from "@/lib/factoryCanvasChrome";
+import { factoryEdgePalette, factoryNodeCardSize } from "@/lib/factoryCanvasChrome";
 import { layoutFactoryRunLeafGraph } from "@/lib/layout/factoryRunLeafLayout";
 import { buildStyledCanvasEdges } from "@/ui/CanvasPage/factoryCanvasEdgeStyle";
 import type { FactoryNodeStatus } from "@/ui/factoryNodeChrome/types";
@@ -19,6 +19,7 @@ export type LineNodeData = {
   nodeId: string;
   isSelected: boolean;
   onSelect?: (id: string) => void;
+  editHref?: string;
   isSideSource: boolean;
   isSpineSource: boolean;
   isSideTarget: boolean;
@@ -47,6 +48,7 @@ export function compactLineCanvasGraph(
   selectedId: string | null,
   onSelect: ((id: string) => void) | undefined,
   resolvedThemeIsDark: boolean,
+  nodeEditHref?: (nodeId: string) => string,
 ): { nodes: Node<LineNodeData>[]; edges: Edge[] } {
   const zero = origin(canvas.nodes);
   const rawNodes: Node<LineNodeData>[] = canvas.nodes
@@ -72,6 +74,7 @@ export function compactLineCanvasGraph(
           nodeId: node.id,
           isSelected: node.id === selectedId,
           onSelect,
+          editHref: node.id === selectedId ? nodeEditHref?.(node.id) : undefined,
           isSideSource: false,
           isSpineSource: false,
           isSideTarget: false,
@@ -112,7 +115,7 @@ export function compactLineCanvasGraph(
       nodes,
       isVerticalFlow: true,
       resolvedThemeIsDark,
-      edgeDefaults: { type: "custom", style: { stroke: "#cbd5e1", strokeWidth: 1.5 } },
+      edgeDefaults: { type: "custom", style: factoryEdgePalette(resolvedThemeIsDark).default },
       hoveredEdgeId: null,
       isEditMode: false,
       isReadOnly: true,

--- a/web_src/src/pages/factories/pages/work-order-split-run/useFactoryAppSplitRunPage.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useFactoryAppSplitRunPage.ts
@@ -1,7 +1,7 @@
 import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useWorkOrderChecks } from "@/hooks/useWorkOrderChecks";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
@@ -82,12 +82,20 @@ export function useFactoryAppSplitRunPage() {
       visual.canvas.title,
     ],
   );
-  const editHref = factoryAppConfigurePath(organizationId, factoryKey, appId, {
-    from: parseFactoryAppNavFrom(query.from),
-    lineId: query.lineId ?? undefined,
-    runId: query.runId ?? undefined,
-    orderNumber: query.orderNumber ?? undefined,
-  });
+  const configureNav = useMemo(
+    () => ({
+      from: parseFactoryAppNavFrom(query.from),
+      lineId: query.lineId ?? undefined,
+      runId: query.runId ?? undefined,
+      orderNumber: query.orderNumber ?? undefined,
+    }),
+    [query.from, query.lineId, query.orderNumber, query.runId],
+  );
+  const editHref = factoryAppConfigurePath(organizationId, factoryKey, appId, configureNav);
+  const nodeEditHref = useCallback(
+    (nodeId: string) => factoryAppConfigurePath(organizationId, factoryKey, appId, { ...configureNav, nodeId }),
+    [appId, configureNav, factoryKey, organizationId],
+  );
 
   usePageTitle([splitRunPageTitle(!order, isLoading, visual.canvas.title), factory?.name ?? "Workspace"]);
 
@@ -99,6 +107,7 @@ export function useFactoryAppSplitRunPage() {
     isLoading,
     liveError: live.isError,
     nodeId,
+    nodeEditHref,
     organizationId,
     phase,
     setNodeId,

--- a/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunPanePercent.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunPanePercent.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_LOG_PERCENT } from "./useSplitRunPanePercent";
+
+describe("useSplitRunPanePercent", () => {
+  it("opens the automation run log at 65 percent width", () => {
+    expect(DEFAULT_LOG_PERCENT).toBe(65);
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunPanePercent.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunPanePercent.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type PointerEvent } from "react";
 
-const DEFAULT_LOG_PERCENT = 40;
+export const DEFAULT_LOG_PERCENT = 65;
 const MIN_LOG_PERCENT = 22;
 const MAX_LOG_PERCENT = 72;
 

--- a/web_src/src/ui/CanvasPage/canvas-reset.css
+++ b/web_src/src/ui/CanvasPage/canvas-reset.css
@@ -21,9 +21,9 @@
 
 /* Factory canvases: Storybook WorkOrderCanvas edge weight + slate stroke. */
 .sp-canvas.sp-canvas-factory {
-  --xy-edge-stroke: #cbd5e1;
-  --xy-edge-stroke-selected: #94a3b8;
-  --xy-edge-stroke-width: 1.5;
+  --xy-edge-stroke: #94a3b8;
+  --xy-edge-stroke-selected: #64748b;
+  --xy-edge-stroke-width: 2;
   --sp-handle-border: #e5e7eb;
   --sp-handle-border-hover: #cbd5e1;
   --sp-handle-highlight-border: #94a3b8;
@@ -32,7 +32,7 @@
 .dark .sp-canvas.sp-canvas-factory {
   --xy-edge-stroke: #4a4740;
   --xy-edge-stroke-selected: #6b6560;
-  --xy-edge-stroke-width: 1.5;
+  --xy-edge-stroke-width: 2;
   --sp-handle-border: #4a4740;
   --sp-handle-border-hover: #6b6560;
   --sp-handle-highlight-border: #8a847c;
@@ -145,7 +145,10 @@
   stroke: #fca5a5 !important;
 }
 
-.dark .sp-canvas.sp-canvas-factory .react-flow__edge.sp-edge-factory-failed.sp-edge-factory-touching .react-flow__edge-path {
+.dark
+  .sp-canvas.sp-canvas-factory
+  .react-flow__edge.sp-edge-factory-failed.sp-edge-factory-touching
+  .react-flow__edge-path {
   stroke: #f87171 !important;
 }
 
@@ -165,7 +168,7 @@
 }
 
 .sp-canvas.sp-canvas-factory .react-flow__connectionline path {
-  stroke-width: 1.5 !important;
+  stroke-width: 2 !important;
 }
 
 .sp-canvas .react-flow__handle {
@@ -215,7 +218,10 @@
 .sp-canvas .sp-append-source-handle {
   background-color: var(--sp-append-handle-bg, #ffffff);
   color: var(--sp-append-handle-icon, #94a3b8);
-  transition: border-color 0.2s ease-in-out, color 0.2s ease-in-out, background-color 0.2s ease-in-out;
+  transition:
+    border-color 0.2s ease-in-out,
+    color 0.2s ease-in-out,
+    background-color 0.2s ease-in-out;
 }
 
 .sp-canvas .sp-append-source-handle:hover {
@@ -227,7 +233,9 @@
   opacity: 0;
   pointer-events: none;
   --sp-append-preview-connector-offset-y: 1px;
-  transition: opacity 140ms ease, transform 140ms ease;
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
 }
 
 .sp-canvas .react-flow__handle.sp-append-source-hitbox.plus-hovered + .sp-append-source-preview {
@@ -240,7 +248,9 @@
   pointer-events: none;
   --edge-label-scale: 0.92;
   transform-origin: center;
-  transition: opacity 140ms ease, transform 140ms ease;
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
 }
 
 .sp-canvas .edge-label-visible {
@@ -251,7 +261,10 @@
 }
 
 .sp-canvas .edge-label .edge-label-button {
-  transition: transform 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
+  transition:
+    transform 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
 }
 
 .sp-canvas .edge-label-visible .edge-label-button:hover {

--- a/web_src/src/ui/CanvasPage/canvasFitOptions.spec.ts
+++ b/web_src/src/ui/CanvasPage/canvasFitOptions.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CANVAS_FIT_VIEW_INCLUDE_HIDDEN,
   CANVAS_NODE_FOCUS_FIT_VIEW_OPTIONS,
+  FACTORY_CONFIGURE_FIT_VIEW_OPTIONS,
   LIVE_CANVAS_FIT_VIEW_OPTIONS,
   RUN_CANVAS_FIT_VIEW_OPTIONS,
 } from "./canvasFitOptions";
@@ -16,5 +17,11 @@ describe("canvasFitOptions", () => {
 
   it("does not clamp run participant fitting to a minimum zoom", () => {
     expect(RUN_CANVAS_FIT_VIEW_OPTIONS).not.toHaveProperty("minZoom");
+  });
+
+  it("locks Factory Configure fitting to 100% zoom", () => {
+    expect(FACTORY_CONFIGURE_FIT_VIEW_OPTIONS.minZoom).toBe(1);
+    expect(FACTORY_CONFIGURE_FIT_VIEW_OPTIONS.maxZoom).toBe(1);
+    expect(FACTORY_CONFIGURE_FIT_VIEW_OPTIONS.includeHiddenNodes).toBe(true);
   });
 });

--- a/web_src/src/ui/CanvasPage/canvasFitOptions.ts
+++ b/web_src/src/ui/CanvasPage/canvasFitOptions.ts
@@ -10,6 +10,14 @@ export const LIVE_CANVAS_FIT_VIEW_OPTIONS = {
   padding: 0.08,
 } as const;
 
+/** Fit at 100% zoom when Factory Configure opens. Do not shrink the graph. */
+export const FACTORY_CONFIGURE_FIT_VIEW_OPTIONS = {
+  ...CANVAS_FIT_VIEW_INCLUDE_HIDDEN,
+  minZoom: 1.0,
+  maxZoom: 1.0,
+  padding: 0.08,
+} as const;
+
 /** Fit options when framing run participant nodes during run inspection. */
 export const RUN_CANVAS_FIT_VIEW_OPTIONS = {
   ...CANVAS_FIT_VIEW_INCLUDE_HIDDEN,

--- a/web_src/src/ui/CanvasPage/edgePathGeometry.ts
+++ b/web_src/src/ui/CanvasPage/edgePathGeometry.ts
@@ -1,3 +1,5 @@
+import { FACTORY_EDGE_STROKE } from "@/lib/factoryCanvasChrome";
+
 export type Point = { x: number; y: number };
 
 export type PathSamplePoint = Point & { angleDeg: number };
@@ -15,7 +17,7 @@ const FLOW_ARROW_MAX_COUNT = 3;
 export const TOUCHING_EDGE_STROKE = "#64748b";
 export const TOUCHING_EDGE_STROKE_DARK = "#94a3b8";
 /** Default factory edge stroke — chevrons match this when not contrast. */
-export const DEFAULT_FACTORY_EDGE_STROKE = "#cbd5e1";
+export const DEFAULT_FACTORY_EDGE_STROKE = FACTORY_EDGE_STROKE;
 /** Class stamped on contrast edges — must beat `--xy-edge-stroke !important`. */
 export const FACTORY_TOUCHING_EDGE_CLASS = "sp-edge-factory-touching";
 

--- a/web_src/src/ui/CanvasPage/factoryCanvasEdgeStyle.spec.ts
+++ b/web_src/src/ui/CanvasPage/factoryCanvasEdgeStyle.spec.ts
@@ -37,7 +37,7 @@ describe("buildStyledCanvasEdges factory run routing", () => {
       nodes,
       isVerticalFlow: true,
       resolvedThemeIsDark: false,
-      edgeDefaults: { type: "custom", style: { stroke: "#cbd5e1", strokeWidth: 1.5 } },
+      edgeDefaults: { type: "custom", style: { stroke: "#94a3b8", strokeWidth: 2 } },
       hoveredEdgeId: null,
       isEditMode: false,
       isReadOnly: false,

--- a/web_src/src/ui/CanvasPage/factoryConfigureFitView.spec.ts
+++ b/web_src/src/ui/CanvasPage/factoryConfigureFitView.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { FACTORY_LAYOUT_ANIMATION_DURATION_MS } from "./nodePositionAnimation";
-import { FACTORY_CONFIGURE_FIT_SETTLE_MS, shouldFitFactoryConfigureEnter } from "./factoryConfigureFitView";
+import {
+  FACTORY_CONFIGURE_FIT_SETTLE_MS,
+  factoryConfigureEnterFitViewOptions,
+  shouldFitFactoryConfigureEnter,
+} from "./factoryConfigureFitView";
 
 describe("shouldFitFactoryConfigureEnter", () => {
   const ready = {
@@ -39,5 +43,29 @@ describe("shouldFitFactoryConfigureEnter", () => {
 describe("FACTORY_CONFIGURE_FIT_SETTLE_MS", () => {
   it("waits for the factory layout animation plus a short measure buffer", () => {
     expect(FACTORY_CONFIGURE_FIT_SETTLE_MS).toBe(FACTORY_LAYOUT_ANIMATION_DURATION_MS + 50);
+  });
+});
+
+describe("factoryConfigureEnterFitViewOptions", () => {
+  it("frames the whole graph at 100% zoom", () => {
+    expect(factoryConfigureEnterFitViewOptions()).toEqual({
+      includeHiddenNodes: true,
+      minZoom: 1,
+      maxZoom: 1,
+      padding: 0.08,
+      duration: 500,
+    });
+  });
+
+  it("centers a deep-linked node at 100% zoom", () => {
+    const focusNode = { id: "generate-pr-text" };
+    expect(factoryConfigureEnterFitViewOptions(focusNode)).toEqual({
+      includeHiddenNodes: true,
+      minZoom: 1,
+      maxZoom: 1,
+      padding: 0.08,
+      duration: 500,
+      nodes: [focusNode],
+    });
   });
 });

--- a/web_src/src/ui/CanvasPage/factoryConfigureFitView.ts
+++ b/web_src/src/ui/CanvasPage/factoryConfigureFitView.ts
@@ -1,9 +1,26 @@
+import { FACTORY_CONFIGURE_FIT_VIEW_OPTIONS } from "./canvasFitOptions";
 import { FACTORY_LAYOUT_ANIMATION_DURATION_MS } from "./nodePositionAnimation";
 
-/** Wait for configure layout + rank expansion to finish, then fit the graph. */
+/** Wait for configure layout + rank expansion to finish, then frame at 100% zoom. */
 export const FACTORY_CONFIGURE_FIT_SETTLE_MS = FACTORY_LAYOUT_ANIMATION_DURATION_MS + 50;
 
-/** One-shot fit when Factory Configure edit becomes ready. Not for later draft edits. */
+/** Frame the Configure enter fit. Center a deep-linked node when one is present. */
+export function factoryConfigureEnterFitViewOptions(focusNode?: { id: string } | null) {
+  if (focusNode) {
+    return {
+      ...FACTORY_CONFIGURE_FIT_VIEW_OPTIONS,
+      nodes: [focusNode],
+      duration: 500,
+    };
+  }
+
+  return {
+    ...FACTORY_CONFIGURE_FIT_VIEW_OPTIONS,
+    duration: 500,
+  };
+}
+
+/** One-shot frame at 100% zoom when Factory Configure edit becomes ready. Not for later draft edits. */
 export function shouldFitFactoryConfigureEnter(input: {
   factoryConfigure: boolean;
   isEditing: boolean;

--- a/web_src/src/ui/CanvasPage/index.factoryConfigureFit.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.factoryConfigureFit.spec.tsx
@@ -4,12 +4,13 @@ import type { ReactElement, ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "@/contexts/ThemeProvider";
-import { LIVE_CANVAS_FIT_VIEW_OPTIONS } from "./canvasFitOptions";
+import { FACTORY_CONFIGURE_FIT_VIEW_OPTIONS } from "./canvasFitOptions";
 import { FACTORY_CONFIGURE_FIT_SETTLE_MS } from "./factoryConfigureFitView";
 
-const { fitViewMock, getViewportMock, reactFlowPropsRef } = vi.hoisted(() => ({
+const { fitViewMock, getViewportMock, getNodesMock, reactFlowPropsRef } = vi.hoisted(() => ({
   fitViewMock: vi.fn().mockResolvedValue(true),
   getViewportMock: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+  getNodesMock: vi.fn(() => [] as Array<{ id: string }>),
   reactFlowPropsRef: {
     current: null as null | {
       onInit?: (instance: { setViewport: (viewport: unknown) => void }) => void;
@@ -56,7 +57,7 @@ vi.mock("@xyflow/react", () => ({
     zoomTo: vi.fn(),
     zoomIn: vi.fn(),
     zoomOut: vi.fn(),
-    getNodes: vi.fn(() => []),
+    getNodes: getNodesMock,
     getZoom: vi.fn(() => 1),
   })),
   useStore: vi.fn((selector: (state: { minZoom: number; maxZoom: number }) => unknown) =>
@@ -138,6 +139,8 @@ function render(ui: ReactElement) {
 function canvasPage(overrides: {
   isEditing: boolean;
   factoryConfigure?: boolean;
+  initialSidebar?: { isOpen: boolean; nodeId: string };
+  initialFocusNodeId?: string;
   hasFitToViewRef: { current: boolean };
   viewportRef: { current: { x: number; y: number; zoom: number } };
 }) {
@@ -164,6 +167,8 @@ describe("CanvasPage factory Configure fit", () => {
     fitViewMock.mockResolvedValue(true);
     getViewportMock.mockReset();
     getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
+    getNodesMock.mockReset();
+    getNodesMock.mockReturnValue([]);
     globalThis.ResizeObserver = class {
       observe() {}
       unobserve() {}
@@ -200,7 +205,7 @@ describe("CanvasPage factory Configure fit", () => {
 
       expect(fitViewMock).toHaveBeenCalledTimes(1);
       expect(fitViewMock).toHaveBeenCalledWith({
-        ...LIVE_CANVAS_FIT_VIEW_OPTIONS,
+        ...FACTORY_CONFIGURE_FIT_VIEW_OPTIONS,
         duration: 500,
       });
       expect(viewportRef.current).toEqual(fittedViewport);
@@ -257,6 +262,40 @@ describe("CanvasPage factory Configure fit", () => {
       });
 
       expect(fitViewMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("centers the deep-linked node when Configure opens from a selected component", async () => {
+    vi.useFakeTimers();
+    try {
+      const hasFitToViewRef = { current: true };
+      const viewportRef = { current: { x: 0, y: 0, zoom: 1 } };
+      getNodesMock.mockReturnValue(singleNode);
+
+      render(
+        canvasPage({
+          isEditing: true,
+          factoryConfigure: true,
+          initialSidebar: { isOpen: true, nodeId: "node-1" },
+          hasFitToViewRef,
+          viewportRef,
+        }),
+      );
+      act(() => {
+        reactFlowPropsRef.current?.onInit?.({ setViewport: vi.fn() });
+      });
+      fitViewMock.mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(FACTORY_CONFIGURE_FIT_SETTLE_MS);
+      });
+
+      expect(fitViewMock).toHaveBeenCalledTimes(1);
+      expect(fitViewMock.mock.calls[0]?.[0]?.nodes?.[0]?.id).toBe("node-1");
+      expect(fitViewMock.mock.calls[0]?.[0]?.minZoom).toBe(1);
+      expect(fitViewMock.mock.calls[0]?.[0]?.maxZoom).toBe(1);
     } finally {
       vi.useRealTimers();
     }

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -599,6 +599,50 @@ describe("CanvasPage connection drop", () => {
     expect(screen.getByTestId("component-sidebar")).toBeInTheDocument();
   });
 
+  it("selects the deep-linked node when the edit sidebar opens from the URL", async () => {
+    const getSidebarData = vi.fn(() => ({
+      latestEvents: [],
+      nextInQueueEvents: [],
+      title: "Node",
+      totalInQueueCount: 0,
+      totalInHistoryCount: 0,
+    }));
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          canvasStateMode="editing"
+          nodes={[
+            {
+              id: "node-1",
+              position: { x: 0, y: 0 },
+              data: {
+                label: "Node",
+                state: "pending",
+                type: "component",
+              },
+            },
+          ]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={true}
+          activeCanvasVersionId="draft-version"
+          initialSidebar={{ isOpen: true, nodeId: "node-1" }}
+          getSidebarData={getSidebarData}
+          workflowNodes={[{ id: "node-1", type: "TYPE_ACTION", name: "Node" }]}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const nodes = reactFlowPropsRef.current?.nodes as Array<{ id: string; selected?: boolean }>;
+      expect(nodes.find((node) => node.id === "node-1")?.selected).toBe(true);
+    });
+    expect(screen.getByTestId("component-sidebar")).toBeInTheDocument();
+  });
+
   it("closes hidden live sidebar state from canvas pane click", async () => {
     const onSidebarChange = vi.fn();
     const getSidebarData = vi.fn(() => ({

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -112,6 +112,7 @@ import { publishBuildingBlocksSidebarChanged, useBuildingBlocksSidebarRequest } 
 import { RightSideControls } from "./RightSideControls";
 import { computeAppendFromNodePlacement } from "./appendFromNodePlacement";
 import { selectCreatedRerun } from "./runInspectionRerunSelection";
+import { nodesWithSelectedId } from "./nodesWithSelectedId";
 import { resolveRunInspectorOpen } from "./resolveRunInspectorOpen";
 import { useBuildingBlocksShortcut } from "./useBuildingBlocksShortcut";
 import type { CanvasPageState } from "./useCanvasState";
@@ -1306,6 +1307,13 @@ function CanvasPage(props: CanvasPageProps) {
     setPendingRuntimeEditNodeId(null);
   }, [pendingRuntimeEditNodeId, props.isEditing, props.isRunInspectionMode, state.componentSidebar]);
 
+  useEffect(() => {
+    if (!props.isEditing || props.isRunInspectionMode || !state.componentSidebar.isOpen) {
+      return;
+    }
+    setCurrentTab("settings");
+  }, [props.isEditing, props.isRunInspectionMode, state.componentSidebar.isOpen]);
+
   const canvasStateMode = props.canvasStateMode || "default";
   const showRunInspectionFloatingBar =
     props.isRunInspectionMode && !props.isEditSessionActive && !props.isEditing && !!props.onBackToLiveCanvas;
@@ -2357,8 +2365,8 @@ function CanvasContent({
   const isVerticalFlow = flowDirection === "vertical";
   const factoryEditGrid = Boolean(factoryEditWorkspace && (isEditing || factoryConfigure));
   const factoryBackground = isVerticalFlow ? factoryCanvasBackground(resolvedTheme === "dark", factoryEditGrid) : null;
-  const flowBgColor = factoryBackground?.bgColor ?? (resolvedTheme === "dark" ? DARK_BASE_BG_HEX : "#F1F5F9");
-  const flowDotColor = factoryBackground?.color ?? (resolvedTheme === "dark" ? "#374151" : "#cbd5e1");
+  const flowBgColor = factoryBackground?.bgColor ?? (resolvedTheme === "dark" ? DARK_BASE_BG_HEX : "#e2e8f0");
+  const flowDotColor = factoryBackground?.color ?? (resolvedTheme === "dark" ? "#374151" : "#b8c4d0");
   const flowDotGap = factoryBackground?.gap ?? 8;
   const flowDotSize = factoryBackground?.size ?? 2;
   // The content-key driven re-fit only applies when viewing the live/version
@@ -2696,29 +2704,23 @@ function CanvasContent({
       return;
     }
 
-    stateRef.current.setNodes((nodes) => {
-      if (!runSelectedNodeId) {
-        if (nodes.every((node) => !node.selected)) {
-          return nodes;
-        }
-        return nodes.map((node) => ({ ...node, selected: false }));
-      }
-
-      if (!nodes.some((node) => node.id === runSelectedNodeId)) {
-        return nodes;
-      }
-
-      const alreadyCorrect = nodes.every((node) => node.selected === (node.id === runSelectedNodeId));
-      if (alreadyCorrect) {
-        return nodes;
-      }
-
-      return nodes.map((node) => ({
-        ...node,
-        selected: node.id === runSelectedNodeId,
-      }));
-    });
+    stateRef.current.setNodes((nodes) => nodesWithSelectedId(nodes, runSelectedNodeId ?? null));
   }, [isRunInspectionMode, runSelectedNodeId, runCanvasNodeIdsKey]);
+
+  useEffect(() => {
+    if (isRunInspectionMode || !isEditing) {
+      return;
+    }
+
+    const selectedNodeId = state.componentSidebar.isOpen ? state.componentSidebar.selectedNodeId : null;
+    stateRef.current.setNodes((nodes) => nodesWithSelectedId(nodes, selectedNodeId));
+  }, [
+    isEditing,
+    isRunInspectionMode,
+    runCanvasNodeIdsKey,
+    state.componentSidebar.isOpen,
+    state.componentSidebar.selectedNodeId,
+  ]);
 
   useEffect(() => {
     return () => {
@@ -2872,12 +2874,20 @@ function CanvasContent({
   ]);
 
   const getFactoryConfigureNodeCount = useCallback(() => stateRef.current.nodes?.length ?? 0, []);
+  const getFactoryConfigureFocusNode = useCallback(() => {
+    const nodeId = stateRef.current.componentSidebar.selectedNodeId ?? initialFocusNodeId ?? null;
+    if (!nodeId) {
+      return undefined;
+    }
+    return getNodes().find((node) => node.id === nodeId) ?? stateRef.current.nodes.find((node) => node.id === nodeId);
+  }, [getNodes, initialFocusNodeId]);
   useFactoryConfigureFitView({
     factoryConfigure,
     isEditing,
     hasReactFlowInitialized,
     nodeCount: state.nodes?.length ?? 0,
     getNodeCount: getFactoryConfigureNodeCount,
+    getFocusNode: getFactoryConfigureFocusNode,
     fitView,
     getViewport,
     viewportRef,

--- a/web_src/src/ui/CanvasPage/nodesWithSelectedId.spec.ts
+++ b/web_src/src/ui/CanvasPage/nodesWithSelectedId.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { nodesWithSelectedId, selectOpenSidebarNode } from "./nodesWithSelectedId";
+
+describe("nodesWithSelectedId", () => {
+  it("selects only the requested node", () => {
+    const nodes = [
+      { id: "a", selected: false },
+      { id: "b", selected: true },
+    ];
+
+    expect(nodesWithSelectedId(nodes, "a")).toEqual([
+      { id: "a", selected: true },
+      { id: "b", selected: false },
+    ]);
+  });
+
+  it("returns the same array when selection is already correct", () => {
+    const nodes = [
+      { id: "a", selected: true },
+      { id: "b", selected: false },
+    ];
+
+    expect(nodesWithSelectedId(nodes, "a")).toBe(nodes);
+  });
+
+  it("leaves nodes unchanged when the requested id is missing", () => {
+    const nodes = [{ id: "a", selected: false }];
+
+    expect(nodesWithSelectedId(nodes, "missing")).toBe(nodes);
+  });
+
+  it("clears selection when no node id is requested", () => {
+    const nodes = [
+      { id: "a", selected: true },
+      { id: "b", selected: false },
+    ];
+
+    expect(nodesWithSelectedId(nodes, null)).toEqual([
+      { id: "a", selected: false },
+      { id: "b", selected: false },
+    ]);
+  });
+});
+
+describe("selectOpenSidebarNode", () => {
+  it("selects the open sidebar node", () => {
+    const nodes = [{ id: "a", selected: false }];
+
+    expect(selectOpenSidebarNode(nodes, "a")).toEqual([{ id: "a", selected: true }]);
+  });
+
+  it("leaves nodes unchanged when the sidebar has no node", () => {
+    const nodes = [{ id: "a", selected: true }];
+
+    expect(selectOpenSidebarNode(nodes, null)).toBe(nodes);
+  });
+});

--- a/web_src/src/ui/CanvasPage/nodesWithSelectedId.ts
+++ b/web_src/src/ui/CanvasPage/nodesWithSelectedId.ts
@@ -1,0 +1,29 @@
+export function nodesWithSelectedId<T extends { id: string; selected?: boolean }>(
+  nodes: T[],
+  selectedNodeId: string | null,
+): T[] {
+  if (selectedNodeId && !nodes.some((node) => node.id === selectedNodeId)) {
+    return nodes;
+  }
+
+  const alreadyCorrect = nodes.every((node) => Boolean(node.selected) === (node.id === selectedNodeId));
+  if (alreadyCorrect) {
+    return nodes;
+  }
+
+  return nodes.map((node) => ({
+    ...node,
+    selected: node.id === selectedNodeId,
+  }));
+}
+
+/** Keep an already-open sidebar node selected without clearing other selection. */
+export function selectOpenSidebarNode<T extends { id: string; selected?: boolean }>(
+  nodes: T[],
+  selectedNodeId: string | null,
+): T[] {
+  if (!selectedNodeId) {
+    return nodes;
+  }
+  return nodesWithSelectedId(nodes, selectedNodeId);
+}

--- a/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
@@ -153,6 +153,46 @@ describe("useCanvasState", () => {
     expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the open sidebar node selected through factory layout animation", () => {
+    const animationFrames = new Map<number, FrameRequestCallback>();
+    let nextFrameId = 1;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      const frameId = nextFrameId++;
+      animationFrames.set(frameId, callback);
+      return frameId;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frameId) => {
+      animationFrames.delete(frameId);
+    });
+
+    const { result, rerender } = renderHook(({ props }: { props: CanvasPageProps }) => useCanvasState(props), {
+      initialProps: {
+        props: {
+          ...makeProps([makeNode("a", 0, 0)]),
+          layoutMode: "factory-auto" as const,
+          initialSidebar: { isOpen: true, nodeId: "a" },
+        } as unknown as CanvasPageProps,
+      },
+    });
+
+    expect(result.current.nodes.find((node) => node.id === "a")?.selected).toBe(true);
+
+    rerender({
+      props: {
+        ...makeProps([makeNode("a", 100, 100)]),
+        layoutMode: "factory-auto" as const,
+        initialSidebar: { isOpen: true, nodeId: "a" },
+      } as unknown as CanvasPageProps,
+    });
+
+    act(() => {
+      const frame = [...animationFrames.values()].at(-1);
+      frame?.(performance.now() + 1_000);
+    });
+
+    expect(result.current.nodes.find((node) => node.id === "a")?.selected).toBe(true);
+  });
+
   it("does not re-push sidebar params when onSidebarChange identity changes", () => {
     const onSidebarChange = vi.fn();
     const props = {

--- a/web_src/src/ui/CanvasPage/useCanvasState.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { expandFactoryEditVerticalPositions } from "@/lib/factoryEditVerticalSpacing";
 import type { CanvasPageProps } from ".";
 import { isFactoryAutoLayout } from "./layoutMode";
+import { selectOpenSidebarNode } from "./nodesWithSelectedId";
 import {
   createLayoutNodeInterpolator,
   easeOutQuadratic,
@@ -137,6 +138,9 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
   const animationTargetKeyRef = useRef<string | null>(null);
   const animationTargetNodesRef = useRef<Node[]>([]);
   const animationEdgesRef = useRef<Edge[]>([]);
+  const sidebarSelectedNodeIdRef = useRef<string | null>(
+    props.initialSidebar?.isOpen ? (props.initialSidebar.nodeId ?? null) : null,
+  );
   displayedNodesRef.current = nodes;
   const localOnlyNodeIdsKey = useMemo(
     () =>
@@ -168,6 +172,11 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
       buildSyncedNodes(currentNodes, initialNodes, pendingNodePositionsRef.current),
       new Set(initialNodes.map((node) => node.id)),
     );
+    const publishLayoutNodes = (nextNodes: Node[]) => {
+      const next = selectOpenSidebarNode(nextNodes, sidebarSelectedNodeIdRef.current);
+      displayedNodesRef.current = next;
+      setNodes(next);
+    };
     const targetKey = getLayoutTargetKey(targetNodes);
     const animationEnabled = !(
       typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
@@ -193,8 +202,7 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
 
     if (!shouldAnimate) {
       animationTargetKeyRef.current = null;
-      displayedNodesRef.current = targetNodes;
-      setNodes(targetNodes);
+      publishLayoutNodes(targetNodes);
       return;
     }
 
@@ -205,16 +213,13 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
       const linearProgress = Math.min((now - startedAt) / FACTORY_LAYOUT_ANIMATION_DURATION_MS, 1);
       const latestTargetNodes = animationTargetNodesRef.current;
       if (linearProgress >= 1) {
-        displayedNodesRef.current = latestTargetNodes;
-        setNodes(latestTargetNodes);
+        publishLayoutNodes(latestTargetNodes);
         animationFrameRef.current = null;
         animationTargetKeyRef.current = null;
         return;
       }
 
-      const animatedNodes = interpolateNodes(latestTargetNodes, easeOutQuadratic(linearProgress));
-      displayedNodesRef.current = animatedNodes;
-      setNodes(animatedNodes);
+      publishLayoutNodes(interpolateNodes(latestTargetNodes, easeOutQuadratic(linearProgress)));
       animationFrameRef.current = window.requestAnimationFrame(animate);
     };
 
@@ -360,6 +365,7 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
   );
 
   const componentSidebar = useComponentSidebarState(props.initialSidebar, props.onSidebarChange);
+  sidebarSelectedNodeIdRef.current = componentSidebar.isOpen ? componentSidebar.selectedNodeId : null;
 
   return {
     nodes,

--- a/web_src/src/ui/CanvasPage/useFactoryConfigureFitView.ts
+++ b/web_src/src/ui/CanvasPage/useFactoryConfigureFitView.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, type MutableRefObject } from "react";
-import { LIVE_CANVAS_FIT_VIEW_OPTIONS } from "./canvasFitOptions";
-import { FACTORY_CONFIGURE_FIT_SETTLE_MS, shouldFitFactoryConfigureEnter } from "./factoryConfigureFitView";
+import {
+  FACTORY_CONFIGURE_FIT_SETTLE_MS,
+  factoryConfigureEnterFitViewOptions,
+  shouldFitFactoryConfigureEnter,
+} from "./factoryConfigureFitView";
 
 type Viewport = { x: number; y: number; zoom: number };
 
@@ -10,6 +13,7 @@ type UseFactoryConfigureFitViewInput = {
   hasReactFlowInitialized: boolean;
   nodeCount: number;
   getNodeCount: () => number;
+  getFocusNode: () => { id: string } | undefined;
   fitView: (options: Record<string, unknown>) => Promise<unknown>;
   getViewport: () => Viewport;
   viewportRef: MutableRefObject<Viewport | undefined>;
@@ -23,6 +27,7 @@ export function useFactoryConfigureFitView({
   hasReactFlowInitialized,
   nodeCount,
   getNodeCount,
+  getFocusNode,
   fitView,
   getViewport,
   viewportRef,
@@ -58,7 +63,7 @@ export function useFactoryConfigureFitView({
         return;
       }
       fittedThisVisitRef.current = true;
-      void fitView({ ...LIVE_CANVAS_FIT_VIEW_OPTIONS, duration: 500 }).then(
+      void fitView(factoryConfigureEnterFitViewOptions(getFocusNode())).then(
         () => {
           const nextViewport = getViewport();
           viewportRef.current = nextViewport;
@@ -72,6 +77,7 @@ export function useFactoryConfigureFitView({
   }, [
     factoryConfigure,
     fitView,
+    getFocusNode,
     getNodeCount,
     getViewport,
     hasReactFlowInitialized,

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.render.spec.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.render.spec.tsx
@@ -29,4 +29,15 @@ describe("FactoryNodeCard", () => {
 
     expect(screen.getByTestId("factory-node-run-bash")).toHaveStyle({ width: "280px" });
   });
+
+  it("uses the same blue selection ring as the run canvas", () => {
+    const { container } = render(
+      <FactoryNodeCard title="Create Pull Request" componentLabel="Create Pull Request" selected canvasMode="edit" />,
+    );
+
+    const frame = container.querySelector("[data-selected='true']");
+    expect(frame).not.toBeNull();
+    expect(frame?.className).toContain("ring-4");
+    expect(frame?.className).toContain("--status-running-dot");
+  });
 });

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import type { DraftDiffStatus } from "@/lib/draftDiff";
 import type { EventStateMap } from "../componentBase/eventState";
 import type { MetadataItem } from "../metadataList";
+import { cn } from "@/lib/utils";
 import { FactoryNodeCardShell } from "./FactoryNodeCardShell";
+import { FACTORY_NODE_SELECTED_RING_CLASSNAME } from "./factoryNodeSelectedRing";
 import { NodeHoverActions } from "./NodeHoverActions";
 import { WarningBadge } from "./WarningBadge";
 import { resolveFactoryNodeCardTitles } from "./resolveFactoryNodeCardTitles";
@@ -166,7 +168,15 @@ export function FactoryNodeCard({
   });
 
   return (
-    <div className="group relative" data-view-mode={isCompactView ? "compact" : "expanded"}>
+    <div
+      className={cn(
+        "group relative overflow-visible rounded-2xl",
+        selected && "z-10",
+        selected && FACTORY_NODE_SELECTED_RING_CLASSNAME,
+      )}
+      data-view-mode={isCompactView ? "compact" : "expanded"}
+      data-selected={selected ? "true" : undefined}
+    >
       <NodeHoverActions
         showHeader={showHeader}
         onDuplicate={onDuplicate}

--- a/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
+++ b/web_src/src/ui/factoryNodeChrome/FactoryNodeCard.tsx
@@ -2,9 +2,8 @@ import React from "react";
 import type { DraftDiffStatus } from "@/lib/draftDiff";
 import type { EventStateMap } from "../componentBase/eventState";
 import type { MetadataItem } from "../metadataList";
-import { cn } from "@/lib/utils";
 import { FactoryNodeCardShell } from "./FactoryNodeCardShell";
-import { FACTORY_NODE_SELECTED_RING_CLASSNAME } from "./factoryNodeSelectedRing";
+import { factoryNodeCardFrameClassName, factoryNodeCardSelectedAttr } from "./factoryNodeSelectedRing";
 import { NodeHoverActions } from "./NodeHoverActions";
 import { WarningBadge } from "./WarningBadge";
 import { resolveFactoryNodeCardTitles } from "./resolveFactoryNodeCardTitles";
@@ -169,13 +168,9 @@ export function FactoryNodeCard({
 
   return (
     <div
-      className={cn(
-        "group relative overflow-visible rounded-2xl",
-        selected && "z-10",
-        selected && FACTORY_NODE_SELECTED_RING_CLASSNAME,
-      )}
+      className={factoryNodeCardFrameClassName(selected)}
       data-view-mode={isCompactView ? "compact" : "expanded"}
-      data-selected={selected ? "true" : undefined}
+      data-selected={factoryNodeCardSelectedAttr(selected)}
     >
       <NodeHoverActions
         showHeader={showHeader}

--- a/web_src/src/ui/factoryNodeChrome/factoryNodeSelectedRing.spec.ts
+++ b/web_src/src/ui/factoryNodeChrome/factoryNodeSelectedRing.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FACTORY_NODE_SELECTED_RING_CLASSNAME,
+  factoryNodeCardFrameClassName,
+  factoryNodeCardSelectedAttr,
+} from "./factoryNodeSelectedRing";
+
+describe("factoryNodeCardFrameClassName", () => {
+  it("adds the shared selection ring when the node is selected", () => {
+    const className = factoryNodeCardFrameClassName(true);
+
+    expect(className).toContain("z-10");
+    expect(className).toContain(FACTORY_NODE_SELECTED_RING_CLASSNAME);
+  });
+
+  it("keeps the card frame without a selection ring when the node is not selected", () => {
+    const className = factoryNodeCardFrameClassName(false);
+
+    expect(className).toContain("rounded-2xl");
+    expect(className).not.toContain("z-10");
+    expect(className).not.toContain("ring-4");
+  });
+});
+
+describe("factoryNodeCardSelectedAttr", () => {
+  it("returns true when the node is selected", () => {
+    expect(factoryNodeCardSelectedAttr(true)).toBe("true");
+  });
+
+  it("returns undefined when the node is not selected", () => {
+    expect(factoryNodeCardSelectedAttr(false)).toBeUndefined();
+  });
+});

--- a/web_src/src/ui/factoryNodeChrome/factoryNodeSelectedRing.ts
+++ b/web_src/src/ui/factoryNodeChrome/factoryNodeSelectedRing.ts
@@ -1,0 +1,3 @@
+/** Blue selection ring shared by factory run view and Configure edit. */
+export const FACTORY_NODE_SELECTED_RING_CLASSNAME =
+  "ring-4 ring-[color:var(--status-running-dot)] ring-offset-2 ring-offset-[color:var(--status-running-bg)]";

--- a/web_src/src/ui/factoryNodeChrome/factoryNodeSelectedRing.ts
+++ b/web_src/src/ui/factoryNodeChrome/factoryNodeSelectedRing.ts
@@ -1,3 +1,20 @@
+import { cn } from "@/lib/utils";
+
 /** Blue selection ring shared by factory run view and Configure edit. */
 export const FACTORY_NODE_SELECTED_RING_CLASSNAME =
   "ring-4 ring-[color:var(--status-running-dot)] ring-offset-2 ring-offset-[color:var(--status-running-bg)]";
+
+const FACTORY_NODE_CARD_FRAME_CLASSNAME = "group relative overflow-visible rounded-2xl";
+
+/** Root frame classes for a factory node card, including the selection ring. */
+export function factoryNodeCardFrameClassName(selected: boolean): string {
+  return cn(FACTORY_NODE_CARD_FRAME_CLASSNAME, selected && "z-10", selected && FACTORY_NODE_SELECTED_RING_CLASSNAME);
+}
+
+/** `data-selected` value when the factory node card is selected. */
+export function factoryNodeCardSelectedAttr(selected: boolean): "true" | undefined {
+  if (!selected) {
+    return undefined;
+  }
+  return "true";
+}

--- a/web_src/src/ui/factoryNodeChrome/index.ts
+++ b/web_src/src/ui/factoryNodeChrome/index.ts
@@ -1,4 +1,5 @@
 export { FactoryNodeCard, type FactoryNodeCardProps } from "./FactoryNodeCard";
+export { FACTORY_NODE_SELECTED_RING_CLASSNAME } from "./factoryNodeSelectedRing";
 export { FactoryNodeStepList } from "./FactoryNodeStepList";
 export {
   factorySidebarCloseButtonClassName,


### PR DESCRIPTION
## Summary

Edit from a selected run node opened Configure without that node. A leftover run param treated the page as run inspection and cleared the selection.

This change keeps `sidebar` and `node` on the Configure URL. Configure highlights that component and centers it on the canvas.

The work-order popup no longer shows elapsed time. Factory canvas chrome is easier to read.

## Test plan

- [ ] Open a work-order run and select a node.
- [ ] Confirm the pencil sits inside the card and is easy to see.
- [ ] Click the pencil.
- [ ] Confirm Configure opens that component in the right sidebar.
- [ ] Confirm the same node is highlighted and centered on the canvas.
- [ ] Confirm the URL has `configure=1`, `sidebar=1`, and `node=` without `run=`.
- [ ] Confirm the work-order popup no longer shows elapsed time.


Made with [Cursor](https://cursor.com)