### PR TITLE
fix: return 409 instead of 500 for duplicate API key name

### DIFF
--- a/pkg/grpc/actions/apikeys/create_api_key.go
+++ b/pkg/grpc/actions/apikeys/create_api_key.go
@@ -2,6 +2,7 @@ package apikeys
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -104,6 +105,9 @@ func CreateAPIKey(ctx context.Context, req *pb.CreateAPIKeyRequest, authService 
 	})
 
 	if err != nil {
+		if errors.Is(err, models.ErrAPIKeyNameAlreadyExists) {
+			return nil, grpcerrors.AlreadyExists(err, "an API key with this name already exists")
+		}
 		return nil, grpcerrors.Internal(err, "failed to create API key")
 	}
 

--- a/pkg/grpc/actions/apikeys/create_api_key_test.go
+++ b/pkg/grpc/actions/apikeys/create_api_key_test.go
@@ -52,6 +52,24 @@ func TestCreateAPIKeyRejectsInvalidCanvasScope(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, grpcerrors.Code(err))
 }
 
+func TestCreateAPIKeyRejectsDuplicateName(t *testing.T) {
+	r := support.Setup(t)
+
+	_, err := CreateAPIKey(apiKeyContext(r), &pb.CreateAPIKeyRequest{
+		Name: "ci-bot",
+		Role: models.RoleOrgViewer,
+	}, r.AuthService)
+	require.NoError(t, err)
+
+	_, err = CreateAPIKey(apiKeyContext(r), &pb.CreateAPIKeyRequest{
+		Name: "ci-bot",
+		Role: models.RoleOrgViewer,
+	}, r.AuthService)
+
+	require.Error(t, err)
+	require.Equal(t, codes.AlreadyExists, grpcerrors.Code(err))
+}
+
 func apiKeyContext(r *support.ResourceRegistry) context.Context {
 	return metadata.NewIncomingContext(
 		context.Background(),

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -1,14 +1,24 @@
 package models
 
 import (
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/utils"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
+
+// ErrAPIKeyNameAlreadyExists is returned when an organization already has an
+// API key with the same name. The unique_api_key_in_organization index enforces
+// this, and CreateAPIKey maps its violation to this error so callers can return
+// a 409 instead of a 500.
+var ErrAPIKeyNameAlreadyExists = errors.New("an API key with this name already exists")
+
+const apiKeyNameUniqueConstraint = "unique_api_key_in_organization"
 
 type User struct {
 	ID              uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()"`
@@ -147,10 +157,19 @@ func CreateAPIKey(tx *gorm.DB, orgID uuid.UUID, name string, description *string
 
 	err := tx.Create(user).Error
 	if err != nil {
-		return nil, err
+		return nil, mapAPIKeyNameUniqueConstraintError(err)
 	}
 
 	return user, nil
+}
+
+func mapAPIKeyNameUniqueConstraintError(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.ConstraintName == apiKeyNameUniqueConstraint {
+		return ErrAPIKeyNameAlreadyExists
+	}
+
+	return err
 }
 
 func FindAPIKeysByOrganization(db *gorm.DB, orgID string) ([]User, error) {


### PR DESCRIPTION
Creating an API key with a name that already exists in the organization returned an HTTP 500. The insert violates the `unique_api_key_in_organization` index, and `CreateAPIKey` wrapped every transaction error as `grpcerrors.Internal`, so the duplicate surfaced as a server error instead of a 409.

`models.CreateAPIKey` now maps that constraint violation to a sentinel `ErrAPIKeyNameAlreadyExists`, the same way `factory.go` and `canvas_folder.go` handle their duplicate-name cases. The handler returns `grpcerrors.AlreadyExists` for it, matching `factories/errors.go`, so the client gets a 409 with "an API key with this name already exists".

I verified the new test catches the bug: with the mapping removed it fails with `codes.Internal`, and passes once restored. The `apikeys` package is green. The two `pkg/models` failures I saw (`Test__RecordComputeUsage__*`) also fail on `main`, so they are pre-existing and unrelated.

Two things I left out on purpose: the issue also mentions disabling the submit button while a create is in flight, which is a separate frontend change, and I did not touch the other error paths in the handler.

Closes #7162
