### PR TITLE
fix: check for CLI updates once per day instead of on every command

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	if cli.ShouldStartUpdateCheck(os.Args[1:]) {
-		cli.StartUpdateCheck()
+		cli.StartUpdateCheck(os.Args[1:])
 	}
 	err := cli.RootCmd.Execute()
 	cli.PrintUpdateNotice()

--- a/pkg/cli/update_check.go
+++ b/pkg/cli/update_check.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+)
+
+const (
+	// ConfigKeyLastUpdateCheck stores, in the CLI configuration file, when the
+	// last check for a new CLI release happened.
+	ConfigKeyLastUpdateCheck = "lastUpdateCheck"
+
+	// updateCheckInterval is how long the CLI waits between two update checks.
+	updateCheckInterval = 24 * time.Hour
+)
+
+// The update check runs before Cobra initializes the global viper instance, so
+// the timestamp is read and written through a dedicated instance. Writing
+// through the global one at this point would persist an empty configuration
+// over the user's file.
+
+func updateCheckConfigPath(args []string) string {
+	if path := configPathFromArgs(args); path != "" {
+		return path
+	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/.superplane.yaml", home)
+}
+
+func configPathFromArgs(args []string) string {
+	for i, arg := range args {
+		if arg == "--config" && i+1 < len(args) {
+			return args[i+1]
+		}
+
+		if value, found := strings.CutPrefix(arg, "--config="); found {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func readLastUpdateCheck(path string) time.Time {
+	if path == "" {
+		return time.Time{}
+	}
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	if err := v.ReadInConfig(); err != nil {
+		return time.Time{}
+	}
+
+	return v.GetTime(ConfigKeyLastUpdateCheck)
+}
+
+// recordLastUpdateCheck is best effort: a configuration file that cannot be
+// written must not break the command the user actually ran.
+func recordLastUpdateCheck(path string, now time.Time) {
+	if path == "" {
+		return
+	}
+
+	v := viper.New()
+	v.SetConfigFile(path)
+
+	// Existing settings are read back first so they survive the write.
+	_ = v.ReadInConfig()
+	v.Set(ConfigKeyLastUpdateCheck, now.UTC().Format(time.RFC3339))
+	_ = v.WriteConfig()
+}
+
+func dueForUpdateCheck(lastCheck, now time.Time) bool {
+	if lastCheck.IsZero() {
+		return true
+	}
+
+	// A timestamp in the future means a clock change or a hand-edited config.
+	// Checking now is better than staying silent until the clock catches up.
+	if lastCheck.After(now) {
+		return true
+	}
+
+	return now.Sub(lastCheck) >= updateCheckInterval
+}

--- a/pkg/cli/update_check_test.go
+++ b/pkg/cli/update_check_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDueForUpdateCheck(t *testing.T) {
+	now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		lastCheck time.Time
+		expected  bool
+	}{
+		{"never checked", time.Time{}, true},
+		{"checked an hour ago", now.Add(-1 * time.Hour), false},
+		{"checked just before the interval", now.Add(-23 * time.Hour), false},
+		{"checked exactly one interval ago", now.Add(-updateCheckInterval), true},
+		{"checked two days ago", now.Add(-48 * time.Hour), true},
+		{"timestamp in the future", now.Add(1 * time.Hour), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, dueForUpdateCheck(tt.lastCheck, now))
+		})
+	}
+}
+
+func TestConfigPathFromArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{"no config flag", []string{"apps", "list"}, ""},
+		{"separate value", []string{"--config", "/tmp/other.yaml", "apps"}, "/tmp/other.yaml"},
+		{"inline value", []string{"--config=/tmp/other.yaml"}, "/tmp/other.yaml"},
+		{"flag without value", []string{"apps", "--config"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, configPathFromArgs(tt.args))
+		})
+	}
+}
+
+func TestRecordLastUpdateCheckKeepsExistingConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".superplane.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("output: json\n"), 0600))
+
+	now := time.Now().UTC().Truncate(time.Second)
+	recordLastUpdateCheck(path, now)
+
+	require.Equal(t, now, readLastUpdateCheck(path).UTC())
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	require.NoError(t, v.ReadInConfig())
+	require.Equal(t, "json", v.GetString(ConfigKeyOutput))
+}
+
+func TestReadLastUpdateCheckWithoutConfigFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".superplane.yaml")
+
+	require.True(t, readLastUpdateCheck(path).IsZero())
+	require.True(t, readLastUpdateCheck("").IsZero())
+}
+
+func TestShouldStartUpdateCheckHonorsInterval(t *testing.T) {
+	originalVersion := Version
+	defer func() { Version = originalVersion }()
+	Version = "v0.13.0"
+
+	path := filepath.Join(t.TempDir(), ".superplane.yaml")
+	args := []string{"--config", path, "whoami"}
+
+	require.True(t, ShouldStartUpdateCheck(args), "first run should check for updates")
+
+	StartUpdateCheck(args)
+	require.False(t, ShouldStartUpdateCheck(args), "a second run on the same day should not check again")
+
+	recordLastUpdateCheck(path, time.Now().Add(-25*time.Hour))
+	require.True(t, ShouldStartUpdateCheck(args), "a run on the next day should check again")
+}

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -45,12 +45,15 @@ func init() {
 	RootCmd.Flags().Bool("version", false, "Print the CLI version")
 }
 
-// StartUpdateCheck begins an async check for a newer CLI version.
-// It is a no-op for dev builds.
-func StartUpdateCheck() {
+// StartUpdateCheck begins an async check for a newer CLI version and records
+// the check in the CLI configuration file, so commands run during the rest of
+// the day skip it. It is a no-op for dev builds.
+func StartUpdateCheck(args []string) {
 	if isDevBuild() {
 		return
 	}
+
+	recordLastUpdateCheck(updateCheckConfigPath(args), time.Now())
 
 	ch := make(chan *updateInfo, 1)
 	updateCheckResult = ch
@@ -60,7 +63,17 @@ func StartUpdateCheck() {
 	}()
 }
 
+// ShouldStartUpdateCheck reports whether the command being run is one that can
+// afford an update check, and whether enough time has passed since the last one.
 func ShouldStartUpdateCheck(args []string) bool {
+	if !isUpdateCheckableCommand(args) {
+		return false
+	}
+
+	return dueForUpdateCheck(readLastUpdateCheck(updateCheckConfigPath(args)), time.Now())
+}
+
+func isUpdateCheckableCommand(args []string) bool {
 	if isDevBuild() {
 		return false
 	}

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"testing"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,6 +61,12 @@ func TestShouldStartUpdateCheck(t *testing.T) {
 	defer func() { Version = original }()
 
 	Version = "v0.13.0"
+
+	// Point the CLI at an empty home so the developer's own configuration file
+	// does not decide whether an update check is due.
+	t.Setenv("HOME", t.TempDir())
+	homedir.Reset()
+	defer homedir.Reset()
 
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## What changed

The CLI now stores a `lastUpdateCheck` timestamp in the CLI configuration file and only checks for a new release when at least 24 hours have passed since the previous check.

  ## Why

Every command was firing an extra HTTP request to the GitHub releases API after it finished, which makes the CLI feel slow for no real benefit.

Closes #5000

## How

- `ShouldStartUpdateCheck` keeps its command filtering (now in `isUpdateCheckableCommand`) and additionally gates on the last check time.
- `StartUpdateCheck` records the timestamp before firing the background check.
- The timestamp is read and written through a dedicated viper instance. The update check runs before Cobra initializes the global viper instance, so writing through the global one at that point would persist an empty configuration over the user's file. The dedicated instance reads the existing file first, so other settings survive the write.
- Writing is best effort: a configuration file that cannot be written does not break the command the user ran.
  - A timestamp in the future (clock change or hand-edited config) is treated as due, instead of muting the check until the clock catches up.

## Tests

Added `pkg/cli/update_check_test.go` covering the interval logic, the `--config` path resolution, config preservation on write, and the skip-then-check-again cycle. `TestShouldStartUpdateCheck` now points `HOME` at a temp dir so the developer's own config file does not affect the result.