### PR TITLE
feat: link origin issue in PR description

### DIFF
--- a/pkg/grpc/actions/factories/factory_app_templates_test.go
+++ b/pkg/grpc/actions/factories/factory_app_templates_test.go
@@ -56,8 +56,15 @@ func TestMaterializeFactoryTemplate(t *testing.T) {
 
 	body, ok := createPR.Configuration["body"].(string)
 	require.True(t, ok, "expected create-pr body to be a string")
-	assert.True(t, strings.HasPrefix(body, "[{{ task().key }}]({{ task().url }})"), "body: %s", body)
+	assert.Contains(t, body, `task().origin != nil ? "Closes " + task().origin.label : ""`)
+	assert.Contains(t, body, "[{{ task().key }}]({{ task().url }})")
+	assert.Less(t, strings.Index(body, "Closes"), strings.Index(body, "task().key"), "body: %s", body)
 	assert.NotContains(t, body, "[Task](")
+
+	updatePR := findYAMLNode(t, canvas, "update-pr")
+	updateBody, ok := updatePR.Configuration["body"].(string)
+	require.True(t, ok, "expected update-pr body to be a string")
+	assert.Contains(t, updateBody, `task().origin != nil ? "Closes " + task().origin.label : ""`)
 
 	console, err := yaml.ConsoleFromYML([]byte(result.consoleYAML))
 	require.NoError(t, err)

--- a/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
+++ b/pkg/grpc/actions/factories/templates/line-implementation.canvas.yaml
@@ -158,8 +158,9 @@ spec:
               1/ Compare the current branch with {{ task().default_branch }} and review the commits you made.
               2/ The title must follow conventional commits structure. Use only feat, fix, chore, or docs.
               3/ The description must start with a brief summary of the changes, and include sections to describe the changes made in each logical part of the system (UI, API, workers, database, ...).
-              4/ Do not hard-wrap lines. Write each paragraph as a single line. Use blank lines only to separate paragraphs, headings, list items, or other Markdown elements. GitHub renders single newlines as line breaks.
-              5/ Write the title to /tmp/TITLE and the description to /tmp/DESCRIPTION.md. Do not add these files to the repository.
+              4/ Do not add GitHub closing keywords (Closes, Fixes, Resolves). The automation adds them.
+              5/ Do not hard-wrap lines. Write each paragraph as a single line. Use blank lines only to separate paragraphs, headings, list items, or other Markdown elements. GitHub renders single newlines as line breaks.
+              6/ Write the title to /tmp/TITLE and the description to /tmp/DESCRIPTION.md. Do not add these files to the repository.
 
               Write clearly, for humans, in ASD-STE100 / Simplified Technical English
           - name: Push output
@@ -227,6 +228,8 @@ spec:
       configuration:
         base: '{{ task().default_branch }}'
         body: |-
+          {{ task().origin != nil ? "Closes " + task().origin.label : "" }}
+
           [{{ task().key }}]({{ task().url }})
 
           {{ fromBase64($["Implement From Task Description"].data.result.description) }}
@@ -253,6 +256,8 @@ spec:
         pullNumber: '{{ $["Find Pull Request"].data.number }}'
         title: '{{ fromBase64($["Implement From Task Description"].data.result.title) }}'
         body: |-
+          {{ task().origin != nil ? "Closes " + task().origin.label : "" }}
+
           [{{ task().key }}]({{ task().url }})
 
           {{ fromBase64($["Implement From Task Description"].data.result.description) }}

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -1048,7 +1048,7 @@ func (b *NodeConfigurationBuilder) resolveRunPayload() (any, error) {
 // and its task() alias. Returns nil when the run is not attached to a
 // factory work-order execution. The url, key, artifacts, comments, and
 // assignees are loaded only when the expression AST references those fields
-// on order() or task().
+// on order() or task(). Origin is attached whenever the work order has one.
 func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, error) {
 	if b.rootEventID == nil {
 		return nil, nil
@@ -1094,6 +1094,7 @@ func (b *NodeConfigurationBuilder) resolveOrderPayload(expression string) (any, 
 	if err := attachOrderSource(b.tx, order, payload); err != nil {
 		return nil, err
 	}
+	attachOrderOrigin(order, payload)
 
 	usesURL, err := expressionvalidation.ExpressionUsesOrderURL(expression)
 	if err != nil {
@@ -1226,6 +1227,19 @@ func (b *NodeConfigurationBuilder) resolveOrderRepository(order *models.FactoryW
 
 func githubRepositoryURL(repository string) string {
 	return "https://github.com/" + strings.TrimSuffix(repository, ".git") + ".git"
+}
+
+func attachOrderOrigin(order *models.FactoryWorkOrder, payload map[string]any) {
+	origin := order.Origin()
+	if origin == nil {
+		return
+	}
+
+	item := map[string]any{"url": origin.URL}
+	if origin.Label != "" {
+		item["label"] = origin.Label
+	}
+	payload["origin"] = item
 }
 
 func attachOrderSource(tx *gorm.DB, order *models.FactoryWorkOrder, payload map[string]any) error {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -351,6 +351,7 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		assert.NotContains(t, payload, "artifacts")
 		assert.NotContains(t, payload, "comments")
 		assert.NotContains(t, payload, "assignees")
+		assert.NotContains(t, payload, "origin")
 
 		source, ok := payload["source"].(map[string]any)
 		require.True(t, ok)
@@ -358,6 +359,38 @@ func Test_NodeConfigurationBuilder_OrderFunction(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, float64(42), issue["number"])
 		assert.Equal(t, "Fix login", issue["title"])
+
+		closingLine, err := builder.Build(map[string]any{
+			"body": `{{ task().origin != nil ? "Closes " + task().origin.label : "" }}`,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", closingLine["body"])
+	})
+
+	t.Run("exposes origin for GitHub closing keywords", func(t *testing.T) {
+		originURL := "https://github.com/acme/payments/issues/12"
+		originLabel := "acme/payments#12"
+		require.NoError(t, database.Conn().Model(order).Updates(map[string]any{
+			"origin_url":   originURL,
+			"origin_label": originLabel,
+		}).Error)
+
+		result, err := builder.ResolveExpression(`task().origin`)
+		require.NoError(t, err)
+		origin, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, originURL, origin["url"])
+		assert.Equal(t, originLabel, origin["label"])
+
+		label, err := builder.ResolveExpression(`task().origin.label`)
+		require.NoError(t, err)
+		assert.Equal(t, originLabel, label)
+
+		built, err := builder.Build(map[string]any{
+			"body": `{{ task().origin != nil ? "Closes " + task().origin.label : "" }}`,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Closes acme/payments#12", built["body"])
 	})
 
 	t.Run("uses workspace values for legacy work orders", func(t *testing.T) {


### PR DESCRIPTION
Factory implementation pull requests did not name the GitHub issue that created the work order.
GitHub could not close that issue when the pull request merged.
This change puts a `Closes owner/repo#n` line at the top of the pull request body.
The full repository form works when the backlog repository is not the app repository.
Tasks with no GitHub origin omit the line.
New factories and rematerialized implementation apps get this body.
Existing implementation canvases keep the old body until they rematerialize.