### PR TITLE
fix: Stop clipping the age label on work order cards

### DIFF
--- a/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
@@ -119,7 +119,7 @@ export function WorkOrderCard({
           <div className="flex h-5 min-w-0 items-center gap-1.5">
             {showStart ? null : <CardOwnerMark entry={entry} organizationId={organizationId} />}
             <span
-              className="truncate text-[11px] leading-none text-muted-foreground"
+              className="truncate text-[11px] leading-4 text-muted-foreground"
               title={startedAt?.toLocaleString()}
             >
               {startedLabel}


### PR DESCRIPTION
## Summary

The age label on work order cards ("6h ago") had its descenders cut off.
The label used a line height equal to the font size together with
truncation. Truncation sets overflow to hidden, so the line box gave no
room for the bottom of letters such as "g".

This change sets the line height to 16px. The label shows the full text
and still fits the 20px footer row, so the owner mark and the Start
button keep their alignment.

## Test plan

- [ ] Open a board that shows work order cards.
- [ ] Look at the age label in the card footer, for example "6h ago".
- [ ] Make sure that no part of the text is cut off.
- [ ] Make sure that the owner mark and the Start button stay aligned
      with the label.


Made with [Cursor](https://cursor.com)