### PR TITLE
fix: Name a model on every generated agent node

### DIFF
--- a/docs/prd/token-usage-and-billing.md
+++ b/docs/prd/token-usage-and-billing.md
@@ -52,7 +52,7 @@ Do not reinvent these pieces:
 | Billing unit | Ledger stores tokens by type and USD cents. Money is the source of truth. |
 | Welcome grant | Once per organization, not per user. |
 | Hosted catalog | Admin picks one hosted provider and an allowlist of models. |
-| BYOK catalog | User connects keys. SuperPlane lists models. User picks the allowlist. |
+| BYOK catalog | User connects keys. SuperPlane lists models. The list guides the picker. It does not gate a run. |
 | BYOK cost | Store estimated or provider-reported dollars. Mark `funding_source=byok`. |
 | Compute | Same ledger, `usage_kind=compute`, later. Phase 1 is model usage only. |
 | Self-hosted | Tracking ships. Welcome credit and Polar checkout are cloud-only. |
@@ -109,11 +109,17 @@ hosted remaining credit is empty.
 ### Phase 4 — BYOK model pools
 
 Reuse org integrations. The organization selects the BYOK model list per
-provider. Empty list means no BYOK models for that provider. Factory Settings
-→ Models may subset the org BYOK list and the installation hosted allowlist.
-An empty factory list inherits the parent list. The agent picker uses the
-resolved list for hosted and BYOK credentials. `funding_source=byok` is
-tracked and does not debit the wallet.
+provider. Factory Settings → Models may subset the org BYOK list and the
+installation hosted allowlist. An empty factory list inherits the parent list.
+The agent picker uses the resolved list for hosted and BYOK credentials.
+`funding_source=byok` is tracked and does not debit the wallet.
+
+The BYOK list guides the picker only. It does not stop a run. A BYOK run
+spends the key of the organization, not SuperPlane credit, so the list gives
+SuperPlane no cost to protect. A gate there only stops the organization from
+using the key it connected. It also rejects an agent CLI alias such as `opus`,
+because the list holds full model ids. Only `PrepareHostedRun` keeps a
+selected-model gate, because hosted spend debits the wallet.
 
 ### Phase 5 — Polar prepaid checkout
 

--- a/pkg/components/runner/claude/component.go
+++ b/pkg/components/runner/claude/component.go
@@ -185,14 +185,8 @@ func (c *RunClaudeCode) Execute(ctx core.ExecutionContext) error {
 func (c *RunClaudeCode) injectCredentials(ctx core.ExecutionContext, environment []runner.BrokerEnvironmentVariable, credentials runner.AgentCredentials, model string) ([]runner.BrokerEnvironmentVariable, error) {
 	switch credentials.Source {
 	case runner.CredentialsSourceSecret:
-		if err := runner.PrepareBYOKRun(ctx, "anthropic", model); err != nil {
-			return nil, err
-		}
 		return runner.InjectSecretAPIKey(ctx, environment, envAnthropicAPIKey, credentials.Secret)
 	case runner.CredentialsSourceIntegration:
-		if err := runner.PrepareBYOKRun(ctx, "anthropic", model); err != nil {
-			return nil, err
-		}
 		return runner.InjectIntegrationKeys(ctx, environment, credentials.Integration)
 	case runner.CredentialsSourceHosted:
 		access, err := runner.PrepareHostedRun(ctx, "anthropic", model)

--- a/pkg/components/runner/claude/component_test.go
+++ b/pkg/components/runner/claude/component_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -197,6 +198,50 @@ func TestRunClaudeCodeExecuteRequiresAPIKeySecret(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "secret not found")
+}
+
+// A BYOK run spends the key of the organization, not SuperPlane credit, so no
+// selected-model list stands between it and the provider. An organization that
+// connects a key must be able to run without an administrator selecting models
+// first, and an agent CLI alias such as "opus" must reach the provider as it is.
+func TestRunClaudeCodeExecuteDoesNotGateBYOKModels(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+	t.Setenv("TASK_BROKER_FLEET_ID", "")
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(`{"id":"task-claude-byok-1"}`))},
+		},
+	}
+
+	component := &RunClaudeCode{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"machineType": testRunnerMachineType,
+			"model":       "opus",
+			"steps": []map[string]any{
+				{"name": "Hello", "type": "prompt", "prompt": "hello"},
+			},
+			"credentials": credentialsSecret("anthropic", "api_key"),
+		},
+		HTTP:    httpContext,
+		Secrets: &contexts.SecretsContext{Values: map[string][]byte{"anthropic/api_key": []byte("sk-byok")}},
+		Webhook: &contexts.NodeWebhookContext{},
+		HostedLLM: &contexts.HostedLLMContext{
+			SelectableErr: fmt.Errorf("model opus is not on the selected-model list"),
+		},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		Requests:       &contexts.RequestContext{},
+	})
+	require.NoError(t, err)
+	require.Len(t, httpContext.Requests, 1)
+
+	body, err := io.ReadAll(httpContext.Requests[0].Body)
+	require.NoError(t, err)
+	var req createTaskRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	assert.Equal(t, "sk-byok", requireEnvironmentValue(t, req.Environment, envAnthropicAPIKey))
 }
 
 func TestRunClaudeCodeExecuteInjectsHostedAPIKey(t *testing.T) {

--- a/pkg/components/runner/codex/component.go
+++ b/pkg/components/runner/codex/component.go
@@ -164,14 +164,8 @@ func (c *RunCodex) Execute(ctx core.ExecutionContext) error {
 func injectCodexCredentials(ctx core.ExecutionContext, environment []runner.BrokerEnvironmentVariable, credentials runner.AgentCredentials, model string) ([]runner.BrokerEnvironmentVariable, error) {
 	switch credentials.Source {
 	case runner.CredentialsSourceSecret:
-		if err := runner.PrepareBYOKRun(ctx, "openai", model); err != nil {
-			return nil, err
-		}
 		return runner.InjectSecretAPIKey(ctx, environment, envOpenAIAPIKey, credentials.Secret)
 	case runner.CredentialsSourceIntegration:
-		if err := runner.PrepareBYOKRun(ctx, "openai", model); err != nil {
-			return nil, err
-		}
 		return runner.InjectIntegrationKeys(ctx, environment, credentials.Integration)
 	case runner.CredentialsSourceHosted:
 		access, err := runner.PrepareHostedRun(ctx, "openai", model)

--- a/pkg/components/runner/hosted.go
+++ b/pkg/components/runner/hosted.go
@@ -82,13 +82,6 @@ func PrepareHostedRun(ctx core.ExecutionContext, provider, model string) (core.H
 	return access, nil
 }
 
-func PrepareBYOKRun(ctx core.ExecutionContext, provider, model string) error {
-	if ctx.HostedLLM == nil {
-		return nil
-	}
-	return ctx.HostedLLM.AssertModelSelectable(provider, "byok", model)
-}
-
 func InjectHostedAPIKey(environment []BrokerEnvironmentVariable, envName, apiKey string, extra ...BrokerEnvironmentVariable) []BrokerEnvironmentVariable {
 	environment = append(environment, BrokerEnvironmentVariable{Name: envName, Value: apiKey})
 	return append(environment, extra...)

--- a/pkg/components/runner/hosted_test.go
+++ b/pkg/components/runner/hosted_test.go
@@ -94,20 +94,6 @@ func TestPrepareHostedRunChecksFactoryAllowlist(t *testing.T) {
 	assert.Equal(t, "sk-hosted", access.APIKey)
 }
 
-func TestPrepareBYOKRunChecksAllowlistWhenModelIsEmpty(t *testing.T) {
-	t.Parallel()
-
-	require.NoError(t, PrepareBYOKRun(core.ExecutionContext{}, "anthropic", ""))
-
-	stub := &byokHostedLLM{}
-	err := PrepareBYOKRun(core.ExecutionContext{HostedLLM: stub}, "anthropic", "")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "model is required")
-	assert.True(t, stub.called)
-
-	require.NoError(t, PrepareBYOKRun(core.ExecutionContext{HostedLLM: stub}, "anthropic", "claude-sonnet-4-6"))
-}
-
 type hostedAllowlistLLM struct {
 	access     core.HostedLLMAccess
 	selectable map[string]bool
@@ -128,24 +114,4 @@ func (c *hostedAllowlistLLM) AssertModelSelectable(_, _, model string) error {
 		return nil
 	}
 	return fmt.Errorf("model %s is not on the selected-model list", model)
-}
-
-type byokHostedLLM struct {
-	called bool
-}
-
-func (c *byokHostedLLM) Resolve(string) (core.HostedLLMAccess, error) {
-	return core.HostedLLMAccess{}, nil
-}
-
-func (c *byokHostedLLM) AssertCreditAvailable() error {
-	return nil
-}
-
-func (c *byokHostedLLM) AssertModelSelectable(_, _, model string) error {
-	c.called = true
-	if strings.TrimSpace(model) == "" {
-		return fmt.Errorf("model is required")
-	}
-	return nil
 }

--- a/pkg/components/runner/openrouter/component.go
+++ b/pkg/components/runner/openrouter/component.go
@@ -185,14 +185,8 @@ func (c *RunOpenRouter) Execute(ctx core.ExecutionContext) error {
 func injectOpenRouterCredentials(ctx core.ExecutionContext, environment []runner.BrokerEnvironmentVariable, credentials runner.AgentCredentials, model string) ([]runner.BrokerEnvironmentVariable, error) {
 	switch credentials.Source {
 	case runner.CredentialsSourceSecret:
-		if err := runner.PrepareBYOKRun(ctx, "openrouter", model); err != nil {
-			return nil, err
-		}
 		return runner.InjectSecretAPIKey(ctx, environment, envOpenRouterAPIKey, credentials.Secret)
 	case runner.CredentialsSourceIntegration:
-		if err := runner.PrepareBYOKRun(ctx, "openrouter", model); err != nil {
-			return nil, err
-		}
 		return runner.InjectIntegrationKeys(ctx, environment, credentials.Integration)
 	case runner.CredentialsSourceHosted:
 		access, err := runner.PrepareHostedRun(ctx, "openrouter", model)

--- a/pkg/grpc/actions/factories/intake_agent.go
+++ b/pkg/grpc/actions/factories/intake_agent.go
@@ -22,9 +22,15 @@ type intakeAgentSpec struct {
 	// hostedModelHint is the part of a model id an intake looks for first on a
 	// hosted allowlist. An allowlist without it falls back to its first model.
 	hostedModelHint string
-	// model is the model the runner asks for when it authenticates with an
-	// installation. Only OpenRouter needs one; the other runners have a
-	// default of their own.
+	// model is the model the generated nodes name. A runner has a default of
+	// its own, but a node that leaves the field empty shows the user no model
+	// and runs on whatever the agent CLI picks, so each spec names one.
+	//
+	// Both nodes an intake generates weigh evidence rather than write code:
+	// the analysis scores an item, and the PR feedback runner judges which
+	// review requests are safe to apply. Anthropic therefore reaches for
+	// Opus, the way the planning agent of the factory line does, while the
+	// implementation agent stays on Sonnet.
 	model string
 }
 
@@ -33,13 +39,15 @@ var intakeAgentSpecs = []intakeAgentSpec{
 		component:       "runnerClaudeCode",
 		integrationApp:  "claude",
 		hostedProvider:  models.UsageProviderAnthropic,
-		hostedModelHint: "sonnet",
+		hostedModelHint: "opus",
+		model:           "opus",
 	},
 	{
 		component:       "runnerCodex",
 		integrationApp:  "openai",
 		hostedProvider:  models.UsageProviderOpenAI,
 		hostedModelHint: "gpt-5",
+		model:           "gpt-5",
 	},
 	{
 		component:       "runnerOpenRouter",
@@ -73,11 +81,24 @@ func (a *intakeAgent) credentials() map[string]any {
 	return a.Credentials
 }
 
+// model is the model the generated node names. An agent that carries no model
+// of its own takes the default of its runner, so the node always shows the
+// model the analysis runs on.
 func (a *intakeAgent) model() string {
-	if a == nil {
+	if a != nil && a.Model != "" {
+		return a.Model
+	}
+	return defaultIntakeAgentModel(a.component())
+}
+
+func defaultIntakeAgentModel(component string) string {
+	index := slices.IndexFunc(intakeAgentSpecs, func(spec intakeAgentSpec) bool {
+		return spec.component == component
+	})
+	if index < 0 {
 		return ""
 	}
-	return a.Model
+	return intakeAgentSpecs[index].model
 }
 
 // resolveIntakeAgent picks the runner and the credentials of the analysis node.

--- a/pkg/grpc/actions/factories/intake_agent_test.go
+++ b/pkg/grpc/actions/factories/intake_agent_test.go
@@ -39,6 +39,22 @@ func Test__ResolveIntakeAgent(t *testing.T) {
 		assert.Equal(t, integrationName(t, organization.ID, agentID), integrationRefName(t, agent))
 	})
 
+	t.Run("an agent on an installation still names the model it runs", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+
+		for app, model := range map[string]string{"claude": "opus", "openai": "gpt-5"} {
+			factory := newFactoryIn(t, organization.ID)
+			agentID := createReadyOnboardingIntegration(t, organization.ID, app)
+			require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
+				AgentIntegrationID: &agentID,
+			}))
+
+			agent := resolveIntakeAgent(db, factory)
+			require.NotNil(t, agent)
+			assert.Equal(t, model, agent.Model, "installation %s", app)
+		}
+	})
+
 	t.Run("OpenRouter needs the model the runner asks for", func(t *testing.T) {
 		organization := support.CreateOrganization(t, r, r.User)
 		factory := newFactoryIn(t, organization.ID)
@@ -87,7 +103,7 @@ func Test__ResolveIntakeAgent(t *testing.T) {
 			Provider:      models.UsageProviderAnthropic,
 			Enabled:       true,
 			APIKey:        []byte("test-hosted-key"),
-			AllowedModels: datatypes.JSONSlice[string]{"claude-haiku-4-6", "claude-sonnet-4-6"},
+			AllowedModels: datatypes.JSONSlice[string]{"claude-haiku-4-6", "claude-opus-4-6", "claude-sonnet-4-6"},
 		})
 		require.NoError(t, err)
 
@@ -95,6 +111,25 @@ func Test__ResolveIntakeAgent(t *testing.T) {
 		require.NotNil(t, agent)
 		assert.Equal(t, "runnerClaudeCode", agent.Component)
 		assert.Equal(t, map[string]any{"source": runner.CredentialsSourceHosted}, agent.Credentials)
+		assert.Equal(t, "claude-opus-4-6", agent.Model)
+	})
+
+	t.Run("a hosted allowlist without Opus still serves the intake", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		clearHostedLLMProviders(t, db)
+		_, err := models.UpsertHostedLLMProvider(db, models.HostedLLMProvider{
+			Provider:      models.UsageProviderAnthropic,
+			Enabled:       true,
+			APIKey:        []byte("test-hosted-key"),
+			AllowedModels: datatypes.JSONSlice[string]{"claude-sonnet-4-6"},
+		})
+		require.NoError(t, err)
+
+		// The allowlist belongs to the installation admin, so a preference
+		// for Opus cannot become a requirement for it.
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
 		assert.Equal(t, "claude-sonnet-4-6", agent.Model)
 	})
 
@@ -124,6 +159,28 @@ func Test__ResolveIntakeAgent(t *testing.T) {
 		}))
 
 		assert.Nil(t, resolveIntakeAgent(db, factory))
+	})
+}
+
+func Test__IntakeAgentModel(t *testing.T) {
+	t.Run("keeps the model the agent carries", func(t *testing.T) {
+		agent := &intakeAgent{Component: "runnerCodex", Model: "gpt-5-mini"}
+		assert.Equal(t, "gpt-5-mini", agent.model())
+	})
+
+	t.Run("takes the default of the runner when the agent names none", func(t *testing.T) {
+		agent := &intakeAgent{Component: "runnerCodex"}
+		assert.Equal(t, "gpt-5", agent.model())
+	})
+
+	t.Run("an intake without an agent takes the default of the default runner", func(t *testing.T) {
+		var agent *intakeAgent
+		assert.Equal(t, intakeAgentSpecs[0].model, agent.model())
+	})
+
+	t.Run("a runner an intake cannot score with has no model to name", func(t *testing.T) {
+		agent := &intakeAgent{Component: "runnerBash"}
+		assert.Empty(t, agent.model())
 	})
 }
 

--- a/pkg/grpc/actions/factories/intake_template_test.go
+++ b/pkg/grpc/actions/factories/intake_template_test.go
@@ -160,8 +160,7 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 			"source":      runner.CredentialsSourceIntegration,
 			"integration": map[string]any{"name": "acme-openai"},
 		}, analysis.Configuration["credentials"])
-		// Codex reads its own default model, so the node leaves the model out.
-		assert.NotContains(t, analysis.Configuration, "model")
+		assert.Equal(t, "gpt-5", analysis.Configuration["model"])
 	})
 
 	t.Run("a hosted agent names the model it runs", func(t *testing.T) {
@@ -187,6 +186,9 @@ func Test__BuildIntakeCanvas(t *testing.T) {
 		analysis := findSpecNode(t, canvas, intakeAnalysisNodeID)
 		assert.Equal(t, intakeAgentSpecs[0].component, analysis.Component)
 		assert.NotContains(t, analysis.Configuration, "credentials")
+		// Only the credentials are missing. The user completes them on a node
+		// that already names the runner and the model.
+		assert.Equal(t, intakeAgentSpecs[0].model, analysis.Configuration["model"])
 	})
 
 	t.Run("the threshold gates on the analysis score", func(t *testing.T) {

--- a/pkg/grpc/actions/factories/pr_feedback_graph_test.go
+++ b/pkg/grpc/actions/factories/pr_feedback_graph_test.go
@@ -107,6 +107,19 @@ func Test__BuildPRFeedbackCanvas(t *testing.T) {
 		assert.Contains(t, checkout, `git checkout "${PR_HEAD}"`)
 		assert.NotContains(t, checkout, "pr-feedback")
 	})
+
+	t.Run("the runner names the model it runs", func(t *testing.T) {
+		canvas := buildPRFeedbackCanvas(prFeedbackBuildRequest{
+			Repository: "acme/app",
+			Agent: &intakeAgent{
+				Component:   "runnerClaudeCode",
+				Credentials: map[string]any{"source": "integration"},
+			},
+		})
+
+		runner := findSpecNode(t, canvas, prFeedbackRunnerNodeID)
+		assert.Equal(t, "opus", runner.Configuration["model"])
+	})
 }
 
 func yamlEdgeChannels(canvas *yaml.Canvas) []string {

--- a/web_src/src/lib/hostedLLMModels.ts
+++ b/web_src/src/lib/hostedLLMModels.ts
@@ -34,6 +34,17 @@ export function pickHostedModel(provider: string, modelIds: string[]): string | 
   return ids[0];
 }
 
+/**
+ * Find the first allowlisted id that contains the hint. Returns undefined when
+ * none does, so a caller can keep the model it already resolved rather than
+ * fall back to an unrelated one.
+ */
+export function pickModelMatching(modelIds: string[], hint: string): string | undefined {
+  const needle = hint.trim().toLowerCase();
+  if (needle === "") return undefined;
+  return uniqueSortedModelIds(modelIds).find((id) => id.toLowerCase().includes(needle));
+}
+
 /** Prefer a Sonnet id from the Anthropic hosted allowlist; otherwise use the first id. */
 export function pickHostedAnthropicModel(modelIds: string[]): string | undefined {
   return pickHostedModel("anthropic", modelIds);

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
@@ -52,6 +52,38 @@ describe("resolveOnboardingAgent", () => {
       integrationName: "openrouter",
       harness: "AGENT_HARNESS_CLAUDE_CODE",
       model: "anthropic/claude-sonnet-4-6",
+      planningModel: "anthropic/claude-sonnet-4-6",
+    });
+  });
+
+  it("gives planning an Opus id when the allowlist has one", () => {
+    expect(
+      resolveOnboardingAgent({
+        connected: connected("openrouter"),
+        remainingCreditCents: 5000,
+        hostedModels: {
+          ...noHostedModels,
+          openrouter: ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6"],
+        },
+      }),
+    ).toMatchObject({
+      model: "anthropic/claude-sonnet-4-6",
+      planningModel: "anthropic/claude-opus-4-6",
+    });
+  });
+
+  // With no allowlist to read, the agent CLI resolves the alias itself.
+  it("gives planning the Opus alias when no allowlist applies", () => {
+    expect(
+      resolveOnboardingAgent({
+        connected: connected("claude"),
+        remainingCreditCents: 0,
+        hostedModels: noHostedModels,
+      }),
+    ).toMatchObject({
+      credentialsSource: "integration",
+      model: "sonnet",
+      planningModel: "opus",
     });
   });
 
@@ -69,6 +101,7 @@ describe("resolveOnboardingAgent", () => {
       integrationName: "openrouter",
       harness: "AGENT_HARNESS_CLAUDE_CODE",
       model: "openai/gpt-4.1",
+      planningModel: "openai/gpt-4.1",
     });
   });
 
@@ -86,6 +119,7 @@ describe("resolveOnboardingAgent", () => {
       integrationName: "openai",
       harness: "AGENT_HARNESS_CODEX",
       model: "gpt-5",
+      planningModel: "gpt-5",
     });
   });
 
@@ -164,6 +198,7 @@ describe("firstWorkOrderAgentError", () => {
           integrationName: "openrouter",
           harness: "AGENT_HARNESS_CLAUDE_CODE",
           model: "openai/gpt-4.1",
+          planningModel: "openai/gpt-4.1",
         },
       }),
     ).toBeNull();

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
@@ -1,4 +1,4 @@
-import { pickHostedModel } from "@/lib/hostedLLMModels";
+import { pickHostedModel, pickModelMatching } from "@/lib/hostedLLMModels";
 import { formatUsdCents } from "@/pages/factories/lib/workOrderUsage";
 
 import type { IntegrationId } from "./onboardingFixtures";
@@ -18,6 +18,8 @@ export type OnboardingAgentPlan = {
   integrationName: AgentProviderId;
   harness: OnboardingAgentHarness;
   model: string;
+  /** Model for agents that weigh evidence rather than write code, such as planning. */
+  planningModel: string;
 };
 
 export type HostedModelsByProvider = Record<HostedLLMProviderId, string[]>;
@@ -27,6 +29,10 @@ type AgentProviderSpec = {
   hostedProvider: HostedLLMProviderId;
   harness: OnboardingAgentHarness;
   defaultModel: string;
+  /** Default for planning-style agents when no allowlist is available. */
+  defaultPlanningModel: string;
+  /** Substring that finds the planning model on an allowlist. */
+  planningModelHint: string;
 };
 
 const AGENT_PROVIDER_SPECS: Record<AgentProviderId, AgentProviderSpec> = {
@@ -35,20 +41,34 @@ const AGENT_PROVIDER_SPECS: Record<AgentProviderId, AgentProviderSpec> = {
     hostedProvider: "anthropic",
     harness: "AGENT_HARNESS_CLAUDE_CODE",
     defaultModel: "sonnet",
+    defaultPlanningModel: "opus",
+    planningModelHint: "opus",
   },
   openai: {
     component: "runnerCodex",
     hostedProvider: "openai",
     harness: "AGENT_HARNESS_CODEX",
     defaultModel: "gpt-5",
+    defaultPlanningModel: "gpt-5",
+    planningModelHint: "gpt-5",
   },
   openrouter: {
     component: "runnerOpenRouter",
     hostedProvider: "openrouter",
     harness: "AGENT_HARNESS_CLAUDE_CODE",
     defaultModel: "anthropic/claude-sonnet-4-6",
+    defaultPlanningModel: "anthropic/claude-opus-4-6",
+    planningModelHint: "opus",
   },
 };
+
+// A hosted run only accepts a model id from the allowlist, so the planning
+// model has to come from the same list as the standard model. An empty list
+// means no allowlist applies, and the agent CLI resolves the alias itself.
+function planningModelFor(spec: AgentProviderSpec, modelIds: string[], model: string): string {
+  if (modelIds.length === 0) return spec.defaultPlanningModel;
+  return pickModelMatching(modelIds, spec.planningModelHint) ?? model;
+}
 
 export function isAgentProviderConnected(connected: Set<IntegrationId>): boolean {
   return AGENT_PROVIDER_IDS.some((id) => connected.has(id));
@@ -72,7 +92,8 @@ export function resolveOnboardingAgent(args: {
 
   for (const providerId of AGENT_PROVIDER_IDS) {
     const spec = AGENT_PROVIDER_SPECS[providerId];
-    const model = pickHostedModel(spec.hostedProvider, args.hostedModels[spec.hostedProvider]);
+    const modelIds = args.hostedModels[spec.hostedProvider];
+    const model = pickHostedModel(spec.hostedProvider, modelIds);
     if (!model) continue;
     return {
       providerId,
@@ -81,6 +102,7 @@ export function resolveOnboardingAgent(args: {
       integrationName: providerId,
       harness: spec.harness,
       model,
+      planningModel: planningModelFor(spec, modelIds, model),
     };
   }
 
@@ -122,12 +144,15 @@ function planForConnectedProvider(
   hostedModels: HostedModelsByProvider,
 ): OnboardingAgentPlan {
   const spec = AGENT_PROVIDER_SPECS[providerId];
+  const modelIds = hostedModels[spec.hostedProvider];
+  const model = pickHostedModel(spec.hostedProvider, modelIds) ?? spec.defaultModel;
   return {
     providerId,
     component: spec.component,
     credentialsSource: "integration",
     integrationName: providerId,
     harness: spec.harness,
-    model: pickHostedModel(spec.hostedProvider, hostedModels[spec.hostedProvider]) ?? spec.defaultModel,
+    model,
+    planningModel: planningModelFor(spec, modelIds, model),
   };
 }

--- a/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.spec.ts
@@ -9,6 +9,7 @@ const readyPlan = {
   integrationName: "openrouter",
   harness: "AGENT_HARNESS_CLAUDE_CODE",
   model: "openai/gpt-4.1",
+  planningModel: "openai/gpt-4.1",
 } as const;
 
 describe("finishOnboardingError", () => {

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.ts
@@ -39,11 +39,17 @@ export function agentRewriteFromPlan(
   selections: IntegrationSelections,
 ): FactoryAgentRewrite {
   if (plan.credentialsSource === "hosted") {
-    return { component: plan.component, model: plan.model, credentials: { source: "hosted" } };
+    return {
+      component: plan.component,
+      model: plan.model,
+      planningModel: plan.planningModel,
+      credentials: { source: "hosted" },
+    };
   }
   return {
     component: plan.component,
     model: plan.model,
+    planningModel: plan.planningModel,
     credentials: {
       source: "integration",
       name: selections[plan.integrationName]?.name ?? plan.integrationName,

--- a/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
@@ -259,6 +259,7 @@ spec:
             valueSource: literal
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
+        model: sonnet
         steps:
           - name: Inject Plan
             type: bash

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -4,6 +4,8 @@ import yaml from "js-yaml";
 import { getFactoryDefinition, ONBOARDING_EVENT_APPS, ONBOARDING_LINE_APPS } from "./index";
 import { FACTORY_CANVAS_ID_PLACEHOLDER, materializeFactoryCanvas } from "./materializeFactoryTemplate";
 
+const AGENT_COMPONENTS = ["runnerClaudeCode", "runnerCodex", "runnerOpenRouter"];
+
 type AgentStep = { name?: string; command?: string; workingDirectory?: string };
 
 type CanvasNode = {
@@ -63,7 +65,7 @@ describe("setup factory line apps", () => {
     }
   });
 
-  it("keeps the planning agent on Opus when the coding agent stays Claude Code", () => {
+  it("gives the planning agent the deeper model the rewrite resolved", () => {
     const planning = materializeOnboardingApp("line-planning");
     const implementation = materializeOnboardingApp("line-implementation");
     const planningAgent = canvasNodes(planning).find((node) => node.id === "planner-agent-no-issue");
@@ -72,6 +74,8 @@ describe("setup factory line apps", () => {
     expect(planningAgent?.configuration?.model).toBe("opus");
     expect(implementationAgent?.configuration?.model).toBe("sonnet");
 
+    // A hosted run rejects a model that is not on the allowlist, so the
+    // planner takes the resolved Opus id rather than the "opus" alias.
     const rewrittenPlanning = materializeFactoryCanvas({
       definition: getFactoryDefinition("line-planning"),
       canvasName: "Plan",
@@ -82,12 +86,45 @@ describe("setup factory line apps", () => {
       },
       agentRewrite: {
         component: "runnerClaudeCode",
-        model: "sonnet",
+        model: "claude-sonnet-4-6",
+        planningModel: "claude-opus-4-6",
         credentials: { source: "hosted" },
       },
     });
     const rewrittenAgent = canvasNodes(rewrittenPlanning).find((node) => node.id === "planner-agent-no-issue");
-    expect(rewrittenAgent?.configuration?.model).toBe("opus");
+    expect(rewrittenAgent?.configuration?.model).toBe("claude-opus-4-6");
+  });
+
+  it("falls back to the standard model when the rewrite resolved no planning model", () => {
+    const planning = materializeFactoryCanvas({
+      definition: getFactoryDefinition("line-planning"),
+      canvasName: "Plan",
+      canvasId: "canvas-abc",
+      installParams: { appRepository: "acme/app", backlogRepository: "acme/backlog" },
+      integrations: { github: { id: "int-1", name: "acme-github", ready: true } },
+      agentRewrite: {
+        component: "runnerCodex",
+        model: "gpt-5",
+        credentials: { source: "hosted" },
+      },
+    });
+    const agent = canvasNodes(planning).find((node) => node.id === "planner-agent-no-issue");
+
+    expect(agent?.component).toBe("runnerCodex");
+    expect(agent?.configuration?.model).toBe("gpt-5");
+  });
+
+  it("names a model on every agent node, with or without an onboarding rewrite", () => {
+    for (const factoryId of ["line-planning", "line-implementation"]) {
+      const agentNodes = canvasNodes(materializeOnboardingApp(factoryId)).filter((node) =>
+        AGENT_COMPONENTS.includes(node.component ?? ""),
+      );
+
+      expect(agentNodes.length).toBeGreaterThanOrEqual(1);
+      for (const node of agentNodes) {
+        expect(node.configuration?.model, `${factoryId}/${node.id}`).toBeTruthy();
+      }
+    }
   });
 
   it("uses the agent provider and model selected during onboarding", () => {

--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.spec.ts
@@ -218,7 +218,9 @@ spec:
     expect(definition.installParams.map((param) => param.name)).toEqual(["appRepository", "backlogRepository"]);
   });
 
-  it("keeps the planning agent on Opus when Claude Code credentials become hosted", () => {
+  // A hosted run rejects a model that is not on the allowlist, so the planner
+  // takes the Opus id the caller resolved, not the "opus" alias.
+  it("gives the planning agent the resolved Opus id on hosted credentials", () => {
     const canvasYaml = materializeFactoryCanvas({
       definition: getFactoryDefinition("line-planning"),
       canvasName: "Plan",
@@ -230,12 +232,14 @@ spec:
       agentRewrite: {
         component: "runnerClaudeCode",
         model: "claude-sonnet-4-6",
+        planningModel: "claude-opus-4-6",
         credentials: { source: "hosted" },
       },
     });
 
-    expect(canvasYaml).toMatch(/id: planner-agent-no-issue[\s\S]*model: opus/);
+    expect(canvasYaml).toMatch(/id: planner-agent-no-issue[\s\S]*model: claude-opus-4-6/);
     expect(canvasYaml).not.toContain("model: claude-sonnet-4-6");
+    expect(canvasYaml).not.toMatch(/model: opus$/m);
   });
 
   it("rewrites Claude Code credentials to hosted when Claude is not connected", () => {

--- a/web_src/src/pages/home/factories/materializeFactoryTemplate.ts
+++ b/web_src/src/pages/home/factories/materializeFactoryTemplate.ts
@@ -109,11 +109,16 @@ export function wireFactoryIntegrations(
 
 const CLAUDE_CODE_COMPONENT = "runnerClaudeCode";
 const PLANNING_AGENT_NODE_ID = "planner-agent-no-issue";
-const PLANNING_AGENT_MODEL = "opus";
 
 export type FactoryAgentRewrite = {
   component: string;
   model: string;
+  /**
+   * Model for the planning agent, which weighs evidence rather than writes
+   * code. Hosted runs reject a model that is not on the allowlist, so the
+   * caller resolves this against the same list as `model`.
+   */
+  planningModel?: string;
   credentials: { source: "hosted" } | { source: "integration"; name: string };
 };
 
@@ -136,8 +141,8 @@ function rewriteOnboardingAgentNodes(doc: YamlCanvas, rewrite: FactoryAgentRewri
 }
 
 function planningAgentModel(nodeId: string | undefined, rewrite: FactoryAgentRewrite): string {
-  if (nodeId === PLANNING_AGENT_NODE_ID && rewrite.component === CLAUDE_CODE_COMPONENT) {
-    return PLANNING_AGENT_MODEL;
+  if (nodeId === PLANNING_AGENT_NODE_ID) {
+    return rewrite.planningModel || rewrite.model;
   }
   return rewrite.model;
 }


### PR DESCRIPTION
## Summary

Workspace onboarding generated agent nodes with an empty `model` field.
The node showed the user no model, and the run used whatever the agent
CLI picked. This applied to the backend intake and PR feedback specs and
to the `generate-pr-text` node of the implementation app.

Each spec now names a model, and an agent that carries no model of its
own falls back to the default of its runner. Nodes that weigh evidence
get Opus, the way the planning agent does. Nodes that write or edit text
get Sonnet.

Naming a model made two model gates visible.

**Planning alias.** The planning agent used the literal alias `opus`. A
hosted run accepts only a model id from the selected-model list, so the
alias failed the check with `model opus is not on the selected-model
list`. The onboarding plan now resolves a planning model from the same
list as the standard model, and keeps the alias only when no list
applies.

**BYOK gate.** The BYOK path also checked the model against the
selected-model list. That check gave SuperPlane no cost to protect,
because a BYOK run spends the key of the organization and not SuperPlane
credit. It stopped an organization from using the key it connected until
an administrator selected models first, and it rejected agent CLI
aliases such as `opus`, because the list holds full model ids.
`PrepareBYOKRun` is removed. Hosted runs keep the gate, because hosted
spend debits the wallet. `docs/prd/token-usage-and-billing.md` is
updated, because it recorded the BYOK gate as a locked decision.

## Test plan

- [ ] `make test PKG_TEST_PACKAGES="./pkg/components/runner/... ./pkg/models ./pkg/grpc/actions/factories/..."` passes.
- [ ] Frontend tests for `src/pages/home/factories/` and `src/pages/factories/pages/onboarding/` pass.
- [ ] `make check.lint.ui` and `make check.build.ui` pass.
- [ ] Complete onboarding with an Anthropic key and no models selected. Confirm the run starts without an administrator action.
- [ ] Complete onboarding on hosted credit. Confirm the planning node names an Opus id from the allowlist, and the implementation node names a Sonnet id.
- [ ] Open a generated intake and PR feedback canvas. Confirm each agent node shows a model.


Made with [Cursor](https://cursor.com)