### PR TITLE
fix: Record canvas event publish failures

### DIFF
--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
@@ -125,7 +125,9 @@ func InvokeNodeTriggerHook(
 	}
 
 	for _, event := range newEvents {
-		messages.PublishCanvasEventCreatedMessage(&event)
+		if err := messages.PublishCanvasEventCreatedMessage(&event); err != nil {
+			logger.Errorf("failed to publish canvas event created RabbitMQ message for event %s in canvas %s: %v", event.ID, event.WorkflowID, err)
+		}
 	}
 
 	// Convert result to protobuf struct

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -834,7 +834,9 @@ func (s *Server) dispatchIntegrationRequest(w http.ResponseWriter, r *http.Reque
 	}
 
 	for _, event := range newEvents {
-		messages.PublishCanvasEventCreatedMessage(&event)
+		if err := messages.PublishCanvasEventCreatedMessage(&event); err != nil {
+			log.Errorf("failed to publish canvas event created RabbitMQ message for event %s in canvas %s: %v", event.ID, event.WorkflowID, err)
+		}
 	}
 }
 
@@ -1289,7 +1291,9 @@ func (s *Server) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, event := range newEvents {
-		messages.PublishCanvasEventCreatedMessage(&event)
+		if err := messages.PublishCanvasEventCreatedMessage(&event); err != nil {
+			log.Errorf("failed to publish canvas event created RabbitMQ message for event %s in canvas %s: %v", event.ID, event.WorkflowID, err)
+		}
 	}
 
 	for executionID, workflowID := range touchedExecutions {

--- a/pkg/workers/app_message_worker.go
+++ b/pkg/workers/app_message_worker.go
@@ -119,7 +119,9 @@ func (w *AppMessageWorker) LockAndProcessMessage(message models.AppMessage) erro
 	}
 
 	for _, event := range newEvents {
-		messages.PublishCanvasEventCreatedMessage(&event)
+		if err := messages.PublishCanvasEventCreatedMessage(&event); err != nil {
+			logger.Errorf("failed to publish canvas event created RabbitMQ message for event %s in canvas %s: %v", event.ID, event.WorkflowID, err)
+		}
 	}
 
 	return nil

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -312,7 +312,9 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 	}
 
 	for _, event := range newEvents {
-		messages.PublishCanvasEventCreatedMessage(&event)
+		if err := messages.PublishCanvasEventCreatedMessage(&event); err != nil {
+			w.logger.Errorf("failed to publish canvas event created RabbitMQ message for event %s in canvas %s: %v", event.ID, event.WorkflowID, err)
+		}
 	}
 
 	for _, pendingRun := range pendingRuns {

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -689,7 +689,9 @@ func (c *MessageCollector) Publish() {
 	}
 
 	for _, event := range c.events {
-		messages.PublishCanvasEventCreatedMessage(&event)
+		if err := messages.PublishCanvasEventCreatedMessage(&event); err != nil {
+			c.logger.Errorf("failed to publish canvas event created RabbitMQ message for event %s in canvas %s: %v", event.ID, event.WorkflowID, err)
+		}
 	}
 
 	for _, queueItem := range c.queueItemsConsumed {

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -122,7 +122,9 @@ func (w *NodeRequestWorker) LockAndProcessRequest(request models.CanvasNodeReque
 	}
 
 	for _, event := range newEvents {
-		messages.PublishCanvasEventCreatedMessage(&event)
+		if err := messages.PublishCanvasEventCreatedMessage(&event); err != nil {
+			logger.Errorf("failed to publish canvas event created RabbitMQ message for event %s in canvas %s: %v", event.ID, event.WorkflowID, err)
+		}
 	}
 
 	runCancellations.Publish()


### PR DESCRIPTION
Fixes #6990

Six production paths ignored the error returned by
`PublishCanvasEventCreatedMessage`, so a failed RabbitMQ publish left no trace.
The durable event is already committed and the pending-event poll recovers it
within a minute, but operators had no way to tell a publish failure apart from
slow processing.

Each site now logs the failure with the event and canvas identifiers, matching
the handling already present at `invoke_node_execution_hook.go:112`.

Sites changed (seven call sites across six paths):

- `InvokeNodeTriggerHook` — trigger hooks
- `HandleWebhook` and `dispatchIntegrationRequest` — `pkg/public/server.go`
- `AppMessageWorker.LockAndProcessMessage`
- `NodeExecutor.LockAndProcessNodeExecution`
- `MessageCollector.Publish` — node queue
- `NodeRequestWorker.LockAndProcessRequest`

**Log and continue rather than return:** every one of these runs after its
database transaction has committed. Returning the error would retry
already-committed work and risk duplicate side effects. The event is durable and
the safety poll recovers it — the only thing missing was the operator signal.

**No metric added:** `pkg/telemetry` has no publish-failure metric today, so
adding one would mean introducing a new convention. Happy to follow up with a
counter if you'd prefer that.

`invoke_node_execution_hook.go:112` is left as-is — it already handles the error,
just without the identifiers.