### PR TITLE
chore: make format.js less verbose

### DIFF
--- a/web_src/package.json
+++ b/web_src/package.json
@@ -23,8 +23,8 @@
     "test:coverage": "vitest run --coverage",
     "storybook": "storybook dev --no-open -p 6006",
     "build-storybook": "storybook build",
-    "format": "prettier --write '**/*.{ts,tsx}'",
-    "format:check": "prettier --check '**/*.{ts,tsx}'"
+    "format": "prettier --write --log-level warn '**/*.{ts,tsx}'",
+    "format:check": "prettier --check --log-level warn '**/*.{ts,tsx}'"
   },
   "dependencies": {
     "@dash0/sdk-web": "^0.22.1",


### PR DESCRIPTION
Every time we run `format.js` or `format.js.check`, we log all the files being processed:

```
cd web_src && npm run format

> web_src@0.0.0 format
> prettier --write '**/*.{ts,tsx}'

.storybook/main.ts 31ms (unchanged)
.storybook/manager.ts 3ms (unchanged)
.storybook/preview.tsx 13ms (unchanged)
.storybook/StorybookThemeShell.tsx 3ms (unchanged)
openapi-ts.config.ts 2ms (unchanged)
src/api-client/client.gen.ts 3ms (unchanged)
...
```

Right now, that means 205k characters going to the context of an agent every time they format the code.