### PR TITLE
feat: Add factory workspace repository

### DIFF
--- a/db/migrations/20260831160100_add-factory-work-order-repository-snapshot.up.sql
+++ b/db/migrations/20260831160100_add-factory-work-order-repository-snapshot.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE factory_work_orders
+  ADD COLUMN repository TEXT,
+  ADD COLUMN default_branch TEXT;
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -638,6 +638,8 @@ CREATE TABLE public.factory_work_orders (
     status_note jsonb,
     origin_url text,
     origin_label text,
+    repository text,
+    default_branch text,
     CONSTRAINT factory_work_orders_number_positive_check CHECK ((number > 0))
 );
 
@@ -3709,7 +3711,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260829133423	f
+20260831160100	f
 \.
 
 

--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -506,6 +506,12 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			DomainType:                   models.DomainTypeOrganization,
 			RequiredExperimentalFeatures: []string{features.FeatureFactories},
 		},
+		{Method: "PATCH", Pattern: "/api/v1/factories/{id}/repository"}: {
+			Resource:                     "factories",
+			Action:                       "update",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureFactories},
+		},
 		{Method: "PATCH", Pattern: "/api/v1/canvases/{canvas_id}/executions/resolve"}: {
 			Resource:           "canvases",
 			Action:             "update",

--- a/pkg/configuration/expressionvalidation/validator.go
+++ b/pkg/configuration/expressionvalidation/validator.go
@@ -148,6 +148,10 @@ func checkTopLevelCall(name string, args []ast.Node) error {
 		if len(args) != 0 {
 			return fmt.Errorf("order() takes no arguments, got %d", len(args))
 		}
+	case "workspace":
+		if len(args) != 0 {
+			return fmt.Errorf("workspace() takes no arguments, got %d", len(args))
+		}
 	}
 	return nil
 }
@@ -188,6 +192,7 @@ func compileWithStubEnv(body string, knownNodeNames map[string]struct{}, extraEn
 		expr.Function("run", func(params ...any) (any, error) { return nil, nil }),
 		expr.Function("app", func(params ...any) (any, error) { return nil, nil }),
 		expr.Function("order", func(params ...any) (any, error) { return nil, nil }),
+		expr.Function("workspace", func(params ...any) (any, error) { return nil, nil }),
 	}
 
 	if _, err := expr.Compile(body, opts...); err != nil {

--- a/pkg/grpc/actions/factories/factory_app_templates_test.go
+++ b/pkg/grpc/actions/factories/factory_app_templates_test.go
@@ -49,8 +49,8 @@ func TestMaterializeFactoryTemplate(t *testing.T) {
 	}, agent.Configuration["credentials"])
 
 	createPR := findYAMLNode(t, canvas, "create-pr")
-	assert.Equal(t, "acme/refunds", createPR.Configuration["repository"])
-	assert.Equal(t, "develop", createPR.Configuration["base"])
+	assert.Equal(t, "{{ order().repository }}", createPR.Configuration["repository"])
+	assert.Equal(t, "{{ order().default_branch }}", createPR.Configuration["base"])
 	assert.Equal(t, &yaml.IntegrationRef{ID: "github-1", Name: "acme-github"}, createPR.Integration)
 
 	console, err := yaml.ConsoleFromYML([]byte(result.consoleYAML))

--- a/pkg/grpc/actions/factories/serialization.go
+++ b/pkg/grpc/actions/factories/serialization.go
@@ -55,6 +55,7 @@ func serializeFactoryOnboarding(factory *models.Factory) *pb.FactoryOnboarding {
 		AgentIntegrationId: config.AgentIntegrationID,
 		AppRepository:      config.AppRepository,
 		BacklogRepository:  config.BacklogRepository,
+		DefaultBranch:      config.DefaultBranch,
 		IssuesSource:       serializeFactoryOnboardingIssuesSource(config.IssuesSource),
 		AgentHarness:       serializeFactoryOnboardingAgentHarness(config.AgentHarness),
 		ProvisionedAppId:   config.ProvisionedAppID,

--- a/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
+++ b/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
@@ -50,10 +50,10 @@ spec:
               name: github
         environment:
           - name: REPO
-            value: '{{ install_params.appRepository }}'
+            value: '{{ order().repository }}'
             valueSource: literal
           - name: BASE
-            value: '{{ install_params.defaultBranch }}'
+            value: '{{ order().default_branch }}'
             valueSource: literal
           - name: WORK_ORDER_TITLE
             value: '{{ order().title }}'
@@ -128,7 +128,7 @@ spec:
             prompt: |-
               You are implementing a fix for a SuperPlane task. The repository is already checked out in your current working directory, on the branch to work on.
 
-              Repository: {{ install_params.appRepository }}
+              Repository: {{ order().repository }}
               Task title: {{ order().title }}
 
               1/ The original task description is at /tmp/ORDER.md. Read it before implementing.
@@ -168,7 +168,7 @@ spec:
 
               Task title: {{ order().title }}
 
-              1/ Compare the current branch with {{ install_params.defaultBranch }} and review the commits you made.
+              1/ Compare the current branch with {{ order().default_branch }} and review the commits you made.
               2/ The title must follow conventional commits structure. Use only feat, fix, chore, or docs.
               3/ The description must start with a brief summary of the changes, and include sections to describe the changes made in each logical part of the system (UI, API, workers, database, ...).
               4/ Write the title to /tmp/TITLE and the description to /tmp/DESCRIPTION.md. Do not add these files to the repository.
@@ -205,7 +205,7 @@ spec:
         artifactType: branch
         name: '{{ $["Agent - Implement from order description"].data.result.branch }}'
         orderId: '{{ order().id }}'
-        repository: '{{ install_params.appRepository }}'
+        repository: '{{ order().repository }}'
       position:
         x: 1495
         'y': 648
@@ -217,7 +217,7 @@ spec:
       concurrency:
         max: 100
       configuration:
-        base: '{{ install_params.defaultBranch }}'
+        base: '{{ order().default_branch }}'
         body: |-
           [Task]({{ order().url }}).
 
@@ -228,7 +228,7 @@ spec:
           Created via [SuperPlane](https://superplane.com).
         draft: false
         head: '{{ $["Agent - Implement from order description"].data.result.branch }}'
-        repository: '{{ install_params.appRepository }}'
+        repository: '{{ order().repository }}'
         title: '{{ fromBase64($["Agent - Implement from order description"].data.result.title) }}'
       position:
         x: 1442
@@ -243,7 +243,7 @@ spec:
       configuration:
         orderId: '{{ order().id }}'
         provider: github
-        repository: '{{ install_params.appRepository }}'
+        repository: '{{ order().repository }}'
         number: '{{ $["Create Pull Request"].data.number }}'
         url: '{{ $["Create Pull Request"].data._links.html.href }}'
         title: '{{ $["Create Pull Request"].data.title }}'

--- a/pkg/grpc/actions/factories/templates/line-planning.canvas.yaml
+++ b/pkg/grpc/actions/factories/templates/line-planning.canvas.yaml
@@ -38,7 +38,7 @@ spec:
               name: github
         environment:
           - name: REPO
-            value: '{{ install_params.appRepository }}'
+            value: '{{ order().repository }}'
             valueSource: literal
           - name: ORDER_DESCRIPTION
             value: '{{ toBase64(order().description) }}'
@@ -61,7 +61,7 @@ spec:
             prompt: |-
               You are writing an implementation plan for a SuperPlane Task. The repository is cloned out in your current working directory.
 
-              Repository: {{ install_params.appRepository }}
+              Repository: {{ order().repository }}
               Task Title: {{ root().data.work_order.title }}
 
               1/ The description is in the /tmp/ORDER.md

--- a/pkg/grpc/actions/factories/update_factory_onboarding.go
+++ b/pkg/grpc/actions/factories/update_factory_onboarding.go
@@ -173,6 +173,7 @@ func factoryOnboardingPatchFromRequest(req *pb.UpdateFactoryOnboardingRequest) (
 		AgentIntegrationID: req.AgentIntegrationId,
 		AppRepository:      req.AppRepository,
 		BacklogRepository:  req.BacklogRepository,
+		DefaultBranch:      req.DefaultBranch,
 		ProvisionedAppID:   req.ProvisionedAppId,
 		ProvisionedLineID:  req.ProvisionedLineId,
 	}

--- a/pkg/grpc/actions/factories/update_factory_repository.go
+++ b/pkg/grpc/actions/factories/update_factory_repository.go
@@ -89,7 +89,7 @@ func UpdateFactoryRepository(
 		if err != nil {
 			return err
 		}
-		if err := factory.SnapshotActiveWorkOrderRepository(tx, previous.AppRepository, previousBranch); err != nil {
+		if err := factory.SnapshotWorkOrderRepository(tx, previous.AppRepository, previousBranch); err != nil {
 			return err
 		}
 

--- a/pkg/grpc/actions/factories/update_factory_repository.go
+++ b/pkg/grpc/actions/factories/update_factory_repository.go
@@ -20,6 +20,13 @@ import (
 
 const defaultFactoryRepositoryBranch = "main"
 
+const (
+	legacyAppRepositoryExpression = "{{ install_params.appRepository }}"
+	legacyDefaultBranchExpression = "{{ install_params.defaultBranch }}"
+	orderRepositoryExpression     = "{{ order().repository }}"
+	orderDefaultBranchExpression  = "{{ order().default_branch }}"
+)
+
 // UpdateFactoryRepository changes the repository that factory-managed
 // automations use. It snapshots active work orders before publishing the
 // generated canvas changes, so an in-progress order stays on its original
@@ -97,7 +104,17 @@ func UpdateFactoryRepository(
 			return err
 		}
 
-		return reconcileFactoryRepository(ctx, tx, deps, factory, actorID, previous.AppRepository, previousBranch, repository)
+		return reconcileFactoryRepository(
+			ctx,
+			tx,
+			deps,
+			factory,
+			actorID,
+			previous.AppRepository,
+			previous.BacklogRepository,
+			previousBranch,
+			repository,
+		)
 	})
 	if err != nil {
 		if _, _, ok := grpcerrors.HandlerStatus(err); ok {
@@ -123,7 +140,7 @@ func reconcileFactoryRepository(
 	deps IntakeDependencies,
 	factory *models.Factory,
 	actorID uuid.UUID,
-	previousRepository, previousBranch, repository string,
+	previousAppRepository, previousBacklogRepository, previousDefaultBranch, repository string,
 ) error {
 	canvasesForFactory, err := factory.ListCanvases(tx)
 	if err != nil {
@@ -161,19 +178,23 @@ func reconcileFactoryRepository(
 		if template, ok := resolveFactoryTemplate(nodes); ok {
 			switch template.id {
 			case "line-planning", "line-implementation":
-				changed = replaceNodeConfigurationStrings(nodes, map[string]string{
-					previousRepository: "{{ order().repository }}",
-					previousBranch:     "{{ order().default_branch }}",
+				changed = replaceNodeConfigurationValues(nodes, []configurationReplacement{
+					{from: previousAppRepository, to: orderRepositoryExpression},
+					{from: previousDefaultBranch, to: orderDefaultBranchExpression},
+					{from: legacyAppRepositoryExpression, to: orderRepositoryExpression},
+					{from: legacyDefaultBranchExpression, to: orderDefaultBranchExpression},
 				}) || changed
-			case "pr-closure", "issue-intake":
-				changed = replaceNodeConfigurationStrings(nodes, map[string]string{previousRepository: repository}) || changed
+			case "pr-closure":
+				changed = replaceNodeConfigurationValues(nodes, []configurationReplacement{{from: previousAppRepository, to: repository}}) || changed
+			case "issue-intake":
+				changed = replaceNodeConfigurationValues(nodes, []configurationReplacement{{from: previousBacklogRepository, to: repository}}) || changed
 			}
 		}
 		if _, ok := intakeCanvasIDs[canvas.ID]; ok {
-			changed = replaceTriggerRepository(nodes, "github.onIssue", previousRepository, repository) || changed
+			changed = replaceTriggerRepository(nodes, "github.onIssue", previousBacklogRepository, repository) || changed
 		}
 		if _, ok := handlerCanvasIDs[canvas.ID]; ok {
-			changed = replaceGitHubTriggerRepository(nodes, previousRepository, repository) || changed
+			changed = replaceGitHubTriggerRepository(nodes, previousAppRepository, repository) || changed
 		}
 		if !changed {
 			continue
@@ -209,7 +230,7 @@ func replaceTriggerRepository(nodes []models.Node, component, previousRepository
 		if nodes[i].ComponentName() != component {
 			continue
 		}
-		configuration, nodeChanged := replaceConfigurationStrings(nodes[i].Configuration, map[string]string{previousRepository: repository})
+		configuration, nodeChanged := replaceConfigurationValues(nodes[i].Configuration, []configurationReplacement{{from: previousRepository, to: repository}})
 		if !nodeChanged {
 			continue
 		}
@@ -225,7 +246,7 @@ func replaceGitHubTriggerRepository(nodes []models.Node, previousRepository, rep
 		if !strings.HasPrefix(nodes[i].ComponentName(), "github.on") {
 			continue
 		}
-		configuration, nodeChanged := replaceConfigurationStrings(nodes[i].Configuration, map[string]string{previousRepository: repository})
+		configuration, nodeChanged := replaceConfigurationValues(nodes[i].Configuration, []configurationReplacement{{from: previousRepository, to: repository}})
 		if !nodeChanged {
 			continue
 		}
@@ -235,10 +256,15 @@ func replaceGitHubTriggerRepository(nodes []models.Node, previousRepository, rep
 	return changed
 }
 
-func replaceNodeConfigurationStrings(nodes []models.Node, replacements map[string]string) bool {
+type configurationReplacement struct {
+	from string
+	to   string
+}
+
+func replaceNodeConfigurationValues(nodes []models.Node, replacements []configurationReplacement) bool {
 	changed := false
 	for i := range nodes {
-		configuration, nodeChanged := replaceConfigurationStrings(nodes[i].Configuration, replacements)
+		configuration, nodeChanged := replaceConfigurationValues(nodes[i].Configuration, replacements)
 		if !nodeChanged {
 			continue
 		}
@@ -248,13 +274,16 @@ func replaceNodeConfigurationStrings(nodes []models.Node, replacements map[strin
 	return changed
 }
 
-func replaceConfigurationStrings(value any, replacements map[string]string) (any, bool) {
+// replaceConfigurationValues updates only complete scalar values. Canvas
+// configuration can contain shell scripts and prose, so replacing substrings
+// would corrupt unrelated values such as a main branch fallback.
+func replaceConfigurationValues(value any, replacements []configurationReplacement) (any, bool) {
 	switch current := value.(type) {
 	case map[string]any:
 		cloned := maps.Clone(current)
 		changed := false
 		for key, child := range cloned {
-			next, childChanged := replaceConfigurationStrings(child, replacements)
+			next, childChanged := replaceConfigurationValues(child, replacements)
 			cloned[key] = next
 			changed = changed || childChanged
 		}
@@ -263,19 +292,18 @@ func replaceConfigurationStrings(value any, replacements map[string]string) (any
 		cloned := slices.Clone(current)
 		changed := false
 		for i, child := range cloned {
-			next, childChanged := replaceConfigurationStrings(child, replacements)
+			next, childChanged := replaceConfigurationValues(child, replacements)
 			cloned[i] = next
 			changed = changed || childChanged
 		}
 		return cloned, changed
 	case string:
-		next := current
-		for previous, replacement := range replacements {
-			if previous != "" {
-				next = strings.ReplaceAll(next, previous, replacement)
+		for _, replacement := range replacements {
+			if replacement.from != "" && current == replacement.from {
+				return replacement.to, true
 			}
 		}
-		return next, next != current
+		return current, false
 	default:
 		return value, false
 	}

--- a/pkg/grpc/actions/factories/update_factory_repository.go
+++ b/pkg/grpc/actions/factories/update_factory_repository.go
@@ -18,8 +18,6 @@ import (
 	"gorm.io/gorm"
 )
 
-const defaultFactoryRepositoryBranch = "main"
-
 const (
 	legacyAppRepositoryExpression = "{{ install_params.appRepository }}"
 	legacyDefaultBranchExpression = "{{ install_params.defaultBranch }}"
@@ -87,9 +85,9 @@ func UpdateFactoryRepository(
 			return invalidArgument("repository settings currently require a GitHub integration")
 		}
 
-		previousBranch := previous.DefaultBranch
-		if previousBranch == "" {
-			previousBranch = defaultFactoryRepositoryBranch
+		previousBranch, err := currentFactoryDefaultBranch(tx, factory, previous.DefaultBranch)
+		if err != nil {
+			return err
 		}
 		if err := factory.SnapshotActiveWorkOrderRepository(tx, previous.AppRepository, previousBranch); err != nil {
 			return err
@@ -132,6 +130,44 @@ func UpdateFactoryRepository(
 		return nil, factoryErrorToStatus(err, "failed to update factory repository")
 	}
 	return &pb.UpdateFactoryRepositoryResponse{Factory: serialized}, nil
+}
+
+// currentFactoryDefaultBranch resolves the branch used before a repository
+// switch. Older factories did not persist this setting, so read it from the
+// generated implementation canvas instead of assuming a default.
+func currentFactoryDefaultBranch(tx *gorm.DB, factory *models.Factory, configuredBranch string) (string, error) {
+	if configuredBranch = strings.TrimSpace(configuredBranch); configuredBranch != "" {
+		return configuredBranch, nil
+	}
+
+	canvasesForFactory, err := factory.ListCanvases(tx)
+	if err != nil {
+		return "", err
+	}
+	for i := range canvasesForFactory {
+		canvas := &canvasesForFactory[i]
+		version, err := models.FindLiveCanvasVersionByCanvasInTransaction(tx, canvas)
+		if err != nil {
+			return "", err
+		}
+		template, ok := resolveFactoryTemplate(version.Nodes)
+		if !ok || template.id != "line-implementation" {
+			continue
+		}
+		if defaultBranch := factoryDefaultBranchFromNodes(version.Nodes); defaultBranch != "" {
+			return defaultBranch, nil
+		}
+	}
+
+	return "", invalidArgument("could not determine the current workspace default branch")
+}
+
+func factoryDefaultBranchFromNodes(nodes []models.Node) string {
+	defaultBranch := strings.TrimSpace(deriveFactoryInstallParams(nodes)["defaultBranch"])
+	if strings.HasPrefix(defaultBranch, "{{") {
+		return ""
+	}
+	return defaultBranch
 }
 
 func reconcileFactoryRepository(

--- a/pkg/grpc/actions/factories/update_factory_repository.go
+++ b/pkg/grpc/actions/factories/update_factory_repository.go
@@ -1,0 +1,282 @@
+package factories
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases/changesets"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"gorm.io/gorm"
+)
+
+const defaultFactoryRepositoryBranch = "main"
+
+// UpdateFactoryRepository changes the repository that factory-managed
+// automations use. It snapshots active work orders before publishing the
+// generated canvas changes, so an in-progress order stays on its original
+// repository and branch.
+func UpdateFactoryRepository(
+	ctx context.Context,
+	deps IntakeDependencies,
+	organizationID string,
+	req *pb.UpdateFactoryRepositoryRequest,
+) (*pb.UpdateFactoryRepositoryResponse, error) {
+	orgID, err := parseOrganizationID(organizationID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory repository")
+	}
+	factoryID, err := parseFactoryID(req.GetId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory repository")
+	}
+	repository := strings.TrimSpace(req.GetRepository())
+	defaultBranch := strings.TrimSpace(req.GetDefaultBranch())
+	if repository == "" {
+		return nil, factoryErrorToStatus(invalidArgument("repository is required"), "failed to update factory repository")
+	}
+	if defaultBranch == "" {
+		return nil, factoryErrorToStatus(invalidArgument("default branch is required"), "failed to update factory repository")
+	}
+
+	userID, ok := authentication.GetUserIdFromMetadata(ctx)
+	if !ok {
+		return nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
+	}
+	actorID, err := uuid.Parse(userID)
+	if err != nil {
+		return nil, factoryErrorToStatus(invalidArgument("invalid user id"), "failed to update factory repository")
+	}
+
+	db := database.DB(ctx)
+	var factory *models.Factory
+	err = db.Transaction(func(tx *gorm.DB) error {
+		loaded, err := models.FindFactory(tx, orgID, factoryID)
+		if err != nil {
+			return err
+		}
+		factory = loaded
+
+		previous := factory.OnboardingConfigValue()
+		if _, err := factory.OnboardingConfigAfter(models.FactoryOnboardingPatch{AppRepository: &repository}); err != nil {
+			return err
+		}
+		if previous.VCSIntegrationID == "" {
+			return invalidArgument("connect GitHub before selecting a repository")
+		}
+		integration, err := findReadyOnboardingIntegration(tx, orgID, previous.VCSIntegrationID)
+		if err != nil {
+			return err
+		}
+		if integration.AppName != "github" {
+			return invalidArgument("repository settings currently require a GitHub integration")
+		}
+
+		previousBranch := previous.DefaultBranch
+		if previousBranch == "" {
+			previousBranch = defaultFactoryRepositoryBranch
+		}
+		if err := factory.SnapshotActiveWorkOrderRepository(tx, previous.AppRepository, previousBranch); err != nil {
+			return err
+		}
+
+		patch := models.FactoryOnboardingPatch{
+			AppRepository:     &repository,
+			BacklogRepository: &repository,
+			DefaultBranch:     &defaultBranch,
+		}
+		if err := factory.UpdateOnboarding(tx, patch); err != nil {
+			return err
+		}
+
+		return reconcileFactoryRepository(ctx, tx, deps, factory, actorID, previous.AppRepository, previousBranch, repository)
+	})
+	if err != nil {
+		if _, _, ok := grpcerrors.HandlerStatus(err); ok {
+			return nil, err
+		}
+		return nil, factoryErrorToStatus(err, "failed to update factory repository")
+	}
+
+	lines, err := factory.ListLines(db)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory repository")
+	}
+	serialized, err := serializeFactoryWithLineMetrics(db, factory, lines)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory repository")
+	}
+	return &pb.UpdateFactoryRepositoryResponse{Factory: serialized}, nil
+}
+
+func reconcileFactoryRepository(
+	ctx context.Context,
+	tx *gorm.DB,
+	deps IntakeDependencies,
+	factory *models.Factory,
+	actorID uuid.UUID,
+	previousRepository, previousBranch, repository string,
+) error {
+	canvasesForFactory, err := factory.ListCanvases(tx)
+	if err != nil {
+		return err
+	}
+	intakes, err := factory.ListIntakes(tx)
+	if err != nil {
+		return err
+	}
+	handlers, err := factory.ListPRFeedbackHandlers(tx)
+	if err != nil {
+		return err
+	}
+
+	intakeCanvasIDs := make(map[uuid.UUID]struct{}, len(intakes))
+	for _, intake := range intakes {
+		if intake.Source == models.FactoryIntakeSourceGitHubIssues {
+			intakeCanvasIDs[intake.CanvasID] = struct{}{}
+		}
+	}
+	handlerCanvasIDs := make(map[uuid.UUID]struct{}, len(handlers))
+	for _, handler := range handlers {
+		handlerCanvasIDs[handler.CanvasID] = struct{}{}
+	}
+
+	for i := range canvasesForFactory {
+		canvas := &canvasesForFactory[i]
+		liveVersion, err := models.FindLiveCanvasVersionByCanvasInTransaction(tx, canvas)
+		if err != nil {
+			return err
+		}
+		nodes := slices.Clone(liveVersion.Nodes)
+		changed := false
+
+		if template, ok := resolveFactoryTemplate(nodes); ok {
+			switch template.id {
+			case "line-planning", "line-implementation":
+				changed = replaceNodeConfigurationStrings(nodes, map[string]string{
+					previousRepository: "{{ order().repository }}",
+					previousBranch:     "{{ order().default_branch }}",
+				}) || changed
+			case "pr-closure", "issue-intake":
+				changed = replaceNodeConfigurationStrings(nodes, map[string]string{previousRepository: repository}) || changed
+			}
+		}
+		if _, ok := intakeCanvasIDs[canvas.ID]; ok {
+			changed = replaceTriggerRepository(nodes, "github.onIssue", previousRepository, repository) || changed
+		}
+		if _, ok := handlerCanvasIDs[canvas.ID]; ok {
+			changed = replaceGitHubTriggerRepository(nodes, previousRepository, repository) || changed
+		}
+		if !changed {
+			continue
+		}
+
+		if err := canvases.PublishGeneratedCanvasNodes(
+			ctx,
+			tx,
+			canvas,
+			actorID,
+			"Update workspace repository",
+			nodes,
+			slices.Clone(liveVersion.Edges),
+			changesets.CanvasPublisherOptions{
+				Registry:       deps.Registry,
+				OrgID:          canvas.OrganizationID,
+				Encryptor:      deps.Encryptor,
+				AuthService:    deps.AuthService,
+				WebhookBaseURL: deps.WebhookBaseURL,
+				GitProvider:    deps.GitProvider,
+			},
+		); err != nil {
+			return fmt.Errorf("publish %q repository update: %w", canvas.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func replaceTriggerRepository(nodes []models.Node, component, previousRepository, repository string) bool {
+	changed := false
+	for i := range nodes {
+		if nodes[i].ComponentName() != component {
+			continue
+		}
+		configuration, nodeChanged := replaceConfigurationStrings(nodes[i].Configuration, map[string]string{previousRepository: repository})
+		if !nodeChanged {
+			continue
+		}
+		nodes[i].Configuration = configuration.(map[string]any)
+		changed = true
+	}
+	return changed
+}
+
+func replaceGitHubTriggerRepository(nodes []models.Node, previousRepository, repository string) bool {
+	changed := false
+	for i := range nodes {
+		if !strings.HasPrefix(nodes[i].ComponentName(), "github.on") {
+			continue
+		}
+		configuration, nodeChanged := replaceConfigurationStrings(nodes[i].Configuration, map[string]string{previousRepository: repository})
+		if !nodeChanged {
+			continue
+		}
+		nodes[i].Configuration = configuration.(map[string]any)
+		changed = true
+	}
+	return changed
+}
+
+func replaceNodeConfigurationStrings(nodes []models.Node, replacements map[string]string) bool {
+	changed := false
+	for i := range nodes {
+		configuration, nodeChanged := replaceConfigurationStrings(nodes[i].Configuration, replacements)
+		if !nodeChanged {
+			continue
+		}
+		nodes[i].Configuration = configuration.(map[string]any)
+		changed = true
+	}
+	return changed
+}
+
+func replaceConfigurationStrings(value any, replacements map[string]string) (any, bool) {
+	switch current := value.(type) {
+	case map[string]any:
+		cloned := maps.Clone(current)
+		changed := false
+		for key, child := range cloned {
+			next, childChanged := replaceConfigurationStrings(child, replacements)
+			cloned[key] = next
+			changed = changed || childChanged
+		}
+		return cloned, changed
+	case []any:
+		cloned := slices.Clone(current)
+		changed := false
+		for i, child := range cloned {
+			next, childChanged := replaceConfigurationStrings(child, replacements)
+			cloned[i] = next
+			changed = changed || childChanged
+		}
+		return cloned, changed
+	case string:
+		next := current
+		for previous, replacement := range replacements {
+			if previous != "" {
+				next = strings.ReplaceAll(next, previous, replacement)
+			}
+		}
+		return next, next != current
+	default:
+		return value, false
+	}
+}

--- a/pkg/grpc/actions/factories/update_factory_repository_test.go
+++ b/pkg/grpc/actions/factories/update_factory_repository_test.go
@@ -7,24 +7,26 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 )
 
-func TestReplaceConfigurationStrings(t *testing.T) {
+func TestReplaceConfigurationValues(t *testing.T) {
 	configuration := map[string]any{
 		"repository": "acme/old",
 		"environment": []any{
 			map[string]any{"name": "REPO", "value": "acme/old"},
 			map[string]any{"name": "BASE", "value": "main"},
 		},
+		"command": "git clone --branch ${BASE:-main} https://github.com/acme/main-service.git",
 	}
 
-	replaced, changed := replaceConfigurationStrings(configuration, map[string]string{
-		"acme/old": "{{ order().repository }}",
-		"main":     "{{ order().default_branch }}",
+	replaced, changed := replaceConfigurationValues(configuration, []configurationReplacement{
+		{from: "acme/old", to: "{{ order().repository }}"},
+		{from: "main", to: "{{ order().default_branch }}"},
 	})
 
 	assert.True(t, changed)
 	assert.Equal(t, "acme/old", configuration["repository"])
 	assert.Equal(t, "{{ order().repository }}", replaced.(map[string]any)["repository"])
 	assert.Equal(t, "{{ order().default_branch }}", replaced.(map[string]any)["environment"].([]any)[1].(map[string]any)["value"])
+	assert.Equal(t, configuration["command"], replaced.(map[string]any)["command"])
 }
 
 func TestReplaceTriggerRepository(t *testing.T) {

--- a/pkg/grpc/actions/factories/update_factory_repository_test.go
+++ b/pkg/grpc/actions/factories/update_factory_repository_test.go
@@ -41,3 +41,25 @@ func TestReplaceTriggerRepository(t *testing.T) {
 	assert.Equal(t, "acme/new", nodes[0].Configuration["repository"])
 	assert.Equal(t, "acme/custom", nodes[1].Configuration["repository"])
 }
+
+func TestFactoryDefaultBranchFromNodes(t *testing.T) {
+	nodes := []models.Node{
+		{
+			Configuration: map[string]any{
+				"environment": []any{
+					map[string]any{"name": "BASE", "value": "develop"},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "develop", factoryDefaultBranchFromNodes(nodes))
+}
+
+func TestFactoryDefaultBranchFromNodesIgnoresExpressions(t *testing.T) {
+	nodes := []models.Node{
+		{Configuration: map[string]any{"base": orderDefaultBranchExpression}},
+	}
+
+	assert.Empty(t, factoryDefaultBranchFromNodes(nodes))
+}

--- a/pkg/grpc/actions/factories/update_factory_repository_test.go
+++ b/pkg/grpc/actions/factories/update_factory_repository_test.go
@@ -1,0 +1,41 @@
+package factories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func TestReplaceConfigurationStrings(t *testing.T) {
+	configuration := map[string]any{
+		"repository": "acme/old",
+		"environment": []any{
+			map[string]any{"name": "REPO", "value": "acme/old"},
+			map[string]any{"name": "BASE", "value": "main"},
+		},
+	}
+
+	replaced, changed := replaceConfigurationStrings(configuration, map[string]string{
+		"acme/old": "{{ order().repository }}",
+		"main":     "{{ order().default_branch }}",
+	})
+
+	assert.True(t, changed)
+	assert.Equal(t, "acme/old", configuration["repository"])
+	assert.Equal(t, "{{ order().repository }}", replaced.(map[string]any)["repository"])
+	assert.Equal(t, "{{ order().default_branch }}", replaced.(map[string]any)["environment"].([]any)[1].(map[string]any)["value"])
+}
+
+func TestReplaceTriggerRepository(t *testing.T) {
+	nodes := []models.Node{
+		{Ref: models.NodeRef{Trigger: &models.TriggerRef{Name: "github.onIssue"}}, Configuration: map[string]any{"repository": "acme/old"}},
+		{Ref: models.NodeRef{Trigger: &models.TriggerRef{Name: "github.onIssue"}}, Configuration: map[string]any{"repository": "acme/custom"}},
+	}
+
+	changed := replaceTriggerRepository(nodes, "github.onIssue", "acme/old", "acme/new")
+
+	assert.True(t, changed)
+	assert.Equal(t, "acme/new", nodes[0].Configuration["repository"])
+	assert.Equal(t, "acme/custom", nodes[1].Configuration["repository"])
+}

--- a/pkg/grpc/factory_service.go
+++ b/pkg/grpc/factory_service.go
@@ -67,6 +67,11 @@ func (s *FactoryService) UpdateFactoryOnboarding(ctx context.Context, req *pb.Up
 	return actions.UpdateFactoryOnboarding(ctx, organizationID, req)
 }
 
+func (s *FactoryService) UpdateFactoryRepository(ctx context.Context, req *pb.UpdateFactoryRepositoryRequest) (*pb.UpdateFactoryRepositoryResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return actions.UpdateFactoryRepository(ctx, s.intakeDeps, organizationID, req)
+}
+
 func (s *FactoryService) DeleteFactory(ctx context.Context, req *pb.DeleteFactoryRequest) (*pb.DeleteFactoryResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 	return actions.DeleteFactory(ctx, organizationID, req.GetId())

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -505,17 +505,17 @@ func (f *Factory) CreateWorkOrder(tx *gorm.DB, title, description string, create
 	return f.createWorkOrder(tx, title, description, createdBy, assignees, sourceRunID, nil)
 }
 
-// SnapshotActiveWorkOrderRepository records the current repository on active
-// work orders before a workspace switches repositories. A nil snapshot is a
-// legacy row, so preserve an existing value from an earlier switch.
-func (f *Factory) SnapshotActiveWorkOrderRepository(tx *gorm.DB, repository, defaultBranch string) error {
+// SnapshotWorkOrderRepository records the current repository before a
+// workspace switches repositories. A nil snapshot is a legacy row, so
+// preserve an existing value from an earlier switch.
+func (f *Factory) SnapshotWorkOrderRepository(tx *gorm.DB, repository, defaultBranch string) error {
 	updates := map[string]any{
 		"repository":     gorm.Expr("COALESCE(repository, ?)", repository),
 		"default_branch": gorm.Expr("COALESCE(default_branch, ?)", defaultBranch),
 	}
 
 	return tx.Model(&FactoryWorkOrder{}).
-		Where("factory_id = ? AND state IN ?", f.ID, []string{FactoryWorkOrderStateDraft, FactoryWorkOrderStateOpen}).
+		Where("factory_id = ?", f.ID).
 		Updates(updates).
 		Error
 }
@@ -570,10 +570,8 @@ func (f *Factory) createWorkOrder(
 		UpdatedAt:      now,
 	}
 	config := f.OnboardingConfigValue()
-	if config.AppRepository != "" {
+	if config.AppRepository != "" && config.DefaultBranch != "" {
 		order.Repository = &config.AppRepository
-	}
-	if config.DefaultBranch != "" {
 		order.DefaultBranch = &config.DefaultBranch
 	}
 	applyWorkOrderOrigin(order, origin)

--- a/pkg/models/factory.go
+++ b/pkg/models/factory.go
@@ -505,6 +505,21 @@ func (f *Factory) CreateWorkOrder(tx *gorm.DB, title, description string, create
 	return f.createWorkOrder(tx, title, description, createdBy, assignees, sourceRunID, nil)
 }
 
+// SnapshotActiveWorkOrderRepository records the current repository on active
+// work orders before a workspace switches repositories. A nil snapshot is a
+// legacy row, so preserve an existing value from an earlier switch.
+func (f *Factory) SnapshotActiveWorkOrderRepository(tx *gorm.DB, repository, defaultBranch string) error {
+	updates := map[string]any{
+		"repository":     gorm.Expr("COALESCE(repository, ?)", repository),
+		"default_branch": gorm.Expr("COALESCE(default_branch, ?)", defaultBranch),
+	}
+
+	return tx.Model(&FactoryWorkOrder{}).
+		Where("factory_id = ? AND state IN ?", f.ID, []string{FactoryWorkOrderStateDraft, FactoryWorkOrderStateOpen}).
+		Updates(updates).
+		Error
+}
+
 func (f *Factory) CreateWorkOrderWithOrigin(
 	tx *gorm.DB,
 	title, description string,
@@ -553,6 +568,13 @@ func (f *Factory) createWorkOrder(
 		SourceRunID:    sourceRunID,
 		CreatedAt:      now,
 		UpdatedAt:      now,
+	}
+	config := f.OnboardingConfigValue()
+	if config.AppRepository != "" {
+		order.Repository = &config.AppRepository
+	}
+	if config.DefaultBranch != "" {
+		order.DefaultBranch = &config.DefaultBranch
 	}
 	applyWorkOrderOrigin(order, origin)
 

--- a/pkg/models/factory_onboarding.go
+++ b/pkg/models/factory_onboarding.go
@@ -49,6 +49,7 @@ type FactoryOnboardingConfig struct {
 	AgentIntegrationID string `json:"agent_integration_id,omitempty"`
 	AppRepository      string `json:"app_repository,omitempty"`
 	BacklogRepository  string `json:"backlog_repository,omitempty"`
+	DefaultBranch      string `json:"default_branch,omitempty"`
 	IssuesSource       string `json:"issues_source,omitempty"`
 	AgentHarness       string `json:"agent_harness,omitempty"`
 	ProvisionedAppID   string `json:"provisioned_app_id,omitempty"`
@@ -64,6 +65,7 @@ type FactoryOnboardingPatch struct {
 	AgentIntegrationID *string
 	AppRepository      *string
 	BacklogRepository  *string
+	DefaultBranch      *string
 	IssuesSource       *string
 	AgentHarness       *string
 	ProvisionedAppID   *string
@@ -195,6 +197,9 @@ func mergeFactoryOnboardingConfig(current FactoryOnboardingConfig, patch Factory
 			return FactoryOnboardingConfig{}, err
 		}
 		next.BacklogRepository = value
+	}
+	if patch.DefaultBranch != nil {
+		next.DefaultBranch = strings.TrimSpace(*patch.DefaultBranch)
 	}
 	if patch.IssuesSource != nil {
 		value := strings.TrimSpace(*patch.IssuesSource)

--- a/pkg/models/factory_onboarding_test.go
+++ b/pkg/models/factory_onboarding_test.go
@@ -45,9 +45,11 @@ func Test__FactoryOnboarding(t *testing.T) {
 		assert.Equal(t, "acme/api", factory.OnboardingConfigValue().AppRepository)
 
 		backlogRepo := "acme/backlog"
+		defaultBranch := "main"
 		issuesSource := models.FactoryOnboardingIssuesSourceVCS
 		require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
 			BacklogRepository: &backlogRepo,
+			DefaultBranch:     &defaultBranch,
 			IssuesSource:      &issuesSource,
 		}))
 
@@ -55,6 +57,7 @@ func Test__FactoryOnboarding(t *testing.T) {
 		assert.Equal(t, vcsID, config.VCSIntegrationID)
 		assert.Equal(t, "acme/api", config.AppRepository)
 		assert.Equal(t, "acme/backlog", config.BacklogRepository)
+		assert.Equal(t, "main", config.DefaultBranch)
 		assert.Equal(t, models.FactoryOnboardingIssuesSourceVCS, config.IssuesSource)
 	})
 

--- a/pkg/models/factory_work_order.go
+++ b/pkg/models/factory_work_order.go
@@ -72,6 +72,8 @@ type FactoryWorkOrder struct {
 	SourceRunID    *uuid.UUID
 	OriginURL      *string
 	OriginLabel    *string
+	Repository     *string
+	DefaultBranch  *string
 	// StatusNote is the jsonb array of current-wait announcements (see
 	// FactoryWorkOrderStatusNote). Cleared on every state transition.
 	StatusNote datatypes.JSON

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -1203,12 +1203,10 @@ func (b *NodeConfigurationBuilder) resolveOrderRepository(order *models.FactoryW
 		return "", "", fmt.Errorf("order() could not resolve the workspace: %w", err)
 	}
 	config := factory.OnboardingConfigValue()
-	if repository == "" {
-		repository = config.AppRepository
-	}
-	if defaultBranch == "" {
-		defaultBranch = config.DefaultBranch
-	}
+	// Repository and branch are one snapshot. Do not combine a saved value
+	// with current workspace settings when a legacy row contains only one.
+	repository = config.AppRepository
+	defaultBranch = config.DefaultBranch
 	if defaultBranch == "" {
 		defaultBranch = "main"
 	}

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -1074,6 +1074,10 @@ func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, 
 	if err != nil {
 		return nil, fmt.Errorf("order() could not resolve the work order: %w", err)
 	}
+	repository, defaultBranch, err := b.resolveOrderRepository(order)
+	if err != nil {
+		return nil, err
+	}
 
 	payload := map[string]any{
 		"id":             order.ID.String(),
@@ -1082,8 +1086,8 @@ func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, 
 		"factory_id":     order.FactoryID.String(),
 		"state":          order.State,
 		"result":         order.Result,
-		"repository":     stringValue(order.Repository),
-		"default_branch": stringValue(order.DefaultBranch),
+		"repository":     repository,
+		"default_branch": defaultBranch,
 	}
 
 	if err := attachOrderSource(b.tx, order, payload); err != nil {
@@ -1183,6 +1187,33 @@ func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, 
 	}
 
 	return payload, nil
+}
+
+// resolveOrderRepository keeps orders created before repository snapshots
+// compatible with workflow templates that use order().repository.
+func (b *NodeConfigurationBuilder) resolveOrderRepository(order *models.FactoryWorkOrder) (string, string, error) {
+	repository := stringValue(order.Repository)
+	defaultBranch := stringValue(order.DefaultBranch)
+	if repository != "" && defaultBranch != "" {
+		return repository, defaultBranch, nil
+	}
+
+	factory, err := models.FindFactory(b.tx, order.OrganizationID, order.FactoryID)
+	if err != nil {
+		return "", "", fmt.Errorf("order() could not resolve the workspace: %w", err)
+	}
+	config := factory.OnboardingConfigValue()
+	if repository == "" {
+		repository = config.AppRepository
+	}
+	if defaultBranch == "" {
+		defaultBranch = config.DefaultBranch
+	}
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+
+	return repository, defaultBranch, nil
 }
 
 func attachOrderSource(tx *gorm.DB, order *models.FactoryWorkOrder, payload map[string]any) error {

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -515,6 +515,13 @@ func (b *NodeConfigurationBuilder) ResolveExpressionWithExtraVariables(expressio
 
 			return b.resolveOrderPayload(expression)
 		}),
+		expr.Function("workspace", func(params ...any) (any, error) {
+			if len(params) != 0 {
+				return nil, fmt.Errorf("workspace() takes no arguments")
+			}
+
+			return b.resolveWorkspacePayload()
+		}),
 	}
 
 	vm, err := expr.Compile(expression, exprOptions...)
@@ -981,6 +988,33 @@ func (b *NodeConfigurationBuilder) resolveAppPayload() (any, error) {
 	}, nil
 }
 
+// resolveWorkspacePayload exposes the factory workspace that owns this app.
+// It is intentionally unavailable for organization apps so expressions cannot
+// infer a workspace outside their execution scope.
+func (b *NodeConfigurationBuilder) resolveWorkspacePayload() (any, error) {
+	canvas, err := models.FindCanvasWithoutOrgScopeInTransaction(b.tx, b.workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("workspace() could not resolve the current app: %w", err)
+	}
+	if canvas.FactoryID == nil {
+		return nil, fmt.Errorf("workspace() is only available in factory apps")
+	}
+
+	factory, err := models.FindFactory(b.tx, canvas.OrganizationID, *canvas.FactoryID)
+	if err != nil {
+		return nil, fmt.Errorf("workspace() could not resolve the current workspace: %w", err)
+	}
+	config := factory.OnboardingConfigValue()
+	return map[string]any{
+		"id":                 factory.ID.String(),
+		"key":                factory.Key,
+		"name":               factory.Name,
+		"repository":         config.AppRepository,
+		"backlog_repository": config.BacklogRepository,
+		"default_branch":     config.DefaultBranch,
+	}, nil
+}
+
 // resolveRunPayload exposes the current run to expressions via run().
 // It returns id, url, and started_at (a time.Time) for the run that the
 // current node belongs to, resolved from the builder's root event.
@@ -1042,12 +1076,14 @@ func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, 
 	}
 
 	payload := map[string]any{
-		"id":          order.ID.String(),
-		"title":       order.Title,
-		"description": order.Description,
-		"factory_id":  order.FactoryID.String(),
-		"state":       order.State,
-		"result":      order.Result,
+		"id":             order.ID.String(),
+		"title":          order.Title,
+		"description":    order.Description,
+		"factory_id":     order.FactoryID.String(),
+		"state":          order.State,
+		"result":         order.Result,
+		"repository":     stringValue(order.Repository),
+		"default_branch": stringValue(order.DefaultBranch),
 	}
 
 	if err := attachOrderSource(b.tx, order, payload); err != nil {
@@ -1427,20 +1463,28 @@ func (b *NodeConfigurationBuilder) populateFromExecutions(
 }
 
 var reservedExpressionIdentifiers = map[string]struct{}{
-	"$":        {},
-	"memory":   {},
-	"config":   {},
-	"root":     {},
-	"previous": {},
-	"run":      {},
-	"app":      {},
-	"order":    {},
-	"ctx":      {},
+	"$":         {},
+	"memory":    {},
+	"config":    {},
+	"root":      {},
+	"previous":  {},
+	"run":       {},
+	"app":       {},
+	"order":     {},
+	"workspace": {},
+	"ctx":       {},
 }
 
 func isReservedExpressionIdentifier(name string) bool {
 	_, ok := reservedExpressionIdentifiers[name]
 	return ok
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 func parseDepth(param any) (int, error) {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -206,12 +206,47 @@ func Test_NodeConfigurationBuilder_AppFunction(t *testing.T) {
 	})
 }
 
+func Test_NodeConfigurationBuilder_WorkspaceFunction(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	factoryModel, err := models.CreateFactory(database.Conn(), r.Organization.ID, support.RandomName("factory"), "", "WK")
+	require.NoError(t, err)
+	repository := "acme/service"
+	defaultBranch := "develop"
+	require.NoError(t, factoryModel.UpdateOnboarding(database.Conn(), models.FactoryOnboardingPatch{
+		AppRepository:     &repository,
+		BacklogRepository: &repository,
+		DefaultBranch:     &defaultBranch,
+	}))
+	canvas := support.CreateFactoryCanvas(t, r, factoryModel.ID, "Workspace app")
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).WithInput(map[string]any{})
+	value, err := builder.ResolveExpression(`workspace()`)
+	require.NoError(t, err)
+	payload, ok := value.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, factoryModel.ID.String(), payload["id"])
+	assert.Equal(t, "WK", payload["key"])
+	assert.Equal(t, repository, payload["repository"])
+	assert.Equal(t, defaultBranch, payload["default_branch"])
+
+	_, err = builder.ResolveExpression(`workspace(1)`)
+	require.ErrorContains(t, err, "workspace() takes no arguments")
+}
+
 func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
 
 	factoryModel, err := models.CreateFactory(database.Conn(), r.Organization.ID, support.RandomName("factory"), "", "")
 	require.NoError(t, err)
+	repository := "acme/service"
+	defaultBranch := "main"
+	require.NoError(t, factoryModel.UpdateOnboarding(database.Conn(), models.FactoryOnboardingPatch{
+		AppRepository: &repository,
+		DefaultBranch: &defaultBranch,
+	}))
 
 	sourceCanvas, _ := support.CreateCanvas(
 		t,
@@ -310,6 +345,8 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		assert.Equal(t, factoryModel.ID.String(), payload["factory_id"])
 		assert.Equal(t, models.FactoryWorkOrderStateDraft, payload["state"])
 		assert.Equal(t, "", payload["result"])
+		assert.Equal(t, repository, payload["repository"])
+		assert.Equal(t, defaultBranch, payload["default_branch"])
 		assert.NotContains(t, payload, "url")
 		assert.NotContains(t, payload, "artifacts")
 		assert.NotContains(t, payload, "comments")

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -373,6 +373,26 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		assert.Equal(t, defaultBranch, payload["default_branch"])
 	})
 
+	t.Run("uses workspace values for partial work order snapshots", func(t *testing.T) {
+		currentRepository := "acme/current-service"
+		currentDefaultBranch := "develop"
+		require.NoError(t, factoryModel.UpdateOnboarding(database.Conn(), models.FactoryOnboardingPatch{
+			AppRepository: &currentRepository,
+			DefaultBranch: &currentDefaultBranch,
+		}))
+		require.NoError(t, database.Conn().Model(order).Updates(map[string]any{
+			"repository":     "acme/previous-service",
+			"default_branch": nil,
+		}).Error)
+
+		result, err := builder.ResolveExpression(`order()`)
+		require.NoError(t, err)
+		payload, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, currentRepository, payload["repository"])
+		assert.Equal(t, currentDefaultBranch, payload["default_branch"])
+	})
+
 	t.Run("field access and templates", func(t *testing.T) {
 		id, err := builder.ResolveExpression(`order().id`)
 		require.NoError(t, err)

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -245,7 +245,6 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 	defaultBranch := "main"
 	require.NoError(t, factoryModel.UpdateOnboarding(database.Conn(), models.FactoryOnboardingPatch{
 		AppRepository: &repository,
-		DefaultBranch: &defaultBranch,
 	}))
 
 	sourceCanvas, _ := support.CreateCanvas(
@@ -358,6 +357,20 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, float64(42), issue["number"])
 		assert.Equal(t, "Fix login", issue["title"])
+	})
+
+	t.Run("uses workspace values for legacy work orders", func(t *testing.T) {
+		require.NoError(t, database.Conn().Model(order).Updates(map[string]any{
+			"repository":     nil,
+			"default_branch": nil,
+		}).Error)
+
+		result, err := builder.ResolveExpression(`order()`)
+		require.NoError(t, err)
+		payload, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, repository, payload["repository"])
+		assert.Equal(t, defaultBranch, payload["default_branch"])
 	})
 
 	t.Run("field access and templates", func(t *testing.T) {

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -85,6 +85,18 @@ service Factories {
     };
   }
 
+  rpc UpdateFactoryRepository(UpdateFactoryRepositoryRequest) returns (UpdateFactoryRepositoryResponse) {
+    option (google.api.http) = {
+      patch: "/api/v1/factories/{id}/repository"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Update factory repository";
+      description: "Updates the repository used by a factory workspace";
+      tags: "Factory";
+    };
+  }
+
   rpc DeleteFactory(DeleteFactoryRequest) returns (DeleteFactoryResponse) {
     option (google.api.http) = {
       delete: "/api/v1/factories/{id}"
@@ -614,9 +626,23 @@ message UpdateFactoryOnboardingRequest {
   optional string provisioned_line_id = 9;
   // When true, validate readiness and set onboarding_completed_at.
   optional bool complete = 10;
+  // Default branch of the app repository.
+  optional string default_branch = 11;
 }
 
 message UpdateFactoryOnboardingResponse {
+  Factory factory = 1;
+}
+
+message UpdateFactoryRepositoryRequest {
+  string id = 1;
+  // Repository slug in owner/name form.
+  string repository = 2;
+  // Default branch resolved from the selected repository.
+  string default_branch = 3;
+}
+
+message UpdateFactoryRepositoryResponse {
   Factory factory = 1;
 }
 
@@ -652,6 +678,7 @@ message FactoryOnboarding {
   AgentHarness agent_harness = 7;
   string provisioned_app_id = 8;
   string provisioned_line_id = 9;
+  string default_branch = 10;
 }
 
 message Factory {

--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -1,6 +1,5 @@
 import { TooltipProvider } from "@/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Blocks } from "lucide-react";
 import React, { useEffect } from "react";
 import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation, useParams } from "react-router";
 import { appPath, appSettingsPath } from "./lib/appPaths";
@@ -40,7 +39,7 @@ import {
   FactorySettingsLayout,
   FactorySettingsNotificationsPage,
   FactorySettingsProfilePage,
-  FactorySettingsSoonPage,
+  FactorySettingsRepositoryPage,
   FactorySettingsUsagePage,
   FactorySettingsModelsPage,
   OrganizationSettingsOverviewPage,
@@ -306,9 +305,7 @@ const factorySettingsSectionRoutes = [
   <Route
     key="factory-settings-workspace-repository"
     path="workspace/repository"
-    element={
-      <FactorySettingsSoonPage title="Repository" description="Repository settings for this workspace." Icon={Blocks} />
-    }
+    element={<FactorySettingsRepositoryPage />}
   />,
   <Route
     key="factory-settings-workspace-automations"

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -117,6 +117,12 @@ export const EXPR_FUNCTIONS: readonly ExprFunction[] = [
       "Returns the task for this run when dispatched from a factory, exposing id, title, description, factory_id, state, result, source, url, artifacts, and comments (the last three loaded when accessed).",
     example: 'none(order().artifacts, {#.type == "pr"})',
   },
+  {
+    name: "workspace",
+    snippet: "workspace().",
+    description: "Returns the factory workspace, including its repository and default branch.",
+    example: "workspace().repository",
+  },
   // String
   {
     name: "trim",
@@ -1482,6 +1488,11 @@ function normalizeSpecialFunctionExpr(expr: string): string | null {
   const orderMatch = expr.match(/^order\(\)/);
   if (orderMatch) {
     return `__order${expr.slice(orderMatch[0].length)}`;
+  }
+
+  const workspaceMatch = expr.match(/^workspace\(\)/);
+  if (workspaceMatch) {
+    return `__workspace${expr.slice(workspaceMatch[0].length)}`;
   }
 
   return expr;

--- a/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
+++ b/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Blocks } from "lucide-react";
 import { useContext, useEffect, useState, type ComponentType, type ReactNode } from "react";
 import { MemoryRouter, Navigate, Outlet, Route, Routes, useParams } from "react-router";
 
@@ -31,7 +30,7 @@ import {
   FactorySettingsLayout,
   FactorySettingsNotificationsPage,
   FactorySettingsProfilePage,
-  FactorySettingsSoonPage,
+  FactorySettingsRepositoryPage,
   FactorySettingsUsagePage,
   FactorySettingsModelsPage,
   LegacyWorkOrderDetailRedirect,
@@ -249,9 +248,7 @@ const factorySettingsStorybookRoutes = [
   <Route
     key="factory-settings-workspace-repository"
     path="workspace/repository"
-    element={
-      <FactorySettingsSoonPage title="Repository" description="Repository settings for this workspace." Icon={Blocks} />
-    }
+    element={<FactorySettingsRepositoryPage />}
   />,
   <Route
     key="factory-settings-workspace-automations"

--- a/web_src/src/pages/app/buildAutocompleteExampleObj.spec.ts
+++ b/web_src/src/pages/app/buildAutocompleteExampleObj.spec.ts
@@ -69,6 +69,12 @@ describe("buildAutocompleteExampleObj", () => {
         artifacts: expect.any(Array),
         comments: expect.any(Array),
       }),
+      __workspace: expect.objectContaining({
+        id: expect.any(String),
+        name: "Example workspace",
+        repository: "acme/service",
+        default_branch: "main",
+      }),
     });
     expect(
       evaluateExpr(
@@ -126,6 +132,12 @@ describe("buildAutocompleteExampleObj", () => {
         title: "Ship feature",
         artifacts: expect.any(Array),
         comments: expect.any(Array),
+      }),
+      __workspace: expect.objectContaining({
+        id: expect.any(String),
+        name: "Example workspace",
+        repository: "acme/service",
+        default_branch: "main",
       }),
     });
     expect(evaluateExpr("root().data.check_run.name", autocompleteContext!)).toBe("Unit tests");

--- a/web_src/src/pages/app/buildAutocompleteExampleObj.ts
+++ b/web_src/src/pages/app/buildAutocompleteExampleObj.ts
@@ -105,6 +105,8 @@ function buildOrderExample(): Record<string, unknown> {
     factory_id: EXAMPLE_FACTORY_ID,
     state: "open",
     result: "",
+    repository: "acme/service",
+    default_branch: "main",
     url: exampleOrderUrl(),
     source: {
       issue: { number: 42, title: "Fix login" },
@@ -124,6 +126,17 @@ function buildOrderExample(): Record<string, unknown> {
         created_at: "2024-01-01T00:00:00Z",
       },
     ],
+  };
+}
+
+function buildWorkspaceExample(): Record<string, unknown> {
+  return {
+    id: EXAMPLE_FACTORY_ID,
+    key: "SP",
+    name: "Example workspace",
+    repository: "acme/service",
+    backlog_repository: "acme/service",
+    default_branch: "main",
   };
 }
 
@@ -300,6 +313,7 @@ type BuildNamedExampleObjInput = {
   appExample: Record<string, unknown>;
   runExample: Record<string, unknown>;
   orderExample: Record<string, unknown>;
+  workspaceExample: Record<string, unknown>;
 };
 
 function buildNamedExampleObj({
@@ -314,6 +328,7 @@ function buildNamedExampleObj({
   appExample,
   runExample,
   orderExample,
+  workspaceExample,
 }: BuildNamedExampleObjInput): Record<string, unknown> | null {
   const rootNodeId = canvasNodes.find((node) => {
     if (!node.id || !chainNodeIds.has(node.id)) return false;
@@ -364,6 +379,7 @@ function buildNamedExampleObj({
   namedExampleObj.__app = appExample;
   namedExampleObj.__run = runExample;
   namedExampleObj.__order = orderExample;
+  namedExampleObj.__workspace = workspaceExample;
 
   const currentNodeName = currentNode?.name?.trim();
   const currentNodeId = currentNode?.id;
@@ -417,6 +433,7 @@ export function buildAutocompleteExampleObj(
     appExample: buildAppExample(context.app),
     runExample: buildRunExample(),
     orderExample: buildOrderExample(),
+    workspaceExample: buildWorkspaceExample(),
     canvasNodes: context.canvasNodes,
     incomingNodeIdsByTargetId: context.incomingNodeIdsByTargetId,
   });

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -230,12 +230,31 @@ function mergedOnboarding(
   if (request.agentIntegrationId) next.agentIntegrationId = request.agentIntegrationId;
   if (request.appRepository) next.appRepository = request.appRepository;
   if (request.backlogRepository) next.backlogRepository = request.backlogRepository;
+  if (request.defaultBranch) next.defaultBranch = request.defaultBranch;
   if (request.issuesSource) next.issuesSource = request.issuesSource;
   if (request.agentHarness) next.agentHarness = request.agentHarness;
   if (request.provisionedAppId) next.provisionedAppId = request.provisionedAppId;
   if (request.provisionedLineId) next.provisionedLineId = request.provisionedLineId;
   if (request.complete) next.completedAt = new Date().toISOString();
   return next;
+}
+
+function factoryRepositoryRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/factories/([^/]+)/repository"),
+    resolve: (match, method, body) => {
+      if (method !== "PATCH") return null;
+      const factory = fixture.factories.find((entry) => entry.id === match[1]);
+      if (!factory) return { json: {} };
+      const request = (body ?? {}) as { repository?: string; defaultBranch?: string };
+      factory.onboarding = mergedOnboarding(factory.onboarding, {
+        appRepository: request.repository,
+        backlogRepository: request.repository,
+        defaultBranch: request.defaultBranch,
+      });
+      return { json: { factory: factoryWithLineMetrics(factory) } };
+    },
+  };
 }
 
 /** Persists workspace setup answers so setup stories advance step by step. */
@@ -663,6 +682,7 @@ function buildRoutes(fixture: FactoriesFixture): FactoriesRoute[] {
     notificationSettingsRoute(fixture),
     ...factoryDetailRoutes(fixture),
     factoryOnboardingRoute(fixture),
+    factoryRepositoryRoute(fixture),
     ...factoryLinesRoutes(fixture),
     ...factoryPullRequestRoutes(fixture),
     ...workOrderRoutes(fixture),

--- a/web_src/src/pages/factories/index.ts
+++ b/web_src/src/pages/factories/index.ts
@@ -13,6 +13,7 @@ export {
   FactorySettingsNotificationsPage,
   FactorySettingsProfilePage,
   FactorySettingsSoonPage,
+  FactorySettingsRepositoryPage,
   FactorySettingsUsagePage,
   FactorySettingsModelsPage,
   FACTORY_SETTINGS_NAV_GROUPS,

--- a/web_src/src/pages/factories/pages/index.ts
+++ b/web_src/src/pages/factories/pages/index.ts
@@ -22,6 +22,7 @@ export { FactorySettingsGeneralPage } from "./settings/FactorySettingsGeneralPag
 export { FactorySettingsNotificationsPage } from "./settings/FactorySettingsNotificationsPage";
 export { FactorySettingsProfilePage } from "./settings/FactorySettingsProfilePage";
 export { FactorySettingsSoonPage } from "./settings/FactorySettingsSoonPage";
+export { FactorySettingsRepositoryPage } from "./settings/FactorySettingsRepositoryPage";
 export { FactorySettingsUsagePage } from "./settings/FactorySettingsUsagePage";
 export { FactorySettingsModelsPage } from "./settings/FactorySettingsModelsPage";
 export { FACTORY_SETTINGS_NAV_GROUPS, FACTORY_SETTINGS_NAV_ITEMS } from "./settings/settingsNavItems";

--- a/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.ts
@@ -106,6 +106,7 @@ async function provisionWorkspace(args: {
   // master, staging, ...) instead of hardcoding "main", so Create Branch and
   // Create Pull Request target the branch GitHub actually treats as default.
   const defaultBranch = (await args.resolveDefaultBranch(args.appRepository)) || "main";
+  await args.updateOnboarding({ defaultBranch });
   const { lineId, primaryAppId } = await provisionLine({
     factory: args.factory,
     savedLineId: args.factory?.onboarding?.provisionedLineId,

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { client } from "@/api-client/client.gen";
@@ -25,12 +25,17 @@ describe("FactorySettingsRepositoryPage", () => {
     );
 
     const settings = await screen.findByTestId("factory-settings-repository", {}, { timeout: 8000 });
-    expect(within(settings).getByRole("option", { name: /acme\/api/i })).toHaveAttribute("aria-selected", "true");
+    expect(await within(settings).findByRole("option", { name: /acme\/api/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
 
     fireEvent.click(within(settings).getByRole("option", { name: /acme\/web/i }));
-    fireEvent.click(within(settings).getByTestId("factory-settings-repository-save"));
+    const saveButton = within(settings).getByTestId("factory-settings-repository-save");
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    fireEvent.click(saveButton);
 
-    expect(await screen.findByText("Workspace repository updated.")).toBeInTheDocument();
+    await waitFor(() => expect(saveButton).toBeDisabled());
     expect(within(settings).getByRole("option", { name: /acme\/web/i })).toHaveAttribute("aria-selected", "true");
   }, 10000);
 });

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.spec.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { client } from "@/api-client/client.gen";
+import { FactoriesHarness } from "../../__fixtures__/FactoriesHarness";
+import { PRIMARY_FACTORY_KEY } from "../../__fixtures__/factoryPageResponses";
+import {
+  CONNECTED_SETUP_INTEGRATIONS,
+  SETUP_ANSWERS,
+  factoriesFixtureWithSetupAnswers,
+} from "../../__fixtures__/setupStoryFixtures";
+
+describe("FactorySettingsRepositoryPage", () => {
+  beforeAll(() => {
+    client.setConfig({ baseUrl: "http://localhost" });
+  });
+
+  it("selects and saves the workspace repository", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/repository`}
+        factoriesFixture={factoriesFixtureWithSetupAnswers(SETUP_ANSWERS.agent)}
+        orgIntegrations={CONNECTED_SETUP_INTEGRATIONS}
+      />,
+    );
+
+    const settings = await screen.findByTestId("factory-settings-repository", {}, { timeout: 8000 });
+    expect(within(settings).getByRole("option", { name: /acme\/api/i })).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(within(settings).getByRole("option", { name: /acme\/web/i }));
+    fireEvent.click(within(settings).getByTestId("factory-settings-repository-save"));
+
+    expect(await screen.findByText("Workspace repository updated.")).toBeInTheDocument();
+    expect(within(settings).getByRole("option", { name: /acme\/web/i })).toHaveAttribute("aria-selected", "true");
+  }, 10000);
+});

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.tsx
@@ -1,0 +1,83 @@
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { usePermissions } from "@/contexts/usePermissions";
+import { useIntegrationResources, resolveGithubDefaultBranch } from "@/hooks/useIntegrations";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { RepositoryPicker } from "../onboarding/onboardingSteps";
+import { useEffect, useMemo, useState } from "react";
+
+import { FactorySettingsCard, FactorySettingsPageFrame } from "./FactorySettingsCard";
+import { useFactorySettingsLayout } from "./factorySettingsLayoutContext";
+import { useFactoryRepository } from "./useFactoryRepository";
+
+export function FactorySettingsRepositoryPage() {
+  const { organizationId, factoryId, factory } = useFactorySettingsLayout();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
+  const integrationId = factory.onboarding?.vcsIntegrationId ?? "";
+  const resources = useIntegrationResources(organizationId, integrationId, "repository");
+  const repositories = useMemo(
+    () =>
+      (resources.data ?? [])
+        .map((resource) => resource.name ?? resource.id ?? "")
+        .filter((repository): repository is string => Boolean(repository)),
+    [resources.data],
+  );
+  const [repository, setRepository] = useState(factory.onboarding?.appRepository ?? "");
+  const updateRepository = useFactoryRepository(organizationId, factoryId);
+  const canUpdate = canAct("factories", "update");
+
+  usePageTitle(["Repository", "Settings", factory.name ?? "Workspace"]);
+
+  useEffect(() => {
+    setRepository(factory.onboarding?.appRepository ?? "");
+  }, [factory.onboarding?.appRepository]);
+
+  const isDirty = repository !== (factory.onboarding?.appRepository ?? "");
+  const save = async () => {
+    if (!repository || !integrationId) return;
+    try {
+      const defaultBranch = await resolveGithubDefaultBranch(organizationId, integrationId, repository);
+      await updateRepository.mutateAsync({ repository, defaultBranch });
+      showSuccessToast("Workspace repository updated.");
+    } catch (error) {
+      showErrorToast(getApiErrorMessage(error, "Failed to update workspace repository"));
+    }
+  };
+
+  return (
+    <FactorySettingsPageFrame
+      title="Repository"
+      subtitle="Select the GitHub repository for workspace work and issue intake."
+    >
+      <FactorySettingsCard title="GitHub repository" data-testid="factory-settings-repository">
+        {!integrationId ? (
+          <p className="text-[13px] text-muted-foreground">Connect GitHub during workspace setup before you select a repository.</p>
+        ) : (
+          <RepositoryPicker host="github" repos={repositories} selectedRepo={repository || null} onSelect={setRepository} />
+        )}
+        {resources.isError ? (
+          <p className="mt-3 text-[13px] text-destructive">We could not load repositories. Try again.</p>
+        ) : null}
+        <div className="mt-4 flex items-center justify-between gap-4 border-t border-border pt-4">
+          <p className="text-[12px] text-muted-foreground">
+            Saving updates factory GitHub issue intake and pull request automations.
+          </p>
+          <PermissionTooltip enabled={!canUpdate} action="update this workspace">
+            <LoadingButton
+              type="button"
+              loading={updateRepository.isPending}
+              loadingText="Saving..."
+              disabled={!repository || !isDirty || !canUpdate || permissionsLoading}
+              onClick={save}
+              data-testid="factory-settings-repository-save"
+            >
+              Save repository
+            </LoadingButton>
+          </PermissionTooltip>
+        </div>
+      </FactorySettingsCard>
+    </FactorySettingsPageFrame>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.tsx
@@ -6,7 +6,7 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { RepositoryPicker } from "../onboarding/onboardingSteps";
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
 import { FactorySettingsCard, FactorySettingsPageFrame } from "./FactorySettingsCard";
 import { useFactorySettingsLayout } from "./factorySettingsLayoutContext";
@@ -46,26 +46,28 @@ export function FactorySettingsRepositoryPage() {
     }
   };
 
+  let repositoryContent: ReactNode;
+  if (!integrationId) {
+    repositoryContent = (
+      <p className="text-[13px] text-muted-foreground">
+        Connect GitHub during workspace setup before you select a repository.
+      </p>
+    );
+  } else if (resources.isLoading) {
+    repositoryContent = <p className="text-[13px] text-muted-foreground">Loading repositories...</p>;
+  } else {
+    repositoryContent = (
+      <RepositoryPicker host="github" repos={repositories} selectedRepo={repository || null} onSelect={setRepository} />
+    );
+  }
+
   return (
     <FactorySettingsPageFrame
       title="Repository"
       subtitle="Select the GitHub repository for workspace work and issue intake."
     >
       <FactorySettingsCard title="GitHub repository" data-testid="factory-settings-repository">
-        {!integrationId ? (
-          <p className="text-[13px] text-muted-foreground">
-            Connect GitHub during workspace setup before you select a repository.
-          </p>
-        ) : resources.isLoading ? (
-          <p className="text-[13px] text-muted-foreground">Loading repositories...</p>
-        ) : (
-          <RepositoryPicker
-            host="github"
-            repos={repositories}
-            selectedRepo={repository || null}
-            onSelect={setRepository}
-          />
-        )}
+        {repositoryContent}
         {resources.isError ? (
           <p className="mt-3 text-[13px] text-destructive">We could not load repositories. Try again.</p>
         ) : null}

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.tsx
@@ -53,9 +53,18 @@ export function FactorySettingsRepositoryPage() {
     >
       <FactorySettingsCard title="GitHub repository" data-testid="factory-settings-repository">
         {!integrationId ? (
-          <p className="text-[13px] text-muted-foreground">Connect GitHub during workspace setup before you select a repository.</p>
+          <p className="text-[13px] text-muted-foreground">
+            Connect GitHub during workspace setup before you select a repository.
+          </p>
+        ) : resources.isLoading ? (
+          <p className="text-[13px] text-muted-foreground">Loading repositories...</p>
         ) : (
-          <RepositoryPicker host="github" repos={repositories} selectedRepo={repository || null} onSelect={setRepository} />
+          <RepositoryPicker
+            host="github"
+            repos={repositories}
+            selectedRepo={repository || null}
+            onSelect={setRepository}
+          />
         )}
         {resources.isError ? (
           <p className="mt-3 text-[13px] text-destructive">We could not load repositories. Try again.</p>
@@ -64,7 +73,10 @@ export function FactorySettingsRepositoryPage() {
           <p className="text-[12px] text-muted-foreground">
             Saving updates factory GitHub issue intake and pull request automations.
           </p>
-          <PermissionTooltip enabled={!canUpdate} action="update this workspace">
+          <PermissionTooltip
+            allowed={canUpdate || permissionsLoading}
+            message="You do not have permission to update this workspace."
+          >
             <LoadingButton
               type="button"
               loading={updateRepository.isPending}

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsRepositoryPage.tsx
@@ -25,6 +25,7 @@ export function FactorySettingsRepositoryPage() {
     [resources.data],
   );
   const [repository, setRepository] = useState(factory.onboarding?.appRepository ?? "");
+  const [isResolvingDefaultBranch, setIsResolvingDefaultBranch] = useState(false);
   const updateRepository = useFactoryRepository(organizationId, factoryId);
   const canUpdate = canAct("factories", "update");
 
@@ -35,14 +36,18 @@ export function FactorySettingsRepositoryPage() {
   }, [factory.onboarding?.appRepository]);
 
   const isDirty = repository !== (factory.onboarding?.appRepository ?? "");
+  const isSaving = isResolvingDefaultBranch || updateRepository.isPending;
   const save = async () => {
-    if (!repository || !integrationId) return;
+    if (!repository || !integrationId || isSaving) return;
+    setIsResolvingDefaultBranch(true);
     try {
       const defaultBranch = await resolveGithubDefaultBranch(organizationId, integrationId, repository);
       await updateRepository.mutateAsync({ repository, defaultBranch });
       showSuccessToast("Workspace repository updated.");
     } catch (error) {
       showErrorToast(getApiErrorMessage(error, "Failed to update workspace repository"));
+    } finally {
+      setIsResolvingDefaultBranch(false);
     }
   };
 
@@ -81,9 +86,9 @@ export function FactorySettingsRepositoryPage() {
           >
             <LoadingButton
               type="button"
-              loading={updateRepository.isPending}
+              loading={isSaving}
               loadingText="Saving..."
-              disabled={!repository || !isDirty || !canUpdate || permissionsLoading}
+              disabled={!repository || !isDirty || !canUpdate || permissionsLoading || isSaving}
               onClick={save}
               data-testid="factory-settings-repository-save"
             >

--- a/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
+++ b/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
@@ -8,7 +8,11 @@ import {
 } from "../../__fixtures__/factoryPageResponses";
 import { eventTypesFromToggles, defaultNotificationTypeToggles } from "@/lib/notificationSettings";
 import { FactorySettingsLayout } from "./FactorySettingsLayout";
-import { CONNECTED_SETUP_INTEGRATIONS, SETUP_ANSWERS, factoriesFixtureWithSetupAnswers } from "../../__fixtures__/setupStoryFixtures";
+import {
+  CONNECTED_SETUP_INTEGRATIONS,
+  SETUP_ANSWERS,
+  factoriesFixtureWithSetupAnswers,
+} from "../../__fixtures__/setupStoryFixtures";
 
 /** Factory settings with Account, Workspace, and Organization navigation. */
 const meta = {

--- a/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
+++ b/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../__fixtures__/factoryPageResponses";
 import { eventTypesFromToggles, defaultNotificationTypeToggles } from "@/lib/notificationSettings";
 import { FactorySettingsLayout } from "./FactorySettingsLayout";
+import { CONNECTED_SETUP_INTEGRATIONS, SETUP_ANSWERS, factoriesFixtureWithSetupAnswers } from "../../__fixtures__/setupStoryFixtures";
 
 /** Factory settings with Account, Workspace, and Organization navigation. */
 const meta = {
@@ -87,7 +88,8 @@ export const Repository: Story = {
   render: () => (
     <FactoriesHarness
       pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/repository`}
-      factoriesFixture={defaultFactoriesFixture}
+      factoriesFixture={factoriesFixtureWithSetupAnswers(SETUP_ANSWERS.agent)}
+      orgIntegrations={CONNECTED_SETUP_INTEGRATIONS}
     />
   ),
 };

--- a/web_src/src/pages/factories/pages/settings/useFactoryRepository.ts
+++ b/web_src/src/pages/factories/pages/settings/useFactoryRepository.ts
@@ -1,0 +1,28 @@
+import { factoriesUpdateFactoryRepository, type FactoriesUpdateFactoryRepositoryBody } from "@/api-client";
+import { factoryQueryKeys } from "@/hooks/useFactoryData";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useFactoryRepository(organizationId: string, factoryId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: FactoriesUpdateFactoryRepositoryBody) => {
+      const response = await factoriesUpdateFactoryRepository(
+        withOrganizationHeader({
+          organizationId,
+          path: { id: factoryId },
+          body: input,
+        }),
+      );
+      if (!response.data?.factory) {
+        throw new Error("Failed to update workspace repository");
+      }
+      return response.data.factory;
+    },
+    onSuccess: (factory) => {
+      queryClient.setQueryData(factoryQueryKeys.detail(organizationId, factoryId), factory);
+      void queryClient.invalidateQueries({ queryKey: factoryQueryKeys.list(organizationId) });
+    },
+  });
+}

--- a/web_src/src/pages/home/__fixtures__/handlers.ts
+++ b/web_src/src/pages/home/__fixtures__/handlers.ts
@@ -442,6 +442,9 @@ export async function matchFactorySetupFixture(
 
   const resourcesMatch = /^\/api\/v1\/organizations\/([^/]+)\/integrations\/([^/]+)\/resources$/.exec(url.pathname);
   if (resourcesMatch && method === "GET") {
+    if (url.searchParams.get("type") === "default_branch") {
+      return { json: { resources: [{ id: "main", name: "main", type: "default_branch" }] } };
+    }
     return { json: { resources: STORYBOOK_GITHUB_REPOSITORIES } };
   }
 


### PR DESCRIPTION
## Summary

Adds a workspace repository setting for factory work and GitHub issue intake.
Active work orders retain their repository and default branch after a change.
Generated factory automations use workspace and order repository values.

## Test plan

- [ ] Run targeted factory, model, and context tests
- [ ] Run UI lint and build checks
- [ ] Verify the Repository settings Storybook story
- [ ] Change repositories during active work order processing