### PR TITLE
fix: Read implement branch from the clone directory

### DIFF
--- a/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
+++ b/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
@@ -150,22 +150,26 @@ spec:
               Write clearly, for humans, in ASD-STE100 / Simplified Technical English
           - name: Push output
             type: bash
+            workingDirectory: repo
             command: |-
+              set -euo pipefail
+
               # Emit branch name plus PR title/description for the next canvas nodes.
-              if [ -s /tmp/TITLE ] && [ -s /tmp/DESCRIPTION.md ]; then
-                echo "Title and description found. Using as output"
-                jq -n \
-                  --arg branch "$(git -C repo rev-parse --abbrev-ref HEAD)" \
-                  --rawfile title /tmp/TITLE \
-                  --rawfile description /tmp/DESCRIPTION.md \
-                  '{branch: $branch, title: ($title | @base64), description: ($description | @base64)}' \
-                  > "$SUPERPLANE_RESULT_FILE"
-              else
+              if [ ! -s /tmp/TITLE ] || [ ! -s /tmp/DESCRIPTION.md ]; then
                 jq -n '{error: "Missing title and/or description at /tmp/TITLE and /tmp/DESCRIPTION.md"}' \
                   > "$SUPERPLANE_RESULT_FILE"
                 echo "Missing title and/or description at /tmp/TITLE and /tmp/DESCRIPTION.md" >&2
                 exit 1
               fi
+
+              echo "Title and description found. Using as output"
+              BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+              jq -n \
+                --arg branch "$BRANCH" \
+                --rawfile title /tmp/TITLE \
+                --rawfile description /tmp/DESCRIPTION.md \
+                '{branch: $branch, title: ($title | @base64), description: ($description | @base64)}' \
+                > "$SUPERPLANE_RESULT_FILE"
       position:
         x: 1475
         'y': 312


### PR DESCRIPTION
## Summary

The Implement line failed after it pushed the branch. The Push output
step read the branch with `git -C repo`. Agent steps share one shell,
and the steps before Push output run in the clone. The step started in
the clone, so git looked for a nested `repo` directory and failed with
`fatal: cannot change to 'repo': No such file or directory`. The branch
value was empty, and the Add Branch Artifact node failed. No pull
request was created for the task.

The step now declares `workingDirectory: repo`. The runner resolves this
path from the task launch directory, so the step always starts in the
clone. The step no longer depends on the directory that the step before
it leaves behind.

The step also stops at the first error and puts the branch in a
variable. A git failure now fails this step, instead of an empty branch
that breaks a later node.

This change is in the factory template. Existing Implement apps keep the
old step until you reset the app to factory defaults, or you edit the
step.

## Test plan

- [ ] Run the step script in a clone: it writes `branch`, `title`, and
      `description` to the result file.
- [ ] Remove `/tmp/TITLE`: the step exits 1 and writes the error result.
- [ ] Create a factory line from the template, dispatch a task, and
      confirm that Add Branch Artifact receives the branch name and that
      Create Pull Request opens the pull request.


Made with [Cursor](https://cursor.com)