### PR TITLE
feat: Improve agent settings layout

### DIFF
--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -581,12 +581,12 @@ describe("LinesPage board", () => {
     expect(
       screen.getByRole("heading", { level: 2, name: "Agent - Implement from order description" }),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("planning-review-component-toggle-implementation-agent")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
+    expect(screen.getByTestId("planning-review-nav-steps")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("planning-review-step-summary-0")).toHaveTextContent("Clone Repo");
+    expect(screen.getByTestId("planning-review-step-toggle-0")).toHaveAttribute("aria-expanded", "false");
+    await user.click(screen.getByTestId("planning-review-step-toggle-0"));
     expect(screen.getByTestId("planning-review-step-name-0")).toHaveValue("Clone Repo");
-    expect(screen.getByTestId("planning-review-step-body-0")).toHaveValue("git clone $REPO repo");
+    expect(screen.getByTestId("planning-review-step-body-0-editor")).toBeInTheDocument();
   });
 
   it("hides Edit Agent when the column canvas has no agent", async () => {
@@ -605,6 +605,7 @@ describe("LinesPage board", () => {
 
     await user.click(screen.getByTestId("lines-phase-menu-0"));
     await user.click(screen.getByTestId("lines-phase-menu-0-edit-agent"));
+    await user.click(screen.getByTestId("planning-review-step-toggle-0"));
     const stepName = screen.getByTestId("planning-review-step-name-0");
     await user.clear(stepName);
     await user.type(stepName, "Clone repository");

--- a/web_src/src/pages/factories/pages/PlanningReviewForm.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewForm.tsx
@@ -2,17 +2,11 @@ import type { ConfigurationField } from "@/api-client";
 import { AutoCompleteInput } from "@/components/AutoCompleteInput/AutoCompleteInput";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { cn } from "@/lib/utils";
 import { ConfigurationFieldRenderer } from "@/ui/configurationFieldRenderer";
-import { ChevronDown } from "lucide-react";
-import { useState } from "react";
 
 import type { PlanningReviewComponent, PlanningReviewDraft, PlanningReviewStep } from "./planningReviewMockup";
-import {
-  PLANNING_REVIEW_ADVANCED_FIELD_NAMES,
-  PLANNING_REVIEW_ENVIRONMENT_MODEL_FIELDS,
-  PLANNING_REVIEW_RUNNER_FIELDS,
-} from "./planningReviewRunnerFields";
+import { PLANNING_REVIEW_RUNNER_FIELDS } from "./planningReviewRunnerFields";
+import { PLANNING_REVIEW_SECTIONS, type PlanningReviewSectionId } from "./planningReviewSections";
 import { PlanningReviewStepList } from "./PlanningReviewStepList";
 
 const FIELDS_BY_NAME = new Map(
@@ -25,14 +19,19 @@ const EXPRESSION_CONTEXT = {
   previous: { data: { result: { branch: "feature/planning-review" } } },
 };
 
+/** Fields that read better side by side than stacked full width. */
+const PAIRED_FIELDS = ["machineType", "model", "workingDirectory", "executionTimeoutSeconds"];
+
 export function PlanningReviewForm({
   draft,
   onChange,
   organizationId,
+  section,
 }: {
   draft: PlanningReviewDraft;
   onChange: (next: PlanningReviewDraft) => void;
   organizationId?: string;
+  section: PlanningReviewSectionId;
 }) {
   const updateComponent = (id: string, next: PlanningReviewComponent) => {
     onChange({
@@ -42,11 +41,12 @@ export function PlanningReviewForm({
   };
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-4">
       {draft.components.map((component) => (
-        <ComponentBlock
+        <SectionPanel
           key={component.id}
           component={component}
+          section={section}
           organizationId={organizationId}
           onChange={(next) => updateComponent(component.id, next)}
         />
@@ -55,65 +55,23 @@ export function PlanningReviewForm({
   );
 }
 
-function ComponentBlock({
+/**
+ * One group of settings. The left column already names the group, so the panel
+ * leads with what the group is for instead of repeating the label.
+ */
+function SectionPanel({
   component,
+  section,
   organizationId,
   onChange,
 }: {
   component: PlanningReviewComponent;
+  section: PlanningReviewSectionId;
   organizationId?: string;
   onChange: (next: PlanningReviewComponent) => void;
 }) {
-  return (
-    <section
-      className="overflow-hidden rounded-xl border border-border bg-card shadow-sm"
-      data-testid={`planning-review-component-${component.id}`}
-    >
-      <button
-        type="button"
-        className={cn(
-          "flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted",
-          component.expanded && "bg-muted",
-        )}
-        aria-expanded={component.expanded}
-        aria-controls={`planning-review-component-body-${component.id}`}
-        data-testid={`planning-review-component-toggle-${component.id}`}
-        onClick={() => onChange({ ...component, expanded: !component.expanded })}
-      >
-        <div className="min-w-0 flex-1">
-          <h3 className="truncate text-[14px] font-semibold text-foreground">{component.title}</h3>
-          <p className="mt-0.5 truncate text-[12px] text-muted-foreground">{component.description}</p>
-        </div>
-        <ChevronDown
-          className={cn(
-            "size-4 shrink-0 text-muted-foreground transition-transform",
-            component.expanded && "rotate-180",
-          )}
-          aria-hidden
-        />
-      </button>
-      {component.expanded ? (
-        <div
-          id={`planning-review-component-body-${component.id}`}
-          className="space-y-6 border-t border-border bg-card px-4 py-5"
-        >
-          <RunnerConfiguration component={component} organizationId={organizationId} onChange={onChange} />
-        </div>
-      ) : null}
-    </section>
-  );
-}
+  const definition = PLANNING_REVIEW_SECTIONS.find((entry) => entry.id === section);
 
-function RunnerConfiguration({
-  component,
-  organizationId,
-  onChange,
-}: {
-  component: PlanningReviewComponent;
-  organizationId?: string;
-  onChange: (next: PlanningReviewComponent) => void;
-}) {
-  const [moreSettingsOpen, setMoreSettingsOpen] = useState(false);
   const setConfigurationField = (name: string, value: unknown) => {
     onChange({
       ...component,
@@ -122,55 +80,60 @@ function RunnerConfiguration({
   };
 
   return (
-    <>
-      <PlanningReviewStepList
-        steps={(component.configuration.steps as PlanningReviewStep[]) ?? []}
-        onChange={(steps) => setConfigurationField("steps", steps)}
-      />
-      <div className="grid grid-cols-2 gap-x-4 gap-y-3" data-testid="planning-review-environment-model-row">
-        {fieldsNamed(PLANNING_REVIEW_ENVIRONMENT_MODEL_FIELDS).map((field) => (
-          <RunnerField
-            key={field.name}
-            field={field}
+    <div
+      className="flex flex-col gap-4"
+      data-testid={`planning-review-component-${component.id}`}
+      data-section={section}
+    >
+      {definition ? (
+        <p className="px-1 text-[13px] leading-6 text-muted-foreground" data-testid="planning-review-section-intro">
+          {definition.description}
+        </p>
+      ) : null}
+      {section === "steps" ? (
+        <PlanningReviewStepList
+          steps={(component.configuration.steps as PlanningReviewStep[]) ?? []}
+          onChange={(steps) => setConfigurationField("steps", steps)}
+        />
+      ) : null}
+      {section === "concurrency" ? <ConcurrencyFields component={component} onChange={onChange} /> : null}
+      {definition && definition.fieldNames.length > 0 ? (
+        <FieldCard>
+          <FieldGrid
+            fieldNames={definition.fieldNames}
             component={component}
             organizationId={organizationId}
             onChange={setConfigurationField}
           />
-        ))}
-      </div>
-      <div className="border-t border-border pt-4">
-        <button
-          type="button"
-          className="flex w-full items-center justify-between py-1 text-left text-[13px] font-medium text-foreground hover:text-foreground/80"
-          aria-expanded={moreSettingsOpen}
-          data-testid="planning-review-more-settings-toggle"
-          onClick={() => setMoreSettingsOpen((open) => !open)}
-        >
-          More settings
-          <ChevronDown
-            className={cn(
-              "size-4 shrink-0 text-muted-foreground transition-transform",
-              moreSettingsOpen && "rotate-180",
-            )}
-            aria-hidden
-          />
-        </button>
-        {moreSettingsOpen ? (
-          <div className="mt-4 space-y-6">
-            {fieldsNamed(PLANNING_REVIEW_ADVANCED_FIELD_NAMES).map((field) => (
-              <RunnerField
-                key={field.name}
-                field={field}
-                component={component}
-                organizationId={organizationId}
-                onChange={setConfigurationField}
-              />
-            ))}
-            <ConcurrencyFields component={component} onChange={onChange} />
-          </div>
-        ) : null}
-      </div>
-    </>
+        </FieldCard>
+      ) : null}
+    </div>
+  );
+}
+
+function FieldCard({ children }: { children: React.ReactNode }) {
+  return <section className="rounded-xl border border-border bg-card px-5 py-5 shadow-sm">{children}</section>;
+}
+
+function FieldGrid({
+  fieldNames,
+  component,
+  organizationId,
+  onChange,
+}: {
+  fieldNames: string[];
+  component: PlanningReviewComponent;
+  organizationId?: string;
+  onChange: (name: string, value: unknown) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-x-6 gap-y-5" data-testid="planning-review-environment-model-row">
+      {fieldsNamed(fieldNames).map((field) => (
+        <div key={field.name} className={PAIRED_FIELDS.includes(field.name!) ? undefined : "col-span-2"}>
+          <RunnerField field={field} component={component} organizationId={organizationId} onChange={onChange} />
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -218,52 +181,53 @@ function ConcurrencyFields({
   onChange: (next: PlanningReviewComponent) => void;
 }) {
   return (
-    <div className="space-y-4 border-t border-border pt-6">
-      <h4 className="text-sm font-semibold text-foreground">Concurrency</h4>
-      <div className="flex flex-col gap-2">
-        <Label htmlFor={`planning-review-concurrency-max-${component.id}`}>Max parallel executions</Label>
-        <Input
-          id={`planning-review-concurrency-max-${component.id}`}
-          data-testid={`planning-review-concurrency-max-${component.id}`}
-          type="number"
-          min={1}
-          value={component.concurrency.max}
-          onChange={(event) =>
-            onChange({
-              ...component,
-              concurrency: { ...component.concurrency, max: event.target.value },
-            })
-          }
-          className="shadow-none"
-        />
-        <p className="text-xs text-muted-foreground">
-          Executions above this limit wait in the queue. Default: one execution at a time.
-        </p>
+    <FieldCard>
+      <div className="space-y-6">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor={`planning-review-concurrency-max-${component.id}`}>Max parallel executions</Label>
+          <Input
+            id={`planning-review-concurrency-max-${component.id}`}
+            data-testid={`planning-review-concurrency-max-${component.id}`}
+            type="number"
+            min={1}
+            value={component.concurrency.max}
+            onChange={(event) =>
+              onChange({
+                ...component,
+                concurrency: { ...component.concurrency, max: event.target.value },
+              })
+            }
+            className="shadow-none"
+          />
+          <p className="text-xs text-muted-foreground">
+            Executions above this limit wait in the queue. Default: one execution at a time.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label>Key</Label>
+          <AutoCompleteInput
+            data-testid={`planning-review-concurrency-key-${component.id}`}
+            exampleObj={EXPRESSION_CONTEXT}
+            value={component.concurrency.key}
+            onChange={(key) =>
+              onChange({
+                ...component,
+                concurrency: { ...component.concurrency, key },
+              })
+            }
+            placeholder="ci-{{ $.data.branch }}"
+            startWord="{{"
+            prefix="{{ "
+            suffix=" }}"
+            inputSize="md"
+            quickTip="Tip: type `{{` to start an expression."
+            className="shadow-none"
+          />
+          <p className="text-xs text-muted-foreground">
+            Optional expression that splits the backlog. Each value is a separate queue.
+          </p>
+        </div>
       </div>
-      <div className="flex flex-col gap-2">
-        <Label>Key</Label>
-        <AutoCompleteInput
-          data-testid={`planning-review-concurrency-key-${component.id}`}
-          exampleObj={EXPRESSION_CONTEXT}
-          value={component.concurrency.key}
-          onChange={(key) =>
-            onChange({
-              ...component,
-              concurrency: { ...component.concurrency, key },
-            })
-          }
-          placeholder="ci-{{ $.data.branch }}"
-          startWord="{{"
-          prefix="{{ "
-          suffix=" }}"
-          inputSize="md"
-          quickTip="Tip: type `{{` to start an expression."
-          className="shadow-none"
-        />
-        <p className="text-xs text-muted-foreground">
-          Optional expression that splits the backlog. Each value is a separate queue.
-        </p>
-      </div>
-    </div>
+    </FieldCard>
   );
 }

--- a/web_src/src/pages/factories/pages/PlanningReviewNav.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewNav.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+
+import { PLANNING_REVIEW_SECTIONS, type PlanningReviewSectionId } from "./planningReviewSections";
+
+/**
+ * Left column of the agent editor. It splits the agent into groups so no
+ * single panel grows long enough to bury the ones below it.
+ */
+export function PlanningReviewNav({
+  active,
+  onSelect,
+  stepCount,
+}: {
+  active: PlanningReviewSectionId;
+  onSelect: (id: PlanningReviewSectionId) => void;
+  stepCount: number;
+}) {
+  return (
+    <nav
+      aria-label="Agent settings"
+      className="w-56 shrink-0 overflow-y-auto border-r border-border bg-muted/50 p-3"
+      data-testid="planning-review-nav"
+    >
+      <ul className="flex flex-col gap-0.5">
+        {PLANNING_REVIEW_SECTIONS.map((section) => {
+          const Icon = section.icon;
+          const isActive = section.id === active;
+          return (
+            <li key={section.id}>
+              <button
+                type="button"
+                aria-current={isActive ? "page" : undefined}
+                onClick={() => onSelect(section.id)}
+                data-testid={`planning-review-nav-${section.id}`}
+                className={cn(
+                  "flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-[13px] font-medium transition-colors",
+                  isActive
+                    ? "bg-card text-foreground shadow-xs"
+                    : "text-muted-foreground hover:bg-card/60 hover:text-foreground",
+                )}
+              >
+                <Icon className="size-4 shrink-0" aria-hidden />
+                <span className="min-w-0 flex-1 truncate">{section.label}</span>
+                {section.id === "steps" ? (
+                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{stepCount}</span>
+                ) : null}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/web_src/src/pages/factories/pages/PlanningReviewPopup.spec.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewPopup.spec.tsx
@@ -9,6 +9,12 @@ import { TooltipProvider } from "@/ui/tooltip";
 import { PLANNING_REVIEW_DRAFT, type PlanningReviewStep } from "./planningReviewMockup";
 import { PlanningReviewPopup } from "./PlanningReviewPopup";
 
+vi.mock("@monaco-editor/react", () => ({
+  Editor: ({ value, onChange }: { value?: string; onChange?: (value: string | undefined) => void }) => (
+    <textarea value={value ?? ""} onChange={(event) => onChange?.(event.target.value)} />
+  ),
+}));
+
 function renderPopup(
   props: Omit<ComponentProps<typeof PlanningReviewPopup>, "onClose"> & { onClose?: () => void } = {},
 ) {
@@ -76,25 +82,34 @@ describe("PlanningReviewPopup", () => {
     expect(within(note).queryByRole("link")).not.toBeInTheDocument();
   });
 
-  it("places Environment and Model on one row under Steps", () => {
+  it("shows runner fields from the runner navigation item", async () => {
+    const user = userEvent.setup();
     renderPopup();
 
-    const steps = screen.getByRole("heading", { name: "Steps" });
+    await user.click(screen.getByTestId("planning-review-nav-runner"));
+
     const row = screen.getByTestId("planning-review-environment-model-row");
     expect(within(row).getByText("Environment")).toBeInTheDocument();
     expect(within(row).getByText("Model")).toBeInTheDocument();
-    expect(steps.compareDocumentPosition(row) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(within(row).getByText("Working directory")).toBeInTheDocument();
+    expect(within(row).getByText("Execution timeout (seconds)")).toBeInTheDocument();
   });
 
-  it("shows the runner component expanded", () => {
+  it("names the agent once, in the header, and describes it below the name", () => {
+    renderPopup();
+
+    expect(screen.getAllByText("Agent - Implement from order description")).toHaveLength(1);
+    expect(screen.getByTestId("planning-review-description")).toHaveTextContent(
+      "Implement the approved plan and prepare the branch for review.",
+    );
+  });
+
+  it("shows the runner settings without an extra collapsed wrapper", () => {
     renderPopup();
 
     const implementation = screen.getByTestId("planning-review-component-implementation-agent");
 
-    expect(within(implementation).getByRole("button", { name: /Agent - Implement/ })).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
+    expect(screen.queryByTestId("planning-review-component-toggle-implementation-agent")).not.toBeInTheDocument();
     expect(within(implementation).getByText("Steps")).toBeInTheDocument();
     expect(within(implementation).queryByText("Working directory")).not.toBeInTheDocument();
     expect(within(implementation).queryByText("Credentials")).not.toBeInTheDocument();
@@ -104,7 +119,7 @@ describe("PlanningReviewPopup", () => {
     expect(within(implementation).queryByText("Concurrency")).not.toBeInTheDocument();
   });
 
-  it("shows every step as a row with a kind chip, a name, and a body", () => {
+  it("shows every step collapsed with a name and kind badge", () => {
     renderPopup();
 
     const implementation = screen.getByTestId("planning-review-component-implementation-agent");
@@ -112,8 +127,8 @@ describe("PlanningReviewPopup", () => {
 
     steps.forEach((step, index) => {
       const row = within(implementation).getByTestId(`planning-review-step-${index}`);
-      expect(within(row).getByTestId(`planning-review-step-name-${index}`)).toHaveValue(step.name);
-      expect(within(row).getByTestId(`planning-review-step-body-${index}`)).toHaveValue(step.command ?? step.prompt);
+      expect(within(row).getByTestId(`planning-review-step-summary-${index}`)).toHaveTextContent(step.name);
+      expect(within(row).getByTestId(`planning-review-step-toggle-${index}`)).toHaveAttribute("aria-expanded", "false");
       expect(within(row).getByText(step.type === "prompt" ? "Prompt" : "Bash")).toBeInTheDocument();
     });
   });
@@ -135,33 +150,24 @@ describe("PlanningReviewPopup", () => {
     const steps = PLANNING_REVIEW_DRAFT.components[0].configuration.steps as PlanningReviewStep[];
     await user.click(screen.getByTestId("planning-review-step-remove-0"));
 
-    expect(screen.getByTestId("planning-review-step-name-0")).toHaveValue(steps[1].name);
+    expect(screen.getByTestId("planning-review-step-summary-0")).toHaveTextContent(steps[1].name);
   });
 
-  it("reveals environment, timeout, and concurrency in more settings", async () => {
+  it("opens each settings group from the navigation", async () => {
     const user = userEvent.setup();
     renderPopup();
-
     const implementation = screen.getByTestId("planning-review-component-implementation-agent");
-    await user.click(within(implementation).getByTestId("planning-review-more-settings-toggle"));
 
-    expect(within(implementation).getByText("Working directory")).toBeInTheDocument();
+    await user.click(screen.getByTestId("planning-review-nav-credentials"));
     expect(within(implementation).getByText("Credentials")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("planning-review-nav-environment"));
     expect(within(implementation).getByText("Environment from")).toBeInTheDocument();
     expect(within(implementation).getByText("Environment variables")).toBeInTheDocument();
-    expect(within(implementation).getByText("Execution timeout (seconds)")).toBeInTheDocument();
-    expect(within(implementation).getByText("Concurrency")).toBeInTheDocument();
-  });
 
-  it("collapses the agent block", async () => {
-    const user = userEvent.setup();
-    renderPopup();
-
-    const implementationToggle = screen.getByTestId("planning-review-component-toggle-implementation-agent");
-
-    await user.click(implementationToggle);
-    expect(implementationToggle).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("Steps")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("planning-review-nav-concurrency"));
+    expect(screen.getByText("Max parallel executions")).toBeInTheDocument();
+    expect(screen.getByText("Key")).toBeInTheDocument();
   });
 
   it("saves component configuration and closes", async () => {
@@ -170,7 +176,7 @@ describe("PlanningReviewPopup", () => {
     const user = userEvent.setup();
     renderPopup({ onClose, onSave });
 
-    await user.click(screen.getByTestId("planning-review-more-settings-toggle"));
+    await user.click(screen.getByTestId("planning-review-nav-concurrency"));
     const max = screen.getByTestId("planning-review-concurrency-max-implementation-agent");
     await user.clear(max);
     await user.type(max, "8");

--- a/web_src/src/pages/factories/pages/PlanningReviewPopup.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewPopup.tsx
@@ -4,7 +4,14 @@ import { Workflow } from "lucide-react";
 import { useState } from "react";
 
 import { PlanningReviewForm } from "./PlanningReviewForm";
-import { PLANNING_REVIEW_DRAFT, singleAgentDraft, type PlanningReviewDraft } from "./planningReviewMockup";
+import { PlanningReviewNav } from "./PlanningReviewNav";
+import { PLANNING_REVIEW_DEFAULT_SECTION, type PlanningReviewSectionId } from "./planningReviewSections";
+import {
+  PLANNING_REVIEW_DRAFT,
+  singleAgentDraft,
+  type PlanningReviewDraft,
+  type PlanningReviewStep,
+} from "./planningReviewMockup";
 import { PopupBody, PopupHeader, PopupShell } from "./work-order-popup-redesign/popupShared";
 
 function planningReviewPopupTitle(draft: PlanningReviewDraft): string {
@@ -13,26 +20,29 @@ function planningReviewPopupTitle(draft: PlanningReviewDraft): string {
 
 /**
  * Note that puts the agent in context. Agents run as part of an automation,
- * so the full automation editor stays one click away.
+ * so the full automation editor stays one click away. It sits in the footer
+ * because it explains the screen, it is not an action on the agent.
  */
 function AutomationNote({ href }: { href?: string }) {
   return (
-    <section
-      className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 shadow-sm"
+    <p
+      className="flex min-w-0 flex-1 items-center gap-2.5 text-[12px] leading-5 text-muted-foreground"
       data-testid="planning-review-automation-note"
     >
-      <Workflow className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-      <p className="min-w-0 flex-1 text-[12px] text-muted-foreground">
+      <Workflow className="size-4 shrink-0" aria-hidden />
+      <span className="min-w-0">
         Agents are part of an automation. Open the automation to add an agent or to change the order of the steps.
-      </p>
+      </span>
       {href ? (
-        <Button asChild size="sm" variant="outline" className="shrink-0">
-          <Link href={href} data-testid="planning-review-edit-automation">
-            Edit Automation
-          </Link>
-        </Button>
+        <Link
+          href={href}
+          data-testid="planning-review-edit-automation"
+          className="shrink-0 font-medium text-foreground underline underline-offset-2 hover:text-primary"
+        >
+          Edit Automation
+        </Link>
       ) : null}
-    </section>
+    </p>
   );
 }
 
@@ -57,9 +67,12 @@ export function PlanningReviewPopup({
 }) {
   const [draft, setDraft] = useState(() => singleAgentDraft(initialDraft));
   const [isSaving, setIsSaving] = useState(false);
+  const [section, setSection] = useState<PlanningReviewSectionId>(PLANNING_REVIEW_DEFAULT_SECTION);
 
   const title = isLoading ? "Editing Agent" : planningReviewPopupTitle(draft);
+  const description = isLoading ? undefined : draft.components[0]?.description;
   const saveDisabled = isLoading || isSaving || draft.components.length === 0;
+  const stepCount = ((draft.components[0]?.configuration.steps as PlanningReviewStep[]) ?? []).length;
 
   const handleSave = async () => {
     if (!onSave) {
@@ -79,26 +92,35 @@ export function PlanningReviewPopup({
 
   return (
     <PopupShell testId="lines-planning-review" fixed onDismiss={onClose}>
-      <PopupHeader title={title} onClose={onClose} />
-      <PopupBody className="bg-muted">
-        <div className="flex flex-col gap-3">
-          <AutomationNote href={automationHref} />
-          {isLoading ? (
-            <p className="px-1 py-6 text-[13px] text-muted-foreground" data-testid="planning-review-loading">
-              Loading agent…
-            </p>
-          ) : (
-            <PlanningReviewForm draft={draft} onChange={setDraft} organizationId={organizationId} />
-          )}
+      <PopupHeader title={title} onClose={onClose}>
+        {description ? (
+          <p className="mt-0.5 truncate text-[12px] text-muted-foreground" data-testid="planning-review-description">
+            {description}
+          </p>
+        ) : null}
+      </PopupHeader>
+      {isLoading ? (
+        <PopupBody className="bg-muted px-6 py-5">
+          <p className="px-1 py-6 text-sm text-muted-foreground" data-testid="planning-review-loading">
+            Loading agent…
+          </p>
+        </PopupBody>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          <PlanningReviewNav active={section} onSelect={setSection} stepCount={stepCount} />
+          <PopupBody className="min-w-0 bg-muted px-6 py-5">
+            <PlanningReviewForm draft={draft} onChange={setDraft} organizationId={organizationId} section={section} />
+          </PopupBody>
         </div>
-      </PopupBody>
-      <footer className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-5 py-3">
-        <Button type="button" size="sm" variant="outline" onClick={onClose} disabled={isSaving}>
+      )}
+      <footer className="flex shrink-0 items-center gap-4 border-t border-border px-6 py-4">
+        <AutomationNote href={automationHref} />
+        <Button type="button" variant="outline" className="shrink-0" onClick={onClose} disabled={isSaving}>
           Cancel
         </Button>
         <Button
           type="button"
-          size="sm"
+          className="shrink-0"
           onClick={() => void handleSave()}
           disabled={saveDisabled}
           data-testid="planning-review-save"

--- a/web_src/src/pages/factories/pages/PlanningReviewStepBody.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewStepBody.tsx
@@ -1,0 +1,91 @@
+import { Editor } from "@monaco-editor/react";
+
+import { Textarea } from "@/components/ui/textarea";
+import { useTheme } from "@/contexts/useTheme";
+
+import type { PlanningReviewStepKind } from "./planningReviewMockup";
+
+const LINE_HEIGHT = 20;
+const MIN_LINES = 2;
+const MAX_LINES = 16;
+
+/** Grow with the script, but never far enough to hide the rest of the panel. */
+function editorHeight(value: string): number {
+  const lines = value === "" ? MIN_LINES : value.split("\n").length;
+  return Math.min(Math.max(lines, MIN_LINES), MAX_LINES) * LINE_HEIGHT;
+}
+
+/**
+ * Bash steps get a real editor with shell highlighting. Prompt steps stay a
+ * plain textarea, because a prompt is prose and highlighting would only add
+ * noise to it.
+ *
+ * Monaco pads vertically only, so the wrapper supplies the horizontal gutter.
+ */
+export function PlanningReviewStepBody({
+  kind,
+  value,
+  onChange,
+  label,
+  testId,
+}: {
+  kind: PlanningReviewStepKind;
+  value: string;
+  onChange: (value: string) => void;
+  label: string;
+  testId: string;
+}) {
+  const { resolvedTheme } = useTheme();
+
+  if (kind === "prompt") {
+    return (
+      <Textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Tell the agent what to do in this step."
+        aria-label={label}
+        data-testid={testId}
+        className="max-h-72 min-h-24 resize-y overflow-auto rounded-lg bg-card px-3 py-2.5 text-[13px] leading-relaxed shadow-none"
+      />
+    );
+  }
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-lg border border-border bg-card px-3 py-2"
+      data-testid={`${testId}-editor`}
+    >
+      <Editor
+        height={editorHeight(value)}
+        language="shell"
+        value={value}
+        theme={resolvedTheme === "dark" ? "vs-dark" : "vs"}
+        onChange={(next) => onChange(next ?? "")}
+        options={{
+          ariaLabel: label,
+          minimap: { enabled: false },
+          lineNumbers: "off",
+          glyphMargin: false,
+          folding: false,
+          lineDecorationsWidth: 0,
+          lineNumbersMinChars: 0,
+          fontSize: 13,
+          lineHeight: LINE_HEIGHT,
+          wordWrap: "on",
+          scrollBeyondLastLine: false,
+          automaticLayout: true,
+          overviewRulerLanes: 0,
+          renderLineHighlight: "none",
+          padding: { top: 0, bottom: 0 },
+          scrollbar: { vertical: "auto", horizontal: "auto", verticalScrollbarSize: 10 },
+          tabSize: 2,
+        }}
+      />
+      {value === "" ? (
+        <p className="pointer-events-none absolute top-2 left-3 text-[13px] text-muted-foreground">
+          Shell commands to run on the runner.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/PlanningReviewStepList.tsx
+++ b/web_src/src/pages/factories/pages/PlanningReviewStepList.tsx
@@ -1,25 +1,20 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Check, ChevronDown, GripVertical, MessageSquareText, Plus, Terminal, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { useListFieldDragReorder } from "@/ui/configurationFieldRenderer/useListFieldDragReorder";
 
 import type { PlanningReviewStep, PlanningReviewStepKind } from "./planningReviewMockup";
+import { PlanningReviewStepBody } from "./PlanningReviewStepBody";
 
 const KIND_LABEL: Record<PlanningReviewStepKind, string> = { bash: "Bash", prompt: "Prompt" };
 
-const BODY_PLACEHOLDER: Record<PlanningReviewStepKind, string> = {
-  bash: "Shell commands to run on the runner.",
-  prompt: "Tell the agent what to do in this step.",
-};
-
 /**
- * Light step rows for the phase editor: a kind chip, the step name, and the
- * body. Type changes and removal stay in the row menu.
+ * Rows stay closed until you open one, so a long script cannot bury the
+ * settings below the list. The list reads top to bottom in run order.
  */
 export function PlanningReviewStepList({
   steps,
@@ -29,51 +24,67 @@ export function PlanningReviewStepList({
   onChange: (steps: PlanningReviewStep[]) => void;
 }) {
   const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const [openStep, setOpenStep] = useState("");
   const { renderedItems, startDrag } = useListFieldDragReorder({
     items: steps,
     allowReorder: true,
-    useAccordion: false,
+    useAccordion: true,
     onChange: (next) => onChange(next as PlanningReviewStep[]),
-    setOpenItem: () => undefined,
+    setOpenItem: setOpenStep,
     rowRefs,
   });
 
   const update = (index: number, next: PlanningReviewStep) =>
     onChange(steps.map((step, position) => (position === index ? next : step)));
 
+  const addStep = () => {
+    onChange([...steps, { name: "", type: "bash", command: "" }]);
+    setOpenStep(String(steps.length));
+  };
+
+  const removeStep = (index: number) => {
+    onChange(steps.filter((_, position) => position !== index));
+    setOpenStep("");
+  };
+
   return (
-    <section className="flex flex-col gap-2" aria-label="Steps">
-      <h4 className="text-sm font-medium text-foreground">Steps</h4>
-      <div className="rounded-lg border border-border bg-muted p-2">
-        <ol className="flex flex-col gap-2">
+    <section className="overflow-hidden rounded-xl border border-border bg-card shadow-sm" aria-label="Steps">
+      <header className="flex items-center gap-2.5 border-b border-border px-5 py-3.5">
+        <h3 className="text-sm font-semibold text-foreground">Steps</h3>
+        <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium tabular-nums text-muted-foreground">
+          {steps.length}
+        </span>
+        <span className="flex-1" />
+        <Button type="button" variant="outline" size="sm" onClick={addStep} data-testid="planning-review-add-step">
+          <Plus aria-hidden />
+          Add step
+        </Button>
+      </header>
+      {steps.length === 0 ? (
+        <p className="px-5 py-10 text-center text-sm text-muted-foreground" data-testid="planning-review-steps-empty">
+          This agent has no steps yet. Add a step to tell the runner what to do.
+        </p>
+      ) : (
+        <ol className="divide-y divide-border">
           {(renderedItems as PlanningReviewStep[]).map((step, index) => (
             <li key={index}>
               <StepRow
                 step={step}
                 position={index}
                 canReorder={steps.length > 1}
+                isOpen={openStep === String(index)}
+                onToggle={() => setOpenStep((current) => (current === String(index) ? "" : String(index)))}
                 rowRef={(element) => {
                   rowRefs.current[index] = element;
                 }}
-                onDragStart={(event) => startDrag(event, index, "")}
+                onDragStart={(event) => startDrag(event, index, openStep)}
                 onChange={(next) => update(index, next)}
-                onRemove={() => onChange(steps.filter((_, position) => position !== index))}
+                onRemove={() => removeStep(index)}
               />
             </li>
           ))}
         </ol>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="mt-1 w-fit text-muted-foreground"
-          onClick={() => onChange([...steps, { name: "", type: "bash", command: "" }])}
-          data-testid="planning-review-add-step"
-        >
-          <Plus aria-hidden />
-          Add step
-        </Button>
-      </div>
+      )}
     </section>
   );
 }
@@ -82,6 +93,8 @@ function StepRow({
   step,
   position,
   canReorder,
+  isOpen,
+  onToggle,
   rowRef,
   onDragStart,
   onChange,
@@ -90,6 +103,8 @@ function StepRow({
   step: PlanningReviewStep;
   position: number;
   canReorder: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
   rowRef: (element: HTMLDivElement | null) => void;
   onDragStart: (event: React.MouseEvent) => void;
   onChange: (step: PlanningReviewStep) => void;
@@ -97,65 +112,106 @@ function StepRow({
 }) {
   const kind = step.type;
   const label = step.name || `Step ${position + 1}`;
+  const bodyId = `planning-review-step-body-wrapper-${position}`;
 
   return (
-    <div ref={rowRef} className="flex items-start gap-1" data-testid={`planning-review-step-${position}`}>
-      {canReorder ? (
+    <div
+      ref={rowRef}
+      className={cn("group/step bg-card transition-colors", isOpen ? "bg-muted/30" : "hover:bg-muted/40")}
+      data-testid={`planning-review-step-${position}`}
+    >
+      <div className="flex items-center gap-2 px-3 py-2.5">
         <button
           type="button"
-          aria-label={`Reorder ${label}`}
-          className="mt-2 flex size-6 shrink-0 cursor-grab items-center justify-center rounded-sm text-muted-foreground/60 hover:bg-accent hover:text-foreground"
-          onMouseDown={onDragStart}
+          aria-expanded={isOpen}
+          aria-controls={bodyId}
+          onClick={onToggle}
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          data-testid={`planning-review-step-toggle-${position}`}
         >
-          <GripVertical className="size-3.5" aria-hidden />
+          <ChevronDown className={cn("size-4 transition-transform", isOpen && "rotate-180")} aria-hidden />
         </button>
-      ) : (
-        <span className="size-6 shrink-0" aria-hidden />
-      )}
-      <div className="min-w-0 flex-1 overflow-hidden rounded-lg border border-border bg-card shadow-xs">
-        <div className="flex items-center gap-1.5 px-2.5 py-1.5">
-          <StepKindMenu step={step} label={label} position={position} onChange={onChange} />
+        {isOpen ? (
           <Input
             value={step.name}
             onChange={(event) => onChange({ ...step, name: event.target.value })}
             placeholder="Step name"
             aria-label={`Name for ${label}`}
             data-testid={`planning-review-step-name-${position}`}
-            className="h-7 flex-1 border-0 bg-transparent px-1 text-[13px] font-medium shadow-none focus-visible:ring-0"
+            className="h-8 min-w-0 flex-1 border-transparent bg-transparent px-2 text-sm font-medium hover:border-border hover:bg-background focus:bg-background"
           />
+        ) : (
           <button
             type="button"
-            aria-label={`Remove ${label}`}
-            className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-            data-testid={`planning-review-step-remove-${position}`}
-            onClick={onRemove}
+            onClick={onToggle}
+            className="min-w-0 flex-1 truncate px-2 text-left text-sm font-medium text-foreground"
+            data-testid={`planning-review-step-summary-${position}`}
           >
-            <Trash2 className="size-3.5" aria-hidden />
+            {step.name || <span className="text-muted-foreground">Untitled step</span>}
           </button>
-        </div>
-        <Textarea
-          value={(kind === "prompt" ? step.prompt : step.command) ?? ""}
-          onChange={(event) =>
-            onChange(
-              kind === "prompt" ? { ...step, prompt: event.target.value } : { ...step, command: event.target.value },
-            )
-          }
-          placeholder={BODY_PLACEHOLDER[kind]}
-          aria-label={`${KIND_LABEL[kind]} for ${label}`}
-          data-testid={`planning-review-step-body-${position}`}
-          className={cn(
-            "min-h-14 resize-y rounded-none border-0 border-t border-border bg-transparent px-2.5 py-2 text-[13px] shadow-none focus-visible:ring-0",
-            kind === "bash" && "bg-muted/60 font-mono text-[12px]",
-          )}
-        />
+        )}
+        <StepKindMenu step={step} label={label} position={position} onChange={onChange} />
+        <button
+          type="button"
+          aria-label={`Remove ${label}`}
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-colors group-focus-within/step:opacity-100 group-hover/step:opacity-100 hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100"
+          data-testid={`planning-review-step-remove-${position}`}
+          onClick={onRemove}
+        >
+          <Trash2 className="size-4" aria-hidden />
+        </button>
+        <StepDragHandle label={label} canReorder={canReorder} onDragStart={onDragStart} />
       </div>
+      {isOpen ? (
+        <div id={bodyId} className="px-3 pb-3">
+          <PlanningReviewStepBody
+            kind={kind}
+            value={(kind === "prompt" ? step.prompt : step.command) ?? ""}
+            onChange={(next) => onChange(kind === "prompt" ? { ...step, prompt: next } : { ...step, command: next })}
+            label={`${KIND_LABEL[kind]} for ${label}`}
+            testId={`planning-review-step-body-${position}`}
+          />
+        </div>
+      ) : null}
     </div>
+  );
+}
+
+/** Quiet until the row is hovered, so the list reads as names, not controls. */
+function StepDragHandle({
+  label,
+  canReorder,
+  onDragStart,
+}: {
+  label: string;
+  canReorder: boolean;
+  onDragStart: (event: React.MouseEvent) => void;
+}) {
+  if (!canReorder) {
+    return <span className="size-5 shrink-0" aria-hidden />;
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`Reorder ${label}`}
+      className="flex size-5 shrink-0 cursor-grab items-center justify-center rounded-sm text-muted-foreground/70 opacity-0 transition-opacity group-focus-within/step:opacity-100 group-hover/step:opacity-100 hover:text-foreground focus-visible:opacity-100"
+      onMouseDown={onDragStart}
+    >
+      <GripVertical className="size-4" aria-hidden />
+    </button>
   );
 }
 
 const KIND_ICON: Record<PlanningReviewStepKind, typeof Terminal> = {
   bash: Terminal,
   prompt: MessageSquareText,
+};
+
+/** Colour carries the step kind, so the row needs no icon and no chevron. */
+const KIND_BADGE: Record<PlanningReviewStepKind, string> = {
+  bash: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  prompt: "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-400",
 };
 
 const KINDS: PlanningReviewStepKind[] = ["bash", "prompt"];
@@ -171,23 +227,22 @@ function StepKindMenu({
   position: number;
   onChange: (step: PlanningReviewStep) => void;
 }) {
-  const CurrentIcon = KIND_ICON[step.type];
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
           aria-label={`Kind for ${label}`}
-          className="inline-flex shrink-0 items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          className={cn(
+            "inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[11px] font-medium transition-opacity hover:opacity-80",
+            KIND_BADGE[step.type],
+          )}
           data-testid={`planning-review-step-kind-${position}`}
         >
-          <CurrentIcon className="size-3" aria-hidden />
           {KIND_LABEL[step.type]}
-          <ChevronDown className="size-3" aria-hidden />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-28">
+      <DropdownMenuContent align="end" className="min-w-32">
         {KINDS.map((kind) => {
           const KindIcon = KIND_ICON[kind];
           return (

--- a/web_src/src/pages/factories/pages/planningReviewRunnerFields.ts
+++ b/web_src/src/pages/factories/pages/planningReviewRunnerFields.ts
@@ -69,16 +69,6 @@ const environmentVariableSchema: ConfigurationField[] = [
   },
 ];
 
-export const PLANNING_REVIEW_ENVIRONMENT_MODEL_FIELDS = ["machineType", "model"];
-
-export const PLANNING_REVIEW_ADVANCED_FIELD_NAMES = [
-  "workingDirectory",
-  "credentials",
-  "environmentFrom",
-  "environment",
-  "executionTimeoutSeconds",
-];
-
 export const PLANNING_REVIEW_RUNNER_FIELDS: ConfigurationField[] = [
   {
     name: "machineType",

--- a/web_src/src/pages/factories/pages/planningReviewSections.ts
+++ b/web_src/src/pages/factories/pages/planningReviewSections.ts
@@ -1,0 +1,53 @@
+import { Cpu, Gauge, KeyRound, ListOrdered, Variable, type LucideIcon } from "lucide-react";
+
+export type PlanningReviewSectionId = "steps" | "runner" | "credentials" | "environment" | "concurrency";
+
+export interface PlanningReviewSection {
+  id: PlanningReviewSectionId;
+  label: string;
+  /** One line under the panel title. It says what the group controls. */
+  description: string;
+  icon: LucideIcon;
+  /** Names from PLANNING_REVIEW_RUNNER_FIELDS, in the order they appear. */
+  fieldNames: string[];
+}
+
+export const PLANNING_REVIEW_SECTIONS: PlanningReviewSection[] = [
+  {
+    id: "steps",
+    label: "Steps",
+    description: "The agent runs these steps in order on the runner.",
+    icon: ListOrdered,
+    fieldNames: [],
+  },
+  {
+    id: "runner",
+    label: "Runner",
+    description: "Where the agent runs, which model it uses, and when it times out.",
+    icon: Cpu,
+    fieldNames: ["machineType", "model", "workingDirectory", "executionTimeoutSeconds"],
+  },
+  {
+    id: "credentials",
+    label: "Credentials",
+    description: "The account the agent uses to call the model.",
+    icon: KeyRound,
+    fieldNames: ["credentials"],
+  },
+  {
+    id: "environment",
+    label: "Environment variables",
+    description: "Values passed into every step of the agent.",
+    icon: Variable,
+    fieldNames: ["environmentFrom", "environment"],
+  },
+  {
+    id: "concurrency",
+    label: "Concurrency",
+    description: "How many executions of this agent can run at the same time.",
+    icon: Gauge,
+    fieldNames: [],
+  },
+];
+
+export const PLANNING_REVIEW_DEFAULT_SECTION: PlanningReviewSectionId = "steps";


### PR DESCRIPTION
## Summary

The agent editor displayed all settings and scripts in one dense view.
This change separates settings into navigation sections and collapses steps by default.
Shell syntax highlighting makes Bash steps easier to scan and edit.

## Test plan

- [x] Run the planning review popup tests.
- [x] Run the UI lint checks.
- [x] Build the UI production bundle.
- [ ] Review each settings section in Storybook.


Made with [Cursor](https://cursor.com)