### PR TITLE
feat: Add org workspace links and actions

### DIFF
--- a/web_src/src/pages/factories/FactoryDeleteDialog.tsx
+++ b/web_src/src/pages/factories/FactoryDeleteDialog.tsx
@@ -6,6 +6,8 @@ import { Trash2 } from "lucide-react";
 interface FactoryDeleteDialogProps {
   open: boolean;
   factoryName: string;
+  title?: string;
+  description?: string;
   canDelete: boolean;
   isDeleting: boolean;
   onClose: () => void;
@@ -15,6 +17,8 @@ interface FactoryDeleteDialogProps {
 export function FactoryDeleteDialog({
   open,
   factoryName,
+  title,
+  description,
   canDelete,
   isDeleting,
   onClose,
@@ -22,9 +26,9 @@ export function FactoryDeleteDialog({
 }: FactoryDeleteDialogProps) {
   return (
     <Dialog open={open} onClose={onClose} size="lg" className="text-left">
-      <DialogTitle className="text-gray-800 dark:text-red-100">Delete "{factoryName}"?</DialogTitle>
+      <DialogTitle className="text-gray-800 dark:text-red-100">{title ?? `Delete "${factoryName}"?`}</DialogTitle>
       <DialogDescription className="text-sm text-gray-800 dark:text-gray-400">
-        This cannot be undone. Are you sure you want to continue?
+        {description ?? "This cannot be undone. Are you sure you want to continue?"}
       </DialogDescription>
       <DialogActions>
         <LoadingButton

--- a/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsLayout.spec.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsLayout.spec.tsx
@@ -64,9 +64,8 @@ describe("OrganizationSettingsLayout", () => {
 
     const table = await screen.findByTestId("organization-settings-workspaces-table");
     expect(table).toHaveTextContent("Semaphore");
-    expect(table).toHaveTextContent("RF");
     expect(table).toHaveTextContent("SuperPlane");
-    expect(table).toHaveTextContent("PF");
+    expect(table).not.toHaveTextContent("RF");
     expect(within(sidebar).getByTestId("organization-settings-nav-workspaces")).toHaveAttribute("aria-current", "page");
   }, 10000);
 

--- a/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsWorkspacesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsWorkspacesPage.spec.tsx
@@ -1,0 +1,69 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { client } from "@/api-client/client.gen";
+import { FactoriesHarness } from "../../__fixtures__/FactoriesHarness";
+import {
+  defaultFactoriesFixture,
+  FACTORIES_ORGANIZATION_ID,
+  PRIMARY_FACTORY_ID,
+  PRIMARY_FACTORY_KEY,
+  REFUND_LINE_PLAN_ID,
+} from "../../__fixtures__/factoryPageResponses";
+import { factoryHomePath, factorySettingsPath } from "../../lib/factoryPagePaths";
+
+describe("OrganizationSettingsWorkspacesPage", () => {
+  beforeAll(() => {
+    client.setConfig({ baseUrl: "http://localhost" });
+  });
+
+  it("lists workspace names as links and hides the key column", async () => {
+    render(<FactoriesHarness pathSuffix="organization/workspaces" factoriesFixture={defaultFactoriesFixture} />);
+
+    const table = await screen.findByTestId("organization-settings-workspaces-table", {}, { timeout: 8000 });
+    const semaphore = within(table).getByTestId(`organization-settings-workspace-name-${PRIMARY_FACTORY_ID}`);
+
+    expect(semaphore).toHaveTextContent("Semaphore");
+    expect(semaphore).toHaveAttribute(
+      "href",
+      factoryHomePath(FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_KEY, REFUND_LINE_PLAN_ID),
+    );
+    expect(table).not.toHaveTextContent("RF");
+    expect(table).not.toHaveTextContent("PF");
+    expect(within(table).queryByText("Key")).not.toBeInTheDocument();
+    expect(within(table).queryByText("Created by")).not.toBeInTheDocument();
+  }, 10000);
+
+  it("opens workspace settings from the cog", async () => {
+    render(<FactoriesHarness pathSuffix="organization/workspaces" factoriesFixture={defaultFactoriesFixture} />);
+
+    const settings = await screen.findByTestId(
+      `organization-settings-workspace-settings-${PRIMARY_FACTORY_ID}`,
+      {},
+      { timeout: 8000 },
+    );
+
+    expect(settings).toHaveAttribute("href", factorySettingsPath(FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_KEY));
+  }, 10000);
+
+  it("asks to confirm before deleting a workspace", async () => {
+    const user = userEvent.setup();
+    render(<FactoriesHarness pathSuffix="organization/workspaces" factoriesFixture={defaultFactoriesFixture} />);
+
+    const deleteButton = await screen.findByTestId(
+      `organization-settings-workspace-delete-${PRIMARY_FACTORY_ID}`,
+      {},
+      { timeout: 8000 },
+    );
+    await user.click(deleteButton);
+
+    expect(await screen.findByText("Do you really want to delete the workspace?")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("factory-delete-confirm-button"));
+
+    const table = await screen.findByTestId("organization-settings-workspaces-table");
+    expect(within(table).queryByText("Semaphore")).not.toBeInTheDocument();
+    expect(within(table).getByText("SuperPlane")).toBeInTheDocument();
+  }, 10000);
+});

--- a/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsWorkspacesPage.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsWorkspacesPage.tsx
@@ -1,8 +1,19 @@
 import type { FactoriesFactory } from "@/api-client";
-import { useFactories } from "@/hooks/useFactoryData";
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { Button } from "@/components/ui/button";
+import { useAccount } from "@/contexts/useAccount";
+import { usePermissions } from "@/contexts/usePermissions";
+import { useDeleteFactory, useFactories } from "@/hooks/useFactoryData";
 import { useOrganization } from "@/hooks/useOrganizationData";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { useParams } from "react-router";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { Settings, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Link, useParams } from "react-router";
+import { FactoryDeleteDialog } from "../../FactoryDeleteDialog";
+import { factoryHomePath, factorySettingsPath, firstFactoryLineId } from "../../lib/factoryPagePaths";
+import { clearLastVisitedFactory } from "../../lib/lastVisitedFactory";
 import { FactorySettingsCard, FactorySettingsPageFrame } from "../settings/FactorySettingsCard";
 
 export function OrganizationSettingsWorkspacesPage() {
@@ -13,24 +24,52 @@ export function OrganizationSettingsWorkspacesPage() {
 
   usePageTitle(["Workspaces", organizationName]);
 
+  if (!organizationId) {
+    return null;
+  }
+
   return (
     <FactorySettingsPageFrame title="Workspaces" subtitle="See the workspaces in this organization.">
       <FactorySettingsCard data-testid="organization-settings-workspaces">
-        <WorkspacesBody isLoading={isLoading} error={error} factories={factories} />
+        <WorkspacesBody organizationId={organizationId} isLoading={isLoading} error={error} factories={factories} />
       </FactorySettingsCard>
     </FactorySettingsPageFrame>
   );
 }
 
 function WorkspacesBody({
+  organizationId,
   isLoading,
   error,
   factories,
 }: {
+  organizationId: string;
   isLoading: boolean;
   error: unknown;
   factories: FactoriesFactory[];
 }) {
+  const { account } = useAccount();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
+  const deleteFactory = useDeleteFactory(organizationId);
+  const [pendingDelete, setPendingDelete] = useState<FactoriesFactory | null>(null);
+
+  const canOpenSettings = canAct("factories", "update");
+  const canDelete = canAct("factories", "delete");
+
+  const handleDelete = async () => {
+    if (!pendingDelete?.id) {
+      return;
+    }
+    try {
+      await deleteFactory.mutateAsync(pendingDelete.id);
+      clearLastVisitedFactory(account?.id ?? "", organizationId, pendingDelete.id);
+      showSuccessToast("Workspace deleted.");
+    } catch (deleteError) {
+      showErrorToast(getApiErrorMessage(deleteError, "Failed to delete workspace."));
+      throw new Error("Failed to delete workspace");
+    }
+  };
+
   if (isLoading) {
     return <p className="text-[13px] text-muted-foreground">Loading workspaces…</p>;
   }
@@ -44,21 +83,130 @@ function WorkspacesBody({
   }
 
   return (
-    <table className="w-full text-left" data-testid="organization-settings-workspaces-table">
-      <thead>
-        <tr className="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
-          <th className="pb-2 pr-4 font-medium">Name</th>
-          <th className="pb-2 font-medium">Key</th>
-        </tr>
-      </thead>
-      <tbody className="text-[13px] text-foreground">
-        {factories.map((factory) => (
-          <tr key={factory.id} data-testid={`organization-settings-workspace-${factory.id}`}>
-            <td className="py-1.5 pr-4">{factory.name || "Workspace"}</td>
-            <td className="py-1.5 text-muted-foreground">{factory.key || "None"}</td>
+    <>
+      <table className="w-full text-left" data-testid="organization-settings-workspaces-table">
+        <thead>
+          <tr className="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
+            <th className="pb-2 pr-4 font-medium">Name</th>
+            <th className="w-10 pb-2 font-medium">
+              <span className="sr-only">Settings</span>
+            </th>
+            <th className="w-10 pb-2 font-medium">
+              <span className="sr-only">Delete</span>
+            </th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody className="text-[13px] text-foreground">
+          {factories.map((factory) => (
+            <WorkspaceRow
+              key={factory.id}
+              organizationId={organizationId}
+              factory={factory}
+              canOpenSettings={canOpenSettings}
+              canDelete={canDelete}
+              permissionsLoading={permissionsLoading}
+              onDelete={() => setPendingDelete(factory)}
+            />
+          ))}
+        </tbody>
+      </table>
+
+      <FactoryDeleteDialog
+        open={pendingDelete !== null}
+        factoryName={pendingDelete?.name ?? ""}
+        title="Do you really want to delete the workspace?"
+        description="This permanently removes the workspace and its work orders, lines, and apps."
+        canDelete={canDelete}
+        isDeleting={deleteFactory.isPending}
+        onClose={() => setPendingDelete(null)}
+        onConfirm={handleDelete}
+      />
+    </>
+  );
+}
+
+function WorkspaceRow({
+  organizationId,
+  factory,
+  canOpenSettings,
+  canDelete,
+  permissionsLoading,
+  onDelete,
+}: {
+  organizationId: string;
+  factory: FactoriesFactory;
+  canOpenSettings: boolean;
+  canDelete: boolean;
+  permissionsLoading: boolean;
+  onDelete: () => void;
+}) {
+  const name = factory.name?.trim() || "Workspace";
+  const factoryKey = factory.key ?? "";
+  const homeHref = factoryKey ? factoryHomePath(organizationId, factoryKey, firstFactoryLineId(factory)) : undefined;
+  const settingsHref = factoryKey ? factorySettingsPath(organizationId, factoryKey) : undefined;
+
+  return (
+    <tr data-testid={`organization-settings-workspace-${factory.id}`}>
+      <td className="py-1.5 pr-4">
+        {homeHref ? (
+          <Link
+            to={homeHref}
+            className="font-medium text-foreground underline-offset-4 hover:underline"
+            data-testid={`organization-settings-workspace-name-${factory.id}`}
+          >
+            {name}
+          </Link>
+        ) : (
+          <span data-testid={`organization-settings-workspace-name-${factory.id}`}>{name}</span>
+        )}
+      </td>
+      <td className="py-1.5 text-right">
+        <PermissionTooltip
+          allowed={canOpenSettings || permissionsLoading}
+          message="You do not have permission to open workspace settings."
+        >
+          {settingsHref && canOpenSettings ? (
+            <Button variant="ghost" size="icon-xs" asChild>
+              <Link
+                to={settingsHref}
+                aria-label={`Open settings for ${name}`}
+                data-testid={`organization-settings-workspace-settings-${factory.id}`}
+              >
+                <Settings className="h-4 w-4" aria-hidden />
+              </Link>
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              disabled
+              aria-label={`Open settings for ${name}`}
+              data-testid={`organization-settings-workspace-settings-${factory.id}`}
+            >
+              <Settings className="h-4 w-4" aria-hidden />
+            </Button>
+          )}
+        </PermissionTooltip>
+      </td>
+      <td className="py-1.5 text-right">
+        <PermissionTooltip
+          allowed={canDelete || permissionsLoading}
+          message="You do not have permission to delete workspaces."
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            disabled={!canDelete}
+            aria-label={`Delete ${name}`}
+            data-testid={`organization-settings-workspace-delete-${factory.id}`}
+            onClick={onDelete}
+          >
+            <Trash2 className="h-4 w-4" aria-hidden />
+          </Button>
+        </PermissionTooltip>
+      </td>
+    </tr>
   );
 }


### PR DESCRIPTION
## Summary

The organization Workspaces table showed names and keys only. Operators could not open a workspace or delete it from that list.

This PR makes the name a link to the workspace. It also adds settings and delete actions. Delete asks for confirmation first. The table no longer shows the key column.

## Test plan

- [ ] Open Organization settings, then open the Workspaces page.
- [ ] Confirm each workspace name is a link to that workspace.
- [ ] Confirm the table does not show a Key column.
- [ ] Click the settings icon and confirm workspace settings open.
- [ ] Click delete, confirm the dialog, and confirm the workspace is removed.
- [ ] Confirm a user without delete permission cannot delete a workspace.


Made with [Cursor](https://cursor.com)