### PR TITLE
fix: Scope app name uniqueness to the workspace

### DIFF
--- a/.models-tx-debt-baseline.json
+++ b/.models-tx-debt-baseline.json
@@ -1,6 +1,6 @@
 {
-  "maxAllowedInTransactionDefinitions": 159,
-  "maxAllowedDatabaseConnCalls": 178,
+  "maxAllowedInTransactionDefinitions": 158,
+  "maxAllowedDatabaseConnCalls": 177,
   "inTransactionDefinitionKeys": [
     "pkg/models/account.go:MarkPasswordChangedInTransaction",
     "pkg/models/account.go:CreateAccountInTransaction",
@@ -30,7 +30,6 @@
     "pkg/models/canvas.go:FindCanvasNodesInTransaction",
     "pkg/models/canvas.go:FindCanvasNodesUnscopedInTransaction",
     "pkg/models/canvas.go:SoftDeleteInTransaction",
-    "pkg/models/canvas.go:FindCanvasByNameInTransaction",
     "pkg/models/canvas.go:FindCanvasInTransaction",
     "pkg/models/canvas.go:FindCanvasWithoutOrgScopeInTransaction",
     "pkg/models/canvas.go:FindUnscopedCanvasInTransaction",
@@ -200,7 +199,6 @@
     "pkg/models/canvas.go:FindCanvasNodesUnscoped:database.Conn()#1",
     "pkg/models/canvas.go:SoftDelete:database.Conn()#1",
     "pkg/models/canvas.go:FindCanvas:database.Conn()#1",
-    "pkg/models/canvas.go:FindCanvasByName:database.Conn()#1",
     "pkg/models/canvas.go:FindCanvasWithoutOrgScope:database.Conn()#1",
     "pkg/models/canvas.go:FindUnscopedCanvas:database.Conn()#1",
     "pkg/models/canvas.go:ListCanvasesPaginated:database.Conn()#1",
@@ -342,5 +340,5 @@
     "pkg/models/webhook.go:ListDeletedWebhooks:database.Conn()#1",
     "pkg/models/webhook.go:ResetStuckProvisioningWebhooks:database.Conn()#1"
   ],
-  "updatedAt": "2026-08-17T23:48:46Z"
+  "updatedAt": "2026-08-28T09:52:20Z"
 }

--- a/db/migrations/20260828094719_scope-app-name-uniqueness-to-workspace.up.sql
+++ b/db/migrations/20260828094719_scope-app-name-uniqueness-to-workspace.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+-- Apps that belong to a workspace only have to be unique inside that
+-- workspace. Every workspace installs the same templates ("Plan", "Implement",
+-- "PR Closure"), so an organization-wide constraint made the second workspace
+-- fall back to "Plan (2)", "Plan (3)" and so on.
+--
+-- Apps that do not belong to a workspace stay unique per organization, because
+-- the organization is the only scope they have.
+--
+-- Both indexes only cover live rows. A soft-deleted app keeps its name for
+-- history and no longer blocks a new app from taking that name.
+
+ALTER TABLE workflows DROP CONSTRAINT workflows_organization_id_name_key;
+
+CREATE UNIQUE INDEX workflows_organization_id_name_active_key
+  ON workflows (organization_id, name)
+  WHERE factory_id IS NULL AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX workflows_factory_id_name_active_key
+  ON workflows (factory_id, name)
+  WHERE factory_id IS NOT NULL AND deleted_at IS NULL;
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1907,14 +1907,6 @@ ALTER TABLE ONLY public.workflow_versions
 
 
 --
--- Name: workflows workflows_organization_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.workflows
-    ADD CONSTRAINT workflows_organization_id_name_key UNIQUE (organization_id, name);
-
-
---
 -- Name: workflows workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2753,6 +2745,20 @@ CREATE UNIQUE INDEX unique_api_key_in_organization ON public.users USING btree (
 --
 
 CREATE UNIQUE INDEX unique_human_user_in_organization ON public.users USING btree (organization_id, account_id, email) WHERE ((type)::text = 'human'::text);
+
+
+--
+-- Name: workflows_factory_id_name_active_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX workflows_factory_id_name_active_key ON public.workflows USING btree (factory_id, name) WHERE ((factory_id IS NOT NULL) AND (deleted_at IS NULL));
+
+
+--
+-- Name: workflows_organization_id_name_active_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX workflows_organization_id_name_active_key ON public.workflows USING btree (organization_id, name) WHERE ((factory_id IS NULL) AND (deleted_at IS NULL));
 
 
 --
@@ -3659,7 +3665,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260828012533	f
+20260828094719	f
 \.
 
 

--- a/pkg/grpc/actions/canvases/common_test.go
+++ b/pkg/grpc/actions/canvases/common_test.go
@@ -39,10 +39,10 @@ func structFromAnyMap(t *testing.T, value map[string]any) *structpb.Struct {
 }
 
 func TestMapCanvasNameUniqueConstraintError(t *testing.T) {
-	t.Run("maps workflow name unique violation to already exists", func(t *testing.T) {
+	t.Run("maps organization name unique violation to already exists", func(t *testing.T) {
 		err := mapCanvasNameUniqueConstraintError(&pgconn.PgError{
 			Code:           "23505",
-			ConstraintName: "workflows_organization_id_name_key",
+			ConstraintName: "workflows_organization_id_name_active_key",
 		})
 
 		assert.Equal(t, codes.AlreadyExists, grpcerrors.Code(err))
@@ -53,6 +53,15 @@ func TestMapCanvasNameUniqueConstraintError(t *testing.T) {
 			}
 			return err.Error()
 		}())
+	})
+
+	t.Run("maps factory name unique violation to already exists", func(t *testing.T) {
+		err := mapCanvasNameUniqueConstraintError(&pgconn.PgError{
+			Code:           "23505",
+			ConstraintName: "workflows_factory_id_name_active_key",
+		})
+
+		assert.Equal(t, codes.AlreadyExists, grpcerrors.Code(err))
 	})
 
 	t.Run("maps model duplicate name error to already exists", func(t *testing.T) {

--- a/pkg/grpc/actions/canvases/create_canvas_test.go
+++ b/pkg/grpc/actions/canvases/create_canvas_test.go
@@ -82,6 +82,43 @@ func TestCreateCanvasDuplicateName(t *testing.T) {
 	require.Equal(t, codes.AlreadyExists, grpcerrors.Code(err))
 }
 
+func TestCreateCanvasNameUniquenessIsScopedToWorkspace(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	baseURL := "https://example.com"
+
+	firstWorkspace, err := models.CreateFactory(database.Conn(), r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	secondWorkspace, err := models.CreateFactory(database.Conn(), r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	createPlan := func(factoryID *uuid.UUID) error {
+		_, err := CreateCanvas(ctx, r.Registry, r.Encryptor, r.AuthService, r.GitProvider, baseURL, r.Organization.ID, "Plan", "", factoryID, nil)
+		return err
+	}
+
+	// Every workspace installs the same templates, so a second workspace has to
+	// be able to keep the template name instead of falling back to "Plan (2)".
+	t.Run("two workspaces can both hold an app with the same name", func(t *testing.T) {
+		require.NoError(t, createPlan(&firstWorkspace.ID))
+		require.NoError(t, createPlan(&secondWorkspace.ID))
+	})
+
+	t.Run("one workspace rejects two apps with the same name", func(t *testing.T) {
+		err := createPlan(&firstWorkspace.ID)
+		require.Error(t, err)
+		require.Equal(t, codes.AlreadyExists, grpcerrors.Code(err))
+	})
+
+	t.Run("apps outside a workspace stay unique per organization", func(t *testing.T) {
+		require.NoError(t, createPlan(nil))
+
+		err := createPlan(nil)
+		require.Error(t, err)
+		require.Equal(t, codes.AlreadyExists, grpcerrors.Code(err))
+	})
+}
+
 func TestCreateCanvasRejectsWhitespaceOnlyName(t *testing.T) {
 	r := support.Setup(t)
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())

--- a/pkg/grpc/actions/factories/create_factory_intake.go
+++ b/pkg/grpc/actions/factories/create_factory_intake.go
@@ -92,7 +92,7 @@ func CreateFactoryIntake(
 	if name == "" {
 		name = intakeDefaultName(source)
 	}
-	name, err = models.AvailableCanvasName(db, orgID, name)
+	name, err = models.AvailableCanvasName(db, orgID, &factoryID, name)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory intake")
 	}

--- a/pkg/grpc/actions/factories/create_factory_pr_feedback_handler.go
+++ b/pkg/grpc/actions/factories/create_factory_pr_feedback_handler.go
@@ -58,7 +58,7 @@ func CreateFactoryPRFeedbackHandler(
 	if name == "" {
 		name = prFeedbackDefaultName
 	}
-	name, err = models.AvailableCanvasName(db, orgID, name)
+	name, err = models.AvailableCanvasName(db, orgID, &factoryID, name)
 	if err != nil {
 		return nil, factoryErrorToStatus(err, "failed to create factory PR feedback handler")
 	}

--- a/pkg/grpc/actions/factories/factory_intake_test.go
+++ b/pkg/grpc/actions/factories/factory_intake_test.go
@@ -151,7 +151,7 @@ func Test__FactoryIntakeActions(t *testing.T) {
 
 		assert.NotEqual(t, first.GetId(), second.GetId())
 		assert.NotEqual(t, first.GetCanvasId(), second.GetCanvasId())
-		// Canvas names are unique per organization, so the second one steps
+		// Canvas names are unique inside a workspace, so the second one steps
 		// aside instead of failing.
 		assert.NotEqual(t, first.GetName(), second.GetName())
 

--- a/pkg/grpc/actions/factories/line_steps.go
+++ b/pkg/grpc/actions/factories/line_steps.go
@@ -119,7 +119,7 @@ func resolveFactoryOwnedApp(
 	if appID, parseErr := uuid.Parse(appRef); parseErr == nil {
 		canvas, err = models.FindCanvasInTransaction(tx, organizationID, appID)
 	} else {
-		canvas, err = models.FindCanvasByNameInTransaction(tx, appRef, organizationID)
+		canvas, err = models.FindCanvasByName(tx, organizationID, &factoryID, appRef)
 	}
 
 	if err != nil {

--- a/pkg/models/canvas.go
+++ b/pkg/models/canvas.go
@@ -16,7 +16,12 @@ import (
 
 var ErrCanvasNameAlreadyExists = errors.New("canvas name already exists")
 
-const canvasNameUniqueConstraint = "workflows_organization_id_name_key"
+// Canvas names are unique inside the factory that owns the canvas, and unique
+// per organization for canvases that no factory owns.
+var canvasNameUniqueConstraints = []string{
+	"workflows_organization_id_name_active_key",
+	"workflows_factory_id_name_active_key",
+}
 
 type Canvas struct {
 	ID                          uuid.UUID
@@ -72,11 +77,22 @@ func MapCanvasNameUniqueConstraintError(err error) error {
 	}
 
 	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) && pgErr.ConstraintName == canvasNameUniqueConstraint {
+	if errors.As(err, &pgErr) && slices.Contains(canvasNameUniqueConstraints, pgErr.ConstraintName) {
 		return ErrCanvasNameAlreadyExists
 	}
 
 	return err
+}
+
+// scopeToCanvasNameOwner narrows a query to the scope a canvas name is unique
+// in: the factory when one owns the canvas, the organization otherwise.
+func scopeToCanvasNameOwner(tx *gorm.DB, organizationID uuid.UUID, factoryID *uuid.UUID) *gorm.DB {
+	query := tx.Where("organization_id = ?", organizationID)
+	if factoryID == nil {
+		return query.Where("factory_id IS NULL")
+	}
+
+	return query.Where("factory_id = ?", *factoryID)
 }
 
 func withActiveCanvas(tx *gorm.DB, workflowIDColumn string) *gorm.DB {
@@ -174,14 +190,13 @@ func FindCanvas(orgID, id uuid.UUID) (*Canvas, error) {
 	return FindCanvasInTransaction(database.Conn(), orgID, id)
 }
 
-func FindCanvasByName(name string, organizationID uuid.UUID) (*Canvas, error) {
-	return FindCanvasByNameInTransaction(database.Conn(), name, organizationID)
-}
-
-func FindCanvasByNameInTransaction(tx *gorm.DB, name string, organizationID uuid.UUID) (*Canvas, error) {
+// FindCanvasByName looks a canvas up in the scope its name is unique in. Pass
+// the factory ID to search inside a factory, or nil to search the canvases that
+// no factory owns.
+func FindCanvasByName(tx *gorm.DB, organizationID uuid.UUID, factoryID *uuid.UUID, name string) (*Canvas, error) {
 	var canvas Canvas
-	err := tx.
-		Where("name = ? AND organization_id = ?", name, organizationID).
+	err := scopeToCanvasNameOwner(tx, organizationID, factoryID).
+		Where("name = ?", name).
 		First(&canvas).
 		Error
 
@@ -303,13 +318,12 @@ func ListCanvases(orgID string) ([]Canvas, error) {
 }
 
 // AvailableCanvasName returns preferred, or preferred with the lowest " (n)"
-// suffix that no canvas in the organization holds. Canvas names are unique per
-// organization, so a generated canvas has to pick a free name before insert.
-func AvailableCanvasName(tx *gorm.DB, organizationID uuid.UUID, preferred string) (string, error) {
+// suffix that no other canvas in the same scope holds. A generated canvas has to
+// pick a free name before insert. Pass the factory ID for a canvas the factory
+// owns, or nil for an organization-level canvas.
+func AvailableCanvasName(tx *gorm.DB, organizationID uuid.UUID, factoryID *uuid.UUID, preferred string) (string, error) {
 	var names []string
-	err := tx.
-		Model(&Canvas{}).
-		Where("organization_id = ?", organizationID).
+	err := scopeToCanvasNameOwner(tx.Model(&Canvas{}), organizationID, factoryID).
 		Where("name = ? OR name LIKE ?", preferred, preferred+" (%)").
 		Pluck("name", &names).
 		Error

--- a/pkg/models/canvas_test.go
+++ b/pkg/models/canvas_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 func Test__Canvas__DeleteRemainingResources__ReturnsCompleteWhenUnderLimit(t *testing.T) {
@@ -144,6 +145,79 @@ func Test__Canvas__DeleteRemainingResources__ReturnsIncompleteWhenLastTypeExceed
 	var remainingRuns int64
 	require.NoError(t, database.Conn().Model(&models.CanvasRun{}).Where("workflow_id = ?", canvas.ID).Count(&remainingRuns).Error)
 	require.Equal(t, int64(100), remainingRuns)
+}
+
+func Test__AvailableCanvasName__LooksOnlyAtTheOwningWorkspace(t *testing.T) {
+	r := support.Setup(t)
+
+	workspace := createWorkspace(t, r.Organization.ID)
+	otherWorkspace := createWorkspace(t, r.Organization.ID)
+	createCanvasNamed(t, r.Organization.ID, r.User, &workspace.ID, "Plan")
+
+	t.Run("steps aside for a name the workspace already holds", func(t *testing.T) {
+		name, err := models.AvailableCanvasName(database.Conn(), r.Organization.ID, &workspace.ID, "Plan")
+		require.NoError(t, err)
+		require.Equal(t, "Plan (2)", name)
+	})
+
+	t.Run("keeps the name in another workspace", func(t *testing.T) {
+		name, err := models.AvailableCanvasName(database.Conn(), r.Organization.ID, &otherWorkspace.ID, "Plan")
+		require.NoError(t, err)
+		require.Equal(t, "Plan", name)
+	})
+
+	t.Run("keeps the name outside every workspace", func(t *testing.T) {
+		name, err := models.AvailableCanvasName(database.Conn(), r.Organization.ID, nil, "Plan")
+		require.NoError(t, err)
+		require.Equal(t, "Plan", name)
+	})
+}
+
+func Test__FindCanvasByName__LooksOnlyAtTheOwningWorkspace(t *testing.T) {
+	r := support.Setup(t)
+
+	workspace := createWorkspace(t, r.Organization.ID)
+	otherWorkspace := createWorkspace(t, r.Organization.ID)
+	canvas := createCanvasNamed(t, r.Organization.ID, r.User, &workspace.ID, "Plan")
+
+	t.Run("finds the app in its own workspace", func(t *testing.T) {
+		found, err := models.FindCanvasByName(database.Conn(), r.Organization.ID, &workspace.ID, "Plan")
+		require.NoError(t, err)
+		require.Equal(t, canvas.ID, found.ID)
+	})
+
+	t.Run("does not reach into another workspace", func(t *testing.T) {
+		_, err := models.FindCanvasByName(database.Conn(), r.Organization.ID, &otherWorkspace.ID, "Plan")
+		require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	})
+
+	t.Run("does not reach into a workspace from outside", func(t *testing.T) {
+		_, err := models.FindCanvasByName(database.Conn(), r.Organization.ID, nil, "Plan")
+		require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	})
+}
+
+func createWorkspace(t *testing.T, organizationID uuid.UUID) *models.Factory {
+	t.Helper()
+
+	workspace, err := models.CreateFactory(database.Conn(), organizationID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	return workspace
+}
+
+func createCanvasNamed(t *testing.T, organizationID, userID uuid.UUID, factoryID *uuid.UUID, name string) *models.Canvas {
+	t.Helper()
+
+	canvas, _ := support.CreateCanvas(t, organizationID, userID, nil, nil)
+	require.NoError(t, database.Conn().Model(canvas).Updates(map[string]any{
+		"name":       name,
+		"factory_id": factoryID,
+	}).Error)
+	canvas.Name = name
+	canvas.FactoryID = factoryID
+
+	return canvas
 }
 
 func createOrphanNodeRequests(t *testing.T, workflowID uuid.UUID, nodeID string, count int) {

--- a/pkg/workers/contexts/app_context.go
+++ b/pkg/workers/contexts/app_context.go
@@ -71,7 +71,7 @@ func (c *AppContext) getAppByID(id uuid.UUID) (*core.App, error) {
 }
 
 func (c *AppContext) getAppByName(name string) (*core.App, error) {
-	otherApp, err := models.FindCanvasByNameInTransaction(c.tx, name, c.canvas.OrganizationID)
+	otherApp, err := models.FindCanvasByName(c.tx, c.canvas.OrganizationID, c.canvas.FactoryID, name)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, core.ErrNotFound

--- a/test/e2e/home_page_test.go
+++ b/test/e2e/home_page_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
@@ -108,7 +109,7 @@ func (steps *TestHomePageSteps) AssertNewAppDisabled() {
 }
 
 func (steps *TestHomePageSteps) AssertCanvasSavedInDB(canvasName string) {
-	canvas, err := models.FindCanvasByName(canvasName, steps.session.OrgID)
+	canvas, err := models.FindCanvasByName(database.Conn(), steps.session.OrgID, nil, canvasName)
 
 	assert.NoError(steps.t, err)
 	assert.Equal(steps.t, canvasName, canvas.Name)

--- a/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
+++ b/web_src/src/pages/factories/pages/duplicateAutomationCanvas.ts
@@ -41,7 +41,7 @@ export type DuplicateAutomationCanvasDeps = {
   factoryId: string;
   app: FactoryApp;
   createCanvas: (input: CreateCanvasInput) => Promise<CreateCanvasResult>;
-  /** Names already taken in the org (used to pick "X copy", "X copy (2)", …). */
+  /** Names already taken in the workspace (used to pick "X copy", "X copy (2)", …). */
   existingCanvasNames?: Iterable<string>;
   /** When set, skip CreateCanvas and reuse this id (retry after failed stage/commit). */
   pendingCanvasId?: string;

--- a/web_src/src/pages/factories/pages/useAutomationCardMutations.ts
+++ b/web_src/src/pages/factories/pages/useAutomationCardMutations.ts
@@ -1,4 +1,4 @@
-import type { CanvasesCanvasSummary, FactoryApp } from "@/api-client";
+import type { FactoryApp } from "@/api-client";
 import { canvasKeys, useCreateCanvas, useDeleteCanvas } from "@/hooks/useCanvasData";
 import { factoryAppsKey } from "@/hooks/useFactoryData";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
@@ -15,6 +15,11 @@ type PendingDuplicateCanvas = {
   name: string;
 };
 
+/**
+ * Collects the names taken in this workspace. Automation names only have to be
+ * unique inside their workspace, so apps in other workspaces and at the
+ * organization level do not compete for the name.
+ */
 function collectExistingCanvasNames(
   queryClient: ReturnType<typeof useQueryClient>,
   organizationId: string,
@@ -22,12 +27,6 @@ function collectExistingCanvasNames(
   sessionNames: Iterable<string>,
 ): string[] {
   const names = new Set<string>([...sessionNames]);
-  const canvases = queryClient.getQueryData<CanvasesCanvasSummary[]>(canvasKeys.list(organizationId));
-  for (const canvas of canvases ?? []) {
-    if (canvas.name?.trim()) {
-      names.add(canvas.name.trim());
-    }
-  }
   const apps = queryClient.getQueryData<FactoryApp[]>(factoryAppsKey(organizationId, factoryId));
   for (const app of apps ?? []) {
     if (app.name?.trim()) {

--- a/web_src/src/pages/home/installFactoryCanvas.spec.ts
+++ b/web_src/src/pages/home/installFactoryCanvas.spec.ts
@@ -1,0 +1,78 @@
+import type { FactoryApp } from "@/api-client";
+import { canvasKeys } from "@/hooks/useCanvasData";
+import { factoryAppsKey } from "@/hooks/useFactoryData";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { getFactoryDefinition } from "./factories";
+import { ensureFactoryCanvas, type CreateFactoryCanvasFn } from "./installFactoryCanvas";
+
+const ORGANIZATION_ID = "org-1";
+const WORKSPACE_ID = "factory-1";
+
+function createCanvasSpy(): CreateFactoryCanvasFn & ReturnType<typeof vi.fn> {
+  return vi.fn(async (input: { name: string }) => ({
+    data: { canvas: { metadata: { id: "canvas-1", name: input.name } } },
+  }));
+}
+
+function seedQueryClient(args: { workspaceApps?: FactoryApp[]; organizationApps?: { name: string }[] }) {
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(factoryAppsKey(ORGANIZATION_ID, WORKSPACE_ID), args.workspaceApps ?? []);
+  queryClient.setQueryData(canvasKeys.list(ORGANIZATION_ID), args.organizationApps ?? []);
+  return queryClient;
+}
+
+async function install(args: {
+  queryClient: QueryClient;
+  workspaceFactoryId?: string;
+  createCanvas: CreateFactoryCanvasFn;
+}) {
+  return ensureFactoryCanvas({
+    pending: null,
+    organizationId: ORGANIZATION_ID,
+    queryClient: args.queryClient,
+    definition: getFactoryDefinition("line-planning"),
+    workspaceFactoryId: args.workspaceFactoryId,
+    createCanvas: args.createCanvas,
+    updateCanvasFolderMembership: vi.fn(),
+  });
+}
+
+describe("ensureFactoryCanvas", () => {
+  it("keeps the template name when only another scope holds it", async () => {
+    const createCanvas = createCanvasSpy();
+
+    const created = await install({
+      queryClient: seedQueryClient({ organizationApps: [{ name: "Plan" }] }),
+      workspaceFactoryId: WORKSPACE_ID,
+      createCanvas,
+    });
+
+    expect(created.canvasName).toBe("Plan");
+    expect(createCanvas).toHaveBeenCalledWith(expect.objectContaining({ name: "Plan" }));
+  });
+
+  it("steps aside when the same workspace already holds the name", async () => {
+    const createCanvas = createCanvasSpy();
+
+    const created = await install({
+      queryClient: seedQueryClient({ workspaceApps: [{ name: "Plan" }] }),
+      workspaceFactoryId: WORKSPACE_ID,
+      createCanvas,
+    });
+
+    expect(created.canvasName).toBe("Plan (2)");
+  });
+
+  it("steps aside for organization apps when no workspace owns the canvas", async () => {
+    const createCanvas = createCanvasSpy();
+
+    const created = await install({
+      queryClient: seedQueryClient({ organizationApps: [{ name: "Plan" }] }),
+      createCanvas,
+    });
+
+    expect(created.canvasName).toBe("Plan (2)");
+  });
+});

--- a/web_src/src/pages/home/installFactoryCanvas.ts
+++ b/web_src/src/pages/home/installFactoryCanvas.ts
@@ -4,10 +4,13 @@ import {
   canvasesInvokeNodeTriggerHook,
   canvasesListCanvases,
   canvasesPutCanvasStaging,
+  factoriesListFactoryApps,
   type CanvasesCanvasSummary,
+  type FactoryApp,
 } from "@/api-client";
 import type { QueryClient } from "@tanstack/react-query";
 import { canvasKeys } from "@/hooks/useCanvasData";
+import { factoryAppsKey } from "@/hooks/useFactoryData";
 import { encodeRepositoryFileContent } from "@/pages/app/files/lib/repository-files";
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "@/pages/app/lib/workflow-spec-paths";
 import { getApiErrorMessage } from "@/lib/errors";
@@ -101,14 +104,34 @@ export async function materializeAndCommitFactoryTemplate(args: {
   await stageAndCommitFactorySpecs(args.canvasId, canvasYaml, consoleYaml);
 }
 
-async function listExistingCanvasNames(organizationId: string, queryClient: QueryClient) {
+function presentNames(items: { name?: string }[]): string[] {
+  return items.map((item) => item.name).filter((name): name is string => Boolean(name));
+}
+
+/**
+ * Lists the names already taken in the scope the new canvas competes with:
+ * the workspace when the canvas belongs to one, the organization otherwise.
+ */
+async function listExistingCanvasNames(organizationId: string, queryClient: QueryClient, workspaceFactoryId?: string) {
+  if (workspaceFactoryId) {
+    const cachedApps = queryClient.getQueryData<FactoryApp[]>(factoryAppsKey(organizationId, workspaceFactoryId));
+    if (cachedApps) {
+      return presentNames(cachedApps);
+    }
+
+    const appsResponse = await factoriesListFactoryApps(
+      withOrganizationHeader({ organizationId, path: { factoryId: workspaceFactoryId } }),
+    );
+    return presentNames(appsResponse.data?.apps ?? []);
+  }
+
   const cached = queryClient.getQueryData<CanvasesCanvasSummary[]>(canvasKeys.list(organizationId));
   if (cached) {
-    return cached.map((canvas) => canvas.name).filter((name): name is string => Boolean(name));
+    return presentNames(cached);
   }
 
   const response = await canvasesListCanvases(withOrganizationHeader({ organizationId }));
-  return (response.data?.canvases ?? []).map((canvas) => canvas.name).filter((name): name is string => Boolean(name));
+  return presentNames(response.data?.canvases ?? []);
 }
 
 async function createCanvasWithUniqueName(args: {
@@ -182,7 +205,9 @@ export async function ensureFactoryCanvas(args: {
 
   if (args.pending) return args.pending;
 
-  const existingNames = new Set(await listExistingCanvasNames(args.organizationId, args.queryClient));
+  const existingNames = new Set(
+    await listExistingCanvasNames(args.organizationId, args.queryClient, args.workspaceFactoryId),
+  );
   const created = await createCanvasWithUniqueName({
     title: args.definition.title,
     description: args.definition.description,


### PR DESCRIPTION
## Summary

App names are unique per organization today. Every workspace installs the same
templates (`Plan`, `Implement`, `PR Closure`), plus generated apps such as
`GitHub issues` and `Address PR feedback`. The second workspace in an
organization therefore collides on every template name, and the retry logic
renames the apps to `Plan (2)`, `Plan (3)`, and so on. New workspaces look
broken before the user does any work.

This change scopes app name uniqueness to the workspace that owns the app, which
is the same rule that factory lines already use. Apps that no workspace owns stay
unique per organization, because the organization is their only scope.

The migration replaces `workflows_organization_id_name_key` with two partial
unique indexes. The new indexes are more permissive than the old constraint, so
no existing row can break them and no backfill is necessary. Both indexes cover
live rows only, so a deleted app no longer holds its name.

A lookup by name becomes ambiguous when two workspaces hold the same name. The
app lookup now takes an explicit workspace, and the two callers that resolve apps
by name pass their own scope: cross-app references at run time, and `runApp`
steps in factory lines. Both callers already rejected apps from a different
workspace, so this narrows the query and does not change what they permit. The
lookup also lost its `database.Conn()` wrapper, which removes two entries from
the models transaction debt baseline.

On the client, the install flow compared a workspace install against the
organization-level app list, which excludes workspace apps. It could neither see
a real conflict nor prove that a name was free. It now reads the app list of the
workspace. Duplication of an automation no longer counts organization-level names
against a workspace-scoped copy.

Existing apps keep their current names. A workspace that sits on `Plan (2)` today
stays on `Plan (2)`; only the freed name becomes available again. Automatic
renames of historical data are a larger risk than the benefit, because users can
refer to an app by name.

## Test plan

- [ ] `make db.migrate DB_NAME=superplane_dev` and `make db.migrate DB_NAME=superplane_test` apply the migration.
- [ ] `make test PKG_TEST_PACKAGES="./pkg/models/... ./pkg/grpc/actions/canvases/... ./pkg/grpc/actions/factories/... ./pkg/workers/contexts/..."` passes.
- [ ] `make lint`, `make check.build.app`, and `make check.models.tx.debt` pass.
- [ ] `make check.lint.ui` and `make check.build.ui` pass.
- [ ] Create two workspaces in one organization. Confirm that both hold an app named `Plan`, and that no name has a `(2)` suffix.
- [ ] Create a second app named `Plan` in one workspace. Confirm that the request fails with "Canvas with the same name already exists".
- [ ] Duplicate an automation. Confirm that the copy takes the next free name inside the same workspace.
- [ ] Start a run that uses a `runApp` step and a cross-app reference by name. Confirm that the run resolves the app in its own workspace.


Made with [Cursor](https://cursor.com)