### PR TITLE
feat: Report velocity summary per task

### DIFF
--- a/pkg/grpc/actions/factories/describe_factory_velocity.go
+++ b/pkg/grpc/actions/factories/describe_factory_velocity.go
@@ -306,6 +306,10 @@ type dayBucket struct {
 	costCents      int64
 	tokens         int64
 	wasteCostCents int64
+	// Work orders reported on the day. A work order counts once here, however
+	// many pull requests it opened.
+	tasksClosed int
+	tasksWaste  int
 }
 
 // dayLabel names the axis tick of a day, as a weekday and a date.
@@ -463,7 +467,9 @@ func fillBuckets(
 		}
 		buckets[idx].costCents += order.costCents
 		buckets[idx].tokens += order.tokens
+		buckets[idx].tasksClosed++
 		if !order.merged {
+			buckets[idx].tasksWaste++
 			buckets[idx].wasteCostCents += order.costCents
 		}
 	}
@@ -489,6 +495,7 @@ func fillBuckets(
 
 func aggregateTotals(buckets []dayBucket, hasPeople bool) *pb.DescribeFactoryVelocityTotals {
 	sp, people, waste := 0, 0, 0
+	tasksClosed, tasksWaste := 0, 0
 	var costCents, tokens, wasteCostCents int64
 	for _, b := range buckets {
 		sp += b.superplaneMerged
@@ -499,6 +506,8 @@ func aggregateTotals(buckets []dayBucket, hasPeople bool) *pb.DescribeFactoryVel
 		costCents += b.costCents
 		tokens += b.tokens
 		wasteCostCents += b.wasteCostCents
+		tasksClosed += b.tasksClosed
+		tasksWaste += b.tasksWaste
 	}
 
 	totals := &pb.DescribeFactoryVelocityTotals{
@@ -508,6 +517,8 @@ func aggregateTotals(buckets []dayBucket, hasPeople bool) *pb.DescribeFactoryVel
 		CostCents:        costCents,
 		Tokens:           tokens,
 		WasteCostCents:   wasteCostCents,
+		TasksClosed:      int32(tasksClosed),
+		TasksWaste:       int32(tasksWaste),
 	}
 	totalMerged := sp + people
 	if totalMerged > 0 && hasPeople {

--- a/pkg/grpc/actions/factories/describe_factory_velocity_test.go
+++ b/pkg/grpc/actions/factories/describe_factory_velocity_test.go
@@ -411,6 +411,8 @@ func TestFillBuckets_CountsIntakeAndChargesOrdersOnce(t *testing.T) {
 	assert.Equal(t, 2, last.intake[models.FactoryIntakeSourceGitHubIssues])
 	assert.Equal(t, int64(250), last.costCents, "the order is charged once")
 	assert.Equal(t, int64(1200), last.tokens)
+	assert.Equal(t, 1, last.tasksClosed, "two pull requests of one order are one task")
+	assert.Zero(t, last.tasksWaste)
 	assert.Zero(t, last.wasteCostCents)
 }
 
@@ -436,12 +438,14 @@ func TestFillBuckets_ChargesWasteCost(t *testing.T) {
 	last := buckets[len(buckets)-1]
 	assert.Equal(t, int64(180), last.costCents)
 	assert.Equal(t, int64(180), last.wasteCostCents, "spend on an unmerged close is waste")
+	assert.Equal(t, 1, last.tasksClosed)
+	assert.Equal(t, 1, last.tasksWaste, "a task that closed without a merge is waste")
 }
 
 func TestAggregateTotals(t *testing.T) {
 	buckets := []dayBucket{
-		{superplaneMerged: 3, peopleMerged: 1, waste: 1, costCents: 400, tokens: 900, wasteCostCents: 100},
-		{superplaneMerged: 1, peopleMerged: 3, waste: 0, costCents: 200, tokens: 300},
+		{superplaneMerged: 3, peopleMerged: 1, waste: 1, costCents: 400, tokens: 900, wasteCostCents: 100, tasksClosed: 3, tasksWaste: 1},
+		{superplaneMerged: 1, peopleMerged: 3, waste: 0, costCents: 200, tokens: 300, tasksClosed: 1},
 	}
 	got := aggregateTotals(buckets, true)
 	assert.Equal(t, int32(4), got.SuperplaneMerged)
@@ -452,6 +456,8 @@ func TestAggregateTotals(t *testing.T) {
 	assert.Equal(t, int64(600), got.CostCents)
 	assert.Equal(t, int64(1200), got.Tokens)
 	assert.Equal(t, int64(100), got.WasteCostCents)
+	assert.Equal(t, int32(4), got.TasksClosed)
+	assert.Equal(t, int32(1), got.TasksWaste)
 
 	gotNoPeople := aggregateTotals(buckets, false)
 	assert.Equal(t, int32(0), gotNoPeople.PeopleMerged)
@@ -562,6 +568,52 @@ func TestDescribeFactoryVelocity_ReportsIntakeAndPeople(t *testing.T) {
 	assert.Equal(t, r.User.String(), resp.People[0].Id)
 	assert.Equal(t, int32(1), resp.People[0].FactoryMerged)
 	assert.Equal(t, int32(0), resp.People[0].AuthoredMerged)
+}
+
+func TestDescribeFactoryVelocity_CountsTasksApartFromPullRequests(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	db := database.DB(t.Context())
+
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+
+	now := time.Now()
+	mergedAt := now.Add(-3 * time.Hour)
+	merged, err := factoryModel.CreateWorkOrder(db, "Merged order", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	for _, url := range []string{
+		"https://github.com/example/repo/pull/1",
+		"https://github.com/example/repo/pull/2",
+	} {
+		_, err = merged.CreatePullRequest(db, models.FactoryPullRequestParams{
+			URL:      url,
+			State:    models.FactoryPullRequestStateMerged,
+			MergedAt: &mergedAt,
+		})
+		require.NoError(t, err)
+	}
+
+	closedAt := now.Add(-2 * time.Hour)
+	wasted, err := factoryModel.CreateWorkOrder(db, "Closed order", "", &r.User, nil, nil)
+	require.NoError(t, err)
+	_, err = wasted.CreatePullRequest(db, models.FactoryPullRequestParams{
+		URL:      "https://github.com/example/repo/pull/3",
+		State:    models.FactoryPullRequestStateClosed,
+		ClosedAt: &closedAt,
+	})
+	require.NoError(t, err)
+
+	resp, err := DescribeFactoryVelocity(ctx, r.Organization.ID.String(), &pb.DescribeFactoryVelocityRequest{
+		FactoryId:  factoryModel.ID.String(),
+		PeriodDays: 7,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), resp.Totals.SuperplaneMerged, "both pull requests of the merged order count")
+	assert.Equal(t, int32(1), resp.Totals.Waste)
+	assert.Equal(t, int32(2), resp.Totals.TasksClosed, "the merged order counts once, however many pull requests it opened")
+	assert.Equal(t, int32(1), resp.Totals.TasksWaste)
 }
 
 func seedPRArtifact(t *testing.T, factoryModel *models.Factory, url string, state string, at time.Time) *models.FactoryPullRequest {

--- a/protos/factories.proto
+++ b/protos/factories.proto
@@ -1762,6 +1762,12 @@ message DescribeFactoryVelocityTotals {
   int64 tokens = 7;
   // Part of `cost_cents` spent on work orders that closed without a merge.
   int64 waste_cost_cents = 8;
+  // Work orders (tasks) that closed in the window. A work order counts once,
+  // even when it opened several pull requests, which is why this differs from
+  // the pull request counts above.
+  int32 tasks_closed = 9;
+  // Part of `tasks_closed` whose pull requests all closed without a merge.
+  int32 tasks_waste = 10;
 }
 
 // Trailing 30-day line summary nested on FactoryLine.

--- a/web_src/src/pages/factories/__fixtures__/velocityReportFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/velocityReportFixtures.ts
@@ -96,6 +96,9 @@ function sumTotals(points: Point[]) {
     costCents: String(costCents),
     tokens: String(tokens),
     wasteCostCents: String(wasteCostCents),
+    // Every pull request of these payloads comes from a task of its own.
+    tasksClosed: superplaneMerged + waste,
+    tasksWaste: waste,
   };
 }
 
@@ -190,6 +193,8 @@ export const EMPTY_FACTORY_VELOCITY: FactoriesDescribeFactoryVelocityResponse = 
     costCents: "0",
     tokens: "0",
     wasteCostCents: "0",
+    tasksClosed: 0,
+    tasksWaste: 0,
   },
   points: Array.from({ length: 14 }, (_, index) => ({
     day: dayLabel(index, 14),

--- a/web_src/src/pages/factories/lib/factoryVelocityReport.spec.ts
+++ b/web_src/src/pages/factories/lib/factoryVelocityReport.spec.ts
@@ -17,6 +17,9 @@ const RESPONSE: FactoriesDescribeFactoryVelocityResponse = {
     costCents: "12000",
     tokens: "450000",
     wasteCostCents: "2500",
+    // Fewer tasks than pull request closes: one task merged two pull requests.
+    tasksClosed: 24,
+    tasksWaste: 6,
   },
   previousTotals: {
     superplaneMerged: 10,
@@ -26,6 +29,8 @@ const RESPONSE: FactoriesDescribeFactoryVelocityResponse = {
     costCents: "9000",
     tokens: "300000",
     wasteCostCents: "3000",
+    tasksClosed: 15,
+    tasksWaste: 6,
   },
   hasPreviousWindow: true,
   points: [
@@ -73,28 +78,31 @@ describe("toVelocityReport", () => {
     expect(report.totals.superplaneMerged).toBe(20);
   });
 
-  it("converts cents to dollars and derives cost per SuperPlane merge", () => {
+  it("converts cents to dollars and spreads spend over the closed tasks", () => {
     const report = toVelocityReport(RESPONSE);
 
     expect(report.totals.costUsd).toBe(120);
     expect(report.totals.wasteCostUsd).toBe(25);
     expect(report.totals.tokens).toBe(450_000);
-    expect(report.totals.costPerMerge).toBe(6);
+    expect(report.totals.costPerTask).toBe(5);
   });
 
-  it("keeps the waste rate the API reports", () => {
+  it("counts tasks apart from the pull requests they opened", () => {
     const report = toVelocityReport(RESPONSE);
 
-    expect(report.totals.wasteRate).toBe(20);
+    expect(report.totals.tasksClosed).toBe(24);
+    expect(report.totals.tasksWaste).toBe(6);
+    expect(report.totals.taskWasteRate).toBe(25);
   });
 
-  it("derives the waste rate when the API omits it", () => {
+  it("reports no task waste and no cost per task when no task closed", () => {
     const report = toVelocityReport({
       ...RESPONSE,
-      totals: { superplaneMerged: 3, peopleMerged: 0, waste: 1 },
+      totals: { superplaneMerged: 3, peopleMerged: 0, waste: 1, costCents: "5000" },
     });
 
-    expect(report.totals.wasteRate).toBe(25);
+    expect(report.totals.taskWasteRate).toBe(0);
+    expect(report.totals.costPerTask).toBe(0);
   });
 
   it("reports no previous totals when the API has no earlier window", () => {
@@ -107,7 +115,7 @@ describe("toVelocityReport", () => {
     const report = toVelocityReport(RESPONSE);
 
     expect(report.previous?.merged).toBe(35);
-    expect(report.previous?.costPerMerge).toBe(9);
+    expect(report.previous?.costPerTask).toBe(6);
   });
 
   it("keys the intake counts of a day by source", () => {
@@ -150,6 +158,7 @@ describe("toVelocityReport", () => {
     const report = toVelocityReport({});
 
     expect(report.totals.merged).toBe(0);
+    expect(report.totals.tasksClosed).toBe(0);
     expect(report.points).toEqual([]);
     expect(report.intakeSeries).toEqual([]);
     expect(report.people).toEqual([]);

--- a/web_src/src/pages/factories/lib/factoryVelocityReport.ts
+++ b/web_src/src/pages/factories/lib/factoryVelocityReport.ts
@@ -57,12 +57,21 @@ export interface VelocityTotals {
   peopleMerged: number;
   superplaneMerged: number;
   waste: number;
-  /** Waste as a share of SuperPlane closes, 0-100. */
-  wasteRate: number;
   costUsd: number;
   wasteCostUsd: number;
   tokens: number;
-  costPerMerge: number;
+  /**
+   * Tasks that closed in the window, with or without a merge. A task counts
+   * once, however many pull requests it opened, so this differs from the pull
+   * request counts above.
+   */
+  tasksClosed: number;
+  /** Part of `tasksClosed` that closed without a merge. */
+  tasksWaste: number;
+  /** Waste as a share of closed tasks, 0-100. */
+  taskWasteRate: number;
+  /** Tracked model spend divided by the tasks that closed. */
+  costPerTask: number;
 }
 
 export interface VelocityIntakeSeries {
@@ -106,10 +115,10 @@ function centsToUsd(value: string | number | undefined): number {
   return parseWorkOrderMetric(value) / 100;
 }
 
-function wasteRate(superplaneMerged: number, waste: number): number {
-  const closes = superplaneMerged + waste;
-  if (closes <= 0) return 0;
-  return Math.round((waste / closes) * 100);
+/** Rounded share of `whole` that `part` holds, 0-100. */
+function sharePct(part: number, whole: number): number {
+  if (whole <= 0) return 0;
+  return Math.round((part / whole) * 100);
 }
 
 function toTotals(totals: FactoriesDescribeFactoryVelocityTotals | undefined): VelocityTotals {
@@ -117,17 +126,21 @@ function toTotals(totals: FactoriesDescribeFactoryVelocityTotals | undefined): V
   const peopleMerged = totals?.peopleMerged ?? 0;
   const waste = totals?.waste ?? 0;
   const costUsd = centsToUsd(totals?.costCents);
+  const tasksClosed = totals?.tasksClosed ?? 0;
+  const tasksWaste = totals?.tasksWaste ?? 0;
 
   return {
     merged: peopleMerged + superplaneMerged,
     peopleMerged,
     superplaneMerged,
     waste,
-    wasteRate: totals?.wastePct ?? wasteRate(superplaneMerged, waste),
     costUsd,
     wasteCostUsd: centsToUsd(totals?.wasteCostCents),
     tokens: parseWorkOrderMetric(totals?.tokens),
-    costPerMerge: superplaneMerged > 0 ? costUsd / superplaneMerged : 0,
+    tasksClosed,
+    tasksWaste,
+    taskWasteRate: sharePct(tasksWaste, tasksClosed),
+    costPerTask: tasksClosed > 0 ? costUsd / tasksClosed : 0,
   };
 }
 

--- a/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
 import type { FactoriesDescribeFactoryVelocityResponse, FactoriesFactory, FactoriesWorkOrder } from "@/api-client";
+import { TooltipProvider } from "@/ui/tooltip";
 
 import { PRIMARY_FACTORY_ID, PRIMARY_FACTORY_KEY, REFUND_FACTORY } from "../__fixtures__/factoryPageResponses";
 import { FactoriesLayoutContext } from "../layout/factoriesLayoutContext";
@@ -74,6 +75,8 @@ function populatedResponse(
       costCents: "4200",
       tokens: "185000",
       wasteCostCents: "900",
+      tasksClosed: 16,
+      tasksWaste: 4,
     },
     points: [
       { day: "1", superplaneMerged: 2, peopleMerged: 1, waste: 1, costCents: "800", tokens: "20000" },
@@ -87,20 +90,22 @@ function populatedResponse(
 function renderShell(factory: FactoriesFactory = REFUND_FACTORY) {
   return render(
     <QueryClientProvider client={new QueryClient()}>
-      <MemoryRouter initialEntries={["/velocity"]}>
-        <FactoriesLayoutContext.Provider
-          value={{
-            organizationId: "org-1",
-            factoryId: PRIMARY_FACTORY_ID,
-            factoryKey: PRIMARY_FACTORY_KEY,
-            factory,
-            factories: [factory],
-            openCreateWorkOrder: vi.fn(),
-          }}
-        >
-          <VelocityPage />
-        </FactoriesLayoutContext.Provider>
-      </MemoryRouter>
+      <TooltipProvider delayDuration={0}>
+        <MemoryRouter initialEntries={["/velocity"]}>
+          <FactoriesLayoutContext.Provider
+            value={{
+              organizationId: "org-1",
+              factoryId: PRIMARY_FACTORY_ID,
+              factoryKey: PRIMARY_FACTORY_KEY,
+              factory,
+              factories: [factory],
+              openCreateWorkOrder: vi.fn(),
+            }}
+          >
+            <VelocityPage />
+          </FactoriesLayoutContext.Provider>
+        </MemoryRouter>
+      </TooltipProvider>
     </QueryClientProvider>,
   );
 }
@@ -225,16 +230,48 @@ describe("VelocityPage shell", () => {
     expect(screen.getByTestId("workspace-page-header-subtitle")).toHaveTextContent("acme/api");
   });
 
-  it("sums people and SuperPlane merges into the headline number", () => {
+  it("leads with the tasks that closed and the share of them that wasted", () => {
     resetState();
     velocityHookState.data = populatedResponse();
 
     renderShell();
 
     const summary = screen.getByTestId("velocity-summary");
-    expect(summary).toHaveTextContent("Merged PRs");
-    expect(summary).toHaveTextContent("20");
+    expect(summary).toHaveTextContent("Tasks closed");
+    expect(summary).toHaveTextContent("16");
+    expect(summary).toHaveTextContent("Task waste");
     expect(summary).toHaveTextContent("25%");
+    expect(summary).not.toHaveTextContent("4 tasks closed without a merge");
+    expect(screen.getByRole("button", { name: "About Tasks closed" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "About Task waste" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "About Median cycle time" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "About Cost per task" })).toBeInTheDocument();
+  });
+
+  it("hides the metric explanations behind info tooltips", async () => {
+    resetState();
+    velocityHookState.data = populatedResponse();
+    const user = userEvent.setup();
+
+    renderShell();
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await user.hover(screen.getByRole("button", { name: "About Task waste" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("4 tasks closed without a merge");
+  });
+
+  it("spreads tracked spend over the tasks that closed", () => {
+    resetState();
+    velocityHookState.data = populatedResponse();
+
+    renderShell();
+
+    const summary = screen.getByTestId("velocity-summary");
+    expect(summary).toHaveTextContent("Cost per task");
+    // $42.00 of spend over 16 closed tasks.
+    expect(summary).toHaveTextContent("$2.63");
   });
 
   it("compares against the previous window when it holds output", () => {
@@ -248,6 +285,8 @@ describe("VelocityPage shell", () => {
         superplaneSharePct: 50,
         wastePct: 50,
         costCents: "3000",
+        tasksClosed: 12,
+        tasksWaste: 6,
       },
     });
 
@@ -255,7 +294,7 @@ describe("VelocityPage shell", () => {
 
     const summary = screen.getByTestId("velocity-summary");
     expect(summary).toHaveTextContent("Compared with the previous 14 days");
-    // Waste fell from 50% to 25% of SuperPlane closes.
+    // Waste fell from 50% to 25% of the tasks that closed.
     expect(summary).toHaveTextContent("25 pp");
   });
 

--- a/web_src/src/pages/factories/pages/useVelocityPageModel.ts
+++ b/web_src/src/pages/factories/pages/useVelocityPageModel.ts
@@ -146,10 +146,10 @@ export function useVelocityPageModel(
 }
 
 /**
- * Deltas are reported per metric, because their baselines differ: merges and
- * spend need the previous API window, while cycle time needs closed tasks in
- * that window. A metric with no baseline shows no chip at all, which is
- * honest about a workspace that only started last week.
+ * Deltas are reported per metric, because their baselines differ: task counts
+ * and spend need the previous API window, while cycle time is measured from the
+ * work orders themselves. A metric with no baseline shows no chip at all, which
+ * is honest about a workspace that only started last week.
  */
 function buildComparison(
   report: VelocityReport | undefined,
@@ -161,9 +161,9 @@ function buildComparison(
 
   const previous = report.previous;
   if (previous) {
-    comparison.merged = report.totals.merged - previous.merged;
-    comparison.wasteRate = report.totals.wasteRate - previous.wasteRate;
-    comparison.costPerMerge = round(report.totals.costPerMerge - previous.costPerMerge, 2);
+    comparison.tasksClosed = report.totals.tasksClosed - previous.tasksClosed;
+    comparison.taskWasteRate = report.totals.taskWasteRate - previous.taskWasteRate;
+    comparison.costPerTask = round(report.totals.costPerTask - previous.costPerTask, 2);
   }
 
   if (flow && previousFlow && flow.sampleSize > 0 && previousFlow.sampleSize > 0) {

--- a/web_src/src/pages/factories/pages/velocityCards.tsx
+++ b/web_src/src/pages/factories/pages/velocityCards.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from "react";
-import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { ArrowDownRight, ArrowUpRight, Info } from "lucide-react";
 
 import { formatCompactTokenValue } from "@/lib/formatTokenCount";
 import { cn } from "@/lib/utils";
 import { SegmentedNav } from "@/ui/SegmentedNav";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
 
 import { formatDurationHours, type FactoryVelocityFlow } from "../lib/factoryVelocityFlow";
 import {
@@ -71,16 +72,36 @@ function Metric({
   label,
   value,
   hint,
+  tooltip,
   change,
 }: {
   label: string;
   value: string;
   hint?: string;
+  tooltip?: string;
   change?: MetricChange;
 }) {
   return (
     <div className="min-w-0">
-      <p className="text-[12px] text-muted-foreground">{label}</p>
+      <div className="flex items-center gap-1">
+        <p className="text-[12px] text-muted-foreground">{label}</p>
+        {tooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
+                aria-label={`About ${label}`}
+              >
+                <Info className="size-3.5" aria-hidden />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+              {tooltip}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+      </div>
       <div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
         <p className="text-[30px] leading-none font-semibold tracking-[-0.04em] tabular-nums text-foreground">
           {value}
@@ -119,10 +140,10 @@ function ChartEmptyNote({ children }: { children: ReactNode }) {
  * before this one holds no comparable sample.
  */
 export interface VelocityComparison {
-  merged?: number;
-  wasteRate?: number;
+  tasksClosed?: number;
+  taskWasteRate?: number;
   cycleHours?: number;
-  costPerMerge?: number;
+  costPerTask?: number;
 }
 
 export function SummaryCard({
@@ -142,29 +163,29 @@ export function SummaryCard({
       <p className="text-[12px] text-muted-foreground">{caption}</p>
       <div className="mt-4 grid grid-cols-2 gap-x-8 gap-y-6 lg:grid-cols-4">
         <Metric
-          label="Merged PRs"
-          value={String(totals.merged)}
-          hint="People and SuperPlane"
+          label="Tasks closed"
+          value={String(totals.tasksClosed)}
+          tooltip="Finished, with or without a result"
           change={
-            comparison?.merged === undefined
+            comparison?.tasksClosed === undefined
               ? undefined
-              : buildChange(comparison.merged, "up", (magnitude) => String(magnitude))
+              : buildChange(comparison.tasksClosed, "up", (magnitude) => String(magnitude))
           }
         />
         <Metric
-          label="SuperPlane waste"
-          value={`${totals.wasteRate}%`}
-          hint={`${totals.waste} ${totals.waste === 1 ? "PR" : "PRs"} closed without merge`}
+          label="Task waste"
+          value={`${totals.taskWasteRate}%`}
+          tooltip={`${totals.tasksWaste} ${totals.tasksWaste === 1 ? "task" : "tasks"} closed without a merge`}
           change={
-            comparison?.wasteRate === undefined
+            comparison?.taskWasteRate === undefined
               ? undefined
-              : buildChange(comparison.wasteRate, "down", (magnitude) => `${magnitude} pp`)
+              : buildChange(comparison.taskWasteRate, "down", (magnitude) => `${magnitude} pp`)
           }
         />
         <Metric
           label="Median cycle time"
           value={medianCycleHours === undefined ? "—" : formatDurationHours(medianCycleHours)}
-          hint="From task start to close"
+          tooltip="From task start to close"
           change={
             comparison?.cycleHours === undefined
               ? undefined
@@ -172,13 +193,13 @@ export function SummaryCard({
           }
         />
         <Metric
-          label="Cost per SuperPlane merge"
-          value={formatUsd(totals.costPerMerge)}
-          hint="Tracked model spend"
+          label="Cost per task"
+          value={formatUsd(totals.costPerTask)}
+          tooltip="Tracked model spend"
           change={
-            comparison?.costPerMerge === undefined
+            comparison?.costPerTask === undefined
               ? undefined
-              : buildChange(comparison.costPerMerge, "down", (magnitude) => `$${magnitude.toFixed(2)}`)
+              : buildChange(comparison.costPerTask, "down", (magnitude) => `$${magnitude.toFixed(2)}`)
           }
         />
       </div>


### PR DESCRIPTION
## Summary

The Velocity summary answered questions about pull requests, but the unit of
work in a factory is a task. One task can open more than one pull request, and
the cost card divided tracked spend by merges, so the headline number did not
tell the reader what one task costs.

The velocity API now reports the tasks that closed in the window and the part
of them that closed without a merge. A task counts once, however many pull
requests it opened, so these counts differ from the pull request counts on
purpose. The four summary cards now read: tasks closed, task waste, median
cycle time, and cost per task.

Each card explains itself in an info tooltip next to its label. The microcopy
under the numbers made the row hard to scan.

The first card no longer adds people merges to SuperPlane merges, because a
people merge has no task behind it. The comparison between people and
SuperPlane stays in the delivery chart and in the People table.

## Test plan

- [ ] Open Velocity for a workspace with closed tasks. Confirm the four cards
      show tasks closed, task waste, median cycle time, and cost per task.
- [ ] Confirm one task with two merged pull requests counts once in
      `Tasks closed`.
- [ ] Confirm `Cost per task` equals the tracked spend divided by the tasks
      that closed.
- [ ] Hover the info icon of each card. Confirm the explanation appears and no
      text sits under the numbers.
- [ ] Select the 30 day period. Confirm the change chips compare against the
      earlier window.
- [ ] Open a new workspace with no closed task. Confirm the page shows the zero
      state and no card shows a wrong number.

Made with [Cursor](https://cursor.com)