### PR TITLE
feat: Use the workspace setup repository on Velocity

### DIFF
--- a/web_src/src/pages/factories/lib/velocitySeriesColors.ts
+++ b/web_src/src/pages/factories/lib/velocitySeriesColors.ts
@@ -1,0 +1,13 @@
+/**
+ * One color per Velocity series. Charts and the metric cells next to them share
+ * these values, so a number and its line or bar always carry the same color.
+ */
+export const VELOCITY_SERIES_COLORS = {
+  merged: "#10b981",
+  waste: "#ef4444",
+  cost: "#64748b",
+  people: "#64748b",
+  superplane: "#10b981",
+  running: "#60a5fa",
+  waiting: "#f59e0b",
+} as const;

--- a/web_src/src/pages/factories/pages/VelocityCharts.tsx
+++ b/web_src/src/pages/factories/pages/VelocityCharts.tsx
@@ -15,26 +15,27 @@ import {
   type FactoryVelocityFlow,
   type FactoryVelocityFlowPeriodDays,
 } from "../lib/factoryVelocityFlow";
+import { VELOCITY_SERIES_COLORS } from "../lib/velocitySeriesColors";
 
 export type VelocityChartsPeriodDays = FactoryVelocityFlowPeriodDays;
 
 const outputChartConfig = {
-  merged: { label: "Merged", color: "#10b981" },
-  waste: { label: "Waste", color: "#ef4444" },
+  merged: { label: "Merged", color: VELOCITY_SERIES_COLORS.merged },
+  waste: { label: "Waste", color: VELOCITY_SERIES_COLORS.waste },
 } satisfies ChartConfig;
 
 const costChartConfig = {
-  costUsd: { label: "Cost", color: "#64748b" },
+  costUsd: { label: "Cost", color: VELOCITY_SERIES_COLORS.cost },
 } satisfies ChartConfig;
 
 const sourceChartConfig = {
-  peopleMerged: { label: "People", color: "#64748b" },
-  superplaneMerged: { label: "SuperPlane", color: "#10b981" },
+  peopleMerged: { label: "People", color: VELOCITY_SERIES_COLORS.people },
+  superplaneMerged: { label: "SuperPlane", color: VELOCITY_SERIES_COLORS.superplane },
 } satisfies ChartConfig;
 
 const timeTrendChartConfig = {
-  runningHours: { label: "Time running", color: "#60a5fa" },
-  waitingHours: { label: "Time in Waiting", color: "#f59e0b" },
+  runningHours: { label: "Time running", color: VELOCITY_SERIES_COLORS.running },
+  waitingHours: { label: "Time in Waiting", color: VELOCITY_SERIES_COLORS.waiting },
 } satisfies ChartConfig;
 
 function formatTimeTrendTooltip(value: unknown, name: unknown) {

--- a/web_src/src/pages/factories/pages/VelocityLoadedView.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityLoadedView.spec.tsx
@@ -76,6 +76,22 @@ describe("VelocityLoadedView", () => {
     expect(split).not.toHaveTextContent(String(FACTORY_VELOCITY_BY_PERIOD[7].totals.peopleMerged));
   });
 
+  it("replaces empty charts with a note when the period has no pull requests", () => {
+    const data: VelocityData = {
+      yesterday: { dateLabel: "Yesterday · Sun, Aug 30", merged: 0, waste: 0, wastePct: 0 },
+      totals: { merged: 0, waste: 0, wastePct: 0, superplaneMerged: 0, peopleMerged: 0, superplaneSharePct: 0 },
+      points: [{ day: "Mon", merged: 0, waste: 0, peopleMerged: 0, superplaneMerged: 0 }],
+    };
+    const sourceSplit: VelocitySourceSplitConfig = { hasPeopleCohort: true };
+
+    render(<VelocityLoadedView periodLabel="Last 7 days" periodDays={7} data={data} sourceSplit={sourceSplit} />);
+
+    expect(screen.getByTestId("velocity-trend")).toHaveTextContent("No pull requests merged or closed in this period.");
+    expect(screen.getByTestId("velocity-source-split")).toHaveTextContent("No pull requests merged in this period.");
+    // Metric cells stay, so the zero counts are still readable.
+    expect(screen.getByTestId("velocity-trend")).toHaveTextContent("Merged PRs");
+  });
+
   it("renders the work-order flow card when a flow config is provided", () => {
     const mock = FACTORY_VELOCITY_FLOW_BY_PERIOD[7];
     const data = toData();

--- a/web_src/src/pages/factories/pages/VelocityLoadedView.tsx
+++ b/web_src/src/pages/factories/pages/VelocityLoadedView.tsx
@@ -7,6 +7,7 @@ import {
   type FactoryVelocityFlow,
   type FactoryVelocityFlowPeriodDays,
 } from "../lib/factoryVelocityFlow";
+import { VELOCITY_SERIES_COLORS } from "../lib/velocitySeriesColors";
 import {
   CostSparkline,
   DailyOutputChart,
@@ -14,6 +15,19 @@ import {
   TimeTrendChart,
   type CostSparklinePoint,
 } from "./VelocityCharts";
+
+/** Every Velocity card shares one frame, so the page reads as one report. */
+const cardClassName = "rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5";
+
+const cardTitleClassName = "text-[14px] font-medium tracking-[-0.01em] text-foreground";
+
+const cardSubtitleClassName = "mt-0.5 text-[12px] text-muted-foreground";
+
+/**
+ * Metric rows stop short of the full card width. Two or three numbers spread
+ * over a wide card drift apart and stop reading as one group.
+ */
+const metricRowClassName = "mt-5 grid grid-cols-2 gap-x-8 gap-y-5";
 
 export type VelocityPeriodDays = FactoryVelocityFlowPeriodDays;
 
@@ -87,10 +101,27 @@ function formatPct(value: number) {
   return `${value}%`;
 }
 
-function MetricCell({ value, label, hint }: { value: string; label: string; hint?: string }) {
+interface MetricCellProps {
+  value: string;
+  label: string;
+  hint?: string;
+  /** Series color, when the number also appears as a line or bar in a chart. */
+  seriesColor?: string;
+}
+
+function MetricCell({ value, label, hint, seriesColor }: MetricCellProps) {
   return (
     <div className="min-w-0">
-      <p className="text-[12px] text-muted-foreground">{label}</p>
+      <p className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+        {seriesColor ? (
+          <span
+            className="size-1.5 shrink-0 rounded-full"
+            style={{ backgroundColor: seriesColor }}
+            aria-hidden="true"
+          />
+        ) : null}
+        {label}
+      </p>
       <p className="mt-2 text-[32px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
         {value}
       </p>
@@ -99,34 +130,57 @@ function MetricCell({ value, label, hint }: { value: string; label: string; hint
   );
 }
 
+/** Empty note used where a chart would otherwise draw an axis with no data. */
+function ChartEmptyNote({ children }: { children: ReactNode }) {
+  return <p className="mt-5 text-[13px] text-muted-foreground">{children}</p>;
+}
+
 interface YesterdayCardProps {
   snapshot: VelocityYesterday;
   cost?: { costUsd: number; tokens: number; costPerMerged: number };
 }
 
 function YesterdayCard({ snapshot, cost }: YesterdayCardProps) {
-  const metrics: { value: string; label: string; hint: string }[] = [
-    { value: String(snapshot.merged), label: "Merged PRs", hint: "Productive SuperPlane work" },
-    { value: String(snapshot.waste), label: "Waste", hint: `${formatPct(snapshot.wastePct)} of SuperPlane output` },
+  const metrics: MetricCellProps[] = [
+    {
+      value: String(snapshot.merged),
+      label: "Merged PRs",
+      hint: "Productive SuperPlane work",
+      seriesColor: VELOCITY_SERIES_COLORS.merged,
+    },
+    {
+      value: String(snapshot.waste),
+      label: "Waste",
+      hint: `${formatPct(snapshot.wastePct)} of SuperPlane output`,
+      seriesColor: VELOCITY_SERIES_COLORS.waste,
+    },
   ];
   if (cost) {
     metrics.push(
-      { value: formatUsd(cost.costUsd), label: "Cost", hint: `${formatTokens(cost.tokens)} tokens` },
+      {
+        value: formatUsd(cost.costUsd),
+        label: "Cost",
+        hint: `${formatTokens(cost.tokens)} tokens`,
+        seriesColor: VELOCITY_SERIES_COLORS.cost,
+      },
       { value: formatUsd(cost.costPerMerged), label: "Cost per merged PR", hint: "Average spend" },
     );
   }
 
-  const gridColsClass = cost ? "sm:grid-cols-4" : "sm:grid-cols-2";
+  const gridColsClass = cost ? "sm:grid-cols-4" : "sm:grid-cols-2 sm:max-w-2xl";
 
   return (
-    <section
-      className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5"
-      data-testid="velocity-yesterday"
-    >
-      <p className="text-[12px] font-medium text-foreground">{snapshot.dateLabel}</p>
-      <div className={`mt-5 grid grid-cols-2 gap-x-8 gap-y-5 ${gridColsClass}`}>
+    <section className={cardClassName} data-testid="velocity-yesterday">
+      <h2 className={cardTitleClassName}>{snapshot.dateLabel}</h2>
+      <div className={`${metricRowClassName} ${gridColsClass}`}>
         {metrics.map((metric) => (
-          <MetricCell key={metric.label} value={metric.value} label={metric.label} hint={metric.hint} />
+          <MetricCell
+            key={metric.label}
+            value={metric.value}
+            label={metric.label}
+            hint={metric.hint}
+            seriesColor={metric.seriesColor}
+          />
         ))}
       </div>
     </section>
@@ -142,36 +196,44 @@ interface TrendCardProps {
 }
 
 function TrendCard({ periodLabel, periodDays, totals, points, cost }: TrendCardProps) {
-  const gridColsClass = cost ? "sm:grid-cols-3" : "sm:grid-cols-2";
+  const gridColsClass = cost ? "sm:grid-cols-3" : "sm:grid-cols-2 sm:max-w-2xl";
   const costPoints: CostSparklinePoint[] = cost
     ? points.map((point, index) => ({ day: point.day, costUsd: cost.seriesUsd[index] ?? 0 }))
     : [];
+  const hasOutput = totals.merged > 0 || totals.waste > 0;
 
   return (
-    <section className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5" data-testid="velocity-trend">
+    <section className={cardClassName} data-testid="velocity-trend">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">SuperPlane output</h2>
-          <p className="mt-0.5 text-[12px] text-muted-foreground">
+          <h2 className={cardTitleClassName}>SuperPlane output</h2>
+          <p className={cardSubtitleClassName}>
             {cost ? "Merged, waste, and cost by day." : "Merged and waste by day."}
           </p>
         </div>
         <p className="text-[12px] text-muted-foreground">{periodLabel}</p>
       </div>
 
-      <div className={`mt-5 grid grid-cols-2 gap-x-8 gap-y-5 ${gridColsClass}`}>
-        <MetricCell value={String(totals.merged)} label="Merged PRs" />
+      <div className={`${metricRowClassName} ${gridColsClass}`}>
+        <MetricCell value={String(totals.merged)} label="Merged PRs" seriesColor={VELOCITY_SERIES_COLORS.merged} />
         <MetricCell
           value={String(totals.waste)}
           label="Waste"
           hint={`${formatPct(totals.wastePct)} of SuperPlane output`}
+          seriesColor={VELOCITY_SERIES_COLORS.waste}
         />
-        {cost ? <MetricCell value={formatUsd(cost.totalCostUsd)} label="Cost" /> : null}
+        {cost ? (
+          <MetricCell value={formatUsd(cost.totalCostUsd)} label="Cost" seriesColor={VELOCITY_SERIES_COLORS.cost} />
+        ) : null}
       </div>
 
-      <div className="mt-6">
-        <DailyOutputChart points={points} days={periodDays} />
-      </div>
+      {hasOutput ? (
+        <div className="mt-6">
+          <DailyOutputChart points={points} days={periodDays} />
+        </div>
+      ) : (
+        <ChartEmptyNote>No pull requests merged or closed in this period.</ChartEmptyNote>
+      )}
 
       {cost ? (
         <div className="mt-4 border-t border-border pt-3">
@@ -191,33 +253,44 @@ interface SourceSplitCardProps {
 }
 
 function SourceSplitCard({ periodDays, totals, points, config }: SourceSplitCardProps) {
+  const hasMerges = totals.peopleMerged > 0 || totals.superplaneMerged > 0;
+
   return (
-    <section
-      className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5"
-      data-testid="velocity-source-split"
-    >
+    <section className={cardClassName} data-testid="velocity-source-split">
       <div>
-        <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">Merged PRs by source</h2>
+        <h2 className={cardTitleClassName}>Merged PRs by source</h2>
         {config.hasPeopleCohort ? (
-          <p className="mt-0.5 text-[12px] text-muted-foreground">
+          <p className={cardSubtitleClassName}>
             SuperPlane authored {formatPct(totals.superplaneSharePct)} of merged PRs in
             {config.repositoryLabel ? ` ${config.repositoryLabel}` : " this repository"} in this period.
           </p>
         ) : (
-          <p className="mt-0.5 text-[12px] text-muted-foreground">Select a repository to see People vs SuperPlane.</p>
+          <p className={cardSubtitleClassName}>People and SuperPlane merges in the workspace repository.</p>
         )}
       </div>
 
       {config.hasPeopleCohort ? (
         <>
-          <div className="mt-5 grid grid-cols-2 gap-x-8 gap-y-5">
-            <MetricCell value={String(totals.peopleMerged)} label="People" />
-            <MetricCell value={String(totals.superplaneMerged)} label="SuperPlane" />
+          <div className={`${metricRowClassName} sm:max-w-2xl`}>
+            <MetricCell
+              value={String(totals.peopleMerged)}
+              label="People"
+              seriesColor={VELOCITY_SERIES_COLORS.people}
+            />
+            <MetricCell
+              value={String(totals.superplaneMerged)}
+              label="SuperPlane"
+              seriesColor={VELOCITY_SERIES_COLORS.superplane}
+            />
           </div>
 
-          <div className="mt-6">
-            <SourceSplitChart points={points} days={periodDays} />
-          </div>
+          {hasMerges ? (
+            <div className="mt-6">
+              <SourceSplitChart points={points} days={periodDays} />
+            </div>
+          ) : (
+            <ChartEmptyNote>No pull requests merged in this period.</ChartEmptyNote>
+          )}
         </>
       ) : (
         <div className="mt-4">{config.emptyState}</div>
@@ -237,14 +310,11 @@ function WorkOrderFlowCard({ periodLabel, periodDays, config }: WorkOrderFlowCar
   const emptyLabel = config.emptyLabel ?? "No tasks closed in this period.";
 
   return (
-    <section
-      className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5"
-      data-testid="velocity-work-order-flow"
-    >
+    <section className={cardClassName} data-testid="velocity-work-order-flow">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">Task time</h2>
-          <p className="mt-0.5 text-[12px] text-muted-foreground">
+          <h2 className={cardTitleClassName}>Task time</h2>
+          <p className={cardSubtitleClassName}>
             Median times for tasks that closed in this period. Cycle time is time running plus time in Waiting after the
             task leaves Draft.
           </p>
@@ -255,7 +325,7 @@ function WorkOrderFlowCard({ periodLabel, periodDays, config }: WorkOrderFlowCar
       {flow && flow.sampleSize > 0 ? (
         <WorkOrderFlowBody flow={flow} periodDays={periodDays} />
       ) : (
-        <p className="mt-5 text-[13px] text-muted-foreground">{emptyLabel}</p>
+        <ChartEmptyNote>{emptyLabel}</ChartEmptyNote>
       )}
     </section>
   );
@@ -275,11 +345,13 @@ function WorkOrderFlowBody({ flow, periodDays }: { flow: FactoryVelocityFlow; pe
             value={formatDurationHours(flow.medianRunningHours)}
             label="Time running"
             hint={`${flow.runningShareOfCyclePct}% of cycle time`}
+            seriesColor={VELOCITY_SERIES_COLORS.running}
           />
           <MetricCell
             value={formatDurationHours(flow.medianWaitingHours)}
             label="Time in Waiting"
             hint={`${flow.waitingShareOfCyclePct}% of cycle time`}
+            seriesColor={VELOCITY_SERIES_COLORS.waiting}
           />
         </div>
         <p className="mt-3 text-[12px] text-muted-foreground">

--- a/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
@@ -3,11 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
-import type {
-  FactoriesDescribeFactoryVelocityResponse,
-  FactoriesWorkOrder,
-  OrganizationsIntegration,
-} from "@/api-client";
+import type { FactoriesDescribeFactoryVelocityResponse, FactoriesFactory, FactoriesWorkOrder } from "@/api-client";
 
 import { PRIMARY_FACTORY_ID, PRIMARY_FACTORY_KEY, REFUND_FACTORY } from "../__fixtures__/factoryPageResponses";
 import { FactoriesLayoutContext } from "../layout/factoriesLayoutContext";
@@ -29,10 +25,11 @@ interface WorkOrdersHookState {
 
 const velocityHookState: VelocityHookState = {};
 const workOrdersHookState: WorkOrdersHookState = {};
-const integrationsHookState: { data: OrganizationsIntegration[] } = { data: [] };
-const repositoryResourcesHookState: { data: Array<{ name?: string }>; isLoading: boolean } = {
-  data: [],
-  isLoading: false,
+
+/** Workspace setup picks the GitHub integration and the app repository. */
+const FACTORY_WITH_SETUP_REPO: FactoriesFactory = {
+  ...REFUND_FACTORY,
+  onboarding: { ...REFUND_FACTORY.onboarding, vcsIntegrationId: "int-1", appRepository: "acme/api" },
 };
 
 vi.mock("@/hooks/useFactoryVelocity", () => ({
@@ -54,15 +51,7 @@ vi.mock("@/hooks/useFactoryData", () => ({
   }),
 }));
 
-vi.mock("@/hooks/useIntegrations", () => ({
-  useConnectedIntegrations: () => ({ data: integrationsHookState.data }),
-  useIntegrationResources: () => ({
-    data: repositoryResourcesHookState.data,
-    isLoading: repositoryResourcesHookState.isLoading,
-  }),
-}));
-
-function renderShell() {
+function renderShell(factory: FactoriesFactory = REFUND_FACTORY) {
   return render(
     <QueryClientProvider client={new QueryClient()}>
       <MemoryRouter initialEntries={["/velocity"]}>
@@ -71,8 +60,8 @@ function renderShell() {
             organizationId: "org-1",
             factoryId: PRIMARY_FACTORY_ID,
             factoryKey: PRIMARY_FACTORY_KEY,
-            factory: REFUND_FACTORY,
-            factories: [REFUND_FACTORY],
+            factory,
+            factories: [factory],
             openCreateWorkOrder: vi.fn(),
           }}
         >
@@ -92,9 +81,6 @@ function resetState() {
   workOrdersHookState.isLoading = false;
   workOrdersHookState.isFetching = false;
   workOrdersHookState.error = null;
-  integrationsHookState.data = [];
-  repositoryResourcesHookState.data = [];
-  repositoryResourcesHookState.isLoading = false;
 }
 
 describe("VelocityPage shell", () => {
@@ -148,7 +134,7 @@ describe("VelocityPage shell", () => {
     expect(screen.queryByTestId("velocity-error-state")).not.toBeInTheDocument();
   });
 
-  it("renders the loaded view and hides People cohort without a repo", () => {
+  it("renders the loaded view and hides People cohort when setup has no repository", () => {
     resetState();
     velocityHookState.data = {
       yesterday: { superplaneMerged: 3, waste: 1 },
@@ -174,19 +160,27 @@ describe("VelocityPage shell", () => {
     expect(yesterday).not.toHaveTextContent("Cost");
 
     const split = screen.getByTestId("velocity-source-split");
-    expect(split).toHaveTextContent("Connect GitHub to compare People and SuperPlane.");
+    expect(split).toHaveTextContent("Connect GitHub in workspace setup to compare People and SuperPlane.");
     expect(split).not.toHaveTextContent("SuperPlane authored");
+  });
+
+  it("names the repository from workspace setup in the header", () => {
+    resetState();
+    velocityHookState.data = {
+      yesterday: { superplaneMerged: 1, waste: 0 },
+      totals: { superplaneMerged: 1, peopleMerged: 0, waste: 0, superplaneSharePct: 0, wastePct: 0 },
+      points: [{ day: "Mon", superplaneMerged: 1, peopleMerged: 0, waste: 0 }],
+      hasPeopleCohort: false,
+    };
+
+    renderShell(FACTORY_WITH_SETUP_REPO);
+
+    expect(screen.getByTestId("workspace-page-header-subtitle")).toHaveTextContent("acme/api");
+    expect(screen.queryByLabelText("Repository")).not.toBeInTheDocument();
   });
 
   it("explains when People merges could not be loaded", () => {
     resetState();
-    integrationsHookState.data = [
-      {
-        metadata: { id: "int-1", name: "GitHub", integrationName: "github" },
-        status: { state: "ready" },
-      },
-    ];
-    repositoryResourcesHookState.data = [{ name: "acme/api" }];
     velocityHookState.data = {
       yesterday: { superplaneMerged: 3, waste: 0 },
       totals: {
@@ -202,7 +196,7 @@ describe("VelocityPage shell", () => {
       repository: "acme/api",
     };
 
-    renderShell();
+    renderShell(FACTORY_WITH_SETUP_REPO);
 
     const split = screen.getByTestId("velocity-source-split");
     expect(split).toHaveTextContent("We could not load People merges. SuperPlane counts still show.");

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -1,9 +1,7 @@
 import { AlertCircle, Loader2 } from "lucide-react";
 import type { ReactNode } from "react";
 
-import type { OrganizationsIntegration } from "@/api-client";
 import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { cn } from "@/lib/utils";
 import { SegmentedNav } from "@/ui/SegmentedNav";
@@ -11,18 +9,16 @@ import { SegmentedNav } from "@/ui/SegmentedNav";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import { VELOCITY_PERIOD_OPTIONS } from "../lib/factoryVelocityFlow";
-import { factorySectionBodyClassName, factorySectionHeaderClassName } from "./factoryPageLayoutStyles";
+import { factoryCenteredSectionBodyClassName, factoryCenteredSectionHeaderClassName } from "./factoryPageLayoutStyles";
 import { VelocityLoadedView, type VelocityPeriodDays, type VelocitySourceSplitConfig } from "./VelocityLoadedView";
 import { useVelocityPageModel, type VelocityPageModel } from "./useVelocityPageModel";
 
 const CARD_CLASSES =
   "flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-card px-6 py-16 text-center";
 
-const NO_REPO_SENTINEL = "__none__";
-
 export function VelocityPage() {
   const { organizationId, factoryId, factory } = useFactoriesLayout();
-  const model = useVelocityPageModel(organizationId, factoryId);
+  const model = useVelocityPageModel(organizationId, factoryId, factory?.onboarding);
   usePageTitle(["Velocity", factory?.name ?? "Workspace"]);
 
   const header = <VelocityHeader model={model} />;
@@ -39,9 +35,8 @@ export function VelocityPage() {
     hasPeopleCohort: model.velocity.hasPeopleCohort,
     repositoryLabel: model.velocity.repositoryLabel,
     emptyState: renderSourceSplitEmptyState({
-      hasGithubIntegration: model.githubIntegrations.length > 0,
-      hasIntegrationSelected: Boolean(model.integrationId),
-      hasRepositorySelected: Boolean(model.repository),
+      hasIntegration: Boolean(model.integrationId),
+      hasRepository: Boolean(model.repository),
       peopleSearchFailed: model.velocity.peopleSearchFailed,
     }),
   };
@@ -70,7 +65,7 @@ function renderShell(header: ReactNode, body: ReactNode, bodyTestId?: string) {
   return (
     <>
       {header}
-      <div className={cn(factorySectionBodyClassName, "space-y-6")} data-testid={bodyTestId}>
+      <div className={cn(factoryCenteredSectionBodyClassName, "space-y-6")} data-testid={bodyTestId}>
         {body}
       </div>
     </>
@@ -78,31 +73,17 @@ function renderShell(header: ReactNode, body: ReactNode, bodyTestId?: string) {
 }
 
 function VelocityHeader({ model }: { model: VelocityPageModel }) {
-  const hasIntegrations = model.githubIntegrations.length > 0;
-
   return (
     <WorkspacePageHeader
-      className={factorySectionHeaderClassName}
+      className={factoryCenteredSectionHeaderClassName}
       title="Velocity"
-      subtitle="Merged pull requests and task time."
+      subtitle={
+        model.repository
+          ? `Merged pull requests and task time for ${model.repository}.`
+          : "Merged pull requests and task time."
+      }
       actions={
         <div className="flex flex-wrap items-center gap-2">
-          {model.githubIntegrations.length > 1 ? (
-            <IntegrationPicker
-              integrations={model.githubIntegrations}
-              selectedIntegrationId={model.integrationId}
-              onChange={model.setIntegrationId}
-            />
-          ) : null}
-
-          <RepositoryPicker
-            hasIntegrations={hasIntegrations}
-            options={model.repositoryOptions}
-            loading={model.repositoriesLoading}
-            value={model.repository}
-            onChange={model.setRepository}
-          />
-
           <SegmentedNav
             ariaLabel="Velocity period in days"
             size="xs"
@@ -119,93 +100,26 @@ function VelocityHeader({ model }: { model: VelocityPageModel }) {
   );
 }
 
-function IntegrationPicker({
-  integrations,
-  selectedIntegrationId,
-  onChange,
-}: {
-  integrations: OrganizationsIntegration[];
-  selectedIntegrationId: string;
-  onChange: (integrationId: string) => void;
-}) {
-  return (
-    <Select value={selectedIntegrationId} onValueChange={onChange}>
-      <SelectTrigger className="h-8 min-w-40 text-[12px]" aria-label="GitHub integration">
-        <SelectValue placeholder="GitHub integration" />
-      </SelectTrigger>
-      <SelectContent>
-        {integrations.map((integration) => {
-          const id = integration.metadata?.id ?? "";
-          const name = integration.metadata?.name ?? id;
-          return (
-            <SelectItem key={id} value={id}>
-              {name}
-            </SelectItem>
-          );
-        })}
-      </SelectContent>
-    </Select>
-  );
-}
-
-function repositoryPlaceholder(hasIntegrations: boolean, loading: boolean): string {
-  if (!hasIntegrations) return "Connect GitHub";
-  if (loading) return "Loading repositories…";
-  return "Select repository";
-}
-
-function RepositoryPicker({
-  hasIntegrations,
-  options,
-  loading,
-  value,
-  onChange,
-}: {
-  hasIntegrations: boolean;
-  options: string[];
-  loading: boolean;
-  value: string;
-  onChange: (value: string) => void;
-}) {
-  return (
-    <Select
-      value={value || NO_REPO_SENTINEL}
-      onValueChange={(next) => onChange(next === NO_REPO_SENTINEL ? "" : next)}
-      disabled={!hasIntegrations || loading}
-    >
-      <SelectTrigger className="h-8 min-w-52 text-[12px]" aria-label="Repository">
-        <SelectValue placeholder={repositoryPlaceholder(hasIntegrations, loading)} />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value={NO_REPO_SENTINEL}>All tasks (no repo)</SelectItem>
-        {options.map((repo) => (
-          <SelectItem key={repo} value={repo}>
-            {repo}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
-
 interface SourceSplitEmptyStateArgs {
-  hasGithubIntegration: boolean;
-  hasIntegrationSelected: boolean;
-  hasRepositorySelected: boolean;
+  hasIntegration: boolean;
+  hasRepository: boolean;
   peopleSearchFailed: boolean;
 }
 
-function renderSourceSplitEmptyState({
-  hasGithubIntegration,
-  hasIntegrationSelected,
-  hasRepositorySelected,
-  peopleSearchFailed,
-}: SourceSplitEmptyStateArgs) {
-  if (!hasGithubIntegration) {
-    return <p className="text-[13px] text-muted-foreground">Connect GitHub to compare People and SuperPlane.</p>;
+function renderSourceSplitEmptyState({ hasIntegration, hasRepository, peopleSearchFailed }: SourceSplitEmptyStateArgs) {
+  if (!hasIntegration) {
+    return (
+      <p className="text-[13px] text-muted-foreground">
+        Connect GitHub in workspace setup to compare People and SuperPlane.
+      </p>
+    );
   }
-  if (!hasIntegrationSelected) {
-    return <p className="text-[13px] text-muted-foreground">Select a GitHub integration and repository.</p>;
+  if (!hasRepository) {
+    return (
+      <p className="text-[13px] text-muted-foreground">
+        Select a repository in workspace setup to compare People and SuperPlane.
+      </p>
+    );
   }
   if (peopleSearchFailed) {
     return (
@@ -213,9 +127,6 @@ function renderSourceSplitEmptyState({
         We could not load People merges. SuperPlane counts still show.
       </p>
     );
-  }
-  if (!hasRepositorySelected) {
-    return <p className="text-[13px] text-muted-foreground">Select a repository to compare People and SuperPlane.</p>;
   }
   return (
     <p className="text-[13px] text-muted-foreground">No merged pull requests in this repository for the period.</p>

--- a/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
@@ -12,7 +12,7 @@ import {
   type FactoryVelocityDay,
   type FactoryVelocityPeriodDays,
 } from "./factoryVelocityMockData";
-import { factorySectionBodyClassName, factorySectionHeaderClassName } from "./factoryPageLayoutStyles";
+import { factoryCenteredSectionBodyClassName, factoryCenteredSectionHeaderClassName } from "./factoryPageLayoutStyles";
 import {
   VelocityLoadedView,
   type VelocityCostConfig,
@@ -92,7 +92,7 @@ export function VelocityPrototypePage() {
   return (
     <>
       <WorkspacePageHeader
-        className={factorySectionHeaderClassName}
+        className={factoryCenteredSectionHeaderClassName}
         title="Velocity"
         subtitle="Merged pull requests, waste, cost, and task time."
         actions={
@@ -109,7 +109,7 @@ export function VelocityPrototypePage() {
         }
       />
 
-      <div className={cn(factorySectionBodyClassName, "space-y-6")} data-testid="factory-velocity-page">
+      <div className={cn(factoryCenteredSectionBodyClassName, "space-y-6")} data-testid="factory-velocity-page">
         <VelocityLoadedView
           periodLabel={period.label}
           periodDays={periodDays}

--- a/web_src/src/pages/factories/pages/factoryPageLayoutStyles.ts
+++ b/web_src/src/pages/factories/pages/factoryPageLayoutStyles.ts
@@ -33,6 +33,17 @@ export const factorySectionHeaderClassName = cn(
 /** Section list/body: same gutter as the header, no extra left inset. */
 export const factorySectionBodyClassName = cn("mx-0 max-w-none pt-0 pb-6 text-foreground", sectionPaneGutter);
 
+/**
+ * Centered variants for report pages such as Velocity. The section title style
+ * stays the same as the other workspace pages, but the header and the body
+ * share one centered column so charts keep a readable width on wide screens.
+ * The header uses a larger top inset than the full-width page header, because a
+ * centered column has no sidebar next to it to set the vertical rhythm.
+ */
+export const factoryCenteredSectionHeaderClassName = cn(factorySectionHeaderClassName, contentColumn, "pt-14");
+
+export const factoryCenteredSectionBodyClassName = cn(factorySectionBodyClassName, contentColumn);
+
 /** Tasks / Lines kanban body: same gutter, fills leftover height. */
 export const factoryWorkOrdersBodyClassName = cn(
   factorySectionBodyClassName,

--- a/web_src/src/pages/factories/pages/useVelocityPageModel.ts
+++ b/web_src/src/pages/factories/pages/useVelocityPageModel.ts
@@ -1,9 +1,8 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
-import type { FactoriesDescribeFactoryVelocityResponse, OrganizationsIntegration } from "@/api-client";
+import type { FactoriesDescribeFactoryVelocityResponse, FactoriesFactory } from "@/api-client";
 import { useFactoryWorkOrders } from "@/hooks/useFactoryData";
 import { useFactoryVelocity } from "@/hooks/useFactoryVelocity";
-import { useConnectedIntegrations, useIntegrationResources } from "@/hooks/useIntegrations";
 
 import {
   aggregateFactoryVelocityFlow,
@@ -24,14 +23,10 @@ export interface VelocityPageModel {
   periodLabel: string;
   setPeriodDays: (days: VelocityPeriodDays) => void;
 
-  githubIntegrations: OrganizationsIntegration[];
+  /** GitHub integration selected during workspace setup. */
   integrationId: string;
-  setIntegrationId: (integrationId: string) => void;
-
-  repositoryOptions: string[];
-  repositoriesLoading: boolean;
+  /** App repository selected during workspace setup, as `owner/repo`. */
   repository: string;
-  setRepository: (repository: string) => void;
 
   velocity: {
     data?: VelocityData;
@@ -89,41 +84,15 @@ function toVelocityData(response: FactoriesDescribeFactoryVelocityResponse, date
   };
 }
 
-export function useVelocityPageModel(organizationId: string, factoryId: string): VelocityPageModel {
+export function useVelocityPageModel(
+  organizationId: string,
+  factoryId: string,
+  onboarding: FactoriesFactory["onboarding"],
+): VelocityPageModel {
   const [periodDays, setPeriodDays] = useState<VelocityPeriodDays>(7);
-  const [integrationId, setIntegrationId] = useState<string>("");
-  const [repository, setRepository] = useState<string>("");
 
-  const { data: connectedIntegrations = [] } = useConnectedIntegrations(organizationId);
-  const githubIntegrations = useMemo(
-    () =>
-      connectedIntegrations.filter(
-        (integration) => integration.metadata?.integrationName === "github" && integration.status?.state === "ready",
-      ),
-    [connectedIntegrations],
-  );
-
-  const effectiveIntegrationId = useMemo(() => {
-    if (integrationId) return integrationId;
-    if (githubIntegrations.length === 1) {
-      return githubIntegrations[0].metadata?.id ?? "";
-    }
-    return "";
-  }, [integrationId, githubIntegrations]);
-
-  const { data: repositoryResources = [], isLoading: repositoriesLoading } = useIntegrationResources(
-    organizationId,
-    effectiveIntegrationId,
-    "repository",
-  );
-
-  const repositoryOptions = useMemo(
-    () =>
-      repositoryResources
-        .map((resource) => resource.name?.trim() ?? "")
-        .filter((name): name is string => name.length > 0),
-    [repositoryResources],
-  );
+  const integrationId = onboarding?.vcsIntegrationId?.trim() ?? "";
+  const repository = onboarding?.appRepository?.trim() ?? "";
 
   const {
     data: velocityResponse,
@@ -133,7 +102,7 @@ export function useVelocityPageModel(organizationId: string, factoryId: string):
     refetch: refetchVelocity,
   } = useFactoryVelocity(organizationId, factoryId, {
     periodDays,
-    integrationId: effectiveIntegrationId || undefined,
+    integrationId: integrationId || undefined,
     repository: repository || undefined,
   });
 
@@ -147,7 +116,7 @@ export function useVelocityPageModel(organizationId: string, factoryId: string):
   const isVelocityLoading = velocityLoading || (velocityFetching && !velocityResponse);
   const isWorkOrdersLoading = workOrdersLoading || (workOrdersFetching && workOrders.length === 0);
 
-  const hasRepoContext = Boolean(effectiveIntegrationId && repository);
+  const hasRepoContext = Boolean(integrationId && repository);
   const hasPeopleCohort = Boolean(velocityResponse?.hasPeopleCohort && hasRepoContext);
 
   const velocityData = velocityResponse
@@ -160,17 +129,8 @@ export function useVelocityPageModel(organizationId: string, factoryId: string):
     periodLabel: factoryVelocityPeriodLabel(periodDays),
     setPeriodDays,
 
-    githubIntegrations,
-    integrationId: effectiveIntegrationId,
-    setIntegrationId: (value: string) => {
-      setIntegrationId(value);
-      setRepository("");
-    },
-
-    repositoryOptions,
-    repositoriesLoading,
+    integrationId,
     repository,
-    setRepository,
 
     velocity: {
       data: velocityData,


### PR DESCRIPTION
## Summary

The Velocity page had its own GitHub integration and repository pickers.
Workspace setup already selects a repository, so the page asked the user
the same question a second time. The default option `All tasks (no repo)`
also removed the People comparison, and the user could not see why.

Velocity now reads the integration and the repository from workspace
setup. The page header names that repository. The empty states point to
workspace setup, because that is the only place that changes the value.

Two smaller changes come with it:

- The page uses one centered column. The charts stretched across the full
  pane on wide screens.
- Metric cells carry the color of the chart series that they belong to,
  and a card with no data shows a short note in place of an empty chart
  axis.

The page stays behind the `factory_velocity` experimental feature.

## Test plan

- [ ] Open a workspace that completed setup with a repository. The
      Velocity header shows `Merged pull requests and task time for
      <owner>/<repo>.` and no repository picker.
- [ ] Confirm the `Merged PRs by source` card compares People and
      SuperPlane for that repository.
- [ ] Open a workspace that has no repository in setup. The source card
      asks the user to select a repository in workspace setup.
- [ ] Select a period with no merged or closed pull requests. The cards
      show a short note, not an empty chart axis.
- [ ] Resize the window. The page stays in one centered column.
- [ ] `make check.lint.ui`, `make check.build.ui`, and the factories test
      suite pass.

Made with [Cursor](https://cursor.com)