### PR TITLE
fix: Fix the Backlog analysis phase order and name in a run log

### DIFF
--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
@@ -889,6 +889,42 @@ describe("line board work-order examples", () => {
     expect(fixture.openPhaseId).toBe("backlog-analysis-run-analysis");
   });
 
+  // Scoring runs on the work order before a line plans it. The log must read
+  // in that order: the intake that created the order, the score, then the plan.
+  it("puts the Backlog analysis before the line steps", () => {
+    const fixture = splitRunFixtureForWorkOrder(
+      order({
+        title: "Handle duplicate refunds on retry",
+        state: "STATE_OPEN",
+        createdBy: { automation: { appId: "app-github-issues-intake", appName: "GitHub issues" } },
+        lineDispatches: [
+          dispatch("STATE_ACTIVE", [
+            { id: "e-plan", step: "Plan", stepIndex: 0, state: "STATE_STARTED", result: "RESULT_UNKNOWN" },
+          ]),
+        ],
+      }),
+      {
+        demoArtifacts: false,
+        analysisRuns: [
+          {
+            canvasId: "canvas-backlog",
+            workOrderId: "wo-1",
+            run: {
+              id: "run-analysis",
+              canvasId: "canvas-backlog",
+              state: "STATE_FINISHED",
+              result: "RESULT_PASSED",
+              createdAt: "2026-08-28T12:00:00Z",
+              finishedAt: "2026-08-28T12:00:20Z",
+            },
+          },
+        ],
+      },
+    );
+
+    expect(fixture.phases.map((phase) => phase.id)).toEqual(["backlog", "backlog-analysis-run-analysis", "plan-0"]);
+  });
+
   it("puts the reported score on the newest analysis phase", () => {
     const fixture = splitRunFixtureForWorkOrder(DRAFT_WORK_ORDER, {
       demoArtifacts: false,

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
@@ -882,6 +882,7 @@ describe("line board work-order examples", () => {
 
     const analysis = fixture.phases.find((phase) => phase.id === "backlog-analysis-run-analysis");
 
+    expect(analysis?.name).toBe("Analysis");
     expect(analysis?.status).toBe("running");
     expect(analysis?.componentName).toBe("Confidence score");
     expect(analysis?.appId).toBe("canvas-backlog");

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
@@ -309,11 +309,7 @@ function mappedWorkOrderFixture(order: FactoriesWorkOrder, options?: SplitRunFix
   const executions = latestDispatchExecutions(order, options?.lineId);
   const current = pickCurrentExecution(executions);
   const demoArtifacts = options?.demoArtifacts !== false;
-  const phases = [
-    ...phasesForOrder(order, executions, options?.checks, demoArtifacts),
-    ...phasesForAnalysisRuns(options?.analysisRuns ?? [], options?.checks),
-    ...phasesForPRFeedbackRuns(options?.prFeedbackRuns ?? []),
-  ];
+  const phases = phasesForOrder(order, executions, options, demoArtifacts);
   const activeAutomationId = activeAutomationPhaseId(phases);
   const fixture: SplitRunFixture = {
     title: order.title ?? "Work order",
@@ -509,15 +505,23 @@ function boardColumnFor(current: FactoriesWorkOrderExecution | undefined, execut
 
 const VERIFY_STEP_KEYS = new Set(VERIFY_STEP_CHECKS.map((check) => check.key).filter(Boolean));
 
+/**
+ * The log reads in the order the work happened: the source that created the
+ * order, the Backlog analysis that scored it, the line steps that acted on it,
+ * and last the PR feedback runs.
+ */
 function phasesForOrder(
   order: FactoriesWorkOrder,
   executions: FactoriesWorkOrderExecution[],
-  apiChecks?: FactoriesWorkOrderCheck[],
-  demoArtifacts = true,
+  options: SplitRunFixtureOptions | undefined,
+  demoArtifacts: boolean,
 ): SplitRunPhase[] {
+  const apiChecks = options?.checks;
   return [
     ...sourcePhasesForOrder(order, executions.length > 0, demoArtifacts),
+    ...phasesForAnalysisRuns(options?.analysisRuns ?? [], apiChecks),
     ...executions.map((execution) => executionToPhase(order, execution, apiChecks, demoArtifacts, executions)),
+    ...phasesForPRFeedbackRuns(options?.prFeedbackRuns ?? []),
   ];
 }
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
@@ -565,7 +565,7 @@ function analysisRunToPhase(entry: BacklogAnalysisRun, checks?: WorkOrderCheckPr
   };
   return {
     id: `${ANALYSIS_PHASE_ID_PREFIX}${entry.run.id}`,
-    name: "Backlog",
+    name: "Analysis",
     status,
     duration,
     componentName,


### PR DESCRIPTION
## Summary

The run log of a work order showed the scoring phase in the wrong place, with a name that repeated an earlier row.

**Order.** The Backlog analysis phase came after the line steps. A reader saw the intake that created the order, then `Plan`, then the score. That order does not match the work. SuperPlane scores a work order before a line plans it.

The phase list is now built in one function, in the order the work happened:

1. the source that created the work order
2. the Backlog analysis that scored it
3. the line steps that acted on it
4. the pull request feedback runs

**Name.** The scoring phase was named `Backlog`. The source phase carries the same name, so the log showed `Backlog` two times. The second row does not put the order in Backlog. It analyzes the order and reports a confidence score. The phase is now named `Analysis`.

The phase id keeps the `backlog-analysis-` prefix, so canvas lookup and the open-while-running behavior do not change.

## Test plan

- [ ] Open a work order that a GitHub intake created and that a line is running.
- [ ] Confirm the log reads: intake source, `Analysis`, then the line steps.
- [ ] Confirm the confidence score stays on the `Analysis` phase.
- [ ] Confirm no run log shows `Backlog` two times.
- [ ] Confirm a running Backlog analysis still opens its log automatically.
- [ ] Confirm pull request feedback runs stay at the end of the log.
