### PR TITLE
fix: Show progress for direct manual runs

### DIFF
--- a/web_src/src/pages/app/mappers/editModeActions.spec.tsx
+++ b/web_src/src/pages/app/mappers/editModeActions.spec.tsx
@@ -99,6 +99,17 @@ function makeTriggerContext(overrides?: Partial<TriggerRendererContext>): Trigge
   };
 }
 
+function makeDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe("workflow v2 edit-mode action affordances", () => {
   it("hides start trigger run buttons in edit mode", () => {
     const props = startTriggerRenderer.getTriggerProps({
@@ -241,7 +252,7 @@ describe("workflow v2 edit-mode action affordances", () => {
     );
   });
 
-  it("invokes manual run directly when templates have no parameters", () => {
+  it("invokes manual run directly when templates have no parameters", async () => {
     const invokeNodeTriggerHook = vi.fn().mockResolvedValue(undefined);
     const openModal = vi.fn();
     const props = startTriggerRenderer.getTriggerProps({
@@ -257,9 +268,54 @@ describe("workflow v2 edit-mode action affordances", () => {
     expect(invokeNodeTriggerHook).toHaveBeenCalledWith("run", {
       template: "Example",
     });
+    await waitFor(() => expect(screen.getByTestId("start-template-run")).toBeEnabled());
   });
 
-  it("invokes manual run directly when template parameters array is empty", () => {
+  it("shows progress and prevents duplicate direct runs", async () => {
+    const request = makeDeferred<void>();
+    const invokeNodeTriggerHook = vi.fn(() => request.promise);
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext(),
+      canvasMode: "live",
+      actions: { invokeNodeTriggerHook, openModal: vi.fn() },
+    });
+
+    render(<Trigger {...props} canvasMode="live" />);
+    const runButton = screen.getByTestId("start-template-run");
+
+    fireEvent.click(runButton);
+
+    expect(runButton).toBeDisabled();
+    expect(runButton).toHaveTextContent("Running...");
+    fireEvent.click(runButton);
+    expect(invokeNodeTriggerHook).toHaveBeenCalledTimes(1);
+
+    request.resolve();
+
+    await waitFor(() => expect(runButton).toBeEnabled());
+    expect(runButton).toHaveTextContent("Run");
+  });
+
+  it("restores the direct run button after a failed request", async () => {
+    const request = makeDeferred<void>();
+    const invokeNodeTriggerHook = vi.fn(() => request.promise);
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext(),
+      canvasMode: "live",
+      actions: { invokeNodeTriggerHook, openModal: vi.fn() },
+    });
+
+    render(<Trigger {...props} canvasMode="live" />);
+    const runButton = screen.getByTestId("start-template-run");
+
+    fireEvent.click(runButton);
+    request.reject(new Error("request failed"));
+
+    await waitFor(() => expect(runButton).toBeEnabled());
+    expect(runButton).toHaveTextContent("Run");
+  });
+
+  it("invokes manual run directly when template parameters array is empty", async () => {
     const invokeNodeTriggerHook = vi.fn().mockResolvedValue(undefined);
     const openModal = vi.fn();
     const props = startTriggerRenderer.getTriggerProps({
@@ -291,6 +347,7 @@ describe("workflow v2 edit-mode action affordances", () => {
     expect(invokeNodeTriggerHook).toHaveBeenCalledWith("run", {
       template: "Example",
     });
+    await waitFor(() => expect(screen.getByTestId("start-template-run")).toBeEnabled());
   });
 
   it("disables approval actions in edit mode", () => {

--- a/web_src/src/pages/app/mappers/start/index.tsx
+++ b/web_src/src/pages/app/mappers/start/index.tsx
@@ -1,5 +1,4 @@
 import { getColorClass, getBackgroundColorClass } from "@/lib/colors";
-import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
 import { nodeCanvasMetadataSectionClassName } from "@/lib/nodeCanvasSections";
 import type {
   TriggerRenderer,
@@ -10,13 +9,12 @@ import type {
   TriggerEventContext,
 } from "../types";
 import type { TriggerProps } from "@/ui/trigger";
-import { flattenObject, cn } from "@/lib/utils";
+import { flattenObject } from "@/lib/utils";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import React from "react";
-import { Button } from "@/components/ui/button";
 import { Play } from "lucide-react";
-import { StartRunModal } from "./runModal";
-import { payloadForTemplateRun, startRunModalTitle, type StartConfiguration } from "./templatePayload";
+import { StartTemplateRunButton } from "./runButton";
+import type { StartConfiguration } from "./templatePayload";
 
 /**
  * Default renderer for the start trigger
@@ -91,39 +89,7 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
               </span>
             </div>
             {showTemplateRun && actions && (
-              <Button
-                size="xs"
-                data-testid="start-template-run"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  if ((template.parameters?.length ?? 0) > 0) {
-                    actions.openModal({
-                      title: startRunModalTitle(node.name, template.name),
-                      content: ({ close }) => (
-                        <StartRunModal
-                          parameters={template.parameters}
-                          initialPayload={payloadForTemplateRun(template)}
-                          onClose={close}
-                          onRun={async (payload) =>
-                            actions.invokeNodeTriggerHook("run", {
-                              template: template.name,
-                              ...payload,
-                            })
-                          }
-                        />
-                      ),
-                    });
-                    return;
-                  }
-                  void actions.invokeNodeTriggerHook("run", {
-                    template: template.name,
-                  });
-                }}
-                className={cn("flex-shrink-0", appDarkModeClasses.primaryAction)}
-              >
-                Run
-              </Button>
+              <StartTemplateRunButton nodeName={node.name} template={template} actions={actions} />
             )}
           </div>
         ))}

--- a/web_src/src/pages/app/mappers/start/runButton.tsx
+++ b/web_src/src/pages/app/mappers/start/runButton.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { appDarkModeClasses } from "@/lib/appDarkModeClasses";
+import { cn } from "@/lib/utils";
+import type { TriggerActionContext } from "../types";
+import { StartRunModal } from "./runModal";
+import { payloadForTemplateRun, startRunModalTitle, type StartTemplate } from "./templatePayload";
+
+export function StartTemplateRunButton({
+  nodeName,
+  template,
+  actions,
+}: {
+  nodeName: string;
+  template: StartTemplate;
+  actions: TriggerActionContext;
+}) {
+  const [isRunning, setIsRunning] = React.useState(false);
+
+  const handleRun = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if ((template.parameters?.length ?? 0) > 0) {
+      actions.openModal({
+        title: startRunModalTitle(nodeName, template.name),
+        content: ({ close }) => (
+          <StartRunModal
+            parameters={template.parameters}
+            initialPayload={payloadForTemplateRun(template)}
+            onClose={close}
+            onRun={async (payload) =>
+              actions.invokeNodeTriggerHook("run", {
+                template: template.name,
+                ...payload,
+              })
+            }
+          />
+        ),
+      });
+      return;
+    }
+
+    setIsRunning(true);
+    try {
+      await actions.invokeNodeTriggerHook("run", {
+        template: template.name,
+      });
+    } catch {
+      // The trigger action context reports request errors to the user.
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <LoadingButton
+      size="xs"
+      data-testid="start-template-run"
+      loading={isRunning}
+      loadingText="Running..."
+      onClick={handleRun}
+      className={cn("flex-shrink-0", appDarkModeClasses.primaryAction)}
+    >
+      Run
+    </LoadingButton>
+  );
+}


### PR DESCRIPTION
## Summary

- Show immediate loading feedback when a user runs a template without parameters.
- Disable the run button until the request finishes to prevent duplicate runs.
- Restore the button after successful and failed requests.

Fixes #5145.

## Test plan

- make check.test.ui
- make check.lint.ui
- make check.build.ui
- make check.format.js