### PR TITLE
feat: Seed GitHub intake with 30 issues

### DIFF
--- a/pkg/grpc/actions/factories/intake_seed.go
+++ b/pkg/grpc/actions/factories/intake_seed.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	// intakeSeedSize is how many items a new intake analyzes at once.
-	intakeSeedSize = 5
+	// intakeSeedSize is how many items a new intake analyzes at once. A source
+	// with few open items gives fewer, so the seed is an upper bound.
+	intakeSeedSize = 30
 
 	// intakeGitHubIssuePayloadType is the payload type the GitHub trigger emits.
 	// A seeded item uses the same one, so the graph reads it the same way.


### PR DESCRIPTION
## Summary

A new GitHub intake previously analyzed only the five newest open issues.

That left most of the repository backlog out of the first batch.

This change raises the seed size to 30 so a new intake has more work to score at once.

A repository with fewer open issues still seeds only the issues that exist.

## Test plan

- [ ] Create a GitHub issues intake on a connected repository.
- [ ] Confirm the intake starts with up to 30 newest open issues.
- [ ] Confirm a repository with fewer than 30 open issues seeds all of them.


Made with [Cursor](https://cursor.com)