### PR TITLE
fix: Show actor name and avatar in work order footer

### DIFF
--- a/pkg/models/factory/events.go
+++ b/pkg/models/factory/events.go
@@ -198,6 +198,9 @@ type LineStepExecutionFinished struct {
 	Line     *LineRef      `json:"line,omitempty"`
 	App      *AppRef       `json:"app,omitempty"`
 	Run      *RunRef       `json:"run,omitempty"`
+	// User is who cancelled the canvas run, when this finish is a
+	// cancellation. Passed finishes leave it empty.
+	User *UserRef `json:"user,omitempty"`
 }
 
 // Refs

--- a/pkg/models/factory_work_order_execution.go
+++ b/pkg/models/factory_work_order_execution.go
@@ -212,6 +212,7 @@ func (e *FactoryWorkOrderExecution) RecordFinished(tx *gorm.DB, result string) e
 		Line:     dispatch.Ref(),
 		App:      &factory.AppRef{ID: run.WorkflowID, Name: e.StepName},
 		Run:      &factory.RunRef{ID: run.ID, State: run.State, Result: &run.Result},
+		User:     cancelledByUserRef(run.CancelledBy),
 	}
 
 	jsonData, err := json.Marshal(data)
@@ -321,4 +322,11 @@ func RootEventSourcePayload(eventData any) any {
 	}
 
 	return source
+}
+
+func cancelledByUserRef(cancelledBy *uuid.UUID) *factory.UserRef {
+	if cancelledBy == nil {
+		return nil
+	}
+	return &factory.UserRef{ID: *cancelledBy}
 }

--- a/pkg/models/factory_work_order_execution_test.go
+++ b/pkg/models/factory_work_order_execution_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/models/factory"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/gorm"
 )
@@ -76,4 +78,72 @@ func Test__ListFactoryWorkOrderExecutionsByLineDispatchIDs__IncludesExecutionsAf
 	assert.Equal(t, "implement", listed[dispatch.ID][0].StepName)
 	assert.Equal(t, models.FactoryWorkOrderExecutionStatusFinished, listed[dispatch.ID][0].Status)
 	assert.Equal(t, models.CanvasRunResultPassed, listed[dispatch.ID][0].Result)
+}
+
+func Test__MarkFinished_CancelledRunWritesCancellerOnStepEvent(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	order, err := factoryModel.CreateWorkOrder(db, "Order", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	line, err := factoryModel.CreateLine(db, "line", nil)
+	require.NoError(t, err)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{NodeID: "node-1", Type: models.NodeTypeComponent},
+		},
+		nil,
+	)
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "trigger", "default", nil)
+	run := createRunForRootEvent(t, rootEvent)
+	require.NoError(t, db.Model(run).Updates(map[string]any{
+		"state":        models.CanvasRunStateFinished,
+		"result":       models.CanvasRunResultCancelled,
+		"cancelled_by": r.User,
+	}).Error)
+
+	dispatch := support.CreateFactoryLineDispatch(t, r.Organization.ID, factoryModel.ID, order.ID, line.ID, line.Name, nil)
+	now := time.Now()
+	execution := models.FactoryWorkOrderExecution{
+		ID:             uuid.New(),
+		OrganizationID: r.Organization.ID,
+		FactoryID:      factoryModel.ID,
+		WorkOrderID:    order.ID,
+		LineID:         line.ID,
+		LineDispatchID: dispatch.ID,
+		StepIndex:      0,
+		StepName:       "implement",
+		RunID:          &run.ID,
+		Status:         models.FactoryWorkOrderExecutionStatusRunning,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	require.NoError(t, db.Create(&execution).Error)
+	require.NoError(t, execution.MarkFinished(db, models.CanvasRunResultCancelled))
+
+	events, err := order.ListEvents(db, 20, nil)
+	require.NoError(t, err)
+	var payload factory.LineStepExecutionFinished
+	found := false
+	for _, event := range events {
+		if event.Type != factory.EventTypeLineStepExecutionFinished {
+			continue
+		}
+		require.NoError(t, json.Unmarshal(event.Data, &payload))
+		found = true
+		break
+	}
+	require.True(t, found)
+	require.NotNil(t, payload.User)
+	assert.Equal(t, r.User, payload.User.ID)
+	require.NotNil(t, payload.Run)
+	require.NotNil(t, payload.Run.Result)
+	assert.Equal(t, models.CanvasRunResultCancelled, *payload.Run.Result)
 }

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -72,6 +72,7 @@ import { type WorkOrderCardContext } from "../workOrders/WorkOrderCard";
 import { WorkOrderSplitRunPopup } from "./work-order-split-run/WorkOrderSplitRunPopup";
 import { canvasKeyForAutomation, type SplitRunCanvasKey } from "./work-order-split-run/splitRunCanvases";
 import { splitRunFixtureForWorkOrder } from "./work-order-split-run/splitRunMocks";
+import { useSplitRunFooterCloser } from "./work-order-split-run/useSplitRunFooterCloser";
 import {
   editFactoryLinePath,
   factoryAppConfigurePath,
@@ -526,6 +527,7 @@ function LineBoardSplitRunPopup({
   });
   const { data: peekHandlers = [] } = useFactoryPRFeedbackHandlers(organizationId, factoryId);
   const prFeedbackRuns = useWorkOrderPRFeedbackLog(peekPullRequests, peekHandlers);
+  const closer = useSplitRunFooterCloser(organizationId, factoryId, peekOrder);
   const resolvedLineName = lineName?.trim();
   return (
     <WorkOrderSplitRunPopup
@@ -542,6 +544,8 @@ function LineBoardSplitRunPopup({
         demoArtifacts: false,
         prFeedbackRuns,
         analysisRuns,
+        stoppedBy: closer.actor,
+        closer,
       })}
       canDispatch={canDispatch && Boolean(resolvedLineName)}
       canUpdate={canUpdate}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -650,6 +650,24 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(within(note).getByRole("heading", { name: /stopped this automation/ })).toBeInTheDocument();
   });
 
+  it("names the person who marked the task successful, with avatar", () => {
+    renderPopup({
+      fixture: splitRunFixtureForWorkOrder(LINE_BOARD_DONE_RECEIPTS_ORDER, {
+        closer: {
+          actor: { id: "user-1", name: "Alex", initials: "A", avatarUrl: "https://example.com/alex.png" },
+        },
+      }),
+    });
+
+    const note = screen.getByTestId("split-run-attention-note");
+    expect(within(note).getByTestId("work-order-mention")).toHaveTextContent("Alex");
+    expect(within(note).getByTestId("work-order-mention").querySelector("img")).toHaveAttribute(
+      "src",
+      "https://example.com/alex.png",
+    );
+    expect(within(note).getByRole("heading", { name: /marked this task as successful/ })).toBeInTheDocument();
+  });
+
   it("keeps Reject and Approve off the header on a running order", () => {
     renderSplitRun();
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooterActor.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooterActor.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import type { FactoriesWorkOrderEvent } from "@/api-client";
+import { createOrgUserDisplayLookup, type OrgUserDisplay } from "@/lib/orgUserDisplay";
+
+import { footerCloserFromEvents } from "./splitRunFooterActor";
+
+const ALEX: OrgUserDisplay = {
+  id: "user-alex",
+  name: "Alex Rivera",
+  initials: "AR",
+  avatarUrl: "https://example.com/alex.png",
+};
+
+const resolveUser = createOrgUserDisplayLookup(new Map([[ALEX.id, ALEX]]));
+
+function statusEvent(
+  at: string,
+  payload: {
+    userId?: string;
+    automationName?: string;
+    toState?: string;
+    toResult?: string;
+  },
+): FactoriesWorkOrderEvent {
+  return {
+    type: "order.status.updated",
+    timestamp: at,
+    event: {
+      ...(payload.userId ? { user: { id: payload.userId } } : {}),
+      ...(payload.automationName ? { automation: { appName: payload.automationName } } : {}),
+      toState: payload.toState ?? "closed",
+      ...(payload.toResult !== undefined ? { toResult: payload.toResult } : {}),
+    },
+  };
+}
+
+describe("footerCloserFromEvents", () => {
+  it("names the person who completed the work order, including avatar", () => {
+    expect(
+      footerCloserFromEvents(
+        [statusEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id, toResult: "completed" })],
+        "completed",
+        resolveUser,
+      ),
+    ).toEqual({ actor: ALEX });
+  });
+
+  it("names the person who rejected the work order", () => {
+    expect(
+      footerCloserFromEvents(
+        [statusEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id, toResult: "rejected" })],
+        "rejected",
+        resolveUser,
+      ),
+    ).toEqual({ actor: ALEX });
+  });
+
+  it("names the automation that closed the work order when no person is set", () => {
+    expect(
+      footerCloserFromEvents(
+        [statusEvent("2026-08-04T12:00:00.000Z", { automationName: "PR Closure", toResult: "completed" })],
+        "completed",
+        resolveUser,
+      ),
+    ).toEqual({ automationName: "PR Closure" });
+  });
+
+  it("uses the latest matching close, not an older one", () => {
+    expect(
+      footerCloserFromEvents(
+        [
+          statusEvent("2026-08-04T10:00:00.000Z", { userId: "user-old", toResult: "completed" }),
+          statusEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id, toResult: "completed" }),
+        ],
+        "completed",
+        resolveUser,
+      ).actor?.id,
+    ).toBe(ALEX.id);
+  });
+
+  it("names the person who stopped the automation from a cancelled result", () => {
+    expect(
+      footerCloserFromEvents(
+        [statusEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id, toState: "open", toResult: "cancelled" })],
+        "waiting",
+        resolveUser,
+      ),
+    ).toEqual({ actor: ALEX });
+  });
+
+  it("returns empty when no matching event exists, so the footer keeps A person", () => {
+    expect(footerCloserFromEvents([], "completed", resolveUser)).toEqual({});
+    expect(
+      footerCloserFromEvents(
+        [statusEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id, toState: "open", toResult: "" })],
+        "waiting",
+        resolveUser,
+      ),
+    ).toEqual({});
+  });
+
+  it("ignores a completed close when the footer is for a rejected order", () => {
+    expect(
+      footerCloserFromEvents(
+        [statusEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id, toResult: "completed" })],
+        "rejected",
+        resolveUser,
+      ),
+    ).toEqual({});
+  });
+});

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooterActor.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooterActor.spec.ts
@@ -35,6 +35,17 @@ function statusEvent(
   };
 }
 
+function stepFinishedEvent(at: string, payload: { userId?: string; runResult?: string }): FactoriesWorkOrderEvent {
+  return {
+    type: "step.execution.finished",
+    timestamp: at,
+    event: {
+      ...(payload.userId ? { user: { id: payload.userId } } : {}),
+      run: { id: "run-1", result: payload.runResult ?? "cancelled" },
+    },
+  };
+}
+
 describe("footerCloserFromEvents", () => {
   it("names the person who completed the work order, including avatar", () => {
     expect(
@@ -79,7 +90,17 @@ describe("footerCloserFromEvents", () => {
     ).toBe(ALEX.id);
   });
 
-  it("names the person who stopped the automation from a cancelled result", () => {
+  it("names the person who stopped the automation from a cancelled step finish", () => {
+    expect(
+      footerCloserFromEvents(
+        [stepFinishedEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id })],
+        "waiting",
+        resolveUser,
+      ),
+    ).toEqual({ actor: ALEX });
+  });
+
+  it("falls back to a cancelled status event when no step finish is present", () => {
     expect(
       footerCloserFromEvents(
         [statusEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id, toState: "open", toResult: "cancelled" })],
@@ -87,6 +108,19 @@ describe("footerCloserFromEvents", () => {
         resolveUser,
       ),
     ).toEqual({ actor: ALEX });
+  });
+
+  it("prefers a cancelled step finish over an older status event", () => {
+    expect(
+      footerCloserFromEvents(
+        [
+          statusEvent("2026-08-04T10:00:00.000Z", { userId: "user-old", toState: "open", toResult: "cancelled" }),
+          stepFinishedEvent("2026-08-04T12:00:00.000Z", { userId: ALEX.id }),
+        ],
+        "running",
+        resolveUser,
+      ).actor?.id,
+    ).toBe(ALEX.id);
   });
 
   it("returns empty when no matching event exists, so the footer keeps A person", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooterActor.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooterActor.ts
@@ -1,0 +1,82 @@
+import type { FactoriesWorkOrderEvent } from "@/api-client";
+import type { OrgUserDisplay, OrgUserDisplayLookup } from "@/lib/orgUserDisplay";
+
+import type { WorkOrderDisplayStatus } from "../../lib/workOrderProgress";
+
+export type SplitRunFooterCloser = {
+  actor?: OrgUserDisplay;
+  automationName?: string;
+};
+
+interface StatusEventPayload {
+  user?: { id?: string };
+  automation?: { nodeName?: string; appName?: string };
+  toState?: string;
+  toResult?: string;
+}
+
+const CLOSED_RESULT_FOR_STATUS: Partial<Record<WorkOrderDisplayStatus, string>> = {
+  completed: "completed",
+  rejected: "rejected",
+  failed: "failed",
+  cancelled: "cancelled",
+};
+
+/**
+ * Person or automation that closed or stopped this work order, taken from
+ * the latest matching `order.status.updated` event. Empty when that event
+ * has no user and no automation name — callers keep the "A person" copy.
+ */
+export function footerCloserFromEvents(
+  events: FactoriesWorkOrderEvent[],
+  displayStatus: WorkOrderDisplayStatus,
+  resolveUser: OrgUserDisplayLookup,
+): SplitRunFooterCloser {
+  const payload = latestMatchingStatusPayload(events, displayStatus);
+  if (!payload) {
+    return {};
+  }
+
+  const actor = resolveUser(payload.user?.id) ?? undefined;
+  const automationName = payload.automation?.nodeName?.trim() || payload.automation?.appName?.trim() || undefined;
+  return {
+    ...(actor ? { actor } : {}),
+    ...(automationName ? { automationName } : {}),
+  };
+}
+
+function latestMatchingStatusPayload(
+  events: FactoriesWorkOrderEvent[],
+  displayStatus: WorkOrderDisplayStatus,
+): StatusEventPayload | undefined {
+  const sorted = [...events].sort(compareEventsNewestFirst);
+  for (const event of sorted) {
+    if (event.type !== "order.status.updated") {
+      continue;
+    }
+    const payload = (event.event ?? {}) as StatusEventPayload;
+    if (statusEventMatchesFooter(payload, displayStatus)) {
+      return payload;
+    }
+  }
+  return undefined;
+}
+
+function statusEventMatchesFooter(payload: StatusEventPayload, displayStatus: WorkOrderDisplayStatus): boolean {
+  const result = (payload.toResult ?? "").toLowerCase();
+  if (displayStatus === "waiting" || displayStatus === "running") {
+    return result === "cancelled";
+  }
+  if (payload.toState !== "closed") {
+    return false;
+  }
+  const wanted = CLOSED_RESULT_FOR_STATUS[displayStatus];
+  if (displayStatus === "completed") {
+    return result === "completed" || result === "";
+  }
+  return Boolean(wanted) && result === wanted;
+}
+
+function compareEventsNewestFirst(left: FactoriesWorkOrderEvent, right: FactoriesWorkOrderEvent): number {
+  return Date.parse(right.timestamp ?? "") - Date.parse(left.timestamp ?? "");
+}

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooterActor.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunFooterActor.ts
@@ -8,11 +8,12 @@ export type SplitRunFooterCloser = {
   automationName?: string;
 };
 
-interface StatusEventPayload {
+interface FooterActorPayload {
   user?: { id?: string };
   automation?: { nodeName?: string; appName?: string };
   toState?: string;
   toResult?: string;
+  run?: { result?: string };
 }
 
 const CLOSED_RESULT_FOR_STATUS: Partial<Record<WorkOrderDisplayStatus, string>> = {
@@ -23,8 +24,10 @@ const CLOSED_RESULT_FOR_STATUS: Partial<Record<WorkOrderDisplayStatus, string>> 
 };
 
 /**
- * Person or automation that closed or stopped this work order, taken from
- * the latest matching `order.status.updated` event. Empty when that event
+ * Person or automation that closed or stopped this work order. Close
+ * attribution comes from `order.status.updated`. Stop attribution comes
+ * from a cancelled `step.execution.finished` (cancelling a run leaves the
+ * order open and does not write a status event). Empty when that event
  * has no user and no automation name — callers keep the "A person" copy.
  */
 export function footerCloserFromEvents(
@@ -32,7 +35,7 @@ export function footerCloserFromEvents(
   displayStatus: WorkOrderDisplayStatus,
   resolveUser: OrgUserDisplayLookup,
 ): SplitRunFooterCloser {
-  const payload = latestMatchingStatusPayload(events, displayStatus);
+  const payload = latestMatchingActorPayload(events, displayStatus);
   if (!payload) {
     return {};
   }
@@ -45,24 +48,32 @@ export function footerCloserFromEvents(
   };
 }
 
-function latestMatchingStatusPayload(
+function latestMatchingActorPayload(
   events: FactoriesWorkOrderEvent[],
   displayStatus: WorkOrderDisplayStatus,
-): StatusEventPayload | undefined {
+): FooterActorPayload | undefined {
   const sorted = [...events].sort(compareEventsNewestFirst);
+  const stoppedOpen = displayStatus === "waiting" || displayStatus === "running";
   for (const event of sorted) {
-    if (event.type !== "order.status.updated") {
-      continue;
+    const payload = (event.event ?? {}) as FooterActorPayload;
+    if (stoppedOpen && isCancelledStepFinished(event, payload)) {
+      return payload;
     }
-    const payload = (event.event ?? {}) as StatusEventPayload;
-    if (statusEventMatchesFooter(payload, displayStatus)) {
+    if (event.type === "order.status.updated" && statusEventMatchesFooter(payload, displayStatus)) {
       return payload;
     }
   }
   return undefined;
 }
 
-function statusEventMatchesFooter(payload: StatusEventPayload, displayStatus: WorkOrderDisplayStatus): boolean {
+function isCancelledStepFinished(event: FactoriesWorkOrderEvent, payload: FooterActorPayload): boolean {
+  if (event.type !== "step.execution.finished") {
+    return false;
+  }
+  return (payload.run?.result ?? "").toLowerCase() === "cancelled";
+}
+
+function statusEventMatchesFooter(payload: FooterActorPayload, displayStatus: WorkOrderDisplayStatus): boolean {
   const result = (payload.toResult ?? "").toLowerCase();
   if (displayStatus === "waiting" || displayStatus === "running") {
     return result === "cancelled";

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
@@ -1152,6 +1152,17 @@ describe("line board work-order examples", () => {
     expect(outputNames(fixture.phases.find((phase) => phase.id === "done-2"))).toEqual(["#510"]);
   });
 
+  it("names the person who marked a completed task successful", () => {
+    const actor = { id: "user-1", name: "Alex", initials: "A", avatarUrl: "https://example.com/alex.png" };
+    const fixture = splitRunFixtureForWorkOrder(LINE_BOARD_DONE_RECEIPTS_ORDER, { closer: { actor } });
+
+    expect(fixture.footer.note).toMatchObject({
+      headline: "marked this task as successful",
+      text: "The work is done. The result met the goal.",
+      actor,
+    });
+  });
+
   it("keeps ingest analysis and a rejected pull request on the rejected done card", () => {
     const fixture = splitRunFixtureForWorkOrder(BOARD_DONE_REJECTED_ORDER);
     expect(fixture.phases.map((phase) => phase.id)).toEqual([

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
@@ -290,6 +290,8 @@ export type SplitRunFixtureOptions = {
   prFeedbackRuns?: PRFeedbackLogRun[];
   /** Person who stopped the current automation, when known. */
   stoppedBy?: OrgUserDisplay;
+  /** Person or automation that closed the work order, when known. */
+  closer?: { actor?: OrgUserDisplay; automationName?: string };
   /** Backlog analysis runs for this work order, shown as extra Log phases. */
   analysisRuns?: BacklogAnalysisRun[];
 };
@@ -333,7 +335,8 @@ function mappedWorkOrderFixture(order: FactoriesWorkOrder, options?: SplitRunFix
       apiChecks: options?.checks,
       demoArtifacts,
       addressingFeedback: Boolean(activePRFeedbackPhaseId(phases)),
-      stoppedBy: options?.stoppedBy,
+      stoppedBy: options?.stoppedBy ?? options?.closer?.actor,
+      closer: options?.closer,
     }),
   };
   if (order.id === "wo-board-implement-notify") {
@@ -352,6 +355,7 @@ function reviewSurfaces(
     demoArtifacts?: boolean;
     addressingFeedback?: boolean;
     stoppedBy?: OrgUserDisplay;
+    closer?: { actor?: OrgUserDisplay; automationName?: string };
   },
 ): Pick<SplitRunFixture, "waitingNotes" | "checks" | "footer" | "footerTone"> {
   const demoArtifacts = input.demoArtifacts !== false;
@@ -368,7 +372,7 @@ function reviewSurfaces(
     );
   }
   if (displayStatus === "completed" || displayStatus === "rejected" || displayStatus === "cancelled") {
-    return surfaces(doneFooterForStatus(displayStatus), [], checks);
+    return surfaces(doneFooterForStatus(displayStatus, input.closer), [], checks);
   }
   if (current?.result === "RESULT_FAILED") {
     return failedReviewSurface(current, displayStatus, checks);
@@ -391,7 +395,7 @@ function reviewSurfaces(
       checks,
     );
   }
-  return surfaces(doneFooterForStatus(displayStatus), [], checks);
+  return surfaces(doneFooterForStatus(displayStatus, input.closer), [], checks);
 }
 
 function stoppedReviewSurface(

--- a/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterCloser.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunFooterCloser.ts
@@ -1,0 +1,23 @@
+import type { FactoriesWorkOrder } from "@/api-client";
+import { useWorkOrderEvents } from "@/hooks/useFactoryData";
+import { useOrgUserLookup } from "@/hooks/useOrgUserLookup";
+import { useMemo } from "react";
+
+import { flattenWorkOrderEventsPages } from "../../lib/workOrderEventsPagination";
+import { getWorkOrderDisplayStatus } from "../../lib/workOrderProgress";
+import { footerCloserFromEvents, type SplitRunFooterCloser } from "./splitRunFooterActor";
+
+export function useSplitRunFooterCloser(
+  organizationId: string,
+  factoryId: string,
+  order: FactoriesWorkOrder,
+): SplitRunFooterCloser {
+  const eventsQuery = useWorkOrderEvents(organizationId, factoryId, order.id ?? "");
+  const { resolveUser } = useOrgUserLookup(organizationId);
+  const events = useMemo(() => flattenWorkOrderEventsPages(eventsQuery.data?.pages), [eventsQuery.data?.pages]);
+  const displayStatus = getWorkOrderDisplayStatus(order);
+  return useMemo(
+    () => footerCloserFromEvents(events, displayStatus, resolveUser),
+    [displayStatus, events, resolveUser],
+  );
+}

--- a/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
@@ -118,10 +118,7 @@ export function WorkOrderCard({
         <div className="mt-2 flex items-center justify-between gap-2">
           <div className="flex h-5 min-w-0 items-center gap-1.5">
             {showStart ? null : <CardOwnerMark entry={entry} organizationId={organizationId} />}
-            <span
-              className="truncate text-[11px] leading-4 text-muted-foreground"
-              title={startedAt?.toLocaleString()}
-            >
+            <span className="truncate text-[11px] leading-4 text-muted-foreground" title={startedAt?.toLocaleString()}>
               {startedLabel}
             </span>
           </div>


### PR DESCRIPTION
## Summary

The work order decision strip showed "A person" for stop, complete, and reject.

The strip already rendered a name and avatar when an actor was set. Live popups did not pass that actor.

This change reads the closer from work-order status events and the organization user list. It keeps the unknown copy when no actor exists.

<img width="670" height="216" alt="image" src="https://github.com/user-attachments/assets/c5873739-a1fa-4183-b0fe-f4f1414de00d" />


## Test plan

- [ ] Open a work order that a person completed. Confirm the footer shows that name and avatar.
- [ ] Open a work order that a person rejected. Confirm the footer shows that name and avatar.
- [ ] Open a work order where a person stopped the automation. Confirm the footer shows that name when the status event has a user.
- [ ] Open a work order with no closer event. Confirm the footer still shows "A person stopped this automation".
- [ ] Confirm `make check.lint.ui` and `make check.build.ui` pass.


Made with [Cursor](https://cursor.com)