### PR TITLE
fix: Keep Create-with-Agent Chat Order

### DIFF
--- a/pkg/components/runner/follow_up_loop.js
+++ b/pkg/components/runner/follow_up_loop.js
@@ -13,6 +13,7 @@ const { spawn } = require("child_process");
 
 const HOLD_SECONDS = 45;
 const WAIT_RETRY_SECONDS = 1;
+const FOLLOW_UP_CMD_INDEX_BASE = 1000;
 
 function nextAction(result) {
   const status = result && result.status ? String(result.status) : "";
@@ -135,11 +136,46 @@ function defaultSleep(ms) {
   });
 }
 
+function writeLiveLogRecord(rec) {
+  process.stdout.write(`${JSON.stringify(rec)}\n`);
+}
+
+function emitFollowUpCommandStart(text, index, startedAt, writeRecord) {
+  writeRecord({
+    type: "cmd_start",
+    index,
+    text,
+    kind: "prompt",
+    preview: text,
+    started_at: startedAt,
+  });
+}
+
+function emitFollowUpCommandEnd(index, code, startedAt, now, writeRecord) {
+  writeRecord({
+    type: "cmd_end",
+    index,
+    status: code === 0 ? "passed" : "failed",
+    duration_ms: Math.max(0, now - startedAt),
+  });
+}
+
+async function runFollowUpPrompt(text, helpers, followUpIndex) {
+  const writeRecord = helpers.writeLiveLogRecord || writeLiveLogRecord;
+  const now = helpers.now || Date.now;
+  const index = FOLLOW_UP_CMD_INDEX_BASE + followUpIndex;
+  const startedAt = now();
+  emitFollowUpCommandStart(text, index, startedAt, writeRecord);
+  const code = await helpers.runPrompt(text);
+  emitFollowUpCommandEnd(index, code, startedAt, now(), writeRecord);
+  return code;
+}
+
 async function runLoop(helpers) {
   const wait = helpers.waitOnce;
-  const runPrompt = helpers.runPrompt;
   const sleep = helpers.sleep || defaultSleep;
   const log = helpers.log || ((msg) => process.stderr.write(msg));
+  let followUpIndex = 0;
   while (true) {
     const result = await wait();
     const action = nextAction(result);
@@ -150,7 +186,8 @@ async function runLoop(helpers) {
       await sleep(WAIT_RETRY_SECONDS * 1000);
       continue;
     }
-    const code = await runPrompt(action.text);
+    const code = await runFollowUpPrompt(action.text, helpers, followUpIndex);
+    followUpIndex += 1;
     if (code !== 0) {
       log(`follow-up prompt failed with exit ${code}; waiting for the next message\n`);
     }
@@ -172,10 +209,12 @@ async function main() {
 }
 
 module.exports = {
+  FOLLOW_UP_CMD_INDEX_BASE,
   interpretWaitResponse,
   nextAction,
   runLoop,
   safeWaitRequest,
+  writeLiveLogRecord,
   writePrompt,
   runPromptFile,
 };

--- a/pkg/components/runner/follow_up_loop_test.js
+++ b/pkg/components/runner/follow_up_loop_test.js
@@ -5,7 +5,14 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { interpretWaitResponse, nextAction, runLoop, runPromptFile, safeWaitRequest } = require("./follow_up_loop.js");
+const {
+  FOLLOW_UP_CMD_INDEX_BASE,
+  interpretWaitResponse,
+  nextAction,
+  runLoop,
+  runPromptFile,
+  safeWaitRequest,
+} = require("./follow_up_loop.js");
 
 const CLOUDFLARE_502 = {
   error: "An error occurred with your request. Please try again.",
@@ -57,6 +64,7 @@ test("runLoop runs the user prompt then exits on ended", async () => {
       return 0;
     },
     sleep: async () => {},
+    writeLiveLogRecord: () => {},
   });
   assert.equal(code, 0);
   assert.deepEqual(prompts, ["Add color"]);
@@ -75,6 +83,7 @@ test("runLoop prompts after create or skip", async () => {
       prompts.push(text);
       return 0;
     },
+    writeLiveLogRecord: () => {},
   });
   assert.equal(code, 0);
   assert.equal(prompts.length, 2);
@@ -126,6 +135,7 @@ test("runLoop sleeps 1s with no log after a Cloudflare 502, then runs the next m
       sleeps.push(ms);
     },
     log: (msg) => logs.push(msg),
+    writeLiveLogRecord: () => {},
   });
   assert.equal(code, 0);
   assert.deepEqual(sleeps, [1000]);
@@ -146,6 +156,7 @@ test("runLoop sleeps 1s with no log when a transient wait has no retry_after", a
       sleeps.push(ms);
     },
     log: (msg) => logs.push(msg),
+    writeLiveLogRecord: () => {},
   });
   assert.equal(code, 0);
   assert.deepEqual(sleeps, [1000]);
@@ -165,6 +176,7 @@ test("runLoop ignores a large retry_after and stays silent", async () => {
       sleeps.push(ms);
     },
     log: (msg) => logs.push(msg),
+    writeLiveLogRecord: () => {},
   });
   assert.equal(code, 0);
   assert.deepEqual(sleeps, [1000]);
@@ -188,6 +200,7 @@ test("runLoop backs off silently on idle pending and empty-message waits", async
       sleeps.push(ms);
     },
     log: (msg) => logs.push(msg),
+    writeLiveLogRecord: () => {},
   });
   assert.equal(code, 0);
   assert.deepEqual(sleeps, [1000, 1000]);
@@ -247,6 +260,7 @@ test("runLoop runs a user message after a dropped wait", async () => {
     },
     sleep: async () => {},
     log: (msg) => logs.push(msg),
+    writeLiveLogRecord: () => {},
   });
   assert.equal(code, 0);
   assert.deepEqual(prompts, ["hello"]);
@@ -266,10 +280,75 @@ test("runLoop stays alive when waitOnce returns pending after a fetch throw", as
       sleeps.push(ms);
     },
     log: (msg) => logs.push(msg),
+    writeLiveLogRecord: () => {},
   });
   assert.equal(code, 0);
   assert.deepEqual(sleeps, [1000]);
   assert.deepEqual(logs, []);
+});
+
+test("runLoop emits cmd_start then cmd_end for each follow-up prompt", async () => {
+  const records = [];
+  const nowValues = [5_000, 5_250, 6_000, 6_400];
+  const results = [
+    { status: "message", text: "Add color" },
+    { status: "created", work_order_key: "NEWWO-12" },
+    { status: "ended" },
+  ];
+  const code = await runLoop({
+    waitOnce: async () => results.shift(),
+    runPrompt: async () => 0,
+    writeLiveLogRecord: (rec) => records.push(rec),
+    now: () => nowValues.shift(),
+  });
+  assert.equal(code, 0);
+  assert.deepEqual(records, [
+    {
+      type: "cmd_start",
+      index: FOLLOW_UP_CMD_INDEX_BASE,
+      text: "Add color",
+      kind: "prompt",
+      preview: "Add color",
+      started_at: 5_000,
+    },
+    {
+      type: "cmd_end",
+      index: FOLLOW_UP_CMD_INDEX_BASE,
+      status: "passed",
+      duration_ms: 250,
+    },
+    {
+      type: "cmd_start",
+      index: FOLLOW_UP_CMD_INDEX_BASE + 1,
+      text: nextAction({ status: "created", work_order_key: "NEWWO-12" }).text,
+      kind: "prompt",
+      preview: nextAction({ status: "created", work_order_key: "NEWWO-12" }).text,
+      started_at: 6_000,
+    },
+    {
+      type: "cmd_end",
+      index: FOLLOW_UP_CMD_INDEX_BASE + 1,
+      status: "passed",
+      duration_ms: 400,
+    },
+  ]);
+});
+
+test("runLoop marks a failed follow-up cmd_end and keeps waiting", async () => {
+  const records = [];
+  const results = [{ status: "message", text: "hello" }, { status: "ended" }];
+  const logs = [];
+  const code = await runLoop({
+    waitOnce: async () => results.shift(),
+    runPrompt: async () => 2,
+    writeLiveLogRecord: (rec) => records.push(rec),
+    now: () => 1_000,
+    log: (msg) => logs.push(msg),
+  });
+  assert.equal(code, 0);
+  assert.equal(records[1].type, "cmd_end");
+  assert.equal(records[1].status, "failed");
+  assert.match(logs[0], /follow-up prompt failed with exit 2/);
 });
 
 test("runPromptFile forwards extra argv to run.js", async () => {

--- a/web_src/src/pages/factories/pages/planningSessionLog.spec.ts
+++ b/web_src/src/pages/factories/pages/planningSessionLog.spec.ts
@@ -35,6 +35,13 @@ describe("isPlanningSessionNoise", () => {
     expect(isPlanningSessionNoise("The repository is ready. What do you want to do?")).toBe(false);
   });
 
+  it("hides runner done and failed footers", () => {
+    expect(isPlanningSessionNoise("✓ done · 1 turns · $0.0018 · 1.5s")).toBe(true);
+    expect(isPlanningSessionNoise("✓ done · 1 turns · 1.6s")).toBe(true);
+    expect(isPlanningSessionNoise("✓ done · 2 turns · $0.0020 · 2.2s")).toBe(true);
+    expect(isPlanningSessionNoise("✗ failed · 1 turns · $0.0020 · 0.9s")).toBe(true);
+  });
+
   it("treats survey JSON as a tool payload", () => {
     expect(isPlanningSessionToolPayload('{"questions":[{"prompt":"Priority?","options":["High"]}]}')).toBe(true);
     expect(isPlanningSessionToolPayload('{"status":"shown"}')).toBe(true);
@@ -359,13 +366,13 @@ describe("mergePlanningSessionNotes", () => {
 
     expect(talk.map((line) => line.componentName)).toEqual([
       "Hi! I'm ready to help you plan work in this repo. Tell me what you'd like to do.",
-      "I want to add color to puppies",
       'Let me take a look at the repo to understand what "puppies" refers to here.',
       "Got it. This is a small Express + EJS CRUD app where a Puppy currently has just a name.",
       "I've asked a few scoping questions above. Once you answer, I'll have what I need to draft the task.",
+      "I want to add color to puppies",
       surveyReply,
     ]);
-    expect(talk[1]?.userTalk).toBe("message");
+    expect(talk[4]?.userTalk).toBe("message");
     expect(talk[5]?.userTalk).toBe("survey");
   });
 
@@ -413,8 +420,8 @@ describe("mergePlanningSessionNotes", () => {
 
     expect(merged.map((line) => line.id)).toEqual([
       "wait",
-      "user-1",
       "asked",
+      "user-1",
       "user-survey",
       "later-turn",
       "later-note",

--- a/web_src/src/pages/factories/pages/planningSessionLog.ts
+++ b/web_src/src/pages/factories/pages/planningSessionLog.ts
@@ -21,6 +21,9 @@ export function isPlanningSessionNoise(text: string): boolean {
   if (!line) {
     return false;
   }
+  if (isPlanningSessionTurnEnd(line)) {
+    return true;
+  }
   return PLANNING_SESSION_NOISE_PREFIXES.some((prefix) => line === prefix || line.startsWith(prefix));
 }
 
@@ -298,8 +301,6 @@ type UserPlacementState = {
   emptyWaits: WaitSlot[];
   waitCursor: number;
   lastWait?: WaitSlot;
-  turnEnds: number[];
-  turnEndCursor: number;
   hasLiveOrder: boolean;
   insertOrder: number;
 };
@@ -318,8 +319,6 @@ function placeUnmatchedUserExtras(
     emptyWaits,
     waitCursor: slots.waitCursor,
     lastWait: slots.lastWait,
-    turnEnds: turnEndIndexes(merged),
-    turnEndCursor: 0,
     hasLiveOrder,
     insertOrder: 0,
   };
@@ -336,11 +335,6 @@ function placeUnmatchedUserExtras(
 }
 
 function nextUserPlacement(state: UserPlacementState, line: SplitRunStreamLine): NoteInsertion | undefined {
-  const turnEnd = state.turnEnds[state.turnEndCursor];
-  if (turnEnd !== undefined) {
-    state.turnEndCursor += 1;
-    return userExtraInsertion(line, turnEnd, state.insertOrder, turnEndParent(state.merged, turnEnd));
-  }
   if (state.hasLiveOrder && typeof line.orderKey === "number") {
     return orderKeyUserInsertion(state.merged, line, line.orderKey, state.insertOrder);
   }
@@ -366,7 +360,7 @@ function waitSlotUserInsertion(state: UserPlacementState, line: SplitRunStreamLi
   if (slot) {
     state.lastWait = slot;
     state.waitCursor += 1;
-    return userExtraInsertion(line, slot.index, state.insertOrder, slot.line.id);
+    return userExtraInsertion(line, lastWaitGroupEndIndex(state.merged, slot), state.insertOrder, slot.line.id);
   }
   if (!state.lastWait) {
     return undefined;
@@ -403,23 +397,9 @@ function insertionIndexByOrderKey(merged: SplitRunStreamLine[], orderKey: number
   return index;
 }
 
-function turnEndIndexes(merged: SplitRunStreamLine[]): number[] {
-  const indexes: number[] = [];
-  for (let i = 0; i < merged.length; i += 1) {
-    if (isPlanningSessionTurnEnd(merged[i]?.componentName ?? "")) {
-      indexes.push(i);
-    }
-  }
-  return indexes;
-}
-
 function isPlanningSessionTurnEnd(text: string): boolean {
   const line = text.trim();
   return line.startsWith("✓ done") || line.startsWith("✗ failed");
-}
-
-function turnEndParent(merged: SplitRunStreamLine[], afterIndex: number): string {
-  return orderKeyInsertionParent(merged, afterIndex) ?? merged[afterIndex]?.id ?? "";
 }
 
 /** The note/step group a chronologically placed insertion should nest under. */

--- a/web_src/src/pages/factories/pages/planningSessionLogOrderKey.spec.ts
+++ b/web_src/src/pages/factories/pages/planningSessionLogOrderKey.spec.ts
@@ -15,11 +15,14 @@ function note(
   };
 }
 
+function talkNames(lines: SplitRunStreamLine[]): string[] {
+  return groupPlanningSessionLog(lines).flatMap((group) =>
+    group.events.filter((event) => event.kind === "note").map((event) => event.line.componentName),
+  );
+}
+
 describe("mergePlanningSessionNotes ordering by orderKey", () => {
   it("places a user message after an earlier agent error even though it sits in the same wait slot", () => {
-    // Repro: setup, then the agent posts an error (later resolved), then the
-    // user sends a message. With orderKey known on both sides, the merge
-    // must not put the user reply before the earlier error note.
     const live: SplitRunStreamLine[] = [
       note({
         id: "wait",
@@ -85,81 +88,82 @@ describe("mergePlanningSessionNotes ordering by orderKey", () => {
     expect(merged.map((line) => line.id)).toEqual(["wait", "note-a", "user-1", "note-b", "user-2"]);
   });
 
-  it("interleaves a user reply when every live note in a turn shares the section start time", () => {
-    // Real live logs stamp every note in an agent turn with the same section
-    // start time, so a later user message would otherwise sort after the whole
-    // turn (the bug from the report). Stamping each agent note with its own
-    // message created_at restores the true order.
+  it("keeps a user after agent notes already on screen when no done line exists", () => {
     const live: SplitRunStreamLine[] = [
       note({
         id: "wait",
         componentType: "prompt",
         componentName: "Wait for the next user message",
         status: "running",
-        orderKey: 1_000,
       }),
       note({
-        id: "greet",
+        id: "look",
         noteParentId: "wait",
         componentType: "note",
-        componentName: "Hi! What would you like to work on today?",
-        orderKey: 1_000,
+        componentName: "Let me take a look at the repo.",
       }),
       note({
-        id: "greet-done",
+        id: "got-it",
         noteParentId: "wait",
         componentType: "note",
-        componentName: "✓ done · 1 turns · $0.0018 · 1.5s",
-        orderKey: 1_000,
-      }),
-      note({
-        id: "reply",
-        noteParentId: "wait",
-        componentType: "note",
-        componentName: "No problem. Everything looks good on my end.",
-        orderKey: 1_000,
-      }),
-      note({
-        id: "reply-done",
-        noteParentId: "wait",
-        componentType: "note",
-        componentName: "✓ done · 1 turns · $0.0184 · 2.2s",
-        orderKey: 1_000,
+        componentName: "This is a small Express app.",
       }),
     ];
 
     const merged = mergePlanningSessionNotes(live, [
       note({
-        id: "agent-greet",
-        componentType: "note",
-        componentName: "Hi! What would you like to work on today?",
-        orderKey: 900,
-      }),
-      note({
         id: "user-1",
         componentType: "prompt",
-        componentName: "hey yesy",
+        componentName: "Add color to puppies",
         userTalk: "message",
-        orderKey: 1_200,
-      }),
-      note({
-        id: "agent-reply",
-        componentType: "note",
-        componentName: "No problem. Everything looks good on my end.",
-        orderKey: 1_500,
       }),
     ]);
 
-    expect(merged.map((line) => line.id)).toEqual(["wait", "greet", "greet-done", "user-1", "reply", "reply-done"]);
-    expect(merged[3]?.noteParentId).toBe("wait");
+    expect(merged.map((line) => line.id)).toEqual(["wait", "look", "got-it", "user-1"]);
   });
 
-  it("places each follow-up after the done line that closed the previous turn", () => {
-    // Real Create with an Agent log: greet is one prompt, then a single
-    // "Wait for the next user message" section holds every later agent turn.
-    // Agent replies are not persisted as extras, so there is nothing to stamp.
-    // User messages after the first must still sit after the done line of the
-    // turn they replied to, not in a pile at the bottom.
+  it("does not pull a later user into a hole made by an extra mid-turn done line", () => {
+    const live: SplitRunStreamLine[] = [
+      note({
+        id: "wait",
+        componentType: "prompt",
+        componentName: "Wait for the next user message",
+        status: "running",
+      }),
+      note({
+        id: "first",
+        noteParentId: "wait",
+        componentType: "note",
+        componentName: "I started looking.",
+      }),
+      note({
+        id: "retry-done",
+        noteParentId: "wait",
+        componentType: "note",
+        componentName: "✓ done · 1 turns · $0.0018 · 1.5s",
+      }),
+      note({
+        id: "second",
+        noteParentId: "wait",
+        componentType: "note",
+        componentName: "Still working through the repo.",
+      }),
+    ];
+
+    const merged = mergePlanningSessionNotes(live, [
+      note({
+        id: "user-1",
+        componentType: "prompt",
+        componentName: "any update?",
+        userTalk: "message",
+      }),
+    ]);
+
+    expect(merged.map((line) => line.id)).toEqual(["wait", "first", "retry-done", "second", "user-1"]);
+    expect(talkNames(merged)).toEqual(["I started looking.", "Still working through the repo.", "any update?"]);
+  });
+
+  it("uses a follow-up cmd_start section as the user bubble and hides runner done footers", () => {
     const live: SplitRunStreamLine[] = [
       note({
         id: "greet",
@@ -171,7 +175,7 @@ describe("mergePlanningSessionNotes ordering by orderKey", () => {
         id: "greet-note",
         noteParentId: "greet",
         componentType: "note",
-        componentName: "Hi there. I'm ready to help you plan work in this repository. What would you like to do?",
+        componentName: "Hi there. What would you like to do?",
         orderKey: 500,
       }),
       note({
@@ -189,46 +193,24 @@ describe("mergePlanningSessionNotes ordering by orderKey", () => {
         orderKey: 1_000,
       }),
       note({
+        id: "agent-step-7",
+        componentType: "prompt",
+        componentName: "hello",
+        orderKey: 1_100,
+      }),
+      note({
         id: "hello-reply",
-        noteParentId: "wait",
+        noteParentId: "agent-step-7",
         componentType: "note",
         componentName: "Hello. What would you like to work on today?",
-        orderKey: 1_000,
+        orderKey: 1_100,
       }),
       note({
         id: "hello-done",
-        noteParentId: "wait",
+        noteParentId: "agent-step-7",
         componentType: "note",
         componentName: "✓ done · 1 turns · $0.0018 · 1.6s",
-        orderKey: 1_000,
-      }),
-      note({
-        id: "alright-reply",
-        noteParentId: "wait",
-        componentType: "note",
-        componentName: "Yes, all good here. The repository is on the master branch with a clean working tree.",
-        orderKey: 1_000,
-      }),
-      note({
-        id: "alright-done",
-        noteParentId: "wait",
-        componentType: "note",
-        componentName: "✓ done · 1 turns · $0.0022 · 1.9s",
-        orderKey: 1_000,
-      }),
-      note({
-        id: "strange-reply",
-        noteParentId: "wait",
-        componentType: "note",
-        componentName: "What didn't work? Can you share more details, like what you tried and what happened?",
-        orderKey: 1_000,
-      }),
-      note({
-        id: "strange-done",
-        noteParentId: "wait",
-        componentType: "note",
-        componentName: "✓ done · 1 turns · $0.0034 · 2.7s",
-        orderKey: 1_000,
+        orderKey: 1_100,
       }),
     ];
 
@@ -238,7 +220,76 @@ describe("mergePlanningSessionNotes ordering by orderKey", () => {
         componentType: "prompt",
         componentName: "hello",
         userTalk: "message",
+        orderKey: 1_050,
+      }),
+    ]);
+
+    expect(merged.map((line) => line.id)).toEqual([
+      "greet",
+      "greet-note",
+      "greet-done",
+      "wait",
+      "agent-step-7",
+      "hello-reply",
+      "hello-done",
+    ]);
+    expect(talkNames(merged)).toEqual([
+      "Hi there. What would you like to do?",
+      "hello",
+      "Hello. What would you like to work on today?",
+    ]);
+  });
+
+  it("places unmatched follow-ups between later turn sections by orderKey, not after each done line", () => {
+    const live: SplitRunStreamLine[] = [
+      note({
+        id: "greet",
+        componentType: "prompt",
+        componentName: "Greet the user in plain text. Then stop.",
+        orderKey: 500,
+      }),
+      note({
+        id: "greet-note",
+        noteParentId: "greet",
+        componentType: "note",
+        componentName: "Hi there. I'm ready to help you plan work in this repository.",
+        orderKey: 500,
+      }),
+      note({
+        id: "hello-turn",
+        componentType: "prompt",
+        componentName: "Plan with the user",
         orderKey: 1_100,
+      }),
+      note({
+        id: "hello-reply",
+        noteParentId: "hello-turn",
+        componentType: "note",
+        componentName: "Hello. What would you like to work on today?",
+        orderKey: 1_100,
+      }),
+      note({
+        id: "alright-turn",
+        componentType: "prompt",
+        componentName: "Plan with the user",
+        orderKey: 1_300,
+      }),
+      note({
+        id: "alright-reply",
+        noteParentId: "alright-turn",
+        componentType: "note",
+        componentName: "Yes, all good here.",
+        orderKey: 1_300,
+      }),
+    ];
+
+    const merged = mergePlanningSessionNotes(live, [
+      note({
+        id: "user-hello",
+        componentType: "prompt",
+        componentName: "hello",
+        userTalk: "message",
+        orderKey: 1_050,
       }),
       note({
         id: "user-alright",
@@ -247,50 +298,28 @@ describe("mergePlanningSessionNotes ordering by orderKey", () => {
         userTalk: "message",
         orderKey: 1_200,
       }),
-      note({
-        id: "user-strange",
-        componentType: "prompt",
-        componentName: "very strange it didnt work",
-        userTalk: "message",
-        orderKey: 1_300,
-      }),
     ]);
 
     expect(merged.map((line) => line.id)).toEqual([
       "greet",
       "greet-note",
-      "greet-done",
       "user-hello",
-      "wait",
+      "hello-turn",
       "hello-reply",
-      "hello-done",
       "user-alright",
+      "alright-turn",
       "alright-reply",
-      "alright-done",
-      "user-strange",
-      "strange-reply",
-      "strange-done",
     ]);
-
-    const talk = groupPlanningSessionLog(merged).flatMap((group) =>
-      group.events.filter((event) => event.kind === "note").map((event) => event.line.componentName),
-    );
-    expect(talk).toEqual([
-      "Hi there. I'm ready to help you plan work in this repository. What would you like to do?",
-      "✓ done · 1 turns · $0.0164 · 1.7s",
+    expect(talkNames(merged)).toEqual([
+      "Hi there. I'm ready to help you plan work in this repository.",
       "hello",
       "Hello. What would you like to work on today?",
-      "✓ done · 1 turns · $0.0018 · 1.6s",
       "everything alright?",
-      "Yes, all good here. The repository is on the master branch with a clean working tree.",
-      "✓ done · 1 turns · $0.0022 · 1.9s",
-      "very strange it didnt work",
-      "What didn't work? Can you share more details, like what you tried and what happened?",
-      "✓ done · 1 turns · $0.0034 · 2.7s",
+      "Yes, all good here.",
     ]);
   });
 
-  it("places follow-ups after Codex and OpenRouter done lines the same way as Claude", () => {
+  it("hides Codex and OpenRouter done footers and keeps users after the notes already on screen", () => {
     const live: SplitRunStreamLine[] = [
       note({ id: "wait", componentType: "prompt", componentName: "Wait for the next user message", status: "running" }),
       note({
@@ -328,16 +357,20 @@ describe("mergePlanningSessionNotes ordering by orderKey", () => {
       "wait",
       "codex-reply",
       "codex-done",
-      "user-1",
       "openrouter-reply",
       "openrouter-done",
+      "user-1",
       "user-2",
+    ]);
+    expect(talkNames(merged)).toEqual([
+      "Hello. What would you like to work on today?",
+      "Yes, all good here.",
+      "hello",
+      "everything alright?",
     ]);
   });
 
-  it("falls back to the wait-slot heuristic when the live log has no orderKey data", () => {
-    // Guards the existing behaviour: without timestamps we cannot tell true
-    // order, so a user message still lands right after the open wait slot.
+  it("falls back to the end of the wait group when the live log has no orderKey data", () => {
     const live: SplitRunStreamLine[] = [
       note({ id: "wait", componentType: "prompt", componentName: "Wait for the next user message", status: "running" }),
       note({ id: "error", noteParentId: "wait", componentType: "note", componentName: "Something went wrong." }),
@@ -347,6 +380,6 @@ describe("mergePlanningSessionNotes ordering by orderKey", () => {
       note({ id: "user-1", componentType: "prompt", componentName: "Can you check?", userTalk: "message" }),
     ]);
 
-    expect(merged.map((line) => line.id)).toEqual(["wait", "user-1", "error"]);
+    expect(merged.map((line) => line.id)).toEqual(["wait", "error", "user-1"]);
   });
 });


### PR DESCRIPTION
## Summary

The Create-with-Agent dialog showed a user message above the agent reply that was already on screen.
The live log stored every follow-up turn in one wait section, and the merge placed the user after the wait prompt.
This change emits one live-log command for each follow-up prompt.
The merge now places each user message by time, or after the last note in the wait group.

## Test plan

- [ ] Open Create with Agent for Claude, Codex, and OpenRouter.
- [ ] Send a follow-up while the agent still writes the current reply.
- [ ] Confirm the user bubble stays after that reply.
- [ ] Send another follow-up after the reply ends.
- [ ] Confirm the chat order stays user then agent for each turn.
- [ ] Confirm done and failed footers stay hidden.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix: Keep Create-with-Agent Chat Order"](https://github.com/superplanehq/superplane/commit/dbbd3f75dd4506283b747c65d11d8302aabf1dd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60267992)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->