### PR TITLE
feat: Show Empty Hosted Credit Banner on Tasks

### DIFF
--- a/web_src/src/pages/factories/HostedCreditEmptyBanner.spec.tsx
+++ b/web_src/src/pages/factories/HostedCreditEmptyBanner.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { HostedCreditEmptyBanner } from "./HostedCreditEmptyBanner";
+
+describe("HostedCreditEmptyBanner", () => {
+  it("links to spending with an add-credit action when billing is on", () => {
+    render(
+      <MemoryRouter>
+        <HostedCreditEmptyBanner billingEnabled spendingHref="/org/workspaces/RF/settings/organization/spending" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("hosted-credit-empty-banner")).toHaveTextContent("Hosted credit is empty");
+    expect(screen.getByTestId("hosted-credit-empty-banner")).toHaveTextContent(
+      "Add hosted credit to start SuperPlane-hosted runs.",
+    );
+    expect(screen.getByRole("link", { name: "Add hosted credit" })).toHaveAttribute(
+      "href",
+      "/org/workspaces/RF/settings/organization/spending",
+    );
+  });
+
+  it("links to spending with a view action when billing is off", () => {
+    render(
+      <MemoryRouter>
+        <HostedCreditEmptyBanner
+          billingEnabled={false}
+          spendingHref="/org/workspaces/RF/settings/organization/spending"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "View spending" })).toHaveAttribute(
+      "href",
+      "/org/workspaces/RF/settings/organization/spending",
+    );
+  });
+});

--- a/web_src/src/pages/factories/HostedCreditEmptyBanner.stories.tsx
+++ b/web_src/src/pages/factories/HostedCreditEmptyBanner.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ComponentStoryShell } from "./__fixtures__/ComponentStoryShell";
+import { withFactoriesTheme } from "./__fixtures__/factoriesStoryTheme";
+import { HostedCreditEmptyBanner } from "./HostedCreditEmptyBanner";
+
+/**
+ * Compact amber banner for empty hosted credit. Tasks shows this above the
+ * board. The action opens Organization Spending.
+ */
+const meta = {
+  title: "Factories/Components/HostedCreditEmptyBanner",
+  component: HostedCreditEmptyBanner,
+  parameters: { layout: "padded" },
+  args: {
+    spendingHref: "/org/workspaces/RF/settings/organization/spending",
+  },
+  decorators: [
+    withFactoriesTheme,
+    (Story) => (
+      <ComponentStoryShell className="max-w-4xl bg-background p-6">
+        <Story />
+      </ComponentStoryShell>
+    ),
+  ],
+} satisfies Meta<typeof HostedCreditEmptyBanner>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Polar billing is on. The action adds hosted credit. */
+export const BillingOn: Story = {
+  name: "Billing on",
+  args: { billingEnabled: true },
+};
+
+/** Polar billing is off. The action opens spending for an installation admin. */
+export const BillingOff: Story = {
+  name: "Billing off",
+  args: { billingEnabled: false },
+};

--- a/web_src/src/pages/factories/HostedCreditEmptyBanner.tsx
+++ b/web_src/src/pages/factories/HostedCreditEmptyBanner.tsx
@@ -1,0 +1,45 @@
+import { TriangleAlert } from "lucide-react";
+import { Link } from "react-router";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { hostedCreditEmptyBannerCopy } from "./lib/hostedCreditEmpty";
+
+interface HostedCreditEmptyBannerProps {
+  billingEnabled: boolean;
+  spendingHref: string;
+  className?: string;
+}
+
+export function HostedCreditEmptyBanner({ billingEnabled, spendingHref, className }: HostedCreditEmptyBannerProps) {
+  const copy = hostedCreditEmptyBannerCopy(billingEnabled);
+
+  return (
+    <div
+      role="status"
+      data-testid="hosted-credit-empty-banner"
+      className={cn(
+        "flex w-full flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50/90 px-3.5 py-2.5 text-sm text-amber-950",
+        "dark:border-amber-700/50 dark:bg-amber-950/30 dark:text-amber-100",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-start gap-2">
+        <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300" aria-hidden />
+        <p>
+          <span className="font-medium">{copy.title}. </span>
+          {copy.description}
+        </p>
+      </div>
+      <Button
+        asChild
+        variant="outline"
+        size="sm"
+        className="border-amber-300 bg-amber-100/70 text-amber-950 hover:bg-amber-100 dark:border-amber-600 dark:bg-amber-900/40 dark:text-amber-50 dark:hover:bg-amber-900/60"
+      >
+        <Link to={spendingHref}>{copy.actionLabel}</Link>
+      </Button>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/__fixtures__/usageReportFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/usageReportFixtures.ts
@@ -91,3 +91,10 @@ export const SPENT_CREDIT_USAGE_REPORT: StorybookUsageReport = {
   billingEnabled: true,
   hasBillingCustomer: true,
 };
+
+/** Polar packs for empty-credit Storybook recovery screens. */
+export const STORYBOOK_HOSTED_CREDIT_PRODUCTS = [
+  { id: "prod-500", name: "Hosted credit 500", amountCents: "50000" },
+  { id: "prod-25", name: "Hosted credit 25", amountCents: "2500" },
+  { id: "prod-100", name: "Hosted credit 100", amountCents: "10000" },
+];

--- a/web_src/src/pages/factories/__fixtures__/usageReportFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/usageReportFixtures.ts
@@ -78,3 +78,16 @@ export const DEFAULT_FACTORY_USAGE: StorybookUsageReport = {
   hostedBilledCents: "876",
   remainingCreditWarning: false,
 };
+
+/** Welcome grant spent. Remaining hosted credit is empty. Polar recovery is available. */
+export const SPENT_CREDIT_USAGE_REPORT: StorybookUsageReport = {
+  ...DEFAULT_FACTORY_USAGE,
+  remainingCreditCents: "0",
+  grantTotalCents: "5000",
+  superplaneGrantCents: "5000",
+  purchasedCreditCents: "0",
+  hostedBilledCents: "5000",
+  remainingCreditWarning: true,
+  billingEnabled: true,
+  hasBillingCustomer: true,
+};

--- a/web_src/src/pages/factories/lib/hostedCreditEmpty.spec.ts
+++ b/web_src/src/pages/factories/lib/hostedCreditEmpty.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { hostedCreditEmptyBannerCopy, shouldShowHostedCreditEmptyBanner } from "./hostedCreditEmpty";
+
+describe("shouldShowHostedCreditEmptyBanner", () => {
+  it("hides the banner when remaining hosted credit is greater than zero", () => {
+    expect(
+      shouldShowHostedCreditEmptyBanner({
+        remainingCreditCents: "4124",
+        grantTotalCents: "5000",
+        billingEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows the banner when a grant is spent and remaining credit is empty", () => {
+    expect(
+      shouldShowHostedCreditEmptyBanner({
+        remainingCreditCents: "0",
+        grantTotalCents: "5000",
+        superplaneGrantCents: "5000",
+        purchasedCreditCents: "0",
+        billingEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("shows the banner when billing is on and remaining credit is empty", () => {
+    expect(
+      shouldShowHostedCreditEmptyBanner({
+        remainingCreditCents: "0",
+        grantTotalCents: "0",
+        billingEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the banner when the organization has no grant and billing is off", () => {
+    expect(
+      shouldShowHostedCreditEmptyBanner({
+        remainingCreditCents: "0",
+        grantTotalCents: "0",
+        superplaneGrantCents: "0",
+        purchasedCreditCents: "0",
+        billingEnabled: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("hostedCreditEmptyBannerCopy", () => {
+  it("tells the user to add hosted credit when billing is on", () => {
+    expect(hostedCreditEmptyBannerCopy(true)).toEqual({
+      title: "Hosted credit is empty",
+      description: "Add hosted credit to start SuperPlane-hosted runs.",
+      actionLabel: "Add hosted credit",
+    });
+  });
+
+  it("asks the user to wait for an installation admin when billing is off", () => {
+    expect(hostedCreditEmptyBannerCopy(false)).toEqual({
+      title: "Hosted credit is empty",
+      description: "SuperPlane-hosted runs cannot start until an installation admin adds credit.",
+      actionLabel: "View spending",
+    });
+  });
+});

--- a/web_src/src/pages/factories/lib/hostedCreditEmpty.ts
+++ b/web_src/src/pages/factories/lib/hostedCreditEmpty.ts
@@ -1,0 +1,40 @@
+import { parseWorkOrderMetric } from "./workOrderUsage";
+
+export function shouldShowHostedCreditEmptyBanner(args: {
+  remainingCreditCents?: string | number;
+  grantTotalCents?: string | number;
+  superplaneGrantCents?: string | number;
+  purchasedCreditCents?: string | number;
+  billingEnabled?: boolean;
+}): boolean {
+  if (parseWorkOrderMetric(args.remainingCreditCents) > 0) {
+    return false;
+  }
+
+  return (
+    parseWorkOrderMetric(args.grantTotalCents) > 0 ||
+    parseWorkOrderMetric(args.superplaneGrantCents) > 0 ||
+    parseWorkOrderMetric(args.purchasedCreditCents) > 0 ||
+    args.billingEnabled === true
+  );
+}
+
+export function hostedCreditEmptyBannerCopy(billingEnabled: boolean): {
+  title: string;
+  description: string;
+  actionLabel: string;
+} {
+  if (billingEnabled) {
+    return {
+      title: "Hosted credit is empty",
+      description: "Add hosted credit to start SuperPlane-hosted runs.",
+      actionLabel: "Add hosted credit",
+    };
+  }
+
+  return {
+    title: "Hosted credit is empty",
+    description: "SuperPlane-hosted runs cannot start until an installation admin adds credit.",
+    actionLabel: "View spending",
+  };
+}

--- a/web_src/src/pages/factories/lib/useHostedCreditEmptyBanner.tsx
+++ b/web_src/src/pages/factories/lib/useHostedCreditEmptyBanner.tsx
@@ -1,0 +1,19 @@
+import { useOrganizationWorkspaceUsage } from "@/hooks/useOrganizationWorkspaceUsage";
+
+import { HostedCreditEmptyBanner } from "../HostedCreditEmptyBanner";
+import { factorySettingsSectionPath } from "./factoryPagePaths";
+import { shouldShowHostedCreditEmptyBanner } from "./hostedCreditEmpty";
+
+export function useHostedCreditEmptyBanner(organizationId: string, factoryKey: string) {
+  const spend = useOrganizationWorkspaceUsage(organizationId);
+  if (!spend.data || !shouldShowHostedCreditEmptyBanner(spend.data)) {
+    return undefined;
+  }
+
+  return (
+    <HostedCreditEmptyBanner
+      billingEnabled={spend.data.billingEnabled === true}
+      spendingHref={factorySettingsSectionPath(organizationId, factoryKey, "organization", "spending")}
+    />
+  );
+}

--- a/web_src/src/pages/factories/pages/WorkOrders.stories.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrders.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import { EMPTY_FACTORY_KEY, PRIMARY_FACTORY_KEY, defaultFactoriesFixture } from "../__fixtures__/factoryPageResponses";
 import { emptyWorkOrdersFactoriesFixture } from "../__fixtures__/factoryPageFixtureVariants";
-import { SPENT_CREDIT_USAGE_REPORT } from "../__fixtures__/usageReportFixtures";
+import { SPENT_CREDIT_USAGE_REPORT, STORYBOOK_HOSTED_CREDIT_PRODUCTS } from "../__fixtures__/usageReportFixtures";
 import { CHECKOUT_RELIABILITY_MISSION, REFUNDS_V2_MISSION } from "./missions/missionMocks";
 import { WorkOrdersPage } from "./WorkOrdersPage";
 
@@ -77,6 +77,7 @@ export const HostedCreditEmpty: Story = {
         factoriesFixture={{
           ...defaultFactoriesFixture,
           organizationWorkspaceUsage: SPENT_CREDIT_USAGE_REPORT,
+          hostedCreditProducts: STORYBOOK_HOSTED_CREDIT_PRODUCTS,
         }}
       />
     );

--- a/web_src/src/pages/factories/pages/WorkOrders.stories.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrders.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import { EMPTY_FACTORY_KEY, PRIMARY_FACTORY_KEY, defaultFactoriesFixture } from "../__fixtures__/factoryPageResponses";
 import { emptyWorkOrdersFactoriesFixture } from "../__fixtures__/factoryPageFixtureVariants";
+import { SPENT_CREDIT_USAGE_REPORT } from "../__fixtures__/usageReportFixtures";
 import { CHECKOUT_RELIABILITY_MISSION, REFUNDS_V2_MISSION } from "./missions/missionMocks";
 import { WorkOrdersPage } from "./WorkOrdersPage";
 
@@ -63,6 +64,23 @@ export const OnlyClosedOrders: Story = {
 export const EmptyWorkspace: Story = {
   name: "Empty workspace",
   render: () => <FactoriesHarness pathSuffix={emptyWorkspacePath} factoriesFixture={defaultFactoriesFixture} />,
+};
+
+/** Remaining hosted credit is empty. A banner sits above the task board. */
+export const HostedCreditEmpty: Story = {
+  name: "Hosted credit empty",
+  render: () => {
+    withWorkOrderLayout("board");
+    return (
+      <FactoriesHarness
+        pathSuffix={workOrdersPath}
+        factoriesFixture={{
+          ...defaultFactoriesFixture,
+          organizationWorkspaceUsage: SPENT_CREDIT_USAGE_REPORT,
+        }}
+      />
+    );
+  },
 };
 
 export const MissionDetailCheckout: Story = {

--- a/web_src/src/pages/factories/pages/WorkOrdersPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrdersPage.spec.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { client } from "@/api-client/client.gen";
+
+import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
+import {
+  defaultFactoriesFixture,
+  FACTORIES_ORGANIZATION_ID,
+  PRIMARY_FACTORY_KEY,
+} from "../__fixtures__/factoryPageResponses";
+import { SPENT_CREDIT_USAGE_REPORT } from "../__fixtures__/usageReportFixtures";
+import { factorySettingsSectionPath } from "../lib/factoryPagePaths";
+import { WorkOrdersPage } from "./WorkOrdersPage";
+
+describe("WorkOrdersPage hosted credit banner", () => {
+  beforeAll(() => {
+    client.setConfig({ baseUrl: "http://localhost" });
+  });
+
+  it("hides the banner when remaining hosted credit is greater than zero", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-orders`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    expect(await screen.findByTestId("work-orders-header", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(screen.queryByTestId("hosted-credit-empty-banner")).not.toBeInTheDocument();
+  }, 10000);
+
+  it("shows the banner on Tasks when remaining hosted credit is empty", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-orders`}
+        factoriesFixture={{
+          ...defaultFactoriesFixture,
+          organizationWorkspaceUsage: SPENT_CREDIT_USAGE_REPORT,
+        }}
+      />,
+    );
+
+    const banner = await screen.findByTestId("hosted-credit-empty-banner", {}, { timeout: 8000 });
+    expect(banner).toHaveTextContent("Hosted credit is empty");
+    expect(banner).toHaveTextContent("Add hosted credit to start SuperPlane-hosted runs.");
+    expect(screen.getByRole("link", { name: "Add hosted credit" })).toHaveAttribute(
+      "href",
+      factorySettingsSectionPath(FACTORIES_ORGANIZATION_ID, PRIMARY_FACTORY_KEY, "organization", "spending"),
+    );
+  }, 10000);
+
+  it("shows the banner on the production Tasks page when remaining credit is empty", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-orders`}
+        factoriesFixture={{
+          ...defaultFactoriesFixture,
+          organizationWorkspaceUsage: SPENT_CREDIT_USAGE_REPORT,
+        }}
+        pageOverrides={{ workOrders: WorkOrdersPage }}
+      />,
+    );
+
+    expect(await screen.findByTestId("hosted-credit-empty-banner", {}, { timeout: 8000 })).toBeInTheDocument();
+  }, 10000);
+});

--- a/web_src/src/pages/factories/pages/WorkOrdersPage.tsx
+++ b/web_src/src/pages/factories/pages/WorkOrdersPage.tsx
@@ -6,6 +6,7 @@ import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { cn } from "@/lib/utils";
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
+import { useHostedCreditEmptyBanner } from "../lib/useHostedCreditEmptyBanner";
 import { useWorkOrderListState } from "../lib/useWorkOrderListState";
 import { WorkOrdersLoadedView } from "../workOrders/WorkOrdersLoadedView";
 import { WorkOrdersErrorState, WorkOrdersLoadingState } from "../workOrders/WorkOrdersEmptyStates";
@@ -40,6 +41,7 @@ export function WorkOrdersPage() {
   const canCreate = canAct("work_orders", "create");
   const canDispatch = canAct("work_orders", "update");
   const canAssign = canAct("work_orders", "update");
+  const hostedCreditEmptyBanner = useHostedCreditEmptyBanner(organizationId, factoryKey);
 
   const isOrdersLoading = workOrdersLoading || (workOrdersFetching && workOrders.length === 0);
 
@@ -80,6 +82,7 @@ export function WorkOrdersPage() {
       canDispatch={canDispatch}
       canAssign={canAssign}
       permissionsLoading={permissionsLoading}
+      hostedCreditEmptyBanner={hostedCreditEmptyBanner}
       {...cardActions}
     />
   );

--- a/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersLoadedView.tsx
+++ b/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersLoadedView.tsx
@@ -1,6 +1,6 @@
 import type { FactoriesFactory, FactoriesFactoryLine, FactoriesWorkOrder } from "@/api-client";
 import { cn } from "@/lib/utils";
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import type { WorkOrderListState } from "../../lib/useWorkOrderListState";
 import {
   applyWorkOrderFilters,
@@ -38,6 +38,7 @@ export interface MissionsWorkOrdersLoadedViewProps {
   isAssigneesSaving: boolean;
   onDispatch: (orderId: string, input: { lineName: string }) => Promise<void>;
   onAssigneesSave: (orderId: string, assigneeIds: string[]) => Promise<void>;
+  hostedCreditEmptyBanner?: ReactNode;
 }
 
 export function MissionsWorkOrdersLoadedView(props: MissionsWorkOrdersLoadedViewProps) {
@@ -108,6 +109,7 @@ export function MissionsWorkOrdersLoadedView(props: MissionsWorkOrdersLoadedView
           onCreateWorkOrder={props.onCreateWorkOrder}
           canCreate={props.canCreate}
           permissionsLoading={props.permissionsLoading}
+          hostedCreditEmptyBanner={props.hostedCreditEmptyBanner}
         />
       </div>
 

--- a/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersPage.tsx
+++ b/web_src/src/pages/factories/pages/missions/MissionsWorkOrdersPage.tsx
@@ -7,6 +7,7 @@ import { useFactoriesLayout } from "../../layout/factoriesLayoutContext";
 import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
 import { WorkOrdersErrorState, WorkOrdersLoadingState } from "../../workOrders/WorkOrdersEmptyStates";
 import { factoryContentBodyClassName, factorySectionHeaderClassName } from "../factoryPageLayoutStyles";
+import { useHostedCreditEmptyBanner } from "../../lib/useHostedCreditEmptyBanner";
 import { useWorkOrderListState } from "../../lib/useWorkOrderListState";
 import { MissionsWorkOrdersLoadedView } from "./MissionsWorkOrdersLoadedView";
 
@@ -30,6 +31,7 @@ export function MissionsWorkOrdersPage() {
   const canCreate = canAct("work_orders", "create");
   const canDispatch = canAct("work_orders", "update");
   const canAssign = canAct("work_orders", "update");
+  const hostedCreditEmptyBanner = useHostedCreditEmptyBanner(organizationId, factoryKey);
   const isOrdersLoading = workOrdersLoading || (workOrdersFetching && workOrders.length === 0);
 
   if (workOrdersError) {
@@ -68,6 +70,7 @@ export function MissionsWorkOrdersPage() {
       canDispatch={canDispatch}
       canAssign={canAssign}
       permissionsLoading={permissionsLoading}
+      hostedCreditEmptyBanner={hostedCreditEmptyBanner}
       {...cardActions}
     />
   );

--- a/web_src/src/pages/factories/pages/organizationSettings/HostedCreditEmpty.stories.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/HostedCreditEmpty.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FactoriesHarness } from "../../__fixtures__/FactoriesHarness";
+import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../../__fixtures__/factoryPageResponses";
+import { SPENT_CREDIT_USAGE_REPORT } from "../../__fixtures__/usageReportFixtures";
+import { FactorySettingsLayout } from "../settings/FactorySettingsLayout";
+
+/**
+ * Current Organization Spending UI when hosted credit is empty.
+ * Hosted runs fail at execute. This page is the recovery screen.
+ */
+const meta = {
+  title: "Factories/Pages/Hosted Credit Empty",
+  component: FactorySettingsLayout,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof FactorySettingsLayout>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const spendingPath = `workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/spending`;
+
+const STORYBOOK_HOSTED_CREDIT_PRODUCTS = [
+  { id: "prod-500", name: "Hosted credit 500", amountCents: "50000" },
+  { id: "prod-25", name: "Hosted credit 25", amountCents: "2500" },
+  { id: "prod-100", name: "Hosted credit 100", amountCents: "10000" },
+];
+
+export const OrganizationSpending: Story = {
+  name: "Organization Spending",
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={spendingPath}
+      factoriesFixture={{
+        ...defaultFactoriesFixture,
+        organizationWorkspaceUsage: SPENT_CREDIT_USAGE_REPORT,
+        hostedCreditProducts: STORYBOOK_HOSTED_CREDIT_PRODUCTS,
+      }}
+    />
+  ),
+};

--- a/web_src/src/pages/factories/pages/organizationSettings/HostedCreditEmpty.stories.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/HostedCreditEmpty.stories.tsx
@@ -40,3 +40,20 @@ export const OrganizationSpending: Story = {
     />
   ),
 };
+
+/** Tasks list with remaining hosted credit empty. The banner sits above the board. */
+export const Tasks: Story = {
+  render: () => {
+    window.localStorage.setItem("sp:work-orders:layout", "board");
+    return (
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/work-orders`}
+        factoriesFixture={{
+          ...defaultFactoriesFixture,
+          organizationWorkspaceUsage: SPENT_CREDIT_USAGE_REPORT,
+          hostedCreditProducts: STORYBOOK_HOSTED_CREDIT_PRODUCTS,
+        }}
+      />
+    );
+  },
+};

--- a/web_src/src/pages/factories/pages/organizationSettings/HostedCreditEmpty.stories.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/HostedCreditEmpty.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../../__fixtures__/FactoriesHarness";
 import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../../__fixtures__/factoryPageResponses";
-import { SPENT_CREDIT_USAGE_REPORT } from "../../__fixtures__/usageReportFixtures";
+import { SPENT_CREDIT_USAGE_REPORT, STORYBOOK_HOSTED_CREDIT_PRODUCTS } from "../../__fixtures__/usageReportFixtures";
 import { FactorySettingsLayout } from "../settings/FactorySettingsLayout";
 
 /**
@@ -20,12 +20,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const spendingPath = `workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/spending`;
-
-const STORYBOOK_HOSTED_CREDIT_PRODUCTS = [
-  { id: "prod-500", name: "Hosted credit 500", amountCents: "50000" },
-  { id: "prod-25", name: "Hosted credit 25", amountCents: "2500" },
-  { id: "prod-100", name: "Hosted credit 100", amountCents: "10000" },
-];
 
 export const OrganizationSpending: Story = {
   name: "Organization Spending",

--- a/web_src/src/pages/factories/workOrders/WorkOrdersLoadedView.tsx
+++ b/web_src/src/pages/factories/workOrders/WorkOrdersLoadedView.tsx
@@ -5,7 +5,7 @@ import type {
   FactoriesWorkOrder,
 } from "@/api-client";
 import { cn } from "@/lib/utils";
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import {
   applyWorkOrderFilters,
   applyWorkOrderOrdering,
@@ -45,6 +45,7 @@ interface WorkOrdersLoadedViewProps {
   isAssigneesSaving: boolean;
   onDispatch: (orderId: string, input: { lineName: string }) => Promise<void>;
   onAssigneesSave: (orderId: string, assigneeIds: string[]) => Promise<void>;
+  hostedCreditEmptyBanner?: ReactNode;
 }
 
 /**
@@ -128,6 +129,7 @@ export function WorkOrdersLoadedView(props: WorkOrdersLoadedViewProps) {
           onCreateWorkOrder={props.onCreateWorkOrder}
           canCreate={props.canCreate}
           permissionsLoading={props.permissionsLoading}
+          hostedCreditEmptyBanner={props.hostedCreditEmptyBanner}
         />
       </div>
 

--- a/web_src/src/pages/factories/workOrders/header/WorkOrdersHeader.tsx
+++ b/web_src/src/pages/factories/workOrders/header/WorkOrdersHeader.tsx
@@ -2,6 +2,7 @@ import type { FactoriesFactoryLine } from "@/api-client";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
+import type { ReactNode } from "react";
 import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
 import type { WorkOrderListState } from "../../lib/useWorkOrderListState";
 import { useWorkOrdersHeaderShortcuts } from "../../lib/useWorkOrdersHeaderShortcuts";
@@ -22,6 +23,7 @@ interface WorkOrdersHeaderProps {
   onCreateWorkOrder: () => void;
   canCreate: boolean;
   permissionsLoading: boolean;
+  hostedCreditEmptyBanner?: ReactNode;
 }
 
 /**
@@ -38,6 +40,7 @@ export function WorkOrdersHeader({
   onCreateWorkOrder,
   canCreate,
   permissionsLoading,
+  hostedCreditEmptyBanner,
 }: WorkOrdersHeaderProps) {
   const searchRef = useWorkOrdersHeaderShortcuts(state);
   const lineOptions = buildLineFilterOptions(factoryLines);
@@ -88,8 +91,13 @@ export function WorkOrdersHeader({
         </>
       }
       belowRow={
-        state.filterCount > 0 ? (
-          <FilterChips state={state} lineOptions={lineOptions} assigneeOptions={assigneeOptions} />
+        hostedCreditEmptyBanner || state.filterCount > 0 ? (
+          <>
+            {hostedCreditEmptyBanner}
+            {state.filterCount > 0 ? (
+              <FilterChips state={state} lineOptions={lineOptions} assigneeOptions={assigneeOptions} />
+            ) : null}
+          </>
         ) : undefined
       }
     />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remaining hosted credit of $0 only showed a warning on Organization Spending. Users who stay on Tasks did not see that SuperPlane-hosted runs cannot start.

This change shows an amber banner on the Tasks list when remaining hosted credit is empty. The action opens Organization Spending so the user can add credit.

Storybook also mounts this empty-credit state on Tasks and Organization Spending.

Preview: [https://pr-7070-storybook.superplane.workers.dev](https://pr-7070-storybook.superplane.workers.dev)

- [Tasks banner](https://pr-7070-storybook.superplane.workers.dev/?path=/story/factories-pages-hosted-credit-empty--tasks)
- [Organization Spending](https://pr-7070-storybook.superplane.workers.dev/?path=/story/factories-pages-hosted-credit-empty--organization-spending)
- [Banner component](https://pr-7070-storybook.superplane.workers.dev/?path=/story/factories-components-hostedcreditemptybanner--billing-on)

[Tasks page with empty hosted credit banner](https://cursor.com/agents/bc-377a5de2-c0bc-420e-b72a-4513c8567a02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhosted_credit_empty_tasks_banner.webp)
[Add hosted credit opens Organization Spending at $0.00](https://cursor.com/agents/bc-377a5de2-c0bc-420e-b72a-4513c8567a02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhosted_credit_empty_spending_from_banner.webp)
[Populated Tasks story without the empty-credit banner](https://cursor.com/agents/bc-377a5de2-c0bc-420e-b72a-4513c8567a02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftasks_populated_no_credit_banner.webp)
[hosted_credit_empty_banner_cta.mp4](https://cursor.com/agents/bc-377a5de2-c0bc-420e-b72a-4513c8567a02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhosted_credit_empty_banner_cta.mp4)

## Test plan

- [x] Run the hosted-credit banner unit tests.
- [x] Open Factories/Pages/Hosted Credit Empty / Tasks in Storybook.
- [x] Confirm the amber banner sits above the task board.
- [x] Confirm Add hosted credit opens Organization Spending.
- [x] Confirm Factories/Pages/Tasks / Hosted credit empty shows the same banner.
- [x] Confirm the populated Tasks story does not show the banner.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-377a5de2-c0bc-420e-b72a-4513c8567a02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-377a5de2-c0bc-420e-b72a-4513c8567a02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

