### PR TITLE
feat: Show task pull requests under Artifacts

### DIFF
--- a/web_src/src/pages/factories/WorkOrderDetailSidebar.tsx
+++ b/web_src/src/pages/factories/WorkOrderDetailSidebar.tsx
@@ -87,13 +87,13 @@ export function WorkOrderDetailSidebar({
         onDispatch={onDispatch}
       />
 
+      <WorkOrderArtifactsList artifacts={artifacts} isLoading={isArtifactsLoading} error={artifactsError} />
+
       <WorkOrderPullRequestsList
         pullRequests={pullRequests}
         isLoading={isPullRequestsLoading}
         error={pullRequestsError}
       />
-
-      <WorkOrderArtifactsList artifacts={artifacts} isLoading={isArtifactsLoading} error={artifactsError} />
     </div>
   );
 }

--- a/web_src/src/pages/factories/WorkOrderPullRequestInline.tsx
+++ b/web_src/src/pages/factories/WorkOrderPullRequestInline.tsx
@@ -3,7 +3,12 @@ import { cn } from "@/lib/utils";
 import type { FactoriesFactoryPullRequest } from "@/api-client";
 import { ExternalLink, GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft } from "lucide-react";
 
-import { pullRequestLabel, pullRequestState, type FactoryPullRequestState } from "./lib/workOrderPullRequest";
+import {
+  pullRequestLabel,
+  pullRequestListLabel,
+  pullRequestState,
+  type FactoryPullRequestState,
+} from "./lib/workOrderPullRequest";
 
 const PR_STATE_PRESENTATION: Record<FactoryPullRequestState, { icon: typeof GitPullRequest; className: string }> = {
   open: { icon: GitPullRequest, className: "text-emerald-600 dark:text-emerald-400" },
@@ -18,13 +23,16 @@ const pullRequestInlineClassName =
 export function WorkOrderPullRequestInline({
   pullRequest,
   className,
+  showTitle = false,
 }: {
   pullRequest: FactoriesFactoryPullRequest;
   className?: string;
+  /** Include the PR title after the number (sidebar lists). */
+  showTitle?: boolean;
 }) {
   const state = pullRequestState(pullRequest.state);
   const { icon: Icon, className: iconClassName } = PR_STATE_PRESENTATION[state];
-  const label = pullRequestLabel(pullRequest);
+  const label = showTitle ? pullRequestListLabel(pullRequest) : pullRequestLabel(pullRequest);
   const title = pullRequest.title?.trim();
   const safeUrl = safeExternalUrl(pullRequest.url);
   const content = (

--- a/web_src/src/pages/factories/WorkOrderPullRequestsList.tsx
+++ b/web_src/src/pages/factories/WorkOrderPullRequestsList.tsx
@@ -27,7 +27,7 @@ export function WorkOrderPullRequestsList({ pullRequests, isLoading, error }: Wo
                 className="flex items-center py-1.5"
                 key={pullRequest.id ?? `${pullRequest.url}-${pullRequest.number}`}
               >
-                <WorkOrderPullRequestInline className="w-full justify-start" pullRequest={pullRequest} />
+                <WorkOrderPullRequestInline className="w-full justify-start" pullRequest={pullRequest} showTitle />
               </li>
             ))}
           </ul>

--- a/web_src/src/pages/factories/lib/workOrderPullRequest.ts
+++ b/web_src/src/pages/factories/lib/workOrderPullRequest.ts
@@ -61,6 +61,19 @@ export function pullRequestLabel(pullRequest: FactoriesFactoryPullRequest): stri
   return "Pull request";
 }
 
+/** Sidebar list label: number plus title when both exist. */
+export function pullRequestListLabel(pullRequest: FactoriesFactoryPullRequest): string {
+  const numberLabel = pullRequestLabel(pullRequest);
+  const title = pullRequest.title?.trim();
+  if (!title || title === numberLabel) {
+    return numberLabel;
+  }
+  if (numberLabel.startsWith("#")) {
+    return `${numberLabel} ${title}`;
+  }
+  return title;
+}
+
 export function isActiveCanvasRun(run: CanvasesCanvasRunRef | undefined): boolean {
   if (!run?.id) {
     return false;

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRun.spec.tsx
@@ -747,6 +747,13 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(within(sidebar).getByText("plan.md")).toBeInTheDocument();
     expect(within(sidebar).queryByText("PAY-842")).not.toBeInTheDocument();
     expect(within(sidebar).queryByText("details.md")).not.toBeInTheDocument();
+    expect(within(sidebar).getByRole("heading", { name: "Pull requests" })).toBeInTheDocument();
+    expect(within(sidebar).getByText("No pull requests yet.")).toBeInTheDocument();
+    const artifactsHeading = within(sidebar).getByRole("heading", { name: "Artifacts" });
+    const pullRequestsHeading = within(sidebar).getByRole("heading", { name: "Pull requests" });
+    expect(
+      artifactsHeading.compareDocumentPosition(pullRequestsHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(within(tab).getByTestId("split-run-overview-checks")).toBeInTheDocument();
     expect(within(tab).getByTestId("split-run-check-comment-wo-review-pay-842-confidence")).toHaveAttribute("open");
     expect(within(tab).getByTestId("split-run-check-comment-check-risk-review")).not.toHaveAttribute("open");
@@ -863,6 +870,12 @@ describe("WorkOrderSplitRunPopup", () => {
     expect(within(note).getByText("The work is done. The result met the goal.")).toBeInTheDocument();
     expect(within(note).queryByRole("button", { name: "Reopen" })).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Description" })).toHaveAttribute("data-state", "active");
+
+    const sidebar = screen.getByTestId("split-run-overview-sidebar");
+    expect(within(sidebar).getByRole("heading", { name: "Pull requests" })).toBeInTheDocument();
+    expect(
+      within(sidebar).getByRole("link", { name: "#510 Send refund receipts after provider confirm" }),
+    ).toHaveAttribute("href", "https://github.com/example/ledger/pull/510");
   });
 
   it("explains a rejected result without Reopen", () => {
@@ -883,6 +896,9 @@ describe("WorkOrderSplitRunPopup", () => {
       fixture: splitRunFixtureForWorkOrder(LINE_BOARD_DONE_RECEIPTS_ORDER, { demoArtifacts: false }),
     });
 
+    const sidebar = screen.getByTestId("split-run-overview-sidebar");
+    expect(within(sidebar).getByRole("heading", { name: "Pull requests" })).toBeInTheDocument();
+    expect(within(sidebar).queryByRole("link", { name: /#510/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /#510/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "closure.md" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /merge-screenshot/ })).not.toBeInTheDocument();

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunOverview.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunOverview.tsx
@@ -1,23 +1,27 @@
-import type { FactoriesWorkOrderArtifact } from "@/api-client";
+import type { FactoriesFactoryPullRequest, FactoriesWorkOrderArtifact } from "@/api-client";
 
 import type { WorkOrderCheckPresentation } from "../../lib/workOrderChecks";
 import { getWorkOrderRunHref } from "../../lib/workOrderExecutions";
 import { SidebarSectionHeading } from "../../sidebar/SidebarPrimitives";
 import { WorkOrderArtifactsList } from "../../WorkOrderArtifactsList";
 import { WorkOrderCheckComment } from "../../WorkOrderCheckComment";
+import { WorkOrderPullRequestsList } from "../../WorkOrderPullRequestsList";
 import { SPLIT_RUN_PANE_GRID_CLASSNAME, splitRunLinkedArtifacts } from "./splitRunPopupModel";
 import type { SplitRunSource } from "./splitRunSource";
 import { WorkOrderSplitRunDescription } from "./WorkOrderSplitRunDescription";
 import { WorkOrderSplitRunSource } from "./WorkOrderSplitRunSource";
 
 /**
- * Description tab: reading column on the left, Source and Artifacts on the
- * right.
+ * Description tab: reading column on the left, Source, Artifacts, and Pull
+ * requests on the right.
  */
 export function WorkOrderSplitRunOverview({
   description,
   artifacts,
   artifactsLoading = false,
+  pullRequests = [],
+  pullRequestsLoading = false,
+  pullRequestsError = null,
   checks,
   organizationId,
   factoryKey,
@@ -31,6 +35,9 @@ export function WorkOrderSplitRunOverview({
   description: string;
   artifacts: FactoriesWorkOrderArtifact[];
   artifactsLoading?: boolean;
+  pullRequests?: FactoriesFactoryPullRequest[];
+  pullRequestsLoading?: boolean;
+  pullRequestsError?: Error | null;
   checks: WorkOrderCheckPresentation[];
   organizationId?: string;
   factoryKey?: string;
@@ -85,6 +92,11 @@ export function WorkOrderSplitRunOverview({
             )}
           </section>
           <WorkOrderArtifactsList artifacts={splitRunLinkedArtifacts(artifacts, source)} isLoading={artifactsLoading} />
+          <WorkOrderPullRequestsList
+            pullRequests={pullRequests}
+            isLoading={pullRequestsLoading}
+            error={pullRequestsError}
+          />
         </div>
       </aside>
     </div>

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -1,4 +1,4 @@
-import { useWorkOrderArtifacts } from "@/hooks/useFactoryData";
+import { useFactoryPullRequests, useWorkOrderArtifacts } from "@/hooks/useFactoryData";
 import { useEffect, useMemo, useState } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -19,8 +19,10 @@ import {
 } from "./splitRunMocks";
 import {
   collectSplitRunArtifacts,
+  collectSplitRunPullRequests,
   defaultSplitRunPopupTab,
   resolveSplitRunPopupArtifacts,
+  resolveSplitRunPopupPullRequests,
   type SplitRunPopupTab,
   splitRunDescriptionMarkdown,
   splitRunLogTabDotClass,
@@ -209,11 +211,22 @@ export function WorkOrderSplitRunPopup({
   const footerActions = useSplitRunFooterActions(organizationId, factoryId, orderId);
   const mutations = footerMutationHandlers(canUpdate, footerActions, fixture);
   const fixtureArtifacts = collectSplitRunArtifacts(fixture);
+  const fixturePullRequests = collectSplitRunPullRequests(fixture);
   const useLiveArtifacts = hasLiveWorkOrder(organizationId, factoryId, orderId);
   const liveArtifactsQuery = useWorkOrderArtifacts(organizationId ?? "", factoryId ?? "", orderId ?? "");
+  const livePullRequestsQuery = useFactoryPullRequests(
+    organizationId ?? "",
+    factoryId ?? "",
+    orderId ? { workOrderIds: [orderId] } : undefined,
+  );
   const artifacts = resolveSplitRunPopupArtifacts({
     fixtureArtifacts,
     liveArtifacts: liveArtifactsQuery.data,
+    useLive: useLiveArtifacts,
+  });
+  const pullRequests = resolveSplitRunPopupPullRequests({
+    fixturePullRequests,
+    livePullRequests: livePullRequestsQuery.data,
     useLive: useLiveArtifacts,
   });
   const artifactDescription = splitRunDescriptionMarkdown(artifacts) || splitRunDescriptionMarkdown(fixtureArtifacts);
@@ -257,6 +270,9 @@ export function WorkOrderSplitRunPopup({
         edits={edits}
         artifacts={artifacts}
         artifactsLoading={useLiveArtifacts && liveArtifactsQuery.isLoading}
+        pullRequests={pullRequests}
+        pullRequestsLoading={useLiveArtifacts && livePullRequestsQuery.isLoading}
+        pullRequestsError={useLiveArtifacts ? (livePullRequestsQuery.error ?? null) : null}
         organizationId={organizationId}
         factoryId={factoryId}
         factoryKey={factoryKey}
@@ -325,6 +341,9 @@ function SplitRunPopupTabs({
   edits,
   artifacts,
   artifactsLoading,
+  pullRequests,
+  pullRequestsLoading,
+  pullRequestsError,
   organizationId,
   factoryId,
   factoryKey,
@@ -340,6 +359,9 @@ function SplitRunPopupTabs({
   edits: ReturnType<typeof useSplitRunWorkOrderEdits>;
   artifacts: ReturnType<typeof collectSplitRunArtifacts>;
   artifactsLoading: boolean;
+  pullRequests: ReturnType<typeof collectSplitRunPullRequests>;
+  pullRequestsLoading: boolean;
+  pullRequestsError: Error | null;
   organizationId?: string;
   factoryId?: string;
   factoryKey?: string;
@@ -389,6 +411,9 @@ function SplitRunPopupTabs({
           artifacts={artifacts}
           checks={fixture.checks}
           artifactsLoading={artifactsLoading}
+          pullRequests={pullRequests}
+          pullRequestsLoading={pullRequestsLoading}
+          pullRequestsError={pullRequestsError}
           organizationId={organizationId}
           factoryKey={factoryKey}
           orderNumber={orderNumber}

--- a/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
+++ b/web_src/src/pages/factories/pages/work-order-split-run/WorkOrderSplitRunPopup.tsx
@@ -1,4 +1,3 @@
-import { useFactoryPullRequests, useWorkOrderArtifacts } from "@/hooks/useFactoryData";
 import { useEffect, useMemo, useState } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -18,18 +17,13 @@ import {
   type SplitRunPhaseId,
 } from "./splitRunMocks";
 import {
-  collectSplitRunArtifacts,
-  collectSplitRunPullRequests,
   defaultSplitRunPopupTab,
-  resolveSplitRunPopupArtifacts,
-  resolveSplitRunPopupPullRequests,
   type SplitRunPopupTab,
-  splitRunDescriptionMarkdown,
   splitRunLogTabDotClass,
   splitRunPhaseAutomationHref,
   splitRunPhaseRunHref,
-  splitRunSourceDescription,
 } from "./splitRunPopupModel";
+import { useSplitRunPopupData } from "./useSplitRunPopupData";
 import { useSplitRunFooterActions, type SplitRunFooterActions } from "./useSplitRunFooterActions";
 import { useSplitRunWorkOrderEdits } from "./useSplitRunWorkOrderEdits";
 import { useSplitRunLiveCanvas } from "./useSplitRunLiveCanvas";
@@ -210,38 +204,14 @@ export function WorkOrderSplitRunPopup({
 }) {
   const footerActions = useSplitRunFooterActions(organizationId, factoryId, orderId);
   const mutations = footerMutationHandlers(canUpdate, footerActions, fixture);
-  const fixtureArtifacts = collectSplitRunArtifacts(fixture);
-  const fixturePullRequests = collectSplitRunPullRequests(fixture);
-  const useLiveArtifacts = hasLiveWorkOrder(organizationId, factoryId, orderId);
-  const liveArtifactsQuery = useWorkOrderArtifacts(organizationId ?? "", factoryId ?? "", orderId ?? "");
-  const livePullRequestsQuery = useFactoryPullRequests(
-    organizationId ?? "",
-    factoryId ?? "",
-    orderId ? { workOrderIds: [orderId] } : undefined,
-  );
-  const artifacts = resolveSplitRunPopupArtifacts({
-    fixtureArtifacts,
-    liveArtifacts: liveArtifactsQuery.data,
-    useLive: useLiveArtifacts,
-  });
-  const pullRequests = resolveSplitRunPopupPullRequests({
-    fixturePullRequests,
-    livePullRequests: livePullRequestsQuery.data,
-    useLive: useLiveArtifacts,
-  });
-  const artifactDescription = splitRunDescriptionMarkdown(artifacts) || splitRunDescriptionMarkdown(fixtureArtifacts);
-  const sourceDescription = splitRunSourceDescription({
-    workOrderDescription: fixture.descriptionText,
-    artifactDescription,
-    preferWorkOrder: useLiveArtifacts,
-  });
+  const popupData = useSplitRunPopupData({ organizationId, factoryId, orderId, fixture });
   const edits = useSplitRunWorkOrderEdits({
     organizationId,
     factoryId,
     orderId,
     canUpdate,
     title: fixture.title,
-    description: sourceDescription,
+    description: popupData.sourceDescription,
     owner: fixture.owner,
     assigneeIds: fixture.assigneeIds ?? [],
     footerKind: fixture.footer.kind,
@@ -268,11 +238,11 @@ export function WorkOrderSplitRunPopup({
       <SplitRunPopupTabs
         fixture={fixture}
         edits={edits}
-        artifacts={artifacts}
-        artifactsLoading={useLiveArtifacts && liveArtifactsQuery.isLoading}
-        pullRequests={pullRequests}
-        pullRequestsLoading={useLiveArtifacts && livePullRequestsQuery.isLoading}
-        pullRequestsError={useLiveArtifacts ? (livePullRequestsQuery.error ?? null) : null}
+        artifacts={popupData.artifacts}
+        artifactsLoading={popupData.artifactsLoading}
+        pullRequests={popupData.pullRequests}
+        pullRequestsLoading={popupData.pullRequestsLoading}
+        pullRequestsError={popupData.pullRequestsError}
         organizationId={organizationId}
         factoryId={factoryId}
         factoryKey={factoryKey}
@@ -332,10 +302,6 @@ function returnToBacklogAction(
   };
 }
 
-function hasLiveWorkOrder(organizationId?: string, factoryId?: string, orderId?: string) {
-  return Boolean(organizationId && factoryId && orderId);
-}
-
 function SplitRunPopupTabs({
   fixture,
   edits,
@@ -357,9 +323,9 @@ function SplitRunPopupTabs({
 }: {
   fixture: SplitRunFixture;
   edits: ReturnType<typeof useSplitRunWorkOrderEdits>;
-  artifacts: ReturnType<typeof collectSplitRunArtifacts>;
+  artifacts: ReturnType<typeof useSplitRunPopupData>["artifacts"];
   artifactsLoading: boolean;
-  pullRequests: ReturnType<typeof collectSplitRunPullRequests>;
+  pullRequests: ReturnType<typeof useSplitRunPopupData>["pullRequests"];
   pullRequestsLoading: boolean;
   pullRequestsError: Error | null;
   organizationId?: string;

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunPopupModel.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunPopupModel.spec.ts
@@ -186,7 +186,9 @@ describe("splitRunPopupModel", () => {
   });
 
   it("uses live pull requests for a real task and fixture pull requests in Storybook", () => {
-    const fixturePullRequests = collectSplitRunPullRequests(splitRunFixtureForWorkOrder(LINE_BOARD_DONE_RECEIPTS_ORDER));
+    const fixturePullRequests = collectSplitRunPullRequests(
+      splitRunFixtureForWorkOrder(LINE_BOARD_DONE_RECEIPTS_ORDER),
+    );
     const livePullRequests = [
       {
         id: "pr-live",

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunPopupModel.spec.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunPopupModel.spec.ts
@@ -14,8 +14,10 @@ import { LINE_BOARD_DONE_RECEIPTS_ORDER } from "../../__fixtures__/lineMetricsFa
 import { REVIEW_CANDIDATE_WORK_ORDERS } from "../onboarding/first-run/reviewCandidates";
 import {
   collectSplitRunArtifacts,
+  collectSplitRunPullRequests,
   defaultSplitRunPopupTab,
   resolveSplitRunPopupArtifacts,
+  resolveSplitRunPopupPullRequests,
   SPLIT_RUN_PANE_GRID_CLASSNAME,
   splitRunAutomationRunHref,
   splitRunDescriptionMarkdown,
@@ -168,6 +170,39 @@ describe("splitRunPopupModel", () => {
     expect(resolveSplitRunPopupArtifacts({ fixtureArtifacts, liveArtifacts, useLive: false })).toEqual(
       fixtureArtifacts,
     );
+  });
+
+  it("collects unique pull requests from fixture streams", () => {
+    const fixture = splitRunFixtureForWorkOrder(LINE_BOARD_DONE_RECEIPTS_ORDER);
+    const pullRequests = collectSplitRunPullRequests(fixture);
+
+    expect(pullRequests).toEqual([
+      expect.objectContaining({
+        number: "510",
+        url: "https://github.com/example/ledger/pull/510",
+        state: "STATE_OPEN",
+      }),
+    ]);
+  });
+
+  it("uses live pull requests for a real task and fixture pull requests in Storybook", () => {
+    const fixturePullRequests = collectSplitRunPullRequests(splitRunFixtureForWorkOrder(LINE_BOARD_DONE_RECEIPTS_ORDER));
+    const livePullRequests = [
+      {
+        id: "pr-live",
+        number: "99",
+        url: "https://github.com/example/ledger/pull/99",
+        state: "STATE_OPEN" as const,
+      },
+    ];
+
+    expect(resolveSplitRunPopupPullRequests({ fixturePullRequests, livePullRequests, useLive: true })).toEqual(
+      livePullRequests,
+    );
+    expect(resolveSplitRunPopupPullRequests({ fixturePullRequests, livePullRequests, useLive: false })).toEqual(
+      fixturePullRequests,
+    );
+    expect(collectSplitRunPullRequests(splitRunFixtureForWorkOrder(REVIEW_CANDIDATE_WORK_ORDERS[0]))).toEqual([]);
   });
 
   it("lists description artifacts oldest first", () => {

--- a/web_src/src/pages/factories/pages/work-order-split-run/splitRunPopupModel.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/splitRunPopupModel.ts
@@ -1,4 +1,4 @@
-import type { FactoriesWorkOrderArtifact } from "@/api-client";
+import type { FactoriesFactoryPullRequest, FactoriesWorkOrderArtifact } from "@/api-client";
 
 import { factoryAppConfigurePath, factoryAppSplitRunPath } from "../../lib/factoryPagePaths";
 import { extractArtifactMarkdownBody, toArtifactDataRecord } from "../../lib/workOrderArtifact";
@@ -114,6 +114,17 @@ export function resolveSplitRunPopupArtifacts(args: {
   return args.fixtureArtifacts;
 }
 
+export function resolveSplitRunPopupPullRequests(args: {
+  fixturePullRequests: FactoriesFactoryPullRequest[];
+  livePullRequests?: FactoriesFactoryPullRequest[];
+  useLive: boolean;
+}): FactoriesFactoryPullRequest[] {
+  if (args.useLive) {
+    return args.livePullRequests ?? [];
+  }
+  return args.fixturePullRequests;
+}
+
 export function collectSplitRunArtifacts(fixture: SplitRunFixture): FactoriesWorkOrderArtifact[] {
   const seen = new Set<string>();
   const artifacts: FactoriesWorkOrderArtifact[] = [];
@@ -128,6 +139,27 @@ export function collectSplitRunArtifacts(fixture: SplitRunFixture): FactoriesWor
     }
   }
   return artifacts;
+}
+
+/** Unique pull requests from every phase stream, first occurrence wins. */
+export function collectSplitRunPullRequests(fixture: SplitRunFixture): FactoriesFactoryPullRequest[] {
+  const seen = new Set<string>();
+  const pullRequests: FactoriesFactoryPullRequest[] = [];
+  for (const phase of fixture.phases) {
+    for (const line of phase.stream) {
+      const pullRequest = line.pullRequest;
+      if (!pullRequest) {
+        continue;
+      }
+      const key = pullRequest.id ?? pullRequest.url ?? String(pullRequest.number ?? "");
+      if (!key || seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      pullRequests.push(pullRequest);
+    }
+  }
+  return pullRequests;
 }
 
 export function splitRunDescriptionMarkdown(artifacts: FactoriesWorkOrderArtifact[]): string {

--- a/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunPopupData.ts
+++ b/web_src/src/pages/factories/pages/work-order-split-run/useSplitRunPopupData.ts
@@ -1,0 +1,59 @@
+import { useFactoryPullRequests, useWorkOrderArtifacts } from "@/hooks/useFactoryData";
+
+import {
+  collectSplitRunArtifacts,
+  collectSplitRunPullRequests,
+  resolveSplitRunPopupArtifacts,
+  resolveSplitRunPopupPullRequests,
+  splitRunDescriptionMarkdown,
+  splitRunSourceDescription,
+} from "./splitRunPopupModel";
+import type { SplitRunFixture } from "./splitRunMocks";
+
+function hasLiveWorkOrder(organizationId?: string, factoryId?: string, orderId?: string) {
+  return Boolean(organizationId && factoryId && orderId);
+}
+
+export function useSplitRunPopupData(args: {
+  organizationId?: string;
+  factoryId?: string;
+  orderId?: string;
+  fixture: SplitRunFixture;
+}) {
+  const { organizationId, factoryId, orderId, fixture } = args;
+  const fixtureArtifacts = collectSplitRunArtifacts(fixture);
+  const fixturePullRequests = collectSplitRunPullRequests(fixture);
+  const useLive = hasLiveWorkOrder(organizationId, factoryId, orderId);
+  const liveArtifactsQuery = useWorkOrderArtifacts(organizationId ?? "", factoryId ?? "", orderId ?? "");
+  const livePullRequestsQuery = useFactoryPullRequests(
+    organizationId ?? "",
+    factoryId ?? "",
+    orderId ? { workOrderIds: [orderId] } : undefined,
+  );
+  const artifacts = resolveSplitRunPopupArtifacts({
+    fixtureArtifacts,
+    liveArtifacts: liveArtifactsQuery.data,
+    useLive,
+  });
+  const pullRequests = resolveSplitRunPopupPullRequests({
+    fixturePullRequests,
+    livePullRequests: livePullRequestsQuery.data,
+    useLive,
+  });
+  const artifactDescription = splitRunDescriptionMarkdown(artifacts) || splitRunDescriptionMarkdown(fixtureArtifacts);
+  const sourceDescription = splitRunSourceDescription({
+    workOrderDescription: fixture.descriptionText,
+    artifactDescription,
+    preferWorkOrder: useLive,
+  });
+
+  return {
+    artifacts,
+    pullRequests,
+    sourceDescription,
+    useLive,
+    artifactsLoading: useLive && liveArtifactsQuery.isLoading,
+    pullRequestsLoading: useLive && livePullRequestsQuery.isLoading,
+    pullRequestsError: useLive ? (livePullRequestsQuery.error ?? null) : null,
+  };
+}


### PR DESCRIPTION
## Summary

The Description sidebar only listed files and branches, so open pull requests were easy to miss. This change lists factory pull requests under Artifacts, shows the PR title next to the number, and keeps the same section order on the classic detail sidebar.

## Test plan

- [x] Open a task with an attached PR and confirm Description shows Artifacts, then Pull requests with `#N` and title
- [x] Open a draft with no PR and confirm Pull requests shows "No pull requests yet."
- [x] Confirm Automations still shows the compact `#N` chip on Implement
- [x] Confirm a live task does not invent demo PR numbers when the API returns none

<img width="1788" height="1043" alt="2026-09-01_16-32-49" src="https://github.com/user-attachments/assets/cd71b254-6a49-406c-b577-c685ad0578e5" />


Made with [Cursor](https://cursor.com)
Closes #7065 