### PR TITLE
docs: Note factory tools on local runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,7 @@
 ##   TASK_BROKER_AUTH_TOKEN=dev-local-token
 ##   WEBHOOKS_BASE_URL=http://host.docker.internal:8000
 ## Local BASE_URL maps browser live logs to localhost and create-task to fleet local.
+## Factory Claude and Codex nodes use organization integrations, not this file.
 ## Set TASK_BROKER_BASE_URL to a remote broker to keep node machine types.
 ## Do not commit real broker tokens. TASK_BROKER_FLEET_ID, when set, is the
 ## create-task fleet_id. Empty TASK_BROKER_FLEET_ID keeps node machine types

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,14 @@ To run Runner nodes locally, start `make dev` in the runner repository.
 Compose defaults already point at that broker. Set `TASK_BROKER_*` in `.env`
 only for a remote broker (see `.env.example`).
 
+The runner `make dev` image includes Claude Code, Codex, git, `gh`, and `jq`.
+Factory line apps run on that worker. Do not install those CLIs on the host.
+Connect GitHub and Claude integrations in the organization before you dispatch
+a factory line. Factory nodes use those integrations, not `.env`
+`ANTHROPIC_API_KEY`. After you change the runner Dockerfile, run `make dev`
+again so Compose rebuilds the worker. Check tools with `make doctor-local` in
+the runner repository.
+
 On first UI load, owner setup is enabled (`OWNER_SETUP_ENABLED=yes`), so you are
 prompted to create an admin account. Open registration is disabled by default
 (`BLOCK_SIGNUP=yes`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,13 @@ To run Runner nodes locally, start `make dev` in the runner repository.
 Compose defaults already point at that broker. Set `TASK_BROKER_*` in `.env`
 only for a remote broker (see `.env.example`).
 
+The runner `make dev` image includes Claude Code, Codex, git, `gh`, and `jq`
+so factory line apps can run locally. Do not install those CLIs on the host.
+Connect GitHub and Claude integrations in the organization before you dispatch
+a factory line. Factory nodes use those integrations, not `.env`
+`ANTHROPIC_API_KEY`. After you change the runner Dockerfile, run `make dev`
+again in the runner repository. Check tools with `make doctor-local`.
+
 ## Additional Development Resources
 
 ### Overview


### PR DESCRIPTION
## Summary

Local factory apps fail when Claude Code is missing on the runner worker.

This change tells contributors that `make dev` in the runner repository now ships those CLIs.

Factory nodes use organization integrations. They do not use `.env` `ANTHROPIC_API_KEY`.

Companion runner change: bake Claude Code, Codex, `gh`, and `jq` into the local worker image.

## Test plan

- [ ] Read the runner section in `AGENTS.md` and `CONTRIBUTING.md`.
- [ ] Confirm the text says not to install Claude on the host.
- [ ] Confirm the text says to connect GitHub and Claude integrations.
- [ ] Start `make dev` in the runner repository.
- [ ] Run `make doctor-local` in the runner repository.


Made with [Cursor](https://cursor.com)