### PR TITLE
feat: track LLM usage on PR runs

### DIFF
--- a/pkg/grpc/actions/factories/factory_pull_request_test.go
+++ b/pkg/grpc/actions/factories/factory_pull_request_test.go
@@ -180,10 +180,12 @@ func Test__FactoryPullRequestActions(t *testing.T) {
 		assert.Equal(t, order.Number, described.GetWorkOrderNumber())
 		assert.Equal(t, "Fix retry", described.GetTitle())
 		require.Len(t, described.GetRuns(), 1)
-		assert.Equal(t, run.ID.String(), described.GetRuns()[0].GetId())
-		assert.Equal(t, canvas.ID.String(), described.GetRuns()[0].GetCanvasId())
-		assert.Equal(t, canvasespb.CanvasRun_STATE_STARTED, described.GetRuns()[0].GetState())
-		assert.Equal(t, "Please add tests for the retry path.", described.GetRuns()[0].GetDescription())
+		linked := described.GetRuns()[0]
+		require.NotNil(t, linked.GetRun())
+		assert.Equal(t, run.ID.String(), linked.GetRun().GetId())
+		assert.Equal(t, canvas.ID.String(), linked.GetRun().GetCanvasId())
+		assert.Equal(t, canvasespb.CanvasRun_STATE_STARTED, linked.GetRun().GetState())
+		assert.Equal(t, "Please add tests for the retry path.", linked.GetDescription())
 	})
 
 	t.Run("updates a tracked pull request", func(t *testing.T) {

--- a/pkg/grpc/actions/factories/pull_request_serialization.go
+++ b/pkg/grpc/actions/factories/pull_request_serialization.go
@@ -6,7 +6,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
 	"github.com/superplanehq/superplane/pkg/models"
-	canvasespb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	pb "github.com/superplanehq/superplane/pkg/protos/factories"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
@@ -42,12 +41,24 @@ func serializeFactoryPullRequests(
 		return nil, err
 	}
 
+	runIDs := make([]uuid.UUID, 0)
+	for _, runs := range runsByPullRequest {
+		for _, linked := range runs {
+			runIDs = append(runIDs, linked.Run.ID)
+		}
+	}
+	usageByRun, err := models.SumUsageForRunTrees(tx, runIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	serialized := make([]*pb.FactoryPullRequest, 0, len(pullRequests))
 	for i := range pullRequests {
 		serialized = append(serialized, serializeFactoryPullRequest(
 			&pullRequests[i],
 			numbers[pullRequests[i].WorkOrderID],
 			runsByPullRequest[pullRequests[i].ID],
+			usageByRun,
 		))
 	}
 	return serialized, nil
@@ -57,6 +68,7 @@ func serializeFactoryPullRequest(
 	pullRequest *models.FactoryPullRequest,
 	workOrderNumber int64,
 	runs []models.FactoryPullRequestLinkedRun,
+	usageByRun map[uuid.UUID]models.UsageTotals,
 ) *pb.FactoryPullRequest {
 	serialized := &pb.FactoryPullRequest{
 		Id:              pullRequest.ID.String(),
@@ -71,7 +83,7 @@ func serializeFactoryPullRequest(
 		State:           pullRequestStateToProto(pullRequest.State),
 		CreatedAt:       timestamppb.New(pullRequest.CreatedAt),
 		UpdatedAt:       timestamppb.New(pullRequest.UpdatedAt),
-		Runs:            serializePullRequestRuns(runs),
+		Runs:            serializePullRequestRuns(runs, usageByRun),
 	}
 	if pullRequest.ExternalID != nil {
 		serialized.ExternalId = *pullRequest.ExternalID
@@ -85,14 +97,21 @@ func serializeFactoryPullRequest(
 	return serialized
 }
 
-func serializePullRequestRuns(runs []models.FactoryPullRequestLinkedRun) []*canvasespb.CanvasRunRef {
-	refs := make([]*canvasespb.CanvasRunRef, 0, len(runs))
+func serializePullRequestRuns(
+	runs []models.FactoryPullRequestLinkedRun,
+	usageByRun map[uuid.UUID]models.UsageTotals,
+) []*pb.FactoryPullRequestRun {
+	result := make([]*pb.FactoryPullRequestRun, 0, len(runs))
 	for _, linked := range runs {
-		ref := canvases.SerializeCanvasRunRef(linked.Run)
-		ref.Description = linked.Description
-		refs = append(refs, ref)
+		usage := usageByRun[linked.Run.ID]
+		result = append(result, &pb.FactoryPullRequestRun{
+			Description: linked.Description,
+			TotalTokens: usage.TotalTokens,
+			CostCents:   usage.CostCents(),
+			Run:         canvases.SerializeCanvasRunRef(linked.Run),
+		})
 	}
-	return refs
+	return result
 }
 
 func workOrderNumbersByID(tx *gorm.DB, workOrderIDs []uuid.UUID) (map[uuid.UUID]int64, error) {

--- a/pkg/grpc/actions/factories/serialization.go
+++ b/pkg/grpc/actions/factories/serialization.go
@@ -286,16 +286,9 @@ func serializeWorkOrder(
 	order *models.FactoryWorkOrder,
 	dispatches []models.FactoryWorkOrderLineDispatchRecord,
 	createdByAutomation *factory.AutomationRef,
+	usage models.UsageTotals,
 ) (*pb.WorkOrder, error) {
 	serializedDispatches := serializeWorkOrderLineDispatches(dispatches)
-
-	var totalTokens, totalCostCents int64
-	for _, d := range dispatches {
-		for _, e := range d.Executions {
-			totalTokens += e.TotalTokens
-			totalCostCents += e.CostCents
-		}
-	}
 
 	displayKey := ""
 	if f != nil {
@@ -320,8 +313,8 @@ func serializeWorkOrder(
 		Assignees:      serializeWorkOrderAssignees(order.Assignees),
 		LineDispatches: serializedDispatches,
 		CreatedBy:      serializeWorkOrderCreator(order, createdByAutomation),
-		TotalTokens:    totalTokens,
-		TotalCostCents: totalCostCents,
+		TotalTokens:    usage.TotalTokens,
+		TotalCostCents: usage.CostCents(),
 		StatusNotes:    statusNotes,
 		Origin:         serializeWorkOrderOrigin(order),
 	}, nil

--- a/pkg/grpc/actions/factories/serialization_test.go
+++ b/pkg/grpc/actions/factories/serialization_test.go
@@ -23,7 +23,7 @@ func mustSerializeWorkOrder(
 	createdByAutomation *factory.AutomationRef,
 ) *pb.WorkOrder {
 	t.Helper()
-	serialized, err := serializeWorkOrder(f, order, dispatches, createdByAutomation)
+	serialized, err := serializeWorkOrder(f, order, dispatches, createdByAutomation, models.UsageTotals{})
 	require.NoError(t, err)
 	return serialized
 }
@@ -165,7 +165,11 @@ func TestSerializeWorkOrder_LineDispatchesReplaceFlatExecutions(t *testing.T) {
 	}
 
 	order := &models.FactoryWorkOrder{ID: uuid.New()}
-	serialized := mustSerializeWorkOrder(t, nil, order, dispatches, nil)
+	serialized, err := serializeWorkOrder(nil, order, dispatches, nil, models.UsageTotals{
+		TotalTokens: 10,
+		CostMicros:  50_000,
+	})
+	require.NoError(t, err)
 
 	require.Len(t, serialized.LineDispatches, 1)
 	dispatch := serialized.LineDispatches[0]
@@ -183,7 +187,7 @@ func TestSerializeWorkOrder_LineDispatchesReplaceFlatExecutions(t *testing.T) {
 	assert.Equal(t, pb.WorkOrderExecution_STATE_FINISHED, execution.State)
 	assert.Equal(t, pb.WorkOrderExecution_RESULT_PASSED, execution.Result)
 
-	// Aggregate usage sums across every dispatch's step executions.
+	// Work-order totals come from the ledger, not from step-cache sums.
 	assert.EqualValues(t, 10, serialized.TotalTokens)
 	assert.EqualValues(t, 5, serialized.TotalCostCents)
 }

--- a/pkg/grpc/actions/factories/work_order_serialization.go
+++ b/pkg/grpc/actions/factories/work_order_serialization.go
@@ -26,11 +26,17 @@ func loadAndSerializeWorkOrder(ctx context.Context, factory *models.Factory, ord
 		return nil, err
 	}
 
+	usageByOrder, err := models.SumUsageForWorkOrders(db, []uuid.UUID{order.ID})
+	if err != nil {
+		return nil, err
+	}
+
 	return serializeWorkOrder(
 		factory,
 		order,
 		dispatchesByOrderID[order.ID],
 		creatorAutomations[order.ID],
+		usageByOrder[order.ID],
 	)
 }
 
@@ -61,6 +67,11 @@ func loadAndSerializeWorkOrders(ctx context.Context, factory *models.Factory, or
 		return nil, err
 	}
 
+	usageByOrder, err := models.SumUsageForWorkOrders(db, workOrderIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	result := make([]*pb.WorkOrder, len(orders))
 	for i := range orders {
 		serialized, err := serializeWorkOrder(
@@ -68,6 +79,7 @@ func loadAndSerializeWorkOrders(ctx context.Context, factory *models.Factory, or
 			&orders[i],
 			dispatchesByOrderID[orders[i].ID],
 			creatorAutomations[orders[i].ID],
+			usageByOrder[orders[i].ID],
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/models/factory_pull_request.go
+++ b/pkg/models/factory_pull_request.go
@@ -449,6 +449,33 @@ func ListPullRequestRuns(tx *gorm.DB, pullRequestIDs []uuid.UUID) (map[uuid.UUID
 	return runsByPullRequest, nil
 }
 
+// FindWorkOrderIDsByLinkedRunIDs returns the work order each canvas run is
+// linked to through factory_pull_request_runs.
+func FindWorkOrderIDsByLinkedRunIDs(tx *gorm.DB, runIDs []uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
+	result := map[uuid.UUID]uuid.UUID{}
+	if len(runIDs) == 0 {
+		return result, nil
+	}
+
+	type row struct {
+		RunID       uuid.UUID
+		WorkOrderID uuid.UUID
+	}
+	var rows []row
+	err := tx.Table("factory_pull_request_runs").
+		Select("factory_pull_request_runs.run_id, factory_pull_requests.work_order_id").
+		Joins("JOIN factory_pull_requests ON factory_pull_requests.id = factory_pull_request_runs.pull_request_id").
+		Where("factory_pull_request_runs.run_id IN ?", runIDs).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[row.RunID] = row.WorkOrderID
+	}
+	return result, nil
+}
+
 func ListPullRequestsByWorkOrderIDs(tx *gorm.DB, workOrderIDs []uuid.UUID) (map[uuid.UUID][]FactoryPullRequest, error) {
 	result := map[uuid.UUID][]FactoryPullRequest{}
 	if len(workOrderIDs) == 0 {

--- a/pkg/models/llm_usage_event.go
+++ b/pkg/models/llm_usage_event.go
@@ -84,20 +84,21 @@ type LLMUsageEventInput struct {
 }
 
 // RecordUsage inserts one factory-linked usage row and copies ledger totals
-// into the step cache so in-progress work orders show spend. Non-factory
-// runs are skipped. Each billed call gets its own row, including retries
-// of the same node execution.
+// into the line-step cache when the run belongs to a line execution.
+// Factory canvases without a line step (Backlog analysis, PR feedback)
+// still persist. Org canvases are skipped. Each billed call gets its own
+// row, including retries of the same node execution.
 func RecordUsage(tx *gorm.DB, in LLMUsageEventInput) error {
 	if in.Provider == "" || in.Model == "" || in.NodeExecutionID == uuid.Nil || in.CanvasRunID == uuid.Nil {
 		return fmt.Errorf("llm usage event requires provider, model, node execution, and canvas run")
 	}
 
-	execution, err := FindWorkOrderExecutionForRun(tx, in.CanvasRunID)
+	scope, err := resolveUsageScope(tx, in.CanvasRunID)
 	if err != nil {
-		if errors.Is(err, ErrFactoryWorkOrderExecutionNotFound) {
-			return nil
-		}
 		return err
+	}
+	if scope == nil {
+		return nil
 	}
 
 	total := in.TotalTokens
@@ -132,7 +133,7 @@ func RecordUsage(tx *gorm.DB, in LLMUsageEventInput) error {
 
 	billedMicros := providerCostMicros
 	if fundingSource == UsageFundingSourceHosted {
-		markupBPS, markupErr := ResolveOrganizationMarkupBPS(tx, execution.OrganizationID)
+		markupBPS, markupErr := ResolveOrganizationMarkupBPS(tx, scope.OrganizationID)
 		if markupErr != nil {
 			return markupErr
 		}
@@ -142,12 +143,12 @@ func RecordUsage(tx *gorm.DB, in LLMUsageEventInput) error {
 	now := time.Now()
 	event := LLMUsageEvent{
 		ID:                   uuid.New(),
-		OrganizationID:       execution.OrganizationID,
-		FactoryID:            &execution.FactoryID,
-		WorkOrderID:          &execution.WorkOrderID,
-		LineID:               &execution.LineID,
-		LineDispatchID:       &execution.LineDispatchID,
-		WorkOrderExecutionID: &execution.ID,
+		OrganizationID:       scope.OrganizationID,
+		FactoryID:            &scope.FactoryID,
+		WorkOrderID:          scope.WorkOrderID,
+		LineID:               scope.LineID,
+		LineDispatchID:       scope.LineDispatchID,
+		WorkOrderExecutionID: scope.WorkOrderExecutionID,
 		CanvasRunID:          in.CanvasRunID,
 		NodeExecutionID:      in.NodeExecutionID,
 		NodeID:               in.NodeID,
@@ -178,8 +179,10 @@ func RecordUsage(tx *gorm.DB, in LLMUsageEventInput) error {
 		return err
 	}
 
-	if err := execution.RollupUsage(tx); err != nil {
-		return err
+	if scope.execution != nil {
+		if err := scope.execution.RollupUsage(tx); err != nil {
+			return err
+		}
 	}
 	return ReleaseHostedCreditHold(tx, in.NodeExecutionID)
 }
@@ -224,6 +227,104 @@ func (t UsageTotals) CostCents() int64 {
 
 func (r UsageByModel) CostCents() int64 {
 	return pricebook.MicrosToCents(r.CostMicros)
+}
+
+type usageSumRow struct {
+	ID          uuid.UUID
+	TotalTokens int64
+	CostMicros  int64
+}
+
+func scanUsageSums(rows []usageSumRow) map[uuid.UUID]UsageTotals {
+	result := make(map[uuid.UUID]UsageTotals, len(rows))
+	for _, row := range rows {
+		result[row.ID] = UsageTotals{TotalTokens: row.TotalTokens, CostMicros: row.CostMicros}
+	}
+	return result
+}
+
+// SumUsageForWorkOrders returns ledger totals keyed by work order. Missing
+// IDs are absent from the map (zero value).
+func SumUsageForWorkOrders(tx *gorm.DB, workOrderIDs []uuid.UUID) (map[uuid.UUID]UsageTotals, error) {
+	if len(workOrderIDs) == 0 {
+		return map[uuid.UUID]UsageTotals{}, nil
+	}
+
+	var rows []usageSumRow
+	err := tx.Model(&LLMUsageEvent{}).
+		Select("work_order_id AS id, COALESCE(SUM(total_tokens), 0) AS total_tokens, COALESCE(SUM(cost_micros), 0) AS cost_micros").
+		Where("work_order_id IN ?", workOrderIDs).
+		Group("work_order_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return scanUsageSums(rows), nil
+}
+
+// SumUsageForRunTrees returns ledger totals for each root run, including
+// spend recorded on descendant runs.
+func SumUsageForRunTrees(tx *gorm.DB, rootIDs []uuid.UUID) (map[uuid.UUID]UsageTotals, error) {
+	result := make(map[uuid.UUID]UsageTotals, len(rootIDs))
+	if len(rootIDs) == 0 {
+		return result, nil
+	}
+
+	rootOf := make(map[uuid.UUID]uuid.UUID, len(rootIDs))
+	treeIDs := make([]uuid.UUID, 0, len(rootIDs))
+	for _, id := range rootIDs {
+		rootOf[id] = id
+		treeIDs = append(treeIDs, id)
+	}
+
+	frontier := append([]uuid.UUID{}, rootIDs...)
+	for len(frontier) > 0 {
+		var children []CanvasRun
+		err := tx.Select("id", "parent_run_id").Where("parent_run_id IN ?", frontier).Find(&children).Error
+		if err != nil {
+			return nil, err
+		}
+
+		frontier = frontier[:0]
+		for i := range children {
+			child := children[i]
+			if child.ParentRunID == nil {
+				continue
+			}
+			parentRoot, ok := rootOf[*child.ParentRunID]
+			if !ok {
+				continue
+			}
+			if _, seen := rootOf[child.ID]; seen {
+				continue
+			}
+			rootOf[child.ID] = parentRoot
+			treeIDs = append(treeIDs, child.ID)
+			frontier = append(frontier, child.ID)
+		}
+	}
+
+	var rows []usageSumRow
+	err := tx.Model(&LLMUsageEvent{}).
+		Select("canvas_run_id AS id, COALESCE(SUM(total_tokens), 0) AS total_tokens, COALESCE(SUM(cost_micros), 0) AS cost_micros").
+		Where("canvas_run_id IN ?", treeIDs).
+		Group("canvas_run_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		rootID, ok := rootOf[row.ID]
+		if !ok {
+			continue
+		}
+		totals := result[rootID]
+		totals.TotalTokens += row.TotalTokens
+		totals.CostMicros += row.CostMicros
+		result[rootID] = totals
+	}
+	return result, nil
 }
 
 func usageReportQuery(tx *gorm.DB, filter UsageReportFilter) *gorm.DB {

--- a/pkg/models/llm_usage_event_test.go
+++ b/pkg/models/llm_usage_event_test.go
@@ -143,13 +143,18 @@ func Test__RecordUsage__ChildRunUsesParentFactoryExecution(t *testing.T) {
 	assertInProgressExecutionUsage(t, db, execution.ID, 120, 0)
 }
 
-func Test__RecordUsage__SkipsRunsWithoutWorkOrderExecution(t *testing.T) {
+func Test__RecordUsage__SkipsRunsWithoutFactoryCanvas(t *testing.T) {
 	r := support.Setup(t)
 	db := database.DB(t.Context())
 
-	err := models.RecordUsage(db, models.LLMUsageEventInput{
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, nil)
+	event := support.EmitCanvasEventForNode(t, canvas.ID, "trigger", "default", nil)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(db, event)
+	require.NoError(t, err)
+
+	err = models.RecordUsage(db, models.LLMUsageEventInput{
 		OrganizationID:  r.Organization.ID,
-		CanvasRunID:     uuid.New(),
+		CanvasRunID:     run.ID,
 		NodeExecutionID: uuid.New(),
 		NodeID:          "prompt",
 		Provider:        models.UsageProviderOpenAI,
@@ -166,6 +171,145 @@ func Test__RecordUsage__SkipsRunsWithoutWorkOrderExecution(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), totals.TotalTokens)
 	assert.Empty(t, byModel)
+}
+
+func Test__RecordUsage__FactoryCanvasWithoutLineStepPersists(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	run := startFactoryCanvasRun(t, r, factory.ID, nil)
+
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, run.ID)))
+
+	event := requireUsageEventForRun(t, db, run.ID)
+	assert.Equal(t, factory.ID, *event.FactoryID)
+	assert.Nil(t, event.WorkOrderID)
+	assert.Nil(t, event.WorkOrderExecutionID)
+	assert.Equal(t, int64(1_000_000), event.TotalTokens)
+}
+
+func Test__RecordUsage__AttachesWorkOrderFromPullRequestLink(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, order := createFactoryOrder(t, r)
+	run := startFactoryCanvasRun(t, r, factory.ID, nil)
+	pullRequest, err := order.CreatePullRequest(db, models.FactoryPullRequestParams{
+		URL: "https://github.com/acme/app/pull/99",
+	})
+	require.NoError(t, err)
+	require.NoError(t, pullRequest.LinkRun(db, run.ID, "Please add tests."))
+
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, run.ID)))
+
+	event := requireUsageEventForRun(t, db, run.ID)
+	require.NotNil(t, event.WorkOrderID)
+	assert.Equal(t, order.ID, *event.WorkOrderID)
+	assert.Nil(t, event.WorkOrderExecutionID)
+}
+
+func Test__RecordUsage__ChildRunInheritsPullRequestWorkOrder(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, order := createFactoryOrder(t, r)
+	parent := startFactoryCanvasRun(t, r, factory.ID, nil)
+	pullRequest, err := order.CreatePullRequest(db, models.FactoryPullRequestParams{
+		URL: "https://github.com/acme/app/pull/100",
+	})
+	require.NoError(t, err)
+	require.NoError(t, pullRequest.LinkRun(db, parent.ID, "Address review."))
+
+	now := parent.CreatedAt
+	if now == nil {
+		created := time.Now()
+		now = &created
+	}
+	child := models.CanvasRun{
+		ID:               uuid.New(),
+		WorkflowID:       parent.WorkflowID,
+		NodeID:           parent.NodeID,
+		VersionID:        parent.VersionID,
+		ParentRunID:      &parent.ID,
+		ParentWorkflowID: &parent.WorkflowID,
+		State:            models.CanvasRunStateStarted,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	require.NoError(t, db.Create(&child).Error)
+
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, child.ID)))
+
+	event := requireUsageEventForRun(t, db, child.ID)
+	require.NotNil(t, event.WorkOrderID)
+	assert.Equal(t, order.ID, *event.WorkOrderID)
+}
+
+func Test__RecordUsage__AttachesWorkOrderFromOnWorkOrderEvent(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, order := createFactoryOrder(t, r)
+	run := startFactoryCanvasRun(t, r, factory.ID, map[string]any{
+		"type": "workOrder.created",
+		"data": map[string]any{
+			"workOrder": map[string]any{"id": order.ID.String()},
+		},
+	})
+
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, run.ID)))
+
+	event := requireUsageEventForRun(t, db, run.ID)
+	require.NotNil(t, event.WorkOrderID)
+	assert.Equal(t, order.ID, *event.WorkOrderID)
+	assert.Nil(t, event.WorkOrderExecutionID)
+}
+
+func Test__SumUsageForRunTrees__IncludesDescendantSpend(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	parent := startFactoryCanvasRun(t, r, factory.ID, nil)
+	now := parent.CreatedAt
+	if now == nil {
+		created := time.Now()
+		now = &created
+	}
+	child := models.CanvasRun{
+		ID:               uuid.New(),
+		WorkflowID:       parent.WorkflowID,
+		NodeID:           parent.NodeID,
+		VersionID:        parent.VersionID,
+		ParentRunID:      &parent.ID,
+		ParentWorkflowID: &parent.WorkflowID,
+		State:            models.CanvasRunStateStarted,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	require.NoError(t, db.Create(&child).Error)
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, child.ID)))
+
+	sums, err := models.SumUsageForRunTrees(db, []uuid.UUID{parent.ID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1_000_000), sums[parent.ID].TotalTokens)
+	assert.Equal(t, int64(300), sums[parent.ID].CostCents())
+}
+
+func Test__SumUsageForWorkOrders__SumsLedgerByWorkOrder(t *testing.T) {
+	r := support.Setup(t)
+	db := database.DB(t.Context())
+	factory, order := createFactoryOrder(t, r)
+	run := startFactoryCanvasRun(t, r, factory.ID, map[string]any{
+		"type": "workOrder.created",
+		"data": map[string]any{
+			"workOrder": map[string]any{"id": order.ID.String()},
+		},
+	})
+	require.NoError(t, models.RecordUsage(db, sonnetUsage(t, r, run.ID)))
+
+	sums, err := models.SumUsageForWorkOrders(db, []uuid.UUID{order.ID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1_000_000), sums[order.ID].TotalTokens)
+	assert.Equal(t, int64(300), sums[order.ID].CostCents())
 }
 
 func Test__RecordUsage__SameIdempotencyKeyRecordsOnce(t *testing.T) {
@@ -259,4 +403,48 @@ func dispatchWorkOrderExecution(t *testing.T, r *support.ResourceRegistry) *mode
 	}))
 	require.NotNil(t, execution)
 	return execution
+}
+
+func createFactoryOrder(t *testing.T, r *support.ResourceRegistry) (*models.Factory, *models.FactoryWorkOrder) {
+	t.Helper()
+	db := database.DB(t.Context())
+	factory, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	order, err := factory.CreateWorkOrder(db, "Order", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	return factory, order
+}
+
+func startFactoryCanvasRun(t *testing.T, r *support.ResourceRegistry, factoryID uuid.UUID, data map[string]any) *models.CanvasRun {
+	t.Helper()
+	db := database.DB(t.Context())
+	canvas, entry := support.CreateFactoryAppWithOnRunTrigger(t, r, factoryID, "score", "start")
+	if data == nil {
+		data = map[string]any{"key": "value"}
+	}
+	event := support.EmitCanvasEventForNodeWithData(t, canvas.ID, entry, "default", nil, data)
+	run, err := models.FindOrCreateCanvasRunForRootEventInTransaction(db, event)
+	require.NoError(t, err)
+	return run
+}
+
+func sonnetUsage(t *testing.T, r *support.ResourceRegistry, runID uuid.UUID) models.LLMUsageEventInput {
+	t.Helper()
+	return models.LLMUsageEventInput{
+		OrganizationID:  r.Organization.ID,
+		CanvasRunID:     runID,
+		NodeExecutionID: uuid.New(),
+		NodeID:          "prompt",
+		Provider:        models.UsageProviderAnthropic,
+		Model:           "claude-sonnet-4-6",
+		InputTokens:     1_000_000,
+		TotalTokens:     1_000_000,
+	}
+}
+
+func requireUsageEventForRun(t *testing.T, db *gorm.DB, runID uuid.UUID) models.LLMUsageEvent {
+	t.Helper()
+	var event models.LLMUsageEvent
+	require.NoError(t, db.Where("canvas_run_id = ?", runID).First(&event).Error)
+	return event
 }

--- a/pkg/models/llm_usage_scope.go
+++ b/pkg/models/llm_usage_scope.go
@@ -1,0 +1,219 @@
+package models
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// usageScope is the factory billing context for one LLM call.
+type usageScope struct {
+	OrganizationID       uuid.UUID
+	FactoryID            uuid.UUID
+	WorkOrderID          *uuid.UUID
+	LineID               *uuid.UUID
+	LineDispatchID       *uuid.UUID
+	WorkOrderExecutionID *uuid.UUID
+	execution            *FactoryWorkOrderExecution
+}
+
+func scopeFromLineExecution(execution *FactoryWorkOrderExecution) *usageScope {
+	workOrderID := execution.WorkOrderID
+	lineID := execution.LineID
+	dispatchID := execution.LineDispatchID
+	executionID := execution.ID
+	return &usageScope{
+		OrganizationID:       execution.OrganizationID,
+		FactoryID:            execution.FactoryID,
+		WorkOrderID:          &workOrderID,
+		LineID:               &lineID,
+		LineDispatchID:       &dispatchID,
+		WorkOrderExecutionID: &executionID,
+		execution:            execution,
+	}
+}
+
+// resolveUsageScope finds factory billing fields for a canvas run. Line
+// executions win. Otherwise the canvas must belong to a factory. The work
+// order comes from a linked PR run, a source_run_id, or an onWorkOrder
+// root event. Returns nil when the run is not a factory canvas.
+func resolveUsageScope(tx *gorm.DB, runID uuid.UUID) (*usageScope, error) {
+	execution, err := FindWorkOrderExecutionForRun(tx, runID)
+	if err == nil {
+		return scopeFromLineExecution(execution), nil
+	}
+	if !errors.Is(err, ErrFactoryWorkOrderExecutionNotFound) {
+		return nil, err
+	}
+
+	canvas, err := findFactoryCanvasForRun(tx, runID)
+	if err != nil || canvas == nil {
+		return nil, err
+	}
+
+	workOrderID, err := findWorkOrderIDForFactoryRun(tx, runID, *canvas.FactoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &usageScope{
+		OrganizationID: canvas.OrganizationID,
+		FactoryID:      *canvas.FactoryID,
+		WorkOrderID:    workOrderID,
+	}, nil
+}
+
+func findFactoryCanvasForRun(tx *gorm.DB, runID uuid.UUID) (*Canvas, error) {
+	seen := make(map[uuid.UUID]struct{}, 8)
+	current := runID
+	for range maxFactoryExecutionRunAncestors {
+		if _, visited := seen[current]; visited {
+			return nil, nil
+		}
+		seen[current] = struct{}{}
+
+		run, err := FindUnscopedCanvasRun(tx, current)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		canvas, err := FindCanvasWithoutOrgScopeInTransaction(tx, run.WorkflowID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		if canvas.FactoryID != nil && *canvas.FactoryID != uuid.Nil {
+			return canvas, nil
+		}
+
+		if run.ParentRunID == nil || *run.ParentRunID == uuid.Nil {
+			return nil, nil
+		}
+		current = *run.ParentRunID
+	}
+	return nil, nil
+}
+
+func findWorkOrderIDForFactoryRun(tx *gorm.DB, runID, factoryID uuid.UUID) (*uuid.UUID, error) {
+	runIDs, err := ancestorRunIDs(tx, runID)
+	if err != nil || len(runIDs) == 0 {
+		return nil, err
+	}
+
+	linked, err := FindWorkOrderIDsByLinkedRunIDs(tx, runIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range runIDs {
+		if workOrderID, ok := linked[id]; ok {
+			return &workOrderID, nil
+		}
+	}
+
+	orders, err := ListWorkOrdersBySourceRunIDs(tx, factoryID, runIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range runIDs {
+		if order, ok := orders[id]; ok {
+			workOrderID := order.ID
+			return &workOrderID, nil
+		}
+	}
+
+	for _, id := range runIDs {
+		workOrderID, err := workOrderIDFromRunEvents(tx, id)
+		if err != nil {
+			return nil, err
+		}
+		if workOrderID != nil {
+			return workOrderID, nil
+		}
+	}
+	return nil, nil
+}
+
+func ancestorRunIDs(tx *gorm.DB, runID uuid.UUID) ([]uuid.UUID, error) {
+	ids := make([]uuid.UUID, 0, 8)
+	seen := make(map[uuid.UUID]struct{}, 8)
+	current := runID
+	for range maxFactoryExecutionRunAncestors {
+		if _, visited := seen[current]; visited {
+			break
+		}
+		seen[current] = struct{}{}
+
+		run, err := FindUnscopedCanvasRun(tx, current)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				break
+			}
+			return nil, err
+		}
+		ids = append(ids, run.ID)
+		if run.ParentRunID == nil || *run.ParentRunID == uuid.Nil {
+			break
+		}
+		current = *run.ParentRunID
+	}
+	return ids, nil
+}
+
+func workOrderIDFromRunEvents(tx *gorm.DB, runID uuid.UUID) (*uuid.UUID, error) {
+	var event CanvasEvent
+	err := tx.Where("run_id = ?", runID).Order("created_at ASC").First(&event).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return workOrderIDFromEventData(event.Data.Data()), nil
+}
+
+func workOrderIDFromEventData(data any) *uuid.UUID {
+	payload, ok := objectMap(RootEventSourcePayload(data))
+	if !ok {
+		return nil
+	}
+
+	workOrder, ok := objectMap(payload["workOrder"])
+	if !ok {
+		workOrder, ok = objectMap(payload["work_order"])
+	}
+	if !ok {
+		return nil
+	}
+
+	raw, ok := workOrder["id"].(string)
+	if !ok || raw == "" {
+		return nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return nil
+	}
+	return &id
+}
+
+func objectMap(value any) (map[string]any, bool) {
+	switch current := value.(type) {
+	case map[string]any:
+		return current, true
+	case json.RawMessage:
+		var decoded map[string]any
+		if err := json.Unmarshal(current, &decoded); err != nil {
+			return nil, false
+		}
+		return decoded, true
+	default:
+		return nil, false
+	}
+}

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -918,6 +918,13 @@ message DeleteFactoryPRFeedbackHandlerRequest {
 
 message DeleteFactoryPRFeedbackHandlerResponse {}
 
+message FactoryPullRequestRun {
+  string description = 1;
+  int64 total_tokens = 2;
+  int64 cost_cents = 3;
+  Superplane.Canvases.CanvasRunRef run = 4;
+}
+
 message FactoryPullRequest {
   enum Provider {
     PROVIDER_UNSPECIFIED = 0;
@@ -948,7 +955,7 @@ message FactoryPullRequest {
   google.protobuf.Timestamp closed_at = 13;
   google.protobuf.Timestamp created_at = 14;
   google.protobuf.Timestamp updated_at = 15;
-  repeated Superplane.Canvases.CanvasRunRef runs = 16;
+  repeated FactoryPullRequestRun runs = 16;
 }
 
 message ListFactoryPullRequestsRequest {

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsModel.spec.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsModel.spec.ts
@@ -21,25 +21,24 @@ describe("prFeedbackLogRunsFromPullRequests", () => {
         workOrderId: "wo-1",
         number: "42",
         runs: [
-          run({
-            id: "later",
-            canvasId: "c-1",
-            state: "STATE_STARTED",
-            createdAt: "2026-08-26T12:00:00Z",
-          }),
-          run({
-            canvasId: "c-2",
-            state: "STATE_FINISHED",
-            result: "RESULT_PASSED",
-            createdAt: "2026-08-26T08:00:00Z",
-          }),
-          run({
-            id: "older",
-            canvasId: "c-2",
-            state: "STATE_FINISHED",
-            result: "RESULT_PASSED",
-            createdAt: "2026-08-26T11:00:00Z",
-          }),
+          { run: run({ id: "later", canvasId: "c-1", state: "STATE_STARTED", createdAt: "2026-08-26T12:00:00Z" }) },
+          {
+            run: run({
+              canvasId: "c-2",
+              state: "STATE_FINISHED",
+              result: "RESULT_PASSED",
+              createdAt: "2026-08-26T08:00:00Z",
+            }),
+          },
+          {
+            run: run({
+              id: "older",
+              canvasId: "c-2",
+              state: "STATE_FINISHED",
+              result: "RESULT_PASSED",
+              createdAt: "2026-08-26T11:00:00Z",
+            }),
+          },
         ],
       },
     ];
@@ -93,10 +92,10 @@ describe("activePRFeedbackWorkOrderIds", () => {
   it("returns work orders that have an active pull request run", () => {
     expect(
       activePRFeedbackWorkOrderIds([
-        { workOrderId: "wo-1", runs: [{ id: "r1", state: "STATE_PENDING" }] },
-        { workOrderId: "wo-2", runs: [{ id: "r2", state: "STATE_FINISHED", result: "RESULT_PASSED" }] },
-        { workOrderId: "wo-3", runs: [{ id: "r3", state: "STATE_STARTED" }] },
-        { runs: [{ id: "r4", state: "STATE_PENDING" }] },
+        { workOrderId: "wo-1", runs: [{ run: { id: "r1", state: "STATE_PENDING" } }] },
+        { workOrderId: "wo-2", runs: [{ run: { id: "r2", state: "STATE_FINISHED", result: "RESULT_PASSED" } }] },
+        { workOrderId: "wo-3", runs: [{ run: { id: "r3", state: "STATE_STARTED" } }] },
+        { runs: [{ run: { id: "r4", state: "STATE_PENDING" } }] },
       ]),
     ).toEqual(new Set(["wo-1", "wo-3"]));
   });

--- a/web_src/src/pages/factories/pages/prFeedbackSettingsModel.ts
+++ b/web_src/src/pages/factories/pages/prFeedbackSettingsModel.ts
@@ -96,7 +96,7 @@ export function activePRFeedbackWorkOrderIds(pullRequests: FactoriesFactoryPullR
     if (!workOrderId) {
       continue;
     }
-    if ((pullRequest.runs ?? []).some(isActiveCanvasRun)) {
+    if ((pullRequest.runs ?? []).some((linked) => isActiveCanvasRun(linked.run))) {
       ids.add(workOrderId);
     }
   }
@@ -107,6 +107,9 @@ export type PRFeedbackLogRun = {
   canvasId: string;
   handlerName?: string;
   pullRequestNumber?: string;
+  description?: string;
+  costCents?: string;
+  totalTokens?: string;
   run: CanvasesCanvasRunRef;
 };
 

--- a/web_src/src/pages/factories/pages/useWorkOrderPRFeedbackRunHref.ts
+++ b/web_src/src/pages/factories/pages/useWorkOrderPRFeedbackRunHref.ts
@@ -27,14 +27,24 @@ export function prFeedbackLogRunsFromPullRequests(
 
   return pullRequests.flatMap((pullRequest) =>
     [...(pullRequest.runs ?? [])]
-      .filter((run) => Boolean(run.id && run.canvasId))
-      .sort((left, right) => Date.parse(left.createdAt ?? "") - Date.parse(right.createdAt ?? ""))
-      .map((run) => ({
-        canvasId: run.canvasId ?? "",
-        handlerName: handlerNameByCanvasId.get(run.canvasId ?? ""),
-        pullRequestNumber: pullRequest.number,
-        run,
-      })),
+      .flatMap((linked) => {
+        const run = linked.run;
+        if (!run?.id || !run.canvasId) {
+          return [];
+        }
+        return [
+          {
+            canvasId: run.canvasId,
+            handlerName: handlerNameByCanvasId.get(run.canvasId),
+            pullRequestNumber: pullRequest.number,
+            description: linked.description,
+            costCents: linked.costCents,
+            totalTokens: linked.totalTokens,
+            run,
+          },
+        ];
+      })
+      .sort((left, right) => Date.parse(left.run.createdAt ?? "") - Date.parse(right.run.createdAt ?? "")),
   );
 }
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.titleLine.spec.tsx
@@ -47,6 +47,19 @@ describe("PhaseLogCard title line", () => {
     expect(within(row).getByRole("button", { name: "Plan" }).querySelector(".lucide-chevron-right")).toBeNull();
   });
 
+  it("shows cost and tokens next to duration when the phase has spend", () => {
+    render(<PhaseLogCard phase={{ ...PHASE, costCents: "45", totalTokens: "1200" }} expanded={false} />);
+
+    const row = screen.getByTestId("split-run-phase-plan");
+    expect(within(row).getByTestId("split-run-phase-duration-plan")).toHaveTextContent("$0.45 · 1.2k · 01:00");
+  });
+
+  it("shows tokens alone when the phase has no dollar spend", () => {
+    render(<PhaseLogCard phase={{ ...PHASE, totalTokens: "1200" }} expanded={false} />);
+
+    expect(screen.getByTestId("split-run-phase-duration-plan")).toHaveTextContent("1.2k · 01:00");
+  });
+
   it("uses one mono face and size on the name and artifact", () => {
     render(
       <PhaseLogCard

--- a/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/PhaseLogCard.tsx
@@ -1,4 +1,5 @@
 import { formatClockDurationLabel } from "@/lib/duration";
+import { formatCompactTokenValue } from "@/lib/formatTokenCount";
 import { cn, resolveIcon } from "@/lib/utils";
 import { ChevronRight, CircleX, Loader2, Maximize2, Pencil, RotateCw } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
@@ -10,6 +11,7 @@ import { useLiveLogStream } from "@/ui/CanvasPage/RunnerLiveLogDialog/useLiveLog
 
 import type { PhaseGlyphKind } from "../../lib/linePhaseRuns";
 import { toArtifactDataRecord } from "../../lib/workOrderArtifact";
+import { formatUsdCents, parseWorkOrderMetric } from "../../lib/workOrderUsage";
 import { WorkOrderArtifactInline } from "../../WorkOrderArtifactInline";
 import { WorkOrderPullRequestInline } from "../../WorkOrderPullRequestInline";
 import { PhaseGlyph } from "../linePhaseGlyph";
@@ -496,7 +498,7 @@ function AutomationHeader({
             ))}
           </span>
         ) : null}
-        <PhaseDuration phase={phase} />
+        <PhaseMetrics phase={phase} />
       </span>
     </div>
   );
@@ -678,21 +680,33 @@ function statusTimeMark(status: SplitRunPhaseStatus): ReactNode {
   return null;
 }
 
-function PhaseDuration({ phase }: { phase: SplitRunPhase }) {
+function PhaseMetrics({ phase }: { phase: SplitRunPhase }) {
   const running = phase.status === "running";
   const { now, sampledAt } = useRunningLogClock(running, phase.duration);
   const clock = running
     ? tickingRunningClock(phase.duration, sampledAt, now)
     : formatClockDurationLabel(phase.duration);
-  if (!clock || clock === "—") {
+  const tokens = parseWorkOrderMetric(phase.totalTokens);
+  const cents = parseWorkOrderMetric(phase.costCents);
+  const parts: string[] = [];
+  if (cents > 0) {
+    parts.push(formatUsdCents(cents));
+  }
+  if (tokens > 0) {
+    parts.push(formatCompactTokenValue(tokens));
+  }
+  if (clock && clock !== "—") {
+    parts.push(clock);
+  }
+  if (parts.length === 0) {
     return null;
   }
   return (
     <span
       data-testid={`split-run-phase-duration-${phase.id}`}
-      className={cn(LOG_FACE, "min-w-[5ch] text-right tabular-nums text-muted-foreground")}
+      className={cn(LOG_FACE, "tabular-nums text-muted-foreground")}
     >
-      {clock}
+      {parts.join(" · ")}
     </span>
   );
 }

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -17,6 +17,7 @@ import {
   OPEN_WORK_ORDER,
   PRIMARY_FACTORY_ID,
   PRIMARY_FACTORY_KEY,
+  RUNNING_WORK_ORDER,
 } from "../../__fixtures__/factoryPageResponses";
 import {
   BOARD_DONE_REJECTED_ORDER,
@@ -110,6 +111,12 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(row.querySelector(".lucide-circle-dollar-sign")).toBeNull();
     expect(row).toHaveTextContent("$0.73");
     expect(row).toHaveTextContent("2.7k tokens");
+  });
+
+  it("shows tokens and cost on a line-step phase", () => {
+    renderPopup({ fixture: splitRunFixtureForWorkOrder(RUNNING_WORK_ORDER, { demoArtifacts: false }) });
+
+    expect(screen.getByTestId("split-run-phase-duration-implement-0")).toHaveTextContent("$0.28 · 900 ·");
   });
 
   it("does not put an Open work order link next to close", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.spec.ts
@@ -94,6 +94,8 @@ describe("splitRunFixtureForWorkOrder", () => {
     expect(fixture.currentPhaseId).toMatch(/^implement-/);
     const implement = fixture.phases.find((phase) => phase.name === "Implement");
     expect(implement?.status).toBe("running");
+    expect(implement?.costCents).toBe("28");
+    expect(implement?.totalTokens).toBe("900");
     expect(implement?.componentName).toBe("Implementation");
     expect(implement?.appId).toBe("app-refund-implementer");
     expect(implement?.runId).toBe(RUNNING_WORK_ORDER.lineDispatches?.[0]?.stepExecutions?.[0]?.run?.id);
@@ -1034,6 +1036,9 @@ describe("line board work-order examples", () => {
           canvasId: "canvas-fb",
           handlerName: "Address PR feedback",
           pullRequestNumber: "6812",
+          description: "Please add tests for the retry path.",
+          costCents: "45",
+          totalTokens: "1200",
           run: {
             id: "run-comment",
             canvasId: "canvas-fb",
@@ -1041,13 +1046,14 @@ describe("line board work-order examples", () => {
             result: "RESULT_PASSED",
             createdAt: "2026-08-26T11:00:00Z",
             finishedAt: "2026-08-26T11:05:00Z",
-            description: "Please add tests for the retry path.",
           },
         },
       ],
     });
     expect(fixture.phases.find((phase) => phase.id === "pr-feedback-run-comment")).toMatchObject({
       name: "Please add tests for the retry path.",
+      costCents: "45",
+      totalTokens: "1200",
     });
   });
 

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunMocks.ts
@@ -115,6 +115,10 @@ export interface SplitRunPhase {
   canvas?: SplitRunCanvasModel;
   /** Line step index used to rerun this automation. */
   stepIndex?: number;
+  /** Ledger cost for this phase, in USD cents. Hidden when zero. */
+  costCents?: string;
+  /** Ledger token count for this phase. Hidden when zero. */
+  totalTokens?: string;
 }
 
 export type { SplitRunFooter, SplitRunFooterKind, SplitRunFooterTone };
@@ -614,7 +618,7 @@ function activePhaseIdWithPrefix(phases: SplitRunPhase[], prefix: string): Split
 
 function prFeedbackRunToPhase(entry: PRFeedbackLogRun): SplitRunPhase {
   const status = statusForCanvasRun(entry.run);
-  const description = entry.run.description?.trim();
+  const description = entry.description?.trim();
   const name = description
     ? description
     : entry.pullRequestNumber
@@ -650,6 +654,8 @@ function prFeedbackRunToPhase(entry: PRFeedbackLogRun): SplitRunPhase {
     canvasSteps: [streamLineToCanvasStep(line, providerForName(componentName))],
     appId: entry.canvasId,
     runId: entry.run.id,
+    costCents: entry.costCents,
+    totalTokens: entry.totalTokens,
   };
 }
 
@@ -889,6 +895,8 @@ function executionToPhase(
     appId: execution.run?.appId,
     runId: execution.run?.id,
     stepIndex: execution.stepIndex,
+    costCents: execution.costCents,
+    totalTokens: execution.totalTokens,
   };
 }
 


### PR DESCRIPTION
Factory pull request runs did not record LLM usage against the work order.
That hid cost on the work order and undercounted work-order totals.
This change records factory-canvas spend when the work order is known.
The work order log shows cost, tokens, and duration on line and pull request phases.
Backlog analysis spend is recorded in the ledger and included in work-order totals.
This change does not show cost on each analysis run.
This change does not backfill old events.