### PR TITLE
fix: Keep planning wait after transient errors

### DIFF
--- a/pkg/components/runner/claude/follow_up_loop.js
+++ b/pkg/components/runner/claude/follow_up_loop.js
@@ -12,6 +12,8 @@ const path = require("path");
 const { spawn } = require("child_process");
 
 const HOLD_SECONDS = 45;
+const MAX_RETRY_WAIT_SECONDS = 60;
+const DEFAULT_RETRY_WAIT_SECONDS = 1;
 
 function nextAction(result) {
   const status = result && result.status ? String(result.status) : "";
@@ -69,13 +71,35 @@ async function requestJSON(method, urlPath) {
       parsed = { message: text };
     }
   }
-  if (!response.ok) {
-    if (response.status === 409) {
-      return { status: "ended" };
-    }
-    throw new Error(parsed.message || parsed.error || text || `HTTP ${response.status}`);
+  return interpretWaitResponse(response.status, parsed, text);
+}
+
+function isTransientWaitFailure(status, parsed) {
+  if (status === 429 || status === 502 || status === 503 || status === 504) {
+    return true;
   }
-  return parsed;
+  return Boolean(parsed && (parsed.retryable === true || parsed.cloudflare_error === true));
+}
+
+function retryWaitSeconds(parsed) {
+  const n = Number(parsed && parsed.retry_after);
+  if (!Number.isFinite(n) || n < 1) {
+    return DEFAULT_RETRY_WAIT_SECONDS;
+  }
+  return Math.min(MAX_RETRY_WAIT_SECONDS, Math.floor(n));
+}
+
+function interpretWaitResponse(status, parsed, text) {
+  if (status === 409) {
+    return { status: "ended" };
+  }
+  if (status >= 200 && status < 300) {
+    return parsed && typeof parsed === "object" ? parsed : {};
+  }
+  if (isTransientWaitFailure(status, parsed)) {
+    return { status: "pending", retry_after: retryWaitSeconds(parsed) };
+  }
+  throw new Error((parsed && (parsed.message || parsed.error)) || text || `HTTP ${status}`);
 }
 
 async function waitOnce() {
@@ -100,9 +124,16 @@ function runPromptFile(taskDir, promptFile, model) {
   });
 }
 
+function defaultSleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 async function runLoop(helpers) {
   const wait = helpers.waitOnce;
   const runPrompt = helpers.runPrompt;
+  const sleep = helpers.sleep || defaultSleep;
   while (true) {
     const result = await wait();
     const action = nextAction(result);
@@ -110,6 +141,11 @@ async function runLoop(helpers) {
       return action.code;
     }
     if (action.type === "wait") {
+      const seconds = Number(result && result.retry_after);
+      if (Number.isFinite(seconds) && seconds > 0) {
+        process.stderr.write(`planning wait hit a transient error; retrying in ${seconds}s\n`);
+        await sleep(seconds * 1000);
+      }
       continue;
     }
     const code = await runPrompt(action.text);
@@ -129,7 +165,7 @@ async function main() {
   process.exit(code);
 }
 
-module.exports = { nextAction, runLoop, writePrompt };
+module.exports = { interpretWaitResponse, nextAction, runLoop, writePrompt };
 
 if (require.main === module) {
   main().catch((err) => {

--- a/pkg/components/runner/claude/follow_up_loop_test.go
+++ b/pkg/components/runner/claude/follow_up_loop_test.go
@@ -1,0 +1,19 @@
+package claude
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFollowUpLoopScript(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is not available")
+	}
+
+	cmd := exec.Command("node", "--test", "follow_up_loop_test.js")
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+}

--- a/pkg/components/runner/claude/follow_up_loop_test.js
+++ b/pkg/components/runner/claude/follow_up_loop_test.js
@@ -2,7 +2,7 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { nextAction, runLoop } = require("./follow_up_loop.js");
+const { interpretWaitResponse, nextAction, runLoop } = require("./follow_up_loop.js");
 
 test("waits while SuperPlane has no event", () => {
   assert.deepEqual(nextAction({ status: "pending" }), { type: "wait" });
@@ -70,4 +70,56 @@ test("runLoop prompts after create or skip", async () => {
   assert.equal(prompts.length, 2);
   assert.match(prompts[0], /NEWWO-12/);
   assert.match(prompts[1], /skipped/i);
+});
+
+test("interpretWaitResponse retries a 502 with retryable body", () => {
+  const got = interpretWaitResponse(502, {
+    error: "An error occurred with your request. Please try again.",
+    retryable: true,
+    retry_after: 60,
+  });
+  assert.deepEqual(got, { status: "pending", retry_after: 60 });
+});
+
+test("interpretWaitResponse retries 503, 504, and 429", () => {
+  assert.equal(interpretWaitResponse(503, {}).status, "pending");
+  assert.equal(interpretWaitResponse(504, {}).status, "pending");
+  assert.equal(interpretWaitResponse(429, { retry_after: 12 }).retry_after, 12);
+});
+
+test("interpretWaitResponse retries a Cloudflare error body", () => {
+  const got = interpretWaitResponse(500, { cloudflare_error: true, retry_after: 30 });
+  assert.deepEqual(got, { status: "pending", retry_after: 30 });
+});
+
+test("interpretWaitResponse caps retry_after at 60 seconds", () => {
+  const got = interpretWaitResponse(502, { retryable: true, retry_after: 120 });
+  assert.equal(got.retry_after, 60);
+});
+
+test("interpretWaitResponse ends on 409", () => {
+  assert.deepEqual(interpretWaitResponse(409, { message: "conflict" }), { status: "ended" });
+});
+
+test("interpretWaitResponse throws on 401", () => {
+  assert.throws(() => interpretWaitResponse(401, { message: "unauthorized" }), /unauthorized/);
+});
+
+test("runLoop waits again after a transient wait, then exits 0", async () => {
+  const sleeps = [];
+  const results = [
+    { status: "pending", retry_after: 60 },
+    { status: "ended" },
+  ];
+  const code = await runLoop({
+    waitOnce: async () => results.shift(),
+    runPrompt: async () => {
+      throw new Error("prompt must not run");
+    },
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  assert.equal(code, 0);
+  assert.deepEqual(sleeps, [60000]);
 });

--- a/pkg/public/runner_planning_session.go
+++ b/pkg/public/runner_planning_session.go
@@ -76,18 +76,20 @@ func (s *Server) handleRunnerPlanningWait(w http.ResponseWriter, r *http.Request
 			return
 		}
 		if session.WaitState == models.PlanningWaitResolved {
-			result, err := session.ConsumeWait(database.DB(r.Context()))
+			result, consumed, err := consumeResolvedWait(session, database.DB(r.Context()))
 			if err != nil {
 				writeRunnerPlanningError(w, err)
 				return
 			}
-			writeJSON(w, http.StatusOK, map[string]any{
-				"status":         result.Kind,
-				"text":           result.Text,
-				"work_order_id":  result.WorkOrderID,
-				"work_order_key": result.WorkOrderKey,
-			})
-			return
+			if consumed {
+				writeJSON(w, http.StatusOK, map[string]any{
+					"status":         result.Kind,
+					"text":           result.Text,
+					"work_order_id":  result.WorkOrderID,
+					"work_order_key": result.WorkOrderKey,
+				})
+				return
+			}
 		}
 		if err := session.BeginWait(database.DB(r.Context())); err != nil {
 			writeRunnerPlanningError(w, err)
@@ -152,6 +154,17 @@ func (s *Server) handleRunnerPlanningSurvey(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"status": "shown"})
+}
+
+func consumeResolvedWait(session *models.FactoryPlanningSession, tx *gorm.DB) (models.PlanningWaitResult, bool, error) {
+	result, err := session.ConsumeWait(tx)
+	if errors.Is(err, models.ErrFactoryPlanningWaitIdle) {
+		return models.PlanningWaitResult{}, false, nil
+	}
+	if err != nil {
+		return models.PlanningWaitResult{}, false, err
+	}
+	return result, true, nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/pkg/public/runner_planning_session_test.go
+++ b/pkg/public/runner_planning_session_test.go
@@ -2,8 +2,10 @@ package public
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,8 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 	runneraction "github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/gorm"
 )
 
 func TestRunnerPlanningSessionDraft(t *testing.T) {
@@ -109,4 +113,105 @@ func TestRunnerPlanningSessionRejectsOtherToken(t *testing.T) {
 	rec := httptest.NewRecorder()
 	server.Router.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestConsumeResolvedWaitTreatsDoubleConsumeAsMiss(t *testing.T) {
+	r := support.Setup(t)
+	_, session, factoryModel, _ := mustPlanningRunnerSession(t, r)
+	db := database.DB(t.Context())
+	requireResolvedCreatedWait(t, db, session, factoryModel)
+
+	winner, err := models.FindPlanningSession(db, session.OrganizationID, session.FactoryID, session.ID)
+	require.NoError(t, err)
+	loser, err := models.FindPlanningSession(db, session.OrganizationID, session.FactoryID, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.PlanningWaitResolved, winner.WaitState)
+	require.Equal(t, models.PlanningWaitResolved, loser.WaitState)
+
+	result, consumed, err := consumeResolvedWait(winner, db)
+	require.NoError(t, err)
+	assert.True(t, consumed)
+	assert.Equal(t, models.PlanningWaitKindCreated, result.Kind)
+
+	_, consumed, err = consumeResolvedWait(loser, db)
+	require.NoError(t, err)
+	assert.False(t, consumed)
+}
+
+func TestRunnerPlanningWaitDoubleConsumeReturnsPending(t *testing.T) {
+	r := support.Setup(t)
+	server, session, factoryModel, token := mustPlanningRunnerSession(t, r)
+	db := database.DB(t.Context())
+	requireResolvedCreatedWait(t, db, session, factoryModel)
+
+	const waiters = 2
+	recs := make([]*httptest.ResponseRecorder, waiters)
+	var wg sync.WaitGroup
+	wg.Add(waiters)
+	for i := range recs {
+		go func(i int) {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/runner/planning-sessions/wait?hold_seconds=1", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+			server.Router.ServeHTTP(rec, req)
+			recs[i] = rec
+		}(i)
+	}
+	wg.Wait()
+
+	createdCount := 0
+	for _, rec := range recs {
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		status, _ := body["status"].(string)
+		require.Contains(t, []string{models.PlanningWaitKindCreated, "pending"}, status)
+		if status == models.PlanningWaitKindCreated {
+			createdCount++
+		}
+	}
+	assert.Equal(t, 1, createdCount)
+}
+
+func mustPlanningRunnerSession(t *testing.T, r *support.ResourceRegistry) (*Server, *models.FactoryPlanningSession, *models.Factory, string) {
+	t.Helper()
+	server, signer := mustRunnerLiveLogServer(t, r)
+	db := database.DB(t.Context())
+	factoryModel, err := models.CreateFactory(db, r.Organization.ID, support.RandomName("factory"), "", "")
+	require.NoError(t, err)
+	canvas, entrypoint := support.CreateFactoryAppWithOnRunTrigger(t, r, factoryModel.ID, "planning", "start")
+	session, err := factoryModel.StartPlanningSession(db, models.StartPlanningSessionParams{
+		CreatedByUserID: r.User,
+		Repository:      "acme/payments",
+		CanvasID:        canvas.ID,
+		Entrypoint:      entrypoint,
+	})
+	require.NoError(t, err)
+	return server, session, factoryModel, mustPlanningRunnerToken(t, signer, session)
+}
+
+func mustPlanningRunnerToken(t *testing.T, signer *jwt.Signer, session *models.FactoryPlanningSession) string {
+	t.Helper()
+	require.NotNil(t, session.CanvasRunID)
+	token, err := runneraction.MintPlanningSessionToken(signer, runneraction.PlanningSessionScope{
+		OrganizationID: session.OrganizationID,
+		FactoryID:      session.FactoryID,
+		SessionID:      session.ID,
+		CanvasRunID:    *session.CanvasRunID,
+	}, time.Hour)
+	require.NoError(t, err)
+	return token
+}
+
+func requireResolvedCreatedWait(t *testing.T, db *gorm.DB, session *models.FactoryPlanningSession, factoryModel *models.Factory) {
+	t.Helper()
+	require.NoError(t, session.ProposeDraft(db, models.PlanningSessionDraft{
+		Title:       "Retry refunds",
+		Description: "Stop double charges.",
+	}))
+	require.NoError(t, session.BeginWait(db))
+	_, err := session.CreateDraftWorkOrder(db, factoryModel, session.CreatedByUserID)
+	require.NoError(t, err)
+	require.Equal(t, models.PlanningWaitResolved, session.WaitState)
 }


### PR DESCRIPTION
## Summary

A Cloudflare 502 on the planning wait hold failed the Planning Agent after a good Claude turn. Two overlapping wait polls after create also returned HTTP 500.

The runner now retries transient wait errors and sleeps `retry_after`. SuperPlane treats an already-consumed wait as pending. It does not log that case as an error.

## Test plan

- [ ] Run `node --test follow_up_loop_test.js` in `pkg/components/runner/claude`.
- [ ] Confirm a 502 wait then `ended` exits 0. Confirm 409 still ends. Confirm 401 still fails.
- [ ] Run `make test PKG_TEST_PACKAGES=./pkg/public`.
- [ ] Confirm two overlapping waits after create return one `created` and one `pending`. Confirm no HTTP 500.


Made with [Cursor](https://cursor.com)