### PR TITLE
feat: Add factory agent settings

### DIFF
--- a/pkg/authorization/gateway_auth_rules.go
+++ b/pkg/authorization/gateway_auth_rules.go
@@ -512,6 +512,12 @@ func DefaultAuthorizationRules() map[HTTPRoute]AuthorizationRule {
 			DomainType:                   models.DomainTypeOrganization,
 			RequiredExperimentalFeatures: []string{features.FeatureFactories},
 		},
+		{Method: "PATCH", Pattern: "/api/v1/factories/{id}/agent"}: {
+			Resource:                     "factories",
+			Action:                       "update",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureFactories},
+		},
 		{Method: "PATCH", Pattern: "/api/v1/canvases/{canvas_id}/executions/resolve"}: {
 			Resource:           "canvases",
 			Action:             "update",

--- a/pkg/grpc/actions/factories/intake_agent.go
+++ b/pkg/grpc/actions/factories/intake_agent.go
@@ -109,6 +109,9 @@ func defaultIntakeAgentModel(component string) string {
 // completes it in the canvas.
 func resolveIntakeAgent(tx *gorm.DB, factory *models.Factory) *intakeAgent {
 	config := factory.OnboardingConfigValue()
+	if agent := intakeAgentFromPersistedWorkspaceAgent(tx, factory, config); agent != nil {
+		return agent
+	}
 	if agent := intakeAgentFromSetup(tx, factory, config.AgentIntegrationID); agent != nil {
 		return agent
 	}
@@ -118,6 +121,48 @@ func resolveIntakeAgent(tx *gorm.DB, factory *models.Factory) *intakeAgent {
 	}
 
 	return intakeAgentFromHostedProvider(tx, factory)
+}
+
+// intakeAgentFromPersistedWorkspaceAgent keeps newly created generated
+// automations on the agent selected in workspace settings. Older factories do
+// not have AgentProvider, so they retain the legacy discovery fallback below.
+func intakeAgentFromPersistedWorkspaceAgent(
+	tx *gorm.DB,
+	factory *models.Factory,
+	config models.FactoryOnboardingConfig,
+) *intakeAgent {
+	spec, ok := factoryAgentProviderSpecs[config.AgentProvider]
+	if !ok {
+		return nil
+	}
+	model := config.AgentModel
+	if model == "" {
+		model = spec.model
+	}
+	if config.AgentIntegrationID == "" {
+		return &intakeAgent{
+			Component:   spec.component,
+			Credentials: map[string]any{"source": runner.CredentialsSourceHosted},
+			Model:       model,
+		}
+	}
+
+	integrationID, err := uuid.Parse(config.AgentIntegrationID)
+	if err != nil {
+		return nil
+	}
+	integration, err := models.FindIntegrationInTransaction(tx, factory.OrganizationID, integrationID)
+	if err != nil || integration.State != models.IntegrationStateReady || integration.AppName != spec.integrationApp {
+		return nil
+	}
+	return &intakeAgent{
+		Component: spec.component,
+		Credentials: map[string]any{
+			"source":      runner.CredentialsSourceIntegration,
+			"integration": map[string]any{"name": integration.InstallationName},
+		},
+		Model: model,
+	}
 }
 
 // intakeAgentFromSetup reads the agent the workspace setup recorded. A setup

--- a/pkg/grpc/actions/factories/intake_agent_test.go
+++ b/pkg/grpc/actions/factories/intake_agent_test.go
@@ -39,6 +39,29 @@ func Test__ResolveIntakeAgent(t *testing.T) {
 		assert.Equal(t, integrationName(t, organization.ID, agentID), integrationRefName(t, agent))
 	})
 
+	t.Run("the intake uses the workspace agent settings after they are saved", func(t *testing.T) {
+		organization := support.CreateOrganization(t, r, r.User)
+		factory := newFactoryIn(t, organization.ID)
+		agentID := createReadyOnboardingIntegration(t, organization.ID, "openai")
+		harness := models.FactoryOnboardingAgentHarnessCodex
+		provider := models.FactoryOnboardingAgentProviderOpenAI
+		model := "gpt-5-mini"
+		planningModel := "gpt-5"
+		require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
+			AgentIntegrationID: &agentID,
+			AgentHarness:       &harness,
+			AgentProvider:      &provider,
+			AgentModel:         &model,
+			AgentPlanningModel: &planningModel,
+		}))
+
+		agent := resolveIntakeAgent(db, factory)
+		require.NotNil(t, agent)
+		assert.Equal(t, "runnerCodex", agent.Component)
+		assert.Equal(t, "gpt-5-mini", agent.Model)
+		assert.Equal(t, integrationName(t, organization.ID, agentID), integrationRefName(t, agent))
+	})
+
 	t.Run("an agent on an installation still names the model it runs", func(t *testing.T) {
 		organization := support.CreateOrganization(t, r, r.User)
 

--- a/pkg/grpc/actions/factories/serialization.go
+++ b/pkg/grpc/actions/factories/serialization.go
@@ -58,6 +58,9 @@ func serializeFactoryOnboarding(factory *models.Factory) *pb.FactoryOnboarding {
 		DefaultBranch:      config.DefaultBranch,
 		IssuesSource:       serializeFactoryOnboardingIssuesSource(config.IssuesSource),
 		AgentHarness:       serializeFactoryOnboardingAgentHarness(config.AgentHarness),
+		AgentProvider:      serializeFactoryOnboardingAgentProvider(config.AgentProvider),
+		AgentModel:         config.AgentModel,
+		AgentPlanningModel: config.AgentPlanningModel,
 		ProvisionedAppId:   config.ProvisionedAppID,
 		ProvisionedLineId:  config.ProvisionedLineID,
 	}
@@ -92,6 +95,19 @@ func serializeFactoryOnboardingAgentHarness(harness string) pb.FactoryOnboarding
 		return pb.FactoryOnboarding_AGENT_HARNESS_CODEX
 	default:
 		return pb.FactoryOnboarding_AGENT_HARNESS_UNSPECIFIED
+	}
+}
+
+func serializeFactoryOnboardingAgentProvider(provider string) pb.FactoryOnboarding_AgentProvider {
+	switch provider {
+	case models.FactoryOnboardingAgentProviderAnthropic:
+		return pb.FactoryOnboarding_AGENT_PROVIDER_ANTHROPIC
+	case models.FactoryOnboardingAgentProviderOpenAI:
+		return pb.FactoryOnboarding_AGENT_PROVIDER_OPENAI
+	case models.FactoryOnboardingAgentProviderOpenRouter:
+		return pb.FactoryOnboarding_AGENT_PROVIDER_OPENROUTER
+	default:
+		return pb.FactoryOnboarding_AGENT_PROVIDER_UNSPECIFIED
 	}
 }
 

--- a/pkg/grpc/actions/factories/update_factory_agent.go
+++ b/pkg/grpc/actions/factories/update_factory_agent.go
@@ -1,0 +1,347 @@
+package factories
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases/changesets"
+	grpcerrors "github.com/superplanehq/superplane/pkg/grpc/errors"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/factories"
+	"gorm.io/gorm"
+)
+
+type factoryAgentPlan struct {
+	provider        string
+	component       string
+	harness         string
+	integrationID   string
+	integrationName string
+	model           string
+	planningModel   string
+}
+
+type factoryAgentProviderSpec struct {
+	provider       string
+	integrationApp string
+	component      string
+	harness        string
+	model          string
+	planningModel  string
+	modelHint      string
+	planningHint   string
+}
+
+var factoryAgentProviderSpecs = map[string]factoryAgentProviderSpec{
+	models.FactoryOnboardingAgentProviderAnthropic: {
+		provider:       models.FactoryOnboardingAgentProviderAnthropic,
+		integrationApp: "claude",
+		component:      "runnerClaudeCode",
+		harness:        models.FactoryOnboardingAgentHarnessClaudeCode,
+		model:          "sonnet",
+		planningModel:  "opus",
+		modelHint:      "sonnet",
+		planningHint:   "opus",
+	},
+	models.FactoryOnboardingAgentProviderOpenAI: {
+		provider:       models.FactoryOnboardingAgentProviderOpenAI,
+		integrationApp: "openai",
+		component:      "runnerCodex",
+		harness:        models.FactoryOnboardingAgentHarnessCodex,
+		model:          "gpt-5",
+		planningModel:  "gpt-5",
+		modelHint:      "gpt-5",
+		planningHint:   "gpt-5",
+	},
+	models.FactoryOnboardingAgentProviderOpenRouter: {
+		provider:       models.FactoryOnboardingAgentProviderOpenRouter,
+		integrationApp: "openrouter",
+		component:      "runnerOpenRouter",
+		harness:        models.FactoryOnboardingAgentHarnessClaudeCode,
+		model:          "anthropic/claude-sonnet-4-6",
+		planningModel:  "anthropic/claude-opus-4-6",
+		modelHint:      "sonnet",
+		planningHint:   "opus",
+	},
+}
+
+func UpdateFactoryAgent(
+	ctx context.Context,
+	deps IntakeDependencies,
+	organizationID string,
+	req *pb.UpdateFactoryAgentRequest,
+) (*pb.UpdateFactoryAgentResponse, error) {
+	orgID, err := parseOrganizationID(organizationID)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory agent")
+	}
+	factoryID, err := parseFactoryID(req.GetId())
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory agent")
+	}
+	actorID, err := factoryAgentActorID(ctx)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory agent")
+	}
+
+	db := database.DB(ctx)
+	var factory *models.Factory
+	err = db.Transaction(func(tx *gorm.DB) error {
+		loaded, err := models.FindFactory(tx, orgID, factoryID)
+		if err != nil {
+			return err
+		}
+		factory = loaded
+
+		plan, err := resolveFactoryAgentPlan(tx, orgID, factoryID, req)
+		if err != nil {
+			return err
+		}
+		if err := factory.UpdateOnboarding(tx, models.FactoryOnboardingPatch{
+			AgentIntegrationID: &plan.integrationID,
+			AgentHarness:       &plan.harness,
+			AgentProvider:      &plan.provider,
+			AgentModel:         &plan.model,
+			AgentPlanningModel: &plan.planningModel,
+		}); err != nil {
+			return err
+		}
+
+		return reconcileFactoryAgent(ctx, tx, deps, factory, actorID, plan)
+	})
+	if err != nil {
+		if _, _, ok := grpcerrors.HandlerStatus(err); ok {
+			return nil, err
+		}
+		return nil, factoryErrorToStatus(err, "failed to update factory agent")
+	}
+
+	lines, err := factory.ListLines(db)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory agent")
+	}
+	serialized, err := serializeFactoryWithLineMetrics(db, factory, lines)
+	if err != nil {
+		return nil, factoryErrorToStatus(err, "failed to update factory agent")
+	}
+	return &pb.UpdateFactoryAgentResponse{Factory: serialized}, nil
+}
+
+func factoryAgentActorID(ctx context.Context) (uuid.UUID, error) {
+	userID, ok := authentication.GetUserIdFromMetadata(ctx)
+	if !ok {
+		return uuid.Nil, grpcerrors.Unauthenticated(nil, "user not authenticated")
+	}
+	actorID, err := uuid.Parse(userID)
+	if err != nil {
+		return uuid.Nil, invalidArgument("invalid user id")
+	}
+	return actorID, nil
+}
+
+func resolveFactoryAgentPlan(
+	tx *gorm.DB,
+	organizationID, factoryID uuid.UUID,
+	req *pb.UpdateFactoryAgentRequest,
+) (factoryAgentPlan, error) {
+	provider, err := factoryAgentProviderFromProto(req.GetProvider())
+	if err != nil {
+		return factoryAgentPlan{}, err
+	}
+	spec := factoryAgentProviderSpecs[provider]
+	if spec.provider == "" {
+		return factoryAgentPlan{}, invalidArgument("unsupported agent provider")
+	}
+
+	switch req.GetCredentialSource() {
+	case pb.FactoryOnboarding_AGENT_CREDENTIAL_SOURCE_HOSTED:
+		if req.IntegrationId != nil && strings.TrimSpace(req.GetIntegrationId()) != "" {
+			return factoryAgentPlan{}, invalidArgument("hosted credentials do not use an integration")
+		}
+		credit, err := models.DescribeOrganizationLLMCredit(tx, organizationID)
+		if err != nil {
+			return factoryAgentPlan{}, err
+		}
+		if credit.RemainingMicros <= 0 {
+			return factoryAgentPlan{}, invalidArgument("SuperPlane-hosted credit is empty")
+		}
+		modelsForFactory, err := models.ResolveSelectableLLMModels(
+			tx,
+			organizationID,
+			&factoryID,
+			provider,
+			models.UsageFundingSourceHosted,
+		)
+		if err != nil {
+			return factoryAgentPlan{}, err
+		}
+		model, planningModel, ok := factoryHostedAgentModels(modelsForFactory, spec)
+		if !ok {
+			return factoryAgentPlan{}, invalidArgument("SuperPlane-hosted models are not available for this provider")
+		}
+		return factoryAgentPlan{
+			provider: provider, component: spec.component, harness: spec.harness, model: model, planningModel: planningModel,
+		}, nil
+	case pb.FactoryOnboarding_AGENT_CREDENTIAL_SOURCE_INTEGRATION:
+		integrationID := strings.TrimSpace(req.GetIntegrationId())
+		if integrationID == "" {
+			return factoryAgentPlan{}, invalidArgument("integration id is required")
+		}
+		integration, err := findReadyOnboardingIntegration(tx, organizationID, integrationID)
+		if err != nil {
+			return factoryAgentPlan{}, err
+		}
+		if integration.AppName != spec.integrationApp {
+			return factoryAgentPlan{}, invalidArgument("agent provider does not match the selected integration")
+		}
+		return factoryAgentPlan{
+			provider: provider, component: spec.component, harness: spec.harness,
+			integrationID: integration.ID.String(), integrationName: integration.InstallationName,
+			model: spec.model, planningModel: spec.planningModel,
+		}, nil
+	default:
+		return factoryAgentPlan{}, invalidArgument("agent credential source is required")
+	}
+}
+
+func factoryHostedAgentModels(modelsForFactory []string, spec factoryAgentProviderSpec) (string, string, bool) {
+	modelsForFactory = models.CompactModelIDs(modelsForFactory)
+	if len(modelsForFactory) == 0 {
+		return "", "", false
+	}
+	slices.SortFunc(modelsForFactory, func(left, right string) int { return strings.Compare(strings.ToLower(left), strings.ToLower(right)) })
+	model := factoryAgentModelMatching(modelsForFactory, spec.modelHint)
+	if model == "" {
+		model = modelsForFactory[0]
+	}
+	planningModel := factoryAgentModelMatching(modelsForFactory, spec.planningHint)
+	if planningModel == "" {
+		planningModel = model
+	}
+	return model, planningModel, true
+}
+
+func factoryAgentModelMatching(modelIDs []string, hint string) string {
+	for _, model := range modelIDs {
+		if strings.Contains(strings.ToLower(model), hint) {
+			return model
+		}
+	}
+	return ""
+}
+
+func factoryAgentProviderFromProto(provider pb.FactoryOnboarding_AgentProvider) (string, error) {
+	return factoryOnboardingAgentProviderFromProto(provider)
+}
+
+func reconcileFactoryAgent(
+	ctx context.Context,
+	tx *gorm.DB,
+	deps IntakeDependencies,
+	factory *models.Factory,
+	actorID uuid.UUID,
+	plan factoryAgentPlan,
+) error {
+	canvasesForFactory, err := factory.ListCanvases(tx)
+	if err != nil {
+		return err
+	}
+
+	for i := range canvasesForFactory {
+		canvas := &canvasesForFactory[i]
+		liveVersion, err := models.FindLiveCanvasVersionByCanvasInTransaction(tx, canvas)
+		if err != nil {
+			return err
+		}
+		nodes := slices.Clone(liveVersion.Nodes)
+		changed := reconcileGeneratedFactoryAgentNodes(nodes, plan)
+		if !changed {
+			continue
+		}
+		if err := canvases.PublishGeneratedCanvasNodes(
+			ctx,
+			tx,
+			canvas,
+			actorID,
+			"Update workspace agent",
+			nodes,
+			slices.Clone(liveVersion.Edges),
+			changesets.CanvasPublisherOptions{
+				Registry:       deps.Registry,
+				OrgID:          canvas.OrganizationID,
+				Encryptor:      deps.Encryptor,
+				AuthService:    deps.AuthService,
+				WebhookBaseURL: deps.WebhookBaseURL,
+				GitProvider:    deps.GitProvider,
+			},
+		); err != nil {
+			return fmt.Errorf("publish %q agent update: %w", canvas.Name, err)
+		}
+	}
+	return nil
+}
+
+func reconcileGeneratedFactoryAgentNodes(nodes []models.Node, plan factoryAgentPlan) bool {
+	template, isTemplate := resolveFactoryTemplate(nodes)
+	if isTemplate {
+		switch template.id {
+		case "line-planning":
+			return updateFactoryAgentNode(nodes, "planner-agent-no-issue", plan, plan.planningModel)
+		case "line-implementation":
+			return updateFactoryAgentNode(nodes, "implementation-agent-no-issue", plan, plan.model)
+		}
+	}
+	return updateGeneratedBacklogAgentNode(nodes, plan)
+}
+
+func updateGeneratedBacklogAgentNode(nodes []models.Node, plan factoryAgentPlan) bool {
+	if !isGeneratedBacklog(nodes) {
+		return false
+	}
+	return updateFactoryAgentNode(nodes, intakeAnalysisNodeID, plan, plan.model)
+}
+
+func isGeneratedBacklog(nodes []models.Node) bool {
+	hasBacklogTrigger := false
+	hasAnalysisNode := false
+	for _, node := range nodes {
+		if node.ID == backlogTriggerNodeID && node.ComponentName() == "onWorkOrder" && node.Name == backlogTriggerName {
+			hasBacklogTrigger = true
+		}
+		if node.ID == intakeAnalysisNodeID && node.Name == intakeAnalysisNodeName {
+			hasAnalysisNode = true
+		}
+	}
+	return hasBacklogTrigger && hasAnalysisNode
+}
+
+func updateFactoryAgentNode(nodes []models.Node, nodeID string, plan factoryAgentPlan, model string) bool {
+	for i := range nodes {
+		if nodes[i].ID != nodeID {
+			continue
+		}
+		nodes[i].Ref.Component = &models.ComponentRef{Name: plan.component}
+		nodes[i].Configuration = maps.Clone(nodes[i].Configuration)
+		if nodes[i].Configuration == nil {
+			nodes[i].Configuration = map[string]any{}
+		}
+		if plan.integrationID == "" {
+			nodes[i].Configuration["credentials"] = map[string]any{"source": "hosted"}
+		} else {
+			nodes[i].Configuration["credentials"] = map[string]any{
+				"source":      "integration",
+				"integration": map[string]any{"name": plan.integrationName},
+			}
+		}
+		nodes[i].Configuration["model"] = model
+		return true
+	}
+	return false
+}

--- a/pkg/grpc/actions/factories/update_factory_agent_test.go
+++ b/pkg/grpc/actions/factories/update_factory_agent_test.go
@@ -1,0 +1,80 @@
+package factories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func TestReconcileGeneratedFactoryAgentNodesUpdatesPlanningRunner(t *testing.T) {
+	nodes := []models.Node{
+		{
+			ID:  "onrun-create-plan",
+			Ref: models.NodeRef{Trigger: &models.TriggerRef{Name: "onRun"}},
+			Metadata: map[string]any{
+				factoryTemplateMetadataKey: map[string]any{"id": "line-planning", "version": factoryTemplateVersion},
+			},
+		},
+		{
+			ID:            "planner-agent-no-issue",
+			Ref:           models.NodeRef{Component: &models.ComponentRef{Name: "runnerClaudeCode"}},
+			Configuration: map[string]any{"model": "opus", "credentials": map[string]any{"source": "integration"}},
+		},
+	}
+
+	changed := reconcileGeneratedFactoryAgentNodes(nodes, factoryAgentPlan{
+		component: "runnerCodex", integrationID: "integration-1", integrationName: "openai-production", model: "gpt-5", planningModel: "gpt-5",
+	})
+
+	require.True(t, changed)
+	assert.Equal(t, "runnerCodex", nodes[1].ComponentName())
+	assert.Equal(t, "gpt-5", nodes[1].Configuration["model"])
+	assert.Equal(t, map[string]any{
+		"source":      "integration",
+		"integration": map[string]any{"name": "openai-production"},
+	}, nodes[1].Configuration["credentials"])
+}
+
+func TestReconcileGeneratedFactoryAgentNodesUpdatesBacklogRunner(t *testing.T) {
+	nodes := []models.Node{
+		{ID: backlogTriggerNodeID, Name: backlogTriggerName, Ref: models.NodeRef{Trigger: &models.TriggerRef{Name: "onWorkOrder"}}},
+		{
+			ID: intakeAnalysisNodeID, Name: intakeAnalysisNodeName,
+			Ref:           models.NodeRef{Component: &models.ComponentRef{Name: "runnerClaudeCode"}},
+			Configuration: map[string]any{"model": "opus"},
+		},
+	}
+
+	changed := reconcileGeneratedFactoryAgentNodes(nodes, factoryAgentPlan{component: "runnerOpenRouter", model: "anthropic/claude-sonnet-4-6"})
+
+	require.True(t, changed)
+	assert.Equal(t, "runnerOpenRouter", nodes[1].ComponentName())
+	assert.Equal(t, "anthropic/claude-sonnet-4-6", nodes[1].Configuration["model"])
+	assert.Equal(t, map[string]any{"source": "hosted"}, nodes[1].Configuration["credentials"])
+}
+
+func TestReconcileGeneratedFactoryAgentNodesLeavesCustomRunnerUnchanged(t *testing.T) {
+	nodes := []models.Node{
+		{
+			ID:            "custom-agent",
+			Ref:           models.NodeRef{Component: &models.ComponentRef{Name: "runnerClaudeCode"}},
+			Configuration: map[string]any{"model": "custom-model"},
+		},
+	}
+
+	changed := reconcileGeneratedFactoryAgentNodes(nodes, factoryAgentPlan{component: "runnerCodex", model: "gpt-5"})
+
+	assert.False(t, changed)
+	assert.Equal(t, "runnerClaudeCode", nodes[0].ComponentName())
+	assert.Equal(t, "custom-model", nodes[0].Configuration["model"])
+}
+
+func TestFactoryHostedAgentModelsUsesProviderDefaults(t *testing.T) {
+	model, planningModel, ok := factoryHostedAgentModels([]string{"claude-haiku", "claude-opus", "claude-sonnet"}, factoryAgentProviderSpecs["anthropic"])
+
+	require.True(t, ok)
+	assert.Equal(t, "claude-sonnet", model)
+	assert.Equal(t, "claude-opus", planningModel)
+}

--- a/pkg/grpc/actions/factories/update_factory_onboarding.go
+++ b/pkg/grpc/actions/factories/update_factory_onboarding.go
@@ -176,6 +176,8 @@ func factoryOnboardingPatchFromRequest(req *pb.UpdateFactoryOnboardingRequest) (
 		DefaultBranch:      req.DefaultBranch,
 		ProvisionedAppID:   req.ProvisionedAppId,
 		ProvisionedLineID:  req.ProvisionedLineId,
+		AgentModel:         req.AgentModel,
+		AgentPlanningModel: req.AgentPlanningModel,
 	}
 
 	if req.IssuesSource != nil {
@@ -194,7 +196,30 @@ func factoryOnboardingPatchFromRequest(req *pb.UpdateFactoryOnboardingRequest) (
 		patch.AgentHarness = &harness
 	}
 
+	if req.AgentProvider != nil {
+		provider, err := factoryOnboardingAgentProviderFromProto(*req.AgentProvider)
+		if err != nil {
+			return models.FactoryOnboardingPatch{}, err
+		}
+		patch.AgentProvider = &provider
+	}
+
 	return patch, nil
+}
+
+func factoryOnboardingAgentProviderFromProto(provider pb.FactoryOnboarding_AgentProvider) (string, error) {
+	switch provider {
+	case pb.FactoryOnboarding_AGENT_PROVIDER_UNSPECIFIED:
+		return "", nil
+	case pb.FactoryOnboarding_AGENT_PROVIDER_ANTHROPIC:
+		return models.FactoryOnboardingAgentProviderAnthropic, nil
+	case pb.FactoryOnboarding_AGENT_PROVIDER_OPENAI:
+		return models.FactoryOnboardingAgentProviderOpenAI, nil
+	case pb.FactoryOnboarding_AGENT_PROVIDER_OPENROUTER:
+		return models.FactoryOnboardingAgentProviderOpenRouter, nil
+	default:
+		return "", invalidArgument("invalid agent provider")
+	}
 }
 
 func factoryOnboardingIssuesSourceFromProto(source pb.FactoryOnboarding_IssuesSource) (string, error) {

--- a/pkg/grpc/factory_service.go
+++ b/pkg/grpc/factory_service.go
@@ -72,6 +72,11 @@ func (s *FactoryService) UpdateFactoryRepository(ctx context.Context, req *pb.Up
 	return actions.UpdateFactoryRepository(ctx, s.intakeDeps, organizationID, req)
 }
 
+func (s *FactoryService) UpdateFactoryAgent(ctx context.Context, req *pb.UpdateFactoryAgentRequest) (*pb.UpdateFactoryAgentResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return actions.UpdateFactoryAgent(ctx, s.intakeDeps, organizationID, req)
+}
+
 func (s *FactoryService) DeleteFactory(ctx context.Context, req *pb.DeleteFactoryRequest) (*pb.DeleteFactoryResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 	return actions.DeleteFactory(ctx, organizationID, req.GetId())

--- a/pkg/models/factory_onboarding.go
+++ b/pkg/models/factory_onboarding.go
@@ -20,11 +20,16 @@ const (
 	FactoryOnboardingAgentHarnessClaudeCode = "claude-code"
 	FactoryOnboardingAgentHarnessCursor     = "cursor"
 	FactoryOnboardingAgentHarnessCodex      = "codex"
+
+	FactoryOnboardingAgentProviderAnthropic  = "anthropic"
+	FactoryOnboardingAgentProviderOpenAI     = "openai"
+	FactoryOnboardingAgentProviderOpenRouter = "openrouter"
 )
 
 var (
 	ErrFactoryOnboardingInvalidIssuesSource      = errors.New("invalid issues source")
 	ErrFactoryOnboardingInvalidAgentHarness      = errors.New("invalid agent harness")
+	ErrFactoryOnboardingInvalidAgentProvider     = errors.New("invalid agent provider")
 	ErrFactoryOnboardingInvalidIntegrationID     = errors.New("invalid integration id")
 	ErrFactoryOnboardingInvalidAppID             = errors.New("invalid provisioned app id")
 	ErrFactoryOnboardingInvalidLineID            = errors.New("invalid provisioned line id")
@@ -52,6 +57,9 @@ type FactoryOnboardingConfig struct {
 	DefaultBranch      string `json:"default_branch,omitempty"`
 	IssuesSource       string `json:"issues_source,omitempty"`
 	AgentHarness       string `json:"agent_harness,omitempty"`
+	AgentProvider      string `json:"agent_provider,omitempty"`
+	AgentModel         string `json:"agent_model,omitempty"`
+	AgentPlanningModel string `json:"agent_planning_model,omitempty"`
 	ProvisionedAppID   string `json:"provisioned_app_id,omitempty"`
 	ProvisionedLineID  string `json:"provisioned_line_id,omitempty"`
 }
@@ -68,6 +76,9 @@ type FactoryOnboardingPatch struct {
 	DefaultBranch      *string
 	IssuesSource       *string
 	AgentHarness       *string
+	AgentProvider      *string
+	AgentModel         *string
+	AgentPlanningModel *string
 	ProvisionedAppID   *string
 	ProvisionedLineID  *string
 }
@@ -94,6 +105,18 @@ func ValidateFactoryOnboardingAgentHarness(harness string) error {
 		return nil
 	default:
 		return ErrFactoryOnboardingInvalidAgentHarness
+	}
+}
+
+func ValidateFactoryOnboardingAgentProvider(provider string) error {
+	switch provider {
+	case "",
+		FactoryOnboardingAgentProviderAnthropic,
+		FactoryOnboardingAgentProviderOpenAI,
+		FactoryOnboardingAgentProviderOpenRouter:
+		return nil
+	default:
+		return ErrFactoryOnboardingInvalidAgentProvider
 	}
 }
 
@@ -214,6 +237,19 @@ func mergeFactoryOnboardingConfig(current FactoryOnboardingConfig, patch Factory
 			return FactoryOnboardingConfig{}, err
 		}
 		next.AgentHarness = value
+	}
+	if patch.AgentProvider != nil {
+		value := strings.TrimSpace(*patch.AgentProvider)
+		if err := ValidateFactoryOnboardingAgentProvider(value); err != nil {
+			return FactoryOnboardingConfig{}, err
+		}
+		next.AgentProvider = value
+	}
+	if patch.AgentModel != nil {
+		next.AgentModel = strings.TrimSpace(*patch.AgentModel)
+	}
+	if patch.AgentPlanningModel != nil {
+		next.AgentPlanningModel = strings.TrimSpace(*patch.AgentPlanningModel)
 	}
 	if patch.ProvisionedAppID != nil {
 		value := strings.TrimSpace(*patch.ProvisionedAppID)

--- a/pkg/models/factory_onboarding_test.go
+++ b/pkg/models/factory_onboarding_test.go
@@ -47,10 +47,16 @@ func Test__FactoryOnboarding(t *testing.T) {
 		backlogRepo := "acme/backlog"
 		defaultBranch := "main"
 		issuesSource := models.FactoryOnboardingIssuesSourceVCS
+		agentProvider := models.FactoryOnboardingAgentProviderAnthropic
+		agentModel := "claude-sonnet-4-6"
+		planningModel := "claude-opus-4-6"
 		require.NoError(t, factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{
-			BacklogRepository: &backlogRepo,
-			DefaultBranch:     &defaultBranch,
-			IssuesSource:      &issuesSource,
+			BacklogRepository:  &backlogRepo,
+			DefaultBranch:      &defaultBranch,
+			IssuesSource:       &issuesSource,
+			AgentProvider:      &agentProvider,
+			AgentModel:         &agentModel,
+			AgentPlanningModel: &planningModel,
 		}))
 
 		config := factory.OnboardingConfigValue()
@@ -59,6 +65,9 @@ func Test__FactoryOnboarding(t *testing.T) {
 		assert.Equal(t, "acme/backlog", config.BacklogRepository)
 		assert.Equal(t, "main", config.DefaultBranch)
 		assert.Equal(t, models.FactoryOnboardingIssuesSourceVCS, config.IssuesSource)
+		assert.Equal(t, agentProvider, config.AgentProvider)
+		assert.Equal(t, agentModel, config.AgentModel)
+		assert.Equal(t, planningModel, config.AgentPlanningModel)
 	})
 
 	t.Run("rejects invalid enum and uuid values", func(t *testing.T) {
@@ -72,6 +81,10 @@ func Test__FactoryOnboarding(t *testing.T) {
 		badHarness := "windsurf"
 		err = factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{AgentHarness: &badHarness})
 		assert.ErrorIs(t, err, models.ErrFactoryOnboardingInvalidAgentHarness)
+
+		badProvider := "gemini"
+		err = factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{AgentProvider: &badProvider})
+		assert.ErrorIs(t, err, models.ErrFactoryOnboardingInvalidAgentProvider)
 
 		badID := "not-a-uuid"
 		err = factory.UpdateOnboarding(db, models.FactoryOnboardingPatch{VCSIntegrationID: &badID})

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -97,6 +97,18 @@ service Factories {
     };
   }
 
+  rpc UpdateFactoryAgent(UpdateFactoryAgentRequest) returns (UpdateFactoryAgentResponse) {
+    option (google.api.http) = {
+      patch: "/api/v1/factories/{id}/agent"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Update factory agent";
+      description: "Updates the provider and credentials used by generated factory runners";
+      tags: "Factory";
+    };
+  }
+
   rpc DeleteFactory(DeleteFactoryRequest) returns (DeleteFactoryResponse) {
     option (google.api.http) = {
       delete: "/api/v1/factories/{id}"
@@ -628,6 +640,9 @@ message UpdateFactoryOnboardingRequest {
   optional bool complete = 10;
   // Default branch of the app repository.
   optional string default_branch = 11;
+  optional FactoryOnboarding.AgentProvider agent_provider = 12;
+  optional string agent_model = 13;
+  optional string agent_planning_model = 14;
 }
 
 message UpdateFactoryOnboardingResponse {
@@ -643,6 +658,17 @@ message UpdateFactoryRepositoryRequest {
 }
 
 message UpdateFactoryRepositoryResponse {
+  Factory factory = 1;
+}
+
+message UpdateFactoryAgentRequest {
+  string id = 1;
+  FactoryOnboarding.AgentProvider provider = 2;
+  FactoryOnboarding.AgentCredentialSource credential_source = 3;
+  optional string integration_id = 4;
+}
+
+message UpdateFactoryAgentResponse {
   Factory factory = 1;
 }
 
@@ -668,6 +694,19 @@ message FactoryOnboarding {
     AGENT_HARNESS_CODEX = 3;
   }
 
+  enum AgentProvider {
+    AGENT_PROVIDER_UNSPECIFIED = 0;
+    AGENT_PROVIDER_ANTHROPIC = 1;
+    AGENT_PROVIDER_OPENAI = 2;
+    AGENT_PROVIDER_OPENROUTER = 3;
+  }
+
+  enum AgentCredentialSource {
+    AGENT_CREDENTIAL_SOURCE_UNSPECIFIED = 0;
+    AGENT_CREDENTIAL_SOURCE_HOSTED = 1;
+    AGENT_CREDENTIAL_SOURCE_INTEGRATION = 2;
+  }
+
   // Set when workspace setup finished. Null while onboarding is open.
   google.protobuf.Timestamp completed_at = 1;
   string vcs_integration_id = 2;
@@ -679,6 +718,9 @@ message FactoryOnboarding {
   string provisioned_app_id = 8;
   string provisioned_line_id = 9;
   string default_branch = 10;
+  AgentProvider agent_provider = 11;
+  string agent_model = 12;
+  string agent_planning_model = 13;
 }
 
 message Factory {

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -20,6 +20,7 @@ import type {
   FactoriesFactoryLine,
   FactoriesFactoryOnboarding,
   FactoriesFactoryPullRequest,
+  FactoriesUpdateFactoryAgentBody,
   FactoriesUpdateFactoryOnboardingBody,
   FactoriesWorkOrder,
   FactoriesWorkOrderEvent,
@@ -233,6 +234,9 @@ function mergedOnboarding(
   if (request.defaultBranch) next.defaultBranch = request.defaultBranch;
   if (request.issuesSource) next.issuesSource = request.issuesSource;
   if (request.agentHarness) next.agentHarness = request.agentHarness;
+  if (request.agentProvider) next.agentProvider = request.agentProvider;
+  if (request.agentModel) next.agentModel = request.agentModel;
+  if (request.agentPlanningModel) next.agentPlanningModel = request.agentPlanningModel;
   if (request.provisionedAppId) next.provisionedAppId = request.provisionedAppId;
   if (request.provisionedLineId) next.provisionedLineId = request.provisionedLineId;
   if (request.complete) next.completedAt = new Date().toISOString();
@@ -251,6 +255,27 @@ function factoryRepositoryRoute(fixture: FactoriesFixture): FactoriesRoute {
         appRepository: request.repository,
         backlogRepository: request.repository,
         defaultBranch: request.defaultBranch,
+      });
+      return { json: { factory: factoryWithLineMetrics(factory) } };
+    },
+  };
+}
+
+function factoryAgentRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/factories/([^/]+)/agent"),
+    resolve: (match, method, body) => {
+      if (method !== "PATCH") return null;
+      const factory = fixture.factories.find((entry) => entry.id === match[1]);
+      if (!factory) return { json: {} };
+      const request = (body ?? {}) as FactoriesUpdateFactoryAgentBody;
+      const integrationId =
+        request.credentialSource === "AGENT_CREDENTIAL_SOURCE_INTEGRATION" ? request.integrationId : "";
+      factory.onboarding = mergedOnboarding(factory.onboarding, {
+        agentIntegrationId: integrationId,
+        agentProvider: request.provider,
+        agentHarness:
+          request.provider === "AGENT_PROVIDER_OPENAI" ? "AGENT_HARNESS_CODEX" : "AGENT_HARNESS_CLAUDE_CODE",
       });
       return { json: { factory: factoryWithLineMetrics(factory) } };
     },
@@ -683,6 +708,7 @@ function buildRoutes(fixture: FactoriesFixture): FactoriesRoute[] {
     ...factoryDetailRoutes(fixture),
     factoryOnboardingRoute(fixture),
     factoryRepositoryRoute(fixture),
+    factoryAgentRoute(fixture),
     ...factoryLinesRoutes(fixture),
     ...factoryPullRequestRoutes(fixture),
     ...workOrderRoutes(fixture),

--- a/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useFinishOnboarding.ts
@@ -22,7 +22,7 @@ import {
 } from "./onboardingProvision";
 import { apiIssuesSource } from "./onboardingStatus";
 import { saveWithFreeWorkspaceName } from "./uniqueFactoryName";
-import { agentRewriteFromPlan } from "./useOnboardingAgentPlan";
+import { agentRewriteFromPlan, onboardingAgentProvider } from "./useOnboardingAgentPlan";
 import type { OnboardingSetupApi } from "./useOnboardingSetupState";
 
 export function finishOnboardingError(args: {
@@ -101,6 +101,9 @@ async function provisionWorkspace(args: {
     backlogRepository: args.backlogRepository,
     issuesSource: apiIssuesSource(args.setup.issuesChoice),
     agentHarness: args.agentPlan.harness,
+    agentProvider: onboardingAgentProvider(args.agentPlan.providerId),
+    agentModel: args.agentPlan.model,
+    agentPlanningModel: args.agentPlan.planningModel,
   });
   // Onboarding installs the Implement app with the real default branch (main,
   // master, staging, ...) instead of hardcoding "main", so Create Branch and

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingAgentPlan.ts
@@ -10,6 +10,17 @@ import {
 } from "./onboardingAgentReadiness";
 import type { IntegrationId } from "./onboardingFixtures";
 
+export function onboardingAgentProvider(providerId: OnboardingAgentPlan["providerId"]) {
+  switch (providerId) {
+    case "claude":
+      return "AGENT_PROVIDER_ANTHROPIC" as const;
+    case "openai":
+      return "AGENT_PROVIDER_OPENAI" as const;
+    case "openrouter":
+      return "AGENT_PROVIDER_OPENROUTER" as const;
+  }
+}
+
 export function useOnboardingAgentPlan(
   organizationId: string,
   connected: Set<IntegrationId>,

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsAgentCards.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsAgentCards.tsx
@@ -1,0 +1,194 @@
+import { Text } from "@/components/Text/text";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { hostedProviderLabel } from "@/lib/hostedCredit";
+import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
+import { Check, CircleDollarSign, Cpu, KeyRound } from "lucide-react";
+
+import {
+  factoryAgentProviders,
+  providerFor,
+  type AgentProvider,
+  type CredentialSource,
+  type ProviderOption,
+} from "./useFactoryAgentSelection";
+
+export function AgentSummary({
+  onboarding,
+}: {
+  onboarding: { agentProvider?: string; agentModel?: string; agentPlanningModel?: string } | undefined;
+}) {
+  const provider = providerFor(onboarding);
+  const model = onboarding?.agentModel || "onboarding default";
+  const planningModel = onboarding?.agentPlanningModel || model;
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-4">
+      <Cpu className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
+      <div>
+        <p className="text-[13px] font-medium">
+          {hostedProviderLabel(provider)} · {model} coding · {planningModel} planning
+        </p>
+        <p className="mt-1 text-[12px] text-muted-foreground">
+          Planning uses the review model. Implementation and Backlog use the coding model.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function AgentResolutionPreview({
+  source,
+  provider,
+  resolution,
+}: {
+  source: CredentialSource;
+  provider: ProviderOption;
+  resolution: { codingModel: string; planningModel: string };
+}) {
+  return (
+    <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
+      <p className="text-[13px] font-medium">Will use {provider.runner}</p>
+      <p className="mt-1 text-[12px] text-muted-foreground">
+        {source === "hosted" ? "SuperPlane-hosted credit" : `${hostedProviderLabel(provider.provider)} key`} · coding{" "}
+        {resolution.codingModel} · planning {resolution.planningModel}
+      </p>
+    </div>
+  );
+}
+
+export function AgentCredentialSelection({
+  source,
+  provider,
+  integrationId,
+  readyIntegrations,
+  onProviderChange,
+  onIntegrationChange,
+}: {
+  source: CredentialSource;
+  provider: AgentProvider;
+  integrationId: string;
+  readyIntegrations: Array<{ metadata?: { id?: string; name?: string } }>;
+  onProviderChange: (provider: AgentProvider) => void;
+  onIntegrationChange: (integrationId: string) => void;
+}) {
+  if (source === "integration") {
+    return (
+      <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
+        <Label htmlFor="factory-agent-integration" className="text-[13px] font-medium">
+          {hostedProviderLabel(provider)} key
+        </Label>
+        {readyIntegrations.length > 0 ? (
+          <Select value={integrationId} onValueChange={onIntegrationChange}>
+            <SelectTrigger id="factory-agent-integration" className="mt-2 h-9">
+              <SelectValue placeholder={`Select a ${hostedProviderLabel(provider)} key`} />
+            </SelectTrigger>
+            <SelectContent>
+              {readyIntegrations.map((integration) => (
+                <SelectItem key={integration.metadata?.id} value={integration.metadata?.id ?? ""}>
+                  {integration.metadata?.name || integration.metadata?.id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Text className="mt-2 text-[13px] text-muted-foreground">
+            Connect a {hostedProviderLabel(provider)} key to use this provider.
+          </Text>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
+      <Label htmlFor="factory-agent-hosted-provider" className="text-[13px] font-medium">
+        Hosted provider
+      </Label>
+      <Select value={provider} onValueChange={(value) => onProviderChange(value as AgentProvider)}>
+        <SelectTrigger id="factory-agent-hosted-provider" className="mt-2 h-9">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {factoryAgentProviders.map((option) => (
+            <SelectItem key={option.provider} value={option.provider}>
+              {hostedProviderLabel(option.provider)} · {option.runner}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export function HostedOption({
+  active,
+  provider,
+  onSelect,
+}: {
+  active: boolean;
+  provider: AgentProvider;
+  onSelect: () => void;
+}) {
+  return (
+    <button type="button" onClick={onSelect} className={optionClassName(active)} aria-pressed={active}>
+      <CircleDollarSign className="mt-0.5 size-5 shrink-0" aria-hidden />
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block text-[13px] font-medium">SuperPlane-hosted credit</span>
+        <span className="mt-0.5 block text-[12px] text-muted-foreground">
+          Use hosted {hostedProviderLabel(provider)} models for this workspace.
+        </span>
+      </span>
+      {active ? <Check className="size-4 shrink-0" aria-hidden /> : null}
+    </button>
+  );
+}
+
+export function ProviderCard({
+  active,
+  option,
+  readyCount,
+  onSelect,
+  onConnect,
+}: {
+  active: boolean;
+  option: ProviderOption;
+  readyCount: number;
+  onSelect: () => void;
+  onConnect: () => void;
+}) {
+  return (
+    <div className={optionClassName(active)}>
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex min-w-0 flex-1 items-start gap-3 text-left"
+        aria-pressed={active}
+      >
+        <IntegrationIcon integrationName={option.integrationName} className="mt-0.5 size-5 shrink-0" size={20} />
+        <span className="min-w-0 flex-1">
+          <span className="block text-[13px] font-medium">{hostedProviderLabel(option.provider)}</span>
+          <span className="mt-0.5 block text-[12px] text-muted-foreground">
+            Use a {hostedProviderLabel(option.provider)} key with {option.runner}.
+          </span>
+        </span>
+      </button>
+      {readyCount > 0 ? (
+        <span className="flex shrink-0 items-center gap-1.5 text-[12px] text-emerald-700 dark:text-emerald-300">
+          {active ? <Check className="size-3.5" aria-hidden /> : <KeyRound className="size-3.5" aria-hidden />}
+          {readyCount === 1 ? "Connected" : `${readyCount} connected`}
+        </span>
+      ) : (
+        <Button type="button" variant="outline" size="sm" onClick={onConnect}>
+          Connect
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function optionClassName(active: boolean): string {
+  return `flex items-start gap-3 rounded-lg border p-4 transition-colors ${
+    active ? "border-foreground bg-accent/40" : "border-border bg-background hover:bg-accent/20"
+  }`;
+}

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsModelsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsModelsPage.tsx
@@ -2,7 +2,6 @@ import { PermissionTooltip } from "@/components/PermissionGate";
 import { Text } from "@/components/Text/text";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { usePermissions } from "@/contexts/usePermissions";
 import { useConnectedIntegrations } from "@/hooks/useIntegrations";
 import { useFactoryLLMModels, useUpdateFactoryLLMModels } from "@/hooks/useLLMModelAllowlists";
@@ -13,22 +12,27 @@ import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
 import { useIntegrationConnectDialog } from "@/pages/home/useIntegrationConnectDialog";
 import { ModelAllowlistEditor } from "@/pages/organization/settings/ModelAllowlistEditor";
-import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
 import { Switch } from "@/ui/switch";
-import { Check, CircleDollarSign, Cpu, KeyRound } from "lucide-react";
 import { useState } from "react";
 import { useLocation } from "react-router";
 
 import { FactorySettingsCard, FactorySettingsPageFrame } from "./FactorySettingsCard";
+import {
+  AgentCredentialSelection,
+  AgentResolutionPreview,
+  AgentSummary,
+  HostedOption,
+  ProviderCard,
+} from "./FactorySettingsAgentCards";
 import { useFactorySettingsLayout } from "./factorySettingsLayoutContext";
 import { useFactoryAgent } from "./useFactoryAgent";
 import {
+  agentProviderToApi,
+  countReadyAgentIntegrations,
   factoryAgentProviders,
-  providerFor,
   resolveAgentModels,
   type AgentProvider,
   type CredentialSource,
-  type ProviderOption,
   useFactoryAgentSelection,
 } from "./useFactoryAgentSelection";
 
@@ -92,7 +96,7 @@ export function FactorySettingsModelsPage() {
               key={option.provider}
               active={source === "integration" && provider === option.provider}
               option={option}
-              readyCount={countReadyIntegrations(integrations, option.integrationName)}
+              readyCount={countReadyAgentIntegrations(integrations, option.integrationName)}
               onSelect={() => {
                 setSource("integration");
                 setProvider(option.provider);
@@ -146,6 +150,7 @@ export function FactorySettingsModelsPage() {
           onboarding default.
         </Text>
         <FactoryProviderModelSection
+          key={`${provider}-${source}`}
           organizationId={organizationId}
           factoryId={factoryId}
           provider={provider}
@@ -176,7 +181,7 @@ function useSaveFactoryAgent({
     if (source === "integration" && !integrationId) return;
     try {
       await updateAgent.mutateAsync({
-        provider: providerToApi(provider),
+        provider: agentProviderToApi(provider),
         credentialSource:
           source === "hosted" ? "AGENT_CREDENTIAL_SOURCE_HOSTED" : "AGENT_CREDENTIAL_SOURCE_INTEGRATION",
         ...(source === "integration" ? { integrationId } : {}),
@@ -187,207 +192,6 @@ function useSaveFactoryAgent({
     }
   };
   return { saveAgent, isPending: updateAgent.isPending };
-}
-
-function AgentSummary({
-  onboarding,
-}: {
-  onboarding: { agentProvider?: string; agentModel?: string; agentPlanningModel?: string } | undefined;
-}) {
-  const provider = providerFor(onboarding);
-  const model = onboarding?.agentModel || "onboarding default";
-  const planningModel = onboarding?.agentPlanningModel || model;
-  return (
-    <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-4">
-      <Cpu className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
-      <div>
-        <p className="text-[13px] font-medium">
-          {hostedProviderLabel(provider)} · {model} coding · {planningModel} planning
-        </p>
-        <p className="mt-1 text-[12px] text-muted-foreground">
-          Planning uses the review model. Implementation and Backlog use the coding model.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function AgentResolutionPreview({
-  source,
-  provider,
-  resolution,
-}: {
-  source: CredentialSource;
-  provider: ProviderOption;
-  resolution: { codingModel: string; planningModel: string };
-}) {
-  return (
-    <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
-      <p className="text-[13px] font-medium">Will use {provider.runner}</p>
-      <p className="mt-1 text-[12px] text-muted-foreground">
-        {source === "hosted" ? "SuperPlane-hosted credit" : `${hostedProviderLabel(provider.provider)} key`} · coding{" "}
-        {resolution.codingModel} · planning {resolution.planningModel}
-      </p>
-    </div>
-  );
-}
-
-function AgentCredentialSelection({
-  source,
-  provider,
-  integrationId,
-  readyIntegrations,
-  onProviderChange,
-  onIntegrationChange,
-}: {
-  source: CredentialSource;
-  provider: AgentProvider;
-  integrationId: string;
-  readyIntegrations: Array<{ metadata?: { id?: string; name?: string } }>;
-  onProviderChange: (provider: AgentProvider) => void;
-  onIntegrationChange: (integrationId: string) => void;
-}) {
-  if (source === "integration") {
-    return (
-      <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
-        <Label htmlFor="factory-agent-integration" className="text-[13px] font-medium">
-          {hostedProviderLabel(provider)} key
-        </Label>
-        {readyIntegrations.length > 0 ? (
-          <Select value={integrationId} onValueChange={onIntegrationChange}>
-            <SelectTrigger id="factory-agent-integration" className="mt-2 h-9">
-              <SelectValue placeholder={`Select a ${hostedProviderLabel(provider)} key`} />
-            </SelectTrigger>
-            <SelectContent>
-              {readyIntegrations.map((integration) => (
-                <SelectItem key={integration.metadata?.id} value={integration.metadata?.id ?? ""}>
-                  {integration.metadata?.name || integration.metadata?.id}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        ) : (
-          <Text className="mt-2 text-[13px] text-muted-foreground">
-            Connect a {hostedProviderLabel(provider)} key to use this provider.
-          </Text>
-        )}
-      </div>
-    );
-  }
-
-  return (
-    <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
-      <Label htmlFor="factory-agent-hosted-provider" className="text-[13px] font-medium">
-        Hosted provider
-      </Label>
-      <Select value={provider} onValueChange={(value) => onProviderChange(value as AgentProvider)}>
-        <SelectTrigger id="factory-agent-hosted-provider" className="mt-2 h-9">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {factoryAgentProviders.map((option) => (
-            <SelectItem key={option.provider} value={option.provider}>
-              {hostedProviderLabel(option.provider)} · {option.runner}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
-
-function HostedOption({
-  active,
-  provider,
-  onSelect,
-}: {
-  active: boolean;
-  provider: AgentProvider;
-  onSelect: () => void;
-}) {
-  return (
-    <button type="button" onClick={onSelect} className={optionClassName(active)} aria-pressed={active}>
-      <CircleDollarSign className="mt-0.5 size-5 shrink-0" aria-hidden />
-      <span className="min-w-0 flex-1 text-left">
-        <span className="block text-[13px] font-medium">SuperPlane-hosted credit</span>
-        <span className="mt-0.5 block text-[12px] text-muted-foreground">
-          Use hosted {hostedProviderLabel(provider)} models for this workspace.
-        </span>
-      </span>
-      {active ? <Check className="size-4 shrink-0" aria-hidden /> : null}
-    </button>
-  );
-}
-
-function ProviderCard({
-  active,
-  option,
-  readyCount,
-  onSelect,
-  onConnect,
-}: {
-  active: boolean;
-  option: ProviderOption;
-  readyCount: number;
-  onSelect: () => void;
-  onConnect: () => void;
-}) {
-  return (
-    <div className={optionClassName(active)}>
-      <button
-        type="button"
-        onClick={onSelect}
-        className="flex min-w-0 flex-1 items-start gap-3 text-left"
-        aria-pressed={active}
-      >
-        <IntegrationIcon integrationName={option.integrationName} className="mt-0.5 size-5 shrink-0" size={20} />
-        <span className="min-w-0 flex-1">
-          <span className="block text-[13px] font-medium">{hostedProviderLabel(option.provider)}</span>
-          <span className="mt-0.5 block text-[12px] text-muted-foreground">
-            Use a {hostedProviderLabel(option.provider)} key with {option.runner}.
-          </span>
-        </span>
-      </button>
-      {readyCount > 0 ? (
-        <span className="flex shrink-0 items-center gap-1.5 text-[12px] text-emerald-700 dark:text-emerald-300">
-          {active ? <Check className="size-3.5" aria-hidden /> : <KeyRound className="size-3.5" aria-hidden />}
-          {readyCount === 1 ? "Connected" : `${readyCount} connected`}
-        </span>
-      ) : (
-        <Button type="button" variant="outline" size="sm" onClick={onConnect}>
-          Connect
-        </Button>
-      )}
-    </div>
-  );
-}
-
-function optionClassName(active: boolean): string {
-  return `flex items-start gap-3 rounded-lg border p-4 transition-colors ${
-    active ? "border-foreground bg-accent/40" : "border-border bg-background hover:bg-accent/20"
-  }`;
-}
-
-function providerToApi(
-  provider: AgentProvider,
-): "AGENT_PROVIDER_ANTHROPIC" | "AGENT_PROVIDER_OPENAI" | "AGENT_PROVIDER_OPENROUTER" {
-  switch (provider) {
-    case "anthropic":
-      return "AGENT_PROVIDER_ANTHROPIC";
-    case "openai":
-      return "AGENT_PROVIDER_OPENAI";
-    case "openrouter":
-      return "AGENT_PROVIDER_OPENROUTER";
-  }
-}
-
-function countReadyIntegrations(
-  integrations: Array<{ metadata?: { integrationName?: string }; status?: { state?: string } }>,
-  name: string,
-) {
-  return integrations.filter(
-    (integration) => integration.metadata?.integrationName === name && integration.status?.state === "ready",
-  ).length;
 }
 
 function FactoryProviderModelSection({

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsModelsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsModelsPage.tsx
@@ -1,57 +1,393 @@
 import { PermissionTooltip } from "@/components/PermissionGate";
+import { Text } from "@/components/Text/text";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/ui/switch";
-import { Text } from "@/components/Text/text";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { usePermissions } from "@/contexts/usePermissions";
+import { useConnectedIntegrations } from "@/hooks/useIntegrations";
+import { useFactoryLLMModels, useUpdateFactoryLLMModels } from "@/hooks/useLLMModelAllowlists";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { BYOK_PROVIDERS, useFactoryLLMModels, useUpdateFactoryLLMModels } from "@/hooks/useLLMModelAllowlists";
 import { getApiErrorMessage } from "@/lib/errors";
 import { hostedProviderLabel } from "@/lib/hostedCredit";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import type { IntegrationSelections } from "@/pages/home/InstallIntegrationsSection";
+import { useIntegrationConnectDialog } from "@/pages/home/useIntegrationConnectDialog";
 import { ModelAllowlistEditor } from "@/pages/organization/settings/ModelAllowlistEditor";
+import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
+import { Switch } from "@/ui/switch";
+import { Check, CircleDollarSign, Cpu, KeyRound } from "lucide-react";
 import { useState } from "react";
+import { useLocation } from "react-router";
+
 import { FactorySettingsCard, FactorySettingsPageFrame } from "./FactorySettingsCard";
 import { useFactorySettingsLayout } from "./factorySettingsLayoutContext";
-
-const PROVIDERS = [...BYOK_PROVIDERS];
+import { useFactoryAgent } from "./useFactoryAgent";
+import {
+  factoryAgentProviders,
+  providerFor,
+  resolveAgentModels,
+  type AgentProvider,
+  type CredentialSource,
+  type ProviderOption,
+  useFactoryAgentSelection,
+} from "./useFactoryAgentSelection";
 
 export function FactorySettingsModelsPage() {
   const { organizationId, factoryId, factory } = useFactorySettingsLayout();
+  const location = useLocation();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
-  const canUpdate = canAct("factories", "update");
+  const canUpdate = canAct("factories", "update") && !permissionsLoading;
+  const onboarding = factory.onboarding;
+  const [selections, setSelections] = useState<IntegrationSelections>({});
+  const { data: integrations = [] } = useConnectedIntegrations(organizationId, { enabled: Boolean(organizationId) });
+  const selection = useFactoryAgentSelection(onboarding, integrations);
+  const {
+    source,
+    setSource,
+    provider,
+    setProvider,
+    integrationId,
+    setIntegrationId,
+    selectedProvider,
+    readyIntegrations,
+    dirty,
+  } = selection;
+  const connect = useIntegrationConnectDialog({
+    organizationId,
+    returnTo: location.pathname,
+    integrationNames: factoryAgentProviders.map((option) => option.integrationName),
+    selections,
+    onSelectionsChange: setSelections,
+  });
+  const { saveAgent, isPending: agentSavePending } = useSaveFactoryAgent({
+    organizationId,
+    factoryId,
+    provider,
+    source,
+    integrationId,
+  });
+  const agentModels = useFactoryLLMModels(
+    organizationId,
+    factoryId,
+    provider,
+    source === "hosted" ? "hosted" : "byok",
+    Boolean(organizationId && factoryId),
+  );
 
   usePageTitle(["Models", "Settings", factory.name ?? "Workspace"]);
+
+  const resolvedAgent = resolveAgentModels(selectedProvider, source, agentModels.data?.selected ?? []);
 
   return (
     <FactorySettingsPageFrame
       title="Models"
-      subtitle="Limit SuperPlane-hosted and your-key models for this workspace. An empty list uses the organization list."
+      subtitle="Choose the agent provider and credentials for generated workspace automations."
     >
-      {PROVIDERS.map((provider) => (
-        <FactorySettingsCard key={provider} title={hostedProviderLabel(provider)}>
-          <FactoryProviderModelSection
-            organizationId={organizationId}
-            factoryId={factoryId}
-            provider={provider}
-            fundingSource="hosted"
-            title="SuperPlane-hosted models"
-            canUpdate={canUpdate && !permissionsLoading}
-          />
-          <div className="mt-6 border-t border-border pt-4">
-            <FactoryProviderModelSection
-              organizationId={organizationId}
-              factoryId={factoryId}
-              provider={provider}
-              fundingSource="byok"
-              title="Use your keys"
-              canUpdate={canUpdate && !permissionsLoading}
+      <FactorySettingsCard title="Workspace agent" data-testid="factory-settings-agent">
+        <AgentSummary onboarding={onboarding} />
+        <div className="mt-5 grid gap-3">
+          <HostedOption active={source === "hosted"} provider={provider} onSelect={() => setSource("hosted")} />
+          {factoryAgentProviders.map((option) => (
+            <ProviderCard
+              key={option.provider}
+              active={source === "integration" && provider === option.provider}
+              option={option}
+              readyCount={countReadyIntegrations(integrations, option.integrationName)}
+              onSelect={() => {
+                setSource("integration");
+                setProvider(option.provider);
+                const next = integrations.find(
+                  (integration) =>
+                    integration.metadata?.integrationName === option.integrationName &&
+                    integration.status?.state === "ready",
+                );
+                setIntegrationId(next?.metadata?.id ?? "");
+              }}
+              onConnect={() => connect.createNew(option.integrationName)}
             />
-          </div>
-        </FactorySettingsCard>
-      ))}
+          ))}
+        </div>
+
+        <AgentCredentialSelection
+          source={source}
+          provider={provider}
+          integrationId={integrationId}
+          readyIntegrations={readyIntegrations}
+          onProviderChange={setProvider}
+          onIntegrationChange={setIntegrationId}
+        />
+
+        <AgentResolutionPreview source={source} provider={selectedProvider} resolution={resolvedAgent} />
+
+        <div className="mt-4 flex items-center justify-between gap-4 border-t border-border pt-4">
+          <Text className="max-w-xl text-[12px] text-muted-foreground">
+            Saving updates generated Planning, Implementation, and Backlog runners. Current runs keep their existing
+            version.
+          </Text>
+          <PermissionTooltip
+            allowed={canUpdate || permissionsLoading}
+            message="You do not have permission to update this workspace."
+          >
+            <Button
+              type="button"
+              disabled={!dirty || !canUpdate || agentSavePending || (source === "integration" && !integrationId)}
+              onClick={() => void saveAgent()}
+              data-testid="factory-settings-agent-save"
+            >
+              {agentSavePending ? "Saving..." : "Save agent"}
+            </Button>
+          </PermissionTooltip>
+        </div>
+      </FactorySettingsCard>
+
+      <FactorySettingsCard title="Available models">
+        <Text className="text-[13px] text-muted-foreground">
+          Choose which {hostedProviderLabel(provider)} models this workspace can use. The workspace agent uses the
+          onboarding default.
+        </Text>
+        <FactoryProviderModelSection
+          organizationId={organizationId}
+          factoryId={factoryId}
+          provider={provider}
+          fundingSource={source === "hosted" ? "hosted" : "byok"}
+          canUpdate={canUpdate}
+        />
+      </FactorySettingsCard>
+      {connect.dialogs}
     </FactorySettingsPageFrame>
   );
+}
+
+function useSaveFactoryAgent({
+  organizationId,
+  factoryId,
+  provider,
+  source,
+  integrationId,
+}: {
+  organizationId: string;
+  factoryId: string;
+  provider: AgentProvider;
+  source: CredentialSource;
+  integrationId: string;
+}) {
+  const updateAgent = useFactoryAgent(organizationId, factoryId);
+  const saveAgent = async () => {
+    if (source === "integration" && !integrationId) return;
+    try {
+      await updateAgent.mutateAsync({
+        provider: providerToApi(provider),
+        credentialSource:
+          source === "hosted" ? "AGENT_CREDENTIAL_SOURCE_HOSTED" : "AGENT_CREDENTIAL_SOURCE_INTEGRATION",
+        ...(source === "integration" ? { integrationId } : {}),
+      });
+      showSuccessToast("Workspace agent updated.");
+    } catch (error) {
+      showErrorToast(getApiErrorMessage(error, "Unable to update the workspace agent."));
+    }
+  };
+  return { saveAgent, isPending: updateAgent.isPending };
+}
+
+function AgentSummary({
+  onboarding,
+}: {
+  onboarding: { agentProvider?: string; agentModel?: string; agentPlanningModel?: string } | undefined;
+}) {
+  const provider = providerFor(onboarding);
+  const model = onboarding?.agentModel || "onboarding default";
+  const planningModel = onboarding?.agentPlanningModel || model;
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-4">
+      <Cpu className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
+      <div>
+        <p className="text-[13px] font-medium">
+          {hostedProviderLabel(provider)} · {model} coding · {planningModel} planning
+        </p>
+        <p className="mt-1 text-[12px] text-muted-foreground">
+          Planning uses the review model. Implementation and Backlog use the coding model.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AgentResolutionPreview({
+  source,
+  provider,
+  resolution,
+}: {
+  source: CredentialSource;
+  provider: ProviderOption;
+  resolution: { codingModel: string; planningModel: string };
+}) {
+  return (
+    <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
+      <p className="text-[13px] font-medium">Will use {provider.runner}</p>
+      <p className="mt-1 text-[12px] text-muted-foreground">
+        {source === "hosted" ? "SuperPlane-hosted credit" : `${hostedProviderLabel(provider.provider)} key`} · coding{" "}
+        {resolution.codingModel} · planning {resolution.planningModel}
+      </p>
+    </div>
+  );
+}
+
+function AgentCredentialSelection({
+  source,
+  provider,
+  integrationId,
+  readyIntegrations,
+  onProviderChange,
+  onIntegrationChange,
+}: {
+  source: CredentialSource;
+  provider: AgentProvider;
+  integrationId: string;
+  readyIntegrations: Array<{ metadata?: { id?: string; name?: string } }>;
+  onProviderChange: (provider: AgentProvider) => void;
+  onIntegrationChange: (integrationId: string) => void;
+}) {
+  if (source === "integration") {
+    return (
+      <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
+        <Label htmlFor="factory-agent-integration" className="text-[13px] font-medium">
+          {hostedProviderLabel(provider)} key
+        </Label>
+        {readyIntegrations.length > 0 ? (
+          <Select value={integrationId} onValueChange={onIntegrationChange}>
+            <SelectTrigger id="factory-agent-integration" className="mt-2 h-9">
+              <SelectValue placeholder={`Select a ${hostedProviderLabel(provider)} key`} />
+            </SelectTrigger>
+            <SelectContent>
+              {readyIntegrations.map((integration) => (
+                <SelectItem key={integration.metadata?.id} value={integration.metadata?.id ?? ""}>
+                  {integration.metadata?.name || integration.metadata?.id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Text className="mt-2 text-[13px] text-muted-foreground">
+            Connect a {hostedProviderLabel(provider)} key to use this provider.
+          </Text>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
+      <Label htmlFor="factory-agent-hosted-provider" className="text-[13px] font-medium">
+        Hosted provider
+      </Label>
+      <Select value={provider} onValueChange={(value) => onProviderChange(value as AgentProvider)}>
+        <SelectTrigger id="factory-agent-hosted-provider" className="mt-2 h-9">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {factoryAgentProviders.map((option) => (
+            <SelectItem key={option.provider} value={option.provider}>
+              {hostedProviderLabel(option.provider)} · {option.runner}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function HostedOption({
+  active,
+  provider,
+  onSelect,
+}: {
+  active: boolean;
+  provider: AgentProvider;
+  onSelect: () => void;
+}) {
+  return (
+    <button type="button" onClick={onSelect} className={optionClassName(active)} aria-pressed={active}>
+      <CircleDollarSign className="mt-0.5 size-5 shrink-0" aria-hidden />
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block text-[13px] font-medium">SuperPlane-hosted credit</span>
+        <span className="mt-0.5 block text-[12px] text-muted-foreground">
+          Use hosted {hostedProviderLabel(provider)} models for this workspace.
+        </span>
+      </span>
+      {active ? <Check className="size-4 shrink-0" aria-hidden /> : null}
+    </button>
+  );
+}
+
+function ProviderCard({
+  active,
+  option,
+  readyCount,
+  onSelect,
+  onConnect,
+}: {
+  active: boolean;
+  option: ProviderOption;
+  readyCount: number;
+  onSelect: () => void;
+  onConnect: () => void;
+}) {
+  return (
+    <div className={optionClassName(active)}>
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex min-w-0 flex-1 items-start gap-3 text-left"
+        aria-pressed={active}
+      >
+        <IntegrationIcon integrationName={option.integrationName} className="mt-0.5 size-5 shrink-0" size={20} />
+        <span className="min-w-0 flex-1">
+          <span className="block text-[13px] font-medium">{hostedProviderLabel(option.provider)}</span>
+          <span className="mt-0.5 block text-[12px] text-muted-foreground">
+            Use a {hostedProviderLabel(option.provider)} key with {option.runner}.
+          </span>
+        </span>
+      </button>
+      {readyCount > 0 ? (
+        <span className="flex shrink-0 items-center gap-1.5 text-[12px] text-emerald-700 dark:text-emerald-300">
+          {active ? <Check className="size-3.5" aria-hidden /> : <KeyRound className="size-3.5" aria-hidden />}
+          {readyCount === 1 ? "Connected" : `${readyCount} connected`}
+        </span>
+      ) : (
+        <Button type="button" variant="outline" size="sm" onClick={onConnect}>
+          Connect
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function optionClassName(active: boolean): string {
+  return `flex items-start gap-3 rounded-lg border p-4 transition-colors ${
+    active ? "border-foreground bg-accent/40" : "border-border bg-background hover:bg-accent/20"
+  }`;
+}
+
+function providerToApi(
+  provider: AgentProvider,
+): "AGENT_PROVIDER_ANTHROPIC" | "AGENT_PROVIDER_OPENAI" | "AGENT_PROVIDER_OPENROUTER" {
+  switch (provider) {
+    case "anthropic":
+      return "AGENT_PROVIDER_ANTHROPIC";
+    case "openai":
+      return "AGENT_PROVIDER_OPENAI";
+    case "openrouter":
+      return "AGENT_PROVIDER_OPENROUTER";
+  }
+}
+
+function countReadyIntegrations(
+  integrations: Array<{ metadata?: { integrationName?: string }; status?: { state?: string } }>,
+  name: string,
+) {
+  return integrations.filter(
+    (integration) => integration.metadata?.integrationName === name && integration.status?.state === "ready",
+  ).length;
 }
 
 function FactoryProviderModelSection({
@@ -59,14 +395,12 @@ function FactoryProviderModelSection({
   factoryId,
   provider,
   fundingSource,
-  title,
   canUpdate,
 }: {
   organizationId: string;
   factoryId: string;
   provider: string;
   fundingSource: "hosted" | "byok";
-  title: string;
   canUpdate: boolean;
 }) {
   const factoryModels = useFactoryLLMModels(organizationId, factoryId, provider, fundingSource, true);
@@ -74,7 +408,6 @@ function FactoryProviderModelSection({
   const [query, setQuery] = useState("");
   const [inherit, setInherit] = useState<boolean | null>(null);
   const [draft, setDraft] = useState<string[] | null>(null);
-
   const parent = (factoryModels.data?.parent ?? []).map((model) => model.id ?? "").filter(Boolean);
   const inheritParent = inherit ?? factoryModels.data?.inheritParent !== false;
   const selected =
@@ -85,11 +418,7 @@ function FactoryProviderModelSection({
 
   const save = async () => {
     try {
-      await update.mutateAsync({
-        provider,
-        fundingSource,
-        allowedModels: inheritParent ? [] : selected,
-      });
+      await update.mutateAsync({ provider, fundingSource, allowedModels: inheritParent ? [] : selected });
       setDraft(null);
       setInherit(null);
       showSuccessToast("Workspace models saved.");
@@ -104,29 +433,23 @@ function FactoryProviderModelSection({
       : "No organization models are selected for this provider.";
 
   return (
-    <div>
-      <p className="text-[13px] font-medium">{title}</p>
-      <FactoryModelSectionBody
-        canUpdate={canUpdate}
-        emptyMessage={emptyMessage}
-        inheritParent={inheritParent}
-        isLoading={factoryModels.isLoading}
-        isPending={update.isPending}
-        parent={parent}
-        query={query}
-        selected={selected}
-        title={title}
-        onInheritChange={(checked) => {
-          setInherit(checked);
-          if (!checked) {
-            setDraft(selected.length > 0 ? selected : parent);
-          }
-        }}
-        onQueryChange={setQuery}
-        onSave={() => void save()}
-        onToggle={(model, checked) => setDraft(checked ? [...selected, model] : selected.filter((id) => id !== model))}
-      />
-    </div>
+    <FactoryModelSectionBody
+      canUpdate={canUpdate}
+      emptyMessage={emptyMessage}
+      inheritParent={inheritParent}
+      isLoading={factoryModels.isLoading}
+      isPending={update.isPending}
+      parent={parent}
+      query={query}
+      selected={selected}
+      onInheritChange={(checked) => {
+        setInherit(checked);
+        if (!checked) setDraft(selected.length > 0 ? selected : parent);
+      }}
+      onQueryChange={setQuery}
+      onSave={() => void save()}
+      onToggle={(model, checked) => setDraft(checked ? [...selected, model] : selected.filter((id) => id !== model))}
+    />
   );
 }
 
@@ -139,7 +462,6 @@ function FactoryModelSectionBody({
   parent,
   query,
   selected,
-  title,
   onInheritChange,
   onQueryChange,
   onSave,
@@ -153,21 +475,16 @@ function FactoryModelSectionBody({
   parent: string[];
   query: string;
   selected: string[];
-  title: string;
   onInheritChange: (checked: boolean) => void;
   onQueryChange: (query: string) => void;
   onSave: () => void;
   onToggle: (model: string, checked: boolean) => void;
 }) {
-  if (isLoading) {
-    return <Text className="mt-2 text-[13px] text-muted-foreground">Loading models...</Text>;
-  }
-  if (parent.length === 0) {
-    return <Text className="mt-2 text-[13px] text-muted-foreground">{emptyMessage}</Text>;
-  }
+  if (isLoading) return <Text className="mt-4 text-[13px] text-muted-foreground">Loading models...</Text>;
+  if (parent.length === 0) return <Text className="mt-4 text-[13px] text-muted-foreground">{emptyMessage}</Text>;
 
   return (
-    <div className="mt-3 space-y-3">
+    <div className="mt-4 space-y-3">
       <div className="flex items-center justify-between gap-3">
         <Label className="text-[13px]">Use organization list</Label>
         <Switch checked={inheritParent} disabled={!canUpdate || isPending} onCheckedChange={onInheritChange} />
@@ -182,16 +499,12 @@ function FactoryModelSectionBody({
           onQueryChange={onQueryChange}
           onToggle={onToggle}
           disabled={!canUpdate || isPending}
-          searchLabel={`Search ${title}`}
+          searchLabel="Search available models"
         />
       )}
-      {canUpdate ? (
-        <PermissionTooltip allowed={canUpdate} message="You do not have permission to update workspace models.">
-          <Button type="button" onClick={onSave} disabled={isPending}>
-            {isPending ? "Saving..." : "Save models"}
-          </Button>
-        </PermissionTooltip>
-      ) : null}
+      <Button type="button" onClick={onSave} disabled={!canUpdate || isPending}>
+        {isPending ? "Saving..." : "Save models"}
+      </Button>
     </div>
   );
 }

--- a/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
+++ b/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
@@ -107,6 +107,17 @@ export const Models: Story = {
   ),
 };
 
+export const ModelsWithOwnKey: Story = {
+  name: "Models (own key)",
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/models`}
+      factoriesFixture={factoriesFixtureWithSetupAnswers(SETUP_ANSWERS.agent)}
+      orgIntegrations={CONNECTED_SETUP_INTEGRATIONS}
+    />
+  ),
+};
+
 export const Spending: Story = {
   render: () => (
     <FactoriesHarness

--- a/web_src/src/pages/factories/pages/settings/useFactoryAgent.ts
+++ b/web_src/src/pages/factories/pages/settings/useFactoryAgent.ts
@@ -1,0 +1,28 @@
+import { factoriesUpdateFactoryAgent, type FactoriesUpdateFactoryAgentBody } from "@/api-client";
+import { factoryQueryKeys } from "@/hooks/useFactoryData";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useFactoryAgent(organizationId: string, factoryId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: FactoriesUpdateFactoryAgentBody) => {
+      const response = await factoriesUpdateFactoryAgent(
+        withOrganizationHeader({
+          organizationId,
+          path: { id: factoryId },
+          body: input,
+        }),
+      );
+      if (!response.data?.factory) {
+        throw new Error("Failed to update workspace agent");
+      }
+      return response.data.factory;
+    },
+    onSuccess: (factory) => {
+      queryClient.setQueryData(factoryQueryKeys.detail(organizationId, factoryId), factory);
+      void queryClient.invalidateQueries({ queryKey: factoryQueryKeys.list(organizationId) });
+    },
+  });
+}

--- a/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.spec.ts
+++ b/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { providerFor } from "./useFactoryAgentSelection";
+
+describe("providerFor", () => {
+  it("uses the persisted Anthropic provider before legacy heuristics", () => {
+    expect(
+      providerFor({
+        agentProvider: "AGENT_PROVIDER_ANTHROPIC",
+        agentHarness: "AGENT_HARNESS_CODEX",
+      }),
+    ).toBe("anthropic");
+  });
+});

--- a/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.ts
+++ b/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.ts
@@ -105,6 +105,8 @@ export function useFactoryAgentSelection(onboarding: AgentOnboarding | undefined
 
 export function providerFor(onboarding: AgentOnboarding | undefined): AgentProvider {
   switch (onboarding?.agentProvider) {
+    case "AGENT_PROVIDER_ANTHROPIC":
+      return "anthropic";
     case "AGENT_PROVIDER_OPENAI":
       return "openai";
     case "AGENT_PROVIDER_OPENROUTER":

--- a/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.ts
+++ b/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.ts
@@ -52,6 +52,7 @@ type AgentOnboarding = {
   agentIntegrationId?: string;
   agentProvider?: string;
   agentHarness?: string;
+  agentModel?: string;
 };
 
 export function useFactoryAgentSelection(onboarding: AgentOnboarding | undefined, integrations: AgentIntegration[]) {
@@ -109,7 +110,9 @@ export function providerFor(onboarding: AgentOnboarding | undefined): AgentProvi
     case "AGENT_PROVIDER_OPENROUTER":
       return "openrouter";
     default:
-      return onboarding?.agentHarness === "AGENT_HARNESS_CODEX" ? "openai" : "anthropic";
+      if (onboarding?.agentHarness === "AGENT_HARNESS_CODEX") return "openai";
+      if (onboarding?.agentModel?.startsWith("anthropic/")) return "openrouter";
+      return "anthropic";
   }
 }
 

--- a/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.ts
+++ b/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.ts
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from "react";
+
+export type AgentProvider = "anthropic" | "openai" | "openrouter";
+export type CredentialSource = "hosted" | "integration";
+
+export type ProviderOption = {
+  provider: AgentProvider;
+  integrationName: "claude" | "openai" | "openrouter";
+  runner: string;
+  codingModel: string;
+  planningModel: string;
+  codingHint: string;
+  planningHint: string;
+};
+
+export const factoryAgentProviders: ProviderOption[] = [
+  {
+    provider: "anthropic",
+    integrationName: "claude",
+    runner: "Claude Code",
+    codingModel: "sonnet",
+    planningModel: "opus",
+    codingHint: "sonnet",
+    planningHint: "opus",
+  },
+  {
+    provider: "openai",
+    integrationName: "openai",
+    runner: "Codex",
+    codingModel: "gpt-5",
+    planningModel: "gpt-5",
+    codingHint: "gpt-5",
+    planningHint: "gpt-5",
+  },
+  {
+    provider: "openrouter",
+    integrationName: "openrouter",
+    runner: "OpenRouter",
+    codingModel: "anthropic/claude-sonnet-4-6",
+    planningModel: "anthropic/claude-opus-4-6",
+    codingHint: "sonnet",
+    planningHint: "opus",
+  },
+];
+
+type AgentIntegration = {
+  metadata?: { id?: string; integrationName?: string };
+  status?: { state?: string };
+};
+
+type AgentOnboarding = {
+  agentIntegrationId?: string;
+  agentProvider?: string;
+  agentHarness?: string;
+};
+
+export function useFactoryAgentSelection(onboarding: AgentOnboarding | undefined, integrations: AgentIntegration[]) {
+  const [source, setSource] = useState<CredentialSource>(() => credentialSourceFor(onboarding?.agentIntegrationId));
+  const [provider, setProvider] = useState<AgentProvider>(() => providerFor(onboarding));
+  const [integrationId, setIntegrationId] = useState(onboarding?.agentIntegrationId ?? "");
+
+  useEffect(() => {
+    setSource(credentialSourceFor(onboarding?.agentIntegrationId));
+    setProvider(providerFor(onboarding));
+    setIntegrationId(onboarding?.agentIntegrationId ?? "");
+  }, [onboarding]);
+
+  const selectedProvider =
+    factoryAgentProviders.find((option) => option.provider === provider) ?? factoryAgentProviders[0];
+  const readyIntegrations = useMemo(
+    () =>
+      integrations.filter(
+        (integration) =>
+          integration.metadata?.integrationName === selectedProvider.integrationName &&
+          integration.status?.state === "ready",
+      ),
+    [integrations, selectedProvider.integrationName],
+  );
+  useEffect(() => {
+    if (source !== "integration" || integrationId || readyIntegrations.length === 0) return;
+    setIntegrationId(readyIntegrations[0]?.metadata?.id ?? "");
+  }, [integrationId, readyIntegrations, source]);
+  useEffect(() => {
+    if (onboarding?.agentProvider || !onboarding?.agentIntegrationId) return;
+    const integration = integrations.find((item) => item.metadata?.id === onboarding.agentIntegrationId);
+    const option = factoryAgentProviders.find(
+      (item) => item.integrationName === integration?.metadata?.integrationName,
+    );
+    if (option) setProvider(option.provider);
+  }, [integrations, onboarding?.agentIntegrationId, onboarding?.agentProvider]);
+
+  return {
+    source,
+    setSource,
+    provider,
+    setProvider,
+    integrationId,
+    setIntegrationId,
+    selectedProvider,
+    readyIntegrations,
+    dirty: isSelectionDirty({ source, provider, integrationId, onboarding }),
+  };
+}
+
+export function providerFor(onboarding: AgentOnboarding | undefined): AgentProvider {
+  switch (onboarding?.agentProvider) {
+    case "AGENT_PROVIDER_OPENAI":
+      return "openai";
+    case "AGENT_PROVIDER_OPENROUTER":
+      return "openrouter";
+    default:
+      return onboarding?.agentHarness === "AGENT_HARNESS_CODEX" ? "openai" : "anthropic";
+  }
+}
+
+export function resolveAgentModels(
+  provider: ProviderOption,
+  source: CredentialSource,
+  availableModels: Array<{ id?: string }>,
+): { codingModel: string; planningModel: string } {
+  if (source === "integration") {
+    return { codingModel: provider.codingModel, planningModel: provider.planningModel };
+  }
+  const modelIDs = availableModels
+    .map((model) => model.id ?? "")
+    .filter(Boolean)
+    .sort();
+  if (modelIDs.length === 0) {
+    return { codingModel: provider.codingModel, planningModel: provider.planningModel };
+  }
+  const codingModel =
+    modelIDs.find((model) => model.toLowerCase().includes(provider.codingHint)) ?? modelIDs[0] ?? provider.codingModel;
+  const planningModel = modelIDs.find((model) => model.toLowerCase().includes(provider.planningHint)) ?? codingModel;
+  return { codingModel, planningModel };
+}
+
+function credentialSourceFor(integrationId: string | undefined): CredentialSource {
+  return integrationId ? "integration" : "hosted";
+}
+
+function isSelectionDirty({
+  source,
+  provider,
+  integrationId,
+  onboarding,
+}: {
+  source: CredentialSource;
+  provider: AgentProvider;
+  integrationId: string;
+  onboarding: AgentOnboarding | undefined;
+}): boolean {
+  if (source !== credentialSourceFor(onboarding?.agentIntegrationId)) return true;
+  if (provider !== providerFor(onboarding)) return true;
+  if (source !== "integration") return false;
+  return integrationId !== (onboarding?.agentIntegrationId ?? "");
+}

--- a/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.ts
+++ b/web_src/src/pages/factories/pages/settings/useFactoryAgentSelection.ts
@@ -134,6 +134,28 @@ export function resolveAgentModels(
   return { codingModel, planningModel };
 }
 
+export function countReadyAgentIntegrations(
+  integrations: Array<{ metadata?: { integrationName?: string }; status?: { state?: string } }>,
+  name: string,
+) {
+  return integrations.filter(
+    (integration) => integration.metadata?.integrationName === name && integration.status?.state === "ready",
+  ).length;
+}
+
+export function agentProviderToApi(
+  provider: AgentProvider,
+): "AGENT_PROVIDER_ANTHROPIC" | "AGENT_PROVIDER_OPENAI" | "AGENT_PROVIDER_OPENROUTER" {
+  switch (provider) {
+    case "anthropic":
+      return "AGENT_PROVIDER_ANTHROPIC";
+    case "openai":
+      return "AGENT_PROVIDER_OPENAI";
+    case "openrouter":
+      return "AGENT_PROVIDER_OPENROUTER";
+  }
+}
+
 function credentialSourceFor(integrationId: string | undefined): CredentialSource {
   return integrationId ? "integration" : "hosted";
 }


### PR DESCRIPTION
## Summary

- Add workspace agent settings that use the same resolved provider configuration as onboarding.
- Update recognized generated Planning, Implementation, and Backlog runners after a provider or credential change.
- Keep custom runners and active run canvas versions unchanged.

## Test plan

- [x] Run focused factory agent tests with the test database.
- [x] Run `make check.build.app`.
- [x] Run `make check.proto.field.numbers`.
- [x] Run `make check.lint.ui`.
- [x] Run the UI production and Storybook builds.