### PR TITLE
fix: Open work order from permalink and email

### DIFF
--- a/pkg/services/email.go
+++ b/pkg/services/email.go
@@ -34,6 +34,10 @@ type WorkOrderNotificationTemplateData struct {
 	// Detail is optional supporting text (comment excerpt, state change).
 	Detail        string
 	WorkOrderLink string
+	// DetailCtaLabel and DetailCtaURL render a secondary HTML link under
+	// the detail block (status-note CTAs). Empty URL skips the link.
+	DetailCtaLabel string
+	DetailCtaURL   string
 	// Kanban-card fields. Colors are light-theme hex values so the HTML
 	// email matches the work order board card.
 	StatusLabel      string

--- a/pkg/services/smtp_email_test.go
+++ b/pkg/services/smtp_email_test.go
@@ -301,6 +301,8 @@ func TestWorkOrderNotificationTemplates_KanbanCard(t *testing.T) {
 		WorkOrderKey:     "SP-52",
 		WorkOrderTitle:   "Metrics on list of lines",
 		Detail:           "Looks good",
+		DetailCtaLabel:   "Review PR #52",
+		DetailCtaURL:     "https://github.com/example/repo/pull/52",
 		WorkOrderLink:    "https://app.superplane.com/org/workspaces/sp/work-order/52",
 		StatusLabel:      "Waiting",
 		StatusFg:         "#b45309",
@@ -324,6 +326,8 @@ func TestWorkOrderNotificationTemplates_KanbanCard(t *testing.T) {
 	assert.Contains(t, html, "&#43;1")
 	assert.Contains(t, html, "#fffbeb")
 	assert.Contains(t, html, "https://app.superplane.com/org/workspaces/sp/work-order/52")
+	assert.Contains(t, html, "href=\"https://github.com/example/repo/pull/52\"")
+	assert.Contains(t, html, "Review PR #52")
 
 	text, err := renderEmailTemplate(templateRoot, "work_order_notification.txt", data)
 	require.NoError(t, err)
@@ -331,6 +335,7 @@ func TestWorkOrderNotificationTemplates_KanbanCard(t *testing.T) {
 	assert.Contains(t, text, "SP-52")
 	assert.Contains(t, text, "Bugs · CI Loop")
 	assert.Contains(t, text, "8h ago")
+	assert.Contains(t, text, "Review PR #52: https://github.com/example/repo/pull/52")
 }
 
 func TestBuildEmailService(t *testing.T) {

--- a/pkg/workers/factory_notification_consumer.go
+++ b/pkg/workers/factory_notification_consumer.go
@@ -395,7 +395,9 @@ func buildWorkOrderNotificationContent(
 	case factory.EventTypeOrderStatusNoteUpdated:
 		content.Subject = fmt.Sprintf("[%s] %s", orderKey, message.StatusNoteHeadline)
 		content.Data.Summary = fmt.Sprintf("%s flagged %s as waiting on you: %s.", actorName, orderKey, message.StatusNoteHeadline)
-		content.Data.Detail = truncateNotificationDetail(statusNoteDetail(message))
+		content.Data.Detail = truncateNotificationDetail(message.StatusNoteBody)
+		content.Data.DetailCtaLabel = message.StatusNoteCtaLabel
+		content.Data.DetailCtaURL = message.StatusNoteCtaURL
 	default:
 		content.Subject = fmt.Sprintf("[%s] Work order update", orderKey)
 		content.Data.Summary = fmt.Sprintf("%s updated %s.", actorName, orderKey)
@@ -423,24 +425,6 @@ func statusChangeDescription(message messages.FactoryWorkOrderNotificationMessag
 	default:
 		return "updated"
 	}
-}
-
-// statusNoteDetail folds the note body and its call-to-action (if any)
-// into the single Detail line the shared email template renders. The
-// template has no secondary link slot, so the CTA is appended as plain
-// text; the primary "Open the work order in SuperPlane" link already
-// covers navigating back to SuperPlane.
-func statusNoteDetail(message messages.FactoryWorkOrderNotificationMessage) string {
-	detail := message.StatusNoteBody
-	if message.StatusNoteCtaLabel == "" || message.StatusNoteCtaURL == "" {
-		return detail
-	}
-
-	cta := fmt.Sprintf("%s: %s", message.StatusNoteCtaLabel, message.StatusNoteCtaURL)
-	if detail == "" {
-		return cta
-	}
-	return detail + "\n\n" + cta
 }
 
 func artifactTypeLabel(artifactType string) string {

--- a/pkg/workers/factory_notification_consumer_test.go
+++ b/pkg/workers/factory_notification_consumer_test.go
@@ -283,7 +283,8 @@ func Test__FactoryNotificationConsumer(t *testing.T) {
 			assert.Contains(t, email.Subject, "Review the pull request")
 			assert.Contains(t, email.Data.Summary, "waiting on you")
 			assert.Contains(t, email.Data.Detail, "Merging the PR completes this work order automatically.")
-			assert.Contains(t, email.Data.Detail, "https://github.com/example/repo/pull/42")
+			assert.Equal(t, "Review PR #42", email.Data.DetailCtaLabel)
+			assert.Equal(t, "https://github.com/example/repo/pull/42", email.Data.DetailCtaURL)
 		}
 		assert.ElementsMatch(t, []string{owner.GetEmail(), creator.GetEmail()}, recipients)
 	})

--- a/templates/email/work_order_notification.html
+++ b/templates/email/work_order_notification.html
@@ -196,6 +196,12 @@
     <div class="detail">{{.Detail}}</div>
     {{end}}
 
+    {{if .DetailCtaURL}}
+    <div class="text">
+        <a href="{{.DetailCtaURL}}" class="link">{{if .DetailCtaLabel}}{{.DetailCtaLabel}}{{else}}{{.DetailCtaURL}}{{end}}</a>
+    </div>
+    {{end}}
+
     <div class="text">
         <a href="{{.WorkOrderLink}}" class="link">Open the work order in SuperPlane</a>
     </div>

--- a/templates/email/work_order_notification.txt
+++ b/templates/email/work_order_notification.txt
@@ -6,6 +6,8 @@
 {{end}}{{.UpdatedLabel}}
 {{if .Detail}}
 {{.Detail}}
+{{end}}{{if .DetailCtaURL}}
+{{if .DetailCtaLabel}}{{.DetailCtaLabel}}: {{end}}{{.DetailCtaURL}}
 {{end}}
 Open the work order in SuperPlane:
 {{.WorkOrderLink}}

--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.pageTitle.spec.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.pageTitle.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -18,7 +18,7 @@ describe("client-side navigation updates document.title", () => {
     client.setConfig({ baseUrl: "http://localhost" });
   });
 
-  it("sends a work-order permalink to the line board", async () => {
+  it("opens a work-order permalink on the line board", async () => {
     render(
       <FactoriesHarness
         pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-order/101`}
@@ -28,7 +28,26 @@ describe("client-side navigation updates document.title", () => {
     );
 
     expect(await screen.findByTestId("lines-detail-page", {}, { timeout: 8000 })).toBeInTheDocument();
+    const permalinkPopup = await screen.findByTestId("work-order-split-run", {}, { timeout: 8000 });
+    expect(
+      within(permalinkPopup).getByRole("heading", { name: "Reconcile duplicate refunds in ledger" }),
+    ).toBeInTheDocument();
     expect(document.title).toBe("Plan and Implement · Semaphore · SuperPlane");
+  }, 15000);
+
+  it("canonicalizes a legacy work-order id URL onto the permalink", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-orders/wo-open-refunds`}
+        factoriesFixture={defaultFactoriesFixture}
+        pageOverrides={pageOverrides}
+      />,
+    );
+
+    const legacyPopup = await screen.findByTestId("work-order-split-run", {}, { timeout: 8000 });
+    expect(
+      within(legacyPopup).getByRole("heading", { name: "Reconcile duplicate refunds in ledger" }),
+    ).toBeInTheDocument();
   }, 15000);
 
   it("updates the tab title on the line board home", async () => {

--- a/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.spec.ts
@@ -37,11 +37,11 @@ describe("resolveFactoryAppBackNav", () => {
     });
   });
 
-  it("returns the line board when from=work-order", () => {
+  it("returns the work-order permalink when from=work-order has a number", () => {
     expect(resolveFactoryAppBackNav("org", "fac", { from: "work-order", orderNumber: "42", lineId: "line-1" })).toEqual(
       {
         label: "Back",
-        href: "/org/workspaces/fac/lines/line-1",
+        href: "/org/workspaces/fac/work-order/42",
       },
     );
   });

--- a/web_src/src/pages/factories/lib/factoryAppNav.ts
+++ b/web_src/src/pages/factories/lib/factoryAppNav.ts
@@ -1,4 +1,10 @@
-import { automationDetailPath, automationsPath, factoryHomePath, factoryLineDetailPath } from "./factoryPagePaths";
+import {
+  automationDetailPath,
+  automationsPath,
+  factoryHomePath,
+  factoryLineDetailPath,
+  workOrderDetailPath,
+} from "./factoryPagePaths";
 
 export type FactoryAppBackNav = {
   label: string;
@@ -47,6 +53,12 @@ export function resolveFactoryAppBackNav(
   }
 
   if (from === "work-order") {
+    if (options.orderNumber) {
+      return {
+        label: "Back",
+        href: workOrderDetailPath(organizationId, factoryKey, options.orderNumber),
+      };
+    }
     return { label: "Back", href: factoryHomePath(organizationId, factoryKey, options.lineId) };
   }
 

--- a/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
@@ -131,6 +131,12 @@ describe("workOrderDetailPath", () => {
   it("is a sibling of, not nested under, the plural work-orders list path", () => {
     expect(workOrderDetailPath("org-1", "SP", "42")).not.toContain(workOrdersPath("org-1", "SP"));
   });
+
+  it("keeps the board line on the permalink when a line id is given", () => {
+    expect(workOrderDetailPath("org-1", "SP", "42", "line-hotfix")).toBe(
+      "/org-1/workspaces/SP/work-order/42?lineId=line-hotfix",
+    );
+  });
 });
 
 describe("workOrderOpenPath", () => {

--- a/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.spec.ts
@@ -23,6 +23,7 @@ import {
   organizationSettingsSectionPath,
   parseFactoryAppNavFrom,
   workOrderDetailPath,
+  workOrderOpenPath,
   workOrdersPath,
 } from "./factoryPagePaths";
 
@@ -129,6 +130,16 @@ describe("workOrderDetailPath", () => {
 
   it("is a sibling of, not nested under, the plural work-orders list path", () => {
     expect(workOrderDetailPath("org-1", "SP", "42")).not.toContain(workOrdersPath("org-1", "SP"));
+  });
+});
+
+describe("workOrderOpenPath", () => {
+  it("uses the canonical permalink when the order has a number", () => {
+    expect(workOrderOpenPath("org-1", "SP", 42, "line-1")).toBe("/org-1/workspaces/SP/work-order/42");
+  });
+
+  it("falls back to the line board when the order has no number", () => {
+    expect(workOrderOpenPath("org-1", "SP", undefined, "line-1")).toBe("/org-1/workspaces/SP/lines/line-1");
   });
 });
 

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -126,6 +126,22 @@ export function workOrderDetailPath(organizationId: string, factoryKey: string, 
 }
 
 /**
+ * Opens a work order at its canonical permalink. Falls back to the line
+ * board when the order has no number yet.
+ */
+export function workOrderOpenPath(
+  organizationId: string,
+  factoryKey: string,
+  orderNumber: string | number | null | undefined,
+  fallbackLineId?: string | null,
+) {
+  if (orderNumber === undefined || orderNumber === null || String(orderNumber).trim() === "") {
+    return factoryHomePath(organizationId, factoryKey, fallbackLineId);
+  }
+  return workOrderDetailPath(organizationId, factoryKey, orderNumber);
+}
+
+/**
  * Old id-based work order URL shape, kept around only so the legacy
  * redirect route can compare against it / build test fixtures. New code
  * should always call `workOrderDetailPath`.

--- a/web_src/src/pages/factories/lib/factoryPagePaths.ts
+++ b/web_src/src/pages/factories/lib/factoryPagePaths.ts
@@ -121,8 +121,26 @@ export function createWorkOrderPath(organizationId: string, factoryKey: string) 
  * factory-scoped sequence number (`FactoriesWorkOrder.number`), not the
  * database id — see `legacyWorkOrderDetailPath` for the old id-based shape.
  */
-export function workOrderDetailPath(organizationId: string, factoryKey: string, orderNumber: string | number) {
-  return `${factoryDetailPath(organizationId, factoryKey)}/work-order/${orderNumber}`;
+export function workOrderDetailPath(
+  organizationId: string,
+  factoryKey: string,
+  orderNumber: string | number,
+  lineId?: string | null,
+) {
+  const path = `${factoryDetailPath(organizationId, factoryKey)}/work-order/${orderNumber}`;
+  const boardLineId = lineId?.trim();
+  if (!boardLineId) {
+    return path;
+  }
+  return `${path}?${WORK_ORDER_LINE_SEARCH_PARAM}=${encodeURIComponent(boardLineId)}`;
+}
+
+/** Line id carried on a work-order permalink when the popup opened from a board. */
+export const WORK_ORDER_LINE_SEARCH_PARAM = "lineId";
+
+export function workOrderBoardLineIdFromSearch(search: string): string | null {
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  return new URLSearchParams(query).get(WORK_ORDER_LINE_SEARCH_PARAM);
 }
 
 /**

--- a/web_src/src/pages/factories/lib/workOrderNumberResolution.spec.ts
+++ b/web_src/src/pages/factories/lib/workOrderNumberResolution.spec.ts
@@ -4,6 +4,8 @@ import {
   canonicalWorkOrderNumber,
   findWorkOrderByRunId,
   latestDispatchForLine,
+  peekOrderFromNavigationState,
+  resolvePeekWorkOrder,
   resolveWorkOrderByNumber,
   workOrderRouteNeedsCanonicalRedirect,
 } from "./workOrderNumberResolution";
@@ -97,6 +99,41 @@ describe("findWorkOrderByRunId", () => {
     expect(findWorkOrderByRunId([ORDERS[0], withRun], "run-new")?.id).toBe("order-run");
     expect(findWorkOrderByRunId([withRun], "missing")).toBeUndefined();
     expect(findWorkOrderByRunId([withRun], "  ")).toBeUndefined();
+  });
+});
+
+describe("peekOrderFromNavigationState", () => {
+  it("reads a work order from navigate state", () => {
+    expect(peekOrderFromNavigationState({ peekOrder: ORDERS[0] })).toBe(ORDERS[0]);
+  });
+
+  it("rejects empty or malformed state", () => {
+    expect(peekOrderFromNavigationState(undefined)).toBeUndefined();
+    expect(peekOrderFromNavigationState({ peekOrder: { title: "no id" } })).toBeUndefined();
+    expect(peekOrderFromNavigationState({ peekOrder: { id: "" } })).toBeUndefined();
+  });
+});
+
+describe("resolvePeekWorkOrder", () => {
+  const notFound = resolveWorkOrderByNumber([], "12", false);
+  const found = resolveWorkOrderByNumber(ORDERS, "42", false);
+  const imported: FactoriesWorkOrder = { id: "wo-imported-12", title: "Handle duplicate refunds" };
+  const numberedImport: FactoriesWorkOrder = { id: "wo-imported-12", number: "12", title: "Handle duplicate refunds" };
+
+  it("prefers the list match over a navigation hint", () => {
+    expect(resolvePeekWorkOrder(found, "42", numberedImport, imported)).toBe(ORDERS[0]);
+  });
+
+  it("uses the navigation hint when the list has not caught up", () => {
+    expect(resolvePeekWorkOrder(notFound, "12", numberedImport, null)).toBe(numberedImport);
+  });
+
+  it("uses the local hint when there is no permalink yet", () => {
+    expect(resolvePeekWorkOrder(notFound, undefined, undefined, imported)).toBe(imported);
+  });
+
+  it("ignores a local hint once a permalink is in the URL", () => {
+    expect(resolvePeekWorkOrder(notFound, "12", undefined, imported)).toBeUndefined();
   });
 });
 

--- a/web_src/src/pages/factories/lib/workOrderNumberResolution.ts
+++ b/web_src/src/pages/factories/lib/workOrderNumberResolution.ts
@@ -114,3 +114,54 @@ export function canonicalWorkOrderNumber(order: FactoriesWorkOrder | null): stri
   const parsed = Number(order.number);
   return Number.isFinite(parsed) ? String(parsed) : null;
 }
+
+/**
+ * Order stashed on `navigate(..., { state })` so a just-imported work order
+ * can open before the list query includes it (and so remount after permalink
+ * navigation does not drop the peek).
+ */
+export function peekOrderFromNavigationState(state: unknown): FactoriesWorkOrder | undefined {
+  if (!state || typeof state !== "object" || !("peekOrder" in state)) {
+    return undefined;
+  }
+  const order = (state as { peekOrder?: unknown }).peekOrder;
+  if (!order || typeof order !== "object" || !("id" in order)) {
+    return undefined;
+  }
+  const id = (order as { id?: unknown }).id;
+  if (typeof id !== "string" || id.length === 0) {
+    return undefined;
+  }
+  return order as FactoriesWorkOrder;
+}
+
+/**
+ * Prefer the list match. Fall back to a navigation hint that matches the
+ * route, then to a local hint when there is no permalink yet (import that
+ * returned no `number`).
+ */
+export function resolvePeekWorkOrder(
+  permalink: WorkOrderResolution,
+  routeNumber: string | undefined,
+  navigationHint: FactoriesWorkOrder | undefined,
+  localHint: FactoriesWorkOrder | null,
+): FactoriesWorkOrder | undefined {
+  if (permalink.status === "found" && permalink.order) {
+    return permalink.order;
+  }
+  if (navigationHint && peekHintMatchesRoute(navigationHint, routeNumber)) {
+    return navigationHint;
+  }
+  if (!routeNumber && localHint) {
+    return localHint;
+  }
+  return undefined;
+}
+
+function peekHintMatchesRoute(order: FactoriesWorkOrder, routeNumber: string | undefined): boolean {
+  if (!routeNumber) {
+    return true;
+  }
+  const number = canonicalWorkOrderNumber(order);
+  return number === routeNumber || order.id === routeNumber;
+}

--- a/web_src/src/pages/factories/pages/LineBoardOrderCard.tsx
+++ b/web_src/src/pages/factories/pages/LineBoardOrderCard.tsx
@@ -25,7 +25,7 @@ export function LineBoardOrderCard({
       isAnalyzing={isAnalyzing}
       onOpen={() => {
         if (order.id) {
-          onOpenWorkOrder(order.id);
+          onOpenWorkOrder(order.id, order);
         }
       }}
     />

--- a/web_src/src/pages/factories/pages/LinesPage.backlogCreate.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.backlogCreate.spec.tsx
@@ -35,6 +35,26 @@ const searchFactoryIntakeItems = vi.fn(() => ({
 }));
 const importFactoryIntakeItem = vi.fn();
 
+const REFUND_INTAKE_SEARCH = {
+  data: [
+    {
+      id: "12",
+      key: "#12",
+      title: "Handle duplicate refunds",
+      body: "Retrying a refund posts twice.",
+      url: "https://github.com/acme/payments/issues/12",
+    },
+  ],
+  isLoading: false,
+  isError: false,
+};
+
+async function importRefundIssue(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId("lines-backlog-create"));
+  await user.click(screen.getByPlaceholderText("Import from GitHub issue"));
+  await user.click(screen.getByTestId("lines-backlog-create-item-12"));
+}
+
 vi.mock("@/hooks/useFactoryData", () => ({
   useFactoryWorkOrders: () => useFactoryWorkOrders(),
   useFactoryApps: () => useFactoryApps(),
@@ -166,19 +186,7 @@ describe("LinesPage backlog create", () => {
   it("imports an intake item and opens the work order popup", async () => {
     Element.prototype.scrollIntoView = vi.fn();
     useFactoryIntakes.mockReturnValue({ data: [GITHUB_ISSUES_INTAKE] });
-    searchFactoryIntakeItems.mockReturnValue({
-      data: [
-        {
-          id: "12",
-          key: "#12",
-          title: "Handle duplicate refunds",
-          body: "Retrying a refund posts twice.",
-          url: "https://github.com/acme/payments/issues/12",
-        },
-      ],
-      isLoading: false,
-      isError: false,
-    });
+    searchFactoryIntakeItems.mockReturnValue(REFUND_INTAKE_SEARCH);
     importFactoryIntakeItem.mockResolvedValue({
       id: "wo-imported-12",
       title: "Handle duplicate refunds",
@@ -187,9 +195,7 @@ describe("LinesPage backlog create", () => {
     const user = userEvent.setup();
     renderLinesBoard();
 
-    await user.click(screen.getByTestId("lines-backlog-create"));
-    await user.click(screen.getByPlaceholderText("Import from GitHub issue"));
-    await user.click(screen.getByTestId("lines-backlog-create-item-12"));
+    await importRefundIssue(user);
 
     expect(importFactoryIntakeItem).toHaveBeenCalledWith({
       intakeId: GITHUB_ISSUES_INTAKE_ID,
@@ -199,6 +205,26 @@ describe("LinesPage backlog create", () => {
       expect(screen.getByTestId("work-order-split-run")).toBeInTheDocument();
     });
     expect(screen.getByRole("tab", { name: "Description" })).toHaveAttribute("data-state", "active");
+  });
+
+  it("opens the popup from a just-imported order that already has a number", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    useFactoryIntakes.mockReturnValue({ data: [GITHUB_ISSUES_INTAKE] });
+    searchFactoryIntakeItems.mockReturnValue(REFUND_INTAKE_SEARCH);
+    importFactoryIntakeItem.mockResolvedValue({
+      id: "wo-imported-12",
+      number: "12",
+      title: "Handle duplicate refunds",
+      state: "STATE_DRAFT",
+    });
+    const user = userEvent.setup();
+    renderLinesBoard();
+
+    await importRefundIssue(user);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("work-order-split-run")).toBeInTheDocument();
+    });
   });
 
   it("shows a backlog onboarding card on Acme when the backlog is empty", () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -14,6 +14,7 @@ import {
   GITHUB_ISSUES_INTAKE_ID,
   PRIMARY_FACTORY_KEY,
   REFUND_FACTORY,
+  REFUND_LINE_HOTFIX_ID,
   REFUND_LINE_PLAN_ID,
 } from "../__fixtures__/factoryPageResponses";
 import { BOARD_DONE_REJECTED_ORDER, BOARD_IMPLEMENT_FAILED_ORDER } from "../__fixtures__/lineMetricsBoardOrders";
@@ -253,7 +254,7 @@ describe("LinesPage board", () => {
     expect(within(dialog).queryByTestId("split-run-phase-plan")).not.toBeInTheDocument();
     expect(screen.queryByTestId("review-candidate-modal")).not.toBeInTheDocument();
     expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
-      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/work-order/842`,
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/work-order/842?lineId=${REFUND_LINE_PLAN_ID}`,
     );
 
     await user.click(within(dialog).getByRole("button", { name: "Close" }));
@@ -282,6 +283,26 @@ describe("LinesPage board", () => {
 
     expect(screen.getByTestId("lines-detail-page")).toBeInTheDocument();
     expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+  });
+
+  it("keeps the current line when a card opens from a second line", async () => {
+    useFactoryWorkOrders.mockReturnValue({ data: REVIEW_CANDIDATE_WORK_ORDERS });
+    const user = userEvent.setup();
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_HOTFIX_ID}`);
+
+    await user.click(screen.getByRole("button", { name: "Open Add retry handling to webhook delivery" }));
+
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/work-order/842?lineId=${REFUND_LINE_HOTFIX_ID}`,
+    );
+
+    await user.click(within(screen.getByTestId("work-order-split-run")).getByRole("button", { name: "Close" }));
+    await waitFor(() => {
+      expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_HOTFIX_ID}`,
+    );
   });
 
   it("lists the intakes at the head of the Backlog column, without a drawer", () => {

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -305,6 +305,26 @@ describe("LinesPage board", () => {
     );
   });
 
+  it("does not reopen the popup when Back is pressed after Close", async () => {
+    useFactoryWorkOrders.mockReturnValue({ data: REVIEW_CANDIDATE_WORK_ORDERS });
+    const user = userEvent.setup();
+    renderLinesBoard();
+
+    await user.click(screen.getByRole("button", { name: "Open Add retry handling to webhook delivery" }));
+    expect(screen.getByTestId("work-order-split-run")).toBeInTheDocument();
+
+    await user.click(within(screen.getByTestId("work-order-split-run")).getByRole("button", { name: "Close" }));
+    await waitFor(() => {
+      expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("lines-test-back"));
+    expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`,
+    );
+  });
+
   it("lists the intakes at the head of the Backlog column, without a drawer", () => {
     useFactoryIntakes.mockReturnValue({ data: CONFIGURED_INTAKES });
     renderLinesBoard();

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -252,6 +252,36 @@ describe("LinesPage board", () => {
     expect(within(dialog).queryByTestId("split-run-phase-analyze")).not.toBeInTheDocument();
     expect(within(dialog).queryByTestId("split-run-phase-plan")).not.toBeInTheDocument();
     expect(screen.queryByTestId("review-candidate-modal")).not.toBeInTheDocument();
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/work-order/842`,
+    );
+
+    await user.click(within(dialog).getByRole("button", { name: "Close" }));
+    await waitFor(() => {
+      expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`,
+    );
+  });
+
+  it("opens the split run from a work-order permalink", () => {
+    useFactoryWorkOrders.mockReturnValue({ data: REVIEW_CANDIDATE_WORK_ORDERS });
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/work-order/842`);
+
+    const popup = screen.getByTestId("work-order-split-run");
+    expect(within(popup).getByRole("heading", { name: "Add retry handling to webhook delivery" })).toBeInTheDocument();
+    expect(screen.getByTestId("lines-test-location")).toHaveTextContent(
+      `/org-1/workspaces/${PRIMARY_FACTORY_KEY}/work-order/842`,
+    );
+  });
+
+  it("keeps the line board without a popup when the permalink is unknown", () => {
+    useFactoryWorkOrders.mockReturnValue({ data: REVIEW_CANDIDATE_WORK_ORDERS });
+    renderLinesBoard(`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/work-order/999`);
+
+    expect(screen.getByTestId("lines-detail-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("work-order-split-run")).not.toBeInTheDocument();
   });
 
   it("lists the intakes at the head of the Backlog column, without a drawer", () => {

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -283,7 +283,7 @@ export function LinesPage() {
 
   const closePeek = () => {
     setPeekHint(null);
-    navigate(factoryHomePath(organizationId, factoryKey, selectedLine.id));
+    navigate(factoryHomePath(organizationId, factoryKey, selectedLine.id), { replace: true });
   };
 
   return (

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -86,6 +86,7 @@ import {
   factoryPRFeedbackPath,
   firstFactoryLineId,
   workOrderDetailPath,
+  workOrderBoardLineIdFromSearch,
   intakeIdFromSearch,
   intakeSettingsTabFromSearch,
   isIntakeSearchOpen,
@@ -181,8 +182,13 @@ export function LinesPage() {
     () => resolveWorkOrderByNumber(workOrders, routeOrderNumber, workOrdersLoading),
     [routeOrderNumber, workOrders, workOrdersLoading],
   );
+  const boardLineId = workOrderBoardLineIdFromSearch(search);
+  const searchLineId = lines.some((line) => line.id === boardLineId) ? boardLineId : undefined;
   const selectedLineId =
-    routeLineId ?? latestDispatchForLine(permalink.order ?? undefined)?.line?.id ?? firstFactoryLineId(factory);
+    routeLineId ??
+    searchLineId ??
+    latestDispatchForLine(permalink.order ?? undefined)?.line?.id ??
+    firstFactoryLineId(factory);
   const selectedLine = useMemo(
     () => (selectedLineId ? (lines.find((line) => line.id === selectedLineId) ?? null) : null),
     [lines, selectedLineId],
@@ -193,7 +199,7 @@ export function LinesPage() {
 
   const canonicalNumber = canonicalWorkOrderNumber(permalink.order);
   if (routeOrderNumber && canonicalNumber && workOrderRouteNeedsCanonicalRedirect(permalink, routeOrderNumber)) {
-    return <Navigate to={workOrderDetailPath(organizationId, factoryKey, canonicalNumber)} replace />;
+    return <Navigate to={workOrderDetailPath(organizationId, factoryKey, canonicalNumber, boardLineId)} replace />;
   }
 
   if (!selectedLine) {
@@ -260,7 +266,7 @@ export function LinesPage() {
     if (!number) {
       return;
     }
-    navigate(workOrderDetailPath(organizationId, factoryKey, number));
+    navigate(workOrderDetailPath(organizationId, factoryKey, number, selectedLine.id));
   };
 
   const closePeek = () => {

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -49,6 +49,8 @@ import { flattenWorkOrderExecutions, isQueuedStepRow } from "../lib/workOrderExe
 import {
   latestDispatchForLine,
   canonicalWorkOrderNumber,
+  peekOrderFromNavigationState,
+  resolvePeekWorkOrder,
   resolveWorkOrderByNumber,
   workOrderRouteNeedsCanonicalRedirect,
 } from "../lib/workOrderNumberResolution";
@@ -149,7 +151,7 @@ export function LinesPage() {
   const { organizationId, factoryId, factoryKey, factory, openCreateWorkOrder } = useFactoriesLayout();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   const { lineId: routeLineId, orderNumber: routeOrderNumber } = useParams<{ lineId?: string; orderNumber?: string }>();
-  const { search } = useLocation();
+  const { search, state: locationState } = useLocation();
   const navigate = useNavigate();
   const intakeOpen = isIntakeSearchOpen(search);
   const intakeId = intakeIdFromSearch(search);
@@ -167,6 +169,7 @@ export function LinesPage() {
   const configuredIntakes = useMemo(() => intakeSourcesFromFactoryIntakes(factoryIntakes), [factoryIntakes]);
   const showAddIntakeControl = useFactoryPreviewFlag("addIntakeControl");
   const [addIntakeOpen, setAddIntakeOpen] = useState(false);
+  const [peekHint, setPeekHint] = useState<FactoriesWorkOrder | null>(null);
   const cardActions = useWorkOrderCardActions(organizationId, factoryId);
   const addressingFeedbackOrderIds = useActivePRFeedbackWorkOrderIds(pullRequests);
 
@@ -193,7 +196,12 @@ export function LinesPage() {
     () => (selectedLineId ? (lines.find((line) => line.id === selectedLineId) ?? null) : null),
     [lines, selectedLineId],
   );
-  const peekOrder = permalink.status === "found" ? permalink.order : undefined;
+  const peekOrder = resolvePeekWorkOrder(
+    permalink,
+    routeOrderNumber,
+    peekOrderFromNavigationState(locationState),
+    peekHint,
+  );
 
   usePageTitle([selectedLine ? humanizeLineName(selectedLine.name) : "Board", factory?.name ?? "Workspace"]);
 
@@ -261,15 +269,19 @@ export function LinesPage() {
   };
 
   const openWorkOrder = (orderId: string, order?: FactoriesWorkOrder) => {
-    const target = order ?? workOrders.find((item) => item.id === orderId);
-    const number = canonicalWorkOrderNumber(target ?? null);
+    const target = order ?? workOrders.find((item) => item.id === orderId) ?? { id: orderId };
+    const number = canonicalWorkOrderNumber(target);
     if (!number) {
+      setPeekHint(target);
       return;
     }
-    navigate(workOrderDetailPath(organizationId, factoryKey, number, selectedLine.id));
+    navigate(workOrderDetailPath(organizationId, factoryKey, number, selectedLine.id), {
+      state: { peekOrder: target },
+    });
   };
 
   const closePeek = () => {
+    setPeekHint(null);
     navigate(factoryHomePath(organizationId, factoryKey, selectedLine.id));
   };
 

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -46,7 +46,12 @@ import {
   type PhaseGlyphKind,
 } from "../lib/linePhaseRuns";
 import { flattenWorkOrderExecutions, isQueuedStepRow } from "../lib/workOrderExecutions";
-import { latestDispatchForLine } from "../lib/workOrderNumberResolution";
+import {
+  latestDispatchForLine,
+  canonicalWorkOrderNumber,
+  resolveWorkOrderByNumber,
+  workOrderRouteNeedsCanonicalRedirect,
+} from "../lib/workOrderNumberResolution";
 import {
   applyWorkOrderFilters,
   applyWorkOrderScope,
@@ -80,6 +85,7 @@ import {
   factoryIntakePath,
   factoryPRFeedbackPath,
   firstFactoryLineId,
+  workOrderDetailPath,
   intakeIdFromSearch,
   intakeSettingsTabFromSearch,
   isIntakeSearchOpen,
@@ -141,7 +147,7 @@ function applyVisibleWorkOrders(
 export function LinesPage() {
   const { organizationId, factoryId, factoryKey, factory, openCreateWorkOrder } = useFactoriesLayout();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
-  const { lineId: routeLineId } = useParams<{ lineId: string }>();
+  const { lineId: routeLineId, orderNumber: routeOrderNumber } = useParams<{ lineId?: string; orderNumber?: string }>();
   const { search } = useLocation();
   const navigate = useNavigate();
   const intakeOpen = isIntakeSearchOpen(search);
@@ -149,7 +155,7 @@ export function LinesPage() {
   const intakeSettingsTab = intakeSettingsTabFromSearch(search);
   const prFeedbackOpen = isPRFeedbackSearchOpen(search);
   const prFeedbackSettingsTab = prFeedbackSettingsTabFromSearch(search);
-  const { data: workOrders = [] } = useFactoryWorkOrders(organizationId, factoryId);
+  const { data: workOrders = [], isLoading: workOrdersLoading } = useFactoryWorkOrders(organizationId, factoryId);
   const { data: pullRequests = [] } = useFactoryPullRequests(organizationId, factoryId);
   const { data: factoryApps = [] } = useFactoryApps(organizationId, factoryId);
   const { data: me } = useMe(false);
@@ -171,14 +177,33 @@ export function LinesPage() {
     [factory, listState.filters, listState.scope, listState.search, me?.id, workOrders],
   );
   const lines = useMemo(() => factory?.lines ?? [], [factory?.lines]);
-  const selectedLine = useMemo(
-    () => (routeLineId ? (lines.find((line) => line.id === routeLineId) ?? null) : null),
-    [lines, routeLineId],
+  const permalink = useMemo(
+    () => resolveWorkOrderByNumber(workOrders, routeOrderNumber, workOrdersLoading),
+    [routeOrderNumber, workOrders, workOrdersLoading],
   );
+  const selectedLineId =
+    routeLineId ?? latestDispatchForLine(permalink.order ?? undefined)?.line?.id ?? firstFactoryLineId(factory);
+  const selectedLine = useMemo(
+    () => (selectedLineId ? (lines.find((line) => line.id === selectedLineId) ?? null) : null),
+    [lines, selectedLineId],
+  );
+  const peekOrder = permalink.status === "found" ? permalink.order : undefined;
 
   usePageTitle([selectedLine ? humanizeLineName(selectedLine.name) : "Board", factory?.name ?? "Workspace"]);
 
+  const canonicalNumber = canonicalWorkOrderNumber(permalink.order);
+  if (routeOrderNumber && canonicalNumber && workOrderRouteNeedsCanonicalRedirect(permalink, routeOrderNumber)) {
+    return <Navigate to={workOrderDetailPath(organizationId, factoryKey, canonicalNumber)} replace />;
+  }
+
   if (!selectedLine) {
+    if (routeOrderNumber && permalink.status === "loading") {
+      return (
+        <div className="flex h-full min-h-0 min-w-0 w-full" data-testid="lines-detail-page">
+          <p className="px-6 py-8 text-[13px] text-muted-foreground">Loading work order…</p>
+        </div>
+      );
+    }
     return <Navigate to={factoryHomePath(organizationId, factoryKey, firstFactoryLineId(factory))} replace />;
   }
 
@@ -227,6 +252,19 @@ export function LinesPage() {
       .catch((error) => {
         showErrorToast(getUsageLimitToastMessage(error, "Failed to create intake automation"));
       });
+  };
+
+  const openWorkOrder = (orderId: string, order?: FactoriesWorkOrder) => {
+    const target = order ?? workOrders.find((item) => item.id === orderId);
+    const number = canonicalWorkOrderNumber(target ?? null);
+    if (!number) {
+      return;
+    }
+    navigate(workOrderDetailPath(organizationId, factoryKey, number));
+  };
+
+  const closePeek = () => {
+    navigate(factoryHomePath(organizationId, factoryKey, selectedLine.id));
   };
 
   return (
@@ -307,6 +345,9 @@ export function LinesPage() {
               addressingFeedbackOrderIds,
               ...cardActions,
             }}
+            peekOrder={peekOrder ?? undefined}
+            onOpenWorkOrder={openWorkOrder}
+            onClosePeek={closePeek}
           />
         </div>
       </div>
@@ -408,6 +449,9 @@ function LineDetail({
   intakePanel,
   verifyListener,
   workOrderCardContext,
+  peekOrder,
+  onOpenWorkOrder,
+  onClosePeek,
 }: {
   organizationId: string;
   factoryId: string;
@@ -421,6 +465,9 @@ function LineDetail({
   intakePanel: BacklogIntakePanel;
   verifyListener: LaneListener;
   workOrderCardContext: WorkOrderCardContext;
+  peekOrder?: FactoriesWorkOrder | null;
+  onOpenWorkOrder: (orderId: string, order?: FactoriesWorkOrder) => void;
+  onClosePeek: () => void;
 }) {
   const steps = line.steps ?? [];
   const fullBoard = useMemo(() => buildLinePhaseBoard(line, workOrders ?? [], apps), [line, workOrders, apps]);
@@ -431,17 +478,8 @@ function LineDetail({
     () => collectLineDoneOrders(workOrders ?? [], line, fullBoard),
     [workOrders, line, fullBoard],
   );
-  const [peekOrderId, setPeekOrderId] = useState<string | null>(null);
-  const [peekOrderHint, setPeekOrderHint] = useState<FactoriesWorkOrder | undefined>();
-  const peekOrder =
-    workOrders.find((order) => order.id === peekOrderId) ??
-    (peekOrderHint?.id === peekOrderId ? peekOrderHint : undefined);
+  const peekOrderId = peekOrder?.id ?? null;
   const backlogAnalysis = useFactoryBacklogAnalysis(organizationId, factoryId);
-
-  const openWorkOrder = (orderId: string, order?: FactoriesWorkOrder) => {
-    setPeekOrderHint(order);
-    setPeekOrderId(orderId);
-  };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="lines-detail">
@@ -463,7 +501,7 @@ function LineDetail({
           intakePanel={intakePanel}
           verifyListener={verifyListener}
           workOrderCardContext={workOrderCardContext}
-          onOpenWorkOrder={openWorkOrder}
+          onOpenWorkOrder={onOpenWorkOrder}
           analyzingOrderIds={backlogAnalysis.analyzingOrderIds}
         />
       )}
@@ -481,10 +519,7 @@ function LineDetail({
           isDispatching={workOrderCardContext.dispatchingOrderIds.has(peekOrderId)}
           onDispatch={workOrderCardContext.onDispatch}
           analysisRuns={backlogAnalysis.runsByWorkOrder.get(peekOrderId) ?? []}
-          onClose={() => {
-            setPeekOrderHint(undefined);
-            setPeekOrderId(null);
-          }}
+          onClose={onClosePeek}
         />
       ) : null}
     </div>
@@ -1105,7 +1140,7 @@ function PhaseRunCard({
         workOrderCardContext={workOrderCardContext}
         onOpen={() => {
           if (run.workOrderId) {
-            onOpenWorkOrder(run.workOrderId);
+            onOpenWorkOrder(run.workOrderId, run.order);
           }
         }}
       />

--- a/web_src/src/pages/factories/pages/WorkOrderDetailPage.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrderDetailPage.tsx
@@ -2,6 +2,7 @@ import { usePermissions } from "@/contexts/usePermissions";
 import {
   useFactory,
   useFactoryPullRequests,
+  useFactoryWorkOrders,
   useWorkOrder,
   useWorkOrderArtifacts,
   useWorkOrderEvents,
@@ -10,25 +11,38 @@ import { useWorkOrderChecks } from "@/hooks/useWorkOrderChecks";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 import { useMemo } from "react";
-import { Navigate } from "react-router";
+import { Navigate, useParams } from "react-router";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
-import { factoryHomePath, firstFactoryLineId } from "../lib/factoryPagePaths";
+import { factoryHomePath, firstFactoryLineId, workOrderDetailPath } from "../lib/factoryPagePaths";
 import { flattenWorkOrderEventsPages } from "../lib/workOrderEventsPagination";
+import { canonicalWorkOrderNumber, resolveWorkOrderByNumber } from "../lib/workOrderNumberResolution";
 import { getWorkOrderDetailDerived } from "../lib/workOrderProgress";
 import { presentWorkOrderChecks, type WorkOrderCheckPresentation } from "../lib/workOrderChecks";
 import { useWorkOrderDetailActions } from "../useWorkOrderDetailActions";
 import { WorkOrderDetailLoadedView } from "../WorkOrderDetailLoadedView";
 import { presentWorkOrderStatusNotes } from "../lib/workOrderStatusNote";
 import { factoryContentBodyClassName } from "./factoryPageLayoutStyles";
+import { LinesPage } from "./LinesPage";
 
+/** Canonical `/work-order/:orderNumber` opens the line board with the popup. */
 export function WorkOrderDetailPage() {
-  const { organizationId, factoryKey, factory } = useFactoriesLayout();
-  return <Navigate to={factoryHomePath(organizationId, factoryKey, firstFactoryLineId(factory))} replace />;
+  return <LinesPage />;
 }
 
-/** Legacy `/work-orders/:orderId` bookmarks go to the workspace line board. */
+/** Legacy `/work-orders/:orderId` bookmarks go to the canonical permalink. */
 export function LegacyWorkOrderDetailRedirect() {
-  const { organizationId, factoryKey, factory } = useFactoriesLayout();
+  const { orderId } = useParams<{ orderId: string }>();
+  const { organizationId, factoryId, factoryKey, factory } = useFactoriesLayout();
+  const { data: workOrders = [], isLoading } = useFactoryWorkOrders(organizationId, factoryId);
+  const resolution = resolveWorkOrderByNumber(workOrders, orderId, isLoading);
+  const number = canonicalWorkOrderNumber(resolution.order);
+
+  if (resolution.status === "loading") {
+    return null;
+  }
+  if (number) {
+    return <Navigate to={workOrderDetailPath(organizationId, factoryKey, number)} replace />;
+  }
   return <Navigate to={factoryHomePath(organizationId, factoryKey, firstFactoryLineId(factory))} replace />;
 }
 

--- a/web_src/src/pages/factories/pages/linesPageSpecRender.tsx
+++ b/web_src/src/pages/factories/pages/linesPageSpecRender.tsx
@@ -49,6 +49,7 @@ export function LinesBoardSpecHarness({
                 <Routes>
                   <Route path="/org-1/workspaces/:factoryKey/lines/:lineId" element={<LinesPage />} />
                   <Route path="/org-1/workspaces/:factoryKey/lines/:lineId/edit" element={<div>Edit line</div>} />
+                  <Route path="/org-1/workspaces/:factoryKey/work-order/:orderNumber" element={<LinesPage />} />
                 </Routes>
                 <LocationProbe />
               </FactoriesLayoutContext.Provider>

--- a/web_src/src/pages/factories/pages/linesPageSpecRender.tsx
+++ b/web_src/src/pages/factories/pages/linesPageSpecRender.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router";
 
 import type { FactoriesFactory } from "@/api-client";
 import { ThemeProvider } from "@/contexts/ThemeProvider";
@@ -16,7 +16,15 @@ import { LinesPage } from "./LinesPage";
 
 export function LocationProbe() {
   const location = useLocation();
-  return <div data-testid="lines-test-location">{`${location.pathname}${location.search}`}</div>;
+  const navigate = useNavigate();
+  return (
+    <>
+      <div data-testid="lines-test-location">{`${location.pathname}${location.search}`}</div>
+      <button type="button" data-testid="lines-test-back" onClick={() => navigate(-1)}>
+        Back
+      </button>
+    </>
+  );
 }
 
 export function LinesBoardSpecHarness({

--- a/web_src/src/pages/factories/pages/missions/MissionWorkOrderList.tsx
+++ b/web_src/src/pages/factories/pages/missions/MissionWorkOrderList.tsx
@@ -4,7 +4,7 @@ import type { OrgUserDisplayLookup } from "@/lib/orgUserDisplay";
 import { cn } from "@/lib/utils";
 import { Link } from "react-router";
 
-import { factoryHomePath } from "../../lib/factoryPagePaths";
+import { workOrderOpenPath } from "../../lib/factoryPagePaths";
 import type { WorkOrderListEntry } from "../../lib/workOrderListModel";
 import { getWorkOrderDisplayStatusMeta } from "../../lib/workOrderProgress";
 import { OrgUserReference } from "../../OrgUserReference";
@@ -47,7 +47,7 @@ function MissionWorkOrderRow({
   resolveUser: OrgUserDisplayLookup;
 }) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
-  const href = factoryHomePath(organizationId, factoryKey);
+  const href = workOrderOpenPath(organizationId, factoryKey, entry.order.number);
   const timeLabel = entry.updatedAtMs > 0 ? formatTimeAgo(new Date(entry.updatedAtMs)) : "—";
   const assignee = entry.order.assignees?.[0];
 

--- a/web_src/src/pages/factories/pages/overview-redesign/OverviewRedesignPage.tsx
+++ b/web_src/src/pages/factories/pages/overview-redesign/OverviewRedesignPage.tsx
@@ -9,7 +9,12 @@ import { cn } from "@/lib/utils";
 
 import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
-import { createWorkOrderPath, factoryHomePath, factoryVelocityPath, workOrdersPath } from "../../lib/factoryPagePaths";
+import {
+  createWorkOrderPath,
+  factoryVelocityPath,
+  workOrderOpenPath,
+  workOrdersPath,
+} from "../../lib/factoryPagePaths";
 import {
   WORK_ORDER_ATTENTION_CHIP_CLASSNAME,
   WORK_ORDER_ATTENTION_ICON,
@@ -159,9 +164,14 @@ const MAX_OVERVIEW_ROWS = 3;
  */
 const MAX_SHIPPED_ROWS = 5;
 
-/** Detail route from a workspace-scoped key like "SP-61" (mock-only parsing). */
-function workOrderHref(organizationId: string, factoryKey: string, _workOrderKey: string) {
-  return factoryHomePath(organizationId, factoryKey);
+function workOrderNumberFromKey(workOrderKey: string): string | undefined {
+  const digits = workOrderKey.match(/(\d+)$/)?.[1];
+  return digits;
+}
+
+/** Detail route from a workspace-scoped key like "SP-61". */
+function workOrderHref(organizationId: string, factoryKey: string, workOrderKey: string) {
+  return workOrderOpenPath(organizationId, factoryKey, workOrderNumberFromKey(workOrderKey));
 }
 
 /**

--- a/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrderCard.tsx
@@ -9,7 +9,7 @@ import {
   WORK_ORDER_ATTENTION_LABEL,
   type WorkOrderAttentionReason,
 } from "../lib/workOrderAttention";
-import { factoryHomePath } from "../lib/factoryPagePaths";
+import { workOrderOpenPath } from "../lib/factoryPagePaths";
 import type { WorkOrderListEntry } from "../lib/workOrderListModel";
 import { getWorkOrderDisplayStatusMeta } from "../lib/workOrderProgress";
 import { ConfidenceAnalyzingIndicator, ConfidenceMeter } from "./ConfidenceMeter";
@@ -78,7 +78,7 @@ export function WorkOrderCard({
   isAnalyzing = false,
 }: WorkOrderCardProps) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
-  const destination = href ?? factoryHomePath(organizationId, factoryKey, factoryLines[0]?.id);
+  const destination = href ?? workOrderOpenPath(organizationId, factoryKey, entry.order.number, factoryLines[0]?.id);
   const startedAt = entry.createdAtMs > 0 ? new Date(entry.createdAtMs) : null;
   const startedLabel = startedAt ? formatTimeAgo(startedAt) : "—";
   const showStart = entry.displayStatus === "draft";
@@ -118,10 +118,7 @@ export function WorkOrderCard({
         <div className="mt-2 flex items-center justify-between gap-2">
           <div className="flex h-5 min-w-0 items-center gap-1.5">
             {showStart ? null : <CardOwnerMark entry={entry} organizationId={organizationId} />}
-            <span
-              className="truncate text-[11px] leading-4 text-muted-foreground"
-              title={startedAt?.toLocaleString()}
-            >
+            <span className="truncate text-[11px] leading-4 text-muted-foreground" title={startedAt?.toLocaleString()}>
               {startedLabel}
             </span>
           </div>

--- a/web_src/src/pages/factories/workOrders/WorkOrdersCardClickHandler.spec.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersCardClickHandler.spec.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { FactoriesFactory, FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 
-import { factoryHomePath } from "../lib/factoryPagePaths";
+import { workOrderDetailPath } from "../lib/factoryPagePaths";
 import { buildWorkOrderListEntry } from "../lib/workOrderListModel";
 import { WorkOrderCard } from "./WorkOrderCard";
 import { WorkOrdersBoardView } from "./WorkOrdersBoardView";
@@ -38,7 +38,7 @@ const entry = buildWorkOrderListEntry(
   factory,
 );
 
-const boardHref = factoryHomePath(organizationId, factoryKey);
+const permalinkHref = workOrderDetailPath(organizationId, factoryKey, entry.order.number ?? "1");
 
 /**
  * Board and list views group entries into lanes based on display status.
@@ -107,7 +107,7 @@ function renderView(
         />
       ),
     },
-    { path: boardHref, element: <div>Line board</div> },
+    { path: permalinkHref, element: <div>Work order</div> },
   ]);
 
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -254,13 +254,13 @@ describe.each(views)("$name click handling", ({ Component }) => {
     expect(effectivePointerEvents(status)).toBe("none");
   });
 
-  it("navigates to the line board when the overlay link is activated", async () => {
+  it("navigates to the work order permalink when the overlay link is activated", async () => {
     const user = userEvent.setup();
     const { router, row } = renderView(Component);
 
     await user.click(within(row).getByRole("link", { name: `Open ${entry.title}` }));
 
-    expect(router.state.location.pathname).toBe(boardHref);
+    expect(router.state.location.pathname).toBe(permalinkHref);
   });
 });
 

--- a/web_src/src/pages/factories/workOrders/WorkOrdersListView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersListView.tsx
@@ -2,7 +2,7 @@ import type { FactoriesFactoryLine } from "@/api-client";
 import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/lib/date";
 import { Link } from "react-router";
-import { factoryHomePath } from "../lib/factoryPagePaths";
+import { workOrderOpenPath } from "../lib/factoryPagePaths";
 import { groupWorkOrderEntriesByLane, type WorkOrderListEntry } from "../lib/workOrderListModel";
 import { WORK_ORDER_BOARD_LANES, getWorkOrderDisplayStatusMeta } from "../lib/workOrderProgress";
 import { WorkOrderLineStep } from "./WorkOrderLineStep";
@@ -70,7 +70,7 @@ function ListRow({
   onAssigneesSave,
 }: WorkOrdersListViewProps & { entry: WorkOrderListEntry }) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
-  const href = factoryHomePath(organizationId, factoryKey, factoryLines[0]?.id);
+  const href = workOrderOpenPath(organizationId, factoryKey, entry.order.number, factoryLines[0]?.id);
   const timeLabel = entry.updatedAtMs > 0 ? formatTimeAgo(new Date(entry.updatedAtMs)) : "—";
   return (
     <article

--- a/web_src/src/pages/factories/workOrders/WorkOrdersTableView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersTableView.tsx
@@ -2,7 +2,7 @@ import type { FactoriesFactoryLine } from "@/api-client";
 import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/lib/date";
 import { Link } from "react-router";
-import { factoryHomePath } from "../lib/factoryPagePaths";
+import { workOrderOpenPath } from "../lib/factoryPagePaths";
 import type { WorkOrderListEntry } from "../lib/workOrderListModel";
 import { getWorkOrderDisplayStatusMeta } from "../lib/workOrderProgress";
 import { formatCompactTokens, formatUsdCents } from "../lib/workOrderUsage";
@@ -82,7 +82,7 @@ function TableRow({
   onAssigneesSave,
 }: WorkOrdersTableViewProps & { entry: WorkOrderListEntry }) {
   const meta = getWorkOrderDisplayStatusMeta(entry.displayStatus);
-  const href = factoryHomePath(organizationId, factoryKey, factoryLines[0]?.id);
+  const href = workOrderOpenPath(organizationId, factoryKey, entry.order.number, factoryLines[0]?.id);
   const timeLabel = entry.updatedAtMs > 0 ? formatTimeAgo(new Date(entry.updatedAtMs)) : "—";
   return (
     <article


### PR DESCRIPTION
## Summary

Email links and copyable work-order URLs opened an empty line board. The board stored the open popup only in React state, so the address bar never held a permalink.

This change keeps the split-run popup and treats `/work-order/:n` as the canonical URL. The line board resolves that number, opens the popup for that order, and writes the path when a card is opened. Close returns to `/lines/:lineId`. List, overview, mission, and legacy UUID routes use the same permalink. Status-note emails render the CTA as an HTML link when a URL is present.

## Test plan

- [ ] Open `/{org}/workspaces/{key}/work-order/{n}` from an email-shaped URL and confirm the line board loads with the split-run popup for that order.
- [ ] Click a work-order card on the line board and confirm the address bar changes to `/work-order/{n}`. Close the popup and confirm the URL returns to `/lines/:lineId`.
- [ ] Open a list, table, overview, or mission work-order link and confirm it opens the same permalink and popup.
- [ ] Open a legacy `/work-orders/:orderId` bookmark and confirm it redirects to `/work-order/{n}` with the popup open.
- [ ] Send or inspect a status-note email that has a CTA URL and confirm the CTA is an HTML link. Confirm the primary SuperPlane work-order link still uses the same URL shape.
- [ ] Open an unknown work-order number and confirm the line board stays visible without a popup.


Made with [Cursor](https://cursor.com)