### PR TITLE
feat: Use one Create button in the New task dialog

### DIFF
--- a/web_src/src/pages/factories/CreateWorkOrderDialog.spec.tsx
+++ b/web_src/src/pages/factories/CreateWorkOrderDialog.spec.tsx
@@ -11,9 +11,7 @@ import {
 import { CreateWorkOrderDialog } from "./CreateWorkOrderDialog";
 import { FactoriesLayoutContext } from "./layout/factoriesLayoutContext";
 
-const { canAct, permissions, createMutate, dispatchMutate, meUser } = vi.hoisted(() => ({
-  canAct: vi.fn((resource: string, action: string) => resource === "work_orders" && action === "create"),
-  permissions: { isLoading: false },
+const { createMutate, dispatchMutate, meUser } = vi.hoisted(() => ({
   createMutate: vi.fn(),
   dispatchMutate: vi.fn(),
   meUser: { current: null as { id: string; name: string } | null },
@@ -26,13 +24,6 @@ vi.mock("@/hooks/useFactoryData", () => ({
 
 vi.mock("@/hooks/useMe", () => ({
   useMe: () => ({ data: meUser.current }),
-}));
-
-vi.mock("@/contexts/usePermissions", () => ({
-  usePermissions: () => ({
-    canAct,
-    isLoading: permissions.isLoading,
-  }),
 }));
 
 vi.mock("./WorkOrderDescriptionEditor", () => ({
@@ -58,8 +49,6 @@ function renderDialog(factory = REFUND_FACTORY) {
 
 describe("CreateWorkOrderDialog", () => {
   beforeEach(() => {
-    permissions.isLoading = false;
-    canAct.mockImplementation((resource: string, action: string) => resource === "work_orders" && action === "create");
     createMutate.mockReset();
     dispatchMutate.mockReset();
     meUser.current = null;
@@ -77,14 +66,14 @@ describe("CreateWorkOrderDialog", () => {
 
     const header = screen.getByTestId("work-order-create-header");
     expect(within(header).getByTestId("work-order-create-fullscreen-button")).toBeInTheDocument();
-    expect(within(header).queryByTestId("work-order-create-draft-button")).not.toBeInTheDocument();
+    expect(within(header).queryByTestId("work-order-create-button")).not.toBeInTheDocument();
   });
 
-  it("renders Save as draft in the footer next to Start, with no line picker", () => {
+  it("renders a single Create button in the footer, with no line picker", () => {
     renderDialog();
 
-    expect(screen.getByTestId("work-order-create-draft-button")).toBeInTheDocument();
-    expect(screen.getByTestId("work-order-create-start")).toHaveTextContent("Start");
+    expect(screen.getByTestId("work-order-create-button")).toHaveTextContent("Create");
+    expect(screen.queryByTestId("work-order-create-start")).not.toBeInTheDocument();
     expect(screen.queryByTestId("work-order-line-button")).not.toBeInTheDocument();
     expect(screen.queryByTestId("work-order-line-picker-panel")).not.toBeInTheDocument();
   });
@@ -97,41 +86,23 @@ describe("CreateWorkOrderDialog", () => {
     expect(screen.queryByTestId("mock-owner-pill")).not.toBeInTheDocument();
   });
 
-  it("disables Start when the user cannot dispatch work orders", () => {
-    renderDialog();
-
-    expect(screen.getByTestId("work-order-create-start").closest(".pointer-events-none")).toBeInTheDocument();
-  });
-
-  it("keeps Start closed while permissions load", () => {
-    permissions.isLoading = true;
-    canAct.mockReturnValue(false);
-    renderDialog();
-
-    expect(screen.getByTestId("work-order-create-start").closest(".pointer-events-none")).toBeInTheDocument();
-  });
-
-  it("starts the work order on the first line", async () => {
+  it("creates the work order without sending it to a line", async () => {
     const user = userEvent.setup();
-    canAct.mockReturnValue(true);
     createMutate.mockResolvedValue({ id: "order-1", number: "101" });
-    dispatchMutate.mockResolvedValue({});
     renderDialog();
 
     await user.type(screen.getByTestId("work-order-title-input"), "Ship the refunds line");
-    await user.click(screen.getByTestId("work-order-create-start"));
+    await user.click(screen.getByTestId("work-order-create-button"));
 
-    expect(screen.queryByTestId("work-order-line-picker-panel")).not.toBeInTheDocument();
-    expect(dispatchMutate).toHaveBeenCalledWith({ orderId: "order-1", lineName: "plan-and-implement" });
+    expect(createMutate).toHaveBeenCalled();
+    expect(dispatchMutate).not.toHaveBeenCalled();
   });
 
-  it("disables Start when the workspace has no lines, while Save as draft stays enabled", async () => {
-    canAct.mockReturnValue(true);
+  it("keeps Create enabled when the workspace has no lines", async () => {
     renderDialog(EMPTY_FACTORY);
 
     await userEvent.setup().type(screen.getByTestId("work-order-title-input"), "Draft only");
 
-    expect(screen.getByTestId("work-order-create-start")).toBeDisabled();
-    expect(screen.getByTestId("work-order-create-draft-button")).not.toBeDisabled();
+    expect(screen.getByTestId("work-order-create-button")).not.toBeDisabled();
   });
 });

--- a/web_src/src/pages/factories/CreateWorkOrderDialog.tsx
+++ b/web_src/src/pages/factories/CreateWorkOrderDialog.tsx
@@ -1,17 +1,13 @@
-import type { FactoriesFactoryLine } from "@/api-client";
-import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
-import { usePermissions } from "@/contexts/usePermissions";
 import { cn } from "@/lib/utils";
-import { ChevronRight, Factory as FactoryIcon, Maximize2, Minimize2, Play, XIcon } from "lucide-react";
+import { ChevronRight, Factory as FactoryIcon, Maximize2, Minimize2, XIcon } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
 import { useFactoriesLayout } from "./layout/factoriesLayoutContext";
-import { firstFactoryLineName } from "./lib/factoryPagePaths";
 import { WorkOrderDescriptionEditor } from "./WorkOrderDescriptionEditor";
 import { useCreateWorkOrderComposer } from "./useCreateWorkOrderComposer";
 
@@ -37,11 +33,8 @@ function CreateWorkOrderDialogSession({
   onCreated: (orderNumber: string) => void;
 }) {
   const { organizationId, factoryId, factory } = useFactoriesLayout();
-  const { canAct } = usePermissions();
   const composer = useCreateWorkOrderComposer({ organizationId, factoryId, onClose, onCreated });
-  const lines = factory?.lines ?? [];
   const [isExpanded, setIsExpanded] = useState(false);
-  const canDispatch = canAct("work_orders", "update");
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
@@ -50,7 +43,7 @@ function CreateWorkOrderDialogSession({
   };
 
   const handleClose = () => {
-    if (composer.isSaving) {
+    if (composer.isCreating) {
       return;
     }
     onClose();
@@ -99,25 +92,16 @@ function CreateWorkOrderDialogSession({
             <WorkOrderDescriptionEditor
               value={composer.description}
               maxLength={composer.maxDescriptionLength}
-              disabled={composer.isSaving}
+              disabled={composer.isCreating}
               onChange={composer.updateDescription}
             />
           </div>
         </div>
 
         <CreateWorkOrderDialogFooter
-          lines={lines}
-          canDispatch={canDispatch}
-          canSaveDraft={composer.canSaveDraft}
-          isSavingDraft={composer.isSavingDraft}
-          isSendingToLine={composer.isSendingToLine}
-          onSaveDraft={() => void composer.handleSaveDraft()}
-          onStart={() => {
-            const lineName = firstFactoryLineName({ lines });
-            if (lineName) {
-              void composer.handleSendToLine(lineName);
-            }
-          }}
+          canCreate={composer.canCreate}
+          isCreating={composer.isCreating}
+          onCreate={() => void composer.handleCreate()}
         />
       </DialogContent>
     </Dialog>
@@ -173,83 +157,27 @@ function CreateWorkOrderDialogHeader({
 }
 
 function CreateWorkOrderDialogFooter({
-  lines,
-  canDispatch,
-  canSaveDraft,
-  isSavingDraft,
-  isSendingToLine,
-  onSaveDraft,
-  onStart,
+  canCreate,
+  isCreating,
+  onCreate,
 }: {
-  lines: FactoriesFactoryLine[];
-  canDispatch: boolean;
-  canSaveDraft: boolean;
-  isSavingDraft: boolean;
-  isSendingToLine: boolean;
-  onSaveDraft: () => void;
-  onStart: () => void;
+  canCreate: boolean;
+  isCreating: boolean;
+  onCreate: () => void;
 }) {
   return (
     <div className="relative z-10 flex items-center justify-end gap-3 border-t border-border px-4 py-3">
-      <div className="flex shrink-0 items-center gap-2">
-        <LoadingButton
-          type="button"
-          variant="outline"
-          disabled={!canSaveDraft}
-          loading={isSavingDraft}
-          loadingText="Saving..."
-          onClick={onSaveDraft}
-          className="h-8 rounded-full px-4"
-          data-testid="work-order-create-draft-button"
-        >
-          Save as draft
-        </LoadingButton>
-
-        <StartWorkOrderButton
-          lines={lines}
-          canDispatch={canDispatch}
-          canSaveDraft={canSaveDraft}
-          isSendingToLine={isSendingToLine}
-          onStart={onStart}
-        />
-      </div>
-    </div>
-  );
-}
-
-function StartWorkOrderButton({
-  lines,
-  canDispatch,
-  canSaveDraft,
-  isSendingToLine,
-  onStart,
-}: {
-  lines: FactoriesFactoryLine[];
-  canDispatch: boolean;
-  canSaveDraft: boolean;
-  isSendingToLine: boolean;
-  onStart: () => void;
-}) {
-  const hasLines = Boolean(firstFactoryLineName({ lines }));
-  const isDisabled = !canDispatch || !canSaveDraft || !hasLines;
-  const tooltipMessage = !canDispatch
-    ? "You do not have permission to start tasks."
-    : "This workspace has no line to start this task on.";
-
-  return (
-    <PermissionTooltip allowed={canDispatch && hasLines} message={tooltipMessage}>
       <LoadingButton
         type="button"
-        disabled={isDisabled}
-        loading={isSendingToLine}
-        loadingText="Starting..."
-        onClick={onStart}
-        className="h-8 shrink-0 rounded-full px-4"
-        data-testid="work-order-create-start"
+        disabled={!canCreate}
+        loading={isCreating}
+        loadingText="Creating..."
+        onClick={onCreate}
+        className="h-8 rounded-full px-4"
+        data-testid="work-order-create-button"
       >
-        <Play className="size-3.5" aria-hidden />
-        Start
+        Create
       </LoadingButton>
-    </PermissionTooltip>
+    </div>
   );
 }

--- a/web_src/src/pages/factories/useCreateWorkOrderComposer.spec.tsx
+++ b/web_src/src/pages/factories/useCreateWorkOrderComposer.spec.tsx
@@ -1,15 +1,13 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createMutate, dispatchMutate, meResult } = vi.hoisted(() => ({
+const { createMutate, meResult } = vi.hoisted(() => ({
   createMutate: vi.fn(),
-  dispatchMutate: vi.fn(),
   meResult: { current: { data: null as { id: string; name: string } | null } },
 }));
 
 vi.mock("@/hooks/useFactoryData", () => ({
   useCreateWorkOrder: () => ({ mutateAsync: createMutate, isPending: false }),
-  useDispatchWorkOrder: () => ({ mutateAsync: dispatchMutate, isPending: false }),
 }));
 
 vi.mock("@/hooks/useMe", () => ({
@@ -28,13 +26,12 @@ describe("useCreateWorkOrderComposer", () => {
 
   beforeEach(() => {
     createMutate.mockReset();
-    dispatchMutate.mockReset();
     onClose.mockReset();
     onCreated.mockReset();
     meResult.current = { data: null };
   });
 
-  it("marks Send to line as loading while the work order is created", async () => {
+  it("marks Create as loading while the work order is created", async () => {
     let resolveCreate: (order: { id: string }) => void = () => {};
     createMutate.mockImplementation(
       () =>
@@ -42,7 +39,6 @@ describe("useCreateWorkOrderComposer", () => {
           resolveCreate = resolve;
         }),
     );
-    dispatchMutate.mockResolvedValue({});
 
     const { result } = renderHook(() =>
       useCreateWorkOrderComposer({
@@ -58,62 +54,14 @@ describe("useCreateWorkOrderComposer", () => {
     });
 
     act(() => {
-      void result.current.handleSendToLine("plan-and-implement");
+      void result.current.handleCreate();
     });
 
-    expect(result.current.isSendingToLine).toBe(true);
-    expect(result.current.isSavingDraft).toBe(false);
+    expect(result.current.isCreating).toBe(true);
 
     await act(async () => {
       resolveCreate({ id: "order-1" });
     });
-  });
-
-  it("creates the order and dispatches it with the line name passed to handleSendToLine", async () => {
-    createMutate.mockResolvedValue({ id: "order-1", number: "101" });
-    dispatchMutate.mockResolvedValue({});
-
-    const { result } = renderHook(() =>
-      useCreateWorkOrderComposer({
-        organizationId: "org-1",
-        factoryId: "factory-1",
-        onClose,
-        onCreated,
-      }),
-    );
-
-    act(() => {
-      result.current.updateTitle("Ship the refunds line");
-    });
-
-    await act(async () => {
-      await result.current.handleSendToLine("hotfix");
-    });
-
-    expect(createMutate).toHaveBeenCalled();
-    expect(dispatchMutate).toHaveBeenCalledWith({ orderId: "order-1", lineName: "hotfix" });
-    expect(onCreated).toHaveBeenCalledWith("101");
-  });
-
-  it("does nothing when handleSendToLine is called without a line name", async () => {
-    const { result } = renderHook(() =>
-      useCreateWorkOrderComposer({
-        organizationId: "org-1",
-        factoryId: "factory-1",
-        onClose,
-        onCreated,
-      }),
-    );
-
-    act(() => {
-      result.current.updateTitle("Ship the refunds line");
-    });
-
-    await act(async () => {
-      await result.current.handleSendToLine("");
-    });
-
-    expect(createMutate).not.toHaveBeenCalled();
   });
 
   it("seeds assigneeIds with the current user once me resolves", () => {
@@ -202,7 +150,7 @@ describe("useCreateWorkOrderComposer", () => {
     });
 
     await act(async () => {
-      await result.current.handleSaveDraft();
+      await result.current.handleCreate();
     });
 
     expect(onCreated).toHaveBeenCalledWith("101");

--- a/web_src/src/pages/factories/useCreateWorkOrderComposer.ts
+++ b/web_src/src/pages/factories/useCreateWorkOrderComposer.ts
@@ -1,4 +1,4 @@
-import { useCreateWorkOrder, useDispatchWorkOrder } from "@/hooks/useFactoryData";
+import { useCreateWorkOrder } from "@/hooks/useFactoryData";
 import { useMe } from "@/hooks/useMe";
 import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast } from "@/lib/toast";
@@ -21,18 +21,16 @@ export function useCreateWorkOrderComposer({
   onCreated,
 }: UseCreateWorkOrderComposerArgs) {
   const createWorkOrder = useCreateWorkOrder(organizationId, factoryId);
-  const dispatchWorkOrder = useDispatchWorkOrder(organizationId, factoryId);
   const { data: me } = useMe(false, organizationId);
 
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [assigneeIds, setAssigneeIdsInternal] = useState<string[]>([]);
   const [titleError, setTitleError] = useState("");
-  const [inFlightAction, setInFlightAction] = useState<"draft" | "send" | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
   const hasSeededOwner = useRef(false);
 
-  const isSaving = inFlightAction !== null;
-  const canSaveDraft = Boolean(title.trim()) && !isSaving;
+  const canCreate = Boolean(title.trim()) && !isCreating;
 
   const setAssigneeIds = (ids: string[]) => {
     hasSeededOwner.current = true;
@@ -55,58 +53,25 @@ export function useCreateWorkOrderComposer({
     onClose();
   };
 
-  const saveOrder = async () => {
+  const handleCreate = async () => {
     const trimmedTitle = title.trim();
     if (!trimmedTitle) {
       setTitleError("Title is required");
-      return null;
+      return;
     }
 
+    setIsCreating(true);
     try {
-      return await createWorkOrder.mutateAsync({
+      const order = await createWorkOrder.mutateAsync({
         title: trimmedTitle,
         description: description.trim(),
         assigneeIds,
       });
+      goToOrder(order);
     } catch (error) {
       showErrorToast(getApiErrorMessage(error, "Failed to create work order"));
-      return null;
-    }
-  };
-
-  const handleSaveDraft = async () => {
-    setInFlightAction("draft");
-    try {
-      const order = await saveOrder();
-      if (order) {
-        goToOrder(order);
-      }
     } finally {
-      setInFlightAction(null);
-    }
-  };
-
-  const handleSendToLine = async (lineName: string) => {
-    if (!lineName) {
-      return;
-    }
-
-    setInFlightAction("send");
-    try {
-      const order = await saveOrder();
-      if (!order?.id) {
-        return;
-      }
-
-      try {
-        await dispatchWorkOrder.mutateAsync({ orderId: order.id, lineName });
-        goToOrder(order);
-      } catch (error) {
-        showErrorToast(getApiErrorMessage(error, "Failed to send work order to line"));
-        goToOrder(order);
-      }
-    } finally {
-      setInFlightAction(null);
+      setIsCreating(false);
     }
   };
 
@@ -126,16 +91,13 @@ export function useCreateWorkOrderComposer({
     description,
     assigneeIds,
     titleError,
-    isSaving,
-    isSavingDraft: inFlightAction === "draft",
-    isSendingToLine: inFlightAction === "send",
-    canSaveDraft,
+    isCreating,
+    canCreate,
     maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
     maxTitleLength: MAX_TITLE_LENGTH,
     setAssigneeIds,
     updateTitle,
     updateDescription,
-    handleSaveDraft,
-    handleSendToLine,
+    handleCreate,
   };
 }


### PR DESCRIPTION
## Summary

The New task dialog had two footer actions: Save as draft and Start.
This made the user choose how to dispatch a task at the moment the
task had no title and no description yet. The choice added friction to
the most common path, which is to write the task down first.

The dialog now has one action. The Create button saves the task and
opens it. The user sends the task to a line later, from the task page.

The change also removes the line lookup and the dispatch permission
check from the dialog. Only the Start button used them.

## Test plan

- [ ] Open a workspace, then click New task.
- [ ] Confirm the footer shows only the Create button.
- [ ] Confirm Create stays disabled until the title is not empty.
- [ ] Type a title, then click Create. Confirm the new task opens.
- [ ] Confirm the task is not sent to a line.
- [ ] Open New task in a workspace that has no lines. Confirm Create is
      enabled.

Made with [Cursor](https://cursor.com)