### PR TITLE
fix(cli-npm): a failed download no longer reports success or truncates the installed binary

### DIFF
--- a/release/superplane-cli-npm/bin/run.js
+++ b/release/superplane-cli-npm/bin/run.js
@@ -8,11 +8,13 @@ const bin = path.join(__dirname, "superplane");
 const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
 
 if (result.error) {
-  if (result.error.code === "ENOENT") {
+  const code = result.error.code;
+  if (code === "ENOENT" || code === "EACCES" || code === "ENOEXEC") {
     console.error(
-      "@superplane/cli: binary not found at " +
+      "@superplane/cli: could not run the binary at " +
         bin +
-        ". Did the postinstall step fail? Try `npm rebuild @superplane/cli`."
+        " (" + code + "). Did the postinstall step fail? " +
+        "Try `npm rebuild @superplane/cli`."
     );
     process.exit(127);
   }

--- a/release/superplane-cli-npm/install.js
+++ b/release/superplane-cli-npm/install.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const https = require("https");
+const { pipeline } = require("stream/promises");
 
 const PLATFORM_MAP = {
   "darwin-x64": "darwin-amd64",
@@ -31,37 +32,47 @@ function resolveTarget() {
   return target;
 }
 
-function download(url, dest) {
+function get(url) {
   return new Promise((resolve, reject) => {
-    function attempt(currentUrl, redirectsLeft) {
-      const req = https.get(currentUrl, (res) => {
-        if (
-          res.statusCode >= 300 &&
-          res.statusCode < 400 &&
-          res.headers.location
-        ) {
-          res.resume();
-          if (redirectsLeft <= 0) {
-            reject(new Error("too many redirects"));
-            return;
-          }
-          attempt(res.headers.location, redirectsLeft - 1);
-          return;
-        }
-        if (res.statusCode !== 200) {
-          res.resume();
-          reject(new Error(`HTTP ${res.statusCode} fetching ${currentUrl}`));
-          return;
-        }
-        const file = fs.createWriteStream(dest);
-        res.pipe(file);
-        file.on("finish", () => file.close((err) => (err ? reject(err) : resolve())));
-        file.on("error", reject);
-      });
-      req.on("error", reject);
-    }
-    attempt(url, 5);
+    const req = https.get(url, resolve);
+    req.on("error", reject);
   });
+}
+
+async function download(url, dest) {
+  let currentUrl = url;
+
+  for (let redirectsLeft = 5; ; redirectsLeft--) {
+    const res = await get(currentUrl);
+
+    if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+      res.resume();
+      if (redirectsLeft <= 0) {
+        throw new Error("too many redirects");
+      }
+      currentUrl = new URL(res.headers.location, currentUrl).toString();
+      continue;
+    }
+
+    if (res.statusCode !== 200) {
+      res.resume();
+      throw new Error(`HTTP ${res.statusCode} fetching ${currentUrl}`);
+    }
+
+    // pipeline propagates a mid-stream response error to the file stream and
+    // rejects. res.pipe() does not, which let a truncated download look like a
+    // successful install.
+    await pipeline(res, fs.createWriteStream(dest));
+
+    const expected = Number.parseInt(res.headers["content-length"], 10);
+    if (Number.isFinite(expected) && fs.statSync(dest).size !== expected) {
+      throw new Error(
+        `incomplete download: expected ${expected} bytes, got ${fs.statSync(dest).size}`
+      );
+    }
+
+    return;
+  }
 }
 
 async function main() {
@@ -76,10 +87,14 @@ async function main() {
   console.log(`@superplane/cli: downloading ${target} binary for v${version}`);
   console.log(`  ${url}`);
 
+  const tmpPath = `${binPath}.download-${process.pid}`;
+
   try {
-    await download(url, binPath);
-    fs.chmodSync(binPath, 0o755);
+    await download(url, tmpPath);
+    fs.chmodSync(tmpPath, 0o755);
+    fs.renameSync(tmpPath, binPath);
   } catch (err) {
+    fs.rmSync(tmpPath, { force: true });
     console.error("@superplane/cli: failed to download binary.");
     console.error(`  ${err.message}`);
     process.exit(1);


### PR DESCRIPTION
The postinstall download writes straight onto `bin/superplane` with `res.pipe()`. `res.pipe()` does not forward a response-stream error to the file stream, so if the connection drops after the headers the promise never settles, the `catch` never runs, and node exits 0.

npm then reports a successful install with a truncated binary in place. Because `createWriteStream` truncates the existing file rather than replacing it, the old `0755` mode survives, so a failed `npm rebuild` leaves a broken executable where a working one was. `run.js` has a message for this and it never fires, because it is gated on `ENOENT` and the file exists.

### Reproduction

A server that sends `Content-Length: 1000`, writes 200 bytes and destroys the socket, run against a `bin/superplane` that already holds a working binary. Measured today against `main` at 992d1b3:

| | Before | After |
|---|---|---|
| Exit code | **0** | 1 |
| Printed | nothing after the download line | `failed to download binary.` / `aborted` |
| `bin/superplane` | **200 bytes**, the working binary gone | the previous binary, untouched |
| Temp files left | none, it wrote straight over the target | none |

Happy path re-tested against a server that completes the body: 1000 bytes, exit 0, `@superplane/cli: installed.` A relative redirect `Location` was tested too and still resolves.

### The change

`install.js` downloads to `bin/superplane.download-<pid>` and renames onto the target only on success, uses `stream.pipeline` so a mid-stream error rejects, compares the written size against `Content-Length` when the server sends one, removes the temp file in the `catch`, and resolves a redirect `Location` against the current URL.

`bin/run.js` treats `EACCES` and `ENOEXEC` the same as `ENOENT`, so the "did the postinstall step fail" message reaches the case it was written for, and names the code in the message.

Small and self-contained, happy to split it if you would rather take the pipeline change on its own.
