### PR TITLE
fix: Expose new capabilities to existing integrations

### DIFF
--- a/pkg/grpc/actions/organizations/create_integration.go
+++ b/pkg/grpc/actions/organizations/create_integration.go
@@ -419,7 +419,7 @@ func serializeCapabilities(registry *registry.Registry, integration *models.Inte
 		capabilities = append(capabilities, group.Capabilities...)
 	}
 	protos := []*pb.Integration_CapabilityState{}
-	for _, capability := range integration.Capabilities {
+	for _, capability := range mergeCapabilityStates(capabilities, integration.Capabilities) {
 		protos = append(protos, &pb.Integration_CapabilityState{
 			Name:  capability.Name,
 			State: CapabilityStateToProto(capability.State),
@@ -427,6 +427,25 @@ func serializeCapabilities(registry *registry.Registry, integration *models.Inte
 	}
 
 	return protos
+}
+
+func mergeCapabilityStates(capabilities []core.Capability, stored []models.CapabilityState) []models.CapabilityState {
+	storedByName := capabilityMap(stored)
+	states := make([]models.CapabilityState, 0, len(capabilities))
+
+	for _, capability := range capabilities {
+		state, ok := storedByName[capability.Name]
+		if !ok {
+			state = models.CapabilityState{
+				Name:  capability.Name,
+				State: core.IntegrationCapabilityStateAvailable,
+			}
+		}
+
+		states = append(states, state)
+	}
+
+	return states
 }
 
 func serializeLegacyCapabilities(integration core.Integration) []*pb.Integration_CapabilityState {

--- a/pkg/grpc/actions/organizations/update_integration_capabilities.go
+++ b/pkg/grpc/actions/organizations/update_integration_capabilities.go
@@ -41,6 +41,10 @@ func UpdateIntegrationCapabilities(ctx context.Context, registry *registry.Regis
 		return nil, grpcerrors.Internal(err, "failed to find integration")
 	}
 
+	if _, err := registry.GetSetupProvider(integration.AppName); err == nil {
+		integration.Capabilities = mergeCapabilityStates(registry.AllCapabilities(integration.AppName), integration.Capabilities)
+	}
+
 	changes := findChanges(integration.Capabilities, capabilities)
 	if len(changes) == 0 {
 		return nil, grpcerrors.InvalidArgument(nil, "no changes")

--- a/pkg/grpc/actions/organizations/update_integration_capabilities_test.go
+++ b/pkg/grpc/actions/organizations/update_integration_capabilities_test.go
@@ -167,4 +167,79 @@ func Test__UpdateIntegrationCapabilities(t *testing.T) {
 		assert.Equal(t, core.IntegrationCapabilityStateEnabled, stored.Capabilities[0].State)
 		assert.Equal(t, "feat", stored.Capabilities[0].Name)
 	})
+
+	t.Run("new capability can be requested by existing integration", func(t *testing.T) {
+		resp, err := CreateIntegration(
+			ctx,
+			r.Registry,
+			nil,
+			"http://localhost",
+			"http://localhost",
+			r.Organization.ID.String(),
+			"dummy",
+			support.RandomName("installation"),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Integration)
+
+		stored, err := models.FindIntegration(r.Organization.ID, uuid.MustParse(resp.Integration.Metadata.Id))
+		require.NoError(t, err)
+		stored.Capabilities = datatypes.NewJSONSlice([]models.CapabilityState{
+			{Name: "feat", State: core.IntegrationCapabilityStateEnabled},
+		})
+		require.NoError(t, database.Conn().Save(stored).Error)
+
+		capabilityUpdateCalled := false
+		r.Registry.SetupProviders["dummy"] = impl.NewDummyIntegrationSetupProvider(impl.DummyIntegrationSetupProviderOptions{
+			CapabilityGroups: []core.CapabilityGroup{{Capabilities: []core.Capability{
+				{Name: "feat"},
+				{Name: "new-feat"},
+			}}},
+			OnCapabilityUpdate: func(ctx core.CapabilityUpdateContext) (*core.SetupStep, error) {
+				capabilityUpdateCalled = true
+				assert.Equal(t, []string{"new-feat"}, ctx.Changes[core.IntegrationCapabilityStateRequested])
+				ctx.Capabilities.Enable("new-feat")
+				return nil, nil
+			},
+		})
+
+		describeResponse, err := DescribeIntegration(
+			ctx,
+			r.Registry,
+			r.Organization.ID.String(),
+			resp.Integration.Metadata.Id,
+		)
+		require.NoError(t, err)
+
+		states := map[string]pb.Integration_CapabilityState_State{}
+		for _, capability := range describeResponse.Integration.Status.Capabilities {
+			states[capability.Name] = capability.State
+		}
+		assert.Equal(t, pb.Integration_CapabilityState_STATE_ENABLED, states["feat"])
+		assert.Equal(t, pb.Integration_CapabilityState_STATE_AVAILABLE, states["new-feat"])
+
+		updateResponse, err := UpdateIntegrationCapabilities(
+			ctx,
+			r.Registry,
+			r.Organization.ID.String(),
+			resp.Integration.Metadata.Id,
+			[]*pb.Integration_CapabilityState{
+				{Name: "new-feat", State: pb.Integration_CapabilityState_STATE_REQUESTED},
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, capabilityUpdateCalled)
+
+		states = map[string]pb.Integration_CapabilityState_State{}
+		for _, capability := range updateResponse.Integration.Status.Capabilities {
+			states[capability.Name] = capability.State
+		}
+		assert.Equal(t, pb.Integration_CapabilityState_STATE_ENABLED, states["feat"])
+		assert.Equal(t, pb.Integration_CapabilityState_STATE_ENABLED, states["new-feat"])
+
+		stored, err = models.FindIntegration(r.Organization.ID, uuid.MustParse(resp.Integration.Metadata.Id))
+		require.NoError(t, err)
+		require.Len(t, stored.Capabilities, 2)
+	})
 }


### PR DESCRIPTION
## Summary

- Existing integrations store only the capability states known during setup.
- This change exposes new capabilities as available, so users can request them without reconnecting.
- Existing capability states remain unchanged.

Closes #6986

## Test plan

- [x] Run `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/organizations`.
- [x] Run `make lint`.
- [x] Run `make check.build.app`.