### PR TITLE
fix: Match Velocity stories to production

### DIFF
--- a/web_src/src/pages/factories/__fixtures__/setupStoryFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/setupStoryFixtures.ts
@@ -4,7 +4,8 @@ import type { StorybookOrgIntegration } from "@/pages/home/__fixtures__/handlers
 import { defaultFactoriesFixture, PRIMARY_FACTORY_ID, type FactoriesFixture } from "./factoryPageResponses";
 import type { StorybookUsageReport } from "./usageReportFixtures";
 
-const GITHUB_CONNECTION_ID = "storybook-github-connection";
+/** GitHub connection every workspace story shares. */
+export const GITHUB_CONNECTION_ID = "storybook-github-connection";
 const CLAUDE_CONNECTION_ID = "storybook-claude-connection";
 
 /** App repository the setup stories continue with. Served by the resources fixture. */

--- a/web_src/src/pages/factories/__fixtures__/velocityReportFixtures.ts
+++ b/web_src/src/pages/factories/__fixtures__/velocityReportFixtures.ts
@@ -6,6 +6,9 @@ import type { FactoriesDescribeFactoryVelocityResponse } from "@/api-client";
  * a mixed result instead of every metric improving at once.
  */
 
+/** Repository these reports are built from. Workspace setup must name the same one. */
+export const VELOCITY_REPOSITORY = "acme/refunds";
+
 const PEOPLE_AUTHORS = [
   { id: "user-darko", name: "Darko Fabijan", email: "darko@superplane.com", accountId: 20469, share: 0.24 },
   { id: "user-aleksandar", name: "Aleksandar Mitrovic", email: "alex@superplane.com", accountId: 61409859, share: 0.2 },
@@ -165,7 +168,7 @@ function buildReport(periodDays: number, withComparison: boolean): FactoriesDesc
     yesterday: { superplaneMerged: yesterday.superplaneMerged, waste: yesterday.waste },
     totals,
     points,
-    repository: "acme/refunds",
+    repository: VELOCITY_REPOSITORY,
     hasPeopleCohort: true,
     peopleSyncedAt: new Date().toISOString(),
     peopleSyncPending: false,

--- a/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
+++ b/web_src/src/pages/factories/layout/WorkspacePageHeader.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Copy, Ellipsis, Funnel, Pencil, Plus, RefreshCw, Search, Settings2 } from "lucide-react";
+import { Copy, Ellipsis, Funnel, MoreHorizontal, Pencil, Plus, RefreshCw, Search, Settings2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { SegmentedNav } from "@/ui/SegmentedNav";
@@ -12,6 +12,7 @@ import {
   REFUND_FACTORY,
   REFUND_LINE_PLAN_ID,
 } from "../__fixtures__/factoryPageResponses";
+import { VELOCITY_PERIOD_OPTIONS } from "../lib/factoryVelocityReport";
 import { factorySectionHeaderClassName } from "../pages/factoryPageLayoutStyles";
 import { FactoriesSidebarNav } from "./FactoriesSidebarNav";
 import { WorkspacePageHeader } from "./WorkspacePageHeader";
@@ -67,22 +68,31 @@ export const SectionWithPrimaryAction: Story = {
   },
 };
 
+/** Matches the header of the Velocity page: period pills and an overflow menu. */
 export const SectionWithPeriodPills: Story = {
   args: {
     ...sectionHeader,
     title: "Velocity",
-    subtitle: "Merged pull requests from SuperPlane, waste, and cost.",
+    subtitle: "What acme/refunds ships, how long the work takes, and what it costs.",
     actions: (
-      <SegmentedNav
-        ariaLabel="Velocity period in days"
-        size="xs"
-        value="7"
-        onValueChange={() => undefined}
-        options={[
-          { value: "7", label: "7d" },
-          { value: "30", label: "30d" },
-        ]}
-      />
+      <div className="flex items-center gap-2">
+        <SegmentedNav
+          ariaLabel="Velocity period in days"
+          size="xs"
+          value="14"
+          onValueChange={() => undefined}
+          options={VELOCITY_PERIOD_OPTIONS}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Velocity menu"
+        >
+          <MoreHorizontal className="size-3.5" aria-hidden />
+        </Button>
+      </div>
     ),
   },
 };

--- a/web_src/src/pages/factories/pages/Velocity.stories.tsx
+++ b/web_src/src/pages/factories/pages/Velocity.stories.tsx
@@ -2,16 +2,22 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FactoriesHarness } from "../__fixtures__/FactoriesHarness";
 import {
-  defaultFactoriesFixture,
   PRIMARY_FACTORY_ID,
   PRIMARY_FACTORY_KEY,
+  REFUND_FACTORY,
   type FactoriesFixture,
 } from "../__fixtures__/factoryPageResponses";
+import {
+  factoriesFixtureWithSetupAnswers,
+  GITHUB_CONNECTION_ID,
+  GITHUB_SETUP_INTEGRATIONS,
+} from "../__fixtures__/setupStoryFixtures";
 import {
   DEFAULT_FACTORY_VELOCITY,
   EARLY_USAGE_FACTORY_VELOCITY,
   EMPTY_FACTORY_VELOCITY,
   PEOPLE_SYNC_PENDING_FACTORY_VELOCITY,
+  VELOCITY_REPOSITORY,
 } from "../__fixtures__/velocityReportFixtures";
 import { VelocityPage } from "./VelocityPage";
 
@@ -27,31 +33,37 @@ type Story = StoryObj<typeof meta>;
 
 const velocityPath = `workspaces/${PRIMARY_FACTORY_KEY}/velocity`;
 
+/**
+ * The page reads the GitHub connection and the repository that workspace setup
+ * stored, so the fixture workspace must name the repository the reports are
+ * built from. Without it the page hides Refresh data and tells the reader to
+ * connect GitHub, which a set-up workspace never shows.
+ */
+const velocityWorkspaceSetup = {
+  ...REFUND_FACTORY.onboarding,
+  vcsIntegrationId: GITHUB_CONNECTION_ID,
+  appRepository: VELOCITY_REPOSITORY,
+};
+
 /** Serves one velocity report for every period the page can request. */
-function fixtureWithVelocity(report: FactoriesFixture["velocityByFactoryId"]): FactoriesFixture {
-  return { ...defaultFactoriesFixture, velocityByFactoryId: report };
+function renderVelocity(report: FactoriesFixture["velocityByFactoryId"]) {
+  return (
+    <FactoriesHarness
+      pathSuffix={velocityPath}
+      factoriesFixture={{ ...factoriesFixtureWithSetupAnswers(velocityWorkspaceSetup), velocityByFactoryId: report }}
+      orgIntegrations={GITHUB_SETUP_INTEGRATIONS}
+    />
+  );
 }
 
 export const Default: Story = {
-  render: () => (
-    <FactoriesHarness
-      pathSuffix={velocityPath}
-      factoriesFixture={fixtureWithVelocity({ [PRIMARY_FACTORY_ID]: DEFAULT_FACTORY_VELOCITY })}
-    />
-  ),
+  render: () => renderVelocity({ [PRIMARY_FACTORY_ID]: DEFAULT_FACTORY_VELOCITY }),
 };
 
 /** New workspace with no merges and no spend — empty state that points at the board. */
 export const ZeroState: Story = {
   name: "Zero state",
-  render: () => (
-    <FactoriesHarness
-      pathSuffix={velocityPath}
-      factoriesFixture={fixtureWithVelocity({
-        [PRIMARY_FACTORY_ID]: { 14: EMPTY_FACTORY_VELOCITY, 30: EMPTY_FACTORY_VELOCITY },
-      })}
-    />
-  ),
+  render: () => renderVelocity({ [PRIMARY_FACTORY_ID]: { 14: EMPTY_FACTORY_VELOCITY, 30: EMPTY_FACTORY_VELOCITY } }),
 };
 
 /**
@@ -60,14 +72,8 @@ export const ZeroState: Story = {
  */
 export const EarlyUsage: Story = {
   name: "Early usage",
-  render: () => (
-    <FactoriesHarness
-      pathSuffix={velocityPath}
-      factoriesFixture={fixtureWithVelocity({
-        [PRIMARY_FACTORY_ID]: { 14: EARLY_USAGE_FACTORY_VELOCITY, 30: EARLY_USAGE_FACTORY_VELOCITY },
-      })}
-    />
-  ),
+  render: () =>
+    renderVelocity({ [PRIMARY_FACTORY_ID]: { 14: EARLY_USAGE_FACTORY_VELOCITY, 30: EARLY_USAGE_FACTORY_VELOCITY } }),
 };
 
 /**
@@ -77,15 +83,11 @@ export const EarlyUsage: Story = {
  */
 export const PeopleSyncPending: Story = {
   name: "People sync pending",
-  render: () => (
-    <FactoriesHarness
-      pathSuffix={velocityPath}
-      factoriesFixture={fixtureWithVelocity({
-        [PRIMARY_FACTORY_ID]: {
-          14: PEOPLE_SYNC_PENDING_FACTORY_VELOCITY,
-          30: PEOPLE_SYNC_PENDING_FACTORY_VELOCITY,
-        },
-      })}
-    />
-  ),
+  render: () =>
+    renderVelocity({
+      [PRIMARY_FACTORY_ID]: {
+        14: PEOPLE_SYNC_PENDING_FACTORY_VELOCITY,
+        30: PEOPLE_SYNC_PENDING_FACTORY_VELOCITY,
+      },
+    }),
 };


### PR DESCRIPTION
## Summary

Storybook Velocity pages did not match a set-up workspace. The fixture had no repository, so the page hid Refresh data and showed setup copy.

This change names the same GitHub connection and repository as the report payload. The header story now uses 14-day and 30-day pills, the live subtitle, and the overflow menu.

## Test plan

- [ ] Open Factories/Pages/Velocity Default in Storybook.
- [ ] Confirm the subtitle names `acme/refunds`.
- [ ] Confirm the overflow menu shows Refresh data.
- [ ] Open People sync pending and confirm the GitHub collection copy.
- [ ] Open Factories/Layout/WorkspacePageHeader SectionWithPeriodPills.
- [ ] Confirm the period pills are 14d and 30d.


Made with [Cursor](https://cursor.com)