### PR TITLE
feat: Ship factory settings redesign

### DIFF
--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { useEffect } from "react";
 import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation, useParams } from "react-router";
 import { appPath, appSettingsPath } from "./lib/appPaths";
-import { FEATURE_FACTORIES, FEATURE_WORKSPACE_MODELS } from "./lib/experimentalFeatures";
+import { FEATURE_FACTORIES } from "./lib/experimentalFeatures";
 import { recordLastVisitedOrganization } from "./lib/lastVisitedOrganization";
 import { isReservedAppPathSegment } from "./lib/reservedAppPaths";
 import { useConsumeIntegrationSetupReturnOnArrival } from "./hooks/useConsumeIntegrationSetupReturnOnArrival";
@@ -18,7 +18,7 @@ import { AccountProvider } from "./contexts/AccountProvider";
 import { ThemeProvider } from "./contexts/ThemeProvider";
 import { useAccount } from "./contexts/useAccount";
 import { PermissionsProvider } from "./contexts/PermissionsProvider";
-import { RequireAnyPermission, RequirePermission } from "./components/PermissionGate";
+import { RequirePermission } from "./components/PermissionGate";
 import { Login } from "./pages/auth/Login";
 import OrganizationCreate from "./pages/auth/OrganizationCreate";
 import OrganizationSelect from "./pages/auth/OrganizationSelect";
@@ -34,16 +34,7 @@ import {
   FactoryAppSplitRunPage,
   FactoryHomeRedirect,
   FactoryLineEditPage,
-  FactorySettingsAutomationsPage,
-  FactorySettingsGeneralPage,
   FactorySettingsLayout,
-  FactorySettingsAccountNotificationsPage,
-  FactorySettingsAccountProfilePage,
-  FactorySettingsAccountSecurityPage,
-  FactorySettingsRepositoryPage,
-  FactorySettingsUsagePage,
-  FactorySettingsModelsPage,
-  OrganizationSettingsOverviewPage,
   LegacyWorkOrderDetailRedirect,
   LinesPage,
   MissionsPage,
@@ -59,27 +50,13 @@ import {
 import { createFactoryLinePath, editFactoryLinePath } from "./pages/factories/lib/factoryPagePaths";
 import {
   LegacyFactoryOrganizationSettingsRedirect,
-  LegacyFactorySettingsIndexRedirect,
-  LegacyFactorySettingsRedirect,
   LegacyOrganizationSettingsRedirect,
 } from "./pages/factories/pages/settings/FactorySettingsRedirects";
 import { HomePage } from "./pages/home";
 import { NewAppPage } from "./pages/home/NewAppPage";
 import { InstallPage } from "./pages/install";
 import { OrganizationSettings } from "./pages/organization/settings";
-import {
-  OrganizationIntegrationDetailsPage,
-  OrganizationIntegrationSetupPage,
-} from "./pages/factories/pages/organizationSettings/organizationSettingsRoutePages";
-import { OrganizationSettingsIntegrationsPage } from "./pages/factories/pages/organizationSettings/OrganizationSettingsIntegrationsPage";
-import { OrganizationSettingsWorkspaceUsagePage } from "./pages/factories/pages/organizationSettings/OrganizationSettingsWorkspaceUsagePage";
-import {
-  FactoryOrganizationApiKeyDetailPage,
-  FactoryOrganizationApiKeysPage,
-  FactoryOrganizationMembersPage,
-  FactoryOrganizationSecretDetailPage,
-  FactoryOrganizationSecretsPage,
-} from "./pages/factories/pages/settings/FactoryOrganizationSettingsPages";
+import { factorySettingsRedesignRoutes } from "./pages/factories/pages/settings/settings-redesign/settingsRedesignRoutes";
 import { AppDefaultTabGate } from "./pages/app/AppDefaultTabGate";
 import InviteLinkAccept from "./pages/auth/InviteLinkAccept";
 import AdminLayout from "./pages/admin/AdminLayout";
@@ -175,7 +152,7 @@ function organizationScopedRouteTree() {
           path=":factoryKey/settings"
           element={withAuthPermissionAndFactoriesFeature(FactorySettingsLayout, "factories", "read")}
         >
-          {factorySettingsSectionRoutes}
+          {factorySettingsRedesignRoutes}
         </Route>
         <Route
           path=":factoryKey/organization/*"
@@ -293,139 +270,6 @@ function FactoryLineEditPageGate() {
     </RequirePermission>
   );
 }
-
-const factorySettingsSectionRoutes = [
-  <Route key="factory-settings-index" index element={<LegacyFactorySettingsIndexRedirect />} />,
-  <Route
-    key="factory-settings-account-general"
-    path="account/general"
-    element={<Navigate to="../profile" replace />}
-  />,
-  <Route
-    key="factory-settings-account-profile"
-    path="account/profile"
-    element={<FactorySettingsAccountProfilePage />}
-  />,
-  <Route
-    key="factory-settings-account-security"
-    path="account/security"
-    element={<FactorySettingsAccountSecurityPage />}
-  />,
-  <Route
-    key="factory-settings-account-notifications"
-    path="account/notifications"
-    element={<FactorySettingsAccountNotificationsPage />}
-  />,
-  <Route key="factory-settings-workspace-general" path="workspace/general" element={<FactorySettingsGeneralPage />} />,
-  <Route
-    key="factory-settings-workspace-repository"
-    path="workspace/repository"
-    element={<FactorySettingsRepositoryPage />}
-  />,
-  <Route
-    key="factory-settings-workspace-automations"
-    path="workspace/automations"
-    element={<FactorySettingsAutomationsPage />}
-  />,
-  <Route
-    key="factory-settings-workspace-models"
-    path="workspace/models"
-    element={
-      <RequireExperimentalFeature featureId={FEATURE_WORKSPACE_MODELS}>
-        <FactorySettingsModelsPage />
-      </RequireExperimentalFeature>
-    }
-  />,
-  <Route key="factory-settings-workspace-spending" path="workspace/spending" element={<FactorySettingsUsagePage />} />,
-  <Route
-    key="factory-settings-organization-general"
-    path="organization/general"
-    element={<OrganizationSettingsOverviewPage />}
-  />,
-  <Route
-    key="factory-settings-organization-members"
-    path="organization/members"
-    element={
-      <RequirePermission resource="members" action="read">
-        <FactoryOrganizationMembersPage />
-      </RequirePermission>
-    }
-  />,
-  <Route
-    key="factory-settings-organization-integrations"
-    path="organization/integrations"
-    element={
-      <RequirePermission resource="integrations" action="read">
-        <OrganizationSettingsIntegrationsPage />
-      </RequirePermission>
-    }
-  />,
-  <Route
-    key="factory-settings-organization-integration-setup"
-    path="organization/integrations/:integrationName/setup"
-    element={
-      <RequireAnyPermission
-        checks={[
-          { resource: "integrations", action: "create" },
-          { resource: "integrations", action: "update" },
-        ]}
-      >
-        <OrganizationIntegrationSetupPage />
-      </RequireAnyPermission>
-    }
-  />,
-  <Route
-    key="factory-settings-organization-integration-detail"
-    path="organization/integrations/:integrationId"
-    element={<OrganizationIntegrationDetailsPage />}
-  />,
-  <Route
-    key="factory-settings-organization-api-keys"
-    path="organization/api-keys"
-    element={
-      <RequirePermission resource="api_keys" action="read">
-        <FactoryOrganizationApiKeysPage />
-      </RequirePermission>
-    }
-  />,
-  <Route
-    key="factory-settings-organization-api-key-detail"
-    path="organization/api-keys/:id"
-    element={
-      <RequirePermission resource="api_keys" action="read">
-        <FactoryOrganizationApiKeyDetailPage />
-      </RequirePermission>
-    }
-  />,
-  <Route
-    key="factory-settings-organization-secrets"
-    path="organization/secrets"
-    element={
-      <RequirePermission resource="secrets" action="read">
-        <FactoryOrganizationSecretsPage />
-      </RequirePermission>
-    }
-  />,
-  <Route
-    key="factory-settings-organization-secret-detail"
-    path="organization/secrets/:secretId"
-    element={
-      <RequirePermission resource="secrets" action="read">
-        <FactoryOrganizationSecretDetailPage />
-      </RequirePermission>
-    }
-  />,
-  <Route
-    key="factory-settings-organization-spending"
-    path="organization/spending"
-    element={
-      <RequirePermission resource="org" action="read">
-        <OrganizationSettingsWorkspaceUsagePage />
-      </RequirePermission>
-    }
-  />,
-  <Route key="factory-settings-legacy" path="*" element={<LegacyFactorySettingsRedirect />} />,
-];
 
 function LegacyAutomationsNewLineRedirect() {
   const { organizationId, factoryKey } = useParams<{ organizationId: string; factoryKey: string }>();

--- a/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
+++ b/web_src/src/pages/__fixtures__/OrgWorkspaceHarness.tsx
@@ -76,6 +76,8 @@ import { TooltipProvider } from "@/ui/tooltip";
 import { FactorySettingsAccountNotificationsPage } from "@/pages/factories/pages/settings/FactorySettingsAccountNotificationsPage";
 import { FactorySettingsAccountProfilePage } from "@/pages/factories/pages/settings/FactorySettingsAccountProfilePage";
 import { FactorySettingsAccountSecurityPage } from "@/pages/factories/pages/settings/FactorySettingsAccountSecurityPage";
+import { factorySettingsRedesignRoutes } from "@/pages/factories/pages/settings/settings-redesign/settingsRedesignRoutes";
+import { SettingsRedesignContext } from "@/pages/factories/pages/settings/settingsChromeContext";
 
 import { createOrgWorkspaceFixtureFetch } from "./createOrgWorkspaceFixtureFetch";
 
@@ -138,6 +140,8 @@ export interface OrgWorkspaceHarnessProps {
   orgIntegrations?: StorybookOrgIntegration[];
   /** Storybook-only: replace selected factory page elements (e.g. wiki wireframe). */
   pageOverrides?: OrgWorkspacePageOverrides;
+  /** Storybook-only: redesigned workspace and organization settings pages. */
+  settingsRedesign?: boolean;
 }
 
 interface FixtureFetchOptions {
@@ -371,13 +375,20 @@ const factorySettingsStorybookRoutes = [
   <Route key="factory-settings-legacy" path="*" element={<LegacyFactorySettingsRedirect />} />,
 ];
 
-function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePageOverrides }) {
+function OrgWorkspaceRoutes({
+  pageOverrides,
+  settingsRedesign = false,
+}: {
+  pageOverrides?: OrgWorkspacePageOverrides;
+  settingsRedesign?: boolean;
+}) {
   const WikiRoutePage = pageOverrides?.wiki ?? WikiPage;
   const OverviewRoutePage = pageOverrides?.overview ?? OverviewPage;
   const WorkOrdersRoutePage = pageOverrides?.workOrders ?? WorkOrdersPage;
   const VelocityRoutePage = pageOverrides?.velocity ?? VelocityPage;
   const OnboardingRoutePage = pageOverrides?.onboarding;
   const onboardingEnabled = Boolean(OnboardingRoutePage);
+  const settingsRoutes = settingsRedesign ? factorySettingsRedesignRoutes : factorySettingsStorybookRoutes;
 
   return (
     <Routes>
@@ -430,7 +441,7 @@ function OrgWorkspaceRoutes({ pageOverrides }: { pageOverrides?: OrgWorkspacePag
             </Route>
           </Route>
           <Route path=":factoryKey/settings" element={factoryRoute(<FactorySettingsLayout />)}>
-            {factorySettingsStorybookRoutes}
+            {settingsRoutes}
           </Route>
           <Route
             path=":factoryKey/organization/*"
@@ -464,6 +475,7 @@ export function OrgWorkspaceHarness({
   agentSuggestions,
   orgIntegrations,
   pageOverrides,
+  settingsRedesign = false,
 }: OrgWorkspaceHarnessProps) {
   const { orgId, canvasId } = resolveWorkspaceIds(homeFixture, appFixture, factoriesFixture);
   useOrgWorkspaceFixtureFetch({
@@ -496,9 +508,11 @@ export function OrgWorkspaceHarness({
         <TooltipProvider delayDuration={150}>
           <div className="h-dvh w-full overflow-auto">
             <MemoryRouter initialEntries={[initialPath]}>
-              <AccountProvider>
-                <OrgWorkspaceRoutes pageOverrides={pageOverrides} />
-              </AccountProvider>
+              <SettingsRedesignContext.Provider value={settingsRedesign}>
+                <AccountProvider>
+                  <OrgWorkspaceRoutes pageOverrides={pageOverrides} settingsRedesign={settingsRedesign} />
+                </AccountProvider>
+              </SettingsRedesignContext.Provider>
             </MemoryRouter>
           </div>
         </TooltipProvider>

--- a/web_src/src/pages/__fixtures__/createOrgWorkspaceFixtureFetch.ts
+++ b/web_src/src/pages/__fixtures__/createOrgWorkspaceFixtureFetch.ts
@@ -130,7 +130,7 @@ function resolveFactoryFixtures(
     factoriesFixture,
   );
   const factoryUsersResolved =
-    url.pathname === "/api/v1/users" && method === "GET" ? factoriesOrganizationUsersResponse() : null;
+    url.pathname === "/api/v1/users" && method === "GET" ? factoriesOrganizationUsersResponse(factoriesFixture) : null;
   return { factoryPagesResolved, factoryUsersResolved };
 }
 

--- a/web_src/src/pages/factories/__fixtures__/FactoriesHarness.tsx
+++ b/web_src/src/pages/factories/__fixtures__/FactoriesHarness.tsx
@@ -45,6 +45,11 @@ interface FactoriesHarnessProps {
   orgIntegrations?: StorybookOrgIntegration[];
   /** Extra organization experimental features to enable on top of the defaults (factories, managed agents). */
   experimentalFeatures?: string[];
+  /**
+   * Storybook default: redesigned workspace and organization settings.
+   * Specs that assert the live pages pass `false`.
+   */
+  settingsRedesign?: boolean;
 }
 
 function DefaultWikiWireframe() {
@@ -71,6 +76,7 @@ export function FactoriesHarness({
   openAgentSidebar = false,
   orgIntegrations,
   experimentalFeatures = [],
+  settingsRedesign = true,
 }: FactoriesHarnessProps) {
   const homeFixture: HomePageFixture = {
     ...defaultHomePageFixture,
@@ -97,6 +103,7 @@ export function FactoriesHarness({
       appFixture={appFixture}
       openAgentSidebar={openAgentSidebar}
       orgIntegrations={orgIntegrations}
+      settingsRedesign={settingsRedesign}
       pageOverrides={
         enableOnboarding
           ? {

--- a/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
+++ b/web_src/src/pages/factories/__fixtures__/factoryPageResponses.ts
@@ -21,15 +21,19 @@ import { DEFAULT_FACTORY_VELOCITY } from "./velocityReportFixtures";
 import {
   ACME_ONBOARDING_FACTORY_ID,
   ACME_ONBOARDING_LINE_ID,
+  ARNOLD_USER,
   GITHUB_ISSUES_INTAKE_APP_ID,
   EMPTY_FACTORY_ID,
   FACTORIES_ORGANIZATION_ID,
   LAST_WEEK,
+  ORGANIZATION_USERS,
+  OPERATOR_USER,
   PRIMARY_FACTORY_ID,
   REFUND_LINE_HOTFIX_ID,
   REFUND_LINE_PLAN_ID,
+  REVIEWER_USER,
+  STORYBOOK_ME_USER_ID,
   YESTERDAY,
-  type ORGANIZATION_USERS,
 } from "./factoryPageIds";
 import {
   APPROVAL_WORK_ORDER,
@@ -57,6 +61,35 @@ export function toStorybookOrganizationUser(user: (typeof ORGANIZATION_USERS)[nu
     spec: { displayName: user.name },
     ...(avatarUrl ? { status: { accountProviders: [{ avatarUrl }] } } : {}),
   };
+}
+
+const STORYBOOK_USER_ROLES: Record<string, { roleName: string; roleDisplayName: string }> = {
+  [STORYBOOK_ME_USER_ID]: { roleName: "org_owner", roleDisplayName: "Owner" },
+  [ARNOLD_USER.id]: { roleName: "org_admin", roleDisplayName: "Admin" },
+  [REVIEWER_USER.id]: { roleName: "org_admin", roleDisplayName: "Admin" },
+  [OPERATOR_USER.id]: { roleName: "org_member", roleDisplayName: "Member" },
+};
+
+export const STORYBOOK_ORGANIZATION_ROLES = [
+  { metadata: { name: "org_owner" }, spec: { displayName: "Owner" } },
+  { metadata: { name: "org_admin" }, spec: { displayName: "Admin" } },
+  { metadata: { name: "org_member" }, spec: { displayName: "Member" } },
+];
+
+export const DEFAULT_STORYBOOK_INVITE_LINK = { token: "storybook-token", enabled: true };
+
+export function defaultStorybookOrganizationUsers(): SuperplaneUsersUser[] {
+  return ORGANIZATION_USERS.map((user) => {
+    const base = toStorybookOrganizationUser(user);
+    const role = STORYBOOK_USER_ROLES[user.id] ?? { roleName: "org_member", roleDisplayName: "Member" };
+    return {
+      ...base,
+      status: {
+        ...base.status,
+        roles: [{ roleName: role.roleName, roleDisplayName: role.roleDisplayName }],
+      },
+    };
+  });
 }
 
 export const GITHUB_ISSUES_INTAKE_APP: FactoryApp = {
@@ -306,7 +339,62 @@ export interface FactoriesFixture {
   checksByOrderId?: Record<string, FactoriesWorkOrderCheck[]>;
   /** Storybook-only intake items for the Backlog create search. */
   intakeItemCatalog?: BacklogIntakeItemCatalog;
+  /** Organization API keys for factory settings. */
+  apiKeys?: StorybookApiKey[];
+  /** Organization secrets for factory settings. */
+  secrets?: StorybookSecret[];
+  /** Mutable Storybook organization members. */
+  organizationUsers?: SuperplaneUsersUser[];
+  inviteLink?: { token: string; enabled: boolean };
+  organizationName?: string;
+  organizationSlug?: string;
+  organizationDescription?: string;
 }
+
+export interface StorybookApiKey {
+  id: string;
+  name: string;
+  description: string;
+  canvasIds: string[];
+  createdByName: string;
+  hasToken: boolean;
+  expiresAt?: string;
+}
+
+export interface StorybookSecret {
+  metadata: { id: string; name: string };
+  spec: { local: { data: Record<string, string> } };
+}
+
+export const DEFAULT_STORYBOOK_SECRETS: StorybookSecret[] = [
+  {
+    metadata: { id: "secret-openai", name: "openai" },
+    spec: { local: { data: { API_KEY: "sk-storybook" } } },
+  },
+  {
+    metadata: { id: "secret-github", name: "github-app" },
+    spec: { local: { data: { APP_ID: "1", PRIVATE_KEY: "x" } } },
+  },
+];
+
+export const DEFAULT_STORYBOOK_API_KEYS: StorybookApiKey[] = [
+  {
+    id: "api-key-ci",
+    name: "CI pipeline",
+    description: "Creates work from CI.",
+    canvasIds: [],
+    createdByName: "Leonardo DiCaprio",
+    hasToken: true,
+  },
+  {
+    id: "api-key-cli",
+    name: "Local CLI",
+    description: "Personal CLI access.",
+    canvasIds: [],
+    createdByName: "Alex Smith",
+    hasToken: true,
+  },
+];
 
 export const defaultFactoriesFixture: FactoriesFixture = {
   organizationId: FACTORIES_ORGANIZATION_ID,
@@ -338,4 +426,9 @@ export const defaultFactoriesFixture: FactoriesFixture = {
     [PRIMARY_FACTORY_ID]: DEFAULT_FACTORY_VELOCITY,
   },
   organizationWorkspaceUsage: DEFAULT_FACTORY_USAGE,
+  apiKeys: DEFAULT_STORYBOOK_API_KEYS,
+  secrets: DEFAULT_STORYBOOK_SECRETS,
+  organizationName: "SuperPlane",
+  organizationSlug: "superplane",
+  organizationDescription: "AI-driven engineering automations.",
 };

--- a/web_src/src/pages/factories/__fixtures__/handlers.spec.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.spec.ts
@@ -81,8 +81,37 @@ describe("matchFactoryPageFixture", () => {
     const me = await fetchFactoryPageFixture("/api/v1/me");
     await expect(me.json()).resolves.toMatchObject({
       user: {
-        permissions: expect.arrayContaining([expect.objectContaining({ resource: "factories", action: "update" })]),
+        permissions: expect.arrayContaining([
+          expect.objectContaining({ resource: "factories", action: "update" }),
+          expect.objectContaining({ resource: "api_keys", action: "read" }),
+        ]),
       },
+    });
+  });
+
+  it("lists organization members with roles and an invite link", async () => {
+    const users = await fetchFactoryPageFixture("/api/v1/users");
+    const body = (await users.json()) as {
+      users: Array<{ spec?: { displayName?: string }; status?: { roles?: Array<{ roleName?: string }> } }>;
+    };
+    const owner = body.users.find((user) => user.spec?.displayName === "Leonardo DiCaprio");
+    expect(owner?.status?.roles?.[0]?.roleName).toBe("org_owner");
+
+    const roles = await fetchFactoryPageFixture("/api/v1/roles");
+    await expect(roles.json()).resolves.toMatchObject({
+      roles: expect.arrayContaining([expect.objectContaining({ metadata: { name: "org_admin" } })]),
+    });
+
+    const invite = await fetchFactoryPageFixture(`/api/v1/organizations/${FACTORIES_ORGANIZATION_ID}/invite-link`);
+    await expect(invite.json()).resolves.toMatchObject({
+      inviteLink: { token: "storybook-token", enabled: true },
+    });
+  });
+
+  it("lists mocked organization API keys", async () => {
+    const response = await fetchFactoryPageFixture("/api/v1/api-keys");
+    await expect(response.json()).resolves.toMatchObject({
+      apiKeys: [expect.objectContaining({ name: "CI pipeline" }), expect.objectContaining({ name: "Local CLI" })],
     });
   });
 

--- a/web_src/src/pages/factories/__fixtures__/handlers.ts
+++ b/web_src/src/pages/factories/__fixtures__/handlers.ts
@@ -2,13 +2,19 @@ import { EMPTY_USAGE_REPORT } from "./usageReportFixtures";
 import { EMPTY_FACTORY_VELOCITY } from "./velocityReportFixtures";
 import { factoryIntakeRoutes } from "./factoryIntakeHandlers";
 import {
+  DEFAULT_STORYBOOK_API_KEYS,
+  DEFAULT_STORYBOOK_INVITE_LINK,
+  DEFAULT_STORYBOOK_SECRETS,
+  STORYBOOK_ORGANIZATION_ROLES,
   defaultFactoriesFixture,
+  defaultStorybookOrganizationUsers,
   ORGANIZATION_USERS,
   STORYBOOK_ME_USER_EMAIL,
   STORYBOOK_ME_USER_ID,
   STORYBOOK_ME_USER_NAME,
-  toStorybookOrganizationUser,
   type FactoriesFixture,
+  type StorybookApiKey,
+  type StorybookSecret,
 } from "./factoryPageResponses";
 import {
   DEFAULT_ARTIFACTS_BY_ORDER_ID,
@@ -669,9 +675,147 @@ function billingPortalSessionRoute(): FactoriesRoute {
   };
 }
 
-const STORYBOOK_ME_MEMBER_PERMISSIONS = ["members"].flatMap((resource) =>
+const STORYBOOK_ME_EXTRA_PERMISSIONS = ["members", "api_keys"].flatMap((resource) =>
   ["read", "create", "update", "delete"].map((action) => ({ resource, action })),
 );
+
+function ensureApiKeys(fixture: FactoriesFixture): StorybookApiKey[] {
+  if (!fixture.apiKeys) {
+    fixture.apiKeys = structuredClone(DEFAULT_STORYBOOK_API_KEYS);
+  }
+  return fixture.apiKeys;
+}
+
+function organizationIdentity(fixture: FactoriesFixture) {
+  return {
+    id: fixture.organizationId,
+    name: fixture.organizationName ?? "SuperPlane",
+    slug: fixture.organizationSlug ?? "superplane",
+    description: fixture.organizationDescription ?? "",
+  };
+}
+
+function organizationRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/organizations/([^/]+)"),
+    resolve: (_match, method, body) => {
+      if (method !== "PUT" && method !== "PATCH") {
+        return null;
+      }
+      const request = (body ?? {}) as {
+        organization?: { metadata?: { name?: string; slug?: string; description?: string } };
+      };
+      const metadata = request.organization?.metadata ?? {};
+      if (metadata.name !== undefined) fixture.organizationName = metadata.name;
+      if (metadata.slug !== undefined) fixture.organizationSlug = metadata.slug;
+      if (metadata.description !== undefined) fixture.organizationDescription = metadata.description;
+      const identity = organizationIdentity(fixture);
+      return {
+        json: {
+          organization: {
+            metadata: identity,
+            spec: { enabledExperimentalFeatures: ["factories", "claude_managed_agents"] },
+            status: {},
+          },
+        },
+      };
+    },
+  };
+}
+
+function ensureSecrets(fixture: FactoriesFixture): StorybookSecret[] {
+  if (!fixture.secrets) {
+    fixture.secrets = structuredClone(DEFAULT_STORYBOOK_SECRETS);
+  }
+  return fixture.secrets;
+}
+
+function secretsCollectionRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/secrets"),
+    resolve: (_match, method, body) => {
+      const secrets = ensureSecrets(fixture);
+      if (method === "POST") {
+        const request = (body ?? {}) as { name?: string; secret?: { metadata?: { name?: string } } };
+        const name = request.secret?.metadata?.name?.trim() || request.name?.trim() || "untitled";
+        const created: StorybookSecret = {
+          metadata: { id: `secret-${secrets.length + 1}`, name },
+          spec: { local: { data: {} } },
+        };
+        secrets.push(created);
+        return { json: { secret: created } };
+      }
+      return { json: { secrets } };
+    },
+  };
+}
+
+function apiKeysCollectionRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/api-keys"),
+    resolve: (_match, method, body) => {
+      const apiKeys = ensureApiKeys(fixture);
+      if (method === "POST") {
+        const request = (body ?? {}) as {
+          name?: string;
+          description?: string;
+          expiresAt?: string;
+          canvasIds?: string[];
+        };
+        const created: StorybookApiKey = {
+          id: `api-key-${apiKeys.length + 1}`,
+          name: request.name?.trim() || "Untitled",
+          description: request.description?.trim() || "",
+          canvasIds: request.canvasIds ?? [],
+          createdByName: STORYBOOK_ME_USER_NAME,
+          hasToken: true,
+          expiresAt: request.expiresAt,
+        };
+        apiKeys.push(created);
+        return { json: { apiKey: created, token: "sp_live_storybook_new" } };
+      }
+      return { json: { apiKeys } };
+    },
+  };
+}
+
+function apiKeyRegenerateRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/api-keys/([^/]+)/regenerate"),
+    resolve: (match, method) => {
+      const apiKeys = ensureApiKeys(fixture);
+      const key = apiKeys.find((item) => item.id === match[1]);
+      if (!key || method !== "POST") {
+        return { json: {} };
+      }
+      return { json: { apiKey: key, token: "sp_live_storybook_regenerated" } };
+    },
+  };
+}
+
+function apiKeyDetailRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/api-keys/([^/]+)"),
+    resolve: (match, method, body) => {
+      const apiKeys = ensureApiKeys(fixture);
+      const id = match[1];
+      const index = apiKeys.findIndex((key) => key.id === id);
+      if (index < 0) {
+        return { json: {} };
+      }
+      if (method === "DELETE") {
+        apiKeys.splice(index, 1);
+        return { json: {} };
+      }
+      if (method === "PUT" || method === "PATCH") {
+        const request = (body ?? {}) as Partial<StorybookApiKey>;
+        apiKeys[index] = { ...apiKeys[index], ...request, id };
+        return { json: { apiKey: apiKeys[index] } };
+      }
+      return { json: { apiKey: apiKeys[index] } };
+    },
+  };
+}
 
 /** Serves `/api/v1/me` so factory stories resolve `useMe` without the Home harness. */
 function meRoute(organizationId: string): FactoriesRoute {
@@ -686,7 +830,7 @@ function meRoute(organizationId: string): FactoriesRoute {
             id: STORYBOOK_ME_USER_ID,
             name: STORYBOOK_ME_USER_NAME,
             email: STORYBOOK_ME_USER_EMAIL,
-            permissions: [...user.permissions, ...STORYBOOK_ME_MEMBER_PERMISSIONS],
+            permissions: [...user.permissions, ...STORYBOOK_ME_EXTRA_PERMISSIONS],
           },
         },
       };
@@ -715,6 +859,17 @@ function buildRoutes(fixture: FactoriesFixture): FactoriesRoute[] {
     factoriesCollectionRoute(fixture),
     meRoute(fixture.organizationId),
     notificationSettingsRoute(fixture),
+    organizationUsersRoute(fixture),
+    organizationRolesRoute(fixture),
+    organizationAssignRoleRoute(fixture),
+    organizationInviteLinkResetRoute(fixture),
+    organizationInviteLinkRoute(fixture),
+    organizationRemoveUserRoute(fixture),
+    organizationRoute(fixture),
+    secretsCollectionRoute(fixture),
+    apiKeysCollectionRoute(fixture),
+    apiKeyRegenerateRoute(fixture),
+    apiKeyDetailRoute(fixture),
     ...factoryDetailRoutes(fixture),
     factoryOnboardingRoute(fixture),
     factoryRepositoryRoute(fixture),
@@ -749,11 +904,101 @@ export function matchFactoryPageFixture(
   return null;
 }
 
+function ensureOrganizationUsers(fixture: FactoriesFixture) {
+  if (!fixture.organizationUsers) {
+    fixture.organizationUsers = defaultStorybookOrganizationUsers();
+  }
+  return fixture.organizationUsers;
+}
+
+function ensureInviteLink(fixture: FactoriesFixture) {
+  if (!fixture.inviteLink) {
+    fixture.inviteLink = { ...DEFAULT_STORYBOOK_INVITE_LINK };
+  }
+  return fixture.inviteLink;
+}
+
+function organizationUsersRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/users"),
+    resolve: (_match, method) => (method === "GET" ? factoriesOrganizationUsersResponse(fixture) : null),
+  };
+}
+
+function organizationRolesRoute(_fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/roles"),
+    resolve: (_match, method) => (method === "GET" ? { json: { roles: STORYBOOK_ORGANIZATION_ROLES } } : null),
+  };
+}
+
+function organizationAssignRoleRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/roles/([^/]+)/users"),
+    resolve: (match, method, body) => {
+      if (method !== "POST") return null;
+      const roleName = match[1];
+      const role = STORYBOOK_ORGANIZATION_ROLES.find((item) => item.metadata.name === roleName);
+      const userId = typeof body?.userId === "string" ? body.userId : "";
+      const users = ensureOrganizationUsers(fixture);
+      const user = users.find((item) => item.metadata?.id === userId);
+      if (user && role) {
+        user.status = {
+          ...user.status,
+          roles: [{ roleName: role.metadata.name, roleDisplayName: role.spec.displayName }],
+        };
+      }
+      return { json: {} };
+    },
+  };
+}
+
+function organizationInviteLinkRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/organizations/([^/]+)/invite-link"),
+    resolve: (_match, method, body) => {
+      const inviteLink = ensureInviteLink(fixture);
+      if (method === "PATCH") {
+        inviteLink.enabled = Boolean(body?.enabled);
+      }
+      if (method === "GET" || method === "PATCH") {
+        return { json: { inviteLink } };
+      }
+      return null;
+    },
+  };
+}
+
+function organizationInviteLinkResetRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/organizations/([^/]+)/invite-link/reset"),
+    resolve: (_match, method) => {
+      if (method !== "POST") return null;
+      const inviteLink = ensureInviteLink(fixture);
+      inviteLink.token = `storybook-token-${Date.now()}`;
+      inviteLink.enabled = true;
+      return { json: { inviteLink } };
+    },
+  };
+}
+
+function organizationRemoveUserRoute(fixture: FactoriesFixture): FactoriesRoute {
+  return {
+    pattern: re("/api/v1/organizations/([^/]+)/users/([^/]+)"),
+    resolve: (match, method) => {
+      if (method !== "DELETE") return null;
+      const users = ensureOrganizationUsers(fixture);
+      fixture.organizationUsers = users.filter((user) => user.metadata?.id !== match[2]);
+      return { json: {} };
+    },
+  };
+}
+
 /** Response body for `GET /api/v1/users` (`useOrganizationUsers`). */
-export function factoriesOrganizationUsersResponse(): FixtureResult {
+export function factoriesOrganizationUsersResponse(fixture: FactoriesFixture = defaultFactoriesFixture): FixtureResult {
   return {
     json: {
-      users: ORGANIZATION_USERS.map(toStorybookOrganizationUser),
+      users: ensureOrganizationUsers(fixture),
     },
   };
 }

--- a/web_src/src/pages/factories/pages/onboarding/onboardingSteps.tsx
+++ b/web_src/src/pages/factories/pages/onboarding/onboardingSteps.tsx
@@ -153,6 +153,8 @@ export function RepositoryPicker({
   onSelect,
   title,
   description,
+  searchClassName,
+  itemClassName,
 }: {
   host: VcsHostId;
   repos: string[];
@@ -161,6 +163,8 @@ export function RepositoryPicker({
   /** Only for pickers that need their own heading, such as the backlog picker. */
   title?: string;
   description?: string;
+  searchClassName?: string;
+  itemClassName?: string;
 }) {
   const [query, setQuery] = useState("");
 
@@ -184,7 +188,7 @@ export function RepositoryPicker({
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Search repositories"
-          className="h-9 pl-9"
+          className={cn("h-9 pl-9", searchClassName)}
           aria-label="Search repositories"
         />
       </div>
@@ -209,6 +213,7 @@ export function RepositoryPicker({
                     className={cn(
                       "flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors",
                       selected ? "bg-accent/50" : "hover:bg-accent/30",
+                      itemClassName,
                     )}
                   >
                     <IntegrationChoiceIcon name={host} />

--- a/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettings.stories.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettings.stories.tsx
@@ -5,6 +5,7 @@ import { defaultFactoriesFixture, PRIMARY_FACTORY_KEY } from "../../__fixtures__
 import { EMPTY_USAGE_REPORT } from "../../__fixtures__/usageReportFixtures";
 import { FactorySettingsLayout } from "../settings/FactorySettingsLayout";
 
+/** Redesigned organization settings. Same chrome as workspace settings. */
 const meta = {
   title: "Factories/Pages/Settings/Organization",
   component: FactorySettingsLayout,

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsAutomationsPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsAutomationsPage.spec.tsx
@@ -23,7 +23,7 @@ describe("FactorySettingsAutomationsPage", () => {
       "aria-current",
       "page",
     );
-    expect(await screen.findByTestId("automations-list-page", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(await screen.findByTestId("settings-redesign-automations", {}, { timeout: 8000 })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
   }, 10000);
 });

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
@@ -1,10 +1,12 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
 import { useFactories, useFactory } from "@/hooks/useFactoryData";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { FEATURE_WORKSPACE_MODELS } from "@/lib/experimentalFeatures";
 import { cn } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Navigate, NavLink, Outlet, useLocation, useParams } from "react-router";
 import {
   factoryRouteNeedsCanonicalRedirect,
@@ -105,12 +107,14 @@ function FactorySettingsLayoutContent({
 }) {
   useFactoriesThemeClass();
   const settingsNavGroups = useFactorySettingsNavGroups();
+  const [navQuery, setNavQuery] = useState("");
   const { data: factory, isLoading, error } = useFactory(organizationId, factoryId);
   const { has: hasExperimentalFeature } = useExperimentalFeature(organizationId);
   const navGroups = visibleFactorySettingsNavGroups(
     settingsNavGroups,
     hasExperimentalFeature(FEATURE_WORKSPACE_MODELS),
   );
+  const filteredNavGroups = filterSettingsNavGroups(navGroups, navQuery);
 
   // See the matching comment in `FactoriesLayout`: once `factory` has loaded
   // the `<Outlet/>` below mounts a leaf settings page that owns the full
@@ -162,8 +166,21 @@ function FactorySettingsLayoutContent({
                   Back to workspace
                 </NavLink>
               </div>
+              <div className="px-3 pt-3">
+                <Label className="sr-only" htmlFor="factory-settings-find">
+                  Find settings
+                </Label>
+                <Input
+                  id="factory-settings-find"
+                  data-testid="factory-settings-find"
+                  value={navQuery}
+                  onChange={(event) => setNavQuery(event.target.value)}
+                  placeholder="Find settings"
+                  className="h-8"
+                />
+              </div>
               <nav className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-2 py-4">
-                {navGroups.map((group) => (
+                {filteredNavGroups.map((group) => (
                   <SettingsNavGroup
                     key={group.id}
                     organizationId={organizationId}
@@ -186,6 +203,22 @@ function FactorySettingsLayoutContent({
       </OrganizationSettingsPathsProvider>
     </FactorySettingsLayoutContext.Provider>
   );
+}
+
+function filterSettingsNavGroups(groups: FactorySettingsNavGroup[], query: string): FactorySettingsNavGroup[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return groups;
+  }
+
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter(
+        (item) => item.label.toLowerCase().includes(normalized) || group.label.toLowerCase().includes(normalized),
+      ),
+    }))
+    .filter((group) => group.items.length > 0);
 }
 
 function SettingsNavGroup({

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsUsagePage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsUsagePage.tsx
@@ -81,7 +81,7 @@ function FactorySettingsUsageBody({
   );
 }
 
-function HostedSpendLimitCard() {
+export function HostedSpendLimitCard() {
   const { organizationId, factoryId, factory } = useFactorySettingsLayout();
   const { data } = useFactoryUsage(organizationId, factoryId);
   const { canAct } = usePermissions();

--- a/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
+++ b/web_src/src/pages/factories/pages/settings/Settings.stories.tsx
@@ -15,7 +15,7 @@ import {
   factoriesFixtureWithSetupAnswers,
 } from "../../__fixtures__/setupStoryFixtures";
 
-/** Factory settings with Account, Workspace, and Organization navigation. */
+/** Redesigned factory settings. Find settings. One identity form per General page. */
 const meta = {
   title: "Factories/Pages/Settings",
   component: FactorySettingsLayout,
@@ -44,7 +44,7 @@ export const Automations: Story = {
   ),
 };
 
-/** Storybook Account settings use the Profile redesign. Live app stays on General. */
+/** Account settings use the live Profile redesign inside the new settings chrome. */
 export const AccountGeneral: Story = {
   render: () => (
     <FactoriesHarness
@@ -106,6 +106,16 @@ export const Models: Story = {
       pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/models`}
       factoriesFixture={defaultFactoriesFixture}
       experimentalFeatures={[FEATURE_WORKSPACE_MODELS]}
+    />
+  ),
+};
+
+export const ApiKeys: Story = {
+  name: "API keys",
+  render: () => (
+    <FactoriesHarness
+      pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/api-keys`}
+      factoriesFixture={defaultFactoriesFixture}
     />
   ),
 };

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesign.spec.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesign.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -151,5 +151,86 @@ describe("Settings redesign chrome", () => {
     await user.click(screen.getByRole("option", { name: "Member" }));
     expect(roleSelect).toHaveTextContent("Member");
     expect(screen.getByTestId(`settings-redesign-member-role-${STORYBOOK_ME_USER_ID}`)).toBeDisabled();
+  }, 10000);
+
+  it("shows the one-time API key token after create", async () => {
+    const user = userEvent.setup();
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/api-keys`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    await user.click(await screen.findByTestId("api-key-create-btn", {}, { timeout: 8000 }));
+    await user.type(screen.getByLabelText("Name"), "Deploy key");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    expect(await screen.findByTestId("api-key-token-display")).toHaveValue("sp_live_storybook_new");
+  }, 10000);
+
+  it("resets the organization invite link", async () => {
+    const user = userEvent.setup();
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/members`}
+        factoriesFixture={{
+          ...defaultFactoriesFixture,
+          inviteLink: { token: "storybook-token-reset", enabled: true },
+        }}
+      />,
+    );
+
+    const section = await screen.findByTestId("settings-redesign-invite-link", {}, { timeout: 8000 });
+    const input = await within(section).findByRole("textbox");
+    const before = (input as HTMLInputElement).value;
+    await user.click(within(section).getByTestId("settings-redesign-invite-reset"));
+    await waitFor(() => {
+      expect((within(section).getByRole("textbox") as HTMLInputElement).value).not.toBe(before);
+    });
+  }, 10000);
+
+  it("shows the hosted spend limit on workspace spending", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/spending`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    expect(await screen.findByLabelText("No limit", {}, { timeout: 8000 })).toBeInTheDocument();
+  }, 10000);
+
+  it("blocks remove when the last owner also has another role", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/members`}
+        factoriesFixture={{
+          ...defaultFactoriesFixture,
+          organizationUsers: [
+            {
+              metadata: { id: "only-owner", email: "owner@example.com" },
+              spec: { displayName: "Only Owner" },
+              status: {
+                roles: [
+                  { roleName: "org_admin", roleDisplayName: "Admin" },
+                  { roleName: "org_owner", roleDisplayName: "Owner" },
+                ],
+              },
+            },
+            {
+              metadata: { id: STORYBOOK_ME_USER_ID, email: "me@example.com" },
+              spec: { displayName: "Me" },
+              status: { roles: [{ roleName: "org_member", roleDisplayName: "Member" }] },
+            },
+          ],
+        }}
+      />,
+    );
+
+    const role = await screen.findByTestId("settings-redesign-member-role-only-owner", {}, { timeout: 8000 });
+    expect(role).toHaveTextContent("Owner");
+    const ownerRow = role.closest("li");
+    expect(ownerRow).not.toBeNull();
+    expect(within(ownerRow as HTMLElement).getByRole("button", { name: "Remove" })).toBeDisabled();
   }, 10000);
 });

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesign.spec.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesign.spec.tsx
@@ -1,0 +1,155 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { client } from "@/api-client/client.gen";
+import { FactoriesHarness } from "../../../__fixtures__/FactoriesHarness";
+import {
+  defaultFactoriesFixture,
+  PRIMARY_FACTORY_KEY,
+  REVIEWER_USER,
+  STORYBOOK_ME_USER_ID,
+} from "../../../__fixtures__/factoryPageResponses";
+import {
+  CONNECTED_SETUP_INTEGRATIONS,
+  SETUP_ANSWERS,
+  factoriesFixtureWithSetupAnswers,
+} from "../../../__fixtures__/setupStoryFixtures";
+
+describe("Settings redesign chrome", () => {
+  beforeAll(() => {
+    client.setConfig({ baseUrl: "http://localhost" });
+    Element.prototype.scrollIntoView ??= vi.fn();
+    Element.prototype.hasPointerCapture ??= () => false;
+    Element.prototype.setPointerCapture ??= () => undefined;
+    Element.prototype.releasePointerCapture ??= () => undefined;
+  });
+
+  it("finds settings without sidebar captions", async () => {
+    const user = userEvent.setup();
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/general`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    const sidebar = await screen.findByTestId("factory-settings-sidebar", {}, { timeout: 8000 });
+    expect(within(sidebar).getByTestId("factory-settings-find")).toBeInTheDocument();
+    expect(within(sidebar).getByTestId("factory-settings-workspace-nav")).toHaveTextContent("Workspace");
+    expect(within(sidebar).getByTestId("factory-settings-workspace-nav")).not.toHaveTextContent("Semaphore");
+
+    await user.type(within(sidebar).getByTestId("factory-settings-find"), "spend");
+    expect(within(sidebar).getByTestId("factory-settings-nav-workspace-spending")).toBeInTheDocument();
+    expect(within(sidebar).queryByTestId("factory-settings-nav-workspace-general")).not.toBeInTheDocument();
+  }, 10000);
+
+  it("shows a workspace identity hero and URL key", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/general`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    expect(await screen.findByTestId("settings-redesign-identity-hero", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(screen.getByTestId("factory-settings-key")).toHaveValue("RF");
+    expect(screen.getByText("/superplane/workspaces/")).toBeInTheDocument();
+  }, 10000);
+
+  it("lets you edit the organization name and lists workspaces", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/general`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    const name = await screen.findByTestId("organization-settings-overview-name", {}, { timeout: 8000 });
+    expect(name).toHaveValue("SuperPlane");
+    expect(screen.getByTestId("settings-redesign-org-workspaces")).toHaveTextContent("Semaphore");
+    expect(screen.getByTestId("settings-redesign-org-danger")).toBeInTheDocument();
+    expect(screen.queryByTestId("settings-redesign-org-delete-confirm")).not.toBeInTheDocument();
+  }, 10000);
+
+  it("asks you to type the organization name in a delete dialog", async () => {
+    const user = userEvent.setup();
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/general`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    await user.click(await screen.findByTestId("settings-redesign-org-delete", {}, { timeout: 8000 }));
+    expect(screen.getByText("Type SuperPlane to confirm")).toBeInTheDocument();
+    const confirm = screen.getByTestId("settings-redesign-org-delete-confirm");
+    const submit = screen.getByTestId("settings-redesign-org-delete-submit");
+    expect(submit).toBeDisabled();
+    await user.type(confirm, "SuperPlane");
+    expect(submit).toBeEnabled();
+  }, 10000);
+
+  it("keeps the workspace identity form without proposed actions", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/general`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    expect(await screen.findByTestId("factory-settings-general-form", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(screen.getByTestId("settings-redesign-identity-hero")).toBeInTheDocument();
+    expect(screen.getByTestId("factory-settings-danger-zone")).toBeInTheDocument();
+    expect(screen.queryByTestId("settings-proposed")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("settings-redesign-archive")).not.toBeInTheDocument();
+  }, 10000);
+
+  it("lists mocked repositories", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/repository`}
+        factoriesFixture={factoriesFixtureWithSetupAnswers(SETUP_ANSWERS.agent)}
+        orgIntegrations={CONNECTED_SETUP_INTEGRATIONS}
+      />,
+    );
+
+    const settings = await screen.findByTestId("factory-settings-repository", {}, { timeout: 8000 });
+    expect(await within(settings).findByRole("option", { name: /acme\/api/ }, { timeout: 8000 })).toBeInTheDocument();
+    expect(within(settings).getByRole("option", { name: /acme\/web/ })).toBeInTheDocument();
+    expect(within(settings).queryByText("Connect GitHub during workspace setup")).not.toBeInTheDocument();
+  }, 10000);
+
+  it("shows organization API keys from factory settings", async () => {
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/api-keys`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    expect(await screen.findByText("CI pipeline", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(screen.getByText("Local CLI")).toBeInTheDocument();
+  }, 10000);
+
+  it("changes a member role", async () => {
+    const user = userEvent.setup();
+    render(
+      <FactoriesHarness
+        pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/organization/members`}
+        factoriesFixture={defaultFactoriesFixture}
+      />,
+    );
+
+    const roleSelect = await screen.findByTestId(
+      `settings-redesign-member-role-${REVIEWER_USER.id}`,
+      {},
+      { timeout: 8000 },
+    );
+    expect(roleSelect).toHaveTextContent("Admin");
+    await user.click(roleSelect);
+    await user.click(screen.getByRole("option", { name: "Member" }));
+    expect(roleSelect).toHaveTextContent("Member");
+    expect(screen.getByTestId(`settings-redesign-member-role-${STORYBOOK_ME_USER_ID}`)).toBeDisabled();
+  }, 10000);
+});

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignApiKeysPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignApiKeysPage.tsx
@@ -11,6 +11,7 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { getApiErrorMessage } from "@/lib/errors";
 import { useOrganizationSettingsPaths } from "@/lib/organizationSettingsPaths";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { CopyButton } from "@/ui/CopyButton";
 import { KeyRound, Plus } from "lucide-react";
 
 import { FactorySettingsPageFrame } from "../FactorySettingsCard";
@@ -28,21 +29,23 @@ export function SettingsRedesignApiKeysPage() {
   const canDelete = canAct("api_keys", "delete");
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
+  const [createdToken, setCreatedToken] = useState("");
 
   usePageTitle(["API keys"]);
 
   const handleCreate = async () => {
     if (!canCreate || !newName.trim()) return;
     try {
-      await createMutation.mutateAsync({
+      const result = await createMutation.mutateAsync({
         name: newName.trim(),
         description: "",
         role: "org_viewer",
         canvasIds: [],
       });
-      showSuccessToast("API key created.");
       setCreateOpen(false);
       setNewName("");
+      setCreatedToken(result.data?.token ?? "");
+      showSuccessToast("API key created.");
     } catch (error) {
       showErrorToast(getApiErrorMessage(error, "Failed to create API key"));
     }
@@ -83,6 +86,7 @@ export function SettingsRedesignApiKeysPage() {
         </PermissionTooltip>
       }
     >
+      {createdToken ? <ApiKeyCreatedToken token={createdToken} onDone={() => setCreatedToken("")} /> : null}
       {createOpen ? (
         <ApiKeyCreateForm
           name={newName}
@@ -102,6 +106,28 @@ export function SettingsRedesignApiKeysPage() {
         onDelete={handleDelete}
       />
     </FactorySettingsPageFrame>
+  );
+}
+
+function ApiKeyCreatedToken({ token, onDone }: { token: string; onDone: () => void }) {
+  return (
+    <div className="space-y-3 rounded-lg border border-border p-4" data-testid="settings-redesign-api-key-token">
+      <p className="text-[13px] text-foreground">Copy this token now. You cannot see it again.</p>
+      <div className="flex flex-wrap items-center gap-2">
+        <Input readOnly value={token} className="min-w-0 flex-1 font-mono" data-testid="api-key-token-display" />
+        <CopyButton
+          variant="button"
+          text={token}
+          data-testid="api-key-token-copy"
+          onCopyError={() => showErrorToast("Failed to copy token")}
+        >
+          Copy
+        </CopyButton>
+        <Button type="button" size="sm" onClick={onDone} data-testid="api-key-token-done">
+          Done
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignApiKeysPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignApiKeysPage.tsx
@@ -113,7 +113,7 @@ function ApiKeyCreatedToken({ token, onDone }: { token: string; onDone: () => vo
   return (
     <div className="space-y-3 rounded-lg border border-border p-4" data-testid="settings-redesign-api-key-token">
       <p className="text-[13px] text-foreground">Copy this token now. You cannot see it again.</p>
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2 ph-no-capture">
         <Input readOnly value={token} className="min-w-0 flex-1 font-mono" data-testid="api-key-token-display" />
         <CopyButton
           variant="button"

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignApiKeysPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignApiKeysPage.tsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import { Link } from "react-router";
+
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { usePermissions } from "@/contexts/usePermissions";
+import { useAPIKeys, useCreateAPIKey, useDeleteAPIKey } from "@/hooks/useApiKeys";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { getApiErrorMessage } from "@/lib/errors";
+import { useOrganizationSettingsPaths } from "@/lib/organizationSettingsPaths";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { KeyRound, Plus } from "lucide-react";
+
+import { FactorySettingsPageFrame } from "../FactorySettingsCard";
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { SettingsListRow, SettingsStackedField } from "./settingsRedesignParts";
+
+export function SettingsRedesignApiKeysPage() {
+  const { organizationId } = useFactorySettingsLayout();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
+  const { data: apiKeys = [], isLoading } = useAPIKeys(organizationId);
+  const createMutation = useCreateAPIKey(organizationId);
+  const deleteMutation = useDeleteAPIKey(organizationId);
+  const settingsPaths = useOrganizationSettingsPaths(organizationId);
+  const canCreate = canAct("api_keys", "create");
+  const canDelete = canAct("api_keys", "delete");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  usePageTitle(["API keys"]);
+
+  const handleCreate = async () => {
+    if (!canCreate || !newName.trim()) return;
+    try {
+      await createMutation.mutateAsync({
+        name: newName.trim(),
+        description: "",
+        role: "org_viewer",
+        canvasIds: [],
+      });
+      showSuccessToast("API key created.");
+      setCreateOpen(false);
+      setNewName("");
+    } catch (error) {
+      showErrorToast(getApiErrorMessage(error, "Failed to create API key"));
+    }
+  };
+
+  const handleDelete = async (id: string, name: string) => {
+    if (!canDelete) return;
+    if (!window.confirm(`Delete API key ${name}? This cannot be undone.`)) return;
+    try {
+      await deleteMutation.mutateAsync(id);
+      showSuccessToast("API key deleted.");
+    } catch (error) {
+      showErrorToast(getApiErrorMessage(error, "Failed to delete API key"));
+    }
+  };
+
+  const sorted = [...apiKeys].sort((left, right) => (left.name || "").localeCompare(right.name || ""));
+
+  return (
+    <FactorySettingsPageFrame
+      title="API keys"
+      subtitle="Keys for programmatic access to SuperPlane."
+      actions={
+        <PermissionTooltip
+          allowed={canCreate || permissionsLoading}
+          message="You do not have permission to create API keys."
+        >
+          <Button
+            type="button"
+            size="sm"
+            disabled={!canCreate}
+            onClick={() => setCreateOpen(true)}
+            data-testid="api-key-create-btn"
+          >
+            <Plus className="size-3.5" aria-hidden />
+            Create API key
+          </Button>
+        </PermissionTooltip>
+      }
+    >
+      {createOpen ? (
+        <ApiKeyCreateForm
+          name={newName}
+          loading={createMutation.isPending}
+          onNameChange={setNewName}
+          onCancel={() => setCreateOpen(false)}
+          onCreate={() => void handleCreate()}
+        />
+      ) : null}
+      <ApiKeyList
+        isLoading={isLoading}
+        keys={sorted}
+        canDelete={canDelete}
+        permissionsLoading={permissionsLoading}
+        deletePending={deleteMutation.isPending}
+        detailPath={settingsPaths.apiKeyDetail}
+        onDelete={handleDelete}
+      />
+    </FactorySettingsPageFrame>
+  );
+}
+
+function ApiKeyCreateForm({
+  name,
+  loading,
+  onNameChange,
+  onCancel,
+  onCreate,
+}: {
+  name: string;
+  loading: boolean;
+  onNameChange: (value: string) => void;
+  onCancel: () => void;
+  onCreate: () => void;
+}) {
+  return (
+    <div className="space-y-3 rounded-lg border border-border p-4" data-testid="settings-redesign-api-key-create">
+      <SettingsStackedField htmlFor="settings-redesign-api-key-name" label="Name">
+        <Input
+          id="settings-redesign-api-key-name"
+          value={name}
+          onChange={(event) => onNameChange(event.target.value)}
+        />
+      </SettingsStackedField>
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+        <LoadingButton type="button" size="sm" disabled={!name.trim()} loading={loading} onClick={onCreate}>
+          Create
+        </LoadingButton>
+      </div>
+    </div>
+  );
+}
+
+function ApiKeyList({
+  isLoading,
+  keys,
+  canDelete,
+  permissionsLoading,
+  deletePending,
+  detailPath,
+  onDelete,
+}: {
+  isLoading: boolean;
+  keys: Array<{ id?: string; name?: string; description?: string; hasToken?: boolean }>;
+  canDelete: boolean;
+  permissionsLoading: boolean;
+  deletePending: boolean;
+  detailPath: (id: string) => string;
+  onDelete: (id: string, name: string) => Promise<void>;
+}) {
+  if (isLoading) {
+    return <p className="text-[13px] text-muted-foreground">Loading API keys...</p>;
+  }
+  if (keys.length === 0) {
+    return <p className="text-[13px] text-muted-foreground">No API keys yet.</p>;
+  }
+
+  return (
+    <ul data-testid="settings-redesign-api-keys">
+      {keys.map((apiKey) => (
+        <SettingsListRow
+          key={apiKey.id}
+          icon={<KeyRound className="size-4" aria-hidden />}
+          title={
+            <Link to={detailPath(apiKey.id || "")} data-testid="api-key-link">
+              {apiKey.name || "Unnamed"}
+            </Link>
+          }
+          subtitle={apiKey.description || "Organization-wide"}
+          meta={apiKey.hasToken ? "Active" : "None"}
+          action={
+            <PermissionTooltip
+              allowed={canDelete || permissionsLoading}
+              message="You do not have permission to delete API keys."
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={!canDelete || deletePending}
+                onClick={() => void onDelete(apiKey.id || "", apiKey.name || "")}
+                data-testid="api-key-delete-btn"
+              >
+                Delete
+              </Button>
+            </PermissionTooltip>
+          }
+        />
+      ))}
+    </ul>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignAutomationsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignAutomationsPage.tsx
@@ -1,0 +1,81 @@
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { Button } from "@/components/ui/button";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { Plus } from "lucide-react";
+
+import { CreateFactoryAppDialog } from "../../../CreateFactoryAppDialog";
+import { FactoriesLayoutContext } from "../../../layout/factoriesLayoutContext";
+import { AutomationsPageBody } from "../../automationsPageBody";
+import { useAutomationsPageModel } from "../../useAutomationsPageModel";
+import { FactorySettingsPageFrame } from "../FactorySettingsCard";
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+
+export function SettingsRedesignAutomationsPage() {
+  const { organizationId, factoryId, factory } = useFactorySettingsLayout();
+
+  return (
+    <FactoriesLayoutContext.Provider
+      value={{
+        organizationId,
+        factoryId,
+        factoryKey: factory.key ?? "",
+        factory,
+        factories: [factory],
+        openCreateWorkOrder: () => undefined,
+      }}
+    >
+      <AutomationsSettingsContent />
+    </FactoriesLayoutContext.Provider>
+  );
+}
+
+function AutomationsSettingsContent() {
+  const model = useAutomationsPageModel();
+  usePageTitle(["Automations", "Settings", model.factory?.name ?? "Workspace"]);
+
+  return (
+    <>
+      <FactorySettingsPageFrame
+        title="Automations"
+        subtitle="One-step lines that listen for a trigger and run a canvas."
+        actions={
+          <PermissionTooltip
+            allowed={model.canCreateApp || model.permissionsLoading}
+            message="You do not have permission to create automations."
+          >
+            <Button
+              type="button"
+              size="sm"
+              disabled={!model.canCreateApp}
+              onClick={() => model.setCreateOpen(true)}
+              data-testid="automations-create-button"
+            >
+              <Plus className="size-3.5" aria-hidden />
+              New automation
+            </Button>
+          </PermissionTooltip>
+        }
+      >
+        <div data-testid="settings-redesign-automations">
+          <AutomationsPageBody
+            organizationId={model.organizationId}
+            factoryKey={model.factoryKey}
+            apps={model.apps}
+            workOrders={model.workOrders}
+            appsLoading={model.appsLoading}
+            actionsForApp={model.actionsForApp}
+            canCreate={model.canCreateApp || model.permissionsLoading}
+            onCreate={() => model.setCreateOpen(true)}
+          />
+        </div>
+      </FactorySettingsPageFrame>
+
+      <CreateFactoryAppDialog
+        open={model.createOpen}
+        isSaving={model.createCanvas.isPending}
+        onClose={() => model.setCreateOpen(false)}
+        onCreate={model.handleCreateAutomation}
+      />
+    </>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignIntegrationsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignIntegrationsPage.tsx
@@ -1,0 +1,16 @@
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { IntegrationCatalog } from "@/pages/organization/settings/IntegrationCatalog";
+
+import { FactorySettingsPageFrame } from "../FactorySettingsCard";
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+
+export function SettingsRedesignIntegrationsPage() {
+  const { organizationId } = useFactorySettingsLayout();
+  usePageTitle(["Integrations"]);
+
+  return (
+    <FactorySettingsPageFrame title="Integrations" subtitle="Connect the tools this organization uses.">
+      <IntegrationCatalog organizationId={organizationId} appearance="factories" />
+    </FactorySettingsPageFrame>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignOrganizationGeneral.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignOrganizationGeneral.tsx
@@ -1,0 +1,278 @@
+import { useState } from "react";
+import { Link } from "react-router";
+
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { Textarea } from "@/components/ui/textarea";
+import { useFactories } from "@/hooks/useFactoryData";
+import { getNameInitials } from "@/lib/nameInitials";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { Trash2 } from "lucide-react";
+
+import { factorySettingsSectionPath } from "../../../lib/factoryPagePaths";
+import { FactorySettingsPageFrame } from "../FactorySettingsCard";
+import {
+  SettingsDangerPanel,
+  SettingsIdentityHero,
+  SettingsListRow,
+  SettingsSaveBar,
+  SettingsStackedField,
+  SettingsUrlField,
+} from "./settingsRedesignParts";
+import {
+  ORGANIZATION_NAME_MAX_LENGTH,
+  useSettingsRedesignOrganizationGeneral,
+} from "./useSettingsRedesignOrganizationGeneral";
+
+export function SettingsRedesignOrganizationGeneralPage() {
+  const general = useSettingsRedesignOrganizationGeneral();
+  const organizationName = general.name.trim() || general.organization?.metadata?.name || "Organization";
+  usePageTitle(["General", organizationName]);
+
+  return (
+    <FactorySettingsPageFrame title="General" subtitle="Name and URL for this organization.">
+      <div className="space-y-8" data-testid="organization-settings-overview">
+        <OrganizationIdentityForm general={general} organizationName={organizationName} />
+        <OrganizationWorkspaces organizationId={general.organizationId} />
+        <OrganizationDanger
+          general={general}
+          organizationName={general.organization?.metadata?.name || organizationName}
+        />
+      </div>
+    </FactorySettingsPageFrame>
+  );
+}
+
+function OrganizationIdentityForm({
+  general,
+  organizationName,
+}: {
+  general: ReturnType<typeof useSettingsRedesignOrganizationGeneral>;
+  organizationName: string;
+}) {
+  const slugCaption = `/${general.slug || "slug"}`;
+
+  return (
+    <div className="space-y-6">
+      <SettingsIdentityHero
+        initials={getNameInitials(organizationName)}
+        title={organizationName}
+        caption={slugCaption}
+      />
+
+      <SettingsStackedField htmlFor="organization-settings-overview-name" label="Name">
+        <Input
+          id="organization-settings-overview-name"
+          data-testid="organization-settings-overview-name"
+          value={general.name}
+          maxLength={ORGANIZATION_NAME_MAX_LENGTH}
+          disabled={!general.canUpdate}
+          onChange={(event) => {
+            if (event.target.value.length <= ORGANIZATION_NAME_MAX_LENGTH) {
+              general.setName(event.target.value);
+            }
+          }}
+        />
+      </SettingsStackedField>
+
+      <SettingsStackedField
+        htmlFor="organization-settings-overview-slug"
+        label="Slug"
+        hint="Used in workspace URLs. Use lowercase letters, numbers, and dashes only."
+      >
+        <SettingsUrlField
+          prefix="/"
+          id="organization-settings-overview-slug"
+          testId="organization-settings-overview-slug-input"
+          value={general.slug}
+          disabled={!general.canUpdate}
+          onChange={(value) => {
+            general.setSlug(value);
+            general.clearSlugError();
+          }}
+        />
+        {general.slugError ? <p className="text-[11px] text-destructive">{general.slugError}</p> : null}
+      </SettingsStackedField>
+
+      <SettingsStackedField htmlFor="organization-settings-overview-description" label="Description">
+        <Textarea
+          id="organization-settings-overview-description"
+          data-testid="organization-settings-overview-description"
+          value={general.description}
+          rows={3}
+          disabled={!general.canUpdate}
+          onChange={(event) => general.setDescription(event.target.value)}
+        />
+      </SettingsStackedField>
+
+      <SettingsSaveBar
+        allowed={general.canUpdate}
+        permissionsLoading={general.permissionsLoading}
+        disabled={!general.canUpdate || !general.name.trim() || !general.isDirty}
+        loading={general.updateOrganization.isPending}
+        onSave={() => void general.saveDetails()}
+        denyMessage="You do not have permission to update this organization."
+        testId="organization-settings-overview-save"
+      />
+    </div>
+  );
+}
+
+function OrganizationWorkspaces({ organizationId }: { organizationId: string }) {
+  const { data: factories = [] } = useFactories(organizationId);
+
+  return (
+    <div className="space-y-3 border-t border-border pt-6" data-testid="settings-redesign-org-workspaces">
+      <h2 className="text-[13px] font-medium text-foreground">Workspaces</h2>
+      {factories.length === 0 ? (
+        <p className="text-[13px] text-muted-foreground">No workspaces yet.</p>
+      ) : (
+        <ul>
+          {factories.map((factory) => (
+            <SettingsListRow
+              key={factory.id}
+              title={factory.name || "Workspace"}
+              subtitle={factory.key ? `/${factory.key}` : undefined}
+              action={
+                factory.key ? (
+                  <Button asChild type="button" variant="outline" size="sm">
+                    <Link to={factorySettingsSectionPath(organizationId, factory.key, "workspace", "general")}>
+                      Open settings
+                    </Link>
+                  </Button>
+                ) : null
+              }
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function OrganizationDanger({
+  general,
+  organizationName,
+}: {
+  general: ReturnType<typeof useSettingsRedesignOrganizationGeneral>;
+  organizationName: string;
+}) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  return (
+    <>
+      <SettingsDangerPanel
+        testId="settings-redesign-org-danger"
+        title="Delete organization"
+        description="Permanently removes workspaces, members, and settings."
+        action={
+          <PermissionTooltip
+            allowed={general.canDelete || general.permissionsLoading}
+            message="You do not have permission to delete this organization."
+          >
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              disabled={!general.canDelete}
+              onClick={() => {
+                general.clearDeleteError();
+                setDeleteOpen(true);
+              }}
+              data-testid="settings-redesign-org-delete"
+            >
+              <Trash2 className="size-3.5" aria-hidden />
+              Delete organization
+            </Button>
+          </PermissionTooltip>
+        }
+      />
+      <OrganizationDeleteDialog
+        open={deleteOpen}
+        organizationName={organizationName}
+        canDelete={general.canDelete}
+        isDeleting={general.deleteOrganization.isPending}
+        deleteError={general.deleteError}
+        onOpenChange={(open) => {
+          setDeleteOpen(open);
+          if (!open) general.clearDeleteError();
+        }}
+        onConfirm={() => void general.handleDelete()}
+      />
+    </>
+  );
+}
+
+function OrganizationDeleteDialog({
+  open,
+  organizationName,
+  canDelete,
+  isDeleting,
+  deleteError,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  organizationName: string;
+  canDelete: boolean;
+  isDeleting: boolean;
+  deleteError: string | null;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  const [confirmation, setConfirmation] = useState("");
+  const canSubmit = canDelete && confirmation === organizationName;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next);
+        if (!next) setConfirmation("");
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete organization</DialogTitle>
+          <DialogDescription>Type {organizationName} to confirm</DialogDescription>
+        </DialogHeader>
+        <Input
+          id="settings-redesign-org-delete-confirm"
+          data-testid="settings-redesign-org-delete-confirm"
+          value={confirmation}
+          disabled={!canDelete}
+          placeholder={organizationName}
+          aria-label={`Type ${organizationName} to confirm`}
+          onChange={(event) => setConfirmation(event.target.value)}
+        />
+        {deleteError ? <p className="text-[11px] text-destructive">{deleteError}</p> : null}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Keep organization
+          </Button>
+          <LoadingButton
+            type="button"
+            variant="destructive"
+            disabled={!canSubmit}
+            loading={isDeleting}
+            loadingText="Deleting..."
+            onClick={onConfirm}
+            data-testid="settings-redesign-org-delete-submit"
+          >
+            Delete organization
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignOrganizationPages.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignOrganizationPages.tsx
@@ -65,6 +65,16 @@ function InviteLinkSection({ members }: { members: ReturnType<typeof useSettings
           >
             Copy link
           </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!members.canManageInvite || members.inviteBusy}
+            onClick={() => void members.resetInviteLink()}
+            data-testid="settings-redesign-invite-reset"
+          >
+            Reset link
+          </Button>
         </div>
       ) : (
         <p className="text-[13px] text-muted-foreground">Invite link is off.</p>

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignOrganizationPages.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignOrganizationPages.tsx
@@ -1,0 +1,152 @@
+import { Avatar } from "@/components/Avatar/avatar";
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { getNameInitials } from "@/lib/nameInitials";
+import { Switch } from "@/ui/switch";
+
+import { FactorySettingsPageFrame } from "../FactorySettingsCard";
+import {
+  type SettingsRedesignMember,
+  type SettingsRedesignRoleOption,
+  useSettingsRedesignOrganizationMembers,
+} from "./useSettingsRedesignOrganizationMembers";
+
+export function SettingsRedesignOrganizationMembersPage() {
+  const members = useSettingsRedesignOrganizationMembers();
+  usePageTitle(["Members"]);
+
+  return (
+    <FactorySettingsPageFrame title="Members" subtitle="Invite people and manage organization access.">
+      <div className="space-y-6">
+        <InviteLinkSection members={members} />
+        <div className="space-y-3 border-t border-border pt-6">
+          <h2 className="text-[13px] font-medium text-foreground">Members ({members.members.length})</h2>
+          {members.usersError ? <p className="text-[13px] text-destructive">{members.usersError}</p> : null}
+          {members.usersLoading ? <p className="text-[13px] text-muted-foreground">Loading members...</p> : null}
+          {!members.usersLoading ? <MemberList members={members} /> : null}
+        </div>
+      </div>
+    </FactorySettingsPageFrame>
+  );
+}
+
+function InviteLinkSection({ members }: { members: ReturnType<typeof useSettingsRedesignOrganizationMembers> }) {
+  return (
+    <div className="space-y-3" data-testid="settings-redesign-invite-link">
+      <div className="flex items-start justify-between gap-6">
+        <div>
+          <h2 className="text-[13px] font-medium text-foreground">Invite link</h2>
+          <p className="text-[12px] text-muted-foreground">People with this link can join the organization.</p>
+        </div>
+        <PermissionTooltip
+          allowed={members.canManageInvite || members.permissionsLoading}
+          message="You do not have permission to manage invite links."
+        >
+          <Switch
+            checked={members.inviteEnabled}
+            onCheckedChange={(enabled) => void members.toggleInvite(enabled)}
+            disabled={members.inviteLoading || members.inviteBusy || !members.canManageInvite}
+            aria-label="Toggle invite link"
+          />
+        </PermissionTooltip>
+      </div>
+      {members.inviteEnabled && members.inviteUrl ? (
+        <div className="flex flex-wrap items-center gap-3">
+          <Input readOnly value={members.inviteUrl} className="min-w-0 flex-1" />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!members.canManageInvite || members.inviteBusy}
+            onClick={() => void members.copyInvite()}
+          >
+            Copy link
+          </Button>
+        </div>
+      ) : (
+        <p className="text-[13px] text-muted-foreground">Invite link is off.</p>
+      )}
+    </div>
+  );
+}
+
+function MemberList({ members }: { members: ReturnType<typeof useSettingsRedesignOrganizationMembers> }) {
+  if (members.members.length === 0) {
+    return <p className="text-[13px] text-muted-foreground">No members yet.</p>;
+  }
+
+  return (
+    <ul className="divide-y divide-border" data-testid="settings-redesign-members">
+      {members.members.map((member) => {
+        const isSelf = member.id === members.meId;
+        const lastOwner = member.roleName === "org_owner" && members.ownerIds.size <= 1;
+        return (
+          <li key={member.id} className="flex items-center justify-between gap-3 py-3 first:pt-0">
+            <div className="flex min-w-0 items-center gap-3">
+              <Avatar initials={getNameInitials(member.name) || "?"} alt={member.name} className="size-8" />
+              <div className="min-w-0">
+                <p className="truncate text-[13px] font-medium text-foreground">{member.name}</p>
+                <p className="truncate text-[12px] text-muted-foreground">{member.email}</p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <MemberRoleSelect
+                member={member}
+                roles={members.roles}
+                disabled={isSelf || !members.canUpdateMembers}
+                loading={members.rolesLoading}
+                onRoleChange={(roleName) => void members.changeRole(member.id, roleName)}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={isSelf || lastOwner || !members.canDeleteMembers}
+                onClick={() => void members.removeMember(member)}
+              >
+                Remove
+              </Button>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function MemberRoleSelect({
+  member,
+  roles,
+  disabled,
+  loading,
+  onRoleChange,
+}: {
+  member: SettingsRedesignMember;
+  roles: SettingsRedesignRoleOption[];
+  disabled: boolean;
+  loading: boolean;
+  onRoleChange: (roleName: string) => void;
+}) {
+  return (
+    <Select value={member.roleName} disabled={disabled || loading} onValueChange={onRoleChange}>
+      <SelectTrigger
+        size="sm"
+        aria-label={`Role for ${member.name}`}
+        data-testid={`settings-redesign-member-role-${member.id}`}
+        className="h-7 w-fit gap-1 px-2 py-0 pr-1.5 text-[13px] data-[size=sm]:h-7"
+      >
+        <SelectValue>{member.roleLabel}</SelectValue>
+      </SelectTrigger>
+      <SelectContent position="popper" align="end">
+        {roles.map((role) => (
+          <SelectItem key={role.name} value={role.name}>
+            {role.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignSecretsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignSecretsPage.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Link } from "react-router";
+
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { Button } from "@/components/ui/button";
+import { usePermissions } from "@/contexts/usePermissions";
+import { useSecrets } from "@/hooks/useSecrets";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { useOrganizationSettingsPaths } from "@/lib/organizationSettingsPaths";
+import { CreateSecretDialog } from "@/ui/CreateSecretDialog";
+import { KeyRound, Plus } from "lucide-react";
+
+import { FactorySettingsPageFrame } from "../FactorySettingsCard";
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { SettingsListRow } from "./settingsRedesignParts";
+
+export function SettingsRedesignSecretsPage() {
+  const { organizationId } = useFactorySettingsLayout();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
+  const { data: secrets = [], isLoading } = useSecrets(organizationId, "DOMAIN_TYPE_ORGANIZATION");
+  const settingsPaths = useOrganizationSettingsPaths(organizationId);
+  const canCreate = canAct("secrets", "create");
+  const [createOpen, setCreateOpen] = useState(false);
+
+  usePageTitle(["Secrets"]);
+
+  const sorted = [...secrets].sort((left, right) =>
+    (left.metadata?.name || "").localeCompare(right.metadata?.name || ""),
+  );
+
+  return (
+    <FactorySettingsPageFrame
+      title="Secrets"
+      subtitle="Store values that automations and canvases can read."
+      actions={
+        <PermissionTooltip
+          allowed={canCreate || permissionsLoading}
+          message="You do not have permission to create secrets."
+        >
+          <Button
+            type="button"
+            size="sm"
+            disabled={!canCreate}
+            onClick={() => setCreateOpen(true)}
+            data-testid="secrets-create-btn"
+          >
+            <Plus className="size-3.5" aria-hidden />
+            Create secret
+          </Button>
+        </PermissionTooltip>
+      }
+    >
+      {isLoading ? <p className="text-[13px] text-muted-foreground">Loading secrets...</p> : null}
+      {!isLoading && sorted.length === 0 ? (
+        <p className="text-[13px] text-muted-foreground">No secrets yet.</p>
+      ) : (
+        <ul data-testid="settings-redesign-secrets">
+          {sorted.map((secret) => {
+            const secretId = secret.metadata?.id || "";
+            const keyCount = Object.keys(secret.spec?.local?.data || {}).length;
+            return (
+              <SettingsListRow
+                key={secretId}
+                icon={<KeyRound className="size-4" aria-hidden />}
+                title={
+                  <Link to={settingsPaths.secretDetail(secretId)} data-testid="secrets-secret-link">
+                    {secret.metadata?.name || "Unnamed secret"}
+                  </Link>
+                }
+                subtitle={`${keyCount} key${keyCount === 1 ? "" : "s"}`}
+              />
+            );
+          })}
+        </ul>
+      )}
+
+      <CreateSecretDialog open={createOpen} onOpenChange={setCreateOpen} organizationId={organizationId} />
+    </FactorySettingsPageFrame>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignSpendingPages.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignSpendingPages.tsx
@@ -1,0 +1,26 @@
+import { formatCompactTokens, formatDurationSeconds, formatUsdCents } from "../../../lib/workOrderUsage";
+
+import { SettingsStat } from "./settingsRedesignParts";
+
+export function SettingsSpendingStats({
+  periodDays,
+  totalTokens,
+  totalCostCents,
+  totalDurationSeconds,
+}: {
+  periodDays: number;
+  totalTokens: number;
+  totalCostCents: number;
+  totalDurationSeconds?: number;
+}) {
+  return (
+    <div
+      className="grid gap-6 border-y border-border py-6 sm:grid-cols-3"
+      data-testid="settings-redesign-spending-stats"
+    >
+      <SettingsStat label={`Tokens · last ${periodDays} days`} value={formatCompactTokens(totalTokens)} />
+      <SettingsStat label="VM time" value={formatDurationSeconds(totalDurationSeconds ?? 0)} />
+      <SettingsStat label="Estimated spend" value={formatUsdCents(totalCostCents)} />
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignWorkspaceGeneralCards.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignWorkspaceGeneralCards.tsx
@@ -1,0 +1,128 @@
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { getNameInitials } from "@/lib/nameInitials";
+import { Trash2 } from "lucide-react";
+
+import { WORKSPACE_KEY_MAX_LENGTH } from "../../../lib/workspaceKey";
+import {
+  SettingsDangerPanel,
+  SettingsIdentityHero,
+  SettingsSaveBar,
+  SettingsStackedField,
+  SettingsUrlField,
+} from "./settingsRedesignParts";
+import {
+  WORKSPACE_DESCRIPTION_MAX_LENGTH,
+  WORKSPACE_NAME_MAX_LENGTH,
+  type SettingsRedesignWorkspaceGeneral,
+} from "./useSettingsRedesignWorkspaceGeneral";
+
+export function WorkspaceIdentityForm({
+  general,
+  organizationSlug,
+}: {
+  general: SettingsRedesignWorkspaceGeneral;
+  organizationSlug: string;
+}) {
+  const displayName = general.name.trim() || general.factory.name || "Workspace";
+  const keyCaption = `/${organizationSlug}/workspaces/${general.key || "KEY"}`;
+
+  return (
+    <div className="space-y-6">
+      <SettingsIdentityHero initials={getNameInitials(displayName)} title={displayName} caption={keyCaption} />
+
+      <SettingsStackedField htmlFor="factory-settings-name" label="Name">
+        <Input
+          id="factory-settings-name"
+          data-testid="factory-settings-name"
+          value={general.name}
+          onChange={(event) => {
+            if (event.target.value.length <= WORKSPACE_NAME_MAX_LENGTH) {
+              general.setName(event.target.value);
+              if (general.nameError) general.clearNameError();
+            }
+          }}
+          maxLength={WORKSPACE_NAME_MAX_LENGTH}
+          disabled={!general.canUpdate}
+        />
+        {general.nameError ? <p className="text-[11px] text-destructive">{general.nameError}</p> : null}
+      </SettingsStackedField>
+
+      <SettingsStackedField
+        htmlFor="factory-settings-key"
+        label="Workspace key"
+        hint="Changing the key updates every task identifier for this workspace."
+      >
+        <SettingsUrlField
+          prefix={`/${organizationSlug}/workspaces/`}
+          id="factory-settings-key"
+          testId="factory-settings-key"
+          value={general.key}
+          disabled={!general.canUpdate}
+          autoComplete="off"
+          className="uppercase tracking-wider"
+          onChange={(value) => {
+            general.setKey(value.slice(0, WORKSPACE_KEY_MAX_LENGTH));
+            if (general.keyError) general.clearKeyError();
+          }}
+        />
+        {general.keyError ? <p className="text-[11px] text-destructive">{general.keyError}</p> : null}
+      </SettingsStackedField>
+
+      <SettingsStackedField htmlFor="factory-settings-description" label="Description">
+        <Textarea
+          id="factory-settings-description"
+          data-testid="factory-settings-description"
+          value={general.description}
+          onChange={(event) => {
+            if (event.target.value.length <= WORKSPACE_DESCRIPTION_MAX_LENGTH) {
+              general.setDescription(event.target.value);
+            }
+          }}
+          rows={3}
+          disabled={!general.canUpdate}
+        />
+      </SettingsStackedField>
+
+      <SettingsSaveBar
+        allowed={general.canUpdate}
+        permissionsLoading={general.permissionsLoading}
+        disabled={!general.canUpdate || !general.name.trim() || !general.isDirty}
+        loading={general.updateFactory.isPending}
+        onSave={() => void general.saveDetails()}
+        denyMessage="You do not have permission to update workspaces."
+        testId="factory-settings-save"
+      />
+    </div>
+  );
+}
+
+export function WorkspaceDangerSection({ general }: { general: SettingsRedesignWorkspaceGeneral }) {
+  return (
+    <SettingsDangerPanel
+      testId="factory-settings-danger-zone"
+      title="Delete workspace"
+      description="Permanently removes tasks, lines, and apps."
+      action={
+        <PermissionTooltip
+          allowed={general.canDelete || general.permissionsLoading}
+          message="You do not have permission to delete workspaces."
+        >
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            disabled={!general.canDelete}
+            onClick={() => general.setDeleteOpen(true)}
+            data-testid="factory-settings-delete-button"
+          >
+            <Trash2 className="size-3.5" aria-hidden />
+            Delete workspace
+          </Button>
+        </PermissionTooltip>
+      }
+    />
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignWorkspacePages.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignWorkspacePages.tsx
@@ -13,6 +13,7 @@ import { parseWorkOrderMetric } from "../../../lib/workOrderUsage";
 import { RepositoryPicker } from "../../onboarding/onboardingSteps";
 import { FactorySettingsPageFrame } from "../FactorySettingsCard";
 import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { HostedSpendLimitCard } from "../FactorySettingsUsagePage";
 import { WorkspaceUsageByMachineTypeTable, WorkspaceUsageByModelTable } from "../WorkspaceUsageBreakdown";
 import { WorkspaceDangerSection, WorkspaceIdentityForm } from "./SettingsRedesignWorkspaceGeneralCards";
 import { SettingsIdentityHero } from "./settingsRedesignParts";
@@ -171,6 +172,7 @@ export function SettingsRedesignWorkspaceSpendingPage() {
             labelClassName="text-[12px] text-muted-foreground"
             valueClassName="mt-1 text-[26px] font-medium tracking-tight"
           />
+          <HostedSpendLimitCard />
           <WorkspaceUsageByModelTable byModel={data.byModel ?? []} />
           <WorkspaceUsageByMachineTypeTable byMachineType={data.byMachineType ?? []} />
         </>

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignWorkspacePages.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/SettingsRedesignWorkspacePages.tsx
@@ -1,0 +1,180 @@
+import { type ReactNode } from "react";
+
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { useFactoryUsage } from "@/hooks/useFactoryUsage";
+import { useOrganization } from "@/hooks/useOrganizationData";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { HostedCreditSummary } from "@/pages/organization/settings/HostedCreditSummary";
+import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
+
+import { FactoryDeleteDialog } from "../../../FactoryDeleteDialog";
+import { parseWorkOrderMetric } from "../../../lib/workOrderUsage";
+import { RepositoryPicker } from "../../onboarding/onboardingSteps";
+import { FactorySettingsPageFrame } from "../FactorySettingsCard";
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { WorkspaceUsageByMachineTypeTable, WorkspaceUsageByModelTable } from "../WorkspaceUsageBreakdown";
+import { WorkspaceDangerSection, WorkspaceIdentityForm } from "./SettingsRedesignWorkspaceGeneralCards";
+import { SettingsIdentityHero } from "./settingsRedesignParts";
+import { useSettingsRedesignWorkspaceGeneral } from "./useSettingsRedesignWorkspaceGeneral";
+import { useSettingsRedesignWorkspaceRepository } from "./useSettingsRedesignWorkspaceRepository";
+import { SettingsSpendingStats } from "./SettingsRedesignSpendingPages";
+
+export function SettingsRedesignWorkspaceGeneralPage() {
+  const general = useSettingsRedesignWorkspaceGeneral();
+  const { organizationId } = useFactorySettingsLayout();
+  const { data: organization } = useOrganization(organizationId);
+  const organizationSlug = organization?.metadata?.slug || organizationId;
+  usePageTitle(["General", "Settings", general.factory.name ?? "Workspace"]);
+
+  return (
+    <>
+      <FactorySettingsPageFrame title="General" subtitle="Identity and URL for this workspace.">
+        <div className="space-y-8" data-testid="factory-settings-general-form">
+          <WorkspaceIdentityForm general={general} organizationSlug={organizationSlug} />
+          <WorkspaceDangerSection general={general} />
+        </div>
+      </FactorySettingsPageFrame>
+
+      <FactoryDeleteDialog
+        open={general.deleteOpen}
+        factoryName={general.factory.name ?? ""}
+        canDelete={general.canDelete}
+        isDeleting={general.deleteFactory.isPending}
+        onClose={() => general.setDeleteOpen(false)}
+        onConfirm={general.handleDelete}
+      />
+    </>
+  );
+}
+
+export function SettingsRedesignWorkspaceRepositoryPage() {
+  const repo = useSettingsRedesignWorkspaceRepository();
+  usePageTitle(["Repository", "Settings", repo.factoryName]);
+
+  return (
+    <FactorySettingsPageFrame title="Repository" subtitle="GitHub repository for workspace work and issue intake.">
+      <div className="space-y-6" data-testid="factory-settings-repository">
+        <SettingsIdentityHero
+          leading={
+            <div className="flex size-14 items-center justify-center rounded-xl border border-border bg-muted">
+              <IntegrationIcon integrationName="github" className="size-7" size={28} />
+            </div>
+          }
+          title={repo.repository || "No repository"}
+          caption="Tasks and pull request automations use this repository."
+          testId="settings-redesign-repository-hero"
+        />
+        <WorkspaceRepositoryPicker
+          integrationId={repo.integrationId}
+          loading={repo.resourcesLoading}
+          error={repo.resourcesError}
+          repositories={repo.repositories}
+          repository={repo.repository}
+          onSelect={repo.setRepository}
+        />
+        <div className="flex justify-end border-t border-border pt-4">
+          <PermissionTooltip
+            allowed={repo.canUpdate || repo.permissionsLoading}
+            message="You do not have permission to update this workspace."
+          >
+            <LoadingButton
+              type="button"
+              loading={repo.isSaving}
+              loadingText="Saving..."
+              disabled={!repo.canSave}
+              onClick={repo.save}
+              data-testid="factory-settings-repository-save"
+            >
+              Save repository
+            </LoadingButton>
+          </PermissionTooltip>
+        </div>
+      </div>
+    </FactorySettingsPageFrame>
+  );
+}
+
+function WorkspaceRepositoryPicker({
+  integrationId,
+  loading,
+  error,
+  repositories,
+  repository,
+  onSelect,
+}: {
+  integrationId: string;
+  loading: boolean;
+  error: boolean;
+  repositories: string[];
+  repository: string;
+  onSelect: (repository: string) => void;
+}) {
+  let content: ReactNode;
+  if (!integrationId) {
+    content = (
+      <p className="text-[13px] text-muted-foreground">
+        Connect GitHub during workspace setup before you select a repository.
+      </p>
+    );
+  } else if (loading) {
+    content = <p className="text-[13px] text-muted-foreground">Loading repositories...</p>;
+  } else {
+    content = (
+      <RepositoryPicker
+        host="github"
+        repos={repositories}
+        selectedRepo={repository || null}
+        onSelect={onSelect}
+        searchClassName="h-10"
+        itemClassName="py-3"
+      />
+    );
+  }
+
+  return (
+    <>
+      {content}
+      {error ? <p className="text-[13px] text-destructive">We could not load repositories. Try again.</p> : null}
+    </>
+  );
+}
+
+export function SettingsRedesignWorkspaceSpendingPage() {
+  const { organizationId, factoryId, factory } = useFactorySettingsLayout();
+  const { data, isLoading, error } = useFactoryUsage(organizationId, factoryId);
+
+  usePageTitle(["Spending", "Settings", factory.name ?? "Workspace"]);
+
+  return (
+    <FactorySettingsPageFrame title="Spending" subtitle="Usage for this workspace in the last 30 days.">
+      <p className="text-[12px] text-muted-foreground" data-testid="settings-redesign-spending-scope">
+        Organization billing is under Organization, Spending.
+      </p>
+
+      {isLoading ? <p className="text-[13px] text-muted-foreground">Loading usage...</p> : null}
+      {error || (!isLoading && !data) ? <p className="text-[13px] text-destructive">Unable to load usage.</p> : null}
+      {data ? (
+        <>
+          <SettingsSpendingStats
+            periodDays={data.periodDays ?? 30}
+            totalTokens={parseWorkOrderMetric(data.totalTokens)}
+            totalCostCents={parseWorkOrderMetric(data.totalCostCents)}
+            totalDurationSeconds={parseWorkOrderMetric(data.totalDurationSeconds)}
+          />
+          <HostedCreditSummary
+            remainingCreditCents={data.remainingCreditCents}
+            grantTotalCents={data.grantTotalCents}
+            hostedBilledCents={data.hostedBilledCents}
+            remainingCreditWarning={data.remainingCreditWarning}
+            cardClassName="border-t border-border pt-6"
+            labelClassName="text-[12px] text-muted-foreground"
+            valueClassName="mt-1 text-[26px] font-medium tracking-tight"
+          />
+          <WorkspaceUsageByModelTable byModel={data.byModel ?? []} />
+          <WorkspaceUsageByMachineTypeTable byMachineType={data.byMachineType ?? []} />
+        </>
+      ) : null}
+    </FactorySettingsPageFrame>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/settingsRedesignParts.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/settingsRedesignParts.tsx
@@ -1,0 +1,192 @@
+import type { ReactNode } from "react";
+
+import { Avatar } from "@/components/Avatar/avatar";
+import { PermissionTooltip } from "@/components/PermissionGate";
+import { Label } from "@/components/ui/label";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { cn } from "@/lib/utils";
+
+export function SettingsIdentityHero({
+  initials,
+  leading,
+  title,
+  caption,
+  testId = "settings-redesign-identity-hero",
+}: {
+  initials?: string;
+  leading?: ReactNode;
+  title: string;
+  caption: string;
+  testId?: string;
+}) {
+  return (
+    <div className="flex items-center gap-4" data-testid={testId}>
+      {leading ?? (
+        <Avatar initials={initials || "?"} alt={title} className="size-14 rounded-xl text-[15px] font-medium" />
+      )}
+      <div className="min-w-0">
+        <p className="truncate text-[15px] font-medium tracking-tight text-foreground">{title}</p>
+        <p className="truncate font-mono text-[12px] text-muted-foreground">{caption}</p>
+      </div>
+    </div>
+  );
+}
+
+export function SettingsStackedField({
+  htmlFor,
+  label,
+  hint,
+  children,
+}: {
+  htmlFor?: string;
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+      {hint ? <p className="text-[12px] text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+export function SettingsUrlField({
+  prefix,
+  id,
+  testId,
+  value,
+  disabled,
+  autoComplete,
+  className,
+  onChange,
+}: {
+  prefix: string;
+  id: string;
+  testId?: string;
+  value: string;
+  disabled?: boolean;
+  autoComplete?: string;
+  className?: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="flex h-9 overflow-hidden rounded-md border border-input bg-background">
+      <span className="flex shrink-0 items-center border-r border-input bg-muted px-2.5 font-mono text-[12px] text-muted-foreground">
+        {prefix}
+      </span>
+      <input
+        id={id}
+        data-testid={testId}
+        value={value}
+        disabled={disabled}
+        autoComplete={autoComplete}
+        onChange={(event) => onChange(event.target.value)}
+        className={cn(
+          "h-full min-w-0 flex-1 bg-transparent px-3 text-[13px] outline-none disabled:opacity-50",
+          className,
+        )}
+      />
+    </div>
+  );
+}
+
+export function SettingsSaveBar({
+  allowed,
+  permissionsLoading,
+  disabled,
+  loading,
+  onSave,
+  denyMessage,
+  testId,
+}: {
+  allowed: boolean;
+  permissionsLoading: boolean;
+  disabled: boolean;
+  loading: boolean;
+  onSave: () => void;
+  denyMessage: string;
+  testId: string;
+}) {
+  return (
+    <div className="flex justify-end border-t border-border pt-4">
+      <PermissionTooltip allowed={allowed || permissionsLoading} message={denyMessage}>
+        <LoadingButton
+          type="button"
+          disabled={disabled}
+          loading={loading}
+          loadingText="Saving..."
+          onClick={onSave}
+          data-testid={testId}
+        >
+          Save
+        </LoadingButton>
+      </PermissionTooltip>
+    </div>
+  );
+}
+
+export function SettingsDangerPanel({
+  title,
+  description,
+  action,
+  children,
+  testId,
+}: {
+  title: string;
+  description: string;
+  action: ReactNode;
+  children?: ReactNode;
+  testId?: string;
+}) {
+  return (
+    <div className="space-y-3 rounded-lg border border-destructive/40 bg-destructive/5 p-4" data-testid={testId}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <p className="text-[13px] font-medium text-destructive">{title}</p>
+          <p className="text-[12px] text-muted-foreground">{description}</p>
+        </div>
+        <div className="shrink-0">{action}</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function SettingsListRow({
+  icon,
+  title,
+  subtitle,
+  meta,
+  action,
+  testId,
+}: {
+  icon?: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  meta?: ReactNode;
+  action?: ReactNode;
+  testId?: string;
+}) {
+  return (
+    <li className="flex items-center gap-3 border-b border-border py-3 last:border-b-0 first:pt-0" data-testid={testId}>
+      {icon ? <div className="shrink-0 text-muted-foreground">{icon}</div> : null}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[13px] font-medium text-foreground">{title}</div>
+        {subtitle ? <div className="truncate text-[12px] text-muted-foreground">{subtitle}</div> : null}
+      </div>
+      {meta ? <div className="shrink-0 text-[12px] text-muted-foreground">{meta}</div> : null}
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </li>
+  );
+}
+
+export function SettingsStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[12px] text-muted-foreground">{label}</p>
+      <p className="mt-1 text-[26px] font-medium tracking-tight text-foreground">{value}</p>
+    </div>
+  );
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/settingsRedesignRoutes.tsx
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/settingsRedesignRoutes.tsx
@@ -1,0 +1,173 @@
+import { Navigate, Route } from "react-router";
+
+import { RequireAnyPermission, RequirePermission } from "@/components/PermissionGate";
+import { RequireExperimentalFeature } from "@/components/RequireExperimentalFeature";
+import { FEATURE_WORKSPACE_MODELS } from "@/lib/experimentalFeatures";
+
+import { OrganizationSettingsWorkspaceUsagePage } from "../../organizationSettings/OrganizationSettingsWorkspaceUsagePage";
+import { FactorySettingsAccountNotificationsPage } from "../FactorySettingsAccountNotificationsPage";
+import { FactorySettingsAccountProfilePage } from "../FactorySettingsAccountProfilePage";
+import { FactorySettingsAccountSecurityPage } from "../FactorySettingsAccountSecurityPage";
+import { FactorySettingsModelsPage } from "../FactorySettingsModelsPage";
+import { LegacyFactorySettingsIndexRedirect, LegacyFactorySettingsRedirect } from "../FactorySettingsRedirects";
+import {
+  OrganizationIntegrationDetailsPage,
+  OrganizationIntegrationSetupPage,
+} from "../../organizationSettings/organizationSettingsRoutePages";
+import {
+  FactoryOrganizationApiKeyDetailPage,
+  FactoryOrganizationSecretDetailPage,
+} from "../FactoryOrganizationSettingsPages";
+import { SettingsRedesignAutomationsPage } from "./SettingsRedesignAutomationsPage";
+import { SettingsRedesignApiKeysPage } from "./SettingsRedesignApiKeysPage";
+import { SettingsRedesignIntegrationsPage } from "./SettingsRedesignIntegrationsPage";
+import { SettingsRedesignOrganizationGeneralPage } from "./SettingsRedesignOrganizationGeneral";
+import { SettingsRedesignOrganizationMembersPage } from "./SettingsRedesignOrganizationPages";
+import { SettingsRedesignSecretsPage } from "./SettingsRedesignSecretsPage";
+import {
+  SettingsRedesignWorkspaceGeneralPage,
+  SettingsRedesignWorkspaceRepositoryPage,
+  SettingsRedesignWorkspaceSpendingPage,
+} from "./SettingsRedesignWorkspacePages";
+
+/** Factory settings routes. Account and Models stay on the existing pages. */
+export const factorySettingsRedesignRoutes = [
+  <Route key="factory-settings-index" index element={<LegacyFactorySettingsIndexRedirect />} />,
+  <Route
+    key="factory-settings-account-general"
+    path="account/general"
+    element={<Navigate to="../profile" replace />}
+  />,
+  <Route
+    key="factory-settings-account-profile"
+    path="account/profile"
+    element={<FactorySettingsAccountProfilePage />}
+  />,
+  <Route
+    key="factory-settings-account-security"
+    path="account/security"
+    element={<FactorySettingsAccountSecurityPage />}
+  />,
+  <Route
+    key="factory-settings-account-notifications"
+    path="account/notifications"
+    element={<FactorySettingsAccountNotificationsPage />}
+  />,
+  <Route
+    key="factory-settings-workspace-general"
+    path="workspace/general"
+    element={<SettingsRedesignWorkspaceGeneralPage />}
+  />,
+  <Route
+    key="factory-settings-workspace-repository"
+    path="workspace/repository"
+    element={<SettingsRedesignWorkspaceRepositoryPage />}
+  />,
+  <Route
+    key="factory-settings-workspace-automations"
+    path="workspace/automations"
+    element={<SettingsRedesignAutomationsPage />}
+  />,
+  <Route
+    key="factory-settings-workspace-models"
+    path="workspace/models"
+    element={
+      <RequireExperimentalFeature featureId={FEATURE_WORKSPACE_MODELS}>
+        <FactorySettingsModelsPage />
+      </RequireExperimentalFeature>
+    }
+  />,
+  <Route
+    key="factory-settings-workspace-spending"
+    path="workspace/spending"
+    element={<SettingsRedesignWorkspaceSpendingPage />}
+  />,
+  <Route
+    key="factory-settings-organization-general"
+    path="organization/general"
+    element={<SettingsRedesignOrganizationGeneralPage />}
+  />,
+  <Route
+    key="factory-settings-organization-members"
+    path="organization/members"
+    element={
+      <RequirePermission resource="members" action="read">
+        <SettingsRedesignOrganizationMembersPage />
+      </RequirePermission>
+    }
+  />,
+  <Route
+    key="factory-settings-organization-integrations"
+    path="organization/integrations"
+    element={
+      <RequirePermission resource="integrations" action="read">
+        <SettingsRedesignIntegrationsPage />
+      </RequirePermission>
+    }
+  />,
+  <Route
+    key="factory-settings-organization-api-keys"
+    path="organization/api-keys"
+    element={
+      <RequirePermission resource="api_keys" action="read">
+        <SettingsRedesignApiKeysPage />
+      </RequirePermission>
+    }
+  />,
+  <Route
+    key="factory-settings-organization-secrets"
+    path="organization/secrets"
+    element={
+      <RequirePermission resource="secrets" action="read">
+        <SettingsRedesignSecretsPage />
+      </RequirePermission>
+    }
+  />,
+  <Route
+    key="factory-settings-organization-spending"
+    path="organization/spending"
+    element={
+      <RequirePermission resource="org" action="read">
+        <OrganizationSettingsWorkspaceUsagePage />
+      </RequirePermission>
+    }
+  />,
+  <Route
+    key="factory-settings-organization-integration-setup"
+    path="organization/integrations/:integrationName/setup"
+    element={
+      <RequireAnyPermission
+        checks={[
+          { resource: "integrations", action: "create" },
+          { resource: "integrations", action: "update" },
+        ]}
+      >
+        <OrganizationIntegrationSetupPage />
+      </RequireAnyPermission>
+    }
+  />,
+  <Route
+    key="factory-settings-organization-integration-detail"
+    path="organization/integrations/:integrationId"
+    element={<OrganizationIntegrationDetailsPage />}
+  />,
+  <Route
+    key="factory-settings-organization-api-key-detail"
+    path="organization/api-keys/:id"
+    element={
+      <RequirePermission resource="api_keys" action="read">
+        <FactoryOrganizationApiKeyDetailPage />
+      </RequirePermission>
+    }
+  />,
+  <Route
+    key="factory-settings-organization-secret-detail"
+    path="organization/secrets/:secretId"
+    element={
+      <RequirePermission resource="secrets" action="read">
+        <FactoryOrganizationSecretDetailPage />
+      </RequirePermission>
+    }
+  />,
+  <Route key="factory-settings-legacy" path="*" element={<LegacyFactorySettingsRedirect />} />,
+];

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignOrganizationGeneral.ts
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignOrganizationGeneral.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+import { usePermissions } from "@/contexts/usePermissions";
+import { useDeleteOrganization, useOrganization, useUpdateOrganization } from "@/hooks/useOrganizationData";
+import { getApiErrorMessage } from "@/lib/errors";
+import { organizationSlugValidationMessage, validateOrganizationSlug } from "@/lib/organizationSlug";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+
+export const ORGANIZATION_NAME_MAX_LENGTH = 128;
+
+export function useSettingsRedesignOrganizationGeneral() {
+  const { organizationId } = useFactorySettingsLayout();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
+  const { data: organization } = useOrganization(organizationId);
+  const updateOrganization = useUpdateOrganization(organizationId);
+  const deleteOrganization = useDeleteOrganization(organizationId);
+
+  const currentName = organization?.metadata?.name || "";
+  const currentSlug = organization?.metadata?.slug || "";
+  const currentDescription = organization?.metadata?.description || "";
+
+  const [name, setName] = useState(currentName);
+  const [slug, setSlug] = useState(currentSlug);
+  const [description, setDescription] = useState(currentDescription);
+  const [slugError, setSlugError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setName(currentName);
+    setSlug(currentSlug);
+    setDescription(currentDescription);
+    setSlugError(null);
+  }, [currentName, currentSlug, currentDescription]);
+
+  const canUpdate = canAct("org", "update");
+  const canDelete = canAct("org", "delete");
+  const trimmedName = name.trim();
+  const trimmedSlug = slug.trim();
+  const isDirty =
+    trimmedName !== currentName || trimmedSlug !== currentSlug || description.trim() !== currentDescription;
+
+  const saveDetails = async () => {
+    if (!canUpdate || !isDirty) return;
+    if (!trimmedName) {
+      showErrorToast("Name is required.");
+      return;
+    }
+    if (trimmedSlug !== currentSlug) {
+      const validationError = validateOrganizationSlug(trimmedSlug);
+      if (validationError) {
+        setSlugError(organizationSlugValidationMessage(validationError));
+        return;
+      }
+    }
+    setSlugError(null);
+    try {
+      await updateOrganization.mutateAsync({
+        name: trimmedName,
+        description: description.trim(),
+        slug: trimmedSlug !== currentSlug ? trimmedSlug : undefined,
+      });
+      showSuccessToast("Organization updated.");
+      if (organizationId === currentSlug && trimmedSlug !== currentSlug) {
+        const newPath = location.pathname.replace(`/${organizationId}/`, `/${trimmedSlug}/`);
+        navigate(`${newPath}${location.search}`, { replace: true });
+      }
+    } catch (error) {
+      const message = getApiErrorMessage(error, "Failed to update organization");
+      setSlugError(message);
+      showErrorToast(message);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!canDelete) return;
+    try {
+      setDeleteError(null);
+      await deleteOrganization.mutateAsync();
+      window.location.href = "/";
+    } catch {
+      setDeleteError("Failed to delete organization.");
+    }
+  };
+
+  return {
+    organizationId,
+    organization,
+    name,
+    setName,
+    slug,
+    setSlug,
+    description,
+    setDescription,
+    slugError,
+    clearSlugError: () => setSlugError(null),
+    deleteError,
+    clearDeleteError: () => setDeleteError(null),
+    canUpdate,
+    canDelete,
+    permissionsLoading,
+    isDirty,
+    updateOrganization,
+    deleteOrganization,
+    saveDetails,
+    handleDelete,
+  };
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignOrganizationMembers.ts
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignOrganizationMembers.ts
@@ -1,0 +1,145 @@
+import { useMemo } from "react";
+
+import { usePermissions } from "@/contexts/usePermissions";
+import { useMe } from "@/hooks/useMe";
+import {
+  useAssignRole,
+  useOrganizationInviteLink,
+  useOrganizationRoles,
+  useOrganizationUsers,
+  useRemoveOrganizationSubject,
+  useResetOrganizationInviteLink,
+  useUpdateOrganizationInviteLink,
+} from "@/hooks/useOrganizationData";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+
+export interface SettingsRedesignMember {
+  id: string;
+  name: string;
+  email: string;
+  roleName: string;
+  roleLabel: string;
+}
+
+export interface SettingsRedesignRoleOption {
+  name: string;
+  label: string;
+}
+
+export function useSettingsRedesignOrganizationMembers() {
+  const { organizationId } = useFactorySettingsLayout();
+  const { data: me } = useMe();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
+  const { data: users = [], isLoading: usersLoading, error: usersError } = useOrganizationUsers(organizationId, true);
+  const { data: organizationRoles = [], isLoading: rolesLoading } = useOrganizationRoles(organizationId);
+  const canManageInvite = canAct("members", "create");
+  const canUpdateMembers = canAct("members", "update");
+  const canDeleteMembers = canAct("members", "delete");
+  const { data: inviteLink, isLoading: inviteLoading } = useOrganizationInviteLink(organizationId, canManageInvite);
+  const assignRole = useAssignRole(organizationId);
+  const removeUser = useRemoveOrganizationSubject(organizationId);
+  const updateInvite = useUpdateOrganizationInviteLink(organizationId);
+  const resetInvite = useResetOrganizationInviteLink(organizationId);
+
+  const members = useMemo(() => users.map(toSettingsMember), [users]);
+  const roles = useMemo(() => organizationRoles.map(toRoleOption).filter((role) => role.name), [organizationRoles]);
+  const ownerIds = useMemo(
+    () => new Set(members.filter((member) => member.roleName === "org_owner").map((member) => member.id)),
+    [members],
+  );
+  const inviteUrl = inviteLink?.token
+    ? `${typeof window === "undefined" ? "" : window.location.origin}/invite/${inviteLink.token}`
+    : "";
+
+  return {
+    meId: me?.id,
+    members,
+    roles,
+    ownerIds,
+    usersLoading,
+    rolesLoading,
+    usersError: usersError ? getApiErrorMessage(usersError, "Failed to load members.") : null,
+    permissionsLoading,
+    canManageInvite,
+    canUpdateMembers,
+    canDeleteMembers,
+    inviteEnabled: inviteLink?.enabled ?? false,
+    inviteUrl,
+    inviteLoading,
+    inviteBusy: updateInvite.isPending || resetInvite.isPending,
+    changeRole: async (memberId: string, roleName: string) => {
+      if (!canUpdateMembers || memberId === me?.id) return;
+      try {
+        await assignRole.mutateAsync({ userId: memberId, roleName });
+        showSuccessToast("Role updated.");
+      } catch {
+        showErrorToast("Failed to update role.");
+      }
+    },
+    removeMember: async (member: SettingsRedesignMember) => {
+      if (!canDeleteMembers || member.id === me?.id) return;
+      if (member.roleName === "org_owner" && ownerIds.size <= 1) {
+        showErrorToast("You must keep at least one organization owner.");
+        return;
+      }
+      try {
+        await removeUser.mutateAsync({ userId: member.id });
+        showSuccessToast("Member removed.");
+      } catch {
+        showErrorToast("Unable to remove this member.");
+      }
+    },
+    toggleInvite: async (enabled: boolean) => {
+      try {
+        await updateInvite.mutateAsync(enabled);
+      } catch {
+        showErrorToast("Failed to update invite link.");
+      }
+    },
+    resetInviteLink: async () => {
+      try {
+        await resetInvite.mutateAsync();
+        showSuccessToast("Invite link reset.");
+      } catch {
+        showErrorToast("Failed to reset invite link.");
+      }
+    },
+    copyInvite: async () => {
+      if (!inviteUrl) return;
+      try {
+        await navigator.clipboard.writeText(inviteUrl);
+        showSuccessToast("Invite link copied.");
+      } catch {
+        showErrorToast("Failed to copy invite link.");
+      }
+    },
+  };
+}
+
+function toSettingsMember(user: {
+  metadata?: { id?: string; email?: string };
+  spec?: { displayName?: string };
+  status?: { roles?: Array<{ roleName?: string; roleDisplayName?: string }> };
+}): SettingsRedesignMember {
+  const role = user.status?.roles?.[0];
+  return {
+    id: user.metadata?.id || "",
+    name: user.spec?.displayName || "Unknown user",
+    email: user.metadata?.email || "",
+    roleName: role?.roleName || "org_member",
+    roleLabel: role?.roleDisplayName || role?.roleName || "Member",
+  };
+}
+
+function toRoleOption(role: {
+  metadata?: { name?: string };
+  spec?: { displayName?: string };
+}): SettingsRedesignRoleOption {
+  return {
+    name: role.metadata?.name || "",
+    label: role.spec?.displayName || role.metadata?.name || "",
+  };
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignOrganizationMembers.ts
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignOrganizationMembers.ts
@@ -119,12 +119,16 @@ export function useSettingsRedesignOrganizationMembers() {
   };
 }
 
+function organizationMemberRole(roles: Array<{ roleName?: string; roleDisplayName?: string }> | undefined) {
+  return roles?.find((item) => item.roleName === "org_owner") ?? roles?.[0];
+}
+
 function toSettingsMember(user: {
   metadata?: { id?: string; email?: string };
   spec?: { displayName?: string };
   status?: { roles?: Array<{ roleName?: string; roleDisplayName?: string }> };
 }): SettingsRedesignMember {
-  const role = user.status?.roles?.[0];
+  const role = organizationMemberRole(user.status?.roles);
   return {
     id: user.metadata?.id || "",
     name: user.spec?.displayName || "Unknown user",

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignWorkspaceGeneral.ts
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignWorkspaceGeneral.ts
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+
+import { useAccount } from "@/contexts/useAccount";
+import { usePermissions } from "@/contexts/usePermissions";
+import { useDeleteFactory, useUpdateFactory } from "@/hooks/useFactoryData";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+
+import { factoryListPath, factorySettingsGeneralPathAfterKeyChange } from "../../../lib/factoryPagePaths";
+import { clearLastVisitedFactory } from "../../../lib/lastVisitedFactory";
+import {
+  WORKSPACE_KEY_MAX_LENGTH,
+  WORKSPACE_KEY_MIN_LENGTH,
+  isValidWorkspaceKey,
+  normalizeWorkspaceKey,
+} from "../../../lib/workspaceKey";
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+
+export const WORKSPACE_NAME_MAX_LENGTH = 128;
+export const WORKSPACE_DESCRIPTION_MAX_LENGTH = 500;
+
+export type SettingsRedesignWorkspaceGeneral = ReturnType<typeof useSettingsRedesignWorkspaceGeneral>;
+
+export function useSettingsRedesignWorkspaceGeneral() {
+  const { organizationId, factoryId, factory } = useFactorySettingsLayout();
+  const { account } = useAccount();
+  const navigate = useNavigate();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
+  const updateFactory = useUpdateFactory(organizationId, factoryId);
+  const deleteFactory = useDeleteFactory(organizationId);
+
+  const [name, setName] = useState(factory.name ?? "");
+  const [description, setDescription] = useState(factory.description ?? "");
+  const [key, setKey] = useState(factory.key ?? "");
+  const [nameError, setNameError] = useState("");
+  const [keyError, setKeyError] = useState("");
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    setName(factory.name ?? "");
+    setDescription(factory.description ?? "");
+    setKey(factory.key ?? "");
+    setNameError("");
+    setKeyError("");
+  }, [factory.name, factory.description, factory.key]);
+
+  const canUpdate = canAct("factories", "update");
+  const canDelete = canAct("factories", "delete");
+
+  const saveDetails = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError("Name is required");
+      return;
+    }
+    if (!isValidWorkspaceKey(key)) {
+      setKeyError(`Use ${WORKSPACE_KEY_MIN_LENGTH} to ${WORKSPACE_KEY_MAX_LENGTH} uppercase letters.`);
+      return;
+    }
+    try {
+      const nextSettingsPath = factorySettingsGeneralPathAfterKeyChange(organizationId, factory.key ?? "", key);
+      await updateFactory.mutateAsync({
+        name: trimmedName,
+        description: description.trim(),
+        key: key !== (factory.key ?? "") ? key : undefined,
+      });
+      showSuccessToast("Workspace updated.");
+      if (nextSettingsPath) {
+        navigate(nextSettingsPath, { replace: true });
+      }
+    } catch (error) {
+      const message = getApiErrorMessage(error, "Failed to update workspace");
+      if (message.toLowerCase().includes("workspace key")) {
+        setKeyError(message);
+        return;
+      }
+      showErrorToast(message);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteFactory.mutateAsync(factoryId);
+      clearLastVisitedFactory(account?.id ?? "", organizationId, factoryId);
+      showSuccessToast("Workspace deleted.");
+      navigate(factoryListPath(organizationId));
+    } catch {
+      showErrorToast("Failed to delete workspace.");
+      throw new Error("Failed to delete workspace");
+    }
+  };
+
+  return {
+    factory,
+    updateFactory,
+    deleteFactory,
+    name,
+    setName,
+    description,
+    setDescription,
+    key,
+    setKey: (next: string) => setKey(normalizeWorkspaceKey(next)),
+    nameError,
+    clearNameError: () => setNameError(""),
+    keyError,
+    clearKeyError: () => setKeyError(""),
+    deleteOpen,
+    setDeleteOpen,
+    canUpdate,
+    canDelete,
+    permissionsLoading,
+    isDirty:
+      name.trim() !== (factory.name ?? "") ||
+      key !== (factory.key ?? "") ||
+      description.trim() !== (factory.description ?? ""),
+    saveDetails,
+    handleDelete,
+  };
+}

--- a/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignWorkspaceRepository.ts
+++ b/web_src/src/pages/factories/pages/settings/settings-redesign/useSettingsRedesignWorkspaceRepository.ts
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { usePermissions } from "@/contexts/usePermissions";
+import { resolveGithubDefaultBranch, useIntegrationResources } from "@/hooks/useIntegrations";
+import { getApiErrorMessage } from "@/lib/errors";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+
+import { useFactorySettingsLayout } from "../factorySettingsLayoutContext";
+import { useFactoryRepository } from "../useFactoryRepository";
+
+export function useSettingsRedesignWorkspaceRepository() {
+  const { organizationId, factoryId, factory } = useFactorySettingsLayout();
+  const { canAct, isLoading: permissionsLoading } = usePermissions();
+  const integrationId = factory.onboarding?.vcsIntegrationId ?? "";
+  const resources = useIntegrationResources(organizationId, integrationId, "repository");
+  const repositories = useMemo(() => namedRepositories(resources.data), [resources.data]);
+  const savedRepository = factory.onboarding?.appRepository ?? "";
+  const [repository, setRepository] = useState(savedRepository);
+  const [isResolvingDefaultBranch, setIsResolvingDefaultBranch] = useState(false);
+  const updateRepository = useFactoryRepository(organizationId, factoryId);
+  const canUpdate = canAct("factories", "update");
+  const isSaving = isResolvingDefaultBranch || updateRepository.isPending;
+  const canSave =
+    Boolean(repository) && repository !== savedRepository && canUpdate && !permissionsLoading && !isSaving;
+
+  useEffect(() => {
+    setRepository(savedRepository);
+  }, [savedRepository]);
+
+  return {
+    factoryName: factory.name ?? "Workspace",
+    integrationId,
+    repositories,
+    repository,
+    setRepository,
+    resourcesLoading: resources.isLoading,
+    resourcesError: resources.isError,
+    canUpdate,
+    permissionsLoading,
+    isSaving,
+    canSave,
+    save: () =>
+      void persistWorkspaceRepository({
+        organizationId,
+        integrationId,
+        repository,
+        isSaving,
+        mutate: (body) => updateRepository.mutateAsync(body),
+        setResolving: setIsResolvingDefaultBranch,
+      }),
+  };
+}
+
+function namedRepositories(resources: Array<{ name?: string; id?: string }> | undefined) {
+  return (resources ?? [])
+    .map((resource) => resource.name ?? resource.id ?? "")
+    .filter((repository): repository is string => Boolean(repository));
+}
+
+async function persistWorkspaceRepository({
+  organizationId,
+  integrationId,
+  repository,
+  isSaving,
+  mutate,
+  setResolving,
+}: {
+  organizationId: string;
+  integrationId: string;
+  repository: string;
+  isSaving: boolean;
+  mutate: (body: { repository: string; defaultBranch: string }) => Promise<unknown>;
+  setResolving: (value: boolean) => void;
+}) {
+  if (!repository || !integrationId || isSaving) return;
+  setResolving(true);
+  try {
+    const defaultBranch = await resolveGithubDefaultBranch(organizationId, integrationId, repository);
+    await mutate({ repository, defaultBranch });
+    showSuccessToast("Workspace repository updated.");
+  } catch (error) {
+    showErrorToast(getApiErrorMessage(error, "Failed to update workspace repository"));
+  } finally {
+    setResolving(false);
+  }
+}

--- a/web_src/src/pages/factories/pages/settings/settingsChromeContext.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsChromeContext.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from "react";
+
+/** Storybook-only: factory settings use the redesigned chrome and pages. */
+export const SettingsRedesignContext = createContext(false);
+
+export function useSettingsRedesign() {
+  return useContext(SettingsRedesignContext);
+}


### PR DESCRIPTION
## Summary

Factory settings stayed on the old pages while Storybook already showed the new chrome. Users could not use the redesign in the product.

This change serves the redesigned factory settings from the live app. Live pages call the real APIs. Storybook still uses fixtures for members, roles, invite links, and repositories.

## Test plan

- [ ] Open factory settings in the live app and walk Account, Workspace, and Organization pages.
- [ ] Edit workspace name and organization name, then save.
- [ ] Select a GitHub repository when GitHub is connected.
- [ ] Confirm Members loads live users, updates a role, and copies the invite link.
- [ ] Create an API key and a secret from factory settings.
- [ ] Click Delete organization and type the organization name in the dialog.
- [ ] Confirm Storybook factory settings stories still render with fixtures.


Made with [Cursor](https://cursor.com)