### PR TITLE
feat: shut down gracefully, draining in-flight work on SIGTERM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,13 @@
 # PPROF_ENABLED=yes
 # PPROF_PORT=6060
 
+## Graceful shutdown
+##
+## How long the process waits on SIGTERM/SIGINT for in-flight work to drain,
+## tracing to shut down and Sentry to flush. Keep it below the deploy target's
+## termination grace period, which is 30s by default on Kubernetes.
+# SHUTDOWN_TIMEOUT=25s
+
 ## Database timeout overrides
 ##
 ## Values can be Go durations such as 60s/2m or integer milliseconds.

--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,12 @@
 ## tracing to shut down and Sentry to flush. Keep it below the deploy target's
 ## termination grace period, which is 30s by default on Kubernetes.
 # SHUTDOWN_TIMEOUT=25s
+##
+## How long the public API keeps serving after the signal, before it stops
+## listening. Kubernetes removes the pod from its Endpoints asynchronously, so
+## traffic still arrives for a moment after SIGTERM. Skipped when
+## APP_ENV=development.
+# SHUTDOWN_DRAIN_DELAY=5s
 
 ## Database timeout overrides
 ##

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,4 +32,10 @@ migrate -lock-timeout "${DB_MIGRATION_LOCK_TIMEOUT}" -source file:///app/db/migr
 migrate -lock-timeout "${DB_MIGRATION_LOCK_TIMEOUT}" -source file:///app/db/data_migrations -database "${DB_URL}&x-migrations-table=data_migrations" up
 
 echo "Starting server..."
-/app/build/superplane
+
+#
+# exec replaces this shell, so the server runs as PID 1 and receives SIGTERM
+# directly. Without it the shell keeps the signal, the server is only killed
+# when the grace period expires, and no graceful shutdown ever runs.
+#
+exec /app/build/superplane

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -78,7 +79,11 @@ const (
 var errUsageServiceUnavailable = errors.New("usage service unavailable")
 
 type Server struct {
+	// httpServerMu guards httpServer and shuttingDown, which Serve writes and
+	// Shutdown reads from the goroutine that watches for the termination signal.
+	httpServerMu          sync.Mutex
 	httpServer            *http.Server
+	shuttingDown          bool
 	encryptor             crypto.Encryptor
 	registry              *registry.Registry
 	jwt                   *jwt.Signer
@@ -1254,13 +1259,23 @@ func (s *Server) HealthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) Serve(host string, port int) error {
+	//
+	// Shutdown may already have run, in which case it found no server to close.
+	// Listening now would ignore it and block until the process is killed, so
+	// stop before starting the hub as well as before listening.
+	//
+	if s.isShuttingDown() {
+		log.Info("Not serving, the server is already shutting down")
+		return http.ErrServerClosed
+	}
+
 	log.Infof("Starting server at %s:%d", host, port)
 
 	// Start the WebSocket hub
 	log.Info("Starting WebSocket hub")
 	s.wsHub.Run()
 
-	s.httpServer = &http.Server{
+	httpServer := &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", host, port),
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 70 * time.Second,
@@ -1268,13 +1283,57 @@ func (s *Server) Serve(host string, port int) error {
 		Handler:      s.Router,
 	}
 
-	return s.httpServer.ListenAndServe()
+	s.httpServerMu.Lock()
+	if s.shuttingDown {
+		s.httpServerMu.Unlock()
+		log.Info("Not serving, the server is already shutting down")
+		return http.ErrServerClosed
+	}
+	s.httpServer = httpServer
+	s.httpServerMu.Unlock()
+
+	return httpServer.ListenAndServe()
+}
+
+func (s *Server) isShuttingDown() bool {
+	s.httpServerMu.Lock()
+	defer s.httpServerMu.Unlock()
+	return s.shuttingDown
 }
 
 func (s *Server) Close() {
-	if err := s.httpServer.Close(); err != nil {
+	httpServer := s.currentHTTPServer()
+	if httpServer == nil {
+		return
+	}
+
+	if err := httpServer.Close(); err != nil {
 		log.Errorf("Error closing server: %v", err)
 	}
+}
+
+// Shutdown stops accepting new connections and waits for the in-flight requests
+// to finish, or for ctx to expire. Serve returns http.ErrServerClosed when this
+// happens, which callers must not treat as a failure. Calling Shutdown before
+// Serve stops the server from listening at all.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.httpServerMu.Lock()
+	s.shuttingDown = true
+	httpServer := s.httpServer
+	s.httpServerMu.Unlock()
+
+	if httpServer == nil {
+		// Serve has not started listening yet, and now it never will.
+		return nil
+	}
+
+	return httpServer.Shutdown(ctx)
+}
+
+func (s *Server) currentHTTPServer() *http.Server {
+	s.httpServerMu.Lock()
+	defer s.httpServerMu.Unlock()
+	return s.httpServer
 }
 
 func (s *Server) HandleWebhook(w http.ResponseWriter, r *http.Request) {

--- a/pkg/public/shutdown_test.go
+++ b/pkg/public/shutdown_test.go
@@ -1,0 +1,43 @@
+package public
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__ServerShutdown(t *testing.T) {
+	t.Run("is a no-op before Serve", func(t *testing.T) {
+		server := &Server{}
+		require.NoError(t, server.Shutdown(context.Background()))
+	})
+
+	t.Run("stops Serve from listening after an early Shutdown", func(t *testing.T) {
+		server := &Server{}
+		require.NoError(t, server.Shutdown(context.Background()))
+
+		//
+		// Shutdown ran before Serve, so it had no listener to close. Serve must
+		// refuse to start, otherwise it blocks until the process is killed and
+		// the drain waits for a goroutine that can never return.
+		//
+		done := make(chan error, 1)
+		go func() { done <- server.Serve("127.0.0.1", 0) }()
+
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, http.ErrServerClosed)
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "Serve started listening after Shutdown")
+		}
+	})
+
+	t.Run("Close is a no-op before Serve", func(t *testing.T) {
+		server := &Server{}
+		assert.NotPanics(t, server.Close)
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -511,6 +511,14 @@ func startPublicAPI(
 	if os.Getenv("START_EVENT_DISTRIBUTER") == "yes" {
 		log.Println("Starting Event Distributer Worker")
 		eventDistributer := workers.NewEventDistributer(server.WebsocketHub())
+
+		//
+		// Deliberately outside the drain. Start blocks on its own channel while
+		// the real work happens in per-route consumers that consumeMessages
+		// creates inside a loop, so there is no handle to stop them. Joining the
+		// drain would report every worker stopped while those consumers still
+		// run. Giving them a lifecycle needs its own change.
+		//
 		go eventDistributer.Start()
 	} else {
 		log.Println("Event Distributer not started (START_EVENT_DISTRIBUTER != yes)")
@@ -840,20 +848,49 @@ func Start() {
 	stop()
 	log.Println("Shutdown signal received, stopping SuperPlane...")
 
-	waitForShutdown(&wg, shutdownTimeout())
+	//
+	// One deadline covers the whole sequence. Giving each step its own full
+	// timeout would let a slow drain plus a slow telemetry flush run for several
+	// times the grace period, and SIGKILL would then cut the process off with no
+	// chance to log why.
+	//
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), shutdownTimeout())
 	defer cancelShutdown()
+
+	drained := waitForShutdown(shutdownCtx, &wg)
 
 	if err := telemetry.ShutdownTracing(shutdownCtx); err != nil {
 		log.Warnf("Error shutting down tracing: %v", err)
 	}
-	telemetry.FlushSentry(shutdownTimeout())
+	telemetry.FlushSentry(timeLeft(shutdownCtx))
+
+	if !drained {
+		log.Warn("SuperPlane is DOWN, with work still in flight.")
+		return
+	}
+
 	log.Println("SuperPlane is DOWN.")
 }
 
-// defaultShutdownTimeout bounds the drain. It stays below the Kubernetes
+// timeLeft reports how much of ctx's deadline remains, for the steps that take a
+// duration rather than a context. It never returns a negative value.
+func timeLeft(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0
+	}
+
+	if left := time.Until(deadline); left > 0 {
+		return left
+	}
+
+	return 0
+}
+
+// defaultShutdownTimeout bounds the entire shutdown: the worker drain, the
+// tracing shutdown and the Sentry flush share it. It stays below the Kubernetes
 // default termination grace period of 30s, which the Helm chart does not
-// override, so the process finishes its own shutdown before SIGKILL arrives.
+// override, so the process finishes before SIGKILL arrives.
 // Raise SHUTDOWN_TIMEOUT and terminationGracePeriodSeconds together.
 const defaultShutdownTimeout = 25 * time.Second
 
@@ -872,9 +909,11 @@ func shutdownTimeout() time.Duration {
 	return timeout
 }
 
-// waitForShutdown waits for every tracked goroutine to return, and gives up
-// once timeout expires so a stuck worker cannot hold the process open forever.
-func waitForShutdown(wg *sync.WaitGroup, timeout time.Duration) {
+// waitForShutdown waits for every tracked goroutine to return, and gives up when
+// ctx expires so a stuck worker cannot hold the process open forever. It reports
+// whether every goroutine finished, so the caller does not announce a clean stop
+// after abandoning work.
+func waitForShutdown(ctx context.Context, wg *sync.WaitGroup) bool {
 	done := make(chan struct{})
 
 	go func() {
@@ -882,14 +921,13 @@ func waitForShutdown(wg *sync.WaitGroup, timeout time.Duration) {
 		close(done)
 	}()
 
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-
 	select {
 	case <-done:
 		log.Println("All workers stopped")
-	case <-timer.C:
-		log.Warnf("Shutdown timeout of %s expired, exiting with work still in flight", timeout)
+		return true
+	case <-ctx.Done():
+		log.Warn("Shutdown deadline expired, exiting with work still in flight")
+		return false
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,15 +2,18 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
 	// Registers pprof handlers on http.DefaultServeMux, served by startPprofServer.
 	_ "net/http/pprof"
 	"os"
+	"os/signal"
 	"runtime"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -114,7 +117,22 @@ func buildAgentService(authService authorization.Authorization) (agents.Provider
 	return provider, service
 }
 
+// startWorker runs a worker's Start loop under ctx and records it in wg, so
+// Start can wait for the loop to return before the process exits. Every worker
+// loop already returns on ctx.Done; before this they were given
+// context.Background() and so were never told to stop.
+func startWorker(ctx context.Context, wg *sync.WaitGroup, start func(context.Context)) {
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		start(ctx)
+	}()
+}
+
 func startWorkers(
+	ctx context.Context,
+	wg *sync.WaitGroup,
 	encryptor crypto.Encryptor,
 	registry *registry.Registry,
 	oidcProvider oidc.Provider,
@@ -131,21 +149,21 @@ func startWorkers(
 	}
 
 	if os.Getenv("START_CONSUMERS") == "yes" {
-		startEmailConsumers(rabbitMQURL, encryptor, baseURL)
+		startEmailConsumers(ctx, wg, rabbitMQURL, encryptor, baseURL)
 	}
 
 	if os.Getenv("START_WORKFLOW_EVENT_ROUTER") == "yes" || os.Getenv("START_EVENT_ROUTER") == "yes" {
 		log.Println("Starting Event Router")
 
 		w := workers.NewEventRouter(rabbitMQURL)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_RUN_FINALIZER") == "yes" {
 		log.Println("Starting Run Finalizer")
 
 		w := workers.NewRunFinalizer(rabbitMQURL, registry)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_WORKFLOW_NODE_EXECUTOR") == "yes" || os.Getenv("START_NODE_EXECUTOR") == "yes" {
@@ -153,14 +171,14 @@ func startWorkers(
 
 		webhookBaseURL := getWebhookBaseURL(baseURL)
 		w := workers.NewNodeExecutor(encryptor, registry, gitProvider, oidcProvider, baseURL, webhookBaseURL, rabbitMQURL, authService)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_EXECUTION_TERMINATOR") == "yes" {
 		log.Println("Starting Execution Terminator")
 
 		w := workers.NewExecutionTerminator(rabbitMQURL, authService, encryptor, registry)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_NODE_REQUEST_WORKER") == "yes" {
@@ -168,20 +186,20 @@ func startWorkers(
 
 		webhookBaseURL := getWebhookBaseURL(baseURL)
 		w := workers.NewNodeRequestWorker(encryptor, registry, gitProvider, webhookBaseURL, authService)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_APP_MESSAGE_WORKER") == "yes" {
 		log.Println("Starting App Message Worker")
 
 		w := workers.NewAppMessageWorker(registry)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_RUN_INITIALIZER") == "yes" {
 		log.Println("Starting Run Initializer")
 		w := workers.NewRunInitializer(rabbitMQURL, registry)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_APP_INSTALLATION_REQUEST_WORKER") == "yes" || os.Getenv("START_INTEGRATION_REQUEST_WORKER") == "yes" {
@@ -189,14 +207,14 @@ func startWorkers(
 
 		webhooksBaseURL := getWebhookBaseURL(baseURL)
 		w := workers.NewIntegrationRequestWorker(encryptor, registry, oidcProvider, baseURL, webhooksBaseURL)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_WORKFLOW_NODE_QUEUE_WORKER") == "yes" || os.Getenv("START_NODE_QUEUE_WORKER") == "yes" {
 		log.Println("Starting Node Queue Worker")
 
 		w := workers.NewNodeQueueWorker(registry, gitProvider, rabbitMQURL)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	// Start Webhook Provisioner when internal API runs so integration webhooks (e.g. GCP On VM Created) get provisioned.
@@ -207,41 +225,41 @@ func startWorkers(
 		}
 		webhookBaseURL := getWebhookBaseURL(baseURL)
 		w := workers.NewWebhookProvisioner(webhookBaseURL, encryptor, registry)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_WEBHOOK_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Webhook Cleanup Worker")
 
 		w := workers.NewWebhookCleanupWorker(encryptor, registry, baseURL)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_INSTALLATION_CLEANUP_WORKER") == "yes" || os.Getenv("START_INTEGRATION_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Integration Cleanup Worker")
 
 		w := workers.NewIntegrationCleanupWorker(registry, encryptor, baseURL)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_WORKFLOW_CLEANUP_WORKER") == "yes" || os.Getenv("START_CANVAS_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Canvas Cleanup Worker")
 
 		w := workers.NewCanvasCleanupWorker(gitProvider, agentProvider)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_NODE_REQUEST_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Node Request Cleanup Worker")
 
 		w := workers.NewNodeRequestCleanupWorker()
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_REPOSITORY_PROVISIONER") == "yes" {
 		log.Println("Starting Repository Provisioner")
 		w := workers.NewRepositoryProvisionerWorker(rabbitMQURL, gitProvider)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	var workerUsageService usage.Service
@@ -277,28 +295,28 @@ func startWorkers(
 		log.Println("Starting Organization Cleanup Worker")
 
 		w := workers.NewOrganizationCleanupWorker(gitProvider, agentProvider)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_FACTORY_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Factory Cleanup Worker")
 
 		w := workers.NewFactoryCleanupWorker()
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_FACTORY_VELOCITY_SYNC_WORKER") == "yes" {
 		log.Println("Starting Factory Velocity Sync Worker")
 
 		w := workers.NewFactoryVelocitySyncWorker(rabbitMQURL, encryptor, registry)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_PLANNING_SESSION_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Planning Session Cleanup Worker")
 
 		w := workers.NewPlanningSessionCleanupWorker()
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if agentProvider != nil && os.Getenv("START_AGENT_STREAM_WORKER") != "no" {
@@ -317,7 +335,7 @@ func startWorkers(
 			getOptionalWorkerUsageService(),
 			agentToolRegistry,
 		)
-		go w.Start(context.Background())
+		startWorker(ctx, wg, w.Start)
 	}
 
 	if os.Getenv("START_EVENT_RETENTION_WORKER") == "yes" || os.Getenv("START_USAGE_SYNC_WORKER") == "yes" {
@@ -326,19 +344,19 @@ func startWorkers(
 		if os.Getenv("START_EVENT_RETENTION_WORKER") == "yes" && usageService.Enabled() {
 			log.Println("Starting Event Retention Worker")
 			w := workers.NewEventRetentionWorker(usageService)
-			go w.Start(context.Background())
+			startWorker(ctx, wg, w.Start)
 		}
 
 		if os.Getenv("START_USAGE_SYNC_WORKER") == "yes" && usageService.Enabled() {
 			log.Println("Starting Usage Sync Worker")
 			w := workers.NewUsageSyncWorker(rabbitMQURL, usageService)
-			go w.Start(context.Background())
+			startWorker(ctx, wg, w.Start)
 		}
 	}
 
 }
 
-func startEmailConsumers(rabbitMQURL string, encryptor crypto.Encryptor, baseURL string) {
+func startEmailConsumers(ctx context.Context, wg *sync.WaitGroup, rabbitMQURL string, encryptor crypto.Encryptor, baseURL string) {
 	emailService := services.BuildEmailService(encryptor, services.EmailServiceConfig{
 		TemplateDir:       os.Getenv("TEMPLATE_DIR"),
 		OwnerSetupEnabled: os.Getenv("OWNER_SETUP_ENABLED") == "yes",
@@ -351,17 +369,74 @@ func startEmailConsumers(rabbitMQURL string, encryptor crypto.Encryptor, baseURL
 		return
 	}
 
-	startEmailConsumersWithService(rabbitMQURL, emailService, baseURL)
+	startEmailConsumersWithService(ctx, wg, rabbitMQURL, emailService, baseURL)
 }
 
-func startEmailConsumersWithService(rabbitMQURL string, emailService services.EmailService, baseURL string) {
+func startEmailConsumersWithService(ctx context.Context, wg *sync.WaitGroup, rabbitMQURL string, emailService services.EmailService, baseURL string) {
 	log.Println("Starting Magic Code Email Consumer")
 	magicCodeEmailConsumer := workers.NewMagicCodeEmailConsumer(rabbitMQURL, emailService, baseURL)
-	go magicCodeEmailConsumer.Start()
+	startConsumer(ctx, wg, "Magic Code Email Consumer", magicCodeEmailConsumer.Start, magicCodeEmailConsumer.Stop)
 
 	log.Println("Starting Factory Notification Consumer")
 	factoryNotificationConsumer := workers.NewFactoryNotificationConsumer(rabbitMQURL, emailService, baseURL)
-	go factoryNotificationConsumer.Start()
+	startConsumer(ctx, wg, "Factory Notification Consumer", factoryNotificationConsumer.Start, factoryNotificationConsumer.Stop)
+}
+
+// stopRetryInterval is how often shutdown re-attempts a consumer's Stop while
+// the consumer is still opening its connection.
+const stopRetryInterval = 50 * time.Millisecond
+
+// startConsumer runs a RabbitMQ consumer and closes it when ctx is cancelled.
+// Cancellation reaches the consumer two ways, and it needs both: ctx ends the
+// reconnect loop, and Stop closes a connection that is already listening.
+func startConsumer(ctx context.Context, wg *sync.WaitGroup, name string, start func(context.Context) error, stop func()) {
+	finished := make(chan struct{})
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		defer close(finished)
+
+		if err := start(ctx); err != nil {
+			log.Errorf("%s stopped: %v", name, err)
+		}
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		select {
+		case <-finished:
+			// The consumer returned on its own, so there is nothing to stop.
+			return
+		case <-ctx.Done():
+		}
+
+		log.Printf("Stopping %s", name)
+
+		//
+		// tackle's Stop does nothing while the consumer is still connecting,
+		// because it only closes a connection in the listening state. A single
+		// Stop can therefore land in that window and be lost, leaving the
+		// consumer blocked on its shutdown channel with nobody left to close it.
+		// Keep asking until the consumer loop returns.
+		//
+		ticker := time.NewTicker(stopRetryInterval)
+		defer ticker.Stop()
+
+		for {
+			stop()
+
+			select {
+			case <-finished:
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
 }
 
 func buildGRPCServices(
@@ -392,6 +467,7 @@ func buildGRPCServices(
 }
 
 func startPublicAPI(
+	ctx context.Context,
 	baseURL, basePath string,
 	encryptor crypto.Encryptor,
 	registry *registry.Registry,
@@ -467,8 +543,28 @@ func startPublicAPI(
 		log.Println("Web server routes not registered (START_WEB_SERVER != yes)")
 	}
 
+	//
+	// Drain the HTTP server when the process is shutting down, so in-flight
+	// requests finish instead of dying with the connection.
+	//
+	go func() {
+		<-ctx.Done()
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout())
+		defer cancel()
+
+		log.Println("Shutting down Public API")
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Errorf("Error shutting down Public API: %v", err)
+		}
+	}()
+
+	//
+	// Shutdown makes ListenAndServe return ErrServerClosed. That is the normal
+	// end of a graceful stop, not a failure.
+	//
 	err = server.Serve("0.0.0.0", lookupPublicAPIPort())
-	if err != nil {
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatal(err)
 	}
 }
@@ -567,6 +663,15 @@ func startPprofServer() {
 }
 
 func Start() {
+	//
+	// Cancelled on SIGINT/SIGTERM. Every worker loop, the public API server and
+	// the RabbitMQ consumers stop when this context is done.
+	//
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	var wg sync.WaitGroup
+
 	configureLogging()
 	setupOtel()
 	startPprofServer()
@@ -692,20 +797,29 @@ func Start() {
 		}
 		grpcServices = services
 
-		go startPublicAPI(
-			baseURL,
-			basePath,
-			encryptorInstance,
-			registry,
-			jwtSigner,
-			oidcProvider,
-			authService,
-			gitProvider,
-			grpcServices,
-		)
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			startPublicAPI(
+				ctx,
+				baseURL,
+				basePath,
+				encryptorInstance,
+				registry,
+				jwtSigner,
+				oidcProvider,
+				authService,
+				gitProvider,
+				grpcServices,
+			)
+		}()
 	}
 
 	startWorkers(
+		ctx,
+		&wg,
 		encryptorInstance,
 		registry,
 		oidcProvider,
@@ -717,7 +831,66 @@ func Start() {
 
 	log.Println("SuperPlane is UP.")
 
-	select {}
+	<-ctx.Done()
+
+	//
+	// Restore the default signal behaviour, so a second SIGTERM during a slow
+	// drain kills the process instead of being swallowed.
+	//
+	stop()
+	log.Println("Shutdown signal received, stopping SuperPlane...")
+
+	waitForShutdown(&wg, shutdownTimeout())
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), shutdownTimeout())
+	defer cancelShutdown()
+
+	if err := telemetry.ShutdownTracing(shutdownCtx); err != nil {
+		log.Warnf("Error shutting down tracing: %v", err)
+	}
+	telemetry.FlushSentry(shutdownTimeout())
+	log.Println("SuperPlane is DOWN.")
+}
+
+// defaultShutdownTimeout bounds the drain. It stays below the Kubernetes
+// default termination grace period of 30s, which the Helm chart does not
+// override, so the process finishes its own shutdown before SIGKILL arrives.
+// Raise SHUTDOWN_TIMEOUT and terminationGracePeriodSeconds together.
+const defaultShutdownTimeout = 25 * time.Second
+
+func shutdownTimeout() time.Duration {
+	value := os.Getenv("SHUTDOWN_TIMEOUT")
+	if value == "" {
+		return defaultShutdownTimeout
+	}
+
+	timeout, err := time.ParseDuration(value)
+	if err != nil {
+		log.Warnf("Invalid SHUTDOWN_TIMEOUT %q, using %s: %v", value, defaultShutdownTimeout, err)
+		return defaultShutdownTimeout
+	}
+
+	return timeout
+}
+
+// waitForShutdown waits for every tracked goroutine to return, and gives up
+// once timeout expires so a stuck worker cannot hold the process open forever.
+func waitForShutdown(wg *sync.WaitGroup, timeout time.Duration) {
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		log.Println("All workers stopped")
+	case <-timer.C:
+		log.Warnf("Shutdown timeout of %s expired, exiting with work still in flight", timeout)
+	}
 }
 
 // getWebhookBaseURL returns the webhook base URL, using the same pattern as SyncContext.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -558,6 +558,18 @@ func startPublicAPI(
 	go func() {
 		<-ctx.Done()
 
+		//
+		// Keep serving for a moment first. Kubernetes removes the pod from the
+		// Endpoints list asynchronously, so kube-proxy still routes here for a
+		// short while after SIGTERM. Closing the listener immediately would turn
+		// those requests into connection refused, which is worse than the abrupt
+		// stop this change replaces.
+		//
+		if delay := drainDelay(); delay > 0 {
+			log.Printf("Draining Public API traffic for %s before shutdown", delay)
+			time.Sleep(delay)
+		}
+
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout())
 		defer cancel()
 
@@ -907,6 +919,34 @@ func shutdownTimeout() time.Duration {
 	}
 
 	return timeout
+}
+
+// defaultDrainDelay is how long the public API keeps serving after the
+// termination signal, so that Kubernetes has time to stop routing new requests
+// here. It is deliberately shorter than the readiness probe period: the point
+// is to outlast kube-proxy's endpoint update, not to wait for a probe.
+const defaultDrainDelay = 5 * time.Second
+
+// drainDelay returns the wait before the public API stops listening.
+// Development restarts skip it, because a five second pause on every local
+// restart pushes people towards killing the process instead.
+func drainDelay() time.Duration {
+	if os.Getenv("APP_ENV") == "development" {
+		return 0
+	}
+
+	value := os.Getenv("SHUTDOWN_DRAIN_DELAY")
+	if value == "" {
+		return defaultDrainDelay
+	}
+
+	delay, err := time.ParseDuration(value)
+	if err != nil {
+		log.Warnf("Invalid SHUTDOWN_DRAIN_DELAY %q, using %s: %v", value, defaultDrainDelay, err)
+		return defaultDrainDelay
+	}
+
+	return delay
 }
 
 // waitForShutdown waits for every tracked goroutine to return, and gives up when

--- a/pkg/server/shutdown_test.go
+++ b/pkg/server/shutdown_test.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -59,7 +62,7 @@ func Test__StartWorker(t *testing.T) {
 		}
 
 		cancel()
-		waitForShutdown(&wg, time.Second)
+		waitForShutdownFor(t, &wg, time.Second)
 
 		select {
 		case <-stopped:
@@ -79,7 +82,7 @@ func Test__WaitForShutdown(t *testing.T) {
 		}()
 
 		start := time.Now()
-		waitForShutdown(&wg, time.Second)
+		assert.True(t, waitForShutdownFor(t, &wg, time.Second), "every worker returned")
 		assert.Less(t, time.Since(start), time.Second)
 	})
 
@@ -94,7 +97,7 @@ func Test__WaitForShutdown(t *testing.T) {
 		defer close(release)
 
 		start := time.Now()
-		waitForShutdown(&wg, 50*time.Millisecond)
+		assert.False(t, waitForShutdownFor(t, &wg, 50*time.Millisecond), "work was abandoned")
 		elapsed := time.Since(start)
 
 		//
@@ -155,7 +158,7 @@ func Test__StartConsumer(t *testing.T) {
 
 		startConsumer(ctx, &wg, "test consumer", start, stop)
 		cancel()
-		waitForShutdown(&wg, 5*time.Second)
+		waitForShutdownFor(t, &wg, 5*time.Second)
 
 		mu.Lock()
 		defer mu.Unlock()
@@ -174,7 +177,65 @@ func Test__StartConsumer(t *testing.T) {
 			func() { stopped = true },
 		)
 
-		waitForShutdown(&wg, 5*time.Second)
+		waitForShutdownFor(t, &wg, 5*time.Second)
 		assert.False(t, stopped, "the watcher must exit when the consumer already returned")
 	})
+}
+
+// waitForShutdownFor adapts waitForShutdown's context to a plain duration, which
+// keeps the timing intent of these tests readable.
+func waitForShutdownFor(t *testing.T, wg *sync.WaitGroup, timeout time.Duration) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return waitForShutdown(ctx, wg)
+}
+
+func Test__TimeLeft(t *testing.T) {
+	t.Run("reports the remaining time", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		left := timeLeft(ctx)
+		assert.Greater(t, left, 50*time.Second)
+		assert.LessOrEqual(t, left, time.Minute)
+	})
+
+	t.Run("is zero for an expired deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), -time.Second)
+		defer cancel()
+
+		assert.Equal(t, time.Duration(0), timeLeft(ctx))
+	})
+
+	t.Run("is zero when there is no deadline", func(t *testing.T) {
+		assert.Equal(t, time.Duration(0), timeLeft(context.Background()))
+	})
+}
+
+// Each worker launch must pass the cancellable context. Reverting a single one
+// of them back to context.Background() compiles and passes every behavioural
+// test, because nothing constructs the full startWorkers dependency graph, so
+// guard the wiring at the source level instead.
+func Test__WorkersAreStartedWithACancellableContext(t *testing.T) {
+	source, err := os.ReadFile("server.go")
+	require.NoError(t, err)
+
+	body := string(source)
+	start := strings.Index(body, "func startWorkers(")
+	require.NotEqual(t, -1, start, "startWorkers not found")
+
+	end := strings.Index(body[start:], "\nfunc ")
+	require.NotEqual(t, -1, end, "end of startWorkers not found")
+
+	var offenders []string
+	for i, line := range strings.Split(body[start:start+end], "\n") {
+		if strings.Contains(line, "context.Background()") {
+			offenders = append(offenders, fmt.Sprintf("line %d: %s", i+1, strings.TrimSpace(line)))
+		}
+	}
+
+	assert.Empty(t, offenders, "startWorkers must hand every worker the cancellable context, not context.Background()")
 }

--- a/pkg/server/shutdown_test.go
+++ b/pkg/server/shutdown_test.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__ShutdownTimeout(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		t.Setenv("SHUTDOWN_TIMEOUT", "")
+		assert.Equal(t, defaultShutdownTimeout, shutdownTimeout())
+	})
+
+	t.Run("reads the environment", func(t *testing.T) {
+		t.Setenv("SHUTDOWN_TIMEOUT", "5s")
+		assert.Equal(t, 5*time.Second, shutdownTimeout())
+	})
+
+	t.Run("falls back when the value does not parse", func(t *testing.T) {
+		t.Setenv("SHUTDOWN_TIMEOUT", "banana")
+		assert.Equal(t, defaultShutdownTimeout, shutdownTimeout())
+	})
+
+	t.Run("stays under the Kubernetes default grace period", func(t *testing.T) {
+		//
+		// The chart does not set terminationGracePeriodSeconds, so Kubernetes
+		// sends SIGKILL after 30s. The drain has to finish before that.
+		//
+		assert.Less(t, defaultShutdownTimeout, 30*time.Second)
+	})
+}
+
+func Test__StartWorker(t *testing.T) {
+	t.Run("cancels the worker and waits for it", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+
+		stopped := make(chan struct{})
+		startWorker(ctx, &wg, func(workerCtx context.Context) {
+			<-workerCtx.Done()
+
+			//
+			// Stand in for work that outlives the signal, so the assertion below
+			// fails if Start stops waiting for the worker.
+			//
+			time.Sleep(50 * time.Millisecond)
+			close(stopped)
+		})
+
+		select {
+		case <-stopped:
+			require.Fail(t, "worker stopped before the context was cancelled")
+		case <-time.After(20 * time.Millisecond):
+		}
+
+		cancel()
+		waitForShutdown(&wg, time.Second)
+
+		select {
+		case <-stopped:
+		default:
+			require.Fail(t, "waitForShutdown returned before the worker finished")
+		}
+	})
+}
+
+func Test__WaitForShutdown(t *testing.T) {
+	t.Run("returns once every worker returns", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(10 * time.Millisecond)
+		}()
+
+		start := time.Now()
+		waitForShutdown(&wg, time.Second)
+		assert.Less(t, time.Since(start), time.Second)
+	})
+
+	t.Run("gives up when a worker does not return", func(t *testing.T) {
+		var wg sync.WaitGroup
+		release := make(chan struct{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-release
+		}()
+		defer close(release)
+
+		start := time.Now()
+		waitForShutdown(&wg, 50*time.Millisecond)
+		elapsed := time.Since(start)
+
+		//
+		// A stuck worker must not hold the process open past the deadline.
+		//
+		assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
+		assert.Less(t, elapsed, time.Second)
+	})
+}
+
+func Test__StartConsumer(t *testing.T) {
+	t.Run("keeps calling stop until the consumer returns", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+
+		//
+		// Mirrors tackle: Stop does nothing until the consumer reaches the
+		// listening state, so the first Stop after cancellation is discarded.
+		//
+		var mu sync.Mutex
+		listening := false
+		stopCalls := 0
+		release := make(chan struct{})
+
+		start := func(startCtx context.Context) error {
+			<-startCtx.Done()
+
+			//
+			// Stand in for tackle's connect(), which does network I/O before it
+			// marks the consumer as listening. Every Stop that lands in this
+			// window is discarded.
+			//
+			time.Sleep(4 * stopRetryInterval)
+
+			mu.Lock()
+			listening = true
+			mu.Unlock()
+
+			<-release
+			return nil
+		}
+
+		stop := func() {
+			mu.Lock()
+			defer mu.Unlock()
+
+			stopCalls++
+			if !listening {
+				return
+			}
+
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		}
+
+		startConsumer(ctx, &wg, "test consumer", start, stop)
+		cancel()
+		waitForShutdown(&wg, 5*time.Second)
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Greater(t, stopCalls, 1, "a single lost stop must not strand the consumer")
+	})
+
+	t.Run("does not call stop when the consumer returns on its own", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var wg sync.WaitGroup
+		stopped := false
+
+		startConsumer(ctx, &wg, "test consumer",
+			func(context.Context) error { return nil },
+			func() { stopped = true },
+		)
+
+		waitForShutdown(&wg, 5*time.Second)
+		assert.False(t, stopped, "the watcher must exit when the consumer already returned")
+	})
+}

--- a/pkg/server/shutdown_test.go
+++ b/pkg/server/shutdown_test.go
@@ -239,3 +239,36 @@ func Test__WorkersAreStartedWithACancellableContext(t *testing.T) {
 
 	assert.Empty(t, offenders, "startWorkers must hand every worker the cancellable context, not context.Background()")
 }
+
+func Test__DrainDelay(t *testing.T) {
+	t.Run("defaults in production-like environments", func(t *testing.T) {
+		t.Setenv("APP_ENV", "production")
+		t.Setenv("SHUTDOWN_DRAIN_DELAY", "")
+		assert.Equal(t, defaultDrainDelay, drainDelay())
+	})
+
+	t.Run("is skipped in development", func(t *testing.T) {
+		t.Setenv("APP_ENV", "development")
+		assert.Equal(t, time.Duration(0), drainDelay())
+	})
+
+	t.Run("reads the environment", func(t *testing.T) {
+		t.Setenv("APP_ENV", "production")
+		t.Setenv("SHUTDOWN_DRAIN_DELAY", "2s")
+		assert.Equal(t, 2*time.Second, drainDelay())
+	})
+
+	t.Run("falls back when the value does not parse", func(t *testing.T) {
+		t.Setenv("APP_ENV", "production")
+		t.Setenv("SHUTDOWN_DRAIN_DELAY", "soon")
+		assert.Equal(t, defaultDrainDelay, drainDelay())
+	})
+
+	t.Run("leaves room inside the shutdown budget", func(t *testing.T) {
+		//
+		// The delay runs before the HTTP drain, and both must finish inside the
+		// Kubernetes grace period.
+		//
+		assert.Less(t, defaultDrainDelay+defaultShutdownTimeout, 31*time.Second)
+	})
+}

--- a/pkg/telemetry/sentry.go
+++ b/pkg/telemetry/sentry.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"os"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -37,4 +38,12 @@ func InitSentry() {
 	}
 
 	log.Info("Sentry telemetry initialized")
+}
+
+// FlushSentry sends the buffered events before the process exits. It is a no-op
+// when InitSentry did not configure a client.
+func FlushSentry(timeout time.Duration) {
+	if !sentry.Flush(timeout) {
+		log.Warn("Sentry flush timed out, some events were dropped")
+	}
 }

--- a/pkg/workers/app_message_worker.go
+++ b/pkg/workers/app_message_worker.go
@@ -30,7 +30,7 @@ type AppMessageWorker struct {
 func NewAppMessageWorker(registry *registry.Registry) *AppMessageWorker {
 	return &AppMessageWorker{
 		registry:  registry,
-		semaphore: semaphore.NewWeighted(25),
+		semaphore: semaphore.NewWeighted(maxConcurrentTasks),
 		logger:    log.WithFields(log.Fields{"worker": "AppMessageWorker"}),
 	}
 }
@@ -42,6 +42,7 @@ func (w *AppMessageWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			appMessages, err := models.ListAppMessages(database.Conn())
@@ -51,6 +52,15 @@ func (w *AppMessageWorker) Start(ctx context.Context) {
 			}
 
 			for _, message := range appMessages {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/canvas_cleanup_worker.go
+++ b/pkg/workers/canvas_cleanup_worker.go
@@ -29,7 +29,7 @@ type CanvasCleanupWorker struct {
 
 func NewCanvasCleanupWorker(gitProvider git.Provider, providers ...agents.Provider) *CanvasCleanupWorker {
 	w := &CanvasCleanupWorker{
-		semaphore:           semaphore.NewWeighted(25),
+		semaphore:           semaphore.NewWeighted(maxConcurrentTasks),
 		logger:              log.WithFields(log.Fields{"worker": "CanvasCleanupWorker"}),
 		maxRunsPerTick:      50,
 		maxResourcesPerTick: 500,
@@ -52,6 +52,7 @@ func (w *CanvasCleanupWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
@@ -67,6 +68,15 @@ func (w *CanvasCleanupWorker) Start(ctx context.Context) {
 			for _, canvas := range canvases {
 				if deletedResourceWithinGracePeriod(canvas.DeletedAt.Time, tickStart) {
 					continue
+				}
+
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
 				}
 
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {

--- a/pkg/workers/email_consumer_shutdown_test.go
+++ b/pkg/workers/email_consumer_shutdown_test.go
@@ -5,7 +5,12 @@ import (
 	"testing"
 	"time"
 
+	tackle "github.com/renderedtext/go-tackle"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/config"
 )
 
 // The consumers reconnect in a loop. Before they took a context, a cancelled
@@ -40,4 +45,66 @@ func requireReturnsBefore(t *testing.T, timeout time.Duration, start func() erro
 	case <-time.After(timeout):
 		require.Fail(t, "Start did not return for a cancelled context")
 	}
+}
+
+// A deliberate Stop during shutdown makes tackle's Start return nil, which the
+// reconnect path would otherwise report as a dropped connection. A deploy would
+// then log a reconnect warning for every consumer, every time.
+func Test__EmailConsumersDoNotWarnAboutReconnectOnShutdown(t *testing.T) {
+	amqpURL, err := config.RabbitMQURL()
+	require.NoError(t, err)
+
+	magicCode := NewMagicCodeEmailConsumer(amqpURL, nil, "https://app.superplane.com")
+	factoryNotification := NewFactoryNotificationConsumer(amqpURL, nil, "https://app.superplane.com")
+
+	consumers := []shutdownTestConsumer{
+		{"magic code", magicCode.Start, magicCode.Stop, magicCode.Consumer},
+		{"factory notification", factoryNotification.Start, factoryNotification.Stop, factoryNotification.Consumer},
+	}
+
+	for _, consumer := range consumers {
+		t.Run(consumer.name, func(t *testing.T) {
+			hook := logtest.NewGlobal()
+			defer hook.Reset()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			done := make(chan error, 1)
+			go func() { done <- consumer.start(ctx) }()
+
+			//
+			// Wait until the consumer is really listening, so Stop closes a live
+			// connection and Start returns nil, which is the shutdown path under test.
+			//
+			require.Eventually(t, func() bool {
+				return consumer.consumer.State == tackle.StateListening
+			}, 10*time.Second, 20*time.Millisecond, "consumer never started listening")
+
+			hook.Reset()
+			cancel()
+			consumer.stop()
+
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(10 * time.Second):
+				require.Fail(t, "Start did not return after Stop")
+			}
+
+			for _, entry := range hook.AllEntries() {
+				assert.NotContains(t, entry.Message, "reconnecting", "a deliberate stop is not a dropped connection")
+				assert.NotEqual(t, log.ErrorLevel, entry.Level, "a deliberate stop is not an error")
+			}
+		})
+	}
+}
+
+// shutdownTestConsumer describes one email consumer for the shutdown tests, so
+// both consumers run the same assertions.
+type shutdownTestConsumer struct {
+	name     string
+	start    func(context.Context) error
+	stop     func()
+	consumer *tackle.Consumer
 }

--- a/pkg/workers/email_consumer_shutdown_test.go
+++ b/pkg/workers/email_consumer_shutdown_test.go
@@ -1,0 +1,43 @@
+package workers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The consumers reconnect in a loop. Before they took a context, a cancelled
+// process still reconnected and accepted new deliveries during the drain, and
+// Start never returned, so nothing could wait for them.
+func Test__EmailConsumersStopOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	t.Run("magic code consumer", func(t *testing.T) {
+		consumer := NewMagicCodeEmailConsumer("amqp://127.0.0.1:1", nil, "https://app.superplane.com")
+		requireReturnsBefore(t, time.Second, func() error { return consumer.Start(ctx) })
+	})
+
+	t.Run("factory notification consumer", func(t *testing.T) {
+		consumer := NewFactoryNotificationConsumer("amqp://127.0.0.1:1", nil, "https://app.superplane.com")
+		requireReturnsBefore(t, time.Second, func() error { return consumer.Start(ctx) })
+	})
+}
+
+// requireReturnsBefore fails if start has not returned when timeout expires.
+// The unreachable broker address makes the test independent of RabbitMQ.
+func requireReturnsBefore(t *testing.T, timeout time.Duration, start func() error) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() { done <- start() }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(timeout):
+		require.Fail(t, "Start did not return for a cancelled context")
+	}
+}

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -28,7 +28,7 @@ type EventRouter struct {
 
 func NewEventRouter(rabbitMQURL string) *EventRouter {
 	return &EventRouter{
-		semaphore:   semaphore.NewWeighted(25),
+		semaphore:   semaphore.NewWeighted(maxConcurrentTasks),
 		logger:      log.WithFields(log.Fields{"worker": "EventRouter"}),
 		rabbitMQURL: rabbitMQURL,
 	}
@@ -47,6 +47,7 @@ func (w *EventRouter) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
@@ -59,6 +60,15 @@ func (w *EventRouter) Start(ctx context.Context) {
 			telemetry.RecordEventWorkerEventsCount(context.Background(), len(events))
 
 			for _, event := range events {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/execution_terminator.go
+++ b/pkg/workers/execution_terminator.go
@@ -43,7 +43,7 @@ func NewExecutionTerminator(
 		encryptor:   encryptor,
 		registry:    registry,
 		authService: authService,
-		semaphore:   semaphore.NewWeighted(25),
+		semaphore:   semaphore.NewWeighted(maxConcurrentTasks),
 		logger:      log.WithFields(log.Fields{"worker": "ExecutionTerminator"}),
 		rabbitMQURL: rabbitMQURL,
 	}
@@ -62,6 +62,7 @@ func (w *ExecutionTerminator) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			executions, err := models.ListCancellingNodeExecutions(database.Conn())
@@ -71,6 +72,15 @@ func (w *ExecutionTerminator) Start(ctx context.Context) {
 			}
 
 			for _, execution := range executions {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/factory_cleanup_worker.go
+++ b/pkg/workers/factory_cleanup_worker.go
@@ -21,7 +21,7 @@ type FactoryCleanupWorker struct {
 
 func NewFactoryCleanupWorker() *FactoryCleanupWorker {
 	return &FactoryCleanupWorker{
-		semaphore:           semaphore.NewWeighted(10),
+		semaphore:           semaphore.NewWeighted(maxConcurrentCleanupTasks),
 		logger:              log.WithFields(log.Fields{"worker": "FactoryCleanupWorker"}),
 		maxResourcesPerTick: 500,
 	}
@@ -34,6 +34,7 @@ func (w *FactoryCleanupWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentCleanupTasks)
 			return
 		case tickTime := <-ticker.C:
 			factories, err := models.ListDeletedFactories(database.Conn())
@@ -47,6 +48,15 @@ func (w *FactoryCleanupWorker) Start(ctx context.Context) {
 			for _, factory := range factories {
 				if !factory.DeletedAt.Valid || deletedResourceWithinGracePeriod(factory.DeletedAt.Time, tickTime) {
 					continue
+				}
+
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
 				}
 
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {

--- a/pkg/workers/factory_notification_consumer.go
+++ b/pkg/workers/factory_notification_consumer.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,7 +50,7 @@ func NewFactoryNotificationConsumer(rabbitMQURL string, emailService services.Em
 	}
 }
 
-func (c *FactoryNotificationConsumer) Start() error {
+func (c *FactoryNotificationConsumer) Start(ctx context.Context) error {
 	options := tackle.Options{
 		URL:            c.RabbitMQURL,
 		ConnectionName: FactoryNotificationConnectionName,
@@ -59,17 +60,27 @@ func (c *FactoryNotificationConsumer) Start() error {
 	}
 
 	for {
-		log.Infof("Connecting to RabbitMQ queue for %s events", messages.FactoryWorkOrderNotificationRoutingKey)
-
-		err := c.Consumer.Start(&options, c.Consume)
-		if err != nil {
-			log.Errorf("Error consuming messages from %s: %v", messages.FactoryWorkOrderNotificationRoutingKey, err)
-			time.Sleep(5 * time.Second)
-			continue
+		if ctx.Err() != nil {
+			return nil
 		}
 
-		log.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.FactoryWorkOrderNotificationRoutingKey)
-		time.Sleep(5 * time.Second)
+		log.Infof("Connecting to RabbitMQ queue for %s events", messages.FactoryWorkOrderNotificationRoutingKey)
+
+		if err := c.Consumer.Start(&options, c.Consume); err != nil {
+			log.Errorf("Error consuming messages from %s: %v", messages.FactoryWorkOrderNotificationRoutingKey, err)
+		} else {
+			log.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.FactoryWorkOrderNotificationRoutingKey)
+		}
+
+		//
+		// Wait before reconnecting, but give up as soon as the process is shutting
+		// down, so a cancelled consumer does not reconnect and take new messages.
+		//
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(reconnectDelay):
+		}
 	}
 }
 

--- a/pkg/workers/factory_notification_consumer.go
+++ b/pkg/workers/factory_notification_consumer.go
@@ -66,7 +66,22 @@ func (c *FactoryNotificationConsumer) Start(ctx context.Context) error {
 
 		log.Infof("Connecting to RabbitMQ queue for %s events", messages.FactoryWorkOrderNotificationRoutingKey)
 
-		if err := c.Consumer.Start(&options, c.Consume); err != nil {
+		err := c.Consumer.Start(&options, c.Consume)
+
+		//
+		// A cancelled context means shutdown closed the connection on purpose,
+		// so this is neither a failure nor a reconnect. Keep a real error
+		// visible, at a level that does not read as an alert during a deploy.
+		//
+		if ctx.Err() != nil {
+			if err != nil {
+				log.Infof("Consumer for %s stopped during shutdown: %v", messages.FactoryWorkOrderNotificationRoutingKey, err)
+			}
+
+			return nil
+		}
+
+		if err != nil {
 			log.Errorf("Error consuming messages from %s: %v", messages.FactoryWorkOrderNotificationRoutingKey, err)
 		} else {
 			log.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.FactoryWorkOrderNotificationRoutingKey)

--- a/pkg/workers/factory_velocity_sync_worker.go
+++ b/pkg/workers/factory_velocity_sync_worker.go
@@ -115,6 +115,7 @@ func (w *FactoryVelocitySyncWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, velocitySyncConcurrency)
 			return
 		case <-ticker.C:
 			w.tick(ctx)

--- a/pkg/workers/integration_cleanup_worker.go
+++ b/pkg/workers/integration_cleanup_worker.go
@@ -26,7 +26,7 @@ type IntegrationCleanupWorker struct {
 
 func NewIntegrationCleanupWorker(registry *registry.Registry, encryptor crypto.Encryptor, baseURL string) *IntegrationCleanupWorker {
 	return &IntegrationCleanupWorker{
-		semaphore: semaphore.NewWeighted(25),
+		semaphore: semaphore.NewWeighted(maxConcurrentTasks),
 		registry:  registry,
 		encryptor: encryptor,
 		baseURL:   baseURL,
@@ -40,6 +40,7 @@ func (w *IntegrationCleanupWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			integrations, err := models.ListDeletedIntegrations()
@@ -48,6 +49,15 @@ func (w *IntegrationCleanupWorker) Start(ctx context.Context) {
 			}
 
 			for _, integration := range integrations {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.log("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/integration_request_worker.go
+++ b/pkg/workers/integration_request_worker.go
@@ -36,7 +36,7 @@ func NewIntegrationRequestWorker(encryptor crypto.Encryptor, registry *registry.
 		oidcProvider:    oidcProvider,
 		baseURL:         baseURL,
 		webhooksBaseURL: webhooksBaseURL,
-		semaphore:       semaphore.NewWeighted(25),
+		semaphore:       semaphore.NewWeighted(maxConcurrentTasks),
 	}
 }
 
@@ -55,6 +55,7 @@ func (w *IntegrationRequestWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			requests, err := models.ListIntegrationRequests()
@@ -63,6 +64,15 @@ func (w *IntegrationRequestWorker) Start(ctx context.Context) {
 			}
 
 			for _, request := range requests {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.log("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/magic_code_email_consumer.go
+++ b/pkg/workers/magic_code_email_consumer.go
@@ -60,7 +60,22 @@ func (c *MagicCodeEmailConsumer) Start(ctx context.Context) error {
 
 		log.Infof("Connecting to RabbitMQ queue for %s events", messages.MagicCodeRequestedRoutingKey)
 
-		if err := c.Consumer.Start(&options, c.Consume); err != nil {
+		err := c.Consumer.Start(&options, c.Consume)
+
+		//
+		// A cancelled context means shutdown closed the connection on purpose,
+		// so this is neither a failure nor a reconnect. Keep a real error
+		// visible, at a level that does not read as an alert during a deploy.
+		//
+		if ctx.Err() != nil {
+			if err != nil {
+				log.Infof("Consumer for %s stopped during shutdown: %v", messages.MagicCodeRequestedRoutingKey, err)
+			}
+
+			return nil
+		}
+
+		if err != nil {
 			log.Errorf("Error consuming messages from %s: %v", messages.MagicCodeRequestedRoutingKey, err)
 		} else {
 			log.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.MagicCodeRequestedRoutingKey)

--- a/pkg/workers/magic_code_email_consumer.go
+++ b/pkg/workers/magic_code_email_consumer.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -12,6 +13,10 @@ import (
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/services"
 )
+
+// reconnectDelay is how long an email consumer waits before it reconnects to
+// RabbitMQ after the connection drops or fails to open.
+const reconnectDelay = 5 * time.Second
 
 const MagicCodeEmailServiceName = "superplane" + "." + messages.CanvasExchange + "." + messages.MagicCodeRequestedRoutingKey + ".worker-consumer"
 const MagicCodeEmailConnectionName = "superplane"
@@ -39,7 +44,7 @@ func NewMagicCodeEmailConsumer(rabbitMQURL string, emailService services.EmailSe
 	}
 }
 
-func (c *MagicCodeEmailConsumer) Start() error {
+func (c *MagicCodeEmailConsumer) Start(ctx context.Context) error {
 	options := tackle.Options{
 		URL:            c.RabbitMQURL,
 		ConnectionName: MagicCodeEmailConnectionName,
@@ -49,17 +54,27 @@ func (c *MagicCodeEmailConsumer) Start() error {
 	}
 
 	for {
-		log.Infof("Connecting to RabbitMQ queue for %s events", messages.MagicCodeRequestedRoutingKey)
-
-		err := c.Consumer.Start(&options, c.Consume)
-		if err != nil {
-			log.Errorf("Error consuming messages from %s: %v", messages.MagicCodeRequestedRoutingKey, err)
-			time.Sleep(5 * time.Second)
-			continue
+		if ctx.Err() != nil {
+			return nil
 		}
 
-		log.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.MagicCodeRequestedRoutingKey)
-		time.Sleep(5 * time.Second)
+		log.Infof("Connecting to RabbitMQ queue for %s events", messages.MagicCodeRequestedRoutingKey)
+
+		if err := c.Consumer.Start(&options, c.Consume); err != nil {
+			log.Errorf("Error consuming messages from %s: %v", messages.MagicCodeRequestedRoutingKey, err)
+		} else {
+			log.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.MagicCodeRequestedRoutingKey)
+		}
+
+		//
+		// Wait before reconnecting, but give up as soon as the process is shutting
+		// down, so a cancelled consumer does not reconnect and take new messages.
+		//
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(reconnectDelay):
+		}
 	}
 }
 

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -56,7 +56,7 @@ func NewNodeExecutor(encryptor crypto.Encryptor, registry *registry.Registry, gi
 		oidcProvider:   oidcProvider,
 		baseURL:        baseURL,
 		webhookBaseURL: webhookBaseURL,
-		semaphore:      semaphore.NewWeighted(25),
+		semaphore:      semaphore.NewWeighted(maxConcurrentTasks),
 		logger:         logrus.WithFields(logrus.Fields{"worker": "NodeExecutor"}),
 		rabbitMQURL:    rabbitMQURL,
 		authService:    authService,
@@ -76,6 +76,7 @@ func (w *NodeExecutor) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
@@ -88,6 +89,15 @@ func (w *NodeExecutor) Start(ctx context.Context) {
 			telemetry.RecordExecutorWorkerNodesCount(context.Background(), len(executions))
 
 			for _, execution := range executions {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -50,7 +50,7 @@ func NewNodeQueueWorker(registry *registry.Registry, gitProvider gitprovider.Pro
 		registry:                  registry,
 		gitProvider:               gitProvider,
 		rabbitMQURL:               rabbitMQURL,
-		semaphore:                 semaphore.NewWeighted(25),
+		semaphore:                 semaphore.NewWeighted(maxConcurrentTasks),
 		logger:                    logger,
 		queueItemConsumer:         queueItemConsumer,
 		executionFinishedConsumer: executionFinishedConsumer,
@@ -89,6 +89,7 @@ func (w *NodeQueueWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
@@ -101,6 +102,15 @@ func (w *NodeQueueWorker) Start(ctx context.Context) {
 
 			for _, node := range nodes {
 				logger := logging.WithNode(w.logger, node)
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					logger.Errorf("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -39,7 +39,7 @@ func NewNodeRequestWorker(encryptor crypto.Encryptor, registry *registry.Registr
 		registry:       registry,
 		gitProvider:    gitProvider,
 		webhookBaseURL: webhookBaseURL,
-		semaphore:      semaphore.NewWeighted(25),
+		semaphore:      semaphore.NewWeighted(maxConcurrentTasks),
 		authService:    authService,
 		logger:         log.WithFields(log.Fields{"worker": "NodeRequestWorker"}),
 	}
@@ -52,6 +52,7 @@ func (w *NodeRequestWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
@@ -64,6 +65,15 @@ func (w *NodeRequestWorker) Start(ctx context.Context) {
 			telemetry.RecordNodeRequestWorkerRequestsCount(context.Background(), len(requests))
 
 			for _, request := range requests {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/organization_cleanup_worker.go
+++ b/pkg/workers/organization_cleanup_worker.go
@@ -24,7 +24,7 @@ type OrganizationCleanupWorker struct {
 
 func NewOrganizationCleanupWorker(gitProvider git.Provider, providers ...agents.Provider) *OrganizationCleanupWorker {
 	return &OrganizationCleanupWorker{
-		semaphore:    semaphore.NewWeighted(10),
+		semaphore:    semaphore.NewWeighted(maxConcurrentCleanupTasks),
 		logger:       log.WithFields(log.Fields{"worker": "OrganizationCleanupWorker"}),
 		canvasWorker: NewCanvasCleanupWorker(gitProvider, providers...),
 		gitProvider:  gitProvider,
@@ -38,6 +38,7 @@ func (w *OrganizationCleanupWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentCleanupTasks)
 			return
 		case tickTime := <-ticker.C:
 			organizations, err := models.ListDeletedOrganizations()
@@ -49,6 +50,15 @@ func (w *OrganizationCleanupWorker) Start(ctx context.Context) {
 			for _, organization := range organizations {
 				if deletedResourceWithinGracePeriod(organization.DeletedAt.Time, tickTime) {
 					continue
+				}
+
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
 				}
 
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {

--- a/pkg/workers/repository_provisioner.go
+++ b/pkg/workers/repository_provisioner.go
@@ -59,6 +59,7 @@ func (w *RepositoryProvisionerWorker) Start(ctx context.Context) {
 
 	<-ctx.Done()
 	w.Stop()
+	drainTasks(w.semaphore, maxConcurrentTasks)
 }
 
 func (w *RepositoryProvisionerWorker) Stop() {

--- a/pkg/workers/run_initializer.go
+++ b/pkg/workers/run_initializer.go
@@ -41,7 +41,7 @@ func NewRunInitializer(rabbitMQURL string, registry *registry.Registry) *RunInit
 	return &RunInitializer{
 		registry:    registry,
 		rabbitMQURL: rabbitMQURL,
-		semaphore:   semaphore.NewWeighted(25),
+		semaphore:   semaphore.NewWeighted(maxConcurrentTasks),
 		logger:      log.WithFields(log.Fields{"worker": "RunInitializer"}),
 	}
 }
@@ -63,6 +63,7 @@ func (w *RunInitializer) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			w.sweepPendingRuns()

--- a/pkg/workers/shutdown.go
+++ b/pkg/workers/shutdown.go
@@ -1,0 +1,32 @@
+package workers
+
+import (
+	"context"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// Workers bound their in-flight tasks with a weighted semaphore. The limits are
+// named here so that drainTasks always waits for the same number of slots the
+// worker is able to hand out. A literal in one place and a different literal in
+// the other would drain part of the work and report success.
+const (
+	maxConcurrentTasks        = 25
+	maxConcurrentCleanupTasks = 10
+)
+
+// drainTasks waits for the tasks a worker has already started. Acquiring the
+// whole weight succeeds only once every in-flight task has released its slot,
+// so a cancelled worker finishes its work instead of abandoning it in the
+// middle of a database transaction or an external API call.
+//
+// The caller bounds this: the shutdown deadline in pkg/server gives up on the
+// drain and exits, so a task that never returns cannot hold the process open.
+func drainTasks(sem *semaphore.Weighted, limit int64) {
+	//
+	// context.Background, not the worker's context: that context is already
+	// cancelled by the time we drain, and passing it would make Acquire return
+	// immediately without waiting for anything.
+	//
+	_ = sem.Acquire(context.Background(), limit)
+}

--- a/pkg/workers/shutdown_test.go
+++ b/pkg/workers/shutdown_test.go
@@ -1,0 +1,50 @@
+package workers
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/semaphore"
+)
+
+func Test__DrainTasks(t *testing.T) {
+	t.Run("waits for in-flight tasks to finish", func(t *testing.T) {
+		sem := semaphore.NewWeighted(maxConcurrentTasks)
+
+		var finished atomic.Int64
+		const inFlight = 5
+
+		for i := 0; i < inFlight; i++ {
+			//
+			// Mirrors a worker: take a slot, then do the work in a goroutine
+			// that releases the slot when it is done.
+			//
+			_ = sem.Acquire(context.Background(), 1)
+
+			go func() {
+				defer sem.Release(1)
+
+				time.Sleep(100 * time.Millisecond)
+				finished.Add(1)
+			}()
+		}
+
+		assert.Less(t, finished.Load(), int64(inFlight), "tasks should still be running")
+
+		drainTasks(sem, maxConcurrentTasks)
+
+		assert.Equal(t, int64(inFlight), finished.Load(), "drain must not return while work is in flight")
+	})
+
+	t.Run("returns immediately when nothing is in flight", func(t *testing.T) {
+		sem := semaphore.NewWeighted(maxConcurrentCleanupTasks)
+
+		start := time.Now()
+		drainTasks(sem, maxConcurrentCleanupTasks)
+
+		assert.Less(t, time.Since(start), time.Second)
+	})
+}

--- a/pkg/workers/webhook_cleanup_worker.go
+++ b/pkg/workers/webhook_cleanup_worker.go
@@ -30,7 +30,7 @@ func NewWebhookCleanupWorker(encryptor crypto.Encryptor, registry *registry.Regi
 	return &WebhookCleanupWorker{
 		registry:  registry,
 		encryptor: encryptor,
-		semaphore: semaphore.NewWeighted(25),
+		semaphore: semaphore.NewWeighted(maxConcurrentTasks),
 		baseURL:   baseURL,
 		logger:    log.WithFields(log.Fields{"worker": "WebhookCleanupWorker"}),
 	}
@@ -43,6 +43,7 @@ func (w *WebhookCleanupWorker) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
@@ -55,6 +56,15 @@ func (w *WebhookCleanupWorker) Start(ctx context.Context) {
 			telemetry.RecordWebhookCleanupWorkerWebhooksCount(context.Background(), len(webhooks))
 
 			for _, webhook := range webhooks {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue

--- a/pkg/workers/webhook_provisioner.go
+++ b/pkg/workers/webhook_provisioner.go
@@ -36,7 +36,7 @@ func NewWebhookProvisioner(baseURL string, encryptor crypto.Encryptor, registry 
 		registry:  registry,
 		baseURL:   baseURL,
 		encryptor: encryptor,
-		semaphore: semaphore.NewWeighted(25),
+		semaphore: semaphore.NewWeighted(maxConcurrentTasks),
 		logger:    log.WithFields(log.Fields{"worker": "WebhookProvisioner"}),
 	}
 }
@@ -56,6 +56,7 @@ func (w *WebhookProvisioner) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			drainTasks(w.semaphore, maxConcurrentTasks)
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
@@ -68,6 +69,15 @@ func (w *WebhookProvisioner) Start(ctx context.Context) {
 			telemetry.RecordWebhookProvisionerWorkerWebhooksCount(context.Background(), len(webhooks))
 
 			for _, webhook := range webhooks {
+				//
+				// Stop handing out new work once shutdown starts. Without this the
+				// worker keeps launching the rest of the batch after cancellation,
+				// and the drain then waits for work it should never have started.
+				//
+				if ctx.Err() != nil {
+					break
+				}
+
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue


### PR DESCRIPTION
Closes #6987.

`pkg/server/server.go` ended in `select {}` and started its 22 workers with `go w.Start(context.Background())`. Nothing was ever cancelled, so SIGTERM killed the process wherever it happened to be.

Two things had to be true before that mattered.

The server never received SIGTERM. `docker-entrypoint.sh` ended with `/app/build/superplane` and no `exec`, so bash stayed PID 1 and kept the signal. I checked it in a container: without `exec` the process runs as PID 7 and exits 137 on SIGKILL, with `exec` it runs as PID 1 and exits 0.

Waiting for worker loops is not waiting for work. Sixteen workers hand each task to a goroutine behind a weighted semaphore. Returning on `ctx.Done()` abandoned up to 25 of them per worker, mid-transaction, which is the first impact the issue lists. `drainTasks` acquires the full weight, which succeeds only once every task has released its slot.

## What changed

`Start()` derives a context from SIGINT and SIGTERM and blocks on it. `startWorker` tracks each worker in a `WaitGroup`. Workers drain in-flight tasks before returning, and stop handing out new ones once shutdown starts. The semaphore limits live in `pkg/workers/shutdown.go` and size both the semaphore and the drain, so the two cannot drift.

The public API gets `Shutdown(ctx)` beside the existing `Close`, and `http.ErrServerClosed` no longer reaches `log.Fatal`. The two email consumers take a context. Their reconnect loop used a plain `time.Sleep`, so `Start()` never returned and would have hung the drain.

One deadline covers the drain, the tracing shutdown and the Sentry flush. Separate budgets could run past the grace period between them. Default 25s, `SHUTDOWN_TIMEOUT` overrides.

## Not refusing requests on the way out

Closing the listener on SIGTERM would have been a regression. Kubernetes removes the pod from Endpoints asynchronously, and the chart polls `/` every 10s (`api.yaml:146`), so requests still arrive. Today bash swallows the signal and those requests are served. A naive fix would answer them with connection refused.

`SHUTDOWN_DRAIN_DELAY` keeps the API listening for 5s after the signal, then drains. Against the built binary, `/health` returns 200 at t+1s, t+2s and t+3s, then refuses. Development skips the delay.

## Races

`tackle.Consumer.Stop()` returns early while `State == StateNotListening` (`consumer.go:77`), and `State` becomes listening only at `consumer.go:173`, after `connect()` finishes its network I/O. A `Stop` in that window is discarded, and `consume()` then blocks on `<-c.shutdown` with nobody left to close it. Shutdown retries `Stop` until the consumer returns.

`Server.Shutdown` had the same shape when it ran before `Serve` assigned `httpServer`. `Serve` now refuses to start once `Shutdown` has run.

A deliberate `Stop` also made `Consumer.Start` return nil, which the reconnect path reported as a dropped connection. Every deploy would have logged a reconnect that never happens.

## Left out

The EventDistributer stays outside the drain. `Start` blocks on its own channel while the real work runs in per-route consumers created inside a loop, with no handle to stop them. Joining the drain would report every worker stopped while those consumers still ran. The pprof server keeps no handle either. Both want their own change.
