### PR TITLE
fix: Use millions notation for large token counts

### DIFF
--- a/web_src/src/pages/factories/pages/LineVelocityPanel.tsx
+++ b/web_src/src/pages/factories/pages/LineVelocityPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/chart";
 import { SegmentedNav } from "@/ui/SegmentedNav";
 import { buildDailyVelocity } from "./buildDailyVelocity";
+import { formatTokens } from "./formatTokens";
 import { VELOCITY_BY_PERIOD, type VelocityPeriodDays, type VelocityPeriodStats } from "./lineVelocityMockData";
 
 const PERIOD_OPTIONS: { value: string; label: string; days: VelocityPeriodDays }[] = [
@@ -23,14 +24,6 @@ const dailyVelocityChartConfig = {
   failed: { label: "Failed", color: "#ef4444" },
   inProgress: { label: "Still in progress", color: "#60a5fa" },
 } satisfies ChartConfig;
-
-function formatTokens(value: number) {
-  if (value >= 1000) {
-    const thousands = value / 1000;
-    return `${thousands % 1 === 0 ? thousands.toFixed(0) : thousands.toFixed(1)}k`;
-  }
-  return String(value);
-}
 
 function formatUsd(value: number) {
   return `$${value.toFixed(2)}`;

--- a/web_src/src/pages/factories/pages/VelocityLoadedView.tsx
+++ b/web_src/src/pages/factories/pages/VelocityLoadedView.tsx
@@ -5,6 +5,7 @@ import {
   type FactoryVelocityFlow,
   type FactoryVelocityFlowPeriodDays,
 } from "../lib/factoryVelocityFlow";
+import { formatTokens } from "./formatTokens";
 import {
   CostSparkline,
   DailyOutputChart,
@@ -75,14 +76,6 @@ export interface VelocityLoadedViewProps {
 
 function formatUsd(value: number) {
   return `$${value.toFixed(2)}`;
-}
-
-function formatTokens(value: number) {
-  if (value >= 1000) {
-    const thousands = value / 1000;
-    return `${thousands % 1 === 0 ? thousands.toFixed(0) : thousands.toFixed(1)}k`;
-  }
-  return String(value);
 }
 
 function formatPct(value: number) {

--- a/web_src/src/pages/factories/pages/formatTokens.spec.ts
+++ b/web_src/src/pages/factories/pages/formatTokens.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTokens } from "./formatTokens";
+
+describe("formatTokens", () => {
+  it("keeps the raw count below one thousand", () => {
+    expect(formatTokens(0)).toBe("0");
+    expect(formatTokens(999)).toBe("999");
+  });
+
+  it("uses k notation for thousands", () => {
+    expect(formatTokens(1000)).toBe("1k");
+    expect(formatTokens(2700)).toBe("2.7k");
+    expect(formatTokens(18400)).toBe("18.4k");
+  });
+
+  it("uses millions notation at or above one million", () => {
+    expect(formatTokens(1_000_000)).toBe("1M");
+    expect(formatTokens(14_616_000)).toBe("14.6M");
+  });
+});

--- a/web_src/src/pages/factories/pages/formatTokens.ts
+++ b/web_src/src/pages/factories/pages/formatTokens.ts
@@ -1,0 +1,13 @@
+function formatScaled(value: number, suffix: string): string {
+  return `${value.toFixed(1).replace(/\.0$/, "")}${suffix}`;
+}
+
+export function formatTokens(value: number): string {
+  if (value >= 1_000_000) {
+    return formatScaled(value / 1_000_000, "M");
+  }
+  if (value >= 1_000) {
+    return formatScaled(value / 1_000, "k");
+  }
+  return String(value);
+}

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFormat.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFormat.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTokenCount } from "./splitRunFormat";
+
+describe("formatTokenCount", () => {
+  it("returns undefined for missing or invalid counts", () => {
+    expect(formatTokenCount()).toBeUndefined();
+    expect(formatTokenCount("")).toBeUndefined();
+    expect(formatTokenCount("not-a-number")).toBeUndefined();
+  });
+
+  it("keeps the raw count below one thousand", () => {
+    expect(formatTokenCount("0")).toBe("0 tokens");
+    expect(formatTokenCount("999")).toBe("999 tokens");
+  });
+
+  it("uses k notation for thousands", () => {
+    expect(formatTokenCount("1000")).toBe("1k tokens");
+    expect(formatTokenCount("2700")).toBe("2.7k tokens");
+  });
+
+  it("uses millions notation at or above one million", () => {
+    expect(formatTokenCount("1000000")).toBe("1M tokens");
+    expect(formatTokenCount("14616000")).toBe("14.6M tokens");
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFormat.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFormat.ts
@@ -1,3 +1,4 @@
+import { formatTokens } from "../formatTokens";
 import type { RunOverlayProvider } from "../work-order-run-overlay/workOrderRunOverlayMocks";
 
 export function formatCostCents(cents?: string): string | undefined {
@@ -19,12 +20,7 @@ export function formatTokenCount(tokens?: string): string | undefined {
   if (!Number.isFinite(count)) {
     return undefined;
   }
-  if (count >= 1000) {
-    const thousands = count / 1000;
-    const compact = thousands >= 10 ? thousands.toFixed(0) : thousands.toFixed(1).replace(/\.0$/, "");
-    return `${compact}k tokens`;
-  }
-  return `${count} tokens`;
+  return `${formatTokens(count)} tokens`;
 }
 
 export function clockLabel(iso?: string): string {


### PR DESCRIPTION
## Summary

Work-order and velocity views showed token counts such as `14616k` once the value passed one million.

Use millions notation (for example `14.6M`) at or above 1,000,000. Keep `k` for thousands and the raw number below 1,000.

Fixes #6977

## Test plan

- [ ] Open a work order whose token count is at or above 1,000,000 and confirm the label uses millions notation such as `14.6M tokens`
- [ ] Confirm a count such as 2700 still shows as `2.7k tokens`
- [ ] Confirm a count below 1000 still shows as a raw number
- [ ] `formatTokens` / `formatTokenCount` unit tests cover the million, thousand, and raw cases