### PR TITLE
fix: index pending webhooks to bound the provisioner poll cost

### DIFF
--- a/db/migrations/20260903195934_add-webhooks-pending-index.down.sql
+++ b/db/migrations/20260903195934_add-webhooks-pending-index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS idx_webhooks_pending;
+
+COMMIT;

--- a/db/migrations/20260903195934_add-webhooks-pending-index.up.sql
+++ b/db/migrations/20260903195934_add-webhooks-pending-index.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+-- The webhook provisioner polls for pending webhooks every second. Without an
+-- access path for the state filter, Postgres scans every active webhook to find
+-- the small pending set. This partial index holds only the pending rows, so the
+-- idle poll cost tracks the number of pending webhooks rather than the total.
+CREATE INDEX IF NOT EXISTS idx_webhooks_pending
+  ON webhooks (created_at)
+  WHERE state = 'pending' AND deleted_at IS NULL;
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2854,6 +2854,13 @@ CREATE INDEX idx_webhooks_deleted_at ON public.webhooks USING btree (deleted_at)
 
 
 --
+-- Name: idx_webhooks_pending; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_webhooks_pending ON public.webhooks USING btree (created_at) WHERE (((state)::text = 'pending'::text) AND (deleted_at IS NULL));
+
+
+--
 -- Name: idx_workflow_events_execution_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4237,7 +4244,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260902175657	f
+20260903195934	f
 \.
 
 


### PR DESCRIPTION
The webhook provisioner polls for pending webhooks every second, filtering `state = 'pending'` (and gorm's `deleted_at IS NULL`). The `webhooks` table had no access path for that filter, so Postgres scanned every active webhook on each poll. Most webhooks stay `ready` after provisioning, so the idle poll cost grew with the total number of connected webhooks rather than the small pending set.

This adds a partial index over the pending, non-deleted rows, the same shape the planning-sessions migration uses (`WHERE state <> 'ended'`). No query change: the planner picks it up.

On a set of 20k `ready` and 5 `pending` webhooks:

```
Without the index (main):
 Seq Scan on webhooks  (cost=0.00..497.06 rows=5)
   Filter: ((deleted_at IS NULL) AND ((state)::text = 'pending'::text))
   Rows Removed by Filter: 20000
   Buffers: shared hit=247

With the index:
 Index Scan using idx_webhooks_pending on webhooks  (cost=0.13..12.21 rows=5)
   Buffers: shared hit=2
```

The idle poll now reads the pending set instead of the whole active table. I left the index non-concurrent in a transaction to match the other migrations here; a large production table may want `CONCURRENTLY`, which is your call.

Closes #6992
