### PR TITLE
fix: Stop Lines board column color flicker after save

### DIFF
--- a/web_src/src/hooks/useFactoryData.ts
+++ b/web_src/src/hooks/useFactoryData.ts
@@ -672,7 +672,16 @@ export function useUpdateFactoryLine(organizationId: string, factoryId: string) 
       }
       return response.data.line;
     },
-    onSuccess: () => {
+    onSuccess: (line) => {
+      queryClient.setQueryData<FactoriesFactory>(factoryDetailKey(organizationId, factoryId), (current) => {
+        if (!current?.lines) {
+          return current;
+        }
+        return {
+          ...current,
+          lines: current.lines.map((existing) => (existing.id === line.id ? line : existing)),
+        };
+      });
       void queryClient.invalidateQueries({ queryKey: factoryDetailKey(organizationId, factoryId) });
     },
   });

--- a/web_src/src/pages/factories/pages/LinesPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.spec.tsx
@@ -42,6 +42,7 @@ function renderLinesBoard(
 
 const createFactoryLineMutateAsync = vi.fn();
 const updateFactoryLineMutateAsync = vi.fn();
+const updateLineIsPending = vi.hoisted(() => ({ value: false }));
 const useFactoryWorkOrders = vi.fn(() => ({ data: [] as FactoriesWorkOrder[] }));
 const useFactoryApps = vi.fn(() => ({ data: [] as FactoryApp[] }));
 const useFactoryIntakes = vi.fn(() => ({ data: [] as FactoriesFactoryIntake[] }));
@@ -82,7 +83,12 @@ vi.mock("@/hooks/useFactoryData", () => ({
   useFactoryWorkOrders: () => useFactoryWorkOrders(),
   useFactoryApps: () => useFactoryApps(),
   useCreateFactoryLine: () => ({ mutateAsync: createFactoryLineMutateAsync, isPending: false }),
-  useUpdateFactoryLine: () => ({ mutateAsync: updateFactoryLineMutateAsync, isPending: false }),
+  useUpdateFactoryLine: () => ({
+    mutateAsync: updateFactoryLineMutateAsync,
+    get isPending() {
+      return updateLineIsPending.value;
+    },
+  }),
   useWorkOrderEvents: () => ({ data: { pages: [] } }),
   useWorkOrderArtifacts: () => ({ data: [] }),
   useFactoryPullRequests: () => ({ data: [] }),
@@ -175,6 +181,7 @@ async function resetLinesBoardMocks() {
   const { DEFAULT_CHECKS_BY_ORDER_ID } = await import("../__fixtures__/workOrderCheckFixtures");
   window.localStorage.clear();
   updateFactoryLineMutateAsync.mockReset();
+  updateLineIsPending.value = false;
   useFactoryWorkOrders.mockReturnValue({ data: [] });
   useFactoryApps.mockReturnValue({ data: [] });
   useFactoryIntakes.mockReturnValue({ data: [] });
@@ -755,7 +762,10 @@ describe("LinesPage board editing", () => {
   });
 
   it("picking a color saves it on the line and updates the lane immediately", async () => {
-    updateFactoryLineMutateAsync.mockResolvedValueOnce({});
+    updateFactoryLineMutateAsync.mockResolvedValueOnce({
+      id: REFUND_LINE_PLAN_ID,
+      columnColors: { backlog: "lime", "phase-0": "sky" },
+    });
     const user = userEvent.setup();
     renderLinesBoard();
 
@@ -767,6 +777,44 @@ describe("LinesPage board editing", () => {
         lineId: REFUND_LINE_PLAN_ID,
         columnColors: { backlog: "lime", "phase-0": "sky" },
       });
+    });
+
+    const phaseLane = screen.getByTestId("lines-phase-column-0");
+    for (const className of lineBoardColumnLaneClassName("sky")!.split(" ")) {
+      expect(phaseLane).toHaveClass(className);
+    }
+  });
+
+  it("keeps the picked color when the save completes before the factory refetch", async () => {
+    const view = renderLinesBoard();
+    updateFactoryLineMutateAsync.mockImplementation(async (input) => {
+      updateLineIsPending.value = true;
+      view.rerender(
+        <LinesBoardSpecHarness
+          path={`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`}
+          factory={REFUND_FACTORY}
+        />,
+      );
+      await Promise.resolve();
+      updateLineIsPending.value = false;
+      view.rerender(
+        <LinesBoardSpecHarness
+          path={`/org-1/workspaces/${PRIMARY_FACTORY_KEY}/lines/${REFUND_LINE_PLAN_ID}`}
+          factory={REFUND_FACTORY}
+        />,
+      );
+      return {
+        id: REFUND_LINE_PLAN_ID,
+        columnColors: input.columnColors,
+      };
+    });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("lines-phase-menu-0"));
+    await user.click(screen.getByTestId("lines-phase-menu-0-color-sky"));
+
+    await waitFor(() => {
+      expect(updateFactoryLineMutateAsync).toHaveBeenCalled();
     });
 
     const phaseLane = screen.getByTestId("lines-phase-column-0");

--- a/web_src/src/pages/factories/pages/LinesPage.tsx
+++ b/web_src/src/pages/factories/pages/LinesPage.tsx
@@ -859,17 +859,23 @@ function PhaseBoard({
         })
       : undefined;
 
-  // The line query is the source of truth for persisted colors. Resync
-  // when it refetches, but skip while a color save is in flight so a
-  // stale cache cannot wipe the optimistic lane color.
+  // The line query is the source of truth for persisted colors. Resync when
+  // it changes, but skip while a color save is in flight so a stale refetch
+  // cannot wipe the optimistic lane color. Do not depend on isPending here:
+  // when a save finishes, isPending flips before the factory query refetch
+  // lands and would briefly restore the previous color.
   useEffect(() => {
     if (updateLine.isPending) {
       return;
     }
     const next = normalizeColumnColors(line.columnColors);
+    if (serializeColumnColors(next) === serializeColumnColors(columnColorsRef.current)) {
+      return;
+    }
     columnColorsRef.current = next;
     setColumnColors(next);
-  }, [line.columnColors, updateLine.isPending]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- isPending must not trigger resync; see comment above
+  }, [line.columnColors]);
 
   const setColumnColor = useCallback(
     async (columnKey: string, colorId: LineBoardColumnColorId | null) => {
@@ -882,10 +888,13 @@ function PhaseBoard({
         return;
       }
       try {
-        await updateLine.mutateAsync({
+        const updatedLine = await updateLine.mutateAsync({
           lineId,
           columnColors: serializeColumnColors(nextColors),
         });
+        const persisted = normalizeColumnColors(updatedLine.columnColors);
+        columnColorsRef.current = persisted;
+        setColumnColors(persisted);
       } catch (error) {
         columnColorsRef.current = previousColors;
         setColumnColors(previousColors);


### PR DESCRIPTION
## Summary

After #7061, changing a Lines board column color briefly showed the new
color, flashed the old color, then showed the new color again. The resync
effect ran when the save finished while the factory query still held stale
`columnColors`.

This change patches the factory cache from the update response, syncs local
lane state from that response, and resyncs from the server only when
`line.columnColors` changes (not when `isPending` flips).

Fixes the flicker reported on #7061.

## Test plan

- [ ] Open a factory line board and change a column color; confirm the lane
      keeps the new color with no flash back to the old color
- [ ] Reload the page and confirm the saved color persists
- [ ] Run `make check.test.ui` and confirm `LinesPage.spec.tsx` passes


Made with [Cursor](https://cursor.com)