### PR TITLE
feat: Add Find settings search in workspace settings

### DIFF
--- a/web_src/src/lib/integrationDisplayName.ts
+++ b/web_src/src/lib/integrationDisplayName.ts
@@ -32,7 +32,19 @@ const INTEGRATION_TYPE_DISPLAY_NAMES: Record<string, string> = {
   dockerhub: "DockerHub",
   harness: "Harness",
   launchdarkly: "LaunchDarkly",
+  perplexity: "Perplexity",
+  sentry: "Sentry",
+  coolify: "Coolify",
+  telegram: "Telegram",
+  teams: "Teams",
+  hetzner: "Hetzner",
+  servicenow: "ServiceNow",
 };
+
+/** Provider ids and labels for settings search (Find settings → Integrations). */
+export function knownIntegrationTypeEntries(): Array<{ name: string; label: string }> {
+  return Object.entries(INTEGRATION_TYPE_DISPLAY_NAMES).map(([name, label]) => ({ name, label }));
+}
 
 /**
  * Returns the display name for an integration type.

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsCard.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsCard.tsx
@@ -37,6 +37,7 @@ export function FactorySettingsCard({
   action,
   children,
   className,
+  id,
   "data-testid": testId,
 }: {
   title?: string;
@@ -44,10 +45,12 @@ export function FactorySettingsCard({
   action?: ReactNode;
   children: ReactNode;
   className?: string;
+  id?: string;
   "data-testid"?: string;
 }) {
+  const sectionId = id ?? testId;
   return (
-    <section className={cn(factoryCardClassName, "p-4", className)} data-testid={testId}>
+    <section id={sectionId} className={cn(factoryCardClassName, "scroll-mt-8 p-4", className)} data-testid={testId}>
       {title || action ? (
         <div className="mb-3 flex items-center justify-between gap-3">
           {title ? (

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsGeneralPage.tsx
@@ -180,7 +180,11 @@ function WorkspaceDetailsSection({
   onSave,
 }: WorkspaceDetailsSectionProps) {
   return (
-    <section className="space-y-4" data-testid="factory-settings-general-form">
+    <section
+      className="space-y-4 scroll-mt-8"
+      data-testid="factory-settings-general-form"
+      id="factory-settings-general-form"
+    >
       <div className="space-y-2">
         <Label htmlFor="factory-settings-name">Name</Label>
         <Input
@@ -197,10 +201,10 @@ function WorkspaceDetailsSection({
         />
         {nameError ? <p className="text-[11px] text-destructive">{nameError}</p> : null}
       </div>
-      <div className="space-y-2">
-        <Label htmlFor="factory-settings-key">Workspace key</Label>
+      <div className="space-y-2 scroll-mt-8" id="factory-settings-key">
+        <Label htmlFor="factory-settings-key-input">Workspace key</Label>
         <Input
-          id="factory-settings-key"
+          id="factory-settings-key-input"
           data-testid="factory-settings-key"
           value={factoryKey}
           onChange={(event) => onKeyChange(event.target.value)}

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.spec.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.spec.tsx
@@ -132,6 +132,130 @@ describe("FactorySettingsLayout sidebar", () => {
     );
   });
 
+  describe("Find settings", () => {
+    it("shows section results for Security and hides the grouped nav", async () => {
+      const user = userEvent.setup();
+      render(
+        <FactoriesHarness
+          pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/account/profile`}
+          factoriesFixture={defaultFactoriesFixture}
+        />,
+      );
+
+      const sidebar = await screen.findByTestId("factory-settings-sidebar", {}, { timeout: 8000 });
+      await user.type(within(sidebar).getByTestId("factory-settings-find"), "secur");
+      expect(within(sidebar).getByTestId("factory-settings-search-results")).toBeInTheDocument();
+      expect(within(sidebar).getByText("Security")).toBeInTheDocument();
+      expect(within(sidebar).getByText("Sign in methods")).toBeInTheDocument();
+      expect(within(sidebar).queryByTestId("factory-settings-account-nav")).not.toBeInTheDocument();
+    }, 10000);
+
+    it("shows Spending results when the query matches billing", async () => {
+      const user = userEvent.setup();
+      render(
+        <FactoriesHarness
+          pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/general`}
+          factoriesFixture={defaultFactoriesFixture}
+        />,
+      );
+
+      const sidebar = await screen.findByTestId("factory-settings-sidebar", {}, { timeout: 8000 });
+      await user.type(within(sidebar).getByTestId("factory-settings-find"), "billing");
+      const results = within(sidebar).getByTestId("factory-settings-search-results");
+      expect(within(results).getAllByText("Spending").length).toBeGreaterThanOrEqual(2);
+      expect(within(sidebar).queryByTestId("factory-settings-workspace-nav")).not.toBeInTheDocument();
+    }, 10000);
+
+    it("shows Workspace key and scrolls to that field when opened", async () => {
+      const user = userEvent.setup();
+      const scrollIntoView = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <FactoriesHarness
+          pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/account/profile`}
+          factoriesFixture={defaultFactoriesFixture}
+        />,
+      );
+
+      const sidebar = await screen.findByTestId("factory-settings-sidebar", {}, { timeout: 8000 });
+      await user.type(within(sidebar).getByTestId("factory-settings-find"), "workspace key");
+      await user.click(
+        within(sidebar).getByTestId("factory-settings-search-section:workspace:general:factory-settings-key"),
+      );
+      expect(await screen.findByTestId("factory-settings-key")).toBeInTheDocument();
+      expect(screen.getByTestId("factory-settings-key").closest("#factory-settings-key")).toHaveAttribute(
+        "id",
+        "factory-settings-key",
+      );
+      await waitFor(() => {
+        expect(scrollIntoView).toHaveBeenCalled();
+      });
+    }, 10000);
+
+    it("shows Claude under Organization Integrations", async () => {
+      const user = userEvent.setup();
+      render(
+        <FactoriesHarness
+          pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/general`}
+          factoriesFixture={defaultFactoriesFixture}
+        />,
+      );
+
+      const sidebar = await screen.findByTestId("factory-settings-sidebar", {}, { timeout: 8000 });
+      await user.type(within(sidebar).getByTestId("factory-settings-find"), "claude");
+      const claudeResult = await waitFor(
+        () => within(sidebar).getByTestId("factory-settings-search-integration:claude"),
+        { timeout: 8000 },
+      );
+      expect(claudeResult).toHaveTextContent("Claude");
+      expect(claudeResult).toHaveTextContent("Organization › Integrations");
+      expect(claudeResult).toHaveAttribute(
+        "href",
+        expect.stringContaining("/settings/organization/integrations?section=integration-claude"),
+      );
+      await user.click(claudeResult);
+      expect(await screen.findByTestId("workspace-page-header-title", {}, { timeout: 8000 })).toHaveTextContent(
+        "Integrations",
+      );
+    }, 15000);
+
+    it("shows an empty state when nothing matches", async () => {
+      const user = userEvent.setup();
+      render(
+        <FactoriesHarness
+          pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/workspace/general`}
+          factoriesFixture={defaultFactoriesFixture}
+        />,
+      );
+
+      const sidebar = await screen.findByTestId("factory-settings-sidebar", {}, { timeout: 8000 });
+      await user.type(within(sidebar).getByTestId("factory-settings-find"), "zzzz-no-match");
+      expect(within(sidebar).getByTestId("factory-settings-find-empty")).toHaveTextContent("No matching settings.");
+      expect(within(sidebar).queryByTestId("factory-settings-account-nav")).not.toBeInTheDocument();
+    }, 10000);
+
+    it("keeps the find query after navigating to a match", async () => {
+      const user = userEvent.setup();
+      render(
+        <FactoriesHarness
+          pathSuffix={`workspaces/${PRIMARY_FACTORY_KEY}/settings/account/profile`}
+          factoriesFixture={defaultFactoriesFixture}
+        />,
+      );
+
+      const sidebar = await screen.findByTestId("factory-settings-sidebar", {}, { timeout: 8000 });
+      const findInput = within(sidebar).getByTestId("factory-settings-find");
+      await user.type(findInput, "sign in methods");
+      await user.click(
+        within(sidebar).getByTestId("factory-settings-search-section:account:security:account-redesign-signin"),
+      );
+      expect(await screen.findByTestId("account-redesign-signin")).toBeInTheDocument();
+      expect(within(sidebar).getByTestId("factory-settings-find")).toHaveValue("sign in methods");
+      expect(within(sidebar).getByTestId("factory-settings-search-results")).toBeInTheDocument();
+    }, 10000);
+  });
+
   describe("workspace-models experimental feature", () => {
     it("hides the Models nav item when the feature is off", async () => {
       render(

--- a/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
+++ b/web_src/src/pages/factories/pages/settings/FactorySettingsLayout.tsx
@@ -1,11 +1,13 @@
+import { Input } from "@/components/ui/input";
 import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
 import { useFactories, useFactory } from "@/hooks/useFactoryData";
+import { useAvailableIntegrations } from "@/hooks/useIntegrations";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { FEATURE_WORKSPACE_MODELS } from "@/lib/experimentalFeatures";
 import { cn } from "@/lib/utils";
-import { ArrowLeft } from "lucide-react";
-import { useEffect, useRef } from "react";
-import { Navigate, NavLink, Outlet, useLocation, useParams } from "react-router";
+import { ArrowLeft, Search } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, Navigate, NavLink, Outlet, useLocation, useParams, useSearchParams } from "react-router";
 import {
   factoryRouteNeedsCanonicalRedirect,
   replaceFactoryKeySegment,
@@ -22,7 +24,14 @@ import { OrganizationSettingsPathsProvider } from "@/lib/organizationSettingsPat
 import { useFactoriesThemeClass } from "../../lib/useFactoriesThemeClass";
 import { FactorySettingsLayoutContext } from "./factorySettingsLayoutContext";
 import { type FactorySettingsNavGroup, type FactorySettingsNavItem } from "./settingsNavItems";
+import {
+  buildFactorySettingsSearchIndex,
+  factorySettingsSearchResultPath,
+  searchFactorySettings,
+  type FactorySettingsSearchResult,
+} from "./settingsSearch";
 import { useFactorySettingsNavGroups } from "./useFactorySettingsNavGroups";
+import { useFactorySettingsSectionScroll } from "./useFactorySettingsSectionScroll";
 
 /** Nav item id for the in-progress workspace Models settings page, gated behind `FEATURE_WORKSPACE_MODELS`. */
 const WORKSPACE_MODELS_NAV_ITEM_ID = "workspace-models";
@@ -104,13 +113,26 @@ function FactorySettingsLayoutContent({
   factoryKey: string;
 }) {
   useFactoriesThemeClass();
+  useFactorySettingsSectionScroll();
   const settingsNavGroups = useFactorySettingsNavGroups();
   const { data: factory, isLoading, error } = useFactory(organizationId, factoryId);
   const { has: hasExperimentalFeature } = useExperimentalFeature(organizationId);
+  const { data: availableIntegrations = [] } = useAvailableIntegrations();
+  const [navQuery, setNavQuery] = useState("");
   const navGroups = visibleFactorySettingsNavGroups(
     settingsNavGroups,
     hasExperimentalFeature(FEATURE_WORKSPACE_MODELS),
   );
+  const searchIndex = useMemo(
+    () =>
+      buildFactorySettingsSearchIndex({
+        navGroups,
+        integrations: availableIntegrations,
+      }),
+    [availableIntegrations, navGroups],
+  );
+  const searchResults = useMemo(() => searchFactorySettings(searchIndex, navQuery), [navQuery, searchIndex]);
+  const isSearching = navQuery.trim().length > 0;
 
   // See the matching comment in `FactoriesLayout`: once `factory` has loaded
   // the `<Outlet/>` below mounts a leaf settings page that owns the full
@@ -148,33 +170,15 @@ function FactorySettingsLayoutContent({
             className="flex h-full min-h-0 w-full bg-background text-foreground"
             data-testid="factory-settings-layout"
           >
-            <aside
-              className="flex h-full w-[240px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
-              data-testid="factory-settings-sidebar"
-            >
-              <div className="border-b border-sidebar-border px-3 py-3">
-                <NavLink
-                  to={factoryDetailPath(organizationId, factoryKey)}
-                  className="inline-flex h-8 items-center gap-2 rounded-md px-2.5 text-[13px] tracking-[-0.01em] text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
-                  data-testid="factory-settings-back"
-                >
-                  <ArrowLeft className="size-3.5" aria-hidden />
-                  Back to workspace
-                </NavLink>
-              </div>
-              <nav className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-2 py-4">
-                {navGroups.map((group) => (
-                  <SettingsNavGroup
-                    key={group.id}
-                    organizationId={organizationId}
-                    factoryKey={factoryKey}
-                    scope={group.id}
-                    title={group.label}
-                    items={group.items}
-                  />
-                ))}
-              </nav>
-            </aside>
+            <FactorySettingsSidebar
+              organizationId={organizationId}
+              factoryKey={factoryKey}
+              navQuery={navQuery}
+              onNavQueryChange={setNavQuery}
+              isSearching={isSearching}
+              searchResults={searchResults}
+              navGroups={navGroups}
+            />
             {/*
               Gray canvas behind white panels, like the Velocity report. Dark
               mode keeps the darker page, because the factories theme paints
@@ -190,6 +194,126 @@ function FactorySettingsLayoutContent({
         </IntegrationsBasePathProvider>
       </OrganizationSettingsPathsProvider>
     </FactorySettingsLayoutContext.Provider>
+  );
+}
+
+function FactorySettingsSidebar({
+  organizationId,
+  factoryKey,
+  navQuery,
+  onNavQueryChange,
+  isSearching,
+  searchResults,
+  navGroups,
+}: {
+  organizationId: string;
+  factoryKey: string;
+  navQuery: string;
+  onNavQueryChange: (query: string) => void;
+  isSearching: boolean;
+  searchResults: FactorySettingsSearchResult[];
+  navGroups: FactorySettingsNavGroup[];
+}) {
+  return (
+    <aside
+      className="flex h-full w-[240px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
+      data-testid="factory-settings-sidebar"
+    >
+      <div className="border-b border-sidebar-border px-3 py-3">
+        <NavLink
+          to={factoryDetailPath(organizationId, factoryKey)}
+          className="inline-flex h-8 items-center gap-2 rounded-md px-2.5 text-[13px] tracking-[-0.01em] text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+          data-testid="factory-settings-back"
+        >
+          <ArrowLeft className="size-3.5" aria-hidden />
+          Back to workspace
+        </NavLink>
+      </div>
+      <div className="px-3 pt-3">
+        <label className="sr-only" htmlFor="factory-settings-find">
+          Find settings
+        </label>
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <Input
+            id="factory-settings-find"
+            data-testid="factory-settings-find"
+            type="search"
+            value={navQuery}
+            onChange={(event) => onNavQueryChange(event.target.value)}
+            placeholder="Find settings"
+            className="h-8 border-border bg-background pl-8 text-[13px] text-foreground shadow-none placeholder:text-muted-foreground focus:border-ring dark:bg-background"
+          />
+        </div>
+      </div>
+      <nav className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-2 py-4">
+        {isSearching ? (
+          <SettingsSearchResults organizationId={organizationId} factoryKey={factoryKey} results={searchResults} />
+        ) : (
+          navGroups.map((group) => (
+            <SettingsNavGroup
+              key={group.id}
+              organizationId={organizationId}
+              factoryKey={factoryKey}
+              scope={group.id}
+              title={group.label}
+              items={group.items}
+            />
+          ))
+        )}
+      </nav>
+    </aside>
+  );
+}
+
+function SettingsSearchResults({
+  organizationId,
+  factoryKey,
+  results,
+}: {
+  organizationId: string;
+  factoryKey: string;
+  results: FactorySettingsSearchResult[];
+}) {
+  const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
+  const activeSection = searchParams.get("section");
+
+  if (results.length === 0) {
+    return (
+      <p className="px-2.5 text-[13px] text-muted-foreground" data-testid="factory-settings-find-empty">
+        No matching settings.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-0.5" data-testid="factory-settings-search-results">
+      {results.map((result) => {
+        const href = factorySettingsSearchResultPath(organizationId, factoryKey, result, factorySettingsSectionPath);
+        const pathMatches = pathname.includes(`/settings/${result.scope}/${result.section}`);
+        const isActive = pathMatches && (result.anchor ? activeSection === result.anchor : !activeSection);
+
+        return (
+          <li key={result.id}>
+            <Link
+              to={href}
+              className={cn(
+                "flex flex-col gap-0.5 rounded-md px-2.5 py-1.5 text-left hover:bg-sidebar-accent hover:text-foreground",
+                isActive && "bg-sidebar-accent font-medium text-foreground",
+              )}
+              data-testid={`factory-settings-search-${result.id}`}
+            >
+              <span className="text-[13px] tracking-[-0.01em] text-foreground/90">{result.title}</span>
+              <span className="text-[11px] text-muted-foreground">{result.breadcrumb.join(" › ")}</span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 

--- a/web_src/src/pages/factories/pages/settings/account-profile-redesign/AccountSecurityTokensCard.tsx
+++ b/web_src/src/pages/factories/pages/settings/account-profile-redesign/AccountSecurityTokensCard.tsx
@@ -17,6 +17,7 @@ export function AccountSecurityTokensCard({
   return (
     <FactorySettingsCard
       title="Personal tokens"
+      data-testid="account-redesign-tokens"
       action={
         <Button size="sm" onClick={onCreate} data-testid="account-redesign-create-token">
           <Plus className="size-3.5" aria-hidden />

--- a/web_src/src/pages/factories/pages/settings/settingsNavItems.spec.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsNavItems.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { FACTORY_SETTINGS_NAV_GROUPS, factorySettingsRouteFromPathname } from "./settingsNavItems";
+import {
+  FACTORY_SETTINGS_NAV_GROUPS,
+  factorySettingsRouteFromPathname,
+  filterFactorySettingsNavGroups,
+} from "./settingsNavItems";
 
 describe("factorySettingsRouteFromPathname", () => {
   it("reads a canonical scoped settings route", () => {
@@ -42,5 +46,59 @@ describe("FACTORY_SETTINGS_NAV_GROUPS", () => {
       "Secrets",
       "Spending",
     ]);
+  });
+});
+
+describe("filterFactorySettingsNavGroups", () => {
+  it("returns the full list when the query is empty or whitespace", () => {
+    expect(filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "")).toEqual(FACTORY_SETTINGS_NAV_GROUPS);
+    expect(filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "   ")).toEqual(FACTORY_SETTINGS_NAV_GROUPS);
+  });
+
+  it("keeps items whose label matches the query", () => {
+    const filtered = filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "secur");
+    expect(filtered.map((group) => group.id)).toEqual(["account"]);
+    expect(filtered[0]?.items.map((item) => item.id)).toEqual(["account-security"]);
+  });
+
+  it("keeps every item in a group when the group label matches", () => {
+    const filtered = filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "workspace");
+    const workspaceGroup = filtered.find((group) => group.id === "workspace");
+    expect(workspaceGroup?.items.map((item) => item.id)).toEqual([
+      "workspace-general",
+      "workspace-repository",
+      "workspace-automations",
+      "workspace-models",
+      "workspace-spending",
+    ]);
+  });
+
+  it("matches keyword aliases such as billing", () => {
+    const filtered = filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "billing");
+    expect(filtered.flatMap((group) => group.items.map((item) => item.id))).toEqual([
+      "workspace-spending",
+      "organization-spending",
+    ]);
+  });
+
+  it("drops groups that have no matching items", () => {
+    const filtered = filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "api keys");
+    expect(filtered.map((group) => group.id)).toEqual(["organization"]);
+    expect(filtered[0]?.items.map((item) => item.id)).toEqual(["organization-api-keys"]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "zzzz-no-match")).toEqual([]);
+  });
+
+  it("matches in-page field labels such as workspace key", () => {
+    const filtered = filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "workspace key");
+    expect(filtered.map((group) => group.id)).toEqual(["workspace"]);
+    expect(filtered[0]?.items.map((item) => item.id)).toEqual(["workspace-general"]);
+  });
+
+  it("matches in-page phrases when query words appear in any order", () => {
+    const filtered = filterFactorySettingsNavGroups(FACTORY_SETTINGS_NAV_GROUPS, "key workspace");
+    expect(filtered.flatMap((group) => group.items.map((item) => item.id))).toContain("workspace-general");
   });
 });

--- a/web_src/src/pages/factories/pages/settings/settingsNavItems.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsNavItems.ts
@@ -37,6 +37,11 @@ export interface FactorySettingsNavItem {
   Icon: LucideIcon;
   scope: FactorySettingsScope;
   section: FactorySettingsSection;
+  /**
+   * Searchable page content: field labels, card titles, and short aliases.
+   * Find settings matches these in addition to the nav label and group label.
+   */
+  keywords?: string[];
 }
 
 export interface FactorySettingsNavGroup {
@@ -50,43 +55,305 @@ export const FACTORY_SETTINGS_NAV_GROUPS: FactorySettingsNavGroup[] = [
     id: "account",
     label: "Account",
     items: [
-      { id: "account-profile", label: "Profile", Icon: CircleUser, scope: "account", section: "profile" },
-      { id: "account-security", label: "Security", Icon: Shield, scope: "account", section: "security" },
-      { id: "account-notifications", label: "Notifications", Icon: Bell, scope: "account", section: "notifications" },
+      {
+        id: "account-profile",
+        label: "Profile",
+        Icon: CircleUser,
+        scope: "account",
+        section: "profile",
+        keywords: [
+          "identity",
+          "name",
+          "primary email",
+          "avatar",
+          "appearance",
+          "theme",
+          "light",
+          "dark",
+          "system",
+          "github for velocity",
+          "velocity",
+          "pull requests",
+          "danger zone",
+          "delete account",
+        ],
+      },
+      {
+        id: "account-security",
+        label: "Security",
+        Icon: Shield,
+        scope: "account",
+        section: "security",
+        keywords: [
+          "sign in methods",
+          "password",
+          "change password",
+          "github",
+          "google",
+          "sso",
+          "personal tokens",
+          "create token",
+          "revoke",
+          "cli",
+          "api",
+          "login",
+        ],
+      },
+      {
+        id: "account-notifications",
+        label: "Notifications",
+        Icon: Bell,
+        scope: "account",
+        section: "notifications",
+        keywords: [
+          "email",
+          "send task emails",
+          "task emails",
+          "events",
+          "mentions",
+          "comments",
+          "task owner",
+          "artifacts",
+          "review requests",
+          "status changes",
+          "workspaces",
+          "all workspaces",
+          "selected workspaces",
+        ],
+      },
     ],
   },
   {
     id: "workspace",
     label: "Workspace",
     items: [
-      { id: "workspace-general", label: "General", Icon: Grid3x3, scope: "workspace", section: "general" },
-      { id: "workspace-repository", label: "Repository", Icon: Blocks, scope: "workspace", section: "repository" },
-      { id: "workspace-automations", label: "Automations", Icon: Workflow, scope: "workspace", section: "automations" },
-      { id: "workspace-models", label: "Models", Icon: Cpu, scope: "workspace", section: "models" },
-      { id: "workspace-spending", label: "Spending", Icon: BarChart3, scope: "workspace", section: "spending" },
+      {
+        id: "workspace-general",
+        label: "General",
+        Icon: Grid3x3,
+        scope: "workspace",
+        section: "general",
+        keywords: [
+          "name",
+          "workspace key",
+          "key",
+          "description",
+          "task identifier",
+          "task ids",
+          "danger zone",
+          "delete workspace",
+        ],
+      },
+      {
+        id: "workspace-repository",
+        label: "Repository",
+        Icon: Blocks,
+        scope: "workspace",
+        section: "repository",
+        keywords: [
+          "github repository",
+          "repo",
+          "git",
+          "github",
+          "issue intake",
+          "pull request automations",
+          "save repository",
+        ],
+      },
+      {
+        id: "workspace-automations",
+        label: "Automations",
+        Icon: Workflow,
+        scope: "workspace",
+        section: "automations",
+        keywords: ["new automation", "triggers", "lines", "canvas", "canvases"],
+      },
+      {
+        id: "workspace-models",
+        label: "Models",
+        Icon: Cpu,
+        scope: "workspace",
+        section: "models",
+        keywords: [
+          "llm",
+          "ai",
+          "allowlist",
+          "anthropic",
+          "openai",
+          "openrouter",
+          "superplane-hosted models",
+          "use your keys",
+          "byok",
+          "organization list",
+          "save models",
+        ],
+      },
+      {
+        id: "workspace-spending",
+        label: "Spending",
+        Icon: BarChart3,
+        scope: "workspace",
+        section: "spending",
+        keywords: [
+          "billing",
+          "usage",
+          "cost",
+          "credit",
+          "tokens",
+          "vm time",
+          "estimated spend",
+          "hosted spend limit",
+          "no limit",
+          "limit in usd",
+          "remaining hosted credit",
+          "hosted billed spend",
+          "by model",
+          "by machine type",
+        ],
+      },
     ],
   },
   {
     id: "organization",
     label: "Organization",
     items: [
-      { id: "organization-general", label: "General", Icon: Settings, scope: "organization", section: "general" },
-      { id: "organization-members", label: "Members", Icon: Users, scope: "organization", section: "members" },
+      {
+        id: "organization-general",
+        label: "General",
+        Icon: Settings,
+        scope: "organization",
+        section: "general",
+        keywords: ["name", "organization slug", "slug", "workspace url"],
+      },
+      {
+        id: "organization-members",
+        label: "Members",
+        Icon: Users,
+        scope: "organization",
+        section: "members",
+        keywords: [
+          "invite",
+          "invite link",
+          "copy link",
+          "people",
+          "team",
+          "role",
+          "email",
+          "name",
+          "remove",
+          "owner",
+          "admin",
+        ],
+      },
       {
         id: "organization-integrations",
         label: "Integrations",
         Icon: Plug,
         scope: "organization",
         section: "integrations",
+        keywords: ["connect", "filter integrations", "github", "slack", "request it"],
       },
-      { id: "organization-api-keys", label: "API keys", Icon: KeyRound, scope: "organization", section: "api-keys" },
-      { id: "organization-secrets", label: "Secrets", Icon: Key, scope: "organization", section: "secrets" },
-      { id: "organization-spending", label: "Spending", Icon: BarChart3, scope: "organization", section: "spending" },
+      {
+        id: "organization-api-keys",
+        label: "API keys",
+        Icon: KeyRound,
+        scope: "organization",
+        section: "api-keys",
+        keywords: [
+          "create api key",
+          "programmatic access",
+          "name",
+          "description",
+          "role",
+          "access",
+          "expiration",
+          "organization-wide",
+          "selected apps",
+          "credentials",
+          "token",
+        ],
+      },
+      {
+        id: "organization-secrets",
+        label: "Secrets",
+        Icon: Key,
+        scope: "organization",
+        section: "secrets",
+        keywords: ["create secret", "secret name", "key-value pairs", "credentials", "env"],
+      },
+      {
+        id: "organization-spending",
+        label: "Spending",
+        Icon: BarChart3,
+        scope: "organization",
+        section: "spending",
+        keywords: [
+          "billing",
+          "usage",
+          "cost",
+          "credit",
+          "tokens",
+          "vm time",
+          "estimated spend",
+          "remaining hosted credit",
+          "superplane grant",
+          "purchased hosted credit",
+          "add hosted credit",
+          "polar invoices",
+          "manage invoices",
+          "use your keys",
+          "byok",
+          "anthropic",
+          "openai",
+          "openrouter",
+          "by model",
+          "by machine type",
+        ],
+      },
     ],
   },
 ];
 
 export const FACTORY_SETTINGS_NAV_ITEMS = FACTORY_SETTINGS_NAV_GROUPS.flatMap((group) => group.items);
+
+/**
+ * Filters settings nav groups for the Find settings field.
+ * Matches item labels, indexed page content, and group labels (group match keeps all items).
+ */
+export function filterFactorySettingsNavGroups(
+  groups: FactorySettingsNavGroup[],
+  query: string,
+): FactorySettingsNavGroup[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return groups;
+  }
+
+  return groups
+    .map((group) => {
+      if (group.label.toLowerCase().includes(normalized)) {
+        return group;
+      }
+
+      const items = group.items.filter((item) => navItemMatchesQuery(item, normalized));
+      return { ...group, items };
+    })
+    .filter((group) => group.items.length > 0);
+}
+
+function navItemSearchText(item: FactorySettingsNavItem): string {
+  return [item.label, ...(item.keywords ?? [])].join(" ").toLowerCase();
+}
+
+function navItemMatchesQuery(item: FactorySettingsNavItem, normalizedQuery: string): boolean {
+  const haystack = navItemSearchText(item);
+  if (haystack.includes(normalizedQuery)) {
+    return true;
+  }
+
+  const words = normalizedQuery.split(/\s+/).filter(Boolean);
+  return words.length > 1 && words.every((word) => haystack.includes(word));
+}
 
 export function factorySettingsRouteFromPathname(pathname: string) {
   const segments = pathname.split("/").filter(Boolean);

--- a/web_src/src/pages/factories/pages/settings/settingsSearch.spec.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsSearch.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { FACTORY_SETTINGS_NAV_GROUPS } from "./settingsNavItems";
+import {
+  buildFactorySettingsSearchIndex,
+  factorySettingsIntegrationSearchEntries,
+  factorySettingsSearchResultPath,
+  searchFactorySettings,
+} from "./settingsSearch";
+
+const index = buildFactorySettingsSearchIndex({
+  navGroups: FACTORY_SETTINGS_NAV_GROUPS,
+  integrations: [
+    { name: "claude", label: "Claude", description: "Use Claude models in workflows" },
+    { name: "github", label: "GitHub", description: "Connect repositories" },
+  ],
+});
+
+describe("searchFactorySettings", () => {
+  it("returns Claude under Organization Integrations", () => {
+    const results = searchFactorySettings(index, "claude");
+    expect(results[0]?.title).toBe("Claude");
+    expect(results[0]?.breadcrumb).toEqual(["Organization", "Integrations"]);
+    expect(results[0]?.anchor).toBe("integration-claude");
+    expect(results[0]?.section).toBe("integrations");
+  });
+
+  it("returns Workspace key under Workspace General", () => {
+    const results = searchFactorySettings(index, "workspace key");
+    expect(results[0]?.title).toBe("Workspace key");
+    expect(results[0]?.breadcrumb).toEqual(["Workspace", "General"]);
+    expect(results[0]?.anchor).toBe("factory-settings-key");
+  });
+
+  it("returns an empty list for a miss", () => {
+    expect(searchFactorySettings(index, "zzzz-no-match")).toEqual([]);
+  });
+
+  it("indexes known providers like Claude even without a live catalog response", () => {
+    const withoutCatalog = buildFactorySettingsSearchIndex({ navGroups: FACTORY_SETTINGS_NAV_GROUPS });
+    const results = searchFactorySettings(withoutCatalog, "claude");
+    expect(results[0]?.title).toBe("Claude");
+    expect(results[0]?.anchor).toBe("integration-claude");
+  });
+
+  it("keeps the specific Identity hit and drops the Profile page hit for email", () => {
+    const results = searchFactorySettings(index, "email");
+    const titles = results.map((result) => result.title);
+    expect(titles).toContain("Identity");
+    expect(titles).not.toContain("Profile");
+    expect(results.find((result) => result.title === "Identity")?.breadcrumb).toEqual(["Account", "Profile"]);
+  });
+
+  it("keeps the Security page and Sign in methods when the query matches the page title", () => {
+    const titles = searchFactorySettings(index, "secur").map((result) => result.title);
+    expect(titles).toContain("Security");
+    expect(titles).toContain("Sign in methods");
+  });
+});
+
+describe("factorySettingsIntegrationSearchEntries", () => {
+  it("builds an anchor per provider", () => {
+    expect(factorySettingsIntegrationSearchEntries([{ name: "claude", label: "Claude" }])).toEqual([
+      expect.objectContaining({
+        id: "integration:claude",
+        title: "Claude",
+        anchor: "integration-claude",
+      }),
+    ]);
+  });
+});
+
+describe("factorySettingsSearchResultPath", () => {
+  it("appends the section query when an anchor exists", () => {
+    const result = searchFactorySettings(index, "claude")[0]!;
+    expect(
+      factorySettingsSearchResultPath("org", "RF", result, (_o, _f, scope, section) => `/settings/${scope}/${section}`),
+    ).toBe("/settings/organization/integrations?section=integration-claude");
+  });
+});

--- a/web_src/src/pages/factories/pages/settings/settingsSearch.ts
+++ b/web_src/src/pages/factories/pages/settings/settingsSearch.ts
@@ -1,0 +1,300 @@
+import type { IntegrationsIntegrationDefinition } from "@/api-client/types.gen";
+import { knownIntegrationTypeEntries } from "@/lib/integrationDisplayName";
+
+import type { FactorySettingsScope } from "../../lib/factoryPagePaths";
+import {
+  FACTORY_SETTINGS_NAV_GROUPS,
+  type FactorySettingsNavGroup,
+  type FactorySettingsSection,
+} from "./settingsNavItems";
+
+export type FactorySettingsSearchResult = {
+  id: string;
+  title: string;
+  breadcrumb: string[];
+  scope: FactorySettingsScope;
+  section: FactorySettingsSection;
+  /** DOM id to scroll to after navigation (without #). */
+  anchor?: string;
+  keywords: string[];
+};
+
+const GROUP_LABEL: Record<FactorySettingsScope, string> = {
+  account: "Account",
+  workspace: "Workspace",
+  organization: "Organization",
+};
+
+/** Static section-level entries: field labels, cards, and page titles users search for. */
+export const FACTORY_SETTINGS_SEARCH_ENTRIES: FactorySettingsSearchResult[] = [
+  // Account · Profile
+  entry("account", "profile", "Profile", undefined, ["identity", "name", "avatar"]),
+  entry("account", "profile", "Identity", "account-redesign-identity", ["name", "primary email", "email", "avatar"]),
+  entry("account", "profile", "Appearance", "account-redesign-appearance", ["theme", "light", "dark", "system"]),
+  entry("account", "profile", "GitHub for Velocity", "account-redesign-velocity-github", [
+    "github",
+    "velocity",
+    "pull requests",
+  ]),
+  entry("account", "profile", "Delete account", "account-redesign-danger", ["danger zone", "delete account"]),
+
+  // Account · Security
+  entry("account", "security", "Security", undefined, ["sign in", "password", "token", "sso", "login"]),
+  entry("account", "security", "Sign in methods", "account-redesign-signin", [
+    "password",
+    "change password",
+    "github",
+    "google",
+    "sso",
+  ]),
+  entry("account", "security", "Personal tokens", "account-redesign-tokens", [
+    "create token",
+    "revoke",
+    "cli",
+    "api",
+    "token",
+  ]),
+
+  // Account · Notifications
+  entry("account", "notifications", "Notifications", "account-redesign-notifications", [
+    "email",
+    "send task emails",
+    "task emails",
+    "events",
+    "mentions",
+    "comments",
+  ]),
+
+  // Workspace · General
+  entry("workspace", "general", "General", "factory-settings-general-form", ["name", "workspace key", "description"]),
+  entry("workspace", "general", "Workspace key", "factory-settings-key", [
+    "workspace key",
+    "key",
+    "task identifier",
+    "task ids",
+  ]),
+  entry("workspace", "general", "Delete workspace", "factory-settings-danger-zone", [
+    "danger zone",
+    "delete workspace",
+  ]),
+
+  // Workspace · Repository
+  entry("workspace", "repository", "Repository", "factory-settings-repository", [
+    "github repository",
+    "repo",
+    "git",
+    "github",
+    "issue intake",
+  ]),
+
+  // Workspace · Automations
+  entry("workspace", "automations", "Automations", undefined, ["new automation", "triggers", "lines", "canvas"]),
+
+  // Workspace · Models
+  entry("workspace", "models", "Models", undefined, [
+    "llm",
+    "ai",
+    "allowlist",
+    "anthropic",
+    "openai",
+    "openrouter",
+    "byok",
+    "use your keys",
+  ]),
+
+  // Workspace · Spending
+  entry("workspace", "spending", "Spending", undefined, [
+    "billing",
+    "usage",
+    "cost",
+    "credit",
+    "tokens",
+    "vm time",
+    "hosted spend limit",
+  ]),
+
+  // Organization · General
+  entry("organization", "general", "General", undefined, ["name", "organization slug", "slug", "workspace url"]),
+
+  // Organization · Members
+  entry("organization", "members", "Members", undefined, ["invite", "invite link", "people", "team", "role"]),
+
+  // Organization · Integrations (page-level; providers are added dynamically)
+  entry("organization", "integrations", "Integrations", undefined, ["connect", "filter integrations", "integration"]),
+
+  // Organization · API keys / Secrets / Spending
+  entry("organization", "api-keys", "API keys", undefined, ["create api key", "token", "credentials", "programmatic"]),
+  entry("organization", "secrets", "Secrets", undefined, ["create secret", "credentials", "env", "key-value"]),
+  entry("organization", "spending", "Spending", undefined, [
+    "billing",
+    "usage",
+    "credit",
+    "hosted credit",
+    "polar invoices",
+    "byok",
+  ]),
+];
+
+function entry(
+  scope: FactorySettingsScope,
+  section: FactorySettingsSection,
+  title: string,
+  anchor: string | undefined,
+  keywords: string[],
+): FactorySettingsSearchResult {
+  const pageLabel =
+    FACTORY_SETTINGS_NAV_GROUPS.find((group) => group.id === scope)?.items.find((item) => item.section === section)
+      ?.label ?? title;
+
+  return {
+    id: anchor ? `section:${scope}:${section}:${anchor}` : `nav:${scope}:${section}`,
+    title,
+    breadcrumb: title === pageLabel ? [GROUP_LABEL[scope]] : [GROUP_LABEL[scope], pageLabel],
+    scope,
+    section,
+    anchor,
+    keywords,
+  };
+}
+
+/** One search hit per available integration provider (e.g. Claude). */
+export function factorySettingsIntegrationSearchEntries(
+  integrations: Array<Pick<IntegrationsIntegrationDefinition, "name" | "label" | "description">>,
+): FactorySettingsSearchResult[] {
+  return integrations
+    .filter((integration) => Boolean(integration.name))
+    .map((integration) => {
+      const name = integration.name!;
+      const label = integration.label || name;
+      return {
+        id: `integration:${name}`,
+        title: label,
+        breadcrumb: ["Organization", "Integrations"],
+        scope: "organization" as const,
+        section: "integrations" as const,
+        anchor: `integration-${name}`,
+        keywords: [name, label, integration.description ?? ""].filter(Boolean),
+      };
+    });
+}
+
+export function buildFactorySettingsSearchIndex(options: {
+  navGroups: FactorySettingsNavGroup[];
+  integrations?: Array<Pick<IntegrationsIntegrationDefinition, "name" | "label" | "description">>;
+}): FactorySettingsSearchResult[] {
+  const allowed = new Set(
+    options.navGroups.flatMap((group) => group.items.map((item) => `${item.scope}/${item.section}`)),
+  );
+
+  const staticEntries = FACTORY_SETTINGS_SEARCH_ENTRIES.filter((result) =>
+    allowed.has(`${result.scope}/${result.section}`),
+  );
+
+  const providersByName = new Map<string, Pick<IntegrationsIntegrationDefinition, "name" | "label" | "description">>();
+  for (const known of knownIntegrationTypeEntries()) {
+    providersByName.set(known.name, known);
+  }
+  for (const integration of options.integrations ?? []) {
+    if (!integration.name) {
+      continue;
+    }
+    providersByName.set(integration.name, {
+      name: integration.name,
+      label: integration.label || providersByName.get(integration.name)?.label || integration.name,
+      description: integration.description || providersByName.get(integration.name)?.description,
+    });
+  }
+
+  const integrationEntries = factorySettingsIntegrationSearchEntries([...providersByName.values()]).filter((result) =>
+    allowed.has(`${result.scope}/${result.section}`),
+  );
+
+  return [...staticEntries, ...integrationEntries];
+}
+
+/**
+ * Cursor-style settings search: returns matching section and integration hits.
+ * Prefers title matches, then breadcrumb/keyword matches.
+ * Drops a page-level hit when a more specific section on the same page also matches.
+ */
+export function searchFactorySettings(
+  entries: FactorySettingsSearchResult[],
+  query: string,
+): FactorySettingsSearchResult[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return [];
+  }
+
+  const scored = entries
+    .map((result) => ({ result, score: scoreSearchResult(result, normalized) }))
+    .filter((row) => row.score > 0)
+    .sort((a, b) => b.score - a.score || a.result.title.localeCompare(b.result.title));
+
+  return dropRedundantPageHits(
+    scored.map((row) => row.result),
+    normalized,
+  );
+}
+
+/**
+ * If Identity (Account › Profile) matches, do not also list Profile (Account).
+ * Keep the page hit when the query matches the page title (Security + Sign in methods).
+ * Page-level entries have no anchor; section/integration entries do.
+ */
+function dropRedundantPageHits(
+  results: FactorySettingsSearchResult[],
+  normalizedQuery: string,
+): FactorySettingsSearchResult[] {
+  const pagesWithSectionHits = new Set(
+    results.filter((result) => Boolean(result.anchor)).map((result) => `${result.scope}/${result.section}`),
+  );
+
+  return results.filter((result) => {
+    if (result.anchor) {
+      return true;
+    }
+    if (!pagesWithSectionHits.has(`${result.scope}/${result.section}`)) {
+      return true;
+    }
+    return result.title.toLowerCase().includes(normalizedQuery);
+  });
+}
+
+function scoreSearchResult(result: FactorySettingsSearchResult, normalizedQuery: string): number {
+  const title = result.title.toLowerCase();
+  if (title === normalizedQuery) {
+    return 100;
+  }
+  if (title.startsWith(normalizedQuery)) {
+    return 80;
+  }
+  if (title.includes(normalizedQuery)) {
+    return 60;
+  }
+
+  const haystack = [result.title, ...result.breadcrumb, ...result.keywords].join(" ").toLowerCase();
+  if (haystack.includes(normalizedQuery)) {
+    return 40;
+  }
+
+  const words = normalizedQuery.split(/\s+/).filter(Boolean);
+  if (words.length > 1 && words.every((word) => haystack.includes(word))) {
+    return 30;
+  }
+
+  return 0;
+}
+
+export function factorySettingsSearchResultPath(
+  organizationId: string,
+  factoryKey: string,
+  result: FactorySettingsSearchResult,
+  sectionPath: (organizationId: string, factoryKey: string, scope: FactorySettingsScope, section: string) => string,
+): string {
+  const path = sectionPath(organizationId, factoryKey, result.scope, result.section);
+  if (!result.anchor) {
+    return path;
+  }
+  return `${path}?section=${encodeURIComponent(result.anchor)}`;
+}

--- a/web_src/src/pages/factories/pages/settings/useFactorySettingsSectionScroll.ts
+++ b/web_src/src/pages/factories/pages/settings/useFactorySettingsSectionScroll.ts
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { useLocation, useSearchParams } from "react-router";
+
+const SECTION_QUERY = "section";
+const MAX_SCROLL_FRAMES = 45;
+
+/**
+ * After Find settings navigates with `?section=<id>`, scroll that element into
+ * view inside the settings main pane. Retries briefly so async catalog cards
+ * (integrations) can mount first.
+ */
+export function useFactorySettingsSectionScroll() {
+  const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
+  const sectionId = searchParams.get(SECTION_QUERY);
+
+  useEffect(() => {
+    if (!sectionId) {
+      return;
+    }
+
+    let frames = 0;
+    let raf = 0;
+    let cancelled = false;
+
+    const tryScroll = () => {
+      if (cancelled) {
+        return;
+      }
+
+      const target = document.getElementById(sectionId);
+      if (target) {
+        target.scrollIntoView({ block: "start", behavior: "smooth" });
+        return;
+      }
+
+      frames += 1;
+      if (frames < MAX_SCROLL_FRAMES) {
+        raf = window.requestAnimationFrame(tryScroll);
+      }
+    };
+
+    raf = window.requestAnimationFrame(() => {
+      raf = window.requestAnimationFrame(tryScroll);
+    });
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(raf);
+    };
+  }, [pathname, sectionId]);
+}
+
+export function factorySettingsSectionQuery(anchor: string | undefined): string {
+  if (!anchor) {
+    return "";
+  }
+  return `?${SECTION_QUERY}=${encodeURIComponent(anchor)}`;
+}

--- a/web_src/src/pages/organization/settings/IntegrationCatalog.tsx
+++ b/web_src/src/pages/organization/settings/IntegrationCatalog.tsx
@@ -149,7 +149,11 @@ function CatalogProviderCard({
   styles: CatalogStyles;
 }) {
   return (
-    <section className={styles.card}>
+    <section
+      id={`integration-${item.providerName}`}
+      className={cn(styles.card, "scroll-mt-8")}
+      data-testid={`integration-card-${item.providerName}`}
+    >
       <div className={styles.cardHeader}>
         <div className="flex items-start gap-3">
           <div className="mt-0.5 flex size-8 items-center justify-center">


### PR DESCRIPTION
## Summary

Settings pages span Account, Workspace, and Organization. Users must browse the grouped nav to find a field or integration.

This change adds a Find settings field in the workspace settings sidebar. The field matches page titles, in-page sections, and integration providers. A match opens the page and scrolls to the section when an anchor exists.

The search query stays in the sidebar after navigation. The grouped nav returns when the field is empty.

## Test plan

- [ ] Open workspace settings and confirm the Find settings field is in the sidebar.
- [ ] Type `secur` and confirm Security and Sign in methods appear.
- [ ] Confirm the grouped Account, Workspace, and Organization nav is hidden.
- [ ] Type `billing` and confirm Spending results appear for Workspace and Organization.
- [ ] Type `workspace key`, open the match, and confirm the page scrolls to that field.
- [ ] Type `claude` and confirm Claude shows under Organization › Integrations.
- [ ] Open the Claude result and confirm the Integrations page scrolls to the Claude card.
- [ ] Type a query with no match and confirm the empty state shows.
- [ ] Open a match and confirm the Find settings query stays in the field.
- [ ] Clear the field and confirm the grouped nav returns.
- [ ] Confirm Models stays hidden in search when the workspace-models feature is off.