### PR TITLE
fix: Move velocity sync into an overflow menu

### DIFF
--- a/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
@@ -159,7 +159,8 @@ describe("VelocityPage shell", () => {
     velocityHookState.data = populatedResponse();
 
     renderShell(FACTORY_WITH_SETUP_REPO);
-    await userEvent.click(screen.getByTestId("velocity-sync-button"));
+    await userEvent.click(screen.getByTestId("velocity-overflow-menu"));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Refresh data" }));
 
     expect(startSync).toHaveBeenCalledTimes(1);
   });
@@ -186,13 +187,13 @@ describe("VelocityPage shell", () => {
     expect(screen.queryByTestId("velocity-sync-progress")).not.toBeInTheDocument();
   });
 
-  it("hides the sync control when there is no repository to read", () => {
+  it("hides the overflow menu when there is no repository to read", () => {
     resetState();
     velocityHookState.data = populatedResponse();
 
     renderShell();
 
-    expect(screen.queryByTestId("velocity-sync-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("velocity-overflow-menu")).not.toBeInTheDocument();
   });
 
   it("keeps the report when a refetch fails and cached data remains", () => {

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactNode } from "react";
-import { AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import { AlertCircle, Loader2, MoreHorizontal, RefreshCw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { cn } from "@/lib/utils";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { SegmentedNav } from "@/ui/SegmentedNav";
 
 import { useFactoriesLayout } from "../layout/factoriesLayoutContext";
@@ -145,7 +146,6 @@ function VelocityHeaderBar({ model }: { model: VelocityPageModel }) {
       }
       actions={
         <div className="flex items-center gap-2">
-          <VelocitySyncButton model={model} />
           <SegmentedNav
             ariaLabel="Velocity period in days"
             size="xs"
@@ -156,6 +156,7 @@ function VelocityHeaderBar({ model }: { model: VelocityPageModel }) {
             }}
             options={VELOCITY_PERIOD_OPTIONS}
           />
+          <VelocityOverflowMenu model={model} />
         </div>
       }
     />
@@ -187,26 +188,40 @@ function VelocitySyncProgress() {
  * time, so a merge made moments ago is not on the page yet. This asks for a
  * fresh read instead of leaving the user to wait for the next scheduled sync.
  */
-function VelocitySyncButton({ model }: { model: VelocityPageModel }) {
+function VelocityOverflowMenu({ model }: { model: VelocityPageModel }) {
   if (model.sync.isUnavailable) return null;
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="xs"
-      onClick={model.sync.start}
-      disabled={model.sync.isSyncing}
-      title={syncButtonTitle(model.velocity.syncedAt)}
-      data-testid="velocity-sync-button"
-    >
-      <RefreshCw className={cn("size-3.5", model.sync.isSyncing && "animate-spin")} aria-hidden />
-      {model.sync.isSyncing ? "Syncing…" : "Sync now"}
-    </Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Velocity menu"
+          data-testid="velocity-overflow-menu"
+        >
+          <MoreHorizontal className="size-3.5" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6} className="min-w-[12rem] rounded-xl border-border p-1 shadow-lg">
+        <DropdownMenuItem
+          className="cursor-pointer rounded-md px-2 py-1.5 text-[13px] [&_svg]:size-3.5"
+          onClick={model.sync.start}
+          disabled={model.sync.isSyncing}
+          title={refreshDataTitle(model.velocity.syncedAt)}
+          data-testid="velocity-refresh-data"
+        >
+          <RefreshCw className={cn(model.sync.isSyncing && "animate-spin")} aria-hidden />
+          Refresh data
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
-function syncButtonTitle(syncedAt?: Date): string {
+function refreshDataTitle(syncedAt?: Date): string {
   const action = "Read the merges of the last 60 days from GitHub.";
   if (!syncedAt) return action;
   return `${action} Last synced ${syncedAt.toLocaleString()}.`;


### PR DESCRIPTION
## Summary

The Velocity header gave the sync control the same weight as the period
control. A manual sync is a rare, secondary action. It does not need
permanent space next to the primary control.

This change moves the action into an overflow menu at the end of the
header row. The label changes from "Sync now" to "Refresh data", because
the new name says what the user gets. The menu stays hidden when the
workspace has no repository to read. The progress bar and the "last
synced" hint do not change.

## Test plan

- [ ] Open Velocity for a workspace with a repository.
- [ ] Confirm the header shows the period control and a "..." menu.
- [ ] Open the menu and confirm it shows "Refresh data".
- [ ] Select "Refresh data" and confirm the progress bar appears.
- [ ] Open the menu during the sync and confirm "Refresh data" is disabled.
- [ ] Open Velocity for a workspace with no repository.
- [ ] Confirm the "..." menu is not present.

Made with [Cursor](https://cursor.com)