### PR TITLE
chore: anchor the server ignore rule to the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ coverage-go.out
 /web_src/src/api-client/
 /api/swagger/*
 !/api/swagger/swagger-ui.html
-server
+/server


### PR DESCRIPTION
`.gitignore:35` is a bare `server`, meant for the compiled binary. A pattern with no slash matches by name at any depth, so it also matches the `pkg/server/` directory:

```
$ git check-ignore -v pkg/server/newfile.go
.gitignore:35:server	pkg/server/newfile.go
```

Tracked files are unaffected, so nothing looks wrong until you add one. `git add pkg/server/foo_test.go` then fails with "The following paths are ignored by one of your .gitignore files: pkg/server" and needs `-f`.

A leading slash anchors the rule to the repo root.
