### PR TITLE
feat: Add Velocity zero state and early usage states

### DIFF
--- a/web_src/src/pages/factories/pages/Velocity.stories.tsx
+++ b/web_src/src/pages/factories/pages/Velocity.stories.tsx
@@ -3,7 +3,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../__fixtures__/factoryPageResponses";
 import { VelocityPage } from "./VelocityPage";
-import { VelocityPrototypePage } from "./VelocityPrototypePage";
+import {
+  VelocityPrototypeEarlyUsagePage,
+  VelocityPrototypePage,
+  VelocityPrototypeZeroStatePage,
+} from "./VelocityPrototypePage";
 
 const meta = {
   title: "Factories/Pages/Velocity",
@@ -15,12 +19,41 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const velocityPath = `workspaces/${PRIMARY_FACTORY_KEY}/velocity`;
+
 export const Default: Story = {
   render: () => (
     <FactoriesHarness
-      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/velocity`}
+      pathSuffix={velocityPath}
       factoriesFixture={defaultFactoriesFixture}
       pageOverrides={{ velocity: VelocityPrototypePage }}
+    />
+  ),
+};
+
+/** New workspace with no closed tasks — empty state that points at the board. */
+export const ZeroState: Story = {
+  name: "Zero state",
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={velocityPath}
+      factoriesFixture={defaultFactoriesFixture}
+      pageOverrides={{ velocity: VelocityPrototypeZeroStatePage }}
+    />
+  ),
+};
+
+/**
+ * A few hours after setup: people merges fill the period, SuperPlane has one
+ * day of output. No period comparison, and medians name their small sample.
+ */
+export const EarlyUsage: Story = {
+  name: "Early usage",
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={velocityPath}
+      factoriesFixture={defaultFactoriesFixture}
+      pageOverrides={{ velocity: VelocityPrototypeEarlyUsagePage }}
     />
   ),
 };

--- a/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPrototypePage.tsx
@@ -1,142 +1,81 @@
 import { useMemo, useState } from "react";
-import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 
-import { formatCompactTokenValue } from "@/lib/formatTokenCount";
-import { cn } from "@/lib/utils";
-import { SegmentedNav } from "@/ui/SegmentedNav";
-
-import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
-import { factoryCenteredSectionBodyClassName, factoryCenteredSectionHeaderClassName } from "./factoryPageLayoutStyles";
-import { VelocityPeopleTable } from "./VelocityPeopleTable";
-import { CostChart, DeliveryChart, FlowChart } from "./VelocityPrototypeCharts";
+import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
+import { workOrdersPath } from "../lib/factoryPagePaths";
 import {
-  BREAKDOWN_COPY,
-  BREAKDOWN_OPTIONS,
-  COST_SERIES_COLORS,
-  PERIOD_OPTIONS,
-  TIME_SERIES_COLORS,
-  WORKSPACE_REPOSITORY,
+  CostCard,
+  DeliveryCard,
+  SummaryCard,
+  TaskTimeCard,
+  VelocityPrototypeChrome,
+  type VelocityComparison,
+} from "./velocityPrototypeCards";
+import { VelocityPeopleTable } from "./VelocityPeopleTable";
+import { VelocityZeroState } from "./VelocityZeroState";
+import {
+  EARLY_USAGE_CLOSED_TASKS,
+  buildEarlyUsageVelocityPoints,
   buildPeople,
   buildVelocityPoints,
   summarizePoints,
   type Breakdown,
   type PeriodDays,
+  type VelocitySummary,
 } from "./velocityPrototypeData";
 
-const cardClassName = "rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5";
-const cardTitleClassName = "text-[14px] font-medium tracking-[-0.01em] text-foreground";
-const cardSubtitleClassName = "mt-0.5 text-[12px] text-muted-foreground";
-
-type ChangeBetter = "up" | "down";
-
-/** The arrow shows which way the number moved. The color shows whether that is good. */
-interface MetricChange {
-  text: string;
-  tone: "better" | "worse" | "same";
-  direction: "up" | "down" | "flat";
-}
-
-const CHANGE_TONE_CLASS: Record<MetricChange["tone"], string> = {
-  better: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-400",
-  worse: "bg-rose-50 text-rose-700 dark:bg-rose-950/60 dark:text-rose-400",
-  same: "bg-muted text-muted-foreground",
-};
-
-function formatHours(value: number) {
-  return `${Math.round(value)}h`;
-}
-
-function formatUsd(value: number) {
-  return `$${value.toFixed(2)}`;
-}
-
-function costShare(part: number, total: number): number {
-  if (total <= 0) return 0;
-  return Math.round((part / total) * 100);
-}
-
-function buildChange(delta: number, better: ChangeBetter, format: (magnitude: number) => string): MetricChange {
-  if (delta === 0) return { text: "No change", tone: "same", direction: "flat" };
-
-  const improved = better === "up" ? delta > 0 : delta < 0;
-  return {
-    text: format(Math.abs(delta)),
-    tone: improved ? "better" : "worse",
-    direction: delta > 0 ? "up" : "down",
-  };
-}
-
-function ChangeChip({ change }: { change: MetricChange }) {
-  const Icon = change.direction === "up" ? ArrowUpRight : ArrowDownRight;
-
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[11px] font-medium tabular-nums",
-        CHANGE_TONE_CLASS[change.tone],
-      )}
-    >
-      {change.direction === "flat" ? null : <Icon className="size-3" aria-hidden />}
-      {change.text}
-    </span>
+function usePeopleShare(summary: VelocitySummary) {
+  return useMemo(
+    () =>
+      buildPeople({
+        peopleMerged: summary.peopleMerged,
+        superplaneMerged: summary.superplaneMerged,
+        waste: summary.waste,
+        costUsd: summary.cost,
+      }),
+    [summary.peopleMerged, summary.superplaneMerged, summary.waste, summary.cost],
   );
 }
 
-function Metric({
-  label,
-  value,
-  hint,
-  change,
-}: {
-  label: string;
-  value: string;
-  hint?: string;
-  change?: MetricChange;
-}) {
+/** First-run empty report: same chrome as the populated prototype, no charts. */
+export function VelocityPrototypeZeroStatePage() {
+  const [periodDays, setPeriodDays] = useState<PeriodDays>(14);
+  const { organizationId, factoryKey } = useFactoriesLayout();
+
   return (
-    <div className="min-w-0">
-      <p className="text-[12px] text-muted-foreground">{label}</p>
-      <div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-        <p className="text-[30px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
-          {value}
-        </p>
-        {change ? <ChangeChip change={change} /> : null}
-      </div>
-      {hint ? <p className="mt-2 text-[12px] text-muted-foreground">{hint}</p> : null}
-    </div>
+    <VelocityPrototypeChrome periodDays={periodDays} onPeriodDaysChange={setPeriodDays}>
+      <VelocityZeroState tasksHref={workOrdersPath(organizationId, factoryKey)} />
+    </VelocityPrototypeChrome>
   );
 }
 
 /**
- * One line of a card split. The dot ties the number to its band in the chart
- * below, so neither chart needs its own legend.
- *
- * `share` is only for splits that partition a total. Medians do not sum to the
- * median of the total, so the time split leaves it out.
+ * A workspace a few hours old. Every card holds real numbers, but SuperPlane
+ * has one day of output, so the page drops the period comparison and names the
+ * sample behind each median.
  */
-function SplitRow({
-  color,
-  label,
-  value,
-  share,
-  hint,
-}: {
-  color: string;
-  label: string;
-  value: string;
-  share?: number;
-  hint?: string;
-}) {
+export function VelocityPrototypeEarlyUsagePage() {
+  const [periodDays, setPeriodDays] = useState<PeriodDays>(14);
+  const [breakdown, setBreakdown] = useState<Breakdown>("origin");
+  const points = useMemo(() => buildEarlyUsageVelocityPoints(periodDays), [periodDays]);
+
+  const summary = summarizePoints(points);
+  const people = usePeopleShare(summary);
+  const periodLabel = `Last ${periodDays} days`;
+  const sampleNote = `From ${EARLY_USAGE_CLOSED_TASKS} tasks closed today`;
+
   return (
-    <div className="flex items-baseline gap-2 py-1.5">
-      <span className="size-1.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
-      <span className="text-[13px] text-foreground">{label}</span>
-      {hint ? <span className="text-[12px] text-muted-foreground">{hint}</span> : null}
-      <span className="ml-auto text-[13px] font-medium tabular-nums text-foreground">{value}</span>
-      {share === undefined ? null : (
-        <span className="w-9 text-right text-[12px] tabular-nums text-muted-foreground">{share}%</span>
-      )}
-    </div>
+    <VelocityPrototypeChrome periodDays={periodDays} onPeriodDaysChange={setPeriodDays}>
+      <SummaryCard
+        summary={summary}
+        caption={`${periodLabel}. SuperPlane started today, so there is no comparison yet.`}
+      />
+      <DeliveryCard points={points} breakdown={breakdown} onBreakdownChange={setBreakdown} />
+      <VelocityPeopleTable people={people} periodLabel={periodLabel} />
+      <div className="grid gap-5 lg:grid-cols-2">
+        <TaskTimeCard summary={summary} points={points} sampleNote={sampleNote} />
+        <CostCard summary={summary} points={points} sampleNote={sampleNote} />
+      </div>
+    </VelocityPrototypeChrome>
   );
 }
 
@@ -146,163 +85,31 @@ export function VelocityPrototypePage() {
   const points = useMemo(() => buildVelocityPoints(periodDays, periodDays), [periodDays]);
   const previousPoints = useMemo(() => buildVelocityPoints(periodDays, 0), [periodDays]);
 
-  const current = summarizePoints(points);
+  const summary = summarizePoints(points);
   const previous = summarizePoints(previousPoints);
-  const mergedDelta = current.merged - previous.merged;
-  const wasteDelta = current.wasteRate - previous.wasteRate;
-  const cycleDelta = Math.round(current.cycleHours - previous.cycleHours);
-  const costDelta = Math.round((current.costPerMerge - previous.costPerMerge) * 100) / 100;
+  const people = usePeopleShare(summary);
   const periodLabel = `Last ${periodDays} days`;
-  const breakdownCopy = BREAKDOWN_COPY[breakdown];
-  const people = useMemo(
-    () =>
-      buildPeople({
-        peopleMerged: current.peopleMerged,
-        superplaneMerged: current.superplaneMerged,
-        waste: current.waste,
-        costUsd: current.cost,
-      }),
-    [current.peopleMerged, current.superplaneMerged, current.waste, current.cost],
-  );
+
+  const comparison: VelocityComparison = {
+    merged: summary.merged - previous.merged,
+    wasteRate: summary.wasteRate - previous.wasteRate,
+    cycleHours: Math.round(summary.cycleHours - previous.cycleHours),
+    costPerMerge: Math.round((summary.costPerMerge - previous.costPerMerge) * 100) / 100,
+  };
 
   return (
-    /* Gray page, white cards. Dark mode keeps its darker page, because the
-       factories theme paints the sidebar and cards the same color. */
-    <div className="min-h-full bg-sidebar dark:bg-background">
-      <WorkspacePageHeader
-        className={cn(factoryCenteredSectionHeaderClassName, "bg-transparent")}
-        title="Velocity"
-        subtitle={`What ${WORKSPACE_REPOSITORY} ships, how long the work takes, and what it costs.`}
-        actions={
-          <SegmentedNav
-            ariaLabel="Velocity period"
-            size="xs"
-            value={String(periodDays)}
-            onValueChange={(value) => setPeriodDays(value === "30" ? 30 : 14)}
-            options={PERIOD_OPTIONS}
-          />
-        }
+    <VelocityPrototypeChrome periodDays={periodDays} onPeriodDaysChange={setPeriodDays}>
+      <SummaryCard
+        summary={summary}
+        caption={`${periodLabel}. Compared with the previous ${periodDays} days.`}
+        comparison={comparison}
       />
-
-      <div className={cn(factoryCenteredSectionBodyClassName, "space-y-5 pb-10")} data-testid="factory-velocity-page">
-        <section className={cardClassName}>
-          <p className="text-[12px] text-muted-foreground">
-            {periodLabel}. Compared with the previous {periodDays} days.
-          </p>
-          <div className="mt-4 grid grid-cols-2 gap-x-8 gap-y-6 lg:grid-cols-4">
-            <Metric
-              label="Merged PRs"
-              value={String(current.merged)}
-              hint="People and SuperPlane"
-              change={buildChange(mergedDelta, "up", (magnitude) => String(magnitude))}
-            />
-            <Metric
-              label="Factory waste"
-              value={`${current.wasteRate}%`}
-              hint={`${current.waste} PRs closed without merge`}
-              change={buildChange(wasteDelta, "down", (magnitude) => `${magnitude} pp`)}
-            />
-            <Metric
-              label="Median cycle time"
-              value={formatHours(current.cycleHours)}
-              hint="From start to close"
-              change={buildChange(cycleDelta, "down", (magnitude) => `${magnitude}h`)}
-            />
-            <Metric
-              label="Cost per Factory merge"
-              value={formatUsd(current.costPerMerge)}
-              hint="Tokens and execution compute"
-              change={buildChange(costDelta, "down", (magnitude) => `$${magnitude.toFixed(2)}`)}
-            />
-          </div>
-        </section>
-
-        <section className={cardClassName}>
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <h2 className={cardTitleClassName}>{breakdownCopy.title}</h2>
-              <p className={cardSubtitleClassName}>{breakdownCopy.description}</p>
-            </div>
-            <SegmentedNav
-              ariaLabel="Group merged pull requests by"
-              size="xs"
-              value={breakdown}
-              onValueChange={(value) => setBreakdown(value as Breakdown)}
-              options={BREAKDOWN_OPTIONS}
-            />
-          </div>
-          <div className="mt-5">
-            <DeliveryChart points={points} breakdown={breakdown} />
-          </div>
-        </section>
-
-        <VelocityPeopleTable people={people} periodLabel={periodLabel} />
-
-        <div className="grid gap-5 lg:grid-cols-2">
-          <section className={cardClassName}>
-            <h2 className={cardTitleClassName}>Task time</h2>
-            <p className={cardSubtitleClassName}>Median time for Factory tasks that closed in this period.</p>
-
-            <div className="mt-5">
-              <Metric label="Cycle time" value={formatHours(current.cycleHours)} />
-            </div>
-
-            <div className="mt-4 border-t border-border pt-2">
-              <SplitRow
-                color={TIME_SERIES_COLORS.running}
-                label="Time running"
-                value={formatHours(current.runningHours)}
-              />
-              <SplitRow
-                color={TIME_SERIES_COLORS.waiting}
-                label="Time waiting"
-                value={formatHours(current.waitingHours)}
-              />
-              <p className="mt-1.5 text-[12px] text-muted-foreground">
-                Waiting is review and queue time, not time the agent runs.
-              </p>
-            </div>
-
-            <div className="mt-5 border-t border-border pt-4">
-              <FlowChart points={points} />
-            </div>
-          </section>
-
-          <section className={cardClassName}>
-            <h2 className={cardTitleClassName}>Tracked Factory cost</h2>
-            <p className={cardSubtitleClassName}>
-              Model tokens and execution compute. Third-party charges are excluded.
-            </p>
-
-            <div className="mt-5">
-              <Metric label="Total cost" value={formatUsd(current.cost)} />
-            </div>
-
-            <div className="mt-4 border-t border-border pt-2">
-              <SplitRow
-                color={COST_SERIES_COLORS.tokens}
-                label="Model tokens"
-                hint={formatCompactTokenValue(current.tokens)}
-                value={formatUsd(current.tokenCost)}
-                share={costShare(current.tokenCost, current.cost)}
-              />
-              <SplitRow
-                color={COST_SERIES_COLORS.compute}
-                label="Execution compute"
-                value={formatUsd(current.computeCost)}
-                share={costShare(current.computeCost, current.cost)}
-              />
-              <p className="mt-1.5 text-[12px] text-muted-foreground">
-                {formatUsd(current.wasteCost)} of this went to Factory work that closed without a merge.
-              </p>
-            </div>
-
-            <div className="mt-5 border-t border-border pt-4">
-              <CostChart points={points} />
-            </div>
-          </section>
-        </div>
+      <DeliveryCard points={points} breakdown={breakdown} onBreakdownChange={setBreakdown} />
+      <VelocityPeopleTable people={people} periodLabel={periodLabel} />
+      <div className="grid gap-5 lg:grid-cols-2">
+        <TaskTimeCard summary={summary} points={points} />
+        <CostCard summary={summary} points={points} />
       </div>
-    </div>
+    </VelocityPrototypeChrome>
   );
 }

--- a/web_src/src/pages/factories/pages/VelocityZeroState.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityZeroState.spec.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { VelocityZeroState } from "./VelocityZeroState";
+
+function renderZeroState(tasksHref = "/org-1/workspaces/refunds/work-orders") {
+  return render(
+    <MemoryRouter>
+      <VelocityZeroState tasksHref={tasksHref} />
+    </MemoryRouter>,
+  );
+}
+
+describe("VelocityZeroState", () => {
+  it("explains what appears here after the first tasks close", () => {
+    renderZeroState();
+
+    expect(screen.getByTestId("velocity-zero-state")).toBeInTheDocument();
+    expect(screen.getByText("No velocity data yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("Velocity reports merged pull requests, task time, and cost after your first tasks close."),
+    ).toBeInTheDocument();
+  });
+
+  it("links to the Tasks board instead of offering to create work from a report", () => {
+    renderZeroState("/org-1/workspaces/refunds/work-orders");
+
+    const link = screen.getByTestId("velocity-zero-state-tasks");
+    expect(link).toHaveAttribute("href", "/org-1/workspaces/refunds/work-orders");
+    expect(link).toHaveTextContent("View tasks");
+    expect(screen.queryByRole("button", { name: "New task" })).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/VelocityZeroState.tsx
+++ b/web_src/src/pages/factories/pages/VelocityZeroState.tsx
@@ -1,0 +1,31 @@
+import { TrendingUp } from "lucide-react";
+import { Link } from "react-router";
+
+import { Button } from "@/components/ui/button";
+
+const CARD_CLASSES =
+  "flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-card px-6 py-16 text-center";
+
+interface VelocityZeroStateProps {
+  /** Tasks board for this workspace. Velocity reports work; it does not start it. */
+  tasksHref: string;
+}
+
+export function VelocityZeroState({ tasksHref }: VelocityZeroStateProps) {
+  return (
+    <div className={CARD_CLASSES} data-testid="velocity-zero-state">
+      <TrendingUp className="size-6 text-muted-foreground" aria-hidden />
+      <div className="space-y-1">
+        <p className="text-[14px] font-medium text-foreground">No velocity data yet</p>
+        <p className="text-[12px] text-muted-foreground">
+          Velocity reports merged pull requests, task time, and cost after your first tasks close.
+        </p>
+      </div>
+      <Button asChild variant="outline" size="sm">
+        <Link to={tasksHref} data-testid="velocity-zero-state-tasks">
+          View tasks
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/velocityPrototypeCards.tsx
+++ b/web_src/src/pages/factories/pages/velocityPrototypeCards.tsx
@@ -1,0 +1,339 @@
+import type { ReactNode } from "react";
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+import { formatCompactTokenValue } from "@/lib/formatTokenCount";
+import { cn } from "@/lib/utils";
+import { SegmentedNav } from "@/ui/SegmentedNav";
+
+import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
+import { factoryCenteredSectionBodyClassName, factoryCenteredSectionHeaderClassName } from "./factoryPageLayoutStyles";
+import { CostChart, DeliveryChart, FlowChart } from "./VelocityPrototypeCharts";
+import {
+  BREAKDOWN_COPY,
+  BREAKDOWN_OPTIONS,
+  COST_SERIES_COLORS,
+  PERIOD_OPTIONS,
+  TIME_SERIES_COLORS,
+  WORKSPACE_REPOSITORY,
+  type Breakdown,
+  type PeriodDays,
+  type VelocityPoint,
+  type VelocitySummary,
+} from "./velocityPrototypeData";
+
+export const cardClassName = "rounded-xl border border-border bg-card px-4 py-4 sm:px-5 sm:py-5";
+const cardTitleClassName = "text-[14px] font-medium tracking-[-0.01em] text-foreground";
+const cardSubtitleClassName = "mt-0.5 text-[12px] text-muted-foreground";
+
+type ChangeBetter = "up" | "down";
+
+/** The arrow shows which way the number moved. The color shows whether that is good. */
+interface MetricChange {
+  text: string;
+  tone: "better" | "worse" | "same";
+  direction: "up" | "down" | "flat";
+}
+
+const CHANGE_TONE_CLASS: Record<MetricChange["tone"], string> = {
+  better: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-400",
+  worse: "bg-rose-50 text-rose-700 dark:bg-rose-950/60 dark:text-rose-400",
+  same: "bg-muted text-muted-foreground",
+};
+
+function formatHours(value: number) {
+  return `${Math.round(value)}h`;
+}
+
+function formatUsd(value: number) {
+  return `$${value.toFixed(2)}`;
+}
+
+function costShare(part: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.round((part / total) * 100);
+}
+
+function buildChange(delta: number, better: ChangeBetter, format: (magnitude: number) => string): MetricChange {
+  if (delta === 0) return { text: "No change", tone: "same", direction: "flat" };
+
+  const improved = better === "up" ? delta > 0 : delta < 0;
+  return {
+    text: format(Math.abs(delta)),
+    tone: improved ? "better" : "worse",
+    direction: delta > 0 ? "up" : "down",
+  };
+}
+
+function ChangeChip({ change }: { change: MetricChange }) {
+  const Icon = change.direction === "up" ? ArrowUpRight : ArrowDownRight;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[11px] font-medium tabular-nums",
+        CHANGE_TONE_CLASS[change.tone],
+      )}
+    >
+      {change.direction === "flat" ? null : <Icon className="size-3" aria-hidden />}
+      {change.text}
+    </span>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  hint,
+  change,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  change?: MetricChange;
+}) {
+  return (
+    <div className="min-w-0">
+      <p className="text-[12px] text-muted-foreground">{label}</p>
+      <div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <p className="text-[30px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
+          {value}
+        </p>
+        {change ? <ChangeChip change={change} /> : null}
+      </div>
+      {hint ? <p className="mt-2 text-[12px] text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+/**
+ * One line of a card split. The dot ties the number to its band in the chart
+ * below, so neither chart needs its own legend.
+ *
+ * `share` is only for splits that partition a total. Medians do not sum to the
+ * median of the total, so the time split leaves it out.
+ */
+function SplitRow({
+  color,
+  label,
+  value,
+  share,
+  hint,
+}: {
+  color: string;
+  label: string;
+  value: string;
+  share?: number;
+  hint?: string;
+}) {
+  return (
+    <div className="flex items-baseline gap-2 py-1.5">
+      <span className="size-1.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+      <span className="text-[13px] text-foreground">{label}</span>
+      {hint ? <span className="text-[12px] text-muted-foreground">{hint}</span> : null}
+      <span className="ml-auto text-[13px] font-medium tabular-nums text-foreground">{value}</span>
+      {share === undefined ? null : (
+        <span className="w-9 text-right text-[12px] tabular-nums text-muted-foreground">{share}%</span>
+      )}
+    </div>
+  );
+}
+
+export function VelocityPrototypeChrome({
+  periodDays,
+  onPeriodDaysChange,
+  children,
+}: {
+  periodDays: PeriodDays;
+  onPeriodDaysChange: (days: PeriodDays) => void;
+  children: ReactNode;
+}) {
+  return (
+    /* Gray page, white cards. Dark mode keeps its darker page, because the
+       factories theme paints the sidebar and cards the same color. */
+    <div className="min-h-full bg-sidebar dark:bg-background">
+      <WorkspacePageHeader
+        className={cn(factoryCenteredSectionHeaderClassName, "bg-transparent")}
+        title="Velocity"
+        subtitle={`What ${WORKSPACE_REPOSITORY} ships, how long the work takes, and what it costs.`}
+        actions={
+          <SegmentedNav
+            ariaLabel="Velocity period"
+            size="xs"
+            value={String(periodDays)}
+            onValueChange={(value) => onPeriodDaysChange(value === "30" ? 30 : 14)}
+            options={PERIOD_OPTIONS}
+          />
+        }
+      />
+
+      <div className={cn(factoryCenteredSectionBodyClassName, "space-y-5 pb-10")} data-testid="factory-velocity-page">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/** Deltas against the previous window. Omit them when there is no history. */
+export interface VelocityComparison {
+  merged: number;
+  wasteRate: number;
+  cycleHours: number;
+  costPerMerge: number;
+}
+
+export function SummaryCard({
+  summary,
+  caption,
+  comparison,
+}: {
+  summary: VelocitySummary;
+  caption: string;
+  comparison?: VelocityComparison;
+}) {
+  return (
+    <section className={cardClassName}>
+      <p className="text-[12px] text-muted-foreground">{caption}</p>
+      <div className="mt-4 grid grid-cols-2 gap-x-8 gap-y-6 lg:grid-cols-4">
+        <Metric
+          label="Merged PRs"
+          value={String(summary.merged)}
+          hint="People and SuperPlane"
+          change={comparison ? buildChange(comparison.merged, "up", (magnitude) => String(magnitude)) : undefined}
+        />
+        <Metric
+          label="Factory waste"
+          value={`${summary.wasteRate}%`}
+          hint={`${summary.waste} PRs closed without merge`}
+          change={comparison ? buildChange(comparison.wasteRate, "down", (magnitude) => `${magnitude} pp`) : undefined}
+        />
+        <Metric
+          label="Median cycle time"
+          value={formatHours(summary.cycleHours)}
+          hint="From start to close"
+          change={comparison ? buildChange(comparison.cycleHours, "down", (magnitude) => `${magnitude}h`) : undefined}
+        />
+        <Metric
+          label="Cost per Factory merge"
+          value={formatUsd(summary.costPerMerge)}
+          hint="Tokens and execution compute"
+          change={
+            comparison
+              ? buildChange(comparison.costPerMerge, "down", (magnitude) => `$${magnitude.toFixed(2)}`)
+              : undefined
+          }
+        />
+      </div>
+    </section>
+  );
+}
+
+export function DeliveryCard({
+  points,
+  breakdown,
+  onBreakdownChange,
+}: {
+  points: VelocityPoint[];
+  breakdown: Breakdown;
+  onBreakdownChange: (breakdown: Breakdown) => void;
+}) {
+  const copy = BREAKDOWN_COPY[breakdown];
+
+  return (
+    <section className={cardClassName}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className={cardTitleClassName}>{copy.title}</h2>
+          <p className={cardSubtitleClassName}>{copy.description}</p>
+        </div>
+        <SegmentedNav
+          ariaLabel="Group merged pull requests by"
+          size="xs"
+          value={breakdown}
+          onValueChange={(value) => onBreakdownChange(value as Breakdown)}
+          options={BREAKDOWN_OPTIONS}
+        />
+      </div>
+      <div className="mt-5">
+        <DeliveryChart points={points} breakdown={breakdown} />
+      </div>
+    </section>
+  );
+}
+
+export function TaskTimeCard({
+  summary,
+  points,
+  sampleNote,
+}: {
+  summary: VelocitySummary;
+  points: VelocityPoint[];
+  /** Names the sample behind the median when it is too small to trust alone. */
+  sampleNote?: string;
+}) {
+  return (
+    <section className={cardClassName}>
+      <h2 className={cardTitleClassName}>Task time</h2>
+      <p className={cardSubtitleClassName}>Median time for Factory tasks that closed in this period.</p>
+
+      <div className="mt-5">
+        <Metric label="Cycle time" value={formatHours(summary.cycleHours)} hint={sampleNote} />
+      </div>
+
+      <div className="mt-4 border-t border-border pt-2">
+        <SplitRow color={TIME_SERIES_COLORS.running} label="Time running" value={formatHours(summary.runningHours)} />
+        <SplitRow color={TIME_SERIES_COLORS.waiting} label="Time waiting" value={formatHours(summary.waitingHours)} />
+        <p className="mt-1.5 text-[12px] text-muted-foreground">
+          Waiting is review and queue time, not time the agent runs.
+        </p>
+      </div>
+
+      <div className="mt-5 border-t border-border pt-4">
+        <FlowChart points={points} />
+      </div>
+    </section>
+  );
+}
+
+export function CostCard({
+  summary,
+  points,
+  sampleNote,
+}: {
+  summary: VelocitySummary;
+  points: VelocityPoint[];
+  sampleNote?: string;
+}) {
+  return (
+    <section className={cardClassName}>
+      <h2 className={cardTitleClassName}>Tracked Factory cost</h2>
+      <p className={cardSubtitleClassName}>Model tokens and execution compute. Third-party charges are excluded.</p>
+
+      <div className="mt-5">
+        <Metric label="Total cost" value={formatUsd(summary.cost)} hint={sampleNote} />
+      </div>
+
+      <div className="mt-4 border-t border-border pt-2">
+        <SplitRow
+          color={COST_SERIES_COLORS.tokens}
+          label="Model tokens"
+          hint={formatCompactTokenValue(summary.tokens)}
+          value={formatUsd(summary.tokenCost)}
+          share={costShare(summary.tokenCost, summary.cost)}
+        />
+        <SplitRow
+          color={COST_SERIES_COLORS.compute}
+          label="Execution compute"
+          value={formatUsd(summary.computeCost)}
+          share={costShare(summary.computeCost, summary.cost)}
+        />
+        <p className="mt-1.5 text-[12px] text-muted-foreground">
+          {formatUsd(summary.wasteCost)} of this went to Factory work that closed without a merge.
+        </p>
+      </div>
+
+      <div className="mt-5 border-t border-border pt-4">
+        <CostChart points={points} />
+      </div>
+    </section>
+  );
+}

--- a/web_src/src/pages/factories/pages/velocityPrototypeData.spec.ts
+++ b/web_src/src/pages/factories/pages/velocityPrototypeData.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EARLY_USAGE_CLOSED_TASKS,
+  buildEarlyUsageVelocityPoints,
+  buildVelocityPoints,
+  summarizePoints,
+} from "./velocityPrototypeData";
+
+describe("buildEarlyUsageVelocityPoints", () => {
+  it("keeps people merges across the period and gives SuperPlane one day of output", () => {
+    const points = buildEarlyUsageVelocityPoints(14);
+    const today = points[points.length - 1]!;
+    const earlier = points.slice(0, -1);
+
+    expect(points).toHaveLength(14);
+    expect(earlier.every((point) => point.people > 0)).toBe(true);
+    expect(earlier.every((point) => point.superplane === 0)).toBe(true);
+    expect(today.superplane).toBeGreaterThan(0);
+  });
+
+  it("closes the same number of tasks as the sample note reports", () => {
+    const today = buildEarlyUsageVelocityPoints(14).at(-1)!;
+
+    expect(today.superplane + today.waste).toBe(EARLY_USAGE_CLOSED_TASKS);
+  });
+
+  it("counts merged pull requests as people plus SuperPlane on every day", () => {
+    const points = buildEarlyUsageVelocityPoints(30);
+
+    for (const point of points) {
+      expect(point.merged).toBe(point.people + point.superplane);
+    }
+  });
+
+  it("reports no task time or cost on days without SuperPlane output", () => {
+    const earlier = buildEarlyUsageVelocityPoints(14).slice(0, -1);
+
+    expect(earlier.every((point) => point.runningHours === 0)).toBe(true);
+    expect(earlier.every((point) => point.waitingHours === 0)).toBe(true);
+    expect(earlier.every((point) => point.costUsd === 0)).toBe(true);
+  });
+});
+
+describe("summarizePoints", () => {
+  it("takes medians from days with closed tasks, so idle days do not hide task time", () => {
+    const points = buildEarlyUsageVelocityPoints(14);
+    const today = points.at(-1)!;
+
+    const summary = summarizePoints(points);
+
+    expect(summary.runningHours).toBe(today.runningHours);
+    expect(summary.waitingHours).toBe(today.waitingHours);
+    expect(summary.cycleHours).toBe(today.runningHours + today.waitingHours);
+  });
+
+  it("keeps waste rate and cost per merge scoped to SuperPlane output", () => {
+    const summary = summarizePoints(buildEarlyUsageVelocityPoints(14));
+    const today = buildEarlyUsageVelocityPoints(14).at(-1)!;
+
+    expect(summary.wasteRate).toBe(Math.round((today.waste / (today.superplane + today.waste)) * 100));
+    expect(summary.costPerMerge).toBeCloseTo(today.costUsd / today.superplane, 2);
+  });
+
+  it("still summarizes a full period where every day has closed tasks", () => {
+    const summary = summarizePoints(buildVelocityPoints(14, 14));
+
+    expect(summary.merged).toBeGreaterThan(0);
+    expect(summary.cycleHours).toBeGreaterThan(0);
+  });
+});

--- a/web_src/src/pages/factories/pages/velocityPrototypeData.ts
+++ b/web_src/src/pages/factories/pages/velocityPrototypeData.ts
@@ -219,12 +219,71 @@ export function buildVelocityPoints(periodDays: PeriodDays, windowOffset = 0): V
   });
 }
 
+/** Factory fields of a day. `day`, `people`, and `merged` come from the series. */
+type FactoryDayOutput = Omit<VelocityPoint, "day" | "people" | "merged">;
+
+const IDLE_FACTORY_DAY: FactoryDayOutput = {
+  superplane: 0,
+  waste: 0,
+  githubIssues: 0,
+  sentryExceptions: 0,
+  manual: 0,
+  api: 0,
+  runningHours: 0,
+  waitingHours: 0,
+  costUsd: 0,
+  tokenCostUsd: 0,
+  computeCostUsd: 0,
+  wasteCostUsd: 0,
+  tokens: 0,
+};
+
+/** Two merges and one task closed without a merge: three closed tasks. */
+const FIRST_FACTORY_DAY: FactoryDayOutput = {
+  superplane: 2,
+  waste: 1,
+  githubIssues: 1,
+  sentryExceptions: 0,
+  manual: 1,
+  api: 0,
+  runningHours: 1.8,
+  waitingHours: 0.8,
+  costUsd: 6.13,
+  tokenCostUsd: 4.78,
+  computeCostUsd: 1.35,
+  wasteCostUsd: 1.85,
+  tokens: 49_400,
+};
+
+/** Sample behind every median on the early-usage page. */
+export const EARLY_USAGE_CLOSED_TASKS = FIRST_FACTORY_DAY.superplane + FIRST_FACTORY_DAY.waste;
+
+/**
+ * A workspace a few hours old. The repository already has people merges over
+ * the whole period, because Velocity reads repository history. SuperPlane has
+ * one day of output, so every median and cost rests on a three-task sample.
+ */
+export function buildEarlyUsageVelocityPoints(periodDays: PeriodDays): VelocityPoint[] {
+  const history = buildVelocityPoints(periodDays, periodDays);
+  const lastIndex = history.length - 1;
+
+  return history.map((point, index) => {
+    const factory = index === lastIndex ? FIRST_FACTORY_DAY : IDLE_FACTORY_DAY;
+    return { ...point, ...factory, merged: point.people + factory.superplane };
+  });
+}
+
+export type VelocitySummary = ReturnType<typeof summarizePoints>;
+
 export function summarizePoints(points: VelocityPoint[]) {
   const merged = sum(points, "merged");
   const superplaneMerged = sum(points, "superplane");
   const waste = sum(points, "waste");
   const cost = sum(points, "costUsd");
-  const cycleHours = median(points.map((point) => point.runningHours + point.waitingHours));
+  /* A day without a closed task holds no median. Counting it as zero would
+     hide the task time of the days that did close work. */
+  const closedTaskDays = points.filter((point) => point.runningHours > 0 || point.waitingHours > 0);
+  const cycleHours = median(closedTaskDays.map((point) => point.runningHours + point.waitingHours));
   const wasteRate = superplaneMerged + waste > 0 ? Math.round((waste / (superplaneMerged + waste)) * 100) : 0;
   const costPerMerge = superplaneMerged > 0 ? cost / superplaneMerged : 0;
 
@@ -235,8 +294,8 @@ export function summarizePoints(points: VelocityPoint[]) {
     waste,
     wasteRate,
     cycleHours,
-    runningHours: median(points.map((point) => point.runningHours)),
-    waitingHours: median(points.map((point) => point.waitingHours)),
+    runningHours: median(closedTaskDays.map((point) => point.runningHours)),
+    waitingHours: median(closedTaskDays.map((point) => point.waitingHours)),
     cost,
     tokenCost: sum(points, "tokenCostUsd"),
     computeCost: sum(points, "computeCostUsd"),


### PR DESCRIPTION
## Summary

Velocity had one Storybook story, and it used a full dataset. Design review could not see the two states a new workspace meets first.

- **Zero state.** No closed tasks yet. The card explains what appears here and links to the Tasks board. Velocity reports work and does not start it, so a create action on a report misleads the reader.
- **Early usage.** A few hours after setup. People merges fill the period, because Velocity reads repository history, and SuperPlane has one day of output. The page drops the period comparison, because there is no history, and it names the three-task sample behind each median.

Two supporting changes:

- Shared cards move to `velocityPrototypeCards.tsx`, so all three prototype pages use one frame.
- `summarizePoints` takes medians from days with closed tasks. Idle days pulled task time to zero, which hid the time of the days that closed work.

All three pages stay in Storybook. The app route still renders `VelocityPage`.

## Test plan

- [ ] Open Storybook: `make storybook`.
- [ ] Open Factories / Pages / Velocity / Default. Confirm the charts and the period comparison still show.
- [ ] Open Zero state. Confirm the card shows "No velocity data yet" and a "View tasks" link.
- [ ] Select "View tasks". Confirm the Tasks board opens.
- [ ] Open Early usage. Confirm no comparison chips show, and the summary caption reports that SuperPlane started today.
- [ ] Confirm Task time shows a cycle time above zero and the note "From 3 tasks closed today".
- [ ] Switch the period to 30d on each story. Confirm the page keeps its shape.
- [ ] Run `make check.test.ui`, `make check.lint.ui`, and `make check.build.ui`.


Made with [Cursor](https://cursor.com)