### PR TITLE
feat: Add task assignees as commit co-authors

### DIFF
--- a/docs/design/factory.md
+++ b/docs/design/factory.md
@@ -60,7 +60,9 @@ references it (e.g. `none(order().artifacts, {#.type == "pr"})`).
 `order().comments` is likewise a list field loaded lazily only when the
 expression references it (e.g. `len(order().comments)`), returning each
 comment as `{id, body, author, created_at, run}` decoded from the
-`order.comment.added` events. `root().data.work_order` remains the onRun
+`order.comment.added` events. `order().assignees` is a list field loaded
+lazily only when the expression references it, returning each assignee as
+`{id, name, email}`. `root().data.work_order` remains the onRun
 snapshot and does not include artifacts or comments.
 
 ## Work order lifecycle

--- a/pkg/configuration/expressionvalidation/order_references.go
+++ b/pkg/configuration/expressionvalidation/order_references.go
@@ -23,6 +23,10 @@ func ExpressionUsesOrderPullRequests(expression string) (bool, error) {
 	return expressionReferencesOrderProperty(expression, "pullRequests")
 }
 
+func ExpressionUsesOrderAssignees(expression string) (bool, error) {
+	return expressionReferencesOrderProperty(expression, "assignees")
+}
+
 // ExpressionUsesOrderURL reports whether the expression accesses order().url
 // (dot or bracket). Used to resolve the work order permalink only when needed,
 // since it costs an extra lookup of the factory that owns the order.

--- a/pkg/configuration/expressionvalidation/order_references_test.go
+++ b/pkg/configuration/expressionvalidation/order_references_test.go
@@ -63,6 +63,38 @@ func TestExpressionUsesOrderURL(t *testing.T) {
 	}
 }
 
+func TestExpressionUsesOrderAssignees(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "order only", raw: `order()`, want: false},
+		{name: "order id", raw: `order().id`, want: false},
+		{name: "order comments", raw: `order().comments`, want: false},
+		{name: "dot assignees", raw: `order().assignees`, want: true},
+		{name: "bracket assignees", raw: `order()["assignees"]`, want: true},
+		{name: "indexed", raw: `order().assignees[0]`, want: true},
+		{name: "nested email", raw: `order().assignees[0].email`, want: true},
+		{name: "mixed bracket", raw: `order()["assignees"][0]["name"]`, want: true},
+		{name: "len", raw: `len(order().assignees)`, want: true},
+		{name: "filter", raw: `filter(order().assignees, {#.email != ""})`, want: true},
+		{name: "unrelated", raw: `root().data.work_order`, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExpressionUsesOrderAssignees(tc.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestExpressionUsesOrderComments(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/grpc/actions/factories/pr_feedback_graph_test.go
+++ b/pkg/grpc/actions/factories/pr_feedback_graph_test.go
@@ -106,6 +106,10 @@ func Test__BuildPRFeedbackCanvas(t *testing.T) {
 		assert.Contains(t, checkout, `git fetch origin "pull/${PR_NUMBER}/head:${PR_HEAD}"`)
 		assert.Contains(t, checkout, `git checkout "${PR_HEAD}"`)
 		assert.NotContains(t, checkout, "pr-feedback")
+
+		assert.Contains(t, runnerEnv(t, runner, "COAUTHORS"), "order().assignees")
+		dco := runnerStepCommand(t, runner, "Set Up DCO Signing")
+		assert.Contains(t, dco, `${COAUTHORS:-}`)
 	})
 
 	t.Run("the runner names the model it runs", func(t *testing.T) {

--- a/pkg/grpc/actions/factories/pr_feedback_template.go
+++ b/pkg/grpc/actions/factories/pr_feedback_template.go
@@ -169,6 +169,10 @@ func prFeedbackPRHeadExpression() string {
 	return "{{ root().data.pull_request?.head?.ref ?? \"\" }}"
 }
 
+func prFeedbackCoauthorsExpression() string {
+	return `{{ order() == nil ? "" : join(map(filter(order().assignees, {#.email != ""}), "Co-authored-by: " + #.name + " <" + #.email + ">"), "\n") }}`
+}
+
 func prFeedbackRunnerConcurrency() *yaml.ConcurrencySpec {
 	max := 1
 	return &yaml.ConcurrencySpec{
@@ -197,6 +201,11 @@ func prFeedbackRunnerConfiguration(request prFeedbackBuildRequest) map[string]an
 			map[string]any{
 				"name":        "PR_HEAD",
 				"value":       prFeedbackPRHeadExpression(),
+				"valueSource": "literal",
+			},
+			map[string]any{
+				"name":        "COAUTHORS",
+				"value":       prFeedbackCoauthorsExpression(),
 				"valueSource": "literal",
 			},
 		},
@@ -264,6 +273,9 @@ func prFeedbackRunnerSteps() []any {
 			"command": strings.Join([]string{
 				"cat > .git/hooks/prepare-commit-msg <<'HOOK'",
 				`printf '\n%s\n' "Signed-off-by: SuperPlane Agent <superplaneagent@superplane.com>" >> "$1"`,
+				`if [ -n "${COAUTHORS:-}" ]; then`,
+				`  printf '\n%s\n' "$COAUTHORS" >> "$1"`,
+				"fi",
 				"HOOK",
 				"",
 				"chmod +x .git/hooks/prepare-commit-msg",

--- a/pkg/models/factory_work_order.go
+++ b/pkg/models/factory_work_order.go
@@ -505,6 +505,21 @@ func (o *FactoryWorkOrder) ReplaceAssignees(tx *gorm.DB, assigneeIDs []uuid.UUID
 	return tx.Create(&assignees).Error
 }
 
+func (o *FactoryWorkOrder) ListAssignees(tx *gorm.DB) ([]FactoryWorkOrderAssignee, error) {
+	assignees := []FactoryWorkOrderAssignee{}
+	err := tx.
+		Preload("User").
+		Where("work_order_id = ?", o.ID).
+		Order("created_at ASC").
+		Find(&assignees).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return assignees, nil
+}
+
 func (o *FactoryWorkOrder) ListEvents(tx *gorm.DB, limit int, before *time.Time) ([]FactoryWorkOrderEvent, error) {
 	query := tx.Where("work_order_id = ?", o.ID)
 

--- a/pkg/models/factory_work_order_assignees_test.go
+++ b/pkg/models/factory_work_order_assignees_test.go
@@ -61,6 +61,17 @@ func TestFactoryWorkOrder_UpdateAssignees(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, loaded.Assignees, 2)
 
+	t.Run("list assignees returns users in assignment order", func(t *testing.T) {
+		listed, err := order.ListAssignees(database.Conn())
+		require.NoError(t, err)
+		require.Len(t, listed, 2)
+		assert.Equal(t, userID, listed[0].UserID)
+		assert.Equal(t, secondUser.ID, listed[1].UserID)
+		require.NotNil(t, listed[0].User)
+		require.NotNil(t, listed[1].User)
+		assert.Equal(t, secondUser.Name, listed[1].User.Name)
+	})
+
 	t.Run("unassigning everyone actually clears all assignees", func(t *testing.T) {
 		require.NoError(t, loaded.UpdateAssignees(database.Conn(), nil, userID))
 

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -1013,8 +1013,8 @@ func (b *NodeConfigurationBuilder) resolveRunPayload() (any, error) {
 
 // resolveOrderPayload exposes the work order driving this run via order().
 // Returns nil when the run is not attached to a factory work-order execution.
-// The url, artifacts, and comments are loaded only when the expression AST
-// references order().url / order().artifacts / order().comments.
+// The url, artifacts, comments, and assignees are loaded only when the expression AST
+// references order().url / order().artifacts / order().comments / order().assignees.
 func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, error) {
 	if b.rootEventID == nil {
 		return nil, nil
@@ -1129,6 +1129,23 @@ func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, 
 		payload["pullRequests"] = payloads
 	}
 
+	usesAssignees, err := expressionvalidation.ExpressionUsesOrderAssignees(expression)
+	if err != nil {
+		return nil, fmt.Errorf("order() could not inspect expression: %w", err)
+	}
+	if usesAssignees {
+		assignees, err := order.ListAssignees(b.tx)
+		if err != nil {
+			return nil, fmt.Errorf("order() could not load assignees: %w", err)
+		}
+
+		assigneePayloads := make([]any, 0, len(assignees))
+		for i := range assignees {
+			assigneePayloads = append(assigneePayloads, assigneeExpressionPayload(&assignees[i]))
+		}
+		payload["assignees"] = assigneePayloads
+	}
+
 	return payload, nil
 }
 
@@ -1152,6 +1169,19 @@ func attachOrderSource(tx *gorm.DB, order *models.FactoryWorkOrder, payload map[
 		payload["source"] = normalizeExpressionValue(source)
 	}
 	return nil
+}
+
+func assigneeExpressionPayload(assignee *models.FactoryWorkOrderAssignee) map[string]any {
+	payload := map[string]any{
+		"id":    assignee.UserID.String(),
+		"name":  "",
+		"email": "",
+	}
+	if assignee.User != nil {
+		payload["name"] = assignee.User.Name
+		payload["email"] = assignee.User.GetEmail()
+	}
+	return payload
 }
 
 func artifactExpressionPayload(artifact *models.FactoryWorkOrderArtifact) (map[string]any, error) {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -313,6 +313,7 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		assert.NotContains(t, payload, "url")
 		assert.NotContains(t, payload, "artifacts")
 		assert.NotContains(t, payload, "comments")
+		assert.NotContains(t, payload, "assignees")
 
 		source, ok := payload["source"].(map[string]any)
 		require.True(t, ok)
@@ -446,6 +447,38 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		secondRunID, err := builder.ResolveExpression(`order().comments[1].run.id`)
 		require.NoError(t, err)
 		assert.Equal(t, run.ID.String(), secondRunID)
+	})
+
+	t.Run("assignees are omitted until referenced and empty when none are assigned", func(t *testing.T) {
+		full, err := builder.ResolveExpression(`order().assignees`)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, full)
+
+		count, err := builder.ResolveExpression(`len(order().assignees)`)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("assigned people expose name and email for commit co-authors", func(t *testing.T) {
+		require.NoError(t, order.UpdateAssignees(database.Conn(), []uuid.UUID{r.User}, r.User))
+
+		full, err := builder.ResolveExpression(`order().assignees`)
+		require.NoError(t, err)
+		assignees, ok := full.([]any)
+		require.True(t, ok)
+		require.Len(t, assignees, 1)
+
+		first, ok := assignees[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, r.User.String(), first["id"])
+		assert.Equal(t, r.UserModel.Name, first["name"])
+		assert.Equal(t, r.UserModel.GetEmail(), first["email"])
+
+		trailer, err := builder.ResolveExpression(
+			`join(map(filter(order().assignees, {#.email != ""}), "Co-authored-by: " + #.name + " <" + #.email + ">"), "\n")`,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "Co-authored-by: "+r.UserModel.Name+" <"+r.UserModel.GetEmail()+">", trailer)
 	})
 
 	t.Run("none and any over artifact types", func(t *testing.T) {

--- a/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
+++ b/web_src/src/pages/home/factories/line-apps/implementation.canvas.yaml
@@ -58,6 +58,9 @@ spec:
           - name: BASE
             value: main
             valueSource: literal
+          - name: COAUTHORS
+            value: '{{ join(map(filter(order().assignees, {#.email != ""}), "Co-authored-by: " + #.name + " <" + #.email + ">"), "\n") }}'
+            valueSource: literal
         execution_mode: host
         execution_timeout_seconds: 3600
         machine_type: e1-large-amd64
@@ -83,6 +86,14 @@ spec:
 
           git clone --depth 1 "$GITURL" "$WORKDIR"
           cd "$WORKDIR"
+
+          cat > .git/hooks/prepare-commit-msg <<'HOOK'
+          printf '\n%s\n' "Signed-off-by: SuperPlane Agent <superplaneagent@superplane.com>" >> "$1"
+          if [ -n "${COAUTHORS:-}" ]; then
+            printf '\n%s\n' "$COAUTHORS" >> "$1"
+          fi
+          HOOK
+          chmod +x .git/hooks/prepare-commit-msg
 
           # Create an empty branch off the base: a single empty commit so a pull request can be
           # opened, with no files added.
@@ -141,6 +152,9 @@ spec:
           - name: PLAN
             value: '{{ toBase64(find(order().artifacts, {#.type == "markdown" && #.data.title == "PLAN.md"}).data.body) }}'
             valueSource: literal
+          - name: COAUTHORS
+            value: '{{ join(map(filter(order().assignees, {#.email != ""}), "Co-authored-by: " + #.name + " <" + #.email + ">"), "\n") }}'
+            valueSource: literal
         executionTimeoutSeconds: 3600
         machineType: e1-large-amd64
         model: sonnet
@@ -174,6 +188,9 @@ spec:
             command: |-
               cat > .git/hooks/prepare-commit-msg <<'HOOK'
               printf '\n%s\n' "Signed-off-by: SuperPlane Agent <superplaneagent@superplane.com>" >> "$1"
+              if [ -n "${COAUTHORS:-}" ]; then
+                printf '\n%s\n' "$COAUTHORS" >> "$1"
+              fi
               HOOK
 
               chmod +x .git/hooks/prepare-commit-msg


### PR DESCRIPTION
## Summary

An agent commits all factory work as SuperPlane Agent. The person who owns the task gets no attribution in the repository history, so `git log` and `git blame` do not show who asked for the change. GitHub also does not show the task owner as a contributor on the pull request.

This change gives credit to the assignees of a task:

- `order().assignees` is now available in canvas expressions. It gives the id, name, and email of each assigned person. The list loads only when an expression uses it, in the same way as `order().artifacts` and `order().comments`.
- The Implement line app and the "Address PR feedback" runner put these people into a `COAUTHORS` environment variable.
- The `prepare-commit-msg` hook adds one `Co-authored-by: Name <email>` trailer for each person that has an email address.

SuperPlane Agent stays the author of the commit. A task with no assignees, or an assignee with no email address, gives no trailer.

New workspaces and regenerated PR feedback apps get this behavior. An existing Implement canvas must be updated to get the new hook.

## Test plan

- [ ] `make test PKG_TEST_PACKAGES="./pkg/configuration/expressionvalidation ./pkg/models ./pkg/workers/contexts ./pkg/grpc/actions/factories"` passes.
- [ ] Create a workspace, assign a task to a user that has an email address, and start the Implement line. The pushed commits show a `Co-authored-by` trailer for that user.
- [ ] Start a task with no assignee. The commits show no `Co-authored-by` trailer and the commit message stays valid.
- [ ] Mention `@superplaneagent` on a pull request of an assigned task. The new commits show the same trailer.
- [ ] The commit author stays SuperPlane Agent, and the `Signed-off-by` trailer is still present.


Made with [Cursor](https://cursor.com)