### PR TITLE
feat: Expand the Velocity prototype in Storybook

### DIFF
--- a/web_src/src/pages/factories/pages/VelocityPeopleTable.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPeopleTable.tsx
@@ -1,0 +1,200 @@
+import { useMemo, useState } from "react";
+import { ArrowDown, ArrowUp } from "lucide-react";
+
+import { Avatar } from "@/components/Avatar/avatar";
+import { getUserInitials } from "@/lib/orgUserDisplay";
+import { cn } from "@/lib/utils";
+
+export interface VelocityPerson {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  /** Pull requests the person authored and merged themselves. */
+  authoredMerged: number;
+  /** Merged pull requests produced by Factory tasks this person started. */
+  factoryMerged: number;
+  /** Factory tasks this person started that closed without a merge. */
+  factoryWaste: number;
+  /** Median hours from task start to close, for their Factory tasks. */
+  medianCycleHours: number;
+  /** Tracked model and compute cost for their Factory tasks. */
+  costUsd: number;
+}
+
+type SortKey = "total" | "authoredMerged" | "factoryMerged" | "factoryWaste" | "medianCycleHours" | "costUsd";
+
+/** Members without a connected account photo still need a stable, legible avatar. */
+const AVATAR_COLORS = [
+  "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+  "bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300",
+  "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
+  "bg-cyan-100 text-cyan-700 dark:bg-cyan-950 dark:text-cyan-300",
+];
+
+function avatarColorClass(id: string): string {
+  let hash = 0;
+  for (let index = 0; index < id.length; index += 1) {
+    hash = (hash * 31 + id.charCodeAt(index)) % AVATAR_COLORS.length;
+  }
+  return AVATAR_COLORS[hash] ?? AVATAR_COLORS[0]!;
+}
+
+interface Column {
+  key: SortKey;
+  label: string;
+  hint: string;
+  format: (person: VelocityPerson) => string;
+}
+
+const COLUMNS: Column[] = [
+  {
+    key: "authoredMerged",
+    label: "Authored",
+    hint: "Pull requests the person merged themselves",
+    format: (person) => String(person.authoredMerged),
+  },
+  {
+    key: "factoryMerged",
+    label: "Factory merged",
+    hint: "Merged pull requests from tasks this person started",
+    format: (person) => String(person.factoryMerged),
+  },
+  {
+    key: "factoryWaste",
+    label: "Factory waste",
+    hint: "Tasks this person started that closed without a merge",
+    format: (person) => String(person.factoryWaste),
+  },
+  {
+    key: "medianCycleHours",
+    label: "Median cycle",
+    hint: "Median time from task start to close",
+    format: (person) => `${Math.round(person.medianCycleHours)}h`,
+  },
+  {
+    key: "costUsd",
+    label: "Tracked cost",
+    hint: "Model tokens and execution compute",
+    format: (person) => `$${person.costUsd.toFixed(0)}`,
+  },
+  {
+    key: "total",
+    label: "Merged PRs",
+    hint: "Authored plus Factory merged",
+    format: (person) => String(totalMerged(person)),
+  },
+];
+
+function totalMerged(person: VelocityPerson): number {
+  return person.authoredMerged + person.factoryMerged;
+}
+
+function sortValue(person: VelocityPerson, key: SortKey): number {
+  if (key === "total") return totalMerged(person);
+  return person[key];
+}
+
+export function VelocityPeopleTable({ people, periodLabel }: { people: VelocityPerson[]; periodLabel: string }) {
+  const [sortKey, setSortKey] = useState<SortKey>("total");
+
+  const sorted = useMemo(
+    () => [...people].sort((a, b) => sortValue(b, sortKey) - sortValue(a, sortKey)),
+    [people, sortKey],
+  );
+
+  return (
+    <section className="rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">People</h2>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">
+            What each member merged directly and through the Factory. Select a column to sort.
+          </p>
+        </div>
+        <p className="text-[12px] text-muted-foreground">{periodLabel}</p>
+      </div>
+
+      <div className="mt-5 overflow-x-auto">
+        <table className="w-full min-w-[720px] border-collapse text-[13px]">
+          <thead>
+            <tr className="border-b border-border">
+              <th scope="col" className="w-8 pb-2 text-left text-[12px] font-normal text-muted-foreground">
+                <span className="sr-only">Rank</span>
+              </th>
+              <th scope="col" className="pb-2 text-left text-[12px] font-normal text-muted-foreground">
+                Member
+              </th>
+              {COLUMNS.map((column) => (
+                <SortableHeader
+                  key={column.key}
+                  column={column}
+                  isActive={sortKey === column.key}
+                  onSort={() => setSortKey(column.key)}
+                />
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((person, index) => (
+              <tr key={person.id} className="border-b border-border/60 last:border-b-0">
+                <td className="py-3 text-[12px] tabular-nums text-muted-foreground">{index + 1}</td>
+                <td className="py-3 pr-6">
+                  <div className="flex min-w-0 items-center gap-2.5">
+                    <Avatar
+                      src={person.avatarUrl}
+                      initials={getUserInitials(person.name)}
+                      alt={person.name}
+                      className={cn("size-7 shrink-0", avatarColorClass(person.id))}
+                    />
+                    <div className="min-w-0">
+                      <p className="truncate text-foreground">{person.name}</p>
+                      <p className="truncate text-[12px] text-muted-foreground">{person.email}</p>
+                    </div>
+                  </div>
+                </td>
+                {COLUMNS.map((column) => (
+                  <td
+                    key={column.key}
+                    className={cn(
+                      "py-3 pl-6 text-right tabular-nums",
+                      sortKey === column.key ? "text-foreground" : "text-muted-foreground",
+                    )}
+                  >
+                    {column.format(person)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-4 text-[12px] text-muted-foreground">
+        {people.length} {people.length === 1 ? "member" : "members"} with activity in this period
+      </p>
+    </section>
+  );
+}
+
+function SortableHeader({ column, isActive, onSort }: { column: Column; isActive: boolean; onSort: () => void }) {
+  return (
+    <th scope="col" className="pb-2 pl-6 text-right text-[12px] font-normal">
+      <button
+        type="button"
+        onClick={onSort}
+        title={column.hint}
+        aria-sort={isActive ? "descending" : "none"}
+        className={cn(
+          "inline-flex items-center gap-1 transition-colors hover:text-foreground",
+          isActive ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {isActive ? <ArrowDown className="size-3" aria-hidden /> : <ArrowUp className="size-3 opacity-0" aria-hidden />}
+        {column.label}
+      </button>
+    </th>
+  );
+}

--- a/web_src/src/pages/factories/pages/VelocityPrototypeCharts.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPrototypeCharts.tsx
@@ -1,0 +1,151 @@
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+
+import {
+  BREAKDOWN_SERIES,
+  COST_SERIES_COLORS,
+  TIME_SERIES_COLORS,
+  type Breakdown,
+  type VelocityPoint,
+} from "./velocityPrototypeData";
+
+const flowChartConfig = {
+  runningHours: { label: "Time running", color: TIME_SERIES_COLORS.running },
+  waitingHours: { label: "Time waiting", color: TIME_SERIES_COLORS.waiting },
+} satisfies ChartConfig;
+
+const costChartConfig = {
+  tokenCostUsd: { label: "Model tokens", color: COST_SERIES_COLORS.tokens },
+  computeCostUsd: { label: "Execution compute", color: COST_SERIES_COLORS.compute },
+} satisfies ChartConfig;
+
+/** Both area charts sit side by side, so they must read as one visual family. */
+const AREA_FILL_OPACITY = 0.3;
+const AREA_STROKE_WIDTH = 1.5;
+
+export function DeliveryChart({ points, breakdown }: { points: VelocityPoint[]; breakdown: Breakdown }) {
+  const series = BREAKDOWN_SERIES[breakdown];
+  const config = Object.fromEntries(
+    series.map((item) => [item.key, { label: item.label, color: item.color }]),
+  ) satisfies ChartConfig;
+
+  return (
+    <ChartContainer
+      config={config}
+      className="aspect-auto h-[260px] w-full"
+      initialDimension={{ width: 760, height: 260 }}
+    >
+      <BarChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis allowDecimals={false} tickLine={false} axisLine={false} width={28} className="text-[11px]" />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+        {series.map((item, index) => (
+          <Bar
+            key={item.key}
+            dataKey={item.key}
+            name={item.label}
+            stackId="day"
+            fill={item.color}
+            radius={index === series.length - 1 ? [3, 3, 0, 0] : undefined}
+            maxBarSize={24}
+          />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+export function FlowChart({ points }: { points: VelocityPoint[] }) {
+  return (
+    <ChartContainer
+      config={flowChartConfig}
+      className="aspect-auto h-[180px] w-full"
+      initialDimension={{ width: 500, height: 180 }}
+    >
+      <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={36}
+          className="text-[11px]"
+          tickFormatter={(value: number) => `${value}h`}
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        {/* No legend: the labeled split above the chart names both bands. */}
+        <Area
+          type="monotone"
+          dataKey="runningHours"
+          stackId="time"
+          stroke={TIME_SERIES_COLORS.running}
+          fill={TIME_SERIES_COLORS.running}
+          fillOpacity={AREA_FILL_OPACITY}
+          strokeWidth={AREA_STROKE_WIDTH}
+        />
+        <Area
+          type="monotone"
+          dataKey="waitingHours"
+          stackId="time"
+          stroke={TIME_SERIES_COLORS.waiting}
+          fill={TIME_SERIES_COLORS.waiting}
+          fillOpacity={AREA_FILL_OPACITY}
+          strokeWidth={AREA_STROKE_WIDTH}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+export function CostChart({ points }: { points: VelocityPoint[] }) {
+  return (
+    <ChartContainer
+      config={costChartConfig}
+      className="aspect-auto h-[180px] w-full"
+      initialDimension={{ width: 500, height: 180 }}
+    >
+      <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={34}
+          className="text-[11px]"
+          tickFormatter={(value: number) => `$${value}`}
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        {/* No legend: the labeled cost split above the chart already names both
+            bands, and its dots use these colors. */}
+        <Area
+          type="monotone"
+          dataKey="tokenCostUsd"
+          stackId="cost"
+          stroke={COST_SERIES_COLORS.tokens}
+          fill={COST_SERIES_COLORS.tokens}
+          fillOpacity={AREA_FILL_OPACITY}
+          strokeWidth={AREA_STROKE_WIDTH}
+        />
+        <Area
+          type="monotone"
+          dataKey="computeCostUsd"
+          stackId="cost"
+          stroke={COST_SERIES_COLORS.compute}
+          fill={COST_SERIES_COLORS.compute}
+          fillOpacity={AREA_FILL_OPACITY}
+          strokeWidth={AREA_STROKE_WIDTH}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}

--- a/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
@@ -37,6 +37,9 @@ interface VelocityPoint {
   runningHours: number;
   waitingHours: number;
   costUsd: number;
+  tokenCostUsd: number;
+  computeCostUsd: number;
+  wasteCostUsd: number;
   tokens: number;
 }
 
@@ -120,7 +123,8 @@ const flowChartConfig = {
 } satisfies ChartConfig;
 
 const costChartConfig = {
-  costUsd: { label: "Tracked cost", color: "#64748b" },
+  tokenCostUsd: { label: "Model tokens", color: "#64748b" },
+  computeCostUsd: { label: "Execution compute", color: "#6366f1" },
 } satisfies ChartConfig;
 
 const cardClassName = "rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5";
@@ -147,7 +151,11 @@ function buildVelocityPoints(periodDays: PeriodDays, windowOffset = 0): Velocity
     const api = Math.max(0, superplane - githubIssues - sentryExceptions - manual);
     const runningHours = 8 + 3 * Math.sin(day * 0.48 + 0.5);
     const waitingHours = 13 + 5 * Math.sin(day * 0.35 + 1.8) + day * 0.18;
-    const costUsd = superplane * 2.14 + waste * 0.72;
+    const mergedCostUsd = superplane * 2.14;
+    const wasteCostUsd = waste * 1.85;
+    const costUsd = mergedCostUsd + wasteCostUsd;
+    const tokenCostUsd = Math.round((superplane * 1.67 + waste * 1.44) * 100) / 100;
+    const computeCostUsd = Math.round((costUsd - tokenCostUsd) * 100) / 100;
 
     return {
       day: periodDays === 14 ? `${index + 1}` : index % 5 === 0 || index === periodDays - 1 ? `${index + 1}` : "",
@@ -162,7 +170,10 @@ function buildVelocityPoints(periodDays: PeriodDays, windowOffset = 0): Velocity
       runningHours: Math.max(2, Math.round(runningHours * 10) / 10),
       waitingHours: Math.max(3, Math.round(waitingHours * 10) / 10),
       costUsd: Math.round(costUsd * 100) / 100,
-      tokens: superplane * 18_500,
+      tokenCostUsd,
+      computeCostUsd,
+      wasteCostUsd: Math.round(wasteCostUsd * 100) / 100,
+      tokens: superplane * 18_500 + waste * 12_400,
     };
   });
 }
@@ -264,6 +275,9 @@ function summarizePoints(points: VelocityPoint[]) {
     runningHours: median(points.map((point) => point.runningHours)),
     waitingHours: median(points.map((point) => point.waitingHours)),
     cost,
+    tokenCost: sum(points, "tokenCostUsd"),
+    computeCost: sum(points, "computeCostUsd"),
+    wasteCost: sum(points, "wasteCostUsd"),
     tokens: sum(points, "tokens"),
     costPerMerge,
   };
@@ -425,7 +439,25 @@ function CostChart({ points }: { points: VelocityPoint[] }) {
           tickFormatter={(value: number) => `$${value}`}
         />
         <ChartTooltip content={<ChartTooltipContent />} />
-        <Area type="monotone" dataKey="costUsd" stroke="#64748b" fill="#64748b" fillOpacity={0.12} strokeWidth={1.5} />
+        <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+        <Area
+          type="monotone"
+          dataKey="tokenCostUsd"
+          stackId="cost"
+          stroke="#64748b"
+          fill="#64748b"
+          fillOpacity={0.28}
+          strokeWidth={1.5}
+        />
+        <Area
+          type="monotone"
+          dataKey="computeCostUsd"
+          stackId="cost"
+          stroke="#6366f1"
+          fill="#6366f1"
+          fillOpacity={0.28}
+          strokeWidth={1.5}
+        />
       </AreaChart>
     </ChartContainer>
   );
@@ -548,7 +580,17 @@ export function VelocityPrototypePage() {
             <p className={cardSubtitleClassName}>Model tokens and execution compute. Third-party charges are excluded.</p>
             <div className="mt-5 grid grid-cols-2 gap-5">
               <Metric label="Total cost" value={formatUsd(current.cost)} />
-              <Metric label="Model tokens" value={formatCompactTokenValue(current.tokens)} />
+              <Metric
+                label="Spend on waste"
+                value={formatUsd(current.wasteCost)}
+                hint="Factory work that closed without a merge"
+              />
+              <Metric
+                label="Model tokens"
+                value={formatUsd(current.tokenCost)}
+                hint={`${formatCompactTokenValue(current.tokens)} tokens`}
+              />
+              <Metric label="Execution compute" value={formatUsd(current.computeCost)} />
             </div>
             <div className="mt-5 border-t border-border pt-4">
               <CostChart points={points} />

--- a/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
@@ -1,287 +1,33 @@
 import { useMemo, useState } from "react";
 import { ArrowDownRight, ArrowUpRight } from "lucide-react";
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
-import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
-  type ChartConfig,
-} from "@/components/ui/chart";
 import { formatCompactTokenValue } from "@/lib/formatTokenCount";
 import { cn } from "@/lib/utils";
 import { SegmentedNav } from "@/ui/SegmentedNav";
 
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
 import { factoryCenteredSectionBodyClassName, factoryCenteredSectionHeaderClassName } from "./factoryPageLayoutStyles";
-import { VelocityPeopleTable, type VelocityPerson } from "./VelocityPeopleTable";
-
-type PeriodDays = 14 | 30;
-type Breakdown = "origin" | "outcome" | "intake";
-
-/** Workspace setup pins one app repository, so Velocity reports on that repository. */
-const WORKSPACE_REPOSITORY = "acme/refunds";
-
-interface VelocityPoint {
-  day: string;
-  people: number;
-  superplane: number;
-  merged: number;
-  waste: number;
-  githubIssues: number;
-  sentryExceptions: number;
-  manual: number;
-  api: number;
-  runningHours: number;
-  waitingHours: number;
-  costUsd: number;
-  tokenCostUsd: number;
-  computeCostUsd: number;
-  wasteCostUsd: number;
-  tokens: number;
-}
-
-interface BreakdownSeries {
-  key: keyof VelocityPoint;
-  label: string;
-  color: string;
-}
-
-const PERIOD_OPTIONS = [
-  { value: "14", label: "14d" },
-  { value: "30", label: "30d" },
-];
-
-const BREAKDOWN_OPTIONS = [
-  { value: "origin", label: "Origin" },
-  { value: "outcome", label: "Outcome" },
-  { value: "intake", label: "Intake source" },
-];
-
-const BREAKDOWN_SERIES: Record<Breakdown, BreakdownSeries[]> = {
-  origin: [
-    { key: "people", label: "People", color: "#64748b" },
-    { key: "superplane", label: "SuperPlane", color: "#10b981" },
-  ],
-  outcome: [
-    { key: "merged", label: "Merged", color: "#10b981" },
-    { key: "waste", label: "Closed without merge", color: "#ef4444" },
-  ],
-  intake: [
-    { key: "githubIssues", label: "GitHub issue", color: "#3b82f6" },
-    { key: "sentryExceptions", label: "Sentry exception", color: "#8b5cf6" },
-    { key: "manual", label: "Manually created", color: "#f59e0b" },
-    { key: "api", label: "API", color: "#06b6d4" },
-  ],
-};
-
-const BREAKDOWN_COPY: Record<Breakdown, { title: string; description: string }> = {
-  origin: {
-    title: "Merged pull requests by origin",
-    description: "Team output split between people and SuperPlane.",
-  },
-  outcome: {
-    title: "Pull requests by outcome",
-    description: "Merged pull requests and Factory pull requests closed without merge.",
-  },
-  intake: {
-    title: "Factory merges by intake source",
-    description: "Merged pull requests grouped by how their tasks entered the Factory.",
-  },
-};
-
-function githubAvatar(accountId: number): string {
-  return `https://avatars.githubusercontent.com/u/${accountId}?v=4&s=64`;
-}
-
-/**
- * Per-member share of the period. Avatars use the GitHub account id, which is
- * how the connected provider serves them in production.
- */
-const PEOPLE_SHARE: Array<
-  Omit<VelocityPerson, "id" | "authoredMerged" | "factoryMerged" | "factoryWaste" | "costUsd"> & {
-    id: string;
-    authoredShare: number;
-    factoryShare: number;
-    wasteShare: number;
-  }
-> = [
-  { id: "darkofabijan", name: "Darko Fabijan", email: "darko@superplane.com", avatarUrl: githubAvatar(20469), authoredShare: 0.24, factoryShare: 0.32, wasteShare: 0.18, medianCycleHours: 16 },
-  { id: "AleksandarCole", name: "Aleksandar Mitrovic", email: "alex@superplane.com", avatarUrl: githubAvatar(61409859), authoredShare: 0.2, factoryShare: 0.2, wasteShare: 0.14, medianCycleHours: 21 },
-  { id: "shiroyasha", name: "Igor Šarčević", email: "igor@superplane.com", avatarUrl: githubAvatar(1779493), authoredShare: 0.16, factoryShare: 0.16, wasteShare: 0.15, medianCycleHours: 19 },
-  { id: "andrecalil", name: "André Calil", email: "andre@superplane.com", avatarUrl: githubAvatar(1105923), authoredShare: 0.14, factoryShare: 0.13, wasteShare: 0.2, medianCycleHours: 28 },
-  { id: "forestileao", name: "Pedro Leão", email: "pedro@superplane.com", avatarUrl: githubAvatar(60622592), authoredShare: 0.12, factoryShare: 0.1, wasteShare: 0.18, medianCycleHours: 24 },
-  { id: "markoa", name: "Marko Anastasov", email: "marko@superplane.com", avatarUrl: githubAvatar(8651), authoredShare: 0.08, factoryShare: 0.06, wasteShare: 0.1, medianCycleHours: 31 },
-  { id: "lucaspin", name: "Lucas Pinheiro", email: "lucas@superplane.com", avatarUrl: githubAvatar(12387728), authoredShare: 0.06, factoryShare: 0.03, wasteShare: 0.05, medianCycleHours: 12 },
-];
-
-const flowChartConfig = {
-  runningHours: { label: "Time running", color: "#60a5fa" },
-  waitingHours: { label: "Time waiting", color: "#f59e0b" },
-} satisfies ChartConfig;
-
-const costChartConfig = {
-  tokenCostUsd: { label: "Model tokens", color: "#64748b" },
-  computeCostUsd: { label: "Execution compute", color: "#6366f1" },
-} satisfies ChartConfig;
+import { VelocityPeopleTable } from "./VelocityPeopleTable";
+import { CostChart, DeliveryChart, FlowChart } from "./VelocityPrototypeCharts";
+import {
+  BREAKDOWN_COPY,
+  BREAKDOWN_OPTIONS,
+  COST_SERIES_COLORS,
+  PERIOD_OPTIONS,
+  TIME_SERIES_COLORS,
+  WORKSPACE_REPOSITORY,
+  buildPeople,
+  buildVelocityPoints,
+  summarizePoints,
+  type Breakdown,
+  type PeriodDays,
+} from "./velocityPrototypeData";
 
 const cardClassName = "rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5";
 const cardTitleClassName = "text-[14px] font-medium tracking-[-0.01em] text-foreground";
 const cardSubtitleClassName = "mt-0.5 text-[12px] text-muted-foreground";
 
-/**
- * `windowOffset` shifts the mock series along the timeline, so the current and
- * previous windows are different slices. Higher offset is more recent.
- *
- * The series drifts on purpose: Factory output ramps up while review time grows.
- * That gives the prototype a mixed result instead of every metric improving.
- */
-function buildVelocityPoints(periodDays: PeriodDays, windowOffset = 0): VelocityPoint[] {
-  return Array.from({ length: periodDays }, (_, index) => {
-    const day = index + windowOffset;
-    const people = Math.max(1, Math.round(8 + 2.6 * Math.sin(day * 0.8)));
-    const superplane = Math.max(1, Math.round(4 + 1.8 * Math.sin(day * 0.55 + 1) + day * 0.09));
-    const merged = people + superplane;
-    const waste = day % 6 === 2 ? Math.max(1, Math.round(superplane * 0.35)) : day % 4 === 0 ? 1 : 0;
-    const githubIssues = Math.round(superplane * 0.43);
-    const sentryExceptions = Math.round(superplane * 0.27);
-    const manual = Math.round(superplane * 0.18);
-    const api = Math.max(0, superplane - githubIssues - sentryExceptions - manual);
-    const runningHours = 8 + 3 * Math.sin(day * 0.48 + 0.5);
-    const waitingHours = 13 + 5 * Math.sin(day * 0.35 + 1.8) + day * 0.18;
-    const mergedCostUsd = superplane * 2.14;
-    const wasteCostUsd = waste * 1.85;
-    const costUsd = mergedCostUsd + wasteCostUsd;
-    const tokenCostUsd = Math.round((superplane * 1.67 + waste * 1.44) * 100) / 100;
-    const computeCostUsd = Math.round((costUsd - tokenCostUsd) * 100) / 100;
-
-    return {
-      day: periodDays === 14 ? `${index + 1}` : index % 5 === 0 || index === periodDays - 1 ? `${index + 1}` : "",
-      people,
-      superplane,
-      merged,
-      waste,
-      githubIssues,
-      sentryExceptions,
-      manual,
-      api,
-      runningHours: Math.max(2, Math.round(runningHours * 10) / 10),
-      waitingHours: Math.max(3, Math.round(waitingHours * 10) / 10),
-      costUsd: Math.round(costUsd * 100) / 100,
-      tokenCostUsd,
-      computeCostUsd,
-      wasteCostUsd: Math.round(wasteCostUsd * 100) / 100,
-      tokens: superplane * 18_500 + waste * 12_400,
-    };
-  });
-}
-
-/**
- * Splits a period total across members with the largest-remainder method, so
- * the People table always adds up to the totals shown above it.
- */
-function distribute(total: number, shares: number[]): number[] {
-  const exact = shares.map((share) => total * share);
-  const floors = exact.map((value) => Math.floor(value));
-  let remainder = total - floors.reduce((sum, value) => sum + value, 0);
-
-  const order = exact
-    .map((value, index) => ({ index, fraction: value - Math.floor(value) }))
-    .sort((a, b) => b.fraction - a.fraction);
-
-  const result = [...floors];
-  for (const { index } of order) {
-    if (remainder <= 0) break;
-    result[index] = (result[index] ?? 0) + 1;
-    remainder -= 1;
-  }
-  return result;
-}
-
-function buildPeople(totals: {
-  peopleMerged: number;
-  superplaneMerged: number;
-  waste: number;
-  costUsd: number;
-}): VelocityPerson[] {
-  const authored = distribute(
-    totals.peopleMerged,
-    PEOPLE_SHARE.map((person) => person.authoredShare),
-  );
-  const factoryMerged = distribute(
-    totals.superplaneMerged,
-    PEOPLE_SHARE.map((person) => person.factoryShare),
-  );
-  const factoryWaste = distribute(
-    totals.waste,
-    PEOPLE_SHARE.map((person) => person.wasteShare),
-  );
-
-  return PEOPLE_SHARE.map((person, index) => ({
-    id: person.id,
-    name: person.name,
-    email: person.email,
-    avatarUrl: person.avatarUrl,
-    authoredMerged: authored[index] ?? 0,
-    factoryMerged: factoryMerged[index] ?? 0,
-    factoryWaste: factoryWaste[index] ?? 0,
-    medianCycleHours: person.medianCycleHours,
-    costUsd: totals.costUsd * person.factoryShare,
-  }));
-}
-
-function sum(points: VelocityPoint[], field: keyof VelocityPoint): number {
-  return points.reduce((total, point) => {
-    const value = point[field];
-    return total + (typeof value === "number" ? value : 0);
-  }, 0);
-}
-
-function median(values: number[]): number {
-  const sorted = [...values].sort((a, b) => a - b);
-  const middle = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 0) return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
-  return sorted[middle] ?? 0;
-}
-
-function formatHours(value: number) {
-  return `${Math.round(value)}h`;
-}
-
-function formatUsd(value: number) {
-  return `$${value.toFixed(2)}`;
-}
-
 type ChangeBetter = "up" | "down";
-
-function summarizePoints(points: VelocityPoint[]) {
-  const merged = sum(points, "merged");
-  const superplaneMerged = sum(points, "superplane");
-  const waste = sum(points, "waste");
-  const cost = sum(points, "costUsd");
-  const cycleHours = median(points.map((point) => point.runningHours + point.waitingHours));
-  const wasteRate = superplaneMerged + waste > 0 ? Math.round((waste / (superplaneMerged + waste)) * 100) : 0;
-  const costPerMerge = superplaneMerged > 0 ? cost / superplaneMerged : 0;
-
-  return {
-    merged,
-    peopleMerged: sum(points, "people"),
-    superplaneMerged,
-    waste,
-    wasteRate,
-    cycleHours,
-    runningHours: median(points.map((point) => point.runningHours)),
-    waitingHours: median(points.map((point) => point.waitingHours)),
-    cost,
-    tokenCost: sum(points, "tokenCostUsd"),
-    computeCost: sum(points, "computeCostUsd"),
-    wasteCost: sum(points, "wasteCostUsd"),
-    tokens: sum(points, "tokens"),
-    costPerMerge,
-  };
-}
 
 /** The arrow shows which way the number moved. The color shows whether that is good. */
 interface MetricChange {
@@ -295,6 +41,19 @@ const CHANGE_TONE_CLASS: Record<MetricChange["tone"], string> = {
   worse: "bg-rose-50 text-rose-700 dark:bg-rose-950/60 dark:text-rose-400",
   same: "bg-muted text-muted-foreground",
 };
+
+function formatHours(value: number) {
+  return `${Math.round(value)}h`;
+}
+
+function formatUsd(value: number) {
+  return `$${value.toFixed(2)}`;
+}
+
+function costShare(part: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.round((part / total) * 100);
+}
 
 function buildChange(delta: number, better: ChangeBetter, format: (magnitude: number) => string): MetricChange {
   if (delta === 0) return { text: "No change", tone: "same", direction: "flat" };
@@ -348,118 +107,36 @@ function Metric({
   );
 }
 
-function DeliveryChart({ points, breakdown }: { points: VelocityPoint[]; breakdown: Breakdown }) {
-  const series = BREAKDOWN_SERIES[breakdown];
-  const config = Object.fromEntries(
-    series.map((item) => [item.key, { label: item.label, color: item.color }]),
-  ) satisfies ChartConfig;
-
+/**
+ * One line of a card split. The dot ties the number to its band in the chart
+ * below, so neither chart needs its own legend.
+ *
+ * `share` is only for splits that partition a total. Medians do not sum to the
+ * median of the total, so the time split leaves it out.
+ */
+function SplitRow({
+  color,
+  label,
+  value,
+  share,
+  hint,
+}: {
+  color: string;
+  label: string;
+  value: string;
+  share?: number;
+  hint?: string;
+}) {
   return (
-    <ChartContainer
-      config={config}
-      className="aspect-auto h-[260px] w-full"
-      initialDimension={{ width: 760, height: 260 }}
-    >
-      <BarChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
-        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
-        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
-        <YAxis allowDecimals={false} tickLine={false} axisLine={false} width={28} className="text-[11px]" />
-        <ChartTooltip content={<ChartTooltipContent />} />
-        <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
-        {series.map((item, index) => (
-          <Bar
-            key={item.key}
-            dataKey={item.key}
-            name={item.label}
-            stackId="day"
-            fill={item.color}
-            radius={index === series.length - 1 ? [3, 3, 0, 0] : undefined}
-            maxBarSize={24}
-          />
-        ))}
-      </BarChart>
-    </ChartContainer>
-  );
-}
-
-function FlowChart({ points }: { points: VelocityPoint[] }) {
-  return (
-    <ChartContainer
-      config={flowChartConfig}
-      className="aspect-auto h-[180px] w-full"
-      initialDimension={{ width: 500, height: 180 }}
-    >
-      <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
-        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
-        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
-        <YAxis
-          tickLine={false}
-          axisLine={false}
-          width={36}
-          className="text-[11px]"
-          tickFormatter={(value: number) => `${value}h`}
-        />
-        <ChartTooltip content={<ChartTooltipContent />} />
-        <Area
-          type="monotone"
-          dataKey="runningHours"
-          stackId="time"
-          stroke="#60a5fa"
-          fill="#60a5fa"
-          fillOpacity={0.3}
-        />
-        <Area
-          type="monotone"
-          dataKey="waitingHours"
-          stackId="time"
-          stroke="#f59e0b"
-          fill="#f59e0b"
-          fillOpacity={0.3}
-        />
-      </AreaChart>
-    </ChartContainer>
-  );
-}
-
-function CostChart({ points }: { points: VelocityPoint[] }) {
-  return (
-    <ChartContainer
-      config={costChartConfig}
-      className="aspect-auto h-[180px] w-full"
-      initialDimension={{ width: 500, height: 180 }}
-    >
-      <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
-        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
-        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
-        <YAxis
-          tickLine={false}
-          axisLine={false}
-          width={34}
-          className="text-[11px]"
-          tickFormatter={(value: number) => `$${value}`}
-        />
-        <ChartTooltip content={<ChartTooltipContent />} />
-        <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
-        <Area
-          type="monotone"
-          dataKey="tokenCostUsd"
-          stackId="cost"
-          stroke="#64748b"
-          fill="#64748b"
-          fillOpacity={0.28}
-          strokeWidth={1.5}
-        />
-        <Area
-          type="monotone"
-          dataKey="computeCostUsd"
-          stackId="cost"
-          stroke="#6366f1"
-          fill="#6366f1"
-          fillOpacity={0.28}
-          strokeWidth={1.5}
-        />
-      </AreaChart>
-    </ChartContainer>
+    <div className="flex items-baseline gap-2 py-1.5">
+      <span className="size-1.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+      <span className="text-[13px] text-foreground">{label}</span>
+      {hint ? <span className="text-[12px] text-muted-foreground">{hint}</span> : null}
+      <span className="ml-auto text-[13px] font-medium tabular-nums text-foreground">{value}</span>
+      {share === undefined ? null : (
+        <span className="w-9 text-right text-[12px] tabular-nums text-muted-foreground">{share}%</span>
+      )}
+    </div>
   );
 }
 
@@ -565,11 +242,27 @@ export function VelocityPrototypePage() {
           <section className={cardClassName}>
             <h2 className={cardTitleClassName}>Task time</h2>
             <p className={cardSubtitleClassName}>Median time for Factory tasks that closed in this period.</p>
-            <div className="mt-5 grid grid-cols-3 gap-5">
+
+            <div className="mt-5">
               <Metric label="Cycle time" value={formatHours(current.cycleHours)} />
-              <Metric label="Running" value={formatHours(current.runningHours)} />
-              <Metric label="Waiting" value={formatHours(current.waitingHours)} />
             </div>
+
+            <div className="mt-4 border-t border-border pt-2">
+              <SplitRow
+                color={TIME_SERIES_COLORS.running}
+                label="Time running"
+                value={formatHours(current.runningHours)}
+              />
+              <SplitRow
+                color={TIME_SERIES_COLORS.waiting}
+                label="Time waiting"
+                value={formatHours(current.waitingHours)}
+              />
+              <p className="mt-1.5 text-[12px] text-muted-foreground">
+                Waiting is review and queue time, not time the agent runs.
+              </p>
+            </div>
+
             <div className="mt-5 border-t border-border pt-4">
               <FlowChart points={points} />
             </div>
@@ -577,21 +270,33 @@ export function VelocityPrototypePage() {
 
           <section className={cardClassName}>
             <h2 className={cardTitleClassName}>Tracked Factory cost</h2>
-            <p className={cardSubtitleClassName}>Model tokens and execution compute. Third-party charges are excluded.</p>
-            <div className="mt-5 grid grid-cols-2 gap-5">
+            <p className={cardSubtitleClassName}>
+              Model tokens and execution compute. Third-party charges are excluded.
+            </p>
+
+            <div className="mt-5">
               <Metric label="Total cost" value={formatUsd(current.cost)} />
-              <Metric
-                label="Spend on waste"
-                value={formatUsd(current.wasteCost)}
-                hint="Factory work that closed without a merge"
-              />
-              <Metric
-                label="Model tokens"
-                value={formatUsd(current.tokenCost)}
-                hint={`${formatCompactTokenValue(current.tokens)} tokens`}
-              />
-              <Metric label="Execution compute" value={formatUsd(current.computeCost)} />
             </div>
+
+            <div className="mt-4 border-t border-border pt-2">
+              <SplitRow
+                color={COST_SERIES_COLORS.tokens}
+                label="Model tokens"
+                hint={formatCompactTokenValue(current.tokens)}
+                value={formatUsd(current.tokenCost)}
+                share={costShare(current.tokenCost, current.cost)}
+              />
+              <SplitRow
+                color={COST_SERIES_COLORS.compute}
+                label="Execution compute"
+                value={formatUsd(current.computeCost)}
+                share={costShare(current.computeCost, current.cost)}
+              />
+              <p className="mt-1.5 text-[12px] text-muted-foreground">
+                {formatUsd(current.wasteCost)} of this went to Factory work that closed without a merge.
+              </p>
+            </div>
+
             <div className="mt-5 border-t border-border pt-4">
               <CostChart points={points} />
             </div>

--- a/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
@@ -1,123 +1,426 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { formatCompactTokenValue } from "@/lib/formatTokenCount";
 import { cn } from "@/lib/utils";
 import { SegmentedNav } from "@/ui/SegmentedNav";
 
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
-import { VELOCITY_PERIOD_OPTIONS } from "../lib/factoryVelocityFlow";
-import { FACTORY_VELOCITY_FLOW_BY_PERIOD } from "./factoryVelocityFlowMockData";
-import {
-  FACTORY_VELOCITY_BY_PERIOD,
-  FACTORY_VELOCITY_YESTERDAY,
-  type FactoryVelocityDay,
-  type FactoryVelocityPeriodDays,
-} from "./factoryVelocityMockData";
 import { factoryCenteredSectionBodyClassName, factoryCenteredSectionHeaderClassName } from "./factoryPageLayoutStyles";
-import {
-  VelocityLoadedView,
-  type VelocityCostConfig,
-  type VelocityData,
-  type VelocitySourceSplitConfig,
-  type VelocityWorkOrderFlowConfig,
-} from "./VelocityLoadedView";
+import { VelocityPeopleTable, type VelocityPerson } from "./VelocityPeopleTable";
 
-function pointsFromMock(points: FactoryVelocityDay[]) {
-  return points.map((point) => ({
-    day: point.day,
-    merged: point.merged,
-    waste: point.waste,
-    peopleMerged: point.peopleMerged,
-    superplaneMerged: point.superplaneMerged,
+type PeriodDays = 14 | 30;
+type Breakdown = "origin" | "outcome";
+
+/** Workspace setup pins one app repository, so Velocity reports on that repository. */
+const WORKSPACE_REPOSITORY = "acme/refunds";
+
+interface VelocityPoint {
+  day: string;
+  people: number;
+  superplane: number;
+  merged: number;
+  waste: number;
+  runningHours: number;
+  waitingHours: number;
+  costUsd: number;
+  tokens: number;
+}
+
+interface BreakdownSeries {
+  key: keyof VelocityPoint;
+  label: string;
+  color: string;
+}
+
+const PERIOD_OPTIONS = [
+  { value: "14", label: "14d" },
+  { value: "30", label: "30d" },
+];
+
+const BREAKDOWN_OPTIONS = [
+  { value: "origin", label: "Origin" },
+  { value: "outcome", label: "Outcome" },
+];
+
+const BREAKDOWN_SERIES: Record<Breakdown, BreakdownSeries[]> = {
+  origin: [
+    { key: "people", label: "People", color: "#64748b" },
+    { key: "superplane", label: "SuperPlane", color: "#10b981" },
+  ],
+  outcome: [
+    { key: "merged", label: "Merged", color: "#10b981" },
+    { key: "waste", label: "Closed without merge", color: "#ef4444" },
+  ],
+};
+
+const BREAKDOWN_COPY: Record<Breakdown, { title: string; description: string }> = {
+  origin: {
+    title: "Merged pull requests by origin",
+    description: "Team output split between people and SuperPlane.",
+  },
+  outcome: {
+    title: "Pull requests by outcome",
+    description: "Merged pull requests and Factory pull requests closed without merge.",
+  },
+};
+
+function githubAvatar(accountId: number): string {
+  return `https://avatars.githubusercontent.com/u/${accountId}?v=4&s=64`;
+}
+
+/**
+ * Per-member share of the period. Avatars use the GitHub account id, which is
+ * how the connected provider serves them in production.
+ */
+const PEOPLE_SHARE: Array<
+  Omit<VelocityPerson, "id" | "authoredMerged" | "factoryMerged" | "factoryWaste" | "costUsd"> & {
+    id: string;
+    authoredShare: number;
+    factoryShare: number;
+    wasteShare: number;
+  }
+> = [
+  { id: "darkofabijan", name: "Darko Fabijan", email: "darko@superplane.com", avatarUrl: githubAvatar(20469), authoredShare: 0.24, factoryShare: 0.32, wasteShare: 0.18, medianCycleHours: 16 },
+  { id: "AleksandarCole", name: "Aleksandar Mitrovic", email: "alex@superplane.com", avatarUrl: githubAvatar(61409859), authoredShare: 0.2, factoryShare: 0.2, wasteShare: 0.14, medianCycleHours: 21 },
+  { id: "shiroyasha", name: "Igor Šarčević", email: "igor@superplane.com", avatarUrl: githubAvatar(1779493), authoredShare: 0.16, factoryShare: 0.16, wasteShare: 0.15, medianCycleHours: 19 },
+  { id: "andrecalil", name: "André Calil", email: "andre@superplane.com", avatarUrl: githubAvatar(1105923), authoredShare: 0.14, factoryShare: 0.13, wasteShare: 0.2, medianCycleHours: 28 },
+  { id: "forestileao", name: "Pedro Leão", email: "pedro@superplane.com", avatarUrl: githubAvatar(60622592), authoredShare: 0.12, factoryShare: 0.1, wasteShare: 0.18, medianCycleHours: 24 },
+  { id: "markoa", name: "Marko Anastasov", email: "marko@superplane.com", avatarUrl: githubAvatar(8651), authoredShare: 0.08, factoryShare: 0.06, wasteShare: 0.1, medianCycleHours: 31 },
+  { id: "lucaspin", name: "Lucas Pinheiro", email: "lucas@superplane.com", avatarUrl: githubAvatar(12387728), authoredShare: 0.06, factoryShare: 0.03, wasteShare: 0.05, medianCycleHours: 12 },
+];
+
+const flowChartConfig = {
+  runningHours: { label: "Time running", color: "#60a5fa" },
+  waitingHours: { label: "Time waiting", color: "#f59e0b" },
+} satisfies ChartConfig;
+
+const costChartConfig = {
+  costUsd: { label: "Tracked cost", color: "#64748b" },
+} satisfies ChartConfig;
+
+const cardClassName = "rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5";
+const cardTitleClassName = "text-[14px] font-medium tracking-[-0.01em] text-foreground";
+const cardSubtitleClassName = "mt-0.5 text-[12px] text-muted-foreground";
+
+function buildVelocityPoints(periodDays: PeriodDays): VelocityPoint[] {
+  return Array.from({ length: periodDays }, (_, index) => {
+    const people = Math.max(1, Math.round(8 + 2.6 * Math.sin(index * 0.8)));
+    const superplane = Math.max(1, Math.round(4 + 1.8 * Math.sin(index * 0.55 + 1)));
+    const merged = people + superplane;
+    const waste = index % 6 === 2 ? Math.max(1, Math.round(superplane * 0.35)) : index % 4 === 0 ? 1 : 0;
+    const runningHours = 8 + 3 * Math.sin(index * 0.48 + 0.5);
+    const waitingHours = 13 + 5 * Math.sin(index * 0.35 + 1.8);
+    const costUsd = superplane * 2.14 + waste * 0.72;
+
+    return {
+      day: periodDays === 14 ? `${index + 1}` : index % 5 === 0 || index === periodDays - 1 ? `${index + 1}` : "",
+      people,
+      superplane,
+      merged,
+      waste,
+      runningHours: Math.max(2, Math.round(runningHours * 10) / 10),
+      waitingHours: Math.max(3, Math.round(waitingHours * 10) / 10),
+      costUsd: Math.round(costUsd * 100) / 100,
+      tokens: superplane * 18_500,
+    };
+  });
+}
+
+/**
+ * Splits a period total across members with the largest-remainder method, so
+ * the People table always adds up to the totals shown above it.
+ */
+function distribute(total: number, shares: number[]): number[] {
+  const exact = shares.map((share) => total * share);
+  const floors = exact.map((value) => Math.floor(value));
+  let remainder = total - floors.reduce((sum, value) => sum + value, 0);
+
+  const order = exact
+    .map((value, index) => ({ index, fraction: value - Math.floor(value) }))
+    .sort((a, b) => b.fraction - a.fraction);
+
+  const result = [...floors];
+  for (const { index } of order) {
+    if (remainder <= 0) break;
+    result[index] = (result[index] ?? 0) + 1;
+    remainder -= 1;
+  }
+  return result;
+}
+
+function buildPeople(totals: {
+  peopleMerged: number;
+  superplaneMerged: number;
+  waste: number;
+  costUsd: number;
+}): VelocityPerson[] {
+  const authored = distribute(
+    totals.peopleMerged,
+    PEOPLE_SHARE.map((person) => person.authoredShare),
+  );
+  const factoryMerged = distribute(
+    totals.superplaneMerged,
+    PEOPLE_SHARE.map((person) => person.factoryShare),
+  );
+  const factoryWaste = distribute(
+    totals.waste,
+    PEOPLE_SHARE.map((person) => person.wasteShare),
+  );
+
+  return PEOPLE_SHARE.map((person, index) => ({
+    id: person.id,
+    name: person.name,
+    email: person.email,
+    avatarUrl: person.avatarUrl,
+    authoredMerged: authored[index] ?? 0,
+    factoryMerged: factoryMerged[index] ?? 0,
+    factoryWaste: factoryWaste[index] ?? 0,
+    medianCycleHours: person.medianCycleHours,
+    costUsd: totals.costUsd * person.factoryShare,
   }));
 }
 
-function toVelocityDataFromMock(periodDays: FactoryVelocityPeriodDays): VelocityData {
-  const period = FACTORY_VELOCITY_BY_PERIOD[periodDays];
-  return {
-    yesterday: {
-      dateLabel: FACTORY_VELOCITY_YESTERDAY.dateLabel,
-      merged: FACTORY_VELOCITY_YESTERDAY.merged,
-      waste: FACTORY_VELOCITY_YESTERDAY.waste,
-      wastePct: FACTORY_VELOCITY_YESTERDAY.wastePct,
-    },
-    totals: {
-      merged: period.totals.merged,
-      waste: period.totals.waste,
-      wastePct: period.totals.wastePct,
-      superplaneMerged: period.totals.superplaneMerged,
-      peopleMerged: period.totals.peopleMerged,
-      superplaneSharePct: period.totals.superplaneSharePct,
-    },
-    points: pointsFromMock(period.points),
-  };
+function sum(points: VelocityPoint[], field: keyof VelocityPoint): number {
+  return points.reduce((total, point) => {
+    const value = point[field];
+    return total + (typeof value === "number" ? value : 0);
+  }, 0);
 }
 
-function toCostConfigFromMock(periodDays: FactoryVelocityPeriodDays): VelocityCostConfig {
-  const period = FACTORY_VELOCITY_BY_PERIOD[periodDays];
-  return {
-    yesterdayCostUsd: FACTORY_VELOCITY_YESTERDAY.costUsd,
-    yesterdayTokens: FACTORY_VELOCITY_YESTERDAY.tokens,
-    yesterdayCostPerMerged: FACTORY_VELOCITY_YESTERDAY.costPerMergedPr,
-    totalCostUsd: period.totals.costUsd,
-    seriesUsd: period.points.map((point) => point.costUsd),
-  };
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+  return sorted[middle] ?? 0;
 }
 
-function toWorkOrderFlowFromMock(periodDays: FactoryVelocityPeriodDays): VelocityWorkOrderFlowConfig {
-  const mock = FACTORY_VELOCITY_FLOW_BY_PERIOD[periodDays];
-  return {
-    flow: {
-      days: periodDays,
-      label: mock.label,
-      sampleSize: 42,
-      medianCycleHours: mock.medianCycleHours,
-      medianRunningHours: mock.medianRunningHours,
-      medianWaitingHours: mock.medianWaitingHours,
-      runningShareOfCyclePct: mock.runningShareOfCyclePct,
-      waitingShareOfCyclePct: mock.waitingShareOfCyclePct,
-      timeTrend: mock.timeTrend,
-    },
-  };
+function formatHours(value: number) {
+  return `${Math.round(value)}h`;
+}
+
+function formatUsd(value: number) {
+  return `$${value.toFixed(2)}`;
+}
+
+function Metric({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-[12px] text-muted-foreground">{label}</p>
+      <p className="mt-2 text-[30px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+        {value}
+      </p>
+      {hint ? <p className="mt-2 text-[12px] text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+function DeliveryChart({ points, breakdown }: { points: VelocityPoint[]; breakdown: Breakdown }) {
+  const series = BREAKDOWN_SERIES[breakdown];
+  const config = Object.fromEntries(
+    series.map((item) => [item.key, { label: item.label, color: item.color }]),
+  ) satisfies ChartConfig;
+
+  return (
+    <ChartContainer
+      config={config}
+      className="aspect-auto h-[260px] w-full"
+      initialDimension={{ width: 760, height: 260 }}
+    >
+      <BarChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis allowDecimals={false} tickLine={false} axisLine={false} width={28} className="text-[11px]" />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" />
+        {series.map((item, index) => (
+          <Bar
+            key={item.key}
+            dataKey={item.key}
+            name={item.label}
+            stackId="day"
+            fill={item.color}
+            radius={index === series.length - 1 ? [3, 3, 0, 0] : undefined}
+            maxBarSize={24}
+          />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+function FlowChart({ points }: { points: VelocityPoint[] }) {
+  return (
+    <ChartContainer
+      config={flowChartConfig}
+      className="aspect-auto h-[180px] w-full"
+      initialDimension={{ width: 500, height: 180 }}
+    >
+      <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={36}
+          className="text-[11px]"
+          tickFormatter={(value: number) => `${value}h`}
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <Area
+          type="monotone"
+          dataKey="runningHours"
+          stackId="time"
+          stroke="#60a5fa"
+          fill="#60a5fa"
+          fillOpacity={0.3}
+        />
+        <Area
+          type="monotone"
+          dataKey="waitingHours"
+          stackId="time"
+          stroke="#f59e0b"
+          fill="#f59e0b"
+          fillOpacity={0.3}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+function CostChart({ points }: { points: VelocityPoint[] }) {
+  return (
+    <ChartContainer
+      config={costChartConfig}
+      className="aspect-auto h-[180px] w-full"
+      initialDimension={{ width: 500, height: 180 }}
+    >
+      <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} interval={0} className="text-[11px]" />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={34}
+          className="text-[11px]"
+          tickFormatter={(value: number) => `$${value}`}
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <Area type="monotone" dataKey="costUsd" stroke="#64748b" fill="#64748b" fillOpacity={0.12} strokeWidth={1.5} />
+      </AreaChart>
+    </ChartContainer>
+  );
 }
 
 export function VelocityPrototypePage() {
-  const [periodDays, setPeriodDays] = useState<FactoryVelocityPeriodDays>(7);
-  const period = FACTORY_VELOCITY_BY_PERIOD[periodDays];
+  const [periodDays, setPeriodDays] = useState<PeriodDays>(14);
+  const [breakdown, setBreakdown] = useState<Breakdown>("origin");
+  const points = useMemo(() => buildVelocityPoints(periodDays), [periodDays]);
 
-  const sourceSplit: VelocitySourceSplitConfig = {
-    hasPeopleCohort: true,
-    repositoryLabel: "acme/refunds",
-  };
+  const merged = sum(points, "merged");
+  const peopleMerged = sum(points, "people");
+  const superplaneMerged = sum(points, "superplane");
+  const waste = sum(points, "waste");
+  const cost = sum(points, "costUsd");
+  const tokens = sum(points, "tokens");
+  const cycleHours = median(points.map((point) => point.runningHours + point.waitingHours));
+  const runningHours = median(points.map((point) => point.runningHours));
+  const waitingHours = median(points.map((point) => point.waitingHours));
+  const wasteRate = superplaneMerged + waste > 0 ? Math.round((waste / (superplaneMerged + waste)) * 100) : 0;
+  const periodLabel = `Last ${periodDays} days`;
+  const breakdownCopy = BREAKDOWN_COPY[breakdown];
+  const people = useMemo(
+    () => buildPeople({ peopleMerged, superplaneMerged, waste, costUsd: cost }),
+    [peopleMerged, superplaneMerged, waste, cost],
+  );
 
   return (
     <>
       <WorkspacePageHeader
         className={factoryCenteredSectionHeaderClassName}
         title="Velocity"
-        subtitle="Merged pull requests, waste, cost, and task time."
+        subtitle={`What ${WORKSPACE_REPOSITORY} ships, how long the work takes, and what it costs.`}
         actions={
           <SegmentedNav
-            ariaLabel="Velocity period in days"
+            ariaLabel="Velocity period"
             size="xs"
             value={String(periodDays)}
-            onValueChange={(value) => {
-              const next = Number(value);
-              if (next === 7 || next === 30) setPeriodDays(next);
-            }}
-            options={VELOCITY_PERIOD_OPTIONS}
+            onValueChange={(value) => setPeriodDays(value === "30" ? 30 : 14)}
+            options={PERIOD_OPTIONS}
           />
         }
       />
 
-      <div className={cn(factoryCenteredSectionBodyClassName, "space-y-6")} data-testid="factory-velocity-page">
-        <VelocityLoadedView
-          periodLabel={period.label}
-          periodDays={periodDays}
-          data={toVelocityDataFromMock(periodDays)}
-          sourceSplit={sourceSplit}
-          workOrderFlow={toWorkOrderFlowFromMock(periodDays)}
-          cost={toCostConfigFromMock(periodDays)}
-        />
+      <div className={cn(factoryCenteredSectionBodyClassName, "space-y-5")} data-testid="factory-velocity-page">
+        <section className={cardClassName}>
+          <p className="text-[12px] text-muted-foreground">{periodLabel}</p>
+          <div className="mt-4 grid grid-cols-2 gap-x-8 gap-y-6 lg:grid-cols-4">
+            <Metric label="Merged PRs" value={String(merged)} hint="People and SuperPlane" />
+            <Metric label="Factory waste" value={`${wasteRate}%`} hint={`${waste} PRs closed without merge`} />
+            <Metric label="Median cycle time" value={formatHours(cycleHours)} hint="From start to close" />
+            <Metric
+              label="Cost per Factory merge"
+              value={formatUsd(superplaneMerged > 0 ? cost / superplaneMerged : 0)}
+              hint="Tokens and execution compute"
+            />
+          </div>
+        </section>
+
+        <section className={cardClassName}>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className={cardTitleClassName}>{breakdownCopy.title}</h2>
+              <p className={cardSubtitleClassName}>{breakdownCopy.description}</p>
+            </div>
+            <SegmentedNav
+              ariaLabel="Group merged pull requests by"
+              size="xs"
+              value={breakdown}
+              onValueChange={(value) => setBreakdown(value as Breakdown)}
+              options={BREAKDOWN_OPTIONS}
+            />
+          </div>
+          <div className="mt-5">
+            <DeliveryChart points={points} breakdown={breakdown} />
+          </div>
+        </section>
+
+        <VelocityPeopleTable people={people} periodLabel={periodLabel} />
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          <section className={cardClassName}>
+            <h2 className={cardTitleClassName}>Task time</h2>
+            <p className={cardSubtitleClassName}>Median time for Factory tasks that closed in this period.</p>
+            <div className="mt-5 grid grid-cols-3 gap-5">
+              <Metric label="Cycle time" value={formatHours(cycleHours)} />
+              <Metric label="Running" value={formatHours(runningHours)} />
+              <Metric label="Waiting" value={formatHours(waitingHours)} />
+            </div>
+            <div className="mt-5 border-t border-border pt-4">
+              <FlowChart points={points} />
+            </div>
+          </section>
+
+          <section className={cardClassName}>
+            <h2 className={cardTitleClassName}>Tracked Factory cost</h2>
+            <p className={cardSubtitleClassName}>Model tokens and execution compute. Third-party charges are excluded.</p>
+            <div className="mt-5 grid grid-cols-2 gap-5">
+              <Metric label="Total cost" value={formatUsd(cost)} />
+              <Metric label="Model tokens" value={formatCompactTokenValue(tokens)} />
+            </div>
+            <div className="mt-5 border-t border-border pt-4">
+              <CostChart points={points} />
+            </div>
+          </section>
+        </div>
       </div>
     </>
   );

--- a/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import {
@@ -18,7 +19,7 @@ import { factoryCenteredSectionBodyClassName, factoryCenteredSectionHeaderClassN
 import { VelocityPeopleTable, type VelocityPerson } from "./VelocityPeopleTable";
 
 type PeriodDays = 14 | 30;
-type Breakdown = "origin" | "outcome";
+type Breakdown = "origin" | "outcome" | "intake";
 
 /** Workspace setup pins one app repository, so Velocity reports on that repository. */
 const WORKSPACE_REPOSITORY = "acme/refunds";
@@ -29,6 +30,10 @@ interface VelocityPoint {
   superplane: number;
   merged: number;
   waste: number;
+  githubIssues: number;
+  sentryExceptions: number;
+  manual: number;
+  api: number;
   runningHours: number;
   waitingHours: number;
   costUsd: number;
@@ -49,6 +54,7 @@ const PERIOD_OPTIONS = [
 const BREAKDOWN_OPTIONS = [
   { value: "origin", label: "Origin" },
   { value: "outcome", label: "Outcome" },
+  { value: "intake", label: "Intake source" },
 ];
 
 const BREAKDOWN_SERIES: Record<Breakdown, BreakdownSeries[]> = {
@@ -60,6 +66,12 @@ const BREAKDOWN_SERIES: Record<Breakdown, BreakdownSeries[]> = {
     { key: "merged", label: "Merged", color: "#10b981" },
     { key: "waste", label: "Closed without merge", color: "#ef4444" },
   ],
+  intake: [
+    { key: "githubIssues", label: "GitHub issue", color: "#3b82f6" },
+    { key: "sentryExceptions", label: "Sentry exception", color: "#8b5cf6" },
+    { key: "manual", label: "Manually created", color: "#f59e0b" },
+    { key: "api", label: "API", color: "#06b6d4" },
+  ],
 };
 
 const BREAKDOWN_COPY: Record<Breakdown, { title: string; description: string }> = {
@@ -70,6 +82,10 @@ const BREAKDOWN_COPY: Record<Breakdown, { title: string; description: string }> 
   outcome: {
     title: "Pull requests by outcome",
     description: "Merged pull requests and Factory pull requests closed without merge.",
+  },
+  intake: {
+    title: "Factory merges by intake source",
+    description: "Merged pull requests grouped by how their tasks entered the Factory.",
   },
 };
 
@@ -111,14 +127,26 @@ const cardClassName = "rounded-xl border border-border bg-card px-4 py-4 sm:px-5
 const cardTitleClassName = "text-[14px] font-medium tracking-[-0.01em] text-foreground";
 const cardSubtitleClassName = "mt-0.5 text-[12px] text-muted-foreground";
 
-function buildVelocityPoints(periodDays: PeriodDays): VelocityPoint[] {
+/**
+ * `windowOffset` shifts the mock series along the timeline, so the current and
+ * previous windows are different slices. Higher offset is more recent.
+ *
+ * The series drifts on purpose: Factory output ramps up while review time grows.
+ * That gives the prototype a mixed result instead of every metric improving.
+ */
+function buildVelocityPoints(periodDays: PeriodDays, windowOffset = 0): VelocityPoint[] {
   return Array.from({ length: periodDays }, (_, index) => {
-    const people = Math.max(1, Math.round(8 + 2.6 * Math.sin(index * 0.8)));
-    const superplane = Math.max(1, Math.round(4 + 1.8 * Math.sin(index * 0.55 + 1)));
+    const day = index + windowOffset;
+    const people = Math.max(1, Math.round(8 + 2.6 * Math.sin(day * 0.8)));
+    const superplane = Math.max(1, Math.round(4 + 1.8 * Math.sin(day * 0.55 + 1) + day * 0.09));
     const merged = people + superplane;
-    const waste = index % 6 === 2 ? Math.max(1, Math.round(superplane * 0.35)) : index % 4 === 0 ? 1 : 0;
-    const runningHours = 8 + 3 * Math.sin(index * 0.48 + 0.5);
-    const waitingHours = 13 + 5 * Math.sin(index * 0.35 + 1.8);
+    const waste = day % 6 === 2 ? Math.max(1, Math.round(superplane * 0.35)) : day % 4 === 0 ? 1 : 0;
+    const githubIssues = Math.round(superplane * 0.43);
+    const sentryExceptions = Math.round(superplane * 0.27);
+    const manual = Math.round(superplane * 0.18);
+    const api = Math.max(0, superplane - githubIssues - sentryExceptions - manual);
+    const runningHours = 8 + 3 * Math.sin(day * 0.48 + 0.5);
+    const waitingHours = 13 + 5 * Math.sin(day * 0.35 + 1.8) + day * 0.18;
     const costUsd = superplane * 2.14 + waste * 0.72;
 
     return {
@@ -127,6 +155,10 @@ function buildVelocityPoints(periodDays: PeriodDays): VelocityPoint[] {
       superplane,
       merged,
       waste,
+      githubIssues,
+      sentryExceptions,
+      manual,
+      api,
       runningHours: Math.max(2, Math.round(runningHours * 10) / 10),
       waitingHours: Math.max(3, Math.round(waitingHours * 10) / 10),
       costUsd: Math.round(costUsd * 100) / 100,
@@ -211,13 +243,92 @@ function formatUsd(value: number) {
   return `$${value.toFixed(2)}`;
 }
 
-function Metric({ label, value, hint }: { label: string; value: string; hint?: string }) {
+type ChangeBetter = "up" | "down";
+
+function summarizePoints(points: VelocityPoint[]) {
+  const merged = sum(points, "merged");
+  const superplaneMerged = sum(points, "superplane");
+  const waste = sum(points, "waste");
+  const cost = sum(points, "costUsd");
+  const cycleHours = median(points.map((point) => point.runningHours + point.waitingHours));
+  const wasteRate = superplaneMerged + waste > 0 ? Math.round((waste / (superplaneMerged + waste)) * 100) : 0;
+  const costPerMerge = superplaneMerged > 0 ? cost / superplaneMerged : 0;
+
+  return {
+    merged,
+    peopleMerged: sum(points, "people"),
+    superplaneMerged,
+    waste,
+    wasteRate,
+    cycleHours,
+    runningHours: median(points.map((point) => point.runningHours)),
+    waitingHours: median(points.map((point) => point.waitingHours)),
+    cost,
+    tokens: sum(points, "tokens"),
+    costPerMerge,
+  };
+}
+
+/** The arrow shows which way the number moved. The color shows whether that is good. */
+interface MetricChange {
+  text: string;
+  tone: "better" | "worse" | "same";
+  direction: "up" | "down" | "flat";
+}
+
+const CHANGE_TONE_CLASS: Record<MetricChange["tone"], string> = {
+  better: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-400",
+  worse: "bg-rose-50 text-rose-700 dark:bg-rose-950/60 dark:text-rose-400",
+  same: "bg-muted text-muted-foreground",
+};
+
+function buildChange(delta: number, better: ChangeBetter, format: (magnitude: number) => string): MetricChange {
+  if (delta === 0) return { text: "No change", tone: "same", direction: "flat" };
+
+  const improved = better === "up" ? delta > 0 : delta < 0;
+  return {
+    text: format(Math.abs(delta)),
+    tone: improved ? "better" : "worse",
+    direction: delta > 0 ? "up" : "down",
+  };
+}
+
+function ChangeChip({ change }: { change: MetricChange }) {
+  const Icon = change.direction === "up" ? ArrowUpRight : ArrowDownRight;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[11px] font-medium tabular-nums",
+        CHANGE_TONE_CLASS[change.tone],
+      )}
+    >
+      {change.direction === "flat" ? null : <Icon className="size-3" aria-hidden />}
+      {change.text}
+    </span>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  hint,
+  change,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  change?: MetricChange;
+}) {
   return (
     <div className="min-w-0">
       <p className="text-[12px] text-muted-foreground">{label}</p>
-      <p className="mt-2 text-[30px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
-        {value}
-      </p>
+      <div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <p className="text-[30px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+          {value}
+        </p>
+        {change ? <ChangeChip change={change} /> : null}
+      </div>
       {hint ? <p className="mt-2 text-[12px] text-muted-foreground">{hint}</p> : null}
     </div>
   );
@@ -323,29 +434,34 @@ function CostChart({ points }: { points: VelocityPoint[] }) {
 export function VelocityPrototypePage() {
   const [periodDays, setPeriodDays] = useState<PeriodDays>(14);
   const [breakdown, setBreakdown] = useState<Breakdown>("origin");
-  const points = useMemo(() => buildVelocityPoints(periodDays), [periodDays]);
+  const points = useMemo(() => buildVelocityPoints(periodDays, periodDays), [periodDays]);
+  const previousPoints = useMemo(() => buildVelocityPoints(periodDays, 0), [periodDays]);
 
-  const merged = sum(points, "merged");
-  const peopleMerged = sum(points, "people");
-  const superplaneMerged = sum(points, "superplane");
-  const waste = sum(points, "waste");
-  const cost = sum(points, "costUsd");
-  const tokens = sum(points, "tokens");
-  const cycleHours = median(points.map((point) => point.runningHours + point.waitingHours));
-  const runningHours = median(points.map((point) => point.runningHours));
-  const waitingHours = median(points.map((point) => point.waitingHours));
-  const wasteRate = superplaneMerged + waste > 0 ? Math.round((waste / (superplaneMerged + waste)) * 100) : 0;
+  const current = summarizePoints(points);
+  const previous = summarizePoints(previousPoints);
+  const mergedDelta = current.merged - previous.merged;
+  const wasteDelta = current.wasteRate - previous.wasteRate;
+  const cycleDelta = Math.round(current.cycleHours - previous.cycleHours);
+  const costDelta = Math.round((current.costPerMerge - previous.costPerMerge) * 100) / 100;
   const periodLabel = `Last ${periodDays} days`;
   const breakdownCopy = BREAKDOWN_COPY[breakdown];
   const people = useMemo(
-    () => buildPeople({ peopleMerged, superplaneMerged, waste, costUsd: cost }),
-    [peopleMerged, superplaneMerged, waste, cost],
+    () =>
+      buildPeople({
+        peopleMerged: current.peopleMerged,
+        superplaneMerged: current.superplaneMerged,
+        waste: current.waste,
+        costUsd: current.cost,
+      }),
+    [current.peopleMerged, current.superplaneMerged, current.waste, current.cost],
   );
 
   return (
-    <>
+    /* Gray page, white cards. Dark mode keeps its darker page, because the
+       factories theme paints the sidebar and cards the same color. */
+    <div className="min-h-full bg-sidebar dark:bg-background">
       <WorkspacePageHeader
-        className={factoryCenteredSectionHeaderClassName}
+        className={cn(factoryCenteredSectionHeaderClassName, "bg-transparent")}
         title="Velocity"
         subtitle={`What ${WORKSPACE_REPOSITORY} ships, how long the work takes, and what it costs.`}
         actions={
@@ -359,17 +475,35 @@ export function VelocityPrototypePage() {
         }
       />
 
-      <div className={cn(factoryCenteredSectionBodyClassName, "space-y-5")} data-testid="factory-velocity-page">
+      <div className={cn(factoryCenteredSectionBodyClassName, "space-y-5 pb-10")} data-testid="factory-velocity-page">
         <section className={cardClassName}>
-          <p className="text-[12px] text-muted-foreground">{periodLabel}</p>
+          <p className="text-[12px] text-muted-foreground">
+            {periodLabel}. Compared with the previous {periodDays} days.
+          </p>
           <div className="mt-4 grid grid-cols-2 gap-x-8 gap-y-6 lg:grid-cols-4">
-            <Metric label="Merged PRs" value={String(merged)} hint="People and SuperPlane" />
-            <Metric label="Factory waste" value={`${wasteRate}%`} hint={`${waste} PRs closed without merge`} />
-            <Metric label="Median cycle time" value={formatHours(cycleHours)} hint="From start to close" />
+            <Metric
+              label="Merged PRs"
+              value={String(current.merged)}
+              hint="People and SuperPlane"
+              change={buildChange(mergedDelta, "up", (magnitude) => String(magnitude))}
+            />
+            <Metric
+              label="Factory waste"
+              value={`${current.wasteRate}%`}
+              hint={`${current.waste} PRs closed without merge`}
+              change={buildChange(wasteDelta, "down", (magnitude) => `${magnitude} pp`)}
+            />
+            <Metric
+              label="Median cycle time"
+              value={formatHours(current.cycleHours)}
+              hint="From start to close"
+              change={buildChange(cycleDelta, "down", (magnitude) => `${magnitude}h`)}
+            />
             <Metric
               label="Cost per Factory merge"
-              value={formatUsd(superplaneMerged > 0 ? cost / superplaneMerged : 0)}
+              value={formatUsd(current.costPerMerge)}
               hint="Tokens and execution compute"
+              change={buildChange(costDelta, "down", (magnitude) => `$${magnitude.toFixed(2)}`)}
             />
           </div>
         </section>
@@ -400,9 +534,9 @@ export function VelocityPrototypePage() {
             <h2 className={cardTitleClassName}>Task time</h2>
             <p className={cardSubtitleClassName}>Median time for Factory tasks that closed in this period.</p>
             <div className="mt-5 grid grid-cols-3 gap-5">
-              <Metric label="Cycle time" value={formatHours(cycleHours)} />
-              <Metric label="Running" value={formatHours(runningHours)} />
-              <Metric label="Waiting" value={formatHours(waitingHours)} />
+              <Metric label="Cycle time" value={formatHours(current.cycleHours)} />
+              <Metric label="Running" value={formatHours(current.runningHours)} />
+              <Metric label="Waiting" value={formatHours(current.waitingHours)} />
             </div>
             <div className="mt-5 border-t border-border pt-4">
               <FlowChart points={points} />
@@ -413,8 +547,8 @@ export function VelocityPrototypePage() {
             <h2 className={cardTitleClassName}>Tracked Factory cost</h2>
             <p className={cardSubtitleClassName}>Model tokens and execution compute. Third-party charges are excluded.</p>
             <div className="mt-5 grid grid-cols-2 gap-5">
-              <Metric label="Total cost" value={formatUsd(cost)} />
-              <Metric label="Model tokens" value={formatCompactTokenValue(tokens)} />
+              <Metric label="Total cost" value={formatUsd(current.cost)} />
+              <Metric label="Model tokens" value={formatCompactTokenValue(current.tokens)} />
             </div>
             <div className="mt-5 border-t border-border pt-4">
               <CostChart points={points} />
@@ -422,6 +556,6 @@ export function VelocityPrototypePage() {
           </section>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/web_src/src/pages/factories/pages/velocityPrototypeData.ts
+++ b/web_src/src/pages/factories/pages/velocityPrototypeData.ts
@@ -1,0 +1,315 @@
+import type { VelocityPerson } from "./VelocityPeopleTable";
+
+export type PeriodDays = 14 | 30;
+export type Breakdown = "origin" | "outcome" | "intake";
+
+/** Workspace setup pins one app repository, so Velocity reports on that repository. */
+export const WORKSPACE_REPOSITORY = "acme/refunds";
+
+export interface VelocityPoint {
+  day: string;
+  people: number;
+  superplane: number;
+  merged: number;
+  waste: number;
+  githubIssues: number;
+  sentryExceptions: number;
+  manual: number;
+  api: number;
+  runningHours: number;
+  waitingHours: number;
+  costUsd: number;
+  tokenCostUsd: number;
+  computeCostUsd: number;
+  wasteCostUsd: number;
+  tokens: number;
+}
+
+export interface BreakdownSeries {
+  key: keyof VelocityPoint;
+  label: string;
+  color: string;
+}
+
+export const PERIOD_OPTIONS = [
+  { value: "14", label: "14d" },
+  { value: "30", label: "30d" },
+];
+
+export const BREAKDOWN_OPTIONS = [
+  { value: "origin", label: "Origin" },
+  { value: "outcome", label: "Outcome" },
+  { value: "intake", label: "Intake source" },
+];
+
+export const BREAKDOWN_SERIES: Record<Breakdown, BreakdownSeries[]> = {
+  origin: [
+    { key: "people", label: "People", color: "#64748b" },
+    { key: "superplane", label: "SuperPlane", color: "#10b981" },
+  ],
+  outcome: [
+    { key: "merged", label: "Merged", color: "#10b981" },
+    { key: "waste", label: "Closed without merge", color: "#ef4444" },
+  ],
+  intake: [
+    { key: "githubIssues", label: "GitHub issue", color: "#3b82f6" },
+    { key: "sentryExceptions", label: "Sentry exception", color: "#8b5cf6" },
+    { key: "manual", label: "Manually created", color: "#f59e0b" },
+    { key: "api", label: "API", color: "#06b6d4" },
+  ],
+};
+
+export const BREAKDOWN_COPY: Record<Breakdown, { title: string; description: string }> = {
+  origin: {
+    title: "Merged pull requests by origin",
+    description: "Team output split between people and SuperPlane.",
+  },
+  outcome: {
+    title: "Pull requests by outcome",
+    description: "Merged pull requests and Factory pull requests closed without merge.",
+  },
+  intake: {
+    title: "Factory merges by intake source",
+    description: "Merged pull requests grouped by how their tasks entered the Factory.",
+  },
+};
+
+export const COST_SERIES_COLORS = {
+  tokens: "#64748b",
+  compute: "#6366f1",
+} as const;
+
+export const TIME_SERIES_COLORS = {
+  running: "#60a5fa",
+  waiting: "#f59e0b",
+} as const;
+
+function githubAvatar(accountId: number): string {
+  return `https://avatars.githubusercontent.com/u/${accountId}?v=4&s=64`;
+}
+
+/**
+ * Per-member share of the period. Avatars use the GitHub account id, which is
+ * how the connected provider serves them in production.
+ */
+const PEOPLE_SHARE: Array<
+  Omit<VelocityPerson, "id" | "authoredMerged" | "factoryMerged" | "factoryWaste" | "costUsd"> & {
+    id: string;
+    authoredShare: number;
+    factoryShare: number;
+    wasteShare: number;
+  }
+> = [
+  {
+    id: "darkofabijan",
+    name: "Darko Fabijan",
+    email: "darko@superplane.com",
+    avatarUrl: githubAvatar(20469),
+    authoredShare: 0.24,
+    factoryShare: 0.32,
+    wasteShare: 0.18,
+    medianCycleHours: 16,
+  },
+  {
+    id: "AleksandarCole",
+    name: "Aleksandar Mitrovic",
+    email: "alex@superplane.com",
+    avatarUrl: githubAvatar(61409859),
+    authoredShare: 0.2,
+    factoryShare: 0.2,
+    wasteShare: 0.14,
+    medianCycleHours: 21,
+  },
+  {
+    id: "shiroyasha",
+    name: "Igor Šarčević",
+    email: "igor@superplane.com",
+    avatarUrl: githubAvatar(1779493),
+    authoredShare: 0.16,
+    factoryShare: 0.16,
+    wasteShare: 0.15,
+    medianCycleHours: 19,
+  },
+  {
+    id: "andrecalil",
+    name: "André Calil",
+    email: "andre@superplane.com",
+    avatarUrl: githubAvatar(1105923),
+    authoredShare: 0.14,
+    factoryShare: 0.13,
+    wasteShare: 0.2,
+    medianCycleHours: 28,
+  },
+  {
+    id: "forestileao",
+    name: "Pedro Leão",
+    email: "pedro@superplane.com",
+    avatarUrl: githubAvatar(60622592),
+    authoredShare: 0.12,
+    factoryShare: 0.1,
+    wasteShare: 0.18,
+    medianCycleHours: 24,
+  },
+  {
+    id: "markoa",
+    name: "Marko Anastasov",
+    email: "marko@superplane.com",
+    avatarUrl: githubAvatar(8651),
+    authoredShare: 0.08,
+    factoryShare: 0.06,
+    wasteShare: 0.1,
+    medianCycleHours: 31,
+  },
+  {
+    id: "lucaspin",
+    name: "Lucas Pinheiro",
+    email: "lucas@superplane.com",
+    avatarUrl: githubAvatar(12387728),
+    authoredShare: 0.06,
+    factoryShare: 0.03,
+    wasteShare: 0.05,
+    medianCycleHours: 12,
+  },
+];
+
+/**
+ * `windowOffset` shifts the mock series along the timeline, so the current and
+ * previous windows are different slices. Higher offset is more recent.
+ *
+ * The series drifts on purpose: Factory output ramps up while review time grows.
+ * That gives the prototype a mixed result instead of every metric improving.
+ */
+export function buildVelocityPoints(periodDays: PeriodDays, windowOffset = 0): VelocityPoint[] {
+  return Array.from({ length: periodDays }, (_, index) => {
+    const day = index + windowOffset;
+    const people = Math.max(1, Math.round(8 + 2.6 * Math.sin(day * 0.8)));
+    const superplane = Math.max(1, Math.round(4 + 1.8 * Math.sin(day * 0.55 + 1) + day * 0.09));
+    const merged = people + superplane;
+    const waste = day % 6 === 2 ? Math.max(1, Math.round(superplane * 0.35)) : day % 4 === 0 ? 1 : 0;
+    const githubIssues = Math.round(superplane * 0.43);
+    const sentryExceptions = Math.round(superplane * 0.27);
+    const manual = Math.round(superplane * 0.18);
+    const api = Math.max(0, superplane - githubIssues - sentryExceptions - manual);
+    const runningHours = 8 + 3 * Math.sin(day * 0.48 + 0.5);
+    const waitingHours = 13 + 5 * Math.sin(day * 0.35 + 1.8) + day * 0.18;
+    const mergedCostUsd = superplane * 2.14;
+    const wasteCostUsd = waste * 1.85;
+    const costUsd = mergedCostUsd + wasteCostUsd;
+    const tokenCostUsd = Math.round((superplane * 1.67 + waste * 1.44) * 100) / 100;
+    const computeCostUsd = Math.round((costUsd - tokenCostUsd) * 100) / 100;
+
+    return {
+      day: periodDays === 14 ? `${index + 1}` : index % 5 === 0 || index === periodDays - 1 ? `${index + 1}` : "",
+      people,
+      superplane,
+      merged,
+      waste,
+      githubIssues,
+      sentryExceptions,
+      manual,
+      api,
+      runningHours: Math.max(2, Math.round(runningHours * 10) / 10),
+      waitingHours: Math.max(3, Math.round(waitingHours * 10) / 10),
+      costUsd: Math.round(costUsd * 100) / 100,
+      tokenCostUsd,
+      computeCostUsd,
+      wasteCostUsd: Math.round(wasteCostUsd * 100) / 100,
+      tokens: superplane * 18_500 + waste * 12_400,
+    };
+  });
+}
+
+export function summarizePoints(points: VelocityPoint[]) {
+  const merged = sum(points, "merged");
+  const superplaneMerged = sum(points, "superplane");
+  const waste = sum(points, "waste");
+  const cost = sum(points, "costUsd");
+  const cycleHours = median(points.map((point) => point.runningHours + point.waitingHours));
+  const wasteRate = superplaneMerged + waste > 0 ? Math.round((waste / (superplaneMerged + waste)) * 100) : 0;
+  const costPerMerge = superplaneMerged > 0 ? cost / superplaneMerged : 0;
+
+  return {
+    merged,
+    peopleMerged: sum(points, "people"),
+    superplaneMerged,
+    waste,
+    wasteRate,
+    cycleHours,
+    runningHours: median(points.map((point) => point.runningHours)),
+    waitingHours: median(points.map((point) => point.waitingHours)),
+    cost,
+    tokenCost: sum(points, "tokenCostUsd"),
+    computeCost: sum(points, "computeCostUsd"),
+    wasteCost: sum(points, "wasteCostUsd"),
+    tokens: sum(points, "tokens"),
+    costPerMerge,
+  };
+}
+
+export function buildPeople(totals: {
+  peopleMerged: number;
+  superplaneMerged: number;
+  waste: number;
+  costUsd: number;
+}): VelocityPerson[] {
+  const authored = distribute(
+    totals.peopleMerged,
+    PEOPLE_SHARE.map((person) => person.authoredShare),
+  );
+  const factoryMerged = distribute(
+    totals.superplaneMerged,
+    PEOPLE_SHARE.map((person) => person.factoryShare),
+  );
+  const factoryWaste = distribute(
+    totals.waste,
+    PEOPLE_SHARE.map((person) => person.wasteShare),
+  );
+
+  return PEOPLE_SHARE.map((person, index) => ({
+    id: person.id,
+    name: person.name,
+    email: person.email,
+    avatarUrl: person.avatarUrl,
+    authoredMerged: authored[index] ?? 0,
+    factoryMerged: factoryMerged[index] ?? 0,
+    factoryWaste: factoryWaste[index] ?? 0,
+    medianCycleHours: person.medianCycleHours,
+    costUsd: totals.costUsd * person.factoryShare,
+  }));
+}
+
+/**
+ * Splits a period total across members with the largest-remainder method, so
+ * the People table always adds up to the totals shown above it.
+ */
+function distribute(total: number, shares: number[]): number[] {
+  const exact = shares.map((share) => total * share);
+  const floors = exact.map((value) => Math.floor(value));
+  let remainder = total - floors.reduce((sum, value) => sum + value, 0);
+
+  const order = exact
+    .map((value, index) => ({ index, fraction: value - Math.floor(value) }))
+    .sort((a, b) => b.fraction - a.fraction);
+
+  const result = [...floors];
+  for (const { index } of order) {
+    if (remainder <= 0) break;
+    result[index] = (result[index] ?? 0) + 1;
+    remainder -= 1;
+  }
+  return result;
+}
+
+function sum(points: VelocityPoint[], field: keyof VelocityPoint): number {
+  return points.reduce((total, point) => {
+    const value = point[field];
+    return total + (typeof value === "number" ? value : 0);
+  }, 0);
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+  return sorted[middle] ?? 0;
+}


### PR DESCRIPTION
## Summary

The Velocity page must answer what the Factory ships, how long the work
takes, and what it costs. We must agree on the content before we build
the page against real data. This pull request grows the Storybook
prototype into a full proposal for that content.

The prototype now shows:

- Four summary numbers with a change against the previous period of the
  same length. Builders ask if the week is better than the last week
  before they ask for more charts.
- One delivery chart with a switchable breakdown: origin, outcome, or
  intake source. Intake source shows how tasks enter the Factory.
- A per-person table. The rows always add up to the totals above them.
- A time card and a cost card that share one template. The cost card
  splits spend into model tokens and execution compute, and names the
  spend on work that did not merge.

The prototype is in Storybook only. It uses mock data and no route in
the application points to it. The repository selector is gone, because
workspace setup pins one application repository.

The page also passed the ESLint max-lines budget. The mock data and the
charts are now separate modules.

Note for review: the per-person table conflicts with the rule in
docs/prd/software-factory.md that keeps human data aggregated. Please
confirm the direction. We must update the PRD or drop the table.

## Test plan

- [ ] Open Storybook at `factories/pages/velocity`.
- [ ] Change the period between 14d and 30d. Confirm all cards update.
- [ ] Confirm the change chips show green for better and red for worse,
      and that at least one number gets worse.
- [ ] Switch the breakdown between origin, outcome, and intake source.
      Confirm the chart and the card title change.
- [ ] Confirm the people rows add up to the merged and waste totals.
- [ ] Confirm the time card and the cost card have the same height.
- [ ] Confirm the dots in each split match the bands in the chart below.
- [ ] Check light mode and dark mode.
- [ ] Run `make check.lint.ui` and `make check.build.ui`.

Made with [Cursor](https://cursor.com)