### PR TITLE
feat: add integration usage and setup for agents

### DIFF
--- a/pkg/components/runner/agent_task.go
+++ b/pkg/components/runner/agent_task.go
@@ -8,34 +8,88 @@ import (
 
 type AgentPromptCommand func(promptName, model string) string
 
-func BuildAgentBrokerTask(
-	prepareName, prepareScript, runScriptName, runScript, workingDirectory string,
-	steps []AgentStep,
-	model string,
-	promptCommand AgentPromptCommand,
-) (commands []BrokerCommand, files []BrokerTaskFile) {
+type AgentBrokerTaskInput struct {
+	PrepareName      string
+	PrepareScript    string
+	RunScriptName    string
+	RunScript        string
+	WorkingDirectory string
+	Steps            []AgentStep
+	Usage            string
+	Setups           []IntegrationSetup
+	Model            string
+	PromptCommand    AgentPromptCommand
+}
+
+func BuildAgentBrokerTask(input AgentBrokerTaskInput) (commands []BrokerCommand, files []BrokerTaskFile) {
 	files = []BrokerTaskFile{
 		LLMUsageTaskFile(),
-		{Path: runScriptName, Content: runScript, Mode: "0644"},
-		{Path: "prepare.sh", Content: prepareScript, Mode: "0644"},
+		{Path: input.RunScriptName, Content: input.RunScript, Mode: "0644"},
+		{Path: "prepare.sh", Content: input.PrepareScript, Mode: "0644"},
 	}
 
-	commands = make([]BrokerCommand, 0, len(steps)+1)
+	setupCommands, setupFiles := BuildIntegrationSetupCommands(input.Setups)
+	files = append(files, setupFiles...)
+
+	commands = make([]BrokerCommand, 0, len(input.Steps)+len(setupCommands)+1)
 	commands = append(commands, BrokerCommand{
-		Name:    prepareName,
-		Command: `source "$SUPERPLANE_TASK_DIR/prepare.sh"`,
+		Name:    input.PrepareName,
+		Command: WithTaskBinOnPath(`source "$SUPERPLANE_TASK_DIR/prepare.sh"`),
 		Kind:    LiveLogKindSetup,
 	})
+	commands = append(commands, setupCommands...)
 
-	for i, step := range steps {
-		file, command := buildAgentStep(i+1, step, workingDirectory, model, runScriptName, promptCommand)
+	for i, step := range input.Steps {
+		file, command := buildAgentStep(i+1, step, input.WorkingDirectory, input.Usage, input.Model, input.PromptCommand)
 		files = append(files, file)
 		commands = append(commands, command)
 	}
 	return commands, files
 }
 
-func buildAgentStep(stepNumber int, step AgentStep, nodeWorkingDirectory, model, runScriptName string, promptCommand AgentPromptCommand) (BrokerTaskFile, BrokerCommand) {
+func ApplyIntegrationUsage(prompt, usage string) string {
+	usage = strings.TrimSpace(usage)
+	if usage == "" {
+		return prompt
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return usage
+	}
+	return usage + "\n\n" + prompt
+}
+
+func WithTaskBinOnPath(command string) string {
+	return `export PATH="$SUPERPLANE_TASK_DIR/bin:$PATH"
+` + command
+}
+
+func BuildIntegrationSetupCommands(setups []IntegrationSetup) (commands []BrokerCommand, files []BrokerTaskFile) {
+	for i, setup := range setups {
+		if strings.TrimSpace(setup.Script) == "" {
+			continue
+		}
+		name := strings.TrimSpace(setup.Name)
+		if name == "" {
+			name = "Set up integration"
+		}
+		scriptName := AgentStepSlug(i+1, name) + ".sh"
+		path := "setup/" + scriptName
+		files = append(files, BrokerTaskFile{
+			Path:    path,
+			Content: setup.Script,
+			Mode:    "0644",
+		})
+		commands = append(commands, BrokerCommand{
+			Name:    name,
+			Command: WrapAgentStepCommand(fmt.Sprintf(`source "$SUPERPLANE_TASK_DIR/%s"`, path)),
+			Kind:    LiveLogKindSetup,
+			Preview: LiveLogPreview(name),
+		})
+	}
+	return commands, files
+}
+
+func buildAgentStep(stepNumber int, step AgentStep, nodeWorkingDirectory, usage, model string, promptCommand AgentPromptCommand) (BrokerTaskFile, BrokerCommand) {
 	stepSlug := AgentStepSlug(stepNumber, step.Name)
 	workingDirectory := EffectiveWorkingDirectory(nodeWorkingDirectory, step.WorkingDirectory)
 	switch NormalizeAgentStepType(step.Type) {
@@ -63,7 +117,7 @@ func buildAgentStep(stepNumber int, step AgentStep, nodeWorkingDirectory, model,
 		promptName := stepSlug + ".txt"
 		return BrokerTaskFile{
 				Path:    "prompts/" + promptName,
-				Content: prompt,
+				Content: ApplyIntegrationUsage(prompt, usage),
 				Mode:    "0644",
 			}, BrokerCommand{
 				Name:    AgentStepLabel(step.Name, promptName),
@@ -104,7 +158,7 @@ cd "$_sp_root"/` + ShellSingleQuote(dir) + ` && ` + command
 func WrapAgentStepCommand(command string) string {
 	return `_sp_status=0
 {
-` + command + `
+` + WithTaskBinOnPath(command) + `
 } || _sp_status=$?
 node "$SUPERPLANE_TASK_DIR/llm_usage.js" merge || true
 if [ "$_sp_status" -ne 0 ]; then

--- a/pkg/components/runner/agent_task_test.go
+++ b/pkg/components/runner/agent_task_test.go
@@ -44,26 +44,26 @@ func TestBuildAgentBrokerTaskAppliesStepWorkingDirectory(t *testing.T) {
 
 	prompt := "implement the change"
 	command := "git push"
-	commands, files := BuildAgentBrokerTask(
-		"Prepare",
-		NodePrepareScript("", "", ""),
-		"run.js",
-		"echo run",
-		"",
-		[]AgentStep{
+	commands, files := BuildAgentBrokerTask(AgentBrokerTaskInput{
+		PrepareName:   "Prepare",
+		PrepareScript: NodePrepareScript("", "", ""),
+		RunScriptName: "run.js",
+		RunScript:     "echo run",
+		Steps: []AgentStep{
 			{Name: "Clone", Type: AgentStepBash, Command: strPtr("git clone dest repo")},
 			{Name: "Implement", Type: AgentStepPrompt, Prompt: &prompt, WorkingDirectory: "repo"},
 			{Name: "Push", Type: AgentStepBash, Command: &command, WorkingDirectory: "repo"},
 		},
-		"google/gemini-3.7-flash",
-		func(promptName, model string) string {
+		Model: "google/gemini-3.7-flash",
+		PromptCommand: func(promptName, model string) string {
 			return "node run.js " + promptName + " " + model
 		},
-	)
+	})
 
 	require.Len(t, commands, 4)
 	assert.Equal(t, LiveLogKindSetup, commands[0].Kind)
-	assert.Equal(t, `source "$SUPERPLANE_TASK_DIR/prepare.sh"`, commands[0].Command)
+	assert.Contains(t, commands[0].Command, `source "$SUPERPLANE_TASK_DIR/prepare.sh"`)
+	assert.Contains(t, commands[0].Command, `export PATH="$SUPERPLANE_TASK_DIR/bin:$PATH"`)
 	assert.Equal(t, LiveLogKindBash, commands[1].Kind)
 	assert.Equal(t, "git clone dest repo", commands[1].Preview)
 	assert.Equal(t, LiveLogKindPrompt, commands[2].Kind)
@@ -87,22 +87,22 @@ func TestBuildAgentBrokerTaskAppliesNodeWorkingDirectoryWhenStepEmpty(t *testing
 
 	prompt := "implement the change"
 	command := "git push"
-	commands, _ := BuildAgentBrokerTask(
-		"Prepare",
-		NodePrepareScript("", "", "repo"),
-		"run.js",
-		"echo run",
-		"repo",
-		[]AgentStep{
+	commands, _ := BuildAgentBrokerTask(AgentBrokerTaskInput{
+		PrepareName:      "Prepare",
+		PrepareScript:    NodePrepareScript("", "", "repo"),
+		RunScriptName:    "run.js",
+		RunScript:        "echo run",
+		WorkingDirectory: "repo",
+		Steps: []AgentStep{
 			{Name: "Clone", Type: AgentStepBash, Command: strPtr("git clone dest repo")},
 			{Name: "Implement", Type: AgentStepPrompt, Prompt: &prompt},
 			{Name: "Push", Type: AgentStepBash, Command: &command, WorkingDirectory: "/tmp/override"},
 		},
-		"google/gemini-3.7-flash",
-		func(promptName, model string) string {
+		Model: "google/gemini-3.7-flash",
+		PromptCommand: func(promptName, model string) string {
 			return "node run.js " + promptName + " " + model
 		},
-	)
+	})
 
 	require.Len(t, commands, 4)
 	assert.Contains(t, commands[1].Command, `'repo'`)
@@ -120,6 +120,55 @@ func TestValidateAgentStepsRejectsParentWorkingDirectory(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "workingDirectory")
+}
+
+func TestApplyIntegrationUsagePrependsUsage(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "user prompt", ApplyIntegrationUsage("user prompt", ""))
+	assert.Equal(t, "Use gh.", ApplyIntegrationUsage("", "Use gh."))
+	assert.Equal(t, "Use gh.\n\nuser prompt", ApplyIntegrationUsage("user prompt", "Use gh."))
+}
+
+func TestBuildAgentBrokerTaskAppliesIntegrationUsageAndSetup(t *testing.T) {
+	t.Parallel()
+
+	prompt := "implement the change"
+	commands, files := BuildAgentBrokerTask(AgentBrokerTaskInput{
+		PrepareName:   "Prepare",
+		PrepareScript: NodePrepareScript("", "", ""),
+		RunScriptName: "run.js",
+		RunScript:     "echo run",
+		Steps: []AgentStep{
+			{Name: "Implement", Type: AgentStepPrompt, Prompt: &prompt},
+		},
+		Usage: "The gh CLI is already installed. Use GITHUB_TOKEN.",
+		Setups: []IntegrationSetup{
+			{Name: "Set up Semaphore", Script: "echo install-sem-ai"},
+		},
+		Model: "google/gemini-3.7-flash",
+		PromptCommand: func(promptName, model string) string {
+			return "node run.js " + promptName + " " + model
+		},
+	})
+
+	require.Len(t, commands, 3)
+	assert.Equal(t, "Prepare", commands[0].Name)
+	assert.Equal(t, LiveLogKindSetup, commands[0].Kind)
+	assert.Equal(t, "Set up Semaphore", commands[1].Name)
+	assert.Equal(t, LiveLogKindSetup, commands[1].Kind)
+	assert.Equal(t, "Set up Semaphore", commands[1].Preview)
+	assert.Contains(t, commands[1].Command, `source "$SUPERPLANE_TASK_DIR/setup/01-set-up-semaphore.sh"`)
+	assert.Equal(t, "Implement", commands[2].Name)
+	assert.Equal(t, "implement the change", commands[2].Preview)
+	assert.Contains(t, commands[2].Command, `export PATH="$SUPERPLANE_TASK_DIR/bin:$PATH"`)
+
+	assert.Equal(t, "echo install-sem-ai", requireBrokerFile(t, files, "setup/01-set-up-semaphore.sh").Content)
+	assert.Equal(
+		t,
+		"The gh CLI is already installed. Use GITHUB_TOKEN.\n\nimplement the change",
+		requireBrokerFile(t, files, "prompts/01-implement.txt").Content,
+	)
 }
 
 func assertAgentStepMergesUsage(t *testing.T, command, inner string) {

--- a/pkg/components/runner/claude/component.go
+++ b/pkg/components/runner/claude/component.go
@@ -137,12 +137,12 @@ func (c *RunClaudeCode) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	environment, err := runner.ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
+	resolved, err := runner.ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
 	if err != nil {
 		return err
 	}
 
-	environment, err = c.injectCredentials(ctx, environment, spec.Credentials, spec.Model)
+	environment, err := c.injectCredentials(ctx, resolved.Variables, spec.Credentials, spec.Model)
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (c *RunClaudeCode) Execute(ctx core.ExecutionContext) error {
 	}
 
 	// command_list tasks only accept commands (+ optional files).
-	task := buildClaudeCodeBrokerTask(spec)
+	task := buildClaudeCodeBrokerTask(spec, resolved.Usage, resolved.Setups)
 	params := runner.CreateTaskParams{
 		MachineType:    spec.MachineType,
 		Commands:       task.Commands,

--- a/pkg/components/runner/claude/component_test.go
+++ b/pkg/components/runner/claude/component_test.go
@@ -94,7 +94,7 @@ func TestRunClaudeCodeExecuteSendsPerStepCommandsToBroker(t *testing.T) {
 	assert.Equal(t, runner.ExecutionModeHost, req.ExecutionMode)
 	require.Len(t, req.Commands, 5)
 	assert.Equal(t, "Prepare Claude Code", req.Commands[0].Name)
-	assert.Equal(t, `source "$SUPERPLANE_TASK_DIR/prepare.sh"`, req.Commands[0].Command)
+	assert.Contains(t, req.Commands[0].Command, `source "$SUPERPLANE_TASK_DIR/prepare.sh"`)
 	assert.Equal(t, "Clone", req.Commands[1].Name)
 	assert.Contains(t, req.Commands[1].Command, `source "$SUPERPLANE_TASK_DIR/steps/01-clone.sh"`)
 	assert.Contains(t, req.Commands[1].Command, `node "$SUPERPLANE_TASK_DIR/llm_usage.js" merge`)
@@ -118,6 +118,80 @@ func TestRunClaudeCodeExecuteSendsPerStepCommandsToBroker(t *testing.T) {
 	assert.Equal(t, "Fix the failing tests", requireTaskFile(t, req.Files, "prompts/02-fix-tests.txt").Content)
 	assert.Equal(t, "Open a pull request", requireTaskFile(t, req.Files, "prompts/03-open-pr.txt").Content)
 	assert.Equal(t, "git -C /tmp/repo status", requireTaskFile(t, req.Files, "steps/04-status.sh").Content)
+}
+
+func TestRunClaudeCodeExecuteExtendsPromptsWithIntegrationUsageAndSetup(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+	t.Setenv("TASK_BROKER_FLEET_ID", "")
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(`{"id":"task-claude-usage-1"}`))},
+		},
+	}
+
+	component := &RunClaudeCode{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"machineType": testRunnerMachineType,
+			"model":       "sonnet",
+			"steps": []map[string]any{
+				{"name": "Fix tests", "type": "prompt", "prompt": "Fix the failing tests"},
+			},
+			"credentials": credentialsSecret("anthropic", "api_key"),
+			"environmentFrom": []map[string]any{
+				{"source": "integration", "integration": map[string]any{"name": "github-acme"}},
+				{"source": "integration", "integration": map[string]any{"name": "semaphore-acme"}},
+			},
+		},
+		HTTP: httpContext,
+		Secrets: &contexts.SecretsContext{
+			Values: map[string][]byte{
+				"anthropic/api_key": []byte("sk-test-key"),
+			},
+			IntegrationKeys: map[string]map[string][]byte{
+				"github-acme":    {"GITHUB_TOKEN": []byte("gh-token")},
+				"semaphore-acme": {"SEMAPHORE_API_TOKEN": []byte("sem-token")},
+			},
+			IntegrationUsage: map[string]string{
+				"github-acme":    "The gh CLI is already installed. Use GITHUB_TOKEN.",
+				"semaphore-acme": "Use sem-ai with SEMAPHORE_API_TOKEN.",
+			},
+			IntegrationSetup: map[string]string{
+				"semaphore-acme": "echo install-sem-ai",
+			},
+			IntegrationSetupName: map[string]string{
+				"semaphore-acme": "Set up Semaphore",
+			},
+		},
+		Webhook:        &contexts.NodeWebhookContext{},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		Requests:       &contexts.RequestContext{},
+	})
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(httpContext.Requests[0].Body)
+	require.NoError(t, err)
+
+	var req createTaskRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+
+	require.Len(t, req.Commands, 3)
+	assert.Equal(t, "Prepare Claude Code", req.Commands[0].Name)
+	assert.Equal(t, "Set up Semaphore", req.Commands[1].Name)
+	assert.Equal(t, runner.LiveLogKindSetup, req.Commands[1].Kind)
+	assert.Equal(t, "Set up Semaphore", req.Commands[1].Preview)
+	assert.Equal(t, "Fix tests", req.Commands[2].Name)
+	assert.Equal(t, "Fix the failing tests", req.Commands[2].Preview)
+	assert.Equal(t, "gh-token", requireEnvironmentValue(t, req.Environment, "GITHUB_TOKEN"))
+	assert.Equal(t, "sem-token", requireEnvironmentValue(t, req.Environment, "SEMAPHORE_API_TOKEN"))
+	assert.Equal(t, "echo install-sem-ai", requireTaskFile(t, req.Files, "setup/01-set-up-semaphore.sh").Content)
+	assert.Equal(
+		t,
+		"The gh CLI is already installed. Use GITHUB_TOKEN.\n\nUse sem-ai with SEMAPHORE_API_TOKEN.\n\nFix the failing tests",
+		requireTaskFile(t, req.Files, "prompts/01-fix-tests.txt").Content,
+	)
 }
 
 func TestRunClaudeCodeExecuteMigratesLegacyPromptConfig(t *testing.T) {
@@ -163,7 +237,7 @@ func TestRunClaudeCodeExecuteMigratesLegacyPromptConfig(t *testing.T) {
 	assert.Empty(t, req.MessageChain)
 	require.Len(t, req.Commands, 4)
 	assert.Equal(t, "Prepare Claude Code", req.Commands[0].Name)
-	assert.Equal(t, `source "$SUPERPLANE_TASK_DIR/prepare.sh"`, req.Commands[0].Command)
+	assert.Contains(t, req.Commands[0].Command, `source "$SUPERPLANE_TASK_DIR/prepare.sh"`)
 	assert.Equal(t, "Setup", req.Commands[1].Name)
 	assert.Contains(t, req.Commands[1].Command, `source "$SUPERPLANE_TASK_DIR/steps/01-setup.sh"`)
 	assert.Equal(t, "Prompt", req.Commands[2].Name)

--- a/pkg/components/runner/claude/spec.go
+++ b/pkg/components/runner/claude/spec.go
@@ -118,7 +118,7 @@ func validateRunClaudeCodeSpec(spec RunClaudeCodeSpec) error {
 // Static helpers ship via `files` (materialized under SUPERPLANE_TASK_DIR).
 // Node and per-step workingDirectory cds from the task launch directory so
 // each broker command starts in the configured workspace.
-func buildClaudeCodeBrokerTask(spec RunClaudeCodeSpec) ClaudeCodeBrokerTask {
+func buildClaudeCodeBrokerTask(spec RunClaudeCodeSpec, usage string, setups []runner.IntegrationSetup) ClaudeCodeBrokerTask {
 	model := strings.TrimSpace(spec.Model)
 	workdir := strings.TrimSpace(spec.WorkingDirectory)
 
@@ -128,25 +128,29 @@ func buildClaudeCodeBrokerTask(spec RunClaudeCodeSpec) ClaudeCodeBrokerTask {
 		{Path: "prepare.sh", Content: claudePrepareScript(workdir), Mode: "0644"},
 	}
 
+	setupCommands, setupFiles := runner.BuildIntegrationSetupCommands(setups)
+	files = append(files, setupFiles...)
+
 	stepCommands := make([]runner.BrokerCommand, 0, len(spec.Steps))
 	for i, step := range spec.Steps {
-		file, command := buildClaudeCodeStep(i+1, step, model, workdir)
+		file, command := buildClaudeCodeStep(i+1, step, usage, model, workdir)
 		files = append(files, file)
 		stepCommands = append(stepCommands, command)
 	}
 
 	prepareCommand := runner.BrokerCommand{
 		Name:    "Prepare Claude Code",
-		Command: `source "$SUPERPLANE_TASK_DIR/prepare.sh"`,
+		Command: runner.WithTaskBinOnPath(`source "$SUPERPLANE_TASK_DIR/prepare.sh"`),
 		Kind:    runner.LiveLogKindSetup,
 	}
+	commands := append([]runner.BrokerCommand{prepareCommand}, setupCommands...)
 	return ClaudeCodeBrokerTask{
-		Commands: append([]runner.BrokerCommand{prepareCommand}, stepCommands...),
+		Commands: append(commands, stepCommands...),
 		Files:    files,
 	}
 }
 
-func buildClaudeCodeStep(stepNumber int, step ClaudeCodeStep, model, nodeWorkingDirectory string) (runner.BrokerTaskFile, runner.BrokerCommand) {
+func buildClaudeCodeStep(stepNumber int, step ClaudeCodeStep, usage, model, nodeWorkingDirectory string) (runner.BrokerTaskFile, runner.BrokerCommand) {
 	stepSlug := runner.AgentStepSlug(stepNumber, step.Name)
 	workingDirectory := runner.EffectiveWorkingDirectory(nodeWorkingDirectory, step.WorkingDirectory)
 	switch runner.NormalizeAgentStepType(step.Type) {
@@ -169,7 +173,7 @@ func buildClaudeCodeStep(stepNumber int, step ClaudeCodeStep, model, nodeWorking
 		promptName := stepSlug + ".txt"
 		return runner.BrokerTaskFile{
 			Path:    "prompts/" + promptName,
-			Content: prompt,
+			Content: runner.ApplyIntegrationUsage(prompt, usage),
 			Mode:    "0644",
 		}, claudePromptStepBrokerCommand(step.Name, promptName, prompt, model, workingDirectory)
 	}

--- a/pkg/components/runner/claude/spec_test.go
+++ b/pkg/components/runner/claude/spec_test.go
@@ -138,11 +138,12 @@ func TestBuildClaudeCodeBrokerTaskRunsOrderedSteps(t *testing.T) {
 		},
 	}
 
-	task := buildClaudeCodeBrokerTask(spec)
+	task := buildClaudeCodeBrokerTask(spec, "", nil)
 	require.Len(t, task.Commands, 5)
 	assert.Equal(t, "Prepare Claude Code", task.Commands[0].Name)
 	assert.Equal(t, runner.LiveLogKindSetup, task.Commands[0].Kind)
-	assert.Equal(t, `source "$SUPERPLANE_TASK_DIR/prepare.sh"`, task.Commands[0].Command)
+	assert.Contains(t, task.Commands[0].Command, `source "$SUPERPLANE_TASK_DIR/prepare.sh"`)
+	assert.Contains(t, task.Commands[0].Command, `export PATH="$SUPERPLANE_TASK_DIR/bin:$PATH"`)
 
 	assert.Equal(t, "Clone repo", task.Commands[1].Name)
 	assert.Equal(t, runner.LiveLogKindBash, task.Commands[1].Kind)
@@ -188,6 +189,33 @@ func TestBuildClaudeCodeBrokerTaskRunsOrderedSteps(t *testing.T) {
 	assert.Contains(t, runScript, `"--permission-mode"`)
 	assert.Contains(t, runScript, `"acceptEdits"`)
 	assert.NotContains(t, runScript, "workdir")
+}
+
+func TestBuildClaudeCodeBrokerTaskAppliesIntegrationUsageAndSetup(t *testing.T) {
+	t.Parallel()
+
+	spec := RunClaudeCodeSpec{
+		Model: "sonnet",
+		Steps: []ClaudeCodeStep{
+			{Name: "Fix tests", Type: runner.AgentStepPrompt, Prompt: strPtr("Fix the failing tests")},
+		},
+	}
+
+	task := buildClaudeCodeBrokerTask(spec, "The gh CLI is already installed. Use GITHUB_TOKEN.", []runner.IntegrationSetup{
+		{Name: "Set up Semaphore", Script: "echo install-sem-ai"},
+	})
+	require.Len(t, task.Commands, 3)
+	assert.Equal(t, "Prepare Claude Code", task.Commands[0].Name)
+	assert.Equal(t, "Set up Semaphore", task.Commands[1].Name)
+	assert.Equal(t, runner.LiveLogKindSetup, task.Commands[1].Kind)
+	assert.Equal(t, "Fix tests", task.Commands[2].Name)
+	assert.Equal(t, "Fix the failing tests", task.Commands[2].Preview)
+	assert.Equal(t, "echo install-sem-ai", requireTaskFile(t, task.Files, "setup/01-set-up-semaphore.sh").Content)
+	assert.Equal(
+		t,
+		"The gh CLI is already installed. Use GITHUB_TOKEN.\n\nFix the failing tests",
+		requireTaskFile(t, task.Files, "prompts/01-fix-tests.txt").Content,
+	)
 }
 
 func TestClaudeStepSlug(t *testing.T) {

--- a/pkg/components/runner/codex/component.go
+++ b/pkg/components/runner/codex/component.go
@@ -122,11 +122,11 @@ func (c *RunCodex) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	environment, err := runner.ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
+	resolved, err := runner.ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
 	if err != nil {
 		return err
 	}
-	environment, err = injectCodexCredentials(ctx, environment, spec.Credentials, spec.Model)
+	environment, err := injectCodexCredentials(ctx, resolved.Variables, spec.Credentials, spec.Model)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (c *RunCodex) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("new broker client: %w", err)
 	}
 
-	commands, files := buildCodexBrokerTask(spec)
+	commands, files := buildCodexBrokerTask(spec, resolved.Usage, resolved.Setups)
 	taskID, err := broker.CreateTask(runner.CreateTaskParams{
 		MachineType:    spec.MachineType,
 		Commands:       commands,

--- a/pkg/components/runner/codex/spec.go
+++ b/pkg/components/runner/codex/spec.go
@@ -63,21 +63,23 @@ func validateRunCodexSpec(spec RunCodexSpec) error {
 	return nil
 }
 
-func buildCodexBrokerTask(spec RunCodexSpec) ([]runner.BrokerCommand, []runner.BrokerTaskFile) {
-	return runner.BuildAgentBrokerTask(
-		"Prepare Codex",
-		runner.NodePrepareScript("codex", "codex CLI not found on PATH; install Codex on the runner", spec.WorkingDirectory),
-		"run.js",
-		runScript,
-		spec.WorkingDirectory,
-		spec.Steps,
-		strings.TrimSpace(spec.Model),
-		func(promptName, model string) string {
+func buildCodexBrokerTask(spec RunCodexSpec, usage string, setups []runner.IntegrationSetup) ([]runner.BrokerCommand, []runner.BrokerTaskFile) {
+	return runner.BuildAgentBrokerTask(runner.AgentBrokerTaskInput{
+		PrepareName:      "Prepare Codex",
+		PrepareScript:    runner.NodePrepareScript("codex", "codex CLI not found on PATH; install Codex on the runner", spec.WorkingDirectory),
+		RunScriptName:    "run.js",
+		RunScript:        runScript,
+		WorkingDirectory: spec.WorkingDirectory,
+		Steps:            spec.Steps,
+		Usage:            usage,
+		Setups:           setups,
+		Model:            strings.TrimSpace(spec.Model),
+		PromptCommand: func(promptName, model string) string {
 			return fmt.Sprintf(
 				`node "$SUPERPLANE_TASK_DIR/run.js" "$SUPERPLANE_TASK_DIR/prompts/%s" %s`,
 				promptName,
 				runner.ShellSingleQuote(model),
 			)
 		},
-	)
+	})
 }

--- a/pkg/components/runner/environment.go
+++ b/pkg/components/runner/environment.go
@@ -139,52 +139,77 @@ func ValidateEnvironmentFrom(environmentFrom []EnvironmentFromEntry) error {
 	return nil
 }
 
+type IntegrationSetup struct {
+	Name   string
+	Script string
+}
+
+type ResolvedEnvironment struct {
+	Variables []BrokerEnvironmentVariable
+	Usage     string
+	Setups    []IntegrationSetup
+}
+
 func ResolveEnvironment(
 	secrets core.SecretsContext,
 	environmentFrom []EnvironmentFromEntry,
 	environment []EnvironmentVariable,
-) ([]BrokerEnvironmentVariable, error) {
+) (ResolvedEnvironment, error) {
 	resolved := make([]BrokerEnvironmentVariable, 0)
 	seen := make(map[string]struct{})
+	usages := make([]string, 0)
+	setups := make([]IntegrationSetup, 0)
 
 	for _, entry := range environmentFrom {
 		switch strings.TrimSpace(entry.Source) {
 		case EnvironmentFromSourceIntegration:
 			if secrets == nil {
-				return nil, fmt.Errorf("failed to resolve environmentFrom integration secrets: secrets context is unavailable")
+				return ResolvedEnvironment{}, fmt.Errorf("failed to resolve environmentFrom integration secrets: secrets context is unavailable")
 			}
 
-			keys, err := secrets.GetIntegrationKeys(strings.TrimSpace(entry.Integration.Name))
+			name := strings.TrimSpace(entry.Integration.Name)
+			imported, err := secrets.GetIntegrationSecrets(name)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve environmentFrom integration secrets: %w", err)
+				return ResolvedEnvironment{}, fmt.Errorf("failed to resolve environmentFrom integration secrets: %w", err)
 			}
 
-			if err := appendImportedEnvironmentVariables(&resolved, seen, keys); err != nil {
-				return nil, err
+			if err := appendImportedEnvironmentVariables(&resolved, seen, imported.Values); err != nil {
+				return ResolvedEnvironment{}, err
+			}
+
+			if usage := strings.TrimSpace(imported.Usage); usage != "" {
+				usages = append(usages, usage)
+			}
+			if setup := strings.TrimSpace(imported.Setup); setup != "" {
+				setupName := strings.TrimSpace(imported.SetupName)
+				if setupName == "" {
+					setupName = "Set up " + name
+				}
+				setups = append(setups, IntegrationSetup{Name: setupName, Script: setup})
 			}
 
 		case EnvironmentFromSourceSecret:
 			if secrets == nil {
-				return nil, fmt.Errorf("failed to resolve environmentFrom secret keys: secrets context is unavailable")
+				return ResolvedEnvironment{}, fmt.Errorf("failed to resolve environmentFrom secret keys: secrets context is unavailable")
 			}
 
 			keys, err := secrets.GetSecretKeys(entry.Secret.Secret)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve environmentFrom secret keys: %w", err)
+				return ResolvedEnvironment{}, fmt.Errorf("failed to resolve environmentFrom secret keys: %w", err)
 			}
 
 			if err := appendImportedEnvironmentVariables(&resolved, seen, keys); err != nil {
-				return nil, err
+				return ResolvedEnvironment{}, err
 			}
 
 		default:
-			return nil, fmt.Errorf("invalid environmentFrom source: %s", entry.Source)
+			return ResolvedEnvironment{}, fmt.Errorf("invalid environmentFrom source: %s", entry.Source)
 		}
 	}
 
 	explicit, err := resolveExplicitEnvironment(secrets, environment)
 	if err != nil {
-		return nil, err
+		return ResolvedEnvironment{}, err
 	}
 
 	for _, variable := range explicit {
@@ -202,7 +227,11 @@ func ResolveEnvironment(
 		resolved = append(resolved, variable)
 	}
 
-	return prependPagerDefaults(resolved), nil
+	return ResolvedEnvironment{
+		Variables: prependPagerDefaults(resolved),
+		Usage:     strings.Join(usages, "\n\n"),
+		Setups:    setups,
+	}, nil
 }
 
 // prependPagerDefaults keeps the configured environment authoritative: a

--- a/pkg/components/runner/environment_test.go
+++ b/pkg/components/runner/environment_test.go
@@ -177,11 +177,13 @@ func Test__ResolveEnvironment(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	got := environmentValues(resolved)
+	got := environmentValues(resolved.Variables)
 
 	assert.Equal(t, "override", got["GITHUB_TOKEN"])
 	assert.Equal(t, "org/repo", got["REPO"])
 	assert.Equal(t, "secret-key-value", got["API_KEY"])
+	assert.Empty(t, resolved.Usage)
+	assert.Empty(t, resolved.Setups)
 }
 
 func Test__ResolveEnvironmentDisablesPagers(t *testing.T) {
@@ -193,7 +195,7 @@ func Test__ResolveEnvironmentDisablesPagers(t *testing.T) {
 		resolved, err := ResolveEnvironment(nil, nil, nil)
 		require.NoError(t, err)
 
-		got := environmentValues(resolved)
+		got := environmentValues(resolved.Variables)
 		assert.Equal(t, "cat", got["GIT_PAGER"])
 		assert.Equal(t, "cat", got["PAGER"])
 	})
@@ -207,13 +209,61 @@ func Test__ResolveEnvironmentDisablesPagers(t *testing.T) {
 		require.NoError(t, err)
 
 		var names []string
-		for _, variable := range resolved {
+		for _, variable := range resolved.Variables {
 			names = append(names, variable.Name)
 		}
 
 		assert.Equal(t, []string{"PAGER", "GIT_PAGER"}, names)
-		assert.Equal(t, "less", environmentValues(resolved)["GIT_PAGER"])
+		assert.Equal(t, "less", environmentValues(resolved.Variables)["GIT_PAGER"])
 	})
+}
+
+func Test__ResolveEnvironmentCollectsUsageAndSetup(t *testing.T) {
+	t.Parallel()
+
+	secrets := &contexts.SecretsContext{
+		IntegrationKeys: map[string]map[string][]byte{
+			"github-acme": {
+				"GITHUB_TOKEN": []byte("gh-token"),
+			},
+			"semaphore-acme": {
+				"SEMAPHORE_API_TOKEN": []byte("sem-token"),
+			},
+		},
+		IntegrationUsage: map[string]string{
+			"github-acme":    "Use gh with GITHUB_TOKEN.",
+			"semaphore-acme": "Use sem-ai with SEMAPHORE_API_TOKEN.",
+		},
+		IntegrationSetup: map[string]string{
+			"semaphore-acme": "echo install-sem-ai",
+		},
+		IntegrationSetupName: map[string]string{
+			"semaphore-acme": "Set up Semaphore",
+		},
+	}
+
+	resolved, err := ResolveEnvironment(
+		secrets,
+		[]EnvironmentFromEntry{
+			{
+				Source:      EnvironmentFromSourceIntegration,
+				Integration: configuration.IntegrationRef{Name: "github-acme"},
+			},
+			{
+				Source:      EnvironmentFromSourceIntegration,
+				Integration: configuration.IntegrationRef{Name: "semaphore-acme"},
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Use gh with GITHUB_TOKEN.\n\nUse sem-ai with SEMAPHORE_API_TOKEN.", resolved.Usage)
+	require.Len(t, resolved.Setups, 1)
+	assert.Equal(t, "Set up Semaphore", resolved.Setups[0].Name)
+	assert.Equal(t, "echo install-sem-ai", resolved.Setups[0].Script)
+	assert.Equal(t, "gh-token", environmentValues(resolved.Variables)["GITHUB_TOKEN"])
+	assert.Equal(t, "sem-token", environmentValues(resolved.Variables)["SEMAPHORE_API_TOKEN"])
 }
 
 func environmentValues(environment []BrokerEnvironmentVariable) map[string]string {

--- a/pkg/components/runner/hosted.go
+++ b/pkg/components/runner/hosted.go
@@ -46,11 +46,11 @@ func InjectSecretAPIKey(ctx core.ExecutionContext, environment []BrokerEnvironme
 }
 
 func InjectIntegrationKeys(ctx core.ExecutionContext, environment []BrokerEnvironmentVariable, integration configuration.IntegrationRef) ([]BrokerEnvironmentVariable, error) {
-	keys, err := ctx.Secrets.GetIntegrationKeys(integration.Name)
+	secrets, err := ctx.Secrets.GetIntegrationSecrets(integration.Name)
 	if err != nil {
 		return nil, fmt.Errorf("resolve integration: %w", err)
 	}
-	for name, value := range keys {
+	for name, value := range secrets.Values {
 		environment = append(environment, BrokerEnvironmentVariable{Name: name, Value: string(value)})
 	}
 	return environment, nil

--- a/pkg/components/runner/openrouter/component.go
+++ b/pkg/components/runner/openrouter/component.go
@@ -143,11 +143,11 @@ func (c *RunOpenRouter) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	environment, err := runner.ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
+	resolved, err := runner.ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
 	if err != nil {
 		return err
 	}
-	environment, err = injectOpenRouterCredentials(ctx, environment, spec.Credentials, spec.Model)
+	environment, err := injectOpenRouterCredentials(ctx, resolved.Variables, spec.Credentials, spec.Model)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (c *RunOpenRouter) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("new broker client: %w", err)
 	}
 
-	commands, files := buildOpenRouterBrokerTask(spec)
+	commands, files := buildOpenRouterBrokerTask(spec, resolved.Usage, resolved.Setups)
 	taskID, err := broker.CreateTask(runner.CreateTaskParams{
 		MachineType:    spec.MachineType,
 		Commands:       commands,

--- a/pkg/components/runner/openrouter/spec.go
+++ b/pkg/components/runner/openrouter/spec.go
@@ -78,17 +78,19 @@ func validateRunOpenRouterSpec(spec RunOpenRouterSpec) error {
 	return nil
 }
 
-func buildOpenRouterBrokerTask(spec RunOpenRouterSpec) ([]runner.BrokerCommand, []runner.BrokerTaskFile) {
+func buildOpenRouterBrokerTask(spec RunOpenRouterSpec, usage string, setups []runner.IntegrationSetup) ([]runner.BrokerCommand, []runner.BrokerTaskFile) {
 	maxTurns := effectiveMaxTurns(spec.MaxTurns)
-	return runner.BuildAgentBrokerTask(
-		"Prepare OpenRouter agent",
-		runner.NodePrepareScript("", "", spec.WorkingDirectory),
-		"run.js",
-		runScript,
-		spec.WorkingDirectory,
-		spec.Steps,
-		strings.TrimSpace(spec.Model),
-		func(promptName, model string) string {
+	return runner.BuildAgentBrokerTask(runner.AgentBrokerTaskInput{
+		PrepareName:      "Prepare OpenRouter agent",
+		PrepareScript:    runner.NodePrepareScript("", "", spec.WorkingDirectory),
+		RunScriptName:    "run.js",
+		RunScript:        runScript,
+		WorkingDirectory: spec.WorkingDirectory,
+		Steps:            spec.Steps,
+		Usage:            usage,
+		Setups:           setups,
+		Model:            strings.TrimSpace(spec.Model),
+		PromptCommand: func(promptName, model string) string {
 			return fmt.Sprintf(
 				`node "$SUPERPLANE_TASK_DIR/run.js" "$SUPERPLANE_TASK_DIR/prompts/%s" %s %d`,
 				promptName,
@@ -96,7 +98,7 @@ func buildOpenRouterBrokerTask(spec RunOpenRouterSpec) ([]runner.BrokerCommand, 
 				maxTurns,
 			)
 		},
-	)
+	})
 }
 
 func effectiveMaxTurns(maxTurns int) int {

--- a/pkg/components/runner/openrouter/spec_test.go
+++ b/pkg/components/runner/openrouter/spec_test.go
@@ -149,7 +149,7 @@ func TestBuildOpenRouterBrokerTaskPassesMaxTurns(t *testing.T) {
 	prompt := "fix tests"
 	spec := validOpenRouterSpec(prompt)
 	spec.MaxTurns = 64
-	commands, _ := buildOpenRouterBrokerTask(spec)
+	commands, _ := buildOpenRouterBrokerTask(spec, "", nil)
 	require.GreaterOrEqual(t, len(commands), 2)
 	require.Contains(t, commands[1].Command, `node "$SUPERPLANE_TASK_DIR/run.js" "$SUPERPLANE_TASK_DIR/prompts/01-prompt.txt" 'anthropic/claude-sonnet-4-6' 64`)
 }
@@ -160,7 +160,7 @@ func TestBuildOpenRouterBrokerTaskDefaultsMaxTurns(t *testing.T) {
 	prompt := "fix tests"
 	spec := validOpenRouterSpec(prompt)
 	spec.MaxTurns = 0
-	commands, _ := buildOpenRouterBrokerTask(spec)
+	commands, _ := buildOpenRouterBrokerTask(spec, "", nil)
 	require.GreaterOrEqual(t, len(commands), 2)
 	require.Contains(t, commands[1].Command, fmt.Sprintf("'anthropic/claude-sonnet-4-6' %d", DefaultMaxTurns))
 }

--- a/pkg/components/runner/run_bash.go
+++ b/pkg/components/runner/run_bash.go
@@ -299,10 +299,11 @@ func (c *RunBash) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	environment, err := ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
+	resolved, err := ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
 	if err != nil {
 		return err
 	}
+	environment := resolved.Variables
 
 	webhookURL, err := ctx.Webhook.Setup()
 	if err != nil {

--- a/pkg/components/runner/run_commands.go
+++ b/pkg/components/runner/run_commands.go
@@ -287,10 +287,11 @@ func (c *Runner) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	environment, err := ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
+	resolved, err := ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
 	if err != nil {
 		return err
 	}
+	environment := resolved.Variables
 
 	webhookURL, err := ctx.Webhook.Setup()
 	if err != nil {

--- a/pkg/components/runner/run_javascript.go
+++ b/pkg/components/runner/run_javascript.go
@@ -297,10 +297,11 @@ func (c *RunJS) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	environment, err := ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
+	resolved, err := ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
 	if err != nil {
 		return err
 	}
+	environment := resolved.Variables
 
 	webhookURL, err := ctx.Webhook.Setup()
 	if err != nil {

--- a/pkg/components/runner/run_python.go
+++ b/pkg/components/runner/run_python.go
@@ -292,10 +292,11 @@ func (c *RunPython) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
-	environment, err := ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
+	resolved, err := ResolveEnvironment(ctx.Secrets, spec.EnvironmentFrom, spec.Environment)
 	if err != nil {
 		return err
 	}
+	environment := resolved.Variables
 
 	webhookURL, err := ctx.Webhook.Setup()
 	if err != nil {

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -215,7 +215,7 @@ type ProcessQueueContext struct {
 type SecretsContext interface {
 	GetKey(secretName, keyName string) ([]byte, error)
 	GetSecretKeys(secretName string) (map[string][]byte, error)
-	GetIntegrationKeys(installationName string) (map[string][]byte, error)
+	GetIntegrationSecrets(installationName string) (IntegrationSecrets, error)
 }
 
 type User struct {

--- a/pkg/core/integration_secret_provider.go
+++ b/pkg/core/integration_secret_provider.go
@@ -14,9 +14,20 @@ type IntegrationSecretContext struct {
 }
 
 /*
+ * IntegrationSecrets is the materialization of an integration's exportable
+ * credentials, plus optional agent-facing guidance and setup.
+ */
+type IntegrationSecrets struct {
+	Values    map[string][]byte
+	Usage     string
+	Setup     string
+	SetupName string
+}
+
+/*
  * IntegrationSecretProvider is an optional integration capability for materializing
  * key/value secrets that other parts of the system may consume (runners, components, etc.).
  */
 type IntegrationSecretProvider interface {
-	ResolveSecrets(ctx IntegrationSecretContext) (map[string][]byte, error)
+	ResolveSecrets(ctx IntegrationSecretContext) (IntegrationSecrets, error)
 }

--- a/pkg/integrations/claude/integration_secrets.go
+++ b/pkg/integrations/claude/integration_secrets.go
@@ -7,20 +7,27 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const integrationSecretAnthropicAPIKey = "ANTHROPIC_API_KEY"
+const (
+	integrationSecretAnthropicAPIKey = "ANTHROPIC_API_KEY"
+	claudeSecretUsage                = `An Anthropic API key is available in the ANTHROPIC_API_KEY environment variable.
+Do not print the key.`
+)
 
-func (i *Claude) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][]byte, error) {
+func (i *Claude) ResolveSecrets(ctx core.IntegrationSecretContext) (core.IntegrationSecrets, error) {
 	apiKey, err := ctx.Integration.GetConfig("apiKey")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get API key: %w", err)
+		return core.IntegrationSecrets{}, fmt.Errorf("failed to get API key: %w", err)
 	}
 
 	key := strings.TrimSpace(string(apiKey))
 	if key == "" {
-		return nil, fmt.Errorf("apiKey is required")
+		return core.IntegrationSecrets{}, fmt.Errorf("apiKey is required")
 	}
 
-	return map[string][]byte{
-		integrationSecretAnthropicAPIKey: []byte(key),
+	return core.IntegrationSecrets{
+		Values: map[string][]byte{
+			integrationSecretAnthropicAPIKey: []byte(key),
+		},
+		Usage: claudeSecretUsage,
 	}, nil
 }

--- a/pkg/integrations/claude/integration_secrets_test.go
+++ b/pkg/integrations/claude/integration_secrets_test.go
@@ -20,5 +20,8 @@ func TestResolveSecrets(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []byte("sk-ant-test"), secrets[integrationSecretAnthropicAPIKey])
+	assert.Equal(t, []byte("sk-ant-test"), secrets.Values[integrationSecretAnthropicAPIKey])
+	assert.Contains(t, secrets.Usage, "ANTHROPIC_API_KEY")
+	assert.NotContains(t, secrets.Usage, "sk-ant-test")
+	assert.Empty(t, secrets.Setup)
 }

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -1184,13 +1184,16 @@ func findAppPrivateKey(ctx core.IntegrationContext) (string, error) {
 	return ctx.Secrets().Get(common.SecretAppPEM)
 }
 
-func (g *GitHub) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][]byte, error) {
+func (g *GitHub) ResolveSecrets(ctx core.IntegrationSecretContext) (core.IntegrationSecrets, error) {
 	token, err := resolveAccessToken(ctx.HTTP, ctx.Integration)
 	if err != nil {
-		return nil, err
+		return core.IntegrationSecrets{}, err
 	}
 
-	return map[string][]byte{
-		integrationSecretGitHubToken: []byte(token),
+	return core.IntegrationSecrets{
+		Values: map[string][]byte{
+			integrationSecretGitHubToken: []byte(token),
+		},
+		Usage: githubSecretUsage,
 	}, nil
 }

--- a/pkg/integrations/github/integration_secrets.go
+++ b/pkg/integrations/github/integration_secrets.go
@@ -15,6 +15,13 @@ import (
 
 const integrationSecretGitHubToken = "GITHUB_TOKEN"
 
+const githubSecretUsage = `A GitHub token is available in the GITHUB_TOKEN environment variable.
+The gh CLI is already installed on this runner. Use gh. Do not download or install gh.
+gh reads GITHUB_TOKEN.
+To clone or push a repository, use this remote URL form:
+https://x-access-token:${GITHUB_TOKEN}@github.com/<owner>/<repo>.git
+Do not print the token.`
+
 type httpContextTransport struct {
 	http core.HTTPContext
 }

--- a/pkg/integrations/github/integration_secrets_test.go
+++ b/pkg/integrations/github/integration_secrets_test.go
@@ -28,5 +28,10 @@ func TestGitHub__ResolveSecrets__PAT(t *testing.T) {
 		Integration: integrationCtx,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []byte("ghp_test_token"), secrets[integrationSecretGitHubToken])
+	assert.Equal(t, []byte("ghp_test_token"), secrets.Values[integrationSecretGitHubToken])
+	assert.Contains(t, secrets.Usage, "GITHUB_TOKEN")
+	assert.Contains(t, secrets.Usage, "The gh CLI is already installed")
+	assert.Contains(t, secrets.Usage, "Do not download or install gh")
+	assert.NotContains(t, secrets.Usage, "ghp_test_token")
+	assert.Empty(t, secrets.Setup)
 }

--- a/pkg/integrations/openai/integration_secrets.go
+++ b/pkg/integrations/openai/integration_secrets.go
@@ -7,20 +7,27 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const integrationSecretOpenAIAPIKey = "OPENAI_API_KEY"
+const (
+	integrationSecretOpenAIAPIKey = "OPENAI_API_KEY"
+	openAISecretUsage             = `An OpenAI API key is available in the OPENAI_API_KEY environment variable.
+Do not print the key.`
+)
 
-func (o *OpenAI) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][]byte, error) {
+func (o *OpenAI) ResolveSecrets(ctx core.IntegrationSecretContext) (core.IntegrationSecrets, error) {
 	apiKey, err := ctx.Integration.GetConfig("apiKey")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get API key: %w", err)
+		return core.IntegrationSecrets{}, fmt.Errorf("failed to get API key: %w", err)
 	}
 
 	key := strings.TrimSpace(string(apiKey))
 	if key == "" {
-		return nil, fmt.Errorf("apiKey is required")
+		return core.IntegrationSecrets{}, fmt.Errorf("apiKey is required")
 	}
 
-	return map[string][]byte{
-		integrationSecretOpenAIAPIKey: []byte(key),
+	return core.IntegrationSecrets{
+		Values: map[string][]byte{
+			integrationSecretOpenAIAPIKey: []byte(key),
+		},
+		Usage: openAISecretUsage,
 	}, nil
 }

--- a/pkg/integrations/openai/integration_secrets_test.go
+++ b/pkg/integrations/openai/integration_secrets_test.go
@@ -20,5 +20,8 @@ func TestResolveSecrets(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []byte("sk-test"), secrets[integrationSecretOpenAIAPIKey])
+	assert.Equal(t, []byte("sk-test"), secrets.Values[integrationSecretOpenAIAPIKey])
+	assert.Contains(t, secrets.Usage, "OPENAI_API_KEY")
+	assert.NotContains(t, secrets.Usage, "sk-test")
+	assert.Empty(t, secrets.Setup)
 }

--- a/pkg/integrations/openrouter/integration_secrets.go
+++ b/pkg/integrations/openrouter/integration_secrets.go
@@ -7,20 +7,27 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const integrationSecretOpenRouterAPIKey = "OPENROUTER_API_KEY"
+const (
+	integrationSecretOpenRouterAPIKey = "OPENROUTER_API_KEY"
+	openRouterSecretUsage             = `An OpenRouter API key is available in the OPENROUTER_API_KEY environment variable.
+Do not print the key.`
+)
 
-func (o *OpenRouter) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][]byte, error) {
+func (o *OpenRouter) ResolveSecrets(ctx core.IntegrationSecretContext) (core.IntegrationSecrets, error) {
 	apiKey, err := findSecret(ctx.Integration, SecretAPIKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read OpenRouter API key: %w", err)
+		return core.IntegrationSecrets{}, fmt.Errorf("failed to read OpenRouter API key: %w", err)
 	}
 
 	key := strings.TrimSpace(apiKey)
 	if key == "" {
-		return nil, fmt.Errorf("OpenRouter API key is required")
+		return core.IntegrationSecrets{}, fmt.Errorf("OpenRouter API key is required")
 	}
 
-	return map[string][]byte{
-		integrationSecretOpenRouterAPIKey: []byte(key),
+	return core.IntegrationSecrets{
+		Values: map[string][]byte{
+			integrationSecretOpenRouterAPIKey: []byte(key),
+		},
+		Usage: openRouterSecretUsage,
 	}, nil
 }

--- a/pkg/integrations/openrouter/integration_secrets_test.go
+++ b/pkg/integrations/openrouter/integration_secrets_test.go
@@ -16,7 +16,10 @@ func TestResolveSecrets(t *testing.T) {
 		Integration: connectedIntegration(map[string]any{}),
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []byte("sk-or-v1-test"), secrets[integrationSecretOpenRouterAPIKey])
+	assert.Equal(t, []byte("sk-or-v1-test"), secrets.Values[integrationSecretOpenRouterAPIKey])
+	assert.Contains(t, secrets.Usage, "OPENROUTER_API_KEY")
+	assert.NotContains(t, secrets.Usage, "sk-or-v1-test")
+	assert.Empty(t, secrets.Setup)
 }
 
 func TestResolveSecretsRequiresAPIKey(t *testing.T) {

--- a/pkg/integrations/semaphore/integration_secrets.go
+++ b/pkg/integrations/semaphore/integration_secrets.go
@@ -7,16 +7,85 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const integrationSecretSemaphoreAPIToken = "SEMAPHORE_API_TOKEN"
+const (
+	integrationSecretSemaphoreAPIToken        = "SEMAPHORE_API_TOKEN"
+	integrationSecretSemaphoreOrganizationURL = "SEMAPHORE_ORGANIZATION_URL"
+	semaphoreSetupName                        = "Set up Semaphore"
+	semaphoreSecretUsage                      = `A Semaphore API token is available in the SEMAPHORE_API_TOKEN environment variable.
+The organization URL is available in the SEMAPHORE_ORGANIZATION_URL environment variable.
+The sem-ai CLI is on PATH and is connected to this organization.
+Use sem-ai for projects, pipelines, diagnose, and YAML validate.
+Do not print the token.`
+	semaphoreSecretUsageWithoutOrganizationURL = `A Semaphore API token is available in the SEMAPHORE_API_TOKEN environment variable.
+Use this token as a Bearer token for the Semaphore API.
+Do not print the token.`
+	semaphoreSetupScript = `set -euo pipefail
+: "${SUPERPLANE_TASK_DIR:?SUPERPLANE_TASK_DIR is required}"
+: "${SEMAPHORE_API_TOKEN:?SEMAPHORE_API_TOKEN is required}"
+: "${SEMAPHORE_ORGANIZATION_URL:?SEMAPHORE_ORGANIZATION_URL is required}"
 
-func (s *Semaphore) ResolveSecrets(ctx core.IntegrationSecretContext) (map[string][]byte, error) {
+bin="$SUPERPLANE_TASK_DIR/bin"
+lib="$SUPERPLANE_TASK_DIR/lib"
+home="$SUPERPLANE_TASK_DIR/home"
+mkdir -p "$bin" "$lib" "$home"
+
+if [ ! -x "$lib/sem-ai" ]; then
+  if command -v sem-ai >/dev/null 2>&1; then
+    cp "$(command -v sem-ai)" "$lib/sem-ai"
+  else
+    curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh
+    if [ -x "${HOME}/.local/bin/sem-ai" ]; then
+      cp "${HOME}/.local/bin/sem-ai" "$lib/sem-ai"
+    elif [ -x "${HOME}/.semaphore-ai/bin/sem-ai" ]; then
+      cp "${HOME}/.semaphore-ai/bin/sem-ai" "$lib/sem-ai"
+    elif command -v sem-ai >/dev/null 2>&1; then
+      cp "$(command -v sem-ai)" "$lib/sem-ai"
+    else
+      echo "sem-ai install did not produce a binary" >&2
+      exit 1
+    fi
+  fi
+  chmod +x "$lib/sem-ai"
+fi
+
+cat > "$bin/sem-ai" <<EOF
+#!/bin/sh
+export HOME='$home'
+exec '$lib/sem-ai' "\$@"
+EOF
+chmod +x "$bin/sem-ai"
+
+org="${SEMAPHORE_ORGANIZATION_URL#https://}"
+org="${org#http://}"
+org="${org%/}"
+HOME="$home" "$lib/sem-ai" connect "$org" "$SEMAPHORE_API_TOKEN"
+`
+)
+
+func (s *Semaphore) ResolveSecrets(ctx core.IntegrationSecretContext) (core.IntegrationSecrets, error) {
 	token, err := resolveAPIToken(ctx.Integration)
 	if err != nil {
-		return nil, err
+		return core.IntegrationSecrets{}, err
 	}
 
-	return map[string][]byte{
+	values := map[string][]byte{
 		integrationSecretSemaphoreAPIToken: []byte(token),
+	}
+
+	orgURL := organizationURL(ctx.Integration)
+	if orgURL == "" {
+		return core.IntegrationSecrets{
+			Values: values,
+			Usage:  semaphoreSecretUsageWithoutOrganizationURL,
+		}, nil
+	}
+
+	values[integrationSecretSemaphoreOrganizationURL] = []byte(orgURL)
+	return core.IntegrationSecrets{
+		Values:    values,
+		Usage:     semaphoreSecretUsage,
+		Setup:     semaphoreSetupScript,
+		SetupName: semaphoreSetupName,
 	}, nil
 }
 
@@ -46,4 +115,20 @@ func resolveAPIToken(integrationCtx core.IntegrationContext) (string, error) {
 	}
 
 	return token, nil
+}
+
+func organizationURL(integrationCtx core.IntegrationContext) string {
+	if !integrationCtx.LegacySetup() {
+		url, err := integrationCtx.Properties().GetString(PropertyOrganizationURL)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimRight(strings.TrimSpace(url), "/")
+	}
+
+	raw, err := integrationCtx.GetConfig("organizationUrl")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(strings.TrimSpace(string(raw)), "/")
 }

--- a/pkg/integrations/semaphore/integration_secrets_test.go
+++ b/pkg/integrations/semaphore/integration_secrets_test.go
@@ -18,8 +18,38 @@ func TestResolveSecrets(t *testing.T) {
 			CurrentSecrets: map[string]core.IntegrationSecret{
 				SecretAPIToken: {Name: SecretAPIToken, Value: []byte("sem-token")},
 			},
+			CurrentProperties: map[string]any{
+				PropertyOrganizationURL: "https://acme.semaphoreci.com",
+			},
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []byte("sem-token"), secrets[integrationSecretSemaphoreAPIToken])
+	assert.Equal(t, []byte("sem-token"), secrets.Values[integrationSecretSemaphoreAPIToken])
+	assert.Equal(t, []byte("https://acme.semaphoreci.com"), secrets.Values[integrationSecretSemaphoreOrganizationURL])
+	assert.Contains(t, secrets.Usage, "SEMAPHORE_API_TOKEN")
+	assert.Contains(t, secrets.Usage, "sem-ai")
+	assert.NotContains(t, secrets.Usage, "sem-token")
+	assert.Equal(t, semaphoreSetupName, secrets.SetupName)
+	assert.Contains(t, secrets.Setup, "sem-ai")
+	assert.Contains(t, secrets.Setup, "SEMAPHORE_API_TOKEN")
+	assert.NotContains(t, secrets.Setup, "sem-token")
+}
+
+func TestResolveSecretsWithoutOrganizationURL(t *testing.T) {
+	t.Parallel()
+
+	secrets, err := (&Semaphore{}).ResolveSecrets(core.IntegrationSecretContext{
+		Integration: &contexts.IntegrationContext{
+			NewSetupFlow: true,
+			CurrentSecrets: map[string]core.IntegrationSecret{
+				SecretAPIToken: {Name: SecretAPIToken, Value: []byte("sem-token")},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("sem-token"), secrets.Values[integrationSecretSemaphoreAPIToken])
+	assert.Empty(t, secrets.Values[integrationSecretSemaphoreOrganizationURL])
+	assert.Contains(t, secrets.Usage, "SEMAPHORE_API_TOKEN")
+	assert.NotContains(t, secrets.Usage, "sem-ai")
+	assert.Empty(t, secrets.Setup)
 }

--- a/pkg/registry/integration_test.go
+++ b/pkg/registry/integration_test.go
@@ -45,8 +45,8 @@ type secretProvidingIntegration struct {
 	panickingIntegration
 }
 
-func (p *secretProvidingIntegration) ResolveSecrets(_ core.IntegrationSecretContext) (map[string][]byte, error) {
-	return map[string][]byte{"TOKEN": []byte("value")}, nil
+func (p *secretProvidingIntegration) ResolveSecrets(_ core.IntegrationSecretContext) (core.IntegrationSecrets, error) {
+	return core.IntegrationSecrets{Values: map[string][]byte{"TOKEN": []byte("value")}}, nil
 }
 
 func TestUnwrapIntegration_UnwrapsPanicableIntegration(t *testing.T) {
@@ -63,7 +63,7 @@ func TestUnwrapIntegration_UnwrapsPanicableIntegration(t *testing.T) {
 
 	secrets, err := unwrapped.ResolveSecrets(core.IntegrationSecretContext{})
 	require.NoError(t, err)
-	assert.Equal(t, []byte("value"), secrets["TOKEN"])
+	assert.Equal(t, []byte("value"), secrets.Values["TOKEN"])
 }
 
 func TestPanicableIntegration_Sync_CatchesPanic(t *testing.T) {

--- a/pkg/workers/contexts/secrets_context.go
+++ b/pkg/workers/contexts/secrets_context.go
@@ -90,29 +90,29 @@ func (c *SecretsContext) GetSecretKeys(secretName string) (map[string][]byte, er
 	return keys, nil
 }
 
-func (c *SecretsContext) GetIntegrationKeys(integrationName string) (map[string][]byte, error) {
+func (c *SecretsContext) GetIntegrationSecrets(integrationName string) (core.IntegrationSecrets, error) {
 	name := strings.TrimSpace(integrationName)
 	if name == "" {
-		return nil, fmt.Errorf("integration name is required")
+		return core.IntegrationSecrets{}, fmt.Errorf("integration name is required")
 	}
 
 	integration, err := models.FindIntegrationByName(c.tx, c.organizationID, name)
 	if err != nil {
-		return nil, err
+		return core.IntegrationSecrets{}, err
 	}
 
 	if integration.State != models.IntegrationStateReady {
-		return nil, fmt.Errorf("integration %q is not ready", integration.InstallationName)
+		return core.IntegrationSecrets{}, fmt.Errorf("integration %q is not ready", integration.InstallationName)
 	}
 
 	integrationImpl, err := c.registry.GetIntegration(integration.AppName)
 	if err != nil {
-		return nil, err
+		return core.IntegrationSecrets{}, err
 	}
 
 	provider, ok := registry.UnwrapIntegration(integrationImpl).(core.IntegrationSecretProvider)
 	if !ok {
-		return nil, fmt.Errorf("integration %q does not provide secrets", integration.InstallationName)
+		return core.IntegrationSecrets{}, fmt.Errorf("integration %q does not provide secrets", integration.InstallationName)
 	}
 
 	secretCtx := core.IntegrationSecretContext{

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -431,9 +431,12 @@ func (c *HTTPContext) Do(request *http.Request) (*http.Response, error) {
 }
 
 type SecretsContext struct {
-	Values          map[string][]byte
-	SecretKeys      map[string]map[string][]byte
-	IntegrationKeys map[string]map[string][]byte
+	Values               map[string][]byte
+	SecretKeys           map[string]map[string][]byte
+	IntegrationKeys      map[string]map[string][]byte
+	IntegrationUsage     map[string]string
+	IntegrationSetup     map[string]string
+	IntegrationSetupName map[string]string
 }
 
 func (c *SecretsContext) GetKey(secretName, keyName string) ([]byte, error) {
@@ -458,18 +461,23 @@ func (c *SecretsContext) GetSecretKeys(secretName string) (map[string][]byte, er
 	return keys, nil
 }
 
-func (c *SecretsContext) GetIntegrationKeys(installationName string) (map[string][]byte, error) {
+func (c *SecretsContext) GetIntegrationSecrets(installationName string) (core.IntegrationSecrets, error) {
 	if c.IntegrationKeys == nil {
-		return nil, fmt.Errorf("integration secrets not configured")
+		return core.IntegrationSecrets{}, fmt.Errorf("integration secrets not configured")
 	}
 
 	name := strings.TrimSpace(installationName)
 	keys, ok := c.IntegrationKeys[name]
 	if !ok {
-		return nil, fmt.Errorf("integration secrets not found for ref %q", name)
+		return core.IntegrationSecrets{}, fmt.Errorf("integration secrets not found for ref %q", name)
 	}
 
-	return keys, nil
+	return core.IntegrationSecrets{
+		Values:    keys,
+		Usage:     c.IntegrationUsage[name],
+		Setup:     c.IntegrationSetup[name],
+		SetupName: c.IntegrationSetupName[name],
+	}, nil
 }
 
 type HostedLLMContext struct {


### PR DESCRIPTION
Coding-agent runners previously received only environment variables from attached integrations.
The agent did not get usage instructions or local tools for those integrations.
This change returns usage text and optional setup scripts from each integration.
Claude, Codex, and OpenRouter inject that material at run time.
Usage and setup come only from `environmentFrom` integrations.
The change does not mutate saved canvas steps.
This slice does not install Claude or Codex plugins or MCP servers.

## Core

- `ResolveSecrets` now returns secret values, usage text, and optional setup.
- The system resolves each integration once.
- That keeps GitHub installation tokens from a second mint.

## Integrations

- GitHub usage says `gh` is already on the runner.
- The text tells the agent not to download `gh`.
- Semaphore with an organization URL installs `sem-ai` into the task directory.
- Connect uses a task-scoped `HOME`, so tokens do not stay in the runner user home.
- Semaphore without an organization URL exports the token only.
- Claude, OpenAI, and OpenRouter still expose a short usage string for their keys.
- They do not add setup.

## Runners

- `ResolveEnvironment` now returns variables, joined usage, and setup scripts.
- Agent builders prepend usage to prompt files.
- The live-log preview keeps the original user prompt.
- Setup commands run after prepare.
- Every agent command puts `$SUPERPLANE_TASK_DIR/bin` on `PATH`.
- Bash, JavaScript, Python, and commands runners still receive environment variables only.

## Workers

- The secrets context now returns the new secrets struct.
- Callers that inject keys continue to use values only.

## UI

- No UI change.
- Canvas configuration for `environmentFrom` stays the same.

## API and database

- No gRPC, OpenAPI, or proto change.
- No database migration.