### PR TITLE
docs: emphasize cost tracking value of OpenAI Admin API key

### DIFF
--- a/docs/components/OpenAI.mdx
+++ b/docs/components/OpenAI.mdx
@@ -24,7 +24,7 @@ Create an [OpenAI API key](https://platform.openai.com/api-keys) and copy it.
 
 ## Admin API Key (optional)
 
-Only required for the **Get Usage Data** component.
+Track your organization's OpenAI spending and usage. Required for the **Get Usage Data** component.
 
 Create an [Admin API key](https://platform.openai.com/settings/organization/admin-keys) and copy it (starts with `sk-admin-`).
 

--- a/pkg/integrations/openai/openai.go
+++ b/pkg/integrations/openai/openai.go
@@ -53,7 +53,7 @@ func (o *OpenAI) Configuration() []configuration.Field {
 			Type:        configuration.FieldTypeString,
 			Required:    false,
 			Sensitive:   true,
-			Description: "Organization admin API key (sk-admin-...). Required for fetching usage data.",
+			Description: "Organization admin API key (sk-admin-...). Enables cost and usage tracking for your OpenAI organization.",
 		},
 		{
 			Name:        "baseURL",
@@ -87,7 +87,7 @@ Create an [OpenAI API key](https://platform.openai.com/api-keys) and copy it.
 
 ## Admin API Key (optional)
 
-Only required for the **Get Usage Data** component.
+Track your organization's OpenAI spending and usage. Required for the **Get Usage Data** component.
 
 Create an [Admin API key](https://platform.openai.com/settings/organization/admin-keys) and copy it (starts with ` + "`sk-admin-`" + `).
 


### PR DESCRIPTION
## What changed

Reworded the Admin API Key copy in the OpenAI integration to lead with the benefit instead of the mechanism. Applied in both the field description (`openai.go`) and the setup instructions, which are mirrored in `docs/components/OpenAI.mdx`.

## Why

As noted in #7038, "Only required for the Get Usage Data component" understates what the key gives you. The value — cost tracking — was already documented further down, but only after the reader had likely decided the field was optional and moved on. Leading with it makes the benefit visible at the point of decision.

## How

Copy only. No changes to validation, the `Required: false` flag, or any OpenAI API behavior. The "Get Usage Data" requirement is preserved, just moved to second position.

## Tests

- `go build ./...` and `go test ./...` from `pkg/integrations/openai`

Closes #7038