### PR TITLE
fix: Clarify velocity origin and people copy

### DIFF
--- a/web_src/src/pages/factories/lib/factoryVelocityReport.ts
+++ b/web_src/src/pages/factories/lib/factoryVelocityReport.ts
@@ -18,15 +18,15 @@ export const VELOCITY_PERIOD_OPTIONS: { value: string; label: string }[] = [
 ];
 
 export const VELOCITY_BREAKDOWN_OPTIONS: { value: VelocityBreakdown; label: string }[] = [
-  { value: "origin", label: "Origin" },
+  { value: "origin", label: "Who created" },
   { value: "outcome", label: "Outcome" },
   { value: "intake", label: "Intake source" },
 ];
 
 export const VELOCITY_BREAKDOWN_COPY: Record<VelocityBreakdown, { title: string; description: string }> = {
   origin: {
-    title: "Merged pull requests by origin",
-    description: "Team output split between people and SuperPlane.",
+    title: "Merged pull requests by who created them",
+    description: "Merged pull requests from people, next to pull requests SuperPlane created.",
   },
   outcome: {
     title: "Pull requests by outcome",
@@ -223,8 +223,8 @@ export function velocityBreakdownSeries(
 ): VelocityBreakdownSeries[] {
   if (breakdown === "origin") {
     return [
-      { key: "people", label: "People", color: VELOCITY_ORIGIN_COLORS.people },
-      { key: "superplane", label: "SuperPlane", color: VELOCITY_ORIGIN_COLORS.superplane },
+      { key: "people", label: "Manual work", color: VELOCITY_ORIGIN_COLORS.people },
+      { key: "superplane", label: "Automated via SuperPlane", color: VELOCITY_ORIGIN_COLORS.superplane },
     ];
   }
   if (breakdown === "outcome") {

--- a/web_src/src/pages/factories/pages/Velocity.stories.tsx
+++ b/web_src/src/pages/factories/pages/Velocity.stories.tsx
@@ -73,7 +73,7 @@ export const EarlyUsage: Story = {
 /**
  * Right after a repository is connected: the background sync has not stored the
  * repository history yet, so the People series is withheld and the People table
- * explains why the Authored column is empty.
+ * explains why the Manual work column is empty.
  */
 export const PeopleSyncPending: Story = {
   name: "People sync pending",

--- a/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.spec.tsx
@@ -334,7 +334,7 @@ describe("VelocityPage shell", () => {
     expect(people).toHaveTextContent("1 person with activity in this period");
   });
 
-  it("explains an empty Authored column when GitHub is not connected", () => {
+  it("explains an empty Manual work column when GitHub is not connected", () => {
     resetState();
     velocityHookState.data = populatedResponse({
       hasPeopleCohort: false,
@@ -344,7 +344,7 @@ describe("VelocityPage shell", () => {
     renderShell();
 
     expect(screen.getByTestId("velocity-people")).toHaveTextContent(
-      "Connect GitHub in workspace setup to count the pull requests people merged.",
+      "Connect GitHub in workspace setup to count the pull requests people created.",
     );
   });
 
@@ -355,7 +355,7 @@ describe("VelocityPage shell", () => {
     renderShell();
 
     expect(screen.queryByText("Intake source")).not.toBeInTheDocument();
-    expect(screen.getByText("Origin")).toBeInTheDocument();
+    expect(screen.getByText("Who created")).toBeInTheDocument();
   });
 
   it("offers the intake split when the response names its sources", () => {

--- a/web_src/src/pages/factories/pages/VelocityPage.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPage.tsx
@@ -72,6 +72,7 @@ function VelocityReportView({ model, report }: { model: VelocityPageModel; repor
       <SummaryCard
         totals={report.totals}
         caption={summaryCaption(model.periodLabel, model.periodDays, Boolean(report.previous))}
+        periodDays={model.periodDays}
         medianCycleHours={flow && flow.sampleSize > 0 ? flow.medianCycleHours : undefined}
         comparison={model.comparison}
       />
@@ -104,13 +105,13 @@ function summaryCaption(periodLabel: string, periodDays: VelocityPeriodDays, has
   return `${periodLabel}. There is no earlier period to compare with yet.`;
 }
 
-/** Explains a People table that lists SuperPlane work but no direct authorship. */
+/** Explains a People table that lists SuperPlane work but no manual work yet. */
 function peopleEmptyAuthorship(report: VelocityReport, model: VelocityPageModel): string | undefined {
   if (report.hasPeopleCohort) return undefined;
-  if (!model.integrationId) return "Connect GitHub in workspace setup to count the pull requests people merged.";
-  if (!model.repository) return "Select a repository in workspace setup to count the pull requests people merged.";
+  if (!model.integrationId) return "Connect GitHub in workspace setup to count the pull requests people created.";
+  if (!model.repository) return "Select a repository in workspace setup to count the pull requests people created.";
   if (model.velocity.peopleSyncPending) {
-    return "SuperPlane is collecting merges from GitHub. The Authored column fills in after the first sync.";
+    return "SuperPlane is collecting merges from GitHub. The Manual work column fills in after the first sync.";
   }
   return undefined;
 }

--- a/web_src/src/pages/factories/pages/VelocityPeopleTable.tsx
+++ b/web_src/src/pages/factories/pages/VelocityPeopleTable.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { formatDurationHours } from "../lib/factoryVelocityFlow";
 import type { VelocityPerson } from "../lib/factoryVelocityReport";
 
-type SortKey = "total" | "authoredMerged" | "factoryMerged" | "factoryWaste" | "medianCycleHours" | "costUsd";
+type SortKey = "total" | "factoryMerged" | "authoredMerged" | "medianCycleHours" | "costUsd";
 
 /** Members without a connected account photo still need a stable, legible avatar. */
 const AVATAR_COLORS = [
@@ -37,22 +37,16 @@ interface Column {
 
 const COLUMNS: Column[] = [
   {
-    key: "authoredMerged",
-    label: "Authored",
-    hint: "Pull requests the person merged themselves",
-    format: (person) => String(person.authoredMerged),
-  },
-  {
     key: "factoryMerged",
-    label: "SuperPlane merged",
-    hint: "Merged pull requests from tasks this person opened",
+    label: "Via SuperPlane",
+    hint: "Merged pull requests from SuperPlane tasks this person opened",
     format: (person) => String(person.factoryMerged),
   },
   {
-    key: "factoryWaste",
-    label: "SuperPlane waste",
-    hint: "Tasks this person opened that closed without a merge",
-    format: (person) => String(person.factoryWaste),
+    key: "authoredMerged",
+    label: "Manual work",
+    hint: "Pull requests this person created without SuperPlane",
+    format: (person) => String(person.authoredMerged),
   },
   {
     key: "medianCycleHours",
@@ -62,14 +56,14 @@ const COLUMNS: Column[] = [
   },
   {
     key: "costUsd",
-    label: "Tracked cost",
-    hint: "Tracked model spend of their tasks",
+    label: "Costs",
+    hint: "Tracked model spend of their SuperPlane tasks",
     format: (person) => `$${person.costUsd.toFixed(0)}`,
   },
   {
     key: "total",
     label: "Merged PRs",
-    hint: "Authored plus SuperPlane merged",
+    hint: "Via SuperPlane plus manual work",
     format: (person) => String(totalMerged(person)),
   },
 ];
@@ -90,7 +84,7 @@ export function VelocityPeopleTable({
 }: {
   people: VelocityPerson[];
   periodLabel: string;
-  /** Names why the Authored column is empty, when the cohort is unavailable. */
+  /** Names why the Manual work column is empty, when the cohort is unavailable. */
   emptyAuthorship?: string;
 }) {
   const [sortKey, setSortKey] = useState<SortKey>("total");
@@ -109,7 +103,7 @@ export function VelocityPeopleTable({
         <div>
           <h2 className="text-[14px] font-medium tracking-[-0.01em] text-foreground">People</h2>
           <p className="mt-0.5 text-[12px] text-muted-foreground">
-            What each member merged directly and through SuperPlane. Select a column to sort.
+            {people.length} {people.length === 1 ? "person" : "people"} with activity in this period
           </p>
         </div>
         <p className="text-[12px] text-muted-foreground">{periodLabel}</p>
@@ -170,10 +164,7 @@ export function VelocityPeopleTable({
         </table>
       </div>
 
-      <p className="mt-4 text-[12px] text-muted-foreground">
-        {people.length} {people.length === 1 ? "person" : "people"} with activity in this period
-      </p>
-      {emptyAuthorship ? <p className="mt-1 text-[12px] text-muted-foreground">{emptyAuthorship}</p> : null}
+      {emptyAuthorship ? <p className="mt-4 text-[12px] text-muted-foreground">{emptyAuthorship}</p> : null}
     </section>
   );
 }

--- a/web_src/src/pages/factories/pages/velocityCards.tsx
+++ b/web_src/src/pages/factories/pages/velocityCards.tsx
@@ -12,6 +12,7 @@ import {
   VELOCITY_BREAKDOWN_OPTIONS,
   type VelocityBreakdown,
   type VelocityIntakeSeries,
+  type VelocityPeriodDays,
   type VelocityPoint,
   type VelocityTotals,
 } from "../lib/factoryVelocityReport";
@@ -149,11 +150,13 @@ export interface VelocityComparison {
 export function SummaryCard({
   totals,
   caption,
+  periodDays,
   medianCycleHours,
   comparison,
 }: {
   totals: VelocityTotals;
   caption: string;
+  periodDays: VelocityPeriodDays;
   /** Median cycle time of the tasks that closed in this window. */
   medianCycleHours?: number;
   comparison?: VelocityComparison;
@@ -165,7 +168,7 @@ export function SummaryCard({
         <Metric
           label="Tasks closed"
           value={String(totals.tasksClosed)}
-          tooltip="Finished, with or without a result"
+          tooltip={`All closed tasks in the last ${periodDays} days`}
           change={
             comparison?.tasksClosed === undefined
               ? undefined


### PR DESCRIPTION
## Summary

The velocity chart used Origin, People, and SuperPlane without a clear split. Readers could not tell who created a merged pull request.

This change names the split as manual work versus SuperPlane. The People table matches that language and drops SuperPlane waste.

## Test plan

- [ ] Open Factory Velocity and select Who created. Confirm the legend says Manual work and Automated via SuperPlane.
- [ ] Switch the period between 14d and 30d. Confirm the Tasks closed tooltip uses that period.
- [ ] Check the People table columns: Via SuperPlane, Manual work, Median cycle, Costs, Merged PRs.
- [ ] Confirm the header shows N people with activity in this period.


Made with [Cursor](https://cursor.com)