### PR TITLE
feat: Match settings pages to the Velocity layout

### DIFF
--- a/web_src/src/pages/factories/pages/AutomationsPage.tsx
+++ b/web_src/src/pages/factories/pages/AutomationsPage.tsx
@@ -5,7 +5,12 @@ import { useWorkOrderCardActions } from "@/hooks/useWorkOrderCardActions";
 import { Plus } from "lucide-react";
 import { CreateFactoryAppDialog } from "../CreateFactoryAppDialog";
 import { WorkspacePageHeader } from "../layout/WorkspacePageHeader";
-import { factorySectionBodyClassName, factorySectionHeaderClassName } from "./factoryPageLayoutStyles";
+import {
+  factorySectionBodyClassName,
+  factorySectionHeaderClassName,
+  factorySettingsSectionBodyClassName,
+  factorySettingsSectionHeaderClassName,
+} from "./factoryPageLayoutStyles";
 import { AutomationDetail } from "./AutomationDetail";
 import { AutomationsPageBody } from "./automationsPageBody";
 import { AutomationsLegacyRedirect } from "./automationsPageRedirect";
@@ -13,7 +18,20 @@ import { useAutomationsPageModel } from "./useAutomationsPageModel";
 import { useFactoryPullRequests } from "@/hooks/useFactoryData";
 import { usePRFeedbackWorkOrderAttention } from "./useWorkOrderPRFeedbackRunHref";
 
-export function AutomationsPage() {
+/**
+ * Where the page is mounted. The workspace route fills the whole pane, while
+ * the settings route shares the centered column of the other settings pages.
+ */
+export type AutomationsPageLayout = "workspace" | "settings";
+
+function layoutClassNames(layout: AutomationsPageLayout) {
+  if (layout === "settings") {
+    return { header: factorySettingsSectionHeaderClassName, body: factorySettingsSectionBodyClassName };
+  }
+  return { header: factorySectionHeaderClassName, body: factorySectionBodyClassName };
+}
+
+export function AutomationsPage({ layout = "workspace" }: { layout?: AutomationsPageLayout }) {
   const model = useAutomationsPageModel();
   const cardActions = useWorkOrderCardActions(model.organizationId, model.factoryId);
   const { data: pullRequests = [] } = useFactoryPullRequests(model.organizationId, model.factoryId);
@@ -74,10 +92,12 @@ export function AutomationsPage() {
     );
   }
 
+  const classNames = layoutClassNames(layout);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col pb-8" data-testid="automations-list-page">
       <WorkspacePageHeader
-        className={factorySectionHeaderClassName}
+        className={classNames.header}
         title="Automations"
         subtitle="Automations are one-step lines. Each one listens for a trigger and runs a canvas when it fires."
         actions={
@@ -99,7 +119,7 @@ export function AutomationsPage() {
         }
       />
 
-      <div className={factorySectionBodyClassName}>
+      <div className={classNames.body}>
         <AutomationsPageBody
           organizationId={model.organizationId}
           factoryKey={model.factoryKey}

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -136,7 +136,7 @@ function VelocityHeader({ model }: { model: VelocityPageModel }) {
 function VelocityHeaderBar({ model }: { model: VelocityPageModel }) {
   return (
     <WorkspacePageHeader
-      className={cn(factoryCenteredSectionHeaderClassName, "bg-transparent")}
+      className={factoryCenteredSectionHeaderClassName}
       title="Velocity"
       subtitle={
         model.repository

--- a/web_src/src/pages/factories/pages/factoryPageLayoutStyles.ts
+++ b/web_src/src/pages/factories/pages/factoryPageLayoutStyles.ts
@@ -6,9 +6,12 @@ const contentColumn = "mx-auto w-full max-w-[var(--workspace-content-max-width)]
  * Shell for the workspace page header: gutter, max width, vertical rhythm.
  * `WorkspacePageHeader` builds on this. Only reach for the class directly
  * when you cannot use the component (very rare — most pages should not).
+ *
+ * The header paints no background of its own, so it keeps the color of the
+ * page behind it. Pages on a gray canvas (Velocity, settings) need this.
  */
 export const factoryContentHeaderClassName = cn(
-  "bg-background px-[var(--workspace-page-gutter)] pt-10 pb-6",
+  "px-[var(--workspace-page-gutter)] pt-10 pb-6",
   contentColumn,
   "flex flex-col gap-3",
 );
@@ -43,6 +46,18 @@ export const factorySectionBodyClassName = cn("mx-0 max-w-none pt-0 pb-6 text-fo
 export const factoryCenteredSectionHeaderClassName = cn(factorySectionHeaderClassName, contentColumn, "pt-14");
 
 export const factoryCenteredSectionBodyClassName = cn(factorySectionBodyClassName, contentColumn);
+
+/**
+ * Settings variants. Same shape as the Velocity report — one centered column
+ * of white panels on a gray page — but a shorter column, because settings are
+ * forms: a label above a full-width input stays readable only at a short
+ * measure, while the report column is sized for charts.
+ */
+const settingsColumn = "mx-auto w-full max-w-3xl";
+
+export const factorySettingsSectionHeaderClassName = cn(factorySectionHeaderClassName, settingsColumn, "pt-14");
+
+export const factorySettingsSectionBodyClassName = cn(factorySectionBodyClassName, settingsColumn, "pb-10");
 
 /** Tasks / Lines kanban body: same gutter, fills leftover height. */
 export const factoryWorkOrdersBodyClassName = cn(

--- a/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsLayout.tsx
+++ b/web_src/src/pages/factories/pages/organizationSettings/OrganizationSettingsLayout.tsx
@@ -75,7 +75,7 @@ function OrganizationSettingsLayoutContent({ organizationId }: { organizationId:
           <SettingsNavGroup organizationId={organizationId} items={ORGANIZATION_SETTINGS_NAV_ITEMS} />
         </nav>
       </aside>
-      <main className="flex min-h-screen min-w-0 flex-1 flex-col bg-background">
+      <main className="flex min-h-screen min-w-0 flex-1 flex-col bg-sidebar dark:bg-background">
         <Outlet />
       </main>
     </div>

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsAutomationsPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsAutomationsPage.tsx
@@ -21,7 +21,7 @@ export function FactorySettingsAutomationsPage() {
         openCreateWorkOrder: () => undefined,
       }}
     >
-      <AutomationsPage />
+      <AutomationsPage layout="settings" />
     </FactoriesLayoutContext.Provider>
   );
 }

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsCard.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsCard.tsx
@@ -1,7 +1,11 @@
 import { cn } from "@/lib/utils";
 import type { ReactNode } from "react";
 import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
-import { factorySectionBodyClassName, factorySectionHeaderClassName } from "../factoryPageLayoutStyles";
+import {
+  factoryCardClassName,
+  factorySettingsSectionBodyClassName,
+  factorySettingsSectionHeaderClassName,
+} from "../factoryPageLayoutStyles";
 
 export function FactorySettingsPageFrame({
   title,
@@ -17,12 +21,12 @@ export function FactorySettingsPageFrame({
   return (
     <>
       <WorkspacePageHeader
-        className={factorySectionHeaderClassName}
+        className={factorySettingsSectionHeaderClassName}
         title={title}
         subtitle={subtitle}
         actions={actions}
       />
-      <div className={cn(factorySectionBodyClassName, "flex flex-col gap-8")}>{children}</div>
+      <div className={cn(factorySettingsSectionBodyClassName, "flex flex-col gap-5")}>{children}</div>
     </>
   );
 }
@@ -43,7 +47,7 @@ export function FactorySettingsCard({
   "data-testid"?: string;
 }) {
   return (
-    <section className={cn("rounded-lg border border-border p-4", className)} data-testid={testId}>
+    <section className={cn(factoryCardClassName, "p-4", className)} data-testid={testId}>
       {title || action ? (
         <div className="mb-3 flex items-center justify-between gap-3">
           {title ? (

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
@@ -175,8 +175,13 @@ function FactorySettingsLayoutContent({
                 ))}
               </nav>
             </aside>
+            {/*
+              Gray canvas behind white panels, like the Velocity report. Dark
+              mode keeps the darker page, because the factories theme paints
+              the sidebar and the panels the same color.
+            */}
             <main
-              className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto bg-background"
+              className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto bg-sidebar dark:bg-background"
               data-testid="factory-settings-main"
             >
               <Outlet />

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsUsagePage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsUsagePage.tsx
@@ -10,8 +10,8 @@ import { getApiErrorMessage } from "@/lib/errors";
 import { centsToDollarInput, parseDollarInputToCents } from "@/lib/hostedCredit";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { formatUsdCents, parseWorkOrderMetric } from "../../lib/workOrderUsage";
-import { WorkspacePageHeader } from "../../layout/WorkspacePageHeader";
-import { factoryCardClassName, factoryContentBodyClassName } from "../factoryPageLayoutStyles";
+import { factoryCardClassName } from "../factoryPageLayoutStyles";
+import { FactorySettingsPageFrame } from "./FactorySettingsCard";
 import { HostedCreditSummary } from "@/pages/organization/settings/HostedCreditSummary";
 import {
   WorkspaceUsageByMachineTypeTable,
@@ -29,15 +29,12 @@ export function FactorySettingsUsagePage() {
   usePageTitle(["Spending", "Settings", factory.name ?? "Workspace"]);
 
   return (
-    <>
-      <WorkspacePageHeader
-        title="Spending"
-        subtitle="LLM tokens, VM seconds, and estimated spend for this workspace."
-      />
-      <div className={factoryContentBodyClassName}>
-        <FactorySettingsUsageBody data={data} error={error} isLoading={isLoading} />
-      </div>
-    </>
+    <FactorySettingsPageFrame
+      title="Spending"
+      subtitle="LLM tokens, VM seconds, and estimated spend for this workspace."
+    >
+      <FactorySettingsUsageBody data={data} error={error} isLoading={isLoading} />
+    </FactorySettingsPageFrame>
   );
 }
 

--- a/web_src/src/pages/factories/pages/settings/account-profile-redesign/AccountProfileRedesignShell.tsx
+++ b/web_src/src/pages/factories/pages/settings/account-profile-redesign/AccountProfileRedesignShell.tsx
@@ -154,7 +154,7 @@ export function AccountProfileRedesignShell({
           })}
         </nav>
       </aside>
-      <main className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-background">{children}</main>
+      <main className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-sidebar dark:bg-background">{children}</main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The workspace settings pages used a white, full-width pane. The Velocity report uses a gray page that holds white panels in one centered column. Both surfaces sit behind the same sidebar, so the difference looked accidental.

Settings pages now use the Velocity shape: a gray canvas, opaque white panels, and one centered column. The column is shorter than the report column, because settings are forms and a label above a full-width input stays readable only at a short measure.

Two supporting changes were necessary:

- The shared workspace header no longer paints its own background, so it keeps the color of the page behind it. Every other workspace page sits on a white pane, so the result there does not change.
- The Automations page is mounted both on the workspace route and in settings. It now takes a layout prop, so the settings route gets the centered column and the workspace route keeps the full pane.

Known gap: Members, API keys, and Secrets embed older organization components. Their panels stay semi-transparent, because those styles are shared with the legacy organization settings shell.

## Test plan

- [ ] Open workspace settings. Confirm the page is gray and the panels are white and centered.
- [ ] Open each Account, Workspace, and Organization settings section. Confirm the column width and the top spacing match.
- [ ] Open settings Automations. Confirm the list is centered and aligns with the other settings pages.
- [ ] Open the workspace Automations route. Confirm the list still fills the pane.
- [ ] Open Velocity and Overview. Confirm no visual change.
- [ ] Switch to dark mode. Confirm the settings page stays darker than the panels.

Made with [Cursor](https://cursor.com)