### PR TITLE
fix: Simplify the Implement app graph

### DIFF
--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunCanvases.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunCanvases.spec.ts
@@ -85,9 +85,7 @@ describe("splitRunCanvasForPhase", () => {
     expect(canvas.nodes.map((node) => node.name)).toContain("Attach PR to Work Order");
     expect(canvas.statuses["create-branch"]).toBe("passed");
     expect(canvas.statuses["implementation-agent-no-issue"]).toBe("running");
-    expect(canvas.statuses["generate-pr-text"]).toBe("did_not_run");
     expect(canvas.statuses["create-draft-pr"]).toBe("did_not_run");
-    expect(canvas.statuses["add-pr-label"]).toBe("did_not_run");
     expect(canvas.statuses["attach-pr-artifact"]).toBe("did_not_run");
     expect(canvas.statuses["set-pr-closure-note"]).toBe("did_not_run");
     expect(canvas.statuses["add-run-error"]).toBe("did_not_run");
@@ -106,9 +104,7 @@ describe("splitRunCanvasForPhase", () => {
     });
 
     expect(canvas.statuses["implementation-agent-no-issue"]).toBe("passed");
-    expect(canvas.statuses["generate-pr-text"]).toBe("passed");
     expect(canvas.statuses["create-draft-pr"]).toBe("passed");
-    expect(canvas.statuses["add-pr-label"]).toBe("passed");
     expect(canvas.statuses["attach-pr-artifact"]).toBe("passed");
     expect(canvas.statuses["set-pr-closure-note"]).toBe("passed");
     expect(canvas.statuses["add-run-error"]).toBe("did_not_run");

--- a/web_src/src/pages/home/factories/index.ts
+++ b/web_src/src/pages/home/factories/index.ts
@@ -43,7 +43,6 @@ function buildSoftwareFactory(): FactoryDefinition {
 // phase — mirroring the production setup. Each app exposes a single onRun
 // entrypoint that the line calls in order, passing the work order through.
 const LINE_APP_COMPONENT_INTEGRATIONS: Record<string, string> = {
-  "github.addIssueLabel": "github",
   "github.createIssueComment": "github",
   "github.createPullRequest": "github",
 };

--- a/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
@@ -16,24 +16,15 @@ spec:
       targetId: implementation-agent-no-issue
     - channel: passed
       sourceId: implementation-agent-no-issue
-      targetId: generate-pr-text
-    - channel: passed
-      sourceId: generate-pr-text
       targetId: create-draft-pr
     - channel: default
       sourceId: create-draft-pr
       targetId: attach-pr-artifact
     - channel: default
       sourceId: attach-pr-artifact
-      targetId: add-pr-label
-    - channel: default
-      sourceId: add-pr-label
       targetId: set-pr-closure-note
     - channel: failed
       sourceId: implementation-agent-no-issue
-      targetId: add-run-error
-    - channel: failed
-      sourceId: generate-pr-text
       targetId: add-run-error
   nodes:
     - id: onrun-implement
@@ -225,74 +216,18 @@ spec:
               fi
               git push origin "$BRANCH"
               echo "Pushed implementation to $BRANCH"
-      position:
-        x: 1475
-        'y': 648
-      isCollapsed: false
-    - id: generate-pr-text
-      name: Generate PR title and description
-      type: TYPE_ACTION
-      component: runnerClaudeCode
-      concurrency:
-        max: 5
-      configuration:
-        credentials:
-          source: integration
-          integration:
-            name: claude
-        environmentFrom:
-          - source: integration
-            integration:
-              name: github
-        environment:
-          - name: REPO
-            value: '{{ install_params.appRepository }}'
-            valueSource: literal
-          - name: PLAN
-            value: '{{ toBase64(find(order().artifacts, {#.type == "markdown" && #.data.title == "PLAN.md"}).data.body) }}'
-            valueSource: literal
-          - name: BRANCH
-            value: '{{ $["Create Branch"].data.result.branch }}'
-            valueSource: literal
-          - name: ORDER_DESCRIPTION
-            value: '{{ toBase64(order().description) }}'
-            valueSource: literal
-        executionTimeoutSeconds: 3600
-        machineType: e1-large-amd64
-        model: sonnet
-        steps:
-          - name: Inject Plan
-            type: bash
-            command: |-
-              echo $PLAN | base64 -d > /tmp/PLAN.md
-              cat /tmp/PLAN.md
-          - name: Inject order description
-            type: bash
-            command: |-
-              echo $ORDER_DESCRIPTION | base64 -d > /tmp/ORDER.md
-              cat /tmp/ORDER.md
-          - name: Checkout Branch
-            type: bash
-            command: |-
-              set -euo pipefail
-              rm -rf repo
-              git clone --depth 1 --branch "$BRANCH" "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git" repo
-              cd repo
           - name: Generate PR title and description
             type: prompt
             workingDirectory: repo
             prompt: |-
-              You are writing a pull request title and description for an implementation done to complete a SuperPlane Work Order.
-              The repository is cloned out in your current working directory.
+              Write the pull request title and description for the change you pushed.
 
               Work order title: {{ order().title }}
 
-              1/ The work order description is at /tmp/ORDER.md
-              2/ The plan used for the implementation is in the /tmp/PLAN.md file.
-              3/ Analyze the plan and the changes in the current branch, compared to main, and compose a concise title and description for the pull request.
-              4/ The title should follow conventional commits structure. Use only feat, fix, chore, or docs.
-              5/ The description should have a brief summary of the changes, and include sections to describe the changes made in each logical part of the system (UI, API, workers, database, ...).
-              6/ Write the title to /tmp/TITLE and the description to /tmp/DESCRIPTION.md
+              1/ Compare the current branch with main and review the commits you made.
+              2/ The title must follow conventional commits structure. Use only feat, fix, chore, or docs.
+              3/ The description must start with a brief summary of the changes, and include sections to describe the changes made in each logical part of the system (UI, API, workers, database, ...).
+              4/ Write the title to /tmp/TITLE and the description to /tmp/DESCRIPTION.md. Do not add these files to the repository.
 
               Write clearly, for humans, in ASD-STE100 / Simplified Technical English
           - name: Push output
@@ -312,8 +247,8 @@ spec:
                 exit 1
               fi
       position:
-        x: 1442
-        'y': 984
+        x: 1475
+        'y': 648
       isCollapsed: false
     - id: create-draft-pr
       name: Create Draft Pull Request
@@ -337,20 +272,7 @@ spec:
         title: '{{ fromBase64(previous().data.result.title) }}'
       position:
         x: 1442
-        'y': 1152
-      isCollapsed: true
-    - id: add-pr-label
-      name: Add Label to Pull Request
-      type: TYPE_ACTION
-      component: github.addIssueLabel
-      configuration:
-        issueNumber: '{{ $["Create Draft Pull Request"].data.number }}'
-        labels:
-          - factory
-        repository: '{{ install_params.appRepository }}'
-      position:
-        x: 1442
-        'y': 1320
+        'y': 984
       isCollapsed: true
     - id: attach-pr-artifact
       name: Attach PR to Work Order
@@ -369,7 +291,7 @@ spec:
         externalId: '{{ $["Create Draft Pull Request"].data.id }}'
       position:
         x: 1442
-        'y': 1488
+        'y': 1152
       isCollapsed: true
     - id: set-pr-closure-note
       name: Set PR closure note
@@ -385,13 +307,14 @@ spec:
         showOnlyWhenWaiting: true
       position:
         x: 1442
-        'y': 1656
+        'y': 1320
       isCollapsed: true
     - id: add-run-error
-      name: addRunError
+      name: Record Implementation Failure
       type: TYPE_ACTION
       component: addRunError
-      configuration: {}
+      configuration:
+        message: The implementation agent failed. Open the agent logs to find the cause.
       position:
         x: 1770
         'y': 984

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -10,9 +10,10 @@ type AgentStep = { name?: string; command?: string; workingDirectory?: string };
 
 type CanvasNode = {
   id?: string;
+  name?: string;
   component?: string;
   concurrency?: { max?: number };
-  configuration?: { model?: string; steps?: AgentStep[] };
+  configuration?: { model?: string; message?: string; steps?: AgentStep[] };
 };
 
 function canvasNodes(canvasYaml: string): CanvasNode[] {
@@ -168,19 +169,16 @@ describe("setup factory line apps", () => {
       "create-branch",
       "add-branch-artifact",
       "implementation-agent-no-issue",
-      "generate-pr-text",
       "create-draft-pr",
-      "add-pr-label",
       "attach-pr-artifact",
       "set-pr-closure-note",
       "add-run-error",
     ]);
     expect(implementation).toMatch(/sourceId: add-branch-artifact\n\s+targetId: implementation-agent-no-issue/);
-    expect(implementation).toMatch(/sourceId: implementation-agent-no-issue\n\s+targetId: generate-pr-text/);
-    expect(implementation).toMatch(/sourceId: generate-pr-text\n\s+targetId: create-draft-pr/);
+    expect(implementation).toMatch(/sourceId: implementation-agent-no-issue\n\s+targetId: create-draft-pr/);
     expect(implementation).toMatch(/component: github\.createPullRequest[\s\S]*repository: acme\/app/);
     expect(implementation).toMatch(/sourceId: create-draft-pr\n\s+targetId: attach-pr-artifact/);
-    expect(implementation).toMatch(/sourceId: attach-pr-artifact\n\s+targetId: add-pr-label/);
+    expect(implementation).toMatch(/sourceId: attach-pr-artifact\n\s+targetId: set-pr-closure-note/);
     expect(implementation).toMatch(/id: attach-pr-artifact[\s\S]*component: addPullRequest/);
     expect(implementation).toMatch(
       /id: attach-pr-artifact[\s\S]*url: '\{\{ \$\["Create Draft Pull Request"\]\.data\._links\.html\.href \}\}'/,
@@ -191,19 +189,28 @@ describe("setup factory line apps", () => {
       "create-branch": 5,
       "add-branch-artifact": 100,
       "implementation-agent-no-issue": 5,
-      "generate-pr-text": 5,
       "create-draft-pr": 100,
-      "add-pr-label": undefined,
       "attach-pr-artifact": 100,
       "set-pr-closure-note": undefined,
       "add-run-error": undefined,
     });
   });
 
-  it("writes the pull request title and description before it opens the draft", () => {
+  it("writes the pull request title and description in the implementation agent", () => {
     const implementation = materializeOnboardingApp("line-implementation");
+    const nodes = canvasNodes(implementation);
+    const agentNodes = nodes.filter((node) => AGENT_COMPONENTS.includes(node.component ?? ""));
+    const steps = nodeStepsByName(nodes, "implementation-agent-no-issue");
 
-    expect(implementation).toContain("id: generate-pr-text");
+    // One agent writes the code and the pull request text, so the run clones
+    // the repository once and the column editor reaches the whole prompt.
+    expect(agentNodes.map((node) => node.id)).toEqual(["implementation-agent-no-issue"]);
+    expect(Object.keys(steps).slice(-3)).toEqual([
+      "Commit and Push",
+      "Generate PR title and description",
+      "Push output",
+    ]);
+    expect(steps["Generate PR title and description"]?.workingDirectory).toBe("repo");
     expect(implementation).toContain("Missing title and/or description at /tmp/TITLE and /tmp/DESCRIPTION.md");
     expect(implementation).toMatch(
       /component: github\.createPullRequest[\s\S]*fromBase64\(previous\(\)\.data\.result\.title\)/,
@@ -217,7 +224,9 @@ describe("setup factory line apps", () => {
   it("announces the PR-merge wait after the work order attaches the pull request", () => {
     const implementation = materializeOnboardingApp("line-implementation");
 
-    expect(implementation).toMatch(/sourceId: add-pr-label[\s\S]*targetId: set-pr-closure-note/);
+    expect(implementation).toMatch(/sourceId: attach-pr-artifact[\s\S]*targetId: set-pr-closure-note/);
+    expect(implementation).not.toContain("github.addIssueLabel");
+    expect(implementation).not.toMatch(/labels:[\s\S]*- factory/);
     expect(implementation).toContain("component: setWorkOrderStatusNote");
     expect(implementation).toContain("noteKey: pr-closure");
     expect(implementation).toContain("headline: Waiting for user review");
@@ -226,6 +235,21 @@ describe("setup factory line apps", () => {
     );
     expect(implementation).toContain("ctaUrl: '{{ $[\"Create Draft Pull Request\"].data.html_url }}'");
     expect(implementation).toContain("showOnlyWhenWaiting: true");
+  });
+
+  it("names the error node and gives it the message addRunError requires", () => {
+    const implementation = materializeOnboardingApp("line-implementation");
+    const errorNode = canvasNodes(implementation).find((node) => node.id === "add-run-error");
+
+    // An empty message fails canvas validation, so the node carries a warning
+    // badge in the editor and fails when the agent reaches the failed channel.
+    expect(errorNode?.name).toBe("Record Implementation Failure");
+    expect(errorNode?.configuration?.message).toBe(
+      "The implementation agent failed. Open the agent logs to find the cause.",
+    );
+    expect(implementation).toMatch(
+      /channel: failed\n\s+sourceId: implementation-agent-no-issue\n\s+targetId: add-run-error/,
+    );
   });
 
   it("fails planning when the agent does not write the plan file", () => {

--- a/web_src/src/ui/CanvasPage/factoryConfigureFitView.spec.ts
+++ b/web_src/src/ui/CanvasPage/factoryConfigureFitView.spec.ts
@@ -58,7 +58,7 @@ describe("factoryConfigureEnterFitViewOptions", () => {
   });
 
   it("centers a deep-linked node at 100% zoom", () => {
-    const focusNode = { id: "generate-pr-text" };
+    const focusNode = { id: "implementation-agent-no-issue" };
     expect(factoryConfigureEnterFitViewOptions(focusNode)).toEqual({
       includeHiddenNodes: true,
       minZoom: 1,


### PR DESCRIPTION
## Summary

The Implement app template carried three problems that showed on the canvas.

- **Two agents for one job.** The app ran a second Claude Code node only to
  write the pull request title and description. That node started a second
  machine, cloned the branch again, and read the order and the plan again.
  The implementation agent now writes the pull request text in two more
  steps. A later prompt continues the same Claude session, so the agent
  already knows the change it made. The simplified column editor shows only
  the first agent of a canvas, so the pull request prompt was also out of
  reach there.
- **A label with no purpose.** The app added a `factory` label to the draft
  pull request. The label gave no value, so the node is removed.
- **An error node that could not run.** The `addRunError` node had an empty
  configuration, but the component makes the `message` field necessary.
  Canvas validation put a warning badge on the node, and the node failed
  when the agent took the failed channel. The node now records a clear
  message and has a human name.

The change touches the install template, so it applies to Implement apps
created from now on.

## Test plan

- [ ] `make check.lint.ui` stays within budget.
- [ ] `make check.build.ui` passes.
- [ ] Vitest: `src/pages/home/factories`, `src/pages/factories/pages/work-order-split-run`, and `src/ui/CanvasPage/factoryConfigureFitView.spec.ts` pass.
- [ ] Install a new line in onboarding. The Implement canvas shows nine nodes, one agent, no label node, and no warning badge on the error node.
- [ ] Run a work order through Implement. The agent pushes the branch, the draft pull request opens with the generated title and description, and the work order shows the review note.

Made with [Cursor](https://cursor.com)