### PR TITLE
feat: Simplify default Implement agent steps

### DIFF
--- a/docs/design/factory.md
+++ b/docs/design/factory.md
@@ -49,7 +49,9 @@ linked source run (`source_run_id` on the work order record).
 Expressions on a dispatched run should prefer `order()` over
 `root().data.work_order`. `order()` resolves the live work order for the
 current run (`id`, `title`, `description`, `factory_id`, `state`, `result`,
-`source`) and returns `nil` when the run is not attached to a work order.
+`repository`, `repository_url`, `default_branch`, `source`) and returns `nil`
+when the run is not attached to a work order. `repository_url` is the
+canonical HTTPS Git URL without credentials.
 `order().url` is the work order permalink
 (`{BASE_URL}/{orgId}/workspaces/{factoryKey}/work-order/{number}`), resolved
 lazily only when the expression references it, because the factory that owns

--- a/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
+++ b/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
@@ -49,20 +49,11 @@ spec:
             integration:
               name: github
         environment:
-          - name: REPO
-            value: '{{ order().repository }}'
+          - name: REPO_URL
+            value: 'https://x-access-token:${GITHUB_TOKEN}@github.com/{{ order().repository }}.git'
             valueSource: literal
           - name: BASE
             value: '{{ order().default_branch }}'
-            valueSource: literal
-          - name: WORK_ORDER_TITLE
-            value: '{{ order().title }}'
-            valueSource: literal
-          - name: ORDER_DESCRIPTION
-            value: '{{ toBase64(order().description) }}'
-            valueSource: literal
-          - name: PLAN
-            value: '{{ toBase64(find(order().artifacts, {#.type == "markdown" && #.data.title == "PLAN.md"}).data.body) }}'
             valueSource: literal
           - name: COAUTHORS
             value: '{{ join(map(filter(order().assignees, {#.email != ""}), "Co-authored-by: " + #.name + " <" + #.email + ">"), "\n") }}'
@@ -71,43 +62,19 @@ spec:
         machineType: e1-large-amd64
         model: sonnet
         steps:
-          - name: Set Up Git User
-            type: bash
-            command: |-
-              echo "Using superplaneagent@superplane.com"
-              git config --global user.email "superplaneagent@superplane.com"
-              git config --global user.name "SuperPlane Agent"
-          - name: Provide order
-            type: bash
-            command: |-
-              echo $ORDER_DESCRIPTION | base64 -d > /tmp/ORDER.md
-              cat /tmp/ORDER.md
-          - name: Provide Plan
-            type: bash
-            command: |-
-              echo $PLAN | base64 -d > /tmp/PLAN.md
-              cat /tmp/PLAN.md
-          - name: Create Branch
+          - name: Clone Repo
             type: bash
             command: |-
               set -euo pipefail
 
-              # Unique branch name: fix/{slug-of-task-title}-{unix-timestamp}-{random}
-              SLUG="$(printf '%s' "${WORK_ORDER_TITLE:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-50 | sed -E 's/-+$//')"
-              [ -z "$SLUG" ] && SLUG="issue"
-              RAND="$(openssl rand -hex 4 2>/dev/null || head -c4 /dev/urandom | od -An -tx1 | tr -d ' \n')"
-              BRANCH="fix/${SLUG}-$(date +%s)-${RAND}"
-              echo "$BRANCH" > /tmp/BRANCH
+              # Identify commits as SuperPlane Agent.
+              git config --global user.email "superplaneagent@superplane.com"
+              git config --global user.name "SuperPlane Agent"
 
-              rm -rf repo
-              git clone --depth 1 --branch "${BASE:-main}" "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git" repo
-              cd repo
-              git checkout -b "$BRANCH"
-              echo "Working on $BRANCH"
-          - name: Set Up DCO Signing
-            type: bash
-            workingDirectory: repo
-            command: |-
+              # Shallow clone of the default branch into ./repo.
+              git clone --depth 1 --branch "${BASE:-main}" "${REPO_URL}" repo && cd repo
+
+              # On every commit: add DCO sign-off, then Co-authored-by from COAUTHORS.
               cat > .git/hooks/prepare-commit-msg <<'HOOK'
               git interpret-trailers --in-place --if-exists doNothing \
                 --trailer "Signed-off-by: SuperPlane Agent <superplaneagent@superplane.com>" "$1"
@@ -120,21 +87,25 @@ spec:
 
               exit 0
               HOOK
-
               chmod +x .git/hooks/prepare-commit-msg
           - name: Implementation
             type: prompt
             workingDirectory: repo
             prompt: |-
-              You are implementing a fix for a SuperPlane task. The repository is already checked out in your current working directory, on the branch to work on.
+              You are implementing a SuperPlane task. The repository is cloned in the current working directory on {{ order().default_branch }}.
 
               Repository: {{ order().repository }}
               Task title: {{ order().title }}
 
-              1/ The original task description is at /tmp/ORDER.md. Read it before implementing.
-              2/ The preliminary plan is at /tmp/PLAN.md. Read it before writing any implementation.
-              3/ Implement. Make the code changes required to resolve the task description and plan.
-              4/ Keep the change focused and commit your work to the current branch with clear commit messages.
+              Task description:
+              {{ order().description }}
+
+              Implementation plan:
+              {{ find(order().artifacts, {#.type == "markdown" && #.data.title == "PLAN.md"}).data.body }}
+
+              1/ Create a new branch. Do not commit on {{ order().default_branch }}.
+              2/ Implement the task and the plan. Keep the change focused.
+              3/ Commit on the working branch with clear messages.
 
               Guidelines:
 
@@ -146,20 +117,20 @@ spec:
             workingDirectory: repo
             command: |-
               set -euo pipefail
-              BRANCH="$(cat /tmp/BRANCH)"
-              echo "cwd=$(pwd -P)"
-              git status
-              git log --oneline -5
+
+              # Commit leftover uncommitted work if the agent did not commit everything.
               git add -A
               if ! git diff --cached --quiet; then
                 git commit -s -m "fix: implement task via SuperPlane"
               fi
+
+              # Fail if this branch has no commits ahead of the default branch.
               if [ "$(git rev-list --count "origin/${BASE:-main}..HEAD")" -eq 0 ]; then
-                echo "No file changes and no unpushed commits on ${BRANCH}" >&2
+                echo "No commits to push" >&2
                 exit 1
               fi
-              git push -u origin "$BRANCH"
-              echo "Pushed implementation to $BRANCH"
+
+              git push -u origin HEAD
           - name: Generate PR title and description
             type: prompt
             workingDirectory: repo
@@ -177,10 +148,11 @@ spec:
           - name: Push output
             type: bash
             command: |-
+              # Emit branch name plus PR title/description for the next canvas nodes.
               if [ -s /tmp/TITLE ] && [ -s /tmp/DESCRIPTION.md ]; then
                 echo "Title and description found. Using as output"
                 jq -n \
-                  --arg branch "$(cat /tmp/BRANCH)" \
+                  --arg branch "$(git -C repo rev-parse --abbrev-ref HEAD)" \
                   --rawfile title /tmp/TITLE \
                   --rawfile description /tmp/DESCRIPTION.md \
                   '{branch: $branch, title: ($title | @base64), description: ($description | @base64)}' \

--- a/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
+++ b/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
@@ -50,7 +50,7 @@ spec:
               name: github
         environment:
           - name: REPO_URL
-            value: 'https://x-access-token:${GITHUB_TOKEN}@github.com/{{ order().repository }}.git'
+            value: '{{ order().repository_url }}'
             valueSource: literal
           - name: BASE
             value: '{{ order().default_branch }}'
@@ -70,6 +70,9 @@ spec:
               # Identify commits as SuperPlane Agent.
               git config --global user.email "superplaneagent@superplane.com"
               git config --global user.name "SuperPlane Agent"
+
+              # Authenticate canonical GitHub URLs with the integration token.
+              git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
 
               # Shallow clone of the default branch into ./repo.
               git clone --depth 1 --branch "${BASE:-main}" "${REPO_URL}" repo && cd repo

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -1087,6 +1087,7 @@ func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, 
 		"state":          order.State,
 		"result":         order.Result,
 		"repository":     repository,
+		"repository_url": githubRepositoryURL(repository),
 		"default_branch": defaultBranch,
 	}
 
@@ -1212,6 +1213,10 @@ func (b *NodeConfigurationBuilder) resolveOrderRepository(order *models.FactoryW
 	}
 
 	return repository, defaultBranch, nil
+}
+
+func githubRepositoryURL(repository string) string {
+	return "https://github.com/" + strings.TrimSuffix(repository, ".git") + ".git"
 }
 
 func attachOrderSource(tx *gorm.DB, order *models.FactoryWorkOrder, payload map[string]any) error {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -345,6 +345,7 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		assert.Equal(t, models.FactoryWorkOrderStateDraft, payload["state"])
 		assert.Equal(t, "", payload["result"])
 		assert.Equal(t, repository, payload["repository"])
+		assert.Equal(t, "https://github.com/"+repository+".git", payload["repository_url"])
 		assert.Equal(t, defaultBranch, payload["default_branch"])
 		assert.NotContains(t, payload, "url")
 		assert.NotContains(t, payload, "artifacts")
@@ -370,6 +371,7 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		payload, ok := result.(map[string]any)
 		require.True(t, ok)
 		assert.Equal(t, repository, payload["repository"])
+		assert.Equal(t, "https://github.com/"+repository+".git", payload["repository_url"])
 		assert.Equal(t, defaultBranch, payload["default_branch"])
 	})
 
@@ -390,6 +392,7 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		payload, ok := result.(map[string]any)
 		require.True(t, ok)
 		assert.Equal(t, currentRepository, payload["repository"])
+		assert.Equal(t, "https://github.com/"+currentRepository+".git", payload["repository_url"])
 		assert.Equal(t, currentDefaultBranch, payload["default_branch"])
 	})
 
@@ -401,6 +404,10 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		title, err := builder.ResolveExpression(`order().title`)
 		require.NoError(t, err)
 		assert.Equal(t, "Ship feature", title)
+
+		repositoryURL, err := builder.ResolveExpression(`order().repository_url`)
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/acme/current-service.git", repositoryURL)
 
 		issueNumber, err := builder.ResolveExpression(`order().source.issue.number`)
 		require.NoError(t, err)

--- a/web_src/src/pages/app/buildAutocompleteExampleObj.ts
+++ b/web_src/src/pages/app/buildAutocompleteExampleObj.ts
@@ -106,6 +106,7 @@ function buildOrderExample(): Record<string, unknown> {
     state: "open",
     result: "",
     repository: "acme/service",
+    repository_url: "https://github.com/acme/service.git",
     default_branch: "main",
     url: exampleOrderUrl(),
     source: {

--- a/web_src/src/pages/factories/pages/planningReviewMockup.ts
+++ b/web_src/src/pages/factories/pages/planningReviewMockup.ts
@@ -49,14 +49,8 @@ const implementationConfiguration: Record<string, unknown> = {
   workingDirectory: "/tmp/repo",
   environmentFrom: [{ source: "integration", integration: "github-superplanehq" }],
   environment: [
-    { name: "REPO", valueSource: "literal", value: "superplanehq/superplane" },
-    { name: "BRANCH", valueSource: "literal", value: '{{ $["Create Branch"].data.result.branch }}' },
-    { name: "ORDER_DESCRIPTION", valueSource: "literal", value: "{{ toBase64(order().description) }}" },
-    {
-      name: "PLAN",
-      valueSource: "literal",
-      value: '{{ toBase64(find(order().artifacts, {#.type == "markdown" && #.data.title == "PLAN.md"}).data.body) }}',
-    },
+    { name: "REPO_URL", valueSource: "literal", value: "{{ order().repository_url }}" },
+    { name: "BASE", valueSource: "literal", value: "{{ order().default_branch }}" },
   ],
   executionTimeoutSeconds: 3600,
 };

--- a/web_src/src/pages/factories/pages/planningReviewMockup.ts
+++ b/web_src/src/pages/factories/pages/planningReviewMockup.ts
@@ -28,7 +28,7 @@ export interface PlanningReviewDraft {
 }
 
 const implementationSteps: PlanningReviewStep[] = [
-  { name: "Clone Repo", type: "bash", command: "git clone --depth 1 \"$REPO_URL\" repo" },
+  { name: "Clone Repo", type: "bash", command: 'git clone --depth 1 "$REPO_URL" repo' },
   {
     name: "Implementation",
     type: "prompt",

--- a/web_src/src/pages/factories/pages/planningReviewMockup.ts
+++ b/web_src/src/pages/factories/pages/planningReviewMockup.ts
@@ -28,20 +28,11 @@ export interface PlanningReviewDraft {
 }
 
 const implementationSteps: PlanningReviewStep[] = [
-  { name: "Set Up Git User", type: "bash", command: 'git config --global user.email "agent@superplane.com"' },
-  {
-    name: "Provide order",
-    type: "bash",
-    command: "echo $ORDER_DESCRIPTION | base64 -d > /tmp/ORDER.md\ncat /tmp/ORDER.md",
-    workingDirectory: "repo",
-  },
-  { name: "Provide Plan", type: "bash", command: "echo $PLAN | base64 -d > /tmp/PLAN.md" },
-  { name: "Checkout Branch", type: "bash", command: "git checkout $BRANCH", workingDirectory: "repo" },
-  { name: "Set Up DCO Signing", type: "bash", command: "git config commit.gpgsign false", workingDirectory: "repo" },
+  { name: "Clone Repo", type: "bash", command: "git clone --depth 1 \"$REPO_URL\" repo" },
   {
     name: "Implementation",
     type: "prompt",
-    prompt: "Implement the approved plan. Make the smallest complete change and update the tests.",
+    prompt: "Create a working branch and implement the approved plan.",
     workingDirectory: "repo",
   },
   { name: "Commit and Push", type: "bash", command: "git push origin HEAD", workingDirectory: "repo" },


### PR DESCRIPTION
## Summary

The default Implement app showed many setup steps before the agent work. Operators could not see the main implementation path.

This change keeps clone, deterministic commit trailers, and push in bash. The agent creates the working branch and receives the task and plan directly.

`order().repository_url` now provides a canonical clone URL without credentials. Git applies the connected GitHub token when it accesses that URL.

## Test plan

- [x] Run the order expression builder tests.
- [x] Run the factory template materialization tests.
- [x] Run the affected Planning Review and autocomplete UI tests.
- [x] Check Go and TypeScript formatting.
- [ ] Reset or recreate the default Implement app from the template.
- [ ] Confirm generated commits contain DCO and assignee co-author trailers.
- [ ] Confirm SuperPlane opens a pull request from the agent-created branch.