### PR TITLE
fix: Open a ready pull request in the Implement app

### DIFF
--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunCanvases.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunCanvases.spec.ts
@@ -81,17 +81,17 @@ describe("splitRunCanvasForPhase", () => {
     expect(canvas.title).toBe("Implement");
     expect(canvas.nodes.map((node) => node.name)).toContain("Create Branch");
     expect(canvas.nodes.map((node) => node.name)).toContain("Agent - Implement from order description");
-    expect(canvas.nodes.map((node) => node.name)).toContain("Create Draft Pull Request");
+    expect(canvas.nodes.map((node) => node.name)).toContain("Create Pull Request");
     expect(canvas.nodes.map((node) => node.name)).toContain("Attach PR to Work Order");
     expect(canvas.statuses["create-branch"]).toBe("passed");
     expect(canvas.statuses["implementation-agent-no-issue"]).toBe("running");
-    expect(canvas.statuses["create-draft-pr"]).toBe("did_not_run");
+    expect(canvas.statuses["create-pr"]).toBe("did_not_run");
     expect(canvas.statuses["attach-pr-artifact"]).toBe("did_not_run");
     expect(canvas.statuses["set-pr-closure-note"]).toBe("did_not_run");
     expect(canvas.statuses["add-run-error"]).toBe("did_not_run");
   });
 
-  it("opens a draft pull request after a finished implement run", () => {
+  it("opens a pull request after a finished implement run", () => {
     const canvas = splitRunCanvasForPhase({
       id: "implement-0",
       name: "Implement",
@@ -104,15 +104,15 @@ describe("splitRunCanvasForPhase", () => {
     });
 
     expect(canvas.statuses["implementation-agent-no-issue"]).toBe("passed");
-    expect(canvas.statuses["create-draft-pr"]).toBe("passed");
+    expect(canvas.statuses["create-pr"]).toBe("passed");
     expect(canvas.statuses["attach-pr-artifact"]).toBe("passed");
     expect(canvas.statuses["set-pr-closure-note"]).toBe("passed");
     expect(canvas.statuses["add-run-error"]).toBe("did_not_run");
 
     const stream = richStreamForCanvas(canvas);
-    expect(stream.find((line) => line.id === "create-draft-pr")).toMatchObject({
+    expect(stream.find((line) => line.id === "create-pr")).toMatchObject({
       componentType: "github.createPullRequest",
-      componentName: "Create Draft Pull Request",
+      componentName: "Create Pull Request",
       action: "passed",
     });
     expect(stream.find((line) => line.id === "attach-pr-artifact")?.pullRequest?.number).toBe("482");

--- a/web_src/src/pages/home/factories/index.ts
+++ b/web_src/src/pages/home/factories/index.ts
@@ -149,7 +149,7 @@ const FACTORY_BY_ID: Record<string, FactoryDefinition> = {
   "line-implementation": buildLineApp({
     id: "line-implementation",
     title: "Implement",
-    description: "Create a branch, implement the plan, and open a draft pull request.",
+    description: "Create a branch, implement the plan, and open a pull request.",
     canvasYaml: implementationCanvasYaml,
     entrypointNodeId: "onrun-implement",
   }),

--- a/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Canvas
 metadata:
   name: Implement
-  description: Create a branch, implement the plan, and open a draft pull request.
+  description: Create a branch, implement the plan, and open a pull request.
 spec:
   edges:
     - channel: default
@@ -16,9 +16,9 @@ spec:
       targetId: implementation-agent-no-issue
     - channel: passed
       sourceId: implementation-agent-no-issue
-      targetId: create-draft-pr
+      targetId: create-pr
     - channel: default
-      sourceId: create-draft-pr
+      sourceId: create-pr
       targetId: attach-pr-artifact
     - channel: default
       sourceId: attach-pr-artifact
@@ -84,8 +84,8 @@ spec:
           git clone --depth 1 "$GITURL" "$WORKDIR"
           cd "$WORKDIR"
 
-          # Create an empty branch off the base: a single empty commit so a draft PR can be opened,
-          # with no files added.
+          # Create an empty branch off the base: a single empty commit so a pull request can be
+          # opened, with no files added.
           git checkout -b "$BRANCH"
           git commit -s --allow-empty -m "chore: initialize ${BRANCH}"
           git push -u origin "$BRANCH"
@@ -250,8 +250,8 @@ spec:
         x: 1475
         'y': 648
       isCollapsed: false
-    - id: create-draft-pr
-      name: Create Draft Pull Request
+    - id: create-pr
+      name: Create Pull Request
       type: TYPE_ACTION
       component: github.createPullRequest
       concurrency:
@@ -266,7 +266,7 @@ spec:
           <hr>
 
           Created via [SuperPlane](https://superplane.com).
-        draft: true
+        draft: false
         head: '{{ $["Create Branch"].data.result.branch }}'
         repository: '{{ install_params.appRepository }}'
         title: '{{ fromBase64(previous().data.result.title) }}'
@@ -284,11 +284,11 @@ spec:
         orderId: '{{ order().id }}'
         provider: github
         repository: '{{ install_params.appRepository }}'
-        number: '{{ $["Create Draft Pull Request"].data.number }}'
-        url: '{{ $["Create Draft Pull Request"].data._links.html.href }}'
-        title: '{{ $["Create Draft Pull Request"].data.title }}'
+        number: '{{ $["Create Pull Request"].data.number }}'
+        url: '{{ $["Create Pull Request"].data._links.html.href }}'
+        title: '{{ $["Create Pull Request"].data.title }}'
         state: open
-        externalId: '{{ $["Create Draft Pull Request"].data.id }}'
+        externalId: '{{ $["Create Pull Request"].data.id }}'
       position:
         x: 1442
         'y': 1152
@@ -302,8 +302,8 @@ spec:
         noteKey: pr-closure
         headline: Waiting for user review
         body: The pull request is open and waiting for user review. Mention @superplaneagent in a pull request comment or review to request changes. Task will automatically close when the pull request is closed or merged.
-        ctaLabel: 'Review PR #{{ $["Create Draft Pull Request"].data.number }}'
-        ctaUrl: '{{ $["Create Draft Pull Request"].data.html_url }}'
+        ctaLabel: 'Review PR #{{ $["Create Pull Request"].data.number }}'
+        ctaUrl: '{{ $["Create Pull Request"].data.html_url }}'
         showOnlyWhenWaiting: true
       position:
         x: 1442

--- a/web_src/src/pages/home/factories/lineApps.spec.ts
+++ b/web_src/src/pages/home/factories/lineApps.spec.ts
@@ -169,19 +169,19 @@ describe("setup factory line apps", () => {
       "create-branch",
       "add-branch-artifact",
       "implementation-agent-no-issue",
-      "create-draft-pr",
+      "create-pr",
       "attach-pr-artifact",
       "set-pr-closure-note",
       "add-run-error",
     ]);
     expect(implementation).toMatch(/sourceId: add-branch-artifact\n\s+targetId: implementation-agent-no-issue/);
-    expect(implementation).toMatch(/sourceId: implementation-agent-no-issue\n\s+targetId: create-draft-pr/);
+    expect(implementation).toMatch(/sourceId: implementation-agent-no-issue\n\s+targetId: create-pr/);
     expect(implementation).toMatch(/component: github\.createPullRequest[\s\S]*repository: acme\/app/);
-    expect(implementation).toMatch(/sourceId: create-draft-pr\n\s+targetId: attach-pr-artifact/);
+    expect(implementation).toMatch(/sourceId: create-pr\n\s+targetId: attach-pr-artifact/);
     expect(implementation).toMatch(/sourceId: attach-pr-artifact\n\s+targetId: set-pr-closure-note/);
     expect(implementation).toMatch(/id: attach-pr-artifact[\s\S]*component: addPullRequest/);
     expect(implementation).toMatch(
-      /id: attach-pr-artifact[\s\S]*url: '\{\{ \$\["Create Draft Pull Request"\]\.data\._links\.html\.href \}\}'/,
+      /id: attach-pr-artifact[\s\S]*url: '\{\{ \$\["Create Pull Request"\]\.data\._links\.html\.href \}\}'/,
     );
     expect(implementation).toMatch(/id: attach-pr-artifact[\s\S]*state: open/);
     expect(Object.fromEntries(canvasNodes(implementation).map((node) => [node.id, node.concurrency?.max]))).toEqual({
@@ -189,7 +189,7 @@ describe("setup factory line apps", () => {
       "create-branch": 5,
       "add-branch-artifact": 100,
       "implementation-agent-no-issue": 5,
-      "create-draft-pr": 100,
+      "create-pr": 100,
       "attach-pr-artifact": 100,
       "set-pr-closure-note": undefined,
       "add-run-error": undefined,
@@ -218,6 +218,8 @@ describe("setup factory line apps", () => {
     expect(implementation).toMatch(
       /component: github\.createPullRequest[\s\S]*\[Work Order\]\(\{\{ order\(\)\.url \}\}\)/,
     );
+    // Reviewers get a pull request they can review and merge right away.
+    expect(implementation).toMatch(/component: github\.createPullRequest[\s\S]*draft: false/);
     expect(implementation).toContain("Created via [SuperPlane](https://superplane.com)");
   });
 
@@ -233,7 +235,7 @@ describe("setup factory line apps", () => {
     expect(implementation).toContain(
       "The pull request is open and waiting for user review. Mention @superplaneagent in a pull request comment or review to request changes.",
     );
-    expect(implementation).toContain("ctaUrl: '{{ $[\"Create Draft Pull Request\"].data.html_url }}'");
+    expect(implementation).toContain("ctaUrl: '{{ $[\"Create Pull Request\"].data.html_url }}'");
     expect(implementation).toContain("showOnlyWhenWaiting: true");
   });
 


### PR DESCRIPTION
## Summary

The Implement line app opened a draft pull request. When the run finished, the work order showed a "Waiting for user review" note with a review link, but a draft pull request is not open for review or merge until a person clicks "Ready for review". The user had to do one manual step that the automation gives no reason for.

The bundled template now creates the pull request ready for review (`draft: false`), so the review note is correct as soon as the run ends. The node is renamed from `Create Draft Pull Request` to `Create Pull Request` (id `create-draft-pr` to `create-pr`), and all references follow: the two edges, the `addPullRequest` node that reads the number, URL, title and external ID, and the closure-note review link. The app description no longer says "draft".

This changes the bundled template only. Apps that are already installed keep their own materialized copy.

## Test plan

- [ ] `make check.test.ui` (or `npx vitest run src/pages/home/factories`) passes; `lineApps.spec.ts` now asserts `draft: false` on the `github.createPullRequest` node.
- [ ] Install the Implement app in a fresh workspace and open the canvas. The GitHub node is named "Create Pull Request" and the Draft checkbox is clear.
- [ ] Dispatch a work order through Plan and Implement. GitHub shows a pull request that is open for review, not a draft.
- [ ] The work order shows the pull request chip in the `open` state, and the "Waiting for user review" note links to the new pull request.

Made with [Cursor](https://cursor.com)