### PR TITLE
fix(web): correct status badge padding and width in legacy integrations

### DIFF
--- a/web_src/src/pages/organization/settings/IntegrationCatalog.tsx
+++ b/web_src/src/pages/organization/settings/IntegrationCatalog.tsx
@@ -231,7 +231,9 @@ function CatalogInstanceRow({
   return (
     <div className={styles.instanceRow}>
       <Plug className={`size-4 shrink-0 ${instancePlugClass(state, styles)}`} />
-      <span className={instanceStatusLabelClass(appearance, state, styles)}>{integrationStatusLabel(state)}</span>
+      <div className={styles.statusLabelWrap}>
+        <span className={instanceStatusLabelClass(appearance, state, styles)}>{integrationStatusLabel(state)}</span>
+      </div>
       <p className={styles.instanceName}>{integration.metadata?.name}</p>
       <div className="ml-auto">
         <PermissionTooltip

--- a/web_src/src/pages/organization/settings/integrationCatalogAppearance.ts
+++ b/web_src/src/pages/organization/settings/integrationCatalogAppearance.ts
@@ -33,7 +33,8 @@ export function catalogAppearance(appearance: CatalogAppearance) {
       plugReady: "text-green-600",
       plugError: "text-destructive",
       plugOther: "text-amber-600",
-      statusLabel: "w-16 text-[12px] font-medium text-muted-foreground",
+      statusLabel: "text-[12px] font-medium text-muted-foreground",
+      statusLabelWrap: "w-16 shrink-0",
       footerRequest: "mt-6 text-center text-[13px] text-muted-foreground",
     };
   }
@@ -62,7 +63,8 @@ export function catalogAppearance(appearance: CatalogAppearance) {
     plugReady: "text-green-500",
     plugError: "text-red-500",
     plugOther: "text-amber-600",
-    statusLabel: "inline-flex w-16 items-center justify-start rounded text-xs font-medium",
+    statusLabel: "inline-flex w-fit items-center rounded px-1.5 py-0.5 text-xs font-medium",
+    statusLabelWrap: "min-w-16 shrink-0",
     footerRequest: "mt-6 text-center text-sm text-gray-500 dark:text-gray-400",
   };
 }


### PR DESCRIPTION
Refs #7037

## Scope

This PR addresses **only** the visual glitch around the "Ready" status badge described in #7037.

The other problem reported in the same issue — the screen showing **"Connect"** even though there is an active connection via a custom app — is **not** included here. That is a state/status problem that most likely lives in the backend, and it deserves a separate change rather than being bundled into a CSS fix.

Using `Refs #7037` instead of `Closes` precisely because part of the issue remains open.

## Root cause

In `web_src/src/pages/organization/settings/integrationCatalogAppearance.ts`, the legacy variant's `statusLabel` was:

```
inline-flex w-16 items-center justify-start rounded text-xs font-medium
```

The fixed `w-16` and `justify-start` were inherited from a layout where the status was plain text — the fixed width existed to keep instance names aligned in a column. Later a background color was added in `instanceStatusLabelClass`, but no padding came with it. The result: the badge painted the full 4rem box, with the text flush against the left edge and a block of unused color trailing to the right.

The fixed width could not simply be removed, since it is what keeps the instance names aligned.

## Approach

Separate the two responsibilities that were conflated in a single class:

- **Column alignment** moves to a new wrapper class, `statusLabelWrap`, applied to a `div` around the badge.
- **The badge itself** sizes to its content (`w-fit`) and gets real padding (`px-1.5 py-0.5`).

The legacy wrapper uses `min-w-16` rather than `w-16`, so that longer status strings coming from the API are not clipped. The `factories` variant gets the same treatment (`w-16 shrink-0` on the wrapper), keeping its existing appearance unchanged.

`instanceStatusLabelClass` and all colors are untouched.

## Validation

The dev server (`npm run dev`) starts, but the app cannot actually render locally: the generated module `@/api-client` is not checked into the repo and is produced by the Docker stack (`make openapi.web.client.gen`, which needs protoc). Any module with a runtime import of it fails at transform time, e.g.:

```
Failed to resolve import "@/api-client/sdk.gen" from
"src/ui/configurationFieldRenderer/SecretKeyFieldRenderer.tsx"
```

`src/hooks/useIntegrations.ts`, which the catalog page depends on, fails the same way. **So this change could not be verified visually in local**, and a screenshot is not included.

Instead it was validated with differential typecheck and lint against the base commit:

- **Typecheck** (`tsc -b`): 906 errors before, 906 after — all pre-existing and caused by the missing generated `@/api-client`. The two outputs are identical apart from a +2 line-number shift in `IntegrationCatalog.tsx` from the added wrapper. **Zero new type errors.**
- **ESLint**: exit code 0 on both touched files; the full `npm run lint` shows no findings in either file, and `npm run lint:budget` reports `WITHIN BUDGET 618/618`.

A visual check on an environment with the full stack running would be welcome during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQpYdmysS7vVi7Nht9ctz8
