### PR TITLE
feat: Skip agent setup on hosted credentials

### DIFF
--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
@@ -1,0 +1,138 @@
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FactoriesFactory } from "@/api-client";
+
+import { FIRST_RUN_COPY } from "./first-run/firstRunCopy";
+import { FirstRunSetup } from "./FirstRunSetup";
+import { useOnboardingSetupState, type OnboardingSetupApi } from "./useOnboardingSetupState";
+import type { useOnboardingPageModel } from "./useOnboardingPageModel";
+
+type OnboardingPageModel = ReturnType<typeof useOnboardingPageModel>;
+
+let factory: FactoriesFactory;
+
+vi.mock("../../layout/factoriesLayoutContext", () => ({
+  useFactoriesLayout: () => ({
+    organizationId: "org-1",
+    factoryId: "factory-1",
+    factoryKey: "PAY",
+    factory,
+  }),
+}));
+
+vi.mock("@/contexts/useAccount", () => ({
+  useAccount: () => ({ account: { id: "user-1", name: "Ada Lovelace", email: "ada@example.com" } }),
+}));
+
+vi.mock("@/posthog", () => ({ posthog: { reset: vi.fn() } }));
+
+// The agent step reports organization spend, which this flow test does not use.
+vi.mock("./AgentStep", () => ({
+  AgentStep: () => <div data-testid="agent-step" />,
+}));
+
+function setupState(): OnboardingSetupApi {
+  const { result } = renderHook(() => useOnboardingSetupState("Payments Service", { simulateDiscovery: false }));
+  return result.current;
+}
+
+function pageModel(overrides: Partial<OnboardingPageModel> = {}): OnboardingPageModel {
+  return {
+    setup: setupState(),
+    hostedAgentReady: false,
+    openSection: "issues",
+    setOpenSection: vi.fn(),
+    requestConnect: vi.fn(),
+    requestPrivateGitHubConnect: vi.fn(),
+    offersPrivateGitHubAppSetup: false,
+    createVcsConnection: vi.fn(),
+    selectVcsConnection: vi.fn(),
+    githubConnections: { name: "github", allInstances: [], readyInstances: [] },
+    selectedVcsConnectionId: "github-1",
+    requestConfigure: vi.fn(),
+    integrationDialogs: null,
+    repositories: ["acme/payments-service"],
+    repositoriesLoading: false,
+    repositoriesError: null,
+    canConfigureWorkspace: true,
+    saving: false,
+    saveName: vi.fn().mockResolvedValue(true),
+    saveRepository: vi.fn().mockResolvedValue(true),
+    saveIssues: vi.fn().mockResolvedValue(true),
+    finish: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderSetup(model: OnboardingPageModel) {
+  render(
+    <MemoryRouter initialEntries={["/org-1/workspaces/PAY/setup?step=issues"]}>
+      <FirstRunSetup model={model} />
+    </MemoryRouter>,
+  );
+}
+
+describe("FirstRunSetup", () => {
+  beforeEach(() => {
+    factory = { id: "factory-1", onboarding: { vcsIntegrationId: "github-1" } };
+  });
+
+  it("finishes setup from the ticket screen when hosted credentials cover the agent", async () => {
+    const user = userEvent.setup();
+    const model = pageModel({ hostedAgentReady: true });
+
+    renderSetup(model);
+
+    await user.click(screen.getByRole("button", { name: FIRST_RUN_COPY.tickets.analyze }));
+
+    expect(model.saveIssues).toHaveBeenCalledWith("vcs");
+    await waitFor(() => expect(model.finish).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId("first-run-agent")).not.toBeInTheDocument();
+  });
+
+  it("counts the ticket screen as the last step when the agent screen is skipped", () => {
+    renderSetup(pageModel({ hostedAgentReady: true }));
+
+    expect(screen.getByRole("navigation", { name: FIRST_RUN_COPY.chrome.stepLabel(4, 4) })).toBeInTheDocument();
+  });
+
+  it("shows setup progress on the ticket screen while it provisions the workspace", () => {
+    renderSetup(pageModel({ hostedAgentReady: true, saving: true }));
+
+    const finish = screen.getByTestId("first-run-analyze-tickets");
+    expect(finish).toHaveTextContent(FIRST_RUN_COPY.finish.saving);
+    expect(finish).toBeDisabled();
+  });
+
+  it("opens the agent screen when the agent needs a connected provider", async () => {
+    const user = userEvent.setup();
+    const model = pageModel({ hostedAgentReady: false });
+
+    renderSetup(model);
+
+    await user.click(screen.getByRole("button", { name: FIRST_RUN_COPY.tickets.continue }));
+
+    expect(model.saveIssues).toHaveBeenCalledWith("vcs");
+    expect(await screen.findByTestId("first-run-agent")).toBeInTheDocument();
+    expect(model.finish).not.toHaveBeenCalled();
+  });
+
+  // Setup saved the ticket answer, then provisioning did not finish. The user
+  // returns to the screen that carries the action, not to a screen with no
+  // question left to answer.
+  it("resumes on the ticket screen when hosted credentials cover the agent", () => {
+    renderSetup(pageModel({ hostedAgentReady: true, openSection: "agent" }));
+
+    expect(screen.getByTestId("first-run-tickets")).toBeInTheDocument();
+    expect(screen.queryByTestId("first-run-agent")).not.toBeInTheDocument();
+  });
+
+  it("resumes on the agent screen when the agent still needs a connected provider", () => {
+    renderSetup(pageModel({ hostedAgentReady: false, openSection: "agent" }));
+
+    expect(screen.getByTestId("first-run-agent")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.spec.tsx
@@ -53,7 +53,7 @@ function pageModel(overrides: Partial<OnboardingPageModel> = {}): OnboardingPage
     githubConnections: { name: "github", allInstances: [], readyInstances: [] },
     selectedVcsConnectionId: "github-1",
     requestConfigure: vi.fn(),
-    integrationDialogs: null,
+    integrationDialogs: <></>,
     repositories: ["acme/payments-service"],
     repositoriesLoading: false,
     repositoriesError: null,

--- a/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/FirstRunSetup.tsx
@@ -10,7 +10,7 @@ import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { AgentStep } from "./AgentStep";
 import { FirstRunChooseScreen } from "./first-run/FirstRunChooseScreen";
 import { FirstRunConnectScreen } from "./first-run/FirstRunConnectScreen";
-import { FirstRunHeading, FirstRunPanel, FirstRunShell } from "./first-run/FirstRunShell";
+import { FIRST_RUN_STEP_COUNT, FirstRunHeading, FirstRunPanel, FirstRunShell } from "./first-run/FirstRunShell";
 import { FirstRunTicketsScreen } from "./first-run/FirstRunTicketsScreen";
 import type { FirstRunChrome, FirstRunTicketSource } from "./first-run/firstRunTypes";
 import { FIRST_RUN_COPY } from "./first-run/firstRunCopy";
@@ -47,6 +47,15 @@ const STEP_INDEX_FOR_SCREEN: Record<FirstRunScreen, number> = {
   tickets: 3,
   agent: 4,
 };
+
+/**
+ * Hosted credentials leave the agent screen with no question to ask, so the
+ * ticket screen becomes the last screen and provisions the workspace.
+ */
+function screenWithoutAgent(screen: FirstRunScreen, skipAgentScreen: boolean): FirstRunScreen {
+  if (screen === "agent" && skipAgentScreen) return "tickets";
+  return screen;
+}
 
 /**
  * The first-run screens have no coding agent screen. This screen keeps the
@@ -132,11 +141,11 @@ function AgentScreen({
           className="w-full"
           disabled={!setup.agentReady}
           loading={saving}
-          loadingText="Finishing setup..."
+          loadingText={FIRST_RUN_COPY.finish.saving}
           onClick={onContinue}
           data-testid="first-run-finish-setup"
         >
-          Finish setup
+          {FIRST_RUN_COPY.finish.action}
         </LoadingButton>
       </div>
     </FirstRunShell>
@@ -152,11 +161,12 @@ function useFirstRunSetupFlow(model: OnboardingPageModel) {
   const [searchParams] = useSearchParams();
   const setup = model.setup;
 
-  const [screen, setScreen] = useState<FirstRunScreen>(() => {
+  const [openedScreen, setOpenedScreen] = useState<FirstRunScreen>(() => {
     const resumed = Boolean(factory?.onboarding?.vcsIntegrationId) || searchParams.get("step") !== null;
     return resumed ? SCREEN_FOR_STEP[model.openSection] : "welcome";
   });
   const openStep = useRef(model.openSection);
+  const skipAgentScreen = model.hostedAgentReady;
 
   useSingleGithubConnection(model);
   useRepositoryErrorToast(model.repositoriesError);
@@ -165,7 +175,7 @@ function useFirstRunSetupFlow(model: OnboardingPageModel) {
   useEffect(() => {
     if (model.openSection === openStep.current) return;
     openStep.current = model.openSection;
-    setScreen(SCREEN_FOR_STEP[model.openSection]);
+    setOpenedScreen(SCREEN_FOR_STEP[model.openSection]);
   }, [model.openSection]);
 
   const goToScreen = (next: FirstRunScreen) => {
@@ -175,7 +185,7 @@ function useFirstRunSetupFlow(model: OnboardingPageModel) {
       openStep.current = step;
       model.setOpenSection(step);
     }
-    setScreen(next);
+    setOpenedScreen(next);
   };
 
   const continueFromRepository = async () => {
@@ -190,6 +200,10 @@ function useFirstRunSetupFlow(model: OnboardingPageModel) {
     setup.setIssuesChoice(DEFAULT_ISSUES_CHOICE);
     setup.commitIssuesStep();
     if (!(await model.saveIssues(DEFAULT_ISSUES_CHOICE))) return;
+    if (skipAgentScreen) {
+      await model.finish();
+      return;
+    }
     goToScreen("agent");
   };
 
@@ -201,7 +215,8 @@ function useFirstRunSetupFlow(model: OnboardingPageModel) {
   };
 
   return {
-    screen,
+    screen: screenWithoutAgent(openedScreen, skipAgentScreen),
+    skipAgentScreen,
     goToScreen,
     continueFromRepository,
     continueFromTickets,
@@ -224,6 +239,7 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
     email: account?.email,
     onLogOut: signOut,
     stepIndex: STEP_INDEX_FOR_SCREEN[target],
+    stepCount: flow.skipAgentScreen ? FIRST_RUN_STEP_COUNT - 1 : FIRST_RUN_STEP_COUNT,
   });
 
   if (flow.screen === "welcome") {
@@ -267,7 +283,8 @@ export function FirstRunSetup({ model }: { model: OnboardingPageModel }) {
       <FirstRunTicketsScreen
         ticketSource={DEFAULT_TICKET_SOURCE}
         chrome={chromeFor("tickets")}
-        continueLabel={FIRST_RUN_COPY.tickets.continue}
+        continueLabel={flow.skipAgentScreen ? FIRST_RUN_COPY.tickets.analyze : FIRST_RUN_COPY.tickets.continue}
+        saving={flow.skipAgentScreen && model.saving}
         onSelectTicketSource={flow.selectTicketSource}
         onAnalyzeTickets={() => void flow.continueFromTickets()}
       />

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunShell.tsx
@@ -21,6 +21,7 @@ export function FirstRunShell({
   useFactoriesThemeClass();
   const copy = FIRST_RUN_COPY.chrome;
   const identity = chrome?.email ?? chrome?.displayName;
+  const stepCount = chrome?.stepCount ?? FIRST_RUN_STEP_COUNT;
 
   return (
     <div className="fixed inset-0 bg-background text-foreground" data-testid={testId}>
@@ -48,10 +49,10 @@ export function FirstRunShell({
       {chrome ? (
         <nav
           className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center pb-6"
-          aria-label={copy.stepLabel(chrome.stepIndex + 1, FIRST_RUN_STEP_COUNT)}
+          aria-label={copy.stepLabel(chrome.stepIndex + 1, stepCount)}
         >
           <ol className="flex items-center gap-1.5">
-            {Array.from({ length: FIRST_RUN_STEP_COUNT }, (_, index) => (
+            {Array.from({ length: stepCount }, (_, index) => (
               <li
                 key={index}
                 className={cn(

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.spec.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.spec.tsx
@@ -48,6 +48,21 @@ describe("FirstRunTicketsScreen", () => {
     expect(onAnalyzeTickets).toHaveBeenCalledTimes(1);
   });
 
+  it("shows finish progress while the screen provisions the workspace", () => {
+    render(
+      <FirstRunTicketsScreen
+        ticketSource="github-issues"
+        saving
+        onSelectTicketSource={vi.fn()}
+        onAnalyzeTickets={vi.fn()}
+      />,
+    );
+
+    const analyze = screen.getByTestId("first-run-analyze-tickets");
+    expect(analyze).toHaveTextContent(FIRST_RUN_COPY.finish.saving);
+    expect(analyze).toBeDisabled();
+  });
+
   it("uses the next-step label when setup names the coding agent step", () => {
     render(
       <FirstRunTicketsScreen

--- a/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/FirstRunTicketsScreen.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
 
 import { ConnectOptionRow, IntegrationChoiceIcon } from "../onboardingSteps";
 import { FIRST_RUN_COPY } from "./firstRunCopy";
@@ -9,12 +9,15 @@ export function FirstRunTicketsScreen({
   ticketSource,
   chrome,
   continueLabel = FIRST_RUN_COPY.tickets.analyze,
+  saving = false,
   onSelectTicketSource,
   onAnalyzeTickets,
 }: {
   ticketSource: FirstRunTicketSource | null;
   chrome?: FirstRunChrome;
   continueLabel?: string;
+  /** True while this screen provisions the workspace, on the last screen. */
+  saving?: boolean;
   onSelectTicketSource: (source: FirstRunTicketSource) => void;
   onAnalyzeTickets: () => void;
 }) {
@@ -56,15 +59,17 @@ export function FirstRunTicketsScreen({
             <p>{copy.trust}</p>
             <p>{copy.scoreHint}</p>
           </div>
-          <Button
+          <LoadingButton
             type="button"
             className="w-full"
             disabled={!ticketSource}
+            loading={saving}
+            loadingText={FIRST_RUN_COPY.finish.saving}
             onClick={onAnalyzeTickets}
             data-testid="first-run-analyze-tickets"
           >
             {continueLabel}
-          </Button>
+          </LoadingButton>
         </div>
       </div>
     </FirstRunShell>

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunCopy.ts
@@ -49,6 +49,12 @@ export const FIRST_RUN_COPY = {
   agent: {
     headline: "Connect agent",
   },
+  // Shared by every screen that provisions the workspace. Hosted credentials
+  // move that action from the agent screen to the ticket screen.
+  finish: {
+    action: "Finish setup",
+    saving: "Finishing setup...",
+  },
   analysis: {
     headline: "Analyzing your backlog",
     body: "SuperPlane reads your code and your tickets. This takes a few minutes.",

--- a/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
+++ b/web_src/src/pages/factories/pages/onboarding/first-run/firstRunTypes.ts
@@ -5,6 +5,8 @@ export type FirstRunChrome = {
   displayName?: string;
   onLogOut?: () => void;
   stepIndex: number;
+  /** Number of step dots. Set it when the flow skips a screen. */
+  stepCount?: number;
 };
 
 export type FirstRunTicketSource = "github-issues" | "jira" | "linear";

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.spec.ts
@@ -6,8 +6,10 @@ import {
   hostedCreditGrantCopy,
   hostedModelsQueriesLoading,
   isAgentStepReady,
+  isHostedAgentReady,
   resolveOnboardingAgent,
   shouldShowHostedCreditGrant,
+  type OnboardingAgentPlan,
 } from "./onboardingAgentReadiness";
 
 function connected(...ids: IntegrationId[]): Set<IntegrationId> {
@@ -152,6 +154,36 @@ describe("hostedModelsQueriesLoading", () => {
 
   it("does not wait when hosted models are not required", () => {
     expect(hostedModelsQueriesLoading(false, [{ isFetched: false }])).toBe(false);
+  });
+});
+
+describe("isHostedAgentReady", () => {
+  function plan(credentialsSource: OnboardingAgentPlan["credentialsSource"]): OnboardingAgentPlan {
+    return {
+      providerId: "openrouter",
+      component: "runnerOpenRouter",
+      credentialsSource,
+      integrationName: "openrouter",
+      harness: "AGENT_HARNESS_CLAUDE_CODE",
+      model: "openai/gpt-4.1",
+      planningModel: "openai/gpt-4.1",
+    };
+  }
+
+  it("is ready when the plan runs on hosted credentials", () => {
+    expect(isHostedAgentReady({ hostedModelsLoading: false, plan: plan("hosted") })).toBe(true);
+  });
+
+  it("is not ready when the plan needs a connected provider", () => {
+    expect(isHostedAgentReady({ hostedModelsLoading: false, plan: plan("integration") })).toBe(false);
+  });
+
+  it("is not ready without a plan", () => {
+    expect(isHostedAgentReady({ hostedModelsLoading: false, plan: undefined })).toBe(false);
+  });
+
+  it("is not ready while hosted models load, because the plan can still change", () => {
+    expect(isHostedAgentReady({ hostedModelsLoading: true, plan: plan("hosted") })).toBe(false);
   });
 });
 

--- a/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingAgentReadiness.ts
@@ -113,6 +113,19 @@ export function hostedModelsQueriesLoading(needHosted: boolean, queries: Array<{
   return needHosted && queries.some((query) => !query.isFetched);
 }
 
+/**
+ * Hosted credentials answer the agent question for the whole organization, so
+ * setup has nothing left to ask about the agent. A plan that still loads can
+ * become a plan that needs a key, so setup waits for the hosted models.
+ */
+export function isHostedAgentReady(args: {
+  hostedModelsLoading: boolean;
+  plan: OnboardingAgentPlan | undefined;
+}): boolean {
+  if (args.hostedModelsLoading) return false;
+  return args.plan?.credentialsSource === "hosted";
+}
+
 export function firstWorkOrderAgentError(args: {
   remainingCreditCents: number;
   hostedModelsLoading: boolean;

--- a/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
+++ b/web_src/src/pages/factories/pages/onboarding/useOnboardingPageModel.ts
@@ -16,7 +16,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 
 import { factorySetupPath } from "../../lib/factoryPagePaths";
-import { AGENT_PROVIDER_IDS } from "./onboardingAgentReadiness";
+import { AGENT_PROVIDER_IDS, isHostedAgentReady } from "./onboardingAgentReadiness";
 import type { IntegrationId, IssuesChoiceId, WizardStepId } from "./onboardingFixtures";
 import type { UpdateOnboarding } from "./onboardingProvision";
 import {
@@ -285,6 +285,9 @@ export function useOnboardingPageModel(args: {
 
   return {
     setup,
+    // True when hosted credentials cover the agent, so setup can skip the
+    // agent screen and provision from the ticket screen.
+    hostedAgentReady: isHostedAgentReady({ hostedModelsLoading: agent.hostedModelsLoading, plan: agent.plan }),
     openSection,
     setOpenSection,
     requestConnect: connect.requestConnect,


### PR DESCRIPTION
## Summary

Workspace setup showed the agent screen to every user and asked them to
connect Anthropic, OpenAI, or OpenRouter. An organization that has hosted
credit and an enabled hosted model allowlist does not need a key of its own,
so that screen asked a question with no answer left, and it delayed the board
by one step.

Setup now skips the agent screen when the agent plan runs on hosted
credentials. The ticket screen becomes the last screen: its button provisions
the workspace, shows the setup progress, and the step dots drop to four. Setup
keeps the agent screen when the agent still needs a connected provider. A user
who returns after a failed provision lands on the ticket screen, which carries
the action, so no screen provisions the workspace without a user action.

The rule waits for the hosted model queries, because a plan that still loads
can become a plan that needs a key.

## Test plan

- [ ] `make check.test.ui` passes.
- [ ] `make check.lint.ui` and `make check.build.ui` pass.
- [ ] Organization with hosted credit and an enabled hosted model allowlist:
      start workspace setup, choose a repository, then press
      `Analyze my tickets`. Setup provisions the workspace and opens the board
      without an agent screen.
- [ ] Organization without hosted credit: the ticket button reads
      `Connect agent` and opens the agent screen, which still finishes setup.
- [ ] Hosted organization, provision fails: setup returns to the ticket
      screen, and the button starts the provision again.


Made with [Cursor](https://cursor.com)