### PR TITLE
fix: Include early weekdays in weekly schedules

### DIFF
--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -734,7 +734,7 @@ func nextWeeksTrigger(interval int, weekDays []string, hour int, minute int, now
 	nextIntervalStart := nowInTZ.AddDate(0, 0, interval*7)
 
 	// start the search on Sunday of the next week
-	nextIntervalStart.Add(-time.Duration(nextIntervalStart.Weekday()) * time.Hour)
+	nextIntervalStart = nextIntervalStart.AddDate(0, 0, -int(nextIntervalStart.Weekday()))
 	for i := 0; i < 7; i++ {
 		checkDate := nextIntervalStart.AddDate(0, 0, i)
 		if validWeekdays[checkDate.Weekday()] {

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -74,6 +74,24 @@ func TestNextMinutesTrigger(t *testing.T) {
 	}
 }
 
+func TestNextWeeksTriggerIncludesWeekdaysBeforeSetupDay(t *testing.T) {
+	now := time.Now().UTC()
+	daysUntilWednesday := (int(time.Wednesday) - int(now.Weekday()) + 7) % 7
+	setupDay := now.AddDate(0, 0, daysUntilWednesday)
+	setupTime := time.Date(setupDay.Year(), setupDay.Month(), setupDay.Day(), 10, 0, 0, 0, time.UTC)
+	expectedDay := setupTime.AddDate(0, 0, 5)
+	expected := time.Date(expectedDay.Year(), expectedDay.Month(), expectedDay.Day(), 15, 30, 0, 0, time.UTC)
+
+	result, err := nextWeeksTrigger(1, []string{WeekDayMonday}, 15, 30, setupTime)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Equal(expected) {
+		t.Errorf("expected next trigger at %v, got %v", expected, *result)
+	}
+}
+
 func TestGetNextTrigger(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary

Fixes #6983.

Weekly schedules could skip selected weekdays that occur before the setup weekday, causing the next trigger to be scheduled one week later than expected.

## Changes

- Preserve the immutable `time.Time` result when aligning the target week.
- Use `AddDate` to advance calendar days instead of adding 24-hour durations.
- Add a regression test covering a Wednesday setup with Monday selected.

## Testing

- Added and passed the focused regression test.
- Passed the complete `pkg/triggers/schedule` test package.
- Ran `gofmt` verification and Git whitespace checks.

The change is intentionally limited to the weekly schedule calculation and its regression test.