### PR TITLE
fix: Retry Planning Wait Without a 60s Stall

### DIFF
--- a/pkg/components/runner/follow_up_loop.js
+++ b/pkg/components/runner/follow_up_loop.js
@@ -12,8 +12,8 @@ const path = require("path");
 const { spawn } = require("child_process");
 
 const HOLD_SECONDS = 45;
-const MAX_RETRY_WAIT_SECONDS = 60;
-const DEFAULT_RETRY_WAIT_SECONDS = 1;
+const WAIT_RETRY_SECONDS = 1;
+const WAIT_ABORT_SLACK_SECONDS = 5;
 
 function nextAction(result) {
   const status = result && result.status ? String(result.status) : "";
@@ -52,17 +52,19 @@ function readEnv(name) {
   return value;
 }
 
-async function requestJSON(method, urlPath) {
-  const baseURL = readEnv("SUPERPLANE_BASE_URL").replace(/\/$/, "");
-  const token = readEnv("SUPERPLANE_RUN_TOKEN");
-  const response = await fetch(`${baseURL}${urlPath}`, {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-  });
-  const text = await response.text();
+function waitAbortSignal() {
+  return AbortSignal.timeout((HOLD_SECONDS + WAIT_ABORT_SLACK_SECONDS) * 1000);
+}
+
+async function safeWaitRequest(doFetch) {
+  let response;
+  let text;
+  try {
+    response = await doFetch();
+    text = await response.text();
+  } catch {
+    return { status: "pending" };
+  }
   let parsed = {};
   if (text) {
     try {
@@ -74,19 +76,26 @@ async function requestJSON(method, urlPath) {
   return interpretWaitResponse(response.status, parsed, text);
 }
 
+async function requestJSON(method, urlPath) {
+  const baseURL = readEnv("SUPERPLANE_BASE_URL").replace(/\/$/, "");
+  const token = readEnv("SUPERPLANE_RUN_TOKEN");
+  return safeWaitRequest(() =>
+    fetch(`${baseURL}${urlPath}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+      signal: waitAbortSignal(),
+    }),
+  );
+}
+
 function isTransientWaitFailure(status, parsed) {
   if (status === 429 || status === 502 || status === 503 || status === 504) {
     return true;
   }
   return Boolean(parsed && (parsed.retryable === true || parsed.cloudflare_error === true));
-}
-
-function retryWaitSeconds(parsed) {
-  const n = Number(parsed && parsed.retry_after);
-  if (!Number.isFinite(n) || n < 1) {
-    return DEFAULT_RETRY_WAIT_SECONDS;
-  }
-  return Math.min(MAX_RETRY_WAIT_SECONDS, Math.floor(n));
 }
 
 function interpretWaitResponse(status, parsed, text) {
@@ -97,7 +106,7 @@ function interpretWaitResponse(status, parsed, text) {
     return parsed && typeof parsed === "object" ? parsed : {};
   }
   if (isTransientWaitFailure(status, parsed)) {
-    return { status: "pending", retry_after: retryWaitSeconds(parsed), transient: true };
+    return { status: "pending" };
   }
   throw new Error((parsed && (parsed.message || parsed.error)) || text || `HTTP ${status}`);
 }
@@ -144,11 +153,7 @@ async function runLoop(helpers) {
       return action.code;
     }
     if (action.type === "wait") {
-      const seconds = retryWaitSeconds(result);
-      if (result && result.transient) {
-        log(`planning wait hit a transient error; retrying in ${seconds}s\n`);
-      }
-      await sleep(seconds * 1000);
+      await sleep(WAIT_RETRY_SECONDS * 1000);
       continue;
     }
     const code = await runPrompt(action.text);
@@ -172,7 +177,14 @@ async function main() {
   process.exit(code);
 }
 
-module.exports = { interpretWaitResponse, nextAction, runLoop, writePrompt, runPromptFile };
+module.exports = {
+  interpretWaitResponse,
+  nextAction,
+  runLoop,
+  safeWaitRequest,
+  writePrompt,
+  runPromptFile,
+};
 
 if (require.main === module) {
   main().catch((err) => {

--- a/pkg/components/runner/follow_up_loop_test.js
+++ b/pkg/components/runner/follow_up_loop_test.js
@@ -5,7 +5,13 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { interpretWaitResponse, nextAction, runLoop, runPromptFile } = require("./follow_up_loop.js");
+const { interpretWaitResponse, nextAction, runLoop, runPromptFile, safeWaitRequest } = require("./follow_up_loop.js");
+
+const CLOUDFLARE_502 = {
+  error: "An error occurred with your request. Please try again.",
+  retryable: true,
+  retry_after: 60,
+};
 
 test("waits while SuperPlane has no event", () => {
   assert.deepEqual(nextAction({ status: "pending" }), { type: "wait" });
@@ -76,29 +82,25 @@ test("runLoop prompts after create or skip", async () => {
   assert.match(prompts[1], /skipped/i);
 });
 
-test("interpretWaitResponse retries a 502 with retryable body", () => {
-  const got = interpretWaitResponse(502, {
-    error: "An error occurred with your request. Please try again.",
-    retryable: true,
-    retry_after: 60,
-  });
-  assert.deepEqual(got, { status: "pending", retry_after: 60, transient: true });
+test("interpretWaitResponse treats a Cloudflare 502 as idle pending", () => {
+  const got = interpretWaitResponse(502, CLOUDFLARE_502);
+  assert.deepEqual(got, { status: "pending" });
 });
 
-test("interpretWaitResponse retries 503, 504, and 429", () => {
-  assert.equal(interpretWaitResponse(503, {}).status, "pending");
-  assert.equal(interpretWaitResponse(504, {}).status, "pending");
-  assert.equal(interpretWaitResponse(429, { retry_after: 12 }).retry_after, 12);
+test("interpretWaitResponse retries 503, 504, and 429 as idle pending", () => {
+  assert.deepEqual(interpretWaitResponse(503, {}), { status: "pending" });
+  assert.deepEqual(interpretWaitResponse(504, {}), { status: "pending" });
+  assert.deepEqual(interpretWaitResponse(429, { retry_after: 12 }), { status: "pending" });
 });
 
-test("interpretWaitResponse retries a Cloudflare error body", () => {
+test("interpretWaitResponse treats a Cloudflare error body as idle pending", () => {
   const got = interpretWaitResponse(500, { cloudflare_error: true, retry_after: 30 });
-  assert.deepEqual(got, { status: "pending", retry_after: 30, transient: true });
+  assert.deepEqual(got, { status: "pending" });
 });
 
-test("interpretWaitResponse caps retry_after at 60 seconds", () => {
+test("interpretWaitResponse ignores retry_after on a transient wait", () => {
   const got = interpretWaitResponse(502, { retryable: true, retry_after: 120 });
-  assert.equal(got.retry_after, 60);
+  assert.deepEqual(got, { status: "pending" });
 });
 
 test("interpretWaitResponse ends on 409", () => {
@@ -109,26 +111,29 @@ test("interpretWaitResponse throws on 401", () => {
   assert.throws(() => interpretWaitResponse(401, { message: "unauthorized" }), /unauthorized/);
 });
 
-test("runLoop waits again after a transient wait, then exits 0", async () => {
+test("runLoop sleeps 1s with no log after a Cloudflare 502, then runs the next message", async () => {
   const sleeps = [];
-  const results = [
-    { status: "pending", retry_after: 60 },
-    { status: "ended" },
-  ];
+  const logs = [];
+  const prompts = [];
+  const results = [interpretWaitResponse(502, CLOUDFLARE_502), { status: "message", text: "hello" }, { status: "ended" }];
   const code = await runLoop({
     waitOnce: async () => results.shift(),
-    runPrompt: async () => {
-      throw new Error("prompt must not run");
+    runPrompt: async (text) => {
+      prompts.push(text);
+      return 0;
     },
     sleep: async (ms) => {
       sleeps.push(ms);
     },
+    log: (msg) => logs.push(msg),
   });
   assert.equal(code, 0);
-  assert.deepEqual(sleeps, [60000]);
+  assert.deepEqual(sleeps, [1000]);
+  assert.deepEqual(logs, []);
+  assert.deepEqual(prompts, ["hello"]);
 });
 
-test("runLoop backs off with the default floor when a transient wait has no retry_after", async () => {
+test("runLoop sleeps 1s with no log when a transient wait has no retry_after", async () => {
   const sleeps = [];
   const logs = [];
   const results = [{ status: "pending", transient: true }, { status: "ended" }];
@@ -144,11 +149,12 @@ test("runLoop backs off with the default floor when a transient wait has no retr
   });
   assert.equal(code, 0);
   assert.deepEqual(sleeps, [1000]);
-  assert.match(logs[0], /planning wait hit a transient error; retrying in 1s/);
+  assert.deepEqual(logs, []);
 });
 
-test("runLoop clamps a large retry_after to the 60s cap", async () => {
+test("runLoop ignores a large retry_after and stays silent", async () => {
   const sleeps = [];
+  const logs = [];
   const results = [{ status: "pending", retry_after: 99999, transient: true }, { status: "ended" }];
   const code = await runLoop({
     waitOnce: async () => results.shift(),
@@ -158,9 +164,11 @@ test("runLoop clamps a large retry_after to the 60s cap", async () => {
     sleep: async (ms) => {
       sleeps.push(ms);
     },
+    log: (msg) => logs.push(msg),
   });
   assert.equal(code, 0);
-  assert.deepEqual(sleeps, [60000]);
+  assert.deepEqual(sleeps, [1000]);
+  assert.deepEqual(logs, []);
 });
 
 test("runLoop backs off silently on idle pending and empty-message waits", async () => {
@@ -183,6 +191,52 @@ test("runLoop backs off silently on idle pending and empty-message waits", async
   });
   assert.equal(code, 0);
   assert.deepEqual(sleeps, [1000, 1000]);
+  assert.deepEqual(logs, []);
+});
+
+test("safeWaitRequest treats a fetch throw as pending", async () => {
+  const got = await safeWaitRequest(async () => {
+    throw new TypeError("fetch failed");
+  });
+  assert.deepEqual(got, { status: "pending" });
+});
+
+test("safeWaitRequest treats an abort as pending", async () => {
+  const got = await safeWaitRequest(async () => {
+    const err = new Error("This operation was aborted");
+    err.name = "AbortError";
+    throw err;
+  });
+  assert.deepEqual(got, { status: "pending" });
+});
+
+test("safeWaitRequest still throws on 401", async () => {
+  await assert.rejects(
+    () =>
+      safeWaitRequest(async () => ({
+        status: 401,
+        text: async () => JSON.stringify({ message: "unauthorized" }),
+      })),
+    /unauthorized/,
+  );
+});
+
+test("runLoop stays alive when waitOnce returns pending after a fetch throw", async () => {
+  const sleeps = [];
+  const logs = [];
+  const results = [await safeWaitRequest(async () => { throw new TypeError("fetch failed"); }), { status: "ended" }];
+  const code = await runLoop({
+    waitOnce: async () => results.shift(),
+    runPrompt: async () => {
+      throw new Error("prompt must not run");
+    },
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+    log: (msg) => logs.push(msg),
+  });
+  assert.equal(code, 0);
+  assert.deepEqual(sleeps, [1000]);
   assert.deepEqual(logs, []);
 });
 

--- a/pkg/public/runner_planning_session.go
+++ b/pkg/public/runner_planning_session.go
@@ -101,6 +101,7 @@ func (s *Server) handleRunnerPlanningWait(w http.ResponseWriter, r *http.Request
 		}
 		select {
 		case <-r.Context().Done():
+			writeJSON(w, http.StatusOK, map[string]any{"status": "pending"})
 			return
 		case <-ticker.C:
 		}

--- a/pkg/public/runner_planning_session_test.go
+++ b/pkg/public/runner_planning_session_test.go
@@ -2,6 +2,7 @@ package public
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -174,6 +175,35 @@ func TestRunnerPlanningWaitDoubleConsumeReturnsPending(t *testing.T) {
 	assert.Equal(t, 1, createdCount)
 }
 
+func TestRunnerPlanningWaitContextCancelReturnsPending(t *testing.T) {
+	r := support.Setup(t)
+	server, session, _, token := mustPlanningRunnerSession(t, r)
+	db := database.DB(t.Context())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runner/planning-sessions/wait?hold_seconds=60", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		server.Router.ServeHTTP(rec, req)
+	}()
+
+	requirePlanningWaitPending(t, db, session)
+	cancel()
+	<-done
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "pending", body["status"])
+}
+
 func mustPlanningRunnerSession(t *testing.T, r *support.ResourceRegistry) (*Server, *models.FactoryPlanningSession, *models.Factory, string) {
 	t.Helper()
 	server, signer := mustRunnerLiveLogServer(t, r)
@@ -214,4 +244,18 @@ func requireResolvedCreatedWait(t *testing.T, db *gorm.DB, session *models.Facto
 	_, err := session.CreateDraftWorkOrder(db, factoryModel, session.CreatedByUserID)
 	require.NoError(t, err)
 	require.Equal(t, models.PlanningWaitResolved, session.WaitState)
+}
+
+func requirePlanningWaitPending(t *testing.T, db *gorm.DB, session *models.FactoryPlanningSession) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		reloaded, err := models.FindPlanningSession(db, session.OrganizationID, session.FactoryID, session.ID)
+		require.NoError(t, err)
+		if reloaded.WaitState == models.PlanningWaitPending {
+			return
+		}
+		require.True(t, time.Now().Before(deadline), "planning wait did not become pending")
+		time.Sleep(20 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
## Summary

An idle Create-with-Agent wait can receive a Cloudflare 502. The follow-up loop logged that error and slept for 60 seconds. A user message that arrived during the sleep waited until the sleep ended. This change retries a transient wait in one second and stays silent.

## Test plan

- [ ] Open Create with Agent and leave the session idle for several minutes.
- [ ] Confirm the stream does not show `planning wait hit a transient error; retrying in 60s`.
- [ ] Send a message after a long idle.
- [ ] Confirm the agent answers without a 60-second delay.
- [ ] Run the Node `follow_up_loop` tests.
- [ ] Run `TestRunnerPlanningWaitContextCancelReturnsPending`.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix: Retry planning wait without 60s sta..."](https://github.com/superplanehq/superplane/commit/a7382edee3744d50b6c0f5b6006fbfe63a2b8135) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60228995)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->