### PR TITLE
chore: Hide the Anthropic admin key in setup

### DIFF
--- a/pkg/integrations/claude/claude.go
+++ b/pkg/integrations/claude/claude.go
@@ -55,8 +55,9 @@ func (i *Claude) Configuration() []configuration.Field {
 			Label:       "Admin API Key",
 			Type:        configuration.FieldTypeString,
 			Sensitive:   true,
-			Description: "Admin API key, required for fetching usage and cost reports.",
+			Description: "Use this key only to fetch usage and cost reports.",
 			Required:    false,
+			Togglable:   true,
 		},
 	}
 }

--- a/pkg/integrations/claude/claude_test.go
+++ b/pkg/integrations/claude/claude_test.go
@@ -18,11 +18,12 @@ func TestClaude_Configuration(t *testing.T) {
 
 	// Use string here instead of configuration.FieldType to avoid type errors
 	expectedFields := map[string]struct {
-		Type     string
-		Required bool
+		Type      string
+		Required  bool
+		Togglable bool
 	}{
-		"apiKey":   {string(configuration.FieldTypeString), true},
-		"adminKey": {string(configuration.FieldTypeString), false},
+		"apiKey":   {string(configuration.FieldTypeString), true, false},
+		"adminKey": {string(configuration.FieldTypeString), false, true},
 	}
 
 	if len(configs) != len(expectedFields) {
@@ -41,6 +42,9 @@ func TestClaude_Configuration(t *testing.T) {
 		}
 		if field.Required != expected.Required {
 			t.Errorf("field %s: expected required %v, got %v", field.Name, expected.Required, field.Required)
+		}
+		if field.Togglable != expected.Togglable {
+			t.Errorf("field %s: expected togglable %v, got %v", field.Name, expected.Togglable, field.Togglable)
 		}
 	}
 }

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -36,6 +36,14 @@ import { useOnboardingGithubConnections } from "./useSelectNewGithubConnection";
 
 const ONBOARDING_INTEGRATIONS = ["github", ...AGENT_PROVIDER_IDS];
 
+/**
+ * Setup only needs the keys that make an agent run. The Anthropic admin key
+ * serves usage and cost reports, so users add it later in organization settings.
+ */
+const ONBOARDING_HIDDEN_CONFIGURATION_FIELDS: Record<string, string[]> = {
+  claude: ["adminKey"],
+};
+
 function useIntegrationSelections(onboarding: FactoriesFactory["onboarding"]) {
   const [selections, setSelections] = useState<IntegrationSelections>(() => initialOnboardingSelections(onboarding));
   const connected = useMemo(() => {
@@ -208,6 +216,7 @@ export function useOnboardingPageModel(args: {
     integrationNames: ONBOARDING_INTEGRATIONS,
     selections: integrations.selections,
     onSelectionsChange: integrations.setSelections,
+    hiddenConfigurationFields: ONBOARDING_HIDDEN_CONFIGURATION_FIELDS,
   });
 
   const [saving, setSaving] = useState(false);

--- a/web_src/src/pages/home/HomeIntegrationCreateDialog.tsx
+++ b/web_src/src/pages/home/HomeIntegrationCreateDialog.tsx
@@ -26,6 +26,7 @@ export function HomeIntegrationCreateDialog({
   onRefetch,
   setupReturnTo,
   preferredCreateName,
+  hiddenFieldNames,
 }: {
   open: boolean;
   dialogIntegrationName: string | null;
@@ -34,6 +35,8 @@ export function HomeIntegrationCreateDialog({
   integrationHomeHref?: string;
   setupReturnTo?: string;
   preferredCreateName?: string;
+  /** Configuration field names this flow never shows for the open integration. */
+  hiddenFieldNames?: string[];
   dialogDefinition: unknown;
   defaultDialogName: string;
   existingIntegrationNames: Set<string>;
@@ -100,6 +103,7 @@ export function HomeIntegrationCreateDialog({
       initialConfiguration={resumePendingForDialog?.spec?.configuration as Record<string, unknown> | undefined}
       setupReturnTo={setupReturnTo}
       existingIntegrationNames={existingIntegrationNames}
+      hiddenFieldNames={hiddenFieldNames}
     />
   );
 }

--- a/web_src/src/pages/home/__fixtures__/handlers.ts
+++ b/web_src/src/pages/home/__fixtures__/handlers.ts
@@ -294,13 +294,13 @@ const STORYBOOK_FACTORY_INTEGRATION_DEFINITIONS = [
     {
       name: "adminKey",
       type: "string",
-      description: "Admin API key, required for fetching usage and cost reports.",
+      description: "Use this key only to fetch usage and cost reports.",
       required: false,
       label: "Admin API Key",
       visibilityConditions: [],
       requiredConditions: [],
       sensitive: true,
-      togglable: false,
+      togglable: true,
     },
   ]),
   storybookIntegrationDefinition("openai", "OpenAI", "Generate text responses with OpenAI models", [

--- a/web_src/src/pages/home/useIntegrationConnectDialog.tsx
+++ b/web_src/src/pages/home/useIntegrationConnectDialog.tsx
@@ -45,6 +45,7 @@ export function useIntegrationConnectDialog({
   selections,
   onSelectionsChange,
   preferredCreateNames,
+  hiddenConfigurationFields,
 }: {
   organizationId: string;
   returnTo?: string;
@@ -53,6 +54,8 @@ export function useIntegrationConnectDialog({
   onSelectionsChange: (selections: IntegrationSelections) => void;
   /** When set, a new connection uses this name instead of the integration type name. */
   preferredCreateNames?: Record<string, string>;
+  /** Configuration field names the create dialog never shows, keyed by integration name. */
+  hiddenConfigurationFields?: Record<string, string[]>;
 }) {
   const { data: me } = useMe();
   const { data: connected = [], refetch } = useConnectedIntegrations(organizationId, {
@@ -207,6 +210,7 @@ export function useIntegrationConnectDialog({
         onRefetch={() => void refetch()}
         setupReturnTo={returnTo}
         preferredCreateName={preferredCreateName}
+        hiddenFieldNames={dialogIntegrationName ? hiddenConfigurationFields?.[dialogIntegrationName] : undefined}
       />
     </>
   );

--- a/web_src/src/ui/IntegrationCreateDialog/configurationFields.spec.ts
+++ b/web_src/src/ui/IntegrationCreateDialog/configurationFields.spec.ts
@@ -1,0 +1,48 @@
+import type { ConfigurationField } from "@/api-client";
+import { describe, expect, it } from "vitest";
+
+import { selectCreateStepFields, selectVisibleFields, selectWebhookStepFields } from "./configurationFields";
+
+const apiKey: ConfigurationField = { name: "apiKey", type: "string", required: true };
+const adminKey: ConfigurationField = { name: "adminKey", type: "string", required: false, togglable: true };
+const signingSecret: ConfigurationField = { name: "signingSecret", type: "string", required: false };
+const unnamed: ConfigurationField = { type: "string" };
+
+describe("selectVisibleFields", () => {
+  it("keeps every named field when nothing is hidden", () => {
+    expect(selectVisibleFields([apiKey, adminKey], [])).toEqual([apiKey, adminKey]);
+  });
+
+  it("drops hidden fields so onboarding never renders them", () => {
+    expect(selectVisibleFields([apiKey, adminKey], ["adminKey"])).toEqual([apiKey]);
+  });
+
+  it("drops fields without a name", () => {
+    expect(selectVisibleFields([apiKey, unnamed], [])).toEqual([apiKey]);
+  });
+});
+
+describe("selectCreateStepFields", () => {
+  it("uses every visible field when the steps are not split", () => {
+    expect(selectCreateStepFields([apiKey, signingSecret], undefined)).toEqual([apiKey, signingSecret]);
+  });
+
+  it("keeps only the requested fields when the steps are split", () => {
+    expect(selectCreateStepFields([apiKey, signingSecret], ["apiKey"])).toEqual([apiKey]);
+  });
+});
+
+describe("selectWebhookStepFields", () => {
+  it("shows the webhook secrets when the steps are not split", () => {
+    expect(selectWebhookStepFields([apiKey, signingSecret], undefined)).toEqual([signingSecret]);
+  });
+
+  it("shows the remaining fields when the steps are split", () => {
+    expect(selectWebhookStepFields([apiKey, signingSecret], ["apiKey"])).toEqual([signingSecret]);
+  });
+
+  it("never shows a hidden field, because it is not visible", () => {
+    const visible = selectVisibleFields([apiKey, adminKey], ["adminKey"]);
+    expect(selectWebhookStepFields(visible, ["apiKey"])).toEqual([]);
+  });
+});

--- a/web_src/src/ui/IntegrationCreateDialog/configurationFields.ts
+++ b/web_src/src/ui/IntegrationCreateDialog/configurationFields.ts
@@ -1,0 +1,31 @@
+import type { ConfigurationField } from "@/api-client";
+
+const WEBHOOK_SECRET_FIELD_NAMES = ["signingSecret", "webhookSigningSecret"];
+
+/** Named fields the dialog may render, minus the ones the caller hides. */
+export function selectVisibleFields(
+  fields: ConfigurationField[] | undefined,
+  hiddenFieldNames: string[],
+): ConfigurationField[] {
+  return (fields ?? []).filter((field) => Boolean(field.name) && !hiddenFieldNames.includes(field.name!));
+}
+
+/** Fields shown in the create step. Without a split, the step owns every visible field. */
+export function selectCreateStepFields(
+  visibleFields: ConfigurationField[],
+  initialStepFieldNames: string[] | undefined,
+): ConfigurationField[] {
+  if (!initialStepFieldNames?.length) return visibleFields;
+  return visibleFields.filter((field) => initialStepFieldNames.includes(field.name!));
+}
+
+/** Fields shown after the webhook URL: the remainder of a split, else the webhook secrets. */
+export function selectWebhookStepFields(
+  visibleFields: ConfigurationField[],
+  initialStepFieldNames: string[] | undefined,
+): ConfigurationField[] {
+  if (initialStepFieldNames?.length) {
+    return visibleFields.filter((field) => !initialStepFieldNames.includes(field.name!));
+  }
+  return visibleFields.filter((field) => WEBHOOK_SECRET_FIELD_NAMES.includes(field.name!));
+}

--- a/web_src/src/ui/IntegrationCreateDialog/index.tsx
+++ b/web_src/src/ui/IntegrationCreateDialog/index.tsx
@@ -16,6 +16,7 @@ import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { useUpdateIntegration } from "@/hooks/useIntegrations";
 import { UsageLimitAlert } from "@/components/UsageLimitAlert";
 import { Alert, AlertDescription, AlertTitle } from "@/ui/alert";
+import { selectCreateStepFields, selectVisibleFields, selectWebhookStepFields } from "./configurationFields";
 import { createWithGeneratedName, useGeneratedIntegrationName } from "./generatedName";
 import { IntegrationCreateDialogFooter } from "./IntegrationCreateDialogFooter";
 import { useBrowserActionSetup } from "./useBrowserActionSetup";
@@ -50,6 +51,8 @@ export interface IntegrationCreateDialogProps {
   instructionsEndBeforeHeading?: string;
   /** If set, only these configuration field names are shown in the initial create step; the rest are shown in the webhook completion step. */
   initialStepFieldNames?: string[];
+  /** Configuration field names this flow never shows, e.g. optional keys that would distract during onboarding. */
+  hiddenFieldNames?: string[];
   /** Optional custom description for the webhook completion step. */
   webhookStepDescription?: ReactNode;
   /** Pre-created integration state for resuming a flow started inline (e.g. browser action after inline creation). */
@@ -65,6 +68,7 @@ export interface IntegrationCreateDialogProps {
 }
 
 const NO_EXISTING_NAMES: Set<string> = new Set();
+const NO_HIDDEN_FIELDS: string[] = [];
 
 export function IntegrationCreateDialog({
   open,
@@ -79,6 +83,7 @@ export function IntegrationCreateDialog({
   onCapabilitySetupRequired,
   instructionsEndBeforeHeading,
   initialStepFieldNames,
+  hiddenFieldNames = NO_HIDDEN_FIELDS,
   webhookStepDescription,
   initialCreatedIntegrationId,
   initialBrowserAction,
@@ -109,11 +114,13 @@ export function IntegrationCreateDialog({
     return idx >= 0 ? raw.slice(0, idx).trim() : raw;
   }, [integrationDefinition?.instructions, instructionsEndBeforeHeading]);
 
-  const configurationFields = useMemo(() => {
-    const fields = integrationDefinition?.configuration ?? [];
-    if (!initialStepFieldNames?.length) return fields;
-    return fields.filter((f) => f.name && initialStepFieldNames.includes(f.name));
-  }, [integrationDefinition?.configuration, initialStepFieldNames]);
+  const { createStepFields, webhookStepFields } = useMemo(() => {
+    const visibleFields = selectVisibleFields(integrationDefinition?.configuration, hiddenFieldNames);
+    return {
+      createStepFields: selectCreateStepFields(visibleFields, initialStepFieldNames),
+      webhookStepFields: selectWebhookStepFields(visibleFields, initialStepFieldNames),
+    };
+  }, [integrationDefinition?.configuration, hiddenFieldNames, initialStepFieldNames]);
 
   const isGitHub = integrationDefinition?.name === "github";
   const {
@@ -360,27 +367,21 @@ export function IntegrationCreateDialog({
                   </Button>
                 </div>
               </div>
-              {(integrationDefinition?.configuration ?? [])
-                .filter((f: ConfigurationField) => {
-                  if (!f.name) return false;
-                  if (initialStepFieldNames?.length) return !initialStepFieldNames.includes(f.name);
-                  return f.name === "signingSecret" || f.name === "webhookSigningSecret";
-                })
-                .map((field) => (
-                  <ConfigurationFieldRenderer
-                    key={field.name}
-                    field={field}
-                    value={configuration[field.name!]}
-                    onChange={(value) =>
-                      setConfiguration((prev) => ({
-                        ...prev,
-                        [field.name!]: value,
-                      }))
-                    }
-                    allValues={configuration}
-                    organizationId={organizationId}
-                  />
-                ))}
+              {webhookStepFields.map((field: ConfigurationField) => (
+                <ConfigurationFieldRenderer
+                  key={field.name}
+                  field={field}
+                  value={configuration[field.name!]}
+                  onChange={(value) =>
+                    setConfiguration((prev) => ({
+                      ...prev,
+                      [field.name!]: value,
+                    }))
+                  }
+                  allValues={configuration}
+                  organizationId={organizationId}
+                />
+              ))}
             </>
           ) : (
             <>
@@ -399,9 +400,9 @@ export function IntegrationCreateDialog({
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">A unique name for this integration</p>
                 </div>
               )}
-              {configurationFields.length > 0 && (
+              {createStepFields.length > 0 && (
                 <div className="space-y-4">
-                  {configurationFields.map((field: ConfigurationField) => {
+                  {createStepFields.map((field: ConfigurationField) => {
                     if (!field.name) return null;
                     return (
                       <ConfigurationFieldRenderer

--- a/web_src/src/ui/configurationFieldRenderer/index.spec.ts
+++ b/web_src/src/ui/configurationFieldRenderer/index.spec.ts
@@ -14,6 +14,43 @@ const runTitleField: ConfigurationField = {
   placeholder: "{{ root().data.context }}",
 };
 
+describe("ConfigurationFieldRenderer togglable Claude admin key", () => {
+  const adminKeyField: ConfigurationField = {
+    name: "adminKey",
+    type: "string",
+    label: "Admin API Key",
+    description: "Use this key only to fetch usage and cost reports.",
+    required: false,
+    sensitive: true,
+    togglable: true,
+  };
+
+  it("hides the admin key input until the optional setting is enabled", () => {
+    render(
+      React.createElement(ConfigurationFieldRenderer, {
+        field: adminKeyField,
+        value: undefined,
+        onChange: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByText("Admin API Key")).toBeInTheDocument();
+    expect(screen.queryByTestId("string-field-adminkey")).not.toBeInTheDocument();
+  });
+
+  it("shows the admin key input when the optional setting is enabled", () => {
+    render(
+      React.createElement(ConfigurationFieldRenderer, {
+        field: adminKeyField,
+        value: "",
+        onChange: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByTestId("string-field-adminkey")).toBeInTheDocument();
+  });
+});
+
 describe("ConfigurationFieldRenderer run title copy", () => {
   it("explains disabled trigger run title customization", () => {
     render(


### PR DESCRIPTION
## Summary

Workspace setup asked for two Anthropic keys. Only the API key lets an agent run. The admin key gives usage and cost reports, so it made the connect step longer and less clear for a new user.

Setup now hides the admin key completely. The connect dialog accepts a list of configuration fields that it must not show, and workspace setup passes `adminKey` for Anthropic. Organization integration settings keep the field, behind an optional switch.

## Test plan

- [ ] Open workspace setup and go to the agent step.
- [ ] Select **Connect Anthropic**. Confirm the dialog shows only the API key.
- [ ] Connect with a valid API key. Confirm the integration becomes ready.
- [ ] Open **Organization settings > Integrations** and connect Claude. Confirm the **Admin API Key** switch is present and off.
- [ ] Enable the switch, enter an admin key, and save. Confirm the value persists.
- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/integrations/claude` and `make check.test.ui`.


Made with [Cursor](https://cursor.com)